### PR TITLE
feat(opener): path-navigation mode in the markdown opener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   as ⌘+clicking a link does. A focused Editor tile keeps its own in-tile ⌘P.
   The search covers what git tracks plus untracked files, so ignored build
   output never crowds out your documents.
+- **Type a path in ⌘P to browse the filesystem.** A query that starts with `/`,
+  `~/`, or `./` lists that folder one level at a time — Enter on a folder goes
+  into it, Enter on a file opens it — so documents outside the session's folder,
+  or ones `.gitignore` hides from the search, are still a few keystrokes away.
+  Ordinary queries like `docs/plan` keep searching as before.
+
+### Changed
+- **Dot-folders like `.claude` are now searchable in ⌘P.** Documents kept in
+  dot-prefixed folders were listed when browsing by path but invisible to the
+  search; both now show them. Git's own `.git` folder stays hidden.
 
 ### Fixed
 - **Sessions interrupted by a daemon or machine restart now recover when their terminal pane opens.** attn preserves the session's launch settings, restarts the recoverable session using the pane's current terminal size, and reconnects it automatically instead of leaving a "Failed to attach PTY" message. Sessions that cannot safely be revived still show the normal attach error.

--- a/app/scripts/real-app-harness/scenario-markdown-opener.mjs
+++ b/app/scripts/real-app-harness/scenario-markdown-opener.mjs
@@ -7,7 +7,9 @@
 //   -> picking docks a markdown tile bound to the session
 //   -> a gitignored file stays invisible to fuzzy mode
 //   -> re-summoning with an empty query now lists the opened files as recents,
-//      most recent first, and picking one reuses its tile.
+//      most recent first, and picking one reuses its tile
+//   -> typing an absolute path switches to path mode: directories descend, and
+//      the gitignored file fuzzy mode could not see opens from there.
 //
 // Everything here is out of reach of the browser e2e: the native keystroke, the
 // real daemon's file-activity table, and git enumeration over a real repository.
