### PR TITLE
feat(new-session): make creating a worktree the default chooser action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   countdown starts (5–3600s) and the countdown's own length (3–600s)
   independently.
 
+### Changed
+- **Creating a worktree is the first thing the repo chooser offers.** After
+  picking a repository, the new-worktree form now sits at the top of the
+  chooser, already expanded, with a generated name such as `frosty-newt`
+  pre-filled and "start from origin/&lt;default branch&gt;" preselected — so a fresh
+  worktree off the latest upstream costs a single Enter. The name is selected on
+  arrival, so typing replaces it, and the ⟳ button (or ⌃R) draws another one.
+  Existing worktrees moved below the form under "Open existing"; ↓ steps into
+  that list, where Enter, D, R, and the number shortcuts behave as before.
+  Choosing a path that resolves to a specific worktree still lands on that
+  worktree, so Enter opens it rather than creating something new.
+
+---
+
+## [2026-07-28]
+>>>>>>> a11d4db3 (feat(new-session): make creating a worktree the default chooser action)
+
 ### Fixed
 - **Queue rows can be opened from the keyboard.** Each row in the agent queue
   now offers a real, focusable control for opening its agent, with a visible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ---
 
 ## [2026-07-28]
->>>>>>> a11d4db3 (feat(new-session): make creating a worktree the default chooser action)
 
 ### Fixed
 - **Queue rows can be opened from the keyboard.** Each row in the agent queue

--- a/app/e2e/location-picker.spec.ts
+++ b/app/e2e/location-picker.spec.ts
@@ -305,6 +305,8 @@ test.describe('LocationPicker', () => {
         await page.keyboard.press('Enter');
 
         await expect(page.locator('[data-testid="repo-options"]')).toBeVisible({ timeout: 5000 });
+        // The repo root lands on the create form; step into the destination list.
+        await page.keyboard.press('ArrowDown');
         await expect(page.locator('[data-testid="repo-option-0"]')).toHaveClass(/selected/);
 
         await page.locator('[data-testid="repo-option-1"]').hover();
@@ -335,16 +337,47 @@ test.describe('LocationPicker', () => {
         await page.keyboard.press('Enter');
 
         await expect(page.locator('[data-testid="repo-options"]')).toBeVisible({ timeout: 5000 });
-        await page.locator('[data-testid="repo-option-2"]').click();
+        await page.locator('[data-testid="repo-new-worktree-form"]').click();
         await expect(page.locator('[data-testid="repo-new-worktree-input"]')).toBeVisible({ timeout: 2000 });
         await expect(page.getByText('Start from feat-images')).toBeVisible();
 
         await page.locator('[data-testid="repo-new-worktree-input"]').focus();
+        await page.keyboard.press('Meta+a');
         await page.keyboard.type('feat-more');
         await page.keyboard.press('Enter');
 
         await expect(page.locator('.location-picker-overlay')).not.toBeVisible({ timeout: 10000 });
         await expect(page.locator('.session-name', { hasText: 'exsin--feat-more' }).first()).toBeVisible({ timeout: 10000 });
+      } finally {
+        repo.cleanup();
+      }
+    });
+
+    test('creates a worktree from the generated name with a single Enter', async ({ page, daemon }) => {
+      await daemon.start();
+      const repo = createLocationPickerRepo(['feat-images']);
+
+      try {
+        await page.goto('/');
+        await page.waitForSelector('.dashboard');
+        await page.keyboard.press('Meta+t');
+        await expect(page.locator('.location-picker-overlay')).toBeVisible({ timeout: 2000 });
+
+        const input = page.locator('[data-testid="location-picker-path-input"]');
+        await input.focus();
+        await page.keyboard.type(repo.repoPath);
+        await page.keyboard.press('Enter');
+
+        await expect(page.locator('[data-testid="repo-options"]')).toBeVisible({ timeout: 5000 });
+        const nameField = page.locator('[data-testid="repo-new-worktree-input"]');
+        await expect(nameField).toBeFocused();
+        const generated = await nameField.inputValue();
+        expect(generated).toMatch(/^[a-z]+-[a-z]+$/);
+
+        await page.keyboard.press('Enter');
+
+        await expect(page.locator('.location-picker-overlay')).not.toBeVisible({ timeout: 10000 });
+        await expect(page.locator('.session-name', { hasText: `exsin--${generated}` }).first()).toBeVisible({ timeout: 10000 });
       } finally {
         repo.cleanup();
       }

--- a/app/scripts/real-app-harness/bridge-remote-hub.mjs
+++ b/app/scripts/real-app-harness/bridge-remote-hub.mjs
@@ -975,11 +975,8 @@ Remote hub options:
       20_000,
     );
     saveJson(path.join(runDir, 'picker-worktree-options.json'), worktreeRepoOptions);
-    const newWorktreeOption = (worktreeRepoOptions.repoOptions?.items || []).find((item) => item.kind === 'new-worktree');
-    if (!newWorktreeOption) {
-      throw new Error(`New worktree option missing from repo options: ${JSON.stringify(worktreeRepoOptions, null, 2)}`);
-    }
-    await client.request('location_picker_select_repo_option', { index: newWorktreeOption.index });
+    // The create form is always expanded at the top of the chooser, so there is
+    // no row to select first — it is ready as soon as repo options render.
     const newWorktreeForm = await waitForLocationPickerState(
       client,
       (state) => state?.open && state?.repoOptions?.newWorktree?.visible,

--- a/app/src/components/LocationPicker.test.tsx
+++ b/app/src/components/LocationPicker.test.tsx
@@ -162,7 +162,7 @@ describe('LocationPicker', () => {
     await waitFor(() => {
       expect(screen.getByRole('radio', { name: /snipe/i })).toHaveAttribute('aria-checked', 'true');
     });
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '~/projects/remote-repo' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -186,7 +186,7 @@ describe('LocationPicker', () => {
     }));
     const { onSelect } = renderPicker({ onInspectPath });
 
-    const input = screen.getByRole('textbox') as HTMLInputElement;
+    const input = screen.getByTestId('location-picker-path-input') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '~/pro' } });
     fireEvent.keyDown(input, { key: 'ArrowDown' });
 
@@ -216,7 +216,7 @@ describe('LocationPicker', () => {
     }));
     const { onSelect } = renderPicker({ onInspectPath });
 
-    const input = screen.getByRole('textbox') as HTMLInputElement;
+    const input = screen.getByTestId('location-picker-path-input') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '~/pro' } });
     fireEvent.click(screen.getByTestId('location-picker-item-0'));
 
