### PR TITLE
feat(queue): settling a turn hands over the next agent that owes one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-07-28]
 
 ### Changed
+- **Settling a turn hands you the next agent that owes one.** ⌘⇧E now settles the
+  selected agent and selects the next turn in queue order — oldest owed first,
+  wrapping to the top — so working through the queue no longer takes two
+  keystrokes per agent. With nothing left to go to, the selection stays where it
+  is. The shortcut is still bound only while the queue arrangement is on, and a
+  row's own settle button still settles just that row without moving you.
 - **Delegated Git work starts isolated by default.** `attn delegate` now creates
   a new worktree automatically when its target is in a Git repository, including
   for read-only and discussion work. Use `--no-worktree` to deliberately continue

--- a/app/scripts/real-app-harness/scenario-agent-queue.mjs
+++ b/app/scripts/real-app-harness/scenario-agent-queue.mjs
@@ -30,7 +30,9 @@
  *   8. the chief of staff occupies its own slot and never the band,
  *   9. turning the arrangement off and back on mid-session restores the whole
  *      workspace tree, then returns the same queue with the same agent selected,
- *  10. a settle survives a daemon restart.
+ *  10. settling by keyboard hands over the next agent that still owes a turn,
+ *      and leaves selection alone when nothing does,
+ *  11. a settle survives a daemon restart.
  *
  * Prereqs: `claude` on PATH; a non-production profile install with the
  * automation layer; a built `./attn` (or ATTN_HARNESS_BIN) for the restart step.
