### PR TITLE
refactor(agent,pty): name the screen detector on the driver, collapse the two

### DIFF
--- a/docs/plans/2026-07-25-agent-state-detection.md
+++ b/docs/plans/2026-07-25-agent-state-detection.md
@@ -525,10 +525,14 @@ being fixed as part of the current step.
       we care about — ~6s after a permission request, and exactly 60s after a Stop
       that settled idle — so it is a first-class source, not a backstop.
 - [ ] Persist `ReviewerInLoop` on the session at spawn.
-- [ ] Enabling refactors 2 and 3: driver-owned observers (drop the capability
-      booleans and the agent-name switch in `manager.go`), and one `screenDetector`
-      in place of the two identical structs. Needed here because this phase adds a
-      third observer per agent.
+- [x] Enabling refactors 2 and 3: driver-named observers (`Capabilities.
+      ScreenDetector` kind replaces `HasStateDetector` plus the agent-name switch
+      in `manager.go`), and one `screenDetector` + `screenPolicy` in place of the
+      two near-identical structs. The per-agent *meaning* stays in
+      `classifyClaudeScreen` / `classifyCopilotScreen`; only the mechanics (tail,
+      claim suppression, working pulse) are shared. `STATE_DETECTOR=0` still
+      disables; `=1` keeps the driver's kind, which is what it already did in every
+      reachable case.
 - [ ] Enabling refactor 4: the Stop hook reports `background_tasks` /
       `session_crons` as facts; `nonTerminalStopState` and `sessionIsChiefOfStaff`
       move daemon-side. Without this the resolver cannot see background work at

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -62,7 +62,7 @@ func (c *Claude) Capabilities() Capabilities {
 		HasTranscript:        true,
 		HasTranscriptWatcher: true,
 		HasClassifier:        true,
-		HasStateDetector:     true,
+		ScreenDetector:       ScreenDetectorClaude,
 		HasApprovalResolver:  true,
 		HasResume:            true,
 		HasYolo:              true,

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -49,7 +49,6 @@ func (c *Codex) Capabilities() Capabilities {
 		HasHooks:            true,
 		HasTranscript:       true,
 		HasClassifier:       true,
-		HasStateDetector:    false,
 		HasApprovalResolver: true,
 		HasResume:           true,
 		HasYolo:             true,

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -38,7 +38,7 @@ func (c *Copilot) Capabilities() Capabilities {
 		HasTranscript:        true,
 		HasTranscriptWatcher: true,
 		HasClassifier:        true,
-		HasStateDetector:     true,
+		ScreenDetector:       ScreenDetectorCopilot,
 		HasResume:            true,
 		HasYolo:              true,
 		HasInitialPrompt:     true,

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -95,8 +95,13 @@ type Capabilities struct {
 	// backend via ClassifierProvider.
 	HasClassifier bool
 
-	// HasStateDetector indicates PTY state detection is enabled for this agent.
-	HasStateDetector bool
+	// ScreenDetector names which screen-scrape state detector this agent gets,
+	// or ScreenDetectorNone for no PTY state detection. It is a named kind rather
+	// than a boolean because the boolean it replaced encoded the same per-agent
+	// fact twice — once here and once as a switch on the agent name in
+	// internal/pty — and the two could disagree silently: a driver that set the
+	// boolean without a matching case got no detector at all, with no error.
+	ScreenDetector ScreenDetectorKind
 
 	// HasApprovalResolver indicates the daemon should clear pending_approval ->
 	// working off the rendered PTY screen for this agent. Needed by hook-driven
@@ -132,6 +137,20 @@ type Capabilities struct {
 	// agents without it.
 	HasEffortPin bool
 }
+
+// ScreenDetectorKind identifies a screen-scrape state detector implementation.
+// The detectors themselves live in internal/pty, which parses the agent's TUI;
+// this names which one to build.
+type ScreenDetectorKind string
+
+const (
+	// ScreenDetectorNone disables screen-scrape state detection.
+	ScreenDetectorNone ScreenDetectorKind = ""
+	// ScreenDetectorClaude reads Claude Code's status-line frames.
+	ScreenDetectorClaude ScreenDetectorKind = "claude"
+	// ScreenDetectorCopilot reads Copilot CLI's prompt and progress frames.
+	ScreenDetectorCopilot ScreenDetectorKind = "copilot"
+)
 
 var capabilityEnvNameSanitizer = regexp.MustCompile(`[^A-Za-z0-9]+`)
 
@@ -173,8 +192,12 @@ func EffectiveCapabilities(d Driver) Capabilities {
 	if v, ok := boolEnv(prefix + "CLASSIFIER"); ok {
 		caps.HasClassifier = v
 	}
-	if v, ok := boolEnv(prefix + "STATE_DETECTOR"); ok {
-		caps.HasStateDetector = v
+	// STATE_DETECTOR=0 disables the detector; =1 keeps whichever kind the driver
+	// declares. There is nothing for =1 to select for an agent whose driver
+	// declares none, which matches the previous behavior exactly: the boolean
+	// could be forced on, but internal/pty had no detector to build for it.
+	if v, ok := boolEnv(prefix + "STATE_DETECTOR"); ok && !v {
+		caps.ScreenDetector = ScreenDetectorNone
 	}
 	if v, ok := boolEnv(prefix + "APPROVAL_RESOLVER"); ok {
 		caps.HasApprovalResolver = v

--- a/internal/agent/driver_test.go
+++ b/internal/agent/driver_test.go
@@ -24,7 +24,7 @@ func (d testDriver) Capabilities() Capabilities                 { return d.caps 
 
 func TestEffectiveCapabilities_NilDriver(t *testing.T) {
 	caps := EffectiveCapabilities(nil)
-	if caps.HasHooks || caps.HasTranscript || caps.HasClassifier || caps.HasStateDetector {
+	if caps.HasHooks || caps.HasTranscript || caps.HasClassifier || caps.ScreenDetector != ScreenDetectorNone {
 		t.Fatalf("expected zero capabilities for nil driver, got %+v", caps)
 	}
 	if _, ok := GetTranscriptFinder(nil); ok {

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -242,7 +242,7 @@ func (d *Daemon) settingsWithAgentAvailability() map[string]interface{} {
 		settings[capabilitySettingKey(name, "transcript_watcher")] = strconv.FormatBool(caps.HasTranscriptWatcher)
 		settings[capabilitySettingKey(name, "classifier")] = strconv.FormatBool(caps.HasClassifier)
 		settings[capabilitySettingKey(name, "initial_prompt")] = strconv.FormatBool(caps.HasInitialPrompt)
-		settings[capabilitySettingKey(name, "state_detector")] = strconv.FormatBool(caps.HasStateDetector)
+		settings[capabilitySettingKey(name, "state_detector")] = strconv.FormatBool(caps.ScreenDetector != agentdriver.ScreenDetectorNone)
 		settings[capabilitySettingKey(name, "resume")] = strconv.FormatBool(caps.HasResume)
 		settings[capabilitySettingKey(name, "yolo")] = strconv.FormatBool(caps.HasYolo)
 		hasHeadlessTask, _ := agentdriver.HeadlessTaskAvailability(driver)

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -328,21 +328,15 @@ func (m *Manager) Spawn(opts SpawnOptions) error {
 	onState := m.onState
 	m.mu.Unlock()
 
-	detectorEnabled := true
+	// The driver names which observers this agent gets; this only builds them.
+	detectorKind := agentdriver.ScreenDetectorNone
 	approvalResolverEnabled := false
 	if d := agentdriver.Get(agent); d != nil {
 		caps := agentdriver.EffectiveCapabilities(d)
-		detectorEnabled = caps.HasStateDetector
+		detectorKind = caps.ScreenDetector
 		approvalResolverEnabled = caps.HasApprovalResolver
 	}
-	if detectorEnabled {
-		switch agent {
-		case "copilot":
-			session.detector = newCopilotStateDetector()
-		case "claude":
-			session.detector = newClaudeWorkingDetector()
-		}
-	}
+	session.detector = newScreenDetector(detectorKind)
 	if approvalResolverEnabled {
 		session.approvalResolver = &approvalResolver{}
 	}

--- a/internal/pty/state_detector.go
+++ b/internal/pty/state_detector.go
@@ -4,6 +4,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	agentdriver "github.com/victorarias/attn/internal/agent"
 )
 
 const (
@@ -39,67 +41,113 @@ var defaultStateHeuristics = stateHeuristics{
 	listRequestTriggers: []string{"pick one", "choose", "select", "tell me"},
 }
 
-type copilotStateDetector struct {
+// screenDetector scrapes session state from the agent's rendered output. The
+// mechanics are shared across agents — accumulate an ANSI-stripped tail, suppress
+// a claim identical to the last one, re-emit a sustained `working` as a keepalive
+// pulse. What a tail *means* is agent-specific and lives in screenPolicy, which is
+// the only part that changes per agent.
+type screenDetector struct {
+	policy           screenPolicy
 	tail             string
 	lastState        string
 	lastWorkingPulse time.Time
 }
 
-type claudeWorkingDetector struct {
-	tail             string
-	lastState        string
-	lastWorkingPulse time.Time
+// screenPolicy is the agent-specific half of screen scraping.
+type screenPolicy struct {
+	// clean turns a raw chunk into the text that joins the tail.
+	clean func(raw string) string
+	// classify reports the state the tail implies. tail is already updated when
+	// the chunk carried visible text; visible says whether it did, which matters
+	// for agents whose working animation repaints without adding any text.
+	// pulseEligible allows a repeated `working` to re-emit as a keepalive, and is
+	// true only for chunks that look like a live animation frame, so a static
+	// screen never pulses.
+	classify func(tail, raw string, visible bool) (state string, pulseEligible bool)
 }
 
-func newCopilotStateDetector() *copilotStateDetector {
-	return &copilotStateDetector{}
-}
-
-func newClaudeWorkingDetector() *claudeWorkingDetector {
-	return &claudeWorkingDetector{}
-}
+const maxScreenTail = 2000
 
 const workingPulseInterval = 1200 * time.Millisecond
 
 var claudeStatusTimerPattern = regexp.MustCompile(`\((?:\d+h\s+)?(?:\d+m\s+)?\d+s(?:\s+·[^)]*)?\)`)
 var claudeFinalSummaryPattern = regexp.MustCompile(`(?i)\bfor\s+(?:\d+h\s+)?(?:\d+m\s+)?\d+s\b`)
 
-func (d *copilotStateDetector) Observe(chunk []byte) (string, bool) {
+// newScreenDetector builds the detector the driver asked for, or nil (as a nil
+// interface, so callers' nil checks work) when the agent gets none.
+func newScreenDetector(kind agentdriver.ScreenDetectorKind) stateDetector {
+	switch kind {
+	case agentdriver.ScreenDetectorClaude:
+		return newClaudeWorkingDetector()
+	case agentdriver.ScreenDetectorCopilot:
+		return newCopilotStateDetector()
+	default:
+		return nil
+	}
+}
+
+func newCopilotStateDetector() *screenDetector {
+	return &screenDetector{policy: screenPolicy{
+		clean:    stripANSI,
+		classify: classifyCopilotScreen,
+	}}
+}
+
+func newClaudeWorkingDetector() *screenDetector {
+	return &screenDetector{policy: screenPolicy{
+		clean:    func(raw string) string { return normalizeDetectorText(stripANSI(raw)) },
+		classify: classifyClaudeScreen,
+	}}
+}
+
+func (d *screenDetector) Observe(chunk []byte) (string, bool) {
 	if len(chunk) == 0 {
 		return "", false
 	}
 	raw := string(chunk)
-	cleaned := stripANSI(raw)
-	if strings.TrimSpace(cleaned) == "" {
+	cleaned := d.policy.clean(raw)
+	visible := strings.TrimSpace(cleaned) != ""
+	if visible {
+		d.tail += cleaned
+		if len(d.tail) > maxScreenTail {
+			d.tail = trimToLastChars(d.tail, maxScreenTail)
+		}
+	}
+
+	state, pulseEligible := d.policy.classify(d.tail, raw, visible)
+	if state == "" {
 		return "", false
 	}
+	return d.claim(state, time.Now(), pulseEligible)
+}
 
-	d.tail += cleaned
-	const maxTail = 2000
-	if len(d.tail) > maxTail {
-		d.tail = trimToLastChars(d.tail, maxTail)
+// claim reports state to the caller unless it says nothing new: a repeat of the
+// last claim is dropped, except for a `working` animation frame once the pulse
+// interval has elapsed, which keeps a long run visibly alive.
+func (d *screenDetector) claim(state string, now time.Time, pulseEligible bool) (string, bool) {
+	if state != d.lastState {
+		d.lastState = state
+		if state == stateWorking {
+			d.lastWorkingPulse = now
+		}
+		return state, true
 	}
+	if state == stateWorking && pulseEligible && now.Sub(d.lastWorkingPulse) >= workingPulseInterval {
+		d.lastWorkingPulse = now
+		return state, true
+	}
+	return "", false
+}
 
-	recent := tailLines(d.tail, 6)
-	desired := classifyState(recent, defaultStateHeuristics)
+func classifyCopilotScreen(tail, raw string, visible bool) (string, bool) {
+	if !visible {
+		return "", false
+	}
+	desired := classifyState(tailLines(tail, 6), defaultStateHeuristics)
 	if desired == "" {
 		return "", false
 	}
-
-	now := time.Now()
-	emitWorkingPulse := desired == stateWorking &&
-		desired == d.lastState &&
-		looksLikeWorkingAnimation(raw) &&
-		(now.Sub(d.lastWorkingPulse) >= workingPulseInterval)
-
-	if desired == d.lastState && !emitWorkingPulse {
-		return "", false
-	}
-	d.lastState = desired
-	if desired == stateWorking {
-		d.lastWorkingPulse = now
-	}
-	return desired, true
+	return desired, desired == stateWorking && looksLikeWorkingAnimation(raw)
 }
 
 func looksLikeWorkingAnimation(raw string) bool {
@@ -115,49 +163,21 @@ func looksLikeWorkingAnimation(raw string) bool {
 	return hasWorkingKeyword && strings.Contains(raw, "\r") && strings.Contains(raw, "\x1b[")
 }
 
-func (d *claudeWorkingDetector) Observe(chunk []byte) (string, bool) {
-	if len(chunk) == 0 {
-		return "", false
-	}
-	raw := string(chunk)
-	cleaned := normalizeDetectorText(stripANSI(raw))
-	if strings.TrimSpace(cleaned) != "" {
-		d.tail += cleaned
-		const maxTail = 2000
-		if len(d.tail) > maxTail {
-			d.tail = trimToLastChars(d.tail, maxTail)
-		}
-		recent := strings.ToLower(tailLines(d.tail, 6))
+func classifyClaudeScreen(tail, raw string, visible bool) (string, bool) {
+	if visible {
+		recent := strings.ToLower(tailLines(tail, 6))
 		if strings.Contains(recent, "interrupted") && strings.Contains(recent, "what should claude do instead?") {
-			if d.lastState != stateWaitingInput {
-				d.lastState = stateWaitingInput
-				return stateWaitingInput, true
-			}
-			return "", false
+			return stateWaitingInput, false
 		}
-		if desired := classifyState(tailLines(d.tail, 6), defaultStateHeuristics); desired == stateWaitingInput || desired == stateIdle || desired == statePendingApproval {
-			if d.lastState != desired {
-				d.lastState = desired
-				return desired, true
-			}
-			return "", false
+		switch desired := classifyState(tailLines(tail, 6), defaultStateHeuristics); desired {
+		case stateWaitingInput, stateIdle, statePendingApproval:
+			return desired, false
 		}
 	}
 	if !looksLikeClaudeWorkingStatusFrame(raw) {
 		return "", false
 	}
-
-	now := time.Now()
-	if d.lastState != stateWorking {
-		d.lastState = stateWorking
-		d.lastWorkingPulse = now
-		return stateWorking, true
-	}
-	if now.Sub(d.lastWorkingPulse) >= workingPulseInterval {
-		d.lastWorkingPulse = now
-		return stateWorking, true
-	}
-	return "", false
+	return stateWorking, true
 }
 
 func normalizeDetectorText(input string) string {

--- a/internal/pty/state_detector_test.go
+++ b/internal/pty/state_detector_test.go
@@ -3,6 +3,8 @@ package pty
 import (
 	"testing"
 	"time"
+
+	agentdriver "github.com/victorarias/attn/internal/agent"
 )
 
 func TestClassifyState_PromptAtEndIsWaiting(t *testing.T) {
@@ -190,5 +192,40 @@ func TestClaudeWorkingDetector_WelcomePromptBecomesWaitingInput(t *testing.T) {
 	}
 	if state != stateWaitingInput {
 		t.Fatalf("state=%q want=%q", state, stateWaitingInput)
+	}
+}
+
+// TestNewScreenDetector_NoneIsNilInterface guards the typed-nil trap: the session
+// wires its state callback on `detector != nil`, so returning a nil *screenDetector
+// as a non-nil stateDetector would silently give a detector-less agent a detector
+// that claims nothing.
+func TestNewScreenDetector_NoneIsNilInterface(t *testing.T) {
+	if d := newScreenDetector(agentdriver.ScreenDetectorNone); d != nil {
+		t.Fatalf("newScreenDetector(none) = %#v, want a nil interface", d)
+	}
+	if d := newScreenDetector(agentdriver.ScreenDetectorKind("nonexistent")); d != nil {
+		t.Fatalf("newScreenDetector(unknown) = %#v, want a nil interface", d)
+	}
+	if newScreenDetector(agentdriver.ScreenDetectorClaude) == nil {
+		t.Fatal("newScreenDetector(claude) = nil, want a detector")
+	}
+	if newScreenDetector(agentdriver.ScreenDetectorCopilot) == nil {
+		t.Fatal("newScreenDetector(copilot) = nil, want a detector")
+	}
+}
+
+// TestScreenDetector_RepeatedSettledClaimIsDroppedOnce covers the claim
+// suppression both agents now share: a settled state is reported once, and a
+// repeat of it says nothing new, so it must not re-emit.
+func TestScreenDetector_RepeatedSettledClaimIsDroppedOnce(t *testing.T) {
+	d := newScreenDetector(agentdriver.ScreenDetectorClaude)
+	frame := []byte("\r\n> Try \"fix the bug\"\r\n")
+
+	state, changed := d.Observe(frame)
+	if !changed || state != stateWaitingInput {
+		t.Fatalf("first observe = (%q, %v), want (%q, true)", state, changed, stateWaitingInput)
+	}
+	if state, changed := d.Observe(frame); changed {
+		t.Fatalf("repeat observe = (%q, true), want no claim", state)
 	}
 }


### PR DESCRIPTION
Second of five enabling refactors from
`docs/plans/2026-07-25-agent-state-detection.md`. Stacked on #664.
Behavior-preserving; no user-visible change.

## The driver named its detector twice

`Capabilities.HasStateDetector` said "this agent gets PTY state detection" and a
`switch agent { case "copilot": ...; case "claude": ... }` in
`internal/pty/manager.go` said which implementation that meant. Nothing tied them
together: a driver that set the boolean without a matching case got **no detector
at all**, silently, with no error.

Replaced with a `ScreenDetector` kind the driver declares, which `manager.go`
builds exactly as named.

The env override keeps working. `STATE_DETECTOR=0` disables the detector;
`STATE_DETECTOR=1` keeps whichever kind the driver declares — which is what it
already did in every reachable case, since forcing the old boolean on for an agent
with no case in the switch produced no detector either.

## The two detectors were the same object with different opinions

`copilotStateDetector` and `claudeWorkingDetector` each held a tail, a last state,
and a working-pulse timestamp; each trimmed the tail to 2000 chars; each
suppressed a repeat claim and re-emitted a sustained `working` after an interval.
Only the classification differed.

The mechanics collapse into one `screenDetector`; the per-agent part stays as a
`screenPolicy` (`classifyClaudeScreen` / `classifyCopilotScreen`). This is what
makes Claude's classifier a single deletion later rather than an unpick of a
shared 560-line file.

`claim()` reproduces both previous dedup/pulse paths exactly, including copilot
stamping the pulse clock on a first transition into `working`.

## Verification

All pre-existing detector tests pass unchanged — they are the safety net for the
collapse. Two new tests cover what the collapse newly risks:

- **the typed-nil trap**: the session wires its state callback on `detector != nil`,
  so returning a nil `*screenDetector` as a non-nil `stateDetector` would hand a
  detector-less agent a silent one. Mutation-checked by returning
  `(*screenDetector)(nil)`.
- **the now-shared claim suppression**: a settled state reported once must not
  re-emit. Mutation-checked by forcing the dedup branch.

`make test` and `make test-frontend` green.

https://claude.ai/code/session_01KzpRFTTbzGz1JFqK1vvVq5