### PR TITLE
fix(terminal): recover from Ghostty model faults

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -75,7 +75,7 @@ import { useOpenPR, type OpenPRProgress } from './hooks/useOpenPR';
 import { useUiAutomationBridge } from './hooks/useUiAutomationBridge';
 import { ptySpawn } from './pty/bridge';
 import { clearBrowserHostFocus, controlBrowserHost, isBrowserHostOwnedTarget } from './browser/host';
-import { probeUiAfterSwitch } from './utils/uiDiagnosticsLog';
+import { probeUiAfterSwitch, UI_DIAGNOSTICS_FILE_DISPLAY } from './utils/uiDiagnosticsLog';
 import {
   agentLabel,
   getAgentAvailability,
@@ -1770,13 +1770,20 @@ sendFetchPRDetails,
   const [locationPickerSessionDirection, setLocationPickerSessionDirection] = useState<TerminalSplitDirection>('vertical');
 
   const [zoomModeBySessionId, setZoomModeBySessionId] = useState<Record<string, boolean>>({});
-  const { message: errorMessage, showError, clearError } = useErrorToast();
+  const { message: errorMessage, durationMs: errorDurationMs, showError, clearError } = useErrorToast();
   const [chiefTransferTarget, setChiefTransferTarget] = useState<{
     sessionId: string;
     targetLabel: string;
     currentLabel: string;
   } | null>(null);
   const [chiefTransferSaving, setChiefTransferSaving] = useState(false);
+
+  const handleTerminalModelRecovered = useCallback(() => {
+    showError(
+      `Terminal issue recovered. We reloaded it for you. Diagnostics were saved to ${UI_DIAGNOSTICS_FILE_DISPLAY}; please send this file to Victor so he can troubleshoot it.`,
+      { durationMs: 12_000 },
+    );
+  }, [showError]);
 
   const handleRebootstrapEndpoint = useCallback(async (endpointId: string) => {
     try {
@@ -3669,6 +3676,7 @@ sendFetchPRDetails,
                         });
                       });
                     }}
+                    onTerminalModelRecovered={handleTerminalModelRecovered}
                     workspace={workspaceState}
                     activePaneId={activePaneId}
                     fontSize={terminalFontSize}
@@ -3880,7 +3888,7 @@ sendFetchPRDetails,
           }
         }}
       />
-      <ErrorToast message={errorMessage} onDone={clearError} />
+      <ErrorToast message={errorMessage} durationMs={errorDurationMs} onDone={clearError} />
       <ChordLeaderHud />
       <WorkspaceContextNavigator
         isOpen={workspaceContextsOpen}

--- a/app/src/components/ErrorToast.css
+++ b/app/src/components/ErrorToast.css
@@ -12,6 +12,7 @@
   align-items: center;
   gap: 8px;
   font-size: 13px;
+  max-width: min(640px, calc(100vw - 32px));
   color: var(--color-text-primary);
   box-shadow: 0 8px 24px rgba(220, 38, 38, 0.2);
   z-index: 400;
@@ -28,4 +29,8 @@
 .error-toast svg {
   color: #dc2626;
   flex-shrink: 0;
+}
+
+.error-toast span {
+  overflow-wrap: anywhere;
 }

--- a/app/src/components/ErrorToast.test.tsx
+++ b/app/src/components/ErrorToast.test.tsx
@@ -1,0 +1,31 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ErrorToast } from './ErrorToast';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('ErrorToast', () => {
+  it('keeps an explicitly extended recovery notice visible for its requested duration', () => {
+    vi.useFakeTimers();
+    const onDone = vi.fn();
+    render(
+      <ErrorToast
+        message="Terminal issue recovered. Diagnostics were saved for Victor."
+        durationMs={12_000}
+        onDone={onDone}
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Terminal issue recovered');
+    act(() => {
+      vi.advanceTimersByTime(11_999);
+    });
+    expect(onDone).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(201);
+    });
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/components/ErrorToast.tsx
+++ b/app/src/components/ErrorToast.tsx
@@ -3,10 +3,11 @@ import './ErrorToast.css';
 
 interface ErrorToastProps {
   message: string | null;
+  durationMs?: number;
   onDone: () => void;
 }
 
-export function ErrorToast({ message, onDone }: ErrorToastProps) {
+export function ErrorToast({ message, durationMs = 3000, onDone }: ErrorToastProps) {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
@@ -15,10 +16,10 @@ export function ErrorToast({ message, onDone }: ErrorToastProps) {
       const timer = setTimeout(() => {
         setVisible(false);
         setTimeout(onDone, 200); // Wait for fade out
-      }, 3000); // Show error for 3 seconds (longer than copy toast)
+      }, durationMs);
       return () => clearTimeout(timer);
     }
-  }, [message, onDone]);
+  }, [durationMs, message, onDone]);
 
   if (!message) return null;
 
