### PR TITLE
feat(daemon): auto-title sessions from the first conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-08-01]
 
+### Added
+- **Automatic session titles from your first conversation.** When a new session
+  finishes its first exchange, attn generates a descriptive title from what you
+  discussed and replaces the default folder-name label. Manual renames always
+  win — any session you've renamed stays that way.
+
 ### Changed
 - **Queue rows give the whole line to the session name.** Sidebar rows in the
   agent queue no longer show the workspace name, the waiting time sits at the

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -162,6 +162,16 @@ type Daemon struct {
 	// lookup seam: nil in production (reconcileGroundTruth derives the fetcher
 	// from ghRegistry per-host); tests set it to a fake so no network runs.
 	ticketReconcilePRFetch prStateFetcher
+	// sessionTitleExec is the Stop-time auto-title classifier spawn (see
+	// session_title.go) — New() wires the real per-agent headless run
+	// (execSessionTitle); it stays nil on test daemons so unit tests never shell
+	// out (maybeGenerateSessionTitle logs and skips). sessionTitleAttempted
+	// marks sessions that already had one LLM title attempt this daemon
+	// lifetime, success or failure, so a Stop storm never re-bills the same
+	// session; lazily allocated under sessionTitleMu.
+	sessionTitleMu        sync.Mutex
+	sessionTitleExec      func(ctx context.Context, session *protocol.Session, slice transcript.ConversationSlice) (string, error)
+	sessionTitleAttempted map[string]struct{}
 	// ticketArtifactMu serializes attach installation with its durable ticket
 	// receipt so concurrent submissions cannot race on destination names.
 	ticketArtifactMu  sync.Mutex
@@ -670,6 +680,9 @@ func New(socketPath string) *Daemon {
 	// constructors leave this nil so unit tests never shell out to a real CLI.
 	d.ticketReconcileExec = d.execTicketReconcileClassifier
 	d.ensureEventBus()
+	// Production wiring for Stop-time session auto-titling (session_title.go).
+	// Test constructors leave this nil so unit tests never shell out.
+	d.sessionTitleExec = d.execSessionTitle
 	return d
 }
 
@@ -2600,6 +2613,7 @@ func (d *Daemon) handleStop(conn net.Conn, msg *protocol.StopMessage) {
 
 	// Async classification
 	go d.classifySessionState(msg.ID, msg.TranscriptPath)
+	go d.maybeGenerateSessionTitle(msg.ID, msg.TranscriptPath)
 }
 
 // resolveTranscriptPathForSession resolves a session's transcript by the

--- a/internal/daemon/session_title.go
+++ b/internal/daemon/session_title.go
@@ -1,0 +1,322 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	agentdriver "github.com/victorarias/attn/internal/agent"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/transcript"
+)
+
+const (
+	// maxSessionTitleRunes bounds a generated session title's display length.
+	// Distinct from maxDelegationNameRunes (delegate.go): that 16-rune clamp is
+	// for delegation names, not auto-generated titles.
+	maxSessionTitleRunes = 48
+	sessionTitleTimeout  = 90 * time.Second
+)
+
+// sessionTitleOutputSchema is the JSON Schema enforced via Claude's
+// --json-schema for the auto-title run.
+const sessionTitleOutputSchema = `{
+	"type": "object",
+	"properties": {
+		"title": { "type": "string" }
+	},
+	"required": ["title"],
+	"additionalProperties": false
+}`
+
+// maybeGenerateSessionTitle is the Stop-hook seam: when a session still carries
+// its default label (cwd basename), it generates a short title from the
+// conversation using a cheap model of the session's own agent, and writes it as
+// the label. Never panics the daemon on bad input; every early return is either
+// silent (retryable states) or logged via d.logf.
+func (d *Daemon) maybeGenerateSessionTitle(sessionID, transcriptPath string) {
+	if !sessionAutoTitleEnabled() || d.sessionTitleExec == nil {
+		return
+	}
+	session := d.store.Get(sessionID)
+	if session == nil {
+		return
+	}
+	if session.Label != defaultSessionLabel(session.Directory, session.ID) {
+		return
+	}
+
+	d.sessionTitleMu.Lock()
+	if _, attempted := d.sessionTitleAttempted[sessionID]; attempted {
+		d.sessionTitleMu.Unlock()
+		return
+	}
+	d.sessionTitleMu.Unlock()
+
+	path := d.resolveTranscriptPathForSession(session, transcriptPath)
+	if strings.TrimSpace(path) == "" {
+		return
+	}
+	slice, err := transcript.ExtractConversationSlice(path, transcript.SliceOptions{
+		MaxRescopingTurns: 2,
+		MaxAgentTurns:     1,
+		TurnCharCap:       1500,
+		SummaryCharCap:    2000,
+	})
+	if err != nil || slice.Empty() || slice.Brief == "" {
+		// No genuine user content yet (or the transcript wasn't readable/found).
+		// Leave the attempted-guard unmarked so a later Stop retries — marking
+		// here would permanently skip titling for a session whose first real
+		// turn hasn't landed yet.
+		return
+	}
+
+	// Marked only now that a real LLM attempt is about to happen: one attempt
+	// per session per daemon lifetime, success or failure. Re-check membership
+	// under the lock — the early check above and this mark are two separate
+	// critical sections with transcript extraction between them, so two
+	// concurrent calls for the same session (e.g. two close-together Stop
+	// events) can both pass the early check; only the first to reach this
+	// point may proceed.
+	d.sessionTitleMu.Lock()
+	if _, attempted := d.sessionTitleAttempted[sessionID]; attempted {
+		d.sessionTitleMu.Unlock()
+		return // another caller won the race while we were extracting the slice
+	}
+	if d.sessionTitleAttempted == nil {
+		d.sessionTitleAttempted = make(map[string]struct{})
+	}
+	d.sessionTitleAttempted[sessionID] = struct{}{}
+	d.sessionTitleMu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), sessionTitleTimeout)
+	defer cancel()
+	result, err := d.sessionTitleExec(ctx, session, slice)
+	if err != nil {
+		d.logf("session title %s: %v", sessionID, err)
+		return
+	}
+	title := sanitizeSessionTitle(result)
+	if title == "" {
+		return
+	}
+
+	// Re-fetch and re-check: the label may have been renamed (by the user or a
+	// concurrent caller) while the LLM run was in flight.
+	session = d.store.Get(sessionID)
+	if session == nil || session.Label != defaultSessionLabel(session.Directory, session.ID) {
+		return
+	}
+	d.store.UpdateSessionLabel(sessionID, title)
+	session.Label = title
+	d.wsHub.Broadcast(&protocol.WebSocketEvent{
+		Event:   protocol.EventSessionStateChanged,
+		Session: d.sessionForBroadcast(session),
+	})
+}
+
+// execSessionTitle dispatches the title generation run per the session's own
+// agent driver. Wired onto d.sessionTitleExec in New(); test daemons leave it
+// nil.
+func (d *Daemon) execSessionTitle(ctx context.Context, session *protocol.Session, slice transcript.ConversationSlice) (string, error) {
+	agent := string(session.Agent)
+	switch agent {
+	case "claude", "codex":
+		return d.execSessionTitleHeadless(ctx, agent, slice)
+	case "copilot":
+		return execSessionTitleCopilot(ctx, buildSessionTitlePrompt(slice), sessionTitleModel(agent))
+	default:
+		return "", fmt.Errorf("unsupported agent for title generation: %s", agent)
+	}
+}
+
+// execSessionTitleHeadless runs the claude/codex title generation through the
+// shared HeadlessTaskProvider seam (see internal/daemon/session_instructions.go
+// for the same pattern).
+func (d *Daemon) execSessionTitleHeadless(ctx context.Context, agent string, slice transcript.ConversationSlice) (string, error) {
+	driver := agentdriver.Get(agent)
+	if driver == nil {
+		return "", fmt.Errorf("%s driver unavailable", agent)
+	}
+	provider, ok := driver.(agentdriver.HeadlessTaskProvider)
+	if !ok {
+		return "", fmt.Errorf("%s driver does not support headless tasks", agent)
+	}
+	executable, err := exec.LookPath(driver.ResolveExecutable(d.store.GetSetting(canonicalExecutableSettingKey(agent))))
+	if err != nil {
+		return "", fmt.Errorf("resolve %s executable: %w", agent, err)
+	}
+	workDir, err := os.MkdirTemp("", "attn-session-title-*")
+	if err != nil {
+		return "", fmt.Errorf("create title scratch dir: %w", err)
+	}
+	defer os.RemoveAll(workDir)
+
+	request := agentdriver.HeadlessTaskRequest{
+		Executable:   executable,
+		Model:        sessionTitleModel(agent),
+		Prompt:       buildSessionTitlePrompt(slice),
+		WorkDir:      workDir,
+		DisableTools: true,
+	}
+	switch agent {
+	case "claude":
+		request.MaxTurns = 2
+		request.MaxBudgetUSD = "0.05"
+		request.OutputSchema = json.RawMessage(sessionTitleOutputSchema)
+	case "codex":
+		request.ReasoningEffort = "low"
+	}
+
+	result, err := provider.RunHeadlessTask(ctx, request)
+	if err != nil {
+		return "", fmt.Errorf("%s title run failed: %w", agent, err)
+	}
+	if agent == "claude" && len(result.StructuredOutput) > 0 {
+		var parsed struct {
+			Title string `json:"title"`
+		}
+		if jsonErr := json.Unmarshal(result.StructuredOutput, &parsed); jsonErr == nil {
+			return parsed.Title, nil
+		}
+	}
+	return result.Text, nil
+}
+
+// execSessionTitleCopilot invokes the copilot CLI directly (Copilot does not
+// implement HeadlessTaskProvider), mirroring the exact command shape of
+// classifier.ClassifyWithCopilot (internal/classifier/classifier.go). Title
+// generation is a distinct concern from stop-time state classification, which
+// internal/classifier owns exclusively (see internal/classifier/CLAUDE.md), so
+// this does not import or call that package.
+func execSessionTitleCopilot(ctx context.Context, prompt, model string) (string, error) {
+	executable := strings.TrimSpace(os.Getenv("ATTN_COPILOT_EXECUTABLE"))
+	if executable == "" {
+		executable = "copilot"
+	}
+	workDir, err := os.MkdirTemp("", "attn-session-title-*")
+	if err != nil {
+		return "", fmt.Errorf("create title scratch dir: %w", err)
+	}
+	defer os.RemoveAll(workDir)
+
+	args := []string{
+		"-p", prompt,
+		"-s",
+		"--model", model,
+		"--no-color",
+		"--no-custom-instructions",
+	}
+	cmd := exec.CommandContext(ctx, executable, args...)
+	cmd.Dir = workDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("copilot title run failed: %w", err)
+	}
+	return string(output), nil
+}
+
+// buildSessionTitlePrompt builds the title-generation prompt shared by every
+// driver.
+func buildSessionTitlePrompt(slice transcript.ConversationSlice) string {
+	return fmt.Sprintf(`You generate short titles for AI-agent terminal sessions. Based on the conversation excerpt below, produce a concise title (3-7 words, at most 48 characters) that captures what the user is working on. Respond with only the title text - no quotes, no trailing punctuation, no explanation.
+
+<conversation>
+%s
+</conversation>`, slice.Render())
+}
+
+// sessionTitleQuoteClosers maps an opening wrapper rune to the closing rune
+// sanitizeSessionTitle strips it against.
+var sessionTitleQuoteClosers = map[rune]rune{
+	'"':  '"',
+	'\'': '\'',
+	'`':  '`',
+	'“':  '”',
+}
+
+// sanitizeSessionTitle turns raw model output into a display-ready title, or
+// "" when no valid title can be extracted.
+func sanitizeSessionTitle(raw string) string {
+	var line string
+	for _, candidate := range strings.Split(raw, "\n") {
+		if trimmed := strings.TrimSpace(candidate); trimmed != "" {
+			line = trimmed
+			break
+		}
+	}
+	if line == "" {
+		return ""
+	}
+
+	if runes := []rune(line); len(runes) >= 2 {
+		if want, ok := sessionTitleQuoteClosers[runes[0]]; ok && runes[len(runes)-1] == want {
+			line = strings.TrimSpace(string(runes[1 : len(runes)-1]))
+		}
+	}
+
+	if lower := strings.ToLower(line); strings.HasPrefix(lower, "title:") {
+		line = strings.TrimSpace(line[len("title:"):])
+	}
+
+	line = strings.Join(strings.Fields(line), " ")
+	line = strings.TrimRight(line, ".,;:! \t")
+
+	if runes := []rune(line); len(runes) > maxSessionTitleRunes {
+		line = strings.TrimRight(string(runes[:maxSessionTitleRunes]), "-_. \t")
+	}
+
+	return line
+}
+
+// defaultSessionLabel mirrors the recovery-path default at daemon.go:1294-1297:
+// filepath.Base(cwd), falling back to sessionID when the basename is "", ".",
+// or the path separator.
+func defaultSessionLabel(cwd, sessionID string) string {
+	label := filepath.Base(cwd)
+	if label == "" || label == "." || label == string(filepath.Separator) {
+		return sessionID
+	}
+	return label
+}
+
+// sessionAutoTitleEnabled reports whether Stop-time auto-titling is on.
+// ATTN_SESSION_AUTO_TITLE of "0"/"false"/"off" (case-insensitive) disables it;
+// anything else, including unset, leaves it enabled.
+func sessionAutoTitleEnabled() bool {
+	switch strings.TrimSpace(strings.ToLower(os.Getenv("ATTN_SESSION_AUTO_TITLE"))) {
+	case "0", "false", "off":
+		return false
+	default:
+		return true
+	}
+}
+
+// sessionTitleModel resolves the per-agent title-generation model, honoring a
+// per-agent env override.
+func sessionTitleModel(agent string) string {
+	switch agent {
+	case "claude":
+		if v := strings.TrimSpace(os.Getenv("ATTN_CLAUDE_TITLE_MODEL")); v != "" {
+			return v
+		}
+		return "haiku"
+	case "codex":
+		if v := strings.TrimSpace(os.Getenv("ATTN_CODEX_TITLE_MODEL")); v != "" {
+			return v
+		}
+		return "gpt-5.6-luna"
+	case "copilot":
+		if v := strings.TrimSpace(os.Getenv("ATTN_COPILOT_TITLE_MODEL")); v != "" {
+			return v
+		}
+		return "claude-haiku-4.5"
+	default:
+		return ""
+	}
+}

