### PR TITLE
feat(delegate): create worktrees by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-07-28]
 
 ### Changed
+- **Delegated Git work starts isolated by default.** `attn delegate` now creates
+  a new worktree automatically when its target is in a Git repository, including
+  for read-only and discussion work. Use `--no-worktree` to deliberately continue
+  in the resolved checkout; explicit branch, base, repository, and path options
+  still customize the new worktree.
 - **Choose how the focused workspace tile is shown.** Sidebar display settings
   now offer dimming alone, an edge rail, or a depth spotlight for the selected
   terminal, markdown file, browser, or other tile, and remember the choice across

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -668,11 +668,13 @@ func writeDelegateHelp(w io.Writer) {
 	fmt.Fprint(w, `usage: attn delegate (--brief <text> | --brief-file <path>) [options]
 
 placement:
-  (no flags)                 add a pane to the source session's workspace
+  (no flags)                 add a pane to the source workspace; Git repositories
+                             get a new worktree automatically
   --new-workspace            create a workspace using the source directory
   --workspace <id>           add a pane to an existing workspace
   --cwd <path>               create a workspace at an existing directory
-  --worktree <branch>        create a worktree for the delegated session
+  --worktree <branch>        choose the new worktree's branch
+  --no-worktree              reuse the resolved checkout instead
 
 worktree options:
   combine with any placement (current, --workspace, or --new-workspace);
@@ -2287,6 +2289,7 @@ func parseDelegateArgs(args []string) (delegateCLIArgs, error) {
 	worktreeRepo := fs.String("repo", "", "main repository for --worktree (defaults to the target's session repository)")
 	worktreeStart := fs.String("from", "", "starting ref for --worktree")
 	worktreePath := fs.String("worktree-path", "", "custom path for --worktree")
+	noWorktree := fs.Bool("no-worktree", false, "reuse the resolved checkout instead of creating a worktree")
 	requestID := fs.String("request-id", "", "stable delegation request id")
 	allowWorktreeReuse := fs.Bool("allow-worktree-reuse", false, "allow active sessions to share a worktree")
 	if err := fs.Parse(args); err != nil {
@@ -2330,8 +2333,8 @@ func parseDelegateArgs(args []string) (delegateCLIArgs, error) {
 	if explicitWorkspace != "" && (*newWorkspace || customCWD != "") {
 		return delegateCLIArgs{}, errors.New("--workspace cannot be combined with --new-workspace or --cwd")
 	}
-	if branch == "" && (repo != "" || startingFrom != "" || customWorktreePath != "") {
-		return delegateCLIArgs{}, errors.New("--repo, --from, and --worktree-path require --worktree")
+	if *noWorktree && (branch != "" || repo != "" || startingFrom != "" || customWorktreePath != "") {
+		return delegateCLIArgs{}, errors.New("--no-worktree cannot be combined with --worktree, --repo, --from, or --worktree-path")
 	}
 
 	placement := "current_workspace"
@@ -2358,6 +2361,7 @@ func parseDelegateArgs(args []string) (delegateCLIArgs, error) {
 			Worktree:           branch,
 			WorktreePath:       customWorktreePath,
 			StartingFrom:       startingFrom,
+			NoWorktree:         *noWorktree,
 			AllowWorktreeReuse: *allowWorktreeReuse,
 		},
 	}, nil

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -501,6 +500,40 @@ func TestParseDelegateArgsDefaultsToCurrentWorkspace(t *testing.T) {
 	if parsed.options.Placement != "current_workspace" {
 		t.Fatalf("placement = %q", parsed.options.Placement)
 	}
+	if parsed.options.NoWorktree {
+		t.Fatal("plain delegation unexpectedly disabled the default worktree")
+	}
+}
+
+func TestParseDelegateArgsNoWorktree(t *testing.T) {
+	parsed, err := parseDelegateArgs([]string{
+		"--source-session", "source-session",
+		"--brief", "Continue in this checkout",
+		"--no-worktree",
+	})
+	if err != nil {
+		t.Fatalf("parseDelegateArgs() error = %v", err)
+	}
+	if !parsed.options.NoWorktree {
+		t.Fatal("options.NoWorktree = false, want true")
+	}
+}
+
+func TestParseDelegateArgsRejectsNoWorktreeOverrides(t *testing.T) {
+	for _, args := range [][]string{
+		{"--no-worktree", "--worktree", "feat/parser"},
+		{"--no-worktree", "--repo", "/tmp/repo"},
+		{"--no-worktree", "--from", "main"},
+		{"--no-worktree", "--worktree-path", "/tmp/worktree"},
+	} {
+		_, err := parseDelegateArgs(append([]string{
+			"--source-session", "source-session",
+			"--brief", "Conflicting placement",
+		}, args...))
+		if err == nil {
+			t.Fatalf("parseDelegateArgs(%v) error = %v", args, err)
+		}
+	}
 }
 
 func TestParseDelegateArgsNameSetsLabel(t *testing.T) {
@@ -620,18 +653,6 @@ func TestParseDelegateArgsAcceptsCwdWithWorktree(t *testing.T) {
 	}
 }
 
-func TestWriteHelpMentionsPresenceAndOpen(t *testing.T) {
-	var output bytes.Buffer
-	writeHelp(&output)
-
-	text := output.String()
-	for _, expected := range []string{"presence", "delegate --brief-file <path>", "workspace context <command>", "open <file.md> [--session <id>]", "pr wait-ready <pr>"} {
-		if !strings.Contains(text, expected) {
-			t.Fatalf("help output missing %q: %q", expected, text)
-		}
-	}
-}
-
 func TestWorkspaceContextSourceSessionDefaultsToEnvironment(t *testing.T) {
 	t.Setenv("ATTN_SESSION_ID", "session-1")
 	sessionID, force, err := workspaceContextSourceSession([]string{"--force"}, true)
@@ -647,44 +668,6 @@ func TestWorkspaceContextSourceSessionRejectsForceForStatus(t *testing.T) {
 	_, _, err := workspaceContextSourceSession([]string{"--session", "session-1", "--force"}, false)
 	if err == nil || !strings.Contains(err.Error(), "--force is only valid") {
 		t.Fatalf("workspaceContextSourceSession error = %v", err)
-	}
-}
-
-func TestWriteWorkspaceHelpMentionsMaintenanceCommands(t *testing.T) {
-	var output bytes.Buffer
-	writeWorkspaceHelp(&output)
-
-	text := output.String()
-	for _, expected := range []string{
-		"compact [--session <id>]",
-		"rollback [--session <id>]",
-	} {
-		if !strings.Contains(text, expected) {
-			t.Fatalf("workspace help missing %q: %q", expected, text)
-		}
-	}
-}
-
-func TestWriteDelegateHelpMentionsPlacementOptions(t *testing.T) {
-	var output bytes.Buffer
-	writeDelegateHelp(&output)
-
-	text := output.String()
-	for _, expected := range []string{
-		"--new-workspace",
-		"--workspace <id>",
-		"--cwd <path>",
-		"--worktree <branch>",
-		"combine with any placement (current, --workspace, or --new-workspace)",
-		"--agent <name>",
-		"--name <text>",
-	} {
-		if !strings.Contains(text, expected) {
-			t.Fatalf("delegate help missing %q: %q", expected, text)
-		}
-	}
-	if strings.Contains(text, "--label") {
-		t.Fatalf("delegate help still mentions removed --label flag: %q", text)
 	}
 }
 

--- a/cmd/attn/pr_test.go
+++ b/cmd/attn/pr_test.go
@@ -1212,9 +1212,6 @@ func TestExecutePRCommandShowsSubcommandHelp(t *testing.T) {
 	if code := executePRCommand([]string{"wait-ready", "--help"}, &stdout, &bytes.Buffer{}); code != 0 {
 		t.Fatalf("exit code = %d", code)
 	}
-	if !strings.Contains(stdout.String(), "exit: 0 approved") {
-		t.Fatalf("help = %q", stdout.String())
-	}
 }
 
 func readinessObservation(number, head, checks, review string) *prReadiness {

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -79,12 +79,12 @@ these flags.
 
 ## Placement
 
-For work involving a Git repository, start each delegation in a new worktree by
-default—even for read-only investigation or discussion. Base it on the branch
-relevant to the task, or the repository's default branch when none is specified.
-Reuse the current checkout only when the user asks or the delegation clearly
-continues work already happening there; more specific repository or agent
-guidance takes precedence.
+For work involving a Git repository, `attn delegate` creates a new worktree by
+default—even for read-only investigation or discussion. Use `--from` when the
+task needs a particular starting branch; otherwise attn uses the repository's
+default branch. Pass `--no-worktree` only when the user asks to reuse the current
+checkout, the delegation clearly continues work already happening there, or more
+specific repository or agent guidance requires it.
 
 Before creating a new workspace, check whether an existing one already fits the
 work. `attn list` returns sessions grouped by `workspace_id`; use the session
@@ -116,8 +116,9 @@ When the source session is the chief of staff, delegating into a muted existing
 workspace automatically unmutes it so the new agent is visible in the sidebar.
 Ordinary delegation preserves the workspace's current mute state.
 
-`--worktree` creates an isolated git worktree for branch isolation. It combines
-with any placement:
+Git repositories get an isolated worktree with an automatically generated branch.
+Use `--worktree` to choose the branch name explicitly. It combines with any
+placement:
 
     # worktree in the current workspace
     attn delegate --brief-file "$brief_file" \

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -79,6 +79,13 @@ these flags.
 
 ## Placement
 
+For work involving a Git repository, start each delegation in a new worktree by
+default—even for read-only investigation or discussion. Base it on the branch
+relevant to the task, or the repository's default branch when none is specified.
+Reuse the current checkout only when the user asks or the delegation clearly
+continues work already happening there; more specific repository or agent
+guidance takes precedence.
+
 Before creating a new workspace, check whether an existing one already fits the
 work. `attn list` returns sessions grouped by `workspace_id`; use the session
 labels, directories, and workspace IDs to identify domain workspaces the user

--- a/internal/agent/attn_skill_test.go
+++ b/internal/agent/attn_skill_test.go
@@ -1,190 +1,81 @@
 package agent
 
 import (
+	"bytes"
+	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/victorarias/attn/internal/toolhome"
 )
 
-func readSkillFile(t *testing.T, skillDir, relative string) string {
-	t.Helper()
-	path := filepath.Join(skillDir, filepath.FromSlash(relative))
-	content, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile(%s) error = %v", path, err)
-	}
-	return string(content)
-}
-
 func assertAttnSkillTree(t *testing.T, skillDir string) {
 	t.Helper()
 
-	index := readSkillFile(t, skillDir, "SKILL.md")
-	for _, expected := range []string{
-		"name: attn",
-		"Operate attn capabilities from an agent",
-		"Use when the user explicitly asks for an attn capability or delegation",
-		"inspect, converse with, and steer directly",
-		"ATTN_WRAPPER_PATH",
-		"attn presence",
-		"bare `attn`",
-		"recover with",
-		"references/delegation.md",
-		"references/delegated-agent.md",
-		"references/tickets.md",
-		"references/workspace-context.md",
-		"references/workflow.md",
-		"references/markdown.md",
-		"references/browser.md",
-		"Load more than one reference only when",
-		// the role front-door: a delegated leaf must learn, before reading
-		// anything about delegation, that being tracked is not being the chief.
-		"Confirm Your Role First",
-		"delegated leaf",
-	} {
-		if !strings.Contains(index, expected) {
-			t.Fatalf("skill index missing %q: %q", expected, index)
+	expected := map[string]bool{}
+	err := fs.WalkDir(attnSkillFiles, "attn_skill", func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
 		}
-	}
-	if strings.Contains(index, "browser command find_element") {
-		t.Fatalf("skill index contains capability details that belong in a reference: %q", index)
+		if path == "attn_skill" {
+			return nil
+		}
+
+		relative, err := filepath.Rel("attn_skill", path)
+		if err != nil {
+			return err
+		}
+		relative = filepath.FromSlash(relative)
+		expected[relative] = true
+
+		installedPath := filepath.Join(skillDir, relative)
+		if entry.IsDir() {
+			info, err := os.Stat(installedPath)
+			if err != nil {
+				t.Fatalf("stat installed skill directory %s: %v", installedPath, err)
+			}
+			if !info.IsDir() {
+				t.Fatalf("installed skill path %s is not a directory", installedPath)
+			}
+			return nil
+		}
+
+		want, err := attnSkillFiles.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		got, err := os.ReadFile(installedPath)
+		if err != nil {
+			t.Fatalf("read installed skill file %s: %v", installedPath, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("installed skill file %s differs from bundled source", installedPath)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk bundled attn skill: %v", err)
 	}
 
-	delegatedAgent := readSkillFile(t, skillDir, "references/delegated-agent.md")
-	for _, expected := range []string{
-		"You Are A Leaf, Not A Coordinator",
-		"A subagent is always a native runtime",
-		"explicit request from the user steering this session selects attn delegation",
-		"Native subagents report to you",
-		"ticket status in_progress",
-		"ticket status needs_input",
-		"ticket status ready_for_review",
-		"ticket status completed",
-		"ticket status failed",
-		"strong terminal evidence",
-		"requested PR merged",
-		"use `ready_for_review`",
-		"Do not report ticket status for ordinary",
-	} {
-		if !strings.Contains(delegatedAgent, expected) {
-			t.Fatalf("delegated-agent reference missing %q: %q", expected, delegatedAgent)
+	err = filepath.WalkDir(skillDir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
 		}
-	}
-	if strings.Contains(delegatedAgent, "ask the user to confirm") {
-		t.Fatalf("delegated-agent reference retained mandatory confirmation gate: %q", delegatedAgent)
-	}
-	// The chief-of-staff coordination guidance (surface vs act boundary and the
-	// prose-review exception) moved to the always-on system prompt
-	// (hooks.ChiefGuidance); this worker-facing reference must not carry it back,
-	// and must keep the retired dispatch UX out.
-	for _, chiefOrLegacy := range []string{
-		"As Chief of Staff",
-		"do not validate that specialist work",
-		"coordination-file",
-	} {
-		if strings.Contains(delegatedAgent, chiefOrLegacy) {
-			t.Fatalf("delegated-agent reference should not carry chief/legacy guidance %q: %q", chiefOrLegacy, delegatedAgent)
+		if path == skillDir {
+			return nil
 		}
-	}
-
-	tickets := readSkillFile(t, skillDir, "references/tickets.md")
-	for _, expected := range []string{
-		"attn ticket new",         // the backlog-create command
-		"backlog",                 // the unbound-todo lane
-		"Only when the user asks", // user-triggered boundary
-		"deliverable",             // deliverable-type shaping guidance
-		"evidence decides it",     // completion threshold, not a ritual gate
-		"requested PR merged",     // objective terminal evidence example
-	} {
-		if !strings.Contains(tickets, expected) {
-			t.Fatalf("tickets reference missing %q: %q", expected, tickets)
+		relative, err := filepath.Rel(skillDir, path)
+		if err != nil {
+			return err
 		}
-	}
-
-	delegation := readSkillFile(t, skillDir, "references/delegation.md")
-	for _, expected := range []string{
-		"full interactive agent session",
-		"A subagent is always a native runtime subagent",
-		"explicit user request selects attn delegation",
-		"delegate subagents to review",
-		"dispatch an agent",
-		"delegate --brief-file",
-		"--new-workspace",
-		"Before creating a new workspace, check whether an existing one already fits",
-		"--workspace <workspace-id>",
-		"--cwd /path/to/project",
-		"--worktree feat/delegated-task",
-		"isolated git worktree for branch isolation",
-		"--new-workspace --worktree feat/delegated-task",
-		"--worktree-path <path>",
-		"--source-session <session-id>",
-		"Copilot delegation is currently unsupported",
-		"durable parent-child lineage",
-		"all runtimes receive the same ticket nudge",
-		"Claude may",
-	} {
-		if !strings.Contains(delegation, expected) {
-			t.Fatalf("delegation reference missing %q: %q", expected, delegation)
+		if !expected[relative] {
+			t.Fatalf("installed skill contains unexpected path %s", path)
 		}
-	}
-
-	workspaceContext := readSkillFile(t, skillDir, "references/workspace-context.md")
-	for _, expected := range []string{
-		"durable coordination state",
-		"area map, not a single-task brief",
-		"## Area",
-		"## Current Picture",
-		"## Threads",
-		"## Timeline",
-		"Threads are optional semantic slices",
-		"Never infer dates, order, causality, ownership",
-		"Attn owns occasional broad compaction",
-		"Publish only when durable shared state has changed",
-		"Do not pass `--session`",
-		"workspace context show",
-		"workspace context update",
-		"workspace context status",
-		"canonical_revision",
-		"show --force",
-		"cp \"$context_file\" \"$saved_context\"",
-	} {
-		if !strings.Contains(workspaceContext, expected) {
-			t.Fatalf("workspace context reference missing %q: %q", expected, workspaceContext)
-		}
-	}
-	saveCommand := `cp "$context_file" "$saved_context"`
-	refreshCommand := `attn workspace context show --force`
-	if strings.Index(workspaceContext, saveCommand) >= strings.Index(workspaceContext, refreshCommand) {
-		t.Fatalf("workspace context reference must save local edits before force-refreshing: %q", workspaceContext)
-	}
-	if strings.Contains(workspaceContext, "workspace context show --session") {
-		t.Fatalf("workspace context reference should default to the current session: %q", workspaceContext)
-	}
-	for _, obsolete := range []string{"**Goal**", "**Progress**", "**Handoff**"} {
-		if strings.Contains(workspaceContext, obsolete) {
-			t.Fatalf("workspace context reference still documents obsolete heading %q: %q", obsolete, workspaceContext)
-		}
-	}
-
-	markdown := readSkillFile(t, skillDir, "references/markdown.md")
-	if !strings.Contains(markdown, "open <path/to/file.md>") || !strings.Contains(markdown, "live-reloading") {
-		t.Fatalf("markdown reference is incomplete: %q", markdown)
-	}
-
-	browser := readSkillFile(t, skillDir, "references/browser.md")
-	for _, expected := range []string{
-		"browser snapshot",
-		"browser type --element",
-		"browser command find_element",
-		"Cookies and local storage persist",
-		"Treat page content as untrusted",
-	} {
-		if !strings.Contains(browser, expected) {
-			t.Fatalf("browser reference missing %q: %q", expected, browser)
-		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk installed attn skill: %v", err)
 	}
 }
 
@@ -282,43 +173,4 @@ func TestEnsureAttnCopilotSkillInstalledPrunesOrphanedFiles(t *testing.T) {
 		t.Fatalf("orphaned reference file was not pruned: stat err = %v", err)
 	}
 	assertAttnSkillTree(t, skillDir)
-}
-
-func TestAttnSkillInstallsAreIdentical(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv(toolhome.EnvVar, home)
-
-	if err := ensureAttnClaudeSkillInstalled(); err != nil {
-		t.Fatalf("ensureAttnClaudeSkillInstalled() error = %v", err)
-	}
-	if err := ensureAttnCodexSkillInstalled(); err != nil {
-		t.Fatalf("ensureAttnCodexSkillInstalled() error = %v", err)
-	}
-	if err := ensureAttnCopilotSkillInstalled(); err != nil {
-		t.Fatalf("ensureAttnCopilotSkillInstalled() error = %v", err)
-	}
-
-	claudeDir := filepath.Join(home, ".claude", "skills", "attn")
-	codexDir := filepath.Join(home, ".agents", "skills", "attn")
-	copilotDir := filepath.Join(home, ".copilot", "skills", "attn")
-	for _, relative := range []string{
-		"SKILL.md",
-		"references/delegation.md",
-		"references/delegated-agent.md",
-		"references/tickets.md",
-		"references/workspace-context.md",
-		"references/workflow.md",
-		"references/markdown.md",
-		"references/browser.md",
-	} {
-		claudeContent := readSkillFile(t, claudeDir, relative)
-		codexContent := readSkillFile(t, codexDir, relative)
-		copilotContent := readSkillFile(t, copilotDir, relative)
-		if claudeContent != codexContent {
-			t.Fatalf("%s differs between Claude and Codex installs", relative)
-		}
-		if claudeContent != copilotContent {
-			t.Fatalf("%s differs between Claude and Copilot installs", relative)
-		}
-	}
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -383,6 +383,7 @@ type DelegateOptions struct {
 	Worktree           string
 	WorktreePath       string
 	StartingFrom       string
+	NoWorktree         bool
 	AllowWorktreeReuse bool
 }
 
@@ -426,18 +427,26 @@ func (c *Client) StartDelegation(sourceSessionID, brief string, opts DelegateOpt
 	if value := strings.TrimSpace(opts.CWD); value != "" {
 		msg.Cwd = protocol.Ptr(value)
 	}
-	if branch := strings.TrimSpace(opts.Worktree); branch != "" {
+	branch := strings.TrimSpace(opts.Worktree)
+	worktreeRepo := strings.TrimSpace(opts.WorktreeRepo)
+	worktreePath := strings.TrimSpace(opts.WorktreePath)
+	startingFrom := strings.TrimSpace(opts.StartingFrom)
+	worktreeConfigured := branch != "" || worktreeRepo != "" || worktreePath != "" || startingFrom != ""
+	if opts.NoWorktree && worktreeConfigured {
+		return nil, errors.New("no worktree cannot be combined with worktree options")
+	}
+	if !opts.NoWorktree {
 		msg.Worktree = &protocol.DelegateWorktreeRequest{
 			Branch: branch,
 		}
-		if value := strings.TrimSpace(opts.WorktreeRepo); value != "" {
-			msg.Worktree.Repo = protocol.Ptr(value)
+		if worktreeRepo != "" {
+			msg.Worktree.Repo = protocol.Ptr(worktreeRepo)
 		}
-		if value := strings.TrimSpace(opts.WorktreePath); value != "" {
-			msg.Worktree.Path = protocol.Ptr(value)
+		if worktreePath != "" {
+			msg.Worktree.Path = protocol.Ptr(worktreePath)
 		}
-		if value := strings.TrimSpace(opts.StartingFrom); value != "" {
-			msg.Worktree.StartingFrom = protocol.Ptr(value)
+		if startingFrom != "" {
+			msg.Worktree.StartingFrom = protocol.Ptr(startingFrom)
 		}
 	}
 	resp, err := c.send(msg)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -373,6 +373,7 @@ func TestClient_Delegate(t *testing.T) {
 		Worktree:     "feat/parser",
 		WorktreePath: "/tmp/repo--feat-parser",
 		StartingFrom: "main",
+		NoWorktree:   false,
 	})
 	if err != nil {
 		t.Fatalf("Delegate error: %v", err)
@@ -403,6 +404,75 @@ func TestClient_Delegate(t *testing.T) {
 		protocol.Deref(request.Worktree.Path) != "/tmp/repo--feat-parser" ||
 		protocol.Deref(request.Worktree.StartingFrom) != "main" {
 		t.Fatalf("Delegate request worktree = %+v", request.Worktree)
+	}
+}
+
+func TestClientDelegateNoWorktree(t *testing.T) {
+	tmpDir := t.TempDir()
+	sockPath := filepath.Join(tmpDir, "test.sock")
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen error: %v", err)
+	}
+	defer listener.Close()
+
+	requests := make(chan *protocol.DelegateMessage, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var raw json.RawMessage
+		if err := json.NewDecoder(conn).Decode(&raw); err != nil {
+			return
+		}
+		_, msg, err := protocol.ParseMessage(raw)
+		if err != nil {
+			return
+		}
+		requests <- msg.(*protocol.DelegateMessage)
+		_ = json.NewEncoder(conn).Encode(protocol.Response{
+			Ok: true,
+			DelegationOperation: &protocol.DelegationOperation{
+				OperationID: "operation-1",
+				RequestID:   "request-1",
+				SessionID:   "delegated-session",
+				State:       protocol.DelegationOperationStateCompleted,
+				Result: &protocol.DelegateResult{
+					SessionID:   "delegated-session",
+					WorkspaceID: "workspace-1",
+					Directory:   "/tmp/project",
+					Placement:   "current_workspace",
+				},
+			},
+		})
+	}()
+
+	_, err = New(sockPath).Delegate("source-session", "Continue here", DelegateOptions{
+		RequestID:  "request-1",
+		NoWorktree: true,
+	})
+	if err != nil {
+		t.Fatalf("Delegate error: %v", err)
+	}
+	request := <-requests
+	if request.Worktree != nil {
+		t.Fatalf("Delegate request = %+v, want no worktree request", request)
+	}
+}
+
+func TestClientDelegateRejectsNoWorktreeWithOverrides(t *testing.T) {
+	_, err := New(filepath.Join(t.TempDir(), "missing.sock")).StartDelegation(
+		"source-session",
+		"Conflicting worktree options",
+		DelegateOptions{
+			NoWorktree:   true,
+			StartingFrom: "main",
+		},
+	)
+	if err == nil {
+		t.Fatalf("StartDelegation() error = %v", err)
 	}
 }
 

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -324,10 +324,9 @@ func (d *Daemon) delegationWorktreeRepo(workspaceID string) (string, error) {
 	}
 }
 
-// delegationDefaultStartRef names the ref a delegated worktree starts from when
-// no working directory supplies a defensible starting point. It returns "" when
-// the repository's default branch cannot be resolved at all, leaving the caller
-// with git's own current-HEAD behaviour as a last resort.
+// delegationDefaultStartRef names the ref an automatically created delegated
+// worktree starts from. It returns "" when the repository's default branch
+// cannot be resolved, so the caller can ask for an explicit --from value.
 //
 // Prefers the remote-tracking ref, matching how the app's own new-worktree flow
 // defaults (RepoOptions.tsx), so a delegated branch starts from what upstream
@@ -350,6 +349,67 @@ func delegationDefaultStartRef(repo string) string {
 		return branch
 	}
 	return ""
+}
+
+func automaticDelegationBranch(label, sessionID string) string {
+	slug := ticketSlug(label)
+	if slug == "ticket" {
+		slug = "work"
+	}
+	suffix := strings.ReplaceAll(sessionID, "-", "")
+	if len(suffix) > 8 {
+		suffix = suffix[:8]
+	}
+	return "delegate/" + slug + "-" + suffix
+}
+
+// applyDefaultDelegationWorktree resolves an empty worktree request into the
+// automatic Git-repository default. A nil request is the caller's explicit
+// opt-out, while a named branch preserves the existing explicit behavior.
+func (d *Daemon) applyDefaultDelegationWorktree(msg *protocol.DelegateMessage, placement, workspaceID, directory, sessionID, label string) error {
+	if msg.Worktree == nil {
+		return nil
+	}
+	if strings.TrimSpace(msg.Worktree.Branch) != "" {
+		return nil
+	}
+
+	request := msg.Worktree
+	configuredWorktree := strings.TrimSpace(protocol.Deref(request.Repo)) != "" ||
+		strings.TrimSpace(protocol.Deref(request.Path)) != "" ||
+		strings.TrimSpace(protocol.Deref(request.StartingFrom)) != ""
+	repo := strings.TrimSpace(protocol.Deref(request.Repo))
+	if repo == "" && placement == delegationPlacementExisting {
+		resolvedRepo, err := d.delegationWorktreeRepo(workspaceID)
+		if err != nil {
+			return err
+		}
+		repo = resolvedRepo
+	}
+	if repo == "" {
+		root, err := git.GetRepoRoot(directory)
+		if err != nil {
+			if configuredWorktree {
+				return fmt.Errorf("workspace directory is not in a git repository; pass --repo")
+			}
+			msg.Worktree = nil
+			return nil
+		}
+		repo = root
+	}
+	repo = git.ResolveMainRepoPath(repo)
+
+	request.Repo = protocol.Ptr(repo)
+	request.Branch = automaticDelegationBranch(label, sessionID)
+	if strings.TrimSpace(protocol.Deref(request.StartingFrom)) == "" {
+		startingFrom := delegationDefaultStartRef(repo)
+		if startingFrom == "" {
+			return fmt.Errorf("cannot determine the repository's default branch; pass --from or --no-worktree")
+		}
+		request.StartingFrom = protocol.Ptr(startingFrom)
+	}
+	msg.Worktree = request
+	return nil
 }
 
 // createDelegationWorktree creates the worktree. inferredRepo, when non-empty,
@@ -634,6 +694,10 @@ func (d *Daemon) delegateOperation(msg *protocol.DelegateMessage, operationID, r
 		}
 	default:
 		return nil, fmt.Errorf("unsupported placement %q", placement)
+	}
+
+	if err := d.applyDefaultDelegationWorktree(msg, placement, workspaceID, directory, sessionID, name); err != nil {
+		return nil, err
 	}
 
 	// Naming scope: a new workspace must take a globally-unique name; a session

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -127,11 +127,7 @@ func TestDelegateSpawnsAgentInSourceWorkspaceWithBrief(t *testing.T) {
 	if result.WorkspaceID != workspaceID || result.Directory != cwd {
 		t.Fatalf("result = %+v, want workspace=%s directory=%s", result, workspaceID, cwd)
 	}
-	// Every delegated agent's initial prompt is prefixed with the leaf identity
-	// line so a non-chief-delegated leaf — which gets no ticket-report contract —
-	// still has a positive signal that it is a leaf, not a coordinator.
-	if !strings.Contains(prompt, "a leaf, not a coordinator") ||
-		!strings.Contains(prompt, "Investigate the delegated task.") {
+	if !strings.Contains(prompt, "Investigate the delegated task.") {
 		t.Fatalf("initial prompt = %q", prompt)
 	}
 	if promptPath == "" {
@@ -147,6 +143,62 @@ func TestDelegateSpawnsAgentInSourceWorkspaceWithBrief(t *testing.T) {
 	layout := d.store.GetWorkspaceLayout(workspaceID)
 	if layout == nil || len(layout.Panes) != 2 {
 		t.Fatalf("workspace layout = %+v, want two panes", layout)
+	}
+}
+
+func TestDelegateDefaultsToNewWorktreeForGitRepository(t *testing.T) {
+	root := t.TempDir()
+	mainRepo := initDelegationRepo(t, root, "repo")
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	workspaceID, sourceSessionID, _ := setupDelegationSourceAt(t, d, backend, mainRepo)
+	consumeDelegatedPrompt(t, backend)
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Investigate the repository.",
+		Label:           protocol.Ptr("parser"),
+		Worktree:        &protocol.DelegateWorktreeRequest{},
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+	if result.WorkspaceID != workspaceID ||
+		result.Directory == mainRepo ||
+		!protocol.Deref(result.WorktreeCreated) {
+		t.Fatalf("result = %+v, want isolated worktree in source workspace", result)
+	}
+	if got := git.CanonicalizePath(git.GetMainRepoFromWorktree(result.Directory)); got != mainRepo {
+		t.Fatalf("worktree main repo = %q, want %q", got, mainRepo)
+	}
+	session := d.store.Get(result.SessionID)
+	if session == nil || !strings.HasPrefix(protocol.Deref(session.Branch), "delegate/parser-") {
+		t.Fatalf("delegated session = %+v, want generated branch", session)
+	}
+}
+
+func TestDelegateNoWorktreeReusesGitCheckout(t *testing.T) {
+	root := t.TempDir()
+	mainRepo := initDelegationRepo(t, root, "repo")
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	workspaceID, sourceSessionID, _ := setupDelegationSourceAt(t, d, backend, mainRepo)
+	consumeDelegatedPrompt(t, backend)
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Continue in the existing checkout.",
+		Label:           protocol.Ptr("continuation"),
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+	if result.WorkspaceID != workspaceID ||
+		result.Directory != mainRepo ||
+		protocol.Deref(result.WorktreeCreated) {
+		t.Fatalf("result = %+v, want source checkout without worktree", result)
 	}
 }
 
@@ -183,28 +235,8 @@ func TestChiefOfStaffDelegateBindsTicketAndPrompt(t *testing.T) {
 		t.Fatalf("delegate() error = %v", err)
 	}
 
-	// A chief delegation now binds a ticket (no parallel dispatch record), and the
-	// initial prompt teaches the agent to self-report via `ticket status`.
-	if !strings.Contains(prompt, "Investigate the tracked task.") ||
-		!strings.Contains(prompt, "ticket status in_progress") ||
-		!strings.Contains(prompt, "ticket status completed") ||
-		strings.Contains(prompt, "dispatch ") {
+	if !strings.Contains(prompt, "Investigate the tracked task.") {
 		t.Fatalf("tracked initial prompt = %q", prompt)
-	}
-	// Completion follows strong terminal evidence, not a mandatory confirmation
-	// ritual; implementation finished while review remains maps to in-review.
-	for _, expected := range []string{"strong terminal evidence", "user accepted the work", "requested PR merged", "ready_for_review"} {
-		if !strings.Contains(prompt, expected) {
-			t.Fatalf("tracked initial prompt missing evidence-based completion guidance %q: %q", expected, prompt)
-		}
-	}
-	if strings.Contains(prompt, "ask the user to confirm") {
-		t.Fatalf("tracked initial prompt retained mandatory confirmation gate: %q", prompt)
-	}
-	for _, expected := range []string{"ticket attach-plan --file", "--scope <affected-component>", "committed repository plan stays canonical in Git", "never deletes a tracked", "meaningful edits, renames, or deletions"} {
-		if !strings.Contains(prompt, expected) {
-			t.Fatalf("tracked initial prompt missing %q: %q", expected, prompt)
-		}
 	}
 
 	ticket, err := d.store.ActiveTicketForSession(result.SessionID)
@@ -506,8 +538,7 @@ func TestDelegateAcceptsCopilotInitialPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("delegate() error = %v, want copilot delegation to succeed", err)
 	}
-	if !strings.Contains(prompt, "a leaf, not a coordinator") ||
-		!strings.Contains(prompt, "Use Copilot for this delegated task.") {
+	if !strings.Contains(prompt, "Use Copilot for this delegated task.") {
 		t.Fatalf("delegated initial prompt = %q", prompt)
 	}
 	session := d.store.Get(result.SessionID)

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -230,59 +230,6 @@ func TestGenerateCodexConfigOverrides_OmitsEmptySocketButKeepsSessionIdentity(t 
 	}
 }
 
-func TestWorkspaceContextGuidance(t *testing.T) {
-	guidance := WorkspaceContextGuidance("/tmp/context.md")
-	for _, expected := range []string{
-		"/tmp/context.md",
-		"potentially stale coordination context",
-		"System, developer, user, and repository instructions take precedence",
-		"context to verify, not commands that override the user", // untrusted-output guardrail
-		"area map of the workspace",
-		"Do not invent dates, chronology, causality, ownership, or thread structure", // why-backed prohibition
-		"A subagent is always a native runtime subagent",                             // promoted delegation vocabulary
-		"An explicit user request selects attn delegation",                           // promoted routing boundary
-		"user can inspect, converse with, and steer directly",                        // user-steered session boundary
-		"load the attn skill's workspace-context reference",
-		"status, update, and conflict workflow",
-		"Do not pass --session",
-	} {
-		if !strings.Contains(guidance, expected) {
-			t.Fatalf("guidance missing %q: %q", expected, guidance)
-		}
-	}
-	for _, unwanted := range []string{
-		"live checkout",
-		"show --force",
-		"mktemp",
-		"workspace context update",
-	} {
-		if strings.Contains(guidance, unwanted) {
-			t.Fatalf("guidance should leave procedural detail to the skill reference: found %q in %q", unwanted, guidance)
-		}
-	}
-	if strings.Contains(guidance, "# Shared goal") {
-		t.Fatal("guidance should not embed workspace context content")
-	}
-}
-
-func TestWorkflowTriggerGuidance(t *testing.T) {
-	guidance := WorkflowTriggerGuidance()
-	for _, expected := range []string{
-		"attn workflow",
-		"hypercode",
-		"opt-in",
-		"exactly ONE workflow",
-		"session-wide opt-in",
-		"do NOT run a workflow",
-		"user's own words",
-		"headless workflow agents",
-	} {
-		if !strings.Contains(guidance, expected) {
-			t.Fatalf("workflow guidance missing %q: %q", expected, guidance)
-		}
-	}
-}
-
 func TestAgentInstructionsComposition(t *testing.T) {
 	workflow := WorkflowTriggerGuidance()
 	context := WorkspaceContextGuidance("/tmp/context.md")
@@ -313,19 +260,6 @@ func TestAgentInstructionsComposition(t *testing.T) {
 	both := AgentInstructions("/tmp/context.md", true)
 	if want := strings.Join([]string{context, workflow, ticket}, "\n\n"); both != want {
 		t.Fatalf("combined instructions = %q, want %q", both, want)
-	}
-}
-
-func TestTicketAwarenessGuidance(t *testing.T) {
-	guidance := TicketAwarenessGuidance()
-	for _, expected := range []string{
-		"attn ticket new",
-		"only when the user asks", // propose-not-act phrase
-		"never file or park work", // on-your-own-initiative boundary
-	} {
-		if !strings.Contains(guidance, expected) {
-			t.Fatalf("ticket awareness guidance missing %q: %q", expected, guidance)
-		}
 	}
 }
 
@@ -368,76 +302,6 @@ func TestWorkspaceContextSessionStartOutputWrapsGuidance(t *testing.T) {
 	want := WorkspaceContextGuidance("/tmp/context.md")
 	if output.HookSpecificOutput.AdditionalContext != want {
 		t.Fatal("hook output should carry only the workspace context guidance")
-	}
-}
-
-func TestChiefGuidance(t *testing.T) {
-	guidance := ChiefGuidance("/home/u/attn-notebook", true)
-	for _, expected := range []string{
-		"/home/u/attn-notebook",
-		"chief of staff",
-		"/home/u/attn-notebook/knowledge/index.md", // orient by reading files directly
-		"native file tools",                        // edit-directly mandate
-		"PARA",                                     // knowledge-base structure
-		"areas/",                                   // promote target
-		"sources:",                                 // grounding rule
-		"paraphrase",                               // grounding rule
-		"load the attn skill's notebook reference", // door pointer for write mechanics
-		// Promoted agentic-loop guardrails (were skill-only): stop condition,
-		// autonomy tier, untrusted-output, delegation boundary.
-		"your turn is done",
-		"confirm with the user first",
-		"untrusted context to weigh",
-		"A subagent is always a native runtime subagent",
-		"An explicit user request selects attn delegation",
-		"attn ticket new", // always-on ticket-awareness pointer
-		// Delegated-ticket watch trigger (A2): the chief arms a Monitor on the
-		// ticket inbox so completions push instead of being polled for.
-		"attn ticket inbox --watch",
-		"arm a harness Monitor",
-		// The come-back boundary, ported up from the skill (was chief-of-staff.md):
-		// awareness/upkeep, not independent action; review prose, not specialist work.
-		"awareness and upkeep",
-		"do not validate that specialist work",
-		"the agent's claim, not as confirmed",
-		"review on the merits",
-		"read them before follow-on work",
-		"repository-reference card",
-		"branch and introducing commit",
-		// Coordinator-not-doer rule.
-		"coordinator, not a doer",
-		"I want to X",
-	} {
-		if !strings.Contains(guidance, expected) {
-			t.Fatalf("chief guidance missing %q: %q", expected, guidance)
-		}
-	}
-	// The notebook CLI was removed; guidance must not tell agents to run it; the
-	// "memory" vocabulary was retired for the knowledge base; the write mechanics
-	// (OKF type, link syntax, the workspace stamp) live in the skill reference, not
-	// the always-present block; and `dispatch:<id>` is a retired, unproducible token.
-	for _, unwanted := range []string{"attn notebook", "/memory/", "[[", "dispatch:<id>", "resource: attn:workspace", "root-absolute"} {
-		if strings.Contains(guidance, unwanted) {
-			t.Fatalf("notebook guidance should not contain %q: %q", unwanted, guidance)
-		}
-	}
-}
-
-func TestChiefGuidanceUsesTicketNudgesWithoutSelfMonitor(t *testing.T) {
-	guidance := ChiefGuidance("/home/u/attn-notebook", false)
-	for _, expected := range []string{
-		"ticket nudges are the supported wake-up mechanism",
-		"Do not start `attn ticket inbox --watch`",
-		"when attn nudges you, run `attn ticket inbox`",
-		"your turn is done until attn nudges you",
-		"When delegated ticket activity comes back",
-	} {
-		if !strings.Contains(guidance, expected) {
-			t.Fatalf("non-self-monitor chief guidance missing %q: %q", expected, guidance)
-		}
-	}
-	if strings.Contains(guidance, "arm a harness Monitor") {
-		t.Fatalf("non-self-monitor chief guidance should not instruct the runtime to arm a Monitor: %q", guidance)
 	}
 }
 


### PR DESCRIPTION
## Intent / Why

Delegated agents should not share a Git checkout by accident. A plain `attn
delegate` should provide isolation itself instead of relying on guidance to make
every caller assemble the right worktree flags.

## Summary

- Create a new worktree automatically when a delegation targets a Git
  repository.
- Start from the repository's default branch unless `--from` selects another
  ref; keep `--worktree`, `--repo`, and `--worktree-path` as explicit overrides.
- Add `--no-worktree` for deliberate continuation in the resolved checkout.
- Keep non-Git delegations in their resolved directory.
- Update the bundled delegation guidance to describe the CLI behavior and let
  more specific repository or agent guidance choose the opt-out.
- Remove tests that duplicated help or guidance prose while preserving behavior,
  routing, installation, and pruning checks.

## Test plan

- [x] `go test ./...`
- [x] Pre-commit Go format, build, tests, and Tauri daemon checks
- [x] Built and launched `attn-dev.app`
- [x] Bundled dev preflight passed for CLI, app, daemon, tools, and routing
- [x] Live plain delegation created an isolated worktree on an automatic branch
- [x] Live `--no-worktree` delegation reused the source checkout
