### PR TITLE
fix(app): clear React Doctor findings on the queue sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-07-28]
 
+### Fixed
+- **Queue rows can be opened from the keyboard.** Each row in the agent queue
+  now offers a real, focusable control for opening its agent, with a visible
+  focus ring and a name screen readers announce. Previously the row responded
+  only to a mouse click. Clicking anywhere on the row still opens it, and the
+  settle, pin, and actions buttons are unchanged.
+
 ### Changed
 - **Delegated Git work starts isolated by default.** `attn delegate` now creates
   a new worktree automatically when its target is in a Git repository, including

--- a/app/scripts/real-app-harness/scenario-agent-queue.mjs
+++ b/app/scripts/real-app-harness/scenario-agent-queue.mjs
@@ -270,11 +270,41 @@ async function main() {
     });
 
     await runner.step('clicking_a_row_hands_the_agent_over', async () => {
-      await client.request('dom_click', { selector: `[data-testid="queue-turn-${alpha.sessionId}"]` });
+      await client.request('dom_click', { selector: `[data-testid="queue-select-${alpha.sessionId}"]` });
       await pollFor(async () => {
         const state = await client.request('get_state');
         return state.activeSessionId === alpha.sessionId ? state : null;
       }, 'the clicked row to select its agent', 15_000);
+      await waitForPaneInputFocus(client, alpha.sessionId, alpha.paneId, 15_000);
+    });
+
+    await runner.step('a_row_opens_from_the_keyboard', async () => {
+      // A queue row must be operable without a mouse. The focus is placed
+      // directly rather than walked to with Tab — where a blind Tab walk ends up
+      // depends on the whole window, which says nothing about this row — but the
+      // keypress itself is a real Return through the packaged app, so it proves
+      // the row responds to the keyboard and not only to a click handler.
+      await client.request('select_session', { sessionId: beta.sessionId });
+      await driver.activateApp();
+
+      const focused = await client.request('dom_focus', {
+        selector: `[data-testid="queue-select-${alpha.sessionId}"]`,
+      });
+      runner.assert(focused.tag === 'BUTTON', `the row's open control is a button: ${JSON.stringify(focused)}`);
+
+      const row = (await queueState(client)).turns.find((entry) => entry.id === alpha.sessionId);
+      runner.assert(
+        row.open?.focused === true && row.open.label.length > 0,
+        `the focused control is the row's own, and is named: ${JSON.stringify(row.open)}`,
+      );
+
+      await driver.pressEnter();
+      await pollFor(async () => {
+        const state = await client.request('get_state');
+        return state.activeSessionId === alpha.sessionId ? state : null;
+      }, 'Return on the focused row to open its agent', 15_000);
+      runner.log('a queue row opened from the keyboard', { row: alpha.sessionId, open: row.open });
+
       await waitForPaneInputFocus(client, alpha.sessionId, alpha.paneId, 15_000);
     });
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -56,7 +56,7 @@ import {
   readWorkspaceSelectionStyle,
   type WorkspaceSelectionStyle,
 } from './utils/workspaceSelectionStyle';
-import { useDaemonSocket, DaemonWorktree, DaemonSession, DaemonWorkspace, DaemonPR, DaemonEndpoint, DaemonPlugin, DaemonPluginIssue, GitStatusUpdate, DaemonWarning, SessionExitInfo, type FsIndexResult, type NotebookEntry } from './hooks/useDaemonSocket';
+import { useDaemonSocket, DaemonWorktree, DaemonSession, DaemonWorkspace, DaemonPR, DaemonEndpoint, DaemonPlugin, DaemonPluginIssue, GitStatusUpdate, DaemonWarning, SessionExitInfo } from './hooks/useDaemonSocket';
 import type { Presentation } from './types/generated';
 import { useSessionWorkspaceController } from './hooks/useSessionWorkspaceController';
 import { isAttentionSessionState, normalizeSessionState, type UISessionState } from './types/sessionState';
