### PR TITLE
feat(sidebar): move the agent-queue switch into the display popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   keystrokes per agent. With nothing left to go to, the selection stays where it
   is. The shortcut is still bound only while the queue arrangement is on, and a
   row's own settle button still settles just that row without moving you.
+- **The agent queue is switched on from the sidebar itself.** The toggle moved
+  out of Settings into the sidebar's display popover — the slider icon beside the
+  "+" in the Workspaces header — where it sits above Display, Tile focus, and
+  Tile-only workspaces. ⌘K still turns it on and off and always agrees with the
+  switch.
 - **Delegated Git work starts isolated by default.** `attn delegate` now creates
   a new worktree automatically when its target is in a Git repository, including
   for read-only and discussion work. Use `--no-worktree` to deliberately continue

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1937,6 +1937,13 @@ sendFetchPRDetails,
     if (claimPaletteFocus()) return;
     setMarkdownOpenerOpen(true);
   }, []);
+
+  // The single writer for the queue setting. The sidebar's display popover and
+  // the command menu both call it, so the two entry points can never disagree
+  // about what is in effect — and neither one has to know the setting's key.
+  const handleToggleQueueMode = useCallback(() => {
+    sendSetSetting(QUEUE_MODE_SETTING, isQueueModeEnabled(settings) ? 'false' : 'true');
+  }, [sendSetSetting, settings]);
   // Fuzzy mode searches the selected session's working directory; with no
   // session selected there is no project context, so it falls back to the
   // notebook root. Neither known = recents only. A remote session's cwd names a
@@ -2031,16 +2038,15 @@ sendFetchPRDetails,
       run: () => openBoardSurface(),
     },
     {
-      // Settings is the right home for a setting and the wrong home for something
-      // flipped ten times a day — and while the arrangement is being evaluated,
-      // flipping it back and forth is the evaluation. Both entries write the same
-      // setting, so they can never disagree.
+      // The switch itself lives in the sidebar's display popover, next to the
+      // other arrangement choices. This entry is the keyboard route to the same
+      // toggle, through the same writer, so the two can never disagree.
       id: 'toggle-queue-mode',
       title: isQueueModeEnabled(settings) ? 'Turn off the agent queue' : 'Turn on the agent queue',
       description: 'Show the turns you owe above the workspace tree',
       keywords: ['queue', 'turn', 'settle', 'attention', 'sidebar'],
       icon: <AttentionActionIcon />,
-      run: () => sendSetSetting(QUEUE_MODE_SETTING, isQueueModeEnabled(settings) ? 'false' : 'true'),
+      run: handleToggleQueueMode,
     },
     {
       id: 'customize-shortcuts',
@@ -2050,7 +2056,7 @@ sendFetchPRDetails,
       icon: <KeyboardActionIcon />,
       run: () => setShortcutEditorOpen(true),
     },
