### PR TITLE
feat(release): compile the changelog from per-PR fragments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,23 @@ jobs:
             tauri:
               - 'app/src-tauri/**'
               - '.github/workflows/ci.yml'
+  changelog:
+    name: Changelog
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Gate
+        run: ./scripts/changelog-gate.sh "${{ github.base_ref }}" "${{ github.head_ref }}"
+
   backend:
     name: Daemon
     needs: changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,5 +350,7 @@ Packaged-app default menu accelerators can consume shortcuts before DOM keydown.
 - Diagnose root cause. Do not remove requested behavior without explicit
   approval. For refactors, list and verify behaviors that must survive.
 - Do not copy production code into tests or test compile-time guarantees.
-- Update `CHANGELOG.md` only for meaningful user-visible changes. Use dated
-  sections; describe the PR's net behavior in concise user-facing bullets.
+- Every PR adds a changelog fragment under `changelog.d/` — CI enforces it.
+  Do not edit `CHANGELOG.md` directly; it is compiled from fragments at
+  release time. Format and release process:
+  [docs/making-a-release.md](docs/making-a-release.md).

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,5 @@
+# changelog.d
+
+Pending changelog fragments — one YAML file per PR, compiled into
+`CHANGELOG.md` at release time by `scripts/compile-changelog.sh`. Format,
+examples, and the release workflow: [docs/making-a-release.md](../docs/making-a-release.md).

--- a/changelog.d/surly-ferret-changelog-fragments.yaml
+++ b/changelog.d/surly-ferret-changelog-fragments.yaml
@@ -1,0 +1,7 @@
+kind: internal
+area: release
+change: >
+  Changelog entries now travel as per-PR fragments under changelog.d/ and are
+  compiled into CHANGELOG.md at release time. CI gates every PR on carrying a
+  fragment (or touching CHANGELOG.md), and scripts/release.sh refuses to cut a
+  release while fragments are pending. No user-visible app change.

--- a/cmd/changelog-check/main.go
+++ b/cmd/changelog-check/main.go
@@ -66,8 +66,11 @@ func validateDir(dir string) []error {
 			continue
 		}
 		path := filepath.Join(dir, name)
-		if e.IsDir() {
-			errs = append(errs, fmt.Errorf("%s: unexpected directory", path))
+		// Type() comes from lstat: a symlink is reported as a symlink, not as
+		// its target. Anything but a regular file is rejected so the compile
+		// step can never be pointed at a file outside changelog.d/.
+		if !e.Type().IsRegular() {
+			errs = append(errs, fmt.Errorf("%s: fragments must be regular files (not directories, symlinks, or other special files)", path))
 			continue
 		}
 		if !strings.HasSuffix(name, ".yaml") {

--- a/cmd/changelog-check/main.go
+++ b/cmd/changelog-check/main.go
@@ -1,0 +1,102 @@
+// changelog-check validates the pending changelog fragments under
+// changelog.d/. It is run by the CI changelog gate (scripts/changelog-gate.sh)
+// and can be run locally with `go run ./cmd/changelog-check`.
+//
+// Fragments are raw material for the release-time changelog compilation, not
+// final copy. docs/making-a-release.md describes the format and workflow.
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type fragment struct {
+	Kind    string `yaml:"kind"`
+	Area    string `yaml:"area"`
+	Change  string `yaml:"change"`
+	Symptom string `yaml:"symptom"`
+	Notes   string `yaml:"notes"`
+}
+
+var validKinds = []string{"added", "changed", "fixed", "removed", "internal"}
+
+func validateFragment(data []byte) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	var f fragment
+	if err := dec.Decode(&f); err != nil {
+		if errors.Is(err, io.EOF) {
+			return fmt.Errorf("fragment is empty")
+		}
+		return err
+	}
+	if !slices.Contains(validKinds, f.Kind) {
+		return fmt.Errorf("kind must be one of %s (got %q)", strings.Join(validKinds, ", "), f.Kind)
+	}
+	if strings.TrimSpace(f.Area) == "" {
+		return fmt.Errorf("area is required")
+	}
+	if strings.TrimSpace(f.Change) == "" {
+		return fmt.Errorf("change is required")
+	}
+	return nil
+}
+
+// validateDir checks every entry in the fragments directory: README.md is
+// ignored, everything else must be a .yaml fragment that parses and passes
+// validateFragment.
+func validateDir(dir string) []error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return []error{err}
+	}
+	var errs []error
+	for _, e := range entries {
+		name := e.Name()
+		if name == "README.md" {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		if e.IsDir() {
+			errs = append(errs, fmt.Errorf("%s: unexpected directory", path))
+			continue
+		}
+		if !strings.HasSuffix(name, ".yaml") {
+			errs = append(errs, fmt.Errorf("%s: fragments must be .yaml files", path))
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", path, err))
+			continue
+		}
+		if err := validateFragment(data); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", path, err))
+		}
+	}
+	return errs
+}
+
+func main() {
+	dir := "changelog.d"
+	if len(os.Args) > 1 {
+		dir = os.Args[1]
+	}
+	errs := validateDir(dir)
+	for _, err := range errs {
+		fmt.Fprintln(os.Stderr, "changelog-check:", err)
+	}
+	if len(errs) > 0 {
+		fmt.Fprintln(os.Stderr, "see docs/making-a-release.md for the fragment format")
+		os.Exit(1)
+	}
+}

