### PR TITLE
feat(state): hold a guardian's approval instead of flashing it

### DIFF
--- a/app/scripts/real-app-harness/probe-state-detection.mjs
+++ b/app/scripts/real-app-harness/probe-state-detection.mjs
@@ -39,13 +39,23 @@ async function main() {
 
   await launchFreshAppAndConnect(client, observer);
 
-  // PROBE_GUARDIAN=off disables the auto-approve guardian for the run. With it
-  // on, codex routes every permission request to its auto_review reviewer, which
-  // answers in milliseconds — so no prompt ever reaches the terminal and the
-  // approval path cannot be observed at all.
-  if (process.env.PROBE_GUARDIAN === 'off') {
-    await client.request('set_setting', { key: 'auto_approve_enabled', value: 'false' });
-    console.log('guardian auto-approve disabled for this run');
+  // PROBE_GUARDIAN picks who answers approval requests, because the two halves
+  // of the approval behavior are only observable under opposite settings.
+  //
+  // `off`: no reviewer, so the prompt reaches the terminal and the approval path
+  // can be watched at all. `on`: codex routes the request to its auto_review
+  // reviewer, which answers in milliseconds — nothing reaches the terminal, and
+  // what is being checked is that the user is never shown a color for it.
+  //
+  // It is set explicitly rather than left alone because the setting is
+  // persistent: a previous run leaves the profile in whichever state it chose.
+  if (process.env.PROBE_GUARDIAN) {
+    const enabled = process.env.PROBE_GUARDIAN === 'on';
+    await client.request('set_setting', {
+      key: 'auto_approve_enabled',
+      value: String(enabled),
+    });
+    console.log(`guardian auto-approve ${enabled ? 'enabled' : 'disabled'} for this run`);
   }
 
   const sessionId = await createSessionAndWaitForInitialPane({

--- a/docs/plans/2026-07-25-agent-state-detection.md
+++ b/docs/plans/2026-07-25-agent-state-detection.md
@@ -731,7 +731,14 @@ its whitelist moved into the resolver, or stays screen-driven on purpose.
 
 ### Phase 3 — policy
 
-- [ ] Dwell gate + `guardianDwell`.
+- [x] Dwell gate + `guardianDwell`.
+      **Deviation.** The plan had `ReviewerInLoop` arriving with the session's
+      persisted launch record. It is filed as ordinary evidence at spawn instead:
+      the fact is decided in the spawn pipeline, the evidence table is already the
+      thing the resolver reads, and persisting it would have added a store field
+      whose only reader is one clause. Claude's hook still refreshes it per turn,
+      which is what catches a mid-session mode change; codex reports no permission
+      mode ever, so for codex the spawn record is the only source.
 - [ ] Stuck detection (`stuckAfter`, reason surfaced in the UI).
 - [ ] `idleStaleAfter` staleness marking, folding in
       `needs_review_after_long_run`. Marked in phase 3; only *consumed* as an

--- a/docs/plans/2026-07-25-agent-state-detection.md
+++ b/docs/plans/2026-07-25-agent-state-detection.md
@@ -491,6 +491,26 @@ being fixed as part of the current step.
   exactly one `state=working` line in `daemon.log`. This matters beyond tidiness —
   the pulse is the liveness signal the resolver's TTL design depends on, so the
   resolver phase must either un-gate it or grow its own heartbeat.
+- **Neither guardian produced observable approval evidence, so the dwell has no
+  live trigger yet.** Measured on `statedet` 2026-07-26, both agents launched
+  with a reviewer and given a command that must escalate. Codex escalated (the
+  write outside the workspace landed) and claude's command ran, and in both runs
+  the daemon recorded *no approval evidence at all* — codex never painted
+  `[ . ] Action Required`, claude sent no `permission_prompt` notification. The
+  same codex prompt with the reviewer removed does produce the title marker, so
+  the escalation is real; what is absent is any signal while a guardian is
+  answering. The dwell is therefore correct-but-unwitnessed: it costs nothing
+  when the guardian is fast, and it is the only thing standing between a slow
+  guardian and the reported flash. Worth deciding in phase 3.5 whether the flash
+  still exists on current agent versions, and if not, whether the dwell earns its
+  place.
+- **`ReviewerInLoop` had two sources and the wrong one won for codex.** Found
+  live: codex's hooks send `permission_mode: default` on every turn as payload
+  filler, which retired the spawn-time reviewer fact on the session's first turn
+  and took the dwell with it. Fixed by reading the mode only for claude, whose
+  mode genuinely governs approval routing. The general shape — a field that means
+  something for one agent and is filler for another, read without asking which
+  agent sent it — is worth a sweep in phase 3.5.
 - **The copilot screen heuristics look stale against copilot 1.0.73.**
   `classifyCopilotScreen` keys off `defaultStateHeuristics` — prompt markers
   ` › ` / ` > ` / `❯ ` and status markers "context left" / "for shortcuts". The

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1765,6 +1765,12 @@ func (d *Daemon) dropSessionRecord(sessionID string) {
 	// rebuilds the ring for an id nothing will ever clean up again.
 	d.forgetStateTrace(sessionID)
 	d.evidenceTable().forget(sessionID)
+	// The dwell gate has to be cleared here rather than left to the resolve
+	// loop's own cleanup: that loop walks the evidence table, so forgetting the
+	// evidence row is exactly what stops it from ever visiting this session
+	// again. A session closed mid-dwell would otherwise leave its pending
+	// transition behind for the daemon's lifetime.
+	d.dwellGate().clear(sessionID)
 }
 
 // handlePTYState applies one PTY-layer observation. It is still last-writer-wins

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -207,8 +207,12 @@ type Daemon struct {
 	stateTraceOnce sync.Once
 	stateTrace     *statetrace.Recorder
 	// sessionEvidence is the per-session evidence table the resolver reads.
-	sessionEvidenceOnce        sync.Once
-	sessionEvidence            *sessionEvidenceTable
+	sessionEvidenceOnce sync.Once
+	sessionEvidence     *sessionEvidenceTable
+	// sessionDwell holds transitions that have been resolved but not yet held
+	// long enough to publish.
+	sessionDwellOnce           sync.Once
+	sessionDwell               *dwellGate
 	nudgeMu                    sync.Mutex
 	nudgeCountdowns            map[string]*nudgeCountdown                 // presence == a running (unpaused) countdown
 	unreadCache                map[string]bool                            // per-session unread ticket activity, for cheap broadcast decoration
@@ -2393,7 +2397,7 @@ func (d *Daemon) handleUnregister(conn net.Conn, msg *protocol.UnregisterMessage
 func (d *Daemon) handleState(conn net.Conn, msg *protocol.StateMessage) {
 	d.logf("state update: id=%s state=%s", msg.ID, msg.State)
 	d.tracePermissionMode(msg.ID, protocol.Deref(msg.PermissionMode))
-	d.recordReviewerEvidence(msg.ID, protocol.Deref(msg.PermissionMode))
+	d.recordReviewerEvidenceFromPermissionMode(msg.ID, protocol.Deref(msg.PermissionMode))
 	d.recordBracketEvidence(msg.ID, msg.State)
 	d.applyState(sessionStateChange{
 		sessionID: msg.ID,

--- a/internal/daemon/session_dwell.go
+++ b/internal/daemon/session_dwell.go
@@ -1,0 +1,85 @@
+package daemon
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// The dwell gate: how long a resolved transition must keep being the answer
+// before anyone is told about it.
+//
+// It exists for one shape — an approval addressed to a guardian rather than to
+// the user. Codex routes permission requests to its auto_review reviewer and
+// claude to its permission classifier, both of which answer in well under a
+// second, and publishing the request the instant it appears paints an
+// attention-demanding color on every tool call of a run nobody is watching. The
+// dwell is not a delay on genuine requests: with no reviewer in the loop the
+// user *is* the reviewer and `sessionstate.DwellFor` returns zero.
+//
+// It lives here rather than in the resolver because it is not a question about
+// the evidence. The resolver is pure and answers "what is true now"; whether an
+// answer has been true for long enough is a fact about the sequence of answers,
+// which only the thing running the tick can know.
+
+// dwellGate tracks, per session, the transition currently waiting out its dwell.
+type dwellGate struct {
+	mu      sync.Mutex
+	pending map[string]dwellPending
+}
+
+type dwellPending struct {
+	state protocol.SessionState
+	since time.Time
+}
+
+func newDwellGate() *dwellGate {
+	return &dwellGate{pending: make(map[string]dwellPending)}
+}
+
+// ready reports whether a transition into state may be published now.
+//
+// A dwell of zero always passes and clears any wait in progress: an agent that
+// drops its reviewer mid-session must not keep serving out a dwell the new mode
+// no longer asks for.
+//
+// A state different from the one being waited on replaces it rather than
+// extending it. That is what cancels the wait when the guardian answers: the
+// approval is retired by the agent's next busy frame, the resolver starts
+// answering `working`, and the pending approval is dropped without ever having
+// been shown.
+func (g *dwellGate) ready(sessionID string, state protocol.SessionState, dwell time.Duration, now time.Time) bool {
+	if g == nil || strings.TrimSpace(sessionID) == "" {
+		return true
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if dwell <= 0 {
+		delete(g.pending, sessionID)
+		return true
+	}
+	pending, ok := g.pending[sessionID]
+	if !ok || pending.state != state {
+		g.pending[sessionID] = dwellPending{state: state, since: now}
+		return false
+	}
+	if now.Sub(pending.since) < dwell {
+		return false
+	}
+	delete(g.pending, sessionID)
+	return true
+}
+
+// clear drops any wait in progress. Called whenever the resolver stops proposing
+// a transition at all, so a later one starts its dwell from scratch instead of
+// inheriting an abandoned clock.
+func (g *dwellGate) clear(sessionID string) {
+	if g == nil {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	delete(g.pending, sessionID)
+}

--- a/internal/daemon/session_dwell.go
+++ b/internal/daemon/session_dwell.go
@@ -72,6 +72,19 @@ func (g *dwellGate) ready(sessionID string, state protocol.SessionState, dwell t
 	return true
 }
 
+// waiting reports whether a transition is currently serving out a dwell. It
+// exists so a lifecycle test can assert the gate holds nothing after a session
+// is gone, which is otherwise invisible from outside.
+func (g *dwellGate) waiting(sessionID string) bool {
+	if g == nil {
+		return false
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	_, ok := g.pending[sessionID]
+	return ok
+}
+
 // clear drops any wait in progress. Called whenever the resolver stops proposing
 // a transition at all, so a later one starts its dwell from scratch instead of
 // inheriting an abandoned clock.

--- a/internal/daemon/session_dwell_test.go
+++ b/internal/daemon/session_dwell_test.go
@@ -1,0 +1,182 @@
+package daemon
+
+import (
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/pty"
+	"github.com/victorarias/attn/internal/sessionstate"
+)
+
+// The gate's own rules, stated without a daemon around them.
+func TestDwellGateHoldsATransitionUntilItHasBeenTrueLongEnough(t *testing.T) {
+	g := newDwellGate()
+	now := time.Now()
+
+	if g.ready("s", protocol.SessionStatePendingApproval, time.Minute, now) {
+		t.Fatal("published on the first tick: nothing has been true for a minute yet")
+	}
+	if g.ready("s", protocol.SessionStatePendingApproval, time.Minute, now.Add(59*time.Second)) {
+		t.Fatal("published a second early")
+	}
+	if !g.ready("s", protocol.SessionStatePendingApproval, time.Minute, now.Add(time.Minute)) {
+		t.Fatal("still held once the dwell had elapsed")
+	}
+}
+
+// A different answer replaces the wait rather than extending it. This is what
+// cancels a guardian-answered approval: the resolver starts saying `working`,
+// and the approval it was holding is dropped without ever being shown.
+func TestDwellGateDropsATransitionThatStoppedBeingTheAnswer(t *testing.T) {
+	g := newDwellGate()
+	now := time.Now()
+
+	g.ready("s", protocol.SessionStatePendingApproval, time.Minute, now)
+	// `working` carries no dwell, so it publishes at once...
+	if !g.ready("s", protocol.SessionStateWorking, 0, now.Add(time.Second)) {
+		t.Fatal("a dwell-free transition was held")
+	}
+	// ...and the approval's clock is gone, not merely paused. A later approval
+	// starts its own minute instead of inheriting the first one's.
+	if g.ready("s", protocol.SessionStatePendingApproval, time.Minute, now.Add(2*time.Minute)) {
+		t.Fatal("a fresh approval inherited the abandoned clock and published immediately")
+	}
+}
+
+// A zero dwell is the no-reviewer case, and it must not merely pass — it has to
+// clear a wait in progress, or a session that drops its reviewer keeps serving
+// out a dwell nothing is asking for any more.
+func TestDwellGateClearsAWaitWhenTheDwellGoesToZero(t *testing.T) {
+	g := newDwellGate()
+	now := time.Now()
+
+	g.ready("s", protocol.SessionStatePendingApproval, time.Minute, now)
+	if !g.ready("s", protocol.SessionStatePendingApproval, 0, now.Add(time.Second)) {
+		t.Fatal("a zero dwell was held")
+	}
+	// Re-arming finds no clock to resume, so it starts a fresh one rather than
+	// publishing on the strength of the wait the zero dwell passed through.
+	if g.ready("s", protocol.SessionStatePendingApproval, time.Minute, now.Add(2*time.Second)) {
+		t.Fatal("a re-armed dwell published immediately: the old wait was still counting")
+	}
+}
+
+// The wire the whole dwell hangs off for codex, which reports no permission
+// mode to the daemon at any point in its life: unless the spawn files who is
+// reviewing, the resolver never learns there is a guardian at all and every
+// guardian-answered request flashes.
+func TestSpawnFilesWhoAnswersApprovals(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		autoApprove bool
+		yolo        bool
+		want        bool
+	}{
+		{name: "guardian", autoApprove: true, want: true},
+		{name: "user answers", autoApprove: false, want: false},
+		// Yolo removes the approval gate rather than delegating it, so there is
+		// nothing for a reviewer to answer and nothing to dwell on.
+		{name: "yolo outranks auto-approve", autoApprove: true, yolo: true, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+			t.Cleanup(func() { _ = d.store.Close() })
+			d.ptyBackend = &fakeSpawnBackend{}
+			cwd := t.TempDir()
+			addTestWorkspace(d, "workspace", cwd)
+			d.store.SetSetting(SettingAutoApproveEnabled, strconv.FormatBool(tc.autoApprove))
+
+			msg := &protocol.SpawnSessionMessage{
+				Cmd:         protocol.CmdSpawnSession,
+				ID:          "spawn-reviewer-" + tc.name,
+				Cwd:         cwd,
+				Agent:       "codex",
+				WorkspaceID: "workspace",
+				Cols:        80,
+				Rows:        24,
+				YoloMode:    protocol.Ptr(tc.yolo),
+			}
+			client := spawnTestClient()
+			d.handleSpawnSession(client, msg)
+			expectSpawnResult(t, client, msg.ID, true)
+
+			if got := evidenceOf(t, d, msg.ID).ReviewerInLoop; got != tc.want {
+				t.Fatalf("ReviewerInLoop = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// The reported bug, end to end: an unattended codex run asks permission on a
+// tool call, its guardian answers in milliseconds, and the user must never see
+// the session demand attention for it.
+func TestAGuardianAnsweredApprovalIsNeverPublished(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-guardian"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentCodex, protocol.SessionStateWorking)
+
+	now := time.Now()
+	d.recordReviewerEvidence(id, true)
+	d.recordBracketEvidence(id, protocol.StateWorking)
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", At: now})
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "approval", At: now, Detail: "Action Required"})
+
+	// A tick while the guardian is thinking. The approval is the resolver's
+	// answer, and it is deliberately not published.
+	d.resolveAllSessions(now.Add(time.Second))
+	if state := d.store.Get(id).State; state == protocol.SessionStatePendingApproval {
+		t.Fatal("the guardian's approval was shown to the user")
+	}
+
+	// The guardian answers: codex paints a busy frame again, which retires the
+	// approval, and the session was never yellow.
+	answeredAt := now.Add(2 * time.Second)
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", At: answeredAt})
+	d.resolveAllSessions(answeredAt.Add(time.Second))
+	if state := d.store.Get(id).State; state != protocol.SessionStateWorking {
+		t.Fatalf("state %q, want working once the guardian answered", state)
+	}
+}
+
+// The other half: a guardian that does not answer must not hide the request
+// forever. The dwell delays the color, it does not suppress it.
+func TestAnUnansweredApprovalIsPublishedOnceTheDwellElapses(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-guardian-silent"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentCodex, protocol.SessionStateWorking)
+
+	now := time.Now()
+	d.recordReviewerEvidence(id, true)
+	d.recordBracketEvidence(id, protocol.StateWorking)
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "approval", At: now, Detail: "Action Required"})
+
+	policy := sessionstate.PolicyFor(string(protocol.SessionAgentCodex))
+	d.resolveAllSessions(now.Add(time.Second))
+	d.resolveAllSessions(now.Add(time.Second + policy.GuardianDwell))
+
+	if state := d.store.Get(id).State; state != protocol.SessionStatePendingApproval {
+		t.Fatalf("state %q, want pending_approval: the dwell delays the request, it does not swallow it", state)
+	}
+}
+
+// With nobody but the user to answer, the request is the user's the instant it
+// arrives. A dwell here would be a regression, not a refinement.
+func TestAnApprovalWithNoReviewerPublishesImmediately(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-no-reviewer"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentCodex, protocol.SessionStateWorking)
+
+	now := time.Now()
+	d.recordReviewerEvidence(id, false)
+	d.recordBracketEvidence(id, protocol.StateWorking)
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "approval", At: now, Detail: "Action Required"})
+
+	d.resolveAllSessions(now.Add(time.Second))
+
+	if state := d.store.Get(id).State; state != protocol.SessionStatePendingApproval {
+		t.Fatalf("state %q, want pending_approval on the first tick", state)
+	}
+}

--- a/internal/daemon/session_dwell_test.go
+++ b/internal/daemon/session_dwell_test.go
@@ -195,6 +195,40 @@ func TestAnUnansweredApprovalIsPublishedOnceTheDwellElapses(t *testing.T) {
 	}
 }
 
+// A session closed mid-dwell must not leave its pending transition behind. The
+// resolve loop's own cleanup cannot do it: that loop walks the evidence table,
+// and removal forgets the evidence row, so the tick never visits this session
+// again. Without a clear in the removal path the entry outlives the daemon's
+// interest in it, and enough short-lived unattended sessions turn a transient UX
+// gate into permanent state.
+func TestClosingASessionMidDwellLeavesNothingBehind(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-dwell-closed"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentCodex, protocol.SessionStateWorking)
+
+	now := time.Now()
+	d.recordReviewerEvidence(id, true)
+	d.recordBracketEvidence(id, protocol.StateWorking)
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "approval", At: now, Detail: "Action Required"})
+
+	d.resolveAllSessions(now.Add(time.Second))
+	if !d.dwellGate().waiting(id) {
+		t.Fatal("no dwell was armed, so the test cannot show one being cleaned up")
+	}
+
+	d.dropSessionRecord(id)
+
+	if d.dwellGate().waiting(id) {
+		t.Fatal("the closed session's dwell is still pending")
+	}
+	// And the tick that would have cleaned it up never comes, which is the whole
+	// reason the removal path has to do it.
+	d.resolveAllSessions(now.Add(2 * time.Second))
+	if d.dwellGate().waiting(id) {
+		t.Fatal("the dwell survived a later tick")
+	}
+}
+
 // With nobody but the user to answer, the request is the user's the instant it
 // arrives. A dwell here would be a regression, not a refinement.
 func TestAnApprovalWithNoReviewerPublishesImmediately(t *testing.T) {

--- a/internal/daemon/session_dwell_test.go
+++ b/internal/daemon/session_dwell_test.go
@@ -110,6 +110,39 @@ func TestSpawnFilesWhoAnswersApprovals(t *testing.T) {
 	}
 }
 
+// Codex's hooks send `permission_mode: default` on every turn as payload
+// filler, while its reviewer is set by the approvals_reviewer flag at launch.
+// Believing that field would retire the spawn-time fact on the session's first
+// turn and take the dwell with it — which is exactly what a live guardian run
+// showed before this guard existed.
+func TestCodexPermissionModeDoesNotRetireTheSpawnTimeReviewer(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-codex-mode"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentCodex, protocol.SessionStateWorking)
+
+	d.recordReviewerEvidence(id, true)
+	d.recordReviewerEvidenceFromPermissionMode(id, "default")
+
+	if !evidenceOf(t, d, id).ReviewerInLoop {
+		t.Fatal("codex's filler permission mode retired the reviewer recorded at spawn")
+	}
+}
+
+// Claude's mode is a genuine report, and a user switching back to answering for
+// themselves mid-session must take effect.
+func TestClaudePermissionModeStillRetiresTheReviewer(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-claude-mode"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+
+	d.recordReviewerEvidence(id, true)
+	d.recordReviewerEvidenceFromPermissionMode(id, "default")
+
+	if evidenceOf(t, d, id).ReviewerInLoop {
+		t.Fatal("claude reported default and kept its reviewer")
+	}
+}
+
 // The reported bug, end to end: an unattended codex run asks permission on a
 // tool call, its guardian answers in milliseconds, and the user must never see
 // the session demand attention for it.

--- a/internal/daemon/session_evidence.go
+++ b/internal/daemon/session_evidence.go
@@ -296,16 +296,43 @@ func reviewerInLoop(opts ptybackend.SpawnOptions) bool {
 	return opts.AutoApprove && !opts.YoloMode
 }
 
-// recordReviewerEvidenceFromPermissionMode files claude's reported mode. An
-// absent mode is not a report of "no reviewer" — it is an older CLI, or a hook
-// payload that omitted the field — and treating it as one would silently retire
-// the fact recorded at spawn.
+// recordReviewerEvidenceFromPermissionMode files claude's reported mode.
+//
+// Two things must not reach the evidence table through here. An absent mode is
+// not a report of "no reviewer" — it is an older CLI, or a payload that omitted
+// the field — and any mode at all from an agent that does not route approvals
+// by permission mode is not a report about approvals. Codex is the second case
+// concretely: its hooks send `default` on every turn as a payload filler while
+// its actual reviewer comes from the `approvals_reviewer` flag, so believing it
+// would retire the spawn-time fact on the first turn of every codex session and
+// take the dwell with it.
 func (d *Daemon) recordReviewerEvidenceFromPermissionMode(sessionID, permissionMode string) {
 	mode := strings.TrimSpace(permissionMode)
 	if mode == "" {
 		return
 	}
+	if !permissionModeGovernsApprovals(d.sessionAgent(sessionID)) {
+		return
+	}
 	d.recordReviewerEvidence(sessionID, mode != "default")
+}
+
+// permissionModeGovernsApprovals reports whether an agent's permission mode is
+// what decides who answers its approval requests. Claude's is; the others state
+// their arrangement at launch and never revise it.
+func permissionModeGovernsApprovals(agent protocol.SessionAgent) bool {
+	return agent == protocol.SessionAgentClaude
+}
+
+func (d *Daemon) sessionAgent(sessionID string) protocol.SessionAgent {
+	if d.store == nil {
+		return ""
+	}
+	session := d.store.Get(sessionID)
+	if session == nil {
+		return ""
+	}
+	return session.Agent
 }
 
 // Notification types claude reports. Both are typed fields on the hook payload,

--- a/internal/daemon/session_evidence.go
+++ b/internal/daemon/session_evidence.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/pty"
+	"github.com/victorarias/attn/internal/ptybackend"
 	"github.com/victorarias/attn/internal/sessionstate"
 	"github.com/victorarias/attn/internal/statetrace"
 )
@@ -129,6 +130,13 @@ func (d *Daemon) evidenceTable() *sessionEvidenceTable {
 		d.sessionEvidence = newSessionEvidenceTable()
 	})
 	return d.sessionEvidence
+}
+
+func (d *Daemon) dwellGate() *dwellGate {
+	d.sessionDwellOnce.Do(func() {
+		d.sessionDwell = newDwellGate()
+	})
+	return d.sessionDwell
 }
 
 // recordPTYEvidence files an observation from the PTY layer. Sources that only
@@ -264,16 +272,40 @@ func (d *Daemon) recordStopFacts(sessionID string, backgroundWork, pendingCron b
 }
 
 // recordReviewerEvidence files who answers approval requests. It is a level, not
-// an edge: it holds until the agent reports a different mode.
-func (d *Daemon) recordReviewerEvidence(sessionID, permissionMode string) {
+// an edge: it holds until something reports a different arrangement.
+//
+// It has two sources because the agents differ in what they will tell us. Both
+// are launched with a reviewer under the same condition, so the spawn is the
+// reliable one and the only one codex has — it reports no permission mode at all.
+// Claude's hook then carries the mode on every turn, which is what catches a user
+// changing it mid-session.
+func (d *Daemon) recordReviewerEvidence(sessionID string, inLoop bool) {
+	d.recordEvidence(sessionID, time.Now(), func(e *sessionstate.Evidence) {
+		e.ReviewerInLoop = inLoop
+	})
+}
+
+// reviewerInLoop reads the launch options for the one arrangement that puts
+// something other than the user in front of an approval request.
+//
+// Both agents gate their reviewer on the same option — claude with
+// `--permission-mode auto`, codex with `approvals_reviewer=auto_review` — and
+// yolo outranks it by removing the approval gate altogether, so a yolo session
+// has no reviewer because it has nothing to review.
+func reviewerInLoop(opts ptybackend.SpawnOptions) bool {
+	return opts.AutoApprove && !opts.YoloMode
+}
+
+// recordReviewerEvidenceFromPermissionMode files claude's reported mode. An
+// absent mode is not a report of "no reviewer" — it is an older CLI, or a hook
+// payload that omitted the field — and treating it as one would silently retire
+// the fact recorded at spawn.
+func (d *Daemon) recordReviewerEvidenceFromPermissionMode(sessionID, permissionMode string) {
 	mode := strings.TrimSpace(permissionMode)
 	if mode == "" {
 		return
 	}
-	inLoop := mode != "default"
-	d.recordEvidence(sessionID, time.Now(), func(e *sessionstate.Evidence) {
-		e.ReviewerInLoop = inLoop
-	})
+	d.recordReviewerEvidence(sessionID, mode != "default")
 }
 
 // Notification types claude reports. Both are typed fields on the hook payload,
@@ -367,14 +399,16 @@ func (d *Daemon) resolveAllSessions(now time.Time) {
 		if session == nil {
 			// The session is gone; so is any reason to keep resolving it.
 			d.evidenceTable().forget(sessionID)
+			d.dwellGate().clear(sessionID)
 			continue
 		}
 		evidence, ok := d.evidenceTable().snapshot(sessionID)
 		if !ok {
 			continue
 		}
-		resolution := sessionstate.Resolve(evidence, sessionstate.PolicyFor(string(session.Agent)), now)
-		d.publishResolution(sessionID, session.State, resolution)
+		policy := sessionstate.PolicyFor(string(session.Agent))
+		resolution := sessionstate.Resolve(evidence, policy, now)
+		d.publishResolution(sessionID, session.State, resolution, sessionstate.DwellFor(resolution.State, evidence, policy), now)
 	}
 }
 
@@ -400,7 +434,7 @@ var resolverOwnedStates = map[protocol.SessionState]bool{
 // diagnosis a wrong color needs: Hold means the evidence is still arriving,
 // no-evidence means nothing has been recorded at all, and an unowned current
 // state means the resolver was not entitled to an opinion.
-func (d *Daemon) publishResolution(sessionID string, current protocol.SessionState, resolution sessionstate.Resolution) {
+func (d *Daemon) publishResolution(sessionID string, current protocol.SessionState, resolution sessionstate.Resolution, dwell time.Duration, now time.Time) {
 	// A hold is traced, and it is the only non-application that is. It is the one
 	// that is both bounded and surprising: bounded because every hold clause
 	// expires, so the rows cannot accumulate, and surprising because a held
@@ -424,6 +458,18 @@ func (d *Daemon) publishResolution(sessionID string, current protocol.SessionSta
 		return
 	}
 	if !resolverOwnedStates[current] || resolution.State == current {
+		// No transition is on the table, so nothing is waiting out a dwell.
+		// Dropping the wait here is what keeps a later transition from
+		// inheriting a clock that started before an unrelated one.
+		d.dwellGate().clear(sessionID)
+		return
+	}
+	// Last gate before publication on purpose: everything above decides what is
+	// true, and this decides whether it has been true long enough to be worth
+	// showing. Putting it earlier would let a transition serve out its dwell and
+	// then be discarded for a reason that had nothing to do with timing.
+	if !d.dwellGate().ready(sessionID, resolution.State, dwell, now) {
+		d.traceResolutionSkip(sessionID, resolution, "dwell")
 		return
 	}
 	d.applyState(sessionStateChange{

--- a/internal/daemon/session_evidence_test.go
+++ b/internal/daemon/session_evidence_test.go
@@ -116,7 +116,7 @@ func TestReviewerEvidenceReadsThePermissionMode(t *testing.T) {
 		d := newTraceDaemon(t)
 		id := "sess-reviewer-" + tc.mode
 		addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
-		d.recordReviewerEvidence(id, tc.mode)
+		d.recordReviewerEvidenceFromPermissionMode(id, tc.mode)
 		if got := evidenceOf(t, d, id).ReviewerInLoop; got != tc.want {
 			t.Fatalf("mode %q -> ReviewerInLoop %v, want %v", tc.mode, got, tc.want)
 		}
@@ -129,7 +129,7 @@ func TestReviewerEvidenceReadsThePermissionMode(t *testing.T) {
 func TestAnAbsentPermissionModeRecordsNothing(t *testing.T) {
 	d := newTraceDaemon(t)
 	addCharacterizationSession(t, d, "sess-no-mode", protocol.SessionAgentClaude, protocol.SessionStateWorking)
-	d.recordReviewerEvidence("sess-no-mode", "  ")
+	d.recordReviewerEvidenceFromPermissionMode("sess-no-mode", "  ")
 	if _, ok := d.evidenceTable().snapshot("sess-no-mode"); ok {
 		t.Fatal("an absent mode created an evidence record")
 	}
@@ -215,7 +215,7 @@ func TestTheResolveTickDoesNotPublishAnAbsenceOfEvidence(t *testing.T) {
 
 	// A reviewer report is evidence of who answers approvals and nothing else,
 	// so it creates the table entry without supporting any state.
-	d.recordReviewerEvidence(id, "acceptEdits")
+	d.recordReviewerEvidenceFromPermissionMode(id, "acceptEdits")
 	d.resolveAllSessions(time.Now())
 
 	if state := d.store.Get(id).State; state != protocol.SessionStateWaitingInput {
@@ -443,7 +443,7 @@ func TestEvidenceIsNotRecordedForAnUnknownSession(t *testing.T) {
 	d.recordPTYEvidence("ghost", pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", At: time.Now()})
 	d.recordBracketEvidence("ghost", protocol.StateWorking)
 	d.recordStopFacts("ghost", true, false)
-	d.recordReviewerEvidence("ghost", "auto")
+	d.recordReviewerEvidence("ghost", true)
 	d.recordProcessEvidence("ghost", true)
 
 	if _, ok := d.evidenceTable().snapshot("ghost"); ok {

--- a/internal/daemon/spawn_pipeline.go
+++ b/internal/daemon/spawn_pipeline.go
@@ -348,6 +348,11 @@ func (d *Daemon) executeSpawn(req *spawnRequest, plan *spawnPlan) *spawnOutcome 
 		plan.rollback(d, msg.ID)
 		return &spawnOutcome{err: err}
 	}
+	// Who answers this session's approval requests is decided here and nowhere
+	// else, so it is filed here. Codex reports no permission mode to the daemon at
+	// any point in its life, and without this its guardian would be invisible —
+	// which is the arrangement the dwell exists for.
+	d.recordReviewerEvidence(msg.ID, reviewerInLoop(plan.spawnOpts))
 	if plan.spawnOpts.InitialPromptFile != "" {
 		// The spawned wrapper removes the file after reading it. Keep a fallback
 		// for failures between PTY spawn and wrapper startup.


### PR DESCRIPTION
First half of phase 3 of `docs/plans/2026-07-25-agent-state-detection.md`
(the dwell gate). The remaining phase 3 items — stuck detection surfaced in
the UI, and `idleStaleAfter` staleness marking — follow in a second PR.

## The change

An unattended run routes permission requests to a reviewer rather than to the
user: codex to its `auto_review` guardian, claude to its permission classifier.
Publishing the request the instant it appears paints an attention-demanding
color on every tool call of a run nobody is watching.

A transition into `pending_approval` now has to keep being the resolver's answer
for `guardianDwell` (60s) before it is published. The guardian's answer cancels
it — the agent's next busy frame retires the approval, the resolver starts
answering `working`, and the pending transition is dropped without ever having
been shown. A guardian that stays silent still surfaces the request once the
dwell elapses. With no reviewer the dwell is zero and a genuine request is not
delayed by a millisecond.

The gate lives in the daemon, not the resolver. The resolver is pure and answers
what is true now; whether an answer has been true for long enough is a fact
about the sequence of answers, which only the thing running the tick can know.

Who reviews is filed as evidence at spawn, where the decision is actually made.
Both agents gate their reviewer on the same launch option, and yolo outranks it
by removing the approval gate rather than delegating it.

## A bug this found live

Codex's hooks send `permission_mode: default` on every turn as payload filler,
while its actual reviewer comes from the `approvals_reviewer` flag. Reading that
field retired the spawn-time reviewer fact on the first turn of every codex
session and took the dwell with it — visible in the trace as three `reviewer
default` rows overwriting the spawn record. The mode is now read only for
claude, whose mode genuinely governs approval routing.

## Live verification, including what it did not show

Profile `statedet`, full install, packaged app, throwaway `CODEX_HOME` so the
sandbox actually forces an escalation.

- codex with the guardian on: `launching -> working -> idle`, never yellow, and
  the write outside the workspace landed — so the escalation was real and the
  guardian approved it.
- claude with the guardian on: `launching -> working -> idle`, command ran,
  reviewer correctly observed as `auto`.
- codex with the reviewer removed: the same prompt does produce
  `[ . ] Action Required` in the title, confirming the escalation path.

What these runs did **not** show is the dwell holding anything. In both
guardian-on runs the daemon recorded no approval evidence at all — codex never
painted the marker and claude sent no `permission_prompt` notification while its
classifier was answering. So on these agent versions the guardian answers
without ever raising a visible request, and the dwell had nothing to suppress.

It is kept because it costs nothing when the guardian is fast and is the only
thing standing between a slow guardian and the reported flash. Whether the flash
still exists on current agent versions — and therefore whether the dwell earns
its place — is logged in the plan as a phase 3.5 decision rather than settled
here.

The gate's own behavior is covered by tests: it holds, it releases on time, a
different answer cancels the wait rather than extending it, a zero dwell clears
a wait in progress, and the spawn files the right reviewer for all three launch
arrangements. Each guard was mutation-tested and fails on its own assertion.