### PR TITLE
fix: selection highlight border hidden on terminal panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-07-27]
 
 ### Fixed
+- **The focus ring around a terminal pane is visible on all four sides again,
+  even with a ticket open.** It was painted as an inset box-shadow, which draws
+  beneath a pane's children — so the terminal's opaque background covered the
+  ring's left, right, and bottom edges, leaving only the header's accent border
+  visible. It is now a `::after` overlay layered above everything in the pane,
+  including the bound-ticket detail overlay, so focus always has one visible
+  owner regardless of what the pane is showing.
 - **A docked markdown file can now be focused like any terminal pane.** Focus in
   a workspace used to belong to terminals only, so a markdown or notebook tile —
   the surface an agent opens when it shows you a file — could never be the

--- a/app/e2e/pane-focus-ring.spec.ts
+++ b/app/e2e/pane-focus-ring.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+// Regression witness for the SessionTerminalWorkspace focus-ring z-index bug:
+// the active-pane `::after` ring must paint above any pane-local overlay
+// (currently the bound-ticket overlay), on the real stylesheet, in a real
+// browser — a stacking bug jsdom/happy-dom cannot see since neither applies
+// the component's CSS file. See SessionTerminalWorkspace.css.
+test('active-pane focus ring paints above the ticket overlay', async ({ page }) => {
+  await page.goto('/test-harness/?component=PaneFocusRing');
+  await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+
+  const pane = page.locator('[data-testid="pane-active"]');
+  const overlay = page.locator('[data-testid="ticket-overlay"]');
+  await expect(overlay).toBeVisible();
+
+  const [paneZ, overlayZ] = await Promise.all([
+    pane.evaluate((el) => getComputedStyle(el, '::after').zIndex),
+    overlay.evaluate((el) => getComputedStyle(el).zIndex),
+  ]);
+  expect(Number(paneZ)).toBeGreaterThan(Number(overlayZ));
+});

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
@@ -111,8 +111,14 @@
    disambiguate. Tile bodies deliberately stay at full opacity: a docked doc is
    read while typing in the terminal, so dimming its prose would be a bad focus
    signal. */
-.session-terminal-workspace.multi-leaf .workspace-pane.active {
-  box-shadow: inset 0 0 0 1px rgba(255, 107, 53, 0.45);
+.session-terminal-workspace.multi-leaf .workspace-pane.active::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border: 1px solid rgba(255, 107, 53, 0.45);
+  border-radius: inherit;
+  pointer-events: none;
+  z-index: 1;
 }
 
 .session-terminal-workspace.multi-leaf .workspace-pane.active .workspace-pane-header,

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
@@ -110,7 +110,12 @@
    more than one leaf is on screen — with a single leaf there is nothing to
    disambiguate. Tile bodies deliberately stay at full opacity: a docked doc is
    read while typing in the terminal, so dimming its prose would be a bad focus
-   signal. */
+   signal.
+
+   z-index sits above every pane-local overlay (currently just
+   .workspace-pane-ticket-overlay at z-index: 5) so the ring stays the single,
+   unambiguous focus signal regardless of what a pane is showing internally —
+   raise this again if a future overlay needs to sit higher than 5. */
 .session-terminal-workspace.multi-leaf .workspace-pane.active::after {
   content: '';
   position: absolute;
@@ -118,7 +123,7 @@
   border: 1px solid rgba(255, 107, 53, 0.45);
   border-radius: inherit;
   pointer-events: none;
-  z-index: 1;
+  z-index: 10;
 }
 
 .session-terminal-workspace.multi-leaf .workspace-pane.active .workspace-pane-header,
