### PR TITLE
OrbStack remote endpoint, tr205 probe legs, and the shell-pane kill-path fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ starts are the baseline.
   `ATTN_HARNESS_PROFILE` overrides it.
 - Production requires both `ATTN_HARNESS_PROFILE=` and `--run-against-prod`.
 - On failure, inspect captured pane text and native screenshots before diagnosis.
+- Remote scenarios target the local OrbStack VM (`attn-remote@orb`); provision with `pnpm --dir app run real-app:provision-remote`.
 
 ## Test safety
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-22]
+
+### Fixed
+- **Terminal panes no longer get stuck narrower than their pane after closing a
+  neighboring split.** Content now grows to fill the pane again; previously it
+  could stay wrapped at the old, narrower width until an unrelated layout change
+  triggered a redraw.
+- Closing a shell pane now hangs the shell up promptly instead of stalling ~10 seconds and force-killing it; remote pane/session close reliably confirms worker teardown instead of timing out mid-kill.
+
 ## [2026-07-21]
 
 ### Fixed

--- a/app/package.json
+++ b/app/package.json
@@ -18,6 +18,7 @@
     "real-app:repro-panes": "node scripts/real-app-harness/repro-older-pane-writability.mjs",
     "real-app:bridge-smoke": "node scripts/real-app-harness/bridge-smoke.mjs",
     "real-app:bridge-remote-hub": "node scripts/real-app-harness/bridge-remote-hub.mjs",
+    "real-app:provision-remote": "bash scripts/real-app-harness/provision-orb-remote.sh",
     "real-app:bridge-repro-shells": "node scripts/real-app-harness/bridge-repro-shell-return.mjs",
     "real-app:bridge-repro-existing-shells": "node scripts/real-app-harness/bridge-repro-existing-shells.mjs",
     "real-app:bridge-repro-main": "node scripts/real-app-harness/bridge-repro-main-return.mjs",

--- a/app/scripts/real-app-harness/AGENTS.md
+++ b/app/scripts/real-app-harness/AGENTS.md
@@ -89,3 +89,23 @@ matters for the assertion.
 - Resolve pane IDs from daemon/app state. Do not hardcode legacy pane IDs such as `main` for new scenarios.
 - Empty workspaces are invalid user-visible state. Tests that create or observe one should assert it is removed or hidden.
 - Shortcut scenarios should exercise the documented app shortcuts or the same shortcut registry IDs used by the app.
+
+## Remote Endpoint Scenarios
+
+Remote scenarios (tr205, tr402-remote, tr502, tr504, bridge-remote-hub) default
+to the local OrbStack VM `attn-remote` (`attn-remote@orb`).
+`ATTN_HARNESS_REMOTE_SSH_TARGET` retargets all of them at once; each
+scenario's own per-scenario env var still wins over it. Provision or repair
+the VM with `pnpm run real-app:provision-remote`. Claude requires a one-time
+`claude /login` inside the VM. The hub daemon installs/updates the attn binary
+on the remote automatically (internal/hub bootstrapper), so the VM never needs
+a manual attn install.
+
+TR-205's matrix legs (`tr205-probe-codex`, `tr205-probe-claude`) run
+`attn _probe-tui` on the remote instead of a live agent: a deterministic
+agent-mimicking TUI whose styles are pinned to codex/claude VT vocabulary
+recorded under `internal/probetui/testdata`, with mirror tests in
+`internal/probetui` enforcing both directions. The real-agent legs
+(`tr205-codex`, `tr205-claude`) are `soakOnly` — excluded from the matrix,
+runnable via run-soak or manually — since they need credentials seeded in the
+VM. Re-capture the probe vocabulary with `go run ./cmd/agent-mirror`.

--- a/app/scripts/real-app-harness/bridge-remote-hub.mjs
+++ b/app/scripts/real-app-harness/bridge-remote-hub.mjs
@@ -7,7 +7,7 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 import WebSocket from 'ws';
 
-import { createRunContext, parseCommonArgs, printCommonHelp } from './common.mjs';
+import { createRunContext, DEFAULT_REMOTE_SSH_TARGET, parseCommonArgs, printCommonHelp } from './common.mjs';
 import { DaemonObserver } from './daemonObserver.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 
