### PR TITLE
feat(opener): global ⌘P markdown file opener with daemon-side recents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-07-24]
 
+### Added
+- **⌘P opens a markdown file from anywhere in the app.** The palette starts on
+  the files you opened most recently and, as you type, fuzzy-searches the
+  markdown under the selected session's folder — no native file dialog, no file
+  tree. Picking a file docks it as a reader tile bound to that session, exactly
+  as ⌘+clicking a link does. A focused Editor tile keeps its own in-tile ⌘P.
+  The search covers what git tracks plus untracked files, so ignored build
+  output never crowds out your documents.
+
 ### Fixed
 - **Sessions interrupted by a daemon or machine restart now recover when their terminal pane opens.** attn preserves the session's launch settings, restarts the recoverable session using the pane's current terminal size, and reconnects it automatically instead of leaving a "Failed to attach PTY" message. Sessions that cannot safely be revived still show the normal attach error.
 

--- a/app/package.json
+++ b/app/package.json
@@ -54,6 +54,7 @@
     "real-app:scenario-workspace-close-last-session-switches-back": "node scripts/real-app-harness/scenario-workspace-close-last-session-switches-back.mjs",
     "real-app:scenario-workspace-close-one-session-keeps-selection": "node scripts/real-app-harness/scenario-workspace-close-one-session-keeps-selection.mjs",
     "real-app:scenario-tile-only-workspace-select": "node scripts/real-app-harness/scenario-tile-only-workspace-select.mjs",
+    "real-app:scenario-markdown-opener": "node scripts/real-app-harness/scenario-markdown-opener.mjs",
     "real-app:scenario-notebook-tile-finder": "node scripts/real-app-harness/scenario-notebook-tile-finder.mjs",
     "real-app:scenario-notebook-tile-close": "node scripts/real-app-harness/scenario-notebook-tile-close.mjs",
     "real-app:scenario-notebook-editor-undo": "node scripts/real-app-harness/scenario-notebook-editor-undo.mjs",

