### PR TITLE
fix: detect a halted turn for claude, codex, and copilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-08-02]
+
+### Fixed
+- **Interrupting an agent settles its session right away.** Hitting ESC to halt
+  claude, codex, or copilot mid-turn used to leave the session showing *working*
+  for a full minute, then briefly *idle*, then *unknown* — because none of them
+  fires any hook when a turn is interrupted, so nothing ever closed the turn.
+  attn now reads the halt out of the agent's own transcript and settles the
+  session to *idle* within a second or two, with `turn_aborted` as the reason in
+  `attn state explain`. A halted copilot session was the worst of the three: it
+  writes no turn-end event either, so the session stayed green for the rest of
+  its life.
+- **Copilot sessions launched through a symlinked directory no longer sit at
+  *launching* forever.** Copilot records the directory it resolved rather than the
+  one it was given, so a session started under a symlinked path — `/tmp` on macOS,
+  for instance — was never matched to its own transcript, and copilot's live state
+  comes from that transcript.
+- **A halted turn is only ever your own.** Quoting or pasting claude's
+  `[Request interrupted by user]` marker into a prompt no longer settles the
+  session you are talking to, a turn codex ended for its own reasons is no longer
+  read as you halting it, and a session that resumes onto a transcript with older
+  halts in it no longer settles on one of them.
+
+---
+
 ## [2026-08-01]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   comes from that transcript.
 - **A halted turn is only ever your own.** Quoting or pasting claude's
   `[Request interrupted by user]` marker into a prompt no longer settles the
-  session you are talking to, a turn codex ended for its own reasons is no longer
-  read as you halting it, and a session that resumes onto a transcript with older
-  halts in it no longer settles on one of them.
+  session you are talking to, a turn codex or copilot ended for its own reasons is
+  no longer read as you halting it, and a session that resumes onto a transcript
+  with older halts in it no longer settles on one of them. A copilot turn that
+  copilot itself abandoned still ends the turn — it just ends it without putting a
+  halt you never made in your history.
 - **A session waiting on its own background task no longer goes grey — or rings
   you — a minute in.** When a Claude turn yields with a background process still
   running ("the build is running; I'll continue when it completes"), attn now

--- a/docs/plans/2026-07-25-agent-state-detection.md
+++ b/docs/plans/2026-07-25-agent-state-detection.md
@@ -96,6 +96,106 @@ entirely. Unwired hooks: Claude **`Notification`** (fires on permission-needed a
 on 60s-idle-waiting), `SessionEnd`, `SubagentStop`; Codex's `notify` program
 (`agent-turn-complete`).
 
