### PR TITLE
Dashboard becomes home; fix workspace undock leaving a dead sidebar row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-08-01]
+
+### Fixed
+- **A workspace that holds only a tile can be closed again.** Closing the last
+  notebook, markdown, or browser tile in a workspace with no agents left the
+  workspace in the sidebar — and every later click on its × did nothing, so the
+  row could never be dismissed. Closing that last tile now closes the workspace
+  with it. Workspaces stranded by the old behaviour are cleaned up the next time
+  the app starts.
+
+---
+
 ## [2026-07-31]
 
 ### Changed
@@ -22,9 +34,18 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   orphaned tickets transfer automatically while active takeovers require
   `--confirm`.
 
+---
+
 ## [2026-07-29]
 
 ### Added
+- **Settling the last turn takes you home, and home tells you everything is
+  settled.** Working down the agent queue used to end nowhere: settling the last
+  agent that owed you a turn left you sitting on that same agent. It now lands
+  you on the home screen, which leads with an "All settled" banner and a line
+  saying what is still running — three working, one scheduled, or nothing at
+  all. Nothing owes you a turn and nothing jumps in on its own; the next turn
+  waits in the queue until you go and take it.
 - **Auto-settle: turns you have already dealt with can close themselves.** Off by
   default; turn it on in Settings > General, or from ⌘K. When a session that owes
   you a turn goes back to work — which is what happens after you steer an agent —
@@ -66,6 +87,20 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   unreachable. Delegating into a hidden workspace still unmutes it only for the
   chief, and only the chief's own delegations are marked as delegated-from-chief
   in the sidebar.
+- **Home is a place in the app, not a screen that replaces it.** The home screen
+  now sits beside the sidebar exactly as an agent's terminal does, so you can see
+  the queue and the workspace tree while you are on it. Grid view still fills the
+  window.
+- **The sidebar has a Home row.** It sits at the very top, above the chief of
+  staff and "Your turn", and highlights while you are on the home screen. It
+  shows the shortcut home is actually bound to (⌘⇧H), and the collapsed sidebar
+  keeps its home button. The "WORKSPACES" heading and the ⌘G hint it carried are
+  gone — that hint had been stale since grid view took ⌘G.
+- **The home screen understands turns.** With the agent queue on, it leads with
+  the turns you owe, oldest first with the age of each, and files everything else
+  under *Settled*, still grouped by what it is doing. Previously it grouped
+  purely by state, so agents you had already settled kept being announced as
+  waiting for you. With the queue off it is unchanged.
 
 ---
 

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -241,6 +241,25 @@ html, body, #root {
   background: transparent;
 }
 
+/* The sidebar and the stack of views it frames. Grid view is not in here: it
+   stays an absolutely positioned child of `.app`, so it still covers the whole
+   window including the sidebar. */
+.app-frame {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  position: relative;
+}
+
+/* Home and the session view stack here, so `.view-container`'s absolute fill
+   resolves against the column beside the sidebar rather than the window. */
+.view-stack {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  position: relative;
+}
+
 .view-container {
   position: absolute;
   top: 0;

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2881,7 +2881,10 @@ sendFetchPRDetails,
   // The next agent is taken from the queue as it stands before the settle: the
   // band only drops the settled row once the daemon broadcast lands, so reading
   // it afterwards would either find the row still there or race the refresh.
-  // With nothing left to go to, selection stays put.
+  //
+  // With nothing left to go to, the queue is empty and home is where that ends:
+  // staying on the agent just settled leaves you on the one screen guaranteed to
+  // be finished with.
   const handleSettleActiveTurn = useMemo(
     () => (queueModeEnabled
       ? () => {
@@ -2890,10 +2893,12 @@ sendFetchPRDetails,
         sendSettleTurn(activeSessionId);
         if (next) {
           handleSelectSession(next.session.id);
+        } else {
+          goToDashboard();
         }
       }
       : undefined),
-    [queueModeEnabled, activeSessionId, queueBands, sendSettleTurn, handleSelectSession],
+    [queueModeEnabled, activeSessionId, queueBands, sendSettleTurn, handleSelectSession, goToDashboard],
   );
 
   // Keep the selected session's turn, cancelling the auto-settle countdown that
@@ -3703,33 +3708,11 @@ sendFetchPRDetails,
           step={openPRLauncherJob.progress.step}
         />
       )}
-      {/* Dashboard - always rendered, shown/hidden via z-index */}
-      <div className={`view-container ${view === 'dashboard' ? 'visible' : 'hidden'}`}>
-        <Dashboard
-          sessions={unmutedEnrichedSessions}
-          mutedWorkspaces={mutedWorkspaceViews}
-          prs={prs}
-          isLoading={!hasReceivedInitialState}
-          isRefreshing={isRefreshingPRs}
-          refreshError={refreshError}
-          rateLimit={rateLimit}
-          endpoints={daemonEndpoints}
-          onRebootstrapEndpoint={handleRebootstrapEndpoint}
-          onSelectSession={handleSelectSession}
-          onNewSession={() => handleNewSession('vertical')}
-          onRefreshPRs={handleRefreshPRs}
-          onOpenPR={handleOpenPR}
-          onOpenSettings={() => setSettingsOpen(true)}
-          onMutedGroupClick={() => {
-            setSidebarCollapsed(false);
-            setSidebarMutedExpanded(true);
-            setView('session');
-          }}
-        />
-      </div>
-
-      {/* Session view - always rendered to keep terminals alive */}
-      <div className={`view-container ${view === 'session' ? 'visible' : 'hidden'}`}>
+      {/* The app shell: the sidebar is a peer of the view stack rather than a
+          child of the session view, so home and a session are both framed by it.
+          Grid view stays outside the shell — it is a full-window takeover and
+          hoisting the sidebar must not quietly put a sidebar beside it. */}
+      <div className="app-frame">
         <Sidebar
           workspaces={sidebarWorkspaceViews}
           visualOrder={visualWorkspaces}
@@ -3784,8 +3767,38 @@ sendFetchPRDetails,
           onCloseSession={handleRequestCloseSession}
           onReloadSession={handleReloadSession}
           onGoToDashboard={goToDashboard}
+          homeActive={view === 'dashboard'}
           onToggleCollapse={toggleSidebarCollapse}
         />
+        <div className="view-stack">
+      {/* Dashboard - always rendered, shown/hidden via z-index */}
+      <div className={`view-container ${view === 'dashboard' ? 'visible' : 'hidden'}`}>
+        <Dashboard
+          sessions={unmutedEnrichedSessions}
+          mutedWorkspaces={mutedWorkspaceViews}
+          prs={prs}
+          isLoading={!hasReceivedInitialState}
+          isRefreshing={isRefreshingPRs}
+          refreshError={refreshError}
+          rateLimit={rateLimit}
+          endpoints={daemonEndpoints}
+          onRebootstrapEndpoint={handleRebootstrapEndpoint}
+          queueModeEnabled={queueModeEnabled}
+          onSelectSession={handleSelectSession}
+          onNewSession={() => handleNewSession('vertical')}
+          onRefreshPRs={handleRefreshPRs}
+          onOpenPR={handleOpenPR}
+          onOpenSettings={() => setSettingsOpen(true)}
+          onMutedGroupClick={() => {
+            setSidebarCollapsed(false);
+            setSidebarMutedExpanded(true);
+            setView('session');
+          }}
+        />
+      </div>
+
+      {/* Session view - always rendered to keep terminals alive */}
+      <div className={`view-container ${view === 'session' ? 'visible' : 'hidden'}`}>
         <div className="terminal-pane">
           <div className="terminal-main-area">
             {workspaceViews.map((workspace) => {
@@ -4008,6 +4021,8 @@ sendFetchPRDetails,
             },
           ]}
         />