-  ], [openDockPanel, openWorkspaceContextNavigator, handleOpenNotebookTile, openBoardSurface, settings, sendSetSetting]);
+  ], [openDockPanel, openWorkspaceContextNavigator, handleOpenNotebookTile, openBoardSurface, settings, handleToggleQueueMode]);
 
   const handleToggleActionMenu = useCallback(() => {
     if (actionMenuOpen) {
@@ -3697,6 +3703,8 @@ sendFetchPRDetails,
           onChangeChiefOfStaff={handleChangeChiefOfStaff}
           showSessionless={showSessionlessWorkspaces}
           onToggleShowSessionless={handleToggleShowSessionlessWorkspaces}
+          queueModeEnabled={queueModeEnabled}
+          onToggleQueueMode={handleToggleQueueMode}
           workspaceSelectionStyle={workspaceSelectionStyle}
           onWorkspaceSelectionStyleChange={handleWorkspaceSelectionStyleChange}
           leafDrag={leafWorkspaceDrag ? {

--- a/app/src/components/SettingsModal.test.tsx
+++ b/app/src/components/SettingsModal.test.tsx
@@ -384,7 +384,9 @@ describe('SettingsModal', () => {
     expect(screen.getByText(/does not register a second tailnet device/i)).toBeInTheDocument();
   });
 
-  it('toggles the agent queue from General', async () => {
+  // The queue switch moved to the sidebar's display popover, where the rest of
+  // the sidebar arrangement lives. Settings must not offer a second one.
+  it('does not carry an agent-queue toggle', async () => {
     const onSetSetting = vi.fn();
     const props = (queueMode: string) => ({
       isOpen: true as const,
@@ -411,19 +413,13 @@ describe('SettingsModal', () => {
       onSetTheme: vi.fn(),
     });
 
-    const { rerender } = render(<SettingsModal {...props('false')} />);
+    render(<SettingsModal {...props('false')} />);
     fireEvent.click(screen.getByTestId('settings-nav-general'));
-    const toggle = await screen.findByTestId('settings-queue-toggle');
-    expect(toggle).toHaveTextContent('Enable');
-    fireEvent.click(toggle);
-    expect(onSetSetting).toHaveBeenCalledWith('queue_mode_enabled', 'true');
+    await screen.findByTestId('settings-projects-directory-input');
 
-    rerender(<SettingsModal {...props('true')} />);
-    fireEvent.click(screen.getByTestId('settings-nav-general'));
-    const toggleOn = await screen.findByTestId('settings-queue-toggle');
-    expect(toggleOn).toHaveTextContent('Disable');
-    fireEvent.click(toggleOn);
-    expect(onSetSetting).toHaveBeenCalledWith('queue_mode_enabled', 'false');
+    expect(screen.queryByTestId('settings-queue-toggle')).toBeNull();
+    expect(screen.queryByText('Agent queue')).toBeNull();
+    expect(onSetSetting).not.toHaveBeenCalled();
   });
 
   it('enables workflows when off and disables them when on', async () => {

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -16,7 +16,6 @@ import {
   setSettingsAutomationHandle,
 } from './settingsAutomation';
 import { normalizeSessionAgent, type SessionAgent } from '../types/sessionAgent';
-import { isQueueModeEnabled, QUEUE_MODE_SETTING } from '../utils/queueBands';
 import type { ThemePreference } from '../hooks/useTheme';
 import {
   AGENT_CAPABILITY_ORDER,
@@ -241,7 +240,6 @@ export function SettingsModal({
   const effectiveNotebookRoot = settings['notebook.root.effective'] || '';
   const tailscaleEnabled = (settings.tailscale_enabled || 'false') === 'true';
   const workflowsEnabled = (settings.workflows_enabled || 'false') === 'true';
-  const queueModeEnabled = isQueueModeEnabled(settings);
   const autoApproveEnabled = (settings.auto_approve_enabled || 'false') === 'true';
   const tailscaleStatus = settings.tailscale_status || 'disabled';
   const tailscaleURL = settings.tailscale_url || '';
@@ -455,10 +453,6 @@ export function SettingsModal({
   const handleToggleTailscale = useCallback(() => {
     onSetSetting('tailscale_enabled', tailscaleEnabled ? 'false' : 'true');
   }, [onSetSetting, tailscaleEnabled]);
-
-  const handleToggleQueueMode = useCallback(() => {
-    onSetSetting(QUEUE_MODE_SETTING, queueModeEnabled ? 'false' : 'true');
-  }, [onSetSetting, queueModeEnabled]);
 
   const handleToggleWorkflows = useCallback(() => {
     onSetSetting('workflows_enabled', workflowsEnabled ? 'false' : 'true');
@@ -1200,38 +1194,6 @@ export function SettingsModal({
                 </button>
               )}
             </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="settings-block">
-        <div className="settings-block-intro">
-          <div className="settings-kicker">Sidebar</div>
-          <h3>Agent queue</h3>
-          <p className="settings-description">
-            Puts the turns you owe at the top of the sidebar, oldest first, across every
-            workspace — with the chief of staff in its own slot above them. Off by default.
-          </p>
-        </div>
-        <div className="settings-block-body">
-          <div className="settings-row-card">
-            <div>
-              <p className="settings-row-title">Show the queue</p>
-              <p className="settings-row-copy">
-                An agent joins the queue when it wants you and stays there until you settle it
-                (⌘⇧E) — running or not, because you are the only one who knows whether you are
-                done with it. Everything stays exactly where it is in the sidebar below; the
-                queue only adds rows.
-              </p>
-            </div>
-            <button
-              type="button"
-              className="settings-action"
-              data-testid="settings-queue-toggle"
-              onClick={handleToggleQueueMode}
-            >
-              {queueModeEnabled ? 'Disable' : 'Enable'}
-            </button>
           </div>
         </div>
       </section>

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -828,6 +828,13 @@
   font-size: var(--font-size-xs);
 }
 
+/* The lead row sits above the first section label, so it carries its spacing
+   below instead of above. */
+.sidebar-settings-switch-row--lead {
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
 .sidebar-settings-switch-row:hover {
   color: var(--color-text-primary);
 }

--- a/app/src/components/Sidebar.test.tsx
+++ b/app/src/components/Sidebar.test.tsx
@@ -532,6 +532,37 @@ describe('Sidebar', () => {
     expect(onToggleShowSessionless).toHaveBeenCalledTimes(1);
   });
 
+  it('reflects and toggles queue mode from the display popover', () => {
+    const onToggleQueueMode = vi.fn();
+    const { rerender } = render(
+      <Sidebar
+        {...baseProps}
+        {...buildSidebarData([])}
+        queueModeEnabled={false}
+        onToggleQueueMode={onToggleQueueMode}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sidebar settings' }));
+    const toggle = screen.getByTestId('toggle-queue-mode');
+    expect(toggle).toHaveAttribute('role', 'switch');
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(toggle);
+    expect(onToggleQueueMode).toHaveBeenCalledTimes(1);
+
+    // The switch tracks the value App hands back, not a local guess about it.
+    rerender(
+      <Sidebar
+        {...baseProps}
+        {...buildSidebarData([])}
+        queueModeEnabled
+        onToggleQueueMode={onToggleQueueMode}
+      />
+    );
+    expect(screen.getByTestId('toggle-queue-mode')).toHaveAttribute('aria-checked', 'true');
+  });
+
   it('keeps display options visible after selecting a mode', () => {
     render(
       <Sidebar

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -149,6 +149,11 @@ interface SidebarProps {
   onChangeChiefOfStaff?: (sessionId: string, enabled: boolean) => void;
   showSessionless?: boolean;
   onToggleShowSessionless?: () => void;
+  // The queue is the one arrangement in this popover the daemon owns: App reads
+  // it out of the settings map and writes it back through sendSetSetting, so the
+  // sidebar takes the resolved value and the writer rather than the key.
+  queueModeEnabled?: boolean;
+  onToggleQueueMode?: () => void;
   workspaceSelectionStyle?: WorkspaceSelectionStyle;
   onWorkspaceSelectionStyleChange?: (style: WorkspaceSelectionStyle) => void;
   leafDrag?: { sourceWorkspaceId: string; endpointId?: string } | null;
@@ -341,6 +346,8 @@ export function Sidebar({
   onChangeChiefOfStaff,
   showSessionless = false,
   onToggleShowSessionless,
+  queueModeEnabled = false,
+  onToggleQueueMode,
   workspaceSelectionStyle = 'rail',
   onWorkspaceSelectionStyleChange,
   leafDrag = null,
@@ -898,6 +905,19 @@ export function Sidebar({
             </button>
             {settingsOpen && (
               <div className="sidebar-settings-popover" role="dialog" aria-label="Sidebar settings">
+                {/* First, because it is the only choice here that changes what the
+                    sidebar contains rather than how the tree below is drawn. */}
+                <button
+                  type="button"
+                  className="sidebar-settings-switch-row sidebar-settings-switch-row--lead"
+                  role="switch"
+                  aria-checked={queueModeEnabled}
+                  data-testid="toggle-queue-mode"
+                  onClick={() => onToggleQueueMode?.()}
+                >
+                  <span className="sidebar-settings-switch-label">Agent queue</span>
+                  <span className={`sidebar-settings-switch ${queueModeEnabled ? 'on' : ''}`} aria-hidden="true" />
+                </button>
                 <span className="sidebar-settings-label">Display</span>
                 <div className="sidebar-display-toggle" role="group" aria-label="Sidebar display">
                   {(['open', 'tight', 'boxed'] as const).map((mode) => (

--- a/app/src/utils/queueBands.ts
+++ b/app/src/utils/queueBands.ts
@@ -3,8 +3,9 @@ import type { WorkspaceWithSessions, WorkspaceViewSession } from './workspaceVie
 /**
  * The daemon-owned setting selecting the sidebar arrangement: off (the default)
  * is the workspace tree alone, on adds the chief's anchored slot and the "Your
- * turn" band above it. Read it through isQueueModeEnabled so Settings, the
- * command menu, and the sidebar can never disagree about what is in effect.
+ * turn" band above it. Read it through isQueueModeEnabled so the sidebar's
+ * display popover, the command menu, and the sidebar itself can never disagree
+ * about what is in effect.
  */
 export const QUEUE_MODE_SETTING = 'queue_mode_enabled';
 

--- a/docs/plans/2026-07-26-agent-queue-turn-and-settle.md
+++ b/docs/plans/2026-07-26-agent-queue-turn-and-settle.md
@@ -192,18 +192,21 @@ regardless of what the remote daemon's own setting says.
 
 ### The UI
 
-A `settings-block` in **General**, following the `workflows_enabled` block
-(`SettingsModal.tsx:1954-1982`) exactly: intro copy, a `settings-row-card`, and
-an Enable/Disable `settings-action` button, `data-testid="settings-queue-toggle"`.
-Heading: **Agent queue**. The copy has to say the one thing a user cannot infer —
-that an agent stays on the list until you settle it, running or not, and that
-everything stays exactly where it is in the sidebar below.
+A switch in the sidebar's display popover (`Sidebar.tsx`,
+`.sidebar-settings-popover`, `data-testid="toggle-queue-mode"`), labelled **Agent
+queue** and first in the popover — it is the only choice there that changes what
+the sidebar contains rather than how the tree below is drawn. It shipped as a
+`settings-block` in Settings → General and moved here afterwards: the queue is a
+sidebar arrangement, and every other control that changes how the sidebar looks
+was already one click away in that popover.
 
-The toggle is also a ⌘K action (`actionMenuItems` in `App.tsx:2103`), titled by
-the state it moves to and carrying the same `set_setting` call. Settings is the
-right home for a setting and the wrong home for something flipped ten times a day
-— and while the mode is being evaluated, flipping it back and forth *is* the
-evaluation. Both entries read the same setting, so they can never disagree.
+Unlike its neighbours the setting is daemon-owned, so `App.tsx` reads it with
+`isQueueModeEnabled` and hands `Sidebar` the resolved boolean plus the writer;
+the sidebar never sees the key.
+
+The toggle is also a ⌘K action (`actionMenuItems` in `App.tsx`), titled by the
+state it moves to and calling the same writer, so the two entries can never
+disagree.
 
 The settle shortcut is registered only while the mode is on: with the band gone
 the keystroke has nothing visible to do, and an invisible verb that silently


### PR DESCRIPTION
The agent-queue on/off switch now lives in the sidebar's display popover — the
one the slider icon opens next to the "+" in the Workspaces header, alongside
Display (open / tight / boxed), Tile focus (dim / rail / spotlight), and
Tile-only workspaces. It is gone from the Settings modal.

The queue *is* a sidebar arrangement, and every other control that changes how
the sidebar looks was already one click away in that popover. Sending people to
a modal for the biggest of those choices was the odd one out.

## Where it sits, and why

**First in the popover, above Display.** Everything else there tunes how the
workspace tree is drawn; the queue changes what the sidebar *contains*, adding
the chief's slot and the "Your turn" band above the tree. Bottom-of-the-list
would have filed the biggest choice under the smallest ones. It carries its
spacing below rather than above (`--lead`) so it reads as its own line rather
than as part of the Display group.

## Wiring

The three existing popover controls are local UI preferences. Queue mode is
daemon-owned: written with `set_setting` and broadcast back to every client. So
`App.tsx` keeps ownership — it reads the value through `isQueueModeEnabled` and
hands `Sidebar` the resolved boolean plus a single writer, `handleToggleQueueMode`.
The sidebar never sees the setting key, and the ⌘K action now calls that same
writer instead of its own copy, so the popover and the command menu cannot
disagree.

## Verification

`pnpm --dir app test` (193 files, 2087 passed) and `pnpm --dir app exec tsc --noEmit`
are green. Sidebar gained a test for the switch's `aria-checked` tracking the prop
and firing the callback; the Settings-modal test now asserts the toggle is *not*
there.

Live, on a throwaway `qtoggle` profile install (preflight PASS, protocol 198):

- Popover switch ON → the "Your turn" / "Settled" band appears
  (`queue_get_state` → `present: true`, the session in `settled`), and
  `queue_mode_enabled` is `true` in the profile's `attn.db` — so it persisted
  through the daemon, not just locally.
- ⌘K then read **"Turn off the agent queue"**, agreeing with the switch. Running
  it removed the band, restored the tree, wrote `false` to the DB, and the popover
  switch was off when reopened — no reload needed.
- Popover switch ON again → band back, DB `true`.
- Settings → General: searching "queue" no longer surfaces an Agent queue section.

Screenshots taken during that run (popover with the switch on and off, the ⌘K
entry reading "Turn off the agent queue", and Settings after the removal) went to
the author directly — GitHub image upload is not available from the CLI.
