### PR TITLE
docs(plans): investigation plan for ghostty WASM terminal model crashes

### DIFF
--- a/app/scripts/repro-ghostty-vt-resize-hang.mjs
+++ b/app/scripts/repro-ghostty-vt-resize-hang.mjs
@@ -1,0 +1,132 @@
+// Minimal deterministic repro for an infinite-loop hang in the vendored
+// ghostty-vt wasm's resize path.
+//
+// Spike artifact of docs/plans/2026-07-27-ghostty-wasm-model-crashes.md.
+// Exit 0 is the pass criterion for a fixed wasm build: run this script
+// against a candidate ghostty-vt.wasm during the bisect/cherry-pick to
+// confirm the fix (exit 1 means the hang still reproduces).
+//
+// Sequence: create a 59x58 terminal, write one line containing a truncated
+// OSC 8 hyperlink + box-drawing + a long run of 'w' that overflows the
+// terminal width, then widen to 69 cols, narrow to 68, narrow to 67. The
+// THIRD call (the second consecutive narrow, 68->67) never returns: 100% CPU,
+// no exception, no trap signal -- a true infinite loop inside
+// ghostty_terminal_resize (or something it calls), distinct from the
+// `unreachable`/OOB traps seen in production from ghostty_terminal_write and
+// the renderer's update(). Confirmed root requirements (see accompanying
+// report/plan doc):
+//   - a widen of at least +10 cols (59->69; +9 does not reproduce)
+//   - followed by two separate narrow-by-1 resize() calls (a single narrow
+//     after the widen does not reproduce)
+//   - specific write content: plain ASCII alone does not reproduce; the
+//     OSC 8 fragment + box-drawing + overflowing 'w' run does
+//
+// Discrimination result: reproduces with BOTH plain term.resize() (as used
+// here) AND the app's mode-7 no-reflow wrapper from
+// app/src/utils/ghosttyResize.ts (write('\x1b[?7l') -> resize() ->
+// write('\x1b[?7h')) -- confirmed by wrapping the same three resize calls in
+// that dance and observing the identical hang at the identical step. So this
+// is not specific to either of the app's two resize call sites
+// (resizeGhosttyWithoutReflow vs. plain resizeLocal); both reach the same
+// wasm-level infinite loop.
+//
+// Loads the wasm exactly like app/src/utils/ghosttyHyperlinks.test.ts. Since
+// the hang is a synchronous, wasm-level infinite loop, it cannot be detected
+// from the same thread it runs on (the event loop never gets control back).
+// This script runs the repro in a worker_thread so the parent can apply a
+// wall-clock watchdog and terminate() the worker if a step never reports
+// back -- worker termination works even mid-blocking-synchronous-call.
+//
+// Exit codes: 0 = no fault (all steps completed); 1 = HANG (a step exceeded
+// the watchdog budget); 2 = unexpected exception/trap while running a step.
+
+import { Worker, isMainThread, parentPort } from 'node:worker_threads';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const APP_ROOT = fileURLToPath(new URL('..', import.meta.url));
+const WASM_PATH = `${APP_ROOT}/vendor/ghostty-vt/ghostty-vt.wasm`;
+const GHOSTTY_WEB_ENTRY = `file://${APP_ROOT}/node_modules/ghostty-web/dist/ghostty-web.js`;
+
+// The exact minimized payload (truncated OSC 8, box drawing, overflowing
+// 'w' run). Do not "clean up" the malformed-looking OSC 8 fragments -- they
+// are load-bearing; plain ASCII of the same length does not reproduce.
+const PAYLOAD =
+  '\x1b]8;;/\x1bine 31 ┌──┐│\x1b]8;;2\x1b\\entry 32\x1b]8;;7\x1b\\entry ' + 'w'.repeat(104);
+
+const WATCHDOG_MS = 2500;
+
+if (isMainThread) {
+  main();
+} else {
+  runInWorker();
+}
+
+async function runInWorker() {
+  const { Ghostty } = await import(GHOSTTY_WEB_ENTRY);
+  const bytes = readFileSync(WASM_PATH);
+  const mod = await WebAssembly.compile(bytes);
+  const instance = await WebAssembly.instantiate(mod, { env: { log: () => {} } });
+  const ghostty = new Ghostty(instance);
+  const term = ghostty.createTerminal(59, 58);
+
+  const steps = [
+    ['write payload', () => term.write(PAYLOAD)],
+    ['resize(69, 58) [widen]', () => term.resize(69, 58)],
+    ['resize(68, 58) [narrow #1]', () => term.resize(68, 58)],
+    ['resize(67, 58) [narrow #2 -- expected to hang]', () => term.resize(67, 58)],
+  ];
+
+  for (const [label, fn] of steps) {
+    parentPort.postMessage({ type: 'starting', label });
+    fn();
+    parentPort.postMessage({ type: 'done', label });
+  }
+  parentPort.postMessage({ type: 'all-done' });
+}
+
+async function main() {
+  const worker = new Worker(new URL(import.meta.url), { workerData: {} });
+  let lastLabel = '(not started)';
+  let settled = false;
+
+  const finish = (code, message) => {
+    if (settled) return;
+    settled = true;
+    console.log(message);
+    clearTimeout(watchdog);
+    worker.terminate().finally(() => process.exit(code));
+  };
+
+  let watchdog = setTimeout(() => {
+    finish(1, `HANG: step "${lastLabel}" did not return within ${WATCHDOG_MS}ms (wasm-level infinite loop). This is expected -- confirms the repro.`);
+  }, WATCHDOG_MS);
+
+  worker.on('message', (msg) => {
+    if (msg.type === 'starting') {
+      lastLabel = msg.label;
+      console.log('>>> ' + msg.label);
+      clearTimeout(watchdog);
+      watchdog = setTimeout(() => {
+        finish(1, `HANG: step "${lastLabel}" did not return within ${WATCHDOG_MS}ms (wasm-level infinite loop). This is expected -- confirms the repro.`);
+      }, WATCHDOG_MS);
+    } else if (msg.type === 'done') {
+      console.log('<<< ' + msg.label);
+    } else if (msg.type === 'all-done') {
+      finish(0, 'NO_HANG: all steps completed -- repro did not reproduce this run.');
+    }
+  });
+
+  worker.on('error', (err) => {
+    finish(2, 'EXCEPTION/TRAP: ' + (err && (err.stack || err.message || String(err))));
+  });
+
+  worker.on('exit', (code) => {
+    if (!settled) {
+      settled = true;
+      clearTimeout(watchdog);
+      console.log(`worker exited unexpectedly with code ${code}`);
+      process.exit(2);
+    }
+  });
+}