@@ -336,7 +341,9 @@
 /* The bound-ticket overlay: TicketDetailPanel laid over the terminal inside the
    pane body (which is position:relative). Absolute inset:0 above the terminal
    canvas; the header stays above it so the chip and drag handle remain clickable.
-   Pane-scoped and non-modal — no backdrop, no FocusTrap. */
+   Pane-scoped and non-modal — no backdrop, no FocusTrap. Stays below the active-pane
+   focus ring's z-index: 10 (see .workspace-pane.active::after) so opening the
+   overlay never hides the focus signal on a multi-leaf workspace. */
 .workspace-pane-ticket-overlay {
   position: absolute;
   inset: 0;

--- a/app/test-harness/harnesses/PaneFocusRingHarness.tsx
+++ b/app/test-harness/harnesses/PaneFocusRingHarness.tsx
@@ -1,0 +1,46 @@
+/**
+ * PaneFocusRing Test Harness
+ *
+ * Reproduces the exact DOM shape SessionTerminalWorkspace renders for a
+ * multi-leaf pane with a bound ticket open — a `.workspace-pane.active` whose
+ * `::after` paints the accent focus ring, with a `.workspace-pane-ticket-overlay`
+ * covering the pane body underneath. Loads the real stylesheet so the actual
+ * cascade/stacking is under test, not a re-description of it. GhosttyTerminal
+ * (WASM/canvas) plays no role in this stacking question, so it is not mounted —
+ * this harness exists to pin the invariant a real browser can uniquely verify:
+ * the ring paints on top of any pane-local overlay, however opaque.
+ */
+import { useEffect } from 'react';
+import '../../src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css';
+import type { HarnessProps } from '../types';
+
+export function PaneFocusRingHarness({ onReady, setTriggerRerender }: HarnessProps) {
+  useEffect(() => {
+    setTriggerRerender(() => () => {});
+    onReady();
+  }, [onReady, setTriggerRerender]);
+
+  return (
+    <div
+      className="session-terminal-workspace multi-leaf"
+      style={{ position: 'relative', width: 400, height: 300 }}
+    >
+      <div
+        className="workspace-pane active"
+        data-testid="pane-active"
+        style={{ position: 'absolute', inset: 0 }}
+      >
+        <div className="workspace-pane-header workspace-pane-header--draggable">
+          <span className="workspace-pane-title">shell</span>
+        </div>
+        <div className="workspace-pane-body">
+          <div
+            className="workspace-pane-ticket-overlay"
+            data-testid="ticket-overlay"
+            style={{ background: 'black' }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/test-harness/harnesses/index.ts
+++ b/app/test-harness/harnesses/index.ts
@@ -14,6 +14,7 @@ import { GridViewHarness } from './GridViewHarness';
 import { LiveMarkdownEditorHarness } from './LiveMarkdownEditorHarness';
 import { NotebookBrowserHarness } from './NotebookBrowserHarness';
 import { NotebookTileHarness } from './NotebookTileHarness';
+import { PaneFocusRingHarness } from './PaneFocusRingHarness';
 import { PresentTourHarness } from './PresentTourHarness';
 
 export const harnesses: Record<string, React.ComponentType<HarnessProps>> = {
@@ -27,5 +28,6 @@ export const harnesses: Record<string, React.ComponentType<HarnessProps>> = {
   LiveMarkdownEditor: LiveMarkdownEditorHarness,
   NotebookBrowser: NotebookBrowserHarness,
   NotebookTile: NotebookTileHarness,
+  PaneFocusRing: PaneFocusRingHarness,
   PresentTour: PresentTourHarness,
 };


### PR DESCRIPTION
## Why

PR #690 introduced a selection highlight ring around the active pane when
multiple leaves are visible. The ring used an `inset box-shadow`, which is
painted *beneath* child elements in the CSS stacking order. Terminal panes
have opaque child backgrounds (`GhosttyTerminal` fills the body with
`--color-bg-editor`), so the shadow was covered on three sides — only the
header's accented `border-bottom` survived. Markdown tiles worked by
accident because `--color-bg-tile` is undefined and resolves to transparent.

## Summary

- Replace the `inset box-shadow` on `.workspace-pane.active` with a
  `::after` pseudo-element that paints the accent ring on top of all
  children
- The pseudo-element uses `position: absolute; inset: 0; z-index: 1;
  pointer-events: none` — no layout shift, no click interference

## Test plan

- [x] Frontend tests pass
- [ ] Open the app with multiple docked tiles (terminal + markdown), verify
  the orange accent ring is visible on all four edges of the active pane
- [ ] Switch focus between terminal and tile panes, confirm the ring moves
  correctly
- [ ] Verify no visual flash when opening a new agent or shell pane