### PR TITLE
refactor(pty): carry state observations instead of bare state names

### DIFF
--- a/docs/plans/2026-07-25-agent-state-detection.md
+++ b/docs/plans/2026-07-25-agent-state-detection.md
@@ -1,0 +1,656 @@
+# Plan: near-perfect agent state detection
+
+## Goal
+
+Make session colors correct essentially all the time for Claude Code and Codex, so
+that a **settled / unsettled** attention mode can be built on top of them. Today's
+detection is right most of the time but has three reproducible failure classes:
+
+1. **Stuck states.** A state can persist forever with no live evidence behind it.
+2. **Background work.** A Claude turn that yields with `attn wait-pr` (or any
+   background Bash/Workflow) outstanding is governed by one binary rule.
+3. **Guardian flash.** Codex auto-approve routes every approval to its
+   `auto_review` guardian LLM, but attn renders the guardian's latency as a
+   user-facing `pending_approval` (yellow) for a second or two on every Bash call.
+
+Phases 0–3 are about the colors themselves and must stand on their own: they are
+worth shipping even if no attention mode ever exists.
+
+**Attention mode sits on top and is opt-in.** It is a working mode the user
+enables, off by default at release — a different projection of the same resolved
+state, never a second source of truth. The end state, with it enabled, is an agent
+that unsettles itself when it is stuck, done-and-stale, or has a question, and
+stays quiet otherwise. With it disabled, nothing about the sidebar changes except
+that the colors are right.
+
+## Why the current design produces these failures
+
+Every source calls `applyState` directly, and every source is **edge-triggered**.
+There is no level signal, no evidence TTL, and no periodic re-evaluation.
+
+```text
+Current (last-writer-wins, all edges):
+
+  claude/codex hooks ──┐
+  stop classifier ─────┤
+  transcript watcher ──┼──> applyState(sessionID, state, cause) ──> store ──> broadcast
+  pty screen scrape ───┤        (cause selects effects only;
+  plugin driver ───────┘         no arbitration between sources)
+  process exit ────────┘
+```
+
+`pending_approval` is set by an edge (`PermissionRequest` hook) and cleared by a
+different edge (`PostToolUse`, or `approvalResolver` seeing the prompt leave the
+screen). Drop either edge — hook spawn fails, the agent emits no output, the TUI
+renders an approval shape `isPendingApproval()` does not match — and the state is
+stuck with nothing in the daemon that will ever revisit it.
+
+`internal/pty/state_detector.go` is the only fallback and it is keyword matching
+over ANSI-stripped screen tails (`"allow"` + `"confirm"` + `"y/n"` …). It
+false-positives on assistant prose and false-negatives on any TUI change.
+
+## The unused signals (verified on live PTYs, 2026-07-25)
+
+Raw PTY captures of `claude` 2.1.220 and `codex`, driven through a real pty:
+
+```text
+claude:  ESC ] 0 ; ⠐ Run background sleep command BEL   <- braille spinner = turn RUNNING
+         ESC ] 0 ; ✳ Run background sleep command BEL   <- U+2733 = turn NOT running
+         ESC ] 777 ; notify ; Claude Code ; Claude is waiting for your input BEL
+
+codex:   ESC ] 0 ; ⠸ attn--fix-state-detec... BEL       <- spinner prefix = busy
+         ESC ] 0 ; attn--fix-state-detec... BEL         <- bare cwd = idle
+```
+
+- **OSC 0 title glyph is a level, refreshed ~1Hz, emitted by the harness itself.**
+  Braille block (U+2800–U+28FF) = running; `✳` (claude) / no glyph (codex) = not
+  running. A level that stops arriving cannot get stuck — though the spike below
+  shows it goes briefly silent mid-tool, which is why it corroborates rather than
+  leads.
+- **OSC 777 is Claude's explicit settle event.** In the background-task capture it
+  did *not* fire while the background task was outstanding; the turn auto-resumed
+  on completion and settled afterwards.
+- The title also carries a live turn summary ("Run background sleep command") —
+  a free sidebar label with no LLM call.
+
+attn parses OSC 133 in `internal/pty/blockfeed.go` and ignores OSC 0 / 777
+entirely. Unwired hooks: Claude **`Notification`** (fires on permission-needed and
+on 60s-idle-waiting), `SessionEnd`, `SubagentStop`; Codex's `notify` program
+(`agent-turn-complete`).
+
+## Spike results (2026-07-25)
+
+Throwaway spike in `internal/pty/spike_state_replay_test.go` and
+`internal/pty/spike_resolver_test.go` (both skip unless `ATTN_SPIKE_CAPTURES` is
+set). Nine scripted `claude`/`codex` sessions were driven through a real PTY with
+byte-level timestamps, while a parallel hook log recorded what the harness itself
+believed — independent ground truth. Detectors were replayed against it at 200ms
+resolution. Codex hook truth needed attn's own trusted-hash overrides, emitted by
+`internal/hooks/spike_codex_overrides_test.go`.
+
+Ground truth comes from hooks, so any hook-driven detector scores well by
+construction. Two things had to be corrected before the numbers meant anything:
+hooks were rebased onto the stream clock by anchoring the first `UserPromptSubmit`
+to the scripted keystroke (`SessionStart` fires seconds late and varies), and a
+`PermissionRequest` under an automated reviewer was relabelled as tool execution
+rather than a user-facing approval — the guardian resolves it in milliseconds and
+there is no hook at the moment it does.
+
+| capture | current (screen scrape) | OSC heartbeat only |
+|---|---|---|
+| `run_approval` (auto mode) | 85.6%, worst wrong streak 13.2s | 95.3%, 3.0s |
+| `run_approval2` (real 27.5s approval) | 15.7%, **43.4s** | 67.0%, 27.6s |
+| `run_bg` (background task) | 71.4%, 11.4s | 93.6%, 3.0s |
+| `run_quiettool` (38s background) | 71.5%, 15.2s | 93.4%, 2.6s |
+| `run_claude_fg` (7.4s foreground tool) | 73.4%, 21.8s | 95.1%, 2.4s |
+| `run_codex_fg` (35.1s foreground tool) | **1.0%**, 40.2s | **99.0%**, 0.4s |
+| `run_falsepos` (prose only) | 16.0%, 13.6s | 81.5%, 2.6s |
+| `run_interrupt` | 36.9%, 15.4s | 91.0%, 2.2s |
+
+What the numbers mean:
+
+- **The heartbeat is real.** Claude emits a spinner frame every 0.97s (max
+  observed gap 0.97s); codex every 0.102s (max gap 0.15s). It tracks harness truth
+  to within ~100ms: the spinner appears **+0.02s to +0.08s** after
+  `UserPromptSubmit`, and the idle glyph lands within **+0.11s** of `Stop`.
+- **A long foreground tool breaks a heartbeat-only design.** When Claude starts a
+  blocking foreground Bash call it sets the title to ✳ and **emits nothing for
+  3.5s** before the spinner resumes. (Codex does not: through a 35.1s blocking
+  `sleep`, it emitted 300 consecutive busy frames, max gap 0.125s.) That produces a
+  false *settled* mid-turn, and the TTL sweep shows no value escapes it:
+
+  | TTL | correct | worst wrong streak | mean late-settle | **worst false-settle** |
+  |---|---|---|---|---|
+  | 0 (idle glyph as an edge) | 76.4% | 40.0s | 0.05s | 40.0s |
+  | 0.5s | 92.2% | 3.8s | 0.30s | 3.8s |
+  | 1.0s | **97.8%** | 3.4s | 0.70s | 3.4s |
+  | 2.0s | 96.1% | 2.4s | 1.70s | 2.4s |
+  | 3.0s | 94.5% | 3.0s | 2.70s | 1.4s |
+  | 4.0s | 93.0% | 4.0s | 3.70s | 0.4s |
+  | 5.0s | 91.4% | 5.0s | 4.70s | 0.2s |
+
+  Killing the false settle needs TTL ≥ 4s, which costs 3.7s of late settle and 5pp
+  of accuracy. **There is no good TTL, so the heartbeat is not a detector on its
+  own.** TTL=0 is also ruled out independently: the title blips idle mid-turn even
+  without a tool (✳ at 14.25s, spinner again at 14.28s).
+- **Title hijack does not break it.** Injecting a competing `ESC]0;victor@mac: ~`
+  every 2s, and a continuous `ESC]0;htop` repaint for 30s, moved accuracy by
+  +0.2pp (93.8% → 94.0%). The resolver keys on *the presence of spinner frames*,
+  not on the last title's content, so a subprocess overwriting the title is simply
+  ignored while the agent keeps painting.
+- **The current detector's failures reproduce exactly as reported.** On
+  `run_approval2` it claimed `working` for **43.4 continuous seconds** after the
+  turn had stopped — the stuck-green bug, on tape. On `run_falsepos` it emitted
+  `pending_approval` for 8.2s with no approval anywhere in the session; the trigger
+  was **the user's own typed prompt** echoed in the input box, containing the words
+  "Do you want to proceed? 1. Yes 2. Yes, and don't ask again". Typing about
+  approvals, pasting one, or reviewing code that renders one turns a session
+  yellow today. These states reach the store: `handlePTYState` applies them as
+  `liveSignal` with no arbitration against the hooks they contradict.
+- **The OSC signal cannot see approvals, and should not.** During an approval the
+  title goes idle — the agent genuinely is not running. `run_approval2`'s 27.6s
+  worst streak *is* the approval window. Approvals stay hook-owned. The valuable
+  part is the other edge: the spinner resumes **+0.05s** after the approval is
+  granted, which is a far better "approval resolved" signal than today's
+  `approvalResolver` waiting for the prompt to vanish from the screen.
+- **Background work confirmed.** In `run_quiettool` the title went idle at 16.0s
+  (0.11s after `Stop`) and then emitted **nothing at all for 38 seconds** while
+  the background task ran, resuming 0.05s after the auto-resume. The heartbeat
+  correctly reports "not thinking"; green during that window must come from the
+  Stop payload's `background_tasks`, as planned.
+
+- **What the heartbeat is actually for: bounding stuck states.** Since hook-derived
+  truth makes a hook-driven detector score 100% by construction, the honest
+  experiment is the failure mode that bites in production — a **lost hook** (spawn
+  failure, socket error, an event the agent never fires). Dropping hooks at
+  increasing rates, averaged over 20 seeds per capture
+  (`spike_resolver_test.go`, TTL 1.0s, staleAfter 4.0s):
+
+  | hooks dropped | hooks only | hooks + heartbeat |
+  |---|---|---|
+  | 0% | 100.0%, worst streak 0.0s | 98.5%, worst **1.0s** |
+  | 5% | 98.3%, worst **60.0s** | 98.3%, worst **3.8s** |
+  | 10% | 94.9%, worst 60.2s | 97.2%, worst 27.6s |
+  | 25% | 84.6%, worst 60.2s | 95.9%, worst 27.6s |
+  | 50% | 70.9%, worst 60.2s | 93.1%, worst 43.4s |
+
+  One dropped `Stop` strands a hooks-only design green **for the rest of the
+  session** (60s = the remainder of the capture). Adding the heartbeat cuts that
+  stuck window to 3.8s — a 16x reduction — at a cost of 1.5pp of steady-state
+  accuracy when hooks are perfect. That trade is the whole point: the heartbeat
+  does not make the common case more accurate, it makes the bad case bounded.
+  The hybrid's residual 27.6s/43.4s streaks are approval windows, where a dropped
+  `PermissionRequest` leaves nothing to recover from.
+
+Two incidental findings worth keeping:
+
+- Victor's global `~/.claude/settings.json` sets `defaultMode: auto`, so Claude
+  already runs a permission classifier on every session attn launches.
+  `ReviewerInLoop` therefore cannot be inferred from attn's launch flags alone —
+  it must account for the resolved permission mode. Measured guardian round trip:
+  `PermissionRequest` → `PostToolUse` in **90ms** (the Claude analogue of the Codex
+  flash).
+- Claude's `Notification` hook fires **6s after** `PermissionRequest` for
+  permission, and exactly **60s after** `Stop` when idle. It is a useful
+  corroborator, not a low-latency trigger.
+
+## Target architecture: evidence table + pure resolver
+
+Sources stop commanding state. They record observations; a pure function resolves
+them; a tick re-runs the resolver so evidence expires.
+
+```text
+Target:
+
+  hook brackets (turn/tool open) ──> recordEvidence(level)   ┐
+  approval edge ──────────────────> recordEvidence(edge)     │
+  OSC 0 title heartbeat ──────────> recordEvidence(level)    ├──> sessionEvidence
+  OSC 777 / Notification ─────────> recordEvidence(edge)     │      (per session)
+  stop classifier ────────────────> recordEvidence(edge)     │
+  process exit ───────────────────> recordEvidence(level)    ┘          │
+                                                                        v
+                          tick (1s) ──────────────> resolve(evidence, now) -> state
+                                                                        │
+                                                           dwellGate(state, policy)
+                                                                        │
+                                                                        v
+                                                       applyState(cause: resolver)
+```
+
+`applyState` stays the single store door; the resolver becomes its only live-signal
+caller. Cause-specific paths that are already ordered and authoritative (plugin
+driver CAS, startup recovery, process exit) keep their existing routes.
+
+**The spike inverted the original hierarchy.** This plan first had the heartbeat as
+the primary level with hooks explaining *why* a turn stopped. The measurements say
+the reverse: hook brackets are the level (they are the only signal that survives a
+3.5s mid-tool title silence), and the heartbeat's job is to bound how long a
+bracket may lie.
+
+```text
+resolve(evidence, now):
+  if process exited                              -> idle (terminal)
+  if heartbeat fresh (now - lastBusy <= TTL)     -> working   # recovers a LOST turn-open hook
+  if approval edge open and not ReviewerInLoop   -> pending_approval
+  if pendingCron                                 -> scheduled
+  if turnOpen or toolOpen:                       # bracket says work is outstanding
+      if heartbeat silent > staleAfter           -> settled   # closing hook LOST: un-stick
+      else                                       -> working
+  if backgroundWork                              -> working   (settled; Victor's call)
+  if settle edge + classifier verdict            -> waiting_input | idle
+  if no movement > stuckAfter                    -> unknown, reason=stuck
+  otherwise                                      -> unknown
+```
+
+Two clauses do the real work and neither exists today: `heartbeat fresh` rescues a
+lost turn-open hook, and `heartbeat silent > staleAfter` closes a bracket whose
+closing hook never arrived. Measured together, they take the worst stuck window
+from "the rest of the session" to under 4 seconds. Starting values: TTL 1.0s,
+`staleAfter` 4.0s.
+
+Screen scraping is **deleted for claude and codex**, not demoted to a fallback. It
+scored 1.0% on a codex foreground tool and manufactures false `pending_approval`
+from ordinary text; keeping it as a tiebreaker would reintroduce both. Agents with
+no harness signals (copilot) keep it until they have some.
+
+## Data model
+
+```go
+// internal/sessionstate (new package, pure, no daemon imports)
+
+type Source string
+const (
+    SourceHarnessEvent Source = "harness_event"   // hooks, OSC 777, Notification
+    SourceHeartbeat    Source = "heartbeat"       // OSC 0 title glyph
+    SourceClassifier   Source = "classifier"      // stop-time LLM
+    SourceBracket      Source = "hook_bracket"    // turn/tool open-close, PRIMARY level
+    SourceScreen       Source = "screen"          // pty scrape — copilot only, deleted for claude/codex
+    SourceProcess      Source = "process"         // exit / no pty
+)
+
+// One recorded observation. Level observations are refreshed continuously and
+// expire; edge observations are one-shot facts that stay until superseded.
+type Observation struct {
+    Source     Source
+    Claim      Claim      // busy | settled | approval_pending | needs_input | exited | ...
+    Detail     string     // turn summary, notify message — diagnostics + sidebar label
+    ObservedAt time.Time
+}
+
+// Everything the resolver may read for one session. Owned by the daemon,
+// mutated only through record(); the resolver never touches the store.
+type Evidence struct {
+    Heartbeat        *Observation // level, TTL 1.5s claude / 0.5s codex (measured)
+    LastHarnessEvent *Observation // edge
+    LastClassifier   *Observation // edge
+    TurnOpen         bool         // UserPromptSubmit seen, no Stop yet  (level)
+    ToolOpen         bool         // PreToolUse seen, no PostToolUse yet  (level)
+    Screen           *Observation // level; copilot only
+    Process          *Observation // level, no TTL
+    BackgroundWork   bool         // from Stop payload background_tasks
+    PendingCron      bool         // from Stop payload session_crons
+    ReviewerInLoop   bool         // codex auto_review / claude --permission-mode auto
+    LastMovement     time.Time    // any evidence change; drives stuck detection
+}
+
+type Resolution struct {
+    State  protocol.SessionState
+    Reason string     // why this state — surfaced by `attn state explain`
+    Unsettles bool    // derived attention projection
+}
+
+func Resolve(e Evidence, now time.Time) Resolution   // pure, table-tested
+```
+
+Resolution order (first match wins):
+
+See the `resolve` pseudocode above for the ordered rules. The property that
+matters: every clause that can hold a state green depends on evidence that either
+refreshes (heartbeat, bracket) or expires, and the resolver re-runs on a tick — so
+no state can outlive its evidence. That is the structural fix for the stuck class,
+and the hook-drop table above is the measurement of it.
+
+## Dwell policy
+
+A transition *into* an attention-demanding state must hold before it is published.
+Keyed on **who is being asked first**:
+
+```go
+func dwellFor(state protocol.SessionState, e Evidence) time.Duration {
+    if state == protocol.SessionStatePendingApproval && e.ReviewerInLoop {
+        return guardianDwell // 60s; cancelled by the next PreToolUse/PostToolUse
+    }
+    return 0                 // no reviewer: the user IS the reviewer, publish now
+}
+```
+
+`ReviewerInLoop` is known at launch: `internal/agent/codex.go` passes
+`approvals_reviewer="auto_review"`, `internal/agent/claude.go` passes
+`--permission-mode auto`. It must be persisted with the session so the daemon can
+read it at resolve time.
+
+This removes the Codex guardian flash without delaying a genuine approval request
+by a single millisecond.
+
+## Attention projection (settled / unsettled) — opt-in layer
+
+A **projection of the resolved state**, not a new state and not a second
+resolver. It is gated behind a user-enabled working mode (off by default at
+release); with the mode off, `Resolution.Unsettles` is computed but nothing in
+the UI consumes it. Nothing in phases 0–3 may depend on the mode being on.
+
+- **Unsettled**: `waiting_input`, post-dwell `pending_approval`, `unknown` with
+  reason `stuck`, crashed/failed, and `idle` that has gone unread past
+  `idleStaleAfter` (generalizes today's `needs_review_after_long_run`).
+- **Settled**: `working` (including background-work and Monitor-armed turns),
+  `scheduled`, `recoverable`, fresh `idle`.
+
+## Boundaries
+
+- `internal/pty` owns byte-level extraction only: OSC 0 title and OSC 777 are
+  parsed where OSC 133 already is (`blockfeed.go` / `boundary.go`) and surfaced
+  through the existing `s.onState` channel (`internal/pty/session.go:360`),
+  widened from `string` to a typed observation. It must not know about
+  `protocol.SessionState` or dwell.
+- `internal/sessionstate` owns `Resolve` and `dwellFor`. Pure, no daemon or store
+  imports, table-tested against recorded evidence traces.
+- `internal/daemon` owns the evidence table, the tick, and the single call into
+  `applyState`. It must not re-implement resolution rules inline.
+- `internal/classifier` keeps its charter unchanged (LLM only, no keyword
+  heuristics) and now answers a narrower question: given a settled turn, is it
+  `idle` or `waiting_input`.
+
+## Refactoring opportunities and tech debt
+
+Two lists. The first are **enabling refactors**: doing them first makes the fix a
+small diff instead of a large one, and each is behavior-preserving on its own. The
+second is debt that the fix should clear on its way past, so we do not leave two
+generations of state logic side by side.
+
+### Enabling refactors (do before the behavior change)
+
+1. **Widen the PTY→daemon state channel from a bare string.**
+   `session.onState func(state string)` (`internal/pty/session.go:136`, wired at
+   `internal/pty/manager.go:350`) is the only way anything the PTY sees reaches the
+   daemon, and it carries a state name with no source, no observation time, and no
+   reason. The evidence table needs all three. Widen it to a small
+   `Observation{Source, Claim, Detail, At}` — mechanically, no behavior change —
+   and every later phase becomes additive. Skipping this forces the heartbeat to
+   masquerade as a `working` string, which is exactly the flattening that caused
+   the current mess.
+
+2. **Let the agent driver own its detectors instead of `manager.go` switching on
+   the agent name.** The per-agent fact is encoded twice today: `HasStateDetector`
+   / `HasApprovalResolver` booleans in `internal/agent/{claude,codex,copilot}.go`,
+   plus a `switch agent { case "copilot": ... case "claude": ... }` in
+   `internal/pty/manager.go:338-345`. Adding an OSC heartbeat detector means
+   editing both again, and the two can silently disagree (a driver with the
+   capability set but no case in the switch gets nothing, no error). Have the
+   driver return its observers; delete the booleans and the switch.
+
+3. **Collapse the two identical screen detectors.** `copilotStateDetector` and
+   `claudeWorkingDetector` (`internal/pty/state_detector.go:42-60`) have the same
+   three fields, duplicate the 2000-char tail trim, and duplicate the
+   working-pulse debounce. One `screenDetector` with an injected classify function
+   makes the claude path a single deletion later instead of a careful unpick of a
+   560-line file.
+
+4. **Move the Stop-hook state decision out of the CLI into the daemon.**
+   `nonTerminalStopState` (`cmd/attn/main.go:114-139`) decides `working` /
+   `scheduled` / classify inside the hook binary — and to do it, `runHookStop`
+   makes a socket round-trip *to the daemon* to ask whether the session is chief of
+   staff (`sessionIsChiefOfStaff`, `cmd/attn/main.go:3222`), then sends the answer
+   back. The daemon already has every input. This one is load-bearing, not
+   cosmetic: the resolver cannot see `BackgroundTasks` or `SessionCrons` as
+   evidence because the CLI collapses them into a state string before they cross
+   the socket. The hook should report the facts; the resolver decides.
+
+5. **Split `classifySessionState` into a pure decision plus an IO shell.**
+   `internal/daemon/daemon.go:2510-2640` is ~130 lines with six `applyState` exits
+   interleaved with capability gates, todo counting, transcript path resolution,
+   file IO, and a 30-second LLM call. It is already a resolver, written as control
+   flow, so the decision can only be tested by standing up a daemon. Extracting
+   the pure part is how Phase 2's `Resolve` absorbs it rather than sitting beside
+   it as a seventh writer.
+
+### Debt to clear while passing through
+
+- **`ShouldApplyPTYState` is a distributed veto that exists only because there is
+  no arbitration, and should be demolished, not ported.** Three drivers each
+  implement a transition filter (`claude.go:584`, `codex.go:484`,
+  `copilot.go:104`) whose comments say so outright — Claude's guards `scheduled`
+  because the detector "would otherwise silently knock the session out"; Codex's
+  allows exactly one transition and rejects all others. That is last-writer-wins
+  being patched per agent at the point of impact. Once the resolver owns
+  precedence, this interface has no reason to exist. Call it out explicitly so a
+  future reader does not preserve it out of caution.
+- **Codex's entire PTY path is one workaround that the heartbeat removes.** Codex
+  has `HasStateDetector: false` but `HasApprovalResolver: true` — the only thing
+  it scrapes for is the approval prompt leaving the screen, because no hook fires
+  when a permission request is approved. The spinner resuming 0.05s later is a
+  better signal from the same stream. Deleting `approval_resolver.go`'s 750ms
+  absence debounce also deletes Codex's `ShouldApplyPTYState`, its capability
+  flag, and its share of `state_detector.go`.
+- **`defaultStateHeuristics.requestPhrases` matches ordinary English.** `"can
+  you"`, `"could you"`, `"do you want"` (`internal/pty/state_detector.go:26-38`)
+  fire on the user's own prompt text echoed in the pane — the measured 16.0%
+  capture. Goes away with the claude scraper; worth naming so nobody tries to
+  tune the list instead.
+- **The todo fast-path is stale-evidence logic of the exact kind we are
+  removing.** `pendingCount > 0 → waiting_input` (`daemon.go:2540-2549`) reads an
+  untimestamped level (the todo list) at a settle edge and wins over everything
+  after it. A session with a forgotten pending todo reads `waiting_input` forever.
+  It should become one evidence row with a TTL, not a fast path.
+- **`internal/pty` re-declares the state enum.** `stateWorking` / `stateIdle` /
+  `statePendingApproval` / `stateWaitingInput` as local string consts
+  (`state_detector.go:9-14`) shadow `protocol.State*`. Two vocabularies for one
+  enum, and a typo in either is a silent no-op rather than a compile error. Use
+  the protocol constants.
+- **State handling has no home.** It is spread across `handlePTYState`,
+  `classifySessionState`, startup recovery, and process exit inside a 3879-line
+  `daemon.go`, plus the CLI hook paths in a 3480-line `main.go`. Phase 2's
+  `internal/sessionstate` should be where the decision lives, with `daemon.go`
+  keeping only the wiring.
+
+### Found while implementing (not yet decided)
+
+Logged as encountered so Victor can decide whether to clean them; nothing here is
+being fixed as part of the current step.
+
+- **The same state stream is deduped twice, with different rules.**
+  `internal/ptyworker/runtime.go:191` drops an observation whose claim equals the
+  previous one (`changed := previousState != state`), then
+  `shouldForwardStateLocked` (`internal/ptybackend/worker.go:166`) dedupes again
+  with a `working`-pulse exemption the first layer does not have. Two suppressors
+  in series over one stream, neither aware of the other.
+- **That dedup is why `approvalResolver` re-emits `pending_approval` it did not
+  observe.** Its own type comment (`internal/pty/approval_resolver.go:13-20`)
+  explains it: the onset hook bypasses the worker, so without a redundant
+  re-emission the later `working` clear "would look unchanged to the worker and
+  never be forwarded". A source-blind dedup is being worked around by fabricating
+  an observation. Once observations carry a source, dedup should be per-source or
+  gone — and the fabricated re-emit deleted with it.
+- **The worker fabricates `working` when it does not know its state, and it does
+  so for every session.** `internal/ptyworker/runtime.go` defaults an empty cached
+  state to `"working"` when a new watcher subscribes. Confirmed live on profile
+  `statedet` (2026-07-25): the *first* observation the daemon logs for a fresh
+  session is `state=working source=worker_info detail="watch subscribe replay"` —
+  including for `agent=shell`, which has no detector at all and therefore cannot
+  have been observed working. Inventing green out of ignorance is precisely the
+  stuck-green failure class; it should report `unknown` or send nothing.
+  Cosmetically invisible today because a spawn is green anyway, but it means every
+  session's evidence table would open with a false row.
+- **`TestDaemon_StopCommand_PendingTodos_SetsWaitingInput` races the reaper.**
+  It waits for async classification with a bare `time.Sleep(200ms)`
+  (`internal/daemon/daemon_test.go:4837`) on a session that has no PTY, so under
+  the sharded suite's load the recovery/reaping loop can demote it to
+  `recoverable` first and the assertion reads that instead of `waiting_input`.
+  Seen once in a 5-shard `make test` run, not reproducible standalone
+  (`-count 3` green). Pre-existing and orthogonal to observations — but it is the
+  same underlying design problem as the product bug: two writers with no
+  arbitration, resolved by whoever gets there first.
+- **`handlePTYState` discards the observation time.** The store timestamps the
+  transition with its own clock, so an observation delayed in the worker→daemon
+  hop is recorded as if it just happened. Harmless today; it stops being harmless
+  once TTLs are measured against `At`.
+
+## Implementation steps
+
+### Phase 0 — instrumentation (ship first, no behavior change)
+
+- [ ] Per-session ring buffer of state observations: `(source, claim, detail, at,
+      resolved_state)`, capped, in memory, dumped to the daemon log on transition.
+- [ ] `attn state explain <session>` — replay the ring and show why the current
+      color is what it is. Makes "sometimes it gets stuck" falsifiable.
+- [ ] Record from every existing source *without* changing arbitration, so the
+      current behavior is captured as a baseline trace.
+- [x] Enabling refactor 1: widen `session.onState` to carry
+      `Observation{Source, Claim, Detail, At}`. Behavior-preserving; every later
+      phase is additive on top of it. Landed as `internal/pty/observation.go` plus
+      additive `state_source`/`state_detail`/`state_observed_at` fields on the
+      worker RPC's `EventStateChanged` (no RPC bump — an older worker omits them
+      and the daemon reads `SourceUnknown` observed on arrival). `handlePTYState`
+      now logs source/detail/observed-at. Live-verified on profile `statedet` with
+      a real Claude session (`real-app:scenario-tr402-local-claude`): states still
+      flow and now arrive attributed.
+
+### Phase 1 — wire the harness signals
+
+- [ ] Parse OSC 0 in the worker; classify the glyph prefix (braille block = busy,
+      `✳`/bare = not busy) per agent; expose title text as `Detail`.
+- [ ] Parse OSC 777 `notify` (Claude settle event).
+- [ ] Add the Claude `Notification` hook to `internal/hooks/hooks.go`, routed to a
+      new `_hook-notification` command, carrying the notification `message`
+      verbatim as evidence detail. It is harness-owned and fires on both branches
+      we care about — ~6s after a permission request, and exactly 60s after a Stop
+      that settled idle — so it is a first-class source, not a backstop.
+- [ ] Persist `ReviewerInLoop` on the session at spawn.
+- [ ] Enabling refactors 2 and 3: driver-owned observers (drop the capability
+      booleans and the agent-name switch in `manager.go`), and one `screenDetector`
+      in place of the two identical structs. Needed here because this phase adds a
+      third observer per agent.
+- [ ] Enabling refactor 4: the Stop hook reports `background_tasks` /
+      `session_crons` as facts; `nonTerminalStopState` and `sessionIsChiefOfStaff`
+      move daemon-side. Without this the resolver cannot see background work at
+      all.
+- [ ] Feed all of the above into the Phase 0 ring only; still no arbitration
+      change. Compare traces against the baseline.
+
+### Phase 2 — resolver
+
+- [ ] New `internal/sessionstate` with `Evidence`, `Resolve`, table tests built
+      from Phase 1 traces.
+- [ ] Enabling refactor 5: extract `classifySessionState`'s decision into
+      `Resolve` (todo level and capability gates become evidence rows), leaving a
+      thin IO shell. Six `applyState` exits collapse to one.
+- [ ] Daemon evidence table + 1s tick; route live signals through the resolver
+      into `applyState` with a new `resolverObservation` cause.
+- [ ] Gate `internal/pty/state_detector.go` to copilot only; delete the keyword
+      lists and `approval_resolver.go`'s screen-absence debounce for claude/codex.
+- [ ] Delete `ShouldApplyPTYState` and all three driver implementations — the
+      resolver now owns precedence. Verify each vetoed transition the comments
+      describe is covered by a `Resolve` table test first (Claude's `scheduled`
+      park, Codex's approval-clear, Copilot's two-state whitelist).
+- [ ] Replace `internal/pty`'s shadow state consts with `protocol.State*`.
+
+### Phase 3 — policy
+
+- [ ] Dwell gate + `guardianDwell`.
+- [ ] Stuck detection (`stuckAfter`, reason surfaced in the UI).
+- [ ] `idleStaleAfter` staleness marking, folding in
+      `needs_review_after_long_run`. Marked in phase 3; only *consumed* as an
+      unsettle trigger by phase 4.
+
+Phases 0–3 are shippable on their own and are judged on one question: are the
+colors right?
+
+### Phase 4 — attention mode (opt-in working mode)
+
+**Not planned yet — deliberately.** Victor's call, 2026-07-25: phases 0–3 are the
+groundwork and are judged on colors alone, and phase 4 needs his full vision
+written down before it is worth designing. The only constraint phases 0–3 must
+respect: the projection is derived from `Resolve`'s output, so nothing below phase
+4 may introduce a second notion of "needs attention". Sketch of what exists today
+so far (`Resolution.Unsettles` on the wire, a setting, sidebar grouping) is
+placeholder only; do not implement against it.
+
+## Decisions
+
+- **A yielded turn with background work stays `working`/green** rather than
+  getting its own state. Victor's call, 2026-07-25: it keeps the state set and the
+  protocol unchanged, and under the attention projection it is settled either way,
+  so the extra state would buy only a color distinction. Revisit if a long
+  `attn wait-pr` reads as misleadingly active in practice.
+- **Done is settled, but goes stale.** An unread idle result unsettles past
+  `idleStaleAfter` so work Victor drove is never silently forgotten. Strict
+  "always settled" was rejected for that reason.
+- **Attention mode is a projection behind a user setting, not a state.** Victor's
+  call, 2026-07-25: it ships as an optional working mode on top of correct colors,
+  off by default. Keeping it a pure projection of `Resolve` means the two can never
+  disagree, and phases 0–3 deliver value with the mode permanently off.
+- **Instrumentation ships before any behavior change.** The failure modes are
+  intermittent; without a replayable per-session trace there is no way to prove a
+  stuck case is gone rather than merely rarer.
+- **The dwell is keyed on the reviewer, not on a global timer.** Delaying all
+  `pending_approval` transitions would slow real approval requests; gating only on
+  `ReviewerInLoop` targets exactly the guardian case.
+- **The heartbeat TTL is per-agent, not global.** Measured frame intervals differ
+  by 10x (claude 0.97s, codex 0.102s). A single global TTL either flickers on
+  claude or settles needlessly late on codex.
+- **The heartbeat, not the screen, clears an approval.** The spinner resumes 0.05s
+  after an approval is granted. `approvalResolver`'s screen-absence debounce is
+  replaced by "approval edge outstanding AND heartbeat went busy again", which is
+  the stuck-yellow fix.
+- **Hook brackets are the level; the heartbeat bounds how long a bracket may
+  lie.** Reversed after the spike. The TTL sweep falsified heartbeat-as-detector:
+  no single TTL gives both a fast settle and no false-settle, because claude's
+  title goes silent 3.5s mid-tool. `turnOpen`/`toolOpen` carry "work is
+  outstanding"; the heartbeat's job is `staleAfter` — a bracket open with a silent
+  heartbeat means a closing hook was lost, so settle anyway.
+- **The heartbeat is still authoritative for *whether* a turn runs, never for
+  *why* it stopped.** A fresh heartbeat outranks everything but process exit
+  (it recovers a lost `UserPromptSubmit`); the settle-reason rules only run when
+  it is quiet.
+- **The heartbeat buys stuck-bounding, not accuracy.** With hooks perfect it
+  *costs* 1.5pp. At 5% hook loss it cuts the worst stuck streak from 60.0s to
+  3.8s. That trade is the whole point — the reported bug is stuck colors, not
+  average error.
+- **Approvals depend on hooks, with no fallback.** Victor's call, 2026-07-25. The
+  heartbeat structurally cannot corroborate an approval (the agent genuinely is
+  not running), which is why the hybrid's residual 27.6s/43.4s worst streaks are
+  all approval windows. Rather than build a fallback that would have to guess, we
+  accept `PermissionRequest` + `Notification` as the approval source of truth. A
+  dropped approval hook is bounded by the settle rules, not by a scraper.
+- **Screen scraping is deleted for claude and codex, not demoted to a fallback.**
+  It scores 1.0% on a 35s foreground tool and invents `pending_approval` from
+  Victor's own prose. A fallback that wrong would poison the evidence table
+  whenever it was consulted. Copilot keeps it until it has harness signals.
+
+## Open questions
+
+- Does Claude emit OSC 777 for permission prompts, or only for turn settle? Not
+  observed in the captures. Either way the `Notification` hook covers it, so this
+  only affects how fast the approval evidence arrives (OSC would be immediate, the
+  hook is ~6s).
+- Codex has no notification OSC. Its `notify` program config
+  (`agent-turn-complete`) is the analogue; confirm it fires for approval requests
+  too, or accept hooks-only for Codex settle detection.
+- Heartbeat TTL was measured on an idle machine (claude 0.97s frame interval,
+  codex 0.102s). A busy PTY under backpressure may batch chunks and stretch the
+  gap. The per-agent TTLs above carry ~55% and ~5x margin respectively; confirm
+  under a loaded matrix run before locking them in.
+
+## Follow-ups
+
+- Delete the three spike files once Phase 0 instrumentation replaces them as the
+  way to get traces: `internal/pty/spike_state_replay_test.go`,
+  `internal/pty/spike_resolver_test.go`,
+  `internal/hooks/spike_codex_overrides_test.go`. They are committed so the
+  measurements above stay reproducible, and all three skip unless their env var is
+  set. `spike_codex_overrides_test.go` is the one worth keeping longer: it reaches
+  into the production trusted-hash computation to wire arbitrary codex hooks, which
+  is how any future codex hook test gets ground truth.
+
+- Use the OSC 0 turn summary as a live sidebar label.
+- Copilot CLI is out of scope here; it keeps the screen-scrape path until it has
+  its own harness signals.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1747,7 +1747,11 @@ func (d *Daemon) dropSessionRecord(sessionID string) {
 	d.store.Remove(sessionID)
 }
 