--- a/docs/plans/2026-07-27-ghostty-wasm-model-crashes.md
+++ b/docs/plans/2026-07-27-ghostty-wasm-model-crashes.md
@@ -1,0 +1,217 @@
+# Plan: Fix ghostty WASM terminal model crashes (resize-triggered faults)
+
+## Goal
+
+Root-cause and fix the recurring frontend terminal crashes behind the
+"Terminal issue recovered. We reloaded it for you." toast. The crash is a WASM
+trap inside the vendored ghostty VT core (`app/vendor/ghostty-vt/ghostty-vt.wasm`,
+pin `29d4aba`), not a rendering or lifecycle bug in the React layer. Recovery
+already works (server-authoritative snapshot remount in ~20ms, no data loss);
+the goal is that the model stops faulting, plus permanent instrumentation so
+any future fault of this class arrives with its own repro.
+
+## Evidence (2026-07-27, production profile)
+
+Three faults on record in `$APPLOCALDATA/debug/terminal-diagnostics.jsonl`
+(window starts 2026-07-08), all on one codex session (`thunk`,
+`8f9f5813-…`, a docked agent tile):
+
+| time (UTC) | operation | error | context |
+|---|---|---|---|
+| 11:52:00 | `render` | `Out of bounds memory access` in `update()` (wasm fn 461) | cols 134 |
+| 19:09:33 | `write` | `Unreachable code should not be executed` in `ghostty_terminal_write` (wasm 510→219→213→328→460) | first PTY write after fit resize 59→60 @58 rows |
+| 19:09:56 | `write` | same trap, same stack | 23s after recovery: remount at 60 → drag resizes 75…93→73→66→67→133→134 → first write → trap |
+
+Key facts established:
+
+- Both write traps land on the **first content write after a burst of
+  single-column fit resizes** (divider drag). `Unreachable` is a Zig
+  assertion/panic under `ReleaseSmall` — internal page state is corrupt before
+  the write arrives.
+- The daemon worker's **native** terminal (libghostty-vt pin `ab0b9da`,
+  2026-07-22) processed the *identical* byte stream and resize sequence
+  (confirmed in the worker log) without faulting. Two differences, either of
+  which may explain it: newer core, and plain resizes (the worker never uses
+  the no-reflow path below).
+- Every app-side fit resize goes through `resizeGhosttyWithoutReflow`
+  (`app/src/utils/ghosttyResize.ts`): `getMode(7)` → `write('\x1b[?7l')` →
+  `resize()` → `write('\x1b[?7h')`. This deliberately selects ghostty's
+  no-reflow resize path and is **load-bearing** (PR #306 / commit `139d50ae`:
+  block-store correct-or-absent semantics and replay-at-historical-geometry
+  depend on it). The live `resizeLocal` path uses plain `terminal.resize()`.
+- Each pane instantiates its **own** WASM instance (`Ghostty.load` per mount,
+  no caching), so cross-terminal memory corruption (ghostty-web issue #141)
+  is ruled out. The 0.4.0 wrapper's `write` builds fresh TypedArray views per
+  call, and attn drives its own renderer — so ghostty-web PR #132's
+  detached-view mechanism does not match our call pattern either.
+- The trap fires inside the core with valid input bytes: this is (or is
+  enabled by) a core-state corruption during resize at pin `29d4aba`.
+
+Upstream landscape (researched 2026-07-27):
+
+- ghostty-web has **no stable release after 0.4.0** (Dec 2025); ~20 fixes sit
+  on `main` as `0.4.0-next.*` prerelease tags only (open request for a cut:
+  coder/ghostty-web#137). Its ghostty submodule pin is *older* than ours —
+  upstream offers no newer core.
+- Relevant upstream issues: PR #132 (merged, resize-crash fix, wrong mechanism
+  for us), issue #139 (viewport corruption across internal page boundaries,
+  column-width dependent — plausible cousin of our render-OOB fault; fix PRs
+  #133/#177 both **unmerged**), issue #141 (ruled out above).
+- Bumping the WASM to the native pin `ab0b9da` is a **rewrite, not a bump**
+  (trial-built 2026-07-27): ghostty redesigned its Terminal C API upstream
+  (`ghostty_terminal_write` → `ghostty_terminal_vt_write`, flat getters →
+  enum-based `ghostty_terminal_get`/`render_state_get`, scrollback getters →
+  `grid_ref` API). ghostty-web's wasm-api patch cannot apply (the files it
+  used to create now exist natively with different shapes); a vanilla ab0b9da
+  WASM builds with zig 0.16 but lacks 23 exports the JS wrapper needs. Full
+  mapping table from the trial lives in the session scratchpad
+  (`wasm-bump/NOTES.md`) — fold it into the follow-up plan when that work
+  starts.
+
+## Architecture map (crash path)
+
+```text
+Current (crash):
+PTY bytes ── daemon worker (native ghostty ab0b9da — survives)
+   └─ WebSocket pty_output
+       └─ GhosttyTerminal write chain (enqueueOperation, serialized)
+           └─ ghostty-web 0.4.0 wrapper .write()
+               └─ wasm ghostty_terminal_write (pin 29d4aba)  ← TRAP (unreachable)
+
+fit resize (divider drag, ResizeObserver):
+fit() ─ applyFitDimensions ─ resizeGhosttyWithoutReflow
+   └─ write(?7l) → terminal.resize(cols,rows) → write(?7h)   ← suspected corruption site
+
+render:
+renderSurface → renderer.update() → render_state getters      ← TRAP (OOB) variant
+
+recovery (works today):
+trap → recoverFromModelFault → noteRecovery(modelFault) → remount epoch
+   └─ fresh Ghostty.load + attach_result.snapshot restore → toast to user
+```
+
+## Phase 1 — Deterministic repro (gates everything)
+
+- [ ] Land a fuzz/replay harness that loads the real vendored wasm through the
+      real ghostty-web wrapper (pattern: `app/src/utils/ghosttyHyperlinks.test.ts`),
+      generates codex-TUI-like content (alt-screen repaints, OSC 8 hyperlinks,
+      wide chars, soft-wrapped primary scrollback), and replays production's
+      exact resize semantics: mixed `resizeGhosttyWithoutReflow` and plain
+      `resize()`, single-column bursts up and down, stale-width writes after
+      resize. Seeded and minimizing. (A first version exists in the session
+      scratchpad, `fuzz.mjs`; sweep was still running when this plan was
+      written — fold its result in here.)
+- [ ] If fuzzing does not reproduce: add **capture-on-fault** instrumentation
+      and wait for the next real fault (this class recurs; 3 faults today).
+      Per-pane bounded ring of raw model inputs, dumped into the existing
+      `ghostty_model_fault` diagnostics record:
+
+```ts
+// owned by GhosttyTerminal, per pane, memory-bounded (e.g. last 512KB bytes + 2k ops)
+type ModelOpRing = Array<
+  | { t: number; kind: 'write'; bytes: Uint8Array }        // raw, pre-wrapper
+  | { t: number; kind: 'resize'; cols: number; rows: number; noReflow: boolean }
+  | { t: number; kind: 'reset' }
+>
+// on trap: base64 the ring into the ghostty_model_fault JSONL record
+// replay = new terminal at ring-start geometry, apply ops in order
+```
+
+      The ring starts at model construction (post-snapshot restore), so a
+      replay needs the snapshot dump too — capture the attach snapshot
+      (`attach_result.snapshot` dump + grid) alongside, same cap.
+- [ ] Minimize any repro to a fixture and commit it as a vitest regression
+      test (`node` environment, real wasm, no mocks).
+
+## Phase 2 — Root-cause discrimination (with repro in hand)
+
+```text
+repro crashes with plain resize() substituted for the no-reflow wrapper?
+├─ yes → pure core bug at 29d4aba
+│        └─ bisect ghostty 29d4aba..<last old-C-API commit>, wasm-build each
+│           step (zig 0.15.2 while it works), find fixing commit → Phase 3A/3B
+└─ no  → the mode-7 no-reflow dance is the enabler
+         ├─ still bisect (the fix may exist upstream regardless)
+         └─ evaluate 3C alongside
+```
+
+Note the bisect ceiling: the old ghostty-web wasm-api patch only applies up to
+the commit where upstream landed the new Terminal C API. Find that boundary
+commit first; it caps how far forward 3B can go.
+
+## Phase 3 — Fix options, ranked
+
+- **3A. Cherry-pick the fixing commit onto `29d4aba`** (preferred; exact
+  precedent: the June `startHyperlink` capacity fix, see
+  `app/vendor/ghostty-vt/README.md`). Extend
+  `ghostty-web-v0.4.0-compat.patch`, rebuild via
+  `app/scripts/build-ghostty-vt-wasm.sh`, update the README sha + rationale,
+  regression test green.
+- **3B. Bump the WASM pin forward** to the newest pre-API-redesign commit, if
+  the fixing commit lies within the patchable range and the patch still
+  applies. Same build/README mechanics as 3A.
+- **3C. Client-side avoidance** — only if Phase 2 shows the mode-7 dance is
+  required for the trap and no upstream fix is cherry-pickable. Constraint:
+  no-reflow semantics must survive (block store correctness + replay at
+  historical geometry). Candidate shapes, in order: reorder the dance so mode
+  writes and resize cannot straddle corrupt state (e.g. drop the mode-7 trick
+  for live fit and instead re-request the server snapshot after a resize
+  burst, which the server-authoritative restore makes cheap); or gate
+  no-reflow to replay-only where it originated.
+- **3D. If no repro materializes** even via capture-on-fault: ship the
+  capture instrumentation permanently and stop — recovery already contains
+  the damage; do not fix blind.
+
+## Phase 4 — Hardening + verification (any fix path)
+
+- [ ] Regression test: minimized repro as a vitest node-env test against the
+      real wasm (fails on `29d4aba`, passes on the fixed build).
+- [ ] Keep a slim capture-on-fault ring in production builds permanently
+      (bounded; this is the third crash class in this component in two months
+      — startup hyperlink corruption in June, `bottom_clip`/`blank_after_resize`
+      incidents ongoing, now this).
+- [ ] Live verification (dev profile, `make dev`): codex session in
+      `~/projects/thunk`, divider-drag resize soak across single-column steps
+      at 58 rows; confirm zero `model_fault` records in the profile's
+      `terminal-diagnostics.jsonl` after a soak that previously trapped twice
+      in 23s. Existing packaged scenario `terminal-block-resize` must stay
+      green (it exercises the no-reflow path's block semantics).
+- [ ] CHANGELOG entry (user-visible: terminal no longer flashes/reloads
+      during split-divider drags).
+
+## Decisions
+
+- **Not upgrading to ghostty-web `-next`**: no stable release; the one merged
+  crash fix (#132) addresses a wrapper mechanism attn doesn't use; wrapper
+  churn without evidence.
+- **Not converging pins now**: trial build proved `ab0b9da` needs a new
+  ~15-function wasm shim against the redesigned C API (`render.h`,
+  `grid_ref.h`) — a scoped project, tracked as a follow-up, not this fix.
+- **Root-cause over live-with-recovery**: recovery masks the trap but the
+  model state is corrupt *before* the trap fires — silent misrendering may
+  precede the crash (see render-OOB variant and the open upstream #139), and
+  the crash loop (twice in 23s) shows recovery alone doesn't converge.
+- **Fuzz-first, capture second**: a synthetic repro is faster if it lands;
+  capture-on-fault is the guaranteed-but-slower path and is worth shipping
+  regardless (Phase 4).
+
+## Open questions
+
+- Fuzz sweep outcome (running at time of writing) — determines whether Phase 1
+  finishes synthetically or via capture-on-fault.
+- Is the render-OOB fault (11:52) the same corruption observed at a different
+  entry point, or a second bug (upstream #139's page-boundary shape is
+  column-width dependent — 120/130 repro, 80/140 don't — suspicious for our
+  134-col pane)? The repro/bisect should try to answer both with one fixture.
+
+## Follow-ups
+
+- **Pin convergence** (single ghostty commit for native + WASM): rewrite the
+  wasm-api shim against ghostty's new Terminal C API, dropping the
+  ghostty-web patch dependency; zig 0.16; `-Demit-lib-vt=true` build form.
+  Deserves its own plan; the trial-build mapping table is the starting point.
+- Report the repro upstream to coder/ghostty-web (and ghostty-org if the
+  fixing commit is identified) — also nudges #137 (stable release).
+- The chronic `bottom_clip` / `blank_after_resize` incident families (44 on
+  record since 2026-07-08) are adjacent but distinct geometry bugs — not in
+  scope here; ticket separately if they persist after this fix.

--- a/docs/plans/2026-07-27-ghostty-wasm-model-crashes.md
+++ b/docs/plans/2026-07-27-ghostty-wasm-model-crashes.md
@@ -22,6 +22,28 @@ Three faults on record in `$APPLOCALDATA/debug/terminal-diagnostics.jsonl`
 | 19:09:33 | `write` | `Unreachable code should not be executed` in `ghostty_terminal_write` (wasm 510→219→213→328→460) | first PTY write after fit resize 59→60 @58 rows |
 | 19:09:56 | `write` | same trap, same stack | 23s after recovery: remount at 60 → drag resizes 75…93→73→66→67→133→134 → first write → trap |
 
+A fourth fault mode was found synthetically (fuzz sweep, 2026-07-27, verified
+2/2 deterministic): an **infinite loop** — `resize()` never returns, 100% CPU,
+no trap. Frozen as `app/scripts/repro-ghostty-vt-resize-hang.mjs`:
+
+- 59x58 terminal, one 153-char write mixing truncated OSC 8 fragments,
+  box-drawing, and a 104-char overflowing `w` run (plain ASCII of the same
+  length does **not** reproduce — the content is load-bearing), then
+  `resize(69)` → `resize(68)` → `resize(67)`. The second consecutive narrow
+  hangs.
+- Boundary-bisected requirements: widen ≥ +10 cols (59→69 hangs, 59→68
+  doesn't), then two further resize calls (one narrow alone doesn't hang;
+  narrow-then-widen also hangs).
+- Reproduces identically through **both** app resize call sites: plain
+  `resize()` (reflow) and the mode-7 no-reflow wrapper. The app's
+  `resizeGhosttyWithoutReflow` dance is **not** the enabler.
+- The production trap signatures (`write` unreachable, render OOB) were *not*
+  synthetically reproduced in ~1500 seeded iterations across five content/
+  resize strategies. The hang is a sibling finding in the same
+  resize/reflow+OSC-8 territory (hyperlinks again — same family as the June
+  `startHyperlink` fix), but equating it with the production traps is
+  unproven.
+
 Key facts established:
 
 - Both write traps land on the **first content write after a burst of
@@ -92,17 +114,15 @@ trap → recoverFromModelFault → noteRecovery(modelFault) → remount epoch
 
 ## Phase 1 — Deterministic repro (gates everything)
 
-- [ ] Land a fuzz/replay harness that loads the real vendored wasm through the
-      real ghostty-web wrapper (pattern: `app/src/utils/ghosttyHyperlinks.test.ts`),
-      generates codex-TUI-like content (alt-screen repaints, OSC 8 hyperlinks,
-      wide chars, soft-wrapped primary scrollback), and replays production's
-      exact resize semantics: mixed `resizeGhosttyWithoutReflow` and plain
-      `resize()`, single-column bursts up and down, stale-width writes after
-      resize. Seeded and minimizing. (A first version exists in the session
-      scratchpad, `fuzz.mjs`; sweep was still running when this plan was
-      written — fold its result in here.)
-- [ ] If fuzzing does not reproduce: add **capture-on-fault** instrumentation
-      and wait for the next real fault (this class recurs; 3 faults today).
+- [x] Fuzz/replay harness against the real vendored wasm through the real
+      ghostty-web wrapper (pattern: `app/src/utils/ghosttyHyperlinks.test.ts`),
+      codex-TUI-like content, production resize semantics. **Outcome: found
+      and minimized the resize-hang repro** (see Evidence), frozen as
+      `app/scripts/repro-ghostty-vt-resize-hang.mjs` (exit 0 = fixed build,
+      1 = hang, 2 = trap — it is the bisect test). The production trap
+      signatures did not fall out of ~1500 iterations.
+- [ ] Add **capture-on-fault** instrumentation for the *trap* fault modes and
+      wait for the next real fault (this class recurs; 3 faults today).
       Per-pane bounded ring of raw model inputs, dumped into the existing
       `ghostty_model_fault` diagnostics record:
 
@@ -125,19 +145,25 @@ type ModelOpRing = Array<
 
 ## Phase 2 — Root-cause discrimination (with repro in hand)
 
-```text
-repro crashes with plain resize() substituted for the no-reflow wrapper?
-├─ yes → pure core bug at 29d4aba
-│        └─ bisect ghostty 29d4aba..<last old-C-API commit>, wasm-build each
-│           step (zig 0.15.2 while it works), find fixing commit → Phase 3A/3B
-└─ no  → the mode-7 no-reflow dance is the enabler
-         ├─ still bisect (the fix may exist upstream regardless)
-         └─ evaluate 3C alongside
-```
+**Answered for the hang** (2026-07-27): it reproduces with plain `resize()`
+and with the mode-7 wrapper alike → pure core bug at `29d4aba`, not enabled by
+the app's resize dance. Option 3C is off the table as a primary fix.
 
-Note the bisect ceiling: the old ghostty-web wasm-api patch only applies up to
-the commit where upstream landed the new Terminal C API. Find that boundary
-commit first; it caps how far forward 3B can go.
+Remaining Phase 2 work:
+
+- [ ] Bisect ghostty `29d4aba..<last old-C-API commit>` using
+      `repro-ghostty-vt-resize-hang.mjs` as the test (wasm-build each step;
+      zig 0.15.2 while the range allows). Find the first commit where the
+      hang disappears — or learn it is unfixed upstream even at the boundary.
+- [ ] Find the bisect ceiling first: the commit where upstream landed the new
+      Terminal C API is where the old ghostty-web wasm-api patch stops
+      applying; it caps how far forward 3B can go.
+- [ ] Hang vs. traps: the hang repro is the bisect vehicle, but the
+      production faults are traps. After building a hang-fixed wasm, run a
+      long fuzz soak + the live divider-drag soak (Phase 4) to test whether
+      the trap family disappears with it. If traps persist, the
+      capture-on-fault ring (Phase 1) produces their own repro and the bisect
+      repeats with that fixture.
 
 ## Phase 3 — Fix options, ranked
 
@@ -150,14 +176,11 @@ commit first; it caps how far forward 3B can go.
 - **3B. Bump the WASM pin forward** to the newest pre-API-redesign commit, if
   the fixing commit lies within the patchable range and the patch still
   applies. Same build/README mechanics as 3A.
-- **3C. Client-side avoidance** — only if Phase 2 shows the mode-7 dance is
-  required for the trap and no upstream fix is cherry-pickable. Constraint:
-  no-reflow semantics must survive (block store correctness + replay at
-  historical geometry). Candidate shapes, in order: reorder the dance so mode
-  writes and resize cannot straddle corrupt state (e.g. drop the mode-7 trick
-  for live fit and instead re-request the server snapshot after a resize
-  burst, which the server-authoritative restore makes cheap); or gate
-  no-reflow to replay-only where it originated.
+- **3C. Client-side avoidance** — *demoted by Phase 2*: the hang reproduces
+  through both resize call sites, so changing the mode-7 dance cannot be the
+  fix for this bug. Retained only as a shape for any future fault that Phase 2
+  shows to be call-site-specific. Constraint if ever used: no-reflow semantics
+  must survive (block store correctness + replay at historical geometry).
 - **3D. If no repro materializes** even via capture-on-fault: ship the
   capture instrumentation permanently and stop — recovery already contains
   the damage; do not fix blind.
@@ -197,12 +220,18 @@ commit first; it caps how far forward 3B can go.
 
 ## Open questions
 
-- Fuzz sweep outcome (running at time of writing) — determines whether Phase 1
-  finishes synthetically or via capture-on-fault.
+- Does fixing the hang also fix the production traps? Same
+  resize/reflow+OSC-8 territory, but unproven — Phase 2's post-fix soak and
+  the capture-on-fault ring answer this empirically.
 - Is the render-OOB fault (11:52) the same corruption observed at a different
   entry point, or a second bug (upstream #139's page-boundary shape is
   column-width dependent — 120/130 repro, 80/140 don't — suspicious for our
-  134-col pane)? The repro/bisect should try to answer both with one fixture.
+  134-col pane)?
+- Why does a synchronous wasm infinite loop in production manifest as a trap
+  instead of a frozen UI? (Or does it — are there unexplained UI freezes?) If
+  the hang can fire in production, the write chain never drains and the pane
+  wedges without a `model_fault` record; worth checking whether any
+  `blank_after_resize` incidents are actually this hang.
 
 ## Follow-ups
 
@@ -210,8 +239,9 @@ commit first; it caps how far forward 3B can go.
   wasm-api shim against ghostty's new Terminal C API, dropping the
   ghostty-web patch dependency; zig 0.16; `-Demit-lib-vt=true` build form.
   Deserves its own plan; the trial-build mapping table is the starting point.
-- Report the repro upstream to coder/ghostty-web (and ghostty-org if the
-  fixing commit is identified) — also nudges #137 (stable release).
+- Report the resize-hang repro upstream to coder/ghostty-web (and ghostty-org
+  once the culprit/fixing commit is identified) — also nudges #137 (stable
+  release). The frozen repro is self-contained and ready to attach.
 - The chronic `bottom_clip` / `blank_after_resize` incident families (44 on
   record since 2026-07-08) are adjacent but distinct geometry bugs — not in
   scope here; ticket separately if they persist after this fix.


### PR DESCRIPTION
## Intent

Today's production session hit the "Terminal issue recovered. We reloaded it for you." toast three times — all WASM traps inside the vendored ghostty VT core (pin `29d4aba`): two Zig `unreachable` traps in `ghostty_terminal_write` on the first write after single-column divider-drag resize bursts, plus one out-of-bounds render fault. This PR captures the investigation and the fix plan, plus the deterministic repro the investigation produced. No behavior changes.

## Summary

- `docs/plans/2026-07-27-ghostty-wasm-model-crashes.md` — evidence, upstream landscape, and a phased fix plan:
  - The daemon's native ghostty (`ab0b9da`) survived the identical byte+resize stream that trapped the app's WASM (`29d4aba`) — the bug lives in the old core pin.
  - Converging the WASM pin to the native pin is a shim rewrite, not a bump (upstream redesigned the Terminal C API; verified by trial build) — tracked as a follow-up.
  - Fix path: bisect ghostty within the range the old wasm-api patch still applies to, then cherry-pick the fixing commit onto the pin (same playbook as the June `startHyperlink` fix), with ranked fallbacks and capture-on-fault instrumentation for the trap fault modes.
- `app/scripts/repro-ghostty-vt-resize-hang.mjs` — spike artifact: fuzzing found a **fourth fault mode**, a deterministic infinite loop in `resize()` (widen ≥ +10 cols, then two more resizes, with OSC 8 + box-drawing + overflowing content; 153-char payload). It reproduces through both app resize call sites — plain `resize()` and the mode-7 no-reflow wrapper — so `resizeGhosttyWithoutReflow` is exonerated. Exit 0 is the pass criterion for a fixed wasm build; this script is the bisect test.

## Test plan

- [x] Repro script verified: exits 1 (hang at the second consecutive narrow) deterministically, 3/3 runs from the repo root.
- [x] Pre-commit frontend suite green.
- [ ] Bisect + cherry-pick per the plan's Phase 2/3 (follow-up PR); repro must exit 0 on the fixed wasm.

## Out of scope

- The fix itself (plan Phase 2–4), the capture-on-fault instrumentation, and the WASM/native pin convergence (follow-up plan).