### PR TITLE
feat(workspace): add selectable focus styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-28]
+
+### Changed
+- **Choose how the focused workspace tile is marked.** Sidebar display settings
+  now offer an edge rail or a depth spotlight for the selected terminal, markdown
+  file, browser, or other tile, and remember the choice across launches. The
+  spotlight fades only tile opacity during focus changes; its depth and corner
+  marks are static so it does not keep consuming animation work.
+
+---
+
 ## [2026-07-27]
 
 ### Fixed

--- a/app/e2e/pane-focus-ring.spec.ts
+++ b/app/e2e/pane-focus-ring.spec.ts
@@ -1,21 +1,28 @@
 import { test, expect } from '@playwright/test';
 
-// Regression witness for the SessionTerminalWorkspace focus-ring z-index bug:
-// the active-pane `::after` ring must paint above any pane-local overlay
-// (currently the bound-ticket overlay), on the real stylesheet, in a real
-// browser — a stacking bug jsdom/happy-dom cannot see since neither applies
-// the component's CSS file. See SessionTerminalWorkspace.css.
-test('active-pane focus ring paints above the ticket overlay', async ({ page }) => {
+// Regression witness for the SessionTerminalWorkspace selection-marker z-index:
+// the edge rail and spotlight corner marks must paint above pane-local overlays.
+// This needs a real browser because jsdom/happy-dom do not apply the stylesheet.
+test('active-pane selection markers paint above the ticket overlay', async ({ page }) => {
   await page.goto('/test-harness/?component=PaneFocusRing');
   await page.waitForFunction(() => window.__HARNESS__?.ready === true);
 
+  const workspace = page.locator('[data-testid="workspace"]');
   const pane = page.locator('[data-testid="pane-active"]');
   const overlay = page.locator('[data-testid="ticket-overlay"]');
   await expect(overlay).toBeVisible();
 
-  const [paneZ, overlayZ] = await Promise.all([
-    pane.evaluate((el) => getComputedStyle(el, '::after').zIndex),
-    overlay.evaluate((el) => getComputedStyle(el).zIndex),
-  ]);
-  expect(Number(paneZ)).toBeGreaterThan(Number(overlayZ));
+  const overlayZ = Number(await overlay.evaluate((el) => getComputedStyle(el).zIndex));
+
+  for (const style of ['rail', 'spotlight']) {
+    await workspace.evaluate((el, selectionStyle) => {
+      el.classList.remove('workspace-selection--rail', 'workspace-selection--spotlight');
+      el.classList.add(`workspace-selection--${selectionStyle}`);
+    }, style);
+
+    const markerZ = Number(
+      await pane.evaluate((el) => getComputedStyle(el, '::after').zIndex),
+    );
+    expect(markerZ, `${style} marker z-index`).toBeGreaterThan(overlayZ);
+  }
 });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -51,6 +51,11 @@ import {
   readWarmWorkspaceLimit,
   writeWarmWorkspaceLimit,
 } from './utils/terminalVirtualization';
+import {
+  persistWorkspaceSelectionStyle,
+  readWorkspaceSelectionStyle,
+  type WorkspaceSelectionStyle,
+} from './utils/workspaceSelectionStyle';
 import { useDaemonSocket, DaemonWorktree, DaemonSession, DaemonWorkspace, DaemonPR, DaemonEndpoint, DaemonPlugin, DaemonPluginIssue, GitStatusUpdate, DaemonWarning, SessionExitInfo, type FsIndexResult, type NotebookEntry } from './hooks/useDaemonSocket';
 import type { Presentation } from './types/generated';
 import { useSessionWorkspaceController } from './hooks/useSessionWorkspaceController';
@@ -2902,6 +2907,11 @@ sendFetchPRDetails,
   // consistent. They never contribute to unmutedWorkspaceViews, which feeds
   // session/attention counts.
   const [showSessionlessWorkspaces, setShowSessionlessWorkspaces] = useState<boolean>(readShowSessionlessWorkspaces);
+  const [workspaceSelectionStyle, setWorkspaceSelectionStyle] = useState<WorkspaceSelectionStyle>(readWorkspaceSelectionStyle);
+  const handleWorkspaceSelectionStyleChange = useCallback((style: WorkspaceSelectionStyle) => {
+    persistWorkspaceSelectionStyle(style);
+    setWorkspaceSelectionStyle(style);
+  }, []);
   const handleToggleShowSessionlessWorkspaces = useCallback(() => {
     setShowSessionlessWorkspaces((prev) => {
       const next = !prev;
@@ -3707,6 +3717,8 @@ sendFetchPRDetails,
           onChangeChiefOfStaff={handleChangeChiefOfStaff}
           showSessionless={showSessionlessWorkspaces}
           onToggleShowSessionless={handleToggleShowSessionlessWorkspaces}
+          workspaceSelectionStyle={workspaceSelectionStyle}
+          onWorkspaceSelectionStyleChange={handleWorkspaceSelectionStyleChange}
           leafDrag={leafWorkspaceDrag ? {
             sourceWorkspaceId: leafWorkspaceDrag.sourceWorkspaceId,
             endpointId: leafWorkspaceDrag.sourceEndpointId,
@@ -3794,6 +3806,7 @@ sendFetchPRDetails,
                     }}
                     onTerminalModelRecovered={handleTerminalModelRecovered}
                     workspace={workspaceState}
+                    workspaceSelectionStyle={workspaceSelectionStyle}
                     activePaneId={activePaneId}
                     fontSize={terminalFontSize}
                     resolvedTheme={resolvedTheme}

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
@@ -5,6 +5,7 @@ import { SessionTerminalWorkspace } from './index';
 import { createPaneRuntimeEventRouterController } from './paneRuntimeEventRouter';
 import { tileContentKey, type TerminalWorkspaceState } from '../../types/workspace';
 import { NotebookSurfaceProvider, type NotebookSurfaceContextValue } from '../../contexts/NotebookSurfaceContext';
+import type { WorkspaceSelectionStyle } from '../../utils/workspaceSelectionStyle';
 
 // The docked markdown tile below reads effectiveNotebookRoot unconditionally
 // via useNotebookSurfaceContext — real usage is always under App's provider.
@@ -96,6 +97,7 @@ function renderSplit(overrides: {
   onClosePane?: () => void;
   onUndockTile?: (tileId: string) => void;
   onFocusPane?: (paneId: string) => void;
+  workspaceSelectionStyle?: WorkspaceSelectionStyle;
 } = {}) {
   const onClosePane = overrides.onClosePane ?? vi.fn();
   const onUndockTile = overrides.onUndockTile ?? vi.fn();
@@ -106,6 +108,7 @@ function renderSplit(overrides: {
       workspaceId="workspace-split"
       workspaceSessions={[{ id: 'sess-1', label: 'shell', agent: 'shell', cwd: '/tmp/project' }]}
       workspace={workspace}
+      workspaceSelectionStyle={overrides.workspaceSelectionStyle}
       activePaneId="pane-term"
       fontSize={13}
       enabled
@@ -137,6 +140,14 @@ function tileEl(container: HTMLElement): HTMLElement {
 function paneEl(container: HTMLElement): HTMLElement {
   return container.querySelector('[data-pane-kind="agent"]') as HTMLElement;
 }
+
+describe('SessionTerminalWorkspace selection style', () => {
+  it('marks the workspace with the selected treatment', () => {
+    const { container } = renderSplit({ workspaceSelectionStyle: 'spotlight' });
+
+    expect(container.querySelector('.session-terminal-workspace')).toHaveClass('workspace-selection--spotlight');
+  });
+});
 
 describe('SessionTerminalWorkspace leaf focus', () => {
   // Clicking a tile must be enough — no programmatic focus() — for the tile to

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
@@ -104,43 +104,82 @@
   opacity: 1;
 }
 
-/* Focus display for the active leaf: an inset accent ring on the leaf frame plus
-   an accented header, applied identically to terminal panes and docked tiles so
-   there is one focus vocabulary across leaf kinds. Both signals appear only when
-   more than one leaf is on screen — with a single leaf there is nothing to
-   disambiguate. Tile bodies deliberately stay at full opacity: a docked doc is
-   read while typing in the terminal, so dimming its prose would be a bad focus
-   signal.
-
-   The ring is an overlay, not an inset box-shadow on the frame itself: an inset
-   shadow paints beneath every descendant background, so an opaque child covers
-   it. A terminal fills the pane body with an opaque background and used to leave
-   only the segment behind the translucent header visible, while a tile — whose
-   background happened to be transparent — showed the whole ring. The overlay
-   stacks above every pane-local overlay (the bound-ticket overlay is z-index 5,
-   so opening a ticket never hides the focus signal) and takes no pointer events.
-   Raise this again if a future overlay needs to sit above 5. */
-.session-terminal-workspace.multi-leaf .workspace-pane.active::after {
+/* The selected-leaf treatment applies only when there is another visible leaf
+   to disambiguate. Edge rail is the default: one strong edge without boxing in
+   terminal or document content. The overlay sits above pane-local overlays but
+   never takes pointer input. */
+.session-terminal-workspace.workspace-selection--rail.multi-leaf .workspace-pane.active::after {
   content: '';
   position: absolute;
-  inset: 0;
+  inset: 0 auto 0 0;
   z-index: 10;
+  width: 3px;
   pointer-events: none;
-  border: 1px solid rgba(255, 107, 53, 0.45);
-  border-radius: inherit;
+  background: var(--accent);
 }
 
-.session-terminal-workspace.multi-leaf .workspace-pane.active .workspace-pane-header,
-.session-terminal-workspace.multi-leaf .workspace-pane.active .workspace-dock-tile-header {
-  background:
-    linear-gradient(90deg, rgba(255, 107, 53, 0.2), rgba(255, 107, 53, 0.06)),
-    var(--color-bg-elevated, var(--color-bg-editor));
-  border-bottom-color: rgba(255, 107, 53, 0.42);
-}
-
-.session-terminal-workspace.multi-leaf .workspace-pane.active .workspace-pane-title,
-.session-terminal-workspace.multi-leaf .workspace-pane.active .workspace-dock-tile-title {
+.session-terminal-workspace.workspace-selection--rail.multi-leaf .workspace-pane.active .workspace-pane-title,
+.session-terminal-workspace.workspace-selection--rail.multi-leaf .workspace-pane.active .workspace-dock-tile-title {
   color: var(--color-text-primary);
+}
+
+/* Spotlight uses contrast plus static depth and corner marks. Selection changes
+   animate opacity only, which compositors can handle without repainting pane
+   contents. The shadow and marks never animate; filters, backdrop blur, and
+   permanent will-change layers are intentionally avoided to keep WebGL terminal
+   GPU memory stable. */
+.session-terminal-workspace.workspace-selection--spotlight.multi-leaf .workspace-pane {
+  opacity: 0.76;
+}
+
+.session-terminal-workspace.workspace-selection--spotlight.multi-leaf .workspace-pane.active {
+  z-index: 4;
+  opacity: 1;
+  box-shadow:
+    0 10px 26px rgba(0, 0, 0, 0.42),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.09);
+}
+
+.session-terminal-workspace.workspace-selection--spotlight.multi-leaf .workspace-pane.active .workspace-pane-header,
+.session-terminal-workspace.workspace-selection--spotlight.multi-leaf .workspace-pane.active .workspace-dock-tile-header {
+  background: color-mix(
+    in srgb,
+    var(--color-bg-elevated, var(--color-bg-editor)) 92%,
+    var(--color-text-primary)
+  );
+}
+
+.session-terminal-workspace.workspace-selection--spotlight.multi-leaf .workspace-pane.active .workspace-pane-title,
+.session-terminal-workspace.workspace-selection--spotlight.multi-leaf .workspace-pane.active .workspace-dock-tile-title {
+  color: var(--color-text-primary);
+}
+
+.session-terminal-workspace.workspace-selection--spotlight.multi-leaf .workspace-pane.active::before,
+.session-terminal-workspace.workspace-selection--spotlight.multi-leaf .workspace-pane.active::after {
+  content: '';
+  position: absolute;
+  z-index: 10;
+  width: 13px;
+  height: 13px;
+  pointer-events: none;
+}
+
+.session-terminal-workspace.workspace-selection--spotlight.multi-leaf .workspace-pane.active::before {
+  inset: 0 auto auto 0;
+  border-top: 2px solid var(--accent);
+  border-left: 2px solid var(--accent);
+}
+
+.session-terminal-workspace.workspace-selection--spotlight.multi-leaf .workspace-pane.active::after {
+  inset: auto 0 0 auto;
+  border-right: 2px solid var(--accent);
+  border-bottom: 2px solid var(--accent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-pane {
+    transition: none;
+  }
 }
 
 .session-terminal-panes > .workspace-pane {
@@ -346,8 +385,8 @@
    pane body (which is position:relative). Absolute inset:0 above the terminal
    canvas; the header stays above it so the chip and drag handle remain clickable.
    Pane-scoped and non-modal — no backdrop, no FocusTrap. Stays below the
-   active-pane focus ring's z-index: 10 (see .workspace-pane.active::after) so
-   opening the overlay never hides the focus signal on a multi-leaf workspace. */
+   selected-leaf markers' z-index: 10 so opening the overlay never hides the
+   focus signal on a multi-leaf workspace. */
 .workspace-pane-ticket-overlay {
   position: absolute;
   inset: 0;

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -41,6 +41,7 @@ import { WorkspaceLayoutRenderer } from './WorkspaceLayoutRenderer';
 import { WorkspaceDockTile } from './WorkspaceDockTile';
 import { startLeafDrag, type LeafDropSnapshot } from './leafDrag';
 import type { DockTarget } from './dockTarget';
+import type { WorkspaceSelectionStyle } from '../../utils/workspaceSelectionStyle';
 
 const ZOOM_PATH_RATIO = 0.76;
 const RESIZE_MOUSE_SUPPRESSION_MS = 1_500;
@@ -137,6 +138,7 @@ interface SessionTerminalWorkspaceProps {
     onResume: (ticketId: string) => void;
   };
   workspace: TerminalWorkspaceState;
+  workspaceSelectionStyle?: WorkspaceSelectionStyle;
   activePaneId: string;
   fontSize: number;
   resolvedTheme?: ResolvedTheme;
@@ -193,6 +195,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     workspaceSessions = [],
     ticketActions,
     workspace,
+    workspaceSelectionStyle = 'rail',
     activePaneId,
     fontSize,
     resolvedTheme,
@@ -1316,7 +1319,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
 
     return (
       <div
-        className={`session-terminal-workspace ${effectivePaneId ? 'focus-mode' : ''} ${effectiveZoomedPaneId && !effectivePaneId ? 'zoom-mode' : ''} ${renderedPaneIds.length > 1 ? 'multi-leaf' : ''}`.trim().replace(/\s+/g, ' ')}
+        className={`session-terminal-workspace workspace-selection--${workspaceSelectionStyle} ${effectivePaneId ? 'focus-mode' : ''} ${effectiveZoomedPaneId && !effectivePaneId ? 'zoom-mode' : ''} ${renderedPaneIds.length > 1 ? 'multi-leaf' : ''}`.trim().replace(/\s+/g, ' ')}
         data-session-terminal-workspace={workspaceId}
         data-workspace-id={workspaceId}
         data-active-pane-id={activePaneId}

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -779,6 +779,18 @@
   background: rgba(255, 255, 255, 0.03);
 }
 
+.sidebar-settings-sub-label {
+  display: block;
+  margin: 11px 2px 6px;
+  color: var(--color-text-muted);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-xs);
+}
+
+.sidebar-display-toggle--selection {
+  grid-template-columns: repeat(2, 1fr);
+}
+
 .sidebar-display-toggle button {
   border: 0;
   border-radius: 5px;

--- a/app/src/components/Sidebar.test.tsx
+++ b/app/src/components/Sidebar.test.tsx
@@ -546,6 +546,25 @@ describe('Sidebar', () => {
     expect(screen.getByRole('dialog', { name: 'Sidebar settings' })).toBeInTheDocument();
   });
 
+  it('selects the workspace tile-focus treatment from display settings', () => {
+    const onWorkspaceSelectionStyleChange = vi.fn();
+    render(
+      <Sidebar
+        {...baseProps}
+        {...buildSidebarData([])}
+        workspaceSelectionStyle="rail"
+        onWorkspaceSelectionStyleChange={onWorkspaceSelectionStyleChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sidebar settings' }));
+
+    expect(screen.getByRole('button', { name: 'rail' })).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(screen.getByRole('button', { name: 'spotlight' }));
+
+    expect(onWorkspaceSelectionStyleChange).toHaveBeenCalledWith('spotlight');
+  });
+
   it('renders config-driven dock items, marks active ones, and fires actions on click', () => {
     const onAttention = vi.fn();
     render(

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -14,6 +14,7 @@ import { isAttentionSessionState, type UISessionState } from '../types/sessionSt
 import { tileContentKey, type TileContentState, type TileLeaf } from '../types/workspace';
 import { deriveTileTitle } from '../utils/tilePresentation';
 import type { WorkspaceWithSessions } from '../utils/workspaceViewModels';
+import type { WorkspaceSelectionStyle } from '../utils/workspaceSelectionStyle';
 
 interface LocalSession {
   id: string;
@@ -139,6 +140,8 @@ interface SidebarProps {
   onChangeChiefOfStaff?: (sessionId: string, enabled: boolean) => void;
   showSessionless?: boolean;
   onToggleShowSessionless?: () => void;
+  workspaceSelectionStyle?: WorkspaceSelectionStyle;
+  onWorkspaceSelectionStyleChange?: (style: WorkspaceSelectionStyle) => void;
   leafDrag?: { sourceWorkspaceId: string; endpointId?: string } | null;
   dragHoverWorkspaceId?: string | null;
   onWorkspaceDragEnter?: (workspace: SidebarWorkspace) => void;
@@ -327,6 +330,8 @@ export function Sidebar({
   onChangeChiefOfStaff,
   showSessionless = false,
   onToggleShowSessionless,
+  workspaceSelectionStyle = 'rail',
+  onWorkspaceSelectionStyleChange,
   leafDrag = null,
   dragHoverWorkspaceId = null,
   onWorkspaceDragEnter,
@@ -857,6 +862,19 @@ export function Sidebar({
                       }}
                     >
                       {mode}
+                    </button>
+                  ))}
+                </div>
+                <span className="sidebar-settings-sub-label">Tile focus</span>
+                <div className="sidebar-display-toggle sidebar-display-toggle--selection" role="group" aria-label="Tile focus style">
+                  {(['rail', 'spotlight'] as const).map((style) => (
+                    <button
+                      key={style}
+                      className={workspaceSelectionStyle === style ? 'active' : ''}
+                      aria-pressed={workspaceSelectionStyle === style}
+                      onClick={() => onWorkspaceSelectionStyleChange?.(style)}
+                    >
+                      {style}
                     </button>
                   ))}
                 </div>

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -869,6 +869,7 @@ export function Sidebar({
                 <div className="sidebar-display-toggle sidebar-display-toggle--selection" role="group" aria-label="Tile focus style">
                   {(['rail', 'spotlight'] as const).map((style) => (
                     <button
+                      type="button"
                       key={style}
                       className={workspaceSelectionStyle === style ? 'active' : ''}
                       aria-pressed={workspaceSelectionStyle === style}

--- a/app/src/utils/workspaceSelectionStyle.test.ts
+++ b/app/src/utils/workspaceSelectionStyle.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  persistWorkspaceSelectionStyle,
+  readWorkspaceSelectionStyle,
+  WORKSPACE_SELECTION_STYLE_STORAGE_KEY,
+} from './workspaceSelectionStyle';
+
+describe('workspace selection style preference', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults missing and unknown values to the edge rail', () => {
+    expect(readWorkspaceSelectionStyle()).toBe('rail');
+
+    localStorage.setItem(WORKSPACE_SELECTION_STYLE_STORAGE_KEY, 'unknown');
+    expect(readWorkspaceSelectionStyle()).toBe('rail');
+  });
+
+  it('persists and restores the spotlight style', () => {
+    persistWorkspaceSelectionStyle('spotlight');
+
+    expect(localStorage.getItem(WORKSPACE_SELECTION_STYLE_STORAGE_KEY)).toBe('spotlight');
+    expect(readWorkspaceSelectionStyle()).toBe('spotlight');
+  });
+});

--- a/app/src/utils/workspaceSelectionStyle.ts
+++ b/app/src/utils/workspaceSelectionStyle.ts
@@ -1,0 +1,21 @@
+export type WorkspaceSelectionStyle = 'rail' | 'spotlight';
+
+export const WORKSPACE_SELECTION_STYLE_STORAGE_KEY = 'attn.workspace.selectionStyle';
+
+export function readWorkspaceSelectionStyle(): WorkspaceSelectionStyle {
+  try {
+    return window.localStorage.getItem(WORKSPACE_SELECTION_STYLE_STORAGE_KEY) === 'spotlight'
+      ? 'spotlight'
+      : 'rail';
+  } catch {
+    return 'rail';
+  }
+}
+
+export function persistWorkspaceSelectionStyle(style: WorkspaceSelectionStyle): void {
+  try {
+    window.localStorage.setItem(WORKSPACE_SELECTION_STYLE_STORAGE_KEY, style);
+  } catch (err) {
+    console.warn('[App] Failed to persist workspace-selection style:', err);
+  }
+}

--- a/app/test-harness/harnesses/PaneFocusRingHarness.tsx
+++ b/app/test-harness/harnesses/PaneFocusRingHarness.tsx
@@ -1,14 +1,13 @@
 /**
- * PaneFocusRing Test Harness
+ * Pane focus treatment test harness
  *
  * Reproduces the exact DOM shape SessionTerminalWorkspace renders for a
- * multi-leaf pane with a bound ticket open — a `.workspace-pane.active` whose
- * `::after` paints the accent focus ring, with a `.workspace-pane-ticket-overlay`
- * covering the pane body underneath. Loads the real stylesheet so the actual
- * cascade/stacking is under test, not a re-description of it. GhosttyTerminal
- * (WASM/canvas) plays no role in this stacking question, so it is not mounted —
- * this harness exists to pin the invariant a real browser can uniquely verify:
- * the ring paints on top of any pane-local overlay, however opaque.
+ * multi-leaf pane with a bound ticket open. The selected leaf's pseudo-elements
+ * paint the edge rail or spotlight corner marks, with a
+ * `.workspace-pane-ticket-overlay` covering the pane body underneath. Loads the
+ * real stylesheet so the actual cascade/stacking is under test, not a
+ * re-description of it. GhosttyTerminal (WASM/canvas) plays no role in this
+ * stacking question, so it is not mounted.
  */
 import { useEffect } from 'react';
 import '../../src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css';
@@ -22,7 +21,8 @@ export function PaneFocusRingHarness({ onReady, setTriggerRerender }: HarnessPro
 
   return (
     <div
-      className="session-terminal-workspace multi-leaf"
+      className="session-terminal-workspace workspace-selection--rail multi-leaf"
+      data-testid="workspace"
       style={{ position: 'relative', width: 400, height: 300 }}
     >
       <div


### PR DESCRIPTION
## Intent / Why

The focused workspace leaf needs to be obvious without a full border competing with terminal, markdown, or browser content. This gives people two quieter focus treatments and keeps the choice consistent across launches.

## Summary

- replace the full active-leaf ring with a 3 px edge rail by default
- add an optional depth spotlight that dims sibling leaves and uses static depth and corner marks
- add Sidebar → Display → Tile focus controls and persist the selection locally
- keep spotlight selection changes compositor-friendly: opacity is the only animated property; shadows and corner marks are static, and reduced-motion disables the transition
- update the browser regression to verify both treatments remain visible over pane-local overlays

## Test plan

- [x] Frontend unit tests: 191 files, 2,062 tests
- [x] Production frontend build
- [x] Playwright E2E: 191 passed, 1 environment-specific case skipped
- [x] Packaged dev app build and bundled dev-profile preflight
- [x] Live packaged-app verification of rail and spotlight on a two-pane workspace
- [x] Relaunch verification that the selected style persists