### PR TITLE
build(plugins): sweep orphaned Bun compile temps

### DIFF
--- a/scripts/build-bundled-plugins.sh
+++ b/scripts/build-bundled-plugins.sh
@@ -84,6 +84,11 @@ stage_plugin() {
   rm -rf "${stage_dir}"
   mkdir -p "${stage_dir}/bin"
   bun build "${source_dir}/src/index.ts" --compile --minify --outfile "${stage_dir}/bin/${name}"
+  # `bun build --compile` writes to a `*.bun-build` temp next to the outfile and
+  # renames it into place on success, but occasionally leaves the temp behind
+  # (a complete, signed Mach-O that only clutters the output dir). Sweep any
+  # orphans so they don't linger next to the real binary and confuse people.
+  find "${stage_dir}/bin" -maxdepth 1 -name '*.bun-build' -delete
   # Bun emits a linker-signed Mach-O. Some dependency graphs leave bytes after
   # the declared signature, which prevents macOS codesign from replacing it.
   # Normalize the generated executable before Tauri copies and signs the bundle.


### PR DESCRIPTION
## Summary
- remove orphaned `*.bun-build` temporary files after each bundled plugin compile
- keep staged plugin directories limited to the intended executable binaries

## Why
`bun build --compile` can occasionally leave its adjacent temporary Mach-O behind after a successful rename, cluttering the bundle output.

## Verification
- `bash -n scripts/build-bundled-plugins.sh`
- `bash scripts/build-bundled-plugins.sh` end-to-end: both plugins staged cleanly, no `*.bun-build` orphans remained, and the real binaries were intact.

## Live verification
Not applicable: this is build-script-only output hygiene with no app or daemon-observable behavior.