### PR TITLE
refactor(daemon): decide stop terminality and classification in the daemon

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -169,7 +169,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '188';
+export const PROTOCOL_VERSION = '189';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -4382,9 +4382,11 @@ export enum StateMessageCmd {
 }
 
 export interface StopMessage {
-    cmd:             StopMessageCmd;
-    id:              string;
-    transcript_path: string;
+    background_task_statuses?: string[];
+    cmd:                       StopMessageCmd;
+    id:                        string;
+    pending_session_crons?:    number;
+    transcript_path:           string;
     [property: string]: any;
 }
 
@@ -11237,8 +11239,10 @@ const typeMap: any = {
         { json: "state", js: "state", typ: "" },
     ], "any"),
     "StopMessage": o([
+        { json: "background_task_statuses", js: "background_task_statuses", typ: u(undefined, a("")) },
         { json: "cmd", js: "cmd", typ: r("StopMessageCmd") },
         { json: "id", js: "id", typ: "" },
+        { json: "pending_session_crons", js: "pending_session_crons", typ: u(undefined, 0) },
         { json: "transcript_path", js: "transcript_path", typ: "" },
     ], "any"),
     "SubscribeGitStatusMessage": o([

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -87,74 +87,6 @@ type sessionCron struct {
 	Prompt    string `json:"prompt"`
 }
 
-// hasActiveBackgroundTask reports whether the Stop payload still has background
-// work in flight. Such a Stop is a yield, not a terminal stop: the agent will
-// auto-resume when the work completes, so the session should stay "working"
-// rather than be classified (which, mid-run, would read a not-yet-flushed
-// transcript and mis-detect the session as unknown/idle).
-func hasActiveBackgroundTask(input hookInput) bool {
-	for _, t := range input.BackgroundTasks {
-		if strings.EqualFold(strings.TrimSpace(t.Status), "running") {
-			return true
-		}
-	}
-	return false
-}
-
-// hasPendingSessionCron reports whether the Stop payload has a pending
-// scheduled wakeup. Such a Stop is not terminal: the session is parked and will
-// auto-resume when a cron fires, so it should read as "scheduled" rather than
-// be classified (which would treat the parked turn as idle/unknown). Detection
-// is presence-only — session_crons carries no per-item status, and a fired or
-// deleted cron leaves the list entirely.
-func hasPendingSessionCron(input hookInput) bool {
-	return len(input.SessionCrons) > 0
-}
-
-// nonTerminalStopState returns the runtime state to report for a Stop that is
-// not terminal, or "" when the Stop should fall through to normal daemon
-// classification. A Stop is non-terminal when the turn yields with background
-// work still in flight (auto-resumes on completion) or parked on a pending
-// scheduled wakeup (auto-resumes when a cron fires); classifying such a Stop
-// reads a not-yet-flushed transcript and mis-detects the session as
-// idle/unknown. Running background work outranks a parked schedule, so a Stop
-// with both stays "working"; once both drain, the next Stop classifies normally.
-//
-// relaxBackgroundWork drops the background-work -> "working" rule. It is set for
-// the chief of staff: a chief that has merely armed a Monitor to watch its
-// delegations (or a poll loop) is async-waiting, not working, and pegging it
-// green makes the at-a-glance "is the chief actually working?" signal
-// meaningless. With it set, background work no longer forces "working" (the Stop
-// falls through to normal classification, settling idle/waiting), while a pending
-// scheduled wakeup still parks "scheduled" (quiet/blue, not green).
-func nonTerminalStopState(input hookInput, relaxBackgroundWork bool) string {
-	switch {
-	case !relaxBackgroundWork && hasActiveBackgroundTask(input):
-		return protocol.StateWorking
-	case hasPendingSessionCron(input):
-		return protocol.StateScheduled
-	default:
-		return ""
-	}
-}
-
-// sessionIsChiefOfStaff reports whether sessionID currently holds the
-// profile-wide chief-of-staff role. The daemon owns the role, so the hook asks
-// it (the same decorated session list `attn list` shows). Best-effort: any query
-// error reports false, leaving the default (non-relaxed) busy detection intact.
-func sessionIsChiefOfStaff(c *client.Client, sessionID string) bool {
-	sessions, err := c.Query("")
-	if err != nil {
-		return false
-	}
-	for i := range sessions {
-		if sessions[i].ID == sessionID {
-			return sessions[i].ChiefOfStaff != nil && *sessions[i].ChiefOfStaff
-		}
-	}
-	return false
-}
-
 // todoWriteInput represents the tool_input for TodoWrite
 type todoWriteInput struct {
 	Todos []struct {
@@ -3102,7 +3034,7 @@ func runAgentDirectly(requestedAgent string) {
 				transcriptPath = tf.FindTranscript(sessionID, cwd, startedAt)
 			}
 		}
-		if sendErr := c.SendStop(sessionID, transcriptPath); sendErr != nil {
+		if sendErr := c.SendStop(sessionID, transcriptPath, client.StopFacts{}); sendErr != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not send stop: %v\n", sendErr)
 		}
 	}
@@ -3211,30 +3143,25 @@ func runHookStop() {
 	c := client.New(strings.TrimSpace(os.Getenv("ATTN_SOCKET_PATH")))
 	syncSessionResumeID(c, sessionID, input.SessionID)
 
-	// A Stop is not always terminal: if the turn yields with background work in
-	// flight or parked on a scheduled wakeup, report that non-terminal state and
-	// skip classification (see nonTerminalStopState for the precedence/rationale).
-	// For the chief of staff we relax the background-work -> "working" rule so a
-	// chief merely watching its delegations is not pegged green; only resolve the
-	// (daemon-owned) chief role when there is background work to relax, so normal
-	// stops pay nothing.
-	relaxBackgroundWork := false
-	if hasActiveBackgroundTask(input) {
-		relaxBackgroundWork = sessionIsChiefOfStaff(c, sessionID)
-	}
-	if state := nonTerminalStopState(input, relaxBackgroundWork); state != "" {
-		if err := c.UpdateState(sessionID, state); err != nil {
-			fmt.Fprintf(os.Stderr, "error sending %s state: %v\n", state, err)
-			os.Exit(1)
-		}
-		return
-	}
-
-	// Send stop event to daemon for classification
-	if err := c.SendStop(sessionID, transcriptPath); err != nil {
+	// Report what the payload says about whether the turn actually finished and let
+	// the daemon decide. A stop that yields with background work in flight or parks
+	// on a scheduled wakeup is not terminal, but that judgment (and the chief-of-
+	// staff exception to it) belongs where every other state source is arbitrated.
+	if err := c.SendStop(sessionID, transcriptPath, stopFacts(input)); err != nil {
 		fmt.Fprintf(os.Stderr, "error sending stop: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// stopFacts extracts the terminality facts from a Stop payload. Statuses are
+// passed through verbatim: they are the agent harness's strings, and the rule that
+// reads them lives in the daemon.
+func stopFacts(input hookInput) client.StopFacts {
+	facts := client.StopFacts{PendingSessionCrons: len(input.SessionCrons)}
+	for _, t := range input.BackgroundTasks {
+		facts.BackgroundTaskStatuses = append(facts.BackgroundTaskStatuses, t.Status)
+	}
+	return facts
 }
 
 func runHookSessionStart() {

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -817,38 +818,61 @@ func TestParseOpenArgs(t *testing.T) {
 	}
 }
 
-func TestHasActiveBackgroundTask(t *testing.T) {
+// TestStopFacts locks what the Stop hook reports to the daemon. The payloads are
+// real Claude Code Stop-hook stdin bodies (trimmed to the fields attn parses),
+// captured from live background Workflow runs and CronCreate/CronDelete probes.
+// Statuses pass through verbatim — the rule that reads them lives in the daemon
+// (see nonTerminalStopState there), so the hook's job is extraction only.
+func TestStopFacts(t *testing.T) {
 	cases := []struct {
-		name string
-		// payload is a real Claude Code 2.1.177 Stop-hook stdin body (trimmed to
-		// the fields attn parses), captured from a live background Workflow run.
-		payload string
-		want    bool
+		name         string
+		payload      string
+		wantStatuses []string
+		wantCrons    int
 	}{
 		{
-			name:    "workflow running (parent yields mid-run)",
-			payload: `{"hook_event_name":"Stop","stop_hook_active":false,"background_tasks":[{"id":"wv9p74ip7","type":"workflow","status":"running","name":"hello-parallel"}],"session_crons":[]}`,
-			want:    true,
+			name:         "workflow running (parent yields mid-run)",
+			payload:      `{"hook_event_name":"Stop","stop_hook_active":false,"background_tasks":[{"id":"wv9p74ip7","type":"workflow","status":"running","name":"hello-parallel"}],"session_crons":[]}`,
+			wantStatuses: []string{"running"},
 		},
 		{
-			name:    "workflow plus background shells running",
-			payload: `{"background_tasks":[{"type":"workflow","status":"running"},{"type":"shell","status":"running"},{"type":"shell","status":"running"}]}`,
-			want:    true,
+			name:         "workflow plus background shells running",
+			payload:      `{"background_tasks":[{"type":"workflow","status":"running"},{"type":"shell","status":"running"},{"type":"shell","status":"running"}]}`,
+			wantStatuses: []string{"running", "running", "running"},
 		},
 		{
 			name:    "empty background_tasks (workflow finished)",
 			payload: `{"hook_event_name":"Stop","stop_hook_active":false,"background_tasks":[],"session_crons":[]}`,
-			want:    false,
 		},
 		{
-			name:    "field absent (e.g. another agent)",
+			name:    "fields absent (e.g. another agent)",
 			payload: `{"hook_event_name":"Stop","stop_hook_active":false}`,
-			want:    false,
 		},
 		{
-			name:    "task present but not running",
-			payload: `{"background_tasks":[{"type":"workflow","status":"completed"}]}`,
-			want:    false,
+			name:         "task present but not running is still reported",
+			payload:      `{"background_tasks":[{"type":"workflow","status":"completed"}]}`,
+			wantStatuses: []string{"completed"},
+		},
+		{
+			name:      "recurring cron pending",
+			payload:   `{"hook_event_name":"Stop","stop_hook_active":false,"background_tasks":[],"session_crons":[{"id":"d0055050","schedule":"*/30 * * * *","recurring":true,"prompt":"echo persist-probe"}]}`,
+			wantCrons: 1,
+		},
+		{
+			name:      "one-shot reminder pending",
+			payload:   `{"hook_event_name":"Stop","stop_hook_active":false,"session_crons":[{"id":"5e9a0f21","schedule":"18 14 * * *","recurring":false,"prompt":"echo oneshot-fired"}]}`,
+			wantCrons: 1,
+		},
+		{
+			name:      "recurring plus one-shot pending",
+			payload:   `{"session_crons":[{"id":"43f0809f","schedule":"*/30 * * * *","recurring":true,"prompt":"echo recurring-probe"},{"id":"2b1dec68","schedule":"15 9 20 6 *","recurring":false,"prompt":"echo oneshot-probe"}]}`,
+			wantCrons: 2,
+		},
+		{
+			name:         "background running and cron pending are reported together",
+			payload:      `{"background_tasks":[{"type":"shell","status":"running"}],"session_crons":[{"id":"d0055050","schedule":"*/30 * * * *","recurring":true,"prompt":"echo x"}]}`,
+			wantStatuses: []string{"running"},
+			wantCrons:    1,
 		},
 	}
 	for _, tc := range cases {
@@ -857,128 +881,12 @@ func TestHasActiveBackgroundTask(t *testing.T) {
 			if err := json.Unmarshal([]byte(tc.payload), &input); err != nil {
 				t.Fatalf("unmarshal payload: %v", err)
 			}
-			if got := hasActiveBackgroundTask(input); got != tc.want {
-				t.Fatalf("hasActiveBackgroundTask() = %v, want %v", got, tc.want)
+			facts := stopFacts(input)
+			if !slices.Equal(facts.BackgroundTaskStatuses, tc.wantStatuses) {
+				t.Fatalf("BackgroundTaskStatuses = %q, want %q", facts.BackgroundTaskStatuses, tc.wantStatuses)
 			}
-		})
-	}
-}
-
-func TestHasPendingSessionCron(t *testing.T) {
-	cases := []struct {
-		name string
-		// payload is a real Claude Code 2.1.177 Stop-hook stdin body, captured
-		// from live CronCreate/CronDelete and one-shot-fire probes.
-		payload string
-		want    bool
-	}{
-		{
-			name:    "recurring cron pending",
-			payload: `{"hook_event_name":"Stop","stop_hook_active":false,"background_tasks":[],"session_crons":[{"id":"d0055050","schedule":"*/30 * * * *","recurring":true,"prompt":"echo persist-probe"}]}`,
-			want:    true,
-		},
-		{
-			name:    "one-shot reminder pending",
-			payload: `{"hook_event_name":"Stop","stop_hook_active":false,"session_crons":[{"id":"5e9a0f21","schedule":"18 14 * * *","recurring":false,"prompt":"echo oneshot-fired"}]}`,
-			want:    true,
-		},
-		{
-			name:    "recurring plus one-shot pending",
-			payload: `{"session_crons":[{"id":"43f0809f","schedule":"*/30 * * * *","recurring":true,"prompt":"echo recurring-probe"},{"id":"2b1dec68","schedule":"15 9 20 6 *","recurring":false,"prompt":"echo oneshot-probe"}]}`,
-			want:    true,
-		},
-		{
-			name:    "empty session_crons (nothing scheduled, or all crons fired/deleted)",
-			payload: `{"hook_event_name":"Stop","stop_hook_active":false,"background_tasks":[],"session_crons":[]}`,
-			want:    false,
-		},
-		{
-			name:    "field absent (e.g. another agent)",
-			payload: `{"hook_event_name":"Stop","stop_hook_active":false}`,
-			want:    false,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			var input hookInput
-			if err := json.Unmarshal([]byte(tc.payload), &input); err != nil {
-				t.Fatalf("unmarshal payload: %v", err)
-			}
-			if got := hasPendingSessionCron(input); got != tc.want {
-				t.Fatalf("hasPendingSessionCron() = %v, want %v", got, tc.want)
-			}
-		})
-	}
-}
-
-// TestNonTerminalStopState locks the non-terminal-Stop precedence: running
-// background work outranks a parked schedule, and either outranks classification.
-// The relax cases lock the chief-of-staff relaxation: background work no longer
-// pegs "working", but a parked schedule still parks "scheduled".
-func TestNonTerminalStopState(t *testing.T) {
-	cases := []struct {
-		name    string
-		payload string
-		relax   bool
-		want    string
-	}{
-		{
-			name:    "background running and cron pending -> working wins",
-			payload: `{"background_tasks":[{"type":"shell","status":"running"}],"session_crons":[{"id":"d0055050","schedule":"*/30 * * * *","recurring":true,"prompt":"echo x"}]}`,
-			want:    protocol.StateWorking,
-		},
-		{
-			name:    "cron pending, no background -> scheduled",
-			payload: `{"background_tasks":[],"session_crons":[{"id":"5e9a0f21","schedule":"18 14 * * *","recurring":false,"prompt":"echo x"}]}`,
-			want:    protocol.StateScheduled,
-		},
-		{
-			name:    "background running, no cron -> working",
-			payload: `{"background_tasks":[{"type":"workflow","status":"running"}],"session_crons":[]}`,
-			want:    protocol.StateWorking,
-		},
-		{
-			name:    "completed background and cron pending -> scheduled (completed is not running)",
-			payload: `{"background_tasks":[{"type":"workflow","status":"completed"}],"session_crons":[{"id":"d0055050","schedule":"*/30 * * * *","recurring":true,"prompt":"echo x"}]}`,
-			want:    protocol.StateScheduled,
-		},
-		{
-			name:    "nothing pending -> classify (empty)",
-			payload: `{"background_tasks":[],"session_crons":[]}`,
-			want:    "",
-		},
-		{
-			name:    "fields absent -> classify (empty)",
-			payload: `{"hook_event_name":"Stop","stop_hook_active":false}`,
-			want:    "",
-		},
-		{
-			name:    "chief relax: background running, no cron -> classify (empty), not working",
-			payload: `{"background_tasks":[{"type":"shell","status":"running"}],"session_crons":[]}`,
-			relax:   true,
-			want:    "",
-		},
-		{
-			name:    "chief relax: background running + cron pending -> scheduled, not working",
-			payload: `{"background_tasks":[{"type":"shell","status":"running"}],"session_crons":[{"id":"d0055050","schedule":"*/30 * * * *","recurring":true,"prompt":"echo x"}]}`,
-			relax:   true,
-			want:    protocol.StateScheduled,
-		},
-		{
-			name:    "chief relax: cron only -> scheduled (unchanged by relax)",
-			payload: `{"background_tasks":[],"session_crons":[{"id":"5e9a0f21","schedule":"18 14 * * *","recurring":false,"prompt":"echo x"}]}`,
-			relax:   true,
-			want:    protocol.StateScheduled,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			var input hookInput
-			if err := json.Unmarshal([]byte(tc.payload), &input); err != nil {
-				t.Fatalf("unmarshal payload: %v", err)
-			}
-			if got := nonTerminalStopState(input, tc.relax); got != tc.want {
-				t.Fatalf("nonTerminalStopState() = %q, want %q", got, tc.want)
+			if facts.PendingSessionCrons != tc.wantCrons {
+				t.Fatalf("PendingSessionCrons = %d, want %d", facts.PendingSessionCrons, tc.wantCrons)
 			}
 		})
 	}

--- a/docs/plans/2026-07-25-agent-state-detection.md
+++ b/docs/plans/2026-07-25-agent-state-detection.md
@@ -533,10 +533,11 @@ being fixed as part of the current step.
       claim suppression, working pulse) are shared. `STATE_DETECTOR=0` still
       disables; `=1` keeps the driver's kind, which is what it already did in every
       reachable case.
-- [ ] Enabling refactor 4: the Stop hook reports `background_tasks` /
-      `session_crons` as facts; `nonTerminalStopState` and `sessionIsChiefOfStaff`
-      move daemon-side. Without this the resolver cannot see background work at
-      all.
+- [x] Enabling refactor 4: the Stop hook reports `background_task_statuses` /
+      `pending_session_crons` as facts on `StopMessage` (protocol 189);
+      `nonTerminalStopState` moved to `internal/daemon/stop_terminality.go` and the
+      chief-of-staff lookup is now an in-process `d.isChiefOfStaffSession` call
+      instead of a socket round-trip from the hook back to the daemon.
 - [ ] Feed all of the above into the Phase 0 ring only; still no arbitration
       change. Compare traces against the baseline.
 
@@ -544,9 +545,12 @@ being fixed as part of the current step.
 
 - [ ] New `internal/sessionstate` with `Evidence`, `Resolve`, table tests built
       from Phase 1 traces.
-- [ ] Enabling refactor 5: extract `classifySessionState`'s decision into
-      `Resolve` (todo level and capability gates become evidence rows), leaving a
-      thin IO shell. Six `applyState` exits collapse to one.
+- [x] Enabling refactor 5 (first half): `classifySessionState`'s rules extracted
+      to `internal/daemon/classify_decision.go` as three pure functions
+      (`classifyPreTranscript`, `classifyPostTranscript`, `classifyVerdict`)
+      returning a `classifyDecision`; the shell performs the IO between them and
+      owns the single store write. Six `applyState` exits collapsed to one. Folding
+      these rules into `Resolve` itself is Phase 2 work — this makes them movable.
 - [ ] Daemon evidence table + 1s tick; route live signals through the resolver
       into `applyState` with a new `resolverObservation` cause.
 - [ ] Gate `internal/pty/state_detector.go` to copilot only; delete the keyword

--- a/docs/plans/2026-07-25-agent-state-detection.md
+++ b/docs/plans/2026-07-25-agent-state-detection.md
@@ -463,6 +463,25 @@ being fixed as part of the current step.
   `shouldForwardStateLocked` (`internal/ptybackend/worker.go:166`) dedupes again
   with a `working`-pulse exemption the first layer does not have. Two suppressors
   in series over one stream, neither aware of the other.
+- **The working keepalive pulse is a dead letter on the default backend.** The
+  outer suppressor wins: `Runtime.run` broadcasts `stateChangedEvent` only
+  `if changed`, so the detector's 1.2s `workingPulseInterval` re-emit never
+  crosses the worker→daemon wire, and the backend's own 2s
+  `shouldForwardStateLocked` window only runs on the info-poll path, which is
+  gated behind `if !legacyLifecycle { continue }`. Confirmed live on profile
+  `statedet` (2026-07-25): eleven continuous seconds of claude working produced
+  exactly one `state=working` line in `daemon.log`. This matters beyond tidiness —
+  the pulse is the liveness signal the resolver's TTL design depends on, so the
+  resolver phase must either un-gate it or grow its own heartbeat.
+- **The copilot screen heuristics look stale against copilot 1.0.73.**
+  `classifyCopilotScreen` keys off `defaultStateHeuristics` — prompt markers
+  ` › ` / ` > ` / `❯ ` and status markers "context left" / "for shortcuts". The
+  current copilot CLI renders none of them (its composer is a `┃`-bordered box),
+  and a live copilot session on `statedet` produced no `source=screen` claim at
+  all. Not confirmed against a working turn — this org's policy blocks copilot
+  turns on that machine — so the finding is "the markers are absent from the
+  rendered frames", not "the detector is proven dead". Worth a deliberate check
+  before the resolver starts weighing copilot screen evidence.
 - **That dedup is why `approvalResolver` re-emits `pending_approval` it did not
   observe.** Its own type comment (`internal/pty/approval_resolver.go:13-20`)
   explains it: the onset hook bypasses the worker, so without a redundant

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -281,11 +281,25 @@ func (c *Client) SessionTranscript(targetSessionID, afterCursor string) (*protoc
 }
 
 // SendStop sends a stop signal with transcript path for classification
-func (c *Client) SendStop(id, transcriptPath string) error {
+// StopFacts carries what the Stop hook observed about whether the turn actually
+// finished. The daemon decides what it means; see nonTerminalStopState there. A
+// caller with nothing to report (a hookless agent's process exit) passes the zero
+// value, which reads as a terminal stop.
+type StopFacts struct {
+	// BackgroundTaskStatuses is one status string per background task the agent
+	// reported, verbatim from the harness.
+	BackgroundTaskStatuses []string
+	// PendingSessionCrons counts the scheduled wakeups still pending.
+	PendingSessionCrons int
+}
+
+func (c *Client) SendStop(id, transcriptPath string, facts StopFacts) error {
 	msg := protocol.StopMessage{
-		Cmd:            protocol.CmdStop,
-		ID:             id,
-		TranscriptPath: transcriptPath,
+		Cmd:                    protocol.CmdStop,
+		ID:                     id,
+		TranscriptPath:         transcriptPath,
+		BackgroundTaskStatuses: facts.BackgroundTaskStatuses,
+		PendingSessionCrons:    protocol.Ptr(facts.PendingSessionCrons),
 	}
 	_, err := c.send(msg)
 	return err

--- a/internal/daemon/classify_decision.go
+++ b/internal/daemon/classify_decision.go
@@ -1,0 +1,95 @@
+package daemon
+
+import (
+	"errors"
+	"strings"
+
+	agentdriver "github.com/victorarias/attn/internal/agent"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// Deciding what a settled turn means is a sequence of rules interleaved with two
+// slow, fallible steps: reading the transcript off disk and asking an LLM. The
+// rules are here as pure functions so they can be read and tested as rules;
+// classifySessionState is the shell that performs the IO between them and owns
+// every store write.
+//
+// Each function answers with a classifyDecision: apply this state, or take the
+// next IO step, or leave the state alone.
+
+type classifyAction int
+
+const (
+	// classifyApply: the state is decided; apply it.
+	classifyApply classifyAction = iota
+	// classifyReadTranscript: the transcript must be read to decide.
+	classifyReadTranscript
+	// classifyRunClassifier: the last assistant message must go to the classifier.
+	classifyRunClassifier
+	// classifySkip: nothing to decide, and nothing to write.
+	classifySkip
+)
+
+type classifyDecision struct {
+	action classifyAction
+	// state is meaningful only for classifyApply.
+	state string
+	// reason is the diagnostic label logged with the decision. The names match the
+	// ones the previous inline log lines used ("transcript_parse_error",
+	// "classifier_error", "classifier_unknown_response"), so a log search for a
+	// past incident still finds them.
+	reason string
+}
+
+// classifyPreTranscript decides from what the daemon already holds, before paying
+// for any IO.
+//
+// pendingTodos outranks everything: a turn that stopped with unfinished todos is
+// waiting on the user. transcriptEnabled / classifierEnabled are the per-agent
+// capability gates; an agent with either disabled settles idle rather than being
+// left in whatever state it was.
+func classifyPreTranscript(pendingTodos int, transcriptEnabled, classifierEnabled bool) classifyDecision {
+	switch {
+	case pendingTodos > 0:
+		return classifyDecision{action: classifyApply, state: protocol.StateWaitingInput, reason: "pending_todos"}
+	case !transcriptEnabled:
+		return classifyDecision{action: classifyApply, state: protocol.StateIdle, reason: "transcript_disabled"}
+	case !classifierEnabled:
+		return classifyDecision{action: classifyApply, state: protocol.StateIdle, reason: "classifier_disabled"}
+	default:
+		return classifyDecision{action: classifyReadTranscript}
+	}
+}
+
+// classifyPostTranscript decides from the transcript read.
+//
+// ErrNoNewAssistantTurn means the turn we would classify has already been
+// classified, so there is nothing to say — importantly not "unknown", which would
+// overwrite a good state with a bad one. Any other read error is genuinely
+// unknown. An empty last message means the agent said nothing, which settles idle
+// without paying for a classifier call.
+func classifyPostTranscript(lastMessage string, err error) classifyDecision {
+	if err != nil {
+		if errors.Is(err, agentdriver.ErrNoNewAssistantTurn) {
+			return classifyDecision{action: classifySkip, reason: "no_new_assistant_turn"}
+		}
+		return classifyDecision{action: classifyApply, state: protocol.StateUnknown, reason: "transcript_parse_error"}
+	}
+	if strings.TrimSpace(lastMessage) == "" {
+		return classifyDecision{action: classifyApply, state: protocol.StateIdle, reason: "empty_last_message"}
+	}
+	return classifyDecision{action: classifyRunClassifier}
+}
+
+// classifyVerdict maps the classifier's answer to a state. A failed call and an
+// unknown answer both land on unknown, but they are separate reasons: one is our
+// plumbing failing, the other is the classifier declining to decide.
+func classifyVerdict(state string, err error) classifyDecision {
+	if err != nil {
+		return classifyDecision{action: classifyApply, state: protocol.StateUnknown, reason: "classifier_error"}
+	}
+	if state == protocol.StateUnknown {
+		return classifyDecision{action: classifyApply, state: protocol.StateUnknown, reason: "classifier_unknown_response"}
+	}
+	return classifyDecision{action: classifyApply, state: state, reason: "classifier"}
+}

--- a/internal/daemon/classify_decision_test.go
+++ b/internal/daemon/classify_decision_test.go
@@ -1,0 +1,166 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	agentdriver "github.com/victorarias/attn/internal/agent"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func TestClassifyPreTranscript(t *testing.T) {
+	cases := []struct {
+		name              string
+		pendingTodos      int
+		transcriptEnabled bool
+		classifierEnabled bool
+		wantAction        classifyAction
+		wantState         string
+	}{
+		{
+			name:              "pending todos outrank everything",
+			pendingTodos:      1,
+			transcriptEnabled: true,
+			classifierEnabled: true,
+			wantAction:        classifyApply,
+			wantState:         protocol.StateWaitingInput,
+		},
+		{
+			name:              "pending todos win even with both capabilities off",
+			pendingTodos:      2,
+			transcriptEnabled: false,
+			classifierEnabled: false,
+			wantAction:        classifyApply,
+			wantState:         protocol.StateWaitingInput,
+		},
+		{
+			name:              "transcript disabled settles idle",
+			transcriptEnabled: false,
+			classifierEnabled: true,
+			wantAction:        classifyApply,
+			wantState:         protocol.StateIdle,
+		},
+		{
+			name:              "classifier disabled settles idle",
+			transcriptEnabled: true,
+			classifierEnabled: false,
+			wantAction:        classifyApply,
+			wantState:         protocol.StateIdle,
+		},
+		{
+			name:              "nothing decided yet reads the transcript",
+			transcriptEnabled: true,
+			classifierEnabled: true,
+			wantAction:        classifyReadTranscript,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyPreTranscript(tc.pendingTodos, tc.transcriptEnabled, tc.classifierEnabled)
+			if got.action != tc.wantAction || got.state != tc.wantState {
+				t.Fatalf("classifyPreTranscript() = %+v, want action %v state %q", got, tc.wantAction, tc.wantState)
+			}
+			if got.reason == "" && got.action == classifyApply {
+				t.Fatal("an applied state must carry a reason")
+			}
+		})
+	}
+}
+
+func TestClassifyPostTranscript(t *testing.T) {
+	cases := []struct {
+		name        string
+		lastMessage string
+		err         error
+		wantAction  classifyAction
+		wantState   string
+		wantReason  string
+	}{
+		{
+			name:       "no new assistant turn writes nothing",
+			err:        fmt.Errorf("wrapped: %w", agentdriver.ErrNoNewAssistantTurn),
+			wantAction: classifySkip,
+			wantReason: "no_new_assistant_turn",
+		},
+		{
+			name:       "any other read error is unknown",
+			err:        errors.New("permission denied"),
+			wantAction: classifyApply,
+			wantState:  protocol.StateUnknown,
+			wantReason: "transcript_parse_error",
+		},
+		{
+			name:       "empty message settles idle without a classifier call",
+			wantAction: classifyApply,
+			wantState:  protocol.StateIdle,
+			wantReason: "empty_last_message",
+		},
+		{
+			name:        "whitespace-only message counts as empty",
+			lastMessage: "  \n\t ",
+			wantAction:  classifyApply,
+			wantState:   protocol.StateIdle,
+			wantReason:  "empty_last_message",
+		},
+		{
+			name:        "real message goes to the classifier",
+			lastMessage: "Done. Want me to open the PR?",
+			wantAction:  classifyRunClassifier,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyPostTranscript(tc.lastMessage, tc.err)
+			if got.action != tc.wantAction || got.state != tc.wantState || got.reason != tc.wantReason {
+				t.Fatalf("classifyPostTranscript() = %+v, want action %v state %q reason %q",
+					got, tc.wantAction, tc.wantState, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestClassifyVerdict(t *testing.T) {
+	cases := []struct {
+		name       string
+		state      string
+		err        error
+		wantState  string
+		wantReason string
+	}{
+		{
+			name:       "classifier failure is unknown, attributed to us",
+			state:      "",
+			err:        errors.New("timeout"),
+			wantState:  protocol.StateUnknown,
+			wantReason: "classifier_error",
+		},
+		{
+			name:       "an unknown answer is attributed to the classifier",
+			state:      protocol.StateUnknown,
+			wantState:  protocol.StateUnknown,
+			wantReason: "classifier_unknown_response",
+		},
+		{
+			name:       "a real answer passes through",
+			state:      protocol.StateWaitingInput,
+			wantState:  protocol.StateWaitingInput,
+			wantReason: "classifier",
+		},
+		{
+			name:       "a failed call outranks whatever state came back with it",
+			state:      protocol.StateIdle,
+			err:        errors.New("timeout"),
+			wantState:  protocol.StateUnknown,
+			wantReason: "classifier_error",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyVerdict(tc.state, tc.err)
+			if got.action != classifyApply || got.state != tc.wantState || got.reason != tc.wantReason {
+				t.Fatalf("classifyVerdict() = %+v, want state %q reason %q", got, tc.wantState, tc.wantReason)
+			}
+		})
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2420,6 +2420,24 @@ func (d *Daemon) persistResumeSessionID(sessionID, resumeSessionID string) {
 
 func (d *Daemon) handleStop(conn net.Conn, msg *protocol.StopMessage) {
 	d.logf("handleStop: session=%s, transcript_path=%s", msg.ID, msg.TranscriptPath)
+
+	// A non-terminal stop is a yield, not an end: hold the session in the state the
+	// facts imply and do none of the end-of-turn work below (no resume-id capture,
+	// no narration enqueue, no classification). The turn resumes on its own.
+	if state := nonTerminalStopState(msg, d.isChiefOfStaffSession(msg.ID)); state != "" {
+		d.logf(
+			"handleStop: non-terminal stop session=%s state=%s background_tasks=%d pending_crons=%d",
+			msg.ID, state, len(msg.BackgroundTaskStatuses), protocol.Deref(msg.PendingSessionCrons),
+		)
+		d.applyState(sessionStateChange{
+			sessionID: msg.ID,
+			state:     state,
+			cause:     liveSignal{},
+		})
+		d.sendOK(conn)
+		return
+	}
+
 	if session := d.store.Get(msg.ID); session != nil {
 		if resumeSessionID := agentdriver.ResumeSessionIDFromStopTranscriptPath(
 			agentdriver.Get(string(session.Agent)),
@@ -2515,9 +2533,15 @@ func (d *Daemon) handleSessionVisualized(sessionID string) {
 	go d.classifySessionState(sessionID, transcriptPath)
 }
 
+// classifySessionState decides what a settled turn means and applies the result.
+// It is the IO shell around the rules in classify_decision.go: it gathers inputs,
+// performs the transcript read and the classifier call between rules, and owns the
+// single store write. The rules themselves make no decision about when to pay for
+// IO — they say what is still needed.
 func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
-	// Capture timestamp BEFORE starting classification
-	// This prevents slow classifier results from overwriting newer state updates
+	// Capture the timestamp BEFORE any classification work: applyState rejects a
+	// classifierObservation older than the state it would overwrite, so a slow
+	// classifier cannot clobber a newer live signal.
 	classificationStartTime := time.Now()
 	d.logf("classifySessionState: starting for session=%s, transcript=%s", sessionID, transcriptPath)
 
@@ -2525,6 +2549,19 @@ func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
 	if session == nil {
 		d.logf("classifySessionState: session %s not found, aborting", sessionID)
 		return
+	}
+
+	apply := func(decision classifyDecision) {
+		if decision.action != classifyApply {
+			d.logf("classifySessionState: session=%s no state applied reason=%s", sessionID, decision.reason)
+			return
+		}
+		d.logf("classifySessionState: session=%s state=%s reason=%s", sessionID, decision.state, decision.reason)
+		d.applyState(sessionStateChange{
+			sessionID: sessionID,
+			state:     decision.state,
+			cause:     classifierObservation{observedAt: classificationStartTime},
+		})
 	}
 
 	// Capability gates: agents can independently disable transcript parsing and
@@ -2537,42 +2574,19 @@ func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
 		classifierEnabled = caps.HasClassifier
 	}
 
-	// Check pending todos first (fast path)
-	// Todos are stored as "[✓] task" (completed), "[→] task" (in_progress), "[ ] task" (pending)
-	pendingCount := 0
+	// Todos are stored as "[✓] task" (completed), "[→] task" (in_progress),
+	// "[ ] task" (pending).
+	pendingTodos := 0
 	for _, todo := range session.Todos {
 		if !strings.HasPrefix(todo, "[✓]") {
-			pendingCount++
+			pendingTodos++
 		}
 	}
-	d.logf("classifySessionState: session %s has %d total todos, %d pending", sessionID, len(session.Todos), pendingCount)
-	if pendingCount > 0 {
-		d.logf("classifySessionState: session %s has pending todos, setting waiting_input", sessionID)
-		d.applyState(sessionStateChange{
-			sessionID: sessionID,
-			state:     protocol.StateWaitingInput,
-			cause:     classifierObservation{observedAt: classificationStartTime},
-		})
-		return
-	}
+	d.logf("classifySessionState: session %s has %d total todos, %d pending", sessionID, len(session.Todos), pendingTodos)
 
-	if !transcriptEnabled {
-		d.logf("classifySessionState: transcript disabled for agent=%s session=%s, setting idle", session.Agent, sessionID)
-		d.applyState(sessionStateChange{
-			sessionID: sessionID,
-			state:     protocol.StateIdle,
-			cause:     classifierObservation{observedAt: classificationStartTime},
-		})
-		return
-	}
-
-	if !classifierEnabled {
-		d.logf("classifySessionState: classifier disabled for agent=%s session=%s, setting idle", session.Agent, sessionID)
-		d.applyState(sessionStateChange{
-			sessionID: sessionID,
-			state:     protocol.StateIdle,
-			cause:     classifierObservation{observedAt: classificationStartTime},
-		})
+	decision := classifyPreTranscript(pendingTodos, transcriptEnabled, classifierEnabled)
+	if decision.action != classifyReadTranscript {
+		apply(decision)
 		return
 	}
 
@@ -2586,7 +2600,6 @@ func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
 		)
 	}
 
-	// Parse transcript for last assistant message
 	d.logf("classifySessionState: parsing transcript for session %s", sessionID)
 	extract := d.extractLastAssistantMessage
 	if d.classificationTranscriptExtractor != nil {
@@ -2594,62 +2607,36 @@ func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
 	}
 	lastMessage, assistantTurnID, err := extract(session, resolvedTranscriptPath, 500, classificationStartTime)
 	if err != nil {
-		if errors.Is(err, agentdriver.ErrNoNewAssistantTurn) {
-			d.logf("classifySessionState: no new assistant turn for session %s, skipping classification", sessionID)
-			return
-		}
-		d.logf("classifySessionState: transcript parse error for %s: %v", sessionID, err)
-		d.logf("classifySessionState: unknown reason=transcript_parse_error session=%s transcript=%s", sessionID, resolvedTranscriptPath)
-		d.applyState(sessionStateChange{
-			sessionID: sessionID,
-			state:     protocol.StateUnknown,
-			cause:     classifierObservation{observedAt: classificationStartTime},
-		})
-		return
+		d.logf("classifySessionState: transcript read failed for %s: %v (transcript=%s)", sessionID, err, resolvedTranscriptPath)
 	}
-	if strings.TrimSpace(assistantTurnID) != "" {
+	if strings.TrimSpace(assistantTurnID) != "" && err == nil {
 		defer d.clearClassifyingTurn(sessionID)
 	}
 
-	lastMessage = strings.TrimSpace(lastMessage)
-	if lastMessage == "" {
-		d.logf("classifySessionState: empty last message for session %s, setting idle", sessionID)
-		d.applyState(sessionStateChange{
-			sessionID: sessionID,
-			state:     protocol.StateIdle,
-			cause:     classifierObservation{observedAt: classificationStartTime},
-		})
+	decision = classifyPostTranscript(lastMessage, err)
+	if decision.action != classifyRunClassifier {
+		apply(decision)
 		return
 	}
+	lastMessage = strings.TrimSpace(lastMessage)
 
-	// Log truncated message
 	logMsg := lastMessage
 	if len(logMsg) > 100 {
 		logMsg = logMsg[:100] + "..."
 	}
 	d.logf("classifySessionState: last message for session %s: %s", sessionID, logMsg)
 
-	// Classify with LLM (can be slow - 30+ seconds)
+	// Can be slow — 30+ seconds.
 	d.logf("classifySessionState: calling classifier for session %s", sessionID)
 	state, err := d.runClassifier(session, lastMessage, 30*time.Second)
 	if err != nil {
 		d.logf("classifySessionState: classifier error for %s: %v", sessionID, err)
-		d.logf("classifySessionState: unknown reason=classifier_error session=%s err=%v", sessionID, err)
-		state = protocol.StateUnknown
 	}
-	if err == nil && state == protocol.StateUnknown {
-		d.logf("classifySessionState: unknown reason=classifier_unknown_response session=%s", sessionID)
-	}
-
-	d.logf("classifySessionState: session %s classified as %s", sessionID, state)
+	decision = classifyVerdict(state, err)
 	if strings.TrimSpace(assistantTurnID) != "" {
 		d.setClassifiedTurnID(sessionID, assistantTurnID)
 	}
-	d.applyState(sessionStateChange{
-		sessionID: sessionID,
-		state:     state,
-		cause:     classifierObservation{observedAt: classificationStartTime},
-	})
+	apply(decision)
 }
 
 func (d *Daemon) runClassifier(session *protocol.Session, text string, timeout time.Duration) (string, error) {

--- a/internal/daemon/stop_terminality.go
+++ b/internal/daemon/stop_terminality.go
@@ -1,0 +1,62 @@
+package daemon
+
+import (
+	"strings"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// A Stop is not always terminal. The turn may yield with background work still
+// in flight, in which case the agent auto-resumes when the work completes, or
+// park on a pending scheduled wakeup, in which case it resumes when a cron
+// fires. Classifying such a stop reads a not-yet-flushed transcript and
+// mis-detects the session as idle/unknown.
+//
+// The Stop hook reports the facts (the statuses of the agent's background tasks
+// and how many scheduled wakeups are pending); the rules below decide what they
+// mean. The decision lives here rather than in the hook binary because the hook
+// had to ask the daemon back for the chief-of-staff role to make it, and because
+// a hook that collapses facts into a state name hides them from the daemon —
+// which is where state from every other source is arbitrated.
+
+// hasActiveBackgroundTask reports whether the stop still has background work in
+// flight. Status comparison is case-insensitive because it is the agent
+// harness's string, not ours.
+func hasActiveBackgroundTask(msg *protocol.StopMessage) bool {
+	for _, status := range msg.BackgroundTaskStatuses {
+		if strings.EqualFold(strings.TrimSpace(status), "running") {
+			return true
+		}
+	}
+	return false
+}
+
+// hasPendingSessionCron reports whether the stop parked on a scheduled wakeup.
+// Detection is presence-only — session_crons carries no per-item status, and a
+// fired or deleted cron leaves the list entirely.
+func hasPendingSessionCron(msg *protocol.StopMessage) bool {
+	return protocol.Deref(msg.PendingSessionCrons) > 0
+}
+
+// nonTerminalStopState returns the runtime state to hold the session in for a
+// Stop that is not terminal, or "" when the stop should fall through to normal
+// classification. Running background work outranks a parked schedule, so a stop
+// with both stays "working"; once both drain, the next stop classifies normally.
+//
+// relaxBackgroundWork drops the background-work -> "working" rule. It is set for
+// the chief of staff: a chief that has merely armed a Monitor to watch its
+// delegations (or a poll loop) is async-waiting, not working, and pegging it
+// green makes the at-a-glance "is the chief actually working?" signal
+// meaningless. With it set, background work no longer forces "working" (the stop
+// falls through to normal classification, settling idle/waiting), while a pending
+// scheduled wakeup still parks "scheduled" (quiet/blue, not green).
+func nonTerminalStopState(msg *protocol.StopMessage, relaxBackgroundWork bool) string {
+	switch {
+	case !relaxBackgroundWork && hasActiveBackgroundTask(msg):
+		return protocol.StateWorking
+	case hasPendingSessionCron(msg):
+		return protocol.StateScheduled
+	default:
+		return ""
+	}
+}

--- a/internal/daemon/stop_terminality_test.go
+++ b/internal/daemon/stop_terminality_test.go
@@ -1,0 +1,193 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/client"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// TestNonTerminalStopState locks the non-terminal-Stop precedence: running
+// background work outranks a parked schedule, and either outranks classification.
+// The relax cases lock the chief-of-staff relaxation: background work no longer
+// pegs "working", but a parked schedule still parks "scheduled".
+//
+// The status strings are the agent harness's, captured from live Claude Code Stop
+// payloads; cmd/attn's TestStopFacts covers extracting them from those payloads.
+func TestNonTerminalStopState(t *testing.T) {
+	cases := []struct {
+		name     string
+		statuses []string
+		crons    int
+		relax    bool
+		want     string
+	}{
+		{
+			name:     "background running and cron pending -> working wins",
+			statuses: []string{"running"},
+			crons:    1,
+			want:     protocol.StateWorking,
+		},
+		{
+			name:  "cron pending, no background -> scheduled",
+			crons: 1,
+			want:  protocol.StateScheduled,
+		},
+		{
+			name:     "background running, no cron -> working",
+			statuses: []string{"running"},
+			want:     protocol.StateWorking,
+		},
+		{
+			name:     "completed background and cron pending -> scheduled (completed is not running)",
+			statuses: []string{"completed"},
+			crons:    1,
+			want:     protocol.StateScheduled,
+		},
+		{
+			name:     "mixed statuses count as running if any is",
+			statuses: []string{"completed", "running"},
+			want:     protocol.StateWorking,
+		},
+		{
+			name:     "status casing is the harness's, not ours",
+			statuses: []string{"Running"},
+			want:     protocol.StateWorking,
+		},
+		{
+			name: "nothing pending -> classify (empty)",
+			want: "",
+		},
+		{
+			name:     "chief relax: background running, no cron -> classify (empty), not working",
+			statuses: []string{"running"},
+			relax:    true,
+			want:     "",
+		},
+		{
+			name:     "chief relax: background running + cron pending -> scheduled, not working",
+			statuses: []string{"running"},
+			crons:    1,
+			relax:    true,
+			want:     protocol.StateScheduled,
+		},
+		{
+			name:  "chief relax: cron only -> scheduled (unchanged by relax)",
+			crons: 1,
+			relax: true,
+			want:  protocol.StateScheduled,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := &protocol.StopMessage{
+				Cmd:                    protocol.CmdStop,
+				ID:                     "sess",
+				BackgroundTaskStatuses: tc.statuses,
+			}
+			if tc.crons > 0 {
+				msg.PendingSessionCrons = protocol.Ptr(tc.crons)
+			}
+			if got := nonTerminalStopState(msg, tc.relax); got != tc.want {
+				t.Fatalf("nonTerminalStopState() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNonTerminalStopState_LegacyHookClassifies covers the version skew the
+// optional fields buy: a hook binary predating them reports neither fact, and the
+// stop must read as terminal rather than parking the session in a state the
+// daemon cannot see a reason for.
+func TestNonTerminalStopState_LegacyHookClassifies(t *testing.T) {
+	msg := &protocol.StopMessage{Cmd: protocol.CmdStop, ID: "sess", TranscriptPath: "/tmp/t.jsonl"}
+	if got := nonTerminalStopState(msg, false); got != "" {
+		t.Fatalf("nonTerminalStopState(legacy) = %q, want the terminal path", got)
+	}
+}
+
+// TestDaemon_StopCommand_BackgroundWork_StaysWorking is the wiring test: the hook
+// now reports facts rather than a state, so handleStop must apply the non-terminal
+// state itself. It also pins that the stop does not fall through to the
+// end-of-turn path — classification on a yield reads a not-yet-flushed transcript
+// and is what used to mis-detect these sessions as idle/unknown.
+func TestDaemon_StopCommand_BackgroundWork_StaysWorking(t *testing.T) {
+	useFreeWSPort(t)
+
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
+	os.Remove(sockPath)
+
+	d := NewForTesting(sockPath)
+	go d.Start()
+	defer func() {
+		d.Stop()
+		os.Remove(sockPath)
+	}()
+	waitForSocket(t, sockPath, 5*time.Second)
+
+	c := client.New(sockPath)
+	if err := c.Register("bg-session", "Test", "/tmp/test"); err != nil {
+		t.Fatalf("Register error: %v", err)
+	}
+
+	// A transcript path that cannot be classified: if the stop wrongly falls
+	// through to the end-of-turn path, the session lands on unknown/idle rather
+	// than staying working.
+	if err := c.SendStop("bg-session", "/nonexistent/transcript.jsonl", client.StopFacts{
+		BackgroundTaskStatuses: []string{"running"},
+	}); err != nil {
+		t.Fatalf("SendStop error: %v", err)
+	}
+
+	sessions, err := c.Query("")
+	if err != nil {
+		t.Fatalf("Query error: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	if sessions[0].State != protocol.SessionStateWorking {
+		t.Fatalf("state = %s, want %s", sessions[0].State, protocol.SessionStateWorking)
+	}
+}
+
+// TestDaemon_StopCommand_PendingCron_Parks covers the other non-terminal branch:
+// a stop parked on a scheduled wakeup reads as scheduled, not classified.
+func TestDaemon_StopCommand_PendingCron_Parks(t *testing.T) {
+	useFreeWSPort(t)
+
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
+	os.Remove(sockPath)
+
+	d := NewForTesting(sockPath)
+	go d.Start()
+	defer func() {
+		d.Stop()
+		os.Remove(sockPath)
+	}()
+	waitForSocket(t, sockPath, 5*time.Second)
+
+	c := client.New(sockPath)
+	if err := c.Register("cron-session", "Test", "/tmp/test"); err != nil {
+		t.Fatalf("Register error: %v", err)
+	}
+	if err := c.SendStop("cron-session", "/nonexistent/transcript.jsonl", client.StopFacts{
+		PendingSessionCrons: 1,
+	}); err != nil {
+		t.Fatalf("SendStop error: %v", err)
+	}
+
+	sessions, err := c.Query("")
+	if err != nil {
+		t.Fatalf("Query error: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	if sessions[0].State != protocol.SessionStateScheduled {
+		t.Fatalf("state = %s, want %s", sessions[0].State, protocol.SessionStateScheduled)
+	}
+}

--- a/internal/daemon/testharness_test.go
+++ b/internal/daemon/testharness_test.go
@@ -99,7 +99,7 @@ func TestHarness_ClaudeStop_RetriesTranscriptReadOnFirstTurn(t *testing.T) {
 		_ = os.WriteFile(transcriptPath, []byte(line), 0o644)
 	}()
 
-	if err := c.SendStop("claude-session", transcriptPath); err != nil {
+	if err := c.SendStop("claude-session", transcriptPath, client.StopFacts{}); err != nil {
 		t.Fatalf("SendStop error: %v", err)
 	}
 

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "188"
+const ProtocolVersion = "189"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -4309,11 +4309,19 @@ type StateMessage struct {
 }
 
 type StopMessage struct {
+	// BackgroundTaskStatuses corresponds to the JSON schema field
+	// "background_task_statuses".
+	BackgroundTaskStatuses []string `json:"background_task_statuses,omitempty,omitzero"`
+
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
 
 	// ID corresponds to the JSON schema field "id".
 	ID string `json:"id"`
+
+	// PendingSessionCrons corresponds to the JSON schema field
+	// "pending_session_crons".
+	PendingSessionCrons *int `json:"pending_session_crons,omitempty,omitzero"`
 
 	// TranscriptPath corresponds to the JSON schema field "transcript_path".
 	TranscriptPath string `json:"transcript_path"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -632,10 +632,23 @@ model SessionTranscriptMessage {
   after_cursor?: string;
 }
 
+// A Stop is not always terminal: the turn may yield with background work still
+// in flight (it auto-resumes on completion) or park on a pending scheduled
+// wakeup. These carry that as FACTS observed by the hook — the statuses of the
+// agent's background tasks, and how many scheduled wakeups are pending — and the
+// daemon decides what they mean. The hook used to decide and report a state
+// instead, which hid the facts from the daemon and forced the hook to query the
+// daemon back for the chief-of-staff role it needed to decide.
+//
+// Both are optional: a hook binary predating them reports neither, and the
+// daemon then classifies the stop as terminal, which is what such a hook already
+// caused by omitting the state update.
 model StopMessage {
   cmd: "stop";
   id: string;
   transcript_path: string;
+  background_task_statuses?: string[];
+  pending_session_crons?: int32;
 }
 
 model TodosMessage {


### PR DESCRIPTION
Refactors 4 and 5 of five from `docs/plans/2026-07-25-agent-state-detection.md`.
Stacked on #665. Behavior-preserving; **protocol 189**.

## The Stop hook was deciding terminality

A Stop that yields with background work in flight (`attn wait-pr`, a Workflow) or
parks on a scheduled wakeup is not the end of a turn. The hook binary decided
that and reported a **state name**. To decide it, `runHookStop` opened a socket to
the daemon and queried the session list to learn whether the session held the
chief-of-staff role — asking the daemon for an input so it could send the daemon a
conclusion.

`StopMessage` now carries the facts: `background_task_statuses` (verbatim harness
strings) and `pending_session_crons`. The precedence rules move to
`internal/daemon/stop_terminality.go`; the chief lookup becomes the in-process
`d.isChiefOfStaffSession` call it should always have been.

This is the one refactor in the series that is not purely structural: the resolver
in Phase 2 **cannot see background work at all** while the CLI collapses it into a
state string before it crosses the socket.

Both fields are optional, protocol bumped to 189. A hook binary predating them
reports neither fact and the stop reads as terminal — exactly what such a hook
already caused by not sending the state update. The non-terminal branch sits at
the top of `handleStop`, before resume-id capture, narration enqueues, and
classification, preserving the old flow where a non-terminal stop never reached
`handleStop` at all.

## classifySessionState was a resolver written as control flow

~130 lines, six `applyState` exits interleaved with capability gates, todo
counting, transcript path resolution, file IO, and a 30-second LLM call. The
decision could only be tested by standing up a daemon.

Split into three pure rules in `classify_decision.go` (`classifyPreTranscript`,
`classifyPostTranscript`, `classifyVerdict`) plus an IO shell that performs the
reads between them and owns a single store write. Reason labels keep the names the
old inline log lines used, so a log search for a past incident still finds them.

Behavior-preserving throughout: `clearClassifyingTurn` still only defers on a
successful read, `setClassifiedTurnID` still only fires on the classifier path, and
a no-new-assistant-turn read still writes nothing rather than overwriting a good
state with `unknown`.

## Verification

`make test-all` green. Tests moved with the decisions: `cmd/attn` keeps the corpus
of real captured Claude Stop payloads (now asserting fact extraction), the daemon
gets the precedence table, a legacy-hook case, and two socket-level wiring tests.
All rules mutation-checked individually.

**Live**, profile `statedet`, full install:

1. Real Claude session via `real-app:scenario-tr402-local-claude` — protocol 189
   connects, and the new decision logging works end to end:
   ```
   handleStop: session=9bad6afc…
   classifySessionState: session=9bad6afc… no state applied reason=no_new_assistant_turn
   classifySessionState: session=9bad6afc… state=idle reason=classifier
   ```
2. Both non-terminal branches through the **real production path** — a real
   captured Claude Stop payload piped into the bundled `attn _hook-stop`, over the
   socket, to the daemon:
   ```
   handleStop: non-terminal stop session=live-bg state=working   background_tasks=1 pending_crons=0
   handleStop: non-terminal stop session=live-bg state=scheduled background_tasks=0 pending_crons=1
   ```
   with `query` confirming the session read `working` then `scheduled`.

https://claude.ai/code/session_01KzpRFTTbzGz1JFqK1vvVq5