### PR TITLE
Make docked tiles first-class focus targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-27]
+
+### Fixed
+- **A docked markdown file can now be focused like any terminal pane.** Focus in
+  a workspace used to belong to terminals only, so a markdown or notebook tile —
+  the surface an agent opens when it shows you a file — could never be the
+  focused thing. Clicking it did nothing you could see, ⌘W acted on whichever
+  terminal was focused before, ⌘⌥arrows skipped over it, ⌘⇧Enter could not
+  zoom it, and ⌘Enter (send annotations) only worked if focus had happened to
+  land inside. Docked tiles are now first-class focus targets: click one, or
+  navigate into it with ⌘⌥arrows, and it becomes the focused leaf — ⌘W closes
+  that tile, ⌘⇧Enter zooms it, and the annotation shortcut is armed.
+
+### Changed
+- **The focused pane or tile is now marked, not just brightened.** The focused
+  leaf carries an accent ring and an accented header, applied the same way to
+  terminals and docked tiles, so which one has the keyboard is readable at a
+  glance. Tiles stay at full brightness whether focused or not — a docked
+  document is there to be read while you type in the terminal.
+
+---
+
 ## [2026-07-26]
 
 ### Fixed

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3247,10 +3247,18 @@ sendFetchPRDetails,
     // must close THAT tile here, not the active session's terminal pane. Without
     // this, Cmd+W while reading a note kills the previously-focused terminal/session.
     // (Native browser tiles are handled natively before session.close ever fires.)
-    const focused = document.activeElement;
-    const tileEl = focused instanceof HTMLElement ? focused.closest('[data-pane-kind="tile"]') : null;
-    const tileId = tileEl?.getAttribute('data-pane-id');
-    if (tileId && activeWorkspaceId) {
+    const focused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    // Inside a tile's own subtree the tile is unambiguous. Otherwise, while focus
+    // is anywhere in the workspace, the workspace's own focus model decides —
+    // data-active-leaf-id names a tile whenever a tile is the focused leaf, so a
+    // click that landed on the workspace frame rather than the tile body still
+    // closes the leaf the user sees as focused.
+    const tileId = focused?.closest('[data-pane-kind="tile"]')?.getAttribute('data-pane-id')
+      ?? focused?.closest('.session-terminal-workspace')?.getAttribute('data-active-leaf-id')
+      ?? '';
+    const isTile = !!tileId
+      && !!document.querySelector(`[data-pane-kind="tile"][data-pane-id="${CSS.escape(tileId)}"]`);
+    if (isTile && activeWorkspaceId) {
       handleCloseTile(activeWorkspaceId, tileId);
       return;
     }

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
@@ -59,6 +59,14 @@ function paneAndTileWorkspace(): TerminalWorkspaceState {
   };
 }
 
