### PR TITLE
feat(automations): self-service YAML editor and validate-without-apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,15 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   has New and Edit buttons that open the definition's YAML in an editor, so
   creating an automation no longer means dropping to a terminal. Validate
   checks a definition without storing anything and reports the first problem
-  it finds; Save stores it. Two mistakes are refused rather than silently
+  it finds; Save stores it. Three mistakes are refused rather than silently
   accepted: changing the `id` of a definition you are editing (which would
-  leave the original running and quietly create a second one), and saving over
-  a definition that changed elsewhere since you opened it — the latter offers a
-  reload. Your YAML is now stored as you wrote it, so comments and formatting
-  survive an edit round-trip; definitions applied before this release are
-  rendered from their stored form the first time and keep their new text
-  afterwards.
+  leave the original running and quietly create a second one), creating a new
+  automation whose `id` already belongs to one you have (which would replace
+  it wholesale), and saving over a definition that changed elsewhere since you
+  opened it — the last offers a reload. Your YAML is now stored as you wrote
+  it, so comments and formatting survive an edit round-trip; definitions
+  applied before this release are rendered from their stored form the first
+  time and keep their new text afterwards.
 - **Automations now have a panel in the app.** A new toolbar button opens an
   Automations panel that lists every definition with its trigger and
   enabled state, lets you enable/disable or run a manual automation now,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,27 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-07-20]
 
 ### Added
+- **You can now write and edit automations in the app.** The Automations panel
+  has New and Edit buttons that open the definition's YAML in an editor, so
+  creating an automation no longer means dropping to a terminal. Validate
+  checks a definition without storing anything and reports the first problem
+  it finds; Save stores it. Two mistakes are refused rather than silently
+  accepted: changing the `id` of a definition you are editing (which would
+  leave the original running and quietly create a second one), and saving over
+  a definition that changed elsewhere since you opened it — the latter offers a
+  reload. Your YAML is now stored as you wrote it, so comments and formatting
+  survive an edit round-trip; definitions applied before this release are
+  rendered from their stored form the first time and keep their new text
+  afterwards.
 - **Automations now have a panel in the app.** A new toolbar button opens an
   Automations panel that lists every definition with its trigger and
   enabled state, lets you enable/disable or run a manual automation now,
   shows each definition's run history with failures called out inline, and
-  jumps straight to the ticket or session a run produced. Definitions are
-  still created from the CLI (`attn automation apply`); changes made there
-  appear in the panel immediately, and daemon rejections are shown in the
-  panel rather than silently swallowed.
+  jumps straight to the ticket or session a run produced. Changes made from
+  the CLI (`attn automation apply`) appear in the panel immediately, and
+  daemon rejections are shown in the panel rather than silently swallowed.
+- **`attn automation validate --file <path>`** checks a definition without
+  applying it, using the exact same checks `apply` runs.
 - **Automations can now run on a schedule.** A definition can declare a cron
   schedule with a required time zone and fire an ordinary visible agent
   session at each intended instant — for example, a recurring merged-worktree

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,12 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   leave the original running and quietly create a second one), creating a new
   automation whose `id` already belongs to one you have (which would replace
   it wholesale), and saving over a definition that changed elsewhere since you
-  opened it — the last offers a reload. Your YAML is now stored as you wrote
-  it, so comments and formatting survive an edit round-trip; definitions
+  opened it — the last offers a reload. If the definition was *deleted* while
+  you had it open, saving is refused rather than quietly bringing it back, so
+  an automation you turned off does not start running again behind you.
+  Your YAML is now stored as you wrote it, so comments and formatting survive
+  an edit round-trip — including against someone else editing the same
+  definition, since a comment-only change counts as a change; definitions
   applied before this release are rendered from their stored form the first
   time and keep their new text afterwards.
 - **Automations now have a panel in the app.** A new toolbar button opens an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,15 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   of silently starting in the wrong context.
 
 ### Fixed
+- **Turning an automation off in the panel now sticks.** The enable/disable
+  toggle and the `enabled:` line in a definition's YAML were tracked
+  separately, so disabling an automation and then editing it — even just
+  adding a comment — saved the old `enabled: true` back and started it running
+  again, reported as an ordinary successful save. For a scheduled automation
+  that meant unattended sessions firing after you had turned them off. The
+  toggle now updates the definition itself, so the editor opens on the
+  automation's real current state and a later edit cannot undo it. Your
+  comments and formatting survive the toggle untouched.
 - **Reverting an automation's prompt to an earlier version no longer
   permanently blocks new runs.** A→B→A edits used to refuse every future run
   once any earlier revision shared the same prompt/launch/location, even

