### PR TITLE
refactor(pty): split snapshot and attach payload families (retirement Phase 4)

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -118,10 +118,6 @@ type WebSocketEvent = GeneratedWebSocketEvent & {
   screen_snapshot?: string;
   screen_rows?: number;
   screen_cols?: number;
-  screen_cursor_x?: number;
-  screen_cursor_y?: number;
-  screen_cursor_visible?: boolean;
-  screen_snapshot_fresh?: boolean;
   last_seq?: number;
   cols?: number;
   rows?: number;
@@ -171,7 +167,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '182';
+export const PROTOCOL_VERSION = '183';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a
@@ -2219,7 +2215,7 @@ export function useDaemonSocket({
                 pendingActionsRef.current.delete(key);
                 if (data.success) {
                   const result: ScreenSnapshotResult = {
-                    screenSnapshot: data.screen_snapshot_fresh ? data.screen_snapshot : undefined,
+                    screenSnapshot: data.screen_snapshot ?? undefined,
                     screenCols: data.screen_cols,
                     screenRows: data.screen_rows,
                     lastSeq: typeof data.last_seq === 'number' ? data.last_seq : 0,

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationActionResultMessage, AutomationApplyMessage, AutomationCleanupMessage, AutomationDefinitionGetMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDeleteMessage, AutomationListMessage, AutomationRunListMessage, AutomationRunMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationSetEnabledMessage, AutomationShowMessage, AutomationValidateMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationActionResultMessage, AutomationApplyMessage, AutomationCleanupMessage, AutomationDefinitionGetMessage, AutomationDefinitionsGetMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationListMessage, AutomationRunListMessage, AutomationRunMessage, AutomationRunsGetMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationShowMessage, AutomationValidateMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -15,18 +15,18 @@
 //   const automationApplyMessage = Convert.toAutomationApplyMessage(json);
 //   const automationCleanupMessage = Convert.toAutomationCleanupMessage(json);
 //   const automationDefinitionGetMessage = Convert.toAutomationDefinitionGetMessage(json);
-//   const automationDefinitionSummary = Convert.toAutomationDefinitionSummary(json);
 //   const automationDefinitionsGetMessage = Convert.toAutomationDefinitionsGetMessage(json);
+//   const automationDefinitionSummary = Convert.toAutomationDefinitionSummary(json);
 //   const automationDeleteMessage = Convert.toAutomationDeleteMessage(json);
 //   const automationListMessage = Convert.toAutomationListMessage(json);
 //   const automationRunListMessage = Convert.toAutomationRunListMessage(json);
 //   const automationRunMessage = Convert.toAutomationRunMessage(json);
-//   const automationRunSummary = Convert.toAutomationRunSummary(json);
 //   const automationRunsGetMessage = Convert.toAutomationRunsGetMessage(json);
+//   const automationRunSummary = Convert.toAutomationRunSummary(json);
+//   const automationsChangedMessage = Convert.toAutomationsChangedMessage(json);
 //   const automationSetEnabledMessage = Convert.toAutomationSetEnabledMessage(json);
 //   const automationShowMessage = Convert.toAutomationShowMessage(json);
 //   const automationValidateMessage = Convert.toAutomationValidateMessage(json);
-//   const automationsChangedMessage = Convert.toAutomationsChangedMessage(json);
 //   const bootstrapEndpointMessage = Convert.toBootstrapEndpointMessage(json);
 //   const branch = Convert.toBranch(json);
 //   const branchChangedMessage = Convert.toBranchChangedMessage(json);
@@ -182,18 +182,20 @@
 //   const openBrowserMessage = Convert.toOpenBrowserMessage(json);
 //   const openMarkdownMessage = Convert.toOpenMarkdownMessage(json);
 //   const openMarkdownResultMessage = Convert.toOpenMarkdownResultMessage(json);
-//   const pR = Convert.toPR(json);
-//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
-//   const pRRole = Convert.toPRRole(json);
-//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
-//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
 //   const pathInspection = Convert.toPathInspection(json);
 //   const pinWorkspaceMessage = Convert.toPinWorkspaceMessage(json);
 //   const pluginActionResultMessage = Convert.toPluginActionResultMessage(json);
 //   const pluginInfo = Convert.toPluginInfo(json);
 //   const pluginIssue = Convert.toPluginIssue(json);
 //   const pluginsUpdatedMessage = Convert.toPluginsUpdatedMessage(json);
+//   const pR = Convert.toPR(json);
+//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
 //   const presentAnnotation = Convert.toPresentAnnotation(json);
+//   const presentation = Convert.toPresentation(json);
+//   const presentationAddedMessage = Convert.toPresentationAddedMessage(json);
+//   const presentationComment = Convert.toPresentationComment(json);
+//   const presentationRound = Convert.toPresentationRound(json);
+//   const presentationUpdatedMessage = Convert.toPresentationUpdatedMessage(json);
 //   const presentCloseMessage = Convert.toPresentCloseMessage(json);
 //   const presentCloseResultMessage = Convert.toPresentCloseResultMessage(json);
 //   const presentCommentInput = Convert.toPresentCommentInput(json);
@@ -205,16 +207,14 @@
 //   const presentOpenResult = Convert.toPresentOpenResult(json);
 //   const presentSubmitRoundMessage = Convert.toPresentSubmitRoundMessage(json);
 //   const presentSubmitRoundResultMessage = Convert.toPresentSubmitRoundResultMessage(json);
-//   const presentation = Convert.toPresentation(json);
-//   const presentationAddedMessage = Convert.toPresentationAddedMessage(json);
-//   const presentationComment = Convert.toPresentationComment(json);
-//   const presentationRound = Convert.toPresentationRound(json);
-//   const presentationUpdatedMessage = Convert.toPresentationUpdatedMessage(json);
+//   const pRRole = Convert.toPRRole(json);
+//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
+//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
 //   const ptyDesyncMessage = Convert.toPtyDesyncMessage(json);
 //   const ptyInputMessage = Convert.toPtyInputMessage(json);
 //   const ptyOutputMessage = Convert.toPtyOutputMessage(json);
-//   const ptyResizeMessage = Convert.toPtyResizeMessage(json);
 //   const ptyResizedMessage = Convert.toPtyResizedMessage(json);
+//   const ptyResizeMessage = Convert.toPtyResizeMessage(json);
 //   const queryAuthorsMessage = Convert.toQueryAuthorsMessage(json);
 //   const queryMessage = Convert.toQueryMessage(json);
 //   const queryPRsMessage = Convert.toQueryPRsMessage(json);
@@ -245,13 +245,13 @@
 //   const sessionSelectedMessage = Convert.toSessionSelectedMessage(json);
 //   const sessionState = Convert.toSessionState(json);
 //   const sessionStateChangedMessage = Convert.toSessionStateChangedMessage(json);
+//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const sessionTodosUpdatedMessage = Convert.toSessionTodosUpdatedMessage(json);
 //   const sessionTranscriptEvent = Convert.toSessionTranscriptEvent(json);
 //   const sessionTranscriptMessage = Convert.toSessionTranscriptMessage(json);
 //   const sessionTranscriptResult = Convert.toSessionTranscriptResult(json);
 //   const sessionUnregisteredMessage = Convert.toSessionUnregisteredMessage(json);
 //   const sessionVisualizedMessage = Convert.toSessionVisualizedMessage(json);
-//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const setChiefOfStaffMessage = Convert.toSetChiefOfStaffMessage(json);
 //   const setEndpointRemoteWebMessage = Convert.toSetEndpointRemoteWebMessage(json);
 //   const setPluginPriorityMessage = Convert.toSetPluginPriorityMessage(json);
@@ -259,8 +259,8 @@
 //   const setSettingMessage = Convert.toSetSettingMessage(json);
 //   const setTerminalThemeMessage = Convert.toSetTerminalThemeMessage(json);
 //   const setTicketStatusMessage = Convert.toSetTicketStatusMessage(json);
-//   const setWorkspaceRankMessage = Convert.toSetWorkspaceRankMessage(json);
 //   const settingsUpdatedMessage = Convert.toSettingsUpdatedMessage(json);
+//   const setWorkspaceRankMessage = Convert.toSetWorkspaceRankMessage(json);
 //   const spawnResultMessage = Convert.toSpawnResultMessage(json);
 //   const spawnSessionMessage = Convert.toSpawnSessionMessage(json);
 //   const stateMessage = Convert.toStateMessage(json);
@@ -305,11 +305,11 @@
 //   const ticketStatusResult = Convert.toTicketStatusResult(json);
 //   const ticketSubscribeMessage = Convert.toTicketSubscribeMessage(json);
 //   const ticketSubscribeResult = Convert.toTicketSubscribeResult(json);
+//   const ticketsUpdatedMessage = Convert.toTicketsUpdatedMessage(json);
 //   const ticketTakeMessage = Convert.toTicketTakeMessage(json);
 //   const ticketTakeResult = Convert.toTicketTakeResult(json);
 //   const ticketUnsubscribeMessage = Convert.toTicketUnsubscribeMessage(json);
 //   const ticketUnsubscribeResult = Convert.toTicketUnsubscribeResult(json);
-//   const ticketsUpdatedMessage = Convert.toTicketsUpdatedMessage(json);
 //   const todosMessage = Convert.toTodosMessage(json);
 //   const triggerNudgeMessage = Convert.toTriggerNudgeMessage(json);
 //   const uninstallPluginMessage = Convert.toUninstallPluginMessage(json);
@@ -362,8 +362,8 @@
 //   const workspaceLayoutSetSplitRatioMessage = Convert.toWorkspaceLayoutSetSplitRatioMessage(json);
 //   const workspaceLayoutSplitDirection = Convert.toWorkspaceLayoutSplitDirection(json);
 //   const workspaceLayoutUndockTileMessage = Convert.toWorkspaceLayoutUndockTileMessage(json);
-//   const workspaceLayoutUpdateTileMessage = Convert.toWorkspaceLayoutUpdateTileMessage(json);
 //   const workspaceLayoutUpdatedMessage = Convert.toWorkspaceLayoutUpdatedMessage(json);
+//   const workspaceLayoutUpdateTileMessage = Convert.toWorkspaceLayoutUpdateTileMessage(json);
 //   const workspaceRegisteredMessage = Convert.toWorkspaceRegisteredMessage(json);
 //   const workspaceSelectedMessage = Convert.toWorkspaceSelectedMessage(json);
 //   const workspaceStateChangedMessage = Convert.toWorkspaceStateChangedMessage(json);
@@ -592,6 +592,16 @@ export enum AutomationDefinitionGetMessageCmd {
     AutomationDefinitionGet = "automation_definition_get",
 }
 
+export interface AutomationDefinitionsGetMessage {
+    cmd:         AutomationDefinitionsGetMessageCmd;
+    request_id?: string;
+    [property: string]: any;
+}
+
+export enum AutomationDefinitionsGetMessageCmd {
+    AutomationDefinitionsGet = "automation_definitions_get",
+}
+
 export interface AutomationDefinitionSummary {
     catch_up?:           string;
     continuity?:         string;
@@ -604,16 +614,6 @@ export interface AutomationDefinitionSummary {
     trigger_type:        string;
     updated_at:          string;
     [property: string]: any;
-}
-
-export interface AutomationDefinitionsGetMessage {
-    cmd:         AutomationDefinitionsGetMessageCmd;
-    request_id?: string;
-    [property: string]: any;
-}
-
-export enum AutomationDefinitionsGetMessageCmd {
-    AutomationDefinitionsGet = "automation_definitions_get",
 }
 
 export interface AutomationDeleteMessage {
@@ -659,6 +659,17 @@ export enum AutomationRunMessageCmd {
     AutomationRun = "automation_run",
 }
 
+export interface AutomationRunsGetMessage {
+    cmd:           AutomationRunsGetMessageCmd;
+    definition_id: string;
+    request_id?:   string;
+    [property: string]: any;
+}
+
+export enum AutomationRunsGetMessageCmd {
+    AutomationRunsGet = "automation_runs_get",
+}
+
 export interface AutomationRunSummary {
     created_at:          string;
     definition_id:       string;
@@ -676,15 +687,14 @@ export interface AutomationRunSummary {
     [property: string]: any;
 }
 
-export interface AutomationRunsGetMessage {
-    cmd:           AutomationRunsGetMessageCmd;
-    definition_id: string;
-    request_id?:   string;
+export interface AutomationsChangedMessage {
+    definition_ids: string[];
+    event:          AutomationsChangedMessageEvent;
     [property: string]: any;
 }
 
-export enum AutomationRunsGetMessageCmd {
-    AutomationRunsGet = "automation_runs_get",
+export enum AutomationsChangedMessageEvent {
+    AutomationsChanged = "automations_changed",
 }
 
 export interface AutomationSetEnabledMessage {
@@ -718,16 +728,6 @@ export interface AutomationValidateMessage {
 
 export enum AutomationValidateMessageCmd {
     AutomationValidate = "automation_validate",
-}
-
-export interface AutomationsChangedMessage {
-    definition_ids: string[];
-    event:          AutomationsChangedMessageEvent;
-    [property: string]: any;
-}
-
-export enum AutomationsChangedMessageEvent {
-    AutomationsChanged = "automations_changed",
 }
 
 export interface BootstrapEndpointMessage {
@@ -1873,7 +1873,7 @@ export interface PresentationElement {
 
 export interface Round {
     base_sha:        string;
-    changed_files?:  FileElement[];
+    changed_files?:  ChangedFileElement[];
     created_at:      string;
     head_sha:        string;
     id:              string;
@@ -1885,7 +1885,7 @@ export interface Round {
     [property: string]: any;
 }
 
-export interface FileElement {
+export interface ChangedFileElement {
     additions?:   number;
     annotations?: AnnotationElement[];
     deletions?:   number;
@@ -1902,7 +1902,7 @@ export interface AnnotationElement {
 }
 
 export interface Manifest {
-    files:    FileElement[];
+    files:    ChangedFileElement[];
     skip:     string[];
     summary?: string;
     title:    string;
@@ -1997,21 +1997,17 @@ export enum GetScreenSnapshotMessageCmd {
 }
 
 export interface GetScreenSnapshotResultMessage {
-    cols?:                  number;
-    error?:                 string;
-    event:                  GetScreenSnapshotResultMessageEvent;
-    id:                     string;
-    last_seq?:              number;
-    rows?:                  number;
-    running?:               boolean;
-    screen_cols?:           number;
-    screen_cursor_visible?: boolean;
-    screen_cursor_x?:       number;
-    screen_cursor_y?:       number;
-    screen_rows?:           number;
-    screen_snapshot?:       string;
-    screen_snapshot_fresh?: boolean;
-    success:                boolean;
+    cols?:            number;
+    error?:           string;
+    event:            GetScreenSnapshotResultMessageEvent;
+    id:               string;
+    last_seq?:        number;
+    rows?:            number;
+    running?:         boolean;
+    screen_cols?:     number;
+    screen_rows?:     number;
+    screen_snapshot?: string;
+    success:          boolean;
     [property: string]: any;
 }
 
@@ -2998,69 +2994,6 @@ export enum OpenMarkdownResultMessageEvent {
     OpenMarkdownResult = "open_markdown_result",
 }
 
-export interface PR {
-    approved_by_me:         boolean;
-    author:                 string;
-    ci_status?:             string;
-    comment_count?:         number;
-    details_fetched:        boolean;
-    details_fetched_at?:    string;
-    has_new_changes:        boolean;
-    head_branch?:           string;
-    head_sha?:              string;
-    heat_state?:            HeatState;
-    host:                   string;
-    id:                     string;
-    last_heat_activity_at?: string;
-    last_polled:            string;
-    last_updated:           string;
-    mergeable?:             boolean;
-    mergeable_state?:       string;
-    muted:                  boolean;
-    number:                 number;
-    reason:                 string;
-    repo:                   string;
-    review_status?:         string;
-    role:                   PRRole;
-    state:                  string;
-    title:                  string;
-    url:                    string;
-    [property: string]: any;
-}
-
-export interface PRActionResultMessage {
-    action:  string;
-    error?:  string;
-    event:   PRActionResultMessageEvent;
-    id:      string;
-    success: boolean;
-    [property: string]: any;
-}
-
-export enum PRActionResultMessageEvent {
-    PRActionResult = "pr_action_result",
-}
-
-export interface PRVisitedMessage {
-    cmd: PRVisitedMessageCmd;
-    id:  string;
-    [property: string]: any;
-}
-
-export enum PRVisitedMessageCmd {
-    PRVisited = "pr_visited",
-}
-
-export interface PRsUpdatedMessage {
-    event: PRsUpdatedMessageEvent;
-    prs?:  PRElement[];
-    [property: string]: any;
-}
-
-export enum PRsUpdatedMessageEvent {
-    PrsUpdated = "prs_updated",
-}
-
 export interface PathInspection {
     exists:        boolean;
     home_path?:    string;
@@ -3164,11 +3097,115 @@ export interface PluginElement {
     [property: string]: any;
 }
 
+export interface PR {
+    approved_by_me:         boolean;
+    author:                 string;
+    ci_status?:             string;
+    comment_count?:         number;
+    details_fetched:        boolean;
+    details_fetched_at?:    string;
+    has_new_changes:        boolean;
+    head_branch?:           string;
+    head_sha?:              string;
+    heat_state?:            HeatState;
+    host:                   string;
+    id:                     string;
+    last_heat_activity_at?: string;
+    last_polled:            string;
+    last_updated:           string;
+    mergeable?:             boolean;
+    mergeable_state?:       string;
+    muted:                  boolean;
+    number:                 number;
+    reason:                 string;
+    repo:                   string;
+    review_status?:         string;
+    role:                   PRRole;
+    state:                  string;
+    title:                  string;
+    url:                    string;
+    [property: string]: any;
+}
+
+export interface PRActionResultMessage {
+    action:  string;
+    error?:  string;
+    event:   PRActionResultMessageEvent;
+    id:      string;
+    success: boolean;
+    [property: string]: any;
+}
+
+export enum PRActionResultMessageEvent {
+    PRActionResult = "pr_action_result",
+}
+
 export interface PresentAnnotation {
     comments:   string[];
     line_end:   number;
     line_start: number;
     [property: string]: any;
+}
+
+export interface Presentation {
+    created_at:             string;
+    id:                     string;
+    kind:                   string;
+    latest_round_seq:       number;
+    latest_round_submitted: boolean;
+    repo_path:              string;
+    session_id:             string;
+    status:                 string;
+    ticket_id?:             string;
+    title:                  string;
+    [property: string]: any;
+}
+
+export interface PresentationAddedMessage {
+    event:        PresentationAddedMessageEvent;
+    presentation: PresentationElement;
+    [property: string]: any;
+}
+
+export enum PresentationAddedMessageEvent {
+    PresentationAdded = "presentation_added",
+}
+
+export interface PresentationComment {
+    author:     string;
+    content:    string;
+    created_at: string;
+    filepath:   string;
+    id:         string;
+    line_end:   number;
+    line_start: number;
+    round_id:   string;
+    side:       string;
+    [property: string]: any;
+}
+
+export interface PresentationRound {
+    base_sha:        string;
+    changed_files?:  ChangedFileElement[];
+    created_at:      string;
+    head_sha:        string;
+    id:              string;
+    manifest:        Manifest;
+    presentation_id: string;
+    seq:             number;
+    submitted_at?:   string;
+    verdict?:        string;
+    [property: string]: any;
+}
+
+export interface PresentationUpdatedMessage {
+    event:        PresentationUpdatedMessageEvent;
+    presentation: PresentationElement;
+    [property: string]: any;
+}
+
+export enum PresentationUpdatedMessageEvent {
+    PresentationUpdated = "presentation_updated",
 }
 
 export interface PresentCloseMessage {
@@ -3232,7 +3269,7 @@ export interface PresentFile {
 }
 
 export interface PresentManifestView {
-    files:    FileElement[];
+    files:    ChangedFileElement[];
     skip:     string[];
     summary?: string;
     title:    string;
@@ -3297,65 +3334,24 @@ export enum PresentSubmitRoundResultMessageEvent {
     PresentSubmitRoundResult = "present_submit_round_result",
 }
 
-export interface Presentation {
-    created_at:             string;
-    id:                     string;
-    kind:                   string;
-    latest_round_seq:       number;
-    latest_round_submitted: boolean;
-    repo_path:              string;
-    session_id:             string;
-    status:                 string;
-    ticket_id?:             string;
-    title:                  string;
+export interface PRsUpdatedMessage {
+    event: PRsUpdatedMessageEvent;
+    prs?:  PRElement[];
     [property: string]: any;
 }
 
-export interface PresentationAddedMessage {
-    event:        PresentationAddedMessageEvent;
-    presentation: PresentationElement;
+export enum PRsUpdatedMessageEvent {
+    PrsUpdated = "prs_updated",
+}
+
+export interface PRVisitedMessage {
+    cmd: PRVisitedMessageCmd;
+    id:  string;
     [property: string]: any;
 }
 
-export enum PresentationAddedMessageEvent {
-    PresentationAdded = "presentation_added",
-}
-
-export interface PresentationComment {
-    author:     string;
-    content:    string;
-    created_at: string;
-    filepath:   string;
-    id:         string;
-    line_end:   number;
-    line_start: number;
-    round_id:   string;
-    side:       string;
-    [property: string]: any;
-}
-
-export interface PresentationRound {
-    base_sha:        string;
-    changed_files?:  FileElement[];
-    created_at:      string;
-    head_sha:        string;
-    id:              string;
-    manifest:        Manifest;
-    presentation_id: string;
-    seq:             number;
-    submitted_at?:   string;
-    verdict?:        string;
-    [property: string]: any;
-}
-
-export interface PresentationUpdatedMessage {
-    event:        PresentationUpdatedMessageEvent;
-    presentation: PresentationElement;
-    [property: string]: any;
-}
-
-export enum PresentationUpdatedMessageEvent {
-    PresentationUpdated = "presentation_updated",
+export enum PRVisitedMessageCmd {
+    PRVisited = "pr_visited",
 }
 
 export interface PtyDesyncMessage {
@@ -3393,18 +3389,6 @@ export enum PtyOutputMessageEvent {
     PtyOutput = "pty_output",
 }
 
-export interface PtyResizeMessage {
-    cmd:  PtyResizeMessageCmd;
-    cols: number;
-    id:   string;
-    rows: number;
-    [property: string]: any;
-}
-
-export enum PtyResizeMessageCmd {
-    PtyResize = "pty_resize",
-}
-
 export interface PtyResizedMessage {
     cols:  number;
     event: PtyResizedMessageEvent;
@@ -3415,6 +3399,18 @@ export interface PtyResizedMessage {
 
 export enum PtyResizedMessageEvent {
     PtyResized = "pty_resized",
+}
+
+export interface PtyResizeMessage {
+    cmd:  PtyResizeMessageCmd;
+    cols: number;
+    id:   string;
+    rows: number;
+    [property: string]: any;
+}
+
+export enum PtyResizeMessageCmd {
+    PtyResize = "pty_resize",
 }
 
 export interface QueryAuthorsMessage {
@@ -3979,6 +3975,16 @@ export enum SessionStateChangedMessageEvent {
     SessionStateChanged = "session_state_changed",
 }
 
+export interface SessionsUpdatedMessage {
+    event:     SessionsUpdatedMessageEvent;
+    sessions?: SessionElement[];
+    [property: string]: any;
+}
+
+export enum SessionsUpdatedMessageEvent {
+    SessionsUpdated = "sessions_updated",
+}
+
 export interface SessionTodosUpdatedMessage {
     event:   SessionTodosUpdatedMessageEvent;
     session: SessionElement;
@@ -4038,16 +4044,6 @@ export interface SessionVisualizedMessage {
 
 export enum SessionVisualizedMessageCmd {
     SessionVisualized = "session_visualized",
-}
-
-export interface SessionsUpdatedMessage {
-    event:     SessionsUpdatedMessageEvent;
-    sessions?: SessionElement[];
-    [property: string]: any;
-}
-
-export enum SessionsUpdatedMessageEvent {
-    SessionsUpdated = "sessions_updated",
 }
 
 export interface SetChiefOfStaffMessage {
@@ -4138,18 +4134,6 @@ export enum DispatchWorkState {
     ReadyForReview = "ready_for_review",
 }
 
-export interface SetWorkspaceRankMessage {
-    cmd:                SetWorkspaceRankMessageCmd;
-    next_workspace_id?: string;
-    prev_workspace_id?: string;
-    workspace_id:       string;
-    [property: string]: any;
-}
-
-export enum SetWorkspaceRankMessageCmd {
-    SetWorkspaceRank = "set_workspace_rank",
-}
-
 export interface SettingsUpdatedMessage {
     changed_key?: string;
     error?:       string;
@@ -4161,6 +4145,18 @@ export interface SettingsUpdatedMessage {
 
 export enum SettingsUpdatedMessageEvent {
     SettingsUpdated = "settings_updated",
+}
+
+export interface SetWorkspaceRankMessage {
+    cmd:                SetWorkspaceRankMessageCmd;
+    next_workspace_id?: string;
+    prev_workspace_id?: string;
+    workspace_id:       string;
+    [property: string]: any;
+}
+
+export enum SetWorkspaceRankMessageCmd {
+    SetWorkspaceRank = "set_workspace_rank",
 }
 
 export interface SpawnResultMessage {
@@ -4390,7 +4386,7 @@ export interface TicketAttachMessage {
     cmd:                 TicketAttachMessageCmd;
     comment?:            string;
     expected_event_seq?: number;
-    files:               FileObject[];
+    files:               FileElement[];
     request_id?:         string;
     source_session_id:   string;
     state?:              DispatchWorkState;
@@ -4402,7 +4398,7 @@ export enum TicketAttachMessageCmd {
     TicketAttach = "ticket_attach",
 }
 
-export interface FileObject {
+export interface FileElement {
     filename:    string;
     source_path: string;
     [property: string]: any;
@@ -4634,6 +4630,16 @@ export interface TicketSubscribeResult {
     [property: string]: any;
 }
 
+export interface TicketsUpdatedMessage {
+    event:   TicketsUpdatedMessageEvent;
+    tickets: TicketElement[];
+    [property: string]: any;
+}
+
+export enum TicketsUpdatedMessageEvent {
+    TicketsUpdated = "tickets_updated",
+}
+
 export interface TicketTakeMessage {
     cmd:               TicketTakeMessageCmd;
     confirm?:          boolean;
@@ -4667,16 +4673,6 @@ export enum TicketUnsubscribeMessageCmd {
 export interface TicketUnsubscribeResult {
     ticket_id: string;
     [property: string]: any;
-}
-
-export interface TicketsUpdatedMessage {
-    event:   TicketsUpdatedMessageEvent;
-    tickets: TicketElement[];
-    [property: string]: any;
-}
-
-export enum TicketsUpdatedMessageEvent {
-    TicketsUpdated = "tickets_updated",
 }
 
 export interface TodosMessage {
@@ -4796,13 +4792,8 @@ export interface WebSocketEvent {
     running?:                  boolean;
     runtime_id?:               string;
     screen_cols?:              number;
-    screen_cursor_visible?:    boolean;
-    screen_cursor_x?:          number;
-    screen_cursor_y?:          number;
     screen_rows?:              number;
     screen_snapshot?:          string;
-    screen_snapshot_fresh?:    boolean;
-    scrollback?:               string;
     scrollback_truncated?:     boolean;
     seq?:                      number;
     session?:                  SessionElement;
@@ -5353,6 +5344,16 @@ export enum WorkspaceLayoutUndockTileMessageCmd {
     WorkspaceLayoutUndockTile = "workspace_layout_undock_tile",
 }
 
+export interface WorkspaceLayoutUpdatedMessage {
+    event:            WorkspaceLayoutUpdatedMessageEvent;
+    workspace_layout: Layout;
+    [property: string]: any;
+}
+
+export enum WorkspaceLayoutUpdatedMessageEvent {
+    WorkspaceLayoutUpdated = "workspace_layout_updated",
+}
+
 export interface WorkspaceLayoutUpdateTileMessage {
     cmd:              WorkspaceLayoutUpdateTileMessageCmd;
     request_id:       string;
@@ -5365,16 +5366,6 @@ export interface WorkspaceLayoutUpdateTileMessage {
 
 export enum WorkspaceLayoutUpdateTileMessageCmd {
     WorkspaceLayoutUpdateTile = "workspace_layout_update_tile",
-}
-
-export interface WorkspaceLayoutUpdatedMessage {
-    event:            WorkspaceLayoutUpdatedMessageEvent;
-    workspace_layout: Layout;
-    [property: string]: any;
-}
-
-export enum WorkspaceLayoutUpdatedMessageEvent {
-    WorkspaceLayoutUpdated = "workspace_layout_updated",
 }
 
 export interface WorkspaceRegisteredMessage {
@@ -5588,20 +5579,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AutomationDefinitionGetMessage")), null, 2);
     }
 
-    public static toAutomationDefinitionSummary(json: string): AutomationDefinitionSummary {
-        return cast(JSON.parse(json), r("AutomationDefinitionSummary"));
-    }
-
-    public static automationDefinitionSummaryToJson(value: AutomationDefinitionSummary): string {
-        return JSON.stringify(uncast(value, r("AutomationDefinitionSummary")), null, 2);
-    }
-
     public static toAutomationDefinitionsGetMessage(json: string): AutomationDefinitionsGetMessage {
         return cast(JSON.parse(json), r("AutomationDefinitionsGetMessage"));
     }
 
     public static automationDefinitionsGetMessageToJson(value: AutomationDefinitionsGetMessage): string {
         return JSON.stringify(uncast(value, r("AutomationDefinitionsGetMessage")), null, 2);
+    }
+
+    public static toAutomationDefinitionSummary(json: string): AutomationDefinitionSummary {
+        return cast(JSON.parse(json), r("AutomationDefinitionSummary"));
+    }
+
+    public static automationDefinitionSummaryToJson(value: AutomationDefinitionSummary): string {
+        return JSON.stringify(uncast(value, r("AutomationDefinitionSummary")), null, 2);
     }
 
     public static toAutomationDeleteMessage(json: string): AutomationDeleteMessage {
@@ -5636,6 +5627,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AutomationRunMessage")), null, 2);
     }
 
+    public static toAutomationRunsGetMessage(json: string): AutomationRunsGetMessage {
+        return cast(JSON.parse(json), r("AutomationRunsGetMessage"));
+    }
+
+    public static automationRunsGetMessageToJson(value: AutomationRunsGetMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationRunsGetMessage")), null, 2);
+    }
+
     public static toAutomationRunSummary(json: string): AutomationRunSummary {
         return cast(JSON.parse(json), r("AutomationRunSummary"));
     }
@@ -5644,12 +5643,12 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AutomationRunSummary")), null, 2);
     }
 
-    public static toAutomationRunsGetMessage(json: string): AutomationRunsGetMessage {
-        return cast(JSON.parse(json), r("AutomationRunsGetMessage"));
+    public static toAutomationsChangedMessage(json: string): AutomationsChangedMessage {
+        return cast(JSON.parse(json), r("AutomationsChangedMessage"));
     }
 
-    public static automationRunsGetMessageToJson(value: AutomationRunsGetMessage): string {
-        return JSON.stringify(uncast(value, r("AutomationRunsGetMessage")), null, 2);
+    public static automationsChangedMessageToJson(value: AutomationsChangedMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationsChangedMessage")), null, 2);
     }
 
     public static toAutomationSetEnabledMessage(json: string): AutomationSetEnabledMessage {
@@ -5674,14 +5673,6 @@ export class Convert {
 
     public static automationValidateMessageToJson(value: AutomationValidateMessage): string {
         return JSON.stringify(uncast(value, r("AutomationValidateMessage")), null, 2);
-    }
-
-    public static toAutomationsChangedMessage(json: string): AutomationsChangedMessage {
-        return cast(JSON.parse(json), r("AutomationsChangedMessage"));
-    }
-
-    public static automationsChangedMessageToJson(value: AutomationsChangedMessage): string {
-        return JSON.stringify(uncast(value, r("AutomationsChangedMessage")), null, 2);
     }
 
     public static toBootstrapEndpointMessage(json: string): BootstrapEndpointMessage {
@@ -6924,46 +6915,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("OpenMarkdownResultMessage")), null, 2);
     }
 
-    public static toPR(json: string): PR {
-        return cast(JSON.parse(json), r("PR"));
-    }
-
-    public static pRToJson(value: PR): string {
-        return JSON.stringify(uncast(value, r("PR")), null, 2);
-    }
-
-    public static toPRActionResultMessage(json: string): PRActionResultMessage {
-        return cast(JSON.parse(json), r("PRActionResultMessage"));
-    }
-
-    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
-        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
-    }
-
-    public static toPRRole(json: string): PRRole {
-        return cast(JSON.parse(json), r("PRRole"));
-    }
-
-    public static pRRoleToJson(value: PRRole): string {
-        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
-    }
-
-    public static toPRVisitedMessage(json: string): PRVisitedMessage {
-        return cast(JSON.parse(json), r("PRVisitedMessage"));
-    }
-
-    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
-        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
-    }
-
-    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
-        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
-    }
-
-    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
-    }
-
     public static toPathInspection(json: string): PathInspection {
         return cast(JSON.parse(json), r("PathInspection"));
     }
@@ -7012,12 +6963,68 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PluginsUpdatedMessage")), null, 2);
     }
 
+    public static toPR(json: string): PR {
+        return cast(JSON.parse(json), r("PR"));
+    }
+
+    public static pRToJson(value: PR): string {
+        return JSON.stringify(uncast(value, r("PR")), null, 2);
+    }
+
+    public static toPRActionResultMessage(json: string): PRActionResultMessage {
+        return cast(JSON.parse(json), r("PRActionResultMessage"));
+    }
+
+    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
+        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
+    }
+
     public static toPresentAnnotation(json: string): PresentAnnotation {
         return cast(JSON.parse(json), r("PresentAnnotation"));
     }
 
     public static presentAnnotationToJson(value: PresentAnnotation): string {
         return JSON.stringify(uncast(value, r("PresentAnnotation")), null, 2);
+    }
+
+    public static toPresentation(json: string): Presentation {
+        return cast(JSON.parse(json), r("Presentation"));
+    }
+
+    public static presentationToJson(value: Presentation): string {
+        return JSON.stringify(uncast(value, r("Presentation")), null, 2);
+    }
+
+    public static toPresentationAddedMessage(json: string): PresentationAddedMessage {
+        return cast(JSON.parse(json), r("PresentationAddedMessage"));
+    }
+
+    public static presentationAddedMessageToJson(value: PresentationAddedMessage): string {
+        return JSON.stringify(uncast(value, r("PresentationAddedMessage")), null, 2);
+    }
+
+    public static toPresentationComment(json: string): PresentationComment {
+        return cast(JSON.parse(json), r("PresentationComment"));
+    }
+
+    public static presentationCommentToJson(value: PresentationComment): string {
+        return JSON.stringify(uncast(value, r("PresentationComment")), null, 2);
+    }
+
+    public static toPresentationRound(json: string): PresentationRound {
+        return cast(JSON.parse(json), r("PresentationRound"));
+    }
+
+    public static presentationRoundToJson(value: PresentationRound): string {
+        return JSON.stringify(uncast(value, r("PresentationRound")), null, 2);
+    }
+
+    public static toPresentationUpdatedMessage(json: string): PresentationUpdatedMessage {
+        return cast(JSON.parse(json), r("PresentationUpdatedMessage"));
+    }
+
+    public static presentationUpdatedMessageToJson(value: PresentationUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("PresentationUpdatedMessage")), null, 2);
     }
 
     public static toPresentCloseMessage(json: string): PresentCloseMessage {
@@ -7108,44 +7115,28 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PresentSubmitRoundResultMessage")), null, 2);
     }
 
-    public static toPresentation(json: string): Presentation {
-        return cast(JSON.parse(json), r("Presentation"));
+    public static toPRRole(json: string): PRRole {
+        return cast(JSON.parse(json), r("PRRole"));
     }
 
-    public static presentationToJson(value: Presentation): string {
-        return JSON.stringify(uncast(value, r("Presentation")), null, 2);
+    public static pRRoleToJson(value: PRRole): string {
+        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
     }
 
-    public static toPresentationAddedMessage(json: string): PresentationAddedMessage {
-        return cast(JSON.parse(json), r("PresentationAddedMessage"));
+    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
+        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
     }
 
-    public static presentationAddedMessageToJson(value: PresentationAddedMessage): string {
-        return JSON.stringify(uncast(value, r("PresentationAddedMessage")), null, 2);
+    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
     }
 
-    public static toPresentationComment(json: string): PresentationComment {
-        return cast(JSON.parse(json), r("PresentationComment"));
+    public static toPRVisitedMessage(json: string): PRVisitedMessage {
+        return cast(JSON.parse(json), r("PRVisitedMessage"));
     }
 
-    public static presentationCommentToJson(value: PresentationComment): string {
-        return JSON.stringify(uncast(value, r("PresentationComment")), null, 2);
-    }
-
-    public static toPresentationRound(json: string): PresentationRound {
-        return cast(JSON.parse(json), r("PresentationRound"));
-    }
-
-    public static presentationRoundToJson(value: PresentationRound): string {
-        return JSON.stringify(uncast(value, r("PresentationRound")), null, 2);
-    }
-
-    public static toPresentationUpdatedMessage(json: string): PresentationUpdatedMessage {
-        return cast(JSON.parse(json), r("PresentationUpdatedMessage"));
-    }
-
-    public static presentationUpdatedMessageToJson(value: PresentationUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("PresentationUpdatedMessage")), null, 2);
+    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
+        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
     }
 
     public static toPtyDesyncMessage(json: string): PtyDesyncMessage {
@@ -7172,20 +7163,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PtyOutputMessage")), null, 2);
     }
 
-    public static toPtyResizeMessage(json: string): PtyResizeMessage {
-        return cast(JSON.parse(json), r("PtyResizeMessage"));
-    }
-
-    public static ptyResizeMessageToJson(value: PtyResizeMessage): string {
-        return JSON.stringify(uncast(value, r("PtyResizeMessage")), null, 2);
-    }
-
     public static toPtyResizedMessage(json: string): PtyResizedMessage {
         return cast(JSON.parse(json), r("PtyResizedMessage"));
     }
 
     public static ptyResizedMessageToJson(value: PtyResizedMessage): string {
         return JSON.stringify(uncast(value, r("PtyResizedMessage")), null, 2);
+    }
+
+    public static toPtyResizeMessage(json: string): PtyResizeMessage {
+        return cast(JSON.parse(json), r("PtyResizeMessage"));
+    }
+
+    public static ptyResizeMessageToJson(value: PtyResizeMessage): string {
+        return JSON.stringify(uncast(value, r("PtyResizeMessage")), null, 2);
     }
 
     public static toQueryAuthorsMessage(json: string): QueryAuthorsMessage {
@@ -7428,6 +7419,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SessionStateChangedMessage")), null, 2);
     }
 
+    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
+        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
+    }
+
+    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
+    }
+
     public static toSessionTodosUpdatedMessage(json: string): SessionTodosUpdatedMessage {
         return cast(JSON.parse(json), r("SessionTodosUpdatedMessage"));
     }
@@ -7474,14 +7473,6 @@ export class Convert {
 
     public static sessionVisualizedMessageToJson(value: SessionVisualizedMessage): string {
         return JSON.stringify(uncast(value, r("SessionVisualizedMessage")), null, 2);
-    }
-
-    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
-        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
-    }
-
-    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
     }
 
     public static toSetChiefOfStaffMessage(json: string): SetChiefOfStaffMessage {
@@ -7540,20 +7531,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SetTicketStatusMessage")), null, 2);
     }
 
-    public static toSetWorkspaceRankMessage(json: string): SetWorkspaceRankMessage {
-        return cast(JSON.parse(json), r("SetWorkspaceRankMessage"));
-    }
-
-    public static setWorkspaceRankMessageToJson(value: SetWorkspaceRankMessage): string {
-        return JSON.stringify(uncast(value, r("SetWorkspaceRankMessage")), null, 2);
-    }
-
     public static toSettingsUpdatedMessage(json: string): SettingsUpdatedMessage {
         return cast(JSON.parse(json), r("SettingsUpdatedMessage"));
     }
 
     public static settingsUpdatedMessageToJson(value: SettingsUpdatedMessage): string {
         return JSON.stringify(uncast(value, r("SettingsUpdatedMessage")), null, 2);
+    }
+
+    public static toSetWorkspaceRankMessage(json: string): SetWorkspaceRankMessage {
+        return cast(JSON.parse(json), r("SetWorkspaceRankMessage"));
+    }
+
+    public static setWorkspaceRankMessageToJson(value: SetWorkspaceRankMessage): string {
+        return JSON.stringify(uncast(value, r("SetWorkspaceRankMessage")), null, 2);
     }
 
     public static toSpawnResultMessage(json: string): SpawnResultMessage {
@@ -7908,6 +7899,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("TicketSubscribeResult")), null, 2);
     }
 
+    public static toTicketsUpdatedMessage(json: string): TicketsUpdatedMessage {
+        return cast(JSON.parse(json), r("TicketsUpdatedMessage"));
+    }
+
+    public static ticketsUpdatedMessageToJson(value: TicketsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("TicketsUpdatedMessage")), null, 2);
+    }
+
     public static toTicketTakeMessage(json: string): TicketTakeMessage {
         return cast(JSON.parse(json), r("TicketTakeMessage"));
     }
@@ -7938,14 +7937,6 @@ export class Convert {
 
     public static ticketUnsubscribeResultToJson(value: TicketUnsubscribeResult): string {
         return JSON.stringify(uncast(value, r("TicketUnsubscribeResult")), null, 2);
-    }
-
-    public static toTicketsUpdatedMessage(json: string): TicketsUpdatedMessage {
-        return cast(JSON.parse(json), r("TicketsUpdatedMessage"));
-    }
-
-    public static ticketsUpdatedMessageToJson(value: TicketsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("TicketsUpdatedMessage")), null, 2);
     }
 
     public static toTodosMessage(json: string): TodosMessage {
@@ -8364,20 +8355,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUndockTileMessage")), null, 2);
     }
 
-    public static toWorkspaceLayoutUpdateTileMessage(json: string): WorkspaceLayoutUpdateTileMessage {
-        return cast(JSON.parse(json), r("WorkspaceLayoutUpdateTileMessage"));
-    }
-
-    public static workspaceLayoutUpdateTileMessageToJson(value: WorkspaceLayoutUpdateTileMessage): string {
-        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdateTileMessage")), null, 2);
-    }
-
     public static toWorkspaceLayoutUpdatedMessage(json: string): WorkspaceLayoutUpdatedMessage {
         return cast(JSON.parse(json), r("WorkspaceLayoutUpdatedMessage"));
     }
 
     public static workspaceLayoutUpdatedMessageToJson(value: WorkspaceLayoutUpdatedMessage): string {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdatedMessage")), null, 2);
+    }
+
+    public static toWorkspaceLayoutUpdateTileMessage(json: string): WorkspaceLayoutUpdateTileMessage {
+        return cast(JSON.parse(json), r("WorkspaceLayoutUpdateTileMessage"));
+    }
+
+    public static workspaceLayoutUpdateTileMessageToJson(value: WorkspaceLayoutUpdateTileMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdateTileMessage")), null, 2);
     }
 
     public static toWorkspaceRegisteredMessage(json: string): WorkspaceRegisteredMessage {
@@ -8759,6 +8750,10 @@ const typeMap: any = {
         { json: "definition_id", js: "definition_id", typ: "" },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
     ], "any"),
+    "AutomationDefinitionsGetMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutomationDefinitionsGetMessageCmd") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    ], "any"),
     "AutomationDefinitionSummary": o([
         { json: "catch_up", js: "catch_up", typ: u(undefined, "") },
         { json: "continuity", js: "continuity", typ: u(undefined, "") },
@@ -8770,10 +8765,6 @@ const typeMap: any = {
         { json: "schedule_time_zone", js: "schedule_time_zone", typ: u(undefined, "") },
         { json: "trigger_type", js: "trigger_type", typ: "" },
         { json: "updated_at", js: "updated_at", typ: "" },
-    ], "any"),
-    "AutomationDefinitionsGetMessage": o([
-        { json: "cmd", js: "cmd", typ: r("AutomationDefinitionsGetMessageCmd") },
-        { json: "request_id", js: "request_id", typ: u(undefined, "") },
     ], "any"),
     "AutomationDeleteMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationDeleteMessageCmd") },
@@ -8794,6 +8785,11 @@ const typeMap: any = {
         { json: "pr_url", js: "pr_url", typ: u(undefined, "") },
         { json: "request_id", js: "request_id", typ: "" },
     ], "any"),
+    "AutomationRunsGetMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutomationRunsGetMessageCmd") },
+        { json: "definition_id", js: "definition_id", typ: "" },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    ], "any"),
     "AutomationRunSummary": o([
         { json: "created_at", js: "created_at", typ: "" },
         { json: "definition_id", js: "definition_id", typ: "" },
@@ -8809,10 +8805,9 @@ const typeMap: any = {
         { json: "updated_at", js: "updated_at", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
     ], "any"),
-    "AutomationRunsGetMessage": o([
-        { json: "cmd", js: "cmd", typ: r("AutomationRunsGetMessageCmd") },
-        { json: "definition_id", js: "definition_id", typ: "" },
-        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    "AutomationsChangedMessage": o([
+        { json: "definition_ids", js: "definition_ids", typ: a("") },
+        { json: "event", js: "event", typ: r("AutomationsChangedMessageEvent") },
     ], "any"),
     "AutomationSetEnabledMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationSetEnabledMessageCmd") },
@@ -8828,10 +8823,6 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("AutomationValidateMessageCmd") },
         { json: "definition_yaml", js: "definition_yaml", typ: "" },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
-    ], "any"),
-    "AutomationsChangedMessage": o([
-        { json: "definition_ids", js: "definition_ids", typ: a("") },
-        { json: "event", js: "event", typ: r("AutomationsChangedMessageEvent") },
     ], "any"),
     "BootstrapEndpointMessage": o([
         { json: "cmd", js: "cmd", typ: r("BootstrapEndpointMessageCmd") },
@@ -9507,7 +9498,7 @@ const typeMap: any = {
     ], "any"),
     "Round": o([
         { json: "base_sha", js: "base_sha", typ: "" },
-        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("FileElement"))) },
+        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("ChangedFileElement"))) },
         { json: "created_at", js: "created_at", typ: "" },
         { json: "head_sha", js: "head_sha", typ: "" },
         { json: "id", js: "id", typ: "" },
@@ -9517,7 +9508,7 @@ const typeMap: any = {
         { json: "submitted_at", js: "submitted_at", typ: u(undefined, "") },
         { json: "verdict", js: "verdict", typ: u(undefined, "") },
     ], "any"),
-    "FileElement": o([
+    "ChangedFileElement": o([
         { json: "additions", js: "additions", typ: u(undefined, 0) },
         { json: "annotations", js: "annotations", typ: u(undefined, a(r("AnnotationElement"))) },
         { json: "deletions", js: "deletions", typ: u(undefined, 0) },
@@ -9530,7 +9521,7 @@ const typeMap: any = {
         { json: "line_start", js: "line_start", typ: 0 },
     ], "any"),
     "Manifest": o([
-        { json: "files", js: "files", typ: a(r("FileElement")) },
+        { json: "files", js: "files", typ: a(r("ChangedFileElement")) },
         { json: "skip", js: "skip", typ: a("") },
         { json: "summary", js: "summary", typ: u(undefined, "") },
         { json: "title", js: "title", typ: "" },
@@ -9591,12 +9582,8 @@ const typeMap: any = {
         { json: "rows", js: "rows", typ: u(undefined, 0) },
         { json: "running", js: "running", typ: u(undefined, true) },
         { json: "screen_cols", js: "screen_cols", typ: u(undefined, 0) },
-        { json: "screen_cursor_visible", js: "screen_cursor_visible", typ: u(undefined, true) },
-        { json: "screen_cursor_x", js: "screen_cursor_x", typ: u(undefined, 0) },
-        { json: "screen_cursor_y", js: "screen_cursor_y", typ: u(undefined, 0) },
         { json: "screen_rows", js: "screen_rows", typ: u(undefined, 0) },
         { json: "screen_snapshot", js: "screen_snapshot", typ: u(undefined, "") },
-        { json: "screen_snapshot_fresh", js: "screen_snapshot_fresh", typ: u(undefined, true) },
         { json: "success", js: "success", typ: true },
     ], "any"),
     "GetSettingsMessage": o([
@@ -10158,49 +10145,6 @@ const typeMap: any = {
         { json: "tile_id", js: "tile_id", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
     ], "any"),
-    "PR": o([
-        { json: "approved_by_me", js: "approved_by_me", typ: true },
-        { json: "author", js: "author", typ: "" },
-        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
-        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
-        { json: "details_fetched", js: "details_fetched", typ: true },
-        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
-        { json: "has_new_changes", js: "has_new_changes", typ: true },
-        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
-        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
-        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
-        { json: "host", js: "host", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
-        { json: "last_polled", js: "last_polled", typ: "" },
-        { json: "last_updated", js: "last_updated", typ: "" },
-        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
-        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
-        { json: "muted", js: "muted", typ: true },
-        { json: "number", js: "number", typ: 0 },
-        { json: "reason", js: "reason", typ: "" },
-        { json: "repo", js: "repo", typ: "" },
-        { json: "review_status", js: "review_status", typ: u(undefined, "") },
-        { json: "role", js: "role", typ: r("PRRole") },
-        { json: "state", js: "state", typ: "" },
-        { json: "title", js: "title", typ: "" },
-        { json: "url", js: "url", typ: "" },
-    ], "any"),
-    "PRActionResultMessage": o([
-        { json: "action", js: "action", typ: "" },
-        { json: "error", js: "error", typ: u(undefined, "") },
-        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
-        { json: "id", js: "id", typ: "" },
-        { json: "success", js: "success", typ: true },
-    ], "any"),
-    "PRVisitedMessage": o([
-        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
-        { json: "id", js: "id", typ: "" },
-    ], "any"),
-    "PRsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
-        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
-    ], "any"),
     "PathInspection": o([
         { json: "exists", js: "exists", typ: true },
         { json: "home_path", js: "home_path", typ: u(undefined, "") },
@@ -10276,10 +10220,88 @@ const typeMap: any = {
         { json: "runtime_state", js: "runtime_state", typ: "" },
         { json: "version", js: "version", typ: "" },
     ], "any"),
+    "PR": o([
+        { json: "approved_by_me", js: "approved_by_me", typ: true },
+        { json: "author", js: "author", typ: "" },
+        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
+        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
+        { json: "details_fetched", js: "details_fetched", typ: true },
+        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
+        { json: "has_new_changes", js: "has_new_changes", typ: true },
+        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
+        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
+        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
+        { json: "host", js: "host", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
+        { json: "last_polled", js: "last_polled", typ: "" },
+        { json: "last_updated", js: "last_updated", typ: "" },
+        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
+        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
+        { json: "muted", js: "muted", typ: true },
+        { json: "number", js: "number", typ: 0 },
+        { json: "reason", js: "reason", typ: "" },
+        { json: "repo", js: "repo", typ: "" },
+        { json: "review_status", js: "review_status", typ: u(undefined, "") },
+        { json: "role", js: "role", typ: r("PRRole") },
+        { json: "state", js: "state", typ: "" },
+        { json: "title", js: "title", typ: "" },
+        { json: "url", js: "url", typ: "" },
+    ], "any"),
+    "PRActionResultMessage": o([
+        { json: "action", js: "action", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
+        { json: "id", js: "id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
     "PresentAnnotation": o([
         { json: "comments", js: "comments", typ: a("") },
         { json: "line_end", js: "line_end", typ: 0 },
         { json: "line_start", js: "line_start", typ: 0 },
+    ], "any"),
+    "Presentation": o([
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "kind", js: "kind", typ: "" },
+        { json: "latest_round_seq", js: "latest_round_seq", typ: 0 },
+        { json: "latest_round_submitted", js: "latest_round_submitted", typ: true },
+        { json: "repo_path", js: "repo_path", typ: "" },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "status", js: "status", typ: "" },
+        { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
+        { json: "title", js: "title", typ: "" },
+    ], "any"),
+    "PresentationAddedMessage": o([
+        { json: "event", js: "event", typ: r("PresentationAddedMessageEvent") },
+        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
+    ], "any"),
+    "PresentationComment": o([
+        { json: "author", js: "author", typ: "" },
+        { json: "content", js: "content", typ: "" },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "filepath", js: "filepath", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "line_end", js: "line_end", typ: 0 },
+        { json: "line_start", js: "line_start", typ: 0 },
+        { json: "round_id", js: "round_id", typ: "" },
+        { json: "side", js: "side", typ: "" },
+    ], "any"),
+    "PresentationRound": o([
+        { json: "base_sha", js: "base_sha", typ: "" },
+        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("ChangedFileElement"))) },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "head_sha", js: "head_sha", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "manifest", js: "manifest", typ: r("Manifest") },
+        { json: "presentation_id", js: "presentation_id", typ: "" },
+        { json: "seq", js: "seq", typ: 0 },
+        { json: "submitted_at", js: "submitted_at", typ: u(undefined, "") },
+        { json: "verdict", js: "verdict", typ: u(undefined, "") },
+    ], "any"),
+    "PresentationUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("PresentationUpdatedMessageEvent") },
+        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
     ], "any"),
     "PresentCloseMessage": o([
         { json: "cmd", js: "cmd", typ: r("PresentCloseMessageCmd") },
@@ -10318,7 +10340,7 @@ const typeMap: any = {
         { json: "path", js: "path", typ: "" },
     ], "any"),
     "PresentManifestView": o([
-        { json: "files", js: "files", typ: a(r("FileElement")) },
+        { json: "files", js: "files", typ: a(r("ChangedFileElement")) },
         { json: "skip", js: "skip", typ: a("") },
         { json: "summary", js: "summary", typ: u(undefined, "") },
         { json: "title", js: "title", typ: "" },
@@ -10359,48 +10381,13 @@ const typeMap: any = {
         { json: "round_id", js: "round_id", typ: "" },
         { json: "success", js: "success", typ: true },
     ], "any"),
-    "Presentation": o([
-        { json: "created_at", js: "created_at", typ: "" },
+    "PRsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
+        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
+    ], "any"),
+    "PRVisitedMessage": o([
+        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
         { json: "id", js: "id", typ: "" },
-        { json: "kind", js: "kind", typ: "" },
-        { json: "latest_round_seq", js: "latest_round_seq", typ: 0 },
-        { json: "latest_round_submitted", js: "latest_round_submitted", typ: true },
-        { json: "repo_path", js: "repo_path", typ: "" },
-        { json: "session_id", js: "session_id", typ: "" },
-        { json: "status", js: "status", typ: "" },
-        { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
-        { json: "title", js: "title", typ: "" },
-    ], "any"),
-    "PresentationAddedMessage": o([
-        { json: "event", js: "event", typ: r("PresentationAddedMessageEvent") },
-        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
-    ], "any"),
-    "PresentationComment": o([
-        { json: "author", js: "author", typ: "" },
-        { json: "content", js: "content", typ: "" },
-        { json: "created_at", js: "created_at", typ: "" },
-        { json: "filepath", js: "filepath", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "line_end", js: "line_end", typ: 0 },
-        { json: "line_start", js: "line_start", typ: 0 },
-        { json: "round_id", js: "round_id", typ: "" },
-        { json: "side", js: "side", typ: "" },
-    ], "any"),
-    "PresentationRound": o([
-        { json: "base_sha", js: "base_sha", typ: "" },
-        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("FileElement"))) },
-        { json: "created_at", js: "created_at", typ: "" },
-        { json: "head_sha", js: "head_sha", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "manifest", js: "manifest", typ: r("Manifest") },
-        { json: "presentation_id", js: "presentation_id", typ: "" },
-        { json: "seq", js: "seq", typ: 0 },
-        { json: "submitted_at", js: "submitted_at", typ: u(undefined, "") },
-        { json: "verdict", js: "verdict", typ: u(undefined, "") },
-    ], "any"),
-    "PresentationUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("PresentationUpdatedMessageEvent") },
-        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
     ], "any"),
     "PtyDesyncMessage": o([
         { json: "event", js: "event", typ: r("PtyDesyncMessageEvent") },
@@ -10419,15 +10406,15 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "seq", js: "seq", typ: 0 },
     ], "any"),
-    "PtyResizeMessage": o([
-        { json: "cmd", js: "cmd", typ: r("PtyResizeMessageCmd") },
-        { json: "cols", js: "cols", typ: 0 },
-        { json: "id", js: "id", typ: "" },
-        { json: "rows", js: "rows", typ: 0 },
-    ], "any"),
     "PtyResizedMessage": o([
         { json: "cols", js: "cols", typ: 0 },
         { json: "event", js: "event", typ: r("PtyResizedMessageEvent") },
+        { json: "id", js: "id", typ: "" },
+        { json: "rows", js: "rows", typ: 0 },
+    ], "any"),
+    "PtyResizeMessage": o([
+        { json: "cmd", js: "cmd", typ: r("PtyResizeMessageCmd") },
+        { json: "cols", js: "cols", typ: 0 },
         { json: "id", js: "id", typ: "" },
         { json: "rows", js: "rows", typ: 0 },
     ], "any"),
@@ -10785,6 +10772,10 @@ const typeMap: any = {
         { json: "event", js: "event", typ: r("SessionStateChangedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionElement") },
     ], "any"),
+    "SessionsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
+        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
+    ], "any"),
     "SessionTodosUpdatedMessage": o([
         { json: "event", js: "event", typ: r("SessionTodosUpdatedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionElement") },
@@ -10817,10 +10808,6 @@ const typeMap: any = {
     "SessionVisualizedMessage": o([
         { json: "cmd", js: "cmd", typ: r("SessionVisualizedMessageCmd") },
         { json: "id", js: "id", typ: "" },
-    ], "any"),
-    "SessionsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
-        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
     ], "any"),
     "SetChiefOfStaffMessage": o([
         { json: "chief_of_staff", js: "chief_of_staff", typ: true },
@@ -10860,18 +10847,18 @@ const typeMap: any = {
         { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
         { json: "work_state", js: "work_state", typ: r("DispatchWorkState") },
     ], "any"),
-    "SetWorkspaceRankMessage": o([
-        { json: "cmd", js: "cmd", typ: r("SetWorkspaceRankMessageCmd") },
-        { json: "next_workspace_id", js: "next_workspace_id", typ: u(undefined, "") },
-        { json: "prev_workspace_id", js: "prev_workspace_id", typ: u(undefined, "") },
-        { json: "workspace_id", js: "workspace_id", typ: "" },
-    ], "any"),
     "SettingsUpdatedMessage": o([
         { json: "changed_key", js: "changed_key", typ: u(undefined, "") },
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("SettingsUpdatedMessageEvent") },
         { json: "settings", js: "settings", typ: u(undefined, m("")) },
         { json: "success", js: "success", typ: u(undefined, true) },
+    ], "any"),
+    "SetWorkspaceRankMessage": o([
+        { json: "cmd", js: "cmd", typ: r("SetWorkspaceRankMessageCmd") },
+        { json: "next_workspace_id", js: "next_workspace_id", typ: u(undefined, "") },
+        { json: "prev_workspace_id", js: "prev_workspace_id", typ: u(undefined, "") },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "SpawnResultMessage": o([
         { json: "error", js: "error", typ: u(undefined, "") },
@@ -11016,13 +11003,13 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("TicketAttachMessageCmd") },
         { json: "comment", js: "comment", typ: u(undefined, "") },
         { json: "expected_event_seq", js: "expected_event_seq", typ: u(undefined, 0) },
-        { json: "files", js: "files", typ: a(r("FileObject")) },
+        { json: "files", js: "files", typ: a(r("FileElement")) },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
         { json: "source_session_id", js: "source_session_id", typ: "" },
         { json: "state", js: "state", typ: u(undefined, r("DispatchWorkState")) },
         { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
     ], "any"),
-    "FileObject": o([
+    "FileElement": o([
         { json: "filename", js: "filename", typ: "" },
         { json: "source_path", js: "source_path", typ: "" },
     ], "any"),
@@ -11155,6 +11142,10 @@ const typeMap: any = {
         { json: "ticket_id", js: "ticket_id", typ: "" },
         { json: "unread_count", js: "unread_count", typ: u(undefined, 0) },
     ], "any"),
+    "TicketsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("TicketsUpdatedMessageEvent") },
+        { json: "tickets", js: "tickets", typ: a(r("TicketElement")) },
+    ], "any"),
     "TicketTakeMessage": o([
         { json: "cmd", js: "cmd", typ: r("TicketTakeMessageCmd") },
         { json: "confirm", js: "confirm", typ: u(undefined, true) },
@@ -11173,10 +11164,6 @@ const typeMap: any = {
     ], "any"),
     "TicketUnsubscribeResult": o([
         { json: "ticket_id", js: "ticket_id", typ: "" },
-    ], "any"),
-    "TicketsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("TicketsUpdatedMessageEvent") },
-        { json: "tickets", js: "tickets", typ: a(r("TicketElement")) },
     ], "any"),
     "TodosMessage": o([
         { json: "cmd", js: "cmd", typ: r("TodosMessageCmd") },
@@ -11253,13 +11240,8 @@ const typeMap: any = {
         { json: "running", js: "running", typ: u(undefined, true) },
         { json: "runtime_id", js: "runtime_id", typ: u(undefined, "") },
         { json: "screen_cols", js: "screen_cols", typ: u(undefined, 0) },
-        { json: "screen_cursor_visible", js: "screen_cursor_visible", typ: u(undefined, true) },
-        { json: "screen_cursor_x", js: "screen_cursor_x", typ: u(undefined, 0) },
-        { json: "screen_cursor_y", js: "screen_cursor_y", typ: u(undefined, 0) },
         { json: "screen_rows", js: "screen_rows", typ: u(undefined, 0) },
         { json: "screen_snapshot", js: "screen_snapshot", typ: u(undefined, "") },
-        { json: "screen_snapshot_fresh", js: "screen_snapshot_fresh", typ: u(undefined, true) },
-        { json: "scrollback", js: "scrollback", typ: u(undefined, "") },
         { json: "scrollback_truncated", js: "scrollback_truncated", typ: u(undefined, true) },
         { json: "seq", js: "seq", typ: u(undefined, 0) },
         { json: "session", js: "session", typ: u(undefined, r("SessionElement")) },
@@ -11588,6 +11570,10 @@ const typeMap: any = {
         { json: "tile_id", js: "tile_id", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
+    "WorkspaceLayoutUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("WorkspaceLayoutUpdatedMessageEvent") },
+        { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
+    ], "any"),
     "WorkspaceLayoutUpdateTileMessage": o([
         { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutUpdateTileMessageCmd") },
         { json: "request_id", js: "request_id", typ: "" },
@@ -11595,10 +11581,6 @@ const typeMap: any = {
         { json: "tile_params", js: "tile_params", typ: "" },
         { json: "tile_session_id", js: "tile_session_id", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: "" },
-    ], "any"),
-    "WorkspaceLayoutUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("WorkspaceLayoutUpdatedMessageEvent") },
-        { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
     ], "any"),
     "WorkspaceRegisteredMessage": o([
         { json: "event", js: "event", typ: r("WorkspaceRegisteredMessageEvent") },
@@ -11698,6 +11680,9 @@ const typeMap: any = {
     "AutomationRunsGetMessageCmd": [
         "automation_runs_get",
     ],
+    "AutomationsChangedMessageEvent": [
+        "automations_changed",
+    ],
     "AutomationSetEnabledMessageCmd": [
         "automation_set_enabled",
     ],
@@ -11706,9 +11691,6 @@ const typeMap: any = {
     ],
     "AutomationValidateMessageCmd": [
         "automation_validate",
-    ],
-    "AutomationsChangedMessageEvent": [
-        "automations_changed",
     ],
     "BootstrapEndpointMessageCmd": [
         "bootstrap_endpoint",
@@ -12136,15 +12118,6 @@ const typeMap: any = {
     "OpenMarkdownResultMessageEvent": [
         "open_markdown_result",
     ],
-    "PRActionResultMessageEvent": [
-        "pr_action_result",
-    ],
-    "PRVisitedMessageCmd": [
-        "pr_visited",
-    ],
-    "PRsUpdatedMessageEvent": [
-        "prs_updated",
-    ],
     "PinWorkspaceMessageCmd": [
         "pin_workspace",
     ],
@@ -12153,6 +12126,15 @@ const typeMap: any = {
     ],
     "PluginsUpdatedMessageEvent": [
         "plugins_updated",
+    ],
+    "PRActionResultMessageEvent": [
+        "pr_action_result",
+    ],
+    "PresentationAddedMessageEvent": [
+        "presentation_added",
+    ],
+    "PresentationUpdatedMessageEvent": [
+        "presentation_updated",
     ],
     "PresentCloseMessageCmd": [
         "present_close",
@@ -12172,11 +12154,11 @@ const typeMap: any = {
     "PresentSubmitRoundResultMessageEvent": [
         "present_submit_round_result",
     ],
-    "PresentationAddedMessageEvent": [
-        "presentation_added",
+    "PRsUpdatedMessageEvent": [
+        "prs_updated",
     ],
-    "PresentationUpdatedMessageEvent": [
-        "presentation_updated",
+    "PRVisitedMessageCmd": [
+        "pr_visited",
     ],
     "PtyDesyncMessageEvent": [
         "pty_desync",
@@ -12187,11 +12169,11 @@ const typeMap: any = {
     "PtyOutputMessageEvent": [
         "pty_output",
     ],
-    "PtyResizeMessageCmd": [
-        "pty_resize",
-    ],
     "PtyResizedMessageEvent": [
         "pty_resized",
+    ],
+    "PtyResizeMessageCmd": [
+        "pty_resize",
     ],
     "QueryAuthorsMessageCmd": [
         "query_authors",
@@ -12271,6 +12253,9 @@ const typeMap: any = {
     "SessionStateChangedMessageEvent": [
         "session_state_changed",
     ],
+    "SessionsUpdatedMessageEvent": [
+        "sessions_updated",
+    ],
     "SessionTodosUpdatedMessageEvent": [
         "session_todos_updated",
     ],
@@ -12282,9 +12267,6 @@ const typeMap: any = {
     ],
     "SessionVisualizedMessageCmd": [
         "session_visualized",
-    ],
-    "SessionsUpdatedMessageEvent": [
-        "sessions_updated",
     ],
     "SetChiefOfStaffMessageCmd": [
         "set_chief_of_staff",
@@ -12314,11 +12296,11 @@ const typeMap: any = {
         "needs_input",
         "ready_for_review",
     ],
-    "SetWorkspaceRankMessageCmd": [
-        "set_workspace_rank",
-    ],
     "SettingsUpdatedMessageEvent": [
         "settings_updated",
+    ],
+    "SetWorkspaceRankMessageCmd": [
+        "set_workspace_rank",
     ],
     "SpawnResultMessageEvent": [
         "spawn_result",
@@ -12399,14 +12381,14 @@ const typeMap: any = {
     "TicketSubscribeMessageCmd": [
         "ticket_subscribe",
     ],
+    "TicketsUpdatedMessageEvent": [
+        "tickets_updated",
+    ],
     "TicketTakeMessageCmd": [
         "ticket_take",
     ],
     "TicketUnsubscribeMessageCmd": [
         "ticket_unsubscribe",
-    ],
-    "TicketsUpdatedMessageEvent": [
-        "tickets_updated",
     ],
     "TodosMessageCmd": [
         "todos",
@@ -12538,11 +12520,11 @@ const typeMap: any = {
     "WorkspaceLayoutUndockTileMessageCmd": [
         "workspace_layout_undock_tile",
     ],
-    "WorkspaceLayoutUpdateTileMessageCmd": [
-        "workspace_layout_update_tile",
-    ],
     "WorkspaceLayoutUpdatedMessageEvent": [
         "workspace_layout_updated",
+    ],
+    "WorkspaceLayoutUpdateTileMessageCmd": [
+        "workspace_layout_update_tile",
     ],
     "WorkspaceRegisteredMessageEvent": [
         "workspace_registered",

--- a/internal/daemon/automations_deliver.go
+++ b/internal/daemon/automations_deliver.go
@@ -15,7 +15,7 @@ import (
 	"github.com/victorarias/attn/internal/automation"
 	attngit "github.com/victorarias/attn/internal/git"
 	"github.com/victorarias/attn/internal/protocol"
-	"github.com/victorarias/attn/internal/ptybackend"
+	"github.com/victorarias/attn/internal/pty"
 	"github.com/victorarias/attn/internal/store"
 )
 
@@ -766,7 +766,7 @@ func (d *Daemon) passUnattendedLaunchGate(req automation.WorkRequest) error {
 		return nil
 	}
 	snapshots, ok := d.ptyBackend.(interface {
-		Snapshot(context.Context, string) (ptybackend.AttachInfo, error)
+		Snapshot(context.Context, string) (pty.SnapshotInfo, error)
 	})
 	if !ok {
 		return errors.New("automation launch cannot verify Codex directory trust gate")
@@ -776,7 +776,11 @@ func (d *Daemon) passUnattendedLaunchGate(req automation.WorkRequest) error {
 	for time.Now().Before(deadline) {
 		info, err := snapshots.Snapshot(context.Background(), req.IDs.SessionID)
 		if err == nil {
-			screen := stripANSIForPromptMatch(info.ScreenSnapshot)
+			var payload []byte
+			if info.Screen != nil {
+				payload = info.Screen.Payload
+			}
+			screen := stripANSIForPromptMatch(payload)
 			if strings.Contains(screen, codexDirectoryTrustPrompt) {
 				if !acknowledged {
 					if err := d.ptyBackend.Input(context.Background(), req.IDs.SessionID, []byte("\r")); err != nil {
@@ -786,7 +790,7 @@ func (d *Daemon) passUnattendedLaunchGate(req automation.WorkRequest) error {
 				}
 			} else if acknowledged {
 				return nil
-			} else if time.Until(deadline) < 5*time.Second && len(info.ScreenSnapshot) > 0 {
+			} else if time.Until(deadline) < 5*time.Second && len(payload) > 0 {
 				// A populated screen with no trust chooser after the startup half of
 				// the window means the launch did not need this compatibility gate.
 				return nil

--- a/internal/daemon/automations_test.go
+++ b/internal/daemon/automations_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/victorarias/attn/internal/github"
 	"github.com/victorarias/attn/internal/launchcontract"
 	"github.com/victorarias/attn/internal/protocol"
-	"github.com/victorarias/attn/internal/ptybackend"
+	"github.com/victorarias/attn/internal/pty"
 	"github.com/victorarias/attn/internal/store"
 )
 
@@ -44,12 +44,13 @@ func writeCodexRolloutFixture(t *testing.T, resumeID string) {
 	}
 }
 
-func (b *automationResumeBackend) Snapshot(context.Context, string) (ptybackend.AttachInfo, error) {
+func (b *automationResumeBackend) Snapshot(context.Context, string) (pty.SnapshotInfo, error) {
 	b.snapshotCalls++
+	payload := []byte("reviewer ready")
 	if b.snapshotCalls == 1 {
-		return ptybackend.AttachInfo{ScreenSnapshot: []byte(codexDirectoryTrustPrompt)}, nil
+		payload = []byte(codexDirectoryTrustPrompt)
 	}
-	return ptybackend.AttachInfo{ScreenSnapshot: []byte("reviewer ready")}, nil
+	return pty.SnapshotInfo{Screen: &pty.ViewportSnapshot{Payload: payload}}, nil
 }
 
 func TestStripANSIForPromptMatch_PreservesStyledSplitPrompt(t *testing.T) {

--- a/internal/daemon/web/index.html
+++ b/internal/daemon/web/index.html
@@ -2236,11 +2236,7 @@
         }
 
         const fallbackPayload = {
-          scrollback: message.scrollback || "",
-          screenSnapshot:
-            message.screen_snapshot && message.screen_snapshot_fresh !== false
-              ? message.screen_snapshot
-              : "",
+          screenSnapshot: message.screen_snapshot || "",
         };
         const queuedOutputs = filteredQueuedAttachOutputs(message.id);
         state.attachQueue = [];

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -738,23 +738,6 @@ func int32PtrToInt(v *int32) *int {
 	return &n
 }
 
-// snapshotSeedScreen resolves the visible frame from the worker's fresh
-// Ghostty snapshot (Manager.Snapshot) to seed an observer. The second result is
-// ok.
-func snapshotSeedScreen(info ptybackend.AttachInfo) (pty.ReplayScreenSnapshot, bool) {
-	if info.ScreenSnapshotFresh && len(info.ScreenSnapshot) > 0 {
-		return pty.ReplayScreenSnapshot{
-			Payload:       info.ScreenSnapshot,
-			Cols:          info.ScreenCols,
-			Rows:          info.ScreenRows,
-			CursorX:       info.ScreenCursorX,
-			CursorY:       info.ScreenCursorY,
-			CursorVisible: info.ScreenCursorVisible,
-		}, true
-	}
-	return pty.ReplayScreenSnapshot{}, false
-}
-
 // handleGetScreenSnapshot serves a read-only snapshot of a session's current
 // screen. It registers no subscriber and starts no stream — purely a seed for
 // observers (grid tiles) that then dedup the live firehose against last_seq.
@@ -792,20 +775,21 @@ func (d *Daemon) handleGetScreenSnapshot(client *wsClient, msg *protocol.GetScre
 		Rows:    protocol.Ptr(int(info.Rows)),
 		Running: protocol.Ptr(info.Running),
 	}
-	screen, haveScreen := snapshotSeedScreen(info)
-	if haveScreen {
-		result.ScreenSnapshot = protocol.Ptr(base64.StdEncoding.EncodeToString(screen.Payload))
-		result.ScreenRows = protocol.Ptr(int(screen.Rows))
-		result.ScreenCols = protocol.Ptr(int(screen.Cols))
-		result.ScreenCursorX = protocol.Ptr(int(screen.CursorX))
-		result.ScreenCursorY = protocol.Ptr(int(screen.CursorY))
-		result.ScreenCursorVisible = protocol.Ptr(screen.CursorVisible)
-		result.ScreenSnapshotFresh = protocol.Ptr(true)
+	snapshotBytes := 0
+	screenCols := 0
+	screenRows := 0
+	if info.Screen != nil {
+		snapshotBytes = len(info.Screen.Payload)
+		screenCols = int(info.Screen.Cols)
+		screenRows = int(info.Screen.Rows)
+		result.ScreenSnapshot = protocol.Ptr(base64.StdEncoding.EncodeToString(info.Screen.Payload))
+		result.ScreenRows = protocol.Ptr(screenRows)
+		result.ScreenCols = protocol.Ptr(screenCols)
 	}
 	d.logf(
 		"PTY screen snapshot: id=%s running=%v last_seq=%d snapshot_bytes=%d screen=%dx%d have_screen=%v",
-		msg.ID, info.Running, info.LastSeq, len(screen.Payload),
-		screen.Cols, screen.Rows, haveScreen,
+		msg.ID, info.Running, info.LastSeq, snapshotBytes,
+		screenCols, screenRows, info.Screen != nil,
 	)
 	d.sendToClient(client, result)
 }

--- a/internal/daemon/ws_pty_snapshot_test.go
+++ b/internal/daemon/ws_pty_snapshot_test.go
@@ -1,40 +1,82 @@
 package daemon
 
 import (
+	"context"
+	"encoding/base64"
 	"testing"
 
-	"github.com/victorarias/attn/internal/ptybackend"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/pty"
 )
 
-// snapshotSeedScreen backs grid-tile seeding from the worker's fresh Ghostty
-// snapshot (Manager.Snapshot). It seeds only when a fresh frame is present.
+type snapshotBackend struct {
+	*fakeSpawnBackend
+	snapshot pty.SnapshotInfo
+}
 
-func TestSnapshotSeedScreenPrefersFreshWorkerScreen(t *testing.T) {
-	info := ptybackend.AttachInfo{
-		ScreenSnapshot:      []byte("rendered-by-worker"),
-		ScreenCols:          80,
-		ScreenRows:          24,
-		ScreenSnapshotFresh: true,
-		Cols:                80,
-		Rows:                24,
-	}
+func (b *snapshotBackend) Snapshot(context.Context, string) (pty.SnapshotInfo, error) {
+	return b.snapshot, nil
+}
 
-	screen, ok := snapshotSeedScreen(info)
-	if !ok {
-		t.Fatal("expected a screen when a fresh worker snapshot is present")
+func TestHandleGetScreenSnapshotSeedsFromViewportPayload(t *testing.T) {
+	d := NewForTesting(t.TempDir())
+	d.ptyBackend = &snapshotBackend{
+		fakeSpawnBackend: &fakeSpawnBackend{},
+		snapshot: pty.SnapshotInfo{
+			LastSeq: 42,
+			Cols:    100,
+			Rows:    30,
+			Running: true,
+			Screen: &pty.ViewportSnapshot{
+				Payload: []byte("rendered-by-worker"),
+				Cols:    80,
+				Rows:    24,
+			},
+		},
 	}
-	if string(screen.Payload) != "rendered-by-worker" {
-		t.Fatalf("expected the worker payload, got %q", screen.Payload)
+	client := &wsClient{send: make(chan outboundMessage, 1)}
+
+	d.handleGetScreenSnapshot(client, &protocol.GetScreenSnapshotMessage{ID: "session-1"})
+
+	var result protocol.GetScreenSnapshotResultMessage
+	readNotebookWSEvent(t, client.send, &result)
+	if !result.Success {
+		t.Fatalf("snapshot result failed: %v", result.Error)
 	}
-	if screen.Cols != 80 || screen.Rows != 24 {
-		t.Fatalf("screen geometry = %dx%d, want 80x24", screen.Cols, screen.Rows)
+	if result.ScreenSnapshot == nil {
+		t.Fatal("expected viewport payload in snapshot result")
+	}
+	payload, err := base64.StdEncoding.DecodeString(*result.ScreenSnapshot)
+	if err != nil {
+		t.Fatalf("decode snapshot payload: %v", err)
+	}
+	if string(payload) != "rendered-by-worker" {
+		t.Fatalf("snapshot payload = %q, want rendered-by-worker", payload)
+	}
+	if got, want := protocol.Deref(result.ScreenCols), 80; got != want {
+		t.Fatalf("screen cols = %d, want %d", got, want)
+	}
+	if got, want := protocol.Deref(result.ScreenRows), 24; got != want {
+		t.Fatalf("screen rows = %d, want %d", got, want)
 	}
 }
 
-func TestSnapshotSeedScreenReturnsNothingWithoutFreshScreen(t *testing.T) {
-	// No fresh worker screen (e.g. a session that has produced no output yet, or
-	// an unsupported-platform buildability stub): nothing to seed.
-	if _, ok := snapshotSeedScreen(ptybackend.AttachInfo{Cols: 80, Rows: 24}); ok {
-		t.Fatal("expected no screen when no fresh frame is available")
+func TestHandleGetScreenSnapshotLeavesObserverUnseededWithoutViewport(t *testing.T) {
+	d := NewForTesting(t.TempDir())
+	d.ptyBackend = &snapshotBackend{
+		fakeSpawnBackend: &fakeSpawnBackend{},
+		snapshot:         pty.SnapshotInfo{LastSeq: 42, Cols: 100, Rows: 30, Running: true},
+	}
+	client := &wsClient{send: make(chan outboundMessage, 1)}
+
+	d.handleGetScreenSnapshot(client, &protocol.GetScreenSnapshotMessage{ID: "session-1"})
+
+	var result protocol.GetScreenSnapshotResultMessage
+	readNotebookWSEvent(t, client.send, &result)
+	if !result.Success {
+		t.Fatalf("snapshot result failed: %v", result.Error)
+	}
+	if result.ScreenSnapshot != nil || result.ScreenCols != nil || result.ScreenRows != nil {
+		t.Fatalf("expected unseeded observer result, got %+v", result)
 	}
 }

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "182"
+const ProtocolVersion = "183"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1706,25 +1706,11 @@ type GetScreenSnapshotResultMessage struct {
 	// ScreenCols corresponds to the JSON schema field "screen_cols".
 	ScreenCols *int `json:"screen_cols,omitempty,omitzero"`
 
-	// ScreenCursorVisible corresponds to the JSON schema field
-	// "screen_cursor_visible".
-	ScreenCursorVisible *bool `json:"screen_cursor_visible,omitempty,omitzero"`
-
-	// ScreenCursorX corresponds to the JSON schema field "screen_cursor_x".
-	ScreenCursorX *int `json:"screen_cursor_x,omitempty,omitzero"`
-
-	// ScreenCursorY corresponds to the JSON schema field "screen_cursor_y".
-	ScreenCursorY *int `json:"screen_cursor_y,omitempty,omitzero"`
-
 	// ScreenRows corresponds to the JSON schema field "screen_rows".
 	ScreenRows *int `json:"screen_rows,omitempty,omitzero"`
 
 	// ScreenSnapshot corresponds to the JSON schema field "screen_snapshot".
 	ScreenSnapshot *string `json:"screen_snapshot,omitempty,omitzero"`
-
-	// ScreenSnapshotFresh corresponds to the JSON schema field
-	// "screen_snapshot_fresh".
-	ScreenSnapshotFresh *bool `json:"screen_snapshot_fresh,omitempty,omitzero"`
 
 	// Success corresponds to the JSON schema field "success".
 	Success bool `json:"success"`
@@ -4957,28 +4943,11 @@ type WebSocketEvent struct {
 	// ScreenCols corresponds to the JSON schema field "screen_cols".
 	ScreenCols *int `json:"screen_cols,omitempty,omitzero"`
 
-	// ScreenCursorVisible corresponds to the JSON schema field
-	// "screen_cursor_visible".
-	ScreenCursorVisible *bool `json:"screen_cursor_visible,omitempty,omitzero"`
-
-	// ScreenCursorX corresponds to the JSON schema field "screen_cursor_x".
-	ScreenCursorX *int `json:"screen_cursor_x,omitempty,omitzero"`
-
-	// ScreenCursorY corresponds to the JSON schema field "screen_cursor_y".
-	ScreenCursorY *int `json:"screen_cursor_y,omitempty,omitzero"`
-
 	// ScreenRows corresponds to the JSON schema field "screen_rows".
 	ScreenRows *int `json:"screen_rows,omitempty,omitzero"`
 
 	// ScreenSnapshot corresponds to the JSON schema field "screen_snapshot".
 	ScreenSnapshot *string `json:"screen_snapshot,omitempty,omitzero"`
-
-	// ScreenSnapshotFresh corresponds to the JSON schema field
-	// "screen_snapshot_fresh".
-	ScreenSnapshotFresh *bool `json:"screen_snapshot_fresh,omitempty,omitzero"`
-
-	// Scrollback corresponds to the JSON schema field "scrollback".
-	Scrollback *string `json:"scrollback,omitempty,omitzero"`
 
 	// ScrollbackTruncated corresponds to the JSON schema field
 	// "scrollback_truncated".

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -2816,10 +2816,6 @@ model GetScreenSnapshotResultMessage {
   screen_snapshot?: string; // base64 ANSI replay of the visible frame
   screen_rows?: int32;
   screen_cols?: int32;
-  screen_cursor_x?: int32; // 0-based
-  screen_cursor_y?: int32; // 0-based
-  screen_cursor_visible?: boolean;
-  screen_snapshot_fresh?: boolean;
   last_seq?: int32;
   cols?: int32;
   rows?: int32;
@@ -3449,15 +3445,10 @@ model WebSocketEvent {
   // PTY lifecycle
   data?: string;
   seq?: int32;
-  scrollback?: string;
   scrollback_truncated?: boolean;
   screen_snapshot?: string;
   screen_rows?: int32;
   screen_cols?: int32;
-  screen_cursor_x?: int32;
-  screen_cursor_y?: int32;
-  screen_cursor_visible?: boolean;
-  screen_snapshot_fresh?: boolean;
   last_seq?: int32;
   cols?: int32;
   rows?: int32;

--- a/internal/pty/attach_race_test.go
+++ b/internal/pty/attach_race_test.go
@@ -225,7 +225,7 @@ func TestScreenSnapshotSeqConsistency(t *testing.T) {
 	// not yet reached the screen, take the observer snapshot inside the gap.
 	var (
 		once    sync.Once
-		gapInfo AttachInfo
+		gapInfo SnapshotInfo
 		gapSeq  uint32
 	)
 	readLoopSeqGapHook = func() {
@@ -240,7 +240,7 @@ func TestScreenSnapshotSeqConsistency(t *testing.T) {
 	if gapSeq == 0 {
 		t.Fatal("readLoopSeqGapHook never fired")
 	}
-	if bytes.Contains(gapInfo.ScreenSnapshot, []byte("MARKER")) {
+	if bytes.Contains(gapInfo.Screen.Payload, []byte("MARKER")) {
 		t.Fatal("gap snapshot already contains the in-flight chunk; the seam fired too late to exercise the race")
 	}
 	// The core invariant: a snapshot whose screen lacks the chunk's bytes must
@@ -256,8 +256,8 @@ func TestScreenSnapshotSeqConsistency(t *testing.T) {
 	if settled.LastSeq != gapSeq {
 		t.Fatalf("settled snapshot LastSeq = %d, want %d (the applied marker chunk)", settled.LastSeq, gapSeq)
 	}
-	if !bytes.Contains(settled.ScreenSnapshot, []byte("MARKER")) {
-		t.Fatalf("settled snapshot screen should contain the applied marker chunk; got %q", settled.ScreenSnapshot)
+	if !bytes.Contains(settled.Screen.Payload, []byte("MARKER")) {
+		t.Fatalf("settled snapshot screen should contain the applied marker chunk; got %q", settled.Screen.Payload)
 	}
 }
 

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -78,32 +78,33 @@ type SpawnOptions struct {
 	Theme TerminalTheme
 }
 
-// ReplayScreenSnapshot is the observer seed serialized from the
-// server-authoritative terminal.
-type ReplayScreenSnapshot struct {
-	Payload       []byte
-	Cols          uint16
-	Rows          uint16
-	CursorX       uint16
-	CursorY       uint16
-	CursorVisible bool
+// ViewportSnapshot is the styled VT serialization of the visible frame. It is
+// self-contained (including cursor state in the payload) and seeds observers
+// (grid tiles) and the automations gate.
+type ViewportSnapshot struct {
+	Payload []byte
+	Cols    uint16
+	Rows    uint16
+}
+
+// SnapshotInfo is the read-only rendered state used to seed observers without
+// attaching or claiming PTY geometry.
+type SnapshotInfo struct {
+	LastSeq uint32
+	Cols    uint16
+	Rows    uint16
+	Running bool
+	Screen  *ViewportSnapshot // nil when the terminal has produced no frame
 }
 
 type AttachInfo struct {
-	LastSeq             uint32
-	Cols                uint16
-	Rows                uint16
-	PID                 int
-	Running             bool
-	ExitCode            *int
-	ExitSignal          *string
-	ScreenSnapshot      []byte
-	ScreenCols          uint16
-	ScreenRows          uint16
-	ScreenCursorX       uint16
-	ScreenCursorY       uint16
-	ScreenCursorVisible bool
-	ScreenSnapshotFresh bool
+	LastSeq    uint32
+	Cols       uint16
+	Rows       uint16
+	PID        int
+	Running    bool
+	ExitCode   *int
+	ExitSignal *string
 	// GhosttySnapshot is the server-authoritative VT serialization of the whole
 	// terminal (primary + alt screens, scrollback, cursor) from libghostty-vt.
 	// Snapshot geometry is Cols/Rows. nil when the ghostty terminal is absent.
@@ -368,10 +369,10 @@ func (m *Manager) SetTheme(sessionID string, theme TerminalTheme) error {
 // session WITHOUT registering a subscriber or claiming geometry. It is the
 // read-only seed for observers (e.g. grid tiles) that then dedup the live
 // firehose against LastSeq.
-func (m *Manager) Snapshot(sessionID string) (AttachInfo, error) {
+func (m *Manager) Snapshot(sessionID string) (SnapshotInfo, error) {
 	session, err := m.getSession(sessionID)
 	if err != nil {
-		return AttachInfo{}, err
+		return SnapshotInfo{}, err
 	}
 	return session.screenSnapshot(), nil
 }

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -702,7 +702,7 @@ func (s *Session) info() AttachInfo {
 // the chunk, so a snapshot landing in that gap would claim to cover bytes the
 // screen does not contain, and an observer deduping the live stream against
 // LastSeq would silently drop the chunk carrying them.
-func (s *Session) screenSnapshot() AttachInfo {
+func (s *Session) screenSnapshot() SnapshotInfo {
 	s.metaMu.RLock()
 	cols := s.cols
 	rows := s.rows
@@ -712,29 +712,20 @@ func (s *Session) screenSnapshot() AttachInfo {
 	running := s.running
 	s.exitMu.RUnlock()
 
-	pid := 0
-	if s.cmd != nil && s.cmd.Process != nil {
-		pid = s.cmd.Process.Pid
-	}
-
-	info := AttachInfo{
+	info := SnapshotInfo{
 		Cols:    cols,
 		Rows:    rows,
-		PID:     pid,
 		Running: running,
 	}
 	s.replayMu.Lock()
 	if s.ghostty != nil {
 		snapshot := s.ghostty.SerializeViewport()
 		if snapshot.VTDump != nil {
-			info.ScreenSnapshot = snapshot.VTDump
-			info.ScreenCols = uint16(snapshot.Cols)
-			info.ScreenRows = uint16(snapshot.Rows)
-			x, y := s.ghostty.CursorPos()
-			info.ScreenCursorX = uint16(x)
-			info.ScreenCursorY = uint16(y)
-			info.ScreenCursorVisible = s.ghostty.CursorVisible()
-			info.ScreenSnapshotFresh = true
+			info.Screen = &ViewportSnapshot{
+				Payload: snapshot.VTDump,
+				Cols:    uint16(snapshot.Cols),
+				Rows:    uint16(snapshot.Rows),
+			}
 		}
 	}
 	info.LastSeq = s.lastReplaySeq

--- a/internal/pty/snapshot_test.go
+++ b/internal/pty/snapshot_test.go
@@ -19,26 +19,23 @@ func TestScreenSnapshot_IncludesScreenSnapshotWhenAvailable(t *testing.T) {
 	gt.Write([]byte("snapshot"))
 
 	info := session.screenSnapshot()
-	if len(info.ScreenSnapshot) == 0 {
-		t.Fatal("expected non-empty screen snapshot")
+	if info.Screen == nil || len(info.Screen.Payload) == 0 {
+		t.Fatal("expected non-empty viewport snapshot")
 	}
-	if !info.ScreenSnapshotFresh {
-		t.Fatal("expected screen snapshot to be marked fresh")
-	}
-	if info.ScreenCols != 12 || info.ScreenRows != 4 {
-		t.Fatalf("screen size = %dx%d, want 12x4", info.ScreenCols, info.ScreenRows)
+	if info.Screen.Cols != 12 || info.Screen.Rows != 4 {
+		t.Fatalf("screen size = %dx%d, want 12x4", info.Screen.Cols, info.Screen.Rows)
 	}
 	assertScreenSnapshotReplays(t, gt, info)
 }
 
-func assertScreenSnapshotReplays(t *testing.T, source *ghosttyvt.Terminal, info AttachInfo) {
+func assertScreenSnapshotReplays(t *testing.T, source *ghosttyvt.Terminal, info SnapshotInfo) {
 	t.Helper()
-	restored, err := ghosttyvt.New(int(info.ScreenCols), int(info.ScreenRows), ghosttyvt.Options{})
+	restored, err := ghosttyvt.New(int(info.Screen.Cols), int(info.Screen.Rows), ghosttyvt.Options{})
 	if err != nil {
 		t.Fatalf("new restored ghostty terminal: %v", err)
 	}
 	t.Cleanup(restored.Close)
-	restored.Write(info.ScreenSnapshot)
+	restored.Write(info.Screen.Payload)
 	if got, want := restored.ViewportText(), source.ViewportText(); got != want {
 		t.Fatalf("replayed viewport text = %q, want %q", got, want)
 	}
@@ -62,11 +59,8 @@ func TestScreenSnapshot_IncludesScreenSnapshotForShellSessions(t *testing.T) {
 	gt.Write([]byte("prompt"))
 
 	info := session.screenSnapshot()
-	if len(info.ScreenSnapshot) == 0 {
-		t.Fatal("expected non-empty screen snapshot for shell session")
-	}
-	if !info.ScreenSnapshotFresh {
-		t.Fatal("expected ScreenSnapshotFresh=true for shell session")
+	if info.Screen == nil || len(info.Screen.Payload) == 0 {
+		t.Fatal("expected non-empty viewport snapshot for shell session")
 	}
 }
 
@@ -91,11 +85,11 @@ func TestScreenSnapshot_ReadOnlyAndLean(t *testing.T) {
 
 	info := session.screenSnapshot()
 
-	if len(info.ScreenSnapshot) == 0 || !info.ScreenSnapshotFresh {
-		t.Fatal("expected a fresh screen snapshot")
+	if info.Screen == nil || len(info.Screen.Payload) == 0 {
+		t.Fatal("expected a viewport snapshot")
 	}
-	if info.ScreenCols != 12 || info.ScreenRows != 4 {
-		t.Fatalf("screen size = %dx%d, want 12x4", info.ScreenCols, info.ScreenRows)
+	if info.Screen.Cols != 12 || info.Screen.Rows != 4 {
+		t.Fatalf("screen size = %dx%d, want 12x4", info.Screen.Cols, info.Screen.Rows)
 	}
 	if info.LastSeq != 7 {
 		t.Fatalf("LastSeq = %d, want 7", info.LastSeq)

--- a/internal/ptybackend/backend.go
+++ b/internal/ptybackend/backend.go
@@ -107,20 +107,13 @@ func validateUnattendedSpawnOptions(opts SpawnOptions) error {
 }
 
 type AttachInfo struct {
-	LastSeq             uint32
-	Cols                uint16
-	Rows                uint16
-	PID                 int
-	Running             bool
-	ExitCode            *int
-	ExitSignal          *string
-	ScreenSnapshot      []byte
-	ScreenCols          uint16
-	ScreenRows          uint16
-	ScreenCursorX       uint16
-	ScreenCursorY       uint16
-	ScreenCursorVisible bool
-	ScreenSnapshotFresh bool
+	LastSeq    uint32
+	Cols       uint16
+	Rows       uint16
+	PID        int
+	Running    bool
+	ExitCode   *int
+	ExitSignal *string
 	// GhosttySnapshot is the server-authoritative VT serialization of the whole
 	// terminal from libghostty-vt (geometry is Cols/Rows). nil when absent.
 	GhosttySnapshot []byte
@@ -242,7 +235,7 @@ type WorkerProcessProvider interface {
 // attaching. Backends that cannot serve a snapshot (e.g. a worker built before
 // the capability existed) return an error; callers degrade gracefully.
 type SnapshotProvider interface {
-	Snapshot(ctx context.Context, sessionID string) (AttachInfo, error)
+	Snapshot(ctx context.Context, sessionID string) (pty.SnapshotInfo, error)
 }
 
 type SessionLivenessProber interface {

--- a/internal/ptybackend/embedded.go
+++ b/internal/ptybackend/embedded.go
@@ -107,38 +107,14 @@ func (b *EmbeddedBackend) Attach(_ context.Context, sessionID, subscriberID stri
 		Running:                    info.Running,
 		ExitCode:                   info.ExitCode,
 		ExitSignal:                 info.ExitSignal,
-		ScreenSnapshot:             info.ScreenSnapshot,
-		ScreenCols:                 info.ScreenCols,
-		ScreenRows:                 info.ScreenRows,
-		ScreenCursorX:              info.ScreenCursorX,
-		ScreenCursorY:              info.ScreenCursorY,
-		ScreenCursorVisible:        info.ScreenCursorVisible,
-		ScreenSnapshotFresh:        info.ScreenSnapshotFresh,
 		GhosttySnapshot:            info.GhosttySnapshot,
 		GhosttyBlocks:              info.GhosttyBlocks,
 		GhosttyScrollbackTruncated: info.GhosttyScrollbackTruncated,
 	}, stream, nil
 }
 
-func (b *EmbeddedBackend) Snapshot(_ context.Context, sessionID string) (AttachInfo, error) {
-	info, err := b.manager.Snapshot(sessionID)
-	if err != nil {
-		return AttachInfo{}, err
-	}
-	return AttachInfo{
-		LastSeq:             info.LastSeq,
-		Cols:                info.Cols,
-		Rows:                info.Rows,
-		PID:                 info.PID,
-		Running:             info.Running,
-		ScreenSnapshot:      info.ScreenSnapshot,
-		ScreenCols:          info.ScreenCols,
-		ScreenRows:          info.ScreenRows,
-		ScreenCursorX:       info.ScreenCursorX,
-		ScreenCursorY:       info.ScreenCursorY,
-		ScreenCursorVisible: info.ScreenCursorVisible,
-		ScreenSnapshotFresh: info.ScreenSnapshotFresh,
-	}, nil
+func (b *EmbeddedBackend) Snapshot(_ context.Context, sessionID string) (pty.SnapshotInfo, error) {
+	return b.manager.Snapshot(sessionID)
 }
 
 func (b *EmbeddedBackend) Input(_ context.Context, sessionID string, data []byte) error {

--- a/internal/ptybackend/worker.go
+++ b/internal/ptybackend/worker.go
@@ -684,13 +684,6 @@ func (b *WorkerBackend) Attach(ctx context.Context, sessionID, subscriberID stri
 				Running:                    attachResult.Running,
 				ExitCode:                   attachResult.ExitCode,
 				ExitSignal:                 attachResult.ExitSignal,
-				ScreenSnapshot:             attachResult.ScreenSnapshot,
-				ScreenCols:                 attachResult.ScreenCols,
-				ScreenRows:                 attachResult.ScreenRows,
-				ScreenCursorX:              attachResult.ScreenCursorX,
-				ScreenCursorY:              attachResult.ScreenCursorY,
-				ScreenCursorVisible:        attachResult.ScreenCursorVisible,
-				ScreenSnapshotFresh:        attachResult.ScreenSnapshotFresh,
 				GhosttySnapshot:            attachResult.GhosttySnapshot,
 				GhosttyBlocks:              attachBlocksFromWire(attachResult.GhosttyBlocks),
 				GhosttyScrollbackTruncated: attachResult.GhosttyScrollbackTruncated,
@@ -1065,35 +1058,29 @@ func (b *WorkerBackend) SessionLaunchParams(ctx context.Context, sessionID strin
 	}, nil
 }
 
-func (b *WorkerBackend) Snapshot(ctx context.Context, sessionID string) (AttachInfo, error) {
+func (b *WorkerBackend) Snapshot(ctx context.Context, sessionID string) (pty.SnapshotInfo, error) {
 	session, err := b.getSession(sessionID)
 	if err != nil {
-		return AttachInfo{}, err
+		return pty.SnapshotInfo{}, err
 	}
 	res, err := b.callSnapshot(ctx, session)
 	if err != nil {
-		return AttachInfo{}, err
+		return pty.SnapshotInfo{}, err
 	}
-	return attachInfoFromAttachResult(res), nil
-}
-
-func attachInfoFromAttachResult(res ptyworker.AttachResult) AttachInfo {
-	return AttachInfo{
-		LastSeq:             res.LastSeq,
-		Cols:                res.Cols,
-		Rows:                res.Rows,
-		PID:                 res.PID,
-		Running:             res.Running,
-		ExitCode:            res.ExitCode,
-		ExitSignal:          res.ExitSignal,
-		ScreenSnapshot:      res.ScreenSnapshot,
-		ScreenCols:          res.ScreenCols,
-		ScreenRows:          res.ScreenRows,
-		ScreenCursorX:       res.ScreenCursorX,
-		ScreenCursorY:       res.ScreenCursorY,
-		ScreenCursorVisible: res.ScreenCursorVisible,
-		ScreenSnapshotFresh: res.ScreenSnapshotFresh,
+	info := pty.SnapshotInfo{
+		LastSeq: res.LastSeq,
+		Cols:    res.Cols,
+		Rows:    res.Rows,
+		Running: res.Running,
 	}
+	if len(res.ScreenSnapshot) > 0 {
+		info.Screen = &pty.ViewportSnapshot{
+			Payload: res.ScreenSnapshot,
+			Cols:    res.ScreenCols,
+			Rows:    res.ScreenRows,
+		}
+	}
+	return info, nil
 }
 
 func (b *WorkerBackend) SessionLikelyAlive(ctx context.Context, sessionID string) (bool, error) {
@@ -1464,36 +1451,36 @@ func (b *WorkerBackend) callInfo(ctx context.Context, session *workerSession) (p
 	}
 }
 
-func (b *WorkerBackend) callSnapshot(ctx context.Context, session *workerSession) (ptyworker.AttachResult, error) {
+func (b *WorkerBackend) callSnapshot(ctx context.Context, session *workerSession) (ptyworker.SnapshotResult, error) {
 	rpcCtx, cancel := withDefaultRPCTimeout(ctx)
 	defer cancel()
 	conn, enc, dec, err := b.connectAuthed(rpcCtx, session)
 	if err != nil {
-		return ptyworker.AttachResult{}, err
+		return ptyworker.SnapshotResult{}, err
 	}
 	defer conn.Close()
 	if err := applyConnDeadline(conn, rpcCtx); err != nil {
-		return ptyworker.AttachResult{}, err
+		return ptyworker.SnapshotResult{}, err
 	}
 
 	reqID := b.nextReqID("snapshot")
 	if err := writeRequest(enc, reqID, ptyworker.MethodSnapshot, map[string]any{}); err != nil {
-		return ptyworker.AttachResult{}, err
+		return ptyworker.SnapshotResult{}, err
 	}
 	for {
 		frameType, res, _, err := readFrame(dec)
 		if err != nil {
-			return ptyworker.AttachResult{}, err
+			return ptyworker.SnapshotResult{}, err
 		}
 		if frameType != "res" || res.ID != reqID {
 			continue
 		}
 		if !res.OK {
-			return ptyworker.AttachResult{}, b.rpcError(session.SessionID, res.Error)
+			return ptyworker.SnapshotResult{}, b.rpcError(session.SessionID, res.Error)
 		}
-		var result ptyworker.AttachResult
+		var result ptyworker.SnapshotResult
 		if err := json.Unmarshal(res.Result, &result); err != nil {
-			return ptyworker.AttachResult{}, err
+			return ptyworker.SnapshotResult{}, err
 		}
 		return result, nil
 	}

--- a/internal/ptybackend/worker_integration_test.go
+++ b/internal/ptybackend/worker_integration_test.go
@@ -157,14 +157,14 @@ gotOutput:
 	if !snap.Running {
 		t.Fatalf("snapshot running=false, expected true")
 	}
-	if len(snap.ScreenSnapshot) == 0 || !snap.ScreenSnapshotFresh {
-		t.Fatalf("expected a fresh screen snapshot, got %d bytes fresh=%v", len(snap.ScreenSnapshot), snap.ScreenSnapshotFresh)
+	if snap.Screen == nil || len(snap.Screen.Payload) == 0 {
+		t.Fatal("expected a viewport snapshot")
 	}
-	if !bytes.Contains(snap.ScreenSnapshot, []byte("__ATTN_WORKER__")) {
-		t.Fatalf("snapshot missing printed marker; got %q", snap.ScreenSnapshot)
+	if !bytes.Contains(snap.Screen.Payload, []byte("__ATTN_WORKER__")) {
+		t.Fatalf("snapshot missing printed marker; got %q", snap.Screen.Payload)
 	}
-	if snap.ScreenCols == 0 || snap.ScreenRows == 0 {
-		t.Fatalf("snapshot geometry = %dx%d, want non-zero", snap.ScreenCols, snap.ScreenRows)
+	if snap.Screen.Cols == 0 || snap.Screen.Rows == 0 {
+		t.Fatalf("snapshot geometry = %dx%d, want non-zero", snap.Screen.Cols, snap.Screen.Rows)
 	}
 
 	// SetTheme round-trips over the worker RPC surface and takes effect on the
@@ -278,18 +278,18 @@ func TestWorkerBackend_SnapshotReadsScreenReadOnly(t *testing.T) {
 	// Snapshot must fetch the rendered screen without a subscriber, so we can
 	// poll it repeatedly until the marker lands; if each call leaked a
 	// subscriber the worker would accumulate dead ones.
-	var info AttachInfo
+	var info pty.SnapshotInfo
 	deadline := time.Now().Add(8 * time.Second)
 	for {
 		info, err = backend.Snapshot(context.Background(), sessionID)
 		if err != nil {
 			t.Fatalf("Snapshot() error: %v", err)
 		}
-		if bytes.Contains(info.ScreenSnapshot, []byte("__ATTN_REPLAY__")) {
+		if bytes.Contains(info.Screen.Payload, []byte("__ATTN_REPLAY__")) {
 			break
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("timed out waiting for marker in read-only snapshot; screen=%q", info.ScreenSnapshot)
+			t.Fatalf("timed out waiting for marker in read-only snapshot; screen=%q", info.Screen.Payload)
 		}
 		time.Sleep(150 * time.Millisecond)
 	}
@@ -297,8 +297,8 @@ func TestWorkerBackend_SnapshotReadsScreenReadOnly(t *testing.T) {
 	if !info.Running {
 		t.Fatalf("Snapshot running=false, expected true")
 	}
-	if !info.ScreenSnapshotFresh || len(info.ScreenSnapshot) == 0 {
-		t.Fatal("expected a fresh screen snapshot, got none")
+	if info.Screen == nil || len(info.Screen.Payload) == 0 {
+		t.Fatal("expected a viewport snapshot")
 	}
 
 	// The session must stay fully usable after the read-only snapshots: a real

--- a/internal/ptyworker/protocol.go
+++ b/internal/ptyworker/protocol.go
@@ -123,14 +123,6 @@ type AttachResult struct {
 	ExitCode   *int    `json:"exit_code,omitempty"`
 	ExitSignal *string `json:"exit_signal,omitempty"`
 
-	ScreenSnapshot      []byte `json:"screen_snapshot,omitempty"`
-	ScreenCols          uint16 `json:"screen_cols,omitempty"`
-	ScreenRows          uint16 `json:"screen_rows,omitempty"`
-	ScreenCursorX       uint16 `json:"screen_cursor_x,omitempty"`
-	ScreenCursorY       uint16 `json:"screen_cursor_y,omitempty"`
-	ScreenCursorVisible bool   `json:"screen_cursor_visible,omitempty"`
-	ScreenSnapshotFresh bool   `json:"screen_snapshot_fresh,omitempty"`
-
 	// GhosttySnapshot is the server-authoritative VT serialization of the whole
 	// terminal from libghostty-vt (geometry is Cols/Rows). Omitted when absent.
 	GhosttySnapshot []byte `json:"ghostty_snapshot,omitempty"`
@@ -142,6 +134,19 @@ type AttachResult struct {
 	// GhosttyScrollbackTruncated reports whether the ghostty terminal dropped
 	// scrollback lines at its cap before GhosttySnapshot was serialized.
 	GhosttyScrollbackTruncated bool `json:"ghostty_scrollback_truncated,omitempty"`
+}
+
+// SnapshotResult is the lean read-only viewport seed returned by MethodSnapshot.
+// An absent ScreenSnapshot leaves observers unseeded for graceful worker-version
+// skew and sessions that have not yet produced a frame.
+type SnapshotResult struct {
+	LastSeq        uint32 `json:"last_seq"`
+	Cols           uint16 `json:"cols"`
+	Rows           uint16 `json:"rows"`
+	Running        bool   `json:"running"`
+	ScreenSnapshot []byte `json:"screen_snapshot,omitempty"`
+	ScreenCols     uint16 `json:"screen_cols,omitempty"`
+	ScreenRows     uint16 `json:"screen_rows,omitempty"`
 }
 
 // AttachBlock is the wire form of one resolved command block (see

--- a/internal/ptyworker/protocol_test.go
+++ b/internal/ptyworker/protocol_test.go
@@ -68,6 +68,32 @@ func TestResponseEnvelopeErrorRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSnapshotResultRoundTrip(t *testing.T) {
+	original := SnapshotResult{
+		LastSeq:        42,
+		Cols:           100,
+		Rows:           30,
+		Running:        true,
+		ScreenSnapshot: []byte("rendered viewport"),
+		ScreenCols:     80,
+		ScreenRows:     24,
+	}
+	payload, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal snapshot result: %v", err)
+	}
+	var decoded SnapshotResult
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("unmarshal snapshot result: %v", err)
+	}
+	if decoded.LastSeq != original.LastSeq || decoded.Cols != original.Cols || decoded.Rows != original.Rows || decoded.Running != original.Running {
+		t.Fatalf("snapshot metadata = %+v, want %+v", decoded, original)
+	}
+	if string(decoded.ScreenSnapshot) != string(original.ScreenSnapshot) || decoded.ScreenCols != original.ScreenCols || decoded.ScreenRows != original.ScreenRows {
+		t.Fatalf("snapshot viewport = %+v, want %+v", decoded, original)
+	}
+}
+
 func TestIsCompatibleVersion(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/ptyworker/runtime.go
+++ b/internal/ptyworker/runtime.go
@@ -799,22 +799,18 @@ func (c *connCtx) handleRequest(req RequestEnvelope) {
 			c.sendError(req.ID, ErrInternal, err.Error())
 			return
 		}
-		// Screen + watermark only; scrollback/replay are intentionally omitted.
-		c.sendResult(req.ID, AttachResult{
-			LastSeq:             info.LastSeq,
-			Cols:                info.Cols,
-			Rows:                info.Rows,
-			PID:                 info.PID,
-			Running:             info.Running,
-			ScreenSnapshot:      info.ScreenSnapshot,
-			ScreenCols:          info.ScreenCols,
-			ScreenRows:          info.ScreenRows,
-			ScreenCursorX:       info.ScreenCursorX,
-			ScreenCursorY:       info.ScreenCursorY,
-			ScreenCursorVisible: info.ScreenCursorVisible,
-			ScreenSnapshotFresh: info.ScreenSnapshotFresh,
-			GhosttySnapshot:     info.GhosttySnapshot,
-		})
+		result := SnapshotResult{
+			LastSeq: info.LastSeq,
+			Cols:    info.Cols,
+			Rows:    info.Rows,
+			Running: info.Running,
+		}
+		if info.Screen != nil {
+			result.ScreenSnapshot = info.Screen.Payload
+			result.ScreenCols = info.Screen.Cols
+			result.ScreenRows = info.Screen.Rows
+		}
+		c.sendResult(req.ID, result)
 	case MethodAttach:
 		var params AttachParams
 		if len(req.Params) > 0 {
@@ -909,13 +905,6 @@ func (c *connCtx) handleRequest(req RequestEnvelope) {
 			Running:                    info.Running,
 			ExitCode:                   info.ExitCode,
 			ExitSignal:                 info.ExitSignal,
-			ScreenSnapshot:             info.ScreenSnapshot,
-			ScreenCols:                 info.ScreenCols,
-			ScreenRows:                 info.ScreenRows,
-			ScreenCursorX:              info.ScreenCursorX,
-			ScreenCursorY:              info.ScreenCursorY,
-			ScreenCursorVisible:        info.ScreenCursorVisible,
-			ScreenSnapshotFresh:        info.ScreenSnapshotFresh,
 			GhosttySnapshot:            info.GhosttySnapshot,
 			GhosttyBlocks:              attachBlocksToWire(info.GhosttyBlocks),
 			GhosttyScrollbackTruncated: info.GhosttyScrollbackTruncated,


### PR DESCRIPTION
Phase 4 of the vt10x retirement plan (`docs/plans/2026-07-24-vt10x-retirement.md`): post-retirement payload cleanup. Since Phase 3, `AttachInfo`'s two snapshot families were perfectly disjoint per method — `Attach` fills only the Ghostty dump + blocks, `Snapshot` fills only the viewport frame — so every RPC dragged the other family through four layers as permanently-zero plumbing. This PR splits them and slims the wire.

## What changed

- **Per-method payload types**: `Snapshot` now returns `pty.SnapshotInfo` (LastSeq/Cols/Rows/Running + nullable `ViewportSnapshot{Payload, Cols, Rows}`) end to end — pty, worker RPC, ptybackend interface, daemon. `AttachInfo` keeps only the attach family (Ghostty dump, blocks, scrollback-truncated). `ReplayScreenSnapshot` is renamed/absorbed into `ViewportSnapshot`.
- **Worker RPC split**: `MethodSnapshot` gets its own lean `SnapshotResult` struct instead of sharing `AttachResult`; `AttachResult` drops all `screen_*` fields. Existing graceful degradation is preserved: an absent `screen_snapshot` leaves the observer unseeded (worker-version skew, or no frame yet).
- **Wire slimming (ProtocolVersion 182 → 183)**: deleted `screen_cursor_x`, `screen_cursor_y`, `screen_cursor_visible`, and `screen_snapshot_fresh` from `get_screen_snapshot_result` and `WebSocketEvent`, plus the vestigial raw-replay `scrollback` string field. The styled VT payload is self-contained — cursor state rides inside the dump, and freshness is payload presence. No consumer read any of the deleted fields (frontend `ScreenSnapshotResult` reads only payload/cols/rows/last_seq); the legacy daemon web fallback's reads of `scrollback`/`screen_snapshot_fresh` were updated to match.
- **Daemon**: `snapshotSeedScreen` helper deleted (collapsed to a nil-check on `SnapshotInfo.Screen`); its tests replaced by handler-level tests (`handleGetScreenSnapshot` seeds from a viewport payload / leaves the observer unseeded without one). The automations unattended-launch gate reads the new `Screen.Payload` shape.
- Three-file lockstep followed: `main.tsp` edit → `make generate-types` → `ProtocolVersion` 183 in `constants.go` and `PROTOCOL_VERSION` '183' in `useDaemonSocket.ts`.
- Net −73 lines.

## Verification

- gofmt clean; `go build ./...`, `go vet ./...`, full `go test ./internal/... ./cmd/... -count=1` green; `pnpm --dir app exec tsc --noEmit` green; frontend suite green (1977 tests). Added `SnapshotResult` JSON round-trip coverage.
- Repo-wide sweep: zero remaining references to `ScreenCursor*`, `ScreenSnapshotFresh`, `screen_cursor_*`, `screen_snapshot_fresh`, or the raw `scrollback` field.
- **Live verification** on an isolated profile (`p2vt`, fresh `make install` from this head; preflight PASS, CLI/app/daemon all protocol 183):
  - Session spawn + live typing render normally.
  - `get_screen_snapshot` against the live session returns a self-contained payload whose decoded text contains the on-screen marker, with correct geometry (62x27).
  - The result message carries none of the retired fields on the wire.
