### PR TITLE
feat(queue): a finished run opens a turn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,8 +197,10 @@ See [docs/plans/2026-07-18-db-loss-mitigation.md](docs/plans/2026-07-18-db-loss-
 - `app`: Tauri frontend; WebSocket `ws://localhost:9849`
 
 States: `launching`, `working`, `pending_approval`, `waiting_input`, `idle`,
-`unknown`. `needs_review_after_long_run` is a separate flag: a 5+ minute run
-defers final classification until viewed, then clears the flag.
+`unknown`, `scheduled`, `recoverable`. A turn opens when a session reaches a
+state that wants the user (`internal/attention`) and closes only when the user
+settles it; `turn_owed` is derived at broadcast from the persisted
+`turn_opened_at`/`turn_settled_at` stamps, never stored.
 
 IPC: `~/.attn/attn.sock`. WebSocket clients buffer 256 messages; sustained
 over-send may drop messages or disconnect slow clients.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   comes back the next time it wants you. Everything you have not settled is still
   there after a restart.
 
+### Changed
+- **An agent that finishes its run joins the queue too.** A run you asked for
+  that ended without a question is still a result nobody has read, so it lands at
+  the bottom of the list. A freshly launched agent sitting at its prompt is
+  unaffected — it has nothing behind it to read yet.
+
+### Removed
+- **The long-run review gate is gone.** Runs over five minutes used to hold their
+  final color back until you looked at the session. A finished run now publishes
+  what it actually is straight away, and the queue is what carries it to you.
+
 ## [2026-07-26]
 
 ### Added

--- a/app/scripts/real-app-harness/scenario-agent-queue.mjs
+++ b/app/scripts/real-app-harness/scenario-agent-queue.mjs
@@ -21,10 +21,13 @@
  *   4. settling removes it, and only settling does,
  *   5. a settled agent that wants the user again returns at the bottom, behind
  *      the turn that has been owed longer,
- *   6. the chief of staff occupies its own slot and never the band,
- *   7. turning the arrangement off and back on mid-session returns the same
+ *   6. a settled agent whose run finishes without asking anything returns too —
+ *      a result nobody has read is still the user's — while a shell pane and an
+ *      agent sitting at its prompt, which reach the same `idle` state, never do,
+ *   7. the chief of staff occupies its own slot and never the band,
+ *   8. turning the arrangement off and back on mid-session returns the same
  *      queue with the same agent still selected,
- *   8. a settle survives a daemon restart.
+ *   9. a settle survives a daemon restart.
  *
  * Prereqs: `claude` on PATH; a non-production profile install with the
  * automation layer; a built `./attn` (or ATTN_HARNESS_BIN) for the restart step.
@@ -205,6 +208,11 @@ async function main() {
       createdSessionIds.push(alpha.sessionId);
       // The sidebar only exists once there is something to list, so the band's
       // empty state is checked here rather than against a sessionless app.
+      //
+      // An agent that has booted to its prompt resolves to `idle`, the same
+      // state a finished run resolves to, and `idle` opens a turn. It must not
+      // queue anyway: there is no result behind it to read. This is the only
+      // place that distinction is observable end to end.
       const empty = await pollFor(async () => {
         const state = await queueState(client);
         return state.present ? state : null;
@@ -295,6 +303,77 @@ async function main() {
         'alpha behind beta, whose turn has been owed longer',
         60_000,
       );
+    });
+
+    await runner.step('a_finished_run_returns_the_agent_to_the_queue', async () => {
+      // Settle alpha first, so nothing but the finish itself can bring it back.
+      await client.request('dom_click', { selector: `[data-testid="queue-settle-${alpha.sessionId}"]` });
+      await waitForTurns(client, [beta.sessionId], 'alpha settled again');
+
+      await submitPrompt(
+        client,
+        alpha.sessionId,
+        alpha.paneId,
+        'Reply with the single word: done. Do not ask me anything and do not use any tools.',
+      );
+      await pollFor(
+        () => (observer.getSession(alpha.sessionId)?.state === 'working' ? 'working' : null),
+        'alpha to start the run',
+        60_000,
+      );
+      const duringRun = await queueState(client);
+      runner.assert(
+        !turnIds(duringRun).includes(alpha.sessionId),
+        `a settled agent stays out of the band while it works: ${JSON.stringify(turnIds(duringRun))}`,
+      );
+
+      const finished = await pollFor(
+        () => {
+          const state = observer.getSession(alpha.sessionId)?.state;
+          return state && state !== 'working' ? state : null;
+        },
+        'alpha to finish the run',
+        180_000,
+      );
+      runner.log('alpha finished', { state: finished });
+      runner.assert(
+        finished === 'idle',
+        `the run ended without a question, so it resolves to idle: got ${finished}`,
+      );
+      await waitForTurns(
+        client,
+        [beta.sessionId, alpha.sessionId],
+        'alpha back at the bottom because its run finished',
+        60_000,
+      );
+    });
+
+    await runner.step('a_shell_pane_never_queues', async () => {
+      // A shell pane is a real store session, registered idle at birth and left
+      // there. Now that idle opens a turn, only the shell exclusion keeps every
+      // ⌘` terminal out of a queue nothing could ever settle.
+      const before = turnIds(await queueState(client));
+      const workspace = await client.request('get_workspace', { sessionId: alpha.sessionId });
+      const targetPaneId = workspace.activePaneId || workspace.panes?.[0]?.paneId;
+      await client.request('split_pane', { sessionId: alpha.sessionId, targetPaneId, direction: 'vertical' });
+      const shell = await pollFor(async () => {
+        const state = await client.request('get_state');
+        return (state.sessions || []).find((session) => session.agent === 'shell') || null;
+      }, 'the shell pane to register as a session', 30_000);
+      runner.assert(shell.state === 'idle', `the shell sits in idle, the state that opens a turn: got ${shell.state}`);
+      await delay(3000);
+      const after = await queueState(client);
+      runner.assert(
+        !turnIds(after).includes(shell.id),
+        `the shell pane is not a turn: ${JSON.stringify(turnIds(after))}`,
+      );
+      runner.assert(
+        JSON.stringify(turnIds(after)) === JSON.stringify(before),
+        `opening a terminal changed nothing in the band: ${JSON.stringify(before)} -> ${JSON.stringify(turnIds(after))}`,
+      );
+      const paneWithShell = await client.request('get_workspace', { sessionId: alpha.sessionId });
+      const shellPaneId = (paneWithShell.paneIds || []).find((paneId) => paneId.includes(shell.id));
+      await client.request('close_pane', { sessionId: alpha.sessionId, paneId: shellPaneId }).catch(() => {});
     });
 
     await runner.step('the_chief_never_queues', async () => {

--- a/app/src/App.chiefOfStaffClose.test.tsx
+++ b/app/src/App.chiefOfStaffClose.test.tsx
@@ -181,7 +181,7 @@ describe('chief-of-staff session is protected from close', () => {
       sendFetchPRDetails: vi.fn(async () => ({ success: true })),
       sendEnsureRepo: vi.fn(async () => ({ success: true, path: '/tmp/repo' })),
       sendSubscribeGitStatus: fn, sendUnsubscribeGitStatus: fn,
-      sendSessionSelected: fn, sendWorkspaceSelected: fn, sendSessionVisualized: fn,
+      sendSessionSelected: fn, sendWorkspaceSelected: fn,
       sendWorkspaceClosePane: mockSendWorkspaceClosePane,
       sendWorkspaceAddSessionPane: vi.fn(async () => ({ success: true })),
       requestTileContent: fn,

--- a/app/src/App.sessionlessWorkspace.test.tsx
+++ b/app/src/App.sessionlessWorkspace.test.tsx
@@ -243,7 +243,7 @@ describe('tile-only (sessionless) workspace selection and render', () => {
       sendFetchPRDetails: vi.fn(async () => ({ success: true })),
       sendEnsureRepo: vi.fn(async () => ({ success: true, path: '/tmp/repo' })),
       sendSubscribeGitStatus: fn, sendUnsubscribeGitStatus: fn,
-      sendSessionSelected: fn, sendWorkspaceSelected: mockSendWorkspaceSelected, sendSessionVisualized: fn,
+      sendSessionSelected: fn, sendWorkspaceSelected: mockSendWorkspaceSelected,
       sendWorkspaceClosePane: vi.fn(async () => ({ success: true })),
       sendWorkspaceAddSessionPane: vi.fn(async () => ({ success: true })),
       requestTileContent: fn,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -647,7 +647,6 @@ function App() {
     sendTriggerNudge,
     sendSettleTurn,
     sendWorkspaceSelected,
-    sendSessionVisualized,
     sendWorkspaceAddSessionPane,
     sendWorkspaceClosePane,
     sendWorkspaceSetSplitRatio,
@@ -867,7 +866,6 @@ function App() {
         sendTriggerNudge={sendTriggerNudge}
         sendSettleTurn={sendSettleTurn}
         sendWorkspaceSelected={sendWorkspaceSelected}
-        sendSessionVisualized={sendSessionVisualized}
         sendWorkspaceAddSessionPane={sendWorkspaceAddSessionPane}
         sendWorkspaceClosePane={sendWorkspaceClosePane}
         sendWorkspaceSetSplitRatio={sendWorkspaceSetSplitRatio}
@@ -994,7 +992,6 @@ interface AppContentProps {
   sendTriggerNudge: ReturnType<typeof useDaemonSocket>['sendTriggerNudge'];
   sendSettleTurn: ReturnType<typeof useDaemonSocket>['sendSettleTurn'];
   sendWorkspaceSelected: ReturnType<typeof useDaemonSocket>['sendWorkspaceSelected'];
-  sendSessionVisualized: ReturnType<typeof useDaemonSocket>['sendSessionVisualized'];
   sendWorkspaceAddSessionPane: ReturnType<typeof useDaemonSocket>['sendWorkspaceAddSessionPane'];
   sendWorkspaceClosePane: ReturnType<typeof useDaemonSocket>['sendWorkspaceClosePane'];
   sendWorkspaceSetSplitRatio: ReturnType<typeof useDaemonSocket>['sendWorkspaceSetSplitRatio'];
@@ -1115,7 +1112,6 @@ sendFetchPRDetails,
   sendTriggerNudge,
   sendSettleTurn,
   sendWorkspaceSelected,
-  sendSessionVisualized,
   sendWorkspaceAddSessionPane,
   sendWorkspaceClosePane,
   sendWorkspaceSetSplitRatio,
@@ -1568,11 +1564,6 @@ sendFetchPRDetails,
   );
   const dockPanelCloseTimersRef = useRef<Partial<Record<DockPanelId, number>>>({});
   const gitStatusSubscribedDirRef = useRef<string | null>(null);
-  const activeSessionVisibleSinceRef = useRef<{ id: string; at: number } | null>(null);
-  const pendingSessionVisualizedRef = useRef<{ key: string | null; timeoutId: number | null }>({
-    key: null,
-    timeoutId: null,
-  });
 
   // When activeSessionId changes, update view
   useEffect(() => {
@@ -1592,70 +1583,6 @@ sendFetchPRDetails,
       sendSessionSelected(activeSessionId);
     }
   }, [activeSessionId, sendSessionSelected, view]);
-
-  // Track when the currently-selected session became visible.
-  useEffect(() => {
-    if (view !== 'session' || !activeSessionId) {
-      activeSessionVisibleSinceRef.current = null;
-      return;
-    }
-    const current = activeSessionVisibleSinceRef.current;
-    if (!current || current.id !== activeSessionId) {
-      activeSessionVisibleSinceRef.current = { id: activeSessionId, at: Date.now() };
-    }
-  }, [activeSessionId, view]);
-
-  // For long runs, defer classification until the user has visualized the session long enough.
-  useEffect(() => {
-    const tracker = pendingSessionVisualizedRef.current;
-    const activeSession =
-      view === 'session' && activeSessionId
-        ? daemonSessions.find((session) => session.id === activeSessionId)
-        : undefined;
-    const needsReview = Boolean(activeSession?.needs_review_after_long_run);
-    const key = needsReview && activeSession ? `${activeSession.id}:${activeSession.state_updated_at}` : null;
-
-    if (tracker.key === key) {
-      return;
-    }
-
-    if (tracker.timeoutId !== null) {
-      clearTimeout(tracker.timeoutId);
-      tracker.timeoutId = null;
-    }
-    tracker.key = key;
-
-    if (!activeSession || !needsReview || !key) {
-      return;
-    }
-
-    let delayMs = 5000;
-    const visibleSince = activeSessionVisibleSinceRef.current;
-    const stateUpdatedAtMs = Date.parse(activeSession.state_updated_at);
-    const userAlreadyViewingWhenFinished =
-      visibleSince?.id === activeSession.id &&
-      Number.isFinite(stateUpdatedAtMs) &&
-      visibleSince.at <= stateUpdatedAtMs;
-    if (userAlreadyViewingWhenFinished) {
-      delayMs = 0;
-    }
-
-    tracker.timeoutId = window.setTimeout(() => {
-      sendSessionVisualized(activeSession.id);
-      tracker.timeoutId = null;
-    }, delayMs);
-  }, [activeSessionId, daemonSessions, sendSessionVisualized, view]);
-
-  useEffect(() => {
-    return () => {
-      const tracker = pendingSessionVisualizedRef.current;
-      if (tracker.timeoutId !== null) {
-        clearTimeout(tracker.timeoutId);
-        tracker.timeoutId = null;
-      }
-      tracker.key = null;
-    };
-  }, []);
 
   // Subscribe to git status for active session
   useEffect(() => {

--- a/app/src/App.worktreeCleanup.test.tsx
+++ b/app/src/App.worktreeCleanup.test.tsx
@@ -335,7 +335,6 @@ describe('worktree cleanup prompt', () => {
       sendUnsubscribeGitStatus: fn,
       sendSessionSelected: fn,
       sendWorkspaceSelected: fn,
-      sendSessionVisualized: fn,
       sendWorkspaceClosePane: mockSendWorkspaceClosePane,
       sendWorkspaceAddSessionPane: vi.fn(async () => ({ success: true })),
       sendGetFileDiff: vi.fn(async () => ({ success: true, original: '', modified: '' })),
@@ -608,118 +607,6 @@ describe('worktree cleanup prompt', () => {
       expect(sendDeleteWorktree).toHaveBeenLastCalledWith('/tmp/repo/.worktrees/feature-a', undefined, { force: true });
     });
     consoleError.mockRestore();
-  });
-
-  it('marks remote long-run sessions as visualized after the visibility delay', async () => {
-    vi.useFakeTimers();
-    const sendSessionVisualized = vi.fn();
-    const sendSessionSelected = vi.fn();
-    const fn = vi.fn();
-
-    mockUseSessionStore.mockReturnValue({
-      sessions: [
-        {
-          id: 'remote-1',
-          label: 'remote-session',
-          state: 'waiting_input',
-          cwd: '/srv/repo',
-          workspaceId: 'workspace-remote-1',
-          agent: 'claude',
-          transcriptMatched: true,
-          branch: 'main',
-          daemonActivePaneId: 'main',
-          endpointId: 'ep-1',
-          workspace: {
-            agents: [{ id: 'pane-session', runtimeId: 'remote-1', sessionId: 'remote-1', title: 'remote-session' }],
-            layoutTree: { type: 'pane', paneId: 'pane-session' },
-          },
-        },
-      ],
-      activeSessionId: 'remote-1',
-      connect: vi.fn(async () => {}),
-      connected: true,
-      launcherConfig: { executables: {} },
-      createSession: vi.fn(async () => 'remote-1'),
-      closeSession: mockCloseSession,
-      setActiveSession: vi.fn(),
-      takeSessionSpawnArgs: vi.fn(() => null),
-      reloadSession: vi.fn(async () => {}),
-      setLauncherConfig: vi.fn(),
-      syncFromDaemonSessions: vi.fn(),
-      syncFromDaemonWorkspaces: vi.fn(),
-    });
-
-    mockUseDaemonStore.mockReturnValue({
-      daemonSessions: [
-        {
-          id: 'remote-1',
-          label: 'remote-session',
-          directory: '/srv/repo',
-          state: 'waiting_input',
-          endpoint_id: 'ep-1',
-          needs_review_after_long_run: true,
-          state_updated_at: '2026-04-03T12:00:00Z',
-        },
-      ],
-      setDaemonSessions: vi.fn(),
-      prs: [],
-      setPRs: vi.fn(),
-      repoStates: [],
-      setRepoStates: vi.fn(),
-      authorStates: [],
-      setAuthorStates: vi.fn(),
-    });
-
-    mockUseDaemonSocket.mockReturnValue({
-      sendPRAction: fn,
-      sendMutePR: fn,
-      sendMuteRepo: fn,
-      sendMuteAuthor: fn,
-      sendPRVisited: fn,
-      sendRefreshPRs: vi.fn(async () => ({ success: true })),
-      sendUnregisterSession: mockSendUnregisterSession,
-      sendRegisterWorkspace: mockSendRegisterWorkspace,
-      sendUnregisterWorkspace: mockSendUnregisterWorkspace,
-      sendSetSetting: fn,
-      sendCreateWorktree: vi.fn(async () => ({ success: true, path: '/tmp/new' })),
-      sendDeleteWorktree: vi.fn(async () => ({ success: true })),
-      sendGetRecentLocations: vi.fn(async () => ({ success: true, locations: [] })),
-      sendCreateWorktreeFromBranch: vi.fn(async () => ({ success: true, path: '/tmp/new' })),
-      sendFetchRemotes: vi.fn(async () => ({ success: true })),
-      sendFetchPRDetails: vi.fn(async () => ({ success: true })),
-      sendEnsureRepo: vi.fn(async () => ({ success: true, path: '/tmp/repo' })),
-      sendSubscribeGitStatus: fn,
-      sendUnsubscribeGitStatus: fn,
-      sendSessionSelected,
-      sendWorkspaceSelected: vi.fn(),
-      sendSessionVisualized,
-      sendWorkspaceClosePane: mockSendWorkspaceClosePane,
-      sendWorkspaceAddSessionPane: vi.fn(async () => ({ success: true })),
-      sendGetFileDiff: vi.fn(async () => ({ success: true, original: '', modified: '' })),
-      getRepoInfo: vi.fn(async () => ({ success: true, is_git_repo: true, branch: 'main' })),
-      listWorkflowRuns: vi.fn(async () => ({ success: true, runs: [] })),
-      getPresentations: vi.fn(async () => []),
-      connectionError: null,
-      hasReceivedInitialState: true,
-      sendNotificationList: vi.fn(async () => ({ notifications: [], unreadCount: 0 })),
-      sendNotificationMarkRead: vi.fn(async () => 0),
-      rateLimit: null,
-      warnings: [],
-      clearWarnings: fn,
-      sendSetTerminalTheme: fn,
-    });
-
-    await act(async () => {
-      render(<App />);
-      await Promise.resolve();
-    });
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(5000);
-    });
-
-    expect(sendSessionSelected).toHaveBeenCalledWith('remote-1');
-    expect(sendSessionVisualized).toHaveBeenCalledWith('remote-1');
   });
 
   it('only lets the active PR launcher request update or clear progress', async () => {

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -169,7 +169,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '196';
+export const PROTOCOL_VERSION = '197';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a
@@ -885,7 +885,6 @@ export function useDaemonSocket({
   const canceledAttachIdsRef = useRef(new Set<string>());
   // Per-session attach serialization chain — see sendAttachSession.
   const attachQueueRef = useRef(new Map<string, Promise<unknown>>());
-  const pendingSessionVisualizedRef = useRef<Set<string>>(new Set());
   const selectedSessionRef = useRef<string | null>(null);
   const selectedWorkspaceRef = useRef<string | null>(null);
   const daemonInstanceIDRef = useRef<string>('');
@@ -1199,12 +1198,6 @@ export function useDaemonSocket({
         ws.send(JSON.stringify({ cmd: 'subscribe_git_status', directory: gitStatusSubscriptionRef.current }));
       }
 
-      if (pendingSessionVisualizedRef.current.size > 0) {
-        for (const sessionID of pendingSessionVisualizedRef.current) {
-          ws.send(JSON.stringify({ cmd: 'session_visualized', id: sessionID }));
-        }
-        pendingSessionVisualizedRef.current.clear();
-      }
       if (selectedSessionRef.current) {
         ws.send(JSON.stringify({ cmd: 'session_selected', id: selectedSessionRef.current }));
       }
@@ -5236,19 +5229,7 @@ export function useDaemonSocket({
     ws.send(JSON.stringify({ cmd: 'unsubscribe_git_status' }));
   }, []);
 
-  // Notify daemon that the user has visualized a session long enough to resume deferred classification.
-  const sendSessionVisualized = useCallback((id: string) => {
-    const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN) {
-      pendingSessionVisualizedRef.current.add(id);
-      return;
-    }
-    ws.send(JSON.stringify({ cmd: 'session_visualized', id }));
-    pendingSessionVisualizedRef.current.delete(id);
-  }, []);
-
-  // Track ordinary UI selection separately from the delayed long-run review
-  // signal so `attn open` always targets the session currently shown.
+  // Records the session the UI is showing, so `attn open` targets it.
   const sendSessionSelected = useCallback((id: string) => {
     selectedSessionRef.current = id;
     const ws = wsRef.current;
@@ -5839,7 +5820,6 @@ export function useDaemonSocket({
     sendTriggerNudge,
     sendSettleTurn,
     sendWorkspaceSelected,
-    sendSessionVisualized,
     sendWorkspaceGet,
     sendWorkspaceAddSessionPane,
     sendWorkspaceClosePane,

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookNotificationMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookNotificationMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -263,7 +263,6 @@
 //   const sessionTranscriptMessage = Convert.toSessionTranscriptMessage(json);
 //   const sessionTranscriptResult = Convert.toSessionTranscriptResult(json);
 //   const sessionUnregisteredMessage = Convert.toSessionUnregisteredMessage(json);
-//   const sessionVisualizedMessage = Convert.toSessionVisualizedMessage(json);
 //   const setChiefOfStaffMessage = Convert.toSetChiefOfStaffMessage(json);
 //   const setEndpointRemoteWebMessage = Convert.toSetEndpointRemoteWebMessage(json);
 //   const setPluginPriorityMessage = Convert.toSetPluginPriorityMessage(json);
@@ -845,29 +844,28 @@ export enum BranchChangedMessageEvent {
 }
 
 export interface SessionElement {
-    agent:                        string;
-    branch?:                      string;
-    chief_of_staff?:              boolean;
-    delegated_from_chief?:        boolean;
-    directory:                    string;
-    endpoint_id?:                 string;
-    id:                           string;
-    is_worktree?:                 boolean;
-    label:                        string;
-    last_seen:                    string;
-    main_repo?:                   string;
-    needs_review_after_long_run?: boolean;
-    nudge_fires_at?:              string;
-    state:                        SessionState;
-    state_reason?:                string;
-    state_since:                  string;
-    state_updated_at:             string;
-    ticket_unread?:               boolean;
-    todos?:                       string[];
-    turn_opened_at?:              string;
-    turn_owed?:                   boolean;
-    workspace_id:                 string;
-    workspace_muted?:             boolean;
+    agent:                 string;
+    branch?:               string;
+    chief_of_staff?:       boolean;
+    delegated_from_chief?: boolean;
+    directory:             string;
+    endpoint_id?:          string;
+    id:                    string;
+    is_worktree?:          boolean;
+    label:                 string;
+    last_seen:             string;
+    main_repo?:            string;
+    nudge_fires_at?:       string;
+    state:                 SessionState;
+    state_reason?:         string;
+    state_since:           string;
+    state_updated_at:      string;
+    ticket_unread?:        boolean;
+    todos?:                string[];
+    turn_opened_at?:       string;
+    turn_owed?:            boolean;
+    workspace_id:          string;
+    workspace_muted?:      boolean;
     [property: string]: any;
 }
 
@@ -4103,29 +4101,28 @@ export enum RuntimeRespawnedMessageEvent {
 }
 
 export interface Session {
-    agent:                        string;
-    branch?:                      string;
-    chief_of_staff?:              boolean;
-    delegated_from_chief?:        boolean;
-    directory:                    string;
-    endpoint_id?:                 string;
-    id:                           string;
-    is_worktree?:                 boolean;
-    label:                        string;
-    last_seen:                    string;
-    main_repo?:                   string;
-    needs_review_after_long_run?: boolean;
-    nudge_fires_at?:              string;
-    state:                        SessionState;
-    state_reason?:                string;
-    state_since:                  string;
-    state_updated_at:             string;
-    ticket_unread?:               boolean;
-    todos?:                       string[];
-    turn_opened_at?:              string;
-    turn_owed?:                   boolean;
-    workspace_id:                 string;
-    workspace_muted?:             boolean;
+    agent:                 string;
+    branch?:               string;
+    chief_of_staff?:       boolean;
+    delegated_from_chief?: boolean;
+    directory:             string;
+    endpoint_id?:          string;
+    id:                    string;
+    is_worktree?:          boolean;
+    label:                 string;
+    last_seen:             string;
+    main_repo?:            string;
+    nudge_fires_at?:       string;
+    state:                 SessionState;
+    state_reason?:         string;
+    state_since:           string;
+    state_updated_at:      string;
+    ticket_unread?:        boolean;
+    todos?:                string[];
+    turn_opened_at?:       string;
+    turn_owed?:            boolean;
+    workspace_id:          string;
+    workspace_muted?:      boolean;
     [property: string]: any;
 }
 
@@ -4252,16 +4249,6 @@ export interface SessionUnregisteredMessage {
 
 export enum SessionUnregisteredMessageEvent {
     SessionUnregistered = "session_unregistered",
-}
-
-export interface SessionVisualizedMessage {
-    cmd: SessionVisualizedMessageCmd;
-    id:  string;
-    [property: string]: any;
-}
-
-export enum SessionVisualizedMessageCmd {
-    SessionVisualized = "session_visualized",
 }
 
 export interface SetChiefOfStaffMessage {
@@ -7827,14 +7814,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SessionUnregisteredMessage")), null, 2);
     }
 
-    public static toSessionVisualizedMessage(json: string): SessionVisualizedMessage {
-        return cast(JSON.parse(json), r("SessionVisualizedMessage"));
-    }
-
-    public static sessionVisualizedMessageToJson(value: SessionVisualizedMessage): string {
-        return JSON.stringify(uncast(value, r("SessionVisualizedMessage")), null, 2);
-    }
-
     public static toSetChiefOfStaffMessage(json: string): SetChiefOfStaffMessage {
         return cast(JSON.parse(json), r("SetChiefOfStaffMessage"));
     }
@@ -9281,7 +9260,6 @@ const typeMap: any = {
         { json: "label", js: "label", typ: "" },
         { json: "last_seen", js: "last_seen", typ: "" },
         { json: "main_repo", js: "main_repo", typ: u(undefined, "") },
-        { json: "needs_review_after_long_run", js: "needs_review_after_long_run", typ: u(undefined, true) },
         { json: "nudge_fires_at", js: "nudge_fires_at", typ: u(undefined, "") },
         { json: "state", js: "state", typ: r("SessionState") },
         { json: "state_reason", js: "state_reason", typ: u(undefined, "") },
@@ -11235,7 +11213,6 @@ const typeMap: any = {
         { json: "label", js: "label", typ: "" },
         { json: "last_seen", js: "last_seen", typ: "" },
         { json: "main_repo", js: "main_repo", typ: u(undefined, "") },
-        { json: "needs_review_after_long_run", js: "needs_review_after_long_run", typ: u(undefined, true) },
         { json: "nudge_fires_at", js: "nudge_fires_at", typ: u(undefined, "") },
         { json: "state", js: "state", typ: r("SessionState") },
         { json: "state_reason", js: "state_reason", typ: u(undefined, "") },
@@ -11312,10 +11289,6 @@ const typeMap: any = {
     "SessionUnregisteredMessage": o([
         { json: "event", js: "event", typ: r("SessionUnregisteredMessageEvent") },
         { json: "session", js: "session", typ: r("SessionElement") },
-    ], "any"),
-    "SessionVisualizedMessage": o([
-        { json: "cmd", js: "cmd", typ: r("SessionVisualizedMessageCmd") },
-        { json: "id", js: "id", typ: "" },
     ], "any"),
     "SetChiefOfStaffMessage": o([
         { json: "chief_of_staff", js: "chief_of_staff", typ: true },
@@ -12846,9 +12819,6 @@ const typeMap: any = {
     ],
     "SessionUnregisteredMessageEvent": [
         "session_unregistered",
-    ],
-    "SessionVisualizedMessageCmd": [
-        "session_visualized",
     ],
     "SetChiefOfStaffMessageCmd": [
         "set_chief_of_staff",

--- a/docs/decisions/2026-05-31-docked-tiles.md
+++ b/docs/decisions/2026-05-31-docked-tiles.md
@@ -101,7 +101,7 @@ authoritative.
   bundled agent skill documents it so agents can show the user a rendered doc.
 - **Session resolution:** explicit `--session` / `session_id` > `ATTN_SESSION_ID`
   (the agent's own session) > the daemon's currently-selected session (tracked
-  from `session_visualized`). This is what makes a bare `attn open notes.md`
+  from `session_selected`). This is what makes a bare `attn open notes.md`
   land next to whatever the user is looking at.
 - **No empty "show tile" toggle.** A markdown tile only exists once it points
   at a real file, so there is no sidebar button that docks a blank tile. Tiles

--- a/docs/plans/2026-07-26-agent-queue-turn-and-settle.md
+++ b/docs/plans/2026-07-26-agent-queue-turn-and-settle.md
@@ -395,9 +395,14 @@ if it still feels heavy the flip is one predicate entry to revert.
 - [x] Protocol: drop `needs_review_after_long_run` and `session_visualized`;
       regenerate; bump. Drop the hub's equality check for the flag.
 - [x] Confirm a 5m+ run publishes its verdict immediately rather than on view.
-- [ ] Live verification: an agent settled while working reappears when it
+- [x] Live verification: an agent settled while working reappears when it
       finishes; a shell pane never appears; a day's worth of finished agents is a
       list you can actually drain.
+      Folded into `real-app:scenario-agent-queue` as two steps: a settled agent
+      whose run ends `idle` returns at the bottom, and a split shell pane —
+      registered `idle`, the same state — changes nothing in the band. The
+      pre-existing empty-band assertion on a freshly booted agent is what covers
+      the `atPrompt` guard.
 
 ## Decisions
 

--- a/docs/plans/2026-07-26-agent-queue-turn-and-settle.md
+++ b/docs/plans/2026-07-26-agent-queue-turn-and-settle.md
@@ -385,15 +385,16 @@ open through the run. That gap is slice 2.
 your plate by itself. It is last on purpose: by then settle is muscle memory, and
 if it still feels heavy the flip is one predicate entry to revert.
 
-- [ ] Add `idle` to `OpensTurn`.
-- [ ] Delete the long-run deferral, `handleSessionVisualized`, the
+- [x] Add `idle` to `OpensTurn`, guarded by `sessionStateChange.atPrompt` so a
+      session that never ran does not queue (see Decisions).
+- [x] Delete the long-run deferral, `handleSessionVisualized`, the
       `session_visualized` command, the app's 5s dwell timer, the `longRun`
       tracking and its call sites, and `longRunReviewThreshold`.
-- [ ] Delete `sessionstate.IdleStale`, `Policy.IdleStaleAfter`,
+- [x] Delete `sessionstate.IdleStale`, `Policy.IdleStaleAfter`,
       `defaultIdleStaleAfter`, and their tests.
-- [ ] Protocol: drop `needs_review_after_long_run` and `session_visualized`;
+- [x] Protocol: drop `needs_review_after_long_run` and `session_visualized`;
       regenerate; bump. Drop the hub's equality check for the flag.
-- [ ] Confirm a 5m+ run publishes its verdict immediately rather than on view.
+- [x] Confirm a 5m+ run publishes its verdict immediately rather than on view.
 - [ ] Live verification: an agent settled while working reappears when it
       finishes; a shell pane never appears; a day's worth of finished agents is a
       list you can actually drain.
@@ -457,6 +458,15 @@ if it still feels heavy the flip is one predicate entry to revert.
   hand a client everything it needs to recompute membership itself, and any
   client that did would get a different answer — it cannot see the shell, chief,
   pinned, or muted exclusions.
+- **A session sitting at its prompt does not open a turn, even though it
+  resolves to `idle`.** Found in slice 2: `sessionstate` resolves a never-run
+  session at its prompt to `idle` with `ReasonAtPrompt`, indistinguishable at the
+  state level from a finished run. Unguarded, `idle → OpensTurn` would queue every
+  freshly launched agent from the moment it booted. `sessionStateChange.atPrompt`
+  carries the distinction through the state door: the state commits identically,
+  it only skips the open, because there is no result behind it for the user to
+  read. The alternative — letting it queue — was rejected as the same "queue fills
+  with things you did not ask for" failure the exclusions exist to prevent.
 - **Enabling the mode settles nothing.** A flip that pre-settled the board would
   start the queue empty and fill it as agents stop, which reads better on the
   first screen and hides live turns at the moment the user is least able to
@@ -505,3 +515,22 @@ if it still feels heavy the flip is one predicate entry to revert.
   as the only exit, the two verbs are almost always pressed together.
 - ⌘1–9 and ⌘↑/⌘↓ still address the workspace tree in queue mode. Whether they
   should address the bands instead is a question for the standing-order rock.
+
+### Simplification opportunities found while implementing
+
+- `handleStop` now does nothing but `go d.classifySessionState(...)` behind a
+  forced-stop check. With the deferral gone, `classifyOrDeferAfterStop` is no
+  longer a seam and the two remaining callers (`handleStop`, the transcript
+  watcher) could share one narrower entry point.
+- `stateEffectProfile` is down to three booleans that vary together for every
+  cause but `startupRecovery`. If no fourth axis arrives, the profile could
+  collapse to a single `silent` flag on the cause.
+- `sessionStateChange.atPrompt` is a second, narrower channel for something the
+  resolver already knows (`resolution.Reason`). Carrying the reason itself
+  through the door would let `applyState` ask the question directly instead of
+  having the answer precomputed for it — worth doing if a second reason-dependent
+  effect ever appears.
+- `internal/daemon/daemon.go` is ~5k lines and lost several clusters here. The
+  turn/attention surface (`turn.go`, `session_evidence.go`, `session_state.go`)
+  is now coherent enough that the remaining session-state helpers still in
+  `daemon.go` could move beside it.

--- a/internal/attention/turn.go
+++ b/internal/attention/turn.go
@@ -25,6 +25,11 @@ import (
 //   - waiting_input, pending_approval, unknown open a turn. The first two are
 //     the agent asking; unknown is the daemon admitting it cannot tell, which is
 //     equally the user's problem.
+//   - idle opens one too. A run you asked for finished and nobody has read the
+//     result; that it ended without a question makes it no less yours. This is
+//     what retired the long-run review deferral, which tried to approximate the
+//     same thing by holding a verdict back on runs over five minutes and
+//     publishing it when the session was looked at.
 //   - launching, working, scheduled never open one: the agent is busy or waiting
 //     on a clock.
 //   - recoverable never opens one either. The daemon revives it unattended, so
@@ -33,7 +38,8 @@ func OpensTurn(state protocol.SessionState) bool {
 	switch state {
 	case protocol.SessionStateWaitingInput,
 		protocol.SessionStatePendingApproval,
-		protocol.SessionStateUnknown:
+		protocol.SessionStateUnknown,
+		protocol.SessionStateIdle:
 		return true
 	default:
 		return false

--- a/internal/attention/turn_test.go
+++ b/internal/attention/turn_test.go
@@ -19,9 +19,8 @@ func TestOpensTurn(t *testing.T) {
 		{protocol.SessionStateWorking, false},
 		{protocol.SessionStateScheduled, false},
 		{protocol.SessionStateRecoverable, false},
-		// idle joins the vocabulary in slice 2; until then a finished run that
-		// has no turn open leaves without asking for anyone.
-		{protocol.SessionStateIdle, false},
+		// A finished run is the user's to read, so idle opens a turn too.
+		{protocol.SessionStateIdle, true},
 	}
 
 	for _, tt := range tests {
@@ -86,9 +85,8 @@ func TestOwedExclusions(t *testing.T) {
 	}
 }
 
-// A shell sitting in idle is the case slice 2 turns live: once idle opens a
-// turn, the exclusion is the only thing keeping every terminal pane out of the
-// queue forever.
+// A shell is registered idle at birth and left there, so the exclusion is the
+// only thing keeping every terminal pane out of the queue forever.
 func TestOwedExcludesIdleShell(t *testing.T) {
 	opened := time.Date(2026, 7, 26, 10, 0, 0, 0, time.UTC)
 	if Owed(Input{OpenedAt: opened, IsShell: true}) {

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -45,7 +45,6 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdFilesEdited:                           commandMetadata(ScopeSession, false, true),
 	protocol.CmdQuery:                                 commandMetadata(ScopeHubMerge, false, true),
 	protocol.CmdHeartbeat:                             commandMetadata(ScopeSession, false, true),
-	protocol.CmdSessionVisualized:                     commandMetadata(ScopeSession, false, true),
 	protocol.CmdSessionSelected:                       commandMetadata(ScopeSession, false, true),
 	protocol.CmdTriggerNudge:                          commandMetadata(ScopeSession, false, true),
 	protocol.CmdWorkspaceSelected:                     commandMetadata(ScopeHubLocal, false, true),

--- a/internal/daemon/command_meta_test.go
+++ b/internal/daemon/command_meta_test.go
@@ -19,7 +19,6 @@ func TestCommandMetaCoversAllCommands(t *testing.T) {
 		protocol.CmdFilesEdited,
 		protocol.CmdQuery,
 		protocol.CmdHeartbeat,
-		protocol.CmdSessionVisualized,
 		protocol.CmdSessionSelected,
 		protocol.CmdTriggerNudge,
 		protocol.CmdMuteWorkspace,
@@ -143,12 +142,6 @@ func TestRemoteCommandSessionID(t *testing.T) {
 			cmd:  protocol.CmdUnregister,
 			msg:  &protocol.UnregisterMessage{ID: "sess-unregister"},
 			want: "",
-		},
-		{
-			name: "session_visualized",
-			cmd:  protocol.CmdSessionVisualized,
-			msg:  &protocol.SessionVisualizedMessage{ID: "sess-visualized"},
-			want: "sess-visualized",
 		},
 		{
 			name: "session_selected",

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -61,16 +61,9 @@ type workerReconcileReport struct {
 	Changed           bool
 }
 
-type longRunSession struct {
-	workingSince       time.Time
-	deferredTranscript string
-	needsReview        bool
-}
-
 const (
-	longRunReviewThreshold = 5 * time.Minute
-	forcedStopSuppressTTL  = 30 * time.Second
-	branchMonitorInterval  = 15 * time.Second
+	forcedStopSuppressTTL = 30 * time.Second
+	branchMonitorInterval = 15 * time.Second
 
 	// backupInterval is how often the daemon takes a rotating snapshot of the
 	// SQLite store in the background. backupKeep is how many rotating
@@ -144,8 +137,6 @@ type Daemon struct {
 	// classification outcomes without waiting on an agent driver's retry policy.
 	// Production leaves it nil and uses extractLastAssistantMessage below.
 	classificationTranscriptExtractor func(*protocol.Session, string, int, time.Time) (string, string, error)
-	longRunMu                         sync.Mutex
-	longRun                           map[string]longRunSession
 	forcedStopMu                      sync.Mutex
 	forcedStop                        map[string]time.Time
 	pendingResumeMu                   sync.Mutex
@@ -625,7 +616,6 @@ func New(socketPath string) *Daemon {
 		startedCh:           make(chan struct{}),
 		classifiedTurn:      make(map[string]string),
 		classifyingTurn:     make(map[string]string),
-		longRun:             make(map[string]longRunSession),
 		forcedStop:          make(map[string]time.Time),
 		pendingResumeID:     make(map[string]string),
 		tailscale:           newTailscaleRuntime(),
@@ -665,7 +655,6 @@ func NewForTesting(socketPath string) *Daemon {
 		startedCh:          make(chan struct{}),
 		classifiedTurn:     make(map[string]string),
 		classifyingTurn:    make(map[string]string),
-		longRun:            make(map[string]longRunSession),
 		forcedStop:         make(map[string]time.Time),
 		pendingResumeID:    make(map[string]string),
 		tailscale:          newTailscaleRuntime(),
@@ -710,7 +699,6 @@ func NewWithGitHubClient(socketPath string, ghClient github.GitHubClient) *Daemo
 		startedCh:          make(chan struct{}),
 		classifiedTurn:     make(map[string]string),
 		classifyingTurn:    make(map[string]string),
-		longRun:            make(map[string]longRunSession),
 		forcedStop:         make(map[string]time.Time),
 		pendingResumeID:    make(map[string]string),
 		tailscale:          newTailscaleRuntime(),
@@ -744,9 +732,6 @@ func (d *Daemon) Start() error {
 	}
 	if d.classifyingTurn == nil {
 		d.classifyingTurn = make(map[string]string)
-	}
-	if d.longRun == nil {
-		d.longRun = make(map[string]longRunSession)
 	}
 	if d.forcedStop == nil {
 		d.forcedStop = make(map[string]time.Time)
@@ -1603,7 +1588,6 @@ func (d *Daemon) handlePTYExit(info ptybackend.ExitInfo) {
 		}
 	}
 	d.stopTranscriptWatcher(info.ID)
-	d.clearLongRunTracking(info.ID)
 	d.closePluginDriverSession(info.ID, "exited", &info.ExitCode, info.Signal)
 
 	if d.ptyBackend != nil {
@@ -1742,7 +1726,6 @@ func (d *Daemon) forgetSession(sessionID string) {
 	if d.hubManager != nil {
 		d.hubManager.ForgetSession(sessionID)
 	}
-	d.clearLongRunTracking(sessionID)
 	d.clearClassifiedTurn(sessionID)
 	d.clearClassifyingTurn(sessionID)
 }
@@ -2244,10 +2227,6 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleQuery(conn, msg.(*protocol.QueryMessage))
 	case protocol.CmdHeartbeat:
 		d.handleHeartbeat(conn, msg.(*protocol.HeartbeatMessage))
-	case protocol.CmdSessionVisualized:
-		visualizedMsg := msg.(*protocol.SessionVisualizedMessage)
-		d.handleSessionVisualized(visualizedMsg.ID)
-		d.sendOK(conn)
 	case protocol.CmdQueryPRs:
 		d.handleQueryPRs(conn, msg.(*protocol.QueryPRsMessage))
 	case protocol.CmdMutePR:
@@ -2298,7 +2277,6 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 
 func (d *Daemon) handleRegister(conn net.Conn, msg *protocol.RegisterMessage) {
 	d.logf("session registered: id=%s label=%s dir=%s", msg.ID, protocol.Deref(msg.Label), msg.Dir)
-	d.clearLongRunTracking(msg.ID)
 	existing := d.store.Get(msg.ID)
 
 	// Get branch info
@@ -2559,59 +2537,8 @@ func (d *Daemon) handleStop(conn net.Conn, msg *protocol.StopMessage) {
 		return
 	}
 
-	// Async classification/deferred-review handling
-	go d.classifyOrDeferAfterStop(msg.ID, msg.TranscriptPath)
-}
-
-func (d *Daemon) classifyOrDeferAfterStop(sessionID, transcriptPath string) {
-	if d.sessionNeedsReviewAfterLongRun(sessionID) {
-		d.logf("classifySessionState: long-run review already pending for session=%s", sessionID)
-		return
-	}
-
-	session := d.store.Get(sessionID)
-	if session == nil {
-		d.clearLongRunTracking(sessionID)
-		return
-	}
-
-	runDuration := d.consumeRunDuration(sessionID, session.StateSince)
-	if runDuration >= longRunReviewThreshold {
-		d.setNeedsReviewAfterLongRun(sessionID, transcriptPath)
-		d.logf(
-			"classifySessionState: deferring long-run classification session=%s duration=%s",
-			sessionID,
-			runDuration.Round(time.Second),
-		)
-		// The deferral itself is the evidence: a turn worth minutes of work ended
-		// and attn is holding the verdict until someone reads it, which the resolver
-		// reports as waiting on the user rather than settling the result away as
-		// seen. Applying that state here is what this used to do, in a write the
-		// resolver's next tick undid — the review flag was invisible to it, so the
-		// same settled evidence resolved to idle a second later.
-		//
-		// The broadcast stays for the case where the state does not move: the flag
-		// rides on session broadcasts, and a long run that ended on an approval or a
-		// question is already the state the deferral would ask for.
-		d.broadcastSessionStateChanged(sessionID)
-		return
-	}
-
-	d.clearNeedsReviewAfterLongRun(sessionID)
-	d.classifySessionState(sessionID, transcriptPath)
-}
-
-func (d *Daemon) handleSessionVisualized(sessionID string) {
-	// The frontend reports the focused session here, so this doubles as our
-	// signal for "currently selected session" (used by `attn open`).
-	d.setSelectedSession(sessionID)
-
-	transcriptPath, shouldClassify := d.consumeNeedsReviewAfterLongRun(sessionID)
-	if !shouldClassify {
-		return
-	}
-	d.logf("classifySessionState: resuming deferred long-run classification session=%s", sessionID)
-	go d.classifySessionState(sessionID, transcriptPath)
+	// Async classification
+	go d.classifySessionState(msg.ID, msg.TranscriptPath)
 }
 
 // classifySessionState decides what a settled turn means and applies the result.
@@ -2870,103 +2797,6 @@ func (d *Daemon) clearClassifyingTurn(sessionID string) {
 	delete(d.classifyingTurn, sessionID)
 }
 
-func (d *Daemon) markRunStartedIfNeeded(sessionID string) {
-	now := time.Now()
-	d.longRunMu.Lock()
-	defer d.longRunMu.Unlock()
-	if d.longRun == nil {
-		d.longRun = make(map[string]longRunSession)
-	}
-	entry := d.longRun[sessionID]
-	if entry.workingSince.IsZero() {
-		entry.workingSince = now
-	}
-	entry.deferredTranscript = ""
-	entry.needsReview = false
-	d.longRun[sessionID] = entry
-}
-
-func (d *Daemon) consumeRunDuration(sessionID, fallbackStateSince string) time.Duration {
-	now := time.Now()
-	d.longRunMu.Lock()
-	if entry, ok := d.longRun[sessionID]; ok && !entry.workingSince.IsZero() {
-		startedAt := entry.workingSince
-		entry.workingSince = time.Time{}
-		if entry.deferredTranscript == "" && !entry.needsReview {
-			delete(d.longRun, sessionID)
-		} else {
-			d.longRun[sessionID] = entry
-		}
-		d.longRunMu.Unlock()
-		if startedAt.IsZero() || !now.After(startedAt) {
-			return 0
-		}
-		return now.Sub(startedAt)
-	}
-	d.longRunMu.Unlock()
-
-	if fallbackStateSince == "" {
-		return 0
-	}
-	startedAt := protocol.Timestamp(fallbackStateSince).Time()
-	if startedAt.IsZero() || !now.After(startedAt) {
-		return 0
-	}
-	return now.Sub(startedAt)
-}
-
-func (d *Daemon) setNeedsReviewAfterLongRun(sessionID, transcriptPath string) {
-	d.longRunMu.Lock()
-	defer d.longRunMu.Unlock()
-	if d.longRun == nil {
-		d.longRun = make(map[string]longRunSession)
-	}
-	entry := d.longRun[sessionID]
-	entry.deferredTranscript = strings.TrimSpace(transcriptPath)
-	entry.needsReview = true
-	d.longRun[sessionID] = entry
-}
-
-func (d *Daemon) consumeNeedsReviewAfterLongRun(sessionID string) (string, bool) {
-	d.longRunMu.Lock()
-	defer d.longRunMu.Unlock()
-	entry, ok := d.longRun[sessionID]
-	if !ok || !entry.needsReview {
-		return "", false
-	}
-	transcriptPath := entry.deferredTranscript
-	entry.deferredTranscript = ""
-	entry.needsReview = false
-	if entry.workingSince.IsZero() {
-		delete(d.longRun, sessionID)
-	} else {
-		d.longRun[sessionID] = entry
-	}
-	return transcriptPath, true
-}
-
-func (d *Daemon) clearNeedsReviewAfterLongRun(sessionID string) {
-	d.longRunMu.Lock()
-	defer d.longRunMu.Unlock()
-	entry, ok := d.longRun[sessionID]
-	if !ok {
-		return
-	}
-	entry.deferredTranscript = ""
-	entry.needsReview = false
-	if entry.workingSince.IsZero() {
-		delete(d.longRun, sessionID)
-	} else {
-		d.longRun[sessionID] = entry
-	}
-}
-
-func (d *Daemon) clearLongRunTracking(sessionID string) {
-	d.longRunMu.Lock()
-	defer d.longRunMu.Unlock()
-	delete(d.longRun, sessionID)
-}
-
 func (d *Daemon) markForcedStopClassification(sessionID string) {
 	if strings.TrimSpace(sessionID) == "" {
 		return
@@ -3014,12 +2844,6 @@ func (d *Daemon) clearForcedStopClassification(sessionID string) {
 	delete(d.forcedStop, sessionID)
 }
 
-func (d *Daemon) sessionNeedsReviewAfterLongRun(sessionID string) bool {
-	d.longRunMu.Lock()
-	defer d.longRunMu.Unlock()
-	return d.longRun[sessionID].needsReview
-}
-
 func cloneSession(session *protocol.Session) *protocol.Session {
 	if session == nil {
 		return nil
@@ -3047,11 +2871,6 @@ func (d *Daemon) sessionForBroadcastWithChiefOfStaff(
 	clone := cloneSession(session)
 	if clone == nil {
 		return nil
-	}
-	if d.sessionNeedsReviewAfterLongRun(clone.ID) {
-		clone.NeedsReviewAfterLongRun = protocol.Ptr(true)
-	} else {
-		clone.NeedsReviewAfterLongRun = nil
 	}
 	d.decorateSessionWithStateReason(clone)
 	d.decorateSessionWithNudge(clone)
@@ -3639,7 +3458,6 @@ func (d *Daemon) handleInjectTestSession(conn net.Conn, msg *protocol.InjectTest
 		return
 	}
 
-	d.clearLongRunTracking(msg.Session.ID)
 	msg.Session.Agent = normalizeStoredSessionAgent(string(msg.Session.Agent), protocol.SessionAgentCodex)
 	workspaceID := strings.TrimSpace(msg.Session.WorkspaceID)
 	if workspaceID == "" {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -5178,7 +5178,6 @@ func TestClassifySessionState_PublishesImmediatelyAfterALongRun(t *testing.T) {
 	}
 }
 
-
 func TestHandleStop_SkipsClassificationForForcedStopSession(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	mockClassifier := &countingClassifier{state: protocol.StateWaitingInput}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -5132,60 +5132,26 @@ func TestClassifySessionState_ClaudeConcurrentDuplicateTurnRunsOnce(t *testing.T
 	}
 }
 
-// TestScheduledClearsLongRunTracking proves that parking on a cron/loop ends
-// the current run for long-run-review purposes: a session that did real work
-// and then goes "scheduled" must drop its workingSince, so a later short
-// resumed turn does not falsely trip the 5-minute long-run review threshold.
-func TestScheduledClearsLongRunTracking(t *testing.T) {
+// A finished run publishes its verdict as soon as it is classified, whatever
+// its duration. The long-run review deferral used to hold verdicts back on runs
+// over five minutes and publish them when the session was next looked at; the
+// turn that the finish opens is what carries the result to the user now.
+func TestClassifySessionState_PublishesImmediatelyAfterALongRun(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-
-	now := time.Now()
-	nowStr := string(protocol.NewTimestamp(now))
-	d.store.Add(&protocol.Session{
-		ID:             "sess-loop",
-		Agent:          protocol.SessionAgentCodex,
-		Label:          "loop",
-		Directory:      "/tmp",
-		State:          protocol.StateWorking,
-		StateSince:     nowStr,
-		StateUpdatedAt: nowStr,
-		LastSeen:       nowStr,
-	})
-	// It has been working for 10 minutes, then parks on a cron.
-	d.longRun["sess-loop"] = longRunSession{workingSince: now.Add(-10 * time.Minute)}
-
-	d.applyState(sessionStateChange{
-		sessionID: "sess-loop",
-		state:     protocol.StateScheduled,
-		cause:     resolverObservation{},
-	})
-
-	d.longRunMu.Lock()
-	_, tracked := d.longRun["sess-loop"]
-	d.longRunMu.Unlock()
-	if tracked {
-		t.Fatal("parking on a schedule must clear long-run tracking; the leaked workingSince would mis-fire a review on the next short turn")
-	}
-}
-
-func TestClassifyOrDeferAfterStop_LongRunDefersUntilVisualized(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	mockClassifier := &countingClassifier{state: protocol.StateWaitingInput}
+	mockClassifier := &countingClassifier{state: protocol.StateIdle}
 	d.classifier = mockClassifier
 
-	now := time.Now()
-	nowStr := string(protocol.NewTimestamp(now))
+	nowStr := string(protocol.NewTimestamp(time.Now()))
 	d.store.Add(&protocol.Session{
 		ID:             "sess-long",
 		Agent:          protocol.SessionAgentCodex,
 		Label:          "long",
 		Directory:      "/tmp",
 		State:          protocol.StateWorking,
-		StateSince:     nowStr,
+		StateSince:     string(protocol.NewTimestamp(time.Now().Add(-10 * time.Minute))),
 		StateUpdatedAt: nowStr,
 		LastSeen:       nowStr,
 	})
-	d.longRun["sess-long"] = longRunSession{workingSince: now.Add(-6 * time.Minute)}
 
 	transcriptPath := filepath.Join(t.TempDir(), "long-transcript.jsonl")
 	content := `{"type":"assistant","message":{"role":"assistant","content":"Completed long run"}}` + "\n"
@@ -5193,125 +5159,17 @@ func TestClassifyOrDeferAfterStop_LongRunDefersUntilVisualized(t *testing.T) {
 		t.Fatalf("write transcript: %v", err)
 	}
 
-	// The turn's closing bracket, so the session has evidence to be resolved from:
-	// the deferral is a fact about a turn that ended, and the resolver is what
-	// turns it into a color.
 	d.recordBracketEvidence("sess-long", protocol.StateWorking)
 	d.recordBracketEvidence("sess-long", protocol.StateIdle)
 
-	d.classifyOrDeferAfterStop("sess-long", transcriptPath)
-	d.resolveAllSessions(time.Now())
-
-	if got := mockClassifier.CallCount(); got != 0 {
-		t.Fatalf("classifier calls=%d, want 0 while long-run review is deferred", got)
-	}
-	if !d.sessionNeedsReviewAfterLongRun("sess-long") {
-		t.Fatal("needs_review_after_long_run should be set for deferred long run")
-	}
-
-	session := d.store.Get("sess-long")
-	if session == nil {
-		t.Fatal("session missing")
-	}
-	if session.State != protocol.StateWaitingInput {
-		t.Fatalf("state=%s, want %s", session.State, protocol.StateWaitingInput)
-	}
-	decorated := d.sessionForBroadcast(session)
-	if decorated == nil || !protocol.Deref(decorated.NeedsReviewAfterLongRun) {
-		t.Fatal("broadcast session should include needs_review_after_long_run=true")
-	}
-
-	d.handleSessionVisualized("sess-long")
-
-	deadline := time.Now().Add(2 * time.Second)
-	for mockClassifier.CallCount() == 0 && time.Now().Before(deadline) {
-		time.Sleep(10 * time.Millisecond)
-	}
-	if got := mockClassifier.CallCount(); got != 1 {
-		t.Fatalf("classifier calls=%d, want 1 after visualization", got)
-	}
-	if d.sessionNeedsReviewAfterLongRun("sess-long") {
-		t.Fatal("needs_review_after_long_run should clear after visualization")
-	}
-}
-
-func TestClassifyOrDeferAfterStop_LongRunKeepsPendingApprovalState(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	mockClassifier := &countingClassifier{state: protocol.StateIdle}
-	d.classifier = mockClassifier
-
-	now := time.Now()
-	nowStr := string(protocol.NewTimestamp(now))
-	d.store.Add(&protocol.Session{
-		ID:             "sess-pending",
-		Agent:          protocol.SessionAgentCodex,
-		Label:          "pending",
-		Directory:      "/tmp",
-		State:          protocol.StatePendingApproval,
-		StateSince:     nowStr,
-		StateUpdatedAt: nowStr,
-		LastSeen:       nowStr,
-	})
-	d.longRun["sess-pending"] = longRunSession{workingSince: now.Add(-7 * time.Minute)}
-
-	d.classifyOrDeferAfterStop("sess-pending", "")
-
-	if got := mockClassifier.CallCount(); got != 0 {
-		t.Fatalf("classifier calls=%d, want 0 while deferred", got)
-	}
-	if !d.sessionNeedsReviewAfterLongRun("sess-pending") {
-		t.Fatal("needs_review_after_long_run should be set")
-	}
-
-	session := d.store.Get("sess-pending")
-	if session == nil {
-		t.Fatal("session missing")
-	}
-	if session.State != protocol.StatePendingApproval {
-		t.Fatalf("state=%s, want %s", session.State, protocol.StatePendingApproval)
-	}
-}
-
-func TestClassifyOrDeferAfterStop_ShortRunClassifiesImmediately(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	mockClassifier := &countingClassifier{state: protocol.StateIdle}
-	d.classifier = mockClassifier
-
-	now := time.Now()
-	nowStr := string(protocol.NewTimestamp(now))
-	d.store.Add(&protocol.Session{
-		ID:             "sess-short",
-		Agent:          protocol.SessionAgentCodex,
-		Label:          "short",
-		Directory:      "/tmp",
-		State:          protocol.StateWorking,
-		StateSince:     nowStr,
-		StateUpdatedAt: nowStr,
-		LastSeen:       nowStr,
-	})
-	d.longRun["sess-short"] = longRunSession{workingSince: now.Add(-2 * time.Minute)}
-
-	transcriptPath := filepath.Join(t.TempDir(), "short-transcript.jsonl")
-	content := `{"type":"assistant","message":{"role":"assistant","content":"Quick done"}}` + "\n"
-	if err := os.WriteFile(transcriptPath, []byte(content), 0644); err != nil {
-		t.Fatalf("write transcript: %v", err)
-	}
-
-	d.recordBracketEvidence("sess-short", protocol.StateWorking)
-	d.recordBracketEvidence("sess-short", protocol.StateIdle)
-
-	d.classifyOrDeferAfterStop("sess-short", transcriptPath)
+	d.classifySessionState("sess-long", transcriptPath)
 	// The verdict is evidence; the resolver is what publishes it.
 	d.resolveAllSessions(time.Now())
 
 	if got := mockClassifier.CallCount(); got != 1 {
-		t.Fatalf("classifier calls=%d, want 1 for short run", got)
+		t.Fatalf("classifier calls=%d, want 1", got)
 	}
-	if d.sessionNeedsReviewAfterLongRun("sess-short") {
-		t.Fatal("needs_review_after_long_run should be false for short run")
-	}
-
-	session := d.store.Get("sess-short")
+	session := d.store.Get("sess-long")
 	if session == nil {
 		t.Fatal("session missing")
 	}
@@ -5319,6 +5177,7 @@ func TestClassifyOrDeferAfterStop_ShortRunClassifiesImmediately(t *testing.T) {
 		t.Fatalf("state=%s, want %s", session.State, protocol.StateIdle)
 	}
 }
+
 
 func TestHandleStop_SkipsClassificationForForcedStopSession(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))

--- a/internal/daemon/plugin_driver.go
+++ b/internal/daemon/plugin_driver.go
@@ -377,14 +377,12 @@ func validatePluginReportedStop(params pluginReportStopParams) error {
 }
 
 func (d *Daemon) applyPluginReportedStop(params pluginReportStopParams) {
-	if d.applyPluginReportedState(pluginReportStateParams{
+	d.applyPluginReportedState(pluginReportStateParams{
 		SessionID: params.SessionID,
 		RunID:     params.RunID,
 		Seq:       params.Seq,
 		State:     strings.TrimSpace(params.Verdict),
-	}) {
-		d.clearLongRunTracking(params.SessionID)
-	}
+	})
 }
 
 func (d *Daemon) applyPluginReportedMetadata(params pluginReportMetadataParams) bool {

--- a/internal/daemon/presence.go
+++ b/internal/daemon/presence.go
@@ -16,7 +16,6 @@ func isUserPresenceCommand(cmd string) bool {
 	switch cmd {
 	case protocol.CmdSessionSelected,
 		protocol.CmdWorkspaceSelected,
-		protocol.CmdSessionVisualized,
 		protocol.CmdPRVisited,
 		protocol.CmdPtyInput,
 		protocol.CmdPtyResize:

--- a/internal/daemon/presence_test.go
+++ b/internal/daemon/presence_test.go
@@ -93,7 +93,6 @@ func TestIsUserPresenceCommandAllowlist(t *testing.T) {
 	present := []string{
 		protocol.CmdSessionSelected,
 		protocol.CmdWorkspaceSelected,
-		protocol.CmdSessionVisualized,
 		protocol.CmdPRVisited,
 		protocol.CmdPtyInput,
 		protocol.CmdPtyResize,

--- a/internal/daemon/session_evidence.go
+++ b/internal/daemon/session_evidence.go
@@ -462,11 +462,6 @@ func (d *Daemon) resolveAllSessions(now time.Time) {
 		if !ok {
 			continue
 		}
-		// Read live rather than mirrored into the table on every mutation. The
-		// deferral is set and consumed from five places, and a copy that drifts from
-		// the flag the UI reads would show a review as pending in one and done in the
-		// other.
-		evidence.AwaitingLongRunReview = d.sessionNeedsReviewAfterLongRun(sessionID)
 		policy := sessionstate.PolicyFor(string(session.Agent))
 		resolution := sessionstate.Resolve(evidence, policy, now)
 		d.publishResolution(sessionID, session.State, resolution, sessionstate.DwellFor(resolution.State, evidence, policy), now)
@@ -580,6 +575,7 @@ func (d *Daemon) publishResolution(sessionID string, current protocol.SessionSta
 			source: stateSourceResolver,
 			detail: resolutionDetail(resolution),
 		},
+		atPrompt: resolution.Reason == sessionstate.ReasonAtPrompt,
 	})
 }
 

--- a/internal/daemon/session_state.go
+++ b/internal/daemon/session_state.go
@@ -59,6 +59,11 @@ type sessionStateChange struct {
 	// name, which is all a daemon-internal transition has to say about itself.
 	// It never affects whether the change commits.
 	origin stateOrigin
+	// atPrompt marks a state the agent reached without ever having taken a turn:
+	// a freshly launched session sitting at its prompt, which resolves to `idle`
+	// exactly as a finished run does. It commits identically; it only must not
+	// open a turn, because there is no result behind it for the user to read.
+	atPrompt bool
 }
 
 // stateOrigin is where a state claim came from, as distinct from the commit rule
@@ -75,7 +80,6 @@ type stateOrigin struct {
 // not assemble these flags themselves.
 type stateEffectProfile struct {
 	touch     bool
-	trackRun  bool
 	syncNudge bool
 	broadcast bool
 }
@@ -83,11 +87,11 @@ type stateEffectProfile struct {
 func stateEffectProfileFor(cause sessionStateCause) (stateEffectProfile, bool) {
 	switch cause.(type) {
 	case liveSignal:
-		return stateEffectProfile{touch: true, trackRun: true, syncNudge: true, broadcast: true}, true
+		return stateEffectProfile{touch: true, syncNudge: true, broadcast: true}, true
 	case resolverObservation:
-		return stateEffectProfile{trackRun: true, syncNudge: true, broadcast: true}, true
+		return stateEffectProfile{syncNudge: true, broadcast: true}, true
 	case pluginReport:
-		return stateEffectProfile{touch: true, trackRun: true, syncNudge: true, broadcast: true}, true
+		return stateEffectProfile{touch: true, syncNudge: true, broadcast: true}, true
 	case startupRecovery:
 		return stateEffectProfile{}, true
 	default:
@@ -148,20 +152,12 @@ func (d *Daemon) applyState(change sessionStateChange) bool {
 	// startup recovery: a session that comes back in a state that wants the user
 	// wants the user regardless of what moved it there. Opening is guarded in the
 	// store, so a state re-reported while a turn is already open changes nothing.
-	if attention.OpensTurn(protocol.SessionState(change.state)) {
+	if !change.atPrompt && attention.OpensTurn(protocol.SessionState(change.state)) {
 		d.store.OpenTurnIfClosed(change.sessionID, time.Now())
 	}
 
 	if profile.touch {
 		d.store.Touch(change.sessionID)
-	}
-	if profile.trackRun {
-		switch change.state {
-		case protocol.StateWorking:
-			d.markRunStartedIfNeeded(change.sessionID)
-		case protocol.StateIdle, protocol.StateScheduled:
-			d.clearLongRunTracking(change.sessionID)
-		}
 	}
 	if profile.syncNudge {
 		d.syncNudgeForState(change.sessionID, change.state)

--- a/internal/daemon/session_state_characterization_test.go
+++ b/internal/daemon/session_state_characterization_test.go
@@ -68,13 +68,6 @@ func assertCharacterizationLiveEffects(t *testing.T, d *Daemon, capture *broadca
 		t.Fatal("live state signal did not Touch the session")
 	}
 
-	d.longRunMu.Lock()
-	tracked := !d.longRun[sessionID].workingSince.IsZero()
-	d.longRunMu.Unlock()
-	if !tracked {
-		t.Fatal("working state did not start long-run tracking")
-	}
-
 	events := capture.snapshot()
 	if got := characterizationEventCount(events, protocol.EventSessionStateChanged, sessionID); got != 1 {
 		t.Fatalf("session_state_changed events=%d, want 1; events=%+v", got, events)
@@ -134,55 +127,10 @@ func TestSessionStateCharacterization_AHookOnlyFilesEvidence(t *testing.T) {
 	}
 }
 
-func TestSessionStateCharacterization_LongRunReviewDoesNotTouch(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "state.sock"))
-	sessionID := "long-run-handoff"
-	addCharacterizationSession(t, d, sessionID, protocol.SessionAgentCodex, protocol.SessionStateWorking)
-	d.longRun[sessionID] = longRunSession{workingSince: time.Now().Add(-longRunReviewThreshold - time.Minute)}
-	// The turn that ran long, and ended.
-	d.recordBracketEvidence(sessionID, protocol.StateWorking)
-	d.recordPTYEvidence(sessionID, pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", At: time.Now()})
-	d.recordBracketEvidence(sessionID, protocol.StateIdle)
-	d.recordPTYEvidence(sessionID, pty.Observation{Source: pty.SourceHeartbeat, Claim: "not_busy", At: time.Now()})
-	capture := captureBroadcasts(d)
-
-	d.classifyOrDeferAfterStop(sessionID, "/tmp/characterization-transcript.jsonl")
-	d.resolveAllSessions(time.Now())
-
-	session := d.store.Get(sessionID)
-	if session == nil || session.State != protocol.SessionStateWaitingInput {
-		t.Fatalf("session=%+v, want waiting_input", session)
-	}
-	if session.LastSeen != characterizationOldTimestamp {
-		t.Fatalf("the resolver touched LastSeen=%q, want %q", session.LastSeen, characterizationOldTimestamp)
-	}
-	if !d.sessionNeedsReviewAfterLongRun(sessionID) {
-		t.Fatal("long-run handoff did not preserve needs-review tracking")
-	}
-	// At least one: the deferral broadcasts so the review flag reaches clients even
-	// when the state does not move, and the resolver broadcasts the state that does.
-	events := capture.snapshot()
-	if got := characterizationEventCount(events, protocol.EventSessionStateChanged, sessionID); got < 1 {
-		t.Fatalf("session_state_changed events=%d, want at least 1; events=%+v", got, events)
-	}
-	if got := characterizationEventCount(events, protocol.EventWorkspaceStateChanged, ""); got < 1 {
-		t.Fatalf("workspace_state_changed events=%d, want at least 1; events=%+v", got, events)
-	}
-}
-
-// The user-visible property the classifier's timestamp guard used to buy: a late
-// verdict must not overwrite an approval that arrived while it was running. The
-// guard is gone with the write — it is clause order now. An open approval outranks
-// a verdict, so the verdict landing changes nothing.
 func TestSessionStateCharacterization_ALateVerdictDoesNotOverwriteAnApproval(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "state.sock"))
 	sessionID := "stale-classifier"
 	addCharacterizationSession(t, d, sessionID, protocol.SessionAgentCodex, protocol.SessionStateWorking)
-	d.longRun[sessionID] = longRunSession{
-		workingSince:       time.Now().Add(-longRunReviewThreshold - time.Minute),
-		deferredTranscript: "/tmp/deferred.jsonl",
-		needsReview:        true,
-	}
 	classifier := newBlockingClassifier(protocol.StateIdle)
 	d.classifier = classifier
 
@@ -229,9 +177,6 @@ func TestSessionStateCharacterization_ALateVerdictDoesNotOverwriteAnApproval(t *
 	if after.StateUpdatedAt != fresh.StateUpdatedAt || after.LastSeen != fresh.LastSeen {
 		t.Fatalf("stale classifier changed timestamps: fresh=%+v after=%+v", fresh, after)
 	}
-	if !d.sessionNeedsReviewAfterLongRun(sessionID) {
-		t.Fatal("stale classifier cleared long-run review tracking")
-	}
 	if got := characterizationEventCount(capture.snapshot(), protocol.EventSessionStateChanged, sessionID); got != stateEventsBeforeRelease {
 		t.Fatalf("stale classifier emitted state event: before=%d after=%d", stateEventsBeforeRelease, got)
 	}
@@ -261,12 +206,6 @@ func TestSessionStateCharacterization_PluginCASGatesEffects(t *testing.T) {
 	if accepted.LastSeen == characterizationOldTimestamp {
 		t.Fatal("accepted plugin report did not Touch the session")
 	}
-	d.longRunMu.Lock()
-	tracked := !d.longRun[sessionID].workingSince.IsZero()
-	d.longRunMu.Unlock()
-	if !tracked {
-		t.Fatal("accepted plugin working report did not start long-run tracking")
-	}
 	stateEventsAfterAccepted := characterizationEventCount(capture.snapshot(), protocol.EventSessionStateChanged, sessionID)
 
 	if d.applyPluginReportedState(pluginReportStateParams{
@@ -291,7 +230,6 @@ func TestSessionStateCharacterization_ProcessExitEffects(t *testing.T) {
 	d.ptyBackend = &fakeSpawnBackend{}
 	sessionID := "process-exit"
 	addCharacterizationSession(t, d, sessionID, protocol.SessionAgentClaude, protocol.SessionStateWorking)
-	d.longRun[sessionID] = longRunSession{workingSince: time.Now().Add(-time.Minute)}
 	capture := captureBroadcasts(d)
 
 	d.handlePTYExit(ptybackend.ExitInfo{ID: sessionID, ExitCode: 0})
@@ -300,12 +238,6 @@ func TestSessionStateCharacterization_ProcessExitEffects(t *testing.T) {
 	session := d.store.Get(sessionID)
 	if session == nil || session.State != protocol.SessionStateIdle {
 		t.Fatalf("session=%+v, want idle after exit", session)
-	}
-	d.longRunMu.Lock()
-	_, tracked := d.longRun[sessionID]
-	d.longRunMu.Unlock()
-	if tracked {
-		t.Fatal("process exit did not clear long-run tracking")
 	}
 	events := capture.snapshot()
 	if got := characterizationEventCount(events, protocol.EventSessionStateChanged, sessionID); got != 1 {

--- a/internal/daemon/session_state_test.go
+++ b/internal/daemon/session_state_test.go
@@ -18,7 +18,6 @@ func TestSessionStateDoor_AcceptedCauseProfiles(t *testing.T) {
 		state         string
 		cause         func(*testing.T, *Daemon, string) sessionStateCause
 		wantTouch     bool
-		wantTracking  bool
 		wantBroadcast bool
 	}{
 		{
@@ -26,14 +25,12 @@ func TestSessionStateDoor_AcceptedCauseProfiles(t *testing.T) {
 			state:         protocol.StateWorking,
 			cause:         func(*testing.T, *Daemon, string) sessionStateCause { return liveSignal{} },
 			wantTouch:     true,
-			wantTracking:  true,
 			wantBroadcast: true,
 		},
 		{
 			name:          "resolver observation",
 			state:         protocol.StateWorking,
 			cause:         func(*testing.T, *Daemon, string) sessionStateCause { return resolverObservation{} },
-			wantTracking:  true,
 			wantBroadcast: true,
 		},
 		{
@@ -46,7 +43,6 @@ func TestSessionStateDoor_AcceptedCauseProfiles(t *testing.T) {
 				return pluginReport{runID: "run", seq: 1}
 			},
 			wantTouch:     true,
-			wantTracking:  true,
 			wantBroadcast: true,
 		},
 		{
@@ -84,12 +80,6 @@ func TestSessionStateDoor_AcceptedCauseProfiles(t *testing.T) {
 			if touched := session.LastSeen != characterizationOldTimestamp; touched != tc.wantTouch {
 				t.Fatalf("Touch=%v, want %v; LastSeen=%q", touched, tc.wantTouch, session.LastSeen)
 			}
-			d.longRunMu.Lock()
-			tracked := !d.longRun[id].workingSince.IsZero()
-			d.longRunMu.Unlock()
-			if tracked != tc.wantTracking {
-				t.Fatalf("long-run tracked=%v, want %v", tracked, tc.wantTracking)
-			}
 			broadcasts := characterizationEventCount(capture.snapshot(), protocol.EventSessionStateChanged, id)
 			if got := broadcasts > 0; got != tc.wantBroadcast {
 				t.Fatalf("state broadcast=%v (%d events), want %v", got, broadcasts, tc.wantBroadcast)
@@ -108,12 +98,6 @@ func TestSessionStateDoor_MissingSessionHasNoEffects(t *testing.T) {
 		cause:     liveSignal{},
 	}) {
 		t.Fatal("applyState(missing) = true, want false")
-	}
-	d.longRunMu.Lock()
-	_, tracked := d.longRun["missing"]
-	d.longRunMu.Unlock()
-	if tracked {
-		t.Fatal("missing-session transition created long-run tracking")
 	}
 	if events := capture.snapshot(); len(events) != 0 {
 		t.Fatalf("missing-session transition broadcast events: %+v", events)

--- a/internal/daemon/spawn_pipeline.go
+++ b/internal/daemon/spawn_pipeline.go
@@ -372,7 +372,6 @@ func (d *Daemon) commitSpawn(req *spawnRequest, plan *spawnPlan) *spawnOutcome {
 		session.StateSince = current.StateSince
 		session.StateUpdatedAt = current.StateUpdatedAt
 	}
-	d.clearLongRunTracking(msg.ID)
 	if err := d.store.AddChecked(session); err != nil {
 		if req.hasPluginDriver {
 			d.abortPluginSessionLaunch(msg.ID, "launch_failed")

--- a/internal/daemon/testharness.go
+++ b/internal/daemon/testharness.go
@@ -254,7 +254,6 @@ func (b *TestHarnessBuilder) Build() *TestHarness {
 		startedCh:        make(chan struct{}),
 		classifiedTurn:   make(map[string]string),
 		classifyingTurn:  make(map[string]string),
-		longRun:          make(map[string]longRunSession),
 		pendingResumeID:  make(map[string]string),
 		plugins:          newPluginRegistry(),
 	}

--- a/internal/daemon/transcript_watcher.go
+++ b/internal/daemon/transcript_watcher.go
@@ -312,7 +312,7 @@ func (d *Daemon) runTranscriptWatcher(w *transcriptWatcher) {
 				transcriptPath,
 				quietSince.Format(time.RFC3339Nano),
 			)
-			go d.classifyOrDeferAfterStop(w.sessionID, transcriptPath)
+			go d.classifySessionState(w.sessionID, transcriptPath)
 		}
 	}
 }

--- a/internal/daemon/turn_test.go
+++ b/internal/daemon/turn_test.go
@@ -70,6 +70,44 @@ func TestTurnSurvivesTheAgentGoingBackToWork(t *testing.T) {
 	}
 }
 
+// A run you asked for that finished without a question is still yours to read.
+func TestAFinishedRunOwesATurn(t *testing.T) {
+	d := newTurnDaemon(t)
+	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+
+	moveTo(d, "s1", protocol.StateWorking)
+	if owed(t, d, "s1") {
+		t.Fatal("a working session owes a turn")
+	}
+
+	moveTo(d, "s1", protocol.StateIdle)
+	if !owed(t, d, "s1") {
+		t.Fatal("a finished run owes no turn; nobody has read its result")
+	}
+}
+
+// A session that never ran resolves to idle sitting at its prompt, which looks
+// identical to a finished run. There is no result behind it, so it must not
+// queue — otherwise every launch would land in the queue.
+func TestASessionAtItsPromptOwesNothing(t *testing.T) {
+	d := newTurnDaemon(t)
+	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+
+	d.applyState(sessionStateChange{
+		sessionID: "s1",
+		state:     protocol.StateIdle,
+		cause:     resolverObservation{},
+		atPrompt:  true,
+	})
+
+	if d.store.Get("s1").State != protocol.StateIdle {
+		t.Fatal("the state did not commit; the case proves nothing about the turn")
+	}
+	if owed(t, d, "s1") {
+		t.Fatal("a session that never took a turn owes one")
+	}
+}
+
 func TestSettleIsTheOnlyExit(t *testing.T) {
 	d := newTurnDaemon(t)
 	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -991,8 +991,6 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleClearSessionsWS()
 	case protocol.CmdClearWarnings:
 		d.handleClearWarningsWS()
-	case protocol.CmdSessionVisualized:
-		d.handleSessionVisualizedWS(msg.(*protocol.SessionVisualizedMessage))
 	case protocol.CmdSessionSelected:
 	case protocol.CmdWorkspaceSelected:
 	case protocol.CmdSettleTurn:
@@ -1281,10 +1279,6 @@ func (d *Daemon) tryHandleRemoteWSCommand(client *wsClient, cmd string, msg inte
 
 func remoteCommandSessionID(cmd string, msg interface{}) string {
 	switch cmd {
-	case protocol.CmdSessionVisualized:
-		if typed, ok := msg.(*protocol.SessionVisualizedMessage); ok {
-			return typed.ID
-		}
 	case protocol.CmdSessionSelected:
 		if typed, ok := msg.(*protocol.SessionSelectedMessage); ok {
 			return typed.ID

--- a/internal/daemon/worktree.go
+++ b/internal/daemon/worktree.go
@@ -325,7 +325,6 @@ func (d *Daemon) cleanupDeletedWorktreeSessions(path string) {
 		d.terminateSession(session.ID, syscall.SIGTERM)
 		d.dropSessionRecord(session.ID)
 		d.clearChiefOfStaffIfSession(session.ID)
-		d.clearLongRunTracking(session.ID)
 		d.wsHub.Broadcast(&protocol.WebSocketEvent{
 			Event:   protocol.EventSessionUnregistered,
 			Session: d.sessionForBroadcast(session),

--- a/internal/daemon/ws_session.go
+++ b/internal/daemon/ws_session.go
@@ -20,10 +20,6 @@ func (d *Daemon) handleClearWarningsWS() {
 	d.clearWarnings()
 }
 
-func (d *Daemon) handleSessionVisualizedWS(msg *protocol.SessionVisualizedMessage) {
-	d.handleSessionVisualized(msg.ID)
-}
-
 func (d *Daemon) handleUnregisterWS(client *wsClient, msg *protocol.UnregisterMessage) {
 	if d.isChiefOfStaffSession(msg.ID) {
 		d.logf("refusing to unregister chief-of-staff session %s; unset the chief role first", msg.ID)
@@ -123,7 +119,6 @@ func (d *Daemon) clearAllSessions() {
 
 	for sessionID := range sessionIDs {
 		d.terminateSession(sessionID, syscall.SIGTERM)
-		d.clearLongRunTracking(sessionID)
 	}
 	d.store.ClearSessions()
 	d.clearChiefOfStaffIfSession(d.chiefOfStaffSessionID())

--- a/internal/hub/manager.go
+++ b/internal/hub/manager.go
@@ -1329,7 +1329,6 @@ func sessionsMatch(left, right protocol.Session) bool {
 		left.StateSince == right.StateSince &&
 		left.StateUpdatedAt == right.StateUpdatedAt &&
 		protocol.Deref(left.StateReason) == protocol.Deref(right.StateReason) &&
-		protocol.Deref(left.NeedsReviewAfterLongRun) == protocol.Deref(right.NeedsReviewAfterLongRun) &&
 		protocol.Deref(left.TurnOwed) == protocol.Deref(right.TurnOwed) &&
 		protocol.Deref(left.TurnOpenedAt) == protocol.Deref(right.TurnOpenedAt) &&
 		protocol.Deref(left.TicketUnread) == protocol.Deref(right.TicketUnread) &&

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "196"
+const ProtocolVersion = "197"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -104,7 +104,6 @@ const (
 	CmdFilesEdited                           = "files_edited"
 	CmdQuery                                 = "query"
 	CmdHeartbeat                             = "heartbeat"
-	CmdSessionVisualized                     = "session_visualized"
 	CmdSessionSelected                       = "session_selected"
 	CmdWorkspaceSelected                     = "workspace_selected"
 	CmdTriggerNudge                          = "trigger_nudge"
@@ -918,13 +917,6 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdHeartbeat:
 		var msg HeartbeatMessage
-		if err := json.Unmarshal(data, &msg); err != nil {
-			return "", nil, err
-		}
-		return peek.Cmd, &msg, nil
-
-	case CmdSessionVisualized:
-		var msg SessionVisualizedMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -3925,10 +3925,6 @@ type Session struct {
 	// MainRepo corresponds to the JSON schema field "main_repo".
 	MainRepo *string `json:"main_repo,omitempty,omitzero"`
 
-	// NeedsReviewAfterLongRun corresponds to the JSON schema field
-	// "needs_review_after_long_run".
-	NeedsReviewAfterLongRun *bool `json:"needs_review_after_long_run,omitempty,omitzero"`
-
 	// NudgeFiresAt corresponds to the JSON schema field "nudge_fires_at".
 	NudgeFiresAt *string `json:"nudge_fires_at,omitempty,omitzero"`
 
@@ -4112,14 +4108,6 @@ type SessionUnregisteredMessage struct {
 
 	// Session corresponds to the JSON schema field "session".
 	Session Session `json:"session"`
-}
-
-type SessionVisualizedMessage struct {
-	// Cmd corresponds to the JSON schema field "cmd".
-	Cmd string `json:"cmd"`
-
-	// ID corresponds to the JSON schema field "id".
-	ID string `json:"id"`
 }
 
 type SessionsUpdatedMessage struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -132,7 +132,6 @@ model Session {
   state_since: string;          // ISO timestamp, always set
   state_updated_at: string;     // ISO timestamp, always set
   state_reason?: string;        // Why the resolver reached this state (e.g. "stuck", "classifier_verdict"); absent for states it does not own
-  needs_review_after_long_run?: boolean; // True when a 5m+ run finished and awaits user visualization
   chief_of_staff?: boolean;     // True when this session holds the profile-wide coordinator role
   delegated_from_chief?: boolean; // True when this session was delegated from the chief of staff (assignee of a chief-authored ticket)
   ticket_unread?: boolean;      // True when this session has unread ticket events (drives the incoming-nudge indicator)
@@ -1322,11 +1321,6 @@ model QueryMessage {
 
 model HeartbeatMessage {
   cmd: "heartbeat";
-  id: string;
-}
-
-model SessionVisualizedMessage {
-  cmd: "session_visualized";
   id: string;
 }
 

--- a/internal/sessionstate/clause_order_test.go
+++ b/internal/sessionstate/clause_order_test.go
@@ -124,20 +124,6 @@ func TestClauseOrder(t *testing.T) {
 			wantReason: ReasonBracketOpen,
 		},
 		{
-			why: "a deferred long-run review outranks every settle below it: the " +
-				"settles all resolve to idle, and idle is the one answer that " +
-				"files an unread result away as seen",
-			evidence: Evidence{
-				AwaitingLongRunReview: true,
-				TurnEverOpened:        true,
-				Heartbeat:             seen(SourceHeartbeat, ClaimSettled, time.Second),
-				LastClassifier:        seen(SourceClassifier, ClaimIdle, time.Second),
-				LastBusyAt:            now.Add(-time.Minute),
-			},
-			wantState:  protocol.SessionStateWaitingInput,
-			wantReason: ReasonLongRunReview,
-		},
-		{
 			why: "total silence outranks an open bracket: the bracket is the one " +
 				"level with no expiry of its own, so an agent with hooks and no " +
 				"heartbeat would otherwise pin itself green for good",

--- a/internal/sessionstate/sessionstate.go
+++ b/internal/sessionstate/sessionstate.go
@@ -108,10 +108,6 @@ type Evidence struct {
 	BackgroundWork bool
 	// PendingCron: the turn yielded with a scheduled wakeup that will resume it.
 	PendingCron bool
-	// AwaitingLongRunReview: the turn ran long enough that attn deferred judging
-	// how it ended until someone looks at it. It is a fact about a turn that is
-	// over, so it only ever refines a settle — never outranks live work.
-	AwaitingLongRunReview bool
 	// ReviewerInLoop: something other than the user answers approval requests —
 	// claude's permission classifier, codex's auto_review guardian. It does not
 	// suppress an approval state; it decides how long that state must hold
@@ -178,10 +174,6 @@ type Policy struct {
 	// when a reviewer is in the loop. It is not a delay on genuine approval
 	// requests: with no reviewer the dwell is zero.
 	GuardianDwell time.Duration
-	// IdleStaleAfter is how long a settled result may sit unread before it stops
-	// counting as done. It does not change the state — an idle session is still
-	// idle — only whether that idle result is still fresh.
-	IdleStaleAfter time.Duration
 }
 
 // Measured on claude 2.1.220 and codex 0.145.0 driven through a real PTY.
@@ -237,13 +229,6 @@ const (
 	// visible settle that a late verdict then corrects; undershooting it
 	// reintroduces the flicker the gate exists to prevent.
 	defaultClassifierTimeout = 30 * time.Second
-	// defaultIdleStaleAfter is how long a finished turn nobody has looked at stays
-	// fresh. It is not measured from anything the agent does — the agent is done —
-	// so it is a judgement about attention rather than about an agent's timing:
-	// long enough that stepping away from a session for a few minutes is not
-	// treated as forgetting it, short enough that a result Victor asked for is not
-	// silently lost for the rest of a working day.
-	defaultIdleStaleAfter = 10 * time.Minute
 )
 
 // PolicyFor returns the timing for an agent. An agent with no measured numbers
@@ -258,7 +243,6 @@ func PolicyFor(agent string) Policy {
 		GuardianDwell:     guardianDwell,
 		SettleGrace:       defaultSettleGrace,
 		ClassifierTimeout: defaultClassifierTimeout,
-		IdleStaleAfter:    defaultIdleStaleAfter,
 	}
 	if agent == string(protocol.SessionAgentClaude) {
 		policy.HeartbeatTTL = claudeHeartbeatTTL
@@ -275,7 +259,6 @@ const (
 	ReasonHeartbeatFresh    Reason = "heartbeat_fresh"
 	ReasonApprovalOpen      Reason = "approval_open"
 	ReasonQuestionOpen      Reason = "question_open"
-	ReasonLongRunReview     Reason = "long_run_review"
 	ReasonCronPending       Reason = "cron_pending"
 	ReasonBracketOpen       Reason = "bracket_open"
 	ReasonPromptIdle        Reason = "prompt_idle"
@@ -422,22 +405,6 @@ func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
 			return Resolution{Hold: true, Reason: ReasonSettleGrace}
 		}
 		return settled(e, ReasonBracketStale, policy, now)
-	}
-
-	// A turn ran long enough that attn deferred judging how it ended until someone
-	// looks at it. There is no verdict to wait for and none is coming — the point
-	// of the deferral is that the classification happens when the session is
-	// opened — so every settle clause below would call it idle and file a result
-	// worth minutes of work away as seen.
-	//
-	// Below the brackets, because a session that has started another turn is
-	// working whatever is still owed on the last one, and above every settle so it
-	// wins the case it exists for. It is the state the deferral used to apply
-	// directly, in a write the resolver undid on its next tick: the review flag was
-	// invisible to the table, so the same settled evidence resolved to idle a
-	// second later.
-	if e.AwaitingLongRunReview {
-		return Resolution{State: protocol.SessionStateWaitingInput, Reason: ReasonLongRunReview}
 	}
 
 	// Brackets closed, and the agent is not painting busy frames: the turn is
@@ -597,36 +564,6 @@ func DwellFor(state protocol.SessionState, e Evidence, policy Policy) time.Durat
 		return policy.GuardianDwell
 	}
 	return 0
-}
-
-// IdleStale reports whether a settled result has gone unread long enough to stop
-// counting as done.
-//
-// Nothing calls it. It is the rule the attention projection needs, kept here
-// tested and unwired: it was on the session wire for a while, and a mark clients
-// could read but nothing produced a decision from was worse than no mark — it
-// invited a client to invent the meaning.
-//
-// It is not part of Resolve and deliberately so. Resolve answers what the agent
-// is doing, and the agent is doing nothing — the session is idle either way.
-// Staleness is a fact about the *user*: how long an answer has sat there with
-// nobody looking at it. That is why it takes the read time rather than the
-// evidence table, which knows everything about the agent and nothing about who
-// has seen its output.
-func IdleStale(state protocol.SessionState, stateSince, lastReadAt time.Time, policy Policy, now time.Time) bool {
-	if state != protocol.SessionStateIdle || policy.IdleStaleAfter <= 0 {
-		return false
-	}
-	// A session that has never been in a state has nothing to have gone stale.
-	if stateSince.IsZero() {
-		return false
-	}
-	// Read after the result arrived: it has been seen, and re-reading the same
-	// finished turn is not something to be reminded about again.
-	if !lastReadAt.Before(stateSince) {
-		return false
-	}
-	return now.Sub(stateSince) > policy.IdleStaleAfter
 }
 
 // supersededByBusy reports whether the agent has painted a busy frame since o

--- a/internal/sessionstate/sessionstate_test.go
+++ b/internal/sessionstate/sessionstate_test.go
@@ -525,38 +525,6 @@ func TestResolve(t *testing.T) {
 			wantReason: ReasonClassifierVerdict,
 		},
 
-		// --- a long run nobody has read yet ---------------------------------
-
-		{
-			// The deferral: a turn worth minutes of work ended and attn is holding
-			// the verdict until someone opens the session. Calling it idle would
-			// file that result away as seen, which is what happened while this was
-			// a state the deferral applied and the resolver overwrote.
-			name: "a long run awaiting review waits on the user",
-			evidence: Evidence{
-				AwaitingLongRunReview: true,
-				TurnEverOpened:        true,
-				Heartbeat:             seen(SourceHeartbeat, ClaimSettled, time.Second),
-				LastBusyAt:            now.Add(-time.Minute),
-			},
-			wantState:  protocol.SessionStateWaitingInput,
-			wantReason: ReasonLongRunReview,
-		},
-		{
-			// It describes a turn that has ended. A session that has started
-			// another one is working, whatever is still owed on the last.
-			name: "a long run awaiting review does not outrank a new turn",
-			evidence: Evidence{
-				AwaitingLongRunReview: true,
-				TurnOpen:              true,
-				TurnEverOpened:        true,
-				Heartbeat:             seen(SourceHeartbeat, ClaimBusy, 100*time.Millisecond),
-				LastBusyAt:            now.Add(-100 * time.Millisecond),
-			},
-			wantState:  protocol.SessionStateWorking,
-			wantReason: ReasonHeartbeatFresh,
-		},
-
 		// --- settled turns --------------------------------------------------
 
 		{
@@ -829,47 +797,5 @@ func TestPolicyForUsesTheMeasuredPerAgentTTL(t *testing.T) {
 		if policy.StaleAfter <= policy.HeartbeatTTL {
 			t.Fatalf("StaleAfter %s must exceed HeartbeatTTL %s", policy.StaleAfter, policy.HeartbeatTTL)
 		}
-	}
-}
-
-// IdleStale is the rule behind the mark: a finished result nobody has looked at
-// stops counting as done. The cases that matter are the ones where it must stay
-// quiet — a session that is still running has produced nothing to miss, and a
-// result already read is not something to be reminded about twice.
-func TestIdleStaleOnlyFiresForAnUnreadFinishedResult(t *testing.T) {
-	policy := PolicyFor(string(protocol.SessionAgentClaude))
-	settled := time.Now()
-	past := settled.Add(policy.IdleStaleAfter + time.Second)
-
-	cases := []struct {
-		name       string
-		state      protocol.SessionState
-		stateSince time.Time
-		lastRead   time.Time
-		now        time.Time
-		want       bool
-	}{
-		{"unread past the window", protocol.SessionStateIdle, settled, time.Time{}, past, true},
-		{"read before it finished", protocol.SessionStateIdle, settled, settled.Add(-time.Hour), past, true},
-		{"still inside the window", protocol.SessionStateIdle, settled, time.Time{}, settled.Add(time.Minute), false},
-		{"read after it finished", protocol.SessionStateIdle, settled, settled.Add(time.Second), past, false},
-		{"read at the same instant", protocol.SessionStateIdle, settled, settled, past, false},
-		{"still working", protocol.SessionStateWorking, settled, time.Time{}, past, false},
-		{"waiting on the user", protocol.SessionStateWaitingInput, settled, time.Time{}, past, false},
-		{"never had a state", protocol.SessionStateIdle, time.Time{}, time.Time{}, past, false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := IdleStale(tc.state, tc.stateSince, tc.lastRead, policy, tc.now); got != tc.want {
-				t.Fatalf("IdleStale = %v, want %v", got, tc.want)
-			}
-		})
-	}
-
-	// A policy with no window turns the whole thing off rather than firing
-	// instantly, which is what an agent with no measured numbers would get if the
-	// default were ever dropped.
-	if IdleStale(protocol.SessionStateIdle, settled, time.Time{}, Policy{}, past) {
-		t.Fatal("a zero window marked a session stale instead of disabling the rule")
 	}
 }


### PR DESCRIPTION
Slice 2 of the agent queue (`docs/plans/2026-07-26-agent-queue-turn-and-settle.md`), on top of slice 1. Targets `epic/agent-state-detection`.

## What changes

**`idle` opens a turn.** A run you asked for that finished without asking anything is a result nobody has read; it lands at the bottom of the queue and stays there until you settle it. This is the vision's largest consequence: nothing that ever ran leaves your plate by itself.

**A session sitting at its prompt does not.** `internal/sessionstate` resolves a never-run session at its prompt to `idle` too — indistinguishable at the state level from a finished run. Unguarded, every freshly launched agent would queue from the moment it booted. `sessionStateChange.atPrompt` carries the distinction through the state door: the state commits identically, it only skips the open, because there is no result behind it to read. This was not in the plan; it is recorded under `Decisions`.

**The long-run review gate is deleted whole.** It approximated the same thing badly — holding a 5+ minute run's final classification back until someone looked at the session. Removed: `needs_review_after_long_run` from the schema, `Session`, and the hub's equality check; the `session_visualized` command and the app's 5s dwell timer; `longRun` tracking with `markRunStartedIfNeeded` / `clearLongRunTracking` / `longRunReviewThreshold` and every call site; `classifyOrDeferAfterStop`'s deferral branch and `handleSessionVisualized`; `sessionstate.IdleStale`, `Policy.IdleStaleAfter`, and `defaultIdleStaleAfter`. A finished run now publishes its true color immediately.

Protocol 197 (`constants.go`, `generated.go`/`generated.ts`, `useDaemonSocket.ts`).

Selected-session tracking is unaffected: the daemon has always had a separate `session_selected` command, which the frontend still sends.

## Verification

`go test ./...` and `pnpm test` (2070 tests) green.

New Go tests: a finished run owes a turn; a session at its prompt owes nothing; a long run publishes its verdict immediately rather than on view.

Live: full `make install PROFILE=queue1`, preflight PASS (protocol 197 CLI/app/daemon), then `real-app:scenario-agent-queue` green across all 13 steps against two live Claude agents, including two new ones —

- `a_finished_run_returns_the_agent_to_the_queue`: alpha is settled, prompted with a task that ends without a question, stays out of the band while working, resolves to `idle`, and returns at the bottom behind the older turn.
- `a_shell_pane_never_queues`: a split shell pane registers as a real session in `idle` — the same state — and changes nothing in the band.

The pre-existing empty-band assertion on a freshly booted agent is what covers the `atPrompt` guard end to end.
