### PR TITLE
feat(queue): the sidebar in queue mode is the standing order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Pin and mute a workspace from anywhere.** Every queue row has a pin button
   that takes its workspace out of the queue, and ⌘K can pin or mute the workspace
   of the agent you are in. Pinning used to be reachable only from a workspace
-  group header, which queue mode no longer draws.
+  group header, which queue mode no longer draws. The per-session menu — chief of
+  staff, close, reload — is on the queue rows for the same reason.
 
 ### Removed
 - **The long-run review gate is gone.** Runs over five minutes used to hold their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,19 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   to yet: nothing will happen in it until you type, which makes it a turn you owe
   like any other.
 
+- **The sidebar in queue mode is now the whole standing order.** *Your turn* is
+  followed by *Settled*, and an agent is drawn in exactly one of them — one row
+  per agent, no workspace groups. Previously the band sat on top of the unchanged
+  workspace tree, so every queued agent appeared twice and looked like it moved
+  when only one of its two copies did. Settling now moves an agent to *Settled*
+  rather than back into a group. Pinned workspaces keep their groups below, which
+  is where a pinned agent lives instead of the queue; muted workspaces are
+  unchanged. Turning the queue off restores the full tree exactly as before.
+- **Pin and mute a workspace from anywhere.** Every queue row has a pin button
+  that takes its workspace out of the queue, and ⌘K can pin or mute the workspace
+  of the agent you are in. Pinning used to be reachable only from a workspace
+  group header, which queue mode no longer draws.
+
 ### Removed
 - **The long-run review gate is gone.** Runs over five minutes used to hold their
   final color back until you looked at the session. A finished run now publishes

--- a/app/scripts/real-app-harness/scenario-agent-queue.mjs
+++ b/app/scripts/real-app-harness/scenario-agent-queue.mjs
@@ -14,21 +14,23 @@
  * the rendered DOM (`queue_get_state`), that:
  *
  *   1. an agent queues from the moment it boots to its prompt, and both owed
- *      turns are in the band, oldest first, and both are still in the workspace
- *      tree below it — the queue is additive, never a filter,
+ *      turns are in the band, oldest first, and in exactly one place — the bands
+ *      replace the workspace tree rather than sitting on top of it,
  *   2. clicking a row hands the agent over with the keyboard in its terminal,
  *   3. steering that agent leaves it exactly where it was, showing its live
  *      (working) state rather than dropping out of the queue,
- *   4. settling removes it, and only settling does,
+ *   4. settling moves it to the Settled band, and only settling does,
  *   5. a settled agent that wants the user again returns at the bottom, behind
  *      the turn that has been owed longer,
  *   6. a settled agent whose run finishes without asking anything returns too —
  *      a result nobody has read is still the user's — while a shell pane, which
  *      reaches the same `idle` state, never queues at all,
- *   7. the chief of staff occupies its own slot and never the band,
- *   8. turning the arrangement off and back on mid-session returns the same
- *      queue with the same agent still selected,
- *   9. a settle survives a daemon restart.
+ *   7. pinning a workspace from its queue row takes the agent out of both bands
+ *      and back into the tree, so the queue is never a one-way door,
+ *   8. the chief of staff occupies its own slot and never the band,
+ *   9. turning the arrangement off and back on mid-session restores the whole
+ *      workspace tree, then returns the same queue with the same agent selected,
+ *  10. a settle survives a daemon restart.
  *
  * Prereqs: `claude` on PATH; a non-production profile install with the
  * automation layer; a built `./attn` (or ATTN_HARNESS_BIN) for the restart step.
@@ -96,6 +98,10 @@ async function queueState(client) {
 
 function turnIds(queue) {
   return (queue.turns || []).map((row) => row.id);
+}
+
+function settledIds(queue) {
+  return (queue.settled || []).map((row) => row.id);
 }
 
 // Claude treats a fast multi-line write as a paste, so the submit has to be a
@@ -242,16 +248,23 @@ async function main() {
       runner.log('beta opened a turn', { state });
     });
 
-    await runner.step('band_is_oldest_first_and_additive', async () => {
+    await runner.step('band_is_oldest_first_and_each_agent_appears_once', async () => {
       const queue = await waitForTurns(client, [alpha.sessionId, beta.sessionId], 'both turns, oldest first');
       runner.assert(
         queue.turns[0].workspace !== queue.turns[1].workspace,
         `the two turns come from different workspaces: ${JSON.stringify(queue.turns.map((row) => row.workspace))}`,
       );
+      // The bands replace the tree rather than sitting on top of it. An agent
+      // drawn in both places is what made a row look like it moved when only one
+      // of its copies did.
       for (const sessionId of [alpha.sessionId, beta.sessionId]) {
         runner.assert(
-          queue.treeSessionIds.includes(sessionId),
-          `${sessionId} still has its own row in the workspace tree: ${JSON.stringify(queue.treeSessionIds)}`,
+          !queue.treeSessionIds.includes(sessionId),
+          `${sessionId} is in the band and nowhere else: ${JSON.stringify(queue.treeSessionIds)}`,
+        );
+        runner.assert(
+          !(queue.settled || []).some((row) => row.id === sessionId),
+          `${sessionId} is owed, so it is not also in Settled: ${JSON.stringify((queue.settled || []).map((row) => row.id))}`,
         );
       }
     });
@@ -298,10 +311,10 @@ async function main() {
       );
 
       await client.request('dom_click', { selector: `[data-testid="queue-settle-${alpha.sessionId}"]` });
-      const settled = await waitForTurns(client, [beta.sessionId], 'alpha gone from the band after settling');
+      const settled = await waitForTurns(client, [beta.sessionId], 'alpha gone from Your turn after settling');
       runner.assert(
-        settled.treeSessionIds.includes(alpha.sessionId),
-        'settling removes the turn, not the session',
+        settledIds(settled).includes(alpha.sessionId),
+        `settling moves the agent to Settled, it does not remove it: ${JSON.stringify(settledIds(settled))}`,
       );
     });
 
@@ -392,6 +405,33 @@ async function main() {
       await client.request('close_pane', { sessionId: alpha.sessionId, paneId: shellPaneId }).catch(() => {});
     });
 
