### PR TITLE
test(tickets): fix ticket-overlay status-select flake

### DIFF
--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.ticketOverlay.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.ticketOverlay.test.tsx
@@ -145,7 +145,7 @@ describe('SessionTerminalWorkspace ticket overlay', () => {
   it('routes a status change through onChangeStatus (wiring proof)', async () => {
     const { getByTestId, onChangeStatus } = renderWorkspace({ ticket: makeTicket() });
     fireEvent.click(getByTestId('ticket-chip-sess-1'));
-    await waitFor(() => getByTestId('ticket-detail-panel'));
+    await waitFor(() => getByTestId('ticket-status-select'));
 
     fireEvent.change(getByTestId('ticket-status-select'), { target: { value: 'done' } });
 


### PR DESCRIPTION
The ticket detail panel container mounts before the async fetchTicket resolves. The test waited for the panel, then immediately fired a change event at ticket-status-select, which renders only after that async load completes — a race condition that flakes under CI load (manifested as a false failure on PR #647's Frontend check).

The fix: wait for the interactive select element itself, ensuring it's rendered and ready before firing the event.

https://claude.ai/code/session_01JDZsPbL6PLMxowhNaL17hX