@@ -40,15 +41,15 @@ export function ErrorToast({ message, onDone }: ErrorToastProps) {
 
 // Hook to manage toast state
 export function useErrorToast() {
-  const [message, setMessage] = useState<string | null>(null);
+  const [toast, setToast] = useState<{ message: string; durationMs: number } | null>(null);
 
-  const showError = useCallback((msg: string) => {
-    setMessage(msg);
+  const showError = useCallback((message: string, options?: { durationMs?: number }) => {
+    setToast({ message, durationMs: options?.durationMs ?? 3000 });
   }, []);
 
   const clearError = useCallback(() => {
-    setMessage(null);
+    setToast(null);
   }, []);
 
-  return { message, showError, clearError };
+  return { message: toast?.message ?? null, durationMs: toast?.durationMs ?? 3000, showError, clearError };
 }

--- a/app/src/components/GhosttyTerminal.modelFault.test.tsx
+++ b/app/src/components/GhosttyTerminal.modelFault.test.tsx
@@ -1,0 +1,186 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const control = {
+    failFirstRendererNextRender: false,
+    useLargeFit: false,
+  };
+  const terminals: Array<{
+    resizeCalls: Array<[number, number]>;
+    resize: (cols: number, rows: number) => void;
+  }> = [];
+  const resizeCallbacks: ResizeObserverCallback[] = [];
+  const createTerminalCalls: unknown[][] = [];
+  const noteModelFaultCalls: unknown[][] = [];
+  const noteRecoveryCalls: unknown[][] = [];
+  const recordUiDiagCalls: unknown[][] = [];
+
+  const createTerminal = () => {
+    createTerminalCalls.push([]);
+    const index = terminals.length;
+    const terminal = {
+      cols: 80,
+      rows: 24,
+      resizeCalls: [] as Array<[number, number]>,
+      write: () => undefined,
+      resize(cols: number, rows: number) {
+        terminal.resizeCalls.push([cols, rows]);
+        if (index === 1) throw new Error('replacement initial fit failed');
+        terminal.cols = cols;
+        terminal.rows = rows;
+      },
+      getMode: () => false,
+      getScrollbackLength: () => 0,
+      getViewport: () => [],
+      getScrollbackLine: () => [],
+      getGraphemeString: () => '',
+      getScrollbackGraphemeString: () => '',
+      free: () => undefined,
+      isAlternateScreen: () => false,
+      hasMouseTracking: () => false,
+    };
+    terminals.push(terminal);
+    return terminal;
+  };
+
+  const renderers: MockRenderer[] = [];
+  class MockRenderer {
+    readonly id = renderers.length;
+    readonly cellWidth = 8;
+    readonly cellHeight = 16;
+
+    constructor() {
+      renderers.push(this);
+    }
+
+    fitDimensions() {
+      return control.useLargeFit ? { cols: 81, rows: 24 } : { cols: 80, rows: 24 };
+    }
+
+    resize() {}
+    render() {
+      if (this.id === 0 && control.failFirstRendererNextRender) {
+        control.failFirstRendererNextRender = false;
+        throw new Error('original model render failed');
+      }
+      return {
+        quads: 0,
+        cellsArrayLen: 0,
+        printableSkippedNull: 0,
+        printableSkippedZeroWidth: 0,
+      };
+    }
+    invalidateGlyphCache() {}
+    setFontSize() {}
+    dispose() {}
+  }
+
+  return {
+    MockRenderer,
+    control,
+    createTerminal,
+    createTerminalCalls,
+    noteModelFault: (...args: unknown[]) => { noteModelFaultCalls.push(args); },
+    noteModelFaultCalls,
+    noteRecovery: (...args: unknown[]) => { noteRecoveryCalls.push(args); },
+    noteRecoveryCalls,
+    recordUiDiag: (...args: unknown[]) => { recordUiDiagCalls.push(args); },
+    recordUiDiagCalls,
+    renderers,
+    resizeCallbacks,
+    terminals,
+  };
+});
+
+vi.mock('ghostty-web', () => ({
+  CellFlags: {},
+  Ghostty: {
+    load: async () => ({ createTerminal: mocks.createTerminal }),
+  },
+  InputHandler: class {
+    dispose() {}
+  },
+}));
+
+vi.mock('../ghostty/wasm', () => ({ ghosttyWasmUrl: 'mock-wasm-url' }));
+vi.mock('./GhosttyWebGlRenderer', () => ({ WebGlTerminalRenderer: mocks.MockRenderer }));
+vi.mock('../utils/terminalIconFont', () => ({
+  ensureTerminalIconFont: () => new Promise<void>(() => undefined),
+}));
+vi.mock('../utils/terminalDiagnosticsLog', () => ({
+  disposePaneDiagnostics: () => undefined,
+  noteModelFault: mocks.noteModelFault,
+  noteRecovery: mocks.noteRecovery,
+  noteResize: () => undefined,
+  recordDiag: () => undefined,
+  recordPaint: () => undefined,
+  registerRenderProbe: () => undefined,
+}));
+vi.mock('../utils/uiDiagnosticsLog', () => ({
+  captureUiSnapshot: () => ({}),
+  recordUiDiag: mocks.recordUiDiag,
+  UI_DIAGNOSTICS_FILE: 'diagnostics.jsonl',
+}));
+vi.mock('../utils/terminalPerf', () => ({
+  registerTerminalPerfGetter: () => () => undefined,
+}));
+
+import { GhosttyTerminal } from './GhosttyTerminal';
+
+describe('GhosttyTerminal model-fault containment', () => {
+  it('rebuilds again when the replacement model fails its initial fit, then only announces a healthy recovery', async () => {
+    const originalResizeObserver = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        mocks.resizeCallbacks.push(callback);
+      }
+
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    const onReady = vi.fn();
+    const onTerminalModelRecovered = vi.fn();
+    try {
+      render(
+        <GhosttyTerminal
+          fontSize={14}
+          debugName="model-fault-test"
+          onInput={vi.fn()}
+          onReady={onReady}
+          onResize={vi.fn()}
+          onTerminalModelRecovered={onTerminalModelRecovered}
+        />,
+      );
+
+      await waitFor(() => expect(onReady).toHaveBeenCalledTimes(1));
+      expect(mocks.resizeCallbacks).toHaveLength(1);
+
+      mocks.control.useLargeFit = true;
+      mocks.control.failFirstRendererNextRender = true;
+      await act(async () => {
+        mocks.resizeCallbacks[0]([], {} as ResizeObserver);
+      });
+
+      await waitFor(() => {
+        expect(mocks.createTerminalCalls).toHaveLength(3);
+        expect(onReady).toHaveBeenCalledTimes(2);
+        expect(onTerminalModelRecovered).toHaveBeenCalledTimes(1);
+      });
+
+      // The first replacement reached its initial fit and faulted there. It
+      // never became ready; only the third, healthy model did.
+      expect(mocks.terminals[1].resizeCalls).toEqual([[81, 24]]);
+      expect(mocks.noteModelFaultCalls).toHaveLength(2);
+      expect(mocks.noteRecoveryCalls.map(([, detail]) => (detail as { outcome: string }).outcome)).toEqual([
+        'modelFault',
+        'modelFault',
+        'recovered',
+      ]);
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver;
+    }
+  });
+});

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -597,15 +597,18 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     // triggering a render.
     const recoveryAttemptRef = useRef(0);
     const recoveryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    // Set before an epoch rebuild caused by a recoverable WASM model fault.