+    await runner.step('pinning_from_a_row_takes_the_agent_out_of_the_queue', async () => {
+      // The workspace group header owns pin in the tree, and the tree does not
+      // draw ordinary workspaces while the queue is on. Without this affordance
+      // turning the queue on would be a one-way door, so the row's own button is
+      // the claim under test — pressed through the DOM, as the user would.
+      const before = await queueState(client);
+      const alphaWorkspaceId = (before.turns.find((row) => row.id === alpha.sessionId) || {}).workspaceId;
+      runner.assert(Boolean(alphaWorkspaceId), 'the row carries the workspace its pin button acts on');
+
+      await client.request('dom_click', { selector: `[data-testid="queue-pin-${alpha.sessionId}"]` });
+      const pinned = await waitForTurns(client, [beta.sessionId], 'alpha out of the band once its workspace is pinned', 20_000);
+      runner.assert(
+        !settledIds(pinned).includes(alpha.sessionId),
+        `a pinned agent is in neither band: ${JSON.stringify(settledIds(pinned))}`,
+      );
+      runner.assert(
+        pinned.treeSessionIds.includes(alpha.sessionId),
+        `a pinned workspace keeps its group in the tree: ${JSON.stringify(pinned.treeSessionIds)}`,
+      );
+
+      // Put it back through the group header's own pin button — the tree affordance
+      // that queue mode leaves in place for exactly this — so the steps below see
+      // the queue they expect.
+      await client.request('dom_click', { selector: `[data-testid="pin-workspace-${alphaWorkspaceId}"]` });
+      await waitForTurns(client, [beta.sessionId, alpha.sessionId], 'alpha back in the band once unpinned', 20_000);
+    });
+
     await runner.step('the_chief_never_queues', async () => {
       await client.request('chief_of_staff_open_actions', { sessionId: beta.sessionId });
       await client.request('chief_of_staff_toggle');
@@ -420,7 +460,7 @@ async function main() {
       }, 'the band to disappear with the arrangement off', 15_000);
       runner.assert(
         off.treeSessionIds.includes(alpha.sessionId) && off.treeSessionIds.includes(beta.sessionId),
-        `the workspace tree is untouched by the arrangement: ${JSON.stringify(off.treeSessionIds)}`,
+        `turning the arrangement off restores the whole workspace tree: ${JSON.stringify(off.treeSessionIds)}`,
       );
 
       await client.request('set_setting', { key: 'queue_mode_enabled', value: 'true' });
@@ -452,8 +492,8 @@ async function main() {
       await relaunchAppAndConnect(client, observer);
       const queue = await waitForTurns(client, [alpha.sessionId], 'the queue rebuilt from persisted stamps', 60_000);
       runner.assert(
-        queue.treeSessionIds.includes(beta.sessionId),
-        'beta came back as a session, just not as a turn',
+        settledIds(queue).includes(beta.sessionId),
+        `beta came back as a session, just not as a turn: ${JSON.stringify(settledIds(queue))}`,
       );
     });
 

--- a/app/scripts/real-app-harness/scenario-agent-queue.mjs
+++ b/app/scripts/real-app-harness/scenario-agent-queue.mjs
@@ -438,6 +438,32 @@ async function main() {
       const promoted = await waitForTurns(client, [alpha.sessionId], 'beta out of the band once it is chief', 20_000);
       runner.assert(promoted.chief?.id === beta.sessionId, `beta occupies the chief slot: ${JSON.stringify(promoted.chief)}`);
 
+      // Pin reaches the chief's workspace like any other, and the chief keeps its
+      // anchored slot regardless — so the group that survives in the tree must
+      // not draw it a second time. Pin it from the tree with the arrangement off,
+      // which is the affordance a user has for a workspace holding only the chief.
+      const chiefWorkspaceId = promoted.chief.workspaceId;
+      await client.request('set_setting', { key: 'queue_mode_enabled', value: 'false' });
+      await pollFor(async () => {
+        const state = await queueState(client);
+        return state.present ? null : state;
+      }, 'the tree back before pinning the chief workspace', 15_000);
+      await client.request('dom_click', { selector: `[data-testid="pin-workspace-${chiefWorkspaceId}"]` });
+      await client.request('set_setting', { key: 'queue_mode_enabled', value: 'true' });
+      const chiefPinned = await pollFor(async () => {
+        const state = await queueState(client);
+        return state.present && state.chief ? state : null;
+      }, 'the band back with the chief workspace pinned', 15_000);
+      runner.assert(
+        chiefPinned.chief.id === beta.sessionId,
+        `the chief keeps its slot while its workspace is pinned: ${JSON.stringify(chiefPinned.chief)}`,
+      );
+      runner.assert(
+        !chiefPinned.treeSessionIds.includes(beta.sessionId),
+        `the pinned group does not draw the chief again: ${JSON.stringify(chiefPinned.treeSessionIds)}`,
+      );
+      await client.request('dom_click', { selector: `[data-testid="pin-workspace-${chiefWorkspaceId}"]` });
+
       await client.request('chief_of_staff_open_actions', { sessionId: beta.sessionId });
       await client.request('chief_of_staff_toggle');
       const demoted = await waitForTurns(

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2759,6 +2759,50 @@ sendFetchPRDetails,
     [queueModeEnabled, unmutedWorkspaceViews],
   );
 
+  // The workspace the pin/mute commands act on: the one holding the agent you
+  // are looking at, since that is what "this workspace" means from inside a
+  // session. Muted workspaces are searched too — unmuting has to be reachable
+  // from the thing it was applied to.
+  const activeWorkspaceForCommands = useMemo(
+    () => workspaceViews.find((workspace) => workspace.sessions.some((session) => session.id === activeSessionId)) ?? null,
+    [workspaceViews, activeSessionId],
+  );
+
+  // Pin and mute reach the command menu because the workspace group header, the
+  // only other place that offers them, is not drawn for ordinary workspaces
+  // while the queue is on. Pinning is how an agent leaves the queue for good, so
+  // without an entry here turning the queue on would be a one-way door. They are
+  // appended rather than declared with the rest because they need the workspace
+  // views, which are built further down.
+  const actionMenuItemsWithWorkspaceActions = useMemo<ActionMenuItem[]>(() => {
+    const workspace = activeWorkspaceForCommands;
+    if (!workspace) return actionMenuItems;
+    return [
+      ...actionMenuItems,
+      {
+        id: 'pin-active-workspace',
+        title: workspace.pinned ? `Unpin ${workspace.title}` : `Pin ${workspace.title}`,
+        description: workspace.pinned
+          ? 'Put this workspace back in the queue'
+          : 'Take this workspace out of the queue and keep it in view',
+        keywords: ['pin', 'unpin', 'workspace', 'queue'],
+        icon: <AttentionActionIcon />,
+        run: () => sendPinWorkspace(workspace.id, !workspace.pinned),
+      },
+      {
+        id: 'mute-active-workspace',
+        title: workspace.muted ? `Unmute ${workspace.title}` : `Mute ${workspace.title}`,
+        description: workspace.muted
+          ? 'Let this workspace ask for you again'
+          : 'Nothing from this workspace reaches you',
+        keywords: ['mute', 'unmute', 'workspace', 'silence'],
+        icon: <AttentionActionIcon />,
+        // mute_workspace toggles; the title is what says which way it will go.
+        run: () => sendMuteWorkspace(workspace.id, workspace.endpointId),
+      },
+    ];
+  }, [actionMenuItems, activeWorkspaceForCommands, sendPinWorkspace, sendMuteWorkspace]);
+
   // Each arrangement has one notion of what wants the user, and the mode selects
   // it. In the queue arrangement that is the daemon's turn_owed — which honours
   // settle, and the shell/chief/pinned/muted exclusions a client cannot see. With
@@ -4075,7 +4119,7 @@ sendFetchPRDetails,
       )}
       <ActionMenu
         isOpen={actionMenuOpen}
