### PR TITLE
test(store): pin the pre-automations upgrade and record real recovery coverage

### DIFF
--- a/docs/plans/2026-07-18-attn-automations-implementation.md
+++ b/docs/plans/2026-07-18-attn-automations-implementation.md
@@ -918,6 +918,37 @@ upgrade and packaged-app matrix pass from the integration branch.
 
 ## Verification strategy
 
+### Upgrade
+
+Run at epic close (2026-07-21) against merged `main` `310fbc8e`.
+
+A database was built by the **pre-automations binary** — `1e300bf7`, the last
+commit before migration 73 — rather than by rewinding head code, so the starting
+schema is what an installed pre-epic app actually produced:
+
+```
+pre-epic binary (1e300bf7) -> schema_head=72  automation_tables=[]
+head binary     (310fbc8e) -> schema_head=75  automation_tables=[7 tables]
+```
+
+Migration 72 → 75 applied cleanly and wrote its pre-migration backup first. A
+copy of the real production database was not used: it sits at version 73, and
+reading `~/.attn` is deliberately out of reach from this workflow.
+
+`TestMigratesPopulatedPreAutomationsDatabaseToHead`
+(`internal/store/sqlite_test.go`) pins this as a regression test, because none
+existed. It seeds tickets, a session, and a PR, rewinds to the pre-73 shape
+(dropping the automation tables, the `idx_tickets_automation_run` index, and the
+`tickets.automation_run_id` column — not merely deleting `schema_migrations`
+rows, which would leave 73/74 hitting their `IF NOT EXISTS` no-op path and prove
+nothing), then migrates and asserts every legacy row survives intact alongside
+the new column and tables. The `ALTER TABLE tickets ADD COLUMN` in migration 73
+is the risk this covers: before this test it had only ever run against an empty
+or already-migrated `tickets` table. Mutation-verified by no-oping that `ALTER`
+and its dependent index so migration 73 still reports success — the test fails at
+the per-ticket integrity assertion (`sqlite_test.go:417`,
+`no such column: automation_run_id`), not at an upstream diagnostic.
+
 ### Idempotency
 
 - Same definition/provider/occurrence key returns the existing occurrence and run.
@@ -949,6 +980,41 @@ Inject a crash/error after each durable or external boundary and run recovery:
 Every case must finish with at most one ticket, worktree, workspace, pane, and live
 session for the reserved delivery IDs. Mismatch or dirty evidence produces a
 visible failure; tests must never make recovery pass by deleting evidence.
