### PR TITLE
fix(queue): correct Cmd+J target and give sidebar rows the full line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,19 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-08-01]
 
+### Changed
+- **Queue rows give the whole line to the session name.** Sidebar rows in the
+  agent queue no longer show the workspace name, the waiting time sits at the
+  right edge, and the settle/pin/actions buttons appear over the right edge on
+  hover instead of permanently reserving space — so long session names are
+  readable instead of truncating next to empty space. The pin button's tooltip
+  still names the workspace a row would leave the queue by.
+
 ### Fixed
+- **⌘J jumps to the agent that has waited longest.** Jump-to-waiting used to
+  pick the first waiting session in sidebar workspace order, which made its
+  target feel arbitrary. It now follows the queue's own order — the turn owed
+  longest, the same row the "Your turn" band lists first.
 - **A workspace that holds only a tile can be closed again.** Closing the last
   notebook, markdown, or browser tile in a workspace with no agents left the
   workspace in the sidebar — and every later click on its × did nothing, so the

--- a/app/scripts/real-app-harness/scenario-agent-queue.mjs
+++ b/app/scripts/real-app-harness/scenario-agent-queue.mjs
@@ -253,8 +253,8 @@ async function main() {
     await runner.step('band_is_oldest_first_and_each_agent_appears_once', async () => {
       const queue = await waitForTurns(client, [alpha.sessionId, beta.sessionId], 'both turns, oldest first');
       runner.assert(
-        queue.turns[0].workspace !== queue.turns[1].workspace,
-        `the two turns come from different workspaces: ${JSON.stringify(queue.turns.map((row) => row.workspace))}`,
+        queue.turns[0].workspaceId !== queue.turns[1].workspaceId,
+        `the two turns come from different workspaces: ${JSON.stringify(queue.turns.map((row) => row.workspaceId))}`,
       );
       // The bands replace the tree rather than sitting on top of it. An agent
       // drawn in both places is what made a row look like it moved when only one

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -110,6 +110,7 @@ import {
   buildQueueBands,
   isQueueModeEnabled,
   nextTurnAfterSettle,
+  oldestWantedTurn,
   QUEUE_MODE_SETTING,
   isAutoSettleEnabled,
   AUTO_SETTLE_ENABLED_SETTING,
@@ -2921,7 +2922,7 @@ sendFetchPRDetails,
 
   // Keyboard shortcut handlers
   const handleJumpToWaiting = useCallback(() => {
-    const waiting = unmutedEnrichedSessions.find(wantsAttention);
+    const waiting = oldestWantedTurn(unmutedEnrichedSessions, wantsAttention);
     if (waiting) {
       handleSelectSession(waiting.id);
     }

--- a/app/src/components/QueueBands.tsx
+++ b/app/src/components/QueueBands.tsx
@@ -92,53 +92,64 @@ function QueueRowView({
         onClick={onSelect}
       />
       <StateIndicator state={session.state} size="md" seed={session.id} reason={session.state_reason} />
+      {/*
+        No workspace name in a band row: the row is about the agent, the label
+        needs every column the sidebar has, and the pin button's tooltip still
+        says which workspace the row would leave the queue by. The age anchors
+        to the right edge; the hover controls float above it (see .queue-row-
+        controls) rather than reserving row width for buttons that are usually
+        invisible.
+      */}
       <span className="session-label">{session.label}</span>
       {session.chiefOfStaff && <ChiefOfStaffBadge />}
-      <span className="queue-row-workspace">{row.workspaceTitle}</span>
       {age && <span className="queue-row-age">{age}</span>}
-      {onOpenActions && (
-        <div className="session-actions">
-          <button
-            type="button"
-            className="session-action-btn session-more-btn"
-            data-testid={`session-actions-${session.id}`}
-            onClick={onOpenActions}
-            title="Session actions"
-            aria-label={`Actions for ${session.label}`}
-          >
-            •••
-          </button>
+      {(onOpenActions || onPin || onSettle) && (
+        <div className="queue-row-controls">
+          {onOpenActions && (
+            <div className="session-actions">
+              <button
+                type="button"
+                className="session-action-btn session-more-btn"
+                data-testid={`session-actions-${session.id}`}
+                onClick={onOpenActions}
+                title="Session actions"
+                aria-label={`Actions for ${session.label}`}
+              >
+                •••
+              </button>
+            </div>
+          )}
+          {onPin && (
+            <button
+              type="button"
+              className="queue-row-pin"
+              data-testid={`queue-pin-${session.id}`}
+              title={`Pin ${row.workspaceTitle} — take it out of the queue`}
+              aria-label={`Pin workspace ${row.workspaceTitle}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onPin();
+              }}
+            >
+              📍
+            </button>
+          )}
+          {onSettle && (
+            <button
+              type="button"
+              className="queue-row-settle"
+              data-testid={`queue-settle-${session.id}`}
+              title={`Settle this turn (${formatShortcut('session.settle')})`}
+              aria-label={`Settle ${session.label}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onSettle();
+              }}
+            >
+              ✓
+            </button>
+          )}
         </div>
-      )}
-      {onPin && (
-        <button
-          type="button"
-          className="queue-row-pin"
-          data-testid={`queue-pin-${session.id}`}
-          title={`Pin ${row.workspaceTitle} — take it out of the queue`}
-          aria-label={`Pin workspace ${row.workspaceTitle}`}
-          onClick={(event) => {
-            event.stopPropagation();
-            onPin();
-          }}
-        >
-          📍
-        </button>
-      )}
-      {onSettle && (
-        <button
-          type="button"
-          className="queue-row-settle"
-          data-testid={`queue-settle-${session.id}`}
-          title={`Settle this turn (${formatShortcut('session.settle')})`}
-          aria-label={`Settle ${session.label}`}
-          onClick={(event) => {
-            event.stopPropagation();
-            onSettle();
-          }}
-        >
-          ✓
-        </button>
       )}
       {showSettling && session.autoSettleFiresAt && (
         <SidebarSettlingBar firesAt={session.autoSettleFiresAt} />

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -1229,26 +1229,48 @@
   outline-offset: -2px;
 }
 
-/* Above the fill, so pressing one of these is not also opening the session. */
-.queue-row > .session-actions,
-.queue-row > .queue-row-pin,
-.queue-row > .queue-row-settle {
-  position: relative;
+/* The hover controls float over the row's right edge instead of sitting in its
+   flex flow: buttons that are invisible at rest must not reserve label width.
+   Above the fill button, so pressing one of these is not also opening the
+   session; opaque, so while shown they read as replacing the age underneath
+   (the background matches the row's hover/selected background). */
+.queue-row-controls {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 4px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding-left: 6px;
   z-index: 1;
+  opacity: 0;
+  pointer-events: none;
+  background: var(--color-bg-elevated);
+  border-radius: inherit;
+  transition: opacity 120ms ease;
 }
 
-.queue-row-workspace {
-  flex: 0 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--color-text-dimmed);
-  font-size: var(--font-size-xs);
+.queue-row:hover .queue-row-controls,
+.queue-row:focus-within .queue-row-controls {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* The container is the only visibility gate: the per-button reveals (hover for
+   settle/pin, .session-item:hover for the actions menu) would leave whichever
+   button the current interaction does not match as an invisible hole in an
+   otherwise visible strip. */
+.queue-row-controls .session-actions,
+.queue-row-controls .queue-row-pin,
+.queue-row-controls .queue-row-settle {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .queue-row-age {
   flex: 0 0 auto;
+  margin-left: auto;
   color: var(--color-text-muted);
   font-size: var(--font-size-xs);
   font-variant-numeric: tabular-nums;

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -2657,7 +2657,18 @@ export function useDaemonSocket({
       if (recoveryNoticeTimeoutRef.current) {
         clearTimeout(recoveryNoticeTimeoutRef.current);
       }
-      wsRef.current?.close();
+      // Detach handlers before closing: onclose otherwise schedules a fresh
+      // reconnect timer synchronously (as it does in tests, and can in real
+      // browsers too), which would leak past this cleanup and fire after
+      // teardown with a stale WebSocket reference.
+      const ws = wsRef.current;
+      if (ws) {
+        ws.onclose = null;
+        ws.onerror = null;
+        ws.onmessage = null;
+        ws.onopen = null;
+        ws.close();
+      }
     };
   }, [connect]);
 

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -1866,7 +1866,6 @@ export function useUiAutomationBridge({
             id: (row.getAttribute('data-testid') || '').slice(prefix.length),
             label: row.querySelector('.session-label')?.textContent?.trim() || '',
             state: row.getAttribute('data-state') || '',
-            workspace: row.querySelector('.queue-row-workspace')?.textContent?.trim() || '',
             workspaceId: row.getAttribute('data-workspace-id') || '',
             age: row.querySelector('.queue-row-age')?.textContent?.trim() || '',
             selected: row.classList.contains('selected'),

--- a/app/src/utils/queueBands.test.ts
+++ b/app/src/utils/queueBands.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildQueueBands, nextTurnAfterSettle, type QueueBandSession } from './queueBands';
+import { buildQueueBands, nextTurnAfterSettle, oldestWantedTurn, type QueueBandSession } from './queueBands';
 import { buildWorkspaceViewModels } from './workspaceViewModels';
 
 const workspaces = [
@@ -158,6 +158,39 @@ describe('buildQueueBands', () => {
     buildQueueBands(tree);
 
     expect(tree.map((workspace) => workspace.sessions.map((session) => session.id))).toEqual([['a'], ['b']]);
+  });
+});
+
+describe('oldestWantedTurn', () => {
+  const wantsOwed = (session: QueueBandSession) => Boolean(session.turnOwed);
+
+  it('lands on the turn owed longest, not the first in list order', () => {
+    // The list arrives in workspace order; ⌘J must follow the queue's order.
+    const target = oldestWantedTurn([
+      { id: 'newest', label: 'newest', workspaceId: 'ws-a', turnOwed: true, turnOpenedAt: '2026-07-26T12:00:00Z' },
+      { id: 'oldest', label: 'oldest', workspaceId: 'ws-b', turnOwed: true, turnOpenedAt: '2026-07-26T09:00:00Z' },
+      { id: 'middle', label: 'middle', workspaceId: 'ws-a', turnOwed: true, turnOpenedAt: '2026-07-26T10:00:00Z' },
+    ], wantsOwed);
+
+    expect(target?.id).toBe('oldest');
+  });
+
+  it('skips sessions that do not want the user, whatever their stamp says', () => {
+    // A settled turn keeps its turnOpenedAt until the next turn opens; being
+    // old is not being owed.
+    const target = oldestWantedTurn([
+      { id: 'settled-old', label: 'a', workspaceId: 'ws-a', turnOwed: false, turnOpenedAt: '2026-07-26T08:00:00Z' },
+      { id: 'owed', label: 'b', workspaceId: 'ws-a', turnOwed: true, turnOpenedAt: '2026-07-26T10:00:00Z' },
+    ], wantsOwed);
+
+    expect(target?.id).toBe('owed');
+  });
+
+  it('is null when nothing wants the user', () => {
+    expect(oldestWantedTurn([
+      { id: 'quiet', label: 'quiet', workspaceId: 'ws-a' },
+    ], wantsOwed)).toBeNull();
+    expect(oldestWantedTurn([], wantsOwed)).toBeNull();
   });
 });
 

--- a/app/src/utils/queueBands.ts
+++ b/app/src/utils/queueBands.ts
@@ -97,6 +97,28 @@ export function compareTurnOrder(a: QueueBandSession, b: QueueBandSession): numb
   return a.id < b.id ? -1 : 1;
 }
 
+/**
+ * The jump-to-waiting (⌘J) target: of the sessions that want the user, the one
+ * whose turn has been owed longest. Queue order, not list order — a jump that
+ * follows workspace rank while the band on screen is sorted by age reads as
+ * random. `wants` is passed in because each arrangement has its own notion of
+ * wanting the user (turn_owed with the queue on, the state predicate with it
+ * off) and that choice belongs to the caller.
+ */
+export function oldestWantedTurn<TSession extends QueueBandSession>(
+  sessions: TSession[],
+  wants: (session: TSession) => boolean,
+): TSession | null {
+  let oldest: TSession | null = null;
+  for (const session of sessions) {
+    if (!wants(session)) continue;
+    if (!oldest || compareTurnOrder(session, oldest) < 0) {
+      oldest = session;
+    }
+  }
+  return oldest;
+}
+
 export interface QueueBands<TSession extends QueueBandSession> {
   /** The chief's anchored slot. It never queues, so it is always its own row. */
   chief: QueueRow<TSession> | null;


### PR DESCRIPTION
## What changed

Two user-reported fixes to the queue/attention UI, plus a CI-blocking test flake fixed along the way:

**1. Cmd+J jumped to the wrong session.** `handleJumpToWaiting` in `App.tsx` picked the target session with `unmutedEnrichedSessions.find(wantsAttention)`, which walks workspace/tree rank order rather than turn order. That disagreed with the queue band's own oldest-first ordering, so pressing Cmd+J could land on a session other than the one that had actually waited longest. Added `oldestWantedTurn(sessions, wants)` to `app/src/utils/queueBands.ts`, reusing the existing `compareTurnOrder` (ascending `turnOpenedAt`, id tiebreak), and switched `App.tsx` to use it.

**2. Queue-mode sidebar rows couldn't show session names.** The row reserved flex space for a truncated workspace-name span plus always-present hover controls (•••, pin, settle), leaving little width for the actual session label. Removed the workspace-name span, moved the hover controls into an absolutely-positioned `.queue-row-controls` overlay so they no longer take up space at rest, and right-anchored the waiting-time age with `margin-left: auto`. The session name now gets the rest of the line.

As a follow-on, the UI automation bridge's `queue_get_state` (`useUiAutomationBridge.ts`) and the `scenario-agent-queue.mjs` harness scenario both read the workspace-name text that was removed; both were switched to read `workspaceId` (`data-workspace-id`) instead.

**3. Fixed a pre-existing, timing-dependent test bug in `useDaemonSocket.ts`** that CI's full-suite run hit on this PR. The reconnect effect's cleanup cleared the pending reconnect timeout and then called `ws.close()`; since `onclose` fires synchronously in this hook's own test WebSocket mock (and can in real browsers), that scheduled a brand-new reconnect timer which outlived the cleanup (the `clearTimeout` guard had already run). The stray timer later fired against a torn-down test environment, surfacing as an unhandled `Cannot read properties of undefined (reading 'OPEN')` rejection. Fixed by nulling out the socket's handlers before calling `close()` during teardown.

`CHANGELOG.md` has entries under `## [2026-08-01]`.

## How it was verified

- Full frontend suite: 196 files / 2147 tests passing, run repeatedly locally with no flake.
- Live-verified in a running dev-profile app by injecting sessions whose oldest owed turn sat in the last-ranked workspace: Cmd+J landed on that oldest-turn session, and screenshots confirmed the row layout at rest (full-width name) and all three hover controls appearing together on hover/focus.
- CI green on the current head (Frontend, Frontend E2E x3, React Doctor, Changes).