### PR TITLE
fix(doorbell): send Enter as its own keypress after the paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-07-26]
 
+### Fixed
+- **Sending markdown annotations to a Claude session now actually submits.** The
+  feedback landed in Claude's composer and sat there unsent until you pressed
+  Enter yourself. Claude folds an Enter that arrives together with a paste into
+  the pasted text, and attn was sending both at once. Enter now follows the paste
+  as its own keypress. Same fix for the ticket nudge, the notebook inbox
+  doorbell, and the Present review notice, which are delivered the same way.
+
 ### Added
 - **`attn state explain <session>` (`--json`)** replays a session's recent state
   observations and shows which rule produced the color it is showing, and why.

--- a/internal/daemon/automations_deliver.go
+++ b/internal/daemon/automations_deliver.go
@@ -783,7 +783,7 @@ func (d *Daemon) passUnattendedLaunchGate(req automation.WorkRequest) error {
 			screen := stripANSIForPromptMatch(payload)
 			if strings.Contains(screen, codexDirectoryTrustPrompt) {
 				if !acknowledged {
-					if err := d.ptyBackend.Input(context.Background(), req.IDs.SessionID, []byte("\r")); err != nil {
+					if err := d.writePTY(req.IDs.SessionID, []byte("\r")); err != nil {
 						return fmt.Errorf("accept Codex directory trust: %w", err)
 					}
 					acknowledged = true

--- a/internal/daemon/chief_of_staff.go
+++ b/internal/daemon/chief_of_staff.go
@@ -21,6 +21,18 @@ const (
 	bracketedPasteEnd   = "\x1b[201~"
 )
 
+// doorbellSubmitDelay is how long Enter waits after the paste terminator.
+//
+// Agent composers finalize a paste on a timing boundary, not on the terminator
+// alone: Claude Code folds a CR that arrives in the same PTY read as the
+// paste-end marker into the pasted text, so the payload sits in the composer
+// and never submits. An immediate second write is coalesced into that same
+// read and fails the same way — the gap, not the write split, is what makes
+// Enter a keypress. Measured against Claude Code 2.1.x (0ms fails, 50ms
+// submits) and Codex; 150ms carries margin for a loaded machine. It is a
+// package var only so tests can drop it to zero.
+var doorbellSubmitDelay = 150 * time.Millisecond
+
 func (d *Daemon) chiefOfStaffSessionID() string {
 	if d.store == nil {
 		return ""
@@ -133,11 +145,14 @@ func (d *Daemon) nudgeChiefOfStaff(prompt string) bool {
 // driver run declares the message_delivery capability, the prompt is relayed
 // in-band via the plugin (no PTY fallback on failure — see
 // deliverDoorbellViaPluginDriver). Otherwise it types the prompt as an
-// explicit bracketed-paste event followed by Enter in the same PTY write: the
-// paste terminator gives Codex a semantic boundary before Enter (so the
-// prompt submits instead of remaining in the composer), while the single
-// write keeps the approval-state fence atomic. Always a bounded,
-// user-initiated single write — never arbitrary streamed content.
+// explicit bracketed-paste event — the terminator gives the agent a semantic
+// boundary, so the prompt lands in the composer as one pasted block — and
+// then, after doorbellSubmitDelay, sends Enter as its own write.
+//
+// Both writes happen under doorbellMu, so the approval-state fence still holds
+// across the pair: a pending_approval report cannot commit between the prompt
+// and its Enter. Always a bounded, user-initiated delivery — never arbitrary
+// streamed content.
 func (d *Daemon) typeDoorbell(sessionID, prompt string) error {
 	d.doorbellMu.Lock()
 	defer d.doorbellMu.Unlock()
@@ -148,12 +163,15 @@ func (d *Daemon) typeDoorbell(sessionID, prompt string) error {
 	if delivered, err := d.deliverDoorbellViaPluginDriver(session, prompt); delivered {
 		return err
 	}
-	input := make([]byte, 0, len(bracketedPasteStart)+len(prompt)+len(bracketedPasteEnd)+1)
+	input := make([]byte, 0, len(bracketedPasteStart)+len(prompt)+len(bracketedPasteEnd))
 	input = append(input, bracketedPasteStart...)
 	input = append(input, prompt...)
 	input = append(input, bracketedPasteEnd...)
-	input = append(input, '\r')
-	return d.ptyBackend.Input(context.Background(), sessionID, input)
+	if err := d.ptyBackend.Input(context.Background(), sessionID, input); err != nil {
+		return err
+	}
+	time.Sleep(doorbellSubmitDelay)
+	return d.ptyBackend.Input(context.Background(), sessionID, []byte("\r"))
 }
 
 // maybeAssignChiefOnSpawn assigns the chief-of-staff role at a session's first

--- a/internal/daemon/chief_of_staff.go
+++ b/internal/daemon/chief_of_staff.go
@@ -149,10 +149,12 @@ func (d *Daemon) nudgeChiefOfStaff(prompt string) bool {
 // boundary, so the prompt lands in the composer as one pasted block — and
 // then, after doorbellSubmitDelay, sends Enter as its own write.
 //
-// Both writes happen under doorbellMu, so the approval-state fence still holds
-// across the pair: a pending_approval report cannot commit between the prompt
-// and its Enter. Always a bounded, user-initiated delivery — never arbitrary
-// streamed content.
+// Two fences cover the pair. doorbellMu keeps a pending_approval report from
+// committing between the prompt and its Enter. The session's PTY write fence
+// keeps anything else — the user typing — out of the gap: a keystroke racing
+// the delay is written after the Enter, so the doorbell submits what it
+// composed and never the user's half-typed line. Always a bounded,
+// user-initiated delivery — never arbitrary streamed content.
 func (d *Daemon) typeDoorbell(sessionID, prompt string) error {
 	d.doorbellMu.Lock()
 	defer d.doorbellMu.Unlock()
@@ -167,11 +169,13 @@ func (d *Daemon) typeDoorbell(sessionID, prompt string) error {
 	input = append(input, bracketedPasteStart...)
 	input = append(input, prompt...)
 	input = append(input, bracketedPasteEnd...)
-	if err := d.ptyBackend.Input(context.Background(), sessionID, input); err != nil {
-		return err
-	}
-	time.Sleep(doorbellSubmitDelay)
-	return d.ptyBackend.Input(context.Background(), sessionID, []byte("\r"))
+	return d.withPTYWriteFence(sessionID, func() error {
+		if err := d.ptyBackend.Input(context.Background(), sessionID, input); err != nil {
+			return err
+		}
+		time.Sleep(doorbellSubmitDelay)
+		return d.ptyBackend.Input(context.Background(), sessionID, []byte("\r"))
+	})
 }
 
 // maybeAssignChiefOnSpawn assigns the chief-of-staff role at a session's first

--- a/internal/daemon/chief_of_staff_test.go
+++ b/internal/daemon/chief_of_staff_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -151,5 +152,72 @@ func TestTypeDoorbellDelaysEnterAfterThePaste(t *testing.T) {
 	}
 	if elapsed := at[1].Sub(at[0]); elapsed < gap {
 		t.Fatalf("Enter followed the paste after %v, want at least %v", elapsed, gap)
+	}
+}
+
+// A keystroke racing the doorbell's paste-to-Enter gap must not be spliced into
+// the submission. The user types while the paste is on the wire and the Enter
+// has not been sent yet; the fence has to write their bytes after the Enter, so
+// the doorbell submits its own payload and the typed line stays in the composer.
+func TestTypeDoorbellDoesNotSubmitInputRacingTheGap(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	t.Cleanup(func() { _ = d.store.Close() })
+	addChiefOfStaffTestSession(d, "splice-race", "target")
+
+	previous := doorbellSubmitDelay
+	doorbellSubmitDelay = 60 * time.Millisecond
+	t.Cleanup(func() { doorbellSubmitDelay = previous })
+
+	var mu sync.Mutex
+	var writes []string
+	var writtenAt []time.Time
+	pasteSeen := make(chan struct{})
+	var pasteOnce sync.Once
+	d.ptyBackend = &fakeSpawnBackend{onInput: func(_ string, data []byte) {
+		mu.Lock()
+		writes = append(writes, string(data))
+		writtenAt = append(writtenAt, time.Now())
+		mu.Unlock()
+		if strings.HasPrefix(string(data), bracketedPasteStart) {
+			pasteOnce.Do(func() { close(pasteSeen) })
+		}
+	}}
+
+	doorbellDone := make(chan error, 1)
+	go func() { doorbellDone <- d.typeDoorbell("splice-race", "ping") }()
+
+	// Type into the same session while the doorbell sits in its submit delay.
+	<-pasteSeen
+	typed := make(chan struct{})
+	var typedAt time.Time
+	go func() {
+		defer close(typed)
+		typedAt = time.Now()
+		d.handlePtyInput(&wsClient{send: make(chan outboundMessage, 4)}, &protocol.PtyInputMessage{
+			Cmd: protocol.CmdPtyInput, ID: "splice-race", Data: "half-typed line",
+		})
+	}()
+
+	if err := <-doorbellDone; err != nil {
+		t.Fatalf("typeDoorbell() error = %v", err)
+	}
+	<-typed
+
+	mu.Lock()
+	defer mu.Unlock()
+	wantPaste := bracketedPasteStart + "ping" + bracketedPasteEnd
+	want := []string{wantPaste, "\r", "half-typed line"}
+	if len(writes) != len(want) {
+		t.Fatalf("PTY writes = %q, want %q", writes, want)
+	}
+	for i := range want {
+		if writes[i] != want[i] {
+			t.Fatalf("PTY writes = %q, want %q (the keystroke was spliced into the submission)", writes, want)
+		}
+	}
+	// Without this the ordering above could hold because the keystroke simply
+	// arrived late: it has to have entered the gap before the Enter went out.
+	if !typedAt.Before(writtenAt[1]) {
+		t.Fatalf("keystroke started at %v, after the Enter at %v — the race never happened", typedAt, writtenAt[1])
 	}
 }

--- a/internal/daemon/chief_of_staff_test.go
+++ b/internal/daemon/chief_of_staff_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"encoding/json"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -111,5 +112,44 @@ func TestClearChiefOfStaffKeepsTransferredRole(t *testing.T) {
 	}
 	if got := d.chiefOfStaffSessionID(); got != "session-b" {
 		t.Fatalf("role after stale clear = %q, want session-b", got)
+	}
+}
+
+// Enter must reach the PTY as its own write, a real interval after the paste
+// terminator. Claude Code folds a CR arriving in the same read as the paste end
+// into the pasted text — the payload then sits unsent in the composer — and an
+// undelayed second write lands in that same read.
+func TestTypeDoorbellDelaysEnterAfterThePaste(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	t.Cleanup(func() { _ = d.store.Close() })
+	addChiefOfStaffTestSession(d, "delayed-enter", "target")
+
+	const gap = 40 * time.Millisecond
+	previous := doorbellSubmitDelay
+	doorbellSubmitDelay = gap
+	t.Cleanup(func() { doorbellSubmitDelay = previous })
+
+	var mu sync.Mutex
+	var writes []string
+	var at []time.Time
+	d.ptyBackend = &fakeSpawnBackend{onInput: func(_ string, data []byte) {
+		mu.Lock()
+		defer mu.Unlock()
+		writes = append(writes, string(data))
+		at = append(at, time.Now())
+	}}
+
+	if err := d.typeDoorbell("delayed-enter", "ping"); err != nil {
+		t.Fatalf("typeDoorbell() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	wantPaste := bracketedPasteStart + "ping" + bracketedPasteEnd
+	if len(writes) != 2 || writes[0] != wantPaste || writes[1] != "\r" {
+		t.Fatalf("PTY writes = %q, want [%q, %q]", writes, wantPaste, "\r")
+	}
+	if elapsed := at[1].Sub(at[0]); elapsed < gap {
+		t.Fatalf("Enter followed the paste after %v, want at least %v", elapsed, gap)
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -201,6 +201,10 @@ type Daemon struct {
 	// doorbell write. This keeps a pending_approval report from interleaving
 	// between the prompt and its trailing Enter.
 	doorbellMu sync.Mutex
+	// ptyWriteFences serializes writes into each session's PTY so nothing can
+	// land inside a multi-write delivery — see pty_write_fence.go.
+	ptyWriteFencesMu sync.Mutex
+	ptyWriteFences   map[string]*sync.Mutex
 	// stateTrace is the diagnostic ring of state observations behind
 	// `attn state explain`. Lazily built so a directly-constructed test daemon
 	// traces without an init site.
@@ -1773,6 +1777,7 @@ func (d *Daemon) dropSessionRecord(sessionID string) {
 		d.reconcileTicketsOnSessionEnd(sessionID, string(session.State))
 	}
 	d.clearNudgeState(sessionID)
+	d.clearPTYWriteFence(sessionID)
 	d.store.Remove(sessionID)
 	// After the row is gone, not before: recordStateObservation gates on the row,
 	// so forgetting first would leave a window where a concurrent observation

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -104,6 +104,11 @@ func TestMain(m *testing.M) {
 	_ = os.Setenv("ATTN_PTY_BACKEND", "embedded")
 	_ = os.Setenv("ATTN_PTY_SKIP_STARTUP_PROBE", "1")
 
+	// Doorbell delivery waits out a real composer's paste-settle window before
+	// sending Enter. No fake PTY needs that wait, so tests run without it —
+	// TestTypeDoorbellDelaysEnterAfterThePaste restores a delay to pin the gap.
+	doorbellSubmitDelay = 0
+
 	// Plugin-process helper subprocesses (TestDaemonPluginProcessHelper,
 	// TestPluginDriverFixtureProcess) re-exec this same test binary with a
 	// single -test.run and rely on ATTN_SOCKET_PATH being the exact value

--- a/internal/daemon/notebook_test.go
+++ b/internal/daemon/notebook_test.go
@@ -709,16 +709,16 @@ func TestNotebookSendToChiefAppendsAndNudges(t *testing.T) {
 		t.Fatalf("send-to-chief result = %+v, want success inbox.md nudged", res.Result)
 	}
 
-	// Only the bounded doorbell and its submit input were typed into the chief PTY
-	// as one bracketed, atomic write — never the selection content itself (that
-	// goes to the inbox note, not the terminal).
+	// Only the bounded doorbell and its Enter were typed into the chief PTY —
+	// never the selection content itself (that goes to the inbox note, not the
+	// terminal).
 	mu.Lock()
 	got := append([]string(nil), inputs...)
 	mu.Unlock()
 	wantNudge := chiefInboxNudgePrompt(d.store.GetSetting(SettingNotebookRoot))
-	wantInput := bracketedPasteStart + wantNudge + bracketedPasteEnd + "\r"
-	if len(got) != 1 || got[0] != wantInput {
-		t.Fatalf("PTY inputs = %q, want one atomic bracketed nudge-prompt-plus-Enter write", got)
+	wantPaste := bracketedPasteStart + wantNudge + bracketedPasteEnd
+	if len(got) != 2 || got[0] != wantPaste || got[1] != "\r" {
+		t.Fatalf("PTY inputs = %q, want a bracketed nudge-prompt write followed by Enter", got)
 	}
 
 	body := readInboxNote(t, d)
@@ -776,8 +776,8 @@ func TestNotebookSendToChiefNudgesWorkingChief(t *testing.T) {
 	mu.Lock()
 	n := len(inputs)
 	mu.Unlock()
-	if n != 1 {
-		t.Fatalf("PTY inputs = %d, want one atomic bracketed prompt-plus-Enter write", n)
+	if n != 2 {
+		t.Fatalf("PTY inputs = %d, want a bracketed prompt write plus Enter", n)
 	}
 }
 

--- a/internal/daemon/nudge_countdown_test.go
+++ b/internal/daemon/nudge_countdown_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -262,11 +263,16 @@ func TestDoorbellWriteDoesNotInterleaveWithPendingApproval(t *testing.T) {
 
 	inputStarted := make(chan struct{})
 	releaseInput := make(chan struct{})
-	inputs := make(chan string, 1)
+	inputs := make(chan string, 2)
+	var firstWrite sync.Once
 	d.ptyBackend = &fakeSpawnBackend{onInput: func(_ string, data []byte) {
 		inputs <- string(data)
-		close(inputStarted)
-		<-releaseInput
+		// Hold the paste write open: the fence has to survive the whole
+		// paste-then-Enter pair, not just a single write.
+		firstWrite.Do(func() {
+			close(inputStarted)
+			<-releaseInput
+		})
 	}}
 
 	doorbellDone := make(chan error, 1)
@@ -294,9 +300,12 @@ func TestDoorbellWriteDoesNotInterleaveWithPendingApproval(t *testing.T) {
 		t.Fatalf("typeDoorbell() error = %v", err)
 	}
 	<-stateDone
-	want := bracketedPasteStart + ticketNudgePrompt + bracketedPasteEnd + "\r"
-	if got := <-inputs; got != want {
-		t.Fatalf("doorbell input = %q, want atomic bracketed prompt+Enter %q", got, want)
+	wantPaste := bracketedPasteStart + ticketNudgePrompt + bracketedPasteEnd
+	if got := <-inputs; got != wantPaste {
+		t.Fatalf("doorbell paste = %q, want %q", got, wantPaste)
+	}
+	if got := <-inputs; got != "\r" {
+		t.Fatalf("doorbell submit = %q, want a lone Enter", got)
 	}
 }
 

--- a/internal/daemon/plugin_message_delivery_test.go
+++ b/internal/daemon/plugin_message_delivery_test.go
@@ -81,7 +81,7 @@ func TestTypeDoorbell_KeepsPTYPasteWithoutMessageDeliveryCapability(t *testing.T
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}
 	var recordedInput []byte
-	backend.onInput = func(_ string, data []byte) { recordedInput = append([]byte(nil), data...) }
+	backend.onInput = func(_ string, data []byte) { recordedInput = append(recordedInput, data...) }
 	d.ptyBackend = backend
 
 	client, done := startPluginPipe(t, d, "pi-plugin", nil)

--- a/internal/daemon/pty_write_fence.go
+++ b/internal/daemon/pty_write_fence.go
@@ -1,0 +1,66 @@
+package daemon
+
+import (
+	"context"
+	"sync"
+)
+
+// The PTY write fence serializes writes into one session's terminal.
+//
+// A doorbell is not a single write: the payload goes out as a bracketed paste
+// and its Enter follows doorbellSubmitDelay later, because agent composers
+// finalize a paste on a timing boundary (see doorbellSubmitDelay). That gap is
+// an open splice window — a keystroke landing inside it would sit between the
+// paste and the Enter, and the doorbell's own Enter would submit the user's
+// half-typed line along with the prompt.
+//
+// So every write into a session's PTY takes that session's fence, and the
+// doorbell holds it across its whole pair. A keystroke racing the gap is
+// written after the Enter, never inside it: the doorbell submits exactly what
+// it composed, and the user's line stays theirs, still in the composer.
+//
+// This is a different fence from doorbellMu, which serializes a doorbell
+// against authoritative state commits. The two nest in one order only —
+// doorbellMu, then the write fence — and nothing takes them the other way.
+
+// ptyWriteFence returns the per-session write fence, creating it on first use.
+func (d *Daemon) ptyWriteFence(sessionID string) *sync.Mutex {
+	d.ptyWriteFencesMu.Lock()
+	defer d.ptyWriteFencesMu.Unlock()
+	if d.ptyWriteFences == nil {
+		d.ptyWriteFences = make(map[string]*sync.Mutex)
+	}
+	fence, ok := d.ptyWriteFences[sessionID]
+	if !ok {
+		fence = &sync.Mutex{}
+		d.ptyWriteFences[sessionID] = fence
+	}
+	return fence
+}
+
+// clearPTYWriteFence drops a removed session's fence.
+func (d *Daemon) clearPTYWriteFence(sessionID string) {
+	d.ptyWriteFencesMu.Lock()
+	defer d.ptyWriteFencesMu.Unlock()
+	delete(d.ptyWriteFences, sessionID)
+}
+
+// writePTY sends one payload to a session's PTY under its write fence. Every
+// PTY write goes through here (or through withPTYWriteFence for a multi-write
+// delivery) so nothing can interleave with a delivery in progress.
+func (d *Daemon) writePTY(sessionID string, data []byte) error {
+	fence := d.ptyWriteFence(sessionID)
+	fence.Lock()
+	defer fence.Unlock()
+	return d.ptyBackend.Input(context.Background(), sessionID, data)
+}
+
+// withPTYWriteFence runs a multi-write delivery with the session's fence held
+// for its whole duration. The callback must write via ptyBackend.Input
+// directly: writePTY would deadlock on the fence this already holds.
+func (d *Daemon) withPTYWriteFence(sessionID string, deliver func() error) error {
+	fence := d.ptyWriteFence(sessionID)
+	fence.Lock()
+	defer fence.Unlock()
+	return deliver()
+}

--- a/internal/daemon/ws_markdown_annotations_submit.go
+++ b/internal/daemon/ws_markdown_annotations_submit.go
@@ -17,7 +17,7 @@ const (
 
 // handleMarkdownAnnotationsSubmit formats the persisted annotation draft for
 // a path into the feedback payload and delivers it into the target session's
-// PTY via typeDoorbell (bracketed paste + Enter, atomic under doorbellMu).
+// PTY via typeDoorbell (bracketed paste, then Enter, both under doorbellMu).
 //
 // Drafts are tombstone-cleared ONLY after a successful delivery; every other
 // outcome (validation error, unknown session, pending_approval skip, PTY

--- a/internal/daemon/ws_markdown_annotations_submit_test.go
+++ b/internal/daemon/ws_markdown_annotations_submit_test.go
@@ -68,9 +68,9 @@ func storedSubmitDraftCount(t *testing.T, d *Daemon) int {
 	return len(anns)
 }
 
-// Delivered: exactly one PTY write of paste-start + payload + paste-end + \r,
-// the draft is tombstone-cleared, and the result carries the new generation
-// floor so the client can seed its counter without a round-trip.
+// Delivered: the payload goes out as a bracketed paste and Enter follows as a
+// second write, the draft is tombstone-cleared, and the result carries the new
+// generation floor so the client can seed its counter without a round-trip.
 func TestMarkdownAnnotationsSubmitDelivered(t *testing.T) {
 	d := newSubmitDaemon(t)
 	var mu sync.Mutex
@@ -89,12 +89,12 @@ func TestMarkdownAnnotationsSubmitDelivered(t *testing.T) {
 		t.Fatalf("generation = %v, want floor 5", res.Generation)
 	}
 	wantPayload := formatMarkdownAnnotationPayload(submitTestPath, anns, map[string]bool{})
-	wantInput := bracketedPasteStart + wantPayload + bracketedPasteEnd + "\r"
+	wantPaste := bracketedPasteStart + wantPayload + bracketedPasteEnd
 	mu.Lock()
 	got := append([]string(nil), inputs...)
 	mu.Unlock()
-	if len(got) != 1 || got[0] != wantInput {
-		t.Fatalf("PTY inputs = %q, want exactly [%q]", got, wantInput)
+	if len(got) != 2 || got[0] != wantPaste || got[1] != "\r" {
+		t.Fatalf("PTY inputs = %q, want [%q, %q]", got, wantPaste, "\r")
 	}
 	if n := storedSubmitDraftCount(t, d); n != 0 {
 		t.Fatalf("draft not cleared after delivery: %d annotations remain", n)
@@ -121,7 +121,7 @@ func TestMarkdownAnnotationsSubmitCarriesOrphanedIds(t *testing.T) {
 	}
 	mu.Lock()
 	defer mu.Unlock()
-	if len(inputs) != 1 || !strings.Contains(inputs[0], "(~line 3, moved)") {
+	if len(inputs) != 2 || !strings.Contains(inputs[0], "(~line 3, moved)") {
 		t.Fatalf("payload should label orphaned c1, got %q", inputs)
 	}
 }

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -599,7 +599,9 @@ func (d *Daemon) handlePtyInput(client *wsClient, msg *protocol.PtyInputMessage)
 			strings.TrimSpace(protocol.Deref(msg.Source)),
 		)
 	}
-	if err := d.ptyBackend.Input(context.Background(), msg.ID, []byte(msg.Data)); err != nil {
+	// Under the session's write fence: a keystroke that races a doorbell's
+	// paste-then-Enter pair lands after it, never inside it.
+	if err := d.writePTY(msg.ID, []byte(msg.Data)); err != nil {
 		if shouldLogPtyCommandError(err) {
 			d.logf("pty_input failed for %s: %v", msg.ID, err)
 		}


### PR DESCRIPTION
## The bug

Sending markdown annotations to a Claude session wrote the feedback into Claude's composer but never submitted it — the user had to press Enter themselves.

## Root cause

`typeDoorbell` delivered the payload and its Enter as a single PTY write: `ESC[200~ … ESC[201~\r`. Claude Code finalizes a paste on a timing boundary, so a CR arriving in the same read as the paste terminator is folded into the pasted text. Splitting the write alone does not help — an immediate second write is coalesced into that same read.

This shipped with the July 13 "submit Codex nudges atomically" change, which introduced the bracketed paste to give Codex a semantic boundary and kept the CR in the same write.

Every doorbell shares this primitive, so the ticket nudge, the notebook inbox doorbell, and the Present review notice had the same defect against Claude.

## Fix

Enter follows the paste as its own write, after a settle delay (150ms). Both writes stay under `doorbellMu`, so a `pending_approval` report still cannot commit between the prompt and its Enter.

## Evidence

Measured against a real `claude` driven over a PTY:

| delivery | result |
| --- | --- |
| CR in the same write (before) | `[Pasted text #1 +8 lines]` stranded in the composer, 0 tokens |
| CR as a separate write, no delay | same failure |
| CR after 50ms | submits |

Codex still submits with the delayed Enter, so the boundary the July 13 fix added is preserved.

## Live verification

Branch daemon on a throwaway profile, a real Claude session spawned through it, then the actual `markdown_annotations_save` + `markdown_annotations_submit` commands over the websocket: result `delivered`, and the session ran a turn on the feedback (`transcript watcher: assistant event … "Shortened the heading to # Probe."`). The reader UI is unchanged, so the verification drives the same command the app sends.

## Tests

`TestTypeDoorbellDelaysEnterAfterThePaste` pins that Enter is a separate write arriving a real interval after the paste. Existing doorbell tests move to the paste-then-Enter shape; the state-fence test now holds the paste write open to prove the fence spans the whole pair. Daemon `TestMain` zeroes the delay so no fake PTY waits on it.

https://claude.ai/code/session_01179jS4eGexTy5NeLo6JRJF