### PR TITLE
fix(pr): wait-ready no longer reports the caller's own comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,10 @@ requested, human comment, approved, bot comment) and the rest are still reported
 the whole answer when you need to know everything that happened. The reviewer's
 own verdict is one event, not a verdict plus a comment. Comments already present
 when the wait starts are the baseline; `--ignore-author` drops an author of
-either kind.
+either kind. Your own comments are never events: the account `gh` is
+authenticated as is resolved once per run and its remarks are dropped, so posting
+a reply and then waiting does not wake you with your own text. Pass
+`--include-self` to watch a PR you also comment on.
 
 The output carries what was said — comment bodies with `file:line` when inline,
 the verdict's text, failing check names with URLs, the PR URL — so act on it

--- a/cmd/attn/pr.go
+++ b/cmd/attn/pr.go
@@ -246,7 +246,9 @@ type ghPRReadinessSource struct{}
 
 // prSelfLoginTimeout bounds the identity lookup. It is one small API call that
 // the wait cannot start without, so a hung network must degrade to "we do not
-// know who we are" rather than hold the wait open.
+// know who we are" rather than spend the caller's whole budget before the first
+// poll. It is a ceiling, never an extension: the lookup runs under the wait's
+// own deadline, so a --timeout shorter than this cuts it short instead.
 const prSelfLoginTimeout = 15 * time.Second
 
 // ghSelfLogin is the seam over `gh api user`. A variable so tests can drive both