-func (d *Daemon) handlePTYState(sessionID, state string) {
+// handlePTYState applies one PTY-layer observation. It is still last-writer-wins
+// against the other sources; the observation's source/detail/observation-time are
+// carried so the resolver can arbitrate once it exists, and are logged meanwhile.
+func (d *Daemon) handlePTYState(sessionID string, obs pty.Observation) {
+	state := obs.Claim
 	session := d.store.Get(sessionID)
 	if session == nil {
 		return
@@ -1762,7 +1766,10 @@ func (d *Daemon) handlePTYState(sessionID, state string) {
 		return
 	}
 
-	d.logf("pty state update: session=%s agent=%s state=%s", sessionID, agent, state)
+	d.logf(
+		"pty state update: session=%s agent=%s state=%s source=%s detail=%q observed_at=%s",
+		sessionID, agent, state, obs.Source, obs.Detail, obs.At.Format(time.RFC3339Nano),
+	)
 	d.applyState(sessionStateChange{
 		sessionID: sessionID,
 		state:     state,

--- a/internal/daemon/plugin_driver_test.go
+++ b/internal/daemon/plugin_driver_test.go
@@ -777,7 +777,7 @@ func TestPluginDriverRun_IgnoresGenericPTYState(t *testing.T) {
 		t.Fatal("failed to begin plugin-owned state run")
 	}
 
-	d.handlePTYState("plugin-state-owner", protocol.StateWorking)
+	d.handlePTYState("plugin-state-owner", screenObs(protocol.StateWorking))
 	if got := d.store.Get("plugin-state-owner").State; got != protocol.SessionStateWaitingInput {
 		t.Fatalf("state=%q after generic PTY event, want plugin-owned waiting_input", got)
 	}

--- a/internal/daemon/session_state_characterization_test.go
+++ b/internal/daemon/session_state_characterization_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/pty"
 	"github.com/victorarias/attn/internal/ptybackend"
 )
 
@@ -103,7 +104,7 @@ func TestSessionStateCharacterization_LiveSignalsShareEffects(t *testing.T) {
 			agent:        protocol.SessionAgentClaude,
 			initialState: protocol.SessionStateWaitingInput,
 			apply: func(d *Daemon, id string) {
-				d.handlePTYState(id, protocol.StateWorking)
+				d.handlePTYState(id, screenObs(protocol.StateWorking))
 			},
 		},
 	} {
@@ -286,5 +287,17 @@ func TestSessionStateCharacterization_ProcessExitEffects(t *testing.T) {
 	}
 	if got := characterizationEventCount(events, protocol.EventSessionExited, ""); got != 1 {
 		t.Fatalf("session_exited events=%d, want 1; events=%+v", got, events)
+	}
+}
+
+// screenObs builds the observation the screen detector would send for state.
+// These tests exercise the daemon's handling of a PTY observation, not the
+// observation's own construction.
+func screenObs(state string) pty.Observation {
+	return pty.Observation{
+		Source: pty.SourceScreen,
+		Claim:  state,
+		Detail: "test",
+		At:     time.Now(),
 	}
 }

--- a/internal/daemon/transcript_watcher_test.go
+++ b/internal/daemon/transcript_watcher_test.go
@@ -30,7 +30,7 @@ func TestHandlePTYState_CodexIgnoresPTYState(t *testing.T) {
 			LastSeen:       nowStr,
 		})
 
-		d.handlePTYState(id, state)
+		d.handlePTYState(id, screenObs(state))
 		if got := d.store.Get(id); got.State != protocol.SessionStateIdle {
 			t.Fatalf("codex %s PTY state should be ignored, got=%s", state, got.State)
 		}
@@ -55,13 +55,13 @@ func TestHandlePTYState_CodexWorkingDoesNotOverrideStoppedStates(t *testing.T) {
 	}
 
 	addCodexSession("codex-idle", protocol.SessionStateIdle)
-	d.handlePTYState("codex-idle", protocol.StateWorking)
+	d.handlePTYState("codex-idle", screenObs(protocol.StateWorking))
 	if got := d.store.Get("codex-idle"); got.State != protocol.SessionStateIdle {
 		t.Fatalf("codex working PTY should not override idle, got=%s", got.State)
 	}
 
 	addCodexSession("codex-waiting", protocol.SessionStateWaitingInput)
-	d.handlePTYState("codex-waiting", protocol.StateWorking)
+	d.handlePTYState("codex-waiting", screenObs(protocol.StateWorking))
 	if got := d.store.Get("codex-waiting"); got.State != protocol.SessionStateWaitingInput {
 		t.Fatalf("codex working PTY should not override waiting_input, got=%s", got.State)
 	}
@@ -86,7 +86,7 @@ func TestHandlePTYState_CodexWorkingClearsPendingApproval(t *testing.T) {
 		LastSeen:       nowStr,
 	})
 
-	d.handlePTYState("codex-pending", protocol.StateWorking)
+	d.handlePTYState("codex-pending", screenObs(protocol.StateWorking))
 	if got := d.store.Get("codex-pending"); got.State != protocol.SessionStateWorking {
 		t.Fatalf("codex working PTY should clear pending_approval, got=%s", got.State)
 	}
@@ -107,7 +107,7 @@ func TestHandlePTYState_ClaudeAcceptsWaiting(t *testing.T) {
 		LastSeen:       nowStr,
 	})
 
