### PR TITLE
Server-authoritative terminal — Phase 0+1 (shadow mode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ app/src-tauri/*.gen.conf.json
 
 # Local env files
 **/.npmrc
+
+# Native libghostty-vt build output (source of truth: scripts/build-libghostty-vt.sh)
+/third_party/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,21 @@ Run full app builds/installs outside the sandbox: code signing needs the macOS
 keychain; sandboxed identity lookup can cause ad-hoc signing and lose persistent
 permissions.
 
+### Native VT library
+
+`internal/ghosttyvt` links `libghostty-vt` (Ghostty's VT core) via cgo on
+Darwin/arm64; every other platform compiles a pure-Go stub. The static archive
+lives under gitignored `third_party/ghostty-vt/` and is built from pinned source
+by `scripts/build-libghostty-vt.sh` (source of truth; pin in
+`ghostty-vt-native.pin`). This needs **zig 0.16.x** on `PATH`.
+
+On a fresh checkout the archive is absent, so the `build` target depends on it
+and runs the script automatically on the first `make build`/`make dev`/
+`make install*` — a one-time clone + zig build of a few minutes. It rebuilds only
+when the pin or script changes; otherwise it is a no-op. If zig 0.16.x is missing
+the script fails early with the required version. See
+[docs/plans/2026-07-22-server-authoritative-terminal.md](docs/plans/2026-07-22-server-authoritative-terminal.md).
+
 ## Profiles and live verification
 
 - Non-production builds, installs, launches, and restarts are pre-authorized.

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,29 @@ ZIG ?= zig
 # fallback; callers may override this with a pinned identity or fingerprint.
 MACOS_CODESIGN_IDENTITY ?=
 
-build:
+# Native VT library (libghostty-vt) for the server-authoritative terminal.
+# Only Darwin/arm64 links it via cgo (internal/ghosttyvt); every other platform
+# compiles the pure-Go stub and needs nothing here. The archive lives under
+# gitignored third_party/ (scripts/build-libghostty-vt.sh is the source of
+# truth), so a fresh checkout has no archive and the first cgo link would fail.
+# `build` therefore depends on the archive target on Darwin/arm64: it runs the
+# build script — which requires zig 0.16.x and clones the pinned source — when
+# the archive is missing or the pin moved, and is a no-op once it is present.
+UNAME_S := $(shell uname -s)
+UNAME_M := $(shell uname -m)
+NATIVE_VT_LIB := third_party/ghostty-vt/lib/libghostty-vt.a
+ifeq ($(UNAME_S)/$(UNAME_M),Darwin/arm64)
+NATIVE_VT_DEP := $(NATIVE_VT_LIB)
+else
+NATIVE_VT_DEP :=
+endif
+
+# Rebuild the native archive when its pin or build script changes (or it is
+# absent). The script installs into third_party/ghostty-vt/{lib,include}.
+$(NATIVE_VT_LIB): ghostty-vt-native.pin scripts/build-libghostty-vt.sh
+	./scripts/build-libghostty-vt.sh
+
+build: $(NATIVE_VT_DEP)
 	go build -ldflags "$(GO_LDFLAGS)" -o $(OUTPUT) $(BUILD_DIR)
 
 build-linux-amd64:
@@ -80,8 +102,6 @@ test-e2e:
 test-harness: test test-frontend test-e2e
 
 test-all: test test-frontend
-
-UNAME_S := $(shell uname -s)
 
 # Installing the PROD bundle while ATTN_PROFILE is set is almost always
 # a mistake — it blows away the live install a developer is using. The

--- a/docs/plans/2026-07-22-server-authoritative-terminal.md
+++ b/docs/plans/2026-07-22-server-authoritative-terminal.md
@@ -1,0 +1,452 @@
+# Plan: Server-authoritative terminal (kill raw replay)
+
+## Goal
+
+Move attn's PTY restore path to the tmux/zellij model: the daemon-side worker
+owns an authoritative parsed terminal (grid + scrollback), and a client attach
+is served by **serializing that grid** — never by replaying the app's raw byte
+stream. Live output keeps streaming as raw bytes exactly as today; only the
+attach/restore path changes.
+
+Why: nearly all of attn's terminal scar tissue (replay-vs-snapshot decision
+tree in `buildAttachReplayPayload`, the 64KB replay tail, oracle verification,
+seq/watermark race hooks, mid-replay resize cancellation, truncated-restore
+warnings) exists to make *raw bytes* safe to re-parse on a second terminal.
+A server-rendered snapshot is deterministic output of parsed state: it cannot
+open mid-escape-sequence, cannot carry stale geometry, cannot contain terminal
+queries, and cannot disagree with the live screen. tmux and zellij have no
+replay bugs because they have no replay.
+
+The enabler is running **libghostty-vt** (Ghostty's VT core, a C library) in
+the worker via cgo. The frontend already renders with Ghostty WASM built from
+the same source (`app/scripts/build-ghostty-vt-wasm.sh`). Same emulator family
+on both sides means server snapshots are faithful to what the client would
+have rendered — the property today's vt10x oracle lacks (visible frame only,
+partial attributes, no scrollback).
+
+**Pin caveat (verified 2026-07-22):** the Terminal C API does NOT exist at the
+WASM pin `29d4aba` (that commit has parser-only headers: osc/key/sgr/paste).
+It exists on ghostty main — verified working at `ab0b9da03...` (2026-07-22).
+The native lib therefore pins its OWN recent commit (`ghostty-vt-native.pin`),
+separate from the WASM pin, until the frontend's ghostty-web dependency can
+move forward. Both are Ghostty; version skew between them is bounded and
+acceptable for restores (see Decisions).
+
+**Phase 0 has been spiked and is GO** — results are recorded inline in
+Phase 0 below and in Decisions. Phase 1+ can start immediately; the remaining
+Phase 0 checkboxes are productionizing the spike (build script + pin file),
+not research.
+
+## Architecture Map
+
+```text
+Current (replay-based):
+child app → ptmx → worker read loop (internal/pty/session.go)
+  ├─ scan bytes for CPR/DA1/OSC-color queries → answer into PTY input
+  ├─ RingBuffer (1MB raw)            \
+  ├─ ReplayLog (8MB raw segments)     } three parallel stores, under replayMu
+  ├─ vt10x virtualScreen (oracle)    /
+  └─ fanOut(raw bytes, seq) → WS → client Ghostty WASM parses + renders
+
+attach → buildAttachReplayPayload (internal/daemon/ws_pty.go:212)
+  → prefer raw ReplayLog tail (≤64KB), verified against vt10x oracle
+  → fallback: vt10x renderVisibleFrame (visible frame only, no scrollback)
+  → client replays bytes through its parser, dedups live stream by seq
+
+Target (server-authoritative restore):
+child app → ptmx → worker read loop
+  ├─ ghosttyvt.Terminal (cgo, libghostty-vt)   ← single authoritative store
+  │    ├─ grid + scrollback + modes + cursor (native memory, capped)
+  │    ├─ answers ALL terminal queries (CPR/DA1/kitty/OSC…) → PTY input
+  │    └─ Serialize() → {scrollbackANSI, frameANSI, cursor, modes, geometry}
+  └─ fanOut(raw bytes, seq) → WS → client Ghostty WASM   (UNCHANGED)
+
+attach → buildAttachSnapshotPayload
+  → worker serializes terminal state under the same lock that applies chunks
+  → client ingests scrollback lines + frame into a fresh Ghostty model,
+    then applies live stream from seq watermark (dedup contract UNCHANGED)
+
+Tests:
+go corpus tests → recorded real-session byte fixtures → ghosttyvt.Terminal
+  → Serialize() → feed into a second ghosttyvt.Terminal → screens must match
+real-app harness → attach/detach/relaunch scenarios → pane text assertions
+```
+
+Explicitly OUT of scope (follow-ups, do not attempt here): streaming rendered
+diffs instead of raw bytes; slow-client discard-and-resnapshot; daemon-side
+geometry arbitration; removing vt10x from the state classifier.
+
+## Data Model / Interfaces
+
+The C API (verified against ghostty main `ab0b9da`, spike code in Phase 0
+notes) maps almost 1:1 onto what we need — the wrapper is thin:
+
+```go
+// internal/ghosttyvt — new package, cgo bindings over include/ghostty/vt.h.
+// Everything below runs inside the worker process (or embedded backend).
+// Underlying C calls are named in comments; do not invent others.
+type Terminal struct { /* opaque handle + mutex + response buffer */ }
+
+func New(cols, rows int, opts Options) (*Terminal, error)
+// ghostty_terminal_new(GhosttyTerminalOptions{cols, rows, max_scrollback}).
+// Install GHOSTTY_TERMINAL_OPT_WRITE_PTY callback at construction: the lib
+// invokes it synchronously during Write() with query-response bytes (CPR,
+// DA1, kitty CSI ? u, DECRQM…). The callback appends to the Terminal's
+// response buffer. Callback must NOT call back into vt_write (no reentrancy).
+
+func (t *Terminal) Write(p []byte)         // ghostty_terminal_vt_write; never
+                                           // fails, malformed input is safe
+func (t *Terminal) Resize(cols, rows int)  // ghostty_terminal_resize; reflows
+func (t *Terminal) DrainResponses() []byte // returns + clears the response
+                                           // buffer filled by the callback
+func (t *Terminal) PlainText() string      // formatter, FORMAT_PLAIN
+func (t *Terminal) Serialize() Snapshot    // formatter, FORMAT_VT — see below
+func (t *Terminal) Close()                 // ghostty_terminal_free — MUST be
+                                           // called; add a finalizer guard
+
+type Snapshot struct {
+    Cols, Rows int
+    // One self-contained VT stream produced by ghostty_formatter_format_*
+    // with GHOSTTY_FORMATTER_FORMAT_VT, unwrap=false, all "extra" fields on
+    // (modes, palette, scrolling region, tabstops, cursor, style, kitty
+    // keyboard, charsets). Verified properties: includes FULL scrollback
+    // (NULL selection = entire screen incl. history); soft-wrap survives the
+    // dump (restored terminal reflows correctly on later resize); replaying
+    // the dump into a fresh same-size terminal reproduces identical plain
+    // text. Post-process: append a final CUP for the true cursor position —
+    // upstream emits cursor BEFORE tabstop resets, which move the cursor
+    // (verified bug; report upstream, keep the trailing-CUP fix regardless).
+    VTDump []byte
+    ScrollbackTruncated bool // scrollback hit max_scrollback cap
+}
+```
+
+Protocol (TypeSpec → `internal/protocol/schema/main.tsp`, then
+`make generate-types`, bump `ProtocolVersion` in constants.go **and**
+`app/src/hooks/useDaemonSocket.ts` — three lockstep spots, re-grep after any
+rebase):
+
+```text
+attach_result gains (alongside the existing replay fields during transition):
+  snapshot?: {
+    cols, rows: int
+    vt_dump_b64: string        // Snapshot.VTDump (one self-contained stream)
+    scrollback_truncated: bool
+  }
+  // last_seq watermark semantics UNCHANGED: every byte reflected in the
+  // snapshot has seq <= last_seq; live chunks with seq <= last_seq drop.
+```
+
+## Boundaries
+
+- `internal/ghosttyvt` owns all cgo; nothing outside it may include vt.h or
+  know about native handles. It exposes only the Go types above.
+- `internal/pty/session.go` owns the ordering invariant: Write(), seq
+  assignment, and Serialize() happen under the same lock (`replayMu` today) so
+  a snapshot + its `last_seq` watermark stay an atomic pair. This invariant is
+  the load-bearing one in the whole design — there are existing race tests
+  (`infoSnapshotHook`, `readLoopSeqGapHook`) that must keep passing.
+- The frontend must not know how a snapshot was produced. It receives ANSI
+  bytes + geometry, writes them into a fresh model with responses suppressed,
+  and applies the existing seq dedup. All replay *decision* logic
+  (`attachPlanning.ts` classify/plan functions) shrinks; it must not grow.
+- The build script for the native lib mirrors
+  `app/scripts/build-ghostty-vt-wasm.sh` but reads its OWN pin file
+  (`ghostty-vt-native.pin`) — the Terminal C API does not exist at the WASM
+  pin (see Goal). Never float either commit. Build command at the native pin:
+  `zig build -Demit-lib-vt=true -Dtarget=aarch64-macos` (the `lib-vt` build
+  step from the WASM era was renamed; it is now an option, not a step). Zig
+  0.16.0 required (installed via asdf; the WASM pin uses 0.15.x — both live
+  side by side). Converging the two pins is a follow-up.
+
+## Implementation Steps
+
+### Phase 0 — Spike: prove libghostty-vt from Go — **DONE, verdict GO**
+      (spiked 2026-07-22 against ghostty main `ab0b9da`; cgo spike source at
+      `/private/tmp/claude-501/-Users-victor-projects-victor-attn--tmux/e616331e-14c5-480b-8b50-5c3948eab5cf/scratchpad/vt-spike/`
+      — port it into `internal/ghosttyvt` tests rather than rewriting; if the
+      scratchpad is gone, the API names + build command in this section and
+      Data Model are sufficient to recreate it)
+
+Go/no-go checklist, answered empirically (a Go cgo binary linking the static
+lib, run on macOS arm64):
+
+1. **Styled read: YES.** The formatter API (`ghostty/vt/formatter.h`) emits
+   the whole terminal as VT sequences (`GHOSTTY_FORMATTER_FORMAT_VT`)
+   preserving colors/styles, with opt-in extras for cursor, SGR state,
+   modes, palette, scrolling region, tabstops, kitty keyboard, charsets.
+   No hand-written cell→ANSI serializer needed.
+2. **Scrollback: YES.** NULL selection formats the entire screen including
+   history (verified: line scrolled 30 rows past a 10-row viewport appears
+   in the dump). `GhosttyPointTag` has HISTORY/SCREEN coordinates for
+   partial ranges if ever needed.
+3. **Soft-wrap: YES.** A 210-char line on an 80-col terminal round-trips
+   through the dump and reflows correctly after resizing the restored
+   terminal to 40 cols. (`unwrap` formatter option exists; we keep it false.)
+4. **Query responses: YES — better than hoped.** Installing the
+   `GHOSTTY_TERMINAL_OPT_WRITE_PTY` callback yields responses synchronously
+   during write. Verified answered: CPR (`ESC[6n` → `ESC[10;15R`), DA1
+   (`ESC[c` → `ESC[?62;22c`), **kitty `CSI ? u` → `ESC[?0u`** — the exact
+   query behind the codex fresh-spawn replay carve-out. Per-query override
+   callbacks also exist (DA, XTVERSION, XTWINOPS size, color scheme).
+5. **Reflow inside the lib: YES** (see 3).
+6. **Memory: PASS by ~30x.** 100k lines of 190-char text through a 200x50
+   terminal with `max_scrollback=10000`: process RSS delta **768KB**
+   (budget was 25MB/session).
+7. Robustness: garbage/malformed/truncated escape input is safe by design
+   (`vt_write` "never fails"; verified with a hostile byte soup).
+8. Speed: serializing the test terminal took ~150–185µs.
+
+Known upstream nits found (neither is gating):
+- **Cursor-vs-tabstops ordering bug:** the VT dump emits the cursor CUP
+  before tabstop resets, and setting tabstops moves the cursor — so a
+  restored terminal's cursor lands on the last tabstop column. Fix on our
+  side: always append a final CUP after the dump. Report upstream.
+- **Per-cell OSC 8 hyperlinks are not serialized** (only cursor-current
+  hyperlink state). Restored scrollback loses clickable OSC 8 links. Minor
+  for attn (path/URL detection is client-side); note in CHANGELOG if user
+  visible, candidate upstream contribution.
+
+Residual items to productionize (not research):
+
+- [x] `scripts/build-libghostty-vt.sh` + `ghostty-vt-native.pin` (pinned
+      `ab0b9da`) — DONE 2026-07-22. Clones ghostty at the pin, applies
+      `ghostty-vt-native.patch` if present, runs
+      `zig build -Demit-lib-vt=true -Dtarget=aarch64-macos` (zig 0.16),
+      installs `libghostty-vt.a` + `include/ghostty/` under
+      `third_party/ghostty-vt/` (gitignored; script is source of truth).
+      Verified reproducible: fresh build sha == spike-built lib
+      (`978c1d02…`). cgo `internal/ghosttyvt` links it; `cmd/attn` grows to
+      ~39MB and codesigns cleanly (no ad-hoc fallback) — the plan's cgo
+      signing worry is retired.
+- [ ] **Primary-screen-behind-alt-screen: CONFIRMED LOST — fix via a small
+      carried patch (decided with Victor 2026-07-22).** DEFERRED to Phase 2
+      (Serialize needs it; Phase 1 shadow mode does not). The build script
+      already applies `ghostty-vt-native.patch` when present, so landing the
+      patch is drop-in. Spike-verified: the
+      formatter only dumps the ACTIVE screen, so a dump taken while the app
+      is in alt-screen (vim, less…) drops the primary screen AND all
+      scrollback; after restore, leaving alt-screen shows a blank shell.
+      Fix: carry `ghostty-vt-native.patch` (applied by the build script,
+      like the WASM build's patches) exposing the EXISTING Zig
+      `ScreenFormatter` through the C API. Upstream already supports this
+      internally — `src/terminal/formatter.zig` has
+      `ScreenFormatter{ screen: *const Screen }` documented as "formats a
+      single terminal screen (e.g. primary vs alt)"; the patch is C-shim
+      plumbing in `src/terminal/c/formatter.zig` + a header entry (e.g.
+      `ghostty_formatter_screen_new(terminal, GHOSTTY_SCREEN_PRIMARY, opts)`),
+      NOT emulator changes. Serializer for alt-active terminals then emits:
+      primary screen (scrollback + frame) → `1049h` → alt frame. Submit the
+      patch upstream so it eventually drops out of our pile. Add a Go test:
+      feed shell history → enter alt → dump → restore → `1049l` → primary
+      prompt and scrollback must be present (the spike's failing case).
+- [ ] Fuzz-ish smoke with REAL corpora (moved into Phase 1 once the recorder
+      exists): feed 100MB of mixed real-session bytes in random chunk sizes;
+      no crash, RSS stable across 10 create/feed/close cycles.
+
+### Phase 1 — Emulator in the worker, shadow mode (no behavior change)
+
+Deliverable: every session feeds bytes to a ghosttyvt.Terminal alongside the
+existing three stores. Nothing reads from it in production yet except
+divergence logging. App behavior is identical; this phase is pure risk burn.
+
+- [x] `internal/ghosttyvt` package with the interface above + `Close`
+      lifecycle tied to session teardown (`closePTY`) — DONE 2026-07-22.
+      cgo owned entirely by the package (New/Write/Resize/DrainResponses/
+      PlainText/Serialize/Close, cgo.Handle-routed write_pty callback,
+      finalizer backstop). Worker cgo: default `CGO_ENABLED=1` on macOS
+      picks it up automatically — no Makefile change needed; full `make
+      install` AND `make install-daemon` both produced a signed working
+      sidecar (verified live, no ad-hoc fallback).
+- [x] Feed path — DONE 2026-07-22. `session.go` read loop (both the main
+      chunk site and the carryover flush) writes `s.ghostty.Write(data)`
+      under `replayMu` alongside the three stores; `resize()` calls
+      `s.ghostty.Resize`. `DrainResponses()` output is discarded this phase
+      (scanner stays sole answerer). Every use nil-guarded — a construction
+      failure never breaks a session.
+- [ ] Byte-corpus recorder + fixtures — NOT DONE. Round-trip tests currently
+      use a synthetic in-test corpus (`styledCorpus`). Real recorded corpora
+      (claude/codex/vim/emoji/long-scroll) become load-bearing for Phase 2
+      serializer correctness; do this next.
+- [x] Round-trip invariant test — DONE 2026-07-22
+      (`internal/ghosttyvt/ghosttyvt_test.go`): plain-text round-trip,
+      cursor-position round-trip (exercises the trailing-CUP fix), and
+      reflow-after-restore vs a directly-resized terminal. Also: query
+      responses (codex trio incl. kitty `CSI ? u`), malformed-input safety,
+      no-interrogative-sequences guard, Close idempotency. All green.
+      (Uses synthetic corpus pending the recorder above.)
+- [x] Shadow divergence metric — DONE 2026-07-22. On session close, behind
+      `ATTN_GHOSTTY_SHADOW_DIVERGENCE=1`, compares ghostty viewport vs vt10x
+      `renderedText()` and logs the first differing row to the worker log.
+      Pure helpers unit-tested (`shadow_divergence_test.go`).
+- [x] Verify — DONE 2026-07-22. Full `go test ./...` green. Live: throwaway
+      `vtshadow` profile, full `make install`, preflight PASS (protocol 180).
+      `real-app:scenario-ghostty-scroll` PASS (both anchor assertions) —
+      existing behavior unchanged. Worker log shows the ghostty viewport
+      **matched vt10x exactly (26 rows)** on a real streamed session; zero
+      panics / cgo faults / construction failures across spawn→feed→teardown.
+      Profile torn down + orphan workers reaped. (Serial matrix not run —
+      single scenario was sufficient signal since nothing reads the terminal;
+      run the full matrix before Phase 2 flips reads on.)
+
+### Phase 2 — Snapshot-first attach behind a flag (raw replay still exists)
+
+Deliverable: with `ATTN_ATTACH_SNAPSHOT=1` (env/config read by the daemon),
+every attach serves a ghostty-serialized snapshot; without it, behavior is
+exactly today's. Protocol carries both shapes during transition.
+
+- [ ] Serializer: implement `Serialize()` per the Snapshot contract above —
+      it is a thin call into the upstream formatter, NOT a hand-rolled
+      cell walker. Rules a weaker model must not improvise on:
+      - one formatter call, `FORMAT_VT`, `unwrap=false`, all extras on,
+        NULL selection; then append the trailing CUP for the true cursor
+        position (upstream ordering bug, see Phase 0 notes).
+      - alt-screen: when the terminal is in alt-screen, use the patched
+        screen-selector API (see Phase 0 residual items) to emit primary
+        screen (scrollback + frame), then `1049h`, then the alt frame.
+        Leaving alt-screen after a restore MUST show the primary content.
+      - audit the dump for host-affecting sequences: it must never contain
+        anything interrogative (queries) nor OSC 52 clipboard writes. Add a
+        Go test asserting the dump of a corpus-fed terminal contains none
+        (scan for the sequence classes `stripDaemonOwnedResponses` handles,
+        plus OSC 52).
+      - never snapshot mid-`Write` — the existing lock already guarantees
+        the dump reflects committed state only (DEC 2026 etc.).
+- [ ] Protocol: add the `snapshot` field per Data Model section; TypeSpec →
+      `make generate-types` (rm -rf tsp-output first) → constants.go bump →
+      useDaemonSocket.ts bump → rebuild `./attn` (stale binary breaks e2e).
+- [ ] Daemon: in `buildAttachReplayPayload`, when the flag is on, return the
+      snapshot (serialized under `replayMu` with `last_seq`, reusing the
+      `info()` atomic-pair pattern) and set replay fields empty with
+      `replay_decision=use_ghostty_snapshot`. Keep every existing decision
+      path intact when the flag is off.
+- [ ] Frontend: in `attachPlanning.ts` + `useGhosttyPaneRuntime.ts`, when
+      `snapshot` is present: reset model → write scrollback → write frame,
+      all with `suppressResponses` (source `attach_replay`), then existing
+      seq dedup applies untouched. Geometry: model is created at snapshot
+      cols/rows; the existing fit/resize flow then runs as normal.
+- [ ] Codex bootstrap: with the flag on, `shouldIncludeAttachReplay`'s codex
+      fresh-spawn carve-out must keep working. The reason it exists: codex
+      emits startup queries (incl. kitty `CSI ? u`) that today's scan-based
+      responder does NOT answer — the client parser answers them from
+      replayed bytes. The spike confirmed libghostty-vt answers kitty
+      `CSI ? u` natively (`ESC[?0u` via the WRITE_PTY callback). Fix
+      properly: extend the worker's responder using
+      `ghostty.DrainResponses()` for exactly the queries the scanner misses
+      (drain after each Write; forward to PTY input; suppress any response
+      classes the scanner already answers to avoid double replies — dedup by
+      query type). Then codex fresh-spawn needs no replay at all. This is
+      the trickiest step in the plan; add a dedicated Go test feeding the
+      recorded codex startup corpus and asserting each query gets exactly
+      one reply, in ask order.
+- [ ] Verify (flag ON via a throwaway profile — NEVER smoke daemon changes on
+      the dev profile; use `eval "$(./attn profile-env <name>)"` + fresh
+      install; run bundled preflight first):
+      1. Go: round-trip tests from Phase 1 now run against `Serialize()`
+         production code; codex query test above.
+      2. Live: start claude session → produce >2 screens of styled output →
+         quit app → reopen → session restores with scrollback, correct
+         colors, cursor at prompt; resize window after restore → text
+         reflows without stair-stepping (soft-wrap check); run vim, detach,
+         reattach → alt-screen intact; `Cmd+T` utility terminal still
+         focuses (per AGENTS.md manual checks).
+      3. Codex fresh spawn with flag on: codex TUI reaches its prompt (the
+         historical hang is the regression to watch).
+      4. Harness: full `real-app:serial-matrix` with the flag on in the
+         profile env; compare failures against a flag-off baseline run.
+      5. Kill the app mid-stream (`pkill` the app, not the daemon), relaunch,
+         attach: no lost/duplicated tail (seq contract), no mid-escape
+         garbage ever (structural guarantee — but assert pane text anyway).
+
+### Phase 3 — Flip default, delete raw replay
+
+Only start after Phase 2 has soaked on Victor's dev profile for real use;
+ask him before flipping.
+
+- [ ] Default snapshot path on; remove the env flag.
+- [ ] Delete: `ReplayLog` + whole-segment machinery (`replaylog.go`), the
+      replay-vs-snapshot decision tree and oracle verification in
+      `ws_pty.go` (`rawReplaySegmentsMatchFreshSnapshot`,
+      `LimitReplaySegmentsTail`, decision/reason plumbing), vt10x
+      `renderVisibleFrame` snapshot path, frontend replay classification in
+      `attachPlanning.ts` (keep geometry planning + seq dedup), the codex
+      raw-replay carve-out, `stripDaemonOwnedResponses` only if the ghostty
+      responder now covers everything the client model could try to answer —
+      otherwise keep it and file a follow-up.
+      KEEP: `RingBuffer` scrollback if anything still reads it (check
+      `scrollbackTruncated` consumers); vt10x + `renderedText()` for the
+      state classifier (untouched by this plan); seq/watermark contract and
+      its race tests.
+- [ ] Sweep for dead protocol fields; deprecate in TypeSpec rather than
+      breaking if the daemon must keep serving older apps (it shouldn't —
+      version skew fails explicitly; prefer removal + version bump).
+- [ ] Update AGENTS.md Terminal section + CHANGELOG (user-visible: deeper,
+      more faithful session restore).
+- [ ] Verify: full `make test-harness`; the specific scenarios
+      `real-app:scenario-ghostty-scroll`, terminal-block-copy, diff-review,
+      tr401 local-window-resize; grep daemon/worker logs for any
+      `replay_decision` stragglers; soak on dev profile.
+
+## Decisions
+
+- **Live streaming stays raw bytes.** Only the attach/restore path becomes
+  server-authoritative. This keeps attn transparent to sequences the middle
+  emulator doesn't model (kitty graphics, OSC 133 command blocks render from
+  the live stream exactly as today) and limits fidelity risk to restores.
+  Full tmux-style diff streaming is a possible future, not this plan.
+- **libghostty-vt over improving vt10x**: same emulator as the client makes
+  snapshot fidelity a non-question by construction; vt10x would need
+  truecolor, scrollback, reflow, kitty modes — that's rewriting Ghostty badly.
+  Cost: cgo + an explicitly unstable C API, mitigated by hard-pinning.
+- **Spike verdict 2026-07-22: GO** (full results in Phase 0). Every gate
+  passed: styled VT serialization via the upstream formatter, scrollback
+  included, soft-wrap/reflow round-trips, queries answered incl. kitty
+  `CSI ? u`, RSS ~0.8MB for a 10k-line scrollback, malformed input safe,
+  ~180µs to serialize. Two non-gating upstream nits (cursor/tabstop
+  ordering; per-cell OSC 8 loss) with fixes noted.
+- **Alt-screen primary loss → carried C-shim patch (Victor, 2026-07-22).**
+  Expose upstream's existing `ScreenFormatter` through the C API via
+  `ghostty-vt-native.patch`; rejected the no-patch cached-dump-at-1049h
+  workaround as more fragile (mid-chunk splits, 47/1047/1049 variants).
+  Submit upstream.
+- **Images (sixel/kitty) lost on restore: accepted (Victor, 2026-07-22).**
+  Live streaming still renders them; restores are text-only where images
+  were. CHANGELOG note when Phase 3 ships; image-preserving restore is a
+  follow-up, not a gate.
+- **Two ghostty pins, not one.** The Terminal C API doesn't exist at the
+  frontend WASM pin `29d4aba`; the native lib pins recent main (verified at
+  `ab0b9da`). Rejected alternative: bumping the WASM pin in the same project
+  — it drags the ghostty-web compat patch along and couples a renderer
+  upgrade into this plan. Restore fidelity is still emulator-verified by the
+  round-trip tests; pin convergence is a follow-up.
+- **vt10x stays (for now)** as the state-classifier's text source. Swapping
+  the classifier input mid-plan couples an approval-detection regression risk
+  into a terminal-fidelity project. Follow-up owns that swap.
+- **Query responder**: scanner stays authoritative for CPR/DA1/OSC-color;
+  ghostty's drained responses fill only the gap (kitty, etc.) with per-type
+  dedup. Single-responder-by-construction comes when the scanner retires in
+  a follow-up.
+- **Worker-only cgo concern**: a native crash in libghostty-vt kills one
+  session's worker, not the daemon — the per-session worker architecture is
+  exactly the right blast-radius container for this experiment. The embedded
+  backend gets the same code path but is dev-only.
+
+## Open Questions
+
+None — all resolved (see Decisions). Scrollback cap: 10k lines stands
+(≈0.8MB RSS measured).
+
+## Follow-ups
+
+- Slow-client handling: replace slow-count disconnect with tmux-style
+  discard + fresh snapshot push (`pty_desync` machinery already exists).
+- Daemon-side geometry arbitration (per-client sizes, latest-active policy,
+  250ms coalescing, tmux double-pulse) → retire suspicious-size guard,
+  overflow re-assertion, bottom-clip repair.
+- Swap state classifier text source to ghosttyvt; then delete vt10x.
+- Retire scan-based query responder in favor of ghostty responses only.
+- Consider `PaneRenderUpdate`-style full-snapshot-then-diffs for web/remote
+  clients (zellij's subscriber model).
+- Converge the native and WASM ghostty pins (requires ghostty-web moving to
+  a commit that has the Terminal C API); report the cursor/tabstop formatter
+  ordering bug and the per-cell OSC 8 serialization gap upstream.

--- a/ghostty-vt-native.pin
+++ b/ghostty-vt-native.pin
@@ -1,0 +1,8 @@
+# Ghostty commit for the NATIVE libghostty-vt static lib built into the worker.
+#
+# This is a SEPARATE pin from the frontend WASM build
+# (app/scripts/build-ghostty-vt-wasm.sh, pin 29d4aba): the Terminal C API used
+# by the server-authoritative restore path does NOT exist at the WASM pin.
+# Verified working at ab0b9da (2026-07-22). Never float either commit.
+# Converging the two pins is a follow-up (needs ghostty-web to move forward).
+ab0b9da9e88fcb4b0533a1854e84628f663930af

--- a/internal/ghosttyvt/callback.go
+++ b/internal/ghosttyvt/callback.go
@@ -1,0 +1,35 @@
+//go:build darwin && arm64
+
+package ghosttyvt
+
+/*
+#include <stddef.h>
+#include <stdint.h>
+#include <ghostty/vt.h>
+*/
+import "C"
+
+import (
+	"runtime/cgo"
+	"unsafe"
+)
+
+// goWritePty is invoked synchronously by libghostty-vt during vt_write when the
+// terminal needs to write a query response back to the pty. userdata points at
+// the owning Terminal's cgo.Handle field. The callback runs on the same
+// goroutine that called Write, which holds t.mu, so appending is race-free.
+//
+// The callback MUST NOT call back into vt_write on the same terminal.
+//
+//export goWritePty
+func goWritePty(term C.GhosttyTerminal, userdata unsafe.Pointer, data *C.uint8_t, length C.size_t) {
+	if userdata == nil || length == 0 {
+		return
+	}
+	h := *(*cgo.Handle)(userdata)
+	t, ok := h.Value().(*Terminal)
+	if !ok {
+		return
+	}
+	t.respBuf = append(t.respBuf, C.GoBytes(unsafe.Pointer(data), C.int(length))...)
+}

--- a/internal/ghosttyvt/callback.go
+++ b/internal/ghosttyvt/callback.go
@@ -15,9 +15,11 @@ import (
 )
 
 // goWritePty is invoked synchronously by libghostty-vt during vt_write when the
-// terminal needs to write a query response back to the pty. userdata points at
-// the owning Terminal's cgo.Handle field. The callback runs on the same
-// goroutine that called Write, which holds t.mu, so appending is race-free.
+// terminal needs to write a query response back to the pty. userdata carries a
+// cgo.Handle VALUE (installed as an opaque void*, never a Go pointer) that
+// references the owning terminal's respSink. The callback runs on the same
+// goroutine that called Write — which holds the Terminal mutex — but appends
+// under the sink's own lock so a concurrent DrainResponses stays race-free.
 //
 // The callback MUST NOT call back into vt_write on the same terminal.
 //
@@ -26,10 +28,11 @@ func goWritePty(term C.GhosttyTerminal, userdata unsafe.Pointer, data *C.uint8_t
 	if userdata == nil || length == 0 {
 		return
 	}
-	h := *(*cgo.Handle)(userdata)
-	t, ok := h.Value().(*Terminal)
+	s, ok := cgo.Handle(uintptr(userdata)).Value().(*respSink)
 	if !ok {
 		return
 	}
-	t.respBuf = append(t.respBuf, C.GoBytes(unsafe.Pointer(data), C.int(length))...)
+	s.mu.Lock()
+	s.buf = append(s.buf, C.GoBytes(unsafe.Pointer(data), C.int(length))...)
+	s.mu.Unlock()
 }

--- a/internal/ghosttyvt/callback.go
+++ b/internal/ghosttyvt/callback.go
@@ -15,11 +15,11 @@ import (
 )
 
 // goWritePty is invoked synchronously by libghostty-vt during vt_write when the
-// terminal needs to write a query response back to the pty. userdata carries a
-// cgo.Handle VALUE (installed as an opaque void*, never a Go pointer) that
-// references the owning terminal's respSink. The callback runs on the same
-// goroutine that called Write — which holds the Terminal mutex — but appends
-// under the sink's own lock so a concurrent DrainResponses stays race-free.
+// terminal needs to write a query response back to the pty. userdata is the
+// pinned address of a cgo.Handle that references the owning terminal's respSink.
+// The callback runs on the same goroutine that called Write — which holds the
+// Terminal mutex — but appends under the sink's own lock so a concurrent
+// DrainResponses stays race-free.
 //
 // The callback MUST NOT call back into vt_write on the same terminal.
 //
@@ -28,7 +28,7 @@ func goWritePty(term C.GhosttyTerminal, userdata unsafe.Pointer, data *C.uint8_t
 	if userdata == nil || length == 0 {
 		return
 	}
-	s, ok := cgo.Handle(uintptr(userdata)).Value().(*respSink)
+	s, ok := (*(*cgo.Handle)(userdata)).Value().(*respSink)
 	if !ok {
 		return
 	}

--- a/internal/ghosttyvt/ghosttyvt.go
+++ b/internal/ghosttyvt/ghosttyvt.go
@@ -18,6 +18,7 @@ package ghosttyvt
 #cgo CFLAGS: -I${SRCDIR}/../../third_party/ghostty-vt/include
 #cgo LDFLAGS: ${SRCDIR}/../../third_party/ghostty-vt/lib/libghostty-vt.a
 #cgo LDFLAGS: -framework CoreFoundation -framework CoreText -framework CoreGraphics -framework Foundation
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ghostty/vt.h>
@@ -26,10 +27,14 @@ package ghosttyvt
 // vt_write with query-response bytes (CPR, DA1, kitty CSI ? u, DECRQM…).
 extern void goWritePty(GhosttyTerminal term, void* userdata, const uint8_t* data, size_t len);
 
-// Install the userdata pointer + write_pty callback in one shot. userdata is a
-// pointer to the Terminal's cgo.Handle field (stable for the Terminal's life).
-static GhosttyResult ghosttyvt_install(GhosttyTerminal t, void* userdata) {
-	GhosttyResult rc = ghostty_terminal_set(t, GHOSTTY_TERMINAL_OPT_USERDATA, userdata);
+// Install the userdata + write_pty callback in one shot. userdata is a cgo.Handle
+// VALUE (an opaque integer), passed as uintptr_t and stored by the terminal as an
+// opaque void*. Crucially this is NOT a Go pointer: C retains the handle integer,
+// never a pointer into Go's heap, so cgo's pointer-lifetime rule is satisfied even
+// though ghostty_terminal_set keeps the value past this call. The callback casts
+// the void* back to a cgo.Handle to recover the owning object.
+static GhosttyResult ghosttyvt_install(GhosttyTerminal t, uintptr_t userdata) {
+	GhosttyResult rc = ghostty_terminal_set(t, GHOSTTY_TERMINAL_OPT_USERDATA, (const void*)userdata);
 	if (rc != GHOSTTY_SUCCESS) return rc;
 	return ghostty_terminal_set(t, GHOSTTY_TERMINAL_OPT_WRITE_PTY, (const void*)goWritePty);
 }
@@ -114,6 +119,17 @@ type Snapshot struct {
 	ScrollbackTruncated bool
 }
 
+// respSink accumulates bytes the terminal wants written back to the pty (query
+// responses: CPR, DA1, kitty CSI ? u, DECRQM…). It is what the cgo.Handle
+// references — deliberately NOT the Terminal — so the handle does not keep the
+// Terminal reachable, and the Terminal's finalizer can still reclaim a leaked
+// one. Its own mutex guards buf; goWritePty appends (synchronously during Write)
+// and DrainResponses reads+clears, independent of the Terminal's mutex.
+type respSink struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
 // Terminal wraps a native libghostty-vt terminal. All methods are safe for
 // concurrent use; each serializes on the Terminal's mutex.
 //
@@ -122,14 +138,10 @@ type Snapshot struct {
 type Terminal struct {
 	mu     sync.Mutex
 	term   C.GhosttyTerminal
-	handle cgo.Handle // routes write_pty callbacks back to this Terminal
+	handle cgo.Handle // opaque userdata value; routes write_pty to sink
+	sink   *respSink  // referenced by handle; holds query-response bytes
 	cols   int
 	rows   int
-
-	// respBuf accumulates bytes the terminal wants written back to the pty
-	// (query responses). Appended by goWritePty synchronously during Write,
-	// under mu. Drained by DrainResponses.
-	respBuf []byte
 
 	closed bool
 }
@@ -143,7 +155,7 @@ func New(cols, rows int, opts Options) (*Terminal, error) {
 	if maxSB <= 0 {
 		maxSB = DefaultMaxScrollback
 	}
-	t := &Terminal{cols: cols, rows: rows}
+	t := &Terminal{cols: cols, rows: rows, sink: &respSink{}}
 	copts := C.GhosttyTerminalOptions{
 		cols:           C.uint16_t(cols),
 		rows:           C.uint16_t(rows),
@@ -152,8 +164,10 @@ func New(cols, rows int, opts Options) (*Terminal, error) {
 	if rc := C.ghostty_terminal_new(nil, &t.term, copts); rc != C.GHOSTTY_SUCCESS {
 		return nil, fmt.Errorf("ghosttyvt: terminal_new failed: rc=%d", int(rc))
 	}
-	t.handle = cgo.NewHandle(t)
-	if rc := C.ghosttyvt_install(t.term, unsafe.Pointer(&t.handle)); rc != C.GHOSTTY_SUCCESS {
+	// The handle references the sink (not t), and is handed to C as an opaque
+	// integer value — never a Go pointer — so C may retain it indefinitely.
+	t.handle = cgo.NewHandle(t.sink)
+	if rc := C.ghosttyvt_install(t.term, C.uintptr_t(t.handle)); rc != C.GHOSTTY_SUCCESS {
 		C.ghostty_terminal_free(t.term)
 		t.handle.Delete()
 		return nil, fmt.Errorf("ghosttyvt: install callbacks failed: rc=%d", int(rc))
@@ -193,15 +207,17 @@ func (t *Terminal) Resize(cols, rows int) {
 }
 
 // DrainResponses returns and clears the bytes the terminal wants written back
-// to the pty (query responses accumulated since the last drain).
+// to the pty (query responses accumulated since the last drain). It reads the
+// sink under the sink's own lock, independent of the Terminal mutex.
 func (t *Terminal) DrainResponses() []byte {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if len(t.respBuf) == 0 {
+	s := t.sink
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.buf) == 0 {
 		return nil
 	}
-	out := t.respBuf
-	t.respBuf = nil
+	out := s.buf
+	s.buf = nil
 	return out
 }
 

--- a/internal/ghosttyvt/ghosttyvt.go
+++ b/internal/ghosttyvt/ghosttyvt.go
@@ -1,0 +1,304 @@
+//go:build darwin && arm64
+
+// Package ghosttyvt is the worker-side owner of an authoritative parsed
+// terminal, backed by libghostty-vt (Ghostty's VT core) via cgo.
+//
+// It is the ONLY package that may include vt.h or touch native handles. It
+// exists so a client attach can be served by serializing the parsed grid +
+// scrollback (the tmux/zellij model) instead of replaying the app's raw byte
+// stream. Live output keeps streaming as raw bytes; only the attach/restore
+// path uses this package.
+//
+// The static library and headers under third_party/ghostty-vt/ are produced by
+// scripts/build-libghostty-vt.sh (source of truth; gitignored output). See
+// docs/plans/2026-07-22-server-authoritative-terminal.md.
+package ghosttyvt
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/../../third_party/ghostty-vt/include
+#cgo LDFLAGS: ${SRCDIR}/../../third_party/ghostty-vt/lib/libghostty-vt.a
+#cgo LDFLAGS: -framework CoreFoundation -framework CoreText -framework CoreGraphics -framework Foundation
+#include <stdlib.h>
+#include <string.h>
+#include <ghostty/vt.h>
+
+// Implemented in callback.go; the terminal invokes it synchronously during
+// vt_write with query-response bytes (CPR, DA1, kitty CSI ? u, DECRQM…).
+extern void goWritePty(GhosttyTerminal term, void* userdata, const uint8_t* data, size_t len);
+
+// Install the userdata pointer + write_pty callback in one shot. userdata is a
+// pointer to the Terminal's cgo.Handle field (stable for the Terminal's life).
+static GhosttyResult ghosttyvt_install(GhosttyTerminal t, void* userdata) {
+	GhosttyResult rc = ghostty_terminal_set(t, GHOSTTY_TERMINAL_OPT_USERDATA, userdata);
+	if (rc != GHOSTTY_SUCCESS) return rc;
+	return ghostty_terminal_set(t, GHOSTTY_TERMINAL_OPT_WRITE_PTY, (const void*)goWritePty);
+}
+
+// Build formatter options: one self-contained VT (or plain) stream with all
+// "extra" state on and unwrap=false so soft-wrap survives the dump. NULL
+// selection = the entire screen including scrollback history.
+static GhosttyFormatterTerminalOptions ghosttyvt_make_opts(GhosttyFormatterFormat emit) {
+	GhosttyFormatterTerminalOptions o;
+	memset(&o, 0, sizeof(o));
+	o.size = sizeof(GhosttyFormatterTerminalOptions);
+	o.emit = emit;
+	o.unwrap = false;
+	o.trim = false;
+	o.extra.size = sizeof(GhosttyFormatterTerminalExtra);
+	o.extra.palette = true;
+	o.extra.modes = true;
+	o.extra.scrolling_region = true;
+	o.extra.tabstops = true;
+	o.extra.pwd = true;
+	o.extra.keyboard = true;
+	o.extra.screen.size = sizeof(GhosttyFormatterScreenExtra);
+	o.extra.screen.cursor = true;
+	o.extra.screen.style = true;
+	o.extra.screen.hyperlink = true;
+	o.extra.screen.protection = true;
+	o.extra.screen.kitty_keyboard = true;
+	o.extra.screen.charsets = true;
+	o.selection = NULL;
+	return o;
+}
+
+static uint16_t ghosttyvt_get_u16(GhosttyTerminal t, GhosttyTerminalData data) {
+	uint16_t v = 0;
+	ghostty_terminal_get(t, data, &v);
+	return v;
+}
+
+static int ghosttyvt_active_screen(GhosttyTerminal t) {
+	GhosttyTerminalScreen s = GHOSTTY_TERMINAL_SCREEN_PRIMARY;
+	ghostty_terminal_get(t, GHOSTTY_TERMINAL_DATA_ACTIVE_SCREEN, &s);
+	return (int)s;
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/cgo"
+	"sync"
+	"unsafe"
+)
+
+// Nominal cell pixel size. We never render, but resize + XTWINOPS size reports
+// need non-zero pixel dimensions. The exact values are immaterial to grid
+// reflow; they only scale pixel-unit size reports.
+const (
+	cellWidthPx  = 8
+	cellHeightPx = 16
+)
+
+// DefaultMaxScrollback is the scrollback cap (lines). ~0.8MB RSS measured for a
+// 10k-line 200x50 scrollback (see plan Phase 0 notes).
+const DefaultMaxScrollback = 10000
+
+// Options configures a new Terminal.
+type Options struct {
+	// MaxScrollback caps retained scrollback lines. Zero uses DefaultMaxScrollback.
+	MaxScrollback int
+}
+
+// Snapshot is a self-contained serialization of a Terminal's full state,
+// suitable for reconstructing an identical terminal on a client.
+type Snapshot struct {
+	Cols, Rows int
+	// VTDump is one self-contained VT stream (FORMAT_VT, unwrap=false, all
+	// extras, full scrollback) that reproduces the terminal when replayed into
+	// a fresh same-size terminal. It carries no interrogative sequences.
+	VTDump []byte
+	// ScrollbackTruncated reports whether scrollback hit the cap.
+	ScrollbackTruncated bool
+}
+
+// Terminal wraps a native libghostty-vt terminal. All methods are safe for
+// concurrent use; each serializes on the Terminal's mutex.
+//
+// The caller MUST call Close exactly once when done; a finalizer is a backstop,
+// not a substitute (native memory + a cgo.Handle leak otherwise).
+type Terminal struct {
+	mu     sync.Mutex
+	term   C.GhosttyTerminal
+	handle cgo.Handle // routes write_pty callbacks back to this Terminal
+	cols   int
+	rows   int
+
+	// respBuf accumulates bytes the terminal wants written back to the pty
+	// (query responses). Appended by goWritePty synchronously during Write,
+	// under mu. Drained by DrainResponses.
+	respBuf []byte
+
+	closed bool
+}
+
+// New creates a Terminal of the given size. cols and rows must be > 0.
+func New(cols, rows int, opts Options) (*Terminal, error) {
+	if cols <= 0 || rows <= 0 {
+		return nil, fmt.Errorf("ghosttyvt: invalid size %dx%d", cols, rows)
+	}
+	maxSB := opts.MaxScrollback
+	if maxSB <= 0 {
+		maxSB = DefaultMaxScrollback
+	}
+	t := &Terminal{cols: cols, rows: rows}
+	copts := C.GhosttyTerminalOptions{
+		cols:           C.uint16_t(cols),
+		rows:           C.uint16_t(rows),
+		max_scrollback: C.size_t(maxSB),
+	}
+	if rc := C.ghostty_terminal_new(nil, &t.term, copts); rc != C.GHOSTTY_SUCCESS {
+		return nil, fmt.Errorf("ghosttyvt: terminal_new failed: rc=%d", int(rc))
+	}
+	t.handle = cgo.NewHandle(t)
+	if rc := C.ghosttyvt_install(t.term, unsafe.Pointer(&t.handle)); rc != C.GHOSTTY_SUCCESS {
+		C.ghostty_terminal_free(t.term)
+		t.handle.Delete()
+		return nil, fmt.Errorf("ghosttyvt: install callbacks failed: rc=%d", int(rc))
+	}
+	runtime.SetFinalizer(t, (*Terminal).finalize)
+	return t, nil
+}
+
+// Write feeds raw PTY bytes through the terminal's parser. It never fails;
+// malformed input is safe by design. Query responses produced during the write
+// are appended to the response buffer (see DrainResponses).
+func (t *Terminal) Write(p []byte) {
+	if len(p) == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.closed {
+		return
+	}
+	C.ghostty_terminal_vt_write(t.term, (*C.uint8_t)(unsafe.Pointer(&p[0])), C.size_t(len(p)))
+}
+
+// Resize changes the terminal dimensions; the primary screen reflows when
+// wraparound is enabled.
+func (t *Terminal) Resize(cols, rows int) {
+	if cols <= 0 || rows <= 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.closed {
+		return
+	}
+	C.ghostty_terminal_resize(t.term, C.uint16_t(cols), C.uint16_t(rows), cellWidthPx, cellHeightPx)
+	t.cols, t.rows = cols, rows
+}
+
+// DrainResponses returns and clears the bytes the terminal wants written back
+// to the pty (query responses accumulated since the last drain).
+func (t *Terminal) DrainResponses() []byte {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.respBuf) == 0 {
+		return nil
+	}
+	out := t.respBuf
+	t.respBuf = nil
+	return out
+}
+
+// Size returns the current terminal dimensions.
+func (t *Terminal) Size() (cols, rows int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.cols, t.rows
+}
+
+// PlainText renders the terminal (viewport + scrollback) as plain UTF-8 text,
+// no escape sequences. Primarily for tests and shadow-mode divergence checks.
+func (t *Terminal) PlainText() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.closed {
+		return ""
+	}
+	return string(t.format(C.GHOSTTY_FORMATTER_FORMAT_PLAIN))
+}
+
+// Serialize produces a Snapshot: one self-contained VT stream that reproduces
+// the terminal state (grid + scrollback + modes + cursor) when replayed into a
+// fresh same-size terminal.
+func (t *Terminal) Serialize() Snapshot {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.serializeLocked()
+}
+
+// serializeLocked assumes t.mu is held. Exposed for callers that must capture a
+// snapshot atomically with an external watermark (e.g. the read-loop seq).
+func (t *Terminal) serializeLocked() Snapshot {
+	if t.closed {
+		return Snapshot{Cols: t.cols, Rows: t.rows}
+	}
+	dump := t.format(C.GHOSTTY_FORMATTER_FORMAT_VT)
+
+	// Upstream ordering bug: the VT dump emits the cursor CUP before tabstop
+	// resets, and setting tabstops moves the cursor — so without a corrective
+	// CUP the restored cursor lands on the last tabstop column. Append the true
+	// cursor position last. (0-indexed native coords → 1-based CUP.)
+	cx, cy := t.cursorXYLocked()
+	dump = fmt.Appendf(dump, "\x1b[%d;%dH", cy+1, cx+1)
+
+	return Snapshot{
+		Cols:   t.cols,
+		Rows:   t.rows,
+		VTDump: dump,
+	}
+}
+
+// cursorXYLocked returns the native cursor position (0-indexed). Caller holds t.mu.
+func (t *Terminal) cursorXYLocked() (x, y int) {
+	return int(C.ghosttyvt_get_u16(t.term, C.GHOSTTY_TERMINAL_DATA_CURSOR_X)),
+		int(C.ghosttyvt_get_u16(t.term, C.GHOSTTY_TERMINAL_DATA_CURSOR_Y))
+}
+
+// format runs the upstream formatter and returns freshly-allocated Go bytes.
+// Caller must hold t.mu and must not call it after Close.
+func (t *Terminal) format(emit C.GhosttyFormatterFormat) []byte {
+	var f C.GhosttyFormatter
+	opts := C.ghosttyvt_make_opts(emit)
+	if rc := C.ghostty_formatter_terminal_new(nil, &f, t.term, opts); rc != C.GHOSTTY_SUCCESS {
+		// Formatter construction should not fail for a live terminal; return
+		// empty rather than panicking a worker over a snapshot.
+		return nil
+	}
+	defer C.ghostty_formatter_free(f)
+	var ptr *C.uint8_t
+	var n C.size_t
+	if rc := C.ghostty_formatter_format_alloc(f, nil, &ptr, &n); rc != C.GHOSTTY_SUCCESS {
+		return nil
+	}
+	defer C.ghostty_free(nil, ptr, n)
+	if n == 0 {
+		return nil
+	}
+	return C.GoBytes(unsafe.Pointer(ptr), C.int(n))
+}
+
+// Close frees the native terminal and releases the cgo.Handle. Idempotent.
+func (t *Terminal) Close() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.closed {
+		return
+	}
+	t.closed = true
+	C.ghostty_terminal_free(t.term)
+	t.term = nil
+	t.handle.Delete()
+	runtime.SetFinalizer(t, nil)
+}
+
+// finalize is the SetFinalizer backstop. It must not depend on t.mu being
+// uncontended; Close handles the real work and is idempotent.
+func (t *Terminal) finalize() {
+	t.Close()
+}

--- a/internal/ghosttyvt/ghosttyvt.go
+++ b/internal/ghosttyvt/ghosttyvt.go
@@ -18,7 +18,6 @@ package ghosttyvt
 #cgo CFLAGS: -I${SRCDIR}/../../third_party/ghostty-vt/include
 #cgo LDFLAGS: ${SRCDIR}/../../third_party/ghostty-vt/lib/libghostty-vt.a
 #cgo LDFLAGS: -framework CoreFoundation -framework CoreText -framework CoreGraphics -framework Foundation
-#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ghostty/vt.h>
@@ -27,14 +26,13 @@ package ghosttyvt
 // vt_write with query-response bytes (CPR, DA1, kitty CSI ? u, DECRQM…).
 extern void goWritePty(GhosttyTerminal term, void* userdata, const uint8_t* data, size_t len);
 
-// Install the userdata + write_pty callback in one shot. userdata is a cgo.Handle
-// VALUE (an opaque integer), passed as uintptr_t and stored by the terminal as an
-// opaque void*. Crucially this is NOT a Go pointer: C retains the handle integer,
-// never a pointer into Go's heap, so cgo's pointer-lifetime rule is satisfied even
-// though ghostty_terminal_set keeps the value past this call. The callback casts
-// the void* back to a cgo.Handle to recover the owning object.
-static GhosttyResult ghosttyvt_install(GhosttyTerminal t, uintptr_t userdata) {
-	GhosttyResult rc = ghostty_terminal_set(t, GHOSTTY_TERMINAL_OPT_USERDATA, (const void*)userdata);
+// Install the userdata pointer + write_pty callback in one shot. userdata is the
+// address of the sink's cgo.Handle field. ghostty_terminal_set retains it past
+// this call, so the caller pins that address with a runtime.Pinner (held until
+// after ghostty_terminal_free) — the supported way for C to legally retain a Go
+// pointer. The callback dereferences it back to a cgo.Handle.
+static GhosttyResult ghosttyvt_install(GhosttyTerminal t, void* userdata) {
+	GhosttyResult rc = ghostty_terminal_set(t, GHOSTTY_TERMINAL_OPT_USERDATA, userdata);
 	if (rc != GHOSTTY_SUCCESS) return rc;
 	return ghostty_terminal_set(t, GHOSTTY_TERMINAL_OPT_WRITE_PTY, (const void*)goWritePty);
 }
@@ -125,9 +123,12 @@ type Snapshot struct {
 // Terminal reachable, and the Terminal's finalizer can still reclaim a leaked
 // one. Its own mutex guards buf; goWritePty appends (synchronously during Write)
 // and DrainResponses reads+clears, independent of the Terminal's mutex.
+//
+// handle references this sink; C retains &handle as its userdata (see New).
 type respSink struct {
-	mu  sync.Mutex
-	buf []byte
+	mu     sync.Mutex
+	buf    []byte
+	handle cgo.Handle
 }
 
 // Terminal wraps a native libghostty-vt terminal. All methods are safe for
@@ -138,8 +139,8 @@ type respSink struct {
 type Terminal struct {
 	mu     sync.Mutex
 	term   C.GhosttyTerminal
-	handle cgo.Handle // opaque userdata value; routes write_pty to sink
-	sink   *respSink  // referenced by handle; holds query-response bytes
+	sink   *respSink      // referenced by sink.handle; holds query-response bytes
+	pinner runtime.Pinner // pins &sink.handle for C to retain as userdata
 	cols   int
 	rows   int
 
@@ -164,12 +165,17 @@ func New(cols, rows int, opts Options) (*Terminal, error) {
 	if rc := C.ghostty_terminal_new(nil, &t.term, copts); rc != C.GHOSTTY_SUCCESS {
 		return nil, fmt.Errorf("ghosttyvt: terminal_new failed: rc=%d", int(rc))
 	}
-	// The handle references the sink (not t), and is handed to C as an opaque
-	// integer value — never a Go pointer — so C may retain it indefinitely.
-	t.handle = cgo.NewHandle(t.sink)
-	if rc := C.ghosttyvt_install(t.term, C.uintptr_t(t.handle)); rc != C.GHOSTTY_SUCCESS {
+	// The handle references the sink (not t) so it does not pin the Terminal.
+	// C retains the userdata past this call, so give it the *address* of the
+	// sink's handle field and pin that address: a runtime.Pinner is the
+	// supported way for C to legally hold a Go pointer. Unpinned in Close, after
+	// ghostty_terminal_free.
+	t.sink.handle = cgo.NewHandle(t.sink)
+	t.pinner.Pin(&t.sink.handle)
+	if rc := C.ghosttyvt_install(t.term, unsafe.Pointer(&t.sink.handle)); rc != C.GHOSTTY_SUCCESS {
 		C.ghostty_terminal_free(t.term)
-		t.handle.Delete()
+		t.pinner.Unpin()
+		t.sink.handle.Delete()
 		return nil, fmt.Errorf("ghosttyvt: install callbacks failed: rc=%d", int(rc))
 	}
 	runtime.SetFinalizer(t, (*Terminal).finalize)
@@ -309,7 +315,10 @@ func (t *Terminal) Close() {
 	t.closed = true
 	C.ghostty_terminal_free(t.term)
 	t.term = nil
-	t.handle.Delete()
+	// Unpin only after the native terminal is gone (it can no longer read the
+	// userdata), then release the handle.
+	t.pinner.Unpin()
+	t.sink.handle.Delete()
 	runtime.SetFinalizer(t, nil)
 }
 

--- a/internal/ghosttyvt/ghosttyvt_test.go
+++ b/internal/ghosttyvt/ghosttyvt_test.go
@@ -1,0 +1,204 @@
+//go:build darwin && arm64
+
+package ghosttyvt
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// newT is a test helper that creates a Terminal and registers cleanup.
+func newT(t *testing.T, cols, rows int) *Terminal {
+	t.Helper()
+	term, err := New(cols, rows, Options{})
+	if err != nil {
+		t.Fatalf("New(%d,%d): %v", cols, rows, err)
+	}
+	t.Cleanup(term.Close)
+	return term
+}
+
+// styledCorpus produces a byte stream with scrollback, SGR styling, a soft-wrap,
+// a hyperlink, and a trailing prompt — a representative session slice.
+func styledCorpus() []byte {
+	var b bytes.Buffer
+	for i := 1; i <= 40; i++ {
+		fmt.Fprintf(&b, "\x1b[3%dmline-%03d\x1b[0m plain tail\r\n", i%7+1, i)
+	}
+	b.WriteString("\x1b[1;4;35mSTYLED-BOLD-UNDER-MAGENTA\x1b[0m\r\n")
+	b.WriteString(strings.Repeat("wrapme-", 30)) // 210 chars > 80 cols → soft wraps
+	b.WriteString("\r\n")
+	b.WriteString("\x1b]8;;https://example.com\x1b\\hyperlinked\x1b]8;;\x1b\\\r\n")
+	b.WriteString("final-prompt$ ")
+	return b.Bytes()
+}
+
+// TestRoundTripPlainText is the core correctness invariant: feed terminal A,
+// serialize it, replay the dump into a fresh terminal B, and assert A and B
+// render identical plain text (viewport + scrollback).
+func TestRoundTripPlainText(t *testing.T) {
+	a := newT(t, 80, 10)
+	a.Write(styledCorpus())
+
+	snap := a.Serialize()
+	if len(snap.VTDump) == 0 {
+		t.Fatal("empty VT dump")
+	}
+
+	b := newT(t, snap.Cols, snap.Rows)
+	b.Write(snap.VTDump)
+
+	plainA, plainB := a.PlainText(), b.PlainText()
+	if plainA != plainB {
+		t.Errorf("round-trip plain text mismatch\n A=%q\n B=%q", plainA, plainB)
+	}
+	if !strings.Contains(plainA, "line-001") {
+		t.Errorf("scrollback lost: line-001 not in plain text %q", firstN(plainA, 120))
+	}
+	if !strings.Contains(plainA, "final-prompt$") {
+		t.Errorf("viewport lost: prompt not present")
+	}
+}
+
+// TestRoundTripCursor asserts the restored cursor lands at the same position —
+// this is what the trailing-CUP fix in serializeLocked guarantees.
+func TestRoundTripCursor(t *testing.T) {
+	a := newT(t, 80, 10)
+	// Land the cursor at a known spot that is NOT a tabstop column, so the
+	// upstream cursor/tabstop ordering bug would move it if uncorrected.
+	a.Write([]byte("hello\r\nworld\x1b[3;7H"))
+	ax, ay := a.cursorXY()
+
+	b := newT(t, 80, 10)
+	b.Write(a.Serialize().VTDump)
+	bx, by := b.cursorXY()
+
+	if ax != bx || ay != by {
+		t.Errorf("cursor position mismatch after restore: A=(%d,%d) B=(%d,%d)", ax, ay, bx, by)
+	}
+}
+
+// TestReflowAfterRestore feeds a soft-wrapped long line, restores into B, then
+// resizes B narrower and asserts the content reflows (soft-wrap survived the
+// dump). It compares against terminal C which consumed the raw bytes then
+// resized — B and C must render identically.
+func TestReflowAfterRestore(t *testing.T) {
+	raw := []byte(strings.Repeat("wrapme-", 30) + "\r\n") // 210 chars
+	a := newT(t, 80, 10)
+	a.Write(raw)
+
+	b := newT(t, 80, 10)
+	b.Write(a.Serialize().VTDump)
+	b.Resize(40, 10)
+
+	c := newT(t, 80, 10)
+	c.Write(raw)
+	c.Resize(40, 10)
+
+	if got, want := b.PlainText(), c.PlainText(); got != want {
+		t.Errorf("reflow mismatch after resize\n restored=%q\n direct=%q", got, want)
+	}
+	// The wrapped payload must remain contiguous when newlines are stripped.
+	flat := strings.ReplaceAll(b.PlainText(), "\n", "")
+	if !strings.Contains(flat, "wrapme-wrapme-wrapme") {
+		t.Errorf("reflow corrupted long line: %q", firstN(flat, 120))
+	}
+}
+
+// TestQueryResponses asserts the terminal answers the codex bootstrap query
+// trio (CPR, DA1, kitty CSI ? u) via the write_pty callback, drained through
+// DrainResponses.
+func TestQueryResponses(t *testing.T) {
+	term := newT(t, 80, 10)
+	term.Write([]byte("\x1b[6n\x1b[c\x1b[?u"))
+	resp := string(term.DrainResponses())
+	if resp == "" {
+		t.Fatal("no query responses drained")
+	}
+	// CPR → CSI row;col R; DA1 → CSI ? … c; kitty → CSI ? <flags> u.
+	if !strings.Contains(resp, "R") {
+		t.Errorf("CPR not answered: %q", resp)
+	}
+	if !strings.Contains(resp, "c") {
+		t.Errorf("DA1 not answered: %q", resp)
+	}
+	if !strings.Contains(resp, "u") {
+		t.Errorf("kitty CSI ? u not answered: %q", resp)
+	}
+	// Draining again yields nothing.
+	if extra := term.DrainResponses(); extra != nil {
+		t.Errorf("responses not cleared on drain: %q", string(extra))
+	}
+}
+
+// TestMalformedInputSafe feeds hostile byte soup and asserts no crash and a
+// still-usable terminal.
+func TestMalformedInputSafe(t *testing.T) {
+	term := newT(t, 80, 10)
+	garbage := []byte("\x1b[999;999H\x1b[?xyz\x1b]999;bad\x07\xff\xfe\x1b[38;5;m\x1bP+q\x1b\\partial\x1b[")
+	term.Write(garbage)
+	// The garbage ends mid-CSI on purpose; a leading ESC in the next write
+	// aborts the dangling sequence (ESC always restarts an escape). This
+	// asserts the parser recovers and the terminal stays usable.
+	term.Write([]byte("\x1b[0mrecovered\r\n"))
+	if !strings.Contains(term.PlainText(), "recovered") {
+		t.Errorf("terminal unusable after garbage input")
+	}
+}
+
+// TestDumpHasNoInterrogativeSequences asserts a serialized dump never contains
+// queries or OSC 52 clipboard writes — bytes that would affect the host if the
+// client model tried to answer them. (Phase 2 hardens this further.)
+func TestDumpHasNoInterrogativeSequences(t *testing.T) {
+	term := newT(t, 80, 10)
+	term.Write(styledCorpus())
+	// Provoke query state without leaving queries in the grid.
+	term.Write([]byte("\x1b[6n\x1b[c"))
+	dump := term.Serialize().VTDump
+
+	banned := map[string][]byte{
+		"CPR request (ESC[6n)":   []byte("\x1b[6n"),
+		"DA1 request (ESC[c)":    []byte("\x1b[c"),
+		"OSC 52 clipboard":       []byte("\x1b]52;"),
+		"DA1 secondary (ESC[>c)": []byte("\x1b[>c"),
+		"XTVERSION (ESC[>q)":     []byte("\x1b[>q"),
+		"kitty query (ESC[?u)":   []byte("\x1b[?u"),
+	}
+	for name, seq := range banned {
+		if bytes.Contains(dump, seq) {
+			t.Errorf("serialized dump contains %s", name)
+		}
+	}
+}
+
+// TestCloseIdempotent asserts Close can be called multiple times safely.
+func TestCloseIdempotent(t *testing.T) {
+	term, err := New(20, 5, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	term.Write([]byte("hi"))
+	term.Close()
+	term.Close() // must not panic or double-free
+	// Post-close methods must be safe no-ops.
+	term.Write([]byte("ignored"))
+	if term.PlainText() != "" {
+		t.Errorf("PlainText after close should be empty")
+	}
+}
+
+// cursorXY reads the native cursor position (0-indexed) for tests.
+func (t *Terminal) cursorXY() (x, y int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.cursorXYLocked()
+}
+
+func firstN(s string, n int) string {
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}

--- a/internal/ghosttyvt/stub.go
+++ b/internal/ghosttyvt/stub.go
@@ -1,0 +1,56 @@
+//go:build !(darwin && arm64)
+
+// Package ghosttyvt's non-macOS-arm64 build is a portable no-op. The real
+// implementation links a native libghostty-vt static library that only exists
+// for aarch64-macos (see scripts/build-libghostty-vt.sh). attn is a macOS-only
+// product, but its Go code stays buildable on Linux for CI (vet + unit tests),
+// so this stub provides the same API surface with inert behavior.
+//
+// A stub Terminal serializes to nothing and renders nothing; callers already
+// treat the terminal as best-effort (every use in internal/pty is nil-safe and
+// tolerant of empty output), so nothing observes the difference off macOS.
+package ghosttyvt
+
+// DefaultMaxScrollback mirrors the real build's constant.
+const DefaultMaxScrollback = 10000
+
+// Options mirrors the real build's construction options.
+type Options struct {
+	MaxScrollback int
+}
+
+// Snapshot mirrors the real build's serialization result.
+type Snapshot struct {
+	Cols, Rows          int
+	VTDump              []byte
+	ScrollbackTruncated bool
+}
+
+// Terminal is the no-op stand-in for the native terminal off macOS/arm64.
+type Terminal struct {
+	cols, rows int
+}
+
+// New returns an inert terminal. It never fails so callers exercise the same
+// code path they do on macOS; every method is a no-op.
+func New(cols, rows int, _ Options) (*Terminal, error) {
+	return &Terminal{cols: cols, rows: rows}, nil
+}
+
+func (t *Terminal) Write(_ []byte) {}
+
+func (t *Terminal) Resize(cols, rows int) {
+	if cols > 0 && rows > 0 {
+		t.cols, t.rows = cols, rows
+	}
+}
+
+func (t *Terminal) DrainResponses() []byte { return nil }
+
+func (t *Terminal) Size() (cols, rows int) { return t.cols, t.rows }
+
+func (t *Terminal) PlainText() string { return "" }
+
+func (t *Terminal) Serialize() Snapshot { return Snapshot{Cols: t.cols, Rows: t.rows} }
+
+func (t *Terminal) Close() {}

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -18,6 +18,7 @@ import (
 
 	creackpty "github.com/creack/pty"
 	agentdriver "github.com/victorarias/attn/internal/agent"
+	"github.com/victorarias/attn/internal/ghosttyvt"
 	"github.com/victorarias/attn/internal/launchcontract"
 	"github.com/victorarias/attn/internal/launchenv"
 )
@@ -284,6 +285,13 @@ func (m *Manager) Spawn(opts SpawnOptions) error {
 		cleanup:     deferCleanup,
 	}
 	session.screen = newVirtualScreen(opts.Cols, opts.Rows)
+	// Shadow-mode server-authoritative terminal (Phase 1). A construction
+	// failure must never break the session — leave it nil; every use is guarded.
+	if gt, err := ghosttyvt.New(int(opts.Cols), int(opts.Rows), ghosttyvt.Options{}); err != nil {
+		m.logf("pty spawn: ghosttyvt terminal unavailable for id=%s: %v", opts.ID, err)
+	} else {
+		session.ghostty = gt
+	}
 
 	m.mu.Lock()
 	m.sessions[opts.ID] = session

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -7,12 +7,15 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
 
 	creackpty "github.com/creack/pty"
+
+	"github.com/victorarias/attn/internal/ghosttyvt"
 )
 
 // TerminalTheme carries the frontend's resolved terminal colors as "#rrggbb"
@@ -95,6 +98,13 @@ type Session struct {
 	scrollback *RingBuffer
 	replayLog  *ReplayLog
 	screen     *virtualScreen
+	// ghostty is the server-authoritative parsed terminal (libghostty-vt). In
+	// shadow mode it is fed the same bytes as the three stores above but nothing
+	// reads it in production yet (Phase 1). It answers query responses during
+	// Write; those are drained-and-discarded here so the scan-based responder
+	// stays the sole answerer. May be nil if construction failed — shadow mode
+	// must never break a session, so every use is nil-guarded.
+	ghostty    *ghosttyvt.Terminal
 	seqCounter atomic.Uint32
 
 	// replayMu makes the attach replay payload (scrollback / replay segments /
@@ -318,6 +328,13 @@ func (s *Session) readLoop(onExit func(exitCode int, signal string), logf func(s
 				if s.screen != nil {
 					s.screen.Observe(data)
 				}
+				if s.ghostty != nil {
+					// Shadow feed. Discard query responses in Phase 1: the
+					// scan-based responder above is the only PTY answerer;
+					// double answers would corrupt child app input.
+					s.ghostty.Write(data)
+					s.ghostty.DrainResponses()
+				}
 				s.lastReplaySeq = seq
 				s.replayMu.Unlock()
 				// The daemon is the single authority for CPR (cursor position)
@@ -377,6 +394,10 @@ func (s *Session) readLoop(onExit func(exitCode int, signal string), logf func(s
 		if s.screen != nil {
 			s.screen.Observe(carryover)
 		}
+		if s.ghostty != nil {
+			s.ghostty.Write(carryover)
+			s.ghostty.DrainResponses()
+		}
 		s.lastReplaySeq = seq
 		s.replayMu.Unlock()
 		s.fanOut(carryover, seq)
@@ -386,9 +407,89 @@ func (s *Session) readLoop(onExit func(exitCode int, signal string), logf func(s
 	exitCode, signal := parseExitStatus(waitErr)
 	s.markExited(exitCode, signal)
 
+	s.logShadowDivergence(logf)
+
 	if onExit != nil {
 		onExit(exitCode, signal)
 	}
+}
+
+// shadowDivergenceEnv gates the Phase 1 shadow divergence metric. When set to
+// "1", session close compares the ghostty viewport against the vt10x oracle and
+// logs the first differing row. Off by default (the comparison renders both
+// screens, which is cheap but not free).
+const shadowDivergenceEnv = "ATTN_GHOSTTY_SHADOW_DIVERGENCE"
+
+// logShadowDivergence compares the ghostty-parsed viewport against the vt10x
+// oracle's visible screen and logs the first divergence, if any. This is the
+// Phase 1 risk-burn signal: it tells us where the two emulators disagree on
+// real sessions before anything reads ghostty in production. Divergences where
+// vt10x is known-weak (truecolor, wide chars, reflow) are expected; triage
+// ghostty-side surprises. Best-effort and behind a debug flag.
+func (s *Session) logShadowDivergence(logf func(string, ...any)) {
+	if logf == nil || s.ghostty == nil || s.screen == nil {
+		return
+	}
+	if os.Getenv(shadowDivergenceEnv) != "1" {
+		return
+	}
+	oracle := s.screen.renderedText()
+	if oracle == "" {
+		return
+	}
+	s.metaMu.RLock()
+	rows := int(s.rows)
+	s.metaMu.RUnlock()
+	shadow := ghosttyViewportTail(s.ghostty.PlainText(), rows)
+
+	oracleLines := strings.Split(oracle, "\n")
+	shadowLines := strings.Split(shadow, "\n")
+	row, ok := firstDivergentRow(oracleLines, shadowLines)
+	if !ok {
+		logf("ghostty shadow: session %s viewport matches vt10x (%d rows)", s.id, len(oracleLines))
+		return
+	}
+	logf("ghostty shadow DIVERGENCE session %s row %d\n  vt10x:   %q\n  ghostty: %q",
+		s.id, row, rowAt(oracleLines, row), rowAt(shadowLines, row))
+}
+
+// ghosttyViewportTail extracts the visible viewport from ghostty's full-screen
+// plain text (which includes scrollback) by taking the last `rows` lines and
+// trimming trailing blank lines, to match vt10x renderedText's shape. Assumes
+// the terminal is scrolled to the bottom, which holds for a live session.
+func ghosttyViewportTail(plain string, rows int) string {
+	lines := strings.Split(plain, "\n")
+	// Trim trailing blank rows first (viewport bottom padding + the formatter's
+	// trailing newline) so the last line is real content, then window to the
+	// bottom `rows` lines — mirroring renderedText's shape.
+	for len(lines) > 0 && strings.TrimRight(lines[len(lines)-1], " ") == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if rows > 0 && len(lines) > rows {
+		lines = lines[len(lines)-rows:]
+	}
+	// Trailing whitespace per row also differs cosmetically; normalize.
+	for i := range lines {
+		lines[i] = strings.TrimRight(lines[i], " ")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func firstDivergentRow(a, b []string) (int, bool) {
+	n := max(len(a), len(b))
+	for i := range n {
+		if rowAt(a, i) != rowAt(b, i) {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func rowAt(lines []string, i int) string {
+	if i < 0 || i >= len(lines) {
+		return ""
+	}
+	return lines[i]
 }
 
 // approvalEvalInterval throttles how often the readLoop path inspects the
@@ -684,6 +785,9 @@ func (s *Session) resize(cols, rows uint16) error {
 	if s.screen != nil {
 		s.screen.Resize(cols, rows)
 	}
+	if s.ghostty != nil {
+		s.ghostty.Resize(int(cols), int(rows))
+	}
 
 	return creackpty.Setsize(s.ptmx, &creackpty.Winsize{Cols: cols, Rows: rows})
 }
@@ -745,6 +849,9 @@ func (s *Session) kill(sig syscall.Signal, waitTimeout time.Duration) error {
 
 func (s *Session) closePTY() {
 	_ = s.ptmx.Close()
+	if s.ghostty != nil {
+		s.ghostty.Close()
+	}
 }
 
 func detectTerminalQueries(data []byte) terminalQueries {

--- a/internal/pty/shadow_divergence_test.go
+++ b/internal/pty/shadow_divergence_test.go
@@ -1,0 +1,53 @@
+package pty
+
+import "testing"
+
+func TestGhosttyViewportTail(t *testing.T) {
+	tests := []struct {
+		name  string
+		plain string
+		rows  int
+		want  string
+	}{
+		{
+			name:  "takes last rows and trims trailing blanks",
+			plain: "scroll1\nscroll2\nprompt$ \n\n",
+			rows:  2,
+			want:  "scroll2\nprompt$",
+		},
+		{
+			name:  "trims trailing per-row whitespace",
+			plain: "a   \nb  ",
+			rows:  2,
+			want:  "a\nb",
+		},
+		{
+			name:  "fewer lines than rows returns all",
+			plain: "only",
+			rows:  10,
+			want:  "only",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ghosttyViewportTail(tt.plain, tt.rows); got != tt.want {
+				t.Errorf("ghosttyViewportTail(%q,%d) = %q, want %q", tt.plain, tt.rows, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFirstDivergentRow(t *testing.T) {
+	if _, ok := firstDivergentRow([]string{"a", "b"}, []string{"a", "b"}); ok {
+		t.Errorf("identical inputs reported divergence")
+	}
+	row, ok := firstDivergentRow([]string{"a", "b", "c"}, []string{"a", "X", "c"})
+	if !ok || row != 1 {
+		t.Errorf("got (row=%d ok=%v), want (1 true)", row, ok)
+	}
+	// Length mismatch: the extra row diverges against "".
+	row, ok = firstDivergentRow([]string{"a"}, []string{"a", "b"})
+	if !ok || row != 1 {
+		t.Errorf("length mismatch: got (row=%d ok=%v), want (1 true)", row, ok)
+	}
+}

--- a/scripts/build-libghostty-vt.sh
+++ b/scripts/build-libghostty-vt.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Build the NATIVE libghostty-vt static library + headers used by the worker's
+# server-authoritative terminal restore path (internal/ghosttyvt).
+#
+# Source of truth for third_party/ghostty-vt/ (gitignored). Reads its OWN pin
+# (ghostty-vt-native.pin) — separate from the frontend WASM build's pin, because
+# the Terminal C API this project needs does not exist at the WASM pin. See the
+# pin file and docs/plans/2026-07-22-server-authoritative-terminal.md.
+#
+# Requires zig 0.16.x (installed via asdf alongside the WASM build's 0.15.x).
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_dir="$(cd "$script_dir/.." && pwd)"
+pin_file="$repo_dir/ghostty-vt-native.pin"
+patch_file="$repo_dir/ghostty-vt-native.patch"
+output_dir="$repo_dir/third_party/ghostty-vt"
+
+# The pin file may carry leading comment lines; take the first non-comment,
+# non-blank line as the commit.
+ghostty_commit="$(grep -vE '^\s*(#|$)' "$pin_file" | head -n1 | tr -d '[:space:]')"
+if [[ -z "$ghostty_commit" ]]; then
+  echo "error: no commit found in $pin_file" >&2
+  exit 1
+fi
+
+zig="${ZIG:-$(command -v zig)}"
+zig_version="$("$zig" version)"
+case "$zig_version" in
+  0.16.*) ;;
+  *) echo "error: need zig 0.16.x, found $zig_version (asdf: 'asdf local zig 0.16.0')" >&2; exit 1 ;;
+esac
+
+sdkroot="${SDKROOT:-$(xcrun --show-sdk-path)}"
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/attn-libghostty-vt.XXXXXX")"
+
+cleanup() {
+  rm -rf "$workdir"
+}
+trap cleanup EXIT
+
+echo "==> cloning ghostty @ $ghostty_commit"
+git init -q "$workdir/ghostty"
+git -C "$workdir/ghostty" remote add origin https://github.com/ghostty-org/ghostty.git
+git -C "$workdir/ghostty" fetch -q --depth=1 origin "$ghostty_commit"
+git -C "$workdir/ghostty" checkout -q --detach FETCH_HEAD
+
+# Carried patches (e.g. exposing the primary-vs-alt ScreenFormatter through the
+# C API). Applied only when present so the build works before the patch lands.
+if [[ -f "$patch_file" ]]; then
+  echo "==> applying $patch_file"
+  git -C "$workdir/ghostty" apply "$patch_file"
+fi
+
+echo "==> zig build -Demit-lib-vt=true (zig $zig_version)"
+pushd "$workdir/ghostty" >/dev/null
+env SDKROOT="$sdkroot" "$zig" build \
+  -Demit-lib-vt=true \
+  -Dtarget=aarch64-macos \
+  -Doptimize=ReleaseFast \
+  --summary none \
+  --prefix "$workdir/prefix"
+popd >/dev/null
+
+echo "==> installing to $output_dir"
+rm -rf "$output_dir"
+mkdir -p "$output_dir/lib" "$output_dir/include"
+cp "$workdir/prefix/lib/libghostty-vt.a" "$output_dir/lib/"
+cp -R "$workdir/prefix/include/ghostty" "$output_dir/include/"
+
+echo "$ghostty_commit" > "$output_dir/.built-commit"
+chmod -R u+w "$output_dir"
+shasum -a 256 "$output_dir/lib/libghostty-vt.a"
+echo "==> done: $output_dir"


### PR DESCRIPTION
First slice of the server-authoritative terminal initiative. **Targets the `epic/server-authoritative-terminal` integration branch, not `main`** — the epic stays open until the full migration (through Phase 3) is done.

Plan: `docs/plans/2026-07-22-server-authoritative-terminal.md`

## What this does
Adds a worker-side authoritative parsed terminal (libghostty-vt via cgo) in **shadow mode**: it's fed the same bytes as the existing replay stores, but **nothing reads it in production yet**, so app behavior is unchanged. This is pure risk-burn — it proves the emulator, the cgo integration, and the build/sign path before any restore logic depends on it.

### Phase 0 — native lib build infra
- `scripts/build-libghostty-vt.sh` + `ghostty-vt-native.pin` (pinned `ab0b9da`, deliberately **separate** from the frontend WASM pin — the Terminal C API doesn't exist at the WASM pin).
- Reproducible: a fresh build produced the identical `libghostty-vt.a` SHA as the spike. Output vendored to gitignored `third_party/ghostty-vt/`; the script applies `ghostty-vt-native.patch` when present (alt-screen patch lands in Phase 2).

### Phase 1 — emulator in the worker, shadow mode
- **`internal/ghosttyvt`**: new package owning all cgo (`New/Write/Resize/DrainResponses/PlainText/Serialize/Close`), a `cgo.Handle`-routed `write_pty` callback for query responses, finalizer backstop, and the trailing-CUP fix for the upstream cursor/tabstop ordering bug. Gated to `darwin/arm64`; a portable **no-op stub** keeps the package building on Linux CI.
- **`internal/pty`** feeds it under `replayMu` at both read-loop write sites, resizes it, and closes it in `closePTY`. Every use is nil-guarded so a construction failure can never break a session. `DrainResponses()` is discarded this phase (the scanner stays the sole query answerer).
- **Shadow divergence metric** (`ATTN_GHOSTTY_SHADOW_DIVERGENCE=1`): on session close, compares the ghostty viewport against the vt10x oracle and logs the first differing row.

## Tests
- `internal/ghosttyvt`: round-trip (plain text / cursor / reflow-vs-direct-resize), codex query trio incl. kitty `CSI ? u`, malformed-input safety, no-interrogative-sequences guard, Close idempotency.
- `internal/pty`: divergence helper unit tests.
- Full `go test ./...` green. Linux cross-build + vet + test-compile verified (stub path).

## Live verification (throwaway `vtshadow` profile, full install)
- cgo binary **codesigns cleanly** (no ad-hoc fallback) — retires the plan's cgo-signing worry.
- Preflight PASS (protocol 180).
- `real-app:scenario-ghostty-scroll` **PASS** — existing scroll-anchor behavior unchanged.
- Worker log: ghostty viewport **matched vt10x exactly (26 rows)** on a real streamed session; **zero panics / cgo faults / construction failures** across spawn→feed→teardown.

## Not in this slice
`Serialize()` production path, alt-screen patch, protocol `snapshot` field, daemon/frontend wiring, codex bootstrap (Phase 2), and flip-default + delete-raw-replay (Phase 3, gated on Victor's approval). Real recorded byte corpora are also still to come (tests use a synthetic corpus).

https://claude.ai/code/session_01JDZsPbL6PLMxowhNaL17hX