### PR TITLE
Improve agent discoverability of wire-command dispatch and daemon-event routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,28 @@ See [docs/plans/2026-07-18-db-loss-mitigation.md](docs/plans/2026-07-18-db-loss-
 - `internal/transcript`: assistant-message extraction from JSONL
 - `app`: Tauri frontend; WebSocket `ws://localhost:9849`
 
+Frontend map (`app/src`) — `app/CLAUDE.md` covers components and test patterns;
+this is where daemon traffic lands:
+
+- `hooks/useDaemonSocket.ts`: the socket. Connection, reconnect/circuit breaker,
+  the event switch, and every `send*` command. Its return value is the frontend's
+  entire daemon API, threaded through `App` → `AppContent` → `DaemonProvider`.
+- `hooks/daemonPendingRequests.ts`: request/result correlation. A fallible
+  command parks its promise under `<kind>:<requestId>` until the matching
+  `*_result` event lands. `settlePendingRequest` is the typed way in.
+- `hooks/daemon<Domain>Events.ts` (`Fs`, `Notebook`, `MarkdownAnnotation`):
+  per-domain event bodies lifted out of the switch, reached from its `default`.
+  Grep a wire name (`fs_write_result`) to find the module that owns it. Adding a
+  domain means a new module plus one line in that `default` chain.
+- `hooks/daemonMarkdownAnnotationEvents.ts` uses a *second* correlation scheme —
+  keyed `<op>:<workspaceId>:<path>`, last-writer-wins, `request_id`-checked — so
+  annotation drafts supersede rather than queue. Do not route it through
+  `daemonPendingRequests`.
+- `store/daemonSessions.ts`: Zustand store for session/PR state.
+- `pty/`: transport, attach planning, binary frame decode, runtime lifecycle.
+- Tests are topic-suffixed: `Source.concern.test.tsx`. Keep that — the suffix
+  names the behavior, and the set of suffixes maps a large file's seams.
+
 States: `launching`, `working`, `pending_approval`, `waiting_input`, `idle`,
 `unknown`, `scheduled`, `recoverable`. A turn opens when a session reaches a
 state that wants the user (`internal/attention`) and closes only when the user

--- a/app/src/hooks/daemonFsEvents.ts
+++ b/app/src/hooks/daemonFsEvents.ts
@@ -1,0 +1,159 @@
+/**
+ * Filesystem daemon events: `fs_changed` and the `fs_*_result` answers to the
+ * filesystem commands the notebook, the markdown opener, and the file pickers
+ * issue. Kept out of `useDaemonSocket.ts` so that grepping an `fs_` wire name
+ * lands in a file about the filesystem rather than in the socket hook.
+ *
+ * The hook still owns the transport; this module owns the event bodies.
+ */
+
+import type { PendingRequests } from './daemonPendingRequests';
+import { settlePendingRequest } from './daemonPendingRequests';
+
+/** The event shapes this module reads, loosely typed off the wire union. */
+type FsEvent = {
+  event: string;
+  request_id?: unknown;
+  success?: boolean;
+  error?: string;
+  origin?: unknown;
+  paths?: unknown;
+  root?: unknown;
+  files?: unknown;
+  truncated?: unknown;
+  entries?: unknown;
+  result?: Record<string, unknown>;
+};
+
+/** What the fs handlers need from the hook: the waiters and the fs-change callback. */
+export interface FsEventContext {
+  pending: PendingRequests;
+  onFsChanged?: (origin: string, paths: string[], root: string) => void;
+}
+
+/**
+ * Handle one filesystem event. Returns false when the event is not one of ours,
+ * so the caller can keep its own dispatch exhaustive.
+ */
+export function handleFsDaemonEvent(event: FsEvent, ctx: FsEventContext): boolean {
+  const { pending } = ctx;
+  switch (event.event) {
+    case 'fs_changed':
+      ctx.onFsChanged?.(
+        typeof event.origin === 'string' ? event.origin : '',
+        Array.isArray(event.paths) ? event.paths : [],
+        typeof event.root === 'string' ? event.root : '',
+      );
+      return true;
+
+    case 'fs_list_result':
+      settlePendingRequest(
+        pending,
+        'fs_list',
+        event,
+        // The wire says is_dir; the public FsEntry shape says isDir.
+        (e) =>
+          ((e.entries || []) as Array<{
+            path: string;
+            name: string;
+            is_dir?: boolean;
+            size?: number;
+            modified?: string;
+          }>).map((entry) => ({
+            path: entry.path,
+            name: entry.name,
+            isDir: !!entry.is_dir,
+            size: typeof entry.size === 'number' ? entry.size : 0,
+            modified: entry.modified,
+          })),
+        'Filesystem list failed',
+      );
+      return true;
+
+    case 'fs_read_result':
+      settlePendingRequest(pending, 'fs_read', event, (e) => e.result, 'Filesystem read failed');
+      return true;
+
+    case 'fs_read_asset_result':
+      settlePendingRequest(
+        pending,
+        'fs_read_asset',
+        event,
+        (e) =>
+          e.result && {
+            path: e.result.path,
+            mimeType: e.result.mime_type,
+            dataBase64: e.result.data_base64,
+          },
+        'Filesystem asset read failed',
+      );
+      return true;
+
+    case 'fs_write_result':
+      settlePendingRequest(
+        pending,
+        'fs_write',
+        event,
+        // A conflict is a SUCCESSFUL result the editor reconciles, not a
+        // rejection — only a transport/daemon error rejects.
+        (e) =>
+          e.result && {
+            path: e.result.path,
+            hash: e.result.hash,
+            conflict: !!e.result.conflict,
+            currentHash: e.result.current_hash,
+          },
+        'Filesystem write failed',
+      );
+      return true;
+
+    case 'fs_rename_result':
+    case 'fs_delete_result':
+      settlePendingRequest(
+        pending,
+        event.event === 'fs_rename_result' ? 'fs_rename' : 'fs_delete',
+        event,
+        (e) => e.result,
+        'Filesystem action failed',
+      );
+      return true;
+
+    case 'fs_exists_result':
+      settlePendingRequest(
+        pending,
+        'fs_exists',
+        event,
+        (e) => e.result && { path: e.result.path, exists: !!e.result.exists },
+        'Filesystem exists check failed',
+      );
+      return true;
+
+    case 'fs_watch_result':
+    case 'fs_unwatch_result':
+      settlePendingRequest(
+        pending,
+        event.event === 'fs_watch_result' ? 'fs_watch' : 'fs_unwatch',
+        event,
+        (e) => (typeof e.root === 'string' && e.root ? { root: e.root } : undefined),
+        'Filesystem watch action failed',
+      );
+      return true;
+
+    case 'fs_index_result':
+      settlePendingRequest(
+        pending,
+        'fs_index',
+        event,
+        (e) => ({
+          root: e.root,
+          files: e.files || [],
+          truncated: !!e.truncated,
+        }),
+        'Filesystem index failed',
+      );
+      return true;
+
+    default:
+      return false;
+  }
+}

--- a/app/src/hooks/daemonMarkdownAnnotationEvents.ts
+++ b/app/src/hooks/daemonMarkdownAnnotationEvents.ts
@@ -1,0 +1,116 @@
+/**
+ * Markdown-annotation daemon events (`markdown_annotations_*_result`).
+ *
+ * These do NOT use the shared `<kind>:<requestId>` correlation in
+ * daemonPendingRequests.ts. Annotation commands are per-document and
+ * last-writer-wins: the waiter is keyed `<op>:<workspaceId>:<path>` so a newer
+ * request supersedes an older one for the same document, and the event's
+ * `request_id` is checked against the stored one to drop a late result whose
+ * request was already replaced. Two correlation schemes in one hook was a large
+ * part of why the events were hard to follow; naming this one is the point of
+ * the module.
+ */
+
+/** The waiter an annotation command parks, keyed by `markdownAnnotationKey`. */
+export interface PendingMarkdownAnnotation {
+  requestId: string;
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+}
+
+export type PendingMarkdownAnnotations = Map<string, PendingMarkdownAnnotation>;
+
+/** `<op>:<workspaceId>:<path>` — one in-flight request per document per op. */
+export function markdownAnnotationKey(op: string, workspaceId: string, path: string): string {
+  return `${op}:${workspaceId}:${path}`;
+}
+
+/** The event shapes this module reads, loosely typed off the wire union. */
+type MarkdownAnnotationEvent = {
+  event: string;
+  request_id?: unknown;
+  workspace_id?: unknown;
+  path?: unknown;
+  success?: boolean;
+  error?: string;
+  stale?: unknown;
+  status?: unknown;
+  generation?: unknown;
+  annotations?: unknown;
+};
+
+/**
+ * Handle one markdown-annotation event. Returns false when the event is not one
+ * of ours, so the caller can keep its own dispatch exhaustive.
+ */
+export function handleMarkdownAnnotationDaemonEvent(
+  event: MarkdownAnnotationEvent,
+  pending: PendingMarkdownAnnotations,
+): boolean {
+  switch (event.event) {
+    case 'markdown_annotations_get_result':
+    case 'markdown_annotations_save_result':
+    case 'markdown_annotations_clear_result': {
+      const op =
+        event.event === 'markdown_annotations_get_result'
+          ? 'get'
+          : event.event === 'markdown_annotations_save_result'
+            ? 'save'
+            : 'clear';
+      const key = markdownAnnotationKey(op, String(event.workspace_id ?? ''), String(event.path));
+      const waiter = pending.get(key);
+      if (!waiter || waiter.requestId !== event.request_id) {
+        return true; // superseded or timed out — drop the late result
+      }
+      pending.delete(key);
+      if (op === 'save' && !event.success && event.stale) {
+        // Stale generation (tombstone / newer writer) is a protocol outcome the
+        // client handles, not an error.
+        waiter.resolve({ stale: true });
+      } else if (!event.success) {
+        waiter.reject(new Error(event.error || `markdown_annotations_${op} failed`));
+      } else if (op === 'get') {
+        waiter.resolve({
+          annotations: Array.isArray(event.annotations) ? event.annotations : [],
+          generation: typeof event.generation === 'number' ? event.generation : 0,
+        });
+      } else if (op === 'save') {
+        waiter.resolve({ stale: false });
+      } else {
+        waiter.resolve({
+          generation: typeof event.generation === 'number' ? event.generation : 0,
+        });
+      }
+      return true;
+    }
+
+    case 'markdown_annotations_submit_result': {
+      // Submit routes by target session, not workspace; the send side keys its
+      // pending entry with workspaceId '' so mirror that here (the daemon echoes
+      // workspace_id '' or omits it).
+      const key = markdownAnnotationKey('submit', String(event.workspace_id ?? ''), String(event.path));
+      const waiter = pending.get(key);
+      if (!waiter || waiter.requestId !== event.request_id) {
+        return true; // superseded or timed out — drop the late result
+      }
+      pending.delete(key);
+      if (event.success || event.status === 'skipped_pending_approval') {
+        // skipped_pending_approval resolves (success:false) so the UI can
+        // message it distinctly from a hard failure; a delivered result may
+        // still carry `error` (delivery succeeded, draft clear failed) — never
+        // re-deliver in that case.
+        waiter.resolve({
+          status: typeof event.status === 'string' && event.status !== '' ? event.status : 'delivered',
+          ...(typeof event.generation === 'number' ? { generation: event.generation } : {}),
+          ...(typeof event.error === 'string' && event.error !== '' ? { error: event.error } : {}),
+        });
+      } else {
+        waiter.reject(new Error(event.error || 'markdown_annotations_submit failed'));
+      }
+      return true;
+    }
+
+    default:
+      return false;
+  }
+}

--- a/app/src/hooks/daemonNotebookEvents.ts
+++ b/app/src/hooks/daemonNotebookEvents.ts
@@ -1,0 +1,91 @@
+/**
+ * Notebook daemon events: `notebook_changed` and the `notebook_*_result` answers
+ * to the notebook read/write/list commands. Kept out of `useDaemonSocket.ts` so
+ * that grepping a `notebook_` wire name lands in a file about the notebook.
+ *
+ * See docs/glossary.md for what the notebook is; this module only moves its
+ * events between the socket and the waiting promise.
+ */
+
+import type { PendingRequests } from './daemonPendingRequests';
+import { settlePendingRequest } from './daemonPendingRequests';
+
+/** The event shapes this module reads, loosely typed off the wire union. */
+type NotebookEvent = {
+  event: string;
+  request_id?: unknown;
+  success?: boolean;
+  error?: string;
+  origin?: unknown;
+  paths?: unknown;
+  entries?: unknown;
+  result?: Record<string, unknown>;
+};
+
+/** What the notebook handlers need from the hook. */
+export interface NotebookEventContext {
+  pending: PendingRequests;
+  onNotebookChanged?: (origin: string, paths: string[]) => void;
+}
+
+/**
+ * Handle one notebook event. Returns false when the event is not one of ours,
+ * so the caller can keep its own dispatch exhaustive.
+ */
+export function handleNotebookDaemonEvent(event: NotebookEvent, ctx: NotebookEventContext): boolean {
+  const { pending } = ctx;
+  switch (event.event) {
+    case 'notebook_changed':
+      ctx.onNotebookChanged?.(
+        typeof event.origin === 'string' ? event.origin : '',
+        Array.isArray(event.paths) ? event.paths : [],
+      );
+      return true;
+
+    case 'notebook_list_result':
+    case 'notebook_backlinks_result':
+      settlePendingRequest(
+        pending,
+        event.event === 'notebook_list_result' ? 'notebook_list' : 'notebook_backlinks',
+        event,
+        (e) => e.entries || [],
+        'Notebook request failed',
+      );
+      return true;
+
+    case 'notebook_read_result':
+      settlePendingRequest(pending, 'notebook_read', event, (e) => e.result, 'Notebook read failed');
+      return true;
+
+    case 'notebook_write_result':
+      settlePendingRequest(
+        pending,
+        'notebook_write',
+        event,
+        // A conflict is a SUCCESSFUL result the editor reconciles, not a
+        // rejection — only a transport/daemon error rejects.
+        (e) =>
+          e.result && {
+            path: e.result.path,
+            hash: e.result.hash,
+            conflict: !!e.result.conflict,
+            currentHash: e.result.current_hash,
+          },
+        'Notebook write failed',
+      );
+      return true;
+
+    case 'notebook_send_to_chief_result':
+      settlePendingRequest(
+        pending,
+        'notebook_send_to_chief',
+        event,
+        (e) => e.result && { path: e.result.path, nudged: !!e.result.nudged },
+        'Send to chief failed',
+      );
+      return true;
+
+    default:
+      return false;
+  }
+}

--- a/app/src/hooks/daemonPendingRequests.ts
+++ b/app/src/hooks/daemonPendingRequests.ts
@@ -1,0 +1,76 @@
+/**
+ * Request/result correlation for daemon commands.
+ *
+ * A fallible daemon command carries a `request_id`; the daemon answers with a
+ * `<command>_result` event carrying the same id. The frontend parks the
+ * promise's resolve/reject under `<kind>:<requestId>` until that event lands.
+ * That key format is the whole protocol, and until this module existed it was
+ * spelled out inline at every one of ~115 call sites with no name to search for.
+ *
+ * See "WebSocket and state" in AGENTS.md.
+ */
+
+/**
+ * The parked half of a command's promise, keyed by `pendingRequestKey`.
+ *
+ * One map holds resolvers for every command, so `resolve` is unavoidably
+ * untyped here — TypeScript has no existential type to say "some T, and the
+ * waiter and the settler agree on it". `settlePendingRequest` is the typed
+ * entry point; prefer it over reaching into the map.
+ */
+export interface PendingRequest {
+  resolve: (result: any) => void;
+  reject: (error: Error) => void;
+}
+
+export type PendingRequests = Map<string, PendingRequest>;
+
+/** `<kind>:<requestId>` — the correlation key both sides of a command agree on. */
+export function pendingRequestKey(kind: string, requestId: string): string {
+  return `${kind}:${requestId}`;
+}
+
+/** The fields every `*_result` event carries, whatever else it adds. */
+interface ResultEvent {
+  request_id?: unknown;
+  success?: boolean;
+  error?: string;
+}
+
+/**
+ * Settle the request a `*_result` event answers.
+ *
+ * Resolves with `extract(event)` when the daemon reports success, rejects with
+ * the daemon's error otherwise, and reports whether a waiter was actually found
+ * — an event whose request already timed out, or that belongs to another client,
+ * is not an error.
+ *
+ * `extract` returning `undefined` counts as failure. Several results are only
+ * meaningful with a payload (`success && data.result`), and a silent
+ * `resolve(undefined)` would hand the caller a shape it never checks for.
+ */
+export function settlePendingRequest<E extends ResultEvent, T>(
+  pending: PendingRequests,
+  kind: string,
+  event: E,
+  extract: (event: E) => T | undefined,
+  failureMessage: string,
+): boolean {
+  const requestId = event.request_id;
+  if (typeof requestId !== 'string') {
+    return false;
+  }
+  const key = pendingRequestKey(kind, requestId);
+  const waiter = pending.get(key);
+  if (!waiter) {
+    return false;
+  }
+  pending.delete(key);
+  const value = event.success ? extract(event) : undefined;
+  if (value === undefined) {
+    waiter.reject(new Error(event.error || failureMessage));
+  } else {
+    waiter.resolve(value);
+  }
+  return true;
+}

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -3027,3 +3027,222 @@ describe('useDaemonSocket ticket request/result', () => {
     unmount();
   });
 });