+### No hook reports a turn the user halted (measured 2026-08-01)
+
+Hitting ESC mid-turn fires **nothing**. Measured on claude 2.1.220 with all 31 of
+its hook events wired to a logger, on codex 0.146.0 with attn's own trusted-hash
+overrides on every hook it supports, and on copilot 1.0.77: no `Stop`, no
+`StopFailure`, no `Notification`, nothing, for as long as you care to wait.
+Claude's `idle_prompt` `Notification` — the resolver's designed rescue for a lost
+`Stop` — does not fire either.
+
+This is a hole in the bracket model, not a late signal: the `UserPromptSubmit`
+that opened the turn has no counterpart coming, so the resolver holds *working*
+until `StaleAfter` (60s) retires the bracket, and because an interrupt writes no
+further evidence, `LastMovement` freezes and the session then flips to *unknown*
+/ *stuck* at 90s.
+
+What all three *do* write, in the same second, is a line in their own transcript:
+
+```text
+claude:  {"type":"user","message":{"content":[{"type":"text",
+          "text":"[Request interrupted by user]"}]},"interruptedMessageId":"msg_…"}
+codex:   {"type":"event_msg","payload":{"type":"turn_aborted","reason":"interrupted"}}
+copilot: {"type":"abort","data":{"reason":"user_initiated"}}
+```
+
+So the transcript is the only place a halt can be read from. `ClaimTurnAborted`
+is filed from there by the transcript watcher and resolved by its own clause to
+*idle* / `turn_aborted` — above compaction and background work, because an abort
+ends everything the turn had running, and below the busy heartbeat, because the
+agent visibly running again is the one thing that contradicts it. It settles
+without consulting the classifier: a halted turn left a truncated fragment and no
+answer, and a verdict drawn from that reports a question the agent never finished
+asking.
+
+Codex's live state is otherwise hook-owned. Its transcript watcher exists for
+this signal alone and its behavior declines classification unconditionally, so it
+cannot race the `Stop` hook's verdict.
+
+Copilot is the worst of the three, and for a second reason: an abort is the one
+turn ending it does **not** follow with `assistant.turn_end`. Its watcher keeps
+its own turn bracket, so before this a halted copilot session was pinned *working*
+for the rest of its life — not for 60s. Every abort closes that bracket whatever
+caused it; only `user_initiated` settles the session.
+
+Live on a non-production profile, halt → *idle* / `turn_aborted`: **1.0s**
+(claude), **1.3s** (codex), **1.2s** (copilot), against 64s before. Pasting the
+marker as a prompt on the same live claude session goes *working* → *waiting_input*
+and never `turn_aborted`.
+
+Two things worth knowing before re-running that verification. Codex 0.146.0 on
+`gpt-5.6-sol` interrupts on **Ctrl+C**, not ESC — ESC is consumed by the composer,
+and a probe that sends it watches codex finish the turn and concludes, wrongly,
+that detection is broken. And copilot's discovery matches on the cwd it *resolved*,
+so a session launched under `/tmp` (a symlink to `/private/tmp` on macOS) found no
+transcript at all until `FindCopilotTranscript` was taught to compare through
+symlinks the way the codex finder already did. That one is not cosmetic: copilot
+has no heartbeat, so a transcript it cannot find leaves the session at *launching*
+for its whole life.
+
+#### Not every abort is a halt, and not every halt is this session's
+
+Three ways the naive reading of those lines is wrong, all measured:
+
+- **The marker is text a user can type.** Claude writes an interrupt as a lone
+  text *block* in an entry carrying none of `promptSource` / `origin` /
+  `permissionMode`; a prompt the user submitted is a *string* stamped with them.
+  Without both guards, pasting the marker settles the session you are talking to.
+  Halting at a tool-use prompt writes the marker with no `interruptedMessageId`
+  at all, so the field cannot be the only signal either.
+- **Codex `turn_aborted` covers four reasons.** The enum in the 0.146.0 binary
+  carries `interrupted`, `replaced`, `review_ended`, and `budget_limited`. Only
+  the first is a user halt — `replaced` means another turn took over, and the
+  session is working again a moment later. (378 real `turn_aborted` events in
+  `~/.codex/sessions` here are all `interrupted`; the others are rarer, not
+  absent.)
+- **The watcher re-reads history routinely.** It rewinds a bootstrap window
+  (256KB, 512KB for copilot) behind the end of the file at discovery, and starts
+  over at offset zero whenever a transcript shrinks. A codex session resumed onto
+  an existing rollout therefore replays old halts. Every agent dates its lines, so
+  the halt is dated by the agent and dropped if it predates the session; an
+  undated halt is dropped outright, because it cannot be told from history.
+  Dating it by the agent rather than the read also settles the 500ms-poll race
+  with the next prompt: a halt the user has already typed past is outranked by the
+  busy frames that follow it.
+
+#### The heartbeat cannot stand in for the transcript
+
+Worth recording because it is the obvious fallback for an agent whose transcript
+attn cannot find. Measured on claude 2.1.220 through a real PTY, watching OSC 0:
+
+```text
+halt, no tool:   28.80s ESC        → 28.86s "✳ Write typewriter history essay" → silence
+60s foreground:  11.23s tool start → 19.99s "✳ Run sleep command for 60 seconds" → silence 64s
+```
+
+A halted turn and a blocking tool call are the same frames in the same order: the
+not-busy glyph carrying the task description, then nothing. No silence threshold
+separates them, which is why `StaleAfter` is sized to the longest tool call and
+why nothing shorter can be layered underneath it. The transcript is the only
+signal.
+
 ## Spike results (2026-07-25)
 
 Throwaway spike in `internal/pty/spike_state_replay_test.go` and

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -44,16 +44,20 @@ func (c *Codex) ResolveExecutable(configured string) string {
 }
 
 func (c *Codex) Capabilities() Capabilities {
-	// Transcripts remain needed for Stop-hook classification; live state is hook-owned.
+	// Transcripts remain needed for Stop-hook classification; live state is
+	// hook-owned. The watcher is on for the one fact the hooks never report — a
+	// turn the user halted, which codex records as `turn_aborted` — and its
+	// behavior deliberately does nothing else.
 	return Capabilities{
-		HasHooks:            true,
-		HasTranscript:       true,
-		HasClassifier:       true,
-		HarnessSignals:      HarnessSignalsCodex,
-		HasResume:           true,
-		HasYolo:             true,
-		HasInitialPrompt:    true,
-		HasWorkspaceContext: true,
+		HasHooks:             true,
+		HasTranscript:        true,
+		HasTranscriptWatcher: true,
+		HasClassifier:        true,
+		HarnessSignals:       HarnessSignalsCodex,
+		HasResume:            true,
+		HasYolo:              true,
+		HasInitialPrompt:     true,
+		HasWorkspaceContext:  true,
 		// HasSelfMonitor: false — Codex has no live ticket Monitor. It still uses
 		// the shared daemon nudge for unread ticket activity.
 		HasModelPin:  true,
@@ -474,6 +478,10 @@ func (c *Codex) ResumeAvailable(resumeID string) bool {
 
 func (c *Codex) BootstrapBytes() int64 {
 	return 256 * 1024
+}
+
+func (c *Codex) NewTranscriptWatcherBehavior() TranscriptWatcherBehavior {
+	return &codexTranscriptWatcherBehavior{}
 }
 
 func (c *Codex) RecoveredRunningState(ptyState string) protocol.SessionState {

--- a/internal/agent/transcript_watcher_behavior.go
+++ b/internal/agent/transcript_watcher_behavior.go
@@ -63,6 +63,15 @@ type WatcherLineResult struct {
 	Aborted     bool
 	AbortDetail string
 	AbortAt     time.Time
+
+	// BracketClosed: the turn this watcher was tracking is over, with nothing to
+	// say about how it ended. Clearing the behavior's own flag is not enough for
+	// an agent whose bracket the watcher opened in the first place — the evidence
+	// bracket outlives it, and for an agent with no heartbeat nothing retires a
+	// bracket except the stuck timer. Distinct from Aborted, which also closes the
+	// brackets but files a halt the resolver can report; and from State, which
+	// asserts what the session is doing now.
+	BracketClosed bool
 }
 
 // WatcherTickResult captures periodic watcher actions on each poll.
@@ -232,13 +241,19 @@ func (b *copilotTranscriptWatcherBehavior) HandleLine(line []byte, now time.Time
 	// without this the bracket below stays open and Tick pins the session working
 	// for the rest of its life. The bracket closes for every abort; only the user's
 	// own settles the session.
+	//
+	// Closing it means closing both: this watcher's flag and the evidence bracket
+	// the same `assistant.turn_start` opened through Tick. Copilot paints no
+	// heartbeat, so an evidence bracket nothing retires is not held for StaleAfter
+	// — it is held until the stuck timer, and the session reports `unknown`.
 	if abort, ok := transcript.CopilotTurnAborted(line); ok {
 		b.turnOpen = false
 		b.pendingTools = make(map[string]copilotPendingTool)
 		b.transcriptPendingLive = false
 		if !abort.UserHalt {
 			return WatcherLineResult{
-				Log: fmt.Sprintf("transcript watcher: copilot turn aborted without a user halt reason=%s", abort.Reason),
+				BracketClosed: true,
+				Log:           fmt.Sprintf("transcript watcher: copilot turn aborted without a user halt reason=%s", abort.Reason),
 			}
 		}
 		return WatcherLineResult{

--- a/internal/agent/transcript_watcher_behavior.go
+++ b/internal/agent/transcript_watcher_behavior.go
@@ -53,6 +53,16 @@ type TranscriptWatcherBehavior interface {
 type WatcherLineResult struct {
 	State string
 	Log   string
+
+	// Aborted: the line records the user halting the turn. Separate from State
+	// because it is not a state the watcher is asking for — it is a fact about the
+	// turn, which the resolver weighs against everything else it knows. AbortDetail
+	// carries what the agent said about it, for the diagnosis, and AbortAt when the
+	// agent says it happened — the watcher re-reads history often enough that an
+	// undated halt cannot be told from one that just occurred.
+	Aborted     bool
+	AbortDetail string
+	AbortAt     time.Time
 }
 
 // WatcherTickResult captures periodic watcher actions on each poll.
@@ -97,6 +107,14 @@ type claudeTranscriptWatcherBehavior struct{}
 func (b *claudeTranscriptWatcherBehavior) Reset() {}
 
 func (b *claudeTranscriptWatcherBehavior) HandleLine(line []byte, now time.Time, sessionState protocol.SessionState) WatcherLineResult {
+	if abort, ok := transcript.ClaudeTurnAborted(line); ok {
+		return WatcherLineResult{
+			Aborted:     true,
+			AbortDetail: abort.Reason,
+			AbortAt:     abort.At,
+			Log:         "transcript watcher: claude turn aborted by user",
+		}
+	}
 	return WatcherLineResult{}
 }
 
@@ -138,6 +156,56 @@ func (b *claudeTranscriptWatcherBehavior) SkipClassification(sessionState protoc
 	return false, ""
 }
 
+// --- Codex behavior ---
+
+// Codex runs the watcher for one reason: an aborted turn is the only thing its
+// hooks do not report. Everything else about a codex session is hook-owned and
+// already arbitrated by the resolver, so this behavior asks for no states, keeps
+// no lifecycle of its own, and — unlike claude, whose watcher predates the hook
+// path and still classifies when hooks go stale — never classifies. A second
+// classification driver would be racing the Stop hook's verdict to describe the
+// same turn.
+type codexTranscriptWatcherBehavior struct{}
+
+func (b *codexTranscriptWatcherBehavior) Reset() {}
+
+func (b *codexTranscriptWatcherBehavior) HandleLine(line []byte, now time.Time, sessionState protocol.SessionState) WatcherLineResult {
+	abort, ok := transcript.CodexTurnAborted(line)
+	if !ok {
+		return WatcherLineResult{}
+	}
+	if !abort.UserHalt {
+		// Codex owns its own state through hooks; a turn it abandoned for its own
+		// reasons is already described there, and `replaced` in particular is
+		// followed straight away by the turn that replaced it.
+		return WatcherLineResult{
+			Log: fmt.Sprintf("transcript watcher: codex turn aborted without a user halt reason=%s", abort.Reason),
+		}
+	}
+	return WatcherLineResult{
+		Aborted:     true,
+		AbortDetail: abort.Reason,
+		AbortAt:     abort.At,
+		Log:         fmt.Sprintf("transcript watcher: codex turn aborted reason=%s", abort.Reason),
+	}
+}
+
+func (b *codexTranscriptWatcherBehavior) HandleAssistantMessage(now time.Time) {}
+
+func (b *codexTranscriptWatcherBehavior) DeduplicateAssistantEvents() bool { return true }
+
+func (b *codexTranscriptWatcherBehavior) QuietSince(lastAssistantAt time.Time) time.Time {
+	return lastAssistantAt
+}
+
+func (b *codexTranscriptWatcherBehavior) Tick(now time.Time, sessionState protocol.SessionState) WatcherTickResult {
+	return WatcherTickResult{}
+}
+
+func (b *codexTranscriptWatcherBehavior) SkipClassification(sessionState protocol.SessionState, lastSeen string, now time.Time) (bool, string) {
+	return true, "transcript watcher: skipping classification, codex classification is hook-owned"
+}
+
 // --- Copilot behavior ---
 
 type copilotPendingTool struct {
@@ -158,6 +226,29 @@ func (b *copilotTranscriptWatcherBehavior) Reset() {
 }
 
 func (b *copilotTranscriptWatcherBehavior) HandleLine(line []byte, now time.Time, sessionState protocol.SessionState) WatcherLineResult {
+	// An abort is the one turn ending copilot does not follow with
+	// `assistant.turn_end`. Measured on copilot 1.0.77: halting mid-reply writes
+	// `{"type":"abort","data":{"reason":"user_initiated"}}` and nothing else, so
+	// without this the bracket below stays open and Tick pins the session working
+	// for the rest of its life. The bracket closes for every abort; only the user's
+	// own settles the session.
+	if abort, ok := transcript.CopilotTurnAborted(line); ok {
+		b.turnOpen = false
+		b.pendingTools = make(map[string]copilotPendingTool)
+		b.transcriptPendingLive = false
+		if !abort.UserHalt {
+			return WatcherLineResult{
+				Log: fmt.Sprintf("transcript watcher: copilot turn aborted without a user halt reason=%s", abort.Reason),
+			}
+		}
+		return WatcherLineResult{
+			Aborted:     true,
+			AbortDetail: abort.Reason,
+			AbortAt:     abort.At,
+			Log:         fmt.Sprintf("transcript watcher: copilot turn aborted reason=%s", abort.Reason),
+		}
+	}
+
 	switch extractTranscriptEventType(line) {
 	case "assistant.turn_start":
 		b.turnOpen = true

--- a/internal/agent/transcript_watcher_behavior_test.go
+++ b/internal/agent/transcript_watcher_behavior_test.go
@@ -138,3 +138,133 @@ func TestClaudeWatcherBehaviorSkipClassification(t *testing.T) {
 		t.Fatal("should skip with legacy RFC3339 timestamp that is still recent")
 	}
 }
+
+// Every watched agent runs the watcher for the same single reason: a turn the
+// user halted is the one ending none of them report through any other channel.
+func TestWatcherBehaviorsDetectAHaltedTurn(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		behavior   TranscriptWatcherBehavior
+		abort      string
+		wantDetail string
+		wantAt     string
+		ignored    string
+		// notAHalt ends a turn for the agent's own reasons. It must not settle the
+		// session: the session is often working again a moment later.
+		notAHalt string
+	}{
+		{
+			name:       "claude",
+			behavior:   &claudeTranscriptWatcherBehavior{},
+			abort:      `{"type":"user","message":{"role":"user","content":"[Request interrupted by user]"},"interruptedMessageId":"msg_01","timestamp":"2026-08-01T22:08:15.284Z"}`,
+			wantDetail: "[Request interrupted by user]",
+			wantAt:     "2026-08-01T22:08:15.284Z",
+			ignored:    `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"working on it"}]}}`,
+		},
+		{
+			name:       "codex",
+			behavior:   &codexTranscriptWatcherBehavior{},
+			abort:      `{"type":"event_msg","timestamp":"2026-08-01T21:58:33.937Z","payload":{"type":"turn_aborted","reason":"interrupted"}}`,
+			wantDetail: "interrupted",
+			wantAt:     "2026-08-01T21:58:33.937Z",
+			ignored:    `{"type":"event_msg","payload":{"type":"task_complete","turn_id":"019f"}}`,
+			notAHalt:   `{"type":"event_msg","payload":{"type":"turn_aborted","reason":"replaced"}}`,
+		},
+		{
+			name:       "copilot",
+			behavior:   newCopilotBehavior(),
+			abort:      `{"type":"abort","timestamp":"2026-08-02T08:52:00.344Z","data":{"reason":"user_initiated"}}`,
+			wantDetail: "user_initiated",
+			wantAt:     "2026-08-02T08:52:00.344Z",
+			ignored:    `{"type":"assistant.message","data":{"content":"working on it"}}`,
+			notAHalt:   `{"type":"abort","data":{"reason":"tool_failure"}}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.behavior.HandleLine([]byte(tc.abort), time.Now(), protocol.SessionStateWorking)
+			if !got.Aborted || got.AbortDetail != tc.wantDetail {
+				t.Fatalf("got %+v, want the halt reported with detail %q", got, tc.wantDetail)
+			}
+			// Undated, the halt cannot be told from one replayed out of history, and
+			// the watcher throws it away.
+			if got.AbortAt.UTC().Format(time.RFC3339Nano) != tc.wantAt {
+				t.Fatalf("abort at %s, want %s", got.AbortAt.UTC().Format(time.RFC3339Nano), tc.wantAt)
+			}
+			// The halt is a fact about the turn, not a state request: the resolver
+			// weighs it against everything else, so the behavior must not also be
+			// naming a state.
+			if got.State != "" {
+				t.Fatalf("state %q, want none: the behavior reports the fact, the resolver decides", got.State)
+			}
+			if got := tc.behavior.HandleLine([]byte(tc.ignored), time.Now(), protocol.SessionStateWorking); got.Aborted {
+				t.Fatalf("an ordinary line was read as a halt: %+v", got)
+			}
+			if tc.notAHalt == "" {
+				return
+			}
+			if got := tc.behavior.HandleLine([]byte(tc.notAHalt), time.Now(), protocol.SessionStateWorking); got.Aborted {
+				t.Fatalf("a turn the agent ended on its own was read as a user halt: %+v", got)
+			}
+		})
+	}
+}
+
+func newCopilotBehavior() TranscriptWatcherBehavior {
+	b := &copilotTranscriptWatcherBehavior{}
+	b.Reset()
+	return b
+}
+
+// Copilot writes no assistant.turn_end after an abort. Its watcher keeps the turn
+// bracket itself, so the abort has to close it — otherwise Tick pins the session
+// working for the rest of the session's life, whoever caused the abort.
+func TestCopilotAbortClosesTheTurnBracket(t *testing.T) {
+	for _, abort := range []string{
+		`{"type":"abort","data":{"reason":"user_initiated"}}`,
+		`{"type":"abort","data":{"reason":"tool_failure"}}`,
+	} {
+		t.Run(abort, func(t *testing.T) {
+			b := &copilotTranscriptWatcherBehavior{}
+			b.Reset()
+
+			now := time.Now()
+			b.HandleLine([]byte(`{"type":"assistant.turn_start","data":{"turnId":"0"}}`), now, protocol.SessionStateWorking)
+			b.HandleLine([]byte(`{"type":"tool.execution_start","data":{"toolCallId":"call_1","toolName":"bash"}}`), now, protocol.SessionStateWorking)
+			if tick := b.Tick(now.Add(2*time.Second), protocol.SessionStateWorking); !tick.BlockClassification {
+				t.Fatal("an open copilot turn should block classification")
+			}
+
+			b.HandleLine([]byte(abort), now.Add(3*time.Second), protocol.SessionStateWorking)
+
+			tick := b.Tick(now.Add(4*time.Second), protocol.SessionStateWorking)
+			if tick.BlockClassification {
+				t.Fatal("the aborted turn is still pinning the session working")
+			}
+			if tick.State != "" {
+				t.Fatalf("state %q, want none after an abort", tick.State)
+			}
+		})
+	}
+}
+
+// Codex must not pick up the default behavior: that one classifies on the quiet
+// window, which would race the Stop hook's verdict on the same turn.
+func TestCodexWatcherNeverClassifies(t *testing.T) {
+	behavior, ok := GetTranscriptWatcherBehavior(Get("codex"))
+	if !ok {
+		t.Fatal("codex has no watcher behavior; its halted turns would go unseen")
+	}
+	if _, isCodex := behavior.(*codexTranscriptWatcherBehavior); !isCodex {
+		t.Fatalf("codex got %T, want its own behavior", behavior)
+	}
+	for _, state := range []protocol.SessionState{
+		protocol.SessionStateIdle,
+		protocol.SessionStateWorking,
+		protocol.SessionStateWaitingInput,
+	} {
+		skip, reason := behavior.SkipClassification(state, "", time.Now())
+		if !skip {
+			t.Fatalf("codex would classify from state %q (%s); classification is hook-owned", state, reason)
+		}
+	}
+}

--- a/internal/agent/transcript_watcher_behavior_test.go
+++ b/internal/agent/transcript_watcher_behavior_test.go
@@ -234,7 +234,15 @@ func TestCopilotAbortClosesTheTurnBracket(t *testing.T) {
 				t.Fatal("an open copilot turn should block classification")
 			}
 
-			b.HandleLine([]byte(abort), now.Add(3*time.Second), protocol.SessionStateWorking)
+			got := b.HandleLine([]byte(abort), now.Add(3*time.Second), protocol.SessionStateWorking)
+
+			// Closing the flag below is only half of it. The same turn_start opened
+			// an evidence bracket through Tick, and the result is the only way to
+			// reach it — copilot paints no heartbeat, so a bracket left open there
+			// outlives the stale test and runs the session into `stuck`.
+			if !got.Aborted && !got.BracketClosed {
+				t.Fatalf("got %+v, want the evidence bracket closed: nothing else closes it", got)
+			}
 
 			tick := b.Tick(now.Add(4*time.Second), protocol.SessionStateWorking)
 			if tick.BlockClassification {

--- a/internal/daemon/session_evidence.go
+++ b/internal/daemon/session_evidence.go
@@ -315,6 +315,25 @@ func (d *Daemon) recordTurnAbortedEvidence(sessionID, detail string, abortedAt, 
 	})
 }
 
+// recordTurnBracketClosedEvidence closes the brackets and says nothing else.
+//
+// It exists for the turn that ended in a way nobody needs reported: copilot
+// abandoning a turn for its own reasons, where filing a halt would put a user
+// action in the diagnosis that no user took, and asserting a state would guess at
+// what the session is doing before the classifier has looked. Closing the
+// brackets on their own is the whole true statement — the turn they described is
+// over — and it leaves the settle to the same quiet-window classification that
+// ends every other copilot turn.
+func (d *Daemon) recordTurnBracketClosedEvidence(sessionID string, at time.Time) {
+	if at.IsZero() {
+		at = time.Now()
+	}
+	d.recordEvidence(sessionID, at, func(e *sessionstate.Evidence) {
+		e.TurnOpen = false
+		e.ToolOpen = false
+	})
+}
+
 // recordClassifierEvidence files a stop-time verdict.
 func (d *Daemon) recordClassifierEvidence(sessionID, state string, observedAt time.Time) {
 	if observedAt.IsZero() {

--- a/internal/daemon/session_evidence.go
+++ b/internal/daemon/session_evidence.go
@@ -213,7 +213,10 @@ func (d *Daemon) recordBracketEvidence(sessionID, state string) {
 			// the user picks an option.
 			if e.LastHarnessEvent != nil {
 				switch e.LastHarnessEvent.Claim {
-				case sessionstate.ClaimApprovalPending, sessionstate.ClaimNeedsInput, sessionstate.ClaimStopFailed:
+				case sessionstate.ClaimApprovalPending,
+					sessionstate.ClaimNeedsInput,
+					sessionstate.ClaimStopFailed,
+					sessionstate.ClaimTurnAborted:
 					e.LastHarnessEvent = nil
 				}
 			}
@@ -276,6 +279,39 @@ func (d *Daemon) recordTranscriptEvidence(sessionID, state, detail string, at ti
 		stateOrigin{source: stateSourceTranscript, detail: detail, observedAt: at},
 		state,
 	)
+}
+
+// recordTurnAbortedEvidence files the transcript's record that the user halted
+// the turn.
+//
+// The brackets are closed here as well as the edge filed, because the two expire
+// differently: the edge is retired by the next turn, while a bracket left open
+// would outlive it and resolve as a session stuck mid-turn. Closing them says the
+// true thing anyway — the turn this bracket described is over.
+// abortedAt is when the agent says the halt happened and observedAt is when attn
+// read it. They are recorded separately on purpose: the observation is dated by
+// the agent, so a halt read late — out of a replayed transcript, or behind a poll
+// the user has already typed past — is outranked by every busy frame that came
+// after it, while the table's movement clock still advances to now so a late read
+// cannot make a live session look stuck.
+func (d *Daemon) recordTurnAbortedEvidence(sessionID, detail string, abortedAt, observedAt time.Time) {
+	if observedAt.IsZero() {
+		observedAt = time.Now()
+	}
+	at := abortedAt
+	if at.IsZero() {
+		at = observedAt
+	}
+	d.recordEvidence(sessionID, observedAt, func(e *sessionstate.Evidence) {
+		e.TurnOpen = false
+		e.ToolOpen = false
+		e.LastHarnessEvent = &sessionstate.Observation{
+			Source:     sessionstate.SourceHarnessEvent,
+			Claim:      sessionstate.ClaimTurnAborted,
+			Detail:     detail,
+			ObservedAt: at,
+		}
+	})
 }
 
 // recordClassifierEvidence files a stop-time verdict.

--- a/internal/daemon/transcript_watcher.go
+++ b/internal/daemon/transcript_watcher.go
@@ -289,6 +289,9 @@ func (d *Daemon) runTranscriptWatcher(w *transcriptWatcher) {
 						classifiedSeq = assistantSeq
 					}
 				}
+				if lineResult.BracketClosed {
+					d.recordTurnBracketClosedEvidence(w.sessionID, now)
+				}
 				if lineResult.State != "" && protocol.SessionState(lineResult.State) != sessionState {
 					d.recordTranscriptEvidence(w.sessionID, lineResult.State, "transcript line", now)
 					sessionState = protocol.SessionState(lineResult.State)

--- a/internal/daemon/transcript_watcher.go
+++ b/internal/daemon/transcript_watcher.go
@@ -15,7 +15,32 @@ const (
 	transcriptPollInterval = 500 * time.Millisecond
 	transcriptQuietWindow  = 1500 * time.Millisecond
 	assistantDedupWindow   = 2 * time.Second
+
+	// Discovery is a directory walk — codex and copilot search their whole session
+	// tree, thousands of files on a working machine — and it repeats every poll
+	// until it lands. A session that never gets a transcript (one parked at a trust
+	// prompt, one whose agent writes nowhere we look) would otherwise walk that
+	// tree twice a second for as long as it lives. Fast while a transcript is
+	// plausibly still being created, then slow, because after a minute it is not
+	// arriving in the next half second either.
+	transcriptDiscoveryFastAttempts = 20
+	transcriptDiscoverySlowAttempts = 40
+	transcriptDiscoverySlowInterval = 2 * time.Second
+	transcriptDiscoveryIdleInterval = 5 * time.Second
 )
+
+// transcriptDiscoveryDelay is how long to wait before the next discovery attempt
+// after `attempts` have failed. Zero means the next poll.
+func transcriptDiscoveryDelay(attempts int) time.Duration {
+	switch {
+	case attempts < transcriptDiscoveryFastAttempts:
+		return 0
+	case attempts < transcriptDiscoverySlowAttempts:
+		return transcriptDiscoverySlowInterval
+	default:
+		return transcriptDiscoveryIdleInterval
+	}
+}
 
 type transcriptWatcher struct {
 	sessionID string
@@ -146,7 +171,9 @@ func (d *Daemon) runTranscriptWatcher(w *transcriptWatcher) {
 		assistantSeq    int64
 		classifiedSeq   int64
 
-		lastDiscoveryLog time.Time
+		lastDiscoveryLog  time.Time
+		discoveryAttempts int
+		nextDiscoveryAt   time.Time
 	)
 
 	for {
@@ -169,14 +196,21 @@ func (d *Daemon) runTranscriptWatcher(w *transcriptWatcher) {
 		sessionState := session.State
 
 		if transcriptPath == "" {
+			if !nextDiscoveryAt.IsZero() && time.Now().Before(nextDiscoveryAt) {
+				continue
+			}
 			transcriptPath = d.findTranscriptPathForWatcher(w)
 			if transcriptPath == "" {
+				discoveryAttempts++
+				nextDiscoveryAt = time.Now().Add(transcriptDiscoveryDelay(discoveryAttempts))
 				if time.Since(lastDiscoveryLog) >= 5*time.Second {
-					d.logf("transcript watcher: waiting for transcript session=%s agent=%s cwd=%s", w.sessionID, w.agent, w.cwd)
+					d.logf("transcript watcher: waiting for transcript session=%s agent=%s cwd=%s attempts=%d", w.sessionID, w.agent, w.cwd, discoveryAttempts)
 					lastDiscoveryLog = time.Now()
 				}
 				continue
 			}
+			discoveryAttempts = 0
+			nextDiscoveryAt = time.Time{}
 			info, err := os.Stat(transcriptPath)
 			if err != nil {
 				d.logf("transcript watcher: transcript stat failed session=%s path=%s err=%v", w.sessionID, transcriptPath, err)
@@ -242,6 +276,18 @@ func (d *Daemon) runTranscriptWatcher(w *transcriptWatcher) {
 				lineResult := w.behavior.HandleLine([]byte(line), now, sessionState)
 				if lineResult.Log != "" {
 					d.logf("%s session=%s", lineResult.Log, w.sessionID)
+				}
+				if lineResult.Aborted {
+					if skip, reason := staleTranscriptAbort(lineResult.AbortAt, w.startedAt); skip {
+						d.logf("transcript watcher: ignoring turn abort session=%s reason=%s abort_at=%s", w.sessionID, reason, lineResult.AbortAt.Format(time.RFC3339Nano))
+					} else {
+						d.recordTurnAbortedEvidence(w.sessionID, lineResult.AbortDetail, lineResult.AbortAt, now)
+						// The halted turn has nothing to classify: what it left on record is
+						// a truncated fragment, and a verdict drawn from that describes a
+						// question the agent never finished asking. Marking the sequence
+						// consumed is what keeps the quiet window below from picking it up.
+						classifiedSeq = assistantSeq
+					}
 				}
 				if lineResult.State != "" && protocol.SessionState(lineResult.State) != sessionState {
 					d.recordTranscriptEvidence(w.sessionID, lineResult.State, "transcript line", now)
@@ -315,6 +361,27 @@ func (d *Daemon) runTranscriptWatcher(w *transcriptWatcher) {
 			go d.classifySessionState(w.sessionID, transcriptPath)
 		}
 	}
+}
+
+// staleTranscriptAbort decides whether a halt read out of the transcript
+// describes this session's life or someone else's.
+//
+// The watcher re-reads history as a matter of course: it rewinds up to a
+// bootstrap window behind the end of the file at discovery, and starts over at
+// offset zero whenever a transcript shrinks. A codex session resumed onto an
+// existing rollout, or a claude transcript rewritten in place, therefore replays
+// old lines — and a halt among them, filed as if it had just happened, settles a
+// session that is working. Dating the halt is what tells the two apart, so a halt
+// that cannot be dated is not believed at all: losing the feature loudly beats
+// settling live sessions on the strength of last week's ESC.
+func staleTranscriptAbort(abortAt, sessionStartedAt time.Time) (bool, string) {
+	if abortAt.IsZero() {
+		return true, "undated"
+	}
+	if !sessionStartedAt.IsZero() && abortAt.Before(sessionStartedAt) {
+		return true, "predates session"
+	}
+	return false, ""
 }
 
 func readTranscriptDelta(path string, offset int64) ([]byte, error) {

--- a/internal/daemon/transcript_watcher_abort_test.go
+++ b/internal/daemon/transcript_watcher_abort_test.go
@@ -1,0 +1,353 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/pty"
+	"github.com/victorarias/attn/internal/sessionstate"
+	"github.com/victorarias/attn/internal/toolhome"
+)
+
+// haltedTurnCase is one agent's captured halt, plus whatever its real transcript
+// finder needs in order to find the file.
+type haltedTurnCase struct {
+	name  string
+	agent protocol.SessionAgent
+	// seed writes the transcript the watcher must discover, and returns its path.
+	// Discovery is per-agent — claude names the file after the session id it was
+	// launched with, codex and copilot are found by cwd and start time — so the
+	// fixture has to satisfy the real finder.
+	seed func(t *testing.T, home, dir, sessionID string) string
+	// abort is the captured line each agent writes when the user hits ESC, dated
+	// at `at`. The date is part of the contract: an undated halt is thrown away.
+	abort func(at time.Time) string
+}
+
+func haltedTurnCases() []haltedTurnCase {
+	return []haltedTurnCase{
+		{
+			name:  "claude",
+			agent: protocol.SessionAgentClaude,
+			seed: func(t *testing.T, home, dir, sessionID string) string {
+				projects := filepath.Join(home, ".claude", "projects", "a-project")
+				if err := os.MkdirAll(projects, 0o755); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				path := filepath.Join(projects, sessionID+".jsonl")
+				writeLine(t, path, `{"type":"user","message":{"role":"user","content":"write an essay"}}`)
+				return path
+			},
+			abort: func(at time.Time) string {
+				return fmt.Sprintf(
+					`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user]"}]},"interruptedMessageId":"msg_011Cdcnp6M5nmsdZuTzGRmaF","timestamp":%q}`,
+					at.UTC().Format(time.RFC3339Nano),
+				)
+			},
+		},
+		{
+			name:  "codex",
+			agent: protocol.SessionAgentCodex,
+			seed: func(t *testing.T, home, dir, sessionID string) string {
+				sessions := filepath.Join(home, ".codex", "sessions", "2026", "08", "01")
+				if err := os.MkdirAll(sessions, 0o755); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				path := filepath.Join(sessions, "rollout-"+sessionID+".jsonl")
+				stamp := time.Now().UTC().Format(time.RFC3339Nano)
+				writeLine(t, path, fmt.Sprintf(
+					`{"timestamp":%q,"type":"session_meta","payload":{"id":%q,"cwd":%q,"timestamp":%q}}`,
+					stamp, sessionID, dir, stamp,
+				))
+				return path
+			},
+			abort: func(at time.Time) string {
+				return fmt.Sprintf(
+					`{"timestamp":%q,"type":"event_msg","payload":{"type":"turn_aborted","turn_id":"019fbf55-ef48","reason":"interrupted"}}`,
+					at.UTC().Format(time.RFC3339Nano),
+				)
+			},
+		},
+		{
+			name:  "copilot",
+			agent: protocol.SessionAgentCopilot,
+			seed: func(t *testing.T, home, dir, sessionID string) string {
+				state := filepath.Join(home, ".copilot", "session-state", sessionID)
+				if err := os.MkdirAll(state, 0o755); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(state, "workspace.yaml"), []byte("cwd: "+dir+"\n"), 0o644); err != nil {
+					t.Fatalf("write workspace.yaml: %v", err)
+				}
+				path := filepath.Join(state, "events.jsonl")
+				writeLine(t, path, fmt.Sprintf(
+					`{"type":"session.start","data":{"sessionId":%q,"startTime":%q}}`,
+					sessionID, time.Now().UTC().Format(time.RFC3339Nano),
+				))
+				writeLine(t, path, `{"type":"assistant.turn_start","data":{"turnId":"0"}}`)
+				return path
+			},
+			abort: func(at time.Time) string {
+				return fmt.Sprintf(
+					`{"type":"abort","timestamp":%q,"data":{"reason":"user_initiated"}}`,
+					at.UTC().Format(time.RFC3339Nano),
+				)
+			},
+		},
+	}
+}
+
+// Halting a turn is the one ending no agent reports. Measured live: claude
+// 2.1.220 with all 31 of its hook events wired to a logger, codex 0.146.0 with
+// attn's own trusted-hash hook overrides, and copilot 1.0.77 — all interrupted
+// with ESC mid-turn, and none of them produce a Stop, a StopFailure, a
+// Notification, or anything else, for as long as you wait. What each does write,
+// in the same second, is a line in its transcript, so that is what the watcher
+// reads.
+//
+// These drive the real watcher against a real file rather than calling the
+// parser directly: discovery, tailing, the per-agent behavior, and the evidence
+// write are one path, and the bug this fixes lived in the fact that nothing
+// connected them.
+func TestTheWatcherSettlesATurnTheUserHalted(t *testing.T) {
+	for _, tc := range haltedTurnCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(toolhome.EnvVar, t.TempDir())
+			home, _ := toolhome.Dir()
+
+			d := newTraceDaemon(t)
+			id := "sess-halted-" + tc.name
+			addCharacterizationSession(t, d, id, tc.agent, protocol.SessionStateWorking)
+			session := d.store.Get(id)
+
+			// The turn the user is about to halt. Its closing hook is the one that
+			// never arrives.
+			d.recordBracketEvidence(id, protocol.StateWorking)
+
+			startedAt := time.Now()
+			path := tc.seed(t, home, session.Directory, id)
+			d.startTranscriptWatcher(id, tc.agent, session.Directory, startedAt)
+			t.Cleanup(func() { d.stopTranscriptWatcher(id) })
+
+			// Let the watcher find the file before the abort lands, so the test
+			// exercises the tail rather than the bootstrap read.
+			waitForTranscriptDiscovery(t, d, id)
+			writeLine(t, path, tc.abort(time.Now()))
+
+			evidence := waitForAbortEvidence(t, d, id)
+			if evidence.TurnOpen || evidence.ToolOpen {
+				t.Fatalf("the halted turn left a bracket open: %+v", evidence)
+			}
+
+			d.resolveAllSessions(time.Now())
+			if state := d.store.Get(id).State; state != protocol.SessionStateIdle {
+				t.Fatalf("state %q, want idle: a halted turn is over the moment it is halted", state)
+			}
+			if got := sessionstate.Resolve(evidence, sessionstate.PolicyFor(string(tc.agent)), time.Now()); got.Reason != sessionstate.ReasonTurnAborted {
+				t.Fatalf("reason %q, want turn_aborted: the diagnosis is half the point", got.Reason)
+			}
+		})
+	}
+}
+
+// The watcher re-reads history as a matter of course — it rewinds a bootstrap
+// window behind the end of the file the moment it discovers one, and starts over
+// at offset zero whenever a transcript shrinks. A codex session resumed onto an
+// existing rollout replays every halt in that window. None of them are this
+// session's, and filing one settles a session that is working right now.
+func TestAHaltFromBeforeTheSessionStartedIsIgnored(t *testing.T) {
+	for _, tc := range haltedTurnCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(toolhome.EnvVar, t.TempDir())
+			home, _ := toolhome.Dir()
+
+			d := newTraceDaemon(t)
+			id := "sess-replayed-halt-" + tc.name
+			addCharacterizationSession(t, d, id, tc.agent, protocol.SessionStateWorking)
+			session := d.store.Get(id)
+			d.recordBracketEvidence(id, protocol.StateWorking)
+
+			// The transcript already holds a halt from an earlier life, and the
+			// watcher starts after it — exactly what a resume looks like.
+			startedAt := time.Now()
+			path := tc.seed(t, home, session.Directory, id)
+			writeLine(t, path, tc.abort(startedAt.Add(-2*time.Hour)))
+
+			d.startTranscriptWatcher(id, tc.agent, session.Directory, startedAt)
+			t.Cleanup(func() { d.stopTranscriptWatcher(id) })
+			waitForTranscriptDiscovery(t, d, id)
+
+			// Long enough for several polls to have read the bootstrap window.
+			time.Sleep(4 * transcriptPollInterval)
+
+			got, ok := d.evidenceTable().snapshot(id)
+			if !ok {
+				t.Fatal("no evidence recorded")
+			}
+			if got.LastHarnessEvent != nil && got.LastHarnessEvent.Claim == sessionstate.ClaimTurnAborted {
+				t.Fatal("a halt replayed out of history settled a session that is working")
+			}
+			if !got.TurnOpen {
+				t.Fatal("the open turn was closed by a halt from a previous session")
+			}
+		})
+	}
+}
+
+// An undated halt cannot be told from one replayed out of history, so it is not
+// believed. Every agent attn watches dates its lines; losing the feature loudly
+// on a format that stops doing so beats settling live sessions on last week's ESC.
+func TestAnUndatedHaltIsIgnored(t *testing.T) {
+	t.Setenv(toolhome.EnvVar, t.TempDir())
+	home, _ := toolhome.Dir()
+
+	d := newTraceDaemon(t)
+	id := "sess-undated-halt"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+	session := d.store.Get(id)
+	d.recordBracketEvidence(id, protocol.StateWorking)
+
+	projects := filepath.Join(home, ".claude", "projects", "a-project")
+	if err := os.MkdirAll(projects, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(projects, id+".jsonl")
+	writeLine(t, path, `{"type":"user","message":{"role":"user","content":"write an essay"}}`)
+
+	d.startTranscriptWatcher(id, protocol.SessionAgentClaude, session.Directory, time.Now())
+	t.Cleanup(func() { d.stopTranscriptWatcher(id) })
+	waitForTranscriptDiscovery(t, d, id)
+
+	writeLine(t, path, `{"type":"user","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user]"}]},"interruptedMessageId":"msg_01"}`)
+	time.Sleep(4 * transcriptPollInterval)
+
+	got, ok := d.evidenceTable().snapshot(id)
+	if !ok {
+		t.Fatal("no evidence recorded")
+	}
+	if got.LastHarnessEvent != nil && got.LastHarnessEvent.Claim == sessionstate.ClaimTurnAborted {
+		t.Fatal("an undated halt was filed as though it had just happened")
+	}
+}
+
+// The halt is dated by the agent, not by the poll that read it. Half a second of
+// polling is long enough for the user to have typed again, and a halt filed with
+// the read time outranks the busy frames of the turn that followed it.
+func TestAHaltIsDatedByTheAgentNotTheRead(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-halt-dating"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+
+	halted := time.Now().Add(-3 * time.Second)
+	d.recordTurnAbortedEvidence(id, "[Request interrupted by user]", halted, time.Now())
+
+	got, ok := d.evidenceTable().snapshot(id)
+	if !ok || got.LastHarnessEvent == nil {
+		t.Fatal("the halt was not recorded")
+	}
+	if !got.LastHarnessEvent.ObservedAt.Equal(halted) {
+		t.Fatalf("observed at %s, want the agent's own %s", got.LastHarnessEvent.ObservedAt, halted)
+	}
+	// The movement clock still has to advance to now, or a halt read out of
+	// history would age the session into `stuck`.
+	if got.LastMovement.Before(halted.Add(time.Second)) {
+		t.Fatalf("last movement %s, want the read time: a late read must not age the session", got.LastMovement)
+	}
+
+	// The user typed again right after halting, and the agent is visibly running.
+	// The halt must not outrank that.
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", At: time.Now()})
+	evidence, _ := d.evidenceTable().snapshot(id)
+	if got := sessionstate.Resolve(evidence, sessionstate.PolicyFor(string(protocol.SessionAgentClaude)), time.Now()); got.Reason == sessionstate.ReasonTurnAborted {
+		t.Fatalf("a halt the agent has already run past still settled the session: %+v", got)
+	}
+}
+
+// A user who quotes the marker back at claude — asking about it, pasting a log —
+// must not settle their own session. The dedicated field is what tells the two
+// apart, and this is the case that would make the fix worse than the bug.
+func TestATranscriptLineThatMerelyMentionsTheMarkerIsNotAHalt(t *testing.T) {
+	t.Setenv(toolhome.EnvVar, t.TempDir())
+	home, _ := toolhome.Dir()
+
+	d := newTraceDaemon(t)
+	id := "sess-marker-mention"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+	session := d.store.Get(id)
+	d.recordBracketEvidence(id, protocol.StateWorking)
+
+	projects := filepath.Join(home, ".claude", "projects", "a-project")
+	if err := os.MkdirAll(projects, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(projects, id+".jsonl")
+	writeLine(t, path, `{"type":"user","message":{"role":"user","content":"why do i see [Request interrupted by user] in my logs?"}}`)
+
+	d.startTranscriptWatcher(id, protocol.SessionAgentClaude, session.Directory, time.Now())
+	t.Cleanup(func() { d.stopTranscriptWatcher(id) })
+	waitForTranscriptDiscovery(t, d, id)
+
+	// Long enough for several polls to have read the line and decided nothing.
+	time.Sleep(4 * transcriptPollInterval)
+
+	got, ok := d.evidenceTable().snapshot(id)
+	if !ok {
+		t.Fatal("no evidence recorded")
+	}
+	if got.LastHarnessEvent != nil && got.LastHarnessEvent.Claim == sessionstate.ClaimTurnAborted {
+		t.Fatal("a prompt that quotes the marker was read as the user halting the turn")
+	}
+	if !got.TurnOpen {
+		t.Fatal("the turn was closed by a line that only talked about interrupts")
+	}
+}
+
+func writeLine(t *testing.T, path, line string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open transcript: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(line + "\n"); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+}
+
+// waitForTranscriptDiscovery blocks until the watcher has adopted a transcript,
+// which is the point from which appended lines are tailed.
+func waitForTranscriptDiscovery(t *testing.T, d *Daemon, sessionID string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		d.watchersMu.Lock()
+		watcher := d.transcriptWatch[sessionID]
+		d.watchersMu.Unlock()
+		if watcher != nil && d.findTranscriptPathForWatcher(watcher) != "" {
+			// One more poll so the watcher itself has adopted it.
+			time.Sleep(3 * transcriptPollInterval)
+			return
+		}
+		time.Sleep(transcriptPollInterval / 2)
+	}
+	t.Fatal("watcher never discovered the transcript")
+}
+
+func waitForAbortEvidence(t *testing.T, d *Daemon, sessionID string) sessionstate.Evidence {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if got, ok := d.evidenceTable().snapshot(sessionID); ok &&
+			got.LastHarnessEvent != nil &&
+			got.LastHarnessEvent.Claim == sessionstate.ClaimTurnAborted {
+			return got
+		}
+		time.Sleep(transcriptPollInterval / 2)
+	}
+	t.Fatal("the halted turn was never filed as evidence")
+	return sessionstate.Evidence{}
+}

