### PR TITLE
Fix Copilot mouse selection lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-07-22]
 
 ### Fixed
+- **Copilot mouse selection no longer remains stuck after releasing the
+  button.** attn now respects Copilot's configured mouse mode, guarantees that
+  a tracked press receives a matching release outside the terminal or on lost
+  focus, and correctly reports passive pointer movement without pretending the
+  left button is still held.
 - **`attn pr wait-ready` no longer returns instantly on a stale review verdict
   while a re-review is pending.** When the reviewer has been re-requested, an
   approval or changes-requested verdict that was already present when the wait

--- a/app/e2e/terminal-interactions.spec.ts
+++ b/app/e2e/terminal-interactions.spec.ts
@@ -550,6 +550,49 @@ test.describe('Ghostty terminal interactions', () => {
     await expectOpenedUrl(page, url);
   });
 
+  test('releases a mouse-tracking TUI outside the terminal and on window blur', async ({ page, daemon }) => {
+    const sessionId = 's-tracked-release-outside';
+    const terminal = await openTerminalSession(page, daemon, sessionId);
+    await writeTerminalOutput(
+      page,
+      sessionId,
+      '\u001b[2J\u001b[H\u001b[?1000h\u001b[?1002h\u001b[?1003h\u001b[?1006htracked mouse',
+    );
+
+    const bounds = await terminal.boundingBox();
+    expect(bounds).not.toBeNull();
+    await page.mouse.move(bounds!.x + 40, bounds!.y + 8);
+    await page.mouse.down();
+    await page.mouse.move(Math.max(1, bounds!.x - 60), bounds!.y + 8);
+    await page.mouse.up();
+
+    let reports = await page.evaluate((id) => (
+      window.__TEST_GET_SESSION_INPUT_EVENTS?.(id) ?? []
+    ).flatMap((event) => event.event === 'send_to_pty' && event.data ? [event.data] : []), sessionId);
+    expect(reports.filter((data) => /^\u001b\[<0;\d+;\d+M$/.test(data))).toHaveLength(1);
+    expect(reports.filter((data) => /^\u001b\[<3;\d+;\d+m$/.test(data))).toHaveLength(1);
+
+    const reportCountAfterRelease = reports.length;
+    await page.mouse.move(bounds!.x + 70, bounds!.y + 16);
+    reports = await page.evaluate((id) => (
+      window.__TEST_GET_SESSION_INPUT_EVENTS?.(id) ?? []
+    ).flatMap((event) => event.event === 'send_to_pty' && event.data ? [event.data] : []), sessionId);
+    const passiveMotionReports = reports.slice(reportCountAfterRelease);
+    expect(passiveMotionReports.some((data) => /^\u001b\[<35;\d+;\d+M$/.test(data))).toBe(true);
+    expect(passiveMotionReports.some((data) => /^\u001b\[<32;\d+;\d+M$/.test(data))).toBe(false);
+
+    await page.mouse.move(bounds!.x + 40, bounds!.y + 8);
+    await page.mouse.down();
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await page.mouse.up();
+
+    reports = await page.evaluate((id) => (
+      window.__TEST_GET_SESSION_INPUT_EVENTS?.(id) ?? []
+    ).flatMap((event) => event.event === 'send_to_pty' && event.data ? [event.data] : []), sessionId);
+    expect(reports.filter((data) => /^\u001b\[<0;\d+;\d+M$/.test(data))).toHaveLength(2);
+    expect(reports.filter((data) => /^\u001b\[<3;\d+;\d+m$/.test(data))).toHaveLength(2);
+  });
+
   test('forwards screenshot paste triggers from ctrl+v and command paste', async ({ page, daemon }) => {
     await page.addInitScript(() => {
       Object.defineProperty(navigator, 'platform', { value: 'MacIntel', configurable: true });

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -545,6 +545,8 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const selectionDragThresholdMetRef = useRef(false);
     const selectionDragCleanupRef = useRef<(() => void) | null>(null);
     const trackedMouseButtonRef = useRef<number | null>(null);
+    const trackedMouseCellRef = useRef<{ row: number; col: number } | null>(null);
+    const trackedMouseReleaseCleanupRef = useRef<(() => void) | null>(null);
     const hoveredCellRef = useRef<{ row: number; col: number } | null>(null);
     const acceleratorHeldRef = useRef(false);
     const cwdRef = useRef(cwd);
@@ -2327,7 +2329,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       });
     }, [lineAtVisibleRow]);
 
-    const mouseModifiers = (event: React.MouseEvent) =>
+    const mouseModifiers = (event: Pick<MouseEvent, 'shiftKey' | 'altKey' | 'ctrlKey'>) =>
       (event.shiftKey ? 4 : 0) + (event.altKey ? 8 : 0) + (event.ctrlKey ? 16 : 0);
 
     const mouseButton = (button: number) => {
@@ -2583,7 +2585,68 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     useEffect(() => () => {
       selectionDragCleanupRef.current?.();
       selectionDragCleanupRef.current = null;
+      trackedMouseReleaseCleanupRef.current?.();
+      trackedMouseReleaseCleanupRef.current = null;
+      const terminal = terminalRef.current;
+      const button = trackedMouseButtonRef.current;
+      const cell = trackedMouseCellRef.current;
+      if (terminal && button !== null && cell) {
+        onInputRef.current(applicationMouseInput(
+          'release',
+          button,
+          cell.col + 1,
+          cell.row + 1,
+          terminal.getMode(1006),
+        ));
+      }
+      trackedMouseButtonRef.current = null;
+      trackedMouseCellRef.current = null;
     }, []);
+
+    const stopTrackedMouseReleaseWatch = () => {
+      trackedMouseReleaseCleanupRef.current?.();
+      trackedMouseReleaseCleanupRef.current = null;
+    };
+
+    const releaseTrackedMouse = (
+      event?: React.MouseEvent | MouseEvent,
+    ): boolean => {
+      const terminal = terminalRef.current;
+      const button = trackedMouseButtonRef.current;
+      if (button === null) return false;
+      const cell = (event ? cellFromPointer(event) : null) ?? trackedMouseCellRef.current;
+      stopTrackedMouseReleaseWatch();
+      trackedMouseButtonRef.current = null;
+      trackedMouseCellRef.current = null;
+      if (!terminal || !cell) return false;
+      onInputRef.current(applicationMouseInput(
+        'release',
+        button,
+        cell.col + 1,
+        cell.row + 1,
+        terminal.getMode(1006),
+        event ? mouseModifiers(event) : 0,
+      ));
+      return true;
+    };
+
+    const startTrackedMouseReleaseWatch = () => {
+      stopTrackedMouseReleaseWatch();
+      const onUp = (event: MouseEvent) => {
+        releaseTrackedMouse(event);
+      };
+      const onCancel = () => {
+        releaseTrackedMouse();
+      };
+      document.addEventListener('mouseup', onUp);
+      window.addEventListener('blur', onCancel);
+      window.addEventListener('pointercancel', onCancel);
+      trackedMouseReleaseCleanupRef.current = () => {
+        document.removeEventListener('mouseup', onUp);
+        window.removeEventListener('blur', onCancel);
+        window.removeEventListener('pointercancel', onCancel);
+      };
+    };
 
     const sendTrackedMouse = (
       action: 'press' | 'move' | 'release',
@@ -2591,6 +2654,11 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     ): boolean => {
       if (isWorkspaceResizeActive(containerRef.current)) return false;
       const terminal = terminalRef.current;
+      if (action === 'release') {
+        const released = releaseTrackedMouse(event);
+        if (released) event.preventDefault();
+        return released;
+      }
       const cell = cellFromPointer(event);
       if (!terminal || !cell || !terminal.hasMouseTracking()) return false;
       const activeButton = trackedMouseButtonRef.current;
@@ -2603,14 +2671,15 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         });
         if (!shouldReport) {
           if (activeButton !== null && event.buttons === 0) {
-            trackedMouseButtonRef.current = null;
+            releaseTrackedMouse(event);
           }
           return true;
         }
-      } else if (action === 'release' && activeButton === null) {
-        return true;
       }
-      const button = action === 'press' ? mouseButton(event.button) : activeButton ?? 0;
+      // Under DECSET 1003, passive motion is reported even with no physical
+      // button held. Xterm encodes that as button 3 + motion (35), not button
+      // 0 + motion (32), which would tell the application left-drag is active.
+      const button = action === 'press' ? mouseButton(event.button) : activeButton ?? 3;
       onInputRef.current(applicationMouseInput(
         action,
         button,
@@ -2619,8 +2688,11 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         terminal.getMode(1006),
         mouseModifiers(event),
       ));
-      if (action === 'press') trackedMouseButtonRef.current = button;
-      if (action === 'release') trackedMouseButtonRef.current = null;
+      trackedMouseCellRef.current = cell;
+      if (action === 'press') {
+        trackedMouseButtonRef.current = button;
+        startTrackedMouseReleaseWatch();
+      }
       event.preventDefault();
       return true;
     };

--- a/app/src/utils/ghosttyScroll.test.ts
+++ b/app/src/utils/ghosttyScroll.test.ts
@@ -29,6 +29,7 @@ describe('applicationMouseInput', () => {
   it('encodes SGR mouse presses, drags and releases', () => {
     expect(applicationMouseInput('press', 0, 7, 9, true)).toBe('\x1b[<0;7;9M');
     expect(applicationMouseInput('move', 0, 8, 9, true)).toBe('\x1b[<32;8;9M');
+    expect(applicationMouseInput('move', 3, 8, 9, true)).toBe('\x1b[<35;8;9M');
     expect(applicationMouseInput('release', 0, 8, 9, true)).toBe('\x1b[<3;8;9m');
   });
 

--- a/docs/alignment/copilot-mouse-scrolling.md
+++ b/docs/alignment/copilot-mouse-scrolling.md
@@ -1,0 +1,30 @@
+# Copilot mouse scrolling
+
+## Why
+
+Copilot sessions launched by attn currently receive `--no-mouse`, overriding
+the user's Copilot configuration. When terminal mouse tracking is enabled,
+attn also misreports passive pointer movement as a held left-button drag. Done
+means attn leaves Copilot's mouse mode to the user and faithfully forwards its
+mouse protocol without leaving selection stuck.
+
+## Aligned on
+
+- Respect the user's Copilot mouse configuration by passing neither
+  `--mouse=on` nor `--no-mouse`.
+- Harden attn's application-mouse forwarding: once a tracked press begins,
+  observe release at document scope and synthesize a release from the last
+  valid terminal cell on blur or pointer cancellation.
+- Encode passive DECSET 1003 motion as "no button" rather than left drag after
+  the actual button has been released.
+- Preserve Option-drag as attn-owned text selection while ordinary mouse input
+  remains owned by a mouse-tracking TUI.
+- Cover both sides of the regression: Copilot receives no launch-time mouse
+  override, a tracked drag released outside the terminal delivers exactly one
+  release report, and later passive motion reports no held button.
+
+## In scope / deferred
+
+In scope: Copilot launch arguments, tracked-mouse lifecycle, automated tests,
+and live verification in a non-production app. Deferred: changing the generic
+alternate-screen/no-mouse wheel fallback used by other TUIs.

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -46,18 +46,7 @@ func (c *Copilot) Capabilities() Capabilities {
 }
 
 func (c *Copilot) BuildCommand(opts SpawnOpts) *exec.Cmd {
-	// attn owns text selection and scroll handling itself (see GhosttyTerminal's
-	// selection-drag and wheel logic). Copilot's TUI independently enables SGR
-	// mouse tracking (DECSET 1000/1002/1003) in alt-screen mode, and attn's
-	// "forward mouse to app" path has no fail-safe for a release event that
-	// lands outside the terminal's own DOM node (unlike the hardened
-	// text-selection path). When that happens, the dropped release leaves
-	// Copilot's TUI believing the button is still held, producing a stuck
-	// selection/drag, plus post-refresh scroll desync (see attn issue: stuck
-	// selection / scroll-in-textarea after refresh, Copilot-only). Disabling
-	// mouse support avoids the whole class of bug; attn's own mouse handling
-	// covers selection and scrolling regardless.
-	args := []string{"--no-mouse"}
+	var args []string
 	if opts.ResumeSessionID != "" {
 		args = append(args, "--resume", opts.ResumeSessionID)
 	} else if opts.ResumePicker {

--- a/internal/agent/yolo_test.go
+++ b/internal/agent/yolo_test.go
@@ -243,11 +243,14 @@ func TestCopilotSupportsInitialPrompt(t *testing.T) {
 	}
 }
 
-func TestCopilotBuildCommand_AlwaysDisablesMouse(t *testing.T) {
+func TestCopilotBuildCommand_RespectsMouseConfiguration(t *testing.T) {
 	c := &Copilot{}
 	cmd := c.BuildCommand(SpawnOpts{Executable: "copilot"})
-	if !slices.Contains(cmd.Args, "--no-mouse") {
-		t.Fatalf("expected --no-mouse in args, got: %v", cmd.Args)
+	if slices.Contains(cmd.Args, "--mouse=on") {
+		t.Fatalf("unexpected --mouse=on override in args: %v", cmd.Args)
+	}
+	if slices.Contains(cmd.Args, "--no-mouse") {
+		t.Fatalf("unexpected --no-mouse override in args: %v", cmd.Args)
 	}
 }
 


### PR DESCRIPTION
## Summary

- stop overriding Copilot's configured mouse mode at launch
- guarantee every forwarded terminal-mouse press receives a release when the pointer leaves the pane or the window loses focus
- encode DECSET 1003 passive motion as no-button motion instead of a left-button drag

## Root cause

The original missed-release workaround disabled Copilot mouse support globally. After restoring terminal-owned mouse input, the release itself reached the PTY, but subsequent DECSET 1003 motion with no physical button down was encoded as SGR 32. That code means left-button drag, so Copilot re-entered selection immediately after a correct release. The correct passive-motion code is SGR 35.

## Validation

- `make test`
- `pnpm --dir app test` — 1,957 tests
- `pnpm --dir app exec tsc --noEmit`
- `ATTN_E2E_BIN=/tmp/attn-copilotmouse-e2e pnpm --dir app exec playwright test e2e/terminal-interactions.spec.ts` — 20/20
- signed `attn-dev` build and bundled Copilot preflight
- packaged-app live probe: press 0 → drag 32 → release 3 → passive motion 35
- installed Copilot launch preserved the current user-configured mouse-off state without either CLI override
