### PR TITLE
fix(delegate): start worktrees from default branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-07-31]
 
+### Changed
+- **Delegated worktrees always start from the repository default branch.** Every
+  `attn delegate` placement now uses `origin/<default>`, or the local default
+  branch when no matching remote exists, instead of inheriting the branch checked
+  out in its source directory. Use `--from <ref>` to deliberately continue or
+  stack on in-progress work.
+
 ### Added
 - **Delegate an existing ticket without duplicating it.** `attn delegate
   --ticket <id>` now starts an agent from that ticket's

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -161,13 +161,11 @@ Worktree options:
   target's existing sessions are in — the session you delegate alongside, not the
   workspace's recorded directory. Delegation fails and asks for `--repo` when
   those sessions span more than one repository.
-- `--from <ref>` chooses the starting branch or ref. Delegating into an existing
-  workspace starts from the repository's default branch — `origin/<default>` when
-  that exists, otherwise the local one — because the workspace's sessions may sit
-  in several worktrees of that repository and none of their branches is a better
-  answer than the others. It does not depend on what the main checkout currently
-  has checked out. Pass `--from` to start somewhere else. Other placements still
-  start from the directory they are based on.
+- `--from <ref>` chooses the starting branch or ref. Without it, every placement
+  starts from the repository's default branch — `origin/<default>` when that
+  exists, otherwise the local one. It never depends on what the source or main
+  checkout currently has checked out. Pass `--from` to deliberately continue or
+  stack on another branch.
 - `--worktree-path <path>` chooses an explicit worktree location.
 
 When running outside the source session, add `--source-session <session-id>`.

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -465,22 +465,15 @@ func (d *Daemon) applyDefaultDelegationWorktree(msg *protocol.DelegateMessage, p
 
 	request.Repo = protocol.Ptr(repo)
 	request.Branch = automaticDelegationBranch(label, sessionID)
-	if strings.TrimSpace(protocol.Deref(request.StartingFrom)) == "" {
-		startingFrom := delegationDefaultStartRef(repo)
-		if startingFrom == "" {
-			return fmt.Errorf("cannot determine the repository's default branch; pass --from or --no-worktree")
-		}
-		request.StartingFrom = protocol.Ptr(startingFrom)
-	}
 	msg.Worktree = request
 	return nil
 }
 
 // createDelegationWorktree creates the worktree. inferredRepo, when non-empty,
 // names the main repository already resolved by the caller; baseDirectory, when
