### PR TITLE
refactor(automations): unify the daemon protocol on one per-action surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   triggered a redraw.
 - Closing a shell pane now hangs the shell up promptly instead of stalling ~10 seconds and force-killing it; remote pane/session close reliably confirms worker teardown instead of timing out mid-kill.
 
+### Changed
+- **The automations CLI's `attn automation show` now prints the definition's
+  YAML directly to stdout** instead of a JSON-wrapped blob, and `delete`,
+  `validate`, and `cleanup` print small purpose-built summaries instead of raw
+  store rows. The Automations panel's list badge (which run failed, and when)
+  now loads with the rest of the list in one request instead of a separate
+  fetch per definition, so opening the panel with many automations feels
+  noticeably snappier.
+
 ## [2026-07-21]
 
 ### Fixed

--- a/app/scripts/real-app-harness/scenario-automation-editor.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-editor.mjs
@@ -29,11 +29,13 @@
  * actually be created.
  *
  * No fake-agent probe is needed: this scenario never triggers a run. Every
- * definition it applies is manual-trigger, and all but leg10's are also
- * enabled: false, so `launch.executable` is never invoked and can stay unset
- * like the starter template's. leg10 must start from an enabled definition in
- * order to disable it from the panel; being manual-trigger, it still never
- * fires, and the leg deletes it before finishing.
+ * definition it applies is manual-trigger, so `launch.executable` is never
+ * invoked and can stay unset like the starter template's, regardless of
+ * enabled state. `enabled` is column-only post-PR5 (spec YAML/JSON no longer
+ * carries it at all — see errEnabledManagedOutsideSpec in
+ * internal/automation/automation.go) and every apply of a brand-new id always
+ * inserts it enabled; leg10 relies on exactly that default to get an enabled
+ * definition to disable from the panel, and deletes it before finishing.
  *
  * Run serially (packaged-app scenarios are single-tenant):
  *   ATTN_HARNESS_PROFILE=<name> node scripts/real-app-harness/scenario-automation-editor.mjs
@@ -97,6 +99,19 @@ function findListRow(binary, id, env) {
   return list.find((row) => row.id === id) || null;
 }
 
