### PR TITLE
feat(automations): scheduled trigger with a real maintenance case (Slice 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-07-20]
 
 ### Added
+- **Automations can now run on a schedule.** A definition can declare a cron
+  schedule with a required time zone and fire an ordinary visible agent
+  session at each intended instant — for example, a recurring merged-worktree
+  cleanup. After daemon downtime, `catch_up: latest` runs the newest missed
+  instant once, while `catch_up: skip` quietly drops instants older than a few
+  minutes; a backlog never replays as a storm of runs. `continuity: singleton`
+  keeps every occurrence on the same ticket and session instead of opening a
+  new one each time.
 - **pi sessions now report their own state and take steering in-band.** A pi
   session launched by attn loads a bundled companion extension that declares
   when the agent is working, tells attn how a turn ended — done, or waiting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   resume token current.
 
 ### Changed
+- **`catch_up` is now schedule-only.** Applying an automation whose manual or
+  GitHub trigger carries a `catch_up` policy fails validation with a clear
+  error; remove the field from the definition. Already-stored definitions are
+  unaffected.
 - **Later review requests return to a safe existing reviewer.** Per-PR
   automations now resume a stopped reviewer with its recorded transcript and
   pinned unattended policy, reopen archived tickets after successful delivery,

--- a/app/package.json
+++ b/app/package.json
@@ -33,6 +33,7 @@
     "real-app:scenario-tr301": "node scripts/real-app-harness/scenario-tr301-local-utility-session-switch.mjs",
     "real-app:scenario-codex-resume": "node scripts/real-app-harness/scenario-codex-resume-mapping.mjs",
     "real-app:scenario-automation-pr-continuity": "node scripts/real-app-harness/scenario-automation-pr-continuity.mjs",
+    "real-app:scenario-automation-scheduled-cleanup": "node scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs",
     "real-app:scenario-tr401": "node scripts/real-app-harness/scenario-tr401-local-window-resize.mjs",
     "real-app:scenario-tr401-local-codex": "node scripts/real-app-harness/scenario-tr401-local-window-resize.mjs --agent codex",
     "real-app:scenario-tr401-codex-main": "node scripts/real-app-harness/scenario-tr401-local-codex-main-window-resize.mjs",