+      </div>
+        </div>
       </div>
 
       {/* Grid view — global mission control. Mounted only while active so its

--- a/app/src/components/Dashboard.css
+++ b/app/src/components/Dashboard.css
@@ -5,11 +5,11 @@
   background: var(--color-bg-app);
   display: flex;
   flex-direction: column;
-  padding: 40px;
+  padding: 24px 28px;
 }
 
 .dashboard-header {
-  margin-bottom: 40px;
+  margin-bottom: 24px;
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
@@ -78,6 +78,37 @@
 }
 
 /* Rate limit banner */
+/* The all-settled banner. Deliberately the calm colour rather than the accent:
+   nothing here wants you, and a banner that shouts would say the opposite. */
+.all-settled-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  margin-bottom: 20px;
+  background: rgba(120, 200, 140, 0.08);
+  border: 1px solid rgba(120, 200, 140, 0.25);
+  border-radius: 6px;
+  color: #78c88c;
+}
+.all-settled-banner svg {
+  flex-shrink: 0;
+}
+.all-settled-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.all-settled-title {
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+}
+.all-settled-detail {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
 .rate-limit-banner {
   display: flex;
   align-items: center;
@@ -179,9 +210,16 @@
 .dashboard-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 20px;
+  gap: 16px;
   flex: 1;
   min-height: 0; /* Allow grid to shrink below content size */
+  /* Home sits beside the sidebar, so the cards stack into one column well
+     before the window is narrow. Rows take the height they need and the grid
+     itself scrolls — dividing the column's height between three stacked cards
+     leaves each of them too short to show anything. */
+  grid-auto-rows: minmax(200px, max-content);
+  align-content: start;
+  overflow-y: auto;
 }
 
 .dashboard-card {
@@ -881,4 +919,30 @@
 .group-label.dim {
   color: var(--color-text-muted);
   font-style: italic;
+}
+
+/* Heads the state groups in queue mode. Sits above them rather than inside one,
+   so every group below reads as settled without repeating the word. */
+.group-label--section {
+  margin-top: 4px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--color-border);
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.group-count {
+  margin-left: 6px;
+  font-family: 'JetBrains Mono', monospace;
+  letter-spacing: 0;
+  color: var(--color-text-muted);
+}
+
+/* How long the turn has been owed, right-aligned so the ages line up as a column. */
+.session-turn-age {
+  margin-left: auto;
+  padding-left: 8px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-dimmed);
 }

--- a/app/src/components/Dashboard.test.tsx
+++ b/app/src/components/Dashboard.test.tsx
@@ -164,3 +164,99 @@ describe('Dashboard sessions', () => {
     expect(screen.queryByTestId('chief-session-summary')).not.toBeInTheDocument();
   });
 });
+
+describe('Dashboard in queue mode', () => {
+  const props = {
+    prs: [],
+    isLoading: false,
+    queueModeEnabled: true,
+    onSelectSession: vi.fn(),
+    onNewSession: vi.fn(),
+    onOpenSettings: vi.fn(),
+  };
+
+  it('leads with the turns owed, oldest first, and keeps them out of the state groups', () => {
+    render(
+      <Dashboard
+        {...props}
+        sessions={[
+          { id: 's1', label: 'newer', state: 'waiting_input', cwd: '/a', turnOwed: true, turnOpenedAt: '2026-07-29T10:05:00Z' },
+          { id: 's2', label: 'older', state: 'pending_approval', cwd: '/b', turnOwed: true, turnOpenedAt: '2026-07-29T09:00:00Z' },
+          { id: 's3', label: 'settled-but-waiting', state: 'waiting_input', cwd: '/c', turnOwed: false },
+        ]}
+      />
+    );
+
+    const turns = screen.getByTestId('session-group-turns');
+    expect(turns).toBeInTheDocument();
+    const names = Array.from(turns.querySelectorAll('.session-name')).map((n) => n.textContent);
+    expect(names).toEqual(['older', 'newer']);
+
+    // The settled agent is still in waiting_input, so the state group exists —
+    // but it holds only the agent whose turn is closed.
+    const waiting = screen.getByTestId('session-group-waiting');
+    expect(waiting).toContainElement(screen.getByTestId('session-s3'));
+    expect(waiting).not.toContainElement(screen.getByTestId('session-s1'));
+    expect(screen.getByTestId('session-group-settled')).toBeInTheDocument();
+    expect(screen.queryByTestId('all-settled')).not.toBeInTheDocument();
+  });
+
+  it('announces all settled with what is still running once nothing is owed', () => {
+    render(
+      <Dashboard
+        {...props}
+        sessions={[
+          { id: 's1', label: 'busy', state: 'working', cwd: '/a', turnOwed: false },
+          { id: 's2', label: 'busy-too', state: 'working', cwd: '/b', turnOwed: false },
+          { id: 's3', label: 'later', state: 'scheduled', cwd: '/c', turnOwed: false },
+        ]}
+      />
+    );
+
+    expect(screen.getByTestId('all-settled')).toBeInTheDocument();
+    expect(screen.getByText('2 working · 1 scheduled')).toBeInTheDocument();
+    expect(screen.queryByTestId('session-group-turns')).not.toBeInTheDocument();
+  });
+
+  it('says nothing is running when everything settled is parked', () => {
+    render(
+      <Dashboard
+        {...props}
+        sessions={[{ id: 's1', label: 'parked', state: 'idle', cwd: '/a', turnOwed: false }]}
+      />
+    );
+
+    expect(screen.getByText('Nothing is running.')).toBeInTheDocument();
+  });
+
+  it('leaves the chief out of the turns, matching the sidebar band', () => {
+    render(
+      <Dashboard
+        {...props}
+        sessions={[
+          { id: 'chief', label: 'chief', state: 'waiting_input', cwd: '/a', chiefOfStaff: true, turnOwed: true, turnOpenedAt: '2026-07-29T09:00:00Z' },
+        ]}
+      />
+    );
+
+    expect(screen.queryByTestId('session-group-turns')).not.toBeInTheDocument();
+    expect(screen.getByTestId('all-settled')).toBeInTheDocument();
+  });
+
+  it('keeps the plain state grouping when the queue is off', () => {
+    render(
+      <Dashboard
+        {...props}
+        queueModeEnabled={false}
+        sessions={[
+          { id: 's1', label: 'asking', state: 'waiting_input', cwd: '/a', turnOwed: true, turnOpenedAt: '2026-07-29T09:00:00Z' },
+        ]}
+      />
+    );
+
+    expect(screen.queryByTestId('session-group-turns')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('session-group-settled')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('all-settled')).not.toBeInTheDocument();
+    expect(screen.getByTestId('session-group-waiting')).toContainElement(screen.getByTestId('session-s1'));
+  });
+});

--- a/app/src/components/Dashboard.tsx
+++ b/app/src/components/Dashboard.tsx
@@ -9,6 +9,8 @@ import { useDaemonContext } from '../contexts/DaemonContext';
 import { getRepoName } from '../utils/repo';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import type { UISessionState } from '../types/sessionState';
+import { compareTurnOrder, formatTurnAge } from '../utils/queueBands';
+import { useNow, TURN_AGE_TICK_MS } from '../hooks/useNow';
 import appIcon from '../assets/icon.png';
 import './Dashboard.css';
 
@@ -20,7 +22,31 @@ type DashboardSession = {
   endpointName?: string;
   endpointStatus?: string;
   chiefOfStaff?: boolean;
+  // The daemon's answer to "does this owe me a turn", and since when. Read,
+  // never derived from state: an agent can sit in waiting_input with its turn
+  // already settled, which is exactly the case grouping by state gets wrong.
+  turnOwed?: boolean;
+  turnOpenedAt?: string;
 };
