### PR TITLE
ci(perf): restore the Bench A/B delta on cgo-linked packages

### DIFF
--- a/.github/workflows/bench-ab.yml
+++ b/.github/workflows/bench-ab.yml
@@ -46,10 +46,25 @@ jobs:
       - name: Install benchstat
         run: go install golang.org/x/perf/cmd/benchstat@latest
 
+      # internal/daemon links libghostty-vt via cgo on Linux; without the
+      # prebuilt archive its test binary does not link and its benchmarks are
+      # silently skipped. Guarded because the PR base may predate the script,
+      # and non-fatal so a fetch failure degrades the delta with a warning
+      # rather than turning this non-gating job red.
+      - name: Ensure native VT library (head)
+        run: |
+          if [ -x ./scripts/build-libghostty-vt.sh ]; then
+            ./scripts/build-libghostty-vt.sh || echo "::warning::could not obtain libghostty-vt for HEAD; cgo-linked packages will not build"
+          fi
+
       - name: Bench PR head
         run: |
           echo "Running: $BENCH_CMD"
-          eval "$BENCH_CMD" 2>&1 | tee head.txt || true
+          # stdout only into head.txt: a build failure's stderr (gcc/ld lines)
+          # parses as benchstat config lines and splits the comparison into two
+          # one-column tables, destroying the delta this job exists to publish.
+          eval "$BENCH_CMD" > head.txt || echo "::warning::the benchmark run on HEAD exited non-zero; the delta may cover fewer packages than intended"
+          cat head.txt
           if [ ! -s head.txt ]; then
             echo "::warning::head.txt is empty; the benchmark run on HEAD produced no output"
           fi
@@ -67,13 +82,38 @@ jobs:
             git checkout origin/main
           fi
 
+      # Re-run against the base checkout: the pin/patch may differ there, and
+      # the archive is keyed by that source identity.
+      - name: Ensure native VT library (base)
+        run: |
+          if [ -x ./scripts/build-libghostty-vt.sh ]; then
+            ./scripts/build-libghostty-vt.sh || echo "::warning::could not obtain libghostty-vt for BASE; cgo-linked packages will not build"
+          fi
+
       - name: Bench PR base
         run: |
           echo "Running: $BENCH_CMD"
-          eval "$BENCH_CMD" 2>&1 | tee base.txt || true
+          eval "$BENCH_CMD" > base.txt || echo "::warning::the benchmark run on BASE exited non-zero; the delta may cover fewer packages than intended"
+          cat base.txt
           if [ ! -s base.txt ]; then
             echo "::warning::base.txt is empty; the benchmark run on BASE produced no output"
           fi
+
+      # A package that fails to build produces no benchmark output, and the
+      # delta table for the packages that did run looks perfectly healthy. Name
+      # the gap explicitly instead of letting coverage shrink unnoticed.
+      - name: Check benchmark coverage
+        if: always()
+        run: |
+          for pkg in $(printf '%s' "$BENCH_CMD" | tr ' ' '\n' | grep '^\./internal/'); do
+            name="${pkg#./}"
+            name="${name%/}"
+            for f in base.txt head.txt; do
+              if ! grep -q "^pkg: .*/${name}$" "$f" 2>/dev/null; then
+                echo "::warning::$f has no benchmark output for $name — that package is missing from the delta"
+              fi
+            done
+          done
 
       - name: Compute benchstat delta
         if: always()


### PR DESCRIPTION
## Problem

`internal/daemon` links `libghostty-vt` via cgo on Linux, but the Bench A/B job never fetched the prebuilt archive. Since the Linux cgo tuples landed, its test binary stopped linking:

```
/usr/bin/ld: cannot find .../third_party/ghostty-vt/linux_amd64/lib/libghostty-vt.a
FAIL github.com/victorarias/attn/internal/daemon [build failed]
```

Two consequences, neither of them visible:

1. **The daemon benchmarks stopped running** — `EncodePtyOutput_*`, `PtyChunkLog_*`. Coverage silently shrank to transcript parsing only.
2. **No delta was produced at all, for any package.** `2>&1 | tee head.txt` folded the gcc/ld errors into the benchstat input files, where lines like `collect2: error: ld returned 1 exit status` parse as configuration lines. benchstat then read base and head as different configurations and printed two separate one-column tables instead of a comparison — so even the package that did build lost its `vs base` numbers, leaving only absolute figures that cannot be compared across runners.

The job kept reporting success throughout: it is trend-only by design, with `|| true` and a final `Always succeed` step. The only outward symptom was runtime dropping from ~5m to ~2m.

## Fix

- Fetch the native VT archive before each side's run. Guarded with `[ -x ... ]` so a PR base predating the script still works, and non-fatal so a download failure degrades the delta with a warning rather than turning this non-gating job red.
- Keep stderr out of the benchstat input files; build errors still reach the job log.
- Warn when a benchmarked package is missing from either side's output, with the package list derived from `BENCH_CMD`. Shrinking coverage was previously indistinguishable from a clean run.

## Verification

Dispatched on this branch — [run 30127209149](https://github.com/victorarias/attn/actions/runs/30127209149), green:

```
ok  github.com/victorarias/attn/internal/daemon      75.111s   <- was "[build failed]"
ok  github.com/victorarias/attn/internal/transcript  41.008s

                             │   base.txt   │              head.txt               │
                             │    sec/op    │    sec/op      vs base              │
EncodePtyOutput_Binary_1KB-4    275.4n ± 3%    261.9n ±  2%  -4.90% (p=0.002 n=6)
PtyChunkLog_64B-4               5.287µ ± 1%    5.237µ ±  1%  -0.96% (p=0.015 n=6)
geomean                         770.8n         765.0n        -0.75%
```

Both guard branches were exercised: head has the script and fetched the archive; the dispatch base is `origin/main`, which does not have it yet, and skipped cleanly. No coverage warnings fired.

The failure path was checked locally on darwin/arm64 by moving the archive aside: the bench file stays benchstat-clean, the surviving package still gets a real `vs base` table, and the coverage check emits `::warning::base.txt has no benchmark output for internal/daemon`.

CI-only change; no product code touched.

https://claude.ai/code/session_015xPYKN6EGJvW4fCZXb1bdu