### PR TITLE
feat(pty): repoint approval/CPR/snapshot readers to ghostty (retirement Phase 2)

### DIFF
--- a/internal/daemon/automations_deliver.go
+++ b/internal/daemon/automations_deliver.go
@@ -711,6 +711,50 @@ func automationSessionPrompt(configuredPrompt, inputPath string, localOnlyReview
 
 const codexDirectoryTrustPrompt = "Do you trust the contents of this directory?"
 
+// stripANSIForPromptMatch removes terminal control sequences from a rendered VT
+// stream so screen prompts can be matched independently of formatting and cursor
+// positioning.
+func stripANSIForPromptMatch(data []byte) string {
+	out := make([]byte, 0, len(data))
+	for i := 0; i < len(data); {
+		if data[i] != 0x1b {
+			out = append(out, data[i])
+			i++
+			continue
+		}
+		if i+1 >= len(data) {
+			break
+		}
+		switch data[i+1] {
+		case '[':
+			i += 2
+			for i < len(data) {
+				if data[i] >= 0x40 && data[i] <= 0x7e {
+					i++
+					break
+				}
+				i++
+			}
+		case ']':
+			i += 2
+			for i < len(data) {
+				if data[i] == 0x07 {
+					i++
+					break
+				}
+				if data[i] == 0x1b && i+1 < len(data) && data[i+1] == '\\' {
+					i += 2
+					break
+				}
+				i++
+			}
+		default:
+			i += 2
+		}
+	}
+	return string(out)
+}
+
 // passUnattendedLaunchGate completes the one driver-owned confirmation that is
 // still shown for some non-repository directories even when Codex receives an
 // explicit trusted-project override. Definition application is the user's
@@ -732,7 +776,7 @@ func (d *Daemon) passUnattendedLaunchGate(req automation.WorkRequest) error {
 	for time.Now().Before(deadline) {
 		info, err := snapshots.Snapshot(context.Background(), req.IDs.SessionID)
 		if err == nil {
-			screen := string(info.ScreenSnapshot)
+			screen := stripANSIForPromptMatch(info.ScreenSnapshot)
 			if strings.Contains(screen, codexDirectoryTrustPrompt) {
 				if !acknowledged {
 					if err := d.ptyBackend.Input(context.Background(), req.IDs.SessionID, []byte("\r")); err != nil {

--- a/internal/daemon/automations_test.go
+++ b/internal/daemon/automations_test.go
@@ -52,6 +52,13 @@ func (b *automationResumeBackend) Snapshot(context.Context, string) (ptybackend.
 	return ptybackend.AttachInfo{ScreenSnapshot: []byte("reviewer ready")}, nil
 }
 
+func TestStripANSIForPromptMatch_PreservesStyledSplitPrompt(t *testing.T) {
+	stream := []byte("\x1b[2J\x1b[H\x1b[1;36mDo you trust \x1b[0m\x1b[8;4Hthe contents \x1b]8;;https://example.com\x1b\\of this directory?\x1b]8;;\x1b\\\x1b7")
+	if got := stripANSIForPromptMatch(stream); !strings.Contains(got, codexDirectoryTrustPrompt) {
+		t.Fatalf("stripped stream = %q, want prompt %q", got, codexDirectoryTrustPrompt)
+	}
+}
+
 func testAutomationLaunch(agent string) automation.EffectiveLaunch {
 	driverMode := launchcontract.ApprovalAuto
 	if agent == string(protocol.SessionAgentCodex) {

--- a/internal/pty/approval_resolver_test.go
+++ b/internal/pty/approval_resolver_test.go
@@ -101,25 +101,30 @@ func TestApprovalResolver_ClearsAfterPromptGoneAndDebounce(t *testing.T) {
 	}
 }
 
-// renderedText must resolve absolute-cursor-addressed output (how TUIs actually
+// ViewportText must resolve absolute-cursor-addressed output (how TUIs actually
 // paint the prompt) into linear text, where the raw byte tail would not.
-func TestRenderedText_ResolvesCursorAddressedPrompt(t *testing.T) {
-	screen := newVirtualScreen(80, 24)
-	// Clear + home, then paint the prompt out of order via absolute moves.
-	screen.Observe([]byte("\x1b[2J\x1b[H"))
-	screen.Observe([]byte("\x1b[7;3H2. No"))
-	screen.Observe([]byte("\x1b[5;1HDo you want to proceed?"))
-	screen.Observe([]byte("\x1b[6;1H❯ 1. Yes"))
+func TestViewportText_ResolvesCursorAddressedPrompt(t *testing.T) {
+	term := newTestGhostty(t, 80, 24)
+	write := func(data string) {
+		t.Helper()
+		term.Write([]byte(data))
+	}
 
-	text := screen.renderedText()
+	// Clear + home, then paint the prompt out of order via absolute moves.
+	write("\x1b[2J\x1b[H")
+	write("\x1b[7;3H2. No")
+	write("\x1b[5;1HDo you want to proceed?")
+	write("\x1b[6;1H❯ 1. Yes")
+
+	text := term.ViewportText()
 	if !isPendingApproval(text) {
 		t.Fatalf("rendered prompt should be detected as pending approval; got:\n%s", text)
 	}
 
 	// After approval the area is repainted with the result; prompt is gone.
-	screen.Observe([]byte("\x1b[2J\x1b[H\x1b[5;1H⏺ Done"))
-	if isPendingApproval(screen.renderedText()) {
-		t.Fatalf("repainted screen should no longer look pending; got:\n%s", screen.renderedText())
+	write("\x1b[2J\x1b[H\x1b[5;1H⏺ Done")
+	if isPendingApproval(term.ViewportText()) {
+		t.Fatalf("repainted screen should no longer look pending; got:\n%s", term.ViewportText())
 	}
 }
 
@@ -163,9 +168,11 @@ func TestApprovalResolver_PromptReappearsResetsDebounce(t *testing.T) {
 // the timer.
 func TestSession_ApprovalClearsWithoutFurtherOutput(t *testing.T) {
 	states := make(chan string, 8)
+	gt := newTestGhostty(t, 80, 24)
 	s := &Session{
 		approvalResolver: &approvalResolver{},
 		screen:           newVirtualScreen(80, 24),
+		ghostty:          gt,
 		onState:          func(state string) { states <- state },
 	}
 	s.running = true
@@ -173,8 +180,8 @@ func TestSession_ApprovalClearsWithoutFurtherOutput(t *testing.T) {
 	paint := func(screen string) {
 		// Clear+home, then paint the screen with CRLF line breaks so each row
 		// starts at column 0 (matching how a TUI repaints).
-		s.screen.Observe([]byte("\x1b[2J\x1b[H"))
-		s.screen.Observe([]byte(strings.ReplaceAll(screen, "\n", "\r\n")))
+		s.ghostty.Write([]byte("\x1b[2J\x1b[H"))
+		s.ghostty.Write([]byte(strings.ReplaceAll(screen, "\n", "\r\n")))
 	}
 
 	// Approval prompt appears -> pending emitted immediately (readLoop path).

--- a/internal/pty/attach_race_test.go
+++ b/internal/pty/attach_race_test.go
@@ -42,6 +42,7 @@ func TestAttachSnapshotSeqConsistency(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = w.Close(); _ = r.Close() })
 
+	gt := newTestGhostty(t, cols, rows)
 	s := &Session{
 		id:          "race",
 		cols:        cols,
@@ -49,6 +50,8 @@ func TestAttachSnapshotSeqConsistency(t *testing.T) {
 		ptmx:        r,
 		cmd:         &exec.Cmd{}, // unstarted: readLoop's Wait() returns an error, never panics
 		screen:      newVirtualScreen(cols, rows),
+		ghostty:     gt,
+		blockFeed:   newBlockFeeder(gt),
 		subscribers: make(map[string]*sessionSubscriber),
 		running:     true,
 		exited:      make(chan struct{}),
@@ -178,6 +181,7 @@ func TestScreenSnapshotSeqConsistency(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = w.Close(); _ = r.Close() })
 
+	gt := newTestGhostty(t, cols, rows)
 	s := &Session{
 		id:          "snapshot-race",
 		cols:        cols,
@@ -185,6 +189,8 @@ func TestScreenSnapshotSeqConsistency(t *testing.T) {
 		ptmx:        r,
 		cmd:         &exec.Cmd{}, // unstarted: readLoop's Wait() returns an error, never panics
 		screen:      newVirtualScreen(cols, rows),
+		ghostty:     gt,
+		blockFeed:   newBlockFeeder(gt),
 		subscribers: make(map[string]*sessionSubscriber),
 		running:     true,
 		exited:      make(chan struct{}),

--- a/internal/pty/cpr_response_test.go
+++ b/internal/pty/cpr_response_test.go
@@ -33,6 +33,7 @@ func TestDaemonAnswersCPRAndDA1FromReadLoop(t *testing.T) {
 	peer := os.NewFile(uintptr(fds[1]), "peer")
 	t.Cleanup(func() { _ = ptmx.Close(); _ = peer.Close() })
 
+	gt := newTestGhostty(t, cols, rows)
 	s := &Session{
 		id:          "cpr",
 		cols:        cols,
@@ -40,6 +41,8 @@ func TestDaemonAnswersCPRAndDA1FromReadLoop(t *testing.T) {
 		ptmx:        ptmx,
 		cmd:         &exec.Cmd{}, // unstarted: readLoop's Wait() returns an error, never panics
 		screen:      newVirtualScreen(cols, rows),
+		ghostty:     gt,
+		blockFeed:   newBlockFeeder(gt),
 		subscribers: make(map[string]*sessionSubscriber),
 		running:     true,
 		exited:      make(chan struct{}),
@@ -92,6 +95,7 @@ func TestTerminalQueryRepliesPreserveChunkOrder(t *testing.T) {
 	peer := os.NewFile(uintptr(fds[1]), "peer")
 	t.Cleanup(func() { _ = ptmx.Close(); _ = peer.Close() })
 
+	gt := newTestGhostty(t, cols, rows)
 	s := &Session{
 		id:          "query-order",
 		cols:        cols,
@@ -99,6 +103,8 @@ func TestTerminalQueryRepliesPreserveChunkOrder(t *testing.T) {
 		ptmx:        ptmx,
 		cmd:         &exec.Cmd{}, // unstarted: readLoop's Wait() returns an error, never panics
 		screen:      newVirtualScreen(cols, rows),
+		ghostty:     gt,
+		blockFeed:   newBlockFeeder(gt),
 		subscribers: make(map[string]*sessionSubscriber),
 		running:     true,
 		exited:      make(chan struct{}),

--- a/internal/pty/ghostty_test.go
+++ b/internal/pty/ghostty_test.go
@@ -1,0 +1,20 @@
+package pty
+
+import (
+	"testing"
+
+	"github.com/victorarias/attn/internal/ghosttyvt"
+)
+
+func newTestGhostty(t *testing.T, cols, rows int) *ghosttyvt.Terminal {
+	t.Helper()
+	term, err := ghosttyvt.New(cols, rows, ghosttyvt.Options{})
+	if err != nil {
+		t.Fatalf("ghosttyvt.New(%d, %d): %v", cols, rows, err)
+	}
+	t.Cleanup(term.Close)
+	if term.Serialize().VTDump == nil {
+		t.Skip("ghosttyvt returned a nil VT dump; skipping on the non-native stub")
+	}
+	return term
+}

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -93,12 +93,12 @@ type Session struct {
 	// such as an isolated startup-file overlay for an interactive shell pane.
 	cleanup func()
 
-	// screen is the vt10x-parsed visible frame. It backs approval-state
-	// detection, CPR replies, and the read-only grid/automation screen snapshot
-	// (Manager.Snapshot); it is not the attach-restore source (ghostty is).
+	// screen is the vt10x-parsed visible frame. It stays fed as a fallback
+	// implementation while ghostty backs terminal readers and attach restore.
 	screen *virtualScreen
-	// ghostty is the server-authoritative parsed terminal (libghostty-vt). It is
-	// serialized on attach to restore the client's terminal (see info()). It
+	// ghostty is the server-authoritative parsed terminal (libghostty-vt). It
+	// backs approval-state detection, CPR replies, the grid/automation screen
+	// snapshot (Manager.Snapshot), and attach restore (see info()). It
 	// answers query responses during Write; the read loop forwards the responses
 	// the scan-based responder does not cover (e.g. kitty CSI ? u) so the worker
 	// is the complete query answerer and a snapshot-restored client can suppress
@@ -508,14 +508,14 @@ func isOSCColorReport(seq []byte) bool {
 // staying well below approvalClearDebounce.
 const approvalEvalInterval = 100 * time.Millisecond
 
-// evaluateApproval samples the rendered screen and applies any approval-state
+// evaluateApproval samples the rendered terminal and applies any approval-state
 // transition the resolver reports. It runs on two paths: the readLoop output path
 // (throttle=true, so high-frequency frames don't re-render constantly) and a
 // scheduled recheck (throttle=false). The scheduled recheck is what lets the
 // pending_approval->working clear complete even when the approved command goes
 // quiet and emits no further PTY output.
 func (s *Session) evaluateApproval(now time.Time, throttle bool) {
-	if s.approvalResolver == nil || s.onState == nil || s.screen == nil {
+	if s.approvalResolver == nil || s.onState == nil || s.ghostty == nil {
 		return
 	}
 	// Never emit a transition for a session that has already exited; a late
@@ -533,7 +533,7 @@ func (s *Session) evaluateApproval(now time.Time, throttle bool) {
 		return
 	}
 	s.lastApprovalEval = now
-	signal := s.approvalResolver.observe(s.screen.renderedText(), now)
+	signal := s.approvalResolver.observe(s.ghostty.ViewportText(), now)
 	switch signal {
 	case approvalClearStarted:
 		s.scheduleApprovalRecheckLocked()
@@ -700,12 +700,13 @@ func (s *Session) info() AttachInfo {
 	}
 }
 
-// screenSnapshot is a lean, read-only view of the current rendered screen plus
-// the sequence watermark. Unlike info() it omits scrollback and replay history,
-// so it is cheap enough to call for many sessions at once (e.g. seeding every
-// grid tile). It registers no subscriber and claims no geometry.
+// screenSnapshot is a lean, read-only ghostty viewport serialization plus the
+// sequence watermark. Its styled VT stream replays into a fresh Ghostty model;
+// unlike info() it omits scrollback and replay history, so it is cheap enough to
+// call for many sessions at once (e.g. seeding every grid tile). It registers no
+// subscriber and claims no geometry.
 //
-// The screen and its watermark are captured atomically under replayMu — the
+// The viewport and its watermark are captured atomically under replayMu — the
 // same critical section the read loop uses to apply a chunk and advance
 // lastReplaySeq — so LastSeq names exactly the last chunk baked into this
 // snapshot, matching info()/Attach semantics (the two must not diverge).
@@ -735,14 +736,16 @@ func (s *Session) screenSnapshot() AttachInfo {
 		Running: running,
 	}
 	s.replayMu.Lock()
-	if s.screen != nil {
-		if snapshot, ok := s.screen.Snapshot(); ok {
-			info.ScreenSnapshot = snapshot.payload
-			info.ScreenCols = snapshot.cols
-			info.ScreenRows = snapshot.rows
-			info.ScreenCursorX = snapshot.cursorX
-			info.ScreenCursorY = snapshot.cursorY
-			info.ScreenCursorVisible = snapshot.cursorVisible
+	if s.ghostty != nil {
+		snapshot := s.ghostty.SerializeViewport()
+		if snapshot.VTDump != nil {
+			info.ScreenSnapshot = snapshot.VTDump
+			info.ScreenCols = uint16(snapshot.Cols)
+			info.ScreenRows = uint16(snapshot.Rows)
+			x, y := s.ghostty.CursorPos()
+			info.ScreenCursorX = uint16(x)
+			info.ScreenCursorY = uint16(y)
+			info.ScreenCursorVisible = s.ghostty.CursorVisible()
 			info.ScreenSnapshotFresh = true
 		}
 	}
@@ -960,11 +963,9 @@ func isValidHexColor(value string) bool {
 // is no double-reply to confuse the shell.
 func (s *Session) writeCursorPositionResponse(logf func(string, ...any)) {
 	row, col := 1, 1
-	if s.screen != nil {
-		if snapshot, ok := s.screen.Snapshot(); ok {
-			row = int(snapshot.cursorY) + 1
-			col = int(snapshot.cursorX) + 1
-		}
+	if s.ghostty != nil {
+		x, y := s.ghostty.CursorPos()
+		row, col = y+1, x+1
 	}
 	s.writeMu.Lock()
 	_, _ = fmt.Fprintf(s.ptmx, "\x1b[%d;%dR", row, col)

--- a/internal/pty/snapshot_test.go
+++ b/internal/pty/snapshot_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/hinshun/vt10x"
+
+	"github.com/victorarias/attn/internal/ghosttyvt"
 )
 
 func TestVirtualScreenSnapshot_RoundTrip(t *testing.T) {
@@ -141,15 +143,17 @@ func TestVirtualScreenSnapshot_PreservesTrueColorBackground(t *testing.T) {
 }
 
 func TestScreenSnapshot_IncludesScreenSnapshotWhenAvailable(t *testing.T) {
+	gt := newTestGhostty(t, 12, 4)
 	session := &Session{
 		id:      "codex-1",
 		agent:   "codex",
 		cols:    12,
 		rows:    4,
 		screen:  newVirtualScreen(12, 4),
+		ghostty: gt,
 		running: true,
 	}
-	session.screen.Observe([]byte("snapshot"))
+	gt.Write([]byte("snapshot"))
 
 	info := session.screenSnapshot()
 	if len(info.ScreenSnapshot) == 0 {
@@ -161,18 +165,39 @@ func TestScreenSnapshot_IncludesScreenSnapshotWhenAvailable(t *testing.T) {
 	if info.ScreenCols != 12 || info.ScreenRows != 4 {
 		t.Fatalf("screen size = %dx%d, want 12x4", info.ScreenCols, info.ScreenRows)
 	}
+	assertScreenSnapshotReplays(t, gt, info)
+}
+
+func assertScreenSnapshotReplays(t *testing.T, source *ghosttyvt.Terminal, info AttachInfo) {
+	t.Helper()
+	restored, err := ghosttyvt.New(int(info.ScreenCols), int(info.ScreenRows), ghosttyvt.Options{})
+	if err != nil {
+		t.Fatalf("new restored ghostty terminal: %v", err)
+	}
+	t.Cleanup(restored.Close)
+	restored.Write(info.ScreenSnapshot)
+	if got, want := restored.ViewportText(), source.ViewportText(); got != want {
+		t.Fatalf("replayed viewport text = %q, want %q", got, want)
+	}
+	gotX, gotY := restored.CursorPos()
+	wantX, wantY := source.CursorPos()
+	if gotX != wantX || gotY != wantY {
+		t.Fatalf("replayed cursor = (%d,%d), want (%d,%d)", gotX, gotY, wantX, wantY)
+	}
 }
 
 func TestScreenSnapshot_IncludesScreenSnapshotForShellSessions(t *testing.T) {
+	gt := newTestGhostty(t, 12, 4)
 	session := &Session{
 		id:      "shell-1",
 		agent:   "shell",
 		cols:    12,
 		rows:    4,
 		screen:  newVirtualScreen(12, 4),
+		ghostty: gt,
 		running: true,
 	}
-	session.screen.Observe([]byte("prompt"))
+	gt.Write([]byte("prompt"))
 
 	info := session.screenSnapshot()
 	if len(info.ScreenSnapshot) == 0 {
@@ -184,12 +209,14 @@ func TestScreenSnapshot_IncludesScreenSnapshotForShellSessions(t *testing.T) {
 }
 
 func TestScreenSnapshot_ReadOnlyAndLean(t *testing.T) {
+	gt := newTestGhostty(t, 12, 4)
 	session := &Session{
 		id:          "codex-1",
 		agent:       "codex",
 		cols:        12,
 		rows:        4,
 		screen:      newVirtualScreen(12, 4),
+		ghostty:     gt,
 		running:     true,
 		subscribers: make(map[string]*sessionSubscriber),
 	}


### PR DESCRIPTION
Phase 2 of the vt10x retirement plan (`docs/plans/2026-07-24-vt10x-retirement.md`). The three live vt10x consumers now read from the session's ghostty terminal; vt10x stays constructed and fed, so revert is flipping the call sites back. No protocol change — AttachInfo fields keep their meaning.

## Repoints (`internal/pty/session.go`)

- **Approval classifier**: `evaluateApproval` samples `ghostty.ViewportText()` instead of `screen.renderedText()` (same row shape, proven by the Phase 1 parity corpus).
- **CPR replies**: `writeCursorPositionResponse` answers from `ghostty.CursorPos()` (0-indexed viewport → 1-indexed row;col).
- **Grid/automation snapshot**: `screenSnapshot()` serves `ghostty.SerializeViewport()` (self-contained styled VT stream, viewport-only) with cursor from `CursorPos`/`CursorVisible`. The payload replays into a fresh Ghostty model — same shape `seedTile` already consumes.

## Hardening (`internal/daemon/automations_deliver.go`)

`passUnattendedLaunchGate` matched the Codex directory-trust prompt with a raw `strings.Contains` over the snapshot payload. Under the styled ghostty stream the prompt text can be split by SGR/cursor runs, so matching now strips ANSI sequences (CSI, OSC with BEL/ST, ESC-single) first. Control flow unchanged; covered by a styled/split-prompt unit test.

## Tests

- `internal/pty` sessions under test now seed a real ghostty terminal (`newTestGhostty`, stub-skip probe) alongside vt10x; CPR/approval/snapshot/attach-race tests updated.
- Snapshot tests round-trip `ScreenSnapshot` into a fresh ghostty terminal and assert viewport text + cursor match the source.

## Verification

- Native tier (darwin/arm64, head 74032f80, macOS 26.5.2): `go test ./internal/pty ./internal/ghosttyvt ./internal/daemon -count=1` all green; `go vet ./...`, `go build ./...` clean.
- Live (isolated `p2vt` profile, full `make install`, preflight PASS, protocol 182):
  - fish pane responsive across window resizes — resize-triggered CPR answered from the ghostty cursor (worker log shows the replies).
  - claude session: `pending_approval` armed and cleared back to `waiting_input` in the daemon log via the pty-layer resolver now reading `ViewportText()`.
  - `get_screen_snapshot` against live claude and codex sessions: fresh styled payload, correct geometry/cursor, decoded content matches the screen — including the codex TUI, the screen vt10x mis-parsed (see the Phase 1 corpus finding).
  - Codex's own approval dialog did not appear live (environment auto-approves shell commands); the codex prompt shape stays covered by the parity corpus fixture.

https://claude.ai/code/session_01JDZsPbL6PLMxowhNaL17hX