--- a/app/scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs
@@ -1,0 +1,457 @@
+#!/usr/bin/env node
+
+/**
+ * Packaged-app proof for Slice 5's scheduled-trigger automation: a `scheduled`
+ * definition fires at its intended minute, survives a daemon restart per its
+ * catch_up policy, does real merged-worktree cleanup in a visible ticket/
+ * session, never touches a dirty worktree, and coalesces later occurrences
+ * onto the same singleton ticket/session.
+ *
+ * Two definitions are applied against one isolated profile daemon:
+ *   - `scheduled-cleanup-<suffix>`: cron `* * * * *`, policy.continuity
+ *     singleton, policy.catch_up latest, a REAL `codex` launch (no
+ *     executable override) pointed at a local fixture repo with one
+ *     fully-merged clean worktree and one dirty worktree. Proves the full
+ *     restart/catch-up/cleanup/coalescing story with genuine agent work.
+ *   - `scheduled-storm-guard-<suffix>`: cron `* * * * *`, policy.continuity
+ *     fresh, policy.catch_up latest, launched against a FAKE codex
+ *     executable (argv logger, like the Slice 4 continuity scenario's
+ *     probe) so the storm-guard re-assertion in leg 4 is cheap and fast.
+ *     It re-proves "one restart catch-up run regardless of missed
+ *     instants" under a different continuity policy; skip-vs-latest
+ *     discard beyond the 5-minute grace is already covered by
+ *     internal/daemon/automations_schedule_test.go and is not re-proven
+ *     live here (see leg 4 below for why).
+ *
+ * Run serially (packaged-app scenarios are single-tenant):
+ *   ATTN_HARNESS_PROFILE=<name> node scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { parseCommonArgs, printCommonHelp } from './common.mjs';
+import { createScenarioRunner } from './scenarioRunner.mjs';
+import { currentHarnessProfile, dataDirForProfile, resolveHarnessResources } from './harnessProfile.mjs';
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Real-time budgets. The daemon's automation-schedule ticker fires once a
+// real minute; these windows are sized around that cadence plus margin, not
+// around wall-clock convenience.
+const ANCHOR_POLL_TIMEOUT_MS = 90_000; // the anchor tick lands within one 60s ticker interval of apply, plus margin.
+const DOWNTIME_MS = 135_000; // >= two whole-minute instants missed while stopped.
+const RESTART_RUN_TIMEOUT_MS = 120_000; // daemon start + first post-restart tick + delivery.
+const CLEANUP_EVIDENCE_TIMEOUT_MS = 240_000; // real codex agent doing real git work.
+const COALESCE_TIMEOUT_MS = 90_000; // one more live tick after cleanup evidence lands.
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') args.shift();
+  const options = parseCommonArgs(args);
+  return { options, help: args.includes('--help') || args.includes('-h') };
+}
+
+function profileEnv(profile, extra = {}) {
+  const env = { ...process.env, ATTN_PROFILE: profile, ...extra };
+  for (const key of ['ATTN_SOCKET_PATH', 'ATTN_DB_PATH', 'ATTN_CONFIG_PATH', 'ATTN_PLUGIN_DIR']) {
+    delete env[key];
+  }
+  return env;
+}
+
+function run(binary, args, env, options = {}) {
+  return execFileSync(binary, args, {
+    encoding: 'utf8',
+    env,
+    stdio: options.stdio || ['ignore', 'pipe', 'pipe'],
+    timeout: options.timeout || 30_000,
+  });
+}
+
+function runJSON(binary, args, env) {
+  return JSON.parse(run(binary, args, env));
+}
+
+async function poll(fn, description, timeoutMs = 30_000) {
+  const started = Date.now();
+  let last = null;
+  while (Date.now() - started < timeoutMs) {
+    last = await fn();
+    if (last) return last;
+    await delay(100);
+  }
+  throw new Error(`timed out waiting for ${description}; last=${JSON.stringify(last)}`);
+}
+
+function sqliteRow(dbPath, sql) {
+  const out = execFileSync('sqlite3', [dbPath, sql], { encoding: 'utf8' }).trim();
+  return out.length === 0 ? null : out.split('|');
+}
+
+function sqlEscape(value) {
+  return value.replaceAll("'", "''");
+}
+
+// --- fixture repo -----------------------------------------------------
+
+function gitConfigIdentity(repoDir) {
+  execFileSync('git', ['config', 'user.name', 'attn'], { cwd: repoDir });
+  execFileSync('git', ['config', 'user.email', 'attn@local'], { cwd: repoDir });
+}
+
+function createFixture(root) {
+  const repo = path.join(root, 'repo');
+  const worktrees = path.join(root, 'worktrees');
+  fs.mkdirSync(repo, { recursive: true });
+  fs.mkdirSync(worktrees, { recursive: true });
+
+  execFileSync('git', ['init', '-q'], { cwd: repo });
+  gitConfigIdentity(repo);
+  // Deterministic default-branch name regardless of the host's
+  // init.defaultBranch config or git version's -b support.
+  execFileSync('git', ['symbolic-ref', 'HEAD', 'refs/heads/main'], { cwd: repo });
+  fs.writeFileSync(path.join(repo, 'README.md'), 'Scheduled cleanup fixture.\n');
+  execFileSync('git', ['add', 'README.md'], { cwd: repo });
+  execFileSync('git', ['commit', '-q', '-m', 'initial'], { cwd: repo });
+
+  // merged-work: fully merged into main, worktree stays clean -> eligible for removal.
+  execFileSync('git', ['checkout', '-q', '-b', 'merged-work'], { cwd: repo });
+  fs.writeFileSync(path.join(repo, 'merged-work.txt'), 'merged work\n');
+  execFileSync('git', ['add', 'merged-work.txt'], { cwd: repo });
+  execFileSync('git', ['commit', '-q', '-m', 'merged work'], { cwd: repo });
+  execFileSync('git', ['checkout', '-q', 'main'], { cwd: repo });
+  execFileSync('git', ['merge', '-q', '--no-ff', 'merged-work', '-m', 'Merge merged-work'], { cwd: repo });
+
+  const mergedClean = path.join(worktrees, 'merged-clean');
+  execFileSync('git', ['worktree', 'add', mergedClean, 'merged-work'], { cwd: repo });
+
+  // wip: dirty worktree -> must be preserved regardless of merge status.
+  execFileSync('git', ['branch', 'wip', 'main'], { cwd: repo });
+  const dirtyWip = path.join(worktrees, 'dirty-wip');
+  execFileSync('git', ['worktree', 'add', dirtyWip, 'wip'], { cwd: repo });
+  fs.writeFileSync(path.join(dirtyWip, 'scratch.txt'), 'uncommitted work in progress\n');
+
+  return { repo, worktrees, mergedClean, dirtyWip };
+}
+
+function worktreeListShows(repo, absolutePath) {
+  const out = execFileSync('git', ['worktree', 'list', '--porcelain'], { cwd: repo, encoding: 'utf8' });
+  return out.includes(absolutePath);
+}
+
+// --- fake codex probe (storm-guard leg only; see file header) ---------
+
+function createCodexProbe(root) {
+  const log = path.join(root, 'codex-invocations.jsonl');
+  const executable = path.join(root, 'codex-probe.mjs');
+  fs.writeFileSync(
+    executable,
+    `#!/usr/bin/env node\nimport fs from 'node:fs';\nfs.appendFileSync(${JSON.stringify(log)}, JSON.stringify({argv: process.argv.slice(2), at: new Date().toISOString()}) + '\\n');\nsetInterval(() => {}, 1000);\n`,
+    { mode: 0o700 },
+  );
+  return { executable, log };
+}
+
+function invocations(log) {
+  if (!fs.existsSync(log)) return [];
+  return fs.readFileSync(log, 'utf8').trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+}
+
+// --- automation definition YAML ----------------------------------------
+
+const API_VERSION = 'attn.dev/automations/v1alpha1';
+
+function cleanupDefinitionYAML({ id, locationPath, enabled }) {
+  return `api_version: ${API_VERSION}
+id: ${id}
+name: Slice 5 packaged scheduled cleanup proof
+enabled: ${enabled}
+trigger:
+  type: scheduled
+  schedule:
+    cron: "* * * * *"
+    time_zone: UTC
+prompt: |
+  Review git worktrees of \`repo/\`; remove with \`git worktree remove\` (never --force) each linked worktree whose branch is fully merged into main AND whose tree is completely clean, then delete that fully-merged branch with \`git branch -d\`. NEVER remove a worktree with staged, unstaged, or untracked changes — list preserved worktrees with reasons. Summarize actions in the ticket.
+launch:
+  driver: codex
+  model: gpt-5.5
+  effort: medium
+location:
+  type: directory
+  path: ${JSON.stringify(locationPath)}
+policy:
+  continuity: singleton
+  catch_up: latest
+`;
+}
+
+function stormGuardDefinitionYAML({ id, locationPath, enabled, executable }) {
+  return `api_version: ${API_VERSION}
+id: ${id}
+name: Slice 5 scheduler storm-guard probe
+enabled: ${enabled}
+trigger:
+  type: scheduled
+  schedule:
+    cron: "* * * * *"
+    time_zone: UTC
+prompt: |
+  Scheduler storm-guard probe. Do nothing; this executable is a test double.
+launch:
+  driver: codex
+  executable: ${JSON.stringify(executable)}
+  model: slice5-storm-probe
+  effort: high
+location:
+  type: directory
+  path: ${JSON.stringify(locationPath)}
+policy:
+  continuity: fresh
+  catch_up: latest
+`;
+}
+
+// The tick AFTER the anchor tick legitimately fires a run (one minute boundary
+// falls between any two ticks of a `* * * * *` schedule), so asserting "no run
+// yet" after a fixed sleep races that second tick. Poll for the cursor row the
+// anchor tick writes instead, and let the caller assert zero runs immediately
+// — the caller then has most of a minute to act (e.g. stop the daemon) before
+// a run can legally fire.
+async function waitForScheduleAnchor(dbPath, definitionID) {
+  await poll(
+    () => sqliteRow(dbPath, `SELECT observed_at FROM automation_provider_cursors WHERE definition_id='${sqlEscape(definitionID)}' AND provider='schedule' AND scope='*';`),
+    `schedule cursor anchor for ${definitionID}`,
+    ANCHOR_POLL_TIMEOUT_MS,
+  );
+}
+
+async function waitForDaemonReady(binary, daemonEnv) {
+  await poll(() => {
+    try {
+      runJSON(binary, ['automation', 'list'], daemonEnv);
+      return { ready: true };
+    } catch {
+      return null;
+    }
+  }, 'profile daemon');
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs');
+    return;
+  }
+  const profile = currentHarnessProfile();
+  if (!profile) throw new Error('automation scheduled-cleanup scenario requires a named non-production profile');
+  const resources = resolveHarnessResources(profile);
+  const binary = path.join(resources.appPath, 'Contents', 'MacOS', 'attn');
+  const dbPath = path.join(dataDirForProfile(profile), 'attn.db');
+  const runner = createScenarioRunner(options, {
+    scenarioId: 'AUTOMATION-SCHEDULED-CLEANUP',
+    tier: 'tier2-local-real-agent',
+    prefix: 'automation-scheduled-cleanup',
+    metadata: { profile, provider: 'local fixture repo', legFour: 'storm-guard re-assertion (fresh continuity); skip-discard-beyond-grace covered by unit tests' },
+  });
+
+  const suffix = Date.now().toString(36);
+  const cleanupID = `scheduled-cleanup-${suffix}`;
+  const stormGuardID = `scheduled-storm-guard-${suffix}`;
+  const fixtureRoot = fs.realpathSync(fs.mkdtempSync(path.join(runner.sessionDir, 'scheduled-cleanup-')));
+  const cleanupDefinitionFile = path.join(runner.sessionDir, 'scheduled-cleanup.yml');
+  const stormGuardDefinitionFile = path.join(runner.sessionDir, 'scheduled-storm-guard.yml');
+
+  let daemonEnv = null;
+  let fixture = null;
+  let probe = null;
+  let cleanupTicketID = '';
+  let cleanupSessionID = '';
+  let cleanupApplied = false;
+  let stormGuardApplied = false;
+
+  try {
+    daemonEnv = profileEnv(profile);
+    fixture = createFixture(fixtureRoot);
+    probe = createCodexProbe(runner.sessionDir);
+
+    await runner.step('restart_isolated_daemon', async () => {
+      try { run(binary, ['daemon', 'stop'], daemonEnv); } catch {}
+      run(binary, ['daemon', 'ensure'], daemonEnv);
+      await waitForDaemonReady(binary, daemonEnv);
+    });
+
+    await runner.step('leg1_apply_and_anchor', async () => {
+      fs.writeFileSync(cleanupDefinitionFile, cleanupDefinitionYAML({ id: cleanupID, locationPath: fixtureRoot, enabled: true }));
+      runJSON(binary, ['automation', 'apply', '--file', cleanupDefinitionFile], daemonEnv);
+      cleanupApplied = true;
+      // First observation after apply only anchors the cursor; it must not fire.
+      await waitForScheduleAnchor(dbPath, cleanupID);
+      const rows = runJSON(binary, ['automation', 'runs', cleanupID], daemonEnv) || [];
+      runner.assert(rows.length === 0, 'no run fires on the anchor-only tick', { rows });
+    });
+
+    await runner.step('leg1_restart_catchup', async () => {
+      run(binary, ['daemon', 'stop'], daemonEnv);
+      await delay(DOWNTIME_MS);
+      run(binary, ['daemon', 'ensure'], daemonEnv);
+      await waitForDaemonReady(binary, daemonEnv);
+      const rows = await poll(() => {
+        const list = runJSON(binary, ['automation', 'runs', cleanupID], daemonEnv) || [];
+        return list.length >= 1 ? list : null;
+      }, 'restart catch-up run', RESTART_RUN_TIMEOUT_MS);
+      runner.assert(rows.length === 1, 'exactly one catch-up run fires despite multiple missed instants (latest policy)', { rows });
+      const runRow = rows[0];
+      cleanupTicketID = runRow.TicketID;
+      cleanupSessionID = runRow.SessionID;
+      runner.assert(Boolean(cleanupTicketID) && Boolean(cleanupSessionID), 'catch-up run reserves a ticket and session', runRow);
+
+      const occurrence = sqliteRow(
+        dbPath,
+        `SELECT o.occurrence_key FROM automation_occurrences o JOIN automation_runs r ON r.occurrence_id=o.id WHERE r.id='${sqlEscape(runRow.ID)}';`,
+      );
+      runner.assert(occurrence !== null, 'catch-up run has a resolvable occurrence row', { runID: runRow.ID });
+      const occurrenceKey = occurrence[0];
+      runner.assert(
+        /^scheduled:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:00Z$/.test(occurrenceKey),
+        'occurrence key carries the scheduled prefix and is minute-aligned',
+        { occurrenceKey },
+      );
+    });
+
+    await runner.step('leg2_real_cleanup_evidence', async () => {
+      await poll(() => {
+        const removedFromDisk = !fs.existsSync(fixture.mergedClean);
+        const removedFromGit = !worktreeListShows(fixture.repo, fixture.mergedClean);
+        return removedFromDisk && removedFromGit ? true : null;
+      }, 'merged-clean worktree removed by the agent', CLEANUP_EVIDENCE_TIMEOUT_MS);
+      runner.assert(!fs.existsSync(fixture.mergedClean), 'merged-clean worktree directory is gone from disk');
+      runner.assert(!worktreeListShows(fixture.repo, fixture.mergedClean), 'merged-clean worktree is untracked by git worktree list');
+      runner.assert(fs.existsSync(fixture.dirtyWip), 'dirty-wip worktree directory is preserved');
+      runner.assert(fs.existsSync(path.join(fixture.dirtyWip, 'scratch.txt')), 'dirty-wip uncommitted file is untouched');
+      runner.assert(worktreeListShows(fixture.repo, fixture.dirtyWip), 'dirty-wip worktree is still tracked by git worktree list');
+
+      // Deliberately weak on agent prose (per brief): filesystem outcome above is
+      // the primary evidence. This only checks the ticket did not fail outright
+      // and has at least the delivery activity row.
+      const ticket = sqliteRow(
+        dbPath,
+        `SELECT status, (SELECT COUNT(*) FROM ticket_activity WHERE ticket_id=tickets.id) FROM tickets WHERE id='${sqlEscape(cleanupTicketID)}';`,
+      );
+      runner.assert(ticket !== null, 'cleanup ticket row exists', { cleanupTicketID });
+      const [ticketStatus, activityCountRaw] = ticket;
+      runner.assert(ticketStatus !== 'failed', 'cleanup ticket did not fail', { ticketStatus });
+      runner.assert(Number(activityCountRaw) >= 1, 'cleanup ticket has recorded activity', { activityCount: activityCountRaw });
+    });
+
+    await runner.step('leg3_singleton_coalescing', async () => {
+      // The definition is still enabled and cron fires every minute, so by the
+      // time leg 2's (possibly multi-minute) cleanup wait completes, later
+      // occurrences have typically already coalesced onto the same ticket.
+      // Poll rather than a fixed ~75s sleep so a fast leg 2 still gets one more
+      // real tick before this asserts.
+      const rows = await poll(() => {
+        const list = runJSON(binary, ['automation', 'runs', cleanupID], daemonEnv) || [];
+        return list.length >= 2 ? list : null;
+      }, 'a second coalesced occurrence', COALESCE_TIMEOUT_MS);
+      runner.assert(rows.length >= 2, 'at least a second occurrence fired while enabled', { count: rows.length });
+      const tickets = new Set(rows.map((row) => row.TicketID));
+      const sessions = new Set(rows.map((row) => row.SessionID));
+      runner.assert(
+        tickets.size === 1 && tickets.has(cleanupTicketID),
+        'every occurrence for this definition coalesces onto the same singleton ticket',
+        { tickets: [...tickets] },
+      );
+      runner.assert(
+        sessions.size === 1 && sessions.has(cleanupSessionID),
+        'every occurrence reuses the same live session; no duplicate session is spawned',
+        { sessions: [...sessions] },
+      );
+
+      fs.writeFileSync(cleanupDefinitionFile, cleanupDefinitionYAML({ id: cleanupID, locationPath: fixtureRoot, enabled: false }));
+      runJSON(binary, ['automation', 'apply', '--file', cleanupDefinitionFile], daemonEnv);
+    });
+
+    // Leg 4: storm-guard re-assertion. A true skip-vs-latest discard proof needs
+    // downtime past the 5-minute grace (internal/daemon/automations_schedule.go
+    // scheduleSkipGrace); that would push this scenario's wall-clock budget well
+    // past ~15 minutes. Per the brief's option (b), skip-discard-beyond-grace is
+    // left to internal/daemon/automations_schedule_test.go (asserts skip fires
+    // nothing past the grace window) and this leg instead re-proves "restart
+    // catch-up fires exactly one run despite missed instants" under a SEPARATE
+    // continuity policy (fresh, not singleton) and a fresh definition ID, using a
+    // fake codex executable so the re-assertion is fast and cheap.
+    await runner.step('leg4_storm_guard_restart', async () => {
+      fs.writeFileSync(
+        stormGuardDefinitionFile,
+        stormGuardDefinitionYAML({ id: stormGuardID, locationPath: fixtureRoot, enabled: true, executable: probe.executable }),
+      );
+      runJSON(binary, ['automation', 'apply', '--file', stormGuardDefinitionFile], daemonEnv);
+      stormGuardApplied = true;
+      await waitForScheduleAnchor(dbPath, stormGuardID);
+      const anchoredRows = runJSON(binary, ['automation', 'runs', stormGuardID], daemonEnv) || [];
+      runner.assert(anchoredRows.length === 0, 'storm-guard probe does not fire on its anchor-only tick', { anchoredRows });
+
+      run(binary, ['daemon', 'stop'], daemonEnv);
+      await delay(DOWNTIME_MS);
+      run(binary, ['daemon', 'ensure'], daemonEnv);
+      await waitForDaemonReady(binary, daemonEnv);
+      const rows = await poll(() => {
+        const list = runJSON(binary, ['automation', 'runs', stormGuardID], daemonEnv) || [];
+        return list.length >= 1 ? list : null;
+      }, 'storm-guard restart catch-up run', RESTART_RUN_TIMEOUT_MS);
+      runner.assert(rows.length === 1, 'storm-guard: exactly one catch-up run under fresh continuity too', { rows });
+
+      await poll(() => (invocations(probe.log).length >= 1 ? invocations(probe.log) : null), 'storm-guard probe launch');
+      runner.assert(invocations(probe.log).length === 1, 'exactly one process spawn backs the single catch-up run (no replay storm)', {
+        invocations: invocations(probe.log),
+      });
+
+      fs.writeFileSync(
+        stormGuardDefinitionFile,
+        stormGuardDefinitionYAML({ id: stormGuardID, locationPath: fixtureRoot, enabled: false, executable: probe.executable }),
+      );
+      runJSON(binary, ['automation', 'apply', '--file', stormGuardDefinitionFile], daemonEnv);
+    });
+
+    runner.finishSuccess({ profile, cleanupID, stormGuardID, cleanupTicketID, cleanupSessionID, fixtureRoot });
+  } catch (error) {
+    runner.finishFailure(error, { profile, cleanupID, stormGuardID, cleanupTicketID, cleanupSessionID, fixtureRoot });
+    throw error;
+  } finally {
+    // Disable both definitions before the fixture directory disappears: an
+    // enabled `directory`-location scheduled definition re-validates its path
+    // (os.Stat) on every future tick, so leaving one enabled against a deleted
+    // temp root would spam schedule-observation errors on this profile forever.
+    if (daemonEnv) {
+      if (cleanupApplied && fs.existsSync(fixtureRoot)) {
+        try {
+          fs.writeFileSync(cleanupDefinitionFile, cleanupDefinitionYAML({ id: cleanupID, locationPath: fixtureRoot, enabled: false }));
+          run(binary, ['automation', 'apply', '--file', cleanupDefinitionFile], daemonEnv);
+        } catch {}
+      }
+      if (stormGuardApplied && fs.existsSync(fixtureRoot) && probe) {
+        try {
+          fs.writeFileSync(
+            stormGuardDefinitionFile,
+            stormGuardDefinitionYAML({ id: stormGuardID, locationPath: fixtureRoot, enabled: false, executable: probe.executable }),
+          );
+          run(binary, ['automation', 'apply', '--file', stormGuardDefinitionFile], daemonEnv);
+        } catch {}
+      }
+    }
+    try { fs.rmSync(fixtureRoot, { recursive: true, force: true }); } catch {}
+    // daemonEnv never diverged from a plain profile daemon (no mock provider,
+    // no CODEX_HOME override) here, so a single idempotent `ensure` is enough
+    // to leave a healthy daemon behind — no stop/swap cycle needed.
+    try { run(binary, ['daemon', 'ensure'], profileEnv(profile)); } catch {}
+    runner.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs
@@ -370,6 +370,13 @@ async function main() {
         { sessions: [...sessions] },
       );
 
+      // Later occurrences coalescing onto the same singleton agent must never
+      // touch the dirty worktree either, re-asserting leg 2's evidence after
+      // at least one more real tick has nudged the same live session.
+      runner.assert(fs.existsSync(fixture.dirtyWip), 'dirty-wip worktree directory is still preserved after coalescing');
+      runner.assert(fs.existsSync(path.join(fixture.dirtyWip, 'scratch.txt')), 'dirty-wip uncommitted file is still untouched after coalescing');
+      runner.assert(worktreeListShows(fixture.repo, fixture.dirtyWip), 'dirty-wip worktree is still tracked by git worktree list after coalescing');
+
       fs.writeFileSync(cleanupDefinitionFile, cleanupDefinitionYAML({ id: cleanupID, locationPath: fixtureRoot, enabled: false }));
       runJSON(binary, ['automation', 'apply', '--file', cleanupDefinitionFile], daemonEnv);
     });
@@ -398,22 +405,31 @@ async function main() {
       await delay(DOWNTIME_MS);
       run(binary, ['daemon', 'ensure'], daemonEnv);
       await waitForDaemonReady(binary, daemonEnv);
+
+      // Poll until the run row exists AND has actually been delivered (its
+      // spawn already happened), not merely created: waiting on existence
+      // alone can race the NEXT real minute tick under fresh continuity (a
+      // second, distinct run+spawn) if delivery is slow. Disable the
+      // definition immediately once delivered — stopping further fires
+      // before polling for the probe invocation — so that race window can't
+      // widen while this step keeps running.
       const rows = await poll(() => {
         const list = runJSON(binary, ['automation', 'runs', stormGuardID], daemonEnv) || [];
-        return list.length >= 1 ? list : null;
-      }, 'storm-guard restart catch-up run', RESTART_RUN_TIMEOUT_MS);
+        const delivered = list.filter((row) => row.State === 'delivered');
+        return delivered.length >= 1 ? delivered : null;
+      }, 'storm-guard restart catch-up run delivered', RESTART_RUN_TIMEOUT_MS);
       runner.assert(rows.length === 1, 'storm-guard: exactly one catch-up run under fresh continuity too', { rows });
-
-      await poll(() => (invocations(probe.log).length >= 1 ? invocations(probe.log) : null), 'storm-guard probe launch');
-      runner.assert(invocations(probe.log).length === 1, 'exactly one process spawn backs the single catch-up run (no replay storm)', {
-        invocations: invocations(probe.log),
-      });
 
       fs.writeFileSync(
         stormGuardDefinitionFile,
         stormGuardDefinitionYAML({ id: stormGuardID, locationPath: fixtureRoot, enabled: false, executable: probe.executable }),
       );
       runJSON(binary, ['automation', 'apply', '--file', stormGuardDefinitionFile], daemonEnv);
+
+      await poll(() => (invocations(probe.log).length >= 1 ? invocations(probe.log) : null), 'storm-guard probe launch');
+      runner.assert(invocations(probe.log).length === 1, 'exactly one process spawn backs the single catch-up run (no replay storm)', {
+        invocations: invocations(probe.log),
+      });
     });
 
     runner.finishSuccess({ profile, cleanupID, stormGuardID, cleanupTicketID, cleanupSessionID, fixtureRoot });

--- a/docs/plans/2026-07-18-attn-automations-implementation.md
+++ b/docs/plans/2026-07-18-attn-automations-implementation.md
@@ -22,8 +22,9 @@
 
 ## Next steps
 
-1. Slice 5 (scheduled prompt with one real maintenance case) is in progress on
-   `slice/automations-scheduled` off `main`.
+1. Slice 5 (scheduled prompt with one real maintenance case) is implemented on
+   `slice/automations-scheduled` with the packaged scenario green (see the
+   checklist entry below); it merges through the ordinary review flow.
 2. Then Slice 6 (profile-level Automations surface) and Slice 7 (self-service
    editing and lifecycle completion), followed by the final verification matrix.
 
@@ -964,7 +965,13 @@ For every slice that touches daemon lifecycle, protocol, PTY, Git, or UI:
 - [x] Finish PR #614: exact-rollout regressions in place and packaged continuity
       verification rerun green on the fixed code (2026-07-20). Merge follows the
       ordinary review flow (green checks plus Figgyster approval on the head).
-- [ ] Add schedule and its real maintenance case through the same engine.
+- [x] Add schedule and its real maintenance case through the same engine:
+      scheduled trigger with catch-up, storm guard, and singleton continuity,
+      proven by the packaged serial scenario
+      `real-app:scenario-automation-scheduled-cleanup` (a real codex agent
+      removing a merged-clean worktree while preserving a dirty one) — run
+      `automation-scheduled-cleanup-2026-07-20T12-22-03-841Z`, all legs green
+      against the app built from `45c7684c` (2026-07-20).
 - [ ] Add operational UI, then the editor and remaining policy depth.
 - [ ] Run the final upgrade, failure-recovery, and packaged-app matrix from the
       integration branch and open the single integration PR to `main`.

--- a/docs/plans/2026-07-18-attn-automations-implementation.md
+++ b/docs/plans/2026-07-18-attn-automations-implementation.md
@@ -410,6 +410,22 @@ fires twice with two distinct UTC occurrence keys. Slice 5 accepts
 same ticket/session across occurrences); scheduled definitions require
 `catch_up` and a `directory` location.
 
+Two deliberate Slice 5 boundaries, both to revisit in Slice 7 (lifecycle):
+
+- Editing a singleton scheduled definition's prompt, launch, or location makes
+  subsequent occurrences fail visibly at delivery: the continuation contract
+  check compares each run against the origin run's snapshot pinned to the
+  continuity binding, and that origin never advances. This is the same
+  fail-visible-on-changed-contract stance Slice 4 chose for per-PR
+  continuations, made total by the single `"singleton"` binding. Recovery today
+  is disabling the definition or recreating it under a new id; proper edit
+  semantics (rotating the continuity binding to a new ticket/session when the
+  contract changes) belong to Slice 7's edit/disable/delete work.
+- Validation now rejects `catch_up` on manual and github triggers (it only ever
+  had meaning for schedules). Stored definitions keep observing fine, but
+  re-applying an old YAML that carried a stray `catch_up` on a non-scheduled
+  trigger fails validation until the field is removed.
+
 The example paths illustrate configuration shape only. No user's path belongs in
 source, fixtures intended for shipping, or built-in defaults.
 

--- a/docs/plans/2026-07-18-attn-automations-implementation.md
+++ b/docs/plans/2026-07-18-attn-automations-implementation.md
@@ -12,31 +12,20 @@
   (`67dca139`). Packaged live verification completed before the
   behavior-preserving rebase at `aac6b7f2`; the rebased head was green and
   Figgyster-approved before merge.
-- Slice 4 is in [attn PR #614](https://github.com/victorarias/attn/pull/614).
-  The continuity path was live-verified at `b2a43445`. Figgyster then found that
-  Codex resume availability accepted any non-empty rollout ID. Fix `3402100f`
-  resolves the exact rollout before unattended continuation; unit and daemon
-  regressions cover present and missing rollouts. The branch was then rebased
-  onto `main` (post pi PRs #613/#615; conflict-resolution-only, verified by the
-  Go suites), and the packaged continuity scenario was rerun green on the fixed
-  code from a fresh `automations` profile (2026-07-20, 15s): same ticket,
-  session, and worktree; copied rollout passed to `codex resume`; pinned
-  `gpt-5.6-terra` high with automatic review approval preserved; dirty review
-  notes preserved; archived ticket reopened; missing delivered worktree failed
-  visibly without recreation. The rerun surfaced one harness bug — a fresh
-  profile's empty `automation list` (JSON `null`) was misread as
-  daemon-not-ready — fixed in the scenario's readiness poll. A separate
-  autoreview rerun was not repeated for the rebase: the only delta since the
-  approved head is mechanical conflict resolution (both sides independently
-  reviewed) plus documentation, and review happens on the exact head anyway.
+- Slice 4 merged through [attn PR #614](https://github.com/victorarias/attn/pull/614)
+  (`25a1c2ec`, 2026-07-20). The continuity path was live-verified at `b2a43445`;
+  Figgyster found Codex resume availability accepted any non-empty rollout ID,
+  fixed in `3402100f` with unit and daemon regressions for present and missing
+  rollouts; the packaged continuity scenario was rerun green on the fixed code
+  from a fresh `automations` profile before merge.
 - Later slices remain pending.
 
 ## Next steps
 
-1. Merge PR #614 through the ordinary review flow: green checks plus Figgyster
-   approval on the exact head. Victor directed merge-on-approval (2026-07-20),
-   superseding the earlier stop-unmerged instruction.
-2. Start Slice 5 (scheduled prompt with one real maintenance case) from `main`.
+1. Slice 5 (scheduled prompt with one real maintenance case) is in progress on
+   `slice/automations-scheduled` off `main`.
+2. Then Slice 6 (profile-level Automations surface) and Slice 7 (self-service
+   editing and lifecycle completion), followed by the final verification matrix.
 
 This guide implements the [attn Automations vision](attn-automations.md)
 as functional walking-skeleton slices. Each slice must leave a real capability
@@ -369,6 +358,58 @@ policy:
   overlap: coalesce
 ```
 
+The scheduled form nests the schedule under the trigger. `time_zone` is a
+required IANA name so a definition means the same instants on any machine;
+`TZ=`/`CRON_TZ=` prefixes inside the cron expression are rejected:
+
+```yaml
+api_version: attn.dev/automations/v1alpha1
+id: worktree-cleanup
+name: Merged-worktree cleanup
+enabled: true
+
+trigger:
+  type: scheduled
+  schedule:
+    cron: "0 9 * * 1-5"
+    time_zone: America/New_York
+
+prompt: |
+  Review the git worktrees under this directory. Remove each linked worktree
+  whose branch is fully merged and whose tree is completely clean using
+  `git worktree remove` (never --force). Never remove a worktree with staged,
+  unstaged, or untracked changes; list preserved worktrees with reasons.
+
+launch:
+  driver: codex
+  model: gpt-5.5
+  effort: high
+
+location:
+  type: directory
+  path: /Users/example/src/repository
+
+policy:
+  continuity: singleton
+  catch_up: latest
+  overlap: coalesce
+```
+
+Scheduled semantics decided at implementation time (Slice 5): occurrence keys
+are the intended instant in UTC (`scheduled:<RFC3339>`), so identity is
+machine-independent. Each observation tick fires at most the newest due
+instant per definition — older missed instants never fire, which is the
+replay-storm guard. `catch_up: latest` always fires the newest missed instant
+after downtime; `catch_up: skip` fires only within a 5-minute grace of the
+intended instant and otherwise discards it. The first observation of a new
+definition anchors its cursor without firing retroactively. Cron follows
+robfig/cron standard parsing, so DST is wall-clock literal: a slot inside the
+spring-forward gap does not fire that day, and the fall-back repeated hour
+fires twice with two distinct UTC occurrence keys. Slice 5 accepts
+`continuity: singleton` (one continuity stream keyed `"singleton"` reusing the
+same ticket/session across occurrences); scheduled definitions require
+`catch_up` and a `directory` location.
+
 The example paths illustrate configuration shape only. No user's path belongs in
 source, fixtures intended for shipping, or built-in defaults.
 
@@ -400,6 +441,7 @@ type LocationSpec struct {
 
 type WorkRequest struct {
     RunID, DefinitionID, SubjectKey, ContinuityKey string
+    Provider                                       string // occurrence provider; gates provider-specific continuation checks
     Prompt                                         string
     Context                                        json.RawMessage
     Launch                                         EffectiveLaunch

--- a/docs/plans/2026-07-18-attn-automations-implementation.md
+++ b/docs/plans/2026-07-18-attn-automations-implementation.md
@@ -409,7 +409,12 @@ spring-forward gap does not fire that day, and the fall-back repeated hour
 fires twice with two distinct UTC occurrence keys. Slice 5 accepts
 `continuity: singleton` (one continuity stream keyed `"singleton"` reusing the
 same ticket/session across occurrences); scheduled definitions require
-`catch_up` and a `directory` location.
+`catch_up` and a `directory` location. A rejected or failed claim holds the
+cursor back so the missed instant stays eligible; the retry fires whatever
+instant is newest-due at that time — identical for hourly-and-coarser
+schedules, possibly a fresher instant on minutely-grade ones — so a claim
+failure delays the appointment rather than dropping it, and never prefers a
+stale instant over a fresher due one.
 
 Two deliberate Slice 5 boundaries, both to revisit in Slice 7 (lifecycle):
 

--- a/internal/automation/automation.go
+++ b/internal/automation/automation.go
@@ -34,7 +34,13 @@ type DefinitionSpec struct {
 type TriggerSpec struct {
 	Type         string               `yaml:"type" json:"type"`
 	Repositories RepositoryFilterSpec `yaml:"repositories,omitempty" json:"repositories,omitempty"`
-	Schedule     ScheduleSpec         `yaml:"schedule,omitempty" json:"schedule,omitempty"`
+	// Schedule is a pointer so that encoding/json's omitempty actually omits it
+	// for non-scheduled triggers: a zero-value ScheduleSpec struct is never
+	// "empty" to json.Marshal, so a value field would put a spurious
+	// "schedule":{...} key in every manual/github_review_requested
+	// definition's canonical JSON and bump UpsertAutomationDefinition's
+	// revision on every byte-identical re-apply.
+	Schedule *ScheduleSpec `yaml:"schedule,omitempty" json:"schedule,omitempty"`
 }
 type ScheduleSpec struct {
 	Cron     string `yaml:"cron,omitempty" json:"cron,omitempty"`
@@ -113,21 +119,24 @@ func ValidateDefinition(s *DefinitionSpec) error {
 		if s.Trigger.Repositories.Mode != "" || len(s.Trigger.Repositories.Include) > 0 || len(s.Trigger.Repositories.Exclude) > 0 {
 			return errors.New("manual trigger cannot configure repositories")
 		}
-		if s.Trigger.Schedule != (ScheduleSpec{}) {
+		if s.Trigger.Schedule != nil {
 			return errors.New("manual trigger cannot configure schedule")
 		}
 	case "github_review_requested":
 		if err := validateRepositoryFilter(&s.Trigger.Repositories); err != nil {
 			return err
 		}
-		if s.Trigger.Schedule != (ScheduleSpec{}) {
+		if s.Trigger.Schedule != nil {
 			return errors.New("github_review_requested trigger cannot configure schedule")
 		}
 	case "scheduled":
 		if s.Trigger.Repositories.Mode != "" || len(s.Trigger.Repositories.Include) > 0 || len(s.Trigger.Repositories.Exclude) > 0 {
 			return errors.New("scheduled trigger cannot configure repositories")
 		}
-		if _, err := CompileSchedule(s.Trigger.Schedule); err != nil {
+		if s.Trigger.Schedule == nil {
+			return errors.New("scheduled trigger requires schedule")
+		}
+		if _, err := CompileSchedule(*s.Trigger.Schedule); err != nil {
 			return err
 		}
 	default:

--- a/internal/automation/automation.go
+++ b/internal/automation/automation.go
@@ -34,6 +34,11 @@ type DefinitionSpec struct {
 type TriggerSpec struct {
 	Type         string               `yaml:"type" json:"type"`
 	Repositories RepositoryFilterSpec `yaml:"repositories,omitempty" json:"repositories,omitempty"`
+	Schedule     ScheduleSpec         `yaml:"schedule,omitempty" json:"schedule,omitempty"`
+}
+type ScheduleSpec struct {
+	Cron     string `yaml:"cron,omitempty" json:"cron,omitempty"`
+	TimeZone string `yaml:"time_zone,omitempty" json:"time_zone,omitempty"`
 }
 type RepositoryFilterSpec struct {
 	Mode    string   `yaml:"mode,omitempty" json:"mode,omitempty"`
@@ -108,12 +113,25 @@ func ValidateDefinition(s *DefinitionSpec) error {
 		if s.Trigger.Repositories.Mode != "" || len(s.Trigger.Repositories.Include) > 0 || len(s.Trigger.Repositories.Exclude) > 0 {
 			return errors.New("manual trigger cannot configure repositories")
 		}
+		if s.Trigger.Schedule != (ScheduleSpec{}) {
+			return errors.New("manual trigger cannot configure schedule")
+		}
 	case "github_review_requested":
 		if err := validateRepositoryFilter(&s.Trigger.Repositories); err != nil {
 			return err
 		}
+		if s.Trigger.Schedule != (ScheduleSpec{}) {
+			return errors.New("github_review_requested trigger cannot configure schedule")
+		}
+	case "scheduled":
+		if s.Trigger.Repositories.Mode != "" || len(s.Trigger.Repositories.Include) > 0 || len(s.Trigger.Repositories.Exclude) > 0 {
+			return errors.New("scheduled trigger cannot configure repositories")
+		}
+		if _, err := CompileSchedule(s.Trigger.Schedule); err != nil {
+			return err
+		}
 	default:
-		return errors.New("trigger.type must be manual or github_review_requested")
+		return errors.New("trigger.type must be manual, github_review_requested, or scheduled")
 	}
 	if strings.TrimSpace(s.Prompt) == "" {
 		return errors.New("prompt is required")
@@ -167,7 +185,8 @@ func ValidateDefinition(s *DefinitionSpec) error {
 	if s.Policy.Overlap != "" && s.Policy.Overlap != "coalesce" {
 		return errors.New("policy.overlap must be coalesce")
 	}
-	if s.Trigger.Type == "github_review_requested" {
+	switch s.Trigger.Type {
+	case "github_review_requested":
 		if s.Location.Type != "repository_worktree" {
 			return errors.New("github_review_requested trigger requires repository_worktree location")
 		}
@@ -177,8 +196,23 @@ func ValidateDefinition(s *DefinitionSpec) error {
 		if s.Policy.CatchUp != "latest" {
 			return errors.New("github_review_requested trigger requires policy.catch_up latest")
 		}
-	} else if s.Policy.Continuity != "fresh" {
-		return errors.New("manual trigger supports only policy.continuity fresh")
+	case "scheduled":
+		if s.Location.Type != "directory" {
+			return errors.New("scheduled trigger requires directory location")
+		}
+		if s.Policy.Continuity != "fresh" && s.Policy.Continuity != "singleton" {
+			return errors.New("scheduled trigger requires policy.continuity fresh or singleton")
+		}
+		if s.Policy.CatchUp != "skip" && s.Policy.CatchUp != "latest" {
+			return errors.New("scheduled trigger requires policy.catch_up skip or latest")
+		}
+	default:
+		if s.Policy.Continuity != "fresh" {
+			return errors.New("manual trigger supports only policy.continuity fresh")
+		}
+		if s.Policy.CatchUp != "" {
+			return errors.New("manual trigger cannot configure policy.catch_up")
+		}
 	}
 	return nil
 }

--- a/internal/automation/automation.go
+++ b/internal/automation/automation.go
@@ -434,12 +434,12 @@ func Effective(spec DefinitionSpec, revision int) (Snapshot, error) {
 
 type DeliveryIDs struct{ TicketID, SessionID, WorkspaceID, PaneID string }
 type WorkRequest struct {
-	RunID, DefinitionID, SubjectKey, ContinuityKey string
-	Prompt                                         string
-	Context                                        json.RawMessage
-	Launch                                         EffectiveLaunch
-	Location                                       LocationSpec
-	IDs                                            DeliveryIDs
+	RunID, DefinitionID, SubjectKey, ContinuityKey, Provider string
+	Prompt                                                   string
+	Context                                                  json.RawMessage
+	Launch                                                   EffectiveLaunch
+	Location                                                 LocationSpec
+	IDs                                                      DeliveryIDs
 }
 type PreparedLocation struct {
 	Directory string          `json:"directory"`

--- a/internal/automation/automation_test.go
+++ b/internal/automation/automation_test.go
@@ -311,6 +311,66 @@ policy: {continuity: per_subject, catch_up: latest}
 	}
 }
 
+// TestCanonicalJSONOmitsScheduleForNonScheduledTriggers is the regression
+// check for Fix 3: encoding/json's omitempty does not omit a zero-value
+// struct, so TriggerSpec.Schedule must be a pointer or every manual/
+// github_review_requested definition's canonical JSON grows a spurious
+// "schedule":{} key, which would bump UpsertAutomationDefinition's revision
+// on every byte-identical re-apply.
+func TestCanonicalJSONOmitsScheduleForNonScheduledTriggers(t *testing.T) {
+	dir := t.TempDir()
+	manual := strings.ReplaceAll(`api_version: attn.dev/automations/v1alpha1
+id: manual-no-schedule
+name: Manual
+enabled: true
+trigger: {type: manual}
+prompt: Inspect.
+launch: {driver: codex}
+location: {type: directory, path: PATH}
+policy: {continuity: fresh}
+`, "PATH", dir)
+	_, canonical, err := ParseDefinitionYAML([]byte(manual))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(canonical), `"schedule"`) {
+		t.Fatalf("canonical JSON contains a schedule key for a manual trigger: %s", canonical)
+	}
+}
+
+// TestScheduledDefinitionRoundTripsCronAndTimeZone locks in that
+// TriggerSpec.Schedule's pointer conversion still carries cron/time_zone
+// through both the YAML parse and a canonical-JSON re-decode.
+func TestScheduledDefinitionRoundTripsCronAndTimeZone(t *testing.T) {
+	dir := t.TempDir()
+	raw := strings.ReplaceAll(`api_version: attn.dev/automations/v1alpha1
+id: nightly
+name: Nightly
+enabled: true
+trigger:
+  type: scheduled
+  schedule: {cron: "0 3 * * *", time_zone: America/New_York}
+prompt: Sweep.
+launch: {driver: codex}
+location: {type: directory, path: PATH}
+policy: {continuity: fresh, catch_up: skip}
+`, "PATH", dir)
+	spec, canonical, err := ParseDefinitionYAML([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.Trigger.Schedule == nil || spec.Trigger.Schedule.Cron != "0 3 * * *" || spec.Trigger.Schedule.TimeZone != "America/New_York" {
+		t.Fatalf("parsed schedule = %#v, want cron/time_zone preserved", spec.Trigger.Schedule)
+	}
+	var reDecoded DefinitionSpec
+	if err := json.Unmarshal(canonical, &reDecoded); err != nil {
+		t.Fatal(err)
+	}
+	if reDecoded.Trigger.Schedule == nil || reDecoded.Trigger.Schedule.Cron != "0 3 * * *" || reDecoded.Trigger.Schedule.TimeZone != "America/New_York" {
+		t.Fatalf("canonical JSON round-trip schedule = %#v, want cron/time_zone preserved", reDecoded.Trigger.Schedule)
+	}
+}
+
 func TestManualTriggerRejectsCatchUp(t *testing.T) {
 	dir := t.TempDir()
 	raw := strings.ReplaceAll(`api_version: attn.dev/automations/v1alpha1

--- a/internal/automation/automation_test.go
+++ b/internal/automation/automation_test.go
@@ -219,6 +219,115 @@ policy: {continuity: per_subject, catch_up: latest, overlap: coalesce}
 	}
 }
 
+func TestScheduledDefinitionValidation(t *testing.T) {
+	dir := t.TempDir()
+	base := strings.ReplaceAll(`api_version: attn.dev/automations/v1alpha1
+id: nightly
+name: Nightly
+enabled: true
+trigger:
+  type: scheduled
+  schedule: {cron: "0 3 * * *", time_zone: America/New_York}
+prompt: Sweep.
+launch: {driver: codex}
+location: {type: directory, path: PATH}
+policy: {continuity: fresh, catch_up: skip}
+`, "PATH", dir)
+	if _, _, err := ParseDefinitionYAML([]byte(base)); err != nil {
+		t.Fatalf("valid scheduled definition rejected: %v", err)
+	}
+	for name, raw := range map[string]string{
+		"missing cron":                 strings.Replace(base, `cron: "0 3 * * *", `, "", 1),
+		"TZ prefix":                    strings.Replace(base, `cron: "0 3 * * *"`, `cron: "TZ=America/New_York 0 3 * * *"`, 1),
+		"CRON_TZ prefix":               strings.Replace(base, `cron: "0 3 * * *"`, `cron: "CRON_TZ=America/New_York 0 3 * * *"`, 1),
+		"invalid cron":                 strings.Replace(base, `cron: "0 3 * * *"`, `cron: "not a cron"`, 1),
+		"never-occurring cron":         strings.Replace(base, `cron: "0 3 * * *"`, `cron: "0 0 30 2 *"`, 1),
+		"missing time zone":            strings.Replace(base, ", time_zone: America/New_York", "", 1),
+		"invalid time zone":            strings.Replace(base, "time_zone: America/New_York", "time_zone: Not/AZone", 1),
+		"repository_worktree location": strings.Replace(base, "location: {type: directory, path: "+dir+"}", "location: {type: repository_worktree, repository_sources: {default: {type: managed_cache}}}", 1),
+		"per_subject continuity":       strings.Replace(base, "continuity: fresh, catch_up: skip", "continuity: per_subject, catch_up: skip", 1),
+		"missing catch_up":             strings.Replace(base, "continuity: fresh, catch_up: skip", "continuity: fresh", 1),
+		"catch_up queue":               strings.Replace(base, "catch_up: skip", "catch_up: queue", 1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			raw = strings.ReplaceAll(raw, "PATH", dir)
+			if _, _, err := ParseDefinitionYAML([]byte(raw)); err == nil {
+				t.Fatal("accepted invalid scheduled definition")
+			}
+		})
+	}
+	for name, catchUp := range map[string]string{"skip": "skip", "latest": "latest"} {
+		t.Run("catch_up "+name, func(t *testing.T) {
+			raw := strings.Replace(base, "catch_up: skip", "catch_up: "+catchUp, 1)
+			if _, _, err := ParseDefinitionYAML([]byte(raw)); err != nil {
+				t.Fatalf("catch_up=%s rejected: %v", catchUp, err)
+			}
+		})
+	}
+	for name, continuity := range map[string]string{"fresh": "fresh", "singleton": "singleton"} {
+		t.Run("continuity "+name, func(t *testing.T) {
+			raw := strings.Replace(base, "continuity: fresh", "continuity: "+continuity, 1)
+			if _, _, err := ParseDefinitionYAML([]byte(raw)); err != nil {
+				t.Fatalf("continuity=%s rejected: %v", continuity, err)
+			}
+		})
+	}
+}
+
+func TestManualAndGitHubTriggersRejectSchedule(t *testing.T) {
+	dir := t.TempDir()
+	manual := strings.ReplaceAll(`api_version: attn.dev/automations/v1alpha1
+id: manual-with-schedule
+name: Manual
+enabled: true
+trigger:
+  type: manual
+  schedule: {cron: "0 3 * * *", time_zone: UTC}
+prompt: Inspect.
+launch: {driver: codex}
+location: {type: directory, path: PATH}
+policy: {continuity: fresh}
+`, "PATH", dir)
+	if _, _, err := ParseDefinitionYAML([]byte(manual)); err == nil || !strings.Contains(err.Error(), "cannot configure schedule") {
+		t.Fatalf("err = %v", err)
+	}
+	github := `api_version: attn.dev/automations/v1alpha1
+id: requested-review
+name: Requested review
+enabled: true
+trigger:
+  type: github_review_requested
+  repositories: {mode: all_accessible}
+  schedule: {cron: "0 3 * * *", time_zone: UTC}
+prompt: Review locally.
+launch: {driver: codex}
+location:
+  type: repository_worktree
+  repository_sources: {default: {type: managed_cache}}
+policy: {continuity: per_subject, catch_up: latest}
+`
+	if _, _, err := ParseDefinitionYAML([]byte(github)); err == nil || !strings.Contains(err.Error(), "cannot configure schedule") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestManualTriggerRejectsCatchUp(t *testing.T) {
+	dir := t.TempDir()
+	raw := strings.ReplaceAll(`api_version: attn.dev/automations/v1alpha1
+id: manual-with-catchup
+name: Manual
+enabled: true
+trigger: {type: manual}
+prompt: Inspect.
+launch: {driver: codex}
+location: {type: directory, path: PATH}
+policy: {continuity: fresh, catch_up: skip}
+`, "PATH", dir)
+	if _, _, err := ParseDefinitionYAML([]byte(raw)); err == nil || !strings.Contains(err.Error(), "cannot configure policy.catch_up") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
 func TestPullRequestInputIsStrictAndCanonical(t *testing.T) {
 	raw := json.RawMessage(`{"provider":"github","host":"GitHub.COM","owner":"Owner","repository":"Repo","number":42,"url":"https://github.com/owner/repo/pull/42/","state":"open","draft":false,"head_sha":"0123456789ABCDEF0123456789ABCDEF01234567"}`)
 	input, err := ParsePullRequestInput(raw)

--- a/internal/automation/schedule.go
+++ b/internal/automation/schedule.go
@@ -1,0 +1,119 @@
+package automation
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+// scheduleValidationSample anchors the "does this cron expression ever fire"
+// check to a fixed instant, so validation is deterministic and independent of
+// when it runs.
+var scheduleValidationSample = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// CompiledSchedule is a parsed, validated ScheduleSpec ready to compute due
+// instants.
+type CompiledSchedule struct {
+	cron     cron.Schedule
+	location *time.Location
+}
+
+// CompileSchedule parses and validates a ScheduleSpec. schedule.cron must parse
+// as a standard cron expression (no embedded TZ=/CRON_TZ= prefix, which would
+// silently compete with schedule.time_zone) and have a real next occurrence;
+// schedule.time_zone must be a loadable IANA name.
+func CompileSchedule(spec ScheduleSpec) (CompiledSchedule, error) {
+	cronExpr := strings.TrimSpace(spec.Cron)
+	if cronExpr == "" {
+		return CompiledSchedule{}, errors.New("schedule.cron is required")
+	}
+	if strings.HasPrefix(cronExpr, "TZ=") || strings.HasPrefix(cronExpr, "CRON_TZ=") {
+		return CompiledSchedule{}, errors.New("schedule.cron must not embed a TZ=/CRON_TZ= prefix; set schedule.time_zone instead")
+	}
+	sched, err := cron.ParseStandard(cronExpr)
+	if err != nil {
+		return CompiledSchedule{}, fmt.Errorf("schedule.cron must be a valid cron expression: %w", err)
+	}
+	tz := strings.TrimSpace(spec.TimeZone)
+	if tz == "" {
+		return CompiledSchedule{}, errors.New("schedule.time_zone is required")
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return CompiledSchedule{}, fmt.Errorf("schedule.time_zone must be an IANA timezone: %w", err)
+	}
+	if sched.Next(scheduleValidationSample).IsZero() {
+		return CompiledSchedule{}, fmt.Errorf("schedule.cron %q describes a time that never occurs", cronExpr)
+	}
+	return CompiledSchedule{cron: sched, location: loc}, nil
+}
+
+// DueInstants returns the schedule's intended instants strictly after cursor and
+// at-or-before now, in order, iterating cron.Next at most limit times. ok is
+// false when the cap was hit before reaching now — the caller's replay-storm
+// guard, so a large backlog (e.g. a very old cursor) cannot fire an unbounded
+// burst of catch-up occurrences in a single pass.
+func (s CompiledSchedule) DueInstants(cursor, now time.Time, limit int) (instants []time.Time, ok bool) {
+	at := cursor.In(s.location)
+	for i := 0; i < limit; i++ {
+		next := s.cron.Next(at)
+		if next.IsZero() || next.After(now) {
+			return instants, true
+		}
+		instants = append(instants, next)
+		at = next
+	}
+	return instants, false
+}
+
+// ScheduledOccurrenceKey derives a scheduled occurrence's idempotency key from
+// its intended instant, normalized to UTC so the key is independent of the
+// schedule's configured time zone (and so an ambiguous local wall-clock time,
+// e.g. during a fall-back DST transition, still maps to a distinct key per
+// underlying instant).
+func ScheduledOccurrenceKey(intended time.Time) string {
+	return "scheduled:" + intended.UTC().Format(time.RFC3339)
+}
+
+// ScheduledInput is the structured occurrence input recorded for a scheduled
+// automation run.
+type ScheduledInput struct {
+	Provider   string `json:"provider"`
+	IntendedAt string `json:"intended_at"`
+	ObservedAt string `json:"observed_at"`
+}
+
+func NewScheduledInput(intended, observed time.Time) ScheduledInput {
+	return ScheduledInput{
+		Provider:   "schedule",
+		IntendedAt: intended.UTC().Format(time.RFC3339),
+		ObservedAt: observed.UTC().Format(time.RFC3339),
+	}
+}
+
+func ParseScheduledInput(raw json.RawMessage) (ScheduledInput, error) {
+	var input ScheduledInput
+	dec := json.NewDecoder(strings.NewReader(string(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&input); err != nil {
+		return input, fmt.Errorf("parse scheduled input: %w", err)
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		return input, errors.New("parse scheduled input: expected one JSON object")
+	}
+	if input.Provider != "schedule" {
+		return input, errors.New("scheduled input provider must be schedule")
+	}
+	if _, err := time.Parse(time.RFC3339, input.IntendedAt); err != nil {
+		return input, fmt.Errorf("scheduled input intended_at: %w", err)
+	}
+	if _, err := time.Parse(time.RFC3339, input.ObservedAt); err != nil {
+		return input, fmt.Errorf("scheduled input observed_at: %w", err)
+	}
+	return input, nil
+}

--- a/internal/automation/schedule_test.go
+++ b/internal/automation/schedule_test.go
@@ -1,0 +1,272 @@
+package automation
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func mustLocation(t *testing.T, name string) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		t.Fatalf("load location %q: %v", name, err)
+	}
+	return loc
+}
+
+func TestCompileScheduleValidation(t *testing.T) {
+	if _, err := CompileSchedule(ScheduleSpec{Cron: "0 3 * * *", TimeZone: "America/New_York"}); err != nil {
+		t.Fatalf("valid schedule rejected: %v", err)
+	}
+	for name, spec := range map[string]ScheduleSpec{
+		"missing cron":         {TimeZone: "UTC"},
+		"TZ prefix":            {Cron: "TZ=UTC 0 3 * * *", TimeZone: "UTC"},
+		"CRON_TZ prefix":       {Cron: "CRON_TZ=UTC 0 3 * * *", TimeZone: "UTC"},
+		"invalid cron":         {Cron: "not a cron", TimeZone: "UTC"},
+		"never-occurring cron": {Cron: "0 0 30 2 *", TimeZone: "UTC"},
+		"missing time zone":    {Cron: "0 3 * * *"},
+		"invalid time zone":    {Cron: "0 3 * * *", TimeZone: "Not/AZone"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := CompileSchedule(spec); err == nil {
+				t.Fatal("accepted invalid schedule")
+			}
+		})
+	}
+}
+
+func TestCompileScheduleTZPrefixErrorMentionsTimeZoneField(t *testing.T) {
+	_, err := CompileSchedule(ScheduleSpec{Cron: "TZ=UTC 0 3 * * *", TimeZone: "UTC"})
+	if err == nil || !strings.Contains(err.Error(), "schedule.time_zone") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// TestScheduleSpringForwardSkipsNonexistentInstant observes robfig/cron's actual
+// behavior for a daily "30 2 * * *" schedule across the America/New_York
+// spring-forward transition on 2026-03-08 (clocks jump 02:00 -> 03:00, so 02:30
+// never exists that day). robfig's field-matching search never finds a match on
+// 2026-03-08 and rolls straight to 2026-03-09 — the day is skipped entirely
+// rather than shifted to a nearby existing time.
+func TestScheduleSpringForwardSkipsNonexistentInstant(t *testing.T) {
+	loc := mustLocation(t, "America/New_York")
+	compiled, err := CompileSchedule(ScheduleSpec{Cron: "30 2 * * *", TimeZone: "America/New_York"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursor := time.Date(2026, 3, 6, 12, 0, 0, 0, loc)
+	now := time.Date(2026, 3, 13, 12, 0, 0, 0, loc)
+	instants, ok := compiled.DueInstants(cursor, now, 10)
+	if !ok {
+		t.Fatal("cap hit unexpectedly")
+	}
+	wantUTC := []string{
+		"2026-03-07T07:30:00Z",
+		"2026-03-09T06:30:00Z", // 2026-03-08 skipped: 02:30 does not exist that day
+		"2026-03-10T06:30:00Z",
+		"2026-03-11T06:30:00Z",
+		"2026-03-12T06:30:00Z",
+		"2026-03-13T06:30:00Z",
+	}
+	if len(instants) != len(wantUTC) {
+		t.Fatalf("instants=%v, want %d entries", instants, len(wantUTC))
+	}
+	var prev time.Time
+	for i, instant := range instants {
+		if got := instant.UTC().Format(time.RFC3339); got != wantUTC[i] {
+			t.Fatalf("instant[%d]=%s, want %s", i, got, wantUTC[i])
+		}
+		if i > 0 && !instant.After(prev) {
+			t.Fatalf("instants not strictly increasing at %d: %v", i, instants)
+		}
+		prev = instant
+	}
+}
+
+// TestScheduleFallBackVisitsAmbiguousHourTwice observes robfig/cron's actual
+// behavior for a daily "30 1 * * *" schedule across the America/New_York
+// fall-back transition on 2026-11-01 (clocks are set back 02:00 -> 01:00, so
+// 01:30 occurs twice). robfig's search visits the wall-clock instant 01:30 on
+// 2026-11-01 twice: once at the pre-transition offset (-04:00) and once at the
+// post-transition offset (-05:00), producing two distinct, strictly increasing
+// UTC instants for the same local time.
+func TestScheduleFallBackVisitsAmbiguousHourTwice(t *testing.T) {
+	loc := mustLocation(t, "America/New_York")
+	compiled, err := CompileSchedule(ScheduleSpec{Cron: "30 1 * * *", TimeZone: "America/New_York"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursor := time.Date(2026, 10, 30, 12, 0, 0, 0, loc)
+	now := time.Date(2026, 11, 2, 12, 0, 0, 0, loc)
+	instants, ok := compiled.DueInstants(cursor, now, 10)
+	if !ok {
+		t.Fatal("cap hit unexpectedly")
+	}
+	wantUTC := []string{
+		"2026-10-31T05:30:00Z",
+		"2026-11-01T05:30:00Z", // ambiguous hour, pre-transition offset -04:00
+		"2026-11-01T06:30:00Z", // ambiguous hour, post-transition offset -05:00
+		"2026-11-02T06:30:00Z",
+	}
+	if len(instants) != len(wantUTC) {
+		t.Fatalf("instants=%v, want %d entries", instants, len(wantUTC))
+	}
+	var prev time.Time
+	for i, instant := range instants {
+		if got := instant.UTC().Format(time.RFC3339); got != wantUTC[i] {
+			t.Fatalf("instant[%d]=%s, want %s", i, got, wantUTC[i])
+		}
+		if i > 0 && !instant.After(prev) {
+			t.Fatalf("instants not strictly increasing at %d: %v", i, instants)
+		}
+		prev = instant
+	}
+	keyOne := ScheduledOccurrenceKey(instants[1])
+	keyTwo := ScheduledOccurrenceKey(instants[2])
+	if keyOne == keyTwo {
+		t.Fatalf("ambiguous fall-back instants collapsed to one key: %s", keyOne)
+	}
+	if keyOne != "scheduled:2026-11-01T05:30:00Z" || keyTwo != "scheduled:2026-11-01T06:30:00Z" {
+		t.Fatalf("keys = %s, %s", keyOne, keyTwo)
+	}
+}
+
+func TestScheduleUTCSanity(t *testing.T) {
+	compiled, err := CompileSchedule(ScheduleSpec{Cron: "0 9 * * *", TimeZone: "UTC"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursor := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 6, 3, 9, 0, 0, 0, time.UTC)
+	instants, ok := compiled.DueInstants(cursor, now, 10)
+	if !ok {
+		t.Fatal("cap hit unexpectedly")
+	}
+	want := []string{"2026-06-01T09:00:00Z", "2026-06-02T09:00:00Z", "2026-06-03T09:00:00Z"}
+	if len(instants) != len(want) {
+		t.Fatalf("instants=%v, want %d entries", instants, len(want))
+	}
+	for i, instant := range instants {
+		if got := instant.UTC().Format(time.RFC3339); got != want[i] {
+			t.Fatalf("instant[%d]=%s, want %s", i, got, want[i])
+		}
+	}
+}
+
+// TestScheduleEuropeLondonAcrossDST checks a Europe/London daily "30 1 * * *"
+// schedule across the 2026-03-29 spring-forward transition (clocks jump 01:00 ->
+// 02:00, so 01:30 does not exist that day): the day is skipped, matching the
+// same field-matching behavior observed for America/New_York.
+func TestScheduleEuropeLondonAcrossDST(t *testing.T) {
+	loc := mustLocation(t, "Europe/London")
+	compiled, err := CompileSchedule(ScheduleSpec{Cron: "30 1 * * *", TimeZone: "Europe/London"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursor := time.Date(2026, 3, 27, 12, 0, 0, 0, loc)
+	now := time.Date(2026, 4, 2, 12, 0, 0, 0, loc)
+	instants, ok := compiled.DueInstants(cursor, now, 10)
+	if !ok {
+		t.Fatal("cap hit unexpectedly")
+	}
+	wantUTC := []string{
+		"2026-03-28T01:30:00Z",
+		"2026-03-30T00:30:00Z", // 2026-03-29 skipped: 01:30 does not exist that day
+		"2026-03-31T00:30:00Z",
+		"2026-04-01T00:30:00Z",
+		"2026-04-02T00:30:00Z",
+	}
+	if len(instants) != len(wantUTC) {
+		t.Fatalf("instants=%v, want %d entries", instants, len(wantUTC))
+	}
+	for i, instant := range instants {
+		if got := instant.UTC().Format(time.RFC3339); got != wantUTC[i] {
+			t.Fatalf("instant[%d]=%s, want %s", i, got, wantUTC[i])
+		}
+	}
+}
+
+func TestDueInstantsCursorEqualsNowReturnsNone(t *testing.T) {
+	compiled, err := CompileSchedule(ScheduleSpec{Cron: "0 9 * * *", TimeZone: "UTC"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+	instants, ok := compiled.DueInstants(now, now, 10)
+	if !ok || len(instants) != 0 {
+		t.Fatalf("instants=%v ok=%v, want none", instants, ok)
+	}
+}
+
+func TestDueInstantsCapHitReturnsNotOK(t *testing.T) {
+	compiled, err := CompileSchedule(ScheduleSpec{Cron: "0 9 * * *", TimeZone: "UTC"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursor := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	instants, ok := compiled.DueInstants(cursor, now, 5)
+	if ok {
+		t.Fatal("expected cap to be hit")
+	}
+	if len(instants) != 5 {
+		t.Fatalf("instants=%v, want 5", instants)
+	}
+}
+
+func TestDueInstantsMidWindowCursor(t *testing.T) {
+	compiled, err := CompileSchedule(ScheduleSpec{Cron: "0 9 * * *", TimeZone: "UTC"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursor := time.Date(2026, 6, 2, 9, 0, 0, 0, time.UTC) // strictly after
+	now := time.Date(2026, 6, 4, 9, 0, 0, 0, time.UTC)
+	instants, ok := compiled.DueInstants(cursor, now, 10)
+	if !ok {
+		t.Fatal("cap hit unexpectedly")
+	}
+	want := []string{"2026-06-03T09:00:00Z", "2026-06-04T09:00:00Z"}
+	if len(instants) != len(want) {
+		t.Fatalf("instants=%v, want %v", instants, want)
+	}
+	for i, instant := range instants {
+		if got := instant.UTC().Format(time.RFC3339); got != want[i] {
+			t.Fatalf("instant[%d]=%s, want %s", i, got, want[i])
+		}
+	}
+}
+
+func TestParseScheduledInput(t *testing.T) {
+	valid := json.RawMessage(`{"provider":"schedule","intended_at":"2026-06-01T09:00:00Z","observed_at":"2026-06-01T09:00:02Z"}`)
+	input, err := ParseScheduledInput(valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if input.Provider != "schedule" || input.IntendedAt != "2026-06-01T09:00:00Z" || input.ObservedAt != "2026-06-01T09:00:02Z" {
+		t.Fatalf("input = %#v", input)
+	}
+	for name, raw := range map[string]string{
+		"unknown field":  `{"provider":"schedule","intended_at":"2026-06-01T09:00:00Z","observed_at":"2026-06-01T09:00:02Z","extra":true}`,
+		"wrong provider": `{"provider":"github","intended_at":"2026-06-01T09:00:00Z","observed_at":"2026-06-01T09:00:02Z"}`,
+		"trailing json":  `{"provider":"schedule","intended_at":"2026-06-01T09:00:00Z","observed_at":"2026-06-01T09:00:02Z"}{}`,
+		"bad timestamp":  `{"provider":"schedule","intended_at":"not-a-time","observed_at":"2026-06-01T09:00:02Z"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseScheduledInput(json.RawMessage(raw)); err == nil {
+				t.Fatal("accepted invalid scheduled input")
+			}
+		})
+	}
+}
+
+func TestNewScheduledInputNormalizesToUTC(t *testing.T) {
+	loc := mustLocation(t, "America/New_York")
+	intended := time.Date(2026, 6, 1, 5, 0, 0, 0, loc)
+	observed := time.Date(2026, 6, 1, 5, 0, 2, 0, loc)
+	input := NewScheduledInput(intended, observed)
+	if input.Provider != "schedule" || input.IntendedAt != "2026-06-01T09:00:00Z" || input.ObservedAt != "2026-06-01T09:00:02Z" {
+		t.Fatalf("input = %#v", input)
+	}
+}

--- a/internal/daemon/automations.go
+++ b/internal/daemon/automations.go
@@ -541,10 +541,13 @@ func (d *Daemon) deliverAutomationRun(ctx context.Context, run *store.Automation
 		}
 	}
 	continuityKey := ""
-	if snapshot.Policy.Continuity == "per_subject" {
+	switch snapshot.Policy.Continuity {
+	case "per_subject":
 		continuityKey = occurrence.SubjectKey
+	case "singleton":
+		continuityKey = "singleton"
 	}
-	req := automation.WorkRequest{RunID: run.ID, DefinitionID: run.DefinitionID, SubjectKey: occurrence.SubjectKey, ContinuityKey: continuityKey, Prompt: snapshot.Prompt, Context: json.RawMessage(occurrence.PayloadJSON), Launch: snapshot.Launch, Location: snapshot.Location, IDs: automation.DeliveryIDs{TicketID: run.TicketID, SessionID: run.SessionID, WorkspaceID: run.WorkspaceID, PaneID: run.PaneID}}
+	req := automation.WorkRequest{RunID: run.ID, DefinitionID: run.DefinitionID, SubjectKey: occurrence.SubjectKey, ContinuityKey: continuityKey, Provider: occurrence.Provider, Prompt: snapshot.Prompt, Context: json.RawMessage(occurrence.PayloadJSON), Launch: snapshot.Launch, Location: snapshot.Location, IDs: automation.DeliveryIDs{TicketID: run.TicketID, SessionID: run.SessionID, WorkspaceID: run.WorkspaceID, PaneID: run.PaneID}}
 	if err := d.validateAutomationContinuation(req); err != nil {
 		return err
 	}
@@ -600,20 +603,25 @@ func (d *Daemon) validateAutomationContinuation(req automation.WorkRequest) erro
 	if originSnapshot.Prompt != req.Prompt || originSnapshot.Launch != req.Launch || !sameAutomationLocation(originSnapshot.Location, req.Location) {
 		return errors.New("automation reviewer contract changed; refusing to reuse a session with stale instructions")
 	}
-	originOccurrence, err := d.store.GetAutomationOccurrence(origin.OccurrenceID)
-	if err != nil || originOccurrence == nil {
-		return errors.Join(errors.New("continuity origin occurrence missing"), err)
-	}
-	originPR, err := automation.ParsePullRequestInput(json.RawMessage(originOccurrence.PayloadJSON))
-	if err != nil {
-		return fmt.Errorf("continuity origin payload: %w", err)
-	}
-	currentPR, err := automation.ParsePullRequestInput(req.Context)
-	if err != nil {
-		return err
-	}
-	if originPR.HeadSHA != currentPR.HeadSHA {
-		return errors.New("reviewer continuity across a changed pull-request revision is not enabled yet")
+	// The origin/current pull-request revision comparison only applies to
+	// GitHub-provider occurrences. A scheduled occurrence's payload is
+	// ScheduledInput, not a pull request; parsing it here would always fail.
+	if req.Provider == "github" {
+		originOccurrence, err := d.store.GetAutomationOccurrence(origin.OccurrenceID)
+		if err != nil || originOccurrence == nil {
+			return errors.Join(errors.New("continuity origin occurrence missing"), err)
+		}
+		originPR, err := automation.ParsePullRequestInput(json.RawMessage(originOccurrence.PayloadJSON))
+		if err != nil {
+			return fmt.Errorf("continuity origin payload: %w", err)
+		}
+		currentPR, err := automation.ParsePullRequestInput(req.Context)
+		if err != nil {
+			return err
+		}
+		if originPR.HeadSHA != currentPR.HeadSHA {
+			return errors.New("reviewer continuity across a changed pull-request revision is not enabled yet")
+		}
 	}
 	if d.canStartWithdrawnUndeliveredReviewer(origin, req.IDs.SessionID) {
 		return nil
@@ -1121,6 +1129,10 @@ func (d *Daemon) recoverAutomations() {
 			// recovery must not race that snapshot using yesterday's active edge.
 			continue
 		}
+		// Scheduled runs (occurrence.Provider == "schedule") fall through to
+		// generic recovery: their payload is self-contained (the intended
+		// instant, immutably snapshotted at claim time), so a pending run can
+		// be delivered directly without refreshing any external demand first.
 		d.automationMu.Lock()
 		run, err := d.store.GetAutomationRun(runs[i].ID)
 		if err == nil && run.State == "pending" {

--- a/internal/daemon/automations_schedule.go
+++ b/internal/daemon/automations_schedule.go
@@ -71,7 +71,12 @@ func (d *Daemon) observeDueSchedules(now time.Time) {
 // observeDueSchedule decides and, if due, claims and delivers the single
 // occurrence owed to one scheduled definition this tick.
 func (d *Daemon) observeDueSchedule(definition store.AutomationDefinition, spec automation.DefinitionSpec, now time.Time) {
-	compiled, err := automation.CompileSchedule(spec.Trigger.Schedule)
+	if spec.Trigger.Schedule == nil {
+		// Definition validation should have prevented this at apply time.
+		d.logf("automation schedule observation %s: scheduled trigger has no schedule", definition.ID)
+		return
+	}
+	compiled, err := automation.CompileSchedule(*spec.Trigger.Schedule)
 	if err != nil {
 		// Definition validation should have prevented this at apply time.
 		d.logf("automation schedule observation compile %s: %v", definition.ID, err)
@@ -114,11 +119,21 @@ func (d *Daemon) observeDueSchedule(definition store.AutomationDefinition, spec 
 		fire = now.Sub(intended) <= scheduleSkipGrace
 	}
 	if fire {
-		d.claimAndDeliverScheduledRun(definition, spec, intended, now)
+		if claimErr := d.claimAndDeliverScheduledRun(definition, spec, intended, now); claimErr != nil {
+			// The claim was rejected (revision mismatch, a singleton's
+			// undelivered-predecessor guard, or a transient store error): the
+			// cursor must stay behind intended so the next tick re-reads the
+			// definition and re-decides, per ClaimScheduledAutomationRun's
+			// documented contract. Advancing here would permanently drop
+			// this occurrence.
+			return
+		}
 	}
-	// Cursor advances after the claim decision regardless of fire/skip: a
-	// crash between claim and this write is safe because the next tick
-	// recomputes the same intended instant and the claim is idempotent.
+	// Cursor advances after a successful claim decision (fire or skip), not
+	// unconditionally: a crash between claim and this write is safe because
+	// the next tick recomputes the same intended instant and the claim is
+	// idempotent; a claim error must not advance past it (handled above) so
+	// the next tick retries the same intended instant instead of losing it.
 	if err := d.store.SetAutomationScheduleCursor(definition.ID, now); err != nil {
 		d.logf("automation schedule observation advance %s: %v", definition.ID, err)
 	}
@@ -126,37 +141,42 @@ func (d *Daemon) observeDueSchedule(definition store.AutomationDefinition, spec 
 
 // claimAndDeliverScheduledRun claims the occurrence for intended (idempotent
 // on definition + occurrence key) and, on a freshly pending run, delivers it
-// exactly like the GitHub review-request observation path.
-func (d *Daemon) claimAndDeliverScheduledRun(definition store.AutomationDefinition, spec automation.DefinitionSpec, intended, observedAt time.Time) {
+// exactly like the GitHub review-request observation path. It returns a
+// non-nil error when no run row was claimed — claim rejection/failure or any
+// pre-claim preparation failure; the caller uses that to withhold the cursor
+// advance. Delivery failures after a successful claim always return nil: the
+// run row already exists and is owned by delivery/recovery from here, not by
+// re-claiming.
+func (d *Daemon) claimAndDeliverScheduledRun(definition store.AutomationDefinition, spec automation.DefinitionSpec, intended, observedAt time.Time) error {
 	observationLock := d.automationObservationLock(definition.ID, "schedule", 0)
 	observationLock.Lock()
 	payload, err := json.Marshal(automation.NewScheduledInput(intended, observedAt))
 	if err != nil {
 		observationLock.Unlock()
 		d.logf("automation schedule observation payload %s: %v", definition.ID, err)
-		return
+		return err
 	}
 	effective, err := automation.Effective(spec, definition.Revision)
 	if err != nil {
 		observationLock.Unlock()
 		d.logf("automation schedule observation snapshot %s: %v", definition.ID, err)
-		return
+		return err
 	}
 	snapshotJSON, err := json.Marshal(effective)
 	if err != nil {
 		observationLock.Unlock()
 		d.logf("automation schedule observation snapshot marshal %s: %v", definition.ID, err)
-		return
+		return err
 	}
 	continuityKey := ""
 	if spec.Policy.Continuity == "singleton" {
 		continuityKey = "singleton"
 	}
-	run, _, err := d.store.ClaimScheduledAutomationRun(definition.ID, automation.ScheduledOccurrenceKey(intended), continuityKey, definition.Revision, string(payload), string(snapshotJSON), observedAt, newAutomationRunReservation())
+	run, _, claimErr := d.store.ClaimScheduledAutomationRun(definition.ID, automation.ScheduledOccurrenceKey(intended), continuityKey, definition.Revision, string(payload), string(snapshotJSON), observedAt, newAutomationRunReservation())
 	observationLock.Unlock()
-	if err != nil {
-		d.logf("automation schedule observation claim %s: %v", definition.ID, err)
-		return
+	if claimErr != nil {
+		d.logf("automation schedule observation claim %s: %v", definition.ID, claimErr)
+		return claimErr
 	}
 	d.automationMu.Lock()
 	current, loadErr := d.store.GetAutomationRun(run.ID)
@@ -170,4 +190,5 @@ func (d *Daemon) claimAndDeliverScheduledRun(definition store.AutomationDefiniti
 	if loadErr != nil {
 		d.logf("automation schedule observation deliver %s: %v", definition.ID, loadErr)
 	}
+	return nil
 }

--- a/internal/daemon/automations_schedule.go
+++ b/internal/daemon/automations_schedule.go
@@ -1,0 +1,173 @@
+package daemon
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/victorarias/attn/internal/automation"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// scheduleDueInstantCap bounds DueInstants' backlog walk. A cursor left far
+// behind (e.g. the daemon was off for a long time on a minutely schedule)
+// must never fire an unbounded burst of catch-up occurrences in one tick.
+// A var, not a const, so tests can shrink it instead of constructing
+// million-instant backlogs.
+var scheduleDueInstantCap = 1_000_000
+
+// scheduleSkipGrace is how long after an intended instant a "skip" catch-up
+// policy will still fire it. Past this window the instant is considered
+// missed and is never delivered.
+const scheduleSkipGrace = 5 * time.Minute
+
+// startAutomationScheduleLoop blocks running the scheduled-automation
+// observation tick until done is closed. Intended to be launched in its own
+// goroutine from Start, mirroring startNotebookCronEnqueuer.
+func (d *Daemon) startAutomationScheduleLoop(done <-chan struct{}) {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			d.observeDueSchedules(time.Now())
+		}
+	}
+}
+
+// observeDueSchedules is the per-tick fan-out over enabled scheduled
+// automation definitions, deciding and claiming at most one due occurrence
+// per definition. now is param-injected for testability.
+func (d *Daemon) observeDueSchedules(now time.Time) {
+	if d.isRecovering() {
+		// Startup recovery has not yet decided existing pending runs; a fresh
+		// observation racing ahead of it could double-claim or misjudge a
+		// definition's cursor before recovery has settled prior state.
+		return
+	}
+	definitions, err := d.store.ListAutomationDefinitions()
+	if err != nil {
+		d.logf("automation schedule observation list definitions: %v", err)
+		return
+	}
+	for i := range definitions {
+		definition := definitions[i]
+		if !definition.Enabled {
+			continue
+		}
+		var spec automation.DefinitionSpec
+		if err := json.Unmarshal([]byte(definition.SpecJSON), &spec); err != nil {
+			d.logf("automation schedule observation parse %s: %v", definition.ID, err)
+			continue
+		}
+		if spec.Trigger.Type != "scheduled" {
+			continue
+		}
+		d.observeDueSchedule(definition, spec, now)
+	}
+}
+
+// observeDueSchedule decides and, if due, claims and delivers the single
+// occurrence owed to one scheduled definition this tick.
+func (d *Daemon) observeDueSchedule(definition store.AutomationDefinition, spec automation.DefinitionSpec, now time.Time) {
+	compiled, err := automation.CompileSchedule(spec.Trigger.Schedule)
+	if err != nil {
+		// Definition validation should have prevented this at apply time.
+		d.logf("automation schedule observation compile %s: %v", definition.ID, err)
+		return
+	}
+	cursor, ok, err := d.store.GetAutomationScheduleCursor(definition.ID)
+	if err != nil {
+		d.logf("automation schedule observation cursor %s: %v", definition.ID, err)
+		return
+	}
+	if !ok {
+		// First observation anchors the cursor at now instead of firing
+		// retroactively: only instants strictly after this point are due.
+		if err := d.store.SetAutomationScheduleCursor(definition.ID, now); err != nil {
+			d.logf("automation schedule observation anchor %s: %v", definition.ID, err)
+		}
+		return
+	}
+	instants, ok := compiled.DueInstants(cursor, now, scheduleDueInstantCap)
+	if !ok {
+		// Replay-storm guard: an enormous backlog must never fire an unbounded
+		// catch-up burst. Jump the cursor to now and resume normal observation
+		// on the next tick.
+		d.logf("automation schedule observation %s: replay storm guard hit, cursor advanced to now", definition.ID)
+		if err := d.store.SetAutomationScheduleCursor(definition.ID, now); err != nil {
+			d.logf("automation schedule observation advance %s: %v", definition.ID, err)
+		}
+		return
+	}
+	if len(instants) == 0 {
+		// Nothing due: leave the cursor untouched so anchor semantics survive
+		// a run of empty ticks between scheduled slots.
+		return
+	}
+	// Only the newest due instant is ever a fire candidate; older due instants
+	// never fire, so at most one claim happens per definition per tick.
+	intended := instants[len(instants)-1]
+	fire := true
+	if spec.Policy.CatchUp == "skip" {
+		fire = now.Sub(intended) <= scheduleSkipGrace
+	}
+	if fire {
+		d.claimAndDeliverScheduledRun(definition, spec, intended, now)
+	}
+	// Cursor advances after the claim decision regardless of fire/skip: a
+	// crash between claim and this write is safe because the next tick
+	// recomputes the same intended instant and the claim is idempotent.
+	if err := d.store.SetAutomationScheduleCursor(definition.ID, now); err != nil {
+		d.logf("automation schedule observation advance %s: %v", definition.ID, err)
+	}
+}
+
+// claimAndDeliverScheduledRun claims the occurrence for intended (idempotent
+// on definition + occurrence key) and, on a freshly pending run, delivers it
+// exactly like the GitHub review-request observation path.
+func (d *Daemon) claimAndDeliverScheduledRun(definition store.AutomationDefinition, spec automation.DefinitionSpec, intended, observedAt time.Time) {
+	observationLock := d.automationObservationLock(definition.ID, "schedule", 0)
+	observationLock.Lock()
+	payload, err := json.Marshal(automation.NewScheduledInput(intended, observedAt))
+	if err != nil {
+		observationLock.Unlock()
+		d.logf("automation schedule observation payload %s: %v", definition.ID, err)
+		return
+	}
+	effective, err := automation.Effective(spec, definition.Revision)
+	if err != nil {
+		observationLock.Unlock()
+		d.logf("automation schedule observation snapshot %s: %v", definition.ID, err)
+		return
+	}
+	snapshotJSON, err := json.Marshal(effective)
+	if err != nil {
+		observationLock.Unlock()
+		d.logf("automation schedule observation snapshot marshal %s: %v", definition.ID, err)
+		return
+	}
+	continuityKey := ""
+	if spec.Policy.Continuity == "singleton" {
+		continuityKey = "singleton"
+	}
+	run, _, err := d.store.ClaimScheduledAutomationRun(definition.ID, automation.ScheduledOccurrenceKey(intended), continuityKey, definition.Revision, string(payload), string(snapshotJSON), observedAt, newAutomationRunReservation())
+	observationLock.Unlock()
+	if err != nil {
+		d.logf("automation schedule observation claim %s: %v", definition.ID, err)
+		return
+	}
+	d.automationMu.Lock()
+	current, loadErr := d.store.GetAutomationRun(run.ID)
+	if loadErr == nil && current != nil && current.State == "pending" {
+		if deliverErr := d.deliverObservedAutomationRun(current); deliverErr != nil {
+			_, deliverErr = d.handleAutomationDeliveryError(current, deliverErr)
+			loadErr = deliverErr
+		}
+	}
+	d.automationMu.Unlock()
+	if loadErr != nil {
+		d.logf("automation schedule observation deliver %s: %v", definition.ID, loadErr)
+	}
+}

--- a/internal/daemon/automations_schedule.go
+++ b/internal/daemon/automations_schedule.go
@@ -121,19 +121,24 @@ func (d *Daemon) observeDueSchedule(definition store.AutomationDefinition, spec 
 	if fire {
 		if claimErr := d.claimAndDeliverScheduledRun(definition, spec, intended, now); claimErr != nil {
 			// The claim was rejected (revision mismatch, a singleton's
-			// undelivered-predecessor guard, or a transient store error): the
-			// cursor must stay behind intended so the next tick re-reads the
-			// definition and re-decides, per ClaimScheduledAutomationRun's
-			// documented contract. Advancing here would permanently drop
-			// this occurrence.
+			// undelivered-predecessor guard, or a transient store error): hold
+			// the cursor behind intended so the missed instant stays eligible
+			// and the next tick re-reads the definition and re-decides. The
+			// retry fires the newest instant due at that time under the normal
+			// newest-due-wins rule — the identical instant unless a newer one
+			// has become due meanwhile (minutely-grade schedules) — so a claim
+			// failure delays the definition's appointment; it never silently
+			// drops it, and it never prefers a stale instant over a fresher
+			// due one.
 			return
 		}
 	}
 	// Cursor advances after a successful claim decision (fire or skip), not
 	// unconditionally: a crash between claim and this write is safe because
 	// the next tick recomputes the same intended instant and the claim is
-	// idempotent; a claim error must not advance past it (handled above) so
-	// the next tick retries the same intended instant instead of losing it.
+	// idempotent; a claim error must not advance (handled above), keeping the
+	// missed instant eligible until a retry succeeds or a newer due instant
+	// supersedes it.
 	if err := d.store.SetAutomationScheduleCursor(definition.ID, now); err != nil {
 		d.logf("automation schedule observation advance %s: %v", definition.ID, err)
 	}

--- a/internal/daemon/automations_schedule_test.go
+++ b/internal/daemon/automations_schedule_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -102,6 +103,78 @@ func TestObserveDueSchedulesFiresWithinGraceForBothCatchUpPolicies(t *testing.T)
 	}
 }
 
+// TestObserveDueSchedulesSkipGraceBoundary is the regression check for Fix
+// 4a: catch_up=skip's grace window is inclusive of exactly scheduleSkipGrace
+// but excludes anything past it, matching observeDueSchedule's `<=` compare.
+// The cursor still advances in both cases either way.
+func TestObserveDueSchedulesSkipGraceBoundary(t *testing.T) {
+	for name, tc := range map[string]struct {
+		offset   time.Duration
+		delivers bool
+	}{
+		"exactly at grace fires":      {scheduleSkipGrace, true},
+		"one second past grace skips": {scheduleSkipGrace + time.Second, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			d, s, def, _ := setupScheduledDaemon(t, "0 * * * *", "fresh", "skip")
+			var delivered []*store.AutomationRun
+			d.automationDeliveryHook = func(run *store.AutomationRun) error {
+				delivered = append(delivered, run)
+				return s.MarkAutomationRunDelivered(run.ID, "{}", time.Now())
+			}
+
+			anchor := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+			d.observeDueSchedules(anchor)
+			intended := time.Date(2026, 7, 20, 4, 0, 0, 0, time.UTC)
+			observedAt := intended.Add(tc.offset)
+			d.observeDueSchedules(observedAt)
+
+			if tc.delivers {
+				if len(delivered) != 1 {
+					t.Fatalf("delivered=%d, want 1", len(delivered))
+				}
+				occurrence, err := s.GetAutomationOccurrence(delivered[0].OccurrenceID)
+				if err != nil || occurrence == nil {
+					t.Fatalf("occurrence missing: %v", err)
+				}
+				if wantKey := automation.ScheduledOccurrenceKey(intended); occurrence.OccurrenceKey != wantKey {
+					t.Fatalf("occurrence key=%s want=%s", occurrence.OccurrenceKey, wantKey)
+				}
+			} else if len(delivered) != 0 {
+				t.Fatalf("delivered=%d, want 0", len(delivered))
+			}
+
+			cursor, ok, err := s.GetAutomationScheduleCursor(def.ID)
+			if err != nil || !ok || !cursor.Equal(observedAt) {
+				t.Fatalf("cursor=%v ok=%v err=%v, want advanced to %v regardless of fire/skip", cursor, ok, err, observedAt)
+			}
+		})
+	}
+}
+
+// TestObserveDueSchedulesSkipsObservationWhileRecovering is the regression
+// check for Fix 4c: a brand-new scheduled definition observed while startup
+// recovery hasn't settled prior state must not anchor a cursor; once
+// recovery clears, the next call anchors normally.
+func TestObserveDueSchedulesSkipsObservationWhileRecovering(t *testing.T) {
+	d, s, def, _ := setupScheduledDaemon(t, "* * * * *", "fresh", "latest")
+	d.setRecovering(true)
+
+	now0 := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	d.observeDueSchedules(now0)
+
+	if _, ok, err := s.GetAutomationScheduleCursor(def.ID); err != nil || ok {
+		t.Fatalf("recovering observation anchored a cursor: ok=%v err=%v", ok, err)
+	}
+
+	d.setRecovering(false)
+	d.observeDueSchedules(now0)
+	cursor, ok, err := s.GetAutomationScheduleCursor(def.ID)
+	if err != nil || !ok || !cursor.Equal(now0) {
+		t.Fatalf("cursor=%v ok=%v err=%v, want anchored at %v once recovery clears", cursor, ok, err, now0)
+	}
+}
+
 func TestObserveDueSchedulesIdempotentAcrossRepeatedTicks(t *testing.T) {
 	d, s, def, _ := setupScheduledDaemon(t, "* * * * *", "fresh", "latest")
 	delivered := 0
@@ -175,6 +248,89 @@ func TestObserveDueSchedulesDowntimeCatchUpPolicies(t *testing.T) {
 				t.Fatalf("cursor=%v ok=%v err=%v, want advanced to %v", cursor, ok, err, resumed)
 			}
 		})
+	}
+}
+
+// TestObserveDueScheduleClaimRejectionLeavesCursorForRetry is the regression
+// check for Fix 1: a claim rejected by ClaimScheduledAutomationRun's revision
+// guard must not advance the cursor past the intended instant, or the next
+// tick would never re-decide that occurrence and it would be dropped
+// permanently. Simulates the observation race directly (definition edited
+// between ListAutomationDefinitions' read and the claim) by calling
+// observeDueSchedule with a stale `definition` copy while the store already
+// holds a newer revision.
+func TestObserveDueScheduleClaimRejectionLeavesCursorForRetry(t *testing.T) {
+	d, s, def, dir := setupScheduledDaemon(t, "* * * * *", "fresh", "latest")
+	var spec automation.DefinitionSpec
+	if err := json.Unmarshal([]byte(def.SpecJSON), &spec); err != nil {
+		t.Fatal(err)
+	}
+	staleDefinition := *def // Revision predates the edit below.
+
+	now0 := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	d.observeDueSchedules(now0) // anchor
+
+	// Edit the definition (bumping its revision), racing an in-flight tick
+	// that already read the pre-edit definition.
+	editedSpec, editedCanonical, err := automation.ParseDefinitionYAML([]byte(scheduledDefinitionYAML(dir, "* * * * *", "fresh", "latest", "Different sweep.")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.UpsertAutomationDefinition(editedSpec.ID, editedSpec.Name, string(editedCanonical), true, now0); err != nil {
+		t.Fatal(err)
+	}
+
+	delivered := 0
+	d.automationDeliveryHook = func(*store.AutomationRun) error { delivered++; return nil }
+	due := now0.Add(60 * time.Second)
+	d.observeDueSchedule(staleDefinition, spec, now0.Add(70*time.Second))
+
+	if delivered != 0 {
+		t.Fatalf("delivered=%d, want 0 on claim rejection", delivered)
+	}
+	cursor, ok, err := s.GetAutomationScheduleCursor(def.ID)
+	if err != nil || !ok || !cursor.Equal(now0) {
+		t.Fatalf("cursor=%v ok=%v err=%v, want unchanged at %v after rejected claim", cursor, ok, err, now0)
+	}
+	runs, err := s.ListAutomationRuns(def.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("runs=%d, want 0 after rejected claim", len(runs))
+	}
+
+	// A later tick re-reads the now-fresh definition and claims the same
+	// intended instant successfully.
+	freshDefinition, err := s.GetAutomationDefinition(def.ID)
+	if err != nil || freshDefinition == nil {
+		t.Fatalf("fresh definition: %v", err)
+	}
+	var freshSpec automation.DefinitionSpec
+	if err := json.Unmarshal([]byte(freshDefinition.SpecJSON), &freshSpec); err != nil {
+		t.Fatal(err)
+	}
+	retryAt := now0.Add(75 * time.Second)
+	d.observeDueSchedule(*freshDefinition, freshSpec, retryAt)
+
+	if delivered != 1 {
+		t.Fatalf("delivered=%d, want 1 after retry with fresh definition", delivered)
+	}
+	runs, err = s.ListAutomationRuns(def.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("runs=%d, want 1", len(runs))
+	}
+	wantKey := automation.ScheduledOccurrenceKey(due)
+	occurrence, err := s.GetAutomationOccurrence(runs[0].OccurrenceID)
+	if err != nil || occurrence == nil || occurrence.OccurrenceKey != wantKey {
+		t.Fatalf("occurrence=%#v err=%v, want key %s for the same intended instant", occurrence, err, wantKey)
+	}
+	cursor, ok, err = s.GetAutomationScheduleCursor(def.ID)
+	if err != nil || !ok || !cursor.Equal(retryAt) {
+		t.Fatalf("cursor=%v ok=%v err=%v, want advanced to %v after the successful retry", cursor, ok, err, retryAt)
 	}
 }
 
@@ -379,5 +535,59 @@ func TestScheduledSingletonContinuationSkipsPullRequestParsing(t *testing.T) {
 	// live-session short circuit and succeeds.
 	if err := d.validateAutomationContinuation(req); err != nil {
 		t.Fatalf("singleton continuation with a live session rejected: %v", err)
+	}
+}
+
+// TestScheduledSingletonMissingContinuityTicketFailsBeforeReusingBoundArtifacts
+// is the scheduled-provider mirror of
+// TestMissingContinuityTicketFailsBeforeReusingBoundArtifacts in
+// automations_test.go. Fix 2 makes ClaimScheduledAutomationRun record
+// subject_key=continuityKey instead of always "": this is what lets
+// HasPriorAutomationContinuityRun ever match a scheduled singleton's prior
+// run, so EnsureTicket's deleted-ticket safety guard actually fires instead
+// of silently recreating the ticket.
+func TestScheduledSingletonMissingContinuityTicketFailsBeforeReusingBoundArtifacts(t *testing.T) {
+	s := store.New()
+	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{}`, true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	intended1 := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	payload1, err := json.Marshal(automation.NewScheduledInput(intended1, now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, _, err := s.ClaimScheduledAutomationRun(def.ID, automation.ScheduledOccurrenceKey(intended1), "singleton", def.Revision, string(payload1), `{}`, now, store.AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.EnsureAutomationTicket(store.Ticket{ID: first.TicketID, Title: "Nightly", Status: store.TicketStatusDone, Assignee: first.SessionID, AutomationRunID: first.ID}, "automation:nightly", store.TicketRoleChiefOfStaff, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MarkAutomationRunDelivered(first.ID, `{}`, now); err != nil {
+		t.Fatal(err)
+	}
+	if removed, err := s.SweepExpiredTickets(now.Add(2*time.Hour), time.Hour); err != nil || removed != 1 {
+		t.Fatalf("sweep removed=%d err=%v", removed, err)
+	}
+
+	intended2 := intended1.Add(time.Minute)
+	payload2, err := json.Marshal(automation.NewScheduledInput(intended2, now.Add(4*time.Hour)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _, err := s.ClaimScheduledAutomationRun(def.ID, automation.ScheduledOccurrenceKey(intended2), "singleton", def.Revision, string(payload2), `{}`, now.Add(4*time.Hour), store.AutomationRunReservation{RunID: "run-2", OccurrenceID: "occ-2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	err = d.EnsureTicket(context.Background(), automation.WorkRequest{RunID: second.ID, DefinitionID: def.ID, ContinuityKey: "singleton", IDs: automation.DeliveryIDs{TicketID: second.TicketID, SessionID: second.SessionID}})
+	if err == nil || !strings.Contains(err.Error(), "continuity ticket is missing") {
+		t.Fatalf("missing continuity ticket err=%v", err)
+	}
+	if ticket, err := s.GetTicket(first.TicketID); err != nil || ticket != nil {
+		t.Fatalf("swept ticket was recreated: ticket=%#v err=%v", ticket, err)
 	}
 }

--- a/internal/daemon/automations_schedule_test.go
+++ b/internal/daemon/automations_schedule_test.go
@@ -334,6 +334,73 @@ func TestObserveDueScheduleClaimRejectionLeavesCursorForRetry(t *testing.T) {
 	}
 }
 
+// A claim rejected at 03:01:30 on a minutely schedule retried a full minute
+// later must fire exactly one run for the NEWEST due instant (03:02), not the
+// failed 03:01: the held-back cursor keeps the definition's appointment
+// eligible, and the normal newest-due-wins rule — not a stale-instant replay —
+// decides what fires on retry. This pins the production cadence where a new
+// cron instant becomes due before the retry.
+func TestObserveDueScheduleClaimRejectionRetryFiresNewestDueInstant(t *testing.T) {
+	d, s, def, dir := setupScheduledDaemon(t, "* * * * *", "fresh", "latest")
+	var spec automation.DefinitionSpec
+	if err := json.Unmarshal([]byte(def.SpecJSON), &spec); err != nil {
+		t.Fatal(err)
+	}
+	staleDefinition := *def // Revision predates the edit below.
+
+	now0 := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	d.observeDueSchedules(now0) // anchor
+
+	editedSpec, editedCanonical, err := automation.ParseDefinitionYAML([]byte(scheduledDefinitionYAML(dir, "* * * * *", "fresh", "latest", "Different sweep.")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.UpsertAutomationDefinition(editedSpec.ID, editedSpec.Name, string(editedCanonical), true, now0); err != nil {
+		t.Fatal(err)
+	}
+
+	delivered := 0
+	d.automationDeliveryHook = func(*store.AutomationRun) error { delivered++; return nil }
+	// 03:01:30 tick with the stale definition: intended 03:01 claim rejected.
+	d.observeDueSchedule(staleDefinition, spec, now0.Add(90*time.Second))
+	if delivered != 0 {
+		t.Fatalf("delivered=%d, want 0 on claim rejection", delivered)
+	}
+
+	// 03:02:30 tick with the fresh definition: both 03:01 and 03:02 are due;
+	// newest-due-wins fires 03:02 exactly once.
+	freshDefinition, err := s.GetAutomationDefinition(def.ID)
+	if err != nil || freshDefinition == nil {
+		t.Fatalf("fresh definition: %v", err)
+	}
+	var freshSpec automation.DefinitionSpec
+	if err := json.Unmarshal([]byte(freshDefinition.SpecJSON), &freshSpec); err != nil {
+		t.Fatal(err)
+	}
+	retryAt := now0.Add(150 * time.Second)
+	d.observeDueSchedule(*freshDefinition, freshSpec, retryAt)
+
+	if delivered != 1 {
+		t.Fatalf("delivered=%d, want exactly 1 after the one-minute-later retry", delivered)
+	}
+	runs, err := s.ListAutomationRuns(def.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("runs=%d, want 1: the failed instant must be superseded, not replayed alongside", len(runs))
+	}
+	wantKey := automation.ScheduledOccurrenceKey(now0.Add(120 * time.Second))
+	occurrence, err := s.GetAutomationOccurrence(runs[0].OccurrenceID)
+	if err != nil || occurrence == nil || occurrence.OccurrenceKey != wantKey {
+		t.Fatalf("occurrence=%#v err=%v, want key %s for the newest due instant", occurrence, err, wantKey)
+	}
+	cursor, ok, err := s.GetAutomationScheduleCursor(def.ID)
+	if err != nil || !ok || !cursor.Equal(retryAt) {
+		t.Fatalf("cursor=%v ok=%v err=%v, want advanced to %v after the successful retry", cursor, ok, err, retryAt)
+	}
+}
+
 func TestObserveDueSchedulesReplayStormGuardAdvancesCursorWithoutClaiming(t *testing.T) {
 	d, s, def, _ := setupScheduledDaemon(t, "* * * * *", "fresh", "latest")
 	now0 := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)

--- a/internal/daemon/automations_schedule_test.go
+++ b/internal/daemon/automations_schedule_test.go
@@ -1,0 +1,383 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/automation"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// scheduledDefinitionYAML builds a minimal valid scheduled-trigger definition,
+// mirroring the fixture shape in automation_test.go's
+// TestScheduledDefinitionValidation.
+func scheduledDefinitionYAML(dir, cron, continuity, catchUp, prompt string) string {
+	return fmt.Sprintf(`api_version: attn.dev/automations/v1alpha1
+id: nightly
+name: Nightly
+enabled: true
+trigger:
+  type: scheduled
+  schedule: {cron: %q, time_zone: UTC}
+prompt: %s
+launch: {driver: codex}
+location: {type: directory, path: %s}
+policy: {continuity: %s, catch_up: %s}
+`, cron, prompt, dir, continuity, catchUp)
+}
+
+// setupScheduledDaemon parses and persists one scheduled automation
+// definition and returns a Daemon wired to an in-memory store, ready for
+// observeDueSchedules.
+func setupScheduledDaemon(t *testing.T, cron, continuity, catchUp string) (*Daemon, *store.Store, *store.AutomationDefinition, string) {
+	t.Helper()
+	dir := t.TempDir()
+	spec, canonical, err := automation.ParseDefinitionYAML([]byte(scheduledDefinitionYAML(dir, cron, continuity, catchUp, "Sweep.")))
+	if err != nil {
+		t.Fatalf("parse definition: %v", err)
+	}
+	s := store.New()
+	def, err := s.UpsertAutomationDefinition(spec.ID, spec.Name, string(canonical), true, time.Now())
+	if err != nil {
+		t.Fatalf("upsert definition: %v", err)
+	}
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	return d, s, def, dir
+}
+
+func TestObserveDueSchedulesFirstObservationAnchorsCursor(t *testing.T) {
+	d, s, def, _ := setupScheduledDaemon(t, "*/5 * * * *", "fresh", "latest")
+	delivered := 0
+	d.automationDeliveryHook = func(*store.AutomationRun) error { delivered++; return nil }
+
+	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	d.observeDueSchedules(now)
+
+	if delivered != 0 {
+		t.Fatalf("first observation delivered %d runs, want 0", delivered)
+	}
+	cursor, ok, err := s.GetAutomationScheduleCursor(def.ID)
+	if err != nil || !ok || !cursor.Equal(now) {
+		t.Fatalf("cursor=%v ok=%v err=%v, want anchored at %v", cursor, ok, err, now)
+	}
+}
+
+func TestObserveDueSchedulesFiresWithinGraceForBothCatchUpPolicies(t *testing.T) {
+	for _, catchUp := range []string{"skip", "latest"} {
+		t.Run(catchUp, func(t *testing.T) {
+			d, s, _, _ := setupScheduledDaemon(t, "* * * * *", "fresh", catchUp)
+			var delivered []*store.AutomationRun
+			d.automationDeliveryHook = func(run *store.AutomationRun) error {
+				delivered = append(delivered, run)
+				return s.MarkAutomationRunDelivered(run.ID, "{}", time.Now())
+			}
+
+			now0 := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+			d.observeDueSchedules(now0) // anchor
+			due := now0.Add(60 * time.Second)
+			d.observeDueSchedules(now0.Add(70 * time.Second)) // 10s past due, well within grace
+
+			if len(delivered) != 1 {
+				t.Fatalf("delivered=%d, want 1", len(delivered))
+			}
+			occurrence, err := s.GetAutomationOccurrence(delivered[0].OccurrenceID)
+			if err != nil || occurrence == nil {
+				t.Fatalf("occurrence missing: %v", err)
+			}
+			wantKey := automation.ScheduledOccurrenceKey(due)
+			if occurrence.OccurrenceKey != wantKey {
+				t.Fatalf("occurrence key=%s want=%s", occurrence.OccurrenceKey, wantKey)
+			}
+			input, err := automation.ParseScheduledInput(json.RawMessage(occurrence.PayloadJSON))
+			if err != nil {
+				t.Fatalf("payload round-trip: %v", err)
+			}
+			if input.IntendedAt != due.UTC().Format(time.RFC3339) {
+				t.Fatalf("intended_at=%s want=%s", input.IntendedAt, due.UTC().Format(time.RFC3339))
+			}
+		})
+	}
+}
+
+func TestObserveDueSchedulesIdempotentAcrossRepeatedTicks(t *testing.T) {
+	d, s, def, _ := setupScheduledDaemon(t, "* * * * *", "fresh", "latest")
+	delivered := 0
+	d.automationDeliveryHook = func(run *store.AutomationRun) error {
+		delivered++
+		return s.MarkAutomationRunDelivered(run.ID, "{}", time.Now())
+	}
+
+	now0 := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	d.observeDueSchedules(now0)
+	due := now0.Add(70 * time.Second)
+	d.observeDueSchedules(due)
+	d.observeDueSchedules(due)                      // same tick repeated
+	d.observeDueSchedules(due.Add(5 * time.Second)) // a later tick still within the same due instant
+
+	if delivered != 1 {
+		t.Fatalf("delivered=%d, want 1", delivered)
+	}
+	runs, err := s.ListAutomationRuns(def.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("runs=%d, want 1", len(runs))
+	}
+}
+
+func TestObserveDueSchedulesDowntimeCatchUpPolicies(t *testing.T) {
+	// Hourly schedule, two hours of missed instants, and the daemon only ticks
+	// once it is back up: catch_up latest fires the newest missed instant;
+	// catch_up skip fires nothing because that instant is well past the grace
+	// window. Both still advance the cursor to now.
+	for name, want := range map[string]struct {
+		catchUp  string
+		delivers bool
+	}{
+		"latest": {"latest", true},
+		"skip":   {"skip", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			d, s, def, _ := setupScheduledDaemon(t, "0 * * * *", "fresh", want.catchUp)
+			var delivered []*store.AutomationRun
+			d.automationDeliveryHook = func(run *store.AutomationRun) error {
+				delivered = append(delivered, run)
+				return s.MarkAutomationRunDelivered(run.ID, "{}", time.Now())
+			}
+
+			anchor := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+			d.observeDueSchedules(anchor)
+			resumed := time.Date(2026, 7, 20, 5, 35, 0, 0, time.UTC) // two missed hourly ticks
+			d.observeDueSchedules(resumed)
+
+			if want.delivers {
+				if len(delivered) != 1 {
+					t.Fatalf("delivered=%d, want 1", len(delivered))
+				}
+				newestMissed := time.Date(2026, 7, 20, 5, 0, 0, 0, time.UTC)
+				occurrence, err := s.GetAutomationOccurrence(delivered[0].OccurrenceID)
+				if err != nil || occurrence == nil {
+					t.Fatalf("occurrence missing: %v", err)
+				}
+				if wantKey := automation.ScheduledOccurrenceKey(newestMissed); occurrence.OccurrenceKey != wantKey {
+					t.Fatalf("occurrence key=%s want=%s", occurrence.OccurrenceKey, wantKey)
+				}
+			} else if len(delivered) != 0 {
+				t.Fatalf("delivered=%d, want 0", len(delivered))
+			}
+
+			cursor, ok, err := s.GetAutomationScheduleCursor(def.ID)
+			if err != nil || !ok || !cursor.Equal(resumed) {
+				t.Fatalf("cursor=%v ok=%v err=%v, want advanced to %v", cursor, ok, err, resumed)
+			}
+		})
+	}
+}
+
+func TestObserveDueSchedulesReplayStormGuardAdvancesCursorWithoutClaiming(t *testing.T) {
+	d, s, def, _ := setupScheduledDaemon(t, "* * * * *", "fresh", "latest")
+	now0 := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	d.observeDueSchedules(now0) // anchor
+
+	orig := scheduleDueInstantCap
+	scheduleDueInstantCap = 5
+	defer func() { scheduleDueInstantCap = orig }()
+
+	delivered := 0
+	d.automationDeliveryHook = func(*store.AutomationRun) error { delivered++; return nil }
+	later := now0.Add(100 * time.Minute) // far more missed minutely instants than the cap
+	d.observeDueSchedules(later)
+
+	if delivered != 0 {
+		t.Fatalf("replay storm guard delivered %d runs, want 0", delivered)
+	}
+	cursor, ok, err := s.GetAutomationScheduleCursor(def.ID)
+	if err != nil || !ok || !cursor.Equal(later) {
+		t.Fatalf("cursor=%v ok=%v err=%v, want jumped to %v", cursor, ok, err, later)
+	}
+}
+
+// claimPendingScheduledRun claims a scheduled occurrence at the store layer
+// without delivering it, modeling a daemon crash between the durable claim
+// and the delivery attempt.
+func claimPendingScheduledRun(t *testing.T, s *store.Store, def *store.AutomationDefinition, intended, observed time.Time) *store.AutomationRun {
+	t.Helper()
+	var spec automation.DefinitionSpec
+	if err := json.Unmarshal([]byte(def.SpecJSON), &spec); err != nil {
+		t.Fatal(err)
+	}
+	effective, err := automation.Effective(spec, def.Revision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshotJSON, err := json.Marshal(effective)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(automation.NewScheduledInput(intended, observed))
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, _, err := s.ClaimScheduledAutomationRun(def.ID, automation.ScheduledOccurrenceKey(intended), "", def.Revision, string(payload), string(snapshotJSON), observed, newAutomationRunReservation())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return run
+}
+
+// TestScheduledPendingRunRecoversOnRestart verifies item C: recoverAutomations
+// does not skip provider "schedule" pending runs the way it skips provider
+// "github" ones (see TestAutomationRecoveryLeavesGitHubRunsForFreshProviderObservation).
+// A real delivery attempt reaches deliverAutomationRun (which recoverAutomations
+// calls directly, not through automationDeliveryHook, so a full spawn is out of
+// reach for a unit test); disabling the definition after the claim gives a
+// deterministic, PTY-free failure that still proves the attempt was made.
+func TestScheduledPendingRunRecoversOnRestart(t *testing.T) {
+	d, s, def, _ := setupScheduledDaemon(t, "* * * * *", "fresh", "latest")
+	intended := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	run := claimPendingScheduledRun(t, s, def, intended, intended.Add(time.Second))
+	if _, err := s.UpsertAutomationDefinition(def.ID, def.Name, def.SpecJSON, false, intended.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	d.recoverAutomations()
+
+	got, err := s.GetAutomationRun(run.ID)
+	if err != nil || got == nil || got.State != "failed" || !strings.Contains(got.LastError, "definition is disabled") {
+		t.Fatalf("recovery did not attempt scheduled run: run=%#v err=%v", got, err)
+	}
+}
+
+// TestScheduledPendingRunDeliversImmutableSnapshotAfterDefinitionEdit drives
+// delivery through deliverObservedAutomationRun (the hookable entry point
+// also used by the observation path) rather than recoverAutomations, so the
+// test can inspect what would be delivered without a real PTY spawn.
+func TestScheduledPendingRunDeliversImmutableSnapshotAfterDefinitionEdit(t *testing.T) {
+	d, s, def, dir := setupScheduledDaemon(t, "* * * * *", "fresh", "latest")
+	intended := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	run := claimPendingScheduledRun(t, s, def, intended, intended.Add(time.Second))
+
+	// Edit the definition after the claim: prompt changes and revision bumps.
+	editedSpec, editedCanonical, err := automation.ParseDefinitionYAML([]byte(scheduledDefinitionYAML(dir, "* * * * *", "fresh", "latest", "Different sweep.")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.UpsertAutomationDefinition(editedSpec.ID, editedSpec.Name, string(editedCanonical), true, intended.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	var capturedPrompt string
+	d.automationDeliveryHook = func(r *store.AutomationRun) error {
+		var snap automation.Snapshot
+		if err := json.Unmarshal([]byte(r.SnapshotJSON), &snap); err != nil {
+			return err
+		}
+		capturedPrompt = snap.Prompt
+		return s.MarkAutomationRunDelivered(r.ID, "{}", time.Now())
+	}
+	if err := d.deliverObservedAutomationRun(run); err != nil {
+		t.Fatal(err)
+	}
+
+	if capturedPrompt != "Sweep." {
+		t.Fatalf("delivered prompt=%q, want original %q", capturedPrompt, "Sweep.")
+	}
+}
+
+func TestObserveDueSchedulesSkipsDisabledDefinition(t *testing.T) {
+	d, s, def, _ := setupScheduledDaemon(t, "* * * * *", "fresh", "latest")
+	if _, err := s.UpsertAutomationDefinition(def.ID, def.Name, def.SpecJSON, false, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	delivered := 0
+	d.automationDeliveryHook = func(*store.AutomationRun) error { delivered++; return nil }
+
+	now0 := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	d.observeDueSchedules(now0)
+	d.observeDueSchedules(now0.Add(70 * time.Second))
+
+	if delivered != 0 {
+		t.Fatalf("disabled definition delivered %d runs, want 0", delivered)
+	}
+}
+
+func TestObserveDueSchedulesFreshContinuityCreatesDistinctRuns(t *testing.T) {
+	d, s, _, _ := setupScheduledDaemon(t, "* * * * *", "fresh", "latest")
+	var delivered []*store.AutomationRun
+	d.automationDeliveryHook = func(run *store.AutomationRun) error {
+		delivered = append(delivered, run)
+		return s.MarkAutomationRunDelivered(run.ID, "{}", time.Now())
+	}
+
+	now0 := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	d.observeDueSchedules(now0)
+	d.observeDueSchedules(now0.Add(70 * time.Second))
+	d.observeDueSchedules(now0.Add(130 * time.Second))
+
+	if len(delivered) != 2 {
+		t.Fatalf("delivered=%d, want 2", len(delivered))
+	}
+	if delivered[0].TicketID == delivered[1].TicketID || delivered[0].SessionID == delivered[1].SessionID {
+		t.Fatalf("fresh continuity reused reservation ids: %#v vs %#v", delivered[0], delivered[1])
+	}
+}
+
+// TestScheduledSingletonContinuationSkipsPullRequestParsing is the regression
+// check for item B of the brief: validateAutomationContinuation must not
+// attempt to parse req.Context as a pull request for a schedule-provider
+// continuation, even when it reuses a singleton-bound ticket/session against
+// a live session. Binding reuse itself is covered at the store layer by
+// TestScheduledAutomationSingletonContinuityReusesBinding.
+func TestScheduledSingletonContinuationSkipsPullRequestParsing(t *testing.T) {
+	s := store.New()
+	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{}`, true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	intended1 := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	payload1, err := json.Marshal(automation.NewScheduledInput(intended1, now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, _, err := s.ClaimScheduledAutomationRun(def.ID, automation.ScheduledOccurrenceKey(intended1), "singleton", def.Revision, string(payload1), `{}`, now, store.AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.EnsureAutomationTicket(store.Ticket{ID: first.TicketID, Title: "Nightly", Status: store.TicketStatusWorking, Assignee: first.SessionID, AutomationRunID: first.ID}, "automation:nightly", store.TicketRoleChiefOfStaff, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MarkAutomationRunDelivered(first.ID, `{}`, now); err != nil {
+		t.Fatal(err)
+	}
+
+	intended2 := intended1.Add(time.Minute)
+	payload2, err := json.Marshal(automation.NewScheduledInput(intended2, now.Add(time.Minute)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _, err := s.ClaimScheduledAutomationRun(def.ID, automation.ScheduledOccurrenceKey(intended2), "singleton", def.Revision, string(payload2), `{}`, now.Add(time.Minute), store.AutomationRunReservation{RunID: "run-2", OccurrenceID: "occ-2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.TicketID != first.TicketID || second.SessionID != first.SessionID {
+		t.Fatalf("singleton reservation not reused: first=%#v second=%#v", first, second)
+	}
+
+	d := &Daemon{store: s, ptyBackend: &fakeSpawnBackend{sessionIDs: []string{first.SessionID}}}
+	req := automation.WorkRequest{
+		RunID: second.ID, DefinitionID: def.ID, ContinuityKey: "singleton", Provider: "schedule",
+		Context: json.RawMessage(payload2),
+		IDs:     automation.DeliveryIDs{TicketID: second.TicketID, SessionID: second.SessionID},
+	}
+	// Pre-fix, this would fail trying to parse a ScheduledInput payload as a
+	// pull request. With the provider gate, it instead falls through to the
+	// live-session short circuit and succeeds.
+	if err := d.validateAutomationContinuation(req); err != nil {
+		t.Fatalf("singleton continuation with a live session rejected: %v", err)
+	}
+}

--- a/internal/daemon/automations_test.go
+++ b/internal/daemon/automations_test.go
@@ -424,7 +424,7 @@ trigger: {type: manual}
 prompt: Check locally.
 launch: {driver: codex}
 location: {type: directory, path: "` + t.TempDir() + `"}
-policy: {continuity: fresh, catch_up: none, overlap: coalesce}
+policy: {continuity: fresh, overlap: coalesce}
 `
 	def, err := d.automationApply(raw)
 	if err != nil {
@@ -884,7 +884,7 @@ func TestChangedHeadContinuationFailsBeforePublishingTicketActivity(t *testing.T
 		t.Fatal(err)
 	}
 	d := &Daemon{store: s, ptyBackend: &fakeSpawnBackend{sessionIDs: []string{first.SessionID}}}
-	req := automation.WorkRequest{RunID: second.ID, DefinitionID: def.ID, ContinuityKey: subject, Context: json.RawMessage(secondPayload), IDs: automation.DeliveryIDs{TicketID: second.TicketID, SessionID: second.SessionID}}
+	req := automation.WorkRequest{RunID: second.ID, DefinitionID: def.ID, ContinuityKey: subject, Provider: "github", Context: json.RawMessage(secondPayload), IDs: automation.DeliveryIDs{TicketID: second.TicketID, SessionID: second.SessionID}}
 	changedContract := req
 	changedContract.Context = json.RawMessage(firstPayload)
 	changedContract.Prompt = "Updated review instructions"
@@ -1133,7 +1133,7 @@ func TestReRequestCanStartReviewerWhenWithdrawnOriginNeverLaunched(t *testing.T)
 		t.Fatal(err)
 	}
 	req := automation.WorkRequest{
-		RunID: second.ID, DefinitionID: def.ID, ContinuityKey: subject, Prompt: "Review", Context: json.RawMessage(payload),
+		RunID: second.ID, DefinitionID: def.ID, ContinuityKey: subject, Provider: "github", Prompt: "Review", Context: json.RawMessage(payload),
 		IDs: automation.DeliveryIDs{TicketID: second.TicketID, SessionID: second.SessionID},
 	}
 	if err := d.validateAutomationContinuation(req); err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -934,6 +934,10 @@ func (d *Daemon) Start() error {
 	// narrate executor is registered before the first tick fires.
 	go d.startNotebookCronEnqueuer(d.done)
 
+	// Start the scheduled-automation observation loop (claims and delivers due
+	// scheduled-trigger occurrences).
+	go d.startAutomationScheduleLoop(d.done)
+
 	d.signalStarted()
 	startSucceeded = true
 

--- a/internal/store/automations.go
+++ b/internal/store/automations.go
@@ -312,7 +312,10 @@ func (s *Store) ClaimScheduledAutomationRun(definitionID, occurrenceKey, continu
 		}
 	}
 	now := formatTicketTime(observedAt)
-	if _, err = tx.Exec(`INSERT INTO automation_occurrences(id,definition_id,provider,occurrence_key,subject_key,observed_at,payload_json,created_at) VALUES(?,?, 'schedule',?,?,?,?,?)`, ids.OccurrenceID, definitionID, occurrenceKey, "", now, payloadJSON, now); err != nil {
+	// subject_key is recorded as continuityKey (not always ""): HasPriorAutomationContinuityRun
+	// keys its lookup on subject_key, so the continuity key must be recorded there for the
+	// deleted-ticket safety guard to ever match a scheduled singleton's prior run.
+	if _, err = tx.Exec(`INSERT INTO automation_occurrences(id,definition_id,provider,occurrence_key,subject_key,observed_at,payload_json,created_at) VALUES(?,?, 'schedule',?,?,?,?,?)`, ids.OccurrenceID, definitionID, occurrenceKey, continuityKey, now, payloadJSON, now); err != nil {
 		return nil, false, err
 	}
 	if _, err = tx.Exec(`INSERT INTO automation_runs(id,definition_id,occurrence_id,definition_revision,snapshot_json,state,ticket_id,session_id,workspace_id,pane_id,created_at,updated_at) VALUES(?,?,?,?,?,'pending',?,?,?,?,?,?)`, ids.RunID, definitionID, ids.OccurrenceID, revision, snapshotJSON, ids.TicketID, ids.SessionID, ids.WorkspaceID, ids.PaneID, now, now); err != nil {
@@ -706,6 +709,12 @@ func (s *Store) EnsureAutomationContinuationTicket(ticketID, sessionID, runID, o
 // the current run. It lets delivery distinguish first-run crash recovery (where
 // the ticket may not exist yet) from a later cycle whose bound ticket was removed.
 func (s *Store) HasPriorAutomationContinuityRun(definitionID, continuityKey, currentRunID string) (bool, error) {
+	// An empty continuity key means "no continuity": without this guard the
+	// subject_key match below would pair any two fresh-continuity occurrences
+	// (both stored with subject_key='').
+	if continuityKey == "" {
+		return false, nil
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.db == nil {

--- a/internal/store/automations.go
+++ b/internal/store/automations.go
@@ -234,6 +234,87 @@ func (s *Store) ClaimManualAutomationRun(definitionID, requestID, subjectKey, pa
 	return run, true, e
 }
 
+// ClaimScheduledAutomationRun claims one scheduled occurrence, keyed by the
+// intended instant's occurrence key. Idempotent on (definition_id, provider,
+// occurrence_key): a second claim for the same key returns the existing run
+// without consuming the reservation.
+func (s *Store) ClaimScheduledAutomationRun(definitionID, occurrenceKey, payloadJSON, snapshotJSON string, observedAt time.Time, reservation AutomationRunReservation) (*AutomationRun, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return nil, false, errors.New("automation persistence unavailable")
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, false, err
+	}
+	defer tx.Rollback()
+	var existingID string
+	err = tx.QueryRow(`SELECT r.id FROM automation_occurrences o JOIN automation_runs r ON r.occurrence_id=o.id WHERE o.definition_id=? AND o.provider='schedule' AND o.occurrence_key=?`, definitionID, occurrenceKey).Scan(&existingID)
+	if err == nil {
+		tx.Rollback()
+		run, e := s.getAutomationRunUnlocked(existingID)
+		return run, false, e
+	}
+	if err != sql.ErrNoRows {
+		return nil, false, err
+	}
+	var revision, enabled int
+	if err := tx.QueryRow(`SELECT revision,enabled FROM automation_definitions WHERE id=? AND deleted_at=''`, definitionID).Scan(&revision, &enabled); err != nil {
+		return nil, false, err
+	}
+	if enabled == 0 {
+		return nil, false, fmt.Errorf("automation %q is disabled", definitionID)
+	}
+	now := formatTicketTime(observedAt)
+	if _, err = tx.Exec(`INSERT INTO automation_occurrences(id,definition_id,provider,occurrence_key,subject_key,observed_at,payload_json,created_at) VALUES(?,?, 'schedule',?,?,?,?,?)`, reservation.OccurrenceID, definitionID, occurrenceKey, "", now, payloadJSON, now); err != nil {
+		return nil, false, err
+	}
+	if _, err = tx.Exec(`INSERT INTO automation_runs(id,definition_id,occurrence_id,definition_revision,snapshot_json,state,ticket_id,session_id,workspace_id,pane_id,created_at,updated_at) VALUES(?,?,?,?,?,'pending',?,?,?,?,?,?)`, reservation.RunID, definitionID, reservation.OccurrenceID, revision, snapshotJSON, reservation.TicketID, reservation.SessionID, reservation.WorkspaceID, reservation.PaneID, now, now); err != nil {
+		return nil, false, err
+	}
+	if err = tx.Commit(); err != nil {
+		return nil, false, err
+	}
+	run, e := s.getAutomationRunUnlocked(reservation.RunID)
+	return run, true, e
+}
+
+// GetAutomationScheduleCursor returns the last observed instant recorded by
+// SetAutomationScheduleCursor for this definition, ok=false when unset.
+func (s *Store) GetAutomationScheduleCursor(definitionID string) (time.Time, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.db == nil {
+		return time.Time{}, false, errors.New("automation persistence unavailable")
+	}
+	var raw string
+	err := s.db.QueryRow(`SELECT observed_at FROM automation_provider_cursors WHERE definition_id=? AND provider='schedule' AND scope='*'`, definitionID).Scan(&raw)
+	if err == sql.ErrNoRows {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	at, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("parse automation schedule cursor: %w", err)
+	}
+	return at, true, nil
+}
+
+// SetAutomationScheduleCursor records the schedule's cursor instant, on the
+// shared automation_provider_cursors table (provider "schedule", scope "*").
+func (s *Store) SetAutomationScheduleCursor(definitionID string, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return errors.New("automation persistence unavailable")
+	}
+	_, err := s.db.Exec(`INSERT INTO automation_provider_cursors(definition_id,provider,scope,observed_at) VALUES(?,'schedule','*',?) ON CONFLICT(definition_id,provider,scope) DO UPDATE SET observed_at=excluded.observed_at`, definitionID, at.UTC().Format(time.RFC3339Nano))
+	return err
+}
+
 // ReconcileAutomationReviewRequests records the provider's complete current
 // review-request demand for one host. It returns active edges whose current cycle
 // either has not been accepted or still owns a pending run, so both detail-fetch

--- a/internal/store/automations.go
+++ b/internal/store/automations.go
@@ -237,8 +237,16 @@ func (s *Store) ClaimManualAutomationRun(definitionID, requestID, subjectKey, pa
 // ClaimScheduledAutomationRun claims one scheduled occurrence, keyed by the
 // intended instant's occurrence key. Idempotent on (definition_id, provider,
 // occurrence_key): a second claim for the same key returns the existing run
-// without consuming the reservation.
-func (s *Store) ClaimScheduledAutomationRun(definitionID, occurrenceKey, payloadJSON, snapshotJSON string, observedAt time.Time, reservation AutomationRunReservation) (*AutomationRun, bool, error) {
+// without consuming the reservation. expectedRevision guards against the
+// observation race where the snapshot was built from a definition revision
+// read before this transaction: a mismatch rejects the claim and lets the
+// next tick re-read and re-decide, mirroring ClaimGitHubReviewAutomationRun.
+// continuityKey is "" for policy.continuity fresh (every occurrence gets its
+// own reservation IDs) or "singleton" for policy.continuity singleton, in
+// which case the reservation's ticket/session/workspace/pane IDs are bound
+// once per definition and reused by every later occurrence, mirroring
+// ClaimGitHubReviewAutomationRun's per-subject binding reuse.
+func (s *Store) ClaimScheduledAutomationRun(definitionID, occurrenceKey, continuityKey string, expectedRevision int, payloadJSON, snapshotJSON string, observedAt time.Time, reservation AutomationRunReservation) (*AutomationRun, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.db == nil {
@@ -263,20 +271,57 @@ func (s *Store) ClaimScheduledAutomationRun(definitionID, occurrenceKey, payload
 	if err := tx.QueryRow(`SELECT revision,enabled FROM automation_definitions WHERE id=? AND deleted_at=''`, definitionID).Scan(&revision, &enabled); err != nil {
 		return nil, false, err
 	}
+	if revision != expectedRevision {
+		return nil, false, errors.New("automation definition changed while accepting observation")
+	}
 	if enabled == 0 {
 		return nil, false, fmt.Errorf("automation %q is disabled", definitionID)
 	}
+	ids := reservation
+	if continuityKey != "" {
+		// A later occurrence must not overtake an earlier one whose ticket has
+		// not been created yet: delivery would otherwise mistake the
+		// not-yet-created ticket for one already swept, the same hazard
+		// ClaimGitHubReviewAutomationRun guards against per subject.
+		var undeliveredPredecessor int
+		if err := tx.QueryRow(`
+			SELECT EXISTS(
+				SELECT 1
+				FROM automation_runs r
+				JOIN automation_occurrences o ON o.id=r.occurrence_id
+				WHERE r.definition_id=? AND o.provider='schedule' AND r.state='pending'
+				  AND NOT EXISTS (SELECT 1 FROM tickets t WHERE t.id=r.ticket_id)
+			)
+		`, definitionID).Scan(&undeliveredPredecessor); err != nil {
+			return nil, false, err
+		}
+		if undeliveredPredecessor != 0 {
+			return nil, false, errors.New("an earlier scheduled automation run for this definition has not created its ticket yet")
+		}
+		var createdAt, updatedAt string
+		err = tx.QueryRow(`SELECT ticket_id,session_id,workspace_id,pane_id,created_at,updated_at FROM automation_continuity_bindings WHERE definition_id=? AND continuity_key=?`, definitionID, continuityKey).Scan(&ids.TicketID, &ids.SessionID, &ids.WorkspaceID, &ids.PaneID, &createdAt, &updatedAt)
+		switch err {
+		case sql.ErrNoRows:
+			now := formatTicketTime(observedAt)
+			if _, err = tx.Exec(`INSERT INTO automation_continuity_bindings(definition_id,continuity_key,ticket_id,session_id,workspace_id,pane_id,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?)`, definitionID, continuityKey, ids.TicketID, ids.SessionID, ids.WorkspaceID, ids.PaneID, now, now); err != nil {
+				return nil, false, err
+			}
+		case nil:
+		default:
+			return nil, false, err
+		}
+	}
 	now := formatTicketTime(observedAt)
-	if _, err = tx.Exec(`INSERT INTO automation_occurrences(id,definition_id,provider,occurrence_key,subject_key,observed_at,payload_json,created_at) VALUES(?,?, 'schedule',?,?,?,?,?)`, reservation.OccurrenceID, definitionID, occurrenceKey, "", now, payloadJSON, now); err != nil {
+	if _, err = tx.Exec(`INSERT INTO automation_occurrences(id,definition_id,provider,occurrence_key,subject_key,observed_at,payload_json,created_at) VALUES(?,?, 'schedule',?,?,?,?,?)`, ids.OccurrenceID, definitionID, occurrenceKey, "", now, payloadJSON, now); err != nil {
 		return nil, false, err
 	}
-	if _, err = tx.Exec(`INSERT INTO automation_runs(id,definition_id,occurrence_id,definition_revision,snapshot_json,state,ticket_id,session_id,workspace_id,pane_id,created_at,updated_at) VALUES(?,?,?,?,?,'pending',?,?,?,?,?,?)`, reservation.RunID, definitionID, reservation.OccurrenceID, revision, snapshotJSON, reservation.TicketID, reservation.SessionID, reservation.WorkspaceID, reservation.PaneID, now, now); err != nil {
+	if _, err = tx.Exec(`INSERT INTO automation_runs(id,definition_id,occurrence_id,definition_revision,snapshot_json,state,ticket_id,session_id,workspace_id,pane_id,created_at,updated_at) VALUES(?,?,?,?,?,'pending',?,?,?,?,?,?)`, ids.RunID, definitionID, ids.OccurrenceID, revision, snapshotJSON, ids.TicketID, ids.SessionID, ids.WorkspaceID, ids.PaneID, now, now); err != nil {
 		return nil, false, err
 	}
 	if err = tx.Commit(); err != nil {
 		return nil, false, err
 	}
-	run, e := s.getAutomationRunUnlocked(reservation.RunID)
+	run, e := s.getAutomationRunUnlocked(ids.RunID)
 	return run, true, e
 }
 

--- a/internal/store/automations_test.go
+++ b/internal/store/automations_test.go
@@ -42,12 +42,12 @@ func TestScheduledAutomationClaimIsIdempotent(t *testing.T) {
 	}
 	key := "scheduled:2026-07-20T03:00:00Z"
 	ids := AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "auto-run-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"}
-	first, created, err := s.ClaimScheduledAutomationRun(def.ID, key, `{"provider":"schedule"}`, `{"prompt":"sweep"}`, now, ids)
+	first, created, err := s.ClaimScheduledAutomationRun(def.ID, key, "", def.Revision, `{"provider":"schedule"}`, `{"prompt":"sweep"}`, now, ids)
 	if err != nil || !created {
 		t.Fatalf("first claim created=%v err=%v", created, err)
 	}
 	other := AutomationRunReservation{RunID: "run-2", OccurrenceID: "occ-2", TicketID: "auto-run-2", SessionID: "session-2", WorkspaceID: "workspace-2", PaneID: "pane-2"}
-	second, created, err := s.ClaimScheduledAutomationRun(def.ID, key, `{"provider":"schedule","changed":true}`, `{"prompt":"changed"}`, now.Add(time.Minute), other)
+	second, created, err := s.ClaimScheduledAutomationRun(def.ID, key, "", def.Revision, `{"provider":"schedule","changed":true}`, `{"prompt":"changed"}`, now.Add(time.Minute), other)
 	if err != nil || created {
 		t.Fatalf("duplicate claim created=%v err=%v", created, err)
 	}
@@ -63,6 +63,30 @@ func TestScheduledAutomationClaimIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestScheduledAutomationClaimRejectsStaleRevision(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A second apply bumps the revision, simulating the definition changing
+	// between the caller's revision read and this claim's transaction.
+	if _, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly","edited":true}`, true, now); err != nil {
+		t.Fatal(err)
+	}
+	ids := AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"}
+	if _, _, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-20T03:00:00Z", "", def.Revision, `{}`, `{}`, now, ids); err == nil {
+		t.Fatal("expected stale revision claim to be rejected")
+	}
+	if occurrence, err := s.GetAutomationOccurrence("occ-1"); err != nil || occurrence != nil {
+		t.Fatalf("rejected claim left an occurrence: %#v err=%v", occurrence, err)
+	}
+	if run, err := s.GetAutomationRun("run-1"); err != nil || run != nil {
+		t.Fatalf("rejected claim persisted a run: %#v err=%v", run, err)
+	}
+}
+
 func TestScheduledAutomationDifferentInstantsClaimDifferentRuns(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
@@ -70,16 +94,63 @@ func TestScheduledAutomationDifferentInstantsClaimDifferentRuns(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	first, created, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-20T03:00:00Z", `{}`, `{}`, now, AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"})
+	first, created, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-20T03:00:00Z", "", def.Revision, `{}`, `{}`, now, AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"})
 	if err != nil || !created {
 		t.Fatalf("first claim created=%v err=%v", created, err)
 	}
-	second, created, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-21T03:00:00Z", `{}`, `{}`, now.Add(24*time.Hour), AutomationRunReservation{RunID: "run-2", OccurrenceID: "occ-2", TicketID: "ticket-2", SessionID: "session-2", WorkspaceID: "workspace-2", PaneID: "pane-2"})
+	second, created, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-21T03:00:00Z", "", def.Revision, `{}`, `{}`, now.Add(24*time.Hour), AutomationRunReservation{RunID: "run-2", OccurrenceID: "occ-2", TicketID: "ticket-2", SessionID: "session-2", WorkspaceID: "workspace-2", PaneID: "pane-2"})
 	if err != nil || !created {
 		t.Fatalf("second claim created=%v err=%v", created, err)
 	}
 	if second.ID == first.ID {
 		t.Fatalf("different instants claimed the same run: %#v", second)
+	}
+}
+
+func TestScheduledAutomationSingletonContinuityReusesBinding(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstIDs := AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"}
+	first, created, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-20T03:00:00Z", "singleton", def.Revision, `{}`, `{}`, now, firstIDs)
+	if err != nil || !created {
+		t.Fatalf("first claim created=%v err=%v", created, err)
+	}
+	if _, err := s.EnsureAutomationTicket(Ticket{ID: first.TicketID, Title: "Nightly", Status: TicketStatusWorking, Assignee: first.SessionID, AutomationRunID: first.ID}, "automation:nightly", TicketRoleChiefOfStaff, now); err != nil {
+		t.Fatal(err)
+	}
+	secondIDs := AutomationRunReservation{RunID: "run-2", OccurrenceID: "occ-2", TicketID: "ticket-2", SessionID: "session-2", WorkspaceID: "workspace-2", PaneID: "pane-2"}
+	second, created, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-21T03:00:00Z", "singleton", def.Revision, `{}`, `{}`, now.Add(24*time.Hour), secondIDs)
+	if err != nil || !created {
+		t.Fatalf("second claim created=%v err=%v", created, err)
+	}
+	if second.ID == first.ID {
+		t.Fatal("second occurrence should claim a distinct run")
+	}
+	if second.TicketID != first.TicketID || second.SessionID != first.SessionID || second.WorkspaceID != first.WorkspaceID || second.PaneID != first.PaneID {
+		t.Fatalf("singleton continuity did not reuse binding IDs: first=%#v second=%#v", first, second)
+	}
+}
+
+func TestScheduledAutomationSingletonContinuityBlocksUndeliveredPredecessor(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstIDs := AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"}
+	if _, created, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-20T03:00:00Z", "singleton", def.Revision, `{}`, `{}`, now, firstIDs); err != nil || !created {
+		t.Fatalf("first claim created=%v err=%v", created, err)
+	}
+	// No ticket was ever created for the first run, so the second occurrence's
+	// claim must refuse rather than reuse a binding whose ticket is missing.
+	secondIDs := AutomationRunReservation{RunID: "run-2", OccurrenceID: "occ-2", TicketID: "ticket-2", SessionID: "session-2", WorkspaceID: "workspace-2", PaneID: "pane-2"}
+	if _, _, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-21T03:00:00Z", "singleton", def.Revision, `{}`, `{}`, now.Add(24*time.Hour), secondIDs); err == nil {
+		t.Fatal("expected second claim to be rejected while the first run has no ticket yet")
 	}
 }
 
@@ -121,7 +192,7 @@ func TestListPendingAutomationRunsIncludesScheduledProvider(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	run, created, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-20T03:00:00Z", `{}`, `{}`, now, AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"})
+	run, created, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-20T03:00:00Z", "", def.Revision, `{}`, `{}`, now, AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"})
 	if err != nil || !created {
 		t.Fatalf("claim created=%v err=%v", created, err)
 	}

--- a/internal/store/automations_test.go
+++ b/internal/store/automations_test.go
@@ -33,6 +33,113 @@ func TestAutomationClaimIsIdempotentAndSnapshotsRevision(t *testing.T) {
 	}
 }
 
+func TestScheduledAutomationClaimIsIdempotent(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := "scheduled:2026-07-20T03:00:00Z"
+	ids := AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "auto-run-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"}
+	first, created, err := s.ClaimScheduledAutomationRun(def.ID, key, `{"provider":"schedule"}`, `{"prompt":"sweep"}`, now, ids)
+	if err != nil || !created {
+		t.Fatalf("first claim created=%v err=%v", created, err)
+	}
+	other := AutomationRunReservation{RunID: "run-2", OccurrenceID: "occ-2", TicketID: "auto-run-2", SessionID: "session-2", WorkspaceID: "workspace-2", PaneID: "pane-2"}
+	second, created, err := s.ClaimScheduledAutomationRun(def.ID, key, `{"provider":"schedule","changed":true}`, `{"prompt":"changed"}`, now.Add(time.Minute), other)
+	if err != nil || created {
+		t.Fatalf("duplicate claim created=%v err=%v", created, err)
+	}
+	if second.ID != first.ID || second.TicketID != first.TicketID || second.SnapshotJSON != `{"prompt":"sweep"}` {
+		t.Fatalf("duplicate returned different run: %#v", second)
+	}
+	var occurrenceCount int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM automation_occurrences WHERE definition_id=? AND provider='schedule'`, def.ID).Scan(&occurrenceCount); err != nil {
+		t.Fatal(err)
+	}
+	if occurrenceCount != 1 {
+		t.Fatalf("occurrence count=%d, want 1", occurrenceCount)
+	}
+}
+
+func TestScheduledAutomationDifferentInstantsClaimDifferentRuns(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, created, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-20T03:00:00Z", `{}`, `{}`, now, AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"})
+	if err != nil || !created {
+		t.Fatalf("first claim created=%v err=%v", created, err)
+	}
+	second, created, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-21T03:00:00Z", `{}`, `{}`, now.Add(24*time.Hour), AutomationRunReservation{RunID: "run-2", OccurrenceID: "occ-2", TicketID: "ticket-2", SessionID: "session-2", WorkspaceID: "workspace-2", PaneID: "pane-2"})
+	if err != nil || !created {
+		t.Fatalf("second claim created=%v err=%v", created, err)
+	}
+	if second.ID == first.ID {
+		t.Fatalf("different instants claimed the same run: %#v", second)
+	}
+}
+
+func TestAutomationScheduleCursorGetSetRoundtrip(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := s.GetAutomationScheduleCursor(def.ID); err != nil || ok {
+		t.Fatalf("missing cursor ok=%v err=%v", ok, err)
+	}
+	instant := time.Date(2026, 7, 20, 3, 0, 0, 123000000, time.UTC)
+	if err := s.SetAutomationScheduleCursor(def.ID, instant); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := s.GetAutomationScheduleCursor(def.ID)
+	if err != nil || !ok {
+		t.Fatalf("roundtrip cursor ok=%v err=%v", ok, err)
+	}
+	if !got.Equal(instant) {
+		t.Fatalf("cursor=%v, want %v", got, instant)
+	}
+	later := instant.Add(time.Hour)
+	if err := s.SetAutomationScheduleCursor(def.ID, later); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err = s.GetAutomationScheduleCursor(def.ID)
+	if err != nil || !ok || !got.Equal(later) {
+		t.Fatalf("advanced cursor=%v ok=%v err=%v", got, ok, err)
+	}
+}
+
+func TestListPendingAutomationRunsIncludesScheduledProvider(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, created, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-20T03:00:00Z", `{}`, `{}`, now, AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"})
+	if err != nil || !created {
+		t.Fatalf("claim created=%v err=%v", created, err)
+	}
+	pending, err := s.ListPendingAutomationRuns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, r := range pending {
+		if r.ID == run.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("pending runs=%#v, missing claimed schedule run %s", pending, run.ID)
+	}
+}
+
 func TestEnsureAutomationTicketAdoptsByRun(t *testing.T) {
 	s := New()
 	now := time.Now()

--- a/internal/store/automations_test.go
+++ b/internal/store/automations_test.go
@@ -87,6 +87,30 @@ func TestScheduledAutomationClaimRejectsStaleRevision(t *testing.T) {
 	}
 }
 
+// TestScheduledAutomationClaimRejectsDisabledDefinition pins the store-level
+// guard itself (Fix 4b): there is already a daemon-level test that a disabled
+// definition never reaches the claim at all, but this proves
+// ClaimScheduledAutomationRun refuses on its own and leaves no occurrence or
+// run rows, matching the enabled-check every other claim path relies on.
+func TestScheduledAutomationClaimRejectsDisabledDefinition(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, false, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"}
+	if _, _, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-20T03:00:00Z", "", def.Revision, `{}`, `{}`, now, ids); err == nil {
+		t.Fatal("expected a disabled definition's claim to be rejected")
+	}
+	if occurrence, err := s.GetAutomationOccurrence("occ-1"); err != nil || occurrence != nil {
+		t.Fatalf("rejected claim left an occurrence: %#v err=%v", occurrence, err)
+	}
+	if run, err := s.GetAutomationRun("run-1"); err != nil || run != nil {
+		t.Fatalf("rejected claim persisted a run: %#v err=%v", run, err)
+	}
+}
+
 func TestScheduledAutomationDifferentInstantsClaimDifferentRuns(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
@@ -132,6 +156,79 @@ func TestScheduledAutomationSingletonContinuityReusesBinding(t *testing.T) {
 	}
 	if second.TicketID != first.TicketID || second.SessionID != first.SessionID || second.WorkspaceID != first.WorkspaceID || second.PaneID != first.PaneID {
 		t.Fatalf("singleton continuity did not reuse binding IDs: first=%#v second=%#v", first, second)
+	}
+}
+
+// TestScheduledAutomationSingletonRecordsContinuityKeyAsSubjectKey is the
+// regression check for Fix 2: HasPriorAutomationContinuityRun matches on
+// automation_occurrences.subject_key, so a scheduled singleton's occurrence
+// must record subject_key="singleton" (not "") or the deleted-ticket safety
+// guard can never fire for scheduled singletons.
+func TestScheduledAutomationSingletonRecordsContinuityKeyAsSubjectKey(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstIDs := AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"}
+	first, created, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-20T03:00:00Z", "singleton", def.Revision, `{}`, `{}`, now, firstIDs)
+	if err != nil || !created {
+		t.Fatalf("first claim created=%v err=%v", created, err)
+	}
+	if _, err := s.EnsureAutomationTicket(Ticket{ID: first.TicketID, Title: "Nightly", Status: TicketStatusWorking, Assignee: first.SessionID, AutomationRunID: first.ID}, "automation:nightly", TicketRoleChiefOfStaff, now); err != nil {
+		t.Fatal(err)
+	}
+	secondIDs := AutomationRunReservation{RunID: "run-2", OccurrenceID: "occ-2", TicketID: "ticket-2", SessionID: "session-2", WorkspaceID: "workspace-2", PaneID: "pane-2"}
+	second, created, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-21T03:00:00Z", "singleton", def.Revision, `{}`, `{}`, now.Add(24*time.Hour), secondIDs)
+	if err != nil || !created {
+		t.Fatalf("second claim created=%v err=%v", created, err)
+	}
+
+	firstOccurrence, err := s.GetAutomationOccurrence(first.OccurrenceID)
+	if err != nil || firstOccurrence == nil || firstOccurrence.SubjectKey != "singleton" {
+		t.Fatalf("first occurrence = %#v err=%v, want subject_key=singleton", firstOccurrence, err)
+	}
+	hasPrior, err := s.HasPriorAutomationContinuityRun(def.ID, "singleton", second.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasPrior {
+		t.Fatal("HasPriorAutomationContinuityRun=false, want true once the singleton's occurrence records subject_key")
+	}
+}
+
+// TestScheduledAutomationFreshContinuityRecordsEmptySubjectKey guards the
+// other half of Fix 2: fresh continuity (policy.continuity=fresh) still
+// records subject_key="" per occurrence, so HasPriorAutomationContinuityRun
+// never spuriously matches unrelated fresh occurrences against each other.
+func TestScheduledAutomationFreshContinuityRecordsEmptySubjectKey(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"}
+	run, created, err := s.ClaimScheduledAutomationRun(def.ID, "scheduled:2026-07-20T03:00:00Z", "", def.Revision, `{}`, `{}`, now, ids)
+	if err != nil || !created {
+		t.Fatalf("claim created=%v err=%v", created, err)
+	}
+	occurrence, err := s.GetAutomationOccurrence(run.OccurrenceID)
+	if err != nil || occurrence == nil || occurrence.SubjectKey != "" {
+		t.Fatalf("occurrence = %#v err=%v, want subject_key empty for fresh continuity", occurrence, err)
+	}
+	// Callers never invoke HasPriorAutomationContinuityRun with an empty
+	// continuity key (both validateAutomationContinuation and EnsureTicket
+	// early-return when req.ContinuityKey == ""), so this only pins that
+	// fresh continuity keeps recording an empty subject_key rather than
+	// accidentally adopting Fix 2's "singleton" literal.
+	hasPrior, err := s.HasPriorAutomationContinuityRun(def.ID, "", run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasPrior {
+		t.Fatal("HasPriorAutomationContinuityRun=true against an empty continuity key, want false")
 	}
 }
 


### PR DESCRIPTION
Slice 5 of the [Automations implementation guide](docs/plans/2026-07-18-attn-automations-implementation.md): automations can now fire on a cron schedule through the same engine, proven by a real recurring merged-worktree cleanup.

## What's in here

- **Scheduled trigger** (`trigger: {type: scheduled, schedule: {cron, time_zone}}`): robfig standard cron with a required IANA time zone (`TZ=`/`CRON_TZ=` prefixes rejected). Occurrence keys are the intended instant in UTC (`scheduled:<RFC3339>`), so identity is machine-independent.
- **Catch-up without storms**: a 1-minute observation loop fires at most the newest due instant per definition per tick. After downtime, `catch_up: latest` runs the newest missed instant once; `catch_up: skip` drops instants older than a 5-minute grace. The first observation of a new definition anchors its cursor without retroactive fires.
- **Singleton continuity**: `continuity: singleton` keeps every occurrence on one ticket/session (continuity key `"singleton"`), reusing the Slice 4 binding machinery; later occurrences nudge the live agent instead of spawning a new one.
- **Claim-failure safety** (from the pre-review verify pass): a rejected or failed claim leaves the schedule cursor behind the intended instant so the next tick retries instead of silently dropping the occurrence; scheduled occurrences record their continuity key as `subject_key` so the deleted-ticket continuity guard actually matches scheduled priors; `TriggerSpec.Schedule` is a pointer so non-scheduled definitions keep byte-identical canonical JSON (no spurious revision bump on re-apply after upgrade).
- **Provider-gated head check**: `WorkRequest.Provider` gates the PR head-SHA continuation check to github deliveries so scheduled continuations don't trip it.

## Documented boundaries (revisited in Slice 7)

- Editing a singleton scheduled definition's prompt/launch/location makes later occurrences fail visibly at delivery (same fail-visible-on-changed-contract stance as Slice 4's per-PR continuations). Recovery today: disable or recreate under a new id; proper edit semantics belong to Slice 7's lifecycle work.
- `catch_up` is now schedule-only: re-applying a manual/github definition carrying a stray `catch_up` fails validation (stored definitions unaffected).

## Verification

- Full Go suite green; new unit tests cover claim-rejection cursor retry, skip-grace boundary, disabled-definition claim rejection, the isRecovering observation gate, singleton subject_key recording, and canonical-JSON omission.
- Live packaged evidence on the isolated `automations` profile, serial scenario `real-app:scenario-automation-scheduled-cleanup` (fingerprint-guarded app built from `45c7684c`): anchor-without-fire, exactly one catch-up run after 135s downtime with a minute-aligned UTC occurrence key, a real codex agent removing a merged-clean worktree while preserving a dirty one (uncommitted file intact), all occurrences coalesced on one singleton ticket/session, and a storm-guard restart leg proving exactly one spawn. Run `automation-scheduled-cleanup-2026-07-20T12-22-03-841Z`, all legs green, verdict `ok:true`.

CHANGELOG and guide ledger updated in this PR.