-// non-empty, is a working directory the repository and the starting ref may be
-// inferred from. A caller that knows the repository but has no defensible
-// starting point passes the repository alone and leaves baseDirectory empty.
+// non-empty, is a working directory the repository may be inferred from. The
+// starting ref is always explicit: --from when supplied, otherwise the
+// repository's default branch.
 func (d *Daemon) createDelegationWorktree(baseDirectory, inferredRepo string, request *protocol.DelegateWorktreeRequest, operationID, ownedPath string, worktreeOwned bool, ownedToken string, allowReuse bool) (string, bool, error) {
 	branch := strings.TrimSpace(request.Branch)
 	if branch == "" {
@@ -543,27 +536,12 @@ func (d *Daemon) createDelegationWorktree(baseDirectory, inferredRepo string, re
 		d.delegationWorktreePrepareHook(expectedPath)
 	}
 	startingFrom := request.StartingFrom
-	if strings.TrimSpace(protocol.Deref(startingFrom)) == "" && baseDirectory == "" {
-		// No working directory whose branch could serve as a starting point, so
-		// name the repository's default branch explicitly. Leaving this empty
-		// would make `git worktree add -b` start from the main checkout's current
-		// HEAD (see starting_from in the protocol schema) — whatever that
-		// checkout happens to have checked out today, which is the same kind of
-		// ambient state this resolution exists to eliminate.
-		if ref := delegationDefaultStartRef(repo); ref != "" {
-			startingFrom = protocol.Ptr(ref)
+	if strings.TrimSpace(protocol.Deref(startingFrom)) == "" {
+		ref := delegationDefaultStartRef(repo)
+		if ref == "" {
+			return "", false, fmt.Errorf("cannot determine the repository's default branch; pass --from or --no-worktree")
 		}
-	}
-	if strings.TrimSpace(protocol.Deref(startingFrom)) == "" && baseDirectory != "" {
-		baseRoot, baseRootErr := git.GetRepoRoot(baseDirectory)
-		baseBranch, baseBranchErr := git.GetBranchInfo(baseDirectory)
-		if baseRootErr == nil &&
-			baseBranchErr == nil &&
-			baseBranch != nil &&
-			strings.TrimSpace(baseBranch.Branch) != "" &&
-			git.ResolveMainRepoPath(baseRoot) == git.ResolveMainRepoPath(repo) {
-			startingFrom = protocol.Ptr(strings.TrimSpace(baseBranch.Branch))
-		}
+		startingFrom = protocol.Ptr(ref)
 	}
 	worktreePath, err := d.doCreateWorktree(&protocol.CreateWorktreeMessage{
 		Cmd:          protocol.CmdCreateWorktree,
@@ -826,26 +804,12 @@ func (d *Daemon) delegateOperation(msg *protocol.DelegateMessage, operationID, r
 	}
 
 	// The workspace record's directory is a registration artifact, not a repo
-	// authority (see delegationWorktreeRepo). Only an existing-workspace
-	// placement would otherwise infer a repo from it; current/new placements
-	// already base off a real session directory or an explicit --cwd, where that
-	// directory legitimately supplies both the repository and the starting ref.
-	//
-	// worktreeStartRefBase is cleared once the repository is known from the
-	// member sessions, which decouples the two inferences. Those sessions may sit
-	// in different worktrees of the one repository, each on its own branch, so
-	// there is no member branch that deserves to become the implicit --from.
-	// Clearing it makes createDelegationWorktree resolve the repository's default
-	// branch explicitly (delegationDefaultStartRef) rather than a branch chosen
-	// by session ordering — and, just as importantly, rather than the main
-	// checkout's current HEAD. An explicit --from still wins.
-	worktreeStartRefBase := directory
+	// authority (see delegationWorktreeRepo). Existing-workspace placement must
+	// infer the repository from its member sessions. Starting-ref selection is
+	// independent of placement: an explicit --from wins, otherwise
+	// createDelegationWorktree uses the repository's default branch.
 	inferredWorktreeRepo := ""
 	if msg.Worktree != nil && placement == delegationPlacementExisting {
-		// Unconditionally, including when --repo is given: the workspace record's
-		// directory never supplies a starting ref for this placement. --repo
-		// selects the repository; only --from selects a non-default starting ref.
-		worktreeStartRefBase = ""
 		if strings.TrimSpace(protocol.Deref(msg.Worktree.Repo)) == "" {
 			resolvedRepo, repoErr := d.delegationWorktreeRepo(workspaceID)
 			if repoErr != nil {
@@ -864,7 +828,7 @@ func (d *Daemon) delegateOperation(msg *protocol.DelegateMessage, operationID, r
 	}
 
 	if msg.Worktree != nil {
-		worktreePath, created, createErr := d.createDelegationWorktree(worktreeStartRefBase, inferredWorktreeRepo, msg.Worktree, operationID, ownedWorktreePath, worktreeOwned, worktreeToken, protocol.Deref(msg.AllowWorktreeReuse))
+		worktreePath, created, createErr := d.createDelegationWorktree(directory, inferredWorktreeRepo, msg.Worktree, operationID, ownedWorktreePath, worktreeOwned, worktreeToken, protocol.Deref(msg.AllowWorktreeReuse))
 		if createErr != nil {
 			return nil, createErr
 		}

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -1975,6 +1975,77 @@ func TestDelegateWorktreeExplicitRepoOverridesWorkspaceSessions(t *testing.T) {
 	}
 }
 
+// TestDelegateNamedWorktreeUsesRepoDefaultForEveryPlacement protects named
+// --worktree delegations from inheriting ambient checkout state. Automatic
+// branch names already resolve the default in applyDefaultDelegationWorktree;
+// these are the placement paths that previously let an omitted --from inherit
+// the branch checked out in the source directory or --cwd.
+func TestDelegateNamedWorktreeUsesRepoDefaultForEveryPlacement(t *testing.T) {
+	tests := []struct {
+		name      string
+		placement string
+		useCWD    bool
+		useRepo   bool
+	}{
+		{name: "no placement flag", placement: delegationPlacementCurrent},
+		{name: "new workspace", placement: delegationPlacementNew, useRepo: true},
+		{name: "cwd", placement: delegationPlacementNew, useCWD: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			repo := initDelegationRepo(t, root, "repo")
+			runGitDaemon(t, repo, "branch", "-M", "main")
+			defaultHead := gitRevParseDaemon(t, repo, "main")
+			runGitDaemon(t, repo, "checkout", "-q", "-b", "topic/ambient")
+			runGitDaemon(t, repo, "commit", "--allow-empty", "-m", "ambient")
+			ambientHead := gitRevParseDaemon(t, repo, "HEAD")
+
+			d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+			backend := &fakeSpawnBackend{}
+			var sourceSessionID string
+			if tt.useCWD {
+				_, sourceSessionID, _ = setupDelegationSource(t, d, backend)
+			} else {
+				_, sourceSessionID, _ = setupDelegationSourceAt(t, d, backend, repo)
+			}
+			consumeDelegatedPrompt(t, backend)
+
+			request := &protocol.DelegateWorktreeRequest{
+				Branch: "feat/from-default",
+				Path:   protocol.Ptr(filepath.Join(root, "repo--delegated")),
+			}
+			if tt.useRepo {
+				request.Repo = protocol.Ptr(repo)
+			}
+			msg := &protocol.DelegateMessage{
+				Cmd:             protocol.CmdDelegate,
+				SourceSessionID: sourceSessionID,
+				Brief:           "Start from the default branch.",
+				Placement:       protocol.Ptr(tt.placement),
+				Label:           protocol.Ptr("delegated"),
+				Worktree:        request,
+			}
+			if tt.useCWD {
+				msg.Cwd = protocol.Ptr(repo)
+			}
+
+			result, err := d.delegate(msg)
+			if err != nil {
+				t.Fatalf("delegate() error = %v", err)
+			}
+			head := gitRevParseDaemon(t, result.Directory, "HEAD")
+			if head == ambientHead {
+				t.Fatalf("new branch inherited ambient checkout head %s", head)
+			}
+			if head != defaultHead {
+				t.Fatalf("new branch head = %s, want default branch head %s", head, defaultHead)
+			}
+		})
+	}
+}
+
 // TestDelegateWorktreeSameRepoDifferentBranchesUsesRepoDefault covers the case
 // where a workspace's member sessions sit in different worktrees of the SAME
 // main repository, each on its own branch. The repository is unambiguous, so


### PR DESCRIPTION
## Intent / Why

Delegated worktrees could silently inherit unrelated commits from whichever branch happened to be checked out in their source directory. That made branch ancestry depend on placement flags and could carry another task into a pull request without either agent choosing it.

This completes the isolation rule introduced in #696: an omitted `--from` now means the repository default branch for every worktree-creating placement.

## Summary

- Resolve named and automatically generated delegation worktrees from `origin/<default>`, falling back to the local default branch, regardless of placement.
- Preserve `--from <ref>` as the explicit way to continue or stack on in-progress work.
- Cover the current-workspace, new-workspace with explicit repository, and `--cwd` paths against a checkout parked on an ahead topic branch.
- Update the bundled delegation reference and changelog to state the unified behavior.

## Verification

- Repository pre-commit gate: Go build and complete Go test suite passed.
- Focused delegation tests passed, including every affected placement, explicit `--from`, existing-workspace defaulting, and remote-default preference.
- Rebuilt and installed `attn-dev.app`; bundled preflight passed with the dev profile and protocol 200.
- Live scenario: created a repository with `topic/ambient` one commit ahead of `main`, delegated with `--cwd` and a named worktree, and confirmed the delegated branch matched `main` exactly (`main..HEAD` contained zero commits while `main..topic/ambient` contained one).
