### PR TITLE
feat(state): publish stuck sessions and say why

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1487,6 +1487,9 @@ sendFetchPRDetails,
       delegatedFromChief: daemonSession?.delegated_from_chief ?? false,
       ticketUnread: daemonSession?.ticket_unread ?? false,
       nudgeFiresAt: daemonSession?.nudge_fires_at,
+      // Dropped when a pane status overrides the state: the reason describes the
+      // resolver's answer, and a pane-derived state was not the resolver's.
+      state_reason: paneState ? undefined : daemonSession?.state_reason,
     };
   });
 

--- a/app/src/components/AttentionDrawer.tsx
+++ b/app/src/components/AttentionDrawer.tsx
@@ -13,6 +13,7 @@ interface AttentionDrawerProps {
     id: string;
     label: string;
     state: UISessionState;
+    state_reason?: string;
   }>;
   prs: DaemonPR[];
   onSelectSession: (id: string) => void;
@@ -53,7 +54,7 @@ export function AttentionDrawer({
                   data-state={s.state}
                   onClick={() => onSelectSession(s.id)}
                 >
-                  <StateIndicator state={s.state} size="sm" kind="session" seed={s.id} />
+                  <StateIndicator state={s.state} size="sm" kind="session" seed={s.id} reason={s.state_reason} />
                   <span className="item-name">{s.label}</span>
                 </div>
               );

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -30,6 +30,7 @@ interface LocalSession {
   delegatedFromChief?: boolean;
   ticketUnread?: boolean;
   nudgeFiresAt?: string;
+  state_reason?: string;
 }
 
 type SidebarWorkspace = WorkspaceWithSessions<LocalSession>;
@@ -1011,7 +1012,7 @@ export function Sidebar({
                       : undefined}
                     title={session.state === 'recoverable' ? 'Session will be recovered when opened' : undefined}
                   >
-                    <StateIndicator state={session.state} size="md" seed={session.id} />
+                    <StateIndicator state={session.state} size="md" seed={session.id} reason={session.state_reason} />
                     <span className="session-label">{session.label}</span>
                     {session.endpointName && (
                       <span className={`session-endpoint-badge status-${session.endpointStatus || 'connected'}`}>
@@ -1174,7 +1175,7 @@ export function Sidebar({
                           data-state={session.state}
                           onClick={() => onSelectSession(session.id)}
                         >
-                          <StateIndicator state={session.state} size="md" seed={session.id} />
+                          <StateIndicator state={session.state} size="md" seed={session.id} reason={session.state_reason} />
                           <span className="session-label">{session.label}</span>
                           {session.chiefOfStaff && <ChiefOfStaffBadge />}
                           {session.delegatedFromChief && <DelegatedFromChiefBadge />}

--- a/app/src/components/StateIndicator.test.tsx
+++ b/app/src/components/StateIndicator.test.tsx
@@ -70,6 +70,29 @@ describe('StateIndicator', () => {
     expect(indicator).toHaveClass('state-indicator--unknown');
   });
 
+  // An unknown badge with no explanation tells the user something is wrong and
+  // nothing about what, which is the dead end the resolver's reason replaces.
+  it('explains an unknown state from the resolver reason', () => {
+    render(<StateIndicator state="unknown" reason="stuck" />);
+    const indicator = screen.getByTestId('state-indicator');
+    expect(indicator).toHaveAttribute('title', expect.stringContaining('Stuck'));
+    expect(indicator.getAttribute('aria-label')).toContain('Stuck');
+  });
+
+  it('falls back rather than inventing an explanation for an unnamed reason', () => {
+    render(<StateIndicator state="unknown" reason="some_future_clause" />);
+    const indicator = screen.getByTestId('state-indicator');
+    expect(indicator).not.toHaveAttribute('title');
+    expect(indicator).toHaveAttribute('aria-label', 'state unknown');
+  });
+
+  // Every other state says what it means by its own name; a tooltip repeating
+  // that is noise.
+  it('does not explain states that speak for themselves', () => {
+    render(<StateIndicator state="working" reason="heartbeat_fresh" />);
+    expect(screen.getByTestId('state-indicator')).not.toHaveAttribute('title');
+  });
+
   it('renders launching state with emoji', () => {
     render(<StateIndicator state="launching" seed="session-emoji-seed" />);
     const indicator = screen.getByTestId('state-indicator');

--- a/app/src/components/StateIndicator.tsx
+++ b/app/src/components/StateIndicator.tsx
@@ -13,6 +13,8 @@ interface StateIndicatorProps {
   kind?: StateIndicatorKind;
   seed?: string;
   className?: string;
+  /** The resolver clause behind this state, from the daemon's `state_reason`. */
+  reason?: string;
 }
 
 export function StateIndicator({
@@ -21,18 +23,24 @@ export function StateIndicator({
   kind = 'session',
   seed,
   className = '',
+  reason,
 }: StateIndicatorProps) {
   // Normalize state for CSS class (waiting_input -> waiting-input)
   const stateClass = state.replace('_', '-');
   const launchingEmoji = state === 'launching' ? pickSessionEmoji(seed ?? '') : null;
+  // Only `unknown` explains itself. Every other state says what it means by its
+  // own name, and a tooltip repeating that is noise; `unknown` is the one badge
+  // that otherwise tells the user something is wrong and nothing about what.
+  const explanation = state === 'unknown' ? describeUnknownReason(reason) : undefined;
 
   return (
     <span
       className={`state-indicator state-indicator--${size} state-indicator--${stateClass} state-indicator--${kind} ${className}`.trim()}
       data-testid="state-indicator"
+      title={explanation}
       aria-label={
         state === 'unknown'
-          ? 'state unknown'
+          ? (explanation ?? 'state unknown')
           : state === 'scheduled'
             ? 'scheduled'
             : undefined
@@ -41,4 +49,19 @@ export function StateIndicator({
       {launchingEmoji}
     </span>
   );
+}
+
+// describeUnknownReason turns a resolver reason into something worth reading on
+// hover. Only the reasons that can actually reach `unknown` are named; anything
+// else falls back rather than inventing an explanation for a state the daemon
+// reached some other way.
+function describeUnknownReason(reason: string | undefined): string | undefined {
+  switch (reason) {
+    case 'stuck':
+      return 'Stuck — the agent has stopped reporting anything at all';
+    case 'no_evidence':
+      return 'No signal from this agent yet';
+    default:
+      return undefined;
+  }
 }

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -169,7 +169,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '192';
+export const PROTOCOL_VERSION = '193';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -858,6 +858,7 @@ export interface SessionElement {
     needs_review_after_long_run?: boolean;
     nudge_fires_at?:              string;
     state:                        SessionState;
+    state_reason?:                string;
     state_since:                  string;
     state_updated_at:             string;
     ticket_unread?:               boolean;
@@ -4113,6 +4114,7 @@ export interface Session {
     needs_review_after_long_run?: boolean;
     nudge_fires_at?:              string;
     state:                        SessionState;
+    state_reason?:                string;
     state_since:                  string;
     state_updated_at:             string;
     ticket_unread?:               boolean;
@@ -9259,6 +9261,7 @@ const typeMap: any = {
         { json: "needs_review_after_long_run", js: "needs_review_after_long_run", typ: u(undefined, true) },
         { json: "nudge_fires_at", js: "nudge_fires_at", typ: u(undefined, "") },
         { json: "state", js: "state", typ: r("SessionState") },
+        { json: "state_reason", js: "state_reason", typ: u(undefined, "") },
         { json: "state_since", js: "state_since", typ: "" },
         { json: "state_updated_at", js: "state_updated_at", typ: "" },
         { json: "ticket_unread", js: "ticket_unread", typ: u(undefined, true) },
@@ -11210,6 +11213,7 @@ const typeMap: any = {
         { json: "needs_review_after_long_run", js: "needs_review_after_long_run", typ: u(undefined, true) },
         { json: "nudge_fires_at", js: "nudge_fires_at", typ: u(undefined, "") },
         { json: "state", js: "state", typ: r("SessionState") },
+        { json: "state_reason", js: "state_reason", typ: u(undefined, "") },
         { json: "state_since", js: "state_since", typ: "" },
         { json: "state_updated_at", js: "state_updated_at", typ: "" },
         { json: "ticket_unread", js: "ticket_unread", typ: u(undefined, true) },

--- a/docs/plans/2026-07-25-agent-state-detection.md
+++ b/docs/plans/2026-07-25-agent-state-detection.md
@@ -491,6 +491,18 @@ being fixed as part of the current step.
   exactly one `state=working` line in `daemon.log`. This matters beyond tidiness —
   the pulse is the liveness signal the resolver's TTL design depends on, so the
   resolver phase must either un-gate it or grow its own heartbeat.
+- **An open bracket outranks stuck, so it can pin a session green forever.**
+  Found while publishing stuck. `TurnOpen` with `LastBusyAt` never set makes
+  `heartbeatSilentFor` return false — an agent that has never reported being
+  busy is deliberately not treated as silent — so the bracket-open clause returns
+  `working` on every tick and the stuck clause below it is unreachable. For
+  claude and codex this cannot happen, since both paint a busy title with every
+  turn. For an agent with hooks but no heartbeat it is exactly the stuck colour
+  the plan exists to remove, only now with a reason to believe it.
+  Consequently stuck is reachable today only when the brackets are the *only*
+  source that ever spoke and they have stopped too. Not fixed here: reordering
+  the clauses is a behavioural change to the resolver's trust model and deserves
+  its own treatment. Decide in phase 3.5.
 - **Neither guardian produced observable approval evidence, so the dwell has no
   live trigger yet.** Measured on `statedet` 2026-07-26, both agents launched
   with a reviewer and given a command that must escalate. Codex escalated (the

--- a/docs/plans/2026-07-25-agent-state-detection.md
+++ b/docs/plans/2026-07-25-agent-state-detection.md
@@ -771,7 +771,11 @@ its whitelist moved into the resolver, or stays screen-driven on purpose.
       whose only reader is one clause. Claude's hook still refreshes it per turn,
       which is what catches a mid-session mode change; codex reports no permission
       mode ever, so for codex the spawn record is the only source.
-- [ ] Stuck detection (`stuckAfter`, reason surfaced in the UI).
+- [x] Stuck detection (`stuckAfter`, reason surfaced in the UI). Sessions carry
+      `state_reason` (protocol 193) and the state indicator turns it into a
+      tooltip for `unknown` only. See the two findings above: stuck is reachable
+      today only when the brackets are the sole source that ever spoke, and an
+      open bracket outranks it.
 - [ ] `idleStaleAfter` staleness marking, folding in
       `needs_review_after_long_run`. Marked in phase 3; only *consumed* as an
       unsettle trigger by phase 4.
@@ -908,3 +912,8 @@ placeholder only; do not implement against it.
 - Use the OSC 0 turn summary as a live sidebar label.
 - Copilot CLI is out of scope here; it keeps the screen-scrape path until it has
   its own harness signals.
+- `state_reason` is not in the UI-automation bridge's session projection
+  (`serializeSession`), so harness scenarios cannot assert on it. The daemon side
+  is verifiable straight off the WebSocket and the rendering is unit-tested;
+  adding it to the projection means threading the field through the app's local
+  session model, which is not worth doing until a scenario needs it.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -211,8 +211,12 @@ type Daemon struct {
 	sessionEvidence     *sessionEvidenceTable
 	// sessionDwell holds transitions that have been resolved but not yet held
 	// long enough to publish.
-	sessionDwellOnce           sync.Once
-	sessionDwell               *dwellGate
+	sessionDwellOnce sync.Once
+	sessionDwell     *dwellGate
+	// sessionStateReason is the resolver clause behind each session's current
+	// state, carried to clients beside the state itself.
+	sessionStateReasonOnce     sync.Once
+	sessionStateReason         *sessionStateReasons
 	nudgeMu                    sync.Mutex
 	nudgeCountdowns            map[string]*nudgeCountdown                 // presence == a running (unpaused) countdown
 	unreadCache                map[string]bool                            // per-session unread ticket activity, for cheap broadcast decoration
@@ -1765,6 +1769,7 @@ func (d *Daemon) dropSessionRecord(sessionID string) {
 	// rebuilds the ring for an id nothing will ever clean up again.
 	d.forgetStateTrace(sessionID)
 	d.evidenceTable().forget(sessionID)
+	d.stateReasons().forget(sessionID)
 	// The dwell gate has to be cleared here rather than left to the resolve
 	// loop's own cleanup: that loop walks the evidence table, so forgetting the
 	// evidence row is exactly what stops it from ever visiting this session
@@ -3013,6 +3018,7 @@ func (d *Daemon) sessionForBroadcastWithChiefOfStaff(
 	} else {
 		clone.NeedsReviewAfterLongRun = nil
 	}
+	d.decorateSessionWithStateReason(clone)
 	d.decorateSessionWithNudge(clone)
 	d.decorateChiefOfStaffWithSessionID(clone, chiefOfStaffSessionID)
 	d.decorateDelegatedFromChief(clone, delegatedFromChief)

--- a/internal/daemon/session_evidence.go
+++ b/internal/daemon/session_evidence.go
@@ -491,12 +491,20 @@ func (d *Daemon) publishResolution(sessionID string, current protocol.SessionSta
 	// Recorded whether or not the state moves. A session that is already
 	// `unknown` still needs to say why, and the reason is the difference between
 	// a badge the user can act on and one that only says "something".
-	d.recordStateReason(sessionID, resolution)
+	reasonChanged := d.recordStateReason(sessionID, resolution)
 	if !resolverOwnedStates[current] || resolution.State == current {
 		// No transition is on the table, so nothing is waiting out a dwell.
 		// Dropping the wait here is what keeps a later transition from
 		// inheriting a clock that started before an unrelated one.
 		d.dwellGate().clear(sessionID)
+		// The reason still has to reach the client. It rides on session
+		// broadcasts, which otherwise only happen when the state itself moves —
+		// so a session that is already `unknown` and then goes silent would keep
+		// its old tooltip while the daemon knew it was stuck. Gated on the delta
+		// because the reason is recomputed every tick and almost never changes.
+		if reasonChanged && resolverOwnedStates[current] {
+			d.broadcastSessionStateChanged(sessionID)
+		}
 		return
 	}
 	// Last gate before publication on purpose: everything above decides what is

--- a/internal/daemon/session_evidence.go
+++ b/internal/daemon/session_evidence.go
@@ -479,11 +479,19 @@ func (d *Daemon) publishResolution(sessionID string, current protocol.SessionSta
 	// ReasonNoEvidence is not a finding, it is the absence of one, and it
 	// resolves to unknown. Publishing it would repaint every session the
 	// evidence table has not heard about yet — including ones a hook is about to
-	// describe perfectly well. Stuck is a real finding, but it is not published
-	// as a state yet.
-	if resolution.Reason == sessionstate.ReasonNoEvidence || resolution.Reason == sessionstate.ReasonStuck {
+	// describe perfectly well.
+	//
+	// Stuck is the opposite: a session whose evidence stopped moving entirely is
+	// the one case where `unknown` is the honest answer rather than a shrug, and
+	// leaving it in whatever color it last showed is the failure this whole plan
+	// exists to remove.
+	if resolution.Reason == sessionstate.ReasonNoEvidence {
 		return
 	}
+	// Recorded whether or not the state moves. A session that is already
+	// `unknown` still needs to say why, and the reason is the difference between
+	// a badge the user can act on and one that only says "something".
+	d.recordStateReason(sessionID, resolution)
 	if !resolverOwnedStates[current] || resolution.State == current {
 		// No transition is on the table, so nothing is waiting out a dwell.
 		// Dropping the wait here is what keeps a later transition from

--- a/internal/daemon/session_state_reason.go
+++ b/internal/daemon/session_state_reason.go
@@ -1,0 +1,88 @@
+package daemon
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/sessionstate"
+)
+
+// The state reason: which resolver clause produced the colour a session is
+// showing, carried to the client alongside the state itself.
+//
+// It exists because `unknown` is now a real answer rather than a shrug. A
+// session whose evidence has stopped moving entirely is reported stuck, and a
+// stuck badge with no reason is the same dead end as the stuck colour it
+// replaces — the user can see that something is wrong and nothing about what.
+//
+// It is not persisted. The resolver recomputes it every tick from evidence that
+// itself does not survive a restart, so a stored reason could only ever be a
+// claim about a daemon that no longer exists.
+
+// sessionStateReasons holds the most recent resolver reason per session.
+type sessionStateReasons struct {
+	mu      sync.Mutex
+	reasons map[string]string
+}
+
+func newSessionStateReasons() *sessionStateReasons {
+	return &sessionStateReasons{reasons: make(map[string]string)}
+}
+
+func (r *sessionStateReasons) set(sessionID, reason string) {
+	if r == nil || strings.TrimSpace(sessionID) == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reasons[sessionID] = reason
+}
+
+func (r *sessionStateReasons) get(sessionID string) string {
+	if r == nil {
+		return ""
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.reasons[sessionID]
+}
+
+func (r *sessionStateReasons) forget(sessionID string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.reasons, sessionID)
+}
+
+func (d *Daemon) stateReasons() *sessionStateReasons {
+	d.sessionStateReasonOnce.Do(func() {
+		d.sessionStateReason = newSessionStateReasons()
+	})
+	return d.sessionStateReason
+}
+
+// recordStateReason files the clause that produced the current resolution.
+func (d *Daemon) recordStateReason(sessionID string, resolution sessionstate.Resolution) {
+	d.stateReasons().set(sessionID, string(resolution.Reason))
+}
+
+// decorateSessionWithStateReason attaches the reason to an outgoing session.
+//
+// Only for states the resolver owns. A `launching` or `recoverable` session is
+// in that state because the spawn or revive path put it there, and labelling it
+// with whatever the resolver last thought would be a caption on the wrong photo.
+func (d *Daemon) decorateSessionWithStateReason(clone *protocol.Session) {
+	if clone == nil {
+		return
+	}
+	clone.StateReason = nil
+	if !resolverOwnedStates[clone.State] {
+		return
+	}
+	if reason := d.stateReasons().get(clone.ID); reason != "" {
+		clone.StateReason = protocol.Ptr(reason)
+	}
+}

--- a/internal/daemon/session_state_reason.go
+++ b/internal/daemon/session_state_reason.go
@@ -30,13 +30,21 @@ func newSessionStateReasons() *sessionStateReasons {
 	return &sessionStateReasons{reasons: make(map[string]string)}
 }
 
-func (r *sessionStateReasons) set(sessionID, reason string) {
+// set files the reason and reports whether it differs from the one already
+// held. The delta is what keeps the one-second resolver tick from turning into
+// a broadcast parade: the reason is recomputed every tick and almost never
+// changes.
+func (r *sessionStateReasons) set(sessionID, reason string) bool {
 	if r == nil || strings.TrimSpace(sessionID) == "" {
-		return
+		return false
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if r.reasons[sessionID] == reason {
+		return false
+	}
 	r.reasons[sessionID] = reason
+	return true
 }
 
 func (r *sessionStateReasons) get(sessionID string) string {
@@ -64,9 +72,10 @@ func (d *Daemon) stateReasons() *sessionStateReasons {
 	return d.sessionStateReason
 }
 
-// recordStateReason files the clause that produced the current resolution.
-func (d *Daemon) recordStateReason(sessionID string, resolution sessionstate.Resolution) {
-	d.stateReasons().set(sessionID, string(resolution.Reason))
+// recordStateReason files the clause that produced the current resolution, and
+// reports whether that is news.
+func (d *Daemon) recordStateReason(sessionID string, resolution sessionstate.Resolution) bool {
+	return d.stateReasons().set(sessionID, string(resolution.Reason))
 }
 
 // decorateSessionWithStateReason attaches the reason to an outgoing session.

--- a/internal/daemon/session_state_reason_test.go
+++ b/internal/daemon/session_state_reason_test.go
@@ -91,6 +91,62 @@ func TestTheReasonIsOmittedForStatesTheResolverDoesNotOwn(t *testing.T) {
 	}
 }
 
+// The reason rides on session broadcasts, which otherwise only happen when the
+// state itself moves. A session that is already `unknown` and then goes silent
+// would keep its old tooltip while the daemon knew it was stuck — the exact
+// explanation this is supposed to deliver, stranded inside the daemon.
+func TestAReasonChangeReachesClientsWithoutAStateChange(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-reason-delta"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentCodex, protocol.SessionStateWorking)
+
+	// The session is already `unknown` — a failed pane, a session the daemon
+	// never heard from — so the state has nowhere left to move.
+	now := time.Now()
+	d.applyState(sessionStateChange{
+		sessionID: id,
+		state:     string(protocol.SessionStateUnknown),
+		cause:     liveSignal{},
+	})
+	if state := d.store.Get(id).State; state != protocol.SessionStateUnknown {
+		t.Fatalf("state %q, want unknown before the reason changes", state)
+	}
+
+	capture := captureBroadcasts(d)
+
+	// The brackets open and close with nothing else ever heard, then stop too:
+	// still `unknown`, but now for a reason the user can act on.
+	d.recordBracketEvidence(id, protocol.StateWorking)
+	d.recordBracketEvidence(id, protocol.StateIdle)
+	policy := sessionstate.PolicyFor(string(protocol.SessionAgentCodex))
+	at := now.Add(policy.StuckAfter + time.Second)
+	d.resolveAllSessions(at)
+
+	if state := d.store.Get(id).State; state != protocol.SessionStateUnknown {
+		t.Fatalf("state %q, want unknown still: this test is about the reason, not the state", state)
+	}
+	var reason string
+	for _, event := range capture.snapshot() {
+		if event.Session != nil && event.Session.ID == id {
+			reason = protocol.Deref(event.Session.StateReason)
+		}
+	}
+	if reason != string(sessionstate.ReasonStuck) {
+		t.Fatalf("broadcast state_reason %q, want stuck: the explanation never left the daemon", reason)
+	}
+
+	// And it does not become a parade. The reason is recomputed every tick and
+	// almost never changes, so an unchanged one must broadcast nothing.
+	quiet := captureBroadcasts(d)
+	d.resolveAllSessions(at.Add(time.Second))
+	d.resolveAllSessions(at.Add(2 * time.Second))
+	for _, event := range quiet.snapshot() {
+		if event.Session != nil && event.Session.ID == id {
+			t.Fatal("an unchanged reason broadcast anyway")
+		}
+	}
+}
+
 // The reason is per-session runtime state with a cleanup path, like every other
 // map hanging off the daemon.
 func TestTheReasonIsForgottenWithTheSession(t *testing.T) {

--- a/internal/daemon/session_state_reason_test.go
+++ b/internal/daemon/session_state_reason_test.go
@@ -1,0 +1,114 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/pty"
+	"github.com/victorarias/attn/internal/sessionstate"
+)
+
+// A session whose evidence has stopped moving entirely is the one case where
+// `unknown` is the honest answer. Leaving it in whatever colour it last showed
+// is the stuck-colour failure the whole plan exists to remove.
+func TestASessionWhoseEvidenceStoppedMovingIsReportedStuck(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-stuck"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentCodex, protocol.SessionStateWorking)
+
+	// A turn opened and closed, and nothing else was ever heard: no title
+	// heartbeat, no verdict, no screen. The brackets are the only thing that
+	// ever spoke, and now they have stopped too.
+	d.recordBracketEvidence(id, protocol.StateWorking)
+	d.recordBracketEvidence(id, protocol.StateIdle)
+	now := time.Now()
+
+	policy := sessionstate.PolicyFor(string(protocol.SessionAgentCodex))
+	d.resolveAllSessions(now.Add(policy.StuckAfter + time.Second))
+
+	session := d.store.Get(id)
+	if session.State != protocol.SessionStateUnknown {
+		t.Fatalf("state %q, want unknown after total evidence silence", session.State)
+	}
+	if got := protocol.Deref(d.sessionForBroadcast(session).StateReason); got != string(sessionstate.ReasonStuck) {
+		t.Fatalf("state_reason %q, want stuck: an unknown badge with no reason is the dead end it replaces", got)
+	}
+}
+
+// A quiet agent is not a stuck one. Both claude and codex repaint their title
+// while parked at the prompt, so an idle session keeps producing evidence and
+// must never be escalated to an attention-demanding colour for sitting still.
+func TestAnIdleSessionStillReportingIsNotStuck(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-idle-quiet"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentCodex, protocol.SessionStateWorking)
+
+	now := time.Now()
+	d.recordBracketEvidence(id, protocol.StateWorking)
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", At: now})
+	d.recordBracketEvidence(id, protocol.StateIdle)
+
+	policy := sessionstate.PolicyFor(string(protocol.SessionAgentCodex))
+	// Well past the stuck window, but the agent keeps painting not-busy frames.
+	for i := 1; i <= 3; i++ {
+		at := now.Add(time.Duration(i) * policy.StuckAfter)
+		d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "not_busy", At: at})
+		d.resolveAllSessions(at.Add(time.Second))
+	}
+
+	if state := d.store.Get(id).State; state != protocol.SessionStateIdle {
+		t.Fatalf("state %q, want idle: a reporting agent is not a stuck one", state)
+	}
+}
+
+// The reason describes the resolver's answer, so it must not be attached to a
+// state the resolver does not own — `launching` belongs to spawn and
+// `recoverable` to the revive path, and captioning either with the resolver's
+// last thought describes a different photo.
+func TestTheReasonIsOmittedForStatesTheResolverDoesNotOwn(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-unowned"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+
+	now := time.Now()
+	d.recordBracketEvidence(id, protocol.StateWorking)
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", At: now})
+	d.resolveAllSessions(now.Add(time.Second))
+
+	if got := protocol.Deref(d.sessionForBroadcast(d.store.Get(id)).StateReason); got == "" {
+		t.Fatal("no reason recorded for a resolver-owned state, so the omission below proves nothing")
+	}
+
+	d.applyState(sessionStateChange{
+		sessionID: id,
+		state:     string(protocol.SessionStateRecoverable),
+		cause:     liveSignal{},
+	})
+
+	if got := protocol.Deref(d.sessionForBroadcast(d.store.Get(id)).StateReason); got != "" {
+		t.Fatalf("state_reason %q on a recoverable session, want none", got)
+	}
+}
+
+// The reason is per-session runtime state with a cleanup path, like every other
+// map hanging off the daemon.
+func TestTheReasonIsForgottenWithTheSession(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-reason-closed"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+
+	now := time.Now()
+	d.recordBracketEvidence(id, protocol.StateWorking)
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", At: now})
+	d.resolveAllSessions(now.Add(time.Second))
+	if d.stateReasons().get(id) == "" {
+		t.Fatal("no reason was recorded, so the cleanup below proves nothing")
+	}
+
+	d.dropSessionRecord(id)
+
+	if got := d.stateReasons().get(id); got != "" {
+		t.Fatalf("reason %q survived the session", got)
+	}
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "192"
+const ProtocolVersion = "193"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -3935,6 +3935,9 @@ type Session struct {
 	// State corresponds to the JSON schema field "state".
 	State SessionState `json:"state"`
 
+	// StateReason corresponds to the JSON schema field "state_reason".
+	StateReason *string `json:"state_reason,omitempty,omitzero"`
+
 	// StateSince corresponds to the JSON schema field "state_since".
 	StateSince string `json:"state_since"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -131,6 +131,7 @@ model Session {
   state: SessionState;
   state_since: string;          // ISO timestamp, always set
   state_updated_at: string;     // ISO timestamp, always set
+  state_reason?: string;        // Why the resolver reached this state (e.g. "stuck", "classifier_verdict"); absent for states it does not own
   needs_review_after_long_run?: boolean; // True when a 5m+ run finished and awaits user visualization
   chief_of_staff?: boolean;     // True when this session holds the profile-wide coordinator role
   delegated_from_chief?: boolean; // True when this session was delegated from the chief of staff (assignee of a chief-authored ticket)


### PR DESCRIPTION
Second slice of phase 3 of `docs/plans/2026-07-25-agent-state-detection.md`.
The third item — `idleStaleAfter` staleness marking — is not in this PR.

## The change

A session whose evidence has stopped moving entirely was already computed as
stuck by the resolver, and then discarded: `publishResolution` dropped
`ReasonStuck` on the floor, leaving the session in whatever colour it last
showed. That is the exact failure the resolver exists to remove. It is now
published as `unknown`, which the UI already treats as needing attention.

An `unknown` badge with no explanation is the same dead end as the stuck colour
it replaces, so the reason travels with it. Sessions carry `state_reason`
(protocol 193) and the state indicator turns it into a tooltip — for `unknown`
only, since every other state says what it means by its own name.

The reason is not persisted. It is recomputed every tick from evidence that does
not survive a restart, so a stored one could only describe a daemon that no
longer exists. It is attached only to states the resolver owns: `launching`
belongs to spawn and `recoverable` to the revive path, and captioning either
with the resolver's last thought describes a different photo.

## Two findings, logged in the plan rather than fixed here

**An open bracket outranks stuck.** `TurnOpen` with `LastBusyAt` never set makes
`heartbeatSilentFor` return false — an agent that has never reported being busy
is deliberately not treated as silent — so the bracket-open clause returns
`working` every tick and the stuck clause below it is unreachable. Claude and
codex both paint a busy title with every turn, so it cannot bite there; for an
agent with hooks and no heartbeat it is a session pinned green forever.
Reordering the clauses changes the resolver's trust model and deserves its own
treatment, so it is a phase 3.5 decision.

Consequently stuck is reachable today only when the brackets are the *only*
source that ever spoke and they have stopped too, which is what the test models.

**`state_reason` is not in the harness session projection**, so scenarios cannot
assert on it. Logged as a follow-up; threading it through the app's local session
model is not worth doing until a scenario needs it.

## Live verification

Profile `statedet`, full install, packaged app, protocol 193 on both sides.

Read straight off the daemon WebSocket:

```
570dda3c state=idle       reason=classifier_verdict
f3228dc9 state=launching  reason=(none)
27f7b053 state=launching  reason=(none)
```

The reason is on the wire with the right value, and correctly absent for
`launching`, which the resolver does not own.

The risk this change carries is spurious attention badges — `unknown` is an
attention state, so a session wrongly called stuck would nag. Across every live
run on this profile the daemon applied `unknown` zero times, and a claude session
watched well past the 90s stuck window settled to `idle` and stayed there.

What the live runs do **not** show is the tooltip on a genuinely stuck session:
producing one needs an agent with brackets and no heartbeat, which neither claude
nor codex can be made into. The rendering is covered by component tests and the
daemon half is proven on the wire.