--- a/internal/daemon/transcript_watcher_abort_test.go
+++ b/internal/daemon/transcript_watcher_abort_test.go
@@ -267,6 +267,74 @@ func TestAHaltIsDatedByTheAgentNotTheRead(t *testing.T) {
 	}
 }
 
+// Copilot aborts for its own reasons too, and those are not the user halting the
+// turn — but they end it just the same, and the bracket they leave behind is the
+// watcher's own: nothing but this closes it, because copilot's turn_start is what
+// opened it and no `assistant.turn_end` follows an abort.
+//
+// It is not a bracket that expires. Copilot paints no heartbeat, so the resolver's
+// stale test can never retire it — `heartbeatSilentFor` answers "not silent"
+// forever for a session that has nothing to have gone quiet from — and the session
+// runs out the stuck timer and reports `unknown`. So the abort has to say the turn
+// is over, without saying the user did it.
+func TestACopilotAbortNobodyAskedForStillClosesTheTurn(t *testing.T) {
+	t.Setenv(toolhome.EnvVar, t.TempDir())
+	home, _ := toolhome.Dir()
+
+	d := newTraceDaemon(t)
+	id := "sess-copilot-tool-failure"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentCopilot, protocol.SessionStateWorking)
+	session := d.store.Get(id)
+	d.recordBracketEvidence(id, protocol.StateWorking)
+
+	var seed func(t *testing.T, home, dir, sessionID string) string
+	for _, tc := range haltedTurnCases() {
+		if tc.name == "copilot" {
+			seed = tc.seed
+		}
+	}
+	path := seed(t, home, session.Directory, id)
+
+	d.startTranscriptWatcher(id, protocol.SessionAgentCopilot, session.Directory, time.Now())
+	t.Cleanup(func() { d.stopTranscriptWatcher(id) })
+	waitForTranscriptDiscovery(t, d, id)
+
+	writeLine(t, path, fmt.Sprintf(
+		`{"type":"abort","timestamp":%q,"data":{"reason":"tool_failure"}}`,
+		time.Now().UTC().Format(time.RFC3339Nano),
+	))
+
+	got := waitForClosedTurnBracket(t, d, id)
+	if got.LastHarnessEvent != nil && got.LastHarnessEvent.Claim == sessionstate.ClaimTurnAborted {
+		t.Fatal("copilot giving up on its own was filed as the user halting the turn")
+	}
+
+	// The bracket is what pins the session, and for copilot it pins it from the
+	// moment the abort lands: with no heartbeat to go silent, the resolver's stale
+	// test cannot retire the bracket at all, so `bracket_open` holds until the
+	// stuck timer converts it to `unknown`. Settling the turn is the classifier's
+	// job — this only has to prove nothing is still claiming the turn is running.
+	policy := sessionstate.PolicyFor(string(protocol.SessionAgentCopilot))
+	if reason := sessionstate.Resolve(got, policy, time.Now()).Reason; reason == sessionstate.ReasonBracketOpen {
+		t.Fatalf("reason %q: the abandoned turn held the session open", reason)
+	}
+}
+
+// waitForClosedTurnBracket blocks until the watcher has closed the evidence
+// brackets, which for copilot is the only thing that ends an abandoned turn.
+func waitForClosedTurnBracket(t *testing.T, d *Daemon, sessionID string) sessionstate.Evidence {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if got, ok := d.evidenceTable().snapshot(sessionID); ok && !got.TurnOpen && !got.ToolOpen {
+			return got
+		}
+		time.Sleep(transcriptPollInterval / 2)
+	}
+	t.Fatal("the abandoned turn left its bracket open")
+	return sessionstate.Evidence{}
+}
+
 // A user who quotes the marker back at claude — asking about it, pasting a log —
 // must not settle their own session. The dedicated field is what tells the two
 // apart, and this is the case that would make the fix worse than the bug.

