### PR TITLE
fix(tickets): stop the ticket-slug fallback test flaking on a numeric suffix

### DIFF
--- a/internal/daemon/delegate_ticket.go
+++ b/internal/daemon/delegate_ticket.go
@@ -117,6 +117,11 @@ func (d *Daemon) adoptDelegatedTicket(creatorSessionID string, ownedByChiefRole 
 // unbounded at the cost of a less pretty id.
 const ticketSlugSequentialAttempts = 50
 
+// ticketSlugRandomSuffixLen is the width of the random tail. Fixed width is what
+// distinguishes a fallback id from the sequential walk at a glance, and it is what
+// the fallback test asserts on — the tail is hex, so it is sometimes all digits.
+const ticketSlugRandomSuffixLen = 6
+
 // createTicketWithUniqueSlug inserts template under base, falling back to base-2,
 // base-3, ... on slug collision, then to base-<random> once the sequential range is
 // exhausted. The template's ID field is ignored — the slug is allocated here. It
@@ -132,7 +137,7 @@ func (d *Daemon) createTicketWithUniqueSlug(template store.Ticket, base, author,
 		case attempt < ticketSlugSequentialAttempts:
 			template.ID = fmt.Sprintf("%s-%d", base, attempt+1)
 		default:
-			template.ID = fmt.Sprintf("%s-%s", base, strings.ToLower(uuid.NewString()[:6]))
+			template.ID = fmt.Sprintf("%s-%s", base, strings.ToLower(uuid.NewString()[:ticketSlugRandomSuffixLen]))
 		}
 		created, err := d.store.CreateTicketWithSubscribers(template, author, ownerRole, subscribers, now)
 		if err == nil {

--- a/internal/daemon/delegate_ticket_test.go
+++ b/internal/daemon/delegate_ticket_test.go
@@ -59,16 +59,24 @@ func TestCreateDelegatedTicketFallsBackPastSequentialRange(t *testing.T) {
 		}
 	}
 
-	session := &protocol.Session{ID: "sess-1", Directory: "/tmp/x"}
-	id, err := d.createDelegatedTicket("sess-a", false, session, "the brief", "attn", "codex")
-	if err != nil {
-		t.Fatalf("createDelegatedTicket past sequential range: %v", err)
+	// Two allocations: the fallback must be random, so it neither repeats itself nor
+	// resumes counting. The suffix is hex and so is all digits about 6% of the time —
+	// its fixed width, not its non-numeric-ness, is what separates it from the walk.
+	var ids []string
+	for i, sessionID := range []string{"sess-1", "sess-2"} {
+		session := &protocol.Session{ID: sessionID, Directory: "/tmp/x"}
+		id, err := d.createDelegatedTicket("sess-a", false, session, "the brief", "attn", "codex")
+		if err != nil {
+			t.Fatalf("createDelegatedTicket %d past sequential range: %v", i, err)
+		}
+		suffix, ok := strings.CutPrefix(id, "attn-")
+		if !ok || len(suffix) != ticketSlugRandomSuffixLen {
+			t.Fatalf("fallback id = %q, want attn- plus a %d-character random suffix, not the sequential walk continuing", id, ticketSlugRandomSuffixLen)
+		}
+		ids = append(ids, id)
 	}
-	if !strings.HasPrefix(id, "attn-") || id == "attn-2" {
-		t.Fatalf("fallback id = %q, want a random attn-<suffix>", id)
-	}
-	if _, err := strconv.Atoi(strings.TrimPrefix(id, "attn-")); err == nil {
-		t.Fatalf("fallback id = %q, want a non-numeric suffix past the sequential range", id)
+	if ids[0] == ids[1] {
+		t.Fatalf("both fallbacks allocated %q, want distinct random suffixes", ids[0])
 	}
 }
 


### PR DESCRIPTION
`TestCreateDelegatedTicketFallsBackPastSequentialRange` fails about 6% of the time in CI.

## Cause

The test asserted that the allocator's random fallback suffix is non-numeric:

```go
if _, err := strconv.Atoi(strings.TrimPrefix(id, "attn-")); err == nil {
    t.Fatalf("fallback id = %q, want a non-numeric suffix past the sequential range", id)
}
```

The suffix is `uuid.NewString()[:6]` — six hex characters, which are all digits with probability (10/16)^6 = 5.96%. That matches the observed failure rate.

The allocator is not wrong. `attn-482913` collides with nothing: the sequential walk the fallback must not resume only reaches `attn-55` (`ticketSlugSequentialAttempts+5`). The assertion was over-specified.

## Fix

Assert the property that actually distinguishes a fallback id from the walk — a fixed-width random tail. The width moves from an inline `6` to `ticketSlugRandomSuffixLen` so the test references the allocator's own constant instead of duplicating a magic number. The test now allocates twice and requires the two ids to differ, so a constant suffix is caught as well.

Production behavior is unchanged: the only non-test edit replaces the literal `6` with the named constant.

## Verification

- 200 runs of `TestCreateDelegatedTicket*` green (the old assertion would be expected to fail ~12 times).
- Mutation: making the fallback continue the sequential walk turns the test red on the load-bearing assertion — `fallback id = "attn-51", want attn- plus a 6-character random suffix, not the sequential walk continuing`.
- `go vet` and the package's `Ticket` tests pass.

No live verification: the only production change is a literal-to-named-constant rename with identical behavior, and the rest is a test assertion.

https://claude.ai/code/session_01429snMWPwXjv1NeqUdV57c