+
+/**
+ * The state groups, in the order they read best: the states that used to mean
+ * "this wants you" first, then the ones that are just what is happening.
+ *
+ * In queue mode these describe *settled* agents only — whether an agent wants
+ * you is the turn's business, and answering it twice is how home ends up
+ * announcing "Waiting for input (3)" directly beneath "All settled".
+ */
+const STATE_GROUPS: { state: UISessionState; label: string; testId: string }[] = [
+  { state: 'waiting_input', label: 'Waiting for input', testId: 'session-group-waiting' },
+  { state: 'pending_approval', label: 'Pending approval', testId: 'session-group-pending' },
+  { state: 'launching', label: 'Launching', testId: 'session-group-launching' },
+  { state: 'working', label: 'Working', testId: 'session-group-working' },
+  { state: 'scheduled', label: 'Scheduled', testId: 'session-group-scheduled' },
+  { state: 'idle', label: 'Idle', testId: 'session-group-idle' },
+  { state: 'recoverable', label: 'Recoverable', testId: 'session-group-recoverable' },
+  { state: 'unknown', label: 'Unknown / error', testId: 'session-group-unknown' },
+];
 
 type DashboardWorkspace = {
   id: string;
@@ -44,6 +70,10 @@ interface DashboardProps {
   onOpenPR?: (pr: DaemonPR) => void;
   onOpenSettings: () => void;
   onMutedGroupClick?: () => void;
+  // Whether the queue arrangement is on. It selects home's whole shape: turns
+  // first with the settled rest below, or the plain state grouping that is all
+  // there is to say when nothing tracks turns.
+  queueModeEnabled?: boolean;
 }
 
 export function Dashboard({
@@ -62,7 +92,10 @@ export function Dashboard({
   onOpenPR,
   onOpenSettings,
   onMutedGroupClick,
+  queueModeEnabled = false,
 }: DashboardProps) {
+  const now = useNow(TURN_AGE_TICK_MS);
+
   const renderEndpointBadge = (session: DashboardProps['sessions'][number]) => {
     if (!session.endpointName) {
       return null;
@@ -74,15 +107,65 @@ export function Dashboard({
     );
   };
 
-  const waitingSessions = sessions.filter((s) => s.state === 'waiting_input');
-  const pendingApprovalSessions = sessions.filter((s) => s.state === 'pending_approval');
-  const launchingSessions = sessions.filter((s) => s.state === 'launching');
-  const workingSessions = sessions.filter((s) => s.state === 'working');
-  const scheduledSessions = sessions.filter((s) => s.state === 'scheduled');
-  const idleSessions = sessions.filter((s) => s.state === 'idle');
-  const recoverableSessions = sessions.filter((s) => s.state === 'recoverable');
-  const unknownSessions = sessions.filter((s) => s.state === 'unknown');
   const chiefSession = sessions.find((session) => session.chiefOfStaff);
+
+  // The chief is left out of the turns, exactly as the sidebar band leaves it
+  // out: it has its own card here and its own slot there. That does mean home
+  // can read "all settled" while the chief wants you — the same thing the
+  // sidebar says, which is the lesser of the two surprises.
+  const turnSessions = useMemo(() => (
+    queueModeEnabled
+      ? sessions.filter((s) => s.turnOwed && !s.chiefOfStaff).sort(compareTurnOrder)
+      : []
+  ), [queueModeEnabled, sessions]);
+
+  // With the queue off nothing has been settled, so every session is grouped by
+  // state and there is no second band to keep them out of.
+  const settledSessions = useMemo(() => (
+    queueModeEnabled
+      ? sessions.filter((s) => !(s.turnOwed && !s.chiefOfStaff))
+      : sessions
+  ), [queueModeEnabled, sessions]);
+
+  const stateGroups = useMemo(() => (
+    STATE_GROUPS
+      .map((group) => ({ ...group, rows: settledSessions.filter((s) => s.state === group.state) }))
+      .filter((group) => group.rows.length > 0)
+  ), [settledSessions]);
+
+  const allSettled = queueModeEnabled && turnSessions.length === 0 && sessions.length > 0;
+
+  // What is still in flight once nothing is owed. "All settled" with six agents
+  // mid-turn is a different situation from "all settled" with everything parked,
+  // and the line is the only thing that tells them apart.
+  const stillRunning = useMemo(() => {
+    const counts = [
+      { label: 'working', n: settledSessions.filter((s) => s.state === 'working').length },
+      { label: 'launching', n: settledSessions.filter((s) => s.state === 'launching').length },
+      { label: 'scheduled', n: settledSessions.filter((s) => s.state === 'scheduled').length },
+      { label: 'recoverable', n: settledSessions.filter((s) => s.state === 'recoverable').length },
+    ].filter((entry) => entry.n > 0);
+    if (counts.length === 0) {
+      return 'Nothing is running.';
+    }
+    return counts.map((entry) => `${entry.n} ${entry.label}`).join(' · ');
+  }, [settledSessions]);
+
+  const renderSessionRow = (s: DashboardSession, age?: string) => (
+    <div
+      key={s.id}
+      className="session-row clickable"
+      data-testid={`session-${s.id}`}
+      data-state={s.state}
+      onClick={() => onSelectSession(s.id)}
+    >
+      <StateIndicator state={s.state} size="sm" seed={s.id} />
+      <span className="session-name">{s.label}</span>
+      {s.chiefOfStaff && <ChiefOfStaffBadge compact />}
+      {renderEndpointBadge(s)}
+      {age && <span className="session-turn-age">{age}</span>}
+    </div>
+  );
 
   // Group PRs by repo
   const [collapsedRepos, setCollapsedRepos] = useState<Set<string>>(new Set());
@@ -205,6 +288,20 @@ export function Dashboard({
         </button>
       </header>
 
+      {/* The queue's terminus. Only in queue mode, because only there does an
+          agent stop wanting you without its state changing. */}
+      {allSettled && (
+        <div className="all-settled-banner" data-testid="all-settled">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+          <div className="all-settled-body">
+            <span className="all-settled-title">All settled</span>
+            <span className="all-settled-detail">{stillRunning}</span>
+          </div>
+        </div>
+      )}
+
       {/* Rate limit banner */}
       {rateLimitCountdown && (
         <div className="rate-limit-banner">
@@ -261,158 +358,31 @@ export function Dashboard({
               <div className="card-empty">No active sessions</div>
             ) : (
               <>
-                {waitingSessions.length > 0 && (
-                  <div className="session-group" data-testid="session-group-waiting">
-                    <div className="group-label">Waiting for input</div>
-                    {waitingSessions.map((s) => (
-                      <div
-                        key={s.id}
-                        className="session-row clickable"
-                        data-testid={`session-${s.id}`}
-                        data-state={s.state}
-                        onClick={() => onSelectSession(s.id)}
-                      >
-                        <StateIndicator state="waiting_input" size="sm" seed={s.id} />
-                        <span className="session-name">{s.label}</span>
-                        {s.chiefOfStaff && <ChiefOfStaffBadge compact />}
-                        {renderEndpointBadge(s)}
-                      </div>
+                {turnSessions.length > 0 && (
+                  <div className="session-group" data-testid="session-group-turns">
+                    <div className="group-label">
+                      Your turn
+                      <span className="group-count">{turnSessions.length}</span>
+                    </div>
+                    {turnSessions.map((s) => (
+                      renderSessionRow(s, formatTurnAge(s.turnOpenedAt, now))
                     ))}
                   </div>
                 )}
-                {pendingApprovalSessions.length > 0 && (
-                  <div className="session-group" data-testid="session-group-pending">
-                    <div className="group-label">Pending approval</div>
-                    {pendingApprovalSessions.map((s) => (
-                      <div
-                        key={s.id}
-                        className="session-row clickable"
-                        data-testid={`session-${s.id}`}
-                        data-state={s.state}
-                        onClick={() => onSelectSession(s.id)}
-                      >
-                        <StateIndicator state="pending_approval" size="sm" seed={s.id} />
-                        <span className="session-name">{s.label}</span>
-                        {s.chiefOfStaff && <ChiefOfStaffBadge compact />}
-                        {renderEndpointBadge(s)}
-                      </div>
-                    ))}
+                {/* Settled is a heading, not a group: the state groups below it
+                    are what those agents are doing, now that whether they want
+                    you has already been answered above. */}
+                {queueModeEnabled && stateGroups.length > 0 && (
+                  <div className="group-label group-label--section" data-testid="session-group-settled">
+                    Settled
                   </div>
                 )}
-                {launchingSessions.length > 0 && (
-                  <div className="session-group" data-testid="session-group-launching">
-                    <div className="group-label">Launching</div>
-                    {launchingSessions.map((s) => (
-                      <div
-                        key={s.id}
-                        className="session-row clickable"
-                        data-testid={`session-${s.id}`}
-                        data-state={s.state}
-                        onClick={() => onSelectSession(s.id)}
-                      >
-                        <StateIndicator state="launching" size="sm" seed={s.id} />
-                        <span className="session-name">{s.label}</span>
-                        {s.chiefOfStaff && <ChiefOfStaffBadge compact />}
-                        {renderEndpointBadge(s)}
-                      </div>
-                    ))}
+                {stateGroups.map((group) => (
+                  <div key={group.state} className="session-group" data-testid={group.testId}>
+                    <div className="group-label">{group.label}</div>
+                    {group.rows.map((s) => renderSessionRow(s))}
                   </div>
-                )}
-                {workingSessions.length > 0 && (
-                  <div className="session-group" data-testid="session-group-working">
-                    <div className="group-label">Working</div>
-                    {workingSessions.map((s) => (
-                      <div
-                        key={s.id}
-                        className="session-row clickable"
-                        data-testid={`session-${s.id}`}
-                        data-state={s.state}
-                        onClick={() => onSelectSession(s.id)}
-                      >
-                        <StateIndicator state="working" size="sm" seed={s.id} />
-                        <span className="session-name">{s.label}</span>
-                        {s.chiefOfStaff && <ChiefOfStaffBadge compact />}
-                        {renderEndpointBadge(s)}
-                      </div>
-                    ))}
-                  </div>
-                )}
-                {scheduledSessions.length > 0 && (
-                  <div className="session-group" data-testid="session-group-scheduled">
-                    <div className="group-label">Scheduled</div>
-                    {scheduledSessions.map((s) => (
-                      <div
-                        key={s.id}
-                        className="session-row clickable"
-                        data-testid={`session-${s.id}`}
-                        data-state={s.state}
-                        onClick={() => onSelectSession(s.id)}
-                      >
-                        <StateIndicator state="scheduled" size="sm" seed={s.id} />
-                        <span className="session-name">{s.label}</span>
-                        {s.chiefOfStaff && <ChiefOfStaffBadge compact />}
-                        {renderEndpointBadge(s)}
-                      </div>
-                    ))}
-                  </div>
-                )}
-                {idleSessions.length > 0 && (
-                  <div className="session-group" data-testid="session-group-idle">
-                    <div className="group-label">Idle</div>
-                    {idleSessions.map((s) => (
-                      <div
-                        key={s.id}
-                        className="session-row clickable"
-                        data-testid={`session-${s.id}`}
-                        data-state={s.state}
-                        onClick={() => onSelectSession(s.id)}
-                      >
-                        <StateIndicator state="idle" size="sm" seed={s.id} />
-                        <span className="session-name">{s.label}</span>
-                        {s.chiefOfStaff && <ChiefOfStaffBadge compact />}
-                        {renderEndpointBadge(s)}
-                      </div>
-                    ))}
-                  </div>
-                )}
-                {recoverableSessions.length > 0 && (
-                  <div className="session-group" data-testid="session-group-recoverable">
-                    <div className="group-label">Recoverable</div>
-                    {recoverableSessions.map((s) => (
-                      <div
-                        key={s.id}
-                        className="session-row clickable"
-                        data-testid={`session-${s.id}`}
-                        data-state={s.state}
-                        onClick={() => onSelectSession(s.id)}
-                      >
-                        <StateIndicator state="recoverable" size="sm" seed={s.id} />
-                        <span className="session-name">{s.label}</span>
-                        {s.chiefOfStaff && <ChiefOfStaffBadge compact />}
-                        {renderEndpointBadge(s)}
-                      </div>
-                    ))}
-                  </div>
-                )}
-                {unknownSessions.length > 0 && (
-                  <div className="session-group" data-testid="session-group-unknown">
-                    <div className="group-label">Unknown / error</div>
-                    {unknownSessions.map((s) => (
-                      <div
-                        key={s.id}
-                        className="session-row clickable"
-                        data-testid={`session-${s.id}`}
-                        data-state={s.state}
-                        onClick={() => onSelectSession(s.id)}
-                      >
-                        <StateIndicator state="unknown" size="sm" seed={s.id} />
-                        <span className="session-name">{s.label}</span>
-                        {s.chiefOfStaff && <ChiefOfStaffBadge compact />}
-                        {renderEndpointBadge(s)}
-                      </div>
-                    ))}
-                  </div>
-                )}
+                ))}
                 {mutedWorkspaces.length > 0 && (
                   <div
                     className="session-group muted-summary clickable"

--- a/app/src/components/QueueBands.tsx
+++ b/app/src/components/QueueBands.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState, type MouseEvent as ReactMouseEvent } from 'react';
+import { type MouseEvent as ReactMouseEvent } from 'react';
 import { StateIndicator } from './StateIndicator';
 import { ChiefOfStaffBadge } from './ChiefOfStaffBadge';
 import { SidebarSettlingBar } from './SettlingIndicator';
 import { formatShortcut } from '../shortcuts/formatShortcut';
 import type { UISessionState } from '../types/sessionState';
 import { formatTurnAge, type QueueBands as QueueBandsModel, type QueueRow } from '../utils/queueBands';
+import { useNow, TURN_AGE_TICK_MS } from '../hooks/useNow';
 
 export interface QueueBandSessionView {
   id: string;
@@ -42,22 +43,6 @@ interface QueueBandsProps {
    * reach for anything in a band.
    */
   onOpenActions?: (session: { id: string; label: string; chiefOfStaff?: boolean }, event: ReactMouseEvent) => void;
-}
-
-/**
- * Turn ages are read from a clock, not from a prop, so a row that has been
- * outstanding for an hour does not keep claiming it arrived a minute ago
- * whenever the daemon happens to go quiet.
- */
-const AGE_TICK_MS = 30_000;
-
-function useNow(intervalMs: number): number {
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const timer = setInterval(() => setNow(Date.now()), intervalMs);
-    return () => clearInterval(timer);
-  }, [intervalMs]);
-  return now;
 }
 
 function QueueRowView({
@@ -175,7 +160,7 @@ function QueueRowView({
  * places you go and get work rather than a list handed to you.
  */
 export function QueueBands({ bands, selectedId, onSelectSession, onSettleTurn, onScreenSessionIds, onPinWorkspace, onOpenActions }: QueueBandsProps) {
-  const now = useNow(AGE_TICK_MS);
+  const now = useNow(TURN_AGE_TICK_MS);
   const offScreen = (id: string) => !onScreenSessionIds?.has(id);
 
   return (

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -46,12 +46,14 @@
   gap: 6px;
 }
 
+/* Nothing labels this row any more — the home row below names the sidebar's
+   place, so the "+" and the display popover trigger sit flush right on their own. */
 .sidebar-header-row {
   gap: 8px;
+  justify-content: flex-end;
 }
 
 .sidebar-tool-btn,
-.home-btn,
 .new-session-btn,
 .collapse-btn,
 .sidebar-settings-btn,
@@ -62,7 +64,6 @@
 }
 
 .sidebar-tool-btn svg,
-.home-btn svg,
 .new-session-btn svg,
 .collapse-btn svg,
 .sidebar-settings-btn svg,
@@ -116,37 +117,6 @@
   font-weight: 700;
   line-height: 18px;
   text-align: center;
-}
-
-.home-btn {
-  background: rgba(255, 255, 255, 0.035);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 8px;
-  color: var(--color-text-secondary);
-  width: 100%;
-  height: 30px;
-  cursor: pointer;
-}
-
-.home-btn:hover {
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--color-text-primary);
-}
-
-.home-shortcut {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: var(--font-size-xs);
-  color: var(--color-text-dimmed);
-}
-
-.sidebar-title {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: var(--font-size-sm);
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--color-text-dimmed);
-  flex: 1;
 }
 
 .new-session-btn {
@@ -1157,6 +1127,50 @@
 
 .muted-session[data-state="waiting_input"]::before {
   display: none;
+}
+
+/* The home row. Above the queue bands and the tree, so it reads as the fixed
+   place you return to rather than a member of either list. */
+.sidebar-home-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: calc(100% - 12px);
+  margin: 4px 6px 0;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 6px;
+  background: none;
+  color: var(--color-text-secondary);
+  font-family: inherit;
+  font-size: var(--font-size-md);
+  text-align: left;
+  cursor: pointer;
+}
+.sidebar-home-row:hover {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--color-text-primary);
+}
+.sidebar-home-row.selected {
+  background: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+}
+.sidebar-home-row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.sidebar-home-row svg {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+.sidebar-home-label {
+  flex: 1;
+}
+.sidebar-home-shortcut {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-dimmed);
 }
 
 /* Queue arrangement: the chief's anchored slot and the "Your turn" band, both

--- a/app/src/components/Sidebar.test.tsx
+++ b/app/src/components/Sidebar.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { Sidebar, type DockItem } from './Sidebar';
+import { formatShortcut } from '../shortcuts/formatShortcut';
 import { buildWorkspaceViewModels, type WorkspaceWithSessions } from '../utils/workspaceViewModels';
 
 function sessionlessWorkspace(): WorkspaceWithSessions<TestSession> {
@@ -786,5 +787,73 @@ describe('Sidebar', () => {
     fireEvent.click(screen.getByTestId('chief-of-staff-session-action'));
 
     expect(onChangeChiefOfStaff).toHaveBeenCalledWith('s1', true);
+  });
+});
+
+describe('Sidebar home row', () => {
+  const sessions: TestSession[] = [{ id: 's1', label: 'agent', state: 'working' }];
+
+  it('goes home when the row is clicked', () => {
+    const onGoToDashboard = vi.fn();
+    render(
+      <Sidebar
+        {...baseProps}
+        {...buildSidebarData(sessions)}
+        onGoToDashboard={onGoToDashboard}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+
+    expect(onGoToDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the row as the current page only while home is on screen', () => {
+    const { rerender } = render(
+      <Sidebar {...baseProps} {...buildSidebarData(sessions)} homeActive={false} />
+    );
+    expect(screen.getByTestId('sidebar-home')).not.toHaveAttribute('aria-current');
+
+    rerender(
+      <Sidebar {...baseProps} {...buildSidebarData(sessions)} homeActive />
+    );
+    expect(screen.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByTestId('sidebar-home').className).toContain('selected');
+  });
+
+  it('replaces the workspaces title, so the header carries no label of its own', () => {
+    render(<Sidebar {...baseProps} {...buildSidebarData(sessions)} />);
+
+    expect(screen.queryByText('Workspaces')).not.toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-home')).toBeInTheDocument();
+  });
+
+  // The old header hardcoded ⌘G, which had already gone stale when grid view
+  // took that chord and home moved to ⌘⇧H. Read the hint from the registry so
+  // it cannot drift again — or disagree with a rebind.
+  it('shows the shortcut home is actually bound to, not a hardcoded one', () => {
+    render(<Sidebar {...baseProps} {...buildSidebarData(sessions)} />);
+
+    const hint = screen.getByTestId('sidebar-home').querySelector('.sidebar-home-shortcut');
+    expect(hint?.textContent).toBe(formatShortcut('session.goToDashboard'));
+    expect(hint?.textContent).not.toBe('⌘G');
+  });
+
+  it('keeps a way home when the sidebar is collapsed', () => {
+    const onGoToDashboard = vi.fn();
+    render(
+      <Sidebar
+        {...baseProps}
+        {...buildSidebarData(sessions)}
+        collapsed
+        homeActive
+        onGoToDashboard={onGoToDashboard}
+      />
+    );
+
+    const home = screen.getByLabelText('Home');
+    expect(home).toHaveAttribute('aria-current', 'page');
+    fireEvent.click(home);
+    expect(onGoToDashboard).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -200,6 +200,9 @@ interface SidebarProps {
   onCloseSession: (id: string) => void;
   onReloadSession: (id: string) => void;
   onGoToDashboard: () => void;
+  // Whether home is the view on screen. Drives the home row's selected state so
+  // it reads like any other row you can be sitting on.
+  homeActive?: boolean;
   onToggleCollapse: () => void;
 }
 
@@ -379,6 +382,7 @@ export function Sidebar({
   onCloseSession,
   onReloadSession,
   onGoToDashboard,
+  homeActive = false,
   onToggleCollapse,
 }: SidebarProps) {
   // Each arrangement has one notion of what wants the user, and the mode selects
@@ -820,7 +824,13 @@ export function Sidebar({
     return (
       <div className="sidebar collapsed">
         <div className="icon-rail">
-          <button className="icon-btn" onClick={onGoToDashboard} title="Dashboard (⌘G)">
+          <button
+            className={`icon-btn ${homeActive ? 'active' : ''}`}
+            onClick={onGoToDashboard}
+            title={`Home (${formatShortcut('session.goToDashboard')})`}
+            aria-label="Home"
+            aria-current={homeActive ? 'page' : undefined}
+          >
             <HomeIcon />
           </button>
           <div className="icon-divider" />
@@ -872,9 +882,6 @@ export function Sidebar({
     <div className={`sidebar sidebar--display-${displayMode}`}>
       <div className="sidebar-header">
         <div className="sidebar-tool-row">
-          <button className="home-btn" onClick={onGoToDashboard} title="Dashboard (⌘G)" aria-label="Dashboard">
-            <HomeIcon />
-          </button>
           {gridLayout && onSelectGridLayout && (
             <GridLayoutControl layout={gridLayout} onSelect={onSelectGridLayout} />
           )}
@@ -898,8 +905,6 @@ export function Sidebar({
           </button>
         </div>
         <div className="sidebar-header-row">
-          <span className="sidebar-title">Workspaces</span>
-          <span className="home-shortcut">⌘G</span>
           <button className="new-session-btn" onClick={onNewSession} title="New Session (⌘N)" aria-label="New Session">
             <PlusIcon />
           </button>
@@ -972,6 +977,21 @@ export function Sidebar({
           </div>
         </div>
       </div>
+
+      {/* Home sits above everything, the chief's slot included: it is the one
+          row that is not an agent, and it is where the queue leaves you once
+          nothing is owed. */}
+      <button
+        type="button"
+        className={`sidebar-home-row ${homeActive ? 'selected' : ''}`}
+        data-testid="sidebar-home"
+        onClick={onGoToDashboard}
+        aria-current={homeActive ? 'page' : undefined}
+      >
+        <HomeIcon />
+        <span className="sidebar-home-label">Home</span>
+        <span className="sidebar-home-shortcut">{formatShortcut('session.goToDashboard')}</span>
+      </button>
 
       {queue && (
         <QueueBands

--- a/app/src/hooks/useNow.ts
+++ b/app/src/hooks/useNow.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * A wall clock that re-renders on an interval.
+ *
+ * Ages shown against a timestamp — how long a turn has been owed, say — are
+ * read from a clock rather than from a prop, so a row outstanding for an hour
+ * does not keep claiming it arrived a minute ago whenever the daemon goes quiet.
+ */
+export function useNow(intervalMs: number): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(timer);
+  }, [intervalMs]);
+  return now;
+}
+
+/** How often turn ages re-read the clock. Shared by the queue band and home. */
+export const TURN_AGE_TICK_MS = 30_000;

--- a/app/src/utils/queueBands.ts
+++ b/app/src/utils/queueBands.ts
@@ -82,6 +82,21 @@ export function formatTurnAge(openedAt: string | undefined, now: number): string
   return `${Math.round(hours / 24)}d`;
 }
 
+/**
+ * Queue order: how long the turn has been owed, oldest first, tie-broken by id
+ * so the order is total and does not shuffle between renders. Exported because
+ * home lists the same turns and must list them in the same order — two orders
+ * for one queue is two queues.
+ */
+export function compareTurnOrder(a: QueueBandSession, b: QueueBandSession): number {
+  const openedA = a.turnOpenedAt ?? '';
+  const openedB = b.turnOpenedAt ?? '';
+  if (openedA !== openedB) {
+    return openedA < openedB ? -1 : 1;
+  }
+  return a.id < b.id ? -1 : 1;
+}
+
 export interface QueueBands<TSession extends QueueBandSession> {
   /** The chief's anchored slot. It never queues, so it is always its own row. */
   chief: QueueRow<TSession> | null;
@@ -145,14 +160,7 @@ export function buildQueueBands<TSession extends QueueBandSession>(
     }
   }
 
-  turns.sort((a, b) => {
-    const openedA = a.session.turnOpenedAt ?? '';
-    const openedB = b.session.turnOpenedAt ?? '';
-    if (openedA !== openedB) {
-      return openedA < openedB ? -1 : 1;
-    }
-    return a.session.id < b.session.id ? -1 : 1;
-  });
+  turns.sort((a, b) => compareTurnOrder(a.session, b.session));
 
   return { chief, turns, settled };
 }

--- a/docs/plans/2026-07-29-attn-home-dashboard.md
+++ b/docs/plans/2026-07-29-attn-home-dashboard.md
@@ -1,0 +1,183 @@
+# Plan: the Dashboard becomes attn's home
+
+## Goal
+
+Settling the last owed turn currently does nothing — `nextTurnAfterSettle` returns
+`null` and selection stays on the agent you just finished with. Give the queue a
+terminus: settling the last turn lands you on the Dashboard, which becomes attn's
+*home* — turn-aware, rendered alongside the sidebar like the session view, and
+reachable from a fixed Home row at the top of the sidebar.
+
+The Dashboard today groups sessions by `UISessionState` and knows nothing about
+turns. In queue mode that makes it contradict the sidebar: it would say
+"Waiting for input (3)" about the three agents you just settled. Teaching it
+turns is what makes it usable as the all-settled screen, and it is the same fix
+either way.
+
+## User-visible shape
+
+```text
+┌────────────────┬──────────────────────────────────────────┐
+│ [grid] [tools] │  ✓ All settled                           │  ← banner, queue mode,
+│  ⌂ Home     ⌘G │    3 working · 1 scheduled               │    only when turns == 0
+│ ─────────────  ├──────────────────────────────────────────┤
+│  chief         │  Sessions          Chief         PRs      │
+│ Your turn   2  │  ┌──────────────┐ ┌────────┐ ┌─────────┐ │
+│   agent-a  12m │  │ Your turn  2 │ │        │ │         │ │  ← "Your turn" leads the
+│   agent-b   4m │  │  agent-a 12m │ │        │ │         │ │    Sessions card; absent
+│ Settled        │  │  agent-b  4m │ │        │ │         │ │    when nothing is owed
+│   agent-c      │  │ Settled      │ │        │ │         │ │
+│   agent-d      │  │  Working     │ │        │ │         │ │  ← state groups, over
+│ ─────────────  │  │   agent-c    │ │        │ │         │ │    settled sessions only
+│  workspace/... │  │  Idle        │ │        │ │         │ │
+└────────────────┴──────────────────────────────────────────┘
+```
+
+- Sidebar header loses the `WORKSPACES` title and the `⌘G` label; the `+` and
+  settings gear right-align. The tool-row home button goes away — the Home row
+  replaces it.
+- Home row sits above everything, including the chief slot, and highlights when
+  the dashboard view is active.
+- Queue off: the Home row still renders, the Dashboard keeps today's state
+  groups, no banner. Only the shell change applies.
+
+## Architecture Map
+
+```text
+Current:
+App render
+  ├─ .view-container (dashboard)     position:absolute inset:0   ← full-window takeover
+  │    └─ Dashboard
+  ├─ .view-container (session)       position:absolute inset:0
+  │    ├─ Sidebar                                                ← sidebar lives INSIDE
+  │    ├─ .terminal-pane
+  │    └─ RightDock
+  └─ .view-container (grid)          position:absolute inset:0, conditional
+
+Target:
+App render
+  ├─ .app-shell                      position:absolute inset:0, flex row
+  │    ├─ Sidebar                                                ← hoisted, always on
+  │    └─ .view-stack                flex:1, position:relative
+  │         ├─ .view-container (dashboard)
+  │         │    └─ Dashboard
+  │         └─ .view-container (session)
+  │              ├─ .terminal-pane
+  │              └─ RightDock
+  └─ .view-container (grid)          UNCHANGED full-window overlay, outside the shell
+
+Sidebar internals:
+Sidebar
+  ├─ .sidebar-header      tool row (no home-btn) + header row (no title, no ⌘G)
+  ├─ .sidebar-home-row    NEW — onGoToDashboard, active when view === 'dashboard'
+  ├─ QueueBands           chief / Your turn / Settled   (queue mode only)
+  └─ .session-list        workspace tree
+```
+
+## Data Model / Interfaces
+
+```ts
+// Dashboard.tsx — turn facts arrive alongside state, both read from the daemon.
+type DashboardSession = {
+  id: string; label: string; state: UISessionState; cwd: string;
+  endpointName?: string; endpointStatus?: string; chiefOfStaff?: boolean;
+  turnOwed?: boolean;        // NEW — daemon's answer, never derived
+  turnOpenedAt?: string;     // NEW — drives the age chip + ordering
+}
+
+interface DashboardProps {
+  // ...existing
+  queueModeEnabled: boolean; // NEW — selects turn-first vs today's state shape
+}
+
+// Sidebar.tsx
+interface SidebarProps {
+  // ...existing (onGoToDashboard already exists)
+  homeActive?: boolean;      // NEW — view === 'dashboard'
+}
+```
+
+Turn ordering and age formatting reuse `queueBands.ts` (`formatTurnAge`, the
+`turnOpenedAt` ascending + session-id tiebreak comparator) rather than
+reimplementing them in the Dashboard.
+
+## Boundaries
+
+- `queueBands.ts` owns turn ordering and age formatting. The Dashboard imports
+  them; it does not derive turn membership from state.
+- `App.tsx` owns the view state and passes `queueModeEnabled` / `homeActive`
+  down. Neither Sidebar nor Dashboard reads the setting itself.
+- The Dashboard's state groups are computed over *settled* sessions in queue
+  mode, so a session is never in two groups.
+- Grid view stays outside the shell. Hoisting the sidebar must not change what
+  grid view looks like.
+
+## Implementation Steps
+
+- [x] Hoist `Sidebar` into a new `.app-frame` wrapper; move the dashboard and
+      session `.view-container`s into a `.view-stack` column. Leave grid alone.
+- [x] `App.css`: `.app-frame` flex row, `.view-stack` flex:1 + position:relative;
+      the view-containers become absolute within the stack, not the window.
+- [x] Sidebar header cleanup: drop `home-btn`, `sidebar-title` and
+      `home-shortcut`; right-align the row (`.sidebar-title { flex: 1 }` was
+      carrying the layout).
+- [x] Add `.sidebar-home-row` above `QueueBands`; `homeActive` drives the
+      selected state. Collapsed rail keeps its icon button and gains the same
+      active state.
+- [x] Dashboard: accept `turnOwed`/`turnOpenedAt`/`queueModeEnabled`; in queue
+      mode lead the Sessions card with a "Your turn" group (age chips, oldest
+      first) and compute state groups over settled sessions under a `Settled`
+      label.
+- [x] Dashboard: all-settled banner above the grid when
+      `queueModeEnabled && turns.length === 0`, with a one-line summary of what
+      is still running.
+- [x] `handleSettleActiveTurn`: `else` branch calls `goToDashboard()` when
+      `nextTurnAfterSettle` returns null.
+- [x] Tests: `Dashboard.test.tsx` for turn-first grouping, the banner, the chief
+      exclusion and the queue-off shape; `Sidebar.test.tsx` for the Home row,
+      its active state, the collapsed rail and the header cleanup.
+- [x] `CHANGELOG.md` entry.
+- [x] Live verification: `make dev` on the dev profile, preflight PASS, queue
+      mode on, two agent sessions owing turns, ⌘⇧E chained to zero — the first
+      settle jumped to the next agent, the second cleared the selection and
+      landed on home showing "All settled".
+
+## Decisions
+
+- **Grid view stays a full-window overlay.** Hoisting the sidebar out of the
+  session container would otherwise put a sidebar next to grid view as a silent
+  side effect. Grid keeps its own container outside `.app-shell`.
+- **The all-settled headline is a banner, not the "Your turn" group's empty
+  state.** Saying it in both places is redundant; the banner gives the moment
+  weight and the group simply does not render when empty.
+- **No auto-jump when a new turn opens while parked on home.** Home is also
+  where you go to start work — getting yanked mid-launch is worse than one
+  keystroke. Pickup stays manual (⌘J / clicking the queue).
+- **State groups survive in queue mode, nested under `Settled`.** Dropping them
+  would lose the working/scheduled/recoverable signal that makes an all-settled
+  screen worth looking at; nesting them removes the contradiction without
+  removing the information.
+- **The chief is outside both bands** (`queueBands.ts:92`), so "all settled" can
+  be true while the chief wants you. Keeping that consistent with the sidebar is
+  the lesser surprise.
+- **The dashboard grid scrolls as a whole, with content-sized rows.** Found in
+  live verification: beside the sidebar the cards stack into one column, and the
+  old `flex: 1` split the column's height three ways, leaving every card too
+  short to show anything. `grid-auto-rows: minmax(200px, max-content)` +
+  `overflow-y: auto` on the grid, rather than per-card scrolling.
+
+## Open Questions
+
+- The dashboard header (app icon, "attn / attention hub") is app chrome that the
+  sidebar now provides. Kept, with the page padding tightened; worth removing
+  outright if it keeps reading as wasted height beside the sidebar.
+- The banner's summary counts `recoverable` as still running. It is — the daemon
+  is reviving those unattended — but "5 recoverable" as the headline detail may
+  read more like a problem than a status.
+
+## Follow-ups
+
+- `⌘J` jump-to-waiting still uses unmuted order, not queue order
+  (`App.tsx:2880`). Worth reconciling once home lands.
+- A pickup affordance on the home screen ("2 waiting — ⏎") if manual pickup
+  proves annoying in practice.

--- a/internal/daemon/notebook_raw_tier_test.go
+++ b/internal/daemon/notebook_raw_tier_test.go
@@ -62,13 +62,13 @@ func TestSnapshotWorkspaceContextAtRemovalSites(t *testing.T) {
 			},
 		},
 		{
-			name: "unregisterWorkspaceIfEmptyAfterMove",
+			name: "unregisterWorkspaceIfEmpty",
 			wsID: "ws-move",
 			remove: func(d *Daemon, sessionID, workspaceID string) {
 				// The session must be gone for the workspace to be considered empty.
 				d.workspaces.dissociateSession(sessionID)
 				d.store.Remove(sessionID)
-				d.unregisterWorkspaceIfEmptyAfterMove(workspaceID)
+				d.unregisterWorkspaceIfEmpty(workspaceID)
 			},
 		},
 	}

--- a/internal/daemon/workspace_keeper_test.go
+++ b/internal/daemon/workspace_keeper_test.go
@@ -669,7 +669,7 @@ func TestWorkspaceTeardownDoesNotPanicBeforeCompactRunnerExists(t *testing.T) {
 		}
 	})
 
-	t.Run("unregisterWorkspaceIfEmptyAfterMove", func(t *testing.T) {
+	t.Run("unregisterWorkspaceIfEmpty", func(t *testing.T) {
 		d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 		setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
 		// The session must be gone for the workspace to be considered empty.
@@ -677,7 +677,7 @@ func TestWorkspaceTeardownDoesNotPanicBeforeCompactRunnerExists(t *testing.T) {
 		d.store.Remove("session-1")
 		d.compactRunner = nil
 
-		d.unregisterWorkspaceIfEmptyAfterMove("workspace-1")
+		d.unregisterWorkspaceIfEmpty("workspace-1")
 
 		if d.store.GetWorkspace("workspace-1") != nil {
 			t.Fatal("empty workspace was not removed after move-out")

--- a/internal/daemon/workspace_tile_lifecycle_test.go
+++ b/internal/daemon/workspace_tile_lifecycle_test.go
@@ -102,6 +102,50 @@ func TestClosingLastPaneKeepsTileOnlyWorkspaceAlive(t *testing.T) {
 	assertTileOnlyWorkspaceAlive(t, d, workspaceID, sessionID)
 }
 
+// Undocking the last tile of a sessionless workspace is the user closing the last
+// thing that workspace holds. It must take the workspace with it: a workspace with
+// a leafless layout is unreachable by every layout command (they all go through
+// ensureWorkspaceLayout), so leaving one behind strands a sidebar row whose close
+// button can never work again.
+func TestUndockingLastTileTearsDownSessionlessWorkspace(t *testing.T) {
+	d, client, workspaceID, sessionID, paneID := setupSessionWorkspaceWithTile(t)
+	d.handleWorkspaceLayoutClosePane(client, &protocol.WorkspaceLayoutClosePaneMessage{
+		Cmd:         protocol.CmdWorkspaceLayoutClosePane,
+		WorkspaceID: workspaceID,
+		PaneID:      paneID,
+	})
+	expectWorkspaceLayoutActionResult(t, client, protocol.CmdWorkspaceLayoutClosePane, workspaceID, paneID, true)
+	assertTileOnlyWorkspaceAlive(t, d, workspaceID, sessionID)
+
+	tileID := workspacelayout.TileIDs(d.store.GetWorkspaceLayout(workspaceID).Layout)[0]
+	cap := captureBroadcasts(d)
+	d.handleWorkspaceLayoutUndockTile(client, &protocol.WorkspaceLayoutUndockTileMessage{
+		Cmd:         protocol.CmdWorkspaceLayoutUndockTile,
+		WorkspaceID: workspaceID,
+		TileID:      tileID,
+	})
+	expectWorkspaceLayoutActionResultIDs(t, client, protocol.CmdWorkspaceLayoutUndockTile, workspaceID, "", "", tileID, true)
+
+	if ws := d.store.GetWorkspace(workspaceID); ws != nil {
+		t.Fatalf("workspace survived undocking its last tile: %+v", ws)
+	}
+	if _, registered := d.workspaces.snapshot(workspaceID); registered {
+		t.Fatal("workspace still in the in-memory registry after its last tile was undocked")
+	}
+	if snapshot := d.store.GetWorkspaceLayout(workspaceID); snapshot != nil {
+		t.Fatalf("leafless layout left behind: %+v", snapshot)
+	}
+	unregistered := false
+	for _, event := range cap.snapshot() {
+		if event.Event == protocol.EventWorkspaceUnregistered && event.Workspace != nil && event.Workspace.ID == workspaceID {
+			unregistered = true
+		}
+	}
+	if !unregistered {
+		t.Fatalf("no workspace_unregistered broadcast; clients keep showing the workspace: %+v", cap.snapshot())
+	}
+}
+
 func TestTileOnlyWorkspaceSurvivesStartupReap(t *testing.T) {
 	d, client, workspaceID, sessionID, paneID := setupSessionWorkspaceWithTile(t)
 	d.handleWorkspaceLayoutClosePane(client, &protocol.WorkspaceLayoutClosePaneMessage{

--- a/internal/daemon/workspacelayout.go
+++ b/internal/daemon/workspacelayout.go
@@ -539,6 +539,29 @@ func (d *Daemon) handleWorkspaceLayoutUndockTile(client *wsClient, msg *protocol
 	}
 	snapshot.Layout = layout
 	normalized := workspacelayout.NormalizeWorkspaceLayout(*snapshot)
+	if workspacelayout.LayoutEmpty(normalized.Layout) {
+		// The tile was the workspace's last leaf — the case of a sessionless
+		// workspace that only existed to hold it. Mirror close-pane: drop the layout
+		// row rather than storing a leafless one, because every layout command goes
+		// through ensureWorkspaceLayout, which rejects a leafless layout. Storing it
+		// and broadcasting through the normal path would leave a workspace nothing
+		// can act on: the sidebar row survives with a close button that can never
+		// work again.
+		d.store.RemoveWorkspaceLayout(msg.WorkspaceID)
+		d.sendWorkspaceLayoutTileActionResult(client, protocol.CmdWorkspaceLayoutUndockTile, msg.WorkspaceID, tileID, nil)
+		if d.unregisterWorkspaceIfEmpty(msg.WorkspaceID) {
+			return
+		}
+		// It survives (pinned, or sessions remain), so publish the empty layout
+		// instead of leaving clients replaying the undocked tile.
+		emptyLayout, err := protocolWorkspaceLayout(normalized)
+		if err != nil {
+			d.logf("workspace empty layout update failed for workspace %s: %v", msg.WorkspaceID, err)
+			return
+		}
+		d.broadcastWorkspaceLayoutSnapshotUpdated(emptyLayout)
+		return
+	}
 	if err := d.store.SaveWorkspaceLayout(normalized); err != nil {
 		d.sendWorkspaceLayoutTileActionResult(client, protocol.CmdWorkspaceLayoutUndockTile, msg.WorkspaceID, tileID, err)
 		return
@@ -727,7 +750,7 @@ func (d *Daemon) handleWorkspaceLayoutMoveLeafToNewWorkspace(client *wsClient, m
 	if err != nil {
 		// The move failed after the workspace was registered. Tear the empty
 		// new workspace back down so a failed drag leaves no orphan behind.
-		d.unregisterWorkspaceIfEmptyAfterMove(newWorkspaceID)
+		d.unregisterWorkspaceIfEmpty(newWorkspaceID)
 	}
 	d.sendWorkspaceLayoutMoveToNewWorkspaceResult(client, sourceWorkspaceID, newWorkspaceID, leafID, finalLeafID, err)
 }
@@ -994,7 +1017,7 @@ func (d *Daemon) moveLeafToWorkspace(sourceWorkspaceID, targetWorkspaceID, leafI
 	}
 
 	if sourceEmpty {
-		d.unregisterWorkspaceIfEmptyAfterMove(sourceWorkspaceID)
+		d.unregisterWorkspaceIfEmpty(sourceWorkspaceID)
 	} else {
 		d.recomputeAndBroadcastWorkspace(sourceWorkspaceID)
 	}
@@ -1002,22 +1025,27 @@ func (d *Daemon) moveLeafToWorkspace(sourceWorkspaceID, targetWorkspaceID, leafI
 	return move.FinalLeafID, nil
 }
 
-func (d *Daemon) unregisterWorkspaceIfEmptyAfterMove(workspaceID string) {
+// unregisterWorkspaceIfEmpty tears down a workspace that holds nothing after a
+// leaf left it — moved away, or undocked. A workspace with sessions, a pin, or a
+// retained tile survives and only has its rollup rebroadcast. Reports whether the
+// workspace was removed, so callers can tell the two outcomes apart.
+func (d *Daemon) unregisterWorkspaceIfEmpty(workspaceID string) bool {
 	if d.workspaces == nil {
-		return
+		return false
 	}
 	if len(d.workspaces.sessionIDs(workspaceID)) > 0 ||
 		d.workspaceHasSessionlessContent(workspaceID) {
 		d.recomputeAndBroadcastWorkspace(workspaceID)
-		return
+		return false
 	}
 	snapshot, removed := d.workspaces.unregister(workspaceID)
 	if !removed {
-		return
+		return false
 	}
 	// Layout teardown (last visible pane/tile removed): tear down and write the
 	// removal-boundary retrospective.
 	d.tearDownRemovedWorkspace(snapshot)
+	return true
 }
 
 func (d *Daemon) recomputeAndBroadcastWorkspace(workspaceID string) {


### PR DESCRIPTION
## Summary

Two related pieces.

**1. The Dashboard becomes attn's turn-aware home.**

- It now renders beside the sidebar, the way an agent's terminal does,
  instead of taking over the whole window. Grid view still fills the
  window.
- The sidebar gets a fixed Home row at the very top (above the chief of
  staff and "Your turn"), bound to ⌘⇧H, highlighted while you're on it.
  The stale "WORKSPACES" heading and its dead ⌘G hint are gone.
- With the agent queue on, home leads with the turns you owe (oldest
  first, with each turn's age) and files everything else under
  *Settled*, still grouped by what it's doing. Previously it grouped
  purely by state, so agents you'd already settled kept being announced
  as waiting on you.
- Settling the last turn you owed used to leave you sitting on that same
  agent with nowhere further to go. It now lands you on home, which
  leads with an "All settled" banner plus a line on what's still
  running. Nothing jumps in on its own — the next turn waits in the
  queue until you go get it.

Plan doc: `docs/plans/2026-07-29-attn-home-dashboard.md`.

**2. Daemon fix: undocking the last tile of a workspace now tears it down.**

Closing the last notebook, markdown, or browser tile in a workspace with
no agents left the workspace stuck in the sidebar — every layout command
rejects a leafless layout, so the workspace's own × could never actually
close it. Undocking the last tile now tears the workspace down instead
of saving an unusable layout. Workspaces stranded by the old behavior
are cleaned up the next time the app starts.

New test: `TestUndockingLastTileTearsDownSessionlessWorkspace` in
`internal/daemon/workspace_tile_lifecycle_test.go`.

No protocol change.

## Test plan

- [x] `go build ./...`, `go vet ./...` — clean
- [x] `go test ./internal/daemon/...` — green (one unrelated pre-existing
      flake in `TestCreateDelegatedTicketFallsBackPastSequentialRange`,
      confirmed passing on rerun and untouched by this diff)
- [x] `pnpm test` — 2136/2136 passing
- [x] `npx tsc --noEmit` — clean
- [x] Both pieces live-verified on the dev profile prior to this PR