### PR TITLE
test: changelog gate red-path check (do not merge)

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -128,3 +128,5 @@ generated from `attn profile tauri-config`, the authority's port and bundle id
 baked into the binary so a profiled app can never reach another profile's
 daemon); and **`attn profile clean`** for teardown. See
 `docs/plans/2026-06-13-parallel-profiles.md` for the design history.
+
+<!-- changelog-gate red test: trivial change, intentionally no fragment -->


### PR DESCRIPTION
Throwaway draft PR verifying that the `Changelog` CI job introduced in #720 fails a PR that neither adds a `changelog.d/` fragment nor modifies `CHANGELOG.md`. Expected result: the `Changelog` check goes red with a message pointing at `docs/making-a-release.md`. Closed after the check completes — never merged.

https://claude.ai/code/session_01WSSv35YUQhgdR35f9zaDJF