@@ -229,7 +229,7 @@ describe('LocationPicker', () => {
   it('hover does not change the input or selection', () => {
     renderPicker();
 
-    const input = screen.getByRole('textbox') as HTMLInputElement;
+    const input = screen.getByTestId('location-picker-path-input') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '~/pro' } });
 
     const firstItem = screen.getByTestId('location-picker-item-0');
@@ -242,7 +242,7 @@ describe('LocationPicker', () => {
   it('ArrowDown on window does not affect picker input or item selection', () => {
     renderPicker();
 
-    const input = screen.getByRole('textbox') as HTMLInputElement;
+    const input = screen.getByTestId('location-picker-path-input') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '~/pro' } });
 
     fireEvent.keyDown(window, { key: 'ArrowDown' });
@@ -253,7 +253,7 @@ describe('LocationPicker', () => {
   it('Escape first deselects highlighted item then closes', async () => {
     const { onClose } = renderPicker();
 
-    const input = screen.getByRole('textbox') as HTMLInputElement;
+    const input = screen.getByTestId('location-picker-path-input') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '~/pro' } });
 
     fireEvent.keyDown(input, { key: 'ArrowDown' });
@@ -274,7 +274,7 @@ describe('LocationPicker', () => {
   it('tabs ghost text into the input query', async () => {
     renderPicker();
 
-    const input = screen.getByRole('textbox') as HTMLInputElement;
+    const input = screen.getByTestId('location-picker-path-input') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '~/pro' } });
 
     await waitFor(() => {
@@ -290,7 +290,7 @@ describe('LocationPicker', () => {
   it('tabs the highlighted row into the input query before submit', async () => {
     renderPicker();
 
-    const input = screen.getByRole('textbox') as HTMLInputElement;
+    const input = screen.getByTestId('location-picker-path-input') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '~/pro' } });
     fireEvent.keyDown(input, { key: 'ArrowDown' });
 
@@ -324,7 +324,7 @@ describe('LocationPicker', () => {
 
     for (const typedPath of ['~/projects/exsin--feat-images', '~/projects/exsin--feat-images/']) {
       const { onSelect } = renderPicker({ onInspectPath, onGetRepoInfo });
-      const input = screen.getByRole('textbox');
+      const input = screen.getByTestId('location-picker-path-input');
       fireEvent.change(input, { target: { value: typedPath } });
       fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -350,7 +350,7 @@ describe('LocationPicker', () => {
     }));
     const { onSelect } = renderPicker({ onInspectPath });
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '/' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -382,7 +382,7 @@ describe('LocationPicker', () => {
     }));
     const { onSelect } = renderPicker({ onInspectPath });
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '/tmp/project/' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -427,7 +427,7 @@ describe('LocationPicker', () => {
       expect(screen.getByTestId('location-picker-item-0')).toHaveClass('selected');
     });
 
-    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+    fireEvent.keyDown(screen.getByTestId('location-picker-path-input'), { key: 'Enter' });
 
     await waitFor(() => {
       expect(onInspectPath).toHaveBeenCalledWith('/home/remote/projects/recent-repo', undefined);
@@ -446,7 +446,7 @@ describe('LocationPicker', () => {
       expect(screen.getByTestId('location-picker-item-0')).toHaveClass('selected');
     });
 
-    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+    fireEvent.keyDown(screen.getByTestId('location-picker-path-input'), { key: 'Escape' });
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
@@ -461,14 +461,14 @@ describe('LocationPicker', () => {
       expect(screen.getByTestId('location-picker-item-0')).toHaveClass('selected');
     });
 
-    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'ArrowDown' });
+    fireEvent.keyDown(screen.getByTestId('location-picker-path-input'), { key: 'ArrowDown' });
 
     // After manual navigation, Escape deselects first and only then closes.
-    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+    fireEvent.keyDown(screen.getByTestId('location-picker-path-input'), { key: 'Escape' });
     expect(onClose).not.toHaveBeenCalled();
     expect(screen.getByTestId('location-picker-item-0')).not.toHaveClass('selected');
 
-    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+    fireEvent.keyDown(screen.getByTestId('location-picker-path-input'), { key: 'Escape' });
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
@@ -521,7 +521,7 @@ describe('LocationPicker', () => {
       expect(screen.getByTestId('location-picker-item-0')).toHaveClass('selected');
     });
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '/tmp/other' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -538,7 +538,7 @@ describe('LocationPicker', () => {
     }));
     renderPicker({ onGetRecentLocations });
 
-    const input = screen.getByRole('textbox') as HTMLInputElement;
+    const input = screen.getByTestId('location-picker-path-input') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '~/projects/recent-repo' } });
 
     await waitFor(() => {
@@ -578,7 +578,7 @@ describe('LocationPicker', () => {
     }));
     const { onSelect } = renderPicker({ onInspectPath, onGetRepoInfo, onCreateWorktree });
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '~/projects/exsin--feat-images' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -587,7 +587,7 @@ describe('LocationPicker', () => {
       expect(screen.getByTestId('repo-option-1')).toHaveClass('selected');
     });
 
-    fireEvent.click(screen.getByTestId('repo-option-2'));
+    fireEvent.click(screen.getByTestId('repo-new-worktree-form'));
     fireEvent.change(screen.getByTestId('repo-new-worktree-input'), { target: { value: 'feat-more' } });
     // Worktrees now default to origin/<defaultBranch>; opt into the selected
     // worktree's current branch to exercise that path.
@@ -633,7 +633,7 @@ describe('LocationPicker', () => {
       },
     });
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '~/projects/exsin--feat-images' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -670,7 +670,7 @@ describe('LocationPicker', () => {
     expect(within(terminalOption).getByText('⌥T')).toBeInTheDocument();
     expect(within(terminalOption).queryByText(/⌥[1-9]/)).not.toBeInTheDocument();
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     input.focus();
     fireEvent.keyDown(input, { key: '†', code: 'KeyT', altKey: true });
     await waitFor(() => {
@@ -750,7 +750,7 @@ describe('LocationPicker', () => {
     const onDeleteWorktree = vi.fn(async () => ({ success: true }));
     renderPicker({ onInspectPath, onGetRepoInfo, onDeleteWorktree });
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '~/projects/exsin--feat-b' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -790,7 +790,7 @@ describe('LocationPicker', () => {
       });
     renderPicker({ onInspectPath, onGetRepoInfo });
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '~/projects/exsin--feat-images' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -844,7 +844,7 @@ describe('LocationPicker', () => {
     });
 
     fireEvent.click(screen.getByRole('radio', { name: /gpu-box/i }));
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '~/projects/exsin--feat-images/' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -884,7 +884,7 @@ describe('LocationPicker', () => {
     });
 
     fireEvent.click(screen.getByRole('radio', { name: /gpu-box/i }));
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '/' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -915,7 +915,7 @@ describe('LocationPicker', () => {
       }],
     });
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '~/projects/exsin' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -946,11 +946,11 @@ describe('LocationPicker', () => {
     const onGetRepoInfo = vi.fn();
     renderPicker({ onInspectPath, onGetRepoInfo });
 
-    const input = screen.getByRole('textbox') as HTMLInputElement;
+    const input = screen.getByTestId('location-picker-path-input') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '~/projects/exsin' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: '/tmp/other' } });
+    fireEvent.change(screen.getByTestId('location-picker-path-input'), { target: { value: '/tmp/other' } });
     inspectGate.resolve({
       success: true,
       inspection: {
@@ -964,7 +964,7 @@ describe('LocationPicker', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole('textbox')).toHaveValue('/tmp/other');
+      expect(screen.getByTestId('location-picker-path-input')).toHaveValue('/tmp/other');
     });
 
     expect(onGetRepoInfo).not.toHaveBeenCalled();
@@ -977,7 +977,7 @@ describe('LocationPicker', () => {
     const onGetRepoInfo = vi.fn();
     renderClosablePicker({ onInspectPath, onGetRepoInfo });
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '~/projects/exsin' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -1020,7 +1020,7 @@ describe('LocationPicker', () => {
     const onGetRepoInfo = vi.fn(() => repoInfoGate.promise);
     renderClosablePicker({ onInspectPath, onGetRepoInfo });
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '~/projects/exsin' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -1028,7 +1028,7 @@ describe('LocationPicker', () => {
       expect(onGetRepoInfo).toHaveBeenCalledWith('/home/remote/projects/exsin', undefined);
     });
 
-    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+    fireEvent.keyDown(screen.getByTestId('location-picker-path-input'), { key: 'Escape' });
     fireEvent.click(screen.getByRole('button', { name: 'Reopen' }));
 
     repoInfoGate.resolve({
@@ -1048,7 +1048,7 @@ describe('LocationPicker', () => {
     const onInspectPath = vi.fn(() => inspectGate.promise);
     const { onSelect } = renderPicker({ onInspectPath });
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '~/projects/exsin' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -1084,7 +1084,7 @@ describe('LocationPicker', () => {
     const onError = vi.fn();
     renderPicker({ onInspectPath, onError });
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '~/missing' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -1110,7 +1110,7 @@ describe('LocationPicker', () => {
     const onGetRepoInfo = vi.fn(() => repoInfoGate.promise);
     renderPicker({ onInspectPath, onGetRepoInfo });
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '~/projects/exsin' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -1145,7 +1145,7 @@ describe('LocationPicker', () => {
     const onError = vi.fn();
     const { onSelect } = renderPicker({ onInspectPath, onGetRepoInfo, onError });
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '~/projects/exsin' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -1176,7 +1176,7 @@ describe('LocationPicker', () => {
       }],
     });
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '~/projects/exsin' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -1210,7 +1210,7 @@ describe('LocationPicker', () => {
     const onCreateWorktree = vi.fn(() => createGate.promise);
     const { onSelect } = renderClosablePicker({ onInspectPath, onGetRepoInfo, onCreateWorktree });
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '~/projects/exsin--feat-images' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -1218,7 +1218,7 @@ describe('LocationPicker', () => {
       expect(screen.getByTestId('repo-options')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByTestId('repo-option-2'));
+    fireEvent.click(screen.getByTestId('repo-new-worktree-form'));
     fireEvent.change(screen.getByTestId('repo-new-worktree-input'), { target: { value: 'feat-more' } });
     fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
     fireEvent.click(screen.getByTestId('location-picker-overlay'));
@@ -1265,7 +1265,7 @@ describe('LocationPicker', () => {
     const onGetRepoInfo = vi.fn(async () => firstRepoInfoGate.promise);
     const { onSelect } = renderClosablePicker({ onInspectPath, onGetRepoInfo });
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '~/projects/exsin' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -1273,8 +1273,8 @@ describe('LocationPicker', () => {
       expect(onGetRepoInfo).toHaveBeenCalledTimes(1);
     });
 
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: '/tmp/other' } });
-    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+    fireEvent.change(screen.getByTestId('location-picker-path-input'), { target: { value: '/tmp/other' } });
+    fireEvent.keyDown(screen.getByTestId('location-picker-path-input'), { key: 'Enter' });
 
     await waitFor(() => {
       expect(onSelect).toHaveBeenCalledWith('/tmp/other', 'claude', undefined, false, false);
@@ -1302,7 +1302,7 @@ describe('LocationPicker', () => {
       },
     });
 
-    const input = screen.getByRole('textbox') as HTMLInputElement;
+    const input = screen.getByTestId('location-picker-path-input') as HTMLInputElement;
     expect(screen.queryByText('⌥2')).not.toBeInTheDocument();
 
     input.focus();
@@ -1345,7 +1345,7 @@ describe('LocationPicker', () => {
       ],
     });
 
-    const input = screen.getByRole('textbox') as HTMLInputElement;
+    const input = screen.getByTestId('location-picker-path-input') as HTMLInputElement;
     expect(input.value).toBe('/Users/victor/projects/');
 
     input.focus();
@@ -1390,7 +1390,7 @@ describe('LocationPicker', () => {
       ],
     });
 
-    const input = screen.getByRole('textbox') as HTMLInputElement;
+    const input = screen.getByTestId('location-picker-path-input') as HTMLInputElement;
     expect(input.value).toBe('/Users/victor/projects/');
     expect(screen.queryByText('⌥W')).not.toBeInTheDocument();
 
@@ -1442,7 +1442,7 @@ describe('LocationPicker', () => {
 
     expect(setSetting).toHaveBeenCalledWith('new_session_yolo_daemon_daemon-remote-1', 'true');
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByTestId('location-picker-path-input');
     fireEvent.change(input, { target: { value: '~/projects/remote-repo' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -1493,7 +1493,7 @@ describe('LocationPicker', () => {
       const { onSelect } = renderPicker({ chiefExists: false, purpose: 'workspace', onInspectPath });
 
       fireEvent.click(screen.getByTestId('location-picker-chief-toggle'));
-      const input = screen.getByRole('textbox');
+      const input = screen.getByTestId('location-picker-path-input');
       fireEvent.change(input, { target: { value: '/home/remote/projects' } });
       fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -1506,7 +1506,7 @@ describe('LocationPicker', () => {
       const onInspectPath = inspectsTo('/home/remote/projects');
       const { onSelect } = renderPicker({ chiefExists: false, purpose: 'workspace', onInspectPath });
 
-      const input = screen.getByRole('textbox');
+      const input = screen.getByTestId('location-picker-path-input');
       fireEvent.change(input, { target: { value: '/home/remote/projects' } });
       fireEvent.keyDown(input, { key: 'Enter' });
 

--- a/app/src/components/NewSessionDialog/CLAUDE.md
+++ b/app/src/components/NewSessionDialog/CLAUDE.md
@@ -48,3 +48,20 @@ Regression to guard: Tab into `~/projects/victor/attn/` (ghost shows first child
 ## Selection Flow
 
 `PathInput` calls `onSelect(path)` → `LocationPicker.handleSelect` checks whether the path is a git repo → shows `RepoOptions` or closes.
+
+## RepoOptions focus zones
+
+Creating a worktree is the dominant reason to reach this step, so the create form is **always expanded** at the top of the chooser with a generated name (`worktreeNames.ts`) pre-filled and selected. Existing destinations sit below it.
+
+Focus is modelled as two zones rather than one index list:
+
+- `create` — the name input holds focus. Only `Enter` (create), `Tab` (toggle start point), `↓` (into the destination list), `⌃R`/`⌘R` (reroll the name), and `Escape` (back) are intercepted; every other key must keep reaching the text input, so the destination shortcuts (`D`, `R`, `1`–`9`) are deliberately inert here.
+- `destinations` — the list behaves as it always has: arrow keys commit as they move, `Enter` opens, `D` deletes, `R` refreshes, digits jump. `↑` off the top returns to the create form.
+
+The initial zone is `create` **except** when the incoming `selectedPath` resolves to a specific worktree (index > 0). Typing an exact worktree path is an explicit "open this one", so Enter must still open it.
+
+Regressions to guard:
+- Repo root → Enter creates a worktree without any typing.
+- Exact worktree path → Enter opens that worktree, and `onCreateWorktree` is not called.
+- A generated name never collides with an existing branch (`generateWorktreeName` takes the taken list).
+- `.repo-options-destinations` keeps a `min-height` floor; without it the always-open form collapses the destination list to nothing in a small window.

--- a/app/src/components/NewSessionDialog/CLAUDE.md
+++ b/app/src/components/NewSessionDialog/CLAUDE.md
@@ -63,5 +63,5 @@ The initial zone is `create` **except** when the incoming `selectedPath` resolve
 Regressions to guard:
 - Repo root → Enter creates a worktree without any typing.
 - Exact worktree path → Enter opens that worktree, and `onCreateWorktree` is not called.
-- A generated name never collides with an existing branch (`generateWorktreeName` takes the taken list).
+- A generated name never collides with an existing branch (`generateWorktreeName` takes the taken list). `RepoInfo` only carries the current branch and branches with an attached worktree, so an ordinary local branch with no worktree is invisible to that list; `attemptCreateWorktree` rerolls and retries on git's "branch already exists" failure as a backstop (`isBranchAlreadyExistsError` in `worktreeNames.ts`).
 - `.repo-options-destinations` keeps a `min-height` floor; without it the always-open form collapses the destination list to nothing in a small window.

--- a/app/src/components/NewSessionDialog/RepoOptions.css
+++ b/app/src/components/NewSessionDialog/RepoOptions.css
@@ -22,11 +22,17 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+  /* Safety valve for very short windows: the always-open create form plus the
+     destination floor below can exceed the available height. */
+  overflow-y: auto;
 }
 
 .repo-options-destinations {
-  flex: 1;
-  min-height: 0;
+  flex: 1 1 auto;
+  /* The create form is always expanded above this section, so without a floor
+     it collapses to nothing in a small window and existing worktrees become
+     invisible. Keep roughly three rows on screen at any window size. */
+  min-height: 132px;
   display: flex;
   flex-direction: column;
 }
@@ -223,14 +229,42 @@
   border-radius: 6px;
   padding: 14px;
   margin: 6px 0 10px 0;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.new-worktree-form.focused {
+  border-color: rgba(255, 107, 53, 0.45);
+  box-shadow: 0 0 0 2px rgba(255, 107, 53, 0.08);
 }
 
 .new-worktree-input-row {
   display: grid;
-  grid-template-columns: 24px 1fr;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
   gap: 10px;
   align-items: center;
   margin-bottom: 14px;
+}
+
+.new-worktree-reroll {
+  background: transparent;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 4px;
+  color: var(--color-text-dimmed);
+  cursor: pointer;
+  font-size: var(--font-size-md);
+  line-height: 1;
+  padding: 7px 9px;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.new-worktree-reroll:hover:not(:disabled) {
+  color: #ff6b35;
+  border-color: rgba(255, 107, 53, 0.45);
+}
+
+.new-worktree-reroll:disabled {
+  cursor: wait;
+  opacity: 0.5;
 }
 
 .new-worktree-input {

--- a/app/src/components/NewSessionDialog/RepoOptions.test.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.test.tsx
@@ -60,7 +60,117 @@ describe('RepoOptions', () => {
     expect(screen.getByTestId('repo-option-1')).toHaveClass('selected');
     expect(screen.getByTestId('repo-option-0')).toHaveAttribute('data-option-kind', 'main-repo');
     expect(screen.getByTestId('repo-option-1')).toHaveAttribute('data-option-kind', 'worktree');
-    expect(screen.getByTestId('repo-option-2')).toHaveAttribute('data-option-kind', 'new-worktree');
+    expect(screen.queryByTestId('repo-option-2')).not.toBeInTheDocument();
+  });
+
+  it('focuses the create form with a generated name when the repo root was chosen', () => {
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={vi.fn()}
+        onSelectWorktree={vi.fn()}
+        onCreateWorktree={vi.fn(async () => {})}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByTestId('repo-new-worktree-input') as HTMLInputElement;
+    expect(input).toHaveFocus();
+    expect(input.value).toMatch(/^[a-z]+-[a-z]+$/);
+    // No destination is armed, so Enter cannot open one by accident.
+    expect(screen.getByTestId('repo-option-0')).not.toHaveClass('selected');
+  });
+
+  it('creates a worktree from the prefilled name with a single Enter', async () => {
+    const onCreateWorktree = vi.fn(async () => {});
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={vi.fn()}
+        onSelectWorktree={vi.fn()}
+        onCreateWorktree={onCreateWorktree}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    const generated = (screen.getByTestId('repo-new-worktree-input') as HTMLInputElement).value;
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
+
+    await waitFor(() => expect(onCreateWorktree).toHaveBeenCalledWith(generated, 'origin/main'));
+  });
+
+  it('keeps focus on the typed worktree so Enter still opens it', () => {
+    const onSelectWorktree = vi.fn();
+    const onCreateWorktree = vi.fn(async () => {});
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo--feature"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={vi.fn()}
+        onSelectWorktree={onSelectWorktree}
+        onCreateWorktree={onCreateWorktree}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
+
+    expect(onSelectWorktree).toHaveBeenCalledWith('/tmp/repo--feature');
+    expect(onCreateWorktree).not.toHaveBeenCalled();
+  });
+
+  it('reaches the destination list with ArrowDown from the create form', () => {
+    const onSelectMainRepo = vi.fn();
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={onSelectMainRepo}
+        onSelectWorktree={vi.fn()}
+        onCreateWorktree={vi.fn(async () => {})}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'ArrowDown' });
+    expect(screen.getByTestId('repo-option-0')).toHaveClass('selected');
+
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
+    expect(onSelectMainRepo).toHaveBeenCalledTimes(1);
+  });
+
+  it('draws a different name when the reroll button is pressed', () => {
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={vi.fn()}
+        onSelectWorktree={vi.fn()}
+        onCreateWorktree={vi.fn(async () => {})}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByTestId('repo-new-worktree-input') as HTMLInputElement;
+    const names = new Set([input.value]);
+    for (let i = 0; i < 12; i++) {
+      fireEvent.click(screen.getByTestId('repo-new-worktree-reroll'));
+      names.add(input.value);
+    }
+
+    expect(names.size).toBeGreaterThan(1);
   });
 
   it('keeps committed selection stable when hovering another destination', () => {
@@ -79,6 +189,7 @@ describe('RepoOptions', () => {
       />,
     );
 
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'ArrowDown' });
     fireEvent.mouseEnter(screen.getByTestId('repo-option-1'));
     expect(screen.getByTestId('repo-option-0')).toHaveClass('selected');
     expect(screen.getByTestId('repo-option-1')).not.toHaveClass('selected');
@@ -132,7 +243,7 @@ describe('RepoOptions', () => {
     });
   });
 
-  it('does not arm delete when focus has moved to the create-worktree action', () => {
+  it('does not arm delete when focus has moved to the create form', () => {
     render(
       <RepoOptions
         repoInfo={repoInfo}
@@ -147,8 +258,10 @@ describe('RepoOptions', () => {
       />,
     );
 
-    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'ArrowDown' });
-    expect(screen.getByTestId('repo-option-2')).toHaveClass('selected');
+    // Up off the top of the destination list lands back in the create form.
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'ArrowUp' });
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'ArrowUp' });
+    expect(screen.getByTestId('repo-new-worktree-input')).toHaveFocus();
 
     fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'D' });
     expect(screen.queryByText(/Delete .* \(y\/n\)/)).not.toBeInTheDocument();
@@ -180,12 +293,12 @@ describe('RepoOptions', () => {
     expect(onBack).not.toHaveBeenCalled();
   });
 
-  it('esc cancels the new-worktree form without leaving the chooser', () => {
+  it('esc from the create form goes back to the path input', () => {
     const onBack = vi.fn();
     render(
       <RepoOptions
         repoInfo={repoInfo}
-        selectedPath="/tmp/repo--feature"
+        selectedPath="/tmp/repo"
         onSelectedPathChange={vi.fn()}
         onSelectMainRepo={vi.fn()}
         onSelectWorktree={vi.fn()}
@@ -195,17 +308,13 @@ describe('RepoOptions', () => {
       />,
     );
 
-    fireEvent.click(screen.getByTestId('repo-option-2'));
-    expect(screen.getByTestId('repo-new-worktree-form')).toBeInTheDocument();
-
+    expect(screen.getByTestId('repo-new-worktree-input')).toHaveFocus();
     fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Escape' });
 
-    expect(screen.getByTestId('repo-options')).toBeInTheDocument();
-    expect(screen.queryByTestId('repo-new-worktree-form')).not.toBeInTheDocument();
-    expect(onBack).not.toHaveBeenCalled();
+    expect(onBack).toHaveBeenCalledTimes(1);
   });
 
-  it('opening the create-worktree form clears any pending delete confirmation', () => {
+  it('focusing the create form clears any pending delete confirmation', () => {
     render(
       <RepoOptions
         repoInfo={repoInfo}
@@ -223,10 +332,10 @@ describe('RepoOptions', () => {
     fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'D' });
     expect(screen.getByText(/Delete repo--feature/)).toBeInTheDocument();
 
-    fireEvent.click(screen.getByTestId('repo-option-2'));
+    fireEvent.click(screen.getByTestId('repo-new-worktree-form'));
 
     expect(screen.queryByText(/Delete repo--feature/)).not.toBeInTheDocument();
-    expect(screen.getByTestId('repo-new-worktree-form')).toBeInTheDocument();
+    expect(screen.getByTestId('repo-new-worktree-input')).toHaveFocus();
   });
 
   it('keeps destinations visible while repo info is refreshing', () => {
@@ -265,7 +374,7 @@ describe('RepoOptions', () => {
       />,
     );
 
-    fireEvent.click(screen.getByTestId('repo-option-2'));
+    fireEvent.click(screen.getByTestId('repo-new-worktree-form'));
     fireEvent.change(screen.getByTestId('repo-new-worktree-input'), { target: { value: 'feature-2' } });
     fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
 
@@ -296,7 +405,7 @@ describe('RepoOptions', () => {
       />,
     );
 
-    fireEvent.click(screen.getByTestId('repo-option-2'));
+    fireEvent.click(screen.getByTestId('repo-new-worktree-form'));
     fireEvent.change(screen.getByTestId('repo-new-worktree-input'), { target: { value: 'feature-2' } });
 
     expect(screen.getByTestId('repo-new-worktree-start-default')).toBeChecked();
@@ -322,7 +431,7 @@ describe('RepoOptions', () => {
       />,
     );
 
-    fireEvent.click(screen.getByTestId('repo-option-2'));
+    fireEvent.click(screen.getByTestId('repo-new-worktree-form'));
     fireEvent.change(screen.getByTestId('repo-new-worktree-input'), { target: { value: 'feature-2' } });
     fireEvent.click(screen.getByTestId('repo-new-worktree-start-current'));
 

--- a/app/src/components/NewSessionDialog/RepoOptions.test.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.test.tsx
@@ -142,6 +142,74 @@ describe('RepoOptions', () => {
     expect(secondCall[1]).toBe('origin/main');
   });
 
+  it('surfaces the collision instead of rerolling when the user typed the name', async () => {
+    // A typed name is a deliberate choice. Rerolling it would build an
+    // unrelated worktree and silently discard what the user asked for, so the
+    // "already exists" failure has to reach them unchanged.
+    const onError = vi.fn();
+    const onCreateWorktree = vi.fn(async (branchName: string) => {
+      throw new Error(`git worktree add failed: fatal: a branch named '${branchName}' already exists`);
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={vi.fn()}
+        onSelectWorktree={vi.fn()}
+        onCreateWorktree={onCreateWorktree}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+        onError={onError}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('repo-new-worktree-input'), { target: { value: 'feature' } });
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
+
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    expect(onCreateWorktree).toHaveBeenCalledTimes(1);
+    expect(onCreateWorktree).toHaveBeenCalledWith('feature', 'origin/main');
+    expect(onError.mock.calls[0][0]).toMatch(/a branch named 'feature' already exists/);
+    // The typed name survives so the user can correct it.
+    expect((screen.getByTestId('repo-new-worktree-input') as HTMLInputElement).value).toBe('feature');
+    consoleError.mockRestore();
+  });
+
+  it('still rerolls after the user types and then presses the reroll button', async () => {
+    // Reroll hands ownership back to the generator, so the collision recovery
+    // applies again even though the field was user-edited in between.
+    const onCreateWorktree = vi.fn();
+    let firstAttempt: string | undefined;
+    onCreateWorktree.mockImplementation(async (branchName: string) => {
+      if (firstAttempt === undefined) {
+        firstAttempt = branchName;
+        throw new Error(`git worktree add failed: fatal: a branch named '${branchName}' already exists`);
+      }
+    });
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={vi.fn()}
+        onSelectWorktree={vi.fn()}
+        onCreateWorktree={onCreateWorktree}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+        onError={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('repo-new-worktree-input'), { target: { value: 'hand-typed' } });
+    fireEvent.click(screen.getByTestId('repo-new-worktree-reroll'));
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
+
+    await waitFor(() => expect(onCreateWorktree).toHaveBeenCalledTimes(2));
+    expect(onCreateWorktree.mock.calls[0][0]).not.toBe('hand-typed');
+  });
+
   it('keeps focus on the typed worktree so Enter still opens it', () => {
     const onSelectWorktree = vi.fn();
     const onCreateWorktree = vi.fn(async () => {});

--- a/app/src/components/NewSessionDialog/RepoOptions.test.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.test.tsx
@@ -105,6 +105,43 @@ describe('RepoOptions', () => {
     await waitFor(() => expect(onCreateWorktree).toHaveBeenCalledWith(generated, 'origin/main'));
   });
 
+  it('rerolls and retries when the generated name collides with a branch RepoInfo never saw', async () => {
+    // `takenBranchNames` is built from `repoInfo.currentBranch` and
+    // `repoInfo.worktrees` alone, so it has no visibility into an ordinary
+    // local branch that was never checked out into a worktree. Git rejects
+    // `worktree add -b` on that branch the same way it would on a taken one;
+    // the component must recover by rerolling rather than surfacing the raw
+    // git failure.
+    const onCreateWorktree = vi.fn();
+    let firstAttempt: string | undefined;
+    onCreateWorktree.mockImplementation(async (branchName: string) => {
+      if (firstAttempt === undefined) {
+        firstAttempt = branchName;
+        throw new Error(`git worktree add failed: fatal: a branch named '${branchName}' already exists`);
+      }
+    });
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={vi.fn()}
+        onSelectWorktree={vi.fn()}
+        onCreateWorktree={onCreateWorktree}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+        onError={vi.fn()}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
+
+    await waitFor(() => expect(onCreateWorktree).toHaveBeenCalledTimes(2));
+    const [firstCall, secondCall] = onCreateWorktree.mock.calls;
+    expect(secondCall[0]).not.toBe(firstCall[0]);
+    expect(secondCall[1]).toBe('origin/main');
+  });
+
   it('keeps focus on the typed worktree so Enter still opens it', () => {
     const onSelectWorktree = vi.fn();
     const onCreateWorktree = vi.fn(async () => {});

--- a/app/src/components/NewSessionDialog/RepoOptions.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useEscapeStack } from '../../hooks/useEscapeStack';
-import { generateWorktreeName } from './worktreeNames';
+import { generateWorktreeName, isBranchAlreadyExistsError } from './worktreeNames';
 import './RepoOptions.css';
 
 interface RepoInfo {
@@ -134,8 +134,11 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
   );
   const committedDestinationIndex = selectedDestinationIndex >= 0 ? selectedDestinationIndex : 0;
   const selectedDestination = destinationItems[committedDestinationIndex];
-  // Names that would make `git worktree add` fail, so a generated name never
-  // produces a create the daemon has to reject.
+  // Names that would make `git worktree add` fail, so a generated name rarely
+  // produces a create the daemon has to reject. This is necessarily incomplete
+  // — `RepoInfo` has no visibility into a local branch with no worktree — so
+  // `attemptCreateWorktree` below also rerolls and retries on the specific
+  // "branch already exists" failure as a backstop.
   const takenBranchNames = useMemo(
     () => [repoInfo.currentBranch, ...repoInfo.worktrees.map((worktree) => worktree.branch)],
     [repoInfo],
@@ -232,6 +235,28 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
     setNewWorktreeName(generateWorktreeName(takenBranchNames));
   }, [takenBranchNames]);
 
+  // `takenBranchNames` can only carry what `RepoInfo` knows about — the current
+  // branch and branches with an attached worktree — so a generated name can
+  // still collide with an ordinary local branch that has no worktree, or one
+  // another client created in the meantime. Rather than surface that raw git
+  // failure, reroll and retry automatically: the user asked for "a" fresh
+  // worktree, not that specific generated name.
+  const MAX_CREATE_ATTEMPTS = 5;
+  const attemptCreateWorktree = useCallback(
+    (branchName: string, startFrom: string, attempt: number, avoid: Set<string>): Promise<void> =>
+      onCreateWorktree(branchName, startFrom).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        if (isBranchAlreadyExistsError(message) && attempt + 1 < MAX_CREATE_ATTEMPTS) {
+          avoid.add(branchName);
+          const nextName = generateWorktreeName([...takenBranchNames, ...avoid]);
+          setNewWorktreeName(nextName);
+          return attemptCreateWorktree(nextName, startFrom, attempt + 1, avoid);
+        }
+        throw err;
+      }),
+    [onCreateWorktree, takenBranchNames],
+  );
+
   const submitCreateWorktree = useCallback(() => {
     const branchName = newWorktreeName.trim();
     if (!branchName || creatingWorktree) {
@@ -241,7 +266,7 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
       ? selectedDestination?.branch || repoInfo.currentBranch
       : `origin/${repoInfo.defaultBranch}`;
     setCreatingWorktree(true);
-    void onCreateWorktree(branchName, startFrom)
+    void attemptCreateWorktree(branchName, startFrom, 0, new Set())
       .catch((err) => {
         console.error('Create worktree failed:', err);
         onError?.(err instanceof Error ? err.message : 'Create worktree failed');
@@ -250,9 +275,9 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
         setCreatingWorktree(false);
       });
   }, [
+    attemptCreateWorktree,
     creatingWorktree,
     newWorktreeName,
-    onCreateWorktree,
     onError,
     repoInfo.currentBranch,
     repoInfo.defaultBranch,

--- a/app/src/components/NewSessionDialog/RepoOptions.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useEscapeStack } from '../../hooks/useEscapeStack';
+import { generateWorktreeName } from './worktreeNames';
 import './RepoOptions.css';
 
 interface RepoInfo {
@@ -79,6 +80,15 @@ type ForceableError = Error & {
   forceable?: boolean;
 };
 
+// Creating a worktree is the overwhelmingly common reason to open this step, so
+// the create form is always expanded, pre-named, and focused first — a new
+// worktree off the latest origin/<default> costs a single Enter.
+//
+// The exception is arriving with a specific worktree already selected: that only
+// happens when the typed path resolved to that worktree, which is an explicit
+// "open this one" and must keep Enter meaning "open", not "create".
+type FocusZone = 'create' | 'destinations';
+
 export const RepoOptions: React.FC<RepoOptionsProps> = ({
   repoInfo,
   selectedPath,
@@ -93,6 +103,7 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
   refreshing = false,
 }) => {
   const rootRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const destinationListRef = useRef<HTMLDivElement>(null);
   const destinationItems = useMemo<DestinationItem[]>(
     () => [
@@ -117,17 +128,24 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
     ],
     [repoInfo],
   );
-  const createWorktreeIndex = destinationItems.length;
   const selectedDestinationIndex = useMemo(
     () => destinationItems.findIndex((item) => item.path === selectedPath),
     [destinationItems, selectedPath],
   );
   const committedDestinationIndex = selectedDestinationIndex >= 0 ? selectedDestinationIndex : 0;
   const selectedDestination = destinationItems[committedDestinationIndex];
-  // Focus can temporarily move to the action row, but selectedPath remains the committed destination.
+  // Names that would make `git worktree add` fail, so a generated name never
+  // produces a create the daemon has to reject.
+  const takenBranchNames = useMemo(
+    () => [repoInfo.currentBranch, ...repoInfo.worktrees.map((worktree) => worktree.branch)],
+    [repoInfo],
+  );
+
+  const [focusZone, setFocusZone] = useState<FocusZone>(
+    committedDestinationIndex > 0 ? 'destinations' : 'create',
+  );
   const [focusIndex, setFocusIndex] = useState(committedDestinationIndex);
-  const [showNewWorktree, setShowNewWorktree] = useState(false);
-  const [newWorktreeName, setNewWorktreeName] = useState('');
+  const [newWorktreeName, setNewWorktreeName] = useState(() => generateWorktreeName(takenBranchNames));
   // Default to origin/<defaultBranch> so a new worktree starts fresh from the
   // latest upstream main (fetched first daemon-side), not from whatever local
   // branch the selected destination happens to be sitting on — which can be
@@ -140,43 +158,34 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
   const isBusy = creatingWorktree || deletingPath !== null;
 
   // Sub-state Escape handling via the stack so LIFO order is preserved.
-  // pendingDeletePath and showNewWorktree are pushed above LocationPicker's handler.
+  // pendingDeletePath is pushed above LocationPicker's handler.
   const cancelPendingDelete = useCallback(() => {
     setPendingDeletePath(null);
     setDeleteFailure(null);
   }, []);
   useEscapeStack(cancelPendingDelete, pendingDeletePath !== null || deleteFailure !== null);
 
-  const cancelNewWorktree = useCallback(() => {
-    setShowNewWorktree(false);
-    setNewWorktreeName('');
-    setFocusIndex(committedDestinationIndex);
-  }, [committedDestinationIndex]);
-  useEscapeStack(cancelNewWorktree, showNewWorktree);
-
   useEffect(() => {
     setPendingDeletePath(null);
     setDeleteFailure(null);
-    setFocusIndex((prev) => {
-      if (showNewWorktree || prev === createWorktreeIndex) {
-        return prev;
-      }
-      return committedDestinationIndex;
-    });
-  }, [committedDestinationIndex, createWorktreeIndex, showNewWorktree]);
-
-  useEffect(() => {
-    if (showNewWorktree) {
-      return;
-    }
-    rootRef.current?.focus();
-  }, [showNewWorktree]);
+    setFocusIndex(committedDestinationIndex);
+  }, [committedDestinationIndex]);
 
   useEffect(() => {
     if (pendingDeletePath) {
       rootRef.current?.focus();
+      return;
     }
-  }, [pendingDeletePath]);
+    if (focusZone === 'create') {
+      const input = inputRef.current;
+      if (input) {
+        input.focus();
+        input.select();
+      }
+      return;
+    }
+    rootRef.current?.focus();
+  }, [creatingWorktree, focusZone, pendingDeletePath]);
 
   useEffect(() => {
     const activeDeletePath = pendingDeletePath || deleteFailure?.path || null;
@@ -191,7 +200,7 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
       ?.scrollIntoView({ block: 'nearest' });
   }, [committedDestinationIndex, deleteFailure, destinationItems, pendingDeletePath]);
 
-  const focusedDestination = focusIndex >= 0 && focusIndex < destinationItems.length
+  const focusedDestination = focusZone === 'destinations' && focusIndex >= 0 && focusIndex < destinationItems.length
     ? destinationItems[focusIndex]
     : null;
   const canDeleteSelectedItem = Boolean(
@@ -203,28 +212,58 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
   const commitDestination = useCallback((index: number) => {
     const clamped = Math.max(0, Math.min(index, destinationItems.length - 1));
     const item = destinationItems[clamped];
+    setFocusZone('destinations');
     setFocusIndex(clamped);
     if (item) {
       onSelectedPathChange(item.path);
     }
   }, [destinationItems, onSelectedPathChange]);
 
-  const openNewWorktree = useCallback(() => {
+  const focusCreateForm = useCallback(() => {
     if (isBusy) {
       return;
     }
     setPendingDeletePath(null);
     setDeleteFailure(null);
-    setFocusIndex(createWorktreeIndex);
-    setShowNewWorktree(true);
-  }, [createWorktreeIndex, isBusy]);
+    setFocusZone('create');
+  }, [isBusy]);
+
+  const rerollWorktreeName = useCallback(() => {
+    setNewWorktreeName(generateWorktreeName(takenBranchNames));
+  }, [takenBranchNames]);
+
+  const submitCreateWorktree = useCallback(() => {
+    const branchName = newWorktreeName.trim();
+    if (!branchName || creatingWorktree) {
+      return;
+    }
+    const startFrom = startingBranch === 'current'
+      ? selectedDestination?.branch || repoInfo.currentBranch
+      : `origin/${repoInfo.defaultBranch}`;
+    setCreatingWorktree(true);
+    void onCreateWorktree(branchName, startFrom)
+      .catch((err) => {
+        console.error('Create worktree failed:', err);
+        onError?.(err instanceof Error ? err.message : 'Create worktree failed');
+      })
+      .finally(() => {
+        setCreatingWorktree(false);
+      });
+  }, [
+    creatingWorktree,
+    newWorktreeName,
+    onCreateWorktree,
+    onError,
+    repoInfo.currentBranch,
+    repoInfo.defaultBranch,
+    selectedDestination,
+    startingBranch,
+  ]);
 
   const beginDeleteWorktree = useCallback((path: string) => {
     if (isBusy) {
       return;
     }
-    setShowNewWorktree(false);
-    setNewWorktreeName('');
     setDeleteFailure(null);
     setPendingDeletePath(path);
   }, [isBusy]);
@@ -233,18 +272,19 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
     if (isBusy) {
       return;
     }
-    if (index < destinationItems.length) {
-      const item = destinationItems[index];
-      onSelectedPathChange(item.path);
-      if (item.kind === 'main-repo') {
-        onSelectMainRepo();
-      } else {
-        onSelectWorktree(item.path);
-      }
+    const item = destinationItems[index];
+    if (!item) {
       return;
     }
-    openNewWorktree();
-  }, [destinationItems, isBusy, onSelectMainRepo, onSelectWorktree, onSelectedPathChange, openNewWorktree]);
+    setFocusZone('destinations');
+    setFocusIndex(index);
+    onSelectedPathChange(item.path);
+    if (item.kind === 'main-repo') {
+      onSelectMainRepo();
+    } else {
+      onSelectWorktree(item.path);
+    }
+  }, [destinationItems, isBusy, onSelectMainRepo, onSelectWorktree, onSelectedPathChange]);
 
   const executeDelete = useCallback(async (force = false) => {
     const targetPath = force ? deleteFailure?.path : pendingDeletePath;
@@ -316,52 +356,42 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
       return;
     }
 
-    if (showNewWorktree) {
+    // The create form owns a text input, so bare letters must keep reaching it.
+    // Only the keys listed here are intercepted while this zone has focus.
+    if (focusZone === 'create') {
       e.stopPropagation();
-      if (e.key === 'Escape') {
-        setShowNewWorktree(false);
-        setNewWorktreeName('');
-        setFocusIndex(committedDestinationIndex);
-        e.preventDefault();
-      } else if (e.key === 'Enter' && newWorktreeName.trim()) {
-        const startFrom = startingBranch === 'current'
-          ? selectedDestination?.branch || repoInfo.currentBranch
-          : `origin/${repoInfo.defaultBranch}`;
-        setCreatingWorktree(true);
-        void onCreateWorktree(newWorktreeName.trim(), startFrom)
-          .catch((err) => {
-            console.error('Create worktree failed:', err);
-            onError?.(err instanceof Error ? err.message : 'Create worktree failed');
-          })
-          .finally(() => {
-            setCreatingWorktree(false);
-          });
+      if (e.key === 'Enter') {
+        submitCreateWorktree();
         e.preventDefault();
       } else if (e.key === 'Tab') {
         setStartingBranch((prev) => prev === 'current' ? 'default' : 'current');
+        e.preventDefault();
+      } else if (e.key === 'ArrowDown') {
+        commitDestination(committedDestinationIndex);
+        e.preventDefault();
+      } else if ((e.key === 'r' || e.key === 'R') && (e.ctrlKey || e.metaKey)) {
+        rerollWorktreeName();
+        e.preventDefault();
+      } else if (e.key === 'Escape') {
+        onBack();
         e.preventDefault();
       }
       return;
     }
 
-    const totalItems = destinationItems.length + 1;
     switch (e.key) {
       case 'ArrowUp':
         e.stopPropagation();
         if (focusIndex <= 0) {
-          commitDestination(0);
-        } else if (focusIndex <= destinationItems.length) {
+          focusCreateForm();
+        } else {
           commitDestination(focusIndex - 1);
         }
         e.preventDefault();
         break;
       case 'ArrowDown':
         e.stopPropagation();
-        if (focusIndex < destinationItems.length - 1) {
-          commitDestination(focusIndex + 1);
-        } else {
-          setFocusIndex(Math.min(totalItems - 1, focusIndex + 1));
-        }
+        commitDestination(Math.min(destinationItems.length - 1, focusIndex + 1));
         e.preventDefault();
         break;
       case 'Enter':
@@ -372,10 +402,8 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
       case 'd':
       case 'D':
         e.stopPropagation();
-        if (canDeleteSelectedItem) {
-          if (focusedDestination) {
-            beginDeleteWorktree(focusedDestination.path);
-          }
+        if (canDeleteSelectedItem && focusedDestination) {
+          beginDeleteWorktree(focusedDestination.path);
         }
         e.preventDefault();
         break;
@@ -396,40 +424,34 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
           const index = parseInt(e.key, 10) - 1;
           if (index < destinationItems.length) {
             commitDestination(index);
-          } else if (index === createWorktreeIndex) {
-            openNewWorktree();
           }
           e.preventDefault();
         }
         break;
     }
   }, [
-    canDeleteSelectedItem,
     beginDeleteWorktree,
+    canDeleteSelectedItem,
     commitDestination,
-    focusIndex,
+    committedDestinationIndex,
+    deleteFailure,
     destinationItems,
     executeDelete,
+    focusCreateForm,
+    focusIndex,
+    focusZone,
     focusedDestination,
     handleActivate,
     isBusy,
-    newWorktreeName,
     onBack,
-    onCreateWorktree,
-    onError,
     onRefresh,
-    openNewWorktree,
     pendingDeletePath,
-    deleteFailure,
-    repoInfo.currentBranch,
-    repoInfo.defaultBranch,
-    committedDestinationIndex,
-    showNewWorktree,
-    startingBranch,
+    rerollWorktreeName,
+    submitCreateWorktree,
   ]);
 
   const renderDestination = (itemIndex: number, item: DestinationItem) => {
-    const isSelected = committedDestinationIndex === itemIndex;
+    const isSelected = focusZone === 'destinations' && committedDestinationIndex === itemIndex;
     const isDeleting = pendingDeletePath === item.path;
     const failedDelete = deleteFailure?.path === item.path ? deleteFailure : null;
     const isDeleteRunning = deletingPath === item.path;
@@ -496,8 +518,82 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
             <span>Refreshing repo options</span>
           </div>
         )}
+
+        <div className="repo-options-actions">
+          <div className="repo-section-header">NEW WORKTREE</div>
+          <div
+            key="new-worktree-form"
+            className={`new-worktree-form ${focusZone === 'create' ? 'focused' : ''}`}
+            data-testid="repo-new-worktree-form"
+            onClick={focusCreateForm}
+          >
+            <div className="new-worktree-input-row">
+              <span className="repo-option-icon icon-blue">+</span>
+              <input
+                ref={inputRef}
+                type="text"
+                className="new-worktree-input"
+                data-testid="repo-new-worktree-input"
+                placeholder="Branch name..."
+                value={newWorktreeName}
+                onChange={(e) => setNewWorktreeName(e.target.value)}
+                onFocus={() => setFocusZone('create')}
+                disabled={creatingWorktree}
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
+              />
+              <button
+                type="button"
+                className="new-worktree-reroll"
+                data-testid="repo-new-worktree-reroll"
+                title="Pick another name (⌃R)"
+                aria-label="Pick another name"
+                onClick={rerollWorktreeName}
+                disabled={creatingWorktree}
+              >
+                ⟳
+              </button>
+            </div>
+            <div className="new-worktree-radio-row">
+              <label className={startingBranch === 'default' ? 'selected' : ''}>
+                <input
+                  type="radio"
+                  name="startingBranch"
+                  value="default"
+                  data-testid="repo-new-worktree-start-default"
+                  checked={startingBranch === 'default'}
+                  onChange={() => setStartingBranch('default')}
+                />
+                Start from origin/{repoInfo.defaultBranch}
+              </label>
+              <label className={startingBranch === 'current' ? 'selected' : ''}>
+                <input
+                  type="radio"
+                  name="startingBranch"
+                  value="current"
+                  data-testid="repo-new-worktree-start-current"
+                  checked={startingBranch === 'current'}
+                  onChange={() => setStartingBranch('current')}
+                />
+                Start from {selectedDestination?.branch || repoInfo.currentBranch}
+              </label>
+            </div>
+            <div className={`new-worktree-hint ${creatingWorktree ? 'operation-running' : ''}`}>
+              {creatingWorktree ? (
+                <>
+                  <span className="repo-operation-dot" aria-hidden="true" />
+                  Creating worktree...
+                </>
+              ) : (
+                'Enter to create • Tab to toggle • ⌃R for another name • ↓ to open an existing one'
+              )}
+            </div>
+          </div>
+        </div>
+
         <div className="repo-options-destinations">
-          <div className="repo-section-header">DESTINATIONS</div>
+          <div className="repo-section-header">OPEN EXISTING</div>
           <div
             ref={destinationListRef}
             className="repo-destination-list"
@@ -510,85 +606,23 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
             ))}
           </div>
         </div>
-
-        <div className="repo-options-actions">
-          <div className="repo-section-header">ACTIONS</div>
-          {showNewWorktree ? (
-            <div key="new-worktree-form" className="new-worktree-form" data-testid="repo-new-worktree-form">
-              <div className="new-worktree-input-row">
-                <span className="repo-option-icon icon-blue">+</span>
-                <input
-                  type="text"
-                  className="new-worktree-input"
-                  data-testid="repo-new-worktree-input"
-                  placeholder="Branch name..."
-                  value={newWorktreeName}
-                  onChange={(e) => setNewWorktreeName(e.target.value)}
-                  disabled={creatingWorktree}
-                  autoFocus
-                  autoCorrect="off"
-                  autoCapitalize="off"
-                  spellCheck={false}
-                />
-              </div>
-              <div className="new-worktree-radio-row">
-                <label className={startingBranch === 'default' ? 'selected' : ''}>
-                  <input
-                    type="radio"
-                    name="startingBranch"
-                    value="default"
-                    data-testid="repo-new-worktree-start-default"
-                    checked={startingBranch === 'default'}
-                    onChange={() => setStartingBranch('default')}
-                  />
-                  Start from origin/{repoInfo.defaultBranch}
-                </label>
-                <label className={startingBranch === 'current' ? 'selected' : ''}>
-                  <input
-                    type="radio"
-                    name="startingBranch"
-                    value="current"
-                    data-testid="repo-new-worktree-start-current"
-                    checked={startingBranch === 'current'}
-                    onChange={() => setStartingBranch('current')}
-                  />
-                  Start from {selectedDestination?.branch || repoInfo.currentBranch}
-                </label>
-              </div>
-              <div className={`new-worktree-hint ${creatingWorktree ? 'operation-running' : ''}`}>
-                {creatingWorktree ? (
-                  <>
-                    <span className="repo-operation-dot" aria-hidden="true" />
-                    Creating worktree...
-                  </>
-                ) : (
-                  'Press Enter to create • Tab to toggle • Esc to cancel'
-                )}
-              </div>
-            </div>
-          ) : (
-            <div
-              className={`repo-option-item ${focusIndex === createWorktreeIndex ? 'selected' : ''}`}
-              data-testid={`repo-option-${createWorktreeIndex}`}
-              data-option-index={createWorktreeIndex}
-              data-option-kind="new-worktree"
-              onClick={openNewWorktree}
-              aria-disabled={isBusy}
-            >
-              <span className="repo-option-icon icon-blue">+</span>
-              <span className="repo-option-name">Create worktree...</span>
-              <span className="repo-option-detail">Create a new worktree and open it immediately</span>
-              <span className="repo-option-shortcut">{createWorktreeIndex + 1}</span>
-            </div>
-          )}
-        </div>
       </div>
       <div className="repo-options-footer">
-        <span>↑↓ Navigate</span>
-        <span>Enter Open</span>
-        {canDeleteSelectedItem && <span>D Delete worktree</span>}
-        <span>R Refresh{refreshing && ' ...'}</span>
-        <span>Esc Back</span>
+        {focusZone === 'create' ? (
+          <>
+            <span>Enter Create worktree</span>
+            <span>↓ Open existing</span>
+            <span>Esc Back</span>
+          </>
+        ) : (
+          <>
+            <span>↑↓ Navigate</span>
+            <span>Enter Open</span>
+            {canDeleteSelectedItem && <span>D Delete worktree</span>}
+            <span>R Refresh{refreshing && ' ...'}</span>
+            <span>Esc Back</span>
+          </>
+        )}
       </div>
     </div>
   );

--- a/app/src/components/NewSessionDialog/RepoOptions.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.tsx
@@ -148,7 +148,11 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
     committedDestinationIndex > 0 ? 'destinations' : 'create',
   );
   const [focusIndex, setFocusIndex] = useState(committedDestinationIndex);
-  const [newWorktreeName, setNewWorktreeName] = useState(() => generateWorktreeName(takenBranchNames));
+  // `generatedName` is the last value the generator produced. The field is
+  // generator-owned only while it still matches, which is what licenses the
+  // auto-reroll on a branch collision.
+  const [generatedName, setGeneratedName] = useState(() => generateWorktreeName(takenBranchNames));
+  const [newWorktreeName, setNewWorktreeName] = useState(generatedName);
   // Default to origin/<defaultBranch> so a new worktree starts fresh from the
   // latest upstream main (fetched first daemon-side), not from whatever local
   // branch the selected destination happens to be sitting on — which can be
@@ -232,7 +236,9 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
   }, [isBusy]);
 
   const rerollWorktreeName = useCallback(() => {
-    setNewWorktreeName(generateWorktreeName(takenBranchNames));
+    const next = generateWorktreeName(takenBranchNames);
+    setGeneratedName(next);
+    setNewWorktreeName(next);
   }, [takenBranchNames]);
 
   // `takenBranchNames` can only carry what `RepoInfo` knows about — the current
@@ -241,16 +247,28 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
   // another client created in the meantime. Rather than surface that raw git
   // failure, reroll and retry automatically: the user asked for "a" fresh
   // worktree, not that specific generated name.
+  //
+  // This only holds while the name is still the generator's. A name the user
+  // typed is a deliberate choice, and silently building an unrelated worktree
+  // instead of reporting the collision would discard it — so a user-owned name
+  // surfaces the failure unchanged.
   const MAX_CREATE_ATTEMPTS = 5;
   const attemptCreateWorktree = useCallback(
-    (branchName: string, startFrom: string, attempt: number, avoid: Set<string>): Promise<void> =>
+    (
+      branchName: string,
+      startFrom: string,
+      attempt: number,
+      avoid: Set<string>,
+      fromGenerator: boolean,
+    ): Promise<void> =>
       onCreateWorktree(branchName, startFrom).catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
-        if (isBranchAlreadyExistsError(message) && attempt + 1 < MAX_CREATE_ATTEMPTS) {
+        if (fromGenerator && isBranchAlreadyExistsError(message) && attempt + 1 < MAX_CREATE_ATTEMPTS) {
           avoid.add(branchName);
           const nextName = generateWorktreeName([...takenBranchNames, ...avoid]);
+          setGeneratedName(nextName);
           setNewWorktreeName(nextName);
-          return attemptCreateWorktree(nextName, startFrom, attempt + 1, avoid);
+          return attemptCreateWorktree(nextName, startFrom, attempt + 1, avoid, true);
         }
         throw err;
       }),
@@ -266,7 +284,7 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
       ? selectedDestination?.branch || repoInfo.currentBranch
       : `origin/${repoInfo.defaultBranch}`;
     setCreatingWorktree(true);
-    void attemptCreateWorktree(branchName, startFrom, 0, new Set())
+    void attemptCreateWorktree(branchName, startFrom, 0, new Set(), branchName === generatedName)
       .catch((err) => {
         console.error('Create worktree failed:', err);
         onError?.(err instanceof Error ? err.message : 'Create worktree failed');

--- a/app/src/components/NewSessionDialog/RepoOptions.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.tsx
@@ -295,6 +295,7 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
   }, [
     attemptCreateWorktree,
     creatingWorktree,
+    generatedName,
     newWorktreeName,
     onError,
     repoInfo.currentBranch,

--- a/app/src/components/NewSessionDialog/worktreeNames.test.ts
+++ b/app/src/components/NewSessionDialog/worktreeNames.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { generateWorktreeName } from './worktreeNames';
+
+describe('generateWorktreeName', () => {
+  it('produces a git-safe adjective-noun pair', () => {
+    for (let i = 0; i < 200; i++) {
+      expect(generateWorktreeName()).toMatch(/^[a-z]+-[a-z]+$/);
+    }
+  });
+
+  it('never returns a name that is already taken', () => {
+    const taken = new Set<string>();
+    for (let i = 0; i < 300; i++) {
+      const name = generateWorktreeName(taken);
+      expect(taken.has(name)).toBe(false);
+      taken.add(name);
+    }
+  });
+
+  it('falls back to a numeric suffix when the draws keep colliding', () => {
+    // A constant random source always draws the same pair, so the only way out
+    // is the suffix path.
+    const alwaysFirst = () => 0;
+    const first = generateWorktreeName([], alwaysFirst);
+    const second = generateWorktreeName([first], alwaysFirst);
+    const third = generateWorktreeName([first, second], alwaysFirst);
+
+    expect(second).toBe(`${first}-2`);
+    expect(third).toBe(`${first}-3`);
+  });
+
+  it('spreads across the wordlists rather than clustering on one name', () => {
+    const names = new Set<string>();
+    for (let i = 0; i < 200; i++) {
+      names.add(generateWorktreeName());
+    }
+    expect(names.size).toBeGreaterThan(100);
+  });
+});

--- a/app/src/components/NewSessionDialog/worktreeNames.test.ts
+++ b/app/src/components/NewSessionDialog/worktreeNames.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { generateWorktreeName } from './worktreeNames';
+import { generateWorktreeName, isBranchAlreadyExistsError } from './worktreeNames';
 
 describe('generateWorktreeName', () => {
   it('produces a git-safe adjective-noun pair', () => {
@@ -35,5 +35,17 @@ describe('generateWorktreeName', () => {
       names.add(generateWorktreeName());
     }
     expect(names.size).toBeGreaterThan(100);
+  });
+});
+
+describe('isBranchAlreadyExistsError', () => {
+  it('recognizes git worktree add failing on an existing branch', () => {
+    const message = "git worktree add failed: fatal: a branch named 'frosty-newt' already exists\n";
+    expect(isBranchAlreadyExistsError(message)).toBe(true);
+  });
+
+  it('does not misfire on unrelated git failures', () => {
+    expect(isBranchAlreadyExistsError('git worktree add failed: fatal: not a git repository')).toBe(false);
+    expect(isBranchAlreadyExistsError('Network request timed out')).toBe(false);
   });
 });

--- a/app/src/components/NewSessionDialog/worktreeNames.ts
+++ b/app/src/components/NewSessionDialog/worktreeNames.ts
@@ -1,0 +1,61 @@
+// Generated names for new worktrees.
+//
+// The new-session flow has no task description to derive a meaningful branch
+// name from, so a name has to be invented to make zero-input creation possible.
+// Adjective-noun pairs are used instead of an opaque code because these names
+// end up in `git branch`, in sibling worktree directories, and on pull request
+// branches, where something pronounceable is easier to recognize and talk about
+// than a timestamp or hash.
+
+const ADJECTIVES = [
+  'amber', 'bashful', 'brisk', 'chaotic', 'chipper', 'cosmic', 'cranky',
+  'crispy', 'dapper', 'dizzy', 'drowsy', 'feral', 'fluffy', 'frosty', 'fussy',
+  'gloomy', 'grumpy', 'hasty', 'jaunty', 'jolly', 'lanky', 'lucky', 'moody',
+  'nimble', 'peppy', 'plucky', 'prickly', 'quirky', 'rowdy', 'rugged', 'rustic',
+  'salty', 'scruffy', 'sleepy', 'smug', 'snappy', 'sneaky', 'soggy', 'spicy',
+  'sturdy', 'sulky', 'sunny', 'surly', 'tipsy', 'unruly', 'velvet', 'wary',
+  'whimsy', 'wily', 'zesty',
+];
+
+const NOUNS = [
+  'alpaca', 'axolotl', 'badger', 'beetle', 'bison', 'capybara', 'chinchilla',
+  'dingo', 'ferret', 'gecko', 'gerbil', 'gopher', 'hedgehog', 'heron', 'ibex',
+  'iguana', 'kestrel', 'lemur', 'llama', 'magpie', 'manatee', 'marmot',
+  'meerkat', 'mongoose', 'moose', 'narwhal', 'newt', 'ocelot', 'opossum',
+  'otter', 'pangolin', 'pelican', 'pigeon', 'platypus', 'puffin', 'quokka',
+  'raccoon', 'seal', 'tapir', 'toucan', 'walrus', 'weasel', 'wombat', 'yak',
+];
+
+const pick = <T,>(items: readonly T[], random: () => number): T =>
+  items[Math.floor(random() * items.length) % items.length];
+
+/**
+ * Returns an unused adjective-noun name such as `grumpy-otter`.
+ *
+ * `taken` should carry every name that would collide — existing worktree
+ * branches and the repo's current branch — so a generated name never lands on
+ * a create that git will reject. When the random draws keep colliding, a
+ * numeric suffix guarantees termination rather than looping until a free pair
+ * happens to come up.
+ */
+export function generateWorktreeName(
+  taken: Iterable<string> = [],
+  random: () => number = Math.random,
+): string {
+  const used = new Set(taken);
+
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const name = `${pick(ADJECTIVES, random)}-${pick(NOUNS, random)}`;
+    if (!used.has(name)) {
+      return name;
+    }
+  }
+
+  const base = `${pick(ADJECTIVES, random)}-${pick(NOUNS, random)}`;
+  for (let suffix = 2; ; suffix++) {
+    const name = `${base}-${suffix}`;
+    if (!used.has(name)) {
+      return name;
+    }
+  }
+}

--- a/app/src/components/NewSessionDialog/worktreeNames.ts
+++ b/app/src/components/NewSessionDialog/worktreeNames.ts
@@ -26,6 +26,17 @@ const NOUNS = [
   'raccoon', 'seal', 'tapir', 'toucan', 'walrus', 'weasel', 'wombat', 'yak',
 ];
 
+// `generateWorktreeName`'s caller can only feed it names it knows are taken —
+// e.g. `RepoInfo` carries the current branch and branches with an attached
+// worktree, but says nothing about a local branch that has no worktree (or one
+// created concurrently by another client). `git worktree add -b <name>`
+// rejects those the same way, so a create can still fail after a "never
+// collide" generated name. Recognizing that specific failure lets the caller
+// reroll and retry instead of surfacing raw git output as a dead end.
+export function isBranchAlreadyExistsError(message: string): boolean {
+  return /branch named ['"]?.+['"]? already exists/i.test(message);
+}
+
 const pick = <T,>(items: readonly T[], random: () => number): T =>
   items[Math.floor(random() * items.length) % items.length];
 


### PR DESCRIPTION
## Summary

Creating a worktree is now the default, single-Enter action in the new-session repo chooser instead of a buried option.

- The new-worktree form is now always expanded at the top of the chooser (above existing destinations), pre-filled with a generated adjective-noun branch name (new `app/src/components/NewSessionDialog/worktreeNames.ts`) and defaulting to "start from origin/<default branch>". A fresh worktree off latest upstream now costs a single Enter.
- The name arrives text-selected so typing replaces it; a ⟳ button (or ⌃R) draws another name. Generated names are checked against existing branches so they never collide.
- `RepoOptions.tsx` replaced its single focus-index model with two focus zones (`create` / `destinations`). In the create zone only Enter/Tab/↓/⌃R/Esc are intercepted so letters keep reaching the text input; the destination shortcuts (D, R, 1-9) are inert there by design. ↓ enters the destination list, ↑ off the top returns to the form.
- The old "Create worktree..." action row is gone; destinations moved under an "Open existing" header.
- Deliberate scoping: focus starts on the create form ONLY when the chosen path is the repo root. If the typed path resolves to a specific worktree, focus stays on that row so Enter still OPENS it rather than creating a new one. Both cases are covered by tests.
- CSS: `.repo-options-destinations` gained a min-height floor and `.repo-options-content` a scroll valve — without them the always-open form collapsed the destination list to zero height in a small window (caught during live verification, not by tests).
- `app/scripts/real-app-harness/bridge-remote-hub.mjs` updated: it used to locate and click the now-deleted `new-worktree` option row.

## Test plan

- [x] `make test-frontend` — full frontend unit suite, 2121 tests passing (includes new `worktreeNames.test.ts` and reworked `RepoOptions.test.tsx` / `LocationPicker.test.tsx`), re-verified after rebasing onto latest `main`.
- [x] `pnpm --dir app run e2e -- e2e/location-picker.spec.ts` — 14/14 against a real daemon, including a new single-Enter creation test.
- [x] `npx tsc --noEmit` clean.
- [x] Live verification in the packaged dev app (`make dev`, preflight PASS on the dev profile): opened the chooser on the real attn repo (60 destinations, create form first, nothing armed), and drove a real end-to-end create on a throwaway repo producing `demo-repo--zesty-toucan` on branch `zesty-toucan` with a session opened in it. Artifacts cleaned up.

No Go changes in this branch.

https://claude.ai/code/session_01TqWwbHppd1pFyeD6vVKDFE