@@ -75,8 +75,19 @@ import { useDaemonStore } from './store/daemonSessions';
 import { usePRsNeedingAttention } from './hooks/usePRsNeedingAttention';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useWhatsNew } from './hooks/useWhatsNew';
-import { shortcutTokens, formatShortcut, dockShortcutLabel } from './shortcuts';
-import type { ShortcutId } from './shortcuts';
+import { shortcutTokens, formatShortcut } from './shortcuts/formatShortcut';
+import { dockShortcutLabel } from './shortcuts/metadata';
+import type { ShortcutId } from './shortcuts/registry';
+import {
+  latestPresentationBySessionId,
+  seedPresentationNotices,
+  upsertPresentationNotice,
+} from './utils/presentationNotices';
+import {
+  bumpFsChangeSignal,
+  fsChangeSignalKey,
+  fsIndexToNotebookEntries,
+} from './utils/fsChangeSignals';
 import { useUIScale } from './hooks/useUIScale';
 import { useTicketBoardScale } from './hooks/useTicketBoardScale';
 import { useTheme } from './hooks/useTheme';
@@ -110,73 +121,6 @@ const DOCK_PANEL_EXIT_MS = 260;
 // from accidental close. ⌘W and the close action no-op on it; this hint tells the
 // user how to close it deliberately (demote it first).
 const CHIEF_OF_STAFF_CLOSE_HINT = 'Chief of staff is protected — unset the chief role to close it.';
-
-// A presentation is worth a notice (surfaced as a chip in its triggering
-// session's pane header) while its latest round is open for review (status
-// "open") and hasn't been submitted yet.
-export function presentationNeedsNotice(presentation: Presentation): boolean {
-  return presentation.status === 'open' && !presentation.latest_round_submitted;
-}
-
-// Pure reducer for the presentation-notice list, shared by the initial
-// getPresentations() seed and the presentation_added/updated broadcasts.
-// Keeps at most one entry per presentation id; a presentation that stops
-// needing a notice (submitted or closed) is dropped.
-export function upsertPresentationNotice(notices: Presentation[], updated: Presentation): Presentation[] {
-  const withoutExisting = notices.filter((n) => n.id !== updated.id);
-  return presentationNeedsNotice(updated) ? [...withoutExisting, updated] : withoutExisting;
-}
-
-export function seedPresentationNotices(all: Presentation[]): Presentation[] {
-  return all.filter(presentationNeedsNotice);
-}
-
-// A session can trigger more than one presentation over time; the pane
-// header chip only ever shows the newest one that still needs review.
-export function latestPresentationBySessionId(notices: Presentation[]): Map<string, Presentation> {
-  const bySessionId = new Map<string, Presentation>();
-  for (const p of notices) {
-    const existing = bySessionId.get(p.session_id);
-    if (!existing || p.created_at > existing.created_at) {
-      bySessionId.set(p.session_id, p);
-    }
-  }
-  return bySessionId;
-}
-// The per-root fs_changed signal key: the daemon-resolved root verbatim, or
-// `effectiveNotebookRoot` when the event carries no root (the daemon's
-// notebook-root events, and — as a safety fallback — any malformed event
-// missing the field). A rootless tile and the fullscreen browser look
-// themselves up with the same normalization (root='' → effectiveNotebookRoot),
-// so they land on this key too.
-export function fsChangeSignalKey(root: string, effectiveNotebookRoot: string): string {
-  return root || effectiveNotebookRoot;
-}
-
-// Pure reducer for the per-root fs_changed signal map: bumps only the key the
-// event resolves to, leaving every other root's counter untouched so a tile
-// bound to root A never re-renders for a change under root B.
-export function bumpFsChangeSignal(
-  signals: Record<string, number>,
-  root: string,
-  effectiveNotebookRoot: string,
-): Record<string, number> {
-  const key = fsChangeSignalKey(root, effectiveNotebookRoot);
-  return { ...signals, [key]: (signals[key] || 0) + 1 };
-}
-
-// Adapts fs_index (a flat, root-scoped file listing) to the shape the ⌘P
-// finder and NotebookBrowser already expect from notebook_list. size is
-// always 0: fs_index deliberately omits stat() per entry to stay fast over
-// large repos, and nothing downstream of the finder reads it. A truncated
-// result still renders — an incomplete list beats none — but is flagged to
-// the console so a silently-cut-off finder doesn't look like a bug report.
-export function fsIndexToNotebookEntries(result: FsIndexResult): NotebookEntry[] {
-  if (result.truncated) {
-    console.warn('[App] fs_index truncated for', result.root, '— finder list is incomplete');
-  }
-  return result.files.map((path) => ({ path, size: 0 }));
-}
 
 const TERMINAL_AGENT: SessionAgent = 'shell';
 