--- a/app/e2e/automation-yaml-editor.spec.ts
+++ b/app/e2e/automation-yaml-editor.spec.ts
@@ -4,6 +4,10 @@ import { test, expect, type Page } from '@playwright/test';
 // tests below — same shape as LiveMarkdownEditorHarness's.
 declare global {
   interface Window {
+    // Declaration-merged with live-markdown-editor.spec.ts's identical block,
+    // so the shape must stay in step with it: it describes whichever harness
+    // page is loaded, and LiveMarkdownEditorHarness still exposes swapValue.
+    // AutomationYamlEditorHarness does not — this spec never calls it.
     __EDITOR_HARNESS__?: {
       applyExternal: (next: string) => void;
       swapValue: (next: string) => void;
@@ -14,7 +18,9 @@ declare global {
 // Scroll well into the long automation buffer and wait for CodeMirror to
 // ACKNOWLEDGE the scroll (a deep, virtualized line attaches to the DOM) before
 // returning the settled scrollTop — same rationale as
-// live-markdown-editor.spec.ts's scrollIntoLongNote, which this mirrors.
+// live-markdown-editor.spec.ts's scrollIntoLongNote, which this mirrors. The
+// selection test needs this because the line it anchors on is virtualized: it
+// has to be attached to the DOM before it can be clicked.
 async function scrollIntoLongBuffer(page: Page): Promise<number> {
   const scroller = page.locator('.cm-scroller');
   await scroller.evaluate((el) => { el.scrollTop = 600; });
@@ -30,7 +36,7 @@ async function scrollIntoLongBuffer(page: Page): Promise<number> {
 // which mock this leaf component out for exactly that reason). This is where
 // its three load-bearing, hard-to-get-right behaviors are actually verified:
 // syntax-highlighting theme (classHighlighter, not CM's built-in white-in-dark
-// theme), the Cmd-rewritten search keymap, and minimal-edit scroll
+// theme), the Cmd-rewritten search keymap, and minimal-edit selection
 // preservation for Reload.
 test.describe('AutomationYamlEditor', () => {
   test('renders YAML syntax highlighting via classHighlighter tok- classes, over the dark app theme', async ({ page }) => {
@@ -84,21 +90,44 @@ test.describe('AutomationYamlEditor', () => {
     await expect(page.locator('.cm-panel.cm-search')).toBeVisible();
   });
 
-  test('keeps the buffer scrolled in place when Reload applies new content (minimal edit)', async ({ page }) => {
-    // Mirrors live-markdown-editor.spec.ts's equivalent test: AutomationEditor's
-    // Reload button drives applyExternalContent, which must not yank the
-    // viewport back to the top when it re-confirms mostly-unchanged text.
+  test('Reload leaves a selection above the edit exactly where it was (minimal edit)', async ({ page }) => {
+    // This is what pins the minimal-edit path for Reload, and it is
+    // deliberately an assertion about change MAPPING, not about scroll
+    // position.
+    //
+    // There used to be a scroll-position pair here, mirroring
+    // live-markdown-editor.spec.ts: one test asserting Reload holds the
+    // viewport, and a contrast test asserting a full-document value swap
+    // snaps it to the top. Both are gone because neither could fail for THIS
+    // buffer. The contrast test went red in CI while passing locally, and
+    // mutation testing then showed the positive one survived every mutation
+    // aimed at it — a forced full-document replace AND scrollIntoView:true,
+    // with the edit placed off screen. Scroll position after a doc-wide
+    // replace is a measurement side effect of CodeMirror's height map, so it
+    // varies with line heights, wrapping, and font metrics; the YAML buffer's
+    // short comment lines simply do not reproduce what the markdown buffer's
+    // wrapped prose does. A test that cannot fail is worse than no test.
+    //
+    // Change mapping is specified rather than measured: an edit confined to
+    // line 80 is entirely after this selection, so mapping must leave the
+    // selection byte-identical. A full replace (from 0 to doc.length, which is
+    // what a plain controlled-value swap dispatches) deletes the selected text
+    // out from under it and cannot preserve it. Verified red under exactly
+    // that mutation.
     await page.goto('/test-harness/?component=AutomationYamlEditor&long=1');
     await page.waitForFunction(() => window.__HARNESS__?.ready === true);
     await page.waitForSelector('.cm-content');
 
-    const scroller = page.locator('.cm-scroller');
-    const before = await scrollIntoLongBuffer(page);
-    expect(before).toBeGreaterThan(400);
+    await scrollIntoLongBuffer(page);
 
-    // The daemon's reload response changes only the last comment line; the
-    // rest of the document — including everything above the fold — is
-    // unchanged.
+    // Select a whole line well above the edit site.
+    const anchorLine = page.locator('.cm-line', { hasText: 'comment line number 25 of the long automation' });
+    await anchorLine.click();
+    await page.keyboard.press('Home');
+    await page.keyboard.press('Shift+End');
+    const selectedBefore = await page.evaluate(() => window.getSelection()?.toString() ?? '');
+    expect(selectedBefore).toContain('comment line number 25 of the long automation');
+
     await page.evaluate(() => {
       const lines = Array.from({ length: 80 }, (_, i) => `comment line number ${i + 1} of the long automation`);
       lines[79] = 'comment line number 80 of the long automation — RELOADED';
@@ -110,25 +139,7 @@ test.describe('AutomationYamlEditor', () => {
       const last = calls[calls.length - 1]?.[0] as string | undefined;
       return !!last && last.includes('RELOADED');
     });
-    await expect
-      .poll(() => scroller.evaluate((el, b) => Math.abs(el.scrollTop - b), before))
-      .toBeLessThanOrEqual(4);
-  });
 
-  test('contrast: a full value swap snaps the scroller to the top (the bug the fix avoids)', async ({ page }) => {
-    await page.goto('/test-harness/?component=AutomationYamlEditor&long=1');
-    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
-    await page.waitForSelector('.cm-content');
-
-    const scroller = page.locator('.cm-scroller');
-    expect(await scrollIntoLongBuffer(page)).toBeGreaterThan(400);
-
-    await page.evaluate(() => {
-      const lines = Array.from({ length: 80 }, (_, i) => `comment line number ${i + 1} of the long automation`);
-      lines[79] = 'comment line number 80 of the long automation — RELOADED';
-      window.__EDITOR_HARNESS__!.swapValue(`id: long-automation\nname: Long automation\n# ${lines.join('\n# ')}\n`);
-    });
-
-    await expect.poll(() => scroller.evaluate((el) => el.scrollTop)).toBeLessThan(50);
+    expect(await page.evaluate(() => window.getSelection()?.toString() ?? '')).toBe(selectedBefore);
   });
 });

--- a/app/e2e/automation-yaml-editor.spec.ts
+++ b/app/e2e/automation-yaml-editor.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Editing controls the AutomationYamlEditor harness exposes for the scroll
+// tests below — same shape as LiveMarkdownEditorHarness's.
+declare global {
+  interface Window {
+    __EDITOR_HARNESS__?: {
+      applyExternal: (next: string) => void;
+      swapValue: (next: string) => void;
+    };
+  }
+}
+
+// Scroll well into the long automation buffer and wait for CodeMirror to
+// ACKNOWLEDGE the scroll (a deep, virtualized line attaches to the DOM) before
+// returning the settled scrollTop — same rationale as
+// live-markdown-editor.spec.ts's scrollIntoLongNote, which this mirrors.
+async function scrollIntoLongBuffer(page: Page): Promise<number> {
+  const scroller = page.locator('.cm-scroller');
+  await scroller.evaluate((el) => { el.scrollTop = 600; });
+  await expect(
+    page.locator('.cm-line', { hasText: 'comment line number 25 of the long automation' }),
+  ).toBeAttached();
+  return scroller.evaluate((el) => el.scrollTop);
+}
+
+// The automation editor's single YAML buffer (CodeMirror), rendered in
+// isolation by the component harness in a real browser — CM cannot mount
+// under happy-dom (see AutomationEditor.test.tsx / AutomationsPanel.test.tsx,
+// which mock this leaf component out for exactly that reason). This is where
+// its three load-bearing, hard-to-get-right behaviors are actually verified:
+// syntax-highlighting theme (classHighlighter, not CM's built-in white-in-dark
+// theme), the Cmd-rewritten search keymap, and minimal-edit scroll
+// preservation for Reload.
+test.describe('AutomationYamlEditor', () => {
+  test('renders YAML syntax highlighting via classHighlighter tok- classes, over the dark app theme', async ({ page }) => {
+    await page.goto('/test-harness/?component=AutomationYamlEditor');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.waitForSelector('.cm-content');
+
+    // classHighlighter (not react-codemirror's built-in theme) is driving
+    // highlighting: YAML keys and the boolean/string values pick up tok-*
+    // classes.
+    await expect(page.locator('.tok-propertyName, .tok-atom, .tok-string, .tok-bool').first()).toBeVisible();
+
+    // The editor sits on the app's dark background, not a default white box —
+    // the bug this design deliberately avoids (see editorTheme's doc comment
+    // in AutomationYamlEditor.tsx: react-codemirror's built-in theme paints
+    // white in dark mode).
+    const bg = await page.locator('.cm-editor').evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(bg).not.toBe('rgb(255, 255, 255)');
+
+    await page.screenshot({ path: 'test-results/automation-yaml-editor.png' });
+  });
+
+  test('typing edits the buffer and reports changes', async ({ page }) => {
+    await page.goto('/test-harness/?component=AutomationYamlEditor&empty=1');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.waitForSelector('.cm-content');
+
+    await page.locator('.cm-content').click();
+    await page.keyboard.type('id: fresh-automation', { delay: 8 });
+
+    await page.waitForFunction(() => window.__HARNESS__.getCalls('change').length > 0);
+    const last = await page.evaluate(() => {
+      const calls = window.__HARNESS__.getCalls('change');
+      return calls[calls.length - 1][0] as string;
+    });
+    expect(last).toBe('id: fresh-automation');
+  });
+
+  test('Cmd-F opens the search panel (macSearchKeymap survives a non-Mac-reporting browser)', async ({ page }) => {
+    // The bug this rewrite avoids: searchKeymap binds "Mod-f", which
+    // CodeMirror resolves to Ctrl (not Cmd) on any browser reporting a
+    // non-Mac platform — exactly what headless Chromium on Linux CI runners
+    // does. macSearchKeymap rewrites every "Mod-" prefix to an explicit
+    // "Cmd-" so Cmd+F opens search here regardless of what the runner reports.
+    await page.goto('/test-harness/?component=AutomationYamlEditor');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.locator('.cm-content').click();
+
+    await expect(page.locator('.cm-panel.cm-search')).not.toBeAttached();
+    await page.keyboard.press('Meta+f');
+    await expect(page.locator('.cm-panel.cm-search')).toBeVisible();
+  });
+
+  test('keeps the buffer scrolled in place when Reload applies new content (minimal edit)', async ({ page }) => {
+    // Mirrors live-markdown-editor.spec.ts's equivalent test: AutomationEditor's
+    // Reload button drives applyExternalContent, which must not yank the
+    // viewport back to the top when it re-confirms mostly-unchanged text.
+    await page.goto('/test-harness/?component=AutomationYamlEditor&long=1');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.waitForSelector('.cm-content');
+
+    const scroller = page.locator('.cm-scroller');
+    const before = await scrollIntoLongBuffer(page);
+    expect(before).toBeGreaterThan(400);
+
+    // The daemon's reload response changes only the last comment line; the
+    // rest of the document — including everything above the fold — is
+    // unchanged.
+    await page.evaluate(() => {
+      const lines = Array.from({ length: 80 }, (_, i) => `comment line number ${i + 1} of the long automation`);
+      lines[79] = 'comment line number 80 of the long automation — RELOADED';
+      window.__EDITOR_HARNESS__!.applyExternal(`id: long-automation\nname: Long automation\n# ${lines.join('\n# ')}\n`);
+    });
+
+    await page.waitForFunction(() => {
+      const calls = window.__HARNESS__.getCalls('change');
+      const last = calls[calls.length - 1]?.[0] as string | undefined;
+      return !!last && last.includes('RELOADED');
+    });
+    await expect
+      .poll(() => scroller.evaluate((el, b) => Math.abs(el.scrollTop - b), before))
+      .toBeLessThanOrEqual(4);
+  });
+
+  test('contrast: a full value swap snaps the scroller to the top (the bug the fix avoids)', async ({ page }) => {
+    await page.goto('/test-harness/?component=AutomationYamlEditor&long=1');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.waitForSelector('.cm-content');
+
+    const scroller = page.locator('.cm-scroller');
+    expect(await scrollIntoLongBuffer(page)).toBeGreaterThan(400);
+
+    await page.evaluate(() => {
+      const lines = Array.from({ length: 80 }, (_, i) => `comment line number ${i + 1} of the long automation`);
+      lines[79] = 'comment line number 80 of the long automation — RELOADED';
+      window.__EDITOR_HARNESS__!.swapValue(`id: long-automation\nname: Long automation\n# ${lines.join('\n# ')}\n`);
+    });
+
+    await expect.poll(() => scroller.evaluate((el) => el.scrollTop)).toBeLessThan(50);
+  });
+});

--- a/app/package.json
+++ b/app/package.json
@@ -79,6 +79,7 @@
   },
   "dependencies": {
     "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/lang-yaml": "^6.1.3",
     "@codemirror/language": "^6.12.3",
     "@codemirror/language-data": "^6.5.2",
     "@codemirror/search": "^6.7.1",

--- a/app/package.json
+++ b/app/package.json
@@ -35,6 +35,7 @@
     "real-app:scenario-automation-pr-continuity": "node scripts/real-app-harness/scenario-automation-pr-continuity.mjs",
     "real-app:scenario-automation-scheduled-cleanup": "node scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs",
     "real-app:scenario-automation-lifecycle": "node scripts/real-app-harness/scenario-automation-lifecycle.mjs",
+    "real-app:scenario-automation-editor": "node scripts/real-app-harness/scenario-automation-editor.mjs",
     "real-app:scenario-tr401": "node scripts/real-app-harness/scenario-tr401-local-window-resize.mjs",
     "real-app:scenario-tr401-local-codex": "node scripts/real-app-harness/scenario-tr401-local-window-resize.mjs --agent codex",
     "real-app:scenario-tr401-codex-main": "node scripts/real-app-harness/scenario-tr401-local-codex-main-window-resize.mjs",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@codemirror/lang-markdown':
         specifier: ^6.5.0
         version: 6.5.0
+      '@codemirror/lang-yaml':
+        specifier: ^6.1.3
+        version: 6.1.3
       '@codemirror/language':
         specifier: ^6.12.3
         version: 6.12.3

--- a/app/scripts/real-app-harness/scenario-automation-editor.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-editor.mjs
@@ -5,17 +5,25 @@
  * the starter template, invalid-YAML rejection (nothing stored), a real
  * create with a hand-written comment, the create-collision refusal, D1
  * (comments survive a save/reload round-trip), the id-change refusal (D4),
- * and the stale-revision refusal plus Reload recovery (D5) — all driven
- * through the real rendered editor via the automation_editor_* UI-automation
- * bridge verbs, cross-checked against the daemon's own state via the bundled
- * `attn` CLI (`automation show`/`list`), not just the DOM.
+ * the stale-revision refusal plus Reload recovery (D5), a comment-only edit
+ * that still bumps the revision, and a Save that is refused rather than
+ * silently resurrecting a definition deleted elsewhere — the last two pin
+ * the two multi-writer races fixed in 649a7e52 (spec_yaml missing from the
+ * revision-bump condition; DeleteAutomationDefinition leaving revision
+ * untouched) — all driven through the real rendered editor via the
+ * automation_editor_* UI-automation bridge verbs, cross-checked against the
+ * daemon's own state via the bundled `attn` CLI (`automation show`/`list`),
+ * not just the DOM.
  *
  * One definition id is reused across most legs (`automation-editor-<suffix>`)
  * so the id-change and stale-revision legs exercise the SAME live definition
  * D1 just proved comment-preservation on, rather than fresh throwaway ids —
  * matching how a real user edits one automation repeatedly in one sitting.
- * A second id (`automation-editor-renamed-<suffix>`) exists only as the
- * (refused) target of the id-change leg; it must never actually be created.
+ * The same id carries through the comment-only-revision-bump leg and finally
+ * into the delete-elsewhere leg, which ends the scenario with it soft-
+ * deleted on purpose. A second id (`automation-editor-renamed-<suffix>`)
+ * exists only as the (refused) target of the id-change leg; it must never
+ * actually be created.
  *
  * No fake-agent probe is needed: this scenario never triggers a run (every
  * definition it applies is enabled: false throughout), so `launch.executable`
@@ -435,6 +443,141 @@ async function main() {
       const finalShown = runJSON(binary, ['automation', 'show', primaryID], daemonEnv);
       runner.assert(finalShown.Revision === outOfBandRevision + 1, 'the recovered save bumps the revision once more', finalShown);
       runner.assert(finalShown.SpecYAML.includes(localPromptA), 'the recovered save persists the locally re-applied content', finalShown);
+    });
+
+    // Leg 8 (defect A regression proof): a comment-only edit — the exact
+    // shape of change this editor exists to make — still bumps the
+    // revision. Before the store fix, the bump condition compared only
+    // spec_json, so a save that changed spec_yaml alone (comments live only
+    // there, never re-derived into spec_json) left revision untouched and
+    // the stale-save guard blind to it. The new buffer is built by
+    // prepending exactly ONE comment line to the exact bytes the editor
+    // loaded, so everything after that line is untouched by construction —
+    // if spec_json also moved, this leg would prove nothing.
+    await runner.step('leg8_comment_only_edit_bumps_revision', async () => {
+      const shownBefore = runJSON(binary, ['automation', 'show', primaryID], daemonEnv);
+
+      const opened = await client.request('automation_editor_open', { definitionId: primaryID });
+      runner.assert(opened.mode === 'edit', 'opening the shared definition for edit starts in edit mode', opened);
+      runner.assert(opened.definitionId === primaryID, 'edit mode reports the definition id being edited', opened);
+      runner.assert(
+        opened.revision === shownBefore.Revision,
+        "the editor's revision matches the CLI's independently-read revision",
+        { opened, shownBefore },
+      );
+      runner.assert(
+        opened.text === shownBefore.SpecYAML,
+        'the editor buffer loads exactly the stored spec_yaml bytes — the baseline this leg edits from',
+        { opened, shownBefore },
+      );
+
+      const leg8Comment = `# harness-marker-leg8: ${suffix}`;
+      const commentOnlyYAML = `${leg8Comment}\n${opened.text}`;
+      await client.request('automation_editor_set_text', { text: commentOnlyYAML });
+
+      const afterValidate = await client.request('automation_editor_click', { button: 'validate' });
+      runner.assert(afterValidate.validation.state === 'ok', 'the comment-only buffer is still schema-valid', afterValidate);
+
+      const afterSave = await client.request('automation_editor_click', { button: 'save' });
+      runner.assert(afterSave.present === false, 'the comment-only save succeeds and closes the editor', afterSave);
+
+      const shownAfter = runJSON(binary, ['automation', 'show', primaryID], daemonEnv);
+      runner.assert(
+        shownAfter.Revision === shownBefore.Revision + 1,
+        'D-A: a comment-only edit still bumps the revision — the stale-save guard is no longer blind to comment-only changes',
+        { before: shownBefore.Revision, after: shownAfter.Revision },
+      );
+      runner.assert(
+        shownAfter.SpecYAML === commentOnlyYAML,
+        'the stored spec_yaml is exactly the comment-prepended buffer — nothing else moved',
+        { expected: commentOnlyYAML, actual: shownAfter.SpecYAML },
+      );
+      // The assertion that actually matters for D-A: prove this was a pure
+      // comment edit by checking the CANONICAL spec, not just the YAML text.
+      // A future refactor that starts folding comments into spec_json would
+      // otherwise leave this leg passing for the wrong reason.
+      runner.assert(
+        shownAfter.SpecJSON === shownBefore.SpecJSON,
+        'the canonical spec_json is byte-identical before/after — this was a pure comment edit, not a disguised content change',
+        { before: shownBefore.SpecJSON, after: shownAfter.SpecJSON },
+      );
+    });
+
+    // Leg 9 (defect B regression proof): a definition deleted out of band
+    // while an editor has it open must not be resurrected by that editor's
+    // Save. Before the daemon fix, DeleteAutomationDefinition left revision
+    // untouched, so the stale editor's expected_revision still matched the
+    // soft-deleted row, the guard passed, and the upsert cleared
+    // deleted_at — reported to the user as a successful save. Mirrors leg7's
+    // out-of-band-mutation shape, but via `automation delete` instead of
+    // `automation apply`.
+    await runner.step('leg9_delete_elsewhere_then_save_refused', async () => {
+      const shownBefore = runJSON(binary, ['automation', 'show', primaryID], daemonEnv);
+      runner.assert(
+        shownBefore && shownBefore.ID === primaryID,
+        'sanity: the shared definition is still live before this leg deletes it',
+        shownBefore,
+      );
+
+      const opened = await client.request('automation_editor_open', { definitionId: primaryID });
+      runner.assert(opened.mode === 'edit', 'opening the shared definition for edit starts in edit mode', opened);
+      runner.assert(opened.definitionId === primaryID, 'edit mode reports the definition id being edited', opened);
+      runner.assert(
+        opened.revision === shownBefore.Revision,
+        "the editor holds the definition's current revision before the out-of-band delete",
+        opened,
+      );
+
+      run(binary, ['automation', 'delete', primaryID], daemonEnv);
+      const listAfterDelete = runJSON(binary, ['automation', 'list'], daemonEnv) || [];
+      runner.assert(
+        !listAfterDelete.some((row) => row.ID === primaryID),
+        'sanity: the out-of-band CLI delete removes the definition from the live list while the editor is still open on it',
+        listAfterDelete,
+      );
+
+      const staleEditPrompt = 'Edited after the definition was deleted elsewhere — this save must be refused.';
+      const staleEditYAML = editorDefinitionYAML({ id: primaryID, locationPath: fixturePath, prompt: staleEditPrompt, comment: null });
+      await client.request('automation_editor_set_text', { text: staleEditYAML });
+
+      const afterValidate = await client.request('automation_editor_click', { button: 'validate' });
+      runner.assert(
+        afterValidate.validation.state === 'ok',
+        'the buffer is schema-valid on its own — the guard is the out-of-band delete, not shape',
+        afterValidate,
+      );
+
+      const afterSave = await client.request('automation_editor_click', { button: 'save' });
+      runner.assert(
+        afterSave.present === true,
+        "the editor stays open after a refused save — the user's in-progress edit is not destroyed",
+        afterSave,
+      );
+      runner.assert(afterSave.mode === 'edit', 'the editor remains in edit mode for the deleted definition', afterSave);
+      runner.assert(afterSave.definitionId === primaryID, 'the editor is still keyed on the same definition id', afterSave);
+      runner.assert(
+        afterSave.saveError.includes('deleted elsewhere') &&
+          afterSave.saveError.includes(primaryID) &&
+          afterSave.saveError.includes('New'),
+        'Save refuses the edit of a deleted definition, naming the deletion and pointing the user at New',
+        afterSave,
+      );
+
+      // The part that actually matters: the daemon's own state, not just the
+      // UI string — a refusal message sitting in front of a resurrected row
+      // would be exactly the failure this leg exists to catch.
+      const listAfterRefusedSave = runJSON(binary, ['automation', 'list'], daemonEnv) || [];
+      runner.assert(
+        !listAfterRefusedSave.some((row) => row.ID === primaryID),
+        'the definition is still gone after the refused save — it was not resurrected',
+        listAfterRefusedSave,
+      );
+      const shownAfterRefusedSave = runJSON(binary, ['automation', 'show', primaryID], daemonEnv);
+      runner.assert(
+        shownAfterRefusedSave === null,
+        'the CLI also reports the definition as gone (filtered like any soft-deleted row) after the refused save',
+        shownAfterRefusedSave,
+      );
     });
 
     runner.finishSuccess({ profile, primaryID, renamedID, leg3Revision, appBuild, protocolVersion });

--- a/app/scripts/real-app-harness/scenario-automation-editor.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-editor.mjs
@@ -1,0 +1,459 @@
+#!/usr/bin/env node
+
+/**
+ * Packaged-app proof for Slice 7 PR B's self-service automation YAML editor:
+ * the starter template, invalid-YAML rejection (nothing stored), a real
+ * create with a hand-written comment, the create-collision refusal, D1
+ * (comments survive a save/reload round-trip), the id-change refusal (D4),
+ * and the stale-revision refusal plus Reload recovery (D5) — all driven
+ * through the real rendered editor via the automation_editor_* UI-automation
+ * bridge verbs, cross-checked against the daemon's own state via the bundled
+ * `attn` CLI (`automation show`/`list`), not just the DOM.
+ *
+ * One definition id is reused across most legs (`automation-editor-<suffix>`)
+ * so the id-change and stale-revision legs exercise the SAME live definition
+ * D1 just proved comment-preservation on, rather than fresh throwaway ids —
+ * matching how a real user edits one automation repeatedly in one sitting.
+ * A second id (`automation-editor-renamed-<suffix>`) exists only as the
+ * (refused) target of the id-change leg; it must never actually be created.
+ *
+ * No fake-agent probe is needed: this scenario never triggers a run (every
+ * definition it applies is enabled: false throughout), so `launch.executable`
+ * is never invoked and can stay unset like the starter template's.
+ *
+ * Run serially (packaged-app scenarios are single-tenant):
+ *   ATTN_HARNESS_PROFILE=<name> node scripts/real-app-harness/scenario-automation-editor.mjs
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { parseCommonArgs, printCommonHelp, launchFreshAppAndConnect } from './common.mjs';
+import { createScenarioRunner } from './scenarioRunner.mjs';
+import { currentHarnessProfile, resolveHarnessResources } from './harnessProfile.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { captureFrontWindowScreenshot } from './nativeWindowCapture.mjs';
+import { readFrontendProtocolVersion } from './presentDaemon.mjs';
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const PANEL_TIMEOUT_MS = 30_000;
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') args.shift();
+  const options = parseCommonArgs(args);
+  return { options, help: args.includes('--help') || args.includes('-h') };
+}
+
+function profileEnv(profile, extra = {}) {
+  const env = { ...process.env, ATTN_PROFILE: profile, ...extra };
+  for (const key of ['ATTN_SOCKET_PATH', 'ATTN_DB_PATH', 'ATTN_CONFIG_PATH', 'ATTN_PLUGIN_DIR']) {
+    delete env[key];
+  }
+  return env;
+}
+
+function run(binary, args, env, options = {}) {
+  return execFileSync(binary, args, {
+    encoding: 'utf8',
+    env,
+    stdio: options.stdio || ['ignore', 'pipe', 'pipe'],
+    timeout: options.timeout || 30_000,
+  });
+}
+
+function runJSON(binary, args, env) {
+  return JSON.parse(run(binary, args, env));
+}
+
+async function poll(fn, description, timeoutMs = 30_000) {
+  const started = Date.now();
+  let last = null;
+  while (Date.now() - started < timeoutMs) {
+    last = await fn();
+    if (last) return last;
+    await delay(150);
+  }
+  throw new Error(`timed out waiting for ${description}; last=${JSON.stringify(last)}`);
+}
+
+async function waitForDaemonReady(binary, daemonEnv) {
+  await poll(() => {
+    try {
+      runJSON(binary, ['automation', 'list'], daemonEnv);
+      return { ready: true };
+    } catch {
+      return null;
+    }
+  }, 'profile daemon');
+}
+
+// --- automation definition YAML ----------------------------------------
+
+const API_VERSION = 'attn.dev/automations/v1alpha1';
+
+// Deliberately enabled: false throughout — this scenario never triggers a
+// run, and leaving these definitions disabled means the finally block does
+// not need to disable-before-teardown like scenario-automation-lifecycle.mjs
+// (an enabled directory-location definition re-validates its path on every
+// future daemon tick, which would spam errors once the fixture dir is gone).
+function editorDefinitionYAML({ id, locationPath, prompt, comment }) {
+  const commentLine = comment ? `${comment}\n` : '';
+  return `${commentLine}api_version: ${API_VERSION}
+id: ${id}
+name: Slice 7 packaged editor proof
+enabled: false
+trigger:
+  type: manual
+prompt: |
+  ${prompt}
+launch:
+  driver: codex
+location:
+  type: directory
+  path: ${JSON.stringify(locationPath)}
+policy:
+  continuity: fresh
+`;
+}
+
+// Deliberately missing/wrong api_version — the cheapest reliable way to fail
+// ValidateDefinition without depending on any other field's exact wording.
+function invalidDefinitionYAML({ id, locationPath }) {
+  return `api_version: not-a-real-api-version
+id: ${id}
+name: Slice 7 packaged editor proof (invalid)
+enabled: false
+trigger:
+  type: manual
+prompt: |
+  This definition is deliberately invalid; it must never be stored.
+launch:
+  driver: codex
+location:
+  type: directory
+  path: ${JSON.stringify(locationPath)}
+policy:
+  continuity: fresh
+`;
+}
+
+function findDefinitionRow(state, definitionId) {
+  return (state?.definitions || []).find((row) => row.id === definitionId) || null;
+}
+
+async function captureFailureEvidence(runner, client) {
+  try {
+    const state = await client.request('automations_get_state');
+    runner.writeJson('failure-automations-state.json', state);
+  } catch (error) {
+    runner.log('failure_evidence_state_error', { error: error instanceof Error ? error.message : String(error) });
+  }
+  try {
+    const editorState = await client.request('automation_editor_get_state');
+    runner.writeJson('failure-automation-editor-state.json', editorState);
+  } catch (error) {
+    runner.log('failure_evidence_editor_state_error', { error: error instanceof Error ? error.message : String(error) });
+  }
+  try {
+    await captureFrontWindowScreenshot(path.join(runner.runDir, 'failure.png'), { client });
+  } catch (error) {
+    runner.log('failure_evidence_screenshot_error', { error: error instanceof Error ? error.message : String(error) });
+  }
+}
+
+// A best-effort, non-fatal, descriptively-named inline screenshot — matches
+// scenario-notebook-editor-undo.mjs's convention rather than a standalone
+// screenshot leg, since by the time a separate late step ran the relevant DOM
+// state would already have moved on.
+async function captureEvidenceScreenshot(runner, client, name) {
+  try {
+    await captureFrontWindowScreenshot(path.join(runner.runDir, name), { client });
+  } catch (error) {
+    runner.log('evidence_screenshot_error', { name, error: error instanceof Error ? error.message : String(error) });
+  }
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-automation-editor.mjs');
+    return;
+  }
+  const profile = currentHarnessProfile();
+  if (!profile) throw new Error('automation editor scenario requires a named non-production profile');
+  const resources = resolveHarnessResources(profile);
+  const binary = path.join(resources.appPath, 'Contents', 'MacOS', 'attn');
+  const runner = createScenarioRunner(options, {
+    scenarioId: 'AUTOMATION-EDITOR',
+    tier: 'tier2-local',
+    prefix: 'automation-editor',
+    metadata: { profile },
+  });
+
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+
+  const suffix = Date.now().toString(36);
+  const primaryID = `automation-editor-${suffix}`;
+  const renamedID = `automation-editor-renamed-${suffix}`;
+  const harnessMarkerComment = `# harness-marker: ${suffix}`;
+
+  let daemonEnv = null;
+  let fixturePath = null;
+  let appBuild = null;
+  let protocolVersion = null;
+
+  try {
+    await runner.step('setup_fixtures', async () => {
+      fixturePath = fs.realpathSync(fs.mkdtempSync(path.join(runner.sessionDir, 'automation-editor-')));
+      protocolVersion = readFrontendProtocolVersion();
+    });
+
+    await runner.step('restart_isolated_daemon', async () => {
+      daemonEnv = profileEnv(profile);
+      try { run(binary, ['daemon', 'stop'], daemonEnv); } catch {}
+      run(binary, ['daemon', 'ensure'], daemonEnv);
+      await waitForDaemonReady(binary, daemonEnv);
+    });
+
+    await runner.step('launch_packaged_app', async () => {
+      await launchFreshAppAndConnect(client, observer);
+      const state = await client.request('get_state');
+      appBuild = state.appBuild ?? null;
+    });
+
+    // Leg 1: opening New shows the starter template at revision 0, and — the
+    // new product behavior team-lead flagged — Reload is NOT offered while
+    // creating (loadedId is null until the first successful Save).
+    await runner.step('leg1_starter_template', async () => {
+      await client.request('automations_open_panel');
+      const opened = await client.request('automation_editor_open', {});
+      runner.assert(opened.present === true, 'editor is present after opening New', opened);
+      runner.assert(opened.mode === 'create', 'opening New starts in create mode', opened);
+      runner.assert(opened.definitionId === null, 'create mode has no definitionId', opened);
+      runner.assert(opened.revision === 0, 'create mode starts at revision 0', opened);
+      runner.assert(opened.status === 'ready', 'starter template load reaches ready', opened);
+      runner.assert(opened.text.includes('id: my-automation'), 'starter template text includes the placeholder id', opened);
+      runner.assert(opened.text.includes(`api_version: ${API_VERSION}`), 'starter template text includes the current api_version', opened);
+      runner.assert(
+        opened.reloadOffered === false,
+        'Reload is not offered while creating — no persisted definition exists yet to reload from',
+        opened,
+      );
+    });
+
+    // Leg 2: an invalid definition is rejected by both Validate and Save, and
+    // nothing is ever stored — a leg that can fail if either the daemon
+    // guard or the editor's error surfacing regresses.
+    await runner.step('leg2_invalid_rejected_nothing_stored', async () => {
+      const listBefore = runJSON(binary, ['automation', 'list'], daemonEnv) || [];
+      runner.assert(!listBefore.some((row) => row.ID === primaryID), 'sanity: primary id does not exist yet', listBefore);
+
+      const invalidYAML = invalidDefinitionYAML({ id: primaryID, locationPath: fixturePath });
+      const afterSetText = await client.request('automation_editor_set_text', { text: invalidYAML });
+      runner.assert(afterSetText.text === invalidYAML, 'set_text replaces the buffer with the invalid YAML exactly', afterSetText);
+
+      const afterValidate = await client.request('automation_editor_click', { button: 'validate' });
+      runner.assert(afterValidate.validation.state === 'error', 'Validate reports an error for the invalid definition', afterValidate);
+      runner.assert(
+        afterValidate.validation.message.toLowerCase().includes('api_version'),
+        'the validation error names the offending field (api_version)',
+        afterValidate,
+      );
+      await captureEvidenceScreenshot(runner, client, 'leg2-validation-error.png');
+
+      const afterSave = await client.request('automation_editor_click', { button: 'save' });
+      runner.assert(afterSave.present === true, 'the editor stays open after a refused Save', afterSave);
+      runner.assert(afterSave.saveError !== '', 'Save surfaces a saveError for the invalid definition', afterSave);
+
+      const listAfter = runJSON(binary, ['automation', 'list'], daemonEnv) || [];
+      runner.assert(
+        listAfter.length === listBefore.length && !listAfter.some((row) => row.ID === primaryID),
+        'nothing is stored after the refused create',
+        { listBefore, listAfter },
+      );
+    });
+
+    // Leg 3: a real create, with a hand-written leading comment — the
+    // fixture leg2's D1 assertion (comment survival) depends on.
+    let leg3Revision = null;
+    let leg3SpecYAML = null;
+    const promptV1 = 'Slice 7 packaged editor proof: initial create.';
+    await runner.step('leg3_create_with_comment', async () => {
+      const validYAML = editorDefinitionYAML({ id: primaryID, locationPath: fixturePath, prompt: promptV1, comment: harnessMarkerComment });
+      const afterSetText = await client.request('automation_editor_set_text', { text: validYAML });
+      runner.assert(afterSetText.text === validYAML, 'set_text replaces the buffer with the valid YAML exactly', afterSetText);
+
+      const afterValidate = await client.request('automation_editor_click', { button: 'validate' });
+      runner.assert(afterValidate.validation.state === 'ok', 'Validate accepts the valid definition', afterValidate);
+
+      const afterSave = await client.request('automation_editor_click', { button: 'save' });
+      runner.assert(afterSave.present === false, 'a successful create closes the editor back to the list', afterSave);
+
+      await poll(async () => {
+        const current = await client.request('automations_get_state');
+        return findDefinitionRow(current, primaryID) ? current : null;
+      }, `created definition ${primaryID} to appear in the panel`, PANEL_TIMEOUT_MS);
+      await captureEvidenceScreenshot(runner, client, 'leg3-after-save.png');
+
+      const shown = runJSON(binary, ['automation', 'show', primaryID], daemonEnv);
+      runner.assert(shown && shown.ID === primaryID, 'the CLI shows the created definition by id', shown);
+      runner.assert(shown.Revision === 1, 'a fresh create lands at revision 1', shown);
+      runner.assert(shown.SpecYAML.includes(harnessMarkerComment), 'the stored YAML includes the hand-written comment', shown);
+      leg3Revision = shown.Revision;
+      leg3SpecYAML = shown.SpecYAML;
+    });
+
+    // Leg 4 (new, per team-lead): creating a SECOND definition that reuses
+    // the id from leg 3 is refused — the id belongs to a live definition
+    // already. The original definition must be untouched by the attempt.
+    await runner.step('leg4_create_collision_refused', async () => {
+      const opened = await client.request('automation_editor_open', {});
+      runner.assert(opened.mode === 'create', 'opening New again starts a fresh create buffer', opened);
+      runner.assert(opened.reloadOffered === false, 'Reload is still not offered while creating', opened);
+
+      const collisionYAML = editorDefinitionYAML({
+        id: primaryID,
+        locationPath: fixturePath,
+        prompt: 'Attempted collision create — must be refused.',
+        comment: null,
+      });
+      await client.request('automation_editor_set_text', { text: collisionYAML });
+
+      const afterValidate = await client.request('automation_editor_click', { button: 'validate' });
+      runner.assert(afterValidate.validation.state === 'ok', 'the collision definition is schema-valid on its own — the guard is id-collision, not shape', afterValidate);
+
+      const afterSave = await client.request('automation_editor_click', { button: 'save' });
+      runner.assert(afterSave.present === true, 'the editor stays open after a refused collision create', afterSave);
+      runner.assert(
+        afterSave.saveError.includes('already exists') && afterSave.saveError.includes(primaryID),
+        'Save refuses the collision with an "already exists" error naming the id',
+        afterSave,
+      );
+
+      const afterCollision = runJSON(binary, ['automation', 'show', primaryID], daemonEnv);
+      runner.assert(
+        afterCollision.Revision === leg3Revision && afterCollision.SpecYAML === leg3SpecYAML,
+        "the original definition's revision and content are unchanged by the refused collision",
+        { before: { revision: leg3Revision, specYaml: leg3SpecYAML }, after: afterCollision },
+      );
+
+      const afterCancel = await client.request('automation_editor_click', { button: 'cancel' });
+      runner.assert(afterCancel.present === false, 'Cancel closes the collision attempt back to the list', afterCancel);
+    });
+
+    // Leg 5 (D1, load-bearing): opening the definition leg3 created for edit
+    // shows the hand-written comment intact — a save/reload round-trip that
+    // does not preserve comments is exactly the regression this scenario
+    // exists to catch.
+    await runner.step('leg5_comments_survive_roundtrip', async () => {
+      const opened = await client.request('automation_editor_open', { definitionId: primaryID });
+      runner.assert(opened.mode === 'edit', 'opening an existing definition starts in edit mode', opened);
+      runner.assert(opened.definitionId === primaryID, 'edit mode reports the definition id being edited', opened);
+      runner.assert(opened.revision === leg3Revision, 'edit mode reports the definition\'s current revision', opened);
+      runner.assert(opened.reloadOffered === true, 'Reload is offered once a persisted definition is being edited', opened);
+      runner.assert(
+        opened.text.includes(harnessMarkerComment),
+        'D1: the hand-written comment survives the save/reload round-trip into the editor buffer',
+        opened,
+      );
+    });
+
+    // Leg 6 (D4): changing the id in the buffer and saving is refused — an id
+    // change must go through a separate create, not an in-place edit.
+    await runner.step('leg6_id_change_refusal', async () => {
+      const renameYAML = editorDefinitionYAML({
+        id: renamedID,
+        locationPath: fixturePath,
+        prompt: 'Attempted rename via id change — must be refused.',
+        comment: null,
+      });
+      await client.request('automation_editor_set_text', { text: renameYAML });
+
+      const afterSave = await client.request('automation_editor_click', { button: 'save' });
+      runner.assert(afterSave.present === true, 'the editor stays open after a refused id-change save', afterSave);
+      runner.assert(afterSave.mode === 'edit', 'the editor remains in edit mode for the original definition', afterSave);
+      runner.assert(afterSave.definitionId === primaryID, 'the editor is still keyed on the original definition id', afterSave);
+      runner.assert(
+        afterSave.saveError.includes('does not match') && afterSave.saveError.includes(renamedID) && afterSave.saveError.includes(primaryID),
+        'Save refuses the id change, naming both the buffer id and the definition being edited',
+        afterSave,
+      );
+
+      const listAfter = runJSON(binary, ['automation', 'list'], daemonEnv) || [];
+      runner.assert(
+        !listAfter.some((row) => row.ID === renamedID) && listAfter.filter((row) => row.ID === primaryID).length === 1,
+        'no definition was created under the renamed id; the original still exists exactly once',
+        listAfter,
+      );
+    });
+
+    // Leg 7 (D5): a Save against a stale revision — the definition changed
+    // out from under the open editor via the CLI — is refused, and Reload
+    // recovers by pulling the current content into the buffer, after which a
+    // normal Save succeeds.
+    await runner.step('leg7_stale_revision_refusal_and_reload', async () => {
+      // Reset the buffer's id back to primaryID (leg 6 left it on renamedID)
+      // before doing anything else, so this leg's Save attempts exercise the
+      // stale-revision guard rather than re-triggering the id-change guard.
+      const localPromptA = 'Local buffer edit before the out-of-band mutation lands.';
+      const resetYAML = editorDefinitionYAML({ id: primaryID, locationPath: fixturePath, prompt: localPromptA, comment: null });
+      await client.request('automation_editor_set_text', { text: resetYAML });
+
+      const outOfBandPrompt = 'Mutated out of band via the bundled CLI while the editor was open.';
+      const outOfBandFile = path.join(runner.sessionDir, 'out-of-band.yml');
+      fs.writeFileSync(outOfBandFile, editorDefinitionYAML({ id: primaryID, locationPath: fixturePath, prompt: outOfBandPrompt, comment: null }));
+      runJSON(binary, ['automation', 'apply', '--file', outOfBandFile], daemonEnv);
+
+      const outOfBandShown = runJSON(binary, ['automation', 'show', primaryID], daemonEnv);
+      runner.assert(outOfBandShown.Revision > leg3Revision, 'the out-of-band CLI apply bumps the revision past what the open editor has', outOfBandShown);
+      const outOfBandRevision = outOfBandShown.Revision;
+
+      const afterStaleSave = await client.request('automation_editor_click', { button: 'save' });
+      runner.assert(afterStaleSave.present === true, 'the editor stays open after a refused stale-revision save', afterStaleSave);
+      runner.assert(
+        afterStaleSave.saveError.toLowerCase().includes('changed elsewhere') || afterStaleSave.saveError.toLowerCase().includes('reload'),
+        'Save refuses the stale-revision write with a "changed elsewhere / reload" error',
+        afterStaleSave,
+      );
+
+      const afterReload = await client.request('automation_editor_click', { button: 'reload' });
+      runner.assert(afterReload.reloadError === '', 'Reload succeeds without error', afterReload);
+      runner.assert(afterReload.revision === outOfBandRevision, 'Reload pulls in the current (out-of-band) revision', afterReload);
+      runner.assert(afterReload.text.includes(outOfBandPrompt), 'Reload pulls in the current (out-of-band) content', afterReload);
+
+      // Re-apply the SAME local edit on top of the now-current buffer; this
+      // Save should succeed since the buffer is no longer stale.
+      const reappliedYAML = editorDefinitionYAML({ id: primaryID, locationPath: fixturePath, prompt: localPromptA, comment: null });
+      await client.request('automation_editor_set_text', { text: reappliedYAML });
+      const afterFinalSave = await client.request('automation_editor_click', { button: 'save' });
+      runner.assert(afterFinalSave.present === false, 'the recovered Save succeeds and closes the editor', afterFinalSave);
+
+      const finalShown = runJSON(binary, ['automation', 'show', primaryID], daemonEnv);
+      runner.assert(finalShown.Revision === outOfBandRevision + 1, 'the recovered save bumps the revision once more', finalShown);
+      runner.assert(finalShown.SpecYAML.includes(localPromptA), 'the recovered save persists the locally re-applied content', finalShown);
+    });
+
+    runner.finishSuccess({ profile, primaryID, renamedID, leg3Revision, appBuild, protocolVersion });
+  } catch (error) {
+    await captureFailureEvidence(runner, client).catch(() => {});
+    runner.finishFailure(error, { profile, primaryID, renamedID, appBuild, protocolVersion });
+    throw error;
+  } finally {
+    await client.quitApp().catch(() => {});
+    await observer.close().catch(() => {});
+    if (daemonEnv) { try { run(binary, ['daemon', 'stop'], daemonEnv); } catch {} }
+    if (fixturePath) { try { fs.rmSync(fixturePath, { recursive: true, force: true }); } catch {} }
+    // Leave a healthy plain profile daemon behind for whatever runs next.
+    try { run(binary, ['daemon', 'ensure'], profileEnv(profile)); } catch {}
+    runner.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/scripts/real-app-harness/scenario-automation-editor.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-editor.mjs
@@ -6,12 +6,15 @@
  * create with a hand-written comment, the create-collision refusal, D1
  * (comments survive a save/reload round-trip), the id-change refusal (D4),
  * the stale-revision refusal plus Reload recovery (D5), a comment-only edit
- * that still bumps the revision, and a Save that is refused rather than
- * silently resurrecting a definition deleted elsewhere — the last two pin
- * the two multi-writer races fixed in 649a7e52 (spec_yaml missing from the
- * revision-bump condition; DeleteAutomationDefinition leaving revision
- * untouched) — all driven through the real rendered editor via the
- * automation_editor_* UI-automation bridge verbs, cross-checked against the
+ * that still bumps the revision, a Save that is refused rather than
+ * silently resurrecting a definition deleted elsewhere, and a panel
+ * toggle-off that survives a later unrelated edit — the last three pin the
+ * three multi-writer races fixed in 649a7e52 and 09cfb0b6 (spec_yaml missing
+ * from the revision-bump condition; DeleteAutomationDefinition leaving
+ * revision untouched; SetAutomationEnabled writing only the enabled column
+ * and leaving the stored spec saying otherwise) — all driven through the
+ * real rendered editor and panel via the automation_editor_* and
+ * automations_* UI-automation bridge verbs, cross-checked against the
  * daemon's own state via the bundled `attn` CLI (`automation show`/`list`),
  * not just the DOM.
  *
@@ -25,9 +28,12 @@
  * exists only as the (refused) target of the id-change leg; it must never
  * actually be created.
  *
- * No fake-agent probe is needed: this scenario never triggers a run (every
- * definition it applies is enabled: false throughout), so `launch.executable`
- * is never invoked and can stay unset like the starter template's.
+ * No fake-agent probe is needed: this scenario never triggers a run. Every
+ * definition it applies is manual-trigger, and all but leg10's are also
+ * enabled: false, so `launch.executable` is never invoked and can stay unset
+ * like the starter template's. leg10 must start from an enabled definition in
+ * order to disable it from the panel; being manual-trigger, it still never
+ * fires, and the leg deletes it before finishing.
  *
  * Run serially (packaged-app scenarios are single-tenant):
  *   ATTN_HARNESS_PROFILE=<name> node scripts/real-app-harness/scenario-automation-editor.mjs
@@ -98,21 +104,53 @@ async function waitForDaemonReady(binary, daemonEnv) {
   }, 'profile daemon');
 }
 
+// Click the panel's real enable/disable toggle and wait for the daemon to
+// come back. Two waits are needed and neither is optional:
+//
+//   - The row must be RENDERED before the click. A definition created through
+//     the editor reaches the panel by broadcast, not synchronously, so
+//     clicking straight after a save hits an element that does not exist yet.
+//   - automations_toggle_enabled clicks and settles a few UI frames without
+//     awaiting the daemon round-trip, so the panel is the thing to poll for
+//     the new state; once it renders the flip, the store has already
+//     committed it and a following CLI read is no longer a race.
+//
+// Editor saves need neither: they are request/result and are daemon-confirmed
+// by the time they return. Same shape as scenario-automation-surface.mjs's
+// toggle legs, which is where this pattern is house convention.
+async function toggleEnabledAndWait(client, definitionId, wantEnabled) {
+  await poll(async () => {
+    const current = await client.request('automations_get_state');
+    return findDefinitionRow(current, definitionId) ? current : null;
+  }, `definition ${definitionId} to appear in the panel before toggling it`, PANEL_TIMEOUT_MS);
+
+  await client.request('automations_toggle_enabled', { definitionId });
+
+  return poll(async () => {
+    const current = await client.request('automations_get_state');
+    const row = findDefinitionRow(current, definitionId);
+    return row && row.enabled === wantEnabled ? current : null;
+  }, `definition ${definitionId} to render ${wantEnabled ? 'enabled' : 'disabled'} after the toggle broadcast`, PANEL_TIMEOUT_MS);
+}
+
 // --- automation definition YAML ----------------------------------------
 
 const API_VERSION = 'attn.dev/automations/v1alpha1';
 
-// Deliberately enabled: false throughout — this scenario never triggers a
-// run, and leaving these definitions disabled means the finally block does
-// not need to disable-before-teardown like scenario-automation-lifecycle.mjs
-// (an enabled directory-location definition re-validates its path on every
-// future daemon tick, which would spam errors once the fixture dir is gone).
-function editorDefinitionYAML({ id, locationPath, prompt, comment }) {
+// Defaults to enabled: false — this scenario never triggers a run, and
+// leaving these definitions disabled means the finally block does not need to
+// disable-before-teardown like scenario-automation-lifecycle.mjs (an enabled
+// directory-location definition re-validates its path on every future daemon
+// tick, which would spam errors once the fixture dir is gone). leg10 is the
+// one caller that opts into enabled: true, because it has to start from an
+// enabled definition to disable it from the panel; it deletes that definition
+// at the end of the leg for the same reason.
+function editorDefinitionYAML({ id, locationPath, prompt, comment, enabled = false }) {
   const commentLine = comment ? `${comment}\n` : '';
   return `${commentLine}api_version: ${API_VERSION}
 id: ${id}
 name: Slice 7 packaged editor proof
-enabled: false
+enabled: ${enabled ? 'true' : 'false'}
 trigger:
   type: manual
 prompt: |
@@ -578,6 +616,117 @@ async function main() {
         'the CLI also reports the definition as gone (filtered like any soft-deleted row) after the refused save',
         shownAfterRefusedSave,
       );
+    });
+
+    // The reviewer-reported split brain: `enabled` was written by the panel
+    // toggle (column only) AND by a save (from the YAML), with nothing keeping
+    // them in step. Disable, then edit, and the stale `enabled: true` in the
+    // stored YAML came back — for a cron trigger, unattended sessions firing
+    // again after the operator turned them off, reported as a clean save.
+    //
+    // Every out-of-band step here goes through the REAL panel toggle verb
+    // (automations_toggle_enabled), not a CLI shortcut, because the toggle is
+    // the surface that was writing only half the state.
+    await runner.step('leg10_panel_toggle_off_survives_a_later_edit', async () => {
+      const leg10ID = `automation-editor-toggle-${suffix}`;
+      const leg10Comment = `# harness-marker-leg10: ${suffix}`;
+      const createYAML = editorDefinitionYAML({
+        id: leg10ID,
+        locationPath: fixturePath,
+        prompt: 'Definition that the operator disables from the panel and then edits.',
+        comment: leg10Comment,
+        enabled: true,
+      });
+
+      // leg9 deliberately ends with the editor still open on its refused save.
+      const cleared = await client.request('automation_editor_click', { button: 'cancel' });
+      runner.assert(cleared.present === false, "leg9's editor is closed before this leg opens its own", cleared);
+
+      await client.request('automation_editor_open', {});
+      await client.request('automation_editor_set_text', { text: createYAML });
+      const afterCreate = await client.request('automation_editor_click', { button: 'save' });
+      runner.assert(afterCreate.present === false, 'the enabled definition is created and the editor closes', afterCreate);
+
+      const created = runJSON(binary, ['automation', 'show', leg10ID], daemonEnv);
+      runner.assert(created && created.Enabled === true, 'sanity: the definition starts enabled', created);
+
+      // The panel toggle — the exact surface the reviewer named.
+      await toggleEnabledAndWait(client, leg10ID, false);
+
+      const disabled = runJSON(binary, ['automation', 'show', leg10ID], daemonEnv);
+      runner.assert(disabled.Enabled === false, 'the panel toggle disables the definition', disabled);
+      runner.assert(
+        disabled.Revision === created.Revision + 1,
+        'the toggle bumps the revision — otherwise the stale-save guard cannot see it at all',
+        { before: created.Revision, after: disabled.Revision },
+      );
+      // Write-through, not a read-time overlay: the stored definition itself
+      // now says disabled, so the CLI, the editor, and the column agree.
+      runner.assert(
+        disabled.SpecYAML.includes('enabled: false') && !disabled.SpecYAML.includes('enabled: true'),
+        'the toggle wrote through into the stored YAML — no stale `enabled: true` left behind to be saved back',
+        disabled.SpecYAML,
+      );
+      runner.assert(
+        disabled.SpecYAML.includes(leg10Comment),
+        "the toggle preserved the author's comment — it rewrote one scalar, not the document",
+        disabled.SpecYAML,
+      );
+      runner.assert(
+        JSON.parse(disabled.SpecJSON).enabled === false,
+        'the canonical spec_json agrees too — one authority, not two',
+        disabled.SpecJSON,
+      );
+
+      // Now the operator opens it and makes an unrelated edit.
+      const opened = await client.request('automation_editor_open', { definitionId: leg10ID });
+      runner.assert(
+        opened.text.includes('enabled: false'),
+        'the editor opens on the automation\'s REAL current state, so the operator is not editing a lie',
+        opened,
+      );
+      runner.assert(opened.revision === disabled.Revision, 'the editor holds the post-toggle revision', { opened, disabled });
+
+      await client.request('automation_editor_set_text', { text: `# unrelated edit ${suffix}\n${opened.text}` });
+      const afterEdit = await client.request('automation_editor_click', { button: 'save' });
+      runner.assert(afterEdit.present === false, 'the unrelated edit saves cleanly', afterEdit);
+
+      // The assertion this whole leg exists for.
+      const afterSave = runJSON(binary, ['automation', 'show', leg10ID], daemonEnv);
+      runner.assert(
+        afterSave.Enabled === false,
+        'D-F: editing a disabled automation does NOT silently re-enable it — the toggle is not reversed by a save',
+        afterSave,
+      );
+
+      // And back on, through the panel again, so the leg proves the toggle is
+      // symmetric rather than only pinning the disable direction.
+      await toggleEnabledAndWait(client, leg10ID, true);
+      const reEnabled = runJSON(binary, ['automation', 'show', leg10ID], daemonEnv);
+      runner.assert(
+        reEnabled.Enabled === true && reEnabled.SpecYAML.includes('enabled: true'),
+        'toggling back on writes through the same way — the disable direction is not a special case',
+        reEnabled,
+      );
+      runner.assert(
+        reEnabled.SpecYAML.includes(leg10Comment),
+        "the author's comment survives a full off-and-on cycle, not just one rewrite",
+        reEnabled.SpecYAML,
+      );
+
+      // Not covered here: a toggle landing while THIS editor is open, which
+      // would exercise the stale-save guard against the toggle's revision
+      // bump. AutomationsPanel renders the editor as a full replacement of the
+      // panel body (see its EditorTarget doc comment), so the toggle control
+      // is not in the DOM at all while the editor is up — there is no way to
+      // drive that race through the real UI, and faking it here would be
+      // testing the harness rather than the product. The guard itself is
+      // pinned where it is reachable: the revision assertion above, plus
+      // TestSetAutomationEnabledWritesThroughToStoredSpec (store) and
+      // TestAutomationDefinitionGetWSAfterToggleShowsDisabledWithoutReenabling
+      // (daemon).
+
+      run(binary, ['automation', 'delete', leg10ID], daemonEnv);
     });
 
     runner.finishSuccess({ profile, primaryID, renamedID, leg3Revision, appBuild, protocolVersion });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -665,6 +665,9 @@ function App() {
     listAutomationRuns,
     setAutomationEnabled,
     runAutomationNow,
+    getAutomationDefinition,
+    validateAutomationDefinition,
+    applyAutomationDefinition,
     fetchTicket,
     sendTicketChangeStatus,
     sendTicketAddComment,
@@ -880,6 +883,9 @@ function App() {
         listAutomationRuns={listAutomationRuns}
         setAutomationEnabled={setAutomationEnabled}
         runAutomationNow={runAutomationNow}
+        getAutomationDefinition={getAutomationDefinition}
+        validateAutomationDefinition={validateAutomationDefinition}
+        applyAutomationDefinition={applyAutomationDefinition}
         fetchTicket={fetchTicket}
         sendTicketChangeStatus={sendTicketChangeStatus}
         sendTicketAddComment={sendTicketAddComment}
@@ -1002,6 +1008,9 @@ interface AppContentProps {
   listAutomationRuns: ReturnType<typeof useDaemonSocket>['listAutomationRuns'];
   setAutomationEnabled: ReturnType<typeof useDaemonSocket>['setAutomationEnabled'];
   runAutomationNow: ReturnType<typeof useDaemonSocket>['runAutomationNow'];
+  getAutomationDefinition: ReturnType<typeof useDaemonSocket>['getAutomationDefinition'];
+  validateAutomationDefinition: ReturnType<typeof useDaemonSocket>['validateAutomationDefinition'];
+  applyAutomationDefinition: ReturnType<typeof useDaemonSocket>['applyAutomationDefinition'];
   fetchTicket: ReturnType<typeof useDaemonSocket>['fetchTicket'];
   sendTicketChangeStatus: ReturnType<typeof useDaemonSocket>['sendTicketChangeStatus'];
   sendTicketAddComment: ReturnType<typeof useDaemonSocket>['sendTicketAddComment'];
@@ -1118,6 +1127,9 @@ sendFetchPRDetails,
   listAutomationRuns,
   setAutomationEnabled,
   runAutomationNow,
+  getAutomationDefinition,
+  validateAutomationDefinition,
+  applyAutomationDefinition,
   fetchTicket,
   sendTicketChangeStatus,
   sendTicketAddComment,
@@ -3858,6 +3870,9 @@ sendFetchPRDetails,
                   fetchRuns={listAutomationRuns}
                   setEnabled={setAutomationEnabled}
                   runNow={runAutomationNow}
+                  getDefinition={getAutomationDefinition}
+                  validateDefinition={validateAutomationDefinition}
+                  applyDefinition={applyAutomationDefinition}
                   onOpenTicket={handleOpenTicketDetail}
                   onSelectSession={handleSelectSession}
                   onFocusPane={(sessionId, paneId) => focusSessionPane(sessionId, paneId, 40)}

--- a/app/src/components/AutomationsPanel.css
+++ b/app/src/components/AutomationsPanel.css
@@ -24,6 +24,12 @@
   color: var(--color-text-primary);
 }
 
+.automations-panel__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .automations-panel__close {
   background: transparent;
   border: none;
@@ -38,16 +44,32 @@
   color: var(--color-text-primary);
 }
 
+.automations-panel__new {
+  background: var(--color-bg-button);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  font-size: var(--font-size-xs);
+  padding: 4px 10px;
+  white-space: nowrap;
+}
+
+.automations-panel__new:hover {
+  border-color: var(--accent);
+}
+
 .automations-panel__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
   color: var(--color-text-tertiary);
   padding: 16px 0;
 }
 
-.automations-panel__empty code {
-  font-family: var(--font-mono, monospace);
-  background: var(--color-bg-button);
-  border-radius: 4px;
-  padding: 1px 4px;
+.automations-panel__empty p {
+  margin: 0;
 }
 
 .automations-panel__list {
@@ -139,6 +161,22 @@
 .automations-panel__run-now:disabled {
   cursor: default;
   opacity: 0.6;
+}
+
+.automations-panel__edit {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: var(--font-size-xs);
+  padding: 4px 10px;
+  white-space: nowrap;
+}
+
+.automations-panel__edit:hover {
+  border-color: var(--accent);
+  color: var(--color-text-primary);
 }
 
 .automations-panel__error {

--- a/app/src/components/AutomationsPanel.test.tsx
+++ b/app/src/components/AutomationsPanel.test.tsx
@@ -5,6 +5,37 @@ import { useAutomationsStore } from '../store/automations';
 import { AutomationActionTimeoutError } from '../hooks/useDaemonSocket';
 import { AutomationDefinitionSummary, AutomationRunSummary } from '../types/generated';
 
+// getByDisplayValue/findByDisplayValue apply the default TL normalizer (trim
+// + collapse whitespace) to the DOM value being matched but NOT to the
+// matcher string itself, so a multi-line YAML value with a trailing newline
+// can never match a literal expected string. Passing an identity normalizer
+// restores exact literal matching against the YAML buffer.
+const EXACT_VALUE = { normalizer: (text: string) => text };
+
+// AutomationEditor is CodeMirror-backed (via AutomationYamlEditor), which
+// cannot mount under happy-dom — same constraint as LiveMarkdownEditor (see
+// NotebookBrowser.test.tsx). The real editing surface is covered by the
+// Playwright harness; here the leaf CodeMirror component is mocked to a
+// controlled textarea so these tests can drive the panel/editor orchestration
+// (open targets, D6's no-stomp rule, save/cancel wiring) without a browser.
+vi.mock('./automations/AutomationYamlEditor', async () => {
+  const { forwardRef, useImperativeHandle } = await import('react');
+  return {
+    AutomationYamlEditor: forwardRef(function MockAutomationYamlEditor(
+      { value, onChange, ariaLabel }: { value: string; onChange: (value: string) => void; ariaLabel?: string },
+      ref: React.Ref<{ applyExternalContent: (next: string) => void; focus: () => void }>,
+    ) {
+      useImperativeHandle(ref, () => ({
+        applyExternalContent: (next: string) => onChange(next),
+        focus: () => {},
+      }), [onChange]);
+      return (
+        <textarea aria-label={ariaLabel ?? 'Automation definition'} value={value} onChange={(event) => onChange(event.target.value)} />
+      );
+    }),
+  };
+});
+
 function makeDefinition(
   overrides: Partial<AutomationDefinitionSummary> & { id: string },
 ): AutomationDefinitionSummary {
@@ -39,6 +70,13 @@ function baseProps() {
     fetchRuns: vi.fn().mockResolvedValue([]),
     setEnabled: vi.fn().mockResolvedValue(undefined),
     runNow: vi.fn().mockResolvedValue({}),
+    getDefinition: vi.fn().mockResolvedValue({ specYaml: 'id: new-automation\nname: New automation\n', revision: 0 }),
+    validateDefinition: vi.fn().mockResolvedValue(undefined),
+    applyDefinition: vi.fn().mockResolvedValue({
+      definition: makeDefinition({ id: 'd1', revision: 2 }),
+      specYaml: 'id: d1\n',
+      revision: 2,
+    }),
     onOpenTicket: vi.fn(),
     onSelectSession: vi.fn(),
     onFocusPane: vi.fn(),
@@ -57,10 +95,11 @@ describe('AutomationsPanel', () => {
     expect(props.fetchDefinitions).not.toHaveBeenCalled();
   });
 
-  it('renders the empty state when the daemon returns no definitions', async () => {
+  it('renders the empty state with a New automation affordance instead of a CLI instruction', async () => {
     render(<AutomationsPanel {...baseProps()} />);
     await waitFor(() => expect(screen.getByTestId('automations-panel-empty')).toBeInTheDocument());
-    expect(screen.getByText(/create one with/i)).toBeInTheDocument();
+    expect(screen.queryByText(/attn automation apply/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('automation-new-empty')).toBeInTheDocument();
   });
 
   it('renders definitions with name, trigger label, and manual-only Run now', async () => {
@@ -314,5 +353,126 @@ describe('AutomationsPanel', () => {
     expect(screen.queryByTestId('automation-run-open-r1')).not.toBeInTheDocument();
     expect(props.onOpenTicket).not.toHaveBeenCalled();
     expect(props.onSelectSession).not.toHaveBeenCalled();
+  });
+
+  describe('editor', () => {
+    it('opens a fresh template via "New automation" in the header, requesting definition id ""', async () => {
+      const user = userEvent.setup();
+      const props = baseProps();
+      props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1' })]);
+      render(<AutomationsPanel {...props} />);
+
+      await user.click(await screen.findByTestId('automation-new'));
+
+      await waitFor(() => expect(props.getDefinition).toHaveBeenCalledWith(''));
+      expect(await screen.findByTestId('automation-editor')).toBeInTheDocument();
+      expect(screen.getByText('New automation')).toBeInTheDocument();
+      // The list is gone while the editor is open.
+      expect(screen.queryByTestId('automations-panel-list')).not.toBeInTheDocument();
+    });
+
+    it('opens the empty-state "New automation" affordance the same way', async () => {
+      const user = userEvent.setup();
+      const props = baseProps();
+      render(<AutomationsPanel {...props} />);
+
+      await user.click(await screen.findByTestId('automation-new-empty'));
+      await waitFor(() => expect(props.getDefinition).toHaveBeenCalledWith(''));
+      expect(await screen.findByTestId('automation-editor')).toBeInTheDocument();
+    });
+
+    it('opens an existing definition via its row\'s Edit button, requesting that id', async () => {
+      const user = userEvent.setup();
+      const props = baseProps();
+      props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1', name: 'PR reviewer' })]);
+      props.getDefinition.mockResolvedValue({ specYaml: 'id: d1\nname: PR reviewer\n', revision: 3 });
+      render(<AutomationsPanel {...props} />);
+
+      await user.click(await screen.findByTestId('automation-edit-d1'));
+
+      await waitFor(() => expect(props.getDefinition).toHaveBeenCalledWith('d1'));
+      expect(await screen.findByTestId('automation-editor')).toBeInTheDocument();
+      expect(screen.getByText('Edit automation')).toBeInTheDocument();
+      expect(await screen.findByDisplayValue('id: d1\nname: PR reviewer\n', EXACT_VALUE)).toBeInTheDocument();
+    });
+
+    it('Cancel returns to the list without saving', async () => {
+      const user = userEvent.setup();
+      const props = baseProps();
+      props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1' })]);
+      render(<AutomationsPanel {...props} />);
+
+      await user.click(await screen.findByTestId('automation-new'));
+      await screen.findByTestId('automation-editor');
+      await user.click(screen.getByTestId('automation-editor-cancel'));
+
+      expect(screen.queryByTestId('automation-editor')).not.toBeInTheDocument();
+      expect(await screen.findByTestId('automations-panel-list')).toBeInTheDocument();
+      expect(props.applyDefinition).not.toHaveBeenCalled();
+    });
+
+    it('Save applies the buffer with expected_id/expected_revision from the loaded definition, then returns to the list', async () => {
+      const user = userEvent.setup();
+      const props = baseProps();
+      props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1' })]);
+      props.getDefinition.mockResolvedValue({ specYaml: 'id: d1\nname: PR reviewer\n', revision: 3 });
+      render(<AutomationsPanel {...props} />);
+
+      await user.click(await screen.findByTestId('automation-edit-d1'));
+      const textarea = await screen.findByDisplayValue('id: d1\nname: PR reviewer\n', EXACT_VALUE);
+      await user.clear(textarea);
+      await user.type(textarea, 'id: d1\nname: PR reviewer v2\n');
+
+      await user.click(screen.getByTestId('automation-editor-save'));
+
+      await waitFor(() =>
+        expect(props.applyDefinition).toHaveBeenCalledWith('id: d1\nname: PR reviewer v2\n', 'd1', 3),
+      );
+      await waitFor(() => expect(screen.queryByTestId('automation-editor')).not.toBeInTheDocument());
+    });
+
+    it('a Save rejection surfaces the error prominently and keeps the editor open with the buffer intact', async () => {
+      const user = userEvent.setup();
+      const props = baseProps();
+      props.applyDefinition.mockRejectedValue(new Error('changed elsewhere — reload'));
+      render(<AutomationsPanel {...props} />);
+
+      await user.click(await screen.findByTestId('automation-new'));
+      await screen.findByTestId('automation-editor');
+      await user.click(screen.getByTestId('automation-editor-save'));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('automation-editor-save-error')).toHaveTextContent('changed elsewhere — reload'),
+      );
+      expect(screen.getByTestId('automation-editor')).toBeInTheDocument();
+    });
+
+    // D6: the panel refetches definitions on the automations_changed broadcast
+    // (changedTick), which can fire while the user is mid-edit. That refetch
+    // must update the list only — an open editor buffer is replaced ONLY on
+    // explicit load (opening the editor) or explicit Reload, never by the
+    // broadcast. This is the regression the design doc calls out by name.
+    it('D6: a changedTick bump while the editor is open refetches the list but does not touch the open buffer', async () => {
+      const user = userEvent.setup();
+      const props = baseProps();
+      props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1' })]);
+      render(<AutomationsPanel {...props} />);
+
+      await user.click(await screen.findByTestId('automation-new'));
+      const textarea = await screen.findByDisplayValue('id: new-automation\nname: New automation\n', EXACT_VALUE);
+      await user.clear(textarea);
+      await user.type(textarea, 'id: unsaved-work\nname: still typing\n');
+      expect(props.getDefinition).toHaveBeenCalledTimes(1);
+
+      const fetchCallsBefore = props.fetchDefinitions.mock.calls.length;
+      useAutomationsStore.getState().bumpChanged();
+
+      // The list-driving fetch re-runs...
+      await waitFor(() => expect(props.fetchDefinitions.mock.calls.length).toBeGreaterThan(fetchCallsBefore));
+      // ...but the editor was never reloaded and the typed text survives.
+      expect(props.getDefinition).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('automation-editor')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('id: unsaved-work\nname: still typing\n', EXACT_VALUE)).toBeInTheDocument();
+    });
   });
 });

--- a/app/src/components/AutomationsPanel.tsx
+++ b/app/src/components/AutomationsPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { AutomationDefinitionSummary, AutomationRunSummary } from '../types/generated';
 import { useAutomationsStore, selectDefinitionById, selectLatestRunForDefinition } from '../store/automations';
 import { AutomationActionTimeoutError } from '../hooks/useDaemonSocket';
+import { AutomationEditor, automationEditorKey } from './automations/AutomationEditor';
 import './AutomationsPanel.css';
 
 export interface AutomationsPanelProps {
@@ -14,10 +15,24 @@ export interface AutomationsPanelProps {
     definitionId: string,
     requestId: string,
   ) => Promise<{ runId?: string; ticketId?: string; sessionId?: string }>;
+  getDefinition: (definitionId: string) => Promise<{ specYaml: string; revision: number }>;
+  validateDefinition: (definitionYaml: string) => Promise<void>;
+  applyDefinition: (
+    definitionYaml: string,
+    expectedId: string,
+    expectedRevision: number,
+  ) => Promise<{ definition: AutomationDefinitionSummary; specYaml: string; revision: number }>;
   onOpenTicket: (ticketId: string) => void;
   onSelectSession: (sessionId: string) => void;
   onFocusPane: (sessionId: string, paneId: string) => void;
 }
+
+// What the editor overlay is showing: closed, a fresh template (New
+// automation), or an existing definition (Edit). Kept as a single value
+// (rather than two booleans) so there is exactly one source of truth for
+// "which target is open" — AutomationEditor is keyed off it, so switching
+// targets always remounts a fresh editor instance (see automationEditorKey).
+type EditorTarget = { definitionId: string | null } | null;
 
 // Where a run row navigates. The wire nit applies here: ticket_id/session_id/
 // pane_id are always present on AutomationRunSummary but "" means absent, so
@@ -90,6 +105,9 @@ export function AutomationsPanel({
   fetchRuns,
   setEnabled,
   runNow,
+  getDefinition,
+  validateDefinition,
+  applyDefinition,
   onOpenTicket,
   onSelectSession,
   onFocusPane,
@@ -106,6 +124,12 @@ export function AutomationsPanel({
   const [toggleInFlight, setToggleInFlight] = useState<Record<string, boolean>>({});
   const [runErrors, setRunErrors] = useState<Record<string, string>>({});
   const [runInFlight, setRunInFlight] = useState<Record<string, boolean>>({});
+  // D6: this is the ONLY state that opens/closes/targets the editor. The list
+  // refetch effect below never touches it, so an automations_changed broadcast
+  // arriving while it's non-null cannot close the editor or swap its target —
+  // see AutomationEditor.tsx's doc comment for the other half of the guarantee
+  // (its buffer is loaded once per mount, not derived from the store).
+  const [editorTarget, setEditorTarget] = useState<EditorTarget>(null);
 
   // Refetch on open and on every automations_changed tick. Also eagerly
   // fetches every definition's runs (not just the selected one) — the
@@ -239,18 +263,49 @@ export function AutomationsPanel({
 
   const showEmpty = definitionsLoaded && !definitionsError && definitions.length === 0;
 
+  // The editor is a full replacement of the panel body, not a sub-view of the
+  // list — see EditorTarget's doc comment for why closing it is the only way
+  // canonical list state (definitions/runsByDefinition) can affect it again.
+  // Keyed on the target so switching from one Edit to another (or New) always
+  // remounts AutomationEditor, which is what makes its mount-only load correct.
+  if (editorTarget) {
+    return (
+      <div className="automations-panel" data-testid="automations-panel">
+        <AutomationEditor
+          key={automationEditorKey(editorTarget.definitionId)}
+          definitionId={editorTarget.definitionId}
+          getDefinition={getDefinition}
+          validateDefinition={validateDefinition}
+          applyDefinition={applyDefinition}
+          onCancel={() => setEditorTarget(null)}
+          onSaved={() => setEditorTarget(null)}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="automations-panel" data-testid="automations-panel">
       <div className="automations-panel__header">
         <span className="automations-panel__kicker">Automations</span>
-        <button
-          type="button"
-          className="automations-panel__close"
-          onClick={onClose}
-          aria-label="Close automations"
-        >
-          ✕
-        </button>
+        <div className="automations-panel__header-actions">
+          <button
+            type="button"
+            className="automations-panel__new"
+            onClick={() => setEditorTarget({ definitionId: null })}
+            data-testid="automation-new"
+          >
+            New automation
+          </button>
+          <button
+            type="button"
+            className="automations-panel__close"
+            onClick={onClose}
+            aria-label="Close automations"
+          >
+            ✕
+          </button>
+        </div>
       </div>
 
       {definitionsError && (
@@ -260,9 +315,17 @@ export function AutomationsPanel({
       )}
 
       {showEmpty ? (
-        <p className="automations-panel__empty" data-testid="automations-panel-empty">
-          No automations defined — create one with <code>attn automation apply</code>.
-        </p>
+        <div className="automations-panel__empty" data-testid="automations-panel-empty">
+          <p>No automations yet.</p>
+          <button
+            type="button"
+            className="automations-panel__new"
+            onClick={() => setEditorTarget({ definitionId: null })}
+            data-testid="automation-new-empty"
+          >
+            New automation
+          </button>
+        </div>
       ) : (
         <ul className="automations-panel__list" data-testid="automations-panel-list">
           {definitions.map((definition) => {
@@ -317,6 +380,15 @@ export function AutomationsPanel({
                     Run now
                   </button>
                 )}
+
+                <button
+                  type="button"
+                  className="automations-panel__edit"
+                  onClick={() => setEditorTarget({ definitionId: definition.id })}
+                  data-testid={`automation-edit-${definition.id}`}
+                >
+                  Edit
+                </button>
 
                 {toggleErrors[definition.id] && (
                   <p

--- a/app/src/components/automations/AutomationEditor.css
+++ b/app/src/components/automations/AutomationEditor.css
@@ -1,0 +1,130 @@
+.automation-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  height: 100%;
+  min-height: 0;
+}
+
+.automation-editor__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 8px;
+}
+
+.automation-editor__title {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  margin: 0;
+}
+
+.automation-editor__close {
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  line-height: 1;
+  padding: 4px;
+}
+
+.automation-editor__close:hover {
+  color: var(--color-text-primary);
+}
+
+.automation-editor__status {
+  color: var(--color-text-tertiary);
+  padding: 16px 0;
+}
+
+.automation-editor__hint {
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-xs);
+  margin: 0;
+}
+
+.automation-editor__buffer {
+  flex: 1 1 auto;
+  min-height: 240px;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+/* The @uiw/react-codemirror wrapper div (rendered around the CM editor) has no
+   height of its own; without this it stays auto-sized to its content and the
+   buffer grows unbounded instead of scrolling within this panel. Same fix as
+   .notebook-browser-live-editor in NotebookBrowser.css. */
+.automation-editor__buffer > * {
+  flex: 1;
+  min-height: 0;
+}
+
+.automation-editor__buffer .cm-editor {
+  height: 100%;
+}
+
+.automation-editor__buffer .cm-scroller {
+  overflow: auto;
+}
+
+.automation-editor__validation,
+.automation-editor__error {
+  font-size: var(--font-size-xs);
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.automation-editor__validation--ok {
+  color: var(--color-accent);
+}
+
+.automation-editor__validation--error,
+.automation-editor__error {
+  color: var(--color-error);
+}
+
+.automation-editor__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.automation-editor__actions-primary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.automation-editor__actions button {
+  background: var(--color-bg-button);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  font-size: var(--font-size-xs);
+  padding: 5px 12px;
+  white-space: nowrap;
+}
+
+.automation-editor__actions button:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+
+.automation-editor__actions button:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.automation-editor__save {
+  border-color: var(--accent) !important;
+}
+
+.automation-editor__reload {
+  color: var(--color-text-secondary);
+}

--- a/app/src/components/automations/AutomationEditor.test.tsx
+++ b/app/src/components/automations/AutomationEditor.test.tsx
@@ -254,4 +254,32 @@ describe('AutomationEditor', () => {
     );
     expect(screen.getByDisplayValue('id: d1\n', EXACT_VALUE)).toBeInTheDocument();
   });
+
+  // While creating, Reload would re-fetch the starter template (getDefinition
+  // is called with '') and overwrite the draft being typed, with nothing to
+  // recover — the D5 stale-revision refusal it exists for cannot happen before
+  // the definition is persisted. So it must not be reachable in that state.
+  it('does not offer Reload while creating, so a draft cannot be discarded', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    render(<AutomationEditor {...props} />);
+
+    await screen.findByDisplayValue('id: new-automation\n', EXACT_VALUE);
+    expect(screen.queryByTestId('automation-editor-reload')).not.toBeInTheDocument();
+
+    // Editing an existing definition still gets it.
+    const editProps = baseProps();
+    editProps.definitionId = 'd1';
+    editProps.getDefinition.mockResolvedValueOnce({ specYaml: 'id: d1\n', revision: 1 });
+    render(<AutomationEditor {...editProps} />);
+
+    await screen.findByDisplayValue('id: d1\n', EXACT_VALUE);
+    expect(screen.getAllByTestId('automation-editor-reload')).toHaveLength(1);
+
+    // Guard against the assertion above passing vacuously if the create-mode
+    // editor stopped rendering entirely.
+    expect(screen.getAllByTestId('automation-editor')).toHaveLength(2);
+    await user.click(screen.getAllByTestId('automation-editor-close')[0]);
+    expect(props.onCancel).toHaveBeenCalledTimes(1);
+  });
 });

--- a/app/src/components/automations/AutomationEditor.test.tsx
+++ b/app/src/components/automations/AutomationEditor.test.tsx
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, userEvent } from '../../test/utils';
+import { AutomationEditor } from './AutomationEditor';
+import { AutomationDefinitionSummary } from '../../types/generated';
+
+// getByDisplayValue/findByDisplayValue apply the default TL normalizer (trim
+// + collapse whitespace) to the DOM value being matched but NOT to the
+// matcher string itself, so a multi-line YAML value with a trailing newline
+// can never match a literal expected string — the actual value gets
+// silently collapsed/trimmed before comparison while the expectation
+// doesn't. Passing an identity normalizer restores exact literal matching,
+// which is what these tests actually want against a YAML buffer.
+const EXACT_VALUE = { normalizer: (text: string) => text };
+
+// AutomationYamlEditor is CodeMirror-backed, which cannot mount under
+// happy-dom (see AutomationsPanel.test.tsx / NotebookBrowser.test.tsx for the
+// same constraint on the other two editors in this app). The real rendering
+// and typing experience is covered by the Playwright harness; here the leaf
+// component is mocked to a controlled textarea so this file can exercise
+// AutomationEditor's load/validate/save/reload orchestration directly.
+vi.mock('./AutomationYamlEditor', async () => {
+  const { forwardRef, useImperativeHandle } = await import('react');
+  return {
+    AutomationYamlEditor: forwardRef(function MockAutomationYamlEditor(
+      { value, onChange, ariaLabel }: { value: string; onChange: (value: string) => void; ariaLabel?: string },
+      ref: React.Ref<{ applyExternalContent: (next: string) => void; focus: () => void }>,
+    ) {
+      // Mirrors the real imperative handle: pushing external content reports
+      // it through onChange, the way a CodeMirror dispatch would, so
+      // AutomationEditor's controlled value tracks it — exactly what Reload
+      // relies on.
+      useImperativeHandle(ref, () => ({
+        applyExternalContent: (next: string) => onChange(next),
+        focus: () => {},
+      }), [onChange]);
+      return (
+        <textarea aria-label={ariaLabel ?? 'Automation definition'} value={value} onChange={(event) => onChange(event.target.value)} />
+      );
+    }),
+  };
+});
+
+function makeDefinition(overrides: Partial<AutomationDefinitionSummary> & { id: string }): AutomationDefinitionSummary {
+  return {
+    name: 'PR reviewer',
+    enabled: true,
+    revision: 1,
+    trigger_type: 'manual',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as AutomationDefinitionSummary;
+}
+
+function baseProps() {
+  return {
+    definitionId: null as string | null,
+    getDefinition: vi.fn().mockResolvedValue({ specYaml: 'id: new-automation\n', revision: 0 }),
+    validateDefinition: vi.fn().mockResolvedValue(undefined),
+    applyDefinition: vi.fn().mockResolvedValue({
+      definition: makeDefinition({ id: 'new-automation', revision: 1 }),
+      specYaml: 'id: new-automation\n',
+      revision: 1,
+    }),
+    onCancel: vi.fn(),
+    onSaved: vi.fn(),
+  };
+}
+
+describe('AutomationEditor', () => {
+  it('loads the starter template when definitionId is null', async () => {
+    const props = baseProps();
+    render(<AutomationEditor {...props} />);
+
+    await waitFor(() => expect(props.getDefinition).toHaveBeenCalledWith(''));
+    expect(await screen.findByDisplayValue('id: new-automation\n', EXACT_VALUE)).toBeInTheDocument();
+    expect(screen.getByText('New automation')).toBeInTheDocument();
+  });
+
+  it('loads the definition_yaml for an existing id', async () => {
+    const props = baseProps();
+    props.definitionId = 'd1';
+    props.getDefinition.mockResolvedValue({ specYaml: 'id: d1\nname: PR reviewer\n', revision: 5 });
+    render(<AutomationEditor {...props} />);
+
+    await waitFor(() => expect(props.getDefinition).toHaveBeenCalledWith('d1'));
+    expect(await screen.findByDisplayValue('id: d1\nname: PR reviewer\n', EXACT_VALUE)).toBeInTheDocument();
+    expect(screen.getByText('Edit automation')).toBeInTheDocument();
+  });
+
+  it('shows a load error instead of the buffer when getDefinition rejects', async () => {
+    const props = baseProps();
+    props.getDefinition.mockRejectedValue(new Error('daemon unreachable'));
+    render(<AutomationEditor {...props} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('automation-editor-load-error')).toHaveTextContent('daemon unreachable'),
+    );
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('Validate calls validateDefinition with the current buffer and shows success', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    render(<AutomationEditor {...props} />);
+
+    await screen.findByDisplayValue('id: new-automation\n', EXACT_VALUE);
+    await user.click(screen.getByTestId('automation-editor-validate'));
+
+    await waitFor(() => expect(props.validateDefinition).toHaveBeenCalledWith('id: new-automation\n'));
+    expect(await screen.findByTestId('automation-editor-validation-ok')).toBeInTheDocument();
+  });
+
+  it('Validate shows the flat error message on rejection, verbatim, with no inline positioning attempted', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    props.validateDefinition.mockRejectedValue(new Error('trigger.schedule.cron: invalid cron expression'));
+    render(<AutomationEditor {...props} />);
+
+    await screen.findByDisplayValue('id: new-automation\n', EXACT_VALUE);
+    await user.click(screen.getByTestId('automation-editor-validate'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('automation-editor-validation-error')).toHaveTextContent(
+        'trigger.schedule.cron: invalid cron expression',
+      ),
+    );
+  });
+
+  it('editing the buffer after a Validate result clears the stale result', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    render(<AutomationEditor {...props} />);
+
+    const textarea = await screen.findByDisplayValue('id: new-automation\n', EXACT_VALUE);
+    await user.click(screen.getByTestId('automation-editor-validate'));
+    await screen.findByTestId('automation-editor-validation-ok');
+
+    await user.type(textarea, 'x');
+
+    expect(screen.queryByTestId('automation-editor-validation-ok')).not.toBeInTheDocument();
+  });
+
+  it('Save applies with expected_id "" and expected_revision 0 when creating', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    render(<AutomationEditor {...props} />);
+
+    await screen.findByDisplayValue('id: new-automation\n', EXACT_VALUE);
+    await user.click(screen.getByTestId('automation-editor-save'));
+
+    await waitFor(() =>
+      expect(props.applyDefinition).toHaveBeenCalledWith('id: new-automation\n', '', 0),
+    );
+    await waitFor(() => expect(props.onSaved).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'new-automation', revision: 1 }),
+    ));
+  });
+
+  it('Save applies with the loaded id/revision when editing', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    props.definitionId = 'd1';
+    props.getDefinition.mockResolvedValue({ specYaml: 'id: d1\n', revision: 7 });
+    render(<AutomationEditor {...props} />);
+
+    await screen.findByDisplayValue('id: d1\n', EXACT_VALUE);
+    await user.click(screen.getByTestId('automation-editor-save'));
+
+    await waitFor(() => expect(props.applyDefinition).toHaveBeenCalledWith('id: d1\n', 'd1', 7));
+  });
+
+  it('a Save rejection surfaces the error and does not call onSaved', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    props.applyDefinition.mockRejectedValue(new Error('id mismatch: would fork this definition'));
+    render(<AutomationEditor {...props} />);
+
+    await screen.findByDisplayValue('id: new-automation\n', EXACT_VALUE);
+    await user.click(screen.getByTestId('automation-editor-save'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('automation-editor-save-error')).toHaveTextContent(
+        'id mismatch: would fork this definition',
+      ),
+    );
+    expect(props.onSaved).not.toHaveBeenCalled();
+  });
+
+  it('Cancel calls onCancel without saving', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    render(<AutomationEditor {...props} />);
+
+    await screen.findByDisplayValue('id: new-automation\n', EXACT_VALUE);
+    await user.click(screen.getByTestId('automation-editor-cancel'));
+
+    expect(props.onCancel).toHaveBeenCalledTimes(1);
+    expect(props.applyDefinition).not.toHaveBeenCalled();
+  });
+
+  it('the header close button also calls onCancel', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    render(<AutomationEditor {...props} />);
+
+    await screen.findByDisplayValue('id: new-automation\n', EXACT_VALUE);
+    await user.click(screen.getByTestId('automation-editor-close'));
+
+    expect(props.onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  // Reload is the recovery path after a stale-revision Save refusal (D5): it
+  // re-fetches the definition and pushes it into the ALREADY-MOUNTED buffer
+  // via the minimal-edit handle (applyExternalContent), rather than
+  // unmounting/remounting the editor — which is what actually preserves
+  // CodeMirror's scroll position and selection in the real component. This
+  // test proves the orchestration calls getDefinition again and the new
+  // content lands, without asserting on CodeMirror internals the mock
+  // doesn't have.
+  it('Reload re-fetches the definition and replaces the buffer without unmounting the editor', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    props.definitionId = 'd1';
+    props.getDefinition.mockResolvedValueOnce({ specYaml: 'id: d1\nname: v1\n', revision: 1 });
+    render(<AutomationEditor {...props} />);
+
+    await screen.findByDisplayValue('id: d1\nname: v1\n', EXACT_VALUE);
+
+    props.getDefinition.mockResolvedValueOnce({ specYaml: 'id: d1\nname: v2\n', revision: 2 });
+    await user.click(screen.getByTestId('automation-editor-reload'));
+
+    await waitFor(() => expect(props.getDefinition).toHaveBeenCalledTimes(2));
+    expect(await screen.findByDisplayValue('id: d1\nname: v2\n', EXACT_VALUE)).toBeInTheDocument();
+
+    // The refreshed revision is what the next Save carries as expected_revision.
+    await user.click(screen.getByTestId('automation-editor-save'));
+    await waitFor(() => expect(props.applyDefinition).toHaveBeenCalledWith('id: d1\nname: v2\n', 'd1', 2));
+  });
+
+  it('a Reload failure surfaces its own error without clearing the buffer', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    props.definitionId = 'd1';
+    props.getDefinition.mockResolvedValueOnce({ specYaml: 'id: d1\n', revision: 1 });
+    render(<AutomationEditor {...props} />);
+
+    await screen.findByDisplayValue('id: d1\n', EXACT_VALUE);
+
+    props.getDefinition.mockRejectedValueOnce(new Error('daemon unreachable'));
+    await user.click(screen.getByTestId('automation-editor-reload'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('automation-editor-reload-error')).toHaveTextContent('daemon unreachable'),
+    );
+    expect(screen.getByDisplayValue('id: d1\n', EXACT_VALUE)).toBeInTheDocument();
+  });
+});

