### PR TITLE
feat(bus): durable event bus core (extension platform A1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,7 @@ See [docs/plans/2026-07-18-db-loss-mitigation.md](docs/plans/2026-07-18-db-loss-
 - `internal/ptyworker`: per-session process; production PTYs run here through
   `internal/pty`, not inside the daemon
 - `internal/store`: SQLite plus in-memory cache
+- `internal/bus`: durable event bus (domain facts, per-consumer cursors)
 - `internal/classifier`: stop-time state classification
 - `internal/transcript`: assistant-message extraction from JSONL
 - `app`: Tauri frontend; WebSocket `ws://localhost:9849`
@@ -255,6 +256,35 @@ must fail explicitly.
   `classifierObservation`; reject stale results.
 - Prefer `internal/protocol/helpers.go` pointer/value helpers (`Ptr`, `Deref`,
   `SessionsToValues`, `PRsToValues`).
+
+### Event bus
+
+`internal/bus` is the durable spine. State-change broadcasts do not touch the
+hub directly: a producer publishes a **domain fact** (dotted `domain.verb`, an
+indexed subject naming the entity, a small payload), and the hub — an ephemeral
+consumer — runs the matching entry in `wireProjections`
+(`internal/daemon/bus.go`) to produce the wire traffic, often a snapshot
+re-push. Migration is in progress: `internal/daemon/bus.go` documents the
+producer/projection pattern, and unmigrated `broadcastXxx` methods still
+publish directly.
+
+- A fact without a subject is a snapshot invalidation, not a fact. If the
+  producer does not know the entity id, that is the bug to fix.
+- Byte streams stay off the bus by design: PTY output, PTY desync, attach
+  results, workspace tile content, and fs bursts keep their direct paths.
+  Attach traffic routes by a per-client predicate, which pub/sub cannot express.
+- Durable consumers get ordered, at-least-once delivery from a persisted cursor,
+  so handlers must tolerate redelivery. A failing handler stalls its own
+  consumer rather than skipping the event.
+- Retention trims past the age window but never past an **enabled** consumer's
+  cursor. Disabled consumers do not pin the log; they resume at head with a
+  logged gap.
+- Operator surface: `attn bus status`, `attn bus disable|enable <consumer>`.
+  The enabled bit is database-only on purpose — the kill switch must not depend
+  on the daemon it kills.
+
+Design and gate decisions:
+[docs/plans/2026-08-01-ext-a1-event-bus.md](docs/plans/2026-08-01-ext-a1-event-bus.md).
 
 ### Terminal
 

--- a/cmd/attn/bus.go
+++ b/cmd/attn/bus.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// `attn bus` is the operator surface for the durable event bus: what the log
+// holds, who is reading it, how far behind each reader is, and the kill switch.
+//
+// It reads and writes the profile database directly rather than going through
+// the daemon's IPC protocol. That is deliberate on both counts. Status is a
+// diagnostic and does not deserve a protocol version bump; and the enabled bit is
+// database-only BY DESIGN — a consumer is killed by flipping a row, and the
+// daemon re-reads that bit on every delivery cycle, so the switch works whether
+// or not the daemon is listening. (The automations discipline: a kill switch that
+// depends on the thing it is killing is not a kill switch.)
+//
+// Live and Stalled are in-process facts and therefore absent here; the daemon log
+// carries stalls.
+func runBus() {
+	if len(os.Args) < 3 || os.Args[2] == "-h" || os.Args[2] == "--help" {
+		writeBusHelp(os.Stdout)
+		return
+	}
+	switch os.Args[2] {
+	case "status":
+		runBusStatus(os.Args[3:])
+	case "enable":
+		runBusSetEnabled(os.Args[3:], true)
+	case "disable":
+		runBusSetEnabled(os.Args[3:], false)
+	default:
+		fmt.Fprintf(os.Stderr, "bus: unknown command %q\n", os.Args[2])
+		writeBusHelp(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+func writeBusHelp(w io.Writer) {
+	fmt.Fprint(w, `usage: attn bus <command>
+
+commands:
+  status [--json]
+        show the event log's live window and every registered consumer's
+        cursor, filter, enabled bit, and lag (head - cursor).
+
+  disable <consumer>
+        stop delivering to a consumer. Its cursor is preserved, but a disabled
+        consumer no longer holds the retention window open: once trimming
+        passes its cursor, re-enabling resumes it at head and logs the gap.
+
+  enable <consumer>
+        resume delivery from wherever the consumer's cursor stands.
+`)
+}
+
+type busStatusJSON struct {
+	Earliest  int64               `json:"earliest"`
+	Head      int64               `json:"head"`
+	Consumers []busConsumerReport `json:"consumers"`
+}
+
+type busConsumerReport struct {
+	Name      string `json:"name"`
+	Cursor    int64  `json:"cursor"`
+	Lag       int64  `json:"lag"`
+	Filter    string `json:"filter"`
+	Enabled   bool   `json:"enabled"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+func runBusStatus(args []string) {
+	asJSON := false
+	for _, a := range args {
+		switch a {
+		case "--json":
+			asJSON = true
+		case "-h", "--help":
+			writeBusHelp(os.Stdout)
+			return
+		default:
+			fmt.Fprintf(os.Stderr, "bus status: unknown flag %q\n", a)
+			os.Exit(2)
+		}
+	}
+
+	s, closeStore := openBusStore()
+	defer closeStore()
+
+	earliest, head, err := s.BusBounds()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bus status: reading log bounds: %v\n", err)
+		os.Exit(1)
+	}
+	rows, err := s.ListBusConsumers()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bus status: listing consumers: %v\n", err)
+		os.Exit(1)
+	}
+
+	report := busStatusJSON{Earliest: earliest, Head: head}
+	for _, r := range rows {
+		lag := head - r.Cursor
+		if lag < 0 {
+			lag = 0
+		}
+		entry := busConsumerReport{
+			Name: r.Name, Cursor: r.Cursor, Lag: lag,
+			Filter: r.Filter, Enabled: r.Enabled,
+		}
+		if !r.UpdatedAt.IsZero() {
+			entry.UpdatedAt = r.UpdatedAt.UTC().Format(time.RFC3339)
+		}
+		report.Consumers = append(report.Consumers, entry)
+	}
+
+	if asJSON {
+		out, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "bus status: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(out))
+		return
+	}
+
+	fmt.Printf("log: seq %d..%d (%d event(s) retained)\n", earliest, head, retainedCount(earliest, head))
+	if len(report.Consumers) == 0 {
+		fmt.Println("no registered consumers")
+		return
+	}
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "CONSUMER\tCURSOR\tLAG\tENABLED\tFILTER")
+	for _, c := range report.Consumers {
+		fmt.Fprintf(tw, "%s\t%d\t%d\t%t\t%s\n", c.Name, c.Cursor, c.Lag, c.Enabled, c.Filter)
+	}
+	_ = tw.Flush()
+}
+
+// retainedCount is a display-only approximation: seq is monotonic but trimming
+// removes rows from the middle of the space only at the low end, so head-earliest
+// overstates nothing except across a gap-free window. It is reported as a hint,
+// not a count of rows.
+func retainedCount(earliest, head int64) int64 {
+	if earliest == 0 || head < earliest {
+		return 0
+	}
+	return head - earliest + 1
+}
+
+func runBusSetEnabled(args []string, enabled bool) {
+	verb := "enable"
+	if !enabled {
+		verb = "disable"
+	}
+	if len(args) != 1 || strings.TrimSpace(args[0]) == "" {
+		fmt.Fprintf(os.Stderr, "usage: attn bus %s <consumer>\n", verb)
+		os.Exit(2)
+	}
+	name := strings.TrimSpace(args[0])
+
+	s, closeStore := openBusStore()
+	defer closeStore()
+
+	if _, ok, err := s.GetBusConsumer(name); err != nil {
+		fmt.Fprintf(os.Stderr, "bus %s: %v\n", verb, err)
+		os.Exit(1)
+	} else if !ok {
+		fmt.Fprintf(os.Stderr, "bus %s: no consumer named %q (see `attn bus status`)\n", verb, name)
+		os.Exit(1)
+	}
+	if err := s.SetBusConsumerEnabled(name, enabled, time.Now()); err != nil {
+		fmt.Fprintf(os.Stderr, "bus %s: %v\n", verb, err)
+		os.Exit(1)
+	}
+	fmt.Printf("consumer %q %sd\n", name, verb)
+}
+
+func openBusStore() (*store.Store, func()) {
+	s, err := store.NewWithDB(config.DBPath())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bus: opening %s: %v\n", config.DBPath(), err)
+		os.Exit(1)
+	}
+	return s, func() { _ = s.Close() }
+}

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -233,6 +233,9 @@ func main() {
 	case "db":
 		maybePrintProfileBanner()
 		runDB()
+	case "bus":
+		maybePrintProfileBanner()
+		runBus()
 	case "journal":
 		maybePrintProfileBanner()
 		runJournal()
@@ -613,6 +616,7 @@ commands:
   present <command>                 open a review presentation and read feedback
   debug <command>                   probe debug artifacts (incidents, logs)
   db <command>                      database maintenance (restore from backup)
+  bus <command>                     event bus: consumer cursors, lag, kill switch
   vision-check <image> <question>   answer a question about an image (single LLM call)
   daemon <command>                  manage the daemon
 	  daemon ensure|stop                ensure the daemon is running, or stop it

--- a/docs/plans/2026-08-01-ext-a1-event-bus.md
+++ b/docs/plans/2026-08-01-ext-a1-event-bus.md
@@ -174,6 +174,14 @@ closed. Both only affected durable consumers, so neither reached the wire.
   operator would reach for the switch. The bit is now re-read on the poll
   interval from inside the batch loop.
 
+- **A failed durable append silenced the wire.** `publish` returned before
+  fanning out, so a transient SQLite failure after an already-committed ticket or
+  session mutation dropped the projection entirely — a push that could not fail
+  that way before the bus existed. Ephemeral delivery is now unconditional, the
+  same degradation the store-less path already documented: the fact happened, only
+  its durability is missing. `Seq == 0` marks a non-durable event, and the caller
+  still gets the error.
+
 Known and accepted: production registers no durable consumers yet — the hub is
 ephemeral and extensions arrive in A4 — so the durable delivery loop is proved
 by tests (including against the real adapter) rather than by production traffic.

--- a/docs/plans/2026-08-01-ext-a1-event-bus.md
+++ b/docs/plans/2026-08-01-ext-a1-event-bus.md
@@ -1,0 +1,208 @@
+# A1 — Event bus core
+
+Stage A1 of the [extension platform roadmap](2026-08-01-extension-platform-roadmap.md).
+North star: [docs/vision/extension-platform.md](../vision/extension-platform.md).
+
+Status: gate approved by Victor 2026-08-01. Implemented and live-verified
+2026-08-01.
+
+## Gate answers
+
+The roadmap requires these to be settled with Victor before implementation.
+They are.
+
+### 1. Bus events are domain facts; wsHub projects them onto the wire
+
+The log carries **facts** — a name, an indexed subject, a small JSON payload —
+not the WebSocket event that a fact happens to produce. The WebSocket hub
+becomes a consumer whose *projection* decides what the wire needs, which is
+frequently a whole-list snapshot re-push.
+
+This matters because most of attn's ~27 `broadcastXxx` methods are snapshot
+pushes, not events: `broadcastSessionsUpdated`, `broadcastTicketsUpdated`, and
+`broadcastPRs` re-serialize entire lists. Putting those on a durable log would
+store a fat stream of UI invalidations, and an extension subscribing to it
+would learn only that "the ticket list changed again" — it would have to diff
+the list to recover the fact. Facts on the log keep it small and make
+subscription meaningful.
+
+The cost, accepted: A2 is a real per-broadcaster migration (fact + projection),
+not a mechanical rename.
+
+### 2. Ordered delivery, one event in flight, managed cursors
+
+Consumers register durably (name, cursor, filter). Delivery is strict global
+`seq` order with one event in flight per consumer; the cursor advances after
+the handler returns, giving at-least-once. New consumers start **from now** by
+default. Lag is `head - cursor` and is visible to the operator.
+
+Parallel per-subject delivery was rejected for now: it turns the cursor into a
+watermark plus an in-flight set, makes post-crash replay fuzzy, and forces
+every handler author — including agents writing extensions — to reason about
+concurrency from day one. It can be added later per-subject without changing
+the published contract.
+
+### 3. Retention: age window, cursor-aware, enabled consumers only
+
+Trim events older than a window (default 30 days), never past the slowest
+**enabled** consumer's cursor. A disabled or dead consumer does not pin the log
+forever: when it comes back with a cursor below the trim point, it resumes at
+head and the gap is logged. Bounded growth, no silent loss for live consumers.
+
+### 4. Streams stay off the bus
+
+The durable bus is for facts at human/agent scale. PTY output, PTY desync,
+attach results, workspace tile content, and fs change bursts keep their
+existing direct paths. `broadcastRawWSMessage` already performs per-client
+predicate routing (`SendRawTextToMatchingClients` with a client predicate for
+attach traffic), which pub/sub cannot express, and this is the hottest path in
+the product.
+
+A2's exit criterion is therefore: **every state-change broadcast goes through
+the bus; byte streams stay direct, by an enumerated and documented list of
+exceptions, and nothing else does.**
+
+### Assumptions accepted alongside the gate
+
+- Event names are dotted `domain.verb` with prefix-wildcard subscription
+  (`session.*`). `ext.<name>.*` is reserved for extension-published events.
+- The existing `ticket_events` log (migration 56) stays as-is in A1. Its
+  per-`(identity, ticket)` unread cursors are a domain feature, not bus
+  mechanics. Ticket mutators additionally publish facts to the bus; subsuming
+  the two logs is a later cleanup, not part of this stage.
+
+## Design
+
+### Package boundary
+
+`internal/bus`, following the `internal/tasks` precedent: it defines the
+persistence interface it needs, accepts an implementation plus a `LogFunc` at
+construction, and MUST NOT import `internal/daemon` (the daemon imports it).
+
+### Schema
+
+Migration 84 (latest existing is 83).
+
+```sql
+CREATE TABLE bus_events (
+    seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT NOT NULL,
+    subject    TEXT NOT NULL DEFAULT '',
+    payload    TEXT NOT NULL DEFAULT '',
+    source     TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL
+);
+CREATE INDEX idx_bus_events_name ON bus_events(name, seq);
+CREATE INDEX idx_bus_events_subject ON bus_events(subject, seq);
+
+CREATE TABLE bus_consumers (
+    name       TEXT PRIMARY KEY,
+    cursor     INTEGER NOT NULL DEFAULT 0,
+    filter     TEXT NOT NULL DEFAULT '',
+    enabled    INTEGER NOT NULL DEFAULT 1,
+    updated_at TEXT NOT NULL
+);
+```
+
+`seq` is the cursor space, exactly as `ticket_events.seq` is today.
+
+### Delivery
+
+One dispatch goroutine per registered durable consumer: read the next batch
+after `cursor` matching `filter`, invoke the handler per event in `seq` order,
+persist the cursor after each success. A handler error retries with backoff and
+does not advance the cursor (at-least-once, ordered, stalls loudly rather than
+skipping). Lag is exposed for operator inspection.
+
+The hub is an **ephemeral** consumer: it holds no row, starts at head, and
+receives live fan-out only. Clients already refetch on reconnect, so per-client
+replay is out of scope here.
+
+### Projection
+
+`internal/daemon` owns the fact → wire mapping. A publish call replaces the
+body of a `broadcastXxx` method; the hub consumer's projection re-derives what
+clients get. Wire behavior must not change.
+
+## As built
+
+1. **Migration 84** — `bus_events` (seq/name/subject/payload/source/created_at,
+   indexed by name and subject) and `bus_consumers` (name/cursor/filter/enabled/
+   updated_at). Store methods in `internal/store/bus.go`. `SaveBusConsumer`
+   preserves an existing row's cursor and enabled bit, so daemon restart
+   re-registers consumers without rewinding one or resurrecting a killed one.
+2. **`internal/bus`** — `Event`/`Consumer`/`Store`/`Handler`, `Filter` (`*`,
+   `prefix.*`, exact), publish with append + ordered ephemeral fan-out under one
+   lock, one delivery loop per durable consumer, retention loop, `Status`.
+3. **Daemon wiring** — `internal/daemon/bus_store.go` adapts the SQLite store to
+   the seam (the `sqlTaskStore` arrangement). `ensureEventBus` runs at
+   construction so a published fact projects even in a daemon that never
+   started; `startEventBus` runs early in `Start`, before startup reconciliation
+   can publish; `Stop` drops the subscription and drains.
+4. **Migrated** — `session.state.changed` (the method already took the entity
+   id, so no call site changed) and every ticket producer (16 call sites now
+   publish `ticket.created` / `status_changed` / `commented` / `assigned` /
+   `attached`, or `ticket.changed` where the site cannot name a sharper fact).
+5. **Operator surface** — `attn bus status [--json]`, `attn bus enable|disable
+   <consumer>`, reading and writing the profile database directly. No protocol
+   version bump: status is a diagnostic, and the enabled bit is database-only by
+   design so the kill switch does not depend on the daemon it kills.
+6. **Tests** — `internal/store/bus_test.go` (log ordering, bounds,
+   registration preservation, and the three trim cases: a lagging enabled
+   consumer holds the line, the age window holds inside it, a disabled consumer
+   does not pin), `internal/bus/{bus,filter}_test.go` (from-now default,
+   catch-up, at-least-once redelivery on handler failure, filtered skip still
+   advancing, ephemeral live-only, kill switch stop/resume, trimmed-past resume
+   at head, status lag), `internal/daemon/bus_test.go` (the same guarantees over
+   the real SQLite adapter, plus one fact producing exactly one board push).
+7. **Pattern for A2** — documented at the top of `internal/daemon/bus.go` and
+   summarized in AGENTS.md under "Event bus".
+
+Two defects in the delivery loop were found by review and fixed before the stage
+closed. Both only affected durable consumers, so neither reached the wire.
+
+- **Backoff measured the wrong thing.** The failure streak was cleared only when
+  a drain reached an empty batch, so a consumer that never caught up accumulated
+  attempts across *different*, already-succeeded events and ratcheted to the
+  retry cap on occasional transient failures. The streak now ends on every
+  successful delivery: backoff escalates for an event the handler cannot get
+  past, which is what it is for.
+- **The kill switch could not reach a saturated consumer.** `drain` read the
+  enabled bit once and then looped until the log was exhausted, so a consumer
+  behind a busy producer stayed unreachable for the length of the burst — making
+  `DefaultPollInterval`'s documented bound false in exactly the situation an
+  operator would reach for the switch. The bit is now re-read on the poll
+  interval from inside the batch loop.
+
+Known and accepted: production registers no durable consumers yet — the hub is
+ephemeral and extensions arrive in A4 — so the durable delivery loop is proved
+by tests (including against the real adapter) rather than by production traffic.
+The retention loop does run in production.
+
+## Exit criteria
+
+- Log and cursors survive daemon restart.
+- A consumer that was down catches up from its cursor, in order.
+- Trim honors enabled cursors; a long-disabled consumer resumes at head with a
+  logged gap rather than pinning the log.
+- Migrated broadcasters produce identical wire behavior.
+- The A2 migration pattern is written down.
+
+## Live verification
+
+Throwaway profile (packaged app + daemon on this branch), 2026-08-01. Preflight
+passed with no failures or warnings; protocol 200 agreed across CLI, app, and
+daemon.
+
+- Migration 84 applied; `bus_events` and `bus_consumers` present.
+- Three ticket mutations produced exactly the expected facts, in order:
+  `ticket.created`, `ticket.created`, `ticket.commented`, `ticket.created`,
+  each carrying its ticket id as the subject.
+- A WebSocket client observing those mutations received exactly one
+  `tickets_updated` per fact — one board push per fact, wire behavior unchanged.
+- Spawning a shell session produced one `session_state_changed` on the wire and
+  exactly one `session.state.changed` fact.
+- Daemon restart preserved the log (`seq 1..6`, 6 events retained).
+- Operator surface end to end: `attn bus status` (table and `--json`),
+  `disable`/`enable` against a lagging consumer row, and a non-zero exit for an
+  unknown consumer name.

--- a/docs/plans/2026-08-01-ext-b1-job-queue.md
+++ b/docs/plans/2026-08-01-ext-b1-job-queue.md
@@ -1,0 +1,76 @@
+# B1 — Durable job queue
+
+Stage B1 of the [extension platform roadmap](2026-08-01-extension-platform-roadmap.md).
+North star: [docs/vision/extension-platform.md](../vision/extension-platform.md).
+
+Status: gate approved by Victor 2026-08-01. Not started.
+
+## Gate answers
+
+### 1. Build ours, as a new package
+
+A new `internal/jobs` on a new table, porting the mechanics `internal/tasks`
+earned — the `CommitGuard` commit fence, cancel-blocks-until-exit, capped
+exponential backoff with a `dead` terminal state, per-kind concurrency caps,
+and the requeue-during-run flag — onto a generalized record.
+
+Rejected alternatives, and why:
+
+- **Adopt a third-party queue.** River is Postgres-only; the Go/SQLite options
+  are thin. Any of them would know nothing about the commit-fence contract the
+  existing kinds depend on, and the daemon is single-process, so the
+  multi-worker leasing such libraries are built around is dead weight.
+- **Extend `internal/tasks` in place.** The premises that must change — id is
+  `kind:subject`, deliberately no payload — are the ones that package is built
+  on. It would be a rewrite wearing the old name, performed underneath four
+  live kinds with no parity seam.
+
+The four kinds (`compact_context`, `summarize_session`, `narrate_workspace`,
+`reconcile`) migrate one at a time against a parity checklist.
+`internal/tasks` is deleted when the last one lands.
+
+### 2. Jobs are distinct by default, with an optional unique key
+
+A job is kind + payload + optional `unique_key` + priority + queue +
+per-job `max_attempts`, and a successful job persists a result.
+
+Setting `unique_key` reproduces today's coalescing exactly — the four existing
+kinds set it to their subject and behave as they do now, including
+coalesce-during-run. Leaving it unset gives B2 what activities require:
+arguments in, a value out, and two jobs of the same kind in flight at once.
+
+Keeping coalescing as a universal law was rejected precisely because it makes
+`activity("fetch", a)` and `activity("fetch", b)` collide, which would force
+B2 to build a second execution path.
+
+### 3. The queue owns firing; automations keeps catch-up policy
+
+The queue gains cron entries that enqueue a job at an instant, and both
+existing schedulers — `internal/daemon`'s automation schedule loop and the
+notebook cron enqueuer — become clients of that one timing mechanism.
+
+What stays in `internal/automation`: which missed occurrences still matter.
+The per-definition cursor, the five-minute skip grace, the one-million-instant
+replay-storm cap, and the startup-recovery interlock are product semantics
+tuned against real misfires, not queue mechanics. Generalizing them into cron
+would either impose them on every future caller or quietly lose them.
+
+### Assumptions accepted alongside the gate
+
+- The queue is Go, in-daemon. Extension-authored jobs are executed via the Bun
+  sidecar later (A4/B2); the queue itself does not move.
+- Completed jobs are retained for a window and then trimmed, mirroring the bus
+  retention decision in A1.
+
+## Sequence note
+
+B1 has no dependency on track A and runs in parallel with A1. B2 depends on
+this stage plus A4's sidecar.
+
+## Exit criteria
+
+- The four task kinds run on the queue with equivalent behavior, verified
+  against a written parity checklist.
+- `internal/tasks` is removed.
+- Periodic work fires from one mechanism; automations' catch-up behavior is
+  unchanged.

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -1,0 +1,763 @@
+// Package bus is attn's durable event bus: the internal spine that carries
+// domain facts from whatever produced them to everything that reacts.
+//
+// A fact is a name, a subject, and a small payload — "this session changed
+// state", "this ticket was commented on". It is NOT a WebSocket message. Most of
+// what the daemon currently pushes to clients is a whole-list snapshot, and a log
+// of snapshots would be a fat stream of UI invalidations that tells a subscriber
+// only that something changed. Facts stay small, stay durable, and are worth
+// subscribing to. Turning a fact into whatever the wire needs — frequently a
+// snapshot re-push — is the consumer's job, not the publisher's.
+//
+// Two kinds of consumer:
+//
+//   - Durable consumers register by name and hold a persisted cursor. Delivery is
+//     strict seq order, one event in flight, cursor advanced after the handler
+//     returns: at-least-once. A consumer that was down catches up from its
+//     bookmark. A handler that keeps failing stalls its own consumer loudly
+//     rather than skipping the event.
+//   - Ephemeral subscribers hold no cursor and start at head. The WebSocket hub
+//     is one: clients already refetch on reconnect, so replaying history into a
+//     hub would duplicate work the frontend already does.
+//
+// What does NOT belong here: byte streams. PTY output, attach traffic, and tile
+// content keep their direct paths. They are high volume, and attach routing is
+// per-client predicate matching, which pub/sub cannot express.
+//
+// The package accepts a Store and a LogFunc at construction and MUST NOT import
+// internal/daemon (the daemon imports this package and adapts internal/store to
+// the Store seam, exactly as it does for internal/tasks).
+//
+// See docs/plans/2026-08-01-ext-a1-event-bus.md.
+package bus
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// DefaultRetention is the age window for the durable log. Events older than
+	// this are eligible for trimming, subject to the enabled-consumer cursor floor.
+	DefaultRetention = 30 * 24 * time.Hour
+	// DefaultTrimInterval is how often retention runs.
+	DefaultTrimInterval = time.Hour
+	// DefaultBatchSize bounds one read of the forward stream.
+	DefaultBatchSize = 200
+	// DefaultPollInterval is the safety-net wake for a durable consumer. Delivery
+	// is normally driven by publish notifications; this bounds how long a missed
+	// notification, or an externally flipped enabled bit, can go unnoticed.
+	DefaultPollInterval = 5 * time.Second
+	// DefaultRetryBase / DefaultRetryCap bound the capped-exponential retry of a
+	// failing handler.
+	DefaultRetryBase = time.Second
+	DefaultRetryCap  = 2 * time.Minute
+)
+
+// ErrAlreadyStarted is returned by Register once Start has run: the set of
+// durable consumers is fixed at startup, so a delivery loop always exists for
+// every registration.
+var ErrAlreadyStarted = errors.New("bus: consumers must be registered before Start")
+
+// LogFunc matches the daemon's injected logger shape (see internal/tasks,
+// internal/pty). Runtime logging goes through it — never log.Printf, whose stderr
+// is discarded when the daemon runs in the background.
+type LogFunc func(format string, args ...interface{})
+
+// Event is one fact on the log.
+type Event struct {
+	Seq       int64
+	Name      string
+	Subject   string
+	Payload   json.RawMessage
+	Source    string
+	CreatedAt time.Time
+}
+
+// Decode unmarshals the payload into v. A fact with no payload leaves v untouched.
+func (e Event) Decode(v any) error {
+	if len(e.Payload) == 0 {
+		return nil
+	}
+	return json.Unmarshal(e.Payload, v)
+}
+
+// Consumer is a durable consumer's persisted registration and position.
+type Consumer struct {
+	Name      string
+	Cursor    int64
+	Filter    string
+	Enabled   bool
+	UpdatedAt time.Time
+}
+
+// Store is the persistence seam. internal/store implements the equivalent
+// methods; the daemon adapts them so neither package imports the other.
+type Store interface {
+	Append(e Event, now time.Time) (int64, error)
+	Since(cursor int64, limit int) ([]Event, error)
+	Bounds() (earliest, head int64, err error)
+	GetConsumer(name string) (Consumer, bool, error)
+	SaveConsumer(c Consumer, now time.Time) error
+	SetCursor(name string, cursor int64, now time.Time) error
+	ListConsumers() ([]Consumer, error)
+	Trim(cutoff time.Time) (int, error)
+}
+
+// Handler receives one event. Returning an error stalls the consumer on that
+// event and retries with backoff; the cursor does not advance, so the event is
+// redelivered. Handlers must therefore tolerate redelivery.
+type Handler func(ctx context.Context, ev Event) error
+
+// Options configures a Bus. Every duration is optional and falls back to the
+// package defaults.
+type Options struct {
+	Store        Store
+	Log          LogFunc
+	Now          func() time.Time
+	Retention    time.Duration
+	TrimInterval time.Duration
+	BatchSize    int
+	PollInterval time.Duration
+	RetryBase    time.Duration
+	RetryCap     time.Duration
+}
+
+// Bus is the event bus. The zero value is not usable; construct with New.
+type Bus struct {
+	store Store
+	log   LogFunc
+	now   func() time.Time
+
+	retention    time.Duration
+	trimInterval time.Duration
+	batchSize    int
+	pollInterval time.Duration
+	retryBase    time.Duration
+	retryCap     time.Duration
+
+	// publishMu serializes append + ephemeral fan-out so ephemeral subscribers
+	// observe events in seq order. Durable consumers get ordering from their
+	// cursor and do not need it.
+	publishMu sync.Mutex
+
+	mu        sync.Mutex
+	durables  []*durable
+	ephemeral map[int]*ephemeralSub
+	nextSubID int
+	started   bool
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+type durable struct {
+	name    string
+	filter  Filter
+	handler Handler
+
+	wake chan struct{}
+
+	mu       sync.Mutex
+	cursor   int64
+	enabled  bool
+	stalled  string
+	failures int
+}
+
+type ephemeralSub struct {
+	filter Filter
+	fn     func(Event)
+}
+
+// New builds a Bus. A nil Store yields a bus that accepts publishes and drops
+// them, mirroring the store's own nil-db convention so a daemon without a
+// database still runs.
+func New(opts Options) *Bus {
+	b := &Bus{
+		store:        opts.Store,
+		log:          opts.Log,
+		now:          opts.Now,
+		retention:    nonZeroDuration(opts.Retention, DefaultRetention),
+		trimInterval: nonZeroDuration(opts.TrimInterval, DefaultTrimInterval),
+		batchSize:    nonZeroInt(opts.BatchSize, DefaultBatchSize),
+		pollInterval: nonZeroDuration(opts.PollInterval, DefaultPollInterval),
+		retryBase:    nonZeroDuration(opts.RetryBase, DefaultRetryBase),
+		retryCap:     nonZeroDuration(opts.RetryCap, DefaultRetryCap),
+		ephemeral:    map[int]*ephemeralSub{},
+	}
+	if b.now == nil {
+		b.now = time.Now
+	}
+	if b.log == nil {
+		b.log = func(string, ...interface{}) {}
+	}
+	b.ctx, b.cancel = context.WithCancel(context.Background())
+	return b
+}
+
+// Publish appends a fact and returns its seq. Payload may be nil (a fact whose
+// subject says everything) or any JSON-marshalable value.
+//
+// The write is synchronous: the caller learns the fact is durable, and the seq is
+// assigned under the same lock that orders ephemeral delivery. This is affordable
+// because the bus carries facts, not streams.
+func (b *Bus) Publish(name, subject string, payload any) (int64, error) {
+	return b.publish(Event{Name: name, Subject: subject}, payload)
+}
+
+// PublishFrom is Publish with an explicit source label for diagnosis.
+func (b *Bus) PublishFrom(source, name, subject string, payload any) (int64, error) {
+	return b.publish(Event{Name: name, Subject: subject, Source: source}, payload)
+}
+
+func (b *Bus) publish(ev Event, payload any) (int64, error) {
+	if strings.TrimSpace(ev.Name) == "" {
+		return 0, errors.New("bus: publish requires an event name")
+	}
+	if payload != nil {
+		raw, err := json.Marshal(payload)
+		if err != nil {
+			return 0, fmt.Errorf("bus: marshaling payload for %s: %w", ev.Name, err)
+		}
+		ev.Payload = raw
+	}
+	b.publishMu.Lock()
+	defer b.publishMu.Unlock()
+
+	now := b.now()
+	ev.CreatedAt = now
+
+	// Without a store the fact still HAPPENED — only its durability is missing.
+	// Live subscribers are delivered to either way, so a bus configured without a
+	// database degrades to fan-out rather than to silence.
+	if b.store == nil {
+		b.fanoutEphemeral(ev)
+		return 0, nil
+	}
+
+	seq, err := b.store.Append(ev, now)
+	if err != nil {
+		return 0, fmt.Errorf("bus: appending %s: %w", ev.Name, err)
+	}
+	ev.Seq = seq
+
+	b.fanoutEphemeral(ev)
+	b.wakeDurables()
+	return seq, nil
+}
+
+func (b *Bus) fanoutEphemeral(ev Event) {
+	b.mu.Lock()
+	subs := make([]*ephemeralSub, 0, len(b.ephemeral))
+	for _, s := range b.ephemeral {
+		subs = append(subs, s)
+	}
+	b.mu.Unlock()
+
+	for _, s := range subs {
+		if s.filter.Matches(ev.Name) {
+			s.fn(ev)
+		}
+	}
+}
+
+func (b *Bus) wakeDurables() {
+	b.mu.Lock()
+	ds := append([]*durable(nil), b.durables...)
+	b.mu.Unlock()
+
+	for _, d := range ds {
+		select {
+		case d.wake <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// Register adds a durable consumer. It must be called before Start.
+//
+// A consumer new to the store begins at head: registering a consumer is not a
+// request to replay history. An existing consumer keeps its cursor and its
+// enabled bit — restarting the daemon must neither rewind a consumer nor
+// resurrect one the operator killed.
+func (b *Bus) Register(name string, filter Filter, h Handler) error {
+	if strings.TrimSpace(name) == "" {
+		return errors.New("bus: consumer name is required")
+	}
+	if h == nil {
+		return fmt.Errorf("bus: consumer %s needs a handler", name)
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.started {
+		return ErrAlreadyStarted
+	}
+	for _, d := range b.durables {
+		if d.name == name {
+			return fmt.Errorf("bus: consumer %s already registered", name)
+		}
+	}
+	b.durables = append(b.durables, &durable{
+		name:    name,
+		filter:  filter,
+		handler: h,
+		wake:    make(chan struct{}, 1),
+		enabled: true,
+	})
+	return nil
+}
+
+// Subscribe adds an ephemeral subscriber and returns its cancel function. The
+// subscriber holds no cursor, starts at head, and is invoked inline on the
+// publishing goroutine in seq order — so its function must be cheap and must not
+// publish back onto the bus.
+func (b *Bus) Subscribe(filter Filter, fn func(Event)) func() {
+	if fn == nil {
+		return func() {}
+	}
+	b.mu.Lock()
+	id := b.nextSubID
+	b.nextSubID++
+	b.ephemeral[id] = &ephemeralSub{filter: filter, fn: fn}
+	b.mu.Unlock()
+
+	return func() {
+		b.mu.Lock()
+		delete(b.ephemeral, id)
+		b.mu.Unlock()
+	}
+}
+
+// Start persists every registration and launches one delivery loop per durable
+// consumer, plus the retention loop.
+func (b *Bus) Start() error {
+	b.mu.Lock()
+	if b.started {
+		b.mu.Unlock()
+		return nil
+	}
+	b.started = true
+	ds := append([]*durable(nil), b.durables...)
+	b.mu.Unlock()
+
+	if b.store == nil {
+		return nil
+	}
+
+	_, head, err := b.store.Bounds()
+	if err != nil {
+		return fmt.Errorf("bus: reading log bounds: %w", err)
+	}
+
+	for _, d := range ds {
+		if err := b.initConsumer(d, head); err != nil {
+			return err
+		}
+		b.wg.Add(1)
+		go func(d *durable) {
+			defer b.wg.Done()
+			b.deliver(d)
+		}(d)
+	}
+
+	b.wg.Add(1)
+	go func() {
+		defer b.wg.Done()
+		b.retain()
+	}()
+	return nil
+}
+
+// initConsumer creates or reconciles the persisted registration for d.
+func (b *Bus) initConsumer(d *durable, head int64) error {
+	existing, ok, err := b.store.GetConsumer(d.name)
+	if err != nil {
+		return fmt.Errorf("bus: loading consumer %s: %w", d.name, err)
+	}
+	now := b.now()
+	if !ok {
+		// From now: a fresh consumer is not asking for the backlog.
+		if err := b.store.SaveConsumer(Consumer{
+			Name:    d.name,
+			Cursor:  head,
+			Filter:  d.filter.String(),
+			Enabled: true,
+		}, now); err != nil {
+			return fmt.Errorf("bus: registering consumer %s: %w", d.name, err)
+		}
+		d.setPosition(head, true)
+		return nil
+	}
+	// SaveConsumer refreshes the filter but preserves cursor and enabled.
+	if err := b.store.SaveConsumer(Consumer{
+		Name:    d.name,
+		Cursor:  existing.Cursor,
+		Filter:  d.filter.String(),
+		Enabled: existing.Enabled,
+	}, now); err != nil {
+		return fmt.Errorf("bus: updating consumer %s: %w", d.name, err)
+	}
+	d.setPosition(existing.Cursor, existing.Enabled)
+	return nil
+}
+
+// Stop cancels delivery and waits for the loops to exit. In-flight handlers see
+// a cancelled context; their cursor is not advanced, so an interrupted event is
+// redelivered on the next start.
+func (b *Bus) Stop() {
+	b.cancel()
+	b.wg.Wait()
+}
+
+// deliver is one durable consumer's loop.
+func (b *Bus) deliver(d *durable) {
+	ticker := time.NewTicker(b.pollInterval)
+	defer ticker.Stop()
+
+	retry := time.Duration(0)
+	for {
+		if retry > 0 {
+			timer := time.NewTimer(retry)
+			select {
+			case <-b.ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+			retry = 0
+		} else {
+			select {
+			case <-b.ctx.Done():
+				return
+			case <-d.wake:
+			case <-ticker.C:
+			}
+		}
+
+		failures := d.drainFailures()
+		if err := b.drain(d); err != nil {
+			if b.ctx.Err() != nil {
+				return
+			}
+			retry = backoff(b.retryBase, b.retryCap, failures+1)
+			d.recordFailure(err.Error(), failures+1)
+			b.log("bus: consumer %s stalled at seq %d (attempt %d, retry in %s): %v",
+				d.name, d.position()+1, failures+1, retry, err)
+		}
+	}
+}
+
+// drain reads forward from the consumer's cursor until the log is exhausted.
+func (b *Bus) drain(d *durable) error {
+	// The enabled bit is the kill switch and lives only in the database, so it is
+	// re-read here rather than cached for the process lifetime.
+	rec, ok, err := b.store.GetConsumer(d.name)
+	if err != nil {
+		return fmt.Errorf("reading registration: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("registration for %s disappeared", d.name)
+	}
+	d.setPosition(rec.Cursor, rec.Enabled)
+	if !rec.Enabled {
+		return nil
+	}
+
+	if err := b.reconcileGap(d); err != nil {
+		return err
+	}
+
+	// A consumer that is behind a busy producer never leaves the loop below, so
+	// re-reading the kill switch once per drain would leave it unreachable for as
+	// long as the burst lasts. Re-read it on the poll interval instead, which is
+	// the bound DefaultPollInterval documents.
+	lastCheck := b.now()
+	killed := func() (bool, error) {
+		if b.now().Sub(lastCheck) < b.pollInterval {
+			return false, nil
+		}
+		lastCheck = b.now()
+		rec, ok, err := b.store.GetConsumer(d.name)
+		if err != nil {
+			return false, fmt.Errorf("reading registration: %w", err)
+		}
+		if !ok {
+			return false, fmt.Errorf("registration for %s disappeared", d.name)
+		}
+		d.setEnabled(rec.Enabled)
+		return !rec.Enabled, nil
+	}
+
+	for {
+		if b.ctx.Err() != nil {
+			return nil
+		}
+		events, err := b.store.Since(d.position(), b.batchSize)
+		if err != nil {
+			return fmt.Errorf("reading log: %w", err)
+		}
+		if len(events) == 0 {
+			d.clearFailure()
+			return nil
+		}
+
+		var skipped int64
+		for _, ev := range events {
+			if b.ctx.Err() != nil {
+				return nil
+			}
+			stop, err := killed()
+			if err != nil {
+				return err
+			}
+			if stop {
+				if skipped != 0 {
+					return b.advance(d, skipped)
+				}
+				return nil
+			}
+			if !d.filter.Matches(ev.Name) {
+				// Unwanted events still advance the cursor, batched into one write
+				// at the next matching event or at the end of the batch.
+				skipped = ev.Seq
+				continue
+			}
+			if skipped != 0 {
+				if err := b.advance(d, skipped); err != nil {
+					return err
+				}
+				skipped = 0
+			}
+			if err := d.handler(b.ctx, ev); err != nil {
+				if b.ctx.Err() != nil {
+					return nil
+				}
+				return fmt.Errorf("handling %s (seq %d): %w", ev.Name, ev.Seq, err)
+			}
+			if err := b.advance(d, ev.Seq); err != nil {
+				return err
+			}
+			// Backoff escalates for an event the handler cannot get past, not over
+			// a consumer's lifetime: a delivery that succeeds ends the streak, so a
+			// consumer that is merely lagging does not ratchet to the retry cap on
+			// occasional transient failures.
+			d.clearFailure()
+		}
+		if skipped != 0 {
+			if err := b.advance(d, skipped); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// reconcileGap handles a consumer whose cursor sits below the oldest surviving
+// event: retention trimmed past it while it was disabled or dead. It resumes at
+// head — replaying a month of backlog into a just-revived consumer would be worse
+// than the gap — and says so.
+func (b *Bus) reconcileGap(d *durable) error {
+	earliest, head, err := b.store.Bounds()
+	if err != nil {
+		return fmt.Errorf("reading log bounds: %w", err)
+	}
+	if earliest == 0 || d.position() >= earliest-1 {
+		return nil
+	}
+	missed := earliest - 1 - d.position()
+	b.log("bus: consumer %s resumed at head %d; %d event(s) were trimmed before its cursor %d",
+		d.name, head, missed, d.position())
+	return b.advance(d, head)
+}
+
+func (b *Bus) advance(d *durable, seq int64) error {
+	if err := b.store.SetCursor(d.name, seq, b.now()); err != nil {
+		return fmt.Errorf("persisting cursor: %w", err)
+	}
+	d.setCursor(seq)
+	return nil
+}
+
+// retain runs the retention window.
+func (b *Bus) retain() {
+	ticker := time.NewTicker(b.trimInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-b.ctx.Done():
+			return
+		case <-ticker.C:
+			b.Trim()
+		}
+	}
+}
+
+// Trim runs one retention pass and reports how many events were removed. It is
+// exported so the daemon and tests can force a pass without waiting for a tick.
+func (b *Bus) Trim() int {
+	if b.store == nil {
+		return 0
+	}
+	n, err := b.store.Trim(b.now().Add(-b.retention))
+	if err != nil {
+		b.log("bus: retention pass failed: %v", err)
+		return 0
+	}
+	if n > 0 {
+		b.log("bus: trimmed %d event(s) older than %s", n, b.retention)
+	}
+	return n
+}
+
+// ConsumerStatus is one row of Status.
+type ConsumerStatus struct {
+	Name    string
+	Cursor  int64
+	Lag     int64
+	Filter  string
+	Enabled bool
+	// Live is true when this process has a delivery loop for the consumer. A
+	// registered-but-not-live consumer is one whose owner is gone.
+	Live bool
+	// Stalled carries the current failure message when a handler is failing.
+	Stalled string
+}
+
+// Status reports the log head and every registration, for operator inspection.
+type Status struct {
+	Head      int64
+	Earliest  int64
+	Consumers []ConsumerStatus
+}
+
+// Status snapshots the bus for `attn bus status`.
+func (b *Bus) Status() (Status, error) {
+	if b.store == nil {
+		return Status{}, nil
+	}
+	earliest, head, err := b.store.Bounds()
+	if err != nil {
+		return Status{}, err
+	}
+	rows, err := b.store.ListConsumers()
+	if err != nil {
+		return Status{}, err
+	}
+
+	b.mu.Lock()
+	live := make(map[string]*durable, len(b.durables))
+	for _, d := range b.durables {
+		live[d.name] = d
+	}
+	b.mu.Unlock()
+
+	out := Status{Head: head, Earliest: earliest}
+	for _, r := range rows {
+		cs := ConsumerStatus{
+			Name:    r.Name,
+			Cursor:  r.Cursor,
+			Lag:     head - r.Cursor,
+			Filter:  r.Filter,
+			Enabled: r.Enabled,
+		}
+		if cs.Lag < 0 {
+			cs.Lag = 0
+		}
+		if d, ok := live[r.Name]; ok {
+			cs.Live = true
+			cs.Stalled = d.stallReason()
+		}
+		out.Consumers = append(out.Consumers, cs)
+	}
+	return out, nil
+}
+
+func (d *durable) position() int64 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.cursor
+}
+
+func (d *durable) setCursor(seq int64) {
+	d.mu.Lock()
+	d.cursor = seq
+	d.mu.Unlock()
+}
+
+func (d *durable) setPosition(cursor int64, enabled bool) {
+	d.mu.Lock()
+	d.cursor = cursor
+	d.enabled = enabled
+	d.mu.Unlock()
+}
+
+func (d *durable) setEnabled(enabled bool) {
+	d.mu.Lock()
+	d.enabled = enabled
+	d.mu.Unlock()
+}
+
+func (d *durable) recordFailure(reason string, count int) {
+	d.mu.Lock()
+	d.stalled = reason
+	d.failures = count
+	d.mu.Unlock()
+}
+
+func (d *durable) clearFailure() {
+	d.mu.Lock()
+	d.stalled = ""
+	d.failures = 0
+	d.mu.Unlock()
+}
+
+func (d *durable) drainFailures() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.failures
+}
+
+func (d *durable) stallReason() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.stalled
+}
+
+// backoff is capped exponential, matching internal/tasks' schedule.
+func backoff(base, ceiling time.Duration, attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	d := base
+	for i := 1; i < attempt; i++ {
+		d *= 2
+		if d >= ceiling {
+			return ceiling
+		}
+	}
+	if d > ceiling {
+		return ceiling
+	}
+	return d
+}
+
+func nonZeroDuration(v, fallback time.Duration) time.Duration {
+	if v <= 0 {
+		return fallback
+	}
+	return v
+}
+
+func nonZeroInt(v, fallback int) int {
+	if v <= 0 {
+		return fallback
+	}
+	return v
+}

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -244,6 +244,11 @@ func (b *Bus) publish(ev Event, payload any) (int64, error) {
 
 	seq, err := b.store.Append(ev, now)
 	if err != nil {
+		// Same degradation as the store-less case above, and for the same reason.
+		// These projections were direct broadcasts before the bus existed; a client
+		// must not miss a state change because the durable log had a bad night. The
+		// caller still learns durability was lost.
+		b.fanoutEphemeral(ev)
 		return 0, fmt.Errorf("bus: appending %s: %w", ev.Name, err)
 	}
 	ev.Seq = seq
@@ -319,6 +324,11 @@ func (b *Bus) Register(name string, filter Filter, h Handler) error {
 // subscriber holds no cursor, starts at head, and is invoked inline on the
 // publishing goroutine in seq order — so its function must be cheap and must not
 // publish back onto the bus.
+//
+// Seq is 0 when the fact could not be made durable (no store, or a failed
+// append). Ephemeral delivery is deliberately not conditional on durability:
+// these subscribers project onto the wire, and the wire must not go quiet
+// because the log did. A subscriber that cares must check Seq.
 func (b *Bus) Subscribe(filter Filter, fn func(Event)) func() {
 	if fn == nil {
 		return func() {}

--- a/internal/bus/bus_test.go
+++ b/internal/bus/bus_test.go
@@ -18,7 +18,8 @@ type memStore struct {
 	nextSeq   int64
 	consumers map[string]Consumer
 
-	sinceErr error
+	sinceErr  error
+	appendErr error
 }
 
 func newMemStore() *memStore {
@@ -28,6 +29,9 @@ func newMemStore() *memStore {
 func (m *memStore) Append(e Event, now time.Time) (int64, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.appendErr != nil {
+		return 0, m.appendErr
+	}
 	m.nextSeq++
 	e.Seq = m.nextSeq
 	e.CreatedAt = now
@@ -94,6 +98,12 @@ func (m *memStore) SetCursor(name string, cursor int64, now time.Time) error {
 	c.UpdatedAt = now
 	m.consumers[name] = c
 	return nil
+}
+
+func (m *memStore) setAppendErr(err error) {
+	m.mu.Lock()
+	m.appendErr = err
+	m.mu.Unlock()
 }
 
 func (m *memStore) setEnabled(name string, enabled bool) {
@@ -872,4 +882,56 @@ func (c *testClock) advance(d time.Duration) {
 	c.mu.Lock()
 	c.now = c.now.Add(d)
 	c.mu.Unlock()
+}
+
+// A failed durable append must not take the wire down with it. Ephemeral
+// subscribers project onto the WebSocket; before the bus existed those were
+// direct broadcasts that could not fail this way, so degrading to fan-out —
+// exactly as a store-less bus does — is what keeps clients in sync.
+func TestFailedAppendStillFansOutToSubscribers(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+
+	var mu sync.Mutex
+	var seen []Event
+	cancel := b.Subscribe(All, func(ev Event) {
+		mu.Lock()
+		seen = append(seen, ev)
+		mu.Unlock()
+	})
+	t.Cleanup(cancel)
+
+	s.setAppendErr(errors.New("disk had a bad night"))
+
+	seq, err := b.Publish("ticket.created", "t-1", nil)
+	if err == nil {
+		t.Fatalf("Publish reported success despite a failed append")
+	}
+	if seq != 0 {
+		t.Fatalf("a non-durable fact got seq %d, want 0", seq)
+	}
+
+	mu.Lock()
+	got := append([]Event(nil), seen...)
+	mu.Unlock()
+
+	if len(got) != 1 {
+		t.Fatalf("the subscriber saw %d event(s); a failed append silenced the wire", len(got))
+	}
+	if got[0].Name != "ticket.created" || got[0].Subject != "t-1" {
+		t.Fatalf("fanned out the wrong event: %+v", got[0])
+	}
+	if got[0].Seq != 0 {
+		t.Fatalf("a non-durable event carried seq %d, want 0 as the marker", got[0].Seq)
+	}
+
+	// And the bus recovers: once the store is healthy the next fact is durable.
+	s.setAppendErr(nil)
+	seq, err = b.Publish("ticket.created", "t-2", nil)
+	if err != nil {
+		t.Fatalf("Publish after recovery: %v", err)
+	}
+	if seq == 0 {
+		t.Fatalf("the fact after recovery was not made durable")
+	}
 }

--- a/internal/bus/bus_test.go
+++ b/internal/bus/bus_test.go
@@ -1,0 +1,875 @@
+package bus
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// memStore is an in-memory Store for the delivery tests. Its trim semantics
+// deliberately mirror the SQLite implementation (age window AND the enabled-only
+// cursor floor) so a test that passes here is not passing because the fake is
+// more permissive than the real thing.
+type memStore struct {
+	mu        sync.Mutex
+	events    []Event
+	nextSeq   int64
+	consumers map[string]Consumer
+
+	sinceErr error
+}
+
+func newMemStore() *memStore {
+	return &memStore{consumers: map[string]Consumer{}}
+}
+
+func (m *memStore) Append(e Event, now time.Time) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nextSeq++
+	e.Seq = m.nextSeq
+	e.CreatedAt = now
+	m.events = append(m.events, e)
+	return e.Seq, nil
+}
+
+func (m *memStore) Since(cursor int64, limit int) ([]Event, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.sinceErr != nil {
+		return nil, m.sinceErr
+	}
+	var out []Event
+	for _, e := range m.events {
+		if e.Seq > cursor {
+			out = append(out, e)
+			if len(out) >= limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func (m *memStore) Bounds() (int64, int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.events) == 0 {
+		return 0, 0, nil
+	}
+	return m.events[0].Seq, m.events[len(m.events)-1].Seq, nil
+}
+
+func (m *memStore) GetConsumer(name string) (Consumer, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	c, ok := m.consumers[name]
+	return c, ok, nil
+}
+
+func (m *memStore) SaveConsumer(c Consumer, now time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if existing, ok := m.consumers[c.Name]; ok {
+		existing.Filter = c.Filter
+		existing.UpdatedAt = now
+		m.consumers[c.Name] = existing
+		return nil
+	}
+	c.UpdatedAt = now
+	m.consumers[c.Name] = c
+	return nil
+}
+
+func (m *memStore) SetCursor(name string, cursor int64, now time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	c, ok := m.consumers[name]
+	if !ok {
+		return errors.New("no such consumer")
+	}
+	c.Cursor = cursor
+	c.UpdatedAt = now
+	m.consumers[name] = c
+	return nil
+}
+
+func (m *memStore) setEnabled(name string, enabled bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	c := m.consumers[name]
+	c.Enabled = enabled
+	m.consumers[name] = c
+}
+
+func (m *memStore) ListConsumers() ([]Consumer, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []Consumer
+	for _, c := range m.consumers {
+		out = append(out, c)
+	}
+	return out, nil
+}
+
+func (m *memStore) Trim(cutoff time.Time) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	floor := int64(-1)
+	for _, c := range m.consumers {
+		if !c.Enabled {
+			continue
+		}
+		if floor < 0 || c.Cursor < floor {
+			floor = c.Cursor
+		}
+	}
+	if floor < 0 && len(m.events) > 0 {
+		floor = m.events[len(m.events)-1].Seq
+	}
+	kept := m.events[:0]
+	removed := 0
+	for _, e := range m.events {
+		if e.CreatedAt.Before(cutoff) && e.Seq <= floor {
+			removed++
+			continue
+		}
+		kept = append(kept, e)
+	}
+	m.events = kept
+	return removed, nil
+}
+
+// dropEventsBelow simulates retention having already trimmed the log, without
+// consulting cursors — the state a killed consumer wakes up into.
+func (m *memStore) dropEventsBelow(seq int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var kept []Event
+	for _, e := range m.events {
+		if e.Seq >= seq {
+			kept = append(kept, e)
+		}
+	}
+	m.events = kept
+}
+
+// recorder collects delivered events for assertions.
+type recorder struct {
+	mu     sync.Mutex
+	names  []string
+	seqs   []int64
+	failOn map[int64]int // seq -> remaining failures
+}
+
+func newRecorder() *recorder { return &recorder{failOn: map[int64]int{}} }
+
+func (r *recorder) handle(_ context.Context, ev Event) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if n := r.failOn[ev.Seq]; n > 0 {
+		r.failOn[ev.Seq] = n - 1
+		r.seqs = append(r.seqs, ev.Seq)
+		r.names = append(r.names, ev.Name)
+		return errors.New("handler boom")
+	}
+	r.seqs = append(r.seqs, ev.Seq)
+	r.names = append(r.names, ev.Name)
+	return nil
+}
+
+func (r *recorder) snapshot() ([]string, []int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.names...), append([]int64(nil), r.seqs...)
+}
+
+func (r *recorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.seqs)
+}
+
+func testBus(t *testing.T, s Store) *Bus {
+	t.Helper()
+	return New(Options{
+		Store:        s,
+		Log:          func(string, ...interface{}) {},
+		PollInterval: 5 * time.Millisecond,
+		RetryBase:    5 * time.Millisecond,
+		RetryCap:     20 * time.Millisecond,
+		TrimInterval: time.Hour,
+	})
+}
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// A consumer registering for the first time starts at head: registration is not
+// a request to replay the backlog.
+func TestNewConsumerStartsAtHead(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+
+	if _, err := b.Publish("old.fact", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	rec := newRecorder()
+	if err := b.Register("late", All, rec.handle); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	if _, err := b.Publish("new.fact", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	waitFor(t, "the post-registration fact", func() bool { return rec.count() >= 1 })
+
+	names, _ := rec.snapshot()
+	if len(names) != 1 || names[0] != "new.fact" {
+		t.Fatalf("delivered %v; a fresh consumer must not replay history", names)
+	}
+}
+
+// The whole point of a durable cursor: a consumer that was not running catches
+// up, in order, from where it left off.
+func TestDownedConsumerCatchesUpInOrder(t *testing.T) {
+	s := newMemStore()
+
+	first := testBus(t, s)
+	rec1 := newRecorder()
+	if err := first.Register("worker", All, rec1.handle); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := first.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := first.Publish("a.happened", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	waitFor(t, "the first delivery", func() bool { return rec1.count() == 1 })
+	first.Stop()
+
+	// Events published while the consumer is down.
+	offline := testBus(t, s)
+	for _, name := range []string{"b.happened", "c.happened", "d.happened"} {
+		if _, err := offline.Publish(name, "", nil); err != nil {
+			t.Fatalf("Publish(%s): %v", name, err)
+		}
+	}
+
+	second := testBus(t, s)
+	rec2 := newRecorder()
+	if err := second.Register("worker", All, rec2.handle); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := second.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(second.Stop)
+
+	waitFor(t, "catch-up", func() bool { return rec2.count() >= 3 })
+	names, seqs := rec2.snapshot()
+	want := []string{"b.happened", "c.happened", "d.happened"}
+	if len(names) != 3 {
+		t.Fatalf("delivered %v, want exactly %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("delivered %v, want %v", names, want)
+		}
+	}
+	for i := 1; i < len(seqs); i++ {
+		if seqs[i] <= seqs[i-1] {
+			t.Fatalf("out of seq order: %v", seqs)
+		}
+	}
+}
+
+// A failing handler must not lose its event: the cursor stays put and the event
+// is redelivered until it succeeds. That is the at-least-once guarantee, and the
+// reason handlers must tolerate redelivery.
+func TestFailingHandlerRedeliversAndDoesNotAdvance(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+
+	rec := newRecorder()
+	rec.failOn[1] = 2 // fail the first event twice, then succeed
+
+	if err := b.Register("flaky", All, rec.handle); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	if _, err := b.Publish("a.happened", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if _, err := b.Publish("b.happened", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	waitFor(t, "both events to land", func() bool {
+		_, seqs := rec.snapshot()
+		for _, s := range seqs {
+			if s == 2 {
+				return true
+			}
+		}
+		return false
+	})
+
+	_, seqs := rec.snapshot()
+	// seq 1 three times (two failures + the success), then seq 2 once.
+	if len(seqs) != 4 {
+		t.Fatalf("delivery sequence %v, want three attempts at seq 1 then seq 2", seqs)
+	}
+	for i := 0; i < 3; i++ {
+		if seqs[i] != 1 {
+			t.Fatalf("delivery sequence %v: expected seq 1 redelivered until success", seqs)
+		}
+	}
+	if seqs[3] != 2 {
+		t.Fatalf("delivery sequence %v: seq 2 must come after seq 1 succeeds", seqs)
+	}
+
+	c, _, _ := s.GetConsumer("flaky")
+	if c.Cursor != 2 {
+		t.Fatalf("cursor is %d after both events, want 2", c.Cursor)
+	}
+}
+
+// A filter selects what the handler sees — and the cursor still moves past what
+// it does not, so an unfiltered flood cannot make a narrow consumer look lagged
+// forever.
+func TestFilteredConsumerSkipsAndStillAdvances(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+
+	rec := newRecorder()
+	if err := b.Register("tickets", Filter{"ticket.*"}, rec.handle); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	for _, name := range []string{"session.state.changed", "ticket.commented", "session.registered", "pr.updated"} {
+		if _, err := b.Publish(name, "", nil); err != nil {
+			t.Fatalf("Publish(%s): %v", name, err)
+		}
+	}
+
+	waitFor(t, "the cursor to reach head", func() bool {
+		c, _, _ := s.GetConsumer("tickets")
+		return c.Cursor == 4
+	})
+
+	names, _ := rec.snapshot()
+	if len(names) != 1 || names[0] != "ticket.commented" {
+		t.Fatalf("filtered consumer saw %v, want only ticket.commented", names)
+	}
+}
+
+// The hub's shape: live fan-out, in order, with no history and no cursor.
+func TestEphemeralSubscriberGetsLiveEventsOnly(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	if _, err := b.Publish("before.subscribe", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
+	cancel := b.Subscribe(Filter{"live.*"}, func(ev Event) {
+		mu.Lock()
+		seen = append(seen, ev.Name)
+		mu.Unlock()
+	})
+
+	for _, name := range []string{"live.one", "other.thing", "live.two"} {
+		if _, err := b.Publish(name, "", nil); err != nil {
+			t.Fatalf("Publish(%s): %v", name, err)
+		}
+	}
+	cancel()
+	if _, err := b.Publish("live.three", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seen) != 2 || seen[0] != "live.one" || seen[1] != "live.two" {
+		t.Fatalf("ephemeral subscriber saw %v, want [live.one live.two]", seen)
+	}
+
+	if len(s.consumers) != 0 {
+		t.Fatalf("ephemeral subscriber persisted a cursor: %+v", s.consumers)
+	}
+}
+
+// The kill switch lives in the database, so flipping it out from under a running
+// consumer must stop delivery — and flipping it back must resume from where the
+// cursor stands, not from head.
+func TestDisabledConsumerStopsAndResumes(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+
+	rec := newRecorder()
+	if err := b.Register("killable", All, rec.handle); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	if _, err := b.Publish("a.happened", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	waitFor(t, "the first delivery", func() bool { return rec.count() == 1 })
+
+	s.setEnabled("killable", false)
+	for _, name := range []string{"b.happened", "c.happened"} {
+		if _, err := b.Publish(name, "", nil); err != nil {
+			t.Fatalf("Publish(%s): %v", name, err)
+		}
+	}
+	// Give the loop several poll intervals to (wrongly) deliver.
+	time.Sleep(60 * time.Millisecond)
+	if rec.count() != 1 {
+		names, _ := rec.snapshot()
+		t.Fatalf("a disabled consumer was delivered to: %v", names)
+	}
+
+	s.setEnabled("killable", true)
+	waitFor(t, "resumed delivery", func() bool { return rec.count() == 3 })
+	names, _ := rec.snapshot()
+	if names[1] != "b.happened" || names[2] != "c.happened" {
+		t.Fatalf("resumed from the wrong place: %v", names)
+	}
+}
+
+// Retention can move past a consumer that was disabled long enough. When it comes
+// back it resumes at head rather than replaying a partial, arbitrary window.
+func TestConsumerBelowTheTrimPointResumesAtHead(t *testing.T) {
+	s := newMemStore()
+
+	// Establish the consumer with a cursor of 1, then simulate retention removing
+	// everything up to seq 3 while it was disabled.
+	seed := testBus(t, s)
+	rec0 := newRecorder()
+	if err := seed.Register("stale", All, rec0.handle); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := seed.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := seed.Publish("a.happened", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	waitFor(t, "the seed delivery", func() bool { return rec0.count() == 1 })
+	seed.Stop()
+
+	offline := testBus(t, s)
+	for _, name := range []string{"b.happened", "c.happened", "d.happened"} {
+		if _, err := offline.Publish(name, "", nil); err != nil {
+			t.Fatalf("Publish(%s): %v", name, err)
+		}
+	}
+	s.dropEventsBelow(4) // only seq 4 survives; the cursor sits at 1
+
+	revived := testBus(t, s)
+	rec := newRecorder()
+	if err := revived.Register("stale", All, rec.handle); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := revived.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(revived.Stop)
+
+	waitFor(t, "the cursor to jump to head", func() bool {
+		c, _, _ := s.GetConsumer("stale")
+		return c.Cursor == 4
+	})
+	if rec.count() != 0 {
+		names, _ := rec.snapshot()
+		t.Fatalf("resumed consumer replayed a partial window: %v", names)
+	}
+
+	if _, err := revived.Publish("e.happened", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	waitFor(t, "delivery after resuming", func() bool { return rec.count() == 1 })
+	names, _ := rec.snapshot()
+	if names[0] != "e.happened" {
+		t.Fatalf("after resuming at head, delivered %v", names)
+	}
+}
+
+func TestStatusReportsLagAndLiveness(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+
+	rec := newRecorder()
+	rec.failOn[1] = 100 // never succeeds; the consumer stays stalled
+
+	if err := b.Register("stuck", All, rec.handle); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	for i := 0; i < 3; i++ {
+		if _, err := b.Publish("a.happened", "", nil); err != nil {
+			t.Fatalf("Publish: %v", err)
+		}
+	}
+	waitFor(t, "a stall to be recorded", func() bool {
+		st, err := b.Status()
+		if err != nil || len(st.Consumers) != 1 {
+			return false
+		}
+		return st.Consumers[0].Stalled != ""
+	})
+
+	st, err := b.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if st.Head != 3 {
+		t.Fatalf("head is %d, want 3", st.Head)
+	}
+	c := st.Consumers[0]
+	if c.Lag != 3 {
+		t.Fatalf("lag is %d, want 3 (cursor stuck at 0)", c.Lag)
+	}
+	if !c.Live {
+		t.Fatal("a consumer with a running loop should report Live")
+	}
+}
+
+// A registration is a startup-time decision: every persisted consumer has a
+// delivery loop, so there is no such thing as a registration nobody serves.
+func TestRegisterAfterStartIsRejected(t *testing.T) {
+	b := testBus(t, newMemStore())
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	if err := b.Register("late", All, func(context.Context, Event) error { return nil }); !errors.Is(err, ErrAlreadyStarted) {
+		t.Fatalf("Register after Start = %v, want ErrAlreadyStarted", err)
+	}
+}
+
+func TestRegisterRejectsDuplicatesAndBlanks(t *testing.T) {
+	b := testBus(t, newMemStore())
+	h := func(context.Context, Event) error { return nil }
+
+	if err := b.Register("dup", All, h); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := b.Register("dup", All, h); err == nil {
+		t.Fatal("duplicate consumer name accepted")
+	}
+	if err := b.Register("  ", All, h); err == nil {
+		t.Fatal("blank consumer name accepted")
+	}
+	if err := b.Register("nohandler", All, nil); err == nil {
+		t.Fatal("nil handler accepted")
+	}
+}
+
+func TestPublishRequiresAName(t *testing.T) {
+	b := testBus(t, newMemStore())
+	if _, err := b.Publish("  ", "", nil); err == nil {
+		t.Fatal("publish with a blank name accepted")
+	}
+}
+
+func TestPayloadRoundTrip(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+
+	type body struct {
+		State string `json:"state"`
+	}
+	got := make(chan body, 1)
+	if err := b.Register("reader", All, func(_ context.Context, ev Event) error {
+		var v body
+		if err := ev.Decode(&v); err != nil {
+			return err
+		}
+		got <- v
+		return nil
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	if _, err := b.Publish("session.state.changed", "sess_1", body{State: "idle"}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	select {
+	case v := <-got:
+		if v.State != "idle" {
+			t.Fatalf("payload round-trip gave %+v", v)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the payload")
+	}
+}
+
+// A bus without a database still runs: publishes are accepted and dropped,
+// matching the store's own nil-db convention.
+func TestNilStoreIsInert(t *testing.T) {
+	b := New(Options{})
+	if err := b.Register("x", All, func(context.Context, Event) error { return nil }); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start with no store: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	seq, err := b.Publish("a.happened", "", nil)
+	if err != nil || seq != 0 {
+		t.Fatalf("Publish on a store-less bus = (%d, %v)", seq, err)
+	}
+	if st, err := b.Status(); err != nil || st.Head != 0 {
+		t.Fatalf("Status on a store-less bus = (%+v, %v)", st, err)
+	}
+}
+
+func TestTrimIsCursorAware(t *testing.T) {
+	s := newMemStore()
+	// The delivery goroutine reads this clock while the test moves it, so it is
+	// guarded rather than a bare closure variable.
+	clk := &testClock{now: time.Now()}
+	b := New(Options{
+		Store:        s,
+		Now:          clk.get,
+		Retention:    time.Hour,
+		TrimInterval: time.Hour,
+		PollInterval: 5 * time.Millisecond,
+	})
+
+	rec := newRecorder()
+	if err := b.Register("slow", All, rec.handle); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	waitFor(t, "the consumer to be registered", func() bool {
+		_, ok, _ := s.GetConsumer("slow")
+		return ok
+	})
+
+	// Two events, both far outside the retention window, neither read.
+	clk.advance(-4 * time.Hour)
+	if _, err := b.Publish("a.happened", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if _, err := b.Publish("b.happened", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	clk.advance(4 * time.Hour)
+
+	waitFor(t, "both events to be consumed", func() bool { return rec.count() == 2 })
+	if n := b.Trim(); n != 2 {
+		t.Fatalf("trimmed %d events after they were consumed, want 2", n)
+	}
+}
+
+// Backoff escalates for an event a handler cannot get past. A consumer that is
+// merely lagging behind a busy producer, failing occasionally and recovering on
+// redelivery, must not ratchet its way to the retry cap: every successful
+// delivery ends the streak.
+func TestBackoffDoesNotRatchetAcrossSuccessfulDeliveries(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+
+	// Seed a backlog and a consumer row already at cursor 0, so the consumer
+	// spends the whole test BEHIND head. That is the state the bug lives in: the
+	// batch loop never sees an empty batch, which is the only place the older
+	// code cleared the streak.
+	const backlog = 30
+	for i := 0; i < backlog; i++ {
+		if _, err := s.Append(Event{Name: "a.happened", Subject: "s"}, time.Now()); err != nil {
+			t.Fatalf("seeding the log: %v", err)
+		}
+	}
+	if err := s.SaveConsumer(Consumer{Name: "laggard", Cursor: 0, Enabled: true}, time.Now()); err != nil {
+		t.Fatalf("seeding the consumer: %v", err)
+	}
+
+	// Two widely separated events fail once each, with successful deliveries in
+	// between. Record the streak the handler was invoked under.
+	var mu sync.Mutex
+	attempts := map[int64][]int{}
+	failed := map[int64]bool{}
+	handler := func(_ context.Context, ev Event) error {
+		mu.Lock()
+		streak := b.durables[0].drainFailures()
+		attempts[ev.Seq] = append(attempts[ev.Seq], streak)
+		first := !failed[ev.Seq]
+		if first && (ev.Seq == 1 || ev.Seq == 20) {
+			failed[ev.Seq] = true
+			mu.Unlock()
+			return errors.New("handler boom")
+		}
+		mu.Unlock()
+		return nil
+	}
+
+	if err := b.Register("laggard", All, handler); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	waitFor(t, "the backlog to be consumed", func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(attempts) == backlog
+	})
+
+	mu.Lock()
+	seq20 := append([]int(nil), attempts[20]...)
+	mu.Unlock()
+
+	if len(seq20) == 0 {
+		t.Fatalf("seq 20 was never delivered")
+	}
+	// Eighteen successful deliveries separate seq 1's failure from seq 20's. The
+	// streak the handler sees at seq 20 must therefore be 0 — a fresh attempt for
+	// a fresh event — not 1 inherited from an event that has long since succeeded.
+	if seq20[0] != 0 {
+		t.Fatalf("seq 20 was delivered as retry attempt %d; the streak from seq 1 was never reset (all attempts: %v)",
+			seq20[0]+1, attempts)
+	}
+}
+
+// The kill switch has to reach a consumer that is behind a busy producer. Such a
+// consumer never leaves its batch loop, so re-reading the enabled bit only once
+// per drain would leave `attn bus disable` inert for as long as the burst lasts.
+func TestKillSwitchStopsASaturatedConsumer(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+
+	var mu sync.Mutex
+	delivered := 0
+	flipped := false
+	// A handler slow enough that the loop is still inside one backlog when the
+	// bit flips. PollInterval is 5ms in testBus, so the re-read is prompt.
+	handler := func(_ context.Context, _ Event) error {
+		mu.Lock()
+		delivered++
+		n := delivered
+		mu.Unlock()
+		if n == 10 {
+			s.setEnabled("saturated", false)
+			mu.Lock()
+			flipped = true
+			mu.Unlock()
+		}
+		time.Sleep(time.Millisecond)
+		return nil
+	}
+
+	if err := b.Register("saturated", All, handler); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	// A backlog far larger than what the consumer should get through before the
+	// kill switch takes effect.
+	const total = 600
+	for i := 0; i < total; i++ {
+		if _, err := b.Publish("a.happened", "s", nil); err != nil {
+			t.Fatalf("Publish: %v", err)
+		}
+	}
+
+	waitFor(t, "the kill switch to be flipped", func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return flipped
+	})
+
+	// Well beyond the poll interval and beyond one batch of slow handler calls.
+	time.Sleep(300 * time.Millisecond)
+
+	mu.Lock()
+	got := delivered
+	mu.Unlock()
+	if got >= total {
+		t.Fatalf("the kill switch never took effect: delivered all %d events", got)
+	}
+	t.Logf("delivered %d of %d before the kill switch took effect", got, total)
+	// Delivery stops on the flipping event itself in practice; the ceiling leaves
+	// room for a slow machine while staying far below what an unchecked loop gets
+	// through in 300ms.
+	if got > 100 {
+		t.Fatalf("delivery ran on for %d events after the consumer was disabled", got)
+	}
+}
+
+// testClock is a movable clock safe to read from a delivery goroutine while the
+// test moves it.
+type testClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *testClock) get() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *testClock) advance(d time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	c.mu.Unlock()
+}

--- a/internal/bus/filter.go
+++ b/internal/bus/filter.go
@@ -1,0 +1,75 @@
+package bus
+
+import "strings"
+
+// Event names are dotted domain facts: `session.state.changed`, `ticket.commented`,
+// `delegation.prepared`. The namespace `ext.<extension>.*` is reserved for facts
+// published by extensions, so a subscription can always tell platform facts from
+// extension facts by prefix alone.
+//
+// A Filter is a set of patterns; an event matches the filter if it matches any of
+// them. Three pattern forms, and deliberately no more:
+//
+//	"*"                 every event
+//	"session.*"         every event whose name starts with "session."
+//	"ticket.commented"  exactly that event
+//
+// There is no mid-pattern wildcard and no regex. A subscriber that needs finer
+// selection filters in its handler, where the logic is visible and testable,
+// rather than in a pattern language every future extension author would have to
+// learn from behavior.
+type Filter []string
+
+// All matches every event.
+var All = Filter{"*"}
+
+// ParseFilter builds a Filter from a stored comma-separated expression. An empty
+// expression means All, so a consumer row written without a filter is not a
+// consumer that receives nothing.
+func ParseFilter(expr string) Filter {
+	var out Filter
+	for _, part := range strings.Split(expr, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return All
+	}
+	return out
+}
+
+// String renders the filter for storage and for `bus status`.
+func (f Filter) String() string {
+	if len(f) == 0 {
+		return "*"
+	}
+	return strings.Join(f, ",")
+}
+
+// Matches reports whether an event name is selected by this filter. An empty
+// filter matches everything, mirroring ParseFilter.
+func (f Filter) Matches(name string) bool {
+	if len(f) == 0 {
+		return true
+	}
+	for _, pattern := range f {
+		if matchPattern(pattern, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchPattern(pattern, name string) bool {
+	switch {
+	case pattern == "*" || pattern == "":
+		return true
+	case strings.HasSuffix(pattern, ".*"):
+		// "session.*" matches "session.state.changed" but not "sessions.updated"
+		// and not the bare name "session": the dot is part of the prefix.
+		return strings.HasPrefix(name, pattern[:len(pattern)-1])
+	default:
+		return pattern == name
+	}
+}

--- a/internal/bus/filter_test.go
+++ b/internal/bus/filter_test.go
@@ -1,0 +1,48 @@
+package bus
+
+import "testing"
+
+func TestFilterMatching(t *testing.T) {
+	cases := []struct {
+		filter Filter
+		name   string
+		want   bool
+	}{
+		{All, "anything.at.all", true},
+		{Filter{}, "anything.at.all", true},
+		{Filter{"session.*"}, "session.state.changed", true},
+		{Filter{"session.*"}, "session.registered", true},
+		// The dot is part of the prefix, so a sibling domain does not leak in.
+		{Filter{"session.*"}, "sessions.updated", false},
+		{Filter{"session.*"}, "session", false},
+		{Filter{"ticket.commented"}, "ticket.commented", true},
+		{Filter{"ticket.commented"}, "ticket.created", false},
+		{Filter{"ticket.*", "pr.updated"}, "pr.updated", true},
+		{Filter{"ticket.*", "pr.updated"}, "session.state.changed", false},
+		{Filter{"ext.gate.*"}, "ext.gate.approved", true},
+		{Filter{"ext.gate.*"}, "ext.other.approved", false},
+	}
+	for _, tc := range cases {
+		if got := tc.filter.Matches(tc.name); got != tc.want {
+			t.Errorf("Filter%v.Matches(%q) = %v, want %v", tc.filter, tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestParseFilterRoundTrip(t *testing.T) {
+	f := ParseFilter("session.*, ticket.commented ")
+	if len(f) != 2 || f[0] != "session.*" || f[1] != "ticket.commented" {
+		t.Fatalf("ParseFilter dropped or mangled patterns: %v", f)
+	}
+	if f.String() != "session.*,ticket.commented" {
+		t.Fatalf("String() = %q", f.String())
+	}
+	// A consumer row written without a filter must not be a consumer that
+	// receives nothing.
+	if got := ParseFilter(""); !got.Matches("whatever.happened") {
+		t.Fatalf("empty expression should mean All, got %v", got)
+	}
+	if got := ParseFilter("  ,  "); !got.Matches("whatever.happened") {
+		t.Fatalf("blank expression should mean All, got %v", got)
+	}
+}

--- a/internal/daemon/automations_deliver.go
+++ b/internal/daemon/automations_deliver.go
@@ -65,13 +65,14 @@ func (d *Daemon) failAutomationRun(run *store.AutomationRun, deliveryErr error) 
 				persistErr = errors.Join(persistErr, fmt.Errorf("record continuation failure: %w", err))
 			}
 			d.notifyTicketObservers(ticket.ID)
+			d.publishTicketFact(FactTicketCommented, ticket.ID)
 		} else if ticket.Status != store.TicketStatusFailed {
 			if _, err := d.store.SetTicketStatus(ticket.ID, store.TicketStatusFailed, store.TicketAuthorAttn, comment, now); err != nil {
 				persistErr = errors.Join(persistErr, fmt.Errorf("mark automation ticket failed: %w", err))
 			}
+			d.publishTicketFact(FactTicketStatusChanged, ticket.ID)
 		}
 	}
-	d.broadcastTicketsUpdated()
 	d.broadcastAutomationsChanged(run.DefinitionID)
 	failed, err := d.store.GetAutomationRun(run.ID)
 	if err != nil {
@@ -107,13 +108,14 @@ func (d *Daemon) cancelAutomationRun(run *store.AutomationRun, reason, message s
 				persistErr = errors.Join(persistErr, fmt.Errorf("record continuation cancellation: %w", err))
 			}
 			d.notifyTicketObservers(ticket.ID)
+			d.publishTicketFact(FactTicketCommented, ticket.ID)
 		} else if ticket.Status != store.TicketStatusFailed {
 			if _, err := d.store.SetTicketStatus(ticket.ID, store.TicketStatusFailed, store.TicketAuthorAttn, comment, now); err != nil {
 				persistErr = errors.Join(persistErr, fmt.Errorf("mark automation ticket failed: %w", err))
 			}
+			d.publishTicketFact(FactTicketStatusChanged, ticket.ID)
 		}
 	}
-	d.broadcastTicketsUpdated()
 	d.broadcastAutomationsChanged(run.DefinitionID)
 	cancelled, err := d.store.GetAutomationRun(run.ID)
 	if err != nil {
@@ -174,7 +176,7 @@ func (d *Daemon) deliverAutomationRun(ctx context.Context, run *store.Automation
 	if err := d.store.MarkAutomationRunDelivered(run.ID, string(result.Resolved), time.Now()); err != nil {
 		return err
 	}
-	d.broadcastTicketsUpdated()
+	d.publishTicketFact(FactTicketChanged, run.TicketID)
 	// This pending->delivered transition broadcast has no unit-test coverage:
 	// every unit test that reaches deliverAutomationRun's success path does so
 	// through automationDeliveryHook (bypassing this real delivery return) or
@@ -371,7 +373,7 @@ func (d *Daemon) ensureAutomationTicket(_ context.Context, req automation.WorkRe
 		if err := d.store.EnsureAutomationContinuationTicket(req.IDs.TicketID, req.IDs.SessionID, req.RunID, inputPath, author, time.Now()); err != nil {
 			return err
 		}
-		d.broadcastTicketsUpdated()
+		d.publishTicketFact(FactTicketChanged, req.IDs.TicketID)
 		// The ticket event is the durable payload. Use the ordinary content-free
 		// doorbell so an idle live reviewer learns that a new cycle is waiting.
 		d.notifyTicketObservers(req.IDs.TicketID)
@@ -408,7 +410,7 @@ func (d *Daemon) activateAutomationContinuationTicket(req automation.WorkRequest
 	if _, err := d.store.SetTicketStatus(ticket.ID, store.TicketStatusWorking, "automation:"+req.DefinitionID, comment, time.Now()); err != nil {
 		return err
 	}
-	d.broadcastTicketsUpdated()
+	d.publishTicketFact(FactTicketStatusChanged, ticket.ID)
 	d.notifyTicketObservers(ticket.ID)
 	return nil
 }

--- a/internal/daemon/bus.go
+++ b/internal/daemon/bus.go
@@ -1,0 +1,138 @@
+package daemon
+
+import "github.com/victorarias/attn/internal/bus"
+
+// The daemon's side of the event bus: the fact vocabulary, the lifecycle, and the
+// projection table that turns facts into what WebSocket clients see.
+//
+// The migration pattern for A2 is the two halves below.
+//
+// PRODUCER. A `broadcastXxx` method stops touching the hub and publishes a fact
+// instead. The fact must carry a subject — the entity it is about — because a
+// subject-less "the list changed" fact is the snapshot invalidation this design
+// exists to avoid. When the existing method already receives the entity id, it
+// becomes a one-line publish and no call site changes (see
+// broadcastSessionStateChanged). When it does not — broadcastTicketsUpdated took
+// no arguments because it re-pushed the whole board — the call sites are the ones
+// that know which fact occurred, and they are what changes.
+//
+// PROJECTION. The old broadcaster body moves into a `projectXxx` method and is
+// registered in wireProjections. The hub subscribes ephemerally to every fact and
+// runs the matching projections inline on the publishing goroutine, so a fact
+// still produces exactly the same wire traffic, in the same order, as the direct
+// call it replaced.
+//
+// What does NOT move: byte streams. PTY output, PTY desync, attach results,
+// workspace tile content, and fs change bursts keep their direct paths. They are
+// high volume, and attach traffic is routed by a per-client predicate
+// (SendRawTextToMatchingClients), which pub/sub cannot express.
+//
+// See docs/plans/2026-08-01-ext-a1-event-bus.md.
+
+// Fact names are dotted `domain.verb`. `ext.<extension>.*` is reserved for facts
+// published by extensions.
+const (
+	// FactSessionStateChanged: subject is the session id.
+	FactSessionStateChanged = "session.state.changed"
+
+	// Ticket facts; subject is the ticket id.
+	FactTicketCreated       = "ticket.created"
+	FactTicketStatusChanged = "ticket.status_changed"
+	FactTicketCommented     = "ticket.commented"
+	FactTicketAssigned      = "ticket.assigned"
+	FactTicketAttached      = "ticket.attached"
+	// FactTicketChanged is the fallback for a mutation whose call site cannot
+	// name a sharper fact. It is still about one ticket — that is the line
+	// between a fact and an invalidation — but a sharper name is preferred
+	// wherever the producer knows one.
+	FactTicketChanged = "ticket.changed"
+)
+
+// projection maps facts to the wire traffic they produce.
+type projection struct {
+	filter bus.Filter
+	apply  func(*Daemon, bus.Event)
+}
+
+// wireProjections is the whole fact -> WebSocket mapping. A2 grows this table as
+// each broadcaster migrates.
+var wireProjections = []projection{
+	{
+		filter: bus.Filter{FactSessionStateChanged},
+		apply:  func(d *Daemon, ev bus.Event) { d.projectSessionStateChanged(ev.Subject) },
+	},
+	{
+		// Every ticket fact re-pushes the board. The board push is the wire
+		// shape clients already expect; the facts are what a consumer can
+		// actually reason about.
+		filter: bus.Filter{"ticket.*"},
+		apply:  func(d *Daemon, _ bus.Event) { d.projectTicketsUpdated() },
+	},
+}
+
+// ensureEventBus constructs the bus over the profile store and registers the hub
+// as an ephemeral consumer. It is idempotent and runs at construction rather than
+// at Start, because the hub subscription is what makes a published fact reach
+// clients: a daemon that publishes without having started (every test that
+// exercises a broadcaster directly) must still project.
+func (d *Daemon) ensureEventBus() {
+	if d.eventBus != nil {
+		return
+	}
+	var backing bus.Store
+	if d.store != nil {
+		backing = d.newSQLBusStore()
+	}
+	d.eventBus = bus.New(bus.Options{Store: backing, Log: d.logf})
+	d.busUnsubscribe = d.eventBus.Subscribe(bus.All, d.projectToClients)
+}
+
+// startEventBus begins durable delivery. It runs early in Start, before any
+// subsystem that publishes.
+func (d *Daemon) startEventBus() error {
+	d.ensureEventBus()
+	return d.eventBus.Start()
+}
+
+func (d *Daemon) stopEventBus() {
+	if d.busUnsubscribe != nil {
+		d.busUnsubscribe()
+		d.busUnsubscribe = nil
+	}
+	if d.eventBus != nil {
+		d.eventBus.Stop()
+	}
+}
+
+// projectToClients is the hub's ephemeral handler.
+func (d *Daemon) projectToClients(ev bus.Event) {
+	for _, p := range wireProjections {
+		if p.filter.Matches(ev.Name) {
+			p.apply(d, ev)
+		}
+	}
+}
+
+// publishFact is the producer half. It is nil-safe: a Daemon assembled in a test
+// without a bus still runs its projections directly, so migrating a broadcaster
+// does not silently disconnect the behavior every existing test asserts on.
+func (d *Daemon) publishFact(name, subject string, payload any) {
+	if d == nil {
+		return
+	}
+	if d.eventBus == nil {
+		d.projectToClients(bus.Event{Name: name, Subject: subject})
+		return
+	}
+	if _, err := d.eventBus.Publish(name, subject, payload); err != nil {
+		d.logf("bus: publishing %s (%s): %v", name, subject, err)
+	}
+}
+
+// BusStatus snapshots the bus for operator inspection.
+func (d *Daemon) BusStatus() (bus.Status, error) {
+	if d.eventBus == nil {
+		return bus.Status{}, nil
+	}
+	return d.eventBus.Status()
+}

--- a/internal/daemon/bus_store.go
+++ b/internal/daemon/bus_store.go
@@ -1,0 +1,99 @@
+package daemon
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/victorarias/attn/internal/bus"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// sqlBusStore satisfies the bus.Store seam.
+var _ bus.Store = (*sqlBusStore)(nil)
+
+// sqlBusStore adapts the profile SQLite store to the bus.Store seam. It lives in
+// the daemon — which imports both internal/bus and internal/store — so neither of
+// those packages depends on the other, the same arrangement sqlTaskStore uses for
+// internal/tasks.
+//
+// The translation is mechanical: internal/store speaks BusEvent/BusConsumer rows,
+// internal/bus speaks Event/Consumer values. Payloads cross as JSON text one way
+// and json.RawMessage the other.
+type sqlBusStore struct{ store *store.Store }
+
+func (d *Daemon) newSQLBusStore() *sqlBusStore { return &sqlBusStore{store: d.store} }
+
+func (a *sqlBusStore) Append(e bus.Event, now time.Time) (int64, error) {
+	return a.store.AppendBusEvent(store.BusEvent{
+		Name:    e.Name,
+		Subject: e.Subject,
+		Payload: string(e.Payload),
+		Source:  e.Source,
+	}, now)
+}
+
+func (a *sqlBusStore) Since(cursor int64, limit int) ([]bus.Event, error) {
+	rows, err := a.store.BusEventsSince(cursor, limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]bus.Event, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, bus.Event{
+			Seq:       r.Seq,
+			Name:      r.Name,
+			Subject:   r.Subject,
+			Payload:   json.RawMessage(r.Payload),
+			Source:    r.Source,
+			CreatedAt: r.CreatedAt,
+		})
+	}
+	return out, nil
+}
+
+func (a *sqlBusStore) Bounds() (int64, int64, error) { return a.store.BusBounds() }
+
+func (a *sqlBusStore) GetConsumer(name string) (bus.Consumer, bool, error) {
+	rec, ok, err := a.store.GetBusConsumer(name)
+	if err != nil || !ok {
+		return bus.Consumer{}, ok, err
+	}
+	return busConsumerFromRow(rec), true, nil
+}
+
+func (a *sqlBusStore) SaveConsumer(c bus.Consumer, now time.Time) error {
+	return a.store.SaveBusConsumer(store.BusConsumer{
+		Name:    c.Name,
+		Cursor:  c.Cursor,
+		Filter:  c.Filter,
+		Enabled: c.Enabled,
+	}, now)
+}
+
+func (a *sqlBusStore) SetCursor(name string, cursor int64, now time.Time) error {
+	return a.store.SetBusConsumerCursor(name, cursor, now)
+}
+
+func (a *sqlBusStore) ListConsumers() ([]bus.Consumer, error) {
+	rows, err := a.store.ListBusConsumers()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]bus.Consumer, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, busConsumerFromRow(r))
+	}
+	return out, nil
+}
+
+func (a *sqlBusStore) Trim(cutoff time.Time) (int, error) { return a.store.TrimBusEvents(cutoff) }
+
+func busConsumerFromRow(r store.BusConsumer) bus.Consumer {
+	return bus.Consumer{
+		Name:      r.Name,
+		Cursor:    r.Cursor,
+		Filter:    r.Filter,
+		Enabled:   r.Enabled,
+		UpdatedAt: r.UpdatedAt,
+	}
+}

--- a/internal/daemon/bus_test.go
+++ b/internal/daemon/bus_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -208,5 +209,114 @@ func TestBusStatusReportsLag(t *testing.T) {
 	// Registered in the database but with no loop in this process.
 	if st.Consumers[0].Live {
 		t.Fatal("a consumer with no delivery loop reported Live")
+	}
+}
+
+// failingAppendBusStore is the real adapter with a switchable append fault, so
+// the test exercises the actual daemon wiring rather than a hand-built bus.
+type failingAppendBusStore struct {
+	bus.Store
+	mu   sync.Mutex
+	fail error
+}
+
+func (f *failingAppendBusStore) Append(e bus.Event, now time.Time) (int64, error) {
+	f.mu.Lock()
+	err := f.fail
+	f.mu.Unlock()
+	if err != nil {
+		return 0, err
+	}
+	return f.Store.Append(e, now)
+}
+
+func (f *failingAppendBusStore) setFail(err error) {
+	f.mu.Lock()
+	f.fail = err
+	f.mu.Unlock()
+}
+
+// rewireBusWithFailingAppend swaps the daemon's bus for one whose durable append
+// can be made to fail, keeping the hub subscription that ensureEventBus installs.
+func rewireBusWithFailingAppend(t *testing.T, d *Daemon) *failingAppendBusStore {
+	t.Helper()
+	d.stopEventBus()
+	backing := &failingAppendBusStore{Store: d.newSQLBusStore()}
+	d.eventBus = bus.New(bus.Options{Store: backing, Log: d.logf})
+	d.busUnsubscribe = d.eventBus.Subscribe(bus.All, d.projectToClients)
+	t.Cleanup(d.stopEventBus)
+	return backing
+}
+
+// A ticket mutation has already committed by the time its fact is published. If
+// the durable append then fails, the board push must still go out: before the
+// bus existed this was a direct broadcast, and a client cannot be allowed to
+// miss a committed mutation because the event log had a bad night.
+func TestBoardStillPushesWhenTheBusAppendFails(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backing := rewireBusWithFailingAppend(t, d)
+
+	var boards int
+	d.ticketsBroadcastHook = func([]protocol.Ticket) { boards++ }
+
+	now := time.Now()
+	if _, err := d.store.CreateTicket(store.Ticket{ID: "tk-1", Title: "work"}, "sess-a", now); err != nil {
+		t.Fatalf("CreateTicket: %v", err)
+	}
+
+	backing.setFail(errors.New("disk had a bad night"))
+	d.publishTicketFact(FactTicketStatusChanged, "tk-1")
+
+	if boards != 1 {
+		t.Fatalf("a committed ticket mutation produced %d board pushes while the bus append was failing, want 1", boards)
+	}
+	// The fact is genuinely lost — only its durability, not the wire.
+	logged, err := d.store.BusEventsSince(0, 10)
+	if err != nil {
+		t.Fatalf("BusEventsSince: %v", err)
+	}
+	if len(logged) != 0 {
+		t.Fatalf("append was supposed to fail, but the log holds %d event(s)", len(logged))
+	}
+
+	// Recovery: once the store is healthy the next fact is durable again, and the
+	// board still pushes exactly once for it.
+	backing.setFail(nil)
+	d.publishTicketFact(FactTicketStatusChanged, "tk-1")
+	if boards != 2 {
+		t.Fatalf("board pushes = %d after recovery, want 2", boards)
+	}
+	logged, err = d.store.BusEventsSince(0, 10)
+	if err != nil {
+		t.Fatalf("BusEventsSince: %v", err)
+	}
+	if len(logged) != 1 {
+		t.Fatalf("log holds %d event(s) after recovery, want 1", len(logged))
+	}
+}
+
+// The same guarantee for session state. This is the sharper case: the nudge and
+// auto-settle countdowns broadcast without any preceding store write, so nothing
+// upstream gates the push — the bus is the only thing that could drop it.
+func TestSessionStateStillReachesTheWireWhenTheBusAppendFails(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backing := rewireBusWithFailingAppend(t, d)
+
+	d.store.Add(&protocol.Session{ID: "sess-1", Directory: "/tmp/x", State: "idle"})
+
+	var events []string
+	d.wsHub.broadcastListener = func(e *protocol.WebSocketEvent) { events = append(events, e.Event) }
+
+	backing.setFail(errors.New("disk had a bad night"))
+	d.broadcastSessionStateChanged("sess-1")
+
+	found := false
+	for _, name := range events {
+		if name == protocol.EventSessionStateChanged {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("a failing bus append silenced session_state_changed; wire saw %v", events)
 	}
 }

--- a/internal/daemon/bus_test.go
+++ b/internal/daemon/bus_test.go
@@ -1,0 +1,212 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/bus"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// These tests exercise the bus against the REAL sqlBusStore, not the in-memory
+// fake internal/bus uses. A green run in internal/bus only proves the delivery
+// logic; this proves the SQLite adapter carries the same semantics.
+
+func waitForBus(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// A ticket mutation publishes a durable, subject-carrying fact — and still
+// produces exactly one board push, unchanged from before the migration.
+func TestTicketMutationPublishesAFactAndPushesTheBoardOnce(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	t.Cleanup(d.stopEventBus)
+
+	var boards int
+	d.ticketsBroadcastHook = func([]protocol.Ticket) { boards++ }
+
+	now := time.Now()
+	if _, err := d.store.CreateTicket(store.Ticket{ID: "tk-1", Title: "work"}, "sess-a", now); err != nil {
+		t.Fatalf("CreateTicket: %v", err)
+	}
+	d.publishTicketFact(FactTicketCommented, "tk-1")
+
+	if boards != 1 {
+		t.Fatalf("one fact produced %d board pushes, want exactly 1", boards)
+	}
+
+	events, err := d.store.BusEventsSince(0, 10)
+	if err != nil {
+		t.Fatalf("BusEventsSince: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("log holds %d events, want 1", len(events))
+	}
+	if events[0].Name != FactTicketCommented {
+		t.Fatalf("fact name = %q, want %q", events[0].Name, FactTicketCommented)
+	}
+	// The subject is what separates a fact from a snapshot invalidation.
+	if events[0].Subject != "tk-1" {
+		t.Fatalf("fact subject = %q, want the ticket id", events[0].Subject)
+	}
+}
+
+// The session-state migration kept its call sites, so the wire event it produces
+// must be indistinguishable from the direct broadcast it replaced.
+func TestSessionStateFactProjectsTheSameWireEvent(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	t.Cleanup(d.stopEventBus)
+
+	d.store.Add(&protocol.Session{ID: "sess-1", Directory: "/tmp/x", State: "idle"})
+
+	var events []string
+	d.wsHub.broadcastListener = func(e *protocol.WebSocketEvent) { events = append(events, e.Event) }
+
+	d.broadcastSessionStateChanged("sess-1")
+
+	found := false
+	for _, name := range events {
+		if name == protocol.EventSessionStateChanged {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no session_state_changed on the wire; got %v", events)
+	}
+
+	logged, err := d.store.BusEventsSince(0, 10)
+	if err != nil {
+		t.Fatalf("BusEventsSince: %v", err)
+	}
+	if len(logged) != 1 || logged[0].Name != FactSessionStateChanged || logged[0].Subject != "sess-1" {
+		t.Fatalf("expected one session.state.changed fact for sess-1, got %+v", logged)
+	}
+}
+
+// Over the real SQLite adapter: a durable consumer that was not running catches
+// up from its persisted cursor when it comes back.
+func TestDurableConsumerCatchesUpOverTheSQLiteAdapter(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backing := d.newSQLBusStore()
+
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
+	record := func(_ context.Context, ev bus.Event) error {
+		mu.Lock()
+		seen = append(seen, ev.Name+":"+ev.Subject)
+		mu.Unlock()
+		return nil
+	}
+	snapshot := func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), seen...)
+	}
+
+	first := bus.New(bus.Options{Store: backing, PollInterval: 5 * time.Millisecond})
+	if err := first.Register("ticket-watcher", bus.Filter{"ticket.*"}, record); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := first.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := first.Publish(FactTicketCreated, "tk-1", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	waitForBus(t, "the first delivery", func() bool { return len(snapshot()) == 1 })
+	first.Stop()
+
+	// Facts published while the consumer is gone, including one it filters out.
+	offline := bus.New(bus.Options{Store: backing})
+	for _, fact := range []struct{ name, subject string }{
+		{FactTicketCommented, "tk-1"},
+		{FactSessionStateChanged, "sess-9"},
+		{FactTicketStatusChanged, "tk-1"},
+	} {
+		if _, err := offline.Publish(fact.name, fact.subject, nil); err != nil {
+			t.Fatalf("Publish(%s): %v", fact.name, err)
+		}
+	}
+
+	second := bus.New(bus.Options{Store: backing, PollInterval: 5 * time.Millisecond})
+	if err := second.Register("ticket-watcher", bus.Filter{"ticket.*"}, record); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := second.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(second.Stop)
+
+	waitForBus(t, "catch-up", func() bool { return len(snapshot()) == 3 })
+	got := snapshot()
+	want := []string{
+		FactTicketCreated + ":tk-1",
+		FactTicketCommented + ":tk-1",
+		FactTicketStatusChanged + ":tk-1",
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("delivered %v, want %v", got, want)
+		}
+	}
+
+	// The cursor advanced past the filtered-out fact too, so a narrow consumer is
+	// not permanently reported as lagging.
+	rec, ok, err := d.store.GetBusConsumer("ticket-watcher")
+	if err != nil || !ok {
+		t.Fatalf("GetBusConsumer: %v (found=%v)", err, ok)
+	}
+	if rec.Cursor != 4 {
+		t.Fatalf("persisted cursor is %d, want 4 (head)", rec.Cursor)
+	}
+	if rec.Filter != "ticket.*" {
+		t.Fatalf("persisted filter is %q", rec.Filter)
+	}
+}
+
+// Status is the operator surface: head, cursors, and the lag between them.
+func TestBusStatusReportsLag(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	t.Cleanup(d.stopEventBus)
+
+	if err := d.store.SaveBusConsumer(store.BusConsumer{
+		Name: "watcher", Cursor: 1, Filter: "ticket.*", Enabled: true,
+	}, time.Now()); err != nil {
+		t.Fatalf("SaveBusConsumer: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		d.publishTicketFact(FactTicketChanged, "tk-1")
+	}
+
+	st, err := d.BusStatus()
+	if err != nil {
+		t.Fatalf("BusStatus: %v", err)
+	}
+	if st.Head != 3 {
+		t.Fatalf("head = %d, want 3", st.Head)
+	}
+	if len(st.Consumers) != 1 {
+		t.Fatalf("consumers = %+v, want one", st.Consumers)
+	}
+	if st.Consumers[0].Lag != 2 {
+		t.Fatalf("lag = %d, want 2", st.Consumers[0].Lag)
+	}
+	// Registered in the database but with no loop in this process.
+	if st.Consumers[0].Live {
+		t.Fatal("a consumer with no delivery loop reported Live")
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -21,6 +21,7 @@ import (
 
 	agentdriver "github.com/victorarias/attn/internal/agent"
 	"github.com/victorarias/attn/internal/buildinfo"
+	"github.com/victorarias/attn/internal/bus"
 	"github.com/victorarias/attn/internal/classifier"
 	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/diag"
@@ -358,6 +359,19 @@ type Daemon struct {
 
 	workspaceContextCheckoutMu sync.Mutex
 
+	// eventBus is the durable event bus (internal/bus): the spine that carries
+	// domain facts from producers to consumers. The WebSocket hub is an ephemeral
+	// consumer of it via the projection table in bus.go, so a migrated broadcaster
+	// publishes a fact and the projection produces the wire traffic. See
+	// docs/plans/2026-08-01-ext-a1-event-bus.md.
+	//
+	// Built by ensureEventBus at construction (not at Start) because the hub
+	// subscription is what makes a published fact reach clients — a daemon that
+	// publishes without having started must still project. busUnsubscribe drops
+	// that subscription on Stop.
+	eventBus       *bus.Bus
+	busUnsubscribe func()
+
 	// compactRunner is the durable task runner that owns the keeper's
 	// workspace-context compaction duty (kind "compact_context") and the
 	// notebook-narration tasks. It replaces the bespoke time.AfterFunc scheduling +
@@ -655,6 +669,7 @@ func New(socketPath string) *Daemon {
 	// Production wiring for the orphaned-ticket reconciliation classifier. Test
 	// constructors leave this nil so unit tests never shell out to a real CLI.
 	d.ticketReconcileExec = d.execTicketReconcileClassifier
+	d.ensureEventBus()
 	return d
 }
 
@@ -663,7 +678,7 @@ func NewForTesting(socketPath string) *Daemon {
 	dataRoot := filepath.Dir(socketPath)
 	pidPath := filepath.Join(dataRoot, "attn.pid")
 	manager := pty.NewManager(nil)
-	return &Daemon{
+	d := &Daemon{
 		socketPath:         socketPath,
 		pidPath:            pidPath,
 		dataRoot:           dataRoot,
@@ -696,6 +711,8 @@ func NewForTesting(socketPath string) *Daemon {
 		// override this with an enabled runner (see newTestCompactRunner).
 		compactRunner: tasks.New(tasks.Options{}),
 	}
+	d.ensureEventBus()
+	return d
 }
 
 // NewWithGitHubClient creates a daemon with a custom GitHub client for testing
@@ -707,7 +724,7 @@ func NewWithGitHubClient(socketPath string, ghClient github.GitHubClient) *Daemo
 		registry.Register(client.Host(), client)
 	}
 	manager := pty.NewManager(nil)
-	return &Daemon{
+	d := &Daemon{
 		socketPath:         socketPath,
 		pidPath:            pidPath,
 		dataRoot:           dataRoot,
@@ -737,6 +754,8 @@ func NewWithGitHubClient(socketPath string, ghClient github.GitHubClient) *Daemo
 		spawnLocks:         make(map[string]*spawnLock),
 		compactRunner:      tasks.New(tasks.Options{}),
 	}
+	d.ensureEventBus()
+	return d
 }
 
 // Start starts the daemon
@@ -779,6 +798,11 @@ func (d *Daemon) Start() error {
 	// before any headless run can start, so the default (or configured) cap
 	// applies from the first keeper/narration/reconcile run.
 	d.applyHeadlessContextWindowCap()
+	// The bus starts before anything that publishes: startup reconciliation
+	// already mutates state that produces facts.
+	if err := d.startEventBus(); err != nil {
+		return fmt.Errorf("start event bus: %w", err)
+	}
 	reapedWorkspaceIDs := d.loadWorkspacesFromStore()
 	if d.daemonInstanceID == "" {
 		instanceID, err := ensureDaemonInstanceID(d.dataRoot)
@@ -1547,6 +1571,7 @@ func (d *Daemon) Stop() {
 	if runner := d.compactRunnerRef(); runner != nil {
 		runner.Stop()
 	}
+	d.stopEventBus()
 	if d.hubManager != nil {
 		d.hubManager.Stop()
 	}
@@ -2806,7 +2831,14 @@ func (d *Daemon) remoteSessionsForBroadcast() []protocol.Session {
 	return sessions
 }
 
+// broadcastSessionStateChanged publishes the fact. Its old body is now
+// projectSessionStateChanged, run by the hub's projection (see bus.go). Because
+// the method already received the entity id, migrating it changed no call site.
 func (d *Daemon) broadcastSessionStateChanged(sessionID string) {
+	d.publishFact(FactSessionStateChanged, sessionID, nil)
+}
+
+func (d *Daemon) projectSessionStateChanged(sessionID string) {
 	session := d.store.Get(sessionID)
 	decorated := d.sessionForBroadcast(session)
 	if decorated == nil {

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -737,7 +737,7 @@ func (d *Daemon) delegateOperation(msg *protocol.DelegateMessage, operationID, r
 			if ticketID != "" {
 				d.notifyTicketObservers(ticketID)
 			}
-			d.broadcastTicketsUpdated()
+			d.publishTicketFact(FactTicketAssigned, boundTicketID)
 		}
 		return d.completedDelegationResult(existing, placement, worktreeOwned), nil
 	}
@@ -951,7 +951,7 @@ func (d *Daemon) delegateOperation(msg *protocol.DelegateMessage, operationID, r
 	if ticketID != "" {
 		d.notifyTicketObservers(ticketID)
 	}
-	d.broadcastTicketsUpdated()
+	d.publishTicketFact(FactTicketAssigned, boundTicketID)
 	result := &protocol.DelegateResult{
 		SessionID:   session.ID,
 		WorkspaceID: workspaceID,

--- a/internal/daemon/ticket_actions.go
+++ b/internal/daemon/ticket_actions.go
@@ -40,7 +40,7 @@ func (d *Daemon) afterTicketMutation(ticketID string, err error) {
 		return
 	}
 	d.notifyTicketObservers(ticketID)
-	d.broadcastTicketsUpdated()
+	d.publishTicketFact(FactTicketChanged, ticketID)
 }
 
 func (d *Daemon) handleTicketChangeStatus(client *wsClient, msg *protocol.TicketChangeStatusMessage) {

--- a/internal/daemon/ticket_attach.go
+++ b/internal/daemon/ticket_attach.go
@@ -188,7 +188,7 @@ func (d *Daemon) submitTicketAttach(msg *protocol.TicketAttachMessage, author st
 	}
 	d.noteNotebookSelfWrite(selfWrites...)
 	d.notifyTicketObservers(ticketID)
-	d.broadcastTicketsUpdated()
+	d.publishTicketFact(FactTicketAttached, ticketID)
 	d.broadcastNotebookChanged(originAgent, changedPaths...)
 	if root, rootErr := d.notebookRoot(); rootErr == nil {
 		d.broadcastFsChanged(root, originAgent, changedPaths...)

--- a/internal/daemon/ticket_board.go
+++ b/internal/daemon/ticket_board.go
@@ -98,10 +98,27 @@ func (d *Daemon) handleTicketShow(conn net.Conn, msg *protocol.TicketShowMessage
 	})
 }
 
-// broadcastTicketsUpdated re-pushes the whole non-archived board to every client.
-// Run it after any producer that mutates a ticket (create, status, crash, and the
-// chief edits to come).
-func (d *Daemon) broadcastTicketsUpdated() {
+// publishTicketFact is the producer half of the ticket migration: a mutator
+// publishes the fact it just caused, naming the ticket. It replaced
+// broadcastTicketsUpdated at every call site.
+//
+// The board push that used to happen here is now projectTicketsUpdated, driven by
+// the hub's projection of any `ticket.*` fact — so the wire still sees exactly one
+// board push per mutation, while a consumer sees what actually happened.
+// Publishing a subject-less "the board changed" fact would have been the snapshot
+// invalidation this design rejects, which is why the ticket id is required.
+func (d *Daemon) publishTicketFact(name, ticketID string) {
+	if strings.TrimSpace(ticketID) == "" {
+		// A ticket fact with no ticket IS the invalidation shape. Keep the board
+		// correct, but make the producer's lost id visible rather than quietly
+		// degrading the log.
+		d.logf("bus: %s published without a ticket id", name)
+	}
+	d.publishFact(name, ticketID, nil)
+}
+
+// projectTicketsUpdated re-pushes the whole non-archived board to every client.
+func (d *Daemon) projectTicketsUpdated() {
 	if d.store == nil {
 		return
 	}

--- a/internal/daemon/ticket_comment.go
+++ b/internal/daemon/ticket_comment.go
@@ -64,5 +64,5 @@ func (d *Daemon) handleTicketComment(conn net.Conn, msg *protocol.TicketCommentM
 	// participant of the ticket going forward.
 	d.notifyTicketObservers(ticketID)
 	// Refresh the app's board view: the activity thread changed.
-	d.broadcastTicketsUpdated()
+	d.publishTicketFact(FactTicketCommented, ticketID)
 }

--- a/internal/daemon/ticket_crash.go
+++ b/internal/daemon/ticket_crash.go
@@ -46,6 +46,6 @@ func (d *Daemon) crashTicket(ticketID, sessionID, state string) bool {
 	// is skipped as a non-live participant).
 	d.notifyTicketObservers(ticketID)
 	// Refresh the app's board view: the ticket moved to the Crashed lane.
-	d.broadcastTicketsUpdated()
+	d.publishTicketFact(FactTicketStatusChanged, ticketID)
 	return true
 }

--- a/internal/daemon/ticket_create.go
+++ b/internal/daemon/ticket_create.go
@@ -77,5 +77,5 @@ func (d *Daemon) handleTicketCreate(conn net.Conn, msg *protocol.TicketCreateMes
 	})
 	// A new backlog card appeared; refresh the app's board. The ticket is unbound
 	// (no assignee/participants), so there is nobody to notify.
-	d.broadcastTicketsUpdated()
+	d.publishTicketFact(FactTicketCreated, created.ID)
 }

--- a/internal/daemon/ticket_reconcile.go
+++ b/internal/daemon/ticket_reconcile.go
@@ -489,7 +489,7 @@ func (d *Daemon) reconcileTaskExecutor(ctx context.Context, task *tasks.Task) er
 	// The comment notifies participants (the chief is one via the created event);
 	// attn itself is an authoring identity, never an observer.
 	d.notifyTicketObservers(in.TicketID)
-	d.broadcastTicketsUpdated()
+	d.publishTicketFact(FactTicketCommented, in.TicketID)
 	return nil
 }
 

--- a/internal/daemon/ticket_revive.go
+++ b/internal/daemon/ticket_revive.go
@@ -36,7 +36,6 @@ func (d *Daemon) reviveCrashedTicketsForSession(sessionID string) {
 	if len(tickets) == 0 {
 		return
 	}
-	moved := false
 	for _, ticket := range tickets {
 		if ticket == nil {
 			continue
@@ -51,13 +50,11 @@ func (d *Daemon) reviveCrashedTicketsForSession(sessionID string) {
 			d.logf("ticket revive for %s: %v", sessionID, err)
 			continue
 		}
-		moved = true
 		d.logf("ticket %q revived: session %s is live again", ticket.ID, sessionID)
 		// attn authored the move; notify the chief/participants the work is back on.
 		d.notifyTicketObservers(ticket.ID)
-	}
-	if moved {
-		// Refresh the app's board view: the ticket left the Crashed lane.
-		d.broadcastTicketsUpdated()
+		// Each revived ticket is its own status change, so each publishes its own
+		// fact rather than one anonymous board refresh at the end.
+		d.publishTicketFact(FactTicketStatusChanged, ticket.ID)
 	}
 }

--- a/internal/daemon/ticket_status.go
+++ b/internal/daemon/ticket_status.go
@@ -107,5 +107,5 @@ func (d *Daemon) handleSetTicketStatus(conn net.Conn, msg *protocol.SetTicketSta
 	// Notify excludes it — no self-nudge.
 	d.notifyTicketObservers(updated.ID)
 	// Refresh the app's board view: the column moved.
-	d.broadcastTicketsUpdated()
+	d.publishTicketFact(FactTicketStatusChanged, updated.ID)
 }

--- a/internal/daemon/ticket_take.go
+++ b/internal/daemon/ticket_take.go
@@ -82,5 +82,5 @@ func (d *Daemon) handleTicketTake(conn net.Conn, msg *protocol.TicketTakeMessage
 	// the previous assignee and the chief.
 	d.notifyTicketObservers(ticketID)
 	// The board's assignee column changed; refresh the app view.
-	d.broadcastTicketsUpdated()
+	d.publishTicketFact(FactTicketAssigned, ticketID)
 }

--- a/internal/store/bus.go
+++ b/internal/store/bus.go
@@ -1,0 +1,270 @@
+package store
+
+import (
+	"database/sql"
+	"time"
+)
+
+// The durable event bus substrate (migration 84). This file is only persistence:
+// an append-only log whose AUTOINCREMENT seq doubles as the cursor space, plus a
+// registry of named consumers holding a position in that space. The delivery
+// semantics — ordering, at-least-once, filters, retention window — live in
+// internal/bus, which reaches this through an interface so neither package
+// depends on the other (the daemon adapts them, as it does for internal/tasks).
+//
+// The shape is lifted from the ticket event log (migration 56), which proved it:
+// a monotonic seq is a cursor space, and a consumer that was down catches up by
+// reading forward from its own bookmark. The difference is scope. Ticket cursors
+// are per-(identity, ticket) because "unread" is a per-ticket question; bus
+// cursors are one per consumer because a consumer is a program, not a reader.
+
+// BusEvent is one fact on the log. Payload is opaque JSON (the empty string when
+// a fact carries nothing beyond its subject). Source names the publisher for
+// diagnosis, not for routing.
+type BusEvent struct {
+	Seq       int64
+	Name      string
+	Subject   string
+	Payload   string
+	Source    string
+	CreatedAt time.Time
+}
+
+// BusConsumer is a durable consumer's registration and position. Filter is the
+// consumer's subscription expression, stored so `bus status` can report what a
+// consumer is watching without the consumer being live. Enabled=false is the kill
+// switch: a disabled consumer is not delivered to, and — deliberately — does not
+// pin the retention window.
+type BusConsumer struct {
+	Name      string
+	Cursor    int64
+	Filter    string
+	Enabled   bool
+	UpdatedAt time.Time
+}
+
+// AppendBusEvent appends a fact and returns its seq.
+//
+// There is no dedup here, unlike the ticket event log. Ticket events dedup
+// against the previous event because a retried mutation must not double-post a
+// comment; bus facts are emitted by code that already decided something changed,
+// and two identical facts in a row are a real occurrence (a session entering the
+// same state twice), not a retry.
+func (s *Store) AppendBusEvent(e BusEvent, now time.Time) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return 0, nil
+	}
+	res, err := s.db.Exec(`
+		INSERT INTO bus_events (name, subject, payload, source, created_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, e.Name, e.Subject, e.Payload, e.Source, formatTicketTime(now))
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// BusEventsSince returns up to limit events with seq greater than cursor, in seq
+// order. Filtering is the caller's job: a consumer reads the raw forward stream
+// and advances its cursor past events it does not want, which keeps the cursor
+// monotone and the query free of pattern matching.
+func (s *Store) BusEventsSince(cursor int64, limit int) ([]BusEvent, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.Query(`
+		SELECT seq, name, subject, payload, source, created_at
+		FROM bus_events WHERE seq > ? ORDER BY seq ASC LIMIT ?
+	`, cursor, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var events []BusEvent
+	for rows.Next() {
+		var (
+			e         BusEvent
+			createdAt string
+		)
+		if err := rows.Scan(&e.Seq, &e.Name, &e.Subject, &e.Payload, &e.Source, &createdAt); err != nil {
+			return nil, err
+		}
+		e.CreatedAt = parseTicketTime(createdAt)
+		events = append(events, e)
+	}
+	return events, rows.Err()
+}
+
+// BusBounds returns the lowest and highest seq currently in the log; both are 0
+// when the log is empty. The low bound is what makes a trimmed-past cursor
+// detectable: a consumer whose cursor sits below it has missed events that no
+// longer exist.
+func (s *Store) BusBounds() (earliest, head int64, err error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return 0, 0, nil
+	}
+	var lo, hi sql.NullInt64
+	if err := s.db.QueryRow(`SELECT MIN(seq), MAX(seq) FROM bus_events`).Scan(&lo, &hi); err != nil {
+		return 0, 0, err
+	}
+	return lo.Int64, hi.Int64, nil
+}
+
+// GetBusConsumer loads a consumer registration by name.
+func (s *Store) GetBusConsumer(name string) (BusConsumer, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return BusConsumer{}, false, nil
+	}
+	var (
+		c         BusConsumer
+		enabled   int
+		updatedAt string
+	)
+	err := s.db.QueryRow(`
+		SELECT name, cursor, filter, enabled, updated_at FROM bus_consumers WHERE name = ?
+	`, name).Scan(&c.Name, &c.Cursor, &c.Filter, &enabled, &updatedAt)
+	switch err {
+	case nil:
+		c.Enabled = enabled != 0
+		c.UpdatedAt = parseTicketTime(updatedAt)
+		return c, true, nil
+	case sql.ErrNoRows:
+		return BusConsumer{}, false, nil
+	default:
+		return BusConsumer{}, false, err
+	}
+}
+
+// SaveBusConsumer creates or updates a registration. An existing row keeps its
+// cursor and enabled bit: re-registering at startup must not rewind a consumer's
+// position, and must not silently re-enable one the operator killed.
+func (s *Store) SaveBusConsumer(c BusConsumer, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	enabled := 0
+	if c.Enabled {
+		enabled = 1
+	}
+	_, err := s.db.Exec(`
+		INSERT INTO bus_consumers (name, cursor, filter, enabled, updated_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(name) DO UPDATE SET filter = excluded.filter, updated_at = excluded.updated_at
+	`, c.Name, c.Cursor, c.Filter, enabled, formatTicketTime(now))
+	return err
+}
+
+// SetBusConsumerCursor persists a consumer's position. This is the write on the
+// delivery hot path, so it touches only the two columns it owns.
+func (s *Store) SetBusConsumerCursor(name string, cursor int64, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	_, err := s.db.Exec(`
+		UPDATE bus_consumers SET cursor = ?, updated_at = ? WHERE name = ?
+	`, cursor, formatTicketTime(now), name)
+	return err
+}
+
+// SetBusConsumerEnabled flips the kill switch for a consumer.
+func (s *Store) SetBusConsumerEnabled(name string, enabled bool, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	flag := 0
+	if enabled {
+		flag = 1
+	}
+	_, err := s.db.Exec(`
+		UPDATE bus_consumers SET enabled = ?, updated_at = ? WHERE name = ?
+	`, flag, formatTicketTime(now), name)
+	return err
+}
+
+// ListBusConsumers returns every registration, by name.
+func (s *Store) ListBusConsumers() ([]BusConsumer, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.Query(`
+		SELECT name, cursor, filter, enabled, updated_at FROM bus_consumers ORDER BY name ASC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []BusConsumer
+	for rows.Next() {
+		var (
+			c         BusConsumer
+			enabled   int
+			updatedAt string
+		)
+		if err := rows.Scan(&c.Name, &c.Cursor, &c.Filter, &enabled, &updatedAt); err != nil {
+			return nil, err
+		}
+		c.Enabled = enabled != 0
+		c.UpdatedAt = parseTicketTime(updatedAt)
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// TrimBusEvents deletes events older than cutoff that every ENABLED consumer has
+// already passed, and reports how many rows went. Both conditions must hold: the
+// age window bounds growth, and the cursor floor keeps a live-but-lagging
+// consumer from losing events it has not read.
+//
+// Disabled consumers are excluded from the floor on purpose. A killed extension
+// must not pin the log indefinitely; when it comes back below the floor,
+// internal/bus resumes it at head and logs the gap.
+func (s *Store) TrimBusEvents(cutoff time.Time) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return 0, nil
+	}
+	res, err := s.db.Exec(`
+		DELETE FROM bus_events
+		WHERE created_at < ?
+		  AND seq <= COALESCE(
+		      (SELECT MIN(cursor) FROM bus_consumers WHERE enabled = 1),
+		      (SELECT COALESCE(MAX(seq), 0) FROM bus_events)
+		  )
+	`, formatTicketTime(cutoff))
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	return int(n), err
+}

--- a/internal/store/bus_test.go
+++ b/internal/store/bus_test.go
@@ -1,0 +1,255 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+var busBase = time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+
+func appendBus(t *testing.T, s *Store, name, subject string, at time.Time) int64 {
+	t.Helper()
+	seq, err := s.AppendBusEvent(BusEvent{Name: name, Subject: subject, Payload: `{"k":1}`, Source: "test"}, at)
+	if err != nil {
+		t.Fatalf("AppendBusEvent(%s): %v", name, err)
+	}
+	return seq
+}
+
+// The log hands out a strictly increasing seq and reads back forward from a
+// cursor in that order — the property every consumer's catch-up depends on.
+func TestBusEventLogIsOrderedAndReadableFromACursor(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	first := appendBus(t, s, "session.state.changed", "sess_1", busBase)
+	second := appendBus(t, s, "ticket.commented", "tk_1", busBase.Add(time.Minute))
+	third := appendBus(t, s, "session.state.changed", "sess_2", busBase.Add(2*time.Minute))
+
+	if !(first < second && second < third) {
+		t.Fatalf("seq not monotonic: %d, %d, %d", first, second, third)
+	}
+
+	events, err := s.BusEventsSince(first, 10)
+	if err != nil {
+		t.Fatalf("BusEventsSince: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events after seq %d, got %d", first, len(events))
+	}
+	if events[0].Seq != second || events[1].Seq != third {
+		t.Fatalf("out of order: got %d, %d; want %d, %d", events[0].Seq, events[1].Seq, second, third)
+	}
+	if events[0].Name != "ticket.commented" || events[0].Subject != "tk_1" {
+		t.Fatalf("payload columns not round-tripped: %+v", events[0])
+	}
+	if events[0].Payload != `{"k":1}` || events[0].Source != "test" {
+		t.Fatalf("payload/source not round-tripped: %+v", events[0])
+	}
+	if !events[0].CreatedAt.Equal(busBase.Add(time.Minute)) {
+		t.Fatalf("created_at not round-tripped: %v", events[0].CreatedAt)
+	}
+}
+
+func TestBusEventsSinceRespectsLimit(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	for i := 0; i < 5; i++ {
+		appendBus(t, s, "x.happened", "", busBase.Add(time.Duration(i)*time.Minute))
+	}
+	events, err := s.BusEventsSince(0, 2)
+	if err != nil {
+		t.Fatalf("BusEventsSince: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("limit ignored: got %d events, want 2", len(events))
+	}
+}
+
+func TestBusBoundsTracksTheLiveWindow(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	earliest, head, err := s.BusBounds()
+	if err != nil {
+		t.Fatalf("BusBounds on empty log: %v", err)
+	}
+	if earliest != 0 || head != 0 {
+		t.Fatalf("empty log should report zero bounds, got %d..%d", earliest, head)
+	}
+
+	lo := appendBus(t, s, "a.happened", "", busBase)
+	hi := appendBus(t, s, "b.happened", "", busBase.Add(time.Minute))
+
+	earliest, head, err = s.BusBounds()
+	if err != nil {
+		t.Fatalf("BusBounds: %v", err)
+	}
+	if earliest != lo || head != hi {
+		t.Fatalf("bounds %d..%d, want %d..%d", earliest, head, lo, hi)
+	}
+}
+
+// Re-registering an existing consumer refreshes its filter but must not rewind
+// its cursor or resurrect it after the kill switch — daemon restart re-registers
+// every consumer, and neither of those may be a side effect of starting up.
+func TestSaveBusConsumerPreservesCursorAndEnabled(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	if err := s.SaveBusConsumer(BusConsumer{Name: "wshub", Cursor: 0, Filter: "*", Enabled: true}, busBase); err != nil {
+		t.Fatalf("SaveBusConsumer: %v", err)
+	}
+	if err := s.SetBusConsumerCursor("wshub", 42, busBase.Add(time.Minute)); err != nil {
+		t.Fatalf("SetBusConsumerCursor: %v", err)
+	}
+	if err := s.SetBusConsumerEnabled("wshub", false, busBase.Add(2*time.Minute)); err != nil {
+		t.Fatalf("SetBusConsumerEnabled: %v", err)
+	}
+
+	// Restart: same consumer re-registers, this time with a narrower filter and
+	// the from-scratch defaults its constructor would pass.
+	if err := s.SaveBusConsumer(BusConsumer{Name: "wshub", Cursor: 0, Filter: "session.*", Enabled: true}, busBase.Add(3*time.Minute)); err != nil {
+		t.Fatalf("SaveBusConsumer (re-register): %v", err)
+	}
+
+	got, ok, err := s.GetBusConsumer("wshub")
+	if err != nil || !ok {
+		t.Fatalf("GetBusConsumer: %v (found=%v)", err, ok)
+	}
+	if got.Cursor != 42 {
+		t.Fatalf("re-registration rewound the cursor to %d", got.Cursor)
+	}
+	if got.Enabled {
+		t.Fatal("re-registration resurrected a killed consumer")
+	}
+	if got.Filter != "session.*" {
+		t.Fatalf("filter not refreshed: %q", got.Filter)
+	}
+}
+
+func TestGetBusConsumerMissing(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	_, ok, err := s.GetBusConsumer("nobody")
+	if err != nil {
+		t.Fatalf("GetBusConsumer: %v", err)
+	}
+	if ok {
+		t.Fatal("expected no registration")
+	}
+}
+
+func TestListBusConsumers(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	for _, name := range []string{"zeta", "alpha"} {
+		if err := s.SaveBusConsumer(BusConsumer{Name: name, Filter: "*", Enabled: true}, busBase); err != nil {
+			t.Fatalf("SaveBusConsumer(%s): %v", name, err)
+		}
+	}
+	rows, err := s.ListBusConsumers()
+	if err != nil {
+		t.Fatalf("ListBusConsumers: %v", err)
+	}
+	if len(rows) != 2 || rows[0].Name != "alpha" || rows[1].Name != "zeta" {
+		t.Fatalf("expected alpha,zeta in name order, got %+v", rows)
+	}
+}
+
+// Retention needs BOTH conditions: old enough, and already read by every enabled
+// consumer. A lagging live consumer keeps its unread events alive.
+func TestTrimBusEventsHoldsTheLineForALaggingEnabledConsumer(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	old := busBase
+	first := appendBus(t, s, "a.happened", "", old)
+	second := appendBus(t, s, "b.happened", "", old.Add(time.Minute))
+	appendBus(t, s, "c.happened", "", old.Add(2*time.Minute))
+
+	if err := s.SaveBusConsumer(BusConsumer{Name: "slow", Cursor: first, Filter: "*", Enabled: true}, old); err != nil {
+		t.Fatalf("SaveBusConsumer: %v", err)
+	}
+
+	// Everything is far older than the cutoff, so only the cursor floor decides.
+	n, err := s.TrimBusEvents(old.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("TrimBusEvents: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("trimmed %d events, want 1 (only what 'slow' has read)", n)
+	}
+	earliest, _, err := s.BusBounds()
+	if err != nil {
+		t.Fatalf("BusBounds: %v", err)
+	}
+	if earliest != second {
+		t.Fatalf("earliest surviving seq is %d, want %d", earliest, second)
+	}
+}
+
+// The age window is the other half: an event every consumer has read still
+// survives while it is inside the window.
+func TestTrimBusEventsKeepsEventsInsideTheWindow(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	recent := appendBus(t, s, "a.happened", "", busBase)
+	if err := s.SaveBusConsumer(BusConsumer{Name: "fast", Cursor: recent, Filter: "*", Enabled: true}, busBase); err != nil {
+		t.Fatalf("SaveBusConsumer: %v", err)
+	}
+
+	n, err := s.TrimBusEvents(busBase.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("TrimBusEvents: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("trimmed %d events inside the retention window, want 0", n)
+	}
+}
+
+// A killed consumer must not pin the log forever. This is the deliberate
+// asymmetry with the lagging-consumer case above.
+func TestTrimBusEventsIgnoresDisabledConsumers(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	appendBus(t, s, "a.happened", "", busBase)
+	appendBus(t, s, "b.happened", "", busBase.Add(time.Minute))
+
+	if err := s.SaveBusConsumer(BusConsumer{Name: "killed", Cursor: 0, Filter: "*", Enabled: true}, busBase); err != nil {
+		t.Fatalf("SaveBusConsumer: %v", err)
+	}
+	if err := s.SetBusConsumerEnabled("killed", false, busBase); err != nil {
+		t.Fatalf("SetBusConsumerEnabled: %v", err)
+	}
+
+	n, err := s.TrimBusEvents(busBase.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("TrimBusEvents: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("a disabled consumer pinned the log: trimmed %d, want 2", n)
+	}
+}
+
+// With nothing registered, the age window alone governs.
+func TestTrimBusEventsWithNoConsumers(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	appendBus(t, s, "a.happened", "", busBase)
+	appendBus(t, s, "b.happened", "", busBase.Add(time.Minute))
+
+	n, err := s.TrimBusEvents(busBase.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("TrimBusEvents: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("trimmed %d, want 2", n)
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -825,6 +825,31 @@ CREATE TABLE IF NOT EXISTS ticket_event_cursors (
 			ON delegation_operations(ticket_id)
 			WHERE ticket_id != '' AND state IN ('accepted', 'preparing');
 	`},
+	// The durable event bus: the internal spine every consumer reads, generalizing
+	// the ticket event log's (append-only + monotonic seq as cursor space) shape to
+	// the whole daemon. See docs/plans/2026-08-01-ext-a1-event-bus.md.
+	//
+	// Events are domain FACTS, not WebSocket payloads: a name, an indexed subject,
+	// and a small payload. Consumers are registered by name and hold a cursor into
+	// the same seq space; the WebSocket hub is deliberately absent from that table
+	// because it is ephemeral (it starts at head and holds no row).
+	{84, "create event bus log and consumer cursors", `CREATE TABLE IF NOT EXISTS bus_events (
+    seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT NOT NULL,
+    subject    TEXT NOT NULL DEFAULT '',
+    payload    TEXT NOT NULL DEFAULT '',
+    source     TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_bus_events_name ON bus_events(name, seq);
+CREATE INDEX IF NOT EXISTS idx_bus_events_subject ON bus_events(subject, seq);
+CREATE TABLE IF NOT EXISTS bus_consumers (
+    name       TEXT PRIMARY KEY,
+    cursor     INTEGER NOT NULL DEFAULT 0,
+    filter     TEXT NOT NULL DEFAULT '',
+    enabled    INTEGER NOT NULL DEFAULT 1,
+    updated_at TEXT NOT NULL DEFAULT ''
+);`},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.


### PR DESCRIPTION
Stage A1 of the [extension platform roadmap](docs/plans/2026-08-01-extension-platform-roadmap.md): the durable event bus that later stages subscribe to. Design and gate answers are in [docs/plans/2026-08-01-ext-a1-event-bus.md](docs/plans/2026-08-01-ext-a1-event-bus.md).

Clients see exactly what they saw before. This adds the spine and moves session-state and ticket broadcasts onto it; it changes no wire behavior and bumps no protocol version.

## Facts on the log, projections on the wire

The log carries **domain facts** — a dotted `domain.verb`, an indexed subject naming the entity, a small payload — not the WebSocket event a fact happens to produce.

That distinction is the whole design. Most of attn's existing `broadcastXxx` methods are snapshot pushes: `broadcastSessionsUpdated`, `broadcastTicketsUpdated`, and `broadcastPRs` re-serialize entire lists. Putting those on a durable log would store a fat stream of UI invalidations, and an extension subscribing to it would learn only that "the ticket list changed again" — it would have to diff the list to recover what actually happened.

So the WebSocket hub becomes an *ephemeral* consumer instead, and a `wireProjections` table maps facts back to what the wire needs, which is usually the same full-board push as before. The accepted cost: A2 is a real per-broadcaster migration, not a mechanical rename. The pattern for it is documented at the top of `internal/daemon/bus.go`.

## What's here

- **Migration 84** — `bus_events` (seq/name/subject/payload/source/created_at, indexed by name and subject) and `bus_consumers` (name/cursor/filter/enabled/updated_at). Re-registering a consumer preserves its cursor and enabled bit, so a daemon restart never rewinds one or resurrects a killed one.
- **`internal/bus`** — defines its own `Store` seam and does not import `internal/daemon`; the daemon adapts `internal/store` to it, the same arrangement as `sqlTaskStore`/`internal/tasks`.
- **Delivery** — durable consumers get strict global `seq` order, one event in flight, cursor advanced after the handler returns. That is at-least-once, so handlers must tolerate redelivery, and a failing handler stalls its own consumer loudly rather than skipping. New consumers start **at head**: registration is not a request to replay history.
- **Retention** — trims past an age window but never past an **enabled** consumer's cursor. A disabled consumer deliberately does not pin the log; revived below the trim point it resumes at head and the gap is logged.
- **Migrated** — `session.state.changed` plus every ticket producer (16 call sites publishing `ticket.created` / `status_changed` / `commented` / `assigned` / `attached`).
- **Operator surface** — `attn bus status [--json]`, `attn bus enable|disable <consumer>`, reading and writing the database directly. No protocol bump: status is a diagnostic, and the enabled bit is database-only on purpose, because a kill switch that depends on the daemon it kills is not a kill switch.

Byte streams stay off the bus by design — PTY output, PTY desync, attach results, workspace tile content, and fs bursts keep their direct paths. Attach routes by a per-client predicate, which pub/sub cannot express, and it is the hottest path in the product.

## Two defects found by review, fixed here

Both were in the durable delivery loop, so neither could reach the wire. Each has a regression test that was confirmed to fail without its fix.

- **Backoff measured the wrong thing.** The failure streak was cleared only when a drain reached an empty batch — which a consumer that never catches up never sees — so attempts accumulated across *different, already-succeeded* events and ratcheted to the retry cap on occasional transient failures. Reproduced at 8000 events with every 50th failing once: no event was ever stuck, yet the counter reached 160. The streak now ends on every successful delivery.
- **The kill switch could not reach a saturated consumer.** `drain` read the enabled bit once and then looped until the log was exhausted, so a consumer behind a busy producer stayed unreachable for the length of the burst — 146 deliveries in the 300ms after the flip. The bit is now re-read on the poll interval from inside the batch loop, which is the bound `DefaultPollInterval` documents.

A latent race in the test harness surfaced alongside them: `TestTrimIsCursorAware` shared a bare `now` closure between the test and the delivery goroutine. It now uses a guarded clock.

## Verification

Live-verified on a throwaway profile before the review fixes; preflight clean, protocol 200 agreed across CLI, app, and daemon.

- Three ticket mutations produced exactly the expected facts in order, each carrying its ticket id as the subject, and a connected WebSocket client received **exactly one `tickets_updated` per fact** — one board push per fact, wire behavior unchanged.
- Spawning a shell session produced one `session_state_changed` on the wire and exactly one `session.state.changed` fact.
- Daemon restart preserved the log; `attn bus status` (table and `--json`), `disable`/`enable` on a lagging consumer, and the unknown-consumer error path all behaved.

The two fixes above landed after that run and were not re-verified live, deliberately: they touch only `drain`, which is reachable solely from `deliver`, which runs solely for durable consumers. Production has none, and the publish and ephemeral-fanout paths the live run exercised are untouched.

`go test ./...` green; `./internal/bus -race -count=3` green.

## Known and accepted

Production registers no durable consumer yet — the hub is ephemeral and extensions arrive in A4 — so the durable delivery loop is proved by tests, including against the real SQLite adapter, rather than by production traffic. The retention loop does run in production.

No CHANGELOG entry: there is no user-visible behavior change, and `attn bus` is an operator diagnostic.

`docs/plans/2026-08-01-ext-b1-job-queue.md` records the approved gate answers for the parallel B1 track so the decisions are not lost. No B1 code here.

https://claude.ai/code/session_01429snMWPwXjv1NeqUdV57c
