### PR TITLE
fix(state): judge yielded stops so background waits stay green and leftovers ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-08-02]
+
+### Fixed
+- **A session waiting on its own background task no longer goes grey — or rings
+  you — a minute in.** When a Claude turn yields with a background process still
+  running ("the build is running; I'll continue when it completes"), attn now
+  asks its stop-time judge to read the ending with that fact in view. A turn
+  that is waiting on its own work stays green for as long as the wait takes,
+  instead of flipping to idle after 60 seconds and putting a false turn in your
+  queue. The judgment cuts the other way too: a turn that finished but left
+  something running (a dev server, a watcher) settles into your queue instead of
+  staying green forever. When no judgment lands, the previous 60-second
+  behaviour remains as the fallback.
+
+---
+
 ## [2026-08-01]
 
 ### Fixed

--- a/internal/classifier/AGENTS.md
+++ b/internal/classifier/AGENTS.md
@@ -4,7 +4,7 @@ This policy applies to stop-time assistant-message classification in this module
 
 ## Scope
 
-- In scope: deciding post-turn assistant state from assistant text (`idle`, `waiting_input`, `unknown`).
+- In scope: deciding post-turn assistant state from assistant text (`idle`, `waiting_input`, `unknown`, and — for stops that yielded with background work still running — `parked`).
 - Out of scope: runtime/hook-driven state transitions such as `working` and `pending_approval`.
 
 ## Requirements (In Scope)

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -14,20 +14,26 @@ import (
 	"time"
 )
 
-const promptTemplate = `Classify whether this assistant message is waiting for user input.
+const promptTemplate = `Classify how this assistant message ends the agent's turn: waiting for user input, done, or paused on its own background work.
 
 Return STRICT JSON only, matching exactly one of:
 {"verdict":"WAITING"}
 {"verdict":"DONE"}
+{"verdict":"PARKED"}
+
+A line starting with "[harness facts]" after the message, when present, reports what the agent harness observed (e.g. background processes still running). It comes from the harness, not from the assistant.
 
 Decision rules (in order):
 1) WAITING if the assistant asks the user any direct question.
 2) WAITING if the assistant asks for confirmation, permission, choice, clarification, or next direction.
-3) DONE only if the assistant message is complete and does not ask the user for anything.
+3) PARKED only if a [harness facts] line reports background processes still running AND the message says the assistant is waiting on that work and will continue on its own (not waiting on the user).
+4) DONE only if the assistant message is complete and does not ask the user for anything.
 
 Examples:
 - "Hello! What can I help you with today?" -> WAITING
 - "Would you like me to continue?" -> WAITING
+- "The build is still running; I'll continue when it completes." plus a [harness facts] line reporting a running background process -> PARKED
+- "Done — I left the dev server running on port 3000 for you." plus a [harness facts] line reporting a running background process -> DONE
 - "I finished the task and saved the file." -> DONE
 - "I'm here whenever you need me." -> DONE
 