--- a/cmd/changelog-check/main_test.go
+++ b/cmd/changelog-check/main_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateFragment(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "valid minimal",
+			yaml: "kind: fixed\narea: queue\nchange: handover no longer skips settled turns\n",
+		},
+		{
+			name: "valid with optional fields",
+			yaml: "kind: fixed\narea: queue\nchange: handover fixed\nsymptom: pressing enter did nothing\nnotes: root cause was a stale band read\n",
+		},
+		{
+			name:    "unknown kind",
+			yaml:    "kind: bugfix\narea: queue\nchange: something\n",
+			wantErr: "kind must be one of",
+		},
+		{
+			name:    "missing change",
+			yaml:    "kind: added\narea: queue\n",
+			wantErr: "change is required",
+		},
+		{
+			name:    "missing area",
+			yaml:    "kind: added\nchange: something\n",
+			wantErr: "area is required",
+		},
+		{
+			name:    "unknown key rejected",
+			yaml:    "kind: added\narea: queue\nchange: something\ndescription: typo field\n",
+			wantErr: "field description not found",
+		},
+		{
+			name:    "empty file",
+			yaml:    "",
+			wantErr: "fragment is empty",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateFragment([]byte(tc.yaml))
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected valid, got: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateDir(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("README.md", "# ignored\n")
+	write("good.yaml", "kind: added\narea: terminal\nchange: something new\n")
+
+	if errs := validateDir(dir); len(errs) != 0 {
+		t.Fatalf("expected clean dir, got: %v", errs)
+	}
+
+	write("bad-extension.yml", "kind: added\narea: x\nchange: y\n")
+	write("bad-schema.yaml", "kind: nope\narea: x\nchange: y\n")
+
+	errs := validateDir(dir)
+	if len(errs) != 2 {
+		t.Fatalf("expected 2 errors, got %d: %v", len(errs), errs)
+	}
+}
+
+// TestRepoFragments validates the real changelog.d in this checkout, so a bad
+// fragment fails `make test` on the branch that introduced it, not just the CI
+// gate job.
+func TestRepoFragments(t *testing.T) {
+	repo := filepath.Join("..", "..", "changelog.d")
+	if _, err := os.Stat(repo); err != nil {
+		t.Skipf("no changelog.d at %s", repo)
+	}
+	if errs := validateDir(repo); len(errs) != 0 {
+		t.Fatalf("repo changelog.d has invalid fragments: %v", errs)
+	}
+}

--- a/cmd/changelog-check/main_test.go
+++ b/cmd/changelog-check/main_test.go
@@ -87,6 +87,36 @@ func TestValidateDir(t *testing.T) {
 	}
 }
 
