### PR TITLE
feat(state): observe agent harness OSC signals as state evidence

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -169,7 +169,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '190';
+export const PROTOCOL_VERSION = '191';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -3925,6 +3925,7 @@ export interface ObservationElement {
     outcome:     string;
     reason?:     string;
     recorded_at: string;
+    repeats?:    number;
     source:      string;
     [property: string]: any;
 }
@@ -4404,6 +4405,7 @@ export interface StateExplainEntry {
     outcome:     string;
     reason?:     string;
     recorded_at: string;
+    repeats?:    number;
     source:      string;
     [property: string]: any;
 }
@@ -11059,6 +11061,7 @@ const typeMap: any = {
         { json: "outcome", js: "outcome", typ: "" },
         { json: "reason", js: "reason", typ: u(undefined, "") },
         { json: "recorded_at", js: "recorded_at", typ: "" },
+        { json: "repeats", js: "repeats", typ: u(undefined, 0) },
         { json: "source", js: "source", typ: "" },
     ], "any"),
     "TicketAttachResultObject": o([
@@ -11342,6 +11345,7 @@ const typeMap: any = {
         { json: "outcome", js: "outcome", typ: "" },
         { json: "reason", js: "reason", typ: u(undefined, "") },
         { json: "recorded_at", js: "recorded_at", typ: "" },
+        { json: "repeats", js: "repeats", typ: u(undefined, 0) },
         { json: "source", js: "source", typ: "" },
     ], "any"),
     "StateExplainMessage": o([

--- a/cmd/attn/state_explain.go
+++ b/cmd/attn/state_explain.go
@@ -103,18 +103,27 @@ func printStateExplain(w io.Writer, result *protocol.StateExplainResult) {
 		fmt.Fprintf(w, "\n(showing the most recent %d observations; older ones were evicted)\n", result.Capacity)
 	}
 
-	fmt.Fprintf(w, "\n%-24s  %-18s  %-16s  %-9s  %s\n", "OBSERVED", "SOURCE", "CLAIM", "OUTCOME", "WHY")
+	fmt.Fprintf(w, "\n%-24s  %-18s  %-16s  %-14s  %s\n", "OBSERVED", "SOURCE", "CLAIM", "OUTCOME", "WHY")
 	for _, obs := range result.Observations {
 		fmt.Fprintf(
 			w,
-			"%-24s  %-18s  %-16s  %-9s  %s\n",
+			"%-24s  %-18s  %-16s  %-14s  %s\n",
 			formatStateExplainTime(obs.ObservedAt),
 			orPlaceholder(obs.Source),
 			orPlaceholder(obs.Claim),
-			obs.Outcome,
+			renderOutcome(obs),
 			stateExplainWhy(obs),
 		)
 	}
+}
+
+// renderOutcome appends a repeat count so a collapsed level source reads as one
+// row that kept saying the same thing, not as a single stale observation.
+func renderOutcome(obs protocol.StateExplainEntry) string {
+	if obs.Repeats != nil && *obs.Repeats > 0 {
+		return fmt.Sprintf("%s ×%d", obs.Outcome, *obs.Repeats+1)
+	}
+	return obs.Outcome
 }
 
 // stateExplainWhy is the human column: the rejection reason if there is one,

--- a/docs/plans/2026-07-25-agent-state-detection.md
+++ b/docs/plans/2026-07-25-agent-state-detection.md
@@ -56,7 +56,6 @@ Raw PTY captures of `claude` 2.1.220 and `codex`, driven through a real pty:
 ```text
 claude:  ESC ] 0 ; ⠐ Run background sleep command BEL   <- braille spinner = turn RUNNING
          ESC ] 0 ; ✳ Run background sleep command BEL   <- U+2733 = turn NOT running
-         ESC ] 777 ; notify ; Claude Code ; Claude is waiting for your input BEL
 
 codex:   ESC ] 0 ; ⠸ attn--fix-state-detec... BEL       <- spinner prefix = busy
          ESC ] 0 ; attn--fix-state-detec... BEL         <- bare cwd = idle
@@ -67,13 +66,16 @@ codex:   ESC ] 0 ; ⠸ attn--fix-state-detec... BEL       <- spinner prefix = bu
   running. A level that stops arriving cannot get stuck — though the spike below
   shows it goes briefly silent mid-tool, which is why it corroborates rather than
   leads.
-- **OSC 777 is Claude's explicit settle event.** In the background-task capture it
-  did *not* fire while the background task was outstanding; the turn auto-resumed
-  on completion and settled afterwards.
+- **OSC 777 is not a signal claude emits.** An earlier draft of this plan listed
+  it as claude's explicit settle event. It is not: no OSC 777 appears in any of
+  the nine captures, and claude 2.1.220 offers only `iterm2`, `iterm2_with_bell`,
+  and `terminal_bell` notification channels. Claude's settle event is the
+  **`Notification` hook**, below. Corrected while implementing phase 1a, after
+  building and then deleting the OSC 777 reader.
 - The title also carries a live turn summary ("Run background sleep command") —
   a free sidebar label with no LLM call.
 
-attn parses OSC 133 in `internal/pty/blockfeed.go` and ignores OSC 0 / 777
+attn parses OSC 133 in `internal/pty/blockfeed.go` and ignored OSC 0
 entirely. Unwired hooks: Claude **`Notification`** (fires on permission-needed and
 on 60s-idle-waiting), `SessionEnd`, `SubagentStop`; Codex's `notify` program
 (`agent-turn-complete`).
@@ -205,7 +207,7 @@ Target:
   hook brackets (turn/tool open) ──> recordEvidence(level)   ┐
   approval edge ──────────────────> recordEvidence(edge)     │
   OSC 0 title heartbeat ──────────> recordEvidence(level)    ├──> sessionEvidence
-  OSC 777 / Notification ─────────> recordEvidence(edge)     │      (per session)
+  Notification hook ──────────────> recordEvidence(edge)     │      (per session)
   stop classifier ────────────────> recordEvidence(edge)     │
   process exit ───────────────────> recordEvidence(level)    ┘          │
                                                                         v
@@ -260,7 +262,7 @@ no harness signals (copilot) keep it until they have some.
 
 type Source string
 const (
-    SourceHarnessEvent Source = "harness_event"   // hooks, OSC 777, Notification
+    SourceHarnessEvent Source = "harness_event"   // hooks, Notification
     SourceHeartbeat    Source = "heartbeat"       // OSC 0 title glyph
     SourceClassifier   Source = "classifier"      // stop-time LLM
     SourceBracket      Source = "hook_bracket"    // turn/tool open-close, PRIMARY level
@@ -347,7 +349,7 @@ the UI consumes it. Nothing in phases 0–3 may depend on the mode being on.
 
 ## Boundaries
 
-- `internal/pty` owns byte-level extraction only: OSC 0 title and OSC 777 are
+- `internal/pty` owns byte-level extraction only: the OSC 0 title is
   parsed where OSC 133 already is (`blockfeed.go` / `boundary.go`) and surfaced
   through the existing `s.onState` channel (`internal/pty/session.go:360`),
   widened from `string` to a typed observation. It must not know about
@@ -547,9 +549,18 @@ being fixed as part of the current step.
 
 ### Phase 1 — wire the harness signals
 
-- [ ] Parse OSC 0 in the worker; classify the glyph prefix (braille block = busy,
-      `✳`/bare = not busy) per agent; expose title text as `Detail`.
-- [ ] Parse OSC 777 `notify` (Claude settle event).
+- [x] **Phase 1a (PR #669).** Parse OSC 0/2 in the worker; classify the glyph
+      prefix (braille block = busy, `✳`/bare = not busy) per agent; expose title
+      text as `Detail`. Read-only `oscScanner` in `internal/pty/oscscan.go` — the
+      OSC 133 segmenter could not be reused because it strips markers from the
+      stream and is corpus-locked to a frontend parity fixture. Per-agent behavior
+      is a driver capability (`Capabilities.HarnessSignals`), matching the
+      `ScreenDetector` kind pattern. An unchanged level re-emits at most once a
+      second, and the phase 0 ring collapses consecutive identical observations
+      into a repeat count, so a long turn cannot flush the ring.
+- [x] ~~Parse OSC 777 `notify`~~ — **dropped**: claude does not emit it (see
+      "The unused signals" above). Built, found unwitnessable on a live PTY, and
+      deleted rather than shipped as untested-in-production code.
 - [ ] Add the Claude `Notification` hook to `internal/hooks/hooks.go`, routed to a
       new `_hook-notification` command, carrying the notification `message`
       verbatim as evidence detail. It is harness-owned and fires on both branches
@@ -569,8 +580,13 @@ being fixed as part of the current step.
       `nonTerminalStopState` moved to `internal/daemon/stop_terminality.go` and the
       chief-of-staff lookup is now an in-process `d.isChiefOfStaffSession` call
       instead of a socket round-trip from the hook back to the daemon.
-- [ ] Feed all of the above into the Phase 0 ring only; still no arbitration
-      change. Compare traces against the baseline.
+- [x] Feed the OSC signals into the Phase 0 ring only; still no arbitration
+      change (phase 1a). `pty.Source.EvidenceOnly()` routes them past
+      `applyState` entirely — their claims are "busy"/"not_busy", not protocol
+      state names — and past the worker/backend state dedup, which would
+      otherwise swallow a repeated level.
+- [ ] Feed the hook signals into the ring the same way (phase 1b), then compare
+      traces against the baseline.
 
 ### Phase 2 — resolver
 
@@ -667,10 +683,9 @@ placeholder only; do not implement against it.
 
 ## Open questions
 
-- Does Claude emit OSC 777 for permission prompts, or only for turn settle? Not
-  observed in the captures. Either way the `Notification` hook covers it, so this
-  only affects how fast the approval evidence arrives (OSC would be immediate, the
-  hook is ~6s).
+- ~~Does Claude emit OSC 777 for permission prompts, or only for turn settle?~~
+  Answered while implementing phase 1a: it emits no OSC 777 at all. The
+  `Notification` hook is the only settle event, at ~6s.
 - Codex has no notification OSC. Its `notify` program config
   (`agent-turn-complete`) is the analogue; confirm it fires for approval requests
   too, or accept hooks-only for Codex settle detection.

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -63,6 +63,7 @@ func (c *Claude) Capabilities() Capabilities {
 		HasTranscriptWatcher: true,
 		HasClassifier:        true,
 		ScreenDetector:       ScreenDetectorClaude,
+		HarnessSignals:       HarnessSignalsClaude,
 		HasApprovalResolver:  true,
 		HasResume:            true,
 		HasYolo:              true,

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -50,6 +50,7 @@ func (c *Codex) Capabilities() Capabilities {
 		HasTranscript:       true,
 		HasClassifier:       true,
 		HasApprovalResolver: true,
+		HarnessSignals:      HarnessSignalsCodex,
 		HasResume:           true,
 		HasYolo:             true,
 		HasInitialPrompt:    true,

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -103,6 +103,12 @@ type Capabilities struct {
 	// boolean without a matching case got no detector at all, with no error.
 	ScreenDetector ScreenDetectorKind
 
+	// HarnessSignals names which harness-owned PTY signals this agent emits (the
+	// OSC 0 title heartbeat, OSC 777 notifications), or HarnessSignalsNone. These
+	// come from the agent itself rather than from reading its rendered TUI, so
+	// unlike ScreenDetector they survive any change to how the agent draws.
+	HarnessSignals HarnessSignalKind
+
 	// HasApprovalResolver indicates the daemon should clear pending_approval ->
 	// working off the rendered PTY screen for this agent. Needed by hook-driven
 	// agents that fire no hook when an approval is granted, so the only signal
@@ -152,6 +158,21 @@ const (
 	ScreenDetectorCopilot ScreenDetectorKind = "copilot"
 )
 
+// HarnessSignalKind identifies a set of harness-owned PTY signals. The parsing
+// lives in internal/pty; this names which agent's dialect to read.
+type HarnessSignalKind string
+
+const (
+	// HarnessSignalsNone is an agent that emits no harness state signals.
+	HarnessSignalsNone HarnessSignalKind = ""
+	// HarnessSignalsClaude is Claude Code: a braille/U+2733 title heartbeat plus
+	// OSC 777 notifications.
+	HarnessSignalsClaude HarnessSignalKind = "claude"
+	// HarnessSignalsCodex is Codex: a braille title heartbeat, no notification
+	// OSC.
+	HarnessSignalsCodex HarnessSignalKind = "codex"
+)
+
 var capabilityEnvNameSanitizer = regexp.MustCompile(`[^A-Za-z0-9]+`)
 
 // EffectiveCapabilities returns driver capabilities after applying env overrides.
@@ -162,6 +183,7 @@ var capabilityEnvNameSanitizer = regexp.MustCompile(`[^A-Za-z0-9]+`)
 //   - ATTN_AGENT_<AGENT>_TRANSCRIPT_WATCHER=0|1
 //   - ATTN_AGENT_<AGENT>_CLASSIFIER=0|1
 //   - ATTN_AGENT_<AGENT>_STATE_DETECTOR=0|1
+//   - ATTN_AGENT_<AGENT>_HARNESS_SIGNALS=0|1
 //   - ATTN_AGENT_<AGENT>_APPROVAL_RESOLVER=0|1
 //   - ATTN_AGENT_<AGENT>_RESUME=0|1
 //   - ATTN_AGENT_<AGENT>_YOLO=0|1
@@ -198,6 +220,12 @@ func EffectiveCapabilities(d Driver) Capabilities {
 	// could be forced on, but internal/pty had no detector to build for it.
 	if v, ok := boolEnv(prefix + "STATE_DETECTOR"); ok && !v {
 		caps.ScreenDetector = ScreenDetectorNone
+	}
+	// HARNESS_SIGNALS=0 disables them; =1 keeps the driver's kind, for the same
+	// reason as STATE_DETECTOR above — there is no dialect for =1 to invent for an
+	// agent whose driver declares none.
+	if v, ok := boolEnv(prefix + "HARNESS_SIGNALS"); ok && !v {
+		caps.HarnessSignals = HarnessSignalsNone
 	}
 	if v, ok := boolEnv(prefix + "APPROVAL_RESOLVER"); ok {
 		caps.HasApprovalResolver = v

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1763,6 +1763,14 @@ func (d *Daemon) dropSessionRecord(sessionID string) {
 func (d *Daemon) handlePTYState(sessionID string, obs pty.Observation) {
 	state := obs.Claim
 	origin := stateOrigin{source: string(obs.Source), detail: obs.Detail, observedAt: obs.At}
+	// The harness signals are wired ahead of the resolver that will weigh them, so
+	// their traces can be compared against the current behavior before anything
+	// arbitrates on them. They are recorded and go no further; their claims are in
+	// their own vocabulary and are not protocol states to apply.
+	if obs.Source.EvidenceOnly() {
+		d.traceStateEvidence(sessionID, origin, state)
+		return
+	}
 	session := d.store.Get(sessionID)
 	if session == nil {
 		d.traceStateVeto(sessionID, origin, state, "session_not_found")

--- a/internal/daemon/state_trace.go
+++ b/internal/daemon/state_trace.go
@@ -122,6 +122,19 @@ func (d *Daemon) traceStateVeto(sessionID string, origin stateOrigin, claim, rea
 	})
 }
 
+// traceStateEvidence records an observation whose source does not drive session
+// state. It is recorded and goes no further — the observation never reaches
+// applyState, so it has no cause and cannot be applied or rejected by the store.
+func (d *Daemon) traceStateEvidence(sessionID string, origin stateOrigin, claim string) {
+	d.recordStateObservation(sessionID, statetrace.Observation{
+		Source:     origin.source,
+		Claim:      claim,
+		Detail:     origin.detail,
+		Outcome:    statetrace.OutcomeObserved,
+		ObservedAt: origin.observedAt,
+	})
+}
+
 // traceStateSkip records a source that looked and reported no claim. A skip and
 // a missing observation look identical in the store; only the trace separates
 // "the classifier ran and had nothing to add" from "the classifier never ran".
@@ -171,6 +184,9 @@ func (d *Daemon) stateExplainResult(session *protocol.Session) *protocol.StateEx
 		}
 		if obs.Reason != "" {
 			entry.Reason = protocol.Ptr(obs.Reason)
+		}
+		if obs.Repeats > 0 {
+			entry.Repeats = protocol.Ptr(obs.Repeats)
 		}
 		observations = append(observations, entry)
 	}

--- a/internal/daemon/state_trace_test.go
+++ b/internal/daemon/state_trace_test.go
@@ -359,3 +359,62 @@ func TestTraceCollapsesRepeatedEvidence(t *testing.T) {
 		t.Fatalf("a changed claim must open a new row: %+v", all)
 	}
 }
+
+// The contract phase 1a is judged on: a long busy turn must not consume one ring
+// slot per second. The heartbeat re-emits its unchanged level once a keepalive,
+// and the spinner frame differs on every one of those emissions — if the frame
+// reaches the trace, each row is distinct, Repeats never increments, and 256
+// seconds of work evicts every other kind of evidence from the ring.
+func TestTraceCollapsesHeartbeatsAcrossSpinnerFrames(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-spinner-frames"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+
+	start := time.Now().Add(-30 * time.Second)
+	frames := []string{"⠐", "⠸", "⠿", "⠇", "⠏", "⠋", "⠙"}
+	for i, frame := range frames {
+		at := start.Add(time.Duration(i) * time.Second)
+		// What the observer produces for that frame. It strips the glyph, so the
+		// summary is identical across frames — see
+		// TestHeartbeatDetailIsStableAcrossSpinnerFrames for the proof that it
+		// does, and the sub-case below for what happens when it does not.
+		_ = frame
+		d.handlePTYState(id, heartbeatObs("busy", "Run background sleep command", at))
+	}
+
+	got := onlyObservation(t, d, id)
+	if got.Repeats != len(frames)-1 {
+		t.Fatalf("Repeats %d, want %d — one row for the whole turn", got.Repeats, len(frames)-1)
+	}
+	if got.Claim != "busy" {
+		t.Fatalf("claim %q, want busy", got.Claim)
+	}
+	if got.Detail != "Run background sleep command" {
+		t.Fatalf("detail %q, want the frame-free summary", got.Detail)
+	}
+	// The surviving row reports the latest sighting: freshness is the only thing
+	// a repeated heartbeat contributes.
+	if want := start.Add(time.Duration(len(frames)-1) * time.Second); !got.ObservedAt.Equal(want) {
+		t.Fatalf("ObservedAt %s, want the newest %s", got.ObservedAt, want)
+	}
+
+	// A genuinely different summary is news and opens its own row.
+	d.handlePTYState(id, heartbeatObs("busy", "Editing files", start.Add(30*time.Second)))
+	if all := traceOf(t, d, id); len(all) != 2 {
+		t.Fatalf("a changed summary must open a new row: %+v", all)
+	}
+
+	// And the failure this guards against: had the glyph reached the detail,
+	// every frame would be a distinct row rather than a repeat.
+	withFrames := newTraceDaemon(t)
+	framed := "sess-spinner-unstripped"
+	addCharacterizationSession(t, withFrames, framed, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+	for i, frame := range frames {
+		at := start.Add(time.Duration(i) * time.Second)
+		withFrames.handlePTYState(framed, heartbeatObs("busy", frame+" Run background sleep command", at))
+	}
+	if all := traceOf(t, withFrames, framed); len(all) != len(frames) {
+		t.Fatalf("volatile details collapsed unexpectedly (%d rows for %d frames); "+
+			"the ring pressure this test guards against would be invisible", len(all), len(frames))
+	}
+}

--- a/internal/daemon/state_trace_test.go
+++ b/internal/daemon/state_trace_test.go
@@ -291,3 +291,71 @@ func TestStateExplainResultRendersTheRing(t *testing.T) {
 		t.Fatalf("recorded_at %q is not RFC3339Nano: %v", entry.RecordedAt, err)
 	}
 }
+
+func heartbeatObs(claim, detail string, at time.Time) pty.Observation {
+	return pty.Observation{Source: pty.SourceHeartbeat, Claim: claim, Detail: detail, At: at}
+}
+
+// The harness signals speak "busy"/"not_busy", not protocol states. They are
+// recorded as evidence for a later resolver to weigh and must never be offered
+// to applyState, where "busy" is not even a valid state.
+func TestTraceRecordsHarnessSignalsAsEvidenceOnly(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-evidence"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateIdle)
+
+	observed := time.Now().Add(-200 * time.Millisecond)
+	d.handlePTYState(id, heartbeatObs("busy", "⠐ Editing files", observed))
+
+	got := onlyObservation(t, d, id)
+	if got.Outcome != statetrace.OutcomeObserved {
+		t.Fatalf("outcome %q, want observed", got.Outcome)
+	}
+	// No cause: the observation never entered the commit path, so attributing one
+	// would imply the store saw and refused it.
+	if got.Cause != "" || got.Reason != "" {
+		t.Fatalf("evidence must carry no cause or reason: %+v", got)
+	}
+	if got.Source != string(pty.SourceHeartbeat) || got.Claim != "busy" {
+		t.Fatalf("got %+v", got)
+	}
+	if got.Detail != "⠐ Editing files" {
+		t.Fatalf("detail %q, want the title verbatim", got.Detail)
+	}
+	if !got.ObservedAt.Equal(observed) {
+		t.Fatalf("ObservedAt %s, want %s", got.ObservedAt, observed)
+	}
+	if state := d.store.Get(id).State; state != protocol.SessionStateIdle {
+		t.Fatalf("evidence changed state to %q", state)
+	}
+}
+
+// A busy heartbeat repeats once a second for the length of a turn. Without
+// collapsing, a long turn would push every other observation out of the ring and
+// make `attn state explain` useless exactly when it is needed.
+func TestTraceCollapsesRepeatedEvidence(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-repeats"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+
+	start := time.Now().Add(-10 * time.Second)
+	for i := range 5 {
+		d.handlePTYState(id, heartbeatObs("busy", "⠐ working", start.Add(time.Duration(i)*time.Second)))
+	}
+
+	got := onlyObservation(t, d, id)
+	if got.Repeats != 4 {
+		t.Fatalf("Repeats %d, want 4 (5 observations collapsed into 1)", got.Repeats)
+	}
+	// The surviving row must report the latest sighting, not the first: freshness
+	// is the only thing a heartbeat contributes.
+	if want := start.Add(4 * time.Second); !got.ObservedAt.Equal(want) {
+		t.Fatalf("ObservedAt %s, want the newest %s", got.ObservedAt, want)
+	}
+
+	// A different claim is news and starts its own row.
+	d.handlePTYState(id, heartbeatObs("not_busy", "✳ done", time.Now()))
+	if all := traceOf(t, d, id); len(all) != 2 || all[1].Repeats != 0 {
+		t.Fatalf("a changed claim must open a new row: %+v", all)
+	}
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "190"
+const ProtocolVersion = "191"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -4322,6 +4322,9 @@ type StateExplainEntry struct {
 	// RecordedAt corresponds to the JSON schema field "recorded_at".
 	RecordedAt string `json:"recorded_at"`
 
+	// Repeats corresponds to the JSON schema field "repeats".
+	Repeats *int `json:"repeats,omitempty,omitzero"`
+
 	// Source corresponds to the JSON schema field "source".
 	Source string `json:"source"`
 }

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -3084,6 +3084,11 @@ model StateExplainEntry {
   reason?: string;
   observed_at: string;
   recorded_at: string;
+  // repeats counts identical consecutive observations collapsed into this one.
+  // A level source (the OSC 0 title heartbeat) restates itself continuously;
+  // without collapsing, it would evict every other kind of evidence from the
+  // bounded ring within a minute.
+  repeats?: int32;
 }
 
 model StateExplainResult {

--- a/internal/pty/harness_signals.go
+++ b/internal/pty/harness_signals.go
@@ -1,0 +1,182 @@
+package pty
+
+import (
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	agentdriver "github.com/victorarias/attn/internal/agent"
+)
+
+// Harness-owned state signals, read off the PTY stream.
+//
+// Both Claude Code and Codex already broadcast what they are doing, and attn has
+// been ignoring it in favour of scraping the rendered screen:
+//
+//	ESC ] 0 ; ⠐ Run background sleep command BEL     claude, turn RUNNING
+//	ESC ] 0 ; ✳ Run background sleep command BEL     claude, turn NOT running
+//	ESC ] 0 ; ⠸ my-project BEL                       codex, busy
+//	ESC ] 0 ; my-project BEL                         codex, idle
+//
+// The title glyph is a *level*, repainted about once a second by claude and ten
+// times a second by codex, and it comes from the harness rather than from
+// guessing at its TUI. Measured against hook ground truth it tracks the turn to
+// within ~100ms in both directions.
+//
+// What it is for is bounding stuck states, not accuracy: a level that stops
+// arriving cannot get stuck the way an edge-triggered claim can. It is not a
+// detector on its own — claude's title goes silent for ~3.5s in the middle of a
+// blocking foreground tool call, so no TTL gives both a fast settle and no false
+// settle. See docs/plans/2026-07-25-agent-state-detection.md.
+//
+// Nothing here drives session state yet. The observations are recorded as
+// evidence so the traces can be compared against the current behavior before
+// anything starts arbitrating on them.
+
+const (
+	// heartbeatKeepalive bounds how often an unchanged heartbeat re-emits. The
+	// level says "still true", so a re-emit carries real information (the agent is
+	// alive right now), but at codex's ~10Hz repaint every frame would drown out
+	// every other kind of evidence in the observation ring. 1s matches claude's
+	// natural repaint rate.
+	heartbeatKeepalive = time.Second
+
+	// claimBusy and claimNotBusy are the heartbeat's vocabulary. It deliberately
+	// does not speak in protocol state names: the title says whether the agent's
+	// turn is running, and nothing about *why* it stopped — an approval, a
+	// question, and a finished turn all look identical to it.
+	claimBusy    = "busy"
+	claimNotBusy = "not_busy"
+)
+
+const (
+	oscCodeTitleAndIcon = 0
+	oscCodeTitle        = 2
+)
+
+// titleClassifier reports whether an OSC 0 title means the agent's turn is
+// running. ok is false when the title says nothing about the agent — most often
+// because a subprocess overwrote it — in which case no observation is made and
+// whatever the previous level was still stands.
+type titleClassifier func(title string) (busy bool, ok bool)
+
+// harnessSignalPolicy is the per-agent part. The mechanics below (scanning,
+// rate limiting, timestamping) are shared; only the reading of a title differs.
+type harnessSignalPolicy struct {
+	classifyTitle titleClassifier
+}
+
+// harnessSignalObserver watches one session's output for harness signals.
+type harnessSignalObserver struct {
+	policy    harnessSignalPolicy
+	scanner   oscScanner
+	lastClaim string
+	lastEmit  time.Time
+}
+
+// newHarnessSignalObserver builds the observer the driver asked for, or nil (as
+// a nil interface value, so callers' nil checks work) for an agent with no
+// harness signals.
+func newHarnessSignalObserver(kind agentdriver.HarnessSignalKind) *harnessSignalObserver {
+	switch kind {
+	case agentdriver.HarnessSignalsClaude:
+		return &harnessSignalObserver{policy: harnessSignalPolicy{
+			classifyTitle: classifyClaudeTitle,
+		}}
+	case agentdriver.HarnessSignalsCodex:
+		return &harnessSignalObserver{policy: harnessSignalPolicy{
+			classifyTitle: classifyCodexTitle,
+		}}
+	default:
+		return nil
+	}
+}
+
+// Observe reports the harness signals in one chunk of PTY output, oldest first.
+// It never modifies the chunk.
+func (o *harnessSignalObserver) Observe(chunk []byte, now time.Time) []Observation {
+	if o == nil || len(chunk) == 0 {
+		return nil
+	}
+	var out []Observation
+	o.scanner.Feed(chunk, func(code int, payload string) {
+		switch code {
+		case oscCodeTitleAndIcon, oscCodeTitle:
+			if obs, ok := o.observeTitle(payload, now); ok {
+				out = append(out, obs)
+			}
+		}
+	})
+	return out
+}
+
+func (o *harnessSignalObserver) observeTitle(title string, now time.Time) (Observation, bool) {
+	if o.policy.classifyTitle == nil {
+		return Observation{}, false
+	}
+	busy, ok := o.policy.classifyTitle(title)
+	if !ok {
+		return Observation{}, false
+	}
+	claim := claimNotBusy
+	if busy {
+		claim = claimBusy
+	}
+	// A level only needs re-stating periodically: it changed, or it has been long
+	// enough that "still true" is news.
+	if claim == o.lastClaim && now.Sub(o.lastEmit) < heartbeatKeepalive {
+		return Observation{}, false
+	}
+	o.lastClaim = claim
+	o.lastEmit = now
+	return newObservation(SourceHeartbeat, claim, strings.TrimSpace(title), now), true
+}
+
+// classifyClaudeTitle reads Claude Code's title glyph: a braille spinner frame
+// while the turn runs, U+2733 EIGHT SPOKED ASTERISK when it does not. Anything
+// else is not claude talking.
+func classifyClaudeTitle(title string) (bool, bool) {
+	switch first, ok := firstRune(title); {
+	case !ok:
+		return false, false
+	case isBrailleSpinner(first):
+		return true, true
+	case first == '✳':
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+// classifyCodexTitle reads Codex's title: a braille spinner frame while busy,
+// the bare working directory otherwise. Unlike claude there is no distinct idle
+// glyph, so a title a subprocess overwrote reads as not-busy. That is safe under
+// a freshness rule — the level that matters is *when busy frames last arrived* —
+// and a live capture confirmed a competing title repaint moves accuracy by
+// 0.2pp, because the agent keeps painting over it.
+func classifyCodexTitle(title string) (bool, bool) {
+	first, ok := firstRune(title)
+	if !ok {
+		return false, false
+	}
+	return isBrailleSpinner(first), true
+}
+
+// isBrailleSpinner reports whether r is in the Braille Patterns block, which is
+// what both agents animate their spinners with.
+func isBrailleSpinner(r rune) bool {
+	return r >= 0x2800 && r <= 0x28FF
+}
+
+// firstRune returns the first non-space rune of s.
+func firstRune(s string) (rune, bool) {
+	trimmed := strings.TrimLeft(s, " \t")
+	if trimmed == "" {
+		return 0, false
+	}
+	r, size := utf8.DecodeRuneInString(trimmed)
+	if r == utf8.RuneError && size <= 1 {
+		return 0, false
+	}
+	return r, true
+}

--- a/internal/pty/harness_signals.go
+++ b/internal/pty/harness_signals.go
@@ -54,11 +54,21 @@ const (
 	oscCodeTitle        = 2
 )
 
-// titleClassifier reports whether an OSC 0 title means the agent's turn is
-// running. ok is false when the title says nothing about the agent — most often
-// because a subprocess overwrote it — in which case no observation is made and
-// whatever the previous level was still stands.
-type titleClassifier func(title string) (busy bool, ok bool)
+// titleClassifier reads an OSC 0 title. It reports whether the agent's turn is
+// running, plus the title with its level glyph removed.
+//
+// The glyph is stripped because it is the noisiest part of the title and the
+// least informative: it cycles through spinner frames several times a second
+// while saying nothing that the busy/not-busy claim does not already say. What
+// is left is the turn summary, which changes only when the agent moves on to
+// something else — so consecutive observations of an unchanged level are
+// genuinely identical and collapse into one trace row instead of consuming one
+// ring slot per second and evicting every other kind of evidence.
+//
+// ok is false when the title says nothing about the agent — most often because a
+// subprocess overwrote it — in which case no observation is made and whatever
+// the previous level was still stands.
+type titleClassifier func(title string) (busy bool, summary string, ok bool)
 
 // harnessSignalPolicy is the per-agent part. The mechanics below (scanning,
 // rate limiting, timestamping) are shared; only the reading of a title differs.
@@ -114,7 +124,7 @@ func (o *harnessSignalObserver) observeTitle(title string, now time.Time) (Obser
 	if o.policy.classifyTitle == nil {
 		return Observation{}, false
 	}
-	busy, ok := o.policy.classifyTitle(title)
+	busy, summary, ok := o.policy.classifyTitle(title)
 	if !ok {
 		return Observation{}, false
 	}
@@ -129,22 +139,22 @@ func (o *harnessSignalObserver) observeTitle(title string, now time.Time) (Obser
 	}
 	o.lastClaim = claim
 	o.lastEmit = now
-	return newObservation(SourceHeartbeat, claim, strings.TrimSpace(title), now), true
+	return newObservation(SourceHeartbeat, claim, summary, now), true
 }
 
 // classifyClaudeTitle reads Claude Code's title glyph: a braille spinner frame
 // while the turn runs, U+2733 EIGHT SPOKED ASTERISK when it does not. Anything
 // else is not claude talking.
-func classifyClaudeTitle(title string) (bool, bool) {
-	switch first, ok := firstRune(title); {
-	case !ok:
-		return false, false
-	case isBrailleSpinner(first):
-		return true, true
-	case first == '✳':
-		return false, true
+func classifyClaudeTitle(title string) (bool, string, bool) {
+	first, ok := firstRune(title)
+	if !ok {
+		return false, "", false
+	}
+	switch {
+	case isBrailleSpinner(first), first == '✳':
+		return isBrailleSpinner(first), stripLevelGlyph(title), true
 	default:
-		return false, false
+		return false, "", false
 	}
 }
 
@@ -154,12 +164,24 @@ func classifyClaudeTitle(title string) (bool, bool) {
 // a freshness rule — the level that matters is *when busy frames last arrived* —
 // and a live capture confirmed a competing title repaint moves accuracy by
 // 0.2pp, because the agent keeps painting over it.
-func classifyCodexTitle(title string) (bool, bool) {
+func classifyCodexTitle(title string) (bool, string, bool) {
 	first, ok := firstRune(title)
 	if !ok {
-		return false, false
+		return false, "", false
 	}
-	return isBrailleSpinner(first), true
+	return isBrailleSpinner(first), stripLevelGlyph(title), true
+}
+
+// stripLevelGlyph removes a leading level glyph and the space after it, leaving
+// the turn summary. A title that is only a glyph leaves an empty summary, which
+// is the honest answer: there was no summary.
+func stripLevelGlyph(title string) string {
+	trimmed := strings.TrimSpace(title)
+	first, size := utf8.DecodeRuneInString(trimmed)
+	if isBrailleSpinner(first) || first == '✳' {
+		return strings.TrimSpace(trimmed[size:])
+	}
+	return trimmed
 }
 
 // isBrailleSpinner reports whether r is in the Braille Patterns block, which is

--- a/internal/pty/harness_signals_test.go
+++ b/internal/pty/harness_signals_test.go
@@ -1,0 +1,164 @@
+package pty
+
+import (
+	"testing"
+	"time"
+
+	agentdriver "github.com/victorarias/attn/internal/agent"
+)
+
+// title builds an OSC 0 window-title sequence, the form both agents repaint
+// their spinner into.
+func title(text string) []byte {
+	return []byte("\x1b]0;" + text + "\x07")
+}
+
+func observeAt(o *harnessSignalObserver, at time.Time, chunks ...[]byte) []Observation {
+	var out []Observation
+	for _, chunk := range chunks {
+		out = append(out, o.Observe(chunk, at)...)
+	}
+	return out
+}
+
+func onlySignal(t *testing.T, got []Observation) Observation {
+	t.Helper()
+	if len(got) != 1 {
+		t.Fatalf("want exactly 1 observation, got %d: %+v", len(got), got)
+	}
+	return got[0]
+}
+
+func TestNoObserverForAnAgentWithoutHarnessSignals(t *testing.T) {
+	if got := newHarnessSignalObserver(agentdriver.HarnessSignalsNone); got != nil {
+		t.Fatalf("got %+v, want nil", got)
+	}
+	// A nil observer must be safe to call so the read loop needs no extra guard.
+	var nilObserver *harnessSignalObserver
+	if got := nilObserver.Observe(title("⠐ x"), time.Now()); got != nil {
+		t.Fatalf("nil observer returned %+v", got)
+	}
+}
+
+func TestClaudeTitleHeartbeat(t *testing.T) {
+	now := time.Now()
+	for _, tc := range []struct {
+		name  string
+		title string
+		claim string
+	}{
+		// The braille block is the spinner; claude cycles through its frames.
+		{name: "braille spinner is busy", title: "⠐ Run background sleep command", claim: claimBusy},
+		{name: "another spinner frame", title: "⠸ Editing files", claim: claimBusy},
+		{name: "asterisk is not busy", title: "✳ Run background sleep command", claim: claimNotBusy},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			o := newHarnessSignalObserver(agentdriver.HarnessSignalsClaude)
+			got := onlySignal(t, observeAt(o, now, title(tc.title)))
+			if got.Source != SourceHeartbeat || got.Claim != tc.claim {
+				t.Fatalf("got %+v, want %s/%s", got, SourceHeartbeat, tc.claim)
+			}
+			// The title doubles as a live turn summary — a free sidebar label.
+			if got.Detail != tc.title {
+				t.Fatalf("detail %q, want the title verbatim", got.Detail)
+			}
+			if !got.At.Equal(now) {
+				t.Fatalf("At %s, want %s", got.At, now)
+			}
+		})
+	}
+}
+
+// A title claude did not write says nothing about claude. Reporting not-busy for
+// it would let any subprocess that sets a title settle the session.
+func TestClaudeIgnoresAForeignTitle(t *testing.T) {
+	o := newHarnessSignalObserver(agentdriver.HarnessSignalsClaude)
+	for _, foreign := range []string{"victor@mac: ~", "htop", ""} {
+		if got := observeAt(o, time.Now(), title(foreign)); got != nil {
+			t.Fatalf("title %q produced %+v", foreign, got)
+		}
+	}
+}
+
+// Codex has no distinct idle glyph: busy is a spinner frame, anything else is
+// the bare working directory. A hijacked title therefore reads as not-busy,
+// which is safe under a freshness rule keyed on when busy frames last arrived.
+func TestCodexTitleHeartbeat(t *testing.T) {
+	now := time.Now()
+	o := newHarnessSignalObserver(agentdriver.HarnessSignalsCodex)
+	if got := onlySignal(t, observeAt(o, now, title("⠸ attn--fix-state-detec..."))); got.Claim != claimBusy {
+		t.Fatalf("got %+v, want busy", got)
+	}
+	if got := onlySignal(t, observeAt(o, now, title("attn--fix-state-detec..."))); got.Claim != claimNotBusy {
+		t.Fatalf("got %+v, want not_busy", got)
+	}
+}
+
+// The level restates itself continuously — codex repaints about ten times a
+// second. Emitting every frame would drown out every other kind of evidence.
+func TestHeartbeatRateLimitsAnUnchangedLevel(t *testing.T) {
+	start := time.Now()
+	o := newHarnessSignalObserver(agentdriver.HarnessSignalsClaude)
+
+	if got := observeAt(o, start, title("⠐ working")); len(got) != 1 {
+		t.Fatalf("first frame produced %d observations", len(got))
+	}
+	for i := range 20 {
+		at := start.Add(time.Duration(i+1) * 10 * time.Millisecond)
+		if got := observeAt(o, at, title("⠸ working")); got != nil {
+			t.Fatalf("repeat frame at +%dms produced %+v", (i+1)*10, got)
+		}
+	}
+	// Past the keepalive, "still busy" is news again: it is what distinguishes a
+	// running agent from one that stopped emitting.
+	at := start.Add(heartbeatKeepalive + time.Millisecond)
+	if got := observeAt(o, at, title("⠿ working")); len(got) != 1 {
+		t.Fatalf("keepalive frame produced %d observations", len(got))
+	}
+}
+
+// A change is never rate limited: busy -> not busy is the edge that matters.
+func TestHeartbeatAlwaysReportsAChange(t *testing.T) {
+	start := time.Now()
+	o := newHarnessSignalObserver(agentdriver.HarnessSignalsClaude)
+	observeAt(o, start, title("⠐ working"))
+
+	got := onlySignal(t, observeAt(o, start.Add(time.Millisecond), title("✳ done")))
+	if got.Claim != claimNotBusy {
+		t.Fatalf("got %+v, want not_busy immediately", got)
+	}
+}
+
+// These sources speak their own vocabulary rather than protocol state names, so
+// nothing may try to apply their claims as states.
+func TestHarnessSignalSourcesAreEvidenceOnly(t *testing.T) {
+	if !SourceHeartbeat.EvidenceOnly() {
+		t.Fatalf("%s must be evidence-only", SourceHeartbeat)
+	}
+	for _, source := range []Source{SourceScreen, SourceApproval, SourceWorkerInfo, SourceUnknown} {
+		if source.EvidenceOnly() {
+			t.Fatalf("%s must not be evidence-only", source)
+		}
+	}
+}
+
+// The read loop hands over PTY chunks as they arrive, so a title routinely
+// straddles one. Splitting the whole exchange at every byte proves the level
+// survives without duplicating or losing a frame.
+func TestHeartbeatSurvivesEverySplitPoint(t *testing.T) {
+	const stream = "\x1b]0;⠐ working\x07output\x1b]0;✳ done\x07"
+	start := time.Now()
+	for split := range len(stream) + 1 {
+		o := newHarnessSignalObserver(agentdriver.HarnessSignalsClaude)
+		got := append(
+			o.Observe([]byte(stream[:split]), start),
+			o.Observe([]byte(stream[split:]), start.Add(time.Millisecond))...,
+		)
+		if len(got) != 2 {
+			t.Fatalf("split at %d: got %d observations %+v", split, len(got), got)
+		}
+		if got[0].Claim != claimBusy || got[1].Claim != claimNotBusy {
+			t.Fatalf("split at %d: got %+v", split, got)
+		}
+	}
+}

--- a/internal/pty/harness_signals_test.go
+++ b/internal/pty/harness_signals_test.go
@@ -43,14 +43,15 @@ func TestNoObserverForAnAgentWithoutHarnessSignals(t *testing.T) {
 func TestClaudeTitleHeartbeat(t *testing.T) {
 	now := time.Now()
 	for _, tc := range []struct {
-		name  string
-		title string
-		claim string
+		name    string
+		title   string
+		claim   string
+		summary string
 	}{
 		// The braille block is the spinner; claude cycles through its frames.
-		{name: "braille spinner is busy", title: "⠐ Run background sleep command", claim: claimBusy},
-		{name: "another spinner frame", title: "⠸ Editing files", claim: claimBusy},
-		{name: "asterisk is not busy", title: "✳ Run background sleep command", claim: claimNotBusy},
+		{name: "braille spinner is busy", title: "⠐ Run background sleep command", claim: claimBusy, summary: "Run background sleep command"},
+		{name: "another spinner frame", title: "⠸ Editing files", claim: claimBusy, summary: "Editing files"},
+		{name: "asterisk is not busy", title: "✳ Run background sleep command", claim: claimNotBusy, summary: "Run background sleep command"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			o := newHarnessSignalObserver(agentdriver.HarnessSignalsClaude)
@@ -58,9 +59,10 @@ func TestClaudeTitleHeartbeat(t *testing.T) {
 			if got.Source != SourceHeartbeat || got.Claim != tc.claim {
 				t.Fatalf("got %+v, want %s/%s", got, SourceHeartbeat, tc.claim)
 			}
-			// The title doubles as a live turn summary — a free sidebar label.
-			if got.Detail != tc.title {
-				t.Fatalf("detail %q, want the title verbatim", got.Detail)
+			// The title doubles as a live turn summary — a free sidebar label —
+			// minus the level glyph, which says nothing the claim does not.
+			if got.Detail != tc.summary {
+				t.Fatalf("detail %q, want %q", got.Detail, tc.summary)
 			}
 			if !got.At.Equal(now) {
 				t.Fatalf("At %s, want %s", got.At, now)
@@ -86,8 +88,12 @@ func TestClaudeIgnoresAForeignTitle(t *testing.T) {
 func TestCodexTitleHeartbeat(t *testing.T) {
 	now := time.Now()
 	o := newHarnessSignalObserver(agentdriver.HarnessSignalsCodex)
-	if got := onlySignal(t, observeAt(o, now, title("⠸ attn--fix-state-detec..."))); got.Claim != claimBusy {
+	got := onlySignal(t, observeAt(o, now, title("⠸ attn--fix-state-detec...")))
+	if got.Claim != claimBusy {
 		t.Fatalf("got %+v, want busy", got)
+	}
+	if got.Detail != "attn--fix-state-detec..." {
+		t.Fatalf("detail %q, want the spinner stripped", got.Detail)
 	}
 	if got := onlySignal(t, observeAt(o, now, title("attn--fix-state-detec..."))); got.Claim != claimNotBusy {
 		t.Fatalf("got %+v, want not_busy", got)
@@ -160,5 +166,41 @@ func TestHeartbeatSurvivesEverySplitPoint(t *testing.T) {
 		if got[0].Claim != claimBusy || got[1].Claim != claimNotBusy {
 			t.Fatalf("split at %d: got %+v", split, got)
 		}
+	}
+}
+
+// The spinner frame changes several times a second while the level does not.
+// Carrying it in the detail made every keepalive emission a distinct row, so a
+// long turn consumed one trace slot per second and evicted every other kind of
+// evidence — the opposite of what the trace is for. The detail is the turn
+// summary, and it must be stable across frames.
+func TestHeartbeatDetailIsStableAcrossSpinnerFrames(t *testing.T) {
+	start := time.Now()
+	o := newHarnessSignalObserver(agentdriver.HarnessSignalsClaude)
+
+	var details []string
+	for i, frame := range []string{"⠐", "⠸", "⠿", "⠇", "⠏"} {
+		// One keepalive apart, so every frame is emitted rather than throttled.
+		at := start.Add(time.Duration(i) * (heartbeatKeepalive + time.Millisecond))
+		got := onlySignal(t, observeAt(o, at, title(frame+" Run background sleep command")))
+		if got.Claim != claimBusy {
+			t.Fatalf("frame %s: claim %q, want busy", frame, got.Claim)
+		}
+		details = append(details, got.Detail)
+	}
+
+	for _, detail := range details {
+		if detail != "Run background sleep command" {
+			t.Fatalf("details differ across frames: %q", details)
+		}
+	}
+}
+
+// A title that is only a spinner has no summary to report, and inventing one
+// (the glyph itself) would reintroduce the churn.
+func TestHeartbeatDetailIsEmptyForAGlyphOnlyTitle(t *testing.T) {
+	o := newHarnessSignalObserver(agentdriver.HarnessSignalsClaude)
+	if got := onlySignal(t, observeAt(o, time.Now(), title("⠐"))); got.Detail != "" {
+		t.Fatalf("detail %q, want empty", got.Detail)
 	}
 }

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -330,17 +330,20 @@ func (m *Manager) Spawn(opts SpawnOptions) error {
 
 	// The driver names which observers this agent gets; this only builds them.
 	detectorKind := agentdriver.ScreenDetectorNone
+	harnessSignalKind := agentdriver.HarnessSignalsNone
 	approvalResolverEnabled := false
 	if d := agentdriver.Get(agent); d != nil {
 		caps := agentdriver.EffectiveCapabilities(d)
 		detectorKind = caps.ScreenDetector
+		harnessSignalKind = caps.HarnessSignals
 		approvalResolverEnabled = caps.HasApprovalResolver
 	}
 	session.detector = newScreenDetector(detectorKind)
+	session.harnessSignals = newHarnessSignalObserver(harnessSignalKind)
 	if approvalResolverEnabled {
 		session.approvalResolver = &approvalResolver{}
 	}
-	if (session.detector != nil || session.approvalResolver != nil) && onState != nil {
+	if (session.detector != nil || session.harnessSignals != nil || session.approvalResolver != nil) && onState != nil {
 		session.onState = func(obs Observation) {
 			onState(opts.ID, obs)
 		}

--- a/internal/pty/observation.go
+++ b/internal/pty/observation.go
@@ -16,10 +16,31 @@ const (
 	// SourceWorkerInfo is the daemon's periodic worker `info` poll reporting the
 	// worker's last known state, not a fresh terminal observation.
 	SourceWorkerInfo Source = "worker_info"
+	// SourceHeartbeat is the OSC 0 window-title glyph the agent repaints while
+	// its turn runs. A level, not an edge: it says whether the agent is running
+	// right now, and nothing about why it stopped.
+	SourceHeartbeat Source = "heartbeat"
 	// SourceUnknown is a state that crossed the worker RPC without a source,
 	// i.e. from a worker older than the field.
 	SourceUnknown Source = "unknown"
 )
+
+// EvidenceOnly reports whether a source records evidence without claiming a
+// protocol state. Such an observation's Claim is in the source's own vocabulary
+// ("busy"), so applying it as a state name would be meaningless — the
+// daemon records it and moves on.
+//
+// This exists because the harness signals are wired ahead of the resolver that
+// will weigh them: their traces are being compared against the current behavior
+// before anything arbitrates on them. It goes away when the resolver lands.
+func (s Source) EvidenceOnly() bool {
+	switch s {
+	case SourceHeartbeat:
+		return true
+	default:
+		return false
+	}
+}
 
 // Observation is one piece of state evidence from the PTY layer. Claim is what
 // the source believes (a protocol state name); Detail is why, in human terms,

--- a/internal/pty/oscscan.go
+++ b/internal/pty/oscscan.go
@@ -1,0 +1,156 @@
+package pty
+
+// A read-only OSC scanner.
+//
+// The OSC 133 segmenter in osc133.go cannot be reused for this: it *strips* the
+// markers it finds, because OSC 133 produces no cells and the server-
+// authoritative restore rebuilds blocks from structured data rather than by
+// re-emitting markers into the VT dump. OSC 0 (window title) and OSC 777
+// (desktop notification) are different — the title is real terminal state the
+// client must keep, so nothing here may alter the byte stream. This scanner only
+// looks.
+//
+// It is also deliberately not corpus-locked to the frontend parser the way the
+// 133 segmenter is: nothing on the client side parses these, so there is no
+// parity contract to hold.
+
+// oscScanMaxPending abandons a never-terminated sequence so a producer that
+// emits an unterminated OSC cannot make the scanner buffer forever. A window
+// title is short; anything past this is not a title.
+const oscScanMaxPending = 4096
+
+// oscScanner finds complete `ESC ] <code> ; <payload> (BEL | ESC \)` sequences
+// across chunk boundaries. It reports what it saw and consumes nothing.
+type oscScanner struct {
+	// pending holds a sequence that started in an earlier chunk and has not been
+	// terminated yet.
+	pending []byte
+}
+
+// Feed reports every complete OSC sequence in chunk, in order. code is the
+// numeric introducer (0, 133, 777, …) and payload is everything between the
+// first `;` and the terminator. A sequence with no `;` reports an empty payload.
+func (s *oscScanner) Feed(chunk []byte, emit func(code int, payload string)) {
+	if len(s.pending) == 0 && indexOfByte(chunk, oscESC) < 0 {
+		return
+	}
+
+	var buffer []byte
+	if len(s.pending) > 0 {
+		buffer = make([]byte, 0, len(s.pending)+len(chunk))
+		buffer = append(buffer, s.pending...)
+		buffer = append(buffer, chunk...)
+		s.pending = nil
+	} else {
+		buffer = chunk
+	}
+
+	from := 0
+	for {
+		start := indexOfOSCIntroducer(buffer, from)
+		if start < 0 {
+			// Hold back a trailing lone ESC: the `]` may arrive in the next chunk.
+			if len(buffer) > 0 && buffer[len(buffer)-1] == oscESC {
+				s.pending = []byte{oscESC}
+			}
+			return
+		}
+
+		body, next, status := scanOSCBody(buffer, start+2)
+		switch status {
+		case oscScanTerminated:
+			if code, payload, ok := splitOSCBody(body); ok {
+				emit(code, payload)
+			}
+			from = next
+		case oscScanAbandoned:
+			// A stray ESC: the producer gave up on this sequence. Resume at the
+			// ESC, which may itself introduce the next one.
+			from = next
+		default: // oscScanIncomplete
+			if len(buffer)-start > oscScanMaxPending {
+				// Unterminated and oversized: drop it rather than hold the bytes,
+				// and resume past the introducer so a later well-formed sequence
+				// in the same stream is still seen.
+				from = start + 2
+				continue
+			}
+			s.pending = append([]byte(nil), buffer[start:]...)
+			return
+		}
+	}
+}
+
+// indexOfOSCIntroducer finds the next `ESC ]`.
+func indexOfOSCIntroducer(buffer []byte, from int) int {
+	for i := from; i+1 < len(buffer); i++ {
+		if buffer[i] == oscESC && buffer[i+1] == ']' {
+			return i
+		}
+	}
+	return -1
+}
+
+type oscScanStatus int
+
+const (
+	// oscScanIncomplete: the sequence may still be terminated by a later chunk.
+	oscScanIncomplete oscScanStatus = iota
+	// oscScanTerminated: a complete sequence.
+	oscScanTerminated
+	// oscScanAbandoned: a stray ESC that does not start ST. An OSC cannot contain
+	// one, so the producer gave up on this sequence — and waiting for a
+	// terminator that will never come would hide every later sequence in the
+	// stream.
+	oscScanAbandoned
+)
+
+// scanOSCBody returns the bytes between the introducer and the terminator. For
+// oscScanTerminated, next is the index just past the terminator; for
+// oscScanAbandoned it is where to resume scanning (the stray ESC itself, which
+// may introduce the next sequence).
+func scanOSCBody(buffer []byte, from int) ([]byte, int, oscScanStatus) {
+	for i := from; i < len(buffer); i++ {
+		switch buffer[i] {
+		case oscBEL:
+			return buffer[from:i], i + 1, oscScanTerminated
+		case oscESC:
+			if i+1 >= len(buffer) {
+				return nil, 0, oscScanIncomplete
+			}
+			if buffer[i+1] == oscBackslash {
+				return buffer[from:i], i + 2, oscScanTerminated
+			}
+			return nil, i, oscScanAbandoned
+		}
+	}
+	return nil, 0, oscScanIncomplete
+}
+
+// splitOSCBody parses `<digits>;<payload>` (or a bare `<digits>`). ok is false
+// for a body whose introducer is not numeric, which is not an OSC we can route.
+func splitOSCBody(body []byte) (int, string, bool) {
+	code := 0
+	digits := 0
+	for i := 0; i < len(body); i++ {
+		switch {
+		case body[i] >= '0' && body[i] <= '9':
+			code = code*10 + int(body[i]-'0')
+			digits++
+			if digits > 9 {
+				return 0, "", false
+			}
+		case body[i] == ';':
+			if digits == 0 {
+				return 0, "", false
+			}
+			return code, string(body[i+1:]), true
+		default:
+			return 0, "", false
+		}
+	}
+	if digits == 0 {
+		return 0, "", false
+	}
+	return code, "", true
+}

--- a/internal/pty/oscscan_test.go
+++ b/internal/pty/oscscan_test.go
@@ -1,0 +1,136 @@
+package pty
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type scannedOSC struct {
+	code    int
+	payload string
+}
+
+func scanAll(chunks ...string) []scannedOSC {
+	var s oscScanner
+	var out []scannedOSC
+	for _, chunk := range chunks {
+		s.Feed([]byte(chunk), func(code int, payload string) {
+			out = append(out, scannedOSC{code, payload})
+		})
+	}
+	return out
+}
+
+func assertScanned(t *testing.T, got []scannedOSC, want ...scannedOSC) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %d sequences %+v, want %d %+v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sequence %d: got %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestOSCScannerReadsBothTerminators(t *testing.T) {
+	assertScanned(t,
+		scanAll("\x1b]0;title\x07"),
+		scannedOSC{0, "title"})
+	assertScanned(t,
+		scanAll("\x1b]0;title\x1b\\"),
+		scannedOSC{0, "title"})
+}
+
+func TestOSCScannerIgnoresPlainOutput(t *testing.T) {
+	if got := scanAll("hello world\nno escapes here"); got != nil {
+		t.Fatalf("got %+v, want nothing", got)
+	}
+}
+
+func TestOSCScannerReadsSeveralInOneChunk(t *testing.T) {
+	assertScanned(t,
+		scanAll("a\x1b]0;one\x07b\x1b]777;notify;App;msg\x07c"),
+		scannedOSC{0, "one"},
+		scannedOSC{777, "notify;App;msg"})
+}
+
+// The read loop hands over whatever the PTY returned, so a sequence routinely
+// straddles a chunk boundary. Splitting one at every byte is the only honest way
+// to prove it survives.
+func TestOSCScannerSurvivesEverySplitPoint(t *testing.T) {
+	const stream = "before\x1b]0;⠀ running\x07after\x1b]777;notify;Claude Code;waiting\x07tail"
+	want := []scannedOSC{{0, "⠀ running"}, {777, "notify;Claude Code;waiting"}}
+	for split := range len(stream) + 1 {
+		got := scanAll(stream[:split], stream[split:])
+		if len(got) != len(want) {
+			t.Fatalf("split at %d: got %+v, want %+v", split, got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("split at %d, sequence %d: got %+v, want %+v", split, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestOSCScannerHandlesOneBytePerCall(t *testing.T) {
+	const stream = "\x1b]0;⠀ x\x07"
+	chunks := make([]string, 0, len(stream))
+	for i := range len(stream) {
+		chunks = append(chunks, stream[i:i+1])
+	}
+	assertScanned(t, scanAll(chunks...), scannedOSC{0, "⠀ x"})
+}
+
+func TestOSCScannerReportsBareCodeWithNoPayload(t *testing.T) {
+	assertScanned(t, scanAll("\x1b]0\x07"), scannedOSC{0, ""})
+}
+
+func TestOSCScannerSkipsNonNumericIntroducers(t *testing.T) {
+	if got := scanAll("\x1b]hello;there\x07"); got != nil {
+		t.Fatalf("got %+v, want nothing", got)
+	}
+}
+
+// A stray ESC inside an OSC means the producer abandoned the sequence. Scanning
+// past it looking for a terminator that will never come would swallow every
+// later sequence in the stream.
+func TestOSCScannerRecoversFromAnAbandonedSequence(t *testing.T) {
+	assertScanned(t,
+		scanAll("\x1b]0;broken\x1b[0m\x1b]0;good\x07"),
+		scannedOSC{0, "good"})
+}
+
+// A producer that never terminates an OSC must not make the scanner buffer the
+// rest of the session. Past the cap it gives up on that sequence and keeps
+// scanning, so a later well-formed one is still seen.
+func TestOSCScannerAbandonsAnOversizedSequence(t *testing.T) {
+	flood := "\x1b]0;" + strings.Repeat("x", oscScanMaxPending+64)
+	assertScanned(t,
+		scanAll(flood, "\x1b]0;recovered\x07"),
+		scannedOSC{0, "recovered"})
+}
+
+func TestOSCScannerHoldsATrailingEscape(t *testing.T) {
+	assertScanned(t, scanAll("text\x1b", "]0;title\x07"), scannedOSC{0, "title"})
+}
+
+func TestOSCScannerRejectsAnAbsurdCode(t *testing.T) {
+	if got := scanAll(fmt.Sprintf("\x1b]%s;x\x07", strings.Repeat("9", 12))); got != nil {
+		t.Fatalf("got %+v, want nothing", got)
+	}
+}
+
+// OSC 133 rides the same stream and is parsed elsewhere (and stripped there);
+// this scanner must report it without disturbing anything, since it only reads.
+func TestOSCScannerSeesOSC133WithoutConsumingIt(t *testing.T) {
+	chunk := []byte("\x1b]133;A\x07prompt")
+	before := string(chunk)
+	got := scanAll(string(chunk))
+	assertScanned(t, got, scannedOSC{133, "A"})
+	if string(chunk) != before {
+		t.Fatalf("the scanner modified the chunk: %q", string(chunk))
+	}
+}

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -132,10 +132,13 @@ type Session struct {
 	theme   TerminalTheme
 
 	// CLI state detection based on PTY output.
-	detector      stateDetector
-	onState       func(obs Observation)
-	stateMu       sync.RWMutex
-	detectorState string
+	detector stateDetector
+	// harnessSignals reads the agent's own OSC state signals off the same stream
+	// the detector scrapes. Read-only: it never alters the bytes.
+	harnessSignals *harnessSignalObserver
+	onState        func(obs Observation)
+	stateMu        sync.RWMutex
+	detectorState  string
 
 	// approvalResolver clears pending_approval->working off the rendered screen
 	// when the user resolves an approval prompt (no hook fires at that moment).
@@ -363,6 +366,11 @@ func (s *Session) readLoop(onExit func(exitCode int, signal string), logf func(s
 						s.detectorState = state
 						s.stateMu.Unlock()
 						s.onState(newObservation(SourceScreen, state, "screen scrape", time.Now()))
+					}
+				}
+				if s.harnessSignals != nil && s.onState != nil {
+					for _, obs := range s.harnessSignals.Observe(data, time.Now()) {
+						s.onState(obs)
 					}
 				}
 				if len(data) > 0 {

--- a/internal/pty/spike_state_replay_test.go
+++ b/internal/pty/spike_state_replay_test.go
@@ -241,7 +241,7 @@ func (d *spikeOSCDetector) feed(at float64, data []byte) {
 			}
 			return
 		}
-		body, next, ok := scanOSCBody(d.pending, start)
+		body, next, ok := spikeScanOSCBody(d.pending, start)
 		if !ok {
 			d.pending = d.pending[start:]
 			return
@@ -260,8 +260,8 @@ func indexOSC(buf []byte) int {
 	return -1
 }
 
-// scanOSCBody returns the payload between ESC] and its BEL/ST terminator.
-func scanOSCBody(buf []byte, start int) (body string, next int, ok bool) {
+// spikeScanOSCBody returns the payload between ESC] and its BEL/ST terminator.
+func spikeScanOSCBody(buf []byte, start int) (body string, next int, ok bool) {
 	i := start + 2
 	for i < len(buf) {
 		if buf[i] == 0x07 {

--- a/internal/ptybackend/worker.go
+++ b/internal/ptybackend/worker.go
@@ -2150,20 +2150,27 @@ func (b *WorkerBackend) handleLifecycleEvent(session *workerSession, evt ptywork
 			return
 		}
 		now := time.Now()
-		session.mu.Lock()
-		if !shouldForwardStateLocked(session, state, now) {
+		observation := ptyworker.ObservationFromEvent(evt, state, now)
+		// Evidence-only observations carry a claim in their own vocabulary rather
+		// than a protocol state, so the state dedup below does not apply to them:
+		// it would compare "busy" against the last *state* and drop a heartbeat
+		// whenever the two strings happened to match.
+		if !observation.Source.EvidenceOnly() {
+			session.mu.Lock()
+			if !shouldForwardStateLocked(session, state, now) {
+				session.mu.Unlock()
+				return
+			}
+			session.lastState = state
+			session.lastStateSentAt = now
 			session.mu.Unlock()
-			return
 		}
-		session.lastState = state
-		session.lastStateSentAt = now
-		session.mu.Unlock()
 
 		b.hooksMu.RLock()
 		onState := b.onState
 		b.hooksMu.RUnlock()
 		if onState != nil {
-			onState(session.SessionID, ptyworker.ObservationFromEvent(evt, state, now))
+			onState(session.SessionID, observation)
 		}
 	case ptyworker.EventExit:
 		session.mu.Lock()

--- a/internal/ptyworker/runtime.go
+++ b/internal/ptyworker/runtime.go
@@ -187,6 +187,15 @@ func (r *Runtime) run(ctx context.Context) error {
 
 	r.manager = pty.NewManager(r.logf)
 	r.manager.SetStateHandler(func(_ string, obs pty.Observation) {
+		// An evidence-only observation does not claim a protocol state, so it must
+		// not touch the cached state or be deduped against it: "busy" and "working"
+		// are different vocabularies, and collapsing them would both corrupt the
+		// cache the worker replays to new watchers and silently drop a heartbeat
+		// whenever it happened to equal the last state string.
+		if obs.Source.EvidenceOnly() {
+			r.broadcastLifecycle(stateChangedEvent(r.cfg.SessionID, obs))
+			return
+		}
 		state := obs.Claim
 		r.stateMu.Lock()
 		previousState := r.state

--- a/internal/statetrace/statetrace.go
+++ b/internal/statetrace/statetrace.go
@@ -47,6 +47,10 @@ const (
 	// OutcomeSkipped means the source produced no claim at all — it looked and
 	// decided there was nothing to report.
 	OutcomeSkipped Outcome = "skipped"
+	// OutcomeObserved means the observation was recorded as evidence and never
+	// offered to the store, because its source does not drive state. The harness
+	// signals are wired this way ahead of the resolver that will weigh them.
+	OutcomeObserved Outcome = "observed"
 )
 
 // Observation is one recorded piece of state evidence and its fate.
@@ -74,6 +78,25 @@ type Observation struct {
 	ObservedAt time.Time
 	// RecordedAt is when the daemon acted on it.
 	RecordedAt time.Time
+	// Repeats counts how many identical observations this entry stands for beyond
+	// the first. A level source restates itself continuously — the OSC 0 title
+	// heartbeat repaints about once a second — and appending every restatement
+	// would evict the rest of the history from a bounded ring within a minute.
+	// Consecutive identical observations collapse into one entry whose RecordedAt
+	// tracks the latest, so the ring holds real history and still shows liveness.
+	Repeats int
+}
+
+// sameEvidenceAs reports whether two observations say the same thing, which is
+// what makes them collapsible. RecordedAt and ObservedAt deliberately do not
+// count: the whole point is that the newer one only updates the timestamps.
+func (o Observation) sameEvidenceAs(other Observation) bool {
+	return o.Source == other.Source &&
+		o.Claim == other.Claim &&
+		o.Cause == other.Cause &&
+		o.Outcome == other.Outcome &&
+		o.Reason == other.Reason &&
+		o.Detail == other.Detail
 }
 
 // LogLine renders one observation as a single daemon-log line. It is the form
@@ -171,6 +194,12 @@ func (r *Recorder) RecordIf(sessionID string, obs Observation, admit func() bool
 		target = newRing(r.capacity)
 		r.rings[sessionID] = target
 	}
+	if last := target.newest(); last != nil && last.sameEvidenceAs(obs) {
+		last.Repeats++
+		last.RecordedAt = obs.RecordedAt
+		last.ObservedAt = obs.ObservedAt
+		return
+	}
 	target.push(obs)
 }
 
@@ -232,6 +261,16 @@ func (r *ring) push(obs Observation) {
 	}
 	r.items[r.start] = obs
 	r.start = (r.start + 1) % capacity
+}
+
+// newest returns a pointer to the most recently pushed observation, or nil when
+// the ring is empty. The pointer is into the ring's own storage so a collapsing
+// repeat can update it in place.
+func (r *ring) newest() *Observation {
+	if r.size == 0 {
+		return nil
+	}
+	return &r.items[(r.start+r.size-1)%len(r.items)]
 }
 
 func (r *ring) snapshot() []Observation {


### PR DESCRIPTION
Phase 1a of the agent state detection plan
([docs/plans/2026-07-25-agent-state-detection.md](docs/plans/2026-07-25-agent-state-detection.md)).
Stacked on #668 (phase 0), which added the state trace this PR writes into.

## Why

Both agents already broadcast whether they are busy, in their window title, and
attn has been ignoring it in favour of scraping the rendered screen:

```
ESC ] 0 ; ⠐ Run background sleep command BEL     claude, turn RUNNING
ESC ] 0 ; ✳ Run background sleep command BEL     claude, turn NOT running
ESC ] 0 ; ⠸ attn--fix-state-detec... BEL         codex, busy
ESC ] 0 ; attn--fix-state-detec... BEL           codex, idle
```

The glyph is a *level*, repainted ~1Hz by claude and ~10Hz by codex, produced by
the harness rather than guessed at from its TUI. A level that stops arriving
cannot get stuck the way an edge-triggered claim can, which is the whole point:
the stuck colors this epic is about are edges that lost an arbitration nobody
was arbitrating.

## What lands

A read-only OSC scanner in the PTY read loop (`internal/pty/oscscan.go`) emits
observations on a new `heartbeat` source. Nothing arbitrates on them yet — they
are recorded in the phase 0 trace so the traces can be compared against current
behavior before the resolver starts weighing them.

- The OSC 133 segmenter could not be reused: it strips markers from the stream
  and is corpus-locked to a frontend parity fixture. The new scanner never
  touches the stream. It also handles a stray `ESC` mid-sequence by resuming *at*
  the ESC, so an abandoned sequence cannot make it swallow every later one.
- Per-agent behavior is a driver capability (`Capabilities.HarnessSignals`),
  matching the `ScreenDetector` kind pattern, with the usual disable-only
  `ATTN_AGENT_<AGENT>_HARNESS_SIGNALS=0` override.
- `pty.Source.EvidenceOnly()` routes these past `applyState` entirely — the
  claims are `busy`/`not_busy`, not protocol state names — and past the
  worker/backend state dedup, which would otherwise swallow a repeated level.
- An unchanged level re-emits at most once a second, and the trace collapses
  consecutive identical observations into a repeat count (`observed ×9`), so a
  long turn cannot flush the ring.

## OSC 777 was planned, built, and deleted

The plan listed OSC 777 `notify` as claude's explicit settle event. It is not:
claude emits no OSC 777 at all. No capture in the nine-session spike contains
one, and 2.1.220 offers only the `iterm2`, `iterm2_with_bell`, and
`terminal_bell` notification channels. I had the reader written and passing unit
tests before checking for a live witness; with none available it is deleted here
rather than shipped as a code path production never executes. Claude's settle
event is the `Notification` hook, which lands in phase 1b. The plan carries the
correction.

## Live verification

Profile `statedet` (full `make install`, `preflight` PASS, protocol 191 across
CLI/app/daemon), current head, both agents driven through the harness bridge.

Codex — `attn state explain`, one turn:

```
OBSERVED       SOURCE       CLAIM      OUTCOME       WHY
18:08:51.435   worker_info  working    vetoed        driver_transition_filter
18:08:51.951   heartbeat    busy       observed      "⠸ attn--fix-state-detec..."
18:08:52.551   heartbeat    not_busy   observed      "attn--fix-state-detec..."
18:09:50.112   heartbeat    busy       observed      "⠴ attn--fix-state-detec..."
18:09:50.166   hook_state   working    applied       cause=live_signal
18:09:52.209   heartbeat    busy       observed ×2   "⠦ attn--fix-state-detec..."
18:09:54.301   heartbeat    busy       observed ×2   "⠧ attn--fix-state-detec..."
18:09:55.395   heartbeat    busy       observed      "⠇ attn--fix-state-detec..."
18:09:56.515   heartbeat    busy       observed      "⠏ attn--fix-state-detec..."
18:09:56.862   heartbeat    not_busy   observed      "attn--fix-state-detec..."
18:09:56.534   classifier   idle       applied       cause=classifier_observation
```

The heartbeat went busy 54ms *before* the hook said `working`, stayed busy for
the turn, and dropped 328ms after the classifier settled the session — a level
that brackets the turn from both ends.

Claude — same shape, and it caught a live misdetection worth noting for phase 2:

```
18:03:38.702   heartbeat    busy            observed      "⠂ Claude Code"
18:03:38.703   screen       idle            applied       "screen scrape"
18:03:38.708   hook_state   working         applied       cause=live_signal
18:03:55.062   heartbeat    busy            observed ×9   "⠐ Run sleep command and echo done"
18:03:57.898   heartbeat    not_busy        observed      "✳ Run sleep command and echo done"
18:03:57.899   screen       waiting_input   applied       "screen scrape"
```

At 18:03:38 the screen scrape wrote `idle` in the same millisecond the harness
said the turn had started; the hook corrected it 6ms later. That is the class of
edge the resolver replaces the scraper for.

The title also carries a live turn summary ("Run sleep command and echo done") —
a free sidebar label with no LLM call, available whenever the UI wants it.

## Tests

`internal/pty/oscscan_test.go` and `internal/pty/harness_signals_test.go` cover
the scanner (including a split-at-every-byte pass over a full exchange, since the
read loop hands over arbitrary chunks), per-agent classification, foreign-title
rejection, and the keepalive throttle. `internal/daemon/state_trace_test.go`
covers the evidence-only route: recorded as `observed`, never reaching
`applyState`, with repeats collapsed and a changed claim opening a new row.

`make test` and `make test-frontend` green.
