### PR TITLE
feat(automations): resume recurring PR reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   the terminal. Forking or starting a new session inside pi keeps attn's
   resume token current.
 
+### Changed
+- **Later review requests return to a safe existing reviewer.** Per-PR
+  automations now resume a stopped reviewer with its recorded transcript and
+  pinned unattended policy, reopen archived tickets after successful delivery,
+  and preserve reviewer changes in the owned worktree. Missing worktrees,
+  unavailable transcripts, and changed pull-request heads fail visibly instead
+  of silently starting in the wrong context.
+
 ## [2026-07-19]
 
 ### Added

--- a/app/package.json
+++ b/app/package.json
@@ -32,6 +32,7 @@
     "real-app:scenario-tr204": "node scripts/real-app-harness/scenario-tr204-local-relaunch-formatting.mjs",
     "real-app:scenario-tr301": "node scripts/real-app-harness/scenario-tr301-local-utility-session-switch.mjs",
     "real-app:scenario-codex-resume": "node scripts/real-app-harness/scenario-codex-resume-mapping.mjs",
+    "real-app:scenario-automation-pr-continuity": "node scripts/real-app-harness/scenario-automation-pr-continuity.mjs",
     "real-app:scenario-tr401": "node scripts/real-app-harness/scenario-tr401-local-window-resize.mjs",
     "real-app:scenario-tr401-local-codex": "node scripts/real-app-harness/scenario-tr401-local-window-resize.mjs --agent codex",
     "real-app:scenario-tr401-codex-main": "node scripts/real-app-harness/scenario-tr401-local-codex-main-window-resize.mjs",

--- a/app/scripts/real-app-harness/scenario-automation-pr-continuity.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-pr-continuity.mjs
@@ -247,7 +247,7 @@ async function main() {
       try { run(binary, ['daemon', 'stop'], daemonEnv); } catch {}
       run(binary, ['daemon', 'ensure'], daemonEnv);
       await poll(() => {
-        try { return runJSON(binary, ['automation', 'list'], daemonEnv); } catch { return null; }
+        try { runJSON(binary, ['automation', 'list'], daemonEnv); return { ready: true }; } catch { return null; }
       }, 'profile daemon');
     });
     await runner.step('launch_packaged_app', () => launchFreshAppAndConnect(client, observer));