+// TestValidateDirRejectsNonRegularFiles pins the symlink guard: a fragment
+// that is a symlink (even to a valid target, and even with a .yaml name) must
+// be rejected without following it, so the release-time compile step can never
+// be pointed at a file outside changelog.d/. Directories are rejected the same
+// way.
+func TestValidateDirRejectsNonRegularFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	outside := filepath.Join(t.TempDir(), "outside.yaml")
+	if err := os.WriteFile(outside, []byte("kind: added\narea: x\nchange: valid target\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, "sneaky.yaml")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "subdir.yaml"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	errs := validateDir(dir)
+	if len(errs) != 2 {
+		t.Fatalf("expected 2 errors, got %d: %v", len(errs), errs)
+	}
+	for _, err := range errs {
+		if !strings.Contains(err.Error(), "regular files") {
+			t.Fatalf("expected a regular-file rejection, got: %v", err)
+		}
+	}
+}
+
 // TestRepoFragments validates the real changelog.d in this checkout, so a bad
 // fragment fails `make test` on the branch that introduced it, not just the CI
 // gate job.

--- a/docs/making-a-release.md
+++ b/docs/making-a-release.md
@@ -1,0 +1,90 @@
+# Making a release
+
+attn's changelog is compiled, not accreted. PRs never edit `CHANGELOG.md`;
+each PR ships a small **changelog fragment** — a raw statement of what changed
+— and a release-time compilation step turns the accumulated fragments into one
+curated, user-facing `CHANGELOG.md` section. This removes the merge conflicts
+that concurrent branches used to hit on `CHANGELOG.md`, and it means the
+changelog is written once per release by a writer that saw the whole release,
+instead of thirty times by authors who each saw one PR.
+
+## Per PR: add a changelog fragment
+
+Every PR adds one YAML file under `changelog.d/`. Name it
+`<branch>-<short-slug>.yaml` — uniqueness across in-flight branches is what
+keeps fragments conflict-free.
+
+```yaml
+# changelog.d/amber-manatee-handover.yaml
+kind: fixed            # added | changed | fixed | removed | internal
+area: queue            # the subsystem touched, free-form
+change: >
+  Closing a turn now hands over the next agent that owes one regardless of
+  how the turn closed, not only via Cmd+Shift+E.
+symptom: >             # optional — for fixes, what the user noticed before
+  Auto-settle finishing on the agent you were watching left you sitting on a
+  done agent instead of moving you to the next one.
+notes: >               # optional — extra context for the release writer
+  Same root cause as the sidebar-row settle path; both fixed here.
+```
+
+A fragment is **evidence for the release writer, not final copy**. State
+plainly what changed and what a user would notice; do not attempt release-note
+voice. The writer merges related fragments, sets the tone, and decides what
+makes the cut.
+
+Rules:
+
+- `kind`, `area`, and `change` are required. `kind` maps to the changelog
+  category (`added` → "### Added", etc.).
+- A change with no user-visible behavior still ships a fragment, with
+  `kind: internal` and a one-line `change`. Internal fragments give the
+  release writer the full picture; they never become bullets.
+- `go run ./cmd/changelog-check` validates fragments locally; the same check
+  runs in CI.
+
+## The CI gate
+
+The `Changelog` job in CI fails any PR that neither adds a
+`changelog.d/*.yaml` fragment nor modifies `CHANGELOG.md`. Touching
+`CHANGELOG.md` directly is the escape hatch for the compilation PR itself and
+for hand-fixes to existing copy. Branches named `release/*` (the version-bump
+PR that `scripts/release.sh` opens) are exempt. Run the gate locally with
+`./scripts/changelog-gate.sh main`.
+
+## At release: compile the changelog
+
+When preparing a release, on a fresh branch off `main`:
+
+```bash
+./scripts/compile-changelog.sh            # or --dry-run to inspect the prompt
+```
+
+The script validates the pending fragments, has `claude` write a dated
+`CHANGELOG.md` section from them (merging related entries, enforcing the
+user-facing voice, dropping noise), inserts it at the top of the file, and
+deletes the consumed fragments. Everything is left staged: **review the
+section** — the writer drafts, you edit — fix copy where it misses, commit,
+and open a PR. That PR passes the gate because it modifies `CHANGELOG.md`.
+
+If every pending fragment is `internal`, the script removes the fragments
+without adding a section.
+
+## Cut the release
+
+With the compilation PR merged and `main` clean of pending fragments:
+
+```bash
+./scripts/release.sh v0.9.5
+```
+
+`release.sh` refuses to run while `changelog.d/` still has pending fragments.
+It bumps versions, opens a `release/<tag>` PR, waits for CI, merges, tags the
+merge commit, and the tag triggers `.github/workflows/release.yml`.
+
+## What's New modal
+
+The in-app What's New modal (`app/src/components/WhatsNewModal.tsx`,
+`WHATS_NEW_ID` in `app/src/hooks/useWhatsNew.ts`) stays hand-written — it
+tells a story per milestone, not per release. When updating it, draw from the
+compiled changelog sections since the last `WHATS_NEW_ID` bump.