@@ -90,13 +92,13 @@ async function closeWorkspacePanes(client, sessionId) {
 // A real git repository: fuzzy mode enumerates through `git ls-files`, so the
 // scenario must exercise that path (and its .gitignore behavior), not the
 // WalkDir fallback.
-function seedRepo(cwd, alpha, beta) {
+function seedRepo(cwd, alpha, beta, ignored) {
   fs.mkdirSync(path.join(cwd, 'docs'), { recursive: true });
   fs.mkdirSync(path.join(cwd, 'build'), { recursive: true });
   fs.writeFileSync(path.join(cwd, '.gitignore'), 'build/\n', 'utf8');
   fs.writeFileSync(path.join(cwd, 'docs', alpha), '# Alpha plan\n', 'utf8');
   fs.writeFileSync(path.join(cwd, 'docs', beta), '# Beta notes\n', 'utf8');
-  fs.writeFileSync(path.join(cwd, 'build', 'ignored-generated.md'), '# Generated\n', 'utf8');
+  fs.writeFileSync(path.join(cwd, 'build', ignored), '# Generated\n', 'utf8');
   const git = (...args) => execFileSync('git', args, { cwd, stdio: 'pipe' });
   git('init');
   git('config', 'user.email', 'harness@example.com');
@@ -119,7 +121,7 @@ async function main() {
     prefix: 'markdown-opener',
     metadata: {
       agent: 'shell',
-      focus: 'native Cmd+P opener: fuzzy over git-enumerated markdown, then recents',
+      focus: 'native Cmd+P opener: fuzzy over git-enumerated markdown, recents, then path mode',
     },
   });
 
@@ -142,11 +144,14 @@ async function main() {
     // recents table persists) still proves THIS run's opens landed in recents.
     const alpha = `alpha-plan-${runner.runId}.md`;
     const beta = `beta-notes-${runner.runId}.md`;
+    // Gitignored, and named per run for the same reason: a previous run opened
+    // its own copy through path mode, so that one legitimately lives in recents.
+    const ignored = `ignored-generated-${runner.runId}.md`;
 
     const { workspaceId, cwd } = await runner.step('create_shell_session', async () => {
       const sessionCwd = path.join(runner.sessionDir, 'opener-ws');
       fs.mkdirSync(sessionCwd, { recursive: true });
-      seedRepo(sessionCwd, alpha, beta);
+      seedRepo(sessionCwd, alpha, beta, ignored);
       sessionId = await createSessionAndWaitForInitialPane({
         client,
         observer,
@@ -218,10 +223,13 @@ async function main() {
 
     await runner.step('gitignored_file_is_invisible', async () => {
       // build/ is gitignored, so git enumeration never reports it.
-      await typeQuery('ignored-generated');
+      await typeQuery('ignoredgenerated');
       const state = await openerState(client);
+      // Earlier runs opened their own copy through path mode, so their
+      // (absolute-path) rows may match this query; only this run's file proves
+      // anything about the index.
       runner.assert(
-        state.rows.length === 0,
+        !state.rows.some((row) => row.path.endsWith(ignored)),
         `A gitignored markdown file must not appear in fuzzy mode: ${JSON.stringify(state.rows)}`,
       );
     });
@@ -308,8 +316,47 @@ async function main() {
       );
     });
 
+    await runner.step('path_mode_reaches_gitignored_file', async () => {
+      await summon('re-summon for path mode');
+      // A query that starts with a slash switches modes: one directory at a
+      // time, straight from the filesystem, so a file .gitignore hides from the
+      // fuzzy index is still reachable.
+      await typeQuery(`${cwd}/`);
+      const listing = await waitForOpener(
+        client,
+        (current) => current.rows.some((row) => row.path.endsWith('/build')),
+        'path mode lists the session directory',
+      );
+      runner.assert(
+        listing.rows.some((row) => row.title === 'docs/'),
+        `Path mode must mark directories with a trailing slash: ${JSON.stringify(listing.rows)}`,
+      );
+
+      // Picking a directory descends instead of opening anything.
+      await pickRow(listing, '/build');
+      const descended = await waitForOpener(
+        client,
+        (current) => current.open && current.rows.some((row) => row.path.endsWith(ignored)),
+        'picking a directory descends into it',
+      );
+      runner.assert(
+        descended.query.endsWith('/build/'),
+        `Descending must rewrite the query to the directory: ${JSON.stringify(descended.query)}`,
+      );
+      await captureFrontWindowScreenshot(path.join(runner.runDir, 'opener-path-mode.png'), { client }).catch(() => {});
+
+      await pickRow(descended, ignored);
+      await waitForOpener(client, (current) => !current.open, 'picking a file in path mode closes the opener');
+      await waitForWorkspaceUi(
+        client,
+        workspaceId,
+        (state) => markdownTileIds(state).length === 3,
+        'the gitignored file opens as a third markdown tile',
+      );
+    });
+
     const result = runner.finishSuccess({ sessionId, workspaceId, cwd });
-    console.log('[verify] PASS — markdown opener: fuzzy (git-enumerated, gitignore-respecting) and recents both worked.');
+    console.log('[verify] PASS — markdown opener: fuzzy (git-enumerated, gitignore-respecting), recents, and path mode all worked.');
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     await captureFrontWindowScreenshot(path.join(runner.runDir, 'failure.png'), { client }).catch(() => {});

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -4062,6 +4062,7 @@ sendFetchPRDetails,
           root={markdownOpenerTarget.root}
           loadRecents={loadOpenerRecents}
           loadIndex={loadOpenerIndex}
+          browseDirectory={sendBrowseDirectory}
           onClose={() => setMarkdownOpenerOpen(false)}
           onPick={(path) => {
             setMarkdownOpenerOpen(false);

--- a/app/src/components/LocationPicker.test.tsx
+++ b/app/src/components/LocationPicker.test.tsx
@@ -124,7 +124,7 @@ describe('LocationPicker', () => {
     expect(useFilesystemSuggestionsMock).toHaveBeenCalled();
     const calls = useFilesystemSuggestionsMock.mock.calls;
     const lastCall = calls[calls.length - 1];
-    expect(lastCall?.[5]).toBe(false);
+    expect(lastCall?.[3]?.enabled).toBe(false);
   });
 
   it('spawns a remote session with an agent advertised only by that endpoint', async () => {

--- a/app/src/components/LocationPicker.tsx
+++ b/app/src/components/LocationPicker.tsx
@@ -339,9 +339,7 @@ export function LocationPicker({
     inputValue,
     selectedEndpointId,
     onBrowseDirectory,
-    homePath,
-    handleHomePathChange,
-    isOpen,
+    { homePath, onHomePathChange: handleHomePathChange, enabled: isOpen },
   );
 
   const orderedAgentList = useMemo(() => {

--- a/app/src/components/palette/MarkdownOpener.test.tsx
+++ b/app/src/components/palette/MarkdownOpener.test.tsx
@@ -7,11 +7,23 @@ const RECENTS = [
   { path: '/other/journal.md', lastAt: '2026-07-23T10:00:00Z' },
 ];
 
+const BROWSE = {
+  success: true,
+  input_path: '~/notes/',
+  directory: '/home/victor/notes',
+  home_path: '/home/victor',
+  entries: [
+    { name: 'archive', path: '/home/victor/notes/archive', is_dir: true },
+    { name: 'ideas.md', path: '/home/victor/notes/ideas.md', is_dir: false },
+  ],
+};
+
 function renderOpener(overrides: Partial<React.ComponentProps<typeof MarkdownOpener>> = {}) {
   const props = {
     root: '/repo',
     loadRecents: vi.fn().mockResolvedValue(RECENTS),
     loadIndex: vi.fn().mockResolvedValue({ files: ['docs/design.md', 'README.md'], truncated: false }),
+    browseDirectory: vi.fn().mockResolvedValue(BROWSE),
     onPick: vi.fn(),
     onClose: vi.fn(),
     ...overrides,
@@ -78,5 +90,65 @@ describe('MarkdownOpener', () => {
 
     fireEvent.change(screen.getByRole('combobox'), { target: { value: 'zzzz' } });
     await waitFor(() => expect(screen.getByText(/index is capped/)).toBeTruthy());
+  });
+
+  describe('path mode', () => {
+    const type = (value: string) => fireEvent.change(screen.getByRole('combobox'), { target: { value } });
+
+    it('lists the typed directory instead of fuzzy-matching', async () => {
+      const { browseDirectory } = renderOpener();
+      await waitFor(() => expect(rows()).toHaveLength(2));
+
+      type('~/notes/');
+      await waitFor(() => expect(rows()).toHaveLength(2));
+      // Directories are marked with a trailing slash; files are not.
+      expect(rows()[0]).toContain('archive/');
+      expect(rows()[1]).toContain('ideas.md');
+      // Markdown-only, so the daemon's listing carries the same filter as the index.
+      await waitFor(() => expect(browseDirectory).toHaveBeenCalledWith('~/notes/', undefined, ['md']));
+    });
+
+    it('opens a file in path mode by its absolute path', async () => {
+      const { onPick } = renderOpener();
+      await waitFor(() => expect(rows()).toHaveLength(2));
+
+      type('~/notes/');
+      await waitFor(() => expect(rows()[1]).toContain('ideas.md'));
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'ArrowDown' });
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' });
+
+      expect(onPick).toHaveBeenCalledWith('/home/victor/notes/ideas.md');
+    });
+
+    it('descends into a directory instead of opening it', async () => {
+      const { onPick } = renderOpener();
+      await waitFor(() => expect(rows()).toHaveLength(2));
+
+      type('~/notes/');
+      await waitFor(() => expect(rows()[0]).toContain('archive/'));
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' });
+
+      // The palette stays open on the deeper directory rather than picking it,
+      // and keeps the ~-shortened spelling the user was reading.
+      expect(onPick).not.toHaveBeenCalled();
+      expect(screen.getByRole('combobox')).toHaveValue('~/notes/archive/');
+    });
+
+    it('resolves a relative query against the fuzzy root, not the daemon cwd', async () => {
+      const { browseDirectory } = renderOpener();
+      await waitFor(() => expect(rows()).toHaveLength(2));
+
+      type('./docs/');
+      await waitFor(() => expect(browseDirectory).toHaveBeenCalledWith('/repo/docs/', undefined, ['md']));
+    });
+
+    it('does not browse for a query that merely contains a slash', async () => {
+      const { browseDirectory } = renderOpener();
+      await waitFor(() => expect(rows()).toHaveLength(2));
+
+      type('docs/plan');
+      await waitFor(() => expect(rows()[0]).toContain('docs/plan.md'));
+      expect(browseDirectory).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/src/components/palette/MarkdownOpener.tsx
+++ b/app/src/components/palette/MarkdownOpener.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Palette } from './Palette';
 import { finderBasename } from './rank';
-import { mergeOpenerFiles, rankOpenerFiles, type OpenerFile } from './openerRank';
+import { mergeOpenerFiles, rankOpenerFiles } from './openerRank';
+import { isPathQuery, toBrowseInput, descendQuery } from './pathMode';
+import { useFilesystemSuggestions } from '../../hooks/useFilesystemSuggestions';
+import type { BrowseDirectoryResult } from '../../hooks/useDaemonSocket';
 
 // Markdown only, for now: the pick opens a reader tile, and that tile renders
-// markdown. The caller passes this to fs_index so the server-side entry cap
-// applies to markdown alone.
+// markdown. The caller passes this to fs_index and browse_directory so the
+// server-side entry cap and the directory listing both apply to markdown alone.
 export const OPENER_EXTENSIONS = ['md'];
 
 export interface MarkdownOpenerProps {
@@ -15,18 +18,39 @@ export interface MarkdownOpenerProps {
   root: string | null;
   loadRecents: () => Promise<{ path: string; lastAt: string }[]>;
   loadIndex: (root: string) => Promise<{ files: string[]; truncated: boolean }>;
+  // Lists one directory for path mode. Omitted, path mode is unavailable and a
+  // path query simply matches nothing.
+  browseDirectory?: (inputPath: string, endpointId?: string, extensions?: string[]) => Promise<BrowseDirectoryResult>;
   onPick: (absPath: string) => void;
   onClose: () => void;
 }
 
-// The global ⌘P file opener: recently opened markdown files on an empty query,
-// a fuzzy filter over the workspace's markdown once you type, both in one
-// ranked list. The shared Palette owns the overlay, keyboard navigation, and
-// selection; this owns the data and the ranking.
+// A row is either a fuzzy/recents result or a path-mode entry. Directories are
+// the one thing that is picked without opening anything: picking one rewrites
+// the query to descend into it.
+interface OpenerRow {
+  key: string;
+  title: string;
+  path: string;
+  isDir: boolean;
+  /** Absolute for files; for directories, the query to descend with. */
+  target: string;
+}
+
+// The global ⌘P file opener. Two modes behind one input:
 //
-// Both sources load asynchronously and independently: the palette opens on
+//  - Fuzzy (default): recently opened markdown files on an empty query, a fuzzy
+//    filter over the workspace's markdown once you type, both in one ranked list.
+//  - Path: a query that starts with /, ~, ./ or ../ lists that directory one
+//    level at a time, so a file outside the workspace — or one .gitignore hides
+//    from the index — is still reachable. Picking a directory descends.
+//
+// The shared Palette owns the overlay, keyboard navigation, and selection; this
+// owns the data, the ranking, and the mode.
+//
+// Both fuzzy sources load asynchronously and independently: the palette opens on
 // whatever it has, so a cold index enumeration never delays ⌘P.
-export function MarkdownOpener({ root, loadRecents, loadIndex, onPick, onClose }: MarkdownOpenerProps) {
+export function MarkdownOpener({ root, loadRecents, loadIndex, browseDirectory, onPick, onClose }: MarkdownOpenerProps) {
   const [query, setQuery] = useState('');
   const [recents, setRecents] = useState<{ path: string; lastAt: string }[]>([]);
   const [indexFiles, setIndexFiles] = useState<string[]>([]);
@@ -62,42 +86,91 @@ export function MarkdownOpener({ root, loadRecents, loadIndex, onPick, onClose }
     return () => { cancelled = true; };
   }, [root, loadIndex]);
 
+  const browseInput = toBrowseInput(query, root);
+  const pathMode = isPathQuery(query);
+  // Path mode is local-only, like the rest of the opener: no endpoint id.
+  const { suggestions, loading: browseLoading, error: browseError } = useFilesystemSuggestions(
+    browseInput || '',
+    undefined,
+    browseDirectory,
+    { enabled: pathMode && !!browseInput, extensions: OPENER_EXTENSIONS },
+  );
+
   const candidates = useMemo(
     () => mergeOpenerFiles(recents, root, indexFiles),
     [recents, root, indexFiles],
   );
-  const results = useMemo(() => rankOpenerFiles(candidates, query), [candidates, query]);
+  const fuzzyRows = useMemo<OpenerRow[]>(
+    () => rankOpenerFiles(candidates, query).map((file) => ({
+      key: file.absPath,
+      title: finderBasename(file.label),
+      path: file.label,
+      isDir: false,
+      target: file.absPath,
+    })),
+    [candidates, query],
+  );
+  const pathRows = useMemo<OpenerRow[]>(
+    () => suggestions.map((entry) => ({
+      key: entry.absPath,
+      title: entry.isDir ? `${entry.name}/` : entry.name,
+      path: entry.path,
+      isDir: entry.isDir,
+      target: entry.isDir ? descendQuery(entry.path) : entry.absPath,
+    })),
+    [suggestions],
+  );
+  const rows = pathMode ? pathRows : fuzzyRows;
 
-  // The index is capped server-side; say so rather than implying the list is
-  // the whole tree.
-  const emptyLabel = indexLoading
-    ? 'Loading files…'
-    : query.trim() === ''
-      ? 'No recently opened files. Type to search.'
-      : truncated
-        ? 'No files match (the index is capped, so some files are missing).'
-        : 'No files match.';
+  const emptyLabel = pathMode
+    ? pathModeEmptyLabel(browseInput, browseLoading, browseError, !!browseDirectory)
+    // The index is capped server-side; say so rather than implying the list is
+    // the whole tree.
+    : indexLoading
+      ? 'Loading files…'
+      : query.trim() === ''
+        ? 'No recently opened files. Type to search, or a path to browse.'
+        : truncated
+          ? 'No files match (the index is capped, so some files are missing). Type a path to browse.'
+          : 'No files match. Type a path to browse.';
 
   return (
-    <Palette<OpenerFile>
+    <Palette<OpenerRow>
       variant="markdown-opener"
       ariaLabel="Open a markdown file"
       placeholder="Open a markdown file…"
       query={query}
       onQueryChange={setQuery}
-      items={results}
-      itemKey={(file) => file.absPath}
+      items={rows}
+      itemKey={(row) => row.key}
       emptyLabel={emptyLabel}
-      onPick={(file) => onPick(file.absPath)}
+      onPick={(row) => {
+        // Descending is a query rewrite, not an open: the palette stays up and
+        // the next listing lands from the same input.
+        if (row.isDir) setQuery(row.target);
+        else onPick(row.target);
+      }}
       onClose={onClose}
-      renderItem={(file) => (
+      renderItem={(row) => (
         <>
-          <span className="palette-option-title markdown-opener-option-title">
-            {finderBasename(file.label)}
-          </span>
-          <span className="palette-option-path markdown-opener-option-path">{file.label}</span>
+          <span className="palette-option-title markdown-opener-option-title">{row.title}</span>
+          <span className="palette-option-path markdown-opener-option-path">{row.path}</span>
         </>
       )}
     />
   );
+}
+
+function pathModeEmptyLabel(
+  browseInput: string | null,
+  loading: boolean,
+  error: string | null,
+  hasBrowse: boolean,
+): string {
+  if (!hasBrowse) return 'Browsing paths is unavailable.';
+  // A relative query with no workspace root has nothing to resolve against.
+  if (!browseInput) return 'No folder to resolve this path against.';
+  if (loading) return 'Listing…';
+  if (error) return 'That folder could not be listed.';
+  return 'Nothing here matches.';
 }

--- a/app/src/components/palette/pathMode.test.ts
+++ b/app/src/components/palette/pathMode.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { isPathQuery, toBrowseInput, descendQuery } from './pathMode';
+
+describe('isPathQuery', () => {
+  it('treats a leading slash, tilde, or dot-slash as a path', () => {
+    expect(isPathQuery('/')).toBe(true);
+    expect(isPathQuery('~')).toBe(true);
+    expect(isPathQuery('~/projects')).toBe(true);
+    expect(isPathQuery('./docs')).toBe(true);
+    expect(isPathQuery('../sibling')).toBe(true);
+  });
+
+  it('leaves an ordinary fuzzy query alone even when it contains slashes', () => {
+    // The whole point of requiring a leading slash: docs/plan is how people
+    // narrow a fuzzy search, not a request to browse.
+    expect(isPathQuery('docs/plan')).toBe(false);
+    expect(isPathQuery('plan')).toBe(false);
+    expect(isPathQuery('')).toBe(false);
+  });
+});
+
+describe('toBrowseInput', () => {
+  it('passes absolute and home-relative queries through for the daemon to expand', () => {
+    expect(toBrowseInput('~/projects/att', '/repo')).toBe('~/projects/att');
+    expect(toBrowseInput('/etc/', '/repo')).toBe('/etc/');
+  });
+
+  it('resolves a relative query against the root, since the daemon would use its own cwd', () => {
+    expect(toBrowseInput('./docs/', '/repo')).toBe('/repo/docs/');
+    expect(toBrowseInput('./docs/pl', '/repo')).toBe('/repo/docs/pl');
+    expect(toBrowseInput('../other/', '/repo/app')).toBe('/repo/other/');
+  });
+
+  it('has nothing to resolve a relative query against without a root', () => {
+    expect(toBrowseInput('./docs/', null)).toBeNull();
+  });
+
+  it('returns null for a query that is not a path at all', () => {
+    expect(toBrowseInput('docs/plan', '/repo')).toBeNull();
+  });
+
+  it('never climbs above the filesystem root', () => {
+    expect(toBrowseInput('../../../../', '/repo')).toBe('/');
+  });
+});
+
+describe('descendQuery', () => {
+  it('adds the trailing slash that means "list this directory"', () => {
+    expect(descendQuery('~/projects/attn')).toBe('~/projects/attn/');
+    expect(descendQuery('~/projects/attn/')).toBe('~/projects/attn/');
+  });
+});

--- a/app/src/components/palette/pathMode.ts
+++ b/app/src/components/palette/pathMode.ts
@@ -1,0 +1,70 @@
+/**
+ * Path mode: the opener's second mode, reached by typing a path rather than a
+ * name. `/`, `~`, `./`, and `../` are the only triggers, so an ordinary fuzzy
+ * query like `docs/plan` — which also contains a slash — stays fuzzy.
+ *
+ * The daemon does the parsing (see parseBrowseInput): it expands `~`, lists the
+ * directory before the last slash, and filters that listing by whatever was
+ * typed after it. The one thing it cannot resolve is a relative path, which
+ * would land on the daemon's own working directory, so `./` and `../` are
+ * expanded here against the opener's root before the query is sent.
+ */
+
+/** True when the query names a path rather than a file to fuzzy-match. */
+export function isPathQuery(query: string): boolean {
+  const trimmed = query.trimStart();
+  return (
+    trimmed.startsWith('/') ||
+    trimmed.startsWith('~') ||
+    trimmed === '.' ||
+    trimmed.startsWith('./') ||
+    trimmed.startsWith('../')
+  );
+}
+
+/**
+ * Converts a path query into the input `browse_directory` expects, or null when
+ * the query is not a path (or is relative with no root to resolve against, in
+ * which case there is nothing honest to list).
+ */
+export function toBrowseInput(query: string, root: string | null): string | null {
+  const trimmed = query.trimStart();
+  if (!isPathQuery(trimmed)) return null;
+  if (trimmed.startsWith('/') || trimmed.startsWith('~')) return trimmed;
+  if (!root) return null;
+  return normalizePath(`${root}/${trimmed}`);
+}
+
+/**
+ * Resolves `.` and `..` segments textually. Symlinks are not followed — the
+ * daemon resolves the final path anyway; this only needs to produce something
+ * it can list.
+ */
+function normalizePath(path: string): string {
+  const trailingSlash = path.endsWith('/');
+  const absolute = path.startsWith('/');
+  const resolved: string[] = [];
+  for (const segment of path.split('/')) {
+    if (segment === '' || segment === '.') continue;
+    if (segment === '..') {
+      if (resolved.length > 0 && resolved[resolved.length - 1] !== '..') {
+        resolved.pop();
+        continue;
+      }
+      if (absolute) continue; // can't go above /
+    }
+    resolved.push(segment);
+  }
+  const joined = (absolute ? '/' : '') + resolved.join('/');
+  if (joined === '/' || joined === '') return absolute ? '/' : '.';
+  return trailingSlash ? `${joined}/` : joined;
+}
+
+/**
+ * The query that descends into a directory the user just picked: its display
+ * path plus a trailing slash, which the daemon reads as "list this directory"
+ * rather than "filter its parent by this name".
+ */
+export function descendQuery(displayPath: string): string {
+  return displayPath.endsWith('/') ? displayPath : `${displayPath}/`;
+}

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -85,6 +85,8 @@ export type DaemonWorkspaceContext = GeneratedWorkspaceContext;
 export interface DirectoryEntry {
   name: string;
   path: string;
+  /** Directories are always listed; files only when the request asked for extensions. */
+  is_dir: boolean;
 }
 export interface PathInspection {
   input_path: string;
@@ -173,7 +175,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '185';
+export const PROTOCOL_VERSION = '186';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a
@@ -5099,7 +5101,10 @@ export function useDaemonSocket({
     });
   }, [nextRequestID]);
 
-  const sendBrowseDirectory = useCallback((inputPath: string, endpointId?: string): Promise<BrowseDirectoryResult> => {
+  // extensions (dotless, e.g. ['md']) widens the listing from directories-only
+  // to directories plus matching files. The daemon gates that variant on this
+  // client's app identity, since file names are documents rather than tree shape.
+  const sendBrowseDirectory = useCallback((inputPath: string, endpointId?: string, extensions?: string[]): Promise<BrowseDirectoryResult> => {
     return new Promise((resolve, reject) => {
       const ws = wsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -5114,6 +5119,7 @@ export function useDaemonSocket({
       ws.send(JSON.stringify({
         cmd: 'browse_directory',
         input_path: inputPath,
+        ...(extensions && extensions.length > 0 ? { extensions } : {}),
         ...(endpointId && { endpoint_id: endpointId }),
         request_id: requestId,
       }));

--- a/app/src/hooks/useFilesystemSuggestions.test.ts
+++ b/app/src/hooks/useFilesystemSuggestions.test.ts
@@ -17,19 +17,12 @@ describe('useFilesystemSuggestions', () => {
       success: true,
       input_path: '~/projects/',
       directory: '/Users/victor/projects',
-      entries: [{ name: 'attn', path: '/Users/victor/projects/attn' }],
+      entries: [{ name: 'attn', path: '/Users/victor/projects/attn', is_dir: true }],
       home_path: '/Users/victor',
     }));
 
     const { result, rerender } = renderHook(
-      ({ inputPath, enabled }) => useFilesystemSuggestions(
-        inputPath,
-        undefined,
-        browseDirectory,
-        undefined,
-        undefined,
-        enabled,
-      ),
+      ({ inputPath, enabled }) => useFilesystemSuggestions(inputPath, undefined, browseDirectory, { enabled }),
       { initialProps: { inputPath: '~/projects/', enabled: true } },
     );
 
@@ -68,7 +61,7 @@ describe('useFilesystemSuggestions', () => {
         success: true,
         input_path: '~/projects/',
         directory: '/Users/victor/projects',
-        entries: [{ name: 'local-repo', path: '/Users/victor/projects/local-repo' }],
+        entries: [{ name: 'local-repo', path: '/Users/victor/projects/local-repo', is_dir: true }],
         home_path: '/Users/victor',
       };
     });
@@ -99,13 +92,13 @@ describe('useFilesystemSuggestions', () => {
         success: true,
         input_path: '~/projects/',
         directory: '/home/remote/projects',
-        entries: [{ name: 'remote-repo', path: '/home/remote/projects/remote-repo' }],
+        entries: [{ name: 'remote-repo', path: '/home/remote/projects/remote-repo', is_dir: true }],
         home_path: '/home/remote',
       });
       await Promise.resolve();
     });
 
-    expect(browseDirectory).toHaveBeenCalledWith('~/projects/', 'ep-1');
+    expect(browseDirectory).toHaveBeenCalledWith('~/projects/', 'ep-1', undefined);
     expect(result.current.currentDir).toBe('~/projects');
     expect(result.current.suggestions.map((entry) => entry.name)).toEqual(['remote-repo']);
   });
@@ -150,6 +143,6 @@ describe('useFilesystemSuggestions', () => {
     });
 
     expect(browseDirectory).toHaveBeenCalledTimes(2);
-    expect(browseDirectory).toHaveBeenLastCalledWith('~/projects/attn', undefined);
+    expect(browseDirectory).toHaveBeenLastCalledWith('~/projects/attn', undefined, undefined);
   });
 });

--- a/app/src/hooks/useFilesystemSuggestions.ts
+++ b/app/src/hooks/useFilesystemSuggestions.ts
@@ -2,9 +2,13 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import type { BrowseDirectoryResult } from './useDaemonSocket';
 import { toDisplayPath } from '../utils/locationPickerPaths';
 
-interface FilesystemSuggestion {
+export interface FilesystemSuggestion {
   name: string;
+  /** Display form (`~`-shortened) — what the picker shows and types back. */
   path: string;
+  /** The path as the daemon resolved it, for callers that must open it. */
+  absPath: string;
+  isDir: boolean;
 }
 
 interface UseFilesystemSuggestionsResult {
@@ -12,23 +16,40 @@ interface UseFilesystemSuggestionsResult {
   loading: boolean;
   error: string | null;
   currentDir: string;
+  /** Home directory of the machine that answered, once one has. */
+  homePath: string;
+}
+
+export interface UseFilesystemSuggestionsOptions {
+  homePath?: string;
+  onHomePathChange?: (nextHomePath: string) => void;
+  enabled?: boolean;
+  /**
+   * Dotless extensions (e.g. ['md']). Omitted, the listing is directories only —
+   * the session picker's behavior. Supplied, matching files join the listing,
+   * which is what the markdown opener's path mode needs.
+   */
+  extensions?: string[];
 }
 
 export function useFilesystemSuggestions(
   inputPath: string,
   endpointId: string | undefined,
-  browseDirectory?: (inputPath: string, endpointId?: string) => Promise<BrowseDirectoryResult>,
-  homePath?: string,
-  onHomePathChange?: (nextHomePath: string) => void,
-  enabled = true,
+  browseDirectory?: (inputPath: string, endpointId?: string, extensions?: string[]) => Promise<BrowseDirectoryResult>,
+  options: UseFilesystemSuggestionsOptions = {},
 ): UseFilesystemSuggestionsResult {
+  const { homePath, onHomePathChange, enabled = true, extensions } = options;
   const [suggestions, setSuggestions] = useState<FilesystemSuggestion[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [currentDir, setCurrentDir] = useState('');
+  const [resolvedHomePath, setResolvedHomePath] = useState(homePath || '');
   const debounceRef = useRef<number | null>(null);
   const requestIdRef = useRef(0);
   const previousEndpointIdRef = useRef<string | undefined>(endpointId);
+  // Identity-stable list so a caller can pass an inline array literal without
+  // re-running the effect on every render.
+  const extensionsKey = (extensions || []).join(',');
 
   const fetchSuggestions = useCallback(async (path: string, targetEndpointId?: string) => {
     if (!enabled || !browseDirectory || !path || path.length < 1) {
@@ -44,7 +65,8 @@ export function useFilesystemSuggestions(
     setError(null);
 
     try {
-      const result = await browseDirectory(path, targetEndpointId);
+      const requested = extensionsKey ? extensionsKey.split(',') : undefined;
+      const result = await browseDirectory(path, targetEndpointId, requested);
       if (requestIdRef.current !== requestId) {
         return;
       }
@@ -52,11 +74,14 @@ export function useFilesystemSuggestions(
       const nextHomePath = result.home_path || homePath || '';
       if (nextHomePath) {
         onHomePathChange?.(nextHomePath);
+        setResolvedHomePath(nextHomePath);
       }
       setCurrentDir(toDisplayPath(result.directory, nextHomePath));
       setSuggestions((result.entries || []).map((entry) => ({
         name: entry.name,
         path: toDisplayPath(entry.path, nextHomePath),
+        absPath: entry.path,
+        isDir: entry.is_dir,
       })));
     } catch (e) {
       if (requestIdRef.current !== requestId) {
@@ -71,7 +96,7 @@ export function useFilesystemSuggestions(
         setLoading(false);
       }
     }
-  }, [browseDirectory, enabled, homePath, onHomePathChange]);
+  }, [browseDirectory, enabled, extensionsKey, homePath, onHomePathChange]);
 
   useEffect(() => {
     if (debounceRef.current) {
@@ -111,5 +136,5 @@ export function useFilesystemSuggestions(
     };
   }, [enabled, endpointId, fetchSuggestions, inputPath]);
 
-  return { suggestions, loading, error, currentDir };
+  return { suggestions, loading, error, currentDir, homePath: resolvedHomePath };
 }

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -867,6 +867,7 @@ export enum BranchesResultMessageEvent {
 export interface BrowseDirectoryMessage {
     cmd:          BrowseDirectoryMessageCmd;
     endpoint_id?: string;
+    extensions?:  string[];
     input_path:   string;
     request_id?:  string;
     [property: string]: any;
@@ -890,8 +891,9 @@ export interface BrowseDirectoryResultMessage {
 }
 
 export interface EntryElement {
-    name: string;
-    path: string;
+    is_dir: boolean;
+    name:   string;
+    path:   string;
     [property: string]: any;
 }
 
@@ -1246,8 +1248,9 @@ export enum DetachSessionMessageCmd {
 }
 
 export interface DirectoryEntry {
-    name: string;
-    path: string;
+    is_dir: boolean;
+    name:   string;
+    path:   string;
     [property: string]: any;
 }
 
@@ -9106,6 +9109,7 @@ const typeMap: any = {
     "BrowseDirectoryMessage": o([
         { json: "cmd", js: "cmd", typ: r("BrowseDirectoryMessageCmd") },
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
+        { json: "extensions", js: "extensions", typ: u(undefined, a("")) },
         { json: "input_path", js: "input_path", typ: "" },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
     ], "any"),
@@ -9121,6 +9125,7 @@ const typeMap: any = {
         { json: "success", js: "success", typ: true },
     ], "any"),
     "EntryElement": o([
+        { json: "is_dir", js: "is_dir", typ: true },
         { json: "name", js: "name", typ: "" },
         { json: "path", js: "path", typ: "" },
     ], "any"),
@@ -9323,6 +9328,7 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
     ], "any"),
     "DirectoryEntry": o([
+        { json: "is_dir", js: "is_dir", typ: true },
         { json: "name", js: "name", typ: "" },
         { json: "path", js: "path", typ: "" },
     ], "any"),

--- a/docs/plans/2026-07-24-markdown-file-opener.md
+++ b/docs/plans/2026-07-24-markdown-file-opener.md
@@ -50,7 +50,6 @@ navigation; the ⌘P registry entry and its tile-focus precedence rule.
 
 ### Deferred
 
-- Path-navigation mode (`/`, `~/`, `./`) — second PR, on the same overlay.
 - Agent-edited files as a ranking signal — schema is ready, feature is not built.
 - Non-markdown file types; creating a file that does not exist.
 - Multi-root workspaces (a workspace whose sessions span several repos).
@@ -121,7 +120,7 @@ root is not a notebook. Introduce a minimal `FileCandidate { path, title?, updat
 move the scorer beside the palette, and let `NotebookEntry` structurally satisfy it.
 Pure move, no behavior change.
 
-### R3 — One path-navigation backend (with path mode, PR2)
+### R3 — One path-navigation backend (with path mode, PR3) — DONE
 
 Two directory-listing surfaces exist:
 
@@ -156,10 +155,10 @@ change how the hook config is generated.
 
 ### Daemon fixes to fold in
 
-Both landed with the opener PR, except the dot-directory harmonization: fuzzy
-mode still hides dot-prefixed paths (git enumeration applies the same rule the
-walk always did), while `listDirectoryEntries` still shows them. Path mode is
-where that inconsistency becomes visible, so it is folded into PR2 (R3).
+Both landed: the extension filter with the opener (PR2), the dot-directory
+harmonization with path mode (PR3). The rule chosen: dot-prefixed files and
+directories are visible on both surfaces — they hold real documents, and path
+mode always listed them — while `.git` is listed by neither.
 
 
 - `fs_index`'s 25k cap counts every file, before any markdown filter, and truncation
@@ -181,7 +180,17 @@ where that inconsistency becomes visible, so it is folded into PR2 (R3).
   ⌘P palette with recents, unified ranking, and an async index load; the
   `paletteClaim` hand-off that keeps a focused Editor tile's own ⌘P. Verified
   live by `real-app:scenario-markdown-opener`.
-- Next: path mode (R3).
+- PR3 (this PR): path mode plus R3. `browse_directory` takes an optional
+  extension filter and returns `is_dir`, so one backend serves both the session
+  picker (directories only) and the opener (directories plus markdown); asking
+  for files is gated on the authenticated app client, closing the gap the plan
+  flagged. `useFilesystemSuggestions` is shared rather than reimplemented, with
+  its trailing positional arguments folded into an options object. Relative
+  queries expand against the opener root before they reach the daemon, which
+  would otherwise resolve them against its own cwd. Protocol 186.
+- Next: nothing queued. Remaining deferred items are unchanged (agent-edited
+  files as a ranking signal, non-markdown types, multi-root workspaces, remote
+  endpoints, daemon-side index caching).
 
 ### Order
 

--- a/internal/daemon/fs_index.go
+++ b/internal/daemon/fs_index.go
@@ -79,17 +79,26 @@ func matchesExtension(name string, extensions []string) bool {
 	return false
 }
 
-// hiddenPath reports whether any component of a root-relative slash path is
-// dot-prefixed. fs_index has always hidden dot files and never descended
-// dot-directories; git enumeration lists them, so it applies the same rule to
-// keep both enumerations returning the same set.
-func hiddenPath(rel string) bool {
+// skippedPath reports whether a root-relative slash path lives inside a
+// directory no file surface should ever offer. Only git's own metadata
+// qualifies: dot-prefixed documents like .claude/notes.md are real files a user
+// can open, and path mode (listDirectoryEntries) lists them, so fuzzy mode
+// hiding them would make the same file reachable one way and invisible the
+// other. See skippedDirName for the shared rule.
+func skippedPath(rel string) bool {
 	for _, segment := range strings.Split(rel, "/") {
-		if strings.HasPrefix(segment, ".") {
+		if skippedDirName(segment) {
 			return true
 		}
 	}
 	return false
+}
+
+// skippedDirName is the one rule both file surfaces apply: .git holds git's
+// object database, not documents, and listing it is noise at best. Everything
+// else — including dot-directories — stays visible.
+func skippedDirName(name string) bool {
+	return name == ".git"
 }
 
 // indexRoot enumerates the files under root, returning their root-relative
@@ -145,7 +154,7 @@ func indexRootViaGit(root string, cap int, extensions []string) (files []string,
 
 	seen := make(map[string]struct{})
 	for _, rel := range strings.Split(string(out), "\x00") {
-		if rel == "" || hiddenPath(rel) || !matchesExtension(rel, extensions) {
+		if rel == "" || skippedPath(rel) || !matchesExtension(rel, extensions) {
 			continue
 		}
 		if _, dup := seen[rel]; dup {
@@ -169,9 +178,9 @@ func indexRootViaGit(root string, cap int, extensions []string) (files []string,
 	return files, truncated, true
 }
 
-// indexRootViaWalk walks root recursively. It skips any directory whose name
-// starts with "." or is named "node_modules" (not descended at all),
-// dot-prefixed files, and any non-regular-file entry — symlinks, FIFOs,
+// indexRootViaWalk walks root recursively. It skips .git (see skippedDirName)
+// and node_modules — not descended at all, since a dependency tree's documents
+// are not the user's — plus any non-regular-file entry — symlinks, FIFOs,
 // sockets, device nodes — via DirEntry.Type().IsRegular(), a no-syscall
 // type-bits check (a symlinked dir is also never descended by WalkDir). This
 // matters beyond symlinks: a FIFO or socket that slipped into the list would be
@@ -195,12 +204,9 @@ func indexRootViaWalk(root string, cap int, extensions []string) ([]string, bool
 		}
 		name := d.Name()
 		if d.IsDir() {
-			if strings.HasPrefix(name, ".") || name == "node_modules" {
+			if skippedDirName(name) || name == "node_modules" {
 				return fs.SkipDir
 			}
-			return nil
-		}
-		if strings.HasPrefix(name, ".") {
 			return nil
 		}
 		if !d.Type().IsRegular() {

--- a/internal/daemon/fs_index_test.go
+++ b/internal/daemon/fs_index_test.go
@@ -22,12 +22,14 @@ func fsIndex(t *testing.T, d *Daemon, client *wsClient, requestID, root string, 
 }
 
 // fs_index over a real tree returns every regular file's root-relative slash
-// path, sorted, while excluding: a dot-dir's contents (not just the dir
-// itself), a node_modules dir's contents, dot-files, symlinked files, and a
-// FIFO (a non-regular-file entry that would otherwise be advertised as an
-// openable file when fs_read rejects anything that isn't a regular file).
-// truncated must be false since nothing hits the cap.
-func TestFsIndexListsFilesExcludingDotDirsNodeModulesAndSymlinks(t *testing.T) {
+// path, sorted. Dot-files and dot-directory contents are real documents and are
+// included — path mode lists them, so hiding them here would make the same file
+// reachable one way and invisible the other. Excluded: .git's contents, a
+// node_modules dir's contents, symlinked files, and a FIFO (a non-regular-file
+// entry that would otherwise be advertised as an openable file when fs_read
+// rejects anything that isn't a regular file). truncated must be false since
+// nothing hits the cap.
+func TestFsIndexListsDotFilesButNotGitOrNodeModules(t *testing.T) {
 	d := newFsDaemon(t)
 	root := t.TempDir()
 
@@ -45,9 +47,10 @@ func TestFsIndexListsFilesExcludingDotDirsNodeModulesAndSymlinks(t *testing.T) {
 	mustWrite("top.md")
 	mustWrite("nested/dir/deep.md")
 	mustWrite("nested/dir/deep2.txt")
-	mustWrite(".hidden-dir/inside.md")     // whole dot-dir excluded
+	mustWrite(".hidden-dir/inside.md")     // dot-dirs hold real documents: included
+	mustWrite(".dotfile")                  // ...as do dot-files
 	mustWrite("node_modules/pkg/index.js") // whole node_modules dir excluded
-	mustWrite(".dotfile")                  // dot-file excluded
+	mustWrite(".git/objects/ab/cdef.md")   // git's own metadata is never listed
 
 	// A symlinked file must be excluded (listed as an entry but skipped, not
 	// followed).
@@ -76,7 +79,7 @@ func TestFsIndexListsFilesExcludingDotDirsNodeModulesAndSymlinks(t *testing.T) {
 	if res.Truncated {
 		t.Fatalf("fs_index.truncated = true, want false")
 	}
-	want := []string{"nested/dir/deep.md", "nested/dir/deep2.txt", "top.md"}
+	want := []string{".dotfile", ".hidden-dir/inside.md", "nested/dir/deep.md", "nested/dir/deep2.txt", "top.md"}
 	if !equalStrings(res.Files, want) {
 		t.Fatalf("fs_index.files = %v, want %v", res.Files, want)
 	}
@@ -233,8 +236,8 @@ func TestIndexRootUsesGitAndHonorsGitignore(t *testing.T) {
 	mustWrite("tracked.md", "x")
 	mustWrite("untracked.md", "x")
 	mustWrite("build/generated.md", "x")
-	// A dot-directory git happily tracks stays hidden, so both enumerations
-	// return the same set.
+	// A dot-directory git tracks holds real documents, and path mode lists it,
+	// so fuzzy mode returns it too.
 	mustWrite(".claude/notes.md", "x")
 
 	for _, args := range [][]string{
@@ -258,8 +261,8 @@ func TestIndexRootUsesGitAndHonorsGitignore(t *testing.T) {
 	if truncated {
 		t.Fatal("truncated = true, want false")
 	}
-	if want := []string{"tracked.md", "untracked.md"}; !slicesEqual(files, want) {
-		t.Fatalf("files = %v, want %v (gitignored and dot-dir paths excluded)", files, want)
+	if want := []string{".claude/notes.md", "tracked.md", "untracked.md"}; !slicesEqual(files, want) {
+		t.Fatalf("files = %v, want %v (gitignored paths excluded, dot-dirs kept)", files, want)
 	}
 }
 

--- a/internal/daemon/ws_picker.go
+++ b/internal/daemon/ws_picker.go
@@ -56,32 +56,60 @@ func parseBrowseInput(input string) (directory string, prefix string, homePath s
 	return filepath.Clean(directory), strings.ToLower(expanded[lastSlash+1:]), homePath, nil
 }
 
-func listDirectoryEntries(dirToQuery string, prefix string) ([]protocol.DirectoryEntry, error) {
+// listDirectoryEntries lists one directory. Directories always come back; a
+// non-empty extensions filter (dotless, lowercased — see normalizeExtensions)
+// adds the regular files carrying those extensions, which is what turns the
+// session picker's directory browser into the markdown opener's path mode.
+// Symlinks and other irregular entries are dropped for files, matching
+// fs_index: only a regular file is openable.
+//
+// .git is never listed, the same rule fs_index applies (skippedDirName), so a
+// dot-directory holding real documents stays reachable both ways while git's
+// object database is noise in neither.
+//
+// Directories sort before files so a listing reads as "where you can go, then
+// what you can open"; within each group the existing rule holds — entries whose
+// name starts with the typed prefix first, then alphabetical.
+func listDirectoryEntries(dirToQuery string, prefix string, extensions []string) ([]protocol.DirectoryEntry, error) {
 	entries, err := os.ReadDir(dirToQuery)
 	if err != nil {
 		return nil, err
 	}
 
 	prefix = strings.ToLower(prefix)
-	var directories []protocol.DirectoryEntry
+	wanted := normalizeExtensions(extensions)
+	var listed []protocol.DirectoryEntry
 	for _, entry := range entries {
 		info, err := entry.Info()
-		if err != nil || !info.IsDir() {
+		if err != nil {
 			continue
 		}
 		name := entry.Name()
+		isDir := info.IsDir()
+		switch {
+		case isDir:
+			if skippedDirName(name) {
+				continue
+			}
+		case len(wanted) == 0 || !info.Mode().IsRegular() || !matchesExtension(name, wanted):
+			continue
+		}
 		if prefix != "" && !strings.Contains(strings.ToLower(name), prefix) {
 			continue
 		}
-		directories = append(directories, protocol.DirectoryEntry{
-			Name: name,
-			Path: filepath.Join(dirToQuery, name),
+		listed = append(listed, protocol.DirectoryEntry{
+			Name:  name,
+			Path:  filepath.Join(dirToQuery, name),
+			IsDir: isDir,
 		})
 	}
 
-	sort.Slice(directories, func(i, j int) bool {
-		left := strings.ToLower(directories[i].Name)
-		right := strings.ToLower(directories[j].Name)
+	sort.Slice(listed, func(i, j int) bool {
+		if listed[i].IsDir != listed[j].IsDir {
+			return listed[i].IsDir
+		}
+		left := strings.ToLower(listed[i].Name)
+		right := strings.ToLower(listed[j].Name)
 		if prefix != "" {
 			leftStarts := strings.HasPrefix(left, prefix)
 			rightStarts := strings.HasPrefix(right, prefix)
@@ -92,7 +120,7 @@ func listDirectoryEntries(dirToQuery string, prefix string) ([]protocol.Director
 		return left < right
 	})
 
-	return directories, nil
+	return listed, nil
 }
 
 func inspectPickerPath(input string) (*protocol.PathInspection, error) {
@@ -133,6 +161,21 @@ func inspectPickerPath(input string) (*protocol.PathInspection, error) {
 }
 
 func (d *Daemon) handleBrowseDirectoryWS(client *wsClient, msg *protocol.BrowseDirectoryMessage) {
+	// Directory names leak only the shape of the tree, which this command has
+	// always been willing to hand any local client. File names are the user's
+	// documents, so the moment a request asks for them it needs the same gate
+	// every fs_* command applies to an arbitrary root (see resolveFsRoot).
+	if len(msg.Extensions) > 0 && !client.isTrustedAppClient() {
+		d.sendToClient(client, &protocol.BrowseDirectoryResultMessage{
+			Event:      protocol.EventBrowseDirectoryResult,
+			InputPath:  msg.InputPath,
+			EndpointID: msg.EndpointID,
+			RequestID:  msg.RequestID,
+			Success:    false,
+			Error:      protocol.Ptr("listing files requires the authenticated attn app client"),
+		})
+		return
+	}
 	go func() {
 		dirToQuery, prefix, homePath, err := parseBrowseInput(msg.InputPath)
 		if err != nil {
@@ -161,7 +204,7 @@ func (d *Daemon) handleBrowseDirectoryWS(client *wsClient, msg *protocol.BrowseD
 			return
 		}
 
-		entries, err := listDirectoryEntries(dirToQuery, prefix)
+		entries, err := listDirectoryEntries(dirToQuery, prefix, msg.Extensions)
 		if err != nil {
 			d.sendToClient(client, &protocol.BrowseDirectoryResultMessage{
 				Event:      protocol.EventBrowseDirectoryResult,

--- a/internal/daemon/ws_picker_test.go
+++ b/internal/daemon/ws_picker_test.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
 )
 
 func sameDirectory(left string, right string) bool {
@@ -179,5 +181,149 @@ func TestInspectPickerPathCanonicalizesSymlinkedRepoRoots(t *testing.T) {
 	}
 	if inspection.RepoRoot == nil || !sameDirectory(*inspection.RepoRoot, realRepoDir) {
 		t.Fatalf("repo root = %v, want same directory as %q", inspection.RepoRoot, realRepoDir)
+	}
+}
+
+// seedBrowseTree lays out one directory holding a mix of things path mode must
+// distinguish: subdirectories, markdown files, an unrelated file type, git's
+// metadata, and a symlink.
+func seedBrowseTree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, dir := range []string{"docs", ".claude", ".git"} {
+		if err := os.MkdirAll(filepath.Join(root, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, file := range []string{"plan.md", "notes.txt", ".git/COMMIT_EDITMSG"} {
+		if err := os.WriteFile(filepath.Join(root, file), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(filepath.Join(root, "plan.md"), filepath.Join(root, "linked.md")); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func entryNames(entries []protocol.DirectoryEntry) []string {
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name)
+	}
+	return names
+}
+
+// Without an extension filter the listing is directories only — the session
+// picker's long-standing behavior, which path mode must not change.
+func TestListDirectoryEntriesWithoutExtensionsListsDirectoriesOnly(t *testing.T) {
+	root := seedBrowseTree(t)
+
+	entries, err := listDirectoryEntries(root, "", nil)
+	if err != nil {
+		t.Fatalf("listDirectoryEntries: %v", err)
+	}
+	if want := []string{".claude", "docs"}; !slicesEqual(entryNames(entries), want) {
+		t.Fatalf("entries = %v, want %v", entryNames(entries), want)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir {
+			t.Fatalf("entry %q reported is_dir = false", entry.Name)
+		}
+	}
+}
+
+// With an extension filter the listing gains matching regular files — and only
+// those: another file type, a symlink (fs_read serves regular files only), and
+// .git stay out, while dot-directories remain visible so a document under
+// ~/.claude is reachable.
+func TestListDirectoryEntriesWithExtensionsAddsMatchingFiles(t *testing.T) {
+	root := seedBrowseTree(t)
+
+	entries, err := listDirectoryEntries(root, "", []string{"md"})
+	if err != nil {
+		t.Fatalf("listDirectoryEntries: %v", err)
+	}
+	// Directories first, then files: "where you can go, then what you can open".
+	if want := []string{".claude", "docs", "plan.md"}; !slicesEqual(entryNames(entries), want) {
+		t.Fatalf("entries = %v, want %v", entryNames(entries), want)
+	}
+	if entries[2].IsDir {
+		t.Fatalf("plan.md reported is_dir = true")
+	}
+	if entries[2].Path != filepath.Join(root, "plan.md") {
+		t.Fatalf("plan.md path = %q, want absolute path under root", entries[2].Path)
+	}
+}
+
+// The typed last segment filters both groups, and a leading dot reaches a
+// dot-directory rather than being swallowed as a hidden-file rule.
+func TestListDirectoryEntriesFiltersByPrefixAcrossKinds(t *testing.T) {
+	root := seedBrowseTree(t)
+
+	entries, err := listDirectoryEntries(root, ".cla", []string{"md"})
+	if err != nil {
+		t.Fatalf("listDirectoryEntries: %v", err)
+	}
+	if want := []string{".claude"}; !slicesEqual(entryNames(entries), want) {
+		t.Fatalf("entries = %v, want %v", entryNames(entries), want)
+	}
+
+	entries, err = listDirectoryEntries(root, "pla", []string{"md"})
+	if err != nil {
+		t.Fatalf("listDirectoryEntries: %v", err)
+	}
+	if want := []string{"plan.md"}; !slicesEqual(entryNames(entries), want) {
+		t.Fatalf("entries = %v, want %v", entryNames(entries), want)
+	}
+}
+
+// Asking for files is gated on the authenticated app client: directory names
+// leak tree shape, file names leak the user's documents. An untrusted client
+// gets an error, not a listing.
+func TestBrowseDirectoryFileListingRequiresTrustedClient(t *testing.T) {
+	d := newFsDaemon(t)
+	root := seedBrowseTree(t)
+
+	untrusted := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleBrowseDirectoryWS(untrusted, &protocol.BrowseDirectoryMessage{
+		Cmd:        protocol.CmdBrowseDirectory,
+		InputPath:  root + "/",
+		Extensions: []string{"md"},
+	})
+	var denied protocol.BrowseDirectoryResultMessage
+	readNotebookWSEvent(t, untrusted.send, &denied)
+	if denied.Success {
+		t.Fatalf("untrusted file listing succeeded: %+v", denied.Entries)
+	}
+
+	// The same client may still browse directories: that surface is unchanged.
+	d.handleBrowseDirectoryWS(untrusted, &protocol.BrowseDirectoryMessage{
+		Cmd:       protocol.CmdBrowseDirectory,
+		InputPath: root + "/",
+	})
+	var allowed protocol.BrowseDirectoryResultMessage
+	readNotebookWSEvent(t, untrusted.send, &allowed)
+	if !allowed.Success {
+		t.Fatalf("untrusted directory listing failed: %v", protocol.Deref(allowed.Error))
+	}
+	if want := []string{".claude", "docs"}; !slicesEqual(entryNames(allowed.Entries), want) {
+		t.Fatalf("entries = %v, want %v", entryNames(allowed.Entries), want)
+	}
+
+	// The app client gets the files.
+	trusted := trustedFsClient(4)
+	d.handleBrowseDirectoryWS(trusted, &protocol.BrowseDirectoryMessage{
+		Cmd:        protocol.CmdBrowseDirectory,
+		InputPath:  root + "/",
+		Extensions: []string{"md"},
+	})
+	var granted protocol.BrowseDirectoryResultMessage
+	readNotebookWSEvent(t, trusted.send, &granted)
+	if !granted.Success {
+		t.Fatalf("trusted file listing failed: %v", protocol.Deref(granted.Error))
+	}
+	if want := []string{".claude", "docs", "plan.md"}; !slicesEqual(entryNames(granted.Entries), want) {
+		t.Fatalf("entries = %v, want %v", entryNames(granted.Entries), want)
 	}
 }

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "185"
+const ProtocolVersion = "186"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -537,6 +537,9 @@ type BrowseDirectoryMessage struct {
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
 	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
+	// Extensions corresponds to the JSON schema field "extensions".
+	Extensions []string `json:"extensions,omitempty,omitzero"`
+
 	// InputPath corresponds to the JSON schema field "input_path".
 	InputPath string `json:"input_path"`
 
@@ -995,6 +998,9 @@ type DetachSessionMessage struct {
 }
 
 type DirectoryEntry struct {
+	// IsDir corresponds to the JSON schema field "is_dir".
+	IsDir bool `json:"is_dir"`
+
 	// Name corresponds to the JSON schema field "name".
 	Name string `json:"name"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -501,6 +501,7 @@ model FileActivity {
 model DirectoryEntry {
   name: string;
   path: string;
+  is_dir: boolean;
 }
 
 model PathInspection {
@@ -1500,9 +1501,14 @@ model RecentFilesMessage {
   request_id?: string;
 }
 
+// Lists one directory. Directories are always returned; extensions adds regular
+// files with those extensions (no dots, e.g. ["md"]) to the listing. Asking for
+// files exposes document names rather than just tree shape, so that variant is
+// restricted to the authenticated app client.
 model BrowseDirectoryMessage {
   cmd: "browse_directory";
   input_path: string;
+  extensions?: string[];
   endpoint_id?: string;
   request_id?: string;
 }


### PR DESCRIPTION
PR3 of the markdown-opener plan (`docs/plans/2026-07-24-markdown-file-opener.md`). PR1 (#653) extracted the palette shell; PR2 (#654) shipped the ⌘P opener with recents and fuzzy search. This adds the second mode and the shared path-navigation backend (R3).

## What the user gets

A query that starts with `/`, `~/`, `./` or `../` switches the opener from fuzzy search to browsing: it lists that folder one level at a time, Enter on a folder descends into it, Enter on a file opens it as a reader tile. A leading slash is the only trigger, so `docs/plan` still fuzzy-searches. This is how a document outside the session's folder — or one `.gitignore` hides from the index — stays reachable, without a native file dialog.

Dot-folders like `.claude` are now searchable too. They hold real documents, path mode always listed them, and fuzzy mode hid them; both now show them, and `.git` is listed by neither.

## Shape

- **One directory-listing backend, not a second copy.** `browse_directory` takes an optional extension filter and reports `is_dir` per entry, so the session picker keeps its directories-only listing and the opener gets directories plus markdown. `useFilesystemSuggestions` is reused as-is; its trailing positional arguments became an options object.
- **The file-listing variant is gated.** Directory names leak only tree shape, which this command always exposed to any local client. File names are the user's documents, so asking for them now requires the authenticated app client — the same gate `resolveFsRoot` applies to an arbitrary `fs_*` root. This closes the gap the plan flagged. Plain directory browsing, including the hub's endpoint-forwarded browsing, is unchanged.
- **Relative queries expand client-side** against the opener's root; the daemon would otherwise resolve them against its own working directory.
- Protocol 186.

## Verification

- Go: new `listDirectoryEntries` tests (directories-only default, files behind the filter, symlink/`.git` exclusion, prefix filtering across kinds) and a `browse_directory` gate test covering all three cases — untrusted+files denied, untrusted+directories allowed, trusted+files allowed. Updated `fs_index` tests pin the new dot-directory rule.
- Frontend: `pathMode.test.ts` (mode detection, relative expansion, no climbing above `/`) and `MarkdownOpener` path-mode tests (lists a directory, descends without opening, opens by absolute path, ignores a slash in an ordinary query). Full suite 2021 tests green; Playwright e2e 190 green.
- Packaged app, throwaway profile `mdpath`: `real-app:scenario-markdown-opener` extended with a path-mode leg — native ⌘P, type the session directory, descend into the gitignored `build/`, open the file fuzzy mode cannot see, assert the third tile docks. Green twice in a row. `real-app:scenario-workspace-creation-shortcuts` re-run to confirm the session picker still browses.