-	d.handlePTYState("claude-sess", protocol.StateWaitingInput)
+	d.handlePTYState("claude-sess", screenObs(protocol.StateWaitingInput))
 	if got := d.store.Get("claude-sess"); got.State != protocol.SessionStateWaitingInput {
 		t.Fatalf("claude waiting_input should be applied, got=%s", got.State)
 	}
@@ -143,7 +143,7 @@ func TestHandlePTYState_ClaudeScheduledSurvivesDetectorNoise(t *testing.T) {
 	} {
 		id := "claude-scheduled-" + noise
 		addScheduled(id)
-		d.handlePTYState(id, noise)
+		d.handlePTYState(id, screenObs(noise))
 		if got := d.store.Get(id); got.State != protocol.SessionStateScheduled {
 			t.Fatalf("scheduled should survive %s PTY detector noise, got=%s", noise, got.State)
 		}
@@ -151,7 +151,7 @@ func TestHandlePTYState_ClaudeScheduledSurvivesDetectorNoise(t *testing.T) {
 
 	// A genuine resume (working) is the one signal that may leave scheduled.
 	addScheduled("claude-scheduled-resume")
-	d.handlePTYState("claude-scheduled-resume", protocol.StateWorking)
+	d.handlePTYState("claude-scheduled-resume", screenObs(protocol.StateWorking))
 	if got := d.store.Get("claude-scheduled-resume"); got.State != protocol.SessionStateWorking {
 		t.Fatalf("working PTY state should resume a scheduled session, got=%s", got.State)
 	}
@@ -172,7 +172,7 @@ func TestHandlePTYState_CopilotKeepsPendingAgainstWorkingNoise(t *testing.T) {
 		LastSeen:       nowStr,
 	})
 
-	d.handlePTYState("copilot-sess", protocol.StateWorking)
+	d.handlePTYState("copilot-sess", screenObs(protocol.StateWorking))
 	if got := d.store.Get("copilot-sess"); got.State != protocol.SessionStatePendingApproval {
 		t.Fatalf("copilot working should not override pending_approval, got=%s", got.State)
 	}

--- a/internal/hooks/spike_codex_overrides_test.go
+++ b/internal/hooks/spike_codex_overrides_test.go
@@ -1,0 +1,77 @@
+package hooks
+
+// SPIKE — throwaway. Emits the codex `-c` overrides needed to wire an arbitrary
+// logger script as codex's hook set, reusing the production trusted-hash
+// computation so codex actually accepts them. Used to give the state-detection
+// spike hook-derived ground truth for codex, the same way --settings does for
+// claude.
+//
+//   go test ./internal/hooks -run TestSpikePrintCodexOverrides -v \
+//     -args-unused   ATTN_SPIKE_HOOKLOG=/path/hooklog.sh
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestSpikePrintCodexOverrides(t *testing.T) {
+	logger := strings.TrimSpace(os.Getenv("ATTN_SPIKE_HOOKLOG"))
+	if logger == "" {
+		t.Skip("set ATTN_SPIKE_HOOKLOG to the hook logger script")
+	}
+
+	// Same shape as GenerateCodexConfigOverrides, but each event invokes the
+	// logger with its own name so the capture can tell them apart.
+	events := []struct {
+		key     string
+		matcher string
+		name    string
+	}{
+		{"session_start", "startup|resume|clear|compact", "SessionStart"},
+		{"user_prompt_submit", "", "UserPromptSubmit"},
+		{"permission_request", "*", "PermissionRequest"},
+		{"pre_tool_use", "*", "PreToolUse"},
+		{"post_tool_use", "*", "PostToolUse"},
+		{"stop", "", "Stop"},
+	}
+
+	hook := func(command string) string {
+		return fmt.Sprintf(`{ type = "command", command = %s, timeout = 5 }`, strconv.Quote(command))
+	}
+	group := func(matcher, command string) string {
+		if strings.TrimSpace(matcher) == "" {
+			return fmt.Sprintf(`[{ hooks = [%s] }]`, hook(command))
+		}
+		return fmt.Sprintf(`[{ matcher = %s, hooks = [%s] }]`, strconv.Quote(matcher), hook(command))
+	}
+
+	var trust []string
+	var out []string
+	out = append(out, "features.hooks=true")
+	for _, e := range events {
+		command := shellQuote(logger) + " " + shellQuote(e.name)
+		key := fmt.Sprintf("/<session-flags>/config.toml:%s:0:0", e.key)
+		trust = append(trust, fmt.Sprintf("%s = { trusted_hash = %s }",
+			strconv.Quote(key),
+			strconv.Quote(commandHookHash(e.key, e.matcher, command))))
+
+		tomlKey := map[string]string{
+			"session_start":      "SessionStart",
+			"user_prompt_submit": "UserPromptSubmit",
+			"permission_request": "PermissionRequest",
+			"pre_tool_use":       "PreToolUse",
+			"post_tool_use":      "PostToolUse",
+			"stop":               "Stop",
+		}[e.key]
+		out = append(out, "hooks."+tomlKey+"="+group(e.matcher, command))
+	}
+	out = append(out, fmt.Sprintf("hooks.state={ %s }", strings.Join(trust, ", ")))
+
+	// One override per line, for the capture script to split on.
+	for _, o := range out {
+		fmt.Println("OVERRIDE\t" + o)
+	}
+}

--- a/internal/pty/approval_resolver_test.go
+++ b/internal/pty/approval_resolver_test.go
@@ -167,12 +167,12 @@ func TestApprovalResolver_PromptReappearsResetsDebounce(t *testing.T) {
 // prompt-gone sample we make no further evaluateApproval calls and rely solely on
 // the timer.
 func TestSession_ApprovalClearsWithoutFurtherOutput(t *testing.T) {
-	states := make(chan string, 8)
+	states := make(chan Observation, 8)
 	gt := newTestGhostty(t, 80, 24)
 	s := &Session{
 		approvalResolver: &approvalResolver{},
 		ghostty:          gt,
-		onState:          func(state string) { states <- state },
+		onState:          func(obs Observation) { states <- obs },
 	}
 	s.running = true
 
@@ -187,9 +187,12 @@ func TestSession_ApprovalClearsWithoutFurtherOutput(t *testing.T) {
 	paint(codexApprovalScreen)
 	s.evaluateApproval(time.Now(), false)
 	select {
-	case st := <-states:
-		if st != statePendingApproval {
-			t.Fatalf("expected %q when the prompt appears, got %q", statePendingApproval, st)
+	case obs := <-states:
+		if obs.Claim != statePendingApproval {
+			t.Fatalf("expected %q when the prompt appears, got %q", statePendingApproval, obs.Claim)
+		}
+		if obs.Source != SourceApproval {
+			t.Fatalf("expected source %q, got %q", SourceApproval, obs.Source)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("expected pending_approval when the prompt appears")
@@ -201,9 +204,12 @@ func TestSession_ApprovalClearsWithoutFurtherOutput(t *testing.T) {
 	s.evaluateApproval(time.Now(), false)
 
 	select {
-	case st := <-states:
-		if st != stateWorking {
-			t.Fatalf("expected %q from the scheduled recheck, got %q", stateWorking, st)
+	case obs := <-states:
+		if obs.Claim != stateWorking {
+			t.Fatalf("expected %q from the scheduled recheck, got %q", stateWorking, obs.Claim)
+		}
+		if obs.Source != SourceApproval {
+			t.Fatalf("expected source %q, got %q", SourceApproval, obs.Source)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("working was not emitted without further PTY output (timer did not drive the clear)")

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -148,7 +148,7 @@ type Manager struct {
 	pendingSpawns map[string]struct{}
 	logf          LogFunc
 	onExit        func(ExitInfo)
-	onState       func(sessionID, state string)
+	onState       func(sessionID string, obs Observation)
 
 	// testHookAfterSpawnReserve, when non-nil, runs after Spawn reserves its
 	// session ID and releases the mutex. Test-only seam for deterministic
@@ -173,7 +173,7 @@ func (m *Manager) SetExitHandler(handler func(ExitInfo)) {
 	m.onExit = handler
 }
 
-func (m *Manager) SetStateHandler(handler func(sessionID, state string)) {
+func (m *Manager) SetStateHandler(handler func(sessionID string, obs Observation)) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.onState = handler
@@ -347,8 +347,8 @@ func (m *Manager) Spawn(opts SpawnOptions) error {
 		session.approvalResolver = &approvalResolver{}
 	}
 	if (session.detector != nil || session.approvalResolver != nil) && onState != nil {
-		session.onState = func(state string) {
-			onState(opts.ID, state)
+		session.onState = func(obs Observation) {
+			onState(opts.ID, obs)
 		}
 	}
 

--- a/internal/pty/observation.go
+++ b/internal/pty/observation.go
@@ -1,0 +1,41 @@
+package pty
+
+import "time"
+
+// Source names where a state observation came from. The daemon arbitrates
+// between sources rather than taking the last writer, so it has to know which
+// source spoke — a bare state name cannot be arbitrated, only obeyed.
+type Source string
+
+const (
+	// SourceScreen is the rendered-screen scrape in state_detector.go.
+	SourceScreen Source = "screen"
+	// SourceApproval is approvalResolver, watching the approval prompt appear
+	// and leave the rendered screen.
+	SourceApproval Source = "approval"
+	// SourceWorkerInfo is the daemon's periodic worker `info` poll reporting the
+	// worker's last known state, not a fresh terminal observation.
+	SourceWorkerInfo Source = "worker_info"
+	// SourceUnknown is a state that crossed the worker RPC without a source,
+	// i.e. from a worker older than the field.
+	SourceUnknown Source = "unknown"
+)
+
+// Observation is one piece of state evidence from the PTY layer. Claim is what
+// the source believes (a protocol state name); Detail is why, in human terms,
+// for diagnostics; At is when it was observed, which matters because an
+// observation can reach the daemon well after the fact.
+//
+// Claim alone is deliberately not enough to act on: two sources can claim the
+// same state for unrelated reasons, and the same source's claim means something
+// different depending on how stale it is.
+type Observation struct {
+	Source Source
+	Claim  string
+	Detail string
+	At     time.Time
+}
+
+func newObservation(source Source, claim, detail string, at time.Time) Observation {
+	return Observation{Source: source, Claim: claim, Detail: detail, At: at}
+}

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -133,7 +133,7 @@ type Session struct {
 
 	// CLI state detection based on PTY output.
 	detector      stateDetector
-	onState       func(state string)
+	onState       func(obs Observation)
 	stateMu       sync.RWMutex
 	detectorState string
 
@@ -362,7 +362,7 @@ func (s *Session) readLoop(onExit func(exitCode int, signal string), logf func(s
 						s.stateMu.Lock()
 						s.detectorState = state
 						s.stateMu.Unlock()
-						s.onState(state)
+						s.onState(newObservation(SourceScreen, state, "screen scrape", time.Now()))
 					}
 				}
 				if len(data) > 0 {
@@ -557,17 +557,17 @@ func (s *Session) evaluateApproval(now time.Time, throttle bool) {
 
 	switch signal {
 	case approvalArmedPending:
-		s.applyApprovalState(statePendingApproval)
+		s.applyApprovalState(statePendingApproval, "approval prompt on screen", now)
 	case approvalCleared:
-		s.applyApprovalState(stateWorking)
+		s.applyApprovalState(stateWorking, "approval prompt gone for debounce", now)
 	}
 }
 
-func (s *Session) applyApprovalState(state string) {
+func (s *Session) applyApprovalState(state, detail string, at time.Time) {
 	s.stateMu.Lock()
 	s.detectorState = state
 	s.stateMu.Unlock()
-	s.onState(state)
+	s.onState(newObservation(SourceApproval, state, detail, at))
 }
 
 // scheduleApprovalRecheckLocked arms a one-shot recheck a little past the

--- a/internal/pty/spike_resolver_test.go
+++ b/internal/pty/spike_resolver_test.go
@@ -1,0 +1,160 @@
+package pty
+
+// SPIKE — throwaway. The TTL sweep showed no single heartbeat TTL gives both a
+// fast settle and no false-settle mid-tool, so the heartbeat alone is not a
+// detector. This file tests the actual proposal: hook brackets as the level for
+// "is work outstanding", with the heartbeat as an independent corroborator.
+//
+// Scoring a bracket detector against hook-derived truth is circular when every
+// hook arrives, so the experiment is the failure mode that actually bites:
+// DROPPED hooks (spawn failure, socket error, a hook event the agent never
+// fires). We drop hooks at increasing rates and ask how much of the truth the
+// heartbeat recovers.
+
+import (
+	"encoding/base64"
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+type spikeResolver struct {
+	turnOpen     bool
+	toolOpen     bool
+	approvalOpen bool
+	autoMode     bool
+
+	osc          *spikeOSCDetector
+	useHeartbeat bool
+	ttl          float64
+	// staleAfter: how long a bracket may stay open with a silent heartbeat
+	// before we conclude a Stop/PostToolUse was lost and settle anyway.
+	staleAfter float64
+}
+
+func (r *spikeResolver) onHook(name string) {
+	switch name {
+	case "UserPromptSubmit":
+		r.turnOpen = true
+		r.approvalOpen = false
+	case "PreToolUse":
+		r.toolOpen = true
+	case "PostToolUse":
+		r.toolOpen = false
+		r.approvalOpen = false
+	case "PermissionRequest":
+		if !r.autoMode {
+			r.approvalOpen = true
+		}
+	case "Stop":
+		r.turnOpen, r.toolOpen, r.approvalOpen = false, false, false
+	}
+}
+
+func (r *spikeResolver) state(now float64) string {
+	heartbeatFresh := r.useHeartbeat && now-r.osc.lastBusyAt <= r.ttl
+	heartbeatSilent := now - r.osc.lastBusyAt
+
+	// A live heartbeat is proof of work regardless of what the brackets say —
+	// this is what recovers a lost UserPromptSubmit.
+	if heartbeatFresh {
+		return gtWorking
+	}
+	if r.approvalOpen {
+		return gtApproval
+	}
+	if r.turnOpen || r.toolOpen {
+		// Bracket says work is outstanding. Trust it, unless the heartbeat has
+		// been silent long enough that a closing hook was clearly lost — that is
+		// the un-stick, and it is only available with the heartbeat wired.
+		if r.useHeartbeat && heartbeatSilent > r.staleAfter {
+			return gtSettled
+		}
+		return gtWorking
+	}
+	return gtSettled
+}
+
+// TestSpikeHookDropResilience is the load-bearing experiment: how does each
+// design degrade as hooks go missing?
+func TestSpikeHookDropResilience(t *testing.T) {
+	const sampleStep = 0.2
+	const ttl = 1.0
+	const staleAfter = 4.0
+
+	dropRates := []float64{0, 0.05, 0.10, 0.25, 0.50}
+
+	fmt.Printf("\n%-10s %22s %22s\n", "drop rate", "hooks only", "hooks + heartbeat")
+	for _, drop := range dropRates {
+		var bSamples, bCorrect, hSamples, hCorrect int
+		bWorst, hWorst := 0.0, 0.0
+
+		for _, dir := range spikeDirs(t) {
+			cap := loadSpikeCapture(t, dir)
+			if len(cap.Hooks) == 0 {
+				continue
+			}
+			truth := groundTruth(cap)
+
+			// Average over seeds so a single unlucky drop pattern does not decide it.
+			for seed := 0; seed < 20; seed++ {
+				rng := rand.New(rand.NewSource(int64(seed)))
+				kept := make([]bool, len(cap.Hooks))
+				for i := range cap.Hooks {
+					kept[i] = rng.Float64() >= drop
+				}
+
+				bracket := &spikeResolver{autoMode: cap.AutoMode, osc: newSpikeOSCDetector(ttl)}
+				hybrid := &spikeResolver{autoMode: cap.AutoMode, osc: newSpikeOSCDetector(ttl),
+					useHeartbeat: true, ttl: ttl, staleAfter: staleAfter}
+
+				chunkIdx, hookIdx := 0, 0
+				var bMarks, hMarks []string
+				for now := 0.0; now <= cap.End; now += sampleStep {
+					for chunkIdx < len(cap.Chunks) && cap.Chunks[chunkIdx].T <= now {
+						data, _ := base64.StdEncoding.DecodeString(cap.Chunks[chunkIdx].B64)
+						hybrid.osc.feed(cap.Chunks[chunkIdx].T, data)
+						chunkIdx++
+					}
+					for hookIdx < len(cap.Hooks) && cap.Hooks[hookIdx].At <= now {
+						if kept[hookIdx] {
+							bracket.onHook(cap.Hooks[hookIdx].Name)
+							hybrid.onHook(cap.Hooks[hookIdx].Name)
+						}
+						hookIdx++
+					}
+					if now < firstHookAt(cap) {
+						continue
+					}
+					tr := truth(now)
+
+					bSamples++
+					if bracket.state(now) == tr {
+						bCorrect++
+						bMarks = append(bMarks, ".")
+					} else {
+						bMarks = append(bMarks, "X")
+					}
+
+					hSamples++
+					if hybrid.state(now) == tr {
+						hCorrect++
+						hMarks = append(hMarks, ".")
+					} else {
+						hMarks = append(hMarks, "X")
+					}
+				}
+				if w := worstStreak(bMarks, sampleStep); w > bWorst {
+					bWorst = w
+				}
+				if w := worstStreak(hMarks, sampleStep); w > hWorst {
+					hWorst = w
+				}
+			}
+		}
+		fmt.Printf("%-10.0f%% %11.1f%% worst %5.1fs %11.1f%% worst %5.1fs\n",
+			100*drop,
+			100*float64(bCorrect)/float64(bSamples), bWorst,
+			100*float64(hCorrect)/float64(hSamples), hWorst)
+	}
+}

--- a/internal/pty/spike_state_replay_test.go
+++ b/internal/pty/spike_state_replay_test.go
@@ -313,8 +313,8 @@ func (d *spikeOSCDetector) state(now float64) string {
 // ---------- scoring ----------
 
 type spikeScore struct {
-	Samples  int
-	Correct  int
+	Samples   int
+	Correct   int
 	Confusion map[string]int // "truth->guess"
 }
 

--- a/internal/pty/spike_state_replay_test.go
+++ b/internal/pty/spike_state_replay_test.go
@@ -1,0 +1,717 @@
+package pty
+
+// SPIKE — throwaway. Replays recorded PTY captures through the current
+// screen-scraping detector and through a candidate OSC-based detector, and
+// scores both against hook-derived ground truth.
+//
+// Run with:
+//   ATTN_SPIKE_CAPTURES=/path/to/spike go test ./internal/pty -run TestSpike -v
+//
+// A capture dir holds:
+//   stream.jsonl  {"t": <sec since start>, "b64": "<raw pty bytes>"}
+//   hooks.log     "<unix epoch>\t<HookName>\t<payload prefix>"
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------- capture loading ----------
+
+type spikeChunk struct {
+	T   float64 `json:"t"`
+	B64 string  `json:"b64"`
+}
+
+type spikeHook struct {
+	At   float64 // seconds since capture start
+	Name string
+}
+
+type spikeCapture struct {
+	Name   string
+	Chunks []spikeChunk
+	Hooks  []spikeHook
+	End    float64
+	// AutoMode marks a capture launched with an automated permission reviewer
+	// (claude defaultMode:auto / codex auto_review), where a PermissionRequest
+	// never reaches the user.
+	AutoMode bool
+}
+
+func loadSpikeCapture(t *testing.T, dir string) spikeCapture {
+	t.Helper()
+	cap := spikeCapture{Name: filepath.Base(dir)}
+
+	f, err := os.Open(filepath.Join(dir, "stream.jsonl"))
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 1<<20), 1<<22)
+	for sc.Scan() {
+		var c spikeChunk
+		if json.Unmarshal(sc.Bytes(), &c) == nil {
+			cap.Chunks = append(cap.Chunks, c)
+		}
+	}
+	if len(cap.Chunks) == 0 {
+		t.Fatalf("%s: empty stream", dir)
+	}
+	cap.End = cap.Chunks[len(cap.Chunks)-1].T
+
+	// hooks.log carries absolute epochs; rebase onto the stream clock using the
+	// SessionStart hook, which fires while the first chunks are being written.
+	raw, err := os.ReadFile(filepath.Join(dir, "hooks.log"))
+	if err != nil {
+		return cap
+	}
+	var epochs []spikeHook
+	for _, line := range strings.Split(string(raw), "\n") {
+		parts := strings.Split(line, "\t")
+		if len(parts) < 2 {
+			continue
+		}
+		ts, err := strconv.ParseFloat(parts[0], 64)
+		if err != nil {
+			continue
+		}
+		epochs = append(epochs, spikeHook{At: ts, Name: parts[1]})
+	}
+	if len(epochs) == 0 {
+		return cap
+	}
+
+	// Rebase hooks onto the stream clock. SessionStart is a poor anchor (it fires
+	// seconds after the process starts, and that boot delay varies), so anchor on
+	// the first UserPromptSubmit, which fires the instant the capture script sent
+	// its scripted Enter at a time we know exactly.
+	base := epochs[0].At
+	var anchor struct {
+		FirstPromptAt float64 `json:"first_prompt_at"`
+		AutoMode      bool    `json:"auto_mode"`
+	}
+	if raw, err := os.ReadFile(filepath.Join(dir, "anchor.json")); err == nil {
+		if json.Unmarshal(raw, &anchor) == nil && anchor.FirstPromptAt > 0 {
+			cap.AutoMode = anchor.AutoMode
+			for _, h := range epochs {
+				if h.Name == "UserPromptSubmit" {
+					base = h.At - anchor.FirstPromptAt
+					break
+				}
+			}
+		}
+	}
+	for _, h := range epochs {
+		cap.Hooks = append(cap.Hooks, spikeHook{At: h.At - base, Name: h.Name})
+	}
+	return cap
+}
+
+// spikeLatency measures how long after a hook-truth transition the PTY-only
+// signal followed. Negative means the PTY signal led the hook.
+func spikeLatency(titles []spikeTitle, hookAt float64, wantBusy bool) (float64, bool) {
+	for _, ti := range titles {
+		if !ti.Known || ti.At < hookAt-5 {
+			continue
+		}
+		if ti.Busy == wantBusy && ti.At >= hookAt-5 {
+			return ti.At - hookAt, true
+		}
+	}
+	return 0, false
+}
+
+// ---------- ground truth ----------
+
+const (
+	gtWorking  = "working"
+	gtApproval = "pending_approval"
+	gtSettled  = "settled" // idle or waiting_input; the classifier's job to split
+)
+
+// groundTruth turns the hook timeline into an interval function. Hooks are
+// harness-authoritative: the agent itself reports when a turn starts, when it
+// blocks on permission, and when it yields.
+func groundTruth(c spikeCapture) func(float64) string {
+	type mark struct {
+		at    float64
+		state string
+	}
+	var marks []mark
+	for _, h := range c.Hooks {
+		switch h.Name {
+		case "UserPromptSubmit", "PostToolUse", "PreToolUse":
+			marks = append(marks, mark{h.At, gtWorking})
+		case "PermissionRequest":
+			// A PermissionRequest only means "the USER is being asked" when no
+			// automated reviewer is in the loop. Under claude defaultMode:auto or
+			// codex auto_review the guardian resolves it in milliseconds and no
+			// human is ever involved, so that window is tool execution (working).
+			// There is no hook at the moment the guardian approves, so this cannot
+			// be inferred from the timeline — it is a property of the launch, which
+			// is exactly how the daemon will know it (ReviewerInLoop).
+			if c.AutoMode {
+				marks = append(marks, mark{h.At, gtWorking})
+			} else {
+				marks = append(marks, mark{h.At, gtApproval})
+			}
+		case "Stop":
+			marks = append(marks, mark{h.At, gtSettled})
+		}
+	}
+	sort.SliceStable(marks, func(i, j int) bool { return marks[i].at < marks[j].at })
+	return func(t float64) string {
+		state := gtSettled
+		for _, m := range marks {
+			if m.at > t {
+				break
+			}
+			state = m.state
+		}
+		return state
+	}
+}
+
+// ---------- candidate detector: OSC title heartbeat ----------
+
+// spikeOSCDetector is the candidate. It reads ONLY what the harness publishes
+// on the wire: the OSC 0 title (whose leading glyph is a spinner while a turn
+// runs) and OSC 777 notifications. No screen scraping, no keyword lists.
+type spikeOSCDetector struct {
+	pending    []byte
+	lastBusyAt float64
+	lastIdleAt float64
+	sawNotify  bool
+	notifyAt   float64
+	titles     []spikeTitle
+	busyTTL    float64
+}
+
+type spikeTitle struct {
+	At    float64
+	Text  string
+	Busy  bool
+	Known bool
+}
+
+func newSpikeOSCDetector(busyTTL float64) *spikeOSCDetector {
+	return &spikeOSCDetector{busyTTL: busyTTL, lastBusyAt: -1e9, lastIdleAt: -1e9, notifyAt: -1e9}
+}
+
+// titleBusy classifies a title's leading glyph.
+//   - U+2800..U+28FF (braille) => spinner frame => a turn is RUNNING.
+//     Both claude and codex animate their title with braille frames.
+//   - U+2722..U+274B (dingbat stars, claude's ✳) => turn NOT running.
+//   - anything else (codex's bare cwd, plain text) => turn NOT running.
+func titleBusy(title string) (busy bool, known bool) {
+	trimmed := strings.TrimLeft(title, " \t")
+	if trimmed == "" {
+		return false, false
+	}
+	r := []rune(trimmed)[0]
+	switch {
+	case r >= 0x2800 && r <= 0x28FF:
+		return true, true
+	case r >= 0x2722 && r <= 0x274B:
+		return false, true
+	default:
+		return false, true
+	}
+}
+
+func (d *spikeOSCDetector) feed(at float64, data []byte) {
+	d.pending = append(d.pending, data...)
+	for {
+		start := indexOSC(d.pending)
+		if start < 0 {
+			// keep a small tail in case an OSC straddles chunks
+			if len(d.pending) > 4096 {
+				d.pending = d.pending[len(d.pending)-64:]
+			}
+			return
+		}
+		body, next, ok := scanOSCBody(d.pending, start)
+		if !ok {
+			d.pending = d.pending[start:]
+			return
+		}
+		d.consumeOSC(at, body)
+		d.pending = d.pending[next:]
+	}
+}
+
+func indexOSC(buf []byte) int {
+	for i := 0; i+1 < len(buf); i++ {
+		if buf[i] == 0x1b && buf[i+1] == ']' {
+			return i
+		}
+	}
+	return -1
+}
+
+// scanOSCBody returns the payload between ESC] and its BEL/ST terminator.
+func scanOSCBody(buf []byte, start int) (body string, next int, ok bool) {
+	i := start + 2
+	for i < len(buf) {
+		if buf[i] == 0x07 {
+			return string(buf[start+2 : i]), i + 1, true
+		}
+		if buf[i] == 0x1b && i+1 < len(buf) && buf[i+1] == '\\' {
+			return string(buf[start+2 : i]), i + 2, true
+		}
+		i++
+	}
+	return "", 0, false
+}
+
+func (d *spikeOSCDetector) consumeOSC(at float64, body string) {
+	switch {
+	case strings.HasPrefix(body, "0;"), strings.HasPrefix(body, "2;"):
+		title := body[2:]
+		busy, known := titleBusy(title)
+		d.titles = append(d.titles, spikeTitle{At: at, Text: title, Busy: busy, Known: known})
+		if !known {
+			return
+		}
+		if busy {
+			d.lastBusyAt = at
+		} else {
+			d.lastIdleAt = at
+		}
+	case strings.HasPrefix(body, "777;notify"):
+		d.sawNotify = true
+		d.notifyAt = at
+	}
+}
+
+// state resolves at an arbitrary time — the point of a level signal is that it
+// answers on a tick, not only when bytes arrive.
+func (d *spikeOSCDetector) state(now float64) string {
+	if now-d.lastBusyAt <= d.busyTTL {
+		return gtWorking
+	}
+	if d.lastIdleAt > d.lastBusyAt || d.sawNotify {
+		return gtSettled
+	}
+	if d.lastBusyAt < -1e8 {
+		return "unknown"
+	}
+	return gtSettled
+}
+
+// ---------- scoring ----------
+
+type spikeScore struct {
+	Samples  int
+	Correct  int
+	Confusion map[string]int // "truth->guess"
+}
+
+func newScore() *spikeScore { return &spikeScore{Confusion: map[string]int{}} }
+
+func (s *spikeScore) add(truth, guess string) {
+	s.Samples++
+	if truth == guess {
+		s.Correct++
+		return
+	}
+	s.Confusion[truth+"->"+guess]++
+}
+
+func (s *spikeScore) pct() float64 {
+	if s.Samples == 0 {
+		return 0
+	}
+	return 100 * float64(s.Correct) / float64(s.Samples)
+}
+
+func spikeDirs(t *testing.T) []string {
+	root := strings.TrimSpace(os.Getenv("ATTN_SPIKE_CAPTURES"))
+	if root == "" {
+		t.Skip("set ATTN_SPIKE_CAPTURES to a dir holding run_* captures")
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read captures: %v", err)
+	}
+	var dirs []string
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), "run_") {
+			dirs = append(dirs, filepath.Join(root, e.Name()))
+		}
+	}
+	sort.Strings(dirs)
+	return dirs
+}
+
+// TestSpikeReplay scores the current detector against the OSC candidate.
+func TestSpikeReplay(t *testing.T) {
+	const sampleStep = 0.2
+	const busyTTL = 3.0
+
+	for _, dir := range spikeDirs(t) {
+		cap := loadSpikeCapture(t, dir)
+		if len(cap.Hooks) == 0 {
+			// No hook ground truth (e.g. codex, which attn wires differently).
+			// Still report the heartbeat's shape, which is what the design leans on.
+			osc := newSpikeOSCDetector(busyTTL)
+			for _, c := range cap.Chunks {
+				data, _ := base64.StdEncoding.DecodeString(c.B64)
+				osc.feed(c.T, data)
+			}
+			fmt.Printf("\n=== %s (%.0fs, %d chunks, NO hook truth)\n", cap.Name, cap.End, len(cap.Chunks))
+			fmt.Printf("  title emissions: %d (busy=%d idle=%d)  median busy interval %.3fs  max gap %.2fs\n",
+				len(osc.titles), countBusy(osc.titles, true), countBusy(osc.titles, false),
+				medianBusyInterval(osc.titles), maxBusyGap(osc.titles))
+			continue
+		}
+		truth := groundTruth(cap)
+
+		current := newClaudeWorkingDetector()
+		osc := newSpikeOSCDetector(busyTTL)
+
+		// currentState tracks what the existing detector last emitted; it is an
+		// edge emitter, so its state persists until it emits again.
+		currentState := "unknown"
+		curScore, oscScore := newScore(), newScore()
+
+		chunkIdx := 0
+		var currentTimeline, oscTimeline []string
+		for now := 0.0; now <= cap.End; now += sampleStep {
+			for chunkIdx < len(cap.Chunks) && cap.Chunks[chunkIdx].T <= now {
+				data, _ := base64.StdEncoding.DecodeString(cap.Chunks[chunkIdx].B64)
+				if s, changed := current.Observe(data); changed {
+					currentState = normalizeSpikeState(s)
+				}
+				osc.feed(cap.Chunks[chunkIdx].T, data)
+				chunkIdx++
+			}
+			tr := truth(now)
+			// Ignore the boot window before the first hook fired.
+			if now < firstHookAt(cap) {
+				continue
+			}
+			curScore.add(tr, currentState)
+			oscScore.add(tr, osc.state(now))
+			currentTimeline = append(currentTimeline, boolStr(currentState == tr))
+			oscTimeline = append(oscTimeline, boolStr(osc.state(now) == tr))
+		}
+
+		fmt.Printf("\n=== %s (%.0fs, %d chunks, %d hooks)\n", cap.Name, cap.End, len(cap.Chunks), len(cap.Hooks))
+		fmt.Printf("  current (screen scrape): %5.1f%% correct  worst-wrong-streak %5.1fs  %v\n",
+			curScore.pct(), worstStreak(currentTimeline, sampleStep), topConfusion(curScore))
+		fmt.Printf("  candidate (OSC title)  : %5.1f%% correct  worst-wrong-streak %5.1fs  %v\n",
+			oscScore.pct(), worstStreak(oscTimeline, sampleStep), topConfusion(oscScore))
+		fmt.Printf("  title emissions: %d  (busy=%d idle=%d)  osc777=%v\n",
+			len(osc.titles), countBusy(osc.titles, true), countBusy(osc.titles, false), osc.sawNotify)
+		fmt.Printf("  max gap between busy titles while running: %.2fs\n", maxBusyGap(osc.titles))
+		fmt.Printf("  longest FALSE-SETTLED window mid-turn: %.2fs\n", falseSettled(cap, truth, busyTTL, sampleStep))
+		for _, h := range cap.Hooks {
+			switch h.Name {
+			case "UserPromptSubmit":
+				if lat, ok := spikeLatency(osc.titles, h.At, true); ok {
+					fmt.Printf("  turn start  @%6.1fs -> spinner appeared %+.2fs later\n", h.At, lat)
+				}
+			case "Stop":
+				if lat, ok := spikeLatency(osc.titles, h.At, false); ok {
+					fmt.Printf("  turn settle @%6.1fs -> idle glyph   %+.2fs later\n", h.At, lat)
+				}
+			}
+		}
+	}
+}
+
+func boolStr(ok bool) string {
+	if ok {
+		return "."
+	}
+	return "X"
+}
+
+// worstStreak is the longest continuous stretch of disagreement with truth —
+// the direct measure of "the color got stuck".
+func worstStreak(marks []string, step float64) float64 {
+	worst, run := 0, 0
+	for _, m := range marks {
+		if m == "X" {
+			run++
+			if run > worst {
+				worst = run
+			}
+		} else {
+			run = 0
+		}
+	}
+	return float64(worst) * step
+}
+
+func normalizeSpikeState(s string) string {
+	switch s {
+	case stateWorking:
+		return gtWorking
+	case statePendingApproval:
+		return gtApproval
+	case stateIdle, stateWaitingInput:
+		return gtSettled
+	default:
+		return s
+	}
+}
+
+func firstHookAt(c spikeCapture) float64 {
+	if len(c.Hooks) == 0 {
+		return 0
+	}
+	return c.Hooks[0].At
+}
+
+func countBusy(titles []spikeTitle, busy bool) int {
+	n := 0
+	for _, ti := range titles {
+		if ti.Known && ti.Busy == busy {
+			n++
+		}
+	}
+	return n
+}
+
+// maxBusyGap is the longest interval between consecutive busy-title emissions,
+// bounded by the following idle title. It sizes the heartbeat TTL: the TTL must
+// exceed this or a running turn will flicker to settled.
+func maxBusyGap(titles []spikeTitle) float64 {
+	worst := 0.0
+	prev := -1.0
+	for _, ti := range titles {
+		if !ti.Known {
+			continue
+		}
+		if !ti.Busy {
+			prev = -1
+			continue
+		}
+		if prev >= 0 && ti.At-prev > worst {
+			worst = ti.At - prev
+		}
+		prev = ti.At
+	}
+	return worst
+}
+
+// falseSettled is the metric that matters for an attention mode: the longest
+// stretch where truth says the agent is working but the heartbeat-only detector
+// says settled. A false settle is what would make a settled/unsettled sidebar
+// declare an agent done while it is mid-tool.
+func falseSettled(cap spikeCapture, truth func(float64) string, ttl, step float64) float64 {
+	osc := newSpikeOSCDetector(ttl)
+	idx := 0
+	worst, run := 0.0, 0.0
+	for now := 0.0; now <= cap.End; now += step {
+		for idx < len(cap.Chunks) && cap.Chunks[idx].T <= now {
+			data, _ := base64.StdEncoding.DecodeString(cap.Chunks[idx].B64)
+			osc.feed(cap.Chunks[idx].T, data)
+			idx++
+		}
+		if truth(now) == gtWorking && osc.state(now) != gtWorking {
+			run += step
+			if run > worst {
+				worst = run
+			}
+		} else {
+			run = 0
+		}
+	}
+	return worst
+}
+
+func medianBusyInterval(titles []spikeTitle) float64 {
+	var gaps []float64
+	prev := -1.0
+	for _, ti := range titles {
+		if !ti.Known || !ti.Busy {
+			prev = -1
+			continue
+		}
+		if prev >= 0 {
+			gaps = append(gaps, ti.At-prev)
+		}
+		prev = ti.At
+	}
+	if len(gaps) == 0 {
+		return 0
+	}
+	sort.Float64s(gaps)
+	return gaps[len(gaps)/2]
+}
+
+func topConfusion(s *spikeScore) string {
+	type kv struct {
+		k string
+		v int
+	}
+	var all []kv
+	for k, v := range s.Confusion {
+		all = append(all, kv{k, v})
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].v > all[j].v })
+	var parts []string
+	for i, e := range all {
+		if i == 3 {
+			break
+		}
+		parts = append(parts, fmt.Sprintf("%s x%d", e.k, e.v))
+	}
+	if len(parts) == 0 {
+		return "(clean)"
+	}
+	return strings.Join(parts, ", ")
+}
+
+// TestSpikeTTLSweep sizes the heartbeat TTL. TTL=0 means "trust the idle glyph
+// as an immediate edge"; larger values absorb mid-turn idle blips at the cost of
+// settling late.
+func TestSpikeTTLSweep(t *testing.T) {
+	const sampleStep = 0.2
+	ttls := []float64{0, 0.5, 1, 1.5, 2, 3, 4, 5, 6}
+
+	fmt.Printf("\n%-8s %10s %10s %14s %14s\n", "TTL", "correct%", "worstWrong", "late-settle(s)", "falseSettled(s)")
+	for _, ttl := range ttls {
+		var samples, correct int
+		worst := 0.0
+		worstFalseSettled := 0.0
+		lateTotal, lateN := 0.0, 0
+		for _, dir := range spikeDirs(t) {
+			cap := loadSpikeCapture(t, dir)
+			if len(cap.Hooks) == 0 {
+				continue
+			}
+			truth := groundTruth(cap)
+			osc := newSpikeOSCDetector(ttl)
+			idx := 0
+			var marks []string
+			for now := 0.0; now <= cap.End; now += sampleStep {
+				for idx < len(cap.Chunks) && cap.Chunks[idx].T <= now {
+					data, _ := base64.StdEncoding.DecodeString(cap.Chunks[idx].B64)
+					osc.feed(cap.Chunks[idx].T, data)
+					idx++
+				}
+				if now < firstHookAt(cap) {
+					continue
+				}
+				tr := truth(now)
+				guess := osc.state(now)
+				// Approvals are hook-owned by design; the PTY signal cannot see
+				// them, so exclude those windows from the busy/settled scoring.
+				if tr == gtApproval {
+					continue
+				}
+				samples++
+				if tr == guess {
+					correct++
+					marks = append(marks, ".")
+				} else {
+					marks = append(marks, "X")
+				}
+			}
+			if w := worstStreak(marks, sampleStep); w > worst {
+				worst = w
+			}
+			if fs := falseSettled(cap, truth, ttl, sampleStep); fs > worstFalseSettled {
+				worstFalseSettled = fs
+			}
+			// How long after each Stop did the detector still claim working?
+			for _, h := range cap.Hooks {
+				if h.Name != "Stop" {
+					continue
+				}
+				for dt := 0.0; dt < 20; dt += sampleStep {
+					if osc.state(h.At+dt) != gtWorking {
+						lateTotal += dt
+						lateN++
+						break
+					}
+				}
+			}
+		}
+		late := 0.0
+		if lateN > 0 {
+			late = lateTotal / float64(lateN)
+		}
+		fmt.Printf("%-8.1f %9.1f%% %9.1fs %13.2f %14.2f\n",
+			ttl, 100*float64(correct)/float64(samples), worst, late, worstFalseSettled)
+	}
+}
+
+// TestSpikeTitleHijack is the adversarial case: a subprocess the agent runs
+// (a shell, vim, ssh, docker) sets the terminal title itself, overwriting the
+// harness spinner. If the heartbeat premise is fragile, this breaks it.
+func TestSpikeTitleHijack(t *testing.T) {
+	const sampleStep = 0.2
+	const busyTTL = 3.0
+
+	for _, mode := range []string{"none", "hijack_every_2s", "hijack_burst"} {
+		var samples, correct int
+		worst := 0.0
+		for _, dir := range spikeDirs(t) {
+			cap := loadSpikeCapture(t, dir)
+			if len(cap.Hooks) == 0 {
+				continue
+			}
+			truth := groundTruth(cap)
+			osc := newSpikeOSCDetector(busyTTL)
+			idx := 0
+			var marks []string
+			nextHijack := 0.0
+			for now := 0.0; now <= cap.End; now += sampleStep {
+				for idx < len(cap.Chunks) && cap.Chunks[idx].T <= now {
+					data, _ := base64.StdEncoding.DecodeString(cap.Chunks[idx].B64)
+					osc.feed(cap.Chunks[idx].T, data)
+					idx++
+				}
+				switch mode {
+				case "hijack_every_2s":
+					if now >= nextHijack {
+						osc.feed(now, []byte("\x1b]0;victor@mac: ~/projects/attn\x07"))
+						nextHijack = now + 2
+					}
+				case "hijack_burst":
+					// A TUI repainting its title continuously (e.g. htop, ssh).
+					if now > 10 && now < 40 {
+						osc.feed(now, []byte("\x1b]0;htop\x07"))
+					}
+				}
+				if now < firstHookAt(cap) {
+					continue
+				}
+				tr := truth(now)
+				if tr == gtApproval {
+					continue
+				}
+				samples++
+				if tr == osc.state(now) {
+					correct++
+					marks = append(marks, ".")
+				} else {
+					marks = append(marks, "X")
+				}
+			}
+			if w := worstStreak(marks, sampleStep); w > worst {
+				worst = w
+			}
+		}
+		fmt.Printf("  hijack mode %-16s -> %5.1f%% correct, worst wrong streak %.1fs\n",
+			mode, 100*float64(correct)/float64(samples), worst)
+	}
+}
+
+var _ = time.Second

--- a/internal/ptybackend/backend.go
+++ b/internal/ptybackend/backend.go
@@ -187,7 +187,7 @@ type Backend interface {
 
 type LifecycleHooks interface {
 	SetExitHandler(func(ExitInfo))
-	SetStateHandler(func(sessionID, state string))
+	SetStateHandler(func(sessionID string, obs pty.Observation))
 }
 
 type SessionInfoProvider interface {

--- a/internal/ptybackend/embedded.go
+++ b/internal/ptybackend/embedded.go
@@ -29,7 +29,7 @@ func (b *EmbeddedBackend) SetExitHandler(handler func(ExitInfo)) {
 	})
 }
 
-func (b *EmbeddedBackend) SetStateHandler(handler func(sessionID, state string)) {
+func (b *EmbeddedBackend) SetStateHandler(handler func(sessionID string, obs pty.Observation)) {
 	b.manager.SetStateHandler(handler)
 }
 

--- a/internal/ptybackend/worker.go
+++ b/internal/ptybackend/worker.go
@@ -131,7 +131,7 @@ type WorkerBackend struct {
 
 	hooksMu sync.RWMutex
 	onExit  func(ExitInfo)
-	onState func(sessionID, state string)
+	onState func(sessionID string, obs pty.Observation)
 
 	reqSeq atomic.Uint64
 }
@@ -312,7 +312,7 @@ func (b *WorkerBackend) SetExitHandler(handler func(ExitInfo)) {
 	b.onExit = handler
 }
 
-func (b *WorkerBackend) SetStateHandler(handler func(sessionID, state string)) {
+func (b *WorkerBackend) SetStateHandler(handler func(sessionID string, obs pty.Observation)) {
 	b.hooksMu.Lock()
 	defer b.hooksMu.Unlock()
 	b.onState = handler
@@ -1988,7 +1988,14 @@ func (b *WorkerBackend) startPoller(session *workerSession) {
 					onState := b.onState
 					b.hooksMu.RUnlock()
 					if onState != nil {
-						onState(session.SessionID, newState)
+						// The poll reports the worker's own last known state, not a
+						// fresh terminal observation.
+						onState(session.SessionID, pty.Observation{
+							Source: pty.SourceWorkerInfo,
+							Claim:  newState,
+							Detail: "worker info poll",
+							At:     now,
+						})
 					}
 				}
 
@@ -2156,7 +2163,7 @@ func (b *WorkerBackend) handleLifecycleEvent(session *workerSession, evt ptywork
 		onState := b.onState
 		b.hooksMu.RUnlock()
 		if onState != nil {
-			onState(session.SessionID, state)
+			onState(session.SessionID, ptyworker.ObservationFromEvent(evt, state, now))
 		}
 	case ptyworker.EventExit:
 		session.mu.Lock()

--- a/internal/ptyworker/protocol.go
+++ b/internal/ptyworker/protocol.go
@@ -1,6 +1,11 @@
 package ptyworker
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/victorarias/attn/internal/pty"
+)
 
 const (
 	RPCMajor = 1
@@ -81,6 +86,16 @@ type EventEnvelope struct {
 	State      *string `json:"state,omitempty"`
 	ExitCode   *int    `json:"exit_code,omitempty"`
 	ExitSignal *string `json:"exit_signal,omitempty"`
+
+	// StateSource / StateDetail / StateObservedAt qualify State on
+	// EventStateChanged: which observer spoke, why, and when it observed. The
+	// daemon arbitrates between observers, which a bare state name cannot
+	// support. Added without an RPC version bump, following the MethodSnapshot
+	// precedent: an older worker simply omits them and the daemon treats the
+	// state as source-unknown, observed on arrival.
+	StateSource     *string `json:"state_source,omitempty"`
+	StateDetail     *string `json:"state_detail,omitempty"`
+	StateObservedAt *string `json:"state_observed_at,omitempty"`
 }
 
 type HelloParams struct {
@@ -198,4 +213,50 @@ func IsCompatibleVersion(peerMajor, peerMinor int) bool {
 		return false
 	}
 	return true
+}
+
+// stateChangedEvent wraps one PTY observation as an EventStateChanged envelope.
+func stateChangedEvent(sessionID string, obs pty.Observation) EventEnvelope {
+	claim := obs.Claim
+	source := string(obs.Source)
+	evt := EventEnvelope{
+		Type:        "evt",
+		Event:       EventStateChanged,
+		SessionID:   sessionID,
+		State:       &claim,
+		StateSource: &source,
+	}
+	if obs.Detail != "" {
+		detail := obs.Detail
+		evt.StateDetail = &detail
+	}
+	if !obs.At.IsZero() {
+		at := obs.At.Format(time.RFC3339Nano)
+		evt.StateObservedAt = &at
+	}
+	return evt
+}
+
+// ObservationFromEvent reads an EventStateChanged envelope back into an
+// Observation. A worker older than the qualifying fields yields
+// pty.SourceUnknown observed at fallbackAt (the receive time), which is the
+// closest honest answer available.
+func ObservationFromEvent(evt EventEnvelope, claim string, fallbackAt time.Time) pty.Observation {
+	obs := pty.Observation{
+		Source: pty.SourceUnknown,
+		Claim:  claim,
+		At:     fallbackAt,
+	}
+	if evt.StateSource != nil && *evt.StateSource != "" {
+		obs.Source = pty.Source(*evt.StateSource)
+	}
+	if evt.StateDetail != nil {
+		obs.Detail = *evt.StateDetail
+	}
+	if evt.StateObservedAt != nil {
+		if at, err := time.Parse(time.RFC3339Nano, *evt.StateObservedAt); err == nil && !at.IsZero() {
+			obs.At = at
+		}
+	}
+	return obs
 }

--- a/internal/ptyworker/runtime.go
+++ b/internal/ptyworker/runtime.go
@@ -186,7 +186,8 @@ func (r *Runtime) run(ctx context.Context) error {
 	}
 
 	r.manager = pty.NewManager(r.logf)
-	r.manager.SetStateHandler(func(_ string, state string) {
+	r.manager.SetStateHandler(func(_ string, obs pty.Observation) {
+		state := obs.Claim
 		r.stateMu.Lock()
 		previousState := r.state
 		changed := previousState != state
@@ -204,12 +205,7 @@ func (r *Runtime) run(ctx context.Context) error {
 			}
 		}
 		if changed {
-			r.broadcastLifecycle(EventEnvelope{
-				Type:      "evt",
-				Event:     EventStateChanged,
-				SessionID: r.cfg.SessionID,
-				State:     &state,
-			})
+			r.broadcastLifecycle(stateChangedEvent(r.cfg.SessionID, obs))
 		}
 	})
 	r.manager.SetExitHandler(func(info pty.ExitInfo) {
@@ -1025,12 +1021,14 @@ func (c *connCtx) handleRequest(req RequestEnvelope) {
 		if state == "" {
 			state = "working"
 		}
-		_ = c.sendEvent(EventEnvelope{
-			Type:      "evt",
-			Event:     EventStateChanged,
-			SessionID: c.runtime.cfg.SessionID,
-			State:     &state,
-		})
+		// Not a fresh terminal observation: this replays the worker's cached state
+		// so a newly subscribed watcher starts in sync.
+		_ = c.sendEvent(stateChangedEvent(c.runtime.cfg.SessionID, pty.Observation{
+			Source: pty.SourceWorkerInfo,
+			Claim:  state,
+			Detail: "watch subscribe replay",
+			At:     time.Now(),
+		}))
 		if exitCode != nil || exitSignal != nil {
 			_ = c.sendEvent(EventEnvelope{
 				Type:       "evt",

--- a/internal/ptyworker/state_observation_test.go
+++ b/internal/ptyworker/state_observation_test.go
@@ -1,0 +1,69 @@
+package ptyworker
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/pty"
+)
+
+// TestStateObservationSurvivesWire is the contract the daemon's arbitration will
+// rest on: which observer spoke, why, and when it observed must cross the worker
+// RPC intact — including through JSON, since the daemon reads these off a socket
+// and not from the same process.
+func TestStateObservationSurvivesWire(t *testing.T) {
+	observedAt := time.Date(2026, 7, 25, 10, 30, 0, 123456789, time.UTC)
+	want := pty.Observation{
+		Source: pty.SourceApproval,
+		Claim:  "working",
+		Detail: "approval prompt gone for debounce",
+		At:     observedAt,
+	}
+
+	encoded, err := json.Marshal(stateChangedEvent("sess-1", want))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var evt EventEnvelope
+	if err := json.Unmarshal(encoded, &evt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if evt.Event != EventStateChanged || evt.SessionID != "sess-1" {
+		t.Fatalf("envelope = %+v, want state_changed for sess-1", evt)
+	}
+
+	got := ObservationFromEvent(evt, *evt.State, time.Now())
+	if got.Source != want.Source || got.Claim != want.Claim || got.Detail != want.Detail {
+		t.Fatalf("observation = %+v, want %+v", got, want)
+	}
+	if !got.At.Equal(want.At) {
+		t.Fatalf("observed-at = %s, want %s", got.At, want.At)
+	}
+}
+
+// TestStateObservationFromLegacyWorker covers the version skew the additive
+// fields buy us: a worker predating them sends state alone, and the daemon must
+// still get a usable observation rather than an empty source it might mistake
+// for a real one.
+func TestStateObservationFromLegacyWorker(t *testing.T) {
+	state := "pending_approval"
+	arrived := time.Date(2026, 7, 25, 11, 0, 0, 0, time.UTC)
+
+	got := ObservationFromEvent(EventEnvelope{
+		Type:      "evt",
+		Event:     EventStateChanged,
+		SessionID: "sess-legacy",
+		State:     &state,
+	}, state, arrived)
+
+	if got.Source != pty.SourceUnknown {
+		t.Fatalf("source = %q, want %q", got.Source, pty.SourceUnknown)
+	}
+	if got.Claim != state {
+		t.Fatalf("claim = %q, want %q", got.Claim, state)
+	}
+	if !got.At.Equal(arrived) {
+		t.Fatalf("observed-at = %s, want the receive time %s", got.At, arrived)
+	}
+}


### PR DESCRIPTION
First of five enabling refactors from
`docs/plans/2026-07-25-agent-state-detection.md` (added here). Behavior-preserving
groundwork; no user-visible change.

## Why

The PTY layer reported state to the daemon as a bare string through
`session.onState`, so the daemon learned *what* a source claimed but never which
source claimed it, why, or when it was observed. That is enough to obey a claim
and not enough to arbitrate between claims — which is the structural reason a
session color can get stuck: every source is a last writer, and a dropped edge
leaves a state with nothing that will ever revisit it.

## What

- New `pty.Observation{Source, Claim, Detail, At}`. Sources name what actually
  produced the claim: `screen` (the scraper), `approval` (the approval resolver),
  `worker_info` (the worker's cached-state replay), and `unknown` for a claim that
  arrives unattributed.
- Threaded through `session.onState`, `Manager.SetStateHandler`, both
  `ptybackend` backends, and `handlePTYState`, which now logs the attribution.
- State crosses a socket, so widening the in-process callback is not enough.
  `EventStateChanged` gains optional `state_source` / `state_detail` /
  `state_observed_at`. **No RPC version bump**, following the `MethodSnapshot`
  precedent documented in `internal/ptyworker/protocol.go`: a worker predating the
  fields omits them and the daemon reads an unknown-source observation timestamped
  on arrival.

Also commits the throwaway spike that produced the plan's measurements (all three
files skip unless their env var is set; the plan lists them for deletion once
Phase 0 instrumentation supersedes them).

## Verification

- `internal/ptyworker/state_observation_test.go` covers the round trip through
  real JSON and the legacy-worker path. Both asserts mutation-checked: perturbing
  the observed-at format and hardcoding the source each fail on the intended line.
- `make test` green, `make test-frontend` green (2048 tests).
- **Live**, full install on throwaway profile `statedet`, real Claude session via
  `real-app:scenario-tr402-local-claude`. States still flow and now arrive
  attributed:
  ```
  pty state update: session=43d04c94… agent=claude state=waiting_input \
    source=screen detail="screen scrape" observed_at=2026-07-25T15:02:32.730678+02:00
  ```

## Debt this surfaced (documented in the plan, not fixed here)

The live run proved one item rather than inferring it: the worker fabricates
`working` when it does not know its state. The *first* observation the daemon logs
for every fresh session is `state=working source=worker_info detail="watch
subscribe replay"` — including for `agent=shell`, which has no detector and
therefore cannot have been observed working. Invisible today because a spawn is
green anyway, but every session's evidence table would open with a false row.

Three more are listed under "Found while implementing" in the plan: the same state
stream is deduped twice with different rules; that dedup is why
`approvalResolver` re-emits a `pending_approval` it never observed; and
`handlePTYState` discards `obs.At` in favour of the store's clock.

https://claude.ai/code/session_01KzpRFTTbzGz1JFqK1vvVq5