### PR TITLE
ci: add React Doctor scan for the app workspace

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -34,7 +34,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: millionco/react-doctor@v2
+      # Pinned to the commit the v2 tag pointed at on 2026-07-24. The tag is
+      # mutable and this action runs on every PR with write access to comments,
+      # issues, and statuses, so the exact code is frozen here. Bump the SHA
+      # (and the comment) deliberately to take a new version.
+      - uses: millionco/react-doctor@01820bb4fd4d0a4aebcd8df2b2a143a098649cb2 # v2
         with:
           # The React app is the `app/` workspace; there is no package.json at
           # the repo root for the default "." to find.

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -1,0 +1,55 @@
+# React Doctor — finds security, performance, correctness, accessibility,
+# bundle-size, and architecture issues in React codebases.
+#
+# Docs: https://www.react.doctor/ci
+# Source: https://github.com/millionco/react-doctor
+
+name: React Doctor
+
+on:
+  # Scans the PR's changed files and posts a sticky summary comment listing only the new issues introduced relative to the merge base of the target branch.
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  # Scans `main` on every push to track the health-score trend and catch regressions that slipped past PR review.
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  statuses: write
+
+# Cancels any in-flight scan for the same PR (or branch, on push) the moment a new commit arrives, so reviewers only ever see the latest run.
+concurrency:
+  group: react-doctor-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  react-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      # fetch-depth: 0 gives React Doctor the full git history it needs to find the merge base with the target branch. Without it a shallow checkout has no merge base, so PR runs can't compare against the base and fall back to reporting every issue in the changed files (pre-existing ones included) instead of only the ones the PR introduced.
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: millionco/react-doctor@v2
+        with:
+          # The React app is the `app/` workspace; there is no package.json at
+          # the repo root for the default "." to find.
+          directory: app
+        # Advisory by default: React Doctor reports findings on every PR — a
+        # sticky summary comment, inline review comments, and a commit status
+        # with the health score — but never fails the check, so it won't red-X
+        # a teammate's PR on day one. When your team trusts the signal, graduate
+        # the gate: uncomment the block below and set blocking to "error" (fail
+        # on new error-severity findings) or "warning" (fail on any finding).
+        # Full reference: https://www.react.doctor/ci
+        #   blocking: error          # Gate level: "none" (advisory, the default) | "warning" | "error"
+        #   scope: full              # On PRs, scan the whole project instead of just changed files
+        #   comment: false           # Disable the sticky PR summary comment
+        #   review-comments: false   # Disable inline review comments on changed lines
+        #   commit-status: false     # Disable the commit status (score + counts, links to the run)
+        #   version: "0.4.0"         # Pin to a specific react-doctor version instead of "latest"
+        #   project: "web,admin"     # In a monorepo, scan specific workspace project(s)

--- a/app/package.json
+++ b/app/package.json
@@ -79,7 +79,8 @@
     "real-app:soak": "node scripts/real-app-harness/run-soak.mjs",
     "e2e": "playwright test",
     "e2e:settings-visual": "playwright test e2e/settings-visual.spec.ts",
-    "e2e:headed": "playwright test --headed"
+    "e2e:headed": "playwright test --headed",
+    "doctor": "npx react-doctor@latest"
   },
   "dependencies": {
     "@codemirror/lang-markdown": "^6.5.0",


### PR DESCRIPTION
Adds the [React Doctor](https://www.react.doctor/ci) action, which reports security, performance, correctness, accessibility, bundle-size, and architecture findings in React code.

- **On pull requests** it scans the changed files and posts a sticky summary comment covering only what the PR introduces relative to the merge base.
- **On pushes to main** it publishes a commit status with the health score, so the trend is visible over time.
- **Advisory, not a gate.** `blocking` stays at its `none` default, so findings never fail a check. The commented reference block in the workflow lists how to graduate it to `warning` or `error` later.

`pnpm --dir app run doctor` runs the same scan locally via the new `doctor` script.

## Two adjustments to the original change

1. **Workflow path.** It was written to `app/.github/workflows/react-doctor.yml`. GitHub only reads workflows from `.github/workflows/` at the repository root, so it would never have run from there; this PR puts it at the root.
2. **`directory: app`.** The default is `"."`, and there is no package.json at the repo root — the React app is the `app/` workspace. The action's `project` input defaults to `"*"` and might have discovered it anyway, but pointing at the workspace is explicit.

## Worth a look before merging

`millionco/react-doctor@v2` is a third-party action, and this grants it `pull-requests: write`, `issues: write`, and `statuses: write` on every PR — enough to write comments and statuses on the repo. The tag is mutable; pinning to the commit SHA (`736abc183ac491b4e954fc6bedec3a9a1b73d38b`) would freeze exactly what runs. Left as `@v2` as originally written — say the word and I'll pin it.

The workflow is inert until it lands on main, so its first real run is on the next PR after merge.