### PR TITLE
fix(build): stop shipping a stale embedded frontend; de-flake split-blank-repro

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,15 @@ permissions.
 - Non-production builds, installs, launches, and restarts are pre-authorized.
 - Production `make`, `make install`, and `make install-daemon` require Victor's
   explicit approval.
-- Default to `make dev`; use `make install-daemon-dev` for daemon-only changes.
+- Install the cheapest tier that covers the change:
+  - Go-only change (`cmd/attn`, `internal/**`) → `make install-daemon-dev`, or
+    `make install-daemon PROFILE=<name>`. Replaces and re-signs the sidecar and
+    restarts the daemon; no Tauri/Rust/frontend build.
+  - Anything under `app/` (frontend, `src-tauri`, plugins), a protocol change
+    (`generated.ts` moves with `generated.go`), or bundle metadata → `make dev`,
+    or `make install PROFILE=<name>`.
+  Escalate to the full build when unsure, or when a daemon-only install does not
+  show the change.
 - Named profile: select it with `eval "$(./attn profile-env <name>)"`, then run
   `make install PROFILE=<name>`. The shell's `ATTN_PROFILE` must match.
 - `profile-env` clears inherited routing overrides. Verify the emitted

--- a/app/e2e/split-blank-repro.spec.ts
+++ b/app/e2e/split-blank-repro.spec.ts
@@ -79,10 +79,7 @@ test('agent pane stays painted after opening a shell split', async ({ page, daem
   const terminal = await setupAgent(page, daemon, agentId);
 
   // 1) Paint a full frame and confirm it actually rendered (high quad count).
-  await emit(page, agentId, fullFrame('OLD'));
-  await expect
-    .poll(async () => page.evaluate((sid) => window.__TEST_GET_SESSION_PANE_TEXT?.(sid) ?? '', agentId), { timeout: 5000 })
-    .toContain('OLD line 0');
+  await emitUntilVisible(page, agentId, fullFrame('OLD'), 'OLD line 0');
   await expect
     .poll(async () => {
       const trace = await readTrace(page, agentId);
@@ -164,6 +161,46 @@ async function setupAgent(
   return terminal;
 }
 
+// Emit setup content and keep re-emitting until the model actually shows it.
+//
+// A single `__TEST_EMIT_PTY_DATA` can be lost: it traverses the router's binding
+// lookup (paneRuntimeEventRouter.handleEvent `if (!match) return`), the pane's
+// handle lookup (useGhosttyPaneRuntime.deliverEvent `if (!terminal) return`),
+// and a fire-and-forget `void terminal.write(...)` — each of which drops
+// silently when the pane is not fully wired. `expect.poll` on the pane text
+// re-READS but never re-SENDS, so one lost emit could only ever expire at the
+// deadline. That is the observed CI flake: these specs failed at 5.9s on
+// `toContain('OLD line 0')` against a 5s poll, i.e. ~0.9s of setup and then a
+// full 5s of fruitless re-reads — a dropped emit, not a slow machine.
+//
+// Re-emitting closes that hole and is timing-independent rather than tuned to a
+// machine's speed. `fullFrame` is idempotent (it opens with `2J`/`H` and
+// absolutely positions every row), so a repeat repaints identical content. A
+// non-idempotent payload (scrollback, which appends) is still safe here: a retry
+// only happens when the previous emit produced nothing at all, since any visible
+// marker ends the poll.
+//
+// Use this ONLY for scaffolding. The post-split redraw each test actually
+// exercises must stay a single emit: its timing against the resize IS the
+// behaviour under test, and retrying it would paper over the very bug these
+// specs exist to catch.
+async function emitUntilVisible(
+  page: import('@playwright/test').Page,
+  sessionId: string,
+  data: string,
+  marker: string,
+) {
+  await expect
+    .poll(async () => {
+      await emit(page, sessionId, data);
+      return page.evaluate((sid) => window.__TEST_GET_SESSION_PANE_TEXT?.(sid) ?? '', sessionId);
+    }, {
+      timeout: 15000,
+      message: `setup frame never reached the model for ${sessionId} (emit dropped before the pane was wired)`,
+    })
+    .toContain(marker);
+}
+
 // The terminal CONTAINER becoming visible is not the same as the pane being
 // ready to receive PTY data. `__TEST_EMIT_PTY_DATA` delivers to the live
 // terminal handle and silently DROPS the event when no handle is registered yet
@@ -173,9 +210,15 @@ async function setupAgent(
 // visible. Emitting in that window loses the bytes and the model never updates,
 // so the downstream `toContain('… line 0')` poll times out — the flake. In prod
 // this race cannot happen: data only arrives in response to attach, which is
-// itself fired from handleTerminalReady (after the handle exists). `getPaneSize`
-// returns a size only once the handle is registered, so it is the precise
-// "emit will be delivered" signal to gate on.
+// itself fired from handleTerminalReady (after the handle exists).
+//
+// `getPaneSize` returning non-null proves that one handle exists, so this gate
+// is necessary — but it is NOT sufficient, and this comment used to claim it
+// was. It misses the router's own binding lookup, and it reads `getSize()`,
+// which GhosttyTerminalHandle documents as reporting the model's provisional
+// construction default until a real fit lands. `emitUntilVisible` covers the
+// remaining gap for setup frames; keep this cheap gate first so the common case
+// settles before any retry loop starts.
 async function waitForPaneReady(
   page: import('@playwright/test').Page,
   sessionId: string,
@@ -229,8 +272,7 @@ test('agent stays painted when split races a chunked redraw', async ({ page, dae
   const agentId = 's-agent-race';
   const terminal = await setupAgent(page, daemon, agentId);
 
-  await emit(page, agentId, fullFrame('OLD'));
-  await expect.poll(async () => page.evaluate((sid) => window.__TEST_GET_SESSION_PANE_TEXT?.(sid) ?? '', agentId), { timeout: 5000 }).toContain('OLD line 0');
+  await emitUntilVisible(page, agentId, fullFrame('OLD'), 'OLD line 0');
   await page.evaluate(() => { (window as Window & { __ATTN_RENDER_TRACE?: unknown[] }).__ATTN_RENDER_TRACE = []; });
 
   // Open a synchronized frame (no close) — mid-frame, like the live log.
@@ -274,9 +316,11 @@ test('agent stays painted when split lands while scrolled up', async ({ page, da
 
   // Build scrollback so wheel-up produces a non-zero viewport offset.
   const scrollback = Array.from({ length: 200 }, (_, i) => `HIST line ${String(i).padStart(3, '0')}`).join('\r\n');
-  await emit(page, agentId, `${ESC}[2J${ESC}[H${scrollback}`);
-  await emit(page, agentId, fullFrame('OLD'));
-  await expect.poll(async () => page.evaluate((sid) => window.__TEST_GET_SESSION_PANE_TEXT?.(sid) ?? '', agentId), { timeout: 5000 }).toContain('OLD line 0');
+  // Assert the scrollback landed rather than assuming it: if this emit were
+  // dropped the wheel-up below would produce a zero offset and the test would
+  // still pass, having silently stopped exercising the scrolled-up case.
+  await emitUntilVisible(page, agentId, `${ESC}[2J${ESC}[H${scrollback}`, 'HIST line 199');
+  await emitUntilVisible(page, agentId, fullFrame('OLD'), 'OLD line 0');
 
   // Scroll up.
   await terminal.hover({ position: { x: 80, y: 200 } });

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -16,6 +16,10 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
+# Used by build.rs to read `build.frontendDist` out of tauri.conf.json so the
+# built frontend can be declared a cargo input. Already a runtime dependency of
+# this crate, so this resolves to the same version and leaves Cargo.lock alone.
+serde_json = "1"
 
 [dependencies]
 tauri = { version = "=2.11.2", features = ["protocol-asset", "unstable"] }

--- a/app/src-tauri/build.rs
+++ b/app/src-tauri/build.rs
@@ -1,3 +1,55 @@
+use std::path::Path;
+
 fn main() {
+    track_frontend_dist();
     tauri_build::build()
+}
+
+/// Teach cargo that the built frontend is an input to this crate.
+///
+/// `tauri::generate_context!()` embeds `build.frontendDist` when the proc macro
+/// expands, but `tauri_build::build()` only emits a `rerun-if-changed` for that
+/// directory on the opt-in codegen path (`CodegenContext`, which we do not use:
+/// it resolves the config at build-script time and so would not see the
+/// `--config` overlay that named-profile builds pass). With the plain macro,
+/// cargo never learns `app/dist` is an input — a frontend-only change leaves the
+/// crate "fresh", the crate is not recompiled, and the packaged app ships the
+/// previously embedded assets.
+///
+/// That staleness is why installing used to require
+/// `touch app/src-tauri/src/lib.rs` first. Emitting the dependency here is
+/// purely additive (it can only cause more rebuilds, never a wrong one) and
+/// lets incremental Rust builds work for Go-only and backend-only changes.
+fn track_frontend_dist() {
+    let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") else {
+        return;
+    };
+    let manifest_dir = Path::new(&manifest_dir);
+
+    let Ok(raw) = std::fs::read_to_string(manifest_dir.join("tauri.conf.json")) else {
+        return;
+    };
+    let Ok(config) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return;
+    };
+    let Some(dist) = config
+        .pointer("/build/frontendDist")
+        .and_then(serde_json::Value::as_str)
+    else {
+        return;
+    };
+
+    // `frontendDist` may also be a dev-server URL or an explicit file list;
+    // only a directory path is meaningful to track here.
+    if dist.starts_with("http://") || dist.starts_with("https://") {
+        return;
+    }
+
+    let dist_dir = manifest_dir.join(dist);
+    if dist_dir.is_dir() {
+        // Track the directory rather than its files: cargo rescans it on each
+        // build, so additions and deletions register too. Vite emits
+        // content-hashed filenames, so any frontend change alters the set.
+        println!("cargo:rerun-if-changed={}", dist_dir.display());
+    }
 }

--- a/app/src-tauri/build.rs
+++ b/app/src-tauri/build.rs
@@ -17,9 +17,17 @@ fn main() {
 /// previously embedded assets.
 ///
 /// That staleness is why installing used to require
-/// `touch app/src-tauri/src/lib.rs` first. Emitting the dependency here is
-/// purely additive (it can only cause more rebuilds, never a wrong one) and
-/// lets incremental Rust builds work for Go-only and backend-only changes.
+/// `touch app/src-tauri/src/lib.rs` first. Emitting the dependency here can only
+/// cause more rebuilds, never a wrong one.
+///
+/// Note what it does NOT buy. `make dev` runs vite first, and vite's
+/// `emptyOutDir` default wipes and rewrites `dist` every time, so the directory
+/// mtime always advances and this crate recompiles on every `make dev` even with
+/// no frontend change (measured back to back with no edits: 27.7s then 29.1s of
+/// a ~50s build). That is exactly what the `touch lib.rs` workaround already
+/// cost, so it is not a regression against how this was actually built — it buys
+/// correctness, not speed. Go-only changes stay fast via
+/// `make install-daemon-dev`, which never builds Tauri at all.
 fn track_frontend_dist() {
     let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") else {
         return;


### PR DESCRIPTION
Three fixes to the build-and-verify loop, found while investigating why the
automations epic (#614–#619) was expensive to run.

## 1. `build.rs` — cargo was never told `app/dist` is an input

`tauri::generate_context!()` embeds `build.frontendDist` when the proc macro
expands, and proc macros cannot emit `cargo:rerun-if-changed`.
`tauri_build::build()` emits that directive for `frontendDist` only on the
opt-in `CodegenContext` path, which we do not use — it resolves the config at
build-script time and so would not see the `--config` overlay named-profile
builds pass.

So on a frontend-only change the crate was **genuinely fresh** and cargo
correctly skipped it — shipping the previously embedded assets. Not a caching
quirk; a missing dependency edge. `build.rs` now reads `build.frontendDist` out
of `tauri.conf.json` and emits the directive itself.

A/B on a frontend-only change:

| `build.rs` | cargo |
|---|---|
| before | `Finished in 0.41s` — no recompile, ships stale assets |
| after | `Compiling app v0.11.1` |

Emitting this is purely additive: it can cause more rebuilds, never a wrong one.

This is what made `touch app/src-tauri/src/lib.rs` a necessary ritual — a
workaround that appears in no repo doc. A known-broken incremental path is why
the epic ran **13 full `make install` and zero `make install-daemon-dev`**.

## 2. `AGENTS.md` — install-tier guidance

Now that the cheap tiers are trustworthy, the guidance is an explicit rule keyed
on what changed (Go-only → daemon-only install; anything under `app/`, a
protocol change, or bundle metadata → full build), with "escalate when unsure."

## 3. `split-blank-repro.spec.ts` — de-flaked, not quarantined

`:68` and `:219` each failed 3× in CI during the epic, costing `gh run rerun`
cycles.

A single `__TEST_EMIT_PTY_DATA` can be dropped silently at three points: the
router's binding lookup (`paneRuntimeEventRouter.handleEvent`), the pane's
handle lookup (`useGhosttyPaneRuntime.deliverEvent`), and the fire-and-forget
`void terminal.write(...)`. `expect.poll` re-**read** the pane text but never
re-**sent** it, so one lost emit could only ever expire at the deadline.

That matches the CI failures exactly — **5.9s against a 5s poll**, i.e. ~0.9s of
setup then a full 5s of fruitless re-reads. The runner was responsive; an emit
was lost.

Setup frames now re-emit until the model shows them. Retry is applied **only to
scaffolding** — the post-split redraw stays a single emit, because its timing
against the resize is the behaviour under test and retrying it would mask the
very bug these specs exist to catch. The scrollback emit is also now asserted
rather than assumed: if it were dropped, wheel-up would yield a zero offset and
the test would pass while exercising nothing.

Also corrected a comment claiming `getPaneSize` was "the precise 'emit will be
delivered' signal" — it isn't: it misses the router binding, and reads a size
`GhosttyTerminalHandle` documents as provisional until a real fit lands.

## Verification

- **Injected-drop control/treatment**: dropping exactly one emit reproduces the
  CI error verbatim (`expect(received).toContain(expected) // indexOf`); the new
  helper survives the identical drop. Deterministic and load-independent.
- Spec **20/20** via `--repeat-each=5` on an idle machine.
- Full e2e suite: **189 passed**, 1 skipped.
- `make dev`: compiles, bundles, signs, installs, launches (exit 0) — the live
  verification for the `app/src-tauri` change.

I could not reproduce the flake *naturally* — CDP CPU throttling, load
saturation and repeat runs all stayed green. The fix rests on the failure
signature and timing plus the injected-drop proof, not on a natural repro.

No `CHANGELOG` entry: docs, build system, and test-only changes.
