### PR TITLE
fix(queue): hand over the next agent however a turn closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   instead of what the agent actually said. Transcripts now resolve by the codex
   session's own id, the classifier no longer saves a log at all, and headless
   codex runs are excluded from transcript discovery.
+- **A turn that closes on its own hands you the next agent.** Auto-settle closes
+  a turn on a timer, and settling from a sidebar row goes straight to the
+  daemon — neither moved you on, so the countdown finishing on the agent you were
+  watching dropped its row from the queue and left you sitting on an agent that
+  was done with you. Closing a turn now hands over the next agent that owes one
+  (or takes you home when none does) however that turn closed, not just when you
+  pressed ⌘⇧E. A turn closing on an agent you are not looking at still leaves
+  your selection alone, and pinning a workspace still keeps you where you are.
 - **A workspace that holds only a tile can be closed again.** Closing the last
   notebook, markdown, or browser tile in a workspace with no agents left the
   workspace in the sidebar — and every later click on its × did nothing, so the

--- a/app/scripts/real-app-harness/scenario-agent-queue.mjs
+++ b/app/scripts/real-app-harness/scenario-agent-queue.mjs
@@ -30,9 +30,11 @@
  *   8. the chief of staff occupies its own slot and never the band,
  *   9. turning the arrangement off and back on mid-session restores the whole
  *      workspace tree, then returns the same queue with the same agent selected,
- *  10. settling by keyboard hands over the next agent that still owes a turn,
- *      and leaves selection alone when nothing does,
- *  11. a settle survives a daemon restart.
+ *  10. an auto-settle completing on the agent the user is watching hands over
+ *      the next agent that owes a turn, the same as settling by hand does,
+ *  11. settling by keyboard hands over the next agent that still owes a turn,
+ *      and lands on home when nothing does,
+ *  12. a settle survives a daemon restart.
  *
  * Prereqs: `claude` on PATH; a non-production profile install with the
  * automation layer; a built `./attn` (or ATTN_HARNESS_BIN) for the restart step.
@@ -404,6 +406,98 @@ async function main() {
       );
     });
 
