### PR TITLE
fix(workspace): restore inactive tile dimming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Choose how the focused workspace tile is marked.** Sidebar display settings
   now offer an edge rail or a depth spotlight for the selected terminal, markdown
   file, browser, or other tile, and remember the choice across launches. The
-  spotlight fades only tile opacity during focus changes; its depth and corner
-  marks are static so it does not keep consuming animation work.
+  selected tile stays fully opaque while every unselected tile is dimmed to the
+  same level in both modes. Spotlight depth and corner marks are static so they
+  do not keep consuming animation work.
 
 ---
 
@@ -40,8 +41,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **The focused pane or tile is now marked, not just brightened.** The focused
   leaf carries an accent ring and an accented header, applied the same way to
   terminals and docked tiles, so which one has the keyboard is readable at a
-  glance. Tiles stay at full brightness whether focused or not — a docked
-  document is there to be read while you type in the terminal.
+  glance.
 
 ---
 

--- a/app/e2e/pane-focus-ring.spec.ts
+++ b/app/e2e/pane-focus-ring.spec.ts
@@ -9,6 +9,7 @@ test('active-pane selection markers paint above the ticket overlay', async ({ pa
 
   const workspace = page.locator('[data-testid="workspace"]');
   const pane = page.locator('[data-testid="pane-active"]');
+  const inactiveTile = page.locator('[data-testid="tile-inactive"]');
   const overlay = page.locator('[data-testid="ticket-overlay"]');
   await expect(overlay).toBeVisible();
 
@@ -24,5 +25,7 @@ test('active-pane selection markers paint above the ticket overlay', async ({ pa
       await pane.evaluate((el) => getComputedStyle(el, '::after').zIndex),
     );
     expect(markerZ, `${style} marker z-index`).toBeGreaterThan(overlayZ);
+    await expect(inactiveTile, `${style} inactive tile opacity`).toHaveCSS('opacity', '0.58');
+    await expect(pane, `${style} active pane opacity`).toHaveCSS('opacity', '1');
   }
 });

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
@@ -100,10 +100,6 @@
   opacity: 1;
 }
 
-.workspace-pane.workspace-pane--tile {
-  opacity: 1;
-}
-
 /* The selected-leaf treatment applies only when there is another visible leaf
    to disambiguate. Edge rail is the default: one strong edge without boxing in
    terminal or document content. The overlay sits above pane-local overlays but
@@ -123,15 +119,12 @@
   color: var(--color-text-primary);
 }
 
-/* Spotlight uses contrast plus static depth and corner marks. Selection changes
-   animate opacity only, which compositors can handle without repainting pane
-   contents. The shadow and marks never animate; filters, backdrop blur, and
-   permanent will-change layers are intentionally avoided to keep WebGL terminal
-   GPU memory stable. */
-.session-terminal-workspace.workspace-selection--spotlight.multi-leaf .workspace-pane {
-  opacity: 0.76;
-}
-
+/* Spotlight adds static depth and corner marks while preserving the same
+   selected/unselected opacity contrast as the rail. Selection changes animate
+   opacity only, which compositors can handle without repainting pane contents.
+   The shadow and marks never animate; filters, backdrop blur, and permanent
+   will-change layers are intentionally avoided to keep WebGL terminal GPU
+   memory stable. */
 .session-terminal-workspace.workspace-selection--spotlight.multi-leaf .workspace-pane.active {
   z-index: 4;
   opacity: 1;

--- a/app/test-harness/harnesses/PaneFocusRingHarness.tsx
+++ b/app/test-harness/harnesses/PaneFocusRingHarness.tsx
@@ -2,12 +2,13 @@
  * Pane focus treatment test harness
  *
  * Reproduces the exact DOM shape SessionTerminalWorkspace renders for a
- * multi-leaf pane with a bound ticket open. The selected leaf's pseudo-elements
- * paint the edge rail or spotlight corner marks, with a
+ * multi-leaf workspace with a bound ticket open. The selected leaf's
+ * pseudo-elements paint the edge rail or spotlight corner marks, with a
  * `.workspace-pane-ticket-overlay` covering the pane body underneath. Loads the
  * real stylesheet so the actual cascade/stacking is under test, not a
  * re-description of it. GhosttyTerminal (WASM/canvas) plays no role in this
- * stacking question, so it is not mounted.
+ * stacking question, so it is not mounted. An unselected docked tile witnesses
+ * that both focus styles preserve the shared inactive opacity.
  */
 import { useEffect } from 'react';
 import '../../src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css';
@@ -28,7 +29,7 @@ export function PaneFocusRingHarness({ onReady, setTriggerRerender }: HarnessPro
       <div
         className="workspace-pane active"
         data-testid="pane-active"
-        style={{ position: 'absolute', inset: 0 }}
+        style={{ position: 'absolute', inset: '0 50% 0 0' }}
       >
         <div className="workspace-pane-header workspace-pane-header--draggable">
           <span className="workspace-pane-title">shell</span>
@@ -39,6 +40,15 @@ export function PaneFocusRingHarness({ onReady, setTriggerRerender }: HarnessPro
             data-testid="ticket-overlay"
             style={{ background: 'black' }}
           />
+        </div>
+      </div>
+      <div
+        className="workspace-pane workspace-pane--tile"
+        data-testid="tile-inactive"
+        style={{ position: 'absolute', inset: '0 0 0 50%' }}
+      >
+        <div className="workspace-dock-tile-header">
+          <span className="workspace-dock-tile-title">notes.md</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Intent / Why

The focus-style change in #694 left docked tiles at full opacity under Rail and dimmed them to a different level under Spotlight. That makes the selected-versus-unselected contrast depend on both the leaf kind and the chosen marker.

Restore one predictable rule: every unselected workspace leaf is dimmed to `0.58`, while the selected leaf remains fully opaque, under both focus styles.

## Summary

- remove the docked-tile full-opacity exception from `SessionTerminalWorkspace.css`
- remove Spotlight's separate `0.76` inactive opacity so both modes inherit `0.58`
- extend the real-browser focus harness to assert inactive docked-tile and active-pane opacity under Rail and Spotlight
- update the changelog to describe the resulting behavior

## Test plan

- [x] Frontend tests and production frontend build via the pre-commit hook
- [x] Playwright E2E: 191 passed, 1 platform-specific test skipped
- [x] Packaged `attn-dev` build and launch
- [x] Bundled dev-profile preflight
- [x] Browser regression verifies inactive docked tiles compute to `0.58` and active panes to `1` in both modes

## Related

- #694