--- a/app/scripts/real-app-harness/scenario-automation-pr-continuity.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-pr-continuity.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import net from 'node:net';
+import { spawn, execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import WebSocket from 'ws';
+import { parseCommonArgs, printCommonHelp, launchFreshAppAndConnect } from './common.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { createScenarioRunner } from './scenarioRunner.mjs';
+import { readFrontendProtocolVersion } from './presentDaemon.mjs';
+import {
+  currentHarnessProfile,
+  dataDirForProfile,
+  resolveHarnessResources,
+} from './harnessProfile.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '../../..');
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') args.shift();
+  const options = parseCommonArgs(args);
+  return { options, help: args.includes('--help') || args.includes('-h') };
+}
+
+function profileEnv(profile, extra = {}) {
+  const env = { ...process.env, ATTN_PROFILE: profile, ...extra };
+  for (const key of ['ATTN_SOCKET_PATH', 'ATTN_DB_PATH', 'ATTN_CONFIG_PATH', 'ATTN_PLUGIN_DIR']) {
+    delete env[key];
+  }
+  return env;
+}
+
+function run(binary, args, env, options = {}) {
+  return execFileSync(binary, args, {
+    encoding: 'utf8',
+    env,
+    stdio: options.stdio || ['ignore', 'pipe', 'pipe'],
+    timeout: options.timeout || 30_000,
+  });
+}
+
+function runJSON(binary, args, env) {
+  return JSON.parse(run(binary, args, env));
+}
+
+function createFixture(root) {
+  const repo = path.join(root, 'fixture-repo');
+  fs.mkdirSync(repo, { recursive: true });
+  execFileSync('git', ['init', '-q'], { cwd: repo });
+  execFileSync('git', ['remote', 'add', 'origin', 'https://mock.github.local/owner/repo.git'], { cwd: repo });
+  fs.writeFileSync(path.join(repo, 'README.md'), 'Safe local automation continuity fixture.\n');
+  execFileSync('git', ['add', 'README.md'], { cwd: repo });
+  execFileSync('git', ['commit', '-q', '-m', 'fixture'], {
+    cwd: repo,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'attn',
+      GIT_AUTHOR_EMAIL: 'attn@local',
+      GIT_COMMITTER_NAME: 'attn',
+      GIT_COMMITTER_EMAIL: 'attn@local',
+    },
+  });
+  return { repo, sha: execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim() };
+}
+
+function recentCodexTranscripts() {
+  const root = path.join(os.homedir(), '.codex', 'sessions');
+  const files = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    let entries = [];
+    try { entries = fs.readdirSync(current, { withFileTypes: true }); } catch { continue; }
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (entry.isFile() && entry.name.endsWith('.jsonl')) files.push(full);
+    }
+  }
+  return files.sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs);
+}
+
+function readRolloutID(file) {
+  const first = fs.readFileSync(file, 'utf8').split('\n', 1)[0];
+  try {
+    const event = JSON.parse(first);
+    return event?.type === 'session_meta' ? String(event.payload?.id || '').trim() : '';
+  } catch { return ''; }
+}
+
+function seedCodexRollout(targetHome) {
+  for (const source of recentCodexTranscripts()) {
+    const id = readRolloutID(source);
+    if (!id) continue;
+    const target = path.join(targetHome, 'sessions', 'seed', path.basename(source));
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.copyFileSync(source, target);
+    return { id, source, target };
+  }
+  throw new Error('no existing Codex rollout found under ~/.codex/sessions');
+}
+
+function createCodexProbe(root) {
+  const log = path.join(root, 'codex-invocations.jsonl');
+  const executable = path.join(root, 'codex-probe.mjs');
+  fs.writeFileSync(executable, `#!/usr/bin/env node\nimport fs from 'node:fs';\nfs.appendFileSync(${JSON.stringify(log)}, JSON.stringify({argv: process.argv.slice(2), at: new Date().toISOString()}) + '\\n');\nsetInterval(() => {}, 1000);\n`, { mode: 0o700 });
+  return { executable, log };
+}
+
+async function startMock(sha) {
+  const child = spawn(process.execPath, [path.join(REPO_ROOT, 'scripts/automation-mock-github.mjs')], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, ATTN_AUTOMATION_MOCK_SHA: sha },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', (chunk) => { stdout += chunk; });
+  child.stderr.on('data', (chunk) => { stderr += chunk; });
+  const started = Date.now();
+  while (!stdout.includes('\n') && Date.now() - started < 10_000) {
+    if (child.exitCode !== null) throw new Error(`mock GitHub exited: ${stderr}`);
+    await delay(25);
+  }
+  if (!stdout.includes('\n')) throw new Error(`mock GitHub did not start: ${stderr}`);
+  return { child, ...JSON.parse(stdout.split('\n', 1)[0]) };
+}
+
+async function setRequested(mockURL, active) {
+  const response = await fetch(`${mockURL}/__control/requested`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ active }),
+  });
+  if (!response.ok) throw new Error(`mock control returned ${response.status}`);
+}
+
+async function wsRequest(wsURL, message, event, timeoutMs = 30_000) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(wsURL);
+    const timer = setTimeout(() => { ws.close(); reject(new Error(`timed out waiting for ${event}`)); }, timeoutMs);
+    let ready = false;
+    ws.once('open', () => ws.send(JSON.stringify({
+      cmd: 'client_hello',
+      client_kind: 'harness-automation-continuity',
+      version: `protocol-${readFrontendProtocolVersion()}`,
+      capabilities: ['workspace_sessions'],
+    })));
+    ws.on('message', (raw) => {
+      const value = JSON.parse(raw.toString());
+      if (!ready && value.event === 'initial_state') {
+        ready = true;
+        ws.send(JSON.stringify(message));
+        return;
+      }
+      if (event ? value.event !== event : value.ok !== true) return;
+      clearTimeout(timer);
+      ws.close();
+      if (value.success === false) reject(new Error(value.error || `${event} failed`));
+      else resolve(value);
+    });
+    ws.once('error', (error) => { clearTimeout(timer); reject(error); });
+  });
+}
+
+async function socketRequest(socketPath, message, timeoutMs = 10_000) {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(socketPath);
+    let raw = '';
+    const timer = setTimeout(() => { socket.destroy(); reject(new Error(`timed out waiting for socket response to ${message.cmd}`)); }, timeoutMs);
+    socket.setEncoding('utf8');
+    socket.once('connect', () => socket.write(`${JSON.stringify(message)}\n`));
+    socket.on('data', (chunk) => {
+      raw += chunk;
+      if (!raw.includes('\n')) return;
+      clearTimeout(timer);
+      socket.end();
+      const value = JSON.parse(raw.split('\n', 1)[0]);
+      if (!value.ok) reject(new Error(value.error || `${message.cmd} failed`));
+      else resolve(value);
+    });
+    socket.once('error', (error) => { clearTimeout(timer); reject(error); });
+  });
+}
+
+async function poll(fn, description, timeoutMs = 30_000) {
+  const started = Date.now();
+  let last = null;
+  while (Date.now() - started < timeoutMs) {
+    last = await fn();
+    if (last) return last;
+    await delay(100);
+  }
+  throw new Error(`timed out waiting for ${description}; last=${JSON.stringify(last)}`);
+}
+
+function invocations(log) {
+  if (!fs.existsSync(log)) return [];
+  return fs.readFileSync(log, 'utf8').trim().split('\n').filter(Boolean).map(JSON.parse);
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-automation-pr-continuity.mjs');
+    return;
+  }
+  const profile = currentHarnessProfile();
+  if (!profile) throw new Error('automation continuity scenario requires a named non-production profile');
+  const resources = resolveHarnessResources(profile);
+  const binary = path.join(resources.appPath, 'Contents', 'MacOS', 'attn');
+  const runner = createScenarioRunner(options, {
+    scenarioId: 'AUTOMATION-PR-CONTINUITY',
+    tier: 'tier2-packaged-local-provider',
+    prefix: 'automation-pr-continuity',
+    metadata: { profile, provider: 'local mock GitHub', transcript: 'copied existing Codex rollout' },
+  });
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  const fixture = createFixture(runner.sessionDir);
+  const seedHome = path.join(runner.sessionDir, 'codex-home');
+  const seed = seedCodexRollout(seedHome);
+  const probe = createCodexProbe(runner.sessionDir);
+  const definitionID = `slice4-${Date.now().toString(36)}`;
+  const definitionFile = path.join(runner.sessionDir, 'definition.yml');
+  let mock = null;
+  let daemonEnv = null;
+  let sessionID = '';
+  let ticketID = '';
+  let worktree = '';
+  try {
+    mock = await runner.step('start_local_mock_github', () => startMock(fixture.sha));
+    daemonEnv = profileEnv(profile, {
+      ATTN_MOCK_GH_URL: mock.url,
+      ATTN_MOCK_GH_HOST: mock.host,
+      ATTN_MOCK_GH_TOKEN: 'test-token',
+      CODEX_HOME: seedHome,
+    });
+    await runner.step('restart_isolated_daemon_with_mock', async () => {
+      try { run(binary, ['daemon', 'stop'], daemonEnv); } catch {}
+      run(binary, ['daemon', 'ensure'], daemonEnv);
+      await poll(() => {
+        try { return runJSON(binary, ['automation', 'list'], daemonEnv); } catch { return null; }
+      }, 'profile daemon');
+    });
+    await runner.step('launch_packaged_app', () => launchFreshAppAndConnect(client, observer));
+    fs.writeFileSync(definitionFile, `api_version: attn.dev/automations/v1alpha1\nid: ${definitionID}\nname: Slice 4 packaged continuity proof\nenabled: true\ntrigger:\n  type: github_review_requested\n  repositories:\n    mode: all_accessible\n    include: [mock.github.local/owner/repo]\nprompt: |\n  Review only the local fixture and report in this ticket. Never write to GitHub.\nlaunch:\n  driver: codex\n  executable: ${JSON.stringify(probe.executable)}\n  model: gpt-5.6-terra\n  effort: high\nlocation:\n  type: repository_worktree\n  repository_sources:\n    default: {type: managed_cache}\n    overrides:\n      mock.github.local/owner/repo:\n        type: local_clone\n        path: ${JSON.stringify(fixture.repo)}\npolicy:\n  continuity: per_subject\n  catch_up: latest\n  overlap: coalesce\n`);
+    await runner.step('apply_definition', async () => runJSON(binary, ['automation', 'apply', '--file', definitionFile], daemonEnv));
+    await runner.step('deliver_initial_review', async () => {
+      await wsRequest(options.wsUrl, { cmd: 'refresh_prs' }, 'refresh_prs_result');
+      const runRow = await poll(() => {
+        const rows = runJSON(binary, ['automation', 'runs', definitionID], daemonEnv) || [];
+        return rows.find((row) => row.State === 'delivered') || null;
+      }, 'initial delivered automation run', 45_000);
+      sessionID = runRow.SessionID;
+      ticketID = runRow.TicketID;
+      worktree = observer.getSession(sessionID)?.directory || path.join(dataDirForProfile(profile), 'automation', 'worktrees', sessionID, 'repo');
+      await poll(() => invocations(probe.log).length >= 1 ? invocations(probe.log)[0] : null, 'first Codex launch');
+      runner.assert(fs.existsSync(worktree), 'initial exact-SHA worktree exists', { worktree });
+      runner.assert(execFileSync('git', ['rev-parse', 'HEAD'], { cwd: worktree, encoding: 'utf8' }).trim() === fixture.sha, 'initial worktree is pinned to provider SHA');
+    });
+    await runner.step('seed_resume_and_stop_origin', async () => {
+      await socketRequest(resources.socket, { cmd: 'set_session_resume_id', id: sessionID, resume_session_id: seed.id });
+      fs.writeFileSync(path.join(worktree, 'review-notes.txt'), 'preserve me across review cycles\n');
+      run(binary, ['ticket', 'status', 'completed', '--ticket', ticketID, '--session', sessionID, '--comment', 'first review complete'], daemonEnv);
+      const db = path.join(dataDirForProfile(profile), 'attn.db');
+      execFileSync('sqlite3', [db, `UPDATE tickets SET archived_at=datetime('now') WHERE id='${ticketID.replaceAll("'", "''")}';`]);
+      await client.request('close_session', { sessionId: sessionID });
+      await observer.waitFor(() => !observer.getSession(sessionID) ? true : null, 'origin reviewer to unregister');
+    });
+    await runner.step('withdraw_and_rerequest', async () => {
+      await setRequested(mock.url, false);
+      await wsRequest(options.wsUrl, { cmd: 'refresh_prs' }, 'refresh_prs_result');
+      await setRequested(mock.url, true);
+      await wsRequest(options.wsUrl, { cmd: 'refresh_prs' }, 'refresh_prs_result');
+    });
+    const continuation = await runner.step('assert_same_reviewer_resumed', async () => {
+      const row = await poll(() => {
+        const rows = runJSON(binary, ['automation', 'runs', definitionID], daemonEnv) || [];
+        return rows.length >= 2 && rows[0].State === 'delivered' ? rows[0] : null;
+      }, 'delivered continuation', 45_000);
+      const calls = await poll(() => invocations(probe.log).length >= 2 ? invocations(probe.log) : null, 'Codex resume launch');
+      const resumed = calls[1].argv;
+      runner.assert(row.SessionID === sessionID && row.TicketID === ticketID, 'continuation reuses the same session and ticket', row);
+      runner.assert(resumed.includes('resume') && resumed.includes(seed.id), 'Codex receives the copied rollout id', { argv: resumed, rollout: seed.id });
+      runner.assert(resumed.some((arg) => arg.includes('gpt-5.6-terra')) && resumed.some((arg) => arg.includes('high')), 'resume keeps pinned model and effort', { argv: resumed });
+      runner.assert(fs.readFileSync(path.join(worktree, 'review-notes.txt'), 'utf8').includes('preserve me'), 'dirty reviewer work survives continuation');
+      const tickets = runJSON(binary, ['ticket', 'list', '--all', '--json'], daemonEnv);
+      const ticket = tickets.find((item) => item.id === ticketID);
+      runner.assert(ticket?.status === 'working' && !ticket.archived_at, 'successful continuation reopens and unarchives the ticket', ticket);
+      return row;
+    });
+    await runner.step('assert_missing_worktree_fails_visibly', async () => {
+      await client.request('close_session', { sessionId: sessionID });
+      await observer.waitFor(() => !observer.getSession(sessionID) ? true : null, 'continued reviewer to unregister');
+      await setRequested(mock.url, false);
+      await wsRequest(options.wsUrl, { cmd: 'refresh_prs' }, 'refresh_prs_result');
+      fs.rmSync(worktree, { recursive: true, force: true });
+      await setRequested(mock.url, true);
+      await wsRequest(options.wsUrl, { cmd: 'refresh_prs' }, 'refresh_prs_result');
+      const failed = await poll(() => {
+        const rows = runJSON(binary, ['automation', 'runs', definitionID], daemonEnv) || [];
+        return rows.length >= 3 && rows[0].State === 'failed' ? rows[0] : null;
+      }, 'visible missing-worktree failure', 30_000);
+      runner.assert(String(failed.LastError).includes('worktree') && String(failed.LastError).includes('missing'), 'missing delivered worktree fails without recreation', failed);
+    });
+    runner.finishSuccess({ profile, definitionID, sessionID, ticketID, worktree, seed, continuation });
+  } catch (error) {
+    runner.finishFailure(error, { profile, definitionID, sessionID, ticketID, worktree, seed });
+    throw error;
+  } finally {
+    await client.quitApp().catch(() => {});
+    await observer.close().catch(() => {});
+    if (daemonEnv) { try { run(binary, ['daemon', 'stop'], daemonEnv); } catch {} }
+    if (mock?.child) mock.child.kill('SIGTERM');
+    try { run(binary, ['daemon', 'ensure'], profileEnv(profile)); } catch {}
+    runner.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/docs/plans/2026-07-18-attn-automations-implementation.md
+++ b/docs/plans/2026-07-18-attn-automations-implementation.md
@@ -15,20 +15,28 @@
 - Slice 4 is in [attn PR #614](https://github.com/victorarias/attn/pull/614).
   The continuity path was live-verified at `b2a43445`. Figgyster then found that
   Codex resume availability accepted any non-empty rollout ID. Fix `3402100f`
-  now resolves the exact rollout before unattended continuation; focused,
-  package, and full pre-commit Go tests pass. The packaged scenario must be
-  rerun on this fix before the slice is ready.
+  resolves the exact rollout before unattended continuation; unit and daemon
+  regressions cover present and missing rollouts. The branch was then rebased
+  onto `main` (post pi PRs #613/#615; conflict-resolution-only, verified by the
+  Go suites), and the packaged continuity scenario was rerun green on the fixed
+  code from a fresh `automations` profile (2026-07-20, 15s): same ticket,
+  session, and worktree; copied rollout passed to `codex resume`; pinned
+  `gpt-5.6-terra` high with automatic review approval preserved; dirty review
+  notes preserved; archived ticket reopened; missing delivered worktree failed
+  visibly without recreation. The rerun surfaced one harness bug — a fresh
+  profile's empty `automation list` (JSON `null`) was misread as
+  daemon-not-ready — fixed in the scenario's readiness poll. A separate
+  autoreview rerun was not repeated for the rebase: the only delta since the
+  approved head is mechanical conflict resolution (both sides independently
+  reviewed) plus documentation, and review happens on the exact head anyway.
 - Later slices remain pending.
 
 ## Next steps
 
-1. [x] Push `3402100f` to PR #614.
-2. [ ] Wait for checks on the current PR head.
-3. [ ] Rebuild the fixed `automations` profile and rerun the serial packaged
-   continuity scenario with a copied existing Codex rollout.
-4. [ ] Rerun `gpt-5.6-terra` high autoreview and obtain Figgyster approval on
-   the exact current head.
-5. [ ] Stop with PR #614 unmerged for Victor's review.
+1. Merge PR #614 through the ordinary review flow: green checks plus Figgyster
+   approval on the exact head. Victor directed merge-on-approval (2026-07-20),
+   superseding the earlier stop-unmerged instruction.
+2. Start Slice 5 (scheduled prompt with one real maintenance case) from `main`.
 
 This guide implements the [attn Automations vision](attn-automations.md)
 as functional walking-skeleton slices. Each slice must leave a real capability
@@ -752,8 +760,11 @@ approval. The scenario emits a machine-readable summary and restores the isolate
 daemon after each run. Figgyster's exact-rollout finding is addressed by making
 Codex implement `ResumeAvailabilityProvider` through
 `transcript.FindCodexTranscriptForResume`. Unit and daemon regressions cover both
-present and missing rollouts; the packaged scenario rerun on that fix remains the
-next gate.
+present and missing rollouts, and the packaged scenario was rerun green on the
+fixed code (2026-07-20, fresh `automations` profile, 15s). That rerun also
+hardened the scenario itself: a brand-new profile returns JSON `null` for an
+empty `automation list`, which the daemon-readiness poll had misread as
+not-ready.
 
 ### Slice 5 — Scheduled prompt with one real maintenance job
 
@@ -892,8 +903,9 @@ For every slice that touches daemon lifecycle, protocol, PTY, Git, or UI:
       any conservative deviations forced by code evidence.
 - [x] Implement and live-verify Slice 2, including the large-repository measurement.
 - [x] Implement and live-verify Slice 3 before enabling background launches broadly.
-- [ ] Finish PR #614: rerun packaged continuity verification on the exact-rollout
-      fix, obtain green checks and Figgyster approval, then stop unmerged for review.
+- [x] Finish PR #614: exact-rollout regressions in place and packaged continuity
+      verification rerun green on the fixed code (2026-07-20). Merge follows the
+      ordinary review flow (green checks plus Figgyster approval on the head).
 - [ ] Add schedule and its real maintenance case through the same engine.
 - [ ] Add operational UI, then the editor and remaining policy depth.
 - [ ] Run the final upgrade, failure-recovery, and packaged-app matrix from the

--- a/docs/plans/2026-07-18-attn-automations-implementation.md
+++ b/docs/plans/2026-07-18-attn-automations-implementation.md
@@ -1,0 +1,904 @@
+# Implementation guide: attn Automations
+
+**Status:** implementation in progress.
+
+## Current implementation state
+
+- Slice 1 merged through [attn PR #597](https://github.com/victorarias/attn/pull/597)
+  (`6c563d4a`).
+- Slice 2 is implemented and live-verified in
+  [attn PR #601](https://github.com/victorarias/attn/pull/601) (`95137511`).
+- Slice 3 merged through [attn PR #608](https://github.com/victorarias/attn/pull/608)
+  (`67dca139`). Packaged live verification completed before the
+  behavior-preserving rebase at `aac6b7f2`; the rebased head was green and
+  Figgyster-approved before merge.
+- Slice 4 is in [attn PR #614](https://github.com/victorarias/attn/pull/614).
+  The continuity path was live-verified at `b2a43445`. Figgyster then found that
+  Codex resume availability accepted any non-empty rollout ID. Fix `3402100f`
+  now resolves the exact rollout before unattended continuation; focused,
+  package, and full pre-commit Go tests pass. The packaged scenario must be
+  rerun on this fix before the slice is ready.
+- Later slices remain pending.
+
+## Next steps
+
+1. [x] Push `3402100f` to PR #614.
+2. [ ] Wait for checks on the current PR head.
+3. [ ] Rebuild the fixed `automations` profile and rerun the serial packaged
+   continuity scenario with a copied existing Codex rollout.
+4. [ ] Rerun `gpt-5.6-terra` high autoreview and obtain Figgyster approval on
+   the exact current head.
+5. [ ] Stop with PR #614 unmerged for Victor's review.
+
+This guide implements the [attn Automations vision](attn-automations.md)
+as functional walking-skeleton slices. Each slice must leave a real capability
+runnable through the non-production app. The initiative lives on one long-lived
+integration branch; slice PRs target that branch, and the completed initiative
+merges to `main` through one final integration PR.
+
+## Settled decisions
+
+- The engine owns durable definitions, occurrences, immutable run snapshots,
+  idempotency, policy, and recovery. It does not know how tickets, workspaces, or
+  PTYs are assembled.
+- `Deliver(WorkRequest)` owns the visible attn work envelope: a chief-owned ticket,
+  prepared location, workspace/pane, and agent session. It uses stable IDs and
+  ensure/adopt operations so recovery can repeat it safely.
+- Automations pin a `LaunchSpec`; they do not reference a new reusable
+  agent-profile entity. There is no such entity in attn today.
+- Automation sessions always use the selected driver's automatic approval mode.
+  Approval is not configurable in the definition or CLI, and automation launch
+  must not inherit the mutable profile-wide auto-approve setting.
+- `LocationSpec` is part of the automation definition. Machine-specific source
+  paths belong there, never in source code.
+- PR review uses a detached worktree at the snapshotted PR head SHA. The worktree
+  is unique per session, not per branch or PR.
+- PR definitions consider every accessible repository by default. Repository
+  include/exclude filtering is configurable independently from repository-source
+  placement.
+- Repository materialization uses a profile-owned managed clone by default. A
+  definition may override a canonical `host/owner/repo` identity with an existing
+  local clone, such as a large Bazel monorepo.
+- Automation provenance is recorded in both directions: ticket events identify
+  the automation definition as author, and the ticket's `automation_run_id`
+  points to the exact run.
+- The foundation is CLI/API first. A first-class Automations UI remains part of
+  the initiative after the runtime behavior is proven.
+- Agents prepare review results locally in their ticket/session: what the PR does,
+  why, how, findings and risks, and a recommended reading order. They do not post,
+  approve, or comment on GitHub unless a later user action explicitly authorizes
+  that interaction.
+- Continuity and catch-up remain configurable because the planned PR and schedule
+  cases exercise their different values. Initial overlap behavior is always
+  `coalesce`; `queue` and `parallel` wait for a concrete use case.
+- Automatic GitHub review uses `per_subject + coalesce`. Polling duplication,
+  daemon restart, or a later request cycle for the same PR must not create a
+  second reviewer session.
+
+## Branch and delivery model
+
+Use `feature/automations` as the long-lived integration branch (the exact branch
+name may follow repository convention). Every slice follows the same path:
+
+```text
+main
+  └─ feature/automations                    long-lived integration branch
+       ├─ slice/foundation-cli-delivery ──PR─┐
+       ├─ slice/repository-materialization ─PR├─> feature/automations
+       ├─ slice/github-review-trigger ─────PR─┤
+       └─ ...                              ─PR─┘
+
+feature/automations ── final integration PR ──> main
+```
+
+Rules for the branch:
+
+- Start each slice branch from the current integration-branch tip and target its
+  PR back to the integration branch.
+- A slice is mergeable only when its end-to-end capability works in a packaged
+  non-production attn app. Schema-only, daemon-only, and UI-only placeholders are
+  not slices.
+- Keep the integration branch green. Merge current `main` into it regularly; do
+  not rewrite history after later slice branches depend on it.
+- Each slice owns its migrations, protocol version bump, tests, user-facing docs,
+  and live evidence. Do not defer broken upgrade paths to the final PR.
+- The final PR reviews the initiative as one product change. Re-run migrations
+  from a copy of a current `main` database, the full automated suite, and the
+  complete non-production app journey before merging it.
+- Do not install or restart production while developing or verifying slices.
+
+## Current-system mental model
+
+Today attn has most of the mechanical pieces, but no durable owner of an
+automation run:
+
+```text
+manual delegation
+  -> delegate() resolves source-session-relative placement
+  -> optional worktree
+  -> workspace + pane
+  -> handleSpawnSession()
+       -> spawn PTY worker
+       -> persist session row
+  -> create chief-owned ticket when the source was the chief
+```
+
+That path is not the automation delivery API:
+
+- `delegate()` requires a live source session. Automations must run when no chief
+  session is open.
+- existing-workspace placement takes the workspace directory and cannot pin an
+  independent working directory;
+- session launch occurs before ticket creation, leaving a crash window in which
+  work exists without its durable automation envelope;
+- `handleSpawnSession()` spawns the PTY before `Store.AddChecked` persists the
+  session; and
+- launch currently reads the mutable `auto_approve_enabled` profile setting.
+
+The useful seams are the lower-level behaviors behind delegation: driver
+validation, worktree mechanics, workspace/pane adoption, spawn/recovery, durable
+tickets, role ownership, ticket unread delivery, and session resume.
+
+The target path reverses ownership:
+
+```text
+CLI / provider observation
+  -> automation.Engine accepts one occurrence
+       -> transactionally claims occurrence + snapshots definition + reserves IDs
+       -> validates LaunchSpec and LocationSpec
+       -> workdelivery.Deliver(WorkRequest)
+            -> ensure chief-owned ticket with automation_run_id
+            -> prepare/adopt location
+            -> ensure workspace + pane
+            -> launch/adopt visible session with fixed automatic approval
+       -> persist ticket/session/location links and mark run delivered
+```
+
+The run is delivered when the durable ticket and visible session are linked.
+Whether the agent later finds issues, needs input, or fails is ordinary
+ticket/session state, not an automation-engine run state.
+
+## Minimal ordered reading path
+
+Read these in order before implementing the foundation. Later-slice files can wait
+until their slice begins.
+
+1. `docs/vision/attn-automations.md` — product invariants and scope. It is the
+   authority when a mechanical shortcut conflicts with the intended behavior.
+2. `internal/daemon/delegate.go`: `delegate`, `createDelegationWorktree`,
+   `createDelegatedTicket` — the current end-to-end assembly path and the behavior
+   to extract without reusing its source-session assumptions or side-effect order.
+3. `internal/daemon/ws_pty.go`: `handleSpawnSession` — driver validation, launch
+   pins, workspace requirements, PTY-before-store crash window, and current global
+   auto-approve inheritance.
+4. `internal/store/tickets.go`: `CreateRoleOwnedTicket`, plus
+   `internal/store/ticket_events.go` and `internal/daemon/ticket_notify.go` — durable
+   chief ownership, append-only authorship, unread cursors, and notification.
+5. `internal/daemon/workspacelayout.go`: `addWorkspaceSessionPane` — existing
+   pane-adoption behavior needed to make delivery retryable rather than additive.
+6. `internal/agent/driver.go`, `codex.go`, and `claude.go` — capability validation
+   and the concrete automatic modes. Codex maps automatic approval to
+   `approval_policy="on-request"` plus `approvals_reviewer="auto_review"`; Claude
+   maps it to `--permission-mode auto`.
+7. `internal/store/sqlite.go` and representative store modules — migration and
+   transaction conventions for definitions, occurrences, runs, and
+   `automation_run_id`.
+8. `internal/daemon/daemon.go`: `performStartupPTYRecovery` and worker-session
+   reconciliation — automation recovery must run after PTY adoption stabilizes.
+9. `internal/tasks/{task,store,runner}.go` — prior art for injected clocks,
+   atomic claiming, orphan recovery, retry backoff, and coalescing. Reuse lessons,
+   not the task record: an automation run has a definition snapshot, occurrence,
+   external side effects, and long-lived delivery links that `kind + subject`
+   cannot represent.
+10. `internal/protocol/schema/main.tsp`, `internal/protocol/constants.go`,
+    `internal/client`, and an existing CLI request/result command — the foundation
+    CLI and later UI must share one daemon API and obey protocol versioning.
+
+Before the repository/GitHub slices, add:
+
+11. `internal/git/worktree.go`, `internal/daemon/worktree.go`, and
+    `internal/git/resolve.go`: `ResolveMainRepoPath`, `OriginHostOwnerRepo` — reuse
+    repository identity checks, but add an exact-revision detached-worktree
+    operation rather than the current named-branch delegation behavior.
+12. `internal/github/client.go`: `SearchReviewRequestedPRs`, `FetchPRDetails`, and
+    `internal/daemon/daemon.go`: `pollPRs`/`doPRPoll` — consume the existing 90-second
+    refresh result; do not add a second GitHub polling loop.
+
+## Module boundaries
+
+```text
+internal/automation
+  Definition + validated immutable snapshot
+  Occurrence claim and dedupe
+  Run state and visible failure
+  RunNow, provider acceptance, recovery
+  continuity/catch-up policy and coalescing as later slices exercise them
+            │
+            │ Deliverer interface only
+            ▼
+internal/workdelivery
+  Deliver(WorkRequest) -> DeliveryResult
+  stable ticket/session/workspace/pane identities
+  ticket-first ensure/adopt lifecycle
+  LocationPreparer + SessionLauncher ports
+            │
+            ├─ internal/git and repository materializer
+            ├─ ticket/store operations
+            └─ daemon workspace, pane, PTY adapters
+
+internal/store
+  SQLite rows, constraints, and transactions
+  no trigger, retry, continuity, or launch policy
+
+internal/daemon
+  composes engine, delivery adapters, GitHub/schedule providers, recovery order
+  translates protocol requests/results and broadcasts compact updates
+
+cmd/attn + internal/client
+  CLI presentation and transport only
+```
+
+The module interfaces should be usable with in-memory fakes. Neither
+`internal/automation` nor the core of `internal/workdelivery` should require a
+live daemon, WebSocket client, wall clock, UUID generator, filesystem, or GitHub
+client in unit tests.
+
+### Core interfaces
+
+```go
+type Engine struct {
+    Store      AutomationStore
+    Deliverer  Deliverer
+    Clock      Clock
+    IDs        IDGenerator
+}
+
+func (e *Engine) ApplyDefinition(ctx context.Context, spec DefinitionSpec) (Definition, error)
+func (e *Engine) RunNow(ctx context.Context, definitionID, requestID string, input json.RawMessage) (Run, error)
+func (e *Engine) Accept(ctx context.Context, observation Observation) (Run, error)
+func (e *Engine) Recover(ctx context.Context) error
+
+type Deliverer interface {
+    Deliver(context.Context, WorkRequest) (DeliveryResult, error)
+}
+
+type LocationPreparer interface {
+    Prepare(context.Context, LocationRequest) (PreparedLocation, error)
+}
+
+type SessionLauncher interface {
+    EnsureSession(context.Context, SessionLaunchRequest) (SessionLaunchResult, error)
+}
+```
+
+`EnsureSession` is an internal daemon operation, not a loopback WebSocket call. It
+should reuse validation and launch helpers from `handleSpawnSession` while allowing
+the caller to pass the automation invariant `AutoApprove: true` explicitly.
+
+## Definition and boundary shapes
+
+Definitions are profile-local YAML/JSON documents stored canonically in SQLite.
+The initial CLI surface is intentionally small:
+
+```text
+attn automation apply --file review.yml
+attn automation list
+attn automation show pr-review
+attn automation run pr-review [--input-file occurrence.json]
+attn automation runs pr-review
+```
+
+The CLI generates one request ID per `run` invocation and reuses it if transport
+delivery is retried. The engine turns it into occurrence key
+`manual:<request-id>`. Repeating the same request ID returns the same run; a new
+CLI invocation intentionally creates a fresh run.
+
+There is no approval field:
+
+```yaml
+api_version: attn.dev/automations/v1alpha1
+id: local-review
+name: Local review
+enabled: true
+
+trigger:
+  type: manual
+
+prompt: |
+  Review the supplied work. Present the result locally in this ticket and session.
+
+launch:
+  driver: codex
+  model: gpt-5.5
+  effort: high
+
+location:
+  type: directory
+  path: /Users/example/src/repository
+
+policy:
+  continuity: fresh
+```
+
+The PR-review form keeps trigger filtering separate from object-source placement:
+
+```yaml
+api_version: attn.dev/automations/v1alpha1
+id: requested-pr-review
+name: Requested PR review
+enabled: true
+
+trigger:
+  type: github_review_requested
+  repositories:
+    mode: all_accessible
+    include: []
+    exclude: []
+
+prompt: |
+  Review this pull request. Explain what it does, why it exists, and how it works.
+  Report findings and risks, then give me the best file reading order. Present the
+  result locally. Do not post, approve, comment, or otherwise modify GitHub.
+
+launch:
+  driver: codex
+  model: gpt-5.5
+  effort: high
+
+location:
+  type: repository_worktree
+  repository_sources:
+    default:
+      type: managed_cache
+    overrides:
+      "github.example.com/platform/large-monorepo":
+        type: local_clone
+        path: /Users/example/src/large-monorepo
+
+policy:
+  continuity: per_subject
+  catch_up: latest
+  overlap: coalesce
+```
+
+The example paths illustrate configuration shape only. No user's path belongs in
+source, fixtures intended for shipping, or built-in defaults.
+
+The first implementation accepts only `overlap: coalesce`. `fresh`,
+`per_subject`, and `singleton` continuity plus `skip` and `latest` catch-up remain
+configurable because the planned manual, PR-review, and scheduled cases exercise
+them. Do not implement `queue` or `parallel` until a real automation needs them.
+
+```go
+type LaunchSpec struct {
+    Driver     string
+    Model      string
+    Effort     string
+    Executable string // optional explicit selection; empty means registered driver executable
+}
+
+// Automatic approval is an engine invariant, not a field above.
+type EffectiveLaunch struct {
+    LaunchSpec
+    ApprovalProductMode string // "auto"
+    ApprovalDriverMode  string // Codex auto_review or Claude auto
+}
+
+type LocationSpec struct {
+    Type              "directory" | "repository_worktree"
+    Path              string
+    RepositorySources RepositorySources
+}
+
+type WorkRequest struct {
+    RunID, DefinitionID, SubjectKey, ContinuityKey string
+    Prompt                                         string
+    Context                                        json.RawMessage
+    Launch                                         EffectiveLaunch
+    Location                                       LocationSpec
+    IDs                                            DeliveryIDs
+    Provenance                                     Provenance
+}
+
+type DeliveryResult struct {
+    TicketID, SessionID, WorkspaceID string
+    Directory, Revision              string
+    Mode                             "created" | "adopted" | "continued" | "resumed"
+}
+```
+
+Provider context remains structured and clearly delimited from the configured
+prompt. The first slices do not add general string templating: an untrusted PR
+title or body must not become executable automation policy.
+
+## Durable data model
+
+Use explicit columns for identity, state, constraints, and links. JSON is
+appropriate for versioned definition/run snapshots and provider context, not for
+fields needed by recovery or uniqueness checks.
+
+### `automation_definitions`
+
+| Field | Purpose |
+|---|---|
+| `id` | Stable profile-local slug and event-author identity component. |
+| `name`, `enabled`, `deleted_at` | Current management state; deletion is soft while history exists. |
+| `revision` | Monotonic integer incremented by semantic definition edits. |
+| `spec_json` | Canonical validated current specification. |
+| `created_at`, `updated_at` | Audit timestamps. |
+
+A separate revisions table is unnecessary initially: every accepted run stores
+the complete immutable effective snapshot. Add revision history only if users need
+to browse unexecuted historical edits.
+
+### `automation_occurrences`
+
+| Field | Purpose |
+|---|---|
+| `id`, `definition_id`, `provider` | Durable observation identity. |
+| `occurrence_key` | Provider-defined dedupe key; unique with definition and provider. |
+| `subject_key` | Stable work subject, such as `host/owner/repo#123`. |
+| `observed_at`, `payload_json` | When and what was observed; payload is untrusted context. |
+| `created_at` | Claim time. |
+
+Unique constraint: `(definition_id, provider, occurrence_key)`. The occurrence
+key answers whether work is new; it never selects a continuity session.
+
+### `automation_runs`
+
+| Field | Purpose |
+|---|---|
+| `id`, `definition_id`, `occurrence_id` | One run per accepted occurrence. |
+| `definition_revision`, `snapshot_json` | Immutable effective prompt, launch, location, policy, and schema version. |
+| `state`, `last_error` | Coarse lifecycle and visible failure. |
+| `ticket_id`, `session_id`, `workspace_id` | Preallocated stable delivery IDs and durable links. |
+| `resolved_location_json` | Configured source, resolved main repo/cache, worktree, and exact revision. |
+| `created_at`, `updated_at`, `delivered_at` | Lifecycle timestamps. |
+
+Persist only the lifecycle state the user or recovery coordinator needs:
+
+```text
+pending -> delivered
+    └───> failed
+```
+
+The idempotent ensure operations and durable artifact links determine the next
+recovery action; intermediate implementation phases are not persisted as a second
+state machine. Do not mark a run delivered based only on a successful spawn call.
+It is delivered after the session exists durably and the run, ticket, and session
+links agree.
+
+### Ticket provenance
+
+Add one nullable `automation_run_id` field to tickets. Automation delivery sets:
+
+```text
+automation_run_id = <run id>
+event author = automation:<definition id>
+role owner   = chief_of_staff
+```
+
+A partial unique index on `automation_run_id` makes ticket creation an idempotent
+ensure. The run stores the forward ticket link; `automation_run_id` enables reverse
+navigation and proves which immutable snapshot created the work without inventing
+a generic origin system before another origin type exists.
+
+Continuity later adds `automation_continuity_bindings(definition_id,
+continuity_key, ticket_id, session_id, updated_at)` with a unique definition/key
+pair. Do not add that table to the foundation before a slice exercises reuse.
+
+## Delivery lifecycle and recovery
+
+### New run
+
+1. In one transaction, claim the occurrence, snapshot the current definition,
+   and reserve stable run, ticket, session, workspace, and pane IDs.
+2. Validate the immutable snapshot before external side effects: driver exists,
+   model/effort are supported, automatic approval is supported, location shape is
+   valid, and required occurrence fields exist.
+3. Ensure the chief-role-owned ticket using `automation_run_id` and author
+   `automation:<definition-id>`. Assign it to the preallocated session ID even
+   though the runtime does not exist yet.
+4. Prepare or adopt the location. On failure, leave a visible failed ticket/run
+   with the specific reason.
+5. Ensure an unmuted workspace and session pane using the stable IDs.
+6. Ensure the session with the snapshotted prompt, structured context, exact CWD,
+   `LaunchSpec`, and explicit automatic approval. Advance the agent's ticket cursor
+   past the creation event because the initial prompt carries the brief out of band.
+7. Persist resolved links and mark the run delivered. Broadcast compact run and
+   ticket updates; best-effort nudge the chief through the normal ticket path.
+
+### Restart recovery
+
+Automation recovery begins only after worker PTY recovery/adoption and workspace
+layout reconciliation have stabilized. For each nonterminal run, replay the
+following ensures with the reserved IDs:
+
+```text
+ticket by automation_run_id exists?    create or adopt
+location exists at expected revision? prepare or adopt; mismatch fails visibly
+workspace/pane exist?                  create or adopt
+worker/session with session ID live?   adopt; otherwise safely spawn once
+all durable links agree?               mark delivered
+```
+
+An existing worktree is adoptable only when its Git common directory matches the
+resolved source and `HEAD` equals the snapshotted revision. A dirty or mismatched
+worktree is evidence, not disposable debris; fail visibly and do not reset it.
+
+Configuration and capability failures move the run to `failed`. Crash interruptions
+leave it `pending` and reconcile automatically with the same snapshot and IDs.
+After correcting a failed definition, Run now creates a new occurrence and run; it
+never retries by mutating the old run's meaning.
+
+## Repository materialization
+
+For `repository_worktree`, resolution is deterministic:
+
+1. Canonicalize the occurrence identity as lowercase host plus owner/repository for
+   matching while retaining provider display values.
+2. If an explicit local-clone override matches, require that the path exists, is a
+   Git repository, resolves through `ResolveMainRepoPath` if it is itself a
+   worktree, and that `OriginHostOwnerRepo` matches the requested identity.
+3. If the explicit override is invalid, fail visibly. Do not ignore the user's
+   configuration by falling back.
+4. Otherwise ensure a non-bare managed clone below the active profile data root,
+   for example `automations/repos/<safe-repo-key>/repo`. The exact internal path is
+   derived by attn and is not stored as a source default in shipped configuration.
+5. Fetch the provider-specified PR ref/revision under a per-repository lock, verify
+   the snapshotted SHA resolves to a commit, and never substitute the moving branch
+   head.
+6. Create a detached worktree below
+   `automations/worktrees/<session-id>/<repo-name>` using the stable session ID.
+   Add a dedicated exact-revision Git helper; do not create or share a named branch.
+7. Start the session with that worktree as its CWD and persist the configured source,
+   resolved main repository, worktree path, and revision on the run.
+
+The managed clone persists across runs. A per-session worktree persists while its
+ticket/session is inspectable; agent idle is not a deletion signal. The initial
+implementation provides explicit cleanup only. Automatic cleanup belongs in a
+later lifecycle slice and must refuse to discard dirty worktrees.
+
+For large Bazel repositories, the local-clone override reuses the repository's Git
+objects and existing machine configuration. Per-session paths still produce
+distinct Bazel output bases, while repository/disk/remote caches configured outside
+the worktree can remain shared. Verification must measure representative disk and
+startup behavior rather than assuming the override removes all per-worktree cost.
+
+## Functional walking-skeleton slices
+
+### Slice 1 — Manual definition to visible agent
+
+**User can:** apply a manual YAML definition with an explicit directory, run it
+from the CLI, see one chief-owned ticket and visible agent session, inspect the
+immutable run, safely repeat a transport request, and recover an interrupted
+delivery after restarting the non-production daemon.
+
+Build the minimal store, `internal/automation`, `internal/workdelivery`, daemon
+composition, CLI/client commands, ticket `automation_run_id`, explicit
+`LaunchSpec`, directory `LocationSpec`, fixed automatic approval, deterministic
+delivery IDs, and startup reconciler. Use a fresh workspace/session for every run.
+Do not add GitHub, schedules, continuity, a polished editor, or repository cloning.
+
+Directory mode is a real generic automation location for manual and scheduled work,
+not a temporary implementation of PR review. This slice uses it to isolate and prove
+the engine-to-delivery/recovery spine before Git enters the path. PR definitions do
+not use directory mode: Slice 2 adds their required exact-SHA per-session worktree
+behind the same `LocationPreparer` interface.
+
+**Exit evidence:** unit/store/protocol tests; every partial-failure checkpoint
+converges to one delivery; `make dev` packaged app run with a real harmless agent;
+restart during delivery; CLI shows the same run/ticket/session afterward.
+
+**Implementation record (2026-07-19):** Slice 1 landed the planned vertical
+spine through PR #597. `internal/automation` owns definition validation
+and immutable effective snapshots; `internal/store/automations.go` and migration
+73 own the atomic occurrence/run claim and provenance; `internal/workdelivery`
+owns ticket-first delivery; and `internal/daemon/automations.go` composes stable-ID
+delivery, recovery, and unattended launch verification. `cmd/attn/automation.go`
+exposes `apply`, `list`, `show`, `run`, and `runs`. Session launch now persists a
+complete row before spawning the PTY, and automatic approval/trust is available
+only through an internal automation launch policy rather than the general spawn
+protocol.
+
+Automated verification passed (`go test ./...`, frontend unit tests, generated
+types, diff checks, and the PR's daemon/frontend/E2E/release/benchmark checks).
+Packaged live verification used the fixed `automations` profile and proved a real
+happy-path ticket/session, reusable-request idempotency, invalid input rejected
+before claim, and daemon-death recovery to exactly the same stable ticket,
+workspace, pane, and session. The durable occurrence artifact keeps provider
+payload separate from configured instructions, and one-shot model/effort/approval
+transport values do not leak into the agent child environment.
+
+The implementation preserves the planned product behavior. The delivery topology
+has one recorded exception: Victor authorized this first slice PR to merge directly
+to `main` after it was green and Figgyster-approved, rather than waiting for a final
+integration PR. PR #597 merged as `6c563d4a` after the exact refreshed head passed
+CI and received Figgyster approval. Reconfirm the branch topology before starting
+Slice 2.
+
+### Slice 2 — Manual PR review in an exact per-session worktree
+
+**User can:** configure managed cache plus repository-specific local-clone
+overrides, run the review automation manually for a PR, and receive a local review
+brief from an agent working at the exact snapshotted head SHA in its own worktree.
+
+Add `repository_worktree`, managed clone/fetch, override validation, detached
+worktree ensure/adopt, structured PR input, and a CLI convenience that resolves a
+PR URL into the typed input. Keep the trigger manual; this slice proves location,
+prompt/context separation, and the actual review output before background
+observation is allowed to launch agents.
+
+**Exit evidence:** managed-cache and local-override paths both work; two runs for
+the same PR create two different session worktrees at the same SHA; a changed PR
+head produces a new snapshot; invalid/mismatched override fails without fallback;
+large-monorepo Bazel cache behavior is measured; no GitHub mutation occurs.
+
+**Implementation record (2026-07-19):** Slice 2 extends the same manual-run spine
+with typed GitHub pull-request occurrences and `repository_worktree` locations.
+`attn automation run <id> --pr-url <url>` performs one focused read-only PR GET,
+validates and stores the provider payload before delivery, and keeps the title,
+body, and other provider fields out of configured instructions. Definitions select
+a profile-managed cache by default and may pin canonical repository identities to
+validated local clones. Delivery resolves the immutable occurrence SHA, creates or
+adopts a clean detached per-session worktree under the active profile, binds the
+ticket CWD only after preparation, and records configured source, main repository,
+worktree, provider ref, and revision in `resolved_location_json`. Existing dirty,
+attached, foreign, or wrong-revision paths fail unchanged.
+
+Automated evidence covers strict definition/PR validation, occurrence subject
+provenance, one-GET/no-mutation GitHub resolution, managed-cache protection,
+local-clone origin validation, moved-ref recovery using an already-present
+snapshot, clean detached worktree creation/adoption, dirty/attached rejection
+before launch, stable-session adoption after an agent has begun editing, delayed
+recovery until initial GitHub host discovery, and retryable recovery when private
+repository credentials are temporarily unavailable.
+`go test ./...`, the 1,848-test frontend suite, generated types, and diff checks
+passed. A final `gpt-5.6-terra` high autoreview reported no actionable findings.
+Figgyster's first review identified a symlinked-profile publication edge: clone
+validation canonicalized the staged path before rename, so the old implementation
+could return the removed staging spelling. The refreshed head revalidates the
+published target and includes the requested symlink-parent regression; the full Go
+suite and a focused `gpt-5.6-terra` high autoreview pass on that fix.
+The refreshed PR CI is green. E2E shard 3 needed two unchanged-head reruns: the
+first two attempts failed in different pre-existing terminal-find and split-render
+tests, and the third passed. Figgyster approved exact head
+`951375115910de2e5d8f3a4f247dcdff2868f3a2` after verifying the requested fix.
+
+Packaged live verification used the fixed `automations` profile and open docs-only
+attn PR #404 at `67fc97c9974239492c9bfb6e7db4f47f0677e4e7`:
+
+- managed-cache run `0929092c-703c-4b08-a73b-c18dfeebc47d` created ticket
+  `auto-0929092c703c4b08` and session
+  `bfab9ef1-3072-47ee-a0c5-5c58fc263d88`;
+- local-override run `cb895816-6aa5-4e58-8253-f570f6b9e151` created ticket
+  `auto-cb8958166aa54e58` and session
+  `8a018788-d15e-4602-be9e-7360f78e42ae`;
+- both tickets reached review, both worktrees were clean and detached at the exact
+  same SHA, their Git common directories resolved to the managed cache and the
+  configured local clone respectively, and replaying the local request ID returned
+  the same run/session/worktree;
+- process launch evidence pinned `gpt-5.6-terra`, high effort,
+  `approval_policy=on-request`, and `approvals_reviewer=auto_review`; and
+- a mismatched explicit override was rejected before persistence with no managed
+  fallback.
+
+After the recovery fixes, the same packaged profile completed a fresh managed
+happy path as run `c9b2fa2f-1e06-4e5c-b051-d33b13fa50dc`, ticket
+`auto-c9b2fa2f1e064e5c`, and session
+`ddac6e6d-dac6-414a-89bb-63f02107ccdb`. It again resolved PR #404 to the exact
+recorded SHA, produced a clean detached worktree, exposed the chief-owned working
+ticket, and returned the same durable run and artifact IDs when its request ID was
+replayed.
+
+For the large-Bazel gate, launching an external model against the private
+`services-pilot` repository was disallowed by the environment's data-boundary
+policy. The local-only equivalent measured an exact detached worktree for PR
+#147816 without exposing source: checkout was about 2.49 GiB while the shared Git
+object store was about 15.28 GiB; `bazel info output_base` started in 3.17 seconds
+and produced a worktree-specific output base distinct from the main checkout's
+3.21-second startup/output base. The clean temporary measurement worktree was
+removed afterward and is reproducible from the recorded SHA. Public-repository
+live agent happy paths still cover both materialization modes.
+
+Victor's per-slice PR instruction is treated as the current delivery topology:
+Slice 2 targets `main` directly and stops after green CI plus exact-head Figgyster
+approval for Victor's review.
+
+### Slice 3 — Review-requested observation without a duplicate reviewer
+
+**User can:** enable a GitHub review-request definition and have a newly requested
+review automatically create the same prepared local result proven in Slice 2.
+
+Add a GitHub observation adapter beside `doPRPoll`, repository all/include/exclude
+filtering, a durable review-request edge ledger, occurrence keys, `latest` downtime
+catch-up, and a `per_subject` binding created before delivery. Use `coalesce` so
+every accepted occurrence for one PR is recorded on the same ticket/reviewer rather
+than launching another session. Consume existing refreshed PR snapshots and fetch
+details only to pin required evidence such as head SHA; do not add another poller.
+
+**Exit evidence:** repeated polls produce one run; remove/re-request produces a new
+occurrence on the same PR ticket/reviewer; daemon downtime with current demand
+produces at most one latest run; excluded repositories do nothing; concurrent or
+replayed observations for one PR never create a second reviewer session.
+
+### Slice 4 — Return later PR cycles to the same reviewer
+
+**User can:** choose `per_subject` continuity so a later review-request cycle for
+the same PR returns to the existing ticket/reviewer when safe, while every accepted
+occurrence and run remains visible.
+
+Deepen the subject binding introduced with automatic GitHub delivery: add
+automation-authored ticket occurrence events, live nudge, ticket resume, and
+explicit fresh fallback/failure rules. Keep occurrence identity and continuity
+identity separate. Decide behavior from evidence for archived tickets, missing or
+dirty worktrees, unavailable transcripts, and changed head SHAs; never silently
+bind a new revision to the wrong CWD.
+
+**Exit evidence:** duplicate occurrence remains one run; a new cycle is a new run
+linked to the same ticket; live, stopped/resumable, archived, missing-worktree, and
+dirty-worktree cases each follow an explicit tested path.
+
+Implemented in PR #614: a live reviewer keeps the nudge path; a stopped reviewer
+resumes only with a recorded resume target under the immutable unattended launch
+snapshot; successful continuation reopens an archived ticket; an automation-owned
+dirty or branch-changed worktree is preserved; missing worktrees, unavailable
+transcripts, and changed PR heads fail visibly. A serial packaged-app scenario on
+the fixed `automations` profile copied an existing Codex rollout and completed the
+happy path plus missing-worktree failure in 36 seconds. It proved the same ticket,
+session, and worktree, preserved dirty review notes, passed the copied rollout to
+`codex resume`, and retained `gpt-5.6-terra` with high effort and automatic review
+approval. The scenario emits a machine-readable summary and restores the isolated
+daemon after each run. Figgyster's exact-rollout finding is addressed by making
+Codex implement `ResumeAvailabilityProvider` through
+`transcript.FindCodexTranscriptForResume`. Unit and daemon regressions cover both
+present and missing rollouts; the packaged scenario rerun on that fix remains the
+next gate.
+
+### Slice 5 — Scheduled prompt with one real maintenance job
+
+**User can:** define and run a scheduled prompt, survive daemon downtime according
+to `skip` or `latest`, and use it for the second proving case: merged-worktree
+cleanup prepared through an ordinary visible agent session.
+
+Add a clock-driven schedule adapter, intended-instant occurrence keys, time-zone
+validation, restart reconciliation, and one real cleanup definition. Provider code
+only observes due instants; the existing engine and delivery path do the work.
+
+**Exit evidence:** DST/time-zone table tests; restart before/after a due instant;
+no replay storm; one visible maintenance ticket/session; dirty worktrees are never
+silently deleted.
+
+### Slice 6 — Profile-level Automations surface
+
+**User can:** scan definitions and failures, enable/disable, Run now, inspect run
+history, and navigate directly to the resulting ticket/session in the app.
+
+Add request/result protocol mutations and compact update broadcasts, then a
+profile-level UI. Keep canonical state in SQLite and re-read after broadcasts. The
+first UI may leave definition authoring in YAML/CLI; it is still functional because
+all operational actions and resulting work are visible.
+
+**Exit evidence:** packaged-app create-via-CLI/manage-via-UI journey; request
+failure is shown rather than optimistically hidden; restart preserves list and
+navigation; no duplicate run from repeated UI response handling.
+
+### Slice 7 — Self-service editing and lifecycle completion
+
+**User can:** create and edit definitions in the app, choose supported continuity,
+catch-up, repository filters, and source overrides, understand validation errors,
+and manage retained history/worktrees.
+
+Add the polished editor only after two providers have fixed the internal provider
+seam. Complete definition edit/disable/delete semantics, bounded retention, and safe
+explicit cleanup. Keep overlap fixed to `coalesce`; `queue`, `parallel`, and public
+provider plugins remain deferred until concrete use cases supply their requirements.
+
+**Exit evidence:** full end-to-end journeys for PR review and scheduled maintenance;
+edits do not change old snapshots; disable stops new occurrences without killing
+active work; delete retains provenance; cleanup preserves dirty worktrees; final
+upgrade and packaged-app matrix pass from the integration branch.
+
+## Verification strategy
+
+### Idempotency
+
+- Same definition/provider/occurrence key returns the existing occurrence and run.
+- Same CLI request ID returns the same run, ticket, session, workspace, and pane.
+- A new CLI request ID creates an independent fresh run.
+- Ticket `automation_run_id` uniqueness prevents a second ticket even if delivery retries after
+  losing the first response.
+- A PR subject binding plus `coalesce` prevents repeated or concurrent observations
+  from creating a second reviewer session for the same PR.
+- Worktree adoption validates Git common directory and exact `HEAD`, not path
+  existence alone.
+
+### Partial failure
+
+Inject a crash/error after each durable or external boundary and run recovery:
+
+| Checkpoint | Required result after recovery |
+|---|---|
+| occurrence/run transaction commits | one pending run proceeds |
+| ticket commits | same ticket is adopted by automation_run_id |
+| managed clone/fetch completes | repository is reused under its lock |
+| worktree is added | same correct worktree is adopted |
+| workspace is registered | same workspace is adopted |
+| pane is added | same pane/session slot is adopted |
+| PTY spawns before session row persists | worker recovery/adoption settles before automation retries |
+| session row persists before run link | links reconcile and run becomes delivered |
+| delivered commit succeeds but response is lost | repeated request returns the delivered run |
+
+Every case must finish with at most one ticket, worktree, workspace, pane, and live
+session for the reserved delivery IDs. Mismatch or dirty evidence produces a
+visible failure; tests must never make recovery pass by deleting evidence.
+
+### Daemon restart
+
+- Start automation reconciliation after `performStartupPTYRecovery`, including its
+  worker recovery retries, not concurrently with it.
+- Cover no chief session, chief starting later, worker already adopted, missing
+  worker metadata, and a recoverable persisted session.
+- Edit the definition before restart and prove the old pending run still uses
+  its immutable snapshot.
+- Restart repeatedly and prove convergence, not just a successful single restart.
+
+### Live non-production app
+
+For every slice that touches daemon lifecycle, protocol, PTY, Git, or UI:
+
+1. Build/install the isolated dev app (`make dev`) outside the sandbox.
+2. Point the CLI at the dev profile and apply a fixture definition containing only
+   temporary/test paths.
+3. Run the user journey with a real supported agent in automatic mode and confirm
+   the workspace, ticket, session, CWD, prompt, and run links in the packaged app.
+4. Restart only the dev daemon/app at the slice's interruption checkpoint and
+   confirm one recovered delivery.
+5. For repository slices, inspect `git rev-parse HEAD`, Git common directory, and
+   worktree path from the live session. For GitHub slices, use a non-production or
+   explicitly read-only PR scenario and verify no comment/review/approval was made.
+6. Capture commands, run IDs, ticket/session IDs, relevant logs, and screenshots in
+   the slice PR. Do not treat unit tests as a substitute for this evidence.
+
+## Risks and implementation-time gates
+
+- **Automatic approval is not a universal no-write policy.** Codex auto-review and
+  Claude auto use different classifiers and runtime/account capabilities. The
+  configured local-only prompt is necessary, but it does not mathematically prevent
+  a tool from mutating GitHub. If stronger enforcement becomes a release
+  requirement, design a driver/tool-policy boundary explicitly rather than calling
+  the fixed `auto` mode sufficient.
+- **Current spawn ordering has a real crash window.** Delivery recovery must account
+  for a worker created before its session row; simply wrapping `handleSpawnSession`
+  and retrying can duplicate or kill work.
+- **Review-request cycles need evidence beyond the current PR row.** The GitHub
+  slice must prove the edge key for remove/re-request and offline `latest` behavior
+  before continuity relies on it.
+- **Repository caches need concurrency and disk lifecycle rules.** Serialize
+  clone/fetch per repository, retain inspectable worktrees, and add deletion only
+  through an explicit dirty-safe lifecycle.
+- **Large Bazel worktrees retain per-path cost.** Shared disk/repository/remote
+  caches help, but every session has its own output-base identity. Measure the real
+  monorepo path during Slice 2 and adjust retention without weakening per-session
+  isolation.
+- **A long feature branch magnifies drift.** Keep slice PRs green and functional,
+  merge `main` regularly, and run the main-to-feature migration and final packaged
+  app matrix before the integration PR.
+
+## Implementation checklist
+
+- [x] Create the long-lived feature branch and protect the slice-PR workflow.
+- [x] Implement and live-verify Slice 1; update this guide with actual symbols and
+      any conservative deviations forced by code evidence.
+- [x] Implement and live-verify Slice 2, including the large-repository measurement.
+- [x] Implement and live-verify Slice 3 before enabling background launches broadly.
+- [ ] Finish PR #614: rerun packaged continuity verification on the exact-rollout
+      fix, obtain green checks and Figgyster approval, then stop unmerged for review.
+- [ ] Add schedule and its real maintenance case through the same engine.
+- [ ] Add operational UI, then the editor and remaining policy depth.
+- [ ] Run the final upgrade, failure-recovery, and packaged-app matrix from the
+      integration branch and open the single integration PR to `main`.
+
+When implementation forces a choice that changes the product behavior described
+in the vision, stop and update the vision by agreement. When it only changes code
+shape while preserving these invariants, record the reason here and continue.

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -466,6 +466,13 @@ func (c *Codex) FindTranscriptForResume(resumeID string) string {
 	return transcript.FindCodexTranscriptForResume(resumeID)
 }
 
+// ResumeAvailable reports whether Codex still has the exact rollout recorded
+// for a stopped session. Unattended continuation must fail closed when Codex
+// has pruned or moved that rollout.
+func (c *Codex) ResumeAvailable(resumeID string) bool {
+	return transcript.FindCodexTranscriptForResume(resumeID) != ""
+}
+
 func (c *Codex) BootstrapBytes() int64 {
 	return 256 * 1024
 }

--- a/internal/agent/resume_available_test.go
+++ b/internal/agent/resume_available_test.go
@@ -47,15 +47,22 @@ func TestResumeAvailableEmptyID(t *testing.T) {
 	}
 }
 
-// Drivers that don't implement ResumeAvailabilityProvider are assumed
-// always-resumable, so their resume behavior is unchanged. Codex resumes by
-// rollout id (not a transcript lookup) and a zero-turn codex never stores a
-// rollout id, so it never reaches the reload path with a doomed resume id.
-func TestResumeAvailableDefaultsTrueForCodex(t *testing.T) {
-	if _, ok := any(&Codex{}).(ResumeAvailabilityProvider); ok {
-		t.Skip("Codex now implements ResumeAvailabilityProvider; update this test to assert its real behavior")
+func TestCodexResumeAvailable(t *testing.T) {
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	if ResumeAvailable(&Codex{}, "missing-rollout-id") {
+		t.Fatal("ResumeAvailable should be false when no Codex rollout exists")
 	}
-	if !ResumeAvailable(&Codex{}, "any-rollout-id") {
-		t.Fatal("ResumeAvailable should default to true for a driver without the capability")
+
+	sessionsDir := filepath.Join(codexHome, "sessions", "2026", "07", "20")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatalf("mkdir Codex sessions dir: %v", err)
+	}
+	rollout := []byte(`{"type":"session_meta","payload":{"id":"has-rollout-id","cwd":"/tmp"}}` + "\n")
+	if err := os.WriteFile(filepath.Join(sessionsDir, "rollout-fixture.jsonl"), rollout, 0o644); err != nil {
+		t.Fatalf("write Codex rollout fixture: %v", err)
+	}
+	if !ResumeAvailable(&Codex{}, "has-rollout-id") {
+		t.Fatal("ResumeAvailable should be true when the exact Codex rollout exists")
 	}
 }

--- a/internal/daemon/automations.go
+++ b/internal/daemon/automations.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	agentdriver "github.com/victorarias/attn/internal/agent"
 	"github.com/victorarias/attn/internal/automation"
 	attngit "github.com/victorarias/attn/internal/git"
 	"github.com/victorarias/attn/internal/github"
@@ -617,15 +618,38 @@ func (d *Daemon) validateAutomationContinuation(req automation.WorkRequest) erro
 	if d.canStartWithdrawnUndeliveredReviewer(origin, req.IDs.SessionID) {
 		return nil
 	}
+	if d.automationSessionIsLive(req.IDs.SessionID) {
+		return nil
+	}
+	_, err = d.automationResumeSessionID(req)
+	return err
+}
+
+func (d *Daemon) automationSessionIsLive(sessionID string) bool {
 	if d.ptyBackend == nil {
-		return errors.New("reviewer continuity cannot verify the existing session")
+		return false
 	}
 	for _, liveID := range d.ptyBackend.SessionIDs(context.Background()) {
-		if liveID == req.IDs.SessionID {
-			return nil
+		if liveID == sessionID {
+			return true
 		}
 	}
-	return errors.New("reviewer continuity requires the existing session to still be live")
+	return false
+}
+
+func (d *Daemon) automationResumeSessionID(req automation.WorkRequest) (string, error) {
+	resumeID := strings.TrimSpace(d.store.GetResumeSessionID(req.IDs.SessionID))
+	if resumeID == "" {
+		resumeID = strings.TrimSpace(d.store.GetTicketResumeSessionID(req.IDs.SessionID))
+	}
+	if resumeID == "" {
+		return "", errors.New("reviewer continuity cannot resume the stopped session without a recorded transcript")
+	}
+	driver := agentdriver.Get(req.Launch.Agent)
+	if !agentdriver.ResumeAvailable(driver, resumeID) {
+		return "", errors.New("reviewer continuity transcript is unavailable; refusing an unattended fresh session")
+	}
+	return resumeID, nil
 }
 
 func (d *Daemon) EnsureTicket(_ context.Context, req automation.WorkRequest) error {
@@ -723,9 +747,11 @@ func (d *Daemon) PrepareLocation(_ context.Context, req automation.WorkRequest) 
 	if err != nil {
 		return automation.PreparedLocation{}, err
 	}
-	if originRun, err := d.automationContinuationOrigin(req); err != nil {
+	originRun, err := d.automationContinuationOrigin(req)
+	if err != nil {
 		return automation.PreparedLocation{}, err
-	} else if originRun != nil {
+	}
+	if originRun != nil {
 		originOccurrence, err := d.store.GetAutomationOccurrence(originRun.OccurrenceID)
 		if err != nil || originOccurrence == nil {
 			return automation.PreparedLocation{}, errors.Join(errors.New("continuity origin occurrence missing"), err)
@@ -735,9 +761,6 @@ func (d *Daemon) PrepareLocation(_ context.Context, req automation.WorkRequest) 
 			return automation.PreparedLocation{}, fmt.Errorf("continuity origin payload: %w", err)
 		}
 		if originPR.HeadSHA != pr.HeadSHA {
-			// The stable session's CWD is the origin run's exact detached worktree.
-			// Until the next continuity slice defines resume/fallback rules for a new
-			// revision, failing is safer than silently reviewing the wrong checkout.
 			return automation.PreparedLocation{}, errors.New("reviewer continuity across a changed pull-request revision is not enabled yet")
 		}
 	}
@@ -808,6 +831,24 @@ func (d *Daemon) PrepareLocation(_ context.Context, req automation.WorkRequest) 
 			sessionPersisted = true
 		}
 	}
+	if originRun != nil && originRun.State == "delivered" {
+		ticket, err := d.store.GetTicket(req.IDs.TicketID)
+		if err != nil {
+			return automation.PreparedLocation{}, err
+		}
+		if ticket == nil || filepath.Clean(ticket.Cwd) != filepath.Clean(worktree) {
+			return automation.PreparedLocation{}, errors.New("reviewer continuity ticket does not own the expected worktree")
+		}
+		if _, err := os.Stat(worktree); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return automation.PreparedLocation{}, errors.New("reviewer continuity worktree is missing; refusing to recreate it silently")
+			}
+			return automation.PreparedLocation{}, fmt.Errorf("inspect reviewer continuity worktree: %w", err)
+		}
+		// A delivered origin proves that this stable session owned the worktree.
+		// Preserve its commits, branch switch, and local changes when resuming.
+		sessionPersisted = true
+	}
 	if _, err := attngit.EnsureAutomationSessionWorktree(mainRepo, worktree, pr.HeadSHA, authorization, sessionPersisted); err != nil {
 		return automation.PreparedLocation{}, &retryableAutomationDeliveryError{cause: err}
 	}
@@ -873,23 +914,34 @@ func (d *Daemon) EnsureSession(_ context.Context, req automation.WorkRequest, di
 	if err != nil {
 		return err
 	}
-	for _, liveID := range d.ptyBackend.SessionIDs(context.Background()) {
-		if liveID == req.IDs.SessionID {
-			// Worker recovery adopted the already-correct original launch. Do not
-			// ask the backend to spawn the stable session ID a second time.
-			return d.verifyUnattendedLaunch(req)
-		}
+	if d.automationSessionIsLive(req.IDs.SessionID) {
+		// Worker recovery adopted the already-correct original launch. Do not ask
+		// the backend to spawn the stable session ID a second time.
+		return d.verifyUnattendedLaunch(req)
 	}
 	if continuationRun != nil {
-		if !d.canStartWithdrawnUndeliveredReviewer(continuationRun, req.IDs.SessionID) {
-			return errors.New("reviewer continuity requires the existing session to still be live")
+		if d.canStartWithdrawnUndeliveredReviewer(continuationRun, req.IDs.SessionID) {
+			return d.startAutomationSession(req, directory, inputPath, "")
 		}
+		resumeID, err := d.automationResumeSessionID(req)
+		if err != nil {
+			return err
+		}
+		return d.startAutomationSession(req, directory, inputPath, resumeID)
 	}
+	return d.startAutomationSession(req, directory, inputPath, "")
+}
+
+func (d *Daemon) startAutomationSession(req automation.WorkRequest, directory, inputPath, resumeID string) error {
 	_, pullRequestErr := automation.ParsePullRequestInput(req.Context)
 	prompt := automationSessionPrompt(req.Prompt, inputPath, pullRequestErr == nil)
 	client := newInternalWSClient()
-	d.handleSpawnSessionWithPolicy(client, &protocol.SpawnSessionMessage{Cmd: protocol.CmdSpawnSession, ID: req.IDs.SessionID, Cwd: directory, WorkspaceID: req.IDs.WorkspaceID, Agent: req.Launch.Agent, Cols: 80, Rows: 24, Label: protocol.Ptr(filepath.Base(directory)), InitialPrompt: protocol.Ptr(prompt), Model: protocol.Ptr(req.Launch.Model), Effort: protocol.Ptr(req.Launch.Effort), Executable: protocol.Ptr(req.Launch.Executable)}, internalSpawnPolicy{unattendedLaunch: req.Launch})
-	_, err = readInternalActionResult(client)
+	message := &protocol.SpawnSessionMessage{Cmd: protocol.CmdSpawnSession, ID: req.IDs.SessionID, Cwd: directory, WorkspaceID: req.IDs.WorkspaceID, Agent: req.Launch.Agent, Cols: 80, Rows: 24, Label: protocol.Ptr(filepath.Base(directory)), InitialPrompt: protocol.Ptr(prompt), Model: protocol.Ptr(req.Launch.Model), Effort: protocol.Ptr(req.Launch.Effort), Executable: protocol.Ptr(req.Launch.Executable)}
+	if resumeID != "" {
+		message.ResumeSessionID = protocol.Ptr(resumeID)
+	}
+	d.handleSpawnSessionWithPolicy(client, message, internalSpawnPolicy{unattendedLaunch: req.Launch})
+	_, err := readInternalActionResult(client)
 	if err != nil {
 		return err
 	}

--- a/internal/daemon/automations_test.go
+++ b/internal/daemon/automations_test.go
@@ -27,6 +27,20 @@ type automationResumeBackend struct {
 	snapshotCalls int
 }
 
+func writeCodexRolloutFixture(t *testing.T, resumeID string) {
+	t.Helper()
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	sessionsDir := filepath.Join(codexHome, "sessions", "2026", "07", "20")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatalf("mkdir Codex sessions dir: %v", err)
+	}
+	rollout := []byte(`{"type":"session_meta","payload":{"id":"` + resumeID + `","cwd":"/tmp"}}` + "\n")
+	if err := os.WriteFile(filepath.Join(sessionsDir, "rollout-fixture.jsonl"), rollout, 0o644); err != nil {
+		t.Fatalf("write Codex rollout fixture: %v", err)
+	}
+}
+
 func (b *automationResumeBackend) Snapshot(context.Context, string) (ptybackend.AttachInfo, error) {
 	b.snapshotCalls++
 	if b.snapshotCalls == 1 {
@@ -916,6 +930,7 @@ func TestStoppedContinuationResumesRecordedReviewerWithPinnedContract(t *testing
 	}
 	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{Cmd: protocol.CmdRegisterWorkspace, ID: origin.WorkspaceID, Title: "review", Directory: directory})
 	d.store.Add(&protocol.Session{ID: origin.SessionID, Agent: protocol.SessionAgentCodex, Directory: directory, WorkspaceID: origin.WorkspaceID})
+	writeCodexRolloutFixture(t, "codex-rollout-1")
 	d.store.SetResumeSessionID(origin.SessionID, "codex-rollout-1")
 
 	req := automation.WorkRequest{
@@ -943,6 +958,14 @@ func TestStoppedContinuationRequiresAvailableTranscript(t *testing.T) {
 	d.store.SetResumeSessionID(req.IDs.SessionID, "")
 	if _, err := d.automationResumeSessionID(req); err == nil || !strings.Contains(err.Error(), "without a recorded transcript") {
 		t.Fatalf("missing transcript id err=%v", err)
+	}
+
+	t.Setenv("CODEX_HOME", t.TempDir())
+	codexReq := automation.WorkRequest{Launch: testAutomationLaunch("codex"), IDs: automation.DeliveryIDs{SessionID: "session-2"}}
+	d.store.Add(&protocol.Session{ID: codexReq.IDs.SessionID, Agent: protocol.SessionAgentCodex})
+	d.store.SetResumeSessionID(codexReq.IDs.SessionID, "missing-codex-rollout")
+	if _, err := d.automationResumeSessionID(codexReq); err == nil || !strings.Contains(err.Error(), "transcript is unavailable") {
+		t.Fatalf("unavailable Codex rollout err=%v", err)
 	}
 }
 

--- a/internal/daemon/automations_test.go
+++ b/internal/daemon/automations_test.go
@@ -18,8 +18,36 @@ import (
 	"github.com/victorarias/attn/internal/github"
 	"github.com/victorarias/attn/internal/launchcontract"
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/ptybackend"
 	"github.com/victorarias/attn/internal/store"
 )
+
+type automationResumeBackend struct {
+	*fakeSpawnBackend
+	snapshotCalls int
+}
+
+func (b *automationResumeBackend) Snapshot(context.Context, string) (ptybackend.AttachInfo, error) {
+	b.snapshotCalls++
+	if b.snapshotCalls == 1 {
+		return ptybackend.AttachInfo{ScreenSnapshot: []byte(codexDirectoryTrustPrompt)}, nil
+	}
+	return ptybackend.AttachInfo{ScreenSnapshot: []byte("reviewer ready")}, nil
+}
+
+func testAutomationLaunch(agent string) automation.EffectiveLaunch {
+	driverMode := launchcontract.ApprovalAuto
+	if agent == string(protocol.SessionAgentCodex) {
+		driverMode = launchcontract.ApprovalAutoReview
+	}
+	return automation.EffectiveLaunch{
+		Agent: agent, Model: "review-model", Effort: "high",
+		ApprovalProductMode: launchcontract.ApprovalAuto,
+		ApprovalDriverMode:  driverMode,
+		DirectoryTrust:      launchcontract.TrustConfiguredDirectory,
+		Recovery:            launchcontract.RecoveryAdoptOrRestartFresh,
+	}
+}
 
 func TestPrepareRepositoryWorktreeUsesLocalOverrideAndExactRevision(t *testing.T) {
 	root := t.TempDir()
@@ -860,6 +888,190 @@ func TestChangedHeadContinuationFailsBeforePublishingTicketActivity(t *testing.T
 	}
 	if len(ticket.Activity) != 0 {
 		t.Fatalf("unsafe continuation published ticket activity before validation: %#v", ticket.Activity)
+	}
+}
+
+func TestStoppedContinuationResumesRecordedReviewerWithPinnedContract(t *testing.T) {
+	d := newDaemonForTest(t)
+	backend := &automationResumeBackend{fakeSpawnBackend: &fakeSpawnBackend{}}
+	d.ptyBackend = backend
+	now := time.Date(2026, 7, 20, 8, 0, 0, 0, time.UTC)
+	def, err := d.store.UpsertAutomationDefinition("review", "Review", `{}`, true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const subject = "github.com/owner/repo#42"
+	if _, err := d.store.ReconcileAutomationReviewRequests(def.ID, "github.com", []string{subject}, now); err != nil {
+		t.Fatal(err)
+	}
+	origin, _, err := d.store.ClaimGitHubReviewAutomationRun(def.ID, subject, 1, def.Revision, `{}`, `{}`, now, store.AutomationRunReservation{
+		RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	directory := t.TempDir()
+	if _, err := d.store.EnsureAutomationTicket(store.Ticket{ID: origin.TicketID, Title: "Review", Status: store.TicketStatusDone, Assignee: origin.SessionID, Cwd: directory, LastAgentID: "codex", AutomationRunID: origin.ID}, "automation:review", store.TicketRoleChiefOfStaff, now); err != nil {
+		t.Fatal(err)
+	}
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{Cmd: protocol.CmdRegisterWorkspace, ID: origin.WorkspaceID, Title: "review", Directory: directory})
+	d.store.Add(&protocol.Session{ID: origin.SessionID, Agent: protocol.SessionAgentCodex, Directory: directory, WorkspaceID: origin.WorkspaceID})
+	d.store.SetResumeSessionID(origin.SessionID, "codex-rollout-1")
+
+	req := automation.WorkRequest{
+		RunID: "run-2", DefinitionID: def.ID, SubjectKey: subject, ContinuityKey: subject,
+		Prompt: "Review locally", Context: json.RawMessage(`{}`), Launch: testAutomationLaunch("codex"),
+		IDs: automation.DeliveryIDs{TicketID: origin.TicketID, SessionID: origin.SessionID, WorkspaceID: origin.WorkspaceID, PaneID: origin.PaneID},
+	}
+	if err := d.EnsureSession(context.Background(), req, directory); err != nil {
+		t.Fatal(err)
+	}
+	spawn, ok := backend.LastSpawn()
+	if !ok || spawn.ResumeSessionID != "codex-rollout-1" || spawn.UnattendedLaunch != req.Launch {
+		t.Fatalf("resume spawn=%#v ok=%v", spawn, ok)
+	}
+}
+
+func TestStoppedContinuationRequiresAvailableTranscript(t *testing.T) {
+	d := newDaemonForTest(t)
+	req := automation.WorkRequest{Launch: testAutomationLaunch("claude"), IDs: automation.DeliveryIDs{SessionID: "session-1"}}
+	d.store.Add(&protocol.Session{ID: req.IDs.SessionID, Agent: protocol.SessionAgentClaude})
+	d.store.SetResumeSessionID(req.IDs.SessionID, "missing-transcript")
+	if _, err := d.automationResumeSessionID(req); err == nil || !strings.Contains(err.Error(), "transcript is unavailable") {
+		t.Fatalf("unavailable transcript err=%v", err)
+	}
+	d.store.SetResumeSessionID(req.IDs.SessionID, "")
+	if _, err := d.automationResumeSessionID(req); err == nil || !strings.Contains(err.Error(), "without a recorded transcript") {
+		t.Fatalf("missing transcript id err=%v", err)
+	}
+}
+
+func TestSuccessfulContinuationReopensArchivedTicket(t *testing.T) {
+	s := store.New()
+	now := time.Date(2026, 7, 20, 9, 0, 0, 0, time.UTC)
+	if _, err := s.CreateTicket(store.Ticket{ID: "ticket-1", Title: "Review", Status: store.TicketStatusDone, Assignee: "session-1", AutomationRunID: "run-1"}, "automation:review", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ArchiveTicket("ticket-1", now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	req := automation.WorkRequest{RunID: "run-2", DefinitionID: "review", ContinuityKey: "github.com/owner/repo#42", IDs: automation.DeliveryIDs{TicketID: "ticket-1"}}
+	if err := d.activateAutomationContinuationTicket(req); err != nil {
+		t.Fatal(err)
+	}
+	ticket, err := s.GetTicket("ticket-1")
+	if err != nil || ticket == nil || ticket.Status != store.TicketStatusWorking || ticket.ArchivedAt != nil {
+		t.Fatalf("reopened archived ticket=%#v err=%v", ticket, err)
+	}
+}
+
+func setupContinuationWorktree(t *testing.T) (*Daemon, automation.WorkRequest, string) {
+	t.Helper()
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitDaemon(t, repo, "init")
+	runGitDaemon(t, repo, "commit", "--allow-empty", "-m", "snapshot")
+	runGitDaemon(t, repo, "remote", "add", "origin", "git@github.com:owner/repo.git")
+	revisionBytes, err := attngit.Output(attngit.OpMetadata, repo, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision := strings.TrimSpace(string(revisionBytes))
+	payload, _ := json.Marshal(automation.PullRequestInput{
+		Provider: "github", Host: "github.com", Owner: "owner", Repository: "repo", Number: 42,
+		URL: "https://github.com/owner/repo/pull/42", State: "open", HeadSHA: revision,
+	})
+	location := automation.LocationSpec{Type: "repository_worktree", RepositorySources: automation.RepositorySources{
+		Default: automation.RepositorySource{Type: "managed_cache"},
+		Overrides: map[string]automation.RepositorySource{
+			"github.com/owner/repo": {Type: "local_clone", Path: repo},
+		},
+	}}
+	d := newDaemonForTest(t)
+	d.dataRoot = filepath.Join(root, "profile")
+	now := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	def, err := d.store.UpsertAutomationDefinition("review", "Review", `{}`, true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const subject = "github.com/owner/repo#42"
+	if _, err := d.store.ReconcileAutomationReviewRequests(def.ID, "github.com", []string{subject}, now); err != nil {
+		t.Fatal(err)
+	}
+	origin, _, err := d.store.ClaimGitHubReviewAutomationRun(def.ID, subject, 1, def.Revision, string(payload), `{}`, now, store.AutomationRunReservation{
+		RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstReq := automation.WorkRequest{RunID: origin.ID, DefinitionID: def.ID, SubjectKey: subject, ContinuityKey: subject, Context: payload, Location: location, Launch: testAutomationLaunch("codex"), IDs: automation.DeliveryIDs{TicketID: origin.TicketID, SessionID: origin.SessionID, WorkspaceID: origin.WorkspaceID, PaneID: origin.PaneID}}
+	prepared, err := d.PrepareLocation(context.Background(), firstReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.store.EnsureAutomationTicket(store.Ticket{ID: origin.TicketID, Title: "Review", Status: store.TicketStatusDone, Assignee: origin.SessionID, Cwd: prepared.Directory, LastAgentID: "codex", AutomationRunID: origin.ID}, "automation:review", store.TicketRoleChiefOfStaff, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.store.MarkAutomationRunDelivered(origin.ID, string(prepared.Resolved), now); err != nil {
+		t.Fatal(err)
+	}
+	continuation := firstReq
+	continuation.RunID = "run-2"
+	return d, continuation, prepared.Directory
+}
+
+func TestContinuationPreservesOwnedDirtyWorktree(t *testing.T) {
+	d, req, worktree := setupContinuationWorktree(t)
+	if err := os.WriteFile(filepath.Join(worktree, "review-notes.txt"), []byte("keep me"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := d.PrepareLocation(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.Directory != worktree {
+		t.Fatalf("continuation worktree=%q want=%q", prepared.Directory, worktree)
+	}
+	if data, err := os.ReadFile(filepath.Join(worktree, "review-notes.txt")); err != nil || string(data) != "keep me" {
+		t.Fatalf("dirty evidence changed: data=%q err=%v", data, err)
+	}
+}
+
+func TestContinuationFailsWhenOwnedWorktreeIsMissing(t *testing.T) {
+	d, req, worktree := setupContinuationWorktree(t)
+	if err := os.RemoveAll(worktree); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.PrepareLocation(context.Background(), req); err == nil || !strings.Contains(err.Error(), "worktree is missing") {
+		t.Fatalf("missing worktree err=%v", err)
+	}
+}
+
+func TestWithdrawnBeforeLaunchReRequestCreatesFirstWorktree(t *testing.T) {
+	d, req, worktree := setupContinuationWorktree(t)
+	ticket, err := d.store.GetTicket(req.IDs.TicketID)
+	if err != nil || ticket == nil {
+		t.Fatalf("ticket=%#v err=%v", ticket, err)
+	}
+	if err := d.store.MarkAutomationRunFailed(ticket.AutomationRunID, store.AutomationReviewWithdrawnError, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(worktree); err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := d.PrepareLocation(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.Directory != worktree {
+		t.Fatalf("re-request worktree=%q want=%q", prepared.Directory, worktree)
+	}
+	if _, err := os.Stat(worktree); err != nil {
+		t.Fatalf("first worktree was not provisioned: %v", err)
 	}
 }
 

--- a/internal/daemon/ticket_resume_test.go
+++ b/internal/daemon/ticket_resume_test.go
@@ -67,12 +67,12 @@ func TestTicketResumeRespawnsClosedBoundSession(t *testing.T) {
 	leafID, ticket := delegateBoundTicket(t, d, backend, "codex")
 
 	// Close the leaf (its session row — and its own resume_session_id — are gone),
-	// then seed the durable resume mirror on the ticket. codex is resumable by
-	// default (no transcript probe), so Resume should adopt the mirrored id.
+	// then seed the durable resume mirror on the ticket and its native rollout.
 	d.unregisterSession(leafID, syscall.SIGTERM)
 	if d.store.Get(leafID) != nil {
 		t.Fatalf("session %s still registered after close", leafID)
 	}
+	writeCodexRolloutFixture(t, "codex-conv-xyz")
 	d.persistResumeSessionID(leafID, "codex-conv-xyz")
 
 	before, err := d.store.GetTicket(ticket.ID)

--- a/scripts/build-bundled-plugins.sh
+++ b/scripts/build-bundled-plugins.sh
@@ -14,6 +14,29 @@ if [[ "$(printf '%s\n' "${minimum_bun_version}" "${bun_version}" | sort -V | hea
   exit 1
 fi
 
+remove_bun_linker_signature() {
+  local executable="$1"
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    return
+  fi
+
+  local signature_end file_size
+  signature_end="$(otool -l "${executable}" | awk '
+    $1 == "cmd" && $2 == "LC_CODE_SIGNATURE" { in_signature = 1; next }
+    in_signature && $1 == "dataoff" { dataoff = $2; next }
+    in_signature && $1 == "datasize" { print dataoff + $2; exit }
+  ')"
+  if [[ -z "${signature_end}" ]]; then
+    return
+  fi
+
+  file_size="$(stat -f '%z' "${executable}")"
+  if (( file_size > signature_end )); then
+    truncate -s "${signature_end}" "${executable}"
+  fi
+  codesign --remove-signature "${executable}"
+}
+
 stage_plugin() {
   local name="$1" description="$2"
   local source_dir="${repo_root}/plugins/${name}"
@@ -31,6 +54,10 @@ stage_plugin() {
   rm -rf "${stage_dir}"
   mkdir -p "${stage_dir}/bin"
   bun build "${source_dir}/src/index.ts" --compile --minify --outfile "${stage_dir}/bin/${name}"
+  # Bun emits a linker-signed Mach-O. Some dependency graphs leave bytes after
+  # the declared signature, which prevents macOS codesign from replacing it.
+  # Normalize the generated executable before Tauri copies and signs the bundle.
+  remove_bun_linker_signature "${stage_dir}/bin/${name}"
   chmod 0755 "${stage_dir}/bin/${name}"
   if [[ "${name}" == "attn-opencode" ]]; then
     bun build "${source_dir}/src/guidance-plugin.ts" --target=bun --format=esm --minify --outfile "${stage_dir}/guidance-plugin.js"


### PR DESCRIPTION
## Intent / Why

Later review-request cycles for the same pull request should return to the reviewer attn already created, without losing the ordinary ticket, local review notes, or the exact launch policy. This deepens the durable subject binding introduced in Slice 3 while keeping each occurrence and run independently visible.

## Summary

- Resume a stopped per-PR reviewer only when attn has a recorded resume target, using the immutable automation launch snapshot and the new occurrence prompt.
- Verify the recorded Codex rollout actually exists before unattended continuation (`ResumeAvailable` via `transcript.FindCodexTranscriptForResume`); a pruned or moved rollout fails closed instead of spawning fresh.
- Reopen archived tickets after successful continuation, preserve automation-owned dirty or branch-changed worktrees, and fail visibly when a delivered worktree is missing or the PR head changed.
- Keep live reviewers on the existing nudge path and retain safe first-launch behavior when a review request was withdrawn before delivery.
- Normalize bundled Bun executables before app signing so non-production packaged builds pass strict macOS validation.
- Add a serial packaged-app scenario that uses local mock GitHub, a copied Codex rollout, and machine-readable assertions to prove continuity and failure behavior in seconds.

## Test plan

- [x] `go test ./internal/agent ./internal/daemon ./internal/store -count=1` (rerun after rebasing onto `main` post pi PRs #613/#615; two conflict resolutions: CHANGELOG.md and `build-bundled-plugins.sh`, both keep-both-sides)
- [x] Focused continuation, withdrawal, archived-ticket, dirty-worktree, changed-head, missing-worktree, and unavailable-transcript tests, plus present/missing Codex rollout regressions
- [x] Pre-commit at `b2a43445`: 1,848 frontend tests, frontend build, 189 Playwright tests passed (1 expected skip)
- [x] `make install PROFILE=automations` and packaged preflight at protocol 175 (rerun 2026-07-20 on a fresh machine/profile)
- [x] `ATTN_PROFILE=automations pnpm --dir app run real-app:scenario-automation-pr-continuity` — **rerun green on the exact-rollout fix** (2026-07-20, fresh `automations` profile, 15s)
  - same ticket `auto-1a7c07b4a1a04b0c`
  - same session `f2d4d83b-a407-44f2-8ffa-b769bb2a2b1e`
  - copied rollout `019f5cd5-3510-7781-b3b0-8ade5b2cef1c` passed to `codex resume`
  - `gpt-5.6-terra` with high effort and automatic review approval preserved
  - dirty review notes preserved and archived ticket reopened
  - missing delivered worktree failed visibly without silent recreation
  - the rerun surfaced one harness bug — a fresh profile's empty `automation list` returns JSON `null`, which the scenario's daemon-readiness poll misread as not-ready — fixed in `test(automations): accept empty automation list in readiness poll`

## Out of scope

- Scheduled automations, inbox providers, and management UI remain in later implementation-guide slices.
- Automated review sessions still never post, approve, or comment on GitHub without a later explicit user action.