+
+// The notebook and markdown-annotation events moved out of useDaemonSocket.ts
+// into daemonNotebookEvents.ts and daemonMarkdownAnnotationEvents.ts. Nothing
+// covered them at the time, so the move was unfalsifiable; these exercise the
+// two correlation schemes through the hook's public surface.
+describe('useDaemonSocket notebook and annotation events', () => {
+  let originalWebSocket: typeof WebSocket;
+
+  beforeEach(() => {
+    originalWebSocket = globalThis.WebSocket;
+    FakeWebSocket.instances = [];
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+  });
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket;
+    vi.clearAllMocks();
+  });
+
+  // Take the socket this render created, by index. Grabbing the newest instance
+  // races with a reconnect leaked from an earlier test and hands back a socket
+  // the hook under test never writes to.
+  async function renderAndOpen(extra: Record<string, unknown> = {}) {
+    const before = FakeWebSocket.instances.length;
+    const rendered = renderNotebookHook(extra);
+    await waitFor(() => {
+      expect(FakeWebSocket.instances.length).toBeGreaterThan(before);
+    });
+    const ws = FakeWebSocket.instances[before];
+    await waitFor(() => {
+      expect(ws.readyState).toBe(FakeWebSocket.OPEN);
+    });
+    return { ...rendered, ws };
+  }
+
+  function renderNotebookHook(extra: Record<string, unknown> = {}) {
+    return renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate: vi.fn(),
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        wsUrl: 'ws://localhost:9999/ws',
+        ...extra,
+      }),
+    );
+  }
+
+  function lastSent(ws: FakeWebSocket): { cmd: string; request_id: string; [k: string]: unknown } {
+    return JSON.parse(ws.sent[ws.sent.length - 1]);
+  }
+
+  it('resolves notebook_read with the daemon result', async () => {
+    const { result, unmount, ws } = await renderAndOpen();
+
+    const promise = result.current.sendNotebookRead('journal/2026-08-01.md');
+    await Promise.resolve();
+    const sent = lastSent(ws);
+    expect(sent).toMatchObject({ cmd: 'notebook_read', path: 'journal/2026-08-01.md' });
+
+    ws.emit({
+      event: 'notebook_read_result',
+      request_id: sent.request_id,
+      success: true,
+      result: { path: 'journal/2026-08-01.md', content: 'today', hash: 'h1' },
+    });
+    await expect(promise).resolves.toEqual({ path: 'journal/2026-08-01.md', content: 'today', hash: 'h1' });
+    unmount();
+  });
+
+  it('rejects notebook_read when the daemon reports success without a result', async () => {
+    const { result, unmount, ws } = await renderAndOpen();
+
+    const promise = result.current.sendNotebookRead('gone.md');
+    await Promise.resolve();
+    ws.emit({ event: 'notebook_read_result', request_id: lastSent(ws).request_id, success: true });
+
+    await expect(promise).rejects.toThrow('Notebook read failed');
+    unmount();
+  });
+
+  it('resolves notebook_write on a conflict rather than rejecting', async () => {
+    const { result, unmount, ws } = await renderAndOpen();
+
+    const promise = result.current.sendNotebookWrite('a.md', 'v2', 'h1');
+    await Promise.resolve();
+    const sent = lastSent(ws);
+    expect(sent).toMatchObject({ cmd: 'notebook_write', path: 'a.md' });
+
+    ws.emit({
+      event: 'notebook_write_result',
+      request_id: sent.request_id,
+      success: true,
+      result: { path: 'a.md', hash: 'h2', conflict: true, current_hash: 'h3' },
+    });
+    await expect(promise).resolves.toEqual({ path: 'a.md', hash: 'h2', conflict: true, currentHash: 'h3' });
+    unmount();
+  });
+
+  it('resolves notebook_list and notebook_backlinks from their own pending keys', async () => {
+    const { result, unmount, ws } = await renderAndOpen();
+
+    const list = result.current.sendNotebookList('journal');
+    await Promise.resolve();
+    const listSent = lastSent(ws);
+    const backlinks = result.current.sendNotebookBacklinks('journal/a.md');
+    await Promise.resolve();
+    const backlinksSent = lastSent(ws);
+    expect(listSent.cmd).toBe('notebook_list');
+    expect(backlinksSent.cmd).toBe('notebook_backlinks');
+
+    // Answer out of order: each result must find its own waiter.
+    ws.emit({ event: 'notebook_backlinks_result', request_id: backlinksSent.request_id, success: true, entries: [{ path: 'b.md' }] });
+    ws.emit({ event: 'notebook_list_result', request_id: listSent.request_id, success: true, entries: [{ path: 'a.md' }] });
+
+    await expect(backlinks).resolves.toEqual([{ path: 'b.md' }]);
+    await expect(list).resolves.toEqual([{ path: 'a.md' }]);
+    unmount();
+  });
+
+  it('resolves markdown annotation get with annotations and generation', async () => {
+    const { result, unmount, ws } = await renderAndOpen();
+
+    const promise = result.current.getMarkdownAnnotations('doc.md', 'ws-1');
+    await Promise.resolve();
+    const sent = lastSent(ws);
+    expect(sent).toMatchObject({ cmd: 'markdown_annotations_get', path: 'doc.md', workspace_id: 'ws-1' });
+
+    ws.emit({
+      event: 'markdown_annotations_get_result',
+      request_id: sent.request_id,
+      workspace_id: 'ws-1',
+      path: 'doc.md',
+      success: true,
+      annotations: [{ id: 'a1' }],
+      generation: 7,
+    });
+    await expect(promise).resolves.toEqual({ annotations: [{ id: 'a1' }], generation: 7 });
+    unmount();
+  });
+
+  it('treats a stale save as a resolved outcome, not an error', async () => {
+    const { result, unmount, ws } = await renderAndOpen();
+
+    const promise = result.current.saveMarkdownAnnotations('doc.md', 'ws-1', [], 3);
+    await Promise.resolve();
+    const sent = lastSent(ws);
+
+    ws.emit({
+      event: 'markdown_annotations_save_result',
+      request_id: sent.request_id,
+      workspace_id: 'ws-1',
+      path: 'doc.md',
+      success: false,
+      stale: true,
+    });
+    await expect(promise).resolves.toEqual({ stale: true });
+    unmount();
+  });
+
+  it('drops an annotation result whose request was superseded', async () => {
+    const { result, unmount, ws } = await renderAndOpen();
+
+    // `get` deliberately shares one in-flight round-trip per document, so
+    // supersede is exercised through `save`, which does replace its waiter.
+    const first = result.current.saveMarkdownAnnotations('doc.md', 'ws-1', [], 1);
+    await Promise.resolve();
+    const firstSent = lastSent(ws);
+    const second = result.current.saveMarkdownAnnotations('doc.md', 'ws-1', [], 2);
+    await Promise.resolve();
+    const secondSent = lastSent(ws);
+    expect(firstSent.request_id).not.toBe(secondSent.request_id);
+    await expect(first).rejects.toThrow('Superseded by a newer request');
+
+    // The late answer to the superseded request must not settle the live one.
+    ws.emit({
+      event: 'markdown_annotations_save_result',
+      request_id: firstSent.request_id,
+      workspace_id: 'ws-1',
+      path: 'doc.md',
+      success: false,
+      stale: true,
+    });
+    ws.emit({
+      event: 'markdown_annotations_save_result',
+      request_id: secondSent.request_id,
+      workspace_id: 'ws-1',
+      path: 'doc.md',
+      success: true,
+    });
+    await expect(second).resolves.toEqual({ stale: false });
+    unmount();
+  });
+
+  it('shares one in-flight round-trip when the same document is hydrated twice', async () => {
+    const { result, unmount, ws } = await renderAndOpen();
+
+    const first = result.current.getMarkdownAnnotations('doc.md', 'ws-1');
+    await Promise.resolve();
+    const sent = lastSent(ws);
+    const second = result.current.getMarkdownAnnotations('doc.md', 'ws-1');
+    await Promise.resolve();
+    // No second command: a rejected hydrate would lock that tile's saves.
+    expect(lastSent(ws).request_id).toBe(sent.request_id);
+
+    ws.emit({
+      event: 'markdown_annotations_get_result',
+      request_id: sent.request_id,
+      workspace_id: 'ws-1',
+      path: 'doc.md',
+      success: true,
+      annotations: [{ id: 'a1' }],
+      generation: 4,
+    });
+    await expect(first).resolves.toEqual({ annotations: [{ id: 'a1' }], generation: 4 });
+    await expect(second).resolves.toEqual({ annotations: [{ id: 'a1' }], generation: 4 });
+    unmount();
+  });
+});

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -61,6 +61,14 @@ import { recordDiag, recordLayout } from '../utils/terminalDiagnosticsLog';
 import { recordPtyCommand, recordWsBinaryPtyOutput, recordWsJsonParse } from '../utils/ptyPerf';
 import { decodeBinaryPtyFrame } from '../pty/binaryPtyFrame';
 import { resolveDaemonWebSocketURL, type DaemonEndpointProfile } from '../utils/daemonEndpoint';
+import { handleFsDaemonEvent } from './daemonFsEvents';
+import { handleNotebookDaemonEvent } from './daemonNotebookEvents';
+import {
+  handleMarkdownAnnotationDaemonEvent,
+  markdownAnnotationKey,
+  type PendingMarkdownAnnotations,
+} from './daemonMarkdownAnnotationEvents';
+import { pendingRequestKey, type PendingRequests } from './daemonPendingRequests';
 import { BUILD_PROFILE, daemonProfileMatches, fetchDaemonHealthProfile, profileMismatchMessage } from '../utils/buildProfile';
 import { controlBrowserHost, serializeBrowserControlResultMessage } from '../browser/host';
 import { useWorkflowRunsStore } from '../store/workflowRuns';
@@ -862,14 +870,12 @@ export function useDaemonSocket({
   };
   const reconnectTimeoutRef = useRef<number | null>(null);
   const reconnectDelayRef = useRef<number>(1000); // Start with 1s, exponential backoff
-  const pendingActionsRef = useRef<Map<string, { resolve: (result: any) => void; reject: (error: Error) => void }>>(new Map());
-  // Markdown-annotation drafts: keyed `<op>:<path>`, request_id-correlated
-  // (see sendMarkdownAnnotationsCommand).
-  const mdAnnotationsPendingRef = useRef<Map<string, {
-    requestId: string;
-    resolve: (value: unknown) => void;
-    reject: (error: Error) => void;
-  }>>(new Map());
+  // Keyed `<kind>:<requestId>` — see daemonPendingRequests.ts for the format and
+  // the settle helper the extracted event modules use.
+  const pendingActionsRef = useRef<PendingRequests>(new Map());
+  // Markdown-annotation drafts use their own last-writer-wins correlation —
+  // see daemonMarkdownAnnotationEvents.ts, not daemonPendingRequests.ts.
+  const mdAnnotationsPendingRef = useRef<PendingMarkdownAnnotations>(new Map());
   // In-flight `get` promises shared per path: two tiles hydrating the same
   // document must share one round-trip, not supersede-reject each other
   // (a rejected hydrate would leave that tile's saves locked until retry).
@@ -1552,13 +1558,6 @@ export function useDaemonSocket({
             break;
           }
 
-          case 'notebook_changed':
-            callbacksRef.current.onNotebookChanged?.(
-              typeof data.origin === 'string' ? data.origin : '',
-              Array.isArray(data.paths) ? data.paths : [],
-            );
-            break;
-
           case 'tasks_changed':
             // Payload-free broadcast: an open Tasks panel refetches the list so it
             // reflects the runner's truth (no optimistic mutation here).
@@ -1572,49 +1571,6 @@ export function useDaemonSocket({
               typeof data.unread_count === 'number' ? data.unread_count : 0,
             );
             break;
-
-          case 'fs_changed':
-            callbacksRef.current.onFsChanged?.(
-              typeof data.origin === 'string' ? data.origin : '',
-              Array.isArray(data.paths) ? data.paths : [],
-              typeof data.root === 'string' ? data.root : '',
-            );
-            break;
-
-          case 'fs_list_result': {
-            const requestId = data.request_id;
-            if (typeof requestId !== 'string') {
-              break;
-            }
-            const key = `fs_list:${requestId}`;
-            const pending = pendingActionsRef.current.get(key);
-            if (!pending) {
-              break;
-            }
-            pendingActionsRef.current.delete(key);
-            if (data.success) {
-              // Convert the wire's is_dir to the camelCase public FsEntry shape.
-              const rawEntries = (data.entries || []) as Array<{
-                path: string;
-                name: string;
-                is_dir?: boolean;
-                size?: number;
-                modified?: string;
-              }>;
-              pending.resolve(
-                rawEntries.map((e) => ({
-                  path: e.path,
-                  name: e.name,
-                  isDir: !!e.is_dir,
-                  size: typeof e.size === 'number' ? e.size : 0,
-                  modified: e.modified,
-                })),
-              );
-            } else {
-              pending.reject(new Error(data.error || 'Filesystem list failed'));
-            }
-            break;
-          }
 
           case 'open_markdown_result': {
             const requestId = data.request_id;
@@ -1631,134 +1587,6 @@ export function useDaemonSocket({
               pending.resolve({ workspaceId: data.workspace_id, tileId: data.tile_id });
             } else {
               pending.reject(new Error(data.error || 'Open markdown failed'));
-            }
-            break;
-          }
-
-          case 'fs_read_result': {
-            const requestId = data.request_id;
-            if (typeof requestId !== 'string') {
-              break;
-            }
-            const key = `fs_read:${requestId}`;
-            const pending = pendingActionsRef.current.get(key);
-            if (!pending) {
-              break;
-            }
-            pendingActionsRef.current.delete(key);
-            if (data.success && data.result) {
-              pending.resolve(data.result);
-            } else {
-              pending.reject(new Error(data.error || 'Filesystem read failed'));
-            }
-            break;
-          }
-
-          case 'fs_read_asset_result': {
-            const requestId = data.request_id;
-            if (typeof requestId !== 'string') {
-              break;
-            }
-            const key = `fs_read_asset:${requestId}`;
-            const pending = pendingActionsRef.current.get(key);
-            if (!pending) {
-              break;
-            }
-            pendingActionsRef.current.delete(key);
-            if (data.success && data.result) {
-              pending.resolve({
-                path: data.result.path,
-                mimeType: data.result.mime_type,
-                dataBase64: data.result.data_base64,
-              });
-            } else {
-              pending.reject(new Error(data.error || 'Filesystem asset read failed'));
-            }
-            break;
-          }
-
-          case 'fs_write_result': {
-            const requestId = data.request_id;
-            if (typeof requestId !== 'string') {
-              break;
-            }
-            const key = `fs_write:${requestId}`;
-            const pending = pendingActionsRef.current.get(key);
-            if (!pending) {
-              break;
-            }
-            pendingActionsRef.current.delete(key);
-            if (data.success && data.result) {
-              // A conflict is a SUCCESSFUL result the editor reconciles, not a
-              // rejection — only a transport/daemon error rejects.
-              pending.resolve({
-                path: data.result.path,
-                hash: data.result.hash,
-                conflict: !!data.result.conflict,
-                currentHash: data.result.current_hash,
-              });
-            } else {
-              pending.reject(new Error(data.error || 'Filesystem write failed'));
-            }
-            break;
-          }
-
-          case 'fs_rename_result':
-          case 'fs_delete_result': {
-            const requestId = data.request_id;
-            if (typeof requestId !== 'string') break;
-            const prefix = data.event === 'fs_rename_result' ? 'fs_rename' : 'fs_delete';
-            const key = `${prefix}:${requestId}`;
-            const pending = pendingActionsRef.current.get(key);
-            if (!pending) break;
-            pendingActionsRef.current.delete(key);
-            if (data.success && data.result) {
-              pending.resolve(data.result);
-            } else {
-              pending.reject(new Error(data.error || 'Filesystem action failed'));
-            }
-            break;
-          }
-
-          case 'fs_exists_result': {
-            const requestId = data.request_id;
-            if (typeof requestId !== 'string') {
-              break;
-            }
-            const key = `fs_exists:${requestId}`;
-            const pending = pendingActionsRef.current.get(key);
-            if (!pending) {
-              break;
-            }
-            pendingActionsRef.current.delete(key);
-            if (data.success && data.result) {
-              pending.resolve({
-                path: data.result.path,
-                exists: !!data.result.exists,
-              });
-            } else {
-              pending.reject(new Error(data.error || 'Filesystem exists check failed'));
-            }
-            break;
-          }
-
-          case 'fs_watch_result':
-          case 'fs_unwatch_result': {
-            const requestId = data.request_id;
-            if (typeof requestId !== 'string') {
-              break;
-            }
-            const prefix = data.event === 'fs_watch_result' ? 'fs_watch' : 'fs_unwatch';
-            const key = `${prefix}:${requestId}`;
-            const pending = pendingActionsRef.current.get(key);
-            if (!pending) {
-              break;
-            }
-            pendingActionsRef.current.delete(key);
-            if (data.success && data.root) {
-              pending.resolve({ root: data.root });
-            } else {
-              pending.reject(new Error(data.error || 'Filesystem watch action failed'));
             }
             break;
           }
@@ -1784,69 +1612,6 @@ export function useDaemonSocket({
               })));
             } else {
               pending.reject(new Error(data.error || 'Recent files failed'));
-            }
-            break;
-          }
-
-          case 'fs_index_result': {
-            const requestId = data.request_id;
-            if (typeof requestId !== 'string') {
-              break;
-            }
-            const key = `fs_index:${requestId}`;
-            const pending = pendingActionsRef.current.get(key);
-            if (!pending) {
-              break;
-            }
-            pendingActionsRef.current.delete(key);
-            if (data.success) {
-              pending.resolve({
-                root: data.root,
-                files: data.files || [],
-                truncated: !!data.truncated,
-              });
-            } else {
-              pending.reject(new Error(data.error || 'Filesystem index failed'));
-            }
-            break;
-          }
-
-          case 'notebook_list_result':
-          case 'notebook_backlinks_result': {
-            const requestId = data.request_id;
-            if (typeof requestId !== 'string') {
-              break;
-            }
-            const prefix = data.event === 'notebook_list_result' ? 'notebook_list' : 'notebook_backlinks';
-            const key = `${prefix}:${requestId}`;
-            const pending = pendingActionsRef.current.get(key);
-            if (!pending) {
-              break;
-            }
-            pendingActionsRef.current.delete(key);
-            if (data.success) {
-              pending.resolve(data.entries || []);
-            } else {
-              pending.reject(new Error(data.error || 'Notebook request failed'));
-            }
-            break;
-          }
-
-          case 'notebook_read_result': {
-            const requestId = data.request_id;
-            if (typeof requestId !== 'string') {
-              break;
-            }
-            const key = `notebook_read:${requestId}`;
-            const pending = pendingActionsRef.current.get(key);
-            if (!pending) {
-              break;
-            }
-            pendingActionsRef.current.delete(key);
-            if (data.success && data.result) {
-              pending.resolve(data.result);
-            } else {
-              pending.reject(new Error(data.error || 'Notebook read failed'));
             }
             break;
           }