-    // It survives the effect cleanup so the replacement model can record the
-    // successful containment and notify the app shell exactly once.
-    const modelFaultRef = useRef<{
+    // Dedupe failures from the same model while React applies the epoch bump.
+    // Do not use this to represent a pending recovery: a replacement can fault
+    // during its own initial fit and must trigger another rebuild.
+    const modelFaultDedupeRef = useRef<{
       operation: string;
       error: string;
       model: number;
       rendererEpoch: number;
     } | null>(null);
+    // Survives epoch rebuilds until a replacement has completed its initial
+    // fit and become ready. Only then may the app announce recovery.
+    const modelRecoveryPendingRef = useRef(false);
     const [error, setError] = useState<string | null>(null);
     const [linkCursorActive, setLinkCursorActive] = useState(false);
     const [findUi, setFindUi] = useState({ open: false, matchCount: 0, focusedIndex: -1, scanning: false, caseSensitive: false });
@@ -638,9 +641,10 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
 
     const recoverFromModelFault = useCallback((operation: string, reason: unknown) => {
       // An invalid model can make several queued render/write operations fail
-      // before React applies the epoch bump. One rebuild is enough; recording
-      // all of them would obscure the first fault that made the model unusable.
-      if (modelFaultRef.current) return;
+      // before React applies the epoch bump. One rebuild per model is enough;
+      // a fault from a replacement model has a new epoch and must not be
+      // suppressed by the old model's dedupe record.
+      if (modelFaultDedupeRef.current?.rendererEpoch === rendererEpoch) return;
       const error = reason instanceof Error ? reason.message : String(reason);
       const stack = reason instanceof Error ? reason.stack : undefined;
       const terminal = terminalRef.current;
@@ -659,7 +663,8 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         model: modelInstanceRef.current,
         rendererEpoch,
       };
-      modelFaultRef.current = fault;
+      modelFaultDedupeRef.current = fault;
+      modelRecoveryPendingRef.current = true;
       const session = runtimeMetaRef.current?.sessionId ?? undefined;
       const paneKind = runtimeMetaRef.current?.paneKind ?? undefined;
       let snapshot: Record<string, unknown> | undefined;
@@ -1921,15 +1926,8 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         });
         terminalRef.current = terminal;
         rendererRef.current = renderer;
