### PR TITLE
feat(agents): make Claude/Codex default model & effort configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-25]
+
+### Added
+- **Claude's (and Codex's) default model and reasoning effort are now
+  configurable for every session, not just chief-of-staff launches.** New
+  Settings > Agents controls ("Default model & effort") set
+  `default_model_<agent>`/`default_effort_<agent>`, applied to every launch
+  of that agent (chief or not) via `--model`/`--effort`. Previously only a
+  chief-of-staff launch could pin a model/effort
+  (`chief_model_<agent>`/`chief_effort_<agent>`); a regular session always
+  fell through to the agent's own hardcoded default with no way to change
+  it. Precedence is unchanged and additive: an explicit per-spawn pin (e.g. a
+  delegation's `--model`) still wins outright, a chief launch still prefers
+  its `chief_model_<agent>`/`chief_effort_<agent>` override, and only then
+  does the new default setting apply; leaving both blank keeps today's
+  behavior (the agent's own default).
+
 ## [2026-07-24]
 
 ### Added
@@ -72,6 +89,26 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   now loads with the rest of the list in one request instead of a separate
   fetch per definition, so opening the panel with many automations feels
   noticeably snappier.
+=======
+## [2026-07-22]
+
+### Added
+- **Claude's (and Codex's) default model and reasoning effort are now
+  configurable for every session, not just chief-of-staff launches.** New
+  Settings > Agents controls ("Default model & effort") set
+  `default_model_<agent>`/`default_effort_<agent>`, applied to every launch
+  of that agent (chief or not) via `--model`/`--effort`. Previously only a
+  chief-of-staff launch could pin a model/effort
+  (`chief_model_<agent>`/`chief_effort_<agent>`); a regular session always
+  fell through to the agent's own hardcoded default with no way to change
+  it. Precedence is unchanged and additive: an explicit per-spawn pin (e.g. a
+  delegation's `--model`) still wins outright, a chief launch still prefers
+  its `chief_model_<agent>`/`chief_effort_<agent>` override, and only then
+  does the new default setting apply; leaving both blank keeps today's
+  behavior (the agent's own default).
+
+---
+>>>>>>> faf95c8c (feat(agents): make Claude/Codex default model & effort configurable)
 
 ## [2026-07-21]
 

--- a/app/src/components/SettingsModal.test.tsx
+++ b/app/src/components/SettingsModal.test.tsx
@@ -1007,6 +1007,70 @@ describe('SettingsModal chief settings', () => {
     expect(await screen.findByTestId('settings-chief-effort-codex')).toHaveValue('low');
   });
 
+  it('renders a default-model input per supported agent and commits a typed model on blur', async () => {
+    const onSetSetting = renderModal({});
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    // claude and codex each get a row; copilot does not (its launch ignores --model).
+    const claudeInput = await screen.findByTestId('settings-default-model-claude');
+    expect(screen.getByTestId('settings-default-model-codex')).toBeInTheDocument();
+    expect(screen.queryByTestId('settings-default-model-copilot')).toBeNull();
+
+    fireEvent.change(claudeInput, { target: { value: 'opus' } });
+    fireEvent.blur(claudeInput);
+    expect(onSetSetting).toHaveBeenCalledWith('default_model_claude', 'opus');
+  });
+
+  it('does not write when a default-model input blurs unchanged', async () => {
+    const onSetSetting = renderModal({ default_model_claude: 'opus' });
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    const claudeInput = await screen.findByTestId('settings-default-model-claude');
+    expect(claudeInput).toHaveValue('opus');
+    fireEvent.blur(claudeInput);
+    expect(onSetSetting).not.toHaveBeenCalledWith('default_model_claude', expect.anything());
+  });
+
+  it('clears a default-model override back to the agent default', async () => {
+    const onSetSetting = renderModal({ default_model_codex: 'gpt-5.4' });
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    const codexInput = await screen.findByTestId('settings-default-model-codex');
+    expect(codexInput).toHaveValue('gpt-5.4');
+    fireEvent.change(codexInput, { target: { value: '' } });
+    fireEvent.blur(codexInput);
+    expect(onSetSetting).toHaveBeenCalledWith('default_model_codex', '');
+  });
+
+  it('renders a default-effort select per supported agent and commits on change', async () => {
+    const onSetSetting = renderModal({});
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    const claudeEffort = await screen.findByTestId('settings-default-effort-claude');
+    expect(screen.getByTestId('settings-default-effort-codex')).toBeInTheDocument();
+    expect(screen.queryByTestId('settings-default-effort-copilot')).toBeNull();
+
+    fireEvent.change(claudeEffort, { target: { value: 'high' } });
+    expect(onSetSetting).toHaveBeenCalledWith('default_effort_claude', 'high');
+  });
+
+  it('shows a saved default-effort override', async () => {
+    renderModal({ default_effort_codex: 'xhigh' });
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    const codexEffort = await screen.findByTestId('settings-default-effort-codex');
+    expect(codexEffort).toHaveValue('xhigh');
+  });
+
+  it('keeps an agent visible when only its default-effort override is saved', async () => {
+    // codex is unavailable but has a saved effort override, so it should still show
+    // (mirrors the chief-effort re-inclusion rule).
+    renderModal({ codex_available: 'false', default_effort_codex: 'low' });
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    expect(await screen.findByTestId('settings-default-effort-codex')).toHaveValue('low');
+  });
+
   it('shows the effective context-window caps and defaults to 128000 when unset', async () => {
     renderModal({ chief_context_window_cap: '120000', headless_context_window_cap: '90000' });
     fireEvent.click(screen.getByTestId('settings-nav-agents'));

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -93,8 +93,9 @@ type SettingsSectionID = 'general' | 'connectivity' | 'plugins' | 'agents' | 're
 // mirrors this default (agent.DefaultContextWindowCap) for both context-window caps.
 const DEFAULT_CONTEXT_WINDOW_CAP = 128000;
 
-// Reasoning-effort levels the chief_effort_<agent> setting accepts, per agent. Blank
-// (agent default) is added separately as the select's first option.
+// Reasoning-effort levels the chief_effort_<agent> and default_effort_<agent>
+// settings accept, per agent. Blank (agent default) is added separately as the
+// select's first option.
 const CHIEF_EFFORT_LEVELS: Partial<Record<SessionAgent, string[]>> = {
   claude: ['low', 'medium', 'high', 'xhigh', 'max'],
   codex: ['minimal', 'low', 'medium', 'high', 'xhigh'],
@@ -187,6 +188,12 @@ export function SettingsModal({
   // Per-agent chief-of-staff reasoning-effort override (chief_effort_<agent>). A
   // <select>, so it commits immediately on change rather than on blur.
   const [chiefEfforts, setChiefEfforts] = useState<Record<SessionAgent, string>>({});
+  // Per-agent default model override (default_model_<agent>) applied to EVERY
+  // launch of that agent, chief or not. Same edit semantics as chiefModels.
+  const [defaultModels, setDefaultModels] = useState<Record<SessionAgent, string>>({});
+  // Per-agent default reasoning-effort override (default_effort_<agent>) applied
+  // to EVERY launch of that agent, chief or not. Same edit semantics as chiefEfforts.
+  const [defaultEfforts, setDefaultEfforts] = useState<Record<SessionAgent, string>>({});
   const [editorExecutable, setEditorExecutable] = useState(settings.editor_executable || '');
   const [defaultAgent, setDefaultAgent] = useState<SessionAgent>('claude');
   const [reviewerModel, setReviewerModel] = useState(settings.reviewer_model || '');
@@ -305,6 +312,37 @@ export function SettingsModal({
     }
     return out;
   }, [settings, chiefOverrideAgentList]);
+  // Agents whose launch honors a --model/--effort default (claude, codex),
+  // applied to EVERY launch of that agent rather than only chief launches.
+  // Same installed-or-configured visibility rule as chiefOverrideAgentList.
+  const defaultOverrideAgentList = useMemo(() => {
+    const list = orderedAgentList.filter((agent) => (
+      ['codex', 'claude'].includes(agent) && isAgentAvailable(agentAvailability, agent)
+    ));
+    for (const agent of ['claude', 'codex'] as const) {
+      if (!list.includes(agent) && (
+        (settings[`default_model_${agent}`] || '').trim() !== ''
+        || (settings[`default_effort_${agent}`] || '').trim() !== ''
+      )) {
+        list.push(agent);
+      }
+    }
+    return list;
+  }, [orderedAgentList, agentAvailability, settings]);
+  const actualDefaultModels = useMemo(() => {
+    const out = {} as Record<SessionAgent, string>;
+    for (const agent of defaultOverrideAgentList) {
+      out[agent] = settings[`default_model_${agent}`] || '';
+    }
+    return out;
+  }, [settings, defaultOverrideAgentList]);
+  const actualDefaultEfforts = useMemo(() => {
+    const out = {} as Record<SessionAgent, string>;
+    for (const agent of defaultOverrideAgentList) {
+      out[agent] = settings[`default_effort_${agent}`] || '';
+    }
+    return out;
+  }, [settings, defaultOverrideAgentList]);
   // Agents eligible to run any keeper duty: installed, headless-task capable, and one
   // of claude/codex. Any agent already configured on a duty is kept in the list even
   // if it has since become unavailable, so its row still shows the saved selection.
@@ -351,6 +389,8 @@ export function SettingsModal({
     setAgentExecutables(actualAgentExecutables);
     setChiefModels(actualChiefModels);
     setChiefEfforts(actualChiefEfforts);
+    setDefaultModels(actualDefaultModels);
+    setDefaultEfforts(actualDefaultEfforts);
     setEditorExecutable(actualEditorExecutable);
     setDefaultAgent(resolvedDefaultAgent);
     setReviewerModel(actualReviewerModel);
@@ -371,7 +411,7 @@ export function SettingsModal({
     setPluginSourcePath('');
     setPluginError(null);
     setPluginActionName(null);
-  }, [isOpen, actualProjectsDir, actualNotebookRoot, actualAgentExecutables, actualChiefModels, actualChiefEfforts, actualEditorExecutable, resolvedDefaultAgent, actualReviewerModel, actualChiefContextCap, actualHeadlessContextCap, actualKeeperConfigs, keeperAgents]);
+  }, [isOpen, actualProjectsDir, actualNotebookRoot, actualAgentExecutables, actualChiefModels, actualChiefEfforts, actualDefaultModels, actualDefaultEfforts, actualEditorExecutable, resolvedDefaultAgent, actualReviewerModel, actualChiefContextCap, actualHeadlessContextCap, actualKeeperConfigs, keeperAgents]);
 
   useEscapeStack(onClose, isOpen);
 
@@ -490,6 +530,24 @@ export function SettingsModal({
   const handleChiefEffortChange = useCallback((agent: SessionAgent, value: string) => {
     setChiefEfforts((prev) => ({ ...prev, [agent]: value }));
     onSetSetting(`chief_effort_${agent}`, value);
+  }, [onSetSetting]);
+
+  const handleDefaultModelChange = useCallback((agent: SessionAgent, value: string) => {
+    setDefaultModels((prev) => ({ ...prev, [agent]: value }));
+  }, []);
+
+  const commitDefaultModel = useCallback((agent: SessionAgent) => {
+    const nextValue = (defaultModels[agent] || '').trim();
+    const currentValue = (actualDefaultModels[agent] || '').trim();
+    if (nextValue !== currentValue) {
+      onSetSetting(`default_model_${agent}`, nextValue);
+    }
+  }, [actualDefaultModels, defaultModels, onSetSetting]);
+
+  // A <select>, so change commits immediately rather than waiting for blur.
+  const handleDefaultEffortChange = useCallback((agent: SessionAgent, value: string) => {
+    setDefaultEfforts((prev) => ({ ...prev, [agent]: value }));
+    onSetSetting(`default_effort_${agent}`, value);
   }, [onSetSetting]);
 
   const handleToggleAutoApprove = useCallback(() => {
@@ -2008,6 +2066,74 @@ export function SettingsModal({
                         className="settings-input"
                         value={effortValue}
                         onChange={(e) => handleChiefEffortChange(agent, e.target.value)}
+                      >
+                        <option value="">Agent default</option>
+                        {effortLevels.map((level) => (
+                          <option key={level} value={level}>{level}</option>
+                        ))}
+                      </select>
+                    </div>
+                  </Fragment>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="settings-block">
+        <div className="settings-block-intro">
+          <div className="settings-kicker">Agents</div>
+          <h3>Default model &amp; effort</h3>
+          <p className="settings-description">
+            Pins the model and reasoning effort EVERY session of an agent launches
+            with, chief or not. Leave blank to use the agent's own default. A
+            chief-of-staff override above, or a per-session --model/--effort pin,
+            still takes priority over this.
+          </p>
+        </div>
+        <div className="settings-block-body">
+          {defaultOverrideAgentList.length === 0 ? (
+            <div className="settings-warning">No installed agent supports a model or effort override.</div>
+          ) : (
+            <div className="settings-field-grid two-column">
+              {defaultOverrideAgentList.map((agent) => {
+                const inputId = `settings-default-model-${agent}`;
+                const effortId = `settings-default-effort-${agent}`;
+                const value = defaultModels[agent] || '';
+                const effortValue = defaultEfforts[agent] || '';
+                const effortLevels = CHIEF_EFFORT_LEVELS[agent] || [];
+                return (
+                  <Fragment key={agent}>
+                    <div className="settings-field">
+                      <label className="settings-label" htmlFor={inputId}>{agentLabel(agent)}</label>
+                      <input
+                        id={inputId}
+                        data-testid={inputId}
+                        type="text"
+                        value={value}
+                        onChange={(e) => handleDefaultModelChange(agent, e.target.value)}
+                        onBlur={() => commitDefaultModel(agent)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            commitDefaultModel(agent);
+                          }
+                        }}
+                        placeholder={agent === 'claude' ? 'opus — blank for default' : 'gpt-5.4 — blank for default'}
+                        className="settings-input"
+                        autoCapitalize="none"
+                        autoCorrect="off"
+                        spellCheck={false}
+                      />
+                    </div>
+                    <div className="settings-field">
+                      <label className="settings-label" htmlFor={effortId}>{agentLabel(agent)} effort</label>
+                      <select
+                        id={effortId}
+                        data-testid={effortId}
+                        className="settings-input"
+                        value={effortValue}
+                        onChange={(e) => handleDefaultEffortChange(agent, e.target.value)}
                       >
                         <option value="">Agent default</option>
                         {effortLevels.map((level) => (

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -2086,10 +2086,10 @@ export function SettingsModal({
           <div className="settings-kicker">Agents</div>
           <h3>Default model &amp; effort</h3>
           <p className="settings-description">
-            Pins the model and reasoning effort EVERY session of an agent launches
-            with, chief or not. Leave blank to use the agent's own default. A
-            chief-of-staff override above, or a per-session --model/--effort pin,
-            still takes priority over this.
+            The model and reasoning effort every session of this agent starts
+            with. Leave blank to use whatever the agent picks on its own. A
+            chief-of-staff override above, or a model pinned when a session is
+            launched, still wins over this.
           </p>
         </div>
         <div className="settings-block-body">

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -257,16 +257,17 @@ type SpawnOpts struct {
 
 	// Model, when set, pins the interactive agent's model via --model (an alias
 	// like "opus"/"sonnet" or a full model id). Empty means the agent's own
-	// default. Sourced from the daemon's chief_model_<agent> setting for chief
-	// launches or a delegation's --model flag, and threaded into the worker via
-	// ATTN_MODEL.
+	// default. Sourced from a delegation's --model flag, or else the daemon's
+	// chief_model_<agent> setting (chief launches only) or default_model_<agent>
+	// setting (every launch), and threaded into the worker via ATTN_MODEL.
 	Model string
 
 	// Effort, when set, pins the interactive agent's reasoning effort using the
 	// agent's native mechanism (Claude --effort, Codex model_reasoning_effort).
 	// Empty means the agent's own default. Sourced from a delegation's --effort
-	// flag and threaded into the worker via ATTN_EFFORT. Only meaningful for
-	// drivers with HasEffortPin.
+	// flag, or else the daemon's chief_effort_<agent> setting (chief launches
+	// only) or default_effort_<agent> setting (every launch), and threaded into
+	// the worker via ATTN_EFFORT. Only meaningful for drivers with HasEffortPin.
 	Effort string
 
 	// AutoCompactWindow, when > 0, caps this launch's effective context window so

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -4244,6 +4244,10 @@ func TestDaemon_SettingsValidation(t *testing.T) {
 		{"headless context cap below min", "headless_context_window_cap", "1", true},
 		{"valid chief_effort_claude", "chief_effort_claude", "high", false},
 		{"empty chief_effort_claude", "chief_effort_claude", "", false},
+		{"valid default_model_claude", "default_model_claude", "opus", false},
+		{"empty default_model_claude", "default_model_claude", "", false},
+		{"valid default_effort_claude", "default_effort_claude", "high", false},
+		{"empty default_effort_claude", "default_effort_claude", "", false},
 	}
 
 	for _, tt := range tests {
@@ -4280,6 +4284,73 @@ func TestDaemon_ContextWindowCapResolutionAndGating(t *testing.T) {
 	d.store.SetSetting(SettingChiefContextWindowCap, "160000")
 	if got := d.chiefContextWindowCap(true); got != 160000 {
 		t.Fatalf("chief cap = %d, want 160000", got)
+	}
+}
+
+func TestDaemon_DefaultLaunchModelAndEffort(t *testing.T) {
+	d := &Daemon{store: store.New()}
+
+	// Unset => "" (the agent's own default), regardless of chief status.
+	if got := d.defaultLaunchModel("claude"); got != "" {
+		t.Fatalf("default model with no setting = %q, want \"\"", got)
+	}
+	if got := d.defaultLaunchEffort("claude"); got != "" {
+		t.Fatalf("default effort with no setting = %q, want \"\"", got)
+	}
+
+	d.store.SetSetting(SettingDefaultModelPrefix+"claude", "opus")
+	d.store.SetSetting(SettingDefaultEffortPrefix+"claude", "high")
+
+	// Applies to non-chief AND chief launches alike, unlike chiefLaunchModel.
+	if got := d.defaultLaunchModel("claude"); got != "opus" {
+		t.Fatalf("default model = %q, want %q", got, "opus")
+	}
+	if got := d.defaultLaunchEffort("claude"); got != "high" {
+		t.Fatalf("default effort = %q, want %q", got, "high")
+	}
+
+	// Agent name is normalized (trimmed and lowercased) before the lookup.
+	if got := d.defaultLaunchModel(" Claude "); got != "opus" {
+		t.Fatalf("default model with unnormalized agent = %q, want %q", got, "opus")
+	}
+}
+
+func TestDaemon_ResolveLaunchModelAndEffort(t *testing.T) {
+	d := &Daemon{store: store.New()}
+	d.store.SetSetting(SettingChiefModelPrefix+"claude", "opus")
+	d.store.SetSetting(SettingChiefEffortPrefix+"claude", "max")
+	d.store.SetSetting(SettingDefaultModelPrefix+"claude", "sonnet")
+	d.store.SetSetting(SettingDefaultEffortPrefix+"claude", "medium")
+
+	// 1. An explicit per-spawn pin always wins, chief or not.
+	if got := d.resolveLaunchModel("claude", false, "haiku"); got != "haiku" {
+		t.Fatalf("explicit pin (non-chief) = %q, want %q", got, "haiku")
+	}
+	if got := d.resolveLaunchModel("claude", true, "haiku"); got != "haiku" {
+		t.Fatalf("explicit pin (chief) = %q, want %q", got, "haiku")
+	}
+
+	// 2. No pin, chief launch: chief_model_<agent> wins over default_model_<agent>.
+	if got := d.resolveLaunchModel("claude", true, ""); got != "opus" {
+		t.Fatalf("chief resolve = %q, want chief override %q", got, "opus")
+	}
+	if got := d.resolveLaunchEffort("claude", true, ""); got != "max" {
+		t.Fatalf("chief resolve effort = %q, want chief override %q", got, "max")
+	}
+
+	// 3. No pin, non-chief launch: falls through to default_model_<agent> (the
+	// new configurable fallback that previously did not exist for non-chief
+	// launches).
+	if got := d.resolveLaunchModel("claude", false, ""); got != "sonnet" {
+		t.Fatalf("non-chief resolve = %q, want default %q", got, "sonnet")
+	}
+	if got := d.resolveLaunchEffort("claude", false, ""); got != "medium" {
+		t.Fatalf("non-chief resolve effort = %q, want default %q", got, "medium")
+	}
+
+	// 4. No pin, no settings at all for an agent: agent's own default (empty).
+	if got := d.resolveLaunchModel("codex", false, ""); got != "" {
+		t.Fatalf("no-setting resolve = %q, want \"\"", got)
 	}
 }
 

--- a/internal/daemon/spawn_pipeline.go
+++ b/internal/daemon/spawn_pipeline.go
@@ -220,16 +220,13 @@ func (d *Daemon) resolveSpawnIntent(req *spawnRequest) (*spawnPlan, *spawnReject
 	}
 	plan.chiefAssigned = d.maybeAssignChiefOnSpawn(msg.ID, req.agent, requestedChief, req.existingSession)
 	plan.isChief = d.isChiefOfStaffSession(msg.ID)
-	if plan.spawnOpts.Model == "" {
-		// No per-spawn pin (delegation); a chief launch falls back to the
-		// chief_model_<agent> setting.
-		plan.spawnOpts.Model = d.chiefLaunchModel(req.agent, plan.isChief)
-	}
-	if plan.spawnOpts.Effort == "" {
-		// No per-spawn pin (delegation); a chief launch falls back to the
-		// chief_effort_<agent> setting.
-		plan.spawnOpts.Effort = d.chiefLaunchEffort(req.agent, plan.isChief)
-	}
+	// Precedence: an explicit per-spawn pin (delegation) wins outright; a chief
+	// launch next falls back to chief_model_<agent>/chief_effort_<agent>; every
+	// launch (chief or not) then falls back to the operator-configured
+	// default_model_<agent>/default_effort_<agent>; otherwise the agent's own
+	// built-in default (empty, meaning no --model/--effort flag).
+	plan.spawnOpts.Model = d.resolveLaunchModel(req.agent, plan.isChief, plan.spawnOpts.Model)
+	plan.spawnOpts.Effort = d.resolveLaunchEffort(req.agent, plan.isChief, plan.spawnOpts.Effort)
 	if launch := req.policy.unattendedLaunch; !launch.IsZero() {
 		if err := launch.Validate(); err != nil {
 			plan.rollback(d, msg.ID)

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -55,6 +55,19 @@ const (
 	// model_reasoning_effort). Empty/unset => the agent's own default. Only
 	// consulted for chief launches.
 	SettingChiefEffortPrefix = "chief_effort_"
+	// SettingDefaultModelPrefix + agent (e.g. "default_model_claude") pins the
+	// model EVERY interactive launch of that agent uses (chief or not), passed
+	// through as --model. Empty/unset => the agent's own default. A per-spawn
+	// pin (delegation) or a chief_model_<agent> override still takes priority
+	// over this; see resolveLaunchModel.
+	SettingDefaultModelPrefix = "default_model_"
+	// SettingDefaultEffortPrefix + agent (e.g. "default_effort_claude") pins
+	// the reasoning effort EVERY interactive launch of that agent uses (chief
+	// or not), passed through as the agent's native effort mechanism (Claude
+	// --effort, Codex model_reasoning_effort). Empty/unset => the agent's own
+	// default. A per-spawn pin (delegation) or a chief_effort_<agent> override
+	// still takes priority over this; see resolveLaunchEffort.
+	SettingDefaultEffortPrefix = "default_effort_"
 	// SettingNotebookRoot overrides the notebook's filesystem root. Empty =>
 	// the profile-derived default (~/attn-notebook[-profile]).
 	SettingNotebookRoot = "notebook.root"
@@ -331,6 +344,50 @@ func (d *Daemon) chiefLaunchEffort(agent string, chief bool) string {
 	return strings.TrimSpace(d.store.GetSetting(SettingChiefEffortPrefix + strings.ToLower(strings.TrimSpace(agent))))
 }
 
+// defaultLaunchModel returns the configured default model for EVERY
+// interactive launch of the given agent (from default_model_<agent>), chief
+// or not, or "" — the agent's own default — when none is configured.
+func (d *Daemon) defaultLaunchModel(agent string) string {
+	return strings.TrimSpace(d.store.GetSetting(SettingDefaultModelPrefix + strings.ToLower(strings.TrimSpace(agent))))
+}
+
+// defaultLaunchEffort returns the configured default reasoning effort for
+// EVERY interactive launch of the given agent (from default_effort_<agent>),
+// chief or not, or "" — the agent's own default — when none is configured.
+func (d *Daemon) defaultLaunchEffort(agent string) string {
+	return strings.TrimSpace(d.store.GetSetting(SettingDefaultEffortPrefix + strings.ToLower(strings.TrimSpace(agent))))
+}
+
+// resolveLaunchModel picks the model an interactive launch of the given agent
+// should use, honoring precedence: an explicit per-spawn pin (requested,
+// e.g. a delegation's --model) wins outright; otherwise a chief-of-staff
+// launch takes chief_model_<agent>; otherwise every launch (chief or not)
+// falls back to the operator-configured default_model_<agent>; otherwise the
+// agent's own built-in default (an empty string, meaning no --model flag).
+func (d *Daemon) resolveLaunchModel(agent string, chief bool, requested string) string {
+	if requested != "" {
+		return requested
+	}
+	if model := d.chiefLaunchModel(agent, chief); model != "" {
+		return model
+	}
+	return d.defaultLaunchModel(agent)
+}
+
+// resolveLaunchEffort mirrors resolveLaunchModel for reasoning effort:
+// explicit per-spawn pin, then chief_effort_<agent> for chief launches, then
+// the operator-configured default_effort_<agent> for any launch, then the
+// agent's own default.
+func (d *Daemon) resolveLaunchEffort(agent string, chief bool, requested string) string {
+	if requested != "" {
+		return requested
+	}
+	if effort := d.chiefLaunchEffort(agent, chief); effort != "" {
+		return effort
+	}
+	return d.defaultLaunchEffort(agent)
+}
+
 // chiefContextWindowCap returns the effective context-window token cap for a
 // chief-of-staff launch, or 0 (no cap) when this is not a chief launch. Mirrors
 // chiefLaunchModel: the policy (what the cap is, and that only the chief gets
@@ -404,6 +461,14 @@ func (d *Daemon) validateSetting(key, value string) error {
 			// Effort levels are agent-native (claude: low/medium/high/xhigh/max,
 			// codex: minimal/low/medium/high/xhigh); accept any value and let
 			// the agent reject bad ones. The UI constrains input.
+			return nil
+		}
+		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(key)), SettingDefaultModelPrefix) {
+			// Model names/aliases are free-form, same as chief_model_<agent>.
+			return nil
+		}
+		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(key)), SettingDefaultEffortPrefix) {
+			// Effort levels are agent-native, same as chief_effort_<agent>.
 			return nil
 		}
 		if _, ok := isAgentExecutableSettingKey(key); ok {


### PR DESCRIPTION
Previously the only settings-driven way to pin a model/reasoning-effort were chief_model_<agent>/chief_effort_<agent>, which apply ONLY to chief-of-staff launches (internal/daemon/ws_settings.go, chiefLaunchModel/chiefLaunchEffort). Every regular (non-chief) session had no configurable default: SpawnOpts.Model/Effort stayed empty unless a delegation passed --model/--effort, so Claude (and Codex) always fell through to their own hardcoded CLI default with no way for an operator to change it (internal/agent/claude.go BuildCommand, internal/agent/ driver.go SpawnOpts).

Add a new, additive settings layer:
- SettingDefaultModelPrefix ("default_model_<agent>") and SettingDefaultEffortPrefix ("default_effort_<agent>") in internal/daemon/ws_settings.go, validated the same way as the existing chief_* prefixes (free-form, agent decides what is valid).
- daemon.defaultLaunchModel/defaultLaunchEffort read those settings for ANY launch (chief or not).
- daemon.resolveLaunchModel/resolveLaunchEffort centralize precedence: explicit per-spawn pin > chief_model_/chief_effort_ (chief launches only) > default_model_/default_effort_ (every launch) > agent's own default. internal/daemon/ws_pty.go's spawn handler now calls these instead of only consulting chiefLaunchModel/chiefLaunchEffort.
- SettingsModal.tsx gets a new "Default model & effort" section mirroring the existing "Chief-of-staff model & effort" section/tests, so users can set this from the app without touching the websocket protocol by hand.

Unattended launches are unaffected: they zero Model/Effort after this resolution step, same as before.

Tests: internal/daemon/daemon_test.go (TestDaemon_DefaultLaunchModelAndEffort, TestDaemon_ResolveLaunchModelAndEffort, extended TestDaemon_SettingsValidation); app/src/components/SettingsModal.test.tsx (6 new cases mirroring the chief ones). go build/vet/gofmt clean; go test ./internal/daemon/... ./internal/agent/... passes; vitest run src/components/SettingsModal.test.tsx passes (52/52).