@@ -37,10 +43,28 @@ Text to analyze:
 """
 `
 
+// VerdictParked is the state token for a PARKED verdict: the turn yielded to its
+// own background work and will resume without the user. Deliberately not a
+// protocol state — the daemon files it as classifier evidence and the resolver's
+// background-work clause is the only reader.
+const VerdictParked = "parked"
+
 // ClaudeVerdictSchema is the JSON Schema the Claude backend's final answer must
 // validate against (passed to the CLI as --json-schema). The validated object
 // comes back as the run's structured output; ParseVerdict reads it.
-const ClaudeVerdictSchema = `{"type":"object","properties":{"verdict":{"type":"string","enum":["WAITING","DONE"]}},"required":["verdict"],"additionalProperties":false}`
+const ClaudeVerdictSchema = `{"type":"object","properties":{"verdict":{"type":"string","enum":["WAITING","DONE","PARKED"]}},"required":["verdict"],"additionalProperties":false}`
+
+// ComposeYieldInput builds the classification input for a stop that yielded with
+// background work still running: the assistant's last message plus the harness
+// facts the prompt's PARKED rule keys on. It lives beside the template so the
+// "[harness facts]" marker and the rule that reads it cannot drift apart.
+func ComposeYieldInput(lastMessage string, runningBackgroundTasks int) string {
+	return fmt.Sprintf(
+		"%s\n\n[harness facts] The turn yielded with %d background process(es) still running; the harness will resume the agent when one exits.",
+		lastMessage,
+		runningBackgroundTasks,
+	)
+}
 
 // ClaudeMaxTurns caps the Claude backend's agentic turns. The run is a tool-less
 // single-shot judgment; the cap is a runaway backstop, and 2 leaves room for the
@@ -51,7 +75,7 @@ const ClaudeMaxTurns = 2
 // when ATTN_CLAUDE_CLASSIFIER_MODEL is unset.
 const DefaultClaudeClassifierModel = "haiku"
 
-var verdictLineRegex = regexp.MustCompile(`(?i)^\s*(?:VERDICT\s*[:=]\s*)?(WAITING_INPUT|WAITING|DONE|IDLE)(?:\s*(?:[-:]\s+.*|\([^)]*\)|[.!?]))?\s*$`)
+var verdictLineRegex = regexp.MustCompile(`(?i)^\s*(?:VERDICT\s*[:=]\s*)?(WAITING_INPUT|WAITING|DONE|IDLE|PARKED)(?:\s*(?:[-:]\s+.*|\([^)]*\)|[.!?]))?\s*$`)
 
 const classifierLogSnippetMaxChars = 600
 
@@ -99,6 +123,8 @@ func parseVerdictToken(value string) (string, bool) {
 		return "waiting_input", true
 	case "DONE", "IDLE":
 		return "idle", true
+	case "PARKED":
+		return VerdictParked, true
 	default:
 		return "", false
 	}

--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -29,6 +29,40 @@ func TestParseResponse_Waiting(t *testing.T) {
 	}
 }
 
+func TestParseResponse_Parked(t *testing.T) {
+	tests := []struct {
+		response string
+		want     string
+	}{
+		{"PARKED", VerdictParked},
+		{"parked", VerdictParked},
+		{`{"verdict":"PARKED"}`, VerdictParked},
+		{"Verdict: PARKED", VerdictParked},
+	}
+
+	for _, tt := range tests {
+		got := ParseResponse(tt.response)
+		if got != tt.want {
+			t.Errorf("ParseResponse(%q) = %q, want %q", tt.response, got, tt.want)
+		}
+	}
+}
+
+// The harness-facts line is composed beside the template on purpose: the PARKED
+// rule keys on its marker, so the two must not drift apart.
+func TestComposeYieldInput_CarriesTheMarkerThePromptKeysOn(t *testing.T) {
+	input := ComposeYieldInput("The build is still running; I'll continue when it completes.", 2)
+	if !strings.Contains(input, "[harness facts]") {
+		t.Fatalf("yield input missing the [harness facts] marker: %q", input)
+	}
+	if !strings.Contains(BuildPrompt("x"), "[harness facts]") {
+		t.Fatal("prompt template no longer mentions the [harness facts] marker the yield input carries")
+	}
+	if !strings.Contains(input, "2 background process(es)") {
+		t.Fatalf("yield input missing the running-task count: %q", input)
+	}
+}
+
 func TestParseResponse_Done(t *testing.T) {
 	tests := []struct {
 		response string

--- a/internal/daemon/classify_decision.go
+++ b/internal/daemon/classify_decision.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	agentdriver "github.com/victorarias/attn/internal/agent"
+	"github.com/victorarias/attn/internal/classifier"
 	"github.com/victorarias/attn/internal/protocol"
 )
 
@@ -42,16 +43,35 @@ type classifyDecision struct {
 	reason string
 }
 
+// stopClassification is what handleStop knew about the stop being judged.
+//
+// yielded marks a stop whose payload reported background work still running, so
+// the turn can resume on its own. A yielded stop is still judged — its last
+// message is the only thing separating "waiting on my build" from "done, but a
+// process I started is still running" — but with two differences: the judge sees
+// the yield (the harness-facts line the PARKED verdict keys on), and every
+// no-answer outcome files nothing instead of settling, because an unjudgeable
+// message must not put a turn that may be about to resume into the user's queue.
+type stopClassification struct {
+	yielded                bool
+	runningBackgroundTasks int
+}
+
 // classifyPreTranscript decides from what the daemon already holds, before paying
 // for any IO.
 //
-// pendingTodos outranks everything: a turn that stopped with unfinished todos is
-// waiting on the user. transcriptEnabled / classifierEnabled are the per-agent
+// pendingTodos outranks everything on a terminal stop: a turn that stopped with
+// unfinished todos is waiting on the user. On a yield it decides nothing — an
+// agent sitting out its own build mid-plan has open todos precisely because it is
+// not finished. transcriptEnabled / classifierEnabled are the per-agent
 // capability gates; an agent with either disabled settles idle rather than being
-// left in whatever state it was.
-func classifyPreTranscript(pendingTodos int, transcriptEnabled, classifierEnabled bool) classifyDecision {
+// left in whatever state it was — except on a yield, where no judgment means no
+// filing and the resolver's fallback ladder decides.
+func classifyPreTranscript(pendingTodos int, transcriptEnabled, classifierEnabled bool, stop stopClassification) classifyDecision {
 	switch {
-	case pendingTodos > 0:
+	case stop.yielded && (!transcriptEnabled || !classifierEnabled):
+		return classifyDecision{action: classifySkip, reason: "yield_unjudgeable"}
+	case !stop.yielded && pendingTodos > 0:
 		return classifyDecision{action: classifyApply, state: protocol.StateWaitingInput, reason: "pending_todos"}
 	case !transcriptEnabled:
 		return classifyDecision{action: classifyApply, state: protocol.StateIdle, reason: "transcript_disabled"}
@@ -68,15 +88,23 @@ func classifyPreTranscript(pendingTodos int, transcriptEnabled, classifierEnable
 // classified, so there is nothing to say — importantly not "unknown", which would
 // overwrite a good state with a bad one. Any other read error is genuinely
 // unknown. An empty last message means the agent said nothing, which settles idle
-// without paying for a classifier call.
-func classifyPostTranscript(lastMessage string, err error) classifyDecision {
+// without paying for a classifier call. A yield files nothing in every non-answer
+// case, empty message included: silence is not evidence the turn is over when the
+// payload says it will resume.
+func classifyPostTranscript(lastMessage string, err error, stop stopClassification) classifyDecision {
 	if err != nil {
 		if errors.Is(err, agentdriver.ErrNoNewAssistantTurn) {
 			return classifyDecision{action: classifySkip, reason: "no_new_assistant_turn"}
 		}
+		if stop.yielded {
+			return classifyDecision{action: classifySkip, reason: "yield_transcript_parse_error"}
+		}
 		return classifyDecision{action: classifyApply, state: protocol.StateUnknown, reason: "transcript_parse_error"}
 	}
 	if strings.TrimSpace(lastMessage) == "" {
+		if stop.yielded {
+			return classifyDecision{action: classifySkip, reason: "yield_empty_message"}
+		}
 		return classifyDecision{action: classifyApply, state: protocol.StateIdle, reason: "empty_last_message"}
 	}
 	return classifyDecision{action: classifyRunClassifier}
@@ -84,23 +112,38 @@ func classifyPostTranscript(lastMessage string, err error) classifyDecision {
 
 // classifyVerdict maps the classifier's answer to a state. A failed call and an
 // unknown answer both land on unknown, but they are separate reasons: one is our
-// plumbing failing, the other is the classifier declining to decide.
-func classifyVerdict(state string, err error) classifyDecision {
+// plumbing failing, the other is the classifier declining to decide. (Neither
+// files any evidence — there is no unknown claim — so on a yield the resolver's
+// fallback ladder still decides.)
+//
+// A parked verdict outside a yield is the judge misapplying a rule whose
+// precondition — the harness-facts line — was never in its input. Filed as
+// nothing rather than remapped: the session settles on its own fallback, and the
+// trace says what the judge actually answered.
+func classifyVerdict(state string, err error, stop stopClassification) classifyDecision {
 	if err != nil {
 		return classifyDecision{action: classifyApply, state: protocol.StateUnknown, reason: "classifier_error"}
 	}
 	if state == protocol.StateUnknown {
 		return classifyDecision{action: classifyApply, state: protocol.StateUnknown, reason: "classifier_unknown_response"}
 	}
+	if state == classifier.VerdictParked && !stop.yielded {
+		return classifyDecision{action: classifyApply, state: protocol.StateUnknown, reason: "classifier_parked_without_yield"}
+	}
 	return classifyDecision{action: classifyApply, state: state, reason: "classifier"}
 }
 
-// classifySessionState decides what a settled turn means and applies the result.
+// classifySessionState judges a terminal stop. See classifyStop.
+func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
+	d.classifyStop(sessionID, transcriptPath, stopClassification{})
+}
+
+// classifyStop decides what a stopped turn means and files the result.
 // It is the IO shell around the rules in classify_decision.go: it gathers inputs,
 // performs the transcript read and the classifier call between rules, and owns the
 // single store write. The rules themselves make no decision about when to pay for
 // IO — they say what is still needed.
-func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
+func (d *Daemon) classifyStop(sessionID, transcriptPath string, stop stopClassification) {
 	// Capture the timestamp BEFORE any classification work: applyState rejects a
 	// classifierObservation older than the state it would overwrite, so a slow
 	// classifier cannot clobber a newer live signal.
@@ -166,7 +209,7 @@ func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
 	}
 	d.logf("classifySessionState: session %s has %d total todos, %d pending", sessionID, len(session.Todos), pendingTodos)
 
-	decision := classifyPreTranscript(pendingTodos, transcriptEnabled, classifierEnabled)
+	decision := classifyPreTranscript(pendingTodos, transcriptEnabled, classifierEnabled, stop)
 	if decision.action != classifyReadTranscript {
 		apply(decision)
 		return
@@ -195,7 +238,7 @@ func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
 		defer d.clearClassifyingTurn(sessionID)
 	}
 
-	decision = classifyPostTranscript(lastMessage, err)
+	decision = classifyPostTranscript(lastMessage, err, stop)
 	if decision.action != classifyRunClassifier {
 		apply(decision)
 		return
@@ -208,13 +251,21 @@ func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
 	}
 	d.logf("classifySessionState: last message for session %s: %s", sessionID, logMsg)
 
+	// On a yield the judge must see the yield: the harness-facts line is the
+	// precondition of the PARKED verdict, and without it the same message reads
+	// as a plain ending.
+	classifierInput := lastMessage
+	if stop.yielded {
+		classifierInput = classifier.ComposeYieldInput(lastMessage, stop.runningBackgroundTasks)
+	}
+
 	// Can be slow — 30+ seconds.
 	d.logf("classifySessionState: calling classifier for session %s", sessionID)
-	state, err := d.runClassifier(session, lastMessage, 30*time.Second)
+	state, err := d.runClassifier(session, classifierInput, 30*time.Second)
 	if err != nil {
 		d.logf("classifySessionState: classifier error for %s: %v", sessionID, err)
 	}
-	decision = classifyVerdict(state, err)
+	decision = classifyVerdict(state, err, stop)
 	if strings.TrimSpace(assistantTurnID) != "" {
 		d.setClassifiedTurnID(sessionID, assistantTurnID)
 	}

--- a/internal/daemon/classify_decision_test.go
+++ b/internal/daemon/classify_decision_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	agentdriver "github.com/victorarias/attn/internal/agent"
+	"github.com/victorarias/attn/internal/classifier"
 	"github.com/victorarias/attn/internal/protocol"
 )
 
@@ -15,9 +16,30 @@ func TestClassifyPreTranscript(t *testing.T) {
 		pendingTodos      int
 		transcriptEnabled bool
 		classifierEnabled bool
+		stop              stopClassification
 		wantAction        classifyAction
 		wantState         string
 	}{
+		{
+			// An agent sitting out its own build mid-plan has open todos precisely
+			// because it is not finished; reading them as "waiting on the user"
+			// would ring on every yielded stop of a multi-step task.
+			name:              "a yield ignores pending todos and reads the transcript",
+			pendingTodos:      3,
+			transcriptEnabled: true,
+			classifierEnabled: true,
+			stop:              stopClassification{yielded: true},
+			wantAction:        classifyReadTranscript,
+		},
+		{
+			// No judgment is possible, so nothing is filed: settling idle here
+			// would queue a turn the payload says will resume on its own.
+			name:              "a yield with no classifier files nothing",
+			transcriptEnabled: true,
+			classifierEnabled: false,
+			stop:              stopClassification{yielded: true},
+			wantAction:        classifySkip,
+		},
 		{
 			name:              "pending todos outrank everything",
 			pendingTodos:      1,
@@ -57,7 +79,7 @@ func TestClassifyPreTranscript(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := classifyPreTranscript(tc.pendingTodos, tc.transcriptEnabled, tc.classifierEnabled)
+			got := classifyPreTranscript(tc.pendingTodos, tc.transcriptEnabled, tc.classifierEnabled, tc.stop)
 			if got.action != tc.wantAction || got.state != tc.wantState {
 				t.Fatalf("classifyPreTranscript() = %+v, want action %v state %q", got, tc.wantAction, tc.wantState)
 			}
@@ -73,6 +95,7 @@ func TestClassifyPostTranscript(t *testing.T) {
 		name        string
 		lastMessage string
 		err         error
+		stop        stopClassification
 		wantAction  classifyAction
 		wantState   string
 		wantReason  string
@@ -82,6 +105,21 @@ func TestClassifyPostTranscript(t *testing.T) {
 			err:        fmt.Errorf("wrapped: %w", agentdriver.ErrNoNewAssistantTurn),
 			wantAction: classifySkip,
 			wantReason: "no_new_assistant_turn",
+		},
+		{
+			// A yield's non-answers all file nothing: unknown or idle here would
+			// move a turn the payload says will resume into the user's queue.
+			name:       "a yield's read error files nothing",
+			err:        errors.New("permission denied"),
+			stop:       stopClassification{yielded: true},
+			wantAction: classifySkip,
+			wantReason: "yield_transcript_parse_error",
+		},
+		{
+			name:       "a yield's empty message files nothing",
+			stop:       stopClassification{yielded: true},
+			wantAction: classifySkip,
+			wantReason: "yield_empty_message",
 		},
 		{
 			name:       "any other read error is unknown",
@@ -111,7 +149,7 @@ func TestClassifyPostTranscript(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := classifyPostTranscript(tc.lastMessage, tc.err)
+			got := classifyPostTranscript(tc.lastMessage, tc.err, tc.stop)
 			if got.action != tc.wantAction || got.state != tc.wantState || got.reason != tc.wantReason {
 				t.Fatalf("classifyPostTranscript() = %+v, want action %v state %q reason %q",
 					got, tc.wantAction, tc.wantState, tc.wantReason)
@@ -125,9 +163,26 @@ func TestClassifyVerdict(t *testing.T) {
 		name       string
 		state      string
 		err        error
+		stop       stopClassification
 		wantState  string
 		wantReason string
 	}{
+		{
+			name:       "a parked verdict on a yield passes through",
+			state:      classifier.VerdictParked,
+			stop:       stopClassification{yielded: true},
+			wantState:  classifier.VerdictParked,
+			wantReason: "classifier",
+		},
+		{
+			// PARKED's precondition — the harness-facts line — is only in a yield's
+			// input; answered without it, the judge misapplied the rule. Unknown
+			// files no evidence, so the session settles on its own fallback.
+			name:       "a parked verdict without a yield is no verdict",
+			state:      classifier.VerdictParked,
+			wantState:  protocol.StateUnknown,
+			wantReason: "classifier_parked_without_yield",
+		},
 		{
 			name:       "classifier failure is unknown, attributed to us",
 			state:      "",
@@ -157,7 +212,7 @@ func TestClassifyVerdict(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := classifyVerdict(tc.state, tc.err)
+			got := classifyVerdict(tc.state, tc.err, tc.stop)
 			if got.action != classifyApply || got.state != tc.wantState || got.reason != tc.wantReason {
 				t.Fatalf("classifyVerdict() = %+v, want state %q reason %q", got, tc.wantState, tc.wantReason)
 			}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2495,9 +2495,10 @@ func (d *Daemon) persistResumeSessionID(sessionID, resumeSessionID string) {
 func (d *Daemon) handleStop(conn net.Conn, msg *protocol.StopMessage) {
 	d.logf("handleStop: session=%s, transcript_path=%s", msg.ID, msg.TranscriptPath)
 
-	// A non-terminal stop is a yield, not an end: do none of the end-of-turn work
-	// below (no resume-id capture, no narration enqueue, no classification), and
-	// leave the color to the facts recorded here. The turn resumes on its own.
+	// A non-terminal stop is a yield, not an end: it skips the end-of-turn work
+	// below (no resume-id capture, no narration enqueue — both belong to a turn
+	// that has actually ended), and the color follows from the facts recorded
+	// here plus the yield-aware judgment kicked off below.
 	//
 	// The facts are recorded as the rules read them, not raw. A background task
 	// the agent has already finished is present in the payload and means nothing,
@@ -2521,6 +2522,22 @@ func (d *Daemon) handleStop(conn net.Conn, msg *protocol.StopMessage) {
 			"",
 		)
 		d.sendOK(conn)
+		if d.consumeForcedStopClassification(msg.ID) {
+			d.logf("handleStop: skipping yield classification for daemon-terminated session=%s", msg.ID)
+			return
+		}
+		// A yield is not excused from judgment. The payload that says the turn can
+		// resume is identical whether the agent is waiting on its own build or
+		// finished and left a process running, and only the turn's own last words
+		// separate the two. The judge sees the yield (three-way verdict: parked
+		// holds the session working with no decay to unknown; waiting/idle settle
+		// it into the user's queue), and a judgment that never lands leaves the
+		// resolver's prompt-idle fallback as the safety valve — exactly the
+		// pre-judgment behavior.
+		go d.classifyStop(msg.ID, msg.TranscriptPath, stopClassification{
+			yielded:                true,
+			runningBackgroundTasks: runningBackgroundTaskCount(msg),
+		})
 		return
 	}
 

--- a/internal/daemon/session_evidence.go
+++ b/internal/daemon/session_evidence.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/victorarias/attn/internal/classifier"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/pty"
 	"github.com/victorarias/attn/internal/ptybackend"
@@ -638,16 +639,19 @@ func (d *Daemon) traceResolutionSkip(sessionID string, resolution sessionstate.R
 	})
 }
 
-// classifierClaim reads a verdict. The classifier judges how a finished turn
-// ended, so it can only say two things, and anything else — including the
-// `unknown` a failed classification used to publish — is no verdict at all
-// rather than a third answer.
+// classifierClaim reads a verdict. The classifier judges how a stopped turn
+// ended — the user is waited on, nothing is, or (on a yield) the turn waits on
+// its own background work — and anything else, including the `unknown` a failed
+// classification used to publish, is no verdict at all rather than a fourth
+// answer.
 func classifierClaim(state string) sessionstate.Claim {
 	switch state {
 	case protocol.StateWaitingInput:
 		return sessionstate.ClaimNeedsInput
 	case protocol.StateIdle:
 		return sessionstate.ClaimIdle
+	case classifier.VerdictParked:
+		return sessionstate.ClaimParked
 	default:
 		return ""
 	}

--- a/internal/daemon/stop_terminality.go
+++ b/internal/daemon/stop_terminality.go
@@ -11,16 +11,23 @@ import (
 // The decision lives here rather than in the hook binary so the facts reach the
 // daemon, which is where state from every other source is arbitrated.
 
-// hasActiveBackgroundTask reports whether the stop still has background work in
-// flight. Status comparison is case-insensitive because it is the agent
+// runningBackgroundTaskCount is how many of the stop's background tasks are
+// still in flight. Status comparison is case-insensitive because it is the agent
 // harness's string, not ours.
-func hasActiveBackgroundTask(msg *protocol.StopMessage) bool {
+func runningBackgroundTaskCount(msg *protocol.StopMessage) int {
+	running := 0
 	for _, status := range msg.BackgroundTaskStatuses {
 		if strings.EqualFold(strings.TrimSpace(status), "running") {
-			return true
+			running++
 		}
 	}
-	return false
+	return running
+}
+
+// hasActiveBackgroundTask reports whether the stop still has background work in
+// flight.
+func hasActiveBackgroundTask(msg *protocol.StopMessage) bool {
+	return runningBackgroundTaskCount(msg) > 0
 }
 
 // hasPendingSessionCron reports whether the stop parked on a scheduled wakeup.
@@ -31,10 +38,12 @@ func hasPendingSessionCron(msg *protocol.StopMessage) bool {
 }
 
 // stopIsNonTerminal reports whether this Stop leaves the turn able to resume on
-// its own, in which case none of the end-of-turn work applies: classifying reads
-// a transcript the agent has not finished writing, and the resume id and
-// narration belong to a turn that has not ended. It says nothing about what color
-// the session should be — that follows from the facts recorded alongside it.
+// its own. The resume id and narration belong to a turn that has actually ended,
+// so a non-terminal stop skips them; it is still judged, with the yield in view,
+// because the payload cannot say whether the running work is what the turn waits
+// on or a leftover it finished around. It says nothing about what color the
+// session should be — that follows from the facts and verdict recorded alongside
+// it.
 //
 // A parked cron is deliberately not one of these. The transcript is flushed and
 // the wakeup may be hours away, so treating it as a yield only meant a cron-parked

--- a/internal/daemon/stop_terminality_test.go
+++ b/internal/daemon/stop_terminality_test.go
@@ -3,11 +3,15 @@ package daemon
 import (
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/victorarias/attn/internal/classifier"
 	"github.com/victorarias/attn/internal/client"
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/pty"
 )
 
 // TestStopIsNonTerminal locks which Stops leave the turn able to resume itself,
@@ -183,6 +187,125 @@ func TestDaemon_StopCommand_PendingCron_Settles(t *testing.T) {
 	}
 
 	waitForResolvedState(t, d, "cron-session", protocol.SessionStateIdle)
+}
+
+// recordingClassifier captures the input it was asked to judge and answers with
+// a fixed verdict.
+type recordingClassifier struct {
+	state string
+	mu    sync.Mutex
+	texts []string
+}
+
+func (c *recordingClassifier) Classify(text string, timeout time.Duration) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.texts = append(c.texts, text)
+	return c.state, nil
+}
+
+func (c *recordingClassifier) Texts() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.texts...)
+}
+
+// yieldedStopDaemon is the shared fixture for the yield-judgment wiring tests: a
+// claude session whose turn ran, settled its heartbeat, and then yielded on a
+// Stop reporting one running background task, with the judge's answer faked.
+// It replays the 2026-08-01 incident's timeline up to the verdict.
+func yieldedStopDaemon(t *testing.T, verdict string) (*Daemon, *recordingClassifier) {
+	t.Helper()
+	d := NewForTesting(filepath.Join(shortTempDir(t), "test.sock"))
+	judge := &recordingClassifier{state: verdict}
+	d.classifier = judge
+	d.classificationTranscriptExtractor = func(*protocol.Session, string, int, time.Time) (string, string, error) {
+		return "The profile build is still running in the background; I'll continue when it completes.", "turn-1", nil
+	}
+
+	now := time.Now()
+	nowStr := string(protocol.NewTimestamp(now))
+	d.store.Add(&protocol.Session{
+		ID:             "yielded",
+		Agent:          protocol.SessionAgentClaude,
+		Label:          "test",
+		Directory:      "/tmp",
+		State:          protocol.StateWorking,
+		StateSince:     nowStr,
+		StateUpdatedAt: nowStr,
+		LastSeen:       nowStr,
+		// Open todos on purpose: a yielded stop must not read them as "waiting
+		// on the user" — the plan is unfinished precisely because the turn is not.
+		Todos: []string{"[→] wait for the build", "[ ] verify live"},
+	})
+	d.recordBracketEvidence("yielded", protocol.StateWorking)
+	d.recordPTYEvidence("yielded", pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", At: now.Add(-time.Second)})
+	d.recordPTYEvidence("yielded", pty.Observation{Source: pty.SourceHeartbeat, Claim: "not_busy", At: now})
+
+	d.handleStop(drainingConn(t), &protocol.StopMessage{
+		Cmd:                    protocol.CmdStop,
+		ID:                     "yielded",
+		TranscriptPath:         "/tmp/transcript.jsonl",
+		BackgroundTaskStatuses: []string{"running"},
+	})
+
+	// The judgment is dispatched async; wait for its verdict to land as evidence.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if e, ok := d.evidenceTable().snapshot("yielded"); ok && e.LastClassifier != nil {
+			break
+		}
+		if !time.Now().Before(deadline) {
+			t.Fatalf("yield verdict never landed as evidence (classifier calls: %d)", len(judge.Texts()))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return d, judge
+}
+
+// TestDaemon_YieldedStop_ParkedVerdictHoldsWorkingPastPromptIdle is the
+// 2026-08-01 incident, end to end: the yield is judged parked, and claude's flat
+// 60s idle_prompt notification — which used to settle the session idle and ring
+// the user mid-build — no longer outranks the verdict.
+func TestDaemon_YieldedStop_ParkedVerdictHoldsWorkingPastPromptIdle(t *testing.T) {
+	d, judge := yieldedStopDaemon(t, classifier.VerdictParked)
+
+	// The judge must have seen the yield: the harness-facts line is the
+	// precondition of the parked verdict.
+	texts := judge.Texts()
+	if len(texts) != 1 || !strings.Contains(texts[0], "[harness facts]") {
+		t.Fatalf("judge input missing the harness-facts line: %q", texts)
+	}
+
+	// The notification that broke the incident open, a minute into the wait.
+	d.recordNotificationEvidence("yielded", notifyIdlePrompt, "Claude is waiting for your input")
+	d.resolveAllSessions(time.Now())
+
+	sess := d.store.Get("yielded")
+	if sess == nil {
+		t.Fatal("session missing after resolve")
+	}
+	if sess.State != protocol.StateWorking {
+		t.Fatalf("state = %s, want %s: a parked verdict outranks the prompt-idle confirmation", sess.State, protocol.StateWorking)
+	}
+}
+
+// TestDaemon_YieldedStop_DoneVerdictSettles pins the inverse failure the parked
+// hold must not reintroduce: a turn that finished but left a process running
+// (a dev server, a watcher) settles into the user's queue on its verdict instead
+// of sitting green forever behind a task that will never exit.
+func TestDaemon_YieldedStop_DoneVerdictSettles(t *testing.T) {
+	d, _ := yieldedStopDaemon(t, protocol.StateIdle)
+
+	d.resolveAllSessions(time.Now())
+
+	sess := d.store.Get("yielded")
+	if sess == nil {
+		t.Fatal("session missing after resolve")
+	}
+	if sess.State != protocol.StateIdle {
+		t.Fatalf("state = %s, want %s: an idle verdict on a yield means the running process is a leftover", sess.State, protocol.StateIdle)
+	}
 }
 
 // waitForResolvedState waits out the resolve tick. Nothing applies a state at the

--- a/internal/sessionstate/clause_order_test.go
+++ b/internal/sessionstate/clause_order_test.go
@@ -100,6 +100,23 @@ func TestClauseOrder(t *testing.T) {
 			wantReason: ReasonQuestionOpen,
 		},
 		{
+			// The verdict answered the exact question the confirmation only
+			// gestures at: the agent sits at its prompt during a background wait
+			// and after a finished turn alike, so the notification adds nothing,
+			// while the judge read the turn's own account of which one this is.
+			why: "a parked verdict outranks the prompt-idle confirmation: the " +
+				"judge read the yield, the flat timer read a clock",
+			evidence: Evidence{
+				BackgroundWork: true,
+				LastClassifier: seen(SourceClassifier, ClaimParked, 55*time.Second),
+				PromptIdleAt:   now.Add(-time.Second),
+				LastBusyAt:     now.Add(-time.Minute),
+				LastMovement:   now.Add(-time.Second),
+			},
+			wantState:  protocol.SessionStateWorking,
+			wantReason: ReasonBackgroundParked,
+		},
+		{
 			// This clause used to run the other way, on the reasoning that the
 			// background task would un-park the turn without anyone doing anything.
 			// Two things retired that. It was not what the code delivered — the

--- a/internal/sessionstate/sessionstate.go
+++ b/internal/sessionstate/sessionstate.go
@@ -60,6 +60,10 @@ const (
 	ClaimNeedsInput Claim = "needs_input"
 	// ClaimIdle: the agent finished and wants nothing.
 	ClaimIdle Claim = "idle"
+	// ClaimParked: the stop-time judge read a yielded turn as waiting on its own
+	// background work, not on the user. Only the background-work clause consumes
+	// it — outside a yield the claim describes nothing.
+	ClaimParked Claim = "parked"
 	// ClaimExited: the process is gone.
 	ClaimExited Claim = "exited"
 	// ClaimStopFailed: the turn ended on an API error rather than on an answer.
@@ -269,6 +273,7 @@ const (
 	ReasonSettleGrace       Reason = "settle_grace"
 	ReasonAwaitingVerdict   Reason = "awaiting_verdict"
 	ReasonBackgroundWork    Reason = "background_work"
+	ReasonBackgroundParked  Reason = "background_parked"
 	ReasonCompacting        Reason = "compacting"
 	ReasonStopFailed        Reason = "stop_failed"
 	ReasonClassifierVerdict Reason = "classifier_verdict"
@@ -335,11 +340,42 @@ func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
 		return Resolution{State: protocol.SessionStateWorking, Reason: ReasonCompacting}
 	}
 
-	// The turn yielded with work still running, so nobody is being waited on —
-	// until the harness says otherwise. The confirmation is a direct answer to the
-	// question this fact only guesses at, and claude fires it on a flat timer that
-	// reads neither fact, so it can be trusted to arrive.
-	if e.BackgroundWork && !promptIdleConfirmed(e) {
+	// The turn yielded with work still running. The fact alone cannot say whether
+	// anyone is waited on — "I'll continue when the build finishes" and "done, I
+	// left the server running" yield identical payloads — so the stop is judged
+	// with the yield in view, and the verdict outranks every guess below it.
+	//
+	// A waiting/idle verdict means the judge read the ending as the user's turn:
+	// the process still running is a leftover, not a reason the turn will resume,
+	// so it settles (and rings) like any other ending. A parked verdict is the
+	// opposite answer — the turn waits on its own work and will resume without
+	// anyone — and it is affirmative evidence for the silence that follows: an
+	// agent sitting out a background wait paints no frames and fires its
+	// prompt-idle notification exactly as a finished one does, so neither total
+	// silence nor the confirmation says anything the verdict has not already
+	// answered. Parked therefore holds working without decaying to unknown —
+	// `unknown` opens a turn, and ringing the user because a build is slow is the
+	// failure this clause exists to remove. The hold is still bounded: the next
+	// busy frame spends the verdict, and the next turn clears the yield.
+	//
+	// With no verdict — the judge failed, declined, or is still out — the ladder
+	// is the old one: hold working while the judgment may yet land, let the
+	// harness's prompt-idle confirmation retire the yield (the safety valve that
+	// keeps a wrongly-held session from staying green forever), and decay to
+	// stuck on total silence.
+	if e.BackgroundWork {
+		if r, ok := classifierVerdict(e); ok {
+			return r
+		}
+		if parkedVerdict(e) {
+			return Resolution{State: protocol.SessionStateWorking, Reason: ReasonBackgroundParked}
+		}
+		if verdictPending(e, policy, now) {
+			return Resolution{State: protocol.SessionStateWorking, Reason: ReasonBackgroundWork}
+		}
+		if promptIdleConfirmed(e) {
+			return settled(e, ReasonPromptIdle, policy, now)
+		}
 		if evidenceStoppedMoving(e, now, policy.StuckAfter) {
 			return Resolution{State: protocol.SessionStateUnknown, Reason: ReasonStuck}
 		}
@@ -511,8 +547,19 @@ func harnessEdge(e Evidence) (Resolution, bool) {
 	}
 }
 
+// parkedVerdict reports whether the stop-time judge read the current yield as
+// the turn waiting on its own background work rather than on the user. Spent
+// the same way every verdict is: by the agent going busy past it — which for a
+// parked turn is precisely the resume it predicted.
+func parkedVerdict(e Evidence) bool {
+	return e.LastClassifier != nil &&
+		e.LastClassifier.Claim == ClaimParked &&
+		!supersededByBusy(e.LastClassifier, e)
+}
+
 // classifierVerdict reads the stop-time verdict, if one belongs to the current
-// turn.
+// turn. It answers only the two claims that name a state; parked is read by the
+// background-work clause alone, because outside a yield it describes nothing.
 //
 // A verdict describes the turn it was computed for and nothing else. The turn
 // bracket clears it when the next turn opens, but a turn may also start without

--- a/internal/sessionstate/sessionstate_test.go
+++ b/internal/sessionstate/sessionstate_test.go
@@ -429,15 +429,62 @@ func TestResolve(t *testing.T) {
 			wantReason: ReasonHeartbeatFresh,
 		},
 		{
-			// An outstanding background task auto-resumes the turn, so the
-			// session keeps working rather than flickering idle and back.
-			name: "background work keeps a yielded turn working",
+			// A yield is judged, and the verdict outranks the yield's own guess. An
+			// idle answer means the judge read the ending as complete — the process
+			// still running is a leftover, not what the turn waits on — so the
+			// session settles into the user's queue instead of sitting green behind
+			// a process that will never exit. (A stale verdict from an earlier turn
+			// cannot masquerade as this: the agent going busy in between spends it.)
+			name: "a judged yield settles on its verdict: the running process is a leftover",
 			evidence: Evidence{
 				BackgroundWork: true,
 				LastClassifier: seen(SourceClassifier, ClaimIdle, time.Second),
 			},
+			wantState:  protocol.SessionStateIdle,
+			wantReason: ReasonClassifierVerdict,
+		},
+		{
+			// The judge read the yielded turn as waiting on its own work: the
+			// session holds working, and — unlike the unjudged yield below — never
+			// decays to unknown, because the verdict is affirmative evidence that
+			// this exact silence is a background wait. LastMovement is well past
+			// StuckAfter to pin that.
+			name: "a parked verdict holds a yielded turn working without decaying to unknown",
+			evidence: Evidence{
+				BackgroundWork: true,
+				TurnEverOpened: true,
+				LastClassifier: seen(SourceClassifier, ClaimParked, 2*time.Minute),
+				LastMovement:   now.Add(-2 * time.Minute),
+			},
+			wantState:  protocol.SessionStateWorking,
+			wantReason: ReasonBackgroundParked,
+		},
+		{
+			// The resume the parked verdict predicted arrived (a busy frame after
+			// the verdict) and the agent has since gone quiet again without a new
+			// stop: the verdict is spent, and the yield falls back to its unjudged
+			// ladder rather than the old answer.
+			name: "a busy frame spends a parked verdict",
+			evidence: Evidence{
+				BackgroundWork: true,
+				TurnEverOpened: true,
+				LastClassifier: seen(SourceClassifier, ClaimParked, 30*time.Second),
+				LastBusyAt:     now.Add(-10 * time.Second),
+				LastMovement:   now.Add(-10 * time.Second),
+			},
 			wantState:  protocol.SessionStateWorking,
 			wantReason: ReasonBackgroundWork,
+		},
+		{
+			// The judge read the yielded turn as ending on a question. Background
+			// work or not, the user is being waited on.
+			name: "a waiting verdict on a yield asks the user",
+			evidence: Evidence{
+				BackgroundWork: true,
+				LastClassifier: seen(SourceClassifier, ClaimNeedsInput, time.Second),
+			},
+			wantState:  protocol.SessionStateWaitingInput,
+			wantReason: ReasonClassifierVerdict,
 		},
 		{
 			// Both facts arrive together on the same Stop payload, and the order
@@ -764,6 +811,51 @@ func TestAPromptIdleConfirmationRetiresAnOutstandingBackgroundTask(t *testing.T)
 		}
 		if got.State != protocol.SessionStateIdle || got.Reason != ReasonPromptIdle {
 			t.Fatalf("%s in: resolved %s/%s, want idle/%s", d, got.State, got.Reason, ReasonPromptIdle)
+		}
+	}
+}
+
+// Replays the 2026-08-01 incident: a turn yielded on "the build is still
+// running; I'll continue when it completes" with the build as an outstanding
+// background task, claude fired its flat-timer prompt-idle notification sixty
+// seconds in, and the resolver settled the session idle — opening a turn and
+// ringing the user for a build that finished on its own forty seconds later.
+//
+// The confirmation was not wrong about the prompt (the agent does sit at it
+// during a background wait); it was wrong about what that means. With a parked
+// verdict on the table the resolver now has the direct answer, so neither the
+// confirmation nor total silence may retire the yield: no idle, no unknown, all
+// the way until the resume.
+func TestAParkedVerdictOutlastsThePromptIdleConfirmation(t *testing.T) {
+	policy := testPolicy()
+
+	yielded := now
+	at := func(d time.Duration) Evidence {
+		e := Evidence{
+			TurnEverOpened: true,
+			BackgroundWork: true,
+			Heartbeat:      &Observation{Source: SourceHeartbeat, Claim: ClaimSettled, ObservedAt: yielded},
+			LastBusyAt:     yielded.Add(-time.Second),
+			LastMovement:   yielded,
+			// The yield was judged seconds after the stop: parked.
+			LastClassifier: &Observation{Source: SourceClassifier, Claim: ClaimParked, ObservedAt: yielded.Add(5 * time.Second)},
+		}
+		if d >= time.Minute {
+			e.PromptIdleAt = yielded.Add(time.Minute)
+			e.LastMovement = yielded.Add(time.Minute)
+		}
+		return e
+	}
+
+	for _, d := range []time.Duration{
+		30 * time.Second,
+		time.Minute, // the notification the incident settled on
+		time.Minute + policy.StuckAfter + time.Second,
+		10 * time.Minute, // a genuinely long build
+	} {
+		got := Resolve(at(d), policy, yielded.Add(d))
+		if got.State != protocol.SessionStateWorking || got.Reason != ReasonBackgroundParked {
+			t.Fatalf("%s in: resolved %s/%s, want working/%s", d, got.State, got.Reason, ReasonBackgroundParked)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

A Claude turn that yields with background tasks still running produces the same Stop payload whether it is **waiting on its own work** ("the build is running; I'll continue when it completes") or **finished around a leftover process** ("done — I left the dev server running"). The daemon skipped all end-of-turn classification on such stops, so the only signal deciding the color afterwards was claude's flat 60-second `idle_prompt` notification — which fires during a background wait exactly as it does after a finished turn.

Observed failure (2026-08-01, production): a session parked on a background build was settled **idle at t+60s**, opening a turn and ringing the user's doorbell for a build that resumed the turn on its own 2 minutes later. The inverse failure is latent in the same design: without the idle-prompt override, a finished turn with a leftover process would sit green forever with nothing left to unpin it (the hazard already documented in `handleStop` and the reason the chief-of-staff `relaxBackgroundWork` exemption exists).

## Change

**Yielded (non-terminal) stops are now judged like any other stop, with the yield in view.**

- The classifier input for a yield is the last assistant message plus a `[harness facts]` line reporting the running background tasks; the verdict vocabulary gains `PARKED` alongside `WAITING`/`DONE` (`internal/classifier`: prompt template, Claude JSON schema, parsers).
- The resolver (`internal/sessionstate`) reads a **parked verdict as affirmative evidence** that the silence is a background wait: the session holds `working` with **no decay to `unknown`** (`unknown` opens a turn, so the old decay didn't just show a wrong color — it rang the doorbell) and no prompt-idle override. The verdict is spent deterministically by the next busy frame — i.e. the resume it predicted — and the next turn clears the yield facts.
- A **`WAITING`/`DONE` verdict on a yield settles and rings**: the running process is a leftover, not a reason the turn will resume. This closes the green-forever case, and faster than the 60s fallback ever did.
- **No verdict at all** (classifier failed, declined, or timed out) leaves the previous ladder byte-for-byte: hold `working`, prompt-idle retires the yield at 60s as the safety valve, stuck at 90s behind it. The 2026-07-27 incident regression test (`TestAPromptIdleConfirmationRetiresAnOutstandingBackgroundTask`) passes unmodified.
- Yield judgments also skip the pending-todos rule (a plan is open precisely because the turn is not finished) and file nothing on every unjudgeable outcome (missing transcript, empty message), so a turn that may resume never lands in the user's queue on a non-answer.
- A `PARKED` answer on a terminal stop (the rule's precondition — the harness-facts line — was never in the input) is treated as no verdict, per the classifier policy of never substituting a guess for invalid LLM output.

No protocol change; daemon-only.

## Testing

- `go test ./...` green.
- New unit coverage: resolver table cases for verdict-vs-yield precedence and both incident timelines (`TestAParkedVerdictOutlastsThePromptIdleConfirmation`), clause-order case for parked-vs-prompt-idle, yield variants of the classify decision rules, `PARKED` parse coverage, and daemon wiring tests (`TestDaemon_YieldedStop_ParkedVerdictHoldsWorkingPastPromptIdle`, `TestDaemon_YieldedStop_DoneVerdictSettles`) driving `handleStop` end to end with a recording classifier.

## Live verification

Branch daemon installed into the dev profile (`make install-daemon-dev`, preflight all-PASS, protocol 200 both sides), driven with real delegated claude sessions and the real haiku classifier:

- **Background wait**: yield on "The sleep is still running in the background; I'll continue when it completes." with a background `sleep 120` → judged `parked` 9.5s after the stop → the real `idle_prompt` notification fired at t+60s and was **not** applied → session held `working` through the whole wait → sleep exited, the harness re-invoked the agent, and the terminal stop classified idle. The only resolver apply in the session's life was `idle` at the true end of turn; `turn_opened_at` was stamped only there.
- **Leftover process**: turn ended with "Done — I left a sleep process running in the background for you" with `sleep 600` still alive → judged `DONE` → settled idle and opened the user's turn **12 seconds** after the stop, process still running.

https://claude.ai/code/session_0184JiBwiizukUkN3EcqfdPo