@@ -2003,54 +1768,6 @@ export function useDaemonSocket({
               pending.resolve(typeof data.unread_count === 'number' ? data.unread_count : 0);
             } else {
               pending.reject(new Error(data.error || 'Notification mark-read failed'));
-            }
-            break;
-          }
-
-          case 'notebook_write_result': {
-            const requestId = data.request_id;
-            if (typeof requestId !== 'string') {
-              break;
-            }
-            const key = `notebook_write:${requestId}`;
-            const pending = pendingActionsRef.current.get(key);
-            if (!pending) {
-              break;
-            }
-            pendingActionsRef.current.delete(key);
-            if (data.success && data.result) {
-              // A conflict is a SUCCESSFUL result the editor reconciles, not a
-              // rejection — only a transport/daemon error rejects.
-              pending.resolve({
-                path: data.result.path,
-                hash: data.result.hash,
-                conflict: !!data.result.conflict,
-                currentHash: data.result.current_hash,
-              });
-            } else {
-              pending.reject(new Error(data.error || 'Notebook write failed'));
-            }
-            break;
-          }
-
-          case 'notebook_send_to_chief_result': {
-            const requestId = data.request_id;
-            if (typeof requestId !== 'string') {
-              break;
-            }
-            const key = `notebook_send_to_chief:${requestId}`;
-            const pending = pendingActionsRef.current.get(key);
-            if (!pending) {
-              break;
-            }
-            pendingActionsRef.current.delete(key);
-            if (data.success && data.result) {
-              pending.resolve({
-                path: data.result.path,
-                nudged: !!data.result.nudged,
-              });
-            } else {
-              pending.reject(new Error(data.error || 'Send to chief failed'));
             }
             break;
           }
@@ -2286,67 +2003,6 @@ export function useDaemonSocket({
                   pending.resolve(null);
                 }
               }
-            }
-            break;
-          }
-
-          case 'markdown_annotations_get_result':
-          case 'markdown_annotations_save_result':
-          case 'markdown_annotations_clear_result': {
-            const op = data.event === 'markdown_annotations_get_result'
-              ? 'get'
-              : data.event === 'markdown_annotations_save_result' ? 'save' : 'clear';
-            const key = `${op}:${data.workspace_id ?? ''}:${data.path}`;
-            const pending = mdAnnotationsPendingRef.current.get(key);
-            if (!pending || pending.requestId !== data.request_id) {
-              break; // superseded or timed out — drop the late result
-            }
-            mdAnnotationsPendingRef.current.delete(key);
-            if (op === 'save' && !data.success && data.stale) {
-              // Stale generation (tombstone / newer writer) is a protocol
-              // outcome the client handles, not an error.
-              pending.resolve({ stale: true });
-            } else if (!data.success) {
-              pending.reject(new Error(data.error || `markdown_annotations_${op} failed`));
-            } else if (op === 'get') {
-              pending.resolve({
-                annotations: Array.isArray(data.annotations) ? data.annotations : [],
-                generation: typeof data.generation === 'number' ? data.generation : 0,
-              });
-            } else if (op === 'save') {
-              pending.resolve({ stale: false });
-            } else {
-              pending.resolve({
-                generation: typeof data.generation === 'number' ? data.generation : 0,
-              });
-            }
-            break;
-          }
-
-          case 'markdown_annotations_submit_result': {
-            // Submit routes by target session, not workspace; the send side
-            // keys its pending entry with workspaceId '' so mirror that here
-            // (daemon echoes workspace_id '' or omits it).
-            const key = `submit:${data.workspace_id ?? ''}:${data.path}`;
-            const pending = mdAnnotationsPendingRef.current.get(key);
-            if (!pending || pending.requestId !== data.request_id) {
-              break; // superseded or timed out — drop the late result
-            }
-            mdAnnotationsPendingRef.current.delete(key);
-            if (data.success || data.status === 'skipped_pending_approval') {
-              // skipped_pending_approval resolves (success:false) so the UI
-              // can message it distinctly from a hard failure; a delivered
-              // result may still carry `error` (delivery succeeded, draft
-              // clear failed) — never re-deliver in that case.
-              pending.resolve({
-                status: typeof data.status === 'string' && data.status !== ''
-                  ? data.status
-                  : 'delivered',
-                ...(typeof data.generation === 'number' ? { generation: data.generation } : {}),
-                ...(typeof data.error === 'string' && data.error !== '' ? { error: data.error } : {}),
-              });
-            } else {
-              pending.reject(new Error(data.error || 'markdown_annotations_submit failed'));
             }
             break;
           }