+    await runner.step('auto_settle_hands_over_the_next_agent', async () => {
+      // A turn closing hands over the next agent that owes one whoever closed
+      // it — a countdown completing is not a lesser settle than the keystroke.
+      // This is the only path where nobody pressed anything, so it is also the
+      // only one where the app has to react to the settle rather than perform
+      // it, and the only one no unit test can stand in for: the timer lives in
+      // the daemon and the handover is in the app.
+      //
+      // Both windows are set to their floors to keep the step short. They are
+      // still real: the agent has to hold `working` through both.
+      await client.request('set_setting', { key: 'auto_settle_arm_seconds', value: '5' });
+      await client.request('set_setting', { key: 'auto_settle_countdown_seconds', value: '3' });
+      await client.request('set_setting', { key: 'auto_settle_enabled', value: 'true' });
+      try {
+        // Polled rather than read once: the settings above each come back as a
+        // broadcast, and a single read can land between the re-renders they
+        // cause. What the band settles on is the precondition, not whatever it
+        // happened to hold at the first opportunity.
+        const owed = await pollFor(async () => {
+          const ids = turnIds(await queueState(client));
+          return ids.length >= 2 ? ids : null;
+        }, 'two agents owing turns, so there is somewhere to hand over to', 30_000);
+        // The bottom row, so the handover wraps to the top — and so the queue
+        // this step hands to the ones below it comes back in the same order it
+        // was given, once the settled agent is driven back to a turn.
+        const watchedId = owed[owed.length - 1];
+        const nextId = owed[0];
+        const watched = [alpha, beta].find((agent) => agent.sessionId === watchedId);
+        runner.assert(Boolean(watched), `the bottom row is one of the two agents: ${watchedId}`);
+        runner.log('auto-settle will run on the bottom of the queue', { watched: watchedId, next: nextId });
+        await client.request('select_session', { sessionId: watched.sessionId });
+
+        // Resolved now rather than taken from the agent's birth record: a pane
+        // can be replaced under a session, and writing to an id it no longer has
+        // goes nowhere silently.
+        const pane = await waitForFirstWorkspacePane(client, watched.sessionId, `current pane for ${watched.sessionId}`, 20_000);
+
+        // Steering is what arms it. The prompt asks for enough output to outlast
+        // both windows — anything shorter finishes first, and leaving `working`
+        // cancels the settle, so a one-word reply would test nothing.
+        await submitPrompt(
+          client,
+          watched.sessionId,
+          pane.paneId,
+          'Count from 1 to 100, one number per line, nothing else. Do not use any tools.',
+        );
+        // Both preconditions are polled separately from the handover so a run
+        // where the steering never landed, or where the agent finished before
+        // the windows elapsed, reads as the setup failing rather than as the
+        // handover regressing.
+        await pollFor(
+          () => (observer.getSession(watched.sessionId)?.state === 'working' ? true : null),
+          'the steered agent to go back to work',
+          60_000,
+        );
+        await pollFor(
+          () => (observer.getSession(watched.sessionId)?.auto_settle_fires_at ? true : null),
+          'the auto-settle countdown to start on the agent being watched',
+          60_000,
+        );
+
+        const handed = await pollFor(async () => {
+          const state = await client.request('get_state');
+          return state.activeSessionId === nextId ? state : null;
+        }, 'the auto-settle to hand over the next agent that owes a turn', 30_000);
+        runner.assert(
+          handed.activeSessionId === nextId,
+          `auto-settle selected the next owed turn: ${handed.activeSessionId}`,
+        );
+        const after = await waitForTurns(client, [nextId], 'the auto-settled agent out of the band');
+        runner.assert(
+          settledIds(after).includes(watched.sessionId),
+          `auto-settle moved it to Settled like any other settle: ${JSON.stringify(settledIds(after))}`,
+        );
+
+        // Put the turn back so the steps below see the queue they were written
+        // against. Turned off first so the restoring run cannot arm a second
+        // countdown behind this step's back.
+        await client.request('set_setting', { key: 'auto_settle_enabled', value: 'false' });
+        await driveToOwedTurn(
+          client,
+          observer,
+          { ...watched, paneId: pane.paneId },
+          'QUEUE_AFTER_AUTO_SETTLE',
+          'the auto-settled agent to want the user again',
+        );
+        await waitForTurns(client, [nextId, watched.sessionId], 'the queue back in the order it was given', 60_000);
+      } finally {
+        await client.request('set_setting', { key: 'auto_settle_enabled', value: 'false' }).catch(() => {});
+      }
+    });
+
     await runner.step('a_shell_pane_never_queues', async () => {
       // A shell pane is a real store session, registered idle at birth and left
       // there. Now that idle opens a turn, only the shell exclusion keeps every
@@ -572,19 +666,23 @@ async function main() {
       );
     });
 