@@ -141,7 +141,7 @@ function saveText(filePath, value) {
 function parseArgs(argv) {
   const remaining = [];
   const options = {
-    sshTarget: process.env.ATTN_REMOTE_HUB_SSH_TARGET || 'ai-sandbox',
+    sshTarget: process.env.ATTN_REMOTE_HUB_SSH_TARGET || DEFAULT_REMOTE_SSH_TARGET,
     remoteDirectory: process.env.ATTN_REMOTE_HUB_REMOTE_DIRECTORY || '',
     remoteAgent: process.env.ATTN_REMOTE_HUB_REMOTE_AGENT || 'codex',
   };
@@ -755,7 +755,7 @@ async function main() {
     printCommonHelp('scripts/real-app-harness/bridge-remote-hub.mjs');
     console.log(`
 Remote hub options:
-  --ssh-target <target>        SSH target for remote daemon smoke (default: ai-sandbox)
+  --ssh-target <target>        SSH target for remote daemon smoke (default: attn-remote@orb — the provisioned OrbStack VM)
   --remote-directory <path>    Remote cwd for the spawned remote session
   --remote-agent <agent>       Agent for the spawned remote session (default: codex)
 `);

--- a/app/scripts/real-app-harness/common.mjs
+++ b/app/scripts/real-app-harness/common.mjs
@@ -11,6 +11,13 @@ import {
   profileForAppPath,
 } from './harnessProfile.mjs';
 
+// Default SSH target for remote-endpoint scenarios: the local OrbStack VM
+// provisioned by provision-orb-remote.sh. ATTN_HARNESS_REMOTE_SSH_TARGET
+// retargets every remote scenario at once; each scenario's own env var
+// still wins over it.
+export const DEFAULT_REMOTE_SSH_TARGET =
+  process.env.ATTN_HARNESS_REMOTE_SSH_TARGET || 'attn-remote@orb';
+
 export function parseCommonArgs(argv) {
   // Default to the active profile's install (the safe dev sibling unless
   // ATTN_PROFILE/ATTN_HARNESS_PROFILE says otherwise). Production requires both

--- a/app/scripts/real-app-harness/provision-orb-remote.sh
+++ b/app/scripts/real-app-harness/provision-orb-remote.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Provision (or re-provision) the local OrbStack VM that remote-endpoint
+# harness scenarios target as attn-remote@orb. Idempotent; safe to re-run.
+# One manual step remains after first provisioning: `claude /login` inside
+# the VM (macOS keeps Claude credentials in the Keychain, so they cannot be
+# copied in).
+set -euo pipefail
+
+VM_NAME="${ATTN_ORB_REMOTE_NAME:-attn-remote}"
+SSH_TARGET="${VM_NAME}@orb"
+
+echo "==> Checking for orbctl"
+if ! command -v orbctl >/dev/null 2>&1; then
+  echo "OrbStack is required: https://orbstack.dev" >&2
+  exit 1
+fi
+
+echo "==> Checking for existing VM '${VM_NAME}'"
+vm_list_output="$(orbctl list -f json 2>/dev/null || orbctl list 2>/dev/null || true)"
+if ! grep -q "${VM_NAME}" <<<"${vm_list_output}"; then
+  echo "==> Creating VM '${VM_NAME}' (ubuntu)"
+  orbctl create ubuntu "${VM_NAME}"
+else
+  echo "==> VM '${VM_NAME}' already exists"
+fi
+
+echo "==> Waiting for SSH on ${SSH_TARGET}"
+ssh_ready=0
+for _ in $(seq 1 30); do
+  if ssh -o BatchMode=yes -o ConnectTimeout=5 "${SSH_TARGET}" true 2>/dev/null; then
+    ssh_ready=1
+    break
+  fi
+  sleep 2
+done
+if [[ "${ssh_ready}" -ne 1 ]]; then
+  echo "SSH to ${SSH_TARGET} never became ready; check 'orbctl logs ${VM_NAME}'" >&2
+  exit 1
+fi
+echo "==> SSH is ready on ${SSH_TARGET}"
+
+echo "==> Installing base packages (git, nodejs, npm)"
+ssh -o BatchMode=yes "${SSH_TARGET}" 'sudo apt-get update -qq && sudo apt-get install -y -qq git nodejs npm'
+
+echo "==> Installing codex and claude CLIs"
+ssh -o BatchMode=yes "${SSH_TARGET}" 'sudo npm install -g @openai/codex @anthropic-ai/claude-code'
+
+echo "==> Verifying required tools are on PATH in the VM"
+missing_tools="$(ssh -o BatchMode=yes "${SSH_TARGET}" '
+  missing=""
+  for tool in git python3 ss codex claude; do
+    command -v "$tool" >/dev/null 2>&1 || missing="$missing $tool"
+  done
+  echo "$missing"
+')"
+if [[ -n "${missing_tools// /}" ]]; then
+  echo "Missing required tools in VM:${missing_tools}" >&2
+  exit 1
+fi
+echo "==> All required tools present: git python3 ss codex claude"
+
+echo "==> Checking codex auth"
+codex_auth_present=0
+if ssh -o BatchMode=yes "${SSH_TARGET}" 'test -f ~/.codex/auth.json' 2>/dev/null; then
+  codex_auth_present=1
+  echo "==> Codex auth already present in VM"
+elif [[ -f "${HOME}/.codex/auth.json" ]]; then
+  echo "==> Copying host codex auth into VM"
+  ssh -o BatchMode=yes "${SSH_TARGET}" 'mkdir -p ~/.codex'
+  ssh -o BatchMode=yes "${SSH_TARGET}" 'cat > ~/.codex/auth.json' < "${HOME}/.codex/auth.json"
+  ssh -o BatchMode=yes "${SSH_TARGET}" 'chmod 600 ~/.codex/auth.json'
+  codex_auth_present=1
+else
+  echo "WARNING: no host ~/.codex/auth.json found; log codex in inside the VM (ssh -t ${SSH_TARGET} codex login)" >&2
+fi
+
+echo "==> Checking claude auth"
+claude_auth_present=0
+if ssh -o BatchMode=yes "${SSH_TARGET}" 'test -f ~/.claude/.credentials.json' 2>/dev/null; then
+  claude_auth_present=1
+  echo "==> Claude auth already present in VM"
+else
+  echo "Claude needs a one-time interactive login inside the VM: ssh -t ${SSH_TARGET} claude /login"
+fi
+
+echo "==> Provisioning summary"
+echo "    VM name:     ${VM_NAME}"
+echo "    SSH target:  ${SSH_TARGET}"
+if [[ "${codex_auth_present}" -eq 1 ]]; then
+  echo "    codex auth:  present"
+else
+  echo "    codex auth:  MISSING"
+fi
+if [[ "${claude_auth_present}" -eq 1 ]]; then
+  echo "    claude auth: present"
+else
+  echo "    claude auth: MISSING (run: ssh -t ${SSH_TARGET} claude /login)"
+fi

--- a/app/scripts/real-app-harness/run-serial-matrix.mjs
+++ b/app/scripts/real-app-harness/run-serial-matrix.mjs
@@ -88,7 +88,7 @@ function harnessArtifactsRoot() {
 function printHelp() {
   console.log(`Usage:
   node scripts/real-app-harness/run-serial-matrix.mjs
-  node scripts/real-app-harness/run-serial-matrix.mjs --scenario tr205-codex --scenario tr504
+  node scripts/real-app-harness/run-serial-matrix.mjs --scenario tr205-probe-codex --scenario tr504
   node scripts/real-app-harness/run-serial-matrix.mjs --fail-fast
   node scripts/real-app-harness/run-serial-matrix.mjs --timeout-ms 180000
   node scripts/real-app-harness/run-serial-matrix.mjs --failed-only

--- a/app/scripts/real-app-harness/scenario-automation-lifecycle.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-lifecycle.mjs
@@ -169,11 +169,10 @@ function createCodexProbe(root) {
 
 const API_VERSION = 'attn.dev/automations/v1alpha1';
 
-function editRebindDefinitionYAML({ id, locationPath, enabled, executable, prompt }) {
+function editRebindDefinitionYAML({ id, locationPath, executable, prompt }) {
   return `api_version: ${API_VERSION}
 id: ${id}
 name: Slice 7 packaged edit-rebind proof
-enabled: ${enabled}
 trigger:
   type: scheduled
   schedule:
@@ -194,11 +193,10 @@ location:
 `;
 }
 
-function deleteResurrectDefinitionYAML({ id, locationPath, enabled, executable }) {
+function deleteResurrectDefinitionYAML({ id, locationPath, executable }) {
   return `api_version: ${API_VERSION}
 id: ${id}
 name: Slice 7 packaged delete-resurrect proof
-enabled: ${enabled}
 trigger:
   type: manual
 prompt: |
@@ -216,11 +214,10 @@ location:
 
 const CLEANUP_IDENTITY = 'mock.github.local/owner/repo';
 
-function cleanupLifecycleDefinitionYAML({ id, enabled, executable, repoPath, prompt }) {
+function cleanupLifecycleDefinitionYAML({ id, executable, repoPath, prompt }) {
   return `api_version: ${API_VERSION}
 id: ${id}
 name: Slice 7 packaged cleanup-dirty-safe proof
-enabled: ${enabled}
 trigger:
   type: github_review_requested
   repositories:
@@ -441,7 +438,7 @@ async function main() {
     let run2 = null;
     let run3 = null;
     await runner.step('leg1_edit_rebind', async () => {
-      fs.writeFileSync(editDefinitionFile, editRebindDefinitionYAML({ id: editID, locationPath: editFixture, enabled: true, executable: probe.executable, prompt: PROMPT_P1 }));
+      fs.writeFileSync(editDefinitionFile, editRebindDefinitionYAML({ id: editID, locationPath: editFixture, executable: probe.executable, prompt: PROMPT_P1 }));
       runJSON(binary, ['automation', 'apply', '--file', editDefinitionFile], daemonEnv);
       editApplied = true;
       await waitForScheduleAnchor(dbPath, editID);
@@ -455,7 +452,7 @@ async function main() {
       runner.assert(Boolean(run1.TicketID) && Boolean(run1.SessionID), 'P1 delivery reserves a ticket and session', run1);
       runner.assert(run1.LastError === '', 'P1 delivery has no error', run1);
 
-      fs.writeFileSync(editDefinitionFile, editRebindDefinitionYAML({ id: editID, locationPath: editFixture, enabled: true, executable: probe.executable, prompt: PROMPT_P2 }));
+      fs.writeFileSync(editDefinitionFile, editRebindDefinitionYAML({ id: editID, locationPath: editFixture, executable: probe.executable, prompt: PROMPT_P2 }));
       runJSON(binary, ['automation', 'apply', '--file', editDefinitionFile], daemonEnv);
 
       run2 = await poll(() => {
@@ -472,7 +469,7 @@ async function main() {
         { before: run1, after: run1AfterEdit },
       );
 
-      fs.writeFileSync(editDefinitionFile, editRebindDefinitionYAML({ id: editID, locationPath: editFixture, enabled: true, executable: probe.executable, prompt: PROMPT_P1 }));
+      fs.writeFileSync(editDefinitionFile, editRebindDefinitionYAML({ id: editID, locationPath: editFixture, executable: probe.executable, prompt: PROMPT_P1 }));
       runJSON(binary, ['automation', 'apply', '--file', editDefinitionFile], daemonEnv);
 
       run3 = await poll(() => {
@@ -488,8 +485,7 @@ async function main() {
         { run1, run2, run3 },
       );
 
-      fs.writeFileSync(editDefinitionFile, editRebindDefinitionYAML({ id: editID, locationPath: editFixture, enabled: false, executable: probe.executable, prompt: PROMPT_P1 }));
-      runJSON(binary, ['automation', 'apply', '--file', editDefinitionFile], daemonEnv);
+      runJSON(binary, ['automation', 'disable', editID], daemonEnv);
     });
 
     // Leg 2: delete-resurrect. Deleting has no UI affordance yet (see the
@@ -499,7 +495,7 @@ async function main() {
     // design A2/A4 actually shipped.
     let deleteRunID = '';
     await runner.step('leg2_delete_resurrect', async () => {
-      fs.writeFileSync(deleteDefinitionFile, deleteResurrectDefinitionYAML({ id: deleteID, locationPath: deleteFixture, enabled: true, executable: probe.executable }));
+      fs.writeFileSync(deleteDefinitionFile, deleteResurrectDefinitionYAML({ id: deleteID, locationPath: deleteFixture, executable: probe.executable }));
       runJSON(binary, ['automation', 'apply', '--file', deleteDefinitionFile], daemonEnv);
       deleteApplied = true;
 
@@ -536,7 +532,7 @@ async function main() {
       const deletedRow = sqliteRow(dbPath, `SELECT id, deleted_at FROM automation_definitions WHERE id='${sqlEscape(deleteID)}';`);
       runner.assert(deletedRow && deletedRow[1] !== '' && deletedRow[1] !== undefined, 'the definition row is soft-deleted (deleted_at set) in the DB', { deletedRow });
 
-      fs.writeFileSync(deleteDefinitionFile, deleteResurrectDefinitionYAML({ id: deleteID, locationPath: deleteFixture, enabled: true, executable: probe.executable }));
+      fs.writeFileSync(deleteDefinitionFile, deleteResurrectDefinitionYAML({ id: deleteID, locationPath: deleteFixture, executable: probe.executable }));
       runJSON(binary, ['automation', 'apply', '--file', deleteDefinitionFile], daemonEnv);
 
       await poll(async () => {
@@ -553,8 +549,7 @@ async function main() {
       const resurrectedRow = sqliteRow(dbPath, `SELECT id, deleted_at FROM automation_definitions WHERE id='${sqlEscape(deleteID)}';`);
       runner.assert(resurrectedRow && (resurrectedRow[1] ?? '') === '', 'the definition row is live again (deleted_at cleared) in the DB', { resurrectedRow });
 
-      fs.writeFileSync(deleteDefinitionFile, deleteResurrectDefinitionYAML({ id: deleteID, locationPath: deleteFixture, enabled: false, executable: probe.executable }));
-      runJSON(binary, ['automation', 'apply', '--file', deleteDefinitionFile], daemonEnv);
+      runJSON(binary, ['automation', 'disable', deleteID], daemonEnv);
     });
 
     // Leg 3: cleanup-dirty-safe. Three independent worktrees under ONE
@@ -568,7 +563,7 @@ async function main() {
     // dropped by the edits that rotated past them, so run1/run2 are
     // genuinely unbound and run3 is not.
     await runner.step('leg3_cleanup_dirty_safe', async () => {
-      fs.writeFileSync(cleanupDefinitionFile, cleanupLifecycleDefinitionYAML({ id: cleanupID, enabled: true, executable: probe.executable, repoPath: cleanupFixture.repo, prompt: CLEANUP_PROMPT_V1 }));
+      fs.writeFileSync(cleanupDefinitionFile, cleanupLifecycleDefinitionYAML({ id: cleanupID, executable: probe.executable, repoPath: cleanupFixture.repo, prompt: CLEANUP_PROMPT_V1 }));
       runJSON(binary, ['automation', 'apply', '--file', cleanupDefinitionFile], daemonEnv);
       cleanupApplied = true;
 
@@ -583,7 +578,7 @@ async function main() {
       await client.request('close_session', { sessionId: cleanRun.SessionID });
       await waitSessionGone(observer, cleanRun.SessionID, 'first cleanup-leg session to unregister');
 
-      fs.writeFileSync(cleanupDefinitionFile, cleanupLifecycleDefinitionYAML({ id: cleanupID, enabled: true, executable: probe.executable, repoPath: cleanupFixture.repo, prompt: CLEANUP_PROMPT_V2 }));
+      fs.writeFileSync(cleanupDefinitionFile, cleanupLifecycleDefinitionYAML({ id: cleanupID, executable: probe.executable, repoPath: cleanupFixture.repo, prompt: CLEANUP_PROMPT_V2 }));
       runJSON(binary, ['automation', 'apply', '--file', cleanupDefinitionFile], daemonEnv);
 
       await setRequested(mock.url, false);
@@ -608,7 +603,7 @@ async function main() {
       // A third edit rotates the binding again, dropping run2's binding (its
       // worktree is now unbound too, just dirty) and minting run3 as the
       // definition's new current thread.
-      fs.writeFileSync(cleanupDefinitionFile, cleanupLifecycleDefinitionYAML({ id: cleanupID, enabled: true, executable: probe.executable, repoPath: cleanupFixture.repo, prompt: CLEANUP_PROMPT_V3 }));
+      fs.writeFileSync(cleanupDefinitionFile, cleanupLifecycleDefinitionYAML({ id: cleanupID, executable: probe.executable, repoPath: cleanupFixture.repo, prompt: CLEANUP_PROMPT_V3 }));
       runJSON(binary, ['automation', 'apply', '--file', cleanupDefinitionFile], daemonEnv);
 
       await setRequested(mock.url, false);
@@ -674,8 +669,7 @@ async function main() {
         second,
       );
 
-      fs.writeFileSync(cleanupDefinitionFile, cleanupLifecycleDefinitionYAML({ id: cleanupID, enabled: false, executable: probe.executable, repoPath: cleanupFixture.repo, prompt: CLEANUP_PROMPT_V3 }));
-      runJSON(binary, ['automation', 'apply', '--file', cleanupDefinitionFile], daemonEnv);
+      runJSON(binary, ['automation', 'disable', cleanupID], daemonEnv);
     });
 
     runner.finishSuccess({ profile, editID, deleteID, cleanupID, run1, run2, run3, deleteRunID });
@@ -694,20 +688,17 @@ async function main() {
     if (daemonEnv) {
       if (editApplied && editFixture && fs.existsSync(editFixture)) {
         try {
-          fs.writeFileSync(editDefinitionFile, editRebindDefinitionYAML({ id: editID, locationPath: editFixture, enabled: false, executable: probe.executable, prompt: PROMPT_P1 }));
-          run(binary, ['automation', 'apply', '--file', editDefinitionFile], daemonEnv);
+          run(binary, ['automation', 'disable', editID], daemonEnv);
         } catch {}
       }
       if (deleteApplied && deleteFixture && fs.existsSync(deleteFixture)) {
         try {
-          fs.writeFileSync(deleteDefinitionFile, deleteResurrectDefinitionYAML({ id: deleteID, locationPath: deleteFixture, enabled: false, executable: probe.executable }));
-          run(binary, ['automation', 'apply', '--file', deleteDefinitionFile], daemonEnv);
+          run(binary, ['automation', 'disable', deleteID], daemonEnv);
         } catch {}
       }
       if (cleanupApplied && cleanupFixture) {
         try {
-          fs.writeFileSync(cleanupDefinitionFile, cleanupLifecycleDefinitionYAML({ id: cleanupID, enabled: false, executable: probe.executable, repoPath: cleanupFixture.repo, prompt: CLEANUP_PROMPT_V3 }));
-          run(binary, ['automation', 'apply', '--file', cleanupDefinitionFile], daemonEnv);
+          run(binary, ['automation', 'disable', cleanupID], daemonEnv);
         } catch {}
       }
     }

--- a/app/scripts/real-app-harness/scenario-tr205-remote-relaunch-close-redraw.mjs
+++ b/app/scripts/real-app-harness/scenario-tr205-remote-relaunch-close-redraw.mjs
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import {
   createSessionAndWaitForInitialPane,
   assertCommonTargetAllowed,
+  DEFAULT_REMOTE_SSH_TARGET,
   launchFreshAppAndConnect,
   parseCommonArgs,
   printCommonHelp,
@@ -19,7 +23,9 @@ import {
   assertPaneVisibleContent,
   assertPaneVisibleContentPreserved,
   captureSessionArtifacts,
+  sleep,
   waitForFirstWorkspacePane,
+  waitForPaneShellReady,
   waitForPaneText,
   waitForNewShellPane,
   waitForPaneState,
@@ -41,6 +47,7 @@ import {
   removeStaleHarnessScenarioSessions,
   waitForEndpointConnected,
 } from './scenarioRemote.mjs';
+import { currentHarnessProfile } from './harnessProfile.mjs';
 
 function isNativeCaptureUnavailable(error) {
   const message = error instanceof Error ? error.message : String(error || '');
@@ -59,7 +66,7 @@ function parseArgs(argv) {
 
   const options = {
     ...parseCommonArgs([]),
-    sshTarget: process.env.ATTN_REMOTE_RELAUNCH_CLOSE_REDRAW_SSH_TARGET || 'ai-sandbox',
+    sshTarget: process.env.ATTN_REMOTE_RELAUNCH_CLOSE_REDRAW_SSH_TARGET || DEFAULT_REMOTE_SSH_TARGET,
     remoteDirectory: process.env.ATTN_REMOTE_RELAUNCH_CLOSE_REDRAW_REMOTE_DIRECTORY || '',
     remoteAgent: process.env.ATTN_REMOTE_RELAUNCH_CLOSE_REDRAW_REMOTE_AGENT || 'codex',
   };
@@ -113,6 +120,148 @@ async function seedTranscriptAnchor(client, sessionId, paneId, anchorPrompt, anc
   );
 }
 
+const PROBE_AGENT_PREFIX = 'probe:';
+
+// `--remote-agent probe:codex` / `probe:claude` select the deterministic
+// `attn _probe-tui` fixture instead of a live agent. Returns null for any
+// other --remote-agent value (the real-agent path is unaffected).
+function parseProbeStyle(remoteAgent) {
+  const raw = String(remoteAgent || '');
+  if (!raw.startsWith(PROBE_AGENT_PREFIX)) {
+    return null;
+  }
+  const style = raw.slice(PROBE_AGENT_PREFIX.length).trim().toLowerCase();
+  if (style !== 'codex' && style !== 'claude') {
+    throw new Error(`Unsupported probe style in --remote-agent '${remoteAgent}' (expected probe:codex or probe:claude)`);
+  }
+  return style;
+}
+
+// Mirrors remoteBinaryName in internal/hub/ssh.go:29 — default profile
+// installs as "attn", named profiles install as "attn-<profile>".
+export function remoteProbeBinaryName(profile) {
+  const trimmed = String(profile || '').trim();
+  return trimmed === '' ? 'attn' : `attn-${trimmed}`;
+}
+
+// Mirrors the remote binary resolution in internal/hub/ssh.go:69 (used by
+// remoteAttnCommand) so the probe launches from whichever location the hub
+// actually installed to. This has to be resolved IN THE REMOTE SHELL, not
+// precomputed in JS: the launchEnv ATTN_REMOTE_ATTN_BIN this scenario passes
+// to the packaged app only reaches a daemon process it spawns fresh — an
+// already-running daemon (the common case once the harness reuses a live
+// app) never sees it, so the bootstrapper installs to the default
+// $HOME/.local/bin/<binaryName> path instead. Precomputing the path in JS
+// guesses which world the daemon is in and guesses wrong whenever a daemon
+// was already running; asking the shell to fall back the same way
+// remoteAttnCommand does is the only way to match the actual install
+// location in both worlds.
+export function buildProbeLaunchCommand(binaryName, style) {
+  return `ATTN_BIN="\${ATTN_REMOTE_ATTN_BIN:-$HOME/.local/bin/${binaryName}}"; if [ ! -x "$ATTN_BIN" ] && [ -z "\${ATTN_REMOTE_ATTN_BIN:-}" ]; then ATTN_BIN="$(command -v ${binaryName} 2>/dev/null || true)"; fi; exec "$ATTN_BIN" _probe-tui --style ${style}`;
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// The probe's style row, independent of geometry/seq — mirrors bannerStyleRow
+// in internal/probetui/probetui.go ("style=<style> seq=<seq> READY").
+function probeStyleRowRegex(style) {
+  return new RegExp(`style=${escapeRegExp(style)} seq=\\d+ READY`);
+}
+
+// Truncation-tolerant style identity: just `style=<style>`, 11-12 chars, so it
+// survives right-truncation in panes as narrow as ~20 cols where the full
+// "style=<style> seq=<n> READY" row (24 chars) cannot fit. Used by the at-grid
+// wait, where the geometry row already proves a fresh repaint; full-row
+// readiness matching stays width-safe because it only runs pre-split at full
+// pane width (prepareRemoteProbeBaseline).
+export function probeStyleIdentityRegex(style) {
+  return new RegExp(`style=${escapeRegExp(style)}(?=\\s|$)`);
+}
+
+// Geometry and style are painted as two SEPARATE rows (bannerGeometryRow /
+// bannerStyleRow in internal/probetui/probetui.go) — split because a single
+// combined banner line truncated past recognition in narrow (~20-31 col)
+// panes. Both matchers must pass independently against the pane's joined
+// visible text; neither row alone proves the fixture is both alive and
+// painting the requested style.
+export function probeBannerReadyMatchers(style) {
+  return [/ATTN-PROBE \d+x\d+/, probeStyleRowRegex(style)];
+}
+
+// The probe's geometry row pinned to an exact grid — used to confirm the
+// fixture has repainted at the pane's *current* geometry after a
+// resize/relaunch, not a stale pre-resize frame. `(?!\d)` guards against a
+// grid like 31x2 matching as a prefix of 31x25.
+export function buildProbeBannerAtGridRegex(cols, rows) {
+  return new RegExp(`ATTN-PROBE ${cols}x${rows}(?!\\d)`);
+}
+
+// Additional probe-mode-only geometry assertion: waits for the pane's visible
+// content to contain the geometry row pinned to the pane's *current* grid
+// (cols x rows) AND the style identity for the expected style, so a redraw
+// claim is verified against ground truth instead of density heuristics alone.
+// The style check uses the truncation-tolerant identity regex, not the full
+// READY row, because narrow post-split panes truncate the style row.
+async function waitForProbeBannerAtGrid(client, sessionId, paneId, style, timeoutMs = 20_000) {
+  const styleRegex = probeStyleIdentityRegex(style);
+  return waitForPaneState(
+    client,
+    sessionId,
+    paneId,
+    (state) => {
+      const visibleContent = state?.pane?.visibleContent || null;
+      const cols = visibleContent?.cols;
+      const rows = Array.isArray(visibleContent?.lines) ? visibleContent.lines.length : null;
+      if (typeof cols !== 'number' || typeof rows !== 'number') {
+        return false;
+      }
+      const joined = (visibleContent.lines || []).join('\n');
+      return buildProbeBannerAtGridRegex(cols, rows).test(joined) && styleRegex.test(joined);
+    },
+    `pane ${paneId} probe banner at current grid (style=${style})`,
+    timeoutMs,
+  );
+}
+
+// Probe-mode counterpart to prepareRemoteAgentBaseline: the session is spawned
+// with agent 'shell' (not the probe style), so the initial pane is a plain
+// shell. Launch the probe TUI in it and wait for its readiness banner — the
+// probe reads no input, so there is no transcript-anchor prompt to seed; the
+// banner itself is the anchor for the rest of the scenario.
+async function prepareRemoteProbeBaseline(client, sessionId, style) {
+  await client.request('select_session', { sessionId });
+  const initialPane = await waitForFirstWorkspacePane(client, sessionId, `initial pane for probe session ${sessionId}`, 30_000);
+  const paneId = initialPane.paneId;
+  await waitForPaneVisible(client, sessionId, paneId, 20_000);
+  await waitForPaneShellReady(client, sessionId, paneId, {
+    timeoutMs: 30_000,
+    description: `probe pane ${paneId} shell ready before launching probe TUI`,
+  });
+  // Text and the doorbell CR are sent as SEPARATE write_pane calls — a fast
+  // burst ending in CR is treated as a bracketed paste and never submits.
+  const probeCommand = buildProbeLaunchCommand(remoteProbeBinaryName(currentHarnessProfile()), style);
+  await client.request('write_pane', { sessionId, paneId, text: probeCommand, submit: false });
+  await sleep(300);
+  await client.request('write_pane', { sessionId, paneId, text: '\r', submit: false });
+  const readyMatchers = probeBannerReadyMatchers(style);
+  await waitForPaneText(
+    client,
+    sessionId,
+    paneId,
+    (text) => readyMatchers.every((matcher) => matcher.test(text)),
+    `probe TUI ready banner (style=${style}) in pane ${paneId}`,
+    45_000,
+  );
+  // Stable across seq and relaunch — unlike the real-agent transcript anchor,
+  // this text never scrolls out or gets collapsed by agent redraw behavior.
+  // Just the geometry row's fixed prefix: the style row can itself truncate
+  // in very narrow panes, so it must not be the anchor other assertions key
+  // off of (see probeBannerReadyMatchers / bannerStyleRow).
+  return { paneId, requiredVisibleText: 'ATTN-PROBE' };
+}
+
 async function prepareRemoteAgentBaseline(client, runner, sessionId, remoteAgent, transcriptAnchorToken, transcriptAnchorPrompt) {
   const agent = String(remoteAgent || 'codex').toLowerCase();
   if (agent === 'claude') {
@@ -145,7 +294,7 @@ async function waitForPaneContentStable(client, sessionId, paneId, { intervalMs 
   }
 }
 
-async function captureInitialPaneHealthyState(client, runner, sessionId, paneId, prefix, descriptionBase, requiredVisibleText = null) {
+async function captureInitialPaneHealthyState(client, runner, sessionId, paneId, prefix, descriptionBase, requiredVisibleText = null, probeStyle = null) {
   await waitForPaneVisible(client, sessionId, paneId, 30_000);
   // No scroll: captures assert on the live bottom viewport — agent startup output has
   // outgrown one screen, so top-of-scrollback holds only banners, and the bottom is
@@ -160,6 +309,12 @@ async function captureInitialPaneHealthyState(client, runner, sessionId, paneId,
     timeoutMs: 30_000,
     description: `${descriptionBase} visible content`,
   });
+  if (probeStyle) {
+    // Probe mode only: verify the banner has repainted at the pane's current
+    // grid, not just that dense content is present (ground truth on top of
+    // the density heuristic above).
+    await waitForProbeBannerAtGrid(client, sessionId, paneId, probeStyle, 30_000);
+  }
   await assertPaneCoverage(client, sessionId, paneId, {
     minWidthRatio: 0.8,
     minHeightRatio: 0.7,
@@ -212,6 +367,7 @@ async function closePaneAndAssertRecovery({
   enforceNativeStability = true,
   requiredVisibleText = null,
   preserveVisibleContent = true,
+  probeStyle = null,
 }) {
   await client.request('select_session', { sessionId });
   await waitForPaneVisible(client, sessionId, initialPaneId, 20_000);
@@ -233,7 +389,13 @@ async function closePaneAndAssertRecovery({
     `${label} initial pane width recovery`,
     20_000,
   );
-  if (preserveVisibleContent) {
+  // Probe mode skips line-anchor preservation: every probe row encodes the
+  // current geometry/frame seq (by design), so baseline lines from a different
+  // grid can never match. The waitForProbeBannerAtGrid call below is the
+  // probe-mode replacement — it proves a fresh repaint at the recovered grid,
+  // which is strictly stronger evidence of redraw recovery than stale-line
+  // matching.
+  if (preserveVisibleContent && !probeStyle) {
     await assertPaneVisibleContentPreserved(
       client,
       sessionId,
@@ -266,6 +428,11 @@ async function closePaneAndAssertRecovery({
         description: `${label} initial pane anchor visibility`,
       })
     : null;
+  if (probeStyle) {
+    // Probe mode only: same ground-truth grid check as
+    // captureInitialPaneHealthyState, applied at this close/recovery point.
+    await waitForProbeBannerAtGrid(client, sessionId, initialPaneId, probeStyle, 20_000);
+  }
   await assertPaneCoverage(client, sessionId, initialPaneId, {
     minWidthRatio: 0.85,
     minHeightRatio: 0.7,
@@ -324,16 +491,24 @@ async function main() {
   if (help) {
     printCommonHelp('scripts/real-app-harness/scenario-tr205-remote-relaunch-close-redraw.mjs');
     console.log(`Additional options:
-  --ssh-target <target>          SSH target for the remote endpoint (default: ai-sandbox)
+  --ssh-target <target>          SSH target for the remote endpoint (default: attn-remote@orb — the provisioned OrbStack VM)
   --remote-directory <path>      Remote cwd for the spawned session (default: remote $HOME)
-  --remote-agent <agent>         Agent for the remote session (default: codex)
+  --remote-agent <agent>         Agent for the remote session (default: codex). Also accepts
+                                  probe:codex / probe:claude to run the deterministic
+                                  'attn _probe-tui' fixture instead of a live agent.
 `);
     return;
   }
 
+  const probeStyle = parseProbeStyle(options.remoteAgent);
+  const isProbeMode = probeStyle !== null;
+  // Probe mode spawns a plain shell — the scenario types the probe TUI
+  // command into it itself, rather than asking the daemon to launch an agent.
+  const spawnAgent = isProbeMode ? 'shell' : options.remoteAgent;
+
   const runner = createScenarioRunner(options, {
     scenarioId: 'TR-205',
-    tier: 'tier3-remote-real-agent',
+    tier: isProbeMode ? 'tier3-remote-probe' : 'tier3-remote-real-agent',
     prefix: 'scenario-tr205-remote-relaunch-close-redraw',
     metadata: {
       sshTarget: options.sshTarget,
@@ -370,6 +545,11 @@ async function main() {
   let finalMainState = null;
   const transcriptAnchorToken = `TR205ANCHOR${Date.now()}`;
   const transcriptAnchorPrompt = buildTranscriptAnchorPrompt(transcriptAnchorToken, 4);
+  // The stable anchor text used for redraw/recovery assertions throughout the
+  // rest of the run: transcriptAnchorToken for real agents, or the probe's
+  // ready banner (set once prepareRemoteProbeBaseline/prepareRemoteAgentBaseline
+  // returns) in probe mode.
+  let anchorText = transcriptAnchorToken;
   let cleanupStarted = false;
 
   const runFinalCleanup = async () => {
@@ -434,7 +614,7 @@ async function main() {
         observer,
         cwd: remoteDirectory,
         label: `tr205-${runner.runId}`,
-        agent: options.remoteAgent,
+        agent: spawnAgent,
         endpointId: endpoint.id,
         waitForInitialPaneVisible: false,
       });
@@ -449,15 +629,18 @@ async function main() {
 
     await runner.step('capture_baseline_initial_pane', async () => {
       await client.request('select_session', { sessionId });
-      const baseline = await prepareRemoteAgentBaseline(
-        client,
-        runner,
-        sessionId,
-        options.remoteAgent,
-        transcriptAnchorToken,
-        transcriptAnchorPrompt,
-      );
+      const baseline = isProbeMode
+        ? await prepareRemoteProbeBaseline(client, sessionId, probeStyle)
+        : await prepareRemoteAgentBaseline(
+            client,
+            runner,
+            sessionId,
+            options.remoteAgent,
+            transcriptAnchorToken,
+            transcriptAnchorPrompt,
+          );
       initialPaneId = baseline.paneId;
+      anchorText = baseline.requiredVisibleText;
       baselineMainState = await captureInitialPaneHealthyState(
         client,
         runner,
@@ -465,7 +648,8 @@ async function main() {
         initialPaneId,
         '01-baseline-initial-pane',
         'baseline initial pane before relaunch-close scenario',
-        baseline.requiredVisibleText,
+        anchorText,
+        isProbeMode ? probeStyle : null,
       );
       await captureSessionArtifacts(client, runner.runDir, '01-baseline', sessionId);
     });
@@ -488,7 +672,7 @@ async function main() {
         30_000,
       );
       await assertPaneVisibleContent(client, sessionId, initialPaneId, {
-        contains: transcriptAnchorToken,
+        contains: anchorText,
         allowWrappedContains: true,
         minNonEmptyLines: 8,
         minDenseLines: 3,
@@ -499,6 +683,9 @@ async function main() {
         timeoutMs: 20_000,
         description: 'initial pane transcript anchor preserved after initial split before relaunch',
       });
+      if (isProbeMode) {
+        await waitForProbeBannerAtGrid(client, sessionId, initialPaneId, probeStyle, 20_000);
+      }
       // Settle the agent TUI before capturing the baseline the post-relaunch
       // redraw is compared against — capturing mid-stream picks anchors from a
       // transient frame that legitimately no longer exists after relaunch.
@@ -510,7 +697,8 @@ async function main() {
         initialPaneId,
         '02-after-initial-split-initial-pane',
         'initial pane after initial split before relaunch',
-        transcriptAnchorToken,
+        anchorText,
+        isProbeMode ? probeStyle : null,
       );
       await captureSessionArtifacts(client, runner.runDir, '02-after-initial-split', sessionId);
       return newPane?.paneId || null;
@@ -528,7 +716,8 @@ async function main() {
         initialPaneId,
         '03-post-relaunch-initial-pane',
         'restored initial pane after relaunch',
-        transcriptAnchorToken,
+        anchorText,
+        isProbeMode ? probeStyle : null,
       );
       await assertPaneVisibleContentPreserved(
         client,
@@ -541,8 +730,8 @@ async function main() {
           minAnchorMatches: 2,
           // Anchor only on token lines (claude echo/reflow flake). Safe here: the baseline
           // is initialSplitMainState, captured via captureInitialPaneHealthyState with
-          // requiredVisibleText: transcriptAnchorToken, which asserts contains: token first.
-          ignoreAnchorPatterns: tokenAnchorIgnorePatterns(transcriptAnchorToken),
+          // requiredVisibleText: anchorText, which asserts contains: token first.
+          ignoreAnchorPatterns: tokenAnchorIgnorePatterns(anchorText),
           timeoutMs: 20_000,
           description: 'restored initial pane content matches pre-relaunch split state',
         },
@@ -568,7 +757,7 @@ async function main() {
         30_000,
       );
       await assertPaneVisibleContent(client, sessionId, initialPaneId, {
-        contains: transcriptAnchorToken,
+        contains: anchorText,
         allowWrappedContains: true,
         minNonEmptyLines: 8,
         // The pane can be ~20 cols once three panes share the main area after the
@@ -580,6 +769,9 @@ async function main() {
         timeoutMs: 20_000,
         description: 'initial pane transcript anchor preserved after relaunch split from initial pane',
       });
+      if (isProbeMode) {
+        await waitForProbeBannerAtGrid(client, sessionId, initialPaneId, probeStyle, 20_000);
+      }
       await captureSessionArtifacts(client, runner.runDir, '04-after-initial-pane-split', sessionId);
       return newPane?.paneId || null;
     });
@@ -624,7 +816,8 @@ async function main() {
         minCharCountRatio: 0.35,
         minAnchorMatches: 1,
         enforceNativeStability: false,
-        requiredVisibleText: transcriptAnchorToken,
+        requiredVisibleText: anchorText,
+        probeStyle: isProbeMode ? probeStyle : null,
       });
       previousInitialPaneWidth = firstRecovered?.state?.pane?.bounds?.width ?? firstRecovered?.widthState?.pane?.bounds?.width ?? previousInitialPaneWidth;
       await captureSessionArtifacts(client, runner.runDir, '06-after-closing-shell-split', sessionId);
@@ -644,7 +837,8 @@ async function main() {
         minCharCountRatio: 0.55,
         minAnchorMatches: 2,
         enforceNativeStability: true,
-        requiredVisibleText: transcriptAnchorToken,
+        requiredVisibleText: anchorText,
+        probeStyle: isProbeMode ? probeStyle : null,
       });
       previousInitialPaneWidth = secondRecovered?.state?.pane?.bounds?.width ?? secondRecovered?.widthState?.pane?.bounds?.width ?? previousInitialPaneWidth;
       await captureSessionArtifacts(client, runner.runDir, '07-after-closing-initial-pane-split', sessionId);
@@ -670,8 +864,9 @@ async function main() {
         minCharCountRatio: 0.6,
         minAnchorMatches: 3,
         enforceNativeStability: true,
-        requiredVisibleText: transcriptAnchorToken,
+        requiredVisibleText: anchorText,
         preserveVisibleContent: options.remoteAgent !== 'claude',
+        probeStyle: isProbeMode ? probeStyle : null,
       });
       await captureSessionArtifacts(client, runner.runDir, '08-after-closing-initial-split', sessionId);
     });
@@ -684,6 +879,8 @@ async function main() {
       remoteDirectory,
       remoteAgent: options.remoteAgent,
       transcriptAnchorToken,
+      anchorText,
+      probeStyle,
       panes: {
         initialPaneId,
         initialShellPaneId,
@@ -735,7 +932,13 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.stack || error.message : String(error));
-  process.exit(1);
-});
+// Guards direct execution only — this module is imported directly by
+// scenario-tr205.test.mjs for its pure helpers, and importing must not
+// trigger a real scenario run or process.exit.
+const isMainModule = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isMainModule) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.stack || error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/app/scripts/real-app-harness/scenario-tr205.test.mjs
+++ b/app/scripts/real-app-harness/scenario-tr205.test.mjs
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildProbeBannerAtGridRegex,
+  buildProbeLaunchCommand,
+  probeBannerReadyMatchers,
+  probeStyleIdentityRegex,
+  remoteProbeBinaryName,
+} from './scenario-tr205-remote-relaunch-close-redraw.mjs';
+
+describe('remoteProbeBinaryName', () => {
+  it('resolves the default profile to "attn"', () => {
+    expect(remoteProbeBinaryName('')).toBe('attn');
+    expect(remoteProbeBinaryName(undefined)).toBe('attn');
+    expect(remoteProbeBinaryName('   ')).toBe('attn');
+  });
+
+  it('resolves a named profile to "attn-<profile>"', () => {
+    expect(remoteProbeBinaryName('dev')).toBe('attn-dev');
+    expect(remoteProbeBinaryName('agent7')).toBe('attn-agent7');
+  });
+});
+
+describe('buildProbeLaunchCommand', () => {
+  // Mirrors the remote binary resolution in internal/hub/ssh.go:69
+  // (remoteAttnCommand). This is resolved IN THE REMOTE SHELL, not
+  // precomputed in JS, because a live run showed the JS-precomputed path can
+  // diverge from where the daemon actually installed: an already-running
+  // daemon never sees this scenario's ATTN_REMOTE_ATTN_BIN launchEnv, so the
+  // bootstrapper falls back to installing at the default
+  // $HOME/.local/bin/<binaryName> path instead of the harness-scoped
+  // override path. The regression this guards against: someone "simplifying"
+  // this back to a single hardcoded path, which is exactly what broke live.
+  it('references both the ATTN_REMOTE_ATTN_BIN override and the default install path, and execs the probe', () => {
+    const command = buildProbeLaunchCommand('attn-fxm1', 'codex');
+    expect(command).toContain('${ATTN_REMOTE_ATTN_BIN:-');
+    expect(command).toContain('$HOME/.local/bin/attn-fxm1');
+    expect(command.trim().endsWith('_probe-tui --style codex')).toBe(true);
+  });
+});
+
+// Mirrors the two-row banner in internal/probetui/probetui.go
+// (bannerGeometryRow "ATTN-PROBE <cols>x<rows>", bannerStyleRow
+// "style=<style> seq=<seq> READY") — split across rows because a single
+// combined banner line truncated past recognition in narrow (~20-31 col)
+// panes.
+describe('probeBannerReadyMatchers', () => {
+  it('both matchers pass against a real two-row banner', () => {
+    const [geometryRegex, styleRegex] = probeBannerReadyMatchers('codex');
+    const text = 'ATTN-PROBE 80x24\nstyle=codex seq=1 READY';
+    expect(geometryRegex.test(text)).toBe(true);
+    expect(styleRegex.test(text)).toBe(true);
+  });
+
+  it('the style matcher is seq-invariant', () => {
+    const [, styleRegex] = probeBannerReadyMatchers('codex');
+    expect(styleRegex.test('style=codex seq=1 READY')).toBe(true);
+    expect(styleRegex.test('style=codex seq=999 READY')).toBe(true);
+  });
+
+  it('the style matcher rejects the wrong style', () => {
+    const [, styleRegex] = probeBannerReadyMatchers('codex');
+    expect(styleRegex.test('style=claude seq=1 READY')).toBe(false);
+  });
+
+  it('the style matcher rejects a malformed style row', () => {
+    const [, styleRegex] = probeBannerReadyMatchers('claude');
+    expect(styleRegex.test('style=claude seq=1')).toBe(false);
+    expect(styleRegex.test('some other output style=claude READY')).toBe(false);
+  });
+});
+
+describe('buildProbeBannerAtGridRegex', () => {
+  it('matches the geometry row pinned to the given grid, any seq', () => {
+    const regex = buildProbeBannerAtGridRegex(80, 24);
+    expect(regex.test('ATTN-PROBE 80x24\nstyle=codex seq=1 READY')).toBe(true);
+    expect(regex.test('ATTN-PROBE 80x24\nstyle=codex seq=42 READY')).toBe(true);
+  });
+
+  it('rejects the wrong grid', () => {
+    const regex = buildProbeBannerAtGridRegex(80, 24);
+    expect(regex.test('ATTN-PROBE 40x12\nstyle=codex seq=1 READY')).toBe(false);
+  });
+
+  it('rejects a grid that is a numeric prefix of another (31x2 must not match 31x25)', () => {
+    const regex = buildProbeBannerAtGridRegex(31, 2);
+    expect(regex.test('ATTN-PROBE 31x25\nstyle=codex seq=1 READY')).toBe(false);
+    expect(regex.test('ATTN-PROBE 31x2\nstyle=codex seq=1 READY')).toBe(true);
+  });
+});
+
+describe('probeStyleIdentityRegex', () => {
+  it('matches a right-truncated style row', () => {
+    const identityRegex = probeStyleIdentityRegex('codex');
+    const truncatedRow = 'style=codex seq=73 R'; // Truncated at 20 cols
+    expect(identityRegex.test(truncatedRow)).toBe(true);
+
+    // Verify the full-row matcher would have failed on the truncated row
+    const fullRowRegex = /style=codex seq=\d+ READY/;
+    expect(fullRowRegex.test(truncatedRow)).toBe(false);
+  });
+
+  it('does not cross-match styles', () => {
+    const codexRegex = probeStyleIdentityRegex('codex');
+    const claudeRegex = probeStyleIdentityRegex('claude');
+
+    expect(codexRegex.test('style=claude seq=2 READY')).toBe(false);
+    expect(claudeRegex.test('style=codex seq=2 READY')).toBe(false);
+  });
+
+  it('matches at end of line', () => {
+    const regex = probeStyleIdentityRegex('codex');
+    expect(regex.test('style=codex')).toBe(true);
+  });
+});

--- a/app/scripts/real-app-harness/scenario-tr401-local-codex-main-window-resize.mjs
+++ b/app/scripts/real-app-harness/scenario-tr401-local-codex-main-window-resize.mjs
@@ -60,13 +60,25 @@ function codexHeaderOptions(description) {
 function assertCompleteCodexHeaderFrame(state, description) {
   const lines = state?.pane?.visibleContent?.lines || [];
   const text = lines.join('\n');
+  // Codex may print extra bordered boxes (e.g. the "Update available!" banner
+  // when a newer release exists), so border counts over the whole pane are not
+  // meaningful. Anchor on the box that CONTAINS the header line instead: the
+  // nearest ╭ line above it and the nearest ╰ line below it must both be
+  // complete at the current width.
   const headerCount = (text.match(/OpenAI Codex/g) || []).length;
-  const topBorders = lines.filter((line) => line.includes('╭'));
-  const bottomBorders = lines.filter((line) => line.includes('╰'));
-  const completeTopBorder = topBorders.length === 1 && topBorders[0].trimEnd().endsWith('╮');
-  const completeBottomBorder = bottomBorders.length === 1 && bottomBorders[0].trimEnd().endsWith('╯');
-  if (headerCount !== 1 || !completeTopBorder || !completeBottomBorder) {
-    throw new Error(`${description}: expected one complete Codex header frame, found ${headerCount} headers, ${topBorders.length} top borders, and ${bottomBorders.length} bottom borders\n${text}`);
+  const headerIndex = lines.findIndex((line) => line.includes('OpenAI Codex'));
+  let topBorder = null;
+  for (let i = headerIndex; i >= 0; i -= 1) {
+    if (lines[i].includes('╭')) { topBorder = lines[i]; break; }
+  }
+  let bottomBorder = null;
+  for (let i = headerIndex; i >= 0 && i < lines.length; i += 1) {
+    if (lines[i].includes('╰')) { bottomBorder = lines[i]; break; }
+  }
+  const completeTopBorder = topBorder != null && topBorder.trimEnd().endsWith('╮');
+  const completeBottomBorder = bottomBorder != null && bottomBorder.trimEnd().endsWith('╯');
+  if (headerCount !== 1 || headerIndex < 0 || !completeTopBorder || !completeBottomBorder) {
+    throw new Error(`${description}: expected one complete Codex header frame, found ${headerCount} headers, topBorderComplete=${completeTopBorder}, bottomBorderComplete=${completeBottomBorder}\n${text}`);
   }
 }
 

--- a/app/scripts/real-app-harness/scenario-tr402-remote-close-redraw.mjs
+++ b/app/scripts/real-app-harness/scenario-tr402-remote-close-redraw.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { assertCommonTargetAllowed, parseCommonArgs, printCommonHelp } from './common.mjs';
+import { assertCommonTargetAllowed, DEFAULT_REMOTE_SSH_TARGET, parseCommonArgs, printCommonHelp } from './common.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 import { DaemonObserver } from './daemonObserver.mjs';
 import { createScenarioRunner } from './scenarioRunner.mjs';
@@ -33,7 +33,7 @@ function parseArgs(argv) {
 
   const options = {
     ...parseCommonArgs([]),
-    sshTarget: process.env.ATTN_REMOTE_CLOSE_REDRAW_SSH_TARGET || 'ai-sandbox',
+    sshTarget: process.env.ATTN_REMOTE_CLOSE_REDRAW_SSH_TARGET || DEFAULT_REMOTE_SSH_TARGET,
     remoteDirectory: process.env.ATTN_REMOTE_CLOSE_REDRAW_REMOTE_DIRECTORY || '',
     remoteAgent: process.env.ATTN_REMOTE_CLOSE_REDRAW_REMOTE_AGENT || 'codex',
   };
@@ -78,7 +78,7 @@ async function main() {
   if (help) {
     printCommonHelp('scripts/real-app-harness/scenario-tr402-remote-close-redraw.mjs');
     console.log(`Additional options:
-  --ssh-target <target>          SSH target for the remote endpoint (default: ai-sandbox)
+  --ssh-target <target>          SSH target for the remote endpoint (default: attn-remote@orb — the provisioned OrbStack VM)
   --remote-directory <path>      Remote cwd for the spawned session (default: remote $HOME)
   --remote-agent <agent>         Agent for the remote session (default: codex)
 `);

--- a/app/scripts/real-app-harness/scenario-tr502-remote-relaunch-splits.mjs
+++ b/app/scripts/real-app-harness/scenario-tr502-remote-relaunch-splits.mjs
@@ -3,6 +3,7 @@
 import {
   createSessionAndWaitForInitialPane,
   assertCommonTargetAllowed,
+  DEFAULT_REMOTE_SSH_TARGET,
   launchFreshAppAndConnect,
   parseCommonArgs,
   printCommonHelp,
@@ -61,7 +62,7 @@ function parseArgs(argv) {
 
   const options = {
     ...parseCommonArgs([]),
-    sshTarget: process.env.ATTN_REMOTE_RELAUNCH_SPLITS_SSH_TARGET || 'ai-sandbox',
+    sshTarget: process.env.ATTN_REMOTE_RELAUNCH_SPLITS_SSH_TARGET || DEFAULT_REMOTE_SSH_TARGET,
     remoteDirectory: process.env.ATTN_REMOTE_RELAUNCH_SPLITS_REMOTE_DIRECTORY || '',
     remoteAgent: process.env.ATTN_REMOTE_RELAUNCH_SPLITS_REMOTE_AGENT || 'codex',
     echoThresholdMs: Number.parseInt(process.env.ATTN_REMOTE_RELAUNCH_SPLITS_ECHO_THRESHOLD_MS || '2500', 10),
@@ -94,7 +95,7 @@ async function main() {
   if (help) {
     printCommonHelp('scripts/real-app-harness/scenario-tr502-remote-relaunch-splits.mjs');
     console.log(`Additional options:
-  --ssh-target <target>          SSH target for the remote endpoint (default: ai-sandbox)
+  --ssh-target <target>          SSH target for the remote endpoint (default: attn-remote@orb — the provisioned OrbStack VM)
   --remote-directory <path>      Remote cwd for the spawned session (default: remote $HOME)
   --remote-agent <agent>         Agent for the remote session (default: codex)
   --echo-threshold-ms <ms>       Max acceptable shell echo latency per typed token (default: 2500)

--- a/app/scripts/real-app-harness/scenario-tr504-remote-cleanup.mjs
+++ b/app/scripts/real-app-harness/scenario-tr504-remote-cleanup.mjs
@@ -4,6 +4,7 @@ import path from 'node:path';
 import {
   createSessionAndWaitForInitialPane,
   assertCommonTargetAllowed,
+  DEFAULT_REMOTE_SSH_TARGET,
   launchFreshAppAndConnect,
   parseCommonArgs,
   printCommonHelp,
@@ -40,7 +41,7 @@ function parseArgs(argv) {
 
   const options = {
     ...parseCommonArgs([]),
-    sshTarget: process.env.ATTN_REMOTE_CLEANUP_SSH_TARGET || 'ai-sandbox',
+    sshTarget: process.env.ATTN_REMOTE_CLEANUP_SSH_TARGET || DEFAULT_REMOTE_SSH_TARGET,
     remoteDirectory: process.env.ATTN_REMOTE_CLEANUP_REMOTE_DIRECTORY || '',
     remoteAgent: process.env.ATTN_REMOTE_CLEANUP_REMOTE_AGENT || 'codex',
   };
@@ -80,7 +81,7 @@ async function main() {
   if (help) {
     printCommonHelp('scripts/real-app-harness/scenario-tr504-remote-cleanup.mjs');
     console.log(`Additional options:
-  --ssh-target <target>          SSH target for the remote endpoint (default: ai-sandbox)
+  --ssh-target <target>          SSH target for the remote endpoint (default: attn-remote@orb — the provisioned OrbStack VM)
   --remote-directory <path>      Remote cwd for the spawned session (default: unique harness workdir)
   --remote-agent <agent>         Agent for the remote session (default: codex)
 `);
@@ -94,7 +95,7 @@ async function main() {
     metadata: {
       sshTarget: options.sshTarget,
       agent: options.remoteAgent,
-      focus: 'remote session close tears down worker-side processes',
+      focus: 'closing every pane/session of a remote workspace tears down worker-side processes',
     },
   });
 
@@ -118,7 +119,9 @@ async function main() {
   let sessionId = null;
   let initialPaneId = null;
   let splitPaneId = null;
+  let shellSessionId = null;
   let activeProcessSnapshot = [];
+  let shellClosedProcessSnapshot = [];
   let postCloseProcessSnapshot = [];
   let cleanedProcessSnapshot = [];
   let postEndpointRemovalProcessSnapshot = [];
@@ -206,7 +209,7 @@ async function main() {
       return resultSessionId;
     });
 
-    splitPaneId = await runner.step('create_remote_split', async () => {
+    ({ splitPaneId, shellSessionId } = await runner.step('create_remote_split', async () => {
       await client.request('select_session', { sessionId });
       initialPaneId = (await waitForFirstWorkspacePane(client, sessionId, 'remote cleanup initial pane', 30_000)).paneId;
       await waitForPaneVisible(client, sessionId, initialPaneId, 45_000);
@@ -225,8 +228,8 @@ async function main() {
         30_000,
       );
       await waitForPaneVisible(client, sessionId, newPane.paneId, 20_000);
-      return newPane.paneId;
-    });
+      return { splitPaneId: newPane.paneId, shellSessionId: newPane.sessionId };
+    }));
 
     await runner.step('observe_remote_processes_before_cleanup', async () => {
       activeProcessSnapshot = await waitForRemoteProcessesByHarnessRoot(
@@ -239,10 +242,33 @@ async function main() {
       runner.writeJson('01-active-processes.json', activeProcessSnapshot);
     });
 
+    // Closing a session (sidebar close / ⌘W) closes only that session's own pane —
+    // a split shell pane deliberately survives in the workspace, locally and
+    // remotely. Full teardown requires closing the shell pane first, the way ⌘W
+    // does, which the hub forwards to the remote daemon as workspace_layout_close_pane.
+    await runner.step('close_shell_pane_and_verify_worker_exit', async () => {
+      await client.request('close_pane', { sessionId, paneId: splitPaneId });
+      await observer.waitFor(
+        () => !observer.getSession(shellSessionId),
+        `shell session ${shellSessionId} to disappear after close_pane`,
+        30_000,
+      );
+      shellClosedProcessSnapshot = await waitForRemoteProcessesByHarnessRoot(
+        options.sshTarget,
+        remotePaths.remoteHarnessRoot,
+        (processes) => (processes.some((p) => String(p?.cmdline || '').includes(shellSessionId)) ? null : processes),
+        'remote shell worker processes to exit after close_pane',
+        60_000,
+      );
+      runner.writeJson('02-shell-pane-closed-processes.json', shellClosedProcessSnapshot);
+    });
+
+    // This closes the last remaining session. Once it disappears, the remote
+    // workspace unregisters and every session worker process must exit.
     await runner.step('close_session_and_verify_remote_cleanup', async () => {
       await client.request('close_session', { sessionId });
       postCloseProcessSnapshot = await listRemoteProcessesByHarnessRoot(options.sshTarget, remotePaths.remoteHarnessRoot, 30_000);
-      runner.writeJson('02-post-close-processes.json', postCloseProcessSnapshot);
+      runner.writeJson('03-post-close-processes.json', postCloseProcessSnapshot);
       await observer.waitFor(
         () => !observer.getSession(sessionId) && !observer.getWorkspace(sessionId),
         `session ${sessionId} to disappear after close`,
@@ -255,7 +281,7 @@ async function main() {
         'remote session worker processes to exit after close_session',
         60_000,
       );
-      runner.writeJson('02-cleaned-processes.json', cleanedProcessSnapshot);
+      runner.writeJson('03-cleaned-processes.json', cleanedProcessSnapshot);
     });
 
     await runner.step('remove_endpoint_and_verify_harness_root_cleanup', async () => {
@@ -269,17 +295,19 @@ async function main() {
         'remote harness-root transport processes to exit after remove_endpoint',
         30_000,
       );
-      runner.writeJson('03-post-endpoint-remove-processes.json', postEndpointRemovalProcessSnapshot);
+      runner.writeJson('04-post-endpoint-remove-processes.json', postEndpointRemovalProcessSnapshot);
     });
 
     const summary = runner.finishSuccess({
       sessionId,
       endpointId: endpoint?.id || null,
       splitPaneId,
+      shellSessionId,
       sshTarget: options.sshTarget,
       remoteDirectory,
       remoteAgent: options.remoteAgent,
       activeProcessCount: activeProcessSnapshot.length,
+      shellClosedProcessCount: shellClosedProcessSnapshot.length,
       postCloseProcessCount: postCloseProcessSnapshot.length,
       cleanedProcessCount: cleanedProcessSnapshot.length,
       postEndpointRemovalProcessCount: postEndpointRemovalProcessSnapshot.length,
@@ -294,6 +322,7 @@ async function main() {
       await captureSessionArtifacts(client, runner.runDir, 'failure', sessionId).catch(() => {});
     }
     runner.writeJson('failure-active-processes.json', activeProcessSnapshot);
+    runner.writeJson('failure-shell-closed-processes.json', shellClosedProcessSnapshot);
     runner.writeJson('failure-post-close-processes.json', postCloseProcessSnapshot);
     runner.writeJson('failure-cleaned-processes.json', cleanedProcessSnapshot);
     runner.writeJson('failure-post-endpoint-remove-processes.json', postEndpointRemovalProcessSnapshot);
@@ -301,10 +330,12 @@ async function main() {
       sessionId,
       endpointId: endpoint?.id || null,
       splitPaneId,
+      shellSessionId,
       sshTarget: options.sshTarget,
       remoteDirectory,
       remoteAgent: options.remoteAgent,
       activeProcessCount: activeProcessSnapshot.length,
+      shellClosedProcessCount: shellClosedProcessSnapshot.length,
       postCloseProcessCount: postCloseProcessSnapshot.length,
       cleanedProcessCount: cleanedProcessSnapshot.length,
       postEndpointRemovalProcessCount: postEndpointRemovalProcessSnapshot.length,

--- a/app/scripts/real-app-harness/scenarioCatalog.mjs
+++ b/app/scripts/real-app-harness/scenarioCatalog.mjs
@@ -120,14 +120,30 @@ export const scenarioCatalog = [
     timeoutMs: 360_000,
   },
   {
+    id: 'tr205-probe-codex',
+    label: 'TR-205 remote probe (codex vocabulary)',
+    command: ['pnpm', 'run', 'real-app:scenario-tr205', '--', '--remote-agent', 'probe:codex'],
+  },
+  {
+    id: 'tr205-probe-claude',
+    label: 'TR-205 remote probe (claude vocabulary)',
+    command: ['pnpm', 'run', 'real-app:scenario-tr205', '--', '--remote-agent', 'probe:claude'],
+  },
+  {
     id: 'tr205-codex',
-    label: 'TR-205 remote codex',
+    label: 'TR-205 remote codex (live agent)',
     command: ['pnpm', 'run', 'real-app:scenario-tr205'],
+    // Live-agent leg: needs codex credentials seeded in the VM. Not part of the
+    // matrix sweep — only runnable directly (run-soak) or manually.
+    soakOnly: true,
   },
   {
     id: 'tr205-claude',
-    label: 'TR-205 remote claude',
+    label: 'TR-205 remote claude (live agent)',
     command: ['pnpm', 'run', 'real-app:scenario-tr205', '--', '--remote-agent', 'claude'],
+    // Live-agent leg: needs claude credentials seeded in the VM. Not part of the
+    // matrix sweep — only runnable directly (run-soak) or manually.
+    soakOnly: true,
   },
   {
     id: 'tr502',

--- a/app/src/components/GhosttyTerminal.resizePolicy.test.ts
+++ b/app/src/components/GhosttyTerminal.resizePolicy.test.ts
@@ -103,6 +103,26 @@ describe('fitShouldBailAsSuspicious', () => {
   it('never bails when the floored fit is a normal usable size', () => {
     expect(fitShouldBailAsSuspicious('agent', { cols: 120, rows: 40 }, 120, 40, 9, 21, 1080, 840)).toBe(false);
   });
+
+  it('does NOT bail when an already-small model grows toward a container that is still in the suspicious range (TR-205 close-after-relaunch stall)', () => {
+    // Model stuck at 15x25 after a 4-way split; a sibling closes and the
+    // container now fits 20x25 (still <= MIN_USABLE_TERMINAL_COLS). The model
+    // does not overflow, but refusing the grow strands the pane at 15 cols.
+    expect(fitShouldBailAsSuspicious('agent', { cols: 20, rows: 25 }, 15, 25, 9, 21, 189, 540)).toBe(false);
+  });
+
+  it('still bails when a HEALTHY model sees a suspicious fit from an unlaid-out container', () => {
+    // Zero-sized container: dims collapse below the live model on both axes —
+    // a shrink — so the transient-measurement protection is retained.
+    expect(fitShouldBailAsSuspicious('agent', { cols: 2, rows: 1 }, 62, 27, 9, 21, 0, 0)).toBe(true);
+  });
+
+  it('still bails when an already-small model would SHRINK further on one axis', () => {
+    // Mixed grow/shrink (cols grow 15->20, rows shrink 25->8); container is
+    // comfortably large so the model doesn't overflow it on either axis, which
+    // isolates the shrink check.
+    expect(fitShouldBailAsSuspicious('agent', { cols: 20, rows: 8 }, 15, 25, 9, 21, 270, 540)).toBe(true);
+  });
 });
 
 describe('liveResizeConflictsWithQueuedReplay', () => {

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -319,6 +319,16 @@ export function geometryOverflowsContainer(
 // terminal beats a clipped one) and we do NOT bail. A not-yet-laid-out container
 // (clientWidth/clientHeight ~0) never registers as overflowing (see
 // geometryOverflowsContainer), so the transient case still bails.
+//
+// One more exception: when the live model is ITSELF already suspicious (e.g.
+// stuck at 15 cols after a relaunch race) and `dims` would only grow it —
+// never shrink either axis — the bail is refused even though `dims` is still
+// in the suspicious range. The guard exists to protect a HEALTHY grid from
+// transient small measurements; a model that's already at/below the usable
+// floor has nothing left to protect, and refusing a non-shrinking fit would
+// strand the pane smaller than its container forever. A shrink (including a
+// not-yet-laid-out container, whose ~0 dims are smaller than any live model)
+// still bails.
 export function fitShouldBailAsSuspicious(
   paneKind: string | undefined,
   dims: TerminalDimensions,
@@ -339,7 +349,18 @@ export function fitShouldBailAsSuspicious(
   // apply it to height (rows) and width (cols) so a narrow split is covered too.
   const overflows = geometryOverflowsContainer(modelRows, cellHeight, clientHeight)
     || geometryOverflowsContainer(modelCols, cellWidth, clientWidth);
-  return !overflows;
+  if (overflows) {
+    return false;
+  }
+  // The bail protects a HEALTHY grid from transient small measurements. A model
+  // already at/below the usable floor has nothing left to protect — refusing a
+  // fit that doesn't shrink it strands the pane smaller than its container
+  // forever (shrinks INTO the suspicious range always apply via the overflow
+  // path above, so the grow back out must apply too). A not-yet-laid-out
+  // container still bails here: its dims are smaller than any live model,
+  // which is a shrink.
+  const shrinksModel = dims.cols < modelCols || dims.rows < modelRows;
+  return !(isSuspiciousTerminalSize(modelCols, modelRows) && !shrinksModel);
 }
 
 // Geometry the queued (not yet applied) historical replay will end at.

--- a/cmd/agent-mirror/main.go
+++ b/cmd/agent-mirror/main.go
@@ -1,0 +1,272 @@
+// Command agent-mirror spawns a child process under a PTY, records its
+// output stream with timing, answers a minimal set of terminal queries so
+// TUIs don't hang waiting for a real terminal, resizes the PTY partway
+// through, and produces an analysis of the VT sequences observed before and
+// after the resize.
+//
+// Dev-only tool to re-capture real agent vocabulary fixtures for
+// internal/probetui (internal/probetui/testdata/agent-vocab-*.json); not
+// shipped. Analysis uses internal/probetui/vtvocab, the same analyzer the
+// probe's mirror tests run against captured fixtures.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/victorarias/attn/internal/probetui/vtvocab"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "agent-mirror: "+err.Error())
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	args := os.Args[1:]
+	dashIdx := -1
+	for i, a := range args {
+		if a == "--" {
+			dashIdx = i
+			break
+		}
+	}
+	if dashIdx == -1 {
+		return fmt.Errorf("usage: agent-mirror [flags] -- <command> [args...]")
+	}
+	flagArgs := args[:dashIdx]
+	cmdArgs := args[dashIdx+1:]
+	if len(cmdArgs) == 0 {
+		return fmt.Errorf("no command given after --")
+	}
+
+	fs := flag.NewFlagSet("agent-mirror", flag.ExitOnError)
+	outDir := fs.String("out", "./capture", "output directory")
+	cols := fs.Int("cols", 80, "initial cols")
+	rows := fs.Int("rows", 24, "initial rows")
+	cols2 := fs.Int("cols2", 62, "resize target cols")
+	rows2 := fs.Int("rows2", 27, "resize target rows")
+	phase1Dur := fs.Duration("phase1", 12*time.Second, "time to record before resize")
+	phase2Dur := fs.Duration("phase2", 6*time.Second, "time to record after resize")
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(*outDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir out dir: %w", err)
+	}
+
+	rawPath := filepath.Join(*outDir, "raw.bin")
+	timelinePath := filepath.Join(*outDir, "timeline.jsonl")
+	phase2Path := filepath.Join(*outDir, "phase2.bin")
+	analysisPath := filepath.Join(*outDir, "analysis.json")
+
+	rawFile, err := os.Create(rawPath)
+	if err != nil {
+		return fmt.Errorf("create raw.bin: %w", err)
+	}
+	defer rawFile.Close()
+
+	timelineFile, err := os.Create(timelinePath)
+	if err != nil {
+		return fmt.Errorf("create timeline.jsonl: %w", err)
+	}
+	defer timelineFile.Close()
+
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+	cmd.Env = buildEnv()
+
+	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{
+		Rows: uint16(*rows),
+		Cols: uint16(*cols),
+	})
+	if err != nil {
+		return fmt.Errorf("start pty: %w", err)
+	}
+
+	start := time.Now()
+
+	var (
+		mu           sync.Mutex // guards rawFile/timelineFile writes and bytesWritten/boundary bookkeeping
+		bytesWritten int64
+		boundary     int64 = -1
+	)
+	var currentPhase atomic.Int32
+	currentPhase.Store(1)
+
+	// currentRows tracks the PTY row count in effect, for CPR replies.
+	var currentRows atomic.Int32
+	currentRows.Store(int32(*rows))
+
+	responder := newQueryResponder(ptmx, &currentRows)
+
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		buf := make([]byte, 32*1024)
+		for {
+			n, rerr := ptmx.Read(buf)
+			if n > 0 {
+				chunk := append([]byte(nil), buf[:n]...)
+				tms := time.Since(start).Milliseconds()
+				phase := currentPhase.Load()
+
+				mu.Lock()
+				rawFile.Write(chunk)
+				bytesWritten += int64(n)
+				fmt.Fprintf(timelineFile, "{\"t_ms\":%d,\"phase\":%d,\"bytes\":%d}\n", tms, phase, n)
+				mu.Unlock()
+
+				responder.handle(chunk)
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+
+	time.Sleep(*phase1Dur)
+
+	mu.Lock()
+	boundary = bytesWritten
+	mu.Unlock()
+	currentPhase.Store(2)
+	currentRows.Store(int32(*rows2))
+
+	if err := pty.Setsize(ptmx, &pty.Winsize{
+		Rows: uint16(*rows2),
+		Cols: uint16(*cols2),
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, "agent-mirror: resize failed: "+err.Error())
+	}
+
+	time.Sleep(*phase2Dur)
+
+	// Terminate the child: SIGTERM, then SIGKILL after 3s if still alive.
+	waitDone := make(chan struct{})
+	go func() {
+		cmd.Wait()
+		close(waitDone)
+	}()
+	if cmd.Process != nil {
+		cmd.Process.Signal(syscall.SIGTERM)
+	}
+	select {
+	case <-waitDone:
+	case <-time.After(3 * time.Second):
+		if cmd.Process != nil {
+			cmd.Process.Signal(syscall.SIGKILL)
+		}
+		<-waitDone
+	}
+
+	ptmx.Close()
+	<-readerDone
+
+	rawFile.Sync()
+	timelineFile.Sync()
+
+	// Re-read raw.bin for post-hoc VT analysis, as specified.
+	rawData, err := os.ReadFile(rawPath)
+	if err != nil {
+		return fmt.Errorf("re-read raw.bin: %w", err)
+	}
+
+	if boundary < 0 || boundary > int64(len(rawData)) {
+		boundary = int64(len(rawData))
+	}
+
+	if err := os.WriteFile(phase2Path, rawData[boundary:], 0o644); err != nil {
+		return fmt.Errorf("write phase2.bin: %w", err)
+	}
+
+	phase1Stats := vtvocab.Analyze(rawData[:boundary])
+	phase2Stats := vtvocab.Analyze(rawData[boundary:])
+	analysis := struct {
+		Boundary int64         `json:"boundaryOffset"`
+		Phase1   vtvocab.Stats `json:"phase1"`
+		Phase2   vtvocab.Stats `json:"phase2"`
+	}{Boundary: boundary, Phase1: phase1Stats, Phase2: phase2Stats}
+
+	analysisBytes, err := json.MarshalIndent(analysis, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal analysis: %w", err)
+	}
+	if err := os.WriteFile(analysisPath, analysisBytes, 0o644); err != nil {
+		return fmt.Errorf("write analysis.json: %w", err)
+	}
+
+	fmt.Println("agent-mirror capture complete:")
+	fmt.Println("  " + rawPath)
+	fmt.Println("  " + timelinePath)
+	fmt.Println("  " + phase2Path)
+	fmt.Println("  " + analysisPath)
+
+	return nil
+}
+
+func buildEnv() []string {
+	env := os.Environ()
+	out := make([]string, 0, len(env)+1)
+	for _, e := range env {
+		if strings.HasPrefix(e, "TERM=") {
+			continue
+		}
+		out = append(out, e)
+	}
+	out = append(out, "TERM=xterm-256color")
+	return out
+}
+
+// --- live query responder -------------------------------------------------
+
+var (
+	reDA1       = regexp.MustCompile(`\x1b\[0?c`)
+	reCPR       = regexp.MustCompile(`\x1b\[6n`)
+	reOSCColorQ = regexp.MustCompile(`\x1b\](10|11|12);\?(?:\x07|\x1b\\)`)
+)
+
+type queryResponder struct {
+	ptmx *os.File
+	rows *atomic.Int32
+	mu   sync.Mutex
+}
+
+func newQueryResponder(ptmx *os.File, rows *atomic.Int32) *queryResponder {
+	return &queryResponder{ptmx: ptmx, rows: rows}
+}
+
+// handle scans a chunk of PTY output for terminal queries the child may have
+// issued and writes minimal replies back into the PTY (i.e. to the child's
+// stdin), so TUIs waiting on a real terminal's response don't hang. This is
+// a best-effort, per-chunk byte scan; queries split across chunk boundaries
+// are not reassembled.
+func (q *queryResponder) handle(chunk []byte) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if reDA1.Match(chunk) {
+		q.ptmx.Write([]byte("\x1b[?62c"))
+	}
+	if reCPR.Match(chunk) {
+		r := q.rows.Load()
+		q.ptmx.Write([]byte(fmt.Sprintf("\x1b[%d;1R", r)))
+	}
+	for _, m := range reOSCColorQ.FindAllSubmatch(chunk, -1) {
+		code := string(m[1])
+		q.ptmx.Write([]byte(fmt.Sprintf("\x1b]%s;rgb:0000/0000/0000\x1b\\", code)))
+	}
+}

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -29,10 +29,12 @@ import (
 	"github.com/victorarias/attn/internal/hooks"
 	"github.com/victorarias/attn/internal/pathutil"
 	"github.com/victorarias/attn/internal/present"
+	"github.com/victorarias/attn/internal/probetui"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/ptyworker"
 	"github.com/victorarias/attn/internal/workflowresult"
 	"github.com/victorarias/attn/internal/wrapper"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -303,6 +305,8 @@ func main() {
 		runHookState()
 	case "_hook-todo":
 		runHookTodo()
+	case "_probe-tui":
+		runProbeTUI()
 	default:
 		// Check if it's a flag (starts with -)
 		if len(os.Args[1]) > 0 && os.Args[1][0] == '-' {
@@ -3362,6 +3366,50 @@ func runHookTodo() {
 
 	if err := c.UpdateTodos(sessionID, todos); err != nil {
 		fmt.Fprintf(os.Stderr, "error updating todos: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// runProbeTUI drives a deterministic agent-mimicking probe (internal/probetui)
+// on stdout, for harness scenarios that need a fake "agent" TUI without a
+// live model in the loop. Hidden command; not listed in writeHelp.
+func runProbeTUI() {
+	fs := flag.NewFlagSet("_probe-tui", flag.ExitOnError)
+	styleFlag := fs.String("style", "", "agent vocabulary to mirror: codex or claude")
+	interval := fs.Duration("interval", 500*time.Millisecond, "frame repaint interval")
+	if err := fs.Parse(os.Args[2:]); err != nil {
+		os.Exit(2)
+	}
+
+	style, err := probetui.ParseStyle(*styleFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "attn _probe-tui: %v\n", err)
+		os.Exit(2)
+	}
+
+	size := func() (int, int, error) {
+		ws, err := unix.IoctlGetWinsize(int(os.Stdout.Fd()), unix.TIOCGWINSZ)
+		if err != nil {
+			return 0, 0, fmt.Errorf("get terminal size: %w", err)
+		}
+		return int(ws.Col), int(ws.Row), nil
+	}
+
+	winch := make(chan os.Signal, 1)
+	signal.Notify(winch, syscall.SIGWINCH)
+	defer signal.Stop(winch)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	term := make(chan os.Signal, 1)
+	signal.Notify(term, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-term
+		cancel()
+	}()
+	defer signal.Stop(term)
+
+	if err := probetui.Run(ctx, os.Stdout, style, size, winch, *interval); err != nil {
+		fmt.Fprintf(os.Stderr, "attn _probe-tui: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
+	golang.org/x/sys v0.13.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -31,6 +32,5 @@ require (
 	github.com/dlclark/regexp2/v2 v2.2.1 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
-	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 )

--- a/internal/probetui/claude.go
+++ b/internal/probetui/claude.go
@@ -1,0 +1,79 @@
+package probetui
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// claude 2.1.217 runs full-screen: alt-screen, mouse tracking, bracketed
+// paste, and positions text with \r plus relative CSI column/row moves
+// rather than CUP+newlines. See
+// internal/probetui/testdata/agent-vocab-claude.json.
+
+var claudeMouseModes = []string{"1000", "1002", "1003", "1006"}
+
+func decsc() []byte { return []byte{0x1b, '7'} }
+func decrc() []byte { return []byte{0x1b, '8'} }
+func decscusr(style int) []byte {
+	return csi(fmt.Sprintf("%d ", style), 'q')
+}
+
+func startupClaude(cols, rows int) []byte {
+	var b bytes.Buffer
+	b.Write(privateMode(true, "1049"))
+	b.Write(privateMode(true, claudeMouseModes...))
+	b.Write(privateMode(true, "1004", "2004", "2031"))
+	b.Write(osc("0", "attn-probe"))
+	b.Write(decscusr(2))
+	b.Write(da1Query())
+	return b.Bytes()
+}
+
+func frameClaude(cols, rows, seq int) []byte {
+	var b bytes.Buffer
+	b.Write(privateMode(true, "2026"))
+	b.Write(privateMode(false, "25")) // hide cursor at frame start
+	b.Write(decsc())
+
+	b.WriteString("\r")
+	b.Write(csi("1", 'G'))
+	b.Write(sgr("38;5;4"))
+	b.WriteString(truncateToWidth(bannerGeometryRow(cols, rows), cols))
+	b.Write(sgr("0"))
+
+	for row := 2; row <= rows; row++ {
+		b.Write(csi("1", 'B'))
+		b.WriteString("\r")
+		switch row {
+		case 2:
+			b.WriteString(truncateToWidth(bannerStyleRow(StyleClaude, seq), cols))
+		case 3:
+			b.Write(csi("2", 'C'))
+			b.Write(hyperlink("file:///tmp/attn-probe/session.log", truncateToWidth("session.log", cols)))
+		default:
+			b.WriteString(fillRow(cols, rows, seq, row))
+		}
+	}
+
+	b.Write(decrc())
+	b.Write(privateMode(true, "25")) // show cursor at frame end
+	b.Write(privateMode(false, "2026"))
+	return b.Bytes()
+}
+
+func onResizeClaude(cols, rows int) []byte {
+	var b bytes.Buffer
+	b.Write(privateMode(true, claudeMouseModes...))
+	b.Write(ed(2))
+	return b.Bytes()
+}
+
+func teardownClaude() []byte {
+	var b bytes.Buffer
+	b.Write(privateMode(false, "2026"))
+	b.Write(privateMode(false, claudeMouseModes...))
+	b.Write(privateMode(false, "1004", "2004", "2031"))
+	b.Write(privateMode(true, "25"))
+	b.Write(privateMode(false, "1049"))
+	return b.Bytes()
+}

--- a/internal/probetui/codex.go
+++ b/internal/probetui/codex.go
@@ -1,0 +1,62 @@
+package probetui
+
+import "bytes"
+
+// codex-cli 0.145.0 never uses the alternate screen, addresses the
+// existing screen with CUP/EL, and queries DA1/CPR/OSC 10+11 colors on
+// startup. See internal/probetui/testdata/agent-vocab-codex.json.
+
+func startupCodex(cols, rows int) []byte {
+	var b bytes.Buffer
+	b.Write(privateMode(true, "1004", "2004"))
+	b.Write(da1Query())
+	b.Write(cprQuery())
+	b.Write(oscColorQuery("10"))
+	b.Write(oscColorQuery("11"))
+	b.Write(decstbm(1, rows))
+	return b.Bytes()
+}
+
+func frameCodex(cols, rows, seq int) []byte {
+	var b bytes.Buffer
+	b.Write(privateMode(true, "2026"))
+	b.Write(privateMode(false, "25")) // hide cursor at frame start
+
+	for row := 1; row <= rows; row++ {
+		b.Write(cup(row, 1))
+		b.Write(el())
+		switch row {
+		case 1:
+			b.WriteString(truncateToWidth(bannerGeometryRow(cols, rows), cols))
+		case 2:
+			b.WriteString(truncateToWidth(bannerStyleRow(StyleCodex, seq), cols))
+		case 3:
+			// One SGR color and one OSC 8 hyperlink per frame.
+			b.Write(sgr("38;5;2"))
+			b.Write(hyperlink("file:///tmp/attn-probe/session.log", truncateToWidth("session.log", cols)))
+			b.Write(sgr("0"))
+		default:
+			b.WriteString(fillRow(cols, rows, seq, row))
+		}
+	}
+
+	b.Write(privateMode(true, "25")) // show cursor at frame end
+	b.Write(privateMode(false, "2026"))
+	return b.Bytes()
+}
+
+func onResizeCodex(cols, rows int) []byte {
+	var b bytes.Buffer
+	b.Write(cprQuery())
+	b.Write(ed(2))
+	return b.Bytes()
+}
+
+func teardownCodex() []byte {
+	var b bytes.Buffer
+	b.Write(privateMode(false, "2026"))
+	b.Write(privateMode(true, "25"))
+	b.Write(privateMode(false, "2004", "1004"))
+	b.Write(decstbm(0, 0))
+	return b.Bytes()
+}

--- a/internal/probetui/export_test.go
+++ b/internal/probetui/export_test.go
@@ -1,0 +1,5 @@
+package probetui
+
+// TruncateToWidth exposes truncateToWidth to tests without widening the
+// package's public API.
+var TruncateToWidth = truncateToWidth

--- a/internal/probetui/mirror_test.go
+++ b/internal/probetui/mirror_test.go
@@ -1,0 +1,450 @@
+package probetui
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/victorarias/attn/internal/probetui/vtvocab"
+)
+
+// fixture mirrors the agent-mirror capture tool's analysis.json shape:
+// real VT vocabulary recorded from a live agent, split at the
+// startup+idle / resize+teardown boundary.
+type fixture struct {
+	BoundaryOffset int64         `json:"boundaryOffset"`
+	Phase1         vtvocab.Stats `json:"phase1"`
+	Phase2         vtvocab.Stats `json:"phase2"`
+}
+
+func loadFixture(t *testing.T, path string) fixture {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", path, err)
+	}
+	var f fixture
+	if err := json.Unmarshal(raw, &f); err != nil {
+		t.Fatalf("unmarshal fixture %s: %v", path, err)
+	}
+	return f
+}
+
+// pin ties one VT feature to two independent checks: does the probe emit
+// it (or correctly withhold it), and does the recorded real-agent fixture
+// exhibit the same behavior somewhere in its capture. A failure on either
+// side names the feature, so drift (probe regression, or the mirror going
+// stale against an agent update) is diagnosable without re-deriving which
+// assertion caught it.
+type pin struct {
+	name    string
+	probe   func(t *testing.T, combined vtvocab.Stats)
+	fixture func(t *testing.T, phase1, phase2 vtvocab.Stats)
+}
+
+func runPins(t *testing.T, pins []pin, combined vtvocab.Stats, f fixture) {
+	t.Helper()
+	for _, p := range pins {
+		p := p
+		t.Run(p.name, func(t *testing.T) {
+			t.Run("probe", func(t *testing.T) { p.probe(t, combined) })
+			t.Run("fixture", func(t *testing.T) { p.fixture(t, f.Phase1, f.Phase2) })
+		})
+	}
+}
+
+func mirrorTranscript(style Style) []byte {
+	var out []byte
+	out = append(out, Startup(style, 80, 24)...)
+	out = append(out, Frame(style, 80, 24, 1)...)
+	out = append(out, OnResize(style, 62, 27)...)
+	out = append(out, Frame(style, 62, 27, 2)...)
+	out = append(out, Teardown(style)...)
+	return out
+}
+
+func TestMirrorCodex(t *testing.T) {
+	combined := vtvocab.Analyze(mirrorTranscript(StyleCodex))
+	f := loadFixture(t, "testdata/agent-vocab-codex.json")
+
+	pins := []pin{
+		{
+			name: "synchronized-update (2026 set + reset)",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.PrivateModeSet["2026"] == 0 || s.PrivateModeReset["2026"] == 0 {
+					t.Errorf("want ?2026h and ?2026l both present, got set=%d reset=%d", s.PrivateModeSet["2026"], s.PrivateModeReset["2026"])
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.PrivateModeSet["2026"] == 0 {
+					t.Errorf("fixture phase1 never sets mode 2026")
+				}
+			},
+		},
+		{
+			name: "no alt-screen",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.AltScreenEnter != 0 || s.AltScreenExit != 0 {
+					t.Errorf("codex probe must never touch the alt screen, got enter=%d exit=%d", s.AltScreenEnter, s.AltScreenExit)
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.AltScreenEnter != 0 || p1.AltScreenExit != 0 || p2.AltScreenEnter != 0 || p2.AltScreenExit != 0 {
+					t.Errorf("codex fixture unexpectedly touches the alt screen")
+				}
+			},
+		},
+		{
+			name: "OSC 8 hyperlinks",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.OSCByCode["8"] == 0 {
+					t.Errorf("want at least one OSC 8 hyperlink")
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.OSCByCode["8"] == 0 && p2.OSCByCode["8"] == 0 {
+					t.Errorf("fixture never emits an OSC 8 hyperlink")
+				}
+			},
+		},
+		{
+			name: "DA1 query on startup",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.DA1QueryFromChild == 0 {
+					t.Errorf("want a DA1 query (ESC[c)")
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.DA1QueryFromChild == 0 {
+					t.Errorf("fixture phase1 never issues a DA1 query")
+				}
+			},
+		},
+		{
+			name: "CPR query on startup",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.CPRQueryFromChild == 0 {
+					t.Errorf("want a CPR query (ESC[6n) on startup")
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.CPRQueryFromChild == 0 {
+					t.Errorf("fixture phase1 never issues a CPR query")
+				}
+			},
+		},
+		{
+			name: "CPR query re-asserted on resize",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.CPRQueryFromChild < 2 {
+					t.Errorf("want CPR queried again on resize, got %d total", s.CPRQueryFromChild)
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p2.CPRQueryFromChild == 0 {
+					t.Errorf("fixture phase2 never re-issues a CPR query after resize")
+				}
+			},
+		},
+		{
+			name: "OSC 10/11 color queries",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.OSCColorQueryFromChild["10"] == 0 || s.OSCColorQueryFromChild["11"] == 0 {
+					t.Errorf("want OSC 10 and 11 color queries, got %v", s.OSCColorQueryFromChild)
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.OSCColorQueryFromChild["10"] == 0 || p1.OSCColorQueryFromChild["11"] == 0 {
+					t.Errorf("fixture phase1 missing OSC 10/11 color queries, got %v", p1.OSCColorQueryFromChild)
+				}
+			},
+		},
+		{
+			name: "DECSTBM scroll region",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.DECSTBM == 0 {
+					t.Errorf("want at least one DECSTBM (CSI r)")
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.DECSTBM == 0 && p2.DECSTBM == 0 {
+					t.Errorf("fixture never sets a scroll region")
+				}
+			},
+		},
+		{
+			name: "startup modes 1004 + 2004",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.PrivateModeSet["1004"] == 0 || s.PrivateModeSet["2004"] == 0 {
+					t.Errorf("want ?1004h and ?2004h on startup, got %v", s.PrivateModeSet)
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.PrivateModeSet["1004"] == 0 || p1.PrivateModeSet["2004"] == 0 {
+					t.Errorf("fixture phase1 missing ?1004h/?2004h, got %v", p1.PrivateModeSet)
+				}
+			},
+		},
+		{
+			name: "cursor hidden during paint (mode 25 reset)",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.PrivateModeReset["25"] == 0 {
+					t.Errorf("want ?25l (hide cursor) during frame paint")
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.PrivateModeReset["25"] == 0 {
+					t.Errorf("fixture phase1 never hides the cursor")
+				}
+			},
+		},
+		{
+			name: "no newlines",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.Newlines != 0 {
+					t.Errorf("codex probe must never emit \\n, got %d", s.Newlines)
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.Newlines != 0 || p2.Newlines != 0 {
+					t.Errorf("codex fixture unexpectedly contains \\n (phase1=%d phase2=%d)", p1.Newlines, p2.Newlines)
+				}
+			},
+		},
+		{
+			name: "no carriage returns",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.CarriageReturns != 0 {
+					t.Errorf("codex probe must never emit \\r, got %d", s.CarriageReturns)
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.CarriageReturns != 0 || p2.CarriageReturns != 0 {
+					t.Errorf("codex fixture unexpectedly contains \\r (phase1=%d phase2=%d)", p1.CarriageReturns, p2.CarriageReturns)
+				}
+			},
+		},
+	}
+
+	runPins(t, pins, combined, f)
+}
+
+func TestMirrorClaude(t *testing.T) {
+	combined := vtvocab.Analyze(mirrorTranscript(StyleClaude))
+	f := loadFixture(t, "testdata/agent-vocab-claude.json")
+
+	pins := []pin{
+		{
+			name: "alt-screen enter on startup",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.AltScreenEnter == 0 {
+					t.Errorf("want ?1049h on startup")
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.AltScreenEnter == 0 {
+					t.Errorf("fixture phase1 never enters the alt screen")
+				}
+			},
+		},
+		{
+			name: "alt-screen exit on teardown",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.AltScreenExit == 0 {
+					t.Errorf("want ?1049l on teardown")
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p2.AltScreenExit == 0 {
+					t.Errorf("fixture phase2 never exits the alt screen")
+				}
+			},
+		},
+		{
+			name: "mouse modes asserted on startup",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				for _, m := range claudeMouseModes {
+					if s.PrivateModeSet[m] == 0 {
+						t.Errorf("want mouse mode %s set, got %v", m, s.PrivateModeSet)
+					}
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				for _, m := range claudeMouseModes {
+					if p1.PrivateModeSet[m] == 0 {
+						t.Errorf("fixture phase1 missing mouse mode %s set", m)
+					}
+				}
+			},
+		},
+		{
+			name: "mouse modes re-asserted on resize",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				for _, m := range claudeMouseModes {
+					if s.PrivateModeSet[m] < 2 {
+						t.Errorf("want mouse mode %s set twice (startup + resize), got %d", m, s.PrivateModeSet[m])
+					}
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				for _, m := range claudeMouseModes {
+					if p2.PrivateModeSet[m] == 0 {
+						t.Errorf("fixture phase2 never re-asserts mouse mode %s after resize", m)
+					}
+				}
+			},
+		},
+		{
+			name: "mouse modes reset on teardown",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				for _, m := range claudeMouseModes {
+					if s.PrivateModeReset[m] == 0 {
+						t.Errorf("want mouse mode %s reset on teardown, got %v", m, s.PrivateModeReset)
+					}
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				for _, m := range claudeMouseModes {
+					if p2.PrivateModeReset[m] == 0 {
+						t.Errorf("fixture phase2 never resets mouse mode %s", m)
+					}
+				}
+			},
+		},
+		{
+			name: "OSC 0 title",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.OSCByCode["0"] == 0 {
+					t.Errorf("want an OSC 0 title sequence")
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.OSCByCode["0"] == 0 {
+					t.Errorf("fixture phase1 never sets an OSC 0 title")
+				}
+			},
+		},
+		{
+			name: "DECSCUSR (final 'q')",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.OtherCSIFinal["q"] == 0 {
+					t.Errorf("want a DECSCUSR sequence (CSI ... q)")
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.OtherCSIFinal["q"] == 0 {
+					t.Errorf("fixture phase1 never emits a final 'q' CSI sequence")
+				}
+			},
+		},
+		{
+			name: "DA1 query on startup",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.DA1QueryFromChild == 0 {
+					t.Errorf("want a DA1 query (ESC[c)")
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.DA1QueryFromChild == 0 {
+					t.Errorf("fixture phase1 never issues a DA1 query")
+				}
+			},
+		},
+		{
+			name: "no CPR query",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.CPRQueryFromChild != 0 {
+					t.Errorf("claude probe must never query CPR, got %d", s.CPRQueryFromChild)
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.CPRQueryFromChild != 0 || p2.CPRQueryFromChild != 0 {
+					t.Errorf("claude fixture unexpectedly queries CPR (phase1=%d phase2=%d)", p1.CPRQueryFromChild, p2.CPRQueryFromChild)
+				}
+			},
+		},
+		{
+			name: "no OSC color queries",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if len(s.OSCColorQueryFromChild) != 0 {
+					t.Errorf("claude probe must never query OSC 10/11/12 colors, got %v", s.OSCColorQueryFromChild)
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if len(p1.OSCColorQueryFromChild) != 0 || len(p2.OSCColorQueryFromChild) != 0 {
+					t.Errorf("claude fixture unexpectedly queries OSC colors (phase1=%v phase2=%v)", p1.OSCColorQueryFromChild, p2.OSCColorQueryFromChild)
+				}
+			},
+		},
+		{
+			name: "DECSC/DECRC cursor save-restore",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.CursorSaveDECSC == 0 || s.CursorRestoreDECRC == 0 {
+					t.Errorf("want ESC 7 / ESC 8 at least once per frame, got save=%d restore=%d", s.CursorSaveDECSC, s.CursorRestoreDECRC)
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.CursorSaveDECSC == 0 || p1.CursorRestoreDECRC == 0 {
+					t.Errorf("fixture phase1 missing DECSC/DECRC, save=%d restore=%d", p1.CursorSaveDECSC, p1.CursorRestoreDECRC)
+				}
+			},
+		},
+		{
+			name: "OSC 8 hyperlinks",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.OSCByCode["8"] == 0 {
+					t.Errorf("want at least one OSC 8 hyperlink")
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.OSCByCode["8"] == 0 {
+					t.Errorf("fixture phase1 never emits an OSC 8 hyperlink")
+				}
+			},
+		},
+		{
+			name: "relative cursor moves (CSI B/C/G)",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.OtherCSIFinal["B"] == 0 || s.OtherCSIFinal["C"] == 0 || s.OtherCSIFinal["G"] == 0 {
+					t.Errorf("want CSI B (down), C (forward) and G (column) all present, got %v", s.OtherCSIFinal)
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.OtherCSIFinal["B"] == 0 || p1.OtherCSIFinal["C"] == 0 || p1.OtherCSIFinal["G"] == 0 {
+					t.Errorf("fixture phase1 missing one of CSI B/C/G, got %v", p1.OtherCSIFinal)
+				}
+			},
+		},
+		{
+			name: "carriage-return driven layout, not newlines",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.CarriageReturns == 0 {
+					t.Errorf("want \\r used for row positioning")
+				}
+				if s.Newlines != 0 {
+					t.Errorf("claude probe must stay deterministic: no \\n, got %d", s.Newlines)
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p1.CarriageReturns <= p1.Newlines {
+					t.Errorf("fixture phase1 does not predominantly use \\r for layout (cr=%d nl=%d)", p1.CarriageReturns, p1.Newlines)
+				}
+			},
+		},
+		{
+			name: "bracketed paste + focus + mode 2031 reset on teardown",
+			probe: func(t *testing.T, s vtvocab.Stats) {
+				if s.PrivateModeReset["1004"] == 0 || s.PrivateModeReset["2004"] == 0 || s.PrivateModeReset["2031"] == 0 {
+					t.Errorf("want ?1004l ?2004l ?2031l on teardown, got %v", s.PrivateModeReset)
+				}
+			},
+			fixture: func(t *testing.T, p1, p2 vtvocab.Stats) {
+				if p2.PrivateModeReset["1004"] == 0 || p2.PrivateModeReset["2004"] == 0 || p2.PrivateModeReset["2031"] == 0 {
+					t.Errorf("fixture phase2 missing ?1004l/?2004l/?2031l, got %v", p2.PrivateModeReset)
+				}
+			},
+		},
+	}
+
+	runPins(t, pins, combined, f)
+}

--- a/internal/probetui/probetui.go
+++ b/internal/probetui/probetui.go
@@ -1,0 +1,254 @@
+// Package probetui renders deterministic byte-for-byte terminal output that
+// mirrors the VT vocabulary of a real coding agent's TUI (codex-cli or
+// claude), without running the real agent. It backs the `attn _probe-tui`
+// harness fixture: a fake "agent" the packaged-app harness can launch that
+// exercises the same private-mode sets, cursor addressing, and query
+// sequences a real agent does, so terminal-handling regressions can be
+// caught without a live model in the loop.
+//
+// Renderers are pure functions of (style, geometry, seq): no wall-clock
+// time, randomness, or PID leaks into the output, so a captured transcript
+// is reproducible.
+package probetui
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+// Style selects which real agent's VT vocabulary to mirror.
+type Style string
+
+const (
+	StyleCodex  Style = "codex"
+	StyleClaude Style = "claude"
+)
+
+// ParseStyle parses a --style flag value.
+func ParseStyle(s string) (Style, error) {
+	switch Style(s) {
+	case StyleCodex:
+		return StyleCodex, nil
+	case StyleClaude:
+		return StyleClaude, nil
+	default:
+		return "", fmt.Errorf("probetui: unknown style %q (want %q or %q)", s, StyleCodex, StyleClaude)
+	}
+}
+
+// Startup returns the byte sequence the probe emits once on start, before
+// the first frame: mode sets and (per style) terminal queries.
+func Startup(style Style, cols, rows int) []byte {
+	switch style {
+	case StyleCodex:
+		return startupCodex(cols, rows)
+	case StyleClaude:
+		return startupClaude(cols, rows)
+	default:
+		panic(fmt.Sprintf("probetui: unknown style %q", style))
+	}
+}
+
+// Frame returns one full deterministic repaint for the given geometry and
+// monotonically increasing seq. Content depends only on (style, cols, rows,
+// seq).
+func Frame(style Style, cols, rows int, seq int) []byte {
+	switch style {
+	case StyleCodex:
+		return frameCodex(cols, rows, seq)
+	case StyleClaude:
+		return frameClaude(cols, rows, seq)
+	default:
+		panic(fmt.Sprintf("probetui: unknown style %q", style))
+	}
+}
+
+// OnResize returns the bytes emitted in response to a size change, BEFORE
+// the next Frame at the new geometry.
+func OnResize(style Style, cols, rows int) []byte {
+	switch style {
+	case StyleCodex:
+		return onResizeCodex(cols, rows)
+	case StyleClaude:
+		return onResizeClaude(cols, rows)
+	default:
+		panic(fmt.Sprintf("probetui: unknown style %q", style))
+	}
+}
+
+// Teardown returns the graceful shutdown sequence (mode resets; claude
+// style exits the alternate screen).
+func Teardown(style Style) []byte {
+	switch style {
+	case StyleCodex:
+		return teardownCodex()
+	case StyleClaude:
+		return teardownClaude()
+	default:
+		panic(fmt.Sprintf("probetui: unknown style %q", style))
+	}
+}
+
+// Run drives the probe against w until ctx is done or a resize arrives on
+// winch: Startup, then a Frame every interval and on each resize (via
+// OnResize followed by a Frame at the new geometry), then Teardown on
+// ctx.Done. size returns the current terminal geometry. Run never reads
+// input.
+func Run(
+	ctx context.Context,
+	w io.Writer,
+	style Style,
+	size func() (cols int, rows int, err error),
+	winch <-chan os.Signal,
+	interval time.Duration,
+) error {
+	cols, rows, err := size()
+	if err != nil {
+		return fmt.Errorf("probetui: initial size: %w", err)
+	}
+
+	if _, err := w.Write(Startup(style, cols, rows)); err != nil {
+		return err
+	}
+
+	seq := 0
+	writeFrame := func() error {
+		seq++
+		_, err := w.Write(Frame(style, cols, rows, seq))
+		return err
+	}
+	if err := writeFrame(); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			_, err := w.Write(Teardown(style))
+			return err
+
+		case <-winch:
+			newCols, newRows, err := size()
+			if err != nil {
+				continue
+			}
+			if newCols == cols && newRows == rows {
+				continue
+			}
+			cols, rows = newCols, newRows
+			if _, err := w.Write(OnResize(style, cols, rows)); err != nil {
+				return err
+			}
+			if err := writeFrame(); err != nil {
+				return err
+			}
+
+		case <-ticker.C:
+			if err := writeFrame(); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// --- shared VT construction helpers ----------------------------------------
+
+func csi(params string, final byte) []byte {
+	return []byte("\x1b[" + params + string(final))
+}
+
+func privateMode(set bool, modes ...string) []byte {
+	final := byte('l')
+	if set {
+		final = 'h'
+	}
+	params := "?"
+	for i, m := range modes {
+		if i > 0 {
+			params += ";"
+		}
+		params += m
+	}
+	return csi(params, final)
+}
+
+func cup(row, col int) []byte { return csi(fmt.Sprintf("%d;%d", row, col), 'H') }
+func el() []byte              { return csi("", 'K') }
+func ed(n int) []byte {
+	if n == 0 {
+		return csi("", 'J')
+	}
+	return csi(fmt.Sprintf("%d", n), 'J')
+}
+func sgr(params string) []byte { return csi(params, 'm') }
+func decstbm(top, bottom int) []byte {
+	if top == 0 && bottom == 0 {
+		return csi("", 'r')
+	}
+	return csi(fmt.Sprintf("%d;%d", top, bottom), 'r')
+}
+func da1Query() []byte { return csi("", 'c') }
+func cprQuery() []byte { return csi("6", 'n') }
+
+func osc(code, data string) []byte {
+	return []byte("\x1b]" + code + ";" + data + "\x1b\\")
+}
+
+func oscColorQuery(code string) []byte { return osc(code, "?") }
+
+func hyperlink(url, text string) []byte {
+	var b bytes.Buffer
+	b.WriteString("\x1b]8;;" + url + "\x1b\\")
+	b.WriteString(text)
+	b.WriteString("\x1b]8;;\x1b\\")
+	return b.Bytes()
+}
+
+// bannerGeometryRow and bannerStyleRow are the two fixed-shape rows both
+// styles' Frame must paint exactly once, at rows 1 and 2 respectively.
+// Callers truncate each to cols when painting. Split across two rows (was
+// one) so the identifying content survives narrow (~20 col) panes where a
+// single combined banner line clipped past recognition.
+func bannerGeometryRow(cols, rows int) string {
+	return fmt.Sprintf("ATTN-PROBE %dx%d", cols, rows)
+}
+
+func bannerStyleRow(style Style, seq int) string {
+	return fmt.Sprintf("style=%s seq=%d READY", style, seq)
+}
+
+// fillRow is a deterministic fill pattern for a non-banner row, a function
+// only of (cols, rows, seq, row).
+func fillRow(cols, rows, seq, row int) string {
+	ch := byte('#')
+	if (row+seq+rows)%2 == 1 {
+		ch = '.'
+	}
+	if cols <= 0 {
+		return ""
+	}
+	b := make([]byte, cols)
+	for i := range b {
+		b[i] = ch
+	}
+	return string(b)
+}
+
+// truncateToWidth clamps s to at most cols visible columns, assuming
+// single-width ASCII content (the only content probetui renders).
+func truncateToWidth(s string, cols int) string {
+	if cols <= 0 {
+		return ""
+	}
+	if len(s) <= cols {
+		return s
+	}
+	return s[:cols]
+}

--- a/internal/probetui/probetui_test.go
+++ b/internal/probetui/probetui_test.go
@@ -1,0 +1,99 @@
+package probetui
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"testing"
+)
+
+var testStyles = []Style{StyleCodex, StyleClaude}
+var testGeometries = [][2]int{{80, 24}, {30, 10}}
+
+var geometryRowPattern = regexp.MustCompile(`ATTN-PROBE \d+x\d+`)
+
+func TestFrameDeterminism(t *testing.T) {
+	for _, style := range testStyles {
+		for _, g := range testGeometries {
+			cols, rows := g[0], g[1]
+			t.Run(fmt.Sprintf("%s/%dx%d", style, cols, rows), func(t *testing.T) {
+				a := Frame(style, cols, rows, 1)
+				b := Frame(style, cols, rows, 1)
+				if !bytes.Equal(a, b) {
+					t.Fatalf("Frame(%s,%d,%d,1) is not deterministic across calls", style, cols, rows)
+				}
+
+				c := Frame(style, cols, rows, 2)
+				if bytes.Equal(a, c) {
+					t.Fatalf("Frame(%s,%d,%d,1) == Frame(...,2); seq must change output", style, cols, rows)
+				}
+
+				matches := geometryRowPattern.FindAll(a, -1)
+				if len(matches) != 1 {
+					t.Fatalf("geometry banner %q appears %d times in frame, want exactly 1 (frame: %q)", geometryRowPattern.String(), len(matches), a)
+				}
+
+				styleRow := truncateToWidth(bannerStyleRow(style, 1), cols)
+				if n := bytes.Count(a, []byte(styleRow)); n != 1 {
+					t.Fatalf("style banner row %q appears %d times in frame, want exactly 1", styleRow, n)
+				}
+			})
+		}
+	}
+}
+
+func TestFrameGeometryDiscipline(t *testing.T) {
+	const cols, rows = 30, 10
+	for _, style := range testStyles {
+		t.Run(string(style), func(t *testing.T) {
+			geoRaw := bannerGeometryRow(cols, rows)
+			styleRaw := bannerStyleRow(style, 1)
+
+			geoTrunc := TruncateToWidth(geoRaw, cols)
+			styleTrunc := TruncateToWidth(styleRaw, cols)
+			if len(geoTrunc) > cols {
+				t.Fatalf("geometry row %q (%d bytes) exceeds %d cols after truncation", geoTrunc, len(geoTrunc), cols)
+			}
+			if len(styleTrunc) > cols {
+				t.Fatalf("style row %q (%d bytes) exceeds %d cols after truncation", styleTrunc, len(styleTrunc), cols)
+			}
+
+			frame := Frame(style, cols, rows, 1)
+			if !bytes.Contains(frame, []byte(geoTrunc)) {
+				t.Fatalf("frame does not contain the expected geometry row %q", geoTrunc)
+			}
+			if !bytes.Contains(frame, []byte(styleTrunc)) {
+				t.Fatalf("frame does not contain the expected style row %q", styleTrunc)
+			}
+		})
+	}
+}
+
+// TestFrameGeometryDisciplineNarrow exercises an actual truncation, at a
+// width narrow enough (~10 cols) that both banner rows must be clipped —
+// the case a single-row combined banner could never satisfy in a
+// realistic ~20-col pane.
+func TestFrameGeometryDisciplineNarrow(t *testing.T) {
+	const cols, rows = 10, 24
+	for _, style := range testStyles {
+		t.Run(string(style), func(t *testing.T) {
+			geoRaw := bannerGeometryRow(cols, rows)
+			if len(geoRaw) <= cols {
+				t.Fatalf("test geometry too wide to exercise truncation: row %q (%d bytes) already fits %d cols", geoRaw, len(geoRaw), cols)
+			}
+
+			geoTrunc := TruncateToWidth(geoRaw, cols)
+			if len(geoTrunc) != cols {
+				t.Fatalf("TruncateToWidth(%q, %d) = %q (%d bytes), want exactly %d bytes", geoRaw, cols, geoTrunc, len(geoTrunc), cols)
+			}
+
+			frame := Frame(style, cols, rows, 1)
+			if bytes.Contains(frame, []byte(geoRaw)) {
+				t.Fatalf("frame contains the untruncated geometry row %q; must be clipped to %d cols", geoRaw, cols)
+			}
+			if !bytes.Contains(frame, []byte(geoTrunc)) {
+				t.Fatalf("frame does not contain the expected truncated geometry row %q", geoTrunc)
+			}
+		})
+	}
+}

--- a/internal/probetui/run_test.go
+++ b/internal/probetui/run_test.go
@@ -1,0 +1,97 @@
+package probetui
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRunDrivesStartupResizeAndTeardown(t *testing.T) {
+	var mu sync.Mutex
+	cols, rows := 80, 24
+	size := func() (int, int, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		return cols, rows, nil
+	}
+
+	var buf bytes.Buffer
+	var writeMu sync.Mutex
+	syncWriter := writerFunc(func(p []byte) (int, error) {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		return buf.Write(p)
+	})
+
+	winch := make(chan os.Signal, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, syncWriter, StyleClaude, size, winch, 10*time.Millisecond)
+	}()
+
+	// Let at least one frame render at the initial geometry before resizing.
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	cols, rows = 62, 27
+	mu.Unlock()
+	winch <- os.Interrupt // stand-in for SIGWINCH; Run only reads from the channel
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancellation")
+	}
+
+	writeMu.Lock()
+	out := buf.Bytes()
+	writeMu.Unlock()
+
+	startup := Startup(StyleClaude, 80, 24)
+	if !bytes.HasPrefix(out, startup) {
+		t.Fatalf("output does not start with Startup(80,24)")
+	}
+
+	oldBanner := []byte(bannerGeometryRow(80, 24))
+	if !bytes.Contains(out, oldBanner) {
+		t.Fatalf("output missing a frame at the initial geometry (banner %q)", oldBanner)
+	}
+
+	resize := OnResize(StyleClaude, 62, 27)
+	if !bytes.Contains(out, resize) {
+		t.Fatalf("output missing the OnResize(62,27) sequence")
+	}
+
+	newBanner := []byte(bannerGeometryRow(62, 27))
+	foundNewFrame := bytes.Contains(out, newBanner)
+	if !foundNewFrame {
+		t.Fatalf("output missing a frame at the resized geometry (62x27)")
+	}
+
+	teardown := Teardown(StyleClaude)
+	if !bytes.HasSuffix(out, teardown) {
+		t.Fatalf("output does not end with Teardown()")
+	}
+
+	// The resize sequence must appear before any frame at the new geometry.
+	resizeIdx := bytes.Index(out, resize)
+	newFrameIdx := bytes.Index(out, newBanner)
+	if resizeIdx < 0 || newFrameIdx < 0 || resizeIdx > newFrameIdx {
+		t.Fatalf("OnResize must precede the first frame at the new geometry, got resizeIdx=%d newFrameIdx=%d", resizeIdx, newFrameIdx)
+	}
+}
+
+type writerFunc func(p []byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }

--- a/internal/probetui/testdata/agent-vocab-claude.json
+++ b/internal/probetui/testdata/agent-vocab-claude.json
@@ -1,0 +1,108 @@
+{
+  "boundaryOffset": 2824,
+  "phase1": {
+    "totalBytes": 2824,
+    "privateModeSet": {
+      "1000": 1,
+      "1002": 1,
+      "1003": 1,
+      "1004": 1,
+      "1006": 1,
+      "1049": 1,
+      "2004": 1,
+      "2026": 4,
+      "2031": 1,
+      "25": 5
+    },
+    "privateModeReset": {
+      "2026": 4,
+      "25": 4
+    },
+    "altScreenEnter": 1,
+    "altScreenExit": 0,
+    "ed": 1,
+    "el": 3,
+    "cup": 13,
+    "sgr": 62,
+    "smNonPrivate": 0,
+    "rmNonPrivate": 0,
+    "oscByCode": {
+      "0": 1,
+      "8": 2
+    },
+    "da1QueryFromChild": 1,
+    "cprQueryFromChild": 0,
+    "decrqmFromChild": 0,
+    "xtgettcapFromChild": 0,
+    "oscColorQueryFromChild": {},
+    "cursorSaveDECSC": 1,
+    "cursorRestoreDECRC": 1,
+    "cursorSaveCSI_s": 0,
+    "cursorRestoreCSI_u": 4,
+    "decstbm": 1,
+    "newlines": 1,
+    "carriageReturns": 20,
+    "otherCSIFinal": {
+      "B": 19,
+      "C": 9,
+      "G": 5,
+      "q": 1
+    },
+    "otherESCFinal": {}
+  },
+  "phase2": {
+    "totalBytes": 1591,
+    "privateModeSet": {
+      "1000": 1,
+      "1002": 1,
+      "1003": 1,
+      "1006": 1,
+      "2026": 2,
+      "25": 6
+    },
+    "privateModeReset": {
+      "1000": 3,
+      "1002": 3,
+      "1003": 3,
+      "1004": 3,
+      "1006": 3,
+      "1049": 1,
+      "2004": 3,
+      "2026": 2,
+      "2031": 3,
+      "25": 1
+    },
+    "altScreenEnter": 0,
+    "altScreenExit": 1,
+    "ed": 1,
+    "el": 0,
+    "cup": 3,
+    "sgr": 45,
+    "smNonPrivate": 0,
+    "rmNonPrivate": 0,
+    "oscByCode": {
+      "0": 1,
+      "8": 2
+    },
+    "da1QueryFromChild": 0,
+    "cprQueryFromChild": 0,
+    "decrqmFromChild": 0,
+    "xtgettcapFromChild": 0,
+    "oscColorQueryFromChild": {},
+    "cursorSaveDECSC": 2,
+    "cursorRestoreDECRC": 2,
+    "cursorSaveCSI_s": 0,
+    "cursorRestoreCSI_u": 4,
+    "decstbm": 2,
+    "newlines": 0,
+    "carriageReturns": 11,
+    "otherCSIFinal": {
+      "B": 11,
+      "C": 5,
+      "G": 5
+    },
+    "otherESCFinal": {
+      "(": 2
+    }
+  }
+}

--- a/internal/probetui/testdata/agent-vocab-codex.json
+++ b/internal/probetui/testdata/agent-vocab-codex.json
@@ -1,0 +1,84 @@
+{
+  "boundaryOffset": 3710,
+  "phase1": {
+    "totalBytes": 3710,
+    "privateModeSet": {
+      "1004": 1,
+      "2004": 1,
+      "2026": 1
+    },
+    "privateModeReset": {
+      "2026": 1,
+      "25": 1
+    },
+    "altScreenEnter": 0,
+    "altScreenExit": 0,
+    "ed": 1,
+    "el": 24,
+    "cup": 38,
+    "sgr": 64,
+    "smNonPrivate": 0,
+    "rmNonPrivate": 0,
+    "oscByCode": {
+      "10": 1,
+      "11": 1,
+      "8": 94
+    },
+    "da1QueryFromChild": 1,
+    "cprQueryFromChild": 1,
+    "decrqmFromChild": 0,
+    "xtgettcapFromChild": 0,
+    "oscColorQueryFromChild": {
+      "10": 1,
+      "11": 1
+    },
+    "cursorSaveDECSC": 0,
+    "cursorRestoreDECRC": 0,
+    "cursorSaveCSI_s": 0,
+    "cursorRestoreCSI_u": 2,
+    "decstbm": 2,
+    "newlines": 0,
+    "carriageReturns": 0,
+    "otherCSIFinal": {
+      "S": 1
+    },
+    "otherESCFinal": {}
+  },
+  "phase2": {
+    "totalBytes": 3588,
+    "privateModeSet": {
+      "2026": 1
+    },
+    "privateModeReset": {
+      "2026": 1,
+      "25": 1
+    },
+    "altScreenEnter": 0,
+    "altScreenExit": 0,
+    "ed": 2,
+    "el": 26,
+    "cup": 41,
+    "sgr": 67,
+    "smNonPrivate": 0,
+    "rmNonPrivate": 0,
+    "oscByCode": {
+      "8": 90
+    },
+    "da1QueryFromChild": 0,
+    "cprQueryFromChild": 1,
+    "decrqmFromChild": 0,
+    "xtgettcapFromChild": 0,
+    "oscColorQueryFromChild": {},
+    "cursorSaveDECSC": 0,
+    "cursorRestoreDECRC": 0,
+    "cursorSaveCSI_s": 0,
+    "cursorRestoreCSI_u": 0,
+    "decstbm": 2,
+    "newlines": 0,
+    "carriageReturns": 0,
+    "otherCSIFinal": {
+      "S": 1
+    },
+    "otherESCFinal": {}
+  }
+}

--- a/internal/probetui/vtvocab/vtvocab.go
+++ b/internal/probetui/vtvocab/vtvocab.go
@@ -1,0 +1,262 @@
+// Package vtvocab scans raw terminal byte streams and counts the VT feature
+// families used by internal/probetui's mirror tests: private mode
+// sets/resets, alt-screen transitions, cursor addressing, OSC codes,
+// terminal queries issued by the child, cursor save/restore, and the
+// leftover CSI/ESC finals that don't fit a named bucket.
+//
+// This is a single linear scan, not a full VT parser: unrecognized CSI/ESC
+// finals fall into "other" buckets keyed by final byte so nothing is
+// silently dropped; DCS sequences are bucketed as XTGETTCAP-style child
+// queries. Ported from the agent-mirror capture tool's analyzer.
+package vtvocab
+
+import "strings"
+
+// Stats counts one phase's worth of VT feature usage. Field JSON tags match
+// the agent-mirror capture tool's analysis.json shape.
+type Stats struct {
+	TotalBytes int64 `json:"totalBytes"`
+
+	PrivateModeSet   map[string]int `json:"privateModeSet"`
+	PrivateModeReset map[string]int `json:"privateModeReset"`
+
+	AltScreenEnter int `json:"altScreenEnter"`
+	AltScreenExit  int `json:"altScreenExit"`
+
+	ED  int `json:"ed"`
+	EL  int `json:"el"`
+	CUP int `json:"cup"`
+	SGR int `json:"sgr"`
+
+	SMNonPrivate int `json:"smNonPrivate"`
+	RMNonPrivate int `json:"rmNonPrivate"`
+
+	OSCByCode map[string]int `json:"oscByCode"`
+
+	// Queries issued BY the child process.
+	DA1QueryFromChild      int            `json:"da1QueryFromChild"`
+	CPRQueryFromChild      int            `json:"cprQueryFromChild"`
+	DECRQMFromChild        int            `json:"decrqmFromChild"`
+	XTGETTCAPFromChild     int            `json:"xtgettcapFromChild"`
+	OSCColorQueryFromChild map[string]int `json:"oscColorQueryFromChild"`
+
+	CursorSaveDECSC    int `json:"cursorSaveDECSC"`
+	CursorRestoreDECRC int `json:"cursorRestoreDECRC"`
+	CursorSaveCSIs     int `json:"cursorSaveCSI_s"`
+	CursorRestoreCSIu  int `json:"cursorRestoreCSI_u"`
+
+	DECSTBM int `json:"decstbm"`
+
+	Newlines        int `json:"newlines"`
+	CarriageReturns int `json:"carriageReturns"`
+
+	OtherCSIFinal map[string]int `json:"otherCSIFinal"`
+	OtherESCFinal map[string]int `json:"otherESCFinal"`
+}
+
+func newStats() *Stats {
+	return &Stats{
+		PrivateModeSet:         map[string]int{},
+		PrivateModeReset:       map[string]int{},
+		OSCByCode:              map[string]int{},
+		OSCColorQueryFromChild: map[string]int{},
+		OtherCSIFinal:          map[string]int{},
+		OtherESCFinal:          map[string]int{},
+	}
+}
+
+var altScreenModes = map[string]bool{"47": true, "1047": true, "1049": true}
+
+// Analyze scans raw and returns the VT feature counts observed in it.
+func Analyze(raw []byte) Stats {
+	s := newStats()
+
+	n := len(raw)
+	i := 0
+	for i < n {
+		b := raw[i]
+		if b != 0x1b {
+			switch b {
+			case '\n':
+				s.Newlines++
+			case '\r':
+				s.CarriageReturns++
+			}
+			i++
+			continue
+		}
+
+		// ESC at i. Need at least one more byte to classify.
+		if i+1 >= n {
+			i++
+			break
+		}
+		esc := raw[i+1]
+
+		switch esc {
+		case '[': // CSI
+			j := i + 2
+			for j < n && raw[j] < 0x40 {
+				j++
+			}
+			if j >= n {
+				i = j
+				break
+			}
+			final := raw[j]
+			params := string(raw[i+2 : j])
+			classifyCSI(s, params, final)
+			i = j + 1
+
+		case ']': // OSC, terminated by BEL or ST (ESC \)
+			j := i + 2
+			for j < n {
+				if raw[j] == 0x07 {
+					break
+				}
+				if raw[j] == 0x1b && j+1 < n && raw[j+1] == '\\' {
+					break
+				}
+				j++
+			}
+			content := string(raw[i+2 : min(j, n)])
+			classifyOSC(s, content)
+			if j < n && raw[j] == 0x07 {
+				i = j + 1
+			} else if j+1 < n {
+				i = j + 2
+			} else {
+				i = n
+			}
+
+		case 'P': // DCS, terminated by ST (ESC \); approximated as XTGETTCAP bucket
+			j := i + 2
+			for j < n {
+				if raw[j] == 0x1b && j+1 < n && raw[j+1] == '\\' {
+					break
+				}
+				j++
+			}
+			s.XTGETTCAPFromChild++
+			if j+1 < n {
+				i = j + 2
+			} else {
+				i = n
+			}
+
+		case '7':
+			s.CursorSaveDECSC++
+			i += 2
+
+		case '8':
+			s.CursorRestoreDECRC++
+			i += 2
+
+		default:
+			s.OtherESCFinal[string(esc)]++
+			i += 2
+		}
+	}
+
+	s.TotalBytes = int64(n)
+
+	return *s
+}
+
+func classifyCSI(c *Stats, params string, final byte) {
+	private := strings.HasPrefix(params, "?")
+
+	switch {
+	case private && (final == 'h' || final == 'l'):
+		modes := strings.Split(strings.TrimPrefix(params, "?"), ";")
+		for _, m := range modes {
+			if m == "" {
+				continue
+			}
+			if final == 'h' {
+				c.PrivateModeSet[m]++
+				if altScreenModes[m] {
+					c.AltScreenEnter++
+				}
+			} else {
+				c.PrivateModeReset[m]++
+				if altScreenModes[m] {
+					c.AltScreenExit++
+				}
+			}
+		}
+		return
+
+	case private && final == 'p' && strings.HasSuffix(params, "$"):
+		c.DECRQMFromChild++
+		return
+
+	case !private && (final == 'h' || final == 'l'):
+		if final == 'h' {
+			c.SMNonPrivate++
+		} else {
+			c.RMNonPrivate++
+		}
+		return
+	}
+
+	switch final {
+	case 'J':
+		c.ED++
+	case 'K':
+		c.EL++
+	case 'H':
+		c.CUP++
+	case 'm':
+		c.SGR++
+	case 'r':
+		if !private {
+			c.DECSTBM++
+		} else {
+			c.OtherCSIFinal[string(final)]++
+		}
+	case 's':
+		if !private {
+			c.CursorSaveCSIs++
+		} else {
+			c.OtherCSIFinal[string(final)]++
+		}
+	case 'u':
+		c.CursorRestoreCSIu++
+	case 'c':
+		if params == "" || params == "0" {
+			c.DA1QueryFromChild++
+		} else {
+			c.OtherCSIFinal[string(final)]++
+		}
+	case 'n':
+		if params == "6" {
+			c.CPRQueryFromChild++
+		} else {
+			c.OtherCSIFinal[string(final)]++
+		}
+	default:
+		c.OtherCSIFinal[string(final)]++
+	}
+}
+
+func classifyOSC(c *Stats, content string) {
+	code := content
+	rest := ""
+	if idx := strings.IndexByte(content, ';'); idx >= 0 {
+		code = content[:idx]
+		rest = content[idx+1:]
+	}
+	c.OSCByCode[code]++
+
+	if (code == "10" || code == "11" || code == "12") && rest == "?" {
+		c.OSCColorQueryFromChild[code]++
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -688,6 +688,12 @@ func (s *Session) resize(cols, rows uint16) error {
 	return creackpty.Setsize(s.ptmx, &creackpty.Winsize{Cols: cols, Rows: rows})
 }
 
+// sigtermToHUPGrace is how long kill waits for a SIGTERM'd child before
+// escalating to SIGHUP. Interactive shells ignore SIGTERM by design but
+// every shell honors terminal hangup; without this escalation a shell
+// pane close stalls the full kill timeout and ends in SIGKILL.
+const sigtermToHUPGrace = 2 * time.Second
+
 func (s *Session) kill(sig syscall.Signal, waitTimeout time.Duration) error {
 	s.exitMu.RLock()
 	running := s.running
@@ -712,10 +718,25 @@ func (s *Session) kill(sig syscall.Signal, waitTimeout time.Duration) error {
 		return err
 	}
 
+	deadline := time.Now().Add(waitTimeout)
+
+	if sig == syscall.SIGTERM {
+		grace := sigtermToHUPGrace
+		if half := waitTimeout / 2; grace > half {
+			grace = half
+		}
+		select {
+		case <-s.exited:
+			return nil
+		case <-time.After(grace):
+			_ = syscall.Kill(-pgid, syscall.SIGHUP)
+		}
+	}
+
 	select {
 	case <-s.exited:
 		return nil
-	case <-time.After(waitTimeout):
+	case <-time.After(time.Until(deadline)):
 		_ = syscall.Kill(-pgid, syscall.SIGKILL)
 		<-s.exited
 		return nil

--- a/internal/pty/session_kill_test.go
+++ b/internal/pty/session_kill_test.go
@@ -1,0 +1,141 @@
+package pty
+
+import (
+	"bytes"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// waitForKillReady polls the session's scrollback until it contains the
+// readiness marker the spawned script emits right after installing its
+// signal traps. Without this, kill() could race the child's own startup and
+// send its signal before the trap is installed, which would make a shell
+// exit to the raw signal for the wrong reason and silently pass the test.
+func waitForKillReady(t *testing.T, s *Session, marker string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if bytes.Contains(s.info().Scrollback, []byte(marker)) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for readiness marker %q", marker)
+}
+
+func spawnKillTestSession(t *testing.T, id, script string) *Session {
+	t.Helper()
+	m := NewManager(DefaultScrollbackSize, nil)
+	t.Cleanup(m.Shutdown)
+
+	if err := m.Spawn(SpawnOptions{
+		ID:              id,
+		CWD:             t.TempDir(),
+		Agent:           "probe-kill",
+		ExternalCommand: []string{"/bin/bash", "-c", script},
+		Cols:            80,
+		Rows:            24,
+	}); err != nil {
+		t.Fatalf("Spawn() error: %v", err)
+	}
+
+	s, err := m.getSession(id)
+	if err != nil {
+		t.Fatalf("getSession() error: %v", err)
+	}
+	waitForKillReady(t, s, "__KILLREADY__")
+	return s
+}
+
+// TestKill_SIGTERMIgnoringShellExitsViaSIGHUP covers a shell that ignores
+// SIGTERM (as interactive/login shells commonly do) but honors SIGHUP. This
+// fails on the pre-fix kill(), which rides the full waitTimeout to SIGKILL
+// (~8s elapsed, exit signal "killed") instead of escalating to SIGHUP.
+func TestKill_SIGTERMIgnoringShellExitsViaSIGHUP(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real PTY spawn in short mode")
+	}
+
+	s := spawnKillTestSession(t, "kill-term-ignored", `trap '' TERM; echo __KILLREADY__; while :; do sleep 0.1; done`)
+
+	start := time.Now()
+	if err := s.kill(syscall.SIGTERM, 8*time.Second); err != nil {
+		t.Fatalf("kill() error: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if elapsed >= 6*time.Second {
+		t.Fatalf("kill() took %v, want well under the 8s deadline (should escalate to SIGHUP)", elapsed)
+	}
+
+	info := s.info()
+	if info.ExitSignal == nil || *info.ExitSignal != syscall.SIGHUP.String() {
+		got := "<nil>"
+		if info.ExitSignal != nil {
+			got = *info.ExitSignal
+		}
+		t.Fatalf("ExitSignal = %s, want %s", got, syscall.SIGHUP.String())
+	}
+}
+
+// TestKill_TERMAndHUPIgnoringChildFallsBackToSIGKILL covers a child that
+// ignores both SIGTERM and SIGHUP, so kill() must still fall back to SIGKILL
+// once waitTimeout expires. Catches a bug where SIGHUP escalation replaced
+// the SIGKILL backstop instead of supplementing it.
+func TestKill_TERMAndHUPIgnoringChildFallsBackToSIGKILL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real PTY spawn in short mode")
+	}
+
+	s := spawnKillTestSession(t, "kill-term-hup-ignored", `trap '' TERM HUP; echo __KILLREADY__; while :; do sleep 0.1; done`)
+
+	start := time.Now()
+	if err := s.kill(syscall.SIGTERM, 1500*time.Millisecond); err != nil {
+		t.Fatalf("kill() error: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	info := s.info()
+	if info.ExitSignal == nil || *info.ExitSignal != syscall.SIGKILL.String() {
+		got := "<nil>"
+		if info.ExitSignal != nil {
+			got = *info.ExitSignal
+		}
+		t.Fatalf("ExitSignal = %s, want %s", got, syscall.SIGKILL.String())
+	}
+	if elapsed < 1200*time.Millisecond {
+		t.Fatalf("kill() took %v, want it to ride the full ladder (>= ~1.2s)", elapsed)
+	}
+}
+
+// TestKill_CooperativeChildExitsOnSIGTERMBeforeGrace covers the common case:
+// a child that exits promptly on SIGTERM should not wait out
+// sigtermToHUPGrace. Catches a regression where kill always waits out the
+// grace period regardless of whether the child already exited.
+func TestKill_CooperativeChildExitsOnSIGTERMBeforeGrace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real PTY spawn in short mode")
+	}
+
+	s := spawnKillTestSession(t, "kill-term-cooperative", `echo __KILLREADY__; while :; do sleep 0.1; done`)
+
+	start := time.Now()
+	if err := s.kill(syscall.SIGTERM, 8*time.Second); err != nil {
+		t.Fatalf("kill() error: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if elapsed >= 1500*time.Millisecond {
+		t.Fatalf("kill() took %v, want well under sigtermToHUPGrace (should not wait out the grace)", elapsed)
+	}
+
+	info := s.info()
+	if info.ExitSignal == nil || *info.ExitSignal != syscall.SIGTERM.String() {
+		got := "<nil>"
+		if info.ExitSignal != nil {
+			got = *info.ExitSignal
+		}
+		t.Fatalf("ExitSignal = %s, want %s", got, syscall.SIGTERM.String())
+	}
+}

--- a/internal/ptybackend/worker.go
+++ b/internal/ptybackend/worker.go
@@ -29,7 +29,13 @@ import (
 )
 
 const (
-	defaultRPCTimeout    = 5 * time.Second
+	defaultRPCTimeout = 5 * time.Second
+	// killRPCTimeout must outlive the worker's in-RPC kill escalation
+	// (pty's 10s kill timeout): the signal RPC replies only once the child
+	// has exited, and the 5s default deadline would abandon a confirmed
+	// kill mid-flight and tear down the serial control connection right
+	// before the follow-up remove call needs it.
+	killRPCTimeout       = 15 * time.Second
 	livenessRPCTimeout   = 2 * time.Second
 	reclaimRPCTimeout    = 3 * time.Second
 	pollerInterval       = 5 * time.Second
@@ -784,6 +790,11 @@ func (b *WorkerBackend) Kill(ctx context.Context, sessionID string, sig syscall.
 	session, err := b.getSession(sessionID)
 	if err != nil {
 		return err
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, killRPCTimeout)
+		defer cancel()
 	}
 	return b.callSimple(ctx, session, ptyworker.MethodSignal, ptyworker.SignalParams{Signal: signalName(sig)})
 }


### PR DESCRIPTION
## Summary

Continues the live-app matrix stabilization from #631. Four arcs:

- **OrbStack remote endpoint**: remote scenarios (tr205, tr402-remote, tr502, tr504, bridge-remote-hub) now default to a local OrbStack VM `attn-remote@orb`, rebuildable from the checked-in `provision-orb-remote.sh` (`pnpm --dir app run real-app:provision-remote`), replacing the retired ai-sandbox host. `ATTN_HARNESS_REMOTE_SSH_TARGET` retargets all remote scenarios at once.
- **tr205 deterministic probe legs**: new hidden `attn _probe-tui` command (`internal/probetui`) mimics codex/claude TUIs with styles pinned to recorded VT vocabulary and two-sided mirror tests; `cmd/agent-mirror` re-captures fixtures. The matrix runs `tr205-probe-codex`/`tr205-probe-claude` without a live model; the real-agent legs become `soakOnly` (need credentials seeded in the VM).
- **Real product fix — pane width recovery** (found by the probe legs): `fitShouldBailAsSuspicious` refused grows from an already-suspicious model, so panes shrunk by a neighboring split stayed stuck narrow after the split closed. Fixed in `GhosttyTerminal.tsx` + unit tests.
- **Real product fix — shell-pane close / remote worker leak** (found via tr504): interactive `bash -l` ignores SIGTERM, so closing a shell pane stalled 10s to SIGKILL, and on remote endpoints the worker's in-RPC kill blew the 5s control-conn deadline and leaked the worker. `Session.kill` now escalates to SIGHUP after a 2s grace (SIGKILL backstop intact); `WorkerBackend.Kill` gets a 15s deadline. Shell panes close in ~2s. Three new real-PTY kill tests. tr504 reworked to model the real ⌘W flow (close_session closes only that session's pane by design — the scenario now closes the split shell pane explicitly and verifies remote worker exit).

Also: automation-lifecycle aligned with the #629 enabled-outside-spec rule; tr401 codex header assertion tolerates the CLI update banner.

## Verification

- `go test ./...` green; new kill tests pass with meaningful timings (SIGHUP path 2.1s, SIGKILL fallback, cooperative fast-exit).
- Frontend unit tests green including new `GhosttyTerminal.resizePolicy` cases; probe mirror tests enforce vocabulary in both directions.
- Live-verified on throwaway profile `fxm1` (full `make install`): tr504 passes solo (shell-close step completes in ~2.1s — the SIGHUP grace — remote worker processes 9→4→0→0) and in-matrix (8.2s vs prior 71.3s timeout).
- Full 35-scenario serial matrix: 32/35; all three fails classified from digests as known rotating flakes (close/unregister matrix-only class, codex-resume live-agent discretion, one ghostty-scroll anchor one-off that passed solo immediately after). Every scenario now has a green steady state.

https://claude.ai/code/session_01LuiYi429D8eqxyPNPunS6C