@@ -512,6 +514,19 @@ async function main() {
       await driver.pressKey('e', { command: true, shift: true });
       await waitForTurns(client, [alpha.sessionId], 'beta settled by shortcut before the restart');
 
+      // Closing a turn hands over the next agent that still owes one, so the
+      // user never has to settle and then go looking. The target is taken from
+      // the queue as it stood before the settle — reading it afterwards would
+      // race the daemon broadcast that drops the settled row.
+      const jumped = await pollFor(async () => {
+        const state = await client.request('get_state');
+        return state.activeSessionId === alpha.sessionId ? state : null;
+      }, 'settling to hand over the next agent in queue order', 15_000);
+      runner.assert(
+        jumped.activeSessionId === alpha.sessionId,
+        `settling selected the next owed turn: ${jumped.activeSessionId}`,
+      );
+
       // The app respawns the daemon, so it has to be down for the restart to be
       // a restart.
       await client.quitApp();
@@ -524,6 +539,22 @@ async function main() {
       runner.assert(
         settledIds(queue).includes(beta.sessionId),
         `beta came back as a session, just not as a turn: ${JSON.stringify(settledIds(queue))}`,
+      );
+    });
+
+    await runner.step('settling_the_last_turn_leaves_selection_alone', async () => {
+      // With nothing left to hand over, the keystroke settles and stops there —
+      // jumping somewhere arbitrary would take the user away from the agent they
+      // were just looking at.
+      await client.request('select_session', { sessionId: alpha.sessionId });
+      await driver.activateApp();
+      await driver.clickWindow(0.5, 0.5);
+      await driver.pressKey('e', { command: true, shift: true });
+      await waitForTurns(client, [], 'the last turn settled by shortcut');
+      const state = await client.request('get_state');
+      runner.assert(
+        state.activeSessionId === alpha.sessionId,
+        `selection stayed on the agent that was just settled: ${state.activeSessionId}`,
       );
     });
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -95,7 +95,9 @@ import {
 import { normalizeInstallChannel, shouldCheckForReleaseUpdates } from './utils/installChannel';
 import { boundTicketForSession } from './utils/tickets';
 import { buildWorkspaceViewModels, filterSessionsRepresentedInWorkspaceLayouts } from './utils/workspaceViewModels';
-import { buildQueueBands, isQueueModeEnabled, QUEUE_MODE_SETTING } from './utils/queueBands';
+import {
+  buildQueueBands, isQueueModeEnabled, nextTurnAfterSettle, QUEUE_MODE_SETTING,
+} from './utils/queueBands';
 import { useWorkspaceSelectionController } from './hooks/useWorkspaceSelectionController';
 import { hideBootSplash } from './utils/bootSplash';
 import { getTerminalTheme } from './utils/terminalSizing';
@@ -2901,17 +2903,27 @@ sendFetchPRDetails,
   const { needsAttention: prsNeedingAttention } = usePRsNeedingAttention(prs);
   const attentionCount = waitingLocalSessions.length + prsNeedingAttention.length;
 
-  // Settle the selected session's turn. Undefined while the queue arrangement is
-  // off so the shortcut is not registered at all.
+  // Settle the selected session's turn and move on to the next agent that still
+  // owes one, so closing a turn and picking up the next is one keystroke.
+  // Undefined while the queue arrangement is off so the shortcut is not
+  // registered at all.
+  //
+  // The next agent is taken from the queue as it stands before the settle: the
+  // band only drops the settled row once the daemon broadcast lands, so reading
+  // it afterwards would either find the row still there or race the refresh.
+  // With nothing left to go to, selection stays put.
   const handleSettleActiveTurn = useMemo(
     () => (queueModeEnabled
       ? () => {
-        if (activeSessionId) {
-          sendSettleTurn(activeSessionId);
+        if (!activeSessionId) return;
+        const next = nextTurnAfterSettle(queueBands?.turns ?? [], activeSessionId);
+        sendSettleTurn(activeSessionId);
+        if (next) {
+          handleSelectSession(next.session.id);
         }
       }
       : undefined),
-    [queueModeEnabled, activeSessionId, sendSettleTurn],
+    [queueModeEnabled, activeSessionId, queueBands, sendSettleTurn, handleSelectSession],
   );
 
   // Keyboard shortcut handlers

--- a/app/src/shortcuts/cheatsheet.ts
+++ b/app/src/shortcuts/cheatsheet.ts
@@ -44,7 +44,7 @@ export function buildCheatsheet(): CheatsheetCategory[] {
         { label: 'Go to dashboard (home)', combos: [fromId('session.goToDashboard')] },
         { label: 'Toggle grid view', combos: [fromId('view.toggleGrid')] },
         { label: 'Jump to next waiting session', combos: [fromId('session.jumpToWaiting')] },
-        { label: 'Settle this turn', combos: [fromId('session.settle')] },
+        { label: 'Settle turn, go to next', combos: [fromId('session.settle')] },
         { label: 'Toggle sidebar', combos: [fromId('session.toggleSidebar')] },
       ],
     },

--- a/app/src/shortcuts/metadata.ts
+++ b/app/src/shortcuts/metadata.ts
@@ -62,7 +62,7 @@ export const SHORTCUT_META: Record<ShortcutId, ShortcutMeta> = {
   'session.goToDashboard': { label: 'Go to dashboard (home)', category: 'sessions' },
   'view.toggleGrid': { label: 'Toggle grid view', category: 'sessions' },
   'session.jumpToWaiting': { label: 'Jump to next waiting session', category: 'sessions' },
-  'session.settle': { label: 'Settle this turn', category: 'sessions' },
+  'session.settle': { label: 'Settle turn, go to next', category: 'sessions' },
   'session.toggleSidebar': { label: 'Toggle sidebar', category: 'sessions', dockLabel: 'sidebar' },
   'workspace.select1': { label: 'Jump to workspace 1', category: 'sessions' },
   'workspace.select2': { label: 'Jump to workspace 2', category: 'sessions' },

--- a/app/src/utils/queueBands.test.ts
+++ b/app/src/utils/queueBands.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildQueueBands, type QueueBandSession } from './queueBands';
+import { buildQueueBands, nextTurnAfterSettle, type QueueBandSession } from './queueBands';
 import { buildWorkspaceViewModels } from './workspaceViewModels';
 
 const workspaces = [
@@ -158,5 +158,46 @@ describe('buildQueueBands', () => {
     buildQueueBands(tree);
 
     expect(tree.map((workspace) => workspace.sessions.map((session) => session.id))).toEqual([['a'], ['b']]);
+  });
+});
+
+describe('nextTurnAfterSettle', () => {
+  function turnsFor(ids: string[]) {
+    return buildQueueBands(views(ids.map((id, index) => ({
+      id,
+      label: id,
+      workspaceId: 'ws-a',
+      turnOwed: true,
+      turnOpenedAt: `2026-07-26T0${index}:00:00Z`,
+    })))).turns;
+  }
+
+  it('lands on the row after the one settled, in queue order', () => {
+    const turns = turnsFor(['oldest', 'middle', 'newest']);
+
+    expect(nextTurnAfterSettle(turns, 'oldest')?.session.id).toBe('middle');
+    expect(nextTurnAfterSettle(turns, 'middle')?.session.id).toBe('newest');
+  });
+
+  it('wraps to the top when the last row is settled', () => {
+    // Queue order is not attention order: the rows above are still owed, so the
+    // bottom row moves on to the oldest rather than falling off the end.
+    const turns = turnsFor(['oldest', 'middle', 'newest']);
+
+    expect(nextTurnAfterSettle(turns, 'newest')?.session.id).toBe('oldest');
+  });
+
+  it('never lands on the row just settled', () => {
+    // The band is read before the settle, so the settled row is still in it.
+    expect(nextTurnAfterSettle(turnsFor(['only']), 'only')).toBeNull();
+    expect(nextTurnAfterSettle([], 'anything')).toBeNull();
+    expect(nextTurnAfterSettle(turnsFor(['only']), null)?.session.id).toBe('only');
+  });
+
+  it('starts at the top for a session the band does not hold', () => {
+    // Already settled, pinned, muted, or the chief: no position to move on from.
+    const turns = turnsFor(['oldest', 'newest']);
+
+    expect(nextTurnAfterSettle(turns, 'elsewhere')?.session.id).toBe('oldest');
   });
 });