-    await runner.step('settling_the_last_turn_leaves_selection_alone', async () => {
-      // With nothing left to hand over, the keystroke settles and stops there —
-      // jumping somewhere arbitrary would take the user away from the agent they
-      // were just looking at.
+    await runner.step('settling_the_last_turn_lands_on_home', async () => {
+      // With nothing left to hand over, home is where the queue ends: staying
+      // would leave the user on the one agent guaranteed to be finished with
+      // them, and home is the surface that says so.
       await client.request('select_session', { sessionId: alpha.sessionId });
       await driver.activateApp();
       await driver.clickWindow(0.5, 0.5);
       await driver.pressKey('e', { command: true, shift: true });
-      await waitForTurns(client, [], 'the last turn settled by shortcut');
-      const state = await client.request('get_state');
+      const emptied = await waitForTurns(client, [], 'the last turn settled by shortcut');
+      runner.assert(emptied.empty, 'the band says so itself once nothing is owed');
+      const state = await pollFor(async () => {
+        const current = await client.request('get_state');
+        return current.activeSessionId === null ? current : null;
+      }, 'settling the last turn to land on home', 15_000);
       runner.assert(
-        state.activeSessionId === alpha.sessionId,
-        `selection stayed on the agent that was just settled: ${state.activeSessionId}`,
+        state.activeSessionId === null,
+        `no agent is selected once the queue is empty: ${state.activeSessionId}`,
       );
     });
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -107,9 +107,9 @@ import { normalizeInstallChannel, shouldCheckForReleaseUpdates } from './utils/i
 import { boundTicketForSession } from './utils/tickets';
 import { buildWorkspaceViewModels, filterSessionsRepresentedInWorkspaceLayouts } from './utils/workspaceViewModels';
 import {
+  advanceAfterTurnClosed,
   buildQueueBands,
   isQueueModeEnabled,
-  nextTurnAfterSettle,
   oldestWantedTurn,
   QUEUE_MODE_SETTING,
   isAutoSettleEnabled,
@@ -2874,33 +2874,54 @@ sendFetchPRDetails,
   const { needsAttention: prsNeedingAttention } = usePRsNeedingAttention(prs);
   const attentionCount = waitingLocalSessions.length + prsNeedingAttention.length;
 
-  // Settle the selected session's turn and move on to the next agent that still
-  // owes one, so closing a turn and picking up the next is one keystroke.
-  // Undefined while the queue arrangement is off so the shortcut is not
-  // registered at all.
+  // Settle the selected session's turn. Undefined while the queue arrangement is
+  // off so the shortcut is not registered at all.
   //
-  // The next agent is taken from the queue as it stands before the settle: the
-  // band only drops the settled row once the daemon broadcast lands, so reading
-  // it afterwards would either find the row still there or race the refresh.
-  //
-  // With nothing left to go to, the queue is empty and home is where that ends:
-  // staying on the agent just settled leaves you on the one screen guaranteed to
-  // be finished with.
+  // Only the settle. Moving on to the next agent is not this handler's job —
+  // see the effect below, which does it for every way a turn closes.
   const handleSettleActiveTurn = useMemo(
     () => (queueModeEnabled
       ? () => {
         if (!activeSessionId) return;
-        const next = nextTurnAfterSettle(queueBands?.turns ?? [], activeSessionId);
         sendSettleTurn(activeSessionId);
-        if (next) {
-          handleSelectSession(next.session.id);
-        } else {
-          goToDashboard();
-        }
       }
       : undefined),
-    [queueModeEnabled, activeSessionId, queueBands, sendSettleTurn, handleSelectSession, goToDashboard],
+    [queueModeEnabled, activeSessionId, sendSettleTurn],
   );
+
+  // Closing a turn hands over the next agent that owes one, or home when none
+  // does. This is the only place that happens, for every way a turn can close:
+  // the shortcut above, the sidebar row's button, an auto-settle countdown
+  // completing on a daemon timer, another client settling the same turn. They
+  // all arrive here as the same thing — the band the user was in changed — which
+  // is why the handover cannot drift between them. It did: for as long as the
+  // jump lived inside the shortcut handler, only the shortcut moved you.
+  //
+  // Reacting rather than predicting also means a settle the daemon rejects moves
+  // nobody, and costs only the round trip the settle already pays for.
+  //
+  // Scoped to the agent the user is actually looking at: auto-settle fires on
+  // unwatched sessions too, and a timer running somewhere off-screen must never
+  // move the selection. Grid is excluded for the same reason — every tile is
+  // being watched there, and an empty queue would drop the user out of the view
+  // entirely.
+  //
+  // advanceAfterTurnClosed owns which band move counts and where it leads; the
+  // two snapshots it compares are what makes the close observable at all, since
+  // the settled row is gone from the band by the time this runs.
+  const previousQueueTurnsRef = useRef<NonNullable<typeof queueBands>['turns']>([]);
+  useEffect(() => {
+    const previousTurns = previousQueueTurnsRef.current;
+    previousQueueTurnsRef.current = queueBands?.turns ?? [];
+    if (!queueModeEnabled || view !== 'session') return;
+    const advance = advanceAfterTurnClosed(previousTurns, queueBands, activeSessionId);
+    if (!advance) return;
+    if (advance.to === 'session') {
+      handleSelectSession(advance.row.session.id);
+    } else {
+      goToDashboard();
+    }
+  }, [queueBands, queueModeEnabled, view, activeSessionId, handleSelectSession, goToDashboard]);
 
   // Keep the selected session's turn, cancelling the auto-settle countdown that
   // is about to close it. Undefined while the queue arrangement is off, so — like

--- a/app/src/utils/queueBands.test.ts
+++ b/app/src/utils/queueBands.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import {
   advanceAfterTurnClosed,
   buildQueueBands,
-  nextTurnAfterSettle,
   oldestWantedTurn,
   type QueueBandSession,
 } from './queueBands';
@@ -200,47 +199,6 @@ describe('oldestWantedTurn', () => {
   });
 });
 
-describe('nextTurnAfterSettle', () => {
-  function turnsFor(ids: string[]) {
-    return buildQueueBands(views(ids.map((id, index) => ({
-      id,
-      label: id,
-      workspaceId: 'ws-a',
-      turnOwed: true,
-      turnOpenedAt: `2026-07-26T0${index}:00:00Z`,
-    })))).turns;
-  }
-
-  it('lands on the row after the one settled, in queue order', () => {
-    const turns = turnsFor(['oldest', 'middle', 'newest']);
-
-    expect(nextTurnAfterSettle(turns, 'oldest')?.session.id).toBe('middle');
-    expect(nextTurnAfterSettle(turns, 'middle')?.session.id).toBe('newest');
-  });
-
-  it('wraps to the top when the last row is settled', () => {
-    // Queue order is not attention order: the rows above are still owed, so the
-    // bottom row moves on to the oldest rather than falling off the end.
-    const turns = turnsFor(['oldest', 'middle', 'newest']);
-
-    expect(nextTurnAfterSettle(turns, 'newest')?.session.id).toBe('oldest');
-  });
-
-  it('never lands on the row just settled', () => {
-    // The band is read before the settle, so the settled row is still in it.
-    expect(nextTurnAfterSettle(turnsFor(['only']), 'only')).toBeNull();
-    expect(nextTurnAfterSettle([], 'anything')).toBeNull();
-    expect(nextTurnAfterSettle(turnsFor(['only']), null)?.session.id).toBe('only');
-  });
-
-  it('starts at the top for a session the band does not hold', () => {
-    // Already settled, pinned, muted, or the chief: no position to move on from.
-    const turns = turnsFor(['oldest', 'newest']);
-
-    expect(nextTurnAfterSettle(turns, 'elsewhere')?.session.id).toBe('oldest');
-  });
-});
-
 describe('advanceAfterTurnClosed', () => {
   function owed(id: string, hour: number, workspaceId = 'ws-a'): QueueBandSession {
     return { id, label: id, workspaceId, turnOwed: true, turnOpenedAt: `2026-07-26T0${hour}:00:00Z` };
@@ -268,6 +226,66 @@ describe('advanceAfterTurnClosed', () => {
     const advance = advanceAfterTurnClosed(before.turns, after, 'watched');
 
     expect(advance?.to === 'session' && advance.row.session.id).toBe('newest');
+  });
+
+  it('wraps to the top when the bottom row is the one that closed', () => {
+    // Queue order is not attention order: the rows above are still owed, so the
+    // bottom row moves on to the oldest rather than falling off the end.
+    const queue = [owed('oldest', 0), owed('middle', 1), owed('watched', 2)];
+    const before = buildQueueBands(views(queue));
+    const after = buildQueueBands(views([queue[0], queue[1], { ...queue[2], turnOwed: false }]));
+
+    const advance = advanceAfterTurnClosed(before.turns, after, 'watched');
+
+    expect(advance?.to === 'session' && advance.row.session.id).toBe('oldest');
+  });
+
+  it('skips a successor that settled in the same broadcast', () => {
+    // One update can close several turns — an auto-settle countdown and a settle
+    // from another client landing together. The successor was owed in the old
+    // snapshot and is not owed in this one, so landing on it would hand the user
+    // a second agent that is already finished with them.
+    const queue = [owed('watched', 0), owed('alsoSettled', 1), owed('after', 2)];
+    const before = buildQueueBands(views(queue));
+    const after = buildQueueBands(views([
+      { ...queue[0], turnOwed: false },
+      { ...queue[1], turnOwed: false },
+      queue[2],
+    ]));
+
+    const advance = advanceAfterTurnClosed(before.turns, after, 'watched');
+
+    expect(advance?.to === 'session' && advance.row.session.id).toBe('after');
+  });
+
+  it('wraps past a coalesced settle rather than falling through to home', () => {
+    // The only row still owed sits above the one that closed, and the row below
+    // it went with it. Eligibility is read from the new band, so the wrap has to
+    // keep going rather than stop at the first old-snapshot successor.
+    const queue = [owed('stillOwed', 0), owed('watched', 1), owed('alsoSettled', 2)];
+    const before = buildQueueBands(views(queue));
+    const after = buildQueueBands(views([
+      queue[0],
+      { ...queue[1], turnOwed: false },
+      { ...queue[2], turnOwed: false },
+    ]));
+
+    const advance = advanceAfterTurnClosed(before.turns, after, 'watched');
+
+    expect(advance?.to === 'session' && advance.row.session.id).toBe('stillOwed');
+  });
+
+  it('lands on a turn that opened in the same broadcast that closed this one', () => {
+    // The arrival has no position in the old snapshot, so the scan cannot find
+    // it. Home is reached from the current band being empty, never from the old
+    // one running out — otherwise a queue that is not empty sends the user home.
+    const watched = owed('watched', 0);
+    const before = buildQueueBands(views([watched]));
+    const after = buildQueueBands(views([{ ...watched, turnOwed: false }, owed('arrival', 1)]));
+
+    const advance = advanceAfterTurnClosed(before.turns, after, 'watched');
+
+    expect(advance?.to === 'session' && advance.row.session.id).toBe('arrival');
   });
 
   it('goes home when the closed turn was the last one owed', () => {

--- a/app/src/utils/queueBands.test.ts
+++ b/app/src/utils/queueBands.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { buildQueueBands, nextTurnAfterSettle, oldestWantedTurn, type QueueBandSession } from './queueBands';
+import {
+  advanceAfterTurnClosed,
+  buildQueueBands,
+  nextTurnAfterSettle,
+  oldestWantedTurn,
+  type QueueBandSession,
+} from './queueBands';
 import { buildWorkspaceViewModels } from './workspaceViewModels';
 
 const workspaces = [
@@ -232,5 +238,94 @@ describe('nextTurnAfterSettle', () => {
     const turns = turnsFor(['oldest', 'newest']);
 
     expect(nextTurnAfterSettle(turns, 'elsewhere')?.session.id).toBe('oldest');
+  });
+});
+
+describe('advanceAfterTurnClosed', () => {
+  function owed(id: string, hour: number, workspaceId = 'ws-a'): QueueBandSession {
+    return { id, label: id, workspaceId, turnOwed: true, turnOpenedAt: `2026-07-26T0${hour}:00:00Z` };
+  }
+
+  it('moves on to the next turn in queue order when the watched turn closes', () => {
+    const queue = [owed('watched', 0), owed('next', 1), owed('after', 2)];
+    const before = buildQueueBands(views(queue));
+    const after = buildQueueBands(views([{ ...queue[0], turnOwed: false }, queue[1], queue[2]]));
+
+    const advance = advanceAfterTurnClosed(before.turns, after, 'watched');
+
+    expect(advance).toEqual({ to: 'session', row: expect.objectContaining({ workspaceTitle: 'A' }) });
+    expect(advance?.to === 'session' && advance.row.session.id).toBe('next');
+  });
+
+  it('reads the position from the earlier snapshot, where the closed row still is', () => {
+    // The row is already out of the turns band by the time this runs, so a
+    // decision made from the new bands alone would have no position to continue
+    // from and would restart at the top of the queue.
+    const queue = [owed('oldest', 0), owed('watched', 1), owed('newest', 2)];
+    const before = buildQueueBands(views(queue));
+    const after = buildQueueBands(views([queue[0], { ...queue[1], turnOwed: false }, queue[2]]));
+
+    const advance = advanceAfterTurnClosed(before.turns, after, 'watched');
+
+    expect(advance?.to === 'session' && advance.row.session.id).toBe('newest');
+  });
+
+  it('goes home when the closed turn was the last one owed', () => {
+    // Staying would leave the user on the one agent guaranteed to be finished
+    // with them.
+    const only = owed('watched', 0);
+    const before = buildQueueBands(views([only]));
+    const after = buildQueueBands(views([{ ...only, turnOwed: false }]));
+
+    expect(advanceAfterTurnClosed(before.turns, after, 'watched')).toEqual({ to: 'dashboard' });
+  });
+
+  it('stays put while the turn is still owed', () => {
+    const queue = [owed('watched', 0), owed('next', 1)];
+    const bands = buildQueueBands(views(queue));
+
+    expect(advanceAfterTurnClosed(bands.turns, bands, 'watched')).toBeNull();
+  });
+
+  it('stays put when the watched agent never owed the turn that closed', () => {
+    // Someone else's turn closing is not a reason to move the user.
+    const queue = [owed('elsewhere', 0)];
+    const before = buildQueueBands(views(queue));
+    const after = buildQueueBands(views([{ ...queue[0], turnOwed: false }, { id: 'watched', label: 'watched', workspaceId: 'ws-a' }]));
+
+    expect(advanceAfterTurnClosed(before.turns, after, 'watched')).toBeNull();
+  });
+
+  it('stays put when the row left the queue by being pinned rather than settled', () => {
+    // Pinning clears turn_owed too, but it means "keep this in view" — being
+    // carried off to another agent is the opposite of what was asked for. The
+    // row lands in no band at all, which is what tells the two apart.
+    const watched = owed('watched', 0);
+    const before = buildQueueBands(views([watched, owed('next', 1, 'ws-b')]));
+    const after = buildQueueBands(buildWorkspaceViewModels(
+      [{ id: 'ws-a', title: 'A', directory: '/repo/a', rank: 'a', pinned: true }, workspaces[1]],
+      [{ ...watched, turnOwed: false }, owed('next', 1, 'ws-b')],
+    ));
+
+    expect(after.turns.map((row) => row.session.id)).toEqual(['next']);
+    expect(after.settled).toEqual([]);
+    expect(advanceAfterTurnClosed(before.turns, after, 'watched')).toBeNull();
+  });
+
+  it('stays put when the watched agent is gone from the bands entirely', () => {
+    // A closed session, or a muted workspace: nothing settled, so nothing to
+    // move on from.
+    const watched = owed('watched', 0);
+    const before = buildQueueBands(views([watched, owed('next', 1)]));
+    const after = buildQueueBands(views([owed('next', 1)]));
+
+    expect(advanceAfterTurnClosed(before.turns, after, 'watched')).toBeNull();
+  });
+
+  it('stays put with no agent selected, or before any bands exist', () => {
+    const bands = buildQueueBands(views([owed('a', 0)]));
+
+    expect(advanceAfterTurnClosed(bands.turns, bands, null)).toBeNull();
+    expect(advanceAfterTurnClosed(bands.turns, null, 'a')).toBeNull();
   });
 });

--- a/app/src/utils/queueBands.ts
+++ b/app/src/utils/queueBands.ts
@@ -188,27 +188,32 @@ export function buildQueueBands<TSession extends QueueBandSession>(
 }
 
 /**
- * The agent to land on once `settledSessionId`'s turn is closed: the next row in
- * queue order, wrapping to the top, and never the row just settled.
+ * The row after `settledSessionId` in queue order, wrapping to the top, that is
+ * still owed according to `stillOwed`.
  *
- * `turns` must be the band as it stood while that turn was still owed — the row
- * being present is what gives the scan a position to continue from. Callers get
- * that from advanceAfterTurnClosed, which holds the earlier snapshot for exactly
- * this reason.
+ * Two snapshots, two jobs. `turns` is the band as it stood while that turn was
+ * still owed, and is consulted only for *order* — the settled row being present
+ * is what gives the scan a position to continue from. `stillOwed` is the current
+ * band, and decides *eligibility*: a broadcast can close several turns at once,
+ * so a successor that looked owed in the old snapshot may have settled in the
+ * very same update, and landing on it would hand the user another finished
+ * agent.
  *
- * A session that is not in the band (already settled, pinned, muted, the chief)
+ * A session that is not in `turns` (already settled, pinned, muted, the chief)
  * has no position to move on from, so the scan simply starts at the top. Null
- * means nothing is left to go to and selection should stay where it is.
+ * means the old snapshot holds nobody still owed — which is not the same as
+ * nothing being owed at all; see advanceAfterTurnClosed.
  */
-export function nextTurnAfterSettle<TSession extends QueueBandSession>(
+function nextOwedAfter<TSession extends QueueBandSession>(
   turns: QueueRow<TSession>[],
-  settledSessionId: string | null,
+  settledSessionId: string,
+  stillOwed: ReadonlySet<string>,
 ): QueueRow<TSession> | null {
   const current = turns.findIndex((row) => row.session.id === settledSessionId);
   const start = current === -1 ? 0 : current + 1;
   for (let offset = 0; offset < turns.length; offset += 1) {
     const row = turns[(start + offset) % turns.length];
-    if (row.session.id !== settledSessionId) {
+    if (row.session.id !== settledSessionId && stillOwed.has(row.session.id)) {
       return row;
     }
   }
@@ -237,6 +242,19 @@ export type QueueAdvance<TSession extends QueueBandSession> =
  * bands entirely rather than landing in settled — so requiring the arrival,
  * rather than just the departure, is what keeps a pin from carrying the user
  * away from the workspace they pinned to keep in view.
+ *
+ * Only the position comes from the old snapshot; whether a row is still worth
+ * going to is always read from `bands`. One broadcast can close several turns —
+ * an auto-settle countdown and a settle from another client landing together,
+ * or two countdowns firing in the same tick — and a successor that was owed in
+ * the old snapshot may be settled in this one. Answering from the old snapshot
+ * alone would hand the user an agent that is already finished with them, which
+ * is the very thing this function exists to avoid.
+ *
+ * Home is therefore reached from the *current* band being empty, never from the
+ * old one running out. A turn that opened in the same broadcast that closed
+ * this one has no position in the old snapshot, so the scan cannot find it; the
+ * head of the current band is where the queue continues.
  */
 export function advanceAfterTurnClosed<TSession extends QueueBandSession>(
   previousTurns: QueueRow<TSession>[],
@@ -247,6 +265,7 @@ export function advanceAfterTurnClosed<TSession extends QueueBandSession>(
   const owedBefore = previousTurns.some((row) => row.session.id === sessionId);
   const settledNow = bands.settled.some((row) => row.session.id === sessionId);
   if (!owedBefore || !settledNow) return null;
-  const next = nextTurnAfterSettle(previousTurns, sessionId);
+  const stillOwed = new Set(bands.turns.map((row) => row.session.id));
+  const next = nextOwedAfter(previousTurns, sessionId, stillOwed) ?? bands.turns[0] ?? null;
   return next ? { to: 'session', row: next } : { to: 'dashboard' };
 }

--- a/app/src/utils/queueBands.ts
+++ b/app/src/utils/queueBands.ts
@@ -191,10 +191,10 @@ export function buildQueueBands<TSession extends QueueBandSession>(
  * The agent to land on once `settledSessionId`'s turn is closed: the next row in
  * queue order, wrapping to the top, and never the row just settled.
  *
- * The target is read from the queue as it stands *before* the settle. The settle
- * is a round trip to the daemon and the band only loses the row when the
- * broadcast comes back, so anything read after the call still contains the row
- * that was settled — deciding here keeps the jump off that race entirely.
+ * `turns` must be the band as it stood while that turn was still owed — the row
+ * being present is what gives the scan a position to continue from. Callers get
+ * that from advanceAfterTurnClosed, which holds the earlier snapshot for exactly
+ * this reason.
  *
  * A session that is not in the band (already settled, pinned, muted, the chief)
  * has no position to move on from, so the scan simply starts at the top. Null
@@ -213,4 +213,40 @@ export function nextTurnAfterSettle<TSession extends QueueBandSession>(
     }
   }
   return null;
+}
+
+/** Where selection goes when a turn closes: the next agent, or home. */
+export type QueueAdvance<TSession extends QueueBandSession> =
+  | { to: 'session'; row: QueueRow<TSession> }
+  | { to: 'dashboard' };
+
+/**
+ * Where the user should land when the turn they were looking at closed without
+ * them asking — an auto-settle countdown completing, or a settle from the
+ * sidebar row. Null means stay put: nothing closed, or what changed was not a
+ * settle.
+ *
+ * `previousTurns` is the turns band as it stood before `bands`, which is what
+ * makes "closed" observable at all — the row is gone from the band by the time
+ * anyone can react, so the two snapshots together are the only record that it
+ * was ever there, and the earlier one is also the only place the user's
+ * position in the queue still exists.
+ *
+ * The move that matters is turns → settled specifically. Pinning or muting a
+ * workspace clears turn_owed on its sessions too, and those rows leave the
+ * bands entirely rather than landing in settled — so requiring the arrival,
+ * rather than just the departure, is what keeps a pin from carrying the user
+ * away from the workspace they pinned to keep in view.
+ */
+export function advanceAfterTurnClosed<TSession extends QueueBandSession>(
+  previousTurns: QueueRow<TSession>[],
+  bands: QueueBands<TSession> | null,
+  sessionId: string | null,
+): QueueAdvance<TSession> | null {
+  if (!sessionId || !bands) return null;
+  const owedBefore = previousTurns.some((row) => row.session.id === sessionId);
+  const settledNow = bands.settled.some((row) => row.session.id === sessionId);
+  if (!owedBefore || !settledNow) return null;
+  const next = nextTurnAfterSettle(previousTurns, sessionId);
+  return next ? { to: 'session', row: next } : { to: 'dashboard' };
 }


### PR DESCRIPTION
## What

Closing a turn hands you the next agent that owes one, or takes you home when none does. That only happened when you pressed <kbd>Cmd+Shift+E</kbd>.

The jump lived inside that shortcut's handler, which computed the next turn locally and moved the selection before the settle even left the app. Every other way a turn closes therefore moved nobody:

- **auto-settle** runs on a daemon timer, so a countdown completing on the agent you were watching dropped its row out of the band and left you sitting on the one agent guaranteed to be finished with you;
- the **sidebar row's settle button** goes straight to the daemon;
- so does a settle from **another client**.

## How

The handover is now a reaction to the turn closing rather than a prediction made by one caller. `handleSettleActiveTurn` only settles. A single effect in `AppContent` watches the queue bands and moves the user when the selected session's row moves out of *Your turn*. Every path arrives there as the same thing — the band the user was in changed — so the handover cannot drift between them again.

`advanceAfterTurnClosed` (`app/src/utils/queueBands.ts`) owns the decision:

- **The predicate is `turns → settled`, not "left the turns band."** Pinning or muting a workspace also clears `turn_owed` on its sessions (`decorateSessionWithTurn`), but those rows land in *no* band. Requiring the arrival rather than just the departure is what keeps a pin — which means "keep this in view" — from carrying you away from the workspace you just pinned.
- **The target comes from the band as it stood before the row moved.** By the time anything can react the settled row is gone, so a scan with no position to continue from restarts at the top of the queue instead of carrying on from where you were.
- **Scoped to the selected agent, and to the session view.** Auto-settle fires on unwatched sessions too, and a timer running off-screen must never move your selection. In grid every tile is being watched, and an empty queue would otherwise drop you out of the view entirely.

A settle the daemon rejects (`SettleTurn` returning false) now moves nobody, which the optimistic jump could not express.

## Behaviour changes beyond the fix

- <kbd>Cmd+Shift+E</kbd> moves you one daemon round trip later rather than instantly, since the move is now a reaction to the broadcast.
- Settling from grid no longer ejects you to the dashboard when nothing is left to hand over.

## Verification

- `advanceAfterTurnClosed`: 8 unit tests in `queueBands.test.ts`. Mutation-checked — relaxing the predicate to "left the turns band" turns the pin guard and the gone-from-bands guard red, and the failing assertion is the load-bearing one rather than an upstream diagnostic.
- Full frontend suite: 2152 tests / 196 files green. `tsc --noEmit` clean.
- **Live**, packaged app on an isolated `settleadv` profile, two real Claude agents: `real-app:scenario-agent-queue`, 13/13 steps, `ok: true`. The new step arms a real auto-settle countdown (both windows at their floors, 5s + 3s) and asserts the app hands over the next owed turn and moves the settled agent to Settled. The two <kbd>Cmd+Shift+E</kbd> steps drive real key presses through the packaged app's native menu and now resolve through the reactive path.

Not measured: the added latency. Those steps poll at 500ms granularity, so they prove the handover happens, not how fast.

## Drive-by

`settling_the_last_turn_leaves_selection_alone` had been asserting the behaviour #707 replaced a day earlier — that PR made settling the last turn land on home but did not update the scenario. Renamed to `settling_the_last_turn_lands_on_home` and now asserts the home landing.

https://claude.ai/code/session_01WwNvxaBqAodV7B4fpefCa5