### PR TITLE
feat(state): record every state observation and explain it

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -169,7 +169,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '189';
+export const PROTOCOL_VERSION = '190';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -274,6 +274,9 @@
 //   const setWorkspaceRankMessage = Convert.toSetWorkspaceRankMessage(json);
 //   const spawnResultMessage = Convert.toSpawnResultMessage(json);
 //   const spawnSessionMessage = Convert.toSpawnSessionMessage(json);
+//   const stateExplainEntry = Convert.toStateExplainEntry(json);
+//   const stateExplainMessage = Convert.toStateExplainMessage(json);
+//   const stateExplainResult = Convert.toStateExplainResult(json);
 //   const stateMessage = Convert.toStateMessage(json);
 //   const stopMessage = Convert.toStopMessage(json);
 //   const subscribeGitStatusMessage = Convert.toSubscribeGitStatusMessage(json);
@@ -3814,6 +3817,7 @@ export interface Response {
     session_instructions_result?:          SessionInstructionsResultObject;
     session_transcript_result?:            SessionTranscriptResultObject;
     sessions?:                             SessionElement[];
+    state_explain_result?:                 StateExplainResultObject;
     ticket_attach_result?:                 TicketAttachResultObject;
     ticket_comment_result?:                TicketCommentResultObject;
     ticket_create_result?:                 TicketCreateResultObject;
@@ -3900,6 +3904,28 @@ export interface EventElement {
     timestamp?:    string;
     tool_call_id?: string;
     tool_name?:    string;
+    [property: string]: any;
+}
+
+export interface StateExplainResultObject {
+    agent:        string;
+    capacity:     number;
+    observations: ObservationElement[];
+    session_id:   string;
+    state:        string;
+    state_since?: string;
+    [property: string]: any;
+}
+
+export interface ObservationElement {
+    cause?:      string;
+    claim:       string;
+    detail?:     string;
+    observed_at: string;
+    outcome:     string;
+    reason?:     string;
+    recorded_at: string;
+    source:      string;
     [property: string]: any;
 }
 
@@ -4368,6 +4394,38 @@ export interface SpawnSessionMessage {
 
 export enum SpawnSessionMessageCmd {
     SpawnSession = "spawn_session",
+}
+
+export interface StateExplainEntry {
+    cause?:      string;
+    claim:       string;
+    detail?:     string;
+    observed_at: string;
+    outcome:     string;
+    reason?:     string;
+    recorded_at: string;
+    source:      string;
+    [property: string]: any;
+}
+
+export interface StateExplainMessage {
+    cmd:               StateExplainMessageCmd;
+    target_session_id: string;
+    [property: string]: any;
+}
+
+export enum StateExplainMessageCmd {
+    StateExplain = "state_explain",
+}
+
+export interface StateExplainResult {
+    agent:        string;
+    capacity:     number;
+    observations: ObservationElement[];
+    session_id:   string;
+    state:        string;
+    state_since?: string;
+    [property: string]: any;
 }
 
 export interface StateMessage {
@@ -7824,6 +7882,30 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SpawnSessionMessage")), null, 2);
     }
 
+    public static toStateExplainEntry(json: string): StateExplainEntry {
+        return cast(JSON.parse(json), r("StateExplainEntry"));
+    }
+
+    public static stateExplainEntryToJson(value: StateExplainEntry): string {
+        return JSON.stringify(uncast(value, r("StateExplainEntry")), null, 2);
+    }
+
+    public static toStateExplainMessage(json: string): StateExplainMessage {
+        return cast(JSON.parse(json), r("StateExplainMessage"));
+    }
+
+    public static stateExplainMessageToJson(value: StateExplainMessage): string {
+        return JSON.stringify(uncast(value, r("StateExplainMessage")), null, 2);
+    }
+
+    public static toStateExplainResult(json: string): StateExplainResult {
+        return cast(JSON.parse(json), r("StateExplainResult"));
+    }
+
+    public static stateExplainResultToJson(value: StateExplainResult): string {
+        return JSON.stringify(uncast(value, r("StateExplainResult")), null, 2);
+    }
+
     public static toStateMessage(json: string): StateMessage {
         return cast(JSON.parse(json), r("StateMessage"));
     }
@@ -10889,6 +10971,7 @@ const typeMap: any = {
         { json: "session_instructions_result", js: "session_instructions_result", typ: u(undefined, r("SessionInstructionsResultObject")) },
         { json: "session_transcript_result", js: "session_transcript_result", typ: u(undefined, r("SessionTranscriptResultObject")) },
         { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
+        { json: "state_explain_result", js: "state_explain_result", typ: u(undefined, r("StateExplainResultObject")) },
         { json: "ticket_attach_result", js: "ticket_attach_result", typ: u(undefined, r("TicketAttachResultObject")) },
         { json: "ticket_comment_result", js: "ticket_comment_result", typ: u(undefined, r("TicketCommentResultObject")) },
         { json: "ticket_create_result", js: "ticket_create_result", typ: u(undefined, r("TicketCreateResultObject")) },
@@ -10959,6 +11042,24 @@ const typeMap: any = {
         { json: "timestamp", js: "timestamp", typ: u(undefined, "") },
         { json: "tool_call_id", js: "tool_call_id", typ: u(undefined, "") },
         { json: "tool_name", js: "tool_name", typ: u(undefined, "") },
+    ], "any"),
+    "StateExplainResultObject": o([
+        { json: "agent", js: "agent", typ: "" },
+        { json: "capacity", js: "capacity", typ: 0 },
+        { json: "observations", js: "observations", typ: a(r("ObservationElement")) },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "state", js: "state", typ: "" },
+        { json: "state_since", js: "state_since", typ: u(undefined, "") },
+    ], "any"),
+    "ObservationElement": o([
+        { json: "cause", js: "cause", typ: u(undefined, "") },
+        { json: "claim", js: "claim", typ: "" },
+        { json: "detail", js: "detail", typ: u(undefined, "") },
+        { json: "observed_at", js: "observed_at", typ: "" },
+        { json: "outcome", js: "outcome", typ: "" },
+        { json: "reason", js: "reason", typ: u(undefined, "") },
+        { json: "recorded_at", js: "recorded_at", typ: "" },
+        { json: "source", js: "source", typ: "" },
     ], "any"),
     "TicketAttachResultObject": o([
         { json: "artifacts", js: "artifacts", typ: a(r("ArtifactElement")) },
@@ -11232,6 +11333,28 @@ const typeMap: any = {
         { json: "rows", js: "rows", typ: 0 },
         { json: "workspace_id", js: "workspace_id", typ: "" },
         { json: "yolo_mode", js: "yolo_mode", typ: u(undefined, true) },
+    ], "any"),
+    "StateExplainEntry": o([
+        { json: "cause", js: "cause", typ: u(undefined, "") },
+        { json: "claim", js: "claim", typ: "" },
+        { json: "detail", js: "detail", typ: u(undefined, "") },
+        { json: "observed_at", js: "observed_at", typ: "" },
+        { json: "outcome", js: "outcome", typ: "" },
+        { json: "reason", js: "reason", typ: u(undefined, "") },
+        { json: "recorded_at", js: "recorded_at", typ: "" },
+        { json: "source", js: "source", typ: "" },
+    ], "any"),
+    "StateExplainMessage": o([
+        { json: "cmd", js: "cmd", typ: r("StateExplainMessageCmd") },
+        { json: "target_session_id", js: "target_session_id", typ: "" },
+    ], "any"),
+    "StateExplainResult": o([
+        { json: "agent", js: "agent", typ: "" },
+        { json: "capacity", js: "capacity", typ: 0 },
+        { json: "observations", js: "observations", typ: a(r("ObservationElement")) },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "state", js: "state", typ: "" },
+        { json: "state_since", js: "state_since", typ: u(undefined, "") },
     ], "any"),
     "StateMessage": o([
         { json: "cmd", js: "cmd", typ: r("StateMessageCmd") },
@@ -12695,6 +12818,9 @@ const typeMap: any = {
     ],
     "SpawnSessionMessageCmd": [
         "spawn_session",
+    ],
+    "StateExplainMessageCmd": [
+        "state_explain",
     ],
     "StateMessageCmd": [
         "state",

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -202,6 +202,9 @@ func main() {
 	case "session":
 		maybePrintProfileBanner()
 		runSession()
+	case "state":
+		maybePrintProfileBanner()
+		runState()
 	case "debug":
 		maybePrintProfileBanner()
 		runDebug()
@@ -567,6 +570,7 @@ func writeHelp(w io.Writer) {
 commands:
   presence                          check whether the current shell runs inside attn
 	  session <command>                 inspect a session's conversation
+  state explain <id>                replay why a session's state is what it is
   delegate --brief-file <path>      start another agent with a delegated brief
   journal append --entry <text>     serialized append to the daily notebook journal
   workspace context <command>       edit shared workspace context

--- a/cmd/attn/state_explain.go
+++ b/cmd/attn/state_explain.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/client"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// `attn state explain <id>` answers "why is this session that color?".
+//
+// The daemon logs the transitions it accepts, which makes a stuck color
+// invisible: a stuck session is one where nothing is being accepted. The daemon
+// keeps a capped ring of every state observation and what became of it, and this
+// command prints it — including the observations that were vetoed before the
+// store door or discarded by it, which is where a stuck color's explanation
+// actually lives.
+
+type stateExplainArgs struct {
+	target string
+	json   bool
+}
+
+func runState() {
+	if len(os.Args) < 3 || os.Args[2] == "-h" || os.Args[2] == "--help" {
+		writeStateHelp(os.Stdout)
+		return
+	}
+	switch os.Args[2] {
+	case "explain":
+		if hasHelpFlag(os.Args[3:]) {
+			writeStateHelp(os.Stdout)
+			return
+		}
+		runStateExplain(os.Args[3:])
+	default:
+		fmt.Fprintf(os.Stderr, "state: unknown command %q\n", os.Args[2])
+		writeStateHelp(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+func parseStateExplainArgs(args []string) (stateExplainArgs, error) {
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		return stateExplainArgs{}, errors.New("exactly one target session id is required")
+	}
+	target := strings.TrimSpace(args[0])
+	fs := flag.NewFlagSet("state explain", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOut := fs.Bool("json", false, "print the machine result as JSON")
+	if err := fs.Parse(args[1:]); err != nil {
+		return stateExplainArgs{}, err
+	}
+	if target == "" || fs.NArg() != 0 {
+		return stateExplainArgs{}, errors.New("exactly one target session id is required")
+	}
+	return stateExplainArgs{target: target, json: *jsonOut}, nil
+}
+
+func runStateExplain(args []string) {
+	parsed, err := parseStateExplainArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "state explain: %v\n", err)
+		writeStateHelp(os.Stderr)
+		os.Exit(2)
+	}
+	result, err := client.New("").StateExplain(parsed.target)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "state explain: %v\n", err)
+		os.Exit(1)
+	}
+	if parsed.json {
+		printJSON(result)
+		return
+	}
+	printStateExplain(os.Stdout, result)
+}
+
+func printStateExplain(w io.Writer, result *protocol.StateExplainResult) {
+	fmt.Fprintf(w, "session %s (%s)\n", result.SessionID, result.Agent)
+	fmt.Fprintf(w, "state:   %s", result.State)
+	if result.StateSince != nil && strings.TrimSpace(*result.StateSince) != "" {
+		fmt.Fprintf(w, " since %s", formatStateExplainTime(*result.StateSince))
+	}
+	fmt.Fprintln(w)
+
+	if len(result.Observations) == 0 {
+		fmt.Fprintln(w, "\nNo state observations recorded. The daemon has seen no state evidence")
+		fmt.Fprintln(w, "for this session since it started — a state shown now predates the trace.")
+		return
+	}
+
+	// A full ring means the oldest observations have already been evicted, so the
+	// trace is a tail and not the whole story. Saying so beats silently showing a
+	// partial history as if it were complete.
+	if result.Capacity > 0 && len(result.Observations) >= result.Capacity {
+		fmt.Fprintf(w, "\n(showing the most recent %d observations; older ones were evicted)\n", result.Capacity)
+	}
+
+	fmt.Fprintf(w, "\n%-24s  %-18s  %-16s  %-9s  %s\n", "OBSERVED", "SOURCE", "CLAIM", "OUTCOME", "WHY")
+	for _, obs := range result.Observations {
+		fmt.Fprintf(
+			w,
+			"%-24s  %-18s  %-16s  %-9s  %s\n",
+			formatStateExplainTime(obs.ObservedAt),
+			orPlaceholder(obs.Source),
+			orPlaceholder(obs.Claim),
+			obs.Outcome,
+			stateExplainWhy(obs),
+		)
+	}
+}
+
+// stateExplainWhy is the human column: the rejection reason if there is one,
+// then the source's own detail, then the commit rule it travelled under.
+func stateExplainWhy(obs protocol.StateExplainEntry) string {
+	parts := make([]string, 0, 3)
+	if reason := derefTrimmed(obs.Reason); reason != "" {
+		parts = append(parts, reason)
+	}
+	if detail := derefTrimmed(obs.Detail); detail != "" {
+		parts = append(parts, fmt.Sprintf("%q", detail))
+	}
+	if cause := derefTrimmed(obs.Cause); cause != "" {
+		parts = append(parts, "cause="+cause)
+	}
+	return strings.Join(parts, "  ")
+}
+
+func derefTrimmed(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}
+
+func orPlaceholder(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return value
+}
+
+// formatStateExplainTime shows wall-clock time to the millisecond. The trace is
+// read while staring at a session, so the date is noise and sub-second ordering
+// is the whole point.
+func formatStateExplainTime(value string) string {
+	parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(value))
+	if err != nil {
+		return orPlaceholder(value)
+	}
+	return parsed.Local().Format("15:04:05.000")
+}
+
+func writeStateHelp(w io.Writer) {
+	fmt.Fprint(w, `usage: attn state <command>
+
+commands:
+  explain <id> [--json]
+        replay the daemon's recorded state observations for one session: which
+        source claimed what, and whether the claim was applied, vetoed before
+        the store, discarded by it, or skipped by its own source. Read-only.
+`)
+}

--- a/cmd/attn/state_explain_test.go
+++ b/cmd/attn/state_explain_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func TestParseStateExplainArgs(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		want    stateExplainArgs
+		wantErr bool
+	}{
+		{name: "target only", args: []string{"abc"}, want: stateExplainArgs{target: "abc"}},
+		{name: "json", args: []string{"abc", "--json"}, want: stateExplainArgs{target: "abc", json: true}},
+		{name: "no target", args: nil, wantErr: true},
+		{name: "flag first", args: []string{"--json", "abc"}, wantErr: true},
+		{name: "two targets", args: []string{"abc", "def"}, wantErr: true},
+		{name: "unknown flag", args: []string{"abc", "--nope"}, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseStateExplainArgs(tc.args)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrintStateExplainShowsEveryOutcome(t *testing.T) {
+	var out bytes.Buffer
+	printStateExplain(&out, &protocol.StateExplainResult{
+		SessionID:  "sess-1",
+		Agent:      "claude",
+		State:      "working",
+		StateSince: protocol.Ptr("2026-07-25T10:00:00Z"),
+		Capacity:   256,
+		Observations: []protocol.StateExplainEntry{
+			{
+				Source: "screen", Claim: "working", Outcome: "applied",
+				Detail: protocol.Ptr("screen scrape"), Cause: protocol.Ptr("live_signal"),
+				ObservedAt: "2026-07-25T10:00:00Z", RecordedAt: "2026-07-25T10:00:00Z",
+			},
+			{
+				Source: "screen", Claim: "idle", Outcome: "vetoed",
+				Reason:     protocol.Ptr("driver_transition_filter"),
+				ObservedAt: "2026-07-25T10:00:01Z", RecordedAt: "2026-07-25T10:00:01Z",
+			},
+			{
+				Source: "classifier", Claim: "", Outcome: "skipped",
+				Reason:     protocol.Ptr("no_new_assistant_turn"),
+				ObservedAt: "2026-07-25T10:00:02Z", RecordedAt: "2026-07-25T10:00:02Z",
+			},
+		},
+	})
+
+	got := out.String()
+	for _, want := range []string{
+		"session sess-1 (claude)",
+		"state:   working",
+		"applied",
+		"vetoed",
+		"driver_transition_filter",
+		"skipped",
+		"no_new_assistant_turn",
+		`"screen scrape"`,
+		"cause=live_signal",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+	// A skip has no claim; the column must not collapse into a blank.
+	if !strings.Contains(got, "-") {
+		t.Fatalf("missing placeholder for the empty claim:\n%s", got)
+	}
+}
+
+// A trace with nothing in it is the answer to "why is it stuck?" too — it says
+// the daemon has seen no evidence at all — so it must not print an empty table.
+func TestPrintStateExplainWithNoObservations(t *testing.T) {
+	var out bytes.Buffer
+	printStateExplain(&out, &protocol.StateExplainResult{
+		SessionID: "sess-1", Agent: "claude", State: "idle", Capacity: 256,
+	})
+	got := out.String()
+	if !strings.Contains(got, "No state observations recorded") {
+		t.Fatalf("got:\n%s", got)
+	}
+	if strings.Contains(got, "OUTCOME") {
+		t.Fatalf("should not print a header with no rows:\n%s", got)
+	}
+}
+
+func TestPrintStateExplainFlagsAFullRingAsTruncated(t *testing.T) {
+	observations := make([]protocol.StateExplainEntry, 3)
+	for i := range observations {
+		observations[i] = protocol.StateExplainEntry{
+			Source: "screen", Claim: "working", Outcome: "applied",
+			ObservedAt: "2026-07-25T10:00:00Z", RecordedAt: "2026-07-25T10:00:00Z",
+		}
+	}
+	var out bytes.Buffer
+	printStateExplain(&out, &protocol.StateExplainResult{
+		SessionID: "sess-1", Agent: "claude", State: "working",
+		Capacity: 3, Observations: observations,
+	})
+	if !strings.Contains(out.String(), "older ones were evicted") {
+		t.Fatalf("a full ring must be reported as a tail:\n%s", out.String())
+	}
+}
+
+func TestFormatStateExplainTimeFallsBackToTheRawValue(t *testing.T) {
+	if got := formatStateExplainTime("not-a-time"); got != "not-a-time" {
+		t.Fatalf("got %q", got)
+	}
+	if got := formatStateExplainTime(""); got != "-" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/docs/plans/2026-07-25-agent-state-detection.md
+++ b/docs/plans/2026-07-25-agent-state-detection.md
@@ -517,12 +517,24 @@ being fixed as part of the current step.
 
 ### Phase 0 — instrumentation (ship first, no behavior change)
 
-- [ ] Per-session ring buffer of state observations: `(source, claim, detail, at,
-      resolved_state)`, capped, in memory, dumped to the daemon log on transition.
-- [ ] `attn state explain <session>` — replay the ring and show why the current
-      color is what it is. Makes "sometimes it gets stuck" falsifiable.
-- [ ] Record from every existing source *without* changing arbitration, so the
-      current behavior is captured as a baseline trace.
+- [x] Per-session ring buffer of state observations in `internal/statetrace`
+      (`Source, Claim, Detail, Cause, Outcome, Reason, ObservedAt, RecordedAt`),
+      capped at 256, in memory, dropped with the session record. Every recorded
+      observation is also mirrored to `daemon.log` as a `state trace:` line, so a
+      session already gone still leaves its trace in the log.
+- [x] `attn state explain <session>` (`--json`) — replays the ring over the new
+      `state_explain` command (protocol 190). Makes "sometimes it gets stuck"
+      falsifiable.
+- [x] Record from every existing source *without* changing arbitration. The
+      recording is deliberately wider than the applied transitions: `Outcome`
+      separates `applied` from `vetoed` (rejected before `applyState` — a driver's
+      `ShouldApplyPTYState`, a plugin-owned session, an unknown session),
+      `discarded` (the store's own commit rule refused it), and `skipped` (the
+      source looked and had nothing to claim). A stuck color is precisely a
+      session with no applied observations, so the rejected ones are the whole
+      point. `sessionStateChange` grew an optional `origin{source, detail,
+      observedAt}` so several sources sharing one cause (every trusted PTY
+      observation is a `liveSignal`) stay distinguishable.
 - [x] Enabling refactor 1: widen `session.onState` to carry
       `Observation{Source, Claim, Detail, At}`. Behavior-preserving; every later
       phase is additive on top of it. Landed as `internal/pty/observation.go` plus

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -280,6 +280,23 @@ func (c *Client) SessionTranscript(targetSessionID, afterCursor string) (*protoc
 	return resp.SessionTranscriptResult, nil
 }
 
+// StateExplain replays the daemon's per-session ring of state observations. It
+// is a read-only diagnostic: it reports what each source claimed and what
+// happened to the claim, and changes nothing.
+func (c *Client) StateExplain(targetSessionID string) (*protocol.StateExplainResult, error) {
+	resp, err := c.send(protocol.StateExplainMessage{
+		Cmd:             protocol.CmdStateExplain,
+		TargetSessionID: targetSessionID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.StateExplainResult == nil {
+		return nil, errors.New("daemon returned no state explain result")
+	}
+	return resp.StateExplainResult, nil
+}
+
 // SendStop sends a stop signal with transcript path for classification
 // StopFacts carries what the Stop hook observed about whether the turn actually
 // finished. The daemon decides what it means; see nonTerminalStopState there. A

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -38,6 +38,7 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdSetSessionResumeID:                    commandMetadata(ScopeSession, false, true),
 	protocol.CmdSessionInstructions:                   commandMetadata(ScopeSession, false, true),
 	protocol.CmdSessionTranscript:                     commandMetadata(ScopeSession, false, true),
+	protocol.CmdStateExplain:                          commandMetadata(ScopeSession, false, true),
 	protocol.CmdStop:                                  commandMetadata(ScopeSession, false, true),
 	protocol.CmdTodos:                                 commandMetadata(ScopeSession, false, true),
 	protocol.CmdFilesEdited:                           commandMetadata(ScopeSession, false, true),

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1750,8 +1750,11 @@ func (d *Daemon) dropSessionRecord(sessionID string) {
 		d.reconcileTicketsOnSessionEnd(sessionID, string(session.State))
 	}
 	d.clearNudgeState(sessionID)
-	d.forgetStateTrace(sessionID)
 	d.store.Remove(sessionID)
+	// After the row is gone, not before: recordStateObservation gates on the row,
+	// so forgetting first would leave a window where a concurrent observation
+	// rebuilds the ring for an id nothing will ever clean up again.
+	d.forgetStateTrace(sessionID)
 }
 
 // handlePTYState applies one PTY-layer observation. It is still last-writer-wins

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -35,6 +35,7 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/pty"
 	"github.com/victorarias/attn/internal/ptybackend"
+	"github.com/victorarias/attn/internal/statetrace"
 	"github.com/victorarias/attn/internal/store"
 	"github.com/victorarias/attn/internal/tasks"
 	"github.com/victorarias/attn/internal/transcript"
@@ -199,7 +200,12 @@ type Daemon struct {
 	// doorbellMu serializes authoritative session-state commits with a complete
 	// doorbell write. This keeps a pending_approval report from interleaving
 	// between the prompt and its trailing Enter.
-	doorbellMu                 sync.Mutex
+	doorbellMu sync.Mutex
+	// stateTrace is the diagnostic ring of state observations behind
+	// `attn state explain`. Lazily built so a directly-constructed test daemon
+	// traces without an init site.
+	stateTraceOnce             sync.Once
+	stateTrace                 *statetrace.Recorder
 	nudgeMu                    sync.Mutex
 	nudgeCountdowns            map[string]*nudgeCountdown                 // presence == a running (unpaused) countdown
 	unreadCache                map[string]bool                            // per-session unread ticket activity, for cheap broadcast decoration
@@ -1744,6 +1750,7 @@ func (d *Daemon) dropSessionRecord(sessionID string) {
 		d.reconcileTicketsOnSessionEnd(sessionID, string(session.State))
 	}
 	d.clearNudgeState(sessionID)
+	d.forgetStateTrace(sessionID)
 	d.store.Remove(sessionID)
 }
 
@@ -1752,17 +1759,21 @@ func (d *Daemon) dropSessionRecord(sessionID string) {
 // carried so the resolver can arbitrate once it exists, and are logged meanwhile.
 func (d *Daemon) handlePTYState(sessionID string, obs pty.Observation) {
 	state := obs.Claim
+	origin := stateOrigin{source: string(obs.Source), detail: obs.Detail, observedAt: obs.At}
 	session := d.store.Get(sessionID)
 	if session == nil {
+		d.traceStateVeto(sessionID, origin, state, "session_not_found")
 		return
 	}
 	if run := d.store.GetAgentDriverRun(sessionID); run.RunID != "" && d.pluginDriverReportsState(session.Agent) {
 		// External drivers own state through sequenced session.report_* calls.
+		d.traceStateVeto(sessionID, origin, state, "plugin_driver_owns_state")
 		return
 	}
 	agent := session.Agent
 	driver := agentdriver.Get(string(agent))
 	if !agentdriver.ShouldApplyPTYState(driver, session.State, state) {
+		d.traceStateVeto(sessionID, origin, state, "driver_transition_filter")
 		return
 	}
 
@@ -1774,6 +1785,7 @@ func (d *Daemon) handlePTYState(sessionID string, obs pty.Observation) {
 		sessionID: sessionID,
 		state:     state,
 		cause:     liveSignal{},
+		origin:    origin,
 	})
 }
 
@@ -2177,6 +2189,8 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleSessionInstructions(conn, msg.(*protocol.SessionInstructionsMessage))
 	case protocol.CmdSessionTranscript:
 		d.handleSessionTranscript(conn, msg.(*protocol.SessionTranscriptMessage))
+	case protocol.CmdStateExplain:
+		d.handleStateExplain(conn, msg.(*protocol.StateExplainMessage))
 	case protocol.CmdStop:
 		d.handleStop(conn, msg.(*protocol.StopMessage))
 	case protocol.CmdTodos:
@@ -2362,6 +2376,7 @@ func (d *Daemon) handleState(conn net.Conn, msg *protocol.StateMessage) {
 		sessionID: msg.ID,
 		state:     msg.State,
 		cause:     liveSignal{},
+		origin:    stateOrigin{source: stateSourceHook},
 	})
 	d.sendOK(conn)
 }
@@ -2433,6 +2448,7 @@ func (d *Daemon) handleStop(conn net.Conn, msg *protocol.StopMessage) {
 			sessionID: msg.ID,
 			state:     state,
 			cause:     liveSignal{},
+			origin:    stateOrigin{source: stateSourceStopHook, detail: "non-terminal stop"},
 		})
 		d.sendOK(conn)
 		return
@@ -2554,6 +2570,7 @@ func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
 	apply := func(decision classifyDecision) {
 		if decision.action != classifyApply {
 			d.logf("classifySessionState: session=%s no state applied reason=%s", sessionID, decision.reason)
+			d.traceStateSkip(sessionID, stateSourceClassifier, decision.reason)
 			return
 		}
 		d.logf("classifySessionState: session=%s state=%s reason=%s", sessionID, decision.state, decision.reason)
@@ -2561,6 +2578,11 @@ func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
 			sessionID: sessionID,
 			state:     decision.state,
 			cause:     classifierObservation{observedAt: classificationStartTime},
+			origin: stateOrigin{
+				source:     stateSourceClassifier,
+				detail:     decision.reason,
+				observedAt: classificationStartTime,
+			},
 		})
 	}
 

--- a/internal/daemon/plugin_driver.go
+++ b/internal/daemon/plugin_driver.go
@@ -358,6 +358,7 @@ func (d *Daemon) applyPluginReportedState(params pluginReportStateParams) bool {
 			runID: params.RunID,
 			seq:   params.Seq,
 		},
+		origin: stateOrigin{source: stateSourcePluginDriver, detail: params.RunID},
 	}) {
 		d.logf("plugin state report discarded: session=%s run=%s seq=%d state=%s", params.SessionID, params.RunID, params.Seq, state)
 		return false

--- a/internal/daemon/session_state.go
+++ b/internal/daemon/session_state.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/statetrace"
 )
 
 // sessionStateCause is a package-private sum type. Each variant identifies one
@@ -50,6 +51,21 @@ type sessionStateChange struct {
 	sessionID string
 	state     string
 	cause     sessionStateCause
+	// origin describes the evidence behind the change for the diagnostic trace.
+	// It is optional: a caller that leaves it zero is traced under its cause
+	// name, which is all a daemon-internal transition has to say about itself.
+	// It never affects whether the change commits.
+	origin stateOrigin
+}
+
+// stateOrigin is where a state claim came from, as distinct from the commit rule
+// it travels under. Several sources share one cause — every trusted PTY
+// observation is a liveSignal — so the cause alone cannot tell a screen scrape
+// from an approval edge when a color turns out wrong.
+type stateOrigin struct {
+	source     string
+	detail     string
+	observedAt time.Time
 }
 
 // stateEffectProfile is internal policy derived from a closed cause. Callers do
@@ -107,6 +123,7 @@ func (d *Daemon) applyState(change sessionStateChange) bool {
 	profile, ok := stateEffectProfileFor(change.cause)
 	if !ok {
 		d.logf("state update discarded: session=%s state=%s cause=unknown", change.sessionID, change.state)
+		d.traceStateChange(change, statetrace.OutcomeDiscarded, "unknown_cause")
 		return false
 	}
 
@@ -124,8 +141,10 @@ func (d *Daemon) applyState(change sessionStateChange) bool {
 			change.state,
 			sessionStateCauseName(change.cause),
 		)
+		d.traceStateChange(change, statetrace.OutcomeDiscarded, "store_rejected")
 		return false
 	}
+	d.traceStateChange(change, statetrace.OutcomeApplied, "")
 
 	if profile.touch {
 		d.store.Touch(change.sessionID)

--- a/internal/daemon/state_trace.go
+++ b/internal/daemon/state_trace.go
@@ -50,6 +50,13 @@ func (d *Daemon) stateTraceRecorder() *statetrace.Recorder {
 }
 
 // recordStateObservation is the single write path into the trace.
+//
+// An observation for a session with no store row is logged and not ringed. Such
+// an id can never be read back — `attn state explain` needs a store row — and it
+// can never be cleaned up either, because the cleanup hangs off session removal.
+// Ringing it would leak one map entry per stale id for the daemon's lifetime,
+// and stale ids are not rare: a worker event racing a session removal produces
+// one every time. The daemon log is the right home for them.
 func (d *Daemon) recordStateObservation(sessionID string, obs statetrace.Observation) {
 	if strings.TrimSpace(sessionID) == "" {
 		return
@@ -60,7 +67,9 @@ func (d *Daemon) recordStateObservation(sessionID string, obs statetrace.Observa
 	if obs.ObservedAt.IsZero() {
 		obs.ObservedAt = obs.RecordedAt
 	}
-	d.stateTraceRecorder().Record(sessionID, obs)
+	if d.store != nil && d.store.Get(sessionID) != nil {
+		d.stateTraceRecorder().Record(sessionID, obs)
+	}
 	d.logf("%s", obs.LogLine(sessionID))
 }
 

--- a/internal/daemon/state_trace.go
+++ b/internal/daemon/state_trace.go
@@ -1,0 +1,163 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/statetrace"
+)
+
+// The daemon logs the state transitions it accepts and says nothing about the
+// ones it drops, which makes a stuck color impossible to diagnose from the log:
+// a stuck session is precisely one where nothing is being applied. These helpers
+// record every observation the daemon acts on — applied, vetoed before the store
+// door, discarded by the store, or skipped by its own source — into a capped
+// per-session ring, and mirror each one to the daemon log.
+//
+// This is Phase 0 of the state-detection plan: it observes, it does not
+// arbitrate. No function here can change which state a session ends up in.
+
+// Source names for state evidence that does not come from the PTY layer (those
+// carry pty.Source through pty.Observation). These are deliberately named after
+// the mechanism, not the state it reports, because two of them can report the
+// same state for unrelated reasons.
+const (
+	// stateSourceHook is the agent's own state hook reporting through
+	// `attn _hook-state`.
+	stateSourceHook = "hook_state"
+	// stateSourceStopHook is the Stop hook holding a yielded turn open on the
+	// facts it reported (background work, a pending scheduled wakeup).
+	stateSourceStopHook = "hook_stop"
+	// stateSourceClassifier is the stop-time classification pipeline, including
+	// the rules that settle a turn without paying for the LLM call.
+	stateSourceClassifier = "classifier"
+	// stateSourceTranscript is the transcript watcher reading the agent's JSONL.
+	stateSourceTranscript = "transcript_watcher"
+	// stateSourcePluginDriver is an external agent driver's sequenced report.
+	stateSourcePluginDriver = "plugin_driver"
+)
+
+// stateTraceRecorder returns the daemon's trace ring, building it on first use
+// so a directly-constructed test daemon traces without a dedicated init site.
+func (d *Daemon) stateTraceRecorder() *statetrace.Recorder {
+	d.stateTraceOnce.Do(func() {
+		d.stateTrace = statetrace.New(statetrace.DefaultCapacity)
+	})
+	return d.stateTrace
+}
+
+// recordStateObservation is the single write path into the trace.
+func (d *Daemon) recordStateObservation(sessionID string, obs statetrace.Observation) {
+	if strings.TrimSpace(sessionID) == "" {
+		return
+	}
+	if obs.RecordedAt.IsZero() {
+		obs.RecordedAt = time.Now()
+	}
+	if obs.ObservedAt.IsZero() {
+		obs.ObservedAt = obs.RecordedAt
+	}
+	d.stateTraceRecorder().Record(sessionID, obs)
+	d.logf("%s", obs.LogLine(sessionID))
+}
+
+// traceStateChange records the fate of a change that reached applyState. The
+// origin is optional; without one the cause name stands in as the source, which
+// is all a daemon-internal transition can say about where it came from.
+func (d *Daemon) traceStateChange(change sessionStateChange, outcome statetrace.Outcome, reason string) {
+	source := change.origin.source
+	if source == "" {
+		source = sessionStateCauseName(change.cause)
+	}
+	d.recordStateObservation(change.sessionID, statetrace.Observation{
+		Source:     source,
+		Claim:      change.state,
+		Detail:     change.origin.detail,
+		Cause:      sessionStateCauseName(change.cause),
+		Outcome:    outcome,
+		Reason:     reason,
+		ObservedAt: change.origin.observedAt,
+	})
+}
+
+// traceStateVeto records an observation rejected before it reached applyState.
+// These are the interesting ones for a stuck color: the state never got near the
+// store, so no other log line mentions it at all.
+func (d *Daemon) traceStateVeto(sessionID string, origin stateOrigin, claim, reason string) {
+	d.recordStateObservation(sessionID, statetrace.Observation{
+		Source:     origin.source,
+		Claim:      claim,
+		Detail:     origin.detail,
+		Outcome:    statetrace.OutcomeVetoed,
+		Reason:     reason,
+		ObservedAt: origin.observedAt,
+	})
+}
+
+// traceStateSkip records a source that looked and reported no claim. A skip and
+// a missing observation look identical in the store; only the trace separates
+// "the classifier ran and had nothing to add" from "the classifier never ran".
+func (d *Daemon) traceStateSkip(sessionID, source, reason string) {
+	d.recordStateObservation(sessionID, statetrace.Observation{
+		Source:  source,
+		Outcome: statetrace.OutcomeSkipped,
+		Reason:  reason,
+	})
+}
+
+// forgetStateTrace drops a session's ring when the session goes away, so the
+// recorder does not grow without bound across a long-lived daemon.
+func (d *Daemon) forgetStateTrace(sessionID string) {
+	d.stateTraceRecorder().Forget(sessionID)
+}
+
+func (d *Daemon) handleStateExplain(conn net.Conn, msg *protocol.StateExplainMessage) {
+	session := d.store.Get(strings.TrimSpace(msg.TargetSessionID))
+	if session == nil {
+		d.sendError(conn, "session_not_found")
+		return
+	}
+	_ = json.NewEncoder(conn).Encode(protocol.Response{
+		Ok:                 true,
+		StateExplainResult: d.stateExplainResult(session),
+	})
+}
+
+// stateExplainResult renders the current trace for one session.
+func (d *Daemon) stateExplainResult(session *protocol.Session) *protocol.StateExplainResult {
+	recorded := d.stateTraceRecorder().Observations(session.ID)
+	observations := make([]protocol.StateExplainEntry, 0, len(recorded))
+	for _, obs := range recorded {
+		entry := protocol.StateExplainEntry{
+			Source:     obs.Source,
+			Claim:      obs.Claim,
+			Outcome:    string(obs.Outcome),
+			ObservedAt: obs.ObservedAt.Format(time.RFC3339Nano),
+			RecordedAt: obs.RecordedAt.Format(time.RFC3339Nano),
+		}
+		if obs.Detail != "" {
+			entry.Detail = protocol.Ptr(obs.Detail)
+		}
+		if obs.Cause != "" {
+			entry.Cause = protocol.Ptr(obs.Cause)
+		}
+		if obs.Reason != "" {
+			entry.Reason = protocol.Ptr(obs.Reason)
+		}
+		observations = append(observations, entry)
+	}
+	result := &protocol.StateExplainResult{
+		SessionID:    session.ID,
+		Agent:        string(session.Agent),
+		State:        string(session.State),
+		Observations: observations,
+		Capacity:     d.stateTraceRecorder().Capacity(),
+	}
+	if strings.TrimSpace(session.StateSince) != "" {
+		result.StateSince = protocol.Ptr(session.StateSince)
+	}
+	return result
+}

--- a/internal/daemon/state_trace.go
+++ b/internal/daemon/state_trace.go
@@ -40,6 +40,11 @@ const (
 	stateSourcePluginDriver = "plugin_driver"
 )
 
+// stateTraceRecordGateHook runs inside the recorder's lock, between the liveness
+// check and the write. Tests only: it is the seam where a concurrent removal
+// would have to interleave for the ring to leak.
+var stateTraceRecordGateHook func(sessionID string)
+
 // stateTraceRecorder returns the daemon's trace ring, building it on first use
 // so a directly-constructed test daemon traces without a dedicated init site.
 func (d *Daemon) stateTraceRecorder() *statetrace.Recorder {
@@ -67,9 +72,20 @@ func (d *Daemon) recordStateObservation(sessionID string, obs statetrace.Observa
 	if obs.ObservedAt.IsZero() {
 		obs.ObservedAt = obs.RecordedAt
 	}
-	if d.store != nil && d.store.Get(sessionID) != nil {
-		d.stateTraceRecorder().Record(sessionID, obs)
-	}
+	// The liveness check runs inside the recorder's lock (RecordIf), not before
+	// it. Checking first and recording after leaves a window where the session is
+	// removed and its ring forgotten in between, and the writer then creates a
+	// fresh ring for an id that will never be forgotten again.
+	d.stateTraceRecorder().RecordIf(sessionID, obs, func() bool {
+		live := d.store != nil && d.store.Get(sessionID) != nil
+		// The hook runs after the check on purpose: check-then-write is the
+		// sequence that leaks when the two are not atomic, so this is where a
+		// racing removal has to be injected to falsify the lock.
+		if hook := stateTraceRecordGateHook; hook != nil {
+			hook(sessionID)
+		}
+		return live
+	})
 	d.logf("%s", obs.LogLine(sessionID))
 }
 

--- a/internal/daemon/state_trace_test.go
+++ b/internal/daemon/state_trace_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -209,6 +210,51 @@ func TestTraceIsDroppedWhenTheSessionRecordGoes(t *testing.T) {
 
 	if got := traceOf(t, d, id); got != nil {
 		t.Fatalf("trace survived session removal: %+v", got)
+	}
+}
+
+// The interleaving the store-row gate has to survive: a writer passes the
+// liveness check, the session is removed and its ring forgotten, and only then
+// does the writer reach the append. If the check and the append are not atomic,
+// the writer creates a ring for an id nothing will ever forget again — one
+// leaked map entry per race, for the daemon's lifetime.
+//
+// The hook fires inside the recorder's lock, which is exactly where the removal
+// must be attempted for the race to be real.
+func TestTraceDoesNotLeakWhenRemovalRacesTheWrite(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-racing"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+
+	removalDone := make(chan struct{})
+	var once sync.Once
+	stateTraceRecordGateHook = func(observed string) {
+		if observed != id {
+			return
+		}
+		once.Do(func() {
+			// Remove the session from under the in-flight writer. This blocks on
+			// the recorder's lock inside forgetStateTrace, which is what proves
+			// the two operations are serialized rather than interleaved.
+			go func() {
+				defer close(removalDone)
+				d.dropSessionRecord(id)
+			}()
+			// Give the removal a chance to get as far as it can before the write
+			// proceeds. Without RecordIf's lock it would complete here.
+			time.Sleep(20 * time.Millisecond)
+		})
+	}
+	t.Cleanup(func() { stateTraceRecordGateHook = nil })
+
+	d.handlePTYState(id, screenObs(protocol.StateIdle))
+	<-removalDone
+
+	if got := traceOf(t, d, id); got != nil {
+		t.Fatalf("ring survived the racing removal: %+v", got)
+	}
+	if got := d.stateTraceRecorder().SessionCount(); got != 0 {
+		t.Fatalf("recorder holds %d rings after the race, want 0", got)
 	}
 }
 

--- a/internal/daemon/state_trace_test.go
+++ b/internal/daemon/state_trace_test.go
@@ -1,0 +1,221 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/pty"
+	"github.com/victorarias/attn/internal/statetrace"
+)
+
+func newTraceDaemon(t *testing.T) *Daemon {
+	t.Helper()
+	return NewForTesting(filepath.Join(t.TempDir(), "state.sock"))
+}
+
+func traceOf(t *testing.T, d *Daemon, sessionID string) []statetrace.Observation {
+	t.Helper()
+	return d.stateTraceRecorder().Observations(sessionID)
+}
+
+func onlyObservation(t *testing.T, d *Daemon, sessionID string) statetrace.Observation {
+	t.Helper()
+	got := traceOf(t, d, sessionID)
+	if len(got) != 1 {
+		t.Fatalf("want exactly 1 observation, got %d: %+v", len(got), got)
+	}
+	return got[0]
+}
+
+func TestTraceRecordsAppliedPTYObservationWithItsSource(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-applied"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWaitingInput)
+
+	observed := time.Now().Add(-500 * time.Millisecond)
+	d.handlePTYState(id, pty.Observation{
+		Source: pty.SourceScreen,
+		Claim:  protocol.StateWorking,
+		Detail: "screen scrape",
+		At:     observed,
+	})
+
+	got := onlyObservation(t, d, id)
+	if got.Outcome != statetrace.OutcomeApplied {
+		t.Fatalf("outcome %q, want applied", got.Outcome)
+	}
+	// The source must survive the trip: liveSignal is shared by every trusted PTY
+	// source, so the cause alone cannot tell a screen scrape from an approval edge.
+	if got.Source != string(pty.SourceScreen) {
+		t.Fatalf("source %q, want %q", got.Source, pty.SourceScreen)
+	}
+	if got.Cause != "live_signal" {
+		t.Fatalf("cause %q, want live_signal", got.Cause)
+	}
+	if got.Claim != protocol.StateWorking || got.Detail != "screen scrape" {
+		t.Fatalf("claim/detail wrong: %+v", got)
+	}
+	if !got.ObservedAt.Equal(observed) {
+		t.Fatalf("ObservedAt %s, want the source's %s", got.ObservedAt, observed)
+	}
+}
+
+// The whole point of the trace: an observation a driver's transition filter
+// refuses never reaches the store and appears in no other log line, which is
+// exactly the case a stuck color needs explained.
+func TestTraceRecordsDriverVetoedObservation(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-vetoed"
+	// Claude's ShouldApplyPTYState guards a scheduled session against the screen
+	// detector knocking it out of the parked state.
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateScheduled)
+
+	d.handlePTYState(id, screenObs(protocol.StateIdle))
+
+	got := onlyObservation(t, d, id)
+	if got.Outcome != statetrace.OutcomeVetoed {
+		t.Fatalf("outcome %q, want vetoed", got.Outcome)
+	}
+	if got.Reason != "driver_transition_filter" {
+		t.Fatalf("reason %q, want driver_transition_filter", got.Reason)
+	}
+	if got.Claim != protocol.StateIdle {
+		t.Fatalf("claim %q, want the rejected claim %q", got.Claim, protocol.StateIdle)
+	}
+	if state := d.store.Get(id).State; state != protocol.SessionStateScheduled {
+		t.Fatalf("tracing must not change arbitration: state is %q", state)
+	}
+}
+
+func TestTraceRecordsObservationForUnknownSession(t *testing.T) {
+	d := newTraceDaemon(t)
+
+	d.handlePTYState("ghost", screenObs(protocol.StateWorking))
+
+	got := onlyObservation(t, d, "ghost")
+	if got.Outcome != statetrace.OutcomeVetoed || got.Reason != "session_not_found" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestTraceRecordsHookSource(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-hook"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentCodex, protocol.SessionStateIdle)
+
+	d.handleState(&syncConn{}, &protocol.StateMessage{ID: id, State: protocol.StateWorking})
+
+	got := onlyObservation(t, d, id)
+	if got.Source != stateSourceHook || got.Outcome != statetrace.OutcomeApplied {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+// A change with no origin still has to be attributable, or the internal
+// transitions (recovery, process exit) become blanks in the middle of a trace.
+func TestTraceFallsBackToTheCauseNameAsSource(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-cause"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+
+	d.applyState(sessionStateChange{sessionID: id, state: protocol.StateIdle, cause: processExit{}})
+
+	got := onlyObservation(t, d, id)
+	if got.Source != "process_exit" || got.Cause != "process_exit" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+// A stale classifier result is refused by the store's commit rule rather than by
+// a caller-side guard, so it is a discard and not a veto — the distinction points
+// at a different layer when a color is wrong.
+func TestTraceRecordsStoreDiscardedClassifierResult(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-stale"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+
+	applied := d.applyState(sessionStateChange{
+		sessionID: id,
+		state:     protocol.StateIdle,
+		// Older than the session's StateSince, which the characterization helper
+		// backdates to characterizationOldTimestamp.
+		cause:  classifierObservation{observedAt: time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)},
+		origin: stateOrigin{source: stateSourceClassifier, detail: "classifier"},
+	})
+	if applied {
+		t.Fatal("a classifier result older than the current state should not commit")
+	}
+
+	got := onlyObservation(t, d, id)
+	if got.Outcome != statetrace.OutcomeDiscarded || got.Reason != "store_rejected" {
+		t.Fatalf("got %+v", got)
+	}
+	if got.Source != stateSourceClassifier {
+		t.Fatalf("source %q, want %q", got.Source, stateSourceClassifier)
+	}
+}
+
+func TestTraceRecordsSkips(t *testing.T) {
+	d := newTraceDaemon(t)
+	d.traceStateSkip("sess-skip", stateSourceClassifier, "no_new_assistant_turn")
+
+	got := onlyObservation(t, d, "sess-skip")
+	if got.Outcome != statetrace.OutcomeSkipped || got.Claim != "" {
+		t.Fatalf("got %+v", got)
+	}
+	if got.Reason != "no_new_assistant_turn" {
+		t.Fatalf("reason %q", got.Reason)
+	}
+}
+
+func TestTraceIsDroppedWhenTheSessionRecordGoes(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-gone"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+	d.handlePTYState(id, screenObs(protocol.StateIdle))
+	if len(traceOf(t, d, id)) == 0 {
+		t.Fatal("precondition: expected a recorded observation")
+	}
+
+	d.dropSessionRecord(id)
+
+	if got := traceOf(t, d, id); got != nil {
+		t.Fatalf("trace survived session removal: %+v", got)
+	}
+}
+
+func TestStateExplainResultRendersTheRing(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-explain"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWaitingInput)
+	d.handlePTYState(id, screenObs(protocol.StateWorking))
+
+	result := d.stateExplainResult(d.store.Get(id))
+	if result.SessionID != id || result.Agent != string(protocol.SessionAgentClaude) {
+		t.Fatalf("identity wrong: %+v", result)
+	}
+	if result.State != protocol.StateWorking {
+		t.Fatalf("state %q, want the session's current state", result.State)
+	}
+	if result.Capacity != statetrace.DefaultCapacity {
+		t.Fatalf("capacity %d, want %d", result.Capacity, statetrace.DefaultCapacity)
+	}
+	if len(result.Observations) != 1 {
+		t.Fatalf("want 1 observation, got %d", len(result.Observations))
+	}
+	entry := result.Observations[0]
+	if entry.Source != string(pty.SourceScreen) || entry.Outcome != string(statetrace.OutcomeApplied) {
+		t.Fatalf("entry %+v", entry)
+	}
+	if entry.Cause == nil || *entry.Cause != "live_signal" {
+		t.Fatalf("cause %v", entry.Cause)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, entry.ObservedAt); err != nil {
+		t.Fatalf("observed_at %q is not RFC3339Nano: %v", entry.ObservedAt, err)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, entry.RecordedAt); err != nil {
+		t.Fatalf("recorded_at %q is not RFC3339Nano: %v", entry.RecordedAt, err)
+	}
+}

--- a/internal/daemon/state_trace_test.go
+++ b/internal/daemon/state_trace_test.go
@@ -89,14 +89,38 @@ func TestTraceRecordsDriverVetoedObservation(t *testing.T) {
 	}
 }
 
-func TestTraceRecordsObservationForUnknownSession(t *testing.T) {
+// An id with no store row can never be read back — `attn state explain` needs a
+// row — and can never be cleaned up, because cleanup hangs off session removal.
+// Ringing one would leak a map entry per stale id for the daemon's lifetime, so
+// these observations are log-only.
+func TestTraceDoesNotRingAnUnknownSession(t *testing.T) {
 	d := newTraceDaemon(t)
 
 	d.handlePTYState("ghost", screenObs(protocol.StateWorking))
 
-	got := onlyObservation(t, d, "ghost")
-	if got.Outcome != statetrace.OutcomeVetoed || got.Reason != "session_not_found" {
-		t.Fatalf("got %+v", got)
+	if got := traceOf(t, d, "ghost"); got != nil {
+		t.Fatalf("an unknown session must not create a ring: %+v", got)
+	}
+}
+
+// The stale-worker race: a session is removed while one of its state updates is
+// still in flight. The late observation must not resurrect a ring for an id that
+// will never be removed again.
+func TestTraceDoesNotResurrectARingAfterRemoval(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-raced"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+	d.handlePTYState(id, screenObs(protocol.StateIdle))
+
+	d.dropSessionRecord(id)
+	// The worker event the daemon was already holding when the row went away.
+	d.handlePTYState(id, screenObs(protocol.StateWorking))
+
+	if got := traceOf(t, d, id); got != nil {
+		t.Fatalf("a late observation resurrected the ring: %+v", got)
+	}
+	if got := d.stateTraceRecorder().SessionCount(); got != 0 {
+		t.Fatalf("recorder holds %d rings, want 0", got)
 	}
 }
 
@@ -159,9 +183,11 @@ func TestTraceRecordsStoreDiscardedClassifierResult(t *testing.T) {
 
 func TestTraceRecordsSkips(t *testing.T) {
 	d := newTraceDaemon(t)
-	d.traceStateSkip("sess-skip", stateSourceClassifier, "no_new_assistant_turn")
+	id := "sess-skip"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+	d.traceStateSkip(id, stateSourceClassifier, "no_new_assistant_turn")
 
-	got := onlyObservation(t, d, "sess-skip")
+	got := onlyObservation(t, d, id)
 	if got.Outcome != statetrace.OutcomeSkipped || got.Claim != "" {
 		t.Fatalf("got %+v", got)
 	}

--- a/internal/daemon/transcript_watcher.go
+++ b/internal/daemon/transcript_watcher.go
@@ -248,6 +248,7 @@ func (d *Daemon) runTranscriptWatcher(w *transcriptWatcher) {
 						sessionID: w.sessionID,
 						state:     lineResult.State,
 						cause:     daemonObservation{},
+						origin:    stateOrigin{source: stateSourceTranscript, detail: "transcript line", observedAt: now},
 					})
 					sessionState = protocol.SessionState(lineResult.State)
 				}
@@ -290,6 +291,7 @@ func (d *Daemon) runTranscriptWatcher(w *transcriptWatcher) {
 				sessionID: w.sessionID,
 				state:     tickResult.State,
 				cause:     daemonObservation{},
+				origin:    stateOrigin{source: stateSourceTranscript, detail: "watcher tick"},
 			})
 			sessionState = protocol.SessionState(tickResult.State)
 		}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "189"
+const ProtocolVersion = "190"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -97,6 +97,7 @@ const (
 	CmdSetSessionResumeID                    = "set_session_resume_id"
 	CmdSessionInstructions                   = "session_instructions"
 	CmdSessionTranscript                     = "session_transcript"
+	CmdStateExplain                          = "state_explain"
 	CmdStop                                  = "stop"
 	CmdTodos                                 = "todos"
 	CmdFilesEdited                           = "files_edited"
@@ -866,6 +867,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdSessionTranscript:
 		var msg SessionTranscriptMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdStateExplain:
+		var msg StateExplainMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -3783,6 +3783,9 @@ type Response struct {
 	// Sessions corresponds to the JSON schema field "sessions".
 	Sessions []Session `json:"sessions,omitempty,omitzero"`
 
+	// StateExplainResult corresponds to the JSON schema field "state_explain_result".
+	StateExplainResult *StateExplainResult `json:"state_explain_result,omitempty,omitzero"`
+
 	// TicketAttachResult corresponds to the JSON schema field "ticket_attach_result".
 	TicketAttachResult *TicketAttachResult `json:"ticket_attach_result,omitempty,omitzero"`
 
@@ -4295,6 +4298,60 @@ type SpawnSessionMessage struct {
 
 	// YoloMode corresponds to the JSON schema field "yolo_mode".
 	YoloMode *bool `json:"yolo_mode,omitempty,omitzero"`
+}
+
+type StateExplainEntry struct {
+	// Cause corresponds to the JSON schema field "cause".
+	Cause *string `json:"cause,omitempty,omitzero"`
+
+	// Claim corresponds to the JSON schema field "claim".
+	Claim string `json:"claim"`
+
+	// Detail corresponds to the JSON schema field "detail".
+	Detail *string `json:"detail,omitempty,omitzero"`
+
+	// ObservedAt corresponds to the JSON schema field "observed_at".
+	ObservedAt string `json:"observed_at"`
+
+	// Outcome corresponds to the JSON schema field "outcome".
+	Outcome string `json:"outcome"`
+
+	// Reason corresponds to the JSON schema field "reason".
+	Reason *string `json:"reason,omitempty,omitzero"`
+
+	// RecordedAt corresponds to the JSON schema field "recorded_at".
+	RecordedAt string `json:"recorded_at"`
+
+	// Source corresponds to the JSON schema field "source".
+	Source string `json:"source"`
+}
+
+type StateExplainMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// TargetSessionID corresponds to the JSON schema field "target_session_id".
+	TargetSessionID string `json:"target_session_id"`
+}
+
+type StateExplainResult struct {
+	// Agent corresponds to the JSON schema field "agent".
+	Agent string `json:"agent"`
+
+	// Capacity corresponds to the JSON schema field "capacity".
+	Capacity int `json:"capacity"`
+
+	// Observations corresponds to the JSON schema field "observations".
+	Observations []StateExplainEntry `json:"observations"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID string `json:"session_id"`
+
+	// State corresponds to the JSON schema field "state".
+	State string `json:"state"`
+
+	// StateSince corresponds to the JSON schema field "state_since".
+	StateSince *string `json:"state_since,omitempty,omitzero"`
 }
 
 type StateMessage struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -632,6 +632,14 @@ model SessionTranscriptMessage {
   after_cursor?: string;
 }
 
+// Replays the daemon's per-session ring of state observations so a wrong color
+// can be explained: which sources spoke, what each claimed, and what happened to
+// each claim. Diagnostic only — reading it changes nothing.
+model StateExplainMessage {
+  cmd: "state_explain";
+  target_session_id: string;
+}
+
 // A Stop is not always terminal: the turn may yield with background work still
 // in flight (it auto-resumes on completion) or park on a pending scheduled
 // wakeup. These carry that as FACTS observed by the hook — the statuses of the
@@ -3059,6 +3067,34 @@ model Response {
   present_feedback_result?: PresentFeedbackResult;
   session_instructions_result?: SessionInstructionsResult;
   session_transcript_result?: SessionTranscriptResult;
+  state_explain_result?: StateExplainResult;
+}
+
+// One recorded state observation and its fate. Outcome separates the ways an
+// observation can fail to reach the store: "vetoed" is a driver transition
+// filter refusing it before the store door, "discarded" is the store's own
+// commit rule refusing it, "skipped" is the source deciding it had nothing to
+// say. A stuck color is a session whose observations are all non-applied.
+model StateExplainEntry {
+  source: string;
+  claim: string;
+  outcome: string; // "applied" | "discarded" | "vetoed" | "skipped"
+  detail?: string;
+  cause?: string;
+  reason?: string;
+  observed_at: string;
+  recorded_at: string;
+}
+
+model StateExplainResult {
+  session_id: string;
+  agent: string;
+  state: string;
+  state_since?: string;
+  observations: StateExplainEntry[];
+  // capacity is the ring size, so a full ring can be reported as truncated
+  // rather than read as the whole history.
+  capacity: int32;
 }
 
 model EvidenceExcerpt {

--- a/internal/statetrace/statetrace.go
+++ b/internal/statetrace/statetrace.go
@@ -1,0 +1,214 @@
+// Package statetrace records the state observations a session received and what
+// happened to each one.
+//
+// "Sometimes the color gets stuck" is unfalsifiable today: the daemon logs the
+// transitions it accepted and says nothing about the ones it dropped, so a
+// session sitting on a wrong color leaves no trace of whether the right
+// observation never arrived, arrived and was vetoed before reaching the store,
+// or arrived and lost to a newer writer. A stuck color is exactly the case where
+// nothing is being applied, so a log of applied transitions is blind to it.
+//
+// The recorder keeps a capped per-session ring of every observation, including
+// the rejected ones, with the reason for the rejection. It is pure bookkeeping:
+// nothing here influences which state a session ends up in, and it holds no
+// reference to the store. Phase 0 of the state-detection plan records into it
+// from every existing source without changing arbitration, so the current
+// behavior is captured as a baseline before the resolver replaces it.
+package statetrace
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultCapacity is how many observations are kept per session. A session
+// producing an observation every second holds a bit over three minutes of
+// history, which covers the window a human takes to notice a wrong color and go
+// looking.
+const DefaultCapacity = 256
+
+// Outcome is what became of an observation. The three rejection outcomes are
+// kept apart because they point at different bugs: a veto means a driver's
+// transition filter refused it, a discard means the store's own commit rule
+// refused it, and a skip means the source itself decided it had nothing to say.
+type Outcome string
+
+const (
+	// OutcomeApplied means the state reached the store and was committed.
+	OutcomeApplied Outcome = "applied"
+	// OutcomeDiscarded means the observation reached applyState and the store's
+	// commit rule refused it (a stale classifier result, a losing plugin CAS).
+	OutcomeDiscarded Outcome = "discarded"
+	// OutcomeVetoed means something rejected the observation before it ever
+	// reached applyState.
+	OutcomeVetoed Outcome = "vetoed"
+	// OutcomeSkipped means the source produced no claim at all — it looked and
+	// decided there was nothing to report.
+	OutcomeSkipped Outcome = "skipped"
+)
+
+// Observation is one recorded piece of state evidence and its fate.
+//
+// ObservedAt and RecordedAt are both kept: an observation can reach the daemon
+// well after the moment it describes (the worker RPC hop, a slow classifier),
+// and the gap between the two is itself diagnostic.
+type Observation struct {
+	// Source names where the evidence came from — a pty source name, a hook, the
+	// classifier. Sources are free-form strings because they cross package
+	// boundaries that must not depend on this one.
+	Source string
+	// Claim is the state the source argued for, or "" for a skip.
+	Claim string
+	// Detail is the human-readable why, carried verbatim from the source.
+	Detail string
+	// Cause names the applyState commit rule the observation travelled under, or
+	// "" when it never got that far.
+	Cause string
+	// Outcome is what happened to it.
+	Outcome Outcome
+	// Reason explains a non-applied outcome.
+	Reason string
+	// ObservedAt is when the source saw what it is reporting.
+	ObservedAt time.Time
+	// RecordedAt is when the daemon acted on it.
+	RecordedAt time.Time
+}
+
+// LogLine renders one observation as a single daemon-log line. It is the form
+// the daemon writes on every recorded observation, so a log tail carries the
+// same trace the ring does for sessions that have already been forgotten.
+func (o Observation) LogLine(sessionID string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "state trace: session=%s source=%s claim=%s outcome=%s", sessionID, orDash(o.Source), orDash(o.Claim), orDash(string(o.Outcome)))
+	if o.Cause != "" {
+		fmt.Fprintf(&b, " cause=%s", o.Cause)
+	}
+	if o.Reason != "" {
+		fmt.Fprintf(&b, " reason=%s", o.Reason)
+	}
+	if o.Detail != "" {
+		fmt.Fprintf(&b, " detail=%q", o.Detail)
+	}
+	if !o.ObservedAt.IsZero() {
+		fmt.Fprintf(&b, " observed_at=%s", o.ObservedAt.Format(time.RFC3339Nano))
+		if !o.RecordedAt.IsZero() {
+			fmt.Fprintf(&b, " lag=%s", o.RecordedAt.Sub(o.ObservedAt).Round(time.Millisecond))
+		}
+	}
+	return b.String()
+}
+
+func orDash(value string) string {
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+// Recorder holds one ring per session. It is safe for concurrent use: every
+// state source in the daemon writes to it from its own goroutine.
+type Recorder struct {
+	mu       sync.Mutex
+	capacity int
+	rings    map[string]*ring
+}
+
+// New returns a recorder keeping capacity observations per session. A capacity
+// of zero or less falls back to DefaultCapacity rather than silently recording
+// nothing.
+func New(capacity int) *Recorder {
+	if capacity <= 0 {
+		capacity = DefaultCapacity
+	}
+	return &Recorder{capacity: capacity, rings: make(map[string]*ring)}
+}
+
+// Capacity is how many observations a session's ring holds.
+func (r *Recorder) Capacity() int {
+	if r == nil {
+		return 0
+	}
+	return r.capacity
+}
+
+// Record appends an observation, evicting the oldest once the ring is full. A
+// nil recorder records nothing, so callers need no guard.
+func (r *Recorder) Record(sessionID string, obs Observation) {
+	if r == nil || sessionID == "" {
+		return
+	}
+	if obs.RecordedAt.IsZero() {
+		obs.RecordedAt = time.Now()
+	}
+	if obs.ObservedAt.IsZero() {
+		obs.ObservedAt = obs.RecordedAt
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	target := r.rings[sessionID]
+	if target == nil {
+		target = newRing(r.capacity)
+		r.rings[sessionID] = target
+	}
+	target.push(obs)
+}
+
+// Observations returns the session's recorded observations, oldest first. The
+// slice is a copy; the caller may hold it while more arrive.
+func (r *Recorder) Observations(sessionID string) []Observation {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	target := r.rings[sessionID]
+	if target == nil {
+		return nil
+	}
+	return target.snapshot()
+}
+
+// Forget drops a session's ring. Called when a session is unregistered so the
+// recorder does not grow without bound across a long-lived daemon.
+func (r *Recorder) Forget(sessionID string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.rings, sessionID)
+}
+
+// ring is a fixed-size FIFO of observations.
+type ring struct {
+	items []Observation
+	// start indexes the oldest item once the ring has wrapped.
+	start int
+	size  int
+}
+
+func newRing(capacity int) *ring {
+	return &ring{items: make([]Observation, capacity)}
+}
+
+func (r *ring) push(obs Observation) {
+	capacity := len(r.items)
+	if r.size < capacity {
+		r.items[(r.start+r.size)%capacity] = obs
+		r.size++
+		return
+	}
+	r.items[r.start] = obs
+	r.start = (r.start + 1) % capacity
+}
+
+func (r *ring) snapshot() []Observation {
+	out := make([]Observation, 0, r.size)
+	capacity := len(r.items)
+	for i := range r.size {
+		out = append(out, r.items[(r.start+i)%capacity])
+	}
+	return out
+}

--- a/internal/statetrace/statetrace.go
+++ b/internal/statetrace/statetrace.go
@@ -136,6 +136,22 @@ func (r *Recorder) Capacity() int {
 // Record appends an observation, evicting the oldest once the ring is full. A
 // nil recorder records nothing, so callers need no guard.
 func (r *Recorder) Record(sessionID string, obs Observation) {
+	r.RecordIf(sessionID, obs, nil)
+}
+
+// RecordIf appends an observation only when admit reports the session is still
+// one the recorder should hold a ring for. A nil admit always appends.
+//
+// admit runs while the recorder's lock is held, which is the whole point: the
+// caller's liveness check and the write are then atomic with respect to Forget.
+// Checking liveness before calling Record instead leaves a window — check
+// passes, the session is removed and its ring forgotten, the writer resumes and
+// creates a fresh ring for an id nothing will ever forget again — which is a
+// leak that grows for the daemon's lifetime.
+//
+// admit must not call back into the recorder, and must not take a lock that
+// anything holds while calling in here.
+func (r *Recorder) RecordIf(sessionID string, obs Observation, admit func() bool) {
 	if r == nil || sessionID == "" {
 		return
 	}
@@ -147,6 +163,9 @@ func (r *Recorder) Record(sessionID string, obs Observation) {
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if admit != nil && !admit() {
+		return
+	}
 	target := r.rings[sessionID]
 	if target == nil {
 		target = newRing(r.capacity)

--- a/internal/statetrace/statetrace.go
+++ b/internal/statetrace/statetrace.go
@@ -170,6 +170,17 @@ func (r *Recorder) Observations(sessionID string) []Observation {
 	return target.snapshot()
 }
 
+// SessionCount is how many sessions currently hold a ring. It exists so a leak —
+// a ring created for an id that will never be forgotten — is assertable.
+func (r *Recorder) SessionCount() int {
+	if r == nil {
+		return 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.rings)
+}
+
 // Forget drops a session's ring. Called when a session is unregistered so the
 // recorder does not grow without bound across a long-lived daemon.
 func (r *Recorder) Forget(sessionID string) {

--- a/internal/statetrace/statetrace_test.go
+++ b/internal/statetrace/statetrace_test.go
@@ -1,0 +1,159 @@
+package statetrace
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func claims(t *testing.T, got []Observation) []string {
+	t.Helper()
+	out := make([]string, 0, len(got))
+	for _, obs := range got {
+		out = append(out, obs.Claim)
+	}
+	return out
+}
+
+func TestRecorderKeepsOrderPerSession(t *testing.T) {
+	r := New(8)
+	r.Record("a", Observation{Claim: "working"})
+	r.Record("b", Observation{Claim: "idle"})
+	r.Record("a", Observation{Claim: "waiting_input"})
+
+	if got := claims(t, r.Observations("a")); strings.Join(got, ",") != "working,waiting_input" {
+		t.Fatalf("session a: got %v", got)
+	}
+	if got := claims(t, r.Observations("b")); strings.Join(got, ",") != "idle" {
+		t.Fatalf("session b: got %v", got)
+	}
+	if got := r.Observations("missing"); got != nil {
+		t.Fatalf("unknown session: got %v, want nil", got)
+	}
+}
+
+// The ring exists to bound memory on a long-lived daemon, so overflow must drop
+// the oldest and keep the newest — the newest is what explains the color now.
+func TestRecorderEvictsOldestOnOverflow(t *testing.T) {
+	r := New(3)
+	for _, claim := range []string{"one", "two", "three", "four", "five"} {
+		r.Record("s", Observation{Claim: claim})
+	}
+	if got := strings.Join(claims(t, r.Observations("s")), ","); got != "three,four,five" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestRecorderWrapsRepeatedly(t *testing.T) {
+	r := New(2)
+	for i := range 7 {
+		r.Record("s", Observation{Claim: string(rune('a' + i))})
+	}
+	if got := strings.Join(claims(t, r.Observations("s")), ","); got != "f,g" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestRecorderSnapshotIsACopy(t *testing.T) {
+	r := New(4)
+	r.Record("s", Observation{Claim: "working"})
+	snapshot := r.Observations("s")
+	snapshot[0].Claim = "mutated"
+	if got := r.Observations("s")[0].Claim; got != "working" {
+		t.Fatalf("recorder state leaked through snapshot: got %q", got)
+	}
+}
+
+func TestRecorderForgetDropsSession(t *testing.T) {
+	r := New(4)
+	r.Record("s", Observation{Claim: "working"})
+	r.Forget("s")
+	if got := r.Observations("s"); got != nil {
+		t.Fatalf("got %v after Forget, want nil", got)
+	}
+}
+
+// A nil recorder is the zero-configuration path (tests, a daemon built without
+// tracing); every call must be a no-op rather than a panic, so call sites need
+// no guard.
+func TestNilRecorderIsInert(t *testing.T) {
+	var r *Recorder
+	r.Record("s", Observation{Claim: "working"})
+	r.Forget("s")
+	if got := r.Observations("s"); got != nil {
+		t.Fatalf("got %v, want nil", got)
+	}
+	if got := r.Capacity(); got != 0 {
+		t.Fatalf("capacity %d, want 0", got)
+	}
+}
+
+func TestNewClampsNonPositiveCapacity(t *testing.T) {
+	if got := New(0).Capacity(); got != DefaultCapacity {
+		t.Fatalf("capacity %d, want %d", got, DefaultCapacity)
+	}
+	if got := New(-5).Capacity(); got != DefaultCapacity {
+		t.Fatalf("capacity %d, want %d", got, DefaultCapacity)
+	}
+}
+
+// A source that reports only ObservedAt must still get a RecordedAt, because the
+// gap between the two is the diagnostic for a delayed observation.
+func TestRecordDefaultsTimestamps(t *testing.T) {
+	r := New(4)
+	observed := time.Now().Add(-2 * time.Second)
+	r.Record("s", Observation{Claim: "working", ObservedAt: observed})
+	r.Record("s", Observation{Claim: "idle"})
+
+	got := r.Observations("s")
+	if !got[0].ObservedAt.Equal(observed) {
+		t.Fatalf("ObservedAt overwritten: %s", got[0].ObservedAt)
+	}
+	if got[0].RecordedAt.IsZero() {
+		t.Fatal("RecordedAt not defaulted")
+	}
+	if !got[1].ObservedAt.Equal(got[1].RecordedAt) {
+		t.Fatalf("ObservedAt %s should default to RecordedAt %s", got[1].ObservedAt, got[1].RecordedAt)
+	}
+}
+
+func TestLogLineCarriesTheWholeObservation(t *testing.T) {
+	observed := time.Date(2026, 7, 25, 10, 0, 0, 0, time.UTC)
+	obs := Observation{
+		Source:     "screen",
+		Claim:      "pending_approval",
+		Detail:     "screen scrape",
+		Cause:      "live_signal",
+		Outcome:    OutcomeVetoed,
+		Reason:     "driver_veto",
+		ObservedAt: observed,
+		RecordedAt: observed.Add(150 * time.Millisecond),
+	}
+	line := obs.LogLine("sess-1")
+	for _, want := range []string{
+		"session=sess-1",
+		"source=screen",
+		"claim=pending_approval",
+		"outcome=vetoed",
+		"cause=live_signal",
+		"reason=driver_veto",
+		`detail="screen scrape"`,
+		"lag=150ms",
+	} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("line %q missing %q", line, want)
+		}
+	}
+}
+
+// A skip carries no claim; the line must stay parseable rather than emitting an
+// empty key.
+func TestLogLineRendersMissingFieldsAsDashes(t *testing.T) {
+	line := Observation{Outcome: OutcomeSkipped}.LogLine("sess-1")
+	if !strings.Contains(line, "source=- claim=- outcome=skipped") {
+		t.Fatalf("got %q", line)
+	}
+	if strings.Contains(line, "cause=") || strings.Contains(line, "reason=") || strings.Contains(line, "detail=") {
+		t.Fatalf("empty optional fields should be omitted: %q", line)
+	}
+}

--- a/internal/statetrace/statetrace_test.go
+++ b/internal/statetrace/statetrace_test.go
@@ -157,3 +157,23 @@ func TestLogLineRendersMissingFieldsAsDashes(t *testing.T) {
 		t.Fatalf("empty optional fields should be omitted: %q", line)
 	}
 }
+
+// SessionCount is how a leaked ring is caught: the daemon gates ring creation on
+// a live session row, and a ring for an id nothing will ever forget would grow
+// the map for the daemon's lifetime.
+func TestRecorderSessionCountTracksRings(t *testing.T) {
+	r := New(4)
+	if got := r.SessionCount(); got != 0 {
+		t.Fatalf("fresh recorder holds %d rings", got)
+	}
+	r.Record("a", Observation{Claim: "working"})
+	r.Record("b", Observation{Claim: "working"})
+	r.Record("a", Observation{Claim: "idle"})
+	if got := r.SessionCount(); got != 2 {
+		t.Fatalf("got %d rings, want 2", got)
+	}
+	r.Forget("a")
+	if got := r.SessionCount(); got != 1 {
+		t.Fatalf("got %d rings after Forget, want 1", got)
+	}
+}


### PR DESCRIPTION
Phase 0 of the state-detection plan (`docs/plans/2026-07-25-agent-state-detection.md`).
Instrumentation only — nothing here changes which state a session ends up in.

## The problem

A stuck session color is invisible in `daemon.log`. The daemon logs the
transitions it *accepts*, and a stuck session is precisely one where nothing is
being accepted. Three very different failures leave an identical log:

- the right observation never arrived;
- it arrived and a driver's transition filter refused it before the store door;
- it arrived and the store's own commit rule refused it.

"Sometimes the colors get stuck" has been unfalsifiable for exactly this reason.

## What this adds

`internal/statetrace`: a capped (256) in-memory ring per session holding every
state observation the daemon acts on, with what became of it.

| outcome | meaning |
|---|---|
| `applied` | committed to the store |
| `vetoed` | rejected before `applyState` — a driver's `ShouldApplyPTYState`, a plugin-owned session, an unknown session |
| `discarded` | reached `applyState`; the store's commit rule refused it |
| `skipped` | the source looked and had no claim to make |

`attn state explain <id> [--json]` replays it over a new `state_explain` command
(protocol 190). Every recorded observation is also mirrored to `daemon.log` as a
`state trace:` line, so a session that has since been removed still leaves its
trace behind.

`sessionStateChange` grows an optional `origin{source, detail, observedAt}`.
Several sources share one cause — every trusted PTY observation commits as a
`liveSignal` — so the cause alone cannot tell a screen scrape from an approval
edge when a color turns out wrong. The origin never affects whether a change
commits.

## Live witness

Profile `statedet`, full `make install`, `attn preflight` PASS, protocol 190
CLI/app/daemon. Two real sessions driven through the packaged app. All four
outcomes observed live.

Claude session, two turns:

```
session d26539e4-b92c-40c3-b4c9-52b2a0b21783 (claude)
state:   idle since 17:41:19.658

OBSERVED                  SOURCE              CLAIM             OUTCOME    WHY
17:40:37.063              worker_info         working           applied    "watch subscribe replay"  cause=live_signal
17:40:55.054              hook_state          working           applied    cause=live_signal
17:41:03.345              hook_state          working           applied    cause=live_signal
17:41:04.602              screen              waiting_input     applied    "screen scrape"  cause=live_signal
17:41:07.065              classifier          -                 skipped    no_new_assistant_turn
17:41:04.595              classifier          idle              discarded  store_rejected  "classifier"  cause=classifier_observation
17:41:17.990              hook_state          working           applied    cause=live_signal
17:41:19.658              classifier          idle              applied    "classifier"  cause=classifier_observation
```

The `discarded` row is the payoff. The classifier's `idle` verdict for turn one
was observed at 17:41:04.595 and reached the daemon 8.163s later; by then the
screen scrape had already moved the session to `waiting_input` at 17:41:04.602 —
7ms after the classifier's observation timestamp. Two sources disagreeing, one
losing on a 7ms margin. Nothing in today's logs shows that at all.

Codex session:

```
session fc82c5c4-145a-4d47-9a11-e1b881a5f97f (codex)
state:   working since 17:42:02.904

OBSERVED                  SOURCE              CLAIM             OUTCOME    WHY
17:41:45.252              worker_info         working           vetoed     driver_transition_filter  "watch subscribe replay"
17:41:52.132              hook_state          working           applied    cause=live_signal
17:41:57.847              hook_state          working           applied    cause=live_signal
17:42:02.904              hook_state          working           applied    cause=live_signal
```

That `vetoed` row is a live confirmation of a debt item the plan already
records: the worker fabricates `working` for a session it knows nothing about on
watch-subscribe. Codex's transition filter happens to reject it; Claude's does
not, which is why the same fabricated row is `applied` in the trace above.

`--json` emits the same rows as an object with `session_id`, `agent`, `state`,
`state_since`, `capacity`, and `observations[]`.

## Tests

- `internal/statetrace`: ring ordering, eviction, repeated wrap, snapshot
  isolation, nil-recorder inertness, timestamp defaulting, log-line rendering.
- `internal/daemon`: source survives the PTY trip, driver veto is recorded
  *and the session does not move*, unknown session, hook source, cause-name
  fallback, store-discarded stale classifier, skip, drop-on-session-removal,
  and the protocol result shape.
- `cmd/attn`: argument parsing, all four outcomes rendered, the
  no-observations case, full-ring truncation notice, timestamp fallback.