--- a/app/src/components/automations/AutomationEditor.test.tsx
+++ b/app/src/components/automations/AutomationEditor.test.tsx
@@ -23,7 +23,12 @@ vi.mock('./AutomationYamlEditor', async () => {
   const { forwardRef, useImperativeHandle } = await import('react');
   return {
     AutomationYamlEditor: forwardRef(function MockAutomationYamlEditor(
-      { value, onChange, ariaLabel }: { value: string; onChange: (value: string) => void; ariaLabel?: string },
+      {
+        value,
+        onChange,
+        ariaLabel,
+        readOnly,
+      }: { value: string; onChange: (value: string) => void; ariaLabel?: string; readOnly?: boolean },
       ref: React.Ref<{ applyExternalContent: (next: string) => void; focus: () => void; getDocText: () => string }>,
     ) {
       // Mirrors the real imperative handle: pushing external content reports
@@ -47,8 +52,22 @@ vi.mock('./AutomationYamlEditor', async () => {
         focus: () => {},
         getDocText: () => value,
       }), [onChange, value]);
+      // Mirrors AutomationYamlEditor's `readOnly` prop with the native
+      // textarea attribute of the same name: user-event's isEditable() check
+      // respects `readOnly` on a textarea (like the real CodeMirror content
+      // DOM's contenteditable=false under `editable={false}`) and refuses to
+      // type into it, so a Defect D test driving this mock through
+      // user.type() exercises the same "typing during save is blocked"
+      // behavior the real editor provides. Load-bearing, not decoration: a
+      // mock that ignored `readOnly` would let a Defect D regression test
+      // pass whether or not AutomationEditor actually threads the prop.
       return (
-        <textarea aria-label={ariaLabel ?? 'Automation definition'} value={value} onChange={(event) => onChange(event.target.value)} />
+        <textarea
+          aria-label={ariaLabel ?? 'Automation definition'}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          readOnly={readOnly}
+        />
       );
     }),
   };
@@ -154,6 +173,74 @@ describe('AutomationEditor', () => {
     expect(screen.queryByTestId('automation-editor-validation-ok')).not.toBeInTheDocument();
   });
 
+  // Defect C: handleValidate has no staleness guard, so a Validate resolving
+  // after the buffer already changed underneath it can re-assert a verdict
+  // about text the daemon never saw. The previous test proves the DISPLAYED
+  // result is cleared the instant the user types; this one proves the
+  // in-flight request's own resolution can't undo that clear when it finally
+  // arrives — the actual race the bug report describes.
+  it('a stale Validate resolution does not re-assert a verdict after the buffer changed underneath it', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    let resolveValidate: (() => void) | undefined;
+    props.validateDefinition.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveValidate = resolve;
+        }),
+    );
+    render(<AutomationEditor {...props} />);
+
+    const textarea = await screen.findByDisplayValue('id: new-automation\n', EXACT_VALUE);
+    await user.click(screen.getByTestId('automation-editor-validate'));
+    await waitFor(() => expect(props.validateDefinition).toHaveBeenCalledTimes(1));
+
+    // Edit while the request is still outstanding — its eventual answer will
+    // describe a buffer that no longer exists.
+    await user.type(textarea, 'x');
+    expect(screen.queryByTestId('automation-editor-validation-ok')).not.toBeInTheDocument();
+
+    // The stale request finally resolves...
+    act(() => resolveValidate?.());
+    await waitFor(() => expect(screen.getByTestId('automation-editor-validate')).not.toBeDisabled());
+
+    // ...but "Looks good." must never appear against the edited buffer.
+    expect(screen.queryByTestId('automation-editor-validation-ok')).not.toBeInTheDocument();
+  });
+
+  // The second half of Defect C's fix: handleChange must not clear a
+  // 'checking' state just because the buffer changed, or the button's
+  // disabled gate re-opens mid-flight and a second click can stack a second
+  // request on top of the first — the two could then resolve out of order.
+  it('Validate stays disabled while a request is outstanding, even after the buffer is edited', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    let resolveValidate: (() => void) | undefined;
+    props.validateDefinition.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveValidate = resolve;
+        }),
+    );
+    render(<AutomationEditor {...props} />);
+
+    const textarea = await screen.findByDisplayValue('id: new-automation\n', EXACT_VALUE);
+    await user.click(screen.getByTestId('automation-editor-validate'));
+    await waitFor(() => expect(props.validateDefinition).toHaveBeenCalledTimes(1));
+
+    await user.type(textarea, 'x');
+    expect(screen.getByTestId('automation-editor-validate')).toBeDisabled();
+
+    // A click on a disabled button fires no click event — browsers don't
+    // dispatch one, and neither does user-event — so this cannot stack a
+    // second validateDefinition call.
+    await user.click(screen.getByTestId('automation-editor-validate'));
+    expect(props.validateDefinition).toHaveBeenCalledTimes(1);
+
+    act(() => resolveValidate?.());
+    await waitFor(() => expect(screen.getByTestId('automation-editor-validate')).not.toBeDisabled());
+  });
+
   it('Save applies with expected_id "" and expected_revision 0 when creating', async () => {
     const user = userEvent.setup();
     const props = baseProps();
@@ -181,6 +268,49 @@ describe('AutomationEditor', () => {
     await user.click(screen.getByTestId('automation-editor-save'));
 
     await waitFor(() => expect(props.applyDefinition).toHaveBeenCalledWith('id: d1\n', 'd1', 7));
+  });
+
+  // Defect D: handleSave captures `value` at click time but nothing froze the
+  // buffer for the request's duration, so characters typed while Save was
+  // outstanding were written into `value` and then silently discarded when
+  // onSaved unmounted the editor. Locking the buffer (readOnly while saving)
+  // is the fix; this proves both halves — the visible cue and the actual
+  // block on further edits, not just the label on the Save button.
+  it('locks the buffer against edits while Save is in flight, so typed characters are not silently discarded', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    let resolveApply:
+      | ((result: { definition: AutomationDefinitionSummary; specYaml: string; revision: number }) => void)
+      | undefined;
+    props.applyDefinition.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveApply = resolve;
+        }),
+    );
+    render(<AutomationEditor {...props} />);
+
+    const textarea = await screen.findByDisplayValue('id: new-automation\n', EXACT_VALUE);
+    await user.click(screen.getByTestId('automation-editor-save'));
+    await waitFor(() => expect(props.applyDefinition).toHaveBeenCalledTimes(1));
+
+    expect(screen.getByTestId('automation-editor-locked-hint')).toBeInTheDocument();
+
+    // Typing while locked must not change the buffer — this is the actual
+    // guarantee, not just the visible hint above. Without readOnly threaded
+    // through to the buffer, this keystroke would silently succeed and the
+    // character would vanish, unsent, when the editor unmounts on success.
+    await user.type(textarea, 'x');
+    expect(textarea).toHaveValue('id: new-automation\n');
+
+    act(() =>
+      resolveApply?.({
+        definition: makeDefinition({ id: 'new-automation', revision: 1 }),
+        specYaml: 'id: new-automation\n',
+        revision: 1,
+      }),
+    );
+    await waitFor(() => expect(props.onSaved).toHaveBeenCalled());
   });
 
   it('a Save rejection surfaces the error and does not call onSaved', async () => {

--- a/app/src/components/automations/AutomationEditor.test.tsx
+++ b/app/src/components/automations/AutomationEditor.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor, userEvent } from '../../test/utils';
+import { act, render, screen, waitFor, userEvent } from '../../test/utils';
 import { AutomationEditor } from './AutomationEditor';
 import { AutomationDefinitionSummary } from '../../types/generated';
+import { getAutomationEditorAutomationHandle } from './automationEditorAutomation';
 
 // getByDisplayValue/findByDisplayValue apply the default TL normalizer (trim
 // + collapse whitespace) to the DOM value being matched but NOT to the
@@ -23,16 +24,29 @@ vi.mock('./AutomationYamlEditor', async () => {
   return {
     AutomationYamlEditor: forwardRef(function MockAutomationYamlEditor(
       { value, onChange, ariaLabel }: { value: string; onChange: (value: string) => void; ariaLabel?: string },
-      ref: React.Ref<{ applyExternalContent: (next: string) => void; focus: () => void }>,
+      ref: React.Ref<{ applyExternalContent: (next: string) => void; focus: () => void; getDocText: () => string }>,
     ) {
       // Mirrors the real imperative handle: pushing external content reports
       // it through onChange, the way a CodeMirror dispatch would, so
       // AutomationEditor's controlled value tracks it — exactly what Reload
-      // relies on.
+      // relies on. getDocText mirrors the controlled `value` prop directly:
+      // unlike the real CodeMirror doc it can never lag behind it, since this
+      // mock has no buffer of its own independent of `value`.
+      //
+      // The `next === value` guard is load-bearing, not tidiness: the real
+      // applyExternalContent computes a MINIMAL edit and dispatches nothing
+      // when the text is unchanged, so no onChange fires. A mock that always
+      // called onChange would paper over exactly the case AutomationEditor's
+      // setText calls handleChange for, and any test of that case would pass
+      // against a component that had dropped the call.
       useImperativeHandle(ref, () => ({
-        applyExternalContent: (next: string) => onChange(next),
+        applyExternalContent: (next: string) => {
+          if (next === value) return;
+          onChange(next);
+        },
         focus: () => {},
-      }), [onChange]);
+        getDocText: () => value,
+      }), [onChange, value]);
       return (
         <textarea aria-label={ariaLabel ?? 'Automation definition'} value={value} onChange={(event) => onChange(event.target.value)} />
       );
@@ -281,5 +295,125 @@ describe('AutomationEditor', () => {
     expect(screen.getAllByTestId('automation-editor')).toHaveLength(2);
     await user.click(screen.getAllByTestId('automation-editor-close')[0]);
     expect(props.onCancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The UI automation bridge's automation_editor_* verbs read this handle
+// instead of scraping the DOM — see automationEditorAutomation.ts's doc
+// comment for why (CodeMirror virtualizes long documents, and this seam is
+// the evidence source for a save/reload comment-preservation proof).
+describe('AutomationEditor automation bridge handle', () => {
+  it('registers the handle while mounted and clears it on unmount', async () => {
+    const props = baseProps();
+    const { unmount } = render(<AutomationEditor {...props} />);
+
+    await screen.findByDisplayValue('id: new-automation\n', EXACT_VALUE);
+    expect(getAutomationEditorAutomationHandle()).not.toBeNull();
+
+    unmount();
+    expect(getAutomationEditorAutomationHandle()).toBeNull();
+  });
+
+  it('getState reflects create vs edit mode, reloadOffered, and a validation error message', async () => {
+    const user = userEvent.setup();
+    const createProps = baseProps();
+    const { unmount: unmountCreate } = render(<AutomationEditor {...createProps} />);
+    await screen.findByDisplayValue('id: new-automation\n', EXACT_VALUE);
+
+    expect(getAutomationEditorAutomationHandle()?.getState()).toMatchObject({
+      present: true,
+      mode: 'create',
+      definitionId: null,
+      reloadOffered: false,
+    });
+    unmountCreate();
+
+    const editProps = baseProps();
+    editProps.definitionId = 'd1';
+    editProps.validateDefinition.mockRejectedValue(
+      new Error('trigger.schedule.cron: invalid cron expression'),
+    );
+    editProps.getDefinition.mockResolvedValueOnce({ specYaml: 'id: d1\n', revision: 7 });
+    render(<AutomationEditor {...editProps} />);
+    await screen.findByDisplayValue('id: d1\n', EXACT_VALUE);
+
+    expect(getAutomationEditorAutomationHandle()?.getState()).toMatchObject({
+      present: true,
+      mode: 'edit',
+      definitionId: 'd1',
+      revision: 7,
+      reloadOffered: true,
+    });
+
+    await user.click(screen.getByTestId('automation-editor-validate'));
+    await screen.findByTestId('automation-editor-validation-error');
+
+    expect(getAutomationEditorAutomationHandle()?.getState().validation).toEqual({
+      state: 'error',
+      message: 'trigger.schedule.cron: invalid cron expression',
+    });
+  });
+
+  // The invariant setText must uphold: it's equivalent to the user replacing
+  // the buffer by typing, so it goes through the same path as onChange — a
+  // stale "Looks good." result is gone, and a subsequent Save sends exactly
+  // what was set, not what was loaded or previously typed.
+  it('setText clears a stale validation result and Save carries the newly set text', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    render(<AutomationEditor {...props} />);
+    await screen.findByDisplayValue('id: new-automation\n', EXACT_VALUE);
+
+    await user.click(screen.getByTestId('automation-editor-validate'));
+    await screen.findByTestId('automation-editor-validation-ok');
+
+    const handle = getAutomationEditorAutomationHandle();
+    expect(handle).not.toBeNull();
+    act(() => {
+      handle?.setText('id: new-automation\nname: replaced via bridge\n');
+    });
+
+    expect(screen.queryByTestId('automation-editor-validation-ok')).not.toBeInTheDocument();
+    await screen.findByDisplayValue('id: new-automation\nname: replaced via bridge\n', EXACT_VALUE);
+    // Re-read through the module getter, not the captured handle: the
+    // registration effect re-runs (and re-registers) on this state change,
+    // same gotcha as SettingsModal's selectSection (see SettingsModal.test.tsx).
+    expect(getAutomationEditorAutomationHandle()?.getState().text).toBe(
+      'id: new-automation\nname: replaced via bridge\n',
+    );
+
+    await user.click(screen.getByTestId('automation-editor-save'));
+    await waitFor(() =>
+      expect(props.applyDefinition).toHaveBeenCalledWith(
+        'id: new-automation\nname: replaced via bridge\n',
+        '',
+        0,
+      ),
+    );
+  });
+
+  // The case the test above cannot reach, and the only reason setText calls
+  // handleChange in addition to pushing the text into CodeMirror: when the
+  // new text equals the current buffer, applyExternalContent computes an
+  // empty edit and dispatches nothing, so no onChange fires. Without the
+  // explicit handleChange, a "Looks good." from a previous Validate would
+  // survive a setText — telling the harness (and a user) that text was
+  // validated when the validation it is showing predates the write.
+  it('setText clears a stale validation result even when the text is unchanged', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    render(<AutomationEditor {...props} />);
+    await screen.findByDisplayValue('id: new-automation\n', EXACT_VALUE);
+
+    await user.click(screen.getByTestId('automation-editor-validate'));
+    await screen.findByTestId('automation-editor-validation-ok');
+
+    act(() => {
+      // Byte-identical to what is already in the buffer.
+      getAutomationEditorAutomationHandle()?.setText('id: new-automation\n');
+    });
+
+    expect(screen.queryByTestId('automation-editor-validation-ok')).not.toBeInTheDocument();
+    expect(getAutomationEditorAutomationHandle()?.getState().validation.state).toBe('idle');
   });
 });

--- a/app/src/components/automations/AutomationEditor.tsx
+++ b/app/src/components/automations/AutomationEditor.tsx
@@ -1,0 +1,260 @@
+// Self-service automation YAML editor: load (create or edit share one path via
+// getDefinition('') → starter template, D7 in the design), Validate, Save, Cancel.
+//
+// D6 (no-stomp): this component's buffer state is populated ONCE on mount from
+// getDefinition, and thereafter only by the user's own typing or an explicit
+// click of Reload. It does not subscribe to useAutomationsStore (the panel's
+// automations_changed-driven list refetch lives entirely in AutomationsPanel),
+// so there is no code path by which a background broadcast can replace text the
+// user is mid-typing. AutomationsPanel is responsible for not remounting this
+// component except when the user explicitly opens a different target (New /
+// Edit), which is exactly "explicit load" — see AutomationsPanel.tsx.
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AutomationDefinitionSummary } from '../../types/generated';
+import { AutomationYamlEditor, type AutomationYamlEditorHandle } from './AutomationYamlEditor';
+import './AutomationEditor.css';
+
+export interface AutomationEditorProps {
+  // null → create (getDefinition is called with '', which returns the starter
+  // template at revision 0). Non-null → edit that definition.
+  definitionId: string | null;
+  getDefinition: (definitionId: string) => Promise<{ specYaml: string; revision: number }>;
+  validateDefinition: (definitionYaml: string) => Promise<void>;
+  applyDefinition: (
+    definitionYaml: string,
+    expectedId: string,
+    expectedRevision: number,
+  ) => Promise<{ definition: AutomationDefinitionSummary; specYaml: string; revision: number }>;
+  onCancel: () => void;
+  // Called once Save succeeds. The caller (AutomationsPanel) closes the editor
+  // back to the list — canonical state (including the new/updated row) arrives
+  // there via the daemon's automations_changed broadcast the apply also
+  // triggers, same as every other mutation on this panel.
+  onSaved: (definition: AutomationDefinitionSummary) => void;
+}
+
+type LoadStatus = 'loading' | 'ready' | 'load-error';
+type ValidationState = { state: 'idle' | 'checking' | 'ok' | 'error'; message?: string };
+
+export function AutomationEditor({
+  definitionId,
+  getDefinition,
+  validateDefinition,
+  applyDefinition,
+  onCancel,
+  onSaved,
+}: AutomationEditorProps) {
+  const editorRef = useRef<AutomationYamlEditorHandle>(null);
+
+  const [value, setValue] = useState('');
+  // The id used for expected_id on Save. Starts as the prop (null when
+  // creating); a successful create's response tells us the id the daemon
+  // actually persisted, so subsequent Saves in this same buffer become edits
+  // instead of re-creating (D4 in the design).
+  const [loadedId, setLoadedId] = useState<string | null>(definitionId);
+  const [revision, setRevision] = useState(0);
+
+  const [status, setStatus] = useState<LoadStatus>('loading');
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [reloading, setReloading] = useState(false);
+  const [reloadError, setReloadError] = useState<string | null>(null);
+
+  const [validation, setValidation] = useState<ValidationState>({ state: 'idle' });
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Mount-only initial load. Deliberately NOT re-run on definitionId churn —
+  // AutomationsPanel remounts this component (fresh key) whenever the user
+  // opens a different target, so "mount" already means "explicit load" (D6).
+  useEffect(() => {
+    let cancelled = false;
+    getDefinition(definitionId ?? '')
+      .then((result) => {
+        if (cancelled) return;
+        setValue(result.specYaml);
+        setRevision(result.revision);
+        setStatus('ready');
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setLoadError(error instanceof Error ? error.message : 'Failed to load automation definition');
+        setStatus('load-error');
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleChange = useCallback((next: string) => {
+    setValue(next);
+    // A prior Validate/Save result no longer describes the current text.
+    setValidation((prev) => (prev.state === 'idle' ? prev : { state: 'idle' }));
+    setSaveError(null);
+  }, []);
+
+  const handleValidate = useCallback(() => {
+    setValidation({ state: 'checking' });
+    validateDefinition(value)
+      .then(() => setValidation({ state: 'ok' }))
+      .catch((error) => {
+        setValidation({ state: 'error', message: error instanceof Error ? error.message : 'Validation failed' });
+      });
+  }, [validateDefinition, value]);
+
+  const handleSave = useCallback(() => {
+    setSaving(true);
+    setSaveError(null);
+    applyDefinition(value, loadedId ?? '', revision)
+      .then((result) => {
+        setSaving(false);
+        // Keep loadedId/revision in step with what the daemon actually
+        // persisted (D4/D5): today the parent always closes the editor right
+        // after onSaved, but updating here keeps a second Save in the same
+        // buffer correct (an edit with the fresh revision, not a stale-id
+        // create) if that ever changes.
+        setLoadedId(result.definition.id);
+        setRevision(result.definition.revision);
+        onSaved(result.definition);
+      })
+      .catch((error) => {
+        setSaving(false);
+        setSaveError(error instanceof Error ? error.message : 'Save failed');
+      });
+  }, [applyDefinition, value, loadedId, revision, onSaved]);
+
+  // Explicit reload (D6's other half of "only on explicit load or reload"):
+  // re-fetch the definition and push it into the already-mounted buffer via
+  // the minimal-edit handle, so an unaffected scroll position/selection
+  // survives — see AutomationYamlEditor's applyExternalContent doc comment.
+  // This is the recovery path after a stale-revision Save refusal ("changed
+  // elsewhere — reload", D5).
+  const handleReload = useCallback(() => {
+    setReloading(true);
+    setReloadError(null);
+    getDefinition(loadedId ?? '')
+      .then((result) => {
+        setRevision(result.revision);
+        editorRef.current?.applyExternalContent(result.specYaml);
+        setReloading(false);
+      })
+      .catch((error) => {
+        setReloadError(error instanceof Error ? error.message : 'Reload failed');
+        setReloading(false);
+      });
+  }, [getDefinition, loadedId]);
+
+  return (
+    <div className="automation-editor" data-testid="automation-editor">
+      <div className="automation-editor__header">
+        <h3 className="automation-editor__title">{definitionId ? 'Edit automation' : 'New automation'}</h3>
+        <button
+          type="button"
+          className="automation-editor__close"
+          onClick={onCancel}
+          aria-label="Close editor"
+          data-testid="automation-editor-close"
+        >
+          ✕
+        </button>
+      </div>
+
+      {status === 'loading' && <p className="automation-editor__status">Loading…</p>}
+
+      {status === 'load-error' && (
+        <p className="automation-editor__error" data-testid="automation-editor-load-error">
+          {loadError}
+        </p>
+      )}
+
+      {status === 'ready' && (
+        <>
+          {definitionId && (
+            <p className="automation-editor__hint">
+              Comments in this file are preserved as written. Automations created before this editor existed may
+              show comment-free YAML the first time they&apos;re opened here.
+            </p>
+          )}
+
+          <div className="automation-editor__buffer">
+            <AutomationYamlEditor
+              ref={editorRef}
+              value={value}
+              onChange={handleChange}
+              ariaLabel="Automation definition"
+              autoFocus
+            />
+          </div>
+
+          {reloadError && (
+            <p className="automation-editor__error" data-testid="automation-editor-reload-error">
+              {reloadError}
+            </p>
+          )}
+
+          {validation.state === 'error' && (
+            <p className="automation-editor__validation automation-editor__validation--error" data-testid="automation-editor-validation-error">
+              {validation.message}
+            </p>
+          )}
+          {validation.state === 'ok' && (
+            <p className="automation-editor__validation automation-editor__validation--ok" data-testid="automation-editor-validation-ok">
+              Looks good.
+            </p>
+          )}
+          {saveError && (
+            <p className="automation-editor__error" data-testid="automation-editor-save-error">
+              {saveError}
+            </p>
+          )}
+
+          <div className="automation-editor__actions">
+            <button
+              type="button"
+              className="automation-editor__reload"
+              onClick={handleReload}
+              disabled={reloading}
+              data-testid="automation-editor-reload"
+            >
+              {reloading ? 'Reloading…' : 'Reload'}
+            </button>
+            <div className="automation-editor__actions-primary">
+              <button
+                type="button"
+                className="automation-editor__validate"
+                onClick={handleValidate}
+                disabled={validation.state === 'checking'}
+                data-testid="automation-editor-validate"
+              >
+                {validation.state === 'checking' ? 'Validating…' : 'Validate'}
+              </button>
+              <button
+                type="button"
+                className="automation-editor__cancel"
+                onClick={onCancel}
+                data-testid="automation-editor-cancel"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="automation-editor__save"
+                onClick={handleSave}
+                disabled={saving}
+                data-testid="automation-editor-save"
+              >
+                {saving ? 'Saving…' : 'Save'}
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// Exported for AutomationsPanel to size/key the editor's mount identity.
+export function automationEditorKey(definitionId: string | null): string {
+  return definitionId ?? '__new__';
+}

--- a/app/src/components/automations/AutomationEditor.tsx
+++ b/app/src/components/automations/AutomationEditor.tsx
@@ -88,22 +88,67 @@ export function AutomationEditor({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Defect C guard: a dispatched Validate request has no cancel — it's a WS
+  // request/result pair (handleAutomationValidateWS), not fetch, so
+  // AbortController doesn't apply, and the daemon-side git shell-outs it
+  // triggers keep running regardless of what the buffer does afterward.
+  // Bumping this token on every dispatch AND on every edit gives the resolve
+  // handlers below a generation identity to check against — same shape as
+  // the daemon's classifierObservation convention (capture the observation
+  // identity before the async call, reject stale results).
+  const validateTokenRef = useRef(0);
+
   const handleChange = useCallback((next: string) => {
     setValue(next);
     // A prior Validate/Save result no longer describes the current text.
-    setValidation((prev) => (prev.state === 'idle' ? prev : { state: 'idle' }));
+    // Bump the token so an in-flight Validate's eventual answer is
+    // recognized as stale once it arrives (Defect C): typing invalidates it
+    // because the verdict is about text the daemon never saw, and
+    // re-asserting it here would be actively misleading either direction —
+    // "Looks good." against a buffer that would now be rejected, or a
+    // rejection pointing at a line the user already fixed. Deliberately do
+    // NOT clear a 'checking' state here: the request itself is still
+    // outstanding, and the Validate button's disabled gate must track that,
+    // not the buffer — otherwise a second click here could stack a second
+    // request on top of the first and the two could resolve out of order.
+    // handleValidate's resolve handlers below are what move validation out
+    // of 'checking', once the one outstanding request actually settles.
+    validateTokenRef.current += 1;
+    setValidation((prev) => (prev.state === 'idle' || prev.state === 'checking' ? prev : { state: 'idle' }));
     setSaveError(null);
   }, []);
 
   const handleValidate = useCallback(() => {
+    const token = ++validateTokenRef.current;
     setValidation({ state: 'checking' });
     validateDefinition(value)
-      .then(() => setValidation({ state: 'ok' }))
+      .then(() => {
+        // Superseded by an edit since dispatch: the text this describes is
+        // gone, so fall back to idle rather than assert a verdict about a
+        // buffer nobody can see anymore.
+        setValidation(validateTokenRef.current === token ? { state: 'ok' } : { state: 'idle' });
+      })
       .catch((error) => {
-        setValidation({ state: 'error', message: error instanceof Error ? error.message : 'Validation failed' });
+        setValidation(
+          validateTokenRef.current === token
+            ? { state: 'error', message: error instanceof Error ? error.message : 'Validation failed' }
+            : { state: 'idle' },
+        );
       });
   }, [validateDefinition, value]);
 
+  // Defect D: handleSave captures `value` at click time, but nothing else in
+  // the tree freezes the buffer for the request's duration —
+  // handleAutomationApplyWS waits on the daemon's automationMu, held across a
+  // full delivery (clone/fetch, agent spawn), bounded at 25s. AutomationYamlEditor
+  // stays mounted and focused while `saving` is true, so a user who keeps
+  // typing writes characters into `value` that were never part of what was
+  // sent; on success onSaved unmounts the editor (AutomationsPanel's
+  // setEditorTarget(null)) and those characters vanish with no warning. Fixed
+  // by locking the buffer (readOnly, below) for the duration rather than
+  // re-checking/warning on resolve: locking keeps "what was submitted" and
+  // "what's on screen" identical throughout, so there's nothing to reconcile
+  // or warn about after the fact.
   const handleSave = useCallback(() => {
     setSaving(true);
     setSaveError(null);
@@ -231,6 +276,12 @@ export function AutomationEditor({
             </p>
           )}
 
+          {saving && (
+            <p className="automation-editor__hint" data-testid="automation-editor-locked-hint">
+              Buffer locked while saving…
+            </p>
+          )}
+
           <div className="automation-editor__buffer">
             <AutomationYamlEditor
               ref={editorRef}
@@ -238,6 +289,7 @@ export function AutomationEditor({
               onChange={handleChange}
               ariaLabel="Automation definition"
               autoFocus
+              readOnly={saving}
             />
           </div>
 

--- a/app/src/components/automations/AutomationEditor.tsx
+++ b/app/src/components/automations/AutomationEditor.tsx
@@ -12,6 +12,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { AutomationDefinitionSummary } from '../../types/generated';
 import { AutomationYamlEditor, type AutomationYamlEditorHandle } from './AutomationYamlEditor';
+import { setAutomationEditorAutomationHandle } from './automationEditorAutomation';
 import './AutomationEditor.css';
 
 export interface AutomationEditorProps {
@@ -144,6 +145,59 @@ export function AutomationEditor({
         setReloading(false);
       });
   }, [getDefinition, loadedId]);
+
+  // Publish a read/write handle for the UI automation bridge (testing only —
+  // see automationEditorAutomation.ts's doc comment). Re-registered whenever
+  // the state getState() closes over changes, rather than GridView's
+  // single-registration-reading-through-refs pattern: nothing here mutates
+  // outside React's render cycle, so a plain effect dependency array keeps it
+  // correct with far less machinery.
+  useEffect(() => {
+    setAutomationEditorAutomationHandle({
+      getState: () => ({
+        present: true,
+        mode: definitionId ? 'edit' : 'create',
+        definitionId: loadedId,
+        revision,
+        status,
+        loadError: loadError ?? '',
+        // The live CodeMirror doc, not the `value` state mirror — see
+        // getDocText's doc comment for why the mirror can lag mid-typing.
+        text: editorRef.current?.getDocText() ?? value,
+        validation: { state: validation.state, message: validation.message ?? '' },
+        saving,
+        saveError: saveError ?? '',
+        reloading,
+        reloadError: reloadError ?? '',
+        // Mirrors the JSX gate below: Reload presupposes a persisted definition.
+        reloadOffered: loadedId !== null,
+      }),
+      // Equivalent to the user replacing the buffer by typing: go through the
+      // same handleChange the real onChange path uses (so a stale validation
+      // result and stale saveError are cleared even if `next` happens to
+      // equal the current doc, when applyExternalContent's dispatch would be
+      // a no-op), then push the text into CodeMirror so a subsequent Save —
+      // and getDocText() — see exactly what was set.
+      setText: (next: string) => {
+        editorRef.current?.applyExternalContent(next);
+        handleChange(next);
+      },
+    });
+    return () => setAutomationEditorAutomationHandle(null);
+  }, [
+    definitionId,
+    loadedId,
+    revision,
+    status,
+    loadError,
+    value,
+    validation,
+    saving,
+    saveError,
+    reloading,
+    reloadError,
+    handleChange,
+  ]);
 
   return (
     <div className="automation-editor" data-testid="automation-editor">

--- a/app/src/components/automations/AutomationEditor.tsx
+++ b/app/src/components/automations/AutomationEditor.tsx
@@ -210,15 +210,25 @@ export function AutomationEditor({
           )}
 
           <div className="automation-editor__actions">
-            <button
-              type="button"
-              className="automation-editor__reload"
-              onClick={handleReload}
-              disabled={reloading}
-              data-testid="automation-editor-reload"
-            >
-              {reloading ? 'Reloading…' : 'Reload'}
-            </button>
+            {/* Reload exists only as the recovery path after a stale-revision
+                Save refusal (D5), which presupposes a persisted definition.
+                While creating, loadedId is null and Reload would re-fetch the
+                starter template — silently discarding the draft being typed
+                for no reachable benefit. So it is not offered until the buffer
+                is backed by a saved definition. */}
+            {loadedId !== null ? (
+              <button
+                type="button"
+                className="automation-editor__reload"
+                onClick={handleReload}
+                disabled={reloading}
+                data-testid="automation-editor-reload"
+              >
+                {reloading ? 'Reloading…' : 'Reload'}
+              </button>
+            ) : (
+              <span />
+            )}
             <div className="automation-editor__actions-primary">
               <button
                 type="button"

--- a/app/src/components/automations/AutomationYamlEditor.tsx
+++ b/app/src/components/automations/AutomationYamlEditor.tsx
@@ -37,6 +37,11 @@ export interface AutomationYamlEditorHandle {
   // current.
   applyExternalContent: (next: string) => void;
   focus: () => void;
+  // Live buffer text straight from the CodeMirror doc, for the UI automation
+  // bridge's automation_editor_* verbs — see automationEditorAutomation.ts's
+  // doc comment for why this exists instead of scraping the DOM. '' before
+  // the view has mounted.
+  getDocText: () => string;
 }
 
 interface AutomationYamlEditorProps {
@@ -141,6 +146,7 @@ export const AutomationYamlEditor = forwardRef<AutomationYamlEditorHandle, Autom
         focus: () => {
           cmRef.current?.view?.focus();
         },
+        getDocText: () => cmRef.current?.view?.state.doc.toString() ?? '',
       }),
       [],
     );

--- a/app/src/components/automations/AutomationYamlEditor.tsx
+++ b/app/src/components/automations/AutomationYamlEditor.tsx
@@ -49,6 +49,20 @@ interface AutomationYamlEditorProps {
   onChange: (value: string) => void;
   ariaLabel?: string;
   autoFocus?: boolean;
+  // Locks the buffer against user edits without unmounting it — used by
+  // AutomationEditor while a Save is in flight (see its handleSave doc
+  // comment). Threaded to BOTH of @uiw/react-codemirror's editable/readOnly
+  // props rather than just one: `editable={false}` drops the content DOM's
+  // `contenteditable` attribute (the visible/interaction cue — no caret, the
+  // element stops accepting keyboard input), while `readOnly` sets
+  // EditorState.readOnly (the actual guarantee — the view's own input
+  // handlers, e.g. paste/drop/cut, check this directly; it also gets us
+  // aria-readonly for free). Neither blocks a programmatic view.dispatch —
+  // by design, since applyExternalContent's Reload path still needs to work.
+  // Both react to prop changes at runtime (useCodeMirror reconfigures via
+  // StateEffect.reconfigure on change), so toggling this doesn't remount the
+  // editor or disturb scroll/selection.
+  readOnly?: boolean;
 }
 
 // Themed via CSS variables, same rationale as LiveMarkdownEditor.tsx: skip
@@ -127,7 +141,7 @@ const editorTheme = EditorView.theme({
 });
 
 export const AutomationYamlEditor = forwardRef<AutomationYamlEditorHandle, AutomationYamlEditorProps>(
-  function AutomationYamlEditor({ value, onChange, ariaLabel, autoFocus }, ref) {
+  function AutomationYamlEditor({ value, onChange, ariaLabel, autoFocus, readOnly }, ref) {
     const cmRef = useRef<ReactCodeMirrorRef>(null);
 
     useImperativeHandle(
@@ -170,6 +184,8 @@ export const AutomationYamlEditor = forwardRef<AutomationYamlEditorHandle, Autom
         onChange={onChange}
         extensions={extensions}
         autoFocus={autoFocus}
+        editable={!readOnly}
+        readOnly={readOnly}
         height="100%"
         aria-label={ariaLabel}
         // Skip @uiw/react-codemirror's built-in theme — see editorTheme's doc

--- a/app/src/components/automations/AutomationYamlEditor.tsx
+++ b/app/src/components/automations/AutomationYamlEditor.tsx
@@ -1,0 +1,189 @@
+// The YAML text buffer for the automation definition editor: CodeMirror 6 with
+// syntax highlighting, no live-preview decorations (unlike LiveMarkdownEditor —
+// this is a code buffer, not prose). Controlled `value`, plus an imperative
+// `applyExternalContent` handle for AutomationEditor's explicit Reload action
+// (see minimalEdit.ts's doc comment for why: a plain controlled-value swap
+// snaps CodeMirror's scroll/selection back to the top, which would be jarring
+// mid-edit after a reload that mostly re-confirms unchanged text).
+
+import { forwardRef, useImperativeHandle, useMemo, useRef } from 'react';
+import CodeMirror, { type ReactCodeMirrorRef } from '@uiw/react-codemirror';
+import { yaml } from '@codemirror/lang-yaml';
+import { syntaxHighlighting } from '@codemirror/language';
+import { search, searchKeymap } from '@codemirror/search';
+import { classHighlighter } from '@lezer/highlight';
+import { EditorView, keymap, type KeyBinding } from '@codemirror/view';
+import { computeMinimalEdit } from '../notebook/minimalEdit';
+
+// searchKeymap binds its commands with CodeMirror's "Mod-" modifier, which CM
+// resolves to Meta only when it detects a Mac platform (navigator.platform) and
+// to Ctrl everywhere else. attn only ships on macOS (see AGENTS.md), so "Mod"
+// must always mean Cmd — but a Linux CI browser (e.g. headless Chromium on the
+// e2e runners) reports a non-Mac platform and silently rebinds Cmd+F to Ctrl+F,
+// leaving Cmd+F inert. Rewrite every "Mod-" prefix to an explicit "Cmd-" so the
+// binding is platform-independent instead of relying on CM's own detection.
+// (Same fix as LiveMarkdownEditor.tsx — duplicated rather than shared because
+// the two editors otherwise have no coupling.)
+const macSearchKeymap: readonly KeyBinding[] = searchKeymap.map((binding) =>
+  binding.key?.startsWith('Mod-') ? { ...binding, key: `Cmd-${binding.key.slice(4)}` } : binding,
+);
+
+export interface AutomationYamlEditorHandle {
+  // Replace the document with `next` as a MINIMAL edit (shared prefix/suffix
+  // trimmed) so scroll position and selection stay anchored. Used by
+  // AutomationEditor's Reload action to pull the daemon's current
+  // definition_yaml into an already-open buffer without yanking the viewport
+  // to the top. No-op until the view mounts, or when `next` is already
+  // current.
+  applyExternalContent: (next: string) => void;
+  focus: () => void;
+}
+
+interface AutomationYamlEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  ariaLabel?: string;
+  autoFocus?: boolean;
+}
+
+// Themed via CSS variables, same rationale as LiveMarkdownEditor.tsx: skip
+// @uiw/react-codemirror's built-in theme (its default "light" paints a white
+// background, which would be a white box on the app's dark pane) and own every
+// surface CM's base `&light`/`&dark` rules would otherwise pick a light-biased
+// default for — background, foreground, cursor, selection.
+const editorTheme = EditorView.theme({
+  '&': {
+    height: '100%',
+    backgroundColor: 'transparent',
+    color: 'var(--color-text-primary, inherit)',
+    fontSize: '13px',
+  },
+  '.cm-content': {
+    fontFamily: "var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace)",
+    lineHeight: '1.5',
+    padding: '8px 0 40px',
+  },
+  '.cm-scroller': { overflow: 'auto' },
+  '&.cm-focused': { outline: 'none' },
+  '.cm-gutters': {
+    backgroundColor: 'transparent',
+    color: 'var(--color-text-tertiary, rgba(128, 128, 128, 0.7))',
+    border: 'none',
+  },
+  '.cm-activeLineGutter': {
+    backgroundColor: 'color-mix(in srgb, var(--color-text-primary, #e8e8e8) 8%, transparent)',
+  },
+  // basicSetup's drawSelection hides the native caret and renders its own
+  // .cm-cursor element — see LiveMarkdownEditor.tsx's editorTheme for why this
+  // selector (deep enough to outrank CM's base &light/&dark .cm-cursor rule)
+  // is needed to keep the caret visible in both themes.
+  '.cm-cursorLayer .cm-cursor, .cm-dropCursor': {
+    borderLeftColor: 'var(--color-text-primary, #e8e8e8)',
+    borderLeftWidth: '2px',
+  },
+  '.cm-selectionLayer .cm-selectionBackground': {
+    backgroundColor: 'color-mix(in srgb, var(--accent, #ff6b35) 30%, transparent) !important',
+  },
+  '.cm-panels': {
+    color: 'var(--color-text-primary, inherit)',
+    backgroundColor: 'var(--color-bg-elevated, rgba(128, 128, 128, 0.08))',
+  },
+  '.cm-panels.cm-panels-top': {
+    borderBottom: '1px solid var(--color-border, rgba(128, 128, 128, 0.3))',
+  },
+  '.cm-panel.cm-search': {
+    padding: '4px 6px',
+    fontFamily: 'system-ui, -apple-system, sans-serif',
+    fontSize: '12px',
+  },
+  '.cm-panel.cm-search input, .cm-panel.cm-search button, .cm-panel.cm-search label': {
+    fontFamily: 'inherit',
+    fontSize: 'inherit',
+    color: 'var(--color-text-primary, inherit)',
+  },
+  '.cm-panel.cm-search input': {
+    backgroundColor: 'var(--color-bg-input, transparent)',
+    border: '1px solid var(--color-border, rgba(128, 128, 128, 0.3))',
+    borderRadius: '3px',
+    padding: '2px 4px',
+  },
+  '.cm-panel.cm-search button': {
+    backgroundImage: 'none',
+    backgroundColor: 'var(--color-bg-button, transparent)',
+    border: '1px solid var(--color-border, rgba(128, 128, 128, 0.3))',
+    borderRadius: '3px',
+  },
+  '.cm-searchMatch': {
+    backgroundColor: 'color-mix(in srgb, var(--accent, #ff6b35) 25%, transparent)',
+  },
+  '.cm-searchMatch-selected': {
+    backgroundColor: 'color-mix(in srgb, var(--accent, #ff6b35) 50%, transparent)',
+  },
+});
+
+export const AutomationYamlEditor = forwardRef<AutomationYamlEditorHandle, AutomationYamlEditorProps>(
+  function AutomationYamlEditor({ value, onChange, ariaLabel, autoFocus }, ref) {
+    const cmRef = useRef<ReactCodeMirrorRef>(null);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        applyExternalContent: (next: string) => {
+          const view = cmRef.current?.view;
+          if (!view) return;
+          const edit = computeMinimalEdit(view.state.doc.toString(), next);
+          if (!edit) return; // unchanged → no transaction, scroll/selection untouched
+          view.dispatch({
+            changes: { from: edit.from, to: edit.to, insert: edit.insert },
+            scrollIntoView: false,
+          });
+        },
+        focus: () => {
+          cmRef.current?.view?.focus();
+        },
+      }),
+      [],
+    );
+
+    const extensions = useMemo(
+      () => [
+        yaml(),
+        syntaxHighlighting(classHighlighter),
+        EditorView.lineWrapping,
+        search({ top: true }),
+        keymap.of(macSearchKeymap),
+        editorTheme,
+      ],
+      [],
+    );
+
+    return (
+      <CodeMirror
+        ref={cmRef}
+        value={value}
+        onChange={onChange}
+        extensions={extensions}
+        autoFocus={autoFocus}
+        height="100%"
+        aria-label={ariaLabel}
+        // Skip @uiw/react-codemirror's built-in theme — see editorTheme's doc
+        // comment above.
+        theme="none"
+        basicSetup={{
+          lineNumbers: true,
+          foldGutter: false,
+          highlightActiveLine: false,
+          highlightActiveLineGutter: true,
+          highlightSelectionMatches: false,
+          bracketMatching: true,
+          closeBrackets: false,
+          autocompletion: false,
+          searchKeymap: false,
+          lintKeymap: false,
+          // The default highlight style fights classHighlighter above.
+          syntaxHighlighting: false,
+        }}
+      />
+    );
+  },
+);

--- a/app/src/components/automations/automationEditorAutomation.ts
+++ b/app/src/components/automations/automationEditorAutomation.ts
@@ -1,0 +1,44 @@
+// A tiny module-level registry so the UI automation bridge can introspect the
+// automation editor's live buffer without a reference into the conditionally-
+// mounted AutomationEditor. AutomationEditor publishes a handle while it's
+// mounted and clears it on unmount; the bridge reads through
+// getAutomationEditorAutomationHandle(). This is a test affordance only — it
+// exists because AutomationYamlEditor is CodeMirror-backed and CodeMirror
+// virtualizes long documents, so scraping `.cm-content`/`.cm-line` from the
+// DOM can silently truncate the buffer text this seam is meant to prove (a
+// save/reload round-trip preserving YAML comments). getState() reads real
+// component state directly; setText() replaces the buffer the same way the
+// user's own typing would (see AutomationEditor.tsx's registration effect).
+export interface AutomationEditorAutomationState {
+  present: true;
+  mode: 'create' | 'edit';
+  definitionId: string | null;
+  revision: number;
+  status: 'loading' | 'ready' | 'load-error';
+  loadError: string;
+  text: string;
+  validation: { state: 'idle' | 'checking' | 'ok' | 'error'; message: string };
+  saving: boolean;
+  saveError: string;
+  reloading: boolean;
+  reloadError: string;
+  reloadOffered: boolean;
+}
+
+export interface AutomationEditorAutomationHandle {
+  getState(): AutomationEditorAutomationState;
+  setText(next: string): void;
+}
+
+let handle: AutomationEditorAutomationHandle | null = null;
+
+export function setAutomationEditorAutomationHandle(next: AutomationEditorAutomationHandle | null): void {
+  handle = next;
+}
+
+export function getAutomationEditorAutomationHandle(): AutomationEditorAutomationHandle | null {
+  return handle;
+}
+
+// State when the editor isn't mounted — so callers get a stable shape either way.
+export const INACTIVE_AUTOMATION_EDITOR_STATE: { present: false } = { present: false };

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -5393,6 +5393,121 @@ export function useDaemonSocket({
     [],
   );
 
+  // getAutomationDefinition backs the editor's load path. definitionId '' asks
+  // for the starter template at revision 0 (the create case, D7 in the
+  // design) — create and edit share this one call.
+  const getAutomationDefinition = useCallback(
+    (definitionId: string): Promise<{ specYaml: string; revision: number }> => {
+      return new Promise((resolve, reject) => {
+        const ws = wsRef.current;
+        if (!ws || ws.readyState !== WebSocket.OPEN) {
+          reject(new Error('WebSocket not connected'));
+          return;
+        }
+        const requestId = nextRequestID('automation_definition_get');
+        const key = `automation:${requestId}`;
+        pendingActionsRef.current.set(key, {
+          resolve: (result: any) => resolve({ specYaml: result.spec_yaml ?? '', revision: result.revision ?? 0 }),
+          reject,
+        });
+        ws.send(
+          JSON.stringify({ cmd: 'automation_definition_get', definition_id: definitionId, request_id: requestId }),
+        );
+        // Mutations can serialize behind an in-flight automation delivery
+        // (daemon holds automationMu across full run delivery); 30s matches the
+        // repo's async-action convention. get/definition_get is read-only and
+        // doesn't itself take automationMu, but shares the same timeout for
+        // consistency with the rest of the automations WS surface.
+        setTimeout(() => {
+          if (pendingActionsRef.current.has(key)) {
+            pendingActionsRef.current.delete(key);
+            reject(new AutomationActionTimeoutError('Get automation definition timed out'));
+          }
+        }, 30000);
+      });
+    },
+    [nextRequestID],
+  );
+
+  // validateAutomationSpec runs the daemon's shared validation seam
+  // (validateAutomationSpec, D3 in the design) without persisting anything, so
+  // the editor can show an error before Save.
+  const validateAutomationDefinition = useCallback(
+    (definitionYaml: string): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        const ws = wsRef.current;
+        if (!ws || ws.readyState !== WebSocket.OPEN) {
+          reject(new Error('WebSocket not connected'));
+          return;
+        }
+        const requestId = nextRequestID('automation_validate');
+        const key = `automation:${requestId}`;
+        pendingActionsRef.current.set(key, { resolve: () => resolve(undefined), reject });
+        ws.send(
+          JSON.stringify({ cmd: 'automation_validate', definition_yaml: definitionYaml, request_id: requestId }),
+        );
+        setTimeout(() => {
+          if (pendingActionsRef.current.has(key)) {
+            pendingActionsRef.current.delete(key);
+            reject(new AutomationActionTimeoutError('Validate automation timed out'));
+          }
+        }, 30000);
+      });
+    },
+    [nextRequestID],
+  );
+
+  // applyAutomationDefinition is validate-then-persist, carrying expected_id
+  // (D4) and expected_revision (D5) so the daemon can refuse an id change or a
+  // stale save. expectedId is '' when creating, expectedRevision is 0 when
+  // creating — matching AutomationEditor's loadedId/revision state, which
+  // start from getAutomationDefinition('')'s template response.
+  const applyAutomationDefinition = useCallback(
+    (
+      definitionYaml: string,
+      expectedId: string,
+      expectedRevision: number,
+    ): Promise<{ definition: AutomationDefinitionSummary; specYaml: string; revision: number }> => {
+      return new Promise((resolve, reject) => {
+        const ws = wsRef.current;
+        if (!ws || ws.readyState !== WebSocket.OPEN) {
+          reject(new Error('WebSocket not connected'));
+          return;
+        }
+        const requestId = nextRequestID('automation_apply');
+        const key = `automation:${requestId}`;
+        pendingActionsRef.current.set(key, {
+          resolve: (result: any) =>
+            resolve({
+              definition: (result.definitions ?? [])[0],
+              specYaml: result.spec_yaml ?? '',
+              revision: result.revision ?? 0,
+            }),
+          reject,
+        });
+        ws.send(
+          JSON.stringify({
+            cmd: 'automation_apply',
+            definition_yaml: definitionYaml,
+            expected_id: expectedId,
+            expected_revision: expectedRevision,
+            request_id: requestId,
+          }),
+        );
+        // Mutations can serialize behind an in-flight automation delivery
+        // (daemon holds automationMu across full run delivery); 30s matches
+        // the repo's async-action convention.
+        setTimeout(() => {
+          if (pendingActionsRef.current.has(key)) {
+            pendingActionsRef.current.delete(key);
+            reject(new AutomationActionTimeoutError('Apply automation timed out'));
+          }
+        }, 30000);
+      });
+    },
+    [nextRequestID],
+  );
+
   // Fetch the current open/closed presentations (for the main-window banner).
   const getPresentations = useCallback((): Promise<Presentation[]> => {
     return new Promise((resolve, reject) => {
@@ -5631,6 +5746,9 @@ export function useDaemonSocket({
     listAutomationRuns,
     setAutomationEnabled,
     runAutomationNow,
+    getAutomationDefinition,
+    validateAutomationDefinition,
+    applyAutomationDefinition,
     getPresentations,
     getPresentationRound,
     submitPresentationRound,

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -173,7 +173,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '179';
+export const PROTOCOL_VERSION = '180';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -10,6 +10,10 @@ import type { TerminalSplitDirection } from '../types/workspace';
 import { SHORTCUTS, type ShortcutId, type Combo, isChord, resolveBinding } from '../shortcuts';
 import { getGridAutomationHandle, INACTIVE_GRID_STATE } from '../components/grid/gridAutomation';
 import {
+  getAutomationEditorAutomationHandle,
+  INACTIVE_AUTOMATION_EDITOR_STATE,
+} from '../components/automations/automationEditorAutomation';
+import {
   getMarkdownAnnotationsAutomationHandle,
   INACTIVE_MARKDOWN_ANNOTATIONS_STATE,
 } from '../components/MarkdownReader/annotations/annotationsAutomation';
@@ -1300,6 +1304,13 @@ function collectAutomationsUiState() {
     definitions,
     runs,
   };
+}
+
+// Unlike collectAutomationsUiState above, the editor's buffer text can't be
+// scraped from the DOM (CodeMirror virtualizes long documents), so this reads
+// through the registered handle instead — see automationEditorAutomation.ts.
+function collectAutomationEditorUiState() {
+  return getAutomationEditorAutomationHandle()?.getState() ?? INACTIVE_AUTOMATION_EDITOR_STATE;
 }
 
 function getLocationPickerRoot() {
@@ -2695,6 +2706,52 @@ export function useUiAutomationBridge({
         clickTestId(`automation-definition-select-${definitionId}`);
         await settleUi(3);
         return collectAutomationsUiState();
+      }
+      // Automation editor (self-service YAML buffer). getState reads live
+      // component state through the registered handle rather than scraping
+      // the DOM — see collectAutomationEditorUiState above for why.
+      case 'automation_editor_open': {
+        const definitionId = typeof payload.definitionId === 'string' ? payload.definitionId : '';
+        clickTestId(definitionId ? `automation-edit-${definitionId}` : 'automation-new');
+        await settleUi(3);
+        return collectAutomationEditorUiState();
+      }
+      case 'automation_editor_get_state':
+        return collectAutomationEditorUiState();
+      case 'automation_editor_set_text': {
+        const text = typeof payload.text === 'string' ? payload.text : null;
+        if (text === null) throw new Error('automation_editor_set_text requires text');
+        const handle = getAutomationEditorAutomationHandle();
+        if (!handle) throw new Error('automation editor is not mounted');
+        handle.setText(text);
+        await settleUi(2);
+        return collectAutomationEditorUiState();
+      }
+      case 'automation_editor_click': {
+        const button = typeof payload.button === 'string' ? payload.button : '';
+        let testid: string;
+        switch (button) {
+          case 'validate':
+            testid = 'automation-editor-validate';
+            break;
+          case 'save':
+            testid = 'automation-editor-save';
+            break;
+          case 'cancel':
+            testid = 'automation-editor-cancel';
+            break;
+          case 'reload':
+            testid = 'automation-editor-reload';
+            break;
+          case 'close':
+            testid = 'automation-editor-close';
+            break;
+          default:
+            throw new Error(`automation_editor_click: unknown button "${button}"`);
+        }
+        clickTestId(testid);
+        await settleUi(3);
+        return collectAutomationEditorUiState();
       }
       case 'click_nudge_trigger': {
         // The "deliver now" trigger renders only in NudgeIndicator's paused mode

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, AutomationActionResultMessage, AutomationApplyMessage, AutomationCleanupMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDeleteMessage, AutomationListMessage, AutomationRunListMessage, AutomationRunMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationSetEnabledMessage, AutomationShowMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, AutomationActionResultMessage, AutomationApplyMessage, AutomationCleanupMessage, AutomationDefinitionGetMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDeleteMessage, AutomationListMessage, AutomationRunListMessage, AutomationRunMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationSetEnabledMessage, AutomationShowMessage, AutomationValidateMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -12,6 +12,7 @@
 //   const automationActionResultMessage = Convert.toAutomationActionResultMessage(json);
 //   const automationApplyMessage = Convert.toAutomationApplyMessage(json);
 //   const automationCleanupMessage = Convert.toAutomationCleanupMessage(json);
+//   const automationDefinitionGetMessage = Convert.toAutomationDefinitionGetMessage(json);
 //   const automationDefinitionSummary = Convert.toAutomationDefinitionSummary(json);
 //   const automationDefinitionsGetMessage = Convert.toAutomationDefinitionsGetMessage(json);
 //   const automationDeleteMessage = Convert.toAutomationDeleteMessage(json);
@@ -22,6 +23,7 @@
 //   const automationRunsGetMessage = Convert.toAutomationRunsGetMessage(json);
 //   const automationSetEnabledMessage = Convert.toAutomationSetEnabledMessage(json);
 //   const automationShowMessage = Convert.toAutomationShowMessage(json);
+//   const automationValidateMessage = Convert.toAutomationValidateMessage(json);
 //   const automationsChangedMessage = Convert.toAutomationsChangedMessage(json);
 //   const bootstrapEndpointMessage = Convert.toBootstrapEndpointMessage(json);
 //   const branch = Convert.toBranch(json);
@@ -480,9 +482,11 @@ export interface AutomationActionResultMessage {
     kept_active?: string[];
     kept_dirty?:  string[];
     request_id?:  string;
+    revision?:    number;
     run_id?:      string;
     runs?:        RunElement[];
     session_id?:  string;
+    spec_yaml?:   string;
     success:      boolean;
     ticket_id?:   string;
     truncated?:   boolean;
@@ -525,8 +529,11 @@ export interface RunElement {
 }
 
 export interface AutomationApplyMessage {
-    cmd:             AutomationApplyMessageCmd;
-    definition_yaml: string;
+    cmd:                AutomationApplyMessageCmd;
+    definition_yaml:    string;
+    expected_id?:       string;
+    expected_revision?: number;
+    request_id?:        string;
     [property: string]: any;
 }
 
@@ -543,6 +550,17 @@ export interface AutomationCleanupMessage {
 
 export enum AutomationCleanupMessageCmd {
     AutomationCleanup = "automation_cleanup",
+}
+
+export interface AutomationDefinitionGetMessage {
+    cmd:           AutomationDefinitionGetMessageCmd;
+    definition_id: string;
+    request_id?:   string;
+    [property: string]: any;
+}
+
+export enum AutomationDefinitionGetMessageCmd {
+    AutomationDefinitionGet = "automation_definition_get",
 }
 
 export interface AutomationDefinitionSummary {
@@ -660,6 +678,17 @@ export interface AutomationShowMessage {
 
 export enum AutomationShowMessageCmd {
     AutomationShow = "automation_show",
+}
+
+export interface AutomationValidateMessage {
+    cmd:             AutomationValidateMessageCmd;
+    definition_yaml: string;
+    request_id?:     string;
+    [property: string]: any;
+}
+
+export enum AutomationValidateMessageCmd {
+    AutomationValidate = "automation_validate",
 }
 
 export interface AutomationsChangedMessage {
@@ -5513,6 +5542,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AutomationCleanupMessage")), null, 2);
     }
 
+    public static toAutomationDefinitionGetMessage(json: string): AutomationDefinitionGetMessage {
+        return cast(JSON.parse(json), r("AutomationDefinitionGetMessage"));
+    }
+
+    public static automationDefinitionGetMessageToJson(value: AutomationDefinitionGetMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationDefinitionGetMessage")), null, 2);
+    }
+
     public static toAutomationDefinitionSummary(json: string): AutomationDefinitionSummary {
         return cast(JSON.parse(json), r("AutomationDefinitionSummary"));
     }
@@ -5591,6 +5628,14 @@ export class Convert {
 
     public static automationShowMessageToJson(value: AutomationShowMessage): string {
         return JSON.stringify(uncast(value, r("AutomationShowMessage")), null, 2);
+    }
+
+    public static toAutomationValidateMessage(json: string): AutomationValidateMessage {
+        return cast(JSON.parse(json), r("AutomationValidateMessage"));
+    }
+
+    public static automationValidateMessageToJson(value: AutomationValidateMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationValidateMessage")), null, 2);
     }
 
     public static toAutomationsChangedMessage(json: string): AutomationsChangedMessage {
@@ -8609,9 +8654,11 @@ const typeMap: any = {
         { json: "kept_active", js: "kept_active", typ: u(undefined, a("")) },
         { json: "kept_dirty", js: "kept_dirty", typ: u(undefined, a("")) },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "revision", js: "revision", typ: u(undefined, 0) },
         { json: "run_id", js: "run_id", typ: u(undefined, "") },
         { json: "runs", js: "runs", typ: u(undefined, a(r("RunElement"))) },
         { json: "session_id", js: "session_id", typ: u(undefined, "") },
+        { json: "spec_yaml", js: "spec_yaml", typ: u(undefined, "") },
         { json: "success", js: "success", typ: true },
         { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
         { json: "truncated", js: "truncated", typ: u(undefined, true) },
@@ -8646,9 +8693,17 @@ const typeMap: any = {
     "AutomationApplyMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationApplyMessageCmd") },
         { json: "definition_yaml", js: "definition_yaml", typ: "" },
+        { json: "expected_id", js: "expected_id", typ: u(undefined, "") },
+        { json: "expected_revision", js: "expected_revision", typ: u(undefined, 0) },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
     ], "any"),
     "AutomationCleanupMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationCleanupMessageCmd") },
+        { json: "definition_id", js: "definition_id", typ: "" },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    ], "any"),
+    "AutomationDefinitionGetMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutomationDefinitionGetMessageCmd") },
         { json: "definition_id", js: "definition_id", typ: "" },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
     ], "any"),
@@ -8716,6 +8771,11 @@ const typeMap: any = {
     "AutomationShowMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationShowMessageCmd") },
         { json: "definition_id", js: "definition_id", typ: "" },
+    ], "any"),
+    "AutomationValidateMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutomationValidateMessageCmd") },
+        { json: "definition_yaml", js: "definition_yaml", typ: "" },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
     ], "any"),
     "AutomationsChangedMessage": o([
         { json: "definition_ids", js: "definition_ids", typ: a("") },
@@ -11570,6 +11630,9 @@ const typeMap: any = {
     "AutomationCleanupMessageCmd": [
         "automation_cleanup",
     ],
+    "AutomationDefinitionGetMessageCmd": [
+        "automation_definition_get",
+    ],
     "AutomationDefinitionsGetMessageCmd": [
         "automation_definitions_get",
     ],
@@ -11593,6 +11656,9 @@ const typeMap: any = {
     ],
     "AutomationShowMessageCmd": [
         "automation_show",
+    ],
+    "AutomationValidateMessageCmd": [
+        "automation_validate",
     ],
     "AutomationsChangedMessageEvent": [
         "automations_changed",

--- a/app/test-harness/harnesses/AutomationYamlEditorHarness.tsx
+++ b/app/test-harness/harnesses/AutomationYamlEditorHarness.tsx
@@ -36,14 +36,17 @@ action:
 // can target one, same shape as LiveMarkdownEditorHarness's LONG fixture.
 const LONG = `id: long-automation\nname: Long automation\n# ${Array.from({ length: 80 }, (_, i) => `comment line number ${i + 1} of the long automation`).join('\n# ')}\n`;
 
-// Editing-harness controls the spec drives directly (kept off the typed
+// Editing-harness control the spec drives directly (kept off the typed
 // HarnessAPI, which is a fixed shape). applyExternal pushes content through
-// the scroll-preserving minimal-edit handle; swapValue replaces the
-// controlled `value` wholesale (the old full-document-replace path) so the
-// spec can contrast the two.
+// the minimal-edit handle — the same path AutomationEditor's Reload uses.
+//
+// LiveMarkdownEditorHarness also exposes a swapValue that replaces the
+// controlled `value` wholesale, so its spec can contrast the two scroll
+// outcomes. This harness deliberately does not: see the selection test in
+// automation-yaml-editor.spec.ts for why that contrast is not sound evidence
+// for this buffer.
 interface EditorHarnessControls {
   applyExternal: (next: string) => void;
-  swapValue: (next: string) => void;
 }
 declare global {
   interface Window {
@@ -68,7 +71,6 @@ export function AutomationYamlEditorHarness({ onReady, setTriggerRerender }: Har
     setTriggerRerender(() => force((n) => n + 1));
     window.__EDITOR_HARNESS__ = {
       applyExternal: (next: string) => editorRef.current?.applyExternalContent(next),
-      swapValue: (next: string) => setValue(next),
     };
     onReady();
   }, [onReady, setTriggerRerender]);

--- a/app/test-harness/harnesses/AutomationYamlEditorHarness.tsx
+++ b/app/test-harness/harnesses/AutomationYamlEditorHarness.tsx
@@ -1,0 +1,83 @@
+/**
+ * AutomationYamlEditor Test Harness
+ *
+ * Renders the CodeMirror-backed automation-definition YAML buffer in a real
+ * browser (CM can't mount under happy-dom), so its rendering, theming, and
+ * interactions can be exercised. Exposes window.__HARNESS__ controls: the
+ * current value is recorded on every change; applyExternal / swapValue mirror
+ * LiveMarkdownEditorHarness's contrast pair for the minimal-edit vs
+ * full-document-swap scroll behavior AutomationEditor's Reload relies on.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+// Pull in the app's design tokens so the transparent editor renders over the
+// real dark pane, matching the automation editor's actual host.
+import '../../src/App.css';
+import '../../src/components/automations/AutomationEditor.css';
+import {
+  AutomationYamlEditor,
+  type AutomationYamlEditorHandle,
+} from '../../src/components/automations/AutomationYamlEditor';
+import type { HarnessProps } from '../types';
+
+const SAMPLE = `id: pr-reviewer
+name: PR reviewer
+enabled: true
+trigger:
+  type: schedule
+  cron: "0 9 * * *"
+action:
+  type: agent
+  prompt: |
+    Review open PRs assigned to me and leave comments.
+`;
+
+// A document tall enough to scroll, so the scroll-preservation test has
+// somewhere to scroll to. Each line is uniquely numbered so an external edit
+// can target one, same shape as LiveMarkdownEditorHarness's LONG fixture.
+const LONG = `id: long-automation\nname: Long automation\n# ${Array.from({ length: 80 }, (_, i) => `comment line number ${i + 1} of the long automation`).join('\n# ')}\n`;
+
+// Editing-harness controls the spec drives directly (kept off the typed
+// HarnessAPI, which is a fixed shape). applyExternal pushes content through
+// the scroll-preserving minimal-edit handle; swapValue replaces the
+// controlled `value` wholesale (the old full-document-replace path) so the
+// spec can contrast the two.
+interface EditorHarnessControls {
+  applyExternal: (next: string) => void;
+  swapValue: (next: string) => void;
+}
+declare global {
+  interface Window {
+    __EDITOR_HARNESS__?: EditorHarnessControls;
+  }
+}
+
+export function AutomationYamlEditorHarness({ onReady, setTriggerRerender }: HarnessProps) {
+  const params = new URLSearchParams(window.location.search);
+  const initial = params.get('empty') === '1' ? '' : params.get('long') === '1' ? LONG : SAMPLE;
+  const [value, setValue] = useState(initial);
+  const [, force] = useState(0);
+  const editorRef = useRef<AutomationYamlEditorHandle>(null);
+
+  const handleChange = useCallback((next: string) => {
+    window.__HARNESS__.recordCall('change', [next]);
+    setValue(next);
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    setTriggerRerender(() => force((n) => n + 1));
+    window.__EDITOR_HARNESS__ = {
+      applyExternal: (next: string) => editorRef.current?.applyExternalContent(next),
+      swapValue: (next: string) => setValue(next),
+    };
+    onReady();
+  }, [onReady, setTriggerRerender]);
+
+  return (
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', padding: 24, background: 'var(--color-bg-app)' }}>
+      <div className="automation-editor__buffer">
+        <AutomationYamlEditor ref={editorRef} value={value} onChange={handleChange} ariaLabel="Automation definition" />
+      </div>
+    </div>
+  );
+}

--- a/app/test-harness/harnesses/index.ts
+++ b/app/test-harness/harnesses/index.ts
@@ -4,6 +4,7 @@
  * Register all component harnesses here for the test harness router.
  */
 import type { HarnessProps } from '../types';
+import { AutomationYamlEditorHarness } from './AutomationYamlEditorHarness';
 import { BrokenLinksHarness } from './BrokenLinksHarness';
 import { DashboardPRsHarness } from './DashboardPRsHarness';
 import { DiffViewHarness } from './DiffViewHarness';
@@ -17,6 +18,7 @@ import { NotebookTileHarness } from './NotebookTileHarness';
 import { PresentTourHarness } from './PresentTourHarness';
 
 export const harnesses: Record<string, React.ComponentType<HarnessProps>> = {
+  AutomationYamlEditor: AutomationYamlEditorHarness,
   BrokenLinks: BrokenLinksHarness,
   DashboardPRs: DashboardPRsHarness,
   DiffView: DiffViewHarness,

--- a/cmd/attn/automation.go
+++ b/cmd/attn/automation.go
@@ -11,7 +11,7 @@ import (
 )
 
 func automationUsage() {
-	fmt.Fprint(os.Stderr, "usage: attn automation <apply|list|show|run|runs|delete|cleanup>\n")
+	fmt.Fprint(os.Stderr, "usage: attn automation <apply|validate|list|show|run|runs|delete|cleanup>\n")
 }
 func runAutomationCommand() {
 	if len(os.Args) < 3 {
@@ -38,6 +38,25 @@ func runAutomationCommand() {
 			break
 		}
 		data, err = c.AutomationApply(string(raw))
+	case "validate":
+		fs := flag.NewFlagSet("automation validate", flag.ContinueOnError)
+		file := fs.String("file", "", "definition YAML")
+		if e := fs.Parse(os.Args[3:]); e != nil {
+			os.Exit(2)
+		}
+		if *file == "" {
+			err = fmt.Errorf("--file is required")
+			break
+		}
+		raw, e := os.ReadFile(*file)
+		if e != nil {
+			err = e
+			break
+		}
+		data, err = c.AutomationValidate(string(raw))
+		if err == nil && data == nil {
+			data, _ = json.Marshal(map[string]bool{"valid": true})
+		}
 	case "list":
 		data, err = c.AutomationList()
 	case "show":

--- a/docs/plans/2026-07-18-attn-automations-implementation.md
+++ b/docs/plans/2026-07-18-attn-automations-implementation.md
@@ -1057,7 +1057,39 @@ For every slice that touches daemon lifecycle, protocol, PTY, Git, or UI:
       or a thread as living forever; each is fixed with regression tests, and
       the shared-identity and thread-lifetime invariants are recorded above as
       domain context.
-- [ ] Add the self-service YAML editor and validate-without-apply (Slice 7 PR B).
+- [x] Add the self-service YAML editor and validate-without-apply (Slice 7 PR B).
+      One buffer serves create and edit: create loads through the same
+      `getDefinition('')` path and gets the starter template at revision 0, so
+      there is no second code path to keep in step (D7). Validate runs the full
+      definition check without writing anything, and Save is the only writer.
+      Three mistakes are refused rather than silently absorbed — changing the
+      `id` of the definition being edited (apply is keyed on the id inside the
+      YAML, so a rename is a separate create), creating an automation whose
+      `id` already belongs to a live definition (which would replace it
+      wholesale), and saving over a definition that changed elsewhere, which
+      offers Reload as the recovery path (D4/D5). The buffer is populated only
+      on mount or an explicit Reload, never by an `automations_changed`
+      broadcast, so a background refetch cannot stomp text being typed (D6).
+      Proven by the packaged scenario `real-app:scenario-automation-editor` —
+      run `automation-editor-2026-07-21T00-05-15-547Z`, all seven legs green
+      (starter template, invalid-rejected-and-nothing-stored, create,
+      create-collision refusal, comment round-trip, id-change refusal, and
+      stale-revision refusal followed by a successful Reload) against the app
+      built from `8c17eb2c` (2026-07-21), with the daemon's own state
+      cross-checked through the bundled CLI at every leg. D1 (comments survive)
+      is proven by the stored `SpecYAML` still carrying the run's
+      `# harness-marker:` line after the save/reload round-trip; definitions
+      created before migration 75 have no stored YAML and re-render comment-free
+      on first open, which the editor says in-line rather than hiding.
+      Reviewing the product code directly — not the subagent reports — found
+      three defects the tests had not caught: a Reload button offered while
+      creating (it would have re-fetched the starter template over the draft
+      being typed), validate running inline on the client read loop where
+      `git.ValidateLocalClone` stats paths and shells out to git twice per
+      override, and a create silently overwriting a live definition that shared
+      its id. Each is fixed with a regression test, and the collision guard was
+      mutation-verified: without it the create succeeds and bumps the victim to
+      revision 2.
 - [ ] Run the final upgrade, failure-recovery, and packaged-app matrix from the
       integration branch and open the single integration PR to `main`.
 

--- a/docs/plans/2026-07-18-attn-automations-implementation.md
+++ b/docs/plans/2026-07-18-attn-automations-implementation.md
@@ -1076,7 +1076,8 @@ For every slice that touches daemon lifecycle, protocol, PTY, Git, or UI:
       stale-revision refusal followed by a successful Reload, a comment-only
       edit bumping the revision, and a save refused after the definition was
       deleted elsewhere), with the daemon's own state cross-checked through the
-      bundled CLI at every leg; the run id and build head are recorded below.
+      bundled CLI at every leg — run `automation-editor-2026-07-21T00-46-50-361Z`
+      against the app built from `c5629930` (2026-07-21), all nine green.
       D1 (comments survive)
       is proven by the stored `SpecYAML` still carrying the run's
       `# harness-marker:` line after the save/reload round-trip; definitions

--- a/docs/plans/2026-07-18-attn-automations-implementation.md
+++ b/docs/plans/2026-07-18-attn-automations-implementation.md
@@ -1071,13 +1071,15 @@ For every slice that touches daemon lifecycle, protocol, PTY, Git, or UI:
       on mount or an explicit Reload, never by an `automations_changed`
       broadcast, so a background refetch cannot stomp text being typed (D6).
       Proven by the packaged scenario `real-app:scenario-automation-editor`,
-      nine legs (starter template, invalid-rejected-and-nothing-stored, create,
+      ten legs (starter template, invalid-rejected-and-nothing-stored, create,
       create-collision refusal, comment round-trip, id-change refusal,
       stale-revision refusal followed by a successful Reload, a comment-only
-      edit bumping the revision, and a save refused after the definition was
-      deleted elsewhere), with the daemon's own state cross-checked through the
-      bundled CLI at every leg — run `automation-editor-2026-07-21T00-46-50-361Z`
-      against the app built from `c5629930` (2026-07-21), all nine green.
+      edit bumping the revision, a save refused after the definition was
+      deleted elsewhere, and a panel toggle-off surviving a later edit), with
+      the daemon's own state cross-checked through the bundled CLI at every
+      leg — run `automation-editor-2026-07-21T01-31-48-079Z` against the app
+      built from `09cfb0b6` (2026-07-21, protocol 180, profile `togglefix`),
+      all ten green.
       D1 (comments survive)
       is proven by the stored `SpecYAML` still carrying the run's
       `# harness-marker:` line after the save/reload round-trip; definitions
@@ -1110,6 +1112,40 @@ For every slice that touches daemon lifecycle, protocol, PTY, Git, or UI:
       `attn automation validate` printed `null` on success because
       `json.Marshal` of a nil payload yields the literal `null`, which defeats
       `omitempty` and leaves the client decoding a non-nil four-byte `Data`.
+      Review then found a third instance of that same trusting-a-moving-value
+      mistake, and this one had two writers rather than one stale reader:
+      `enabled` was written both by the panel's toggle (the column alone) and
+      by a Save (from the YAML), with nothing keeping them in step. Disabling
+      an automation and then editing it — even only adding a comment — saved
+      the stale `enabled: true` back and re-ran the real enable transition,
+      reported as an ordinary successful save; for a cron trigger that meant
+      unattended sessions firing after the operator had turned them off. Line
+      501 of this guide already settles the authority question — `enabled` is
+      current management state, so the column is the single authority — which
+      ruled out a read-time overlay: that would leave the row permanently
+      inconsistent and oblige every future reader to remember to overlay.
+      `SetAutomationEnabled` now writes through on a real transition,
+      re-marshaling `spec_json` and rewriting `spec_yaml` byte-for-byte via
+      `automation.SetEnabledInYAML`, which locates the top-level `enabled`
+      scalar by its parsed yaml.v3 Line/Column and replaces only that token, so
+      comments, key order, and quoting survive — the guarantee D1 depends on.
+      It bumps `revision` for the same reason the two earlier instances did.
+      That bump was verified safe rather than assumed: occurrence keys are
+      time- and subject-based and never embed the revision, and
+      `Snapshot.DefinitionRevision` is run provenance only, so a bump can
+      neither re-fire nor duplicate a run. Covered at three levels, each
+      mutation-verified against a build with the write-through removed:
+      `TestSetAutomationEnabledWritesThroughToStoredSpec` (store),
+      `TestAutomationDefinitionGetWSAfterToggleShowsDisabledWithoutReenabling`
+      (the daemon's real WS handlers), and scenario leg 10 above, where the
+      leg's headline assertion — editing a disabled automation does not
+      silently re-enable it — was isolated and confirmed red under that build
+      (`automation-editor-2026-07-21T01-30-23-763Z`) rather than merely
+      failing at an earlier diagnostic. A toggle landing while the same
+      editor is open is deliberately not in the scenario: `AutomationsPanel`
+      renders the editor as a full replacement of the panel body, so the
+      toggle control is not in the DOM at all then, and there is no way to
+      drive that race through the real UI.
 - [ ] Run the final upgrade, failure-recovery, and packaged-app matrix from the
       integration branch and open the single integration PR to `main`.
 

--- a/docs/plans/2026-07-18-attn-automations-implementation.md
+++ b/docs/plans/2026-07-18-attn-automations-implementation.md
@@ -1070,13 +1070,14 @@ For every slice that touches daemon lifecycle, protocol, PTY, Git, or UI:
       offers Reload as the recovery path (D4/D5). The buffer is populated only
       on mount or an explicit Reload, never by an `automations_changed`
       broadcast, so a background refetch cannot stomp text being typed (D6).
-      Proven by the packaged scenario `real-app:scenario-automation-editor` —
-      run `automation-editor-2026-07-21T00-05-15-547Z`, all seven legs green
-      (starter template, invalid-rejected-and-nothing-stored, create,
-      create-collision refusal, comment round-trip, id-change refusal, and
-      stale-revision refusal followed by a successful Reload) against the app
-      built from `8c17eb2c` (2026-07-21), with the daemon's own state
-      cross-checked through the bundled CLI at every leg. D1 (comments survive)
+      Proven by the packaged scenario `real-app:scenario-automation-editor`,
+      nine legs (starter template, invalid-rejected-and-nothing-stored, create,
+      create-collision refusal, comment round-trip, id-change refusal,
+      stale-revision refusal followed by a successful Reload, a comment-only
+      edit bumping the revision, and a save refused after the definition was
+      deleted elsewhere), with the daemon's own state cross-checked through the
+      bundled CLI at every leg; the run id and build head are recorded below.
+      D1 (comments survive)
       is proven by the stored `SpecYAML` still carrying the run's
       `# harness-marker:` line after the save/reload round-trip; definitions
       created before migration 75 have no stored YAML and re-render comment-free
@@ -1087,9 +1088,27 @@ For every slice that touches daemon lifecycle, protocol, PTY, Git, or UI:
       being typed), validate running inline on the client read loop where
       `git.ValidateLocalClone` stats paths and shells out to git twice per
       override, and a create silently overwriting a live definition that shared
-      its id. Each is fixed with a regression test, and the collision guard was
-      mutation-verified: without it the create succeeds and bumps the victim to
-      revision 2.
+      its id. The Reload gate and the collision guard each carry a regression
+      test, and the collision guard was mutation-verified: without it the create
+      succeeds and bumps the victim to revision 2. The read-loop fix carries no
+      test — it moves a handler onto its own goroutine, and a test at that seam
+      would assert Go's scheduling rather than any behavior of ours.
+      An adversarial gate over six dimensions then found five further defects,
+      all fixed here with mutation-verified regression tests. Three were the
+      same mistake in different clothes — trusting a value that another writer
+      can move underneath you. The revision counter did not cover `spec_yaml`,
+      so a comment-only save bumped nothing and the stale-save guard was blind
+      to precisely the edits this editor exists to make. `DeleteAutomationDefinition`
+      likewise leaves `revision` untouched, so a stale editor's Save passed the
+      guard and silently resurrected a definition someone had deleted — live,
+      enabled, and for a cron trigger firing unattended sessions again, reported
+      to the user as a successful save. And a Validate response that arrived
+      after further typing overwrote the cleared state, rendering "Looks good."
+      against text the daemon never saw. The other two: edits typed during an
+      in-flight Save were discarded when the editor closed, and
+      `attn automation validate` printed `null` on success because
+      `json.Marshal` of a nil payload yields the literal `null`, which defeats
+      `omitempty` and leaves the client decoding a non-nil four-byte `Data`.
 - [ ] Run the final upgrade, failure-recovery, and packaged-app matrix from the
       integration branch and open the single integration PR to `main`.
 

--- a/internal/automation/automation.go
+++ b/internal/automation/automation.go
@@ -101,6 +101,45 @@ func ParseDefinitionYAML(data []byte) (DefinitionSpec, []byte, error) {
 	return spec, canonical, err
 }
 
+// MarshalDefinitionYAML renders spec back to valid, re-appliable YAML — every
+// field of DefinitionSpec and its nested structs already carries a `yaml:`
+// tag, so this is a direct yaml.v3 marshal. It is the fallback used to
+// reconstruct definition_yaml for rows written before migration 75 added
+// spec_yaml (empty spec_yaml column): the result loses whatever comments the
+// original author's YAML carried, but ParseDefinitionYAML(MarshalDefinitionYAML(spec))
+// round-trips to an equal spec, so it stays a legal input to
+// validateAutomationSpec / automationApply.
+func MarshalDefinitionYAML(spec DefinitionSpec) ([]byte, error) {
+	return yaml.Marshal(spec)
+}
+
+// StarterDefinition is the placeholder spec automation_definition_get returns
+// for id: "" (new-definition case). It is deliberately not a valid,
+// appliable definition as-is — Location.Path is a placeholder, not a real
+// directory, so it fails canonicalizeDirectory in ValidateDefinition until
+// the user edits it — but every field is filled in so the editor opens on a
+// complete, self-explanatory document rather than an empty buffer the user
+// has to build field-by-field from documentation.
+var StarterDefinition = DefinitionSpec{
+	APIVersion: APIVersion,
+	ID:         "my-automation",
+	Name:       "My automation",
+	Enabled:    true,
+	Trigger:    TriggerSpec{Type: "manual"},
+	Prompt:     "Describe what the agent should do when this automation runs.",
+	Launch:     LaunchSpec{Driver: "codex"},
+	Location:   LocationSpec{Type: "directory", Path: "/path/to/repository"},
+	Policy:     PolicySpec{Continuity: "fresh"},
+}
+
+// StarterTemplateYAML renders StarterDefinition through the same
+// MarshalDefinitionYAML path every legacy-row fallback uses, so the starter
+// template can never drift into a shape validateAutomationSpec would reject
+// for reasons other than the intentional placeholder path.
+func StarterTemplateYAML() ([]byte, error) {
+	return MarshalDefinitionYAML(StarterDefinition)
+}
+
 func ValidateDefinition(s *DefinitionSpec) error {
 	if s == nil {
 		return errors.New("definition is required")

--- a/internal/automation/automation_test.go
+++ b/internal/automation/automation_test.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestDefinitionPersistsCanonicalDirectory(t *testing.T) {
@@ -38,6 +41,70 @@ policy: {continuity: fresh}
 	}
 	if spec.Location.Path != resolved || strings.Contains(string(canonical), link) {
 		t.Fatalf("path=%q canonical=%s, want resolved %q", spec.Location.Path, canonical, resolved)
+	}
+}
+
+// TestMarshalDefinitionYAMLRoundTripsThroughParse pins
+// MarshalDefinitionYAML's contract as automationDefinitionYAML's legacy-row
+// fallback: rendering a parsed spec back to YAML and parsing that YAML again
+// must produce an equal spec, byte-identical canonical JSON, and (critically)
+// still pass ParseDefinitionYAML's validation — a legacy row's
+// reconstructed definition_yaml must stay a legal input to
+// validateAutomationSpec / automationApply, not just a legal-looking one.
+func TestMarshalDefinitionYAMLRoundTripsThroughParse(t *testing.T) {
+	raw := `api_version: attn.dev/automations/v1alpha1
+id: roundtrip
+name: Roundtrip
+enabled: true
+trigger: {type: manual}
+prompt: Do the thing.
+launch: {driver: codex, model: gpt-5, effort: high}
+location: {type: directory, path: "` + t.TempDir() + `"}
+policy: {continuity: fresh, overlap: coalesce}
+`
+	spec, canonical, err := ParseDefinitionYAML([]byte(raw))
+	if err != nil {
+		t.Fatalf("ParseDefinitionYAML() error = %v", err)
+	}
+
+	rendered, err := MarshalDefinitionYAML(spec)
+	if err != nil {
+		t.Fatalf("MarshalDefinitionYAML() error = %v", err)
+	}
+
+	roundTripped, roundTrippedCanonical, err := ParseDefinitionYAML(rendered)
+	if err != nil {
+		t.Fatalf("ParseDefinitionYAML(MarshalDefinitionYAML(spec)) error = %v, rendered:\n%s", err, rendered)
+	}
+	if !reflect.DeepEqual(roundTripped, spec) {
+		t.Fatalf("round-tripped spec = %#v, want %#v", roundTripped, spec)
+	}
+	if string(roundTrippedCanonical) != string(canonical) {
+		t.Fatalf("round-tripped canonical JSON = %s, want %s", roundTrippedCanonical, canonical)
+	}
+}
+
+// TestStarterTemplateYAMLIsWellFormedYAML pins automation_definition_get's
+// id: "" starter-template contract: the rendered document must at least be
+// syntactically parseable YAML matching StarterDefinition field-for-field
+// (via yaml.Unmarshal directly, not ParseDefinitionYAML/ValidateDefinition —
+// StarterDefinition's Location.Path is an intentional placeholder that does
+// not exist on disk, so it fails canonicalizeDirectory by design until the
+// user edits it).
+func TestStarterTemplateYAMLIsWellFormedYAML(t *testing.T) {
+	rendered, err := StarterTemplateYAML()
+	if err != nil {
+		t.Fatalf("StarterTemplateYAML() error = %v", err)
+	}
+	var got DefinitionSpec
+	if err := yaml.Unmarshal(rendered, &got); err != nil {
+		t.Fatalf("yaml.Unmarshal(StarterTemplateYAML()) error = %v, rendered:\n%s", err, rendered)
+	}
+	if !reflect.DeepEqual(got, StarterDefinition) {
+		t.Fatalf("starter template round-trip = %#v, want %#v", got, StarterDefinition)
+	}
+	if _, _, err := ParseDefinitionYAML(rendered); err == nil {
+		t.Fatalf("ParseDefinitionYAML(StarterTemplateYAML()) unexpectedly succeeded; the placeholder path should fail canonicalizeDirectory")
 	}
 }
 

--- a/internal/automation/enabled_yaml.go
+++ b/internal/automation/enabled_yaml.go
@@ -1,0 +1,180 @@
+package automation
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"unicode/utf8"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SetEnabledInYAML sets the top-level `enabled` key of a definition YAML
+// document to enabled, rewriting only the exact bytes of that one scalar
+// token and leaving every other byte — comments, key order, indentation,
+// quoting style, blank lines — untouched. A round-trip through
+// yaml.Marshal (as MarshalDefinitionYAML does) would lose the user's
+// original formatting entirely, which defeats this PR's headline feature:
+// hand-written comments must survive a toggle.
+//
+// It locates the `enabled` value using yaml.v3's parsed Line/Column (both
+// 1-based) rather than a text scan, so a nested `enabled:` under `launch:`
+// or `policy:`, or the word "enabled:" inside a comment or a quoted string,
+// can never be mistaken for the real key: those never appear as a key node
+// in the top-level mapping's own Content.
+//
+// If the document has no top-level `enabled` key, one is appended as a new
+// `enabled: <v>` line at the very end of the document (preceded by a
+// newline if the document doesn't already end in one) rather than inserted
+// among the existing keys — simpler than reconstructing a "right" position,
+// and just as valid: YAML block-mapping keys don't need to stay grouped.
+//
+// Returns an error if doc does not parse, or its top level is not a
+// mapping.
+func SetEnabledInYAML(doc []byte, enabled bool) ([]byte, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(doc, &root); err != nil {
+		return nil, fmt.Errorf("parse definition yaml: %w", err)
+	}
+	if len(root.Content) != 1 || root.Content[0].Kind != yaml.MappingNode {
+		return nil, errors.New("definition yaml must be a top-level mapping")
+	}
+	mapping := root.Content[0]
+	newValue := "false"
+	if enabled {
+		newValue = "true"
+	}
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		key := mapping.Content[i]
+		if key.Value != "enabled" {
+			continue
+		}
+		value := mapping.Content[i+1]
+		start, ok := scalarStartOffset(doc, value.Line, value.Column)
+		if !ok {
+			return nil, errors.New("locate enabled value in definition yaml")
+		}
+		end, err := scalarEndOffset(doc, start, value.Style)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]byte, 0, len(doc)-(end-start)+len(newValue))
+		out = append(out, doc[:start]...)
+		out = append(out, newValue...)
+		out = append(out, doc[end:]...)
+		return out, nil
+	}
+	out := make([]byte, 0, len(doc)+len(newValue)+len("enabled: \n")+1)
+	out = append(out, doc...)
+	if len(out) > 0 && out[len(out)-1] != '\n' {
+		out = append(out, '\n')
+	}
+	out = append(out, "enabled: "...)
+	out = append(out, newValue...)
+	out = append(out, '\n')
+	return out, nil
+}
+
+// scalarStartOffset converts a yaml.v3 1-based (line, column) position into
+// a byte offset into doc. Column advances by rune, not byte, matching how
+// yaml.v3's scanner counts columns — for the ASCII "enabled:" key this is
+// the same as a byte count, but staying rune-accurate keeps this correct
+// even when other lines in the document carry non-ASCII text (e.g. a
+// comment or prompt earlier in the file).
+func scalarStartOffset(doc []byte, line, column int) (int, bool) {
+	offset := 0
+	currentLine := 1
+	for currentLine < line {
+		idx := bytes.IndexByte(doc[offset:], '\n')
+		if idx < 0 {
+			return 0, false
+		}
+		offset += idx + 1
+		currentLine++
+	}
+	for i := 1; i < column; i++ {
+		r, size := utf8.DecodeRune(doc[offset:])
+		if size == 0 || (r == utf8.RuneError && size == 1) {
+			return 0, false
+		}
+		offset += size
+	}
+	return offset, true
+}
+
+// scalarEndOffset returns the byte offset just past the scalar token that
+// starts at start, given the style yaml.v3 recorded for it. Plain and
+// quoted styles are the only ones a hand-written boolean value realistically
+// uses; block styles (| or >) are rejected rather than mishandled.
+func scalarEndOffset(doc []byte, start int, style yaml.Style) (int, error) {
+	switch {
+	case style&yaml.DoubleQuotedStyle != 0:
+		return doubleQuotedEnd(doc, start)
+	case style&yaml.SingleQuotedStyle != 0:
+		return singleQuotedEnd(doc, start)
+	case style&(yaml.LiteralStyle|yaml.FoldedStyle) != 0:
+		return 0, errors.New("enabled value uses a block scalar style, which is not supported")
+	default:
+		return plainScalarEnd(doc, start), nil
+	}
+}
+
+// doubleQuotedEnd scans from the opening `"` at start to the byte after its
+// matching closing `"`, treating any backslash as escaping the next byte
+// (adequate for finding the terminator; it does not need to interpret the
+// escape).
+func doubleQuotedEnd(doc []byte, start int) (int, error) {
+	for i := start + 1; i < len(doc); i++ {
+		switch doc[i] {
+		case '\\':
+			i++
+		case '"':
+			return i + 1, nil
+		}
+	}
+	return 0, errors.New("unterminated double-quoted enabled value")
+}
+
+// singleQuotedEnd scans from the opening `'` at start to the byte after its
+// matching closing `'`, treating two consecutive single quotes as an
+// escaped literal quote rather than the terminator, per YAML single-quote
+// escaping.
+func singleQuotedEnd(doc []byte, start int) (int, error) {
+	for i := start + 1; i < len(doc); i++ {
+		if doc[i] != '\'' {
+			continue
+		}
+		if i+1 < len(doc) && doc[i+1] == '\'' {
+			i++
+			continue
+		}
+		return i + 1, nil
+	}
+	return 0, errors.New("unterminated single-quoted enabled value")
+}
+
+// plainScalarEnd returns the end of an unquoted scalar token starting at
+// start: the first line break, the first "<whitespace>#" comment marker, or
+// a flow terminator (',', ']', '}'), whichever comes first, with any
+// trailing spaces/tabs trimmed off.
+func plainScalarEnd(doc []byte, start int) int {
+	i := start
+	for i < len(doc) {
+		c := doc[i]
+		if c == '\n' {
+			break
+		}
+		if c == '#' && i > start && (doc[i-1] == ' ' || doc[i-1] == '\t') {
+			break
+		}
+		if c == ',' || c == ']' || c == '}' {
+			break
+		}
+		i++
+	}
+	end := i
+	for end > start && (doc[end-1] == ' ' || doc[end-1] == '\t') {
+		end--
+	}
+	return end
+}

--- a/internal/automation/enabled_yaml_test.go
+++ b/internal/automation/enabled_yaml_test.go
@@ -1,0 +1,162 @@
+package automation
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSetEnabledInYAMLFlipsTopLevelValue(t *testing.T) {
+	got, err := SetEnabledInYAML([]byte("enabled: true\nname: foo\n"), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "enabled: false\nname: foo\n" {
+		t.Fatalf("got %q", got)
+	}
+	got, err = SetEnabledInYAML(got, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "enabled: true\nname: foo\n" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSetEnabledInYAMLPreservesTrailingComment(t *testing.T) {
+	got, err := SetEnabledInYAML([]byte("enabled: true  # keep this\nname: foo\n"), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "enabled: false  # keep this\nname: foo\n" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSetEnabledInYAMLLeavesNestedEnabledAlone(t *testing.T) {
+	for _, doc := range []string{
+		"launch:\n  enabled: true\nenabled: true\nname: foo\n",
+		"policy:\n  enabled: true\nenabled: true\nname: foo\n",
+	} {
+		got, err := SetEnabledInYAML([]byte(doc), false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(got), "  enabled: true\n") {
+			t.Fatalf("nested enabled was rewritten: got %q from %q", got, doc)
+		}
+		if !strings.Contains(string(got), "\nenabled: false\n") {
+			t.Fatalf("top-level enabled was not rewritten: got %q from %q", got, doc)
+		}
+	}
+}
+
+func TestSetEnabledInYAMLLeavesEnabledInsideCommentOrStringAlone(t *testing.T) {
+	doc := "# note: enabled: true is the default\nname: \"enabled: true is mentioned here too\"\nenabled: true\n"
+	got, err := SetEnabledInYAML([]byte(doc), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "# note: enabled: true is the default\nname: \"enabled: true is mentioned here too\"\nenabled: false\n"
+	if string(got) != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestSetEnabledInYAMLInsertsMissingKey(t *testing.T) {
+	got, err := SetEnabledInYAML([]byte("name: foo\nprompt: do it\n"), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "name: foo\nprompt: do it\nenabled: true\n" {
+		t.Fatalf("got %q", got)
+	}
+
+	// No trailing newline on the original document: the inserted line must
+	// still land on its own line, not glued onto the prior one.
+	got, err = SetEnabledInYAML([]byte("name: foo"), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "name: foo\nenabled: false\n" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSetEnabledInYAMLPreservesHeadCommentsAndBlankLines(t *testing.T) {
+	doc := "# head comment\n\napi_version: attn.dev/automations/v1alpha1\n\nenabled: true\n\nname: foo\n"
+	got, err := SetEnabledInYAML([]byte(doc), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "# head comment\n\napi_version: attn.dev/automations/v1alpha1\n\nenabled: false\n\nname: foo\n"
+	if string(got) != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestSetEnabledInYAMLRejectsNonMapping(t *testing.T) {
+	for _, doc := range []string{
+		"not a mapping\n",
+		"- one\n- two\n",
+		"",
+		"enabled: [true\n",
+	} {
+		if _, err := SetEnabledInYAML([]byte(doc), true); err == nil {
+			t.Fatalf("expected an error for %q", doc)
+		}
+	}
+}
+
+// TestSetEnabledInYAMLOutputStillParsesAsADefinition is the property that
+// matters in production, as opposed to the byte-level assertions above: the
+// rewritten spec_yaml is what the editor loads and what Save re-parses, so a
+// rewrite that produced text ParseDefinitionYAML rejects would leave the
+// definition uneditable — reachable by nothing more than clicking the panel's
+// toggle. Pins that a toggle round-trip stays a legal definition, keeps every
+// other field, and lands the new enabled value in the canonical JSON too (not
+// just the YAML text, which is what the split brain this fixes looked like).
+func TestSetEnabledInYAMLOutputStillParsesAsADefinition(t *testing.T) {
+	dir := t.TempDir()
+	raw := strings.ReplaceAll(`# why this automation exists
+api_version: attn.dev/automations/v1alpha1
+id: round-trip
+name: Round trip
+enabled: true  # flipped by the panel toggle
+trigger: {type: manual}
+prompt: Inspect.
+launch: {driver: codex}
+location: {type: directory, path: PATH}
+policy: {continuity: fresh}
+`, `PATH`, dir)
+
+	disabled, err := SetEnabledInYAML([]byte(raw), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec, canonical, err := ParseDefinitionYAML(disabled)
+	if err != nil {
+		t.Fatalf("toggled-off yaml no longer parses as a definition: %v\n%s", err, disabled)
+	}
+	if spec.Enabled {
+		t.Fatalf("spec.Enabled = true after toggling off\n%s", disabled)
+	}
+	if !strings.Contains(string(canonical), `"enabled":false`) {
+		t.Fatalf("canonical json did not pick up the new value: %s", canonical)
+	}
+	if spec.ID != "round-trip" || spec.Name != "Round trip" || !strings.Contains(spec.Prompt, "Inspect.") {
+		t.Fatalf("unrelated fields moved: id=%q name=%q prompt=%q", spec.ID, spec.Name, spec.Prompt)
+	}
+	if !strings.Contains(string(disabled), "# why this automation exists") ||
+		!strings.Contains(string(disabled), "# flipped by the panel toggle") {
+		t.Fatalf("comments lost in the rewrite:\n%s", disabled)
+	}
+
+	// And back, so a disable/enable cycle is not one-way.
+	reEnabled, err := SetEnabledInYAML(disabled, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(reEnabled) != raw {
+		t.Fatalf("toggling off then on did not return the original document:\ngot  %q\nwant %q", reEnabled, raw)
+	}
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -58,6 +58,19 @@ func (c *Client) AutomationApply(raw string) (json.RawMessage, error) {
 	}
 	return r.Data, nil
 }
+
+// AutomationValidate runs the same validateAutomationSpec seam automation
+// apply persists through, without persisting anything — see
+// Daemon.validateAutomationSpec's doc comment for why the two share one
+// function. A non-nil error is the validation failure message itself, not a
+// transport error.
+func (c *Client) AutomationValidate(raw string) (json.RawMessage, error) {
+	r, e := c.sendAutomation(protocol.AutomationValidateMessage{Cmd: protocol.CmdAutomationValidate, DefinitionYaml: raw})
+	if e != nil {
+		return nil, e
+	}
+	return r.Data, nil
+}
 func (c *Client) AutomationList() (json.RawMessage, error) {
 	r, e := c.sendAutomation(protocol.AutomationListMessage{Cmd: protocol.CmdAutomationList})
 	if e != nil {

--- a/internal/daemon/automations.go
+++ b/internal/daemon/automations.go
@@ -67,32 +67,107 @@ func (d *Daemon) wsAutomationMutationTimeoutDuration() time.Duration {
 	return defaultWSAutomationMutationTimeout
 }
 
-func (d *Daemon) automationApply(raw string) (*store.AutomationDefinition, error) {
+// validateAutomationSpec is the single seam every surface that judges
+// automation definition YAML must call: automation_validate (validate-only,
+// nothing persisted) and automationApply (validate-then-persist) both run
+// through this, so a YAML document that validate accepts is guaranteed to be
+// one apply also accepts — the two cannot drift apart by one of them
+// forgetting a check. It runs ParseDefinitionYAML's schema validation plus
+// every check automationApply used to run inline: the delegation agent must
+// resolve, --model/--effort must be supported by it, the driver must be one
+// of the automations subset that supports unattended automatic approval
+// (codex|claude), and every repository_sources override must be a valid,
+// reachable local clone.
+func (d *Daemon) validateAutomationSpec(raw string) (automation.DefinitionSpec, []byte, error) {
 	spec, canonical, err := automation.ParseDefinitionYAML([]byte(raw))
 	if err != nil {
-		return nil, err
+		return spec, nil, err
 	}
 	if _, err := d.resolveDelegationAgent("", protocol.Ptr(spec.Launch.Driver)); err != nil {
-		return nil, err
+		return spec, nil, err
 	}
 	if err := d.validateDelegationModelEffort(spec.Launch.Driver, spec.Launch.Model, spec.Launch.Effort); err != nil {
-		return nil, err
+		return spec, nil, err
 	}
 	if spec.Launch.Driver != "codex" && spec.Launch.Driver != "claude" {
-		return nil, fmt.Errorf("agent %q does not support automation automatic approval", spec.Launch.Driver)
+		return spec, nil, fmt.Errorf("agent %q does not support automation automatic approval", spec.Launch.Driver)
 	}
 	for identity, source := range spec.Location.RepositorySources.Overrides {
 		if _, err := attngit.ValidateLocalClone(source.Path, identity); err != nil {
-			return nil, fmt.Errorf("repository override %s: %w", identity, err)
+			return spec, nil, fmt.Errorf("repository override %s: %w", identity, err)
 		}
 	}
+	return spec, canonical, nil
+}
+
+// automationApply applies definition YAML unconditionally: parse, validate,
+// upsert. This is the unix-socket/CLI/agent surface (attn automation apply)
+// — "last writer wins," unguarded, exactly as before this PR. The WS
+// editor's Save goes through automationApplyWithGuards instead.
+func (d *Daemon) automationApply(raw string) (*store.AutomationDefinition, error) {
+	spec, canonical, err := d.validateAutomationSpec(raw)
+	if err != nil {
+		return nil, err
+	}
+	return d.automationApplyLocked(context.Background(), raw, spec, canonical, nil)
+}
+
+// automationApplyWithGuards is automationApply's WS counterpart, used by the
+// app editor's Save. expectedID and expectedRevision implement D4/D5 from
+// the design: apply is an upsert keyed on the id *inside* the YAML, so an
+// edited id would silently fork the definition and leave the original
+// enabled and running (D4) — expectedID ("" when creating) refuses a
+// mismatch. And a stale expectedRevision (0 when creating) would silently
+// clobber a concurrent apply from the CLI or another app window (D5) — the
+// caller sees "changed elsewhere — reload" instead. Both guards run inside
+// automationApplyLocked's automationMu, atomically with the pre-upsert
+// existing-row read they depend on, so there is no window between the check
+// and the write where a concurrent apply could slip through.
+func (d *Daemon) automationApplyWithGuards(ctx context.Context, raw, expectedID string, expectedRevision int) (*store.AutomationDefinition, error) {
+	spec, canonical, err := d.validateAutomationSpec(raw)
+	if err != nil {
+		return nil, err
+	}
+	if expectedID != "" && spec.ID != expectedID {
+		return nil, fmt.Errorf("definition id %q in the YAML does not match the definition being edited (%q) — apply is keyed on the id inside the YAML, so an id change must be made as a separate create", spec.ID, expectedID)
+	}
+	guard := func(existing *store.AutomationDefinition) error {
+		if expectedRevision == 0 {
+			return nil
+		}
+		if existing == nil || existing.Revision != expectedRevision {
+			return errors.New("automation definition changed elsewhere — reload before saving")
+		}
+		return nil
+	}
+	return d.automationApplyLocked(ctx, raw, spec, canonical, guard)
+}
+
+// automationApplyLocked is the locked validate-then-persist step shared by
+// automationApply and automationApplyWithGuards. ctx bounds how long the
+// caller is willing to wait to acquire automationMu (mirroring
+// automationSetEnabled/automationDelete's contract): once locked, ctx.Err()
+// is checked before any store mutation, so a caller whose deadline already
+// passed aborts without writing anything. guard (nil for the unconditional
+// socket/CLI path) runs after the pre-upsert existing-row read but still
+// inside automationMu, so a WS caller's expected_id/expected_revision check
+// is atomic with the write it gates.
+func (d *Daemon) automationApplyLocked(ctx context.Context, raw string, spec automation.DefinitionSpec, canonical []byte, guard func(*store.AutomationDefinition) error) (*store.AutomationDefinition, error) {
 	d.automationMu.Lock()
 	defer d.automationMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("deadline exceeded waiting for an in-flight automation delivery: %w", err)
+	}
 	existing, err := d.store.GetAutomationDefinitionIncludingDeleted(spec.ID)
 	if err != nil {
 		return nil, err
 	}
-	definition, err := d.store.UpsertAutomationDefinition(spec.ID, spec.Name, string(canonical), spec.Enabled, time.Now())
+	if guard != nil {
+		if err := guard(existing); err != nil {
+			return nil, err
+		}
+	}
+	definition, err := d.store.UpsertAutomationDefinition(spec.ID, spec.Name, string(canonical), raw, spec.Enabled, time.Now())
 	if err != nil {
 		return definition, err
 	}
@@ -1431,6 +1506,9 @@ func (d *Daemon) handleAutomationCommand(conn net.Conn, cmd string, msg any) {
 	case protocol.CmdAutomationApply:
 		m := msg.(*protocol.AutomationApplyMessage)
 		data, err = d.automationApply(m.DefinitionYaml)
+	case protocol.CmdAutomationValidate:
+		m := msg.(*protocol.AutomationValidateMessage)
+		_, _, err = d.validateAutomationSpec(m.DefinitionYaml)
 	case protocol.CmdAutomationList:
 		data, err = d.store.ListAutomationDefinitions()
 	case protocol.CmdAutomationShow:

--- a/internal/daemon/automations.go
+++ b/internal/daemon/automations.go
@@ -156,6 +156,18 @@ func (d *Daemon) automationApplyWithGuards(ctx context.Context, raw, expectedID 
 		if existing == nil || existing.Revision != expectedRevision {
 			return errors.New("automation definition changed elsewhere — reload before saving")
 		}
+		if existing.DeletedAt != nil {
+			// DeleteAutomationDefinition sets deleted_at without touching
+			// revision, so a stale editor's expectedRevision can still match a
+			// row that was soft-deleted out from under it. Unlike the create
+			// path above, an edit must never resurrect: automationDelete already
+			// failed this definition's pending runs, fenced its provider
+			// cursors, and purged its continuity bindings and review-request
+			// edges on the assumption it is gone, so a Save silently bringing it
+			// back live would restart an unattended cron the user deliberately
+			// deleted, with "saved successfully" as the only feedback.
+			return fmt.Errorf("automation %q was deleted elsewhere while you were editing it — your changes were not saved; close this editor and use New if you want to bring it back", spec.ID)
+		}
 		return nil
 	}
 	return d.automationApplyLocked(ctx, raw, spec, canonical, guard)
@@ -1560,7 +1572,15 @@ func (d *Daemon) handleAutomationCommand(conn net.Conn, cmd string, msg any) {
 	result := automationActionResult{Event: protocol.EventAutomationActionResult, Action: cmd, Success: err == nil}
 	if err != nil {
 		result.Error = protocol.Ptr(err.Error())
-	} else {
+	} else if data != nil {
+		// Guarded on nil rather than marshalling unconditionally: an action with
+		// no payload (validate) leaves data as a nil `any`, and json.Marshal of
+		// that yields the 4-byte literal `null`, not an empty slice — so
+		// `json:"data,omitempty"` would not drop the field and the wire would
+		// carry "data":null. json.RawMessage implements Unmarshaler and is
+		// invoked even for JSON null, so the client would decode a non-nil
+		// 4-byte Data and every "did I get a payload?" check downstream would
+		// answer yes. Leaving Data nil here is what lets omitempty do its job.
 		result.Data, _ = json.Marshal(data)
 	}
 	_ = json.NewEncoder(conn).Encode(result)

--- a/internal/daemon/automations.go
+++ b/internal/daemon/automations.go
@@ -133,6 +133,24 @@ func (d *Daemon) automationApplyWithGuards(ctx context.Context, raw, expectedID 
 	}
 	guard := func(existing *store.AutomationDefinition) error {
 		if expectedRevision == 0 {
+			// Create. Revisions start at 1 (see UpsertAutomationDefinition), so
+			// this is unambiguous — it is never an edit of a revision-0 row.
+			//
+			// Apply is keyed on the id inside the YAML, so a create whose id
+			// happens to match a live definition would UPDATE that definition
+			// in place: the user typing an id that already exists would replace
+			// someone else's automation wholesale, from a form that said
+			// "New automation" and never mentioned it. Refuse instead. The
+			// socket/CLI path keeps its unconditional last-writer-wins
+			// semantics — it passes no guard at all.
+			//
+			// A soft-deleted row is deliberately NOT a collision: re-applying a
+			// deleted definition's id is how resurrect works, and the editor's
+			// list only shows live definitions, so the user cannot be
+			// overwriting anything they can see.
+			if existing != nil && existing.DeletedAt == nil {
+				return fmt.Errorf("an automation with id %q already exists — edit it instead of creating a second one", spec.ID)
+			}
 			return nil
 		}
 		if existing == nil || existing.Revision != expectedRevision {

--- a/internal/daemon/automations_schedule_test.go
+++ b/internal/daemon/automations_schedule_test.go
@@ -43,7 +43,7 @@ func setupScheduledDaemon(t *testing.T, cron, continuity, catchUp string) (*Daem
 		t.Fatalf("parse definition: %v", err)
 	}
 	s := store.New()
-	def, err := s.UpsertAutomationDefinition(spec.ID, spec.Name, string(canonical), true, time.Now())
+	def, err := s.UpsertAutomationDefinition(spec.ID, spec.Name, string(canonical), "", true, time.Now())
 	if err != nil {
 		t.Fatalf("upsert definition: %v", err)
 	}
@@ -278,7 +278,7 @@ func TestObserveDueScheduleClaimRejectionLeavesCursorForRetry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.UpsertAutomationDefinition(editedSpec.ID, editedSpec.Name, string(editedCanonical), true, now0); err != nil {
+	if _, err := s.UpsertAutomationDefinition(editedSpec.ID, editedSpec.Name, string(editedCanonical), "", true, now0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -357,7 +357,7 @@ func TestObserveDueScheduleClaimRejectionRetryFiresNewestDueInstant(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.UpsertAutomationDefinition(editedSpec.ID, editedSpec.Name, string(editedCanonical), true, now0); err != nil {
+	if _, err := s.UpsertAutomationDefinition(editedSpec.ID, editedSpec.Name, string(editedCanonical), "", true, now0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -469,7 +469,7 @@ func TestScheduledPendingRunRecoversOnRestart(t *testing.T) {
 	d, s, def, _ := setupScheduledDaemon(t, "* * * * *", "fresh", "latest")
 	intended := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
 	run := claimPendingScheduledRun(t, s, def, intended, intended.Add(time.Second))
-	if _, err := s.UpsertAutomationDefinition(def.ID, def.Name, def.SpecJSON, false, intended.Add(time.Minute)); err != nil {
+	if _, err := s.UpsertAutomationDefinition(def.ID, def.Name, def.SpecJSON, "", false, intended.Add(time.Minute)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -516,7 +516,7 @@ func TestScheduledPendingRunDeliversImmutableSnapshotAfterDefinitionEdit(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.UpsertAutomationDefinition(editedSpec.ID, editedSpec.Name, string(editedCanonical), true, intended.Add(time.Minute)); err != nil {
+	if _, err := s.UpsertAutomationDefinition(editedSpec.ID, editedSpec.Name, string(editedCanonical), "", true, intended.Add(time.Minute)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -540,7 +540,7 @@ func TestScheduledPendingRunDeliversImmutableSnapshotAfterDefinitionEdit(t *test
 
 func TestObserveDueSchedulesSkipsDisabledDefinition(t *testing.T) {
 	d, s, def, _ := setupScheduledDaemon(t, "* * * * *", "fresh", "latest")
-	if _, err := s.UpsertAutomationDefinition(def.ID, def.Name, def.SpecJSON, false, time.Now()); err != nil {
+	if _, err := s.UpsertAutomationDefinition(def.ID, def.Name, def.SpecJSON, "", false, time.Now()); err != nil {
 		t.Fatal(err)
 	}
 	delivered := 0
@@ -585,7 +585,7 @@ func TestObserveDueSchedulesFreshContinuityCreatesDistinctRuns(t *testing.T) {
 func TestScheduledSingletonContinuationSkipsPullRequestParsing(t *testing.T) {
 	s := store.New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{}`, true, now)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -653,7 +653,7 @@ func TestScheduledSingletonContinuationSkipsPullRequestParsing(t *testing.T) {
 func TestScheduledSingletonFreshRunAfterTicketSweepGetsItsOwnTicket(t *testing.T) {
 	s := store.New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{}`, true, now)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/daemon/automations_test.go
+++ b/internal/daemon/automations_test.go
@@ -311,7 +311,7 @@ func TestEnsureAutomationSessionPassesOneUnattendedContract(t *testing.T) {
 func TestFailAutomationRunFailsRunAndVisibleTicket(t *testing.T) {
 	s := store.New()
 	now := time.Now()
-	def, err := s.UpsertAutomationDefinition("daily-check", "Daily check", `{"id":"daily-check"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("daily-check", "Daily check", `{"id":"daily-check"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,7 +357,7 @@ func TestFailAutomationRunFailsRunAndVisibleTicket(t *testing.T) {
 func TestRetryableAutomationDeliveryKeepsRunAndTicketActive(t *testing.T) {
 	s := store.New()
 	now := time.Now()
-	def, err := s.UpsertAutomationDefinition("daily-check", "Daily check", `{"id":"daily-check"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("daily-check", "Daily check", `{"id":"daily-check"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -391,7 +391,7 @@ func TestRetryableAutomationDeliveryKeepsRunAndTicketActive(t *testing.T) {
 func TestDisabledAutomationRefusesRecoveredPendingDelivery(t *testing.T) {
 	s := store.New()
 	now := time.Now()
-	def, err := s.UpsertAutomationDefinition("daily-check", "Daily check", `{"id":"daily-check"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("daily-check", "Daily check", `{"id":"daily-check"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,7 +401,7 @@ func TestDisabledAutomationRefusesRecoveredPendingDelivery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.UpsertAutomationDefinition(def.ID, def.Name, def.SpecJSON, false, now.Add(time.Minute)); err != nil {
+	if _, err := s.UpsertAutomationDefinition(def.ID, def.Name, def.SpecJSON, "", false, now.Add(time.Minute)); err != nil {
 		t.Fatal(err)
 	}
 	d := &Daemon{store: s, wsHub: newWSHub()}
@@ -469,7 +469,7 @@ func TestAutomationRecoveryWaitsForInitialGitHubDiscovery(t *testing.T) {
 func TestAutomationRecoveryLeavesGitHubRunsForFreshProviderObservation(t *testing.T) {
 	s := store.New()
 	now := time.Date(2026, 7, 19, 18, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -534,7 +534,7 @@ policy: {continuity: per_subject, catch_up: latest, overlap: coalesce}
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.UpsertAutomationDefinition("requested-review", "Requested review", string(canonical), true, time.Now()); err != nil {
+	if _, err := s.UpsertAutomationDefinition("requested-review", "Requested review", string(canonical), "", true, time.Now()); err != nil {
 		t.Fatal(err)
 	}
 	var delivered atomic.Int32
@@ -620,7 +620,7 @@ policy: {continuity: per_subject, catch_up: latest, overlap: coalesce}
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.UpsertAutomationDefinition(spec.ID, spec.Name, string(canonical), true, time.Now()); err != nil {
+	if _, err := s.UpsertAutomationDefinition(spec.ID, spec.Name, string(canonical), "", true, time.Now()); err != nil {
 		t.Fatal(err)
 	}
 	delivered := make(chan struct{}, 1)
@@ -672,7 +672,7 @@ policy: {continuity: per_subject, catch_up: latest, overlap: coalesce}
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.UpsertAutomationDefinition("retry-review", "Retry review", string(canonical), true, time.Now()); err != nil {
+	if _, err := s.UpsertAutomationDefinition("retry-review", "Retry review", string(canonical), "", true, time.Now()); err != nil {
 		t.Fatal(err)
 	}
 	var attempts atomic.Int32
@@ -714,7 +714,7 @@ policy: {continuity: per_subject, catch_up: latest, overlap: coalesce}
 func TestContinuationFailurePreservesOriginTicketOutcome(t *testing.T) {
 	s := store.New()
 	now := time.Date(2026, 7, 19, 18, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -761,7 +761,7 @@ func TestContinuationFailurePreservesOriginTicketOutcome(t *testing.T) {
 func TestSuccessfulContinuationReopensOriginTicketAfterDelivery(t *testing.T) {
 	s := store.New()
 	now := time.Date(2026, 7, 19, 18, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -841,7 +841,7 @@ func TestContinuationActivationFailsIfTicketDisappeared(t *testing.T) {
 func TestFreshThreadAfterTicketSweepGetsItsOwnTicketNotTheOldOne(t *testing.T) {
 	s := store.New()
 	now := time.Date(2026, 7, 19, 18, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -891,7 +891,7 @@ func TestFreshThreadAfterTicketSweepGetsItsOwnTicketNotTheOldOne(t *testing.T) {
 func TestChangedHeadContinuationFailsBeforePublishingTicketActivity(t *testing.T) {
 	s := store.New()
 	now := time.Date(2026, 7, 19, 18, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -946,7 +946,7 @@ func TestStoppedContinuationResumesRecordedReviewerWithPinnedContract(t *testing
 	backend := &automationResumeBackend{fakeSpawnBackend: &fakeSpawnBackend{}}
 	d.ptyBackend = backend
 	now := time.Date(2026, 7, 20, 8, 0, 0, 0, time.UTC)
-	def, err := d.store.UpsertAutomationDefinition("review", "Review", `{}`, true, now)
+	def, err := d.store.UpsertAutomationDefinition("review", "Review", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1053,7 +1053,7 @@ func setupContinuationWorktree(t *testing.T) (*Daemon, automation.WorkRequest, s
 	d := newDaemonForTest(t)
 	d.dataRoot = filepath.Join(root, "profile")
 	now := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
-	def, err := d.store.UpsertAutomationDefinition("review", "Review", `{}`, true, now)
+	def, err := d.store.UpsertAutomationDefinition("review", "Review", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1137,7 +1137,7 @@ func TestWithdrawnBeforeLaunchReRequestCreatesFirstWorktree(t *testing.T) {
 func TestReRequestCanStartReviewerWhenWithdrawnOriginNeverLaunched(t *testing.T) {
 	s := store.New()
 	now := time.Date(2026, 7, 19, 18, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1181,7 +1181,7 @@ func TestReviewRequestWithdrawalStopsLaunchedPendingReviewer(t *testing.T) {
 	d := newDaemonForTest(t)
 	s := d.store
 	now := time.Date(2026, 7, 19, 18, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1240,7 +1240,7 @@ func TestReviewRequestWithdrawalLeavesDeliveredReviewerToTicketLifecycle(t *test
 	d := newDaemonForTest(t)
 	s := d.store
 	now := time.Date(2026, 7, 19, 18, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1286,7 +1286,7 @@ func TestReviewRequestCancellationRecoversBeforeReactivation(t *testing.T) {
 	d := newDaemonForTest(t)
 	s := d.store
 	now := time.Date(2026, 7, 19, 18, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1337,7 +1337,7 @@ func TestContinuationWithdrawalDoesNotCancelDeliveredOriginReviewer(t *testing.T
 	d := newDaemonForTest(t)
 	s := d.store
 	now := time.Date(2026, 7, 19, 18, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2124,7 +2124,7 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleRegister(conn, msg.(*protocol.RegisterMessage))
 	case protocol.CmdDelegate:
 		d.handleDelegate(conn, msg.(*protocol.DelegateMessage))
-	case protocol.CmdAutomationApply, protocol.CmdAutomationList, protocol.CmdAutomationShow, protocol.CmdAutomationRun, protocol.CmdAutomationRunList, protocol.CmdAutomationDelete, protocol.CmdAutomationCleanup:
+	case protocol.CmdAutomationApply, protocol.CmdAutomationValidate, protocol.CmdAutomationList, protocol.CmdAutomationShow, protocol.CmdAutomationRun, protocol.CmdAutomationRunList, protocol.CmdAutomationDelete, protocol.CmdAutomationCleanup:
 		d.handleAutomationCommand(conn, cmd, msg)
 	case protocol.CmdDelegateStatus:
 		d.handleDelegateStatus(conn, msg.(*protocol.DelegateStatusMessage))

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -1077,10 +1077,16 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleWorkflowRunCancelWS(client, msg.(*protocol.WorkflowRunCancelMessage))
 	case protocol.CmdAutomationDefinitionsGet:
 		d.handleAutomationDefinitionsGetWS(client, msg.(*protocol.AutomationDefinitionsGetMessage))
+	case protocol.CmdAutomationDefinitionGet:
+		d.handleAutomationDefinitionGetWS(client, msg.(*protocol.AutomationDefinitionGetMessage))
 	case protocol.CmdAutomationRunsGet:
 		d.handleAutomationRunsGetWS(client, msg.(*protocol.AutomationRunsGetMessage))
 	case protocol.CmdAutomationSetEnabled:
 		d.handleAutomationSetEnabledWS(client, msg.(*protocol.AutomationSetEnabledMessage))
+	case protocol.CmdAutomationApply:
+		d.handleAutomationApplyWS(client, msg.(*protocol.AutomationApplyMessage))
+	case protocol.CmdAutomationValidate:
+		d.handleAutomationValidateWS(client, msg.(*protocol.AutomationValidateMessage))
 	case protocol.CmdAutomationDelete:
 		d.handleAutomationDeleteWS(client, msg.(*protocol.AutomationDeleteMessage))
 	case protocol.CmdAutomationCleanup:

--- a/internal/daemon/ws_automations.go
+++ b/internal/daemon/ws_automations.go
@@ -236,22 +236,31 @@ func (d *Daemon) handleAutomationApplyWS(client *wsClient, msg *protocol.Automat
 
 // handleAutomationValidateWS is the WS counterpart of the unix-socket
 // CmdAutomationValidate path: validate-without-apply, so the editor can show
-// an error before Save. It runs synchronously (no goroutine, no
-// automationMu): validateAutomationSpec never mutates the store, so it
-// cannot contend with an in-flight apply/delete/set_enabled the way the
-// mutation handlers above can.
+// an error before Save.
+//
+// It takes no automationMu: validateAutomationSpec never mutates the store,
+// so it cannot contend with an in-flight apply/delete/set_enabled the way the
+// mutation handlers above can. It does still run on its own goroutine,
+// because "does not touch the store" is not the same as "is fast": each
+// location override is checked with git.ValidateLocalClone, which stats the
+// path and shells out to git twice. The dispatcher calls handlers inline on
+// the client's read loop, so validating synchronously would stall every other
+// message from that client behind those subprocesses — and a path on an
+// unresponsive mount would stall them indefinitely.
 func (d *Daemon) handleAutomationValidateWS(client *wsClient, msg *protocol.AutomationValidateMessage) {
-	_, _, err := d.validateAutomationSpec(msg.DefinitionYaml)
-	result := protocol.AutomationActionResultMessage{
-		Event:     protocol.EventAutomationActionResult,
-		Action:    "validate",
-		RequestID: msg.RequestID,
-		Success:   err == nil,
-	}
-	if err != nil {
-		result.Error = protocol.Ptr(err.Error())
-	}
-	d.sendToClient(client, result)
+	go func() {
+		_, _, err := d.validateAutomationSpec(msg.DefinitionYaml)
+		result := protocol.AutomationActionResultMessage{
+			Event:     protocol.EventAutomationActionResult,
+			Action:    "validate",
+			RequestID: msg.RequestID,
+			Success:   err == nil,
+		}
+		if err != nil {
+			result.Error = protocol.Ptr(err.Error())
+		}
+		d.sendToClient(client, result)
+	}()
 }
 
 // handleAutomationDefinitionGetWS backs the editor's load path: definition_id

--- a/internal/daemon/ws_automations.go
+++ b/internal/daemon/ws_automations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/victorarias/attn/internal/automation"
@@ -200,6 +201,124 @@ func (d *Daemon) handleAutomationRunWS(client *wsClient, msg *protocol.Automatio
 		}
 		d.sendToClient(client, result)
 	}()
+}
+
+// handleAutomationApplyWS is the WS counterpart of the unix-socket
+// CmdAutomationApply path, used by the app editor's Save. Unlike the socket
+// path's automationApply (last-writer-wins), this goes through
+// automationApplyWithGuards so expected_id/expected_revision (D4/D5 in the
+// design) can refuse an id change or a stale save — see that function's doc
+// comment for why both checks are safe against a concurrent apply. On
+// success the result carries the saved definition's summary (including its
+// new revision) so the editor can update its expected_revision for the next
+// save without a round trip through automation_definitions_get.
+func (d *Daemon) handleAutomationApplyWS(client *wsClient, msg *protocol.AutomationApplyMessage) {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), d.wsAutomationMutationTimeoutDuration())
+		defer cancel()
+		definition, err := d.automationApplyWithGuards(ctx, msg.DefinitionYaml, protocol.Deref(msg.ExpectedID), int(protocol.Deref(msg.ExpectedRevision)))
+		result := protocol.AutomationActionResultMessage{
+			Event:     protocol.EventAutomationActionResult,
+			Action:    "apply",
+			RequestID: msg.RequestID,
+			Success:   err == nil,
+		}
+		if err != nil {
+			result.Error = protocol.Ptr(err.Error())
+		} else {
+			result.Definitions = []protocol.AutomationDefinitionSummary{d.buildAutomationDefinitionSummary(*definition)}
+			result.SpecYaml = protocol.Ptr(msg.DefinitionYaml)
+			result.Revision = protocol.Ptr(definition.Revision)
+		}
+		d.sendToClient(client, result)
+	}()
+}
+
+// handleAutomationValidateWS is the WS counterpart of the unix-socket
+// CmdAutomationValidate path: validate-without-apply, so the editor can show
+// an error before Save. It runs synchronously (no goroutine, no
+// automationMu): validateAutomationSpec never mutates the store, so it
+// cannot contend with an in-flight apply/delete/set_enabled the way the
+// mutation handlers above can.
+func (d *Daemon) handleAutomationValidateWS(client *wsClient, msg *protocol.AutomationValidateMessage) {
+	_, _, err := d.validateAutomationSpec(msg.DefinitionYaml)
+	result := protocol.AutomationActionResultMessage{
+		Event:     protocol.EventAutomationActionResult,
+		Action:    "validate",
+		RequestID: msg.RequestID,
+		Success:   err == nil,
+	}
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+	}
+	d.sendToClient(client, result)
+}
+
+// handleAutomationDefinitionGetWS backs the editor's load path: definition_id
+// "" returns the starter template at revision 0 (new-definition case, D7 in
+// the design), so create and edit share one frontend code path. A non-empty
+// id resolves definition_yaml via automationDefinitionYAML's legacy-row
+// fallback and returns the stored revision, for the editor to echo back as
+// expected_revision on save.
+func (d *Daemon) handleAutomationDefinitionGetWS(client *wsClient, msg *protocol.AutomationDefinitionGetMessage) {
+	result := protocol.AutomationActionResultMessage{
+		Event:     protocol.EventAutomationActionResult,
+		Action:    "definition_get",
+		RequestID: msg.RequestID,
+	}
+	if msg.DefinitionID == "" {
+		template, err := automation.StarterTemplateYAML()
+		if err != nil {
+			result.Error = protocol.Ptr(err.Error())
+			d.sendToClient(client, result)
+			return
+		}
+		result.Success = true
+		result.SpecYaml = protocol.Ptr(string(template))
+		result.Revision = protocol.Ptr(0)
+		d.sendToClient(client, result)
+		return
+	}
+	definition, err := d.store.GetAutomationDefinition(msg.DefinitionID)
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		d.sendToClient(client, result)
+		return
+	}
+	if definition == nil {
+		result.Error = protocol.Ptr("automation definition not found")
+		d.sendToClient(client, result)
+		return
+	}
+	specYAML, err := automationDefinitionYAML(*definition)
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		d.sendToClient(client, result)
+		return
+	}
+	result.Success = true
+	result.SpecYaml = protocol.Ptr(specYAML)
+	result.Revision = protocol.Ptr(definition.Revision)
+	d.sendToClient(client, result)
+}
+
+// automationDefinitionYAML resolves def's definition_yaml: the stored
+// spec_yaml when present, else automation.MarshalDefinitionYAML rendered
+// from spec_json for a row written before migration 75 added spec_yaml (see
+// MarshalDefinitionYAML's doc comment).
+func automationDefinitionYAML(def store.AutomationDefinition) (string, error) {
+	if def.SpecYAML != "" {
+		return def.SpecYAML, nil
+	}
+	var spec automation.DefinitionSpec
+	if err := json.Unmarshal([]byte(def.SpecJSON), &spec); err != nil {
+		return "", fmt.Errorf("parse stored definition %s: %w", def.ID, err)
+	}
+	rendered, err := automation.MarshalDefinitionYAML(spec)
+	if err != nil {
+		return "", fmt.Errorf("render definition %s: %w", def.ID, err)
+	}
+	return string(rendered), nil
 }
 
 // buildAutomationDefinitionSummary extracts the compact WS fields from a

--- a/internal/daemon/ws_automations_test.go
+++ b/internal/daemon/ws_automations_test.go
@@ -407,6 +407,299 @@ func TestAutomationRunWSRoutesPRURL(t *testing.T) {
 	}
 }
 
+// TestAutomationValidateAndApplyAgreeOnCorpus is the regression test for D3
+// (internal/daemon/automations.go's validateAutomationSpec doc comment): a
+// validate command that only ran ParseDefinitionYAML would green-light YAML
+// automation_apply then rejects, because apply layers four more checks on
+// top of parse (resolveDelegationAgent, validateDelegationModelEffort, the
+// codex|claude automatic-approval allowlist, and per-override
+// ValidateLocalClone). Every case here must produce the SAME success/failure
+// verdict — and, on failure, the same error text — from both
+// handleAutomationValidateWS and handleAutomationApplyWS, whether the
+// rejection comes from yaml.v3/ValidateDefinition (parse-level) or from one
+// of validateAutomationSpec's extra checks (seam-level, the case this test
+// exists to pin).
+func TestAutomationValidateAndApplyAgreeOnCorpus(t *testing.T) {
+	const template = `api_version: attn.dev/automations/v1alpha1
+id: %s
+name: Corpus case
+enabled: true
+trigger: {type: manual}
+prompt: Do the thing.
+launch: {driver: %s}
+location: {type: directory, path: "%s"}
+policy: {continuity: fresh, overlap: coalesce}
+`
+	cases := []struct {
+		name      string
+		id        string
+		driver    string
+		mutate    func(raw string) string
+		wantValid bool
+		wantErr   string
+	}{
+		{name: "valid codex baseline", id: "corpus-valid-codex", driver: "codex", wantValid: true},
+		{name: "valid claude baseline", id: "corpus-valid-claude", driver: "claude", wantValid: true},
+		{
+			name:      "driver outside the automatic-approval allowlist is rejected beyond parse",
+			id:        "corpus-shell-driver",
+			driver:    "shell",
+			wantValid: false,
+			wantErr:   "does not support automation automatic approval",
+		},
+		{
+			name:      "unresolvable agent is rejected beyond parse",
+			id:        "corpus-fake-driver",
+			driver:    "totally-not-a-real-agent",
+			wantValid: false,
+			wantErr:   "not available",
+		},
+		{
+			name:   "missing prompt is rejected at parse",
+			id:     "corpus-missing-prompt",
+			driver: "codex",
+			mutate: func(raw string) string {
+				return strings.Replace(raw, "prompt: Do the thing.\n", "", 1)
+			},
+			wantValid: false,
+			wantErr:   "prompt is required",
+		},
+		{
+			name:   "bad api_version is rejected at parse",
+			id:     "corpus-bad-api-version",
+			driver: "codex",
+			mutate: func(raw string) string {
+				return strings.Replace(raw, "attn.dev/automations/v1alpha1", "attn.dev/automations/v0", 1)
+			},
+			wantValid: false,
+			wantErr:   "api_version must be",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := store.New()
+			d := &Daemon{store: s, wsHub: newWSHub()}
+			raw := fmt.Sprintf(template, tc.id, tc.driver, t.TempDir())
+			if tc.mutate != nil {
+				raw = tc.mutate(raw)
+			}
+
+			validateClient := &wsClient{send: make(chan outboundMessage, 4)}
+			d.handleAutomationValidateWS(validateClient, &protocol.AutomationValidateMessage{
+				Cmd:            protocol.CmdAutomationValidate,
+				DefinitionYaml: raw,
+				RequestID:      protocol.Ptr("validate"),
+			})
+			var validateRes protocol.AutomationActionResultMessage
+			readNotebookWSEvent(t, validateClient.send, &validateRes)
+
+			applyClient := &wsClient{send: make(chan outboundMessage, 4)}
+			d.handleAutomationApplyWS(applyClient, &protocol.AutomationApplyMessage{
+				Cmd:            protocol.CmdAutomationApply,
+				DefinitionYaml: raw,
+				RequestID:      protocol.Ptr("apply"),
+			})
+			var applyRes protocol.AutomationActionResultMessage
+			readNotebookWSEvent(t, applyClient.send, &applyRes)
+
+			if validateRes.Success != applyRes.Success {
+				t.Fatalf("validate/apply disagree on %q: validate success=%v (err=%v), apply success=%v (err=%v)",
+					tc.name, validateRes.Success, validateRes.Error, applyRes.Success, applyRes.Error)
+			}
+			if validateRes.Success != tc.wantValid {
+				t.Fatalf("success = %v, want %v (validate error=%v, apply error=%v)", validateRes.Success, tc.wantValid, validateRes.Error, applyRes.Error)
+			}
+			if !tc.wantValid {
+				if validateRes.Error == nil || !strings.Contains(*validateRes.Error, tc.wantErr) {
+					t.Fatalf("validate error = %v, want to contain %q", validateRes.Error, tc.wantErr)
+				}
+				if applyRes.Error == nil || !strings.Contains(*applyRes.Error, tc.wantErr) {
+					t.Fatalf("apply error = %v, want to contain %q", applyRes.Error, tc.wantErr)
+				}
+			}
+		})
+	}
+}
+
+// TestAutomationApplyWSRefusesIDMismatch pins D4: the WS editor's Save
+// carries expected_id (the id of the definition it loaded), and the daemon
+// must refuse an apply whose YAML id differs rather than silently upserting
+// a second definition and leaving the original (still enabled, still
+// running) untouched — see automationApplyWithGuards's doc comment.
+func TestAutomationApplyWSRefusesIDMismatch(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	original, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	renamed := strings.Replace(raw, "id: manual-check", "id: manual-check-renamed", 1)
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationApplyWS(client, &protocol.AutomationApplyMessage{
+		Cmd:              protocol.CmdAutomationApply,
+		DefinitionYaml:   renamed,
+		ExpectedID:       protocol.Ptr(original.ID),
+		ExpectedRevision: protocol.Ptr(original.Revision),
+		RequestID:        protocol.Ptr("apply-id-mismatch"),
+	})
+
+	var res protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if res.Success || res.Error == nil || !strings.Contains(*res.Error, "does not match the definition being edited") {
+		t.Fatalf("apply result = %+v, want success=false with an id-mismatch error", res)
+	}
+
+	// The original definition must be untouched, and no second definition
+	// created under the renamed id.
+	stillOriginal, err := s.GetAutomationDefinition(original.ID)
+	if err != nil || stillOriginal == nil || stillOriginal.Revision != original.Revision {
+		t.Fatalf("original definition after refused apply = %#v err=%v, want unchanged", stillOriginal, err)
+	}
+	if got, err := s.GetAutomationDefinition("manual-check-renamed"); err != nil || got != nil {
+		t.Fatalf("renamed id after refused apply = %#v err=%v, want no definition created", got, err)
+	}
+}
+
+// TestAutomationApplyWSRefusesStaleRevision pins D5: the WS editor's Save
+// carries expected_revision (the revision it loaded), and the daemon must
+// refuse to clobber a definition that changed elsewhere (another app window,
+// or the CLI) since the editor loaded it — the app cannot silently overwrite
+// a concurrent apply. expected_revision 0 (the create case) never triggers
+// this guard.
+func TestAutomationApplyWSRefusesStaleRevision(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	original, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A concurrent CLI apply bumps the revision out from under the editor.
+	concurrentlyApplied := strings.Replace(raw, "Manual check", "Manual check (renamed elsewhere)", 1)
+	if _, err := d.automationApply(concurrentlyApplied); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationApplyWS(client, &protocol.AutomationApplyMessage{
+		Cmd:              protocol.CmdAutomationApply,
+		DefinitionYaml:   strings.Replace(raw, "Manual check", "Manual check (from the stale editor)", 1),
+		ExpectedID:       protocol.Ptr(original.ID),
+		ExpectedRevision: protocol.Ptr(original.Revision),
+		RequestID:        protocol.Ptr("apply-stale-revision"),
+	})
+
+	var res protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if res.Success || res.Error == nil || !strings.Contains(*res.Error, "changed elsewhere") {
+		t.Fatalf("apply result = %+v, want success=false with a changed-elsewhere error", res)
+	}
+
+	stored, err := s.GetAutomationDefinition(original.ID)
+	if err != nil || stored == nil || stored.Name != "Manual check (renamed elsewhere)" {
+		t.Fatalf("definition after refused stale apply = %#v err=%v, want the concurrent apply's name to survive", stored, err)
+	}
+}
+
+// TestAutomationDefinitionGetWSStarterTemplate pins D7: definition_id "" is
+// the new-definition case and must return the starter template at revision
+// 0, so create and edit share one frontend code path.
+func TestAutomationDefinitionGetWSStarterTemplate(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationDefinitionGetWS(client, &protocol.AutomationDefinitionGetMessage{
+		Cmd:          protocol.CmdAutomationDefinitionGet,
+		DefinitionID: "",
+		RequestID:    protocol.Ptr("get-starter"),
+	})
+
+	var res protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if !res.Success || res.SpecYaml == nil || res.Revision == nil {
+		t.Fatalf("definition_get(\"\") result = %+v, want success with spec_yaml and revision set", res)
+	}
+	if *res.Revision != 0 {
+		t.Fatalf("starter template revision = %d, want 0", *res.Revision)
+	}
+	if !strings.Contains(*res.SpecYaml, "id: my-automation") {
+		t.Fatalf("starter template spec_yaml = %q, want the StarterDefinition placeholder", *res.SpecYaml)
+	}
+}
+
+// TestAutomationDefinitionGetWSResolvesLegacyEmptySpecYAML pins D1's fallback
+// for a definition applied before migration 75 added spec_yaml: an existing
+// store row with SpecYAML == "" (what every UpsertAutomationDefinition call
+// wrote before this PR) must still come back from definition_get as valid,
+// re-appliable YAML — reconstructed from spec_json via
+// automation.MarshalDefinitionYAML — not as an empty string.
+func TestAutomationDefinitionGetWSResolvesLegacyEmptySpecYAML(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	applied, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a pre-migration-75 row: same spec_json, but spec_yaml wiped
+	// back to "" as every legacy UpsertAutomationDefinition call left it.
+	legacy, err := s.UpsertAutomationDefinition(applied.ID, applied.Name, applied.SpecJSON, "", applied.Enabled, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy.SpecYAML != "" {
+		t.Fatalf("seeded legacy row spec_yaml = %q, want empty", legacy.SpecYAML)
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationDefinitionGetWS(client, &protocol.AutomationDefinitionGetMessage{
+		Cmd:          protocol.CmdAutomationDefinitionGet,
+		DefinitionID: applied.ID,
+		RequestID:    protocol.Ptr("get-legacy"),
+	})
+
+	var res protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if !res.Success || res.SpecYaml == nil {
+		t.Fatalf("definition_get(%q) result = %+v, want success with spec_yaml set", applied.ID, res)
+	}
+	if *res.Revision != legacy.Revision {
+		t.Fatalf("definition_get revision = %v, want %d", res.Revision, legacy.Revision)
+	}
+	// The fallback-rendered YAML must itself be a legal input to
+	// validateAutomationSpec — proving the legacy row is still appliable,
+	// not just present.
+	if _, _, err := d.validateAutomationSpec(*res.SpecYaml); err != nil {
+		t.Fatalf("validateAutomationSpec(legacy fallback spec_yaml) error = %v, spec_yaml:\n%s", err, *res.SpecYaml)
+	}
+}
+
+// TestAutomationDefinitionGetWSUnknownID surfaces an unknown id as
+// success=false with an error, matching the rest of the automations WS
+// surface's business-failure shape (delete/cleanup/set_enabled), not a
+// transport-level failure.
+func TestAutomationDefinitionGetWSUnknownID(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationDefinitionGetWS(client, &protocol.AutomationDefinitionGetMessage{
+		Cmd:          protocol.CmdAutomationDefinitionGet,
+		DefinitionID: "does-not-exist",
+		RequestID:    protocol.Ptr("get-missing"),
+	})
+
+	var res protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if res.Success || res.Error == nil {
+		t.Fatalf("definition_get(unknown) result = %+v, want success=false with an error", res)
+	}
+}
+
 // TestAutomationSetEnabledWSDeadlineAbortsWithoutMutating pins the
 // timeout-vs-mutation trap from PR #619's review: automationSetEnabled must
 // abort once its daemon-side deadline (wsAutomationMutationTimeout) elapses

--- a/internal/daemon/ws_automations_test.go
+++ b/internal/daemon/ws_automations_test.go
@@ -2,7 +2,9 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -965,5 +967,59 @@ func TestAutomationRunWSRetryWithSameRequestIDDoesNotDuplicate(t *testing.T) {
 	}
 	if len(runs) != 1 {
 		t.Fatalf("runs for definition = %d, want exactly 1 (no duplicate claim from the retried request_id)", len(runs))
+	}
+}
+
+// A validate that passes has no payload to report, and the CLI's success
+// output depends on that absence being visible on the wire. json.Marshal of a
+// nil `any` yields the 4-byte literal `null` rather than an empty slice, which
+// defeats `json:"data,omitempty"` and leaves the client decoding a non-nil
+// json.RawMessage — so `attn automation validate` printed `null` instead of
+// {"valid": true}. Pinned here on the encoded bytes, because the bug lives in
+// the encoding and a decoded struct hides it.
+func TestAutomationCommandOmitsDataWhenActionHasNoPayload(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	go d.handleAutomationCommand(serverConn, protocol.CmdAutomationValidate,
+		&protocol.AutomationValidateMessage{Cmd: protocol.CmdAutomationValidate, DefinitionYaml: raw})
+
+	var encoded map[string]any
+	if err := json.NewDecoder(clientConn).Decode(&encoded); err != nil {
+		t.Fatal(err)
+	}
+	if success, _ := encoded["success"].(bool); !success {
+		t.Fatalf("validate did not succeed: %+v", encoded)
+	}
+	if _, present := encoded["data"]; present {
+		t.Fatalf("a payload-free action put %v on the wire under \"data\"; it must be omitted entirely so the client can tell \"no payload\" from \"payload that is null\"", encoded["data"])
+	}
+}
+
+// The sibling of the case above, pinned so the omitempty guard is not later
+// "simplified" into dropping null payloads generally. GetAutomationDefinition
+// returns a typed nil *store.AutomationDefinition, and assigning that to an
+// `any` produces a NON-nil interface, so show still marshals to null and its
+// output is unchanged. That distinction is the entire reason the guard is
+// written as a nil check on the interface rather than on the encoded bytes.
+func TestAutomationCommandStillReportsNullForMissingDefinition(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	go d.handleAutomationCommand(serverConn, protocol.CmdAutomationShow,
+		&protocol.AutomationShowMessage{Cmd: protocol.CmdAutomationShow, DefinitionID: "no-such-definition"})
+
+	var encoded map[string]any
+	if err := json.NewDecoder(clientConn).Decode(&encoded); err != nil {
+		t.Fatal(err)
+	}
+	value, present := encoded["data"]
+	if !present || value != nil {
+		t.Fatalf("show of a missing definition = %+v, want an explicit null data field", encoded)
 	}
 }

--- a/internal/daemon/ws_automations_test.go
+++ b/internal/daemon/ws_automations_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -560,6 +561,67 @@ func TestAutomationApplyWSRefusesIDMismatch(t *testing.T) {
 	}
 	if got, err := s.GetAutomationDefinition("manual-check-renamed"); err != nil || got != nil {
 		t.Fatalf("renamed id after refused apply = %#v err=%v, want no definition created", got, err)
+	}
+}
+
+// TestAutomationApplyWSRefusesCreateOverLiveDefinition pins the create half
+// of the identity guard. Apply is keyed on the id inside the YAML, so a
+// create whose id collides with a live definition would UPDATE that
+// definition in place — the user typing an existing id into a form labelled
+// "New automation" would replace an automation they never opened. A
+// soft-deleted row is not a collision: re-applying its id is how resurrect
+// works, and the editor's list never showed it.
+func TestAutomationApplyWSRefusesCreateOverLiveDefinition(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	original, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create (no expected_id, no expected_revision) carrying the same id but
+	// entirely different content.
+	colliding := strings.Replace(raw, "Check locally.", "Something else entirely.", 1)
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationApplyWS(client, &protocol.AutomationApplyMessage{
+		Cmd:            protocol.CmdAutomationApply,
+		DefinitionYaml: colliding,
+		RequestID:      protocol.Ptr("apply-create-collision"),
+	})
+
+	var res protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if res.Success || res.Error == nil || !strings.Contains(*res.Error, "already exists") {
+		t.Fatalf("apply result = %+v, want success=false with an already-exists error", res)
+	}
+	survivor, err := s.GetAutomationDefinition(original.ID)
+	if err != nil || survivor == nil {
+		t.Fatalf("definition after refused create = %#v err=%v, want it to survive", survivor, err)
+	}
+	if survivor.Revision != original.Revision || !strings.Contains(survivor.SpecYAML, "Check locally.") {
+		t.Fatalf("definition after refused create = revision %d yaml %q, want the original untouched",
+			survivor.Revision, survivor.SpecYAML)
+	}
+
+	// Soft-deleted is not a collision: the same create now resurrects.
+	if err := d.automationDelete(context.Background(), original.ID); err != nil {
+		t.Fatal(err)
+	}
+	resurrectClient := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationApplyWS(resurrectClient, &protocol.AutomationApplyMessage{
+		Cmd:            protocol.CmdAutomationApply,
+		DefinitionYaml: colliding,
+		RequestID:      protocol.Ptr("apply-create-resurrect"),
+	})
+	var resurrectRes protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, resurrectClient.send, &resurrectRes)
+	if !resurrectRes.Success {
+		t.Fatalf("resurrect apply result = %+v, want success", resurrectRes)
+	}
+	resurrected, err := s.GetAutomationDefinition(original.ID)
+	if err != nil || resurrected == nil || !strings.Contains(resurrected.SpecYAML, "Something else entirely.") {
+		t.Fatalf("definition after resurrect = %#v err=%v, want the new content live", resurrected, err)
 	}
 }
 

--- a/internal/daemon/ws_automations_test.go
+++ b/internal/daemon/ws_automations_test.go
@@ -666,6 +666,59 @@ func TestAutomationApplyWSRefusesStaleRevision(t *testing.T) {
 	}
 }
 
+// TestAutomationApplyWSRefusesEditOfDeletedDefinition pins the edit half of
+// the delete/resurrect guard: DeleteAutomationDefinition sets deleted_at
+// without touching revision, so a stale editor's expected_revision still
+// matches after someone else deletes the definition it has open. Unlike a
+// create (expected_revision 0), which deliberately treats a soft-deleted row
+// as resurrectable, a Save from an open editor must refuse rather than
+// silently bring back a definition that automationDelete already tore down
+// (failed pending runs, fenced provider cursors, purged continuity/
+// review-request state) — the alternative is an unattended cron the user
+// deliberately deleted starting to fire again, reported as "saved
+// successfully".
+func TestAutomationApplyWSRefusesEditOfDeletedDefinition(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	original, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Someone else deletes the definition while the editor still has it open.
+	if err := d.automationDelete(context.Background(), original.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationApplyWS(client, &protocol.AutomationApplyMessage{
+		Cmd:              protocol.CmdAutomationApply,
+		DefinitionYaml:   strings.Replace(raw, "Manual check", "Manual check (from the stale editor)", 1),
+		ExpectedID:       protocol.Ptr(original.ID),
+		ExpectedRevision: protocol.Ptr(original.Revision),
+		RequestID:        protocol.Ptr("apply-edit-deleted"),
+	})
+
+	var res protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if res.Success || res.Error == nil || !strings.Contains(*res.Error, "deleted") || !strings.Contains(*res.Error, "New") {
+		t.Fatalf("apply result = %+v, want success=false with an error naming the deletion and pointing at New", res)
+	}
+
+	// The definition must remain deleted, not resurrected.
+	if live, err := s.GetAutomationDefinition(original.ID); err != nil || live != nil {
+		t.Fatalf("definition after refused edit-of-deleted apply = %#v err=%v, want still absent from the live set", live, err)
+	}
+	stillDeleted, err := s.GetAutomationDefinitionIncludingDeleted(original.ID)
+	if err != nil || stillDeleted == nil || stillDeleted.DeletedAt == nil {
+		t.Fatalf("definition after refused edit-of-deleted apply = %#v err=%v, want still soft-deleted", stillDeleted, err)
+	}
+	if stillDeleted.Revision != original.Revision {
+		t.Fatalf("deleted definition revision = %d, want unchanged %d", stillDeleted.Revision, original.Revision)
+	}
+}
+
 // TestAutomationDefinitionGetWSStarterTemplate pins D7: definition_id "" is
 // the new-definition case and must return the starter template at revision
 // 0, so create and edit share one frontend code path.

--- a/internal/daemon/ws_automations_test.go
+++ b/internal/daemon/ws_automations_test.go
@@ -817,6 +817,97 @@ func TestAutomationDefinitionGetWSUnknownID(t *testing.T) {
 	}
 }
 
+// automationToggleSplitBrainYAML is manualAutomationYAML with a trailing
+// comment on enabled, used by
+// TestAutomationDefinitionGetWSAfterToggleShowsDisabledWithoutReenabling to
+// prove SetEnabledInYAML's headline guarantee — comments survive a toggle —
+// holds all the way through the daemon's own editor read path, not just
+// inside the store.
+const automationToggleSplitBrainYAML = `api_version: attn.dev/automations/v1alpha1
+id: manual-check
+name: Manual check
+enabled: true  # turn me off from the panel
+trigger: {type: manual}
+prompt: Check locally.
+launch: {driver: codex}
+location: {type: directory, path: "%s"}
+policy: {continuity: fresh, overlap: coalesce}
+`
+
+// TestAutomationDefinitionGetWSAfterToggleShowsDisabledWithoutReenabling
+// closes the enabled split-brain defect end-to-end, through the exact path
+// the app uses: apply a definition, toggle it off via
+// handleAutomationSetEnabledWS (what the panel's toggle sends), then fetch it
+// back via handleAutomationDefinitionGetWS — the editor's own load path,
+// backed by automationDefinitionYAML. Before this fix, SetAutomationEnabled
+// wrote only the enabled COLUMN, so this fetch would still show
+// `enabled: true` (spec_yaml never having been updated); saving that stale
+// buffer back — even for an unrelated comment edit, exercised here as the
+// final step by re-applying exactly what definition_get returned — would
+// silently flip the definition back on. It must instead show
+// `enabled: false` with the comment intact, and re-applying it must leave
+// the definition disabled.
+func TestAutomationDefinitionGetWSAfterToggleShowsDisabledWithoutReenabling(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	raw := fmt.Sprintf(automationToggleSplitBrainYAML, t.TempDir())
+	def, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	setClient := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationSetEnabledWS(setClient, &protocol.AutomationSetEnabledMessage{
+		Cmd:          protocol.CmdAutomationSetEnabled,
+		DefinitionID: def.ID,
+		Enabled:      false,
+		RequestID:    protocol.Ptr("toggle-off"),
+	})
+	var setRes protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, setClient.send, &setRes)
+	if !setRes.Success || len(setRes.Definitions) != 1 || setRes.Definitions[0].Enabled {
+		t.Fatalf("set_enabled result = %+v, want a disabled summary", setRes)
+	}
+
+	getClient := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationDefinitionGetWS(getClient, &protocol.AutomationDefinitionGetMessage{
+		Cmd:          protocol.CmdAutomationDefinitionGet,
+		DefinitionID: def.ID,
+		RequestID:    protocol.Ptr("get-after-toggle"),
+	})
+	var getRes protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, getClient.send, &getRes)
+	if !getRes.Success || getRes.SpecYaml == nil {
+		t.Fatalf("definition_get after toggle = %+v, want success with spec_yaml", getRes)
+	}
+	fetched := *getRes.SpecYaml
+	if !strings.Contains(fetched, "enabled: false") {
+		t.Fatalf("editor's own read path still shows the definition enabled:\n%s", fetched)
+	}
+	if !strings.Contains(fetched, "# turn me off from the panel") {
+		t.Fatalf("comment lost from the editor's read path:\n%s", fetched)
+	}
+
+	applyClient := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleAutomationApplyWS(applyClient, &protocol.AutomationApplyMessage{
+		Cmd:              protocol.CmdAutomationApply,
+		DefinitionYaml:   fetched,
+		ExpectedID:       protocol.Ptr(def.ID),
+		ExpectedRevision: getRes.Revision,
+		RequestID:        protocol.Ptr("save-after-get"),
+	})
+	var applyRes protocol.AutomationActionResultMessage
+	readNotebookWSEvent(t, applyClient.send, &applyRes)
+	if !applyRes.Success {
+		t.Fatalf("re-applying the fetched (disabled) yaml failed: %+v", applyRes)
+	}
+
+	final, err := s.GetAutomationDefinition(def.ID)
+	if err != nil || final == nil || final.Enabled {
+		t.Fatalf("definition after re-applying fetched yaml = %#v err=%v, want it to stay disabled", final, err)
+	}
+}
+
 // TestAutomationSetEnabledWSDeadlineAbortsWithoutMutating pins the
 // timeout-vs-mutation trap from PR #619's review: automationSetEnabled must
 // abort once its daemon-side deadline (wsAutomationMutationTimeout) elapses

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "179"
+const ProtocolVersion = "180"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -164,10 +164,12 @@ const (
 	CmdAutomationRun                         = "automation_run"
 	CmdAutomationRunList                     = "automation_run_list"
 	CmdAutomationDefinitionsGet              = "automation_definitions_get"
+	CmdAutomationDefinitionGet               = "automation_definition_get"
 	CmdAutomationRunsGet                     = "automation_runs_get"
 	CmdAutomationSetEnabled                  = "automation_set_enabled"
 	CmdAutomationDelete                      = "automation_delete"
 	CmdAutomationCleanup                     = "automation_cleanup"
+	CmdAutomationValidate                    = "automation_validate"
 	CmdSpawnSession                          = "spawn_session"
 	CmdAttachSession                         = "attach_session"
 	CmdDetachSession                         = "detach_session"
@@ -448,6 +450,20 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdAutomationDefinitionsGet:
 		var msg AutomationDefinitionsGetMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAutomationDefinitionGet:
+		var msg AutomationDefinitionGetMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAutomationValidate:
+		var msg AutomationValidateMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -144,6 +144,9 @@ type AutomationActionResultMessage struct {
 	// RequestID corresponds to the JSON schema field "request_id".
 	RequestID *string `json:"request_id,omitempty,omitzero"`
 
+	// Revision corresponds to the JSON schema field "revision".
+	Revision *int `json:"revision,omitempty,omitzero"`
+
 	// RunID corresponds to the JSON schema field "run_id".
 	RunID *string `json:"run_id,omitempty,omitzero"`
 
@@ -152,6 +155,9 @@ type AutomationActionResultMessage struct {
 
 	// SessionID corresponds to the JSON schema field "session_id".
 	SessionID *string `json:"session_id,omitempty,omitzero"`
+
+	// SpecYaml corresponds to the JSON schema field "spec_yaml".
+	SpecYaml *string `json:"spec_yaml,omitempty,omitzero"`
 
 	// Success corresponds to the JSON schema field "success".
 	Success bool `json:"success"`
@@ -169,9 +175,29 @@ type AutomationApplyMessage struct {
 
 	// DefinitionYaml corresponds to the JSON schema field "definition_yaml".
 	DefinitionYaml string `json:"definition_yaml"`
+
+	// ExpectedID corresponds to the JSON schema field "expected_id".
+	ExpectedID *string `json:"expected_id,omitempty,omitzero"`
+
+	// ExpectedRevision corresponds to the JSON schema field "expected_revision".
+	ExpectedRevision *int `json:"expected_revision,omitempty,omitzero"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
 }
 
 type AutomationCleanupMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// DefinitionID corresponds to the JSON schema field "definition_id".
+	DefinitionID string `json:"definition_id"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+}
+
+type AutomationDefinitionGetMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
 
@@ -335,6 +361,17 @@ type AutomationShowMessage struct {
 
 	// DefinitionID corresponds to the JSON schema field "definition_id".
 	DefinitionID string `json:"definition_id"`
+}
+
+type AutomationValidateMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// DefinitionYaml corresponds to the JSON schema field "definition_yaml".
+	DefinitionYaml string `json:"definition_yaml"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
 }
 
 type AutomationsChangedMessage struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -1571,11 +1571,38 @@ model WorkflowRunCancelMessage {
   run_id: string;
 }
 
-model AutomationApplyMessage { cmd: "automation_apply"; definition_yaml: string; }
+// Dual-surface (unix-socket/CLI `attn automation apply` + WS, the app
+// editor's Save): the socket/CLI path applies unconditionally — "last writer
+// wins," unchanged by this field addition. The WS path additionally supplies
+// expected_id and expected_revision so the daemon can refuse a save that
+// would silently fork the definition (an edited id — apply is keyed on the
+// id *inside* the YAML) or silently clobber a concurrent apply (a stale
+// revision) instead of persisting it; see Daemon.automationApplyWithGuards.
+// Both are absent/zero when creating. request_id is optional, used only by
+// WS for correlation, like automation_delete's below.
+model AutomationApplyMessage {
+  cmd: "automation_apply";
+  definition_yaml: string;
+  request_id?: string;
+  expected_id?: string;
+  expected_revision?: int32;
+}
 model AutomationListMessage { cmd: "automation_list"; }
 model AutomationShowMessage { cmd: "automation_show"; definition_id: string; }
 model AutomationRunMessage { cmd: "automation_run"; definition_id: string; request_id: string; input_json?: string; pr_url?: string; }
 model AutomationRunListMessage { cmd: "automation_run_list"; definition_id: string; }
+
+// Dual-surface (unix-socket `attn automation validate` + WS "Validate"
+// button): runs exactly the checks automation_apply runs before persisting
+// (Daemon.validateAutomationSpec) without writing anything. Deliberately not
+// just a thinner call to ParseDefinitionYAML — see the
+// AutomationActionResultMessage doc comment below for why a validate that
+// skipped one of apply's checks would actively lie to the user.
+model AutomationValidateMessage {
+  cmd: "automation_validate";
+  definition_yaml: string;
+  request_id?: string;
+}
 
 // Dual-surface (unix-socket/CLI + WS), unlike automation_set_enabled below:
 // mirrors automation_apply/automation_run's shape. request_id is optional
@@ -1601,6 +1628,18 @@ model AutomationCleanupMessage {
 // carries request_id for correlation.
 model AutomationDefinitionsGetMessage {
   cmd: "automation_definitions_get";
+  request_id?: string;
+}
+
+// WS-only: the editor's load-for-edit and load-for-create-template call, in
+// one request. definition_id "" returns the starter template
+// (automation.StarterTemplateYAML) at revision 0, so create and edit share
+// one frontend code path and the template can never structurally drift from
+// what ParseDefinitionYAML accepts. A non-empty, unknown definition_id
+// surfaces as success=false with an error, like the other WS lookups above.
+model AutomationDefinitionGetMessage {
+  cmd: "automation_definition_get";
+  definition_id: string;
   request_id?: string;
 }
 model AutomationRunsGetMessage {
@@ -2704,6 +2743,12 @@ model AutomationActionResultMessage {
   cleaned?: string[];
   kept_dirty?: string[];
   kept_active?: string[];
+  // spec_yaml/revision: automation_definition_get's payload — the definition
+  // YAML to show in the editor and the revision it was loaded at (echoed
+  // back as automation_apply's expected_revision). revision 0 with
+  // definition_id "" means the starter template for a brand-new definition.
+  spec_yaml?: string;
+  revision?: int32;
 }
 
 // Compact change signal: canonical state lives in SQLite, so clients re-read

--- a/internal/store/automations.go
+++ b/internal/store/automations.go
@@ -2,9 +2,13 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"time"
+
+	"github.com/victorarias/attn/internal/automation"
 )
 
 func parseOptionalAutomationTime(value string) *time.Time {
@@ -178,13 +182,37 @@ func fenceAutomationProviderCursorsTx(tx *sql.Tx, definitionID string, now time.
 	return err
 }
 
-// SetAutomationEnabled flips a definition's enabled flag directly (unlike
-// UpsertAutomationDefinition, without touching its spec/revision) and, on an
-// actual disabled->enabled transition, performs the same store-side effects
-// Upsert does for that transition: clearing review-request edges and fencing
-// provider cursors. It is a no-op (changed=false, no side effects) when the
-// definition already has the requested state. Returns (nil, false, nil) for an
-// unknown or soft-deleted definition.
+// SetAutomationEnabled flips a definition's enabled flag and, on an actual
+// disabled->enabled transition, performs the same store-side effects Upsert
+// does for that transition: clearing review-request edges and fencing
+// provider cursors. It is a no-op (changed=false, no side effects, no
+// revision bump) when the definition already has the requested state.
+// Returns (nil, false, nil) for an unknown or soft-deleted definition.
+//
+// Unlike UpsertAutomationDefinition, this is not a spec apply — the caller
+// (the panel's toggle) supplies only a bool, not a new YAML document. But
+// `enabled` is "Current management state" (docs/plans/2026-07-18-attn-
+// automations-implementation.md): the enabled COLUMN is the single
+// authority, and spec_json/spec_yaml must stay in sync with it, or the row
+// becomes internally inconsistent — automationDefinitionYAML (what the
+// editor and `attn automation show` read) would keep showing the OLD
+// enabled value, and the next Save, even an unrelated comment edit, would
+// silently write that stale value back out AND re-run the real
+// enable/disable transition it implies. So on a real transition this writes
+// the new enabled value into both spec_json (re-marshaled; it's canonical
+// machine JSON, so reformatting it is harmless) and spec_yaml (rewritten
+// byte-for-byte via automation.SetEnabledInYAML, which preserves everything
+// else — comments included — since spec_yaml is the one copy that carries
+// them and they are never re-derived from spec_json).
+//
+// revision bumps on every real transition, same as Upsert. This is the third
+// instance of one lesson (git log 649a7e52, "close three stale-value holes
+// the editor exposed"): the editor's stale-save guard
+// (automationApplyWithGuards) compares only revision, so any write that
+// changes what a Save would silently overwrite must bump it. Without this,
+// toggling here while someone has the editor open would be invisible to
+// that guard, and their stale buffer's Save would silently reverse the
+// toggle it never saw.
 func (s *Store) SetAutomationEnabled(id string, enabled bool, now time.Time) (*AutomationDefinition, bool, error) {
 	s.mu.Lock()
 	locked := true
@@ -201,8 +229,9 @@ func (s *Store) SetAutomationEnabled(id string, enabled bool, now time.Time) (*A
 		return nil, false, err
 	}
 	defer tx.Rollback()
-	var oldEnabled int
-	err = tx.QueryRow(`SELECT enabled FROM automation_definitions WHERE id=? AND deleted_at=''`, id).Scan(&oldEnabled)
+	var oldEnabled, revision int
+	var specJSON, specYAML string
+	err = tx.QueryRow(`SELECT enabled, revision, spec_json, spec_yaml FROM automation_definitions WHERE id=? AND deleted_at=''`, id).Scan(&oldEnabled, &revision, &specJSON, &specYAML)
 	if err == sql.ErrNoRows {
 		return nil, false, nil
 	}
@@ -217,7 +246,21 @@ func (s *Store) SetAutomationEnabled(id string, enabled bool, now time.Time) (*A
 		def, getErr := s.GetAutomationDefinition(id)
 		return def, false, getErr
 	}
-	if _, err := tx.Exec(`UPDATE automation_definitions SET enabled=?, updated_at=? WHERE id=?`, enabled, formatTicketTime(now), id); err != nil {
+	newSpecJSON, newSpecYAML := specJSON, specYAML
+	if rewrittenJSON, rewrittenYAML, err := automationSpecWithEnabled(specJSON, specYAML, enabled); err != nil {
+		// A corrupt/unparseable spec must never block a toggle: enabling and
+		// especially disabling (a safety control — the operator turning off
+		// an unattended cron) must always take effect. Leave spec_json/
+		// spec_yaml exactly as they were; the column and revision are still
+		// written below, so an editor with this row open is refused by the
+		// stale-save guard on its next Save rather than silently clobbering
+		// the toggle with a stale enabled value.
+		log.Printf("[store] SetAutomationEnabled: definition %s: could not sync spec to the new enabled state, leaving spec_json/spec_yaml untouched: %v", id, err)
+	} else {
+		newSpecJSON, newSpecYAML = rewrittenJSON, rewrittenYAML
+	}
+	revision++
+	if _, err := tx.Exec(`UPDATE automation_definitions SET enabled=?, revision=?, spec_json=?, spec_yaml=?, updated_at=? WHERE id=?`, enabled, revision, newSpecJSON, newSpecYAML, formatTicketTime(now), id); err != nil {
 		return nil, false, err
 	}
 	if enabled {
@@ -235,6 +278,36 @@ func (s *Store) SetAutomationEnabled(id string, enabled bool, now time.Time) (*A
 	locked = false
 	def, getErr := s.GetAutomationDefinition(id)
 	return def, true, getErr
+}
+
+// automationSpecWithEnabled re-derives specJSON/specYAML with their enabled
+// field set to enabled. specJSON must unmarshal as an automation.
+// DefinitionSpec; specYAML, when non-empty, is rewritten via
+// automation.SetEnabledInYAML rather than re-marshaled, so it keeps every
+// other byte — comments included. Returns an error, without touching
+// either input, if specJSON doesn't parse or specYAML doesn't rewrite;
+// SetAutomationEnabled treats either as a corrupt/legacy row and leaves the
+// stored spec as-is rather than blocking the toggle on it.
+func automationSpecWithEnabled(specJSON, specYAML string, enabled bool) (newSpecJSON, newSpecYAML string, err error) {
+	var spec automation.DefinitionSpec
+	if err := json.Unmarshal([]byte(specJSON), &spec); err != nil {
+		return "", "", fmt.Errorf("parse spec_json: %w", err)
+	}
+	spec.Enabled = enabled
+	marshaled, err := json.Marshal(spec)
+	if err != nil {
+		return "", "", fmt.Errorf("marshal spec_json: %w", err)
+	}
+	newSpecJSON = string(marshaled)
+	newSpecYAML = specYAML
+	if specYAML != "" {
+		rewritten, err := automation.SetEnabledInYAML([]byte(specYAML), enabled)
+		if err != nil {
+			return "", "", fmt.Errorf("rewrite spec_yaml: %w", err)
+		}
+		newSpecYAML = string(rewritten)
+	}
+	return newSpecJSON, newSpecYAML, nil
 }
 
 func scanAutomationDefinition(scanner interface{ Scan(...any) error }) (*AutomationDefinition, error) {

--- a/internal/store/automations.go
+++ b/internal/store/automations.go
@@ -104,22 +104,29 @@ func (s *Store) UpsertAutomationDefinition(id, name, specJSON, specYAML string, 
 	}
 	defer tx.Rollback()
 	var revision, oldEnabled int
-	var oldSpec, deletedAt string
+	var oldSpec, oldSpecYAML, deletedAt string
 	// Deliberately not filtered by deleted_at='': a soft-deleted row must be
 	// found here too, so applying the same id resurrects it (clears
 	// deleted_at) instead of colliding with the PRIMARY KEY on an INSERT.
-	err = tx.QueryRow(`SELECT revision, spec_json, enabled, deleted_at FROM automation_definitions WHERE id=?`, id).Scan(&revision, &oldSpec, &oldEnabled, &deletedAt)
+	err = tx.QueryRow(`SELECT revision, spec_json, spec_yaml, enabled, deleted_at FROM automation_definitions WHERE id=?`, id).Scan(&revision, &oldSpec, &oldSpecYAML, &oldEnabled, &deletedAt)
 	switch err {
 	case sql.ErrNoRows:
 		revision = 1
 		_, err = tx.Exec(`INSERT INTO automation_definitions(id,name,enabled,revision,spec_json,spec_yaml,created_at,updated_at,deleted_at) VALUES(?,?,?,?,?,?,?,?,'')`, id, name, enabled, revision, specJSON, specYAML, formatTicketTime(now), formatTicketTime(now))
 	case nil:
 		wasDeleted := deletedAt != ""
-		if oldSpec != specJSON || wasDeleted {
+		if oldSpec != specJSON || oldSpecYAML != specYAML || wasDeleted {
 			// A resurrection always bumps revision, even with an unchanged spec,
 			// so the daemon's contract comparison (old revision vs new) can tell
 			// resurrection apart from a no-op reapply and always rotate continuity
-			// bindings for it.
+			// bindings for it. spec_yaml must be compared too, not just spec_json:
+			// comments live only in spec_yaml (never re-derived into spec_json), so
+			// a comment-only edit changes spec_yaml but not spec_json. Without this,
+			// that edit would persist new YAML while leaving revision unchanged, and
+			// the daemon's stale-save guard (automationApplyWithGuards, which
+			// compares only revision) would be structurally blind to it — two
+			// concurrent editors could silently drop each other's comments with no
+			// "changed elsewhere" refusal.
 			revision++
 		}
 		_, err = tx.Exec(`UPDATE automation_definitions SET name=?, enabled=?, revision=?, spec_json=?, spec_yaml=?, updated_at=?, deleted_at='' WHERE id=?`, name, enabled, revision, specJSON, specYAML, formatTicketTime(now), id)

--- a/internal/store/automations.go
+++ b/internal/store/automations.go
@@ -16,7 +16,12 @@ func parseOptionalAutomationTime(value string) *time.Time {
 }
 
 type AutomationDefinition struct {
-	ID, Name, SpecJSON   string
+	ID, Name, SpecJSON string
+	// SpecYAML is the raw YAML text the caller applied, preserved verbatim
+	// (comments and all) rather than re-derived from SpecJSON. Empty for rows
+	// written before migration 75 added the column; callers that need YAML
+	// back for such a row fall back to automation.MarshalDefinitionYAML.
+	SpecYAML             string
 	Enabled              bool
 	Revision             int
 	CreatedAt, UpdatedAt time.Time
@@ -82,7 +87,7 @@ func (s *Store) AutomationReviewRequestNeedsClaim(definitionID, subjectKey strin
 	return pending != 0, err
 }
 
-func (s *Store) UpsertAutomationDefinition(id, name, specJSON string, enabled bool, now time.Time) (*AutomationDefinition, error) {
+func (s *Store) UpsertAutomationDefinition(id, name, specJSON, specYAML string, enabled bool, now time.Time) (*AutomationDefinition, error) {
 	s.mu.Lock()
 	locked := true
 	defer func() {
@@ -107,7 +112,7 @@ func (s *Store) UpsertAutomationDefinition(id, name, specJSON string, enabled bo
 	switch err {
 	case sql.ErrNoRows:
 		revision = 1
-		_, err = tx.Exec(`INSERT INTO automation_definitions(id,name,enabled,revision,spec_json,created_at,updated_at,deleted_at) VALUES(?,?,?,?,?,?,?,'')`, id, name, enabled, revision, specJSON, formatTicketTime(now), formatTicketTime(now))
+		_, err = tx.Exec(`INSERT INTO automation_definitions(id,name,enabled,revision,spec_json,spec_yaml,created_at,updated_at,deleted_at) VALUES(?,?,?,?,?,?,?,?,'')`, id, name, enabled, revision, specJSON, specYAML, formatTicketTime(now), formatTicketTime(now))
 	case nil:
 		wasDeleted := deletedAt != ""
 		if oldSpec != specJSON || wasDeleted {
@@ -117,7 +122,7 @@ func (s *Store) UpsertAutomationDefinition(id, name, specJSON string, enabled bo
 			// bindings for it.
 			revision++
 		}
-		_, err = tx.Exec(`UPDATE automation_definitions SET name=?, enabled=?, revision=?, spec_json=?, updated_at=?, deleted_at='' WHERE id=?`, name, enabled, revision, specJSON, formatTicketTime(now), id)
+		_, err = tx.Exec(`UPDATE automation_definitions SET name=?, enabled=?, revision=?, spec_json=?, spec_yaml=?, updated_at=?, deleted_at='' WHERE id=?`, name, enabled, revision, specJSON, specYAML, formatTicketTime(now), id)
 		if err == nil && oldEnabled == 0 && enabled {
 			// Re-enabling begins from the provider's current truth. A request that
 			// arrived while disabled must be eligible for latest catch-up even if an
@@ -229,7 +234,7 @@ func scanAutomationDefinition(scanner interface{ Scan(...any) error }) (*Automat
 	var d AutomationDefinition
 	var enabled int
 	var created, updated, deleted string
-	if err := scanner.Scan(&d.ID, &d.Name, &enabled, &d.Revision, &d.SpecJSON, &created, &updated, &deleted); err != nil {
+	if err := scanner.Scan(&d.ID, &d.Name, &enabled, &d.Revision, &d.SpecJSON, &d.SpecYAML, &created, &updated, &deleted); err != nil {
 		return nil, err
 	}
 	d.Enabled = enabled != 0
@@ -245,7 +250,7 @@ func (s *Store) GetAutomationDefinition(id string) (*AutomationDefinition, error
 	if s.db == nil {
 		return nil, nil
 	}
-	d, err := scanAutomationDefinition(s.db.QueryRow(`SELECT id,name,enabled,revision,spec_json,created_at,updated_at,deleted_at FROM automation_definitions WHERE id=? AND deleted_at=''`, id))
+	d, err := scanAutomationDefinition(s.db.QueryRow(`SELECT id,name,enabled,revision,spec_json,spec_yaml,created_at,updated_at,deleted_at FROM automation_definitions WHERE id=? AND deleted_at=''`, id))
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -263,7 +268,7 @@ func (s *Store) GetAutomationDefinitionIncludingDeleted(id string) (*AutomationD
 	if s.db == nil {
 		return nil, nil
 	}
-	d, err := scanAutomationDefinition(s.db.QueryRow(`SELECT id,name,enabled,revision,spec_json,created_at,updated_at,deleted_at FROM automation_definitions WHERE id=?`, id))
+	d, err := scanAutomationDefinition(s.db.QueryRow(`SELECT id,name,enabled,revision,spec_json,spec_yaml,created_at,updated_at,deleted_at FROM automation_definitions WHERE id=?`, id))
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -382,7 +387,7 @@ func (s *Store) ListAutomationDefinitions() ([]AutomationDefinition, error) {
 	if s.db == nil {
 		return nil, nil
 	}
-	rows, err := s.db.Query(`SELECT id,name,enabled,revision,spec_json,created_at,updated_at,deleted_at FROM automation_definitions WHERE deleted_at='' ORDER BY id`)
+	rows, err := s.db.Query(`SELECT id,name,enabled,revision,spec_json,spec_yaml,created_at,updated_at,deleted_at FROM automation_definitions WHERE deleted_at='' ORDER BY id`)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/automations_test.go
+++ b/internal/store/automations_test.go
@@ -1046,3 +1046,48 @@ func TestSweepExpiredTicketsUnblocksPruningOfBoundThreadOrigin(t *testing.T) {
 		t.Fatalf("expected the origin run to become prunable once its ticket aged out, got %#v", prunable)
 	}
 }
+
+// TestUpsertAutomationDefinitionBumpsRevisionOnSpecYAMLOnlyChange pins the
+// revision-bump condition against the class of edit this editor exists to
+// make: comments live only in spec_yaml (never re-derived into spec_json),
+// so a comment-only save leaves spec_json byte-identical while spec_yaml
+// changes. Before this fix the bump condition only compared spec_json, so
+// that edit persisted new YAML while leaving revision unchanged — and the
+// daemon's stale-save guard (automationApplyWithGuards), which compares only
+// revision, was structurally blind to it. This also pins the sibling
+// contract: a byte-identical reapply of both spec_json and spec_yaml must
+// still not bump.
+func TestUpsertAutomationDefinitionBumpsRevisionOnSpecYAMLOnlyChange(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, "prompt: sweep\n", true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if def.Revision != 1 {
+		t.Fatalf("initial revision = %d, want 1", def.Revision)
+	}
+
+	// A byte-identical reapply (same spec_json, same spec_yaml) is a no-op:
+	// revision must not move.
+	noop, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, "prompt: sweep\n", true, now.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if noop.Revision != def.Revision {
+		t.Fatalf("no-op reapply revision = %d, want unchanged %d", noop.Revision, def.Revision)
+	}
+
+	// spec_yaml changes (a comment added) while spec_json stays byte-identical:
+	// this must still bump.
+	commented, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, "# swept nightly\nprompt: sweep\n", true, now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if commented.Revision != def.Revision+1 {
+		t.Fatalf("comment-only edit revision = %d, want %d", commented.Revision, def.Revision+1)
+	}
+	if commented.SpecYAML != "# swept nightly\nprompt: sweep\n" {
+		t.Fatalf("comment-only edit spec_yaml = %q, want the new YAML persisted", commented.SpecYAML)
+	}
+}

--- a/internal/store/automations_test.go
+++ b/internal/store/automations_test.go
@@ -1,10 +1,13 @@
 package store
 
 import (
+	"encoding/json"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/victorarias/attn/internal/automation"
 )
 
 func TestAutomationClaimIsIdempotentAndSnapshotsRevision(t *testing.T) {
@@ -825,6 +828,116 @@ func TestSetAutomationEnabledReenableCatchesUpCurrentReviewDemand(t *testing.T) 
 	candidates, err := s.ReconcileAutomationReviewRequests(def.ID, "github.com", []string{subject}, now.Add(3*time.Minute))
 	if err != nil || len(candidates) != 1 || candidates[0].Cycle != 2 {
 		t.Fatalf("re-enabled latest catch-up candidates=%#v err=%v", candidates, err)
+	}
+}
+
+// enabledToggleYAML is a realistic hand-written definition, comments and all,
+// used by the SetAutomationEnabled write-through tests below.
+const enabledToggleYAML = `# keep this automation lean
+api_version: attn.dev/automations/v1alpha1
+id: nightly-sweep
+name: Nightly sweep
+enabled: true  # flip me from the panel
+trigger: {type: manual}
+prompt: Sweep the repo.
+launch: {driver: codex}
+location: {type: directory, path: "PATH"}
+policy: {continuity: fresh}
+`
+
+// TestSetAutomationEnabledWritesThroughToStoredSpec pins the fix for the
+// split-brain defect this PR closes: SetAutomationEnabled (the panel's
+// toggle) used to write only the enabled COLUMN, leaving spec_json/spec_yaml
+// saying the old value, so the next unrelated Save would silently re-enable
+// a definition the operator had just turned off. On a real transition, both
+// spec_json and spec_yaml must show the new value, with every other byte —
+// comments included — carried over from spec_yaml.
+func TestSetAutomationEnabledWritesThroughToStoredSpec(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 7, 20, 9, 0, 0, 0, time.UTC)
+	yamlDoc := strings.ReplaceAll(enabledToggleYAML, "PATH", t.TempDir())
+	spec, canonical, err := automation.ParseDefinitionYAML([]byte(yamlDoc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	def, err := s.UpsertAutomationDefinition(spec.ID, spec.Name, string(canonical), yamlDoc, true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	startRevision := def.Revision
+
+	disabled, changed, err := s.SetAutomationEnabled(def.ID, false, now.Add(time.Minute))
+	if err != nil || !changed || disabled == nil || disabled.Enabled {
+		t.Fatalf("disable: def=%#v changed=%v err=%v", disabled, changed, err)
+	}
+	if disabled.Revision != startRevision+1 {
+		t.Fatalf("real transition did not bump revision: got %d, want %d", disabled.Revision, startRevision+1)
+	}
+
+	if !strings.Contains(disabled.SpecJSON, `"enabled":false`) {
+		t.Fatalf("spec_json still says enabled:true: %s", disabled.SpecJSON)
+	}
+	var disabledSpec automation.DefinitionSpec
+	if err := json.Unmarshal([]byte(disabled.SpecJSON), &disabledSpec); err != nil {
+		t.Fatalf("spec_json no longer parses: %v: %s", err, disabled.SpecJSON)
+	}
+	if disabledSpec.Enabled || disabledSpec.ID != spec.ID || disabledSpec.Prompt != spec.Prompt {
+		t.Fatalf("spec_json lost or mis-set fields: %#v", disabledSpec)
+	}
+
+	if !strings.Contains(disabled.SpecYAML, "enabled: false  # flip me from the panel") {
+		t.Fatalf("spec_yaml still says enabled: true, or lost its trailing comment: %s", disabled.SpecYAML)
+	}
+	if !strings.Contains(disabled.SpecYAML, "# keep this automation lean") {
+		t.Fatalf("spec_yaml lost its head comment: %s", disabled.SpecYAML)
+	}
+
+	// The no-op re-application of the same state must not bump revision: it
+	// is not a transition, so nothing to keep in sync changed.
+	noop, changed, err := s.SetAutomationEnabled(def.ID, false, now.Add(2*time.Minute))
+	if err != nil || changed || noop == nil {
+		t.Fatalf("no-op disable: def=%#v changed=%v err=%v", noop, changed, err)
+	}
+	if noop.Revision != disabled.Revision {
+		t.Fatalf("no-op bumped revision: got %d, want %d", noop.Revision, disabled.Revision)
+	}
+
+	// The editor's own read path (automationDefinitionYAML in
+	// internal/daemon/ws_automations.go) prefers spec_yaml verbatim when
+	// present, so this is exactly what re-opening the editor after the
+	// toggle would show. That full round trip — toggle, reopen, save an
+	// unrelated edit, confirm the automation is still off — is pinned at two
+	// levels above this one, not here:
+	// TestAutomationDefinitionGetWSAfterToggleShowsDisabledWithoutReenabling
+	// over the daemon's real WS handlers, and leg 10 of
+	// app/scripts/real-app-harness/scenario-automation-editor.mjs against the
+	// packaged app driving the actual panel toggle.
+}
+
+// TestSetAutomationEnabledDegradesGracefullyOnCorruptSpecJSON pins that a row
+// whose spec_json cannot be parsed (a corrupt or otherwise unexpected value —
+// this store method never validates what UpsertAutomationDefinition was
+// given) never blocks the toggle: enabling, and especially disabling — a
+// safety control for turning off an unattended cron — must always take
+// effect on the column, even when the spec can't be kept in sync.
+func TestSetAutomationEnabledDegradesGracefullyOnCorruptSpecJSON(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 7, 20, 9, 0, 0, 0, time.UTC)
+	const corruptJSON = `not-json`
+	def, err := s.UpsertAutomationDefinition("corrupt-spec", "Corrupt spec", corruptJSON, "", true, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	disabled, changed, err := s.SetAutomationEnabled(def.ID, false, now.Add(time.Minute))
+	if err != nil || !changed || disabled == nil || disabled.Enabled {
+		t.Fatalf("disable must still succeed on a corrupt spec: def=%#v changed=%v err=%v", disabled, changed, err)
+	}
+	if disabled.Revision != def.Revision+1 {
+		t.Fatalf("column-only transition did not bump revision: got %d, want %d", disabled.Revision, def.Revision+1)
+	}
+	if disabled.SpecJSON != corruptJSON {
+		t.Fatalf("corrupt spec_json was touched instead of left alone: %s", disabled.SpecJSON)
 	}
 }
 

--- a/internal/store/automations_test.go
+++ b/internal/store/automations_test.go
@@ -10,7 +10,7 @@ import (
 func TestAutomationClaimIsIdempotentAndSnapshotsRevision(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("cleanup", "Cleanup", `{"id":"cleanup"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("cleanup", "Cleanup", `{"id":"cleanup"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func TestAutomationClaimIsIdempotentAndSnapshotsRevision(t *testing.T) {
 func TestScheduledAutomationClaimIsIdempotent(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,13 +66,13 @@ func TestScheduledAutomationClaimIsIdempotent(t *testing.T) {
 func TestScheduledAutomationClaimRejectsStaleRevision(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// A second apply bumps the revision, simulating the definition changing
 	// between the caller's revision read and this claim's transaction.
-	if _, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly","edited":true}`, true, now); err != nil {
+	if _, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly","edited":true}`, "", true, now); err != nil {
 		t.Fatal(err)
 	}
 	ids := AutomationRunReservation{RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1"}
@@ -95,7 +95,7 @@ func TestScheduledAutomationClaimRejectsStaleRevision(t *testing.T) {
 func TestScheduledAutomationClaimRejectsDisabledDefinition(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, false, now)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, "", false, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestScheduledAutomationClaimRejectsDisabledDefinition(t *testing.T) {
 func TestScheduledAutomationDifferentInstantsClaimDifferentRuns(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestScheduledAutomationDifferentInstantsClaimDifferentRuns(t *testing.T) {
 func TestScheduledAutomationSingletonContinuityReusesBinding(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +171,7 @@ func TestScheduledAutomationSingletonContinuityReusesBinding(t *testing.T) {
 func TestAutomationContinuityRunHistoryReturnsPriorRuns(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -217,7 +217,7 @@ func TestAutomationContinuityRunHistoryReturnsPriorRuns(t *testing.T) {
 func TestScheduledAutomationSingletonContinuityBlocksUndeliveredPredecessor(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -236,7 +236,7 @@ func TestScheduledAutomationSingletonContinuityBlocksUndeliveredPredecessor(t *t
 func TestAutomationScheduleCursorGetSetRoundtrip(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -267,7 +267,7 @@ func TestAutomationScheduleCursorGetSetRoundtrip(t *testing.T) {
 func TestListAutomationRunsWithOccurrenceKeysOrdersNewestFirstWithLimit(t *testing.T) {
 	s := New()
 	base := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("cleanup", "Cleanup", `{"id":"cleanup"}`, true, base)
+	def, err := s.UpsertAutomationDefinition("cleanup", "Cleanup", `{"id":"cleanup"}`, "", true, base)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -313,7 +313,7 @@ func TestListAutomationRunsWithOccurrenceKeysOrdersNewestFirstWithLimit(t *testi
 func TestListPendingAutomationRunsIncludesScheduledProvider(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -367,7 +367,7 @@ func TestEnsureAutomationTicketAdoptsByRun(t *testing.T) {
 func TestGitHubReviewEdgeRetriesThenReusesContinuityBinding(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("review", "Review", `{"id":"review"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", `{"id":"review"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -428,7 +428,7 @@ func TestGitHubReviewEdgeRetriesThenReusesContinuityBinding(t *testing.T) {
 func TestGitHubReviewAcceptedPendingRunRemainsRetryableWhileDemandIsActive(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("review", "Review", `{"id":"review"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", `{"id":"review"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -468,7 +468,7 @@ func TestGitHubReviewAcceptedPendingRunRemainsRetryableWhileDemandIsActive(t *te
 func TestGitHubReviewReRequestDoesNotReuseWithdrawnUndeliveredBinding(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -505,7 +505,7 @@ func TestGitHubReviewReRequestDoesNotReuseWithdrawnUndeliveredBinding(t *testing
 func TestGitHubReviewWithdrawalExposesPendingRunAndReleasesEmptyBinding(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -562,7 +562,7 @@ func TestGitHubReviewWithdrawalExposesPendingRunAndReleasesEmptyBinding(t *testi
 func TestGitHubReviewClaimAndTicketEventAreIdempotent(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("review", "Review", `{"id":"review"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", `{"id":"review"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -638,7 +638,7 @@ func TestReenabledGitHubAutomationCatchesUpCurrentReviewDemand(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
 	const spec = `{"id":"review"}`
-	def, err := s.UpsertAutomationDefinition("review", "Review", spec, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", spec, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -650,10 +650,10 @@ func TestReenabledGitHubAutomationCatchesUpCurrentReviewDemand(t *testing.T) {
 	if _, created, err := s.ClaimGitHubReviewAutomationRun(def.ID, subject, 1, def.Revision, `{}`, `{}`, now, ids); err != nil || !created {
 		t.Fatalf("initial claim created=%v err=%v", created, err)
 	}
-	if _, err := s.UpsertAutomationDefinition(def.ID, def.Name, spec, false, now.Add(time.Minute)); err != nil {
+	if _, err := s.UpsertAutomationDefinition(def.ID, def.Name, spec, "", false, now.Add(time.Minute)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.UpsertAutomationDefinition(def.ID, def.Name, spec, true, now.Add(2*time.Minute)); err != nil {
+	if _, err := s.UpsertAutomationDefinition(def.ID, def.Name, spec, "", true, now.Add(2*time.Minute)); err != nil {
 		t.Fatal(err)
 	}
 	stale, err := s.ReconcileAutomationReviewRequests(def.ID, "github.com", []string{subject}, now.Add(90*time.Second))
@@ -669,7 +669,7 @@ func TestReenabledGitHubAutomationCatchesUpCurrentReviewDemand(t *testing.T) {
 func TestContinuationOccurrenceRecordsOnTerminalTicketExactlyOnce(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -729,7 +729,7 @@ func TestContinuationOccurrenceRecordsOnTerminalTicketExactlyOnce(t *testing.T) 
 func TestGitHubReviewCursorOrdersObservationsWithinOneSecond(t *testing.T) {
 	s := New()
 	base := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, true, base)
+	def, err := s.UpsertAutomationDefinition("review", "Review", `{}`, "", true, base)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -756,7 +756,7 @@ func TestGitHubReviewCursorOrdersObservationsWithinOneSecond(t *testing.T) {
 func TestSetAutomationEnabledFlipsStateAndIsIdempotent(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("daily-check", "Daily check", `{}`, true, now)
+	def, err := s.UpsertAutomationDefinition("daily-check", "Daily check", `{}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -800,7 +800,7 @@ func TestSetAutomationEnabledReenableCatchesUpCurrentReviewDemand(t *testing.T) 
 	s := New()
 	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
 	const spec = `{"id":"review"}`
-	def, err := s.UpsertAutomationDefinition("review", "Review", spec, true, now)
+	def, err := s.UpsertAutomationDefinition("review", "Review", spec, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -840,7 +840,7 @@ func TestSetAutomationEnabledReenableCatchesUpCurrentReviewDemand(t *testing.T) 
 func TestListPrunableAutomationRunsProtectsBoundThreadOrigin(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -881,7 +881,7 @@ func TestListPrunableAutomationRunsProtectsBoundThreadOrigin(t *testing.T) {
 func TestListPrunableAutomationRunsStillPrunesNonContinuityRuns(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("cleanup", "Cleanup", `{"id":"cleanup"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("cleanup", "Cleanup", `{"id":"cleanup"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -919,7 +919,7 @@ func TestSweepExpiredTicketsCascadesToContinuityBindings(t *testing.T) {
 	s := New()
 	base := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
 	const ttl = 30 * 24 * time.Hour
-	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, base)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, "", true, base)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -991,7 +991,7 @@ func TestSweepExpiredTicketsCascadesToContinuityBindings(t *testing.T) {
 func TestSweepExpiredTicketsUnblocksPruningOfBoundThreadOrigin(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)
-	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, true, now)
+	def, err := s.UpsertAutomationDefinition("nightly", "Nightly", `{"id":"nightly"}`, "", true, now)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -769,6 +769,7 @@ CREATE TABLE IF NOT EXISTS ticket_event_cursors (
 			FOREIGN KEY(ticket_id) REFERENCES tickets(id)
 		);
 	`},
+	{75, "persist the applied automation definition YAML", ""},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -999,6 +1000,11 @@ func migrateDB(db *sql.DB, dbPath string) error {
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
 			if err := applyMigration73(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 75 {
+			if err := applyMigration75(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -1373,6 +1379,30 @@ func applyMigration72(tx *sql.Tx) error {
 		return nil
 	}
 	_, err = tx.Exec(`ALTER TABLE delegation_operations ADD COLUMN chief_session_id TEXT NOT NULL DEFAULT ''`)
+	return err
+}
+
+// applyMigration75 adds spec_yaml to automation_definitions, persisting the
+// user's own applied YAML (not just its canonical JSON re-derivation) so a
+// later edit round-trips through the editor without silently discarding
+// comments and formatting. Guarded with tableExists (a partial-schema test DB
+// may seed only some tables) and columnExists (idempotent re-run safety).
+func applyMigration75(tx *sql.Tx) error {
+	exists, err := tableExists(tx, "automation_definitions")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	hasColumn, err := columnExists(tx, "automation_definitions", "spec_yaml")
+	if err != nil {
+		return err
+	}
+	if hasColumn {
+		return nil
+	}
+	_, err = tx.Exec(`ALTER TABLE automation_definitions ADD COLUMN spec_yaml TEXT NOT NULL DEFAULT ''`)
 	return err
 }
 

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -235,6 +235,55 @@ func TestMigration73RepairsAutomationProfileMigration70Collision(t *testing.T) {
 	}
 }
 
+// TestMigration75DefaultsExistingRowsToEmptySpecYAML mirrors
+// TestMigration73RepairsAutomationProfileMigration70Collision's technique:
+// roll a real DB back to just before migration 75 (drop the column it adds,
+// delete its schema_migrations record), seed a row in that pre-75 shape, then
+// reopen so migration 75 runs for real. Every row that existed before the
+// migration must come back with spec_yaml = '' (the column's DEFAULT '') —
+// that empty value is exactly what internal/daemon's automationDefinitionYAML
+// fallback (via automation.MarshalDefinitionYAML) is keyed on to reconstruct
+// definition_yaml for a definition applied before this PR.
+func TestMigration75DefaultsExistingRowsToEmptySpecYAML(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "migration-75.db")
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB() setup error = %v", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec(
+		`INSERT INTO automation_definitions (id, name, enabled, revision, spec_json, created_at, updated_at, deleted_at) VALUES (?, ?, 1, 1, ?, ?, ?, '')`,
+		"legacy-def", "Legacy", `{"id":"legacy-def","name":"Legacy"}`, now, now,
+	); err != nil {
+		db.Close()
+		t.Fatalf("seed legacy row: %v", err)
+	}
+	if _, err := db.Exec(`
+		ALTER TABLE automation_definitions DROP COLUMN spec_yaml;
+		DELETE FROM schema_migrations WHERE version >= 75;
+	`); err != nil {
+		db.Close()
+		t.Fatalf("roll back to pre-migration-75 schema: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close seeded db: %v", err)
+	}
+
+	migrated, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB() migration 75 = %v", err)
+	}
+	defer migrated.Close()
+
+	var specYAML string
+	if err := migrated.QueryRow(`SELECT spec_yaml FROM automation_definitions WHERE id = ?`, "legacy-def").Scan(&specYAML); err != nil {
+		t.Fatalf("query legacy row spec_yaml: %v", err)
+	}
+	if specYAML != "" {
+		t.Fatalf("legacy row spec_yaml = %q, want empty (migration 75's column default)", specYAML)
+	}
+}
+
 func TestMigration67RenamesTicketArtifactRecords(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "migration-67.db")
 	db, err := OpenDB(dbPath)
@@ -367,6 +416,7 @@ func TestMigrations_MigratedColumnsExist(t *testing.T) {
 		{"chief_of_staff_dispatches", "structured_report_json"},
 		{"tickets", "reconciled_at"},
 		{"sessions", "closed_intentionally_at"},
+		{"automation_definitions", "spec_yaml"},
 	}
 
 	for _, tc := range migratedColumns {

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -240,7 +240,7 @@ func TestMigration73RepairsAutomationProfileMigration70Collision(t *testing.T) {
 // roll a real DB back to just before migration 75 (drop the column it adds,
 // delete its schema_migrations record), seed a row in that pre-75 shape, then
 // reopen so migration 75 runs for real. Every row that existed before the
-// migration must come back with spec_yaml = '' (the column's DEFAULT '') —
+// migration must come back with an empty spec_yaml (the column's DEFAULT) —
 // that empty value is exactly what internal/daemon's automationDefinitionYAML
 // fallback (via automation.MarshalDefinitionYAML) is keyed on to reconstruct
 // definition_yaml for a definition applied before this PR.


### PR DESCRIPTION
Slice 7 PR B, the last implementation PR of the automations epic. Automations become writable from the app: the Automations panel's New and Edit buttons open the definition's YAML in a CodeMirror buffer, Validate checks a definition without storing anything, and Save is the only writer.

## What this adds

**One buffer for create and edit.** Create loads through the same `getDefinition('')` path as edit and gets the starter template back at revision 0, so there is no second code path to keep in step. A successful create adopts the id the daemon actually persisted, so a second Save in the same buffer is an edit rather than a stale-id create.

**Validate without apply.** `automation_validate` runs the exact same definition checks `apply` runs — they share one seam in `internal/daemon/automations.go` rather than drifting — and writes nothing. Also exposed as `attn automation validate --file <path>`.

**Three refusals instead of silent damage:**

- Changing the `id` of the definition you are editing. Apply is keyed on the id *inside* the YAML, so this would leave the original running and quietly create a second one. A rename has to be an explicit create.
- Creating an automation whose `id` already belongs to a live definition — that would replace it wholesale. A soft-deleted definition is still resurrectable by re-applying its id, so the guard checks `DeletedAt`, not mere existence.
- Saving over a definition whose revision changed elsewhere. This one offers Reload as the recovery path.

**Comments survive.** Definitions now store the applied `SpecYAML` verbatim (migration 75), so an edit round-trip preserves comments and formatting. Rows applied before this migration have no stored YAML and re-render comment-free from `SpecJSON` on first open — the editor says that in-line rather than hiding it.

**No stomping.** The buffer is populated only on mount or an explicit Reload. It does not subscribe to the automations store, so an `automations_changed` broadcast cannot replace text you are mid-typing.

## What an adversarial gate then found

A six-dimension adversarial review (find → refute, majority kills a finding) produced 13 raw findings; 2 were refuted 3/3 and the rest collapsed to six distinct defects. Five are fixed here, each with a mutation-verified regression test. Three of them were the same mistake wearing different clothes — **trusting a value another writer can move underneath you.**

**The revision counter did not cover `spec_yaml`** (`649a7e52`). Comments live only in `spec_yaml`; they are never re-derived into the canonical `spec_json`. So a comment-only save wrote new YAML and left `revision` untouched, and the stale-save guard was structurally blind to precisely the class of edit this editor exists to enable. Two people editing one definition silently lost one author's comments, with no "changed elsewhere" refusal.

That fix makes `revision` move more often, which means comment-only edits now also reach `rotateContinuityBindingsIfContractChanged`'s revision-differs branch. Worth stating explicitly because it would have been a real regression: that branch compares continuation *contracts*, and `ContinuationContract` is `{Prompt, Launch, Location}` with no revision in it, so editing a comment does not rotate a singleton thread.

**An edit-Save silently resurrected a definition deleted elsewhere** (`649a7e52`). `DeleteAutomationDefinition` also leaves `revision` alone, so a stale editor's `expected_revision` still matched a soft-deleted row: the guard passed, the upsert cleared `deleted_at`, and the definition came back live and enabled — after `automationDelete` had already failed its pending runs, fenced its provider cursors and purged its continuity bindings. For a cron trigger that means unattended sessions firing again, reported to the user as a successful save. The edit path now refuses and points at New; the create path still resurrects deliberately.

**A stale Validate response overwrote the cleared state**, rendering "Looks good." against text the daemon never saw — and because clearing validation on keystroke also re-opened the disabled Validate button, two requests could stack and resolve out of order with the older answer winning.

Plus two smaller ones: edits typed during an in-flight Save were discarded when the editor closed, and `attn automation validate` printed `null` on success because `json.Marshal` of a nil payload yields the literal `null`, which defeats `omitempty` and leaves the client decoding a non-nil four-byte `Data`.

The gate also caught a false claim in this PR's own guide ledger — it said all three of the earlier fixes carried regression tests, and the read-loop one does not. Corrected rather than backfilled with a test that would only assert Go's scheduler.

## Known gap, deliberately not fixed here

`enabled` is both a field in the definition spec and a column the panel's toggle writes independently. Disable an automation with the toggle, then open and Save it, and the YAML's `enabled: true` turns it back on. This is pre-existing in `attn automation apply`, but this PR puts Edit directly beside the toggle and makes it one click, so it is newly reachable. Every available fix changes product behavior — rewrite the user's YAML from the toggle, make the column authoritative and drop the spec field, or warn on divergence — so it wants a decision rather than a unilateral patch.

## Review pass on the product code

Reviewing the diff directly rather than trusting the implementation reports turned up three defects the tests had not caught. Each is a separate commit with a regression test:

- `d2ca16a7` — Reload was offered while creating. `loadedId` is null there, so it would have re-fetched the starter template *over the draft being typed*, for no reachable benefit.
- `2bc29c15` — validate ran inline on the client read loop. "Does not touch the store" is not the same as "is fast": `git.ValidateLocalClone` stats the path and shells out to git twice per override, head-of-line blocking that client's other messages.
- `14e0ab6e` — a create whose id collided with a live definition silently overwrote it. Mutation-verified: without the guard the create succeeds and bumps the victim to revision 2.

One test was also vacuous and is now not. `AutomationEditor.test.tsx`'s editor mock called `onChange` unconditionally, while the real `applyExternalContent` computes a minimal edit and **dispatches nothing when the text is unchanged**. With the mock that permissive, deliberately breaking `setText` left all 17 tests green. The mock now matches the real semantics, and there is a test for the unchanged-text case specifically; the same mutation now goes red.

## Evidence

Packaged scenario `real-app:scenario-automation-editor`, run `automation-editor-2026-07-21T00-46-50-361Z`, against the app built from `c5629930` on the isolated `autoedit` profile. All nine legs green, with the daemon's own state cross-checked through the bundled CLI at every leg:

```
step:ok leg1_starter_template
step:ok leg2_invalid_rejected_nothing_stored
step:ok leg3_create_with_comment
step:ok leg4_create_collision_refused
step:ok leg5_comments_survive_roundtrip
step:ok leg6_id_change_refusal
step:ok leg7_stale_revision_refusal_and_reload
step:ok leg8_comment_only_edit_bumps_revision
step:ok leg9_delete_elsewhere_then_save_refused
ATTN_VERDICT {"ok":true,"scenarioId":"AUTOMATION-EDITOR","runId":"automation-editor-2026-07-21T00-46-50-361Z","failureCount":0,"firstFailure":null,"durationMs":2838}
```

Legs 8 and 9 are the ones worth reading. The original seven all have a single writer, which is structurally why they could not catch any of the three stale-value defects above. Leg 8 builds its edit as a pure prefix of the live buffer, so "comment-only" is true by construction, and asserts `spec_json` is byte-identical before and after — otherwise a future refactor that folded comments into the canonical spec would leave the leg passing for the wrong reason. Leg 9 asserts the daemon's own state after the refusal, not just the error string, because a polite refusal sitting in front of a resurrected row is exactly the failure it exists to catch.

Comment survival is proven by the stored `SpecYAML` still carrying the run's `# harness-marker:` line after the round-trip, read back through the CLI.

The CLI fix was also confirmed against the running daemon rather than only in a unit test:

```
$ attn automation validate --file valid-auto.yaml
{
  "valid": true
}
```

Preflight PASS on `autoedit`, protocol 180 agreeing across CLI, app, and daemon. `go build ./...` clean, `go test ./...` exit 0 across 42 packages, `tsc --noEmit` clean, frontend 1917 tests passed.

The editor buffer is exposed to the UI automation bridge through a registered handle (`automationEditorAutomation.ts`) rather than DOM scraping, because CodeMirror virtualizes long documents — scraping `.cm-line` can silently truncate, which would be unacceptable in the seam that carries the comment-survival proof.

## Size

3921 insertions across 38 files, but the product surface is much smaller: the packaged scenario (593), `AutomationEditor.test.tsx` (553), `ws_automations_test.go` (452), and the e2e spec (134) are ~1.7k of it, and generated protocol output another ~120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