--- a/app/scripts/real-app-harness/scenario-markdown-opener.mjs
+++ b/app/scripts/real-app-harness/scenario-markdown-opener.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+
+// The global markdown opener (⌘P) in the packaged app, end to end:
+//
+//   native ⌘P -> palette opens on recents (empty at first)
+//   -> typing filters the session's markdown via git-backed fs_index
+//   -> picking docks a markdown tile bound to the session
+//   -> a gitignored file stays invisible to fuzzy mode
+//   -> re-summoning with an empty query now lists the opened files as recents,
+//      most recent first, and picking one reuses its tile.
+//
+// Everything here is out of reach of the browser e2e: the native keystroke, the
+// real daemon's file-activity table, and git enumeration over a real repository.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import {
+  createSessionAndWaitForInitialPane,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+} from './common.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { MacOSDriver, delay } from './macosDriver.mjs';
+import { captureFrontWindowScreenshot } from './nativeWindowCapture.mjs';
+import {
+  waitForFirstWorkspacePane,
+  waitForPaneShellReady,
+  waitForPaneVisible,
+} from './scenarioAssertions.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { createScenarioRunner } from './scenarioRunner.mjs';
+
+const OPENER_INPUT = '.markdown-opener-input';
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') {
+    args.shift();
+  }
+  return {
+    options: parseCommonArgs(args),
+    help: args.includes('--help') || args.includes('-h'),
+  };
+}
+
+// The opener's rendered rows, straight from the DOM — assertions read what the
+// palette is showing rather than inferring it from a screenshot.
+async function openerState(client) {
+  return client.request('markdown_opener_get_state', {});
+}
+
+async function waitForOpener(client, predicate, description, timeoutMs = 10_000) {
+  const startedAt = Date.now();
+  let last = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    last = await openerState(client);
+    if (predicate(last)) return last;
+    await delay(150);
+  }
+  throw new Error(`Timed out waiting for ${description}. Last opener state:\n${JSON.stringify(last, null, 2)}`);
+}
+
+async function waitForWorkspaceUi(client, workspaceId, predicate, description, timeoutMs = 20_000) {
+  const startedAt = Date.now();
+  let last = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    last = await client.request('get_workspace_ui_state', { workspaceId }).catch((error) => ({ error: String(error) }));
+    if (predicate(last)) return last;
+    await delay(200);
+  }
+  throw new Error(`Timed out waiting for ${description}. Last workspace UI state:\n${JSON.stringify(last, null, 2)}`);
+}
+
+function markdownTileIds(state) {
+  return (state?.tileIds || []).filter((id) => id.startsWith('tile-markdown'));
+}
+
+async function closeWorkspacePanes(client, sessionId) {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const workspace = await client.request('get_workspace', { sessionId }).catch(() => null);
+    const pane = workspace?.panes?.[0];
+    if (!pane) return;
+    await client.request('close_pane', { sessionId, paneId: pane.paneId }).catch(() => {});
+    await delay(200);
+  }
+}
+
+// A real git repository: fuzzy mode enumerates through `git ls-files`, so the
+// scenario must exercise that path (and its .gitignore behavior), not the
+// WalkDir fallback.
+function seedRepo(cwd, alpha, beta) {
+  fs.mkdirSync(path.join(cwd, 'docs'), { recursive: true });
+  fs.mkdirSync(path.join(cwd, 'build'), { recursive: true });
+  fs.writeFileSync(path.join(cwd, '.gitignore'), 'build/\n', 'utf8');
+  fs.writeFileSync(path.join(cwd, 'docs', alpha), '# Alpha plan\n', 'utf8');
+  fs.writeFileSync(path.join(cwd, 'docs', beta), '# Beta notes\n', 'utf8');
+  fs.writeFileSync(path.join(cwd, 'build', 'ignored-generated.md'), '# Generated\n', 'utf8');
+  const git = (...args) => execFileSync('git', args, { cwd, stdio: 'pipe' });
+  git('init');
+  git('config', 'user.email', 'harness@example.com');
+  git('config', 'user.name', 'Harness');
+  git('add', '.gitignore', path.join('docs', alpha));
+  git('commit', '-m', 'seed');
+  // The beta file stays untracked-but-not-ignored: it must still be findable.
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-markdown-opener.mjs');
+    return;
+  }
+
+  const runner = createScenarioRunner(options, {
+    scenarioId: 'MARKDOWN-OPENER',
+    tier: 'tier1-local-shell',
+    prefix: 'markdown-opener',
+    metadata: {
+      agent: 'shell',
+      focus: 'native Cmd+P opener: fuzzy over git-enumerated markdown, then recents',
+    },
+  });
+
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  const driver = new MacOSDriver({ appPath: options.appPath });
+  let sessionId = null;
+
+  runner.log(`[RealAppHarness] wsUrl=${options.wsUrl}`);
+  runner.registerCleanup('close_observer', () => observer.close());
+  runner.registerCleanup('quit_app', () => client.quitApp());
+
+  try {
+    process.env.ATTN_HARNESS_PARK_VISIBLE_PX ??= '0';
+    await runner.step('launch_app', async () => {
+      await launchFreshAppAndConnect(client, observer);
+    });
+
+    // Files are named per run so a re-run against the same profile (whose
+    // recents table persists) still proves THIS run's opens landed in recents.
+    const alpha = `alpha-plan-${runner.runId}.md`;
+    const beta = `beta-notes-${runner.runId}.md`;
+
+    const { workspaceId, cwd } = await runner.step('create_shell_session', async () => {
+      const sessionCwd = path.join(runner.sessionDir, 'opener-ws');
+      fs.mkdirSync(sessionCwd, { recursive: true });
+      seedRepo(sessionCwd, alpha, beta);
+      sessionId = await createSessionAndWaitForInitialPane({
+        client,
+        observer,
+        cwd: sessionCwd,
+        label: `markdown-opener-${runner.runId}`,
+        agent: 'shell',
+        waitForInitialPaneVisible: false,
+        sessionWaitMs: 30_000,
+      });
+      runner.registerCleanup('close_session_panes', () => (sessionId ? closeWorkspacePanes(client, sessionId) : null));
+      const pane = await waitForFirstWorkspacePane(client, sessionId, 'initial workspace pane');
+      await client.request('select_session', { sessionId });
+      await waitForPaneVisible(client, sessionId, pane.paneId, 20_000);
+      await waitForPaneShellReady(client, sessionId, pane.paneId, {
+        timeoutMs: 20_000,
+        description: 'shell prompt ready',
+      });
+      const workspace = await client.request('get_workspace', { sessionId });
+      if (!workspace.workspaceId) {
+        throw new Error(`Could not resolve workspace id for session ${sessionId}: ${JSON.stringify(workspace)}`);
+      }
+      return { workspaceId: workspace.workspaceId, cwd: sessionCwd };
+    });
+
+    // The real ⌘P: the registry binding through the macOS/WebView key path,
+    // which browser e2e never exercises.
+    const summon = async (description) => {
+      await driver.activateApp();
+      await driver.pressKey('p', { command: true });
+      try {
+        await waitForOpener(client, (state) => state.open, description);
+      } catch (error) {
+        const frontmost = await driver.frontmostBundleId().catch(() => '(unknown)');
+        throw new Error(
+          `${error.message}\n\nThe native Cmd+P did not reach the app. This scenario needs native `
+          + `keyboard input: grant Accessibility permission to the process running it and keep attn `
+          + `frontmost. Frontmost app was "${frontmost}" (expected "${driver.bundleId}").`,
+        );
+      }
+    };
+
+    // Pick a specific row by its label. Rows carry stable per-index ids, and a
+    // previous run's recents can outrank this run's file, so never assume the
+    // wanted row is the highlighted one.
+    const pickRow = async (state, endsWith) => {
+      const index = state.rows.findIndex((row) => row.path.endsWith(endsWith));
+      if (index < 0) {
+        throw new Error(`No opener row for ${endsWith}: ${JSON.stringify(state.rows)}`);
+      }
+      await client.request('dom_click', { selector: `#markdown-opener-opt-${index}` });
+    };
+
+    const typeQuery = async (text) => {
+      await client.request('dom_type', { selector: OPENER_INPUT, text });
+      await delay(400);
+    };
+
+    await runner.step('opener_summons', async () => {
+      await summon('native Cmd+P opens the markdown opener');
+      // The empty query lists recents, never the whole tree: whatever is showing,
+      // none of it is this run's freshly created files.
+      const state = await openerState(client);
+      runner.assert(
+        !state.rows.some((row) => row.path.includes(runner.runId)),
+        `Empty query must not list files that have never been opened: ${JSON.stringify(state.rows)}`,
+      );
+      await captureFrontWindowScreenshot(path.join(runner.runDir, 'opener-empty.png'), { client }).catch(() => {});
+    });
+
+    await runner.step('gitignored_file_is_invisible', async () => {
+      // build/ is gitignored, so git enumeration never reports it.
+      await typeQuery('ignored-generated');
+      const state = await openerState(client);
+      runner.assert(
+        state.rows.length === 0,
+        `A gitignored markdown file must not appear in fuzzy mode: ${JSON.stringify(state.rows)}`,
+      );
+    });
+
+    await runner.step('fuzzy_opens_untracked_file', async () => {
+      // The untracked-but-not-ignored file must still be findable: git
+      // enumeration asks for --others --exclude-standard, not just the index.
+      await typeQuery('betanotes');
+      const state = await waitForOpener(
+        client,
+        (current) => current.rows.some((row) => row.path.endsWith(beta)),
+        'fuzzy query matches the untracked markdown file',
+      );
+      // Rows from the fuzzy index are labeled relative to the session root.
+      // (Earlier runs' recents can also match — they carry absolute paths
+      // because they live outside this run's root — so assert on this run's
+      // file rather than on row 0.)
+      const betaRow = state.rows.find((row) => row.path.endsWith(beta));
+      runner.assert(
+        betaRow.path === `docs/${beta}`,
+        `Fuzzy rows must be labeled relative to the session root: ${JSON.stringify(state.rows)}`,
+      );
+      await captureFrontWindowScreenshot(path.join(runner.runDir, 'opener-fuzzy.png'), { client }).catch(() => {});
+      await pickRow(state, beta);
+      await waitForOpener(client, (current) => !current.open, 'picking a file closes the opener');
+      const ui = await waitForWorkspaceUi(
+        client,
+        workspaceId,
+        (state) => markdownTileIds(state).length === 1,
+        'picking a file docks its markdown tile',
+      );
+      runner.log(`[RealAppHarness] docked ${markdownTileIds(ui)[0]} for ${beta}`);
+    });
+
+    await runner.step('fuzzy_opens_tracked_file', async () => {
+      await summon('re-summon for the tracked file');
+      await typeQuery('alphaplan');
+      const state = await waitForOpener(
+        client,
+        (current) => current.rows.some((row) => row.path.endsWith(alpha)),
+        'fuzzy query matches the tracked markdown file',
+      );
+      await pickRow(state, alpha);
+      await waitForWorkspaceUi(
+        client,
+        workspaceId,
+        (state) => markdownTileIds(state).length === 2,
+        'the second pick docks a second markdown tile',
+      );
+    });
+
+    const beforeRecents = await client.request('get_workspace_ui_state', { workspaceId });
+    await runner.step('recents_list_opened_files', async () => {
+      await summon('re-summon to inspect recents');
+      // Both opens are now recents — recorded daemon-side by the open itself,
+      // with no client bookkeeping — and the most recent one ranks first.
+      const state = await waitForOpener(
+        client,
+        (current) => current.rows.some((row) => row.path.endsWith(alpha)),
+        'recents appear on an empty query',
+      );
+      // Both files this run opened are listed, and the later open ranks ahead
+      // of the earlier one. Rows from previous runs against the same profile
+      // legitimately outrank both (higher use count), so compare positions
+      // within this run's files rather than against row 0.
+      const alphaAt = state.rows.findIndex((row) => row.path.endsWith(alpha));
+      const betaAt = state.rows.findIndex((row) => row.path.endsWith(beta));
+      runner.assert(
+        alphaAt >= 0 && betaAt >= 0 && alphaAt < betaAt,
+        `Recents must list both opened files, the later open first: ${JSON.stringify(state.rows)}`,
+      );
+      await captureFrontWindowScreenshot(path.join(runner.runDir, 'opener-recents.png'), { client }).catch(() => {});
+
+      // Picking a recent reuses its tile rather than docking a duplicate.
+      await pickRow(state, alpha);
+      await waitForOpener(client, (current) => !current.open, 'picking a recent closes the opener');
+      await delay(1_500);
+      const after = await client.request('get_workspace_ui_state', { workspaceId });
+      const before = markdownTileIds(beforeRecents);
+      const now = markdownTileIds(after);
+      runner.assert(
+        now.length === 2 && before.every((id) => now.includes(id)),
+        `Picking a recent must reuse its tile. Before: ${JSON.stringify(before)}, after: ${JSON.stringify(now)}`,
+      );
+    });
+
+    const result = runner.finishSuccess({ sessionId, workspaceId, cwd });
+    console.log('[verify] PASS — markdown opener: fuzzy (git-enumerated, gitignore-respecting) and recents both worked.');
+    console.log(JSON.stringify(result, null, 2));
+  } catch (error) {
+    await captureFrontWindowScreenshot(path.join(runner.runDir, 'failure.png'), { client }).catch(() => {});
+    const result = runner.finishFailure(error, { sessionId });
+    console.error(result.error);
+    process.exitCode = 1;
+  } finally {
+    if (sessionId) {
+      await closeWorkspacePanes(client, sessionId).catch(() => {});
+    }
+    await client.quitApp().catch(() => {});
+    await observer.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/scripts/real-app-harness/scenarioCatalog.mjs
+++ b/app/scripts/real-app-harness/scenarioCatalog.mjs
@@ -38,6 +38,11 @@ export const scenarioCatalog = [
     command: ['pnpm', 'run', 'real-app:scenario-tile-only-workspace-select'],
   },
   {
+    id: 'markdown-opener',
+    label: 'Global Cmd+P markdown opener (git-enumerated fuzzy search + recents)',
+    command: ['pnpm', 'run', 'real-app:scenario-markdown-opener'],
+  },
+  {
     id: 'notebook-tile-finder',
     label: 'Notebook tile finder (native Cmd+Opt+N dock, Cmd+P re-summon)',
     command: ['pnpm', 'run', 'real-app:scenario-notebook-tile-finder'],

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -31,6 +31,8 @@ import { ShortcutsModal } from './components/ShortcutsModal';
 import { ShortcutEditorModal } from './components/ShortcutEditorModal';
 import { WhatsNewModal } from './components/WhatsNewModal';
 import { ActionMenu, type ActionMenuItem } from './components/ActionMenu';
+import { MarkdownOpener, OPENER_EXTENSIONS } from './components/palette/MarkdownOpener';
+import { claimPaletteFocus } from './components/palette/paletteClaim';
 import { WorkspaceContextNavigator, type WorkspaceContextView } from './components/WorkspaceContextNavigator';
 import { NotebookBrowser } from './components/NotebookBrowser';
 import { NotificationsPanel } from './components/NotificationsPanel';
@@ -624,6 +626,7 @@ function App() {
     sendFsWatch,
     sendFsUnwatch,
     sendFsIndex,
+    sendRecentFiles,
     sendTaskList,
     sendTaskRetry,
     sendNotificationList,
@@ -838,6 +841,7 @@ function App() {
         sendFsWatch={sendFsWatch}
         sendFsUnwatch={sendFsUnwatch}
         sendFsIndex={sendFsIndex}
+        sendRecentFiles={sendRecentFiles}
         sendTaskList={sendTaskList}
         sendTaskRetry={sendTaskRetry}
         sendNotificationList={sendNotificationList}
@@ -963,6 +967,7 @@ interface AppContentProps {
   sendFsWatch: ReturnType<typeof useDaemonSocket>['sendFsWatch'];
   sendFsUnwatch: ReturnType<typeof useDaemonSocket>['sendFsUnwatch'];
   sendFsIndex: ReturnType<typeof useDaemonSocket>['sendFsIndex'];
+  sendRecentFiles: ReturnType<typeof useDaemonSocket>['sendRecentFiles'];
   sendTaskList: ReturnType<typeof useDaemonSocket>['sendTaskList'];
   sendTaskRetry: ReturnType<typeof useDaemonSocket>['sendTaskRetry'];
   sendNotificationList: ReturnType<typeof useDaemonSocket>['sendNotificationList'];
@@ -1082,6 +1087,7 @@ function AppContent({
   sendFsWatch,
   sendFsUnwatch,
   sendFsIndex,
+  sendRecentFiles,
   sendTaskList,
   sendTaskRetry,
   sendNotificationList,
@@ -2033,6 +2039,31 @@ sendFetchPRDetails,
   // (rootless tileParams) when the workspace has no directory, the directory
   // belongs to a remote endpoint (see localWorkspaceDirectory), or the directory
   // already matches the notebook root — see resolveEditorTileRoot.
+  // --- Markdown file opener (Cmd+P) ---
+  const [markdownOpenerOpen, setMarkdownOpenerOpen] = useState(false);
+  // A focused notebook tile owns Cmd+P for its own in-tile finder; the global
+  // dispatcher gets the keystroke first (capture phase), so hand it back here
+  // rather than letting two bindings race.
+  const handleOpenMarkdownFile = useCallback(() => {
+    if (claimPaletteFocus()) return;
+    setMarkdownOpenerOpen(true);
+  }, []);
+  // Fuzzy mode searches the selected session's working directory; with no
+  // session selected there is no project context, so it falls back to the
+  // notebook root. Neither known = recents only.
+  const markdownOpenerRoot = useMemo(() => {
+    const activeSession = sessions.find((session) => session.id === activeSessionId);
+    return activeSession?.cwd || settings['notebook.root.effective'] || null;
+  }, [sessions, activeSessionId, settings]);
+  const loadOpenerRecents = useCallback(
+    () => sendRecentFiles(50).then((files) => files.map((file) => ({ path: file.path, lastAt: file.lastAt }))),
+    [sendRecentFiles],
+  );
+  const loadOpenerIndex = useCallback(
+    (root: string) => sendFsIndex(root, OPENER_EXTENSIONS),
+    [sendFsIndex],
+  );
+
   const handleOpenNotebookTile = useCallback(() => {
     const workspaceId = activeWorkspaceIdRef.current;
     if (!workspaceId) return;
@@ -2058,6 +2089,15 @@ sendFetchPRDetails,
   }, [sendWorkspaceDockTile, settings]);
 
   const actionMenuItems = useMemo<ActionMenuItem[]>(() => [
+    {
+      id: 'open-markdown-file',
+      title: 'Open a markdown file',
+      description: 'Recently opened documents, then a fuzzy search of this session\u2019s folder',
+      keywords: ['open', 'file', 'markdown', 'md', 'recent', 'doc', 'find'],
+      icon: <ContextActionIcon />,
+      shortcut: [shortcutTokens('file.open')],
+      run: () => setMarkdownOpenerOpen(true),
+    },
     {
       id: 'notebook-tile',
       title: 'Open Editor tile',
@@ -3475,6 +3515,7 @@ sendFetchPRDetails,
     onIncreaseFontSize: increaseScale,
     onDecreaseFontSize: decreaseScale,
     onResetFontSize: resetScale,
+    onOpenFile: handleOpenMarkdownFile,
     onOpenNotebookTile: handleOpenNotebookTile,
     onOpenNotebookFullscreen: openNotebookBrowser,
     onOpenBoard: openBoardSurface,
@@ -3482,6 +3523,7 @@ sendFetchPRDetails,
     enabled: !locationPickerOpen
       && !whatsNew.isOpen
       && !actionMenuOpen
+      && !markdownOpenerOpen
       && !shortcutEditorOpen
       && !workspaceContextsOpen
       && !notebookOpen
@@ -4009,6 +4051,26 @@ sendFetchPRDetails,
         retryTask={sendTaskRetry}
         changeSignal={notificationsChangeSignal}
       />
+      {markdownOpenerOpen && (
+        <MarkdownOpener
+          root={markdownOpenerRoot}
+          loadRecents={loadOpenerRecents}
+          loadIndex={loadOpenerIndex}
+          onClose={() => setMarkdownOpenerOpen(false)}
+          onPick={(path) => {
+            setMarkdownOpenerOpen(false);
+            void sendOpenMarkdown(path, activeSessionId ?? '').catch((error) => {
+              // Same fallback as a cmd+click on a link: if the daemon can't dock
+              // a tile (no local workspace, socket dropped), open the file in the
+              // OS default app rather than doing nothing.
+              console.error('[MarkdownOpener] in-app open failed, falling back to OS open:', error);
+              void openPath(path).catch((openError) => {
+                console.error('[MarkdownOpener] OS open fallback failed:', openError);
+              });
+            });
+          }}
+        />
+      )}
       <ActionMenu
         isOpen={actionMenuOpen}
         actions={actionMenuItems}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -32,6 +32,7 @@ import { ShortcutEditorModal } from './components/ShortcutEditorModal';
 import { WhatsNewModal } from './components/WhatsNewModal';
 import { ActionMenu, type ActionMenuItem } from './components/ActionMenu';
 import { MarkdownOpener, OPENER_EXTENSIONS } from './components/palette/MarkdownOpener';
+import { resolveMarkdownOpenerTarget } from './components/palette/openerTarget';
 import { claimPaletteFocus } from './components/palette/paletteClaim';
 import { WorkspaceContextNavigator, type WorkspaceContextView } from './components/WorkspaceContextNavigator';
 import { NotebookBrowser } from './components/NotebookBrowser';
@@ -2050,11 +2051,16 @@ sendFetchPRDetails,
   }, []);
   // Fuzzy mode searches the selected session's working directory; with no
   // session selected there is no project context, so it falls back to the
-  // notebook root. Neither known = recents only.
-  const markdownOpenerRoot = useMemo(() => {
-    const activeSession = sessions.find((session) => session.id === activeSessionId);
-    return activeSession?.cwd || settings['notebook.root.effective'] || null;
-  }, [sessions, activeSessionId, settings]);
+  // notebook root. Neither known = recents only. A remote session's cwd names a
+  // path on another machine and never enters this route — see
+  // resolveMarkdownOpenerTarget.
+  const markdownOpenerTarget = useMemo(
+    () => resolveMarkdownOpenerTarget(
+      sessions.find((session) => session.id === activeSessionId),
+      settings['notebook.root.effective'],
+    ),
+    [sessions, activeSessionId, settings],
+  );
   const loadOpenerRecents = useCallback(
     () => sendRecentFiles(50).then((files) => files.map((file) => ({ path: file.path, lastAt: file.lastAt }))),
     [sendRecentFiles],
@@ -4053,13 +4059,22 @@ sendFetchPRDetails,
       />
       {markdownOpenerOpen && (
         <MarkdownOpener
-          root={markdownOpenerRoot}
+          root={markdownOpenerTarget.root}
           loadRecents={loadOpenerRecents}
           loadIndex={loadOpenerIndex}
           onClose={() => setMarkdownOpenerOpen(false)}
           onPick={(path) => {
             setMarkdownOpenerOpen(false);
-            void sendOpenMarkdown(path, activeSessionId ?? '').catch((error) => {
+            const bindTo = markdownOpenerTarget.sessionId;
+            if (bindTo === null) {
+              // The selected session lives on another machine; docking a tile
+              // for this local file would bind it there. Open it locally.
+              void openPath(path).catch((openError) => {
+                console.error('[MarkdownOpener] OS open failed:', openError);
+              });
+              return;
+            }
+            void sendOpenMarkdown(path, bindTo).catch((error) => {
               // Same fallback as a cmd+click on a link: if the daemon can't dock
               // a tile (no local workspace, socket dropped), open the file in the
               // OS default app rather than doing nothing.

--- a/app/src/components/NotebookSurface.tsx
+++ b/app/src/components/NotebookSurface.tsx
@@ -11,6 +11,7 @@ import { parseFrontmatter } from './notebook/frontmatter';
 import { headingSlug, noteDir, resolveNotebookLink } from './notebook/linkResolver';
 import { LiveMarkdownEditor, type LiveMarkdownEditorHandle, type LiveSelection } from './notebook/LiveMarkdownEditor';
 import { NotebookFinder } from './notebook/NotebookFinder';
+import { registerPaletteClaim } from './palette/paletteClaim';
 import { parseOutline } from './notebook/outline';
 import './NotebookBrowser.css';
 
@@ -202,11 +203,18 @@ export const NotebookSurface = forwardRef<NotebookSurfaceHandle, NotebookSurface
     finderReturnFocusRef.current = document.activeElement as HTMLElement | null;
     setFinderOpen(true);
   }, []);
-  // Summon the finder with Cmd+P from inside the surface. Scoped to this container's
-  // keydown so a tile only responds when focus is in THIS tile (two tiles don't fight
-  // over one global binding), and the modal responds only while it's the focused
-  // surface; preventDefault stops the WebView's print dialog. Shift is excluded —
-  // Cmd+Shift+P is the global attention dock.
+  // Claim ⌘P while focus is inside this surface, so the global markdown opener
+  // hands the keystroke back to THIS tile's finder (two tiles never fight over
+  // one binding, and the app-wide opener stays out of a focused notebook).
+  useEffect(() => {
+    if (!finderEnabled) return;
+    return registerPaletteClaim({ container: () => dialogRef.current, open: openFinder });
+  }, [finderEnabled, openFinder]);
+  // The same summon from this container's own keydown. In the app the global
+  // dispatcher (capture phase) gets there first and routes through the claim
+  // above; this path is what makes the surface work standalone, outside an App
+  // that registers the shortcut. preventDefault stops the WebView's print
+  // dialog. Shift is excluded — Cmd+Shift+P is the global attention dock.
   const handleSurfaceKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.metaKey && !event.shiftKey && !event.altKey && event.key.toLowerCase() === 'p') {
       event.preventDefault();

--- a/app/src/components/palette/MarkdownOpener.test.tsx
+++ b/app/src/components/palette/MarkdownOpener.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MarkdownOpener } from './MarkdownOpener';
+
+const RECENTS = [
+  { path: '/repo/docs/plan.md', lastAt: '2026-07-24T10:00:00Z' },
+  { path: '/other/journal.md', lastAt: '2026-07-23T10:00:00Z' },
+];
+
+function renderOpener(overrides: Partial<React.ComponentProps<typeof MarkdownOpener>> = {}) {
+  const props = {
+    root: '/repo',
+    loadRecents: vi.fn().mockResolvedValue(RECENTS),
+    loadIndex: vi.fn().mockResolvedValue({ files: ['docs/design.md', 'README.md'], truncated: false }),
+    onPick: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides,
+  };
+  render(<MarkdownOpener {...props} />);
+  return props;
+}
+
+const rows = () => screen.queryAllByRole('option').map((row) => row.textContent);
+
+describe('MarkdownOpener', () => {
+  it('lists recents on an empty query, not the whole index', async () => {
+    renderOpener();
+    await waitFor(() => expect(rows()).toHaveLength(2));
+    // Recents are labeled relative to the fuzzy root when they live under it.
+    expect(rows()[0]).toContain('docs/plan.md');
+    expect(rows()[1]).toContain('/other/journal.md');
+  });
+
+  it('opens on recents before the index resolves', async () => {
+    let resolveIndex: (value: { files: string[]; truncated: boolean }) => void = () => {};
+    const loadIndex = vi.fn().mockReturnValue(new Promise<{ files: string[]; truncated: boolean }>((resolve) => {
+      resolveIndex = resolve;
+    }));
+    renderOpener({ loadIndex });
+
+    // The palette is usable while the enumeration is still running: a cold
+    // index must never delay Cmd+P.
+    await waitFor(() => expect(rows()).toHaveLength(2));
+    resolveIndex({ files: ['docs/design.md'], truncated: false });
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'design' } });
+    await waitFor(() => expect(rows()[0]).toContain('docs/design.md'));
+  });
+
+  it('ranks recents and index results in one list once typing starts', async () => {
+    renderOpener();
+    await waitFor(() => expect(rows()).toHaveLength(2));
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'd' } });
+    await waitFor(() => expect(rows().length).toBeGreaterThan(1));
+    // One list: a remembered file and an index-only file both appear.
+    const text = rows().join('|');
+    expect(text).toContain('docs/plan.md');
+    expect(text).toContain('docs/design.md');
+  });
+
+  it('picks the absolute path, not the displayed label', async () => {
+    const { onPick } = renderOpener();
+    await waitFor(() => expect(rows()).toHaveLength(2));
+
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' });
+    expect(onPick).toHaveBeenCalledWith('/repo/docs/plan.md');
+  });
+
+  it('skips the index and lists recents when there is no root', async () => {
+    const { loadIndex } = renderOpener({ root: null });
+    await waitFor(() => expect(rows()).toHaveLength(2));
+    expect(loadIndex).not.toHaveBeenCalled();
+  });
+
+  it('says the index is capped rather than implying the list is complete', async () => {
+    renderOpener({ loadIndex: vi.fn().mockResolvedValue({ files: [], truncated: true }) });
+    await waitFor(() => expect(rows()).toHaveLength(2));
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'zzzz' } });
+    await waitFor(() => expect(screen.getByText(/index is capped/)).toBeTruthy());
+  });
+});

--- a/app/src/components/palette/MarkdownOpener.tsx
+++ b/app/src/components/palette/MarkdownOpener.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Palette } from './Palette';
+import { finderBasename } from './rank';
+import { mergeOpenerFiles, rankOpenerFiles, type OpenerFile } from './openerRank';
+
+// Markdown only, for now: the pick opens a reader tile, and that tile renders
+// markdown. The caller passes this to fs_index so the server-side entry cap
+// applies to markdown alone.
+export const OPENER_EXTENSIONS = ['md'];
+
+export interface MarkdownOpenerProps {
+  // The tree fuzzy mode searches: the selected session's working directory,
+  // falling back to the notebook root when no session is selected. null means
+  // neither is known, so only recents are available.
+  root: string | null;
+  loadRecents: () => Promise<{ path: string; lastAt: string }[]>;
+  loadIndex: (root: string) => Promise<{ files: string[]; truncated: boolean }>;
+  onPick: (absPath: string) => void;
+  onClose: () => void;
+}
+
+// The global ⌘P file opener: recently opened markdown files on an empty query,
+// a fuzzy filter over the workspace's markdown once you type, both in one
+// ranked list. The shared Palette owns the overlay, keyboard navigation, and
+// selection; this owns the data and the ranking.
+//
+// Both sources load asynchronously and independently: the palette opens on
+// whatever it has, so a cold index enumeration never delays ⌘P.
+export function MarkdownOpener({ root, loadRecents, loadIndex, onPick, onClose }: MarkdownOpenerProps) {
+  const [query, setQuery] = useState('');
+  const [recents, setRecents] = useState<{ path: string; lastAt: string }[]>([]);
+  const [indexFiles, setIndexFiles] = useState<string[]>([]);
+  const [truncated, setTruncated] = useState(false);
+  const [indexLoading, setIndexLoading] = useState(!!root);
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadRecents()
+      .then((files) => { if (!cancelled) setRecents(files); })
+      .catch((error) => { console.error('[MarkdownOpener] recent files failed:', error); });
+    return () => { cancelled = true; };
+  }, [loadRecents]);
+
+  useEffect(() => {
+    if (!root) {
+      setIndexFiles([]);
+      setIndexLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setIndexLoading(true);
+    void loadIndex(root)
+      .then((result) => {
+        if (cancelled) return;
+        setIndexFiles(result.files);
+        setTruncated(result.truncated);
+      })
+      .catch((error) => {
+        if (!cancelled) console.error('[MarkdownOpener] file index failed:', error);
+      })
+      .finally(() => { if (!cancelled) setIndexLoading(false); });
+    return () => { cancelled = true; };
+  }, [root, loadIndex]);
+
+  const candidates = useMemo(
+    () => mergeOpenerFiles(recents, root, indexFiles),
+    [recents, root, indexFiles],
+  );
+  const results = useMemo(() => rankOpenerFiles(candidates, query), [candidates, query]);
+
+  // The index is capped server-side; say so rather than implying the list is
+  // the whole tree.
+  const emptyLabel = indexLoading
+    ? 'Loading files…'
+    : query.trim() === ''
+      ? 'No recently opened files. Type to search.'
+      : truncated
+        ? 'No files match (the index is capped, so some files are missing).'
+        : 'No files match.';
+
+  return (
+    <Palette<OpenerFile>
+      variant="markdown-opener"
+      ariaLabel="Open a markdown file"
+      placeholder="Open a markdown file…"
+      query={query}
+      onQueryChange={setQuery}
+      items={results}
+      itemKey={(file) => file.absPath}
+      emptyLabel={emptyLabel}
+      onPick={(file) => onPick(file.absPath)}
+      onClose={onClose}
+      renderItem={(file) => (
+        <>
+          <span className="palette-option-title markdown-opener-option-title">
+            {finderBasename(file.label)}
+          </span>
+          <span className="palette-option-path markdown-opener-option-path">{file.label}</span>
+        </>
+      )}
+    />
+  );
+}

--- a/app/src/components/palette/Palette.css
+++ b/app/src/components/palette/Palette.css
@@ -93,3 +93,10 @@
 @keyframes palette-reveal {
   from { opacity: 0; transform: scale(0.995); }
 }
+
+/* The global markdown opener is app-level, not scoped to a tile, so it covers
+   the window. z-index matches the action menu (the other app-wide palette). */
+.markdown-opener {
+  position: fixed;
+  z-index: 420;
+}

--- a/app/src/components/palette/openerRank.test.ts
+++ b/app/src/components/palette/openerRank.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { mergeOpenerFiles, rankOpenerFiles, type OpenerFile } from './openerRank';
+
+describe('mergeOpenerFiles', () => {
+  it('labels recents inside the fuzzy root relative to it', () => {
+    const merged = mergeOpenerFiles(
+      [{ path: '/repo/docs/plan.md', lastAt: '2026-07-24T10:00:00Z' }],
+      '/repo',
+      [],
+    );
+    expect(merged).toEqual([
+      { absPath: '/repo/docs/plan.md', label: 'docs/plan.md', recentAt: '2026-07-24T10:00:00Z' },
+    ]);
+  });
+
+  it('keeps the absolute label for a recent outside the fuzzy root', () => {
+    const merged = mergeOpenerFiles(
+      [{ path: '/other/notes.md', lastAt: '2026-07-24T10:00:00Z' }],
+      '/repo',
+      [],
+    );
+    expect(merged[0].label).toBe('/other/notes.md');
+  });
+
+  it('lists an index file once even when it is also a recent', () => {
+    const merged = mergeOpenerFiles(
+      [{ path: '/repo/docs/plan.md', lastAt: '2026-07-24T10:00:00Z' }],
+      '/repo',
+      ['docs/plan.md', 'docs/other.md'],
+    );
+    expect(merged.map((file) => file.absPath)).toEqual([
+      '/repo/docs/plan.md',
+      '/repo/docs/other.md',
+    ]);
+    // The surviving entry is the recent one, so it keeps its recency bonus.
+    expect(merged[0].recentAt).toBe('2026-07-24T10:00:00Z');
+  });
+
+  it('lists recents alone when there is no fuzzy root', () => {
+    const merged = mergeOpenerFiles(
+      [{ path: '/other/notes.md', lastAt: '2026-07-24T10:00:00Z' }],
+      null,
+      ['ignored.md'],
+    );
+    expect(merged.map((file) => file.absPath)).toEqual(['/other/notes.md']);
+  });
+});
+
+describe('rankOpenerFiles', () => {
+  const recent = (label: string, at: string): OpenerFile => ({ absPath: `/repo/${label}`, label, recentAt: at });
+  const indexed = (label: string): OpenerFile => ({ absPath: `/repo/${label}`, label });
+
+  it('shows only recents on an empty query, in the order given', () => {
+    const files = [recent('b.md', '2026-07-24T09:00:00Z'), indexed('a.md'), recent('c.md', '2026-07-24T10:00:00Z')];
+    expect(rankOpenerFiles(files, '').map((file) => file.label)).toEqual(['b.md', 'c.md']);
+  });
+
+  it('ranks recents and index entries in one list once typing starts', () => {
+    const files = [indexed('docs/plan.md'), recent('notes/plan.md', '2026-07-24T10:00:00Z')];
+    const ranked = rankOpenerFiles(files, 'plan');
+    // Equal textual matches: the remembered one wins on the recency bonus, but
+    // both stay in the same list.
+    expect(ranked.map((file) => file.label)).toEqual(['notes/plan.md', 'docs/plan.md']);
+  });
+
+  it('still lets a clearly better match beat a recent', () => {
+    const files = [recent('unrelated-scratch.md', '2026-07-24T10:00:00Z'), indexed('plan.md')];
+    expect(rankOpenerFiles(files, 'plan')[0].label).toBe('plan.md');
+  });
+
+  it('drops entries the query does not subsequence-match', () => {
+    const files = [indexed('plan.md'), indexed('readme.md')];
+    expect(rankOpenerFiles(files, 'plan').map((file) => file.label)).toEqual(['plan.md']);
+  });
+
+  it('caps the list', () => {
+    const files = Array.from({ length: 80 }, (_, i) => indexed(`plan-${i}.md`));
+    expect(rankOpenerFiles(files, 'plan')).toHaveLength(50);
+  });
+});

--- a/app/src/components/palette/openerRank.ts
+++ b/app/src/components/palette/openerRank.ts
@@ -1,0 +1,76 @@
+import { scoreFile } from './rank';
+
+// One row in the markdown opener. `label` is what the user sees and what the
+// fuzzy scorer matches — root-relative for files inside the fuzzy root, the
+// absolute path for anything else (a recent from another project). `absPath` is
+// what actually gets opened. `recentAt` is set only for remembered files, and
+// carries the last-open timestamp so ties break toward the fresher document.
+export interface OpenerFile {
+  absPath: string;
+  label: string;
+  recentAt?: string;
+}
+
+// How much a recently-opened file's score is multiplied by. Enough to win ties
+// and near-ties against an equally good match you've never opened, not enough
+// to keep a weak match above a clearly better one.
+export const RECENT_BONUS = 1.4;
+
+// Join a root and a root-relative slash path into an absolute path.
+function joinRoot(root: string, rel: string): string {
+  return root.endsWith('/') ? `${root}${rel}` : `${root}/${rel}`;
+}
+
+// Build the opener's candidate list: remembered files first (their order is the
+// daemon's frecency ranking, which is what an empty query shows), then the
+// fuzzy index, with any index entry that is already a recent dropped so a file
+// never appears twice. Recents inside the fuzzy root are labeled relative to it
+// so they read the same as their index counterparts.
+export function mergeOpenerFiles(
+  recents: { path: string; lastAt: string }[],
+  root: string | null,
+  indexFiles: string[],
+): OpenerFile[] {
+  const prefix = root ? (root.endsWith('/') ? root : `${root}/`) : null;
+  const merged: OpenerFile[] = recents.map((recent) => ({
+    absPath: recent.path,
+    label: prefix && recent.path.startsWith(prefix) ? recent.path.slice(prefix.length) : recent.path,
+    recentAt: recent.lastAt,
+  }));
+  const seen = new Set(merged.map((file) => file.absPath));
+  if (!root) return merged;
+  for (const rel of indexFiles) {
+    const absPath = joinRoot(root, rel);
+    if (seen.has(absPath)) continue;
+    seen.add(absPath);
+    merged.push({ absPath, label: rel });
+  }
+  return merged;
+}
+
+// Rank the opener list for a query. An empty query is the recents list — the
+// index is deliberately not listed, since "everything in the repo" is noise
+// before you have typed anything. Once there is a query, recents and index
+// entries rank together in one list (no pinned section, no mode change
+// mid-typing), with recents carrying RECENT_BONUS.
+export function rankOpenerFiles(files: OpenerFile[], query: string, limit = 50): OpenerFile[] {
+  if (query.trim() === '') {
+    return files.filter((file) => file.recentAt).slice(0, limit);
+  }
+  return files
+    .map((file) => ({
+      file,
+      score: scoreFile({ path: file.label, updated: file.recentAt }, query) * (file.recentAt ? RECENT_BONUS : 1),
+    }))
+    .filter(({ score }) => score > 0)
+    .sort((left, right) => {
+      if (right.score !== left.score) return right.score - left.score;
+      // Ties: most recently opened first, then alphabetically for stability.
+      const leftAt = left.file.recentAt ?? '';
+      const rightAt = right.file.recentAt ?? '';
+      if (leftAt !== rightAt) return leftAt < rightAt ? 1 : -1;
+      return left.file.label < right.file.label ? -1 : left.file.label > right.file.label ? 1 : 0;
+    })
+    .slice(0, limit)
+    .map(({ file }) => file);
+}

--- a/app/src/components/palette/openerTarget.test.ts
+++ b/app/src/components/palette/openerTarget.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { resolveMarkdownOpenerTarget } from './openerTarget';
+
+describe('resolveMarkdownOpenerTarget', () => {
+  it('searches a local session’s working directory', () => {
+    expect(resolveMarkdownOpenerTarget({ id: 's1', cwd: '/repo' }, '/notebook')).toEqual({
+      root: '/repo',
+      sessionId: 's1',
+    });
+  });
+
+  it('never indexes or binds a remote session’s directory', () => {
+    // The remote cwd names a path on another machine: handing it to fs_index
+    // would enumerate this machine's filesystem under a remote label, and
+    // open_markdown would bind a local file to a session the local daemon does
+    // not own. Fall back to the local notebook root, with no session binding.
+    const target = resolveMarkdownOpenerTarget(
+      { id: 's1', cwd: '/repo', endpointId: 'orb-remote' },
+      '/notebook',
+    );
+    expect(target).toEqual({ root: '/notebook', sessionId: null });
+  });
+
+  it('falls back to recents alone when a remote session is selected and there is no notebook root', () => {
+    expect(resolveMarkdownOpenerTarget({ id: 's1', cwd: '/repo', endpointId: 'orb' }, '')).toEqual({
+      root: null,
+      sessionId: null,
+    });
+  });
+
+  it('uses the notebook root when no session is selected', () => {
+    expect(resolveMarkdownOpenerTarget(undefined, '/notebook')).toEqual({
+      root: '/notebook',
+      sessionId: '',
+    });
+  });
+
+  it('falls back to the notebook root when a local session has no cwd', () => {
+    expect(resolveMarkdownOpenerTarget({ id: 's1' }, '/notebook')).toEqual({
+      root: '/notebook',
+      sessionId: 's1',
+    });
+  });
+
+  it('reports no root when nothing local is known', () => {
+    expect(resolveMarkdownOpenerTarget(undefined, null)).toEqual({ root: null, sessionId: '' });
+  });
+});

--- a/app/src/components/palette/openerTarget.ts
+++ b/app/src/components/palette/openerTarget.ts
@@ -1,0 +1,44 @@
+/**
+ * Where the markdown opener is allowed to look, and which session (if any) an
+ * opened file may be bound to.
+ *
+ * The opener's index-and-open route runs entirely against the locally-connected
+ * daemon: `fs_index` enumerates this machine's filesystem and `open_markdown`
+ * docks a tile whose content this machine reads from disk. A session on a remote
+ * endpoint has a `cwd` that names a path on *that* machine, so handing it to
+ * either call crosses the ownership boundary — usually failing, but on a path
+ * that happens to exist here it would silently show local files under a remote
+ * label and then bind one of them to a remote session.
+ *
+ * So locality must be positively proven, the same rule `localWorkspaceDirectory`
+ * applies to workspace directories. With a remote session selected the opener
+ * falls back to the local notebook root (recents are daemon-local and always
+ * fine) and forfeits the session binding: picking a file opens it in the OS
+ * default app instead of docking a tile against the wrong machine.
+ */
+export interface OpenerSessionLike {
+  id: string;
+  cwd?: string;
+  endpointId?: string;
+}
+
+export interface MarkdownOpenerTarget {
+  /** Root for fuzzy indexing, or null when there is no local project context. */
+  root: string | null;
+  /**
+   * Session to bind an opened file to. `''` means "let the daemon use its
+   * currently selected session"; `null` means no local session owns this open,
+   * so it must not go through the daemon at all.
+   */
+  sessionId: string | null;
+}
+
+export function resolveMarkdownOpenerTarget(
+  session: OpenerSessionLike | undefined,
+  notebookRoot: string | undefined | null,
+): MarkdownOpenerTarget {
+  const fallbackRoot = notebookRoot || null;
+  if (!session) return { root: fallbackRoot, sessionId: '' };
+  if (session.endpointId) return { root: fallbackRoot, sessionId: null };
+  return { root: session.cwd || fallbackRoot, sessionId: session.id };
+}

--- a/app/src/components/palette/paletteClaim.test.ts
+++ b/app/src/components/palette/paletteClaim.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { registerPaletteClaim, claimPaletteFocus } from './paletteClaim';
+
+const cleanups: (() => void)[] = [];
+
+afterEach(() => {
+  cleanups.splice(0).forEach((fn) => fn());
+  document.body.innerHTML = '';
+});
+
+function claim(container: HTMLElement | null, open: () => void) {
+  cleanups.push(registerPaletteClaim({ container: () => container, open }));
+}
+
+describe('claimPaletteFocus', () => {
+  it('hands the shortcut to the surface containing the focused element', () => {
+    const surface = document.createElement('div');
+    const inner = document.createElement('button');
+    surface.appendChild(inner);
+    document.body.appendChild(surface);
+    const open = vi.fn();
+    claim(surface, open);
+
+    expect(claimPaletteFocus(inner)).toBe(true);
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it('declines when focus is outside every registered surface', () => {
+    const surface = document.createElement('div');
+    const outside = document.createElement('button');
+    document.body.append(surface, outside);
+    const open = vi.fn();
+    claim(surface, open);
+
+    expect(claimPaletteFocus(outside)).toBe(false);
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('picks the surface that actually holds focus when several are registered', () => {
+    const first = document.createElement('div');
+    const second = document.createElement('div');
+    const inner = document.createElement('button');
+    second.appendChild(inner);
+    document.body.append(first, second);
+    const openFirst = vi.fn();
+    const openSecond = vi.fn();
+    claim(first, openFirst);
+    claim(second, openSecond);
+
+    expect(claimPaletteFocus(inner)).toBe(true);
+    expect(openFirst).not.toHaveBeenCalled();
+    expect(openSecond).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops claiming once unregistered', () => {
+    const surface = document.createElement('div');
+    const inner = document.createElement('button');
+    surface.appendChild(inner);
+    document.body.appendChild(surface);
+    const open = vi.fn();
+    const unregister = registerPaletteClaim({ container: () => surface, open });
+
+    unregister();
+
+    expect(claimPaletteFocus(inner)).toBe(false);
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('declines when nothing is focused', () => {
+    const surface = document.createElement('div');
+    document.body.appendChild(surface);
+    claim(surface, vi.fn());
+    expect(claimPaletteFocus(null)).toBe(false);
+  });
+});

--- a/app/src/components/palette/paletteClaim.ts
+++ b/app/src/components/palette/paletteClaim.ts
@@ -1,0 +1,36 @@
+// ⌘P is one global shortcut, but a focused notebook tile owns its own in-tile
+// finder (two tiles must not fight over one binding). The global dispatcher
+// runs in the capture phase, so it always sees the keystroke first; instead of
+// racing it with a container keydown, a surface registers a claim here and the
+// global handler hands ⌘P back to whichever registered surface currently
+// contains focus.
+
+interface PaletteClaim {
+  // Resolved at claim time — a ref's element is null on the render that
+  // registers it.
+  container: () => HTMLElement | null;
+  open: () => void;
+}
+
+const claims = new Set<PaletteClaim>();
+
+// Register a surface that owns ⌘P while focus is inside it. Returns the
+// unregister function, so a caller can use it directly as an effect cleanup.
+export function registerPaletteClaim(claim: PaletteClaim): () => void {
+  claims.add(claim);
+  return () => { claims.delete(claim); };
+}
+
+// Hand ⌘P to the registered surface containing `active`, if any. Returns true
+// when a surface handled it and the global opener must stand down.
+export function claimPaletteFocus(active: Element | null = document.activeElement): boolean {
+  if (!active) return false;
+  for (const claim of claims) {
+    const container = claim.container();
+    if (container && container.contains(active)) {
+      claim.open();
+      return true;
+    }
+  }
+  return false;
+}

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -173,7 +173,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '184';
+export const PROTOCOL_VERSION = '185';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a
@@ -478,6 +478,17 @@ export interface FsIndexResult {
   root: string;
   files: string[];
   truncated: boolean;
+}
+
+// One remembered file, ranked by frecency. Mirrors the daemon's
+// protocol.FileActivity: source is what happened to it ("opened" today), count
+// is how many times, lastAt when it last happened.
+export interface RecentFile {
+  path: string;
+  source: string;
+  lastAt: string;
+  count: number;
+  sessionId?: string;
 }
 
 interface UseDaemonSocketOptions {
@@ -1762,6 +1773,31 @@ export function useDaemonSocket({
               pending.resolve({ root: data.root });
             } else {
               pending.reject(new Error(data.error || 'Filesystem watch action failed'));
+            }
+            break;
+          }
+
+          case 'recent_files_result': {
+            const requestId = data.request_id;
+            if (typeof requestId !== 'string') {
+              break;
+            }
+            const key = `recent_files:${requestId}`;
+            const pending = pendingActionsRef.current.get(key);
+            if (!pending) {
+              break;
+            }
+            pendingActionsRef.current.delete(key);
+            if (data.success) {
+              pending.resolve((data.files || []).map((file: Record<string, unknown>) => ({
+                path: file.path as string,
+                source: file.source as string,
+                lastAt: file.last_at as string,
+                count: (file.count as number) ?? 0,
+                sessionId: file.session_id as string | undefined,
+              })));
+            } else {
+              pending.reject(new Error(data.error || 'Recent files failed'));
             }
             break;
           }
@@ -4984,7 +5020,9 @@ export function useDaemonSocket({
   // Bounded recursive file index of root (undefined/empty = the notebook
   // root), for the ⌘P finder. No client-controlled limit — the daemon caps
   // entries server-side and reports truncated=true if the walk was cut short.
-  const sendFsIndex = useCallback((root?: string): Promise<FsIndexResult> => {
+  // extensions (dotless, case-insensitive) filter server-side, before the cap,
+  // so asking for markdown cannot be truncated away by files nobody wanted.
+  const sendFsIndex = useCallback((root?: string, extensions?: string[]): Promise<FsIndexResult> => {
     return new Promise((resolve, reject) => {
       const ws = wsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -4994,7 +5032,12 @@ export function useDaemonSocket({
       const requestId = nextRequestID('fs_index');
       const key = `fs_index:${requestId}`;
       pendingActionsRef.current.set(key, { resolve, reject });
-      ws.send(JSON.stringify({ cmd: 'fs_index', request_id: requestId, ...(root ? { root } : {}) }));
+      ws.send(JSON.stringify({
+        cmd: 'fs_index',
+        request_id: requestId,
+        ...(root ? { root } : {}),
+        ...(extensions && extensions.length > 0 ? { extensions } : {}),
+      }));
       setTimeout(() => {
         if (pendingActionsRef.current.has(key)) {
           pendingActionsRef.current.delete(key);
@@ -5005,6 +5048,28 @@ export function useDaemonSocket({
   }, [nextRequestID]);
 
   // Get recent locations from daemon
+  // Files recently opened as reader tiles, frecency-ranked. Recorded daemon-side
+  // for every route into a markdown tile, so this list needs no client bookkeeping.
+  const sendRecentFiles = useCallback((limit?: number): Promise<RecentFile[]> => {
+    return new Promise((resolve, reject) => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        reject(new Error('WebSocket not connected'));
+        return;
+      }
+      const requestId = nextRequestID('recent_files');
+      const key = `recent_files:${requestId}`;
+      pendingActionsRef.current.set(key, { resolve, reject });
+      ws.send(JSON.stringify({ cmd: 'recent_files', request_id: requestId, ...(limit ? { limit } : {}) }));
+      setTimeout(() => {
+        if (pendingActionsRef.current.has(key)) {
+          pendingActionsRef.current.delete(key);
+          reject(new Error('Recent files timed out'));
+        }
+      }, 10000);
+    });
+  }, [nextRequestID]);
+
   const sendGetRecentLocations = useCallback((endpointId?: string, limit?: number): Promise<RecentLocationsResult> => {
     return new Promise((resolve, reject) => {
       const ws = wsRef.current;
@@ -5775,6 +5840,7 @@ export function useDaemonSocket({
     sendFsWatch,
     sendFsUnwatch,
     sendFsIndex,
+    sendRecentFiles,
     sendGetRecentLocations,
     sendBrowseDirectory,
     sendInspectPath,

--- a/app/src/hooks/useKeyboardShortcuts.ts
+++ b/app/src/hooks/useKeyboardShortcuts.ts
@@ -23,6 +23,7 @@ interface KeyboardShortcutsConfig {
   onIncreaseFontSize?: () => void;
   onDecreaseFontSize?: () => void;
   onResetFontSize?: () => void;
+  onOpenFile?: () => void;
   onOpenNotebookTile?: () => void;
   onOpenNotebookFullscreen?: () => void;
   onOpenBoard?: () => void;
@@ -50,6 +51,7 @@ export function useKeyboardShortcuts({
   onIncreaseFontSize,
   onDecreaseFontSize,
   onResetFontSize,
+  onOpenFile,
   onOpenNotebookTile,
   onOpenNotebookFullscreen,
   onOpenBoard,
@@ -94,6 +96,10 @@ export function useKeyboardShortcuts({
   useShortcut('ui.increaseFontSize', onIncreaseFontSize ?? (() => {}), !!onIncreaseFontSize);
   useShortcut('ui.decreaseFontSize', onDecreaseFontSize ?? (() => {}), !!onDecreaseFontSize);
   useShortcut('ui.resetFontSize', onResetFontSize ?? (() => {}), !!onResetFontSize);
+
+  // Markdown file opener (⌘P). Enabled like other surface shortcuts; a focused
+  // notebook tile gets the keystroke handed back to it by the handler itself.
+  useShortcut('file.open', onOpenFile ?? (() => {}), enabled && !!onOpenFile);
 
   // Notebook: dock a tile into the active workspace, or open the fullscreen modal.
   useShortcut('notebook.openTile', onOpenNotebookTile ?? (() => {}), enabled && !!onOpenNotebookTile);

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -1358,6 +1358,27 @@ function getLocationPickerOverlay() {
   return overlay instanceof HTMLElement ? overlay : null;
 }
 
+// The global markdown opener's rendered state, for harness assertions: what the
+// palette is actually showing, in order, without guessing from screenshots.
+function collectMarkdownOpenerUiState() {
+  const root = document.querySelector('.markdown-opener');
+  if (!root) {
+    return { open: false, query: '', rows: [], emptyText: '' };
+  }
+  const input = root.querySelector('.markdown-opener-input');
+  const rows = Array.from(root.querySelectorAll('.markdown-opener-option')).map((row) => ({
+    title: row.querySelector('.markdown-opener-option-title')?.textContent?.trim() || '',
+    path: row.querySelector('.markdown-opener-option-path')?.textContent?.trim() || '',
+    selected: row.getAttribute('aria-selected') === 'true',
+  }));
+  return {
+    open: true,
+    query: input instanceof HTMLInputElement ? input.value : '',
+    rows,
+    emptyText: root.querySelector('.markdown-opener-empty')?.textContent?.trim() || '',
+  };
+}
+
 function collectLocationPickerUiState() {
   const root = getLocationPickerRoot();
   if (!root) {
@@ -2075,6 +2096,8 @@ export function useUiAutomationBridge({
         return {
           label: await invoke<string | null>('browser_host_focus_state'),
         };
+      case 'markdown_opener_get_state':
+        return collectMarkdownOpenerUiState();
       case 'location_picker_get_state':
         return collectLocationPickerUiState();
       case 'location_picker_open': {

--- a/app/src/shortcuts/metadata.ts
+++ b/app/src/shortcuts/metadata.ts
@@ -101,6 +101,7 @@ export const SHORTCUT_META: Record<ShortcutId, ShortcutMeta> = {
   'ui.increaseFontSize': { label: 'Increase font size', category: 'app' },
   'ui.decreaseFontSize': { label: 'Decrease font size', category: 'app' },
   'ui.resetFontSize': { label: 'Reset font size', category: 'app' },
+  'file.open': { label: 'Open a markdown file', category: 'app' },
   'notebook.openTile': { label: 'Open Editor tile', category: 'app' },
   'notebook.openFullscreen': { label: 'Open Notebook fullscreen', category: 'app' },
   'board.open': { label: 'Open Tickets board', category: 'app' },

--- a/app/src/shortcuts/registry.ts
+++ b/app/src/shortcuts/registry.ts
@@ -110,6 +110,12 @@ export const SHORTCUTS = {
   'notebook.openTile': { key: 'n', code: 'KeyN', meta: true, alt: true },
   'notebook.openFullscreen': { key: 'n', code: 'KeyN', meta: true, alt: true, shift: true },
 
+  // Markdown file opener: a ⌘P-style palette listing recently opened markdown
+  // files, then fuzzy-filtering the selected session's tree as you type. A
+  // focused notebook tile keeps its own in-tile ⌘P (see paletteClaim.ts); this
+  // is what ⌘P does everywhere else.
+  'file.open': { key: 'p', meta: true },
+
   // Tickets board (fullscreen surface). meta+shift+T parallels meta+T = new workspace.
   'board.open': { key: 't', meta: true, shift: true },
 

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -75,6 +75,7 @@
 //   const fetchPRDetailsResultMessage = Convert.toFetchPRDetailsResultMessage(json);
 //   const fetchRemotesMessage = Convert.toFetchRemotesMessage(json);
 //   const fetchRemotesResultMessage = Convert.toFetchRemotesResultMessage(json);
+//   const fileActivity = Convert.toFileActivity(json);
 //   const fileDiffResultMessage = Convert.toFileDiffResultMessage(json);
 //   const fSChangedMessage = Convert.toFSChangedMessage(json);
 //   const fSDeleteMessage = Convert.toFSDeleteMessage(json);
@@ -223,6 +224,8 @@
 //   const queryPRsMessage = Convert.toQueryPRsMessage(json);
 //   const queryReposMessage = Convert.toQueryReposMessage(json);
 //   const rateLimitedMessage = Convert.toRateLimitedMessage(json);
+//   const recentFilesMessage = Convert.toRecentFilesMessage(json);
+//   const recentFilesResultMessage = Convert.toRecentFilesResultMessage(json);
 //   const recentLocation = Convert.toRecentLocation(json);
 //   const recentLocationsResultMessage = Convert.toRecentLocationsResultMessage(json);
 //   const refreshPRsMessage = Convert.toRefreshPRsMessage(json);
@@ -1453,6 +1456,15 @@ export enum FetchRemotesResultMessageEvent {
     FetchRemotesResult = "fetch_remotes_result",
 }
 
+export interface FileActivity {
+    count:       number;
+    last_at:     string;
+    path:        string;
+    session_id?: string;
+    source:      string;
+    [property: string]: any;
+}
+
 export interface FileDiffResultMessage {
     directory:   string;
     error?:      string;
@@ -1564,6 +1576,7 @@ export interface FSExistsResultMessageResult {
 
 export interface FSIndexMessage {
     cmd:         FSIndexMessageCmd;
+    extensions?: string[];
     request_id?: string;
     root?:       string;
     [property: string]: any;
@@ -3524,6 +3537,39 @@ export enum RateLimitedMessageEvent {
     RateLimited = "rate_limited",
 }
 
+export interface RecentFilesMessage {
+    cmd:         RecentFilesMessageCmd;
+    limit?:      number;
+    request_id?: string;
+    [property: string]: any;
+}
+
+export enum RecentFilesMessageCmd {
+    RecentFiles = "recent_files",
+}
+
+export interface RecentFilesResultMessage {
+    error?:     string;
+    event:      RecentFilesResultMessageEvent;
+    files:      FileElement[];
+    request_id: string;
+    success:    boolean;
+    [property: string]: any;
+}
+
+export enum RecentFilesResultMessageEvent {
+    RecentFilesResult = "recent_files_result",
+}
+
+export interface FileElement {
+    count:       number;
+    last_at:     string;
+    path:        string;
+    session_id?: string;
+    source:      string;
+    [property: string]: any;
+}
+
 export interface RecentLocation {
     last_seen: string;
     path:      string;
@@ -4477,7 +4523,7 @@ export interface TicketAttachMessage {
     cmd:                 TicketAttachMessageCmd;
     comment?:            string;
     expected_event_seq?: number;
-    files:               FileElement[];
+    files:               FileObject[];
     request_id?:         string;
     source_session_id:   string;
     state?:              DispatchWorkState;
@@ -4489,7 +4535,7 @@ export enum TicketAttachMessageCmd {
     TicketAttach = "ticket_attach",
 }
 
-export interface FileElement {
+export interface FileObject {
     filename:    string;
     source_path: string;
     [property: string]: any;
@@ -6155,6 +6201,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("FetchRemotesResultMessage")), null, 2);
     }
 
+    public static toFileActivity(json: string): FileActivity {
+        return cast(JSON.parse(json), r("FileActivity"));
+    }
+
+    public static fileActivityToJson(value: FileActivity): string {
+        return JSON.stringify(uncast(value, r("FileActivity")), null, 2);
+    }
+
     public static toFileDiffResultMessage(json: string): FileDiffResultMessage {
         return cast(JSON.parse(json), r("FileDiffResultMessage"));
     }
@@ -7337,6 +7391,22 @@ export class Convert {
 
     public static rateLimitedMessageToJson(value: RateLimitedMessage): string {
         return JSON.stringify(uncast(value, r("RateLimitedMessage")), null, 2);
+    }
+
+    public static toRecentFilesMessage(json: string): RecentFilesMessage {
+        return cast(JSON.parse(json), r("RecentFilesMessage"));
+    }
+
+    public static recentFilesMessageToJson(value: RecentFilesMessage): string {
+        return JSON.stringify(uncast(value, r("RecentFilesMessage")), null, 2);
+    }
+
+    public static toRecentFilesResultMessage(json: string): RecentFilesResultMessage {
+        return cast(JSON.parse(json), r("RecentFilesResultMessage"));
+    }
+
+    public static recentFilesResultMessageToJson(value: RecentFilesResultMessage): string {
+        return JSON.stringify(uncast(value, r("RecentFilesResultMessage")), null, 2);
     }
 
     public static toRecentLocation(json: string): RecentLocation {
@@ -9384,6 +9454,13 @@ const typeMap: any = {
         { json: "event", js: "event", typ: r("FetchRemotesResultMessageEvent") },
         { json: "success", js: "success", typ: true },
     ], "any"),
+    "FileActivity": o([
+        { json: "count", js: "count", typ: 0 },
+        { json: "last_at", js: "last_at", typ: "" },
+        { json: "path", js: "path", typ: "" },
+        { json: "session_id", js: "session_id", typ: u(undefined, "") },
+        { json: "source", js: "source", typ: "" },
+    ], "any"),
     "FileDiffResultMessage": o([
         { json: "directory", js: "directory", typ: "" },
         { json: "error", js: "error", typ: u(undefined, "") },
@@ -9449,6 +9526,7 @@ const typeMap: any = {
     ], "any"),
     "FSIndexMessage": o([
         { json: "cmd", js: "cmd", typ: r("FSIndexMessageCmd") },
+        { json: "extensions", js: "extensions", typ: u(undefined, a("")) },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
         { json: "root", js: "root", typ: u(undefined, "") },
     ], "any"),
@@ -10601,6 +10679,25 @@ const typeMap: any = {
         { json: "rate_limit_reset_at", js: "rate_limit_reset_at", typ: "" },
         { json: "rate_limit_resource", js: "rate_limit_resource", typ: "" },
     ], "any"),
+    "RecentFilesMessage": o([
+        { json: "cmd", js: "cmd", typ: r("RecentFilesMessageCmd") },
+        { json: "limit", js: "limit", typ: u(undefined, 0) },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    ], "any"),
+    "RecentFilesResultMessage": o([
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("RecentFilesResultMessageEvent") },
+        { json: "files", js: "files", typ: a(r("FileElement")) },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "FileElement": o([
+        { json: "count", js: "count", typ: 0 },
+        { json: "last_at", js: "last_at", typ: "" },
+        { json: "path", js: "path", typ: "" },
+        { json: "session_id", js: "session_id", typ: u(undefined, "") },
+        { json: "source", js: "source", typ: "" },
+    ], "any"),
     "RecentLocation": o([
         { json: "last_seen", js: "last_seen", typ: "" },
         { json: "path", js: "path", typ: "" },
@@ -11182,13 +11279,13 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("TicketAttachMessageCmd") },
         { json: "comment", js: "comment", typ: u(undefined, "") },
         { json: "expected_event_seq", js: "expected_event_seq", typ: u(undefined, 0) },
-        { json: "files", js: "files", typ: a(r("FileElement")) },
+        { json: "files", js: "files", typ: a(r("FileObject")) },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
         { json: "source_session_id", js: "source_session_id", typ: "" },
         { json: "state", js: "state", typ: u(undefined, r("DispatchWorkState")) },
         { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
     ], "any"),
-    "FileElement": o([
+    "FileObject": o([
         { json: "filename", js: "filename", typ: "" },
         { json: "source_path", js: "source_path", typ: "" },
     ], "any"),
@@ -12399,6 +12496,12 @@ const typeMap: any = {
     ],
     "RateLimitedMessageEvent": [
         "rate_limited",
+    ],
+    "RecentFilesMessageCmd": [
+        "recent_files",
+    ],
+    "RecentFilesResultMessageEvent": [
+        "recent_files_result",
     ],
     "RecentLocationsResultMessageEvent": [
         "recent_locations_result",

--- a/docs/plans/2026-07-24-markdown-file-opener.md
+++ b/docs/plans/2026-07-24-markdown-file-opener.md
@@ -139,7 +139,7 @@ Attached finding: `fs_index` and `fs_list` gate arbitrary roots on the authentic
 client via `resolveFsRoot`; `browse_directory` has no equivalent gate. That is tolerable
 while it leaks only directory names. Making it list files is the moment to close it.
 
-### R4 — File-activity store placement (with the opener)
+### R4 — File-activity store placement (with the opener) — DONE
 
 `recent_locations` lives inline in `store.go` with its own frecency scorer, pruning, and
 delete-on-missing. Put file activity in its own `internal/store/file_activity.go`
@@ -156,6 +156,12 @@ change how the hook config is generated.
 
 ### Daemon fixes to fold in
 
+Both landed with the opener PR, except the dot-directory harmonization: fuzzy
+mode still hides dot-prefixed paths (git enumeration applies the same rule the
+walk always did), while `listDirectoryEntries` still shows them. Path mode is
+where that inconsistency becomes visible, so it is folded into PR2 (R3).
+
+
 - `fs_index`'s 25k cap counts every file, before any markdown filter, and truncation
   follows `WalkDir` lexicographic order — so in a large repo, documents under
   late-alphabet directories silently vanish from fuzzy mode. An optional server-side
@@ -163,6 +169,19 @@ change how the hook config is generated.
 - Dot-directory rule is inconsistent: `fs_index` skips dot-directories entirely,
   `listDirectoryEntries` does not. So `~/.claude/` is reachable in path mode but invisible
   in fuzzy mode. Pick one rule and apply it to both.
+
+### Shipped so far
+
+- PR1 (merged): R1 + R2 — the shared palette shell and the scorer's move off
+  `NotebookEntry`.
+- PR2 (this PR): the opener itself. `file_activity` table (migration 80) plus
+  `internal/store/file_activity.go`; recording in `openMarkdownTile`, which also
+  now refuses a deleted file and forgets it; protocol 185 with `recent_files`
+  and an `extensions` filter on `fs_index`; git-backed enumeration; the global
+  ⌘P palette with recents, unified ranking, and an async index load; the
+  `paletteClaim` hand-off that keeps a focused Editor tile's own ⌘P. Verified
+  live by `real-app:scenario-markdown-opener`.
+- Next: path mode (R3).
 
 ### Order
 

--- a/internal/daemon/fs_index.go
+++ b/internal/daemon/fs_index.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/victorarias/attn/internal/git"
 	"github.com/victorarias/attn/internal/protocol"
 )
 
@@ -22,14 +23,15 @@ const maxFsIndexEntries = 25000
 // every other fs_* command uses, so fs_index inherits the auth gate (an
 // explicit root is honored only for the authenticated app client; an
 // omitted/empty root always resolves to the notebook root) with no separate
-// check here — then walks it bounded by maxFsIndexEntries. Replies with an
+// check here — then enumerates it bounded by maxFsIndexEntries. extensions
+// filters the result server-side (see indexRoot). Replies with an
 // fs_index_result event correlated by requestID.
-func (d *Daemon) handleFsIndex(client *wsClient, requestID, rawRoot string) {
+func (d *Daemon) handleFsIndex(client *wsClient, requestID, rawRoot string, extensions []string) {
 	var files []string
 	var truncated bool
 	root, err := d.resolveFsRoot(client, rawRoot)
 	if err == nil {
-		files, truncated, err = indexRoot(root, maxFsIndexEntries)
+		files, truncated, err = indexRoot(root, maxFsIndexEntries, extensions)
 	}
 	msg := protocol.FsIndexResultMessage{
 		Event:     protocol.EventFsIndexResult,
@@ -46,18 +48,64 @@ func (d *Daemon) handleFsIndex(client *wsClient, requestID, rawRoot string) {
 	d.sendToClient(client, msg)
 }
 
-// indexRoot walks root recursively and returns every regular file's
-// root-relative slash path, sorted lexicographically, plus whether the walk
-// was truncated at cap entries. It skips any directory whose name starts with
-// "." or is named "node_modules" (not descended at all), dot-prefixed files,
-// and any non-regular-file entry — symlinks, FIFOs, sockets, device nodes —
-// via DirEntry.Type().IsRegular(), a no-syscall type-bits check (a symlinked
-// dir is also never descended by WalkDir). This matters beyond symlinks: a
-// FIFO or socket that slipped into the list would be advertised as an
-// openable file when fs_read rejects anything that isn't a regular file. A
-// per-entry walk error (e.g. permission denied) skips that entry/subtree
-// without failing the whole index. cap is injected so tests can exercise
-// truncation with a tiny value instead of the real maxFsIndexEntries.
+// normalizeExtensions lowercases the requested extensions and strips a leading
+// dot, so a client may send "md" or ".md". An empty result means "every file".
+func normalizeExtensions(extensions []string) []string {
+	normalized := make([]string, 0, len(extensions))
+	for _, ext := range extensions {
+		ext = strings.ToLower(strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(ext), ".")))
+		if ext != "" {
+			normalized = append(normalized, ext)
+		}
+	}
+	return normalized
+}
+
+// matchesExtension reports whether name has one of the wanted extensions. No
+// filter means everything matches.
+func matchesExtension(name string, extensions []string) bool {
+	if len(extensions) == 0 {
+		return true
+	}
+	ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(name), "."))
+	if ext == "" {
+		return false
+	}
+	for _, want := range extensions {
+		if ext == want {
+			return true
+		}
+	}
+	return false
+}
+
+// hiddenPath reports whether any component of a root-relative slash path is
+// dot-prefixed. fs_index has always hidden dot files and never descended
+// dot-directories; git enumeration lists them, so it applies the same rule to
+// keep both enumerations returning the same set.
+func hiddenPath(rel string) bool {
+	for _, segment := range strings.Split(rel, "/") {
+		if strings.HasPrefix(segment, ".") {
+			return true
+		}
+	}
+	return false
+}
+
+// indexRoot enumerates the files under root, returning their root-relative
+// slash paths sorted lexicographically plus whether the enumeration was
+// truncated at cap entries. extensions (dotless, case-insensitive) filter the
+// result, and the cap applies AFTER filtering — otherwise a large repository
+// exhausts the cap on files nobody asked for and the documents being searched
+// for silently vanish from the tail of the alphabet.
+//
+// Inside a git repository the file list comes from git (tracked files plus
+// untracked-but-not-ignored ones), which honors .gitignore and reads an index
+// git already maintains instead of stat-ing the whole tree. Outside one — or
+// if git fails for any reason — it falls back to walking the tree.
+//
+// cap is injected so tests can exercise truncation with a tiny value instead
+// of the real maxFsIndexEntries.
 //
 // normalizeExternalRoot only canonicalizes the deepest EXISTING ancestor, so a
 // root that does not exist (or a root that is a file, not a directory) can
@@ -67,7 +115,7 @@ func (d *Daemon) handleFsIndex(client *wsClient, requestID, rawRoot string) {
 // nothing-to-walk, and the whole call silently succeeds with zero files —
 // fs_index would report success+empty for a root fs_list correctly errors on.
 // Stat first and fail loudly instead.
-func indexRoot(root string, cap int) ([]string, bool, error) {
+func indexRoot(root string, cap int, extensions []string) ([]string, bool, error) {
 	info, err := os.Stat(root)
 	if err != nil {
 		return nil, false, err
@@ -75,9 +123,65 @@ func indexRoot(root string, cap int) ([]string, bool, error) {
 	if !info.IsDir() {
 		return nil, false, fmt.Errorf("root %s is not a directory", root)
 	}
+	wanted := normalizeExtensions(extensions)
+	if files, truncated, ok := indexRootViaGit(root, cap, wanted); ok {
+		return files, truncated, nil
+	}
+	return indexRootViaWalk(root, cap, wanted)
+}
+
+// indexRootViaGit lists root's files through `git ls-files`, run inside root so
+// paths come back relative to it. ok=false means git could not answer (root is
+// not in a repository, git is missing, the command failed or timed out) and the
+// caller should fall back to walking.
+func indexRootViaGit(root string, cap int, extensions []string) (files []string, truncated bool, ok bool) {
+	// -z: NUL-separated, so paths with spaces, newlines, or non-ASCII bytes
+	// come back verbatim instead of git's quoted form.
+	out, err := git.Output(git.OpMetadata, root,
+		"ls-files", "-z", "--cached", "--others", "--exclude-standard")
+	if err != nil {
+		return nil, false, false
+	}
+
+	seen := make(map[string]struct{})
+	for _, rel := range strings.Split(string(out), "\x00") {
+		if rel == "" || hiddenPath(rel) || !matchesExtension(rel, extensions) {
+			continue
+		}
+		if _, dup := seen[rel]; dup {
+			continue
+		}
+		// git lists index entries, which include symlinks, submodule gitlinks,
+		// and files deleted from the working tree. fs_read only serves regular
+		// files, so drop anything else rather than advertising it as openable.
+		info, statErr := os.Lstat(filepath.Join(root, filepath.FromSlash(rel)))
+		if statErr != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		if len(files) >= cap {
+			truncated = true
+			break
+		}
+		seen[rel] = struct{}{}
+		files = append(files, rel)
+	}
+	sort.Strings(files)
+	return files, truncated, true
+}
+
+// indexRootViaWalk walks root recursively. It skips any directory whose name
+// starts with "." or is named "node_modules" (not descended at all),
+// dot-prefixed files, and any non-regular-file entry — symlinks, FIFOs,
+// sockets, device nodes — via DirEntry.Type().IsRegular(), a no-syscall
+// type-bits check (a symlinked dir is also never descended by WalkDir). This
+// matters beyond symlinks: a FIFO or socket that slipped into the list would be
+// advertised as an openable file when fs_read rejects anything that isn't a
+// regular file. A per-entry walk error (e.g. permission denied) skips that
+// entry/subtree without failing the whole index.
+func indexRootViaWalk(root string, cap int, extensions []string) ([]string, bool, error) {
 	var files []string
 	truncated := false
-	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			// Skip the entry (and, for a directory, its subtree) rather than
 			// aborting the whole walk on one permission-denied or similar error.
@@ -100,6 +204,9 @@ func indexRoot(root string, cap int) ([]string, bool, error) {
 			return nil
 		}
 		if !d.Type().IsRegular() {
+			return nil
+		}
+		if !matchesExtension(name, extensions) {
 			return nil
 		}
 		if len(files) >= cap {

--- a/internal/daemon/fs_index_test.go
+++ b/internal/daemon/fs_index_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -12,9 +13,9 @@ import (
 )
 
 // fsIndex drives handleFsIndex directly and returns the decoded result event.
-func fsIndex(t *testing.T, d *Daemon, client *wsClient, requestID, root string) protocol.FsIndexResultMessage {
+func fsIndex(t *testing.T, d *Daemon, client *wsClient, requestID, root string, extensions ...string) protocol.FsIndexResultMessage {
 	t.Helper()
-	d.handleFsIndex(client, requestID, root)
+	d.handleFsIndex(client, requestID, root, extensions)
 	var res protocol.FsIndexResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	return res
@@ -109,7 +110,7 @@ func TestIndexRootTruncatesAtInjectedCap(t *testing.T) {
 		}
 	}
 
-	files, truncated, err := indexRoot(root, cap)
+	files, truncated, err := indexRoot(root, cap, nil)
 	if err != nil {
 		t.Fatalf("indexRoot: %v", err)
 	}
@@ -181,4 +182,95 @@ func TestFsIndexWithExplicitRootDeniedForUntrustedClient(t *testing.T) {
 	if !omittedRes.Success {
 		t.Fatalf("fs_index(omitted root, untrusted client) = %+v, want success", omittedRes)
 	}
+}
+
+// The extension filter is applied server-side, and the cap counts only files
+// that survive it. Capping before the filter is what makes a large repository
+// truncate on files nobody asked for, hiding markdown that sorts late.
+func TestIndexRootAppliesCapAfterExtensionFilter(t *testing.T) {
+	root := t.TempDir()
+	for i := range 40 {
+		if err := os.WriteFile(filepath.Join(root, fmt.Sprintf("noise%02d.txt", i)), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{"zz-late.md", "aa-early.MD"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files, truncated, err := indexRoot(root, 5, []string{".MD"})
+	if err != nil {
+		t.Fatalf("indexRoot: %v", err)
+	}
+	if truncated {
+		t.Fatalf("truncated = true, want false: only 2 markdown files exist")
+	}
+	// Extension matching is case-insensitive on both sides, and a leading dot
+	// in the request is optional.
+	if want := []string{"aa-early.MD", "zz-late.md"}; !slicesEqual(files, want) {
+		t.Fatalf("files = %v, want %v", files, want)
+	}
+}
+
+// Inside a git repository the enumeration comes from git, so .gitignore is
+// honored — build output and vendored trees cost nothing — while
+// untracked-but-not-ignored files still show up immediately.
+func TestIndexRootUsesGitAndHonorsGitignore(t *testing.T) {
+	root := t.TempDir()
+	mustWrite := func(rel, body string) {
+		t.Helper()
+		full := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite(".gitignore", "build/\n")
+	mustWrite("tracked.md", "x")
+	mustWrite("untracked.md", "x")
+	mustWrite("build/generated.md", "x")
+	// A dot-directory git happily tracks stays hidden, so both enumerations
+	// return the same set.
+	mustWrite(".claude/notes.md", "x")
+
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+		{"add", "tracked.md", ".claude/notes.md"},
+		{"commit", "-m", "seed"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = root
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	files, truncated, err := indexRoot(root, maxFsIndexEntries, []string{"md"})
+	if err != nil {
+		t.Fatalf("indexRoot: %v", err)
+	}
+	if truncated {
+		t.Fatal("truncated = true, want false")
+	}
+	if want := []string{"tracked.md", "untracked.md"}; !slicesEqual(files, want) {
+		t.Fatalf("files = %v, want %v (gitignored and dot-dir paths excluded)", files, want)
+	}
+}
+
+func slicesEqual(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/daemon/tilecontent.go
+++ b/internal/daemon/tilecontent.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
 	"github.com/victorarias/attn/internal/workspacelayout"
 )
 
@@ -446,6 +447,14 @@ func (d *Daemon) openMarkdownTile(path, sessionID string) (workspaceID, tileID s
 		return "", "", fmt.Errorf("path must be absolute: %s", path)
 	}
 	path = filepath.Clean(path)
+	// Refuse to dock a tile for a file that is gone, and forget it: a stale
+	// recent-files entry then costs one failed open rather than a permanent
+	// slot in the opener. This is the only place recents are pruned — the
+	// opener never stats its list on summon.
+	if _, statErr := os.Stat(path); statErr != nil {
+		d.store.DeleteFileActivity(path)
+		return "", "", fmt.Errorf("file not found: %s", path)
+	}
 	if sessionID == "" {
 		return "", "", fmt.Errorf("no session selected; open a session in attn or pass --session")
 	}
@@ -485,6 +494,10 @@ func (d *Daemon) openMarkdownTile(path, sessionID string) (workspaceID, tileID s
 		return "", "", err
 	}
 	d.broadcastTileContentNow(workspaceID, tileID)
+	// Every route into a markdown tile — ⌘+click, `attn open`, the opener
+	// itself — passes through here, so recents need no client bookkeeping and
+	// no origin flag.
+	d.store.RecordFileActivity(path, store.FileActivitySourceOpened, sessionID)
 	return workspaceID, tileID, nil
 }
 

--- a/internal/daemon/tilecontent_test.go
+++ b/internal/daemon/tilecontent_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/victorarias/attn/internal/hub"
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
 	"github.com/victorarias/attn/internal/workspacelayout"
 )
 
@@ -743,5 +744,61 @@ func TestCollectChangedMarkdownTilesTracksMultipleTiles(t *testing.T) {
 	changed = d.collectChangedMarkdownTiles()
 	if len(changed) != 1 || changed[0].path != second || changed[0].tileID != markdownTileIDForPath(second) {
 		t.Fatalf("after edit = %+v, want only the edited tile", changed)
+	}
+}
+
+// Every route into a markdown tile passes through openMarkdownTile, so recents
+// are recorded there rather than by each caller.
+func TestOpenMarkdownRecordsRecentFile(t *testing.T) {
+	d, _, _ := setupMarkdownWorkspace(t)
+	file := filepath.Join(t.TempDir(), "notes.md")
+	if err := os.WriteFile(file, []byte("# Notes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for range 2 {
+		if _, _, err := d.openMarkdownTile(file, "session-1"); err != nil {
+			t.Fatalf("openMarkdownTile: %v", err)
+		}
+	}
+
+	files := d.store.GetRecentFiles(10)
+	if len(files) != 1 {
+		t.Fatalf("recent files = %+v, want one entry", files)
+	}
+	if files[0].Path != file || files[0].Count != 2 {
+		t.Fatalf("recent file = %+v, want %s opened twice", files[0], file)
+	}
+	if files[0].Source != store.FileActivitySourceOpened {
+		t.Fatalf("source = %q, want %q", files[0].Source, store.FileActivitySourceOpened)
+	}
+}
+
+// A remembered file that has since been deleted must not dock a broken tile,
+// and must drop out of recents — the opener never stats its list on summon, so
+// this failed open is where a dead entry gets cleaned up.
+func TestOpenMarkdownForgetsMissingFile(t *testing.T) {
+	d, _, workspaceID := setupMarkdownWorkspace(t)
+	file := filepath.Join(t.TempDir(), "notes.md")
+	if err := os.WriteFile(file, []byte("# Notes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := d.openMarkdownTile(file, "session-1"); err != nil {
+		t.Fatalf("openMarkdownTile: %v", err)
+	}
+	if err := os.Remove(file); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := d.openMarkdownTile(file, "session-1"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("openMarkdownTile(deleted) error = %v, want not-found", err)
+	}
+	if files := d.store.GetRecentFiles(10); len(files) != 0 {
+		t.Fatalf("recent files = %+v, want the deleted file forgotten", files)
+	}
+	// The already-docked tile stays put: only the recents entry is pruned.
+	snapshot := d.store.GetWorkspaceLayout(workspaceID)
+	if leaves := workspacelayout.TileLeaves(snapshot.Layout); len(leaves) != 1 {
+		t.Fatalf("tile leaves = %+v, want the existing tile untouched", leaves)
 	}
 }

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -968,7 +968,7 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		go d.handleFsUnwatch(client, protocol.Deref(fsUnwatch.RequestID), protocol.Deref(fsUnwatch.Root))
 	case protocol.CmdFsIndex:
 		fsIndex := msg.(*protocol.FsIndexMessage)
-		go d.handleFsIndex(client, protocol.Deref(fsIndex.RequestID), protocol.Deref(fsIndex.Root))
+		go d.handleFsIndex(client, protocol.Deref(fsIndex.RequestID), protocol.Deref(fsIndex.Root), fsIndex.Extensions)
 	case protocol.CmdApprovePR:
 		d.handleApprovePRWS(client, msg.(*protocol.ApprovePRMessage))
 	case protocol.CmdMergePR:
@@ -1037,6 +1037,8 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleUnregisterWS(client, msg.(*protocol.UnregisterMessage))
 	case protocol.CmdGetRecentLocations:
 		d.handleGetRecentLocationsWS(client, msg.(*protocol.GetRecentLocationsMessage))
+	case protocol.CmdRecentFiles:
+		d.handleRecentFilesWS(client, msg.(*protocol.RecentFilesMessage))
 	case protocol.CmdBrowseDirectory:
 		d.handleBrowseDirectoryWS(client, msg.(*protocol.BrowseDirectoryMessage))
 	case protocol.CmdInspectPath:

--- a/internal/daemon/ws_session.go
+++ b/internal/daemon/ws_session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strings"
 	"syscall"
 
 	"github.com/victorarias/attn/internal/protocol"
@@ -75,6 +76,22 @@ func (d *Daemon) handleGetRecentLocationsWS(client *wsClient, msg *protocol.GetR
 		RequestID:       msg.RequestID,
 		HomePath:        protocol.Ptr(homePath),
 		Success:         true,
+	})
+}
+
+// handleRecentFilesWS answers the file opener's request for recently touched
+// files, frecency-ranked. Local filesystem only: the opener does not browse
+// remote endpoints, so there is no endpoint routing here.
+func (d *Daemon) handleRecentFilesWS(client *wsClient, msg *protocol.RecentFilesMessage) {
+	limit := 20
+	if msg.Limit != nil {
+		limit = int(*msg.Limit)
+	}
+	d.sendToClient(client, &protocol.RecentFilesResultMessage{
+		Event:     protocol.EventRecentFilesResult,
+		Files:     d.store.GetRecentFiles(limit),
+		RequestID: strings.TrimSpace(protocol.Deref(msg.RequestID)),
+		Success:   true,
 	})
 }
 

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "184"
+const ProtocolVersion = "185"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -141,6 +141,7 @@ const (
 	CmdInjectTestPR                          = "inject_test_pr"
 	CmdInjectTestSession                     = "inject_test_session"
 	CmdGetRecentLocations                    = "get_recent_locations"
+	CmdRecentFiles                           = "recent_files"
 	CmdBrowseDirectory                       = "browse_directory"
 	CmdInspectPath                           = "inspect_path"
 	CmdListBranches                          = "list_branches"
@@ -299,6 +300,7 @@ const (
 	EventPluginActionResult              = "plugin_action_result"
 	EventRateLimited                     = "rate_limited"
 	EventRecentLocationsResult           = "recent_locations_result"
+	EventRecentFilesResult               = "recent_files_result"
 	EventBrowseDirectoryResult           = "browse_directory_result"
 	EventInspectPathResult               = "inspect_path_result"
 	EventBranchesResult                  = "branches_result"
@@ -1171,6 +1173,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdGetRecentLocations:
 		var msg GetRecentLocationsMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdRecentFiles:
+		var msg RecentFilesMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1190,6 +1190,23 @@ type FetchRemotesResultMessage struct {
 	Success bool `json:"success"`
 }
 
+type FileActivity struct {
+	// Count corresponds to the JSON schema field "count".
+	Count int `json:"count"`
+
+	// LastAt corresponds to the JSON schema field "last_at".
+	LastAt string `json:"last_at"`
+
+	// Path corresponds to the JSON schema field "path".
+	Path string `json:"path"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID *string `json:"session_id,omitempty,omitzero"`
+
+	// Source corresponds to the JSON schema field "source".
+	Source string `json:"source"`
+}
+
 type FileDiffResultMessage struct {
 	// Directory corresponds to the JSON schema field "directory".
 	Directory string `json:"directory"`
@@ -1325,6 +1342,9 @@ type FsExistsResultMessage struct {
 type FsIndexMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
+
+	// Extensions corresponds to the JSON schema field "extensions".
+	Extensions []string `json:"extensions,omitempty,omitzero"`
 
 	// RequestID corresponds to the JSON schema field "request_id".
 	RequestID *string `json:"request_id,omitempty,omitzero"`
@@ -3433,6 +3453,34 @@ type RateLimitedMessage struct {
 
 	// RateLimitResource corresponds to the JSON schema field "rate_limit_resource".
 	RateLimitResource string `json:"rate_limit_resource"`
+}
+
+type RecentFilesMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Limit corresponds to the JSON schema field "limit".
+	Limit *int `json:"limit,omitempty,omitzero"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+}
+
+type RecentFilesResultMessage struct {
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// Files corresponds to the JSON schema field "files".
+	Files []FileActivity `json:"files"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
 }
 
 type RecentLocation struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -486,6 +486,18 @@ model RecentLocation {
   use_count: int32;
 }
 
+// One file the user has touched, as recorded in the daemon's file-activity log.
+// `source` says how it was touched: "opened" is the only value today (every
+// open_markdown, whatever route it came from). It exists so a later signal —
+// files an agent edited — becomes another source value rather than a migration.
+model FileActivity {
+  path: string;         // absolute
+  source: string;       // "opened"
+  last_at: string;      // ISO timestamp
+  count: int32;
+  session_id?: string;  // the session in play at the time, when known
+}
+
 model DirectoryEntry {
   name: string;
   path: string;
@@ -1237,6 +1249,11 @@ model FsUnwatchMessage {
 model FsIndexMessage {
   cmd: "fs_index";
   root?: string; // Absolute directory to operate under; omitted/empty = the notebook root.
+  // Restrict the index to these file extensions, without leading dots and
+  // case-insensitive (e.g. ["md", "markdown"]). Omitted/empty indexes every
+  // file. The entry cap applies AFTER filtering, so a markdown-only index
+  // cannot be truncated by unrelated files.
+  extensions?: string[];
   request_id?: string; // set by the WS frontend to correlate the result event
 }
 
@@ -1470,6 +1487,16 @@ model GetRecentLocationsMessage {
   cmd: "get_recent_locations";
   limit?: int32;  // Default 20
   endpoint_id?: string;
+  request_id?: string;
+}
+
+// Recently touched files, frecency-ranked (frequency weighted by recency, the
+// same model as get_recent_locations). Feeds the ⌘P markdown opener's list on
+// an empty query. Entries whose file no longer exists are pruned rather than
+// returned.
+model RecentFilesMessage {
+  cmd: "recent_files";
+  limit?: int32;  // Default 20
   request_id?: string;
 }
 
@@ -3392,6 +3419,15 @@ model FsUnwatchResultMessage {
   root?: string;
 }
 
+// Result of recent_files. files are absolute paths, best-first by frecency.
+model RecentFilesResultMessage {
+  event: "recent_files_result";
+  request_id: string;
+  success: boolean;
+  error?: string;
+  files: FileActivity[];
+}
+
 // Result of fs_index. root is the resolved absolute root (echoed for
 // correlation with the request). files are root-relative slash paths, files
 // only (no directories), sorted lexicographically. truncated is true when the
@@ -3617,6 +3653,7 @@ alias DaemonEvent =
   | FsWatchResultMessage
   | FsUnwatchResultMessage
   | FsIndexResultMessage
+  | RecentFilesResultMessage
   | FsChangedMessage
   | TaskListResultMessage
   | TaskRetryResultMessage

--- a/internal/store/file_activity.go
+++ b/internal/store/file_activity.go
@@ -1,0 +1,113 @@
+package store
+
+import (
+	"sort"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// FileActivitySourceOpened marks a file that was opened as a reader tile, by
+// any route (⌘+click on a link, `attn open`, or the file opener itself).
+const FileActivitySourceOpened = "opened"
+
+// RecordFileActivity records that something happened to a file, incrementing
+// the (path, source) counter and stamping the time. sessionID is the session
+// the activity belongs to, or "" when there is none; the most recent one wins.
+//
+// Keying on (path, source) rather than path alone keeps future sources — an
+// agent editing a file — accumulating independently, so a ranking change never
+// needs a migration.
+func (s *Store) RecordFileActivity(path, source, sessionID string) {
+	if path == "" || source == "" {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return
+	}
+
+	var session any
+	if sessionID != "" {
+		session = sessionID
+	}
+	s.execLog(`
+		INSERT INTO file_activity (path, source, session_id, last_at, count)
+		VALUES (?, ?, ?, ?, 1)
+		ON CONFLICT(path, source) DO UPDATE SET
+			session_id = COALESCE(excluded.session_id, session_id),
+			last_at = excluded.last_at,
+			count = count + 1`,
+		path, source, session, time.Now().Format(time.RFC3339))
+}
+
+// GetRecentFiles returns file activity ranked by frecency — the same
+// frequency-weighted-by-recency scoring the location picker uses, so a file
+// opened often keeps its slot after a burst of one-off opens.
+//
+// Rows are not stat'd here: a summon of the opener must not touch the disk
+// once per remembered file. A file that has since disappeared is pruned when
+// opening it fails.
+func (s *Store) GetRecentFiles(limit int) []protocol.FileActivity {
+	if limit <= 0 {
+		limit = 20
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.db == nil {
+		return nil
+	}
+
+	// Read every row: ranking happens below, so pre-truncating by last_at
+	// would hide old-but-frequent files. The table holds one row per file
+	// ever opened, and dead entries are dropped on a failed open, so it
+	// stays small.
+	rows, err := s.db.Query(`SELECT path, source, session_id, last_at, count FROM file_activity`)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var all []protocol.FileActivity
+	for rows.Next() {
+		var entry protocol.FileActivity
+		var session *string
+		if err := rows.Scan(&entry.Path, &entry.Source, &session, &entry.LastAt, &entry.Count); err != nil {
+			continue
+		}
+		entry.SessionID = session
+		all = append(all, entry)
+	}
+
+	now := time.Now()
+	sort.Slice(all, func(i, j int) bool {
+		si := frecencyScore(all[i].Count, all[i].LastAt, now)
+		sj := frecencyScore(all[j].Count, all[j].LastAt, now)
+		if si != sj {
+			return si > sj
+		}
+		if all[i].LastAt != all[j].LastAt {
+			return all[i].LastAt > all[j].LastAt
+		}
+		return all[i].Path < all[j].Path
+	})
+	if len(all) > limit {
+		all = all[:limit]
+	}
+	return all
+}
+
+// DeleteFileActivity forgets every source for a path. Called when opening a
+// remembered file fails because it no longer exists, so a dead entry costs one
+// failed open rather than a slot forever.
+func (s *Store) DeleteFileActivity(path string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return
+	}
+	s.execLog("DELETE FROM file_activity WHERE path = ?", path)
+}

--- a/internal/store/file_activity_test.go
+++ b/internal/store/file_activity_test.go
@@ -1,0 +1,144 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newFileActivityStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := NewWithDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+// seedFileActivity writes a row directly so tests control last_at.
+func seedFileActivity(t *testing.T, s *Store, path, source, lastAt string, count int) {
+	t.Helper()
+	_, err := s.db.Exec(
+		"INSERT INTO file_activity (path, source, last_at, count) VALUES (?, ?, ?, ?)",
+		path, source, lastAt, count,
+	)
+	if err != nil {
+		t.Fatalf("failed to seed file activity: %v", err)
+	}
+}
+
+func TestRecordFileActivityAccumulatesCount(t *testing.T) {
+	s := newFileActivityStore(t)
+
+	s.RecordFileActivity("/docs/plan.md", FileActivitySourceOpened, "session-1")
+	s.RecordFileActivity("/docs/plan.md", FileActivitySourceOpened, "session-2")
+
+	files := s.GetRecentFiles(10)
+	if len(files) != 1 {
+		t.Fatalf("files = %d, want 1", len(files))
+	}
+	if files[0].Count != 2 {
+		t.Errorf("count = %d, want 2", files[0].Count)
+	}
+	// The latest opener wins, so "which session was this for" tracks the most
+	// recent open rather than the first one.
+	if files[0].SessionID == nil || *files[0].SessionID != "session-2" {
+		t.Errorf("session_id = %v, want session-2", files[0].SessionID)
+	}
+}
+
+func TestRecordFileActivityKeepsSourcesSeparate(t *testing.T) {
+	s := newFileActivityStore(t)
+
+	// The key is (path, source): a future "edited" source must accumulate
+	// beside "opened" instead of overwriting it.
+	s.RecordFileActivity("/docs/plan.md", FileActivitySourceOpened, "")
+	s.RecordFileActivity("/docs/plan.md", "edited", "")
+
+	files := s.GetRecentFiles(10)
+	if len(files) != 2 {
+		t.Fatalf("files = %d, want one row per source", len(files))
+	}
+	for _, file := range files {
+		if file.Count != 1 {
+			t.Errorf("%s count = %d, want 1", file.Source, file.Count)
+		}
+	}
+}
+
+func TestGetRecentFilesRanksByFrecency(t *testing.T) {
+	s := newFileActivityStore(t)
+	now := time.Now()
+	frequentOld := "/docs/frequent-old.md" // 10 opens 3 days ago: 10 * 0.5 = 5
+	recentOnce := "/docs/recent-once.md"   // 1 open just now:      1 * 4   = 4
+	staleOnce := "/docs/stale-once.md"     // 1 open a month ago:   1 * 0.25
+
+	seedFileActivity(t, s, frequentOld, FileActivitySourceOpened, now.Add(-72*time.Hour).Format(time.RFC3339), 10)
+	seedFileActivity(t, s, recentOnce, FileActivitySourceOpened, now.Format(time.RFC3339), 1)
+	seedFileActivity(t, s, staleOnce, FileActivitySourceOpened, now.Add(-30*24*time.Hour).Format(time.RFC3339), 1)
+
+	files := s.GetRecentFiles(10)
+	want := []string{frequentOld, recentOnce, staleOnce}
+	if len(files) != len(want) {
+		t.Fatalf("files = %d, want %d", len(files), len(want))
+	}
+	for i, path := range want {
+		if files[i].Path != path {
+			t.Errorf("position %d = %s, want %s", i, files[i].Path, path)
+		}
+	}
+}
+
+func TestGetRecentFilesRanksBeforeTruncating(t *testing.T) {
+	s := newFileActivityStore(t)
+	now := time.Now()
+
+	// An old but heavily opened document must beat a burst of fresher one-off
+	// opens, so ranking has to run over the whole table rather than a
+	// recency-truncated prefix of it.
+	seedFileActivity(t, s, "/docs/frequent-old.md", FileActivitySourceOpened,
+		now.Add(-30*24*time.Hour).Format(time.RFC3339), 100) // 100 * 0.25 = 25
+	for i := range 250 {
+		seedFileActivity(t, s, filepath.Join("/docs", "fresh", string(rune('a'+i%26))+string(rune('a'+i/26))+".md"),
+			FileActivitySourceOpened, now.Format(time.RFC3339), 1) // 1 * 4 = 4
+	}
+
+	files := s.GetRecentFiles(5)
+	if len(files) != 5 {
+		t.Fatalf("files = %d, want 5", len(files))
+	}
+	if files[0].Path != "/docs/frequent-old.md" {
+		t.Errorf("first = %s, want /docs/frequent-old.md", files[0].Path)
+	}
+}
+
+func TestGetRecentFilesDoesNotStatMissingFiles(t *testing.T) {
+	s := newFileActivityStore(t)
+
+	// Recents are listed without touching the disk; a file that has since
+	// disappeared stays in the list until opening it fails.
+	s.RecordFileActivity("/nowhere/gone.md", FileActivitySourceOpened, "")
+	if files := s.GetRecentFiles(10); len(files) != 1 {
+		t.Fatalf("files = %d, want the missing file still listed", len(files))
+	}
+
+	s.DeleteFileActivity("/nowhere/gone.md")
+	if files := s.GetRecentFiles(10); len(files) != 0 {
+		t.Fatalf("files = %d, want the entry forgotten", len(files))
+	}
+}
+
+func TestDeleteFileActivityForgetsEverySource(t *testing.T) {
+	s := newFileActivityStore(t)
+	s.RecordFileActivity("/docs/plan.md", FileActivitySourceOpened, "")
+	s.RecordFileActivity("/docs/plan.md", "edited", "")
+	s.RecordFileActivity("/docs/keep.md", FileActivitySourceOpened, "")
+
+	s.DeleteFileActivity("/docs/plan.md")
+
+	files := s.GetRecentFiles(10)
+	if len(files) != 1 || files[0].Path != "/docs/keep.md" {
+		t.Fatalf("files = %+v, want only /docs/keep.md", files)
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -774,6 +774,18 @@ CREATE TABLE IF NOT EXISTS ticket_event_cursors (
 	{77, "automations v2: explicit run and binding state", ""},
 	{78, "add launch_intent to sessions", ""},
 	{79, "convert recoverable flag to session state", ""},
+	// File activity is a log of what happened to a file, keyed by (path, source),
+	// so a future source ("edited" by an agent) accumulates alongside "opened"
+	// instead of overwriting it.
+	{80, "create file_activity table", `CREATE TABLE IF NOT EXISTS file_activity (
+		path TEXT NOT NULL,
+		source TEXT NOT NULL,
+		session_id TEXT,
+		last_at TEXT NOT NULL,
+		count INTEGER NOT NULL DEFAULT 1,
+		PRIMARY KEY(path, source)
+	);
+	CREATE INDEX IF NOT EXISTS idx_file_activity_last_at ON file_activity(last_at DESC);`},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1002,7 +1002,7 @@ func TestMigration79_ConvertsRecoverableFlagToState(t *testing.T) {
 		VALUES ('recoverable-session', 'Recoverable', '/tmp/recoverable', 'idle', '2026-07-24T00:00:00Z', '2026-07-24T00:00:00Z', '2026-07-24T00:00:00Z');
 		ALTER TABLE sessions ADD COLUMN recoverable INTEGER NOT NULL DEFAULT 0;
 		UPDATE sessions SET recoverable = 1 WHERE id = 'recoverable-session';
-		DELETE FROM schema_migrations WHERE version = 79;
+		DELETE FROM schema_migrations WHERE version >= 79;
 	`); err != nil {
 		t.Fatalf("seed pre-79 database: %v", err)
 	}
@@ -1026,7 +1026,10 @@ func TestMigration79_ConvertsRecoverableFlagToState(t *testing.T) {
 	if _, err := migrated.Exec(`SELECT recoverable FROM sessions LIMIT 1`); err == nil {
 		t.Fatal("recoverable column still exists after migration")
 	}
-	if _, err := migrated.Exec(`DELETE FROM schema_migrations WHERE version = 79`); err != nil {
+	// Rewind past 79: the runner resumes from MAX(version), so deleting only
+	// row 79 would leave a later migration's row holding the watermark and
+	// migration 79 would never re-run.
+	if _, err := migrated.Exec(`DELETE FROM schema_migrations WHERE version >= 79`); err != nil {
 		t.Fatalf("rewind migration 79 after column drop: %v", err)
 	}
 	if err := migrated.Close(); err != nil {


### PR DESCRIPTION
Adds a keyboard-driven way to open a markdown document when there is no link to ⌘+click and the agent is busy. ⌘P anywhere in the app opens a palette that starts on recently opened markdown files and fuzzy-filters the selected session's markdown as you type; picking a file docks it as a reader tile bound to that session, the same tile ⌘+click and `attn open` produce. A focused Editor tile keeps its own in-tile ⌘P.

This is the second PR of the opener work. The first (#653) extracted the shared palette shell; this one is the feature. Absolute-path navigation (typing `~/…` to browse) is the next PR.

## Recents

Recorded daemon-side in `openMarkdownTile` — the single chokepoint every route already passes through — so there is no client bookkeeping and no origin flag. They live in a new `file_activity` table keyed by `(path, source)` and ranked with the existing frecency scorer (`last_at` + `count`). `source` is `"opened"` today; surfacing files an agent edited becomes a new source value plus a ranking weight rather than a migration.

`openMarkdownTile` now refuses a file that no longer exists and forgets its entry. That failed open is the only place recents are pruned: summoning the opener never stats its list.

On an empty query the list is recents. Once you type, recents and index results rank in one list with a recency bonus — no pinned section, no mode change mid-typing.

## Index

`fs_index` gains a server-side extension filter applied **before** the 25k entry cap. Previously the cap counted every file and truncated in `WalkDir` lexicographic order, so in a large repository markdown under late-alphabet directories could silently vanish from the finder.

Inside a git repository the enumeration now comes from git (`ls-files --cached --others --exclude-standard`) with a `WalkDir` fallback outside one. That honors `.gitignore` instead of a hardcoded `node_modules` + dot-directory skip list, so build output and vendored trees cost nothing, and it reads an index git already maintains rather than stat-ing the tree. Accepted consequence: a gitignored markdown file is invisible to fuzzy mode — path navigation, next PR, still reaches it.

The palette opens on recents immediately and loads the corpus asynchronously, so a cold enumeration never delays ⌘P. When the walk reports `truncated`, the empty state says the index is capped rather than implying completeness.

## ⌘P ownership

`file.open` is a normal rebindable registry entry. The global dispatcher runs in the capture phase, so instead of racing it with the notebook surface's own container keydown, a surface registers a claim (`paletteClaim.ts`) and the global handler hands ⌘P back to whichever registered surface currently contains focus.

## Protocol

Version 185: `recent_files` / `recent_files_result`, and `extensions` on `fs_index`.

## Also

`TestMigration79` rewound only its own `schema_migrations` row. The runner resumes from `MAX(version)`, so that stops re-running the migration as soon as a later one holds the watermark — fixed to rewind past it.

## Verification

- Go suite, 2002 frontend unit tests, and the browser e2e suite green.
- New: store tests for file-activity recording/ranking/pruning, `fs_index` tests for the cap-after-filter rule and for git enumeration honoring `.gitignore` while still listing untracked files, daemon tests for open-recording and the forget-on-missing path, plus frontend tests for the opener's ranking, async load, and the ⌘P claim.
- Live-verified in the packaged app on a throwaway profile with a new packaged-app scenario (`real-app:scenario-markdown-opener`), green on consecutive runs: native ⌘P opens the palette, a gitignored file is invisible, an untracked file is findable, both picks dock session-bound markdown tiles, and a re-summon lists both opens as recents with the later one first while picking one reuses its tile.

https://claude.ai/code/session_01JgB8qSfAyiuhhwTZqy5jVm