+// The same workspace with the tile undocked — one terminal pane, no split.
+function paneOnlyWorkspace(): TerminalWorkspaceState {
+  return {
+    agents: [{ id: 'pane-term', runtimeId: 'rt-1', sessionId: 'sess-1', title: 'shell' }],
+    layoutTree: { type: 'pane', paneId: 'pane-term' },
+  };
+}
+
 function renderSplit(overrides: {
   onClosePane?: () => void;
   onUndockTile?: (tileId: string) => void;
@@ -67,16 +75,17 @@ function renderSplit(overrides: {
   const onClosePane = overrides.onClosePane ?? vi.fn();
   const onUndockTile = overrides.onUndockTile ?? vi.fn();
   const onFocusPane = overrides.onFocusPane ?? vi.fn();
-  const utils = render(
+  const eventRouter = createPaneRuntimeEventRouterController();
+  const element = (workspace: TerminalWorkspaceState) => (
     <SessionTerminalWorkspace
       workspaceId="workspace-split"
       workspaceSessions={[{ id: 'sess-1', label: 'shell', agent: 'shell', cwd: '/tmp/project' }]}
-      workspace={paneAndTileWorkspace()}
+      workspace={workspace}
       activePaneId="pane-term"
       fontSize={13}
       enabled
       isActiveSession
-      eventRouter={createPaneRuntimeEventRouterController()}
+      eventRouter={eventRouter}
       onSplitPane={vi.fn()}
       onClosePane={onClosePane}
       onFocusPane={onFocusPane}
@@ -89,10 +98,11 @@ function renderSplit(overrides: {
         },
       }}
       onRequestTileContent={vi.fn()}
-    />,
-    { wrapper: NotebookSurfaceTestWrapper },
+    />
   );
-  return { ...utils, onClosePane, onUndockTile, onFocusPane };
+  const utils = render(element(paneAndTileWorkspace()), { wrapper: NotebookSurfaceTestWrapper });
+  const setWorkspace = (workspace: TerminalWorkspaceState) => utils.rerender(element(workspace));
+  return { ...utils, setWorkspace, onClosePane, onUndockTile, onFocusPane };
 }
 
 function tileEl(container: HTMLElement): HTMLElement {
@@ -140,6 +150,25 @@ describe('SessionTerminalWorkspace leaf focus', () => {
     // The maximized tile renders alone, keeping its identity as a tile leaf.
     expect(container.querySelector('[data-pane-kind="agent"]')).toBeNull();
     expect(tileEl(container).getAttribute('data-pane-id')).toBe('tile-notes');
+  });
+
+  // A markdown tile's id is derived from its file path, so closing one and
+  // reopening the same file produces the SAME leaf id. A maximized leaf that
+  // leaves the layout must therefore be forgotten, or reopening the file would
+  // silently come back maximized.
+  it('forgets a maximized tile once it leaves the layout', () => {
+    const { container, setWorkspace } = renderSplit();
+    const surface = () => container.querySelector('.session-terminal-workspace') as HTMLElement;
+
+    fireEvent.mouseDown(tileEl(container));
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Enter', metaKey: true, shiftKey: true });
+    expect(surface().getAttribute('data-maximized-pane-id')).toBe('tile-notes');
+
+    setWorkspace(paneOnlyWorkspace());
+    setWorkspace(paneAndTileWorkspace());
+
+    expect(surface().getAttribute('data-maximized-pane-id')).toBe('');
+    expect(container.querySelector('[data-pane-kind="agent"]')).not.toBeNull();
   });
 
   // Clicking back onto the terminal returns the focus display to the pane. The

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
@@ -205,6 +205,28 @@ describe('SessionTerminalWorkspace Cmd+W closes the focused leaf', () => {
     expect(onClosePane).not.toHaveBeenCalled();
   });
 
+  // Focus utility terminal (⌘`) focuses the pane without changing activePaneId —
+  // the pane was already the session's active one. The focused tile has to be
+  // released anyway, or the active leaf stays the tile and Cmd+W undocks the
+  // document you just typed away from.
+  it('closes the terminal pane after Focus utility terminal takes focus back from a tile', () => {
+    const { container, onClosePane, onUndockTile } = renderSplit();
+
+    fireEvent.mouseDown(tileEl(container));
+    expect(tileEl(container).className).toContain('active');
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: '`', metaKey: true });
+
+    expect(tileEl(container).className).not.toContain('active');
+    expect(paneEl(container).className).toContain('active');
+
+    fireEvent.keyDown(paneEl(container), { key: 'w', metaKey: true });
+
+    expect(onClosePane).toHaveBeenCalledTimes(1);
+    expect(onClosePane).toHaveBeenCalledWith('pane-term');
+    expect(onUndockTile).not.toHaveBeenCalled();
+  });
+
   // The terminal-pane path is unchanged: Cmd+W with the pane focused closes that
   // pane, never the tile — including after a tile visit.
   it('closes the active terminal pane when the pane is the focused leaf', () => {

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
@@ -124,6 +124,24 @@ describe('SessionTerminalWorkspace leaf focus', () => {
     expect(document.activeElement).toBe(tileBody);
   });
 
+  // Zoom and maximize follow the focused leaf, so they land on a tile too —
+  // ⌘⇧Z used to be able to target only a terminal pane.
+  it('zooms and maximizes the focused tile', () => {
+    const { container } = renderSplit();
+    const surface = container.querySelector('.session-terminal-workspace') as HTMLElement;
+
+    fireEvent.mouseDown(tileEl(container));
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'z', metaKey: true, shiftKey: true });
+    expect(surface.getAttribute('data-zoomed-pane-id')).toBe('tile-notes');
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Enter', metaKey: true, shiftKey: true });
+    expect(surface.getAttribute('data-maximized-pane-id')).toBe('tile-notes');
+    expect(surface.getAttribute('data-zoomed-pane-id')).toBe('');
+    // The maximized tile renders alone, keeping its identity as a tile leaf.
+    expect(container.querySelector('[data-pane-kind="agent"]')).toBeNull();
+    expect(tileEl(container).getAttribute('data-pane-id')).toBe('tile-notes');
+  });
+
   // Clicking back onto the terminal returns the focus display to the pane. The
   // pane's own focus goes through onFocusPane (activePaneId is owned upstream),
   // so the assertion here is the callback plus the chrome.

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
@@ -30,12 +30,37 @@ function NotebookSurfaceTestWrapper({ children }: { children: ReactNode }) {
 }
 
 // The terminal surface pulls in the Ghostty WASM model; stub it so the import
-// graph stays light in jsdom (this spec only cares about Cmd+W routing).
+// graph stays light in jsdom. The stub still announces readiness and takes real
+// DOM focus, because when a mounting terminal grabs focus is exactly what this
+// spec is about.
+const terminalFocusCalls = vi.hoisted(() => [] as string[]);
 vi.mock('../GhosttyTerminal', async () => {
   const React = await import('react');
   return {
-    GhosttyTerminal: React.forwardRef(function MockTerminal() {
-      return null;
+    GhosttyTerminal: React.forwardRef(function MockTerminal(
+      props: { onReady?: (handle: unknown) => void; runtimeLogMeta?: { paneId?: string } },
+      ref,
+    ) {
+      const nodeRef = React.useRef<HTMLDivElement | null>(null);
+      const paneId = props.runtimeLogMeta?.paneId ?? 'pane';
+      const handle = React.useMemo(() => ({
+        focus: () => {
+          terminalFocusCalls.push(paneId);
+          nodeRef.current?.focus();
+          return true;
+        },
+        getSize: () => null,
+        fit: () => {},
+      }), [paneId]);
+      React.useImperativeHandle(ref, () => handle, [handle]);
+      // Once per mount, like the real terminal: onReady's identity changes every
+      // parent render, so firing on its identity would announce readiness forever.
+      const onReadyRef = React.useRef(props.onReady);
+      onReadyRef.current = props.onReady;
+      React.useEffect(() => {
+        onReadyRef.current?.(handle);
+      }, [handle]);
+      return <div ref={nodeRef} tabIndex={-1} data-testid={`mock-terminal-${paneId}`} />;
     }),
   };
 });
@@ -225,6 +250,30 @@ describe('SessionTerminalWorkspace Cmd+W closes the focused leaf', () => {
     expect(onClosePane).toHaveBeenCalledTimes(1);
     expect(onClosePane).toHaveBeenCalledWith('pane-term');
     expect(onUndockTile).not.toHaveBeenCalled();
+  });
+
+  // A terminal that mounts while a tile holds focus must leave it alone. Maximizing
+  // the tile unmounts the terminal and restoring remounts it, so its ready callback
+  // fires with the tile still the focused leaf — if it grabbed focus there, DOM
+  // focus and the active leaf would disagree, which is the state the Cmd+W cases
+  // above are protecting against.
+  it('leaves a focused tile alone when a terminal remounts and announces readiness', () => {
+    const { container } = renderSplit();
+    terminalFocusCalls.length = 0;
+
+    fireEvent.mouseDown(tileEl(container));
+    const tileBody = tileEl(container).querySelector('.workspace-dock-tile-body') as HTMLElement;
+    expect(document.activeElement).toBe(tileBody);
+
+    // Maximize the tile (terminal unmounts), then restore it (terminal remounts).
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Enter', metaKey: true, shiftKey: true });
+    expect(container.querySelector('[data-pane-kind="agent"]')).toBeNull();
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Enter', metaKey: true, shiftKey: true });
+    expect(container.querySelector('[data-pane-kind="agent"]')).not.toBeNull();
+
+    expect(terminalFocusCalls).toEqual([]);
+    expect(tileEl(container).className).toContain('active');
+    expect(document.activeElement).toBe(tileEl(container).querySelector('.workspace-dock-tile-body'));
   });
 
   // The terminal-pane path is unchanged: Cmd+W with the pane focused closes that

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
@@ -59,9 +59,14 @@ function paneAndTileWorkspace(): TerminalWorkspaceState {
   };
 }
 
-function renderSplit(overrides: { onClosePane?: () => void; onUndockTile?: (tileId: string) => void } = {}) {
+function renderSplit(overrides: {
+  onClosePane?: () => void;
+  onUndockTile?: (tileId: string) => void;
+  onFocusPane?: (paneId: string) => void;
+} = {}) {
   const onClosePane = overrides.onClosePane ?? vi.fn();
   const onUndockTile = overrides.onUndockTile ?? vi.fn();
+  const onFocusPane = overrides.onFocusPane ?? vi.fn();
   const utils = render(
     <SessionTerminalWorkspace
       workspaceId="workspace-split"
@@ -74,7 +79,7 @@ function renderSplit(overrides: { onClosePane?: () => void; onUndockTile?: (tile
       eventRouter={createPaneRuntimeEventRouterController()}
       onSplitPane={vi.fn()}
       onClosePane={onClosePane}
-      onFocusPane={vi.fn()}
+      onFocusPane={onFocusPane}
       onNavigateOutOfSession={vi.fn()}
       onUndockTile={onUndockTile}
       tileContents={{
@@ -87,8 +92,54 @@ function renderSplit(overrides: { onClosePane?: () => void; onUndockTile?: (tile
     />,
     { wrapper: NotebookSurfaceTestWrapper },
   );
-  return { ...utils, onClosePane, onUndockTile };
+  return { ...utils, onClosePane, onUndockTile, onFocusPane };
 }
+
+function tileEl(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-pane-kind="tile"]') as HTMLElement;
+}
+
+function paneEl(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-pane-kind="agent"]') as HTMLElement;
+}
+
+describe('SessionTerminalWorkspace leaf focus', () => {
+  // Clicking a tile must be enough — no programmatic focus() — for the tile to
+  // become the focused leaf and take real DOM focus. Everything else here
+  // (Cmd+W routing, the ⌘Enter send gate, keyboard scrolling) rides on it.
+  it('makes a clicked tile the active leaf and gives its body DOM focus', () => {
+    const { container } = renderSplit();
+
+    const tile = tileEl(container);
+    expect(tile.getAttribute('data-pane-id')).toBe('tile-notes');
+    expect(tile.className).not.toContain('active');
+
+    fireEvent.mouseDown(tile);
+
+    expect(tile.className).toContain('active');
+    expect(paneEl(container).className).not.toContain('active');
+    expect(container.querySelector('.session-terminal-workspace')
+      ?.getAttribute('data-active-leaf-id')).toBe('tile-notes');
+    const tileBody = tile.querySelector('.workspace-dock-tile-body') as HTMLElement;
+    expect(document.activeElement).toBe(tileBody);
+  });
+
+  // Clicking back onto the terminal returns the focus display to the pane. The
+  // pane's own focus goes through onFocusPane (activePaneId is owned upstream),
+  // so the assertion here is the callback plus the chrome.
+  it('returns the active leaf to the terminal pane when it is clicked', () => {
+    const { container, onFocusPane } = renderSplit();
+
+    fireEvent.mouseDown(tileEl(container));
+    expect(tileEl(container).className).toContain('active');
+
+    fireEvent.mouseDown(paneEl(container));
+
+    expect(onFocusPane).toHaveBeenCalledWith('pane-term');
+    expect(tileEl(container).className).not.toContain('active');
+    expect(paneEl(container).className).toContain('active');
+  });
+});
 
 describe('SessionTerminalWorkspace Cmd+W closes the focused leaf', () => {
   // Regression: Cmd+W from inside a docked notebook tile used to close the
@@ -97,26 +148,25 @@ describe('SessionTerminalWorkspace Cmd+W closes the focused leaf', () => {
   it('undocks the focused tile instead of closing the active terminal pane', () => {
     const { container, onClosePane, onUndockTile } = renderSplit();
 
-    const tile = container.querySelector('[data-pane-kind="tile"]');
-    expect(tile?.getAttribute('data-pane-id')).toBe('tile-notes');
-    const tileBody = tile?.querySelector('.workspace-dock-tile-body') as HTMLElement;
-    expect(tileBody).toBeTruthy();
-    tileBody.focus();
+    const tile = tileEl(container);
+    fireEvent.mouseDown(tile);
 
-    fireEvent.keyDown(tileBody, { key: 'w', metaKey: true });
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'w', metaKey: true });
 
     expect(onUndockTile).toHaveBeenCalledTimes(1);
     expect(onUndockTile).toHaveBeenCalledWith('tile-notes');
     expect(onClosePane).not.toHaveBeenCalled();
   });
 
-  // The terminal-pane path is unchanged: Cmd+W with focus on a terminal pane
-  // closes that pane (activePaneId), never the tile.
-  it('closes the active terminal pane when focus is not inside a tile', () => {
+  // The terminal-pane path is unchanged: Cmd+W with the pane focused closes that
+  // pane, never the tile — including after a tile visit.
+  it('closes the active terminal pane when the pane is the focused leaf', () => {
     const { container, onClosePane, onUndockTile } = renderSplit();
 
-    const pane = container.querySelector('[data-pane-kind="agent"]') as HTMLElement;
-    expect(pane?.getAttribute('data-pane-id')).toBe('pane-term');
+    const pane = paneEl(container);
+    expect(pane.getAttribute('data-pane-id')).toBe('pane-term');
+    fireEvent.mouseDown(tileEl(container));
+    fireEvent.mouseDown(pane);
 
     fireEvent.keyDown(pane, { key: 'w', metaKey: true });
 

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
@@ -104,6 +104,30 @@
   opacity: 1;
 }
 
+/* Focus display for the active leaf: an inset accent ring on the leaf frame plus
+   an accented header, applied identically to terminal panes and docked tiles so
+   there is one focus vocabulary across leaf kinds. Both signals appear only when
+   more than one leaf is on screen — with a single leaf there is nothing to
+   disambiguate. Tile bodies deliberately stay at full opacity: a docked doc is
+   read while typing in the terminal, so dimming its prose would be a bad focus
+   signal. */
+.session-terminal-workspace.multi-leaf .workspace-pane.active {
+  box-shadow: inset 0 0 0 1px rgba(255, 107, 53, 0.45);
+}
+
+.session-terminal-workspace.multi-leaf .workspace-pane.active .workspace-pane-header,
+.session-terminal-workspace.multi-leaf .workspace-pane.active .workspace-dock-tile-header {
+  background:
+    linear-gradient(90deg, rgba(255, 107, 53, 0.2), rgba(255, 107, 53, 0.06)),
+    var(--color-bg-elevated, var(--color-bg-editor));
+  border-bottom-color: rgba(255, 107, 53, 0.42);
+}
+
+.session-terminal-workspace.multi-leaf .workspace-pane.active .workspace-pane-title,
+.session-terminal-workspace.multi-leaf .workspace-pane.active .workspace-dock-tile-title {
+  color: var(--color-text-primary);
+}
+
 .session-terminal-panes > .workspace-pane {
   position: absolute;
   box-sizing: border-box;

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -6,8 +6,8 @@ import {
   getNormalizedPaneBounds,
   getSplitDividers,
   applyRatioOverrides,
-  hasPane,
-  findPaneInDirection,
+  hasLeaf,
+  findLeafInDirection,
   leafSlotId,
   tileContentKey,
   type SplitDivider,
@@ -56,16 +56,16 @@ function suppressTerminalMouseDuringResize(durationMs = RESIZE_MOUSE_SUPPRESSION
   );
 }
 
-function zoomLayoutTowardPane(node: TerminalLayoutNode, paneId: string): TerminalLayoutNode {
+function zoomLayoutTowardLeaf(node: TerminalLayoutNode, leafId: string): TerminalLayoutNode {
   if (node.type !== 'split') {
     return node;
   }
 
-  const firstContainsPane = hasPane(node.children[0], paneId);
-  const secondContainsPane = hasPane(node.children[1], paneId);
+  const firstContainsPane = hasLeaf(node.children[0], leafId);
+  const secondContainsPane = hasLeaf(node.children[1], leafId);
   const nextChildren: [TerminalLayoutNode, TerminalLayoutNode] = [
-    zoomLayoutTowardPane(node.children[0], paneId),
-    zoomLayoutTowardPane(node.children[1], paneId),
+    zoomLayoutTowardLeaf(node.children[0], leafId),
+    zoomLayoutTowardLeaf(node.children[1], leafId),
   ];
 
   if (!firstContainsPane && !secondContainsPane) {
@@ -226,8 +226,13 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     allowLocalTileTargets = true,
     onRequestTileContent,
   }, ref) {
-    const [maximizedPaneId, setMaximizedPaneId] = useState<string | null>(null);
-    const [zoomedPaneId, setZoomedPaneId] = useState<string | null>(null);
+    const [maximizedLeafId, setMaximizedLeafId] = useState<string | null>(null);
+    const [zoomedLeafId, setZoomedLeafId] = useState<string | null>(null);
+    // The docked tile that currently owns workspace focus, or null when a
+    // terminal pane does. `activePaneId` is derived from the focused session, so
+    // it can only ever name an agent pane; this is the other half of the focus
+    // model, and the two combine into `activeLeafId` below.
+    const [activeTileId, setActiveTileId] = useState<string | null>(null);
     // The agent pane whose bound-ticket overlay is open (one per workspace at a
     // time), or null. Pane-scoped and non-modal — not part of blockingOverlayOpen.
     const [ticketOverlayPaneId, setTicketOverlayPaneId] = useState<string | null>(null);
@@ -247,9 +252,11 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     const [dockTarget, setDockTarget] = useState<DockTarget | null>(null);
     const [ghostPos, setGhostPos] = useState<{ x: number; y: number } | null>(null);
     const tileDragCleanupRef = useRef<(() => void) | null>(null);
-    // Scrollable body of the first docked tile, focused on select when the
-    // workspace has no terminal to own focus (see the focus effect below).
-    const firstTileBodyRef = useRef<HTMLDivElement | null>(null);
+    // Scrollable body of every docked tile, keyed by tile id. Focusing one is
+    // how a tile takes real DOM focus (keyboard scrolling, ⌘Enter send, and the
+    // shortcut dispatcher's terminal-target check all depend on it).
+    const tileBodyRefs = useRef(new Map<string, HTMLDivElement>());
+    const tileBodyRefCallbacks = useRef(new Map<string, (node: HTMLDivElement | null) => void>());
     const panesContainerRef = useRef<HTMLDivElement | null>(null);
     const draggingSplitRef = useRef<string | null>(null);
     const activePaneIdRef = useRef(activePaneId);
@@ -331,12 +338,26 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       return map;
     }, [workspace.layoutTree]);
 
-    // First tile in tree order (DFS-left). Used only to route the select-time
-    // focus ref to a single tile when the workspace is fully tile-only.
+    // First tile in tree order (DFS-left). The focus fallback for a workspace
+    // with no terminal pane to own focus.
     const firstTileId = useMemo(
       () => (tileLeafById.size > 0 ? tileLeafById.keys().next().value ?? null : null),
       [tileLeafById],
     );
+
+    // The focused leaf. A tile wins while one is focused; otherwise the
+    // session-derived active pane; otherwise (a tile-only workspace) the first
+    // tile. Every leaf-scoped action — close, zoom, maximize, directional
+    // navigation — and the `active` focus chrome key off this, not activePaneId.
+    const focusedTileId = activeTileId && tileLeafById.has(activeTileId) ? activeTileId : null;
+    const activeLeafId = focusedTileId || activePaneId || firstTileId || '';
+    const activeLeafIsTile = tileLeafById.has(activeLeafId);
+
+    // Session-derived pane focus moving (sidebar select, pane click, close)
+    // takes focus back from any tile.
+    useEffect(() => {
+      setActiveTileId(null);
+    }, [activePaneId]);
 
     const runtimePanes = useMemo(() => ([
       ...agentPanes.filter((pane) => !pane.status || pane.status === 'ready').map((pane) => {
@@ -390,8 +411,13 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     // workspace holds more than one leaf — including tiles, so a lone pane sharing
     // space with a docked tile is still draggable.
     const showPaneHeader = paneIds.length + tileLeafById.size > 1;
-    const effectivePaneId = maximizedPaneId && paneIds.includes(maximizedPaneId) ? maximizedPaneId : null;
-    const effectiveZoomedPaneId = zoomedPaneId && paneIds.includes(zoomedPaneId) ? zoomedPaneId : null;
+    // Every leaf slot in the layout — panes and tiles both zoom and maximize.
+    const leafIds = useMemo(
+      () => [...paneIds, ...tileLeafById.keys()],
+      [paneIds, tileLeafById],
+    );
+    const effectivePaneId = maximizedLeafId && leafIds.includes(maximizedLeafId) ? maximizedLeafId : null;
+    const effectiveZoomedPaneId = zoomedLeafId && leafIds.includes(zoomedLeafId) ? zoomedLeafId : null;
     const baseLayoutTree = useMemo(() => (
       workspace.layoutTree ? applyRatioOverrides(workspace.layoutTree, ratioOverrides) : null
     ), [workspace.layoutTree, ratioOverrides]);
@@ -400,13 +426,16 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
         return null;
       }
       if (effectivePaneId) {
-        return { type: 'pane', paneId: effectivePaneId } satisfies TerminalLayoutNode;
+        // Maximizing renders the leaf alone: its own tile node when it is a
+        // tile, so the tile keeps its identity (params, session binding).
+        return tileLeafById.get(effectivePaneId)
+          ?? ({ type: 'pane', paneId: effectivePaneId } satisfies TerminalLayoutNode);
       }
       if (!effectiveZoomedPaneId) {
         return baseLayoutTree;
       }
-      return zoomLayoutTowardPane(baseLayoutTree, effectiveZoomedPaneId);
-    }, [effectivePaneId, effectiveZoomedPaneId, baseLayoutTree]);
+      return zoomLayoutTowardLeaf(baseLayoutTree, effectiveZoomedPaneId);
+    }, [effectivePaneId, effectiveZoomedPaneId, baseLayoutTree, tileLeafById]);
 
     const clearRatioOverride = useCallback((splitId: string, expectedRatio?: number) => {
       setRatioOverrides((prev) => {
@@ -499,22 +528,22 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     }), [activePaneId, renderedPaneBounds, runtime]);
 
     useEffect(() => {
-      if (!maximizedPaneId) {
+      if (!maximizedLeafId) {
         return;
       }
-      if (!paneIds.includes(maximizedPaneId)) {
-        setMaximizedPaneId(null);
+      if (!leafIds.includes(maximizedLeafId)) {
+        setMaximizedLeafId(null);
       }
-    }, [maximizedPaneId, paneIds]);
+    }, [maximizedLeafId, leafIds]);
 
     useEffect(() => {
-      if (!zoomedPaneId) {
+      if (!zoomedLeafId) {
         return;
       }
-      if (!paneIds.includes(zoomedPaneId)) {
-        setZoomedPaneId(null);
+      if (!leafIds.includes(zoomedLeafId)) {
+        setZoomedLeafId(null);
       }
-    }, [paneIds, zoomedPaneId]);
+    }, [leafIds, zoomedLeafId]);
 
     // Close the ticket overlay if its pane leaves the layout (e.g. the pane was
     // closed while the overlay was open), mirroring the maximizedPaneId cleanup.
@@ -531,10 +560,10 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       if (!effectiveZoomedPaneId || effectivePaneId) {
         return;
       }
-      if (effectiveZoomedPaneId !== activePaneId) {
-        setZoomedPaneId(activePaneId);
+      if (effectiveZoomedPaneId !== activeLeafId) {
+        setZoomedLeafId(activeLeafId);
       }
-    }, [activePaneId, effectivePaneId, effectiveZoomedPaneId]);
+    }, [activeLeafId, effectivePaneId, effectiveZoomedPaneId]);
 
     useEffect(() => {
       onZoomModeChange?.(Boolean(effectiveZoomedPaneId));
@@ -558,23 +587,41 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     // with the board surface and other overlays.
     useEscapeStack(closeTicketOverlay, ticketOverlayPaneId !== null);
 
-    // A fully tile-only workspace has no terminal to own focus. Focus the first
-    // tile's scrollable body so keyboard scrolling works the moment it is shown.
-    // preventScroll keeps the body's own scroll position from jumping on focus.
-    const focusFirstTile = useCallback(() => {
-      firstTileBodyRef.current?.focus({ preventScroll: true });
+    // Focusing a tile means focusing its scrollable body: that is what enables
+    // keyboard scrolling, satisfies the shortcut dispatcher's terminal-target
+    // check (so ⌘W reaches the workspace instead of falling through to
+    // session.close), and lets the tile's own focus-within gates arm.
+    // preventScroll keeps the body's scroll position from jumping on focus.
+    const focusTile = useCallback((tileId: string) => {
+      tileBodyRefs.current.get(tileId)?.focus({ preventScroll: true });
+    }, []);
+
+    const tileBodyRefFor = useCallback((tileId: string) => {
+      const existing = tileBodyRefCallbacks.current.get(tileId);
+      if (existing) return existing;
+      const callback = (node: HTMLDivElement | null) => {
+        if (node) {
+          tileBodyRefs.current.set(tileId, node);
+        } else {
+          tileBodyRefs.current.delete(tileId);
+        }
+      };
+      tileBodyRefCallbacks.current.set(tileId, callback);
+      return callback;
     }, []);
 
     useEffect(() => {
       if (!sessionVisible) {
         return;
       }
-      if (activePaneId) {
-        focusActivePane();
+      if (activeLeafIsTile) {
+        focusTile(activeLeafId);
         return;
       }
-      focusFirstTile();
-    }, [activePaneId, focusActivePane, focusFirstTile, focusRequestToken, isActiveSession, isSessionViewVisible, workspaceId, sessionVisible]);
+      if (activePaneId) {
+        focusActivePane();
+      }
+    }, [activeLeafId, activeLeafIsTile, activePaneId, focusActivePane, focusTile, focusRequestToken, isActiveSession, isSessionViewVisible, workspaceId, sessionVisible]);
 
     // After relaunch, first-show, or split topology changes, the terminal can briefly keep
     // stale narrow geometry from the previous layout. Re-fitting immediately and then
@@ -654,63 +701,68 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       return refitPanesNowAndIfStillWrong(movedPanes);
     }, [panePaths, refitPanesNowAndIfStillWrong, sessionVisible, workspaceTopologyKey]);
 
+    // Splitting is a terminal operation: the daemon splits beside an agent pane.
+    // With a tile focused there is no such anchor, so the shortcut does nothing
+    // rather than silently splitting whichever terminal was focused before.
     const handleSplit = useCallback((direction: TerminalSplitDirection) => {
-      onSplitPane(activePaneId, direction);
-    }, [activePaneId, onSplitPane]);
+      if (activeLeafIsTile || !activeLeafId) {
+        return;
+      }
+      onSplitPane(activeLeafId, direction);
+    }, [activeLeafId, activeLeafIsTile, onSplitPane]);
 
     const handleClosePane = useCallback((paneId: string) => {
       onClosePane(paneId);
     }, [onClosePane]);
 
-    // Cmd+W closes the focused leaf. A docked tile (e.g. a notebook tile beside a
-    // terminal) lives inside .session-terminal-workspace, so the global dispatcher
-    // routes its Cmd+W to terminal.close — but the tile is not a terminal pane and
-    // `activePaneId` still points at the terminal that was last focused. Without the
-    // tile check below, Cmd+W from inside the notebook would kill that previous pane
-    // (the reported bug). When focus is inside a tile, undock THAT tile instead.
+    // Cmd+W closes the focused leaf: undock a focused tile, close a focused pane.
     const handleCloseFocusedLeaf = useCallback(() => {
-      const focused = document.activeElement;
-      const tileEl = focused instanceof HTMLElement
-        ? focused.closest('[data-pane-kind="tile"]')
-        : null;
-      const tileId = tileEl?.getAttribute('data-pane-id');
-      if (tileId) {
-        onUndockTile?.(tileId);
+      if (!activeLeafId) {
         return;
       }
-      handleClosePane(activePaneId);
-    }, [activePaneId, handleClosePane, onUndockTile]);
+      if (activeLeafIsTile) {
+        onUndockTile?.(activeLeafId);
+        return;
+      }
+      handleClosePane(activeLeafId);
+    }, [activeLeafId, activeLeafIsTile, handleClosePane, onUndockTile]);
 
     const toggleMaximizeActivePane = useCallback(() => {
-      setZoomedPaneId(null);
-      setMaximizedPaneId((current) => (current ? null : activePaneId));
-    }, [activePaneId]);
+      setZoomedLeafId(null);
+      setMaximizedLeafId((current) => (current ? null : activeLeafId));
+    }, [activeLeafId]);
 
     const toggleZoomActivePane = useCallback(() => {
-      setMaximizedPaneId(null);
-      setZoomedPaneId((current) => (current === activePaneId ? null : activePaneId));
-    }, [activePaneId]);
+      setMaximizedLeafId(null);
+      setZoomedLeafId((current) => (current === activeLeafId ? null : activeLeafId));
+    }, [activeLeafId]);
 
-    const handleMovePane = useCallback((direction: TerminalNavigationDirection) => {
-      const visibleLayout: TerminalLayoutNode | null = effectivePaneId
-        ? { type: 'pane', paneId: effectivePaneId }
-        : renderedLayoutTree;
-      if (!visibleLayout) {
+    // Focus a leaf by id: a tile takes DOM focus in place (the session's pane
+    // focus is left alone), a pane goes through the session-level focus path.
+    const focusLeaf = useCallback((leafId: string) => {
+      if (tileLeafById.has(leafId)) {
+        setActiveTileId(leafId);
+        focusTile(leafId);
         return;
       }
-      const nextPaneId = findPaneInDirection(visibleLayout, activePaneId, direction);
-      if (nextPaneId) {
-        onFocusPane(nextPaneId);
-        runtime.focusPane(nextPaneId);
+      setActiveTileId(null);
+      onFocusPane(leafId);
+      runtime.focusPane(leafId);
+    }, [focusTile, onFocusPane, runtime, tileLeafById]);
+
+    const handleMovePane = useCallback((direction: TerminalNavigationDirection) => {
+      // In maximize mode renderedLayoutTree is already the lone visible leaf, so
+      // navigation off it correctly leaves the session.
+      if (!renderedLayoutTree) {
+        return;
+      }
+      const nextLeafId = findLeafInDirection(renderedLayoutTree, activeLeafId, direction);
+      if (nextLeafId) {
+        focusLeaf(nextLeafId);
         return;
       }
       onNavigateOutOfSession(direction);
-    }, [activePaneId, effectivePaneId, onFocusPane, onNavigateOutOfSession, renderedLayoutTree, runtime]);
-
-    const handleAgentPaneMouseDown = useCallback((paneId: string) => {
-      onFocusPane(paneId);
-      runtime.focusPane(paneId);
-    }, [onFocusPane, runtime]);
+    }, [activeLeafId, focusLeaf, onNavigateOutOfSession, renderedLayoutTree]);
 
     const focusPaneIfCurrentlyActive = useCallback((paneId: string) => {
       if (!isActiveSessionRef.current || !sessionViewVisibleRef.current || activePaneIdRef.current !== paneId) {
@@ -831,8 +883,8 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
         return (
           <div
             key={agentPane.id}
-            className={`workspace-pane ${activePaneId === agentPane.id ? 'active' : ''} ${effectiveDraggingLeafId === agentPane.id ? 'workspace-pane--dragging' : ''}`.trim()}
-            onMouseDown={() => handleAgentPaneMouseDown(agentPane.id)}
+            className={`workspace-pane ${activeLeafId === agentPane.id ? 'active' : ''} ${effectiveDraggingLeafId === agentPane.id ? 'workspace-pane--dragging' : ''}`.trim()}
+            onMouseDown={() => focusLeaf(agentPane.id)}
             data-pane-session-id={agentPane.sessionId}
             data-pane-id={agentPane.id}
             data-pane-kind="agent"
@@ -972,7 +1024,12 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
         return (
           <div
             key={`tile:${tileLeaf.tileId}`}
-            className="workspace-pane workspace-pane--tile"
+            className={`workspace-pane workspace-pane--tile ${activeLeafId === tileLeaf.tileId ? 'active' : ''}`.trim()}
+            // Clicking anywhere in the tile makes it the focused leaf, exactly
+            // like clicking a terminal pane. Focus then lands on whatever the
+            // click targets (the body, an input in the header) via the default
+            // action, so this never fights the click.
+            onMouseDown={() => focusLeaf(tileLeaf.tileId)}
             data-pane-id={tileLeaf.tileId}
             data-pane-kind="tile"
             data-tile-kind={tileLeaf.tileKind}
@@ -1001,7 +1058,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
               )}
               onHeaderPointerDown={(event) => beginLeafDrag(tileLeaf.tileId, event)}
               onRequestContent={onRequestTileContent ?? (() => {})}
-              bodyRef={tileLeaf.tileId === firstTileId ? firstTileBodyRef : undefined}
+              bodyRef={tileBodyRefFor(tileLeaf.tileId)}
             />
           </div>
         );
@@ -1010,6 +1067,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       return null;
     }, [
       activePaneId,
+      activeLeafId,
       beginLeafDrag,
       effectiveDraggingLeafId,
       onOpenMarkdown,
@@ -1017,7 +1075,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       onUpdateTile,
       tileLeafById,
       tileSessionOptions,
-      firstTileId,
+      tileBodyRefFor,
       tileContents,
       allowLocalTileTargets,
       onRequestTileContent,
@@ -1027,7 +1085,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       isActiveSession,
       isSessionViewVisible,
       enabled,
-      handleAgentPaneMouseDown,
+      focusLeaf,
       handleGhosttyTerminalReady,
       paneFrameStyle,
       panePaths,
@@ -1050,8 +1108,13 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       if (agentPane) {
         return sessionById.get(agentPane.sessionId)?.label || agentPane.title || 'Session';
       }
+      const tile = tileLeafById.get(effectivePaneId);
+      if (tile) {
+        const base = (tile.tileParams ?? '').split('/').filter(Boolean).pop();
+        return base || tile.tileKind || 'Tile';
+      }
       return 'Pane';
-    }, [agentPaneById, effectivePaneId, sessionById]);
+    }, [agentPaneById, effectivePaneId, sessionById, tileLeafById]);
 
     // Label shown in the drag ghost: the dragged leaf's session/title (pane) or
     // file name/kind (tile).
@@ -1237,6 +1300,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
           data-session-terminal-workspace={workspaceId}
           data-workspace-id={workspaceId}
           data-active-pane-id=""
+          data-active-leaf-id=""
           data-maximized-pane-id=""
           data-session-visible={sessionVisible ? '1' : '0'}
           data-zoomed-pane-id=""
@@ -1246,10 +1310,11 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
 
     return (
       <div
-        className={`session-terminal-workspace ${effectivePaneId ? 'focus-mode' : ''} ${effectiveZoomedPaneId && !effectivePaneId ? 'zoom-mode' : ''}`.trim()}
+        className={`session-terminal-workspace ${effectivePaneId ? 'focus-mode' : ''} ${effectiveZoomedPaneId && !effectivePaneId ? 'zoom-mode' : ''} ${renderedPaneIds.length > 1 ? 'multi-leaf' : ''}`.trim().replace(/\s+/g, ' ')}
         data-session-terminal-workspace={workspaceId}
         data-workspace-id={workspaceId}
         data-active-pane-id={activePaneId}
+        data-active-leaf-id={activeLeafId}
         data-maximized-pane-id={effectivePaneId || ''}
         data-session-visible={sessionVisible ? '1' : '0'}
         data-zoomed-pane-id={effectiveZoomedPaneId || ''}
@@ -1263,7 +1328,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
             <button
               type="button"
               className="workspace-focus-exit"
-              onClick={() => setMaximizedPaneId(null)}
+              onClick={() => setMaximizedLeafId(null)}
               title="Exit focus mode (⌘⇧Enter)"
             >
               Return to split

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -227,12 +227,14 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     onRequestTileContent,
   }, ref) {
     const [maximizedLeafId, setMaximizedLeafId] = useState<string | null>(null);
-    const [zoomedLeafId, setZoomedLeafId] = useState<string | null>(null);
+    // Zoom is a mode, not a target: it always widens whichever leaf is focused,
+    // so it is a flag rather than a leaf id that has to chase focus.
+    const [zoomActive, setZoomActive] = useState(false);
     // The docked tile that currently owns workspace focus, or null when a
     // terminal pane does. `activePaneId` is derived from the focused session, so
     // it can only ever name an agent pane; this is the other half of the focus
     // model, and the two combine into `activeLeafId` below.
-    const [activeTileId, setActiveTileId] = useState<string | null>(null);
+    const [activeTile, setActiveTile] = useState<{ tileId: string; whileActivePaneId: string } | null>(null);
     // The agent pane whose bound-ticket overlay is open (one per workspace at a
     // time), or null. Pane-scoped and non-modal — not part of blockingOverlayOpen.
     const [ticketOverlayPaneId, setTicketOverlayPaneId] = useState<string | null>(null);
@@ -349,15 +351,17 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     // session-derived active pane; otherwise (a tile-only workspace) the first
     // tile. Every leaf-scoped action — close, zoom, maximize, directional
     // navigation — and the `active` focus chrome key off this, not activePaneId.
-    const focusedTileId = activeTileId && tileLeafById.has(activeTileId) ? activeTileId : null;
+    // A focused tile is recorded against the pane that was active when it took
+    // focus, so session-derived pane focus moving (sidebar select, pane click,
+    // close) takes focus back from the tile by simply no longer matching — no
+    // reset effect, and no frame where the stale tile still reads as focused.
+    const focusedTileId = activeTile
+      && activeTile.whileActivePaneId === activePaneId
+      && tileLeafById.has(activeTile.tileId)
+      ? activeTile.tileId
+      : null;
     const activeLeafId = focusedTileId || activePaneId || firstTileId || '';
     const activeLeafIsTile = tileLeafById.has(activeLeafId);
-
-    // Session-derived pane focus moving (sidebar select, pane click, close)
-    // takes focus back from any tile.
-    useEffect(() => {
-      setActiveTileId(null);
-    }, [activePaneId]);
 
     const runtimePanes = useMemo(() => ([
       ...agentPanes.filter((pane) => !pane.status || pane.status === 'ready').map((pane) => {
@@ -417,7 +421,9 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       [paneIds, tileLeafById],
     );
     const effectivePaneId = maximizedLeafId && leafIds.includes(maximizedLeafId) ? maximizedLeafId : null;
-    const effectiveZoomedPaneId = zoomedLeafId && leafIds.includes(zoomedLeafId) ? zoomedLeafId : null;
+    // Zoom follows focus by construction: the widened leaf is the focused one,
+    // and it stops zooming on its own once that leaf leaves the layout.
+    const effectiveZoomedPaneId = zoomActive && leafIds.includes(activeLeafId) ? activeLeafId : null;
     const baseLayoutTree = useMemo(() => (
       workspace.layoutTree ? applyRatioOverrides(workspace.layoutTree, ratioOverrides) : null
     ), [workspace.layoutTree, ratioOverrides]);
@@ -536,15 +542,6 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       }
     }, [maximizedLeafId, leafIds]);
 
-    useEffect(() => {
-      if (!zoomedLeafId) {
-        return;
-      }
-      if (!leafIds.includes(zoomedLeafId)) {
-        setZoomedLeafId(null);
-      }
-    }, [leafIds, zoomedLeafId]);
-
     // Close the ticket overlay if its pane leaves the layout (e.g. the pane was
     // closed while the overlay was open), mirroring the maximizedPaneId cleanup.
     useEffect(() => {
@@ -555,15 +552,6 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
         setTicketOverlayPaneId(null);
       }
     }, [paneIds, ticketOverlayPaneId]);
-
-    useEffect(() => {
-      if (!effectiveZoomedPaneId || effectivePaneId) {
-        return;
-      }
-      if (effectiveZoomedPaneId !== activeLeafId) {
-        setZoomedLeafId(activeLeafId);
-      }
-    }, [activeLeafId, effectivePaneId, effectiveZoomedPaneId]);
 
     useEffect(() => {
       onZoomModeChange?.(Boolean(effectiveZoomedPaneId));
@@ -728,27 +716,27 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     }, [activeLeafId, activeLeafIsTile, handleClosePane, onUndockTile]);
 
     const toggleMaximizeActivePane = useCallback(() => {
-      setZoomedLeafId(null);
+      setZoomActive(false);
       setMaximizedLeafId((current) => (current ? null : activeLeafId));
     }, [activeLeafId]);
 
     const toggleZoomActivePane = useCallback(() => {
       setMaximizedLeafId(null);
-      setZoomedLeafId((current) => (current === activeLeafId ? null : activeLeafId));
-    }, [activeLeafId]);
+      setZoomActive((current) => !current);
+    }, []);
 
     // Focus a leaf by id: a tile takes DOM focus in place (the session's pane
     // focus is left alone), a pane goes through the session-level focus path.
     const focusLeaf = useCallback((leafId: string) => {
       if (tileLeafById.has(leafId)) {
-        setActiveTileId(leafId);
+        setActiveTile({ tileId: leafId, whileActivePaneId: activePaneId });
         focusTile(leafId);
         return;
       }
-      setActiveTileId(null);
+      setActiveTile(null);
       onFocusPane(leafId);
       runtime.focusPane(leafId);
-    }, [focusTile, onFocusPane, runtime, tileLeafById]);
+    }, [activePaneId, focusTile, onFocusPane, runtime, tileLeafById]);
 
     const handleMovePane = useCallback((direction: TerminalNavigationDirection) => {
       // In maximize mode renderedLayoutTree is already the lone visible leaf, so

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -235,6 +235,9 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     // it can only ever name an agent pane; this is the other half of the focus
     // model, and the two combine into `activeLeafId` below.
     const [activeTile, setActiveTile] = useState<{ tileId: string; whileActivePaneId: string } | null>(null);
+    // Bumped when a terminal announces readiness; re-runs the leaf focus effect so
+    // the committed active leaf, not the mounting terminal, decides where focus goes.
+    const [paneReadyFocusRequest, setPaneReadyFocusRequest] = useState(0);
     // The agent pane whose bound-ticket overlay is open (one per workspace at a
     // time), or null. Pane-scoped and non-modal — not part of blockingOverlayOpen.
     const [ticketOverlayPaneId, setTicketOverlayPaneId] = useState<string | null>(null);
@@ -264,7 +267,6 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     const activePaneIdRef = useRef(activePaneId);
     const isActiveSessionRef = useRef(isActiveSession);
     const sessionViewVisibleRef = useRef(isSessionViewVisible);
-    const activeLeafIsTileRef = useRef(false);
 
     activePaneIdRef.current = activePaneId;
     isActiveSessionRef.current = isActiveSession;
@@ -365,7 +367,6 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       : null;
     const activeLeafId = focusedTileId || activePaneId || firstTileId || '';
     const activeLeafIsTile = tileLeafById.has(activeLeafId);
-    activeLeafIsTileRef.current = activeLeafIsTile;
 
     const runtimePanes = useMemo(() => ([
       ...agentPanes.filter((pane) => !pane.status || pane.status === 'ready').map((pane) => {
@@ -619,7 +620,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       if (activePaneId) {
         focusActivePane();
       }
-    }, [activeLeafId, activeLeafIsTile, activePaneId, focusActivePane, focusTile, focusRequestToken, isActiveSession, isSessionViewVisible, workspaceId, sessionVisible]);
+    }, [activeLeafId, activeLeafIsTile, activePaneId, focusActivePane, focusTile, focusRequestToken, isActiveSession, isSessionViewVisible, paneReadyFocusRequest, workspaceId, sessionVisible]);
 
     // After relaunch, first-show, or split topology changes, the terminal can briefly keep
     // stale narrow geometry from the previous layout. Re-fitting immediately and then
@@ -762,23 +763,24 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       onNavigateOutOfSession(direction);
     }, [activeLeafId, focusLeaf, onNavigateOutOfSession, renderedLayoutTree]);
 
-    // A terminal mounting must not pull focus out of a tile the user is reading:
-    // it would leave DOM focus and the active leaf disagreeing, which is exactly
-    // what makes Cmd+W act on the wrong leaf.
-    const focusPaneIfCurrentlyActive = useCallback((paneId: string) => {
+    // A mounting terminal asks for focus, it does not take it: the leaf effect
+    // above owns the decision and reads committed state, so a terminal that comes
+    // back while a tile is the focused leaf leaves the tile alone. Deciding here
+    // instead would mean reading leaf state from a ref that a child's ready
+    // callback can observe before the parent has mirrored it, leaving DOM focus
+    // and the active leaf disagreeing — which is what makes Cmd+W act on the
+    // wrong leaf.
+    const requestFocusForReadyPane = useCallback((paneId: string) => {
       if (!isActiveSessionRef.current || !sessionViewVisibleRef.current || activePaneIdRef.current !== paneId) {
         return;
       }
-      if (activeLeafIsTileRef.current) {
-        return;
-      }
-      runtime.focusPane(paneId);
-    }, [runtime]);
+      setPaneReadyFocusRequest((token) => token + 1);
+    }, []);
 
     const handleGhosttyTerminalReady = useCallback((paneId: string) => (terminal: GhosttyTerminalHandle) => {
       void runtime.handleTerminalReady(paneId)(terminal);
-      focusPaneIfCurrentlyActive(paneId);
-    }, [focusPaneIfCurrentlyActive, runtime]);
+      requestFocusForReadyPane(paneId);
+    }, [requestFocusForReadyPane, runtime]);
 
     useShortcut('terminal.open', focusActivePane, sessionVisible);
     useShortcut('terminal.find', () => { runtime.openFindInActivePane(); }, sessionVisible);

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -264,9 +264,12 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     const activePaneIdRef = useRef(activePaneId);
     const isActiveSessionRef = useRef(isActiveSession);
     const sessionViewVisibleRef = useRef(isSessionViewVisible);
+    const activeLeafIsTileRef = useRef(false);
 
     activePaneIdRef.current = activePaneId;
     isActiveSessionRef.current = isActiveSession;
+    // Read by callbacks that fire outside render (terminal ready) to avoid
+    // stealing focus from a focused tile.
     sessionViewVisibleRef.current = isSessionViewVisible;
 
     const paneIds = useMemo(() => {
@@ -362,6 +365,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       : null;
     const activeLeafId = focusedTileId || activePaneId || firstTileId || '';
     const activeLeafIsTile = tileLeafById.has(activeLeafId);
+    activeLeafIsTileRef.current = activeLeafIsTile;
 
     const runtimePanes = useMemo(() => ([
       ...agentPanes.filter((pane) => !pane.status || pane.status === 'ready').map((pane) => {
@@ -557,7 +561,13 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       onZoomModeChange?.(Boolean(effectiveZoomedPaneId));
     }, [effectiveZoomedPaneId, onZoomModeChange]);
 
+    // Focusing the terminal is a leaf handoff, not just a DOM focus call: it
+    // has to release any focused tile. `activePaneId` does not change here (the
+    // pane was already the session's active one), so without the release the
+    // tile would stay the active leaf and Cmd+W would undock it while you are
+    // typing in the terminal.
     const focusActivePane = useCallback(() => {
+      setActiveTile(null);
       // Single attempt — terminal is already mounted in every case this fires.
       runtime.focusPane(activePaneId, 0);
     }, [activePaneId, runtime]);
@@ -752,8 +762,14 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       onNavigateOutOfSession(direction);
     }, [activeLeafId, focusLeaf, onNavigateOutOfSession, renderedLayoutTree]);
 
+    // A terminal mounting must not pull focus out of a tile the user is reading:
+    // it would leave DOM focus and the active leaf disagreeing, which is exactly
+    // what makes Cmd+W act on the wrong leaf.
     const focusPaneIfCurrentlyActive = useCallback((paneId: string) => {
       if (!isActiveSessionRef.current || !sessionViewVisibleRef.current || activePaneIdRef.current !== paneId) {
+        return;
+      }
+      if (activeLeafIsTileRef.current) {
         return;
       }
       runtime.focusPane(paneId);

--- a/app/src/types/workspace.test.ts
+++ b/app/src/types/workspace.test.ts
@@ -3,10 +3,12 @@ import { WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus } from './generated'
 import {
   applyRatioOverrides,
   collectSplitRatios,
+  findLeafInDirection,
   findPaneInDirection,
   findTileByKind,
   getNormalizedPaneBounds,
   getSplitDividers,
+  hasLeaf,
   hasPane,
   localWorkspaceDirectory,
   soleWorkspaceForId,
@@ -209,9 +211,21 @@ describe('docked tiles', () => {
     expect(findPaneInDirection(paneWithTile, 'md', 'left')).toBeNull();
   });
 
-  it('hasPane never matches a tile id', () => {
+  it('navigates into and out of a tile as a focus target', () => {
+    // Focus navigation treats a docked tile as a leaf like any other: right from
+    // 'a' lands on the tile, and moving on from the tile reaches 'b'.
+    expect(findLeafInDirection(paneWithTile, 'a', 'right')).toBe('md');
+    expect(findLeafInDirection(paneWithTile, 'md', 'right')).toBe('b');
+    expect(findLeafInDirection(paneWithTile, 'md', 'left')).toBe('a');
+    expect(findLeafInDirection(paneWithTile, 'b', 'left')).toBe('md');
+  });
+
+  it('hasPane never matches a tile id, hasLeaf does', () => {
     expect(hasPane(paneWithTile, 'md')).toBe(false);
     expect(hasPane(paneWithTile, 'a')).toBe(true);
+    expect(hasLeaf(paneWithTile, 'md')).toBe(true);
+    expect(hasLeaf(paneWithTile, 'a')).toBe(true);
+    expect(hasLeaf(paneWithTile, 'missing')).toBe(false);
   });
 
   it('findTileByKind locates a docked tile', () => {

--- a/app/src/types/workspace.ts
+++ b/app/src/types/workspace.ts
@@ -144,6 +144,16 @@ export function hasPane(node: TerminalLayoutNode, paneId: string): boolean {
   return hasPane(node.children[0], paneId) || hasPane(node.children[1], paneId);
 }
 
+// hasLeaf is hasPane widened to the whole focus model: any leaf slot, terminal
+// pane or docked tile. Callers that must resolve to a session-bearing pane
+// (daemon active pane, close-pane focus fallback) keep using hasPane.
+export function hasLeaf(node: TerminalLayoutNode, leafId: string): boolean {
+  if (node.type !== 'split') {
+    return leafSlotId(node) === leafId;
+  }
+  return hasLeaf(node.children[0], leafId) || hasLeaf(node.children[1], leafId);
+}
+
 function paneBounds(
   left: number,
   top: number,
@@ -290,18 +300,39 @@ function overlapSize(aStart: number, aEnd: number, bStart: number, bEnd: number)
   return Math.max(0, Math.min(aEnd, bEnd) - Math.max(aStart, bStart));
 }
 
+// findLeafInDirection moves focus between any two leaf slots — terminal panes
+// and docked tiles alike. This is the workspace's focus navigation: a docked
+// markdown tile is a focus target like any pane.
+export function findLeafInDirection(
+  node: TerminalLayoutNode,
+  fromLeafId: string,
+  direction: TerminalNavigationDirection
+): string | null {
+  return findInDirection(node, fromLeafId, direction, null);
+}
+
+// findPaneInDirection is the pane-only variant, for callers that must resolve
+// to a session-bearing terminal (e.g. picking the next active pane after a
+// close) rather than to whatever leaf sits next to it.
 export function findPaneInDirection(
   node: TerminalLayoutNode,
   fromPaneId: string,
   direction: TerminalNavigationDirection
 ): string | null {
+  return findInDirection(node, fromPaneId, direction, 'pane');
+}
+
+function findInDirection(
+  node: TerminalLayoutNode,
+  fromPaneId: string,
+  direction: TerminalNavigationDirection,
+  onlyKind: LeafKind | null
+): string | null {
   const leaves = new Map<string, LeafBounds>();
   collectLeafBounds(node, paneBounds(0, 0, 1, 1), leaves);
-  // Navigation only moves between terminal panes — docked tiles are not focus
-  // targets.
   const rects = new Map<string, PaneBounds>();
   for (const [slotId, { bounds, kind }] of leaves) {
-    if (kind === 'pane') {
+    if (!onlyKind || kind === onlyKind) {
       rects.set(slotId, bounds);
     }
   }

--- a/docs/decisions/2026-05-31-docked-tiles.md
+++ b/docs/decisions/2026-05-31-docked-tiles.md
@@ -113,7 +113,20 @@ authoritative.
   can't reproduce the same configuration across clients/screen sizes. Dragging a
   tile shows a transient ghost + target highlight and always lands docked; a
   drop outside any pane is a no-op (the tile stays where it was).
-- **Terminal arrow-key navigation skips tiles.** A tile is not a focus target.
+- **A docked tile is a focus target, like a terminal pane.** Focus is a property
+  of a *leaf*, not of a session: the workspace's focused leaf is whichever
+  pane or tile the user last clicked or navigated to, and every leaf-scoped
+  action — ⌘W close, ⌘⇧Enter zoom/maximize, ⌘⌥arrow navigation, the focus
+  chrome — targets it. Focusing a tile does not change which session is active
+  (a tile has no session of its own; markdown tiles only carry a Send binding),
+  so `activePaneId` stays session-derived and agent-pane-only, and the frontend
+  combines the two into the workspace's active leaf. Splitting (⌘D) stays
+  terminal-only: the daemon splits beside an agent pane, so the shortcut is
+  inert while a tile is focused rather than acting on some other terminal.
+  (Revises the original rule, which excluded tiles from navigation and focus
+  entirely. That made a docked file unclosable by ⌘W — the key acted on the
+  terminal focused before it — and left no way to tell which leaf had the
+  keyboard.)
 - Dropping onto a terminal docks on that terminal's nearest edge; dropping near
   the border between two terminals slots the tile between them.
 


### PR DESCRIPTION
When an agent opens a markdown file into the workspace, the resulting tile could not be focused. Workspace focus was an agent-pane-only model: `activePaneId` is derived from the focused session, `findPaneInDirection` filtered tiles out of navigation, and CSS pinned tiles at full opacity so the app's only focus affordance never applied to them.

The consequences went well past the reported symptom:

- ⌘W acted on whichever terminal was focused before the tile — or, when the click landed DOM focus outside the workspace, fell through to `session.close` and killed the session.
- ⌘⌥arrows skipped tiles entirely, in and out.
- ⌘⇧Enter could not zoom or maximize a tile.
- ⌘Enter (send markdown annotations) is registration-gated on focus-within, so it was not even armed unless focus happened to land inside the tile.
- Keyboard scrolling of a tile body only worked in a workspace with no terminal at all.
- Nothing in the UI said which leaf had the keyboard.

## What changed

**Focus is now a property of a leaf, not of a session.** The workspace resolves an active leaf — the focused tile, else the session-derived active pane, else the first tile — and every leaf-scoped action targets it: close, zoom, maximize, directional navigation, and the focus chrome. Focusing a tile does not change which session is active (a tile has no session of its own; markdown tiles only carry a Send binding), so `activePaneId` stays session-derived and agent-pane-only and the two combine in the workspace view.

Splitting stays terminal-only: the daemon splits beside an agent pane, so ⌘D is inert while a tile is focused rather than acting on some other terminal.

Each tile now gets a body ref, so a plain click puts real DOM focus inside the tile. That is also what makes the shortcut dispatcher route ⌘W to the workspace rather than letting it fall through to `session.close`. The native ⌘W path in `App.tsx` additionally falls back to the workspace's `data-active-leaf-id` when focus is in the workspace but not inside the tile subtree.

`hasLeaf` and `findLeafInDirection` are new. `hasPane` and `findPaneInDirection` remain for the callers that must resolve to a session-bearing terminal (daemon active pane, close-pane focus fallback).

**Focus display.** The focused leaf is marked rather than merely undimmed: an inset accent ring on the leaf frame plus an accented header, applied identically to terminals and docked tiles so there is one focus vocabulary across leaf kinds. Both signals appear only when more than one leaf is on screen. Tile bodies stay at full opacity — a docked document is read while typing in the terminal, so dimming its prose would be a bad focus signal.

`docs/decisions/2026-05-31-docked-tiles.md` stated the old rule ("Terminal arrow-key navigation skips tiles. A tile is not a focus target") and is revised.

## Verification

Live, in the packaged `attn-dev` app (preflight clean), driving the daemon's real `open_markdown` — the command a ⌘-click on a terminal path issues:

- clicking the tile's prose gives its body DOM focus and moves the focus chrome off the terminal; clicking the terminal takes it back;
- ⌘⌥→ / ⌘⌥← cross into and out of the tile;
- ⌘⇧Enter renders the tile alone, with the focus bar naming the file;
- native ⌘W undocks the tile, with the terminal pane and session intact.

`real-app:scenario-notebook-tile-close` (native menu → `session.close` → undock) still passes. Full frontend unit suite green. The existing ⌘W regression test no longer forces focus with `tileBody.focus()` — it clicks, which is the gesture the old model could not survive; added coverage for the active-leaf chrome moving between pane and tile, and for leaf-vs-pane directional navigation.

https://claude.ai/code/session_01XzfHadX7TYFCtSFTUbjgmU