### PR TITLE
fix(queue): an agent you launched and have not spoken to owes a turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Changed
 - **An agent that finishes its run joins the queue too.** A run you asked for
   that ended without a question is still a result nobody has read, so it lands at
-  the bottom of the list. A freshly launched agent sitting at its prompt is
-  unaffected — it has nothing behind it to read yet.
+  the bottom of the list. So does an agent you just launched and have not spoken
+  to yet: nothing will happen in it until you type, which makes it a turn you owe
+  like any other.
 
 ### Removed
 - **The long-run review gate is gone.** Runs over five minutes used to hold their

--- a/app/scripts/real-app-harness/scenario-agent-queue.mjs
+++ b/app/scripts/real-app-harness/scenario-agent-queue.mjs
@@ -360,11 +360,16 @@ async function main() {
       const workspace = await client.request('get_workspace', { sessionId: alpha.sessionId });
       const targetPaneId = workspace.activePaneId || workspace.panes?.[0]?.paneId;
       await client.request('split_pane', { sessionId: alpha.sessionId, targetPaneId, direction: 'vertical' });
+      // Waiting for `idle` specifically, not merely for the session to exist: a
+      // pane is registered in the spawn-time `working` color and the resolver
+      // settles it a beat later, so asserting on first sight reads the wrong
+      // state. Idle is the state under test — it is what opens a turn — so the
+      // exclusion is only proved once the shell is actually in it.
       const shell = await pollFor(async () => {
         const state = await client.request('get_state');
-        return (state.sessions || []).find((session) => session.agent === 'shell') || null;
-      }, 'the shell pane to register as a session', 30_000);
-      runner.assert(shell.state === 'idle', `the shell sits in idle, the state that opens a turn: got ${shell.state}`);
+        const session = (state.sessions || []).find((entry) => entry.agent === 'shell');
+        return session?.state === 'idle' ? session : null;
+      }, 'the shell pane to register and settle into idle', 30_000);
       await delay(3000);
       const after = await queueState(client);
       runner.assert(

--- a/app/scripts/real-app-harness/scenario-agent-queue.mjs
+++ b/app/scripts/real-app-harness/scenario-agent-queue.mjs
@@ -13,8 +13,9 @@
  * The run drives two real Claude agents in two workspaces and asserts, against
  * the rendered DOM (`queue_get_state`), that:
  *
- *   1. both owed turns are in the band, oldest first, and both are still in the
- *      workspace tree below it — the queue is additive, never a filter,
+ *   1. an agent queues from the moment it boots to its prompt, and both owed
+ *      turns are in the band, oldest first, and both are still in the workspace
+ *      tree below it — the queue is additive, never a filter,
  *   2. clicking a row hands the agent over with the keyboard in its terminal,
  *   3. steering that agent leaves it exactly where it was, showing its live
  *      (working) state rather than dropping out of the queue,
@@ -22,8 +23,8 @@
  *   5. a settled agent that wants the user again returns at the bottom, behind
  *      the turn that has been owed longer,
  *   6. a settled agent whose run finishes without asking anything returns too —
- *      a result nobody has read is still the user's — while a shell pane and an
- *      agent sitting at its prompt, which reach the same `idle` state, never do,
+ *      a result nobody has read is still the user's — while a shell pane, which
+ *      reaches the same `idle` state, never queues at all,
  *   7. the chief of staff occupies its own slot and never the band,
  *   8. turning the arrangement off and back on mid-session returns the same
  *      queue with the same agent still selected,
@@ -206,22 +207,25 @@ async function main() {
     await runner.step('open_first_turn', async () => {
       alpha = await createAgent(client, observer, runner, 'alpha', `queue-alpha-${runner.runId}`);
       createdSessionIds.push(alpha.sessionId);
-      // The sidebar only exists once there is something to list, so the band's
-      // empty state is checked here rather than against a sessionless app.
+      // The sidebar only exists once there is something to list, so the band is
+      // checked here rather than against a sessionless app.
       //
-      // An agent that has booted to its prompt resolves to `idle`, the same
-      // state a finished run resolves to, and `idle` opens a turn. It must not
-      // queue anyway: there is no result behind it to read. This is the only
-      // place that distinction is observable end to end.
-      const empty = await pollFor(async () => {
+      // An agent you launched and have not spoken to boots to its prompt and
+      // resolves to `idle`, the same state a finished run resolves to, and idle
+      // opens a turn. Nothing will happen in it until you type, so it queues
+      // from the moment it boots — no prompt required. This is the only place
+      // the launch case is observable end to end.
+      await pollFor(async () => {
         const state = await queueState(client);
         return state.present ? state : null;
       }, 'the queue band to render once the arrangement is on', 15_000);
-      runner.assert(empty.empty, `a freshly launched agent owes nothing: ${JSON.stringify(empty.turns)}`);
+      await waitForTurns(client, [alpha.sessionId], 'alpha queued from the moment it booted');
 
+      // Steering it into a real ask keeps the same turn — the later steps settle
+      // and re-open against an agent that has actually run something.
       const state = await driveToOwedTurn(client, observer, alpha, 'QUEUE_ALPHA', 'alpha to want the user');
       runner.log('alpha opened a turn', { state });
-      await waitForTurns(client, [alpha.sessionId], 'alpha in the band');
+      await waitForTurns(client, [alpha.sessionId], 'alpha still in the band');
     });
 
     await runner.step('open_second_turn', async () => {

--- a/app/scripts/real-app-harness/scenario-agent-queue.mjs
+++ b/app/scripts/real-app-harness/scenario-agent-queue.mjs
@@ -135,6 +135,13 @@ function questionPrompt(token) {
   ].join(' ');
 }
 
+// The budget is generous because it is not what is under test. The prompt asks
+// for one short question and no tools, but a live agent may go exploring anyway,
+// and how long it takes to stop says nothing about whether the queue reacts to
+// the state it stops in. A tight bound here just turns agent discretion into a
+// failure that reads like a product regression.
+const OWED_TURN_TIMEOUT_MS = 240_000;
+
 async function driveToOwedTurn(client, observer, agent, token, description) {
   await submitPrompt(client, agent.sessionId, agent.paneId, questionPrompt(token));
   return pollFor(
@@ -143,7 +150,7 @@ async function driveToOwedTurn(client, observer, agent, token, description) {
       return TURN_OPENING_STATES.has(state) ? state : null;
     },
     description,
-    120_000,
+    OWED_TURN_TIMEOUT_MS,
   );
 }
 

--- a/docs/plans/2026-07-26-agent-queue-turn-and-settle.md
+++ b/docs/plans/2026-07-26-agent-queue-turn-and-settle.md
@@ -385,8 +385,8 @@ open through the run. That gap is slice 2.
 your plate by itself. It is last on purpose: by then settle is muscle memory, and
 if it still feels heavy the flip is one predicate entry to revert.
 
-- [x] Add `idle` to `OpensTurn`, guarded by `sessionStateChange.atPrompt` so a
-      session that never ran does not queue (see Decisions).
+- [x] Add `idle` to `OpensTurn`. A session launched and never spoken to reaches
+      the same state and queues too (see Decisions).
 - [x] Delete the long-run deferral, `handleSessionVisualized`, the
       `session_visualized` command, the app's 5s dwell timer, the `longRun`
       tracking and its call sites, and `longRunReviewThreshold`.
@@ -400,9 +400,8 @@ if it still feels heavy the flip is one predicate entry to revert.
       list you can actually drain.
       Folded into `real-app:scenario-agent-queue` as two steps: a settled agent
       whose run ends `idle` returns at the bottom, and a split shell pane —
-      registered `idle`, the same state — changes nothing in the band. The
-      pre-existing empty-band assertion on a freshly booted agent is what covers
-      the `atPrompt` guard.
+      registered `idle`, the same state — changes nothing in the band. The first
+      step also asserts an agent queues from the moment it boots to its prompt.
 
 ## Decisions
 
@@ -463,15 +462,19 @@ if it still feels heavy the flip is one predicate entry to revert.
   hand a client everything it needs to recompute membership itself, and any
   client that did would get a different answer — it cannot see the shell, chief,
   pinned, or muted exclusions.
-- **A session sitting at its prompt does not open a turn, even though it
-  resolves to `idle`.** Found in slice 2: `sessionstate` resolves a never-run
-  session at its prompt to `idle` with `ReasonAtPrompt`, indistinguishable at the
-  state level from a finished run. Unguarded, `idle → OpensTurn` would queue every
-  freshly launched agent from the moment it booted. `sessionStateChange.atPrompt`
-  carries the distinction through the state door: the state commits identically,
-  it only skips the open, because there is no result behind it for the user to
-  read. The alternative — letting it queue — was rejected as the same "queue fills
-  with things you did not ask for" failure the exclusions exist to prevent.
+- **A session sitting at its prompt opens a turn like any other.** Victor's call,
+  2026-07-27, reversing the guard slice 2 shipped with. `sessionstate` resolves a
+  never-run session at its prompt to `idle` with `ReasonAtPrompt`,
+  indistinguishable at the state level from a finished run, and slice 2 carried
+  that distinction through the state door on `sessionStateChange.atPrompt` so the
+  launch would not queue — reading the queue as results waiting to be read. The
+  queue is turns you owe, and an agent you launched and have not spoken to is the
+  purest one there is: nothing will ever happen in it until you type. The guard
+  is gone, so `idle` opening a turn needs no exception. Its removal also retires a
+  sharper edge: the guard read `everTookATurn`, which is in-memory evidence scoped
+  to the daemon's lifetime rather than the session's, so after a daemon restart
+  every quiet session resolved `at_prompt` and a run finishing inside the restart
+  gap could be swallowed.
 - **Enabling the mode settles nothing.** A flip that pre-settled the board would
   start the queue empty and fill it as agents stop, which reads better on the
   first screen and hides live turns at the moment the user is least able to
@@ -530,11 +533,8 @@ if it still feels heavy the flip is one predicate entry to revert.
 - Deleting the deferral collapsed `classifyOrDeferAfterStop` entirely: both
   callers (`handleStop`, the transcript watcher) now call `classifySessionState`
   directly, so there is nothing further to narrow there.
-- `sessionStateChange.atPrompt` is a second, narrower channel for something the
-  resolver already knows (`resolution.Reason`). Carrying the reason itself
-  through the door would let `applyState` ask the question directly instead of
-  having the answer precomputed for it. Not worth it for one consumer; revisit if
-  a second reason-dependent effect appears.
+- ~~`sessionStateChange.atPrompt` is a second, narrower channel for something the
+  resolver already knows.~~ Moot: the field is gone with the guard it carried.
 - `stateEffectProfile` does *not* collapse to a single flag, despite looking like
   it should: `touch` is what separates `resolverObservation` (a re-reading of
   evidence, which is not itself proof the session is alive) from every other

--- a/internal/attention/turn.go
+++ b/internal/attention/turn.go
@@ -25,11 +25,15 @@ import (
 //   - waiting_input, pending_approval, unknown open a turn. The first two are
 //     the agent asking; unknown is the daemon admitting it cannot tell, which is
 //     equally the user's problem.
-//   - idle opens one too. A run you asked for finished and nobody has read the
-//     result; that it ended without a question makes it no less yours. This is
-//     what retired the long-run review deferral, which tried to approximate the
-//     same thing by holding a verdict back on runs over five minutes and
-//     publishing it when the session was looked at.
+//   - idle opens one too, and it covers two cases that are indistinguishable
+//     here on purpose. A run you asked for finished and nobody has read the
+//     result; that it ended without a question makes it no less yours. And a
+//     session you launched and have not yet spoken to sits at its prompt in the
+//     same state — the purest turn there is, since nothing will ever happen in
+//     it until you type. Idle opening a turn is also what retired the long-run
+//     review deferral, which tried to approximate the first case by holding a
+//     verdict back on runs over five minutes and publishing it when the session
+//     was looked at.
 //   - launching, working, scheduled never open one: the agent is busy or waiting
 //     on a clock.
 //   - recoverable never opens one either. The daemon revives it unattended, so

--- a/internal/daemon/session_evidence.go
+++ b/internal/daemon/session_evidence.go
@@ -575,7 +575,6 @@ func (d *Daemon) publishResolution(sessionID string, current protocol.SessionSta
 			source: stateSourceResolver,
 			detail: resolutionDetail(resolution),
 		},
-		atPrompt: resolution.Reason == sessionstate.ReasonAtPrompt,
 	})
 }
 

--- a/internal/daemon/session_state.go
+++ b/internal/daemon/session_state.go
@@ -59,11 +59,6 @@ type sessionStateChange struct {
 	// name, which is all a daemon-internal transition has to say about itself.
 	// It never affects whether the change commits.
 	origin stateOrigin
-	// atPrompt marks a state the agent reached without ever having taken a turn:
-	// a freshly launched session sitting at its prompt, which resolves to `idle`
-	// exactly as a finished run does. It commits identically; it only must not
-	// open a turn, because there is no result behind it for the user to read.
-	atPrompt bool
 }
 
 // stateOrigin is where a state claim came from, as distinct from the commit rule
@@ -152,7 +147,7 @@ func (d *Daemon) applyState(change sessionStateChange) bool {
 	// startup recovery: a session that comes back in a state that wants the user
 	// wants the user regardless of what moved it there. Opening is guarded in the
 	// store, so a state re-reported while a turn is already open changes nothing.
-	if !change.atPrompt && attention.OpensTurn(protocol.SessionState(change.state)) {
+	if attention.OpensTurn(protocol.SessionState(change.state)) {
 		d.store.OpenTurnIfClosed(change.sessionID, time.Now())
 	}
 

--- a/internal/daemon/turn_test.go
+++ b/internal/daemon/turn_test.go
@@ -86,10 +86,11 @@ func TestAFinishedRunOwesATurn(t *testing.T) {
 	}
 }
 
-// A session that never ran resolves to idle sitting at its prompt, which looks
-// identical to a finished run. There is no result behind it, so it must not
-// queue — otherwise every launch would land in the queue.
-func TestASessionAtItsPromptOwesNothing(t *testing.T) {
+// A session you launched and have not spoken to resolves to idle sitting at its
+// prompt. Nothing will ever happen in it until you type, so it owes a turn — the
+// same one a finished run owes, which is why the resolver need not distinguish
+// them.
+func TestASessionAtItsPromptOwesATurn(t *testing.T) {
 	d := newTurnDaemon(t)
 	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
 
@@ -97,14 +98,10 @@ func TestASessionAtItsPromptOwesNothing(t *testing.T) {
 		sessionID: "s1",
 		state:     protocol.StateIdle,
 		cause:     resolverObservation{},
-		atPrompt:  true,
 	})
 
-	if d.store.Get("s1").State != protocol.StateIdle {
-		t.Fatal("the state did not commit; the case proves nothing about the turn")
-	}
-	if owed(t, d, "s1") {
-		t.Fatal("a session that never took a turn owes one")
+	if !owed(t, d, "s1") {
+		t.Fatal("a launched session sitting at its prompt owes no turn")
 	}
 }
 


### PR DESCRIPTION
An agent launched into a fresh workspace and never prompted sat outside the
queue. Reported live against a build of the epic, and confirmed in the daemon
log: the session resolved `idle` with reason `at_prompt` one second after spawn
and no turn was opened.

That was the guard slice 2 shipped with, working as written. `sessionstate`
resolves a never-run session at its prompt to `idle` — the same state a finished
run resolves to — and `sessionStateChange.atPrompt` carried the distinction
through the state door so the launch would not queue.

The guard read the queue as results waiting to be read. It is turns you owe, and
an agent you launched and have not typed into is the purest one there is:
nothing will ever happen in it until you do. The guard is gone, so `idle`
opening a turn needs no exception.

Removing it also retires a sharper edge. The guard's evidence, `everTookATurn`,
is in-memory and scoped to the daemon's lifetime rather than the session's, so
after a daemon restart every quiet session resolved `at_prompt` — including a
conversation hundreds of exchanges deep — and a run finishing inside the restart
gap could be swallowed instead of queued.

## Tests

- `TestASessionAtItsPromptOwesATurn` replaces `TestASessionAtItsPromptOwesNothing`,
  asserting the launch case now queues.
- Two harness changes, both fixing tests that were reading the wrong thing:
  the shell step waited for the session to exist and asserted its state on first
  sight, catching the spawn-time `working` color rather than the `idle` the
  exclusion is about; and the drive-to-a-turn budget was tight enough that a live
  agent choosing to explore looked like a product failure.

## Live verification

`real-app:scenario-agent-queue` against `attn-queue1.app`, protocol 197 matching
across CLI, app, and daemon (`attn preflight` PASS). All 13 steps green,
including the new assertion that an agent joins the band from the moment it
boots to its prompt, and the shell pane still never queuing from the same `idle`
state.

https://claude.ai/code/session_01KzpRFTTbzGz1JFqK1vvVq5