--- a/internal/daemon/session_title_test.go
+++ b/internal/daemon/session_title_test.go
@@ -1,0 +1,331 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/transcript"
+)
+
+func TestSanitizeSessionTitle(t *testing.T) {
+	longMultibyte := strings.Repeat("é", 60) // multibyte rune: a byte-based cut would corrupt/mis-truncate this
+	wantLongMultibyte := strings.Repeat("é", maxSessionTitleRunes)
+
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"plain", "Fix login flow", "Fix login flow"},
+		{"double_quotes", `"Fix login flow"`, "Fix login flow"},
+		{"backticks", "`Fix login flow`", "Fix login flow"},
+		{"curly_quotes", "“Fix login flow”", "Fix login flow"},
+		{"title_prefix", "Title: Fix login flow", "Fix login flow"},
+		{"title_prefix_lower", "title: fix login flow", "fix login flow"},
+		{"multiline_first_nonempty", "\n  \nFix login flow\nsecond line", "Fix login flow"},
+		{"internal_whitespace_collapsed", "Fix   login\tflow", "Fix login flow"},
+		{"trailing_punctuation", "Fix login flow.", "Fix login flow"},
+		{"trailing_punctuation_mixed", "Fix login flow!;", "Fix login flow"},
+		{"over_limit_multibyte", longMultibyte, wantLongMultibyte},
+		{"empty", "", ""},
+		{"whitespace_only", "   \n\t  ", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeSessionTitle(tc.raw)
+			if got != tc.want {
+				t.Errorf("sanitizeSessionTitle(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaultSessionLabel(t *testing.T) {
+	cases := []struct {
+		name      string
+		cwd       string
+		sessionID string
+		want      string
+	}{
+		{"normal_path", "/Users/victor/projects/attn", "sess-1", "attn"},
+		{"empty_cwd", "", "sess-1", "sess-1"},
+		{"dot_cwd", ".", "sess-1", "sess-1"},
+		{"root_cwd", string(filepath.Separator), "sess-1", "sess-1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := defaultSessionLabel(tc.cwd, tc.sessionID)
+			if got != tc.want {
+				t.Errorf("defaultSessionLabel(%q, %q) = %q, want %q", tc.cwd, tc.sessionID, got, tc.want)
+			}
+		})
+	}
+}
+
+// writeSessionTitleTranscript writes a minimal Claude-format transcript JSONL
+// with a genuine human turn, so slice.Brief is non-empty.
+func writeSessionTitleTranscript(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	lines := []string{
+		`{"type":"session_meta","cwd":"/tmp"}`,
+		`{"type":"user","origin":{"kind":"human"},"message":{"content":"fix the login flow"}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"looking into it"}]}}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+// writeSessionTitleTranscriptNoUserContent writes a transcript with no
+// genuine human turn (only a tool-result-shaped user line), so slice.Brief
+// stays empty.
+func writeSessionTitleTranscriptNoUserContent(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	lines := []string{
+		`{"type":"session_meta","cwd":"/tmp"}`,
+		`{"type":"user","message":{"content":[{"type":"tool_result","text":"some tool output"}]}}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+// seedSessionTitleSession adds a session whose label is its directory's
+// default label (filepath.Base) unless label is explicitly given.
+func seedSessionTitleSession(t *testing.T, d *Daemon, id, directory, label string) *protocol.Session {
+	t.Helper()
+	if label == "" {
+		label = defaultSessionLabel(directory, id)
+	}
+	session := &protocol.Session{
+		ID:        id,
+		Label:     label,
+		Agent:     protocol.SessionAgentClaude,
+		Directory: directory,
+		State:     protocol.SessionStateIdle,
+	}
+	d.store.Add(session)
+	return session
+}
+
+func TestMaybeGenerateSessionTitle_HappyPath(t *testing.T) {
+	d := newDaemonForTest(t)
+	directory := t.TempDir()
+	seedSessionTitleSession(t, d, "sess-1", directory, "")
+	transcriptPath := writeSessionTitleTranscript(t)
+
+	calls := 0
+	d.sessionTitleExec = func(ctx context.Context, session *protocol.Session, slice transcript.ConversationSlice) (string, error) {
+		calls++
+		return "Fix login flow", nil
+	}
+
+	d.maybeGenerateSessionTitle("sess-1", transcriptPath)
+
+	if calls != 1 {
+		t.Fatalf("exec calls = %d, want 1", calls)
+	}
+	got := d.store.Get("sess-1")
+	if got == nil || got.Label != "Fix login flow" {
+		t.Fatalf("session label = %+v, want %q", got, "Fix login flow")
+	}
+}
+
+func TestMaybeGenerateSessionTitle_CustomLabelSkipped(t *testing.T) {
+	d := newDaemonForTest(t)
+	directory := t.TempDir()
+	seedSessionTitleSession(t, d, "sess-1", directory, "user renamed me")
+	transcriptPath := writeSessionTitleTranscript(t)
+
+	calls := 0
+	d.sessionTitleExec = func(ctx context.Context, session *protocol.Session, slice transcript.ConversationSlice) (string, error) {
+		calls++
+		return "Fix login flow", nil
+	}
+
+	d.maybeGenerateSessionTitle("sess-1", transcriptPath)
+
+	if calls != 0 {
+		t.Fatalf("exec calls = %d, want 0 (custom label must never be clobbered)", calls)
+	}
+	got := d.store.Get("sess-1")
+	if got == nil || got.Label != "user renamed me" {
+		t.Fatalf("session label = %+v, want unchanged", got)
+	}
+}
+
+func TestMaybeGenerateSessionTitle_ExecError(t *testing.T) {
+	d := newDaemonForTest(t)
+	directory := t.TempDir()
+	seedSessionTitleSession(t, d, "sess-1", directory, "")
+	transcriptPath := writeSessionTitleTranscript(t)
+	wantLabel := defaultSessionLabel(directory, "sess-1")
+
+	d.sessionTitleExec = func(ctx context.Context, session *protocol.Session, slice transcript.ConversationSlice) (string, error) {
+		return "", errors.New("boom")
+	}
+
+	d.maybeGenerateSessionTitle("sess-1", transcriptPath)
+
+	got := d.store.Get("sess-1")
+	if got == nil || got.Label != wantLabel {
+		t.Fatalf("session label = %+v, want unchanged %q", got, wantLabel)
+	}
+}
+
+func TestMaybeGenerateSessionTitle_UnusableOutput(t *testing.T) {
+	d := newDaemonForTest(t)
+	directory := t.TempDir()
+	seedSessionTitleSession(t, d, "sess-1", directory, "")
+	transcriptPath := writeSessionTitleTranscript(t)
+	wantLabel := defaultSessionLabel(directory, "sess-1")
+
+	d.sessionTitleExec = func(ctx context.Context, session *protocol.Session, slice transcript.ConversationSlice) (string, error) {
+		return "   \n\t  ", nil
+	}
+
+	d.maybeGenerateSessionTitle("sess-1", transcriptPath)
+
+	got := d.store.Get("sess-1")
+	if got == nil || got.Label != wantLabel {
+		t.Fatalf("session label = %+v, want unchanged %q", got, wantLabel)
+	}
+}
+
+func TestMaybeGenerateSessionTitle_OneAttemptPerSession(t *testing.T) {
+	directory := t.TempDir()
+	transcriptPath := writeSessionTitleTranscript(t)
+
+	t.Run("after_success", func(t *testing.T) {
+		d := newDaemonForTest(t)
+		seedSessionTitleSession(t, d, "sess-1", directory, "")
+		calls := 0
+		d.sessionTitleExec = func(ctx context.Context, session *protocol.Session, slice transcript.ConversationSlice) (string, error) {
+			calls++
+			return "Fix login flow", nil
+		}
+		d.maybeGenerateSessionTitle("sess-1", transcriptPath)
+		if calls != 1 {
+			t.Fatalf("first call: exec calls = %d, want 1", calls)
+		}
+		d.maybeGenerateSessionTitle("sess-1", transcriptPath)
+		if calls != 1 {
+			t.Fatalf("second call: exec calls = %d, want still 1 (label no longer default)", calls)
+		}
+	})
+
+	t.Run("after_failure", func(t *testing.T) {
+		d := newDaemonForTest(t)
+		seedSessionTitleSession(t, d, "sess-1", directory, "")
+		calls := 0
+		d.sessionTitleExec = func(ctx context.Context, session *protocol.Session, slice transcript.ConversationSlice) (string, error) {
+			calls++
+			return "", errors.New("boom")
+		}
+		d.maybeGenerateSessionTitle("sess-1", transcriptPath)
+		if calls != 1 {
+			t.Fatalf("first call: exec calls = %d, want 1", calls)
+		}
+		d.maybeGenerateSessionTitle("sess-1", transcriptPath)
+		if calls != 1 {
+			t.Fatalf("second call after failure: exec calls = %d, want still 1 (attempted-guard)", calls)
+		}
+	})
+}
+
+func TestMaybeGenerateSessionTitle_RenameRace(t *testing.T) {
+	d := newDaemonForTest(t)
+	directory := t.TempDir()
+	seedSessionTitleSession(t, d, "sess-1", directory, "")
+	transcriptPath := writeSessionTitleTranscript(t)
+
+	d.sessionTitleExec = func(ctx context.Context, session *protocol.Session, slice transcript.ConversationSlice) (string, error) {
+		// Simulate a user rename landing while the LLM call is in flight.
+		d.store.UpdateSessionLabel("sess-1", "user choice")
+		return "llm title", nil
+	}
+
+	d.maybeGenerateSessionTitle("sess-1", transcriptPath)
+
+	got := d.store.Get("sess-1")
+	if got == nil || got.Label != "user choice" {
+		t.Fatalf("session label = %+v, want %q (must not clobber the in-flight rename)", got, "user choice")
+	}
+}
+
+func TestMaybeGenerateSessionTitle_EmptyTranscriptNotMarkedAttempted(t *testing.T) {
+	d := newDaemonForTest(t)
+	directory := t.TempDir()
+	seedSessionTitleSession(t, d, "sess-1", directory, "")
+	emptyTranscriptPath := writeSessionTitleTranscriptNoUserContent(t)
+	goodTranscriptPath := writeSessionTitleTranscript(t)
+
+	calls := 0
+	d.sessionTitleExec = func(ctx context.Context, session *protocol.Session, slice transcript.ConversationSlice) (string, error) {
+		calls++
+		return "Fix login flow", nil
+	}
+
+	d.maybeGenerateSessionTitle("sess-1", emptyTranscriptPath)
+	if calls != 0 {
+		t.Fatalf("exec calls after empty transcript = %d, want 0", calls)
+	}
+
+	d.maybeGenerateSessionTitle("sess-1", goodTranscriptPath)
+	if calls != 1 {
+		t.Fatalf("exec calls after good transcript = %d, want 1 (empty transcript must not have marked attempted)", calls)
+	}
+	got := d.store.Get("sess-1")
+	if got == nil || got.Label != "Fix login flow" {
+		t.Fatalf("session label = %+v, want %q", got, "Fix login flow")
+	}
+}
+
+// TestMaybeGenerateSessionTitle_ConcurrentAttemptRunsExecOnce simulates two
+// Stop events for the same session interleaving between the early
+// attempted-check and the mark: exec, on its first invocation, synchronously
+// re-enters maybeGenerateSessionTitle for the same session — standing in for a
+// second concurrent Stop that raced past the early attempted-check while the
+// first call was still extracting the transcript slice, before either had
+// marked the session attempted. At that point the session's label is still
+// default (the outer call hasn't written the title yet), so only the
+// attempted-guard — not the label check — can stop the inner call. With the
+// fix, the inner call's re-check under the lock finds the session already
+// marked and returns without a second exec; if the guard mutex were instead
+// held across exec, this would deadlock.
+func TestMaybeGenerateSessionTitle_ConcurrentAttemptRunsExecOnce(t *testing.T) {
+	d := newDaemonForTest(t)
+	directory := t.TempDir()
+	seedSessionTitleSession(t, d, "sess-1", directory, "")
+	transcriptPath := writeSessionTitleTranscript(t)
+
+	calls := 0
+	d.sessionTitleExec = func(ctx context.Context, session *protocol.Session, slice transcript.ConversationSlice) (string, error) {
+		calls++
+		if calls == 1 {
+			d.maybeGenerateSessionTitle("sess-1", transcriptPath)
+		}
+		return "Fix login flow", nil
+	}
+
+	d.maybeGenerateSessionTitle("sess-1", transcriptPath)
+
+	if calls != 1 {
+		t.Fatalf("exec calls = %d, want 1 (concurrent caller must not double-run the paid LLM call)", calls)
+	}
+	got := d.store.Get("sess-1")
+	if got == nil || got.Label != "Fix login flow" {
+		t.Fatalf("session label = %+v, want %q", got, "Fix login flow")
+	}
+}


### PR DESCRIPTION
## What

Sessions now name themselves. When a session finishes its first exchange (Stop hook) and its label still equals the derived default (cwd basename), the daemon generates a short descriptive title from the conversation transcript and applies it through the existing label + `session_state_changed` broadcast path.

## How

- **Trigger**: `handleStop` kicks off `maybeGenerateSessionTitle` in a goroutine alongside state classification. The transcript is guaranteed on disk at Stop time, and having the first assistant turn available improves title quality over titling at prompt-submit time.
- **Model**: the session's own agent with a cheap model — claude → `haiku`, codex → `gpt-5.6-luna` (low reasoning effort), copilot → `claude-haiku-4.5` via direct CLI invocation (copilot has no headless-task driver support; the invocation mirrors `classifier.ClassifyWithCopilot`). Overridable via `ATTN_CLAUDE_TITLE_MODEL` / `ATTN_CODEX_TITLE_MODEL` / `ATTN_COPILOT_TITLE_MODEL`; `ATTN_SESSION_AUTO_TITLE=0` disables the feature.
- **Input**: `transcript.ExtractConversationSlice` (the same agent-agnostic slice the ticket-reconcile classifier uses), rendered into a constrained prompt (3–7 words, ≤48 chars). Claude runs with a structured-output schema, tools disabled, 2-turn / $0.05 budget caps.
- **Guards**:
  - Only fires when the label still equals the default — delegations, ticket sessions, and manually renamed sessions are naturally skipped. No new column or protocol change.
  - Manual renames always win: the guard is re-checked against a fresh store read right before the write, so a rename landing mid-generation discards the generated title.
  - One LLM attempt per session per daemon lifetime, marked under a mutex with a re-check at mark time so concurrent Stops can't double-bill. Empty/unusable transcripts skip *without* consuming the attempt (early Stops retry on later turns).
  - Titles are sanitized (quotes/prefixes stripped, whitespace collapsed, rune-clamped at 48) and empty results are discarded.

## Testing

- Unit tests cover the happy path, sanitizer edge cases (including multibyte rune clamping), the custom-label skip, exec failure, unusable output, single-attempt semantics after both success and failure, the mid-flight rename race, empty-transcript retry, and concurrent-Stop single-execution.
- Live-verified on a dev-profile install: a delegated haiku session was auto-titled "Create sea haiku file", visible in the running app.
- Corpus check against 10 real historical transcripts (claude sessions of varying length/shape): 10/10 produced accurate human-quality titles, 12–17s latency, no schema or sanitizer failures.

https://claude.ai/code/session_014jtryTVEwLPhydHqx2qtFU