### PR TITLE
fix(pr): wait-ready reports every event, its content, and remembers what it reported

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,10 +137,16 @@ output as product evidence.
 
 To wait on a GitHub PR, run `attn pr wait-ready <pr> --repo <owner/repo>
 --reviewer <login>` once; do not poll checks, reviews, and comments separately.
-It returns on the first actionable update and reports which one by exit code:
-`0` approved, `1` checks failed, `3` changes requested, `4` new human comment,
-`124` timeout. Bot comments are ignored; comments already present when the wait
-starts are the baseline.
+It returns on the first poll with an actionable update and reports it by exit
+code: `0` approved, `1` checks failed, `3` changes requested, `4` human comment,
+`5` error, `6` bot comment, `124` timeout. One poll can see several of those at
+once; the exit code names the highest ranked (closed, checks failed, changes
+requested, human comment, approved, bot comment) and the rest are still reported
+— `also <event>:` on stdout, `events` in `--json`. Do not treat the exit code as
+the whole answer when you need to know everything that happened. The reviewer's
+own verdict is one event, not a verdict plus a comment. Comments already present
+when the wait starts are the baseline; `--ignore-author` drops an author of
+either kind.
 
 ### Packaged-app harness
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,14 @@ own verdict is one event, not a verdict plus a comment. Comments already present
 when the wait starts are the baseline; `--ignore-author` drops an author of
 either kind.
 
+The output carries what was said — comment bodies with `file:line` when inline,
+the verdict's text, failing check names with URLs, the PR URL — so act on it
+instead of querying GitHub again. Successive waits on the same PR resume from
+what the previous one reported (recorded under the data dir), so a comment that
+lands while you are answering the last one is still reported, and a failing check
+you were already told about does not return instantly a second time. `--reset`
+forgets that position and `--since <RFC3339>` replays from an instant.
+
 ### Packaged-app harness
 
 - Single-tenant: never run packaged-app scenarios in parallel.

