### PR TITLE
feat(state): resolve session state from an evidence table, in shadow mode

### DIFF
--- a/docs/plans/2026-07-25-agent-state-detection.md
+++ b/docs/plans/2026-07-25-agent-state-detection.md
@@ -596,7 +596,7 @@ being fixed as part of the current step.
       `applyState` entirely — their claims are "busy"/"not_busy", not protocol
       state names — and past the worker/backend state dedup, which would
       otherwise swallow a repeated level.
-- [ ] Feed the hook signals into the ring the same way (phase 1b), then compare
+- [x] Feed the hook signals into the ring the same way (phase 1b), then compare
       traces against the baseline.
 
 ### Phase 2 — resolver
@@ -614,8 +614,14 @@ being fixed as part of the current step.
       returning a `classifyDecision`; the shell performs the IO between them and
       owns the single store write. Six `applyState` exits collapsed to one. Folding
       these rules into `Resolve` itself is Phase 2 work — this makes them movable.
-- [ ] Daemon evidence table + 1s tick; route live signals through the resolver
-      into `applyState` with a new `resolverObservation` cause.
+- [x] **Phase 2b (PR #672), shadow half.** Daemon evidence table + 1s tick.
+      Every existing source is teed into the table alongside its current path,
+      the tick re-resolves each session, and the resolution is recorded in the
+      trace *only when it disagrees* with the stored state. No `applyState` call
+      — the flip is deliberately separate so the resolver can be witnessed
+      agreeing first.
+- [ ] **Phase 2c**, the flip: route live signals through the resolver into
+      `applyState` with a new `resolverObservation` cause.
 - [ ] Gate `internal/pty/state_detector.go` to copilot only; delete the keyword
       lists and `approval_resolver.go`'s screen-absence debounce for claude/codex.
 - [ ] Delete `ShouldApplyPTYState` and all three driver implementations — the
@@ -698,6 +704,19 @@ placeholder only; do not implement against it.
   whenever it was consulted. Copilot keeps it until it has harness signals.
 
 ## Open questions
+
+- **A stale bracket with no classifier verdict settles to `idle`, and the
+  classifier may then say `waiting_input`.** Found in phase 2b's shadow run: the
+  agent said not-busy at 18:33:44.418 and the resolver reached `idle` about a
+  second later via `bracket_stale`, while the store stayed `working` until the
+  classifier landed ~8s after that. Settling fast is the improvement — it is the
+  whole point of the stale clause — but on a turn that ended in a question, the
+  flip would show `idle` for those 8s and then correct to `waiting_input`. That
+  is a flicker where today there is a delay. Options for phase 2c: hold the
+  pre-settle state until the verdict arrives, publish `idle` immediately and
+  accept the correction, or gate on whether a classification is in flight. Needs
+  a decision before the flip, and the shadow traces can measure how often the
+  verdict is `waiting_input` at all.
 
 - ~~Does Claude emit OSC 777 for permission prompts, or only for turn settle?~~
   Answered while implementing phase 1a: it emits no OSC 777 at all. The

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -206,6 +206,9 @@ type Daemon struct {
 	// traces without an init site.
 	stateTraceOnce             sync.Once
 	stateTrace                 *statetrace.Recorder
+	// sessionEvidence is the per-session evidence table the resolver reads.
+	sessionEvidenceOnce sync.Once
+	sessionEvidence     *sessionEvidenceTable
 	nudgeMu                    sync.Mutex
 	nudgeCountdowns            map[string]*nudgeCountdown                 // presence == a running (unpaused) countdown
 	unreadCache                map[string]bool                            // per-session unread ticket activity, for cheap broadcast decoration
@@ -936,6 +939,7 @@ func (d *Daemon) Start() error {
 	// piggybacking the schedule-observation tick — that tick's cadence is
 	// driven by cron granularity, not retention policy.
 	go d.runAutomationRetentionSweep()
+	go d.runEvidenceResolveLoop()
 
 	// Ticket TTL sweep: hard-deletes terminal tickets past their retention
 	// window. This is also what actually bounds a bound continuity thread's
@@ -1590,6 +1594,7 @@ func (d *Daemon) handlePTYExit(info ptybackend.ExitInfo) {
 		}
 	}
 
+	d.recordProcessEvidence(info.ID, true)
 	if session := d.store.Get(info.ID); session != nil {
 		// Reconcile bound tickets against the pre-clobber state: the idle-clobber
 		// just below erases whether the agent was mid-flight (a crash or kill) or at
@@ -1755,6 +1760,7 @@ func (d *Daemon) dropSessionRecord(sessionID string) {
 	// so forgetting first would leave a window where a concurrent observation
 	// rebuilds the ring for an id nothing will ever clean up again.
 	d.forgetStateTrace(sessionID)
+	d.evidenceTable().forget(sessionID)
 }
 
 // handlePTYState applies one PTY-layer observation. It is still last-writer-wins
@@ -1763,6 +1769,7 @@ func (d *Daemon) dropSessionRecord(sessionID string) {
 func (d *Daemon) handlePTYState(sessionID string, obs pty.Observation) {
 	state := obs.Claim
 	origin := stateOrigin{source: string(obs.Source), detail: obs.Detail, observedAt: obs.At}
+	d.recordPTYEvidence(sessionID, obs)
 	// The harness signals are wired ahead of the resolver that will weigh them, so
 	// their traces can be compared against the current behavior before anything
 	// arbitrates on them. They are recorded and go no further; their claims are in
@@ -2386,6 +2393,8 @@ func (d *Daemon) handleUnregister(conn net.Conn, msg *protocol.UnregisterMessage
 func (d *Daemon) handleState(conn net.Conn, msg *protocol.StateMessage) {
 	d.logf("state update: id=%s state=%s", msg.ID, msg.State)
 	d.tracePermissionMode(msg.ID, protocol.Deref(msg.PermissionMode))
+	d.recordReviewerEvidence(msg.ID, protocol.Deref(msg.PermissionMode))
+	d.recordBracketEvidence(msg.ID, msg.State)
 	d.applyState(sessionStateChange{
 		sessionID: msg.ID,
 		state:     msg.State,
@@ -2453,6 +2462,7 @@ func (d *Daemon) handleStop(conn net.Conn, msg *protocol.StopMessage) {
 	// A non-terminal stop is a yield, not an end: hold the session in the state the
 	// facts imply and do none of the end-of-turn work below (no resume-id capture,
 	// no narration enqueue, no classification). The turn resumes on its own.
+	d.recordStopFacts(msg.ID, len(msg.BackgroundTaskStatuses) > 0, protocol.Deref(msg.PendingSessionCrons) > 0)
 	if state := nonTerminalStopState(msg, d.isChiefOfStaffSession(msg.ID)); state != "" {
 		d.logf(
 			"handleStop: non-terminal stop session=%s state=%s background_tasks=%d pending_crons=%d",
@@ -2588,6 +2598,7 @@ func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
 			return
 		}
 		d.logf("classifySessionState: session=%s state=%s reason=%s", sessionID, decision.state, decision.reason)
+		d.recordClassifierEvidence(sessionID, decision.state, classificationStartTime)
 		d.applyState(sessionStateChange{
 			sessionID: sessionID,
 			state:     decision.state,

--- a/internal/daemon/session_evidence.go
+++ b/internal/daemon/session_evidence.go
@@ -1,0 +1,306 @@
+package daemon
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/pty"
+	"github.com/victorarias/attn/internal/sessionstate"
+	"github.com/victorarias/attn/internal/statetrace"
+)
+
+// The evidence table: what each source has said about a session, kept so the
+// resolver can weigh them instead of the last writer winning.
+//
+// This is shadow mode. The table is filled and resolved on a tick, and the
+// resolution is recorded in the state trace — it does not reach applyState. The
+// point is to have a live witness that the resolver agrees with the current
+// behavior (and a record of exactly where it does not) before it takes over.
+// The flip is a separate change.
+
+// evidenceTickInterval is how often every session's evidence is re-resolved.
+// The tick is what makes evidence expire: without it a resolution would only be
+// recomputed when a source spoke, which is precisely the case that fails when a
+// source stops speaking.
+const evidenceTickInterval = time.Second
+
+// sessionEvidenceTable holds one evidence record per live session.
+type sessionEvidenceTable struct {
+	mu       sync.Mutex
+	sessions map[string]*sessionstate.Evidence
+}
+
+func newSessionEvidenceTable() *sessionEvidenceTable {
+	return &sessionEvidenceTable{sessions: make(map[string]*sessionstate.Evidence)}
+}
+
+// update mutates one session's evidence under the table's lock, creating the
+// record on first use. It stamps LastMovement, so stuck detection cannot drift
+// out of sync with the writes it is supposed to be watching.
+func (t *sessionEvidenceTable) update(sessionID string, at time.Time, mutate func(*sessionstate.Evidence)) {
+	if t == nil || strings.TrimSpace(sessionID) == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	evidence := t.sessions[sessionID]
+	if evidence == nil {
+		evidence = &sessionstate.Evidence{}
+		t.sessions[sessionID] = evidence
+	}
+	mutate(evidence)
+	evidence.LastMovement = at
+}
+
+// snapshot returns a copy of one session's evidence, or false when nothing has
+// been recorded for it. The copy matters: the resolver must not read a table
+// that is being mutated underneath it.
+func (t *sessionEvidenceTable) snapshot(sessionID string) (sessionstate.Evidence, bool) {
+	if t == nil {
+		return sessionstate.Evidence{}, false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	evidence := t.sessions[sessionID]
+	if evidence == nil {
+		return sessionstate.Evidence{}, false
+	}
+	return *evidence, true
+}
+
+func (t *sessionEvidenceTable) sessionIDs() []string {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	ids := make([]string, 0, len(t.sessions))
+	for id := range t.sessions {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func (t *sessionEvidenceTable) forget(sessionID string) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.sessions, sessionID)
+}
+
+func (d *Daemon) evidenceTable() *sessionEvidenceTable {
+	d.sessionEvidenceOnce.Do(func() {
+		d.sessionEvidence = newSessionEvidenceTable()
+	})
+	return d.sessionEvidence
+}
+
+// recordPTYEvidence files an observation from the PTY layer. Sources that only
+// report a level (the heartbeat) and sources that report an edge (approval) land
+// in different fields, because the resolver ages them differently.
+func (d *Daemon) recordPTYEvidence(sessionID string, obs pty.Observation) {
+	at := obs.At
+	if at.IsZero() {
+		at = time.Now()
+	}
+	switch obs.Source {
+	case pty.SourceHeartbeat:
+		claim := sessionstate.ClaimSettled
+		if obs.Claim == "busy" {
+			claim = sessionstate.ClaimBusy
+		}
+		d.evidenceTable().update(sessionID, at, func(e *sessionstate.Evidence) {
+			e.Heartbeat = &sessionstate.Observation{
+				Source:     sessionstate.SourceHeartbeat,
+				Claim:      claim,
+				Detail:     obs.Detail,
+				ObservedAt: at,
+			}
+			// LastBusyAt only advances on a busy frame: staleness is measured
+			// from the last time the turn was seen running, not from the last
+			// time the agent said anything. A non-busy frame mid-turn is a blip,
+			// not a settle.
+			if claim == sessionstate.ClaimBusy {
+				e.LastBusyAt = at
+			}
+		})
+	case pty.SourceApproval:
+		d.evidenceTable().update(sessionID, at, func(e *sessionstate.Evidence) {
+			e.LastHarnessEvent = &sessionstate.Observation{
+				Source:     sessionstate.SourceHarnessEvent,
+				Claim:      approvalClaim(obs.Claim),
+				Detail:     obs.Detail,
+				ObservedAt: at,
+			}
+		})
+	case pty.SourceScreen:
+		d.evidenceTable().update(sessionID, at, func(e *sessionstate.Evidence) {
+			e.Screen = &sessionstate.Observation{
+				Source:     sessionstate.SourceScreen,
+				Claim:      stateClaim(obs.Claim),
+				Detail:     obs.Detail,
+				ObservedAt: at,
+			}
+		})
+	}
+}
+
+// recordBracketEvidence files a hook opening or closing a turn. The brackets are
+// the primary level: they are the only signal that survives the multi-second
+// title silence claude produces inside a blocking tool call.
+func (d *Daemon) recordBracketEvidence(sessionID, state string) {
+	at := time.Now()
+	d.evidenceTable().update(sessionID, at, func(e *sessionstate.Evidence) {
+		switch state {
+		case protocol.StateWorking:
+			e.TurnOpen = true
+		case protocol.StateIdle, protocol.StateWaitingInput:
+			e.TurnOpen = false
+			e.ToolOpen = false
+		case protocol.StatePendingApproval:
+			e.LastHarnessEvent = &sessionstate.Observation{
+				Source:     sessionstate.SourceHarnessEvent,
+				Claim:      sessionstate.ClaimApprovalPending,
+				ObservedAt: at,
+			}
+		}
+	})
+}
+
+// recordClassifierEvidence files a stop-time verdict.
+func (d *Daemon) recordClassifierEvidence(sessionID, state string, observedAt time.Time) {
+	if observedAt.IsZero() {
+		observedAt = time.Now()
+	}
+	claim := stateClaim(state)
+	if claim == "" {
+		return
+	}
+	d.evidenceTable().update(sessionID, observedAt, func(e *sessionstate.Evidence) {
+		e.LastClassifier = &sessionstate.Observation{
+			Source:     sessionstate.SourceClassifier,
+			Claim:      claim,
+			ObservedAt: observedAt,
+		}
+	})
+}
+
+// recordStopFacts files what the Stop hook reported about why a turn yielded.
+// These are the facts the CLI used to collapse into a state string before they
+// crossed the socket, which is why the resolver could not see them.
+func (d *Daemon) recordStopFacts(sessionID string, backgroundWork, pendingCron bool) {
+	d.evidenceTable().update(sessionID, time.Now(), func(e *sessionstate.Evidence) {
+		e.BackgroundWork = backgroundWork
+		e.PendingCron = pendingCron
+	})
+}
+
+// recordReviewerEvidence files who answers approval requests. It is a level, not
+// an edge: it holds until the agent reports a different mode.
+func (d *Daemon) recordReviewerEvidence(sessionID, permissionMode string) {
+	mode := strings.TrimSpace(permissionMode)
+	if mode == "" {
+		return
+	}
+	inLoop := mode != "default"
+	d.evidenceTable().update(sessionID, time.Now(), func(e *sessionstate.Evidence) {
+		e.ReviewerInLoop = inLoop
+	})
+}
+
+// recordProcessEvidence files the PTY lifecycle. An exited process is terminal
+// and outranks every other clause.
+func (d *Daemon) recordProcessEvidence(sessionID string, exited bool) {
+	if !exited {
+		return
+	}
+	at := time.Now()
+	d.evidenceTable().update(sessionID, at, func(e *sessionstate.Evidence) {
+		e.Process = &sessionstate.Observation{
+			Source:     sessionstate.SourceProcess,
+			Claim:      sessionstate.ClaimExited,
+			ObservedAt: at,
+		}
+	})
+}
+
+// runEvidenceResolveLoop re-resolves every session on a tick and records what
+// the resolver would have said. Shadow mode: nothing here writes state.
+func (d *Daemon) runEvidenceResolveLoop() {
+	ticker := time.NewTicker(evidenceTickInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-d.done:
+			return
+		case <-ticker.C:
+			d.resolveAllSessions(time.Now())
+		}
+	}
+}
+
+func (d *Daemon) resolveAllSessions(now time.Time) {
+	for _, sessionID := range d.evidenceTable().sessionIDs() {
+		session := d.store.Get(sessionID)
+		if session == nil {
+			// The session is gone; so is any reason to keep resolving it.
+			d.evidenceTable().forget(sessionID)
+			continue
+		}
+		evidence, ok := d.evidenceTable().snapshot(sessionID)
+		if !ok {
+			continue
+		}
+		resolution := sessionstate.Resolve(evidence, sessionstate.PolicyFor(string(session.Agent)), now)
+		d.traceResolution(sessionID, session.State, resolution)
+	}
+}
+
+// traceResolution records the resolver's verdict and how it compares to the
+// state the session is actually in. Only a disagreement is worth a row: a tick
+// that agrees every second would bury everything else in the ring.
+func (d *Daemon) traceResolution(sessionID string, current protocol.SessionState, resolution sessionstate.Resolution) {
+	if resolution.State == current {
+		return
+	}
+	d.recordStateObservation(sessionID, statetrace.Observation{
+		Source:  stateSourceResolver,
+		Claim:   string(resolution.State),
+		Detail:  resolution.Detail,
+		Outcome: statetrace.OutcomeObserved,
+		Reason:  string(resolution.Reason),
+	})
+}
+
+// approvalClaim reads the approval resolver's vocabulary. It reports the state
+// it wants rather than an approval-specific claim, so an approval that cleared
+// arrives as some other state entirely.
+func approvalClaim(claim string) sessionstate.Claim {
+	if claim == protocol.StatePendingApproval {
+		return sessionstate.ClaimApprovalPending
+	}
+	return sessionstate.ClaimSettled
+}
+
+// stateClaim maps a protocol state name onto what the source actually observed.
+// Sources that speak in state names are the ones this plan is unwinding; until
+// they are converted, the translation lives here rather than being spread across
+// every call site.
+func stateClaim(state string) sessionstate.Claim {
+	switch state {
+	case protocol.StateWorking:
+		return sessionstate.ClaimBusy
+	case protocol.StateWaitingInput:
+		return sessionstate.ClaimNeedsInput
+	case protocol.StateIdle:
+		return sessionstate.ClaimIdle
+	case protocol.StatePendingApproval:
+		return sessionstate.ClaimApprovalPending
+	default:
+		return ""
+	}
+}

--- a/internal/daemon/session_evidence.go
+++ b/internal/daemon/session_evidence.go
@@ -36,15 +36,27 @@ func newSessionEvidenceTable() *sessionEvidenceTable {
 	return &sessionEvidenceTable{sessions: make(map[string]*sessionstate.Evidence)}
 }
 
-// update mutates one session's evidence under the table's lock, creating the
-// record on first use. It stamps LastMovement, so stuck detection cannot drift
-// out of sync with the writes it is supposed to be watching.
-func (t *sessionEvidenceTable) update(sessionID string, at time.Time, mutate func(*sessionstate.Evidence)) {
+// updateIf mutates one session's evidence, creating the record on first use, but
+// only when admit says the session is live. It stamps LastMovement, so stuck
+// detection cannot drift out of sync with the writes it is watching.
+//
+// admit runs while holding the table's lock, which is the whole point: the
+// caller's liveness check and the write have to be one atomic step. Removal
+// deletes the store row and then forgets the table, so with admission inside the
+// lock the two possible interleavings are "the writer wins and its entry is then
+// forgotten" and "removal wins and the writer is refused". Checking liveness
+// outside the lock leaves a third: the writer passes the check, removal deletes
+// and forgets, and the writer then recreates an entry for an id nothing will
+// ever clean up again. That is the leak #668 fixed in the trace ring.
+func (t *sessionEvidenceTable) updateIf(sessionID string, at time.Time, admit func() bool, mutate func(*sessionstate.Evidence)) {
 	if t == nil || strings.TrimSpace(sessionID) == "" {
 		return
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if admit != nil && !admit() {
+		return
+	}
 	evidence := t.sessions[sessionID]
 	if evidence == nil {
 		evidence = &sessionstate.Evidence{}
@@ -92,6 +104,25 @@ func (t *sessionEvidenceTable) forget(sessionID string) {
 	delete(t.sessions, sessionID)
 }
 
+// evidenceRecordGateHook runs inside the evidence table's lock, between the
+// live-row check and the write. Tests only: it is the seam where a concurrent
+// removal would have to interleave for an orphan entry to appear.
+var evidenceRecordGateHook func(sessionID string)
+
+// recordEvidence is the single write path into the evidence table. Every source
+// goes through it so the liveness gate cannot be forgotten at one call site.
+func (d *Daemon) recordEvidence(sessionID string, at time.Time, mutate func(*sessionstate.Evidence)) {
+	d.evidenceTable().updateIf(sessionID, at, func() bool {
+		live := d.store != nil && d.store.Get(sessionID) != nil
+		// The hook runs after the check on purpose: check-then-write is the
+		// sequence that leaks when the two are not atomic.
+		if hook := evidenceRecordGateHook; hook != nil {
+			hook(sessionID)
+		}
+		return live
+	}, mutate)
+}
+
 func (d *Daemon) evidenceTable() *sessionEvidenceTable {
 	d.sessionEvidenceOnce.Do(func() {
 		d.sessionEvidence = newSessionEvidenceTable()
@@ -113,7 +144,7 @@ func (d *Daemon) recordPTYEvidence(sessionID string, obs pty.Observation) {
 		if obs.Claim == "busy" {
 			claim = sessionstate.ClaimBusy
 		}
-		d.evidenceTable().update(sessionID, at, func(e *sessionstate.Evidence) {
+		d.recordEvidence(sessionID, at, func(e *sessionstate.Evidence) {
 			e.Heartbeat = &sessionstate.Observation{
 				Source:     sessionstate.SourceHeartbeat,
 				Claim:      claim,
@@ -129,7 +160,7 @@ func (d *Daemon) recordPTYEvidence(sessionID string, obs pty.Observation) {
 			}
 		})
 	case pty.SourceApproval:
-		d.evidenceTable().update(sessionID, at, func(e *sessionstate.Evidence) {
+		d.recordEvidence(sessionID, at, func(e *sessionstate.Evidence) {
 			e.LastHarnessEvent = &sessionstate.Observation{
 				Source:     sessionstate.SourceHarnessEvent,
 				Claim:      approvalClaim(obs.Claim),
@@ -138,7 +169,7 @@ func (d *Daemon) recordPTYEvidence(sessionID string, obs pty.Observation) {
 			}
 		})
 	case pty.SourceScreen:
-		d.evidenceTable().update(sessionID, at, func(e *sessionstate.Evidence) {
+		d.recordEvidence(sessionID, at, func(e *sessionstate.Evidence) {
 			e.Screen = &sessionstate.Observation{
 				Source:     sessionstate.SourceScreen,
 				Claim:      stateClaim(obs.Claim),
@@ -154,7 +185,7 @@ func (d *Daemon) recordPTYEvidence(sessionID string, obs pty.Observation) {
 // title silence claude produces inside a blocking tool call.
 func (d *Daemon) recordBracketEvidence(sessionID, state string) {
 	at := time.Now()
-	d.evidenceTable().update(sessionID, at, func(e *sessionstate.Evidence) {
+	d.recordEvidence(sessionID, at, func(e *sessionstate.Evidence) {
 		switch state {
 		case protocol.StateWorking:
 			e.TurnOpen = true
@@ -180,7 +211,7 @@ func (d *Daemon) recordClassifierEvidence(sessionID, state string, observedAt ti
 	if claim == "" {
 		return
 	}
-	d.evidenceTable().update(sessionID, observedAt, func(e *sessionstate.Evidence) {
+	d.recordEvidence(sessionID, observedAt, func(e *sessionstate.Evidence) {
 		e.LastClassifier = &sessionstate.Observation{
 			Source:     sessionstate.SourceClassifier,
 			Claim:      claim,
@@ -193,7 +224,7 @@ func (d *Daemon) recordClassifierEvidence(sessionID, state string, observedAt ti
 // These are the facts the CLI used to collapse into a state string before they
 // crossed the socket, which is why the resolver could not see them.
 func (d *Daemon) recordStopFacts(sessionID string, backgroundWork, pendingCron bool) {
-	d.evidenceTable().update(sessionID, time.Now(), func(e *sessionstate.Evidence) {
+	d.recordEvidence(sessionID, time.Now(), func(e *sessionstate.Evidence) {
 		e.BackgroundWork = backgroundWork
 		e.PendingCron = pendingCron
 	})
@@ -207,7 +238,7 @@ func (d *Daemon) recordReviewerEvidence(sessionID, permissionMode string) {
 		return
 	}
 	inLoop := mode != "default"
-	d.evidenceTable().update(sessionID, time.Now(), func(e *sessionstate.Evidence) {
+	d.recordEvidence(sessionID, time.Now(), func(e *sessionstate.Evidence) {
 		e.ReviewerInLoop = inLoop
 	})
 }
@@ -219,7 +250,7 @@ func (d *Daemon) recordProcessEvidence(sessionID string, exited bool) {
 		return
 	}
 	at := time.Now()
-	d.evidenceTable().update(sessionID, at, func(e *sessionstate.Evidence) {
+	d.recordEvidence(sessionID, at, func(e *sessionstate.Evidence) {
 		e.Process = &sessionstate.Observation{
 			Source:     sessionstate.SourceProcess,
 			Claim:      sessionstate.ClaimExited,

--- a/internal/daemon/session_evidence_test.go
+++ b/internal/daemon/session_evidence_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ func evidenceOf(t *testing.T, d *Daemon, sessionID string) sessionstate.Evidence
 func TestHeartbeatEvidenceKeepsItsObservationTime(t *testing.T) {
 	d := newTraceDaemon(t)
 	id := "sess-hb-evidence"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
 	observed := time.Now().Add(-300 * time.Millisecond)
 
 	d.recordPTYEvidence(id, pty.Observation{
@@ -49,6 +51,7 @@ func TestHeartbeatEvidenceKeepsItsObservationTime(t *testing.T) {
 func TestNotBusyHeartbeatEvidenceIsSettled(t *testing.T) {
 	d := newTraceDaemon(t)
 	id := "sess-hb-settled"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
 
 	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "not_busy", At: time.Now()})
 
@@ -62,6 +65,7 @@ func TestNotBusyHeartbeatEvidenceIsSettled(t *testing.T) {
 func TestBracketEvidenceOpensAndCloses(t *testing.T) {
 	d := newTraceDaemon(t)
 	id := "sess-bracket"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
 
 	d.recordBracketEvidence(id, protocol.StateWorking)
 	if !evidenceOf(t, d, id).TurnOpen {
@@ -81,6 +85,7 @@ func TestBracketEvidenceOpensAndCloses(t *testing.T) {
 func TestStopFactsBecomeEvidence(t *testing.T) {
 	d := newTraceDaemon(t)
 	id := "sess-stop-facts"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
 
 	d.recordStopFacts(id, true, false)
 	if got := evidenceOf(t, d, id); !got.BackgroundWork || got.PendingCron {
@@ -108,6 +113,7 @@ func TestReviewerEvidenceReadsThePermissionMode(t *testing.T) {
 	} {
 		d := newTraceDaemon(t)
 		id := "sess-reviewer-" + tc.mode
+		addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
 		d.recordReviewerEvidence(id, tc.mode)
 		if got := evidenceOf(t, d, id).ReviewerInLoop; got != tc.want {
 			t.Fatalf("mode %q -> ReviewerInLoop %v, want %v", tc.mode, got, tc.want)
@@ -120,6 +126,7 @@ func TestReviewerEvidenceReadsThePermissionMode(t *testing.T) {
 // every codex session.
 func TestAnAbsentPermissionModeRecordsNothing(t *testing.T) {
 	d := newTraceDaemon(t)
+	addCharacterizationSession(t, d, "sess-no-mode", protocol.SessionAgentClaude, protocol.SessionStateWorking)
 	d.recordReviewerEvidence("sess-no-mode", "  ")
 	if _, ok := d.evidenceTable().snapshot("sess-no-mode"); ok {
 		t.Fatal("an absent mode created an evidence record")
@@ -131,6 +138,7 @@ func TestAnAbsentPermissionModeRecordsNothing(t *testing.T) {
 func TestEveryEvidenceWriteStampsMovement(t *testing.T) {
 	d := newTraceDaemon(t)
 	id := "sess-movement"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
 
 	d.recordBracketEvidence(id, protocol.StateWorking)
 	first := evidenceOf(t, d, id).LastMovement
@@ -220,6 +228,7 @@ func TestTheResolveTickForgetsARemovedSession(t *testing.T) {
 func TestOnlyABusyHeartbeatAdvancesLastBusy(t *testing.T) {
 	d := newTraceDaemon(t)
 	id := "sess-lastbusy"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
 
 	busy := time.Now().Add(-2 * time.Second)
 	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", At: busy})
@@ -236,5 +245,81 @@ func TestOnlyABusyHeartbeatAdvancesLastBusy(t *testing.T) {
 	// heartbeat-fresh clause reads.
 	if got.Heartbeat.Claim != sessionstate.ClaimSettled {
 		t.Fatalf("latest heartbeat %+v, want the settled frame", got.Heartbeat)
+	}
+}
+
+// An id with no store row can never be read back — the tick resolves against a
+// store row — and can never be cleaned up, because cleanup hangs off session
+// removal. Ringing one would leak an entry per stale id for the daemon's life.
+func TestEvidenceIsNotRecordedForAnUnknownSession(t *testing.T) {
+	d := newTraceDaemon(t)
+
+	d.recordPTYEvidence("ghost", pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", At: time.Now()})
+	d.recordBracketEvidence("ghost", protocol.StateWorking)
+	d.recordStopFacts("ghost", true, false)
+	d.recordReviewerEvidence("ghost", "auto")
+	d.recordProcessEvidence("ghost", true)
+
+	if _, ok := d.evidenceTable().snapshot("ghost"); ok {
+		t.Fatal("an unknown session created an evidence entry")
+	}
+}
+
+// The stale-worker race: a session is removed while one of its observations is
+// still in flight. The write's liveness check and its append have to be one
+// atomic step, or the late writer recreates an entry for an id that will never
+// be removed again.
+//
+// The hook parks the writer *after* it has read the store row and *before* it
+// appends — the exact window that leaks when the check sits outside the lock.
+func TestEvidenceDoesNotLeakWhenRemovalRacesTheWrite(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-evidence-race"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+
+	paused := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	evidenceRecordGateHook = func(observed string) {
+		if observed != id {
+			return
+		}
+		once.Do(func() {
+			close(paused)
+			<-release
+		})
+	}
+	t.Cleanup(func() { evidenceRecordGateHook = nil })
+
+	wrote := make(chan struct{})
+	go func() {
+		defer close(wrote)
+		d.recordBracketEvidence(id, protocol.StateWorking)
+	}()
+
+	<-paused
+	// Removal runs entirely while the writer is parked mid-write. With admission
+	// inside the lock it cannot interleave here at all — it blocks until the
+	// writer finishes and then forgets whatever the writer left.
+	go func() {
+		d.dropSessionRecord(id)
+	}()
+	// Give the removal a chance to reach the table before the writer resumes, so
+	// the ordering under test is the hostile one rather than a lucky one.
+	time.Sleep(20 * time.Millisecond)
+	close(release)
+	<-wrote
+
+	// Whichever order won, no entry may survive the session.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got, ok := d.evidenceTable().snapshot(id)
+		if !ok {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("evidence survived the racing removal: %+v", got)
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }

--- a/internal/daemon/session_evidence_test.go
+++ b/internal/daemon/session_evidence_test.go
@@ -1,0 +1,240 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/pty"
+	"github.com/victorarias/attn/internal/sessionstate"
+	"github.com/victorarias/attn/internal/statetrace"
+)
+
+func evidenceOf(t *testing.T, d *Daemon, sessionID string) sessionstate.Evidence {
+	t.Helper()
+	got, ok := d.evidenceTable().snapshot(sessionID)
+	if !ok {
+		t.Fatalf("no evidence recorded for %s", sessionID)
+	}
+	return got
+}
+
+// The heartbeat is a level with its own vocabulary. It has to land in the
+// heartbeat slot with its observation time intact, because its freshness — not
+// its arrival — is what the resolver reads.
+func TestHeartbeatEvidenceKeepsItsObservationTime(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-hb-evidence"
+	observed := time.Now().Add(-300 * time.Millisecond)
+
+	d.recordPTYEvidence(id, pty.Observation{
+		Source: pty.SourceHeartbeat,
+		Claim:  "busy",
+		Detail: "⠐ working",
+		At:     observed,
+	})
+
+	got := evidenceOf(t, d, id).Heartbeat
+	if got == nil || got.Claim != sessionstate.ClaimBusy {
+		t.Fatalf("got %+v, want a busy heartbeat", got)
+	}
+	if !got.ObservedAt.Equal(observed) {
+		t.Fatalf("ObservedAt %s, want the source's %s", got.ObservedAt, observed)
+	}
+	if got.Detail != "⠐ working" {
+		t.Fatalf("detail %q, want the title", got.Detail)
+	}
+}
+
+func TestNotBusyHeartbeatEvidenceIsSettled(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-hb-settled"
+
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "not_busy", At: time.Now()})
+
+	if got := evidenceOf(t, d, id).Heartbeat; got == nil || got.Claim != sessionstate.ClaimSettled {
+		t.Fatalf("got %+v, want settled", got)
+	}
+}
+
+// The brackets are levels: a turn opens and stays open until something closes
+// it. Getting this wrong is the whole stuck class.
+func TestBracketEvidenceOpensAndCloses(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-bracket"
+
+	d.recordBracketEvidence(id, protocol.StateWorking)
+	if !evidenceOf(t, d, id).TurnOpen {
+		t.Fatal("working must open the turn")
+	}
+
+	d.recordBracketEvidence(id, protocol.StateIdle)
+	got := evidenceOf(t, d, id)
+	if got.TurnOpen || got.ToolOpen {
+		t.Fatalf("a settled state must close both brackets: %+v", got)
+	}
+}
+
+// The Stop facts are the ones the CLI used to collapse into a state string
+// before they crossed the socket, which is exactly why the resolver could not
+// see them.
+func TestStopFactsBecomeEvidence(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-stop-facts"
+
+	d.recordStopFacts(id, true, false)
+	if got := evidenceOf(t, d, id); !got.BackgroundWork || got.PendingCron {
+		t.Fatalf("got %+v, want background work only", got)
+	}
+
+	// They are levels, so a later stop with nothing outstanding clears them.
+	d.recordStopFacts(id, false, false)
+	if got := evidenceOf(t, d, id); got.BackgroundWork {
+		t.Fatalf("background work outlived the stop that cleared it: %+v", got)
+	}
+}
+
+// "default" is the one mode that means the user answers. Everything else puts
+// something between the agent and the user.
+func TestReviewerEvidenceReadsThePermissionMode(t *testing.T) {
+	for _, tc := range []struct {
+		mode string
+		want bool
+	}{
+		{mode: "default", want: false},
+		{mode: "auto", want: true},
+		{mode: "acceptEdits", want: true},
+		{mode: "bypassPermissions", want: true},
+	} {
+		d := newTraceDaemon(t)
+		id := "sess-reviewer-" + tc.mode
+		d.recordReviewerEvidence(id, tc.mode)
+		if got := evidenceOf(t, d, id).ReviewerInLoop; got != tc.want {
+			t.Fatalf("mode %q -> ReviewerInLoop %v, want %v", tc.mode, got, tc.want)
+		}
+	}
+}
+
+// An agent that reports no mode must not be recorded as having no reviewer:
+// silence is not a claim, and treating it as one would remove the dwell from
+// every codex session.
+func TestAnAbsentPermissionModeRecordsNothing(t *testing.T) {
+	d := newTraceDaemon(t)
+	d.recordReviewerEvidence("sess-no-mode", "  ")
+	if _, ok := d.evidenceTable().snapshot("sess-no-mode"); ok {
+		t.Fatal("an absent mode created an evidence record")
+	}
+}
+
+// Every write stamps LastMovement, so stuck detection cannot drift out of sync
+// with the writes it is watching.
+func TestEveryEvidenceWriteStampsMovement(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-movement"
+
+	d.recordBracketEvidence(id, protocol.StateWorking)
+	first := evidenceOf(t, d, id).LastMovement
+	if first.IsZero() {
+		t.Fatal("LastMovement not stamped")
+	}
+
+	d.recordStopFacts(id, false, true)
+	if second := evidenceOf(t, d, id).LastMovement; !second.After(first) {
+		t.Fatalf("LastMovement %s did not advance past %s", second, first)
+	}
+}
+
+// Shadow mode's contract: the tick records what the resolver would have said and
+// changes nothing.
+func TestTheResolveTickRecordsADisagreementWithoutApplyingIt(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-shadow"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateIdle)
+
+	now := time.Now()
+	d.recordPTYEvidence(id, pty.Observation{
+		Source: pty.SourceHeartbeat,
+		Claim:  "busy",
+		Detail: "⠐ working",
+		At:     now,
+	})
+
+	d.resolveAllSessions(now)
+
+	got := onlyObservation(t, d, id)
+	if got.Source != stateSourceResolver {
+		t.Fatalf("source %q, want %q", got.Source, stateSourceResolver)
+	}
+	if got.Outcome != statetrace.OutcomeObserved {
+		t.Fatalf("outcome %q, want observed — the resolver must not write state yet", got.Outcome)
+	}
+	if got.Claim != string(protocol.SessionStateWorking) {
+		t.Fatalf("claim %q, want working: a fresh heartbeat outranks the stored idle", got.Claim)
+	}
+	if got.Reason != string(sessionstate.ReasonHeartbeatFresh) {
+		t.Fatalf("reason %q, want %q", got.Reason, sessionstate.ReasonHeartbeatFresh)
+	}
+	if state := d.store.Get(id).State; state != protocol.SessionStateIdle {
+		t.Fatalf("the shadow tick changed state to %q", state)
+	}
+}
+
+// A tick that agreed every second would bury every other observation in a ring
+// that holds 256 of them.
+func TestTheResolveTickIsSilentWhenItAgrees(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-shadow-agree"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+
+	now := time.Now()
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", At: now})
+	for range 5 {
+		d.resolveAllSessions(now)
+	}
+
+	if got := traceOf(t, d, id); len(got) != 0 {
+		t.Fatalf("an agreeing tick recorded %+v", got)
+	}
+}
+
+// A removed session must stop being resolved, or the table grows for the
+// lifetime of the daemon — the same leak the trace ring was fixed for.
+func TestTheResolveTickForgetsARemovedSession(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-shadow-gone"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+	d.recordBracketEvidence(id, protocol.StateWorking)
+
+	d.store.Remove(id)
+	d.resolveAllSessions(time.Now())
+
+	if _, ok := d.evidenceTable().snapshot(id); ok {
+		t.Fatal("evidence survived the session it described")
+	}
+}
+
+// LastBusyAt is what the resolver measures staleness from, so it must advance
+// only on busy frames. Advancing it on any heartbeat would make a mid-turn idle
+// blip look like fresh proof of work; not advancing it at all would settle every
+// turn after one window.
+func TestOnlyABusyHeartbeatAdvancesLastBusy(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-lastbusy"
+
+	busy := time.Now().Add(-2 * time.Second)
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", At: busy})
+	if got := evidenceOf(t, d, id).LastBusyAt; !got.Equal(busy) {
+		t.Fatalf("LastBusyAt %s, want %s", got, busy)
+	}
+
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "not_busy", At: time.Now()})
+	got := evidenceOf(t, d, id)
+	if !got.LastBusyAt.Equal(busy) {
+		t.Fatalf("a not-busy frame moved LastBusyAt to %s", got.LastBusyAt)
+	}
+	// The latest frame is still recorded — it is the detail and freshness the
+	// heartbeat-fresh clause reads.
+	if got.Heartbeat.Claim != sessionstate.ClaimSettled {
+		t.Fatalf("latest heartbeat %+v, want the settled frame", got.Heartbeat)
+	}
+}

--- a/internal/daemon/state_trace.go
+++ b/internal/daemon/state_trace.go
@@ -46,6 +46,9 @@ const (
 	// fact on the state hook. It says who answers an approval request, which is
 	// what separates a real approval stall from a guardian's brief round trip.
 	stateSourceReviewer = "reviewer"
+	// stateSourceResolver is the evidence resolver's own verdict. In shadow mode
+	// it is recorded only when it disagrees with the state the session is in.
+	stateSourceResolver = "resolver"
 )
 
 // stateTraceRecordGateHook runs inside the recorder's lock, between the liveness


### PR DESCRIPTION
Phase 2b of the agent state detection plan
([docs/plans/2026-07-25-agent-state-detection.md](docs/plans/2026-07-25-agent-state-detection.md)).
Stacked on #671, which added the resolver this fills evidence for.

**Shadow mode: nothing here writes state.** The table is filled and re-resolved
on a 1s tick, and the resolution is recorded in the state trace as an
observation. Flipping it authoritative and deleting the sources it replaces is
the next change, deliberately separate so the resolver can be witnessed agreeing
first — and so the places it disagrees are on record before anyone acts on them.

## What lands

Every existing source is teed into the evidence table alongside its current
path: PTY observations (heartbeat, approval, screen), hook brackets, the
stop-time classifier verdict with its observation time, the Stop payload's
background-work and pending-cron facts, the resolved permission mode, and
process exit.

The Stop facts are the ones that motivated moving the decision daemon-side in
the first place: the CLI used to collapse them into a state string before they
crossed the socket, so the resolver could not see them at all.

The tick matters as much as the table. Without it a resolution would only be
recomputed when a source spoke — which is exactly the case that fails when a
source stops speaking.

A resolution that agrees is not recorded. An agreeing tick every second would
bury everything else in a 256-entry ring.

Evidence is forgotten when its session is removed, and the tick forgets any
session whose store row has gone. Both were leaks worth pre-empting; the trace
ring had the same one in #668.

## Live verification

Profile `statedet` (full `make install`), one claude session running a 20s
foreground `sleep`. `attn state explain`, abridged:

```
OBSERVED       SOURCE      CLAIM     OUTCOME        WHY
18:33:07.220   heartbeat   not_busy  observed       "✳ Claude Code"
18:33:19.385   resolver    unknown   observed ×13   no_evidence
18:33:19.715   hook_state  working   applied        cause=live_signal
18:33:42.798   heartbeat   busy      observed ×12   "⠂ Run bash sleep and echo command"
18:33:44.418   heartbeat   not_busy  observed       "✳ Run bash sleep and echo command"
18:33:50.386   resolver    idle      observed ×6    bracket_stale
18:33:44.406   classifier  idle      applied        cause=classifier_observation
```

Two things to read here.

The resolver stayed silent for the entire 20s tool call — it agreed with
`working` on every tick, through the mid-tool heartbeat gaps that would have
tripped a naive TTL.

Then it reached `idle` via `bracket_stale` about a second after the agent said
not-busy, while the store stayed `working` until the classifier landed roughly
eight seconds later. That gap is the improvement the phase is for, measured on a
real turn.

The early `resolver unknown / no_evidence` run is correct rather than a gap: a
settled heartbeat alone says the turn is not running and nothing about what the
session wants, which is precisely why the hooks and the classifier are in the
table too.

## One finding, recorded not fixed

Settling fast has a cost the flip has to answer for. On a turn that ends in a
question, the resolver would publish `idle` immediately and then correct to
`waiting_input` when the classifier lands — a flicker where today there is a
delay. In this run the verdict was `idle` and the two agreed, so nothing was
visible. The plan's Open questions section now carries the case and the three
options; it needs a decision before phase 2c, and these same shadow traces can
measure how often the verdict is `waiting_input` at all.

## Tests

`internal/daemon/session_evidence_test.go` covers each source landing in the
right slot with its observation time intact, the brackets as levels, the stop
facts clearing when a later stop reports nothing outstanding, `default` being
the only permission mode that means the user answers, an absent mode recording
nothing at all, every write stamping `LastMovement`, and the three shadow-mode
properties: a disagreement is recorded without being applied, an agreement is
silent, and a removed session stops being resolved.

Both shadow-mode properties were mutation-checked — dropping the agreement guard
and adding an `applyState` call each turn their own case red.

`make test` green.
