### PR TITLE
feat(workspace): add dim-only focus style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-07-28]
 
 ### Changed
-- **Choose how the focused workspace tile is marked.** Sidebar display settings
-  now offer an edge rail or a depth spotlight for the selected terminal, markdown
-  file, browser, or other tile, and remember the choice across launches. The
-  selected tile stays fully opaque while every unselected tile is dimmed to the
-  same level in both modes. Spotlight depth and corner marks are static so they
-  do not keep consuming animation work.
+- **Choose how the focused workspace tile is shown.** Sidebar display settings
+  now offer dimming alone, an edge rail, or a depth spotlight for the selected
+  terminal, markdown file, browser, or other tile, and remember the choice across
+  launches. The selected tile stays fully opaque while every unselected tile is
+  dimmed to the same level in all three modes. Spotlight depth and corner marks
+  are static so they do not keep consuming animation work.
 
 ---
 

--- a/app/e2e/pane-focus-ring.spec.ts
+++ b/app/e2e/pane-focus-ring.spec.ts
@@ -17,7 +17,7 @@ test('active-pane selection markers paint above the ticket overlay', async ({ pa
 
   for (const style of ['rail', 'spotlight']) {
     await workspace.evaluate((el, selectionStyle) => {
-      el.classList.remove('workspace-selection--rail', 'workspace-selection--spotlight');
+      el.classList.remove('workspace-selection--dim', 'workspace-selection--rail', 'workspace-selection--spotlight');
       el.classList.add(`workspace-selection--${selectionStyle}`);
     }, style);
 
@@ -28,4 +28,15 @@ test('active-pane selection markers paint above the ticket overlay', async ({ pa
     await expect(inactiveTile, `${style} inactive tile opacity`).toHaveCSS('opacity', '0.58');
     await expect(pane, `${style} active pane opacity`).toHaveCSS('opacity', '1');
   }
+
+  await workspace.evaluate((el) => {
+    el.classList.remove('workspace-selection--rail', 'workspace-selection--spotlight');
+    el.classList.add('workspace-selection--dim');
+  });
+
+  expect(await pane.evaluate((el) => getComputedStyle(el, '::before').content)).toBe('none');
+  expect(await pane.evaluate((el) => getComputedStyle(el, '::after').content)).toBe('none');
+  await expect(pane).toHaveCSS('box-shadow', 'none');
+  await expect(inactiveTile).toHaveCSS('opacity', '0.58');
+  await expect(pane).toHaveCSS('opacity', '1');
 });

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -788,7 +788,7 @@
 }
 
 .sidebar-display-toggle--selection {
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(3, 1fr);
 }
 
 .sidebar-display-toggle button {

--- a/app/src/components/Sidebar.test.tsx
+++ b/app/src/components/Sidebar.test.tsx
@@ -560,9 +560,9 @@ describe('Sidebar', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Sidebar settings' }));
 
     expect(screen.getByRole('button', { name: 'rail' })).toHaveAttribute('aria-pressed', 'true');
-    fireEvent.click(screen.getByRole('button', { name: 'spotlight' }));
+    fireEvent.click(screen.getByRole('button', { name: 'dim' }));
 
-    expect(onWorkspaceSelectionStyleChange).toHaveBeenCalledWith('spotlight');
+    expect(onWorkspaceSelectionStyleChange).toHaveBeenCalledWith('dim');
   });
 
   it('renders config-driven dock items, marks active ones, and fires actions on click', () => {

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -867,7 +867,7 @@ export function Sidebar({
                 </div>
                 <span className="sidebar-settings-sub-label">Tile focus</span>
                 <div className="sidebar-display-toggle sidebar-display-toggle--selection" role="group" aria-label="Tile focus style">
-                  {(['rail', 'spotlight'] as const).map((style) => (
+                  {(['dim', 'rail', 'spotlight'] as const).map((style) => (
                     <button
                       type="button"
                       key={style}

--- a/app/src/utils/workspaceSelectionStyle.test.ts
+++ b/app/src/utils/workspaceSelectionStyle.test.ts
@@ -17,10 +17,10 @@ describe('workspace selection style preference', () => {
     expect(readWorkspaceSelectionStyle()).toBe('rail');
   });
 
-  it('persists and restores the spotlight style', () => {
-    persistWorkspaceSelectionStyle('spotlight');
+  it.each(['dim', 'spotlight'] as const)('persists and restores the %s style', (style) => {
+    persistWorkspaceSelectionStyle(style);
 
-    expect(localStorage.getItem(WORKSPACE_SELECTION_STYLE_STORAGE_KEY)).toBe('spotlight');
-    expect(readWorkspaceSelectionStyle()).toBe('spotlight');
+    expect(localStorage.getItem(WORKSPACE_SELECTION_STYLE_STORAGE_KEY)).toBe(style);
+    expect(readWorkspaceSelectionStyle()).toBe(style);
   });
 });

--- a/app/src/utils/workspaceSelectionStyle.ts
+++ b/app/src/utils/workspaceSelectionStyle.ts
@@ -1,12 +1,11 @@
-export type WorkspaceSelectionStyle = 'rail' | 'spotlight';
+export type WorkspaceSelectionStyle = 'dim' | 'rail' | 'spotlight';
 
 export const WORKSPACE_SELECTION_STYLE_STORAGE_KEY = 'attn.workspace.selectionStyle';
 
 export function readWorkspaceSelectionStyle(): WorkspaceSelectionStyle {
   try {
-    return window.localStorage.getItem(WORKSPACE_SELECTION_STYLE_STORAGE_KEY) === 'spotlight'
-      ? 'spotlight'
-      : 'rail';
+    const stored = window.localStorage.getItem(WORKSPACE_SELECTION_STYLE_STORAGE_KEY);
+    return stored === 'dim' || stored === 'spotlight' ? stored : 'rail';
   } catch {
     return 'rail';
   }

--- a/app/test-harness/harnesses/PaneFocusRingHarness.tsx
+++ b/app/test-harness/harnesses/PaneFocusRingHarness.tsx
@@ -8,7 +8,8 @@
  * real stylesheet so the actual cascade/stacking is under test, not a
  * re-description of it. GhosttyTerminal (WASM/canvas) plays no role in this
  * stacking question, so it is not mounted. An unselected docked tile witnesses
- * that both focus styles preserve the shared inactive opacity.
+ * that all focus styles preserve the shared inactive opacity; dim additionally
+ * witnesses that no marker is drawn.
  */
 import { useEffect } from 'react';
 import '../../src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css';


### PR DESCRIPTION
## Intent / Why

Some workspace layouts only need a quiet indication of which leaf has keyboard focus. Rail and spotlight both add a selected-leaf marker; this adds an opacity-only choice for users who want less visual chrome.

## Summary

- add a persisted `dim` tile-focus option alongside `rail` and `spotlight`
- keep the selected leaf fully opaque and dim every unselected terminal, shell, agent, browser, markdown, or other tile without adding markers, shadows, or header treatment
- cover persistence, settings selection, and the real browser CSS cascade, including the absence of pseudo-element markers
- update the changelog to describe all three focus styles

## Test plan

- [x] `pnpm --dir app test` — 2,063 tests passed
- [x] frontend production build via the pre-commit gate
- [x] `pnpm --dir app run e2e` — 191 passed, 1 intentionally skipped
- [x] `make dev`
- [x] bundled `attn-dev` preflight — 0 failures, 0 warnings
- [x] selected `dim` in the running packaged dev app and verified it became the active option