### PR TITLE
feat(delegate): adopt existing tickets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-31]
+
+### Added
+- **Delegate an existing ticket without duplicating it.** `attn delegate
+  --ticket <id>` now starts an agent from that ticket's
+  description, preserving its activity thread instead of creating a duplicate;
+  orphaned tickets transfer automatically while active takeovers require
+  `--confirm`.
+
 ## [2026-07-29]
 
 ### Added

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -169,7 +169,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '199';
+export const PROTOCOL_VERSION = '200';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1127,6 +1127,7 @@ export interface DelegateMessage {
     allow_worktree_reuse?: boolean;
     brief:                 string;
     cmd:                   DelegateMessageCmd;
+    confirm?:              boolean;
     cwd?:                  string;
     effort?:               string;
     label?:                string;
@@ -1134,6 +1135,7 @@ export interface DelegateMessage {
     placement?:            string;
     request_id:            string;
     source_session_id:     string;
+    ticket_id?:            string;
     workspace_id?:         string;
     worktree?:             DelegateMessageWorktree;
     yolo_mode?:            boolean;
@@ -9471,6 +9473,7 @@ const typeMap: any = {
         { json: "allow_worktree_reuse", js: "allow_worktree_reuse", typ: u(undefined, true) },
         { json: "brief", js: "brief", typ: "" },
         { json: "cmd", js: "cmd", typ: r("DelegateMessageCmd") },
+        { json: "confirm", js: "confirm", typ: u(undefined, true) },
         { json: "cwd", js: "cwd", typ: u(undefined, "") },
         { json: "effort", js: "effort", typ: u(undefined, "") },
         { json: "label", js: "label", typ: u(undefined, "") },
@@ -9478,6 +9481,7 @@ const typeMap: any = {
         { json: "placement", js: "placement", typ: u(undefined, "") },
         { json: "request_id", js: "request_id", typ: "" },
         { json: "source_session_id", js: "source_session_id", typ: "" },
+        { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
         { json: "worktree", js: "worktree", typ: u(undefined, r("DelegateMessageWorktree")) },
         { json: "yolo_mode", js: "yolo_mode", typ: u(undefined, true) },

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -600,6 +600,7 @@ commands:
 	  session <command>                 inspect a session's conversation
   state explain <id>                replay why a session's state is what it is
   delegate --brief-file <path>      start another agent with a delegated brief
+  delegate --ticket <id>            start another agent on an existing ticket
   journal append --entry <text>     serialized append to the daily notebook journal
   workspace context <command>       edit shared workspace context
   open <file.md> [--session <id>]   show a markdown file in attn
@@ -682,7 +683,13 @@ func runDelegate() {
 }
 
 func writeDelegateHelp(w io.Writer) {
-	fmt.Fprint(w, `usage: attn delegate (--brief <text> | --brief-file <path>) [options]
+	fmt.Fprint(w, `usage: attn delegate (--brief <text> | --brief-file <path> | --ticket <id>) [options]
+
+task source:
+  --brief <text>              delegate a short task and create its ticket
+  --brief-file <path>         delegate a task file and create its ticket
+  --ticket <id>               adopt an existing ticket and use its description
+  --confirm                   take over a ticket with a non-orphan assignee
 
 placement:
   (no flags)                 add a pane to the source workspace; Git repositories
@@ -712,7 +719,8 @@ session options:
                              medium, high, xhigh)
   --name <text>              name for the agent and, when a new workspace is
                              created, the workspace (max 16 chars, must be
-                             unique; defaults to the directory name)
+                             unique; defaults to the ticket title for --ticket,
+                             otherwise the directory name)
   --source-session <id>      source session (defaults to ATTN_SESSION_ID)
   --yolo                     bypass agent approval prompts
 	--allow-worktree-reuse     explicitly allow another active session to share the worktree
@@ -2293,6 +2301,8 @@ func parseDelegateArgs(args []string) (delegateCLIArgs, error) {
 	fs.SetOutput(io.Discard)
 	briefText := fs.String("brief", "", "delegated task brief")
 	briefFile := fs.String("brief-file", "", "file containing the delegated task brief")
+	ticketID := fs.String("ticket", "", "existing ticket to adopt")
+	confirm := fs.Bool("confirm", false, "take over a ticket with a non-orphan assignee")
 	agentName := fs.String("agent", "", "target agent (defaults to the source session agent)")
 	model := fs.String("model", "", "pin the delegated agent's model (alias or full id)")
 	effort := fs.String("effort", "", "pin the delegated agent's reasoning effort")
@@ -2322,8 +2332,19 @@ func parseDelegateArgs(args []string) (delegateCLIArgs, error) {
 	if source == "" {
 		return delegateCLIArgs{}, errors.New("no source session; run inside attn or pass --source-session")
 	}
-	if strings.TrimSpace(*briefText) != "" && strings.TrimSpace(*briefFile) != "" {
-		return delegateCLIArgs{}, errors.New("pass only one of --brief or --brief-file")
+	ticket := strings.TrimSpace(*ticketID)
+	sources := 0
+	if strings.TrimSpace(*briefText) != "" {
+		sources++
+	}
+	if strings.TrimSpace(*briefFile) != "" {
+		sources++
+	}
+	if ticket != "" {
+		sources++
+	}
+	if sources > 1 {
+		return delegateCLIArgs{}, errors.New("pass only one of --brief, --brief-file, or --ticket")
 	}
 	brief := strings.TrimSpace(*briefText)
 	if strings.TrimSpace(*briefFile) != "" {
@@ -2333,8 +2354,11 @@ func parseDelegateArgs(args []string) (delegateCLIArgs, error) {
 		}
 		brief = strings.TrimSpace(string(content))
 	}
-	if brief == "" {
-		return delegateCLIArgs{}, errors.New("--brief or --brief-file is required")
+	if sources == 0 || (brief == "" && ticket == "") {
+		return delegateCLIArgs{}, errors.New("--brief, --brief-file, or --ticket is required")
+	}
+	if *confirm && ticket == "" {
+		return delegateCLIArgs{}, errors.New("--confirm requires --ticket")
 	}
 
 	explicitWorkspace := strings.TrimSpace(*workspaceID)
@@ -2366,6 +2390,8 @@ func parseDelegateArgs(args []string) (delegateCLIArgs, error) {
 		brief:           brief,
 		options: client.DelegateOptions{
 			RequestID:          stableRequestID,
+			TicketID:           ticket,
+			Confirm:            *confirm,
 			Agent:              strings.TrimSpace(*agentName),
 			Model:              strings.TrimSpace(*model),
 			Effort:             strings.TrimSpace(*effort),

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -505,6 +505,44 @@ func TestParseDelegateArgsDefaultsToCurrentWorkspace(t *testing.T) {
 	}
 }
 
+func TestParseDelegateArgsAdoptsTicket(t *testing.T) {
+	parsed, err := parseDelegateArgs([]string{
+		"--source-session", "source-session",
+		"--ticket", " planned-work ",
+		"--confirm",
+	})
+	if err != nil {
+		t.Fatalf("parseDelegateArgs() error = %v", err)
+	}
+	if parsed.brief != "" || parsed.options.TicketID != "planned-work" || !parsed.options.Confirm {
+		t.Fatalf("parsed = %+v", parsed)
+	}
+}
+
+func TestParseDelegateArgsRejectsMultipleTaskSources(t *testing.T) {
+	for _, args := range [][]string{
+		{"--brief", "text", "--ticket", "planned"},
+		{"--brief-file", "brief.md", "--ticket", "planned"},
+		{"--brief", "text", "--brief-file", "brief.md"},
+	} {
+		_, err := parseDelegateArgs(append([]string{"--source-session", "source-session"}, args...))
+		if err == nil || !strings.Contains(err.Error(), "pass only one") {
+			t.Fatalf("parseDelegateArgs(%v) error = %v", args, err)
+		}
+	}
+}
+
+func TestParseDelegateArgsConfirmRequiresTicket(t *testing.T) {
+	_, err := parseDelegateArgs([]string{
+		"--source-session", "source-session",
+		"--brief", "text",
+		"--confirm",
+	})
+	if err == nil || !strings.Contains(err.Error(), "--confirm requires --ticket") {
+		t.Fatalf("parseDelegateArgs() error = %v", err)
+	}
+}
+
 func TestParseDelegateArgsNoWorktree(t *testing.T) {
 	parsed, err := parseDelegateArgs([]string{
 		"--source-session", "source-session",

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -63,29 +63,17 @@ Use `--brief <text>` only for short, simple tasks.
 
 ## Adopt an Existing Ticket
 
-When the task already exists on the board, delegate that ticket instead of
-copying its brief into a new delegation:
+When the task already has a ticket, adopt it instead of creating a duplicate:
 
     attn delegate --ticket <ticket-id>
 
-The existing ticket's description becomes the agent's initial task. Attn keeps
-the ticket id and activity thread, binds it to the new session, and moves it to
-`working`; it does not create another ticket. The description must be non-empty.
-The session name defaults to the ticket title (shortened to the normal 16-character
-limit), while `--name` still overrides it. Placement and worktree flags have their
-normal meanings and the delegated session's resolved directory becomes the
-ticket's current `cwd`.
-
-An unassigned ticket can be adopted directly. A ticket assigned to a session is
-also adopted directly when orphan reconciliation has stamped it, because no agent
-is still working on it. A non-orphan assignee is protected from silent takeover:
+Its description becomes the task; the ticket keeps its id and thread, binds to
+the new session, and moves to `working`. Unassigned and reconciled-orphan tickets
+transfer directly. Taking over a live assignee requires confirmation:
 
     attn delegate --ticket <ticket-id> --confirm
 
-Adoption clears the orphan stamp. The previous assignee remains a participant so
-the reassignment appears in its ticket activity. `--ticket`, `--brief`, and
-`--brief-file` are mutually exclusive task sources, and `--confirm` is valid only
-with `--ticket`.
+`--name`, placement, and worktree flags behave as usual.
 
 ## Agent Selection
 

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -61,6 +61,32 @@ Use `--brief <text>` only for short, simple tasks.
 
 > The same brief is a ticket's description. To capture a backlog item *without* delegating — an unbound `todo` — use `attn ticket new` (see [tickets.md](tickets.md)); do this only when the user asks.
 
+## Adopt an Existing Ticket
+
+When the task already exists on the board, delegate that ticket instead of
+copying its brief into a new delegation:
+
+    attn delegate --ticket <ticket-id>
+
+The existing ticket's description becomes the agent's initial task. Attn keeps
+the ticket id and activity thread, binds it to the new session, and moves it to
+`working`; it does not create another ticket. The description must be non-empty.
+The session name defaults to the ticket title (shortened to the normal 16-character
+limit), while `--name` still overrides it. Placement and worktree flags have their
+normal meanings and the delegated session's resolved directory becomes the
+ticket's current `cwd`.
+
+An unassigned ticket can be adopted directly. A ticket assigned to a session is
+also adopted directly when orphan reconciliation has stamped it, because no agent
+is still working on it. A non-orphan assignee is protected from silent takeover:
+
+    attn delegate --ticket <ticket-id> --confirm
+
+Adoption clears the orphan stamp. The previous assignee remains a participant so
+the reassignment appears in its ticket activity. `--ticket`, `--brief`, and
+`--brief-file` are mutually exclusive task sources, and `--confirm` is valid only
+with `--ticket`.
+
 ## Agent Selection
 
 The source agent is used by default. Select another supported agent with:

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -401,6 +401,8 @@ func (c *Client) RecordFilesEdited(id string, paths []string) error {
 
 type DelegateOptions struct {
 	RequestID          string
+	TicketID           string
+	Confirm            bool
 	Agent              string
 	Model              string
 	Effort             string
@@ -428,7 +430,13 @@ func (c *Client) StartDelegation(sourceSessionID, brief string, opts DelegateOpt
 		Cmd:             protocol.CmdDelegate,
 		RequestID:       requestID,
 		SourceSessionID: sourceSessionID,
-		Brief:           brief,
+		Brief:           strings.TrimSpace(brief),
+	}
+	if value := strings.TrimSpace(opts.TicketID); value != "" {
+		msg.TicketID = protocol.Ptr(value)
+	}
+	if opts.Confirm {
+		msg.Confirm = protocol.Ptr(true)
 	}
 	if value := strings.TrimSpace(opts.Agent); value != "" {
 		msg.Agent = protocol.Ptr(value)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -407,7 +407,7 @@ func TestClient_Delegate(t *testing.T) {
 	}
 }
 
-func TestClientDelegateNoWorktree(t *testing.T) {
+func TestClientDelegateTicket(t *testing.T) {
 	tmpDir := t.TempDir()
 	sockPath := filepath.Join(tmpDir, "test.sock")
 	listener, err := net.Listen("unix", sockPath)
@@ -449,8 +449,10 @@ func TestClientDelegateNoWorktree(t *testing.T) {
 		})
 	}()
 
-	_, err = New(sockPath).Delegate("source-session", "Continue here", DelegateOptions{
+	_, err = New(sockPath).Delegate("source-session", "", DelegateOptions{
 		RequestID:  "request-1",
+		TicketID:   "planned-work",
+		Confirm:    true,
 		NoWorktree: true,
 	})
 	if err != nil {
@@ -459,6 +461,9 @@ func TestClientDelegateNoWorktree(t *testing.T) {
 	request := <-requests
 	if request.Worktree != nil {
 		t.Fatalf("Delegate request = %+v, want no worktree request", request)
+	}
+	if request.Brief != "" || protocol.Deref(request.TicketID) != "planned-work" || !protocol.Deref(request.Confirm) {
+		t.Fatalf("Delegate ticket source = %+v", request)
 	}
 }
 

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -15,6 +15,7 @@ import (
 	agentdriver "github.com/victorarias/attn/internal/agent"
 	"github.com/victorarias/attn/internal/git"
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
 )
 
 const (
@@ -631,8 +632,9 @@ func (d *Daemon) delegateOperation(msg *protocol.DelegateMessage, operationID, r
 		return nil, fmt.Errorf("source_session_id is required")
 	}
 	brief := strings.TrimSpace(msg.Brief)
-	if brief == "" {
-		return nil, fmt.Errorf("brief is required")
+	ticketID := strings.TrimSpace(protocol.Deref(msg.TicketID))
+	if (brief == "") == (ticketID == "") {
+		return nil, fmt.Errorf("exactly one of brief or ticket_id is required")
 	}
 	source := d.store.Get(sourceSessionID)
 	if source == nil {
@@ -650,12 +652,33 @@ func (d *Daemon) delegateOperation(msg *protocol.DelegateMessage, operationID, r
 	if err := d.validateDelegationModelEffort(agent, model, effort); err != nil {
 		return nil, err
 	}
-	// name is the explicit --name, or empty to default to the directory basename
-	// once the directory is finalized below.
-	name := strings.TrimSpace(protocol.Deref(msg.Label))
 	sessionID := reservedSessionID
 	if sessionID == "" {
 		sessionID = uuid.NewString()
+	}
+	// An adopted ticket is validated before any worktree or runtime side effect.
+	// The durable operation reservation prevents another delegation from racing
+	// this one; the store repeats the ownership check atomically at bind time so a
+	// concurrent ticket-take still cannot be overwritten silently.
+	var adoptedTicket *store.Ticket
+	if ticketID != "" {
+		adoptedTicket, err = d.store.GetTicket(ticketID)
+		if err != nil {
+			return nil, err
+		}
+		if adoptedTicket == nil {
+			return nil, fmt.Errorf("ticket not found: %s", ticketID)
+		}
+		if err := store.ValidateTicketDelegationAdoption(adoptedTicket, sessionID, protocol.Deref(msg.Confirm)); err != nil {
+			return nil, fmt.Errorf("adopt ticket %s: %w", ticketID, err)
+		}
+		brief = strings.TrimSpace(adoptedTicket.Description)
+	}
+	// name is the explicit --name, otherwise an adopted ticket's title, otherwise
+	// the finalized directory basename below.
+	name := strings.TrimSpace(protocol.Deref(msg.Label))
+	if name == "" && adoptedTicket != nil {
+		name = truncateDelegationName(adoptedTicket.Title)
 	}
 	// Every delegation is ticket-tracked; only the chief's own delegations are
 	// additionally chief-OWNED. delegatedByChief therefore no longer gates tracking,
@@ -704,8 +727,24 @@ func (d *Daemon) delegateOperation(msg *protocol.DelegateMessage, operationID, r
 		if ticketErr != nil {
 			return nil, ticketErr
 		}
+		// Adoption may have committed immediately before a daemon crash, and the
+		// agent may even have moved the ticket to a terminal column before this
+		// operation's completed state persisted. Recognize the requested ticket by
+		// assignment, not only through ActiveTicketForSession (which excludes
+		// terminal tickets), so recovery never reopens finished work.
+		if ticketID != "" && adoptedTicket.Assignee == sessionID {
+			ticket = adoptedTicket
+		}
+		if ticket != nil && ticketID != "" && ticket.ID != ticketID {
+			return nil, fmt.Errorf("reserved delegated session is already bound to ticket %s", ticket.ID)
+		}
 		if ticket == nil {
-			ticketID, ticketErr := d.createDelegatedTicket(sourceSessionID, delegatedByChief, existing, brief, existing.Label, agent)
+			boundTicketID := ""
+			if ticketID != "" {
+				boundTicketID, ticketErr = d.adoptDelegatedTicket(sourceSessionID, delegatedByChief, existing, ticketID, agent, protocol.Deref(msg.Confirm))
+			} else {
+				boundTicketID, ticketErr = d.createDelegatedTicket(sourceSessionID, delegatedByChief, existing, brief, existing.Label, agent)
+			}
 			if ticketErr != nil {
 				return nil, ticketErr
 			}
@@ -715,7 +754,10 @@ func (d *Daemon) delegateOperation(msg *protocol.DelegateMessage, operationID, r
 					worktreePath = existing.Directory
 				}
 				_ = d.store.UpdateDelegationOperation(operationID, protocol.DelegationOperationStatePreparing,
-					"recovered delegated ticket", existing.WorkspaceID, ticketID, worktreePath, nil, nil, time.Now())
+					"recovered delegated ticket", existing.WorkspaceID, boundTicketID, worktreePath, nil, nil, time.Now())
+			}
+			if ticketID != "" {
+				d.notifyTicketObservers(ticketID)
 			}
 			d.broadcastTicketsUpdated()
 		}
@@ -928,14 +970,22 @@ func (d *Daemon) delegateOperation(msg *protocol.DelegateMessage, operationID, r
 	// tells it to report through `attn ticket status`, and the ticket is the only
 	// channel back to it. A ticket failure therefore still fails the whole delegation
 	// atomically rather than leaving a running session nobody can reach.
-	ticketID, err := d.createDelegatedTicket(sourceSessionID, delegatedByChief, session, brief, name, agent)
-	if err != nil {
-		return nil, rollback.fail(fmt.Errorf("create delegated ticket: %w", err))
+	boundTicketID := ""
+	if ticketID != "" {
+		boundTicketID, err = d.adoptDelegatedTicket(sourceSessionID, delegatedByChief, session, ticketID, agent, protocol.Deref(msg.Confirm))
+	} else {
+		boundTicketID, err = d.createDelegatedTicket(sourceSessionID, delegatedByChief, session, brief, name, agent)
 	}
-	d.logf("delegate: bound ticket %q to session %s", ticketID, session.ID)
+	if err != nil {
+		return nil, rollback.fail(fmt.Errorf("bind delegated ticket: %w", err))
+	}
+	d.logf("delegate: bound ticket %q to session %s", boundTicketID, session.ID)
 	if operationID != "" {
 		_ = d.store.UpdateDelegationOperation(operationID, protocol.DelegationOperationStatePreparing,
-			"delegated session and ticket created", workspaceID, ticketID, operationWorktreePath, nil, nil, time.Now())
+			"delegated session and ticket bound", workspaceID, boundTicketID, operationWorktreePath, nil, nil, time.Now())
+	}
+	if ticketID != "" {
+		d.notifyTicketObservers(ticketID)
 	}
 	d.broadcastTicketsUpdated()
 	result := &protocol.DelegateResult{

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -147,6 +147,49 @@ func TestDelegateSpawnsAgentInSourceWorkspaceWithBrief(t *testing.T) {
 	}
 }
 
+func TestDelegateAdoptsExistingTicketAsTaskSource(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	if _, err := d.store.CreateTicket(store.Ticket{
+		ID: "planned-fix", Title: "Planned fix", Description: "Implement the complete planned fix.",
+		Status: store.TicketStatusDone,
+	}, "you", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	var prompt string
+	backend.onSpawn = func(opts ptybackend.SpawnOptions) {
+		content, err := os.ReadFile(opts.InitialPromptFile)
+		if err != nil {
+			t.Fatalf("read initial prompt: %v", err)
+		}
+		prompt = string(content)
+		_ = os.Remove(opts.InitialPromptFile)
+	}
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd: protocol.CmdDelegate, SourceSessionID: sourceSessionID,
+		TicketID: protocol.Ptr("planned-fix"), Agent: protocol.Ptr("codex"),
+	})
+	if err != nil {
+		t.Fatalf("delegate: %v", err)
+	}
+	if !strings.Contains(prompt, "Implement the complete planned fix.") {
+		t.Fatalf("prompt does not contain ticket description: %q", prompt)
+	}
+	delegated := d.store.Get(result.SessionID)
+	if delegated == nil || delegated.Label != "Planned fix" {
+		t.Fatalf("delegated session = %+v", delegated)
+	}
+	tickets, err := d.store.ListTickets(store.TicketListFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tickets) != 1 || tickets[0].ID != "planned-fix" || tickets[0].Assignee != result.SessionID || tickets[0].Status != store.TicketStatusWorking {
+		t.Fatalf("tickets = %+v", tickets)
+	}
+}
+
 func TestDelegateDefaultsToNewWorktreeForGitRepository(t *testing.T) {
 	root := t.TempDir()
 	mainRepo := initDelegationRepo(t, root, "repo")

--- a/internal/daemon/delegate_ticket.go
+++ b/internal/daemon/delegate_ticket.go
@@ -85,6 +85,29 @@ func (d *Daemon) createDelegatedTicket(creatorSessionID string, ownedByChiefRole
 	return created.ID, nil
 }
 
+// adoptDelegatedTicket binds an existing ticket instead of minting a duplicate.
+// Its description has already been delivered in the spawn prompt, so the store
+// advances the new assignee's cursor through the adoption events. The previous
+// assignee remains subscribed so a deliberate takeover is visible to it.
+func (d *Daemon) adoptDelegatedTicket(creatorSessionID string, ownedByChiefRole bool, session *protocol.Session, ticketID, agent string, confirm bool) (string, error) {
+	ownerRole := ""
+	chiefRoleIdentity := store.TicketRoleIdentity(store.TicketRoleChiefOfStaff)
+	subscribers := []string{creatorSessionID}
+	if ownedByChiefRole {
+		ownerRole = store.TicketRoleChiefOfStaff
+	} else {
+		subscribers = append(subscribers, chiefRoleIdentity)
+	}
+	adopted, err := d.store.AdoptTicketForDelegation(
+		ticketID, session.ID, session.Directory, agent, creatorSessionID,
+		ownerRole, subscribers, confirm, time.Now(),
+	)
+	if err != nil {
+		return "", err
+	}
+	return adopted.ID, nil
+}
+
 // ticketSlugSequentialAttempts bounds the readable base-2, base-3, ... walk before
 // the allocator switches to random suffixes. Now that EVERY delegation creates a
 // ticket, one popular base (a repo's directory basename, the common default label)

--- a/internal/daemon/delegation_operation.go
+++ b/internal/daemon/delegation_operation.go
@@ -32,7 +32,7 @@ func (d *Daemon) startDelegation(msg *protocol.DelegateMessage) (*protocol.Deleg
 	if currentChief := d.chiefOfStaffSessionID(); currentChief == strings.TrimSpace(msg.SourceSessionID) {
 		chiefSessionID = currentChief
 	}
-	record, claimed, err := d.store.ClaimDelegationOperation(requestID, "op-"+uuid.NewString(), uuid.NewString(), chiefSessionID, string(encoded), time.Now())
+	record, claimed, err := d.store.ClaimDelegationOperation(requestID, "op-"+uuid.NewString(), uuid.NewString(), chiefSessionID, strings.TrimSpace(protocol.Deref(msg.TicketID)), string(encoded), time.Now())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/daemon/delegation_operation_test.go
+++ b/internal/daemon/delegation_operation_test.go
@@ -214,7 +214,7 @@ func TestDelegationOperationRestartResumesAcceptedRecord(t *testing.T) {
 	_, sourceID, _ := setupDelegationSource(t, d1, backend)
 	msg := protocol.DelegateMessage{Cmd: protocol.CmdDelegate, RequestID: "restart-request", SourceSessionID: sourceID, Brief: "Resume after restart.", Agent: protocol.Ptr("codex"), Label: protocol.Ptr("restart")}
 	requestJSON, _ := json.Marshal(msg)
-	record, claimed, err := d1.store.ClaimDelegationOperation(msg.RequestID, "operation-restart", "session-restart", "", string(requestJSON), time.Now())
+	record, claimed, err := d1.store.ClaimDelegationOperation(msg.RequestID, "operation-restart", "session-restart", "", "", string(requestJSON), time.Now())
 	if err != nil || !claimed {
 		t.Fatalf("claim: claimed=%v err=%v", claimed, err)
 	}
@@ -245,7 +245,7 @@ func TestDelegationOperationAdoptsReconciledReservedRuntime(t *testing.T) {
 	workspaceID, sourceID, cwd := setupDelegationSource(t, d, backend)
 	msg := protocol.DelegateMessage{Cmd: protocol.CmdDelegate, RequestID: "spawn-crash", SourceSessionID: sourceID, Brief: "Adopt the surviving runtime.", Agent: protocol.Ptr("codex"), Label: protocol.Ptr("adopted")}
 	encoded, _ := json.Marshal(msg)
-	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-spawn-crash", "session-spawn-crash", "", string(encoded), time.Now())
+	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-spawn-crash", "session-spawn-crash", "", "", string(encoded), time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,13 +268,47 @@ func TestDelegationOperationAdoptsReconciledReservedRuntime(t *testing.T) {
 	}
 }
 
+func TestDelegationRecoveryDoesNotReopenAdoptedTerminalTicket(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	workspaceID, sourceID, cwd := setupDelegationSource(t, d, backend)
+	const sessionID = "session-adopted"
+	now := string(protocol.TimestampNow())
+	d.store.Add(&protocol.Session{
+		ID: sessionID, WorkspaceID: workspaceID, Label: "adopted", Agent: protocol.SessionAgentCodex,
+		Directory: cwd, State: protocol.SessionStateWorking, StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	})
+	backend.sessionIDs = append(backend.sessionIDs, sessionID)
+	if _, err := d.store.CreateTicket(store.Ticket{
+		ID: "finished-adoption", Title: "Finished", Description: "Already completed.",
+		Status: store.TicketStatusDone, Assignee: sessionID,
+	}, sourceID, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := d.delegateOperation(&protocol.DelegateMessage{
+		Cmd: protocol.CmdDelegate, SourceSessionID: sourceID,
+		TicketID: protocol.Ptr("finished-adoption"), Agent: protocol.Ptr("codex"),
+	}, "", sessionID, "", false, "", "")
+	if err != nil {
+		t.Fatalf("recover delegation: %v", err)
+	}
+	if result.SessionID != sessionID {
+		t.Fatalf("result = %+v", result)
+	}
+	ticket, err := d.store.GetTicket("finished-adoption")
+	if err != nil || ticket.Status != store.TicketStatusDone {
+		t.Fatalf("ticket = %+v, err = %v", ticket, err)
+	}
+}
+
 func TestDelegationOperationRespawnsPersistedSessionWithoutLiveRuntime(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}
 	workspaceID, sourceID, cwd := setupDelegationSource(t, d, backend)
 	msg := protocol.DelegateMessage{Cmd: protocol.CmdDelegate, RequestID: "spawn-missing", SourceSessionID: sourceID, Brief: "Recover the missing runtime.", Agent: protocol.Ptr("codex"), Label: protocol.Ptr("respawned")}
 	encoded, _ := json.Marshal(msg)
-	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-spawn-missing", "session-spawn-missing", "", string(encoded), time.Now())
+	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-spawn-missing", "session-spawn-missing", "", "", string(encoded), time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -336,7 +370,7 @@ func TestDelegationRestartDoesNotOwnWorktreeFromPathJournalAlone(t *testing.T) {
 		Worktree: &protocol.DelegateWorktreeRequest{Repo: protocol.Ptr(mainRepo), Branch: "feat/external", Path: protocol.Ptr(path)},
 	}
 	encoded, _ := json.Marshal(msg)
-	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-path-only", "session-path-only", "", string(encoded), time.Now())
+	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-path-only", "session-path-only", "", "", string(encoded), time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -382,7 +416,7 @@ func TestDelegationRestartDoesNotDeleteReplacementForPreviouslyOwnedWorktree(t *
 		Worktree: &protocol.DelegateWorktreeRequest{Repo: protocol.Ptr(mainRepo), Branch: "feat/replacement", Path: protocol.Ptr(path)},
 	}
 	encoded, _ := json.Marshal(msg)
-	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-owned-replaced", "session-owned-replaced", "", string(encoded), time.Now())
+	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-owned-replaced", "session-owned-replaced", "", "", string(encoded), time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -424,7 +458,7 @@ func TestDelegationRestartResumesPreviouslyOwnedWorktreeWithMatchingMarker(t *te
 		Worktree: &protocol.DelegateWorktreeRequest{Repo: protocol.Ptr(mainRepo), Branch: "feat/owned", Path: protocol.Ptr(path)},
 	}
 	encoded, _ := json.Marshal(msg)
-	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-owned-resume", "session-owned-resume", "", string(encoded), time.Now())
+	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-owned-resume", "session-owned-resume", "", "", string(encoded), time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -465,7 +499,7 @@ func TestDelegationRestartLeavesOwnedWorktreeWhenAnotherSessionOccupiesIt(t *tes
 		Worktree: &protocol.DelegateWorktreeRequest{Repo: protocol.Ptr(mainRepo), Branch: "feat/occupied", Path: protocol.Ptr(path)},
 	}
 	encoded, _ := json.Marshal(msg)
-	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-owned-occupied", "session-owned-occupied", "", string(encoded), time.Now())
+	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-owned-occupied", "session-owned-occupied", "", "", string(encoded), time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "199"
+const ProtocolVersion = "200"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -831,6 +831,9 @@ type DelegateMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
 
+	// Confirm corresponds to the JSON schema field "confirm".
+	Confirm *bool `json:"confirm,omitempty,omitzero"`
+
 	// Cwd corresponds to the JSON schema field "cwd".
 	Cwd *string `json:"cwd,omitempty,omitzero"`
 
@@ -851,6 +854,9 @@ type DelegateMessage struct {
 
 	// SourceSessionID corresponds to the JSON schema field "source_session_id".
 	SourceSessionID string `json:"source_session_id"`
+
+	// TicketID corresponds to the JSON schema field "ticket_id".
+	TicketID *string `json:"ticket_id,omitempty,omitzero"`
 
 	// WorkspaceID corresponds to the JSON schema field "workspace_id".
 	WorkspaceID *string `json:"workspace_id,omitempty,omitzero"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -729,7 +729,9 @@ model DelegateMessage {
   cmd: "delegate";
   request_id: string; // Stable caller-supplied idempotency key for one logical delegation
   source_session_id: string;
-  brief: string;
+  brief: string; // Empty only when ticket_id supplies the task source
+  ticket_id?: string; // Existing ticket to adopt; mutually exclusive with brief
+  confirm?: boolean; // Allow takeover when the ticket has a non-orphan assignee
   agent?: string;
   label?: string;
   yolo_mode?: boolean;

--- a/internal/store/delegation_operations.go
+++ b/internal/store/delegation_operations.go
@@ -11,7 +11,10 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-var ErrDelegationRequestConflict = errors.New("delegation request id already has different inputs")
+var (
+	ErrDelegationRequestConflict = errors.New("delegation request id already has different inputs")
+	ErrTicketDelegationReserved  = errors.New("ticket already has a delegation being prepared")
+)
 
 // DelegationOperationRecord is the durable launch journal. RequestJSON is kept
 // alongside the public operation shape so a daemon restart can resume the exact
@@ -24,7 +27,7 @@ type DelegationOperationRecord struct {
 	ChiefSessionID string
 }
 
-func (s *Store) ClaimDelegationOperation(requestID, operationID, sessionID, chiefSessionID, requestJSON string, now time.Time) (*DelegationOperationRecord, bool, error) {
+func (s *Store) ClaimDelegationOperation(requestID, operationID, sessionID, chiefSessionID, ticketID, requestJSON string, now time.Time) (*DelegationOperationRecord, bool, error) {
 	if strings.HasPrefix(requestID, "op-") {
 		return nil, false, fmt.Errorf("request id uses reserved operation prefix op-")
 	}
@@ -34,11 +37,15 @@ func (s *Store) ClaimDelegationOperation(requestID, operationID, sessionID, chie
 		return nil, false, errors.New("delegation idempotency requires a database")
 	}
 	stamp := now.UTC().Format(time.RFC3339Nano)
-	result, err := s.db.Exec(`INSERT OR IGNORE INTO delegation_operations
-		(request_id, operation_id, request_json, state, progress, session_id, chief_session_id, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, requestID, operationID, requestJSON,
-		string(protocol.DelegationOperationStateAccepted), "accepted by daemon", sessionID, chiefSessionID, stamp, stamp)
+	result, err := s.db.Exec(`INSERT INTO delegation_operations
+		(request_id, operation_id, request_json, state, progress, session_id, chief_session_id, ticket_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(request_id) DO NOTHING`, requestID, operationID, requestJSON,
+		string(protocol.DelegationOperationStateAccepted), "accepted by daemon", sessionID, chiefSessionID, ticketID, stamp, stamp)
 	if err != nil {
+		if ticketID != "" && strings.Contains(err.Error(), "delegation_operations.ticket_id") {
+			return nil, false, fmt.Errorf("%w: %s", ErrTicketDelegationReserved, ticketID)
+		}
 		return nil, false, fmt.Errorf("claim delegation operation: %w", err)
 	}
 	rows, err := result.RowsAffected()

--- a/internal/store/delegation_operations_test.go
+++ b/internal/store/delegation_operations_test.go
@@ -1,0 +1,32 @@
+package store
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func TestDelegationOperationReservesActiveTicket(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+	now := time.Now()
+	first, claimed, err := s.ClaimDelegationOperation("request-1", "operation-1", "session-1", "", "planned", `{"ticket_id":"planned"}`, now)
+	if err != nil || !claimed {
+		t.Fatalf("first claim = %+v, %v, %v", first, claimed, err)
+	}
+	if protocol.Deref(first.Operation.TicketID) != "planned" {
+		t.Fatalf("reserved ticket = %q", protocol.Deref(first.Operation.TicketID))
+	}
+	_, _, err = s.ClaimDelegationOperation("request-2", "operation-2", "session-2", "", "planned", `{"ticket_id":"planned"}`, now)
+	if !errors.Is(err, ErrTicketDelegationReserved) {
+		t.Fatalf("second claim error = %v, want ErrTicketDelegationReserved", err)
+	}
+	if err := s.UpdateDelegationOperation("operation-1", protocol.DelegationOperationStateFailed, "failed", "", "", "", nil, errors.New("failed"), now); err != nil {
+		t.Fatal(err)
+	}
+	if _, claimed, err := s.ClaimDelegationOperation("request-3", "operation-3", "session-3", "", "planned", `{"ticket_id":"planned"}`, now); err != nil || !claimed {
+		t.Fatalf("claim after terminal operation = %v, %v", claimed, err)
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -112,7 +112,10 @@ const delegationOperationsSchema = `CREATE TABLE IF NOT EXISTS delegation_operat
 	updated_at TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_delegation_operations_operation_id
-	ON delegation_operations(operation_id);`
+	ON delegation_operations(operation_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_delegation_operations_active_ticket
+	ON delegation_operations(ticket_id)
+	WHERE ticket_id != '' AND state IN ('accepted', 'preparing');`
 
 // migrations defines all schema migrations in order.
 // Each migration is applied exactly once, tracked in schema_migrations table.
@@ -816,6 +819,11 @@ CREATE TABLE IF NOT EXISTS ticket_event_cursors (
 			SELECT ticket_id, identity FROM ticket_subscriptions WHERE identity != ''
 			UNION
 			SELECT ticket_id, ('role:' || role) FROM ticket_role_owners WHERE role != '';
+	`},
+	{83, "reserve tickets during delegation preparation", `
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_delegation_operations_active_ticket
+			ON delegation_operations(ticket_id)
+			WHERE ticket_id != '' AND state IN ('accepted', 'preparing');
 	`},
 }
 

--- a/internal/store/ticket_adoption_test.go
+++ b/internal/store/ticket_adoption_test.go
@@ -1,0 +1,95 @@
+package store
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestAdoptTicketForDelegationMovesAndBindsExistingTicket(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+	now := ticketBase.Add(time.Hour)
+	if _, err := s.CreateTicket(Ticket{
+		ID: "planned", Title: "Planned work", Description: "Complete implementation brief.",
+		Status: TicketStatusDone,
+	}, "you", ticketBase); err != nil {
+		t.Fatal(err)
+	}
+
+	adopted, err := s.AdoptTicketForDelegation(
+		"planned", "session-new", "/repo/worktree", "codex", "session-chief",
+		TicketRoleChiefOfStaff, []string{"session-chief"}, false, now,
+	)
+	if err != nil {
+		t.Fatalf("AdoptTicketForDelegation: %v", err)
+	}
+	if adopted.ID != "planned" || adopted.Assignee != "session-new" || adopted.Status != TicketStatusWorking {
+		t.Fatalf("adopted = %+v", adopted)
+	}
+	if adopted.Cwd != "/repo/worktree" || adopted.LastAgentID != "codex" || adopted.ClosedAt != nil {
+		t.Fatalf("session metadata = %+v", adopted)
+	}
+	cursor, err := s.GetTicketCursor("session-new", "planned")
+	if err != nil || cursor != adopted.LatestEventSeq {
+		t.Fatalf("cursor = %d, latest = %d, err = %v", cursor, adopted.LatestEventSeq, err)
+	}
+	participants, err := s.TicketParticipants("planned")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]bool{"session-new": true, "session-chief": true, TicketRoleIdentity(TicketRoleChiefOfStaff): true}
+	for _, participant := range participants {
+		delete(want, participant)
+	}
+	if len(want) != 0 {
+		t.Fatalf("participants = %v, missing %v", participants, want)
+	}
+}
+
+func TestAdoptTicketForDelegationUsesOrphanStampAsConfirmation(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+	if _, err := s.CreateTicket(Ticket{
+		ID: "orphan", Title: "Orphan", Description: "Resume this work.",
+		Status: TicketStatusInReview, Assignee: "session-old",
+	}, "session-old", ticketBase); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := s.AdoptTicketForDelegation("orphan", "session-new", "/repo", "codex", "chief", "", nil, false, ticketBase.Add(time.Minute))
+	if !errors.Is(err, ErrTicketAdoptionConfirmRequired) {
+		t.Fatalf("live takeover error = %v, want ErrTicketAdoptionConfirmRequired", err)
+	}
+	if claimed, err := s.ClaimTicketReconciliation("orphan", ticketBase.Add(2*time.Minute)); err != nil || !claimed {
+		t.Fatalf("ClaimTicketReconciliation = %v, %v", claimed, err)
+	}
+	adopted, err := s.AdoptTicketForDelegation("orphan", "session-new", "/repo", "codex", "chief", "", nil, false, ticketBase.Add(3*time.Minute))
+	if err != nil {
+		t.Fatalf("orphan adoption: %v", err)
+	}
+	if adopted.Assignee != "session-new" || adopted.ReconciledAt != nil || adopted.Status != TicketStatusWorking {
+		t.Fatalf("adopted orphan = %+v", adopted)
+	}
+	subscribed, err := s.IsTicketSubscribed("session-old", "orphan")
+	if err != nil || !subscribed {
+		t.Fatalf("previous assignee subscription = %v, %v", subscribed, err)
+	}
+}
+
+func TestAdoptTicketForDelegationConfirmAndDescriptionValidation(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+	if _, err := s.CreateTicket(Ticket{ID: "live", Title: "Live", Description: "Take over.", Assignee: "session-old"}, "you", ticketBase); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.AdoptTicketForDelegation("live", "session-new", "/repo", "codex", "chief", "", nil, true, ticketBase.Add(time.Minute)); err != nil {
+		t.Fatalf("confirmed adoption: %v", err)
+	}
+	if _, err := s.CreateTicket(Ticket{ID: "empty", Title: "Empty"}, "you", ticketBase); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.AdoptTicketForDelegation("empty", "session-new", "/repo", "codex", "chief", "", nil, false, ticketBase.Add(time.Minute)); err == nil {
+		t.Fatal("empty description adoption succeeded")
+	}
+}

--- a/internal/store/tickets.go
+++ b/internal/store/tickets.go
@@ -172,6 +172,10 @@ var (
 	// ErrTicketNotClosed means an open ticket can't be archived — open tickets
 	// are durable and never leave the board until they settle.
 	ErrTicketNotClosed = errors.New("ticket is not closed")
+	// ErrTicketAdoptionConfirmRequired prevents a delegation from silently
+	// replacing a ticket's live owner. A reconciled ticket is a proven orphan and
+	// may be adopted without confirmation.
+	ErrTicketAdoptionConfirmRequired = errors.New("ticket has a non-orphan assignee")
 )
 
 // ticketIDPattern is a human-friendly slug: lowercase alphanumerics and hyphens,
@@ -764,6 +768,116 @@ func (s *Store) AssignTicket(id, assignee, author string, now time.Time) error {
 		return err
 	}
 	return tx.Commit()
+}
+
+// ValidateTicketDelegationAdoption checks whether ticket can be bound to the
+// reserved delegated session. Unassigned tickets and tickets carrying the
+// durable reconciliation stamp are safe to adopt. A different non-orphan
+// assignee requires the caller's explicit confirmation.
+func ValidateTicketDelegationAdoption(ticket *Ticket, sessionID string, confirm bool) error {
+	if ticket == nil {
+		return ErrTicketNotFound
+	}
+	if strings.TrimSpace(ticket.Description) == "" {
+		return errors.New("ticket description is empty; add a description before delegating it")
+	}
+	if ticket.Assignee != "" && ticket.Assignee != sessionID && ticket.ReconciledAt == nil && !confirm {
+		return fmt.Errorf("%w: %s; pass --confirm to take it over", ErrTicketAdoptionConfirmRequired, ticket.Assignee)
+	}
+	return nil
+}
+
+// AdoptTicketForDelegation atomically binds an existing ticket to a delegated
+// session, moves it to Working, records the session metadata used by Resume,
+// and installs the same participant routing as a newly-created delegation
+// ticket. The delegated agent's cursor advances through the adoption events
+// because its initial prompt already contains the full ticket description.
+func (s *Store) AdoptTicketForDelegation(id, sessionID, cwd, lastAgentID, author, ownerRole string, subscribers []string, confirm bool, now time.Time) (*Ticket, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	current, err := scanTicket(tx.QueryRow(ticketSelect+` WHERE id = ?`, id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("%w: %q", ErrTicketNotFound, id)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := ValidateTicketDelegationAdoption(current, sessionID, confirm); err != nil {
+		return nil, err
+	}
+
+	previousAssignee := current.Assignee
+	if _, err := tx.Exec(`
+		UPDATE tickets SET assignee = ?, cwd = ?, last_agent_id = ?, reconciled_at = '', updated_at = ? WHERE id = ?
+	`, sessionID, cwd, lastAgentID, formatTicketTime(now), id); err != nil {
+		return nil, err
+	}
+	if previousAssignee != sessionID {
+		if _, _, err := appendTicketEventTx(tx, TicketEvent{
+			TicketID: id, Kind: TicketEventAssigned, Author: author, Detail: sessionID,
+		}, now); err != nil {
+			return nil, err
+		}
+	}
+	if current.Status != TicketStatusWorking {
+		if _, err := setTicketStatusTx(tx, id, TicketStatusWorking, author, "", now); err != nil {
+			return nil, err
+		}
+	}
+
+	if ownerRole != "" {
+		if _, err := tx.Exec(`
+			INSERT INTO ticket_role_owners (role, ticket_id, created_at)
+			VALUES (?, ?, ?) ON CONFLICT(role, ticket_id) DO NOTHING
+		`, ownerRole, id, formatTicketTime(now)); err != nil {
+			return nil, err
+		}
+	}
+	if previousAssignee != "" && previousAssignee != sessionID {
+		subscribers = append(subscribers, previousAssignee)
+	}
+	for _, identity := range subscribers {
+		identity = strings.TrimSpace(identity)
+		if identity == "" {
+			continue
+		}
+		if _, err := tx.Exec(`
+			INSERT INTO ticket_subscriptions (identity, ticket_id, created_at)
+			VALUES (?, ?, ?) ON CONFLICT(identity, ticket_id) DO NOTHING
+		`, identity, id, formatTicketTime(now)); err != nil {
+			return nil, err
+		}
+	}
+	var latestSeq int64
+	if err := tx.QueryRow(`SELECT COALESCE(MAX(seq), 0) FROM ticket_events WHERE ticket_id = ?`, id).Scan(&latestSeq); err != nil {
+		return nil, err
+	}
+	if err := setTicketCursorTx(tx, sessionID, id, latestSeq, now); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	current.Assignee = sessionID
+	current.Cwd = cwd
+	current.LastAgentID = lastAgentID
+	current.Status = TicketStatusWorking
+	current.ClosedAt = nil
+	current.ArchivedAt = nil
+	current.ReconciledAt = nil
+	current.UpdatedAt = now
+	current.LatestEventSeq = latestSeq
+	return current, nil
 }
 
 // SetTicketSession records the last session's working dir and agent id, which the


### PR DESCRIPTION
## Intent / Why

Planned work can already exist as a backlog ticket. Starting an agent previously required submitting the brief again, which created a second ticket and left the original looking unstarted.

## Summary

- add `attn delegate --ticket <id>` as a third task source alongside `--brief` and `--brief-file`
- bind and move the existing ticket to `working`, using its description as the initial prompt
- allow unassigned and reconciled-orphan adoption directly; require `--confirm` for a non-orphan assignee
- reserve tickets while delegation prepares, preserving idempotency and restart recovery
- update protocol types, CLI help, bundled delegation guidance, and the changelog

## Verification

- repository pre-commit gate: Go build and tests, frontend tests and production build, Playwright E2E (192 passed, 1 skipped)
- packaged dev preflight with protocol version 200
- live dev scenario confirmed that the original ticket ID and activity thread were retained, assigned, moved to `working`, and completed without creating a duplicate