--- a/app/src/utils/queueBands.ts
+++ b/app/src/utils/queueBands.ts
@@ -98,3 +98,31 @@ export function buildQueueBands<TSession extends QueueBandSession>(
 
   return { chief, turns, settled };
 }
+
+/**
+ * The agent to land on once `settledSessionId`'s turn is closed: the next row in
+ * queue order, wrapping to the top, and never the row just settled.
+ *
+ * The target is read from the queue as it stands *before* the settle. The settle
+ * is a round trip to the daemon and the band only loses the row when the
+ * broadcast comes back, so anything read after the call still contains the row
+ * that was settled — deciding here keeps the jump off that race entirely.
+ *
+ * A session that is not in the band (already settled, pinned, muted, the chief)
+ * has no position to move on from, so the scan simply starts at the top. Null
+ * means nothing is left to go to and selection should stay where it is.
+ */
+export function nextTurnAfterSettle<TSession extends QueueBandSession>(
+  turns: QueueRow<TSession>[],
+  settledSessionId: string | null,
+): QueueRow<TSession> | null {
+  const current = turns.findIndex((row) => row.session.id === settledSessionId);
+  const start = current === -1 ? 0 : current + 1;
+  for (let offset = 0; offset < turns.length; offset += 1) {
+    const row = turns[(start + offset) % turns.length];
+    if (row.session.id !== settledSessionId) {
+      return row;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
Working through the agent queue took two keystrokes per agent: ⌘⇧E to settle the
one you are looking at, then ⌘J to go find the next. Settle now does both, so the
queue is worked front to back with one shortcut.

## What it does

Settling the selected agent selects the next row in **queue order** — turn age,
oldest first — wrapping to the top, and never the row just settled. With nothing
left to go to, selection stays where it is.

Unchanged: what Settle means, the fact that it is bound only while the queue
arrangement is on (off by default; Settings > General or ⌘K), and a queue row's
own settle button, which still settles that row without moving you — that is what
settling an agent you are not looking at should do.

## Two decisions worth naming

**Queue order, not attention order.** ⌘J jumps to the first session in a state
that wants attention; the queue is a different list, ordered by how long a turn
has been owed and with membership from the daemon's `turn_owed`. A settled agent
leaves the band while it may still be, say, `waiting_input`. So the target comes
from the queue band itself (`nextTurnAfterSettle`) rather than being re-derived.
⌘J's own behavior is untouched — whether it should become queue-aware is a
separate product question, not decided here.

Wrapping is the one addition to the queue's own model: settling the bottom row
moves to the top, since the rows above are still owed and falling off the end
would leave the user on a settled agent with work still queued.

**The target is read before the settle.** `sendSettleTurn` is a round trip to the
daemon and the band only drops the row once the broadcast lands. Reading the band
after the call would either find the settled row still in it or race the refresh —
intermittently landing on the agent you just settled, or doing nothing. Deciding
the target from the pre-settle list keeps the jump off that race entirely.

## Verification

`pnpm --dir app test` (2095 passed) and `pnpm --dir app exec tsc --noEmit` green.

Unit tests on `nextTurnAfterSettle` cover the next-in-order case, the wrap, the
session the band does not hold, and nothing-left-to-jump-to (single row, and an
empty band).

Live, in a packaged non-production profile (`settlejump`, preflight PASS,
protocol 198 across CLI/app/daemon), driving the real ⌘⇧E through the packaged
app's native menu path with two live Claude agents queued —
`real-app:scenario-agent-queue`, `ATTN_VERDICT ok:true`, 0 failures:

```
settling selected the next owed turn: d7ca4e2c-…   (pressed while beta was selected; alpha was the next turn)
selection stayed on the agent that was just settled: d7ca4e2c-…   (last turn in the band)
```

Both assertions are in the scenario, so the keystroke's behavior stays covered.