@@ -3664,12 +3608,14 @@ sendFetchPRDetails,
             Version {updateAvailableVersion} is available on GitHub.
           </span>
           <button
+            type="button"
             className="update-install"
             onClick={() => void onOpenLatestRelease()}
           >
             View Release
           </button>
           <button
+            type="button"
             className="update-dismiss"
             onClick={onDismissLatestRelease}
             title="Dismiss"

--- a/app/src/components/QueueBands.test.tsx
+++ b/app/src/components/QueueBands.test.tsx
@@ -1,8 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { Sidebar } from './Sidebar';
-import { formatTurnAge } from './QueueBands';
-import { buildQueueBands } from '../utils/queueBands';
+import { buildQueueBands, formatTurnAge } from '../utils/queueBands';
 import { buildWorkspaceViewModels } from '../utils/workspaceViewModels';
 
 interface TestSession {
@@ -120,8 +119,23 @@ describe('the queue arrangement', () => {
     const onSelectSession = vi.fn();
     renderSidebar(sessions, true, { onSelectSession });
 
-    fireEvent.click(screen.getByTestId('queue-turn-older'));
+    fireEvent.click(screen.getByTestId('queue-select-older'));
     expect(onSelectSession).toHaveBeenCalledWith('older');
+  });
+
+  it('hands the agent over from the keyboard, so the queue is not mouse-only', () => {
+    // The row opens through a real button rather than a click handler on the
+    // row div, which is what makes it reachable by Tab and pressed by Enter or
+    // Space without the component handling either key itself.
+    const onSelectSession = vi.fn();
+    renderSidebar(sessions, true, { onSelectSession });
+
+    const open = screen.getByTestId('queue-select-older');
+    expect(open.tagName).toBe('BUTTON');
+    expect(open.getAttribute('aria-label')).toBe('Open older');
+
+    open.focus();
+    expect(document.activeElement).toBe(open);
   });
 
   it('settles a row without selecting it', () => {

--- a/app/src/components/QueueBands.tsx
+++ b/app/src/components/QueueBands.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState, type MouseEvent as ReactMouseEvent } from 'react';
 import { StateIndicator } from './StateIndicator';
 import { ChiefOfStaffBadge } from './ChiefOfStaffBadge';
-import { formatShortcut } from '../shortcuts';
+import { formatShortcut } from '../shortcuts/formatShortcut';
 import type { UISessionState } from '../types/sessionState';
-import type { QueueBands as QueueBandsModel, QueueRow } from '../utils/queueBands';
+import { formatTurnAge, type QueueBands as QueueBandsModel, type QueueRow } from '../utils/queueBands';
 
 export interface QueueBandSessionView {
   id: string;
@@ -43,19 +43,6 @@ interface QueueBandsProps {
  */
 const AGE_TICK_MS = 30_000;
 
-export function formatTurnAge(openedAt: string | undefined, now: number): string {
-  if (!openedAt) return '';
-  const opened = Date.parse(openedAt);
-  if (Number.isNaN(opened)) return '';
-  const seconds = Math.max(0, Math.round((now - opened) / 1000));
-  if (seconds < 60) return 'now';
-  const minutes = Math.round(seconds / 60);
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.round(minutes / 60);
-  if (hours < 24) return `${hours}h`;
-  return `${Math.round(hours / 24)}d`;
-}
-
 function useNow(intervalMs: number): number {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
@@ -91,8 +78,24 @@ function QueueRowView({
       data-testid={`${testIdPrefix}-${session.id}`}
       data-state={session.state}
       data-workspace-id={row.workspaceId}
-      onClick={onSelect}
     >
+      {/*
+        Opening the session is a real button so it is reachable by Tab and
+        pressed by Enter or Space, not a click handler on the row. It fills the
+        row from behind rather than wrapping its contents, which keeps a click
+        anywhere on the row opening the session and leaves every other child a
+        direct child of .session-item — the row's flex layout and the `>`
+        selectors that style it are untouched. The settle, pin, and actions
+        controls are lifted above it so they stay independently clickable and
+        do not sit inside an interactive ancestor.
+      */}
+      <button
+        type="button"
+        className="queue-row-select"
+        data-testid={`queue-select-${session.id}`}
+        aria-label={`Open ${session.label}`}
+        onClick={onSelect}
+      />
       <StateIndicator state={session.state} size="md" seed={session.id} reason={session.state_reason} />
       <span className="session-label">{session.label}</span>
       {session.chiefOfStaff && <ChiefOfStaffBadge />}

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -1189,6 +1189,33 @@
   margin: 0 6px;
 }
 
+/* Fills the row from behind, so a click lands on it wherever it falls. Absolute
+   rather than a wrapper: the row's other children stay direct children of
+   .session-item and keep their layout. */
+.queue-row-select {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  border-radius: inherit;
+  cursor: pointer;
+}
+
+.queue-row-select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+/* Above the fill, so pressing one of these is not also opening the session. */
+.queue-row > .session-actions,
+.queue-row > .queue-row-pin,
+.queue-row > .queue-row-settle {
+  position: relative;
+  z-index: 1;
+}
+
 .queue-row-workspace {
   flex: 0 1 auto;
   min-width: 0;

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -10,7 +10,7 @@ import type { GridLayout } from './grid/gridLayout';
 import { StateIndicator } from './StateIndicator';
 import { QueueBands } from './QueueBands';
 import { SidebarNudgeBar, deriveNudgeMode } from './NudgeIndicator';
-import { formatShortcut } from '../shortcuts';
+import { formatShortcut } from '../shortcuts/formatShortcut';
 import { isAttentionSessionState, type UISessionState } from '../types/sessionState';
 import { tileContentKey, type TileContentState, type TileLeaf } from '../types/workspace';
 import { deriveTileTitle } from '../utils/tilePresentation';
@@ -443,9 +443,10 @@ export function Sidebar({
   const isTreeWorkspace = (workspace: SidebarWorkspace) => (
     !queue || workspace.pinned || isSessionless(workspace)
   );
-  const visibleWorkspaces = workspaces
-    .map(withoutChiefRow)
-    .filter((workspace) => isWorkspaceVisible(workspace) && isTreeWorkspace(workspace));
+  const visibleWorkspaces = workspaces.flatMap((candidate) => {
+    const workspace = withoutChiefRow(candidate);
+    return isWorkspaceVisible(workspace) && isTreeWorkspace(workspace) ? [workspace] : [];
+  });
   const visibleVisualOrder = visualOrder.filter(isWorkspaceVisible);
   const visibleVisualIndexByWorkspaceId = new Map(
     visibleVisualOrder.map((workspace, index) => [workspace.id, index]),
@@ -1173,7 +1174,9 @@ export function Sidebar({
           </button>
           {mutedExpanded && (
             <div className="muted-sessions-list">
-              {mutedWorkspaces.map(withoutChiefRow).map((workspace) => (
+              {mutedWorkspaces.map((mutedWorkspace) => {
+                const workspace = withoutChiefRow(mutedWorkspace);
+                return (
                 <div
                   key={`${workspace.endpointId || 'local'}:${workspace.id}`}
                   className={`workspace-group muted-workspace ${selectedWorkspaceId === workspace.id ? 'selected' : ''}${workspaceDragClass(workspace)}`}
@@ -1265,7 +1268,8 @@ export function Sidebar({
                     })}
                   </div>
                 </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </div>

--- a/app/src/hooks/useKeyboardShortcuts.ts
+++ b/app/src/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,6 @@
 // app/src/hooks/useKeyboardShortcuts.ts
 import { useEffect } from 'react';
-import { useShortcut } from '../shortcuts';
+import { useShortcut } from '../shortcuts/useShortcut';
 import { isAccelKeyPressed } from '../shortcuts/platform';
 
 interface KeyboardShortcutsConfig {

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -7,7 +7,8 @@ import type { Presentation } from '../types/generated';
 import type { Ticket } from './useDaemonSocket';
 import type { SessionAgent } from '../types/sessionAgent';
 import type { TerminalSplitDirection } from '../types/workspace';
-import { SHORTCUTS, type ShortcutId, type Combo, isChord, resolveBinding } from '../shortcuts';
+import { SHORTCUTS, type ShortcutId, type Combo, isChord } from '../shortcuts/registry';
+import { resolveBinding } from '../shortcuts/resolver';
 import { getGridAutomationHandle, INACTIVE_GRID_STATE } from '../components/grid/gridAutomation';
 import {
   getAutomationFormAutomationHandle,
@@ -1774,6 +1775,24 @@ export function useUiAutomationBridge({
         await settleUi(2);
         return { clicked: true, bounds: rectSnapshot(element) };
       }
+      case 'dom_focus': {
+        // Focus without clicking, so a scenario can put the keyboard on a
+        // control and then press real keys at it. Fails loudly when the target
+        // refuses focus, which is the interesting answer for anything claiming
+        // to be keyboard-reachable.
+        const selector = typeof payload.selector === 'string' ? payload.selector : null;
+        if (!selector) throw new Error('dom_focus requires selector');
+        const element = document.querySelector(selector);
+        if (!(element instanceof HTMLElement)) {
+          throw new Error(`dom_focus selector not found in DOM: ${selector}`);
+        }
+        element.focus();
+        await settleUi(2);
+        if (document.activeElement !== element) {
+          throw new Error(`dom_focus target did not take focus: ${selector}`);
+        }
+        return { focused: true, tag: element.tagName };
+      }
       case 'dom_type': {
         const selector = typeof payload.selector === 'string' ? payload.selector : null;
         const text = typeof payload.text === 'string' ? payload.text : null;
@@ -1837,15 +1856,29 @@ export function useUiAutomationBridge({
         // and the live state dot are the whole claim of the queue arrangement,
         // and only the DOM can testify that what the user sees matches it.
         const band = document.querySelector('[data-testid="sidebar-queue"]');
-        const readRow = (row: Element, prefix: string) => ({
-          id: (row.getAttribute('data-testid') || '').slice(prefix.length),
-          label: row.querySelector('.session-label')?.textContent?.trim() || '',
-          state: row.getAttribute('data-state') || '',
-          workspace: row.querySelector('.queue-row-workspace')?.textContent?.trim() || '',
-          workspaceId: row.getAttribute('data-workspace-id') || '',
-          age: row.querySelector('.queue-row-age')?.textContent?.trim() || '',
-          selected: row.classList.contains('selected'),
-        });
+        const readRow = (row: Element, prefix: string) => {
+          // The control that opens the row. Reported as its own element rather
+          // than folded into the row so a caller can testify that opening an
+          // agent is reachable by keyboard — a real button, focusable, with an
+          // accessible name — and not a click handler the keyboard cannot see.
+          const open = row.querySelector('.queue-row-select');
+          return {
+            id: (row.getAttribute('data-testid') || '').slice(prefix.length),
+            label: row.querySelector('.session-label')?.textContent?.trim() || '',
+            state: row.getAttribute('data-state') || '',
+            workspace: row.querySelector('.queue-row-workspace')?.textContent?.trim() || '',
+            workspaceId: row.getAttribute('data-workspace-id') || '',
+            age: row.querySelector('.queue-row-age')?.textContent?.trim() || '',
+            selected: row.classList.contains('selected'),
+            open: open
+              ? {
+                tag: open.tagName,
+                label: open.getAttribute('aria-label') || '',
+                focused: document.activeElement === open,
+              }
+              : null,
+          };
+        };
         const chiefRow = band?.querySelector('[data-testid^="queue-chief-"]');
         return {
           present: Boolean(band),

--- a/app/src/utils/fsChangeSignals.test.ts
+++ b/app/src/utils/fsChangeSignals.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { bumpFsChangeSignal, fsChangeSignalKey } from './App';
+import { bumpFsChangeSignal, fsChangeSignalKey } from './fsChangeSignals';
 
 // Pure-logic coverage for the per-root fs_changed routing that feeds every
 // notebook surface's changeSignal (see makeNotebookSurfaceDaemon in App.tsx).
 // App.tsx has no dedicated render-level test suite for this wiring (see
-// App.presentationNotices.test.ts for the same pattern applied to another
+// utils/presentationNotices.test.ts for the same pattern applied to another
 // piece of App.tsx state), so this exercises the extracted key/reducer
 // functions directly rather than standing up a full App render + mocked
 // WebSocket.

--- a/app/src/utils/fsChangeSignals.ts
+++ b/app/src/utils/fsChangeSignals.ts
@@ -1,0 +1,36 @@
+import type { FsIndexResult, NotebookEntry } from '../hooks/useDaemonSocket';
+
+// The per-root fs_changed signal key: the daemon-resolved root verbatim, or
+// `effectiveNotebookRoot` when the event carries no root (the daemon's
+// notebook-root events, and — as a safety fallback — any malformed event
+// missing the field). A rootless tile and the fullscreen browser look
+// themselves up with the same normalization (root='' → effectiveNotebookRoot),
+// so they land on this key too.
+export function fsChangeSignalKey(root: string, effectiveNotebookRoot: string): string {
+  return root || effectiveNotebookRoot;
+}
+
+// Pure reducer for the per-root fs_changed signal map: bumps only the key the
+// event resolves to, leaving every other root's counter untouched so a tile
+// bound to root A never re-renders for a change under root B.
+export function bumpFsChangeSignal(
+  signals: Record<string, number>,
+  root: string,
+  effectiveNotebookRoot: string,
+): Record<string, number> {
+  const key = fsChangeSignalKey(root, effectiveNotebookRoot);
+  return { ...signals, [key]: (signals[key] || 0) + 1 };
+}
+
+// Adapts fs_index (a flat, root-scoped file listing) to the shape the ⌘P
+// finder and NotebookBrowser already expect from notebook_list. size is
+// always 0: fs_index deliberately omits stat() per entry to stay fast over
+// large repos, and nothing downstream of the finder reads it. A truncated
+// result still renders — an incomplete list beats none — but is flagged to
+// the console so a silently-cut-off finder doesn't look like a bug report.
+export function fsIndexToNotebookEntries(result: FsIndexResult): NotebookEntry[] {
+  if (result.truncated) {
+    console.warn('[App] fs_index truncated for', result.root, '— finder list is incomplete');
+  }
+  return result.files.map((path) => ({ path, size: 0 }));
+}

--- a/app/src/utils/fsIndexToNotebookEntries.test.ts
+++ b/app/src/utils/fsIndexToNotebookEntries.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { fsIndexToNotebookEntries } from './App';
-import type { FsIndexResult } from './hooks/useDaemonSocket';
+import { fsIndexToNotebookEntries } from './fsChangeSignals';
+import type { FsIndexResult } from '../hooks/useDaemonSocket';
 
 // Pure-logic coverage for the fs_index -> NotebookEntry adapter that backs the
 // ⌘P finder (both notebook tiles and the fullscreen NotebookBrowser) since PR5

--- a/app/src/utils/presentationNotices.test.ts
+++ b/app/src/utils/presentationNotices.test.ts
@@ -4,8 +4,8 @@ import {
   presentationNeedsNotice,
   seedPresentationNotices,
   upsertPresentationNotice,
-} from './App';
-import type { Presentation } from './types/generated';
+} from './presentationNotices';
+import type { Presentation } from '../types/generated';
 
 // Pure-logic coverage for the presentation-notice list that feeds the pane
 // header chip (HeaderPresentationChip in components/PresentationChip.tsx).

--- a/app/src/utils/presentationNotices.ts
+++ b/app/src/utils/presentationNotices.ts
@@ -1,0 +1,34 @@
+import type { Presentation } from '../types/generated';
+
+// A presentation is worth a notice (surfaced as a chip in its triggering
+// session's pane header) while its latest round is open for review (status
+// "open") and hasn't been submitted yet.
+export function presentationNeedsNotice(presentation: Presentation): boolean {
+  return presentation.status === 'open' && !presentation.latest_round_submitted;
+}
+
+// Pure reducer for the presentation-notice list, shared by the initial
+// getPresentations() seed and the presentation_added/updated broadcasts.
+// Keeps at most one entry per presentation id; a presentation that stops
+// needing a notice (submitted or closed) is dropped.
+export function upsertPresentationNotice(notices: Presentation[], updated: Presentation): Presentation[] {
+  const withoutExisting = notices.filter((n) => n.id !== updated.id);
+  return presentationNeedsNotice(updated) ? [...withoutExisting, updated] : withoutExisting;
+}
+
+export function seedPresentationNotices(all: Presentation[]): Presentation[] {
+  return all.filter(presentationNeedsNotice);
+}
+
+// A session can trigger more than one presentation over time; the pane
+// header chip only ever shows the newest one that still needs review.
+export function latestPresentationBySessionId(notices: Presentation[]): Map<string, Presentation> {
+  const bySessionId = new Map<string, Presentation>();
+  for (const p of notices) {
+    const existing = bySessionId.get(p.session_id);
+    if (!existing || p.created_at > existing.created_at) {
+      bySessionId.set(p.session_id, p);
+    }
+  }
+  return bySessionId;
+}

--- a/app/src/utils/queueBands.ts
+++ b/app/src/utils/queueBands.ts
@@ -24,6 +24,24 @@ export interface QueueRow<TSession extends QueueBandSession> {
   workspaceTitle: string;
 }
 
+/**
+ * How long a turn has been outstanding, in the coarsest unit that still reads
+ * as an age. `now` is passed in rather than read here so the caller owns the
+ * clock and the function stays a pure projection of the two timestamps.
+ */
+export function formatTurnAge(openedAt: string | undefined, now: number): string {
+  if (!openedAt) return '';
+  const opened = Date.parse(openedAt);
+  if (Number.isNaN(opened)) return '';
+  const seconds = Math.max(0, Math.round((now - opened) / 1000));
+  if (seconds < 60) return 'now';
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.round(hours / 24)}d`;
+}
+
 export interface QueueBands<TSession extends QueueBandSession> {
   /** The chief's anchored slot. It never queues, so it is always its own row. */
   chief: QueueRow<TSession> | null;


### PR DESCRIPTION
React Doctor reported **19 warnings on the lines PR #689 changed** (score 60/100,
0 errors — [run 30397323031](https://github.com/victorarias/attn/actions/runs/30397323031)).
This clears all of them but one, with no suppressions, no rule or workflow edits,
and no behavior change beyond the accessibility fix.

Verified with `react-doctor --scope changed --base origin/main` — the same
diff-scoped question CI asks — which now reports **0 findings across the 14
changed files**.

## The one real defect: queue rows were mouse-only

A row in the agent queue carried its `onClick` on a plain `<div>`. It could not
be reached by Tab, no key press activated it, and a screen reader had no reason
to announce it as something you could do anything with.

Opening an agent is now a real `<button>` that fills the row, so Tab reaches it,
Return and Space press it, and it announces as "Open &lt;agent&gt;". It fills the
row from behind rather than wrapping its contents, which matters for two reasons:
clicking anywhere on the row still opens it, and every other child stays a direct
child of `.session-item`, so the row's flex layout and the `>` selectors that
style it are untouched. The settle, pin, and actions controls are lifted above it
so they stay independently clickable and no longer sit inside an interactive
ancestor.

The first attempt — `role="button"` plus key handlers on the row div — cleared the
two accessibility findings but introduced three `html-no-nested-interactive`
warnings, since the settle, pin, and actions buttons then sat inside an
interactive ancestor. The button-behind-the-row shape is what clears both.

## The structural findings

- **`no-barrel-import`** — direct imports instead of the `../shortcuts` barrel in
  `QueueBands`, `Sidebar`, `App`, `useKeyboardShortcuts`, and
  `useUiAutomationBridge`.
- **`only-export-components`** — `App.tsx` exported seven pure helpers alongside
  the component, which breaks Fast Refresh state preservation on every edit to a
  3600-line file. The presentation-notice helpers move to
  `src/utils/presentationNotices.ts` and the fs-signal helpers to
  `src/utils/fsChangeSignals.ts`, with their existing tests, which move and keep
  their coverage. `formatTurnAge` moves out of `QueueBands.tsx` to
  `utils/queueBands.ts` for the same reason.
- **`js-combine-iterations`** — `Sidebar`'s `map().filter()` and `map().map()`
  chains walk their lists once.
- **`button-has-type`** — the update banner's two buttons declare
  `type="button"`.

## Left deliberately

**`prefer-useReducer` on `SettingsModal.tsx:182`.** The rule fires on the count
of `useState` calls in one component, but its premise — state that changes
together — does not hold here. Those 23 values are independent per-field drafts,
each committed on its own blur or change; only the "reset the drafts when the
modal opens" effect touches them together, and React batches that into one render
anyway. Collapsing them into a single reducer would be a large rewrite of a
heavily interactive modal, with real regression risk, in exchange for a worse
fit. Left as-is rather than suppressed.

For context, the six files this PR touches still carry 53 findings of these same
rules on lines PR #689 did not change (mostly `button-has-type` and pre-existing
`Sidebar` rows with the same click-handler-on-a-div shape). Those are outside
this PR's contract and are not addressed here.

## Verification

- `pnpm --dir app exec tsc --noEmit`, `pnpm --dir app test` (2092 passed),
  `pnpm --dir app run e2e` (191 passed, 1 skipped) — all green.
- **Live, packaged app** on a throwaway `rdfix` profile (`make install
  PROFILE=rdfix`, preflight PASS): `real-app:scenario-agent-queue` green,
  `ATTN_VERDICT ok:true`, all 13 steps. That covers opening a row by click
  through the new control, settling, pinning, the chief slot, the arrangement
  toggle, and a settle surviving a daemon restart.
- **The keyboard fix specifically**, in that run: focus placed on a row's open
  control, which reports `{"tag":"BUTTON","label":"Open queue-alpha-…","focused":true}`,
  then a **real Return key through the packaged app** (CGEvent, not a synthesized
  DOM event) opens that agent and lands input focus in its pane.
- **Visually**: the row renders unchanged — state dot, label, workspace, actions
  in place — and the focus ring draws around the row when its open control has
  focus.

To support that evidence, `queue_get_state` now reports each row's open control,
and the automation bridge gains a `dom_focus` verb. Focus is placed directly
rather than walked to with Tab: where a blind Tab walk ends up depends on the
whole window and says nothing about this row, and an earlier version that walked
proved flaky across profiles. The key press itself stays real.

https://claude.ai/code/session_01RZL3Tpa2g9hXQ2BNQ3iqDG