@@ -2933,6 +2589,17 @@ export function useDaemonSocket({
             console.error('[Daemon] Command error:', data.cmd, data.error);
             rejectPendingForCommand(data.cmd, data.error || `Command ${data.cmd || ''} failed`);
             break;
+
+          // Domains that live in their own module. The chain sits in `default`
+          // so the hot cases above (pty_output) never pay for it, and an event
+          // no module claims stays silently ignored, as it was before.
+          default: {
+            const pending = pendingActionsRef.current;
+            if (handleFsDaemonEvent(data, { pending, onFsChanged: callbacksRef.current.onFsChanged })) break;
+            if (handleNotebookDaemonEvent(data, { pending, onNotebookChanged: callbacksRef.current.onNotebookChanged })) break;
+            if (handleMarkdownAnnotationDaemonEvent(data, mdAnnotationsPendingRef.current)) break;
+            break;
+          }
         }
       } catch (err) {
         console.error('[Daemon] Parse error:', err);
@@ -3706,7 +3373,7 @@ export function useDaemonSocket({
       }
       // workspace-scoped: the same path open in two workspaces (possibly on
       // two different endpoints) must not supersede each other's requests.
-      const key = `${op}:${workspaceId}:${path}`;
+      const key = markdownAnnotationKey(op, workspaceId, path);
       const requestId = crypto.randomUUID();
       mdAnnotationsPendingRef.current.get(key)?.reject(new Error('Superseded by a newer request'));
       mdAnnotationsPendingRef.current.set(key, { requestId, resolve: resolve as (value: unknown) => void, reject });
@@ -4437,7 +4104,7 @@ export function useDaemonSocket({
         return;
       }
       const requestId = nextRequestID('notebook_list');
-      const key = `notebook_list:${requestId}`;
+      const key = pendingRequestKey('notebook_list', requestId);
       pendingActionsRef.current.set(key, { resolve, reject });
       ws.send(JSON.stringify({ cmd: 'notebook_list', request_id: requestId, ...(prefix ? { prefix } : {}) }));
       setTimeout(() => {
@@ -4458,7 +4125,7 @@ export function useDaemonSocket({
         return;
       }
       const requestId = nextRequestID('notebook_read');
-      const key = `notebook_read:${requestId}`;
+      const key = pendingRequestKey('notebook_read', requestId);
       pendingActionsRef.current.set(key, { resolve, reject });
       ws.send(JSON.stringify({ cmd: 'notebook_read', request_id: requestId, path }));
       setTimeout(() => {
@@ -4720,7 +4387,7 @@ export function useDaemonSocket({
         return;
       }
       const requestId = nextRequestID('notebook_backlinks');
-      const key = `notebook_backlinks:${requestId}`;
+      const key = pendingRequestKey('notebook_backlinks', requestId);
       pendingActionsRef.current.set(key, { resolve, reject });
       ws.send(JSON.stringify({ cmd: 'notebook_backlinks', request_id: requestId, path }));
       setTimeout(() => {
@@ -4744,7 +4411,7 @@ export function useDaemonSocket({
         return;
       }
       const requestId = nextRequestID('notebook_write');
-      const key = `notebook_write:${requestId}`;
+      const key = pendingRequestKey('notebook_write', requestId);
       pendingActionsRef.current.set(key, { resolve, reject });
       ws.send(JSON.stringify({ cmd: 'notebook_write', request_id: requestId, path, content, ...(baseHash ? { base_hash: baseHash } : {}) }));
       setTimeout(() => {
@@ -4768,7 +4435,7 @@ export function useDaemonSocket({
         return;
       }
       const requestId = nextRequestID('notebook_send_to_chief');
-      const key = `notebook_send_to_chief:${requestId}`;
+      const key = pendingRequestKey('notebook_send_to_chief', requestId);
       pendingActionsRef.current.set(key, { resolve, reject });
       ws.send(JSON.stringify({ cmd: 'notebook_send_to_chief', request_id: requestId, selection, ...(sourcePath ? { source_path: sourcePath } : {}) }));
       setTimeout(() => {
@@ -4791,7 +4458,7 @@ export function useDaemonSocket({
         return;
       }
       const requestId = nextRequestID('fs_list');
-      const key = `fs_list:${requestId}`;
+      const key = pendingRequestKey('fs_list', requestId);
       pendingActionsRef.current.set(key, { resolve, reject });
       ws.send(JSON.stringify({ cmd: 'fs_list', request_id: requestId, ...(path ? { path } : {}), ...(root ? { root } : {}) }));
       setTimeout(() => {
@@ -4812,7 +4479,7 @@ export function useDaemonSocket({
         return;
       }
       const requestId = nextRequestID('fs_read');
-      const key = `fs_read:${requestId}`;
+      const key = pendingRequestKey('fs_read', requestId);
       pendingActionsRef.current.set(key, { resolve, reject });
       ws.send(JSON.stringify({ cmd: 'fs_read', request_id: requestId, path, ...(root ? { root } : {}) }));
       setTimeout(() => {
@@ -4834,7 +4501,7 @@ export function useDaemonSocket({
         return;
       }
       const requestId = nextRequestID('fs_read_asset');
-      const key = `fs_read_asset:${requestId}`;
+      const key = pendingRequestKey('fs_read_asset', requestId);
       pendingActionsRef.current.set(key, { resolve, reject });
       ws.send(JSON.stringify({ cmd: 'fs_read_asset', request_id: requestId, path, ...(root ? { root } : {}) }));
       setTimeout(() => {
@@ -4857,7 +4524,7 @@ export function useDaemonSocket({
         return;
       }
       const requestId = nextRequestID('fs_write');
-      const key = `fs_write:${requestId}`;
+      const key = pendingRequestKey('fs_write', requestId);
       pendingActionsRef.current.set(key, { resolve, reject });
       ws.send(JSON.stringify({ cmd: 'fs_write', request_id: requestId, path, content, ...(baseHash ? { base_hash: baseHash } : {}), ...(root ? { root } : {}) }));
       setTimeout(() => {
@@ -4876,7 +4543,7 @@ export function useDaemonSocket({
       return;
     }
     const requestId = nextRequestID('fs_rename');
-    const key = `fs_rename:${requestId}`;
+    const key = pendingRequestKey('fs_rename', requestId);
     pendingActionsRef.current.set(key, { resolve, reject });
     ws.send(JSON.stringify({ cmd: 'fs_rename', request_id: requestId, path, new_path: newPath, ...(root ? { root } : {}) }));
     setTimeout(() => {
@@ -4894,7 +4561,7 @@ export function useDaemonSocket({
       return;
     }
     const requestId = nextRequestID('fs_delete');
-    const key = `fs_delete:${requestId}`;
+    const key = pendingRequestKey('fs_delete', requestId);
     pendingActionsRef.current.set(key, { resolve, reject });
     ws.send(JSON.stringify({ cmd: 'fs_delete', request_id: requestId, path, ...(root ? { root } : {}) }));
     setTimeout(() => {
@@ -4916,7 +4583,7 @@ export function useDaemonSocket({
         return;
       }
       const requestId = nextRequestID('fs_exists');
-      const key = `fs_exists:${requestId}`;
+      const key = pendingRequestKey('fs_exists', requestId);
       pendingActionsRef.current.set(key, { resolve, reject });
       ws.send(JSON.stringify({ cmd: 'fs_exists', request_id: requestId, path, ...(root ? { root } : {}) }));
       setTimeout(() => {
@@ -4940,7 +4607,7 @@ export function useDaemonSocket({
         return;
       }
       const requestId = nextRequestID('fs_watch');
-      const key = `fs_watch:${requestId}`;
+      const key = pendingRequestKey('fs_watch', requestId);
       pendingActionsRef.current.set(key, { resolve, reject });
       ws.send(JSON.stringify({ cmd: 'fs_watch', request_id: requestId, ...(root ? { root } : {}) }));
       setTimeout(() => {
@@ -4963,7 +4630,7 @@ export function useDaemonSocket({
         return;
       }
       const requestId = nextRequestID('fs_unwatch');
-      const key = `fs_unwatch:${requestId}`;
+      const key = pendingRequestKey('fs_unwatch', requestId);
       pendingActionsRef.current.set(key, { resolve, reject });
       ws.send(JSON.stringify({ cmd: 'fs_unwatch', request_id: requestId, ...(root ? { root } : {}) }));
       setTimeout(() => {
@@ -4988,7 +4655,7 @@ export function useDaemonSocket({
         return;
       }
       const requestId = nextRequestID('fs_index');
-      const key = `fs_index:${requestId}`;
+      const key = pendingRequestKey('fs_index', requestId);
       pendingActionsRef.current.set(key, { resolve, reject });
       ws.send(JSON.stringify({
         cmd: 'fs_index',

--- a/docs/plans/2026-07-25-agent-discoverability.md
+++ b/docs/plans/2026-07-25-agent-discoverability.md
@@ -1,0 +1,241 @@
+# Plan: agent discoverability of the attn codebase
+
+## Goal
+
+Make attn cheaper and more accurate for coding agents to navigate. Agents locate
+code by ripgrep over names, not by semantic analysis, so the cost of a change is
+driven by how many tokens an agent burns before it finds the right definition —
+and by whether it finds the wrong one confidently.
+
+Source: [How Coding Agents Read Your Code](https://modem.dev/blog/how-coding-agents-read-your-code).
+Its two measured results that apply here:
+
+- splitting a 4,943-line monolith into concept-named modules cut token spend
+  ~31–34% for weaker models;
+- on the same four planted bugs with an eight-turn budget, Haiku found 4/8 and
+  Sonnet 3/8 in the monolith, and both found 8/8 after the split.
+
+This is not a naming-convention sweep. attn already scores well on most of the
+article's checklist (see Non-goals). Four specific gaps are worth closing.
+
+## Current state, re-measured 2026-08-01 (on `origin/main` @ b4efe628)
+
+| Surface | Measurement |
+| --- | --- |
+| `app/src/hooks/useDaemonSocket.ts` | 5,869 lines, 134 event cases, 52 exports, 20 `any` |
+| `app/src/App.tsx` | 4,231 lines |
+| Wire strings | 88 of 170 `protocol.Cmd*` wire strings appear nowhere in `internal/daemon` |
+| `AGENTS.md` `app/` coverage | one bullet for ~99k lines of frontend |
+| `internal/daemon/daemon.go` | 3,684 lines, in a package of 108 non-test files |
+
+Already good, and deliberately left alone: concept-named Go packages
+(`internal/pty`, `internal/ptyworker`, `internal/classifier`, `internal/transcript`),
+`internal/daemon` already split by concept (`branch.go`, `browser.go`,
+`delegate.go`, `ws_pty.go`), 177 distinctive `handleXWS` methods, near-zero `any`
+in TS, and topic-suffixed test files (`App.worktreeCleanup.test.tsx`) that name
+the concern rather than just the source file.
+
+## Step 1 — wire-string back-references — DONE 2026-08-01
+
+An agent starting from a `daemon.log` line, a frontend `cmd: "delete_worktree"`,
+or a user report greps the wire string and lands in `constants.go`, `main.tsp`,
+and generated code — never the handler. It must infer `CmdDeleteWorktree` and
+grep again. Two hops on the single most-walked path in the repo.
+
+```text
+Current:
+  rg delete_worktree
+    -> internal/protocol/constants.go        (CmdDeleteWorktree = "delete_worktree")
+    -> internal/protocol/generated.go        (noise)
+    -> internal/protocol/schema/main.tsp     (noise)
+    -> app/src/hooks/useDaemonSocket.ts
+    (handler not in results; infer symbol, grep again)
+
+Now:
+  rg -A1 delete_worktree
+    internal/daemon/websocket.go: case protocol.CmdDeleteWorktree: // wire: delete_worktree
+    internal/daemon/websocket.go-   d.handleDeleteWorktreeWS(client, ...)
+    internal/daemon/daemon.go:    case protocol.CmdDeleteWorktree: // wire: delete_worktree
+    internal/daemon/daemon.go-      d.handleDeleteWorktree(conn, ...)
+```
+
+The annotation went on the **dispatch case**, not on each handler. The switches
+are the routing tables, and the case line sits one line above the handler's name,
+so a single grep result window carries both. It is also uniform: several commands
+dispatch from more than one switch (WebSocket and unix socket), and some cases
+inline their work instead of calling a `handleXWS`, so "annotate the handler" had
+no single meaning.
+
+- [x] `// wire: <cmd>` on all 244 `case protocol.Cmd*:` lines across
+      `websocket.go`, `daemon.go`, and `automations.go`. All 170 wire strings are
+      now greppable in `internal/daemon`; 88 were not.
+- [x] `internal/daemon/wire_dispatch_test.go` enforces it. This is the value of
+      the step — a one-time comment pass decays; an enforced invariant does not.
+  - `TestWireCommandsAreGreppable` — every dispatch case carries its constants'
+    wire names, and every `Cmd*` constant has a dispatch case.
+  - `TestWireCommentsMatchTheirConstants` — a comment naming a *different*
+    command's wire string fails. Drift is worse than absence: it sends the next
+    reader to the wrong handler with full confidence.
+- Each assertion was mutation-checked separately (drop a comment, swap it for
+  another valid wire name, add an undispatched constant); each failed on its own
+  line with the message that names the fix.
+- Not done: the same treatment for `Event*` constants. Events have no dispatch
+  table on the daemon side — they are emitted from wherever the state changes —
+  so there is no equivalent single line to anchor to. Left for a later pass.
+
+## Step 2 — split `useDaemonSocket.ts` — STARTED 2026-08-01, 3 of ~13 domains
+
+Every frontend agent touching anything daemon-adjacent loads 5,897 lines. The
+134 cases already group cleanly by wire-name prefix (measured): workspace 18,
+fs 11, automations 9, notebook 6, session 5, tickets 4, markdown 4, pty 3,
+git 3, worktree 2, workflow 2, presentation 2, endpoints 2, plugins, tasks,
+notifications.
+
+```text
+Current:
+  App.tsx
+    -> useDaemonSocket.ts        (5,897 lines: transport + 134 cases + 53 exports)
+
+Target:
+  App.tsx
+    -> useDaemonSocket.ts        (transport, reconnect, request/result plumbing)
+      -> daemonWorkspaceEvents.ts
+      -> daemonFsEvents.ts
+      -> daemonNotebookEvents.ts
+      -> daemonPtyEvents.ts
+      -> daemonGitPrEvents.ts
+      -> daemonTicketEvents.ts
+      -> daemonAutomationEvents.ts
+```
+
+The plan assumed pure reducers over a `DaemonState`. There is no such state: the
+whole hook is one ~5,000-line function and the case bodies close over 28 refs and
+setters. What the cases actually share is not state — it is a **correlation
+protocol**. 115 of the 134 cases are the same five lines: look up
+`<kind>:<requestId>` in `pendingActionsRef`, delete it, resolve or reject. That
+protocol had no name anywhere in the codebase, which is why the file reads as
+undifferentiated bulk.
+
+So the seam is: name the protocol, then move each domain's event bodies to a
+module that takes only the collaborators it needs.
+
+```text
+useDaemonSocket.ts          transport, reconnect, the switch, every send*
+  daemonPendingRequests.ts  `<kind>:<requestId>` + settlePendingRequest
+  daemonFsEvents.ts         fs_changed + 10 fs_*_result
+  daemonNotebookEvents.ts   notebook_changed + 5 notebook_*_result
+  daemonMarkdownAnnotationEvents.ts
+                            a SECOND correlation scheme: `<op>:<wsId>:<path>`,
+                            last-writer-wins, request_id-checked
+```
+
+Extracted domains are reached from the switch's `default`, so the hot cases
+(`pty_output`) never pay for the chain and an unclaimed event stays ignored,
+exactly as before.
+
+- [x] `daemonPendingRequests.ts` — `pendingRequestKey` + `settlePendingRequest`.
+      Adopted at 16 call sites so far.
+- [x] `daemonFsEvents.ts`, `daemonNotebookEvents.ts`,
+      `daemonMarkdownAnnotationEvents.ts`. 5,869 → 5,536 lines.
+- [x] Public surface unchanged; no consumer touched.
+- [x] Tests for the notebook and annotation paths. They had **none** — the first
+      extraction passed the whole suite vacuously, and only fs failed under
+      mutation. 8 new tests; every extracted case now fails when its wire name is
+      mutated.
+- [ ] Remaining domains: workspace 10, automations 9, session 5, tickets 4,
+      git 3, pty 3, worktrees 2, workflow 2, presentations 2, endpoints 2.
+      Workspace/session/pty are the stateful ones — they belong with the
+      transport unless a clean collaborator set appears.
+- [ ] The other 17 `any`, and the generic `*Result` interface names.
+- [ ] Split `useDaemonSocket.test.tsx` (now 3,190 lines) along the same seams.
+
+## Step 3 — split `App.tsx` (deferred; premise was wrong)
+
+The original argument was that six topic-scoped test files named seams `App.tsx`
+had not yet been split along. Re-measured 2026-08-01, that is no longer true:
+
+```text
+app/src/utils/fsChangeSignals.ts            <- extracted (also owns
+app/src/utils/fsChangeSignals.test.ts          fsIndexToNotebookEntries)
+app/src/utils/fsIndexToNotebookEntries.test.ts
+app/src/utils/presentationNotices.ts        <- extracted
+app/src/components/WorktreeCleanupPrompt.tsx
+
+app/src/App.worktreeCleanup.test.tsx        \  all three render(<App/>) —
+app/src/App.sessionlessWorkspace.test.tsx    > integration tests by design,
+app/src/App.chiefOfStaffClose.test.tsx      /  not orphaned unit tests
+```
+
+Three of the six concerns already have named modules. The three remaining test
+files import `App` and render it whole, so their existence is not evidence of a
+missing module — they are testing composed behavior on purpose.
+
+`App.tsx` is still 4,231 lines and probably still worth splitting, but the seams
+have to be found by reading it, not inferred from test names. Defer until steps
+1 and 2 land and we have a measured token delta to justify the cost.
+
+Same caveat applies to `GhosttyTerminal.tsx` (3,396 lines).
+
+## Step 4 — document the frontend in AGENTS.md — DONE 2026-08-01
+
+- [x] Frontend map in the Architecture section, sized like the Go one: the socket
+      hook and what its return value feeds, the two correlation schemes and which
+      one an annotation command must not use, the `daemon<Domain>Events.ts`
+      convention and how to add one, and the `Source.concern.test.tsx` naming.
+- Written after step 2's first domains landed, so it describes real files. It
+  will need one more pass when the remaining domains move.
+
+## Decisions
+
+- Not renaming domain identifiers. `Session` (709 hits), `State` (707), `Status`
+  (664) look like the article's `create()` problem but are attn's actual domain
+  vocabulary; Go package qualification and the frontend's `Daemon*` prefixes
+  already disambiguate. Renaming is churn with no retrieval win.
+- Step 1 ships an enforcing test, not just comments. A comment pass alone rots
+  within a few PRs and leaves a false signal behind.
+- Step 2's real seam is the request/result correlation protocol, not per-domain
+  state. Naming `<kind>:<requestId>` collapsed most of the 134 cases to one line
+  each; the plan's original "pure reducer over DaemonState" shape does not exist
+  in this hook and would have meant inventing state to refactor toward.
+- A green suite is not evidence that a move was safe. The notebook and annotation
+  events had zero tests, so the first extraction "passed" without executing any
+  of the moved code. Mutating each wire name is what turned that into a signal.
+- Step 2 keeps the `useDaemonSocket` public surface frozen. Splitting the file and
+  changing the API at once makes it impossible to tell a regression from a
+  refactor, and this hook is on the critical path for every session.
+- Step 3 was demoted, not dropped. Its stated evidence (orphan test files) had
+  already been acted on by the time we re-measured; splitting a 4,231-line file
+  on a premise that no longer holds is how a refactor ends up unjustified.
+- `daemon.go` (3,684 lines) is listed but not scheduled. Its siblings were already
+  concept-split; what remains is lifecycle and registration, which is a coherent
+  concern even if large. Revisit only if it keeps accreting.
+
+## Verification, 2026-08-01
+
+- `go test ./internal/daemon/... ./internal/protocol/...` — pass. Each of the
+  three wire-comment assertions mutation-checked separately.
+- `pnpm --dir app test` — 2,134 pass. Each extracted event mutation-checked; five
+  that previously passed vacuously now fail when mutated.
+- `pnpm --dir app run e2e` — 190 pass, 2 fail (`settings.spec.ts:204`,
+  `workspace-sessions.spec.ts:138`). Both pass when re-run on their own, so they
+  are load flakes in a 16-minute suite, not regressions. Neither touches an
+  extracted domain.
+- `make dev` install, dev-profile preflight clean (protocol 200 end to end).
+- Live scenarios on the branch: `markdown-opener`, `notebook-tile-finder`,
+  `notebook-link-nav` (exercises `fs_read_asset_result` via a `..`-relative
+  image), `notebook-tile-close`, `editor-workspace-root`, `present-flow` — all
+  pass.
+- `notebook-editor-undo` fails at `focus_editor_with_native_click`. **Pre-existing**:
+  it fails identically on an `origin/main` worktree built and run the same way.
+  The note's content renders in the tile, so the extracted read path is fine; the
+  CodeMirror pane never takes focus. Not investigated further — out of scope here.
+- Not covered live: markdown annotations. No harness scenario exercises them, and
+  none did before. Covered only by the new unit tests.
+
+## Follow-ups
+
+- Consider re-measuring after step 2: run the same agent task (locate and fix a
+  planted frontend bug) before and after, and record the token delta. Would tell
+  us whether to keep going into `GhosttyTerminal.tsx` and `SettingsModal.tsx`.
+- `internal/store/store.go` (2,228) and `internal/hub/manager.go` (1,806) are the
+  next Go monoliths if the frontend work pays off.

--- a/internal/daemon/automations.go
+++ b/internal/daemon/automations.go
@@ -112,23 +112,23 @@ func (d *Daemon) handleAutomationCommand(conn net.Conn, cmd string, msg any) {
 	ctx := context.Background()
 	var result any
 	switch cmd {
-	case protocol.CmdAutomationApply:
+	case protocol.CmdAutomationApply: // wire: automation_apply
 		result = d.actionAutomationApply(ctx, msg.(*protocol.AutomationApplyMessage))
-	case protocol.CmdAutomationValidate:
+	case protocol.CmdAutomationValidate: // wire: automation_validate
 		result = d.actionAutomationValidate(msg.(*protocol.AutomationValidateMessage))
-	case protocol.CmdAutomationDefinitionsGet:
+	case protocol.CmdAutomationDefinitionsGet: // wire: automation_definitions_get
 		result = d.actionAutomationDefinitionsGet(msg.(*protocol.AutomationDefinitionsGetMessage))
-	case protocol.CmdAutomationDefinitionGet:
+	case protocol.CmdAutomationDefinitionGet: // wire: automation_definition_get
 		result = d.actionAutomationDefinitionGet(msg.(*protocol.AutomationDefinitionGetMessage))
-	case protocol.CmdAutomationRun:
+	case protocol.CmdAutomationRun: // wire: automation_run
 		result = d.actionAutomationRun(ctx, msg.(*protocol.AutomationRunMessage))
-	case protocol.CmdAutomationRunsGet:
+	case protocol.CmdAutomationRunsGet: // wire: automation_runs_get
 		result = d.actionAutomationRunsGet(msg.(*protocol.AutomationRunsGetMessage))
-	case protocol.CmdAutomationSetEnabled:
+	case protocol.CmdAutomationSetEnabled: // wire: automation_set_enabled
 		result = d.actionAutomationSetEnabled(ctx, msg.(*protocol.AutomationSetEnabledMessage))
-	case protocol.CmdAutomationDelete:
+	case protocol.CmdAutomationDelete: // wire: automation_delete
 		result = d.actionAutomationDelete(ctx, msg.(*protocol.AutomationDeleteMessage))
-	case protocol.CmdAutomationCleanup:
+	case protocol.CmdAutomationCleanup: // wire: automation_cleanup
 		result = d.actionAutomationCleanup(ctx, msg.(*protocol.AutomationCleanupMessage))
 	}
 	_ = json.NewEncoder(conn).Encode(result)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2165,143 +2165,146 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 	}
 
 	switch cmd {
-	case protocol.CmdRegister:
+	case protocol.CmdRegister: // wire: register
 		d.handleRegister(conn, msg.(*protocol.RegisterMessage))
-	case protocol.CmdDelegate:
+	case protocol.CmdDelegate: // wire: delegate
 		d.handleDelegate(conn, msg.(*protocol.DelegateMessage))
+	// wire: automation_apply, automation_validate, automation_definitions_get,
+	// automation_definition_get, automation_run, automation_runs_get,
+	// automation_set_enabled, automation_delete, automation_cleanup
 	case protocol.CmdAutomationApply, protocol.CmdAutomationValidate, protocol.CmdAutomationDefinitionsGet, protocol.CmdAutomationDefinitionGet, protocol.CmdAutomationRun, protocol.CmdAutomationRunsGet, protocol.CmdAutomationSetEnabled, protocol.CmdAutomationDelete, protocol.CmdAutomationCleanup:
 		d.handleAutomationCommand(conn, cmd, msg)
-	case protocol.CmdDelegateStatus:
+	case protocol.CmdDelegateStatus: // wire: delegate_status
 		d.handleDelegateStatus(conn, msg.(*protocol.DelegateStatusMessage))
-	case protocol.CmdSetTicketStatus:
+	case protocol.CmdSetTicketStatus: // wire: set_ticket_status
 		d.handleSetTicketStatus(conn, msg.(*protocol.SetTicketStatusMessage))
-	case protocol.CmdTicketInbox:
+	case protocol.CmdTicketInbox: // wire: ticket_inbox
 		d.handleTicketInbox(conn, msg.(*protocol.TicketInboxMessage))
-	case protocol.CmdTicketList:
+	case protocol.CmdTicketList: // wire: ticket_list
 		d.handleTicketList(conn, msg.(*protocol.TicketListMessage))
-	case protocol.CmdTicketShow:
+	case protocol.CmdTicketShow: // wire: ticket_show
 		d.handleTicketShow(conn, msg.(*protocol.TicketShowMessage))
-	case protocol.CmdTicketSubscribe:
+	case protocol.CmdTicketSubscribe: // wire: ticket_subscribe
 		d.handleTicketSubscribe(conn, msg.(*protocol.TicketSubscribeMessage))
-	case protocol.CmdTicketUnsubscribe:
+	case protocol.CmdTicketUnsubscribe: // wire: ticket_unsubscribe
 		d.handleTicketUnsubscribe(conn, msg.(*protocol.TicketUnsubscribeMessage))
-	case protocol.CmdTicketAttach:
+	case protocol.CmdTicketAttach: // wire: ticket_attach
 		d.handleTicketAttach(conn, msg.(*protocol.TicketAttachMessage))
-	case protocol.CmdTicketCreate:
+	case protocol.CmdTicketCreate: // wire: ticket_create
 		d.handleTicketCreate(conn, msg.(*protocol.TicketCreateMessage))
-	case protocol.CmdTicketComment:
+	case protocol.CmdTicketComment: // wire: ticket_comment
 		d.handleTicketComment(conn, msg.(*protocol.TicketCommentMessage))
-	case protocol.CmdPresentOpen:
+	case protocol.CmdPresentOpen: // wire: present_open
 		d.handlePresentOpen(conn, msg.(*protocol.PresentOpenMessage))
-	case protocol.CmdPresentFeedback:
+	case protocol.CmdPresentFeedback: // wire: present_feedback
 		d.handlePresentFeedback(conn, msg.(*protocol.PresentFeedbackMessage))
-	case protocol.CmdTicketTake:
+	case protocol.CmdTicketTake: // wire: ticket_take
 		d.handleTicketTake(conn, msg.(*protocol.TicketTakeMessage))
-	case protocol.CmdWorkspaceContextCheckout:
+	case protocol.CmdWorkspaceContextCheckout: // wire: workspace_context_checkout
 		d.handleWorkspaceContextCheckout(conn, msg.(*protocol.WorkspaceContextCheckoutMessage))
-	case protocol.CmdWorkspaceContextUpdate:
+	case protocol.CmdWorkspaceContextUpdate: // wire: workspace_context_update
 		d.handleWorkspaceContextUpdate(conn, msg.(*protocol.WorkspaceContextUpdateMessage))
-	case protocol.CmdWorkspaceContextStatus:
+	case protocol.CmdWorkspaceContextStatus: // wire: workspace_context_status
 		d.handleWorkspaceContextStatus(conn, msg.(*protocol.WorkspaceContextStatusMessage))
-	case protocol.CmdWorkspaceContextList:
+	case protocol.CmdWorkspaceContextList: // wire: workspace_context_list
 		d.handleWorkspaceContextList(conn)
-	case protocol.CmdWorkspaceContextCompact:
+	case protocol.CmdWorkspaceContextCompact: // wire: workspace_context_compact
 		d.handleWorkspaceContextCompact(conn, msg.(*protocol.WorkspaceContextCompactMessage))
-	case protocol.CmdWorkspaceContextRollback:
+	case protocol.CmdWorkspaceContextRollback: // wire: workspace_context_rollback
 		d.handleWorkspaceContextRollback(conn, msg.(*protocol.WorkspaceContextRollbackMessage))
-	case protocol.CmdNotebookGuide:
+	case protocol.CmdNotebookGuide: // wire: notebook_guide
 		// notebook_guide is the one surviving unix-socket notebook command: the
 		// agent-launch wrapper uses it to learn whether a session is the chief of
 		// staff and where the notebook root is. The former user-facing
 		// `attn notebook …` subcommands were removed; the frontend reads and writes
 		// the notebook over the WebSocket path instead.
 		d.handleNotebookGuide(conn, msg.(*protocol.NotebookGuideMessage))
-	case protocol.CmdJournalAppend:
+	case protocol.CmdJournalAppend: // wire: journal_append
 		// journal_append is the contention-safe way an agent writes the daily
 		// journal: it goes through the daemon's single serialized notebook.Store
 		// writer instead of the agent editing journal/<date>.md directly, which
 		// races the keeper's own writes to the same file.
 		d.handleJournalAppend(conn, msg.(*protocol.JournalAppendMessage))
-	case protocol.CmdUnregister:
+	case protocol.CmdUnregister: // wire: unregister
 		d.handleUnregister(conn, msg.(*protocol.UnregisterMessage))
-	case protocol.CmdState:
+	case protocol.CmdState: // wire: state
 		d.handleState(conn, msg.(*protocol.StateMessage))
-	case protocol.CmdHookNotification:
+	case protocol.CmdHookNotification: // wire: hook_notification
 		d.handleHookNotification(conn, msg.(*protocol.HookNotificationMessage))
-	case protocol.CmdHookStopFailure:
+	case protocol.CmdHookStopFailure: // wire: hook_stop_failure
 		d.handleHookStopFailure(conn, msg.(*protocol.HookStopFailureMessage))
-	case protocol.CmdHookCompaction:
+	case protocol.CmdHookCompaction: // wire: hook_compaction
 		d.handleHookCompaction(conn, msg.(*protocol.HookCompactionMessage))
-	case protocol.CmdSetSessionResumeID:
+	case protocol.CmdSetSessionResumeID: // wire: set_session_resume_id
 		d.handleSetSessionResumeID(conn, msg.(*protocol.SetSessionResumeIDMessage))
-	case protocol.CmdSessionInstructions:
+	case protocol.CmdSessionInstructions: // wire: session_instructions
 		d.handleSessionInstructions(conn, msg.(*protocol.SessionInstructionsMessage))
-	case protocol.CmdSessionTranscript:
+	case protocol.CmdSessionTranscript: // wire: session_transcript
 		d.handleSessionTranscript(conn, msg.(*protocol.SessionTranscriptMessage))
-	case protocol.CmdStateExplain:
+	case protocol.CmdStateExplain: // wire: state_explain
 		d.handleStateExplain(conn, msg.(*protocol.StateExplainMessage))
-	case protocol.CmdStop:
+	case protocol.CmdStop: // wire: stop
 		d.handleStop(conn, msg.(*protocol.StopMessage))
-	case protocol.CmdTodos:
+	case protocol.CmdTodos: // wire: todos
 		d.handleTodos(conn, msg.(*protocol.TodosMessage))
-	case protocol.CmdFilesEdited:
+	case protocol.CmdFilesEdited: // wire: files_edited
 		d.handleFilesEdited(conn, msg.(*protocol.FilesEditedMessage))
-	case protocol.CmdWorkflowRunUpsert:
+	case protocol.CmdWorkflowRunUpsert: // wire: workflow_run_upsert
 		d.handleWorkflowRunUpsert(conn, msg.(*protocol.WorkflowRunUpsertMessage))
-	case protocol.CmdWorkflowCallUpsert:
+	case protocol.CmdWorkflowCallUpsert: // wire: workflow_call_upsert
 		d.handleWorkflowCallUpsert(conn, msg.(*protocol.WorkflowCallUpsertMessage))
-	case protocol.CmdWorkflowRunGet:
+	case protocol.CmdWorkflowRunGet: // wire: workflow_run_get
 		d.handleWorkflowRunGet(conn, msg.(*protocol.WorkflowRunGetMessage))
-	case protocol.CmdWorkflowRunList:
+	case protocol.CmdWorkflowRunList: // wire: workflow_run_list
 		d.handleWorkflowRunList(conn, msg.(*protocol.WorkflowRunListMessage))
-	case protocol.CmdWorkflowRunCancel:
+	case protocol.CmdWorkflowRunCancel: // wire: workflow_run_cancel
 		d.handleWorkflowRunCancel(conn, msg.(*protocol.WorkflowRunCancelMessage))
-	case protocol.CmdQuery:
+	case protocol.CmdQuery: // wire: query
 		d.handleQuery(conn, msg.(*protocol.QueryMessage))
-	case protocol.CmdHeartbeat:
+	case protocol.CmdHeartbeat: // wire: heartbeat
 		d.handleHeartbeat(conn, msg.(*protocol.HeartbeatMessage))
-	case protocol.CmdQueryPRs:
+	case protocol.CmdQueryPRs: // wire: query_prs
 		d.handleQueryPRs(conn, msg.(*protocol.QueryPRsMessage))
-	case protocol.CmdMutePR:
+	case protocol.CmdMutePR: // wire: mute_pr
 		d.handleMutePR(conn, msg.(*protocol.MutePRMessage))
-	case protocol.CmdMuteRepo:
+	case protocol.CmdMuteRepo: // wire: mute_repo
 		d.handleMuteRepo(conn, msg.(*protocol.MuteRepoMessage))
-	case protocol.CmdMuteWorkspace:
+	case protocol.CmdMuteWorkspace: // wire: mute_workspace
 		if _, errMsg := d.toggleWorkspaceMute(msg.(*protocol.MuteWorkspaceMessage).WorkspaceID); errMsg != "" {
 			d.sendError(conn, errMsg)
 			return
 		}
 		d.sendOK(conn)
-	case protocol.CmdPinWorkspace:
+	case protocol.CmdPinWorkspace: // wire: pin_workspace
 		m := msg.(*protocol.PinWorkspaceMessage)
 		if _, errMsg := d.setWorkspacePinned(m.WorkspaceID, m.Pinned); errMsg != "" {
 			d.sendError(conn, errMsg)
 			return
 		}
 		d.sendOK(conn)
-	case protocol.CmdCollapseRepo:
+	case protocol.CmdCollapseRepo: // wire: collapse_repo
 		d.handleCollapseRepo(conn, msg.(*protocol.CollapseRepoMessage))
-	case protocol.CmdQueryRepos:
+	case protocol.CmdQueryRepos: // wire: query_repos
 		d.handleQueryRepos(conn, msg.(*protocol.QueryReposMessage))
-	case protocol.CmdQueryAuthors:
+	case protocol.CmdQueryAuthors: // wire: query_authors
 		d.handleQueryAuthors(conn, msg.(*protocol.QueryAuthorsMessage))
-	case protocol.CmdFetchPRDetails:
+	case protocol.CmdFetchPRDetails: // wire: fetch_pr_details
 		d.handleFetchPRDetails(conn, msg.(*protocol.FetchPRDetailsMessage))
-	case protocol.CmdInjectTestPR:
+	case protocol.CmdInjectTestPR: // wire: inject_test_pr
 		d.handleInjectTestPR(conn, msg.(*protocol.InjectTestPRMessage))
-	case protocol.CmdInjectTestSession:
+	case protocol.CmdInjectTestSession: // wire: inject_test_session
 		d.handleInjectTestSession(conn, msg.(*protocol.InjectTestSessionMessage))
-	case protocol.CmdOpenMarkdown:
+	case protocol.CmdOpenMarkdown: // wire: open_markdown
 		d.handleOpenMarkdown(conn, msg.(*protocol.OpenMarkdownMessage))
-	case protocol.CmdOpenBrowser:
+	case protocol.CmdOpenBrowser: // wire: open_browser
 		d.handleOpenBrowser(conn, msg.(*protocol.OpenBrowserMessage))
-	case protocol.CmdBrowserControl:
+	case protocol.CmdBrowserControl: // wire: browser_control
 		d.handleBrowserControl(conn, msg.(*protocol.BrowserControlMessage))
-	case protocol.CmdListWorktrees:
+	case protocol.CmdListWorktrees: // wire: list_worktrees
 		d.handleListWorktrees(conn, msg.(*protocol.ListWorktreesMessage))
-	case protocol.CmdCreateWorktree:
+	case protocol.CmdCreateWorktree: // wire: create_worktree
 		d.handleCreateWorktree(conn, msg.(*protocol.CreateWorktreeMessage))
-	case protocol.CmdDeleteWorktree:
+	case protocol.CmdDeleteWorktree: // wire: delete_worktree
 		d.handleDeleteWorktree(conn, msg.(*protocol.DeleteWorktreeMessage))
 	default:
 		d.sendError(conn, "unknown command")

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -876,296 +876,296 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 	}
 
 	switch cmd {
-	case protocol.CmdClientHello:
+	case protocol.CmdClientHello: // wire: client_hello
 		d.handleClientHello(client, msg.(*protocol.ClientHelloMessage))
-	case protocol.CmdDelegate:
+	case protocol.CmdDelegate: // wire: delegate
 		go d.handleDelegateWS(client, msg.(*protocol.DelegateMessage))
-	case protocol.CmdDelegateStatus:
+	case protocol.CmdDelegateStatus: // wire: delegate_status
 		go d.handleDelegateStatusWS(client, msg.(*protocol.DelegateStatusMessage))
-	case protocol.CmdWorkspaceContextCheckout:
+	case protocol.CmdWorkspaceContextCheckout: // wire: workspace_context_checkout
 		go func() {
 			result, err := d.checkoutWorkspaceContext(msg.(*protocol.WorkspaceContextCheckoutMessage))
 			d.sendWorkspaceContextWSResult(client, "checkout", result, err)
 		}()
-	case protocol.CmdWorkspaceContextUpdate:
+	case protocol.CmdWorkspaceContextUpdate: // wire: workspace_context_update
 		go func() {
 			result, _, err := d.updateWorkspaceContext(msg.(*protocol.WorkspaceContextUpdateMessage))
 			d.sendWorkspaceContextWSResult(client, "update", result, err)
 		}()
-	case protocol.CmdWorkspaceContextStatus:
+	case protocol.CmdWorkspaceContextStatus: // wire: workspace_context_status
 		go func() {
 			result, err := d.workspaceContextStatus(msg.(*protocol.WorkspaceContextStatusMessage))
 			d.sendWorkspaceContextWSResult(client, "status", result, err)
 		}()
-	case protocol.CmdWorkspaceContextList:
+	case protocol.CmdWorkspaceContextList: // wire: workspace_context_list
 		go d.sendWorkspaceContextListWSResult(client, msg.(*protocol.WorkspaceContextListMessage).RequestID)
-	case protocol.CmdNotebookList:
+	case protocol.CmdNotebookList: // wire: notebook_list
 		nbList := msg.(*protocol.NotebookListMessage)
 		go d.sendNotebookListWSResult(client, protocol.Deref(nbList.RequestID), protocol.Deref(nbList.Prefix))
-	case protocol.CmdNotebookRead:
+	case protocol.CmdNotebookRead: // wire: notebook_read
 		nbRead := msg.(*protocol.NotebookReadMessage)
 		go d.sendNotebookReadWSResult(client, protocol.Deref(nbRead.RequestID), nbRead.Path)
-	case protocol.CmdNotebookBacklinks:
+	case protocol.CmdNotebookBacklinks: // wire: notebook_backlinks
 		nbBack := msg.(*protocol.NotebookBacklinksMessage)
 		go d.sendNotebookBacklinksWSResult(client, protocol.Deref(nbBack.RequestID), nbBack.Path)
-	case protocol.CmdNotebookWrite:
+	case protocol.CmdNotebookWrite: // wire: notebook_write
 		nbWrite := msg.(*protocol.NotebookWriteMessage)
 		go d.sendNotebookWriteWSResult(client, protocol.Deref(nbWrite.RequestID), nbWrite.Path, nbWrite.Content, protocol.Deref(nbWrite.BaseHash))
-	case protocol.CmdNotebookSendToChief:
+	case protocol.CmdNotebookSendToChief: // wire: notebook_send_to_chief
 		nbChief := msg.(*protocol.NotebookSendToChiefMessage)
 		go d.sendNotebookToChiefWSResult(client, protocol.Deref(nbChief.RequestID), protocol.Deref(nbChief.SourcePath), nbChief.Selection)
-	case protocol.CmdTaskList:
+	case protocol.CmdTaskList: // wire: task_list
 		nbTaskList := msg.(*protocol.TaskListMessage)
 		go d.sendTaskListWSResult(client, protocol.Deref(nbTaskList.RequestID))
-	case protocol.CmdTaskRetry:
+	case protocol.CmdTaskRetry: // wire: task_retry
 		nbTaskRetry := msg.(*protocol.TaskRetryMessage)
 		go d.sendTaskRetryWSResult(client, protocol.Deref(nbTaskRetry.RequestID), nbTaskRetry.TaskID)
-	case protocol.CmdNotificationList:
+	case protocol.CmdNotificationList: // wire: notification_list
 		notifList := msg.(*protocol.NotificationListMessage)
 		go d.sendNotificationListWSResult(client, protocol.Deref(notifList.RequestID))
-	case protocol.CmdNotificationMarkRead:
+	case protocol.CmdNotificationMarkRead: // wire: notification_mark_read
 		notifMark := msg.(*protocol.NotificationMarkReadMessage)
 		go d.sendNotificationMarkReadWSResult(client, protocol.Deref(notifMark.RequestID), notifMark.NotificationID)
-	case protocol.CmdGetTicket:
+	case protocol.CmdGetTicket: // wire: get_ticket
 		getTicket := msg.(*protocol.GetTicketMessage)
 		go d.sendGetTicketWSResult(client, protocol.Deref(getTicket.RequestID), getTicket.TicketID)
-	case protocol.CmdTicketChangeStatus:
+	case protocol.CmdTicketChangeStatus: // wire: ticket_change_status
 		go d.handleTicketChangeStatus(client, msg.(*protocol.TicketChangeStatusMessage))
-	case protocol.CmdTicketAddComment:
+	case protocol.CmdTicketAddComment: // wire: ticket_add_comment
 		go d.handleTicketAddComment(client, msg.(*protocol.TicketAddCommentMessage))
-	case protocol.CmdTicketEditDescription:
+	case protocol.CmdTicketEditDescription: // wire: ticket_edit_description
 		go d.handleTicketEditDescription(client, msg.(*protocol.TicketEditDescriptionMessage))
-	case protocol.CmdTicketAttach:
+	case protocol.CmdTicketAttach: // wire: ticket_attach
 		go d.handleTicketAttachWS(client, msg.(*protocol.TicketAttachMessage))
-	case protocol.CmdTicketResume:
+	case protocol.CmdTicketResume: // wire: ticket_resume
 		go d.handleTicketResume(client, msg.(*protocol.TicketResumeMessage))
-	case protocol.CmdFsList:
+	case protocol.CmdFsList: // wire: fs_list
 		fsList := msg.(*protocol.FsListMessage)
 		go d.sendFsListWSResult(client, protocol.Deref(fsList.RequestID), protocol.Deref(fsList.Path), protocol.Deref(fsList.Root))
-	case protocol.CmdFsRead:
+	case protocol.CmdFsRead: // wire: fs_read
 		fsRead := msg.(*protocol.FsReadMessage)
 		go d.sendFsReadWSResult(client, protocol.Deref(fsRead.RequestID), fsRead.Path, protocol.Deref(fsRead.Root))
-	case protocol.CmdFsReadAsset:
+	case protocol.CmdFsReadAsset: // wire: fs_read_asset
 		fsReadAsset := msg.(*protocol.FsReadAssetMessage)
 		go d.sendFsReadAssetWSResult(client, protocol.Deref(fsReadAsset.RequestID), fsReadAsset.Path, protocol.Deref(fsReadAsset.Root))
-	case protocol.CmdFsWrite:
+	case protocol.CmdFsWrite: // wire: fs_write
 		fsWrite := msg.(*protocol.FsWriteMessage)
 		go d.sendFsWriteWSResult(client, protocol.Deref(fsWrite.RequestID), fsWrite.Path, fsWrite.Content, protocol.Deref(fsWrite.BaseHash), protocol.Deref(fsWrite.Root))
-	case protocol.CmdFsRename:
+	case protocol.CmdFsRename: // wire: fs_rename
 		fsRename := msg.(*protocol.FsRenameMessage)
 		go d.sendFsRenameWSResult(client, protocol.Deref(fsRename.RequestID), fsRename.Path, fsRename.NewPath, protocol.Deref(fsRename.Root))
-	case protocol.CmdFsDelete:
+	case protocol.CmdFsDelete: // wire: fs_delete
 		fsDelete := msg.(*protocol.FsDeleteMessage)
 		go d.sendFsDeleteWSResult(client, protocol.Deref(fsDelete.RequestID), fsDelete.Path, protocol.Deref(fsDelete.Root))
-	case protocol.CmdFsExists:
+	case protocol.CmdFsExists: // wire: fs_exists
 		fsExists := msg.(*protocol.FsExistsMessage)
 		go d.sendFsExistsWSResult(client, protocol.Deref(fsExists.RequestID), fsExists.Path, protocol.Deref(fsExists.Root))
-	case protocol.CmdFsWatch:
+	case protocol.CmdFsWatch: // wire: fs_watch
 		fsWatch := msg.(*protocol.FsWatchMessage)
 		go d.handleFsWatch(client, protocol.Deref(fsWatch.RequestID), protocol.Deref(fsWatch.Root))
-	case protocol.CmdFsUnwatch:
+	case protocol.CmdFsUnwatch: // wire: fs_unwatch
 		fsUnwatch := msg.(*protocol.FsUnwatchMessage)
 		go d.handleFsUnwatch(client, protocol.Deref(fsUnwatch.RequestID), protocol.Deref(fsUnwatch.Root))
-	case protocol.CmdFsIndex:
+	case protocol.CmdFsIndex: // wire: fs_index
 		fsIndex := msg.(*protocol.FsIndexMessage)
 		go d.handleFsIndex(client, protocol.Deref(fsIndex.RequestID), protocol.Deref(fsIndex.Root), fsIndex.Extensions)
-	case protocol.CmdApprovePR:
+	case protocol.CmdApprovePR: // wire: approve_pr
 		d.handleApprovePRWS(client, msg.(*protocol.ApprovePRMessage))
-	case protocol.CmdMergePR:
+	case protocol.CmdMergePR: // wire: merge_pr
 		d.handleMergePRWS(client, msg.(*protocol.MergePRMessage))
-	case protocol.CmdMutePR:
+	case protocol.CmdMutePR: // wire: mute_pr
 		d.handleMutePRWS(msg.(*protocol.MutePRMessage))
-	case protocol.CmdMuteRepo:
+	case protocol.CmdMuteRepo: // wire: mute_repo
 		d.handleMuteRepoWS(msg.(*protocol.MuteRepoMessage))
-	case protocol.CmdMuteAuthor:
+	case protocol.CmdMuteAuthor: // wire: mute_author
 		d.handleMuteAuthorWS(msg.(*protocol.MuteAuthorMessage))
-	case protocol.CmdMuteWorkspace:
+	case protocol.CmdMuteWorkspace: // wire: mute_workspace
 		d.handleMuteWorkspaceWS(client, msg.(*protocol.MuteWorkspaceMessage))
-	case protocol.CmdPinWorkspace:
+	case protocol.CmdPinWorkspace: // wire: pin_workspace
 		d.handlePinWorkspaceWS(client, msg.(*protocol.PinWorkspaceMessage))
-	case protocol.CmdRefreshPRs:
+	case protocol.CmdRefreshPRs: // wire: refresh_prs
 		d.handleRefreshPRsWS(client)
-	case protocol.CmdFetchPRDetails:
+	case protocol.CmdFetchPRDetails: // wire: fetch_pr_details
 		d.handleFetchPRDetailsWS(client, msg.(*protocol.FetchPRDetailsMessage))
-	case protocol.CmdClearSessions:
+	case protocol.CmdClearSessions: // wire: clear_sessions
 		d.handleClearSessionsWS()
-	case protocol.CmdClearWarnings:
+	case protocol.CmdClearWarnings: // wire: clear_warnings
 		d.handleClearWarningsWS()
-	case protocol.CmdSessionSelected:
-	case protocol.CmdWorkspaceSelected:
-	case protocol.CmdSettleTurn:
+	case protocol.CmdSessionSelected: // wire: session_selected
+	case protocol.CmdWorkspaceSelected: // wire: workspace_selected
+	case protocol.CmdSettleTurn: // wire: settle_turn
 		d.handleSettleTurn(msg.(*protocol.SettleTurnMessage))
-	case protocol.CmdCancelAutoSettle:
+	case protocol.CmdCancelAutoSettle: // wire: cancel_auto_settle
 		d.handleCancelAutoSettle(msg.(*protocol.CancelAutoSettleMessage))
-	case protocol.CmdTriggerNudge:
+	case protocol.CmdTriggerNudge: // wire: trigger_nudge
 		go d.handleTriggerNudge(msg.(*protocol.TriggerNudgeMessage))
-	case protocol.CmdPRVisited:
+	case protocol.CmdPRVisited: // wire: pr_visited
 		d.handlePRVisitedWS(msg.(*protocol.PRVisitedMessage))
-	case protocol.CmdListWorktrees:
+	case protocol.CmdListWorktrees: // wire: list_worktrees
 		d.handleListWorktreesWS(client, msg.(*protocol.ListWorktreesMessage))
-	case protocol.CmdCreateWorktree:
+	case protocol.CmdCreateWorktree: // wire: create_worktree
 		d.handleCreateWorktreeWS(client, msg.(*protocol.CreateWorktreeMessage))
-	case protocol.CmdDeleteWorktree:
+	case protocol.CmdDeleteWorktree: // wire: delete_worktree
 		d.handleDeleteWorktreeWS(client, msg.(*protocol.DeleteWorktreeMessage))
-	case protocol.CmdGetSettings:
+	case protocol.CmdGetSettings: // wire: get_settings
 		d.handleGetSettingsWS(client)
-	case protocol.CmdSetSetting:
+	case protocol.CmdSetSetting: // wire: set_setting
 		d.handleSetSettingWS(client, msg.(*protocol.SetSettingMessage))
-	case protocol.CmdListPlugins:
+	case protocol.CmdListPlugins: // wire: list_plugins
 		d.handleListPluginsWS(client)
-	case protocol.CmdInstallPlugin:
+	case protocol.CmdInstallPlugin: // wire: install_plugin
 		d.handleInstallPluginWS(client, msg.(*protocol.InstallPluginMessage))
-	case protocol.CmdInstallBundledPlugin:
+	case protocol.CmdInstallBundledPlugin: // wire: install_bundled_plugin
 		d.handleInstallBundledPluginWS(client, msg.(*protocol.InstallBundledPluginMessage))
-	case protocol.CmdUninstallPlugin:
+	case protocol.CmdUninstallPlugin: // wire: uninstall_plugin
 		d.handleUninstallPluginWS(client, msg.(*protocol.UninstallPluginMessage))
-	case protocol.CmdRemovePlugin:
+	case protocol.CmdRemovePlugin: // wire: remove_plugin
 		d.handleRemovePluginWS(client, msg.(*protocol.RemovePluginMessage))
-	case protocol.CmdSetPluginPriority:
+	case protocol.CmdSetPluginPriority: // wire: set_plugin_priority
 		d.handleSetPluginPriorityWS(client, msg.(*protocol.SetPluginPriorityMessage))
-	case protocol.CmdAddEndpoint:
+	case protocol.CmdAddEndpoint: // wire: add_endpoint
 		d.handleAddEndpointWS(client, msg.(*protocol.AddEndpointMessage))
-	case protocol.CmdRemoveEndpoint:
+	case protocol.CmdRemoveEndpoint: // wire: remove_endpoint
 		d.handleRemoveEndpointWS(client, msg.(*protocol.RemoveEndpointMessage))
-	case protocol.CmdUpdateEndpoint:
+	case protocol.CmdUpdateEndpoint: // wire: update_endpoint
 		d.handleUpdateEndpointWS(client, msg.(*protocol.UpdateEndpointMessage))
-	case protocol.CmdBootstrapEndpoint:
+	case protocol.CmdBootstrapEndpoint: // wire: bootstrap_endpoint
 		d.handleBootstrapEndpointWS(client, msg.(*protocol.BootstrapEndpointMessage))
-	case protocol.CmdListEndpoints:
+	case protocol.CmdListEndpoints: // wire: list_endpoints
 		d.handleListEndpointsWS(client)
-	case protocol.CmdSetEndpointRemoteWeb:
+	case protocol.CmdSetEndpointRemoteWeb: // wire: set_endpoint_remote_web
 		d.handleSetEndpointRemoteWebWS(client, msg.(*protocol.SetEndpointRemoteWebMessage))
-	case protocol.CmdUnregister:
+	case protocol.CmdUnregister: // wire: unregister
 		d.handleUnregisterWS(client, msg.(*protocol.UnregisterMessage))
-	case protocol.CmdGetRecentLocations:
+	case protocol.CmdGetRecentLocations: // wire: get_recent_locations
 		d.handleGetRecentLocationsWS(client, msg.(*protocol.GetRecentLocationsMessage))
-	case protocol.CmdRecentFiles:
+	case protocol.CmdRecentFiles: // wire: recent_files
 		d.handleRecentFilesWS(client, msg.(*protocol.RecentFilesMessage))
-	case protocol.CmdBrowseDirectory:
+	case protocol.CmdBrowseDirectory: // wire: browse_directory
 		d.handleBrowseDirectoryWS(client, msg.(*protocol.BrowseDirectoryMessage))
-	case protocol.CmdInspectPath:
+	case protocol.CmdInspectPath: // wire: inspect_path
 		d.handleInspectPathWS(client, msg.(*protocol.InspectPathMessage))
-	case protocol.CmdListBranches:
+	case protocol.CmdListBranches: // wire: list_branches
 		d.handleListBranchesWS(client, msg.(*protocol.ListBranchesMessage))
-	case protocol.CmdCreateWorktreeFromBranch:
+	case protocol.CmdCreateWorktreeFromBranch: // wire: create_worktree_from_branch
 		d.handleCreateWorktreeFromBranchWS(client, msg.(*protocol.CreateWorktreeFromBranchMessage))
-	case protocol.CmdGetDefaultBranch:
+	case protocol.CmdGetDefaultBranch: // wire: get_default_branch
 		d.handleGetDefaultBranchWS(client, msg.(*protocol.GetDefaultBranchMessage))
-	case protocol.CmdFetchRemotes:
+	case protocol.CmdFetchRemotes: // wire: fetch_remotes
 		d.handleFetchRemotesWS(client, msg.(*protocol.FetchRemotesMessage))
-	case protocol.CmdListRemoteBranches:
+	case protocol.CmdListRemoteBranches: // wire: list_remote_branches
 		d.handleListRemoteBranchesWS(client, msg.(*protocol.ListRemoteBranchesMessage))
-	case protocol.CmdEnsureRepo:
+	case protocol.CmdEnsureRepo: // wire: ensure_repo
 		d.handleEnsureRepoWS(client, msg.(*protocol.EnsureRepoMessage))
-	case protocol.CmdSubscribeGitStatus:
+	case protocol.CmdSubscribeGitStatus: // wire: subscribe_git_status
 		d.handleSubscribeGitStatus(client, msg.(*protocol.SubscribeGitStatusMessage))
-	case protocol.CmdUnsubscribeGitStatus:
+	case protocol.CmdUnsubscribeGitStatus: // wire: unsubscribe_git_status
 		d.handleUnsubscribeGitStatusWS(client)
-	case protocol.CmdGetFileDiff:
+	case protocol.CmdGetFileDiff: // wire: get_file_diff
 		d.handleGetFileDiffWS(client, msg.(*protocol.GetFileDiffMessage))
-	case protocol.CmdGetRepoInfo:
+	case protocol.CmdGetRepoInfo: // wire: get_repo_info
 		d.handleGetRepoInfoWS(client, msg.(*protocol.GetRepoInfoMessage))
-	case protocol.CmdGetPresentations:
+	case protocol.CmdGetPresentations: // wire: get_presentations
 		d.handleGetPresentations(client, msg.(*protocol.GetPresentationsMessage))
-	case protocol.CmdGetPresentationRound:
+	case protocol.CmdGetPresentationRound: // wire: get_presentation_round
 		d.handleGetPresentationRound(client, msg.(*protocol.GetPresentationRoundMessage))
-	case protocol.CmdPresentSubmitRound:
+	case protocol.CmdPresentSubmitRound: // wire: present_submit_round
 		d.handlePresentSubmitRound(client, msg.(*protocol.PresentSubmitRoundMessage))
-	case protocol.CmdPresentClose:
+	case protocol.CmdPresentClose: // wire: present_close
 		d.handlePresentClose(client, msg.(*protocol.PresentCloseMessage))
-	case protocol.CmdWorkflowRunGet:
+	case protocol.CmdWorkflowRunGet: // wire: workflow_run_get
 		d.handleWorkflowRunGetWS(client, msg.(*protocol.WorkflowRunGetMessage))
-	case protocol.CmdWorkflowRunList:
+	case protocol.CmdWorkflowRunList: // wire: workflow_run_list
 		d.handleWorkflowRunListWS(client, msg.(*protocol.WorkflowRunListMessage))
-	case protocol.CmdWorkflowRunCancel:
+	case protocol.CmdWorkflowRunCancel: // wire: workflow_run_cancel
 		d.handleWorkflowRunCancelWS(client, msg.(*protocol.WorkflowRunCancelMessage))
-	case protocol.CmdAutomationDefinitionsGet:
+	case protocol.CmdAutomationDefinitionsGet: // wire: automation_definitions_get
 		d.handleAutomationDefinitionsGetWS(client, msg.(*protocol.AutomationDefinitionsGetMessage))
-	case protocol.CmdAutomationDefinitionGet:
+	case protocol.CmdAutomationDefinitionGet: // wire: automation_definition_get
 		d.handleAutomationDefinitionGetWS(client, msg.(*protocol.AutomationDefinitionGetMessage))
-	case protocol.CmdAutomationRunsGet:
+	case protocol.CmdAutomationRunsGet: // wire: automation_runs_get
 		d.handleAutomationRunsGetWS(client, msg.(*protocol.AutomationRunsGetMessage))
-	case protocol.CmdAutomationSetEnabled:
+	case protocol.CmdAutomationSetEnabled: // wire: automation_set_enabled
 		d.handleAutomationSetEnabledWS(client, msg.(*protocol.AutomationSetEnabledMessage))
-	case protocol.CmdAutomationApply:
+	case protocol.CmdAutomationApply: // wire: automation_apply
 		d.handleAutomationApplyWS(client, msg.(*protocol.AutomationApplyMessage))
-	case protocol.CmdAutomationValidate:
+	case protocol.CmdAutomationValidate: // wire: automation_validate
 		d.handleAutomationValidateWS(client, msg.(*protocol.AutomationValidateMessage))
-	case protocol.CmdAutomationDelete:
+	case protocol.CmdAutomationDelete: // wire: automation_delete
 		d.handleAutomationDeleteWS(client, msg.(*protocol.AutomationDeleteMessage))
-	case protocol.CmdAutomationCleanup:
+	case protocol.CmdAutomationCleanup: // wire: automation_cleanup
 		d.handleAutomationCleanupWS(client, msg.(*protocol.AutomationCleanupMessage))
-	case protocol.CmdAutomationRun:
+	case protocol.CmdAutomationRun: // wire: automation_run
 		d.handleAutomationRunWS(client, msg.(*protocol.AutomationRunMessage))
-	case protocol.CmdSpawnSession:
+	case protocol.CmdSpawnSession: // wire: spawn_session
 		d.handleSpawnSession(client, msg.(*protocol.SpawnSessionMessage))
-	case protocol.CmdAttachSession:
+	case protocol.CmdAttachSession: // wire: attach_session
 		d.handleAttachSession(client, msg.(*protocol.AttachSessionMessage))
-	case protocol.CmdDetachSession:
+	case protocol.CmdDetachSession: // wire: detach_session
 		d.handleDetachSessionWS(client, msg.(*protocol.DetachSessionMessage))
-	case protocol.CmdGetScreenSnapshot:
+	case protocol.CmdGetScreenSnapshot: // wire: get_screen_snapshot
 		d.handleGetScreenSnapshot(client, msg.(*protocol.GetScreenSnapshotMessage))
-	case protocol.CmdPtyInput:
+	case protocol.CmdPtyInput: // wire: pty_input
 		d.handlePtyInput(client, msg.(*protocol.PtyInputMessage))
-	case protocol.CmdPtyResize:
+	case protocol.CmdPtyResize: // wire: pty_resize
 		d.handlePtyResize(client, msg.(*protocol.PtyResizeMessage))
-	case protocol.CmdKillSession:
+	case protocol.CmdKillSession: // wire: kill_session
 		d.handleKillSession(client, msg.(*protocol.KillSessionMessage))
-	case protocol.CmdReloadSession:
+	case protocol.CmdReloadSession: // wire: reload_session
 		d.handleReloadSession(client, msg.(*protocol.ReloadSessionMessage))
-	case protocol.CmdSetTerminalTheme:
+	case protocol.CmdSetTerminalTheme: // wire: set_terminal_theme
 		d.handleSetTerminalTheme(client, msg.(*protocol.SetTerminalThemeMessage))
-	case protocol.CmdWorkspaceLayoutGet:
+	case protocol.CmdWorkspaceLayoutGet: // wire: workspace_layout_get
 		d.handleWorkspaceLayoutGet(client, msg.(*protocol.WorkspaceLayoutGetMessage))
-	case protocol.CmdWorkspaceLayoutAddSessionPane:
+	case protocol.CmdWorkspaceLayoutAddSessionPane: // wire: workspace_layout_add_session_pane
 		d.handleWorkspaceLayoutAddSessionPane(client, msg.(*protocol.WorkspaceLayoutAddSessionPaneMessage))
-	case protocol.CmdWorkspaceLayoutClosePane:
+	case protocol.CmdWorkspaceLayoutClosePane: // wire: workspace_layout_close_pane
 		d.handleWorkspaceLayoutClosePane(client, msg.(*protocol.WorkspaceLayoutClosePaneMessage))
-	case protocol.CmdWorkspaceLayoutFocusPane:
+	case protocol.CmdWorkspaceLayoutFocusPane: // wire: workspace_layout_focus_pane
 		d.handleWorkspaceLayoutFocusPane(client, msg.(*protocol.WorkspaceLayoutFocusPaneMessage))
-	case protocol.CmdWorkspaceLayoutRenamePane:
+	case protocol.CmdWorkspaceLayoutRenamePane: // wire: workspace_layout_rename_pane
 		d.handleWorkspaceLayoutRenamePane(client, msg.(*protocol.WorkspaceLayoutRenamePaneMessage))
-	case protocol.CmdWorkspaceLayoutSetSplitRatio:
+	case protocol.CmdWorkspaceLayoutSetSplitRatio: // wire: workspace_layout_set_split_ratio
 		d.handleWorkspaceLayoutSetSplitRatio(client, msg.(*protocol.WorkspaceLayoutSetSplitRatioMessage))
-	case protocol.CmdWorkspaceLayoutDockTile:
+	case protocol.CmdWorkspaceLayoutDockTile: // wire: workspace_layout_dock_tile
 		d.handleWorkspaceLayoutDockTile(client, msg.(*protocol.WorkspaceLayoutDockTileMessage))
-	case protocol.CmdWorkspaceLayoutUndockTile:
+	case protocol.CmdWorkspaceLayoutUndockTile: // wire: workspace_layout_undock_tile
 		d.handleWorkspaceLayoutUndockTile(client, msg.(*protocol.WorkspaceLayoutUndockTileMessage))
-	case protocol.CmdWorkspaceLayoutUpdateTile:
+	case protocol.CmdWorkspaceLayoutUpdateTile: // wire: workspace_layout_update_tile
 		d.handleWorkspaceLayoutUpdateTile(client, msg.(*protocol.WorkspaceLayoutUpdateTileMessage))
-	case protocol.CmdWorkspaceLayoutMoveLeaf:
+	case protocol.CmdWorkspaceLayoutMoveLeaf: // wire: workspace_layout_move_leaf
 		d.handleWorkspaceLayoutMoveLeaf(client, msg.(*protocol.WorkspaceLayoutMoveLeafMessage))
-	case protocol.CmdWorkspaceLayoutMoveLeafToWorkspace:
+	case protocol.CmdWorkspaceLayoutMoveLeafToWorkspace: // wire: workspace_layout_move_leaf_to_workspace
 		d.handleWorkspaceLayoutMoveLeafToWorkspace(client, msg.(*protocol.WorkspaceLayoutMoveLeafToWorkspaceMessage))
-	case protocol.CmdWorkspaceLayoutMoveLeafToNewWorkspace:
+	case protocol.CmdWorkspaceLayoutMoveLeafToNewWorkspace: // wire: workspace_layout_move_leaf_to_new_workspace
 		d.handleWorkspaceLayoutMoveLeafToNewWorkspace(client, msg.(*protocol.WorkspaceLayoutMoveLeafToNewWorkspaceMessage))
-	case protocol.CmdSetWorkspaceRank:
+	case protocol.CmdSetWorkspaceRank: // wire: set_workspace_rank
 		d.handleSetWorkspaceRank(client, msg.(*protocol.SetWorkspaceRankMessage))
-	case protocol.CmdWorkspaceTileContentGet:
+	case protocol.CmdWorkspaceTileContentGet: // wire: workspace_tile_content_get
 		d.handleWorkspaceTileContentGet(client, msg.(*protocol.WorkspaceTileContentGetMessage))
-	case protocol.CmdOpenMarkdown:
+	case protocol.CmdOpenMarkdown: // wire: open_markdown
 		d.handleOpenMarkdownWS(client, msg.(*protocol.OpenMarkdownMessage))
-	case protocol.CmdMarkdownAnnotationsGet:
+	case protocol.CmdMarkdownAnnotationsGet: // wire: markdown_annotations_get
 		d.handleMarkdownAnnotationsGet(client, msg.(*protocol.MarkdownAnnotationsGetMessage))
-	case protocol.CmdMarkdownAnnotationsSave:
+	case protocol.CmdMarkdownAnnotationsSave: // wire: markdown_annotations_save
 		d.handleMarkdownAnnotationsSave(client, msg.(*protocol.MarkdownAnnotationsSaveMessage))
-	case protocol.CmdMarkdownAnnotationsClear:
+	case protocol.CmdMarkdownAnnotationsClear: // wire: markdown_annotations_clear
 		d.handleMarkdownAnnotationsClear(client, msg.(*protocol.MarkdownAnnotationsClearMessage))
-	case protocol.CmdMarkdownAnnotationsSubmit:
+	case protocol.CmdMarkdownAnnotationsSubmit: // wire: markdown_annotations_submit
 		d.handleMarkdownAnnotationsSubmit(client, msg.(*protocol.MarkdownAnnotationsSubmitMessage))
-	case protocol.CmdBrowserControl:
+	case protocol.CmdBrowserControl: // wire: browser_control
 		go d.handleRemoteBrowserControl(client, msg.(*protocol.BrowserControlMessage))
-	case protocol.CmdBrowserControlResult:
+	case protocol.CmdBrowserControlResult: // wire: browser_control_result
 		d.handleBrowserControlResult(client, msg.(*protocol.BrowserControlResultMessage))
-	case protocol.CmdRegisterWorkspace:
+	case protocol.CmdRegisterWorkspace: // wire: register_workspace
 		d.handleRegisterWorkspace(client, msg.(*protocol.RegisterWorkspaceMessage))
-	case protocol.CmdUnregisterWorkspace:
+	case protocol.CmdUnregisterWorkspace: // wire: unregister_workspace
 		d.handleUnregisterWorkspace(client, msg.(*protocol.UnregisterWorkspaceMessage))
-	case protocol.CmdRenameSession:
+	case protocol.CmdRenameSession: // wire: rename_session
 		d.handleRenameSession(client, msg.(*protocol.RenameSessionMessage))
-	case protocol.CmdRenameWorkspace:
+	case protocol.CmdRenameWorkspace: // wire: rename_workspace
 		d.handleRenameWorkspace(client, msg.(*protocol.RenameWorkspaceMessage))
-	case protocol.CmdSetChiefOfStaff:
+	case protocol.CmdSetChiefOfStaff: // wire: set_chief_of_staff
 		d.handleSetChiefOfStaff(client, msg.(*protocol.SetChiefOfStaffMessage))
 	default:
 		d.sendCommandError(client, cmd, "unsupported command")
@@ -1201,9 +1201,9 @@ func (d *Daemon) tryHandleRemoteWSCommand(client *wsClient, cmd string, msg inte
 			return false
 		}
 		switch cmd {
-		case protocol.CmdAttachSession:
+		case protocol.CmdAttachSession: // wire: attach_session
 			client.notePendingRemoteAttach(ptyTargetID)
-		case protocol.CmdDetachSession:
+		case protocol.CmdDetachSession: // wire: detach_session
 			client.clearRemoteAttach(ptyTargetID)
 		}
 		if err := d.hubManager.ForwardPTYCommand(context.Background(), ptyTargetID, raw); err != nil {
@@ -1281,27 +1281,27 @@ func (d *Daemon) tryHandleRemoteWSCommand(client *wsClient, cmd string, msg inte
 
 func remoteCommandSessionID(cmd string, msg interface{}) string {
 	switch cmd {
-	case protocol.CmdSessionSelected:
+	case protocol.CmdSessionSelected: // wire: session_selected
 		if typed, ok := msg.(*protocol.SessionSelectedMessage); ok {
 			return typed.ID
 		}
-	case protocol.CmdTriggerNudge:
+	case protocol.CmdTriggerNudge: // wire: trigger_nudge
 		if typed, ok := msg.(*protocol.TriggerNudgeMessage); ok {
 			return typed.SessionID
 		}
-	case protocol.CmdRenameSession:
+	case protocol.CmdRenameSession: // wire: rename_session
 		if typed, ok := msg.(*protocol.RenameSessionMessage); ok {
 			return typed.SessionID
 		}
-	case protocol.CmdOpenMarkdown:
+	case protocol.CmdOpenMarkdown: // wire: open_markdown
 		if typed, ok := msg.(*protocol.OpenMarkdownMessage); ok {
 			return protocol.Deref(typed.SessionID)
 		}
-	case protocol.CmdMarkdownAnnotationsSubmit:
+	case protocol.CmdMarkdownAnnotationsSubmit: // wire: markdown_annotations_submit
 		if typed, ok := msg.(*protocol.MarkdownAnnotationsSubmitMessage); ok {
 			return typed.TargetSessionID
 		}
-	case protocol.CmdSettleTurn:
+	case protocol.CmdSettleTurn: // wire: settle_turn
 		// The turn's stamps live in the store of the daemon that owns the
 		// session, so settling a remote row has to reach that daemon. Handled
 		// locally it would write nothing the remote knows about, and the next
@@ -1309,7 +1309,7 @@ func remoteCommandSessionID(cmd string, msg interface{}) string {
 		if typed, ok := msg.(*protocol.SettleTurnMessage); ok {
 			return typed.SessionID
 		}
-	case protocol.CmdCancelAutoSettle:
+	case protocol.CmdCancelAutoSettle: // wire: cancel_auto_settle
 		// Same reasoning as settle_turn: the countdown that would close the turn
 		// runs in the daemon that owns the session, so the cancel has to reach it.
 		if typed, ok := msg.(*protocol.CancelAutoSettleMessage); ok {
@@ -1321,75 +1321,75 @@ func remoteCommandSessionID(cmd string, msg interface{}) string {
 
 func remoteCommandWorkspaceID(cmd string, msg interface{}) string {
 	switch cmd {
-	case protocol.CmdWorkspaceLayoutGet:
+	case protocol.CmdWorkspaceLayoutGet: // wire: workspace_layout_get
 		if typed, ok := msg.(*protocol.WorkspaceLayoutGetMessage); ok {
 			return typed.WorkspaceID
 		}
-	case protocol.CmdWorkspaceLayoutAddSessionPane:
+	case protocol.CmdWorkspaceLayoutAddSessionPane: // wire: workspace_layout_add_session_pane
 		if typed, ok := msg.(*protocol.WorkspaceLayoutAddSessionPaneMessage); ok {
 			return typed.WorkspaceID
 		}
-	case protocol.CmdWorkspaceLayoutClosePane:
+	case protocol.CmdWorkspaceLayoutClosePane: // wire: workspace_layout_close_pane
 		if typed, ok := msg.(*protocol.WorkspaceLayoutClosePaneMessage); ok {
 			return typed.WorkspaceID
 		}
-	case protocol.CmdWorkspaceLayoutFocusPane:
+	case protocol.CmdWorkspaceLayoutFocusPane: // wire: workspace_layout_focus_pane
 		if typed, ok := msg.(*protocol.WorkspaceLayoutFocusPaneMessage); ok {
 			return typed.WorkspaceID
 		}
-	case protocol.CmdWorkspaceLayoutRenamePane:
+	case protocol.CmdWorkspaceLayoutRenamePane: // wire: workspace_layout_rename_pane
 		if typed, ok := msg.(*protocol.WorkspaceLayoutRenamePaneMessage); ok {
 			return typed.WorkspaceID
 		}
-	case protocol.CmdWorkspaceLayoutSetSplitRatio:
+	case protocol.CmdWorkspaceLayoutSetSplitRatio: // wire: workspace_layout_set_split_ratio
 		if typed, ok := msg.(*protocol.WorkspaceLayoutSetSplitRatioMessage); ok {
 			return typed.WorkspaceID
 		}
-	case protocol.CmdWorkspaceLayoutDockTile:
+	case protocol.CmdWorkspaceLayoutDockTile: // wire: workspace_layout_dock_tile
 		if typed, ok := msg.(*protocol.WorkspaceLayoutDockTileMessage); ok {
 			return typed.WorkspaceID
 		}
-	case protocol.CmdWorkspaceLayoutUndockTile:
+	case protocol.CmdWorkspaceLayoutUndockTile: // wire: workspace_layout_undock_tile
 		if typed, ok := msg.(*protocol.WorkspaceLayoutUndockTileMessage); ok {
 			return typed.WorkspaceID
 		}
-	case protocol.CmdWorkspaceLayoutUpdateTile:
+	case protocol.CmdWorkspaceLayoutUpdateTile: // wire: workspace_layout_update_tile
 		if typed, ok := msg.(*protocol.WorkspaceLayoutUpdateTileMessage); ok {
 			return typed.WorkspaceID
 		}
-	case protocol.CmdWorkspaceLayoutMoveLeaf:
+	case protocol.CmdWorkspaceLayoutMoveLeaf: // wire: workspace_layout_move_leaf
 		if typed, ok := msg.(*protocol.WorkspaceLayoutMoveLeafMessage); ok {
 			return typed.WorkspaceID
 		}
-	case protocol.CmdWorkspaceLayoutMoveLeafToWorkspace:
+	case protocol.CmdWorkspaceLayoutMoveLeafToWorkspace: // wire: workspace_layout_move_leaf_to_workspace
 		if typed, ok := msg.(*protocol.WorkspaceLayoutMoveLeafToWorkspaceMessage); ok {
 			return typed.SourceWorkspaceID
 		}
-	case protocol.CmdWorkspaceLayoutMoveLeafToNewWorkspace:
+	case protocol.CmdWorkspaceLayoutMoveLeafToNewWorkspace: // wire: workspace_layout_move_leaf_to_new_workspace
 		if typed, ok := msg.(*protocol.WorkspaceLayoutMoveLeafToNewWorkspaceMessage); ok {
 			return typed.SourceWorkspaceID
 		}
-	case protocol.CmdSetWorkspaceRank:
+	case protocol.CmdSetWorkspaceRank: // wire: set_workspace_rank
 		if typed, ok := msg.(*protocol.SetWorkspaceRankMessage); ok {
 			return typed.WorkspaceID
 		}
-	case protocol.CmdWorkspaceTileContentGet:
+	case protocol.CmdWorkspaceTileContentGet: // wire: workspace_tile_content_get
 		if typed, ok := msg.(*protocol.WorkspaceTileContentGetMessage); ok {
 			return typed.WorkspaceID
 		}
-	case protocol.CmdMarkdownAnnotationsGet:
+	case protocol.CmdMarkdownAnnotationsGet: // wire: markdown_annotations_get
 		if typed, ok := msg.(*protocol.MarkdownAnnotationsGetMessage); ok {
 			return typed.WorkspaceID
 		}
-	case protocol.CmdMarkdownAnnotationsSave:
+	case protocol.CmdMarkdownAnnotationsSave: // wire: markdown_annotations_save
 		if typed, ok := msg.(*protocol.MarkdownAnnotationsSaveMessage); ok {
 			return typed.WorkspaceID
 		}
-	case protocol.CmdMarkdownAnnotationsClear:
+	case protocol.CmdMarkdownAnnotationsClear: // wire: markdown_annotations_clear
 		if typed, ok := msg.(*protocol.MarkdownAnnotationsClearMessage); ok {
 			return typed.WorkspaceID
 		}
-	case protocol.CmdRenameWorkspace:
+	case protocol.CmdRenameWorkspace: // wire: rename_workspace
 		if typed, ok := msg.(*protocol.RenameWorkspaceMessage); ok {
 			return typed.WorkspaceID
 		}
@@ -1399,39 +1399,39 @@ func remoteCommandWorkspaceID(cmd string, msg interface{}) string {
 
 func remoteCommandEndpointID(cmd string, msg interface{}) string {
 	switch cmd {
-	case protocol.CmdGetRecentLocations:
+	case protocol.CmdGetRecentLocations: // wire: get_recent_locations
 		if typed, ok := msg.(*protocol.GetRecentLocationsMessage); ok {
 			return strings.TrimSpace(protocol.Deref(typed.EndpointID))
 		}
-	case protocol.CmdBrowseDirectory:
+	case protocol.CmdBrowseDirectory: // wire: browse_directory
 		if typed, ok := msg.(*protocol.BrowseDirectoryMessage); ok {
 			return strings.TrimSpace(protocol.Deref(typed.EndpointID))
 		}
-	case protocol.CmdInspectPath:
+	case protocol.CmdInspectPath: // wire: inspect_path
 		if typed, ok := msg.(*protocol.InspectPathMessage); ok {
 			return strings.TrimSpace(protocol.Deref(typed.EndpointID))
 		}
-	case protocol.CmdSpawnSession:
+	case protocol.CmdSpawnSession: // wire: spawn_session
 		if typed, ok := msg.(*protocol.SpawnSessionMessage); ok {
 			return strings.TrimSpace(protocol.Deref(typed.EndpointID))
 		}
-	case protocol.CmdRegisterWorkspace:
+	case protocol.CmdRegisterWorkspace: // wire: register_workspace
 		if typed, ok := msg.(*protocol.RegisterWorkspaceMessage); ok {
 			return strings.TrimSpace(protocol.Deref(typed.EndpointID))
 		}
-	case protocol.CmdMuteWorkspace:
+	case protocol.CmdMuteWorkspace: // wire: mute_workspace
 		if typed, ok := msg.(*protocol.MuteWorkspaceMessage); ok {
 			return strings.TrimSpace(protocol.Deref(typed.EndpointID))
 		}
-	case protocol.CmdCreateWorktree:
+	case protocol.CmdCreateWorktree: // wire: create_worktree
 		if typed, ok := msg.(*protocol.CreateWorktreeMessage); ok {
 			return strings.TrimSpace(protocol.Deref(typed.EndpointID))
 		}
-	case protocol.CmdDeleteWorktree:
+	case protocol.CmdDeleteWorktree: // wire: delete_worktree
 		if typed, ok := msg.(*protocol.DeleteWorktreeMessage); ok {
 			return strings.TrimSpace(protocol.Deref(typed.EndpointID))
 		}
-	case protocol.CmdGetRepoInfo:
+	case protocol.CmdGetRepoInfo: // wire: get_repo_info
 		if typed, ok := msg.(*protocol.GetRepoInfoMessage); ok {
 			return strings.TrimSpace(protocol.Deref(typed.EndpointID))
 		}
@@ -1441,28 +1441,28 @@ func remoteCommandEndpointID(cmd string, msg interface{}) string {
 
 func remoteCommandPTYTargetID(cmd string, msg interface{}) string {
 	switch cmd {
-	case protocol.CmdSpawnSession:
-	case protocol.CmdAttachSession:
+	case protocol.CmdSpawnSession: // wire: spawn_session
+	case protocol.CmdAttachSession: // wire: attach_session
 		if typed, ok := msg.(*protocol.AttachSessionMessage); ok {
 			return typed.ID
 		}
-	case protocol.CmdDetachSession:
+	case protocol.CmdDetachSession: // wire: detach_session
 		if typed, ok := msg.(*protocol.DetachSessionMessage); ok {
 			return typed.ID
 		}
-	case protocol.CmdPtyInput:
+	case protocol.CmdPtyInput: // wire: pty_input
 		if typed, ok := msg.(*protocol.PtyInputMessage); ok {
 			return typed.ID
 		}
-	case protocol.CmdPtyResize:
+	case protocol.CmdPtyResize: // wire: pty_resize
 		if typed, ok := msg.(*protocol.PtyResizeMessage); ok {
 			return typed.ID
 		}
-	case protocol.CmdKillSession:
+	case protocol.CmdKillSession: // wire: kill_session
 		if typed, ok := msg.(*protocol.KillSessionMessage); ok {
 			return typed.ID
 		}
-	case protocol.CmdReloadSession:
+	case protocol.CmdReloadSession: // wire: reload_session
 		if typed, ok := msg.(*protocol.ReloadSessionMessage); ok {
 			return typed.ID
 		}

--- a/internal/daemon/wire_dispatch_test.go
+++ b/internal/daemon/wire_dispatch_test.go
@@ -1,0 +1,157 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// Agents locate code by grepping names, so a wire command name that appears only
+// in internal/protocol (constant, TypeSpec schema, generated code) forces a
+// second search to reach the code that runs it. These tests keep every wire
+// command name greppable at every switch case that dispatches it:
+//
+//	case protocol.CmdDeleteWorktree: // wire: delete_worktree
+//
+// Adding a command, or a second dispatch site for one, without the comment fails
+// TestWireCommandsAreGreppable.
+
+var (
+	wireConstRe   = regexp.MustCompile(`\b(Cmd[A-Za-z0-9]+)\s*=\s*"([a-z0-9_]+)"`)
+	dispatchRe    = regexp.MustCompile(`^\s*case ((?:protocol\.Cmd[A-Za-z0-9]+)(?:,\s*protocol\.Cmd[A-Za-z0-9]+)*):`)
+	cmdRefRe      = regexp.MustCompile(`protocol\.(Cmd[A-Za-z0-9]+)`)
+	wireCommentRe = regexp.MustCompile(`//\s*wire:\s*(.*)$`)
+)
+
+// dispatchFiles hold the command switches: the WebSocket dispatch, the
+// unix-socket dispatch, and the automation sub-dispatch.
+var dispatchFiles = []string{"websocket.go", "daemon.go", "automations.go"}
+
+// dispatchSite is one `case protocol.Cmd...:` line and the wire names visible in
+// the comment attached to it.
+type dispatchSite struct {
+	where     string
+	constants []string
+	annotated []string
+}
+
+// wireCommands maps every protocol.Cmd* constant to its wire string.
+func wireCommands(t *testing.T) map[string]string {
+	t.Helper()
+	src, err := os.ReadFile(filepath.Join("..", "protocol", "constants.go"))
+	if err != nil {
+		t.Fatalf("read constants.go: %v", err)
+	}
+	out := map[string]string{}
+	for _, m := range wireConstRe.FindAllStringSubmatch(string(src), -1) {
+		out[m[1]] = m[2]
+	}
+	if len(out) < 100 {
+		t.Fatalf("parsed only %d Cmd constants; the regex probably stopped matching", len(out))
+	}
+	return out
+}
+
+// dispatchSites reads the wire comment trailing each case line, or the
+// contiguous // block directly above it. Both forms put the name inside the
+// window ripgrep prints for the case.
+func dispatchSites(t *testing.T) []dispatchSite {
+	t.Helper()
+	var sites []dispatchSite
+	for _, name := range dispatchFiles {
+		src, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		lines := strings.Split(string(src), "\n")
+		for i, line := range lines {
+			if !dispatchRe.MatchString(line) {
+				continue
+			}
+			comment := ""
+			if m := wireCommentRe.FindStringSubmatch(line); m != nil {
+				comment = m[1]
+			} else {
+				for j := i - 1; j >= 0; j-- {
+					trimmed := strings.TrimSpace(lines[j])
+					if !strings.HasPrefix(trimmed, "//") {
+						break
+					}
+					comment = strings.TrimPrefix(trimmed, "//") + " " + comment
+				}
+			}
+			site := dispatchSite{
+				where: fmt.Sprintf("%s:%d", name, i+1),
+				annotated: strings.FieldsFunc(comment, func(r rune) bool {
+					return r == ',' || r == ' ' || r == '\t'
+				}),
+			}
+			for _, c := range cmdRefRe.FindAllStringSubmatch(line, -1) {
+				site.constants = append(site.constants, c[1])
+			}
+			sites = append(sites, site)
+		}
+	}
+	if len(sites) < 100 {
+		t.Fatalf("found only %d dispatch cases across %v; the regex probably stopped matching", len(sites), dispatchFiles)
+	}
+	return sites
+}
+
+func TestWireCommandsAreGreppable(t *testing.T) {
+	commands := wireCommands(t)
+	sites := dispatchSites(t)
+
+	dispatched := map[string]bool{}
+	for _, site := range sites {
+		for _, name := range site.constants {
+			wire, known := commands[name]
+			if !known {
+				t.Errorf("%s: dispatches unknown constant protocol.%s", site.where, name)
+				continue
+			}
+			dispatched[name] = true
+			if !slices.Contains(site.annotated, wire) {
+				t.Errorf("%s: protocol.%s dispatched without its wire name; add `// wire: %s` so grepping %q reaches this case",
+					site.where, name, wire, wire)
+			}
+		}
+	}
+
+	for name, wire := range commands {
+		if !dispatched[name] {
+			t.Errorf("protocol.%s (%q) has no dispatch case in %v; it is either dead or handled somewhere this test does not look",
+				name, wire, dispatchFiles)
+		}
+	}
+}
+
+// A wire comment that drifts from its constant is worse than none: it sends the
+// next reader to the wrong handler with full confidence.
+func TestWireCommentsMatchTheirConstants(t *testing.T) {
+	commands := wireCommands(t)
+	byWire := map[string]string{}
+	for name, wire := range commands {
+		byWire[wire] = name
+	}
+
+	for _, site := range dispatchSites(t) {
+		expected := make([]string, 0, len(site.constants))
+		for _, name := range site.constants {
+			expected = append(expected, commands[name])
+		}
+		for _, annotated := range site.annotated {
+			if slices.Contains(expected, annotated) {
+				continue
+			}
+			if other, isWire := byWire[annotated]; isWire {
+				t.Errorf("%s: annotated %q, which is protocol.%s's wire name, but dispatches %v",
+					site.where, annotated, other, site.constants)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Coding agents locate code primarily by ripgrep over names, so a name that isn't greppable near its definition costs tokens and correctness. This addresses that gap in two places, per plan doc `docs/plans/2026-07-25-agent-discoverability.md`.

**1. Wire-command back-references (`internal/daemon`).** Added `// wire: <command>` comments to all 244 dispatch case lines across `websocket.go`, `daemon.go`, and `automations.go`. All 170 protocol wire strings are now greppable in `internal/daemon`; 88 were not before. New `internal/daemon/wire_dispatch_test.go` enforces this going forward: every dispatch case must be annotated, every wire constant must be dispatched, and a comment naming a different command's wire string fails the test. The annotation lives on the dispatch case rather than the handler because several commands dispatch from two switches and some cases inline their work.

**2. Named the request/result correlation protocol (`app/src/hooks`).** 115 of 134 event cases in `useDaemonSocket.ts` repeated the same `<kind>:<requestId>` pending-promise lookup inline with no name to search for. New `daemonPendingRequests.ts` names it (`pendingRequestKey` / `settlePendingRequest`). Three domains were then extracted into their own modules reached from a new `default` clause: `daemonFsEvents.ts`, `daemonNotebookEvents.ts`, `daemonMarkdownAnnotationEvents.ts`. The annotation module documents a second, different correlation scheme (`<op>:<workspaceId>:<path>`, last-writer-wins, `request_id`-checked) that was previously interleaved with the first without distinction. `useDaemonSocket.ts` went 5,869 → 5,536 lines; public surface unchanged. 8 new tests in `useDaemonSocket.test.tsx` cover the notebook and markdown-annotation event paths, which the first extraction had passed vacuously — those paths had zero prior coverage.

**3.** Added a "Frontend map (`app/src`)" section to `AGENTS.md`'s Architecture section, covering where daemon traffic lands and the `daemon<Domain>Events.ts` convention for future extractions.

## Test plan

- [x] Go daemon/protocol tests green (`go build ./...`, `go test ./internal/daemon/...`, including new `wire_dispatch_test.go`)
- [x] 2,134 frontend tests green (`pnpm --dir app test`), `tsc --noEmit` clean
- [x] Dev-profile preflight green
- [x] Six live packaged-app scenarios green
- [x] e2e: 2 flaky failures (`settings.spec.ts:204`, `workspace-sessions.spec.ts:138`) that pass on isolated re-run — load flakes in a 16-minute suite, neither touching an extracted domain
- [x] Known pre-existing, unrelated: `notebook-editor-undo` scenario fails at `focus_editor_with_native_click`; reproduces identically on `origin/main` built in a scratch worktree

https://claude.ai/code/session_01Nhq7m5tZGkobQZuZgYqxqs