### PR TITLE
Phase 3: mark an unread idle result stale, and stop calling a never-prompted session stuck

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -169,7 +169,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '193';
+export const PROTOCOL_VERSION = '194';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -851,6 +851,7 @@ export interface SessionElement {
     directory:                    string;
     endpoint_id?:                 string;
     id:                           string;
+    idle_stale?:                  boolean;
     is_worktree?:                 boolean;
     label:                        string;
     last_seen:                    string;
@@ -4107,6 +4108,7 @@ export interface Session {
     directory:                    string;
     endpoint_id?:                 string;
     id:                           string;
+    idle_stale?:                  boolean;
     is_worktree?:                 boolean;
     label:                        string;
     last_seen:                    string;
@@ -9254,6 +9256,7 @@ const typeMap: any = {
         { json: "directory", js: "directory", typ: "" },
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
         { json: "id", js: "id", typ: "" },
+        { json: "idle_stale", js: "idle_stale", typ: u(undefined, true) },
         { json: "is_worktree", js: "is_worktree", typ: u(undefined, true) },
         { json: "label", js: "label", typ: "" },
         { json: "last_seen", js: "last_seen", typ: "" },
@@ -11206,6 +11209,7 @@ const typeMap: any = {
         { json: "directory", js: "directory", typ: "" },
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
         { json: "id", js: "id", typ: "" },
+        { json: "idle_stale", js: "idle_stale", typ: u(undefined, true) },
         { json: "is_worktree", js: "is_worktree", typ: u(undefined, true) },
         { json: "label", js: "label", typ: "" },
         { json: "last_seen", js: "last_seen", typ: "" },

--- a/docs/plans/2026-07-25-agent-state-detection.md
+++ b/docs/plans/2026-07-25-agent-state-detection.md
@@ -523,6 +523,15 @@ being fixed as part of the current step.
   mode genuinely governs approval routing. The general shape — a field that means
   something for one agent and is filler for another, read without asking which
   agent sent it — is worth a sweep in phase 3.5.
+- **A session that has never taken a turn reads as `working` forever.** Visible
+  in the same live run that produced the stuck fix: a claude session created and
+  left alone sat at `working` for fourteen minutes with no reason attached. It
+  comes from the `worker_info` replay applying `working` at spawn, and no clause
+  can retire it — the settle clauses all require a turn to have opened, on
+  purpose. Not fixed with the stuck guard, which only stops the wrong colour from
+  getting worse. The honest answer for a launched-and-quiet agent is probably
+  `idle`, but saying so means deciding what evidence proves an agent has finished
+  booting, which is a phase 3.5 question.
 - **"Read" is coarser than it sounds.** The staleness mark clears when the
   daemon is told a session was visualized, or while it is the selected session.
   Both mean "this session was on screen", not "Victor read the result" — an app

--- a/docs/plans/2026-07-25-agent-state-detection.md
+++ b/docs/plans/2026-07-25-agent-state-detection.md
@@ -787,6 +787,15 @@ its whitelist moved into the resolver, or stays screen-driven on purpose.
       tooltip for `unknown` only. See the two findings above: stuck is reachable
       today only when the brackets are the sole source that ever spoke, and an
       open bracket outranks it.
+      **Corrected 2026-07-26.** As shipped it also fired on a session that had
+      been launched and never prompted. Witnessed live on `statedet`: a claude
+      session painted one `not_busy` title frame at launch and nothing after, and
+      turned `unknown` ninety seconds later while sitting at a healthy empty
+      prompt. Claude paints its title on activity, and a session that has taken
+      no turn has no Stop and no `idle_prompt` notification to contradict the
+      verdict — the settled ones are unstickable only because that notification
+      arrives. Stuck now requires a turn to have opened: silence before the first
+      turn is nothing to report, not a stopped report.
 - [x] `idleStaleAfter` staleness marking. Sessions carry `idle_stale`
       (protocol 194) when an idle result has sat past `IdleStaleAfter` with
       nobody looking at it; nothing consumes it yet.

--- a/docs/plans/2026-07-25-agent-state-detection.md
+++ b/docs/plans/2026-07-25-agent-state-detection.md
@@ -523,6 +523,17 @@ being fixed as part of the current step.
   mode genuinely governs approval routing. The general shape — a field that means
   something for one agent and is filler for another, read without asking which
   agent sent it — is worth a sweep in phase 3.5.
+- **"Read" is coarser than it sounds.** The staleness mark clears when the
+  daemon is told a session was visualized, or while it is the selected session.
+  Both mean "this session was on screen", not "Victor read the result" — an app
+  left open on a session all night keeps it permanently fresh, and a session read
+  in a background window that never reports selection stays stale. Good enough
+  for a mark nothing consumes; phase 4 should decide whether the attention
+  projection needs window focus in the signal before it acts on this.
+- **Two overlapping "you have not looked at this yet" mechanisms now exist.**
+  `needs_review_after_long_run` and `idle_stale`. See the phase 3 deviation
+  above: keeping both was the conservative call, but shipping both to phase 4
+  would mean two answers to the same question.
 - **The copilot screen heuristics look stale against copilot 1.0.73.**
   `classifyCopilotScreen` keys off `defaultStateHeuristics` — prompt markers
   ` › ` / ` > ` / `❯ ` and status markers "context left" / "for shortcuts". The
@@ -776,9 +787,28 @@ its whitelist moved into the resolver, or stays screen-driven on purpose.
       tooltip for `unknown` only. See the two findings above: stuck is reachable
       today only when the brackets are the sole source that ever spoke, and an
       open bracket outranks it.
-- [ ] `idleStaleAfter` staleness marking, folding in
-      `needs_review_after_long_run`. Marked in phase 3; only *consumed* as an
-      unsettle trigger by phase 4.
+- [x] `idleStaleAfter` staleness marking. Sessions carry `idle_stale`
+      (protocol 194) when an idle result has sat past `IdleStaleAfter` with
+      nobody looking at it; nothing consumes it yet.
+      **Deviation — the fold is deferred, not done.** The item said "folding in
+      `needs_review_after_long_run`". That mechanism is live and user-visible (a
+      5m+ run defers its classification until the session is viewed), and its
+      replacement has no consumer until phase 4, so folding it in now would
+      delete working behaviour and put nothing in its place. Both exist; phase
+      3.5 or 4 decides which survives. They are not duplicates: the existing one
+      measures how long the *run* took, the new one measures how long the
+      *result* has gone unread.
+      **Deviation — the window is a judgement, not a measurement.** The plan
+      names no duration. `defaultIdleStaleAfter` is 10 minutes, picked so that
+      stepping away from a session is not treated as forgetting it while a result
+      Victor asked for is not lost for a working day. Nothing depends on the
+      exact number until phase 4 gives it a consumer.
+      **Deviation — staleness is not a `Resolve` clause.** `IdleStale` is a
+      separate pure function taking the read time, and the daemon tick applies
+      it. The resolver answers what the agent is doing, and the agent is doing
+      nothing either way; staleness is a fact about who has looked, which the
+      evidence table does not and should not know. Same reasoning that put the
+      dwell in the daemon.
 
 Phases 0–3 are shippable on their own and are judged on one question: are the
 colors right?
@@ -912,6 +942,9 @@ placeholder only; do not implement against it.
 - Use the OSC 0 turn summary as a live sidebar label.
 - Copilot CLI is out of scope here; it keeps the screen-scrape path until it has
   its own harness signals.
+- `idle_stale` has no consumer. It is broadcast and nothing reads it — by design,
+  since the attention projection is phase 4. If phase 4 is dropped or changes
+  shape, delete the field rather than leaving a wire nothing is on the end of.
 - `state_reason` is not in the UI-automation bridge's session projection
   (`serializeSession`), so harness scenarios cannot assert on it. The daemon side
   is verifiable straight off the WebSocket and the rendering is unit-tested;

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -215,8 +215,12 @@ type Daemon struct {
 	sessionDwell     *dwellGate
 	// sessionStateReason is the resolver clause behind each session's current
 	// state, carried to clients beside the state itself.
-	sessionStateReasonOnce     sync.Once
-	sessionStateReason         *sessionStateReasons
+	sessionStateReasonOnce sync.Once
+	sessionStateReason     *sessionStateReasons
+	// sessionReadTimes is when the user last saw each session's output, and the
+	// idle-staleness mark derived from it.
+	sessionReadTimesOnce       sync.Once
+	sessionReadTimes           *sessionReadTimes
 	nudgeMu                    sync.Mutex
 	nudgeCountdowns            map[string]*nudgeCountdown                 // presence == a running (unpaused) countdown
 	unreadCache                map[string]bool                            // per-session unread ticket activity, for cheap broadcast decoration
@@ -1770,6 +1774,7 @@ func (d *Daemon) dropSessionRecord(sessionID string) {
 	d.forgetStateTrace(sessionID)
 	d.evidenceTable().forget(sessionID)
 	d.stateReasons().forget(sessionID)
+	d.readTimes().forget(sessionID)
 	// The dwell gate has to be cleared here rather than left to the resolve
 	// loop's own cleanup: that loop walks the evidence table, so forgetting the
 	// evidence row is exactly what stops it from ever visiting this session
@@ -2584,8 +2589,12 @@ func (d *Daemon) classifyOrDeferAfterStop(sessionID, transcriptPath string) {
 
 func (d *Daemon) handleSessionVisualized(sessionID string) {
 	// The frontend reports the focused session here, so this doubles as our
-	// signal for "currently selected session" (used by `attn open`).
+	// signal for "currently selected session" (used by `attn open`) and as the
+	// moment attn can say a session's output has been seen. The tick keeps the
+	// selected session read while it stays on screen; this is what survives the
+	// user switching away from it.
 	d.setSelectedSession(sessionID)
+	d.markSessionRead(sessionID, time.Now())
 
 	transcriptPath, shouldClassify := d.consumeNeedsReviewAfterLongRun(sessionID)
 	if !shouldClassify {
@@ -3019,6 +3028,7 @@ func (d *Daemon) sessionForBroadcastWithChiefOfStaff(
 		clone.NeedsReviewAfterLongRun = nil
 	}
 	d.decorateSessionWithStateReason(clone)
+	d.decorateSessionWithIdleStale(clone)
 	d.decorateSessionWithNudge(clone)
 	d.decorateChiefOfStaffWithSessionID(clone, chiefOfStaffSessionID)
 	d.decorateDelegatedFromChief(clone, delegatedFromChief)

--- a/internal/daemon/session_evidence.go
+++ b/internal/daemon/session_evidence.go
@@ -436,6 +436,10 @@ func (d *Daemon) resolveAllSessions(now time.Time) {
 		policy := sessionstate.PolicyFor(string(session.Agent))
 		resolution := sessionstate.Resolve(evidence, policy, now)
 		d.publishResolution(sessionID, session.State, resolution, sessionstate.DwellFor(resolution.State, evidence, policy), now)
+		// After publication, and re-read from the store: staleness is a question
+		// about the state the session actually ended up in, which the line above
+		// may have just changed.
+		d.refreshIdleStaleness(d.store.Get(sessionID), policy, now)
 	}
 }
 

--- a/internal/daemon/session_staleness.go
+++ b/internal/daemon/session_staleness.go
@@ -1,0 +1,136 @@
+package daemon
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/sessionstate"
+)
+
+// Idle staleness: a finished turn that nobody has looked at since it finished.
+//
+// It is a mark, not a state. The session is idle and stays idle; what the mark
+// adds is that the idle answer is no longer fresh. Nothing consumes it yet — the
+// attention projection is what will turn it into a reason to unsettle a session
+// — so today it exists to be observed, and to make the read time something the
+// daemon actually tracks rather than something a later phase has to invent.
+//
+// Like the state reason, it is not persisted. It is derived every tick from the
+// session's own `state_since` plus a read time that only means anything for the
+// daemon that observed the reads.
+
+// sessionReadTimes holds when each session's output was last seen by the user.
+type sessionReadTimes struct {
+	mu    sync.Mutex
+	read  map[string]time.Time
+	stale map[string]bool
+}
+
+func newSessionReadTimes() *sessionReadTimes {
+	return &sessionReadTimes{read: make(map[string]time.Time), stale: make(map[string]bool)}
+}
+
+func (r *sessionReadTimes) markRead(sessionID string, at time.Time) {
+	if r == nil || strings.TrimSpace(sessionID) == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing, ok := r.read[sessionID]; ok && !at.After(existing) {
+		return
+	}
+	r.read[sessionID] = at
+}
+
+func (r *sessionReadTimes) lastRead(sessionID string) time.Time {
+	if r == nil {
+		return time.Time{}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.read[sessionID]
+}
+
+// setStale files the mark and reports whether it differs from the one already
+// held, so a tick that changes nothing broadcasts nothing.
+func (r *sessionReadTimes) setStale(sessionID string, stale bool) bool {
+	if r == nil || strings.TrimSpace(sessionID) == "" {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.stale[sessionID] == stale {
+		return false
+	}
+	if stale {
+		r.stale[sessionID] = true
+	} else {
+		delete(r.stale, sessionID)
+	}
+	return true
+}
+
+func (r *sessionReadTimes) isStale(sessionID string) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.stale[sessionID]
+}
+
+func (r *sessionReadTimes) forget(sessionID string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.read, sessionID)
+	delete(r.stale, sessionID)
+}
+
+func (d *Daemon) readTimes() *sessionReadTimes {
+	d.sessionReadTimesOnce.Do(func() {
+		d.sessionReadTimes = newSessionReadTimes()
+	})
+	return d.sessionReadTimes
+}
+
+// markSessionRead records that the user has seen this session's output now.
+func (d *Daemon) markSessionRead(sessionID string, at time.Time) {
+	d.readTimes().markRead(sessionID, at)
+}
+
+// refreshIdleStaleness recomputes one session's mark and broadcasts a change.
+//
+// The session the UI is currently showing is read continuously, not at the
+// moment it was selected: a turn that finishes while Victor is watching it has
+// been seen, and there is no second `session_visualized` to say so.
+func (d *Daemon) refreshIdleStaleness(session *protocol.Session, policy sessionstate.Policy, now time.Time) {
+	if session == nil {
+		return
+	}
+	if session.ID == d.currentlySelectedSession() {
+		d.markSessionRead(session.ID, now)
+	}
+	stateSince := protocol.Timestamp(session.StateSince).Time()
+	stale := sessionstate.IdleStale(session.State, stateSince, d.readTimes().lastRead(session.ID), policy, now)
+	if d.readTimes().setStale(session.ID, stale) {
+		d.broadcastSessionStateChanged(session.ID)
+	}
+}
+
+// decorateSessionWithIdleStale attaches the mark to an outgoing session. The
+// field is omitted rather than sent false: absent and not-stale are the same
+// claim, and a wire that says so twice invites a client to tell them apart.
+func (d *Daemon) decorateSessionWithIdleStale(clone *protocol.Session) {
+	if clone == nil {
+		return
+	}
+	clone.IdleStale = nil
+	if d.readTimes().isStale(clone.ID) {
+		clone.IdleStale = protocol.Ptr(true)
+	}
+}

--- a/internal/daemon/session_staleness_test.go
+++ b/internal/daemon/session_staleness_test.go
@@ -1,0 +1,259 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/pty"
+	"github.com/victorarias/attn/internal/sessionstate"
+)
+
+// stalenessSession stages a session that settled at stateSince and has never
+// been looked at since.
+func stalenessSession(t *testing.T, d *Daemon, id string, state protocol.SessionState, stateSince time.Time) {
+	t.Helper()
+	directory := t.TempDir()
+	workspaceID := "workspace-" + id
+	addTestWorkspace(d, workspaceID, directory)
+	stamp := stateSince.Format(time.RFC3339Nano)
+	d.store.Add(&protocol.Session{
+		ID:             id,
+		Label:          id,
+		Agent:          protocol.SessionAgentClaude,
+		Directory:      directory,
+		State:          state,
+		StateSince:     stamp,
+		StateUpdatedAt: stamp,
+		LastSeen:       stamp,
+	})
+	d.associateSessionWithWorkspace(id, workspaceID)
+}
+
+func stalePolicy() sessionstate.Policy {
+	return sessionstate.PolicyFor(string(protocol.SessionAgentClaude))
+}
+
+// The point of the mark: a result Victor asked for, finished, and never came
+// back to. Nothing else in the system remembers that nobody looked.
+func TestAnIdleResultNobodyReadGoesStale(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-unread"
+	policy := stalePolicy()
+	settledAt := time.Now()
+	stalenessSession(t, d, id, protocol.SessionStateIdle, settledAt)
+
+	d.refreshIdleStaleness(d.store.Get(id), policy, settledAt.Add(policy.IdleStaleAfter/2))
+	if protocol.Deref(d.sessionForBroadcast(d.store.Get(id)).IdleStale) {
+		t.Fatal("marked stale inside the window: a result is not forgotten the moment it lands")
+	}
+
+	d.refreshIdleStaleness(d.store.Get(id), policy, settledAt.Add(policy.IdleStaleAfter+time.Second))
+	if !protocol.Deref(d.sessionForBroadcast(d.store.Get(id)).IdleStale) {
+		t.Fatal("an idle result nobody read never went stale")
+	}
+}
+
+// Reading it is what stops the clock. Without this the mark would fire on every
+// finished session regardless of whether Victor had already seen the answer,
+// which is noise rather than attention.
+func TestAReadResultNeverGoesStale(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-read"
+	policy := stalePolicy()
+	settledAt := time.Now()
+	stalenessSession(t, d, id, protocol.SessionStateIdle, settledAt)
+
+	d.handleSessionVisualized(id)
+
+	d.refreshIdleStaleness(d.store.Get(id), policy, settledAt.Add(2*policy.IdleStaleAfter))
+	if protocol.Deref(d.sessionForBroadcast(d.store.Get(id)).IdleStale) {
+		t.Fatal("a session read after it settled went stale anyway")
+	}
+}
+
+// Reading a session is a fact about that session, not about which one happens to
+// be on screen right now. Switching away is what normally follows reading a
+// finished result, and it must not undo having read it.
+func TestReadingASessionSurvivesSwitchingAwayFromIt(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-read-then-left"
+	policy := stalePolicy()
+	settledAt := time.Now()
+	stalenessSession(t, d, id, protocol.SessionStateIdle, settledAt)
+	stalenessSession(t, d, "sess-elsewhere", protocol.SessionStateWorking, settledAt)
+
+	d.handleSessionVisualized(id)
+	d.handleSessionVisualized("sess-elsewhere")
+
+	d.refreshIdleStaleness(d.store.Get(id), policy, settledAt.Add(2*policy.IdleStaleAfter))
+	if protocol.Deref(d.sessionForBroadcast(d.store.Get(id)).IdleStale) {
+		t.Fatal("a session that was read went stale because the user moved on to another one")
+	}
+}
+
+// A read that happened before the turn finished says nothing about the result:
+// Victor looked, walked away, and the agent finished afterwards.
+func TestAReadFromBeforeTheResultDoesNotCount(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-read-early"
+	policy := stalePolicy()
+	settledAt := time.Now()
+	stalenessSession(t, d, id, protocol.SessionStateIdle, settledAt)
+
+	d.markSessionRead(id, settledAt.Add(-time.Hour))
+
+	d.refreshIdleStaleness(d.store.Get(id), policy, settledAt.Add(policy.IdleStaleAfter+time.Second))
+	if !protocol.Deref(d.sessionForBroadcast(d.store.Get(id)).IdleStale) {
+		t.Fatal("a read from before the turn finished counted as having seen its result")
+	}
+}
+
+// The session on screen is being read continuously. A turn that finishes while
+// Victor is watching it produces no `session_visualized` of its own, so without
+// this the session he is literally looking at would go stale.
+func TestTheSessionOnScreenIsReadContinuously(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-onscreen"
+	policy := stalePolicy()
+	settledAt := time.Now()
+	stalenessSession(t, d, id, protocol.SessionStateIdle, settledAt)
+
+	// Selected long before the turn ended, and never re-reported since.
+	d.setSelectedSession(id)
+	d.markSessionRead(id, settledAt.Add(-time.Hour))
+
+	d.refreshIdleStaleness(d.store.Get(id), policy, settledAt.Add(policy.IdleStaleAfter+time.Second))
+	if protocol.Deref(d.sessionForBroadcast(d.store.Get(id)).IdleStale) {
+		t.Fatal("the session on screen went stale while it was on screen")
+	}
+}
+
+// Staleness is about a finished result. A session that is still working has
+// produced nothing to miss, however long it has been running.
+func TestOnlyAnIdleSessionCanGoStale(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-working"
+	policy := stalePolicy()
+	startedAt := time.Now()
+	stalenessSession(t, d, id, protocol.SessionStateWorking, startedAt)
+
+	d.refreshIdleStaleness(d.store.Get(id), policy, startedAt.Add(10*policy.IdleStaleAfter))
+	if protocol.Deref(d.sessionForBroadcast(d.store.Get(id)).IdleStale) {
+		t.Fatal("a long-running turn was marked stale: it has produced nothing to miss")
+	}
+}
+
+// The mark rides on session broadcasts, which otherwise only happen when the
+// state moves — and staleness is precisely the case where it does not. Without
+// its own delta broadcast the daemon would know a result had been forgotten and
+// no client would ever hear it.
+func TestGoingStaleReachesClientsWithoutAStateChange(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-stale-delta"
+	policy := stalePolicy()
+	settledAt := time.Now()
+	stalenessSession(t, d, id, protocol.SessionStateIdle, settledAt)
+
+	capture := captureBroadcasts(d)
+	d.refreshIdleStaleness(d.store.Get(id), policy, settledAt.Add(policy.IdleStaleAfter+time.Second))
+
+	var delivered bool
+	for _, event := range capture.snapshot() {
+		if event.Session != nil && event.Session.ID == id && protocol.Deref(event.Session.IdleStale) {
+			delivered = true
+		}
+	}
+	if !delivered {
+		t.Fatal("the mark never left the daemon")
+	}
+
+	// And it does not become a parade: the tick recomputes it every second.
+	quiet := captureBroadcasts(d)
+	d.refreshIdleStaleness(d.store.Get(id), policy, settledAt.Add(policy.IdleStaleAfter+2*time.Second))
+	for _, event := range quiet.snapshot() {
+		if event.Session != nil && event.Session.ID == id {
+			t.Fatal("an unchanged mark broadcast anyway")
+		}
+	}
+}
+
+// A stale session Victor finally opens is no longer stale, and the client has to
+// be told — otherwise the mark is a one-way door.
+func TestReadingAStaleSessionClearsTheMark(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-stale-cleared"
+	policy := stalePolicy()
+	settledAt := time.Now()
+	stalenessSession(t, d, id, protocol.SessionStateIdle, settledAt)
+
+	now := settledAt.Add(policy.IdleStaleAfter + time.Second)
+	d.refreshIdleStaleness(d.store.Get(id), policy, now)
+	if !protocol.Deref(d.sessionForBroadcast(d.store.Get(id)).IdleStale) {
+		t.Fatal("not stale to begin with, so clearing it below proves nothing")
+	}
+
+	capture := captureBroadcasts(d)
+	d.handleSessionVisualized(id)
+	d.refreshIdleStaleness(d.store.Get(id), policy, now.Add(time.Second))
+
+	if protocol.Deref(d.sessionForBroadcast(d.store.Get(id)).IdleStale) {
+		t.Fatal("the mark survived the user reading the session")
+	}
+	var cleared bool
+	for _, event := range capture.snapshot() {
+		if event.Session != nil && event.Session.ID == id && !protocol.Deref(event.Session.IdleStale) {
+			cleared = true
+		}
+	}
+	if !cleared {
+		t.Fatal("clients were never told the session had been read")
+	}
+}
+
+// The resolve tick is what makes the mark appear on its own. Everything above
+// calls refreshIdleStaleness directly; this is the wire that makes it run.
+func TestTheResolveTickMarksStaleness(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-tick-stale"
+	policy := stalePolicy()
+	settledAt := time.Now()
+	stalenessSession(t, d, id, protocol.SessionStateIdle, settledAt)
+
+	// A turn that ran and finished, with the agent still painting not-busy frames
+	// at the prompt: idle, and demonstrably not stuck.
+	d.recordBracketEvidence(id, protocol.StateWorking)
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", At: settledAt})
+	d.recordBracketEvidence(id, protocol.StateIdle)
+	at := settledAt.Add(policy.IdleStaleAfter + time.Second)
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "not_busy", At: at})
+
+	d.resolveAllSessions(at.Add(time.Second))
+
+	if !protocol.Deref(d.sessionForBroadcast(d.store.Get(id)).IdleStale) {
+		t.Fatalf("the tick resolved the session (state=%s) without ever asking whether its result had been read", d.store.Get(id).State)
+	}
+}
+
+// Per-session runtime state with a cleanup path, like every other map hanging
+// off the daemon.
+func TestTheStalenessMarkIsForgottenWithTheSession(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-stale-closed"
+	policy := stalePolicy()
+	settledAt := time.Now()
+	stalenessSession(t, d, id, protocol.SessionStateIdle, settledAt)
+	d.refreshIdleStaleness(d.store.Get(id), policy, settledAt.Add(policy.IdleStaleAfter+time.Second))
+	if !d.readTimes().isStale(id) {
+		t.Fatal("never marked stale, so the cleanup below proves nothing")
+	}
+
+	d.dropSessionRecord(id)
+
+	if d.readTimes().isStale(id) {
+		t.Fatal("the mark survived the session")
+	}
+	if !d.readTimes().lastRead(id).IsZero() {
+		t.Fatal("the read time survived the session")
+	}
+}

--- a/internal/hub/manager.go
+++ b/internal/hub/manager.go
@@ -1328,6 +1328,8 @@ func sessionsMatch(left, right protocol.Session) bool {
 		left.State == right.State &&
 		left.StateSince == right.StateSince &&
 		left.StateUpdatedAt == right.StateUpdatedAt &&
+		protocol.Deref(left.StateReason) == protocol.Deref(right.StateReason) &&
+		protocol.Deref(left.IdleStale) == protocol.Deref(right.IdleStale) &&
 		protocol.Deref(left.NeedsReviewAfterLongRun) == protocol.Deref(right.NeedsReviewAfterLongRun) &&
 		protocol.Deref(left.TicketUnread) == protocol.Deref(right.TicketUnread) &&
 		protocol.Deref(left.NudgeFiresAt) == protocol.Deref(right.NudgeFiresAt) &&

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "193"
+const ProtocolVersion = "194"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -3913,6 +3913,9 @@ type Session struct {
 	// ID corresponds to the JSON schema field "id".
 	ID string `json:"id"`
 
+	// IdleStale corresponds to the JSON schema field "idle_stale".
+	IdleStale *bool `json:"idle_stale,omitempty,omitzero"`
+
 	// IsWorktree corresponds to the JSON schema field "is_worktree".
 	IsWorktree *bool `json:"is_worktree,omitempty,omitzero"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -132,6 +132,7 @@ model Session {
   state_since: string;          // ISO timestamp, always set
   state_updated_at: string;     // ISO timestamp, always set
   state_reason?: string;        // Why the resolver reached this state (e.g. "stuck", "classifier_verdict"); absent for states it does not own
+  idle_stale?: boolean;         // True when an idle result has sat unread past the staleness window; absent otherwise
   needs_review_after_long_run?: boolean; // True when a 5m+ run finished and awaits user visualization
   chief_of_staff?: boolean;     // True when this session holds the profile-wide coordinator role
   delegated_from_chief?: boolean; // True when this session was delegated from the chief of staff (assignee of a chief-authored ticket)

--- a/internal/sessionstate/sessionstate.go
+++ b/internal/sessionstate/sessionstate.go
@@ -414,7 +414,14 @@ func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
 	// Nothing has moved at all. That is its own diagnosis, and reporting it is
 	// the whole point: a stuck session used to be indistinguishable from a
 	// correctly-quiet one.
-	if !e.LastMovement.IsZero() && now.Sub(e.LastMovement) > policy.StuckAfter {
+	//
+	// It needs a turn to have opened first. An agent that has been launched and
+	// left alone is silent because there is nothing to report, not because it
+	// stopped reporting: claude paints its title on activity and then goes quiet
+	// at an empty prompt, with no Stop and no idle_prompt notification to
+	// contradict a stuck verdict. Witnessed live on 2026-07-26 — a session
+	// created and never prompted turned `unknown` ninety seconds later.
+	if e.TurnEverOpened && !e.LastMovement.IsZero() && now.Sub(e.LastMovement) > policy.StuckAfter {
 		return Resolution{State: protocol.SessionStateUnknown, Reason: ReasonStuck}
 	}
 

--- a/internal/sessionstate/sessionstate.go
+++ b/internal/sessionstate/sessionstate.go
@@ -180,6 +180,10 @@ type Policy struct {
 	// when a reviewer is in the loop. It is not a delay on genuine approval
 	// requests: with no reviewer the dwell is zero.
 	GuardianDwell time.Duration
+	// IdleStaleAfter is how long a settled result may sit unread before it stops
+	// counting as done. It does not change the state — an idle session is still
+	// idle — only whether that idle result is still fresh.
+	IdleStaleAfter time.Duration
 }
 
 // Measured on claude 2.1.220 and codex 0.145.0 driven through a real PTY.
@@ -215,6 +219,13 @@ const (
 	// visible settle that a late verdict then corrects; undershooting it
 	// reintroduces the flicker the gate exists to prevent.
 	defaultClassifierTimeout = 30 * time.Second
+	// defaultIdleStaleAfter is how long a finished turn nobody has looked at stays
+	// fresh. It is not measured from anything the agent does — the agent is done —
+	// so it is a judgement about attention rather than about an agent's timing:
+	// long enough that stepping away from a session for a few minutes is not
+	// treated as forgetting it, short enough that a result Victor asked for is not
+	// silently lost for the rest of a working day.
+	defaultIdleStaleAfter = 10 * time.Minute
 )
 
 // PolicyFor returns the timing for an agent. An agent with no measured numbers
@@ -229,6 +240,7 @@ func PolicyFor(agent string) Policy {
 		GuardianDwell:     guardianDwell,
 		SettleGrace:       defaultSettleGrace,
 		ClassifierTimeout: defaultClassifierTimeout,
+		IdleStaleAfter:    defaultIdleStaleAfter,
 	}
 	if agent == string(protocol.SessionAgentClaude) {
 		policy.HeartbeatTTL = claudeHeartbeatTTL
@@ -497,6 +509,31 @@ func DwellFor(state protocol.SessionState, e Evidence, policy Policy) time.Durat
 		return policy.GuardianDwell
 	}
 	return 0
+}
+
+// IdleStale reports whether a settled result has gone unread long enough to stop
+// counting as done.
+//
+// It is not part of Resolve and deliberately so. Resolve answers what the agent
+// is doing, and the agent is doing nothing — the session is idle either way.
+// Staleness is a fact about the *user*: how long an answer has sat there with
+// nobody looking at it. That is why it takes the read time rather than the
+// evidence table, which knows everything about the agent and nothing about who
+// has seen its output.
+func IdleStale(state protocol.SessionState, stateSince, lastReadAt time.Time, policy Policy, now time.Time) bool {
+	if state != protocol.SessionStateIdle || policy.IdleStaleAfter <= 0 {
+		return false
+	}
+	// A session that has never been in a state has nothing to have gone stale.
+	if stateSince.IsZero() {
+		return false
+	}
+	// Read after the result arrived: it has been seen, and re-reading the same
+	// finished turn is not something to be reminded about again.
+	if !lastReadAt.Before(stateSince) {
+		return false
+	}
+	return now.Sub(stateSince) > policy.IdleStaleAfter
 }
 
 // supersededByBusy reports whether the agent has painted a busy frame since o

--- a/internal/sessionstate/sessionstate_test.go
+++ b/internal/sessionstate/sessionstate_test.go
@@ -644,3 +644,45 @@ func TestPolicyForUsesTheMeasuredPerAgentTTL(t *testing.T) {
 		}
 	}
 }
+
+// IdleStale is the rule behind the mark: a finished result nobody has looked at
+// stops counting as done. The cases that matter are the ones where it must stay
+// quiet — a session that is still running has produced nothing to miss, and a
+// result already read is not something to be reminded about twice.
+func TestIdleStaleOnlyFiresForAnUnreadFinishedResult(t *testing.T) {
+	policy := PolicyFor(string(protocol.SessionAgentClaude))
+	settled := time.Now()
+	past := settled.Add(policy.IdleStaleAfter + time.Second)
+
+	cases := []struct {
+		name       string
+		state      protocol.SessionState
+		stateSince time.Time
+		lastRead   time.Time
+		now        time.Time
+		want       bool
+	}{
+		{"unread past the window", protocol.SessionStateIdle, settled, time.Time{}, past, true},
+		{"read before it finished", protocol.SessionStateIdle, settled, settled.Add(-time.Hour), past, true},
+		{"still inside the window", protocol.SessionStateIdle, settled, time.Time{}, settled.Add(time.Minute), false},
+		{"read after it finished", protocol.SessionStateIdle, settled, settled.Add(time.Second), past, false},
+		{"read at the same instant", protocol.SessionStateIdle, settled, settled, past, false},
+		{"still working", protocol.SessionStateWorking, settled, time.Time{}, past, false},
+		{"waiting on the user", protocol.SessionStateWaitingInput, settled, time.Time{}, past, false},
+		{"never had a state", protocol.SessionStateIdle, time.Time{}, time.Time{}, past, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IdleStale(tc.state, tc.stateSince, tc.lastRead, policy, tc.now); got != tc.want {
+				t.Fatalf("IdleStale = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// A policy with no window turns the whole thing off rather than firing
+	// instantly, which is what an agent with no measured numbers would get if the
+	// default were ever dropped.
+	if IdleStale(protocol.SessionStateIdle, settled, time.Time{}, Policy{}, past) {
+		t.Fatal("a zero window marked a session stale instead of disabling the rule")
+	}
+}

--- a/internal/sessionstate/sessionstate_test.go
+++ b/internal/sessionstate/sessionstate_test.go
@@ -477,10 +477,24 @@ func TestResolve(t *testing.T) {
 			// anything about used to be indistinguishable from a quiet one.
 			name: "evidence that stopped moving is stuck",
 			evidence: Evidence{
-				LastMovement: now.Add(-91 * time.Second),
+				TurnEverOpened: true,
+				LastMovement:   now.Add(-91 * time.Second),
 			},
 			wantState:  protocol.SessionStateUnknown,
 			wantReason: ReasonStuck,
+		},
+		{
+			// A session launched and left alone is silent because there is nothing
+			// to report. Claude paints its title on activity and then goes quiet at
+			// an empty prompt, with no Stop and no idle_prompt notification to
+			// contradict a stuck verdict — witnessed live turning `unknown` ninety
+			// seconds after launch.
+			name: "a session that never took a turn is quiet, not stuck",
+			evidence: Evidence{
+				LastMovement: now.Add(-10 * time.Minute),
+			},
+			wantState:  protocol.SessionStateUnknown,
+			wantReason: ReasonNoEvidence,
 		},
 		{
 			name: "recent silence is not yet stuck",


### PR DESCRIPTION
Last item of phase 3 of `docs/plans/2026-07-25-agent-state-detection.md`, plus a
live-caught correction to the stuck detection that shipped in #676.

## The mark

A finished turn that has sat past `IdleStaleAfter` with nobody looking at it is
carried to clients as `idle_stale` (protocol 194). The state does not change —
the session is idle either way — only whether that idle answer is still fresh.
Nothing consumes it yet: the attention projection that turns it into a reason to
unsettle a session is phase 4.

Staleness is deliberately **not** a `Resolve` clause. `Resolve` answers what the
agent is doing, and the agent is doing nothing; whether anyone has seen its
result is a fact about the user, which the evidence table does not and should not
know. It is a pure `sessionstate.IdleStale` rule fed by daemon-tracked read times
and applied by the resolve tick — the same split that put the guardian dwell in
the daemon rather than the resolver.

"Read" means the daemon was told the session was visualized, or it is the session
currently on screen. The on-screen half matters: a turn that finishes while
someone is watching it produces no `session_visualized` of its own, so without it
the session being looked at would go stale.

Two deviations from the plan, both recorded in it:

- **The `needs_review_after_long_run` fold is deferred, not done.** The plan item
  said to fold it in. That mechanism is live and user-visible (a 5m+ run defers
  its classification until the session is viewed) and its replacement has no
  consumer until phase 4, so folding it in now would delete working behaviour and
  put nothing in its place. They are not duplicates — the old one measures how
  long the *run* took, the new one how long the *result* has gone unread — and
  phase 3.5 or 4 decides which survives.
- **The window is a judgement, not a measurement.** The plan names no duration.
  `defaultIdleStaleAfter` is 10 minutes: long enough that stepping away from a
  session is not treated as forgetting it, short enough that a result someone
  asked for is not lost for a working day. Nothing depends on the exact number
  until it has a consumer.

## The stuck correction

Live verification of the above caught a wrong colour from the stuck publication
merged in #676. A claude session that is **launched and never prompted** turned
`unknown` ninety seconds later while sitting at a healthy empty prompt:

```
02:16:10  worker_info  working   applied
02:16:11  heartbeat    not_busy  observed   "Claude Code"
02:17:41  resolver     unknown   applied    "stuck"
```

Claude paints its title on activity and then goes quiet at an empty prompt. A
session with no turn behind it has neither a Stop nor an `idle_prompt`
notification to contradict a stuck verdict — that notification is the only reason
*settled* sessions are unstickable. Stuck now requires a turn to have opened:
silence before the first turn is nothing to report, not a stopped report.

Also fixed: `internal/hub`'s `sessionsMatch` compared neither `state_reason` nor
`idle_stale`, so a remote session's reason or mark would never propagate to a hub
client.

## Verification

Full Go and frontend suites pass. Every new wire was mutation-checked (dropping
the read stamp, the tick call, and the on-screen read each turn a specific test
red).

Live on profile `statedet`, protocol 194, packaged app, preflight clean. One
session was prompted and the app moved to a second session while it was still
working, so its result landed unwatched:

```
+600s   9c319285 state=idle reason=classifier_verdict idle_stale=false
+720s   9c319285 state=idle reason=classifier_verdict idle_stale=true
opened  9c319285 state=idle reason=classifier_verdict idle_stale=false
```

The mark appears between 10 and 12 minutes after the result lands, and opening
the session clears it. The second session — launched and never prompted — stayed
out of `unknown` for the full fourteen minutes, which is the stuck fix.

That second session did sit at `working` the whole time, which is its own wrong
colour: the `worker_info` replay applies `working` at spawn and no clause can
retire it, because every settle clause requires a turn to have opened. Logged in
the plan for phase 3.5 rather than fixed here — the honest answer is probably
`idle`, but saying so means deciding what evidence proves an agent has finished
booting.

https://claude.ai/code/session_01KzpRFTTbzGz1JFqK1vvVq5