--- a/scripts/changelog-gate.sh
+++ b/scripts/changelog-gate.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PR changelog gate. Every PR must either add a fragment under changelog.d/ or
+# modify CHANGELOG.md directly (the release compilation PR does the latter;
+# hand-fixes to changelog copy also pass). release/* branches are the version
+# bump opened by scripts/release.sh and are exempt.
+#
+# usage: changelog-gate.sh <base-ref> [head-branch]
+#
+# Runs in CI (.github/workflows/ci.yml, job "Changelog") and locally:
+#   ./scripts/changelog-gate.sh main
+#
+# See docs/making-a-release.md.
+
+BASE_REF="${1:?usage: changelog-gate.sh <base-ref> [head-branch]}"
+HEAD_BRANCH="${2:-$(git branch --show-current)}"
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [[ "$HEAD_BRANCH" == release/* ]]; then
+  echo "changelog gate: release branch ${HEAD_BRANCH}, skipping"
+  exit 0
+fi
+
+# Diff against the merge-base with the base branch; prefer origin/<base> when
+# it exists (CI checks out with full history).
+RANGE="${BASE_REF}...HEAD"
+if git rev-parse -q --verify "origin/${BASE_REF}" >/dev/null; then
+  RANGE="origin/${BASE_REF}...HEAD"
+fi
+
+# Committed additions, plus staged/untracked ones so the gate is honest when
+# run locally before committing (CI only ever sees the committed set).
+added_fragment="$(
+  git diff --diff-filter=A --name-only "$RANGE" -- 'changelog.d/*.yaml'
+  git diff --diff-filter=A --name-only --cached -- 'changelog.d/*.yaml'
+  git ls-files --others --exclude-standard -- 'changelog.d/*.yaml'
+)"
+touched_changelog="$(
+  git diff --name-only "$RANGE" -- CHANGELOG.md
+  git diff --name-only HEAD -- CHANGELOG.md
+)"
+
+if [[ -z "$added_fragment" && -z "$touched_changelog" ]]; then
+  cat >&2 <<EOF
+changelog gate: this branch neither adds a changelog fragment nor touches
+CHANGELOG.md.
+
+Add one YAML fragment under changelog.d/ describing what changed (use
+kind: internal for changes with no user-visible behavior). Format and
+examples: docs/making-a-release.md
+EOF
+  exit 1
+fi
+
+if [[ -n "$added_fragment" ]]; then
+  echo "changelog gate: fragment(s) added:"
+  echo "$added_fragment" | sed 's/^/  /'
+else
+  echo "changelog gate: CHANGELOG.md modified directly"
+fi
+
+echo "changelog gate: validating changelog.d/"
+go run ./cmd/changelog-check
+echo "changelog gate: OK"

--- a/scripts/compile-changelog.sh
+++ b/scripts/compile-changelog.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Compile pending changelog fragments into a dated CHANGELOG.md section.
+#
+# Collects changelog.d/*.yaml (the raw facts each PR shipped), asks claude to
+# write the user-facing section per the style rules below, inserts it at the
+# top of CHANGELOG.md, and deletes the consumed fragments. The result is left
+# staged for review: read the section, fix the copy where it misses, then
+# commit and open a PR. See docs/making-a-release.md.
+#
+# usage: compile-changelog.sh [--dry-run]
+#   --dry-run  print the prompt that would be sent and exit without changes
+
+DRY_RUN=0
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1
+
+cd "$(git rev-parse --show-toplevel)"
+
+shopt -s nullglob
+fragments=(changelog.d/*.yaml)
+shopt -u nullglob
+
+if (( ${#fragments[@]} == 0 )); then
+  echo "no pending fragments in changelog.d/; nothing to compile"
+  exit 0
+fi
+
+if [[ "$DRY_RUN" -eq 0 ]] && ! command -v claude >/dev/null 2>&1; then
+  echo "error: claude CLI is required (https://claude.ai/code)" >&2
+  exit 1
+fi
+
+echo "validating ${#fragments[@]} fragment(s)..."
+go run ./cmd/changelog-check
+
+TODAY="$(date +%Y-%m-%d)"
+
+# Each fragment plus the subject of the commit that added it — after a squash
+# merge the subject carries the PR number, which the writer can use for context.
+FACTS=""
+for f in "${fragments[@]}"; do
+  subject="$(git log --diff-filter=A --format=%s -1 -- "$f" 2>/dev/null || true)"
+  [[ -z "$subject" ]] && subject="(uncommitted)"
+  FACTS+="--- fragment: ${f}
+--- introduced by: ${subject}
+$(cat "$f")
+
+"
+done
+
+# If the top section already carries today's date (a second compile in one
+# day), hand it to the writer to fold the new facts into.
+TOP_DATE="$(grep -m1 -o '^## \[[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\]' CHANGELOG.md | tr -d '#[] ' || true)"
+EXISTING_SECTION=""
+REPLACE_TOP=0
+if [[ "$TOP_DATE" == "$TODAY" ]]; then
+  REPLACE_TOP=1
+  EXISTING_SECTION="$(awk '/^## \[/{n++} n==1 && !/^---$/' CHANGELOG.md)"
+fi
+
+PROMPT="You are writing the changelog for attn, a macOS app that orchestrates
+coding agents. Below are raw changelog fragments, one per merged PR, written by
+the engineers who shipped each change. Compile them into one dated CHANGELOG.md
+section.
+
+Style rules — these matter more than fidelity to the fragment wording:
+- Write for the app's user, not the codebase. Lead every bullet with a bold
+  sentence stating the change in terms of what the user experiences, then
+  explain in plain prose. Clarity beats technical correctness.
+- Category headers in this order, only when non-empty: ### Added, ### Changed,
+  ### Fixed, ### Removed. kind maps to the header; kind: internal fragments are
+  context for you but get no bullet.
+- Merge related fragments into one bullet when they tell one story.
+- Drop what is below the noise floor for a user reading release notes.
+- Wrap lines at roughly 80 columns.
+
+Match the voice of these examples from the existing changelog:
+
+### Fixed
+- **⌘J jumps to the agent that has waited longest.** Jump-to-waiting used to
+  pick the first waiting session in sidebar workspace order, which made its
+  target feel arbitrary. It now follows the queue's own order — the turn owed
+  longest, the same row the \"Your turn\" band lists first.
+
+Output format: ONLY the markdown section, starting with the line
+## [${TODAY}]
+and nothing after the last bullet. No preamble, no code fences.
+If no fragment merits a user-facing bullet, output exactly: EMPTY
+
+Fragments:
+
+${FACTS}"
+
+if [[ "$REPLACE_TOP" -eq 1 ]]; then
+  PROMPT+="
+
+CHANGELOG.md already has a section for ${TODAY}. Fold its bullets and the new
+fragments into one merged section (rewriting bullets is fine):
+
+${EXISTING_SECTION}"
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "--- prompt (dry run, no changes made) ---"
+  echo "$PROMPT"
+  exit 0
+fi
+
+echo "writing section with claude..."
+SECTION="$(claude --strict-mcp-config -p "$PROMPT" < /dev/null)"
+
+if [[ "$SECTION" == "EMPTY" ]]; then
+  echo "no user-facing changes in pending fragments; removing them without a new section"
+  rm -f "${fragments[@]}"
+  git add -A changelog.d
+  echo "done — review with 'git status', then commit"
+  exit 0
+fi
+
+if [[ "$SECTION" != "## [${TODAY}]"* ]]; then
+  echo "error: unexpected writer output (expected a section starting with '## [${TODAY}]'):" >&2
+  printf '%s\n' "$SECTION" >&2
+  exit 1
+fi
+
+SECTION="$SECTION" REPLACE_TOP="$REPLACE_TOP" python3 - <<'PY'
+import os, re
+
+section = os.environ["SECTION"].strip()
+replace_top = os.environ["REPLACE_TOP"] == "1"
+
+with open("CHANGELOG.md") as fh:
+    content = fh.read()
+
+m = re.search(r"(?m)^## \[", content)
+if not m:
+    raise SystemExit("CHANGELOG.md has no dated sections; refusing to guess")
+
+head, rest = content[: m.start()], content[m.start() :]
+if replace_top:
+    # Drop the existing top section up to (and including) its trailing --- line.
+    parts = rest.split("\n---\n", 1)
+    rest = parts[1].lstrip("\n") if len(parts) > 1 else ""
+
+with open("CHANGELOG.md", "w") as fh:
+    fh.write(head + section + "\n\n---\n\n" + rest)
+PY
+
+rm -f "${fragments[@]}"
+git add -A changelog.d CHANGELOG.md
+
+echo
+echo "compiled ${#fragments[@]} fragment(s) into CHANGELOG.md section [${TODAY}]"
+echo "next: review the section (git diff --cached), fix copy where it misses,"
+echo "commit, and open a PR"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -103,6 +103,16 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
   exit 1
 fi
 
+shopt -s nullglob
+PENDING_FRAGMENTS=(changelog.d/*.yaml)
+shopt -u nullglob
+if (( ${#PENDING_FRAGMENTS[@]} > 0 )); then
+  echo "error: ${#PENDING_FRAGMENTS[@]} pending changelog fragment(s) in changelog.d/"
+  echo "compile the changelog first: ./scripts/compile-changelog.sh"
+  echo "(see docs/making-a-release.md)"
+  exit 1
+fi
+
 if git rev-parse -q --verify "refs/tags/${VERSION_TAG}" >/dev/null; then
   echo "error: tag ${VERSION_TAG} already exists locally"
   exit 1


### PR DESCRIPTION
## Why

CHANGELOG.md is a serialization point: every PR appends bullets to the same few lines at the top of the file, so any two in-flight branches conflict on it. With several agents working concurrently, changelog conflicts were a constant tax on merges. GitHub computes PR conflicts server-side without custom merge drivers, so the only structural fix is for PRs to stop editing the shared file.

## What

The changelog becomes a compiled artifact. PRs ship a small **fragment** — a raw statement of what changed — and a release-time step compiles the accumulated fragments into one curated, user-facing dated section, written once by a writer that sees the whole release.

- **`changelog.d/`** — one YAML fragment per PR (`kind`/`area`/`change`, optional `symptom`/`notes`). Fragments are evidence for the release writer, not final copy. `kind: internal` records changes with no user-visible behavior; they inform the writer but never become bullets. Unique filenames per branch make fragments conflict-free by construction.
- **`cmd/changelog-check`** — schema validator (unknown kinds, missing fields, and typo'd keys all rejected). Unit-tested; `TestRepoFragments` also validates the checked-in `changelog.d/` so a bad fragment fails `make test` on the branch that introduced it.
- **`Changelog` CI job + `scripts/changelog-gate.sh`** — every PR must add a `changelog.d/*.yaml` fragment or modify `CHANGELOG.md` directly (the escape hatch used by the compilation PR and copy hand-fixes). `release/*` branches (the version bump from `scripts/release.sh`) are exempt. Runs locally too, counting staged/untracked fragments so pre-commit runs are honest.
- **`scripts/compile-changelog.sh`** — validates pending fragments, has `claude -p` write the dated section per the changelog's house style (bold user-facing lead, related entries merged, internal dropped), inserts it at the top of `CHANGELOG.md`, deletes the consumed fragments, and leaves everything staged for human review. Handles a second same-day compile by folding the existing section in, and an all-internal set by removing fragments without a section. `--dry-run` prints the prompt.
- **`scripts/release.sh`** — refuses to cut a release while fragments are pending.
- **`docs/making-a-release.md`** — owns the fragment format, gate rules, and release workflow; AGENTS.md points there.

This PR carries its own `kind: internal` fragment, so the new gate passes on the PR that introduces it.

## Verification

- Validator: `go test ./cmd/changelog-check` green; `gofmt`/`go vet` clean.
- Gate exercised locally on all three paths: pass (fragment present), fail (empty diff → doc-pointing error, exit 1), and `release/*` exemption.
- Full live compile smoke: two fake user-facing fragments plus the real internal one, real `claude` invocation. The writer folded the existing same-day section in verbatim, wrote the fakes in the existing voice, omitted the internal fragment, and left all section separators intact. Working tree restored byte-identical afterward.
- The `Changelog` job on this PR is the live positive test of the CI wiring; a companion throwaway PR with no fragment verifies the job fails (link in comments, closed after).

## Notes

- The gate becomes *required* only once the `Changelog` check is added to branch protection — repo settings, not in this diff.
- The What's New modal stays hand-written; the doc notes it should draw from compiled sections.

https://claude.ai/code/session_01WSSv35YUQhgdR35f9zaDJF