### PR TITLE
feat(automations): profile-level Automations surface (Slice 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-07-20]
 
 ### Added
+- **Automations now have a panel in the app.** A new toolbar button opens an
+  Automations panel that lists every definition with its trigger and
+  enabled state, lets you enable/disable or run a manual automation now,
+  shows each definition's run history with failures called out inline, and
+  jumps straight to the ticket or session a run produced. Definitions are
+  still created from the CLI (`attn automation apply`); changes made there
+  appear in the panel immediately, and daemon rejections are shown in the
+  panel rather than silently swallowed.
 - **Automations can now run on a schedule.** A definition can declare a cron
   schedule with a required time zone and fire an ordinary visible agent
   session at each intended instant — for example, a recurring merged-worktree

--- a/app/scripts/real-app-harness/scenario-automation-surface.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-surface.mjs
@@ -1,0 +1,432 @@
+#!/usr/bin/env node
+
+/**
+ * Packaged-app proof for Slice 6's profile-level Automations dock panel: a
+ * CLI-created definition appears in the panel via broadcast with no restart,
+ * "run now" driven through the real panel controls produces a navigable run
+ * and re-rendering the panel never duplicates it, a rejected run-now surfaces
+ * its error inline instead of failing silently, and both the definition list
+ * and run history survive a daemon+app restart.
+ *
+ * Two definitions are applied against one isolated profile daemon:
+ *   - `automations-surface-manual-<suffix>`: trigger.type manual, policy
+ *     continuity fresh (the only continuity manual trigger validation
+ *     allows), launched against a FAKE codex executable (argv logger, like
+ *     the Slice 5 storm-guard probe) so a run-now click reaches `delivered`
+ *     fast and deterministically.
+ *   - `automations-surface-scheduled-<suffix>`: trigger.type scheduled with
+ *     a once-a-year cron so it never fires during the scenario window;
+ *     exists only to prove the panel hides the run-now affordance for a
+ *     non-manual trigger.
+ *
+ * Run serially (packaged-app scenarios are single-tenant):
+ *   ATTN_HARNESS_PROFILE=<name> node scripts/real-app-harness/scenario-automation-surface.mjs
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { parseCommonArgs, printCommonHelp, launchFreshAppAndConnect } from './common.mjs';
+import { createScenarioRunner } from './scenarioRunner.mjs';
+import { currentHarnessProfile, resolveHarnessResources } from './harnessProfile.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { captureFrontWindowScreenshot } from './nativeWindowCapture.mjs';
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Poll budgets. The panel refetches on every `automations_changed` broadcast,
+// so appearance/toggle/run-state changes should land fast; these windows are
+// generous margin over that, not tuned to any real cadence.
+const PANEL_APPEAR_TIMEOUT_MS = 30_000;
+const RUN_DELIVERED_TIMEOUT_MS = 45_000;
+const TOGGLE_TIMEOUT_MS = 20_000;
+const RUN_ERROR_TIMEOUT_MS = 20_000;
+const RESTART_READY_TIMEOUT_MS = 60_000;
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') args.shift();
+  const options = parseCommonArgs(args);
+  return { options, help: args.includes('--help') || args.includes('-h') };
+}
+
+function profileEnv(profile, extra = {}) {
+  const env = { ...process.env, ATTN_PROFILE: profile, ...extra };
+  for (const key of ['ATTN_SOCKET_PATH', 'ATTN_DB_PATH', 'ATTN_CONFIG_PATH', 'ATTN_PLUGIN_DIR']) {
+    delete env[key];
+  }
+  return env;
+}
+
+function run(binary, args, env, options = {}) {
+  return execFileSync(binary, args, {
+    encoding: 'utf8',
+    env,
+    stdio: options.stdio || ['ignore', 'pipe', 'pipe'],
+    timeout: options.timeout || 30_000,
+  });
+}
+
+function runJSON(binary, args, env) {
+  return JSON.parse(run(binary, args, env));
+}
+
+async function poll(fn, description, timeoutMs = 30_000) {
+  const started = Date.now();
+  let last = null;
+  while (Date.now() - started < timeoutMs) {
+    last = await fn();
+    if (last) return last;
+    await delay(250);
+  }
+  throw new Error(`timed out waiting for ${description}; last=${JSON.stringify(last)}`);
+}
+
+async function waitForDaemonReady(binary, daemonEnv) {
+  await poll(() => {
+    try {
+      runJSON(binary, ['automation', 'list'], daemonEnv);
+      return { ready: true };
+    } catch {
+      return null;
+    }
+  }, 'profile daemon', RESTART_READY_TIMEOUT_MS);
+}
+
+// --- fixture location: both definitions use `location.type: directory`,
+// which only requires an existing absolute directory (no git needed). ---
+
+function createFixture(root) {
+  const dir = fs.mkdtempSync(path.join(root, 'automations-surface-'));
+  return fs.realpathSync(dir);
+}
+
+// --- fake codex probe: an argv logger, not a real agent, so run-now reaches
+// delivered fast and deterministically (mirrors the Slice 5 storm-guard
+// probe in scenario-automation-scheduled-cleanup.mjs). ---
+
+function createCodexProbe(root) {
+  const log = path.join(root, 'codex-invocations.jsonl');
+  const executable = path.join(root, 'codex-probe.mjs');
+  fs.writeFileSync(
+    executable,
+    `#!/usr/bin/env node\nimport fs from 'node:fs';\nfs.appendFileSync(${JSON.stringify(log)}, JSON.stringify({argv: process.argv.slice(2), at: new Date().toISOString()}) + '\\n');\nsetInterval(() => {}, 1000);\n`,
+    { mode: 0o700 },
+  );
+  return { executable, log };
+}
+
+// --- automation definition YAML ----------------------------------------
+
+const API_VERSION = 'attn.dev/automations/v1alpha1';
+
+function manualDefinitionYAML({ id, locationPath, enabled, executable }) {
+  return `api_version: ${API_VERSION}
+id: ${id}
+name: Slice 6 packaged automations-panel proof (manual)
+enabled: ${enabled}
+trigger:
+  type: manual
+prompt: |
+  Slice 6 packaged automations-panel proof. Do nothing; this executable is a test double.
+launch:
+  driver: codex
+  executable: ${JSON.stringify(executable)}
+  model: slice6-manual-probe
+  effort: high
+location:
+  type: directory
+  path: ${JSON.stringify(locationPath)}
+policy:
+  continuity: fresh
+`;
+}
+
+function scheduledDefinitionYAML({ id, locationPath, enabled, executable }) {
+  return `api_version: ${API_VERSION}
+id: ${id}
+name: Slice 6 packaged automations-panel proof (non-manual)
+enabled: ${enabled}
+trigger:
+  type: scheduled
+  schedule:
+    cron: "0 0 1 1 *"
+    time_zone: UTC
+prompt: |
+  Slice 6 non-manual trigger fixture. Never fires during the scenario window
+  (once-a-year cron); exists only to prove the panel hides run-now for a
+  non-manual trigger.
+launch:
+  driver: codex
+  executable: ${JSON.stringify(executable)}
+  model: slice6-scheduled-probe
+  effort: high
+location:
+  type: directory
+  path: ${JSON.stringify(locationPath)}
+policy:
+  continuity: fresh
+  catch_up: latest
+`;
+}
+
+// --- panel bridge helpers ------------------------------------------------
+
+function findDefinitionRow(state, definitionId) {
+  return (state?.definitions || []).find((row) => row.id === definitionId) || null;
+}
+
+function currentRuns(state) {
+  // collectAutomationsUiState() only renders a runs section for the
+  // currently-selected definition, so this is scoped to whichever
+  // definition automations_select_definition last selected.
+  return state?.runs || [];
+}
+
+async function closeAndReopenPanel(client) {
+  // No automations_close_panel bridge verb exists (openAutomationsPanel in
+  // App.tsx is open-only — calling automations_open_panel again on an
+  // already-open panel is a no-op and would not force a refetch); the real
+  // close button also has no data-testid. Drive it through the generic
+  // dom_click verb instead, the documented house convention for controls
+  // without a dedicated bridge verb.
+  await client.request('dom_click', { selector: '.automations-panel__close' });
+  return client.request('automations_open_panel');
+}
+
+async function captureFailureEvidence(runner, client) {
+  try {
+    const state = await client.request('automations_get_state');
+    runner.writeJson('failure-automations-state.json', state);
+  } catch (error) {
+    runner.log('failure_evidence_state_error', { error: error instanceof Error ? error.message : String(error) });
+  }
+  try {
+    await captureFrontWindowScreenshot(path.join(runner.runDir, 'failure.png'), { client });
+  } catch (error) {
+    runner.log('failure_evidence_screenshot_error', { error: error instanceof Error ? error.message : String(error) });
+  }
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-automation-surface.mjs');
+    return;
+  }
+  const profile = currentHarnessProfile();
+  if (!profile) throw new Error('automation surface scenario requires a named non-production profile');
+  const resources = resolveHarnessResources(profile);
+  const binary = path.join(resources.appPath, 'Contents', 'MacOS', 'attn');
+  const runner = createScenarioRunner(options, {
+    scenarioId: 'AUTOMATION-SURFACE',
+    tier: 'tier2-local-fake-agent',
+    prefix: 'automation-surface',
+    metadata: { profile, panel: 'profile-level Automations dock panel' },
+  });
+
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+
+  const suffix = Date.now().toString(36);
+  const manualID = `automations-surface-manual-${suffix}`;
+  const scheduledID = `automations-surface-scheduled-${suffix}`;
+  const manualDefinitionFile = path.join(runner.sessionDir, 'manual.yml');
+  const scheduledDefinitionFile = path.join(runner.sessionDir, 'scheduled.yml');
+
+  let daemonEnv = null;
+  let fixturePath = null;
+  let probe = null;
+  let manualApplied = false;
+  let scheduledApplied = false;
+  let firstRunId = '';
+
+  try {
+    daemonEnv = profileEnv(profile);
+    fixturePath = createFixture(runner.sessionDir);
+    probe = createCodexProbe(runner.sessionDir);
+
+    await runner.step('restart_isolated_daemon', async () => {
+      try { run(binary, ['daemon', 'stop'], daemonEnv); } catch {}
+      run(binary, ['daemon', 'ensure'], daemonEnv);
+      await waitForDaemonReady(binary, daemonEnv);
+    });
+
+    await runner.step('launch_packaged_app', async () => {
+      await launchFreshAppAndConnect(client, observer);
+    });
+
+    // Leg 1 (create via CLI, appears in UI via broadcast): apply a
+    // manual-trigger definition via the bundled CLI, then confirm the panel
+    // renders it without a restart.
+    await runner.step('leg1_apply_manual_and_panel_shows_it', async () => {
+      fs.writeFileSync(
+        manualDefinitionFile,
+        manualDefinitionYAML({ id: manualID, locationPath: fixturePath, enabled: true, executable: probe.executable }),
+      );
+      runJSON(binary, ['automation', 'apply', '--file', manualDefinitionFile], daemonEnv);
+      manualApplied = true;
+
+      await client.request('automations_open_panel');
+      const state = await poll(async () => {
+        const current = await client.request('automations_get_state');
+        return findDefinitionRow(current, manualID) ? current : null;
+      }, `manual definition ${manualID} to appear in the panel`, PANEL_APPEAR_TIMEOUT_MS);
+      const row = findDefinitionRow(state, manualID);
+      runner.assert(row.trigger === 'Manual', 'manual definition renders trigger label "Manual"', row);
+      runner.assert(row.enabled === true, 'manual definition renders enabled', row);
+      runner.assert(row.canRunNow === true, 'manual definition renders the run-now affordance', row);
+    });
+
+    // Leg 2 (run-now via UI produces a navigable run; no duplicate run from
+    // repeated UI response handling): run now through the real button,
+    // confirm exactly one delivered, navigable run, then close+reopen the
+    // panel (a fresh fetch, not a second click) and confirm it is still
+    // exactly one run.
+    await runner.step('leg2_run_now_and_navigable', async () => {
+      await client.request('automations_select_definition', { definitionId: manualID });
+      await client.request('automations_run_now', { definitionId: manualID });
+      const state = await poll(async () => {
+        const current = await client.request('automations_get_state');
+        const delivered = currentRuns(current).filter((r) => r.state === 'delivered');
+        return delivered.length >= 1 ? current : null;
+      }, 'run-now run to reach delivered', RUN_DELIVERED_TIMEOUT_MS);
+      const runs = currentRuns(state);
+      runner.assert(runs.length === 1, 'exactly one run exists after a single run-now click', runs);
+      runner.assert(runs[0].state === 'delivered', 'the run reached delivered', runs[0]);
+      runner.assert(runs[0].navigable === true, 'the delivered run is navigable (its ticket exists)', runs[0]);
+      firstRunId = runs[0].id;
+
+      const reopened = await closeAndReopenPanel(client);
+      const reopenedRuns = currentRuns(reopened);
+      runner.assert(reopenedRuns.length === 1, 'reopening the panel does not duplicate the run row', reopenedRuns);
+      runner.assert(reopenedRuns[0].id === firstRunId, 'reopening the panel shows the same run id', reopenedRuns);
+    });
+
+    // Leg 3 (request failure is shown, not hidden): a non-manual definition
+    // has no run-now affordance; a disabled manual definition still renders
+    // one (by design), and clicking it surfaces the daemon's rejection
+    // inline rather than hiding it, without creating a new run row.
+    await runner.step('leg3_failure_shown_not_hidden', async () => {
+      fs.writeFileSync(
+        scheduledDefinitionFile,
+        scheduledDefinitionYAML({ id: scheduledID, locationPath: fixturePath, enabled: true, executable: probe.executable }),
+      );
+      runJSON(binary, ['automation', 'apply', '--file', scheduledDefinitionFile], daemonEnv);
+      scheduledApplied = true;
+      const withScheduled = await poll(async () => {
+        const current = await client.request('automations_get_state');
+        return findDefinitionRow(current, scheduledID) ? current : null;
+      }, `scheduled definition ${scheduledID} to appear in the panel`, PANEL_APPEAR_TIMEOUT_MS);
+      const scheduledRow = findDefinitionRow(withScheduled, scheduledID);
+      runner.assert(scheduledRow.trigger.startsWith('Scheduled'), 'non-manual definition renders a Scheduled trigger label', scheduledRow);
+      runner.assert(scheduledRow.canRunNow === false, 'non-manual definition has no run-now affordance', scheduledRow);
+
+      await client.request('automations_toggle_enabled', { definitionId: manualID });
+      await poll(async () => {
+        const current = await client.request('automations_get_state');
+        const row = findDefinitionRow(current, manualID);
+        return row && row.enabled === false ? current : null;
+      }, 'manual definition to render disabled after broadcast', TOGGLE_TIMEOUT_MS);
+
+      await client.request('automations_run_now', { definitionId: manualID });
+      const rejected = await poll(async () => {
+        const current = await client.request('automations_get_state');
+        const row = findDefinitionRow(current, manualID);
+        return row && row.runError ? current : null;
+      }, 'daemon rejection of run-now on a disabled definition to render inline', RUN_ERROR_TIMEOUT_MS);
+      const rejectedRow = findDefinitionRow(rejected, manualID);
+      runner.assert(rejectedRow.canRunNow === true, 'run-now still renders for a disabled manual definition (the rejection is surfaced, not hidden by the button disappearing)', rejectedRow);
+      runner.assert(rejectedRow.runError.toLowerCase().includes('disabled'), 'the inline run error names the daemon rejection reason', rejectedRow);
+      runner.assert(currentRuns(rejected).length === 1, 'the rejected run-now click did not create a new run row', currentRuns(rejected));
+
+      await client.request('automations_toggle_enabled', { definitionId: manualID });
+      await poll(async () => {
+        const current = await client.request('automations_get_state');
+        const row = findDefinitionRow(current, manualID);
+        return row && row.enabled === true ? current : null;
+      }, 'manual definition to render enabled again after broadcast', TOGGLE_TIMEOUT_MS);
+    });
+
+    // Leg 4 (restart preserves list and navigation): stop the daemon, quit
+    // the app, bring both back up (same mechanics as
+    // scenario-automation-scheduled-cleanup.mjs's restart leg), then confirm
+    // both definitions and the prior run still render correctly.
+    await runner.step('leg4_restart_preserves_list_and_navigation', async () => {
+      await client.quitApp();
+      await observer.close();
+      try { run(binary, ['daemon', 'stop'], daemonEnv); } catch {}
+      run(binary, ['daemon', 'ensure'], daemonEnv);
+      await waitForDaemonReady(binary, daemonEnv);
+      await launchFreshAppAndConnect(client, observer);
+
+      await client.request('automations_open_panel');
+      const state = await poll(async () => {
+        const current = await client.request('automations_get_state');
+        return findDefinitionRow(current, manualID) && findDefinitionRow(current, scheduledID) ? current : null;
+      }, 'both definitions to render after restart', RESTART_READY_TIMEOUT_MS);
+      const manualRow = findDefinitionRow(state, manualID);
+      const scheduledRow = findDefinitionRow(state, scheduledID);
+      runner.assert(manualRow.enabled === true, 'manual definition is still enabled after restart', manualRow);
+      runner.assert(scheduledRow.enabled === true, 'scheduled definition is still enabled after restart', scheduledRow);
+
+      await client.request('automations_select_definition', { definitionId: manualID });
+      const withRuns = await poll(async () => {
+        const current = await client.request('automations_get_state');
+        return currentRuns(current).length >= 1 ? current : null;
+      }, 'manual definition run history to render after restart', RESTART_READY_TIMEOUT_MS);
+      const runs = currentRuns(withRuns);
+      runner.assert(runs.length === 1, 'exactly one run still exists after restart', runs);
+      runner.assert(runs[0].id === firstRunId, 'the surviving run is the same run created before restart', runs[0]);
+      runner.assert(runs[0].navigable === true, 'the run is still navigable after restart', runs[0]);
+    });
+
+    runner.finishSuccess({ profile, manualID, scheduledID, firstRunId, fixturePath });
+  } catch (error) {
+    await captureFailureEvidence(runner, client).catch(() => {});
+    runner.finishFailure(error, { profile, manualID, scheduledID, firstRunId, fixturePath });
+    throw error;
+  } finally {
+    // Disable both definitions before the fixture directory disappears: an
+    // enabled `directory`-location definition re-validates its path on
+    // future observation, so leaving one enabled against a deleted temp root
+    // would spam errors on this profile forever (same defensive ordering as
+    // scenario-automation-scheduled-cleanup.mjs's finally block).
+    if (daemonEnv && fixturePath && fs.existsSync(fixturePath)) {
+      if (manualApplied) {
+        try {
+          fs.writeFileSync(
+            manualDefinitionFile,
+            manualDefinitionYAML({ id: manualID, locationPath: fixturePath, enabled: false, executable: probe.executable }),
+          );
+          run(binary, ['automation', 'apply', '--file', manualDefinitionFile], daemonEnv);
+        } catch {}
+      }
+      if (scheduledApplied) {
+        try {
+          fs.writeFileSync(
+            scheduledDefinitionFile,
+            scheduledDefinitionYAML({ id: scheduledID, locationPath: fixturePath, enabled: false, executable: probe.executable }),
+          );
+          run(binary, ['automation', 'apply', '--file', scheduledDefinitionFile], daemonEnv);
+        } catch {}
+      }
+    }
+    if (fixturePath) {
+      try { fs.rmSync(fixturePath, { recursive: true, force: true }); } catch {}
+    }
+    await client.quitApp().catch(() => {});
+    await observer.close().catch(() => {});
+    // daemonEnv never diverged from a plain profile daemon here (no mock
+    // provider, no CODEX_HOME override), so a single idempotent `ensure` is
+    // enough to leave a healthy daemon behind.
+    try { run(binary, ['daemon', 'ensure'], profileEnv(profile)); } catch {}
+    runner.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -15,6 +15,7 @@ import { ChiefOfStaffTransferPrompt } from './components/ChiefOfStaffTransferPro
 import { TicketDetailPanel } from './components/TicketDetailPanel';
 import { TicketBoardSurface } from './components/TicketBoardSurface';
 import { WorkflowRunView } from './components/WorkflowRunView';
+import { AutomationsPanel } from './components/AutomationsPanel';
 import {
   useWorkflowRunsStore,
   selectLatestWorkflowRunForSession,
@@ -226,6 +227,21 @@ function NotificationsBellIcon() {
         strokeLinejoin="round"
       />
       <path d="M6.6 12.6a1.5 1.5 0 0 0 2.8 0" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function AutomationsIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path
+        d="M8 1.6 9.6 5l3.6.6-2.6 2.6.6 3.6-3.2-1.7-3.2 1.7.6-3.6L2.8 5.6 6.4 5 8 1.6Z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+      />
+      <circle cx="8" cy="8" r="1.3" fill="currentColor" stroke="none" />
     </svg>
   );
 }
@@ -645,6 +661,10 @@ function App() {
     getRepoInfo,
     listWorkflowRuns,
     getWorkflowRun,
+    listAutomationDefinitions,
+    listAutomationRuns,
+    setAutomationEnabled,
+    runAutomationNow,
     fetchTicket,
     sendTicketChangeStatus,
     sendTicketAddComment,
@@ -856,6 +876,10 @@ function App() {
         getRepoInfo={getRepoInfo}
         listWorkflowRuns={listWorkflowRuns}
         getWorkflowRun={getWorkflowRun}
+        listAutomationDefinitions={listAutomationDefinitions}
+        listAutomationRuns={listAutomationRuns}
+        setAutomationEnabled={setAutomationEnabled}
+        runAutomationNow={runAutomationNow}
         fetchTicket={fetchTicket}
         sendTicketChangeStatus={sendTicketChangeStatus}
         sendTicketAddComment={sendTicketAddComment}
@@ -974,6 +998,10 @@ interface AppContentProps {
   getRepoInfo: ReturnType<typeof useDaemonSocket>['getRepoInfo'];
   listWorkflowRuns: ReturnType<typeof useDaemonSocket>['listWorkflowRuns'];
   getWorkflowRun: ReturnType<typeof useDaemonSocket>['getWorkflowRun'];
+  listAutomationDefinitions: ReturnType<typeof useDaemonSocket>['listAutomationDefinitions'];
+  listAutomationRuns: ReturnType<typeof useDaemonSocket>['listAutomationRuns'];
+  setAutomationEnabled: ReturnType<typeof useDaemonSocket>['setAutomationEnabled'];
+  runAutomationNow: ReturnType<typeof useDaemonSocket>['runAutomationNow'];
   fetchTicket: ReturnType<typeof useDaemonSocket>['fetchTicket'];
   sendTicketChangeStatus: ReturnType<typeof useDaemonSocket>['sendTicketChangeStatus'];
   sendTicketAddComment: ReturnType<typeof useDaemonSocket>['sendTicketAddComment'];
@@ -1086,6 +1114,10 @@ sendFetchPRDetails,
   getRepoInfo,
   listWorkflowRuns,
   getWorkflowRun,
+  listAutomationDefinitions,
+  listAutomationRuns,
+  setAutomationEnabled,
+  runAutomationNow,
   fetchTicket,
   sendTicketChangeStatus,
   sendTicketAddComment,
@@ -1477,7 +1509,7 @@ sendFetchPRDetails,
     void connect();
   }, [connect]);
 
-  type DockPanelId = 'workflowRun' | 'attention' | 'ticketDetail';
+  type DockPanelId = 'workflowRun' | 'attention' | 'ticketDetail' | 'automations';
 
   // Muted section expansion (controlled by Dashboard click)
   const [sidebarMutedExpanded, setSidebarMutedExpanded] = useState(false);
@@ -1495,6 +1527,7 @@ sendFetchPRDetails,
         workflowRun: false,
         attention: false,
         ticketDetail: false,
+        automations: false,
     },
     stack: [],
   });
@@ -1864,6 +1897,7 @@ sendFetchPRDetails,
   const workflowRunPanelOpen = openDockPanels.workflowRun;
   const attentionPanelOpen = openDockPanels.attention;
   const ticketDetailPanelOpen = openDockPanels.ticketDetail;
+  const automationsPanelOpen = openDockPanels.automations;
   const blockingOverlayOpen = locationPickerOpen
     || whatsNew.isOpen
     || settingsOpen
@@ -2549,6 +2583,7 @@ sendFetchPRDetails,
       setSelectedTicketId(null);
     },
     tickets,
+    openAutomationsPanel: () => openDockPanel('automations'),
     presentationNotices,
     resetSessionPaneTerminal,
     injectSessionPaneBytes,
@@ -3323,6 +3358,13 @@ sendFetchPRDetails,
       badge: notificationsUnread > 0 ? notificationsUnread : undefined,
       onClick: toggleNotificationsPanel,
     },
+    {
+      id: 'automations',
+      title: automationsPanelOpen ? 'Hide Automations' : 'Show Automations',
+      icon: <AutomationsIcon />,
+      active: automationsPanelOpen,
+      onClick: () => toggleDockPanel('automations'),
+    },
   ]), [
     activeSessionId,
     remoteEditorAvailable,
@@ -3337,6 +3379,7 @@ sendFetchPRDetails,
     openBoardSurface,
     notificationsPanelOpen,
     notificationsUnread,
+    automationsPanelOpen,
     toggleNotificationsPanel,
   ]);
 
@@ -3799,6 +3842,25 @@ sendFetchPRDetails,
                   }}
                   onResume={handleResumeTicket}
                   onClose={handleCloseTicketDetail}
+                />
+              ),
+            },
+            {
+              id: 'automations',
+              isOpen: automationsPanelOpen,
+              width: 'clamp(420px, 42vw, 640px)',
+              className: 'dock-panel dock-panel--automations',
+              children: (
+                <AutomationsPanel
+                  isOpen={automationsPanelOpen}
+                  onClose={() => closeDockPanel('automations')}
+                  fetchDefinitions={listAutomationDefinitions}
+                  fetchRuns={listAutomationRuns}
+                  setEnabled={setAutomationEnabled}
+                  runNow={runAutomationNow}
+                  onOpenTicket={handleOpenTicketDetail}
+                  onSelectSession={handleSelectSession}
+                  onFocusPane={(sessionId, paneId) => focusSessionPane(sessionId, paneId, 40)}
                 />
               ),
             },

--- a/app/src/components/AutomationsPanel.css
+++ b/app/src/components/AutomationsPanel.css
@@ -1,0 +1,258 @@
+.automations-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  padding: 16px;
+  overflow-y: auto;
+  color: var(--color-text-primary);
+  background: var(--color-bg-panel);
+  font-size: var(--font-size-sm);
+}
+
+.automations-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 8px;
+}
+
+.automations-panel__kicker {
+  font-size: var(--font-size-xl);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.automations-panel__close {
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  line-height: 1;
+  padding: 4px;
+}
+
+.automations-panel__close:hover {
+  color: var(--color-text-primary);
+}
+
+.automations-panel__empty {
+  color: var(--color-text-tertiary);
+  padding: 16px 0;
+}
+
+.automations-panel__empty code {
+  font-family: var(--font-mono, monospace);
+  background: var(--color-bg-button);
+  border-radius: 4px;
+  padding: 1px 4px;
+}
+
+.automations-panel__list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.automations-panel__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 8px;
+  padding: 8px 10px;
+}
+
+.automations-panel__row.is-selected {
+  border-color: var(--color-border-hover);
+}
+
+.automations-panel__row-main {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+}
+
+.automations-panel__name {
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.automations-panel__trigger {
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+}
+
+.automations-panel__badge {
+  border-radius: 999px;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  padding: 1px 8px;
+}
+
+.automations-panel__badge--failed {
+  background: color-mix(in srgb, var(--color-error) 20%, transparent);
+  color: var(--color-error);
+}
+
+.automations-panel__toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+}
+
+.automations-panel__run-now {
+  background: var(--color-bg-button);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  font-size: var(--font-size-xs);
+  padding: 4px 10px;
+  white-space: nowrap;
+}
+
+.automations-panel__run-now:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+
+.automations-panel__run-now:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.automations-panel__error {
+  color: var(--color-error);
+  flex-basis: 100%;
+  font-size: var(--font-size-xs);
+  margin: 0;
+}
+
+.automations-panel__last-error {
+  color: var(--color-text-tertiary);
+  flex-basis: 100%;
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs);
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.automations-panel__runs {
+  border-top: 1px solid var(--color-border);
+  padding-top: 12px;
+}
+
+.automations-panel__runs-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.automations-panel__runs-title {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  margin: 0;
+}
+
+.automations-panel__runs-close {
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: var(--font-size-xs);
+}
+
+.automations-panel__runs-close:hover {
+  color: var(--color-text-primary);
+}
+
+.automations-panel__run-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.automations-panel__run-row {
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 6px;
+  padding: 6px 8px;
+}
+
+.automations-panel__run-row-main {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: inherit;
+  padding: 0;
+  text-align: left;
+  width: 100%;
+}
+
+button.automations-panel__run-row-main {
+  cursor: pointer;
+}
+
+.automations-panel__run-state {
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.automations-panel__run-state--failed {
+  color: var(--color-error);
+}
+
+.automations-panel__run-state--delivered {
+  color: var(--color-accent);
+}
+
+.automations-panel__run-created,
+.automations-panel__run-delivered,
+.automations-panel__run-occurrence {
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-xs);
+}
+
+.automations-panel__run-error {
+  color: var(--color-error);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs);
+  margin: 4px 0 0;
+}
+
+.automations-panel__run-empty {
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-xs);
+  padding: 8px 0;
+}

--- a/app/src/components/AutomationsPanel.test.tsx
+++ b/app/src/components/AutomationsPanel.test.tsx
@@ -202,6 +202,64 @@ describe('AutomationsPanel', () => {
     await waitFor(() => expect(useAutomationsStore.getState().pendingRunRequests['d1']).toBeUndefined());
   });
 
+  it('adopts a pending manual run id from run history after a simulated relaunch, so Run now retries it instead of minting a fresh id', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1', trigger_type: 'manual' })]);
+    props.fetchRuns.mockResolvedValue([
+      makeRun({ id: 'r1', occurrence_key: 'manual:restart-key-1', state: 'pending' }),
+    ]);
+    // Simulate relaunch: the store starts empty regardless of what the
+    // daemon still has pending.
+    useAutomationsStore.getState().reset();
+    render(<AutomationsPanel {...props} />);
+
+    const button = await screen.findByTestId('automation-run-now-d1');
+    await waitFor(() => expect(useAutomationsStore.getState().pendingRunRequests['d1']).toBe('restart-key-1'));
+
+    await user.click(button);
+    expect(props.runNow).toHaveBeenCalledWith('d1', 'restart-key-1');
+  });
+
+  it('does not adopt a pending run whose occurrence_key is not manual-prefixed', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1', trigger_type: 'manual' })]);
+    props.fetchRuns.mockResolvedValue([
+      makeRun({ id: 'r1', occurrence_key: 'sched:2026-01-01T00:00:00Z', state: 'pending' }),
+    ]);
+    useAutomationsStore.getState().reset();
+    render(<AutomationsPanel {...props} />);
+
+    const button = await screen.findByTestId('automation-run-now-d1');
+    await waitFor(() => expect(props.fetchRuns).toHaveBeenCalled());
+    expect(useAutomationsStore.getState().pendingRunRequests['d1']).toBeUndefined();
+
+    await user.click(button);
+    const [requestId] = props.runNow.mock.calls[0].slice(1);
+    expect(requestId).not.toBe('sched:2026-01-01T00:00:00Z');
+    expect(typeof requestId).toBe('string');
+  });
+
+  it('adoption never overwrites a key already stored for this session', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1', trigger_type: 'manual' })]);
+    useAutomationsStore.getState().reset();
+    const storedKey = useAutomationsStore.getState().ensureRunRequest('d1');
+    props.fetchRuns.mockResolvedValue([
+      makeRun({ id: 'r1', occurrence_key: 'manual:some-other-pending-run', state: 'pending' }),
+    ]);
+    render(<AutomationsPanel {...props} />);
+
+    const button = await screen.findByTestId('automation-run-now-d1');
+    await waitFor(() => expect(props.fetchRuns).toHaveBeenCalled());
+    expect(useAutomationsStore.getState().pendingRunRequests['d1']).toBe(storedKey);
+
+    await user.click(button);
+    expect(props.runNow).toHaveBeenCalledWith('d1', storedKey);
+  });
+
   it('refetches definitions when changedTick bumps', async () => {
     const props = baseProps();
     props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1' })]);

--- a/app/src/components/AutomationsPanel.test.tsx
+++ b/app/src/components/AutomationsPanel.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, userEvent } from '../test/utils';
+import { AutomationsPanel } from './AutomationsPanel';
+import { useAutomationsStore } from '../store/automations';
+import { AutomationDefinitionSummary, AutomationRunSummary } from '../types/generated';
+
+function makeDefinition(
+  overrides: Partial<AutomationDefinitionSummary> & { id: string },
+): AutomationDefinitionSummary {
+  return {
+    name: 'PR reviewer',
+    enabled: true,
+    revision: 1,
+    trigger_type: 'manual',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as AutomationDefinitionSummary;
+}
+
+function makeRun(
+  overrides: Partial<AutomationRunSummary> & { id: string },
+): AutomationRunSummary {
+  return {
+    definition_id: 'd1',
+    definition_revision: 1,
+    state: 'delivered',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as AutomationRunSummary;
+}
+
+function baseProps() {
+  return {
+    isOpen: true,
+    onClose: vi.fn(),
+    fetchDefinitions: vi.fn().mockResolvedValue([]),
+    fetchRuns: vi.fn().mockResolvedValue([]),
+    setEnabled: vi.fn().mockResolvedValue(undefined),
+    runNow: vi.fn().mockResolvedValue({}),
+    onOpenTicket: vi.fn(),
+    onSelectSession: vi.fn(),
+    onFocusPane: vi.fn(),
+  };
+}
+
+describe('AutomationsPanel', () => {
+  beforeEach(() => {
+    useAutomationsStore.getState().reset();
+  });
+
+  it('renders null when closed', () => {
+    const props = baseProps();
+    const { container } = render(<AutomationsPanel {...props} isOpen={false} />);
+    expect(container).toBeEmptyDOMElement();
+    expect(props.fetchDefinitions).not.toHaveBeenCalled();
+  });
+
+  it('renders the empty state when the daemon returns no definitions', async () => {
+    render(<AutomationsPanel {...baseProps()} />);
+    await waitFor(() => expect(screen.getByTestId('automations-panel-empty')).toBeInTheDocument());
+    expect(screen.getByText(/create one with/i)).toBeInTheDocument();
+  });
+
+  it('renders definitions with name, trigger label, and manual-only Run now', async () => {
+    const props = baseProps();
+    props.fetchDefinitions.mockResolvedValue([
+      makeDefinition({ id: 'd1', name: 'PR reviewer', trigger_type: 'manual' }),
+      makeDefinition({
+        id: 'd2',
+        name: 'Nightly digest',
+        trigger_type: 'scheduled',
+        schedule_cron: '0 9 * * *',
+        schedule_time_zone: 'UTC',
+      }),
+    ]);
+    render(<AutomationsPanel {...props} />);
+
+    await waitFor(() => expect(screen.getAllByTestId('automation-definition-row')).toHaveLength(2));
+    expect(screen.getByText('PR reviewer')).toBeInTheDocument();
+    expect(screen.getByText('Nightly digest')).toBeInTheDocument();
+    expect(screen.getByText('Scheduled — 0 9 * * * (UTC)')).toBeInTheDocument();
+
+    expect(screen.getByTestId('automation-run-now-d1')).toBeInTheDocument();
+    expect(screen.queryByTestId('automation-run-now-d2')).not.toBeInTheDocument();
+  });
+
+  it('shows a failure badge and last_error when a definition latest run failed', async () => {
+    const props = baseProps();
+    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1' })]);
+    props.fetchRuns.mockResolvedValue([
+      makeRun({ id: 'r1', state: 'failed', created_at: '2026-01-02T00:00:00Z', last_error: 'boom' }),
+      makeRun({ id: 'r2', state: 'delivered', created_at: '2026-01-01T00:00:00Z' }),
+    ]);
+    render(<AutomationsPanel {...props} />);
+
+    await waitFor(() => expect(screen.getByTestId('automation-failure-badge-d1')).toBeInTheDocument());
+    expect(screen.getByText('boom')).toBeInTheDocument();
+  });
+
+  it('does not flip the toggle optimistically and shows an inline error on rejection', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1', enabled: true })]);
+    props.setEnabled.mockRejectedValue(new Error('daemon refused'));
+    render(<AutomationsPanel {...props} />);
+
+    const toggle = await screen.findByTestId('automation-toggle-d1');
+    expect(toggle).toBeChecked();
+
+    await user.click(toggle);
+
+    await waitFor(() => expect(screen.getByTestId('automation-toggle-error-d1')).toHaveTextContent('daemon refused'));
+    expect(props.setEnabled).toHaveBeenCalledWith('d1', false);
+    // Store state was never locally mutated; the checkbox reflects the
+    // (unchanged) definition.enabled from the store, not an optimistic flip.
+    expect(toggle).toBeChecked();
+  });
+
+  it('shows an inline error on Run now rejection without disabling the button afterward', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1', trigger_type: 'manual' })]);
+    props.runNow.mockRejectedValue(new Error('busy'));
+    render(<AutomationsPanel {...props} />);
+
+    const button = await screen.findByTestId('automation-run-now-d1');
+    await user.click(button);
+
+    await waitFor(() => expect(screen.getByTestId('automation-run-error-d1')).toHaveTextContent('busy'));
+    expect(props.runNow).toHaveBeenCalledWith('d1');
+    expect(button).not.toBeDisabled();
+  });
+
+  it('refetches definitions when changedTick bumps', async () => {
+    const props = baseProps();
+    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1' })]);
+    render(<AutomationsPanel {...props} />);
+
+    await waitFor(() => expect(props.fetchDefinitions).toHaveBeenCalledTimes(1));
+
+    useAutomationsStore.getState().bumpChanged();
+
+    await waitFor(() => expect(props.fetchDefinitions).toHaveBeenCalledTimes(2));
+  });
+
+  it('navigates to the ticket when a run has a ticket_id', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1' })]);
+    props.fetchRuns.mockResolvedValue([makeRun({ id: 'r1', ticket_id: 't1', session_id: 's1' })]);
+    render(<AutomationsPanel {...props} />);
+
+    await user.click(await screen.findByText('PR reviewer'));
+    const runOpen = await screen.findByTestId('automation-run-open-r1');
+    await user.click(runOpen);
+
+    expect(props.onOpenTicket).toHaveBeenCalledWith('t1');
+    expect(props.onSelectSession).not.toHaveBeenCalled();
+  });
+
+  it('navigates to the session and focuses the pane when a run has session_id/pane_id but no ticket_id', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1' })]);
+    props.fetchRuns.mockResolvedValue([makeRun({ id: 'r1', session_id: 's1', pane_id: 'p1' })]);
+    render(<AutomationsPanel {...props} />);
+
+    await user.click(await screen.findByText('PR reviewer'));
+    const runOpen = await screen.findByTestId('automation-run-open-r1');
+    await user.click(runOpen);
+
+    expect(props.onSelectSession).toHaveBeenCalledWith('s1');
+    expect(props.onFocusPane).toHaveBeenCalledWith('s1', 'p1');
+  });
+
+  it('renders a run with no ticket_id/session_id as non-navigable', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1' })]);
+    props.fetchRuns.mockResolvedValue([makeRun({ id: 'r1' })]);
+    render(<AutomationsPanel {...props} />);
+
+    await user.click(await screen.findByText('PR reviewer'));
+    await screen.findByTestId('automation-run-row');
+    expect(screen.queryByTestId('automation-run-open-r1')).not.toBeInTheDocument();
+    expect(props.onOpenTicket).not.toHaveBeenCalled();
+    expect(props.onSelectSession).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/components/AutomationsPanel.test.tsx
+++ b/app/src/components/AutomationsPanel.test.tsx
@@ -73,13 +73,16 @@ describe('AutomationsPanel', () => {
         schedule_cron: '0 9 * * *',
         schedule_time_zone: 'UTC',
       }),
+      makeDefinition({ id: 'd3', name: 'Recurring reviewer', trigger_type: 'github_review_requested' }),
     ]);
     render(<AutomationsPanel {...props} />);
 
-    await waitFor(() => expect(screen.getAllByTestId('automation-definition-row')).toHaveLength(2));
+    await waitFor(() => expect(screen.getAllByTestId('automation-definition-row')).toHaveLength(3));
     expect(screen.getByText('PR reviewer')).toBeInTheDocument();
     expect(screen.getByText('Nightly digest')).toBeInTheDocument();
     expect(screen.getByText('Scheduled — 0 9 * * * (UTC)')).toBeInTheDocument();
+    expect(screen.getByText('Recurring reviewer')).toBeInTheDocument();
+    expect(screen.getByText('GitHub')).toBeInTheDocument();
 
     expect(screen.getByTestId('automation-run-now-d1')).toBeInTheDocument();
     expect(screen.queryByTestId('automation-run-now-d2')).not.toBeInTheDocument();

--- a/app/src/components/AutomationsPanel.test.tsx
+++ b/app/src/components/AutomationsPanel.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, userEvent } from '../test/utils';
 import { AutomationsPanel } from './AutomationsPanel';
 import { useAutomationsStore } from '../store/automations';
+import { AutomationActionTimeoutError } from '../hooks/useDaemonSocket';
 import { AutomationDefinitionSummary, AutomationRunSummary } from '../types/generated';
 
 function makeDefinition(
@@ -131,8 +132,74 @@ describe('AutomationsPanel', () => {
     await user.click(button);
 
     await waitFor(() => expect(screen.getByTestId('automation-run-error-d1')).toHaveTextContent('busy'));
-    expect(props.runNow).toHaveBeenCalledWith('d1');
+    expect(props.runNow).toHaveBeenCalledWith('d1', expect.any(String));
     expect(button).not.toBeDisabled();
+  });
+
+  it('a definitive Run now rejection clears the pending request id', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1', trigger_type: 'manual' })]);
+    props.runNow.mockRejectedValue(new Error('automation is disabled'));
+    render(<AutomationsPanel {...props} />);
+
+    const button = await screen.findByTestId('automation-run-now-d1');
+    await user.click(button);
+
+    await waitFor(() => expect(screen.getByTestId('automation-run-error-d1')).toHaveTextContent('automation is disabled'));
+    expect(useAutomationsStore.getState().pendingRunRequests['d1']).toBeUndefined();
+
+    await user.click(button);
+    const [firstCall, secondCall] = props.runNow.mock.calls;
+    expect(secondCall[1]).not.toBe(firstCall[1]);
+  });
+
+  it('a Run now timeout keeps the pending request id so a retry reuses it', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1', trigger_type: 'manual' })]);
+    props.runNow.mockRejectedValue(new AutomationActionTimeoutError('Run automation timed out'));
+    render(<AutomationsPanel {...props} />);
+
+    const button = await screen.findByTestId('automation-run-now-d1');
+    await user.click(button);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('automation-run-error-d1')).toHaveTextContent(/still in flight/i),
+    );
+    const pendingId = useAutomationsStore.getState().pendingRunRequests['d1'];
+    expect(pendingId).toBeTruthy();
+
+    await user.click(button);
+    const [firstCall, secondCall] = props.runNow.mock.calls;
+    expect(firstCall[1]).toBe(pendingId);
+    expect(secondCall[1]).toBe(pendingId);
+  });
+
+  it('reconciles a pending run request once a fetched run for its request id reaches delivered', async () => {
+    const props = baseProps();
+    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1', trigger_type: 'manual' })]);
+    props.fetchRuns.mockResolvedValue([]);
+    useAutomationsStore.getState().reset();
+    render(<AutomationsPanel {...props} />);
+    await screen.findByTestId('automation-run-now-d1');
+
+    const pendingId = useAutomationsStore.getState().ensureRunRequest('d1');
+
+    // Still pending: the key survives.
+    props.fetchRuns.mockResolvedValue([
+      makeRun({ id: 'r1', occurrence_key: `manual:${pendingId}`, state: 'pending' }),
+    ]);
+    useAutomationsStore.getState().bumpChanged();
+    await waitFor(() => expect(props.fetchRuns).toHaveBeenCalled());
+    await waitFor(() => expect(useAutomationsStore.getState().pendingRunRequests['d1']).toBe(pendingId));
+
+    // Delivered: the key clears, so the next click mints a fresh id.
+    props.fetchRuns.mockResolvedValue([
+      makeRun({ id: 'r1', occurrence_key: `manual:${pendingId}`, state: 'delivered' }),
+    ]);
+    useAutomationsStore.getState().bumpChanged();
+    await waitFor(() => expect(useAutomationsStore.getState().pendingRunRequests['d1']).toBeUndefined());
   });
 
   it('refetches definitions when changedTick bumps', async () => {

--- a/app/src/components/AutomationsPanel.tsx
+++ b/app/src/components/AutomationsPanel.tsx
@@ -34,7 +34,7 @@ function triggerLabel(definition: AutomationDefinitionSummary): string {
   switch (definition.trigger_type) {
     case 'manual':
       return 'Manual';
-    case 'github':
+    case 'github_review_requested':
       return 'GitHub';
     case 'scheduled': {
       if (!definition.schedule_cron) return 'Scheduled';

--- a/app/src/components/AutomationsPanel.tsx
+++ b/app/src/components/AutomationsPanel.tsx
@@ -40,13 +40,29 @@ export function runNavigationTarget(run: AutomationRunSummary): RunNavigationTar
 // (see internal/daemon/automations.go's automationRun); a run still pending
 // keeps the key so an impatient re-click reuses the same request_id instead
 // of minting a new one and claiming a duplicate run.
+//
+// When this session's store has no key for definitionId — most notably right
+// after an app relaunch, since pendingRunRequests is in-memory only — a
+// still-pending durable run on the daemon IS the retry identity. Adopt the
+// newest pending manual occurrence from run history so the next click reuses
+// it instead of minting a fresh id and claiming a second run.
 function reconcilePendingRunRequest(definitionId: string, runs: AutomationRunSummary[]) {
   const key = useAutomationsStore.getState().pendingRunRequests[definitionId];
-  if (!key) return;
-  const occurrenceKey = `manual:${key}`;
-  const match = runs.find((run) => run.occurrence_key === occurrenceKey);
-  if (match && (match.state === 'delivered' || match.state === 'failed')) {
-    useAutomationsStore.getState().clearRunRequest(definitionId);
+  if (key) {
+    const occurrenceKey = `manual:${key}`;
+    const match = runs.find((run) => run.occurrence_key === occurrenceKey);
+    if (match && (match.state === 'delivered' || match.state === 'failed')) {
+      useAutomationsStore.getState().clearRunRequest(definitionId);
+    }
+    return;
+  }
+  // Runs arrive newest-first, so the first match is the newest pending
+  // manual run.
+  const adoptable = runs.find((run) => run.state === 'pending' && run.occurrence_key?.startsWith('manual:'));
+  if (adoptable?.occurrence_key) {
+    useAutomationsStore
+      .getState()
+      .adoptRunRequest(definitionId, adoptable.occurrence_key.slice('manual:'.length));
   }
 }
 

--- a/app/src/components/AutomationsPanel.tsx
+++ b/app/src/components/AutomationsPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { AutomationDefinitionSummary, AutomationRunSummary } from '../types/generated';
 import { useAutomationsStore, selectDefinitionById, selectLatestRunForDefinition } from '../store/automations';
+import { AutomationActionTimeoutError } from '../hooks/useDaemonSocket';
 import './AutomationsPanel.css';
 
 export interface AutomationsPanelProps {
@@ -9,7 +10,10 @@ export interface AutomationsPanelProps {
   fetchDefinitions: () => Promise<AutomationDefinitionSummary[]>;
   fetchRuns: (definitionId: string) => Promise<AutomationRunSummary[]>;
   setEnabled: (definitionId: string, enabled: boolean) => Promise<void>;
-  runNow: (definitionId: string) => Promise<{ runId?: string; ticketId?: string; sessionId?: string }>;
+  runNow: (
+    definitionId: string,
+    requestId: string,
+  ) => Promise<{ runId?: string; ticketId?: string; sessionId?: string }>;
   onOpenTicket: (ticketId: string) => void;
   onSelectSession: (sessionId: string) => void;
   onFocusPane: (sessionId: string, paneId: string) => void;
@@ -28,6 +32,22 @@ export function runNavigationTarget(run: AutomationRunSummary): RunNavigationTar
   if (run.ticket_id) return { kind: 'ticket', ticketId: run.ticket_id };
   if (run.session_id) return { kind: 'session', sessionId: run.session_id, paneId: run.pane_id || null };
   return null;
+}
+
+// reconcilePendingRunRequest clears a definition's in-flight run-now request
+// key once a freshly-fetched run proves it reached a terminal state
+// (delivered or failed). The key's occurrence_key is always "manual:<key>"
+// (see internal/daemon/automations.go's automationRun); a run still pending
+// keeps the key so an impatient re-click reuses the same request_id instead
+// of minting a new one and claiming a duplicate run.
+function reconcilePendingRunRequest(definitionId: string, runs: AutomationRunSummary[]) {
+  const key = useAutomationsStore.getState().pendingRunRequests[definitionId];
+  if (!key) return;
+  const occurrenceKey = `manual:${key}`;
+  const match = runs.find((run) => run.occurrence_key === occurrenceKey);
+  if (match && (match.state === 'delivered' || match.state === 'failed')) {
+    useAutomationsStore.getState().clearRunRequest(definitionId);
+  }
 }
 
 function triggerLabel(definition: AutomationDefinitionSummary): string {
@@ -87,7 +107,9 @@ export function AutomationsPanel({
         fetched.forEach((definition) => {
           fetchRuns(definition.id)
             .then((runs) => {
-              if (!cancelled) useAutomationsStore.getState().setRuns(definition.id, runs);
+              if (cancelled) return;
+              useAutomationsStore.getState().setRuns(definition.id, runs);
+              reconcilePendingRunRequest(definition.id, runs);
             })
             .catch(() => {
               // Best-effort enrichment for the list badge; the definition row
@@ -114,6 +136,7 @@ export function AutomationsPanel({
       .then((runs) => {
         if (cancelled) return;
         useAutomationsStore.getState().setRuns(selectedDefinitionId, runs);
+        reconcilePendingRunRequest(selectedDefinitionId, runs);
         setRunsError(null);
       })
       .catch((error) => {
@@ -149,6 +172,7 @@ export function AutomationsPanel({
   }
 
   function handleRunNow(definitionId: string) {
+    const requestId = useAutomationsStore.getState().ensureRunRequest(definitionId);
     setRunInFlight((prev) => ({ ...prev, [definitionId]: true }));
     setRunErrors((prev) => {
       if (!(definitionId in prev)) return prev;
@@ -156,10 +180,26 @@ export function AutomationsPanel({
       delete next[definitionId];
       return next;
     });
-    runNow(definitionId)
+    runNow(definitionId, requestId)
       // Success: the daemon's automations_changed broadcast drives the
       // refetch above. No synthetic run row is injected here.
+      .then(() => {
+        useAutomationsStore.getState().clearRunRequest(definitionId);
+      })
       .catch((error) => {
+        if (error instanceof AutomationActionTimeoutError) {
+          // No definitive outcome yet: the daemon may still deliver this run
+          // after our wait window closed. Keep the request_id so a re-click
+          // reuses it (dedups onto the same run) instead of claiming a
+          // duplicate.
+          setRunErrors((prev) => ({
+            ...prev,
+            [definitionId]:
+              'Run request is still in flight — it will appear in run history; clicking again retries the same run.',
+          }));
+          return;
+        }
+        useAutomationsStore.getState().clearRunRequest(definitionId);
         setRunErrors((prev) => ({
           ...prev,
           [definitionId]: error instanceof Error ? error.message : 'Run failed',

--- a/app/src/components/AutomationsPanel.tsx
+++ b/app/src/components/AutomationsPanel.tsx
@@ -1,0 +1,358 @@
+import { useEffect, useState } from 'react';
+import { AutomationDefinitionSummary, AutomationRunSummary } from '../types/generated';
+import { useAutomationsStore, selectDefinitionById, selectLatestRunForDefinition } from '../store/automations';
+import './AutomationsPanel.css';
+
+export interface AutomationsPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  fetchDefinitions: () => Promise<AutomationDefinitionSummary[]>;
+  fetchRuns: (definitionId: string) => Promise<AutomationRunSummary[]>;
+  setEnabled: (definitionId: string, enabled: boolean) => Promise<void>;
+  runNow: (definitionId: string) => Promise<{ runId?: string; ticketId?: string; sessionId?: string }>;
+  onOpenTicket: (ticketId: string) => void;
+  onSelectSession: (sessionId: string) => void;
+  onFocusPane: (sessionId: string, paneId: string) => void;
+}
+
+// Where a run row navigates. The wire nit applies here: ticket_id/session_id/
+// pane_id are always present on AutomationRunSummary but "" means absent, so
+// a plain truthiness check is the correct emptiness test. Exported for direct
+// unit coverage of the ticket-over-session precedence.
+export type RunNavigationTarget =
+  | { kind: 'ticket'; ticketId: string }
+  | { kind: 'session'; sessionId: string; paneId: string | null }
+  | null;
+
+export function runNavigationTarget(run: AutomationRunSummary): RunNavigationTarget {
+  if (run.ticket_id) return { kind: 'ticket', ticketId: run.ticket_id };
+  if (run.session_id) return { kind: 'session', sessionId: run.session_id, paneId: run.pane_id || null };
+  return null;
+}
+
+function triggerLabel(definition: AutomationDefinitionSummary): string {
+  switch (definition.trigger_type) {
+    case 'manual':
+      return 'Manual';
+    case 'github':
+      return 'GitHub';
+    case 'scheduled': {
+      if (!definition.schedule_cron) return 'Scheduled';
+      return definition.schedule_time_zone
+        ? `Scheduled — ${definition.schedule_cron} (${definition.schedule_time_zone})`
+        : `Scheduled — ${definition.schedule_cron}`;
+    }
+    default:
+      return definition.trigger_type;
+  }
+}
+
+export function AutomationsPanel({
+  isOpen,
+  onClose,
+  fetchDefinitions,
+  fetchRuns,
+  setEnabled,
+  runNow,
+  onOpenTicket,
+  onSelectSession,
+  onFocusPane,
+}: AutomationsPanelProps) {
+  const definitions = useAutomationsStore((state) => state.definitions);
+  const runsByDefinition = useAutomationsStore((state) => state.runsByDefinition);
+  const changedTick = useAutomationsStore((state) => state.changedTick);
+
+  const [selectedDefinitionId, setSelectedDefinitionId] = useState<string | null>(null);
+  const [definitionsLoaded, setDefinitionsLoaded] = useState(false);
+  const [definitionsError, setDefinitionsError] = useState<string | null>(null);
+  const [runsError, setRunsError] = useState<string | null>(null);
+  const [toggleErrors, setToggleErrors] = useState<Record<string, string>>({});
+  const [toggleInFlight, setToggleInFlight] = useState<Record<string, boolean>>({});
+  const [runErrors, setRunErrors] = useState<Record<string, string>>({});
+  const [runInFlight, setRunInFlight] = useState<Record<string, boolean>>({});
+
+  // Refetch on open and on every automations_changed tick. Also eagerly
+  // fetches every definition's runs (not just the selected one) — the
+  // definitions list shows a failure badge per row, so the badge data has to
+  // exist before the user expands anything.
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    fetchDefinitions()
+      .then((fetched) => {
+        if (cancelled) return;
+        useAutomationsStore.getState().setDefinitions(fetched);
+        setDefinitionsError(null);
+        setDefinitionsLoaded(true);
+        fetched.forEach((definition) => {
+          fetchRuns(definition.id)
+            .then((runs) => {
+              if (!cancelled) useAutomationsStore.getState().setRuns(definition.id, runs);
+            })
+            .catch(() => {
+              // Best-effort enrichment for the list badge; the definition row
+              // still renders without it.
+            });
+        });
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setDefinitionsError(error instanceof Error ? error.message : 'Failed to load automations');
+        setDefinitionsLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, changedTick, fetchDefinitions, fetchRuns]);
+
+  // Refetch the selected definition's runs the moment it is selected, so the
+  // expanded history is not stuck on whatever the eager fetch above last saw.
+  useEffect(() => {
+    if (!isOpen || !selectedDefinitionId) return;
+    let cancelled = false;
+    fetchRuns(selectedDefinitionId)
+      .then((runs) => {
+        if (cancelled) return;
+        useAutomationsStore.getState().setRuns(selectedDefinitionId, runs);
+        setRunsError(null);
+      })
+      .catch((error) => {
+        if (!cancelled) setRunsError(error instanceof Error ? error.message : 'Failed to load runs');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, selectedDefinitionId, fetchRuns]);
+
+  if (!isOpen) return null;
+
+  const selectedDefinition = selectDefinitionById(definitions, selectedDefinitionId);
+
+  function handleToggle(definitionId: string, nextEnabled: boolean) {
+    setToggleInFlight((prev) => ({ ...prev, [definitionId]: true }));
+    setToggleErrors((prev) => {
+      if (!(definitionId in prev)) return prev;
+      const next = { ...prev };
+      delete next[definitionId];
+      return next;
+    });
+    setEnabled(definitionId, nextEnabled)
+      .catch((error) => {
+        setToggleErrors((prev) => ({
+          ...prev,
+          [definitionId]: error instanceof Error ? error.message : 'Failed to update',
+        }));
+      })
+      .finally(() => {
+        setToggleInFlight((prev) => ({ ...prev, [definitionId]: false }));
+      });
+  }
+
+  function handleRunNow(definitionId: string) {
+    setRunInFlight((prev) => ({ ...prev, [definitionId]: true }));
+    setRunErrors((prev) => {
+      if (!(definitionId in prev)) return prev;
+      const next = { ...prev };
+      delete next[definitionId];
+      return next;
+    });
+    runNow(definitionId)
+      // Success: the daemon's automations_changed broadcast drives the
+      // refetch above. No synthetic run row is injected here.
+      .catch((error) => {
+        setRunErrors((prev) => ({
+          ...prev,
+          [definitionId]: error instanceof Error ? error.message : 'Run failed',
+        }));
+      })
+      .finally(() => {
+        setRunInFlight((prev) => ({ ...prev, [definitionId]: false }));
+      });
+  }
+
+  function handleRunRowClick(run: AutomationRunSummary) {
+    const target = runNavigationTarget(run);
+    if (!target) return;
+    if (target.kind === 'ticket') {
+      onOpenTicket(target.ticketId);
+      return;
+    }
+    onSelectSession(target.sessionId);
+    if (target.paneId) onFocusPane(target.sessionId, target.paneId);
+  }
+
+  const showEmpty = definitionsLoaded && !definitionsError && definitions.length === 0;
+
+  return (
+    <div className="automations-panel" data-testid="automations-panel">
+      <div className="automations-panel__header">
+        <span className="automations-panel__kicker">Automations</span>
+        <button
+          type="button"
+          className="automations-panel__close"
+          onClick={onClose}
+          aria-label="Close automations"
+        >
+          ✕
+        </button>
+      </div>
+
+      {definitionsError && (
+        <p className="automations-panel__error" data-testid="automations-panel-error">
+          {definitionsError}
+        </p>
+      )}
+
+      {showEmpty ? (
+        <p className="automations-panel__empty" data-testid="automations-panel-empty">
+          No automations defined — create one with <code>attn automation apply</code>.
+        </p>
+      ) : (
+        <ul className="automations-panel__list" data-testid="automations-panel-list">
+          {definitions.map((definition) => {
+            const latestRun = selectLatestRunForDefinition(runsByDefinition[definition.id]);
+            const failed = latestRun?.state === 'failed';
+            const selected = definition.id === selectedDefinitionId;
+            return (
+              <li
+                key={definition.id}
+                className={`automations-panel__row${selected ? ' is-selected' : ''}`}
+                data-testid="automation-definition-row"
+                data-definition-id={definition.id}
+              >
+                <button
+                  type="button"
+                  className="automations-panel__row-main"
+                  aria-pressed={selected}
+                  onClick={() => setSelectedDefinitionId(selected ? null : definition.id)}
+                  data-testid={`automation-definition-select-${definition.id}`}
+                >
+                  <span className="automations-panel__name">{definition.name}</span>
+                  <span className="automations-panel__trigger">{triggerLabel(definition)}</span>
+                  {failed && (
+                    <span
+                      className="automations-panel__badge automations-panel__badge--failed"
+                      data-testid={`automation-failure-badge-${definition.id}`}
+                    >
+                      Failed
+                    </span>
+                  )}
+                </button>
+
+                <label className="automations-panel__toggle">
+                  <input
+                    type="checkbox"
+                    checked={definition.enabled}
+                    disabled={Boolean(toggleInFlight[definition.id])}
+                    onChange={(event) => handleToggle(definition.id, event.target.checked)}
+                    data-testid={`automation-toggle-${definition.id}`}
+                  />
+                  <span>{definition.enabled ? 'Enabled' : 'Disabled'}</span>
+                </label>
+
+                {definition.trigger_type === 'manual' && (
+                  <button
+                    type="button"
+                    className="automations-panel__run-now"
+                    disabled={Boolean(runInFlight[definition.id])}
+                    onClick={() => handleRunNow(definition.id)}
+                    data-testid={`automation-run-now-${definition.id}`}
+                  >
+                    Run now
+                  </button>
+                )}
+
+                {toggleErrors[definition.id] && (
+                  <p
+                    className="automations-panel__error"
+                    data-testid={`automation-toggle-error-${definition.id}`}
+                  >
+                    {toggleErrors[definition.id]}
+                  </p>
+                )}
+                {runErrors[definition.id] && (
+                  <p
+                    className="automations-panel__error"
+                    data-testid={`automation-run-error-${definition.id}`}
+                  >
+                    {runErrors[definition.id]}
+                  </p>
+                )}
+                {failed && latestRun?.last_error && (
+                  <p className="automations-panel__last-error">{latestRun.last_error}</p>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {selectedDefinition && (
+        <div className="automations-panel__runs" data-testid="automations-panel-runs">
+          <div className="automations-panel__runs-header">
+            <h3 className="automations-panel__runs-title">{selectedDefinition.name} — runs</h3>
+            <button
+              type="button"
+              className="automations-panel__runs-close"
+              onClick={() => setSelectedDefinitionId(null)}
+            >
+              Close
+            </button>
+          </div>
+          {runsError && <p className="automations-panel__error">{runsError}</p>}
+          <ul className="automations-panel__run-list">
+            {[...(runsByDefinition[selectedDefinition.id] ?? [])]
+              .sort((a, b) => (a.created_at < b.created_at ? 1 : a.created_at > b.created_at ? -1 : 0))
+              .map((run) => {
+                const target = runNavigationTarget(run);
+                const content = (
+                  <>
+                    <span className={`automations-panel__run-state automations-panel__run-state--${run.state}`}>
+                      {run.state}
+                    </span>
+                    <span className="automations-panel__run-created">
+                      {new Date(run.created_at).toLocaleString()}
+                    </span>
+                    {run.delivered_at && (
+                      <span className="automations-panel__run-delivered">
+                        delivered {new Date(run.delivered_at).toLocaleString()}
+                      </span>
+                    )}
+                    {run.occurrence_key && (
+                      <span className="automations-panel__run-occurrence">{run.occurrence_key}</span>
+                    )}
+                  </>
+                );
+                return (
+                  <li
+                    key={run.id}
+                    className="automations-panel__run-row"
+                    data-testid="automation-run-row"
+                    data-run-id={run.id}
+                    data-state={run.state}
+                  >
+                    {target ? (
+                      <button
+                        type="button"
+                        className="automations-panel__run-row-main"
+                        onClick={() => handleRunRowClick(run)}
+                        data-testid={`automation-run-open-${run.id}`}
+                      >
+                        {content}
+                      </button>
+                    ) : (
+                      <div className="automations-panel__run-row-main">{content}</div>
+                    )}
+                    {run.last_error && <p className="automations-panel__run-error">{run.last_error}</p>}
+                  </li>
+                );
+              })}
+            {(runsByDefinition[selectedDefinition.id] ?? []).length === 0 && (
+              <li className="automations-panel__run-empty">No runs yet.</li>
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -4,6 +4,7 @@ import { invoke, isTauri } from '@tauri-apps/api/core';
 import { ptyAttach, ptyDetach, ptyKill, ptySpawn } from '../pty/bridge';
 import { PROTOCOL_VERSION, retryTransientAttachRequest, useDaemonSocket } from './useDaemonSocket';
 import { useWorkflowRunsStore } from '../store/workflowRuns';
+import { useAutomationsStore } from '../store/automations';
 import { TicketStatus } from '../types/generated';
 
 class FakeWebSocket {
@@ -669,6 +670,156 @@ describe('useDaemonSocket PTY kill sequencing', () => {
       updated_by_session_id: 'session-1',
       updated_at: '2026-06-09T10:00:00Z',
     }]);
+    unmount();
+  });
+
+  it('resolves automation definitions from a correlated automation_action_result, ignoring a mismatched request_id', async () => {
+    const { result, unmount } = renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate: vi.fn(),
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        wsUrl: 'ws://localhost:9999/ws',
+      }),
+    );
+
+    const ws = await waitForOpenSocket();
+    const request = result.current.listAutomationDefinitions();
+    const command = ws.sent
+      .map((entry) => JSON.parse(entry))
+      .find((entry) => entry.cmd === 'automation_definitions_get');
+    expect(command.request_id).toMatch(/^automation_definitions_get:/);
+
+    let resolved = false;
+    request.then(() => {
+      resolved = true;
+    });
+
+    act(() => {
+      ws.emit({
+        event: 'automation_action_result',
+        action: 'definitions_get',
+        request_id: 'mismatched-request-id',
+        success: true,
+        definitions: [{ id: 'wrong' }],
+      });
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    const definition = {
+      id: 'd1',
+      name: 'PR reviewer',
+      enabled: true,
+      revision: 1,
+      trigger_type: 'manual',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    act(() => {
+      ws.emit({
+        event: 'automation_action_result',
+        action: 'definitions_get',
+        request_id: command.request_id,
+        success: true,
+        definitions: [definition],
+      });
+    });
+
+    await expect(request).resolves.toEqual([definition]);
+    unmount();
+  });
+
+  it('rejects setAutomationEnabled with the daemon error string on failure', async () => {
+    const { result, unmount } = renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate: vi.fn(),
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        wsUrl: 'ws://localhost:9999/ws',
+      }),
+    );
+
+    const ws = await waitForOpenSocket();
+    const request = result.current.setAutomationEnabled('d1', false);
+    const command = ws.sent
+      .map((entry) => JSON.parse(entry))
+      .find((entry) => entry.cmd === 'automation_set_enabled');
+    expect(command).toMatchObject({ definition_id: 'd1', enabled: false });
+
+    act(() => {
+      ws.emit({
+        event: 'automation_action_result',
+        action: 'set_enabled',
+        request_id: command.request_id,
+        success: false,
+        error: 'automation definition is disabled elsewhere',
+      });
+    });
+
+    await expect(request).rejects.toThrow('automation definition is disabled elsewhere');
+    unmount();
+  });
+
+  it('resolves runAutomationNow with run/ticket/session ids', async () => {
+    const { result, unmount } = renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate: vi.fn(),
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        wsUrl: 'ws://localhost:9999/ws',
+      }),
+    );
+
+    const ws = await waitForOpenSocket();
+    const request = result.current.runAutomationNow('d1');
+    const command = ws.sent
+      .map((entry) => JSON.parse(entry))
+      .find((entry) => entry.cmd === 'automation_run');
+    expect(command).toMatchObject({ definition_id: 'd1' });
+
+    act(() => {
+      ws.emit({
+        event: 'automation_action_result',
+        action: 'run',
+        request_id: command.request_id,
+        success: true,
+        run_id: 'run-1',
+        ticket_id: 'ticket-1',
+        session_id: 'session-1',
+      });
+    });
+
+    await expect(request).resolves.toEqual({ runId: 'run-1', ticketId: 'ticket-1', sessionId: 'session-1' });
+    unmount();
+  });
+
+  it('bumps useAutomationsStore changedTick on automations_changed', async () => {
+    useAutomationsStore.getState().reset();
+    const { unmount } = renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate: vi.fn(),
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        wsUrl: 'ws://localhost:9999/ws',
+      }),
+    );
+
+    const ws = await waitForOpenSocket();
+    const before = useAutomationsStore.getState().changedTick;
+
+    act(() => {
+      ws.emit({ event: 'automations_changed', definition_ids: ['d1'] });
+    });
+
+    expect(useAutomationsStore.getState().changedTick).toBe(before + 1);
     unmount();
   });
 

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -2,7 +2,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { invoke, isTauri } from '@tauri-apps/api/core';
 import { ptyAttach, ptyDetach, ptyKill, ptySpawn } from '../pty/bridge';
-import { PROTOCOL_VERSION, retryTransientAttachRequest, useDaemonSocket } from './useDaemonSocket';
+import { AutomationActionTimeoutError, PROTOCOL_VERSION, retryTransientAttachRequest, useDaemonSocket } from './useDaemonSocket';
 import { useWorkflowRunsStore } from '../store/workflowRuns';
 import { useAutomationsStore } from '../store/automations';
 import { TicketStatus } from '../types/generated';
@@ -777,11 +777,11 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     );
 
     const ws = await waitForOpenSocket();
-    const request = result.current.runAutomationNow('d1');
+    const request = result.current.runAutomationNow('d1', 'req-1');
     const command = ws.sent
       .map((entry) => JSON.parse(entry))
       .find((entry) => entry.cmd === 'automation_run');
-    expect(command).toMatchObject({ definition_id: 'd1' });
+    expect(command).toMatchObject({ definition_id: 'd1', request_id: 'req-1' });
 
     act(() => {
       ws.emit({
@@ -796,6 +796,34 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     });
 
     await expect(request).resolves.toEqual({ runId: 'run-1', ticketId: 'ticket-1', sessionId: 'session-1' });
+    unmount();
+  });
+
+  it('rejects runAutomationNow with AutomationActionTimeoutError when no result arrives within 30s', async () => {
+    const { result, unmount } = renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate: vi.fn(),
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        wsUrl: 'ws://localhost:9999/ws',
+      }),
+    );
+
+    await waitForOpenSocket();
+
+    vi.useFakeTimers();
+    let caught: unknown;
+    const request = result.current.runAutomationNow('d1', 'req-timeout').catch((err) => {
+      caught = err;
+    });
+
+    await vi.advanceTimersByTimeAsync(30000);
+    await request;
+    vi.useRealTimers();
+
+    expect(caught).toBeInstanceOf(AutomationActionTimeoutError);
     unmount();
   });
 

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -176,6 +176,16 @@ export interface RateLimitState {
 export const PROTOCOL_VERSION = '176';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
+// AutomationActionTimeoutError distinguishes "the daemon never sent a
+// definitive result within the client's wait window" from an ordinary
+// rejection carrying a daemon-reported error string (e.g. "automation is
+// disabled"). The four automation wrappers below (listAutomationDefinitions,
+// listAutomationRuns, setAutomationEnabled, runAutomationNow) all reject with
+// this on their timeout path so callers — notably AutomationsPanel's run-now
+// handler — can tell "no outcome yet, retry is safe" apart from "the daemon
+// definitively said no, don't retry blindly".
+export class AutomationActionTimeoutError extends Error {}
+
 interface PRActionResult {
   success: boolean;
   error?: string;
@@ -5286,7 +5296,7 @@ export function useDaemonSocket({
       setTimeout(() => {
         if (pendingActionsRef.current.has(key)) {
           pendingActionsRef.current.delete(key);
-          reject(new Error('List automation definitions timed out'));
+          reject(new AutomationActionTimeoutError('List automation definitions timed out'));
         }
       }, 30000);
     });
@@ -5312,7 +5322,7 @@ export function useDaemonSocket({
       setTimeout(() => {
         if (pendingActionsRef.current.has(key)) {
           pendingActionsRef.current.delete(key);
-          reject(new Error('List automation runs timed out'));
+          reject(new AutomationActionTimeoutError('List automation runs timed out'));
         }
       }, 30000);
     });
@@ -5341,26 +5351,27 @@ export function useDaemonSocket({
       setTimeout(() => {
         if (pendingActionsRef.current.has(key)) {
           pendingActionsRef.current.delete(key);
-          reject(new Error('Set automation enabled timed out'));
+          reject(new AutomationActionTimeoutError('Set automation enabled timed out'));
         }
       }, 30000);
     });
   }, [nextRequestID]);
 
   const runAutomationNow = useCallback(
-    (definitionId: string): Promise<{ runId?: string; ticketId?: string; sessionId?: string }> => {
+    (definitionId: string, requestId: string): Promise<{ runId?: string; ticketId?: string; sessionId?: string }> => {
       return new Promise((resolve, reject) => {
         const ws = wsRef.current;
         if (!ws || ws.readyState !== WebSocket.OPEN) {
           reject(new Error('WebSocket not connected'));
           return;
         }
-        // crypto.randomUUID(), not nextRequestID's counter scheme: the daemon
-        // persists this as ClaimManualAutomationRun's idempotency key
-        // (internal/daemon/automations.go automationRun), so a caller-side
-        // retry of the same click that reuses this id claims the same run
-        // instead of creating a duplicate.
-        const requestId = crypto.randomUUID();
+        // requestId is caller-owned (useAutomationsStore's
+        // ensureRunRequest), not nextRequestID's counter scheme: the daemon
+        // persists it as ClaimManualAutomationRun's idempotency key
+        // (internal/daemon/automations.go automationRun), so callers reuse
+        // the same id across a retry of the same click (e.g. after this
+        // promise rejects with AutomationActionTimeoutError) to claim the
+        // same run instead of creating a duplicate.
         const key = `automation:${requestId}`;
         pendingActionsRef.current.set(key, {
           resolve: (result: any) =>
@@ -5374,7 +5385,7 @@ export function useDaemonSocket({
         setTimeout(() => {
           if (pendingActionsRef.current.has(key)) {
             pendingActionsRef.current.delete(key);
-            reject(new Error('Run automation timed out'));
+            reject(new AutomationActionTimeoutError('Run automation timed out'));
           }
         }, 30000);
       });

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -27,6 +27,8 @@ import type {
   PresentCommentInput,
   PRRole,
   HeatState,
+  AutomationDefinitionSummary,
+  AutomationRunSummary,
 } from '../types/generated';
 import {
   emitPtyEvent,
@@ -61,6 +63,7 @@ import { resolveDaemonWebSocketURL, type DaemonEndpointProfile } from '../utils/
 import { BUILD_PROFILE, daemonProfileMatches, fetchDaemonHealthProfile, profileMismatchMessage } from '../utils/buildProfile';
 import { controlBrowserHost, serializeBrowserControlResultMessage } from '../browser/host';
 import { useWorkflowRunsStore } from '../store/workflowRuns';
+import { useAutomationsStore } from '../store/automations';
 
 // Short names for daemon payloads used throughout the app.
 export type DaemonSession = GeneratedSession;
@@ -2838,6 +2841,34 @@ export function useDaemonSocket({
             break;
           }
 
+          // Single generic result event for the automations WS surface
+          // (definitions_get / runs_get / set_enabled / run) — see
+          // AutomationActionResultMessage's doc comment. Correlated by
+          // request_id, not action, so concurrent calls (e.g. listing runs for
+          // two different definitions) never cross-resolve; each caller wraps
+          // its own extraction of the raw payload at registration time.
+          case 'automation_action_result': {
+            const requestId = data.request_id;
+            if (typeof requestId !== 'string') break;
+            const key = `automation:${requestId}`;
+            const pending = pendingActionsRef.current.get(key);
+            if (!pending) break;
+            pendingActionsRef.current.delete(key);
+            if ((data as any).success) {
+              pending.resolve(data);
+            } else {
+              pending.reject(new Error((data as any).error || 'Automation action failed'));
+            }
+            break;
+          }
+
+          // Canonical state stays daemon-side: this broadcast carries no
+          // payload views need. Bump the tick and let open views re-fetch.
+          case 'automations_changed': {
+            useAutomationsStore.getState().bumpChanged();
+            break;
+          }
+
           case 'command_error':
             if (data.error === 'daemon_recovering') {
               console.debug('[Daemon] Command deferred while daemon recovers:', data.cmd);
@@ -5229,6 +5260,110 @@ export function useDaemonSocket({
     });
   }, []);
 
+  const listAutomationDefinitions = useCallback((): Promise<AutomationDefinitionSummary[]> => {
+    return new Promise((resolve, reject) => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        reject(new Error('WebSocket not connected'));
+        return;
+      }
+      const requestId = nextRequestID('automation_definitions_get');
+      const key = `automation:${requestId}`;
+      pendingActionsRef.current.set(key, {
+        resolve: (result: any) => resolve((result.definitions ?? []) as AutomationDefinitionSummary[]),
+        reject,
+      });
+      ws.send(JSON.stringify({ cmd: 'automation_definitions_get', request_id: requestId }));
+      setTimeout(() => {
+        if (pendingActionsRef.current.has(key)) {
+          pendingActionsRef.current.delete(key);
+          reject(new Error('List automation definitions timed out'));
+        }
+      }, 10000);
+    });
+  }, [nextRequestID]);
+
+  const listAutomationRuns = useCallback((definitionId: string): Promise<AutomationRunSummary[]> => {
+    return new Promise((resolve, reject) => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        reject(new Error('WebSocket not connected'));
+        return;
+      }
+      const requestId = nextRequestID('automation_runs_get');
+      const key = `automation:${requestId}`;
+      pendingActionsRef.current.set(key, {
+        resolve: (result: any) => resolve((result.runs ?? []) as AutomationRunSummary[]),
+        reject,
+      });
+      ws.send(JSON.stringify({ cmd: 'automation_runs_get', definition_id: definitionId, request_id: requestId }));
+      setTimeout(() => {
+        if (pendingActionsRef.current.has(key)) {
+          pendingActionsRef.current.delete(key);
+          reject(new Error('List automation runs timed out'));
+        }
+      }, 10000);
+    });
+  }, [nextRequestID]);
+
+  const setAutomationEnabled = useCallback((definitionId: string, enabled: boolean): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        reject(new Error('WebSocket not connected'));
+        return;
+      }
+      const requestId = nextRequestID('automation_set_enabled');
+      const key = `automation:${requestId}`;
+      // Success carries the daemon's updated definition, but canonical state
+      // flows back through the automations_changed broadcast + refetch, not
+      // this promise — resolve void and let the caller's store stay
+      // untouched here.
+      pendingActionsRef.current.set(key, { resolve: () => resolve(undefined), reject });
+      ws.send(
+        JSON.stringify({ cmd: 'automation_set_enabled', definition_id: definitionId, enabled, request_id: requestId }),
+      );
+      setTimeout(() => {
+        if (pendingActionsRef.current.has(key)) {
+          pendingActionsRef.current.delete(key);
+          reject(new Error('Set automation enabled timed out'));
+        }
+      }, 10000);
+    });
+  }, [nextRequestID]);
+
+  const runAutomationNow = useCallback(
+    (definitionId: string): Promise<{ runId?: string; ticketId?: string; sessionId?: string }> => {
+      return new Promise((resolve, reject) => {
+        const ws = wsRef.current;
+        if (!ws || ws.readyState !== WebSocket.OPEN) {
+          reject(new Error('WebSocket not connected'));
+          return;
+        }
+        // crypto.randomUUID(), not nextRequestID's counter scheme: the daemon
+        // persists this as ClaimManualAutomationRun's idempotency key
+        // (internal/daemon/automations.go automationRun), so a caller-side
+        // retry of the same click that reuses this id claims the same run
+        // instead of creating a duplicate.
+        const requestId = crypto.randomUUID();
+        const key = `automation:${requestId}`;
+        pendingActionsRef.current.set(key, {
+          resolve: (result: any) =>
+            resolve({ runId: result.run_id, ticketId: result.ticket_id, sessionId: result.session_id }),
+          reject,
+        });
+        ws.send(JSON.stringify({ cmd: 'automation_run', definition_id: definitionId, request_id: requestId }));
+        setTimeout(() => {
+          if (pendingActionsRef.current.has(key)) {
+            pendingActionsRef.current.delete(key);
+            reject(new Error('Run automation timed out'));
+          }
+        }, 10000);
+      });
+    },
+    [],
+  );
+
   // Fetch the current open/closed presentations (for the main-window banner).
   const getPresentations = useCallback((): Promise<Presentation[]> => {
     return new Promise((resolve, reject) => {
@@ -5463,6 +5598,10 @@ export function useDaemonSocket({
     getRepoInfo,
     getWorkflowRun,
     listWorkflowRuns,
+    listAutomationDefinitions,
+    listAutomationRuns,
+    setAutomationEnabled,
+    runAutomationNow,
     getPresentations,
     getPresentationRound,
     submitPresentationRound,

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -170,7 +170,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '175';
+export const PROTOCOL_VERSION = '176';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -1304,6 +1304,12 @@ export function useDaemonSocket({
             }
             hasReceivedInitialStateRef.current = true;
             setHasReceivedInitialState(true);
+            // Automations aren't part of initial_state (they're pulled on
+            // demand via automation_definitions_list), so a panel open across
+            // a daemon restart/reconnect never sees a fresh event to refetch
+            // on. Bump changedTick on every (re)connect so an open panel
+            // re-reads instead of staying on a stale error.
+            useAutomationsStore.getState().bumpChanged();
             flushQueuedCommands(ws);
             requestTileContentsForWorkspaces(ws, nextWorkspaces);
             // The daemon's terminal theme is in-memory only, so a restarted
@@ -5274,12 +5280,15 @@ export function useDaemonSocket({
         reject,
       });
       ws.send(JSON.stringify({ cmd: 'automation_definitions_get', request_id: requestId }));
+      // Mutations can serialize behind an in-flight automation delivery
+      // (daemon holds automationMu across full run delivery); 30s matches the
+      // repo's async-action convention.
       setTimeout(() => {
         if (pendingActionsRef.current.has(key)) {
           pendingActionsRef.current.delete(key);
           reject(new Error('List automation definitions timed out'));
         }
-      }, 10000);
+      }, 30000);
     });
   }, [nextRequestID]);
 
@@ -5297,12 +5306,15 @@ export function useDaemonSocket({
         reject,
       });
       ws.send(JSON.stringify({ cmd: 'automation_runs_get', definition_id: definitionId, request_id: requestId }));
+      // Mutations can serialize behind an in-flight automation delivery
+      // (daemon holds automationMu across full run delivery); 30s matches the
+      // repo's async-action convention.
       setTimeout(() => {
         if (pendingActionsRef.current.has(key)) {
           pendingActionsRef.current.delete(key);
           reject(new Error('List automation runs timed out'));
         }
-      }, 10000);
+      }, 30000);
     });
   }, [nextRequestID]);
 
@@ -5323,12 +5335,15 @@ export function useDaemonSocket({
       ws.send(
         JSON.stringify({ cmd: 'automation_set_enabled', definition_id: definitionId, enabled, request_id: requestId }),
       );
+      // Mutations can serialize behind an in-flight automation delivery
+      // (daemon holds automationMu across full run delivery); 30s matches the
+      // repo's async-action convention.
       setTimeout(() => {
         if (pendingActionsRef.current.has(key)) {
           pendingActionsRef.current.delete(key);
           reject(new Error('Set automation enabled timed out'));
         }
-      }, 10000);
+      }, 30000);
     });
   }, [nextRequestID]);
 
@@ -5353,12 +5368,15 @@ export function useDaemonSocket({
           reject,
         });
         ws.send(JSON.stringify({ cmd: 'automation_run', definition_id: definitionId, request_id: requestId }));
+        // Mutations can serialize behind an in-flight automation delivery
+        // (daemon holds automationMu across full run delivery); 30s matches
+        // the repo's async-action convention.
         setTimeout(() => {
           if (pendingActionsRef.current.has(key)) {
             pendingActionsRef.current.delete(key);
             reject(new Error('Run automation timed out'));
           }
-        }, 10000);
+        }, 30000);
       });
     },
     [],

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -98,6 +98,10 @@ interface UseUiAutomationBridgeArgs {
   openTicketDetail?: (ticketId: string) => void;
   closeTicketDetail?: () => void;
   tickets?: Ticket[];
+  // Automations panel (profile-level). Mutation verbs drive the real panel
+  // controls (toggle/run-now/select), same rationale as the ticket panel
+  // above; the bridge only needs to open the dock and read the rendered DOM.
+  openAutomationsPanel?: () => void;
   // Presentation notices (pane-header review chips). Read-only for the
   // bridge: the chip DOM is the source of truth for what's actually rendered.
   presentationNotices?: Presentation[];
@@ -1252,6 +1256,52 @@ function collectTicketDetailUiState() {
   };
 }
 
+// Serialize what AutomationsPanel is actually rendering: definition rows
+// (with enabled/failure/inline-error state) and, when a definition is
+// selected, its run history. Mirrors collectTicketDetailUiState above.
+function collectAutomationsUiState() {
+  const panel = document.querySelector('[data-testid="automations-panel"]');
+  if (!(panel instanceof HTMLElement)) {
+    return { present: false };
+  }
+  const definitionRows = Array.from(
+    panel.querySelectorAll('[data-testid="automation-definition-row"]'),
+  );
+  const definitions = definitionRows.map((row) => {
+    const id = row.getAttribute('data-definition-id') ?? '';
+    const toggle = row.querySelector(`[data-testid="automation-toggle-${id}"]`);
+    return {
+      id,
+      name: row.querySelector('.automations-panel__name')?.textContent?.trim() ?? '',
+      trigger: row.querySelector('.automations-panel__trigger')?.textContent?.trim() ?? '',
+      enabled: toggle instanceof HTMLInputElement ? toggle.checked : false,
+      selected: row.classList.contains('is-selected'),
+      failed: Boolean(row.querySelector(`[data-testid="automation-failure-badge-${id}"]`)),
+      canRunNow: Boolean(row.querySelector(`[data-testid="automation-run-now-${id}"]`)),
+      toggleError:
+        row.querySelector(`[data-testid="automation-toggle-error-${id}"]`)?.textContent?.trim() ?? '',
+      runError:
+        row.querySelector(`[data-testid="automation-run-error-${id}"]`)?.textContent?.trim() ?? '',
+    };
+  });
+  const runsSection = panel.querySelector('[data-testid="automations-panel-runs"]');
+  const runs = runsSection
+    ? Array.from(runsSection.querySelectorAll('[data-testid="automation-run-row"]')).map((row) => ({
+        id: row.getAttribute('data-run-id') ?? '',
+        state: row.getAttribute('data-state') ?? '',
+        navigable: Boolean(row.querySelector('button.automations-panel__run-row-main')),
+        lastError: row.querySelector('.automations-panel__run-error')?.textContent?.trim() ?? '',
+      }))
+    : [];
+  return {
+    present: true,
+    empty: Boolean(panel.querySelector('[data-testid="automations-panel-empty"]')),
+    error: panel.querySelector('[data-testid="automations-panel-error"]')?.textContent?.trim() ?? '',
+    definitions,
+    runs,
+  };
+}
+
 function getLocationPickerRoot() {
   const root = document.querySelector('[data-testid="location-picker"]');
   return root instanceof HTMLElement ? root : null;
@@ -1556,6 +1606,7 @@ export function useUiAutomationBridge({
   openTicketDetail,
   closeTicketDetail,
   tickets,
+  openAutomationsPanel,
   presentationNotices,
   resetSessionPaneTerminal,
   injectSessionPaneBytes,
@@ -2604,6 +2655,46 @@ export function useUiAutomationBridge({
         clickTestId('ticket-resume');
         await settleUi(2);
         return { ok: true };
+      }
+      // Automations panel (profile-level). Mutations drive the real rendered
+      // controls (checkbox/button clicks), same convention as the ticket_*
+      // verbs above; automations_get_state is the read-only DOM snapshot.
+      case 'automations_open_panel': {
+        if (!openAutomationsPanel) {
+          throw new Error('automations_open_panel is not configured');
+        }
+        openAutomationsPanel();
+        await settleUi(3);
+        return collectAutomationsUiState();
+      }
+      case 'automations_get_state':
+        return collectAutomationsUiState();
+      case 'automations_toggle_enabled': {
+        const definitionId = typeof payload.definitionId === 'string' ? payload.definitionId : '';
+        if (!definitionId) {
+          throw new Error('automations_toggle_enabled requires definitionId');
+        }
+        clickTestId(`automation-toggle-${definitionId}`);
+        await settleUi(3);
+        return collectAutomationsUiState();
+      }
+      case 'automations_run_now': {
+        const definitionId = typeof payload.definitionId === 'string' ? payload.definitionId : '';
+        if (!definitionId) {
+          throw new Error('automations_run_now requires definitionId');
+        }
+        clickTestId(`automation-run-now-${definitionId}`);
+        await settleUi(3);
+        return collectAutomationsUiState();
+      }
+      case 'automations_select_definition': {
+        const definitionId = typeof payload.definitionId === 'string' ? payload.definitionId : '';
+        if (!definitionId) {
+          throw new Error('automations_select_definition requires definitionId');
+        }
+        clickTestId(`automation-definition-select-${definitionId}`);
+        await settleUi(3);
+        return collectAutomationsUiState();
       }
       case 'click_nudge_trigger': {
         // The "deliver now" trigger renders only in NudgeIndicator's paused mode

--- a/app/src/store/automations.test.ts
+++ b/app/src/store/automations.test.ts
@@ -128,6 +128,26 @@ describe('useAutomationsStore', () => {
     store.reset();
     expect(useAutomationsStore.getState().pendingRunRequests).toEqual({});
   });
+
+  it('adoptRunRequest stores the key when none is present for the definition', () => {
+    const store = useAutomationsStore.getState();
+    store.adoptRunRequest('d1', 'restart-key-1');
+    expect(useAutomationsStore.getState().pendingRunRequests['d1']).toBe('restart-key-1');
+  });
+
+  it('adoptRunRequest never overwrites an already-stored key', () => {
+    const store = useAutomationsStore.getState();
+    const existing = store.ensureRunRequest('d1');
+    store.adoptRunRequest('d1', 'some-other-key');
+    expect(useAutomationsStore.getState().pendingRunRequests['d1']).toBe(existing);
+  });
+
+  it('adoptRunRequest is cleared by reset', () => {
+    const store = useAutomationsStore.getState();
+    store.adoptRunRequest('d1', 'restart-key-1');
+    store.reset();
+    expect(useAutomationsStore.getState().pendingRunRequests).toEqual({});
+  });
 });
 
 describe('selectDefinitionById', () => {

--- a/app/src/store/automations.test.ts
+++ b/app/src/store/automations.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  useAutomationsStore,
+  selectDefinitionById,
+  selectLatestRunForDefinition,
+} from './automations';
+import { AutomationDefinitionSummary, AutomationRunSummary } from '../types/generated';
+
+function makeDefinition(
+  overrides: Partial<AutomationDefinitionSummary> & { id: string },
+): AutomationDefinitionSummary {
+  return {
+    name: 'PR reviewer',
+    enabled: true,
+    revision: 1,
+    trigger_type: 'manual',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as AutomationDefinitionSummary;
+}
+
+function makeRun(
+  overrides: Partial<AutomationRunSummary> & { id: string },
+): AutomationRunSummary {
+  return {
+    definition_id: 'd1',
+    definition_revision: 1,
+    state: 'pending',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as AutomationRunSummary;
+}
+
+describe('useAutomationsStore', () => {
+  beforeEach(() => {
+    useAutomationsStore.getState().reset();
+  });
+
+  it('setDefinitions replaces the definitions list', () => {
+    useAutomationsStore.getState().setDefinitions([makeDefinition({ id: 'd1' }), makeDefinition({ id: 'd2' })]);
+    expect(useAutomationsStore.getState().definitions.map((d) => d.id)).toEqual(['d1', 'd2']);
+  });
+
+  it('setDefinitions with an empty/undefined list clears to []', () => {
+    useAutomationsStore.getState().setDefinitions([makeDefinition({ id: 'd1' })]);
+    useAutomationsStore.getState().setDefinitions(undefined as unknown as AutomationDefinitionSummary[]);
+    expect(useAutomationsStore.getState().definitions).toEqual([]);
+  });
+
+  it('setRuns stores runs keyed by definition_id', () => {
+    useAutomationsStore.getState().setRuns('d1', [makeRun({ id: 'r1' }), makeRun({ id: 'r2' })]);
+    const runs = useAutomationsStore.getState().runsByDefinition;
+    expect(runs['d1']?.map((r) => r.id)).toEqual(['r1', 'r2']);
+  });
+
+  it('setRuns ignores an empty definitionId', () => {
+    useAutomationsStore.getState().setRuns('', [makeRun({ id: 'r1' })]);
+    expect(useAutomationsStore.getState().runsByDefinition).toEqual({});
+  });
+
+  it('setRuns for one definition leaves another definition untouched', () => {
+    const store = useAutomationsStore.getState();
+    store.setRuns('d1', [makeRun({ id: 'r1' })]);
+    store.setRuns('d2', [makeRun({ id: 'r2' })]);
+    const runs = useAutomationsStore.getState().runsByDefinition;
+    expect(runs['d1']?.map((r) => r.id)).toEqual(['r1']);
+    expect(runs['d2']?.map((r) => r.id)).toEqual(['r2']);
+  });
+
+  it('re-setting runs for a definition replaces its prior entry', () => {
+    const store = useAutomationsStore.getState();
+    store.setRuns('d1', [makeRun({ id: 'r1' })]);
+    store.setRuns('d1', [makeRun({ id: 'r2' })]);
+    expect(useAutomationsStore.getState().runsByDefinition['d1']?.map((r) => r.id)).toEqual(['r2']);
+  });
+
+  it('bumpChanged increments changedTick', () => {
+    expect(useAutomationsStore.getState().changedTick).toBe(0);
+    useAutomationsStore.getState().bumpChanged();
+    useAutomationsStore.getState().bumpChanged();
+    expect(useAutomationsStore.getState().changedTick).toBe(2);
+  });
+
+  it('reset clears definitions, runs, and changedTick', () => {
+    const store = useAutomationsStore.getState();
+    store.setDefinitions([makeDefinition({ id: 'd1' })]);
+    store.setRuns('d1', [makeRun({ id: 'r1' })]);
+    store.bumpChanged();
+    store.reset();
+    const state = useAutomationsStore.getState();
+    expect(state.definitions).toEqual([]);
+    expect(state.runsByDefinition).toEqual({});
+    expect(state.changedTick).toBe(0);
+  });
+});
+
+describe('selectDefinitionById', () => {
+  it('returns null when definitionId is empty/undefined', () => {
+    const definitions = [makeDefinition({ id: 'd1' })];
+    expect(selectDefinitionById(definitions, null)).toBeNull();
+    expect(selectDefinitionById(definitions, undefined)).toBeNull();
+    expect(selectDefinitionById(definitions, '')).toBeNull();
+  });
+
+  it('returns null when no definition matches', () => {
+    expect(selectDefinitionById([makeDefinition({ id: 'd1' })], 'd2')).toBeNull();
+  });
+
+  it('returns the matching definition', () => {
+    const definitions = [makeDefinition({ id: 'd1' }), makeDefinition({ id: 'd2', name: 'Second' })];
+    expect(selectDefinitionById(definitions, 'd2')?.name).toBe('Second');
+  });
+});
+
+describe('selectLatestRunForDefinition', () => {
+  it('returns null when runs is undefined or empty', () => {
+    expect(selectLatestRunForDefinition(undefined)).toBeNull();
+    expect(selectLatestRunForDefinition([])).toBeNull();
+  });
+
+  it('picks the most recently created run', () => {
+    const runs = [
+      makeRun({ id: 'r1', created_at: '2026-01-01T00:00:00Z' }),
+      makeRun({ id: 'r2', created_at: '2026-01-03T00:00:00Z' }),
+      makeRun({ id: 'r3', created_at: '2026-01-02T00:00:00Z' }),
+    ];
+    expect(selectLatestRunForDefinition(runs)?.id).toBe('r2');
+  });
+});

--- a/app/src/store/automations.test.ts
+++ b/app/src/store/automations.test.ts
@@ -93,6 +93,41 @@ describe('useAutomationsStore', () => {
     expect(state.runsByDefinition).toEqual({});
     expect(state.changedTick).toBe(0);
   });
+
+  it('ensureRunRequest returns a stable id for a definition until cleared', () => {
+    const store = useAutomationsStore.getState();
+    const first = store.ensureRunRequest('d1');
+    const second = store.ensureRunRequest('d1');
+    expect(second).toBe(first);
+    expect(useAutomationsStore.getState().pendingRunRequests['d1']).toBe(first);
+
+    store.clearRunRequest('d1');
+    expect(useAutomationsStore.getState().pendingRunRequests['d1']).toBeUndefined();
+
+    const third = store.ensureRunRequest('d1');
+    expect(third).not.toBe(first);
+  });
+
+  it('ensureRunRequest tracks separate ids per definition', () => {
+    const store = useAutomationsStore.getState();
+    const d1 = store.ensureRunRequest('d1');
+    const d2 = store.ensureRunRequest('d2');
+    expect(d1).not.toBe(d2);
+    expect(useAutomationsStore.getState().pendingRunRequests).toEqual({ d1, d2 });
+  });
+
+  it('clearRunRequest is a no-op when there is no pending request', () => {
+    const store = useAutomationsStore.getState();
+    store.clearRunRequest('does-not-exist');
+    expect(useAutomationsStore.getState().pendingRunRequests).toEqual({});
+  });
+
+  it('reset clears pendingRunRequests', () => {
+    const store = useAutomationsStore.getState();
+    store.ensureRunRequest('d1');
+    store.reset();
+    expect(useAutomationsStore.getState().pendingRunRequests).toEqual({});
+  });
 });
 
 describe('selectDefinitionById', () => {

--- a/app/src/store/automations.ts
+++ b/app/src/store/automations.ts
@@ -1,0 +1,69 @@
+import { create } from 'zustand';
+import { AutomationDefinitionSummary, AutomationRunSummary } from '../types/generated';
+
+interface AutomationsStore {
+  // All automation definitions for the profile, as last fetched via
+  // automation_definitions_get. Empty until the panel's first fetch resolves.
+  definitions: AutomationDefinitionSummary[];
+
+  // Runs per definition, keyed by definition_id, as last fetched via
+  // automation_runs_get. A definition with no entry has not been fetched yet
+  // (distinct from an entry of []: no runs exist).
+  runsByDefinition: Record<string, AutomationRunSummary[]>;
+
+  // Bumped by the automations_changed broadcast handler. Views watch this to
+  // know when to re-fetch; it carries no data of its own.
+  changedTick: number;
+
+  setDefinitions: (definitions: AutomationDefinitionSummary[]) => void;
+  setRuns: (definitionId: string, runs: AutomationRunSummary[]) => void;
+  bumpChanged: () => void;
+
+  // Clears the store (test convenience).
+  reset: () => void;
+}
+
+export const useAutomationsStore = create<AutomationsStore>((set) => ({
+  definitions: [],
+  runsByDefinition: {},
+  changedTick: 0,
+
+  setDefinitions: (definitions) => set({ definitions: definitions ?? [] }),
+
+  setRuns: (definitionId, runs) =>
+    set((state) => {
+      if (!definitionId) return state;
+      return { runsByDefinition: { ...state.runsByDefinition, [definitionId]: runs ?? [] } };
+    }),
+
+  bumpChanged: () => set((state) => ({ changedTick: state.changedTick + 1 })),
+
+  reset: () => set({ definitions: [], runsByDefinition: {}, changedTick: 0 }),
+}));
+
+// selectDefinitionById returns the definition with the given id, or null.
+// Pure and unit-testable so AutomationsPanel stays a thin selector over the
+// slice.
+export function selectDefinitionById(
+  definitions: AutomationDefinitionSummary[],
+  definitionId: string | null | undefined,
+): AutomationDefinitionSummary | null {
+  if (!definitionId) return null;
+  return definitions.find((definition) => definition.id === definitionId) ?? null;
+}
+
+// selectLatestRunForDefinition returns the most recently created run in
+// `runs`, or null when there are none. created_at is an ISO-8601 string so a
+// lexicographic max is a correct chronological max. Used for the definitions
+// list's failure badge, which reflects each definition's latest run without
+// requiring the user to expand it.
+export function selectLatestRunForDefinition(
+  runs: AutomationRunSummary[] | undefined,
+): AutomationRunSummary | null {
+  if (!runs || runs.length === 0) return null;
+  let latest: AutomationRunSummary | null = null;
+  for (const run of runs) {
+    if (!latest || run.created_at > latest.created_at) latest = run;
+  }
+  return latest;
+}

--- a/app/src/store/automations.ts
+++ b/app/src/store/automations.ts
@@ -15,18 +15,32 @@ interface AutomationsStore {
   // know when to re-fetch; it carries no data of its own.
   changedTick: number;
 
+  // The run-now idempotency key currently in flight per definition, keyed by
+  // definition_id. The daemon persists this as ClaimManualAutomationRun's
+  // dedup key (occurrence_key "manual:<key>"), so a client-side retry of the
+  // same click must reuse it rather than minting a fresh crypto.randomUUID()
+  // — otherwise a run-now that times out client-side but still delivers on
+  // the daemon can be re-triggered as a duplicate run by an impatient second
+  // click. Populated by ensureRunRequest, cleared by clearRunRequest once the
+  // run reaches a terminal state (delivered/failed) or a definitive daemon
+  // rejection makes retrying pointless.
+  pendingRunRequests: Record<string, string>;
+
   setDefinitions: (definitions: AutomationDefinitionSummary[]) => void;
   setRuns: (definitionId: string, runs: AutomationRunSummary[]) => void;
   bumpChanged: () => void;
+  ensureRunRequest: (definitionId: string) => string;
+  clearRunRequest: (definitionId: string) => void;
 
   // Clears the store (test convenience).
   reset: () => void;
 }
 
-export const useAutomationsStore = create<AutomationsStore>((set) => ({
+export const useAutomationsStore = create<AutomationsStore>((set, get) => ({
   definitions: [],
   runsByDefinition: {},
   changedTick: 0,
+  pendingRunRequests: {},
 
   setDefinitions: (definitions) => set({ definitions: definitions ?? [] }),
 
@@ -38,7 +52,23 @@ export const useAutomationsStore = create<AutomationsStore>((set) => ({
 
   bumpChanged: () => set((state) => ({ changedTick: state.changedTick + 1 })),
 
-  reset: () => set({ definitions: [], runsByDefinition: {}, changedTick: 0 }),
+  ensureRunRequest: (definitionId) => {
+    const existing = get().pendingRunRequests[definitionId];
+    if (existing) return existing;
+    const requestId = crypto.randomUUID();
+    set((state) => ({ pendingRunRequests: { ...state.pendingRunRequests, [definitionId]: requestId } }));
+    return requestId;
+  },
+
+  clearRunRequest: (definitionId) =>
+    set((state) => {
+      if (!(definitionId in state.pendingRunRequests)) return state;
+      const next = { ...state.pendingRunRequests };
+      delete next[definitionId];
+      return { pendingRunRequests: next };
+    }),
+
+  reset: () => set({ definitions: [], runsByDefinition: {}, changedTick: 0, pendingRunRequests: {} }),
 }));
 
 // selectDefinitionById returns the definition with the given id, or null.

--- a/app/src/store/automations.ts
+++ b/app/src/store/automations.ts
@@ -24,6 +24,12 @@ interface AutomationsStore {
   // click. Populated by ensureRunRequest, cleared by clearRunRequest once the
   // run reaches a terminal state (delivered/failed) or a definitive daemon
   // rejection makes retrying pointless.
+  //
+  // This map is in-memory only and does not survive an app relaunch. The key
+  // still has to be recoverable afterward: an unsettled durable run persists
+  // in the daemon's SQLite state regardless of what this store remembers, so
+  // canonical run history (not a local persistence layer) is the recovery
+  // source — see adoptRunRequest.
   pendingRunRequests: Record<string, string>;
 
   setDefinitions: (definitions: AutomationDefinitionSummary[]) => void;
@@ -31,6 +37,12 @@ interface AutomationsStore {
   bumpChanged: () => void;
   ensureRunRequest: (definitionId: string) => string;
   clearRunRequest: (definitionId: string) => void;
+
+  // adoptRunRequest recovers a pending run's request id when this session's
+  // store has none for definitionId (e.g. right after an app relaunch). It
+  // never overwrites an already-stored key: a key already in flight for this
+  // session is more current than anything derived from a later fetch.
+  adoptRunRequest: (definitionId: string, requestId: string) => void;
 
   // Clears the store (test convenience).
   reset: () => void;
@@ -66,6 +78,12 @@ export const useAutomationsStore = create<AutomationsStore>((set, get) => ({
       const next = { ...state.pendingRunRequests };
       delete next[definitionId];
       return { pendingRunRequests: next };
+    }),
+
+  adoptRunRequest: (definitionId, requestId) =>
+    set((state) => {
+      if (state.pendingRunRequests[definitionId]) return state;
+      return { pendingRunRequests: { ...state.pendingRunRequests, [definitionId]: requestId } };
     }),
 
   reset: () => set({ definitions: [], runsByDefinition: {}, changedTick: 0, pendingRunRequests: {} }),

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationListMessage, AutomationRunListMessage, AutomationRunMessage, AutomationShowMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, AutomationActionResultMessage, AutomationApplyMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationListMessage, AutomationRunListMessage, AutomationRunMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationSetEnabledMessage, AutomationShowMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -9,11 +9,18 @@
 //   const attachSessionMessage = Convert.toAttachSessionMessage(json);
 //   const authorState = Convert.toAuthorState(json);
 //   const authorsUpdatedMessage = Convert.toAuthorsUpdatedMessage(json);
+//   const automationActionResultMessage = Convert.toAutomationActionResultMessage(json);
 //   const automationApplyMessage = Convert.toAutomationApplyMessage(json);
+//   const automationDefinitionSummary = Convert.toAutomationDefinitionSummary(json);
+//   const automationDefinitionsGetMessage = Convert.toAutomationDefinitionsGetMessage(json);
 //   const automationListMessage = Convert.toAutomationListMessage(json);
 //   const automationRunListMessage = Convert.toAutomationRunListMessage(json);
 //   const automationRunMessage = Convert.toAutomationRunMessage(json);
+//   const automationRunSummary = Convert.toAutomationRunSummary(json);
+//   const automationRunsGetMessage = Convert.toAutomationRunsGetMessage(json);
+//   const automationSetEnabledMessage = Convert.toAutomationSetEnabledMessage(json);
 //   const automationShowMessage = Convert.toAutomationShowMessage(json);
+//   const automationsChangedMessage = Convert.toAutomationsChangedMessage(json);
 //   const bootstrapEndpointMessage = Convert.toBootstrapEndpointMessage(json);
 //   const branch = Convert.toBranch(json);
 //   const branchChangedMessage = Convert.toBranchChangedMessage(json);
@@ -462,6 +469,56 @@ export enum AuthorsUpdatedMessageEvent {
     AuthorsUpdated = "authors_updated",
 }
 
+export interface AutomationActionResultMessage {
+    action:       string;
+    definitions?: Items[];
+    error?:       string;
+    event:        AutomationActionResultMessageEvent;
+    request_id?:  string;
+    run_id?:      string;
+    runs?:        RunElement[];
+    session_id?:  string;
+    success:      boolean;
+    ticket_id?:   string;
+    truncated?:   boolean;
+    [property: string]: any;
+}
+
+export interface Items {
+    catch_up?:           string;
+    continuity?:         string;
+    enabled:             boolean;
+    id:                  string;
+    name:                string;
+    revision:            number;
+    schedule_cron?:      string;
+    schedule_time_zone?: string;
+    trigger_type:        string;
+    updated_at:          string;
+    [property: string]: any;
+}
+
+export enum AutomationActionResultMessageEvent {
+    AutomationActionResult = "automation_action_result",
+}
+
+export interface RunElement {
+    created_at:          string;
+    definition_id:       string;
+    definition_revision: number;
+    delivered_at?:       string;
+    id:                  string;
+    last_error?:         string;
+    occurrence_key?:     string;
+    pane_id?:            string;
+    session_id?:         string;
+    state:               string;
+    ticket_id?:          string;
+    updated_at:          string;
+    workspace_id?:       string;
+    [property: string]: any;
+}
+
 export interface AutomationApplyMessage {
     cmd:             AutomationApplyMessageCmd;
     definition_yaml: string;
@@ -470,6 +527,30 @@ export interface AutomationApplyMessage {
 
 export enum AutomationApplyMessageCmd {
     AutomationApply = "automation_apply",
+}
+
+export interface AutomationDefinitionSummary {
+    catch_up?:           string;
+    continuity?:         string;
+    enabled:             boolean;
+    id:                  string;
+    name:                string;
+    revision:            number;
+    schedule_cron?:      string;
+    schedule_time_zone?: string;
+    trigger_type:        string;
+    updated_at:          string;
+    [property: string]: any;
+}
+
+export interface AutomationDefinitionsGetMessage {
+    cmd:         AutomationDefinitionsGetMessageCmd;
+    request_id?: string;
+    [property: string]: any;
+}
+
+export enum AutomationDefinitionsGetMessageCmd {
+    AutomationDefinitionsGet = "automation_definitions_get",
 }
 
 export interface AutomationListMessage {
@@ -504,6 +585,46 @@ export enum AutomationRunMessageCmd {
     AutomationRun = "automation_run",
 }
 
+export interface AutomationRunSummary {
+    created_at:          string;
+    definition_id:       string;
+    definition_revision: number;
+    delivered_at?:       string;
+    id:                  string;
+    last_error?:         string;
+    occurrence_key?:     string;
+    pane_id?:            string;
+    session_id?:         string;
+    state:               string;
+    ticket_id?:          string;
+    updated_at:          string;
+    workspace_id?:       string;
+    [property: string]: any;
+}
+
+export interface AutomationRunsGetMessage {
+    cmd:           AutomationRunsGetMessageCmd;
+    definition_id: string;
+    request_id?:   string;
+    [property: string]: any;
+}
+
+export enum AutomationRunsGetMessageCmd {
+    AutomationRunsGet = "automation_runs_get",
+}
+
+export interface AutomationSetEnabledMessage {
+    cmd:           AutomationSetEnabledMessageCmd;
+    definition_id: string;
+    enabled:       boolean;
+    request_id?:   string;
+    [property: string]: any;
+}
+
+export enum AutomationSetEnabledMessageCmd {
+    AutomationSetEnabled = "automation_set_enabled",
+}
+
 export interface AutomationShowMessage {
     cmd:           AutomationShowMessageCmd;
     definition_id: string;
@@ -512,6 +633,16 @@ export interface AutomationShowMessage {
 
 export enum AutomationShowMessageCmd {
     AutomationShow = "automation_show",
+}
+
+export interface AutomationsChangedMessage {
+    definition_ids: string[];
+    event:          AutomationsChangedMessageEvent;
+    [property: string]: any;
+}
+
+export enum AutomationsChangedMessageEvent {
+    AutomationsChanged = "automations_changed",
 }
 
 export interface BootstrapEndpointMessage {
@@ -5331,12 +5462,36 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AuthorsUpdatedMessage")), null, 2);
     }
 
+    public static toAutomationActionResultMessage(json: string): AutomationActionResultMessage {
+        return cast(JSON.parse(json), r("AutomationActionResultMessage"));
+    }
+
+    public static automationActionResultMessageToJson(value: AutomationActionResultMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationActionResultMessage")), null, 2);
+    }
+
     public static toAutomationApplyMessage(json: string): AutomationApplyMessage {
         return cast(JSON.parse(json), r("AutomationApplyMessage"));
     }
 
     public static automationApplyMessageToJson(value: AutomationApplyMessage): string {
         return JSON.stringify(uncast(value, r("AutomationApplyMessage")), null, 2);
+    }
+
+    public static toAutomationDefinitionSummary(json: string): AutomationDefinitionSummary {
+        return cast(JSON.parse(json), r("AutomationDefinitionSummary"));
+    }
+
+    public static automationDefinitionSummaryToJson(value: AutomationDefinitionSummary): string {
+        return JSON.stringify(uncast(value, r("AutomationDefinitionSummary")), null, 2);
+    }
+
+    public static toAutomationDefinitionsGetMessage(json: string): AutomationDefinitionsGetMessage {
+        return cast(JSON.parse(json), r("AutomationDefinitionsGetMessage"));
+    }
+
+    public static automationDefinitionsGetMessageToJson(value: AutomationDefinitionsGetMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationDefinitionsGetMessage")), null, 2);
     }
 
     public static toAutomationListMessage(json: string): AutomationListMessage {
@@ -5363,12 +5518,44 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AutomationRunMessage")), null, 2);
     }
 
+    public static toAutomationRunSummary(json: string): AutomationRunSummary {
+        return cast(JSON.parse(json), r("AutomationRunSummary"));
+    }
+
+    public static automationRunSummaryToJson(value: AutomationRunSummary): string {
+        return JSON.stringify(uncast(value, r("AutomationRunSummary")), null, 2);
+    }
+
+    public static toAutomationRunsGetMessage(json: string): AutomationRunsGetMessage {
+        return cast(JSON.parse(json), r("AutomationRunsGetMessage"));
+    }
+
+    public static automationRunsGetMessageToJson(value: AutomationRunsGetMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationRunsGetMessage")), null, 2);
+    }
+
+    public static toAutomationSetEnabledMessage(json: string): AutomationSetEnabledMessage {
+        return cast(JSON.parse(json), r("AutomationSetEnabledMessage"));
+    }
+
+    public static automationSetEnabledMessageToJson(value: AutomationSetEnabledMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationSetEnabledMessage")), null, 2);
+    }
+
     public static toAutomationShowMessage(json: string): AutomationShowMessage {
         return cast(JSON.parse(json), r("AutomationShowMessage"));
     }
 
     public static automationShowMessageToJson(value: AutomationShowMessage): string {
         return JSON.stringify(uncast(value, r("AutomationShowMessage")), null, 2);
+    }
+
+    public static toAutomationsChangedMessage(json: string): AutomationsChangedMessage {
+        return cast(JSON.parse(json), r("AutomationsChangedMessage"));
+    }
+
+    public static automationsChangedMessageToJson(value: AutomationsChangedMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationsChangedMessage")), null, 2);
     }
 
     public static toBootstrapEndpointMessage(json: string): BootstrapEndpointMessage {
@@ -8370,9 +8557,65 @@ const typeMap: any = {
         { json: "author", js: "author", typ: "" },
         { json: "muted", js: "muted", typ: true },
     ], "any"),
+    "AutomationActionResultMessage": o([
+        { json: "action", js: "action", typ: "" },
+        { json: "definitions", js: "definitions", typ: u(undefined, a(r("Items"))) },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("AutomationActionResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "run_id", js: "run_id", typ: u(undefined, "") },
+        { json: "runs", js: "runs", typ: u(undefined, a(r("RunElement"))) },
+        { json: "session_id", js: "session_id", typ: u(undefined, "") },
+        { json: "success", js: "success", typ: true },
+        { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
+        { json: "truncated", js: "truncated", typ: u(undefined, true) },
+    ], "any"),
+    "Items": o([
+        { json: "catch_up", js: "catch_up", typ: u(undefined, "") },
+        { json: "continuity", js: "continuity", typ: u(undefined, "") },
+        { json: "enabled", js: "enabled", typ: true },
+        { json: "id", js: "id", typ: "" },
+        { json: "name", js: "name", typ: "" },
+        { json: "revision", js: "revision", typ: 0 },
+        { json: "schedule_cron", js: "schedule_cron", typ: u(undefined, "") },
+        { json: "schedule_time_zone", js: "schedule_time_zone", typ: u(undefined, "") },
+        { json: "trigger_type", js: "trigger_type", typ: "" },
+        { json: "updated_at", js: "updated_at", typ: "" },
+    ], "any"),
+    "RunElement": o([
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "definition_id", js: "definition_id", typ: "" },
+        { json: "definition_revision", js: "definition_revision", typ: 0 },
+        { json: "delivered_at", js: "delivered_at", typ: u(undefined, "") },
+        { json: "id", js: "id", typ: "" },
+        { json: "last_error", js: "last_error", typ: u(undefined, "") },
+        { json: "occurrence_key", js: "occurrence_key", typ: u(undefined, "") },
+        { json: "pane_id", js: "pane_id", typ: u(undefined, "") },
+        { json: "session_id", js: "session_id", typ: u(undefined, "") },
+        { json: "state", js: "state", typ: "" },
+        { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
+        { json: "updated_at", js: "updated_at", typ: "" },
+        { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
+    ], "any"),
     "AutomationApplyMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationApplyMessageCmd") },
         { json: "definition_yaml", js: "definition_yaml", typ: "" },
+    ], "any"),
+    "AutomationDefinitionSummary": o([
+        { json: "catch_up", js: "catch_up", typ: u(undefined, "") },
+        { json: "continuity", js: "continuity", typ: u(undefined, "") },
+        { json: "enabled", js: "enabled", typ: true },
+        { json: "id", js: "id", typ: "" },
+        { json: "name", js: "name", typ: "" },
+        { json: "revision", js: "revision", typ: 0 },
+        { json: "schedule_cron", js: "schedule_cron", typ: u(undefined, "") },
+        { json: "schedule_time_zone", js: "schedule_time_zone", typ: u(undefined, "") },
+        { json: "trigger_type", js: "trigger_type", typ: "" },
+        { json: "updated_at", js: "updated_at", typ: "" },
+    ], "any"),
+    "AutomationDefinitionsGetMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutomationDefinitionsGetMessageCmd") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
     ], "any"),
     "AutomationListMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationListMessageCmd") },
@@ -8388,9 +8631,39 @@ const typeMap: any = {
         { json: "pr_url", js: "pr_url", typ: u(undefined, "") },
         { json: "request_id", js: "request_id", typ: "" },
     ], "any"),
+    "AutomationRunSummary": o([
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "definition_id", js: "definition_id", typ: "" },
+        { json: "definition_revision", js: "definition_revision", typ: 0 },
+        { json: "delivered_at", js: "delivered_at", typ: u(undefined, "") },
+        { json: "id", js: "id", typ: "" },
+        { json: "last_error", js: "last_error", typ: u(undefined, "") },
+        { json: "occurrence_key", js: "occurrence_key", typ: u(undefined, "") },
+        { json: "pane_id", js: "pane_id", typ: u(undefined, "") },
+        { json: "session_id", js: "session_id", typ: u(undefined, "") },
+        { json: "state", js: "state", typ: "" },
+        { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
+        { json: "updated_at", js: "updated_at", typ: "" },
+        { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
+    ], "any"),
+    "AutomationRunsGetMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutomationRunsGetMessageCmd") },
+        { json: "definition_id", js: "definition_id", typ: "" },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    ], "any"),
+    "AutomationSetEnabledMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutomationSetEnabledMessageCmd") },
+        { json: "definition_id", js: "definition_id", typ: "" },
+        { json: "enabled", js: "enabled", typ: true },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    ], "any"),
     "AutomationShowMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationShowMessageCmd") },
         { json: "definition_id", js: "definition_id", typ: "" },
+    ], "any"),
+    "AutomationsChangedMessage": o([
+        { json: "definition_ids", js: "definition_ids", typ: a("") },
+        { json: "event", js: "event", typ: r("AutomationsChangedMessageEvent") },
     ], "any"),
     "BootstrapEndpointMessage": o([
         { json: "cmd", js: "cmd", typ: r("BootstrapEndpointMessageCmd") },
@@ -11232,8 +11505,14 @@ const typeMap: any = {
     "AuthorsUpdatedMessageEvent": [
         "authors_updated",
     ],
+    "AutomationActionResultMessageEvent": [
+        "automation_action_result",
+    ],
     "AutomationApplyMessageCmd": [
         "automation_apply",
+    ],
+    "AutomationDefinitionsGetMessageCmd": [
+        "automation_definitions_get",
     ],
     "AutomationListMessageCmd": [
         "automation_list",
@@ -11244,8 +11523,17 @@ const typeMap: any = {
     "AutomationRunMessageCmd": [
         "automation_run",
     ],
+    "AutomationRunsGetMessageCmd": [
+        "automation_runs_get",
+    ],
+    "AutomationSetEnabledMessageCmd": [
+        "automation_set_enabled",
+    ],
     "AutomationShowMessageCmd": [
         "automation_show",
+    ],
+    "AutomationsChangedMessageEvent": [
+        "automations_changed",
     ],
     "BootstrapEndpointMessageCmd": [
         "bootstrap_endpoint",

--- a/docs/plans/2026-07-18-attn-automations-implementation.md
+++ b/docs/plans/2026-07-18-attn-automations-implementation.md
@@ -986,10 +986,10 @@ For every slice that touches daemon lifecycle, protocol, PTY, Git, or UI:
       ticket/session navigation, fed by `automations_changed` broadcasts and
       typed WS get commands (protocol 176), proven by the packaged serial
       scenario `real-app:scenario-automation-surface` — run
-      `automation-surface-2026-07-20T15-35-53-343Z`, all four legs green
+      `automation-surface-2026-07-20T15-48-06-271Z`, all four legs green
       (broadcast-driven listing, delivered navigable run with no duplicates,
       inline daemon rejection on a disabled definition, daemon restart
-      preserving definitions and runs) against the app built from `383da961`
+      preserving definitions and runs) against the app built from `91f899b5`
       (2026-07-20).
 - [ ] Add the self-service editor and remaining policy depth.
 - [ ] Run the final upgrade, failure-recovery, and packaged-app matrix from the

--- a/docs/plans/2026-07-18-attn-automations-implementation.md
+++ b/docs/plans/2026-07-18-attn-automations-implementation.md
@@ -18,15 +18,19 @@
   fixed in `3402100f` with unit and daemon regressions for present and missing
   rollouts; the packaged continuity scenario was rerun green on the fixed code
   from a fresh `automations` profile before merge.
+- Slice 5 merged through [attn PR #617](https://github.com/victorarias/attn/pull/617)
+  (`69ba6978`, 2026-07-20): scheduled trigger with catch-up, storm guard, and
+  singleton continuity, proven by the packaged serial scenario (see the
+  checklist entry below).
 - Later slices remain pending.
 
 ## Next steps
 
-1. Slice 5 (scheduled prompt with one real maintenance case) is implemented on
-   `slice/automations-scheduled` with the packaged scenario green (see the
-   checklist entry below); it merges through the ordinary review flow.
-2. Then Slice 6 (profile-level Automations surface) and Slice 7 (self-service
-   editing and lifecycle completion), followed by the final verification matrix.
+1. Slice 6 (profile-level Automations surface) is implemented on
+   `slice/automations-surface` (see the checklist entry below); it merges
+   through the ordinary review flow.
+2. Then Slice 7 (self-service editing and lifecycle completion), followed by
+   the final verification matrix.
 
 This guide implements the [attn Automations vision](attn-automations.md)
 as functional walking-skeleton slices. Each slice must leave a real capability
@@ -977,7 +981,17 @@ For every slice that touches daemon lifecycle, protocol, PTY, Git, or UI:
       removing a merged-clean worktree while preserving a dirty one) — run
       `automation-scheduled-cleanup-2026-07-20T12-22-03-841Z`, all legs green
       against the app built from `45c7684c` (2026-07-20).
-- [ ] Add operational UI, then the editor and remaining policy depth.
+- [x] Add operational UI: a profile-level Automations panel listing definitions
+      with enable/disable, run-now for manual definitions, and run history with
+      ticket/session navigation, fed by `automations_changed` broadcasts and
+      typed WS get commands (protocol 176), proven by the packaged serial
+      scenario `real-app:scenario-automation-surface` — run
+      `automation-surface-2026-07-20T15-00-09-048Z`, all four legs green
+      (broadcast-driven listing, delivered navigable run with no duplicates,
+      inline daemon rejection on a disabled definition, daemon restart
+      preserving definitions and runs) against the app built from `d6844d68`
+      (2026-07-20).
+- [ ] Add the self-service editor and remaining policy depth.
 - [ ] Run the final upgrade, failure-recovery, and packaged-app matrix from the
       integration branch and open the single integration PR to `main`.
 

--- a/docs/plans/2026-07-18-attn-automations-implementation.md
+++ b/docs/plans/2026-07-18-attn-automations-implementation.md
@@ -986,10 +986,10 @@ For every slice that touches daemon lifecycle, protocol, PTY, Git, or UI:
       ticket/session navigation, fed by `automations_changed` broadcasts and
       typed WS get commands (protocol 176), proven by the packaged serial
       scenario `real-app:scenario-automation-surface` — run
-      `automation-surface-2026-07-20T15-00-09-048Z`, all four legs green
+      `automation-surface-2026-07-20T15-35-53-343Z`, all four legs green
       (broadcast-driven listing, delivered navigable run with no duplicates,
       inline daemon rejection on a disabled definition, daemon restart
-      preserving definitions and runs) against the app built from `d6844d68`
+      preserving definitions and runs) against the app built from `383da961`
       (2026-07-20).
 - [ ] Add the self-service editor and remaining policy depth.
 - [ ] Run the final upgrade, failure-recovery, and packaged-app matrix from the

--- a/internal/daemon/automations.go
+++ b/internal/daemon/automations.go
@@ -61,22 +61,61 @@ func (d *Daemon) automationApply(raw string) (*store.AutomationDefinition, error
 	d.automationMu.Lock()
 	defer d.automationMu.Unlock()
 	definition, err := d.store.UpsertAutomationDefinition(spec.ID, spec.Name, string(canonical), spec.Enabled, time.Now())
-	if err != nil || spec.Enabled {
-		return definition, err
-	}
-	pending, err := d.store.ListPendingAutomationRuns()
 	if err != nil {
 		return definition, err
 	}
+	d.broadcastAutomationsChanged(spec.ID)
+	if spec.Enabled {
+		return definition, nil
+	}
+	return definition, d.failPendingAutomationRuns(spec.ID)
+}
+
+// failPendingAutomationRuns fails every pending run for definitionID via
+// failAutomationRun, e.g. when a definition is disabled before its pending
+// occurrences were delivered. One run's failure does not stop the rest;
+// errors are joined. Shared by automationApply's disable path and
+// automationSetEnabled's disable path so both fail pending runs identically.
+func (d *Daemon) failPendingAutomationRuns(definitionID string) error {
+	pending, err := d.store.ListPendingAutomationRuns()
+	if err != nil {
+		return err
+	}
 	for i := range pending {
 		run := pending[i]
-		if run.DefinitionID != spec.ID {
+		if run.DefinitionID != definitionID {
 			continue
 		}
 		if _, failErr := d.failAutomationRun(&run, errors.New("automation definition disabled before delivery")); failErr != nil {
 			err = errors.Join(err, failErr)
 		}
 	}
+	return err
+}
+
+// automationSetEnabled flips definitionID's enabled flag, reusing the store's
+// shared enable-transition side effects (review-edge clear + provider-cursor
+// fence — see store.SetAutomationEnabled) and, on a disable transition,
+// failing any pending runs through the same path automationApply uses. It is
+// a no-op (success, no broadcast) when the definition already has the
+// requested state, and errors for an unknown or soft-deleted definition.
+func (d *Daemon) automationSetEnabled(definitionID string, enabled bool) (*store.AutomationDefinition, error) {
+	d.automationMu.Lock()
+	defer d.automationMu.Unlock()
+	definition, changed, err := d.store.SetAutomationEnabled(definitionID, enabled, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	if definition == nil {
+		return nil, fmt.Errorf("automation %q not found", definitionID)
+	}
+	if !changed {
+		return definition, nil
+	}
+	if !enabled {
+		err = d.failPendingAutomationRuns(definitionID)
+	}
+	d.broadcastAutomationsChanged(definitionID)
 	return definition, err
 }
 
@@ -134,6 +173,11 @@ func (d *Daemon) automationRun(ctx context.Context, definitionID, requestID, inp
 	if err != nil {
 		return nil, err
 	}
+	// A run now exists for this definition (freshly claimed, or the idempotent
+	// dedup of an already-claimed one) whether or not delivery below succeeds;
+	// broadcast so a WS client watching this definition's runs sees it appear
+	// without waiting on the delivery outcome.
+	d.broadcastAutomationsChanged(definitionID)
 	if run.State != "pending" {
 		return run, nil
 	}
@@ -493,6 +537,7 @@ func (d *Daemon) failAutomationRun(run *store.AutomationRun, deliveryErr error) 
 		}
 	}
 	d.broadcastTicketsUpdated()
+	d.broadcastAutomationsChanged(run.DefinitionID)
 	failed, err := d.store.GetAutomationRun(run.ID)
 	if err != nil {
 		persistErr = errors.Join(persistErr, fmt.Errorf("reload failed run: %w", err))
@@ -562,6 +607,7 @@ func (d *Daemon) deliverAutomationRun(ctx context.Context, run *store.Automation
 		return err
 	}
 	d.broadcastTicketsUpdated()
+	d.broadcastAutomationsChanged(run.DefinitionID)
 	return nil
 }
 

--- a/internal/daemon/automations.go
+++ b/internal/daemon/automations.go
@@ -39,6 +39,25 @@ func (e *retryableAutomationDeliveryError) Unwrap() error { return e.cause }
 
 var errAutomationReviewWithdrawn = errors.New(store.AutomationReviewWithdrawnError)
 
+// defaultWSAutomationMutationTimeout is the fallback for
+// Daemon.wsAutomationMutationTimeout (see wsAutomationMutationTimeoutDuration).
+// 25s is deliberately strictly inside the frontend's 30s client timeout
+// (useDaemonSocket.ts) so a WS set_enabled mutation either completes or
+// aborts with a definitive error before the client gives up waiting — the
+// client's timer can never observe a flip that happens after it already
+// reported failure.
+const defaultWSAutomationMutationTimeout = 25 * time.Second
+
+// wsAutomationMutationTimeoutDuration resolves the effective deadline for a
+// WS-originated automation mutation: the configured override if set, else
+// defaultWSAutomationMutationTimeout.
+func (d *Daemon) wsAutomationMutationTimeoutDuration() time.Duration {
+	if d.wsAutomationMutationTimeout > 0 {
+		return d.wsAutomationMutationTimeout
+	}
+	return defaultWSAutomationMutationTimeout
+}
+
 func (d *Daemon) automationApply(raw string) (*store.AutomationDefinition, error) {
 	spec, canonical, err := automation.ParseDefinitionYAML([]byte(raw))
 	if err != nil {
@@ -99,9 +118,19 @@ func (d *Daemon) failPendingAutomationRuns(definitionID string) error {
 // failing any pending runs through the same path automationApply uses. It is
 // a no-op (success, no broadcast) when the definition already has the
 // requested state, and errors for an unknown or soft-deleted definition.
-func (d *Daemon) automationSetEnabled(definitionID string, enabled bool) (*store.AutomationDefinition, error) {
+//
+// ctx bounds how long the caller is willing to wait to acquire automationMu:
+// once locked, ctx.Err() is checked before any store mutation, so a caller
+// whose deadline already passed aborts without flipping the flag (see
+// wsAutomationMutationTimeoutDuration for the WS caller's deadline). The
+// unix-socket caller passes context.Background() — the CLI/agent path waits
+// synchronously with no deadline of its own, so behavior there is unchanged.
+func (d *Daemon) automationSetEnabled(ctx context.Context, definitionID string, enabled bool) (*store.AutomationDefinition, error) {
 	d.automationMu.Lock()
 	defer d.automationMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("deadline exceeded waiting for an in-flight automation delivery: %w", err)
+	}
 	definition, changed, err := d.store.SetAutomationEnabled(definitionID, enabled, time.Now())
 	if err != nil {
 		return nil, err

--- a/internal/daemon/automations.go
+++ b/internal/daemon/automations.go
@@ -386,6 +386,12 @@ func (d *Daemon) observeGitHubReviewRequests(host string, prs []*protocol.PR, ob
 				d.logf("automation GitHub observation claim %s: %v", candidate.SubjectKey, err)
 				continue
 			}
+			// A run now exists for this definition (freshly claimed, or the
+			// idempotent dedup of an already-claimed one) whether or not
+			// delivery below succeeds; broadcast so a WS client watching this
+			// definition's runs sees it appear without waiting on the
+			// delivery outcome.
+			d.broadcastAutomationsChanged(definition.ID)
 			d.automationMu.Lock()
 			current, loadErr := d.store.GetAutomationRun(run.ID)
 			if loadErr == nil && current != nil && current.State == "pending" {
@@ -607,6 +613,16 @@ func (d *Daemon) deliverAutomationRun(ctx context.Context, run *store.Automation
 		return err
 	}
 	d.broadcastTicketsUpdated()
+	// This pending->delivered transition broadcast has no unit-test coverage:
+	// every unit test that reaches deliverAutomationRun's success path does so
+	// through automationDeliveryHook (bypassing this real delivery return) or
+	// forces a deterministic pre-broadcast failure (e.g.
+	// TestDisabledAutomationRefusesRecoveredPendingDelivery,
+	// TestScheduledPendingRunRecoversOnRestart's failed-transition variant).
+	// Reaching this line for real requires a full workdelivery spawn, which is
+	// out of reach for a unit test; the invariant is pinned live instead by
+	// scenario-automation-surface.mjs leg2_run_now_and_navigable, which drives
+	// a real run-now to `delivered` and asserts the panel reflects it.
 	d.broadcastAutomationsChanged(run.DefinitionID)
 	return nil
 }

--- a/internal/daemon/automations_broadcast.go
+++ b/internal/daemon/automations_broadcast.go
@@ -1,0 +1,27 @@
+package daemon
+
+import "github.com/victorarias/attn/internal/protocol"
+
+// broadcastAutomationsChanged emits an id-only automations_changed event for
+// the given definition IDs. Automation definitions/runs change at low
+// frequency and the event carries only opaque IDs (canonical state lives in
+// SQLite; clients re-read via automation_definitions_get / automation_runs_get
+// on receipt), so unlike the workflow run broadcaster (workflow_broadcast.go)
+// this emits directly on every mutation/transition rather than through a
+// coalescing loop. No-op for an empty id list so callers can pass through a
+// possibly-empty definitionID without a guard.
+func (d *Daemon) broadcastAutomationsChanged(definitionIDs ...string) {
+	if d == nil || len(definitionIDs) == 0 {
+		return
+	}
+	msg := &protocol.AutomationsChangedMessage{
+		Event:         protocol.EventAutomationsChanged,
+		DefinitionIds: definitionIDs,
+	}
+	if d.automationsBroadcastHook != nil {
+		d.automationsBroadcastHook(msg)
+	}
+	if d.wsHub != nil {
+		d.wsHub.BroadcastValue(msg)
+	}
+}

--- a/internal/daemon/automations_schedule.go
+++ b/internal/daemon/automations_schedule.go
@@ -183,6 +183,11 @@ func (d *Daemon) claimAndDeliverScheduledRun(definition store.AutomationDefiniti
 		d.logf("automation schedule observation claim %s: %v", definition.ID, claimErr)
 		return claimErr
 	}
+	// A run now exists for this definition (freshly claimed, or the
+	// idempotent dedup of an already-claimed one) whether or not delivery
+	// below succeeds; broadcast so a WS client watching this definition's
+	// runs sees it appear without waiting on the delivery outcome.
+	d.broadcastAutomationsChanged(definition.ID)
 	d.automationMu.Lock()
 	current, loadErr := d.store.GetAutomationRun(run.ID)
 	if loadErr == nil && current != nil && current.State == "pending" {

--- a/internal/daemon/automations_schedule_test.go
+++ b/internal/daemon/automations_schedule_test.go
@@ -685,3 +685,37 @@ func TestScheduledSingletonMissingContinuityTicketFailsBeforeReusingBoundArtifac
 		t.Fatalf("swept ticket was recreated: ticket=%#v err=%v", ticket, err)
 	}
 }
+
+// TestObserveDueScheduleBroadcastsAtClaimTimeEvenWhenDeliveryFailsRetryably
+// pins Fix F1: a claimed scheduled run must be visible to an open WS panel
+// immediately, not only after delivery settles. A retryable delivery error
+// leaves the run pending (recovery/next-tick retries it), so without a
+// claim-time broadcast the panel would have no signal the run exists at all
+// until some later transition.
+func TestObserveDueScheduleBroadcastsAtClaimTimeEvenWhenDeliveryFailsRetryably(t *testing.T) {
+	d, s, def, _ := setupScheduledDaemon(t, "* * * * *", "fresh", "latest")
+	var broadcasts []string
+	d.automationsBroadcastHook = func(msg *protocol.AutomationsChangedMessage) {
+		broadcasts = append(broadcasts, msg.DefinitionIds...)
+	}
+	d.automationDeliveryHook = func(run *store.AutomationRun) error {
+		return &retryableAutomationDeliveryError{cause: fmt.Errorf("session not ready yet")}
+	}
+
+	now0 := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
+	d.observeDueSchedules(now0) // anchor
+	d.observeDueSchedules(now0.Add(70 * time.Second))
+
+	if len(broadcasts) == 0 {
+		t.Fatal("no automations_changed broadcast fired at claim time")
+	}
+	for _, id := range broadcasts {
+		if id != def.ID {
+			t.Fatalf("broadcast for unexpected definition %q, want %q", id, def.ID)
+		}
+	}
+	runs, err := s.ListAutomationRuns(def.ID)
+	if err != nil || len(runs) != 1 || runs[0].State != "pending" {
+		t.Fatalf("runs=%#v err=%v, want exactly one pending run despite the retryable delivery failure", runs, err)
+	}
+}

--- a/internal/daemon/automations_schedule_test.go
+++ b/internal/daemon/automations_schedule_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/victorarias/attn/internal/automation"
+	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/store"
 )
 
@@ -458,7 +460,11 @@ func claimPendingScheduledRun(t *testing.T, s *store.Store, def *store.Automatio
 // A real delivery attempt reaches deliverAutomationRun (which recoverAutomations
 // calls directly, not through automationDeliveryHook, so a full spawn is out of
 // reach for a unit test); disabling the definition after the claim gives a
-// deterministic, PTY-free failure that still proves the attempt was made.
+// deterministic, PTY-free failure that still proves the attempt was made. That
+// same real deliverAutomationRun -> failAutomationRun path is also where a
+// scheduled run's delivered/failed transition broadcasts automations_changed,
+// so this is extended to assert the broadcast fires for a scheduled run too
+// (not just the manual/WS paths covered in automations_test.go).
 func TestScheduledPendingRunRecoversOnRestart(t *testing.T) {
 	d, s, def, _ := setupScheduledDaemon(t, "* * * * *", "fresh", "latest")
 	intended := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
@@ -467,11 +473,32 @@ func TestScheduledPendingRunRecoversOnRestart(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var mu sync.Mutex
+	var broadcastIDs []string
+	d.automationsBroadcastHook = func(msg *protocol.AutomationsChangedMessage) {
+		mu.Lock()
+		broadcastIDs = append(broadcastIDs, msg.DefinitionIds...)
+		mu.Unlock()
+	}
+
 	d.recoverAutomations()
 
 	got, err := s.GetAutomationRun(run.ID)
 	if err != nil || got == nil || got.State != "failed" || !strings.Contains(got.LastError, "definition is disabled") {
 		t.Fatalf("recovery did not attempt scheduled run: run=%#v err=%v", got, err)
+	}
+	mu.Lock()
+	ids := append([]string(nil), broadcastIDs...)
+	mu.Unlock()
+	found := false
+	for _, id := range ids {
+		if id == def.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("scheduled run's failed transition did not broadcast automations_changed: broadcasts=%v", ids)
 	}
 }
 

--- a/internal/daemon/automations_test.go
+++ b/internal/daemon/automations_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1385,5 +1387,156 @@ func TestContinuationWithdrawalDoesNotCancelDeliveredOriginReviewer(t *testing.T
 	origin, err := s.GetAutomationRun(first.ID)
 	if err != nil || origin == nil || origin.State != "delivered" {
 		t.Fatalf("origin run changed after continuation withdrawal: run=%#v err=%v", origin, err)
+	}
+}
+
+// automationBroadcastRecorder installs an automationsBroadcastHook on d and
+// returns a function that snapshots every definition ID broadcast so far,
+// safe for concurrent use since automationSetEnabledWS-style callers run the
+// mutation in a goroutine.
+func automationBroadcastRecorder(d *Daemon) func() []string {
+	var mu sync.Mutex
+	var ids []string
+	d.automationsBroadcastHook = func(msg *protocol.AutomationsChangedMessage) {
+		mu.Lock()
+		ids = append(ids, msg.DefinitionIds...)
+		mu.Unlock()
+	}
+	return func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), ids...)
+	}
+}
+
+const manualAutomationYAML = `api_version: attn.dev/automations/v1alpha1
+id: manual-check
+name: Manual check
+enabled: true
+trigger: {type: manual}
+prompt: Check locally.
+launch: {driver: codex}
+location: {type: directory, path: "%s"}
+policy: {continuity: fresh, overlap: coalesce}
+`
+
+func TestAutomationApplyBroadcastsOnUpsert(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	broadcasts := automationBroadcastRecorder(d)
+
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	def, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := broadcasts(); len(got) != 1 || got[0] != def.ID {
+		t.Fatalf("broadcasts after enabled apply = %v, want [%s]", got, def.ID)
+	}
+
+	if _, err := d.automationApply(strings.Replace(raw, "enabled: true", "enabled: false", 1)); err != nil {
+		t.Fatal(err)
+	}
+	if got := broadcasts(); len(got) != 2 || got[1] != def.ID {
+		t.Fatalf("broadcasts after disable apply = %v, want two entries ending in %s", got, def.ID)
+	}
+}
+
+// TestAutomationRunBroadcastsAfterClaim exercises automationRun's post-claim
+// broadcast (automations.go's "after claim" call) without reaching real
+// delivery/backend machinery: the run is pre-claimed and pre-marked delivered
+// directly through the store, so automationRun's own ClaimManualAutomationRun
+// call hits the idempotent same-request-id dedup path and returns without
+// re-entering deliverAutomationRun (run.State != "pending").
+func TestAutomationRunBroadcastsAfterClaim(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	def, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	run, _, err := s.ClaimManualAutomationRun(def.ID, "request-1", "", `{}`, def.Revision, `{}`, now, store.AutomationRunReservation{
+		RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MarkAutomationRunDelivered(run.ID, "{}", now); err != nil {
+		t.Fatal(err)
+	}
+
+	broadcasts := automationBroadcastRecorder(d)
+	got, err := d.automationRun(context.Background(), def.ID, "request-1", `{}`)
+	if err != nil {
+		t.Fatalf("automationRun on already-delivered idempotent claim: %v", err)
+	}
+	if got.State != "delivered" {
+		t.Fatalf("automationRun state = %q, want delivered (idempotent dedup, no re-delivery)", got.State)
+	}
+	if ids := broadcasts(); len(ids) != 1 || ids[0] != def.ID {
+		t.Fatalf("broadcasts after automationRun claim = %v, want [%s]", ids, def.ID)
+	}
+}
+
+func TestAutomationSetEnabledDisableFailsPendingRunsAndBroadcasts(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	def, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, _, err := s.ClaimManualAutomationRun(def.ID, "request-1", "", `{}`, def.Revision, `{}`, time.Now(), store.AutomationRunReservation{
+		RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	broadcasts := automationBroadcastRecorder(d)
+	got, err := d.automationSetEnabled(def.ID, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Enabled {
+		t.Fatalf("definition = %#v, want disabled", got)
+	}
+	failed, err := s.GetAutomationRun(run.ID)
+	if err != nil || failed == nil || failed.State != "failed" || !strings.Contains(failed.LastError, "disabled before delivery") {
+		t.Fatalf("pending run after disable = %#v err=%v, want failed", failed, err)
+	}
+	if ids := broadcasts(); len(ids) == 0 {
+		t.Fatal("automationSetEnabled disable did not broadcast")
+	}
+
+	if _, err := d.automationSetEnabled("does-not-exist", false); err == nil {
+		t.Fatal("expected error for unknown definition")
+	}
+}
+
+func TestAutomationSetEnabledNoOpDoesNotBroadcast(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	def, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	broadcasts := automationBroadcastRecorder(d)
+	got, err := d.automationSetEnabled(def.ID, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Enabled {
+		t.Fatalf("definition = %#v, want still enabled", got)
+	}
+	if ids := broadcasts(); len(ids) != 0 {
+		t.Fatalf("no-op automationSetEnabled broadcast = %v, want none", ids)
 	}
 }

--- a/internal/daemon/automations_test.go
+++ b/internal/daemon/automations_test.go
@@ -1528,7 +1528,7 @@ func TestAutomationSetEnabledDisableFailsPendingRunsAndBroadcasts(t *testing.T) 
 	}
 
 	broadcasts := automationBroadcastRecorder(d)
-	got, err := d.automationSetEnabled(def.ID, false)
+	got, err := d.automationSetEnabled(context.Background(), def.ID, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1543,7 +1543,7 @@ func TestAutomationSetEnabledDisableFailsPendingRunsAndBroadcasts(t *testing.T) 
 		t.Fatal("automationSetEnabled disable did not broadcast")
 	}
 
-	if _, err := d.automationSetEnabled("does-not-exist", false); err == nil {
+	if _, err := d.automationSetEnabled(context.Background(), "does-not-exist", false); err == nil {
 		t.Fatal("expected error for unknown definition")
 	}
 }
@@ -1559,7 +1559,7 @@ func TestAutomationSetEnabledNoOpDoesNotBroadcast(t *testing.T) {
 	}
 
 	broadcasts := automationBroadcastRecorder(d)
-	got, err := d.automationSetEnabled(def.ID, true)
+	got, err := d.automationSetEnabled(context.Background(), def.ID, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/daemon/automations_test.go
+++ b/internal/daemon/automations_test.go
@@ -683,12 +683,21 @@ policy: {continuity: per_subject, catch_up: latest, overlap: coalesce}
 		}
 		return s.MarkAutomationRunDelivered(run.ID, `{}`, time.Now())
 	}
+	var broadcasts []string
+	d.automationsBroadcastHook = func(msg *protocol.AutomationsChangedMessage) {
+		broadcasts = append(broadcasts, msg.DefinitionIds...)
+	}
 	demand := []*protocol.PR{{Host: "github.com", Repo: "owner/repo", Number: 42, Role: protocol.PRRoleReviewer, State: protocol.PRStateWaiting, Reason: protocol.PRReasonReviewNeeded}}
 	observedAt := time.Now()
 	d.observeGitHubReviewRequests("github.com", demand, observedAt)
 	runs, err := s.ListAutomationRuns("retry-review")
 	if err != nil || len(runs) != 1 || runs[0].State != "pending" || attempts.Load() != 1 {
 		t.Fatalf("first observation runs=%#v attempts=%d err=%v", runs, attempts.Load(), err)
+	}
+	// Fix F1: the claim broadcasts before delivery is attempted, so an open WS
+	// panel sees the pending run even though delivery below fails retryably.
+	if len(broadcasts) == 0 || broadcasts[0] != "retry-review" {
+		t.Fatalf("broadcasts at claim time=%#v, want [\"retry-review\", ...]", broadcasts)
 	}
 
 	d.observeGitHubReviewRequests("github.com", demand, observedAt.Add(time.Second))
@@ -1478,6 +1487,27 @@ func TestAutomationRunBroadcastsAfterClaim(t *testing.T) {
 	}
 	if ids := broadcasts(); len(ids) != 1 || ids[0] != def.ID {
 		t.Fatalf("broadcasts after automationRun claim = %v, want [%s]", ids, def.ID)
+	}
+}
+
+// TestAutomationRunRejectsNonManualTrigger pins Fix F8: driving
+// d.automationRun against a provider-driven (scheduled) definition must be
+// rejected before any occurrence/run row is created — schedule/GitHub
+// observation are the only paths allowed to produce a run for it.
+func TestAutomationRunRejectsNonManualTrigger(t *testing.T) {
+	d, s, def, _ := setupScheduledDaemon(t, "* * * * *", "fresh", "latest")
+
+	_, err := d.automationRun(context.Background(), def.ID, "request-1", `{}`)
+	if err == nil || !strings.Contains(err.Error(), "cannot be run manually") {
+		t.Fatalf("automationRun err=%v, want a manual-trigger rejection", err)
+	}
+	// automationRun's non-manual check runs before any store write, so runs
+	// being empty is sufficient proof no occurrence was created either — the
+	// two are always inserted together in one transaction (see
+	// ClaimManualAutomationRun).
+	runs, err := s.ListAutomationRuns(def.ID)
+	if err != nil || len(runs) != 0 {
+		t.Fatalf("runs=%#v err=%v, want no run created", runs, err)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -319,6 +319,12 @@ type Daemon struct {
 	workflowAttentionHook func(attention.Result)                    // optional, tests only
 	ticketsBroadcastHook  func([]protocol.Ticket)                   // optional, tests only
 
+	// automationsBroadcastHook mirrors workflowBroadcastHook for the automations
+	// WS surface (automations_broadcast.go): invoked before every
+	// automations_changed broadcast so tests can observe it deterministically
+	// without a live socket.
+	automationsBroadcastHook func(*protocol.AutomationsChangedMessage)
+
 	workspaceContextCheckoutMu sync.Mutex
 
 	// compactRunner is the durable task runner that owns the keeper's

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -97,17 +97,23 @@ const (
 
 // Daemon manages Claude sessions
 type Daemon struct {
-	socketPath                 string
-	pidPath                    string
-	pidFile                    *os.File // Held open with flock for exclusive access
-	dataRoot                   string
-	daemonInstanceID           string
-	store                      *store.Store
-	automationMu               sync.Mutex // serializes idempotent ensure/adopt delivery per profile
-	automationObservationMu    sync.Mutex
-	automationObservationLocks map[string]*sync.Mutex
-	automationRepoMu           sync.Mutex
-	automationRepos            map[string]*sync.Mutex
+	socketPath       string
+	pidPath          string
+	pidFile          *os.File // Held open with flock for exclusive access
+	dataRoot         string
+	daemonInstanceID string
+	store            *store.Store
+	automationMu     sync.Mutex // serializes idempotent ensure/adopt delivery per profile
+	// wsAutomationMutationTimeout bounds how long a WS-originated automation
+	// mutation (set_enabled) waits to acquire automationMu before aborting
+	// without mutating. 0 resolves to defaultWSAutomationMutationTimeout via
+	// wsAutomationMutationTimeoutDuration; tests shrink it to exercise the
+	// deadline without holding the lock for tens of seconds.
+	wsAutomationMutationTimeout time.Duration
+	automationObservationMu     sync.Mutex
+	automationObservationLocks  map[string]*sync.Mutex
+	automationRepoMu            sync.Mutex
+	automationRepos             map[string]*sync.Mutex
 	// automationDeliveryHook replaces only the final delivery call in focused
 	// provider-observation tests; production always leaves it nil.
 	automationDeliveryHook func(*store.AutomationRun) error

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -1075,6 +1075,14 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleWorkflowRunListWS(client, msg.(*protocol.WorkflowRunListMessage))
 	case protocol.CmdWorkflowRunCancel:
 		d.handleWorkflowRunCancelWS(client, msg.(*protocol.WorkflowRunCancelMessage))
+	case protocol.CmdAutomationDefinitionsGet:
+		d.handleAutomationDefinitionsGetWS(client, msg.(*protocol.AutomationDefinitionsGetMessage))
+	case protocol.CmdAutomationRunsGet:
+		d.handleAutomationRunsGetWS(client, msg.(*protocol.AutomationRunsGetMessage))
+	case protocol.CmdAutomationSetEnabled:
+		d.handleAutomationSetEnabledWS(client, msg.(*protocol.AutomationSetEnabledMessage))
+	case protocol.CmdAutomationRun:
+		d.handleAutomationRunWS(client, msg.(*protocol.AutomationRunMessage))
 	case protocol.CmdSpawnSession:
 		d.handleSpawnSession(client, msg.(*protocol.SpawnSessionMessage))
 	case protocol.CmdAttachSession:

--- a/internal/daemon/ws_automations.go
+++ b/internal/daemon/ws_automations.go
@@ -1,0 +1,163 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/victorarias/attn/internal/automation"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// WS wrappers for the automations surface: list definitions, list one
+// definition's runs, enable/disable, and run-now. Canonical state stays in
+// SQLite; every handler here replies with a compact
+// AutomationActionResultMessage and mutations also broadcast
+// automations_changed (automations_broadcast.go) so other clients re-read.
+//
+// This is a distinct wire shape from the unix-socket automation_action_result
+// used by the CLI/agent path (automations.go's automationActionResult /
+// internal/client's AutomationResult, which carry a generic `data` payload) —
+// see the AutomationActionResultMessage doc comment in main.tsp for why the
+// two are not merged.
+
+// automationRunSummaryListCap bounds automation_runs_get: a defensive cap
+// against an unbounded WS payload for a long-lived definition, not a
+// UI-driven pagination contract.
+const automationRunSummaryListCap = 100
+
+func (d *Daemon) handleAutomationDefinitionsGetWS(client *wsClient, msg *protocol.AutomationDefinitionsGetMessage) {
+	definitions, err := d.store.ListAutomationDefinitions()
+	result := protocol.AutomationActionResultMessage{
+		Event:     protocol.EventAutomationActionResult,
+		Action:    "definitions_get",
+		RequestID: msg.RequestID,
+		Success:   err == nil,
+	}
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+	} else {
+		result.Definitions = make([]protocol.AutomationDefinitionSummary, len(definitions))
+		for i := range definitions {
+			result.Definitions[i] = d.buildAutomationDefinitionSummary(definitions[i])
+		}
+	}
+	d.sendToClient(client, result)
+}
+
+func (d *Daemon) handleAutomationRunsGetWS(client *wsClient, msg *protocol.AutomationRunsGetMessage) {
+	runs, err := d.store.ListAutomationRunsWithOccurrenceKeys(msg.DefinitionID, automationRunSummaryListCap+1)
+	result := protocol.AutomationActionResultMessage{
+		Event:     protocol.EventAutomationActionResult,
+		Action:    "runs_get",
+		RequestID: msg.RequestID,
+		Success:   err == nil,
+	}
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+	} else {
+		if len(runs) > automationRunSummaryListCap {
+			runs = runs[:automationRunSummaryListCap]
+			result.Truncated = protocol.Ptr(true)
+		}
+		result.Runs = make([]protocol.AutomationRunSummary, len(runs))
+		for i := range runs {
+			result.Runs[i] = automationRunSummary(runs[i])
+		}
+	}
+	d.sendToClient(client, result)
+}
+
+func (d *Daemon) handleAutomationSetEnabledWS(client *wsClient, msg *protocol.AutomationSetEnabledMessage) {
+	go func() {
+		definition, err := d.automationSetEnabled(msg.DefinitionID, msg.Enabled)
+		result := protocol.AutomationActionResultMessage{
+			Event:     protocol.EventAutomationActionResult,
+			Action:    "set_enabled",
+			RequestID: msg.RequestID,
+			Success:   err == nil,
+		}
+		if err != nil {
+			result.Error = protocol.Ptr(err.Error())
+		} else {
+			result.Definitions = []protocol.AutomationDefinitionSummary{d.buildAutomationDefinitionSummary(*definition)}
+		}
+		d.sendToClient(client, result)
+	}()
+}
+
+// handleAutomationRunWS is the WS counterpart of the unix-socket
+// CmdAutomationRun path (automations.go's handleAutomationCommand): run-now,
+// manual trigger only. A manual-trigger rejection (e.g. a provider-driven
+// definition) surfaces as success=false with the error text, matching the
+// socket path's existing behavior — it is not a transport-level failure.
+func (d *Daemon) handleAutomationRunWS(client *wsClient, msg *protocol.AutomationRunMessage) {
+	go func() {
+		run, err := d.automationRun(context.Background(), msg.DefinitionID, msg.RequestID, protocol.Deref(msg.InputJson))
+		result := protocol.AutomationActionResultMessage{
+			Event:     protocol.EventAutomationActionResult,
+			Action:    "run",
+			RequestID: protocol.Ptr(msg.RequestID),
+			Success:   err == nil,
+		}
+		if err != nil {
+			result.Error = protocol.Ptr(err.Error())
+		} else {
+			result.RunID = protocol.Ptr(run.ID)
+			result.TicketID = protocol.Ptr(run.TicketID)
+			result.SessionID = protocol.Ptr(run.SessionID)
+		}
+		d.sendToClient(client, result)
+	}()
+}
+
+// buildAutomationDefinitionSummary extracts the compact WS fields from a
+// definition's SpecJSON. An unmarshal failure (should not happen for a
+// definition that passed automationApply's validation, but is not assumed)
+// degrades to an id/name/enabled-only summary rather than dropping the
+// definition from the list.
+func (d *Daemon) buildAutomationDefinitionSummary(def store.AutomationDefinition) protocol.AutomationDefinitionSummary {
+	summary := protocol.AutomationDefinitionSummary{
+		ID:        def.ID,
+		Name:      def.Name,
+		Enabled:   def.Enabled,
+		Revision:  def.Revision,
+		UpdatedAt: string(protocol.NewTimestamp(def.UpdatedAt)),
+	}
+	var spec automation.DefinitionSpec
+	if err := json.Unmarshal([]byte(def.SpecJSON), &spec); err != nil {
+		d.logf("automation definition summary parse %s: %v", def.ID, err)
+		return summary
+	}
+	summary.TriggerType = spec.Trigger.Type
+	if spec.Trigger.Schedule != nil {
+		summary.ScheduleCron = protocol.Ptr(spec.Trigger.Schedule.Cron)
+		summary.ScheduleTimeZone = protocol.Ptr(spec.Trigger.Schedule.TimeZone)
+	}
+	summary.Continuity = protocol.Ptr(spec.Policy.Continuity)
+	summary.CatchUp = protocol.Ptr(spec.Policy.CatchUp)
+	return summary
+}
+
+func automationRunSummary(run store.AutomationRunWithOccurrenceKey) protocol.AutomationRunSummary {
+	summary := protocol.AutomationRunSummary{
+		ID:                 run.ID,
+		DefinitionID:       run.DefinitionID,
+		DefinitionRevision: run.DefinitionRevision,
+		State:              run.State,
+		TicketID:           protocol.Ptr(run.TicketID),
+		SessionID:          protocol.Ptr(run.SessionID),
+		WorkspaceID:        protocol.Ptr(run.WorkspaceID),
+		PaneID:             protocol.Ptr(run.PaneID),
+		CreatedAt:          string(protocol.NewTimestamp(run.CreatedAt)),
+		UpdatedAt:          string(protocol.NewTimestamp(run.UpdatedAt)),
+		OccurrenceKey:      protocol.Ptr(run.OccurrenceKey),
+	}
+	if run.LastError != "" {
+		summary.LastError = protocol.Ptr(run.LastError)
+	}
+	if run.DeliveredAt != nil {
+		summary.DeliveredAt = protocol.Ptr(string(protocol.NewTimestamp(*run.DeliveredAt)))
+	}
+	return summary
+}

--- a/internal/daemon/ws_automations.go
+++ b/internal/daemon/ws_automations.go
@@ -26,7 +26,21 @@ import (
 // Mutations here (set_enabled, run) can block behind d.automationMu while it
 // is held for an in-flight automation delivery (clone/fetch, agent spawn),
 // which can take tens of seconds — the frontend's wrappers use a 30s timeout
-// to match.
+// to match. The two mutations resolve that race differently:
+//
+//   - set_enabled aborts, rather than mutating, once
+//     wsAutomationMutationTimeoutDuration's daemon-side deadline (25s, strictly
+//     inside the client's 30s) passes while still waiting on automationMu — see
+//     automationSetEnabled. So the client's timer can never fire before a
+//     set_enabled either lands or is provably abandoned; a late store flip
+//     after a reported timeout is not possible.
+//   - run-now cannot use the same trick: automationRun durably claims the run
+//     via ClaimManualAutomationRun before waiting on automationMu, so an
+//     abandoned wait still leaves a pending run that will eventually deliver.
+//     Instead the client is expected to reuse the same request_id across a
+//     retry of the same click (ClaimManualAutomationRun is idempotent per
+//     request_id), so a retry after a client-side timeout dedups onto the
+//     original claim rather than creating a second one.
 
 // automationRunSummaryListCap bounds automation_runs_get: a defensive cap
 // against an unbounded WS payload for a long-lived definition, not a
@@ -77,7 +91,9 @@ func (d *Daemon) handleAutomationRunsGetWS(client *wsClient, msg *protocol.Autom
 
 func (d *Daemon) handleAutomationSetEnabledWS(client *wsClient, msg *protocol.AutomationSetEnabledMessage) {
 	go func() {
-		definition, err := d.automationSetEnabled(msg.DefinitionID, msg.Enabled)
+		ctx, cancel := context.WithTimeout(context.Background(), d.wsAutomationMutationTimeoutDuration())
+		defer cancel()
+		definition, err := d.automationSetEnabled(ctx, msg.DefinitionID, msg.Enabled)
 		result := protocol.AutomationActionResultMessage{
 			Event:     protocol.EventAutomationActionResult,
 			Action:    "set_enabled",

--- a/internal/daemon/ws_automations.go
+++ b/internal/daemon/ws_automations.go
@@ -3,6 +3,8 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"strings"
 
 	"github.com/victorarias/attn/internal/automation"
 	"github.com/victorarias/attn/internal/protocol"
@@ -20,6 +22,11 @@ import (
 // internal/client's AutomationResult, which carry a generic `data` payload) —
 // see the AutomationActionResultMessage doc comment in main.tsp for why the
 // two are not merged.
+//
+// Mutations here (set_enabled, run) can block behind d.automationMu while it
+// is held for an in-flight automation delivery (clone/fetch, agent spawn),
+// which can take tens of seconds — the frontend's wrappers use a 30s timeout
+// to match.
 
 // automationRunSummaryListCap bounds automation_runs_get: a defensive cap
 // against an unbounded WS payload for a long-lived definition, not a
@@ -93,7 +100,18 @@ func (d *Daemon) handleAutomationSetEnabledWS(client *wsClient, msg *protocol.Au
 // socket path's existing behavior — it is not a transport-level failure.
 func (d *Daemon) handleAutomationRunWS(client *wsClient, msg *protocol.AutomationRunMessage) {
 	go func() {
-		run, err := d.automationRun(context.Background(), msg.DefinitionID, msg.RequestID, protocol.Deref(msg.InputJson))
+		var run *store.AutomationRun
+		var err error
+		prURL := strings.TrimSpace(protocol.Deref(msg.PRURL))
+		inputJSON := strings.TrimSpace(protocol.Deref(msg.InputJson))
+		switch {
+		case prURL != "" && inputJSON != "":
+			err = errors.New("pr_url and input_json are mutually exclusive")
+		case prURL != "":
+			run, err = d.automationRunPullRequest(context.Background(), msg.DefinitionID, msg.RequestID, prURL)
+		default:
+			run, err = d.automationRun(context.Background(), msg.DefinitionID, msg.RequestID, protocol.Deref(msg.InputJson))
+		}
 		result := protocol.AutomationActionResultMessage{
 			Event:     protocol.EventAutomationActionResult,
 			Action:    "run",

--- a/internal/daemon/ws_automations_test.go
+++ b/internal/daemon/ws_automations_test.go
@@ -296,3 +296,156 @@ func TestAutomationRunWSRoutesPRURL(t *testing.T) {
 		t.Fatalf("run result error = %q, want automationRunPullRequest's own validation error, not a manual-path error", *res.Error)
 	}
 }
+
+// TestAutomationSetEnabledWSDeadlineAbortsWithoutMutating pins the
+// timeout-vs-mutation trap from PR #619's review: automationSetEnabled must
+// abort once its daemon-side deadline (wsAutomationMutationTimeout) elapses
+// while still waiting on automationMu, and must NOT mutate the definition
+// afterward. Without this guard, a slow in-flight delivery holding
+// automationMu for longer than the frontend's 30s client timeout lets the
+// toggle flip after the UI has already reported "timed out" — invisible to
+// the user who believes their click had no effect.
+func TestAutomationSetEnabledWSDeadlineAbortsWithoutMutating(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub(), wsAutomationMutationTimeout: 50 * time.Millisecond}
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	def, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !def.Enabled {
+		t.Fatalf("fixture definition = %#v, want enabled", def)
+	}
+
+	// Simulate an in-flight automation delivery holding automationMu well past
+	// the 50ms deadline; released after 200ms.
+	d.automationMu.Lock()
+	released := make(chan struct{})
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		d.automationMu.Unlock()
+		close(released)
+	}()
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationSetEnabledWS(client, &protocol.AutomationSetEnabledMessage{
+		Cmd:          protocol.CmdAutomationSetEnabled,
+		DefinitionID: def.ID,
+		Enabled:      false,
+		RequestID:    protocol.Ptr("set-deadline"),
+	})
+
+	var res protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if res.Success || res.Error == nil || !strings.Contains(*res.Error, "deadline exceeded") {
+		t.Fatalf("set_enabled result = %+v, want success=false with a deadline error", res)
+	}
+
+	<-released
+
+	stored, err := s.GetAutomationDefinition(def.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stored.Enabled {
+		t.Fatalf("definition after deadline abort = %#v, want still enabled (no late flip)", stored)
+	}
+
+	// Sanity: an uncontended set_enabled once the lock has freed still succeeds.
+	client2 := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationSetEnabledWS(client2, &protocol.AutomationSetEnabledMessage{
+		Cmd:          protocol.CmdAutomationSetEnabled,
+		DefinitionID: def.ID,
+		Enabled:      false,
+		RequestID:    protocol.Ptr("set-after"),
+	})
+	var res2 protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client2.send, &res2)
+	if !res2.Success {
+		t.Fatalf("set_enabled after lock freed = %+v, want success", res2)
+	}
+	stored2, err := s.GetAutomationDefinition(def.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored2.Enabled {
+		t.Fatalf("definition after uncontended set_enabled = %#v, want disabled", stored2)
+	}
+}
+
+// TestAutomationRunWSRetryWithSameRequestIDDoesNotDuplicate pins the run-now
+// half of the timeout-vs-mutation trap: a client that times out waiting for
+// automation_run and retries with the SAME request_id (the fix in
+// AutomationsPanel/useDaemonSocket) must dedup onto the original claim rather
+// than creating a second run, even when both calls contend on automationMu.
+//
+// The run is pre-claimed and pre-marked delivered directly through the store
+// (matching TestAutomationRunBroadcastsAfterClaim's technique) so neither
+// call re-enters deliverAutomationRun/real backend machinery: automationRun's
+// own ClaimManualAutomationRun call idempotently dedups on request_id before
+// either goroutine even reaches automationMu, and both then read back the
+// same already-delivered run once the held lock frees. automationDeliveryHook
+// does not apply here — it only affects deliverObservedAutomationRun's
+// provider-observation path, not automationRun's manual-run path.
+func TestAutomationRunWSRetryWithSameRequestIDDoesNotDuplicate(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	def, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	run, _, err := s.ClaimManualAutomationRun(def.ID, "retry-request", "", `{}`, def.Revision, `{}`, now, store.AutomationRunReservation{
+		RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MarkAutomationRunDelivered(run.ID, "{}", now); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate an in-flight delivery holding automationMu while both retry
+	// attempts arrive and queue behind it.
+	d.automationMu.Lock()
+	released := make(chan struct{})
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		d.automationMu.Unlock()
+		close(released)
+	}()
+
+	client1 := &wsClient{send: make(chan outboundMessage, 4)}
+	client2 := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationRunWS(client1, &protocol.AutomationRunMessage{
+		Cmd:          protocol.CmdAutomationRun,
+		DefinitionID: def.ID,
+		RequestID:    "retry-request",
+	})
+	d.handleAutomationRunWS(client2, &protocol.AutomationRunMessage{
+		Cmd:          protocol.CmdAutomationRun,
+		DefinitionID: def.ID,
+		RequestID:    "retry-request",
+	})
+
+	var res1, res2 protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client1.send, &res1)
+	readNotebookWSEvent(t, client2.send, &res2)
+	<-released
+
+	if !res1.Success || !res2.Success {
+		t.Fatalf("run results = %+v / %+v, want both success", res1, res2)
+	}
+	if res1.RunID == nil || res2.RunID == nil || *res1.RunID != run.ID || *res2.RunID != run.ID {
+		t.Fatalf("run ids = %v / %v, want both %s", res1.RunID, res2.RunID, run.ID)
+	}
+
+	runs, err := s.ListAutomationRuns(def.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("runs for definition = %d, want exactly 1 (no duplicate claim from the retried request_id)", len(runs))
+	}
+}

--- a/internal/daemon/ws_automations_test.go
+++ b/internal/daemon/ws_automations_test.go
@@ -1,0 +1,214 @@
+package daemon
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// TestAutomationDefinitionsGetWSResultCorrelatesRequest exercises the WS list
+// path: an applied definition comes back as one summary correlated by
+// request_id, with the schedule/policy fields pulled from its spec.
+func TestAutomationDefinitionsGetWSResultCorrelatesRequest(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	def, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationDefinitionsGetWS(client, &protocol.AutomationDefinitionsGetMessage{
+		Cmd:       protocol.CmdAutomationDefinitionsGet,
+		RequestID: protocol.Ptr("defs-1"),
+	})
+
+	var res protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if !res.Success || res.RequestID == nil || *res.RequestID != "defs-1" {
+		t.Fatalf("definitions_get result = %+v, want success for defs-1", res)
+	}
+	if len(res.Definitions) != 1 || res.Definitions[0].ID != def.ID {
+		t.Fatalf("definitions = %+v, want one summary for %s", res.Definitions, def.ID)
+	}
+	summary := res.Definitions[0]
+	if summary.TriggerType != "manual" || !summary.Enabled {
+		t.Fatalf("summary = %+v, want manual+enabled", summary)
+	}
+}
+
+// TestAutomationRunsGetWSResultCorrelatesRequest claims one manual run and
+// confirms the WS runs_get result carries it, including the joined
+// occurrence_key, correlated by request_id.
+func TestAutomationRunsGetWSResultCorrelatesRequest(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	def, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, _, err := s.ClaimManualAutomationRun(def.ID, "request-1", "", `{}`, def.Revision, `{}`, time.Now(), store.AutomationRunReservation{
+		RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationRunsGetWS(client, &protocol.AutomationRunsGetMessage{
+		Cmd:          protocol.CmdAutomationRunsGet,
+		DefinitionID: def.ID,
+		RequestID:    protocol.Ptr("runs-1"),
+	})
+
+	var res protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if !res.Success || res.RequestID == nil || *res.RequestID != "runs-1" {
+		t.Fatalf("runs_get result = %+v, want success for runs-1", res)
+	}
+	if res.Truncated != nil && *res.Truncated {
+		t.Fatalf("runs_get result truncated=%v, want unset/false for one run", res.Truncated)
+	}
+	if len(res.Runs) != 1 || res.Runs[0].ID != run.ID {
+		t.Fatalf("runs = %+v, want one summary for %s", res.Runs, run.ID)
+	}
+	if res.Runs[0].OccurrenceKey == nil || *res.Runs[0].OccurrenceKey != "manual:request-1" {
+		t.Fatalf("run occurrence_key = %v, want manual:request-1", res.Runs[0].OccurrenceKey)
+	}
+}
+
+// TestAutomationRunsGetWSResultTruncatesAtCap seeds one more run than
+// automationRunSummaryListCap and confirms the result caps the list and sets
+// truncated=true rather than returning an unbounded payload.
+func TestAutomationRunsGetWSResultTruncatesAtCap(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	def, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < automationRunSummaryListCap+1; i++ {
+		requestID := fmt.Sprintf("request-%d", i)
+		if _, _, err := s.ClaimManualAutomationRun(def.ID, requestID, "", `{}`, def.Revision, `{}`, time.Now(), store.AutomationRunReservation{
+			RunID: fmt.Sprintf("run-%d", i), OccurrenceID: fmt.Sprintf("occ-%d", i),
+			TicketID: fmt.Sprintf("ticket-%d", i), SessionID: fmt.Sprintf("session-%d", i),
+			WorkspaceID: fmt.Sprintf("workspace-%d", i), PaneID: fmt.Sprintf("pane-%d", i),
+		}); err != nil {
+			t.Fatalf("claim %d: %v", i, err)
+		}
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationRunsGetWS(client, &protocol.AutomationRunsGetMessage{
+		Cmd:          protocol.CmdAutomationRunsGet,
+		DefinitionID: def.ID,
+		RequestID:    protocol.Ptr("runs-cap"),
+	})
+
+	var res protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if !res.Success {
+		t.Fatalf("runs_get result = %+v, want success", res)
+	}
+	if len(res.Runs) != automationRunSummaryListCap {
+		t.Fatalf("runs = %d, want capped at %d", len(res.Runs), automationRunSummaryListCap)
+	}
+	if res.Truncated == nil || !*res.Truncated {
+		t.Fatalf("truncated = %v, want true", res.Truncated)
+	}
+}
+
+// TestAutomationSetEnabledWSResultCorrelatesRequest drives the mutation
+// handler (which runs the store call in a goroutine) and confirms the result
+// is still correlated by request_id once it lands.
+func TestAutomationSetEnabledWSResultCorrelatesRequest(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	def, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationSetEnabledWS(client, &protocol.AutomationSetEnabledMessage{
+		Cmd:          protocol.CmdAutomationSetEnabled,
+		DefinitionID: def.ID,
+		Enabled:      false,
+		RequestID:    protocol.Ptr("set-1"),
+	})
+
+	var res protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if !res.Success || res.RequestID == nil || *res.RequestID != "set-1" {
+		t.Fatalf("set_enabled result = %+v, want success for set-1", res)
+	}
+	if len(res.Definitions) != 1 || res.Definitions[0].Enabled {
+		t.Fatalf("set_enabled definitions = %+v, want one disabled summary", res.Definitions)
+	}
+
+	// Unknown definition surfaces as success=false with an error, not a
+	// transport failure.
+	client2 := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationSetEnabledWS(client2, &protocol.AutomationSetEnabledMessage{
+		Cmd:          protocol.CmdAutomationSetEnabled,
+		DefinitionID: "does-not-exist",
+		Enabled:      true,
+		RequestID:    protocol.Ptr("set-2"),
+	})
+	var errRes protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client2.send, &errRes)
+	if errRes.Success || errRes.Error == nil {
+		t.Fatalf("set_enabled unknown definition result = %+v, want success=false with error", errRes)
+	}
+}
+
+// TestAutomationRunWSResultCorrelatesRequest exercises handleAutomationRunWS
+// (also goroutine-backed) via the same idempotent-dedup technique as
+// TestAutomationRunBroadcastsAfterClaim: pre-claiming and pre-delivering the
+// run under the same request_id means the handler's own claim short-circuits
+// before reaching real delivery/backend machinery.
+func TestAutomationRunWSResultCorrelatesRequest(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	def, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	run, _, err := s.ClaimManualAutomationRun(def.ID, "request-1", "", `{}`, def.Revision, `{}`, now, store.AutomationRunReservation{
+		RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MarkAutomationRunDelivered(run.ID, "{}", now); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationRunWS(client, &protocol.AutomationRunMessage{
+		Cmd:          protocol.CmdAutomationRun,
+		DefinitionID: def.ID,
+		RequestID:    "request-1",
+	})
+
+	var res protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if !res.Success || res.RequestID == nil || *res.RequestID != "request-1" {
+		t.Fatalf("run result = %+v, want success for request-1", res)
+	}
+	if res.RunID == nil || *res.RunID != run.ID {
+		t.Fatalf("run result run_id = %v, want %s", res.RunID, run.ID)
+	}
+	if res.TicketID == nil || *res.TicketID != run.TicketID || res.SessionID == nil || *res.SessionID != run.SessionID {
+		t.Fatalf("run result ticket/session = %+v, want %s/%s", res, run.TicketID, run.SessionID)
+	}
+}

--- a/internal/daemon/ws_automations_test.go
+++ b/internal/daemon/ws_automations_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -210,5 +211,88 @@ func TestAutomationRunWSResultCorrelatesRequest(t *testing.T) {
 	}
 	if res.TicketID == nil || *res.TicketID != run.TicketID || res.SessionID == nil || *res.SessionID != run.SessionID {
 		t.Fatalf("run result ticket/session = %+v, want %s/%s", res, run.TicketID, run.SessionID)
+	}
+}
+
+// TestAutomationRunWSRejectsNonManualTrigger is the WS-level half of Fix F8:
+// handleAutomationRunWS must surface a provider-driven definition's
+// manual-trigger rejection as success=false with the same error text as the
+// daemon-level automationRun path, not a transport-level failure.
+func TestAutomationRunWSRejectsNonManualTrigger(t *testing.T) {
+	d, _, def, _ := setupScheduledDaemon(t, "* * * * *", "fresh", "latest")
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationRunWS(client, &protocol.AutomationRunMessage{
+		Cmd:          protocol.CmdAutomationRun,
+		DefinitionID: def.ID,
+		RequestID:    "request-1",
+	})
+
+	var res protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if res.Success || res.Error == nil || !strings.Contains(*res.Error, "cannot be run manually") {
+		t.Fatalf("run result = %+v, want success=false with a manual-trigger rejection", res)
+	}
+}
+
+// TestAutomationRunWSMutualExclusion mirrors the unix-socket arm's pr_url /
+// input_json mutual-exclusion guard (Fix F3): the WS arm must reject both
+// being set with the same error text rather than silently ignoring pr_url.
+func TestAutomationRunWSMutualExclusion(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	def, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationRunWS(client, &protocol.AutomationRunMessage{
+		Cmd:          protocol.CmdAutomationRun,
+		DefinitionID: def.ID,
+		RequestID:    "request-1",
+		PRURL:        protocol.Ptr("https://github.com/owner/repo/pull/1"),
+		InputJson:    protocol.Ptr(`{}`),
+	})
+
+	var res protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if res.Success || res.Error == nil || !strings.Contains(*res.Error, "mutually exclusive") {
+		t.Fatalf("run result = %+v, want success=false mutual-exclusion error", res)
+	}
+}
+
+// TestAutomationRunWSRoutesPRURL mirrors the unix-socket arm's pr_url
+// routing (Fix F3): a WS automation_run with only pr_url set must reach
+// automationRunPullRequest, not the manual automationRun path. A manual
+// definition's location isn't repository_worktree, so
+// automationRunPullRequest's own validation rejects it — proving routing
+// without building GitHub fixtures, and with an error text distinct from the
+// manual-path's own errors.
+func TestAutomationRunWSRoutesPRURL(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	def, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationRunWS(client, &protocol.AutomationRunMessage{
+		Cmd:          protocol.CmdAutomationRun,
+		DefinitionID: def.ID,
+		RequestID:    "request-1",
+		PRURL:        protocol.Ptr("https://github.com/owner/repo/pull/1"),
+	})
+
+	var res protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if res.Success || res.Error == nil {
+		t.Fatalf("run result = %+v, want success=false (pr_url routed to the pull-request path)", res)
+	}
+	if strings.Contains(*res.Error, "mutually exclusive") || strings.Contains(*res.Error, "cannot be run manually") {
+		t.Fatalf("run result error = %q, want automationRunPullRequest's own validation error, not a manual-path error", *res.Error)
 	}
 }

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "175"
+const ProtocolVersion = "176"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -163,6 +163,9 @@ const (
 	CmdAutomationShow                        = "automation_show"
 	CmdAutomationRun                         = "automation_run"
 	CmdAutomationRunList                     = "automation_run_list"
+	CmdAutomationDefinitionsGet              = "automation_definitions_get"
+	CmdAutomationRunsGet                     = "automation_runs_get"
+	CmdAutomationSetEnabled                  = "automation_set_enabled"
 	CmdSpawnSession                          = "spawn_session"
 	CmdAttachSession                         = "attach_session"
 	CmdDetachSession                         = "detach_session"
@@ -201,6 +204,11 @@ const (
 )
 
 const EventAutomationActionResult = "automation_action_result"
+
+// EventAutomationsChanged is the id-only automations broadcast: canonical state
+// stays in SQLite, so clients re-read via automation_definitions_get /
+// automation_runs_get on receipt.
+const EventAutomationsChanged = "automations_changed"
 
 // WebSocket Events (daemon -> client)
 const (
@@ -431,6 +439,27 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 		return peek.Cmd, &msg, nil
 	case CmdAutomationRunList:
 		var msg AutomationRunListMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAutomationDefinitionsGet:
+		var msg AutomationDefinitionsGetMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAutomationRunsGet:
+		var msg AutomationRunsGetMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAutomationSetEnabled:
+		var msg AutomationSetEnabledMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -119,12 +119,87 @@ type AuthorsUpdatedMessage struct {
 	Event string `json:"event"`
 }
 
+type AutomationActionResultMessage struct {
+	// Action corresponds to the JSON schema field "action".
+	Action string `json:"action"`
+
+	// Definitions corresponds to the JSON schema field "definitions".
+	Definitions []AutomationDefinitionSummary `json:"definitions,omitempty,omitzero"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// RunID corresponds to the JSON schema field "run_id".
+	RunID *string `json:"run_id,omitempty,omitzero"`
+
+	// Runs corresponds to the JSON schema field "runs".
+	Runs []AutomationRunSummary `json:"runs,omitempty,omitzero"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID *string `json:"session_id,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+
+	// TicketID corresponds to the JSON schema field "ticket_id".
+	TicketID *string `json:"ticket_id,omitempty,omitzero"`
+
+	// Truncated corresponds to the JSON schema field "truncated".
+	Truncated *bool `json:"truncated,omitempty,omitzero"`
+}
+
 type AutomationApplyMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
 
 	// DefinitionYaml corresponds to the JSON schema field "definition_yaml".
 	DefinitionYaml string `json:"definition_yaml"`
+}
+
+type AutomationDefinitionSummary struct {
+	// CatchUp corresponds to the JSON schema field "catch_up".
+	CatchUp *string `json:"catch_up,omitempty,omitzero"`
+
+	// Continuity corresponds to the JSON schema field "continuity".
+	Continuity *string `json:"continuity,omitempty,omitzero"`
+
+	// Enabled corresponds to the JSON schema field "enabled".
+	Enabled bool `json:"enabled"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
+
+	// Name corresponds to the JSON schema field "name".
+	Name string `json:"name"`
+
+	// Revision corresponds to the JSON schema field "revision".
+	Revision int `json:"revision"`
+
+	// ScheduleCron corresponds to the JSON schema field "schedule_cron".
+	ScheduleCron *string `json:"schedule_cron,omitempty,omitzero"`
+
+	// ScheduleTimeZone corresponds to the JSON schema field "schedule_time_zone".
+	ScheduleTimeZone *string `json:"schedule_time_zone,omitempty,omitzero"`
+
+	// TriggerType corresponds to the JSON schema field "trigger_type".
+	TriggerType string `json:"trigger_type"`
+
+	// UpdatedAt corresponds to the JSON schema field "updated_at".
+	UpdatedAt string `json:"updated_at"`
+}
+
+type AutomationDefinitionsGetMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
 }
 
 type AutomationListMessage struct {
@@ -157,12 +232,86 @@ type AutomationRunMessage struct {
 	RequestID string `json:"request_id"`
 }
 
+type AutomationRunSummary struct {
+	// CreatedAt corresponds to the JSON schema field "created_at".
+	CreatedAt string `json:"created_at"`
+
+	// DefinitionID corresponds to the JSON schema field "definition_id".
+	DefinitionID string `json:"definition_id"`
+
+	// DefinitionRevision corresponds to the JSON schema field "definition_revision".
+	DefinitionRevision int `json:"definition_revision"`
+
+	// DeliveredAt corresponds to the JSON schema field "delivered_at".
+	DeliveredAt *string `json:"delivered_at,omitempty,omitzero"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
+
+	// LastError corresponds to the JSON schema field "last_error".
+	LastError *string `json:"last_error,omitempty,omitzero"`
+
+	// OccurrenceKey corresponds to the JSON schema field "occurrence_key".
+	OccurrenceKey *string `json:"occurrence_key,omitempty,omitzero"`
+
+	// PaneID corresponds to the JSON schema field "pane_id".
+	PaneID *string `json:"pane_id,omitempty,omitzero"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID *string `json:"session_id,omitempty,omitzero"`
+
+	// State corresponds to the JSON schema field "state".
+	State string `json:"state"`
+
+	// TicketID corresponds to the JSON schema field "ticket_id".
+	TicketID *string `json:"ticket_id,omitempty,omitzero"`
+
+	// UpdatedAt corresponds to the JSON schema field "updated_at".
+	UpdatedAt string `json:"updated_at"`
+
+	// WorkspaceID corresponds to the JSON schema field "workspace_id".
+	WorkspaceID *string `json:"workspace_id,omitempty,omitzero"`
+}
+
+type AutomationRunsGetMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// DefinitionID corresponds to the JSON schema field "definition_id".
+	DefinitionID string `json:"definition_id"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+}
+
+type AutomationSetEnabledMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// DefinitionID corresponds to the JSON schema field "definition_id".
+	DefinitionID string `json:"definition_id"`
+
+	// Enabled corresponds to the JSON schema field "enabled".
+	Enabled bool `json:"enabled"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+}
+
 type AutomationShowMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
 
 	// DefinitionID corresponds to the JSON schema field "definition_id".
 	DefinitionID string `json:"definition_id"`
+}
+
+type AutomationsChangedMessage struct {
+	// DefinitionIds corresponds to the JSON schema field "definition_ids".
+	DefinitionIds []string `json:"definition_ids"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
 }
 
 type BootstrapEndpointMessage struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -1577,6 +1577,25 @@ model AutomationShowMessage { cmd: "automation_show"; definition_id: string; }
 model AutomationRunMessage { cmd: "automation_run"; definition_id: string; request_id: string; input_json?: string; pr_url?: string; }
 model AutomationRunListMessage { cmd: "automation_run_list"; definition_id: string; }
 
+// WS-only automations surface: list definitions, list one definition's runs, and
+// toggle enabled. automation_run (above) is reused for WS run-now; it already
+// carries request_id for correlation.
+model AutomationDefinitionsGetMessage {
+  cmd: "automation_definitions_get";
+  request_id?: string;
+}
+model AutomationRunsGetMessage {
+  cmd: "automation_runs_get";
+  definition_id: string;
+  request_id?: string;
+}
+model AutomationSetEnabledMessage {
+  cmd: "automation_set_enabled";
+  definition_id: string;
+  enabled: boolean;
+  request_id?: string;
+}
+
 model SpawnSessionMessage {
   cmd: "spawn_session";
   id: string;
@@ -2599,6 +2618,68 @@ model WorkflowActionResultMessage {
   error?: string;
 }
 
+// Compact automations summaries for the WS surface. Canonical state (full
+// SpecJSON, occurrence payloads, snapshots) stays server-side in SQLite; these
+// carry only what the UI renders. AutomationDefinitionSummary's schedule/policy
+// fields are extracted daemon-side from the definition's SpecJSON.
+model AutomationDefinitionSummary {
+  id: string;
+  name: string;
+  enabled: boolean;
+  revision: int32;
+  trigger_type: string;
+  schedule_cron?: string;
+  schedule_time_zone?: string;
+  continuity?: string;
+  catch_up?: string;
+  updated_at: string;
+}
+
+model AutomationRunSummary {
+  id: string;
+  definition_id: string;
+  definition_revision: int32;
+  state: string;
+  last_error?: string;
+  ticket_id?: string;
+  session_id?: string;
+  workspace_id?: string;
+  pane_id?: string;
+  created_at: string;
+  updated_at: string;
+  delivered_at?: string;
+  occurrence_key?: string;
+}
+
+// Result for the WS automations surface (automation_definitions_get,
+// automation_runs_get, automation_set_enabled, automation_run). Distinct from
+// the unix-socket automation_action_result shape used by the CLI/agent path
+// (see internal/daemon/automations.go's automationActionResult and
+// internal/client's AutomationResult, which carry a generic `data` payload
+// instead of these typed fields): the two are not wire-compatible, so the
+// socket path keeps its own struct.
+model AutomationActionResultMessage {
+  event: "automation_action_result";
+  action: string;
+  request_id?: string;
+  success: boolean;
+  error?: string;
+  definitions?: AutomationDefinitionSummary[];
+  runs?: AutomationRunSummary[];
+  truncated?: boolean;
+  run_id?: string;
+  ticket_id?: string;
+  session_id?: string;
+}
+
+// Compact change signal: canonical state lives in SQLite, so clients re-read
+// (automation_definitions_get / automation_runs_get) on receipt rather than
+// trusting a broadcast payload.
+model AutomationsChangedMessage {
+  event: "automations_changed";
+  definition_ids: string[];
+}
+
 // Reviewer agent streaming events
 model SpawnResultMessage {
   event: "spawn_result";
@@ -3347,6 +3428,8 @@ alias DaemonEvent =
   | GetRepoInfoResultMessage
   | WorkflowRunUpdatedMessage
   | WorkflowActionResultMessage
+  | AutomationActionResultMessage
+  | AutomationsChangedMessage
   | WorkspaceContextResultMessage
   | WorkspaceContextListResultMessage
   | NotebookListResultMessage

--- a/internal/store/automations.go
+++ b/internal/store/automations.go
@@ -113,8 +113,9 @@ func (s *Store) UpsertAutomationDefinition(id, name, specJSON string, enabled bo
 		if err == nil && oldEnabled == 0 && enabled {
 			// Re-enabling begins from the provider's current truth. A request that
 			// arrived while disabled must be eligible for latest catch-up even if an
-			// older cycle for the same subject had been active before disable.
-			_, err = tx.Exec(`UPDATE automation_review_request_edges SET active=0,updated_at=? WHERE definition_id=?`, formatTicketTime(now), id)
+			// older cycle for the same subject had been active before disable. Shared
+			// with SetAutomationEnabled's own enabled-state transition.
+			err = clearAutomationReviewRequestEdgesTx(tx, id, now)
 		}
 	}
 	if err != nil {
@@ -124,9 +125,9 @@ func (s *Store) UpsertAutomationDefinition(id, name, specJSON string, enabled bo
 		// Fence provider snapshots that began before this definition became
 		// active (or was reapplied). Observation timestamps are captured before
 		// provider fetches, so an in-flight stale refresh cannot launch work under
-		// a newly enabled revision.
-		fence := now.UTC().Format(time.RFC3339Nano)
-		if _, err := tx.Exec(`INSERT INTO automation_provider_cursors(definition_id,provider,scope,observed_at) VALUES(?,'github_review_requested','*',?) ON CONFLICT(definition_id,provider,scope) DO UPDATE SET observed_at=excluded.observed_at`, id, fence); err != nil {
+		// a newly enabled revision. Unlike the edge clear above, this runs on
+		// every apply that leaves the definition enabled, not just a transition.
+		if err := fenceAutomationProviderCursorsTx(tx, id, now); err != nil {
 			return nil, err
 		}
 	}
@@ -136,6 +137,84 @@ func (s *Store) UpsertAutomationDefinition(id, name, specJSON string, enabled bo
 	s.mu.Unlock()
 	locked = false
 	return s.GetAutomationDefinition(id)
+}
+
+// clearAutomationReviewRequestEdgesTx deactivates every review-request edge for
+// a definition, so a fresh provider observation after re-enabling accepts
+// latest demand instead of an older, possibly-stale cycle.
+func clearAutomationReviewRequestEdgesTx(tx *sql.Tx, definitionID string, now time.Time) error {
+	_, err := tx.Exec(`UPDATE automation_review_request_edges SET active=0,updated_at=? WHERE definition_id=?`, formatTicketTime(now), definitionID)
+	return err
+}
+
+// fenceAutomationProviderCursorsTx records the instant a definition became (or
+// remained) enabled as its github_review_requested provider fence. Observation
+// timestamps are captured before provider fetches, so an in-flight stale
+// refresh started before this fence cannot launch work under the newly
+// enabled/reapplied revision.
+func fenceAutomationProviderCursorsTx(tx *sql.Tx, definitionID string, now time.Time) error {
+	fence := now.UTC().Format(time.RFC3339Nano)
+	_, err := tx.Exec(`INSERT INTO automation_provider_cursors(definition_id,provider,scope,observed_at) VALUES(?,'github_review_requested','*',?) ON CONFLICT(definition_id,provider,scope) DO UPDATE SET observed_at=excluded.observed_at`, definitionID, fence)
+	return err
+}
+
+// SetAutomationEnabled flips a definition's enabled flag directly (unlike
+// UpsertAutomationDefinition, without touching its spec/revision) and, on an
+// actual disabled->enabled transition, performs the same store-side effects
+// Upsert does for that transition: clearing review-request edges and fencing
+// provider cursors. It is a no-op (changed=false, no side effects) when the
+// definition already has the requested state. Returns (nil, false, nil) for an
+// unknown or soft-deleted definition.
+func (s *Store) SetAutomationEnabled(id string, enabled bool, now time.Time) (*AutomationDefinition, bool, error) {
+	s.mu.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			s.mu.Unlock()
+		}
+	}()
+	if s.db == nil {
+		return nil, false, errors.New("automation persistence unavailable")
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, false, err
+	}
+	defer tx.Rollback()
+	var oldEnabled int
+	err = tx.QueryRow(`SELECT enabled FROM automation_definitions WHERE id=? AND deleted_at=''`, id).Scan(&oldEnabled)
+	if err == sql.ErrNoRows {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	wasEnabled := oldEnabled != 0
+	if wasEnabled == enabled {
+		tx.Rollback()
+		s.mu.Unlock()
+		locked = false
+		def, getErr := s.GetAutomationDefinition(id)
+		return def, false, getErr
+	}
+	if _, err := tx.Exec(`UPDATE automation_definitions SET enabled=?, updated_at=? WHERE id=?`, enabled, formatTicketTime(now), id); err != nil {
+		return nil, false, err
+	}
+	if enabled {
+		if err := clearAutomationReviewRequestEdgesTx(tx, id, now); err != nil {
+			return nil, false, err
+		}
+		if err := fenceAutomationProviderCursorsTx(tx, id, now); err != nil {
+			return nil, false, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, false, err
+	}
+	s.mu.Unlock()
+	locked = false
+	def, getErr := s.GetAutomationDefinition(id)
+	return def, true, getErr
 }
 
 func scanAutomationDefinition(scanner interface{ Scan(...any) error }) (*AutomationDefinition, error) {
@@ -799,6 +878,51 @@ func (s *Store) ListAutomationRuns(definitionID string) ([]AutomationRun, error)
 	}
 	return out, rows.Err()
 }
+
+// AutomationRunWithOccurrenceKey pairs a run with its occurrence's
+// occurrence_key, for surfaces (the WS runs list) that need to show which
+// provider occurrence produced the run without exposing its full payload.
+type AutomationRunWithOccurrenceKey struct {
+	AutomationRun
+	OccurrenceKey string
+}
+
+// ListAutomationRunsWithOccurrenceKeys returns up to limit runs for
+// definitionID, newest first, each carrying its occurrence's occurrence_key
+// via one join (mirrors ListAutomationRuns's columns/ordering).
+func (s *Store) ListAutomationRunsWithOccurrenceKeys(definitionID string, limit int) ([]AutomationRunWithOccurrenceKey, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.Query(`
+		SELECT r.id,r.definition_id,r.occurrence_id,r.definition_revision,r.snapshot_json,r.state,r.last_error,r.ticket_id,r.session_id,r.workspace_id,r.pane_id,r.resolved_location_json,r.created_at,r.updated_at,r.delivered_at,o.occurrence_key
+		FROM automation_runs r
+		JOIN automation_occurrences o ON o.id=r.occurrence_id
+		WHERE r.definition_id=?
+		ORDER BY r.created_at DESC
+		LIMIT ?
+	`, definitionID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []AutomationRunWithOccurrenceKey
+	for rows.Next() {
+		var r AutomationRun
+		var created, updated, delivered, occurrenceKey string
+		if err := rows.Scan(&r.ID, &r.DefinitionID, &r.OccurrenceID, &r.DefinitionRevision, &r.SnapshotJSON, &r.State, &r.LastError, &r.TicketID, &r.SessionID, &r.WorkspaceID, &r.PaneID, &r.ResolvedLocationJSON, &created, &updated, &delivered, &occurrenceKey); err != nil {
+			return nil, err
+		}
+		r.CreatedAt = parseTicketTime(created)
+		r.UpdatedAt = parseTicketTime(updated)
+		r.DeliveredAt = parseOptionalAutomationTime(delivered)
+		out = append(out, AutomationRunWithOccurrenceKey{AutomationRun: r, OccurrenceKey: occurrenceKey})
+	}
+	return out, rows.Err()
+}
+
 func (s *Store) ListPendingAutomationRuns() ([]AutomationRun, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/store/automations_test.go
+++ b/internal/store/automations_test.go
@@ -282,6 +282,52 @@ func TestAutomationScheduleCursorGetSetRoundtrip(t *testing.T) {
 	}
 }
 
+func TestListAutomationRunsWithOccurrenceKeysOrdersNewestFirstWithLimit(t *testing.T) {
+	s := New()
+	base := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	def, err := s.UpsertAutomationDefinition("cleanup", "Cleanup", `{"id":"cleanup"}`, true, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed := func(requestID string, at time.Time) *AutomationRun {
+		ids := AutomationRunReservation{
+			RunID:        "run-" + requestID,
+			OccurrenceID: "occ-" + requestID,
+			TicketID:     "ticket-" + requestID,
+			SessionID:    "session-" + requestID,
+			WorkspaceID:  "workspace-" + requestID,
+			PaneID:       "pane-" + requestID,
+		}
+		run, created, err := s.ClaimManualAutomationRun(def.ID, requestID, "", `{}`, def.Revision, `{}`, at, ids)
+		if err != nil || !created {
+			t.Fatalf("claim %s created=%v err=%v", requestID, created, err)
+		}
+		return run
+	}
+	// Distinct clock-injected timestamps, not wall-clock spacing, so ordering
+	// is deterministic regardless of test execution speed.
+	seed("req-1", base)
+	second := seed("req-2", base.Add(time.Minute))
+	third := seed("req-3", base.Add(2*time.Minute))
+
+	runs, err := s.ListAutomationRunsWithOccurrenceKeys(def.ID, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("len(runs)=%d, want 2: %#v", len(runs), runs)
+	}
+	if runs[0].ID != third.ID || runs[0].OccurrenceKey != "manual:req-3" {
+		t.Fatalf("newest run = %#v, want run %s with occurrence_key manual:req-3", runs[0], third.ID)
+	}
+	if runs[1].ID != second.ID || runs[1].OccurrenceKey != "manual:req-2" {
+		t.Fatalf("second-newest run = %#v, want run %s with occurrence_key manual:req-2", runs[1], second.ID)
+	}
+	if !runs[0].CreatedAt.After(runs[1].CreatedAt) {
+		t.Fatalf("runs not newest-first by created_at: %v then %v", runs[0].CreatedAt, runs[1].CreatedAt)
+	}
+}
+
 func TestListPendingAutomationRunsIncludesScheduledProvider(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)

--- a/internal/store/automations_test.go
+++ b/internal/store/automations_test.go
@@ -724,3 +724,78 @@ func TestGitHubReviewCursorOrdersObservationsWithinOneSecond(t *testing.T) {
 		t.Fatal("stale same-second observation reactivated withdrawn demand")
 	}
 }
+
+func TestSetAutomationEnabledFlipsStateAndIsIdempotent(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	def, err := s.UpsertAutomationDefinition("daily-check", "Daily check", `{}`, true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-applying the current state is a no-op: changed=false, no update.
+	got, changed, err := s.SetAutomationEnabled(def.ID, true, now.Add(time.Minute))
+	if err != nil || changed || got == nil || !got.Enabled {
+		t.Fatalf("no-op enable: def=%#v changed=%v err=%v", got, changed, err)
+	}
+	if !got.UpdatedAt.Equal(def.UpdatedAt) {
+		t.Fatalf("no-op enable touched updated_at: got %v, want %v", got.UpdatedAt, def.UpdatedAt)
+	}
+
+	disabled, changed, err := s.SetAutomationEnabled(def.ID, false, now.Add(2*time.Minute))
+	if err != nil || !changed || disabled == nil || disabled.Enabled {
+		t.Fatalf("disable: def=%#v changed=%v err=%v", disabled, changed, err)
+	}
+
+	againNoOp, changed, err := s.SetAutomationEnabled(def.ID, false, now.Add(3*time.Minute))
+	if err != nil || changed || againNoOp == nil || againNoOp.Enabled {
+		t.Fatalf("no-op disable: def=%#v changed=%v err=%v", againNoOp, changed, err)
+	}
+
+	reenabled, changed, err := s.SetAutomationEnabled(def.ID, true, now.Add(4*time.Minute))
+	if err != nil || !changed || reenabled == nil || !reenabled.Enabled {
+		t.Fatalf("re-enable: def=%#v changed=%v err=%v", reenabled, changed, err)
+	}
+
+	missing, changed, err := s.SetAutomationEnabled("does-not-exist", true, now)
+	if err != nil || changed || missing != nil {
+		t.Fatalf("unknown id: def=%#v changed=%v err=%v", missing, changed, err)
+	}
+}
+
+// TestSetAutomationEnabledReenableCatchesUpCurrentReviewDemand is the
+// SetAutomationEnabled parity of TestReenabledGitHubAutomationCatchesUpCurrentReviewDemand
+// above: the disable/re-enable cycle drives through SetAutomationEnabled
+// instead of UpsertAutomationDefinition, and must produce the identical
+// review-request-edge-clear + provider-cursor-fence side effects.
+func TestSetAutomationEnabledReenableCatchesUpCurrentReviewDemand(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	const spec = `{"id":"review"}`
+	def, err := s.UpsertAutomationDefinition("review", "Review", spec, true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const subject = "github.com/owner/repo#42"
+	if _, err := s.ReconcileAutomationReviewRequests(def.ID, "github.com", []string{subject}, now); err != nil {
+		t.Fatal(err)
+	}
+	ids := AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"}
+	if _, created, err := s.ClaimGitHubReviewAutomationRun(def.ID, subject, 1, def.Revision, `{}`, `{}`, now, ids); err != nil || !created {
+		t.Fatalf("initial claim created=%v err=%v", created, err)
+	}
+	if _, changed, err := s.SetAutomationEnabled(def.ID, false, now.Add(time.Minute)); err != nil || !changed {
+		t.Fatalf("disable: changed=%v err=%v", changed, err)
+	}
+	if _, changed, err := s.SetAutomationEnabled(def.ID, true, now.Add(2*time.Minute)); err != nil || !changed {
+		t.Fatalf("re-enable: changed=%v err=%v", changed, err)
+	}
+	stale, err := s.ReconcileAutomationReviewRequests(def.ID, "github.com", []string{subject}, now.Add(90*time.Second))
+	if err != nil || len(stale) != 0 {
+		t.Fatalf("pre-enable observation crossed enable fence: candidates=%#v err=%v", stale, err)
+	}
+	candidates, err := s.ReconcileAutomationReviewRequests(def.ID, "github.com", []string{subject}, now.Add(3*time.Minute))
+	if err != nil || len(candidates) != 1 || candidates[0].Cycle != 2 {
+		t.Fatalf("re-enabled latest catch-up candidates=%#v err=%v", candidates, err)
+	}
+}


### PR DESCRIPTION
# Automations: profile-level surface (Slice 6)

Slice 6 of the [Automations implementation plan](docs/plans/2026-07-18-attn-automations-implementation.md): the first operational UI for automations. A dock panel lists every definition with its trigger, enable/disable toggle, run-now for manual definitions, and run history with navigation to the run's ticket/session.

## What's in it

**Protocol (175 → 176).** Three new WS commands (`automation_definitions_get`, `automation_runs_get`, `automation_set_enabled`; the existing `automation_run` message is reused for run-now) answered by a typed `automation_action_result` correlated by `request_id`, plus a thin `automations_changed` broadcast carrying definition ids only. The broadcast is emitted from the daemon's core mutation/transition methods (apply, claim on all three trigger paths, fail, deliver, set-enabled), so CLI-socket and WS mutations both fan out; the frontend re-reads canonical SQLite state via the get commands instead of trusting event payloads. `automation_action_result` is deliberately not merged with the legacy unix-socket result shape (generic `data`) — they are not wire-compatible.

**Daemon.** `automationSetEnabled` flips the flag without touching spec/revision; re-enable shares the apply path's side effects (clears review-request edges, fences provider cursors), disable fails pending runs. Run-now is idempotent per `request_id` (persisted as the manual claim key). Runs-get is capped at 100 with an explicit `truncated` flag. WS `automation_run` mirrors the socket arm's `pr_url`/`input_json` mutual exclusion and routing.

**Frontend.** `AutomationsPanel` as a new dock panel, backed by a small Zustand store keyed by a `changedTick` that bumps on `automations_changed` and on every (re)connect (panel recovers across daemon restarts). No optimistic toggles — every mutation round-trips and errors render inline per definition. Run rows navigate to their ticket or session (empty-string pointer = absent). Wrapper timeouts are 30s: mutations can serialize behind an in-flight delivery holding `automationMu` (pre-existing lock structure, deliberately not restructured in this slice).

## Verification

- `go build ./...`, `go test ./internal/store ./internal/daemon`, `tsc --noEmit`, full frontend vitest suite green on `d6844d68` (the head minus the docs-only commit).
- Adversarial verify gate over the slice diff (4 lenses, 2 refuters per finding): 10 confirmed findings, all fixed in `d6844d68` (claim-time broadcasts on scheduled/GitHub paths, reconnect refetch, WS `pr_url` routing, timeout convention, dead label branch, plus the missing unit coverage for the hook pipe, store ordering/limit, and non-manual rejection).
- Live packaged evidence on the isolated `automations` profile (protocol 176 lockstep preflight PASS), scripted serial scenario `real-app:scenario-automation-surface`, run `automation-surface-2026-07-20T15-00-09-048Z`, all 4 legs green against the app built from `d6844d68` (this branch's last code commit; `3e9737d4` on top is docs-only): CLI-applied definition appears via broadcast; run-now yields exactly one delivered navigable run with no duplicate on reopen; disabled-definition run-now surfaces the daemon rejection inline without creating a run; full daemon restart preserves definitions and the same run id, still navigable.

Slice 7 (self-service editor, edit/delete lifecycle, retention/policy depth) follows.