--- a/internal/daemon/transcript_watcher_test.go
+++ b/internal/daemon/transcript_watcher_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
 )
@@ -28,11 +29,39 @@ func TestIsTranscriptWatchedAgent(t *testing.T) {
 	if !isTranscriptWatchedAgent(protocol.SessionAgentClaude) {
 		t.Fatal("claude should be transcript-watched")
 	}
-	if isTranscriptWatchedAgent(protocol.SessionAgentCodex) {
-		t.Fatal("codex live state is hook-owned and should not be transcript-watched")
+	// Codex live state is hook-owned, with one exception: its hooks never report
+	// a turn the user halted, and `turn_aborted` in its transcript is the only
+	// record of one. The watcher is on for that and its behavior does nothing
+	// else — see codexTranscriptWatcherBehavior.
+	if !isTranscriptWatchedAgent(protocol.SessionAgentCodex) {
+		t.Fatal("codex should be transcript-watched so a halted turn is seen")
 	}
 	if !isTranscriptWatchedAgent(protocol.SessionAgentCopilot) {
 		t.Fatal("copilot should be transcript-watched")
+	}
+}
+
+// Discovery is a directory walk over the agent's whole session tree, and it
+// repeats until it lands. A session that never gets a transcript would otherwise
+// walk thousands of files twice a second for as long as it lives.
+func TestTranscriptDiscoveryBacksOff(t *testing.T) {
+	if got := transcriptDiscoveryDelay(1); got != 0 {
+		t.Fatalf("first attempts should retry on the next poll, got %s", got)
+	}
+	if got := transcriptDiscoveryDelay(transcriptDiscoveryFastAttempts - 1); got != 0 {
+		t.Fatalf("a transcript still plausibly being created should be looked for eagerly, got %s", got)
+	}
+	if got := transcriptDiscoveryDelay(transcriptDiscoveryFastAttempts); got != transcriptDiscoverySlowInterval {
+		t.Fatalf("delay = %s, want %s once the eager window is spent", got, transcriptDiscoverySlowInterval)
+	}
+	if got := transcriptDiscoveryDelay(transcriptDiscoverySlowAttempts); got != transcriptDiscoveryIdleInterval {
+		t.Fatalf("delay = %s, want %s for a session that is never getting one", got, transcriptDiscoveryIdleInterval)
+	}
+	// The eager window has to be short enough to matter and long enough to cover
+	// an agent that takes a few seconds to write its first line.
+	eager := time.Duration(transcriptDiscoveryFastAttempts) * transcriptPollInterval
+	if eager < 5*time.Second || eager > 30*time.Second {
+		t.Fatalf("eager discovery window is %s, which is outside the range any agent takes to start writing", eager)
 	}
 }
 

--- a/internal/sessionstate/sessionstate.go
+++ b/internal/sessionstate/sessionstate.go
@@ -67,6 +67,11 @@ const (
 	// was cut off — and a diagnosis that says so is worth more than one that
 	// reports a question nobody asked.
 	ClaimStopFailed Claim = "stop_failed"
+	// ClaimTurnAborted: the user halted the turn. Distinct from every settle above
+	// because nothing announces it — no agent fires a hook when its turn is
+	// interrupted — so it is the one turn ending that must be read out of the
+	// agent's transcript, and the one that leaves no answer to judge.
+	ClaimTurnAborted Claim = "turn_aborted"
 )
 
 // Observation is one recorded piece of evidence.
@@ -271,6 +276,7 @@ const (
 	ReasonBackgroundWork    Reason = "background_work"
 	ReasonCompacting        Reason = "compacting"
 	ReasonStopFailed        Reason = "stop_failed"
+	ReasonTurnAborted       Reason = "turn_aborted"
 	ReasonClassifierVerdict Reason = "classifier_verdict"
 	ReasonAtPrompt          Reason = "at_prompt"
 	ReasonStuck             Reason = "stuck"
@@ -320,6 +326,25 @@ func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
 	// in the daemon's recorder.
 	if r, ok := harnessEdge(e); ok {
 		return r
+	}
+
+	// The user halted the turn. No agent reports this — the closing bracket is not
+	// late, it is never coming — so without this clause the turn stays open until
+	// the stale window retires it, and a halted agent reads as working for the
+	// whole minute that takes.
+	//
+	// It settles without consulting the classifier: an aborted turn left a
+	// truncated fragment and no answer, and a verdict drawn from that reports a
+	// question the agent never finished asking. It sits above compaction and
+	// background work because an abort ends everything the turn had running, and
+	// below the busy heartbeat because the agent visibly running again is the one
+	// thing that contradicts it.
+	if turnAborted(e) {
+		return Resolution{
+			State:  protocol.SessionStateIdle,
+			Reason: ReasonTurnAborted,
+			Detail: e.LastHarnessEvent.Detail,
+		}
 	}
 
 	// Compaction is work no other clause can see: it opens no turn and no tool
@@ -509,6 +534,21 @@ func harnessEdge(e Evidence) (Resolution, bool) {
 	default:
 		return Resolution{}, false
 	}
+}
+
+// turnAborted reports whether the harness recorded the user halting the turn,
+// with nothing since to spend that.
+//
+// It shares LastHarnessEvent with the edges above rather than taking a field of
+// its own: an abort is a one-shot harness announcement like the others, it
+// retires on the same terms — the agent going busy past it, or the next turn
+// opening — and it cannot coexist with them, because a turn the user halted is
+// not also blocked on an approval. harnessEdge ignores the claim, so the two
+// readers of the slot cannot both fire.
+func turnAborted(e Evidence) bool {
+	return e.LastHarnessEvent != nil &&
+		e.LastHarnessEvent.Claim == ClaimTurnAborted &&
+		!supersededByBusy(e.LastHarnessEvent, e)
 }
 
 // classifierVerdict reads the stop-time verdict, if one belongs to the current

--- a/internal/sessionstate/sessionstate_test.go
+++ b/internal/sessionstate/sessionstate_test.go
@@ -623,6 +623,80 @@ func TestResolve(t *testing.T) {
 			wantState:  protocol.SessionStateUnknown,
 			wantReason: ReasonNoEvidence,
 		},
+
+		// --- the user halting a turn ---------------------------------------
+
+		{
+			// No agent fires a hook on an interrupt, so the turn bracket is still
+			// open and its heartbeat has only just gone quiet: every other clause
+			// reads this as a turn in progress.
+			name: "an aborted turn settles immediately, with its bracket still open",
+			evidence: Evidence{
+				TurnOpen:         true,
+				TurnEverOpened:   true,
+				Heartbeat:        seen(SourceHeartbeat, ClaimSettled, 200*time.Millisecond),
+				LastBusyAt:       now.Add(-300 * time.Millisecond),
+				LastHarnessEvent: seen(SourceHarnessEvent, ClaimTurnAborted, 200*time.Millisecond),
+				LastMovement:     now.Add(-200 * time.Millisecond),
+			},
+			wantState:  protocol.SessionStateIdle,
+			wantReason: ReasonTurnAborted,
+		},
+		{
+			// The abort outranks a classification still running: an interrupted turn
+			// left a fragment, and holding for a verdict on it would sit on the
+			// settle for the classifier's whole timeout.
+			name: "an aborted turn does not wait for a verdict",
+			evidence: Evidence{
+				TurnEverOpened:   true,
+				LastHarnessEvent: seen(SourceHarnessEvent, ClaimTurnAborted, time.Second),
+				ClassifyingSince: now.Add(-time.Second),
+				LastMovement:     now.Add(-time.Second),
+			},
+			wantState:  protocol.SessionStateIdle,
+			wantReason: ReasonTurnAborted,
+		},
+		{
+			// Interrupting a compaction is the case with no other way out: nothing
+			// but total silence retires `Compacting`, so it would hold the session
+			// working for 90s.
+			name: "an aborted turn outranks compaction",
+			evidence: Evidence{
+				TurnEverOpened:   true,
+				Compacting:       true,
+				LastHarnessEvent: seen(SourceHarnessEvent, ClaimTurnAborted, time.Second),
+				LastMovement:     now.Add(-time.Second),
+			},
+			wantState:  protocol.SessionStateIdle,
+			wantReason: ReasonTurnAborted,
+		},
+		{
+			// The user halted the turn and then started another one. The agent is
+			// visibly running, so the abort is spent.
+			name: "a busy frame after an abort retires it",
+			evidence: Evidence{
+				TurnOpen:         true,
+				TurnEverOpened:   true,
+				Heartbeat:        seen(SourceHeartbeat, ClaimBusy, 100*time.Millisecond),
+				LastBusyAt:       now.Add(-100 * time.Millisecond),
+				LastHarnessEvent: seen(SourceHarnessEvent, ClaimTurnAborted, 3*time.Second),
+				LastMovement:     now.Add(-100 * time.Millisecond),
+			},
+			wantState:  protocol.SessionStateWorking,
+			wantReason: ReasonHeartbeatFresh,
+		},
+		{
+			// An abort is not an approval: the agent asked nothing, so the session
+			// must not be reported as blocked on a person.
+			name: "an aborted turn is not read as an outstanding approval",
+			evidence: Evidence{
+				TurnEverOpened:   true,
+				LastHarnessEvent: seen(SourceHarnessEvent, ClaimTurnAborted, time.Second),
+				LastMovement:     now.Add(-time.Second),
+			},
+			wantState:  protocol.SessionStateIdle,
+			wantReason: ReasonTurnAborted,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got := Resolve(tc.evidence, testPolicy(), now)
@@ -1040,5 +1114,52 @@ func TestATurnKilledByTheAPIAsksForTheUser(t *testing.T) {
 	e.LastBusyAt = now.Add(-100 * time.Millisecond)
 	if got := Resolve(e, policy, now); got.State != protocol.SessionStateWorking {
 		t.Fatalf("resolved %s/%s once the agent ran again, want working", got.State, got.Reason)
+	}
+}
+
+// The regression this whole clause exists for. An interrupt fires no hook on any
+// agent, so the turn bracket opened by the prompt is never closed: without the
+// abort edge, the only thing that retires it is StaleAfter, and the session shows
+// the halted agent as working for that entire window. Written against the clock
+// rather than against a single instant because the wrong answer here was not a
+// wrong state, it was a right state that arrived a minute late.
+func TestHaltingATurnSettlesItWithoutWaitingOutTheStaleWindow(t *testing.T) {
+	policy := testPolicy()
+	// Measured on claude 2.1.220: the last busy frame lands just before ESC, the
+	// idle glyph 0.07s after it, and nothing at all after that.
+	abortedAt := now
+	e := Evidence{
+		TurnOpen:       true,
+		TurnEverOpened: true,
+		LastBusyAt:     abortedAt.Add(-300 * time.Millisecond),
+		Heartbeat: &Observation{
+			Source:     SourceHeartbeat,
+			Claim:      ClaimSettled,
+			ObservedAt: abortedAt.Add(70 * time.Millisecond),
+		},
+		LastHarnessEvent: &Observation{
+			Source:     SourceHarnessEvent,
+			Claim:      ClaimTurnAborted,
+			Detail:     "[Request interrupted by user]",
+			ObservedAt: abortedAt,
+		},
+		LastMovement: abortedAt.Add(70 * time.Millisecond),
+	}
+
+	// Every point across the window the bracket would otherwise have held, and
+	// past the one where evidence silence would have called it stuck.
+	for _, age := range []time.Duration{
+		time.Second,
+		policy.StaleAfter,
+		policy.StaleAfter + policy.SettleGrace + time.Second,
+		policy.StuckAfter + time.Second,
+	} {
+		got := Resolve(e, policy, abortedAt.Add(age))
+		if got.State != protocol.SessionStateIdle || got.Reason != ReasonTurnAborted {
+			t.Fatalf("%s after the halt: resolved %s/%s, want idle/turn_aborted", age, got.State, got.Reason)
+		}
+		if got.Detail != "[Request interrupted by user]" {
+			t.Fatalf("%s after the halt: detail = %q, want what the transcript said", age, got.Detail)
+		}
 	}
 }

--- a/internal/transcript/discovery.go
+++ b/internal/transcript/discovery.go
@@ -288,8 +288,13 @@ func FindCopilotTranscript(cwd string, startedAt time.Time) string {
 			return filepath.SkipDir
 		}
 
+		// Compared through symlinks, as codex's finder is: copilot records the
+		// resolved cwd, so a session launched under /tmp writes /private/tmp and a
+		// literal comparison finds nothing. Copilot's live state comes from the
+		// watcher, so a transcript it cannot find leaves the session showing
+		// `launching` for as long as it runs.
 		matchedCWD := readCopilotWorkspaceCWD(workspacePath)
-		if matchedCWD == "" || matchedCWD != cwdClean {
+		if matchedCWD == "" || !pathsEquivalent(matchedCWD, cwdClean) {
 			return filepath.SkipDir
 		}
 

--- a/internal/transcript/discovery_test.go
+++ b/internal/transcript/discovery_test.go
@@ -192,6 +192,32 @@ func TestFindCopilotTranscript_PrefersClosestStartTime(t *testing.T) {
 	}
 }
 
+// Copilot records the cwd it resolved, not the one it was handed. On macOS a
+// session launched under /tmp writes /private/tmp, and a literal comparison finds
+// nothing — which leaves the session showing `launching` for as long as it runs,
+// because copilot's live state comes from the watcher.
+func TestFindCopilotTranscript_MatchesThroughASymlinkedCWD(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv(toolhome.EnvVar, homeDir)
+
+	real := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(real, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(t.TempDir(), "link-to-project")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+
+	startedAt := time.Date(2026, 2, 8, 15, 30, 0, 0, time.UTC)
+	// Copilot writes the resolved path...
+	expected := writeCopilotSessionState(t, homeDir, "session-a", real, startedAt, true, true, startedAt.Add(time.Minute))
+	// ...and attn asks with the path the session was launched from.
+	if got := FindCopilotTranscript(link, startedAt); got != expected {
+		t.Fatalf("FindCopilotTranscript() = %q, want %q", got, expected)
+	}
+}
+
 func TestFindCopilotTranscript_FallsBackToNewestModTime(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv(toolhome.EnvVar, homeDir)

--- a/internal/transcript/parser.go
+++ b/internal/transcript/parser.go
@@ -95,14 +95,7 @@ func extractLineTimestamp(line []byte) time.Time {
 	if err := json.Unmarshal(line, &entry); err != nil {
 		return time.Time{}
 	}
-	if strings.TrimSpace(entry.Timestamp) == "" {
-		return time.Time{}
-	}
-	ts, err := time.Parse(time.RFC3339Nano, entry.Timestamp)
-	if err != nil {
-		return time.Time{}
-	}
-	return ts
+	return parseTranscriptTime(entry.Timestamp)
 }
 
 func extractLineUUID(line []byte) string {
@@ -331,6 +324,201 @@ func ExtractCopilotToolLifecycle(line []byte) (CopilotToolLifecycle, bool) {
 	default:
 		return CopilotToolLifecycle{}, false
 	}
+}
+
+// Turn aborts.
+//
+// No agent reports a turn the user halted. Measured on claude 2.1.220 with all
+// 31 of its hook events wired to a logger, on codex 0.146.0 with attn's own
+// trusted-hash hook overrides, and on copilot 1.0.77: ESC mid-turn produces no
+// Stop, no StopFailure, no Notification — nothing, for as long as you care to
+// wait. All three write the abort to their transcript in the same second, which
+// is the only place it can be read from.
+//
+// Nor can the title heartbeat stand in for the transcript. Measured on claude
+// 2.1.220: halting a turn paints `✳ <task description>` 60ms later and then
+// nothing for as long as you watch; a 60-second foreground `sleep` paints
+// `✳ <task description>` partway through and then nothing for the remaining 64
+// seconds. A halted turn and a blocking tool call are the same frames in the same
+// order, so no silence threshold separates them — which is why the stale window
+// is sized to the longest tool call rather than to the halt it cannot see.
+const (
+	// The two markers claude writes. Matched exactly rather than by prefix: a
+	// user is free to type the text.
+	claudeInterruptMarker           = "[Request interrupted by user]"
+	claudeInterruptMarkerForToolUse = "[Request interrupted by user for tool use]"
+	// The reason copilot gives when the user halts, as against the other ways it
+	// abandons a turn.
+	copilotUserAbortReason = "user_initiated"
+	// The one codex reason that is a user halt. The enum in the 0.146.0 binary
+	// also carries `replaced`, `review_ended`, and `budget_limited`, none of which
+	// are: `replaced` means another turn took over and the session is working
+	// again a moment later.
+	codexUserAbortReason = "interrupted"
+)
+
+// TurnAbort describes a transcript line that ended a turn before it finished.
+type TurnAbort struct {
+	// Reason is what the agent called it, for the diagnosis.
+	Reason string
+
+	// UserHalt: the user did this. Only a user halt settles a session. The other
+	// ways a turn can be abandoned are the harness's own business, and some of
+	// them are followed immediately by another turn.
+	UserHalt bool
+
+	// At is the line's own timestamp, zero when the line carries none. It is what
+	// separates a halt that just happened from one being re-read out of history —
+	// which the watcher does routinely, because it rewinds into the file at
+	// discovery and starts over at zero when a transcript is rewritten.
+	At time.Time
+}
+
+// ClaudeTurnAborted reports whether a Claude transcript line records the user
+// halting the turn.
+//
+// Two shapes, because claude writes two. `interruptedMessageId` is a dedicated
+// field naming the API message ESC cancelled, and nothing else produces it — so
+// it is believed on its own, and a release that reworded the marker would still
+// be caught. Halting during a tool-use prompt writes the marker with no such
+// field, so the marker is honored too, but only in the exact shape claude emits
+// it: a lone text block, in an entry carrying none of the fields that mark a
+// prompt the user submitted. A user who types or pastes the marker gets string
+// content and a promptSource, and must not settle their own session.
+func ClaudeTurnAborted(line []byte) (TurnAbort, bool) {
+	var entry struct {
+		Type                 string          `json:"type"`
+		InterruptedMessageID string          `json:"interruptedMessageId"`
+		Timestamp            string          `json:"timestamp"`
+		PromptSource         string          `json:"promptSource"`
+		PermissionMode       string          `json:"permissionMode"`
+		Origin               json.RawMessage `json:"origin"`
+		Message              struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(line, &entry); err != nil || entry.Type != "user" {
+		return TurnAbort{}, false
+	}
+
+	abort := TurnAbort{UserHalt: true, At: parseTranscriptTime(entry.Timestamp)}
+
+	if strings.TrimSpace(entry.InterruptedMessageID) != "" {
+		abort.Reason = claudeInterruptMarker
+		if marker, ok := claudeInterruptMarkerBlock(entry.Message.Content); ok {
+			abort.Reason = marker
+		}
+		return abort, true
+	}
+
+	submitted := strings.TrimSpace(entry.PromptSource) != "" ||
+		strings.TrimSpace(entry.PermissionMode) != "" ||
+		len(entry.Origin) > 0
+	if submitted {
+		return TurnAbort{}, false
+	}
+	marker, ok := claudeInterruptMarkerBlock(entry.Message.Content)
+	if !ok {
+		return TurnAbort{}, false
+	}
+	abort.Reason = marker
+	return abort, true
+}
+
+// claudeInterruptMarkerBlock matches the content shape claude writes for an
+// interrupt: an array holding exactly one text block that is exactly a marker.
+// The array is required — a marker the user typed arrives as a plain string.
+func claudeInterruptMarkerBlock(raw json.RawMessage) (string, bool) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return "", false
+	}
+	var blocks []contentBlock
+	if err := json.Unmarshal(trimmed, &blocks); err != nil || len(blocks) != 1 {
+		return "", false
+	}
+	if blocks[0].Type != "text" {
+		return "", false
+	}
+	switch text := strings.TrimSpace(blocks[0].Text); text {
+	case claudeInterruptMarker, claudeInterruptMarkerForToolUse:
+		return text, true
+	default:
+		return "", false
+	}
+}
+
+// CodexTurnAborted reports whether a Codex transcript line is a turn_aborted
+// event.
+//
+// Only `interrupted` is reported as a halt. The event itself means the turn ended
+// early, but codex also emits it when one turn replaces another — where the
+// session is working again immediately, and settling it would be wrong.
+func CodexTurnAborted(line []byte) (TurnAbort, bool) {
+	var envelope struct {
+		Type      string          `json:"type"`
+		Timestamp string          `json:"timestamp"`
+		Payload   json.RawMessage `json:"payload"`
+	}
+	if err := json.Unmarshal(line, &envelope); err != nil || envelope.Type != "event_msg" {
+		return TurnAbort{}, false
+	}
+	var payload struct {
+		Type   string `json:"type"`
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal(envelope.Payload, &payload); err != nil || payload.Type != "turn_aborted" {
+		return TurnAbort{}, false
+	}
+	reason := strings.TrimSpace(payload.Reason)
+	if reason == "" {
+		reason = "aborted"
+	}
+	return TurnAbort{
+		Reason:   reason,
+		UserHalt: reason == codexUserAbortReason,
+		At:       parseTranscriptTime(envelope.Timestamp),
+	}, true
+}
+
+// CopilotTurnAborted reports whether a Copilot transcript line is an abort.
+//
+// Copilot writes a bare top-level `abort` event and — unlike its normal path —
+// no `assistant.turn_end`, so every abort has to be seen whether or not the user
+// caused it: the watcher's own turn bracket would otherwise stay open for the
+// rest of the session, pinning it working. Only `user_initiated` is a halt.
+func CopilotTurnAborted(line []byte) (TurnAbort, bool) {
+	var entry struct {
+		Type      string `json:"type"`
+		Timestamp string `json:"timestamp"`
+		Data      struct {
+			Reason string `json:"reason"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(line, &entry); err != nil || entry.Type != "abort" {
+		return TurnAbort{}, false
+	}
+	reason := strings.TrimSpace(entry.Data.Reason)
+	if reason == "" {
+		reason = "aborted"
+	}
+	return TurnAbort{
+		Reason:   reason,
+		UserHalt: reason == copilotUserAbortReason,
+		At:       parseTranscriptTime(entry.Timestamp),
+	}, true
+}
+
+func parseTranscriptTime(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}
+	}
+	ts, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}
+	}
+	return ts
 }
 
 // extractTextContent extracts text from the content field which can be:

--- a/internal/transcript/parser_test.go
+++ b/internal/transcript/parser_test.go
@@ -360,3 +360,212 @@ func TestExtractLastAssistantMessageAfterLastUserSince_Claude_FreshAssistantRetu
 		t.Fatalf("got %q, want %q", result, expected)
 	}
 }
+
+// The abort lines below are verbatim captures: claude 2.1.220, codex 0.146.0 and
+// copilot 1.0.77 each driven through a real PTY and interrupted with ESC
+// mid-turn. They are the only record any of them produces of the user halting a
+// turn — no hook fires — so the exact shape is the contract.
+
+type turnAbortCase struct {
+	name         string
+	line         string
+	wantReason   string
+	wantUserHalt bool
+	wantAt       string
+	wantOK       bool
+}
+
+func runTurnAbortCases(t *testing.T, parse func([]byte) (TurnAbort, bool), cases []turnAbortCase) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			abort, ok := parse([]byte(tc.line))
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (abort %+v)", ok, tc.wantOK, abort)
+			}
+			if !ok {
+				return
+			}
+			if abort.Reason != tc.wantReason {
+				t.Fatalf("reason = %q, want %q", abort.Reason, tc.wantReason)
+			}
+			if abort.UserHalt != tc.wantUserHalt {
+				t.Fatalf("user halt = %v, want %v", abort.UserHalt, tc.wantUserHalt)
+			}
+			got := ""
+			if !abort.At.IsZero() {
+				got = abort.At.UTC().Format(time.RFC3339Nano)
+			}
+			if got != tc.wantAt {
+				t.Fatalf("at = %q, want %q", got, tc.wantAt)
+			}
+		})
+	}
+}
+
+func TestClaudeTurnAborted(t *testing.T) {
+	runTurnAbortCases(t, ClaudeTurnAborted, []turnAbortCase{
+		{
+			name:         "captured interrupt entry",
+			line:         `{"parentUuid":"60baa6e9-1760-40c8-9f12-134f9051980d","type":"user","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user]"}]},"uuid":"2f177d9e-15fa-4617-bb8b-fb3d8150027e","timestamp":"2026-08-01T22:08:15.284Z","interruptedMessageId":"msg_011Cdcnp6M5nmsdZuTzGRmaF"}`,
+			wantReason:   "[Request interrupted by user]",
+			wantUserHalt: true,
+			wantAt:       "2026-08-01T22:08:15.284Z",
+			wantOK:       true,
+		},
+		{
+			// Captured: halting at a tool-use prompt writes the marker and no
+			// interruptedMessageId at all, so the marker has to be honored on its own.
+			name:         "captured tool-use interrupt with no dedicated field",
+			line:         `{"parentUuid":"9f5d4154-154b-40c5-9f6a-a4fe7de054f2","type":"user","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user for tool use]"}]},"uuid":"b2cf7717-d87d-4613-bf08-f73edb9e0e07","timestamp":"2026-08-01T12:30:36.311Z","userType":"external","entrypoint":"cli"}`,
+			wantReason:   "[Request interrupted by user for tool use]",
+			wantUserHalt: true,
+			wantAt:       "2026-08-01T12:30:36.311Z",
+			wantOK:       true,
+		},
+		{
+			// The field alone is enough, so a claude release that reworded the
+			// marker still reports the halt.
+			name:         "the dedicated field carries an unrecognized marker",
+			line:         `{"type":"user","message":{"role":"user","content":"[Request stopped]"},"interruptedMessageId":"msg_01"}`,
+			wantReason:   "[Request interrupted by user]",
+			wantUserHalt: true,
+			wantOK:       true,
+		},
+		{
+			// Captured shape of a prompt the user typed. Claude writes submitted
+			// prompts as a plain string and stamps them with promptSource/origin;
+			// its own interrupt entries are a lone text block with neither. Without
+			// that distinction a user who pastes the marker settles their own
+			// working session.
+			name: "the marker pasted as a prompt is not an abort",
+			line: `{"type":"user","message":{"role":"user","content":"[Request interrupted by user]"},"promptSource":"typed","origin":{"kind":"human"},"permissionMode":"auto","timestamp":"2026-08-01T21:48:07.459Z"}`,
+		},
+		{
+			// The same paste as a content block, which is what an attachment or an
+			// image alongside the text produces.
+			name: "the marker submitted as a block is not an abort",
+			line: `{"type":"user","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user]"}]},"promptSource":"paste","origin":{"kind":"human"}}`,
+		},
+		{
+			// Claude has written user entries without promptSource/origin for as long
+			// as it has written transcripts, so the metadata cannot be the only guard.
+			// The content shape is the other one: claude's own interrupt is a block,
+			// and anything arriving as a bare string was submitted by someone.
+			name: "the marker as a bare string is not an abort",
+			line: `{"type":"user","message":{"role":"user","content":"[Request interrupted by user]"},"uuid":"6d41deb5","timestamp":"2026-08-01T22:06:44.538Z"}`,
+		},
+		{
+			// The whole reason the marker is matched exactly rather than by prefix.
+			name: "a user quoting the marker in a prompt is not an abort",
+			line: `{"type":"user","message":{"role":"user","content":"why does [Request interrupted by user] show up in my logs?"}}`,
+		},
+		{
+			// Captured: tool output that happens to contain the marker arrives as a
+			// user entry too, and a grep result quoting attn's own source must not
+			// halt the session reading it.
+			name: "a tool result quoting the marker is not an abort",
+			line: `{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_01","type":"tool_result","content":"parser.go:12:[Request interrupted by user]"}]}}`,
+		},
+		{
+			name: "an assistant message is not an abort",
+			line: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"[Request interrupted by user]"}]}}`,
+		},
+		{
+			name: "a codex line is not a claude abort",
+			line: `{"type":"event_msg","payload":{"type":"turn_aborted","reason":"interrupted"}}`,
+		},
+		{
+			name: "malformed json is not an abort",
+			line: `{"type":"user",`,
+		},
+	})
+}
+
+func TestCodexTurnAborted(t *testing.T) {
+	runTurnAbortCases(t, CodexTurnAborted, []turnAbortCase{
+		{
+			name:         "captured turn_aborted event",
+			line:         `{"timestamp":"2026-08-01T21:58:33.937Z","type":"event_msg","payload":{"type":"turn_aborted","turn_id":"019fbf55-ef48-70f1-991c-989a330a104a","reason":"interrupted","started_at":1785621507,"completed_at":1785621513,"duration_ms":6019}}`,
+			wantReason:   "interrupted",
+			wantUserHalt: true,
+			wantAt:       "2026-08-01T21:58:33.937Z",
+			wantOK:       true,
+		},
+		{
+			// The reason codex gives when one turn supersedes another. The turn did
+			// end, but the session is working again immediately, so reporting it as
+			// a halt settles a session that is running.
+			name:       "a replaced turn is not a user halt",
+			line:       `{"type":"event_msg","payload":{"type":"turn_aborted","reason":"replaced"}}`,
+			wantReason: "replaced",
+			wantOK:     true,
+		},
+		{
+			name:       "leaving review mode is not a user halt",
+			line:       `{"type":"event_msg","payload":{"type":"turn_aborted","reason":"review_ended"}}`,
+			wantReason: "review_ended",
+			wantOK:     true,
+		},
+		{
+			name:       "running out of budget is not a user halt",
+			line:       `{"type":"event_msg","payload":{"type":"turn_aborted","reason":"budget_limited"}}`,
+			wantReason: "budget_limited",
+			wantOK:     true,
+		},
+		{
+			name:       "a reasonless abort is not a user halt",
+			line:       `{"type":"event_msg","payload":{"type":"turn_aborted"}}`,
+			wantReason: "aborted",
+			wantOK:     true,
+		},
+		{
+			name: "a completed turn is not an abort",
+			line: `{"type":"event_msg","payload":{"type":"task_complete","turn_id":"019fbf55"}}`,
+		},
+		{
+			name: "a response item is not an abort",
+			line: `{"type":"response_item","payload":{"type":"message","role":"assistant"}}`,
+		},
+		{
+			name: "a claude line is not a codex abort",
+			line: `{"type":"user","message":{"role":"user","content":"[Request interrupted by user]"},"interruptedMessageId":"msg_01"}`,
+		},
+	})
+}
+
+func TestCopilotTurnAborted(t *testing.T) {
+	runTurnAbortCases(t, CopilotTurnAborted, []turnAbortCase{
+		{
+			name:         "captured abort event",
+			line:         `{"type":"abort","timestamp":"2026-08-02T08:52:00.344Z","data":{"reason":"user_initiated"}}`,
+			wantReason:   "user_initiated",
+			wantUserHalt: true,
+			wantAt:       "2026-08-02T08:52:00.344Z",
+			wantOK:       true,
+		},
+		{
+			// Reported even though it is not a halt: copilot writes no
+			// assistant.turn_end after an abort, so the watcher's turn bracket has to
+			// be closed by this line whatever caused it.
+			name:       "an abort copilot caused is still reported",
+			line:       `{"type":"abort","data":{"reason":"tool_failure"}}`,
+			wantReason: "tool_failure",
+			wantOK:     true,
+		},
+		{
+			name:       "a reasonless abort is not a user halt",
+			line:       `{"type":"abort","data":{}}`,
+			wantReason: "aborted",
+			wantOK:     true,
+		},
+		{
+			name: "a turn end is not an abort",
+			line: `{"type":"assistant.turn_end","data":{"turnId":"0"}}`,
+		},
+		{
+			name: "a claude line is not a copilot abort",
+			line: `{"type":"user","message":{"role":"user","content":"[Request interrupted by user]"},"interruptedMessageId":"msg_01"}`,
+		},
+	})
+}


### PR DESCRIPTION
Interrupting an agent mid-turn left the session showing `working`.

No agent fires a hook when the user halts a turn. Claude's `Stop` hook does not
run on interrupt (documented behavior — `Stop` is "the main agent has finished
responding", and an interrupt is not finishing). Codex has no hook surface at
all, and copilot 1.0.77 fires nothing either. So the session only recovered when
the heartbeat aged out at `StaleAfter` (60s) — and for copilot, whose live state
comes entirely from its transcript watcher, it never recovered at all: the
watcher held the turn bracket open for the rest of the session's life.

Each agent does record the halt in its transcript. The transcript watcher now
detects it and settles the turn.

## Detection is structural, not textual

**Claude** writes a user entry carrying `interruptedMessageId`, or a lone
`[Request interrupted by user]` text block. The field alone is not enough —
halting at a tool-use prompt writes the marker *without* it — so a marker-only
entry is accepted only when the entry carries none of `promptSource`, `origin`,
or `permissionMode`. Those three are what a real prompt has and a synthesized
interrupt record does not, which is why pasting the marker as a prompt no longer
settles the session it was typed into.

**Codex** aborts for four reasons; only `interrupted` is a user halt.
`replaced`, `review_ended`, and `budget_limited` are parsed and explicitly are
not.

**Copilot** writes `{"type":"abort","data":{"reason":"user_initiated"}}` and,
unlike every other turn ending, no `assistant.turn_end`. Every abort now closes
its watcher-owned turn bracket; only `user_initiated` settles.

## A halt is dated by the agent, not by the read

It is dropped if it predates the session or carries no timestamp. One rule
covers the three ways a halt can be read out of its own time:

- the bootstrap rewind, which tails the last 256KB/512KB of a resumed transcript
- the truncation reset to offset 0
- the 500ms poll landing after the next prompt has already gone out

A late-read halt is now outranked by the busy frames that followed it (the
existing `supersededByBusy` rule), while `LastMovement` still advances to the
read time, so nothing ages into `stuck`.

## Two more fixes

**Copilot transcript discovery compared cwds literally.** Copilot records the
*resolved* path, so any session launched under a symlink (`/tmp` on macOS) never
found its transcript and sat at `launching` for its whole life. It now compares
through symlinks, as the codex finder already did. Found while verifying the
halt fix.

**Codex and copilot discovery walked the whole session tree twice a second** for
as long as a transcript stayed unfound. It now backs off: every poll for the
first 10s, then every 2s, then every 5s.

## Verification

Live, on a throwaway profile, against real agents. Halt to settled:

| agent | halt key | settled |
|---|---|---|
| claude 2.1.220 | ESC | **1.02s** |
| codex 0.146.0 | Ctrl+C | **1.29s** |
| copilot 1.0.77 | ESC | **1.20s** |

Pasting `[Request interrupted by user]` into a live claude session goes `working`
-> `waiting_input` and never settles.

Every guard is mutation-tested: removing it turns the load-bearing assertion red
(stale gate, both claude discriminators independently, codex reason filter,
copilot bracket clear, agent-vs-read dating, copilot symlink match).

Note for anyone re-running this: **codex 0.146.0 interrupts on Ctrl+C, not ESC.**
Sending ESC looks exactly like a regression in this code and is not. That, and
copilot's reuse-a-directory discovery trap, are recorded in the plan doc.

## What was deliberately not shipped

An agent-agnostic idle backstop — settle any session that goes quiet for N
seconds regardless of agent. Measured on claude 2.1.220:

```
halt, no tool:   ESC        -> 60ms later  "* Write typewriter history essay"   -> silence
60s foreground:  tool start -> 8s later    "* Run sleep command for 60 seconds" -> silence 64s
```

Same glyph, same shape, same silence. No threshold below the longest tool call
separates a halted turn from a blocking one, which is exactly why `StaleAfter` is
sized to the longest tool call in the first place. The traces are in the plan doc
so this doesn't get re-proposed.

https://claude.ai/code/session_015EYRHFgwnr143eV4im2JrF