-        actions={actionMenuItems}
+        actions={actionMenuItemsWithWorkspaceActions}
         onClose={() => setActionMenuOpen(false)}
       />
       <ShortcutsModal

--- a/app/src/components/QueueBands.test.tsx
+++ b/app/src/components/QueueBands.test.tsx
@@ -150,6 +150,15 @@ describe('the queue arrangement', () => {
     expect(onSelectSession).not.toHaveBeenCalled();
   });
 
+  it('keeps the per-session menu reachable from every band', () => {
+    // Chief of staff, close and reload live on this menu, which the workspace
+    // tree row owns when the queue is off. Queue mode stops drawing that row.
+    renderSidebar(sessions, true);
+    for (const id of ['chief', 'older', 'settled']) {
+      expect(screen.getByTestId(`session-actions-${id}`)).toBeTruthy();
+    }
+  });
+
   it('offers no settle affordance on a settled row, which has nothing to discharge', () => {
     renderSidebar(sessions, true);
     expect(screen.getByTestId('queue-settled-settled')).toBeTruthy();

--- a/app/src/components/QueueBands.test.tsx
+++ b/app/src/components/QueueBands.test.tsx
@@ -29,11 +29,13 @@ const baseProps = {
   onToggleCollapse: () => {},
 };
 
-function sidebarData(sessions: TestSession[]) {
+type WorkspaceFlags = { pinned?: boolean; muted?: boolean };
+
+function sidebarData(sessions: TestSession[], flags: Record<string, WorkspaceFlags> = {}) {
   const workspaces = buildWorkspaceViewModels(
     [
-      { id: 'ws-a', title: 'alpha', directory: '/repo/a', rank: 'a' },
-      { id: 'ws-b', title: 'beta', directory: '/repo/b', rank: 'b' },
+      { id: 'ws-a', title: 'alpha', directory: '/repo/a', rank: 'a', ...flags['ws-a'] },
+      { id: 'ws-b', title: 'beta', directory: '/repo/b', rank: 'b', ...flags['ws-b'] },
     ],
     sessions,
   );
@@ -44,8 +46,13 @@ function sidebarData(sessions: TestSession[]) {
   };
 }
 
-function renderSidebar(sessions: TestSession[], queueMode: boolean, overrides = {}) {
-  const data = sidebarData(sessions);
+function renderSidebar(
+  sessions: TestSession[],
+  queueMode: boolean,
+  overrides = {},
+  workspaceFlags: Record<string, WorkspaceFlags> = {},
+) {
+  const data = sidebarData(sessions, workspaceFlags);
   return render(
     <Sidebar
       {...baseProps}
@@ -69,26 +76,39 @@ describe('the queue arrangement', () => {
     expect(screen.queryByTestId('sidebar-queue')).toBeNull();
   });
 
-  it('lists owed turns oldest first, with the chief anchored above them', () => {
+  it('lists owed turns oldest first, then the settled rest, with the chief anchored above both', () => {
     const { container } = renderSidebar(sessions, true);
 
     const rows = Array.from(container.querySelectorAll('.queue-bands .queue-row'))
       .map((row) => row.getAttribute('data-testid'));
-    expect(rows).toEqual(['queue-chief-chief', 'queue-turn-older', 'queue-turn-newer']);
+    expect(rows).toEqual(['queue-chief-chief', 'queue-turn-older', 'queue-turn-newer', 'queue-settled-settled']);
   });
 
-  it('keeps the workspace tree complete and unchanged — the queue only adds rows', () => {
-    const off = renderSidebar(sessions, false);
-    const treeOff = Array.from(off.container.querySelectorAll('.session-list [data-testid^="sidebar-session-"]'))
-      .map((row) => row.getAttribute('data-testid'));
-    off.unmount();
+  it('draws each agent exactly once — the bands replace the tree, they do not sit on top of it', () => {
+    // The duplication this replaces made a row look like it moved when only one
+    // of an agent's two copies did.
+    const { container } = renderSidebar(sessions, true);
 
-    const on = renderSidebar(sessions, true);
-    const treeOn = Array.from(on.container.querySelectorAll('.session-list [data-testid^="sidebar-session-"]'))
+    const tree = Array.from(container.querySelectorAll('.session-list [data-testid^="sidebar-session-"]'))
       .map((row) => row.getAttribute('data-testid'));
+    expect(tree).toEqual([]);
+    expect(container.querySelectorAll(
+      '[data-testid="queue-turn-older"], [data-testid="sidebar-session-older"]',
+    )).toHaveLength(1);
+  });
 
-    expect(treeOn).toEqual(treeOff);
-    expect(treeOn).toContain('sidebar-session-older');
+  it('keeps pinned workspaces as groups, and their agents out of both bands', () => {
+    // Pinned is the way out of the queue, so a pinned agent must not be in it —
+    // and the group has to survive, because it is where you go and get that work.
+    const { container } = renderSidebar(sessions, true, {}, { 'ws-b': { pinned: true } });
+
+    const bandRows = Array.from(container.querySelectorAll('.queue-bands .queue-row'))
+      .map((row) => row.getAttribute('data-testid'));
+    expect(bandRows).toEqual(['queue-chief-chief', 'queue-turn-newer']);
+
+    const tree = Array.from(container.querySelectorAll('.session-list [data-testid^="sidebar-session-"]'))
+      .map((row) => row.getAttribute('data-testid'));
+    expect(tree).toEqual(['sidebar-session-older', 'sidebar-session-settled']);
   });
 
   it('shows the live state of a queued agent, because being queued no longer means stopped', () => {
@@ -112,6 +132,28 @@ describe('the queue arrangement', () => {
     fireEvent.click(screen.getByTestId('queue-settle-older'));
     expect(onSettleTurn).toHaveBeenCalledWith('older');
     expect(onSelectSession).not.toHaveBeenCalled();
+  });
+
+  it('pins a row\'s workspace without selecting it, from either band', () => {
+    // The workspace group header owns pin in the tree, and queue mode does not
+    // draw the group for these workspaces. Without this the queue would be a
+    // one-way door: pinning is how an agent leaves it for good.
+    const onPinWorkspace = vi.fn();
+    const onSelectSession = vi.fn();
+    renderSidebar(sessions, true, { onPinWorkspace, onSelectSession });
+
+    fireEvent.click(screen.getByTestId('queue-pin-older'));
+    expect(onPinWorkspace).toHaveBeenCalledWith('ws-b', true);
+
+    fireEvent.click(screen.getByTestId('queue-pin-settled'));
+    expect(onPinWorkspace).toHaveBeenLastCalledWith('ws-b', true);
+    expect(onSelectSession).not.toHaveBeenCalled();
+  });
+
+  it('offers no settle affordance on a settled row, which has nothing to discharge', () => {
+    renderSidebar(sessions, true);
+    expect(screen.getByTestId('queue-settled-settled')).toBeTruthy();
+    expect(screen.queryByTestId('queue-settle-settled')).toBeNull();
   });
 
   it('offers no settle affordance on the chief, which never queues', () => {

--- a/app/src/components/QueueBands.test.tsx
+++ b/app/src/components/QueueBands.test.tsx
@@ -150,6 +150,31 @@ describe('the queue arrangement', () => {
     expect(onSelectSession).not.toHaveBeenCalled();
   });
 
+  it('draws the chief once when its own workspace stays in the tree', () => {
+    // The chief keeps its anchored slot whatever its workspace is, and pin and
+    // mute are both reachable for it, so the surviving group must not draw it
+    // again.
+    const pinned = renderSidebar(sessions, true, {}, { 'ws-a': { pinned: true } });
+    expect(pinned.getByTestId('queue-chief-chief')).toBeTruthy();
+    expect(pinned.queryByTestId('sidebar-session-chief')).toBeNull();
+    pinned.unmount();
+
+    const data = sidebarData(sessions, { 'ws-a': { muted: true } });
+    const muted = render(
+      <Sidebar
+        {...baseProps}
+        {...data}
+        workspaces={data.workspaces.filter((workspace) => !workspace.muted)}
+        mutedWorkspaces={data.workspaces.filter((workspace) => workspace.muted)}
+        mutedExpanded
+        queue={buildQueueBands(data.workspaces)}
+      />
+    );
+    expect(muted.getByTestId('queue-chief-chief')).toBeTruthy();
+    expect(muted.queryByTestId('sidebar-session-chief')).toBeNull();
+    expect(muted.getByTestId('sidebar-muted-workspace-ws-a')).toBeTruthy();
+  });
+
   it('keeps the per-session menu reachable from every band', () => {
     // Chief of staff, close and reload live on this menu, which the workspace
     // tree row owns when the queue is off. Queue mode stops drawing that row.

--- a/app/src/components/QueueBands.tsx
+++ b/app/src/components/QueueBands.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type MouseEvent as ReactMouseEvent } from 'react';
 import { StateIndicator } from './StateIndicator';
 import { ChiefOfStaffBadge } from './ChiefOfStaffBadge';
 import { formatShortcut } from '../shortcuts';
@@ -27,6 +27,13 @@ interface QueueBandsProps {
    * workspaces these rows come from.
    */
   onPinWorkspace?: (workspaceId: string, pinned: boolean) => void;
+  /**
+   * The per-session menu — chief of staff, close, reload — which the workspace
+   * tree row owns when the queue is off. Queue mode does not draw that row for
+   * these agents, so without it here everything on that menu would be out of
+   * reach for anything in a band.
+   */
+  onOpenActions?: (session: { id: string; label: string; chiefOfStaff?: boolean }, event: ReactMouseEvent) => void;
 }
 
 /**
@@ -65,6 +72,7 @@ function QueueRowView({
   onSelect,
   onSettle,
   onPin,
+  onOpenActions,
   testIdPrefix,
 }: {
   row: QueueRow<QueueBandSessionView>;
@@ -73,6 +81,7 @@ function QueueRowView({
   onSelect: () => void;
   onSettle?: () => void;
   onPin?: () => void;
+  onOpenActions?: (event: ReactMouseEvent) => void;
   testIdPrefix: string;
 }) {
   const { session } = row;
@@ -89,6 +98,20 @@ function QueueRowView({
       {session.chiefOfStaff && <ChiefOfStaffBadge />}
       <span className="queue-row-workspace">{row.workspaceTitle}</span>
       {age && <span className="queue-row-age">{age}</span>}
+      {onOpenActions && (
+        <div className="session-actions">
+          <button
+            type="button"
+            className="session-action-btn session-more-btn"
+            data-testid={`session-actions-${session.id}`}
+            onClick={onOpenActions}
+            title="Session actions"
+            aria-label={`Actions for ${session.label}`}
+          >
+            •••
+          </button>
+        </div>
+      )}
       {onPin && (
         <button
           type="button"
@@ -135,7 +158,7 @@ function QueueRowView({
  * Only pinned and muted workspaces still render as groups, below; they are
  * places you go and get work rather than a list handed to you.
  */
-export function QueueBands({ bands, selectedId, onSelectSession, onSettleTurn, onPinWorkspace }: QueueBandsProps) {
+export function QueueBands({ bands, selectedId, onSelectSession, onSettleTurn, onPinWorkspace, onOpenActions }: QueueBandsProps) {
   const now = useNow(AGE_TICK_MS);
 
   return (
@@ -145,6 +168,7 @@ export function QueueBands({ bands, selectedId, onSelectSession, onSettleTurn, o
           row={bands.chief}
           selected={selectedId === bands.chief.session.id}
           onSelect={() => onSelectSession(bands.chief!.session.id)}
+          onOpenActions={onOpenActions && ((event) => onOpenActions(bands.chief!.session, event))}
           testIdPrefix="queue-chief"
         />
       )}
@@ -164,6 +188,7 @@ export function QueueBands({ bands, selectedId, onSelectSession, onSettleTurn, o
             onSelect={() => onSelectSession(row.session.id)}
             onSettle={() => onSettleTurn(row.session.id)}
             onPin={onPinWorkspace && (() => onPinWorkspace(row.workspaceId, true))}
+            onOpenActions={onOpenActions && ((event) => onOpenActions(row.session, event))}
             testIdPrefix="queue-turn"
           />
         ))
@@ -182,6 +207,7 @@ export function QueueBands({ bands, selectedId, onSelectSession, onSettleTurn, o
               selected={selectedId === row.session.id}
               onSelect={() => onSelectSession(row.session.id)}
               onPin={onPinWorkspace && (() => onPinWorkspace(row.workspaceId, true))}
+              onOpenActions={onOpenActions && ((event) => onOpenActions(row.session, event))}
               testIdPrefix="queue-settled"
             />
           ))}

--- a/app/src/components/QueueBands.tsx
+++ b/app/src/components/QueueBands.tsx
@@ -20,6 +20,13 @@ interface QueueBandsProps {
   selectedId: string | null;
   onSelectSession: (id: string) => void;
   onSettleTurn: (id: string) => void;
+  /**
+   * Pinning a row's workspace is how an agent leaves the queue for good. The
+   * band rows are the only place it can be asked for while queue mode is on:
+   * the workspace group header, which owns it in the tree, is not drawn for the
+   * workspaces these rows come from.
+   */
+  onPinWorkspace?: (workspaceId: string, pinned: boolean) => void;
 }
 
 /**
@@ -57,6 +64,7 @@ function QueueRowView({
   age,
   onSelect,
   onSettle,
+  onPin,
   testIdPrefix,
 }: {
   row: QueueRow<QueueBandSessionView>;
@@ -64,6 +72,7 @@ function QueueRowView({
   age?: string;
   onSelect: () => void;
   onSettle?: () => void;
+  onPin?: () => void;
   testIdPrefix: string;
 }) {
   const { session } = row;
@@ -72,6 +81,7 @@ function QueueRowView({
       className={`session-item queue-row ${selected ? 'selected' : ''}`.trim()}
       data-testid={`${testIdPrefix}-${session.id}`}
       data-state={session.state}
+      data-workspace-id={row.workspaceId}
       onClick={onSelect}
     >
       <StateIndicator state={session.state} size="md" seed={session.id} reason={session.state_reason} />
@@ -79,6 +89,21 @@ function QueueRowView({
       {session.chiefOfStaff && <ChiefOfStaffBadge />}
       <span className="queue-row-workspace">{row.workspaceTitle}</span>
       {age && <span className="queue-row-age">{age}</span>}
+      {onPin && (
+        <button
+          type="button"
+          className="queue-row-pin"
+          data-testid={`queue-pin-${session.id}`}
+          title={`Pin ${row.workspaceTitle} — take it out of the queue`}
+          aria-label={`Pin workspace ${row.workspaceTitle}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            onPin();
+          }}
+        >
+          📍
+        </button>
+      )}
       {onSettle && (
         <button
           type="button"
@@ -99,15 +124,18 @@ function QueueRowView({
 }
 
 /**
- * The queue arrangement's two bands, rendered above the workspace tree: the
- * chief in its own anchored slot, then the turns the user owes, oldest first.
+ * The sidebar's standing order: the chief in its own anchored slot, the turns
+ * the user owes oldest first, then the settled rest.
  *
- * The tree below is untouched, so an agent the daemon never promoted is still
- * exactly where it has always been. Rows carry their live state because being
- * in the queue no longer implies being stopped — an agent you steered is still
- * yours until you settle it.
+ * An agent appears in exactly one of these, which is what lets its position
+ * carry meaning. Rows carry their live state in both bands, because neither
+ * band is about whether an agent is running — an agent you steered is still
+ * yours until you settle it, and a settled one may well be working.
+ *
+ * Only pinned and muted workspaces still render as groups, below; they are
+ * places you go and get work rather than a list handed to you.
  */
-export function QueueBands({ bands, selectedId, onSelectSession, onSettleTurn }: QueueBandsProps) {
+export function QueueBands({ bands, selectedId, onSelectSession, onSettleTurn, onPinWorkspace }: QueueBandsProps) {
   const now = useNow(AGE_TICK_MS);
 
   return (
@@ -135,9 +163,29 @@ export function QueueBands({ bands, selectedId, onSelectSession, onSettleTurn }:
             age={formatTurnAge(row.session.turnOpenedAt, now)}
             onSelect={() => onSelectSession(row.session.id)}
             onSettle={() => onSettleTurn(row.session.id)}
+            onPin={onPinWorkspace && (() => onPinWorkspace(row.workspaceId, true))}
             testIdPrefix="queue-turn"
           />
         ))
+      )}
+      {bands.settled.length > 0 && (
+        <>
+          <div className="queue-band-header">
+            <span>Settled</span>
+          </div>
+          {bands.settled.map((row) => (
+            // No settle button: it is already settled, and offering the act
+            // again would suggest there is something here to discharge.
+            <QueueRowView
+              key={row.session.id}
+              row={row}
+              selected={selectedId === row.session.id}
+              onSelect={() => onSelectSession(row.session.id)}
+              onPin={onPinWorkspace && (() => onPinWorkspace(row.workspaceId, true))}
+              testIdPrefix="queue-settled"
+            />
+          ))}
+        </>
       )}
     </div>
   );

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -1194,7 +1194,8 @@
   font-variant-numeric: tabular-nums;
 }
 
-.queue-row-settle {
+.queue-row-settle,
+.queue-row-pin {
   flex: 0 0 auto;
   background: none;
   border: none;
@@ -1206,10 +1207,13 @@
 }
 
 .queue-row:hover .queue-row-settle,
-.queue-row-settle:focus-visible {
+.queue-row:hover .queue-row-pin,
+.queue-row-settle:focus-visible,
+.queue-row-pin:focus-visible {
   opacity: 1;
 }
 
-.queue-row-settle:hover {
+.queue-row-settle:hover,
+.queue-row-pin:hover {
   color: var(--color-text-primary);
 }

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -133,8 +133,9 @@ interface SidebarProps {
   dockItems?: DockItem[];
   dockCollapsed?: boolean;
   onToggleDockCollapsed?: () => void;
-  // The queue arrangement's bands, or null when the arrangement is off. The
-  // workspace tree below is identical either way — the queue only adds rows.
+  // The queue arrangement's bands, or null when the arrangement is off. While it
+  // is on the tree below is reduced to what the bands exclude: pinned and
+  // tile-only workspaces.
   queue?: QueueBandsModel<LocalSession> | null;
   onSettleTurn?: (id: string) => void;
   mutedWorkspaces?: SidebarWorkspace[];
@@ -412,6 +413,21 @@ export function Sidebar({
     onMutedExpandedChange?.(v);
   };
 
+  // The chief holds its anchored slot whatever its workspace is, so a workspace
+  // that survives in the tree — pinned, or muted — must not draw it a second
+  // time. This is the one session the bands claim from a workspace they
+  // otherwise leave alone.
+  const withoutChiefRow = (workspace: SidebarWorkspace): SidebarWorkspace => {
+    if (!queue || !workspace.sessions.some((session) => session.chiefOfStaff)) {
+      return workspace;
+    }
+    return {
+      ...workspace,
+      sessions: workspace.sessions.filter((session) => !session.chiefOfStaff),
+      children: workspace.children.filter((child) => child.kind === 'tile' || !child.session.chiefOfStaff),
+    };
+  };
+
   const isWorkspaceVisible = (workspace: SidebarWorkspace) => workspace.pinned || !isSessionless(workspace) || showSessionless;
   // Queue mode renders every ordinary agent as a flat row in a band, so drawing
   // its workspace group as well would show the same agent twice and make it look
@@ -422,7 +438,9 @@ export function Sidebar({
   const isTreeWorkspace = (workspace: SidebarWorkspace) => (
     !queue || workspace.pinned || isSessionless(workspace)
   );
-  const visibleWorkspaces = workspaces.filter((workspace) => isWorkspaceVisible(workspace) && isTreeWorkspace(workspace));
+  const visibleWorkspaces = workspaces
+    .map(withoutChiefRow)
+    .filter((workspace) => isWorkspaceVisible(workspace) && isTreeWorkspace(workspace));
   const visibleVisualOrder = visualOrder.filter(isWorkspaceVisible);
   const visibleVisualIndexByWorkspaceId = new Map(
     visibleVisualOrder.map((workspace, index) => [workspace.id, index]),
@@ -1136,7 +1154,7 @@ export function Sidebar({
           </button>
           {mutedExpanded && (
             <div className="muted-sessions-list">
-              {mutedWorkspaces.map((workspace) => (
+              {mutedWorkspaces.map(withoutChiefRow).map((workspace) => (
                 <div
                   key={`${workspace.endpointId || 'local'}:${workspace.id}`}
                   className={`workspace-group muted-workspace ${selectedWorkspaceId === workspace.id ? 'selected' : ''}${workspaceDragClass(workspace)}`}

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -411,7 +411,16 @@ export function Sidebar({
   };
 
   const isWorkspaceVisible = (workspace: SidebarWorkspace) => workspace.pinned || !isSessionless(workspace) || showSessionless;
-  const visibleWorkspaces = workspaces.filter(isWorkspaceVisible);
+  // Queue mode renders every ordinary agent as a flat row in a band, so drawing
+  // its workspace group as well would show the same agent twice and make it look
+  // like a row moved when only one of the two copies did. What is left in the
+  // tree is what the bands deliberately exclude: pinned workspaces, and — when
+  // the toggle asks for them — tile-only ones, which have no agent and so no row
+  // anywhere else.
+  const isTreeWorkspace = (workspace: SidebarWorkspace) => (
+    !queue || workspace.pinned || isSessionless(workspace)
+  );
+  const visibleWorkspaces = workspaces.filter((workspace) => isWorkspaceVisible(workspace) && isTreeWorkspace(workspace));
   const visibleVisualOrder = visualOrder.filter(isWorkspaceVisible);
   const visibleVisualIndexByWorkspaceId = new Map(
     visibleVisualOrder.map((workspace, index) => [workspace.id, index]),
@@ -900,6 +909,7 @@ export function Sidebar({
           selectedId={selectedId}
           onSelectSession={onSelectSession}
           onSettleTurn={(id) => onSettleTurn?.(id)}
+          onPinWorkspace={onPinWorkspace}
         />
       )}
 

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -391,8 +391,10 @@ export function Sidebar({
     const rect = event.currentTarget.getBoundingClientRect();
     setRenameTarget({ kind, id, name, anchor: { top: rect.bottom + 4, left: rect.left } });
   };
+  // Takes the fields it reads rather than a whole LocalSession, so the queue
+  // rows — which carry a narrower session view — can open the same menu.
   const openSessionActions = (
-    session: LocalSession,
+    session: { id: string; label: string; chiefOfStaff?: boolean },
     event: ReactMouseEvent,
   ) => {
     event.stopPropagation();
@@ -910,6 +912,7 @@ export function Sidebar({
           onSelectSession={onSelectSession}
           onSettleTurn={(id) => onSettleTurn?.(id)}
           onPinWorkspace={onPinWorkspace}
+          onOpenActions={openSessionActions}
         />
       )}
 

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -1842,6 +1842,7 @@ export function useUiAutomationBridge({
           label: row.querySelector('.session-label')?.textContent?.trim() || '',
           state: row.getAttribute('data-state') || '',
           workspace: row.querySelector('.queue-row-workspace')?.textContent?.trim() || '',
+          workspaceId: row.getAttribute('data-workspace-id') || '',
           age: row.querySelector('.queue-row-age')?.textContent?.trim() || '',
           selected: row.classList.contains('selected'),
         });
@@ -1852,8 +1853,11 @@ export function useUiAutomationBridge({
           chief: chiefRow ? readRow(chiefRow, 'queue-chief-') : null,
           turns: Array.from(band?.querySelectorAll('[data-testid^="queue-turn-"]') || [])
             .map((row) => readRow(row, 'queue-turn-')),
-          // The tree is additive, never filtered — the scenario asserts every
-          // session still has its own row below the band.
+          settled: Array.from(band?.querySelectorAll('[data-testid^="queue-settled-"]') || [])
+            .map((row) => readRow(row, 'queue-settled-')),
+          // What is left of the tree while the queue is on: pinned and tile-only
+          // workspaces. An agent in a band must not also be here — appearing
+          // twice is what made a row look like it moved.
           treeSessionIds: Array.from(document.querySelectorAll('.session-list [data-testid^="sidebar-session-"]'))
             .map((row) => (row.getAttribute('data-testid') || '').slice('sidebar-session-'.length)),
         };

--- a/app/src/utils/queueBands.test.ts
+++ b/app/src/utils/queueBands.test.ts
@@ -95,6 +95,47 @@ describe('buildQueueBands', () => {
     expect(bands.turns).toEqual([]);
   });
 
+  it('puts everything not owed into settled, so no agent is in both bands', () => {
+    const bands = buildQueueBands(views([
+      { id: 'owed', label: 'owed', workspaceId: 'ws-a', turnOwed: true, turnOpenedAt: '2026-07-26T09:00:00Z' },
+      { id: 'quiet', label: 'quiet', workspaceId: 'ws-a' },
+      { id: 'busy', label: 'busy', workspaceId: 'ws-b', state: 'working' },
+    ]));
+
+    expect(bands.turns.map((row) => row.session.id)).toEqual(['owed']);
+    expect(bands.settled.map((row) => row.session.id)).toEqual(['quiet', 'busy']);
+  });
+
+  it('settling moves a row from one band to the other rather than out of the sidebar', () => {
+    const session: QueueBandSession = {
+      id: 'a', label: 'a', workspaceId: 'ws-a', turnOwed: true, turnOpenedAt: '2026-07-26T09:00:00Z',
+    };
+    const before = buildQueueBands(views([session]));
+    const after = buildQueueBands(views([{ ...session, turnOwed: false }]));
+
+    expect(before.turns.map((row) => row.session.id)).toEqual(['a']);
+    expect(before.settled).toEqual([]);
+    expect(after.turns).toEqual([]);
+    expect(after.settled.map((row) => row.session.id)).toEqual(['a']);
+  });
+
+  it('keeps pinned and muted workspaces out of both bands — they stay in the tree', () => {
+    // Pinning is the way out of the queue entirely, and muting is its absolute
+    // sibling. Either one landing in Settled would put it back in the list it
+    // was taken out of.
+    const pinnedAndMuted = [
+      { id: 'ws-a', title: 'A', directory: '/repo/a', rank: 'a', pinned: true },
+      { id: 'ws-b', title: 'B', directory: '/repo/b', rank: 'b', muted: true },
+    ];
+    const bands = buildQueueBands(buildWorkspaceViewModels(pinnedAndMuted, [
+      { id: 'pinned-owed', label: 'a', workspaceId: 'ws-a', turnOwed: true, turnOpenedAt: '2026-07-26T09:00:00Z' },
+      { id: 'muted-quiet', label: 'b', workspaceId: 'ws-b' },
+    ]));
+
+    expect(bands.turns).toEqual([]);
+    expect(bands.settled).toEqual([]);
+  });
+
   it('leaves the workspace tree untouched — it is not an output of the queue', () => {
     const sessions: QueueBandSession[] = [
       { id: 'a', label: 'a', workspaceId: 'ws-a', turnOwed: true, turnOpenedAt: '2026-07-26T09:00:00Z' },

--- a/app/src/utils/queueBands.test.ts
+++ b/app/src/utils/queueBands.test.ts
@@ -136,6 +136,19 @@ describe('buildQueueBands', () => {
     expect(bands.settled).toEqual([]);
   });
 
+  it('anchors the chief even when its workspace is pinned or muted', () => {
+    // The chief is the seat you always want to reach, not a piece of work you
+    // filed away, so neither pin nor mute takes its slot from it.
+    for (const flag of [{ pinned: true }, { muted: true }]) {
+      const bands = buildQueueBands(buildWorkspaceViewModels(
+        [{ id: 'ws-a', title: 'A', directory: '/repo/a', rank: 'a', ...flag }],
+        [{ id: 'chief', label: 'chief', workspaceId: 'ws-a', chiefOfStaff: true }],
+      ));
+
+      expect(bands.chief?.session.id).toBe('chief');
+    }
+  });
+
   it('leaves the workspace tree untouched — it is not an output of the queue', () => {
     const sessions: QueueBandSession[] = [
       { id: 'a', label: 'a', workspaceId: 'ws-a', turnOwed: true, turnOpenedAt: '2026-07-26T09:00:00Z' },

--- a/app/src/utils/queueBands.ts
+++ b/app/src/utils/queueBands.ts
@@ -43,6 +43,11 @@ export interface QueueBands<TSession extends QueueBandSession> {
  * and get work rather than a list handed to you, and a muted one is out of
  * sight by definition.
  *
+ * The chief is the one exception: it holds its anchored slot whatever its
+ * workspace is, since it is the seat you always want to reach rather than a
+ * piece of work you filed away. The tree drops it from a workspace it still
+ * draws, so it is never in two places at once either.
+ *
  * Membership is read, never derived: `turnOwed` is the daemon's answer, which
  * already accounts for the exclusions a client cannot see. Turn ordering is by
  * `turnOpenedAt` ascending — how long the turn has been owed, which does not

--- a/app/src/utils/queueBands.ts
+++ b/app/src/utils/queueBands.ts
@@ -29,27 +29,34 @@ export interface QueueBands<TSession extends QueueBandSession> {
   chief: QueueRow<TSession> | null;
   /** Turns the user owes, oldest first. */
   turns: QueueRow<TSession>[];
+  /** Everything else you could go and look at, in a stable order. */
+  settled: QueueRow<TSession>[];
 }
 
 /**
- * Derive the queue bands that sit above the workspace tree.
+ * Derive the sidebar's standing order: the chief, the turns you owe, and the
+ * settled rest.
  *
- * The tree itself is not an input to this: the queue is additive, so a promoted
- * agent appears in both the band and its workspace group and the tree below is
- * left exactly as queue-mode-off renders it. That duplication is the point — it
- * is the only defence against an agent that needs the user and never enters the
- * queue.
+ * Every agent lands in exactly one band, which is what makes a row's position
+ * mean something. Pinned and muted workspaces are in none of them — they keep
+ * the tree's grouped rendering, because a pinned workspace is a place you go
+ * and get work rather than a list handed to you, and a muted one is out of
+ * sight by definition.
  *
  * Membership is read, never derived: `turnOwed` is the daemon's answer, which
- * already accounts for the exclusions a client cannot see. Ordering is by
+ * already accounts for the exclusions a client cannot see. Turn ordering is by
  * `turnOpenedAt` ascending — how long the turn has been owed, which does not
- * move when the agent changes state under the user.
+ * move when the agent changes state under the user. Settled keeps the tree's
+ * own order — workspace rank, then the workspace's session order — which is
+ * deliberately not a state order: an agent nobody is asking you about should
+ * not jump around the list as it works.
  */
 export function buildQueueBands<TSession extends QueueBandSession>(
   workspaces: WorkspaceWithSessions<TSession>[],
 ): QueueBands<TSession> {
   let chief: QueueRow<TSession> | null = null;
   const turns: QueueRow<TSession>[] = [];
+  const settled: QueueRow<TSession>[] = [];
 
   for (const workspace of workspaces) {
     for (const session of workspace.sessions) {
@@ -64,8 +71,13 @@ export function buildQueueBands<TSession extends QueueBandSession>(
         }
         continue;
       }
+      if (workspace.pinned || workspace.muted) {
+        continue;
+      }
       if (session.turnOwed) {
         turns.push(row);
+      } else {
+        settled.push(row);
       }
     }
   }
@@ -79,5 +91,5 @@ export function buildQueueBands<TSession extends QueueBandSession>(
     return a.session.id < b.session.id ? -1 : 1;
   });
 
-  return { chief, turns };
+  return { chief, turns, settled };
 }

--- a/docs/plans/2026-07-26-agent-queue-turn-and-settle.md
+++ b/docs/plans/2026-07-26-agent-queue-turn-and-settle.md
@@ -26,11 +26,10 @@ workspaces as their own band, a designed empty state, and default-on.
 
 ## The shape
 
-Queue mode is **today's sidebar plus a band on top**. The workspace tree below is
-untouched and complete, so an agent the daemon fails to promote is still exactly
-where it has always been — that is the vision's "reorders, never hides", taken
-literally. The daemon decides who owes a turn and stamps it on every session it
-broadcasts; the app renders and sorts.
+Queue mode is **the vision's standing order**: chief, then the turns you owe,
+then pinned workspaces, then the settled rest, then muted. An agent appears in
+exactly one place. The daemon decides who owes a turn and stamps it on every
+session it broadcasts; the app renders and sorts.
 
 ```text
 Sidebar, queue mode on               Sidebar, queue mode off (unchanged)
@@ -39,8 +38,11 @@ Sidebar, queue mode on               Sidebar, queue mode off (unchanged)
     api-refactor  working    12m         session row
     docs-pass     waiting     4m       workspace group
     flaky-tests   idle        1m         ...
-  ── (the tree, unchanged) ──          ── Muted ──
-    workspace group                      workspace group
+  ── Settled ──                        ── Muted ──
+    exo-main      idle                   workspace group
+    md-focus      working
+  ── Pinned ──
+    workspace group
       session row
   ── Muted ──
     workspace group
@@ -48,7 +50,18 @@ Sidebar, queue mode on               Sidebar, queue mode off (unchanged)
 
 A queued row shows its live state, because being in the queue no longer implies
 being stopped. `api-refactor` above is running: you steered it and have not yet
-said you are done with it.
+said you are done with it. So does a settled row: settling says you are finished
+with an agent, not that it stopped.
+
+*Your turn* and *Settled* are flat — one agent is one row, never a workspace and
+never a group with a count. Pinned and muted workspaces keep the tree's grouped
+rendering, because those are places you go and get work rather than a list handed
+to you.
+
+Slices 1 and 2 shipped a narrower shape — a band on top of the untouched
+workspace tree — which drew every queued agent twice, gave settled agents no band
+of their own, and made a row look like it moved when only one of its two copies
+did. Slice 3 is what makes the sidebar the standing order. See Decisions.
 
 ## Data model
 
@@ -402,6 +415,47 @@ if it still feels heavy the flip is one predicate entry to revert.
       whose run ends `idle` returns at the bottom, and a split shell pane —
       registered `idle`, the same state — changes nothing in the band. The first
       step also asserts an agent queues from the moment it boots to its prompt.
+
+### Slice 3 — the standing order
+
+*Puts into use:* the vision's sidebar, rather than a band bolted onto the old
+one. Slices 1 and 2 rendered queue mode as *Your turn* over the untouched
+workspace tree, so a queued agent was drawn twice, settled agents had no band,
+and a row appeared to move when only one of its copies did. This makes an agent
+appear exactly once, in the band that says what it is.
+
+Nothing here is daemon work: `turn_owed` and the exclusions already say
+everything the app needs. It is entirely a rendering and reachability change.
+
+```text
+buildQueueBands(workspaces) -> { chief, turns, settled }
+  turns    = turnOwed, oldest turnOpenedAt first          (flat, as today)
+  settled  = the rest, from workspaces that are neither pinned nor muted
+             (flat; excludes the chief, which has its own slot)
+  pinned + muted workspaces are not in the bands at all — the tree renders them
+```
+
+- [x] `buildQueueBands` gains `settled`, ordered by workspace then label so it
+      does not shuffle as states change. Pinned and muted workspaces contribute
+      to neither band.
+- [x] `QueueBands` renders a *Settled* header and its rows. A settled row shows
+      live state and has no settle button; it is already settled.
+- [x] `Sidebar` renders only pinned workspaces as groups while queue mode is on.
+      The muted section is unchanged — it is already its own collapsible section
+      below, not part of the tree.
+- [x] Reachability, because the group header is the only place `onPinWorkspace`
+      and `onMuteWorkspace` exist today and pinning is the vision's way *out* of
+      the queue: a right-click menu on any flat row pins or mutes its workspace,
+      plus a ⌘K command for both. Without this, turning the queue on is a
+      one-way door.
+- [x] Tile-only workspaces have no agent and so no row. They are already hidden
+      unless pinned or `showSessionless` is on; when it is on, they render in the
+      pinned-style tree so the toggle keeps meaning something.
+- [x] Live verification: extend `real-app:scenario-agent-queue` — a queued agent
+      appears exactly once (in the band, not in the tree), settling moves it to
+      *Settled* rather than into a workspace group, a pinned workspace keeps its
+      group and its agent stays out of both bands, and pin from the row menu
+      moves an agent out of the queue.
 
 ## Decisions
 


### PR DESCRIPTION
## What

With the agent queue on, the sidebar is now the standing order itself rather than a band sitting on top of the unchanged workspace tree:

- **Your turn** — the turns you owe, oldest first.
- **Settled** — everything else you could go and look at, in the tree's own order (workspace rank, then session order), which is deliberately not a state order.
- The chief keeps its anchored slot above both and never queues.

An agent is drawn in exactly **one** place. Before this, every queued agent appeared twice — once in the band and once in its workspace group — so a row looked like it moved when only one of its two copies did, and there was nowhere for a settled agent to go.

Pinned and muted workspaces keep their groups below the bands. A pinned workspace is where you go and get work rather than a list handed to you, and pinning is how an agent leaves the queue for good. Turning the queue off restores the full tree unchanged.

## Affordances that the tree used to own

Removing the groups removes the only place two things could be asked for, so both move onto the rows:

- **Pin** — a 📍 on every queue row pins its workspace; without it the queue would be a one-way door. ⌘K also gains *Pin workspace* and *Mute workspace* for the workspace of the agent you are in.
- **The per-session menu** (chief of staff, close, reload) — the ••• that the workspace-tree session row owned. The packaged-app run caught this one: with the row gone, the whole menu was out of reach for anything in a band.

## Shape chosen

Settled rows are flat, with no workspace grouping; only pinned and muted workspaces still render as groups.

## Verification

`ATTN_PROFILE=queue1 pnpm run real-app:scenario-agent-queue` against a packaged build of this branch — 14/14 steps green, including the two new ones (`pinning_from_a_row_takes_the_agent_out_of_the_queue`, and `the_chief_never_queues` now opening the actions menu from a band row). Frontend suite: 2077 passing. `tsc --noEmit` clean.