@@ -267,11 +269,15 @@ var ghSelfLogin = func(ctx context.Context, host string) (string, error) {
 // fail. The login only ever removes an event, so not knowing it costs the caller
 // one spurious wake-up, while erroring out would cost them the wait entirely —
 // the command has to keep working on a machine whose `gh` cannot reach the API.
-func resolvePRSelfLogin(opts prWaitOptions, stderr io.Writer) string {
+//
+// It takes the wait's context rather than making its own, so the lookup spends
+// the caller's budget instead of adding to it: whichever of the two deadlines
+// comes first wins.
+func resolvePRSelfLogin(ctx context.Context, opts prWaitOptions, stderr io.Writer) string {
 	if opts.IncludeSelf {
 		return ""
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), prSelfLoginTimeout)
+	ctx, cancel := context.WithTimeout(ctx, prSelfLoginTimeout)
 	defer cancel()
 	login, err := ghSelfLogin(ctx, opts.Host)
 	if err != nil || login == "" {
@@ -330,10 +336,16 @@ func executePRCommand(args []string, stdout, stderr io.Writer) int {
 	// line can reach a data dir on its own.
 	opts.CursorDir = filepath.Join(config.DataDir(), "pr-wait")
 
-	// Resolve who we are once, here, for the same reason: one `gh` call for the
-	// whole wait, made only when a wait is actually about to run, and never
-	// reachable from the polling loop.
-	opts.SelfLogin = resolvePRSelfLogin(opts, stderr)
+	// The deadline covers everything the caller is waiting through, not just the
+	// polling. --timeout is a promise about when this command returns, so any
+	// network call made on the way to the first poll has to run inside it.
+	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
+	defer cancel()
+
+	// Resolve who we are once, here, for the same reason the cursor dir is
+	// resolved here: one `gh` call for the whole wait, made only when a wait is
+	// actually about to run, and never reachable from the polling loop.
+	opts.SelfLogin = resolvePRSelfLogin(ctx, opts, stderr)
 
 	var cursor prWaitCursor
 	if !opts.Reset {
@@ -346,8 +358,6 @@ func executePRCommand(args []string, stdout, stderr io.Writer) int {
 		cursor = loaded
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
-	defer cancel()
 	result, err := waitForPRActionable(ctx, ghPRReadinessSource{}, opts, cursor, progress)
 	if err != nil {
 		fmt.Fprintf(stderr, "pr wait-ready: %v\n", err)

--- a/cmd/attn/pr.go
+++ b/cmd/attn/pr.go
@@ -219,9 +219,21 @@ type prWaitOptions struct {
 	// pull request's current state, as a first-ever call would.
 	Since time.Time
 	Reset bool
+	// SelfLogin is the account this wait is running as, and its comments are not
+	// news to it. IncludeSelf turns that off, and is also why SelfLogin is a
+	// resolved value rather than a flag: leaving it empty is how the caller says
+	// "report everyone", and is what an unresolvable login falls back to.
+	SelfLogin   string
+	IncludeSelf bool
 }
 
+// ignored reports whether a comment by this author should never be reported. The
+// caller's own login and --ignore-author share this one path, so the two compose:
+// suppressing yourself is the same operation as suppressing anyone else.
 func (o prWaitOptions) ignored(author string) bool {
+	if o.SelfLogin != "" && strings.EqualFold(o.SelfLogin, author) {
+		return true
+	}
 	for _, ignored := range o.IgnoreAuthors {
 		if strings.EqualFold(ignored, author) {
 			return true
@@ -231,6 +243,43 @@ func (o prWaitOptions) ignored(author string) bool {
 }
 
 type ghPRReadinessSource struct{}
+
+// prSelfLoginTimeout bounds the identity lookup. It is one small API call that
+// the wait cannot start without, so a hung network must degrade to "we do not
+// know who we are" rather than hold the wait open.
+const prSelfLoginTimeout = 15 * time.Second
+
+// ghSelfLogin is the seam over `gh api user`. A variable so tests can drive both
+// answers without a GitHub account.
+var ghSelfLogin = func(ctx context.Context, host string) (string, error) {
+	args := []string{"api", "user", "--jq", ".login"}
+	if host != "" {
+		args = append(args, "--hostname", host)
+	}
+	output, err := exec.CommandContext(ctx, "gh", args...).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// resolvePRSelfLogin answers "who is this wait running as", and is allowed to
+// fail. The login only ever removes an event, so not knowing it costs the caller
+// one spurious wake-up, while erroring out would cost them the wait entirely —
+// the command has to keep working on a machine whose `gh` cannot reach the API.
+func resolvePRSelfLogin(opts prWaitOptions, stderr io.Writer) string {
+	if opts.IncludeSelf {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), prSelfLoginTimeout)
+	defer cancel()
+	login, err := ghSelfLogin(ctx, opts.Host)
+	if err != nil || login == "" {
+		fmt.Fprintln(stderr, "pr wait-ready: could not resolve the authenticated GitHub user; your own comments will be reported")
+		return ""
+	}
+	return login
+}
 
 type stringSliceFlag []string
 
@@ -280,6 +329,11 @@ func executePRCommand(args []string, stdout, stderr io.Writer) int {
 	// Resolve the cursor directory here and pass it down, so nothing below this
 	// line can reach a data dir on its own.
 	opts.CursorDir = filepath.Join(config.DataDir(), "pr-wait")
+
+	// Resolve who we are once, here, for the same reason: one `gh` call for the
+	// whole wait, made only when a wait is actually about to run, and never
+	// reachable from the polling loop.
+	opts.SelfLogin = resolvePRSelfLogin(opts, stderr)
 
 	var cursor prWaitCursor
 	if !opts.Reset {
@@ -496,6 +550,7 @@ func parsePRWaitArgs(args []string) (prWaitOptions, error) {
 	asJSON := fs.Bool("json", false, "emit the result as JSON")
 	reset := fs.Bool("reset", false, "forget what earlier waits reported and baseline from the current state")
 	since := fs.String("since", "", "report anything after this RFC3339 instant instead of resuming")
+	includeSelf := fs.Bool("include-self", false, "report your own comments as events")
 	var ignore stringSliceFlag
 	fs.Var(&ignore, "ignore-author", "comment author to ignore (repeatable)")
 
@@ -525,6 +580,7 @@ func parsePRWaitArgs(args []string) (prWaitOptions, error) {
 		Interval:      *interval,
 		JSON:          *asJSON,
 		Reset:         *reset,
+		IncludeSelf:   *includeSelf,
 	}
 	if strings.TrimSpace(*since) != "" {
 		at, err := time.Parse(time.RFC3339, strings.TrimSpace(*since))
@@ -835,10 +891,13 @@ func parsePRSnapshot(output []byte, opts prWaitOptions) (*prReadiness, error) {
 // ranked below a human's and carries its own exit code, so a caller can act on
 // one and ignore the other. `--ignore-author` drops either kind.
 //
-// The token owner is deliberately NOT filtered, because the operator and the
-// agent share one token and the operator's own comment is the most actionable
-// event there is. Self-waking is prevented by the baseline instead: anything
-// present when the wait starts is never reported.
+// The account running the wait is dropped too, because a wait is something its
+// caller starts after acting, and its own remark is never the update it is
+// waiting for. The baseline alone does not cover this: a comment posted between
+// one wait returning and the next one starting is genuinely new to the cursor,
+// so a caller that answers a reviewer and waits again is woken by its own reply.
+// `--include-self` puts those comments back for a caller watching a pull request
+// it does not act on.
 func appendPRComment(comments []prComment, node prGraphQLComment, kind string, opts prWaitOptions) []prComment {
 	if node.ID == "" || opts.ignored(node.Author.Login) {
 		return comments
@@ -1159,6 +1218,7 @@ options:
   --json                          emit the result as JSON on stdout
   --reset                         forget earlier waits; baseline from now
   --since RFC3339                 report anything after this instant instead
+  --include-self                  report your own comments as events
 
 One poll can see several of these at once. The exit code reports the highest
 ranked: closed, checks failed, changes requested, human comment, approved, bot
@@ -1171,6 +1231,15 @@ its body is the verdict's explanation, not a separate comment.
 
 A bot comment ends the wait with its own exit code, so a caller can act on a
 human's remark and skip a doctor report; --ignore-author drops either kind.
+
+Your own comments are not events. The account gh is authenticated as is resolved
+once per run and its remarks are dropped, because the caller of a wait is the one
+who just acted and being told about your own comment is never the update you were
+waiting for. The baseline does not cover this on its own: a comment posted
+between two waits is new to the second one. Pass --include-self to watch a pull
+request you also comment on. If the login cannot be resolved, the wait runs
+exactly as it would without this, reporting everyone.
+
 Comments already present when the wait starts are the baseline and never
 reported; only comments posted during the wait are. A review verdict present at
 wait start is likewise baselined: while the reviewer is re-requested (a re-review

--- a/cmd/attn/pr_test.go
+++ b/cmd/attn/pr_test.go
@@ -1028,7 +1028,7 @@ func TestResolvePRSelfLoginIsSkippableAndFailureTolerant(t *testing.T) {
 		return "", errors.New("gh: not authenticated")
 	}
 	var stderr bytes.Buffer
-	if login := resolvePRSelfLogin(prWaitOptions{}, &stderr); login != "" {
+	if login := resolvePRSelfLogin(context.Background(), prWaitOptions{}, &stderr); login != "" {
 		t.Fatalf("login = %q, want an unresolvable login to report everyone", login)
 	}
 	if calls != 1 || !strings.Contains(stderr.String(), "could not resolve") {
@@ -1042,7 +1042,7 @@ func TestResolvePRSelfLoginIsSkippableAndFailureTolerant(t *testing.T) {
 		}
 		return "victorarias", nil
 	}
-	if login := resolvePRSelfLogin(prWaitOptions{Host: "ghe.example.com"}, io.Discard); login != "victorarias" {
+	if login := resolvePRSelfLogin(context.Background(), prWaitOptions{Host: "ghe.example.com"}, io.Discard); login != "victorarias" {
 		t.Fatalf("login = %q", login)
 	}
 
@@ -1050,8 +1050,40 @@ func TestResolvePRSelfLoginIsSkippableAndFailureTolerant(t *testing.T) {
 		t.Error("--include-self asked GitHub who we are")
 		return "", nil
 	}
-	if login := resolvePRSelfLogin(prWaitOptions{IncludeSelf: true}, io.Discard); login != "" {
+	if login := resolvePRSelfLogin(context.Background(), prWaitOptions{IncludeSelf: true}, io.Discard); login != "" {
 		t.Fatalf("login = %q under --include-self", login)
+	}
+}
+
+// --timeout is a promise about when the command returns, and the identity lookup
+// happens before the first poll. Given a clock of its own it would spend up to
+// prSelfLoginTimeout on top of the caller's budget, so `--timeout 1s` against a
+// stalled GitHub would take sixteen seconds to come back.
+func TestResolvePRSelfLoginCannotOutlastTheWaitDeadline(t *testing.T) {
+	original := ghSelfLogin
+	t.Cleanup(func() { ghSelfLogin = original })
+
+	// A GitHub that never answers. Only the context can end this call, so the
+	// deadline the lookup runs under is the one that decides when it returns.
+	ghSelfLogin = func(ctx context.Context, _ string) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+
+	budget := 50 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+	start := time.Now()
+	login := resolvePRSelfLogin(ctx, prWaitOptions{}, io.Discard)
+	elapsed := time.Since(start)
+
+	if login != "" {
+		t.Fatalf("login = %q, want a stalled lookup to report everyone", login)
+	}
+	// The bound is deliberately loose: the point is prSelfLoginTimeout not being
+	// spent, not the exact millisecond the short budget expires on.
+	if elapsed >= prSelfLoginTimeout {
+		t.Fatalf("lookup took %s with a %s budget: it borrowed its own clock", elapsed, budget)
 	}
 }
 

--- a/cmd/attn/pr_test.go
+++ b/cmd/attn/pr_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -931,6 +932,129 @@ func TestWaitForPRActionableSinceReplaysByTime(t *testing.T) {
 	}
 }
 
+// snapshotSource drives the waiter through the real snapshot parser, so a test
+// about which comments become events exercises the same path a live wait does.
+type snapshotSource struct {
+	payloads [][]byte
+	calls    int
+}
+
+func (s *snapshotSource) Fetch(_ context.Context, opts prWaitOptions) (*prReadiness, error) {
+	index := s.calls
+	s.calls++
+	if index >= len(s.payloads) {
+		index = len(s.payloads) - 1
+	}
+	return parsePRSnapshot(s.payloads[index], opts)
+}
+
+// The scenario the self-suppression exists for. A wait resumes from where the
+// previous one stopped, so a comment the caller posts between two waits is
+// genuinely new to the cursor and the start-of-wait baseline cannot catch it:
+// answer a reviewer, wait again, and the wait returns instantly quoting you back
+// at yourself.
+func TestWaitForPRActionableDoesNotWakeOnTheCallersOwnComment(t *testing.T) {
+	head := strings.Repeat("a", 40)
+	mine := `{"id":"c1","createdAt":"2026-07-26T10:00:00Z","bodyText":"answering the review",
+	          "author":{"__typename":"User","login":"victorarias"}}`
+	theirs := `{"id":"c2","createdAt":"2026-07-26T10:05:00Z","bodyText":"one more thing",
+	            "author":{"__typename":"User","login":"figgyster"}}`
+	// Login comparison is case-insensitive: GitHub renders a login in whatever
+	// case it was registered with, and `gh api user` and a comment author need not
+	// agree on it.
+	opts := prWaitOptions{Reviewer: "figgyster", Interval: time.Millisecond, SelfLogin: "VictorArias"}
+	// A non-empty cursor is what makes this a resumed wait rather than a first
+	// one, so nothing is baselined away and c1 arrives as unseen.
+	resumed := prWaitCursor{VerdictAt: mustTime(t, "2026-07-26T09:00:00Z")}
+	// The two waits below are supposed to return an event on their first poll.
+	// Given a deadline, one that stops returning fails the assertion below; given
+	// context.Background() it would poll a fixed snapshot forever and hang the
+	// package instead.
+	bounded := func() (context.Context, context.CancelFunc) {
+		return context.WithTimeout(context.Background(), 10*time.Second)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	own, err := waitForPRActionable(ctx, &snapshotSource{payloads: [][]byte{snapshotPayload(head, "", "", mine)}},
+		opts, resumed, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if own.Outcome != outcomeTimeout {
+		t.Fatalf("the caller's own comment ended the wait: outcome=%s comments=%#v", own.Outcome, own.Observation.Comments)
+	}
+
+	// Someone else's comment on the same poll is still the update being waited for.
+	otherCtx, cancelOther := bounded()
+	defer cancelOther()
+	other, err := waitForPRActionable(otherCtx,
+		&snapshotSource{payloads: [][]byte{snapshotPayload(head, "", "", mine+","+theirs)}},
+		opts, resumed, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if other.Outcome != outcomeComment || len(other.Observation.Comments) != 1 ||
+		other.Observation.Comments[0].ID != "c2" {
+		t.Fatalf("outcome=%s comments=%#v, want only figgyster's comment", other.Outcome, other.Observation.Comments)
+	}
+
+	// --include-self leaves SelfLogin unresolved, which is also what an
+	// unreachable `gh api user` falls back to: both report every author.
+	opts.SelfLogin = ""
+	includedCtx, cancelIncluded := bounded()
+	defer cancelIncluded()
+	included, err := waitForPRActionable(includedCtx,
+		&snapshotSource{payloads: [][]byte{snapshotPayload(head, "", "", mine)}},
+		opts, resumed, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if included.Outcome != outcomeComment || len(included.Observation.Comments) != 1 ||
+		included.Observation.Comments[0].ID != "c1" {
+		t.Fatalf("outcome=%s comments=%#v, want the caller's own comment reported", included.Outcome, included.Observation.Comments)
+	}
+}
+
+// The identity lookup costs a `gh` call, so it must not happen when the caller
+// has opted out, and it must never be able to fail a wait.
+func TestResolvePRSelfLoginIsSkippableAndFailureTolerant(t *testing.T) {
+	original := ghSelfLogin
+	t.Cleanup(func() { ghSelfLogin = original })
+
+	calls := 0
+	ghSelfLogin = func(context.Context, string) (string, error) {
+		calls++
+		return "", errors.New("gh: not authenticated")
+	}
+	var stderr bytes.Buffer
+	if login := resolvePRSelfLogin(prWaitOptions{}, &stderr); login != "" {
+		t.Fatalf("login = %q, want an unresolvable login to report everyone", login)
+	}
+	if calls != 1 || !strings.Contains(stderr.String(), "could not resolve") {
+		t.Fatalf("calls=%d stderr=%q", calls, stderr.String())
+	}
+
+	ghSelfLogin = func(_ context.Context, host string) (string, error) {
+		calls++
+		if host != "ghe.example.com" {
+			t.Fatalf("host = %q, want the lookup scoped to the pull request's host", host)
+		}
+		return "victorarias", nil
+	}
+	if login := resolvePRSelfLogin(prWaitOptions{Host: "ghe.example.com"}, io.Discard); login != "victorarias" {
+		t.Fatalf("login = %q", login)
+	}
+
+	ghSelfLogin = func(context.Context, string) (string, error) {
+		t.Error("--include-self asked GitHub who we are")
+		return "", nil
+	}
+	if login := resolvePRSelfLogin(prWaitOptions{IncludeSelf: true}, io.Discard); login != "" {
+		t.Fatalf("login = %q under --include-self", login)
+	}
+}
+
 func TestPRWaitCursorRoundTripsOnDisk(t *testing.T) {
 	dir := t.TempDir()
 	opts := prWaitOptions{Owner: "victorarias", Name: "attn", Number: 679}
@@ -1027,11 +1151,11 @@ func TestParsePRWaitArgs(t *testing.T) {
 	}
 
 	opts, err = parsePRWaitArgs([]string{"602", "--repo", "victorarias/attn", "--reviewer", "figgyster",
-		"--reset", "--since", "2026-07-26T10:00:00Z"})
+		"--reset", "--since", "2026-07-26T10:00:00Z", "--include-self"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !opts.Reset || !opts.Since.Equal(mustTime(t, "2026-07-26T10:00:00Z")) {
+	if !opts.Reset || !opts.IncludeSelf || !opts.Since.Equal(mustTime(t, "2026-07-26T10:00:00Z")) {
 		t.Fatalf("opts = %#v", opts)
 	}
 	if _, err := parsePRWaitArgs([]string{"602", "--repo", "victorarias/attn", "--reviewer", "figgyster", "--since", "yesterday"}); err == nil ||


### PR DESCRIPTION
`attn pr wait-ready` reported the invoking GitHub account's own comments as
actionable events. Observed on a real pull request: an agent posted a reply to
its reviewer, started a wait, and was handed exit 4 with
`comment: 1 new comment from victorarias` and its own text echoed back.

## Why the existing baseline does not cover it

Comments present when a wait starts are baselined and never reported, but a wait
now resumes from the position the previous wait recorded. A comment posted
*between* two waits is genuinely new to that cursor — including one the caller
posted itself. `--ignore-author` worked as a manual workaround but had to be
passed on every call.

## What changed

The account `gh` is authenticated as is resolved once per run, and its comments
no longer produce an event. The caller of a wait is the actor; being told about
your own action is never the update you were waiting for. `--include-self`
restores the old behavior for a caller watching a pull request it does not act
on.

Design calls behind that:

- **Default on, with `--include-self` to opt back in.** Suppression by default is
  right for the only way this command is used — act, then wait. Watching a pull
  request you also comment on is the rarer case and now says so explicitly.
- **Lazy, once per run, inside the caller's deadline.** One
  `gh api user --jq .login`, issued after argument validation and immediately
  before the first poll, so `--help`, a usage error, and `--include-self` never
  pay for it. The polling loop cannot reach the lookup; it consumes a resolved
  value on `prWaitOptions`. The call is scoped to the pull request's host and
  runs under the wait's own timeout context, so its 15s ceiling can only cut the
  lookup short, never extend the budget `--timeout` promised.
- **Failure is not fatal.** A login that cannot be resolved leaves `SelfLogin`
  empty, which is the same state `--include-self` produces: every author is
  reported, exactly as before this change, with a one-line note on stderr. The
  login can only ever *remove* an event, so not knowing it costs one spurious
  wake-up, while erroring out would cost the caller the whole wait.
- **It composes with `--ignore-author`.** Both go through `prWaitOptions.ignored`,
  so suppressing yourself is the same operation as suppressing anyone else, and
  the two stack.

Unchanged: event ranking, exit codes, the cursor format and its location, and the
content payload. A verdict is read from the review record rather than the comment
surfaces, so a self-authored review still ends the wait as it did.

## Tests

`go test ./cmd/attn` green. Three new tests. The first drives the waiter through
the real snapshot parser rather than a hand-built readiness value, so it covers
the same path a live wait takes:

- `TestWaitForPRActionableDoesNotWakeOnTheCallersOwnComment` — with a non-empty
  cursor (a resumed wait, where the baseline cannot help), a self-authored
  comment produces no event, another author's comment on the same poll still
  does, and clearing the resolved login restores the old behavior.
- `TestResolvePRSelfLoginIsSkippableAndFailureTolerant` — a failing lookup yields
  no login and no error, the lookup is scoped to the pull request's host, and
  `--include-self` does not perform it at all.
- `TestResolvePRSelfLoginCannotOutlastTheWaitDeadline` — against a GitHub that
  never answers, the lookup ends with the caller's deadline rather than with its
  own ceiling.

Mutation-checked. Six mutations, each red on its own intended assertion:

| mutation | assertion that failed |
| --- | --- |
| suppression deleted | `the caller's own comment ended the wait: outcome=comment` |
| suppress every author once self is known | `want only figgyster's comment` |
| suppress self even under `--include-self` | `want the caller's own comment reported` |
| a failed lookup returns a login anyway | `want an unresolvable login to report everyone` |
| `--include-self` still performs the lookup | `--include-self asked GitHub who we are` |
| lookup gets its own clock again | `lookup took 15.00220875s with a 50ms budget: it borrowed its own clock` |


The second mutation also exposed a flaw in the test as first written: with an
unbounded context, a wait that stops firing an event polls a fixed snapshot
forever and hangs the package instead of failing. The two waits that are supposed
to return now carry a deadline.

The last row is the review finding from the first round, reproduced: with the
lookup on its own clock, a 50ms budget still took 15 seconds.

## Live verification

`attn pr wait-ready` shells out to `gh` and touches no daemon or app surface, so
per `AGENTS.md` the built binary run against a real pull request is the right
tier. Run against this PR at head `b947b5e2` with `ATTN_DATA_DIR` pointed at a
temp directory, so no cursor was written to `~/.attn`.

The two waits below see **identical pull request state and the identical stored
cursor** (`['IC_kwDOQoFRj88AAAABLwos7g', 'IC_kwDOQoFRj88AAAABLwpBiw']` before and
after A). The only difference is whether the running account is treated as self.

**A — post a comment, then wait.** The cursor already held earlier comments, so
this is a resumed wait and the new comment is unseen by it:

```
$ gh pr comment 681 --body "Third live-witness remark, posted by the account that runs the waits below (head b947b5e2)."
https://github.com/victorarias/attn/pull/681#issuecomment-5084194651

$ attn pr wait-ready 681 --repo victorarias/attn --reviewer figgyster --timeout 25s --interval 10s
pr=#681 head=b947b5e2e9a3 state=open draft=false checks=pending [...] review=waiting reviewer=figgyster
timeout: no actionable update after 25s (checks=pending review=waiting)
https://github.com/victorarias/attn/pull/681
exit=124
```

The stored cursor is unchanged afterwards — a suppressed comment is never
recorded as reported.

**B — control, same state, same cursor, `--include-self`:**

```
$ attn pr wait-ready 681 --repo victorarias/attn --reviewer figgyster --timeout 25s --interval 10s --include-self
pr=#681 head=b947b5e2e9a3 state=open draft=false checks=pending [...] review=waiting reviewer=figgyster
comment: 1 new comment from victorarias
  --- victorarias ---
  Third live-witness remark, posted by the account that runs the waits below (head b947b5e).
https://github.com/victorarias/attn/pull/681
exit=4
```

Same comment, same poll, same cursor: reported when the author is not treated as
self, silent when it is. That is the suppression being identity-scoped rather
than blanket.

**Another author still ends the wait**, witnessed on this PR: the babysitting
wait on head `89b9b9b9` — running as `victorarias` with suppression on — returned
on figgyster's review:

```
pr=#681 head=89b9b9b98109 ... review=changes_requested reviewer=figgyster
changes_requested: figgyster requested changes on 89b9b9b98109
  --- figgyster ---
  [review text]
exit=3
```

**Short timeout stays inside its budget** at head `b947b5e2`:

```
$ time attn pr wait-ready 681 --repo victorarias/attn --reviewer figgyster --timeout 1s --interval 20s
timeout: no actionable update after 1s (checks=none review=waiting)
elapsed_ms=1567
```

The witness comments on this PR are the fixture for the runs above.

`AGENTS.md` records the new default in the `wait-ready` paragraph.
