### PR TITLE
fix: attn resolved the wrong codex transcript when its own classifier ran in the same cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   pick the first waiting session in sidebar workspace order, which made its
   target feel arbitrary. It now follows the queue's own order — the turn owed
   longest, the same row the "Your turn" band lists first.
+- **Codex sessions no longer mistake attn's own bookkeeping for their
+  conversation.** attn's stop-time classifier runs a small codex call from the
+  session's directory, and its saved log could be picked up as the session's
+  transcript — so state classification, session digests in the Notebook, and
+  orphaned-ticket reconciliation could read an internal `{"verdict":...}` note
+  instead of what the agent actually said. Transcripts now resolve by the codex
+  session's own id, the classifier no longer saves a log at all, and headless
+  codex runs are excluded from transcript discovery.
 - **A workspace that holds only a tile can be closed again.** Closing the last
   notebook, markdown, or browser tile in a workspace with no agents left the
   workspace in the sidebar — and every later click on its × did nothing, so the

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -281,6 +281,13 @@ func runCodexClassifierAttempt(ctx context.Context, executable, model, reasoning
 	args := []string{
 		"exec",
 		"--json",
+		// Never persist a rollout under ~/.codex/sessions: the classifier runs
+		// from the session's own cwd, so a persisted rollout is a decoy that
+		// cwd-based transcript discovery can resolve instead of the session's
+		// real conversation — the classifier would then classify its own prior
+		// verdict. The verdict is read from --output-last-message and stdout;
+		// nothing reads the rollout.
+		"--ephemeral",
 		"--output-last-message", lastMessagePath,
 		// Classify regardless of the session's cwd. Codex refuses `exec` outside a
 		// trusted git repo otherwise, which is how a codex turn that ends in an

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2577,6 +2577,12 @@ func (d *Daemon) handleStop(conn net.Conn, msg *protocol.StopMessage) {
 	go d.classifySessionState(msg.ID, msg.TranscriptPath)
 }
 
+// resolveTranscriptPathForSession resolves a session's transcript by the
+// strongest identity available: the path the agent's own hook reported, then
+// the agent-native resume id synced from hooks, and only then the finder's
+// cwd/time guess. The guess must stay last for codex: several codex processes
+// can share one cwd (a second attn pane, a user's own `codex exec`), and
+// "newest matching cwd" cannot tell them apart.
 func (d *Daemon) resolveTranscriptPathForSession(session *protocol.Session, transcriptPath string) string {
 	path := strings.TrimSpace(transcriptPath)
 	if session == nil {
@@ -2589,12 +2595,20 @@ func (d *Daemon) resolveTranscriptPathForSession(session *protocol.Session, tran
 		}
 	}
 
-	if driver := agentdriver.Get(string(session.Agent)); driver != nil {
-		if tf, ok := agentdriver.GetTranscriptFinder(driver); ok {
-			if discovered := strings.TrimSpace(tf.FindTranscript(session.ID, session.Directory, time.Now())); discovered != "" {
-				return discovered
-			}
+	driver := agentdriver.Get(string(session.Agent))
+	tf, ok := agentdriver.GetTranscriptFinder(driver)
+	if !ok {
+		return path
+	}
+
+	if resumeID := strings.TrimSpace(d.store.GetResumeSessionID(session.ID)); resumeID != "" {
+		if resolved := strings.TrimSpace(tf.FindTranscriptForResume(resumeID)); resolved != "" {
+			return resolved
 		}
+	}
+
+	if discovered := strings.TrimSpace(tf.FindTranscript(session.ID, session.Directory, time.Now())); discovered != "" {
+		return discovered
 	}
 
 	return path

--- a/internal/daemon/ticket_reconcile.go
+++ b/internal/daemon/ticket_reconcile.go
@@ -361,13 +361,13 @@ func (d *Daemon) hasForcedStopMark(sessionID string) bool {
 }
 
 // resolveReconcileTranscript locates the dead session's transcript via the
-// judged agent's driver. Claude transcripts resolve by id — prefer the ticket's
-// mirrored resume id (the latest claude-native id after resumes; the session
-// row's copy dies with the row) and fall back to the attn session id. Codex has
-// no id-based lookup (ResumeSessionIDFromStopTranscriptPath returns ""), so it
-// resolves by cwd + time anchor: time.Now() at the death seam (fresh mod-time
-// window), the ticket's CreatedAt from the sweep (delegation ≈ spawn; an early
-// anchor only widens the window). "" means rule 7: comment, don't vanish.
+// judged agent's driver, preferring the ticket's mirrored resume id (the
+// latest agent-native id — claude's from stop payloads, codex's from its hook
+// session_id sync; the session row's copy dies with the row). Only when no id
+// was mirrored does it fall back to the finder's cwd + time-anchor guess:
+// time.Now() at the death seam (fresh mod-time window), the ticket's CreatedAt
+// from the sweep (delegation ≈ spawn; an early anchor only widens the window).
+// "" means rule 7: comment, don't vanish.
 func (d *Daemon) resolveReconcileTranscript(agentID, sessionID, cwd string, anchor time.Time, assignee string) string {
 	driver := agentdriver.Get(agentID)
 	if driver == nil {

--- a/internal/daemon/transcript_resolution_test.go
+++ b/internal/daemon/transcript_resolution_test.go
@@ -1,0 +1,88 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// writeCodexInteractiveRollout writes a codex rollout into codexHome with the given
+// native session id, cwd, and session_meta timestamps, mirroring the shape
+// codex-cli persists under ~/.codex/sessions.
+func writeCodexInteractiveRollout(t *testing.T, codexHome, nativeID, cwd string, at time.Time) string {
+	t.Helper()
+	dir := filepath.Join(codexHome, "sessions", "2026", "05", "17")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir rollout dir: %v", err)
+	}
+	path := filepath.Join(dir, fmt.Sprintf("rollout-%s-%s.jsonl", at.UTC().Format("2006-01-02T15-04-05"), nativeID))
+	line := fmt.Sprintf(
+		`{"timestamp":"%s","type":"session_meta","payload":{"id":"%s","timestamp":"%s","cwd":"%s","source":"cli"}}`+"\n",
+		at.UTC().Format(time.RFC3339Nano), nativeID, at.UTC().Format(time.RFC3339Nano), cwd,
+	)
+	if err := os.WriteFile(path, []byte(line), 0o644); err != nil {
+		t.Fatalf("write rollout: %v", err)
+	}
+	if err := os.Chtimes(path, at, at); err != nil {
+		t.Fatalf("chtimes rollout: %v", err)
+	}
+	return path
+}
+
+// Regression for the wrong-rollout bug: two codex processes sharing one cwd
+// (here two interactive sessions; live it was attn's own classifier) are
+// indistinguishable to the finder's cwd+newest guess, so resolution must
+// prefer the codex-native session id the hooks synced for this session.
+func TestResolveTranscriptPathForSession_PrefersCodexNativeSessionID(t *testing.T) {
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	cwd := "/repo/project"
+	now := time.Now()
+
+	own := writeCodexInteractiveRollout(t, codexHome, "native-own", cwd, now.Add(-time.Minute))
+	newerNeighbor := writeCodexInteractiveRollout(t, codexHome, "native-neighbor", cwd, now.Add(-5*time.Second))
+
+	d.store.Add(&protocol.Session{
+		ID:        "sess",
+		Label:     "sess",
+		Agent:     protocol.SessionAgentCodex,
+		Directory: cwd,
+	})
+	d.store.SetResumeSessionID("sess", "native-own")
+
+	got := d.resolveTranscriptPathForSession(d.store.Get("sess"), "")
+	if got != own {
+		t.Fatalf("resolveTranscriptPathForSession() = %q, want own rollout %q (newer neighbor=%q)", got, own, newerNeighbor)
+	}
+}
+
+// Without a synced native id the cwd guess is still the fallback: resolution
+// degrades to the finder's pick instead of returning nothing.
+func TestResolveTranscriptPathForSession_FallsBackToCWDGuessWithoutNativeID(t *testing.T) {
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	cwd := "/repo/project"
+	now := time.Now()
+
+	newest := writeCodexInteractiveRollout(t, codexHome, "native-only", cwd, now.Add(-time.Minute))
+
+	d.store.Add(&protocol.Session{
+		ID:        "sess",
+		Label:     "sess",
+		Agent:     protocol.SessionAgentCodex,
+		Directory: cwd,
+	})
+
+	got := d.resolveTranscriptPathForSession(d.store.Get("sess"), "")
+	if got != newest {
+		t.Fatalf("resolveTranscriptPathForSession() = %q, want cwd-guess rollout %q", got, newest)
+	}
+}

--- a/internal/transcript/discovery.go
+++ b/internal/transcript/discovery.go
@@ -26,6 +26,7 @@ func FindCodexTranscript(cwd string, startedAt time.Time) string {
 		Payload   struct {
 			Cwd       string `json:"cwd"`
 			Timestamp string `json:"timestamp"`
+			Source    string `json:"source"`
 		} `json:"payload"`
 	}
 
@@ -72,6 +73,17 @@ func FindCodexTranscript(cwd string, startedAt time.Time) string {
 			return nil
 		}
 		if entry.Type != "session_meta" {
+			return nil
+		}
+
+		// This finder resolves interactive attn panes, which codex records with
+		// source "cli". `codex exec` rollouts (source "exec") are headless runs —
+		// attn's own stop-time classifier among them — that share the pane's cwd
+		// and land seconds after the real conversation, so cwd+newest would pick
+		// them over the pane's rollout. They are categorically not what any
+		// caller is looking for. Rollouts predating the source field keep the old
+		// behavior.
+		if entry.Payload.Source == "exec" {
 			return nil
 		}
 

--- a/internal/transcript/discovery_test.go
+++ b/internal/transcript/discovery_test.go
@@ -66,19 +66,41 @@ func writeCodexTranscript(
 	modTime time.Time,
 ) string {
 	t.Helper()
+	return writeCodexTranscriptWithSource(t, homeDir, sessionID, cwd, "", startTime, modTime)
+}
+
+// writeCodexTranscriptWithSource writes a codex rollout whose session_meta
+// carries an explicit payload.source ("cli" for interactive sessions, "exec"
+// for headless `codex exec` runs). An empty source omits the field, matching
+// rollouts from codex versions that predate it.
+func writeCodexTranscriptWithSource(
+	t *testing.T,
+	homeDir,
+	sessionID,
+	cwd,
+	source string,
+	startTime time.Time,
+	modTime time.Time,
+) string {
+	t.Helper()
 
 	sessionDir := filepath.Join(homeDir, ".codex", "sessions", "2026", "05", "17")
 	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
 		t.Fatalf("mkdir codex session dir: %v", err)
 	}
 
+	sourceField := ""
+	if source != "" {
+		sourceField = fmt.Sprintf(`,"source":"%s"`, source)
+	}
 	transcriptPath := filepath.Join(sessionDir, fmt.Sprintf("rollout-%s-%s.jsonl", startTime.UTC().Format("2006-01-02T15-04-05"), sessionID))
 	lines := fmt.Sprintf(
-		`{"timestamp":"%s","type":"session_meta","payload":{"id":"%s","timestamp":"%s","cwd":"%s"}}`+"\n",
+		`{"timestamp":"%s","type":"session_meta","payload":{"id":"%s","timestamp":"%s","cwd":"%s"%s}}`+"\n",
 		startTime.UTC().Format(time.RFC3339Nano),
 		sessionID,
 		startTime.UTC().Format(time.RFC3339Nano),
 		cwd,
+		sourceField,
 	)
 	if err := os.WriteFile(transcriptPath, []byte(lines), 0o644); err != nil {
 		t.Fatalf("write codex transcript: %v", err)
@@ -119,6 +141,60 @@ func TestFindCodexTranscript_MatchesSymlinkEquivalentCWD(t *testing.T) {
 	got := FindCodexTranscript(linkCWD, startedAt)
 	if got != expected {
 		t.Fatalf("FindCodexTranscript() = %q, want %q", got, expected)
+	}
+}
+
+// Regression for the classifier-decoy bug: attn's stop-time classifier used to
+// run `codex exec` from the session's own cwd and persist a rollout there, so
+// "newest rollout matching cwd" resolved attn's internal bookkeeping instead of
+// the user's conversation. Headless rollouts carry payload.source "exec" and
+// must never win interactive discovery, no matter how fresh they are.
+func TestFindCodexTranscript_IgnoresExecSourcedRollouts(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("CODEX_HOME", "")
+	t.Setenv(toolhome.EnvVar, homeDir)
+
+	cwd := "/repo/project"
+	startedAt := time.Date(2026, 5, 17, 14, 0, 0, 0, time.UTC)
+
+	session := writeCodexTranscriptWithSource(
+		t, homeDir, "codex-session-real", cwd, "cli",
+		startedAt.Add(5*time.Second), startedAt.Add(5*time.Second),
+	)
+	// The classifier's rollout: same cwd, written seconds later.
+	classifier := writeCodexTranscriptWithSource(
+		t, homeDir, "codex-classifier-decoy", cwd, "exec",
+		startedAt.Add(11*time.Second), startedAt.Add(11*time.Second),
+	)
+
+	if got := FindCodexTranscript(cwd, startedAt); got != session {
+		t.Fatalf("FindCodexTranscript() = %q, want session rollout %q (classifier decoy=%q)", got, session, classifier)
+	}
+}
+
+// Exec-sourced rollouts are excluded from the mod-time fallback too, not just
+// the timestamp-ranked path.
+func TestFindCodexTranscript_FallbackIgnoresExecSourcedRollouts(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("CODEX_HOME", "")
+	t.Setenv(toolhome.EnvVar, homeDir)
+
+	cwd := "/repo/project"
+	startedAt := time.Date(2026, 5, 17, 14, 0, 0, 0, time.UTC)
+
+	// A resumed session: session_meta timestamp is old, but the file is still
+	// actively written (fresh mod time), so it resolves via the fallback.
+	session := writeCodexTranscriptWithSource(
+		t, homeDir, "codex-session-resumed", cwd, "cli",
+		startedAt.Add(-2*time.Hour), startedAt.Add(1*time.Minute),
+	)
+	classifier := writeCodexTranscriptWithSource(
+		t, homeDir, "codex-classifier-decoy", cwd, "exec",
+		startedAt.Add(-1*time.Hour), startedAt.Add(2*time.Minute),
+	)
+
+	if got := FindCodexTranscript(cwd, startedAt); got != session {
+		t.Fatalf("FindCodexTranscript() = %q, want session rollout %q (classifier decoy=%q)", got, session, classifier)
 	}
 }
 


### PR DESCRIPTION
## The bug

`transcript.FindCodexTranscript(cwd, startedAt)` picked a codex rollout by matching the session's working directory and taking the newest match. attn's own stop-time classifier runs `codex exec` **from the session's cwd** (`ClassifyWithCodexExecutableInDir`) and, lacking `--ephemeral`, persisted its own rollout under `~/.codex/sessions` with that same cwd. Seconds after every codex turn, the classifier's rollout became the newest match, so transcript reads resolved attn's internal bookkeeping — a rollout whose last message is `{"verdict":"DONE"}` — instead of what codex actually said (observed live 2026-08-01, codex-cli 0.146.0).

## The fix — identity over heuristics

Codex hooks already sync the codex-native session id to the daemon on every hook event (`syncSessionResumeID` → `set_session_resume_id` → `persistResumeSessionID`, mirrored onto any bound ticket), so an exact identity is available almost immediately after spawn. Three changes, ordered strongest-identity-first:

1. **Daemon transcript resolution prefers the native id.** `resolveTranscriptPathForSession` now resolves: hook-reported path (exact, from the agent itself) → `FindTranscriptForResume(stored native id)` → cwd/time guess. This also benefits claude sessions after resumes, where the native id tracks the latest transcript file while the attn session id names the original one.
2. **The classifier stops writing rollouts.** Its `codex exec` invocation now runs with `--ephemeral` (already used by every other headless codex path in attn), so the polluting file is never created.
3. **`FindCodexTranscript` skips headless rollouts.** Rollouts whose `session_meta` declares `source: "exec"` are excluded from cwd discovery. This is provenance, not content matching: the finder's callers are exclusively resolving interactive panes (`source: "cli"`), and a `codex exec` rollout — attn's classifier on older binaries, workflow-engine runs, a user's own scripts — is categorically never the pane's transcript. Rollouts predating the `source` field are unaffected.

## Affected callers (what they read before → now)

Callers that resolved fresh via the cwd guess and could silently read classifier output:

- **Stop-time classification fallback** (`classifySessionState` → `resolveTranscriptPathForSession`): the codex stop hook payload does carry `transcript_path`, so the common path was safe — but whenever that path was missing or stale, the fallback could hand the classifier **its own previous verdict** to classify (the feedback loop the ticket flagged: `{"verdict":"DONE"}` classifies as DONE, pinning the session idle). Now resolves by native id.
- **Notebook narration** (`summarize_session` / narrate retrospective, which pass an empty path for sessions without a carried transcript): could summarize classifier bookkeeping into the journal. Now resolves by native id.
- **Ticket reconciliation** (`resolveReconcileTranscript`): already preferred the ticket's mirrored resume id; its cwd fallback (used when no id was mirrored) is now protected by the `source: "exec"` exclusion. The stale comment claiming codex has no id-based lookup is corrected.

Not affected (already identity-based, listed for completeness): `attn session transcript` (`inspectableTranscriptPath`, id-or-nothing by design), `session instructions`, automation resume, spawn resume. The transcript watcher never runs for codex.

## Verification

- **Unit regression, both layers, verified falsifiable**: `TestFindCodexTranscript_IgnoresExecSourcedRollouts` (+ mod-time-fallback variant) builds the ticket's exact fixture — the session's rollout plus a later classifier rollout sharing its cwd — and `TestResolveTranscriptPathForSession_PrefersCodexNativeSessionID` covers the id-first referee with two interactive rollouts in one cwd. Each was run with its fix piece reverted and failed on the load-bearing assertion (the decoy path was returned), then re-greened with the fix restored.
- **`make test` green** (full Go suite).
- **Live on a throwaway profile** (`make install PROFILE=codextx`, preflight PASS): spawned a real codex session via the daemon, prompted for a distinctive prose answer ("INDIGO MARMOSET…"). Evidence: the classifier's input logged in `daemon.log` was the real answer, not a verdict blob; verdict `idle` applied; exactly **one** rollout exists with the session's cwd (the pane's own — the classifier run left none, confirming `--ephemeral`); the stored `resume_session_id` matches that rollout's native id; `attn session transcript` returns the conversation. Profile torn down after.

## Notes

- Copilot's `FindCopilotTranscript` shares the cwd+newest ambiguity in principle, but attn's copilot classifier already runs from an isolated temp cwd precisely to avoid polluting that discovery, so attn does not decoy itself there. The residual ambiguity (two interactive copilot sessions sharing one directory) is out of this ticket's scope — flagged rather than fixed.

https://claude.ai/code/session_0125XqNjfU58ZJGuswMUWwTD