-        const recoveredModelFault = modelFaultRef.current;
-        if (recoveryAttemptRef.current > 0 || recoveredModelFault) {
-          noteRecovery(diagKeyRef.current, {
-            session: runtimeMetaRef.current?.sessionId ?? undefined,
-            paneKind: runtimeMetaRef.current?.paneKind ?? undefined,
-            attempt: recoveryAttemptRef.current || 1,
-            outcome: 'recovered',
-          });
-        }
+        const recoveryAttempt = recoveryAttemptRef.current;
+        const recoveredModelFault = modelRecoveryPendingRef.current;
         recoveryAttemptRef.current = 0;
         setError(null);
         // The bundled Nerd Font may not be loaded yet, so the first glyphs that
@@ -1982,6 +1980,18 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           (mode) => terminal.getMode(mode),
         );
         fit();
+        // `fit()` contains WASM traps and schedules a fresh epoch. Do not mark
+        // this model ready (or announce recovery) if its initial fit was the
+        // next fault in the chain.
+        if (modelFaultDedupeRef.current?.rendererEpoch === rendererEpoch) return;
+        if (recoveryAttempt > 0 || recoveredModelFault) {
+          noteRecovery(diagKeyRef.current, {
+            session: runtimeMetaRef.current?.sessionId ?? undefined,
+            paneKind: runtimeMetaRef.current?.paneKind ?? undefined,
+            attempt: recoveryAttempt || 1,
+            outcome: 'recovered',
+          });
+        }
         readyRef.current = true;
         startupRef.current.firstReadyAt = Date.now();
         startupRef.current.firstReadyCols = terminal.cols;