+
+#### Actual coverage as shipped (2026-07-21)
+
+The table above is the specification. It is not what shipped. Surveyed on merged
+`main` (`310fbc8e`) at epic close, the nine checkpoints stand at **one covered,
+four partial, four uncovered**, and the epic was closed on that basis by explicit
+decision rather than by meeting the spec. Recorded here so the gap is visible to
+whoever next touches this code instead of being implied-covered by a checked box.
+
+"Partial" means the test re-invokes a function and asserts key idempotency. It
+does not restart a daemon, kill a process, or resume from durable state written
+mid-sequence — which is what this section actually asks for.
+
+| # | Checkpoint | Status | Where |
+|---|---|---|---|
+| 1 | occurrence/run txn commits | partial | `TestAutomationClaimIsIdempotentAndSnapshotsRevision`, `TestScheduledAutomationClaimIsIdempotent` (`internal/store/automations_test.go`); `TestScheduledPendingRunRecoversOnRestart` (`internal/daemon/automations_schedule_test.go`) forces delivery to fail, so it proves recovery was attempted, not that exactly one delivery proceeded |
+| 2 | ticket commits | partial | `TestEnsureAutomationTicketAdoptsByRun`, `TestContinuationOccurrenceRecordsOnTerminalTicketExactlyOnce` (`internal/store/automations_test.go`); enforcement is the partial unique index in `applyMigration73`. Nothing crashes between ticket commit and the next step |
+| 3 | managed clone/fetch | **none** | The per-repository lock (`internal/daemon/automations.go`, `d.automationRepos`) has no concurrency test, and no test re-enters after an interrupted publish |
+| 4 | worktree added | partial | Best of the nine. `TestEnsureDetachedWorktreeAtRevisionCreateAdoptAndProtectEvidence` and `…RecoversFreshStaleMetadata` (`internal/git/worktree_test.go`) — the latter is a genuine interruption test. No daemon-layer re-entry after a simulated crash |
+| 5 | workspace registered | **none** | `Daemon.EnsureWorkspace` has zero test callers; only the `fakePorts` stub in `internal/workdelivery/workdelivery_test.go` |
+| 6 | pane added | **none** | `Daemon.EnsurePane` likewise has zero test callers outside `fakePorts` |
+| 7 | PTY spawn before session row | partial | `TestAutomationRecoveryWaitsForInitialGitHubDiscovery` pins only the GitHub-ready gate. `automationSessionIsLive` — the guard against a second spawn of the stable session ID — has **no test**, and the startup ordering in `daemon.go` is unpinned. This is the window this guide's own risk list calls "a real crash window" |
+| 8 | session row before run link | **none** | `VerifyDelivery` is never called by any test; its link assertions never execute. `internal/daemon/automations.go` says so in a source comment: reaching that line for real needs a full workdelivery spawn, out of reach for a unit test |
+| 9 | delivered commit, response lost | **covered** | `TestAutomationRunWSRetryWithSameRequestIDDoesNotDuplicate` (`internal/daemon/ws_automations_test.go`) — holds `automationMu` while two concurrent same-`request_id` retries queue behind it, asserts both return the same run ID and exactly one run exists |
+
+Highest residual risk, in order: checkpoint 8 (a run can strand in `pending`
+forever with a live session, or mark delivered on mismatched links) and
+checkpoint 7 (a duplicate live agent session). Both fail silently. Checkpoints
+3, 5, and 6 are adopt-or-create guards with smaller blast radius.
+
+The only automated evidence anywhere that asserts "at most one" after a genuine
+daemon stop/start lives in the packaged scenarios, not in `go test`:
+`leg1_restart_catchup` and `leg4_storm_guard_restart` in
+`app/scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs`. Those
+restart the daemon *between* runs, not at a mid-delivery boundary.
 
 ### Daemon restart
 
@@ -1148,6 +1214,28 @@ For every slice that touches daemon lifecycle, protocol, PTY, Git, or UI:
       drive that race through the real UI.
 - [ ] Run the final upgrade, failure-recovery, and packaged-app matrix from the
       integration branch and open the single integration PR to `main`.
+      Slices merged directly to `main` through their own PRs, so there is no
+      long-lived integration branch and no separate integration PR to open; this
+      item reduces to the three-part matrix. Status at 2026-07-21:
+      - **Upgrade — done.** Pre-epic binary `1e300bf7` produced a real v72
+        database; head migrated it 72 → 75 cleanly. Pinned going forward by
+        `TestMigratesPopulatedPreAutomationsDatabaseToHead`. See "Upgrade" above.
+      - **Failure recovery — closed by decision, not by evidence.** One of nine
+        checkpoints is covered, four are partial, four have nothing. Victor's
+        call was to ship and document rather than close the gap. The honest
+        per-checkpoint table is under "Partial failure" above; checkpoints 7 and
+        8 are the ones worth returning to.
+      - **Packaged-app matrix — not yet run.** Blocked on macOS revoking the
+        Accessibility grant for
+        `app/scripts/real-app-harness/.build/attn-real-input-driver` after it was
+        rebuilt. Every input-driven scenario fails at
+        `AXIsProcessTrustedWithOptions` until that binary is re-granted in System
+        Settings → Privacy & Security → Accessibility. A run attempted on
+        2026-07-21 failed 8 of 14 scenarios entirely for this reason — seven with
+        the explicit permission error and one timing out on an undelivered
+        keystroke — with no product regression among them. Re-run
+        `pnpm --dir app run real-app:serial-matrix` against a rebuilt
+        non-production profile once the grant is restored.
 
 When implementation forces a choice that changes the product behavior described
 in the vision, stop and update the vision by agreement. When it only changes code

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -284,6 +284,191 @@ func TestMigration75DefaultsExistingRowsToEmptySpecYAML(t *testing.T) {
 	}
 }
 
