### PR TITLE
test(e2e): de-flake terminal specs racing the mock pty banner

### DIFF
--- a/app/e2e/fixtures.ts
+++ b/app/e2e/fixtures.ts
@@ -630,4 +630,53 @@ export const test = base.extend<Fixtures>({
   },
 });
 
+/**
+ * Wait until the mock PTY's startup banner has landed in a session's pane.
+ *
+ * The mock backend emits `attn mock pty: <id>` on a 30ms timer inside
+ * `ptyAttach` (`src/pty/bridge.ts`). The pane is already registered by then —
+ * `useGhosttyPaneRuntime` records `connect_terminal` *before* it calls
+ * `ptyAttach` — so the banner reliably reaches the pane; the only question is
+ * whether it arrives before or after the test's own first write.
+ *
+ * Tests that open a session and immediately write `[2J[H` + content
+ * are racing that timer. Usually `expect.poll` notices `connect_terminal` on a
+ * tick 100ms+ later, the banner has already landed, and the `[2J` wipes it. But
+ * when the poll happens to catch it inside the 30ms window, the test writes
+ * first and the banner then lands *at the cursor*, directly appended to the
+ * test's own output. Two CI failures on 2026-07-20, both of which passed on a
+ * re-run of the same commit:
+ *
+ *   terminal-interactions: "…/terminal-link" + "attn mock pty: s-link"
+ *                          → link hit-test returned "…/terminal-linkattn"
+ *   terminal-find:         "Case case CASE" + "attn mock pty: s-find-case"
+ *                          → find counted 4 matches for "case" instead of 3
+ *                            (the session id itself contains "case")
+ *
+ * Note that the screen assertions these tests make first — `.toContain(...)` on
+ * the pane text — cannot catch this: they are satisfied by a screen that also
+ * carries the banner. Only the *derived* assertion (a match count, an extracted
+ * URL) sees the damage, which is why the failure looks unrelated to timing.
+ *
+ * Gating on the banner makes the subsequent `[2J[H` meaningful: it clears a
+ * known screen instead of an arbitrary point in the startup race. Call this
+ * after the pane is ready and before writing test output.
+ */
+export async function waitForMockPtyBanner(
+  page: import('@playwright/test').Page,
+  sessionId: string,
+) {
+  await expect
+    .poll(
+      async () => page.evaluate((id) => window.__TEST_GET_SESSION_PANE_TEXT?.(id) ?? '', sessionId),
+      {
+        timeout: 5000,
+        message:
+          `mock pty banner never reached the pane for ${sessionId}; the session did not `
+          + `attach, or startup output is being dropped before the pane registers`,
+      },
+    )
+    .toContain(`attn mock pty: ${sessionId}`);
+}
+
 export { expect };

--- a/app/e2e/terminal-blocks.spec.ts
+++ b/app/e2e/terminal-blocks.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect, waitForMockPtyBanner } from './fixtures';
 
 const OSC = ']133;';
 const BEL = '';
@@ -58,6 +58,9 @@ async function openTerminalSession(
       { timeout: 5000 },
     )
     .toBe(true);
+  // connect_terminal fires before ptyAttach, so the mock banner is still in
+  // flight here. Let it land before the caller clears the screen.
+  await waitForMockPtyBanner(page, sessionId);
   return terminal;
 }
 

--- a/app/e2e/terminal-find.spec.ts
+++ b/app/e2e/terminal-find.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect, waitForMockPtyBanner } from './fixtures';
 
 declare global {
   interface Window {
@@ -48,6 +48,9 @@ async function openTerminalSession(
       { timeout: 5000 },
     )
     .toBe(true);
+  // connect_terminal fires before ptyAttach, so the mock banner is still in
+  // flight here. Let it land before the caller clears the screen.
+  await waitForMockPtyBanner(page, sessionId);
   return terminal;
 }
 

--- a/app/e2e/terminal-interactions.spec.ts
+++ b/app/e2e/terminal-interactions.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect, waitForMockPtyBanner } from './fixtures';
 
 async function createSession(
   page: import('@playwright/test').Page,
@@ -133,6 +133,9 @@ async function openTerminalSession(
       { timeout: 10000 },
     )
     .not.toBeNull();
+  // A measured pane does not mean the session's startup output has arrived.
+  // Let the mock banner land before the caller clears the screen.
+  await waitForMockPtyBanner(page, sessionId);
   return terminal;
 }
 


### PR DESCRIPTION
## What

Three e2e specs open a session, gate on `connect_terminal`, then immediately write `ESC[2J ESC[H` + content. That races the mock PTY's startup banner, which corrupts assertions derived from the pane.

## Root cause

`src/pty/bridge.ts` emits `attn mock pty: <id>` on a **30ms timer** inside `ptyAttach`. `useGhosttyPaneRuntime` records `connect_terminal` *before* it calls `ptyAttach` (`useGhosttyPaneRuntime.ts:244` vs `:253`), so the pane is already registered and the banner reliably arrives — the only question is whether it lands before or after the test's first write.

Usually `expect.poll` notices `connect_terminal` on a tick 100ms+ later, the banner has already landed, and the `2J` wipes it. When the poll catches it *inside* the 30ms window, the test writes first and the banner lands **at the cursor**, appended to the test's own output:

| spec | pane ends up as | assertion sees |
|---|---|---|
| terminal-interactions | `.../terminal-link` + `attn mock pty: s-link` | `.../terminal-link**attn**` |
| terminal-find | `Case case CASE` + `attn mock pty: s-find-**case**` | `4/4` instead of `3/3` |

The find case is a nice coincidence: the session id `s-find-case` itself contains a fourth `case`.

Note the first-line assertions **cannot** catch this — `.toContain(...)` is satisfied by a pane that also carries the banner. Only the *derived* assertion (a match count, an extracted URL) sees the damage, which is why the failure reads as unrelated to timing.

## Observed

CI run [29776474100](https://github.com/victorarias/attn/actions/runs/29776474100) on #620, shard 3/3. Both tests failed on attempt 1 and passed on a re-run of the **same commit** (the only diff in that PR's second push was a Rust doc comment, and the E2E job does not build `src-tauri`).

## Fix

`waitForMockPtyBanner()` in `e2e/fixtures.ts`, called after the pane is ready and before any test output. Gating on the banner makes the subsequent `2J` meaningful: it clears a *known* screen instead of an arbitrary point in the startup race. `terminal-blocks` shares the pattern and gets the same guard preventively.

No production code changed.

## Verification

Reproduced deterministically by widening the banner timer, then control/treatment:

| banner delay | without fix | with fix |
|---|---|---|
| 60ms | 2 passed | — |
| **120ms** | **2 failed — exact CI strings (`4/4`, `terminal-linkattn`)** | **2 passed** |
| 250ms / 500ms | 1 failed (window shifts past one test) | — |
| 2000ms | 2 passed (banner lands after the test finishes) | — |

The sweep matters: my first attempt used 2000ms and passed, because too *long* a delay lets the banner land after the assertions rather than between the write and the assertion. The failure window is narrow, which is why this flakes rather than fails outright.

Then with the timer back at its real 30ms:

- three affected specs, `--repeat-each=5`: **145 passed**
- full e2e suite: **189 passed, 1 skipped**
- `tsc --noEmit`: clean

## Live verification

Exempt: e2e test code only, no product code, no daemon lifecycle / protocol / PTY / background-runner / UI surface touched.