@@ -2021,7 +2031,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           drain: () => writeChainRef.current,
         });
         if (recoveredModelFault) {
-          modelFaultRef.current = null;
+          modelRecoveryPendingRef.current = false;
           onTerminalModelRecoveredRef.current?.();
         }
       }).catch((reason) => {

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -85,11 +85,13 @@ import { recordTerminalLinkHitTestEvent } from '../utils/terminalLinkHitTestLog'
 import {
   recordDiag,
   recordPaint,
+  noteModelFault,
   noteRecovery,
   noteResize,
   registerRenderProbe,
   disposePaneDiagnostics,
 } from '../utils/terminalDiagnosticsLog';
+import { captureUiSnapshot, recordUiDiag, UI_DIAGNOSTICS_FILE } from '../utils/uiDiagnosticsLog';
 import type { TerminalVisibleContentSnapshot } from '../utils/terminalVisibleContent';
 import { analyzeTerminalVisibleLines } from '../utils/terminalVisibleContent';
 import type { TerminalVisibleStyleSnapshot, TerminalVisibleStyleLineSnapshot } from '../utils/terminalStyleSummary';
@@ -143,6 +145,9 @@ interface GhosttyTerminalProps {
   // history is gone from the model; the owner should re-request the attach
   // replay once the geometry settles.
   onReplayInterrupted?: () => void;
+  // A corrupt Ghostty WASM model was discarded and replaced. The owner uses
+  // this only for the user-facing notice; onReady performs the actual reattach.
+  onTerminalModelRecovered?: () => void;
 }
 
 export interface GhosttyTerminalHandle {
@@ -499,7 +504,7 @@ function cellText(
 }
 
 export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminalProps>(
-  function GhosttyTerminal({ fontSize, resolvedTheme = 'dark', debugName, cwd, runtimeLogMeta, onInput, onOpenMarkdown, onReady, onResize, onReplayInterrupted }, ref) {
+  function GhosttyTerminal({ fontSize, resolvedTheme = 'dark', debugName, cwd, runtimeLogMeta, onInput, onOpenMarkdown, onReady, onResize, onReplayInterrupted, onTerminalModelRecovered }, ref) {
     const containerRef = useRef<HTMLDivElement>(null);
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const terminalRef = useRef<GhosttyModel | null>(null);
@@ -577,6 +582,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const onReadyRef = useRef(onReady);
     const onResizeRef = useRef(onResize);
     const onReplayInterruptedRef = useRef(onReplayInterrupted);
+    const onTerminalModelRecoveredRef = useRef(onTerminalModelRecovered);
     const runtimeMetaRef = useRef(runtimeLogMeta);
     const debugNameRef = useRef(debugName);
     const diagKeyRef = useRef<string>(runtimeLogMeta?.paneId ?? runtimeLogMeta?.sessionId ?? debugName);
@@ -591,6 +597,15 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     // triggering a render.
     const recoveryAttemptRef = useRef(0);
     const recoveryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Set before an epoch rebuild caused by a recoverable WASM model fault.
+    // It survives the effect cleanup so the replacement model can record the
+    // successful containment and notify the app shell exactly once.
+    const modelFaultRef = useRef<{
+      operation: string;
+      error: string;
+      model: number;
+      rendererEpoch: number;
+    } | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [linkCursorActive, setLinkCursorActive] = useState(false);
     const [findUi, setFindUi] = useState({ open: false, matchCount: 0, focusedIndex: -1, scanning: false, caseSensitive: false });
@@ -610,6 +625,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     onReadyRef.current = onReady;
     onResizeRef.current = onResize;
     onReplayInterruptedRef.current = onReplayInterrupted;
+    onTerminalModelRecoveredRef.current = onTerminalModelRecovered;
     runtimeMetaRef.current = runtimeLogMeta;
     debugNameRef.current = debugName;
     cwdRef.current = cwd;
@@ -619,6 +635,72 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     // debugName can change (its agent/title segment is reassigned on relabel).
     // A ref keeps the key out of callback dependency arrays.
     diagKeyRef.current = runtimeLogMeta?.paneId ?? runtimeLogMeta?.sessionId ?? debugName;
+
+    const recoverFromModelFault = useCallback((operation: string, reason: unknown) => {
+      // An invalid model can make several queued render/write operations fail
+      // before React applies the epoch bump. One rebuild is enough; recording
+      // all of them would obscure the first fault that made the model unusable.
+      if (modelFaultRef.current) return;
+      const error = reason instanceof Error ? reason.message : String(reason);
+      const stack = reason instanceof Error ? reason.stack : undefined;
+      const terminal = terminalRef.current;
+      let cols: number | undefined;
+      let rows: number | undefined;
+      try {
+        cols = terminal?.cols;
+        rows = terminal?.rows;
+      } catch {
+        // The fault itself may make a model accessor unsafe. The model id and
+        // operation still correlate this record with the surrounding timeline.
+      }
+      const fault = {
+        operation,
+        error,
+        model: modelInstanceRef.current,
+        rendererEpoch,
+      };
+      modelFaultRef.current = fault;
+      const session = runtimeMetaRef.current?.sessionId ?? undefined;
+      const paneKind = runtimeMetaRef.current?.paneKind ?? undefined;
+      let snapshot: Record<string, unknown> | undefined;
+      try {
+        snapshot = captureUiSnapshot();
+      } catch {
+        // Capturing supplementary DOM state must never defeat containment.
+      }
+      noteModelFault(diagKeyRef.current, {
+        session,
+        paneKind,
+        ...fault,
+        stack,
+        cols,
+        rows,
+      });
+      noteRecovery(diagKeyRef.current, {
+        session,
+        paneKind,
+        attempt: 1,
+        outcome: 'modelFault',
+        error,
+      });
+      recordUiDiag({
+        kind: 'ghostty_model_fault',
+        diagnosticFile: UI_DIAGNOSTICS_FILE,
+        pane: diagKeyRef.current,
+        session,
+        paneKind,
+        ...fault,
+        stack,
+        cols,
+        rows,
+        snapshot,
+      });
+      // The bad model lives in WASM, so do not try to reset or redraw it. A
+      // new epoch replaces both the canvas and model; onReady then reattaches
+      // the daemon-owned PTY and replays its retained screen state.
+      setError(null);
+      setRendererEpoch((value) => value + 1);
+    }, [rendererEpoch]);
 
     const getViewportCells = useCallback((): GhosttyCell[] | undefined => {
       const terminal = terminalRef.current;
@@ -637,8 +719,9 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const renderSurface = useCallback((force = false) => {
       const terminal = terminalRef.current;
       const renderer = rendererRef.current;
-      if (!terminal || !renderer) return;
-      if (runtimeMetaRef.current && !runtimeMetaRef.current.isActiveSession) return;
+      if (!terminal || !renderer) return true;
+      if (runtimeMetaRef.current && !runtimeMetaRef.current.isActiveSession) return true;
+      try {
       const range = selectionRef.current ? normalizeSelection(selectionRef.current) : null;
       const scrollbackLength = terminal.getScrollbackLength();
       const overlays: WebGlOverlay[] = [];
@@ -750,7 +833,16 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         skipNull: sample ? sample.printableSkippedNull : null,
         skipZeroWidth: sample ? sample.printableSkippedZeroWidth : null,
       });
-    }, [getViewportCells, resolvedTheme]);
+      return true;
+      } catch (reason) {
+        // `renderer.render()` reads Ghostty's WASM-owned dirty cells. A bounds
+        // trap or invalid code point there used to escape React and unmount the
+        // whole application. Contain it to this pane and rebuild from daemon
+        // replay instead.
+        recoverFromModelFault('render', reason);
+        return false;
+      }
+    }, [getViewportCells, recoverFromModelFault, resolvedTheme]);
 
     const clearSynchronizedOutputRenderTimer = useCallback(() => {
       if (!synchronizedOutputRenderTimerRef.current) return;
@@ -1199,18 +1291,18 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       containerRef.current?.focus();
     }, [renderSurface]);
 
-    const enqueueOperation = useCallback((operation: () => void | Promise<void>) => {
+    const enqueueOperation = useCallback((label: string, operation: () => void | Promise<void>) => {
       writeChainRef.current = writeChainRef.current
         .catch(() => undefined)
         .then(async () => {
           try {
             await operation();
           } catch (reason) {
-            setError(`Ghostty terminal update failed: ${String(reason)}`);
+            recoverFromModelFault(label, reason);
           }
         });
       return writeChainRef.current;
-    }, []);
+    }, [recoverFromModelFault]);
 
     // Coalesce a verification fit into the next animation frame, replacing
     // any frame already queued. Shared by the overflow-correction path and
@@ -1238,7 +1330,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       if (options?.historicalReplay) {
         pendingReplayOpsRef.current += 1;
       }
-      return enqueueOperation(async () => {
+      return enqueueOperation('write', async () => {
         if (options?.historicalReplay) {
           pendingReplayOpsRef.current = Math.max(0, pendingReplayOpsRef.current - 1);
           if (pendingReplayOpsRef.current === 0 && droppedReplayResizeRef.current) {
@@ -1481,7 +1573,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           }
         }
       }
-      return enqueueOperation(() => {
+      return enqueueOperation('resizeLocal', () => {
         if (options?.historicalReplay) {
           pendingReplayOpsRef.current = Math.max(0, pendingReplayOpsRef.current - 1);
           if (pendingReplayGeometryRef.current) {
@@ -1630,19 +1722,23 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         // owner re-requests the attach replay once geometry settles.
         onReplayInterruptedRef.current?.();
       }
-      const fromCols = terminal.cols;
-      const fromRows = terminal.rows;
-      resizeGhosttyWithoutReflow(terminal, dims.cols, dims.rows);
-      reconcileBlocksAfterResize(dims.cols !== fromCols);
-      modelSizeRef.current = dims;
-      renderer.resize(dims.cols, dims.rows);
-      hoverGenerationRef.current += 1;
-      noteResize(diagKeyRef.current, {
-        session, paneKind, source: 'fit', fromCols, fromRows, toCols: dims.cols, toRows: dims.rows,
-      });
-      renderSurface(true);
-      onResizeRef.current(dims.cols, dims.rows, { reason: 'ghostty_fit' });
-    }, [reconcileBlocksAfterResize, renderSurface]);
+      try {
+        const fromCols = terminal.cols;
+        const fromRows = terminal.rows;
+        resizeGhosttyWithoutReflow(terminal, dims.cols, dims.rows);
+        reconcileBlocksAfterResize(dims.cols !== fromCols);
+        modelSizeRef.current = dims;
+        renderer.resize(dims.cols, dims.rows);
+        hoverGenerationRef.current += 1;
+        noteResize(diagKeyRef.current, {
+          session, paneKind, source: 'fit', fromCols, fromRows, toCols: dims.cols, toRows: dims.rows,
+        });
+        if (!renderSurface(true)) return;
+        onResizeRef.current(dims.cols, dims.rows, { reason: 'ghostty_fit' });
+      } catch (reason) {
+        recoverFromModelFault('fit', reason);
+      }
+    }, [reconcileBlocksAfterResize, recoverFromModelFault, renderSurface]);
 
     applyFitDimensionsRef.current = applyFitDimensions;
 
@@ -1825,11 +1921,12 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         });
         terminalRef.current = terminal;
         rendererRef.current = renderer;
-        if (recoveryAttemptRef.current > 0) {
+        const recoveredModelFault = modelFaultRef.current;
+        if (recoveryAttemptRef.current > 0 || recoveredModelFault) {
           noteRecovery(diagKeyRef.current, {
             session: runtimeMetaRef.current?.sessionId ?? undefined,
             paneKind: runtimeMetaRef.current?.paneKind ?? undefined,
-            attempt: recoveryAttemptRef.current,
+            attempt: recoveryAttemptRef.current || 1,
             outcome: 'recovered',
           });
         }
@@ -1923,6 +2020,10 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           getBlockState,
           drain: () => writeChainRef.current,
         });
+        if (recoveredModelFault) {
+          modelFaultRef.current = null;
+          onTerminalModelRecoveredRef.current?.();
+        }
       }).catch((reason) => {
         if (!active) return;
         noteRecovery(diagKeyRef.current, {
@@ -2007,9 +2108,23 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         cancelScheduledOutputRender();
         fitResizeCoalescerRef.current?.cancel();
         fitResizeCoalescerRef.current = null;
-        inputRef.current?.dispose();
-        rendererRef.current?.dispose();
-        terminalRef.current?.free();
+        try {
+          inputRef.current?.dispose();
+          rendererRef.current?.dispose();
+          terminalRef.current?.free();
+        } catch (reason) {
+          // If the invalid model also faults during disposal, the epoch
+          // replacement must still complete rather than leaking that error
+          // through React's effect cleanup.
+          recordUiDiag({
+            kind: 'ghostty_model_cleanup_fault',
+            diagnosticFile: UI_DIAGNOSTICS_FILE,
+            pane: diagKeyRef.current,
+            session: runtimeMetaRef.current?.sessionId ?? undefined,
+            error: reason instanceof Error ? reason.message : String(reason),
+            stack: reason instanceof Error ? reason.stack : undefined,
+          });
+        }
         inputRef.current = null;
         rendererRef.current = null;
         terminalRef.current = null;

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -159,6 +159,7 @@ interface SessionTerminalWorkspaceProps {
   // markdown tile bound to that pane's session (empty sessionId = let the
   // daemon use the selected session).
   onOpenMarkdown?: (path: string, sessionId: string) => void;
+  onTerminalModelRecovered?: () => void;
   onZoomModeChange?: (zoomed: boolean) => void;
   onNavigateOutOfSession: (direction: TerminalNavigationDirection) => void;
   onResizeSplit?: (splitId: string, ratio: number) => Promise<unknown> | void;
@@ -208,6 +209,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     onTriggerNudge,
     onOpenPresentation,
     onOpenMarkdown,
+    onTerminalModelRecovered,
     onZoomModeChange,
     onNavigateOutOfSession,
     onResizeSplit,
@@ -925,6 +927,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
                   onReady={handleGhosttyTerminalReady(agentPane.id)}
                   onResize={runtime.handleTerminalResize(agentPane.id)}
                   onReplayInterrupted={runtime.handleReplayInterrupted(agentPane.id)}
+                  onTerminalModelRecovered={onTerminalModelRecovered}
                 />
               )}
               {ticketOverlayOpen && paneTicket && ticketActions ? (

--- a/app/src/utils/terminalDiagnosticsLog.test.ts
+++ b/app/src/utils/terminalDiagnosticsLog.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   dumpTerminalGeometry,
+  noteModelFault,
   noteRecovery,
   noteResize,
   recordDiag,
@@ -84,6 +85,34 @@ describe('noteRecovery', () => {
     const events = ringEventsFor(pane).filter((event) => event.kind === 'recovery');
     expect(events.map((event) => event.outcome)).toEqual(['contextLost', 'scheduled', 'recovered']);
     expect(events[1]?.delayMs).toBe(250);
+  });
+});
+
+describe('noteModelFault', () => {
+  beforeEach(() => {
+    window.localStorage.setItem('attn:terminal-diagnostics', '1');
+  });
+
+  it('persists the operation and model geometry needed after the pane rebuilds', () => {
+    const pane = 'pane-model-fault';
+    noteModelFault(pane, {
+      session: 'session-model-fault',
+      paneKind: 'agent',
+      operation: 'render',
+      error: 'Out of bounds memory access',
+      model: 4,
+      cols: 307,
+      rows: 77,
+      rendererEpoch: 2,
+    });
+
+    expect(ringEventsFor(pane)).toContainEqual(expect.objectContaining({
+      kind: 'model_fault',
+      operation: 'render',
+      model: 4,
+      cols: 307,
+      rows: 77,
+    }));
   });
 });
 

--- a/app/src/utils/terminalDiagnosticsLog.ts
+++ b/app/src/utils/terminalDiagnosticsLog.ts
@@ -80,7 +80,8 @@ export type DiagKind =
   | 'desync'
   | 'watchdog'
   | 'incident'
-  | 'recovery';
+  | 'recovery'
+  | 'model_fault';
 
 export interface DiagEvent {
   at: number;
@@ -104,6 +105,7 @@ const LIFECYCLE_KINDS = new Set<DiagKind>([
   'watchdog',
   'incident',
   'recovery',
+  'model_fault',
 ]);
 
 export interface RenderProbe {
@@ -495,12 +497,32 @@ export function noteRecovery(
     session?: string;
     paneKind?: string;
     attempt: number;
-    outcome: 'contextLost' | 'constructFailed' | 'scheduled' | 'recovered' | 'giveUp';
+    outcome: 'contextLost' | 'constructFailed' | 'scheduled' | 'recovered' | 'giveUp' | 'modelFault';
     delayMs?: number;
     error?: string;
   },
 ): void {
   recordDiag({ kind: 'recovery', pane, ...info });
+}
+
+// A Ghostty WASM model can become unusable while the renderer is asking it for
+// dirty cells. Persist the fault before the pane rebuilds: after recovery, the
+// replacement model has no knowledge of the invalid instance that triggered it.
+export function noteModelFault(
+  pane: string,
+  info: {
+    session?: string;
+    paneKind?: string;
+    operation: string;
+    error: string;
+    stack?: string;
+    model: number;
+    cols?: number;
+    rows?: number;
+    rendererEpoch: number;
+  },
+): void {
+  recordDiag({ kind: 'model_fault', pane, ...info });
 }
 
 function armWatchdog(pane: string, session?: string) {

--- a/app/src/utils/uiDiagnosticsLog.ts
+++ b/app/src/utils/uiDiagnosticsLog.ts
@@ -6,6 +6,11 @@ import { isTauri } from '@tauri-apps/api/core';
 
 const DEBUG_DIR = 'debug';
 const FILE = `${DEBUG_DIR}/ui-diagnostics.jsonl`;
+// Kept as an app-local path so the UI can name the exact durable artifact
+// without guessing an installation-specific macOS container directory.
+export const UI_DIAGNOSTICS_FILE = `$APPLOCALDATA/${FILE}`;
+const appLocalDataBundleId = import.meta.env.VITE_ATTN_BUILD_BUNDLE_ID || 'com.attn.manager';
+export const UI_DIAGNOSTICS_FILE_DISPLAY = `~/Library/Application Support/${appLocalDataBundleId}/${FILE}`;
 const FILE_SIZE_CAP_BYTES = 4 * 1024 * 1024;
 const RING_LIMIT = 300;
 const SWITCH_PROBE_DELAYS_MS = [0, 250, 1500];
@@ -36,7 +41,7 @@ let switchGeneration = 0;
 function exposeGlobals(): void {
   window.__ATTN_UI_DIAG = ring;
   window.__ATTN_UI_DIAG_DUMP = () => [...ring];
-  window.__ATTN_UI_DIAG_FILE = `$APPLOCALDATA/${FILE}`;
+  window.__ATTN_UI_DIAG_FILE = UI_DIAGNOSTICS_FILE;
 }
 
 function byteLength(value: string): number {


### PR DESCRIPTION
## Intent / Why

A Ghostty terminal-model fault currently escapes React and crashes the entire attn UI. This change contains that fault to the affected pane, restores its daemon-owned PTY view, and leaves Victor an actionable diagnostic record for a proper native fix.

## Summary

- Catch Ghostty model faults from rendering, fit-resize, queued writes, and disposal; rebuild the canvas and WASM model instead of letting the error reach the app error boundary.
- Reattach the rebuilt pane through the existing same-app-remount path so the daemon replays its retained terminal state.
- Persist a model-fault record with operation, error, stack, model id, geometry, and UI snapshot in the UI diagnostics stream; also add a terminal lifecycle model_fault event.
- Show a 12-second notification after the replacement model is ready: Terminal issue recovered. We reloaded it for you. The toast names the exact profile-local ui-diagnostics.jsonl path and asks the user to send it to Victor.
- Keep long diagnostic paths readable in the toast and add focused coverage for the durable event and extended notice duration.

## Investigation findings

The two production failures on 2026-07-20 were not caused by a Notebook tile. The active screen was a Ghostty terminal; NotebookTile appeared only as a dynamically-loaded bundle ancestor.

- First failure: an out-of-range code point during rendering immediately after a fit from 82x48 to 153x76.
- Second failure: an out-of-bounds WASM memory access in terminal.update() immediately after a fit from 153x76 to 307x77.
- Both are faults in the Ghostty model/render path. The terminal component had no local fault boundary, so React unmounted the app after the exception.
- The shared fit path calls resizeGhosttyWithoutReflow. It temporarily injects DEC wraparound-off around resize to select Ghostty's no-reflow behavior. That policy protects attn's detachable, reconnectable UI from rewriting replayed terminal history when pane geometry changes.
- Replaying the retained terminal bytes and repeating the observed size transitions outside the live app did not reproduce the invalid model. The exact native trigger is therefore still unresolved; this PR captures the next occurrence rather than claiming an upstream root cause it cannot prove.

## Deferred proper fix

1. Replace the injected DEC wraparound resize trick with a native Ghostty WASM no-reflow resize API, if or when Ghostty exposes one. The API should make the preservation policy explicit instead of changing a terminal mode around resize.
2. Use the new fault-time records to build a minimal Ghostty-core reproduction, then fix or upgrade the vendored core rather than relying on UI containment.
3. Preserve the no-reflow user behavior until that native replacement is proven. Switching to ordinary reflow would be a behavioral regression for attached replay and geometry changes, not a neutral cleanup.
4. Consider a narrower terminal-runtime isolation boundary only if native model faults remain possible after the upstream fix.

## Test plan

- [x] Focused Vitest coverage for model-fault lifecycle diagnostics and the extended recovery notice.
- [x] Full frontend Vitest suite and Playwright suite via the repository pre-commit hook.
- [x] pnpm --dir app run build.
- [x] Installed and ran the final isolated attn-dev bundle.
- [x] Ran real-app:scenario-webgl-recovery: forced context loss, observed contextLost -> scheduled -> recovered, reattached the PTY, rendered fresh output, and confirmed no error overlay.
- [ ] Trigger a real model fault with the new diagnostics and use that artifact to land the native Ghostty fix.