+// TestMigratesPopulatedPreAutomationsDatabaseToHead guards migrations 73-75
+// against a REAL pre-existing database, not an empty or already-migrated one.
+// Migration 73's `ALTER TABLE tickets ADD COLUMN automation_run_id` is the
+// highest-risk statement in the trio: every other test exercises it against a
+// fresh or already-migrated tickets table. Just deleting schema_migrations
+// rows wouldn't exercise that risk either — 73/74's CREATE TABLE IF NOT
+// EXISTS and the ALTER's columnExists guard would silently no-op against a
+// DB that still has the automation schema. So this test seeds tickets,
+// sessions, and prs rows through a real head-schema store, physically
+// rewinds the on-disk schema to its pre-73 shape (dropping the automation
+// tables and the tickets column, mirroring
+// TestMigration75DefaultsExistingRowsToEmptySpecYAML's technique), reopens so
+// migrations 73-75 run for real, and asserts every legacy row survived
+// alongside the new schema.
+func TestMigratesPopulatedPreAutomationsDatabaseToHead(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pre-automations.db")
+
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB() setup error = %v", err)
+	}
+
+	now := time.Now().UTC()
+	// Seeded via raw SQL rather than CreateTicket: CreateTicket's INSERT
+	// names automation_run_id explicitly, which would make seeding itself
+	// (not just the post-migration assertions below) depend on migration 73
+	// having already run — muddying the mutation-check this test exists for.
+	tickets := []Ticket{
+		{ID: "legacy-ticket-1", Title: "Legacy ticket one", Status: TicketStatusTodo},
+		{ID: "legacy-ticket-2", Title: "Legacy ticket two", Status: TicketStatusWorking, Assignee: "agent-a"},
+		{ID: "legacy-ticket-3", Title: "Legacy ticket three", Status: TicketStatusDone},
+	}
+	for _, tk := range tickets {
+		if _, err := s.db.Exec(
+			`INSERT INTO tickets (id, title, status, assignee, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+			tk.ID, tk.Title, string(tk.Status), tk.Assignee, now.Format(time.RFC3339), now.Format(time.RFC3339),
+		); err != nil {
+			t.Fatalf("seed ticket %s: %v", tk.ID, err)
+		}
+	}
+
+	s.Add(&protocol.Session{
+		ID:         "legacy-session-1",
+		Label:      "Legacy session",
+		Directory:  "/repo/legacy",
+		Agent:      "claude",
+		State:      protocol.SessionStateIdle,
+		StateSince: protocol.TimestampNow().String(),
+		LastSeen:   protocol.TimestampNow().String(),
+	})
+
+	s.AddPR(&protocol.PR{
+		ID:          "github.com:owner/repo#42",
+		Host:        "github.com",
+		Repo:        "owner/repo",
+		Number:      42,
+		Title:       "Legacy PR",
+		URL:         "https://github.com/owner/repo/pull/42",
+		Author:      "octocat",
+		Role:        protocol.PRRoleAuthor,
+		State:       protocol.PRStateWaiting,
+		LastUpdated: now.Format(time.RFC3339),
+		LastPolled:  now.Format(time.RFC3339),
+	})
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("close seeded store: %v", err)
+	}
+
+	raw, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	if _, err := raw.Exec(`
+		DROP TABLE IF EXISTS automation_ticket_occurrence_events;
+		DROP TABLE IF EXISTS automation_continuity_bindings;
+		DROP TABLE IF EXISTS automation_review_request_edges;
+		DROP TABLE IF EXISTS automation_provider_cursors;
+		DROP TABLE IF EXISTS automation_runs;
+		DROP TABLE IF EXISTS automation_occurrences;
+		DROP TABLE IF EXISTS automation_definitions;
+		DROP INDEX IF EXISTS idx_tickets_automation_run;
+	`); err != nil {
+		raw.Close()
+		t.Fatalf("roll back to pre-migration-73/74 tables: %v", err)
+	}
+	var hasAutomationRunID int
+	if err := raw.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('tickets') WHERE name = 'automation_run_id'`,
+	).Scan(&hasAutomationRunID); err != nil {
+		raw.Close()
+		t.Fatalf("check tickets.automation_run_id before rollback: %v", err)
+	}
+	if hasAutomationRunID == 1 {
+		if _, err := raw.Exec(`ALTER TABLE tickets DROP COLUMN automation_run_id`); err != nil {
+			raw.Close()
+			t.Fatalf("drop tickets.automation_run_id: %v", err)
+		}
+	}
+	if _, err := raw.Exec(`DELETE FROM schema_migrations WHERE version >= 73`); err != nil {
+		raw.Close()
+		t.Fatalf("unrecord migrations 73-75: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close raw rollback db: %v", err)
+	}
+
+	migrated, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB() migrate pre-automations db: %v", err)
+	}
+	defer migrated.Close()
+
+	version, err := GetSchemaVersion(migrated.db)
+	if err != nil {
+		t.Fatalf("GetSchemaVersion() error = %v", err)
+	}
+	if version != latestSchemaVersion() {
+		t.Fatalf("schema version = %d, want %d", version, latestSchemaVersion())
+	}
+
+	// Every pre-existing row must survive with its original values, and
+	// automation_run_id must exist and be NULL for all of them (a legacy
+	// ticket has no automation provenance).
+	for _, tk := range tickets {
+		var title, status, assignee string
+		var automationRunID sql.NullString
+		if err := migrated.db.QueryRow(
+			`SELECT title, status, assignee, automation_run_id FROM tickets WHERE id = ?`, tk.ID,
+		).Scan(&title, &status, &assignee, &automationRunID); err != nil {
+			t.Fatalf("query migrated ticket %s: %v", tk.ID, err)
+		}
+		if title != tk.Title || status != string(tk.Status) || assignee != tk.Assignee {
+			t.Fatalf("migrated ticket %s = (title %q, status %q, assignee %q), want (%q, %q, %q)",
+				tk.ID, title, status, assignee, tk.Title, tk.Status, tk.Assignee)
+		}
+		if automationRunID.Valid {
+			t.Fatalf("migrated ticket %s automation_run_id = %q, want NULL", tk.ID, automationRunID.String)
+		}
+	}
+	var ticketCount int
+	if err := migrated.db.QueryRow(`SELECT COUNT(*) FROM tickets`).Scan(&ticketCount); err != nil {
+		t.Fatalf("count migrated tickets: %v", err)
+	}
+	if ticketCount != len(tickets) {
+		t.Fatalf("migrated ticket count = %d, want %d", ticketCount, len(tickets))
+	}
+
+	gotSession := migrated.Get("legacy-session-1")
+	if gotSession == nil {
+		t.Fatal("legacy session missing after migration")
+	}
+	if gotSession.Label != "Legacy session" || gotSession.Directory != "/repo/legacy" || gotSession.Agent != "claude" {
+		t.Fatalf("migrated session = %+v, want label/directory/agent preserved", gotSession)
+	}
+
+	gotPR := migrated.GetPR("github.com:owner/repo#42")
+	if gotPR == nil {
+		t.Fatal("legacy PR missing after migration")
+	}
+	if gotPR.Title != "Legacy PR" || gotPR.Repo != "owner/repo" || gotPR.Number != 42 {
+		t.Fatalf("migrated PR = %+v, want title/repo/number preserved", gotPR)
+	}
+
+	// The new automation schema must exist alongside the preserved data.
+	for _, table := range []string{
+		"automation_definitions", "automation_occurrences", "automation_runs",
+		"automation_provider_cursors", "automation_review_request_edges",
+		"automation_continuity_bindings", "automation_ticket_occurrence_events",
+	} {
+		if !tableExistsForTest(t, migrated.db, table) {
+			t.Fatalf("table %s missing after migration", table)
+		}
+	}
+	var specYAMLColumns int
+	if err := migrated.db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('automation_definitions') WHERE name = 'spec_yaml'`,
+	).Scan(&specYAMLColumns); err != nil {
+		t.Fatalf("query automation_definitions.spec_yaml: %v", err)
+	}
+	if specYAMLColumns != 1 {
+		t.Fatalf("automation_definitions.spec_yaml columns = %d, want 1", specYAMLColumns)
+	}
+}
+
 func TestMigration67RenamesTicketArtifactRecords(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "migration-67.db")
 	db, err := OpenDB(dbPath)


### PR DESCRIPTION
Closes out the automations epic's final verification matrix. Two files: one new test, one guide update.

## Upgrade — the gap this closes

Migration 73 does `ALTER TABLE tickets ADD COLUMN automation_run_id`. Until now that statement had only ever run against an empty or already-migrated `tickets` table — no test seeded a populated pre-automations database and migrated it forward. That's the statement most likely to fail on a real user's install.

`TestMigratesPopulatedPreAutomationsDatabaseToHead` seeds tickets, a session, and a PR, rewinds to the genuine pre-73 shape, migrates, and asserts every legacy row survives intact alongside the new column and the seven automation tables.

The rewind drops the automation tables, the `idx_tickets_automation_run` index, and the `automation_run_id` column — deliberately not just `DELETE FROM schema_migrations`, which would leave 73/74 hitting their `IF NOT EXISTS` no-op path and prove nothing.

**Evidence.** A database built by the *pre-epic binary* (`1e300bf7`, last commit before migration 73) rather than by rewinding head code:

```
pre-epic binary (1e300bf7) -> schema_head=72  automation_tables=[]
head binary     (310fbc8e) -> schema_head=75  automation_tables=[7 tables]
```

**Mutation-verified.** No-oped migration 73's `ALTER` and its dependent index so the migration still reports success. The test fails at the per-ticket integrity assertion — `sqlite_test.go:417`, `no such column: automation_run_id` — not at an upstream diagnostic. `GetSchemaVersion` still passed under the mutation, confirming the failing assertion is the one carrying the claim.

## Failure recovery — documented, not closed

The guide's nine-checkpoint partial-failure table was a specification that never became evidence. Surveyed on merged `main`: **one covered, four partial, four uncovered**. `EnsureWorkspace`, `EnsurePane`, `VerifyDelivery`, and `automationSessionIsLive` have zero test callers outside `fakePorts` stubs — verified directly, not just reported.

"Partial" here means the test re-invokes a function and asserts key idempotency; it never restarts a daemon or resumes from mid-sequence durable state, which is what that section actually asks for.

Victor's call was to ship and document rather than close the gap, so the guide now carries the honest per-checkpoint table with residual risk ranked. Highest: checkpoint 8 (a run can strand in `pending` forever, or mark delivered on mismatched links — `internal/daemon/automations.go` admits in a comment that this path is unreachable from unit tests) and checkpoint 7 (duplicate live agent session). Both fail silently.

No production code changed.

## Still outstanding

The packaged-app serial matrix has **not** run. macOS revoked the Accessibility grant for `app/scripts/real-app-harness/.build/attn-real-input-driver` after it was rebuilt, so every input-driven scenario dies at `AXIsProcessTrustedWithOptions`. An attempted run failed 8 of 14 scenarios entirely for that reason — seven with the explicit permission error, one timing out on an undelivered keystroke — **no product regression among them**. The guide records this and the final checklist item stays unchecked until the matrix actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)