--- a/cmd/attn/pr.go
+++ b/cmd/attn/pr.go
@@ -795,6 +795,7 @@ func parsePRSnapshot(output []byte, opts prWaitOptions) (*prReadiness, error) {
 		if strings.TrimSpace(review.BodyText) != "" && !isTrackedReviewerVerdict(review.Author.Login, state, opts) {
 			result.Comments = appendPRComment(result.Comments, prGraphQLComment{
 				ID: review.ID, CreatedAt: review.SubmittedAt, Author: review.Author,
+				BodyText: review.BodyText,
 			}, "review", opts)
 		}
 		if review.Comments.PageInfo.HasNextPage {

--- a/cmd/attn/pr.go
+++ b/cmd/attn/pr.go
@@ -24,6 +24,7 @@ const (
 	prWaitExitChangesRequested = 3
 	prWaitExitComment          = 4
 	prWaitExitError            = 5
+	prWaitExitBotComment       = 6
 	prWaitExitTimeout          = 124
 
 	checksNone    = "none"
@@ -42,9 +43,56 @@ const (
 	outcomeChecksFailed     prOutcome = "checks_failed"
 	outcomeChangesRequested prOutcome = "changes_requested"
 	outcomeComment          prOutcome = "comment"
+	outcomeBotComment       prOutcome = "bot_comment"
 	outcomeClosed           prOutcome = "closed"
 	outcomeTimeout          prOutcome = "timeout"
 )
+
+// prOutcomeRanking is the whole precedence order, in one place. One poll can see
+// several events at once — CI can fail in the same 20 seconds someone comments —
+// and the exit code can only carry one, so the ranking decides which. It reads
+// by who is waiting on whom: the pull request being gone or broken first, then a
+// verdict, then a human who asked something and is waiting for an answer.
+//
+// Approval ranks below a human comment because approval says nothing needs doing
+// and reporting it over a fresh question would bury the question. It ranks above
+// a bot comment for the mirror-image reason: a bot is not waiting for an answer,
+// its findings usually arrive as a check as well, and it comments on nearly every
+// push — ranking it higher would report "a bot said something" instead of "you
+// can merge" in the ordinary case.
+//
+// Nothing is lost to the ranking: every event the ending poll saw is reported,
+// so a caller that gets `comment` still sees the approval that came with it.
+var prOutcomeRanking = []prOutcome{
+	outcomeClosed,
+	outcomeChecksFailed,
+	outcomeChangesRequested,
+	outcomeComment,
+	outcomeApproved,
+	outcomeBotComment,
+}
+
+// rankPROutcomes returns the highest-ranked event, and the events sorted by that
+// same ranking so the report reads in the order the operator should read it.
+func rankPROutcomes(events []prOutcome) (prOutcome, []prOutcome) {
+	if len(events) == 0 {
+		return "", nil
+	}
+	present := make(map[prOutcome]bool, len(events))
+	for _, event := range events {
+		present[event] = true
+	}
+	ranked := make([]prOutcome, 0, len(events))
+	for _, candidate := range prOutcomeRanking {
+		if present[candidate] {
+			ranked = append(ranked, candidate)
+		}
+	}
+	if len(ranked) == 0 {
+		return events[0], events
+	}
+	return ranked[0], ranked
+}
 
 func (o prOutcome) exitCode() int {
 	switch o {
@@ -56,6 +104,8 @@ func (o prOutcome) exitCode() int {
 		return prWaitExitChangesRequested
 	case outcomeComment:
 		return prWaitExitComment
+	case outcomeBotComment:
+		return prWaitExitBotComment
 	case outcomeTimeout:
 		return prWaitExitTimeout
 	default:
@@ -70,11 +120,45 @@ type prCheck struct {
 
 // prComment is any commentary surface: a standalone PR comment, an inline
 // review-thread comment, or a review submitted without a verdict.
+//
+// A review that carries a verdict is not commentary. Its body is the verdict's
+// explanation, and reporting it here as well would turn one review into two
+// events — which is how an approval used to end the wait as "a new comment".
 type prComment struct {
 	ID        string    `json:"-"`
 	Author    string    `json:"author"`
 	Kind      string    `json:"kind"`
+	Bot       bool      `json:"bot"`
 	CreatedAt time.Time `json:"created_at"`
+}
+
+// isTrackedReviewerVerdict reports whether a review is the one the waiter reads
+// as the reviewer's answer. Only those reviews are exempt from being reported as
+// commentary; a `COMMENTED` review from the same person is a remark like any
+// other, and is what the reviewer uses to say something without answering yet.
+func isTrackedReviewerVerdict(author, state string, opts prWaitOptions) bool {
+	if !strings.EqualFold(author, opts.Reviewer) {
+		return false
+	}
+	return state == "APPROVED" || state == "CHANGES_REQUESTED"
+}
+
+func humanPRComments(comments []prComment) []prComment {
+	return filterPRComments(comments, false)
+}
+
+func botPRComments(comments []prComment) []prComment {
+	return filterPRComments(comments, true)
+}
+
+func filterPRComments(comments []prComment, bot bool) []prComment {
+	result := make([]prComment, 0, len(comments))
+	for _, comment := range comments {
+		if comment.Bot == bot {
+			result = append(result, comment)
+		}
+	}
+	return result
 }
 
 type prReadiness struct {
@@ -169,25 +253,32 @@ func executePRCommand(args []string, stdout, stderr io.Writer) int {
 
 	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
 	defer cancel()
-	result, outcome, err := waitForPRActionable(ctx, ghPRReadinessSource{}, opts, progress)
+	result, outcome, events, err := waitForPRActionable(ctx, ghPRReadinessSource{}, opts, progress)
 	if err != nil {
 		fmt.Fprintf(stderr, "pr wait-ready: %v\n", err)
 		return prWaitExitError
 	}
-	return reportPROutcome(result, outcome, opts, stdout)
+	return reportPROutcome(result, outcome, events, opts, stdout)
 }
 
-func reportPROutcome(result *prReadiness, outcome prOutcome, opts prWaitOptions, stdout io.Writer) int {
+func reportPROutcome(result *prReadiness, outcome prOutcome, events []prOutcome, opts prWaitOptions, stdout io.Writer) int {
 	detail := describePROutcome(result, outcome, opts)
 	if opts.JSON {
-		// "comments" reports what arrived during the wait. On any other outcome
-		// the observation still carries the baseline, which is not news.
-		fresh := []prComment{}
-		if outcome == outcomeComment {
-			fresh = result.Comments
+		// "comments" is everything that arrived during the wait, whichever event
+		// won: the exit code can only name one, and a caller that has to re-query
+		// for the rest is being made to fetch what this poll already saw. The
+		// waiter has already reduced Comments to the unseen ones.
+		fresh := result.Comments
+		if fresh == nil {
+			fresh = []prComment{}
+		}
+		reported := make([]string, 0, len(events))
+		for _, event := range events {
+			reported = append(reported, string(event))
 		}
 		payload := map[string]any{
 			"outcome": string(outcome),
+			"events":  reported,
 			"pr":      result.Number,
 			"head":    result.HeadSHA,
 			"state":   result.State,
@@ -211,6 +302,15 @@ func reportPROutcome(result *prReadiness, outcome prOutcome, opts prWaitOptions,
 		return outcome.exitCode()
 	}
 	fmt.Fprintf(stdout, "%s: %s\n", outcome, detail)
+	// Plain text gets the same completeness as JSON: the events the ranking did
+	// not pick are still things that happened, and a reader who only sees the
+	// winner will go looking for them.
+	for _, event := range events {
+		if event == outcome {
+			continue
+		}
+		fmt.Fprintf(stdout, "also %s: %s\n", event, describePROutcome(result, event, opts))
+	}
 	return outcome.exitCode()
 }
 
@@ -224,7 +324,9 @@ func describePROutcome(result *prReadiness, outcome prOutcome, opts prWaitOption
 	case outcomeChecksFailed:
 		return fmt.Sprintf("%s failed on %s", strings.Join(failedCheckNames(result.Checks), ", "), head)
 	case outcomeComment:
-		return describePRComments(result.Comments)
+		return describePRComments(humanPRComments(result.Comments))
+	case outcomeBotComment:
+		return describePRComments(botPRComments(result.Comments))
 	case outcomeClosed:
 		return fmt.Sprintf("pull request is %s", result.State)
 	case outcomeTimeout:
@@ -526,7 +628,13 @@ func parsePRSnapshot(output []byte, opts prWaitOptions) (*prReadiness, error) {
 		// A review with no text of its own is just the wrapper GitHub creates
 		// around an inline comment; its comments are reported below, so
 		// counting the wrapper too would report one remark twice.
-		if strings.TrimSpace(review.BodyText) != "" {
+		//
+		// The tracked reviewer's verdict is skipped for the same reason from the
+		// other direction: its body is the verdict's own explanation, and the
+		// verdict event already sends the caller to read it. Another author's
+		// approval is not tracked as a verdict at all, so their prose is
+		// commentary and stays reported.
+		if strings.TrimSpace(review.BodyText) != "" && !isTrackedReviewerVerdict(review.Author.Login, state, opts) {
 			result.Comments = appendPRComment(result.Comments, prGraphQLComment{
 				ID: review.ID, CreatedAt: review.SubmittedAt, Author: review.Author,
 			}, "review", opts)
@@ -561,17 +669,26 @@ func parsePRSnapshot(output []byte, opts prWaitOptions) (*prReadiness, error) {
 	return result, nil
 }
 
-// appendPRComment keeps only comments a human needs to answer. Bot authorship
-// comes from __typename; the token owner is deliberately NOT filtered, because
-// the operator and the agent share one token and the operator's own comment is
-// the most actionable event there is. Self-waking is prevented by the baseline
-// instead: anything present when the wait starts is never reported.
+// appendPRComment records a comment and who wrote it. Bot authorship comes from
+// __typename and separates the two comment events rather than dropping one: a
+// bot's remark is real news (a doctor report, a coverage regression) but it is
+// ranked below a human's and carries its own exit code, so a caller can act on
+// one and ignore the other. `--ignore-author` drops either kind.
+//
+// The token owner is deliberately NOT filtered, because the operator and the
+// agent share one token and the operator's own comment is the most actionable
+// event there is. Self-waking is prevented by the baseline instead: anything
+// present when the wait starts is never reported.
 func appendPRComment(comments []prComment, node prGraphQLComment, kind string, opts prWaitOptions) []prComment {
-	if node.ID == "" || node.Author.TypeName != "User" || opts.ignored(node.Author.Login) {
+	if node.ID == "" || opts.ignored(node.Author.Login) {
 		return comments
 	}
 	return append(comments, prComment{
-		ID: node.ID, Author: node.Author.Login, Kind: kind, CreatedAt: node.CreatedAt,
+		ID:        node.ID,
+		Author:    node.Author.Login,
+		Kind:      kind,
+		Bot:       node.Author.TypeName != "User",
+		CreatedAt: node.CreatedAt,
 	})
 }
 
@@ -616,10 +733,13 @@ func summarizePRChecks(checks []prCheck) string {
 	return result
 }
 
-// waitForPRActionable returns on the first actionable update. The error return
-// is reserved for the waiter itself failing; every product outcome, including a
-// timeout, comes back as a prOutcome so the caller can report it uniformly.
-func waitForPRActionable(ctx context.Context, source prReadinessSource, opts prWaitOptions, progress io.Writer) (*prReadiness, prOutcome, error) {
+// waitForPRActionable returns on the first poll that sees an actionable update.
+// It returns every event that poll saw, ranked, plus the winner the exit code
+// reports; a caller that only wants the winner can ignore the rest. The error
+// return is reserved for the waiter itself failing; every product outcome,
+// including a timeout, comes back as a prOutcome so the caller can report it
+// uniformly.
+func waitForPRActionable(ctx context.Context, source prReadinessSource, opts prWaitOptions, progress io.Writer) (*prReadiness, prOutcome, []prOutcome, error) {
 	var lastLine, lastHead string
 	var baseline map[string]bool
 	var reviewBaseline time.Time
@@ -630,9 +750,9 @@ func waitForPRActionable(ctx context.Context, source prReadinessSource, opts prW
 		observation, err := source.Fetch(ctx, opts)
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
-				return last, outcomeTimeout, nil
+				return last, outcomeTimeout, []prOutcome{outcomeTimeout}, nil
 			}
-			return last, "", err
+			return last, "", nil, err
 		}
 		last = observation
 
@@ -657,9 +777,13 @@ func waitForPRActionable(ctx context.Context, source prReadinessSource, opts prW
 			// review at wait start is stale context, so a verdict returns only
 			// when it (or a re-review) is newer than this.
 			reviewBaseline = observation.LatestReviewAt
-		} else if fresh := unseenPRComments(observation.Comments, baseline); len(fresh) > 0 {
-			observation.Comments = fresh
-			return observation, outcomeComment, nil
+			// Nothing already on the PR is news, so this poll contributes no
+			// comment event. Dropping them here rather than skipping the event
+			// tests below also keeps the report honest if some other event ends
+			// the wait on this very poll: no comment arrived during it.
+			observation.Comments = nil
+		} else {
+			observation.Comments = unseenPRComments(observation.Comments, baseline)
 		}
 
 		// An existing verdict that a pending re-review holds back is not a return
@@ -670,19 +794,37 @@ func waitForPRActionable(ctx context.Context, source prReadinessSource, opts prW
 			notedStaleVerdict = true
 		}
 
-		switch {
-		case observation.State != "open":
-			return observation, outcomeClosed, nil
-		case observation.CheckState == checksFailed:
-			return observation, outcomeChecksFailed, nil
-		case observation.ReviewState == "changes_requested" && freshReviewVerdict(observation, reviewBaseline):
-			return observation, outcomeChangesRequested, nil
-		case observation.ready() && freshReviewVerdict(observation, reviewBaseline):
-			return observation, outcomeApproved, nil
+		// Collect the whole poll before deciding anything. Every branch here used
+		// to return the moment it matched, in two separate places, so whichever
+		// event the code happened to test first won and the others were never
+		// looked at. The ranking is the only thing that chooses now.
+		var events []prOutcome
+		if observation.State != "open" {
+			events = append(events, outcomeClosed)
+		}
+		if observation.CheckState == checksFailed {
+			events = append(events, outcomeChecksFailed)
+		}
+		if freshReviewVerdict(observation, reviewBaseline) {
+			switch {
+			case observation.ReviewState == "changes_requested":
+				events = append(events, outcomeChangesRequested)
+			case observation.ready():
+				events = append(events, outcomeApproved)
+			}
+		}
+		if len(humanPRComments(observation.Comments)) > 0 {
+			events = append(events, outcomeComment)
+		}
+		if len(botPRComments(observation.Comments)) > 0 {
+			events = append(events, outcomeBotComment)
+		}
+		if winner, ranked := rankPROutcomes(events); winner != "" {
+			return observation, winner, ranked, nil
 		}
 
 		if err := waitPRPoll(ctx, opts.Interval); err != nil {
-			return observation, outcomeTimeout, nil
+			return observation, outcomeTimeout, []prOutcome{outcomeTimeout}, nil
 		}
 	}
 }
@@ -764,8 +906,9 @@ func shortSHA(sha string) string {
 func writePRHelp(w io.Writer) {
 	fmt.Fprint(w, `usage: attn pr wait-ready <number-or-url> --reviewer <login> [options]
 
-Wait until a pull request has an actionable update: a failing check, a review
-requesting changes, a new human comment, or approval on a green exact head.
+Wait until a pull request has an actionable update: it closes, a check fails, the
+reviewer requests changes, a human comments, a bot comments, or the reviewer
+approves a green exact head.
 
 options:
   --repo [host/]owner/repository  required with a pull request number
@@ -775,14 +918,25 @@ options:
   --ignore-author login           comment author to ignore (repeatable)
   --json                          emit the result as JSON on stdout
 
-Bot comments are ignored. Comments already present when the wait starts are the
-baseline and never reported; only comments posted during the wait are. A review
-verdict present at wait start is likewise baselined: while the reviewer is
-re-requested (a re-review is pending) the pre-existing verdict is stale and does
-not end the wait; only a review submitted after the baseline does. When the
-reviewer is not re-requested, an existing verdict returns immediately.
+One poll can see several of these at once. The exit code reports the highest
+ranked: closed, checks failed, changes requested, human comment, approved, bot
+comment. A human comment outranks approval because someone is waiting for an
+answer; a bot comment ranks last because nobody is. Every event that poll saw is
+still reported — "also <event>: ..." on stdout, "events" in --json — so an
+approval that arrives alongside a comment is never lost to the one the exit code
+names. The reviewer's own approval or changes-requested is one event, not two:
+its body is the verdict's explanation, not a separate comment.
 
-exit: 0 approved; 1 checks failed; 2 usage; 3 changes requested; 4 new comment;
-      5 error; 124 timeout
+A bot comment ends the wait with its own exit code, so a caller can act on a
+human's remark and skip a doctor report; --ignore-author drops either kind.
+Comments already present when the wait starts are the baseline and never
+reported; only comments posted during the wait are. A review verdict present at
+wait start is likewise baselined: while the reviewer is re-requested (a re-review
+is pending) the pre-existing verdict is stale and does not end the wait; only a
+review submitted after the baseline does. When the reviewer is not re-requested,
+an existing verdict returns immediately.
+
+exit: 0 approved; 1 checks failed; 2 usage; 3 changes requested; 4 human comment;
+      5 error; 6 bot comment; 124 timeout
 `)
 }

--- a/cmd/attn/pr.go
+++ b/cmd/attn/pr.go
@@ -9,12 +9,14 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/victorarias/attn/internal/automation"
+	"github.com/victorarias/attn/internal/config"
 )
 
 const (
@@ -116,6 +118,9 @@ func (o prOutcome) exitCode() int {
 type prCheck struct {
 	Name  string `json:"name"`
 	State string `json:"state"`
+	// URL is where the run's logs are. A failed check whose logs the caller has to
+	// go hunting for is a follow-up query in everything but name.
+	URL string `json:"url,omitempty"`
 }
 
 // prComment is any commentary surface: a standalone PR comment, an inline
@@ -130,6 +135,11 @@ type prComment struct {
 	Kind      string    `json:"kind"`
 	Bot       bool      `json:"bot"`
 	CreatedAt time.Time `json:"created_at"`
+	// Body is what the comment actually says, and Location is `path:line` for an
+	// inline comment. Both are carried so the caller can act on the remark instead
+	// of going back to GitHub to read it.
+	Body     string `json:"body,omitempty"`
+	Location string `json:"location,omitempty"`
 }
 
 // isTrackedReviewerVerdict reports whether a review is the one the waiter reads
@@ -176,6 +186,13 @@ type prReadiness struct {
 	// baseline the waiter records at start to recognize a stale verdict.
 	ReviewSubmittedAt time.Time
 	LatestReviewAt    time.Time
+	// ReviewBody is the verdict's own text — for changes_requested, the thing the
+	// caller has to act on. It was already being fetched and dropped, which meant
+	// every caller learning "changes requested" had to ask GitHub what was said.
+	ReviewBody string
+	// URL is the pull request's web address, so a caller reporting the outcome
+	// does not have to assemble one from host, owner, name and number.
+	URL string
 }
 
 func (r *prReadiness) ready() bool {
@@ -193,6 +210,15 @@ type prWaitOptions struct {
 	IgnoreAuthors     []string
 	Timeout, Interval time.Duration
 	JSON              bool
+	// CursorDir is where waits remember what they have already reported, so a
+	// second call resumes instead of re-baselining. Empty disables the memory
+	// entirely, which is what tests use; the CLI resolves it once at entry.
+	CursorDir string
+	// Since overrides the remembered position: report anything after this instant
+	// and ignore the cursor. Reset discards the cursor and baselines from the
+	// pull request's current state, as a first-ever call would.
+	Since time.Time
+	Reset bool
 }
 
 func (o prWaitOptions) ignored(author string) bool {
@@ -251,17 +277,38 @@ func executePRCommand(args []string, stdout, stderr io.Writer) int {
 		progress = stderr
 	}
 
+	// Resolve the cursor directory here and pass it down, so nothing below this
+	// line can reach a data dir on its own.
+	opts.CursorDir = filepath.Join(config.DataDir(), "pr-wait")
+
+	var cursor prWaitCursor
+	if !opts.Reset {
+		loaded, err := loadPRWaitCursor(opts.CursorDir, opts)
+		if err != nil {
+			// A cursor that cannot be read costs history, not correctness: the wait
+			// falls back to baselining from the PR's current state.
+			fmt.Fprintf(stderr, "pr wait-ready: %v; starting from the current state\n", err)
+		}
+		cursor = loaded
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
 	defer cancel()
-	result, outcome, events, err := waitForPRActionable(ctx, ghPRReadinessSource{}, opts, progress)
+	result, err := waitForPRActionable(ctx, ghPRReadinessSource{}, opts, cursor, progress)
 	if err != nil {
 		fmt.Fprintf(stderr, "pr wait-ready: %v\n", err)
 		return prWaitExitError
 	}
-	return reportPROutcome(result, outcome, events, opts, stdout)
+	if err := savePRWaitCursor(opts.CursorDir, opts, result.Cursor, time.Now()); err != nil {
+		// Losing the cursor means the next wait re-baselines, which is the old
+		// behavior — worth a warning, not worth discarding this wait's answer.
+		fmt.Fprintf(stderr, "pr wait-ready: could not save cursor: %v\n", err)
+	}
+	return reportPROutcome(result, opts, stdout)
 }
 
-func reportPROutcome(result *prReadiness, outcome prOutcome, events []prOutcome, opts prWaitOptions, stdout io.Writer) int {
+func reportPROutcome(wait prWaitResult, opts prWaitOptions, stdout io.Writer) int {
+	result, outcome, events := wait.Observation, wait.Outcome, wait.Events
 	detail := describePROutcome(result, outcome, opts)
 	if opts.JSON {
 		// "comments" is everything that arrived during the wait, whichever event
@@ -280,19 +327,28 @@ func reportPROutcome(result *prReadiness, outcome prOutcome, events []prOutcome,
 			"outcome": string(outcome),
 			"events":  reported,
 			"pr":      result.Number,
+			"url":     result.URL,
 			"head":    result.HeadSHA,
 			"state":   result.State,
 			"draft":   result.Draft,
 			"detail":  detail,
 			"checks": map[string]any{
-				"state": result.CheckState,
-				"items": result.Checks,
+				"state":  result.CheckState,
+				"items":  result.Checks,
+				"failed": failedChecks(result.Checks),
 			},
 			"review": map[string]any{
 				"state":    result.ReviewState,
 				"reviewer": result.Reviewer,
+				// The verdict's own text. On changes_requested it is the whole
+				// point: what to fix.
+				"body": result.ReviewBody,
 			},
 			"comments": fresh,
+			// The position this wait leaves behind. Echoing it makes the memory
+			// inspectable, and it is what a caller passes back as --since to replay
+			// from a known point.
+			"cursor": wait.Cursor,
 		}
 		encoder := json.NewEncoder(stdout)
 		encoder.SetIndent("", "  ")
@@ -311,7 +367,57 @@ func reportPROutcome(result *prReadiness, outcome prOutcome, events []prOutcome,
 		}
 		fmt.Fprintf(stdout, "also %s: %s\n", event, describePROutcome(result, event, opts))
 	}
+	writePRContent(stdout, result, events)
 	return outcome.exitCode()
+}
+
+// writePRContent prints what was actually said. Without it the caller knows a
+// remark exists and has to go read it, which is the follow-up query this command
+// exists to remove — and stdout is the only surface a shell caller has.
+func writePRContent(stdout io.Writer, result *prReadiness, events []prOutcome) {
+	reported := make(map[prOutcome]bool, len(events))
+	for _, event := range events {
+		reported[event] = true
+	}
+	if failed := failedChecks(result.Checks); reported[outcomeChecksFailed] && len(failed) > 0 {
+		for _, check := range failed {
+			if check.URL != "" {
+				fmt.Fprintf(stdout, "  %s %s\n", check.Name, check.URL)
+				continue
+			}
+			fmt.Fprintf(stdout, "  %s\n", check.Name)
+		}
+	}
+	if (reported[outcomeChangesRequested] || reported[outcomeApproved]) && result.ReviewBody != "" {
+		fmt.Fprintf(stdout, "  --- %s ---\n%s\n", result.Reviewer, indentPRBody(result.ReviewBody))
+	}
+	for _, comment := range result.Comments {
+		if comment.Bot && !reported[outcomeBotComment] {
+			continue
+		}
+		if !comment.Bot && !reported[outcomeComment] {
+			continue
+		}
+		where := comment.Author
+		if comment.Location != "" {
+			where += " on " + comment.Location
+		}
+		fmt.Fprintf(stdout, "  --- %s ---\n", where)
+		if comment.Body != "" {
+			fmt.Fprintln(stdout, indentPRBody(comment.Body))
+		}
+	}
+	if result.URL != "" {
+		fmt.Fprintf(stdout, "%s\n", result.URL)
+	}
+}
+
+func indentPRBody(body string) string {
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		lines[i] = "  " + line
+	}
+	return strings.Join(lines, "\n")
 }
 
 func describePROutcome(result *prReadiness, outcome prOutcome, opts prWaitOptions) string {
@@ -356,6 +462,18 @@ func describePRComments(comments []prComment) string {
 	return fmt.Sprintf("%d new %s from %s", len(comments), noun, strings.Join(authors, ", "))
 }
 
+// failedChecks is the failing subset with its log URLs, reported separately so a
+// caller does not have to filter a hundred green rows to find what broke.
+func failedChecks(checks []prCheck) []prCheck {
+	failed := make([]prCheck, 0)
+	for _, check := range checks {
+		if check.State == checksFailed {
+			failed = append(failed, check)
+		}
+	}
+	return failed
+}
+
 func failedCheckNames(checks []prCheck) []string {
 	var names []string
 	for _, check := range checks {
@@ -376,6 +494,8 @@ func parsePRWaitArgs(args []string) (prWaitOptions, error) {
 	timeout := fs.Duration("timeout", 30*time.Minute, "maximum wait")
 	interval := fs.Duration("interval", 20*time.Second, "poll interval")
 	asJSON := fs.Bool("json", false, "emit the result as JSON")
+	reset := fs.Bool("reset", false, "forget what earlier waits reported and baseline from the current state")
+	since := fs.String("since", "", "report anything after this RFC3339 instant instead of resuming")
 	var ignore stringSliceFlag
 	fs.Var(&ignore, "ignore-author", "comment author to ignore (repeatable)")
 
@@ -404,6 +524,14 @@ func parsePRWaitArgs(args []string) (prWaitOptions, error) {
 		Timeout:       *timeout,
 		Interval:      *interval,
 		JSON:          *asJSON,
+		Reset:         *reset,
+	}
+	if strings.TrimSpace(*since) != "" {
+		at, err := time.Parse(time.RFC3339, strings.TrimSpace(*since))
+		if err != nil {
+			return prWaitOptions{}, fmt.Errorf("--since must be an RFC3339 timestamp: %w", err)
+		}
+		opts.Since = at
 	}
 	if strings.HasPrefix(target, "https://") {
 		host, owner, repository, number, err := automation.ParsePullRequestURL(target)
@@ -449,19 +577,25 @@ func parseRepoFlag(repo string) (host, owner, name string, err error) {
 // bot authorship is authoritative. `gh pr view --json comments` strips the
 // "[bot]" suffix and omits the author type, which makes bots indistinguishable
 // from humans; GraphQL's __typename does not.
+//
+// It asks for the text too — review bodies, comment bodies, an inline comment's
+// file and line, a failing check's URL. A caller that has to fetch the words
+// after being told a comment exists is making the second round trip this command
+// exists to remove, and it is the same round trip either way: these are fields on
+// objects the query already walks.
 const prSnapshotQuery = `
 query($owner:String!,$name:String!,$number:Int!){
   repository(owner:$owner,name:$name){
     pullRequest(number:$number){
-      number state isDraft headRefOid
+      number state isDraft headRefOid url
       commits(last:1){nodes{commit{statusCheckRollup{contexts(first:100){
         pageInfo{hasNextPage}
-        nodes{__typename ... on CheckRun{name status conclusion} ... on StatusContext{context state}}
+        nodes{__typename ... on CheckRun{name status conclusion detailsUrl} ... on StatusContext{context state targetUrl}}
       }}}}}
       reviewRequests(first:100){nodes{requestedReviewer{__typename ... on User{login}}}}
       reviews(last:100){nodes{id state bodyText submittedAt author{__typename login} commit{oid}
-        comments(first:100){pageInfo{hasNextPage} nodes{id createdAt author{__typename login}}}}}
-      comments(last:100){nodes{id createdAt author{__typename login}}}
+        comments(first:100){pageInfo{hasNextPage} nodes{id createdAt bodyText path line originalLine author{__typename login}}}}}
+      comments(last:100){nodes{id createdAt bodyText author{__typename login}}}
     }}}`
 
 func (ghPRReadinessSource) Fetch(ctx context.Context, opts prWaitOptions) (*prReadiness, error) {
@@ -490,9 +624,29 @@ type prGraphQLAuthor struct {
 }
 
 type prGraphQLComment struct {
-	ID        string          `json:"id"`
-	CreatedAt time.Time       `json:"createdAt"`
-	Author    prGraphQLAuthor `json:"author"`
+	ID           string          `json:"id"`
+	CreatedAt    time.Time       `json:"createdAt"`
+	BodyText     string          `json:"bodyText"`
+	Path         string          `json:"path"`
+	Line         *int            `json:"line"`
+	OriginalLine *int            `json:"originalLine"`
+	Author       prGraphQLAuthor `json:"author"`
+}
+
+// location renders where an inline comment sits. GitHub nulls `line` once the
+// comment's hunk is outdated, and then `originalLine` is the only anchor left.
+func (c prGraphQLComment) location() string {
+	if c.Path == "" {
+		return ""
+	}
+	line := c.Line
+	if line == nil {
+		line = c.OriginalLine
+	}
+	if line == nil {
+		return c.Path
+	}
+	return fmt.Sprintf("%s:%d", c.Path, *line)
 }
 
 func parsePRSnapshot(output []byte, opts prWaitOptions) (*prReadiness, error) {
@@ -504,6 +658,7 @@ func parsePRSnapshot(output []byte, opts prWaitOptions) (*prReadiness, error) {
 					State          string      `json:"state"`
 					IsDraft        bool        `json:"isDraft"`
 					HeadRefOID     string      `json:"headRefOid"`
+					URL            string      `json:"url"`
 					ReviewRequests struct {
 						Nodes []struct {
 							RequestedReviewer prGraphQLAuthor `json:"requestedReviewer"`
@@ -524,6 +679,8 @@ func parsePRSnapshot(output []byte, opts prWaitOptions) (*prReadiness, error) {
 											Status     string `json:"status"`
 											Conclusion string `json:"conclusion"`
 											State      string `json:"state"`
+											DetailsURL string `json:"detailsUrl"`
+											TargetURL  string `json:"targetUrl"`
 										} `json:"nodes"`
 									} `json:"contexts"`
 								} `json:"statusCheckRollup"`
@@ -579,6 +736,7 @@ func parsePRSnapshot(output []byte, opts prWaitOptions) (*prReadiness, error) {
 	result := &prReadiness{
 		Number: pr.Number.String(), State: strings.ToLower(pr.State), Draft: pr.IsDraft,
 		HeadSHA: pr.HeadRefOID, Reviewer: opts.Reviewer, ReviewState: "waiting",
+		URL: pr.URL,
 	}
 
 	for _, request := range pr.ReviewRequests.Nodes {
@@ -596,11 +754,11 @@ func parsePRSnapshot(output []byte, opts prWaitOptions) (*prReadiness, error) {
 				return nil, errors.New("PR has more than 100 checks; readiness cannot be verified without truncation")
 			}
 			for _, check := range rollup.Contexts.Nodes {
-				name, state := "status:"+check.Context, statusState(check.State)
+				name, state, url := "status:"+check.Context, statusState(check.State), check.TargetURL
 				if check.TypeName == "CheckRun" {
-					name, state = "check:"+check.Name, checkRunState(check.Status, check.Conclusion)
+					name, state, url = "check:"+check.Name, checkRunState(check.Status, check.Conclusion), check.DetailsURL
 				}
-				result.Checks = append(result.Checks, prCheck{Name: name, State: state})
+				result.Checks = append(result.Checks, prCheck{Name: name, State: state, URL: url})
 			}
 		}
 	}
@@ -654,6 +812,7 @@ func parsePRSnapshot(output []byte, opts prWaitOptions) (*prReadiness, error) {
 		}
 		latest = review.SubmittedAt
 		result.ReviewSubmittedAt = review.SubmittedAt
+		result.ReviewBody = strings.TrimSpace(review.BodyText)
 		if state == "APPROVED" {
 			result.ReviewState = "approved"
 		} else {
@@ -689,6 +848,8 @@ func appendPRComment(comments []prComment, node prGraphQLComment, kind string, o
 		Kind:      kind,
 		Bot:       node.Author.TypeName != "User",
 		CreatedAt: node.CreatedAt,
+		Body:      strings.TrimSpace(node.BodyText),
+		Location:  node.location(),
 	})
 }
 
@@ -733,26 +894,50 @@ func summarizePRChecks(checks []prCheck) string {
 	return result
 }
 
+// prWaitResult is one wait's answer: what happened, everything that happened,
+// and the cursor the next wait should start from.
+type prWaitResult struct {
+	Observation *prReadiness
+	Outcome     prOutcome
+	Events      []prOutcome
+	Cursor      prWaitCursor
+}
+
 // waitForPRActionable returns on the first poll that sees an actionable update.
 // It returns every event that poll saw, ranked, plus the winner the exit code
 // reports; a caller that only wants the winner can ignore the rest. The error
 // return is reserved for the waiter itself failing; every product outcome,
 // including a timeout, comes back as a prOutcome so the caller can report it
 // uniformly.
-func waitForPRActionable(ctx context.Context, source prReadinessSource, opts prWaitOptions, progress io.Writer) (*prReadiness, prOutcome, []prOutcome, error) {
+//
+// `cursor` is what a previous wait already reported, and starting from it is what
+// closes the window between two calls. Zero means "baseline from the pull
+// request's current state", which is right for a first call: nothing that
+// happened before the agent started watching is news.
+func waitForPRActionable(ctx context.Context, source prReadinessSource, opts prWaitOptions, cursor prWaitCursor, progress io.Writer) (prWaitResult, error) {
 	var lastLine, lastHead string
 	var baseline map[string]bool
 	var reviewBaseline time.Time
 	var notedStaleVerdict bool
 	last := &prReadiness{Number: strconv.Itoa(opts.Number), Reviewer: opts.Reviewer, CheckState: checksNone, ReviewState: "waiting"}
+	if !opts.Since.IsZero() {
+		// --since is the manual override: report everything after this instant and
+		// forget what any previous wait recorded.
+		cursor = prWaitCursor{VerdictAt: opts.Since}
+		baseline = map[string]bool{}
+		reviewBaseline = opts.Since
+	} else if !cursor.empty() {
+		baseline = cursor.seenComments()
+		reviewBaseline = cursor.VerdictAt
+	}
 
 	for {
 		observation, err := source.Fetch(ctx, opts)
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
-				return last, outcomeTimeout, []prOutcome{outcomeTimeout}, nil
+				return prWaitResult{Observation: last, Outcome: outcomeTimeout, Events: []prOutcome{outcomeTimeout}, Cursor: cursor}, nil
 			}
-			return last, "", nil, err
+			return prWaitResult{Observation: last}, err
 		}
 		last = observation
 
@@ -773,6 +958,12 @@ func waitForPRActionable(ctx context.Context, source prReadinessSource, opts prW
 			for _, comment := range observation.Comments {
 				baseline[comment.ID] = true
 			}
+			// The baseline is also what the next wait must not be told again, so
+			// it goes straight into the cursor: a wait that ends in a timeout
+			// reports nothing, and without this the following call would rebuild
+			// the same baseline from a later state and swallow whatever landed in
+			// between.
+			cursor.CommentIDs = append(cursor.CommentIDs, prCommentIDs(observation.Comments)...)
 			// Mirror the comment baseline for reviews: the reviewer's newest
 			// review at wait start is stale context, so a verdict returns only
 			// when it (or a re-review) is newer than this.
@@ -783,7 +974,7 @@ func waitForPRActionable(ctx context.Context, source prReadinessSource, opts prW
 			// the wait on this very poll: no comment arrived during it.
 			observation.Comments = nil
 		} else {
-			observation.Comments = unseenPRComments(observation.Comments, baseline)
+			observation.Comments = unseenPRComments(observation.Comments, baseline, opts.Since)
 		}
 
 		// An existing verdict that a pending re-review holds back is not a return
@@ -802,7 +993,11 @@ func waitForPRActionable(ctx context.Context, source prReadinessSource, opts prW
 		if observation.State != "open" {
 			events = append(events, outcomeClosed)
 		}
-		if observation.CheckState == checksFailed {
+		// A failing check is a condition, not an occurrence: it stays true until
+		// someone pushes. Reporting it again for the same checks on the same commit
+		// would turn a second wait into an instant return with nothing new in it,
+		// which is the hot loop a caller uses this command to avoid.
+		if observation.CheckState == checksFailed && !cursor.sameFailure(observation.HeadSHA, observation.Checks) {
 			events = append(events, outcomeChecksFailed)
 		}
 		if freshReviewVerdict(observation, reviewBaseline) {
@@ -820,11 +1015,16 @@ func waitForPRActionable(ctx context.Context, source prReadinessSource, opts prW
 			events = append(events, outcomeBotComment)
 		}
 		if winner, ranked := rankPROutcomes(events); winner != "" {
-			return observation, winner, ranked, nil
+			return prWaitResult{
+				Observation: observation,
+				Outcome:     winner,
+				Events:      ranked,
+				Cursor:      advancePRWaitCursor(cursor, observation, ranked),
+			}, nil
 		}
 
 		if err := waitPRPoll(ctx, opts.Interval); err != nil {
-			return observation, outcomeTimeout, []prOutcome{outcomeTimeout}, nil
+			return prWaitResult{Observation: observation, Outcome: outcomeTimeout, Events: []prOutcome{outcomeTimeout}, Cursor: cursor}, nil
 		}
 	}
 }
@@ -842,14 +1042,53 @@ func freshReviewVerdict(observation *prReadiness, baseline time.Time) bool {
 	return observation.ReviewSubmittedAt.After(baseline)
 }
 
-func unseenPRComments(comments []prComment, baseline map[string]bool) []prComment {
+// unseenPRComments keeps the comments the caller has not been told about. `since`
+// is the --since override: it selects by arrival time instead of by identity, so
+// a caller can replay a window without knowing any comment IDs.
+func unseenPRComments(comments []prComment, baseline map[string]bool, since time.Time) []prComment {
 	var fresh []prComment
 	for _, comment := range comments {
-		if !baseline[comment.ID] {
-			fresh = append(fresh, comment)
+		if baseline[comment.ID] {
+			continue
 		}
+		if !since.IsZero() && !comment.CreatedAt.After(since) {
+			continue
+		}
+		fresh = append(fresh, comment)
 	}
 	return fresh
+}
+
+func prCommentIDs(comments []prComment) []string {
+	ids := make([]string, 0, len(comments))
+	for _, comment := range comments {
+		ids = append(ids, comment.ID)
+	}
+	return ids
+}
+
+// advancePRWaitCursor records what this wait reported, and nothing more. A poll
+// sees more than it returns — a failure it recognized as already-reported, a
+// verdict held back by a pending re-review — and folding those in would mark them
+// seen without anyone having been told.
+func advancePRWaitCursor(cursor prWaitCursor, observation *prReadiness, events []prOutcome) prWaitCursor {
+	reported := make(map[prOutcome]bool, len(events))
+	for _, event := range events {
+		reported[event] = true
+	}
+	// observation.Comments is already reduced to the ones being reported, and a
+	// poll carrying both human and bot remarks reports them together.
+	if reported[outcomeComment] || reported[outcomeBotComment] {
+		cursor.CommentIDs = append(cursor.CommentIDs, prCommentIDs(observation.Comments)...)
+	}
+	if reported[outcomeApproved] || reported[outcomeChangesRequested] {
+		cursor.VerdictAt = observation.ReviewSubmittedAt
+	}
+	if reported[outcomeChecksFailed] {
+		cursor.FailureHead = observation.HeadSHA
+		cursor.FailureChecks = failedCheckNames(observation.Checks)
+	}
+	return cursor
 }
 
 func waitPRPoll(ctx context.Context, interval time.Duration) error {
@@ -917,6 +1156,8 @@ options:
   --interval duration             poll interval (default 20s)
   --ignore-author login           comment author to ignore (repeatable)
   --json                          emit the result as JSON on stdout
+  --reset                         forget earlier waits; baseline from now
+  --since RFC3339                 report anything after this instant instead
 
 One poll can see several of these at once. The exit code reports the highest
 ranked: closed, checks failed, changes requested, human comment, approved, bot
@@ -935,6 +1176,19 @@ wait start is likewise baselined: while the reviewer is re-requested (a re-revie
 is pending) the pre-existing verdict is stale and does not end the wait; only a
 review submitted after the baseline does. When the reviewer is not re-requested,
 an existing verdict returns immediately.
+
+Successive waits on the same pull request resume rather than re-baseline. Each
+wait records what it reported under the data dir, so a remark that lands while the
+caller is answering the previous one is still reported by the next wait instead of
+being absorbed into a fresh baseline. The same memory keeps a failing check from
+returning instantly a second time for the same checks on the same commit; a
+different failure, or the same one on a new commit, is reported again. --json
+echoes the recorded position; --reset discards it and --since replays from an
+instant of your choosing.
+
+Also printed on stdout: comment bodies with their file:line when inline, the
+verdict's own text, failing check names with their URLs, and the pull request URL
+— so acting on the result needs no second query.
 
 exit: 0 approved; 1 checks failed; 2 usage; 3 changes requested; 4 human comment;
       5 error; 6 bot comment; 124 timeout

--- a/cmd/attn/pr_cursor.go
+++ b/cmd/attn/pr_cursor.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// prWaitCursor is what a previous wait on this pull request already reported.
+//
+// Without it, every call baselines from the pull request's current state, so
+// anything that happened between one wait returning and the next one starting is
+// absorbed into the new baseline and never reported: the agent answers a comment,
+// waits again, and a remark that landed while it was working is now "already
+// there". The wait then blocks for its whole timeout as if the PR were quiet.
+// That is the failure this file exists to prevent, and it is worse than a wrong
+// exit code because a swallowed event is invisible.
+//
+// It therefore records the three different shapes an event comes in, because
+// "seen" means something different for each:
+//
+//   - comments are discrete, so their IDs are the record, and one already
+//     reported is never news again;
+//   - a verdict supersedes itself, so the record is when it was submitted. It is
+//     the baseline a later wait measures a re-review against, not a suppression:
+//     an approval or changes-requested that still stands is the pull request's
+//     current answer and every wait should say so;
+//   - a failing check is a condition that stays true, so the record is which
+//     checks failed on which commit — the same failure on the same commit is not
+//     news twice, while a different one, or the same one after a push, is.
+//
+// The cursor advances to what a wait reported, plus the state a first-ever wait
+// deliberately treats as pre-existing context — in other words, exactly what the
+// caller need not be told again. Advancing it to everything a poll saw would lose
+// events permanently, silently.
+type prWaitCursor struct {
+	CommentIDs    []string  `json:"comment_ids,omitempty"`
+	VerdictAt     time.Time `json:"verdict_at,omitempty"`
+	FailureHead   string    `json:"failure_head,omitempty"`
+	FailureChecks []string  `json:"failure_checks,omitempty"`
+	UpdatedAt     time.Time `json:"updated_at,omitempty"`
+}
+
+// MarshalJSON keeps zero timestamps out of the encoded cursor. `omitempty` does
+// not apply to time.Time, and a cursor echoed to a caller with
+// "verdict_at":"0001-01-01T00:00:00Z" reads as a bug rather than as "no verdict
+// has been reported".
+func (c prWaitCursor) MarshalJSON() ([]byte, error) {
+	type payload struct {
+		CommentIDs    []string   `json:"comment_ids,omitempty"`
+		VerdictAt     *time.Time `json:"verdict_at,omitempty"`
+		FailureHead   string     `json:"failure_head,omitempty"`
+		FailureChecks []string   `json:"failure_checks,omitempty"`
+		UpdatedAt     *time.Time `json:"updated_at,omitempty"`
+	}
+	out := payload{CommentIDs: c.CommentIDs, FailureHead: c.FailureHead, FailureChecks: c.FailureChecks}
+	if !c.VerdictAt.IsZero() {
+		out.VerdictAt = &c.VerdictAt
+	}
+	if !c.UpdatedAt.IsZero() {
+		out.UpdatedAt = &c.UpdatedAt
+	}
+	return json.Marshal(out)
+}
+
+func (c prWaitCursor) empty() bool {
+	return len(c.CommentIDs) == 0 && c.VerdictAt.IsZero() && c.FailureHead == ""
+}
+
+func (c prWaitCursor) seenComments() map[string]bool {
+	seen := make(map[string]bool, len(c.CommentIDs))
+	for _, id := range c.CommentIDs {
+		seen[id] = true
+	}
+	return seen
+}
+
+// sameFailure reports whether a failing-checks observation is the one already
+// reported. Check order comes from the API, so compare as a set.
+func (c prWaitCursor) sameFailure(head string, checks []prCheck) bool {
+	if c.FailureHead != head {
+		return false
+	}
+	names := failedCheckNames(checks)
+	sort.Strings(names)
+	previous := append([]string(nil), c.FailureChecks...)
+	sort.Strings(previous)
+	return strings.Join(names, "\n") == strings.Join(previous, "\n")
+}
+
+// prCursorFileLimit caps how many comment IDs a cursor carries. A PR's comment
+// surfaces are queried newest-100 anyway, so an ID older than that window can
+// never come back as unseen and keeping it would grow the file forever.
+const prCursorFileLimit = 500
+
+// prCursorMaxAge is how long a cursor outlives its last use. Each file is a few
+// hundred bytes, but one per pull request ever waited on is unbounded, and
+// nothing else would ever clean the directory.
+const prCursorMaxAge = 30 * 24 * time.Hour
+
+// cursorPath locates one pull request's cursor. Every segment is a legal
+// filename without escaping: a GitHub owner or repository name cannot contain a
+// slash and the host is a domain, which also keeps the tree readable by hand.
+func cursorPath(dir string, opts prWaitOptions) string {
+	host := opts.Host
+	if host == "" {
+		host = "github.com"
+	}
+	return filepath.Join(dir, host, opts.Owner, opts.Name, fmt.Sprintf("%d.json", opts.Number))
+}
+
+// loadPRWaitCursor reads the cursor for this pull request. A missing file is the
+// normal first call, not an error. A file that cannot be parsed is treated the
+// same way: the cursor is an optimization over re-baselining, and refusing to
+// wait because of a corrupt one would be worse than losing its history.
+func loadPRWaitCursor(dir string, opts prWaitOptions) (prWaitCursor, error) {
+	if dir == "" {
+		return prWaitCursor{}, nil
+	}
+	data, err := os.ReadFile(cursorPath(dir, opts))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return prWaitCursor{}, nil
+		}
+		return prWaitCursor{}, err
+	}
+	var cursor prWaitCursor
+	if err := json.Unmarshal(data, &cursor); err != nil {
+		return prWaitCursor{}, fmt.Errorf("parse cursor %s: %w", cursorPath(dir, opts), err)
+	}
+	return cursor, nil
+}
+
+// savePRWaitCursor writes the cursor atomically — temp file in the same
+// directory, then rename — so a wait killed mid-write leaves either the old
+// cursor or the new one. A half-written file would be unparseable and would drop
+// the whole history for that pull request.
+func savePRWaitCursor(dir string, opts prWaitOptions, cursor prWaitCursor, now time.Time) error {
+	if dir == "" {
+		return nil
+	}
+	if len(cursor.CommentIDs) > prCursorFileLimit {
+		cursor.CommentIDs = cursor.CommentIDs[len(cursor.CommentIDs)-prCursorFileLimit:]
+	}
+	cursor.UpdatedAt = now
+	path := cursorPath(dir, opts)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(cursor, "", "  ")
+	if err != nil {
+		return err
+	}
+	temp, err := os.CreateTemp(filepath.Dir(path), ".cursor-*")
+	if err != nil {
+		return err
+	}
+	if _, err := temp.Write(append(data, '\n')); err != nil {
+		temp.Close()
+		os.Remove(temp.Name())
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		os.Remove(temp.Name())
+		return err
+	}
+	if err := os.Rename(temp.Name(), path); err != nil {
+		os.Remove(temp.Name())
+		return err
+	}
+	prunePRWaitCursors(dir, now)
+	return nil
+}
+
+// prunePRWaitCursors drops cursors nothing has touched in prCursorMaxAge. Best
+// effort: a failure to prune must never fail a wait.
+func prunePRWaitCursors(dir string, now time.Time) {
+	cutoff := now.Add(-prCursorMaxAge)
+	_ = filepath.WalkDir(dir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry.IsDir() || !strings.HasSuffix(path, ".json") {
+			return nil
+		}
+		if info, statErr := entry.Info(); statErr == nil && info.ModTime().Before(cutoff) {
+			os.Remove(path)
+		}
+		return nil
+	})
+}

--- a/cmd/attn/pr_test.go
+++ b/cmd/attn/pr_test.go
@@ -162,6 +162,14 @@ func TestParsePRSnapshotTagsBotCommentsAndDropsIgnoredAuthors(t *testing.T) {
 	if readiness.ReviewState != "waiting" {
 		t.Fatalf("COMMENTED review changed review state: %#v", readiness)
 	}
+	// A prose review is reported as a remark, so it has to carry its prose: a
+	// header with no body sends the caller back to GitHub for the one thing the
+	// event was about.
+	for _, comment := range readiness.Comments {
+		if comment.ID == "r1" && comment.Body != "a real review remark" {
+			t.Fatalf("review comment lost its body: %#v", comment)
+		}
+	}
 }
 
 // GitHub wraps a standalone inline comment in a bodyless COMMENTED review.

--- a/cmd/attn/pr_test.go
+++ b/cmd/attn/pr_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -110,7 +112,10 @@ func TestParsePRSnapshotRequiresGreenChecksAndCurrentHeadApproval(t *testing.T) 
 	}
 }
 
-func TestParsePRSnapshotCollectsHumanCommentsAndDropsBots(t *testing.T) {
+// Bot comments are collected and tagged rather than dropped: they are their own
+// event with their own exit code, so the caller decides whether to care.
+// `--ignore-author` is the only thing that removes a comment outright.
+func TestParsePRSnapshotTagsBotCommentsAndDropsIgnoredAuthors(t *testing.T) {
 	head := strings.Repeat("a", 40)
 	reviews := reviewNode("r1", "COMMENTED", "a real review remark", "2026-07-19T10:00:00Z", "figgyster", head,
 		inlineNode("t1", "2026-07-19T11:00:00Z", "figgyster"))
@@ -126,12 +131,24 @@ func TestParsePRSnapshotCollectsHumanCommentsAndDropsBots(t *testing.T) {
 
 	var got []string
 	for _, comment := range readiness.Comments {
-		got = append(got, comment.ID+":"+comment.Kind+":"+comment.Author)
+		kind := "human"
+		if comment.Bot {
+			kind = "bot"
+		}
+		got = append(got, comment.ID+":"+comment.Kind+":"+comment.Author+":"+kind)
 	}
-	// Sorted oldest-first; the bot and the ignored author are gone.
-	want := []string{"c1:issue:victorarias", "r1:review:figgyster", "t1:inline:figgyster"}
+	// Sorted oldest-first; the ignored author is gone and the bot is tagged.
+	want := []string{
+		"c1:issue:victorarias:human",
+		"c2:issue:chatgpt-codex-connector:bot",
+		"r1:review:figgyster:human",
+		"t1:inline:figgyster:human",
+	}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("comments = %v, want %v", got, want)
+	}
+	if len(humanPRComments(readiness.Comments)) != 3 || len(botPRComments(readiness.Comments)) != 1 {
+		t.Fatalf("split = %d human / %d bot", len(humanPRComments(readiness.Comments)), len(botPRComments(readiness.Comments)))
 	}
 	// A COMMENTED review carries no verdict and must not move the review state.
 	if readiness.ReviewState != "waiting" {
@@ -244,7 +261,7 @@ func TestWaitForPRActionableResetsAcrossHeadChangeAndSuppressesDuplicatePolls(t 
 	opts := prWaitOptions{Number: 12, Owner: "owner", Name: "repo", Reviewer: "figgyster", Interval: 0}
 
 	var output bytes.Buffer
-	got, outcome, err := waitForPRActionable(context.Background(), source, opts, &output)
+	got, outcome, _, err := waitForPRActionable(context.Background(), source, opts, &output)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -269,7 +286,7 @@ func TestWaitForPRActionableReturnsPromptlyOnChangesRequested(t *testing.T) {
 	observation := readinessObservation("12", head, checksGreen, "changes_requested")
 	source := &fakeReadinessSource{results: []*prReadiness{observation}}
 
-	got, outcome, err := waitForPRActionable(context.Background(), source, prWaitOptions{Reviewer: "figgyster"}, &bytes.Buffer{})
+	got, outcome, _, err := waitForPRActionable(context.Background(), source, prWaitOptions{Reviewer: "figgyster"}, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +311,7 @@ func TestWaitForPRActionableBaselinesExistingCommentsAndWakesOnNewOnes(t *testin
 	third.Comments = []prComment{existing, fresh}
 	source := &fakeReadinessSource{results: []*prReadiness{first, second, third}}
 
-	got, outcome, err := waitForPRActionable(context.Background(), source, prWaitOptions{Reviewer: "figgyster"}, &bytes.Buffer{})
+	got, outcome, _, err := waitForPRActionable(context.Background(), source, prWaitOptions{Reviewer: "figgyster"}, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -309,14 +326,14 @@ func TestWaitForPRActionableBaselinesExistingCommentsAndWakesOnNewOnes(t *testin
 
 func TestWaitForPRActionableReportsCheckFailureAndClosure(t *testing.T) {
 	failed := readinessObservation("12", strings.Repeat("c", 40), checksFailed, "approved")
-	_, outcome, err := waitForPRActionable(context.Background(), &fakeReadinessSource{results: []*prReadiness{failed}}, prWaitOptions{}, &bytes.Buffer{})
+	_, outcome, _, err := waitForPRActionable(context.Background(), &fakeReadinessSource{results: []*prReadiness{failed}}, prWaitOptions{}, &bytes.Buffer{})
 	if err != nil || outcome != outcomeChecksFailed || outcome.exitCode() != prWaitExitChecksFailed {
 		t.Fatalf("outcome=%s err=%v", outcome, err)
 	}
 
 	closed := readinessObservation("12", strings.Repeat("c", 40), checksGreen, "waiting")
 	closed.State = "merged"
-	_, outcome, err = waitForPRActionable(context.Background(), &fakeReadinessSource{results: []*prReadiness{closed}}, prWaitOptions{}, &bytes.Buffer{})
+	_, outcome, _, err = waitForPRActionable(context.Background(), &fakeReadinessSource{results: []*prReadiness{closed}}, prWaitOptions{}, &bytes.Buffer{})
 	if err != nil || outcome != outcomeClosed || outcome.exitCode() != prWaitExitError {
 		t.Fatalf("outcome=%s err=%v", outcome, err)
 	}
@@ -328,7 +345,7 @@ func TestWaitForPRActionableReturnsTimeoutOutcome(t *testing.T) {
 	pending := readinessObservation("12", strings.Repeat("d", 40), checksPending, "waiting")
 	source := &fakeReadinessSource{results: []*prReadiness{pending}}
 
-	_, outcome, err := waitForPRActionable(ctx, source, prWaitOptions{Interval: time.Hour}, &bytes.Buffer{})
+	_, outcome, _, err := waitForPRActionable(ctx, source, prWaitOptions{Interval: time.Hour}, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -342,22 +359,22 @@ func TestReportPROutcomeWritesPlainTextAndJSON(t *testing.T) {
 	result := readinessObservation("12", head, checksGreen, "approved")
 
 	var plain bytes.Buffer
-	if code := reportPROutcome(result, outcomeApproved, prWaitOptions{}, &plain); code != prWaitExitApproved {
+	if code := reportPROutcome(result, outcomeApproved, []prOutcome{outcomeApproved}, prWaitOptions{}, &plain); code != prWaitExitApproved {
 		t.Fatalf("exit code = %d", code)
 	}
 	if got := plain.String(); !strings.HasPrefix(got, "approved: figgyster approved eeeeeeeeeeee") {
 		t.Fatalf("plain output = %q", got)
 	}
 
-	// Baseline comments on the observation are not news on a non-comment outcome.
 	result.Comments = []prComment{{ID: "c1", Author: "victorarias", Kind: "issue"}}
 	var encoded bytes.Buffer
-	code := reportPROutcome(result, outcomeChangesRequested, prWaitOptions{JSON: true}, &encoded)
+	code := reportPROutcome(result, outcomeChangesRequested, []prOutcome{outcomeChangesRequested}, prWaitOptions{JSON: true}, &encoded)
 	if code != prWaitExitChangesRequested {
 		t.Fatalf("exit code = %d", code)
 	}
 	var payload struct {
 		Outcome  string      `json:"outcome"`
+		Events   []string    `json:"events"`
 		Head     string      `json:"head"`
 		Detail   string      `json:"detail"`
 		Comments []prComment `json:"comments"`
@@ -372,9 +389,217 @@ func TestReportPROutcomeWritesPlainTextAndJSON(t *testing.T) {
 		!strings.Contains(payload.Detail, "requested changes") {
 		t.Fatalf("payload = %#v", payload)
 	}
-	if len(payload.Comments) != 0 {
-		t.Fatalf("baseline comments reported as new: %#v", payload.Comments)
+	// Comments ride along whatever event won: the waiter has already reduced them
+	// to what arrived during the wait, so withholding them here would only make
+	// the caller re-query for news this poll already had.
+	if len(payload.Comments) != 1 || payload.Comments[0].Author != "victorarias" {
+		t.Fatalf("comments = %#v, want the fresh comment reported beside the verdict", payload.Comments)
 	}
+	if strings.Join(payload.Events, ",") != "changes_requested" {
+		t.Fatalf("events = %v", payload.Events)
+	}
+}
+
+// The regression that motivated the rewrite: figgyster approves with prose, and
+// the approval used to be reported as "a new comment" — exit 4, not 0 — because
+// the review body was collected as commentary and the comment branch returned
+// before the verdict branch was ever evaluated.
+func TestWaitForPRActionableApprovalWithBodyIsOneEvent(t *testing.T) {
+	head := strings.Repeat("f", 40)
+	at := mustTime(t, "2026-07-26T10:00:00Z")
+	reviews := reviewNode("r1", "APPROVED", "Approved. The witness is the proof I wanted.", "2026-07-26T10:00:00Z", "figgyster", head, "")
+	opts := prWaitOptions{Reviewer: "figgyster", Interval: 0}
+
+	observation, err := parsePRSnapshot(snapshotPayload(head, "", reviews, ""), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(observation.Comments) != 0 {
+		t.Fatalf("the verdict body was collected as a comment: %#v", observation.Comments)
+	}
+	if observation.ReviewState != "approved" || !observation.ReviewSubmittedAt.Equal(at) {
+		t.Fatalf("verdict not read: %#v", observation)
+	}
+
+	// Drive it through the waiter with the verdict arriving during the wait, so
+	// the baseline cannot be what hides the phantom comment.
+	waiting, err := parsePRSnapshot(snapshotPayload(head, "", "", ""), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := &fakeReadinessSource{results: []*prReadiness{waiting, observation}}
+	_, outcome, events, err := waitForPRActionable(context.Background(), source, opts, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != outcomeApproved || outcome.exitCode() != prWaitExitApproved {
+		t.Fatalf("outcome = %s (exit %d), want approved", outcome, outcome.exitCode())
+	}
+	if strings.Join(outcomeStrings(events), ",") != "approved" {
+		t.Fatalf("events = %v, want the verdict alone", outcomeStrings(events))
+	}
+
+	// A COMMENTED review from the same reviewer stays commentary: it is how they
+	// say something without answering.
+	remark := reviewNode("r2", "COMMENTED", "one question before I approve", "2026-07-26T10:05:00Z", "figgyster", head, "")
+	commented, err := parsePRSnapshot(snapshotPayload(head, "", remark, ""), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(commented.Comments) != 1 || commented.Comments[0].Kind != "review" {
+		t.Fatalf("a COMMENTED review must stay a comment: %#v", commented.Comments)
+	}
+}
+
+// One poll can hold several events. The exit code names the highest ranked, and
+// the rest must still be reported — a caller that gets `comment` alongside an
+// approval should not have to re-query to learn it can merge once answered.
+func TestWaitForPRActionableRanksConcurrentEventsAndReportsAll(t *testing.T) {
+	head := strings.Repeat("g", 40)
+	opts := prWaitOptions{Reviewer: "figgyster", Interval: 0}
+	human := prComment{ID: "c1", Author: "victorarias", Kind: "issue", CreatedAt: time.Unix(2, 0)}
+	bot := prComment{ID: "c2", Author: "react-doctor", Kind: "issue", Bot: true, CreatedAt: time.Unix(3, 0)}
+
+	first := readinessObservation("12", head, checksPending, "waiting")
+	second := readinessObservation("12", head, checksGreen, "approved")
+	second.Comments = []prComment{human, bot}
+	source := &fakeReadinessSource{results: []*prReadiness{first, second}}
+
+	var output bytes.Buffer
+	_, outcome, events, err := waitForPRActionable(context.Background(), source, opts, &output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Human comment outranks both the bot's and the approval: someone has to read
+	// it before the approval means anything. The bot ranks below the approval —
+	// nobody is waiting on a doctor report, and it comments on nearly every push.
+	if outcome != outcomeComment {
+		t.Fatalf("outcome = %s, want the human comment to win", outcome)
+	}
+	if got := strings.Join(outcomeStrings(events), ","); got != "comment,approved,bot_comment" {
+		t.Fatalf("events = %s, want all three ranked", got)
+	}
+
+	var plain bytes.Buffer
+	if code := reportPROutcome(second, outcome, events, opts, &plain); code != prWaitExitComment {
+		t.Fatalf("exit code = %d, want %d", code, prWaitExitComment)
+	}
+	text := plain.String()
+	for _, want := range []string{"comment: 1 new comment from victorarias", "also approved:", "also bot_comment: 1 new comment from react-doctor"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("plain output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+// A failing check outranks any comment. The comment check used to return before
+// the check state was ever looked at, so a poll that saw both reported exit 4
+// while its own payload said the checks had failed.
+func TestWaitForPRActionableChecksFailedOutranksComment(t *testing.T) {
+	head := strings.Repeat("h", 40)
+	opts := prWaitOptions{Reviewer: "figgyster", Interval: 0}
+	first := readinessObservation("12", head, checksPending, "waiting")
+	second := readinessObservation("12", head, checksFailed, "waiting")
+	second.Comments = []prComment{{ID: "c1", Author: "victorarias", Kind: "issue", CreatedAt: time.Unix(2, 0)}}
+
+	_, outcome, events, err := waitForPRActionable(context.Background(),
+		&fakeReadinessSource{results: []*prReadiness{first, second}}, opts, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != outcomeChecksFailed || outcome.exitCode() != prWaitExitChecksFailed {
+		t.Fatalf("outcome = %s, want checks_failed to outrank the comment", outcome)
+	}
+	if got := strings.Join(outcomeStrings(events), ","); got != "checks_failed,comment" {
+		t.Fatalf("events = %s", got)
+	}
+}
+
+// A bot comment is its own event with its own exit code, so a caller can wake on
+// a doctor report without treating it as a human waiting for an answer.
+func TestWaitForPRActionableBotCommentIsItsOwnEvent(t *testing.T) {
+	head := strings.Repeat("i", 40)
+	opts := prWaitOptions{Reviewer: "figgyster", Interval: 0}
+	first := readinessObservation("12", head, checksPending, "waiting")
+	second := readinessObservation("12", head, checksPending, "waiting")
+	second.Comments = []prComment{{ID: "c1", Author: "react-doctor", Kind: "issue", Bot: true, CreatedAt: time.Unix(2, 0)}}
+
+	_, outcome, events, err := waitForPRActionable(context.Background(),
+		&fakeReadinessSource{results: []*prReadiness{first, second}}, opts, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != outcomeBotComment || outcome.exitCode() != prWaitExitBotComment {
+		t.Fatalf("outcome = %s (exit %d), want bot_comment", outcome, outcome.exitCode())
+	}
+	if got := strings.Join(outcomeStrings(events), ","); got != "bot_comment" {
+		t.Fatalf("events = %s", got)
+	}
+
+	// --ignore-author silences a bot exactly as it silences a human.
+	ignoring := prWaitOptions{Reviewer: "figgyster", Interval: 0, IgnoreAuthors: []string{"react-doctor"}}
+	snapshot, err := parsePRSnapshot(snapshotPayload(head, "",
+		"", `{"id":"c1","createdAt":"2026-07-26T10:00:00Z","author":{"__typename":"Bot","login":"react-doctor"}}`), ignoring)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Comments) != 0 {
+		t.Fatalf("ignored bot still collected: %#v", snapshot.Comments)
+	}
+}
+
+// The fixture is a real `gh api graphql` response for the pull request that
+// exposed the bug — figgyster's approval carrying prose, plus a react-doctor
+// comment — with `state` flipped to OPEN so the closed event does not short the
+// wait. Hand-built fragments prove the logic; this proves the field names and
+// author typenames it keys on are GitHub's.
+func TestParsePRSnapshotAgainstRealApprovalPayload(t *testing.T) {
+	payload, err := os.ReadFile(filepath.Join("testdata", "pr-approval-with-body.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts := prWaitOptions{Reviewer: "figgyster", Interval: 0}
+	observation, err := parsePRSnapshot(payload, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observation.ReviewState != "approved" || observation.CheckState != checksGreen || !observation.ready() {
+		t.Fatalf("real approval not read as ready: %#v", observation)
+	}
+	if len(humanPRComments(observation.Comments)) != 0 {
+		t.Fatalf("verdict prose collected as a human comment: %#v", humanPRComments(observation.Comments))
+	}
+	bots := botPRComments(observation.Comments)
+	if len(bots) != 1 || bots[0].Author != "github-actions" || !bots[0].Bot {
+		t.Fatalf("bot comment = %#v, want the react-doctor post tagged as a bot", bots)
+	}
+
+	// End to end: the bot comment arrives during the wait alongside the approval,
+	// and the approval is what the exit code reports.
+	first, err := parsePRSnapshot(payload, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first.ReviewState, first.ReviewSubmittedAt = "waiting", time.Time{}
+	_, outcome, events, err := waitForPRActionable(context.Background(),
+		&fakeReadinessSource{results: []*prReadiness{first, observation}}, opts, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != outcomeApproved || outcome.exitCode() != prWaitExitApproved {
+		t.Fatalf("outcome = %s (exit %d), want approved", outcome, outcome.exitCode())
+	}
+	if got := strings.Join(outcomeStrings(events), ","); got != "approved" {
+		t.Fatalf("events = %s; the bot comment was in the baseline, so only the verdict is news", got)
+	}
+}
+
+func outcomeStrings(events []prOutcome) []string {
+	result := make([]string, 0, len(events))
+	for _, event := range events {
+		result = append(result, string(event))
+	}
+	return result
 }
 
 // A re-review request marks any pre-existing verdict as stale: parse must
@@ -429,7 +654,7 @@ func TestWaitForPRActionableIgnoresStaleVerdictWhileReReviewPending(t *testing.T
 	opts := prWaitOptions{Reviewer: "figgyster", Interval: 0}
 
 	var output bytes.Buffer
-	got, outcome, err := waitForPRActionable(context.Background(), source, opts, &output)
+	got, outcome, _, err := waitForPRActionable(context.Background(), source, opts, &output)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -461,7 +686,7 @@ func TestWaitForPRActionableReturnsOnFreshChangesRequestedAfterReReview(t *testi
 	fresh := reReviewObservation(head, checksGreen, "changes_requested", true, freshAt, freshAt)
 	source := &fakeReadinessSource{results: []*prReadiness{stale, fresh}}
 
-	got, outcome, err := waitForPRActionable(context.Background(), source, prWaitOptions{Reviewer: "figgyster", Interval: 0}, &bytes.Buffer{})
+	got, outcome, _, err := waitForPRActionable(context.Background(), source, prWaitOptions{Reviewer: "figgyster", Interval: 0}, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -481,7 +706,7 @@ func TestWaitForPRActionableReturnsImmediatelyWithoutReReview(t *testing.T) {
 
 	approved := reReviewObservation(head, checksGreen, "approved", false, at, at)
 	source := &fakeReadinessSource{results: []*prReadiness{approved}}
-	got, outcome, err := waitForPRActionable(context.Background(), source, prWaitOptions{Reviewer: "figgyster", Interval: 0}, &bytes.Buffer{})
+	got, outcome, _, err := waitForPRActionable(context.Background(), source, prWaitOptions{Reviewer: "figgyster", Interval: 0}, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -491,7 +716,7 @@ func TestWaitForPRActionableReturnsImmediatelyWithoutReReview(t *testing.T) {
 
 	changes := reReviewObservation(head, checksGreen, "changes_requested", false, at, at)
 	source = &fakeReadinessSource{results: []*prReadiness{changes}}
-	got, outcome, err = waitForPRActionable(context.Background(), source, prWaitOptions{Reviewer: "figgyster", Interval: 0}, &bytes.Buffer{})
+	got, outcome, _, err = waitForPRActionable(context.Background(), source, prWaitOptions{Reviewer: "figgyster", Interval: 0}, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/attn/pr_test.go
+++ b/cmd/attn/pr_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,6 +25,13 @@ func (f *fakeReadinessSource) Fetch(context.Context, prWaitOptions) (*prReadines
 		index = len(f.results) - 1
 	}
 	return f.results[index], nil
+}
+
+// waitTuple runs a first-ever wait — no remembered position — and unpacks the
+// result, for the tests that are about the outcome rather than the memory.
+func waitTuple(ctx context.Context, source prReadinessSource, opts prWaitOptions, progress io.Writer) (*prReadiness, prOutcome, []prOutcome, error) {
+	result, err := waitForPRActionable(ctx, source, opts, prWaitCursor{}, progress)
+	return result.Observation, result.Outcome, result.Events, err
 }
 
 // snapshotPayload wraps GraphQL fragments in the envelope gh api graphql emits.
@@ -204,7 +212,7 @@ func TestParsePRSnapshotSeesReplyOnLongDormantThread(t *testing.T) {
 	for _, comment := range baseline {
 		seen[comment.ID] = true
 	}
-	fresh := unseenPRComments(readiness.Comments, seen)
+	fresh := unseenPRComments(readiness.Comments, seen, time.Time{})
 	if len(fresh) != 1 || fresh[0].ID != "reply-t" {
 		t.Fatalf("reply on a dormant thread was missed: fresh = %#v", fresh)
 	}
@@ -261,7 +269,7 @@ func TestWaitForPRActionableResetsAcrossHeadChangeAndSuppressesDuplicatePolls(t 
 	opts := prWaitOptions{Number: 12, Owner: "owner", Name: "repo", Reviewer: "figgyster", Interval: 0}
 
 	var output bytes.Buffer
-	got, outcome, _, err := waitForPRActionable(context.Background(), source, opts, &output)
+	got, outcome, _, err := waitTuple(context.Background(), source, opts, &output)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -286,7 +294,7 @@ func TestWaitForPRActionableReturnsPromptlyOnChangesRequested(t *testing.T) {
 	observation := readinessObservation("12", head, checksGreen, "changes_requested")
 	source := &fakeReadinessSource{results: []*prReadiness{observation}}
 
-	got, outcome, _, err := waitForPRActionable(context.Background(), source, prWaitOptions{Reviewer: "figgyster"}, &bytes.Buffer{})
+	got, outcome, _, err := waitTuple(context.Background(), source, prWaitOptions{Reviewer: "figgyster"}, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -311,7 +319,7 @@ func TestWaitForPRActionableBaselinesExistingCommentsAndWakesOnNewOnes(t *testin
 	third.Comments = []prComment{existing, fresh}
 	source := &fakeReadinessSource{results: []*prReadiness{first, second, third}}
 
-	got, outcome, _, err := waitForPRActionable(context.Background(), source, prWaitOptions{Reviewer: "figgyster"}, &bytes.Buffer{})
+	got, outcome, _, err := waitTuple(context.Background(), source, prWaitOptions{Reviewer: "figgyster"}, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -326,14 +334,14 @@ func TestWaitForPRActionableBaselinesExistingCommentsAndWakesOnNewOnes(t *testin
 
 func TestWaitForPRActionableReportsCheckFailureAndClosure(t *testing.T) {
 	failed := readinessObservation("12", strings.Repeat("c", 40), checksFailed, "approved")
-	_, outcome, _, err := waitForPRActionable(context.Background(), &fakeReadinessSource{results: []*prReadiness{failed}}, prWaitOptions{}, &bytes.Buffer{})
+	_, outcome, _, err := waitTuple(context.Background(), &fakeReadinessSource{results: []*prReadiness{failed}}, prWaitOptions{}, &bytes.Buffer{})
 	if err != nil || outcome != outcomeChecksFailed || outcome.exitCode() != prWaitExitChecksFailed {
 		t.Fatalf("outcome=%s err=%v", outcome, err)
 	}
 
 	closed := readinessObservation("12", strings.Repeat("c", 40), checksGreen, "waiting")
 	closed.State = "merged"
-	_, outcome, _, err = waitForPRActionable(context.Background(), &fakeReadinessSource{results: []*prReadiness{closed}}, prWaitOptions{}, &bytes.Buffer{})
+	_, outcome, _, err = waitTuple(context.Background(), &fakeReadinessSource{results: []*prReadiness{closed}}, prWaitOptions{}, &bytes.Buffer{})
 	if err != nil || outcome != outcomeClosed || outcome.exitCode() != prWaitExitError {
 		t.Fatalf("outcome=%s err=%v", outcome, err)
 	}
@@ -345,7 +353,7 @@ func TestWaitForPRActionableReturnsTimeoutOutcome(t *testing.T) {
 	pending := readinessObservation("12", strings.Repeat("d", 40), checksPending, "waiting")
 	source := &fakeReadinessSource{results: []*prReadiness{pending}}
 
-	_, outcome, _, err := waitForPRActionable(ctx, source, prWaitOptions{Interval: time.Hour}, &bytes.Buffer{})
+	_, outcome, _, err := waitTuple(ctx, source, prWaitOptions{Interval: time.Hour}, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -359,7 +367,7 @@ func TestReportPROutcomeWritesPlainTextAndJSON(t *testing.T) {
 	result := readinessObservation("12", head, checksGreen, "approved")
 
 	var plain bytes.Buffer
-	if code := reportPROutcome(result, outcomeApproved, []prOutcome{outcomeApproved}, prWaitOptions{}, &plain); code != prWaitExitApproved {
+	if code := reportPROutcome(prWaitResult{Observation: result, Outcome: outcomeApproved, Events: []prOutcome{outcomeApproved}}, prWaitOptions{}, &plain); code != prWaitExitApproved {
 		t.Fatalf("exit code = %d", code)
 	}
 	if got := plain.String(); !strings.HasPrefix(got, "approved: figgyster approved eeeeeeeeeeee") {
@@ -368,7 +376,7 @@ func TestReportPROutcomeWritesPlainTextAndJSON(t *testing.T) {
 
 	result.Comments = []prComment{{ID: "c1", Author: "victorarias", Kind: "issue"}}
 	var encoded bytes.Buffer
-	code := reportPROutcome(result, outcomeChangesRequested, []prOutcome{outcomeChangesRequested}, prWaitOptions{JSON: true}, &encoded)
+	code := reportPROutcome(prWaitResult{Observation: result, Outcome: outcomeChangesRequested, Events: []prOutcome{outcomeChangesRequested}}, prWaitOptions{JSON: true}, &encoded)
 	if code != prWaitExitChangesRequested {
 		t.Fatalf("exit code = %d", code)
 	}
@@ -428,7 +436,7 @@ func TestWaitForPRActionableApprovalWithBodyIsOneEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 	source := &fakeReadinessSource{results: []*prReadiness{waiting, observation}}
-	_, outcome, events, err := waitForPRActionable(context.Background(), source, opts, &bytes.Buffer{})
+	_, outcome, events, err := waitTuple(context.Background(), source, opts, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -466,7 +474,7 @@ func TestWaitForPRActionableRanksConcurrentEventsAndReportsAll(t *testing.T) {
 	source := &fakeReadinessSource{results: []*prReadiness{first, second}}
 
 	var output bytes.Buffer
-	_, outcome, events, err := waitForPRActionable(context.Background(), source, opts, &output)
+	_, outcome, events, err := waitTuple(context.Background(), source, opts, &output)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -481,7 +489,7 @@ func TestWaitForPRActionableRanksConcurrentEventsAndReportsAll(t *testing.T) {
 	}
 
 	var plain bytes.Buffer
-	if code := reportPROutcome(second, outcome, events, opts, &plain); code != prWaitExitComment {
+	if code := reportPROutcome(prWaitResult{Observation: second, Outcome: outcome, Events: events}, opts, &plain); code != prWaitExitComment {
 		t.Fatalf("exit code = %d, want %d", code, prWaitExitComment)
 	}
 	text := plain.String()
@@ -502,7 +510,7 @@ func TestWaitForPRActionableChecksFailedOutranksComment(t *testing.T) {
 	second := readinessObservation("12", head, checksFailed, "waiting")
 	second.Comments = []prComment{{ID: "c1", Author: "victorarias", Kind: "issue", CreatedAt: time.Unix(2, 0)}}
 
-	_, outcome, events, err := waitForPRActionable(context.Background(),
+	_, outcome, events, err := waitTuple(context.Background(),
 		&fakeReadinessSource{results: []*prReadiness{first, second}}, opts, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
@@ -524,7 +532,7 @@ func TestWaitForPRActionableBotCommentIsItsOwnEvent(t *testing.T) {
 	second := readinessObservation("12", head, checksPending, "waiting")
 	second.Comments = []prComment{{ID: "c1", Author: "react-doctor", Kind: "issue", Bot: true, CreatedAt: time.Unix(2, 0)}}
 
-	_, outcome, events, err := waitForPRActionable(context.Background(),
+	_, outcome, events, err := waitTuple(context.Background(),
 		&fakeReadinessSource{results: []*prReadiness{first, second}}, opts, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
@@ -581,7 +589,7 @@ func TestParsePRSnapshotAgainstRealApprovalPayload(t *testing.T) {
 		t.Fatal(err)
 	}
 	first.ReviewState, first.ReviewSubmittedAt = "waiting", time.Time{}
-	_, outcome, events, err := waitForPRActionable(context.Background(),
+	_, outcome, events, err := waitTuple(context.Background(),
 		&fakeReadinessSource{results: []*prReadiness{first, observation}}, opts, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
@@ -654,7 +662,7 @@ func TestWaitForPRActionableIgnoresStaleVerdictWhileReReviewPending(t *testing.T
 	opts := prWaitOptions{Reviewer: "figgyster", Interval: 0}
 
 	var output bytes.Buffer
-	got, outcome, _, err := waitForPRActionable(context.Background(), source, opts, &output)
+	got, outcome, _, err := waitTuple(context.Background(), source, opts, &output)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -686,7 +694,7 @@ func TestWaitForPRActionableReturnsOnFreshChangesRequestedAfterReReview(t *testi
 	fresh := reReviewObservation(head, checksGreen, "changes_requested", true, freshAt, freshAt)
 	source := &fakeReadinessSource{results: []*prReadiness{stale, fresh}}
 
-	got, outcome, _, err := waitForPRActionable(context.Background(), source, prWaitOptions{Reviewer: "figgyster", Interval: 0}, &bytes.Buffer{})
+	got, outcome, _, err := waitTuple(context.Background(), source, prWaitOptions{Reviewer: "figgyster", Interval: 0}, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -706,7 +714,7 @@ func TestWaitForPRActionableReturnsImmediatelyWithoutReReview(t *testing.T) {
 
 	approved := reReviewObservation(head, checksGreen, "approved", false, at, at)
 	source := &fakeReadinessSource{results: []*prReadiness{approved}}
-	got, outcome, _, err := waitForPRActionable(context.Background(), source, prWaitOptions{Reviewer: "figgyster", Interval: 0}, &bytes.Buffer{})
+	got, outcome, _, err := waitTuple(context.Background(), source, prWaitOptions{Reviewer: "figgyster", Interval: 0}, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -716,12 +724,277 @@ func TestWaitForPRActionableReturnsImmediatelyWithoutReReview(t *testing.T) {
 
 	changes := reReviewObservation(head, checksGreen, "changes_requested", false, at, at)
 	source = &fakeReadinessSource{results: []*prReadiness{changes}}
-	got, outcome, _, err = waitForPRActionable(context.Background(), source, prWaitOptions{Reviewer: "figgyster", Interval: 0}, &bytes.Buffer{})
+	got, outcome, _, err = waitTuple(context.Background(), source, prWaitOptions{Reviewer: "figgyster", Interval: 0}, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if outcome != outcomeChangesRequested || got != changes || source.calls != 1 {
 		t.Fatalf("changes_requested not returned immediately: outcome=%s calls=%d", outcome, source.calls)
+	}
+}
+
+// A caller that has to go read the remark on GitHub is making the follow-up query
+// this command exists to remove, so the words themselves are part of the report.
+func TestReportPROutcomePrintsWhatWasSaid(t *testing.T) {
+	head := strings.Repeat("a", 40)
+	result := readinessObservation("12", head, checksFailed, "changes_requested")
+	result.URL = "https://github.com/victorarias/attn/pull/12"
+	result.ReviewBody = "The witness is missing."
+	result.Checks = []prCheck{
+		{Name: "CI", State: checksFailed, URL: "https://github.com/victorarias/attn/runs/1"},
+		{Name: "Lint", State: checksGreen},
+	}
+	result.Comments = []prComment{
+		{ID: "c1", Author: "victorarias", Kind: "review", Body: "This drops the guard.", Location: "cmd/attn/pr.go:42"},
+		{ID: "c2", Author: "react-doctor", Kind: "issue", Bot: true, Body: "One finding."},
+	}
+
+	var plain bytes.Buffer
+	events := []prOutcome{outcomeChecksFailed, outcomeChangesRequested, outcomeComment, outcomeBotComment}
+	reportPROutcome(prWaitResult{Observation: result, Outcome: outcomeChecksFailed, Events: events}, prWaitOptions{Reviewer: "figgyster"}, &plain)
+
+	for _, want := range []string{
+		"CI https://github.com/victorarias/attn/runs/1",
+		"--- figgyster ---",
+		"  The witness is missing.",
+		"--- victorarias on cmd/attn/pr.go:42 ---",
+		"  This drops the guard.",
+		"--- react-doctor ---",
+		"  One finding.",
+		"https://github.com/victorarias/attn/pull/12",
+	} {
+		if !strings.Contains(plain.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, plain.String())
+		}
+	}
+	if strings.Contains(plain.String(), "Lint https") {
+		t.Fatalf("a passing check was printed as a failure:\n%s", plain.String())
+	}
+
+	var encoded bytes.Buffer
+	reportPROutcome(prWaitResult{Observation: result, Outcome: outcomeChangesRequested, Events: events}, prWaitOptions{JSON: true, Reviewer: "figgyster"}, &encoded)
+	var payload struct {
+		URL    string `json:"url"`
+		Checks struct {
+			Failed []prCheck `json:"failed"`
+		} `json:"checks"`
+		Review struct {
+			Body string `json:"body"`
+		} `json:"review"`
+		Comments []prComment `json:"comments"`
+	}
+	if err := json.Unmarshal(encoded.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.URL == "" || payload.Review.Body != "The witness is missing." ||
+		len(payload.Checks.Failed) != 1 || payload.Checks.Failed[0].Name != "CI" ||
+		len(payload.Comments) != 2 || payload.Comments[0].Location != "cmd/attn/pr.go:42" ||
+		payload.Comments[0].Body != "This drops the guard." {
+		t.Fatalf("payload = %#v", payload)
+	}
+}
+
+// The gap between two waits is where events used to disappear: the caller answers
+// a comment, waits again, and the wait baselines from a state that already
+// includes whatever landed while it was working.
+func TestWaitForPRActionableResumesFromCursorAcrossCalls(t *testing.T) {
+	head := strings.Repeat("b", 40)
+	first := prComment{ID: "c1", Author: "victorarias", Kind: "issue", CreatedAt: time.Unix(1, 0)}
+	gap := prComment{ID: "c2", Author: "victorarias", Kind: "issue", CreatedAt: time.Unix(2, 0)}
+	opts := prWaitOptions{Reviewer: "figgyster", Interval: 0}
+
+	start := readinessObservation("12", head, checksPending, "waiting")
+	start.Comments = []prComment{first}
+	arrived := readinessObservation("12", head, checksPending, "waiting")
+	arrived.Comments = []prComment{first, gap}
+
+	// The first wait times out having seen only the pre-existing comment.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	timedOut, err := waitForPRActionable(ctx, &fakeReadinessSource{results: []*prReadiness{start}}, opts, prWaitCursor{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if timedOut.Outcome != outcomeTimeout {
+		t.Fatalf("outcome = %s", timedOut.Outcome)
+	}
+	// Even reporting nothing, the wait must carry its baseline forward, or the
+	// next call rebuilds one from a later state and swallows the gap.
+	if strings.Join(timedOut.Cursor.CommentIDs, ",") != "c1" {
+		t.Fatalf("cursor = %#v, want the baseline comment recorded", timedOut.Cursor)
+	}
+
+	// The comment landed while the caller was between waits: the second wait must
+	// report it on its first poll rather than absorb it into a fresh baseline.
+	second, err := waitForPRActionable(context.Background(),
+		&fakeReadinessSource{results: []*prReadiness{arrived}}, opts, timedOut.Cursor, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Outcome != outcomeComment || len(second.Observation.Comments) != 1 ||
+		second.Observation.Comments[0].ID != "c2" {
+		t.Fatalf("outcome=%s comments=%#v", second.Outcome, second.Observation.Comments)
+	}
+	if strings.Join(second.Cursor.CommentIDs, ",") != "c1,c2" {
+		t.Fatalf("cursor = %#v, want the reported comment added", second.Cursor)
+	}
+
+	// And a third wait on the same state has nothing new to say.
+	ctx, cancel = context.WithCancel(context.Background())
+	cancel()
+	third, err := waitForPRActionable(ctx, &fakeReadinessSource{results: []*prReadiness{arrived}}, opts, second.Cursor, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if third.Outcome != outcomeTimeout {
+		t.Fatalf("a comment already reported was reported again: outcome = %s", third.Outcome)
+	}
+}
+
+// A failing check stays true until someone pushes, so re-reporting it would make
+// every subsequent wait return instantly with nothing new.
+func TestWaitForPRActionableSuppressesAlreadyReportedFailure(t *testing.T) {
+	head := strings.Repeat("c", 40)
+	opts := prWaitOptions{Reviewer: "figgyster", Interval: 0}
+	failing := readinessObservation("12", head, checksFailed, "waiting")
+	failing.Checks = []prCheck{{Name: "CI", State: checksFailed}}
+
+	first, err := waitForPRActionable(context.Background(), &fakeReadinessSource{results: []*prReadiness{failing}}, opts, prWaitCursor{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Outcome != outcomeChecksFailed || first.Cursor.FailureHead != head ||
+		strings.Join(first.Cursor.FailureChecks, ",") != "CI" {
+		t.Fatalf("outcome=%s cursor=%#v", first.Outcome, first.Cursor)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	again, err := waitForPRActionable(ctx, &fakeReadinessSource{results: []*prReadiness{failing}}, opts, first.Cursor, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Outcome != outcomeTimeout {
+		t.Fatalf("the same failure returned twice: outcome = %s", again.Outcome)
+	}
+
+	// A different failing check on the same commit is a different failure.
+	worse := readinessObservation("12", head, checksFailed, "waiting")
+	worse.Checks = []prCheck{{Name: "CI", State: checksFailed}, {Name: "Lint", State: checksFailed}}
+	changed, err := waitForPRActionable(context.Background(), &fakeReadinessSource{results: []*prReadiness{worse}}, opts, first.Cursor, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed.Outcome != outcomeChecksFailed {
+		t.Fatalf("a new failing check was suppressed: outcome = %s", changed.Outcome)
+	}
+
+	// So is the same failure after a push.
+	pushed := readinessObservation("12", strings.Repeat("d", 40), checksFailed, "waiting")
+	pushed.Checks = []prCheck{{Name: "CI", State: checksFailed}}
+	repushed, err := waitForPRActionable(context.Background(), &fakeReadinessSource{results: []*prReadiness{pushed}}, opts, first.Cursor, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repushed.Outcome != outcomeChecksFailed {
+		t.Fatalf("the failure on a new head was suppressed: outcome = %s", repushed.Outcome)
+	}
+}
+
+// --since is the escape hatch: it replays by arrival time, so a caller does not
+// need to know any comment ID to recover a window.
+func TestWaitForPRActionableSinceReplaysByTime(t *testing.T) {
+	head := strings.Repeat("e", 40)
+	old := prComment{ID: "c1", Author: "victorarias", Kind: "issue", CreatedAt: time.Unix(100, 0)}
+	recent := prComment{ID: "c2", Author: "victorarias", Kind: "issue", CreatedAt: time.Unix(300, 0)}
+	observation := readinessObservation("12", head, checksPending, "waiting")
+	observation.Comments = []prComment{old, recent}
+
+	opts := prWaitOptions{Reviewer: "figgyster", Interval: 0, Since: time.Unix(200, 0)}
+	// The cursor claims both comments were already reported; --since overrides it.
+	result, err := waitForPRActionable(context.Background(), &fakeReadinessSource{results: []*prReadiness{observation}}, opts,
+		prWaitCursor{CommentIDs: []string{"c1", "c2"}}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != outcomeComment || len(result.Observation.Comments) != 1 ||
+		result.Observation.Comments[0].ID != "c2" {
+		t.Fatalf("outcome=%s comments=%#v", result.Outcome, result.Observation.Comments)
+	}
+}
+
+func TestPRWaitCursorRoundTripsOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	opts := prWaitOptions{Owner: "victorarias", Name: "attn", Number: 679}
+	now := time.Unix(1_700_000_000, 0)
+
+	if cursor, err := loadPRWaitCursor(dir, opts); err != nil || !cursor.empty() {
+		t.Fatalf("first call must start empty: cursor=%#v err=%v", cursor, err)
+	}
+
+	saved := prWaitCursor{CommentIDs: []string{"c1"}, VerdictAt: now, FailureHead: "abc", FailureChecks: []string{"CI"}}
+	if err := savePRWaitCursor(dir, opts, saved, now); err != nil {
+		t.Fatal(err)
+	}
+	// Host defaults so a --repo owner/name target and a github.com URL agree.
+	path := filepath.Join(dir, "github.com", "victorarias", "attn", "679.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("cursor not at %s: %v", path, err)
+	}
+	loaded, err := loadPRWaitCursor(dir, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(loaded.CommentIDs, ",") != "c1" || !loaded.VerdictAt.Equal(now) ||
+		loaded.FailureHead != "abc" || !loaded.sameFailure("abc", []prCheck{{Name: "CI", State: checksFailed}}) {
+		t.Fatalf("loaded = %#v", loaded)
+	}
+
+	// A cursor with nothing recorded in a field says nothing about it, rather than
+	// claiming a verdict at the zero time.
+	encoded, err := json.Marshal(prWaitCursor{CommentIDs: []string{"c1"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "0001-01-01") {
+		t.Fatalf("cursor = %s", encoded)
+	}
+
+	// A cursor is an optimization over re-baselining: a corrupt one must not stop
+	// the caller from waiting.
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if cursor, err := loadPRWaitCursor(dir, opts); err == nil || !cursor.empty() {
+		t.Fatalf("corrupt cursor must report the problem and read as empty: cursor=%#v err=%v", cursor, err)
+	}
+
+	// Cursors nobody has waited on in a month are dropped, and the directory has
+	// no other owner to clean it.
+	stale := filepath.Join(dir, "github.com", "victorarias", "attn", "1.json")
+	if err := os.WriteFile(stale, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := now.Add(-2 * prCursorMaxAge)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := savePRWaitCursor(dir, opts, saved, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale cursor survived: %v", err)
+	}
+}
+
+// An empty directory disables the memory, which is what any code path that has no
+// business resolving a data dir passes.
+func TestPRWaitCursorWithoutDirectoryIsInert(t *testing.T) {
+	if err := savePRWaitCursor("", prWaitOptions{Number: 1}, prWaitCursor{CommentIDs: []string{"c1"}}, time.Unix(1, 0)); err != nil {
+		t.Fatal(err)
+	}
+	if cursor, err := loadPRWaitCursor("", prWaitOptions{Number: 1}); err != nil || !cursor.empty() {
+		t.Fatalf("cursor=%#v err=%v", cursor, err)
 	}
 }
 
@@ -743,6 +1016,19 @@ func TestParsePRWaitArgs(t *testing.T) {
 	if opts.Host != "ghe.example.com" || opts.Owner != "victorarias" || opts.Name != "attn" || !opts.JSON ||
 		strings.Join(opts.IgnoreAuthors, ",") != "bot-one,bot-two" {
 		t.Fatalf("opts = %#v", opts)
+	}
+
+	opts, err = parsePRWaitArgs([]string{"602", "--repo", "victorarias/attn", "--reviewer", "figgyster",
+		"--reset", "--since", "2026-07-26T10:00:00Z"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !opts.Reset || !opts.Since.Equal(mustTime(t, "2026-07-26T10:00:00Z")) {
+		t.Fatalf("opts = %#v", opts)
+	}
+	if _, err := parsePRWaitArgs([]string{"602", "--repo", "victorarias/attn", "--reviewer", "figgyster", "--since", "yesterday"}); err == nil ||
+		!strings.Contains(err.Error(), "RFC3339") {
+		t.Fatalf("--since error = %v", err)
 	}
 
 	if _, err := parsePRWaitArgs([]string{"602", "--reviewer", "figgyster"}); err == nil || !strings.Contains(err.Error(), "--repo is required") {

--- a/cmd/attn/testdata/pr-approval-with-body.json
+++ b/cmd/attn/testdata/pr-approval-with-body.json
@@ -1,0 +1,132 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "number": 679,
+        "state": "OPEN",
+        "isDraft": false,
+        "headRefOid": "689f742d73b66efd07770f5cd244cdc65de22fcd",
+        "commits": {
+          "nodes": [
+            {
+              "commit": {
+                "statusCheckRollup": {
+                  "contexts": {
+                    "pageInfo": {
+                      "hasNextPage": false
+                    },
+                    "nodes": [
+                      {
+                        "__typename": "CheckRun",
+                        "name": "Bench A/B (base vs head)",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS"
+                      },
+                      {
+                        "__typename": "CheckRun",
+                        "name": "Changes",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS"
+                      },
+                      {
+                        "__typename": "CheckRun",
+                        "name": "react-doctor",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS"
+                      },
+                      {
+                        "__typename": "CheckRun",
+                        "name": "Daemon",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS"
+                      },
+                      {
+                        "__typename": "CheckRun",
+                        "name": "Frontend",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS"
+                      },
+                      {
+                        "__typename": "CheckRun",
+                        "name": "Frontend E2E (1/3)",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS"
+                      },
+                      {
+                        "__typename": "CheckRun",
+                        "name": "Frontend E2E (2/3)",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS"
+                      },
+                      {
+                        "__typename": "CheckRun",
+                        "name": "Frontend E2E (3/3)",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS"
+                      },
+                      {
+                        "__typename": "CheckRun",
+                        "name": "Tauri",
+                        "status": "COMPLETED",
+                        "conclusion": "SKIPPED"
+                      },
+                      {
+                        "__typename": "CheckRun",
+                        "name": "Frontend E2E",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS"
+                      },
+                      {
+                        "__typename": "StatusContext",
+                        "context": "React Doctor",
+                        "state": "SUCCESS"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "reviewRequests": {
+          "nodes": []
+        },
+        "reviews": {
+          "nodes": [
+            {
+              "id": "PRR_kwDOQoFRj88AAAABHQSTJg",
+              "state": "APPROVED",
+              "bodyText": "You finally made Phase 3\u2019s dwell gate mean what it said. #675 put the policy in the right room, but handleState still had a side door into pending_approval; this shuts it, and the yellow-flash witness is the proof I wanted to see.\nI traced the remaining evidence paths through the resolver, including the stale-bracket, classifier, long-run, and external-driver escapes. The clause-order tests give the next poor soul a map instead of a s\u00e9ance, and the live guardian/background-work runs cover the two races most likely to lie in a unit test. Daemon, Frontend, all three frontend E2E shards, Changes, and React Doctor are green. Bench A/B is still doing its slow walk, but it is trend evidence here, not a gate. Approved. The old scraper and staleness machinery can stay buried.",
+              "submittedAt": "2026-07-26T13:11:27Z",
+              "author": {
+                "__typename": "User",
+                "login": "figgyster"
+              },
+              "commit": {
+                "oid": "689f742d73b66efd07770f5cd244cdc65de22fcd"
+              },
+              "comments": {
+                "pageInfo": {
+                  "hasNextPage": false
+                },
+                "nodes": []
+              }
+            }
+          ]
+        },
+        "comments": {
+          "nodes": [
+            {
+              "id": "IC_kwDOQoFRj88AAAABLwGMVw",
+              "createdAt": "2026-07-26T13:06:04Z",
+              "author": {
+                "__typename": "Bot",
+                "login": "github-actions"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
`attn pr wait-ready` is the one call an agent makes to wait on a pull request: it exists so nobody writes a polling script, and so the answer carries enough to act on without a follow-up query. Three things kept it from doing that.

**It threw away events.** Precedence lived in two places — an early return for comments and a switch for everything else — so whichever condition the code happened to test first won and the rest were discarded. figgyster approving with prose exited 4 ("a new comment") instead of 0, because the approval body was collected as commentary and the comment branch returned before the verdict branch was ever reached. A closed PR or a failed check could likewise lose to a comment.

Now a poll collects every event it sees and one ordered list picks the winner: closed, checks failed, changes requested, human comment, approved, bot comment. A human comment outranks approval because someone is waiting for an answer; a bot comment ranks last because nobody is. Everything else that poll saw is still reported — `also <event>: …` on stdout, `events` in `--json`. The reviewer's own verdict is one event, not a verdict plus a comment. Bot comments are tagged rather than dropped and get their own exit code (6), so a caller can act on a human's remark and skip a doctor report.

**It reported that something was said, not what.** stdout and `--json` now carry comment bodies with `file:line` when inline, the verdict's own text, failing check names with their URLs, and the pull request URL.

**Every call re-baselined.** Comments present at wait start are correctly treated as context, but that baseline was rebuilt from scratch on each invocation — so a remark that landed while the caller was answering the previous one was absorbed into the new baseline and never reported, and the wait then blocked for its whole timeout as if the PR were quiet. Waits now resume: each records what it reported under `<data-dir>/pr-wait/<host>/<owner>/<repo>/<number>.json`, written atomically and pruned after 30 days.

The record keeps each event in the shape it comes in, because "already seen" means something different for each:

- comments are discrete, so their IDs are the record;
- a verdict supersedes itself, so its submission time is the record — used as the baseline a re-review is measured against, not as suppression, since a standing approval is the PR's current answer and every wait should say so;
- a failing check is a condition that stays true until someone pushes, so the record is which checks failed on which commit. The same failure on the same commit does not make the next wait return instantly with nothing new; a different failure, or the same one after a push, does.

It advances only to what was reported, plus the state a first-ever wait deliberately treats as pre-existing context — a wait that times out still carries its baseline forward, which is what closes the gap. `--reset` discards the record; `--since <RFC3339>` replays from an instant by arrival time, needing no comment IDs.

## Verification

Unit tests cover the ranking, the event set, the resume across calls (including the timeout-then-gap case), failure suppression and its three re-report cases, `--since`, and the on-disk round trip including a corrupt cursor and pruning. The two new gates were mutation-checked: removing the baseline-into-cursor line and removing the `sameFailure` gate each fail exactly one test.

`attn pr wait-ready` shells out to `gh` and touches no daemon or app surface, so the built binary was exercised against real pull requests with `ATTN_DATA_DIR` pointed at a scratch dir:

- #679 (merged; figgyster approved with prose, react-doctor commented) with `--since`: `closed` plus `also bot_comment`, the bot's body and the PR URL printed, exit 5.
- #679 without `--since`: `closed`, and the cursor written with the baseline comment ID.
- #404 (open, approved with a long verdict body): exit 0, one event, the verdict text printed, cursor recording `verdict_at`. A second call reports the standing approval again, as intended.

https://claude.ai/code/session_01KzpRFTTbzGz1JFqK1vvVq5