+// A soft-deleted (or never-existed) id makes `automation show` exit 1 with
+// "automation: daemon error: ..." on stderr, rather than printing anything
+// JSON-parseable — there is no more null/empty-document result to check.
+function showFailsWithDaemonError(binary, id, env) {
+  try {
+    run(binary, ['automation', 'show', id], env);
+    return false;
+  } catch (error) {
+    const stderr = typeof error.stderr === 'string' ? error.stderr : String(error.stderr || error.message || error);
+    return stderr.includes('automation: daemon error');
+  }
+}
+
 async function poll(fn, description, timeoutMs = 30_000) {
   const started = Date.now();
   let last = null;
@@ -152,20 +167,20 @@ async function toggleEnabledAndWait(client, definitionId, wantEnabled) {
 
 const API_VERSION = 'attn.dev/automations/v1alpha1';
 
-// Defaults to enabled: false — this scenario never triggers a run, and
-// leaving these definitions disabled means the finally block does not need to
-// disable-before-teardown like scenario-automation-lifecycle.mjs (an enabled
-// directory-location definition re-validates its path on every future daemon
-// tick, which would spam errors once the fixture dir is gone). leg10 is the
-// one caller that opts into enabled: true, because it has to start from an
-// enabled definition to disable it from the panel; it deletes that definition
-// at the end of the leg for the same reason.
-function editorDefinitionYAML({ id, locationPath, prompt, comment, enabled = false }) {
+// `enabled` is not a spec field post-PR5 (it is the enabled COLUMN's sole
+// authority; a YAML carrying `enabled:` is rejected outright — see
+// errEnabledManagedOutsideSpec in internal/automation/automation.go), so this
+// template never emits it. Every apply of a brand-new id is inserted enabled
+// regardless (store.UpsertAutomationDefinition); that is harmless here since
+// every definition this scenario applies is manual-trigger and never fires on
+// its own. leg10 relies on that same default-enabled behavior to get a
+// definition it can disable from the panel, and deletes it at the end of the
+// leg.
+function editorDefinitionYAML({ id, locationPath, prompt, comment }) {
   const commentLine = comment ? `${comment}\n` : '';
   return `${commentLine}api_version: ${API_VERSION}
 id: ${id}
 name: Slice 7 packaged editor proof
-enabled: ${enabled ? 'true' : 'false'}
 trigger:
   type: manual
 prompt: |
@@ -494,9 +509,10 @@ async function main() {
       const afterFinalSave = await client.request('automation_editor_click', { button: 'save' });
       runner.assert(afterFinalSave.present === false, 'the recovered Save succeeds and closes the editor', afterFinalSave);
 
-      const finalShown = runJSON(binary, ['automation', 'show', primaryID], daemonEnv);
-      runner.assert(finalShown.Revision === outOfBandRevision + 1, 'the recovered save bumps the revision once more', finalShown);
-      runner.assert(finalShown.SpecYAML.includes(localPromptA), 'the recovered save persists the locally re-applied content', finalShown);
+      const finalRow = findListRow(binary, primaryID, daemonEnv);
+      const finalYAML = showSpecYAML(binary, primaryID, daemonEnv);
+      runner.assert(finalRow.revision === outOfBandRevision + 1, 'the recovered save bumps the revision once more', finalRow);
+      runner.assert(finalYAML.includes(localPromptA), 'the recovered save persists the locally re-applied content', finalYAML);
     });
 
     // Leg 8 (defect A regression proof): a comment-only edit — the exact
@@ -509,20 +525,21 @@ async function main() {
     // loaded, so everything after that line is untouched by construction —
     // if spec_json also moved, this leg would prove nothing.
     await runner.step('leg8_comment_only_edit_bumps_revision', async () => {
-      const shownBefore = runJSON(binary, ['automation', 'show', primaryID], daemonEnv);
+      const rowBefore = findListRow(binary, primaryID, daemonEnv);
+      const yamlBefore = showSpecYAML(binary, primaryID, daemonEnv);
 
       const opened = await client.request('automation_editor_open', { definitionId: primaryID });
       runner.assert(opened.mode === 'edit', 'opening the shared definition for edit starts in edit mode', opened);
       runner.assert(opened.definitionId === primaryID, 'edit mode reports the definition id being edited', opened);
       runner.assert(
-        opened.revision === shownBefore.Revision,
+        opened.revision === rowBefore.revision,
         "the editor's revision matches the CLI's independently-read revision",
-        { opened, shownBefore },
+        { opened, rowBefore },
       );
       runner.assert(
-        opened.text === shownBefore.SpecYAML,
+        opened.text === yamlBefore,
         'the editor buffer loads exactly the stored spec_yaml bytes — the baseline this leg edits from',
-        { opened, shownBefore },
+        { opened, yamlBefore },
       );
 
       const leg8Comment = `# harness-marker-leg8: ${suffix}`;
@@ -535,26 +552,28 @@ async function main() {
       const afterSave = await client.request('automation_editor_click', { button: 'save' });
       runner.assert(afterSave.present === false, 'the comment-only save succeeds and closes the editor', afterSave);
 
-      const shownAfter = runJSON(binary, ['automation', 'show', primaryID], daemonEnv);
+      const rowAfter = findListRow(binary, primaryID, daemonEnv);
+      const yamlAfter = showSpecYAML(binary, primaryID, daemonEnv);
       runner.assert(
-        shownAfter.Revision === shownBefore.Revision + 1,
+        rowAfter.revision === rowBefore.revision + 1,
         'D-A: a comment-only edit still bumps the revision — the stale-save guard is no longer blind to comment-only changes',
-        { before: shownBefore.Revision, after: shownAfter.Revision },
+        { before: rowBefore.revision, after: rowAfter.revision },
       );
       runner.assert(
-        shownAfter.SpecYAML === commentOnlyYAML,
+        yamlAfter === commentOnlyYAML,
         'the stored spec_yaml is exactly the comment-prepended buffer — nothing else moved',
-        { expected: commentOnlyYAML, actual: shownAfter.SpecYAML },
+        { expected: commentOnlyYAML, actual: yamlAfter },
       );
-      // The assertion that actually matters for D-A: prove this was a pure
-      // comment edit by checking the CANONICAL spec, not just the YAML text.
-      // A future refactor that starts folding comments into spec_json would
-      // otherwise leave this leg passing for the wrong reason.
-      runner.assert(
-        shownAfter.SpecJSON === shownBefore.SpecJSON,
-        'the canonical spec_json is byte-identical before/after — this was a pure comment edit, not a disguised content change',
-        { before: shownBefore.SpecJSON, after: shownAfter.SpecJSON },
-      );
+      // D-A originally also proved the canonical spec_json was byte-identical
+      // before/after, to rule out this leg passing because a refactor folded
+      // comments into spec_json instead of because the revision bump logic
+      // was fixed. The unified CLI (`automation show`/`list`) no longer
+      // exposes spec_json at all — it prints plain spec_yaml text or a
+      // lowercase summary with no spec fields — so that check has no
+      // CLI-observable equivalent post-PR5. Equivalent coverage lives at the
+      // store/daemon unit-test level (internal/store/automations_test.go,
+      // internal/store/sqlite_test.go), which assert the spec_json bump
+      // condition directly against the canonical struct.
     });
 
     // Leg 9 (defect B regression proof): a definition deleted out of band
@@ -566,18 +585,18 @@ async function main() {
     // out-of-band-mutation shape, but via `automation delete` instead of
     // `automation apply`.
     await runner.step('leg9_delete_elsewhere_then_save_refused', async () => {
-      const shownBefore = runJSON(binary, ['automation', 'show', primaryID], daemonEnv);
+      const rowBefore = findListRow(binary, primaryID, daemonEnv);
       runner.assert(
-        shownBefore && shownBefore.ID === primaryID,
+        rowBefore && rowBefore.id === primaryID,
         'sanity: the shared definition is still live before this leg deletes it',
-        shownBefore,
+        rowBefore,
       );
 
       const opened = await client.request('automation_editor_open', { definitionId: primaryID });
       runner.assert(opened.mode === 'edit', 'opening the shared definition for edit starts in edit mode', opened);
       runner.assert(opened.definitionId === primaryID, 'edit mode reports the definition id being edited', opened);
       runner.assert(
-        opened.revision === shownBefore.Revision,
+        opened.revision === rowBefore.revision,
         "the editor holds the definition's current revision before the out-of-band delete",
         opened,
       );
@@ -626,19 +645,25 @@ async function main() {
         'the definition is still gone after the refused save — it was not resurrected',
         listAfterRefusedSave,
       );
-      const shownAfterRefusedSave = runJSON(binary, ['automation', 'show', primaryID], daemonEnv);
       runner.assert(
-        shownAfterRefusedSave === null,
-        'the CLI also reports the definition as gone (filtered like any soft-deleted row) after the refused save',
-        shownAfterRefusedSave,
+        showFailsWithDaemonError(binary, primaryID, daemonEnv),
+        'the CLI also reports the definition as gone (a daemon error, like any soft-deleted row) after the refused save',
+        primaryID,
       );
     });
 
-    // The reviewer-reported split brain: `enabled` was written by the panel
-    // toggle (column only) AND by a save (from the YAML), with nothing keeping
-    // them in step. Disable, then edit, and the stale `enabled: true` in the
-    // stored YAML came back — for a cron trigger, unattended sessions firing
-    // again after the operator turned them off, reported as a clean save.
+    // The reviewer-reported split brain: `enabled` used to be written by the
+    // panel toggle (column only) AND by a save (from the YAML), with nothing
+    // keeping them in step. Disable, then edit, and the stale `enabled: true`
+    // in the stored YAML came back — for a cron trigger, unattended sessions
+    // firing again after the operator turned them off, reported as a clean
+    // save. Post-PR5 `enabled` has exactly one authority (the column; the spec
+    // cannot carry it at all — errEnabledManagedOutsideSpec), which makes the
+    // split brain structurally impossible rather than merely fixed — this leg
+    // now also pins that the editor's buffer and the stored spec_yaml never
+    // contain an `enabled:` key at all, so a regression that reintroduces one
+    // fails loudly (a parse error on apply) rather than silently disagreeing
+    // with the column again.
     //
     // Every out-of-band step here goes through the REAL panel toggle verb
     // (automations_toggle_enabled), not a CLI shortcut, because the toggle is
@@ -651,7 +676,6 @@ async function main() {
         locationPath: fixturePath,
         prompt: 'Definition that the operator disables from the panel and then edits.',
         comment: leg10Comment,
-        enabled: true,
       });
 
       // leg9 deliberately ends with the editor still open on its refused save.
@@ -661,73 +685,71 @@ async function main() {
       await client.request('automation_editor_open', {});
       await client.request('automation_editor_set_text', { text: createYAML });
       const afterCreate = await client.request('automation_editor_click', { button: 'save' });
-      runner.assert(afterCreate.present === false, 'the enabled definition is created and the editor closes', afterCreate);
+      runner.assert(afterCreate.present === false, 'the definition is created and the editor closes', afterCreate);
 
-      const created = runJSON(binary, ['automation', 'show', leg10ID], daemonEnv);
-      runner.assert(created && created.Enabled === true, 'sanity: the definition starts enabled', created);
+      const createdRow = findListRow(binary, leg10ID, daemonEnv);
+      runner.assert(createdRow && createdRow.enabled === true, 'sanity: a brand-new definition starts enabled by default', createdRow);
 
       // The panel toggle — the exact surface the reviewer named.
       await toggleEnabledAndWait(client, leg10ID, false);
 
-      const disabled = runJSON(binary, ['automation', 'show', leg10ID], daemonEnv);
-      runner.assert(disabled.Enabled === false, 'the panel toggle disables the definition', disabled);
+      const disabledRow = findListRow(binary, leg10ID, daemonEnv);
+      const disabledYAML = showSpecYAML(binary, leg10ID, daemonEnv);
+      runner.assert(disabledRow.enabled === false, 'the panel toggle disables the definition', disabledRow);
       runner.assert(
-        disabled.Revision === created.Revision + 1,
+        disabledRow.revision === createdRow.revision + 1,
         'the toggle bumps the revision — otherwise the stale-save guard cannot see it at all',
-        { before: created.Revision, after: disabled.Revision },
+        { before: createdRow.revision, after: disabledRow.revision },
       );
-      // Write-through, not a read-time overlay: the stored definition itself
-      // now says disabled, so the CLI, the editor, and the column agree.
+      // The stored spec_yaml never carries `enabled` at all now (column-only,
+      // PR #629) — the write-through this leg used to pin against a disagreeing
+      // spec collapses into: the key is simply never there to disagree with.
       runner.assert(
-        disabled.SpecYAML.includes('enabled: false') && !disabled.SpecYAML.includes('enabled: true'),
-        'the toggle wrote through into the stored YAML — no stale `enabled: true` left behind to be saved back',
-        disabled.SpecYAML,
-      );
-      runner.assert(
-        disabled.SpecYAML.includes(leg10Comment),
-        "the toggle preserved the author's comment — it rewrote one scalar, not the document",
-        disabled.SpecYAML,
+        !disabledYAML.includes('enabled:'),
+        'the stored spec_yaml carries no enabled key at all — there is nothing for the toggle to leave stale',
+        disabledYAML,
       );
       runner.assert(
-        JSON.parse(disabled.SpecJSON).enabled === false,
-        'the canonical spec_json agrees too — one authority, not two',
-        disabled.SpecJSON,
+        disabledYAML.includes(leg10Comment),
+        "the toggle preserved the author's comment — it only touches the enabled column, never the document",
+        disabledYAML,
       );
 
       // Now the operator opens it and makes an unrelated edit.
       const opened = await client.request('automation_editor_open', { definitionId: leg10ID });
       runner.assert(
-        opened.text.includes('enabled: false'),
-        'the editor opens on the automation\'s REAL current state, so the operator is not editing a lie',
+        !opened.text.includes('enabled:'),
+        'the editor buffer carries no enabled key either — disabled state is not something a save can echo back wrong',
         opened,
       );
-      runner.assert(opened.revision === disabled.Revision, 'the editor holds the post-toggle revision', { opened, disabled });
+      runner.assert(opened.revision === disabledRow.revision, 'the editor holds the post-toggle revision', { opened, disabledRow });
 
       await client.request('automation_editor_set_text', { text: `# unrelated edit ${suffix}\n${opened.text}` });
       const afterEdit = await client.request('automation_editor_click', { button: 'save' });
       runner.assert(afterEdit.present === false, 'the unrelated edit saves cleanly', afterEdit);
 
       // The assertion this whole leg exists for.
-      const afterSave = runJSON(binary, ['automation', 'show', leg10ID], daemonEnv);
+      const afterSaveRow = findListRow(binary, leg10ID, daemonEnv);
       runner.assert(
-        afterSave.Enabled === false,
-        'D-F: editing a disabled automation does NOT silently re-enable it — the toggle is not reversed by a save',
-        afterSave,
+        afterSaveRow.enabled === false,
+        'D-F: editing a disabled automation does NOT silently re-enable it — a save never touches the enabled column',
+        afterSaveRow,
       );
 
       // And back on, through the panel again, so the leg proves the toggle is
       // symmetric rather than only pinning the disable direction.
       await toggleEnabledAndWait(client, leg10ID, true);
-      const reEnabled = runJSON(binary, ['automation', 'show', leg10ID], daemonEnv);
+      const reEnabledRow = findListRow(binary, leg10ID, daemonEnv);
+      const reEnabledYAML = showSpecYAML(binary, leg10ID, daemonEnv);
       runner.assert(
-        reEnabled.Enabled === true && reEnabled.SpecYAML.includes('enabled: true'),
-        'toggling back on writes through the same way — the disable direction is not a special case',
-        reEnabled,
+        reEnabledRow.enabled === true && !reEnabledYAML.includes('enabled:'),
+        'toggling back on writes through the same way — the disable direction is not a special case, and the spec still carries no enabled key',
+        reEnabledRow,
       );
       runner.assert(
-        reEnabled.SpecYAML.includes(leg10Comment),
+        reEnabledYAML.includes(leg10Comment),
         "the author's comment survives a full off-and-on cycle, not just one rewrite",
-        reEnabled.SpecYAML,
+        reEnabledYAML,
       );
 
       // Not covered here: a toggle landing while THIS editor is open, which

--- a/app/scripts/real-app-harness/scenario-automation-editor.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-editor.mjs
@@ -3,38 +3,48 @@
 /**
  * Packaged-app proof for Slice 7 PR B's self-service automation YAML editor:
  * the starter template, invalid-YAML rejection (nothing stored), a real
- * create with a hand-written comment, the create-collision refusal, D1
- * (comments survive a save/reload round-trip), the id-change refusal (D4),
- * the stale-revision refusal plus Reload recovery (D5), a comment-only edit
- * that still bumps the revision, a Save that is refused rather than
- * silently resurrecting a definition deleted elsewhere, and a panel
- * toggle-off that survives a later unrelated edit — the last three pin the
- * three multi-writer races fixed in 649a7e52 and 09cfb0b6 (spec_yaml missing
- * from the revision-bump condition; DeleteAutomationDefinition leaving
- * revision untouched; SetAutomationEnabled writing only the enabled column
- * and leaving the stored spec saying otherwise) — all driven through the
- * real rendered editor and panel via the automation_editor_* and
- * automations_* UI-automation bridge verbs, cross-checked against the
- * daemon's own state via the bundled `attn` CLI (`automation show`/`list`),
- * not just the DOM.
+ * create, the create-collision refusal, the v2 spec-canonical save/reload
+ * contract, the id-change refusal (D4), the stale-revision refusal plus
+ * Reload recovery (D5), a comment-only edit that is a no-op revision-wise
+ * (immediately followed by a real semantic edit that does bump), a Save
+ * that is refused rather than silently resurrecting a definition deleted
+ * elsewhere, and a panel toggle-off that survives a later unrelated edit —
+ * all driven through the real rendered editor and panel via the
+ * automation_editor_* and automations_* UI-automation bridge verbs,
+ * cross-checked against the daemon's own state via the bundled `attn` CLI
+ * (`automation show`/`list`), not just the DOM.
+ *
+ * v2 spec-canonical contract (PR #629, "make enabled column-only and drop
+ * spec_yaml storage"): the stored source of truth is spec_json alone: the
+ * `spec_yaml` DB column is gone. Every YAML read (`attn automation show`,
+ * the editor's Save-then-reopen) is re-derived canonically from spec_json via
+ * automation.MarshalDefinitionYAML — 4-space indent, no comments, no
+ * original formatting. This is intentional, not a bug: hand-written
+ * comments are interchange-only and do not round-trip. `enabled` and
+ * `policy` are likewise outside the spec entirely (column-only /
+ * trigger-implied) and a YAML carrying either key is rejected outright
+ * (errEnabledManagedOutsideSpec / errPolicyRemoved in
+ * internal/automation/automation.go). Revision bumps exactly when spec_json
+ * changes (store.UpsertAutomationDefinition): a comment-only edit changes
+ * only the buffer, not the canonical spec, so re-saving it is a no-op for
+ * revision purposes; a real content edit (e.g. `name:`) always bumps by
+ * exactly one.
  *
  * One definition id is reused across most legs (`automation-editor-<suffix>`)
  * so the id-change and stale-revision legs exercise the SAME live definition
- * D1 just proved comment-preservation on, rather than fresh throwaway ids —
- * matching how a real user edits one automation repeatedly in one sitting.
- * The same id carries through the comment-only-revision-bump leg and finally
- * into the delete-elsewhere leg, which ends the scenario with it soft-
- * deleted on purpose. A second id (`automation-editor-renamed-<suffix>`)
- * exists only as the (refused) target of the id-change leg; it must never
- * actually be created.
+ * leg3 just created, rather than fresh throwaway ids — matching how a real
+ * user edits one automation repeatedly in one sitting. The same id carries
+ * through the no-op/bump revision leg and finally into the delete-elsewhere
+ * leg, which ends the scenario with it soft-deleted on purpose. A second id
+ * (`automation-editor-renamed-<suffix>`) exists only as the (refused) target
+ * of the id-change leg; it must never actually be created.
  *
  * No fake-agent probe is needed: this scenario never triggers a run. Every
  * definition it applies is manual-trigger, so `launch.executable` is never
  * invoked and can stay unset like the starter template's, regardless of
- * enabled state. `enabled` is column-only post-PR5 (spec YAML/JSON no longer
- * carries it at all — see errEnabledManagedOutsideSpec in
- * internal/automation/automation.go) and every apply of a brand-new id always
- * inserts it enabled; leg10 relies on exactly that default to get an enabled
+ * enabled state. `enabled` is column-only post-PR5/#629 (spec YAML/JSON no
+ * longer carries it at all) and every apply of a brand-new id always inserts
+ * it enabled; leg9 relies on exactly that default to get an enabled
  * definition to disable from the panel, and deletes it before finishing.
  *
  * Run serially (packaged-app scenarios are single-tenant):
@@ -173,7 +183,7 @@ const API_VERSION = 'attn.dev/automations/v1alpha1';
 // template never emits it. Every apply of a brand-new id is inserted enabled
 // regardless (store.UpsertAutomationDefinition); that is harmless here since
 // every definition this scenario applies is manual-trigger and never fires on
-// its own. leg10 relies on that same default-enabled behavior to get a
+// its own. leg9 relies on that same default-enabled behavior to get a
 // definition it can disable from the panel, and deletes it at the end of the
 // leg.
 function editorDefinitionYAML({ id, locationPath, prompt, comment }) {
@@ -195,11 +205,15 @@ location:
 
 // Deliberately missing/wrong api_version — the cheapest reliable way to fail
 // ValidateDefinition without depending on any other field's exact wording.
+// Must not carry `enabled:` — ParseDefinitionYAML probes for that key BEFORE
+// api_version validation (errEnabledManagedOutsideSpec in
+// internal/automation/automation.go), so leaving it in would make this
+// fixture fail for the wrong reason and never reach the api_version
+// complaint this leg pins.
 function invalidDefinitionYAML({ id, locationPath }) {
   return `api_version: not-a-real-api-version
 id: ${id}
 name: Slice 7 packaged editor proof (invalid)
-enabled: false
 trigger:
   type: manual
 prompt: |
@@ -349,12 +363,18 @@ async function main() {
       );
     });
 
-    // Leg 3: a real create, with a hand-written leading comment — the
-    // fixture leg2's D1 assertion (comment survival) depends on.
+    // Leg 3: a real create, with a hand-written leading comment, then a
+    // reload through both the CLI and the real editor — pinning the v2
+    // spec-canonical contract (PR #629): the re-read YAML is a canonical
+    // rendering of the saved content (same id/name/prompt), and the
+    // hand-written comment is gone — comments are interchange-only and do
+    // not round-trip since spec_yaml storage was dropped. Also folds in what
+    // used to be a separate leg (D1, pre-#629) proving the editor's own
+    // reopen path gets the same canonical rendering, not just the CLI.
     let leg3Revision = null;
     let leg3SpecYAML = null;
     const promptV1 = 'Slice 7 packaged editor proof: initial create.';
-    await runner.step('leg3_create_with_comment', async () => {
+    await runner.step('leg3_create_then_reload_is_canonical', async () => {
       const validYAML = editorDefinitionYAML({ id: primaryID, locationPath: fixturePath, prompt: promptV1, comment: harnessMarkerComment });
       const afterSetText = await client.request('automation_editor_set_text', { text: validYAML });
       runner.assert(afterSetText.text === validYAML, 'set_text replaces the buffer with the valid YAML exactly', afterSetText);
@@ -375,9 +395,39 @@ async function main() {
       const shownYAML = showSpecYAML(binary, primaryID, daemonEnv);
       runner.assert(shownRow && shownRow.id === primaryID, 'the CLI shows the created definition by id', shownRow);
       runner.assert(shownRow.revision === 1, 'a fresh create lands at revision 1', shownRow);
-      runner.assert(shownYAML.includes(harnessMarkerComment), 'the stored YAML includes the hand-written comment', shownYAML);
+      runner.assert(
+        shownYAML.includes(`id: ${primaryID}`) && shownYAML.includes('name: Slice 7 packaged editor proof') && shownYAML.includes(promptV1),
+        'the re-read YAML is the canonical rendering of the saved spec — same id/name/prompt content',
+        shownYAML,
+      );
+      runner.assert(
+        !shownYAML.includes(harnessMarkerComment) && !shownYAML.includes('#'),
+        'v2: the hand-written comment does not survive the round-trip — comments are interchange-only, not stored (PR #629 dropped spec_yaml storage)',
+        shownYAML,
+      );
       leg3Revision = shownRow.revision;
       leg3SpecYAML = shownYAML;
+
+      // Reopen through the real editor too — same canonical-rendering
+      // guarantee on the WS load path, not just the CLI.
+      const opened = await client.request('automation_editor_open', { definitionId: primaryID });
+      runner.assert(opened.mode === 'edit', 'opening an existing definition starts in edit mode', opened);
+      runner.assert(opened.definitionId === primaryID, 'edit mode reports the definition id being edited', opened);
+      runner.assert(opened.revision === leg3Revision, "edit mode reports the definition's current revision", opened);
+      runner.assert(opened.reloadOffered === true, 'Reload is offered once a persisted definition is being edited', opened);
+      runner.assert(
+        opened.text.includes(promptV1) && !opened.text.includes(harnessMarkerComment),
+        'the editor buffer reopens with the same canonical rendering — content preserved, hand-written comment absent',
+        opened,
+      );
+
+      // Close back out before the next leg. The editor replaces the panel
+      // body entirely while open (see leg9's not-covered note), so leaving
+      // it open here would make leg4's `automation_editor_open {}` for New
+      // an undrivable flow — the New button isn't reachable while an editor
+      // is already up.
+      const afterReopenCancel = await client.request('automation_editor_click', { button: 'cancel' });
+      runner.assert(afterReopenCancel.present === false, 'Cancel closes the reopened editor back to the list', afterReopenCancel);
     });
 
     // Leg 4 (new, per team-lead): creating a SECOND definition that reuses
@@ -422,26 +472,16 @@ async function main() {
       runner.assert(afterCancel.present === false, 'Cancel closes the collision attempt back to the list', afterCancel);
     });
 
-    // Leg 5 (D1, load-bearing): opening the definition leg3 created for edit
-    // shows the hand-written comment intact — a save/reload round-trip that
-    // does not preserve comments is exactly the regression this scenario
-    // exists to catch.
-    await runner.step('leg5_comments_survive_roundtrip', async () => {
-      const opened = await client.request('automation_editor_open', { definitionId: primaryID });
-      runner.assert(opened.mode === 'edit', 'opening an existing definition starts in edit mode', opened);
-      runner.assert(opened.definitionId === primaryID, 'edit mode reports the definition id being edited', opened);
-      runner.assert(opened.revision === leg3Revision, 'edit mode reports the definition\'s current revision', opened);
-      runner.assert(opened.reloadOffered === true, 'Reload is offered once a persisted definition is being edited', opened);
-      runner.assert(
-        opened.text.includes(harnessMarkerComment),
-        'D1: the hand-written comment survives the save/reload round-trip into the editor buffer',
-        opened,
-      );
-    });
-
-    // Leg 6 (D4): changing the id in the buffer and saving is refused — an id
+    // Leg 5 (D4): changing the id in the buffer and saving is refused — an id
     // change must go through a separate create, not an in-place edit.
-    await runner.step('leg6_id_change_refusal', async () => {
+    await runner.step('leg5_id_change_refusal', async () => {
+      // leg4's cancel closed the editor entirely (it left the collision
+      // attempt's create buffer, not primaryID's edit buffer) — open the
+      // shared definition for edit fresh before attempting the rename.
+      const reopened = await client.request('automation_editor_open', { definitionId: primaryID });
+      runner.assert(reopened.mode === 'edit', 'opening the shared definition for edit starts in edit mode', reopened);
+      runner.assert(reopened.revision === leg3Revision, "the editor's revision matches the definition's current revision", { reopened, leg3Revision });
+
       const renameYAML = editorDefinitionYAML({
         id: renamedID,
         locationPath: fixturePath,
@@ -468,12 +508,12 @@ async function main() {
       );
     });
 
-    // Leg 7 (D5): a Save against a stale revision — the definition changed
+    // Leg 6 (D5): a Save against a stale revision — the definition changed
     // out from under the open editor via the CLI — is refused, and Reload
     // recovers by pulling the current content into the buffer, after which a
     // normal Save succeeds.
-    await runner.step('leg7_stale_revision_refusal_and_reload', async () => {
-      // Reset the buffer's id back to primaryID (leg 6 left it on renamedID)
+    await runner.step('leg6_stale_revision_refusal_and_reload', async () => {
+      // Reset the buffer's id back to primaryID (leg 5 left it on renamedID)
       // before doing anything else, so this leg's Save attempts exercise the
       // stale-revision guard rather than re-triggering the id-change guard.
       const localPromptA = 'Local buffer edit before the out-of-band mutation lands.';
@@ -515,16 +555,17 @@ async function main() {
       runner.assert(finalYAML.includes(localPromptA), 'the recovered save persists the locally re-applied content', finalYAML);
     });
 
-    // Leg 8 (defect A regression proof): a comment-only edit — the exact
-    // shape of change this editor exists to make — still bumps the
-    // revision. Before the store fix, the bump condition compared only
-    // spec_json, so a save that changed spec_yaml alone (comments live only
-    // there, never re-derived into spec_json) left revision untouched and
-    // the stale-save guard blind to it. The new buffer is built by
-    // prepending exactly ONE comment line to the exact bytes the editor
-    // loaded, so everything after that line is untouched by construction —
-    // if spec_json also moved, this leg would prove nothing.
-    await runner.step('leg8_comment_only_edit_bumps_revision', async () => {
+    // Leg 7: v2 revision semantics (store.UpsertAutomationDefinition —
+    // revision bumps exactly when spec_json changes). Part A: a comment-only
+    // edit changes only the buffer's interchange formatting, not the
+    // canonical spec, so re-saving the exact same content the editor loaded
+    // (modulo a leading comment, which is dropped on every read anyway per
+    // leg3) reapplies an IDENTICAL spec_json — a no-op, revision unchanged.
+    // Part B: immediately after, a real semantic edit (changing `name:`)
+    // DOES change spec_json and bumps revision by exactly one — proving
+    // part A's unchanged revision is because nothing meaningful changed, not
+    // because saves stopped bumping revision at all.
+    await runner.step('leg7_comment_only_save_is_noop_then_semantic_edit_bumps', async () => {
       const rowBefore = findListRow(binary, primaryID, daemonEnv);
       const yamlBefore = showSpecYAML(binary, primaryID, daemonEnv);
 
@@ -538,12 +579,12 @@ async function main() {
       );
       runner.assert(
         opened.text === yamlBefore,
-        'the editor buffer loads exactly the stored spec_yaml bytes — the baseline this leg edits from',
+        'the editor buffer loads exactly the stored (canonically-rendered) YAML — the baseline this leg edits from',
         { opened, yamlBefore },
       );
 
-      const leg8Comment = `# harness-marker-leg8: ${suffix}`;
-      const commentOnlyYAML = `${leg8Comment}\n${opened.text}`;
+      const leg7Comment = `# harness-marker-leg7: ${suffix}`;
+      const commentOnlyYAML = `${leg7Comment}\n${opened.text}`;
       await client.request('automation_editor_set_text', { text: commentOnlyYAML });
 
       const afterValidate = await client.request('automation_editor_click', { button: 'validate' });
@@ -552,39 +593,51 @@ async function main() {
       const afterSave = await client.request('automation_editor_click', { button: 'save' });
       runner.assert(afterSave.present === false, 'the comment-only save succeeds and closes the editor', afterSave);
 
-      const rowAfter = findListRow(binary, primaryID, daemonEnv);
-      const yamlAfter = showSpecYAML(binary, primaryID, daemonEnv);
+      const rowAfterCommentOnly = findListRow(binary, primaryID, daemonEnv);
+      const yamlAfterCommentOnly = showSpecYAML(binary, primaryID, daemonEnv);
       runner.assert(
-        rowAfter.revision === rowBefore.revision + 1,
-        'D-A: a comment-only edit still bumps the revision — the stale-save guard is no longer blind to comment-only changes',
-        { before: rowBefore.revision, after: rowAfter.revision },
+        rowAfterCommentOnly.revision === rowBefore.revision,
+        'v2: a comment-only save is a no-op for revision — spec_json is unchanged, and revision guards spec content only',
+        { before: rowBefore.revision, after: rowAfterCommentOnly.revision },
       );
       runner.assert(
-        yamlAfter === commentOnlyYAML,
-        'the stored spec_yaml is exactly the comment-prepended buffer — nothing else moved',
-        { expected: commentOnlyYAML, actual: yamlAfter },
+        !yamlAfterCommentOnly.includes(leg7Comment),
+        "the comment does not persist either way — it never reached spec_json, so the canonical re-render can't echo it back",
+        yamlAfterCommentOnly,
       );
-      // D-A originally also proved the canonical spec_json was byte-identical
-      // before/after, to rule out this leg passing because a refactor folded
-      // comments into spec_json instead of because the revision bump logic
-      // was fixed. The unified CLI (`automation show`/`list`) no longer
-      // exposes spec_json at all — it prints plain spec_yaml text or a
-      // lowercase summary with no spec fields — so that check has no
-      // CLI-observable equivalent post-PR5. Equivalent coverage lives at the
-      // store/daemon unit-test level (internal/store/automations_test.go,
-      // internal/store/sqlite_test.go), which assert the spec_json bump
-      // condition directly against the canonical struct.
+      runner.assert(
+        yamlAfterCommentOnly === yamlBefore,
+        'the canonical rendering is byte-identical before/after the comment-only save — nothing meaningful moved',
+        { before: yamlBefore, after: yamlAfterCommentOnly },
+      );
+
+      // Part B: a real semantic edit — change `name:` — must bump revision by
+      // exactly one, proving part A's unchanged revision was content-specific.
+      const reopened = await client.request('automation_editor_open', { definitionId: primaryID });
+      const semanticYAML = reopened.text.replace('name: Slice 7 packaged editor proof', 'name: Slice 7 packaged editor proof (renamed)');
+      runner.assert(semanticYAML !== reopened.text, 'sanity: the name replacement actually changed the buffer', { reopened });
+      await client.request('automation_editor_set_text', { text: semanticYAML });
+      const afterSemanticSave = await client.request('automation_editor_click', { button: 'save' });
+      runner.assert(afterSemanticSave.present === false, 'the semantic edit saves cleanly', afterSemanticSave);
+
+      const rowAfterSemantic = findListRow(binary, primaryID, daemonEnv);
+      runner.assert(
+        rowAfterSemantic.revision === rowBefore.revision + 1,
+        'v2: a real semantic edit (name change) bumps revision by exactly one — spec_json content actually changed',
+        { before: rowBefore.revision, after: rowAfterSemantic.revision },
+      );
+      runner.assert(rowAfterSemantic.name === 'Slice 7 packaged editor proof (renamed)', 'the renamed name is what got stored', rowAfterSemantic);
     });
 
-    // Leg 9 (defect B regression proof): a definition deleted out of band
+    // Leg 8 (defect B regression proof): a definition deleted out of band
     // while an editor has it open must not be resurrected by that editor's
     // Save. Before the daemon fix, DeleteAutomationDefinition left revision
     // untouched, so the stale editor's expected_revision still matched the
     // soft-deleted row, the guard passed, and the upsert cleared
-    // deleted_at — reported to the user as a successful save. Mirrors leg7's
+    // deleted_at — reported to the user as a successful save. Mirrors leg6's
     // out-of-band-mutation shape, but via `automation delete` instead of
     // `automation apply`.
-    await runner.step('leg9_delete_elsewhere_then_save_refused', async () => {
+    await runner.step('leg8_delete_elsewhere_then_save_refused', async () => {
       const rowBefore = findListRow(binary, primaryID, daemonEnv);
       runner.assert(
         rowBefore && rowBefore.id === primaryID,
@@ -652,71 +705,61 @@ async function main() {
       );
     });
 
-    // The reviewer-reported split brain: `enabled` used to be written by the
-    // panel toggle (column only) AND by a save (from the YAML), with nothing
-    // keeping them in step. Disable, then edit, and the stale `enabled: true`
-    // in the stored YAML came back — for a cron trigger, unattended sessions
-    // firing again after the operator turned them off, reported as a clean
-    // save. Post-PR5 `enabled` has exactly one authority (the column; the spec
-    // cannot carry it at all — errEnabledManagedOutsideSpec), which makes the
-    // split brain structurally impossible rather than merely fixed — this leg
-    // now also pins that the editor's buffer and the stored spec_yaml never
-    // contain an `enabled:` key at all, so a regression that reintroduces one
-    // fails loudly (a parse error on apply) rather than silently disagreeing
-    // with the column again.
+    // Leg 9: `enabled` has exactly one authority post-#629 — the column,
+    // set only by SetAutomationEnabled — and that function never touches
+    // spec_json or revision (TestSetAutomationEnabledNeverTouchesSpecOrRevision,
+    // internal/store/automations_test.go). This leg pins both directions of
+    // that split: (1) the panel toggle does what it says (enabled flips) and
+    // does NOT bump revision, in either direction; (2) a later spec save does
+    // not silently flip enabled back on. It also keeps pinning that neither
+    // the stored nor the buffered YAML ever carries an `enabled:` key, so a
+    // regression that reintroduces one fails loudly (a parse error on apply)
+    // rather than silently disagreeing with the column again.
     //
     // Every out-of-band step here goes through the REAL panel toggle verb
     // (automations_toggle_enabled), not a CLI shortcut, because the toggle is
-    // the surface that was writing only half the state.
-    await runner.step('leg10_panel_toggle_off_survives_a_later_edit', async () => {
-      const leg10ID = `automation-editor-toggle-${suffix}`;
-      const leg10Comment = `# harness-marker-leg10: ${suffix}`;
+    // the surface under test.
+    await runner.step('leg9_panel_toggle_off_survives_a_later_edit', async () => {
+      const leg9ID = `automation-editor-toggle-${suffix}`;
       const createYAML = editorDefinitionYAML({
-        id: leg10ID,
+        id: leg9ID,
         locationPath: fixturePath,
         prompt: 'Definition that the operator disables from the panel and then edits.',
-        comment: leg10Comment,
+        comment: null,
       });
 
-      // leg9 deliberately ends with the editor still open on its refused save.
+      // leg8 deliberately ends with the editor still open on its refused save.
       const cleared = await client.request('automation_editor_click', { button: 'cancel' });
-      runner.assert(cleared.present === false, "leg9's editor is closed before this leg opens its own", cleared);
+      runner.assert(cleared.present === false, "leg8's editor is closed before this leg opens its own", cleared);
 
       await client.request('automation_editor_open', {});
       await client.request('automation_editor_set_text', { text: createYAML });
       const afterCreate = await client.request('automation_editor_click', { button: 'save' });
       runner.assert(afterCreate.present === false, 'the definition is created and the editor closes', afterCreate);
 
-      const createdRow = findListRow(binary, leg10ID, daemonEnv);
+      const createdRow = findListRow(binary, leg9ID, daemonEnv);
       runner.assert(createdRow && createdRow.enabled === true, 'sanity: a brand-new definition starts enabled by default', createdRow);
 
-      // The panel toggle — the exact surface the reviewer named.
-      await toggleEnabledAndWait(client, leg10ID, false);
+      // The panel toggle.
+      await toggleEnabledAndWait(client, leg9ID, false);
 
-      const disabledRow = findListRow(binary, leg10ID, daemonEnv);
-      const disabledYAML = showSpecYAML(binary, leg10ID, daemonEnv);
+      const disabledRow = findListRow(binary, leg9ID, daemonEnv);
+      const disabledYAML = showSpecYAML(binary, leg9ID, daemonEnv);
       runner.assert(disabledRow.enabled === false, 'the panel toggle disables the definition', disabledRow);
       runner.assert(
-        disabledRow.revision === createdRow.revision + 1,
-        'the toggle bumps the revision — otherwise the stale-save guard cannot see it at all',
+        disabledRow.revision === createdRow.revision,
+        'v2: the toggle does NOT bump revision — enabled is column-only and never touches spec_json',
         { before: createdRow.revision, after: disabledRow.revision },
       );
-      // The stored spec_yaml never carries `enabled` at all now (column-only,
-      // PR #629) — the write-through this leg used to pin against a disagreeing
-      // spec collapses into: the key is simply never there to disagree with.
+      // The stored YAML never carries `enabled` at all now (column-only, #629).
       runner.assert(
         !disabledYAML.includes('enabled:'),
-        'the stored spec_yaml carries no enabled key at all — there is nothing for the toggle to leave stale',
-        disabledYAML,
-      );
-      runner.assert(
-        disabledYAML.includes(leg10Comment),
-        "the toggle preserved the author's comment — it only touches the enabled column, never the document",
+        'the stored YAML carries no enabled key at all',
         disabledYAML,
       );
 
       // Now the operator opens it and makes an unrelated edit.
-      const opened = await client.request('automation_editor_open', { definitionId: leg10ID });
+      const opened = await client.request('automation_editor_open', { definitionId: leg9ID });
       runner.assert(
         !opened.text.includes('enabled:'),
         'the editor buffer carries no enabled key either — disabled state is not something a save can echo back wrong',
@@ -729,42 +772,40 @@ async function main() {
       runner.assert(afterEdit.present === false, 'the unrelated edit saves cleanly', afterEdit);
 
       // The assertion this whole leg exists for.
-      const afterSaveRow = findListRow(binary, leg10ID, daemonEnv);
+      const afterSaveRow = findListRow(binary, leg9ID, daemonEnv);
       runner.assert(
         afterSaveRow.enabled === false,
-        'D-F: editing a disabled automation does NOT silently re-enable it — a save never touches the enabled column',
+        'editing a disabled automation does NOT silently re-enable it — a save never touches the enabled column',
         afterSaveRow,
       );
 
       // And back on, through the panel again, so the leg proves the toggle is
-      // symmetric rather than only pinning the disable direction.
-      await toggleEnabledAndWait(client, leg10ID, true);
-      const reEnabledRow = findListRow(binary, leg10ID, daemonEnv);
-      const reEnabledYAML = showSpecYAML(binary, leg10ID, daemonEnv);
+      // symmetric rather than only pinning the disable direction — and that
+      // re-enabling also does not bump revision.
+      await toggleEnabledAndWait(client, leg9ID, true);
+      const reEnabledRow = findListRow(binary, leg9ID, daemonEnv);
+      const reEnabledYAML = showSpecYAML(binary, leg9ID, daemonEnv);
       runner.assert(
         reEnabledRow.enabled === true && !reEnabledYAML.includes('enabled:'),
         'toggling back on writes through the same way — the disable direction is not a special case, and the spec still carries no enabled key',
         reEnabledRow,
       );
       runner.assert(
-        reEnabledYAML.includes(leg10Comment),
-        "the author's comment survives a full off-and-on cycle, not just one rewrite",
-        reEnabledYAML,
+        reEnabledRow.revision === disabledRow.revision,
+        'v2: re-enabling also does not bump revision — the toggle never touches spec_json in either direction',
+        { disabled: disabledRow.revision, reEnabled: reEnabledRow.revision },
       );
 
-      // Not covered here: a toggle landing while THIS editor is open, which
-      // would exercise the stale-save guard against the toggle's revision
-      // bump. AutomationsPanel renders the editor as a full replacement of the
+      // Not covered here: a toggle landing while THIS editor is open.
+      // AutomationsPanel renders the editor as a full replacement of the
       // panel body (see its EditorTarget doc comment), so the toggle control
       // is not in the DOM at all while the editor is up — there is no way to
       // drive that race through the real UI, and faking it here would be
       // testing the harness rather than the product. The guard itself is
-      // pinned where it is reachable: the revision assertion above, plus
-      // TestSetAutomationEnabledWritesThroughToStoredSpec (store) and
-      // TestAutomationDefinitionGetWSAfterToggleShowsDisabledWithoutReenabling
-      // (daemon).
+      // pinned where it is reachable: the revision assertions above, plus
+      // TestSetAutomationEnabledNeverTouchesSpecOrRevision (store).
 
-      run(binary, ['automation', 'delete', leg10ID], daemonEnv);
+      run(binary, ['automation', 'delete', leg9ID], daemonEnv);
     });
 
     runner.finishSuccess({ profile, primaryID, renamedID, leg3Revision, appBuild, protocolVersion });

--- a/app/scripts/real-app-harness/scenario-automation-editor.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-editor.mjs
@@ -82,6 +82,21 @@ function runJSON(binary, args, env) {
   return JSON.parse(run(binary, args, env));
 }
 
+// `attn automation show <id>` prints the canonical rendered YAML alone (no
+// JSON wrapper — see cmd/attn/automation.go), unlike the pre-unification CLI
+// which printed the raw store row (Enabled/Revision/SpecYAML/SpecJSON). Get
+// the definition summary (id/enabled/revision) from `automation list`
+// instead, filtered by id — the two together are the CLI-observable
+// replacement for the old single `show` call.
+function showSpecYAML(binary, id, env) {
+  return run(binary, ['automation', 'show', id], env);
+}
+
+function findListRow(binary, id, env) {
+  const list = runJSON(binary, ['automation', 'list'], env) || [];
+  return list.find((row) => row.id === id) || null;
+}
+
 async function poll(fn, description, timeoutMs = 30_000) {
   const started = Date.now();
   let last = null;
@@ -292,7 +307,7 @@ async function main() {
     // guard or the editor's error surfacing regresses.
     await runner.step('leg2_invalid_rejected_nothing_stored', async () => {
       const listBefore = runJSON(binary, ['automation', 'list'], daemonEnv) || [];
-      runner.assert(!listBefore.some((row) => row.ID === primaryID), 'sanity: primary id does not exist yet', listBefore);
+      runner.assert(!listBefore.some((row) => row.id === primaryID), 'sanity: primary id does not exist yet', listBefore);
 
       const invalidYAML = invalidDefinitionYAML({ id: primaryID, locationPath: fixturePath });
       const afterSetText = await client.request('automation_editor_set_text', { text: invalidYAML });
@@ -313,7 +328,7 @@ async function main() {
 
       const listAfter = runJSON(binary, ['automation', 'list'], daemonEnv) || [];
       runner.assert(
-        listAfter.length === listBefore.length && !listAfter.some((row) => row.ID === primaryID),
+        listAfter.length === listBefore.length && !listAfter.some((row) => row.id === primaryID),
         'nothing is stored after the refused create',
         { listBefore, listAfter },
       );
@@ -341,12 +356,13 @@ async function main() {
       }, `created definition ${primaryID} to appear in the panel`, PANEL_TIMEOUT_MS);
       await captureEvidenceScreenshot(runner, client, 'leg3-after-save.png');
 
-      const shown = runJSON(binary, ['automation', 'show', primaryID], daemonEnv);
-      runner.assert(shown && shown.ID === primaryID, 'the CLI shows the created definition by id', shown);
-      runner.assert(shown.Revision === 1, 'a fresh create lands at revision 1', shown);
-      runner.assert(shown.SpecYAML.includes(harnessMarkerComment), 'the stored YAML includes the hand-written comment', shown);
-      leg3Revision = shown.Revision;
-      leg3SpecYAML = shown.SpecYAML;
+      const shownRow = findListRow(binary, primaryID, daemonEnv);
+      const shownYAML = showSpecYAML(binary, primaryID, daemonEnv);
+      runner.assert(shownRow && shownRow.id === primaryID, 'the CLI shows the created definition by id', shownRow);
+      runner.assert(shownRow.revision === 1, 'a fresh create lands at revision 1', shownRow);
+      runner.assert(shownYAML.includes(harnessMarkerComment), 'the stored YAML includes the hand-written comment', shownYAML);
+      leg3Revision = shownRow.revision;
+      leg3SpecYAML = shownYAML;
     });
 
     // Leg 4 (new, per team-lead): creating a SECOND definition that reuses
@@ -376,11 +392,15 @@ async function main() {
         afterSave,
       );
 
-      const afterCollision = runJSON(binary, ['automation', 'show', primaryID], daemonEnv);
+      const afterCollisionRow = findListRow(binary, primaryID, daemonEnv);
+      const afterCollisionYAML = showSpecYAML(binary, primaryID, daemonEnv);
       runner.assert(
-        afterCollision.Revision === leg3Revision && afterCollision.SpecYAML === leg3SpecYAML,
+        afterCollisionRow.revision === leg3Revision && afterCollisionYAML === leg3SpecYAML,
         "the original definition's revision and content are unchanged by the refused collision",
-        { before: { revision: leg3Revision, specYaml: leg3SpecYAML }, after: afterCollision },
+        {
+          before: { revision: leg3Revision, specYaml: leg3SpecYAML },
+          after: { revision: afterCollisionRow.revision, specYaml: afterCollisionYAML },
+        },
       );
 
       const afterCancel = await client.request('automation_editor_click', { button: 'cancel' });
@@ -427,7 +447,7 @@ async function main() {
 
       const listAfter = runJSON(binary, ['automation', 'list'], daemonEnv) || [];
       runner.assert(
-        !listAfter.some((row) => row.ID === renamedID) && listAfter.filter((row) => row.ID === primaryID).length === 1,
+        !listAfter.some((row) => row.id === renamedID) && listAfter.filter((row) => row.id === primaryID).length === 1,
         'no definition was created under the renamed id; the original still exists exactly once',
         listAfter,
       );
@@ -448,11 +468,11 @@ async function main() {
       const outOfBandPrompt = 'Mutated out of band via the bundled CLI while the editor was open.';
       const outOfBandFile = path.join(runner.sessionDir, 'out-of-band.yml');
       fs.writeFileSync(outOfBandFile, editorDefinitionYAML({ id: primaryID, locationPath: fixturePath, prompt: outOfBandPrompt, comment: null }));
-      runJSON(binary, ['automation', 'apply', '--file', outOfBandFile], daemonEnv);
+      run(binary, ['automation', 'apply', '--file', outOfBandFile], daemonEnv);
 
-      const outOfBandShown = runJSON(binary, ['automation', 'show', primaryID], daemonEnv);
-      runner.assert(outOfBandShown.Revision > leg3Revision, 'the out-of-band CLI apply bumps the revision past what the open editor has', outOfBandShown);
-      const outOfBandRevision = outOfBandShown.Revision;
+      const outOfBandRow = findListRow(binary, primaryID, daemonEnv);
+      runner.assert(outOfBandRow.revision > leg3Revision, 'the out-of-band CLI apply bumps the revision past what the open editor has', outOfBandRow);
+      const outOfBandRevision = outOfBandRow.revision;
 
       const afterStaleSave = await client.request('automation_editor_click', { button: 'save' });
       runner.assert(afterStaleSave.present === true, 'the editor stays open after a refused stale-revision save', afterStaleSave);
@@ -565,7 +585,7 @@ async function main() {
       run(binary, ['automation', 'delete', primaryID], daemonEnv);
       const listAfterDelete = runJSON(binary, ['automation', 'list'], daemonEnv) || [];
       runner.assert(
-        !listAfterDelete.some((row) => row.ID === primaryID),
+        !listAfterDelete.some((row) => row.id === primaryID),
         'sanity: the out-of-band CLI delete removes the definition from the live list while the editor is still open on it',
         listAfterDelete,
       );
@@ -602,7 +622,7 @@ async function main() {
       // would be exactly the failure this leg exists to catch.
       const listAfterRefusedSave = runJSON(binary, ['automation', 'list'], daemonEnv) || [];
       runner.assert(
-        !listAfterRefusedSave.some((row) => row.ID === primaryID),
+        !listAfterRefusedSave.some((row) => row.id === primaryID),
         'the definition is still gone after the refused save — it was not resurrected',
         listAfterRefusedSave,
       );

--- a/app/scripts/real-app-harness/scenario-automation-lifecycle.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-lifecycle.mjs
@@ -118,7 +118,7 @@ async function poll(fn, description, timeoutMs = 30_000) {
 }
 
 function sqliteRow(dbPath, sql) {
-  const out = execFileSync('sqlite3', [dbPath, sql], { encoding: 'utf8' }).trim();
+  const out = execFileSync('sqlite3', ['-cmd', '.timeout 5000', dbPath, sql], { encoding: 'utf8' }).trim();
   return out.length === 0 ? null : out.split('|');
 }
 

--- a/app/scripts/real-app-harness/scenario-automation-lifecycle.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-lifecycle.mjs
@@ -100,6 +100,12 @@ function runJSON(binary, args, env) {
   return JSON.parse(run(binary, args, env));
 }
 
+// `enable`/`disable` are the only way to move the enabled column post-PR5;
+// both print the updated (lowercase) definition summary.
+function disableDefinition(binary, id, env) {
+  return runJSON(binary, ['automation', 'disable', id], env);
+}
+
 async function poll(fn, description, timeoutMs = 30_000) {
   const started = Date.now();
   let last = null;
@@ -169,6 +175,15 @@ function createCodexProbe(root) {
 
 const API_VERSION = 'attn.dev/automations/v1alpha1';
 
+// `enabled` is not a spec field post-PR5 (column-only; a YAML carrying
+// `enabled:` is rejected outright — errEnabledManagedOutsideSpec in
+// internal/automation/automation.go), so none of these templates emit it.
+// Every apply of a brand-new id is inserted enabled regardless
+// (store.UpsertAutomationDefinition), and re-applying an existing id never
+// touches its current enabled value — only `automation enable`/`disable`
+// does. Where this scenario used to reapply with `enabled: false` for
+// teardown, it now calls `automation disable <id>` directly (see
+// disableDefinition below).
 function editRebindDefinitionYAML({ id, locationPath, executable, prompt }) {
   return `api_version: ${API_VERSION}
 id: ${id}
@@ -439,32 +454,33 @@ async function main() {
     let run3 = null;
     await runner.step('leg1_edit_rebind', async () => {
       fs.writeFileSync(editDefinitionFile, editRebindDefinitionYAML({ id: editID, locationPath: editFixture, executable: probe.executable, prompt: PROMPT_P1 }));
-      runJSON(binary, ['automation', 'apply', '--file', editDefinitionFile], daemonEnv);
+      const created = runJSON(binary, ['automation', 'apply', '--file', editDefinitionFile], daemonEnv);
       editApplied = true;
+      runner.assert(created && created.enabled === true, 'sanity: a brand-new definition is inserted enabled by default', created);
       await waitForScheduleAnchor(dbPath, editID);
       const anchoredRows = runJSON(binary, ['automation', 'runs', editID], daemonEnv) || [];
       runner.assert(anchoredRows.length === 0, 'no run fires on the anchor-only tick', { anchoredRows });
 
       run1 = await poll(() => {
-        const rows = (runJSON(binary, ['automation', 'runs', editID], daemonEnv) || []).filter((row) => row.State === 'delivered');
+        const rows = (runJSON(binary, ['automation', 'runs', editID], daemonEnv) || []).filter((row) => row.state === 'delivered');
         return rows.length >= 1 ? rows[0] : null;
       }, 'P1 initial delivery', SCHEDULE_RUN_TIMEOUT_MS);
-      runner.assert(Boolean(run1.TicketID) && Boolean(run1.SessionID), 'P1 delivery reserves a ticket and session', run1);
-      runner.assert(run1.LastError === '', 'P1 delivery has no error', run1);
+      runner.assert(Boolean(run1.ticket_id) && Boolean(run1.session_id), 'P1 delivery reserves a ticket and session', run1);
+      runner.assert(!run1.last_error, 'P1 delivery has no error', run1);
 
       fs.writeFileSync(editDefinitionFile, editRebindDefinitionYAML({ id: editID, locationPath: editFixture, executable: probe.executable, prompt: PROMPT_P2 }));
       runJSON(binary, ['automation', 'apply', '--file', editDefinitionFile], daemonEnv);
 
       run2 = await poll(() => {
-        const rows = (runJSON(binary, ['automation', 'runs', editID], daemonEnv) || []).filter((row) => row.State === 'delivered' && row.TicketID !== run1.TicketID);
+        const rows = (runJSON(binary, ['automation', 'runs', editID], daemonEnv) || []).filter((row) => row.state === 'delivered' && row.ticket_id !== run1.ticket_id);
         return rows.length >= 1 ? rows[0] : null;
       }, 'P2 edit delivery on a fresh thread', SCHEDULE_RUN_TIMEOUT_MS);
-      runner.assert(run2.LastError === '', 'P2 edit delivery succeeds; no "contract changed" refusal', run2);
-      runner.assert(run2.TicketID !== run1.TicketID && run2.SessionID !== run1.SessionID, 'P2 edit delivery reserves a fresh ticket and session', { run1, run2 });
+      runner.assert(!run2.last_error, 'P2 edit delivery succeeds; no "contract changed" refusal', run2);
+      runner.assert(run2.ticket_id !== run1.ticket_id && run2.session_id !== run1.session_id, 'P2 edit delivery reserves a fresh ticket and session', { run1, run2 });
 
-      const run1AfterEdit = (runJSON(binary, ['automation', 'runs', editID], daemonEnv) || []).find((row) => row.ID === run1.ID);
+      const run1AfterEdit = (runJSON(binary, ['automation', 'runs', editID], daemonEnv) || []).find((row) => row.id === run1.id);
       runner.assert(
-        run1AfterEdit && run1AfterEdit.State === run1.State && run1AfterEdit.TicketID === run1.TicketID && run1AfterEdit.SessionID === run1.SessionID,
+        run1AfterEdit && run1AfterEdit.state === run1.state && run1AfterEdit.ticket_id === run1.ticket_id && run1AfterEdit.session_id === run1.session_id,
         "P1's original run row is unchanged after the P2 edit",
         { before: run1, after: run1AfterEdit },
       );
@@ -474,18 +490,18 @@ async function main() {
 
       run3 = await poll(() => {
         const rows = (runJSON(binary, ['automation', 'runs', editID], daemonEnv) || []).filter(
-          (row) => row.State === 'delivered' && row.TicketID !== run1.TicketID && row.TicketID !== run2.TicketID,
+          (row) => row.state === 'delivered' && row.ticket_id !== run1.ticket_id && row.ticket_id !== run2.ticket_id,
         );
         return rows.length >= 1 ? rows[0] : null;
       }, 'P1 revert delivery on yet another fresh thread (the A1-fix, live)', SCHEDULE_RUN_TIMEOUT_MS);
-      runner.assert(run3.LastError === '', 'P1 revert delivery succeeds; the revert edge does not brick delivery', run3);
+      runner.assert(!run3.last_error, 'P1 revert delivery succeeds; the revert edge does not brick delivery', run3);
       runner.assert(
-        run3.TicketID !== run1.TicketID && run3.TicketID !== run2.TicketID,
+        run3.ticket_id !== run1.ticket_id && run3.ticket_id !== run2.ticket_id,
         'P1 revert delivery reserves a third distinct thread even though its contract matches run1 exactly',
         { run1, run2, run3 },
       );
 
-      runJSON(binary, ['automation', 'disable', editID], daemonEnv);
+      disableDefinition(binary, editID, daemonEnv);
     });
 
     // Leg 2: delete-resurrect. Deleting has no UI affordance yet (see the
@@ -523,7 +539,7 @@ async function main() {
 
       const runsAfterDelete = runJSON(binary, ['automation', 'runs', deleteID], daemonEnv) || [];
       runner.assert(
-        runsAfterDelete.some((row) => row.ID === deleteRunID),
+        runsAfterDelete.some((row) => row.id === deleteRunID),
         'runs remain queryable via the CLI after delete',
         runsAfterDelete,
       );
@@ -532,6 +548,8 @@ async function main() {
       const deletedRow = sqliteRow(dbPath, `SELECT id, deleted_at FROM automation_definitions WHERE id='${sqlEscape(deleteID)}';`);
       runner.assert(deletedRow && deletedRow[1] !== '' && deletedRow[1] !== undefined, 'the definition row is soft-deleted (deleted_at set) in the DB', { deletedRow });
 
+      // Resurrection always re-enables (store.UpsertAutomationDefinition), so
+      // there is no enabled param to pass here even conceptually.
       fs.writeFileSync(deleteDefinitionFile, deleteResurrectDefinitionYAML({ id: deleteID, locationPath: deleteFixture, executable: probe.executable }));
       runJSON(binary, ['automation', 'apply', '--file', deleteDefinitionFile], daemonEnv);
 
@@ -542,14 +560,14 @@ async function main() {
 
       const runsAfterResurrect = runJSON(binary, ['automation', 'runs', deleteID], daemonEnv) || [];
       runner.assert(
-        runsAfterResurrect.some((row) => row.ID === deleteRunID),
+        runsAfterResurrect.some((row) => row.id === deleteRunID),
         'old run history survives resurrection',
         runsAfterResurrect,
       );
       const resurrectedRow = sqliteRow(dbPath, `SELECT id, deleted_at FROM automation_definitions WHERE id='${sqlEscape(deleteID)}';`);
       runner.assert(resurrectedRow && (resurrectedRow[1] ?? '') === '', 'the definition row is live again (deleted_at cleared) in the DB', { resurrectedRow });
 
-      runJSON(binary, ['automation', 'disable', deleteID], daemonEnv);
+      disableDefinition(binary, deleteID, daemonEnv);
     });
 
     // Leg 3: cleanup-dirty-safe. Three independent worktrees under ONE
@@ -569,14 +587,14 @@ async function main() {
 
       await wsRequest(options.wsUrl, { cmd: 'refresh_prs' }, 'refresh_prs_result');
       const cleanRun = await poll(() => {
-        const rows = (runJSON(binary, ['automation', 'runs', cleanupID], daemonEnv) || []).filter((row) => row.State === 'delivered');
+        const rows = (runJSON(binary, ['automation', 'runs', cleanupID], daemonEnv) || []).filter((row) => row.state === 'delivered');
         return rows.length >= 1 ? rows[0] : null;
       }, 'cleanup leg first delivery', GH_DELIVERY_TIMEOUT_MS);
-      const cleanWorktree = resolveWorktree(observer, profile, cleanRun.SessionID);
+      const cleanWorktree = resolveWorktree(observer, profile, cleanRun.session_id);
       runner.assert(fs.existsSync(cleanWorktree), 'first delivery worktree exists', { cleanWorktree });
 
-      await client.request('close_session', { sessionId: cleanRun.SessionID });
-      await waitSessionGone(observer, cleanRun.SessionID, 'first cleanup-leg session to unregister');
+      await client.request('close_session', { sessionId: cleanRun.session_id });
+      await waitSessionGone(observer, cleanRun.session_id, 'first cleanup-leg session to unregister');
 
       fs.writeFileSync(cleanupDefinitionFile, cleanupLifecycleDefinitionYAML({ id: cleanupID, executable: probe.executable, repoPath: cleanupFixture.repo, prompt: CLEANUP_PROMPT_V2 }));
       runJSON(binary, ['automation', 'apply', '--file', cleanupDefinitionFile], daemonEnv);
@@ -588,15 +606,15 @@ async function main() {
 
       const dirtyRun = await poll(() => {
         const rows = (runJSON(binary, ['automation', 'runs', cleanupID], daemonEnv) || [])
-          .filter((row) => row.State === 'delivered' && row.TicketID !== cleanRun.TicketID);
+          .filter((row) => row.state === 'delivered' && row.ticket_id !== cleanRun.ticket_id);
         return rows.length >= 1 ? rows[0] : null;
       }, 'cleanup leg second delivery on a fresh thread', GH_DELIVERY_TIMEOUT_MS);
-      const dirtyWorktree = resolveWorktree(observer, profile, dirtyRun.SessionID);
+      const dirtyWorktree = resolveWorktree(observer, profile, dirtyRun.session_id);
       runner.assert(dirtyWorktree !== cleanWorktree, 'the edit-rotated second delivery gets an independent worktree', { cleanWorktree, dirtyWorktree });
       runner.assert(fs.existsSync(dirtyWorktree), 'second delivery worktree exists', { dirtyWorktree });
 
-      await client.request('close_session', { sessionId: dirtyRun.SessionID });
-      await waitSessionGone(observer, dirtyRun.SessionID, 'second cleanup-leg session to unregister');
+      await client.request('close_session', { sessionId: dirtyRun.session_id });
+      await waitSessionGone(observer, dirtyRun.session_id, 'second cleanup-leg session to unregister');
 
       fs.writeFileSync(path.join(dirtyWorktree, 'uncommitted-scratch.txt'), 'dirty for leg3 cleanup-dirty-safe\n');
 
@@ -613,10 +631,10 @@ async function main() {
 
       const activeRun = await poll(() => {
         const rows = (runJSON(binary, ['automation', 'runs', cleanupID], daemonEnv) || [])
-          .filter((row) => row.State === 'delivered' && row.TicketID !== cleanRun.TicketID && row.TicketID !== dirtyRun.TicketID);
+          .filter((row) => row.state === 'delivered' && row.ticket_id !== cleanRun.ticket_id && row.ticket_id !== dirtyRun.ticket_id);
         return rows.length >= 1 ? rows[0] : null;
       }, 'cleanup leg third delivery on the current thread', GH_DELIVERY_TIMEOUT_MS);
-      const activeWorktree = resolveWorktree(observer, profile, activeRun.SessionID);
+      const activeWorktree = resolveWorktree(observer, profile, activeRun.session_id);
       runner.assert(activeWorktree !== cleanWorktree && activeWorktree !== dirtyWorktree, 'the third delivery gets an independent worktree', { cleanWorktree, dirtyWorktree, activeWorktree });
       runner.assert(fs.existsSync(activeWorktree), 'third delivery worktree exists', { activeWorktree });
 
@@ -627,22 +645,22 @@ async function main() {
       // that surviving binding, with no live session row backing it, is
       // exactly the case that used to make cleanup silently skip the run and
       // destroy a live thread's worktree.
-      await client.request('close_session', { sessionId: activeRun.SessionID });
-      await waitSessionGone(observer, activeRun.SessionID, 'third cleanup-leg session to unregister');
+      await client.request('close_session', { sessionId: activeRun.session_id });
+      await waitSessionGone(observer, activeRun.session_id, 'third cleanup-leg session to unregister');
 
       const result = runJSON(binary, ['automation', 'cleanup', cleanupID], daemonEnv);
       runner.assert(
-        Array.isArray(result.cleaned) && result.cleaned.includes(cleanRun.ID) && !result.cleaned.includes(dirtyRun.ID) && !result.cleaned.includes(activeRun.ID),
+        Array.isArray(result.cleaned) && result.cleaned.includes(cleanRun.id) && !result.cleaned.includes(dirtyRun.id) && !result.cleaned.includes(activeRun.id),
         'cleanup reports only the clean run in cleaned',
         result,
       );
       runner.assert(
-        Array.isArray(result.kept_dirty) && result.kept_dirty.includes(dirtyRun.ID) && !result.kept_dirty.includes(cleanRun.ID) && !result.kept_dirty.includes(activeRun.ID),
+        Array.isArray(result.kept_dirty) && result.kept_dirty.includes(dirtyRun.id) && !result.kept_dirty.includes(cleanRun.id) && !result.kept_dirty.includes(activeRun.id),
         'cleanup reports only the dirty run in kept_dirty',
         result,
       );
       runner.assert(
-        Array.isArray(result.kept_active) && result.kept_active.includes(activeRun.ID) && !result.kept_active.includes(cleanRun.ID) && !result.kept_active.includes(dirtyRun.ID),
+        Array.isArray(result.kept_active) && result.kept_active.includes(activeRun.id) && !result.kept_active.includes(cleanRun.id) && !result.kept_active.includes(dirtyRun.id),
         'cleanup reports the still-bound current thread in kept_active rather than silently skipping it',
         result,
       );
@@ -657,19 +675,19 @@ async function main() {
       const rowsAfterCleanup = runJSON(binary, ['automation', 'runs', cleanupID], daemonEnv) || [];
       runner.assert(rowsAfterCleanup.length === 3, 'all three run rows still exist after cleanup', rowsAfterCleanup);
       runner.assert(
-        rowsAfterCleanup.every((row) => row.State === 'delivered'),
+        rowsAfterCleanup.every((row) => row.state === 'delivered'),
         'cleanup never mutates run state',
         rowsAfterCleanup,
       );
 
       const second = runJSON(binary, ['automation', 'cleanup', cleanupID], daemonEnv);
       runner.assert(
-        (second.cleaned || []).length === 0 && (second.kept_dirty || []).includes(dirtyRun.ID) && (second.kept_active || []).includes(activeRun.ID),
+        (second.cleaned || []).length === 0 && (second.kept_dirty || []).includes(dirtyRun.id) && (second.kept_active || []).includes(activeRun.id),
         'a second cleanup invocation is a no-op for the already-cleaned run and still reports the dirty and still-bound runs',
         second,
       );
 
-      runJSON(binary, ['automation', 'disable', cleanupID], daemonEnv);
+      disableDefinition(binary, cleanupID, daemonEnv);
     });
 
     runner.finishSuccess({ profile, editID, deleteID, cleanupID, run1, run2, run3, deleteRunID });
@@ -684,23 +702,13 @@ async function main() {
     // github_review_requested definition keeps observing the mock — leaving
     // either running against a torn-down fixture would spam errors on this
     // profile forever (same defensive ordering as
-    // scenario-automation-scheduled-cleanup.mjs's finally block).
+    // scenario-automation-scheduled-cleanup.mjs's finally block). Each leg
+    // already disables its own definition at the end of its happy path; these
+    // are a defensive backstop for the case where an assertion threw first.
     if (daemonEnv) {
-      if (editApplied && editFixture && fs.existsSync(editFixture)) {
-        try {
-          run(binary, ['automation', 'disable', editID], daemonEnv);
-        } catch {}
-      }
-      if (deleteApplied && deleteFixture && fs.existsSync(deleteFixture)) {
-        try {
-          run(binary, ['automation', 'disable', deleteID], daemonEnv);
-        } catch {}
-      }
-      if (cleanupApplied && cleanupFixture) {
-        try {
-          run(binary, ['automation', 'disable', cleanupID], daemonEnv);
-        } catch {}
-      }
+      if (editApplied) { try { disableDefinition(binary, editID, daemonEnv); } catch {} }
+      if (deleteApplied) { try { disableDefinition(binary, deleteID, daemonEnv); } catch {} }
+      if (cleanupApplied) { try { disableDefinition(binary, cleanupID, daemonEnv); } catch {} }
     }
     await client.quitApp().catch(() => {});
     await observer.close().catch(() => {});

--- a/app/scripts/real-app-harness/scenario-automation-pr-continuity.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-pr-continuity.mjs
@@ -251,16 +251,21 @@ async function main() {
       }, 'profile daemon');
     });
     await runner.step('launch_packaged_app', () => launchFreshAppAndConnect(client, observer));
-    fs.writeFileSync(definitionFile, `api_version: attn.dev/automations/v1alpha1\nid: ${definitionID}\nname: Slice 4 packaged continuity proof\nenabled: true\ntrigger:\n  type: github_review_requested\n  repositories:\n    mode: all_accessible\n    include: [mock.github.local/owner/repo]\nprompt: |\n  Review only the local fixture and report in this ticket. Never write to GitHub.\nlaunch:\n  driver: codex\n  executable: ${JSON.stringify(probe.executable)}\n  model: gpt-5.6-terra\n  effort: high\nlocation:\n  type: repository_worktree\n  repository_sources:\n    default: {type: managed_cache}\n    overrides:\n      mock.github.local/owner/repo:\n        type: local_clone\n        path: ${JSON.stringify(fixture.repo)}\n`);
+    // `enabled` is not a spec field post-PR5 (column-only; a YAML carrying
+    // `enabled:` is rejected outright — errEnabledManagedOutsideSpec in
+    // internal/automation/automation.go), so this literal no longer emits it.
+    // A brand-new id is inserted enabled regardless
+    // (store.UpsertAutomationDefinition).
+    fs.writeFileSync(definitionFile, `api_version: attn.dev/automations/v1alpha1\nid: ${definitionID}\nname: Slice 4 packaged continuity proof\ntrigger:\n  type: github_review_requested\n  repositories:\n    mode: all_accessible\n    include: [mock.github.local/owner/repo]\nprompt: |\n  Review only the local fixture and report in this ticket. Never write to GitHub.\nlaunch:\n  driver: codex\n  executable: ${JSON.stringify(probe.executable)}\n  model: gpt-5.6-terra\n  effort: high\nlocation:\n  type: repository_worktree\n  repository_sources:\n    default: {type: managed_cache}\n    overrides:\n      mock.github.local/owner/repo:\n        type: local_clone\n        path: ${JSON.stringify(fixture.repo)}\n`);
     await runner.step('apply_definition', async () => runJSON(binary, ['automation', 'apply', '--file', definitionFile], daemonEnv));
     await runner.step('deliver_initial_review', async () => {
       await wsRequest(options.wsUrl, { cmd: 'refresh_prs' }, 'refresh_prs_result');
       const runRow = await poll(() => {
         const rows = runJSON(binary, ['automation', 'runs', definitionID], daemonEnv) || [];
-        return rows.find((row) => row.State === 'delivered') || null;
+        return rows.find((row) => row.state === 'delivered') || null;
       }, 'initial delivered automation run', 45_000);
-      sessionID = runRow.SessionID;
-      ticketID = runRow.TicketID;
+      sessionID = runRow.session_id;
+      ticketID = runRow.ticket_id;
       worktree = observer.getSession(sessionID)?.directory || path.join(dataDirForProfile(profile), 'automation', 'worktrees', sessionID, 'repo');
       await poll(() => invocations(probe.log).length >= 1 ? invocations(probe.log)[0] : null, 'first Codex launch');
       runner.assert(fs.existsSync(worktree), 'initial exact-SHA worktree exists', { worktree });
@@ -284,11 +289,11 @@ async function main() {
     const continuation = await runner.step('assert_same_reviewer_resumed', async () => {
       const row = await poll(() => {
         const rows = runJSON(binary, ['automation', 'runs', definitionID], daemonEnv) || [];
-        return rows.length >= 2 && rows[0].State === 'delivered' ? rows[0] : null;
+        return rows.length >= 2 && rows[0].state === 'delivered' ? rows[0] : null;
       }, 'delivered continuation', 45_000);
       const calls = await poll(() => invocations(probe.log).length >= 2 ? invocations(probe.log) : null, 'Codex resume launch');
       const resumed = calls[1].argv;
-      runner.assert(row.SessionID === sessionID && row.TicketID === ticketID, 'continuation reuses the same session and ticket', row);
+      runner.assert(row.session_id === sessionID && row.ticket_id === ticketID, 'continuation reuses the same session and ticket', row);
       runner.assert(resumed.includes('resume') && resumed.includes(seed.id), 'Codex receives the copied rollout id', { argv: resumed, rollout: seed.id });
       runner.assert(resumed.some((arg) => arg.includes('gpt-5.6-terra')) && resumed.some((arg) => arg.includes('high')), 'resume keeps pinned model and effort', { argv: resumed });
       runner.assert(fs.readFileSync(path.join(worktree, 'review-notes.txt'), 'utf8').includes('preserve me'), 'dirty reviewer work survives continuation');
@@ -307,9 +312,9 @@ async function main() {
       await wsRequest(options.wsUrl, { cmd: 'refresh_prs' }, 'refresh_prs_result');
       const failed = await poll(() => {
         const rows = runJSON(binary, ['automation', 'runs', definitionID], daemonEnv) || [];
-        return rows.length >= 3 && rows[0].State === 'failed' ? rows[0] : null;
+        return rows.length >= 3 && rows[0].state === 'failed' ? rows[0] : null;
       }, 'visible missing-worktree failure', 30_000);
-      runner.assert(String(failed.LastError).includes('worktree') && String(failed.LastError).includes('missing'), 'missing delivered worktree fails without recreation', failed);
+      runner.assert(String(failed.last_error).includes('worktree') && String(failed.last_error).includes('missing'), 'missing delivered worktree fails without recreation', failed);
     });
     runner.finishSuccess({ profile, definitionID, sessionID, ticketID, worktree, seed, continuation });
   } catch (error) {

--- a/app/scripts/real-app-harness/scenario-automation-pr-continuity.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-pr-continuity.mjs
@@ -276,7 +276,7 @@ async function main() {
       fs.writeFileSync(path.join(worktree, 'review-notes.txt'), 'preserve me across review cycles\n');
       run(binary, ['ticket', 'status', 'completed', '--ticket', ticketID, '--session', sessionID, '--comment', 'first review complete'], daemonEnv);
       const db = path.join(dataDirForProfile(profile), 'attn.db');
-      execFileSync('sqlite3', [db, `UPDATE tickets SET archived_at=datetime('now') WHERE id='${ticketID.replaceAll("'", "''")}';`]);
+      execFileSync('sqlite3', ['-cmd', '.timeout 5000', db, `UPDATE tickets SET archived_at=datetime('now') WHERE id='${ticketID.replaceAll("'", "''")}';`]);
       await client.request('close_session', { sessionId: sessionID });
       await observer.waitFor(() => !observer.getSession(sessionID) ? true : null, 'origin reviewer to unregister');
     });

--- a/app/scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs
@@ -95,7 +95,7 @@ async function poll(fn, description, timeoutMs = 30_000) {
 }
 
 function sqliteRow(dbPath, sql) {
-  const out = execFileSync('sqlite3', [dbPath, sql], { encoding: 'utf8' }).trim();
+  const out = execFileSync('sqlite3', ['-cmd', '.timeout 5000', dbPath, sql], { encoding: 'utf8' }).trim();
   return out.length === 0 ? null : out.split('|');
 }
 

--- a/app/scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs
@@ -74,6 +74,12 @@ function runJSON(binary, args, env) {
   return JSON.parse(run(binary, args, env));
 }
 
+// `enable`/`disable` are the only way to move the enabled column post-PR5;
+// both print the updated (lowercase) definition summary.
+function disableDefinition(binary, id, env) {
+  return runJSON(binary, ['automation', 'disable', id], env);
+}
+
 async function poll(fn, description, timeoutMs = 30_000) {
   const started = Date.now();
   let last = null;
@@ -163,11 +169,17 @@ function invocations(log) {
 
 const API_VERSION = 'attn.dev/automations/v1alpha1';
 
-function cleanupDefinitionYAML({ id, locationPath, enabled }) {
+// `enabled` is not a spec field post-PR5 (column-only; a YAML carrying
+// `enabled:` is rejected outright — errEnabledManagedOutsideSpec in
+// internal/automation/automation.go), so neither template below emits it.
+// Every apply of a brand-new id is inserted enabled regardless
+// (store.UpsertAutomationDefinition); teardown/leg-end disabling now goes
+// through `automation disable <id>` (disableDefinition above) instead of a
+// reapply with `enabled: false`.
+function cleanupDefinitionYAML({ id, locationPath }) {
   return `api_version: ${API_VERSION}
 id: ${id}
 name: Slice 5 packaged scheduled cleanup proof
-enabled: ${enabled}
 trigger:
   type: scheduled
   schedule:
@@ -187,11 +199,10 @@ location:
 `;
 }
 
-function stormGuardDefinitionYAML({ id, locationPath, enabled, executable }) {
+function stormGuardDefinitionYAML({ id, locationPath, executable }) {
   return `api_version: ${API_VERSION}
 id: ${id}
 name: Slice 5 scheduler storm-guard probe
-enabled: ${enabled}
 trigger:
   type: scheduled
   schedule:
@@ -282,7 +293,7 @@ async function main() {
     });
 
     await runner.step('leg1_apply_and_anchor', async () => {
-      fs.writeFileSync(cleanupDefinitionFile, cleanupDefinitionYAML({ id: cleanupID, locationPath: fixtureRoot, enabled: true }));
+      fs.writeFileSync(cleanupDefinitionFile, cleanupDefinitionYAML({ id: cleanupID, locationPath: fixtureRoot }));
       runJSON(binary, ['automation', 'apply', '--file', cleanupDefinitionFile], daemonEnv);
       cleanupApplied = true;
       // First observation after apply only anchors the cursor; it must not fire.
@@ -302,15 +313,15 @@ async function main() {
       }, 'restart catch-up run', RESTART_RUN_TIMEOUT_MS);
       runner.assert(rows.length === 1, 'exactly one catch-up run fires despite multiple missed instants (latest policy)', { rows });
       const runRow = rows[0];
-      cleanupTicketID = runRow.TicketID;
-      cleanupSessionID = runRow.SessionID;
+      cleanupTicketID = runRow.ticket_id;
+      cleanupSessionID = runRow.session_id;
       runner.assert(Boolean(cleanupTicketID) && Boolean(cleanupSessionID), 'catch-up run reserves a ticket and session', runRow);
 
       const occurrence = sqliteRow(
         dbPath,
-        `SELECT o.occurrence_key FROM automation_occurrences o JOIN automation_runs r ON r.occurrence_id=o.id WHERE r.id='${sqlEscape(runRow.ID)}';`,
+        `SELECT o.occurrence_key FROM automation_occurrences o JOIN automation_runs r ON r.occurrence_id=o.id WHERE r.id='${sqlEscape(runRow.id)}';`,
       );
-      runner.assert(occurrence !== null, 'catch-up run has a resolvable occurrence row', { runID: runRow.ID });
+      runner.assert(occurrence !== null, 'catch-up run has a resolvable occurrence row', { runID: runRow.id });
       const occurrenceKey = occurrence[0];
       runner.assert(
         /^scheduled:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:00Z$/.test(occurrenceKey),
@@ -355,8 +366,8 @@ async function main() {
         return list.length >= 2 ? list : null;
       }, 'a second coalesced occurrence', COALESCE_TIMEOUT_MS);
       runner.assert(rows.length >= 2, 'at least a second occurrence fired while enabled', { count: rows.length });
-      const tickets = new Set(rows.map((row) => row.TicketID));
-      const sessions = new Set(rows.map((row) => row.SessionID));
+      const tickets = new Set(rows.map((row) => row.ticket_id));
+      const sessions = new Set(rows.map((row) => row.session_id));
       runner.assert(
         tickets.size === 1 && tickets.has(cleanupTicketID),
         'every occurrence for this definition coalesces onto the same singleton ticket',
@@ -375,8 +386,7 @@ async function main() {
       runner.assert(fs.existsSync(path.join(fixture.dirtyWip, 'scratch.txt')), 'dirty-wip uncommitted file is still untouched after coalescing');
       runner.assert(worktreeListShows(fixture.repo, fixture.dirtyWip), 'dirty-wip worktree is still tracked by git worktree list after coalescing');
 
-      fs.writeFileSync(cleanupDefinitionFile, cleanupDefinitionYAML({ id: cleanupID, locationPath: fixtureRoot, enabled: false }));
-      runJSON(binary, ['automation', 'apply', '--file', cleanupDefinitionFile], daemonEnv);
+      disableDefinition(binary, cleanupID, daemonEnv);
     });
 
     // Leg 4: storm-guard re-assertion. A true skip-vs-latest discard proof needs
@@ -391,7 +401,7 @@ async function main() {
     await runner.step('leg4_storm_guard_restart', async () => {
       fs.writeFileSync(
         stormGuardDefinitionFile,
-        stormGuardDefinitionYAML({ id: stormGuardID, locationPath: fixtureRoot, enabled: true, executable: probe.executable }),
+        stormGuardDefinitionYAML({ id: stormGuardID, locationPath: fixtureRoot, executable: probe.executable }),
       );
       runJSON(binary, ['automation', 'apply', '--file', stormGuardDefinitionFile], daemonEnv);
       stormGuardApplied = true;
@@ -413,16 +423,12 @@ async function main() {
       // widen while this step keeps running.
       const rows = await poll(() => {
         const list = runJSON(binary, ['automation', 'runs', stormGuardID], daemonEnv) || [];
-        const delivered = list.filter((row) => row.State === 'delivered');
+        const delivered = list.filter((row) => row.state === 'delivered');
         return delivered.length >= 1 ? delivered : null;
       }, 'storm-guard restart catch-up run delivered', RESTART_RUN_TIMEOUT_MS);
       runner.assert(rows.length === 1, 'storm-guard: exactly one catch-up run under fresh continuity too', { rows });
 
-      fs.writeFileSync(
-        stormGuardDefinitionFile,
-        stormGuardDefinitionYAML({ id: stormGuardID, locationPath: fixtureRoot, enabled: false, executable: probe.executable }),
-      );
-      runJSON(binary, ['automation', 'apply', '--file', stormGuardDefinitionFile], daemonEnv);
+      disableDefinition(binary, stormGuardID, daemonEnv);
 
       await poll(() => (invocations(probe.log).length >= 1 ? invocations(probe.log) : null), 'storm-guard probe launch');
       runner.assert(invocations(probe.log).length === 1, 'exactly one process spawn backs the single catch-up run (no replay storm)', {
@@ -440,21 +446,8 @@ async function main() {
     // (os.Stat) on every future tick, so leaving one enabled against a deleted
     // temp root would spam schedule-observation errors on this profile forever.
     if (daemonEnv) {
-      if (cleanupApplied && fs.existsSync(fixtureRoot)) {
-        try {
-          fs.writeFileSync(cleanupDefinitionFile, cleanupDefinitionYAML({ id: cleanupID, locationPath: fixtureRoot, enabled: false }));
-          run(binary, ['automation', 'apply', '--file', cleanupDefinitionFile], daemonEnv);
-        } catch {}
-      }
-      if (stormGuardApplied && fs.existsSync(fixtureRoot) && probe) {
-        try {
-          fs.writeFileSync(
-            stormGuardDefinitionFile,
-            stormGuardDefinitionYAML({ id: stormGuardID, locationPath: fixtureRoot, enabled: false, executable: probe.executable }),
-          );
-          run(binary, ['automation', 'apply', '--file', stormGuardDefinitionFile], daemonEnv);
-        } catch {}
-      }
+      if (cleanupApplied) { try { disableDefinition(binary, cleanupID, daemonEnv); } catch {} }
+      if (stormGuardApplied) { try { disableDefinition(binary, stormGuardID, daemonEnv); } catch {} }
     }
     try { fs.rmSync(fixtureRoot, { recursive: true, force: true }); } catch {}
     // daemonEnv never diverged from a plain profile daemon (no mock provider,

--- a/app/scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs
@@ -5,7 +5,9 @@
  * definition fires at its intended minute, survives a daemon restart per its
  * catch_up policy, does real merged-worktree cleanup in a visible ticket/
  * session, never touches a dirty worktree, and coalesces later occurrences
- * onto the same singleton ticket/session.
+ * onto the same singleton ticket/session. The scenario quits the profile's app
+ * first (ensureFreshWorld) because a running app would respawn the daemon during
+ * the simulated downtime and invalidate the restart-catch-up leg.
  *
  * Two definitions are applied against one isolated profile daemon:
  *   - `scheduled-cleanup-<suffix>`: cron `* * * * *`, policy.continuity
@@ -34,6 +36,7 @@ import { fileURLToPath } from 'node:url';
 import { parseCommonArgs, printCommonHelp } from './common.mjs';
 import { createScenarioRunner } from './scenarioRunner.mjs';
 import { currentHarnessProfile, dataDirForProfile, resolveHarnessResources } from './harnessProfile.mjs';
+import { ensureFreshWorld } from './freshWorld.mjs';
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -287,6 +290,7 @@ async function main() {
     probe = createCodexProbe(runner.sessionDir);
 
     await runner.step('restart_isolated_daemon', async () => {
+      await ensureFreshWorld({ profile, appPath: resources.appPath });
       try { run(binary, ['daemon', 'stop'], daemonEnv); } catch {}
       run(binary, ['daemon', 'ensure'], daemonEnv);
       await waitForDaemonReady(binary, daemonEnv);

--- a/app/scripts/real-app-harness/scenario-automation-surface.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-surface.mjs
@@ -72,6 +72,12 @@ function runJSON(binary, args, env) {
   return JSON.parse(run(binary, args, env));
 }
 
+// `enable`/`disable` are the only way to move the enabled column post-PR5;
+// both print the updated (lowercase) definition summary.
+function disableDefinition(binary, id, env) {
+  return runJSON(binary, ['automation', 'disable', id], env);
+}
+
 async function poll(fn, description, timeoutMs = 30_000) {
   const started = Date.now();
   let last = null;
@@ -121,11 +127,17 @@ function createCodexProbe(root) {
 
 const API_VERSION = 'attn.dev/automations/v1alpha1';
 
-function manualDefinitionYAML({ id, locationPath, enabled, executable }) {
+// `enabled` is not a spec field post-PR5 (column-only; a YAML carrying
+// `enabled:` is rejected outright — errEnabledManagedOutsideSpec in
+// internal/automation/automation.go), so neither template below emits it.
+// Every apply of a brand-new id is inserted enabled regardless
+// (store.UpsertAutomationDefinition); teardown disabling goes through
+// `automation disable <id>` (disableDefinition above) instead of a reapply
+// with `enabled: false`.
+function manualDefinitionYAML({ id, locationPath, executable }) {
   return `api_version: ${API_VERSION}
 id: ${id}
 name: Slice 6 packaged automations-panel proof (manual)
-enabled: ${enabled}
 trigger:
   type: manual
 prompt: |
@@ -141,11 +153,10 @@ location:
 `;
 }
 
-function scheduledDefinitionYAML({ id, locationPath, enabled, executable }) {
+function scheduledDefinitionYAML({ id, locationPath, executable }) {
   return `api_version: ${API_VERSION}
 id: ${id}
 name: Slice 6 packaged automations-panel proof (non-manual)
-enabled: ${enabled}
 trigger:
   type: scheduled
   schedule:
@@ -260,7 +271,7 @@ async function main() {
     await runner.step('leg1_apply_manual_and_panel_shows_it', async () => {
       fs.writeFileSync(
         manualDefinitionFile,
-        manualDefinitionYAML({ id: manualID, locationPath: fixturePath, enabled: true, executable: probe.executable }),
+        manualDefinitionYAML({ id: manualID, locationPath: fixturePath, executable: probe.executable }),
       );
       runJSON(binary, ['automation', 'apply', '--file', manualDefinitionFile], daemonEnv);
       manualApplied = true;
@@ -308,7 +319,7 @@ async function main() {
     await runner.step('leg3_failure_shown_not_hidden', async () => {
       fs.writeFileSync(
         scheduledDefinitionFile,
-        scheduledDefinitionYAML({ id: scheduledID, locationPath: fixturePath, enabled: true, executable: probe.executable }),
+        scheduledDefinitionYAML({ id: scheduledID, locationPath: fixturePath, executable: probe.executable }),
       );
       runJSON(binary, ['automation', 'apply', '--file', scheduledDefinitionFile], daemonEnv);
       scheduledApplied = true;
@@ -390,25 +401,9 @@ async function main() {
     // future observation, so leaving one enabled against a deleted temp root
     // would spam errors on this profile forever (same defensive ordering as
     // scenario-automation-scheduled-cleanup.mjs's finally block).
-    if (daemonEnv && fixturePath && fs.existsSync(fixturePath)) {
-      if (manualApplied) {
-        try {
-          fs.writeFileSync(
-            manualDefinitionFile,
-            manualDefinitionYAML({ id: manualID, locationPath: fixturePath, enabled: false, executable: probe.executable }),
-          );
-          run(binary, ['automation', 'apply', '--file', manualDefinitionFile], daemonEnv);
-        } catch {}
-      }
-      if (scheduledApplied) {
-        try {
-          fs.writeFileSync(
-            scheduledDefinitionFile,
-            scheduledDefinitionYAML({ id: scheduledID, locationPath: fixturePath, enabled: false, executable: probe.executable }),
-          );
-          run(binary, ['automation', 'apply', '--file', scheduledDefinitionFile], daemonEnv);
-        } catch {}
-      }
+    if (daemonEnv) {
+      if (manualApplied) { try { disableDefinition(binary, manualID, daemonEnv); } catch {} }
+      if (scheduledApplied) { try { disableDefinition(binary, scheduledID, daemonEnv); } catch {} }
     }
     if (fixturePath) {
       try { fs.rmSync(fixturePath, { recursive: true, force: true }); } catch {}

--- a/app/src/components/AutomationsPanel.test.tsx
+++ b/app/src/components/AutomationsPanel.test.tsx
@@ -54,7 +54,6 @@ function makeRun(
 ): AutomationRunSummary {
   return {
     definition_id: 'd1',
-    definition_revision: 1,
     state: 'delivered',
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
@@ -69,13 +68,12 @@ function baseProps() {
     fetchDefinitions: vi.fn().mockResolvedValue([]),
     fetchRuns: vi.fn().mockResolvedValue([]),
     setEnabled: vi.fn().mockResolvedValue(undefined),
-    runNow: vi.fn().mockResolvedValue({}),
-    getDefinition: vi.fn().mockResolvedValue({ specYaml: 'id: new-automation\nname: New automation\n', revision: 0 }),
+    runNow: vi.fn().mockResolvedValue(undefined),
+    getDefinition: vi.fn().mockResolvedValue({ specYaml: 'id: new-automation\nname: New automation\n' }),
     validateDefinition: vi.fn().mockResolvedValue(undefined),
     applyDefinition: vi.fn().mockResolvedValue({
       definition: makeDefinition({ id: 'd1', revision: 2 }),
       specYaml: 'id: d1\n',
-      revision: 2,
     }),
     onOpenTicket: vi.fn(),
     onSelectSession: vi.fn(),
@@ -128,12 +126,13 @@ describe('AutomationsPanel', () => {
     expect(screen.queryByTestId('automation-run-now-d2')).not.toBeInTheDocument();
   });
 
-  it('shows a failure badge and last_error when a definition latest run failed', async () => {
+  it('shows a failure badge and last_error when a definition\'s embedded last_run failed', async () => {
     const props = baseProps();
-    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1' })]);
-    props.fetchRuns.mockResolvedValue([
-      makeRun({ id: 'r1', state: 'failed', created_at: '2026-01-02T00:00:00Z', last_error: 'boom' }),
-      makeRun({ id: 'r2', state: 'delivered', created_at: '2026-01-01T00:00:00Z' }),
+    props.fetchDefinitions.mockResolvedValue([
+      makeDefinition({
+        id: 'd1',
+        last_run: makeRun({ id: 'r1', state: 'failed', created_at: '2026-01-02T00:00:00Z', last_error: 'boom' }),
+      }),
     ]);
     render(<AutomationsPanel {...props} />);
 
@@ -215,10 +214,9 @@ describe('AutomationsPanel', () => {
     expect(secondCall[1]).toBe(pendingId);
   });
 
-  it('reconciles a pending run request once a fetched run for its request id reaches delivered', async () => {
+  it('reconciles a pending run request once a definition\'s embedded last_run for its request id reaches delivered', async () => {
     const props = baseProps();
     props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1', trigger_type: 'manual' })]);
-    props.fetchRuns.mockResolvedValue([]);
     useAutomationsStore.getState().reset();
     render(<AutomationsPanel {...props} />);
     await screen.findByTestId('automation-run-now-d1');
@@ -226,27 +224,38 @@ describe('AutomationsPanel', () => {
     const pendingId = useAutomationsStore.getState().ensureRunRequest('d1');
 
     // Still pending: the key survives.
-    props.fetchRuns.mockResolvedValue([
-      makeRun({ id: 'r1', occurrence_key: `manual:${pendingId}`, state: 'pending' }),
+    props.fetchDefinitions.mockResolvedValue([
+      makeDefinition({
+        id: 'd1',
+        trigger_type: 'manual',
+        last_run: makeRun({ id: 'r1', occurrence_key: `manual:${pendingId}`, state: 'pending' }),
+      }),
     ]);
     useAutomationsStore.getState().bumpChanged();
-    await waitFor(() => expect(props.fetchRuns).toHaveBeenCalled());
+    await waitFor(() => expect(props.fetchDefinitions).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(useAutomationsStore.getState().pendingRunRequests['d1']).toBe(pendingId));
 
     // Delivered: the key clears, so the next click mints a fresh id.
-    props.fetchRuns.mockResolvedValue([
-      makeRun({ id: 'r1', occurrence_key: `manual:${pendingId}`, state: 'delivered' }),
+    props.fetchDefinitions.mockResolvedValue([
+      makeDefinition({
+        id: 'd1',
+        trigger_type: 'manual',
+        last_run: makeRun({ id: 'r1', occurrence_key: `manual:${pendingId}`, state: 'delivered' }),
+      }),
     ]);
     useAutomationsStore.getState().bumpChanged();
     await waitFor(() => expect(useAutomationsStore.getState().pendingRunRequests['d1']).toBeUndefined());
   });
 
-  it('adopts a pending manual run id from run history after a simulated relaunch, so Run now retries it instead of minting a fresh id', async () => {
+  it('adopts a pending manual run id from a definition\'s embedded last_run after a simulated relaunch, so Run now retries it instead of minting a fresh id', async () => {
     const user = userEvent.setup();
     const props = baseProps();
-    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1', trigger_type: 'manual' })]);
-    props.fetchRuns.mockResolvedValue([
-      makeRun({ id: 'r1', occurrence_key: 'manual:restart-key-1', state: 'pending' }),
+    props.fetchDefinitions.mockResolvedValue([
+      makeDefinition({
+        id: 'd1',
+        trigger_type: 'manual',
+        last_run: makeRun({ id: 'r1', occurrence_key: 'manual:restart-key-1', state: 'pending' }),
+      }),
     ]);
     // Simulate relaunch: the store starts empty regardless of what the
     // daemon still has pending.
@@ -263,15 +272,18 @@ describe('AutomationsPanel', () => {
   it('does not adopt a pending run whose occurrence_key is not manual-prefixed', async () => {
     const user = userEvent.setup();
     const props = baseProps();
-    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1', trigger_type: 'manual' })]);
-    props.fetchRuns.mockResolvedValue([
-      makeRun({ id: 'r1', occurrence_key: 'sched:2026-01-01T00:00:00Z', state: 'pending' }),
+    props.fetchDefinitions.mockResolvedValue([
+      makeDefinition({
+        id: 'd1',
+        trigger_type: 'manual',
+        last_run: makeRun({ id: 'r1', occurrence_key: 'sched:2026-01-01T00:00:00Z', state: 'pending' }),
+      }),
     ]);
     useAutomationsStore.getState().reset();
     render(<AutomationsPanel {...props} />);
 
     const button = await screen.findByTestId('automation-run-now-d1');
-    await waitFor(() => expect(props.fetchRuns).toHaveBeenCalled());
+    await waitFor(() => expect(props.fetchDefinitions).toHaveBeenCalled());
     expect(useAutomationsStore.getState().pendingRunRequests['d1']).toBeUndefined();
 
     await user.click(button);
@@ -283,16 +295,19 @@ describe('AutomationsPanel', () => {
   it('adoption never overwrites a key already stored for this session', async () => {
     const user = userEvent.setup();
     const props = baseProps();
-    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1', trigger_type: 'manual' })]);
     useAutomationsStore.getState().reset();
     const storedKey = useAutomationsStore.getState().ensureRunRequest('d1');
-    props.fetchRuns.mockResolvedValue([
-      makeRun({ id: 'r1', occurrence_key: 'manual:some-other-pending-run', state: 'pending' }),
+    props.fetchDefinitions.mockResolvedValue([
+      makeDefinition({
+        id: 'd1',
+        trigger_type: 'manual',
+        last_run: makeRun({ id: 'r1', occurrence_key: 'manual:some-other-pending-run', state: 'pending' }),
+      }),
     ]);
     render(<AutomationsPanel {...props} />);
 
     const button = await screen.findByTestId('automation-run-now-d1');
-    await waitFor(() => expect(props.fetchRuns).toHaveBeenCalled());
+    await waitFor(() => expect(props.fetchDefinitions).toHaveBeenCalled());
     expect(useAutomationsStore.getState().pendingRunRequests['d1']).toBe(storedKey);
 
     await user.click(button);
@@ -385,7 +400,7 @@ describe('AutomationsPanel', () => {
       const user = userEvent.setup();
       const props = baseProps();
       props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1', name: 'PR reviewer' })]);
-      props.getDefinition.mockResolvedValue({ specYaml: 'id: d1\nname: PR reviewer\n', revision: 3 });
+      props.getDefinition.mockResolvedValue({ specYaml: 'id: d1\nname: PR reviewer\n', definition: makeDefinition({ id: 'd1', revision: 3 }) });
       render(<AutomationsPanel {...props} />);
 
       await user.click(await screen.findByTestId('automation-edit-d1'));
@@ -415,7 +430,7 @@ describe('AutomationsPanel', () => {
       const user = userEvent.setup();
       const props = baseProps();
       props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1' })]);
-      props.getDefinition.mockResolvedValue({ specYaml: 'id: d1\nname: PR reviewer\n', revision: 3 });
+      props.getDefinition.mockResolvedValue({ specYaml: 'id: d1\nname: PR reviewer\n', definition: makeDefinition({ id: 'd1', revision: 3 }) });
       render(<AutomationsPanel {...props} />);
 
       await user.click(await screen.findByTestId('automation-edit-d1'));

--- a/app/src/components/AutomationsPanel.test.tsx
+++ b/app/src/components/AutomationsPanel.test.tsx
@@ -326,6 +326,27 @@ describe('AutomationsPanel', () => {
     await waitFor(() => expect(props.fetchDefinitions).toHaveBeenCalledTimes(2));
   });
 
+  it('refetches the selected definition\'s runs when changedTick bumps, so a newly delivered run appears without re-selecting', async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    props.fetchDefinitions.mockResolvedValue([makeDefinition({ id: 'd1' })]);
+    props.fetchRuns.mockResolvedValueOnce([makeRun({ id: 'r1', state: 'pending' })]);
+    render(<AutomationsPanel {...props} />);
+
+    await user.click(await screen.findByText('PR reviewer'));
+    await screen.findByTestId('automation-run-row');
+    await waitFor(() => expect(props.fetchRuns).toHaveBeenCalledTimes(1));
+
+    props.fetchRuns.mockResolvedValueOnce([
+      makeRun({ id: 'r1', state: 'delivered' }),
+      makeRun({ id: 'r2', state: 'delivered' }),
+    ]);
+    useAutomationsStore.getState().bumpChanged();
+
+    await waitFor(() => expect(props.fetchRuns).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getAllByTestId('automation-run-row')).toHaveLength(2));
+  });
+
   it('navigates to the ticket when a run has a ticket_id', async () => {
     const user = userEvent.setup();
     const props = baseProps();

--- a/app/src/components/AutomationsPanel.tsx
+++ b/app/src/components/AutomationsPanel.tsx
@@ -163,6 +163,9 @@ export function AutomationsPanel({
 
   // Refetch the selected definition's runs the moment it is selected, so the
   // expanded history is not stuck on whatever the eager fetch above last saw.
+  // Also refetch on every automations_changed broadcast (changedTick), so the
+  // expanded history tracks run-state transitions (create/deliver/fail)
+  // without requiring the user to re-select the definition.
   useEffect(() => {
     if (!isOpen || !selectedDefinitionId) return;
     let cancelled = false;
@@ -179,7 +182,7 @@ export function AutomationsPanel({
     return () => {
       cancelled = true;
     };
-  }, [isOpen, selectedDefinitionId, fetchRuns]);
+  }, [isOpen, selectedDefinitionId, fetchRuns, changedTick]);
 
   if (!isOpen) return null;
 

--- a/app/src/components/AutomationsPanel.tsx
+++ b/app/src/components/AutomationsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { AutomationDefinitionSummary, AutomationRunSummary } from '../types/generated';
-import { useAutomationsStore, selectDefinitionById, selectLatestRunForDefinition } from '../store/automations';
+import { useAutomationsStore, selectDefinitionById } from '../store/automations';
 import { AutomationActionTimeoutError } from '../hooks/useDaemonSocket';
 import { AutomationEditor, automationEditorKey } from './automations/AutomationEditor';
 import './AutomationsPanel.css';
@@ -11,17 +11,16 @@ export interface AutomationsPanelProps {
   fetchDefinitions: () => Promise<AutomationDefinitionSummary[]>;
   fetchRuns: (definitionId: string) => Promise<AutomationRunSummary[]>;
   setEnabled: (definitionId: string, enabled: boolean) => Promise<void>;
-  runNow: (
+  runNow: (definitionId: string, requestId: string) => Promise<AutomationRunSummary | undefined>;
+  getDefinition: (
     definitionId: string,
-    requestId: string,
-  ) => Promise<{ runId?: string; ticketId?: string; sessionId?: string }>;
-  getDefinition: (definitionId: string) => Promise<{ specYaml: string; revision: number }>;
+  ) => Promise<{ specYaml: string; definition?: AutomationDefinitionSummary }>;
   validateDefinition: (definitionYaml: string) => Promise<void>;
   applyDefinition: (
     definitionYaml: string,
     expectedId: string,
     expectedRevision: number,
-  ) => Promise<{ definition: AutomationDefinitionSummary; specYaml: string; revision: number }>;
+  ) => Promise<{ definition: AutomationDefinitionSummary; specYaml: string }>;
   onOpenTicket: (ticketId: string) => void;
   onSelectSession: (sessionId: string) => void;
   onFocusPane: (sessionId: string, paneId: string) => void;
@@ -131,10 +130,14 @@ export function AutomationsPanel({
   // (its buffer is loaded once per mount, not derived from the store).
   const [editorTarget, setEditorTarget] = useState<EditorTarget>(null);
 
-  // Refetch on open and on every automations_changed tick. Also eagerly
-  // fetches every definition's runs (not just the selected one) — the
-  // definitions list shows a failure badge per row, so the badge data has to
-  // exist before the user expands anything.
+  // Refetch on open and on every automations_changed tick. The list badge
+  // reads each definition's embedded last_run (see the store's
+  // LatestAutomationRunPerDefinition query), so there is no per-definition
+  // runs fetch here anymore. Reconciliation of a pending run-now request
+  // still runs off that same embedded last_run — it is by construction the
+  // newest run for the definition, which is all reconcilePendingRunRequest
+  // ever needed (a still-pending durable run or a freshly delivered/failed
+  // one), so this preserves that behavior without a per-definition fetch.
   useEffect(() => {
     if (!isOpen) return;
     let cancelled = false;
@@ -145,16 +148,7 @@ export function AutomationsPanel({
         setDefinitionsError(null);
         setDefinitionsLoaded(true);
         fetched.forEach((definition) => {
-          fetchRuns(definition.id)
-            .then((runs) => {
-              if (cancelled) return;
-              useAutomationsStore.getState().setRuns(definition.id, runs);
-              reconcilePendingRunRequest(definition.id, runs);
-            })
-            .catch(() => {
-              // Best-effort enrichment for the list badge; the definition row
-              // still renders without it.
-            });
+          reconcilePendingRunRequest(definition.id, definition.last_run ? [definition.last_run] : []);
         });
       })
       .catch((error) => {
@@ -165,7 +159,7 @@ export function AutomationsPanel({
     return () => {
       cancelled = true;
     };
-  }, [isOpen, changedTick, fetchDefinitions, fetchRuns]);
+  }, [isOpen, changedTick, fetchDefinitions]);
 
   // Refetch the selected definition's runs the moment it is selected, so the
   // expanded history is not stuck on whatever the eager fetch above last saw.
@@ -329,7 +323,7 @@ export function AutomationsPanel({
       ) : (
         <ul className="automations-panel__list" data-testid="automations-panel-list">
           {definitions.map((definition) => {
-            const latestRun = selectLatestRunForDefinition(runsByDefinition[definition.id]);
+            const latestRun = definition.last_run;
             const failed = latestRun?.state === 'failed';
             const selected = definition.id === selectedDefinitionId;
             return (

--- a/app/src/components/automations/AutomationEditor.test.tsx
+++ b/app/src/components/automations/AutomationEditor.test.tsx
@@ -87,12 +87,11 @@ function makeDefinition(overrides: Partial<AutomationDefinitionSummary> & { id: 
 function baseProps() {
   return {
     definitionId: null as string | null,
-    getDefinition: vi.fn().mockResolvedValue({ specYaml: 'id: new-automation\n', revision: 0 }),
+    getDefinition: vi.fn().mockResolvedValue({ specYaml: 'id: new-automation\n' }),
     validateDefinition: vi.fn().mockResolvedValue(undefined),
     applyDefinition: vi.fn().mockResolvedValue({
       definition: makeDefinition({ id: 'new-automation', revision: 1 }),
       specYaml: 'id: new-automation\n',
-      revision: 1,
     }),
     onCancel: vi.fn(),
     onSaved: vi.fn(),
@@ -112,7 +111,10 @@ describe('AutomationEditor', () => {
   it('loads the definition_yaml for an existing id', async () => {
     const props = baseProps();
     props.definitionId = 'd1';
-    props.getDefinition.mockResolvedValue({ specYaml: 'id: d1\nname: PR reviewer\n', revision: 5 });
+    props.getDefinition.mockResolvedValue({
+      specYaml: 'id: d1\nname: PR reviewer\n',
+      definition: makeDefinition({ id: 'd1', revision: 5 }),
+    });
     render(<AutomationEditor {...props} />);
 
     await waitFor(() => expect(props.getDefinition).toHaveBeenCalledWith('d1'));
@@ -261,7 +263,10 @@ describe('AutomationEditor', () => {
     const user = userEvent.setup();
     const props = baseProps();
     props.definitionId = 'd1';
-    props.getDefinition.mockResolvedValue({ specYaml: 'id: d1\n', revision: 7 });
+    props.getDefinition.mockResolvedValue({
+      specYaml: 'id: d1\n',
+      definition: makeDefinition({ id: 'd1', revision: 7 }),
+    });
     render(<AutomationEditor {...props} />);
 
     await screen.findByDisplayValue('id: d1\n', EXACT_VALUE);
@@ -280,7 +285,7 @@ describe('AutomationEditor', () => {
     const user = userEvent.setup();
     const props = baseProps();
     let resolveApply:
-      | ((result: { definition: AutomationDefinitionSummary; specYaml: string; revision: number }) => void)
+      | ((result: { definition: AutomationDefinitionSummary; specYaml: string }) => void)
       | undefined;
     props.applyDefinition.mockImplementation(
       () =>
@@ -307,7 +312,6 @@ describe('AutomationEditor', () => {
       resolveApply?.({
         definition: makeDefinition({ id: 'new-automation', revision: 1 }),
         specYaml: 'id: new-automation\n',
-        revision: 1,
       }),
     );
     await waitFor(() => expect(props.onSaved).toHaveBeenCalled());
@@ -365,12 +369,18 @@ describe('AutomationEditor', () => {
     const user = userEvent.setup();
     const props = baseProps();
     props.definitionId = 'd1';
-    props.getDefinition.mockResolvedValueOnce({ specYaml: 'id: d1\nname: v1\n', revision: 1 });
+    props.getDefinition.mockResolvedValueOnce({
+      specYaml: 'id: d1\nname: v1\n',
+      definition: makeDefinition({ id: 'd1', revision: 1 }),
+    });
     render(<AutomationEditor {...props} />);
 
     await screen.findByDisplayValue('id: d1\nname: v1\n', EXACT_VALUE);
 
-    props.getDefinition.mockResolvedValueOnce({ specYaml: 'id: d1\nname: v2\n', revision: 2 });
+    props.getDefinition.mockResolvedValueOnce({
+      specYaml: 'id: d1\nname: v2\n',
+      definition: makeDefinition({ id: 'd1', revision: 2 }),
+    });
     await user.click(screen.getByTestId('automation-editor-reload'));
 
     await waitFor(() => expect(props.getDefinition).toHaveBeenCalledTimes(2));
@@ -385,7 +395,10 @@ describe('AutomationEditor', () => {
     const user = userEvent.setup();
     const props = baseProps();
     props.definitionId = 'd1';
-    props.getDefinition.mockResolvedValueOnce({ specYaml: 'id: d1\n', revision: 1 });
+    props.getDefinition.mockResolvedValueOnce({
+      specYaml: 'id: d1\n',
+      definition: makeDefinition({ id: 'd1', revision: 1 }),
+    });
     render(<AutomationEditor {...props} />);
 
     await screen.findByDisplayValue('id: d1\n', EXACT_VALUE);
@@ -414,7 +427,7 @@ describe('AutomationEditor', () => {
     // Editing an existing definition still gets it.
     const editProps = baseProps();
     editProps.definitionId = 'd1';
-    editProps.getDefinition.mockResolvedValueOnce({ specYaml: 'id: d1\n', revision: 1 });
+    editProps.getDefinition.mockResolvedValueOnce({ specYaml: 'id: d1\n', definition: makeDefinition({ id: 'd1', revision: 1 }) });
     render(<AutomationEditor {...editProps} />);
 
     await screen.findByDisplayValue('id: d1\n', EXACT_VALUE);
@@ -463,7 +476,7 @@ describe('AutomationEditor automation bridge handle', () => {
     editProps.validateDefinition.mockRejectedValue(
       new Error('trigger.schedule.cron: invalid cron expression'),
     );
-    editProps.getDefinition.mockResolvedValueOnce({ specYaml: 'id: d1\n', revision: 7 });
+    editProps.getDefinition.mockResolvedValueOnce({ specYaml: 'id: d1\n', definition: makeDefinition({ id: 'd1', revision: 7 }) });
     render(<AutomationEditor {...editProps} />);
     await screen.findByDisplayValue('id: d1\n', EXACT_VALUE);
 

--- a/app/src/components/automations/AutomationEditor.tsx
+++ b/app/src/components/automations/AutomationEditor.tsx
@@ -17,15 +17,18 @@ import './AutomationEditor.css';
 
 export interface AutomationEditorProps {
   // null → create (getDefinition is called with '', which returns the starter
-  // template at revision 0). Non-null → edit that definition.
+  // template with no definition — revision 0). Non-null → edit that
+  // definition.
   definitionId: string | null;
-  getDefinition: (definitionId: string) => Promise<{ specYaml: string; revision: number }>;
+  getDefinition: (
+    definitionId: string,
+  ) => Promise<{ specYaml: string; definition?: AutomationDefinitionSummary }>;
   validateDefinition: (definitionYaml: string) => Promise<void>;
   applyDefinition: (
     definitionYaml: string,
     expectedId: string,
     expectedRevision: number,
-  ) => Promise<{ definition: AutomationDefinitionSummary; specYaml: string; revision: number }>;
+  ) => Promise<{ definition: AutomationDefinitionSummary; specYaml: string }>;
   onCancel: () => void;
   // Called once Save succeeds. The caller (AutomationsPanel) closes the editor
   // back to the list — canonical state (including the new/updated row) arrives
@@ -74,7 +77,7 @@ export function AutomationEditor({
       .then((result) => {
         if (cancelled) return;
         setValue(result.specYaml);
-        setRevision(result.revision);
+        setRevision(result.definition?.revision ?? 0);
         setStatus('ready');
       })
       .catch((error) => {
@@ -181,7 +184,7 @@ export function AutomationEditor({
     setReloadError(null);
     getDefinition(loadedId ?? '')
       .then((result) => {
-        setRevision(result.revision);
+        setRevision(result.definition?.revision ?? 0);
         editorRef.current?.applyExternalContent(result.specYaml);
         setReloading(false);
       })

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -673,7 +673,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     unmount();
   });
 
-  it('resolves automation definitions from a correlated automation_action_result, ignoring a mismatched request_id', async () => {
+  it('resolves automation definitions from a correlated automation_definitions_result, ignoring a mismatched request_id', async () => {
     const { result, unmount } = renderHook(() =>
       useDaemonSocket({
         onSessionsUpdate: vi.fn(),
@@ -699,8 +699,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
 
     act(() => {
       ws.emit({
-        event: 'automation_action_result',
-        action: 'definitions_get',
+        event: 'automation_definitions_result',
         request_id: 'mismatched-request-id',
         success: true,
         definitions: [{ id: 'wrong' }],
@@ -719,8 +718,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     };
     act(() => {
       ws.emit({
-        event: 'automation_action_result',
-        action: 'definitions_get',
+        event: 'automation_definitions_result',
         request_id: command.request_id,
         success: true,
         definitions: [definition],
@@ -752,8 +750,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
 
     act(() => {
       ws.emit({
-        event: 'automation_action_result',
-        action: 'set_enabled',
+        event: 'automation_set_enabled_result',
         request_id: command.request_id,
         success: false,
         error: 'automation definition is disabled elsewhere',
@@ -764,7 +761,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     unmount();
   });
 
-  it('resolves runAutomationNow with run/ticket/session ids', async () => {
+  it('resolves runAutomationNow with the run summary', async () => {
     const { result, unmount } = renderHook(() =>
       useDaemonSocket({
         onSessionsUpdate: vi.fn(),
@@ -783,19 +780,25 @@ describe('useDaemonSocket PTY kill sequencing', () => {
       .find((entry) => entry.cmd === 'automation_run');
     expect(command).toMatchObject({ definition_id: 'd1', request_id: 'req-1' });
 
+    const run = {
+      id: 'run-1',
+      definition_id: 'd1',
+      state: 'delivered',
+      ticket_id: 'ticket-1',
+      session_id: 'session-1',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
     act(() => {
       ws.emit({
-        event: 'automation_action_result',
-        action: 'run',
+        event: 'automation_run_result',
         request_id: command.request_id,
         success: true,
-        run_id: 'run-1',
-        ticket_id: 'ticket-1',
-        session_id: 'session-1',
+        run,
       });
     });
 
-    await expect(request).resolves.toEqual({ runId: 'run-1', ticketId: 'ticket-1', sessionId: 'session-1' });
+    await expect(request).resolves.toEqual(run);
     unmount();
   });
 

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -173,7 +173,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '180';
+export const PROTOCOL_VERSION = '181';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -2857,13 +2857,22 @@ export function useDaemonSocket({
             break;
           }
 
-          // Single generic result event for the automations WS surface
-          // (definitions_get / runs_get / set_enabled / run) — see
-          // AutomationActionResultMessage's doc comment. Correlated by
-          // request_id, not action, so concurrent calls (e.g. listing runs for
-          // two different definitions) never cross-resolve; each caller wraps
-          // its own extraction of the raw payload at registration time.
-          case 'automation_action_result': {
+          // The 9 typed automations result events (one per command — see
+          // internal/protocol/schema/main.tsp's Automation*ResultMessage
+          // family and daemon/automations_actions.go). Correlated by
+          // request_id, not action/event, so concurrent calls (e.g. listing
+          // runs for two different definitions) never cross-resolve; each
+          // caller wraps its own extraction of the typed payload at
+          // registration time (see the wrapper functions below).
+          case 'automation_apply_result':
+          case 'automation_validate_result':
+          case 'automation_definitions_result':
+          case 'automation_definition_result':
+          case 'automation_runs_result':
+          case 'automation_run_result':
+          case 'automation_set_enabled_result':
+          case 'automation_delete_result':
+          case 'automation_cleanup_result': {
             const requestId = data.request_id;
             if (typeof requestId !== 'string') break;
             const key = `automation:${requestId}`;
@@ -5358,7 +5367,7 @@ export function useDaemonSocket({
   }, [nextRequestID]);
 
   const runAutomationNow = useCallback(
-    (definitionId: string, requestId: string): Promise<{ runId?: string; ticketId?: string; sessionId?: string }> => {
+    (definitionId: string, requestId: string): Promise<AutomationRunSummary | undefined> => {
       return new Promise((resolve, reject) => {
         const ws = wsRef.current;
         if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -5374,8 +5383,7 @@ export function useDaemonSocket({
         // same run instead of creating a duplicate.
         const key = `automation:${requestId}`;
         pendingActionsRef.current.set(key, {
-          resolve: (result: any) =>
-            resolve({ runId: result.run_id, ticketId: result.ticket_id, sessionId: result.session_id }),
+          resolve: (result: any) => resolve(result.run as AutomationRunSummary | undefined),
           reject,
         });
         ws.send(JSON.stringify({ cmd: 'automation_run', definition_id: definitionId, request_id: requestId }));
@@ -5394,10 +5402,12 @@ export function useDaemonSocket({
   );
 
   // getAutomationDefinition backs the editor's load path. definitionId '' asks
-  // for the starter template at revision 0 (the create case, D7 in the
-  // design) — create and edit share this one call.
+  // for the starter template (the create case, D7 in the design) — create and
+  // edit share this one call. The template response carries no `definition`
+  // (revision 0, unsaved); an edit's response carries the current definition
+  // summary, whose `.revision` is what the editor tracks for Save's guard.
   const getAutomationDefinition = useCallback(
-    (definitionId: string): Promise<{ specYaml: string; revision: number }> => {
+    (definitionId: string): Promise<{ specYaml: string; definition?: AutomationDefinitionSummary }> => {
       return new Promise((resolve, reject) => {
         const ws = wsRef.current;
         if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -5407,7 +5417,8 @@ export function useDaemonSocket({
         const requestId = nextRequestID('automation_definition_get');
         const key = `automation:${requestId}`;
         pendingActionsRef.current.set(key, {
-          resolve: (result: any) => resolve({ specYaml: result.spec_yaml ?? '', revision: result.revision ?? 0 }),
+          resolve: (result: any) =>
+            resolve({ specYaml: result.spec_yaml ?? '', definition: result.definition ?? undefined }),
           reject,
         });
         ws.send(
@@ -5461,13 +5472,14 @@ export function useDaemonSocket({
   // (D4) and expected_revision (D5) so the daemon can refuse an id change or a
   // stale save. expectedId is '' when creating, expectedRevision is 0 when
   // creating — matching AutomationEditor's loadedId/revision state, which
-  // start from getAutomationDefinition('')'s template response.
+  // start from getAutomationDefinition('')'s template response. The result's
+  // revision lives on `definition.revision`, not a top-level field.
   const applyAutomationDefinition = useCallback(
     (
       definitionYaml: string,
       expectedId: string,
       expectedRevision: number,
-    ): Promise<{ definition: AutomationDefinitionSummary; specYaml: string; revision: number }> => {
+    ): Promise<{ definition: AutomationDefinitionSummary; specYaml: string }> => {
       return new Promise((resolve, reject) => {
         const ws = wsRef.current;
         if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -5479,9 +5491,8 @@ export function useDaemonSocket({
         pendingActionsRef.current.set(key, {
           resolve: (result: any) =>
             resolve({
-              definition: (result.definitions ?? [])[0],
+              definition: result.definition,
               specYaml: result.spec_yaml ?? '',
-              revision: result.revision ?? 0,
             }),
           reject,
         });

--- a/app/src/store/automations.test.ts
+++ b/app/src/store/automations.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import {
-  useAutomationsStore,
-  selectDefinitionById,
-  selectLatestRunForDefinition,
-} from './automations';
+import { useAutomationsStore, selectDefinitionById } from './automations';
 import { AutomationDefinitionSummary, AutomationRunSummary } from '../types/generated';
 
 function makeDefinition(
@@ -165,21 +161,5 @@ describe('selectDefinitionById', () => {
   it('returns the matching definition', () => {
     const definitions = [makeDefinition({ id: 'd1' }), makeDefinition({ id: 'd2', name: 'Second' })];
     expect(selectDefinitionById(definitions, 'd2')?.name).toBe('Second');
-  });
-});
-
-describe('selectLatestRunForDefinition', () => {
-  it('returns null when runs is undefined or empty', () => {
-    expect(selectLatestRunForDefinition(undefined)).toBeNull();
-    expect(selectLatestRunForDefinition([])).toBeNull();
-  });
-
-  it('picks the most recently created run', () => {
-    const runs = [
-      makeRun({ id: 'r1', created_at: '2026-01-01T00:00:00Z' }),
-      makeRun({ id: 'r2', created_at: '2026-01-03T00:00:00Z' }),
-      makeRun({ id: 'r3', created_at: '2026-01-02T00:00:00Z' }),
-    ];
-    expect(selectLatestRunForDefinition(runs)?.id).toBe('r2');
   });
 });

--- a/app/src/store/automations.ts
+++ b/app/src/store/automations.ts
@@ -99,19 +99,3 @@ export function selectDefinitionById(
   if (!definitionId) return null;
   return definitions.find((definition) => definition.id === definitionId) ?? null;
 }
-
-// selectLatestRunForDefinition returns the most recently created run in
-// `runs`, or null when there are none. created_at is an ISO-8601 string so a
-// lexicographic max is a correct chronological max. Used for the definitions
-// list's failure badge, which reflects each definition's latest run without
-// requiring the user to expand it.
-export function selectLatestRunForDefinition(
-  runs: AutomationRunSummary[] | undefined,
-): AutomationRunSummary | null {
-  if (!runs || runs.length === 0) return null;
-  let latest: AutomationRunSummary | null = null;
-  for (const run of runs) {
-    if (!latest || run.created_at > latest.created_at) latest = run;
-  }
-  return latest;
-}

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, AutomationActionResultMessage, AutomationApplyMessage, AutomationCleanupMessage, AutomationDefinitionGetMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDeleteMessage, AutomationListMessage, AutomationRunListMessage, AutomationRunMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationSetEnabledMessage, AutomationShowMessage, AutomationValidateMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -9,21 +9,26 @@
 //   const attachSessionMessage = Convert.toAttachSessionMessage(json);
 //   const authorState = Convert.toAuthorState(json);
 //   const authorsUpdatedMessage = Convert.toAuthorsUpdatedMessage(json);
-//   const automationActionResultMessage = Convert.toAutomationActionResultMessage(json);
 //   const automationApplyMessage = Convert.toAutomationApplyMessage(json);
+//   const automationApplyResultMessage = Convert.toAutomationApplyResultMessage(json);
 //   const automationCleanupMessage = Convert.toAutomationCleanupMessage(json);
+//   const automationCleanupResultMessage = Convert.toAutomationCleanupResultMessage(json);
 //   const automationDefinitionGetMessage = Convert.toAutomationDefinitionGetMessage(json);
+//   const automationDefinitionResultMessage = Convert.toAutomationDefinitionResultMessage(json);
 //   const automationDefinitionSummary = Convert.toAutomationDefinitionSummary(json);
 //   const automationDefinitionsGetMessage = Convert.toAutomationDefinitionsGetMessage(json);
+//   const automationDefinitionsResultMessage = Convert.toAutomationDefinitionsResultMessage(json);
 //   const automationDeleteMessage = Convert.toAutomationDeleteMessage(json);
-//   const automationListMessage = Convert.toAutomationListMessage(json);
-//   const automationRunListMessage = Convert.toAutomationRunListMessage(json);
+//   const automationDeleteResultMessage = Convert.toAutomationDeleteResultMessage(json);
 //   const automationRunMessage = Convert.toAutomationRunMessage(json);
+//   const automationRunResultMessage = Convert.toAutomationRunResultMessage(json);
 //   const automationRunSummary = Convert.toAutomationRunSummary(json);
 //   const automationRunsGetMessage = Convert.toAutomationRunsGetMessage(json);
+//   const automationRunsResultMessage = Convert.toAutomationRunsResultMessage(json);
 //   const automationSetEnabledMessage = Convert.toAutomationSetEnabledMessage(json);
-//   const automationShowMessage = Convert.toAutomationShowMessage(json);
+//   const automationSetEnabledResultMessage = Convert.toAutomationSetEnabledResultMessage(json);
 //   const automationValidateMessage = Convert.toAutomationValidateMessage(json);
+//   const automationValidateResultMessage = Convert.toAutomationValidateResultMessage(json);
 //   const automationsChangedMessage = Convert.toAutomationsChangedMessage(json);
 //   const bootstrapEndpointMessage = Convert.toBootstrapEndpointMessage(json);
 //   const branch = Convert.toBranch(json);
@@ -473,61 +478,6 @@ export enum AuthorsUpdatedMessageEvent {
     AuthorsUpdated = "authors_updated",
 }
 
-export interface AutomationActionResultMessage {
-    action:       string;
-    cleaned?:     string[];
-    definitions?: Items[];
-    error?:       string;
-    event:        AutomationActionResultMessageEvent;
-    kept_active?: string[];
-    kept_dirty?:  string[];
-    request_id?:  string;
-    revision?:    number;
-    run_id?:      string;
-    runs?:        RunElement[];
-    session_id?:  string;
-    spec_yaml?:   string;
-    success:      boolean;
-    ticket_id?:   string;
-    truncated?:   boolean;
-    [property: string]: any;
-}
-
-export interface Items {
-    catch_up?:           string;
-    continuity?:         string;
-    enabled:             boolean;
-    id:                  string;
-    name:                string;
-    revision:            number;
-    schedule_cron?:      string;
-    schedule_time_zone?: string;
-    trigger_type:        string;
-    updated_at:          string;
-    [property: string]: any;
-}
-
-export enum AutomationActionResultMessageEvent {
-    AutomationActionResult = "automation_action_result",
-}
-
-export interface RunElement {
-    created_at:          string;
-    definition_id:       string;
-    definition_revision: number;
-    delivered_at?:       string;
-    id:                  string;
-    last_error?:         string;
-    occurrence_key?:     string;
-    pane_id?:            string;
-    session_id?:         string;
-    state:               string;
-    ticket_id?:          string;
-    updated_at:          string;
-    workspace_id?:       string;
-    [property: string]: any;
-}
-
 export interface AutomationApplyMessage {
     cmd:                AutomationApplyMessageCmd;
     definition_yaml:    string;
@@ -541,6 +491,49 @@ export enum AutomationApplyMessageCmd {
     AutomationApply = "automation_apply",
 }
 
+export interface AutomationApplyResultMessage {
+    definition?: Items;
+    error?:      string;
+    event:       AutomationApplyResultMessageEvent;
+    request_id?: string;
+    spec_yaml?:  string;
+    success:     boolean;
+    [property: string]: any;
+}
+
+export interface Items {
+    enabled:             boolean;
+    id:                  string;
+    last_run?:           LastRun;
+    name:                string;
+    revision:            number;
+    schedule_cron?:      string;
+    schedule_time_zone?: string;
+    trigger_type:        string;
+    updated_at:          string;
+    [property: string]: any;
+}
+
+export interface LastRun {
+    cancel_reason?:  string;
+    created_at:      string;
+    definition_id:   string;
+    delivered_at?:   string;
+    id:              string;
+    last_error?:     string;
+    occurrence_key?: string;
+    pane_id?:        string;
+    session_id?:     string;
+    state:           string;
+    ticket_id?:      string;
+    updated_at:      string;
+    [property: string]: any;
+}
+
+export enum AutomationApplyResultMessageEvent {
+    AutomationApplyResult = "automation_apply_result",
+}
+
 export interface AutomationCleanupMessage {
     cmd:           AutomationCleanupMessageCmd;
     definition_id: string;
@@ -550,6 +543,21 @@ export interface AutomationCleanupMessage {
 
 export enum AutomationCleanupMessageCmd {
     AutomationCleanup = "automation_cleanup",
+}
+
+export interface AutomationCleanupResultMessage {
+    cleaned?:     string[];
+    error?:       string;
+    event:        AutomationCleanupResultMessageEvent;
+    kept_active?: string[];
+    kept_dirty?:  string[];
+    request_id?:  string;
+    success:      boolean;
+    [property: string]: any;
+}
+
+export enum AutomationCleanupResultMessageEvent {
+    AutomationCleanupResult = "automation_cleanup_result",
 }
 
 export interface AutomationDefinitionGetMessage {
@@ -563,11 +571,24 @@ export enum AutomationDefinitionGetMessageCmd {
     AutomationDefinitionGet = "automation_definition_get",
 }
 
+export interface AutomationDefinitionResultMessage {
+    definition?: Items;
+    error?:      string;
+    event:       AutomationDefinitionResultMessageEvent;
+    request_id?: string;
+    spec_yaml?:  string;
+    success:     boolean;
+    [property: string]: any;
+}
+
+export enum AutomationDefinitionResultMessageEvent {
+    AutomationDefinitionResult = "automation_definition_result",
+}
+
 export interface AutomationDefinitionSummary {
-    catch_up?:           string;
-    continuity?:         string;
     enabled:             boolean;
     id:                  string;
+    last_run?:           LastRun;
     name:                string;
     revision:            number;
     schedule_cron?:      string;
@@ -587,6 +608,19 @@ export enum AutomationDefinitionsGetMessageCmd {
     AutomationDefinitionsGet = "automation_definitions_get",
 }
 
+export interface AutomationDefinitionsResultMessage {
+    definitions?: Items[];
+    error?:       string;
+    event:        AutomationDefinitionsResultMessageEvent;
+    request_id?:  string;
+    success:      boolean;
+    [property: string]: any;
+}
+
+export enum AutomationDefinitionsResultMessageEvent {
+    AutomationDefinitionsResult = "automation_definitions_result",
+}
+
 export interface AutomationDeleteMessage {
     cmd:           AutomationDeleteMessageCmd;
     definition_id: string;
@@ -598,23 +632,16 @@ export enum AutomationDeleteMessageCmd {
     AutomationDelete = "automation_delete",
 }
 
-export interface AutomationListMessage {
-    cmd: AutomationListMessageCmd;
+export interface AutomationDeleteResultMessage {
+    error?:      string;
+    event:       AutomationDeleteResultMessageEvent;
+    request_id?: string;
+    success:     boolean;
     [property: string]: any;
 }
 
-export enum AutomationListMessageCmd {
-    AutomationList = "automation_list",
-}
-
-export interface AutomationRunListMessage {
-    cmd:           AutomationRunListMessageCmd;
-    definition_id: string;
-    [property: string]: any;
-}
-
-export enum AutomationRunListMessageCmd {
-    AutomationRunList = "automation_run_list",
+export enum AutomationDeleteResultMessageEvent {
+    AutomationDeleteResult = "automation_delete_result",
 }
 
 export interface AutomationRunMessage {
@@ -630,20 +657,32 @@ export enum AutomationRunMessageCmd {
     AutomationRun = "automation_run",
 }
 
+export interface AutomationRunResultMessage {
+    error?:      string;
+    event:       AutomationRunResultMessageEvent;
+    request_id?: string;
+    run?:        LastRun;
+    success:     boolean;
+    [property: string]: any;
+}
+
+export enum AutomationRunResultMessageEvent {
+    AutomationRunResult = "automation_run_result",
+}
+
 export interface AutomationRunSummary {
-    created_at:          string;
-    definition_id:       string;
-    definition_revision: number;
-    delivered_at?:       string;
-    id:                  string;
-    last_error?:         string;
-    occurrence_key?:     string;
-    pane_id?:            string;
-    session_id?:         string;
-    state:               string;
-    ticket_id?:          string;
-    updated_at:          string;
-    workspace_id?:       string;
+    cancel_reason?:  string;
+    created_at:      string;
+    definition_id:   string;
+    delivered_at?:   string;
+    id:              string;
+    last_error?:     string;
+    occurrence_key?: string;
+    pane_id?:        string;
+    session_id?:     string;
+    state:           string;
+    ticket_id?:      string;
+    updated_at:      string;
     [property: string]: any;
 }
 
@@ -658,6 +697,21 @@ export enum AutomationRunsGetMessageCmd {
     AutomationRunsGet = "automation_runs_get",
 }
 
+export interface AutomationRunsResultMessage {
+    definition_id: string;
+    error?:        string;
+    event:         AutomationRunsResultMessageEvent;
+    request_id?:   string;
+    runs?:         LastRun[];
+    success:       boolean;
+    truncated?:    boolean;
+    [property: string]: any;
+}
+
+export enum AutomationRunsResultMessageEvent {
+    AutomationRunsResult = "automation_runs_result",
+}
+
 export interface AutomationSetEnabledMessage {
     cmd:           AutomationSetEnabledMessageCmd;
     definition_id: string;
@@ -670,14 +724,17 @@ export enum AutomationSetEnabledMessageCmd {
     AutomationSetEnabled = "automation_set_enabled",
 }
 
-export interface AutomationShowMessage {
-    cmd:           AutomationShowMessageCmd;
-    definition_id: string;
+export interface AutomationSetEnabledResultMessage {
+    definition?: Items;
+    error?:      string;
+    event:       AutomationSetEnabledResultMessageEvent;
+    request_id?: string;
+    success:     boolean;
     [property: string]: any;
 }
 
-export enum AutomationShowMessageCmd {
-    AutomationShow = "automation_show",
+export enum AutomationSetEnabledResultMessageEvent {
+    AutomationSetEnabledResult = "automation_set_enabled_result",
 }
 
 export interface AutomationValidateMessage {
@@ -689,6 +746,18 @@ export interface AutomationValidateMessage {
 
 export enum AutomationValidateMessageCmd {
     AutomationValidate = "automation_validate",
+}
+
+export interface AutomationValidateResultMessage {
+    error?:      string;
+    event:       AutomationValidateResultMessageEvent;
+    request_id?: string;
+    success:     boolean;
+    [property: string]: any;
+}
+
+export enum AutomationValidateResultMessageEvent {
+    AutomationValidateResult = "automation_validate_result",
 }
 
 export interface AutomationsChangedMessage {
@@ -5518,20 +5587,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AuthorsUpdatedMessage")), null, 2);
     }
 
-    public static toAutomationActionResultMessage(json: string): AutomationActionResultMessage {
-        return cast(JSON.parse(json), r("AutomationActionResultMessage"));
-    }
-
-    public static automationActionResultMessageToJson(value: AutomationActionResultMessage): string {
-        return JSON.stringify(uncast(value, r("AutomationActionResultMessage")), null, 2);
-    }
-
     public static toAutomationApplyMessage(json: string): AutomationApplyMessage {
         return cast(JSON.parse(json), r("AutomationApplyMessage"));
     }
 
     public static automationApplyMessageToJson(value: AutomationApplyMessage): string {
         return JSON.stringify(uncast(value, r("AutomationApplyMessage")), null, 2);
+    }
+
+    public static toAutomationApplyResultMessage(json: string): AutomationApplyResultMessage {
+        return cast(JSON.parse(json), r("AutomationApplyResultMessage"));
+    }
+
+    public static automationApplyResultMessageToJson(value: AutomationApplyResultMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationApplyResultMessage")), null, 2);
     }
 
     public static toAutomationCleanupMessage(json: string): AutomationCleanupMessage {
@@ -5542,12 +5611,28 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AutomationCleanupMessage")), null, 2);
     }
 
+    public static toAutomationCleanupResultMessage(json: string): AutomationCleanupResultMessage {
+        return cast(JSON.parse(json), r("AutomationCleanupResultMessage"));
+    }
+
+    public static automationCleanupResultMessageToJson(value: AutomationCleanupResultMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationCleanupResultMessage")), null, 2);
+    }
+
     public static toAutomationDefinitionGetMessage(json: string): AutomationDefinitionGetMessage {
         return cast(JSON.parse(json), r("AutomationDefinitionGetMessage"));
     }
 
     public static automationDefinitionGetMessageToJson(value: AutomationDefinitionGetMessage): string {
         return JSON.stringify(uncast(value, r("AutomationDefinitionGetMessage")), null, 2);
+    }
+
+    public static toAutomationDefinitionResultMessage(json: string): AutomationDefinitionResultMessage {
+        return cast(JSON.parse(json), r("AutomationDefinitionResultMessage"));
+    }
+
+    public static automationDefinitionResultMessageToJson(value: AutomationDefinitionResultMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationDefinitionResultMessage")), null, 2);
     }
 
     public static toAutomationDefinitionSummary(json: string): AutomationDefinitionSummary {
@@ -5566,6 +5651,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AutomationDefinitionsGetMessage")), null, 2);
     }
 
+    public static toAutomationDefinitionsResultMessage(json: string): AutomationDefinitionsResultMessage {
+        return cast(JSON.parse(json), r("AutomationDefinitionsResultMessage"));
+    }
+
+    public static automationDefinitionsResultMessageToJson(value: AutomationDefinitionsResultMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationDefinitionsResultMessage")), null, 2);
+    }
+
     public static toAutomationDeleteMessage(json: string): AutomationDeleteMessage {
         return cast(JSON.parse(json), r("AutomationDeleteMessage"));
     }
@@ -5574,20 +5667,12 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AutomationDeleteMessage")), null, 2);
     }
 
-    public static toAutomationListMessage(json: string): AutomationListMessage {
-        return cast(JSON.parse(json), r("AutomationListMessage"));
+    public static toAutomationDeleteResultMessage(json: string): AutomationDeleteResultMessage {
+        return cast(JSON.parse(json), r("AutomationDeleteResultMessage"));
     }
 
-    public static automationListMessageToJson(value: AutomationListMessage): string {
-        return JSON.stringify(uncast(value, r("AutomationListMessage")), null, 2);
-    }
-
-    public static toAutomationRunListMessage(json: string): AutomationRunListMessage {
-        return cast(JSON.parse(json), r("AutomationRunListMessage"));
-    }
-
-    public static automationRunListMessageToJson(value: AutomationRunListMessage): string {
-        return JSON.stringify(uncast(value, r("AutomationRunListMessage")), null, 2);
+    public static automationDeleteResultMessageToJson(value: AutomationDeleteResultMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationDeleteResultMessage")), null, 2);
     }
 
     public static toAutomationRunMessage(json: string): AutomationRunMessage {
@@ -5596,6 +5681,14 @@ export class Convert {
 
     public static automationRunMessageToJson(value: AutomationRunMessage): string {
         return JSON.stringify(uncast(value, r("AutomationRunMessage")), null, 2);
+    }
+
+    public static toAutomationRunResultMessage(json: string): AutomationRunResultMessage {
+        return cast(JSON.parse(json), r("AutomationRunResultMessage"));
+    }
+
+    public static automationRunResultMessageToJson(value: AutomationRunResultMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationRunResultMessage")), null, 2);
     }
 
     public static toAutomationRunSummary(json: string): AutomationRunSummary {
@@ -5614,6 +5707,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AutomationRunsGetMessage")), null, 2);
     }
 
+    public static toAutomationRunsResultMessage(json: string): AutomationRunsResultMessage {
+        return cast(JSON.parse(json), r("AutomationRunsResultMessage"));
+    }
+
+    public static automationRunsResultMessageToJson(value: AutomationRunsResultMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationRunsResultMessage")), null, 2);
+    }
+
     public static toAutomationSetEnabledMessage(json: string): AutomationSetEnabledMessage {
         return cast(JSON.parse(json), r("AutomationSetEnabledMessage"));
     }
@@ -5622,12 +5723,12 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AutomationSetEnabledMessage")), null, 2);
     }
 
-    public static toAutomationShowMessage(json: string): AutomationShowMessage {
-        return cast(JSON.parse(json), r("AutomationShowMessage"));
+    public static toAutomationSetEnabledResultMessage(json: string): AutomationSetEnabledResultMessage {
+        return cast(JSON.parse(json), r("AutomationSetEnabledResultMessage"));
     }
 
-    public static automationShowMessageToJson(value: AutomationShowMessage): string {
-        return JSON.stringify(uncast(value, r("AutomationShowMessage")), null, 2);
+    public static automationSetEnabledResultMessageToJson(value: AutomationSetEnabledResultMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationSetEnabledResultMessage")), null, 2);
     }
 
     public static toAutomationValidateMessage(json: string): AutomationValidateMessage {
@@ -5636,6 +5737,14 @@ export class Convert {
 
     public static automationValidateMessageToJson(value: AutomationValidateMessage): string {
         return JSON.stringify(uncast(value, r("AutomationValidateMessage")), null, 2);
+    }
+
+    public static toAutomationValidateResultMessage(json: string): AutomationValidateResultMessage {
+        return cast(JSON.parse(json), r("AutomationValidateResultMessage"));
+    }
+
+    public static automationValidateResultMessageToJson(value: AutomationValidateResultMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationValidateResultMessage")), null, 2);
     }
 
     public static toAutomationsChangedMessage(json: string): AutomationsChangedMessage {
@@ -8645,29 +8754,25 @@ const typeMap: any = {
         { json: "author", js: "author", typ: "" },
         { json: "muted", js: "muted", typ: true },
     ], "any"),
-    "AutomationActionResultMessage": o([
-        { json: "action", js: "action", typ: "" },
-        { json: "cleaned", js: "cleaned", typ: u(undefined, a("")) },
-        { json: "definitions", js: "definitions", typ: u(undefined, a(r("Items"))) },
-        { json: "error", js: "error", typ: u(undefined, "") },
-        { json: "event", js: "event", typ: r("AutomationActionResultMessageEvent") },
-        { json: "kept_active", js: "kept_active", typ: u(undefined, a("")) },
-        { json: "kept_dirty", js: "kept_dirty", typ: u(undefined, a("")) },
+    "AutomationApplyMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutomationApplyMessageCmd") },
+        { json: "definition_yaml", js: "definition_yaml", typ: "" },
+        { json: "expected_id", js: "expected_id", typ: u(undefined, "") },
+        { json: "expected_revision", js: "expected_revision", typ: u(undefined, 0) },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
-        { json: "revision", js: "revision", typ: u(undefined, 0) },
-        { json: "run_id", js: "run_id", typ: u(undefined, "") },
-        { json: "runs", js: "runs", typ: u(undefined, a(r("RunElement"))) },
-        { json: "session_id", js: "session_id", typ: u(undefined, "") },
+    ], "any"),
+    "AutomationApplyResultMessage": o([
+        { json: "definition", js: "definition", typ: u(undefined, r("Items")) },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("AutomationApplyResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
         { json: "spec_yaml", js: "spec_yaml", typ: u(undefined, "") },
         { json: "success", js: "success", typ: true },
-        { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
-        { json: "truncated", js: "truncated", typ: u(undefined, true) },
     ], "any"),
     "Items": o([
-        { json: "catch_up", js: "catch_up", typ: u(undefined, "") },
-        { json: "continuity", js: "continuity", typ: u(undefined, "") },
         { json: "enabled", js: "enabled", typ: true },
         { json: "id", js: "id", typ: "" },
+        { json: "last_run", js: "last_run", typ: u(undefined, r("LastRun")) },
         { json: "name", js: "name", typ: "" },
         { json: "revision", js: "revision", typ: 0 },
         { json: "schedule_cron", js: "schedule_cron", typ: u(undefined, "") },
@@ -8675,10 +8780,10 @@ const typeMap: any = {
         { json: "trigger_type", js: "trigger_type", typ: "" },
         { json: "updated_at", js: "updated_at", typ: "" },
     ], "any"),
-    "RunElement": o([
+    "LastRun": o([
+        { json: "cancel_reason", js: "cancel_reason", typ: u(undefined, "") },
         { json: "created_at", js: "created_at", typ: "" },
         { json: "definition_id", js: "definition_id", typ: "" },
-        { json: "definition_revision", js: "definition_revision", typ: 0 },
         { json: "delivered_at", js: "delivered_at", typ: u(undefined, "") },
         { json: "id", js: "id", typ: "" },
         { json: "last_error", js: "last_error", typ: u(undefined, "") },
@@ -8688,30 +8793,38 @@ const typeMap: any = {
         { json: "state", js: "state", typ: "" },
         { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
         { json: "updated_at", js: "updated_at", typ: "" },
-        { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
-    ], "any"),
-    "AutomationApplyMessage": o([
-        { json: "cmd", js: "cmd", typ: r("AutomationApplyMessageCmd") },
-        { json: "definition_yaml", js: "definition_yaml", typ: "" },
-        { json: "expected_id", js: "expected_id", typ: u(undefined, "") },
-        { json: "expected_revision", js: "expected_revision", typ: u(undefined, 0) },
-        { json: "request_id", js: "request_id", typ: u(undefined, "") },
     ], "any"),
     "AutomationCleanupMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationCleanupMessageCmd") },
         { json: "definition_id", js: "definition_id", typ: "" },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
     ], "any"),
+    "AutomationCleanupResultMessage": o([
+        { json: "cleaned", js: "cleaned", typ: u(undefined, a("")) },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("AutomationCleanupResultMessageEvent") },
+        { json: "kept_active", js: "kept_active", typ: u(undefined, a("")) },
+        { json: "kept_dirty", js: "kept_dirty", typ: u(undefined, a("")) },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
     "AutomationDefinitionGetMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationDefinitionGetMessageCmd") },
         { json: "definition_id", js: "definition_id", typ: "" },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
     ], "any"),
+    "AutomationDefinitionResultMessage": o([
+        { json: "definition", js: "definition", typ: u(undefined, r("Items")) },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("AutomationDefinitionResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "spec_yaml", js: "spec_yaml", typ: u(undefined, "") },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
     "AutomationDefinitionSummary": o([
-        { json: "catch_up", js: "catch_up", typ: u(undefined, "") },
-        { json: "continuity", js: "continuity", typ: u(undefined, "") },
         { json: "enabled", js: "enabled", typ: true },
         { json: "id", js: "id", typ: "" },
+        { json: "last_run", js: "last_run", typ: u(undefined, r("LastRun")) },
         { json: "name", js: "name", typ: "" },
         { json: "revision", js: "revision", typ: 0 },
         { json: "schedule_cron", js: "schedule_cron", typ: u(undefined, "") },
@@ -8723,17 +8836,23 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("AutomationDefinitionsGetMessageCmd") },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
     ], "any"),
+    "AutomationDefinitionsResultMessage": o([
+        { json: "definitions", js: "definitions", typ: u(undefined, a(r("Items"))) },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("AutomationDefinitionsResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
     "AutomationDeleteMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationDeleteMessageCmd") },
         { json: "definition_id", js: "definition_id", typ: "" },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
     ], "any"),
-    "AutomationListMessage": o([
-        { json: "cmd", js: "cmd", typ: r("AutomationListMessageCmd") },
-    ], "any"),
-    "AutomationRunListMessage": o([
-        { json: "cmd", js: "cmd", typ: r("AutomationRunListMessageCmd") },
-        { json: "definition_id", js: "definition_id", typ: "" },
+    "AutomationDeleteResultMessage": o([
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("AutomationDeleteResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "success", js: "success", typ: true },
     ], "any"),
     "AutomationRunMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationRunMessageCmd") },
@@ -8742,10 +8861,17 @@ const typeMap: any = {
         { json: "pr_url", js: "pr_url", typ: u(undefined, "") },
         { json: "request_id", js: "request_id", typ: "" },
     ], "any"),
+    "AutomationRunResultMessage": o([
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("AutomationRunResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "run", js: "run", typ: u(undefined, r("LastRun")) },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
     "AutomationRunSummary": o([
+        { json: "cancel_reason", js: "cancel_reason", typ: u(undefined, "") },
         { json: "created_at", js: "created_at", typ: "" },
         { json: "definition_id", js: "definition_id", typ: "" },
-        { json: "definition_revision", js: "definition_revision", typ: 0 },
         { json: "delivered_at", js: "delivered_at", typ: u(undefined, "") },
         { json: "id", js: "id", typ: "" },
         { json: "last_error", js: "last_error", typ: u(undefined, "") },
@@ -8755,12 +8881,20 @@ const typeMap: any = {
         { json: "state", js: "state", typ: "" },
         { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
         { json: "updated_at", js: "updated_at", typ: "" },
-        { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
     ], "any"),
     "AutomationRunsGetMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationRunsGetMessageCmd") },
         { json: "definition_id", js: "definition_id", typ: "" },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    ], "any"),
+    "AutomationRunsResultMessage": o([
+        { json: "definition_id", js: "definition_id", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("AutomationRunsResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "runs", js: "runs", typ: u(undefined, a(r("LastRun"))) },
+        { json: "success", js: "success", typ: true },
+        { json: "truncated", js: "truncated", typ: u(undefined, true) },
     ], "any"),
     "AutomationSetEnabledMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationSetEnabledMessageCmd") },
@@ -8768,14 +8902,23 @@ const typeMap: any = {
         { json: "enabled", js: "enabled", typ: true },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
     ], "any"),
-    "AutomationShowMessage": o([
-        { json: "cmd", js: "cmd", typ: r("AutomationShowMessageCmd") },
-        { json: "definition_id", js: "definition_id", typ: "" },
+    "AutomationSetEnabledResultMessage": o([
+        { json: "definition", js: "definition", typ: u(undefined, r("Items")) },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("AutomationSetEnabledResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "success", js: "success", typ: true },
     ], "any"),
     "AutomationValidateMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationValidateMessageCmd") },
         { json: "definition_yaml", js: "definition_yaml", typ: "" },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    ], "any"),
+    "AutomationValidateResultMessage": o([
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("AutomationValidateResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "success", js: "success", typ: true },
     ], "any"),
     "AutomationsChangedMessage": o([
         { json: "definition_ids", js: "definition_ids", typ: a("") },
@@ -11621,44 +11764,59 @@ const typeMap: any = {
     "AuthorsUpdatedMessageEvent": [
         "authors_updated",
     ],
-    "AutomationActionResultMessageEvent": [
-        "automation_action_result",
-    ],
     "AutomationApplyMessageCmd": [
         "automation_apply",
+    ],
+    "AutomationApplyResultMessageEvent": [
+        "automation_apply_result",
     ],
     "AutomationCleanupMessageCmd": [
         "automation_cleanup",
     ],
+    "AutomationCleanupResultMessageEvent": [
+        "automation_cleanup_result",
+    ],
     "AutomationDefinitionGetMessageCmd": [
         "automation_definition_get",
+    ],
+    "AutomationDefinitionResultMessageEvent": [
+        "automation_definition_result",
     ],
     "AutomationDefinitionsGetMessageCmd": [
         "automation_definitions_get",
     ],
+    "AutomationDefinitionsResultMessageEvent": [
+        "automation_definitions_result",
+    ],
     "AutomationDeleteMessageCmd": [
         "automation_delete",
     ],
-    "AutomationListMessageCmd": [
-        "automation_list",
-    ],
-    "AutomationRunListMessageCmd": [
-        "automation_run_list",
+    "AutomationDeleteResultMessageEvent": [
+        "automation_delete_result",
     ],
     "AutomationRunMessageCmd": [
         "automation_run",
     ],
+    "AutomationRunResultMessageEvent": [
+        "automation_run_result",
+    ],
     "AutomationRunsGetMessageCmd": [
         "automation_runs_get",
+    ],
+    "AutomationRunsResultMessageEvent": [
+        "automation_runs_result",
     ],
     "AutomationSetEnabledMessageCmd": [
         "automation_set_enabled",
     ],
-    "AutomationShowMessageCmd": [
-        "automation_show",
+    "AutomationSetEnabledResultMessageEvent": [
+        "automation_set_enabled_result",
     ],
     "AutomationValidateMessageCmd": [
         "automation_validate",
+    ],
+    "AutomationValidateResultMessageEvent": [
+        "automation_validate_result",
     ],
     "AutomationsChangedMessageEvent": [
         "automations_changed",

--- a/cmd/attn/automation.go
+++ b/cmd/attn/automation.go
@@ -1,25 +1,25 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
 
 	"github.com/google/uuid"
 	"github.com/victorarias/attn/internal/client"
+	"github.com/victorarias/attn/internal/protocol"
 )
 
 func automationUsage() {
 	fmt.Fprint(os.Stderr, "usage: attn automation <apply|validate|list|show|run|runs|enable|disable|delete|cleanup>\n")
 }
+
 func runAutomationCommand() {
 	if len(os.Args) < 3 {
 		automationUsage()
 		os.Exit(2)
 	}
 	c := client.New(client.DefaultSocketPath())
-	var data json.RawMessage
 	var err error
 	switch os.Args[2] {
 	case "apply":
@@ -37,7 +37,11 @@ func runAutomationCommand() {
 			err = e
 			break
 		}
-		data, err = c.AutomationApply(string(raw))
+		var result *protocol.AutomationApplyResultMessage
+		result, err = c.AutomationApply(string(raw))
+		if err == nil {
+			printJSON(result.Definition)
+		}
 	case "validate":
 		fs := flag.NewFlagSet("automation validate", flag.ContinueOnError)
 		file := fs.String("file", "", "definition YAML")
@@ -53,18 +57,25 @@ func runAutomationCommand() {
 			err = e
 			break
 		}
-		data, err = c.AutomationValidate(string(raw))
-		if err == nil && data == nil {
-			data, _ = json.Marshal(map[string]bool{"valid": true})
+		if err = c.AutomationValidate(string(raw)); err == nil {
+			printJSON(map[string]bool{"valid": true})
 		}
 	case "list":
-		data, err = c.AutomationList()
+		var result *protocol.AutomationDefinitionsResultMessage
+		result, err = c.AutomationDefinitions()
+		if err == nil {
+			printJSON(result.Definitions)
+		}
 	case "show":
 		if len(os.Args) != 4 {
 			err = fmt.Errorf("usage: attn automation show <definition-id>")
 			break
 		}
-		data, err = c.AutomationShow(os.Args[3])
+		var result *protocol.AutomationDefinitionResultMessage
+		result, err = c.AutomationDefinition(os.Args[3])
+		if err == nil && result.SpecYaml != nil {
+			fmt.Print(*result.SpecYaml)
+		}
 	case "run":
 		if len(os.Args) < 4 {
 			err = fmt.Errorf("usage: attn automation run <definition-id> [--input-file <file> | --pr-url <url>] [--request-id <id>]")
@@ -98,43 +109,67 @@ func runAutomationCommand() {
 		if *requestID == "" {
 			*requestID = uuid.NewString()
 		}
+		var result *protocol.AutomationRunResultMessage
 		if *prURL != "" {
-			data, err = c.AutomationRunPullRequest(definitionID, *requestID, *prURL)
+			result, err = c.AutomationRunPullRequest(definitionID, *requestID, *prURL)
 		} else {
-			data, err = c.AutomationRun(definitionID, *requestID, input)
+			result, err = c.AutomationRun(definitionID, *requestID, input)
+		}
+		if err == nil {
+			printJSON(result.Run)
 		}
 	case "runs":
 		if len(os.Args) != 4 {
 			err = fmt.Errorf("usage: attn automation runs <definition-id>")
 			break
 		}
-		data, err = c.AutomationRuns(os.Args[3])
+		var result *protocol.AutomationRunsResultMessage
+		result, err = c.AutomationRuns(os.Args[3])
+		if err == nil {
+			printJSON(result.Runs)
+		}
 	case "enable":
 		if len(os.Args) != 4 {
 			err = fmt.Errorf("usage: attn automation enable <definition-id>")
 			break
 		}
-		data, err = c.AutomationSetEnabled(os.Args[3], true)
+		var result *protocol.AutomationSetEnabledResultMessage
+		result, err = c.AutomationSetEnabled(os.Args[3], true)
+		if err == nil {
+			printJSON(result.Definition)
+		}
 	case "disable":
 		if len(os.Args) != 4 {
 			err = fmt.Errorf("usage: attn automation disable <definition-id>")
 			break
 		}
-		data, err = c.AutomationSetEnabled(os.Args[3], false)
+		var result *protocol.AutomationSetEnabledResultMessage
+		result, err = c.AutomationSetEnabled(os.Args[3], false)
+		if err == nil {
+			printJSON(result.Definition)
+		}
 	case "delete":
 		if len(os.Args) != 4 {
 			err = fmt.Errorf("usage: attn automation delete <definition-id>")
 			break
 		}
 		if err = c.AutomationDelete(os.Args[3]); err == nil {
-			data, _ = json.Marshal(map[string]string{"deleted": os.Args[3]})
+			printJSON(map[string]string{"deleted": os.Args[3]})
 		}
 	case "cleanup":
 		if len(os.Args) != 4 {
 			err = fmt.Errorf("usage: attn automation cleanup <definition-id>")
 			break
 		}
-		data, err = c.AutomationCleanup(os.Args[3])
+		var result *protocol.AutomationCleanupResultMessage
+		result, err = c.AutomationCleanup(os.Args[3])
+		if err == nil {
+			printJSON(map[string][]string{
+				"cleaned":     result.Cleaned,
+				"kept_dirty":  result.KeptDirty,
+				"kept_active": result.KeptActive,
+			})
+		}
 	default:
 		err = fmt.Errorf("unknown automation command %q", os.Args[2])
 	}
@@ -142,11 +177,4 @@ func runAutomationCommand() {
 		fmt.Fprintf(os.Stderr, "automation: %v\n", err)
 		os.Exit(1)
 	}
-	var pretty any
-	if json.Unmarshal(data, &pretty) == nil {
-		encoded, _ := json.MarshalIndent(pretty, "", "  ")
-		fmt.Println(string(encoded))
-		return
-	}
-	fmt.Println(string(data))
 }

--- a/docs/plans/2026-07-21-automations-v2-simplification.md
+++ b/docs/plans/2026-07-21-automations-v2-simplification.md
@@ -124,7 +124,7 @@ real concept and drives binding rotation.
       verbs `attn automation enable|disable`; `SetEnabledInYAML` and the
       spec-rewrite path in `SetAutomationEnabled` are deleted; the WS
       definition-YAML surface falls back to rendering YAML from spec JSON. Shipped as #629.
-- [ ] **PR2b — v2 state model + claim semantics** (consolidates former
+- [x] **PR2b — v2 state model + claim semantics** (consolidates former
       PR2b/PR3/PR4 — one migration, one live-verify matrix, one review
       round). Migration 77 recreates `automation_runs` (adds `cancel_reason`,
       `attempts`), `automation_continuity_bindings` (append-only: surrogate
@@ -141,12 +141,17 @@ real concept and drives binding rotation.
       trigger-implied per the YAML sketch above; `scheduled` absorbs
       `continuity`/`catch_up`; validation matrix and snapshot shrink. Engine
       `Store` interface lands here. Built as sequential reviewable commits on
-      one branch.
-- [ ] **PR5 — protocol unification.** One handler layer for socket + WS;
+      one branch. Shipped as #630 (live-verified on the dev profile: migration 77, policy rejection, manual run delivered, scheduled-singleton continuity across two real cron ticks).
+- [x] **PR5 — protocol unification.** One handler layer for socket + WS;
       per-action results; drop dead wire fields (`continuity`, `catch_up`,
       `workspace_id`, `definition_revision`); embed `last_run` in the
       definition summary (kills the panel's N+1); protocol version bump
-      (remember the useDaemonSocket.ts third lockstep spot).
+      (remember the useDaemonSocket.ts third lockstep spot). ProtocolVersion
+      181. Apply's `expected_id`/`expected_revision` guard is keyed on pointer
+      presence, not the zero value: the socket/CLI path always sends neither
+      (unguarded last-writer-wins, matching the old `attn automation apply`
+      behavior), the WS editor always sends both (enforced, including a
+      create-time 0 vs. a live definition).
 - [ ] **PR6 — form UI.** Replace the YAML editor and validate-without-apply UI
       with a structured create/edit form (trigger picker with per-trigger
       fields, prompt, launch via the delegation picker components, location,

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -25,38 +25,50 @@ type Client struct {
 	socketPath string
 }
 
-type AutomationResult struct {
-	Event   string          `json:"event"`
-	Action  string          `json:"action"`
-	Success bool            `json:"success"`
-	Error   *string         `json:"error,omitempty"`
-	Data    json.RawMessage `json:"data,omitempty"`
+// automationResult is the minimal shape every per-action automations result
+// message shares (event/success/error) — enough to decide success/failure
+// generically in sendAutomation before the caller decodes the full typed
+// result (which also carries this shape) a second time for its payload.
+type automationResult struct {
+	Success bool    `json:"success"`
+	Error   *string `json:"error,omitempty"`
 }
 
-func (c *Client) sendAutomation(msg any) (*AutomationResult, error) {
+// sendAutomation sends msg over a fresh unix-socket connection and decodes
+// the raw response into out, a pointer to one of the typed
+// protocol.Automation*ResultMessage structs — every automations command
+// (socket/CLI and WS) now returns its own typed result directly, not a
+// generic wrapper with a `data` payload. A success=false result becomes a Go
+// error carrying the daemon's error text, exactly as before.
+func (c *Client) sendAutomation(msg any, out any) error {
 	conn, err := net.Dial("unix", c.socketPath)
 	if err != nil {
-		return nil, explainConnectError(c.socketPath, err)
+		return explainConnectError(c.socketPath, err)
 	}
 	defer conn.Close()
 	if err := json.NewEncoder(conn).Encode(msg); err != nil {
-		return nil, err
+		return err
 	}
-	var result AutomationResult
-	if err := json.NewDecoder(conn).Decode(&result); err != nil {
-		return nil, err
+	var raw json.RawMessage
+	if err := json.NewDecoder(conn).Decode(&raw); err != nil {
+		return err
 	}
-	if !result.Success {
-		return nil, fmt.Errorf("daemon error: %s", protocol.Deref(result.Error))
+	var probe automationResult
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return err
+	}
+	if !probe.Success {
+		return fmt.Errorf("daemon error: %s", protocol.Deref(probe.Error))
+	}
+	return json.Unmarshal(raw, out)
+}
+
+func (c *Client) AutomationApply(raw string) (*protocol.AutomationApplyResultMessage, error) {
+	var result protocol.AutomationApplyResultMessage
+	if err := c.sendAutomation(protocol.AutomationApplyMessage{Cmd: protocol.CmdAutomationApply, DefinitionYaml: raw}, &result); err != nil {
+		return nil, err
 	}
 	return &result, nil
-}
-func (c *Client) AutomationApply(raw string) (json.RawMessage, error) {
-	r, e := c.sendAutomation(protocol.AutomationApplyMessage{Cmd: protocol.CmdAutomationApply, DefinitionYaml: raw})
-	if e != nil {
-		return nil, e
-	}
-	return r.Data, nil
 }
 
 // AutomationValidate runs the same validateAutomationSpec seam automation
@@ -64,69 +76,72 @@ func (c *Client) AutomationApply(raw string) (json.RawMessage, error) {
 // Daemon.validateAutomationSpec's doc comment for why the two share one
 // function. A non-nil error is the validation failure message itself, not a
 // transport error.
-func (c *Client) AutomationValidate(raw string) (json.RawMessage, error) {
-	r, e := c.sendAutomation(protocol.AutomationValidateMessage{Cmd: protocol.CmdAutomationValidate, DefinitionYaml: raw})
-	if e != nil {
-		return nil, e
-	}
-	return r.Data, nil
-}
-func (c *Client) AutomationList() (json.RawMessage, error) {
-	r, e := c.sendAutomation(protocol.AutomationListMessage{Cmd: protocol.CmdAutomationList})
-	if e != nil {
-		return nil, e
-	}
-	return r.Data, nil
-}
-func (c *Client) AutomationShow(id string) (json.RawMessage, error) {
-	r, e := c.sendAutomation(protocol.AutomationShowMessage{Cmd: protocol.CmdAutomationShow, DefinitionID: id})
-	if e != nil {
-		return nil, e
-	}
-	return r.Data, nil
-}
-func (c *Client) AutomationRun(id, requestID, input string) (json.RawMessage, error) {
-	r, e := c.sendAutomation(protocol.AutomationRunMessage{Cmd: protocol.CmdAutomationRun, DefinitionID: id, RequestID: requestID, InputJson: protocol.Ptr(input)})
-	if e != nil {
-		return nil, e
-	}
-	return r.Data, nil
+func (c *Client) AutomationValidate(raw string) error {
+	var result protocol.AutomationValidateResultMessage
+	return c.sendAutomation(protocol.AutomationValidateMessage{Cmd: protocol.CmdAutomationValidate, DefinitionYaml: raw}, &result)
 }
 
-func (c *Client) AutomationRunPullRequest(id, requestID, prURL string) (json.RawMessage, error) {
-	r, e := c.sendAutomation(protocol.AutomationRunMessage{Cmd: protocol.CmdAutomationRun, DefinitionID: id, RequestID: requestID, PRURL: protocol.Ptr(prURL)})
-	if e != nil {
-		return nil, e
+func (c *Client) AutomationDefinitions() (*protocol.AutomationDefinitionsResultMessage, error) {
+	var result protocol.AutomationDefinitionsResultMessage
+	if err := c.sendAutomation(protocol.AutomationDefinitionsGetMessage{Cmd: protocol.CmdAutomationDefinitionsGet}, &result); err != nil {
+		return nil, err
 	}
-	return r.Data, nil
+	return &result, nil
 }
-func (c *Client) AutomationRuns(id string) (json.RawMessage, error) {
-	r, e := c.sendAutomation(protocol.AutomationRunListMessage{Cmd: protocol.CmdAutomationRunList, DefinitionID: id})
-	if e != nil {
-		return nil, e
+
+func (c *Client) AutomationDefinition(id string) (*protocol.AutomationDefinitionResultMessage, error) {
+	var result protocol.AutomationDefinitionResultMessage
+	if err := c.sendAutomation(protocol.AutomationDefinitionGetMessage{Cmd: protocol.CmdAutomationDefinitionGet, DefinitionID: id}, &result); err != nil {
+		return nil, err
 	}
-	return r.Data, nil
+	return &result, nil
+}
+
+func (c *Client) AutomationRun(id, requestID, input string) (*protocol.AutomationRunResultMessage, error) {
+	var result protocol.AutomationRunResultMessage
+	if err := c.sendAutomation(protocol.AutomationRunMessage{Cmd: protocol.CmdAutomationRun, DefinitionID: id, RequestID: requestID, InputJson: protocol.Ptr(input)}, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *Client) AutomationRunPullRequest(id, requestID, prURL string) (*protocol.AutomationRunResultMessage, error) {
+	var result protocol.AutomationRunResultMessage
+	if err := c.sendAutomation(protocol.AutomationRunMessage{Cmd: protocol.CmdAutomationRun, DefinitionID: id, RequestID: requestID, PRURL: protocol.Ptr(prURL)}, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *Client) AutomationRuns(id string) (*protocol.AutomationRunsResultMessage, error) {
+	var result protocol.AutomationRunsResultMessage
+	if err := c.sendAutomation(protocol.AutomationRunsGetMessage{Cmd: protocol.CmdAutomationRunsGet, DefinitionID: id}, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // AutomationSetEnabled toggles a definition's enabled flag over the same
 // automation_set_enabled command the WS panel's toggle uses.
-func (c *Client) AutomationSetEnabled(id string, enabled bool) (json.RawMessage, error) {
-	r, e := c.sendAutomation(protocol.AutomationSetEnabledMessage{Cmd: protocol.CmdAutomationSetEnabled, DefinitionID: id, Enabled: enabled})
-	if e != nil {
-		return nil, e
+func (c *Client) AutomationSetEnabled(id string, enabled bool) (*protocol.AutomationSetEnabledResultMessage, error) {
+	var result protocol.AutomationSetEnabledResultMessage
+	if err := c.sendAutomation(protocol.AutomationSetEnabledMessage{Cmd: protocol.CmdAutomationSetEnabled, DefinitionID: id, Enabled: enabled}, &result); err != nil {
+		return nil, err
 	}
-	return r.Data, nil
+	return &result, nil
 }
+
 func (c *Client) AutomationDelete(id string) error {
-	_, e := c.sendAutomation(protocol.AutomationDeleteMessage{Cmd: protocol.CmdAutomationDelete, DefinitionID: id})
-	return e
+	var result protocol.AutomationDeleteResultMessage
+	return c.sendAutomation(protocol.AutomationDeleteMessage{Cmd: protocol.CmdAutomationDelete, DefinitionID: id}, &result)
 }
-func (c *Client) AutomationCleanup(id string) (json.RawMessage, error) {
-	r, e := c.sendAutomation(protocol.AutomationCleanupMessage{Cmd: protocol.CmdAutomationCleanup, DefinitionID: id})
-	if e != nil {
-		return nil, e
+
+func (c *Client) AutomationCleanup(id string) (*protocol.AutomationCleanupResultMessage, error) {
+	var result protocol.AutomationCleanupResultMessage
+	if err := c.sendAutomation(protocol.AutomationCleanupMessage{Cmd: protocol.CmdAutomationCleanup, DefinitionID: id}, &result); err != nil {
+		return nil, err
 	}
-	return r.Data, nil
+	return &result, nil
 }
 
 type ListResult struct {

--- a/internal/daemon/automations.go
+++ b/internal/daemon/automations.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -15,23 +14,6 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/store"
 )
-
-type automationActionResult struct {
-	Event   string          `json:"event"`
-	Action  string          `json:"action"`
-	Success bool            `json:"success"`
-	Error   *string         `json:"error,omitempty"`
-	Data    json.RawMessage `json:"data,omitempty"`
-}
-
-// automationCleanupResult is automation_cleanup's socket/CLI data payload —
-// mirrors AutomationActionResultMessage's cleaned/kept_dirty/kept_active WS
-// fields.
-type automationCleanupResult struct {
-	Cleaned    []string `json:"cleaned"`
-	KeptDirty  []string `json:"kept_dirty"`
-	KeptActive []string `json:"kept_active"`
-}
 
 func (d *Daemon) automationRun(ctx context.Context, definitionID, requestID, input string) (*store.AutomationRun, error) {
 	if strings.TrimSpace(requestID) == "" {
@@ -118,62 +100,36 @@ func (d *Daemon) automationObservationLock(definitionID, subjectKey string, cycl
 	}
 	return lock
 }
+
+// handleAutomationCommand is the unix-socket transport for the automations
+// surface: one command set shared with WS (see ws_automations.go), each
+// dispatched to the same action function in automations_actions.go that WS
+// uses, so the two transports can never drift in what a given action returns.
+// The socket is synchronous, so a context.Background()-derived ctx is fine —
+// there is no client-side timeout race to bound here the way WS's
+// wsAutomationMutationTimeoutDuration does.
 func (d *Daemon) handleAutomationCommand(conn net.Conn, cmd string, msg any) {
-	var data any
-	var err error
+	ctx := context.Background()
+	var result any
 	switch cmd {
 	case protocol.CmdAutomationApply:
-		m := msg.(*protocol.AutomationApplyMessage)
-		data, err = d.automationApply(m.DefinitionYaml)
+		result = d.actionAutomationApply(ctx, msg.(*protocol.AutomationApplyMessage))
 	case protocol.CmdAutomationValidate:
-		m := msg.(*protocol.AutomationValidateMessage)
-		_, _, err = d.validateAutomationSpec(m.DefinitionYaml)
-	case protocol.CmdAutomationList:
-		data, err = d.store.ListAutomationDefinitions()
-	case protocol.CmdAutomationShow:
-		m := msg.(*protocol.AutomationShowMessage)
-		data, err = d.store.GetAutomationDefinition(m.DefinitionID)
+		result = d.actionAutomationValidate(msg.(*protocol.AutomationValidateMessage))
+	case protocol.CmdAutomationDefinitionsGet:
+		result = d.actionAutomationDefinitionsGet(msg.(*protocol.AutomationDefinitionsGetMessage))
+	case protocol.CmdAutomationDefinitionGet:
+		result = d.actionAutomationDefinitionGet(msg.(*protocol.AutomationDefinitionGetMessage))
 	case protocol.CmdAutomationRun:
-		m := msg.(*protocol.AutomationRunMessage)
-		if strings.TrimSpace(protocol.Deref(m.PRURL)) != "" && strings.TrimSpace(protocol.Deref(m.InputJson)) != "" {
-			err = errors.New("pr_url and input_json are mutually exclusive")
-			break
-		}
-		if strings.TrimSpace(protocol.Deref(m.PRURL)) != "" {
-			data, err = d.automationRunPullRequest(context.Background(), m.DefinitionID, m.RequestID, protocol.Deref(m.PRURL))
-		} else {
-			data, err = d.automationRun(context.Background(), m.DefinitionID, m.RequestID, protocol.Deref(m.InputJson))
-		}
-	case protocol.CmdAutomationRunList:
-		m := msg.(*protocol.AutomationRunListMessage)
-		data, err = d.store.ListAutomationRuns(m.DefinitionID)
+		result = d.actionAutomationRun(ctx, msg.(*protocol.AutomationRunMessage))
+	case protocol.CmdAutomationRunsGet:
+		result = d.actionAutomationRunsGet(msg.(*protocol.AutomationRunsGetMessage))
 	case protocol.CmdAutomationSetEnabled:
-		m := msg.(*protocol.AutomationSetEnabledMessage)
-		data, err = d.automationSetEnabled(context.Background(), m.DefinitionID, m.Enabled)
+		result = d.actionAutomationSetEnabled(ctx, msg.(*protocol.AutomationSetEnabledMessage))
 	case protocol.CmdAutomationDelete:
-		m := msg.(*protocol.AutomationDeleteMessage)
-		err = d.automationDelete(context.Background(), m.DefinitionID)
+		result = d.actionAutomationDelete(ctx, msg.(*protocol.AutomationDeleteMessage))
 	case protocol.CmdAutomationCleanup:
-		m := msg.(*protocol.AutomationCleanupMessage)
-		var cleaned, keptDirty, keptActive []string
-		cleaned, keptDirty, keptActive, err = d.automationCleanup(context.Background(), m.DefinitionID)
-		if err == nil {
-			data = automationCleanupResult{Cleaned: cleaned, KeptDirty: keptDirty, KeptActive: keptActive}
-		}
-	}
-	result := automationActionResult{Event: protocol.EventAutomationActionResult, Action: cmd, Success: err == nil}
-	if err != nil {
-		result.Error = protocol.Ptr(err.Error())
-	} else if data != nil {
-		// Guarded on nil rather than marshalling unconditionally: an action with
-		// no payload (validate) leaves data as a nil `any`, and json.Marshal of
-		// that yields the 4-byte literal `null`, not an empty slice — so
-		// `json:"data,omitempty"` would not drop the field and the wire would
-		// carry "data":null. json.RawMessage implements Unmarshaler and is
-		// invoked even for JSON null, so the client would decode a non-nil
-		// 4-byte Data and every "did I get a payload?" check downstream would
-		// answer yes. Leaving Data nil here is what lets omitempty do its job.
-		result.Data, _ = json.Marshal(data)
+		result = d.actionAutomationCleanup(ctx, msg.(*protocol.AutomationCleanupMessage))
 	}
 	_ = json.NewEncoder(conn).Encode(result)
 }

--- a/internal/daemon/automations_actions.go
+++ b/internal/daemon/automations_actions.go
@@ -1,0 +1,310 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/victorarias/attn/internal/automation"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// automationDefinitionYAML resolves def's definition_yaml by rendering
+// automation.MarshalDefinitionYAML from spec_json — spec_yaml storage is
+// gone (see MarshalDefinitionYAML's doc comment), so this is the only path;
+// every read (the editor's Save-then-reopen, `attn automation show`) gets
+// its YAML re-derived from the canonical spec, comments and formatting
+// choices not preserved.
+func automationDefinitionYAML(def store.AutomationDefinition) (string, error) {
+	var spec automation.DefinitionSpec
+	if err := json.Unmarshal([]byte(def.SpecJSON), &spec); err != nil {
+		return "", fmt.Errorf("parse stored definition %s: %w", def.ID, err)
+	}
+	rendered, err := automation.MarshalDefinitionYAML(spec)
+	if err != nil {
+		return "", fmt.Errorf("render definition %s: %w", def.ID, err)
+	}
+	return string(rendered), nil
+}
+
+// This file is the one action layer shared by both transports (the
+// unix-socket/CLI dispatch in automations.go and the WS handlers in
+// ws_automations.go): one function per command, each taking its typed
+// request message and returning the complete typed result message with
+// Success/Error set. All result-shape construction — building summaries,
+// deciding what to omit — lives here, not duplicated per transport.
+
+// automationRunSummaryListCap bounds automation_runs_get: a defensive cap
+// against an unbounded WS payload for a long-lived definition, not a
+// UI-driven pagination contract.
+const automationRunSummaryListCap = 100
+
+func (d *Daemon) actionAutomationDefinitionsGet(msg *protocol.AutomationDefinitionsGetMessage) protocol.AutomationDefinitionsResultMessage {
+	result := protocol.AutomationDefinitionsResultMessage{
+		Event:     protocol.EventAutomationDefinitionsResult,
+		RequestID: msg.RequestID,
+	}
+	definitions, err := d.store.ListAutomationDefinitions()
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		return result
+	}
+	lastRuns, err := d.store.LatestAutomationRunPerDefinition()
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		return result
+	}
+	result.Success = true
+	result.Definitions = make([]protocol.AutomationDefinitionSummary, len(definitions))
+	for i := range definitions {
+		var lastRun *store.AutomationRunWithOccurrenceKey
+		if run, ok := lastRuns[definitions[i].ID]; ok {
+			lastRun = &run
+		}
+		result.Definitions[i] = d.buildAutomationDefinitionSummary(definitions[i], lastRun)
+	}
+	return result
+}
+
+// actionAutomationDefinitionGet backs the editor's load path: definition_id
+// "" returns the starter template at revision 0 (no definition — the
+// new-definition case, D7 in the design), so create and edit share one
+// frontend code path. A non-empty id resolves definition_yaml via
+// automationDefinitionYAML's spec-JSON rendering.
+func (d *Daemon) actionAutomationDefinitionGet(msg *protocol.AutomationDefinitionGetMessage) protocol.AutomationDefinitionResultMessage {
+	result := protocol.AutomationDefinitionResultMessage{
+		Event:     protocol.EventAutomationDefinitionResult,
+		RequestID: msg.RequestID,
+	}
+	if msg.DefinitionID == "" {
+		template, err := automation.StarterTemplateYAML()
+		if err != nil {
+			result.Error = protocol.Ptr(err.Error())
+			return result
+		}
+		result.Success = true
+		result.SpecYaml = protocol.Ptr(string(template))
+		return result
+	}
+	definition, err := d.store.GetAutomationDefinition(msg.DefinitionID)
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		return result
+	}
+	if definition == nil {
+		result.Error = protocol.Ptr("automation definition not found")
+		return result
+	}
+	specYAML, err := automationDefinitionYAML(*definition)
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		return result
+	}
+	result.Success = true
+	result.SpecYaml = protocol.Ptr(specYAML)
+	summary := d.buildAutomationDefinitionSummary(*definition, nil)
+	result.Definition = &summary
+	return result
+}
+
+func (d *Daemon) actionAutomationRunsGet(msg *protocol.AutomationRunsGetMessage) protocol.AutomationRunsResultMessage {
+	result := protocol.AutomationRunsResultMessage{
+		Event:        protocol.EventAutomationRunsResult,
+		RequestID:    msg.RequestID,
+		DefinitionID: msg.DefinitionID,
+	}
+	runs, err := d.store.ListAutomationRunsWithOccurrenceKeys(msg.DefinitionID, automationRunSummaryListCap+1)
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		return result
+	}
+	if len(runs) > automationRunSummaryListCap {
+		runs = runs[:automationRunSummaryListCap]
+		result.Truncated = protocol.Ptr(true)
+	}
+	result.Success = true
+	result.Runs = make([]protocol.AutomationRunSummary, len(runs))
+	for i := range runs {
+		result.Runs[i] = automationRunSummary(runs[i])
+	}
+	return result
+}
+
+func (d *Daemon) actionAutomationValidate(msg *protocol.AutomationValidateMessage) protocol.AutomationValidateResultMessage {
+	result := protocol.AutomationValidateResultMessage{
+		Event:     protocol.EventAutomationValidateResult,
+		RequestID: msg.RequestID,
+	}
+	if _, _, err := d.validateAutomationSpec(msg.DefinitionYaml); err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		return result
+	}
+	result.Success = true
+	return result
+}
+
+// actionAutomationApply is the one apply path for both transports, unified on
+// automationApplyWithGuards. The socket/CLI path never sets
+// expected_id/expected_revision (both nil after JSON decode, since cmd/attn
+// omits them), so automationApplyWithGuards enforces neither check and
+// behaves exactly like the old unguarded last-writer-wins automationApply.
+// The WS editor's Save always sends both (possibly zero-valued for a create),
+// so its guards apply as before — see automationApplyWithGuards's doc
+// comment for why enforcement is keyed on pointer presence rather than on the
+// zero value itself.
+func (d *Daemon) actionAutomationApply(ctx context.Context, msg *protocol.AutomationApplyMessage) protocol.AutomationApplyResultMessage {
+	result := protocol.AutomationApplyResultMessage{
+		Event:     protocol.EventAutomationApplyResult,
+		RequestID: msg.RequestID,
+	}
+	definition, err := d.automationApplyWithGuards(ctx, msg.DefinitionYaml, msg.ExpectedID, msg.ExpectedRevision)
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		return result
+	}
+	result.Success = true
+	summary := d.buildAutomationDefinitionSummary(*definition, nil)
+	result.Definition = &summary
+	specYAML, err := automationDefinitionYAML(*definition)
+	if err == nil {
+		result.SpecYaml = protocol.Ptr(specYAML)
+	}
+	return result
+}
+
+func (d *Daemon) actionAutomationSetEnabled(ctx context.Context, msg *protocol.AutomationSetEnabledMessage) protocol.AutomationSetEnabledResultMessage {
+	result := protocol.AutomationSetEnabledResultMessage{
+		Event:     protocol.EventAutomationSetEnabledResult,
+		RequestID: msg.RequestID,
+	}
+	definition, err := d.automationSetEnabled(ctx, msg.DefinitionID, msg.Enabled)
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		return result
+	}
+	result.Success = true
+	summary := d.buildAutomationDefinitionSummary(*definition, nil)
+	result.Definition = &summary
+	return result
+}
+
+func (d *Daemon) actionAutomationDelete(ctx context.Context, msg *protocol.AutomationDeleteMessage) protocol.AutomationDeleteResultMessage {
+	result := protocol.AutomationDeleteResultMessage{
+		Event:     protocol.EventAutomationDeleteResult,
+		RequestID: msg.RequestID,
+	}
+	if err := d.automationDelete(ctx, msg.DefinitionID); err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		return result
+	}
+	result.Success = true
+	return result
+}
+
+func (d *Daemon) actionAutomationCleanup(ctx context.Context, msg *protocol.AutomationCleanupMessage) protocol.AutomationCleanupResultMessage {
+	result := protocol.AutomationCleanupResultMessage{
+		Event:     protocol.EventAutomationCleanupResult,
+		RequestID: msg.RequestID,
+	}
+	cleaned, keptDirty, keptActive, err := d.automationCleanup(ctx, msg.DefinitionID)
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		return result
+	}
+	result.Success = true
+	result.Cleaned = cleaned
+	result.KeptDirty = keptDirty
+	result.KeptActive = keptActive
+	return result
+}
+
+// actionAutomationRun handles run-now for both transports: pr_url and
+// input_json are mutually exclusive, and a manual-trigger rejection (e.g. a
+// provider-driven definition) surfaces as success=false with the error text,
+// not a transport-level failure.
+func (d *Daemon) actionAutomationRun(ctx context.Context, msg *protocol.AutomationRunMessage) protocol.AutomationRunResultMessage {
+	result := protocol.AutomationRunResultMessage{
+		Event:     protocol.EventAutomationRunResult,
+		RequestID: protocol.Ptr(msg.RequestID),
+	}
+	prURL := strings.TrimSpace(protocol.Deref(msg.PRURL))
+	inputJSON := strings.TrimSpace(protocol.Deref(msg.InputJson))
+	if prURL != "" && inputJSON != "" {
+		result.Error = protocol.Ptr("pr_url and input_json are mutually exclusive")
+		return result
+	}
+	var run *store.AutomationRun
+	var err error
+	if prURL != "" {
+		run, err = d.automationRunPullRequest(ctx, msg.DefinitionID, msg.RequestID, prURL)
+	} else {
+		run, err = d.automationRun(ctx, msg.DefinitionID, msg.RequestID, protocol.Deref(msg.InputJson))
+	}
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		return result
+	}
+	result.Success = true
+	summary := automationRunSummary(store.AutomationRunWithOccurrenceKey{AutomationRun: *run})
+	result.Run = &summary
+	return result
+}
+
+// buildAutomationDefinitionSummary extracts the compact wire fields from a
+// definition's SpecJSON. An unmarshal failure (should not happen for a
+// definition that passed automationApply's validation, but is not assumed)
+// degrades to an id/name/enabled-only summary rather than dropping the
+// definition from the list. lastRun is embedded when the caller has it handy
+// (definitions_get provides one query's worth for every definition); mutation
+// results (apply/set_enabled) pass nil rather than pay for a per-definition
+// lookup — the frontend's automations_changed-driven refetch fills it in.
+func (d *Daemon) buildAutomationDefinitionSummary(def store.AutomationDefinition, lastRun *store.AutomationRunWithOccurrenceKey) protocol.AutomationDefinitionSummary {
+	summary := protocol.AutomationDefinitionSummary{
+		ID:        def.ID,
+		Name:      def.Name,
+		Enabled:   def.Enabled,
+		Revision:  def.Revision,
+		UpdatedAt: string(protocol.NewTimestamp(def.UpdatedAt)),
+	}
+	if lastRun != nil {
+		runSummary := automationRunSummary(*lastRun)
+		summary.LastRun = &runSummary
+	}
+	var spec automation.DefinitionSpec
+	if err := json.Unmarshal([]byte(def.SpecJSON), &spec); err != nil {
+		d.logf("automation definition summary parse %s: %v", def.ID, err)
+		return summary
+	}
+	summary.TriggerType = spec.Trigger.Type
+	if spec.Trigger.Schedule != nil {
+		summary.ScheduleCron = protocol.Ptr(spec.Trigger.Schedule.Cron)
+		summary.ScheduleTimeZone = protocol.Ptr(spec.Trigger.Schedule.TimeZone)
+	}
+	return summary
+}
+
+func automationRunSummary(run store.AutomationRunWithOccurrenceKey) protocol.AutomationRunSummary {
+	summary := protocol.AutomationRunSummary{
+		ID:            run.ID,
+		DefinitionID:  run.DefinitionID,
+		State:         run.State,
+		TicketID:      protocol.Ptr(run.TicketID),
+		SessionID:     protocol.Ptr(run.SessionID),
+		PaneID:        protocol.Ptr(run.PaneID),
+		CreatedAt:     string(protocol.NewTimestamp(run.CreatedAt)),
+		UpdatedAt:     string(protocol.NewTimestamp(run.UpdatedAt)),
+		OccurrenceKey: protocol.Ptr(run.OccurrenceKey),
+	}
+	if run.LastError != "" {
+		summary.LastError = protocol.Ptr(run.LastError)
+	}
+	if run.CancelReason != "" {
+		summary.CancelReason = protocol.Ptr(run.CancelReason)
+	}
+	if run.DeliveredAt != nil {
+		summary.DeliveredAt = protocol.Ptr(string(protocol.NewTimestamp(*run.DeliveredAt)))
+	}
+	return summary
+}

--- a/internal/daemon/automations_definitions.go
+++ b/internal/daemon/automations_definitions.go
@@ -66,38 +66,57 @@ func (d *Daemon) validateAutomationSpec(raw string) (automation.DefinitionSpec, 
 }
 
 // automationApply applies definition YAML unconditionally: parse, validate,
-// upsert. This is the unix-socket/CLI/agent surface (attn automation apply)
-// — "last writer wins," unguarded, exactly as before this PR. The WS
-// editor's Save goes through automationApplyWithGuards instead.
+// upsert. This is the unguarded shape used by test fixtures and — via
+// actionAutomationApply passing nil/nil for expectedID/expectedRevision — the
+// unix-socket/CLI/agent surface (attn automation apply): "last writer wins."
+// Thin wrapper over automationApplyWithGuards with both guards off; kept
+// separate only because so many tests use it as fixture setup.
 func (d *Daemon) automationApply(raw string) (*store.AutomationDefinition, error) {
-	spec, canonical, err := d.validateAutomationSpec(raw)
-	if err != nil {
-		return nil, err
-	}
-	return d.automationApplyLocked(context.Background(), spec, canonical, nil)
+	return d.automationApplyWithGuards(context.Background(), raw, nil, nil)
 }
 
-// automationApplyWithGuards is automationApply's WS counterpart, used by the
-// app editor's Save. expectedID and expectedRevision implement D4/D5 from
-// the design: apply is an upsert keyed on the id *inside* the YAML, so an
-// edited id would silently fork the definition and leave the original
-// enabled and running (D4) — expectedID ("" when creating) refuses a
-// mismatch. And a stale expectedRevision (0 when creating) would silently
-// clobber a concurrent apply from the CLI or another app window (D5) — the
-// caller sees "changed elsewhere — reload" instead. Both guards run inside
-// automationApplyLocked's automationMu, atomically with the pre-upsert
-// existing-row read they depend on, so there is no window between the check
-// and the write where a concurrent apply could slip through.
-func (d *Daemon) automationApplyWithGuards(ctx context.Context, raw, expectedID string, expectedRevision int) (*store.AutomationDefinition, error) {
+// automationApplyWithGuards is the one apply path shared by both transports
+// (see actionAutomationApply). expectedID and expectedRevision implement
+// D4/D5 from the design: apply is an upsert keyed on the id *inside* the
+// YAML, so an edited id would silently fork the definition and leave the
+// original enabled and running (D4) — a non-nil expectedID that mismatches
+// refuses. And a stale expectedRevision would silently clobber a concurrent
+// apply from the CLI or another app window (D5) — the caller sees "changed
+// elsewhere — reload" instead.
+//
+// Both guards are keyed on POINTER PRESENCE, not on the zero value: nil means
+// "this caller does not want this guard enforced at all" — the socket/CLI
+// path (attn automation apply) never sets either field, so it gets true
+// last-writer-wins, unguarded, exactly as the old unconditional automationApply
+// did. The WS editor's Save always sends both fields (zero-valued for a
+// create — expectedID "" / expectedRevision 0, matching AutomationEditor's
+// loadedId/revision state before a first save), so its guards apply exactly
+// as before this unification: expectedRevision 0 means "creating" (refuse a
+// collision with a live definition) and a non-zero expectedRevision must
+// match the stored one. Using the dereferenced zero value here instead of
+// pointer presence would force EVERY caller — including the CLI's unguarded
+// edits of existing definitions — through the "0 means creating" branch,
+// wrongly rejecting a CLI apply of an existing definition as "already
+// exists".
+//
+// Both guards run inside automationApplyLocked's automationMu, atomically
+// with the pre-upsert existing-row read they depend on, so there is no
+// window between the check and the write where a concurrent apply could
+// slip through.
+func (d *Daemon) automationApplyWithGuards(ctx context.Context, raw string, expectedID *string, expectedRevision *int) (*store.AutomationDefinition, error) {
 	spec, canonical, err := d.validateAutomationSpec(raw)
 	if err != nil {
 		return nil, err
 	}
-	if expectedID != "" && spec.ID != expectedID {
-		return nil, fmt.Errorf("definition id %q in the YAML does not match the definition being edited (%q) — apply is keyed on the id inside the YAML, so an id change must be made as a separate create", spec.ID, expectedID)
+	if expectedID != nil && *expectedID != "" && spec.ID != *expectedID {
+		return nil, fmt.Errorf("definition id %q in the YAML does not match the definition being edited (%q) — apply is keyed on the id inside the YAML, so an id change must be made as a separate create", spec.ID, *expectedID)
 	}
 	guard := func(existing *store.AutomationDefinition) error {
-		if expectedRevision == 0 {
+		if expectedRevision == nil {
+			// No revision guard requested at all (the unguarded socket/CLI path).
+			return nil
+		}
+		if *expectedRevision == 0 {
 			// Create. Revisions start at 1 (see UpsertAutomationDefinition), so
 			// this is unambiguous — it is never an edit of a revision-0 row.
 			//
@@ -118,7 +137,7 @@ func (d *Daemon) automationApplyWithGuards(ctx context.Context, raw, expectedID 
 			}
 			return nil
 		}
-		if existing == nil || existing.Revision != expectedRevision {
+		if existing == nil || existing.Revision != *expectedRevision {
 			return errors.New("automation definition changed elsewhere — reload before saving")
 		}
 		if existing.DeletedAt != nil {

--- a/internal/daemon/automations_test.go
+++ b/internal/daemon/automations_test.go
@@ -1647,3 +1647,113 @@ func TestAutomationSetEnabledNoOpDoesNotBroadcast(t *testing.T) {
 		t.Fatalf("no-op automationSetEnabled broadcast = %v, want none", ids)
 	}
 }
+
+// TestAutomationDefinitionsGetReachesRealSocketDispatchWithLastRun drives
+// automation_definitions_get through handleConnection (not the action
+// function directly) to guard against the PR2a class of bug where a command
+// is wired into the schema/constants but never reaches the dispatch switch —
+// and pins that the summary's last_run is populated from the store's
+// per-definition latest-run query, not left for the frontend to backfill.
+func TestAutomationDefinitionsGetReachesRealSocketDispatchWithLastRun(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	def, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	run, _, err := s.ClaimManualAutomationRun(def.ID, "request-1", "", `{}`, def.Revision, `{}`, now, store.AutomationRunReservation{
+		RunID: "run-1", OccurrenceID: "occ-1", TicketID: "ticket-1", SessionID: "session-1", WorkspaceID: "workspace-1", PaneID: "pane-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MarkAutomationRunDelivered(run.ID, "{}", now); err != nil {
+		t.Fatal(err)
+	}
+
+	server, client := net.Pipe()
+	defer client.Close()
+	go d.handleConnection(server)
+	if err := json.NewEncoder(client).Encode(protocol.AutomationDefinitionsGetMessage{
+		Cmd: protocol.CmdAutomationDefinitionsGet,
+	}); err != nil {
+		t.Fatalf("encode automation_definitions_get: %v", err)
+	}
+
+	var result protocol.AutomationDefinitionsResultMessage
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if err := json.NewDecoder(client).Decode(&result); err != nil {
+		t.Fatalf("decode automation_definitions_get response: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("automation_definitions_get over the real socket dispatch failed: success=%v error=%v", result.Success, result.Error)
+	}
+	var got *protocol.AutomationDefinitionSummary
+	for i := range result.Definitions {
+		if result.Definitions[i].ID == def.ID {
+			got = &result.Definitions[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("definitions = %#v, want an entry for %s", result.Definitions, def.ID)
+	}
+	if got.LastRun == nil || got.LastRun.ID != run.ID {
+		t.Fatalf("definition.last_run = %#v, want run %s embedded", got.LastRun, run.ID)
+	}
+}
+
+// TestAutomationApplySocketPathIsUnguardedButWSPathEnforcesStaleRevision pins
+// the pointer-presence contract on automationApplyWithGuards's
+// expectedID/expectedRevision: the socket/CLI path (automationApply, wrapping
+// automationApplyWithGuards with nil, nil) always overwrites last-writer-wins,
+// while the WS/editor path (always sending non-nil expected_revision) refuses
+// a stale save.
+func TestAutomationApplySocketPathIsUnguardedButWSPathEnforcesStaleRevision(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	dir := t.TempDir()
+	raw := fmt.Sprintf(manualAutomationYAML, dir)
+
+	def, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if def.Revision != 1 {
+		t.Fatalf("fixture revision = %d, want 1", def.Revision)
+	}
+
+	// Unguarded socket/CLI path: re-applying the same id with no expected
+	// revision at all overwrites unconditionally, even though a WS-style
+	// caller would by now be holding a stale revision (1) once a concurrent
+	// edit bumps it to 2 below.
+	edited := strings.Replace(fmt.Sprintf(manualAutomationYAML, dir), "Check locally.", "Check locally, edited by someone else.", 1)
+	if _, err := d.automationApply(edited); err != nil {
+		t.Fatalf("automationApply (unguarded socket path) on existing id: %v", err)
+	}
+	afterConcurrentEdit, err := s.GetAutomationDefinition(def.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterConcurrentEdit.Revision != 2 {
+		t.Fatalf("revision after unguarded concurrent apply = %d, want 2", afterConcurrentEdit.Revision)
+	}
+
+	// WS/editor path: expectedRevision is a non-nil pointer holding the stale
+	// value (1) the editor loaded before the concurrent edit above landed —
+	// must refuse rather than overwrite.
+	staleRevision := 1
+	expectedID := def.ID
+	_, err = d.automationApplyWithGuards(context.Background(), raw, &expectedID, &staleRevision)
+	if err == nil || !strings.Contains(err.Error(), "changed elsewhere") {
+		t.Fatalf("automationApplyWithGuards with stale expected_revision err=%v, want a stale-revision refusal", err)
+	}
+	stillAfterConcurrentEdit, err := s.GetAutomationDefinition(def.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stillAfterConcurrentEdit.Revision != 2 {
+		t.Fatalf("revision after refused guarded apply = %d, want unchanged at 2", stillAfterConcurrentEdit.Revision)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2124,7 +2124,7 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleRegister(conn, msg.(*protocol.RegisterMessage))
 	case protocol.CmdDelegate:
 		d.handleDelegate(conn, msg.(*protocol.DelegateMessage))
-	case protocol.CmdAutomationApply, protocol.CmdAutomationValidate, protocol.CmdAutomationList, protocol.CmdAutomationShow, protocol.CmdAutomationRun, protocol.CmdAutomationRunList, protocol.CmdAutomationSetEnabled, protocol.CmdAutomationDelete, protocol.CmdAutomationCleanup:
+	case protocol.CmdAutomationApply, protocol.CmdAutomationValidate, protocol.CmdAutomationDefinitionsGet, protocol.CmdAutomationDefinitionGet, protocol.CmdAutomationRun, protocol.CmdAutomationRunsGet, protocol.CmdAutomationSetEnabled, protocol.CmdAutomationDelete, protocol.CmdAutomationCleanup:
 		d.handleAutomationCommand(conn, cmd, msg)
 	case protocol.CmdDelegateStatus:
 		d.handleDelegateStatus(conn, msg.(*protocol.DelegateStatusMessage))

--- a/internal/daemon/ws_automations.go
+++ b/internal/daemon/ws_automations.go
@@ -2,39 +2,31 @@ package daemon
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"strings"
 
-	"github.com/victorarias/attn/internal/automation"
 	"github.com/victorarias/attn/internal/protocol"
-	"github.com/victorarias/attn/internal/store"
 )
 
 // WS wrappers for the automations surface: list definitions, list one
-// definition's runs, enable/disable, delete, cleanup, and run-now. Canonical state
-// stays in SQLite; every handler here replies with a compact
-// AutomationActionResultMessage and mutations also broadcast
-// automations_changed (automations_broadcast.go) so other clients re-read.
+// definition's runs, enable/disable, delete, cleanup, run-now, apply, and
+// validate. Every handler here delegates to the same action function in
+// automations_actions.go that the unix-socket transport uses
+// (handleAutomationCommand in automations.go), then d.sendToClient's the
+// per-action typed result — the two transports can never drift in what a
+// given action returns.
 //
-// This is a distinct wire shape from the unix-socket automation_action_result
-// used by the CLI/agent path (automations.go's automationActionResult /
-// internal/client's AutomationResult, which carry a generic `data` payload) —
-// see the AutomationActionResultMessage doc comment in main.tsp for why the
-// two are not merged.
+// Mutations here (set_enabled, delete, run, apply) can block behind
+// d.automationMu while it is held for an in-flight automation delivery
+// (clone/fetch, agent spawn), which can take tens of seconds — the
+// frontend's wrappers use a 30s timeout to match. The mutations resolve that
+// race in one of two ways:
 //
-// Mutations here (set_enabled, delete, run) can block behind d.automationMu
-// while it is held for an in-flight automation delivery (clone/fetch, agent
-// spawn), which can take tens of seconds — the frontend's wrappers use a 30s
-// timeout to match. The mutations resolve that race in one of two ways:
-//
-//   - set_enabled and delete both abort, rather than mutating, once
+//   - set_enabled, delete, and apply all abort, rather than mutating, once
 //     wsAutomationMutationTimeoutDuration's daemon-side deadline (25s, strictly
 //     inside the client's 30s) passes while still waiting on automationMu — see
-//     automationSetEnabled and automationDelete. So the client's timer can
-//     never fire before one of these either lands or is provably abandoned; a
-//     late store flip after a reported timeout is not possible.
+//     automationSetEnabled, automationDelete, and automationApplyLocked. So the
+//     client's timer can never fire before one of these either lands or is
+//     provably abandoned; a late store flip after a reported timeout is not
+//     possible.
 //   - run-now cannot use the same trick: automationRun durably claims the run
 //     via ClaimManualAutomationRun before waiting on automationMu, so an
 //     abandoned wait still leaves a pending run that will eventually deliver.
@@ -46,50 +38,13 @@ import (
 //     automationMu (see handleAutomationCleanupWS), so it has nothing to
 //     abort ahead of — the WS timeout there is only a defensive bound.
 
-// automationRunSummaryListCap bounds automation_runs_get: a defensive cap
-// against an unbounded WS payload for a long-lived definition, not a
-// UI-driven pagination contract.
-const automationRunSummaryListCap = 100
-
 func (d *Daemon) handleAutomationDefinitionsGetWS(client *wsClient, msg *protocol.AutomationDefinitionsGetMessage) {
-	definitions, err := d.store.ListAutomationDefinitions()
-	result := protocol.AutomationActionResultMessage{
-		Event:     protocol.EventAutomationActionResult,
-		Action:    "definitions_get",
-		RequestID: msg.RequestID,
-		Success:   err == nil,
-	}
-	if err != nil {
-		result.Error = protocol.Ptr(err.Error())
-	} else {
-		result.Definitions = make([]protocol.AutomationDefinitionSummary, len(definitions))
-		for i := range definitions {
-			result.Definitions[i] = d.buildAutomationDefinitionSummary(definitions[i])
-		}
-	}
+	result := d.actionAutomationDefinitionsGet(msg)
 	d.sendToClient(client, result)
 }
 
 func (d *Daemon) handleAutomationRunsGetWS(client *wsClient, msg *protocol.AutomationRunsGetMessage) {
-	runs, err := d.store.ListAutomationRunsWithOccurrenceKeys(msg.DefinitionID, automationRunSummaryListCap+1)
-	result := protocol.AutomationActionResultMessage{
-		Event:     protocol.EventAutomationActionResult,
-		Action:    "runs_get",
-		RequestID: msg.RequestID,
-		Success:   err == nil,
-	}
-	if err != nil {
-		result.Error = protocol.Ptr(err.Error())
-	} else {
-		if len(runs) > automationRunSummaryListCap {
-			runs = runs[:automationRunSummaryListCap]
-			result.Truncated = protocol.Ptr(true)
-		}
-		result.Runs = make([]protocol.AutomationRunSummary, len(runs))
-		for i := range runs {
-			result.Runs[i] = automationRunSummary(runs[i])
-		}
-	}
+	result := d.actionAutomationRunsGet(msg)
 	d.sendToClient(client, result)
 }
 
@@ -97,43 +52,22 @@ func (d *Daemon) handleAutomationSetEnabledWS(client *wsClient, msg *protocol.Au
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), d.wsAutomationMutationTimeoutDuration())
 		defer cancel()
-		definition, err := d.automationSetEnabled(ctx, msg.DefinitionID, msg.Enabled)
-		result := protocol.AutomationActionResultMessage{
-			Event:     protocol.EventAutomationActionResult,
-			Action:    "set_enabled",
-			RequestID: msg.RequestID,
-			Success:   err == nil,
-		}
-		if err != nil {
-			result.Error = protocol.Ptr(err.Error())
-		} else {
-			result.Definitions = []protocol.AutomationDefinitionSummary{d.buildAutomationDefinitionSummary(*definition)}
-		}
+		result := d.actionAutomationSetEnabled(ctx, msg)
 		d.sendToClient(client, result)
 	}()
 }
 
 // handleAutomationDeleteWS is the WS counterpart of the unix-socket
-// CmdAutomationDelete path (automations.go's handleAutomationCommand):
-// soft-delete a definition. Unlike set_enabled's result, there is no
-// updated definition summary to return — a deleted definition drops out of
-// automation_definitions_get/automations_changed listings entirely, so
-// clients learn of the removal from the broadcast automationDelete already
-// sends, not from this result's payload.
+// CmdAutomationDelete path: soft-delete a definition. Unlike set_enabled's
+// result, there is no updated definition summary to return — a deleted
+// definition drops out of automation_definitions_get/automations_changed
+// listings entirely, so clients learn of the removal from the broadcast
+// automationDelete already sends, not from this result's payload.
 func (d *Daemon) handleAutomationDeleteWS(client *wsClient, msg *protocol.AutomationDeleteMessage) {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), d.wsAutomationMutationTimeoutDuration())
 		defer cancel()
-		err := d.automationDelete(ctx, msg.DefinitionID)
-		result := protocol.AutomationActionResultMessage{
-			Event:     protocol.EventAutomationActionResult,
-			Action:    "delete",
-			RequestID: msg.RequestID,
-			Success:   err == nil,
-		}
-		if err != nil {
-			result.Error = protocol.Ptr(err.Error())
-		}
+		result := d.actionAutomationDelete(ctx, msg)
 		d.sendToClient(client, result)
 	}()
 }
@@ -149,87 +83,32 @@ func (d *Daemon) handleAutomationCleanupWS(client *wsClient, msg *protocol.Autom
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), d.wsAutomationMutationTimeoutDuration())
 		defer cancel()
-		cleaned, keptDirty, keptActive, err := d.automationCleanup(ctx, msg.DefinitionID)
-		result := protocol.AutomationActionResultMessage{
-			Event:     protocol.EventAutomationActionResult,
-			Action:    "cleanup",
-			RequestID: msg.RequestID,
-			Success:   err == nil,
-		}
-		if err != nil {
-			result.Error = protocol.Ptr(err.Error())
-		} else {
-			result.Cleaned = cleaned
-			result.KeptDirty = keptDirty
-			result.KeptActive = keptActive
-		}
+		result := d.actionAutomationCleanup(ctx, msg)
 		d.sendToClient(client, result)
 	}()
 }
 
 // handleAutomationRunWS is the WS counterpart of the unix-socket
-// CmdAutomationRun path (automations.go's handleAutomationCommand): run-now,
-// manual trigger only. A manual-trigger rejection (e.g. a provider-driven
-// definition) surfaces as success=false with the error text, matching the
-// socket path's existing behavior — it is not a transport-level failure.
+// CmdAutomationRun path: run-now. A manual-trigger rejection (e.g. a
+// provider-driven definition) surfaces as success=false with the error text,
+// matching the socket path's behavior — it is not a transport-level failure.
 func (d *Daemon) handleAutomationRunWS(client *wsClient, msg *protocol.AutomationRunMessage) {
 	go func() {
-		var run *store.AutomationRun
-		var err error
-		prURL := strings.TrimSpace(protocol.Deref(msg.PRURL))
-		inputJSON := strings.TrimSpace(protocol.Deref(msg.InputJson))
-		switch {
-		case prURL != "" && inputJSON != "":
-			err = errors.New("pr_url and input_json are mutually exclusive")
-		case prURL != "":
-			run, err = d.automationRunPullRequest(context.Background(), msg.DefinitionID, msg.RequestID, prURL)
-		default:
-			run, err = d.automationRun(context.Background(), msg.DefinitionID, msg.RequestID, protocol.Deref(msg.InputJson))
-		}
-		result := protocol.AutomationActionResultMessage{
-			Event:     protocol.EventAutomationActionResult,
-			Action:    "run",
-			RequestID: protocol.Ptr(msg.RequestID),
-			Success:   err == nil,
-		}
-		if err != nil {
-			result.Error = protocol.Ptr(err.Error())
-		} else {
-			result.RunID = protocol.Ptr(run.ID)
-			result.TicketID = protocol.Ptr(run.TicketID)
-			result.SessionID = protocol.Ptr(run.SessionID)
-		}
+		result := d.actionAutomationRun(context.Background(), msg)
 		d.sendToClient(client, result)
 	}()
 }
 
 // handleAutomationApplyWS is the WS counterpart of the unix-socket
-// CmdAutomationApply path, used by the app editor's Save. Unlike the socket
-// path's automationApply (last-writer-wins), this goes through
-// automationApplyWithGuards so expected_id/expected_revision (D4/D5 in the
-// design) can refuse an id change or a stale save — see that function's doc
-// comment for why both checks are safe against a concurrent apply. On
-// success the result carries the saved definition's summary (including its
-// new revision) so the editor can update its expected_revision for the next
-// save without a round trip through automation_definitions_get.
+// CmdAutomationApply path, used by the app editor's Save. The app always
+// sends expected_id/expected_revision (see actionAutomationApply's doc
+// comment on why that's what makes them enforced here but not on the
+// socket/CLI path).
 func (d *Daemon) handleAutomationApplyWS(client *wsClient, msg *protocol.AutomationApplyMessage) {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), d.wsAutomationMutationTimeoutDuration())
 		defer cancel()
-		definition, err := d.automationApplyWithGuards(ctx, msg.DefinitionYaml, protocol.Deref(msg.ExpectedID), int(protocol.Deref(msg.ExpectedRevision)))
-		result := protocol.AutomationActionResultMessage{
-			Event:     protocol.EventAutomationActionResult,
-			Action:    "apply",
-			RequestID: msg.RequestID,
-			Success:   err == nil,
-		}
-		if err != nil {
-			result.Error = protocol.Ptr(err.Error())
-		} else {
-			result.Definitions = []protocol.AutomationDefinitionSummary{d.buildAutomationDefinitionSummary(*definition)}
-			result.SpecYaml = protocol.Ptr(msg.DefinitionYaml)
-			result.Revision = protocol.Ptr(definition.Revision)
-		}
+		result := d.actionAutomationApply(ctx, msg)
 		d.sendToClient(client, result)
 	}()
 }
@@ -249,134 +128,15 @@ func (d *Daemon) handleAutomationApplyWS(client *wsClient, msg *protocol.Automat
 // unresponsive mount would stall them indefinitely.
 func (d *Daemon) handleAutomationValidateWS(client *wsClient, msg *protocol.AutomationValidateMessage) {
 	go func() {
-		_, _, err := d.validateAutomationSpec(msg.DefinitionYaml)
-		result := protocol.AutomationActionResultMessage{
-			Event:     protocol.EventAutomationActionResult,
-			Action:    "validate",
-			RequestID: msg.RequestID,
-			Success:   err == nil,
-		}
-		if err != nil {
-			result.Error = protocol.Ptr(err.Error())
-		}
+		result := d.actionAutomationValidate(msg)
 		d.sendToClient(client, result)
 	}()
 }
 
 // handleAutomationDefinitionGetWS backs the editor's load path: definition_id
-// "" returns the starter template at revision 0 (new-definition case, D7 in
-// the design), so create and edit share one frontend code path. A non-empty
-// id resolves definition_yaml via automationDefinitionYAML's legacy-row
-// fallback and returns the stored revision, for the editor to echo back as
-// expected_revision on save.
+// "" returns the starter template at revision 0 (new-definition case), so
+// create and edit share one frontend code path.
 func (d *Daemon) handleAutomationDefinitionGetWS(client *wsClient, msg *protocol.AutomationDefinitionGetMessage) {
-	result := protocol.AutomationActionResultMessage{
-		Event:     protocol.EventAutomationActionResult,
-		Action:    "definition_get",
-		RequestID: msg.RequestID,
-	}
-	if msg.DefinitionID == "" {
-		template, err := automation.StarterTemplateYAML()
-		if err != nil {
-			result.Error = protocol.Ptr(err.Error())
-			d.sendToClient(client, result)
-			return
-		}
-		result.Success = true
-		result.SpecYaml = protocol.Ptr(string(template))
-		result.Revision = protocol.Ptr(0)
-		d.sendToClient(client, result)
-		return
-	}
-	definition, err := d.store.GetAutomationDefinition(msg.DefinitionID)
-	if err != nil {
-		result.Error = protocol.Ptr(err.Error())
-		d.sendToClient(client, result)
-		return
-	}
-	if definition == nil {
-		result.Error = protocol.Ptr("automation definition not found")
-		d.sendToClient(client, result)
-		return
-	}
-	specYAML, err := automationDefinitionYAML(*definition)
-	if err != nil {
-		result.Error = protocol.Ptr(err.Error())
-		d.sendToClient(client, result)
-		return
-	}
-	result.Success = true
-	result.SpecYaml = protocol.Ptr(specYAML)
-	result.Revision = protocol.Ptr(definition.Revision)
+	result := d.actionAutomationDefinitionGet(msg)
 	d.sendToClient(client, result)
-}
-
-// automationDefinitionYAML resolves def's definition_yaml by rendering
-// automation.MarshalDefinitionYAML from spec_json — spec_yaml storage is
-// gone (see MarshalDefinitionYAML's doc comment), so this is now the only
-// path; every read (the editor's Save-then-reopen, `attn automation show`)
-// gets its YAML re-derived from the canonical spec, comments and all
-// formatting choices not preserved.
-func automationDefinitionYAML(def store.AutomationDefinition) (string, error) {
-	var spec automation.DefinitionSpec
-	if err := json.Unmarshal([]byte(def.SpecJSON), &spec); err != nil {
-		return "", fmt.Errorf("parse stored definition %s: %w", def.ID, err)
-	}
-	rendered, err := automation.MarshalDefinitionYAML(spec)
-	if err != nil {
-		return "", fmt.Errorf("render definition %s: %w", def.ID, err)
-	}
-	return string(rendered), nil
-}
-
-// buildAutomationDefinitionSummary extracts the compact WS fields from a
-// definition's SpecJSON. An unmarshal failure (should not happen for a
-// definition that passed automationApply's validation, but is not assumed)
-// degrades to an id/name/enabled-only summary rather than dropping the
-// definition from the list.
-func (d *Daemon) buildAutomationDefinitionSummary(def store.AutomationDefinition) protocol.AutomationDefinitionSummary {
-	summary := protocol.AutomationDefinitionSummary{
-		ID:        def.ID,
-		Name:      def.Name,
-		Enabled:   def.Enabled,
-		Revision:  def.Revision,
-		UpdatedAt: string(protocol.NewTimestamp(def.UpdatedAt)),
-	}
-	var spec automation.DefinitionSpec
-	if err := json.Unmarshal([]byte(def.SpecJSON), &spec); err != nil {
-		d.logf("automation definition summary parse %s: %v", def.ID, err)
-		return summary
-	}
-	summary.TriggerType = spec.Trigger.Type
-	if spec.Trigger.Schedule != nil {
-		summary.ScheduleCron = protocol.Ptr(spec.Trigger.Schedule.Cron)
-		summary.ScheduleTimeZone = protocol.Ptr(spec.Trigger.Schedule.TimeZone)
-	}
-	continuity, catchUp := automation.ResolvedTriggerPolicy(spec)
-	summary.Continuity = protocol.Ptr(continuity)
-	summary.CatchUp = protocol.Ptr(catchUp)
-	return summary
-}
-
-func automationRunSummary(run store.AutomationRunWithOccurrenceKey) protocol.AutomationRunSummary {
-	summary := protocol.AutomationRunSummary{
-		ID:                 run.ID,
-		DefinitionID:       run.DefinitionID,
-		DefinitionRevision: run.DefinitionRevision,
-		State:              run.State,
-		TicketID:           protocol.Ptr(run.TicketID),
-		SessionID:          protocol.Ptr(run.SessionID),
-		WorkspaceID:        protocol.Ptr(run.WorkspaceID),
-		PaneID:             protocol.Ptr(run.PaneID),
-		CreatedAt:          string(protocol.NewTimestamp(run.CreatedAt)),
-		UpdatedAt:          string(protocol.NewTimestamp(run.UpdatedAt)),
-		OccurrenceKey:      protocol.Ptr(run.OccurrenceKey),
-	}
-	if run.LastError != "" {
-		summary.LastError = protocol.Ptr(run.LastError)
-	}
-	if run.DeliveredAt != nil {
-		summary.DeliveredAt = protocol.Ptr(string(protocol.NewTimestamp(*run.DeliveredAt)))
-	}
-	return summary
 }

--- a/internal/daemon/ws_automations_test.go
+++ b/internal/daemon/ws_automations_test.go
@@ -33,7 +33,7 @@ func TestAutomationDefinitionsGetWSResultCorrelatesRequest(t *testing.T) {
 		RequestID: protocol.Ptr("defs-1"),
 	})
 
-	var res protocol.AutomationActionResultMessage
+	var res protocol.AutomationDefinitionsResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	if !res.Success || res.RequestID == nil || *res.RequestID != "defs-1" {
 		t.Fatalf("definitions_get result = %+v, want success for defs-1", res)
@@ -72,7 +72,7 @@ func TestAutomationRunsGetWSResultCorrelatesRequest(t *testing.T) {
 		RequestID:    protocol.Ptr("runs-1"),
 	})
 
-	var res protocol.AutomationActionResultMessage
+	var res protocol.AutomationRunsResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	if !res.Success || res.RequestID == nil || *res.RequestID != "runs-1" {
 		t.Fatalf("runs_get result = %+v, want success for runs-1", res)
@@ -117,7 +117,7 @@ func TestAutomationRunsGetWSResultTruncatesAtCap(t *testing.T) {
 		RequestID:    protocol.Ptr("runs-cap"),
 	})
 
-	var res protocol.AutomationActionResultMessage
+	var res protocol.AutomationRunsResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	if !res.Success {
 		t.Fatalf("runs_get result = %+v, want success", res)
@@ -150,13 +150,13 @@ func TestAutomationSetEnabledWSResultCorrelatesRequest(t *testing.T) {
 		RequestID:    protocol.Ptr("set-1"),
 	})
 
-	var res protocol.AutomationActionResultMessage
+	var res protocol.AutomationSetEnabledResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	if !res.Success || res.RequestID == nil || *res.RequestID != "set-1" {
 		t.Fatalf("set_enabled result = %+v, want success for set-1", res)
 	}
-	if len(res.Definitions) != 1 || res.Definitions[0].Enabled {
-		t.Fatalf("set_enabled definitions = %+v, want one disabled summary", res.Definitions)
+	if res.Definition == nil || res.Definition.Enabled {
+		t.Fatalf("set_enabled definition = %+v, want a disabled summary", res.Definition)
 	}
 
 	// Unknown definition surfaces as success=false with an error, not a
@@ -168,7 +168,7 @@ func TestAutomationSetEnabledWSResultCorrelatesRequest(t *testing.T) {
 		Enabled:      true,
 		RequestID:    protocol.Ptr("set-2"),
 	})
-	var errRes protocol.AutomationActionResultMessage
+	var errRes protocol.AutomationSetEnabledResultMessage
 	readNotebookWSEvent(t, client2.send, &errRes)
 	if errRes.Success || errRes.Error == nil {
 		t.Fatalf("set_enabled unknown definition result = %+v, want success=false with error", errRes)
@@ -196,7 +196,7 @@ func TestAutomationDeleteWSResultCorrelatesRequest(t *testing.T) {
 		RequestID:    protocol.Ptr("delete-1"),
 	})
 
-	var res protocol.AutomationActionResultMessage
+	var res protocol.AutomationDeleteResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	if !res.Success || res.RequestID == nil || *res.RequestID != "delete-1" {
 		t.Fatalf("delete result = %+v, want success for delete-1", res)
@@ -214,7 +214,7 @@ func TestAutomationDeleteWSResultCorrelatesRequest(t *testing.T) {
 		DefinitionID: "does-not-exist",
 		RequestID:    protocol.Ptr("delete-2"),
 	})
-	var errRes protocol.AutomationActionResultMessage
+	var errRes protocol.AutomationDeleteResultMessage
 	readNotebookWSEvent(t, client2.send, &errRes)
 	if errRes.Success || errRes.Error == nil {
 		t.Fatalf("delete unknown definition result = %+v, want success=false with error", errRes)
@@ -253,7 +253,7 @@ func TestAutomationCleanupWSResultCorrelatesRequest(t *testing.T) {
 		RequestID:    protocol.Ptr("cleanup-1"),
 	})
 
-	var res protocol.AutomationActionResultMessage
+	var res protocol.AutomationCleanupResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	if !res.Success || res.RequestID == nil || *res.RequestID != "cleanup-1" {
 		t.Fatalf("cleanup result = %+v, want success for cleanup-1", res)
@@ -276,7 +276,7 @@ func TestAutomationCleanupWSResultCorrelatesRequest(t *testing.T) {
 		DefinitionID: "does-not-exist",
 		RequestID:    protocol.Ptr("cleanup-2"),
 	})
-	var errRes protocol.AutomationActionResultMessage
+	var errRes protocol.AutomationCleanupResultMessage
 	readNotebookWSEvent(t, client2.send, &errRes)
 	if errRes.Success || errRes.Error == nil {
 		t.Fatalf("cleanup unknown definition result = %+v, want success=false with error", errRes)
@@ -314,16 +314,16 @@ func TestAutomationRunWSResultCorrelatesRequest(t *testing.T) {
 		RequestID:    "request-1",
 	})
 
-	var res protocol.AutomationActionResultMessage
+	var res protocol.AutomationRunResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	if !res.Success || res.RequestID == nil || *res.RequestID != "request-1" {
 		t.Fatalf("run result = %+v, want success for request-1", res)
 	}
-	if res.RunID == nil || *res.RunID != run.ID {
-		t.Fatalf("run result run_id = %v, want %s", res.RunID, run.ID)
+	if res.Run == nil || res.Run.ID != run.ID {
+		t.Fatalf("run result run = %+v, want %s", res.Run, run.ID)
 	}
-	if res.TicketID == nil || *res.TicketID != run.TicketID || res.SessionID == nil || *res.SessionID != run.SessionID {
-		t.Fatalf("run result ticket/session = %+v, want %s/%s", res, run.TicketID, run.SessionID)
+	if res.Run.TicketID == nil || *res.Run.TicketID != run.TicketID || res.Run.SessionID == nil || *res.Run.SessionID != run.SessionID {
+		t.Fatalf("run result ticket/session = %+v, want %s/%s", res.Run, run.TicketID, run.SessionID)
 	}
 }
 
@@ -341,7 +341,7 @@ func TestAutomationRunWSRejectsNonManualTrigger(t *testing.T) {
 		RequestID:    "request-1",
 	})
 
-	var res protocol.AutomationActionResultMessage
+	var res protocol.AutomationRunResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	if res.Success || res.Error == nil || !strings.Contains(*res.Error, "cannot be run manually") {
 		t.Fatalf("run result = %+v, want success=false with a manual-trigger rejection", res)
@@ -369,7 +369,7 @@ func TestAutomationRunWSMutualExclusion(t *testing.T) {
 		InputJson:    protocol.Ptr(`{}`),
 	})
 
-	var res protocol.AutomationActionResultMessage
+	var res protocol.AutomationRunResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	if res.Success || res.Error == nil || !strings.Contains(*res.Error, "mutually exclusive") {
 		t.Fatalf("run result = %+v, want success=false mutual-exclusion error", res)
@@ -400,7 +400,7 @@ func TestAutomationRunWSRoutesPRURL(t *testing.T) {
 		PRURL:        protocol.Ptr("https://github.com/owner/repo/pull/1"),
 	})
 
-	var res protocol.AutomationActionResultMessage
+	var res protocol.AutomationRunResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	if res.Success || res.Error == nil {
 		t.Fatalf("run result = %+v, want success=false (pr_url routed to the pull-request path)", res)
@@ -492,7 +492,7 @@ location: {type: directory, path: "%s"}
 				DefinitionYaml: raw,
 				RequestID:      protocol.Ptr("validate"),
 			})
-			var validateRes protocol.AutomationActionResultMessage
+			var validateRes protocol.AutomationValidateResultMessage
 			readNotebookWSEvent(t, validateClient.send, &validateRes)
 
 			applyClient := &wsClient{send: make(chan outboundMessage, 4)}
@@ -501,7 +501,7 @@ location: {type: directory, path: "%s"}
 				DefinitionYaml: raw,
 				RequestID:      protocol.Ptr("apply"),
 			})
-			var applyRes protocol.AutomationActionResultMessage
+			var applyRes protocol.AutomationApplyResultMessage
 			readNotebookWSEvent(t, applyClient.send, &applyRes)
 
 			if validateRes.Success != applyRes.Success {
@@ -528,6 +528,42 @@ location: {type: directory, path: "%s"}
 // must refuse an apply whose YAML id differs rather than silently upserting
 // a second definition and leaving the original (still enabled, still
 // running) untouched — see automationApplyWithGuards's doc comment.
+// TestAutomationCommandApplyOverSocketIsUnguarded pins the other half of the
+// apply unification: the socket/CLI path (attn automation apply) never sets
+// expected_id/expected_revision, so automationApplyWithGuards must enforce
+// NEITHER check for it — an apply that would be refused as an
+// already-exists collision over WS (TestAutomationApplyWSRefusesCreateOverLiveDefinition,
+// which explicitly sends expected_revision: 0) must instead succeed and
+// overwrite in place when dispatched with no guard fields at all, exactly as
+// the old unconditional automationApply did before this unification.
+func TestAutomationCommandApplyOverSocketIsUnguarded(t *testing.T) {
+	s := store.New()
+	d := &Daemon{store: s, wsHub: newWSHub()}
+	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
+	original, err := d.automationApply(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	colliding := strings.Replace(raw, "Check locally.", "Something else entirely.", 1)
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	go d.handleAutomationCommand(serverConn, protocol.CmdAutomationApply,
+		&protocol.AutomationApplyMessage{Cmd: protocol.CmdAutomationApply, DefinitionYaml: colliding})
+
+	var res protocol.AutomationApplyResultMessage
+	if err := json.NewDecoder(clientConn).Decode(&res); err != nil {
+		t.Fatal(err)
+	}
+	if !res.Success {
+		t.Fatalf("socket apply result = %+v, want success (unguarded last-writer-wins)", res)
+	}
+	overwritten, err := s.GetAutomationDefinition(original.ID)
+	if err != nil || overwritten == nil || !strings.Contains(overwritten.SpecJSON, "Something else entirely.") {
+		t.Fatalf("definition after unguarded socket apply = %#v err=%v, want the new content live", overwritten, err)
+	}
+}
+
 func TestAutomationApplyWSRefusesIDMismatch(t *testing.T) {
 	s := store.New()
 	d := &Daemon{store: s, wsHub: newWSHub()}
@@ -547,7 +583,7 @@ func TestAutomationApplyWSRefusesIDMismatch(t *testing.T) {
 		RequestID:        protocol.Ptr("apply-id-mismatch"),
 	})
 
-	var res protocol.AutomationActionResultMessage
+	var res protocol.AutomationApplyResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	if res.Success || res.Error == nil || !strings.Contains(*res.Error, "does not match the definition being edited") {
 		t.Fatalf("apply result = %+v, want success=false with an id-mismatch error", res)
@@ -580,17 +616,19 @@ func TestAutomationApplyWSRefusesCreateOverLiveDefinition(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create (no expected_id, no expected_revision) carrying the same id but
-	// entirely different content.
+	// Create (no expected_id, expected_revision explicitly 0 — matching what
+	// the real editor always sends for a not-yet-saved definition) carrying
+	// the same id but entirely different content.
 	colliding := strings.Replace(raw, "Check locally.", "Something else entirely.", 1)
 	client := &wsClient{send: make(chan outboundMessage, 4)}
 	d.handleAutomationApplyWS(client, &protocol.AutomationApplyMessage{
-		Cmd:            protocol.CmdAutomationApply,
-		DefinitionYaml: colliding,
-		RequestID:      protocol.Ptr("apply-create-collision"),
+		Cmd:              protocol.CmdAutomationApply,
+		DefinitionYaml:   colliding,
+		ExpectedRevision: protocol.Ptr(0),
+		RequestID:        protocol.Ptr("apply-create-collision"),
 	})
 
-	var res protocol.AutomationActionResultMessage
+	var res protocol.AutomationApplyResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	if res.Success || res.Error == nil || !strings.Contains(*res.Error, "already exists") {
 		t.Fatalf("apply result = %+v, want success=false with an already-exists error", res)
@@ -610,11 +648,12 @@ func TestAutomationApplyWSRefusesCreateOverLiveDefinition(t *testing.T) {
 	}
 	resurrectClient := &wsClient{send: make(chan outboundMessage, 4)}
 	d.handleAutomationApplyWS(resurrectClient, &protocol.AutomationApplyMessage{
-		Cmd:            protocol.CmdAutomationApply,
-		DefinitionYaml: colliding,
-		RequestID:      protocol.Ptr("apply-create-resurrect"),
+		Cmd:              protocol.CmdAutomationApply,
+		DefinitionYaml:   colliding,
+		ExpectedRevision: protocol.Ptr(0),
+		RequestID:        protocol.Ptr("apply-create-resurrect"),
 	})
-	var resurrectRes protocol.AutomationActionResultMessage
+	var resurrectRes protocol.AutomationApplyResultMessage
 	readNotebookWSEvent(t, resurrectClient.send, &resurrectRes)
 	if !resurrectRes.Success {
 		t.Fatalf("resurrect apply result = %+v, want success", resurrectRes)
@@ -654,7 +693,7 @@ func TestAutomationApplyWSRefusesStaleRevision(t *testing.T) {
 		RequestID:        protocol.Ptr("apply-stale-revision"),
 	})
 
-	var res protocol.AutomationActionResultMessage
+	var res protocol.AutomationApplyResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	if res.Success || res.Error == nil || !strings.Contains(*res.Error, "changed elsewhere") {
 		t.Fatalf("apply result = %+v, want success=false with a changed-elsewhere error", res)
@@ -700,7 +739,7 @@ func TestAutomationApplyWSRefusesEditOfDeletedDefinition(t *testing.T) {
 		RequestID:        protocol.Ptr("apply-edit-deleted"),
 	})
 
-	var res protocol.AutomationActionResultMessage
+	var res protocol.AutomationApplyResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	if res.Success || res.Error == nil || !strings.Contains(*res.Error, "deleted") || !strings.Contains(*res.Error, "New") {
 		t.Fatalf("apply result = %+v, want success=false with an error naming the deletion and pointing at New", res)
@@ -733,13 +772,15 @@ func TestAutomationDefinitionGetWSStarterTemplate(t *testing.T) {
 		RequestID:    protocol.Ptr("get-starter"),
 	})
 
-	var res protocol.AutomationActionResultMessage
+	var res protocol.AutomationDefinitionResultMessage
 	readNotebookWSEvent(t, client.send, &res)
-	if !res.Success || res.SpecYaml == nil || res.Revision == nil {
-		t.Fatalf("definition_get(\"\") result = %+v, want success with spec_yaml and revision set", res)
+	if !res.Success || res.SpecYaml == nil {
+		t.Fatalf("definition_get(\"\") result = %+v, want success with spec_yaml set", res)
 	}
-	if *res.Revision != 0 {
-		t.Fatalf("starter template revision = %d, want 0", *res.Revision)
+	// No definition means revision 0 / new — the client treats an absent
+	// definition as the create case (see the design's D7).
+	if res.Definition != nil {
+		t.Fatalf("starter template result definition = %+v, want absent (new-definition case)", res.Definition)
 	}
 	if !strings.Contains(*res.SpecYaml, "id: my-automation") {
 		t.Fatalf("starter template spec_yaml = %q, want the StarterDefinition placeholder", *res.SpecYaml)
@@ -761,7 +802,7 @@ func TestAutomationDefinitionGetWSUnknownID(t *testing.T) {
 		RequestID:    protocol.Ptr("get-missing"),
 	})
 
-	var res protocol.AutomationActionResultMessage
+	var res protocol.AutomationDefinitionResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	if res.Success || res.Error == nil {
 		t.Fatalf("definition_get(unknown) result = %+v, want success=false with an error", res)
@@ -793,9 +834,9 @@ func TestAutomationDefinitionGetWSAfterToggleDerivesFromSpecJSON(t *testing.T) {
 		Enabled:      false,
 		RequestID:    protocol.Ptr("toggle-off"),
 	})
-	var setRes protocol.AutomationActionResultMessage
+	var setRes protocol.AutomationSetEnabledResultMessage
 	readNotebookWSEvent(t, setClient.send, &setRes)
-	if !setRes.Success || len(setRes.Definitions) != 1 || setRes.Definitions[0].Enabled {
+	if !setRes.Success || setRes.Definition == nil || setRes.Definition.Enabled {
 		t.Fatalf("set_enabled result = %+v, want a disabled summary", setRes)
 	}
 
@@ -805,10 +846,10 @@ func TestAutomationDefinitionGetWSAfterToggleDerivesFromSpecJSON(t *testing.T) {
 		DefinitionID: def.ID,
 		RequestID:    protocol.Ptr("get-after-toggle"),
 	})
-	var getRes protocol.AutomationActionResultMessage
+	var getRes protocol.AutomationDefinitionResultMessage
 	readNotebookWSEvent(t, getClient.send, &getRes)
-	if !getRes.Success || getRes.SpecYaml == nil {
-		t.Fatalf("definition_get after toggle = %+v, want success with spec_yaml", getRes)
+	if !getRes.Success || getRes.SpecYaml == nil || getRes.Definition == nil {
+		t.Fatalf("definition_get after toggle = %+v, want success with spec_yaml and definition set", getRes)
 	}
 	fetched := *getRes.SpecYaml
 	if strings.Contains(fetched, "enabled:") {
@@ -820,10 +861,10 @@ func TestAutomationDefinitionGetWSAfterToggleDerivesFromSpecJSON(t *testing.T) {
 		Cmd:              protocol.CmdAutomationApply,
 		DefinitionYaml:   fetched,
 		ExpectedID:       protocol.Ptr(def.ID),
-		ExpectedRevision: getRes.Revision,
+		ExpectedRevision: protocol.Ptr(getRes.Definition.Revision),
 		RequestID:        protocol.Ptr("save-after-get"),
 	})
-	var applyRes protocol.AutomationActionResultMessage
+	var applyRes protocol.AutomationApplyResultMessage
 	readNotebookWSEvent(t, applyClient.send, &applyRes)
 	if !applyRes.Success {
 		t.Fatalf("re-applying the fetched (disabled) yaml failed: %+v", applyRes)
@@ -873,7 +914,7 @@ func TestAutomationSetEnabledWSDeadlineAbortsWithoutMutating(t *testing.T) {
 		RequestID:    protocol.Ptr("set-deadline"),
 	})
 
-	var res protocol.AutomationActionResultMessage
+	var res protocol.AutomationSetEnabledResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	if res.Success || res.Error == nil || !strings.Contains(*res.Error, "deadline exceeded") {
 		t.Fatalf("set_enabled result = %+v, want success=false with a deadline error", res)
@@ -897,7 +938,7 @@ func TestAutomationSetEnabledWSDeadlineAbortsWithoutMutating(t *testing.T) {
 		Enabled:      false,
 		RequestID:    protocol.Ptr("set-after"),
 	})
-	var res2 protocol.AutomationActionResultMessage
+	var res2 protocol.AutomationSetEnabledResultMessage
 	readNotebookWSEvent(t, client2.send, &res2)
 	if !res2.Success {
 		t.Fatalf("set_enabled after lock freed = %+v, want success", res2)
@@ -967,7 +1008,7 @@ func TestAutomationRunWSRetryWithSameRequestIDDoesNotDuplicate(t *testing.T) {
 		RequestID:    "retry-request",
 	})
 
-	var res1, res2 protocol.AutomationActionResultMessage
+	var res1, res2 protocol.AutomationRunResultMessage
 	readNotebookWSEvent(t, client1.send, &res1)
 	readNotebookWSEvent(t, client2.send, &res2)
 	<-released
@@ -975,8 +1016,8 @@ func TestAutomationRunWSRetryWithSameRequestIDDoesNotDuplicate(t *testing.T) {
 	if !res1.Success || !res2.Success {
 		t.Fatalf("run results = %+v / %+v, want both success", res1, res2)
 	}
-	if res1.RunID == nil || res2.RunID == nil || *res1.RunID != run.ID || *res2.RunID != run.ID {
-		t.Fatalf("run ids = %v / %v, want both %s", res1.RunID, res2.RunID, run.ID)
+	if res1.Run == nil || res2.Run == nil || res1.Run.ID != run.ID || res2.Run.ID != run.ID {
+		t.Fatalf("runs = %+v / %+v, want both %s", res1.Run, res2.Run, run.ID)
 	}
 
 	runs, err := s.ListAutomationRuns(def.ID)
@@ -988,14 +1029,13 @@ func TestAutomationRunWSRetryWithSameRequestIDDoesNotDuplicate(t *testing.T) {
 	}
 }
 
-// A validate that passes has no payload to report, and the CLI's success
-// output depends on that absence being visible on the wire. json.Marshal of a
-// nil `any` yields the 4-byte literal `null` rather than an empty slice, which
-// defeats `json:"data,omitempty"` and leaves the client decoding a non-nil
-// json.RawMessage — so `attn automation validate` printed `null` instead of
-// {"valid": true}. Pinned here on the encoded bytes, because the bug lives in
-// the encoding and a decoded struct hides it.
-func TestAutomationCommandOmitsDataWhenActionHasNoPayload(t *testing.T) {
+// TestAutomationCommandValidateHasNoPayload pins automation_validate's
+// socket-transport result shape: success with no payload fields at all —
+// there is no generic `data` wrapper in the per-action typed-result design
+// (each action returns its own concrete result message directly), so a
+// payload-free action like validate simply has nothing beyond
+// event/success/request_id on the wire.
+func TestAutomationCommandValidateHasNoPayload(t *testing.T) {
 	s := store.New()
 	d := &Daemon{store: s, wsHub: newWSHub()}
 	raw := fmt.Sprintf(manualAutomationYAML, t.TempDir())
@@ -1005,15 +1045,12 @@ func TestAutomationCommandOmitsDataWhenActionHasNoPayload(t *testing.T) {
 	go d.handleAutomationCommand(serverConn, protocol.CmdAutomationValidate,
 		&protocol.AutomationValidateMessage{Cmd: protocol.CmdAutomationValidate, DefinitionYaml: raw})
 
-	var encoded map[string]any
-	if err := json.NewDecoder(clientConn).Decode(&encoded); err != nil {
+	var res protocol.AutomationValidateResultMessage
+	if err := json.NewDecoder(clientConn).Decode(&res); err != nil {
 		t.Fatal(err)
 	}
-	if success, _ := encoded["success"].(bool); !success {
-		t.Fatalf("validate did not succeed: %+v", encoded)
-	}
-	if _, present := encoded["data"]; present {
-		t.Fatalf("a payload-free action put %v on the wire under \"data\"; it must be omitted entirely so the client can tell \"no payload\" from \"payload that is null\"", encoded["data"])
+	if !res.Success || res.Error != nil {
+		t.Fatalf("validate result = %+v, want success with no error", res)
 	}
 }
 
@@ -1057,27 +1094,27 @@ func TestAutomationCommandSetEnabledTogglesColumn(t *testing.T) {
 	}
 }
 
-// The sibling of the case above, pinned so the omitempty guard is not later
-// "simplified" into dropping null payloads generally. GetAutomationDefinition
-// returns a typed nil *store.AutomationDefinition, and assigning that to an
-// `any` produces a NON-nil interface, so show still marshals to null and its
-// output is unchanged. That distinction is the entire reason the guard is
-// written as a nil check on the interface rather than on the encoded bytes.
-func TestAutomationCommandStillReportsNullForMissingDefinition(t *testing.T) {
+// TestAutomationCommandDefinitionGetMissingDefinitionOverSocket is the
+// unix-socket-transport sibling of TestAutomationDefinitionGetWSUnknownID:
+// automation_definition_get for an unknown, non-empty id must surface as
+// success=false with an error over the raw socket dispatch
+// (handleAutomationCommand), the same business-failure shape WS gets — not a
+// transport failure, and not the old generic "data: null" wire quirk (which
+// the typed-per-action-result design no longer has a way to express).
+func TestAutomationCommandDefinitionGetMissingDefinitionOverSocket(t *testing.T) {
 	s := store.New()
 	d := &Daemon{store: s, wsHub: newWSHub()}
 
 	clientConn, serverConn := net.Pipe()
 	defer clientConn.Close()
-	go d.handleAutomationCommand(serverConn, protocol.CmdAutomationShow,
-		&protocol.AutomationShowMessage{Cmd: protocol.CmdAutomationShow, DefinitionID: "no-such-definition"})
+	go d.handleAutomationCommand(serverConn, protocol.CmdAutomationDefinitionGet,
+		&protocol.AutomationDefinitionGetMessage{Cmd: protocol.CmdAutomationDefinitionGet, DefinitionID: "no-such-definition"})
 
-	var encoded map[string]any
-	if err := json.NewDecoder(clientConn).Decode(&encoded); err != nil {
+	var res protocol.AutomationDefinitionResultMessage
+	if err := json.NewDecoder(clientConn).Decode(&res); err != nil {
 		t.Fatal(err)
 	}
-	value, present := encoded["data"]
-	if !present || value != nil {
-		t.Fatalf("show of a missing definition = %+v, want an explicit null data field", encoded)
+	if res.Success || res.Error == nil {
+		t.Fatalf("definition_get(missing) over socket = %+v, want success=false with an error", res)
 	}
 }

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "180"
+const ProtocolVersion = "181"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -159,10 +159,7 @@ const (
 	CmdWorkflowRunList                       = "workflow_run_list"
 	CmdWorkflowRunCancel                     = "workflow_run_cancel"
 	CmdAutomationApply                       = "automation_apply"
-	CmdAutomationList                        = "automation_list"
-	CmdAutomationShow                        = "automation_show"
 	CmdAutomationRun                         = "automation_run"
-	CmdAutomationRunList                     = "automation_run_list"
 	CmdAutomationDefinitionsGet              = "automation_definitions_get"
 	CmdAutomationDefinitionGet               = "automation_definition_get"
 	CmdAutomationRunsGet                     = "automation_runs_get"
@@ -207,7 +204,19 @@ const (
 	CmdSetChiefOfStaff                       = "set_chief_of_staff"
 )
 
-const EventAutomationActionResult = "automation_action_result"
+// Per-action automations result events (socket + WS share one command set;
+// see the Cmd constants above and internal/daemon/automations_actions.go).
+const (
+	EventAutomationApplyResult       = "automation_apply_result"
+	EventAutomationValidateResult    = "automation_validate_result"
+	EventAutomationDefinitionsResult = "automation_definitions_result"
+	EventAutomationDefinitionResult  = "automation_definition_result"
+	EventAutomationRunsResult        = "automation_runs_result"
+	EventAutomationRunResult         = "automation_run_result"
+	EventAutomationSetEnabledResult  = "automation_set_enabled_result"
+	EventAutomationDeleteResult      = "automation_delete_result"
+	EventAutomationCleanupResult     = "automation_cleanup_result"
+)
 
 // EventAutomationsChanged is the id-only automations broadcast: canonical state
 // stays in SQLite, so clients re-read via automation_definitions_get /
@@ -423,26 +432,8 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 			return "", nil, err
 		}
 		return peek.Cmd, &msg, nil
-	case CmdAutomationList:
-		var msg AutomationListMessage
-		if err := json.Unmarshal(data, &msg); err != nil {
-			return "", nil, err
-		}
-		return peek.Cmd, &msg, nil
-	case CmdAutomationShow:
-		var msg AutomationShowMessage
-		if err := json.Unmarshal(data, &msg); err != nil {
-			return "", nil, err
-		}
-		return peek.Cmd, &msg, nil
 	case CmdAutomationRun:
 		var msg AutomationRunMessage
-		if err := json.Unmarshal(data, &msg); err != nil {
-			return "", nil, err
-		}
-		return peek.Cmd, &msg, nil
-	case CmdAutomationRunList:
-		var msg AutomationRunListMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -119,56 +119,6 @@ type AuthorsUpdatedMessage struct {
 	Event string `json:"event"`
 }
 
-type AutomationActionResultMessage struct {
-	// Action corresponds to the JSON schema field "action".
-	Action string `json:"action"`
-
-	// Cleaned corresponds to the JSON schema field "cleaned".
-	Cleaned []string `json:"cleaned,omitempty,omitzero"`
-
-	// Definitions corresponds to the JSON schema field "definitions".
-	Definitions []AutomationDefinitionSummary `json:"definitions,omitempty,omitzero"`
-
-	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty,omitzero"`
-
-	// Event corresponds to the JSON schema field "event".
-	Event string `json:"event"`
-
-	// KeptActive corresponds to the JSON schema field "kept_active".
-	KeptActive []string `json:"kept_active,omitempty,omitzero"`
-
-	// KeptDirty corresponds to the JSON schema field "kept_dirty".
-	KeptDirty []string `json:"kept_dirty,omitempty,omitzero"`
-
-	// RequestID corresponds to the JSON schema field "request_id".
-	RequestID *string `json:"request_id,omitempty,omitzero"`
-
-	// Revision corresponds to the JSON schema field "revision".
-	Revision *int `json:"revision,omitempty,omitzero"`
-
-	// RunID corresponds to the JSON schema field "run_id".
-	RunID *string `json:"run_id,omitempty,omitzero"`
-
-	// Runs corresponds to the JSON schema field "runs".
-	Runs []AutomationRunSummary `json:"runs,omitempty,omitzero"`
-
-	// SessionID corresponds to the JSON schema field "session_id".
-	SessionID *string `json:"session_id,omitempty,omitzero"`
-
-	// SpecYaml corresponds to the JSON schema field "spec_yaml".
-	SpecYaml *string `json:"spec_yaml,omitempty,omitzero"`
-
-	// Success corresponds to the JSON schema field "success".
-	Success bool `json:"success"`
-
-	// TicketID corresponds to the JSON schema field "ticket_id".
-	TicketID *string `json:"ticket_id,omitempty,omitzero"`
-
-	// Truncated corresponds to the JSON schema field "truncated".
-	Truncated *bool `json:"truncated,omitempty,omitzero"`
-}
-
 type AutomationApplyMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -186,6 +136,26 @@ type AutomationApplyMessage struct {
 	RequestID *string `json:"request_id,omitempty,omitzero"`
 }
 
+type AutomationApplyResultMessage struct {
+	// Definition corresponds to the JSON schema field "definition".
+	Definition *AutomationDefinitionSummary `json:"definition,omitempty,omitzero"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// SpecYaml corresponds to the JSON schema field "spec_yaml".
+	SpecYaml *string `json:"spec_yaml,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
 type AutomationCleanupMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -195,6 +165,29 @@ type AutomationCleanupMessage struct {
 
 	// RequestID corresponds to the JSON schema field "request_id".
 	RequestID *string `json:"request_id,omitempty,omitzero"`
+}
+
+type AutomationCleanupResultMessage struct {
+	// Cleaned corresponds to the JSON schema field "cleaned".
+	Cleaned []string `json:"cleaned,omitempty,omitzero"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// KeptActive corresponds to the JSON schema field "kept_active".
+	KeptActive []string `json:"kept_active,omitempty,omitzero"`
+
+	// KeptDirty corresponds to the JSON schema field "kept_dirty".
+	KeptDirty []string `json:"kept_dirty,omitempty,omitzero"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
 }
 
 type AutomationDefinitionGetMessage struct {
@@ -208,18 +201,35 @@ type AutomationDefinitionGetMessage struct {
 	RequestID *string `json:"request_id,omitempty,omitzero"`
 }
 
+type AutomationDefinitionResultMessage struct {
+	// Definition corresponds to the JSON schema field "definition".
+	Definition *AutomationDefinitionSummary `json:"definition,omitempty,omitzero"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// SpecYaml corresponds to the JSON schema field "spec_yaml".
+	SpecYaml *string `json:"spec_yaml,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
 type AutomationDefinitionSummary struct {
-	// CatchUp corresponds to the JSON schema field "catch_up".
-	CatchUp *string `json:"catch_up,omitempty,omitzero"`
-
-	// Continuity corresponds to the JSON schema field "continuity".
-	Continuity *string `json:"continuity,omitempty,omitzero"`
-
 	// Enabled corresponds to the JSON schema field "enabled".
 	Enabled bool `json:"enabled"`
 
 	// ID corresponds to the JSON schema field "id".
 	ID string `json:"id"`
+
+	// LastRun corresponds to the JSON schema field "last_run".
+	LastRun *AutomationRunSummary `json:"last_run,omitempty,omitzero"`
 
 	// Name corresponds to the JSON schema field "name".
 	Name string `json:"name"`
@@ -248,6 +258,23 @@ type AutomationDefinitionsGetMessage struct {
 	RequestID *string `json:"request_id,omitempty,omitzero"`
 }
 
+type AutomationDefinitionsResultMessage struct {
+	// Definitions corresponds to the JSON schema field "definitions".
+	Definitions []AutomationDefinitionSummary `json:"definitions,omitempty,omitzero"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
 type AutomationDeleteMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -259,17 +286,18 @@ type AutomationDeleteMessage struct {
 	RequestID *string `json:"request_id,omitempty,omitzero"`
 }
 
-type AutomationListMessage struct {
-	// Cmd corresponds to the JSON schema field "cmd".
-	Cmd string `json:"cmd"`
-}
+type AutomationDeleteResultMessage struct {
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
 
-type AutomationRunListMessage struct {
-	// Cmd corresponds to the JSON schema field "cmd".
-	Cmd string `json:"cmd"`
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
 
-	// DefinitionID corresponds to the JSON schema field "definition_id".
-	DefinitionID string `json:"definition_id"`
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
 }
 
 type AutomationRunMessage struct {
@@ -289,15 +317,32 @@ type AutomationRunMessage struct {
 	RequestID string `json:"request_id"`
 }
 
+type AutomationRunResultMessage struct {
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// Run corresponds to the JSON schema field "run".
+	Run *AutomationRunSummary `json:"run,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
 type AutomationRunSummary struct {
+	// CancelReason corresponds to the JSON schema field "cancel_reason".
+	CancelReason *string `json:"cancel_reason,omitempty,omitzero"`
+
 	// CreatedAt corresponds to the JSON schema field "created_at".
 	CreatedAt string `json:"created_at"`
 
 	// DefinitionID corresponds to the JSON schema field "definition_id".
 	DefinitionID string `json:"definition_id"`
-
-	// DefinitionRevision corresponds to the JSON schema field "definition_revision".
-	DefinitionRevision int `json:"definition_revision"`
 
 	// DeliveredAt corresponds to the JSON schema field "delivered_at".
 	DeliveredAt *string `json:"delivered_at,omitempty,omitzero"`
@@ -325,9 +370,6 @@ type AutomationRunSummary struct {
 
 	// UpdatedAt corresponds to the JSON schema field "updated_at".
 	UpdatedAt string `json:"updated_at"`
-
-	// WorkspaceID corresponds to the JSON schema field "workspace_id".
-	WorkspaceID *string `json:"workspace_id,omitempty,omitzero"`
 }
 
 type AutomationRunsGetMessage struct {
@@ -339,6 +381,29 @@ type AutomationRunsGetMessage struct {
 
 	// RequestID corresponds to the JSON schema field "request_id".
 	RequestID *string `json:"request_id,omitempty,omitzero"`
+}
+
+type AutomationRunsResultMessage struct {
+	// DefinitionID corresponds to the JSON schema field "definition_id".
+	DefinitionID string `json:"definition_id"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// Runs corresponds to the JSON schema field "runs".
+	Runs []AutomationRunSummary `json:"runs,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+
+	// Truncated corresponds to the JSON schema field "truncated".
+	Truncated *bool `json:"truncated,omitempty,omitzero"`
 }
 
 type AutomationSetEnabledMessage struct {
@@ -355,12 +420,21 @@ type AutomationSetEnabledMessage struct {
 	RequestID *string `json:"request_id,omitempty,omitzero"`
 }
 
-type AutomationShowMessage struct {
-	// Cmd corresponds to the JSON schema field "cmd".
-	Cmd string `json:"cmd"`
+type AutomationSetEnabledResultMessage struct {
+	// Definition corresponds to the JSON schema field "definition".
+	Definition *AutomationDefinitionSummary `json:"definition,omitempty,omitzero"`
 
-	// DefinitionID corresponds to the JSON schema field "definition_id".
-	DefinitionID string `json:"definition_id"`
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
 }
 
 type AutomationValidateMessage struct {
@@ -372,6 +446,20 @@ type AutomationValidateMessage struct {
 
 	// RequestID corresponds to the JSON schema field "request_id".
 	RequestID *string `json:"request_id,omitempty,omitzero"`
+}
+
+type AutomationValidateResultMessage struct {
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
 }
 
 type AutomationsChangedMessage struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -1587,17 +1587,14 @@ model AutomationApplyMessage {
   expected_id?: string;
   expected_revision?: int32;
 }
-model AutomationListMessage { cmd: "automation_list"; }
-model AutomationShowMessage { cmd: "automation_show"; definition_id: string; }
 model AutomationRunMessage { cmd: "automation_run"; definition_id: string; request_id: string; input_json?: string; pr_url?: string; }
-model AutomationRunListMessage { cmd: "automation_run_list"; definition_id: string; }
 
 // Dual-surface (unix-socket `attn automation validate` + WS "Validate"
 // button): runs exactly the checks automation_apply runs before persisting
 // (Daemon.validateAutomationSpec) without writing anything. Deliberately not
-// just a thinner call to ParseDefinitionYAML — see the
-// AutomationActionResultMessage doc comment below for why a validate that
-// skipped one of apply's checks would actively lie to the user.
+// just a thinner call to ParseDefinitionYAML — see AutomationValidateResultMessage
+// below for why a validate that skipped one of apply's checks would actively
+// lie to the user.
 model AutomationValidateMessage {
   cmd: "automation_validate";
   definition_yaml: string;
@@ -1616,7 +1613,7 @@ model AutomationDeleteMessage {
 
 // Same dual-surface shape as automation_delete above. Unlike delete, cleanup
 // is disk-only (worktrees only; never rows or artifacts) and repeatable —
-// see AutomationActionResultMessage's cleaned/kept_dirty/kept_active fields.
+// see AutomationCleanupResultMessage's cleaned/kept_dirty/kept_active fields.
 model AutomationCleanupMessage {
   cmd: "automation_cleanup";
   definition_id: string;
@@ -2678,8 +2675,10 @@ model WorkflowActionResultMessage {
 
 // Compact automations summaries for the WS surface. Canonical state (full
 // SpecJSON, occurrence payloads, snapshots) stays server-side in SQLite; these
-// carry only what the UI renders. AutomationDefinitionSummary's schedule/policy
-// fields are extracted daemon-side from the definition's SpecJSON.
+// carry only what the UI renders. AutomationDefinitionSummary's schedule
+// fields are extracted daemon-side from the definition's SpecJSON. last_run is
+// the definition's single most-recent run (Store.LatestAutomationRunPerDefinition),
+// embedded so the panel's list badge never needs a per-definition runs fetch.
 model AutomationDefinitionSummary {
   id: string;
   name: string;
@@ -2688,20 +2687,18 @@ model AutomationDefinitionSummary {
   trigger_type: string;
   schedule_cron?: string;
   schedule_time_zone?: string;
-  continuity?: string;
-  catch_up?: string;
   updated_at: string;
+  last_run?: AutomationRunSummary;
 }
 
 model AutomationRunSummary {
   id: string;
   definition_id: string;
-  definition_revision: int32;
   state: string;
   last_error?: string;
+  cancel_reason?: string;
   ticket_id?: string;
   session_id?: string;
-  workspace_id?: string;
   pane_id?: string;
   created_at: string;
   updated_at: string;
@@ -2709,46 +2706,103 @@ model AutomationRunSummary {
   occurrence_key?: string;
 }
 
-// Result for the WS automations surface (automation_definitions_get,
-// automation_runs_get, automation_set_enabled, automation_run). Distinct from
-// the unix-socket automation_action_result shape used by the CLI/agent path
-// (see internal/daemon/automations.go's automationActionResult and
-// internal/client's AutomationResult, which carry a generic `data` payload
-// instead of these typed fields): the two are not wire-compatible, so the
-// socket path keeps its own struct.
-model AutomationActionResultMessage {
-  event: "automation_action_result";
-  action: string;
+// Per-action result messages for the automations surface (socket + WS share
+// one command set — see the commands above). Each carries the base
+// request_id/success/error triple plus that action's own typed payload,
+// replacing the old shared AutomationActionResultMessage grab-bag and the
+// unix-socket's separate generic-`data` automationActionResult struct: both
+// transports now emit the same typed shape per action.
+
+model AutomationApplyResultMessage {
+  event: "automation_apply_result";
+  request_id?: string;
+  success: boolean;
+  error?: string;
+  definition?: AutomationDefinitionSummary;
+  // spec_yaml: the canonical rendered YAML of the saved spec
+  // (automationDefinitionYAML), not an echo of the input.
+  spec_yaml?: string;
+}
+
+model AutomationValidateResultMessage {
+  event: "automation_validate_result";
+  request_id?: string;
+  success: boolean;
+  error?: string;
+}
+
+model AutomationDefinitionsResultMessage {
+  event: "automation_definitions_result";
   request_id?: string;
   success: boolean;
   error?: string;
   definitions?: AutomationDefinitionSummary[];
+}
+
+// definition_id "" returns the starter template YAML (automation.StarterTemplateYAML)
+// with no definition — the client treats a missing definition as revision 0 /
+// new, so create and edit share one frontend code path.
+model AutomationDefinitionResultMessage {
+  event: "automation_definition_result";
+  request_id?: string;
+  success: boolean;
+  error?: string;
+  definition?: AutomationDefinitionSummary;
+  spec_yaml?: string;
+}
+
+model AutomationRunsResultMessage {
+  event: "automation_runs_result";
+  request_id?: string;
+  success: boolean;
+  error?: string;
+  definition_id: string;
   runs?: AutomationRunSummary[];
   truncated?: boolean;
-  run_id?: string;
-  ticket_id?: string;
-  session_id?: string;
-  // cleaned/kept_dirty/kept_active: automation_cleanup's three-way per-run-id
-  // partition of the terminal runs it examined — cleaned had their worktree
-  // removed; kept_dirty were skipped because the worktree had uncommitted
-  // changes; kept_active were skipped because the run's thread is still in
-  // use (its session is live, or its session id is still referenced by a
-  // continuity binding even though the session row is gone) — a bound
-  // continuity thread shares its worktree with its whole thread, so an old
-  // terminal run's worktree may still be the thread's live working
-  // directory. One bucket for both live-session and bound-thread cases,
-  // deliberately: the user-facing story is identical, "still in use, not
-  // reclaimable" — only the daemon log distinguishes them. All three omitted
-  // (not just empty) when the action isn't automation_cleanup.
+}
+
+model AutomationRunResultMessage {
+  event: "automation_run_result";
+  request_id?: string;
+  success: boolean;
+  error?: string;
+  run?: AutomationRunSummary;
+}
+
+model AutomationSetEnabledResultMessage {
+  event: "automation_set_enabled_result";
+  request_id?: string;
+  success: boolean;
+  error?: string;
+  definition?: AutomationDefinitionSummary;
+}
+
+model AutomationDeleteResultMessage {
+  event: "automation_delete_result";
+  request_id?: string;
+  success: boolean;
+  error?: string;
+}
+
+// cleaned/kept_dirty/kept_active: automation_cleanup's three-way per-run-id
+// partition of the terminal runs it examined — cleaned had their worktree
+// removed; kept_dirty were skipped because the worktree had uncommitted
+// changes; kept_active were skipped because the run's thread is still in use
+// (its session is live, or its session id is still referenced by a
+// continuity binding even though the session row is gone) — a bound
+// continuity thread shares its worktree with its whole thread, so an old
+// terminal run's worktree may still be the thread's live working directory.
+// One bucket for both live-session and bound-thread cases, deliberately: the
+// user-facing story is identical, "still in use, not reclaimable" — only the
+// daemon log distinguishes them.
+model AutomationCleanupResultMessage {
+  event: "automation_cleanup_result";
+  request_id?: string;
+  success: boolean;
+  error?: string;
   cleaned?: string[];
   kept_dirty?: string[];
   kept_active?: string[];
-  // spec_yaml/revision: automation_definition_get's payload — the definition
-  // YAML to show in the editor and the revision it was loaded at (echoed
-  // back as automation_apply's expected_revision). revision 0 with
-  // definition_id "" means the starter template for a brand-new definition.
-  spec_yaml?: string;
-  revision?: int32;
 }
 
 // Compact change signal: canonical state lives in SQLite, so clients re-read
@@ -3507,7 +3561,15 @@ alias DaemonEvent =
   | GetRepoInfoResultMessage
   | WorkflowRunUpdatedMessage
   | WorkflowActionResultMessage
-  | AutomationActionResultMessage
+  | AutomationApplyResultMessage
+  | AutomationValidateResultMessage
+  | AutomationDefinitionsResultMessage
+  | AutomationDefinitionResultMessage
+  | AutomationRunsResultMessage
+  | AutomationRunResultMessage
+  | AutomationSetEnabledResultMessage
+  | AutomationDeleteResultMessage
+  | AutomationCleanupResultMessage
   | AutomationsChangedMessage
   | WorkspaceContextResultMessage
   | WorkspaceContextListResultMessage

--- a/internal/store/automations.go
+++ b/internal/store/automations.go
@@ -1201,6 +1201,49 @@ func (s *Store) ListAutomationRunsWithOccurrenceKeys(definitionID string, limit 
 	return out, rows.Err()
 }
 
+// LatestAutomationRunPerDefinition returns, for every definition that has at
+// least one run, its single most-recent run (by created_at, ties broken by
+// id) paired with its occurrence's occurrence_key — one query, used to embed
+// last_run in the definitions listing instead of the panel issuing one
+// automation_runs_get per definition. A definition with zero runs has no
+// entry in the returned map.
+func (s *Store) LatestAutomationRunPerDefinition() (map[string]AutomationRunWithOccurrenceKey, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.Query(`
+		SELECT ` + automationRunColumnsQualified + `,o.occurrence_key
+		FROM automation_runs r
+		JOIN automation_occurrences o ON o.id=r.occurrence_id
+		WHERE r.id IN (
+			SELECT id FROM (
+				SELECT id, definition_id,
+					ROW_NUMBER() OVER (PARTITION BY definition_id ORDER BY created_at DESC, id DESC) AS rn
+				FROM automation_runs
+			) WHERE rn = 1
+		)
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]AutomationRunWithOccurrenceKey)
+	for rows.Next() {
+		var r AutomationRun
+		var created, updated, delivered, occurrenceKey string
+		if err := rows.Scan(&r.ID, &r.DefinitionID, &r.OccurrenceID, &r.DefinitionRevision, &r.SnapshotJSON, &r.State, &r.CancelReason, &r.Attempts, &r.LastError, &r.TicketID, &r.SessionID, &r.WorkspaceID, &r.PaneID, &r.ResolvedLocationJSON, &created, &updated, &delivered, &occurrenceKey); err != nil {
+			return nil, err
+		}
+		r.CreatedAt = parseTicketTime(created)
+		r.UpdatedAt = parseTicketTime(updated)
+		r.DeliveredAt = parseOptionalAutomationTime(delivered)
+		out[r.DefinitionID] = AutomationRunWithOccurrenceKey{AutomationRun: r, OccurrenceKey: occurrenceKey}
+	}
+	return out, rows.Err()
+}
+
 func (s *Store) ListPendingAutomationRuns() ([]AutomationRun, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/store/automations_test.go
+++ b/internal/store/automations_test.go
@@ -456,6 +456,61 @@ func TestListAutomationRunsWithOccurrenceKeysOrdersNewestFirstWithLimit(t *testi
 	}
 }
 
+func TestLatestAutomationRunPerDefinitionPicksNewestPerDefinitionAndOmitsZeroRunDefinitions(t *testing.T) {
+	s := New()
+	base := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	defA, err := s.UpsertAutomationDefinition("def-a", "A", `{"id":"def-a"}`, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defB, err := s.UpsertAutomationDefinition("def-b", "B", `{"id":"def-b"}`, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defEmpty, err := s.UpsertAutomationDefinition("def-empty", "Empty", `{"id":"def-empty"}`, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = defEmpty
+	seed := func(defID, requestID string, at time.Time) *AutomationRun {
+		ids := AutomationRunReservation{
+			RunID:        "run-" + defID + "-" + requestID,
+			OccurrenceID: "occ-" + defID + "-" + requestID,
+			TicketID:     "ticket-" + defID + "-" + requestID,
+			SessionID:    "session-" + defID + "-" + requestID,
+			WorkspaceID:  "workspace-" + defID + "-" + requestID,
+			PaneID:       "pane-" + defID + "-" + requestID,
+		}
+		run, created, err := s.ClaimManualAutomationRun(defID, requestID, "", `{}`, 1, `{}`, at, ids)
+		if err != nil || !created {
+			t.Fatalf("claim %s/%s created=%v err=%v", defID, requestID, created, err)
+		}
+		return run
+	}
+	seed(defA.ID, "a-1", base)
+	newestA := seed(defA.ID, "a-2", base.Add(time.Minute))
+	newestB := seed(defB.ID, "b-1", base.Add(30*time.Second))
+
+	latest, err := s.LatestAutomationRunPerDefinition()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(latest) != 2 {
+		t.Fatalf("len(latest)=%d, want 2: %#v", len(latest), latest)
+	}
+	got, ok := latest[defA.ID]
+	if !ok || got.ID != newestA.ID || got.OccurrenceKey != "manual:a-2" {
+		t.Fatalf("def-a latest = %#v (ok=%v), want run %s with occurrence_key manual:a-2", got, ok, newestA.ID)
+	}
+	got, ok = latest[defB.ID]
+	if !ok || got.ID != newestB.ID || got.OccurrenceKey != "manual:b-1" {
+		t.Fatalf("def-b latest = %#v (ok=%v), want run %s with occurrence_key manual:b-1", got, ok, newestB.ID)
+	}
+	if _, ok := latest[defEmpty.ID]; ok {
+		t.Fatalf("def-empty should have no entry, got %#v", latest[defEmpty.ID])
+	}
+}
+
 func TestListPendingAutomationRunsIncludesScheduledProvider(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 7, 20, 3, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## What
- One automation command set (9 commands) shared by the Unix-socket CLI and the WebSocket app client, dispatched through a single action layer (`internal/daemon/automations_actions.go`); the daemon no longer has parallel socket/WS code paths.
- 9 typed per-action result messages replace the generic result envelope; dead wire fields dropped; `last_run` is embedded in definition summaries so the panel's list badge loads in one request.
- ProtocolVersion 180 → 181 (constants.go + useDaemonSocket.ts in lockstep).
- CLI: `attn automation show` prints the definition's canonical YAML to stdout; `delete`/`validate`/`cleanup` print purpose-built summaries; list/runs emit lowercase snake_case JSON.
- Frontend adapted to the unified protocol; fixes a regression found by the packaged-app harness where the selected definition's run history went stale on `automations_changed` broadcasts (now refetched on every broadcast; pinned by a panel unit test).
- Harness: automation scenarios adapted to v2 spec-canonical YAML semantics and the new wire shapes; scheduled-cleanup now runs `ensureFreshWorld` before its simulated daemon downtime (a running app respawned the daemon and invalidated the catch-up leg); sqlite3 CLI probes got a busy timeout ("database is locked (5)" flake).

## Evidence (macOS, dev profile, packaged app rebuilt from head b4d5fbf4)
- `attn preflight` (dev): all PASS; CLI/app/daemon all protocol 181.
- Packaged-app scenarios, all ATTN_VERDICT ok:true on this head, run serially:
  - AUTOMATION-EDITOR: 9/9 legs (canonical-YAML reload, collision/id-change/stale-revision/deleted-elsewhere refusals, comment-only save is a revision no-op, disable/enable never bumps revision).
  - AUTOMATION-SCHEDULED-CLEANUP: 4/4 legs — first full pass ever (restart catch-up fires exactly one run under latest policy, real merged-worktree cleanup, dirty-worktree preservation, singleton coalescing, storm guard).
  - AUTOMATION-PR-CONTINUITY: continuation reuses session/ticket, Codex resumes with the copied rollout id keeping pinned model/effort, missing continuity worktree fails visibly.
  - AUTOMATION-SURFACE: 4/4 legs incl. run-now → delivered visible in the panel (the regression fix, live).
  - AUTOMATION-LIFECYCLE: 3/3 legs (edit-rebind across prompt changes, delete-resurrect with history survival, cleanup-dirty-safe).
- `go test ./internal/...` green; frontend 1940/1940.

https://claude.ai/code/session_01APU1R83oaVeshfJM5W5QCM