### PR TITLE
test(automations): PR7 — proving matrix on a fresh profile with daemon-restart recovery leg

### DIFF
--- a/app/scripts/real-app-harness/scenario-automation-pr-continuity.mjs
+++ b/app/scripts/real-app-harness/scenario-automation-pr-continuity.mjs
@@ -302,6 +302,32 @@ async function main() {
       runner.assert(ticket?.status === 'working' && !ticket.archived_at, 'successful continuation reopens and unarchives the ticket', ticket);
       return row;
     });
+    await runner.step('daemon_restart_preserves_continuity', async () => {
+      // Quit the app before restarting: a running app respawns the daemon
+      // without the mock GitHub env and would invalidate the leg.
+      await client.quitApp();
+      await observer.close().catch(() => {});
+      try { run(binary, ['daemon', 'stop'], daemonEnv); } catch {}
+      run(binary, ['daemon', 'ensure'], daemonEnv);
+      await poll(() => {
+        try { runJSON(binary, ['automation', 'list'], daemonEnv); return { ready: true }; } catch { return null; }
+      }, 'restarted profile daemon');
+      await launchFreshAppAndConnect(client, observer, { sweepStaleSessions: false });
+      await client.request('close_session', { sessionId: sessionID });
+      await observer.waitFor(() => !observer.getSession(sessionID) ? true : null, 'reviewer to unregister after restart');
+      await setRequested(mock.url, false);
+      await wsRequest(options.wsUrl, { cmd: 'refresh_prs' }, 'refresh_prs_result');
+      await setRequested(mock.url, true);
+      await wsRequest(options.wsUrl, { cmd: 'refresh_prs' }, 'refresh_prs_result');
+      const row = await poll(() => {
+        const rows = runJSON(binary, ['automation', 'runs', definitionID], daemonEnv) || [];
+        return rows.length >= 3 && rows[0].state === 'delivered' ? rows[0] : null;
+      }, 'post-restart delivered continuation', 45_000);
+      runner.assert(row.session_id === sessionID && row.ticket_id === ticketID, 'post-restart continuation reuses the same session and ticket', row);
+      const calls = await poll(() => invocations(probe.log).length >= 3 ? invocations(probe.log) : null, 'post-restart Codex resume launch');
+      runner.assert(calls[2].argv.includes('resume'), 'post-restart launch resumes rather than starting fresh', { argv: calls[2].argv });
+      runner.assert(fs.readFileSync(path.join(worktree, 'review-notes.txt'), 'utf8').includes('preserve me'), 'reviewer work survives the daemon restart');
+    });
     await runner.step('assert_missing_worktree_fails_visibly', async () => {
       await client.request('close_session', { sessionId: sessionID });
       await observer.waitFor(() => !observer.getSession(sessionID) ? true : null, 'continued reviewer to unregister');
@@ -312,7 +338,7 @@ async function main() {
       await wsRequest(options.wsUrl, { cmd: 'refresh_prs' }, 'refresh_prs_result');
       const failed = await poll(() => {
         const rows = runJSON(binary, ['automation', 'runs', definitionID], daemonEnv) || [];
-        return rows.length >= 3 && rows[0].state === 'failed' ? rows[0] : null;
+        return rows.length >= 4 && rows[0].state === 'failed' ? rows[0] : null;
       }, 'visible missing-worktree failure', 30_000);
       runner.assert(String(failed.last_error).includes('worktree') && String(failed.last_error).includes('missing'), 'missing delivered worktree fails without recreation', failed);
     });

--- a/docs/plans/2026-07-21-automations-v2-simplification.md
+++ b/docs/plans/2026-07-21-automations-v2-simplification.md
@@ -173,9 +173,18 @@ real concept and drives binding rotation.
       `expected_revision` guard survives. Landed 2026-07-23; live-verified on the dev profile via
       scenario-automation-form.mjs (11 legs) plus the lifecycle and surface
       scenarios.
-- [ ] **PR7 — proving matrix.** Both vision proving cases end-to-end on a
+- [x] **PR7 — proving matrix.** Both vision proving cases end-to-end on a
       fresh profile (PR pre-review with continuity + scheduled worktree
-      cleanup), daemon-restart recovery leg, changelog.
+      cleanup), daemon-restart recovery leg, changelog. Landed 2026-07-23:
+      both proving scenarios ran green on a fresh throwaway profile
+      (`pr7prove`, protocol-182 preflight all-PASS) —
+      scenario-automation-pr-continuity.mjs with a new
+      `daemon_restart_preserves_continuity` leg (post-restart re-request
+      resumes the same session/ticket via Codex resume, dirty reviewer work
+      intact) and scenario-automation-scheduled-cleanup.mjs (4 legs incl.
+      restart catch-up, real codex cleanup, storm guard). No new CHANGELOG
+      entry: PR7 adds test coverage only; all v2 user-visible behavior was
+      changelogged with PR5/PR6.
 
 ## Decisions
 


### PR DESCRIPTION
Final step of docs/plans/2026-07-21-automations-v2-simplification.md: run both vision proving cases end-to-end on a fresh profile, add the missing daemon-restart recovery leg, and settle the changelog question.

**Code change**: `scenario-automation-pr-continuity.mjs` gains a `daemon_restart_preserves_continuity` leg between the resume leg and the missing-worktree leg: quit the app (so it cannot respawn the daemon without the mock GitHub env), restart the profile daemon, relaunch, withdraw/re-request — and assert the continuity binding still resumes the **same session and ticket** via a Codex `resume` launch with the reviewer's dirty work intact. The scheduled side already had a restart catch-up leg; this covers the observed-event side. The follow-on missing-worktree leg's row-count predicate moves from >=3 to >=4 accordingly.

**Live proof on a fresh throwaway profile `pr7prove`** (never dev/prod; bundled preflight all-PASS at protocol 182, codex preflight PASS):
- `scenario-automation-pr-continuity.mjs` — green, 10/10 steps in 19.5s, including the new restart leg (post-restart occurrence `:3` delivered to the same session/ticket, argv contains `resume` with pinned model/effort, `review-notes.txt` intact).
- `scenario-automation-scheduled-cleanup.mjs` — green, 4/4 legs in 9.6 min: anchor tick, restart catch-up after 135s simulated downtime, real codex merged-worktree cleanup evidence, singleton coalescing, storm-guard restart under `fresh` continuity.

**Changelog**: intentionally no new entry — this PR adds test coverage only; every v2 user-visible behavior was already changelogged with PR5 (#637) and PR6 (#640).

Claude-Session: https://claude.ai/code/session_01APU1R83oaVeshfJM5W5QCM