### PR TITLE
feat(state): add the pure session-state resolver

### DIFF
--- a/docs/plans/2026-07-25-agent-state-detection.md
+++ b/docs/plans/2026-07-25-agent-state-detection.md
@@ -601,8 +601,13 @@ being fixed as part of the current step.
 
 ### Phase 2 — resolver
 
-- [ ] New `internal/sessionstate` with `Evidence`, `Resolve`, table tests built
-      from Phase 1 traces.
+- [x] **Phase 2a (PR #671).** New `internal/sessionstate` with `Evidence`,
+      `Resolve`, `DwellFor`, and table tests. Timing is a `Policy` argument
+      rather than package constants, so each table case states the window it is
+      testing; `PolicyFor` holds the measured per-agent defaults. `Resolution`
+      ships without the plan's `Unsettles` projection — nothing consumes it
+      until the attention mode exists, and an unconsumed field is the same
+      unwitnessed-code mistake as the OSC 777 reader.
 - [x] Enabling refactor 5 (first half): `classifySessionState`'s rules extracted
       to `internal/daemon/classify_decision.go` as three pure functions
       (`classifyPreTranscript`, `classifyPostTranscript`, `classifyVerdict`)

--- a/internal/sessionstate/sessionstate.go
+++ b/internal/sessionstate/sessionstate.go
@@ -115,6 +115,14 @@ type Evidence struct {
 	// before it is worth showing anyone.
 	ReviewerInLoop bool
 
+	// LastBusyAt is when the heartbeat last said the turn was running. Staleness
+	// is measured from here rather than from the latest heartbeat: claude blips
+	// its not-busy glyph mid-turn (between tool calls, and while a foreground
+	// tool is still running), so treating any non-busy frame as an immediate
+	// settle would flip a healthy open turn to idle. Zero means the agent has
+	// never reported being busy, which is not the same as having gone quiet.
+	LastBusyAt time.Time
+
 	// LastMovement is when any evidence last changed. A session whose evidence
 	// has stopped moving entirely is stuck, which is a distinct condition from
 	// any state it might be reported in.
@@ -243,7 +251,7 @@ func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
 	// what the heartbeat is for: a bracket whose closing hook was lost would
 	// otherwise hold the session working for the rest of its life.
 	if e.TurnOpen || e.ToolOpen {
-		if !heartbeatSilentFor(e.Heartbeat, now, policy.StaleAfter) {
+		if !heartbeatSilentFor(e, now, policy.StaleAfter) {
 			return Resolution{State: protocol.SessionStateWorking, Reason: ReasonBracketOpen}
 		}
 		// The bracket is stale. Fall through to the settled clauses below, which
@@ -345,16 +353,19 @@ func fresh(o *Observation, claim Claim, now time.Time, ttl time.Duration) bool {
 }
 
 // heartbeatSilentFor reports whether the agent has stopped saying it is busy for
-// longer than d. A heartbeat that never arrived is not silence: an agent with no
+// longer than d.
+//
+// It reads LastBusyAt, not the latest heartbeat. A single non-busy frame is not
+// a settle: claude blips its idle glyph mid-turn, so closing the bracket on that
+// frame would reintroduce the false-settle path the measurements ruled out. Only
+// the absence of busy frames for a full window counts, and an explicit settle
+// arrives as its own fact — the Stop hook closing the bracket.
+//
+// An agent that has never reported being busy is not silent: an agent with no
 // harness signals must not have its brackets closed out from under it.
-func heartbeatSilentFor(o *Observation, now time.Time, d time.Duration) bool {
-	if o == nil {
+func heartbeatSilentFor(e Evidence, now time.Time, d time.Duration) bool {
+	if e.LastBusyAt.IsZero() {
 		return false
 	}
-	if o.Claim != ClaimBusy {
-		// The agent said out loud that it is not busy. That is stronger than
-		// silence, so the bracket is stale immediately.
-		return true
-	}
-	return now.Sub(o.ObservedAt) > d
+	return now.Sub(e.LastBusyAt) > d
 }

--- a/internal/sessionstate/sessionstate.go
+++ b/internal/sessionstate/sessionstate.go
@@ -1,0 +1,360 @@
+// Package sessionstate resolves what an agent session is doing from the
+// evidence collected about it.
+//
+// It exists because attn's state was previously decided by whoever wrote last.
+// Every source — hooks, the screen scraper, the stop classifier, the worker
+// poll — called the store directly with a state name, and a session got stuck
+// whenever the source that would have moved it on never fired. There was no
+// arbitration to fix, because there was no arbitration.
+//
+// The fix is structural rather than a better heuristic: sources record what they
+// saw, this package decides what that means, and a tick re-runs the decision so
+// evidence expires. Every clause below that can hold a session in a state
+// depends on evidence that either refreshes or ages out, which is what makes a
+// stuck state impossible rather than merely unlikely.
+//
+// The package is pure — no daemon, store, or IO imports — so the rules are
+// table-tested directly instead of by standing up a daemon.
+package sessionstate
+
+import (
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// Source names where an observation came from. The resolver treats sources
+// differently, so this is not merely diagnostic.
+type Source string
+
+const (
+	// SourceHeartbeat is the agent's own OSC 0 title glyph: a level, refreshed
+	// while its turn runs.
+	SourceHeartbeat Source = "heartbeat"
+	// SourceBracket is a hook opening or closing a turn or a tool call. The
+	// primary level — the only signal that survives the multi-second title
+	// silence claude produces in the middle of a blocking tool call.
+	SourceBracket Source = "hook_bracket"
+	// SourceHarnessEvent is a one-shot harness announcement: an approval
+	// request, Claude's Notification hook.
+	SourceHarnessEvent Source = "harness_event"
+	// SourceClassifier is the stop-time verdict on a settled turn.
+	SourceClassifier Source = "classifier"
+	// SourceScreen is the rendered-screen scrape. Copilot only: it has no
+	// harness signals to read. It is deleted for claude and codex, not demoted
+	// to a fallback, because it manufactures approvals from ordinary prose.
+	SourceScreen Source = "screen"
+	// SourceProcess is the PTY process itself. A level with no expiry: an exited
+	// process does not become un-exited.
+	SourceProcess Source = "process"
+)
+
+// Claim is what an observation asserts. Deliberately not a protocol state name:
+// a source reports what it saw, and only the resolver names a state. "The turn
+// is running" and "the session is working" are different statements, and
+// collapsing them is what let a heartbeat masquerade as an applied state.
+type Claim string
+
+const (
+	// ClaimBusy: the agent's turn is running right now.
+	ClaimBusy Claim = "busy"
+	// ClaimSettled: the turn is over. It says nothing about why it ended — an
+	// approval, a question, and a finished turn all settle.
+	ClaimSettled Claim = "settled"
+	// ClaimApprovalPending: the agent asked for permission and has not been
+	// answered.
+	ClaimApprovalPending Claim = "approval_pending"
+	// ClaimNeedsInput: the agent is waiting on the user specifically, as opposed
+	// to having simply finished.
+	ClaimNeedsInput Claim = "needs_input"
+	// ClaimIdle: the agent finished and wants nothing.
+	ClaimIdle Claim = "idle"
+	// ClaimExited: the process is gone.
+	ClaimExited Claim = "exited"
+)
+
+// Observation is one recorded piece of evidence.
+type Observation struct {
+	Source     Source
+	Claim      Claim
+	Detail     string
+	ObservedAt time.Time
+}
+
+// Evidence is everything the resolver may read about one session. The daemon
+// owns it and mutates it as observations arrive; the resolver only reads.
+//
+// Levels (Heartbeat, TurnOpen, ToolOpen, Screen, Process) describe a condition
+// that holds until it changes. Edges (LastHarnessEvent, LastClassifier) are
+// one-shot facts that stay until superseded.
+type Evidence struct {
+	// Heartbeat is the most recent title-glyph observation. Its freshness is
+	// what bounds how long a stale bracket may lie.
+	Heartbeat *Observation
+	// LastHarnessEvent is the most recent approval/notification edge.
+	LastHarnessEvent *Observation
+	// LastClassifier is the most recent stop-time verdict.
+	LastClassifier *Observation
+	// Screen is the scraped-screen level. Copilot only.
+	Screen *Observation
+	// Process is the PTY lifecycle level.
+	Process *Observation
+
+	// TurnOpen: a prompt was submitted and no Stop has closed it.
+	TurnOpen bool
+	// ToolOpen: a tool call started and has not reported completion.
+	ToolOpen bool
+	// BackgroundWork: the turn yielded with asynchronous work outstanding, so
+	// it will auto-resume. Reported as a fact on the Stop payload.
+	BackgroundWork bool
+	// PendingCron: the turn yielded with a scheduled wakeup that will resume it.
+	PendingCron bool
+	// ReviewerInLoop: something other than the user answers approval requests —
+	// claude's permission classifier, codex's auto_review guardian. It does not
+	// suppress an approval state; it decides how long that state must hold
+	// before it is worth showing anyone.
+	ReviewerInLoop bool
+
+	// LastMovement is when any evidence last changed. A session whose evidence
+	// has stopped moving entirely is stuck, which is a distinct condition from
+	// any state it might be reported in.
+	LastMovement time.Time
+}
+
+// Policy holds the timing constants. They are per-agent and measured, so they
+// are an input rather than package constants: a table test states the timing it
+// is testing instead of inheriting it.
+type Policy struct {
+	// HeartbeatTTL is how long a busy heartbeat keeps a session working on its
+	// own. It must exceed the agent's title repaint interval by enough margin to
+	// survive a PTY read that batches chunks under load.
+	HeartbeatTTL time.Duration
+	// StaleAfter is the heartbeat silence that closes a bracket whose closing
+	// hook never arrived. It must exceed the longest silence the agent produces
+	// mid-turn, or a slow tool call reads as a finished turn.
+	StaleAfter time.Duration
+	// StuckAfter is total evidence silence — no source of any kind — after which
+	// the session is reported stuck rather than left in whatever it last showed.
+	StuckAfter time.Duration
+	// GuardianDwell is how long an approval must hold before it is published
+	// when a reviewer is in the loop. It is not a delay on genuine approval
+	// requests: with no reviewer the dwell is zero.
+	GuardianDwell time.Duration
+}
+
+// Measured on claude 2.1.220 and codex 0.145.0 driven through a real PTY.
+// Claude repaints its title about once a second and goes silent for up to ~3.5s
+// in the middle of a blocking foreground tool call; codex repaints about ten
+// times a second and never goes quiet mid-turn. Hence claude's TTL carries ~55%
+// margin over its repaint interval and codex's carries ~5x.
+const (
+	claudeHeartbeatTTL = 1500 * time.Millisecond
+	codexHeartbeatTTL  = 500 * time.Millisecond
+	defaultStaleAfter  = 4 * time.Second
+	defaultStuckAfter  = 90 * time.Second
+	// guardianDwell is the round trip a guardian needs to answer in the user's
+	// place. Measured: 90ms for claude's permission classifier, low seconds for
+	// codex's auto_review. 60s is deliberately far above both — the cost of
+	// waiting is a late notification, the cost of not waiting is a yellow flash
+	// on every tool call of an unattended run.
+	guardianDwell = 60 * time.Second
+)
+
+// PolicyFor returns the timing for an agent. An agent with no measured numbers
+// gets the conservative end of each: a TTL short enough not to hold a session
+// working on a stale glyph, and a stale window long enough not to close a
+// bracket early.
+func PolicyFor(agent string) Policy {
+	policy := Policy{
+		HeartbeatTTL:  codexHeartbeatTTL,
+		StaleAfter:    defaultStaleAfter,
+		StuckAfter:    defaultStuckAfter,
+		GuardianDwell: guardianDwell,
+	}
+	if agent == string(protocol.SessionAgentClaude) {
+		policy.HeartbeatTTL = claudeHeartbeatTTL
+	}
+	return policy
+}
+
+// Reason names why the resolver reached a state. It is what `attn state explain`
+// shows, and it is the difference between "the color is wrong" and a diagnosis.
+type Reason string
+
+const (
+	ReasonProcessExited    Reason = "process_exited"
+	ReasonHeartbeatFresh   Reason = "heartbeat_fresh"
+	ReasonApprovalOpen     Reason = "approval_open"
+	ReasonCronPending      Reason = "cron_pending"
+	ReasonBracketOpen      Reason = "bracket_open"
+	ReasonBracketStale     Reason = "bracket_stale"
+	ReasonBackgroundWork   Reason = "background_work"
+	ReasonClassifierVerdict Reason = "classifier_verdict"
+	ReasonScreen           Reason = "screen"
+	ReasonStuck            Reason = "stuck"
+	ReasonNoEvidence       Reason = "no_evidence"
+)
+
+// Resolution is the resolver's answer.
+type Resolution struct {
+	State  protocol.SessionState
+	Reason Reason
+	// Detail carries the winning observation's detail so a diagnosis does not
+	// require re-reading the evidence table.
+	Detail string
+}
+
+// Resolve decides what a session is doing. Pure: same evidence and same clock
+// always give the same answer.
+//
+// The clauses are ordered, first match wins, and the order encodes trust rather
+// than recency. A fresh heartbeat outranks an open approval because the agent
+// cannot be blocked on the user while its turn is visibly running — that
+// combination means the approval was already answered and its closing edge was
+// lost.
+func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
+	// A process that exited is terminal. Nothing below can outrank it, and no
+	// amount of stale evidence should keep a dead session colored as alive.
+	if e.Process != nil && e.Process.Claim == ClaimExited {
+		return Resolution{State: protocol.SessionStateIdle, Reason: ReasonProcessExited, Detail: e.Process.Detail}
+	}
+
+	// The clause that rescues a lost turn-open hook: the agent is visibly
+	// running, whatever the brackets say.
+	if fresh(e.Heartbeat, ClaimBusy, now, policy.HeartbeatTTL) {
+		return Resolution{State: protocol.SessionStateWorking, Reason: ReasonHeartbeatFresh, Detail: e.Heartbeat.Detail}
+	}
+
+	if e.LastHarnessEvent != nil && e.LastHarnessEvent.Claim == ClaimApprovalPending {
+		return Resolution{
+			State:  protocol.SessionStatePendingApproval,
+			Reason: ReasonApprovalOpen,
+			Detail: e.LastHarnessEvent.Detail,
+		}
+	}
+
+	// A scheduled wakeup will resume this session without anyone doing
+	// anything, so it is parked rather than waiting on a person.
+	if e.PendingCron {
+		return Resolution{State: protocol.SessionStateScheduled, Reason: ReasonCronPending}
+	}
+
+	// An open bracket says work is outstanding. Whether to believe it is exactly
+	// what the heartbeat is for: a bracket whose closing hook was lost would
+	// otherwise hold the session working for the rest of its life.
+	if e.TurnOpen || e.ToolOpen {
+		if !heartbeatSilentFor(e.Heartbeat, now, policy.StaleAfter) {
+			return Resolution{State: protocol.SessionStateWorking, Reason: ReasonBracketOpen}
+		}
+		// The bracket is stale. Fall through to the settled clauses below, which
+		// decide *how* it settled — but remember it, so a settle with no verdict
+		// is reported as an un-stick rather than as an absence of evidence.
+		return settled(e, ReasonBracketStale)
+	}
+
+	// Background work auto-resumes the turn, so the session is still working
+	// even though the turn yielded. Deliberate: the alternative flickers a
+	// session to idle and back for every backgrounded command.
+	if e.BackgroundWork {
+		return Resolution{State: protocol.SessionStateWorking, Reason: ReasonBackgroundWork}
+	}
+
+	if r, ok := classifierVerdict(e); ok {
+		return r
+	}
+
+	if e.Screen != nil {
+		if state, ok := screenState(e.Screen.Claim); ok {
+			return Resolution{State: state, Reason: ReasonScreen, Detail: e.Screen.Detail}
+		}
+	}
+
+	// Nothing has moved at all. That is its own diagnosis, and reporting it is
+	// the whole point: a stuck session used to be indistinguishable from a
+	// correctly-quiet one.
+	if !e.LastMovement.IsZero() && now.Sub(e.LastMovement) > policy.StuckAfter {
+		return Resolution{State: protocol.SessionStateUnknown, Reason: ReasonStuck}
+	}
+
+	return Resolution{State: protocol.SessionStateUnknown, Reason: ReasonNoEvidence}
+}
+
+// settled resolves a turn that is over, preferring the classifier's verdict and
+// falling back to the reason that got us here.
+func settled(e Evidence, fallback Reason) Resolution {
+	if r, ok := classifierVerdict(e); ok {
+		return r
+	}
+	return Resolution{State: protocol.SessionStateIdle, Reason: fallback}
+}
+
+func classifierVerdict(e Evidence) (Resolution, bool) {
+	if e.LastClassifier == nil {
+		return Resolution{}, false
+	}
+	switch e.LastClassifier.Claim {
+	case ClaimNeedsInput:
+		return Resolution{
+			State:  protocol.SessionStateWaitingInput,
+			Reason: ReasonClassifierVerdict,
+			Detail: e.LastClassifier.Detail,
+		}, true
+	case ClaimIdle:
+		return Resolution{
+			State:  protocol.SessionStateIdle,
+			Reason: ReasonClassifierVerdict,
+			Detail: e.LastClassifier.Detail,
+		}, true
+	default:
+		return Resolution{}, false
+	}
+}
+
+func screenState(claim Claim) (protocol.SessionState, bool) {
+	switch claim {
+	case ClaimBusy:
+		return protocol.SessionStateWorking, true
+	case ClaimApprovalPending:
+		return protocol.SessionStatePendingApproval, true
+	case ClaimNeedsInput:
+		return protocol.SessionStateWaitingInput, true
+	case ClaimIdle, ClaimSettled:
+		return protocol.SessionStateIdle, true
+	default:
+		return "", false
+	}
+}
+
+// DwellFor is how long a transition into state must hold before it is published.
+//
+// It is keyed on who is being asked first. With a guardian in the loop, an
+// approval request is addressed to the guardian, and showing it to the user
+// immediately produces a flash of attention-demanding color on every tool call
+// of an unattended run. With no guardian the user *is* the reviewer, so the
+// dwell is zero and a genuine request is not delayed by a millisecond.
+func DwellFor(state protocol.SessionState, e Evidence, policy Policy) time.Duration {
+	if state == protocol.SessionStatePendingApproval && e.ReviewerInLoop {
+		return policy.GuardianDwell
+	}
+	return 0
+}
+
+// fresh reports whether o makes claim and is recent enough to still be believed.
+func fresh(o *Observation, claim Claim, now time.Time, ttl time.Duration) bool {
+	return o != nil && o.Claim == claim && now.Sub(o.ObservedAt) <= ttl
+}
+
+// heartbeatSilentFor reports whether the agent has stopped saying it is busy for
+// longer than d. A heartbeat that never arrived is not silence: an agent with no
+// harness signals must not have its brackets closed out from under it.
+func heartbeatSilentFor(o *Observation, now time.Time, d time.Duration) bool {
+	if o == nil {
+		return false
+	}
+	if o.Claim != ClaimBusy {
+		// The agent said out loud that it is not busy. That is stronger than
+		// silence, so the bracket is stale immediately.
+		return true
+	}
+	return now.Sub(o.ObservedAt) > d
+}

--- a/internal/sessionstate/sessionstate_test.go
+++ b/internal/sessionstate/sessionstate_test.go
@@ -1,0 +1,371 @@
+package sessionstate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// now is the fixed clock every case resolves against. Ages are expressed as
+// offsets from it so a case reads as "this evidence, this old".
+var now = time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+
+func testPolicy() Policy {
+	return Policy{
+		HeartbeatTTL:  time.Second,
+		StaleAfter:    4 * time.Second,
+		StuckAfter:    90 * time.Second,
+		GuardianDwell: 60 * time.Second,
+	}
+}
+
+// seen builds an observation aged `age` before the fixed clock.
+func seen(source Source, claim Claim, age time.Duration) *Observation {
+	return &Observation{Source: source, Claim: claim, ObservedAt: now.Add(-age)}
+}
+
+func TestResolve(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		evidence   Evidence
+		wantState  protocol.SessionState
+		wantReason Reason
+	}{
+		// --- the two clauses that do not exist today ------------------------
+
+		{
+			// A lost turn-open hook used to leave the session idle for the whole
+			// turn. The agent is visibly running, so it is working.
+			name: "a fresh heartbeat works without any bracket",
+			evidence: Evidence{
+				Heartbeat: seen(SourceHeartbeat, ClaimBusy, 200*time.Millisecond),
+			},
+			wantState:  protocol.SessionStateWorking,
+			wantReason: ReasonHeartbeatFresh,
+		},
+		{
+			// A lost Stop hook used to hold the session working forever. Once the
+			// agent stops saying it is busy, the bracket has to give way.
+			name: "an open bracket goes stale when the heartbeat goes silent",
+			evidence: Evidence{
+				TurnOpen:  true,
+				Heartbeat: seen(SourceHeartbeat, ClaimBusy, 5*time.Second),
+			},
+			wantState:  protocol.SessionStateIdle,
+			wantReason: ReasonBracketStale,
+		},
+		{
+			// The stale bracket still asks the classifier how the turn ended
+			// rather than assuming it ended quietly.
+			name: "a stale bracket takes the classifier's verdict when there is one",
+			evidence: Evidence{
+				TurnOpen:       true,
+				Heartbeat:      seen(SourceHeartbeat, ClaimBusy, 5*time.Second),
+				LastClassifier: seen(SourceClassifier, ClaimNeedsInput, 2*time.Second),
+			},
+			wantState:  protocol.SessionStateWaitingInput,
+			wantReason: ReasonClassifierVerdict,
+		},
+		{
+			// The agent saying "not busy" is stronger than silence: there is no
+			// reason to wait out StaleAfter for a fact already reported.
+			name: "an explicit not-busy heartbeat makes the bracket stale immediately",
+			evidence: Evidence{
+				TurnOpen:  true,
+				Heartbeat: seen(SourceHeartbeat, ClaimSettled, 10*time.Millisecond),
+			},
+			wantState:  protocol.SessionStateIdle,
+			wantReason: ReasonBracketStale,
+		},
+		{
+			// An agent with no harness signals must not have its brackets closed
+			// out from under it — absent evidence is not evidence of absence.
+			name: "a bracket with no heartbeat at all stays open",
+			evidence: Evidence{
+				ToolOpen: true,
+			},
+			wantState:  protocol.SessionStateWorking,
+			wantReason: ReasonBracketOpen,
+		},
+		{
+			// Claude goes quiet for seconds inside a blocking tool call. Closing
+			// the bracket there would flicker every long tool to idle.
+			name: "a mid-tool heartbeat gap inside StaleAfter keeps the bracket open",
+			evidence: Evidence{
+				ToolOpen:  true,
+				Heartbeat: seen(SourceHeartbeat, ClaimBusy, 3500*time.Millisecond),
+			},
+			wantState:  protocol.SessionStateWorking,
+			wantReason: ReasonBracketOpen,
+		},
+
+		// --- ordering -------------------------------------------------------
+
+		{
+			// Nothing outranks a dead process. A session whose agent exited must
+			// not stay colored as alive on stale evidence.
+			name: "an exited process beats every live signal",
+			evidence: Evidence{
+				Process:          seen(SourceProcess, ClaimExited, time.Second),
+				Heartbeat:        seen(SourceHeartbeat, ClaimBusy, 10*time.Millisecond),
+				TurnOpen:         true,
+				LastHarnessEvent: seen(SourceHarnessEvent, ClaimApprovalPending, time.Second),
+			},
+			wantState:  protocol.SessionStateIdle,
+			wantReason: ReasonProcessExited,
+		},
+		{
+			// The agent cannot be blocked on the user while its turn is visibly
+			// running: the approval was answered and its closing edge was lost.
+			name: "a fresh heartbeat beats a stale approval edge",
+			evidence: Evidence{
+				Heartbeat:        seen(SourceHeartbeat, ClaimBusy, 100*time.Millisecond),
+				LastHarnessEvent: seen(SourceHarnessEvent, ClaimApprovalPending, 30*time.Second),
+			},
+			wantState:  protocol.SessionStateWorking,
+			wantReason: ReasonHeartbeatFresh,
+		},
+		{
+			// Once the heartbeat expires, the approval stands again.
+			name: "an approval survives an expired heartbeat",
+			evidence: Evidence{
+				Heartbeat:        seen(SourceHeartbeat, ClaimBusy, 3*time.Second),
+				LastHarnessEvent: seen(SourceHarnessEvent, ClaimApprovalPending, 2*time.Second),
+			},
+			wantState:  protocol.SessionStatePendingApproval,
+			wantReason: ReasonApprovalOpen,
+		},
+		{
+			// A reviewer does not suppress the state — it only changes how long
+			// the state must hold before anyone is told. See TestDwellFor.
+			name: "a reviewer in the loop does not hide an approval",
+			evidence: Evidence{
+				LastHarnessEvent: seen(SourceHarnessEvent, ClaimApprovalPending, time.Second),
+				ReviewerInLoop:   true,
+			},
+			wantState:  protocol.SessionStatePendingApproval,
+			wantReason: ReasonApprovalOpen,
+		},
+		{
+			// A pending wakeup resumes the session with nobody doing anything, so
+			// it is parked, not waiting on a person.
+			name: "a pending cron parks the session",
+			evidence: Evidence{
+				PendingCron:    true,
+				LastClassifier: seen(SourceClassifier, ClaimIdle, time.Second),
+			},
+			wantState:  protocol.SessionStateScheduled,
+			wantReason: ReasonCronPending,
+		},
+		{
+			// An outstanding background task auto-resumes the turn, so the
+			// session keeps working rather than flickering idle and back.
+			name: "background work keeps a yielded turn working",
+			evidence: Evidence{
+				BackgroundWork: true,
+				LastClassifier: seen(SourceClassifier, ClaimIdle, time.Second),
+			},
+			wantState:  protocol.SessionStateWorking,
+			wantReason: ReasonBackgroundWork,
+		},
+
+		// --- settled turns --------------------------------------------------
+
+		{
+			name: "the classifier settles a finished turn to idle",
+			evidence: Evidence{
+				LastClassifier: seen(SourceClassifier, ClaimIdle, time.Second),
+			},
+			wantState:  protocol.SessionStateIdle,
+			wantReason: ReasonClassifierVerdict,
+		},
+		{
+			name: "the classifier settles a question to waiting_input",
+			evidence: Evidence{
+				LastClassifier: seen(SourceClassifier, ClaimNeedsInput, time.Second),
+			},
+			wantState:  protocol.SessionStateWaitingInput,
+			wantReason: ReasonClassifierVerdict,
+		},
+
+		// --- screen (copilot only) ------------------------------------------
+
+		{
+			// Copilot has no harness signals, so the scrape is all there is —
+			// but it ranks below every source that does have one.
+			name: "the screen resolves when nothing better exists",
+			evidence: Evidence{
+				Screen: seen(SourceScreen, ClaimNeedsInput, time.Second),
+			},
+			wantState:  protocol.SessionStateWaitingInput,
+			wantReason: ReasonScreen,
+		},
+		{
+			// The scrape manufactures approvals from ordinary prose, which is why
+			// it must never outrank the harness's own account of itself.
+			name: "the classifier beats the screen",
+			evidence: Evidence{
+				Screen:         seen(SourceScreen, ClaimApprovalPending, 100*time.Millisecond),
+				LastClassifier: seen(SourceClassifier, ClaimIdle, time.Second),
+			},
+			wantState:  protocol.SessionStateIdle,
+			wantReason: ReasonClassifierVerdict,
+		},
+
+		// --- nothing to go on ------------------------------------------------
+
+		{
+			// The diagnosis that did not exist before: a session nothing has said
+			// anything about used to be indistinguishable from a quiet one.
+			name: "evidence that stopped moving is stuck",
+			evidence: Evidence{
+				LastMovement: now.Add(-91 * time.Second),
+			},
+			wantState:  protocol.SessionStateUnknown,
+			wantReason: ReasonStuck,
+		},
+		{
+			name: "recent silence is not yet stuck",
+			evidence: Evidence{
+				LastMovement: now.Add(-30 * time.Second),
+			},
+			wantState:  protocol.SessionStateUnknown,
+			wantReason: ReasonNoEvidence,
+		},
+		{
+			// A session nothing has ever reported on is not stuck — it has not
+			// had the chance to move.
+			name:       "an empty evidence table reports no evidence",
+			evidence:   Evidence{},
+			wantState:  protocol.SessionStateUnknown,
+			wantReason: ReasonNoEvidence,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Resolve(tc.evidence, testPolicy(), now)
+			if got.State != tc.wantState || got.Reason != tc.wantReason {
+				t.Fatalf("got %s/%s, want %s/%s", got.State, got.Reason, tc.wantState, tc.wantReason)
+			}
+		})
+	}
+}
+
+// The heartbeat's TTL is what decides whether a repaint gap reads as "still
+// running" or "stopped", so the boundary is the behavior, not an implementation
+// detail. Exactly at the TTL the observation is still believed.
+func TestHeartbeatFreshnessBoundary(t *testing.T) {
+	policy := testPolicy()
+	for _, tc := range []struct {
+		age  time.Duration
+		want protocol.SessionState
+	}{
+		{age: policy.HeartbeatTTL - time.Millisecond, want: protocol.SessionStateWorking},
+		{age: policy.HeartbeatTTL, want: protocol.SessionStateWorking},
+		{age: policy.HeartbeatTTL + time.Millisecond, want: protocol.SessionStateUnknown},
+	} {
+		e := Evidence{Heartbeat: seen(SourceHeartbeat, ClaimBusy, tc.age)}
+		if got := Resolve(e, policy, now); got.State != tc.want {
+			t.Fatalf("heartbeat aged %s resolved %s, want %s", tc.age, got.State, tc.want)
+		}
+	}
+}
+
+// Same for the stale window: a bracket holds until the silence passes it.
+func TestBracketStalenessBoundary(t *testing.T) {
+	policy := testPolicy()
+	for _, tc := range []struct {
+		age  time.Duration
+		want Reason
+	}{
+		{age: policy.StaleAfter, want: ReasonBracketOpen},
+		{age: policy.StaleAfter + time.Millisecond, want: ReasonBracketStale},
+	} {
+		e := Evidence{TurnOpen: true, Heartbeat: seen(SourceHeartbeat, ClaimBusy, tc.age)}
+		if got := Resolve(e, policy, now); got.Reason != tc.want {
+			t.Fatalf("bracket with %s of silence resolved %s, want %s", tc.age, got.Reason, tc.want)
+		}
+	}
+}
+
+// Resolve is pure: it must not depend on anything but its arguments, which is
+// what makes the tick safe to run as often as it likes.
+func TestResolveIsStableForTheSameInputs(t *testing.T) {
+	e := Evidence{
+		TurnOpen:       true,
+		Heartbeat:      seen(SourceHeartbeat, ClaimBusy, 2*time.Second),
+		LastClassifier: seen(SourceClassifier, ClaimIdle, time.Second),
+		LastMovement:   now.Add(-time.Second),
+	}
+	first := Resolve(e, testPolicy(), now)
+	for range 5 {
+		if got := Resolve(e, testPolicy(), now); got != first {
+			t.Fatalf("got %+v, want the same %+v", got, first)
+		}
+	}
+}
+
+// The winning observation's detail rides along so a diagnosis does not require
+// re-reading the evidence table.
+func TestResolutionCarriesTheWinningDetail(t *testing.T) {
+	e := Evidence{Heartbeat: &Observation{
+		Source:     SourceHeartbeat,
+		Claim:      ClaimBusy,
+		Detail:     "⠐ Run sleep command",
+		ObservedAt: now,
+	}}
+	if got := Resolve(e, testPolicy(), now); got.Detail != "⠐ Run sleep command" {
+		t.Fatalf("detail %q, want the heartbeat's title", got.Detail)
+	}
+}
+
+func TestDwellFor(t *testing.T) {
+	policy := testPolicy()
+
+	// With a guardian answering first, showing the user an approval immediately
+	// is the yellow flash on every tool call of an unattended run.
+	if got := DwellFor(protocol.SessionStatePendingApproval, Evidence{ReviewerInLoop: true}, policy); got != policy.GuardianDwell {
+		t.Fatalf("guardian dwell = %s, want %s", got, policy.GuardianDwell)
+	}
+	// With no guardian the user IS the reviewer: a genuine request must not be
+	// delayed at all.
+	if got := DwellFor(protocol.SessionStatePendingApproval, Evidence{}, policy); got != 0 {
+		t.Fatalf("unattended approval dwell = %s, want 0", got)
+	}
+	// The dwell is about approvals specifically, not about attention in general.
+	for _, state := range []protocol.SessionState{
+		protocol.SessionStateWaitingInput,
+		protocol.SessionStateWorking,
+		protocol.SessionStateIdle,
+	} {
+		if got := DwellFor(state, Evidence{ReviewerInLoop: true}, policy); got != 0 {
+			t.Fatalf("%s dwell = %s, want 0", state, got)
+		}
+	}
+}
+
+// The per-agent TTLs are measured, and getting them backwards would make codex
+// (which repaints ~10x faster) the one held working on a stale glyph.
+func TestPolicyForUsesTheMeasuredPerAgentTTL(t *testing.T) {
+	claude := PolicyFor(string(protocol.SessionAgentClaude))
+	codex := PolicyFor(string(protocol.SessionAgentCodex))
+
+	if claude.HeartbeatTTL <= codex.HeartbeatTTL {
+		t.Fatalf("claude TTL %s must exceed codex's %s: claude repaints ~1Hz, codex ~10Hz",
+			claude.HeartbeatTTL, codex.HeartbeatTTL)
+	}
+	// An unmeasured agent must not accidentally inherit the most permissive TTL.
+	if got := PolicyFor("copilot"); got.HeartbeatTTL > claude.HeartbeatTTL {
+		t.Fatalf("unknown agent TTL %s, want no more than claude's %s", got.HeartbeatTTL, claude.HeartbeatTTL)
+	}
+	for _, policy := range []Policy{claude, codex, PolicyFor("copilot")} {
+		if policy.StaleAfter <= 0 || policy.StuckAfter <= 0 || policy.GuardianDwell <= 0 {
+			t.Fatalf("policy has an unset window: %+v", policy)
+		}
+		// A stale window inside the TTL would close brackets the heartbeat still
+		// considers live, which is self-contradictory.
+		if policy.StaleAfter <= policy.HeartbeatTTL {
+			t.Fatalf("StaleAfter %s must exceed HeartbeatTTL %s", policy.StaleAfter, policy.HeartbeatTTL)
+		}
+	}
+}

--- a/internal/sessionstate/sessionstate_test.go
+++ b/internal/sessionstate/sessionstate_test.go
@@ -49,8 +49,9 @@ func TestResolve(t *testing.T) {
 			// agent stops saying it is busy, the bracket has to give way.
 			name: "an open bracket goes stale when the heartbeat goes silent",
 			evidence: Evidence{
-				TurnOpen:  true,
-				Heartbeat: seen(SourceHeartbeat, ClaimBusy, 5*time.Second),
+				TurnOpen:   true,
+				Heartbeat:  seen(SourceHeartbeat, ClaimBusy, 5*time.Second),
+				LastBusyAt: now.Add(-5 * time.Second),
 			},
 			wantState:  protocol.SessionStateIdle,
 			wantReason: ReasonBracketStale,
@@ -62,18 +63,46 @@ func TestResolve(t *testing.T) {
 			evidence: Evidence{
 				TurnOpen:       true,
 				Heartbeat:      seen(SourceHeartbeat, ClaimBusy, 5*time.Second),
+				LastBusyAt:     now.Add(-5 * time.Second),
 				LastClassifier: seen(SourceClassifier, ClaimNeedsInput, 2*time.Second),
 			},
 			wantState:  protocol.SessionStateWaitingInput,
 			wantReason: ReasonClassifierVerdict,
 		},
 		{
-			// The agent saying "not busy" is stronger than silence: there is no
-			// reason to wait out StaleAfter for a fact already reported.
-			name: "an explicit not-busy heartbeat makes the bracket stale immediately",
+			// Claude blips its idle glyph mid-turn — between tool calls, and while
+			// a foreground tool is still running. Closing the bracket on that one
+			// frame is the false-settle path the measurements ruled out, so
+			// staleness is measured from the last *busy* frame, not the latest one.
+			name: "a not-busy blip inside the window does not settle an open turn",
 			evidence: Evidence{
-				TurnOpen:  true,
-				Heartbeat: seen(SourceHeartbeat, ClaimSettled, 10*time.Millisecond),
+				TurnOpen:   true,
+				Heartbeat:  seen(SourceHeartbeat, ClaimSettled, 10*time.Millisecond),
+				LastBusyAt: now.Add(-500 * time.Millisecond),
+			},
+			wantState:  protocol.SessionStateWorking,
+			wantReason: ReasonBracketOpen,
+		},
+		{
+			// And the turn survives the blip being followed by more busy frames,
+			// which is what a real mid-turn gap looks like.
+			name: "busy resuming after a blip keeps the turn working",
+			evidence: Evidence{
+				TurnOpen:   true,
+				Heartbeat:  seen(SourceHeartbeat, ClaimBusy, 50*time.Millisecond),
+				LastBusyAt: now.Add(-50 * time.Millisecond),
+			},
+			wantState:  protocol.SessionStateWorking,
+			wantReason: ReasonHeartbeatFresh,
+		},
+		{
+			// Only a full window with no busy frame at all settles it, however
+			// recently the agent said it was idle.
+			name: "a not-busy level past the window settles the turn",
+			evidence: Evidence{
+				TurnOpen:   true,
+				Heartbeat:  seen(SourceHeartbeat, ClaimSettled, 10*time.Millisecond),
+				LastBusyAt: now.Add(-5 * time.Second),
 			},
 			wantState:  protocol.SessionStateIdle,
 			wantReason: ReasonBracketStale,
@@ -93,8 +122,9 @@ func TestResolve(t *testing.T) {
 			// the bracket there would flicker every long tool to idle.
 			name: "a mid-tool heartbeat gap inside StaleAfter keeps the bracket open",
 			evidence: Evidence{
-				ToolOpen:  true,
-				Heartbeat: seen(SourceHeartbeat, ClaimBusy, 3500*time.Millisecond),
+				ToolOpen:   true,
+				Heartbeat:  seen(SourceHeartbeat, ClaimBusy, 3500*time.Millisecond),
+				LastBusyAt: now.Add(-3500 * time.Millisecond),
 			},
 			wantState:  protocol.SessionStateWorking,
 			wantReason: ReasonBracketOpen,
@@ -281,7 +311,7 @@ func TestBracketStalenessBoundary(t *testing.T) {
 		{age: policy.StaleAfter, want: ReasonBracketOpen},
 		{age: policy.StaleAfter + time.Millisecond, want: ReasonBracketStale},
 	} {
-		e := Evidence{TurnOpen: true, Heartbeat: seen(SourceHeartbeat, ClaimBusy, tc.age)}
+		e := Evidence{TurnOpen: true, Heartbeat: seen(SourceHeartbeat, ClaimBusy, tc.age), LastBusyAt: now.Add(-tc.age)}
 		if got := Resolve(e, policy, now); got.Reason != tc.want {
 			t.Fatalf("bracket with %s of silence resolved %s, want %s", tc.age, got.Reason, tc.want)
 		}
@@ -294,6 +324,7 @@ func TestResolveIsStableForTheSameInputs(t *testing.T) {
 	e := Evidence{
 		TurnOpen:       true,
 		Heartbeat:      seen(SourceHeartbeat, ClaimBusy, 2*time.Second),
+		LastBusyAt:     now.Add(-2 * time.Second),
 		LastClassifier: seen(SourceClassifier, ClaimIdle, time.Second),
 		LastMovement:   now.Add(-time.Second),
 	}


### PR DESCRIPTION
Phase 2a of the agent state detection plan
([docs/plans/2026-07-25-agent-state-detection.md](docs/plans/2026-07-25-agent-state-detection.md)).
Stacked on #670. The decision rules only — nothing calls them yet, so they land
reviewable on their own before the daemon's evidence table and tick arrive.

## Why a resolver at all

attn's session state is decided by whoever wrote last. Hooks, the screen
scraper, the stop classifier and the worker poll each call `applyState` directly
with a state name, so a session gets stuck whenever the source that would have
moved it on never fires. There is no arbitration to fix — there is no
arbitration.

## The two clauses that carry the fix

Neither has an equivalent today:

- **A fresh heartbeat resolves to working regardless of the brackets.** This
  rescues a lost turn-open hook, which used to leave a running agent showing
  idle for the whole turn.
- **An open bracket goes stale once the heartbeat has been silent past
  `StaleAfter`.** This closes a bracket whose closing hook never arrived — the
  case that used to hold a session working for the rest of its life.

The structural property matters more than either clause: every rule that can
hold a session in a state now depends on evidence that either refreshes or ages
out, and the tick re-runs the decision. No state can outlive its evidence.

## Ordering encodes trust, not recency

- An exited process outranks everything. Stale evidence must not keep a dead
  session colored as alive.
- A fresh heartbeat outranks an open approval. The agent cannot be blocked on
  the user while its turn is visibly running, so that combination means the
  approval was answered and its closing edge was lost.
- The screen scrape ranks below every source that reads the harness's own
  account of itself. It manufactures approvals from ordinary prose, which is why
  the plan deletes it for claude and codex rather than demoting it to a
  tiebreaker.

## Dwell

`DwellFor` is keyed on who is being asked first. With a guardian in the loop
(claude's permission classifier, codex's `auto_review`) an approval must hold
before it is published, which removes the flash of attention-demanding color on
every tool call of an unattended run. With no guardian the user *is* the
reviewer and the dwell is zero — a genuine request is not delayed by a
millisecond.

## Timing is an argument

`Policy` is passed in rather than read from package constants, so each table
case states the window it is testing instead of inheriting it. `PolicyFor` holds
the measured per-agent defaults: claude repaints its title about once a second
and goes quiet for up to ~3.5s inside a blocking foreground tool call; codex
repaints about ten times a second and never goes quiet mid-turn.

## Deliberately not included

The plan's `Resolution.Unsettles` projection. Nothing consumes it until the
attention mode exists, and shipping an unconsumed field is the same mistake as
the OSC 777 reader deleted in #669.

## Tests

Table tests over every clause and every ordering pair above, plus both timing
boundaries (a heartbeat exactly at its TTL is still believed; a bracket exactly
at `StaleAfter` still holds), purity, and a consistency check on `PolicyFor`
that fails if `StaleAfter` ever falls inside `HeartbeatTTL` — a window that
would close brackets the heartbeat still considers live.

Both load-bearing clauses were mutation-checked: disabling the heartbeat-fresh
clause and making brackets never go stale each turn their own cases red, and
nothing else's.

## Verification tier

No live verification: this is a pure package with no callers, no daemon
lifecycle, protocol, PTY, or UI surface, fully covered by unit tests. The tier
the plan's remaining phases need arrives with the daemon wiring, where the rules
first affect a running session.
