### PR TITLE
feat(queue): snooze an agent until a time you name

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -66,6 +66,7 @@
     "real-app:scenario-ordinary-delegation-ticket": "node scripts/real-app-harness/scenario-ordinary-delegation-ticket.mjs",
     "real-app:scenario-ticket-resume": "node scripts/real-app-harness/scenario-ticket-resume.mjs",
     "real-app:scenario-agent-queue": "node scripts/real-app-harness/scenario-agent-queue.mjs",
+    "real-app:scenario-agent-queue-snooze": "node scripts/real-app-harness/scenario-agent-queue-snooze.mjs",
     "real-app:scenario-nudge-trigger": "node scripts/real-app-harness/scenario-nudge-trigger.mjs",
     "real-app:scenario-terminal-block-copy": "node scripts/real-app-harness/scenario-terminal-block-copy.mjs",
     "real-app:scenario-terminal-context-menu": "node scripts/real-app-harness/scenario-terminal-context-menu.mjs",

--- a/app/scripts/real-app-harness/scenario-agent-queue-snooze.mjs
+++ b/app/scripts/real-app-harness/scenario-agent-queue-snooze.mjs
@@ -1,0 +1,475 @@
+#!/usr/bin/env node
+
+/**
+ * Real-app scenario: snoozing an agent in the queue.
+ *
+ * Settle answers *I dealt with this*. Snooze answers *not now*: it closes the
+ * open turn and stops the next one from opening until a time the user named.
+ * The claim only exists end to end — the daemon writes the settle and the
+ * deadline in one statement, suppresses the turn-open while the deadline holds,
+ * arms a timer, and the sidebar draws the row in its own section with the time
+ * it comes back.
+ *
+ * The run drives two real Claude agents in two workspaces and asserts, against
+ * the rendered DOM (`queue_get_state`) and the daemon's own broadcast, that:
+ *
+ *   1. snoozing from a queue row's menu closes that turn, takes the row out of
+ *      both bands, and puts it in the Snoozed section with a wake time,
+ *   2. snoozing the agent the user is looking at hands over the next agent that
+ *      owes a turn, the same way settling does,
+ *   3. the deferral actually holds: the snoozed agent runs, stops in a state
+ *      that would open a turn, and no turn opens,
+ *   4. waking early puts it back — and at the *tail*, behind the turn that has
+ *      been owed longer, because the clock on what you owe starts when you said
+ *      you would come back,
+ *   5. the wake timer does the same thing on its own when the deadline passes,
+ *   6. a deferral survives a daemon restart, deadline and all,
+ *   7. break-through: an agent whose process dies clears its own snooze and
+ *      opens a turn immediately, because that is what the user could not have
+ *      anticipated.
+ *
+ * The menu's shortest choice is 30 minutes, which is the product's answer and
+ * not a testable wait, so the timed legs send `snooze_turn` with a few-second
+ * deadline over the daemon socket. The menu itself is exercised in full for leg
+ * 1 — what the six buttons compute is unit-tested in snoozeDurations.test.ts.
+ *
+ * Prereqs: `claude` on PATH; a non-production profile install with the
+ * automation layer; a built `./attn` (or ATTN_HARNESS_BIN) for the restart step.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+import {
+  createSessionAndWaitForInitialPane,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+  relaunchAppAndConnect,
+} from './common.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { createScenarioRunner } from './scenarioRunner.mjs';
+import { currentHarnessProfile } from './harnessProfile.mjs';
+import { preTrustClaudeFolder, ensureClaudePromptReadyViaPty } from './scenarioAgents.mjs';
+import { waitForFirstWorkspacePane } from './scenarioAssertions.mjs';
+
+const HARNESS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+const TURN_OPENING_STATES = new Set(['waiting_input', 'pending_approval', 'unknown', 'idle']);
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') args.shift();
+  const options = parseCommonArgs(args);
+  return { options, help: args.includes('--help') || args.includes('-h') };
+}
+
+async function pollFor(fn, description, timeoutMs = 60_000, intervalMs = 500) {
+  const startedAt = Date.now();
+  let last = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    last = await fn();
+    if (last) return last;
+    await delay(intervalMs);
+  }
+  throw new Error(`Timed out waiting for: ${description}. Last value: ${JSON.stringify(last)}`);
+}
+
+function resolveAttnBin() {
+  const candidates = [process.env.ATTN_HARNESS_BIN, path.resolve(HARNESS_DIR, '../../../attn')].filter(Boolean);
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  throw new Error('attn binary not found (build ./attn or set ATTN_HARNESS_BIN)');
+}
+
+const queueState = (client) => client.request('queue_get_state');
+const turnIds = (queue) => (queue.turns || []).map((row) => row.id);
+const snoozedIds = (queue) => (queue.snoozed?.rows || []).map((row) => row.id);
+
+// Claude treats a fast multi-line write as a paste, so the submit has to be a
+// lone carriage return a beat later.
+async function submitPrompt(client, sessionId, paneId, text) {
+  await client.request('write_pane', { sessionId, paneId, text, submit: false });
+  await delay(600);
+  await client.request('write_pane', { sessionId, paneId, text: '\r', submit: false });
+}
+
+async function createAgent(client, observer, runner, dirName, label) {
+  const cwd = path.join(runner.sessionDir, dirName);
+  fs.mkdirSync(cwd, { recursive: true });
+  preTrustClaudeFolder(cwd);
+  const sessionId = await createSessionAndWaitForInitialPane({
+    client,
+    observer,
+    cwd,
+    label,
+    agent: 'claude',
+    sessionWaitMs: 60_000,
+    promptReadyFn: ensureClaudePromptReadyViaPty,
+    promptReadyTimeoutMs: 90_000,
+  });
+  const pane = await waitForFirstWorkspacePane(client, sessionId, `pane for ${label}`, 20_000);
+  return { sessionId, paneId: pane.paneId, runtimeId: pane.runtimeId, cwd };
+}
+
+function questionPrompt(token) {
+  return [
+    `I am thinking about ${token} but I have not decided anything yet.`,
+    'Ask me exactly one short clarifying question about it and then stop and wait for my answer.',
+    'Do not use any tools and do not answer it yourself.',
+  ].join(' ');
+}
+
+// Generous on purpose: how long a live agent takes to stop says nothing about
+// whether the queue reacts to the state it stops in.
+const AGENT_STOP_TIMEOUT_MS = 240_000;
+
+async function driveToStop(client, observer, agent, token, description) {
+  await submitPrompt(client, agent.sessionId, agent.paneId, questionPrompt(token));
+  // It has to be seen working first, or a stop that has not started yet reads
+  // as a stop that already finished.
+  await pollFor(
+    () => (observer.getSession(agent.sessionId)?.state === 'working' ? true : null),
+    `${description} to start working`,
+    120_000,
+  );
+  return pollFor(
+    () => {
+      const state = observer.getSession(agent.sessionId)?.state;
+      return TURN_OPENING_STATES.has(state) ? state : null;
+    },
+    description,
+    AGENT_STOP_TIMEOUT_MS,
+  );
+}
+
+async function waitForTurns(client, expected, description, timeoutMs = 30_000) {
+  return pollFor(
+    async () => {
+      const queue = await queueState(client);
+      return JSON.stringify(turnIds(queue)) === JSON.stringify(expected) ? queue : null;
+    },
+    `${description} (expected turns ${JSON.stringify(expected)})`,
+    timeoutMs,
+  );
+}
+
+/**
+ * The live agent process for a session, found by its working directory.
+ *
+ * By cwd rather than by name: a `pkill -f` against the command line would match
+ * any sibling agent on this machine, and the run's cwd is unique to it.
+ */
+function agentPidForCwd(cwd) {
+  const rows = execFileSync('ps', ['-axo', 'pid=,command='], { encoding: 'utf8' }).split('\n');
+  const candidates = rows
+    .map((row) => row.trim().match(/^(\d+)\s+(.*)$/))
+    .filter((match) => match && /(^|\/)claude(\s|$)/.test(match[2]))
+    .map((match) => Number(match[1]));
+  for (const pid of candidates) {
+    let out = '';
+    try {
+      out = execFileSync('lsof', ['-a', '-d', 'cwd', '-p', String(pid), '-Fn'], { encoding: 'utf8' });
+    } catch {
+      continue; // gone between the listing and the probe
+    }
+    if (out.split('\n').some((line) => line.startsWith('n') && line.slice(1) === cwd)) return pid;
+  }
+  return null;
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-agent-queue-snooze.mjs');
+    return;
+  }
+
+  const runner = createScenarioRunner(options, {
+    scenarioId: 'AGENT-QUEUE-SNOOZE',
+    tier: 'tier3-local-agent',
+    prefix: 'agent-queue-snooze',
+    metadata: {
+      focus: 'a snooze closes the turn, suppresses the next one, and wakes to the tail',
+    },
+  });
+
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  const profile = currentHarnessProfile();
+  const attnBin = resolveAttnBin();
+  const daemonEnv = { ...process.env, ATTN_PROFILE: profile };
+  const createdSessionIds = [];
+
+  runner.log('run context', { runDir: runner.runDir, sessionDir: runner.sessionDir, profile });
+
+  runner.registerCleanup('close_observer', () => observer.close());
+  runner.registerCleanup('quit_app', () => client.quitApp());
+  runner.registerCleanup('close_sessions', async () => {
+    for (const sessionId of [...createdSessionIds].reverse()) {
+      await client.request('close_session', { sessionId }).catch(() => {});
+    }
+  });
+  runner.registerCleanup('restore_queue_mode', () =>
+    client.request('set_setting', { key: 'queue_mode_enabled', value: 'false' }).catch(() => {}));
+
+  const snoozeUntil = (sessionId, ms) => {
+    const until = new Date(Date.now() + ms).toISOString();
+    observer.send({ cmd: 'snooze_turn', session_id: sessionId, until });
+    return until;
+  };
+
+  let alpha;
+  let beta;
+
+  try {
+    await runner.step('launch_app_with_queue_mode', async () => {
+      process.env.ATTN_HARNESS_PARK_VISIBLE_PX ??= '0';
+      await launchFreshAppAndConnect(client, observer);
+      await client.request('set_setting', { key: 'queue_mode_enabled', value: 'true' });
+    });
+
+    await runner.step('two_agents_owe_turns', async () => {
+      alpha = await createAgent(client, observer, runner, 'alpha', `snooze-alpha-${runner.runId}`);
+      createdSessionIds.push(alpha.sessionId);
+      await driveToStop(client, observer, alpha, 'SNOOZE_ALPHA', 'alpha to want the user');
+
+      beta = await createAgent(client, observer, runner, 'beta', `snooze-beta-${runner.runId}`);
+      createdSessionIds.push(beta.sessionId);
+      await driveToStop(client, observer, beta, 'SNOOZE_BETA', 'beta to want the user');
+
+      // Alpha's turn opened first, so it stays ahead of beta throughout — which
+      // is what makes "beta came back at the tail" a real assertion rather than
+      // a coincidence of a one-row band.
+      await waitForTurns(client, [alpha.sessionId, beta.sessionId], 'both turns, oldest first');
+    });
+
+    await runner.step('snoozing_from_the_row_menu_parks_the_agent_and_hands_over', async () => {
+      // Snooze the agent the user is looking at: closing its turn should move
+      // them on, exactly as settling does.
+      await client.request('select_session', { sessionId: beta.sessionId });
+      await pollFor(async () => {
+        const state = await client.request('get_state');
+        return state.activeSessionId === beta.sessionId ? state : null;
+      }, 'beta to be the agent on screen', 15_000);
+
+      await client.request('dom_click', { selector: `[data-testid="queue-snooze-${beta.sessionId}"]` });
+      // The click on the choice is itself the assertion that the menu opened:
+      // dom_click fails loudly when the selector is not in the DOM.
+      const chosen = await pollFor(
+        () => client.request('dom_click', { selector: '[data-testid="snooze-choice-30m"]' }).catch(() => null),
+        'the snooze duration menu to open with its 30-minute choice',
+        10_000,
+      );
+      runner.log('chose 30 minutes', chosen);
+
+      const queue = await waitForTurns(client, [alpha.sessionId], 'beta out of the turns band');
+      runner.assert(
+        !(queue.settled || []).some((row) => row.id === beta.sessionId),
+        `a deferred agent is not in Settled either: ${JSON.stringify((queue.settled || []).map((r) => r.id))}`,
+      );
+      runner.assert(queue.snoozed.present, 'the Snoozed section is drawn once something is deferred');
+      runner.assert(
+        queue.snoozed.header.includes('(1)'),
+        `the section counts what is in it: ${queue.snoozed.header}`,
+      );
+      runner.assert(
+        !queue.snoozed.expanded && queue.snoozed.rows.length === 0,
+        'the section ships collapsed — a snooze surfaces itself when it wakes',
+      );
+
+      await client.request('dom_click', { selector: '[data-testid="snoozed-section-header"]' });
+      const expanded = await pollFor(async () => {
+        const current = await queueState(client);
+        return current.snoozed.expanded ? current : null;
+      }, 'the Snoozed section to expand', 10_000);
+      const row = expanded.snoozed.rows.find((entry) => entry.id === beta.sessionId);
+      runner.assert(row, `beta is the deferred row: ${JSON.stringify(snoozedIds(expanded))}`);
+      runner.assert(row.wake, `the row says when it comes back: ${JSON.stringify(row)}`);
+      runner.log('deferred row', row);
+
+      // The daemon's own answer, not just the drawing of it.
+      const session = await pollFor(
+        () => {
+          const current = observer.getSession(beta.sessionId);
+          // turn_owed is omitted from the broadcast when false, so its absence
+          // is the closed turn.
+          return current && !current.turn_owed && current.turn_snoozed_until ? current : null;
+        },
+        'the daemon to broadcast the closed turn and the deadline',
+        15_000,
+      );
+      runner.log('broadcast deadline', {
+        turnOwed: session.turn_owed ?? false,
+        snoozedUntil: session.turn_snoozed_until,
+      });
+      const minutes = (Date.parse(session.turn_snoozed_until) - Date.now()) / 60_000;
+      runner.assert(
+        minutes > 28 && minutes < 31,
+        `the 30-minute choice deferred it by about 30 minutes: ${minutes.toFixed(1)}`,
+      );
+
+      const moved = await pollFor(async () => {
+        const state = await client.request('get_state');
+        return state.activeSessionId === alpha.sessionId ? state : null;
+      }, 'snoozing the watched agent to hand over the next one that wants the user', 15_000);
+      runner.assert(moved.activeSessionId === alpha.sessionId, 'handover landed on alpha');
+    });
+
+    await runner.step('the_deferral_holds_while_the_agent_runs_and_stops', async () => {
+      // The whole point. The agent works, stops in a state that would open a
+      // turn, and nothing opens — this is the suppression, and it is the one
+      // claim a unit test of the band cannot make.
+      const state = await driveToStop(client, observer, beta, 'SNOOZE_BETA_AGAIN', 'the deferred agent to stop again');
+      runner.log('the deferred agent stopped', { state });
+      await delay(3_000);
+
+      const queue = await queueState(client);
+      runner.assert(
+        JSON.stringify(turnIds(queue)) === JSON.stringify([alpha.sessionId]),
+        `stopping opened no turn for the deferred agent: ${JSON.stringify(turnIds(queue))}`,
+      );
+      runner.assert(
+        snoozedIds(queue).includes(beta.sessionId),
+        `it is still parked, with its wake time: ${JSON.stringify(queue.snoozed)}`,
+      );
+      runner.assert(
+        !observer.getSession(beta.sessionId)?.turn_owed,
+        'and the daemon agrees no turn is owed',
+      );
+    });
+
+    await runner.step('waking_early_returns_it_to_the_tail', async () => {
+      await client.request('dom_click', { selector: `[data-testid="queue-wake-${beta.sessionId}"]` });
+      const queue = await waitForTurns(
+        client,
+        [alpha.sessionId, beta.sessionId],
+        'the woken agent back in the band, behind the turn owed longer',
+      );
+      runner.assert(
+        !queue.snoozed.present,
+        `the section goes away with the last deferral: ${JSON.stringify(queue.snoozed)}`,
+      );
+      // The tail, not the head: the woken turn is stamped at the wake instant,
+      // so alpha — owed since before the snooze — stays ahead of it.
+      runner.assert(turnIds(queue)[1] === beta.sessionId, 'it came back at the tail');
+    });
+
+    await runner.step('the_timer_wakes_it_on_its_own', async () => {
+      const until = snoozeUntil(beta.sessionId, 8_000);
+      runner.log('deferred by the daemon command', { until });
+      await waitForTurns(client, [alpha.sessionId], 'the short deferral to close the turn');
+
+      const queue = await pollFor(
+        async () => {
+          const current = await queueState(client);
+          return turnIds(current).length === 2 ? current : null;
+        },
+        'the wake timer to put it back by itself',
+        45_000,
+      );
+      runner.assert(
+        JSON.stringify(turnIds(queue)) === JSON.stringify([alpha.sessionId, beta.sessionId]),
+        `the timer woke it to the tail: ${JSON.stringify(turnIds(queue))}`,
+      );
+      runner.assert(
+        !queue.snoozed.present,
+        `and cleared the deferral: ${JSON.stringify(queue.snoozed)}`,
+      );
+    });
+
+    await runner.step('a_deferral_survives_a_daemon_restart', async () => {
+      snoozeUntil(beta.sessionId, 20 * 60_000);
+      await waitForTurns(client, [alpha.sessionId], 'beta deferred again, for long enough to restart under');
+
+      await client.quitApp();
+      await observer.close();
+      try { execFileSync(attnBin, ['daemon', 'stop'], { env: daemonEnv, encoding: 'utf8' }); } catch { /* already down */ }
+      execFileSync(attnBin, ['daemon', 'ensure'], { env: daemonEnv, encoding: 'utf8' });
+      await relaunchAppAndConnect(client, observer);
+
+      const queue = await waitForTurns(
+        client,
+        [alpha.sessionId],
+        'the deferral rebuilt from the persisted deadline',
+        60_000,
+      );
+      runner.assert(
+        snoozedIds(queue).includes(beta.sessionId) || queue.snoozed.header.includes('(1)'),
+        `beta is still parked after the restart: ${JSON.stringify(queue.snoozed)}`,
+      );
+      runner.assert(
+        observer.getSession(beta.sessionId)?.turn_snoozed_until,
+        'and the daemon still broadcasts its deadline',
+      );
+    });
+
+    await runner.step('a_dead_agent_breaks_through_its_own_snooze', async () => {
+      // The one thing the user could not have anticipated. Killing the process
+      // with a signal rather than a clean exit is deliberate: a clean exit is
+      // auto-close's business, and closing the session would take the row away
+      // instead of ringing.
+      const pid = agentPidForCwd(beta.cwd);
+      runner.assert(pid, `found the deferred agent's process: ${pid}`);
+      process.kill(pid, 'SIGKILL');
+
+      const queue = await pollFor(
+        async () => {
+          const current = await queueState(client);
+          return turnIds(current).includes(beta.sessionId) ? current : null;
+        },
+        'the dead agent to break through its deferral and ring',
+        60_000,
+      );
+      runner.log('after the break-through', {
+        turns: turnIds(queue),
+        state: observer.getSession(beta.sessionId)?.state,
+        reason: observer.getSession(beta.sessionId)?.state_reason,
+      });
+      runner.assert(
+        !queue.snoozed.present,
+        `the break-through consumed the deferral rather than pausing it: ${JSON.stringify(queue.snoozed)}`,
+      );
+      runner.assert(
+        !observer.getSession(beta.sessionId)?.turn_snoozed_until,
+        'and the daemon dropped the deadline',
+      );
+    });
+
+    const result = runner.finishSuccess({
+      alphaSessionId: alpha.sessionId,
+      betaSessionId: beta.sessionId,
+    });
+    console.log('[RealAppHarness] Agent queue snooze passed.');
+    console.log(JSON.stringify(result, null, 2));
+  } catch (error) {
+    const result = runner.finishFailure(error, {
+      queue: await queueState(client).catch(() => null),
+      sessions: (await client.request('get_state').catch(() => null))?.sessions?.map((session) => ({
+        id: session.id,
+        label: session.label,
+        state: session.state,
+      })) ?? null,
+    });
+    console.error(result.error);
+    process.exitCode = 1;
+  } finally {
+    await client.request('set_setting', { key: 'queue_mode_enabled', value: 'false' }).catch(() => {});
+    for (const sessionId of createdSessionIds.reverse()) {
+      await client.request('close_session', { sessionId }).catch(() => {});
+    }
+    await client.quitApp().catch(() => {});
+    await observer.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/scripts/real-app-harness/scenarioCatalog.mjs
+++ b/app/scripts/real-app-harness/scenarioCatalog.mjs
@@ -103,6 +103,15 @@ export const scenarioCatalog = [
     timeoutMs: 900_000,
   },
   {
+    id: 'agent-queue-snooze',
+    label: 'Agent queue snooze: a deferral closes the turn, suppresses the next one, and wakes to the tail',
+    command: ['pnpm', 'run', 'real-app:scenario-agent-queue-snooze'],
+    // Boots two real Claude agents, defers one through the row menu, drives it
+    // through a second run under the deferral, restarts the daemon, and kills
+    // an agent process to prove the break-through.
+    timeoutMs: 900_000,
+  },
+  {
     id: 'automation-lifecycle',
     label: 'Automation lifecycle: edit-rebind, delete-resurrect, cleanup-dirty-safe',
     command: ['pnpm', 'run', 'real-app:scenario-automation-lifecycle'],

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { MouseEvent as ReactMouseEvent } from 'react';
 import { onOpenUrl, getCurrent } from '@tauri-apps/plugin-deep-link';
 import { invoke, isTauri } from '@tauri-apps/api/core';
 import { getVersion } from '@tauri-apps/api/app';
@@ -31,6 +32,7 @@ import { ShortcutsModal } from './components/ShortcutsModal';
 import { ShortcutEditorModal } from './components/ShortcutEditorModal';
 import { WhatsNewModal } from './components/WhatsNewModal';
 import { ActionMenu, type ActionMenuItem } from './components/ActionMenu';
+import { SnoozeMenu } from './components/SnoozeMenu';
 import { MarkdownOpener, OPENER_EXTENSIONS } from './components/palette/MarkdownOpener';
 import { resolveMarkdownOpenerTarget } from './components/palette/openerTarget';
 import { claimPaletteFocus } from './components/palette/paletteClaim';
@@ -603,6 +605,8 @@ function App() {
     sendSessionSelected,
     sendTriggerNudge,
     sendSettleTurn,
+    sendSnoozeTurn,
+    sendWakeTurn,
     sendCancelAutoSettle,
     sendWorkspaceSelected,
     sendWorkspaceAddSessionPane,
@@ -823,6 +827,8 @@ function App() {
         sendSessionSelected={sendSessionSelected}
         sendTriggerNudge={sendTriggerNudge}
         sendSettleTurn={sendSettleTurn}
+        sendSnoozeTurn={sendSnoozeTurn}
+        sendWakeTurn={sendWakeTurn}
         sendCancelAutoSettle={sendCancelAutoSettle}
         sendWorkspaceSelected={sendWorkspaceSelected}
         sendWorkspaceAddSessionPane={sendWorkspaceAddSessionPane}
@@ -950,6 +956,8 @@ interface AppContentProps {
   sendSessionSelected: ReturnType<typeof useDaemonSocket>['sendSessionSelected'];
   sendTriggerNudge: ReturnType<typeof useDaemonSocket>['sendTriggerNudge'];
   sendSettleTurn: ReturnType<typeof useDaemonSocket>['sendSettleTurn'];
+  sendSnoozeTurn: ReturnType<typeof useDaemonSocket>['sendSnoozeTurn'];
+  sendWakeTurn: ReturnType<typeof useDaemonSocket>['sendWakeTurn'];
   sendCancelAutoSettle: ReturnType<typeof useDaemonSocket>['sendCancelAutoSettle'];
   sendWorkspaceSelected: ReturnType<typeof useDaemonSocket>['sendWorkspaceSelected'];
   sendWorkspaceAddSessionPane: ReturnType<typeof useDaemonSocket>['sendWorkspaceAddSessionPane'];
@@ -1071,6 +1079,8 @@ sendFetchPRDetails,
   sendSessionSelected,
   sendTriggerNudge,
   sendSettleTurn,
+  sendSnoozeTurn,
+  sendWakeTurn,
   sendCancelAutoSettle,
   sendWorkspaceSelected,
   sendWorkspaceAddSessionPane,
@@ -1451,6 +1461,7 @@ sendFetchPRDetails,
       nudgeFiresAt: daemonSession?.nudge_fires_at,
       turnOwed: daemonSession?.turn_owed ?? false,
       turnOpenedAt: daemonSession?.turn_opened_at,
+      turnSnoozedUntil: daemonSession?.turn_snoozed_until,
       autoSettleFiresAt: daemonSession?.auto_settle_fires_at,
       // Dropped when a pane status overrides the state: the reason describes the
       // resolver's answer, and a pane-derived state was not the resolver's.
@@ -2781,6 +2792,7 @@ sendFetchPRDetails,
     ];
   }, [actionMenuItems, activeWorkspaceForCommands, sendPinWorkspace, sendMuteWorkspace]);
 
+
   // Each arrangement has one notion of what wants the user, and the mode selects
   // it. In the queue arrangement that is the daemon's turn_owed — which honours
   // settle, and the shell/chief/pinned/muted exclusions a client cannot see. With
@@ -2888,6 +2900,83 @@ sendFetchPRDetails,
       : undefined),
     [queueModeEnabled, activeSessionId, sendSettleTurn],
   );
+
+  // The snooze duration menu. Snooze needs a *when*, so unlike settle the verb
+  // cannot fire straight from a keystroke or a click — every entry point opens
+  // this and the choice is what sends the command.
+  const [snoozeMenu, setSnoozeMenu] = useState<
+    { session: { id: string; label: string }; anchor: { top: number; left: number } } | null
+  >(null);
+
+  const openSnoozeMenu = useCallback(
+    (session: { id: string; label: string }, event: ReactMouseEvent) => {
+      const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+      setSnoozeMenu({ session, anchor: { top: rect.bottom + 4, left: rect.left } });
+    },
+    [],
+  );
+
+  // The keyboard path has no click to anchor to, so it anchors to the selected
+  // session's own row — the menu belongs to that agent, and opening it in the
+  // middle of the screen would make the user check which one it means. Falling
+  // back to the viewport corner keeps the verb usable when the row is scrolled
+  // out or the sidebar is collapsed.
+  const handleSnoozeActiveSession = useMemo(
+    () => (queueModeEnabled
+      ? () => {
+        if (!activeSessionId) return;
+        const session = enrichedLocalSessions.find((s) => s.id === activeSessionId);
+        if (!session) return;
+        const row = document.querySelector<HTMLElement>(`[data-testid$="-${activeSessionId}"].queue-row`);
+        const rect = row?.getBoundingClientRect();
+        setSnoozeMenu({
+          session: { id: session.id, label: session.label },
+          anchor: rect ? { top: rect.bottom + 4, left: rect.left } : { top: 72, left: 72 },
+        });
+      }
+      : undefined),
+    [queueModeEnabled, activeSessionId, enrichedLocalSessions],
+  );
+
+  // Snooze and wake for the agent you are in. One entry each rather than one per
+  // duration: six near-identical rows would crowd the palette, and the duration
+  // menu is where the wake times are actually shown. Both are queue-only, like
+  // the shortcut — there is no queue to defer out of with the arrangement off.
+  const activeSessionSnoozedUntil = enrichedLocalSessions.find(
+    (session) => session.id === activeSessionId,
+  )?.turnSnoozedUntil;
+  const actionMenuItemsWithQueueActions = useMemo<ActionMenuItem[]>(() => {
+    if (!queueModeEnabled || !activeSessionId) return actionMenuItemsWithWorkspaceActions;
+    const items = [...actionMenuItemsWithWorkspaceActions];
+    if (activeSessionSnoozedUntil) {
+      items.push({
+        id: 'wake-active-session',
+        title: 'Wake this agent now',
+        description: 'End the snooze and let it back into the queue',
+        keywords: ['wake', 'snooze', 'defer', 'queue', 'turn'],
+        icon: <AttentionActionIcon />,
+        run: () => sendWakeTurn(activeSessionId),
+      });
+    } else if (handleSnoozeActiveSession) {
+      items.push({
+        id: 'snooze-active-session',
+        title: 'Snooze this agent…',
+        description: 'Take it off your plate until a time you choose',
+        keywords: ['snooze', 'defer', 'later', 'queue', 'turn'],
+        icon: <AttentionActionIcon />,
+        shortcut: [shortcutTokens('session.snooze')],
+        run: handleSnoozeActiveSession,
+      });
+    }
+    return items;
+  }, [
+    actionMenuItemsWithWorkspaceActions,
+    queueModeEnabled,
+    activeSessionId,
+    activeSessionSnoozedUntil,
+    handleSnoozeActiveSession,
+    sendWakeTurn,
+  ]);
 
   // Closing a turn hands over the next agent that owes one, or home when none
   // does. This is the only place that happens, for every way a turn can close:
@@ -3596,6 +3685,7 @@ sendFetchPRDetails,
     onToggleGridMode: toggleGridMode,
     onJumpToWaiting: handleJumpToWaiting,
     onSettleTurn: handleSettleActiveTurn,
+    onSnoozeTurn: handleSnoozeActiveSession,
     onCancelAutoSettle: handleCancelAutoSettle,
     onSelectWorkspaceByIndex: handleSelectWorkspaceByIndex,
     onPrevSession: handlePrevWorkspace,
@@ -3778,6 +3868,8 @@ sendFetchPRDetails,
           onWorkspaceReorder={handleWorkspaceReorder}
           queue={queueBands}
           onSettleTurn={sendSettleTurn}
+          onOpenSnooze={openSnoozeMenu}
+          onWakeTurn={sendWakeTurn}
           onScreenSessionIds={onScreenSessionIds}
           onSelectSession={handleSelectSession}
           onTriggerNudge={sendTriggerNudge}
@@ -4196,9 +4288,20 @@ sendFetchPRDetails,
           }}
         />
       )}
+      {/* Owned here rather than in the sidebar because ⌘⇧S opens it too, and a
+          menu that exists only while the sidebar drew the row would be missing
+          exactly when the shortcut is most useful. */}
+      {snoozeMenu && (
+        <SnoozeMenu
+          sessionLabel={snoozeMenu.session.label}
+          anchor={snoozeMenu.anchor}
+          onSnooze={(until) => sendSnoozeTurn(snoozeMenu.session.id, until)}
+          onClose={() => setSnoozeMenu(null)}
+        />
+      )}
       <ActionMenu
         isOpen={actionMenuOpen}
-        actions={actionMenuItemsWithWorkspaceActions}
+        actions={actionMenuItemsWithQueueActions}
         onClose={() => setActionMenuOpen(false)}
       />
       <ShortcutsModal

--- a/app/src/components/QueueBands.test.tsx
+++ b/app/src/components/QueueBands.test.tsx
@@ -12,6 +12,7 @@ interface TestSession {
   chiefOfStaff?: boolean;
   turnOwed?: boolean;
   turnOpenedAt?: string;
+  turnSnoozedUntil?: string;
 }
 
 const baseProps = {
@@ -232,6 +233,100 @@ describe('the queue arrangement', () => {
       .map((icon) => icon.getAttribute('title'));
     expect(badgedTitles).toHaveLength(1);
     expect(badgedTitles[0]).toContain('beta');
+  });
+});
+
+describe('snoozing from the sidebar', () => {
+  // A real clock, because buildQueueBands compares the deadline against now.
+  const inAnHour = () => new Date(Date.now() + 3600_000).toISOString();
+
+  it('offers snooze on an owed turn and on a settled row alike', () => {
+    // Deferring a run *before* it finishes — so the turn it would open never
+    // opens — is the case the verb exists for, and that agent is settled.
+    const onOpenSnooze = vi.fn();
+    renderSidebar(sessions, true, { onOpenSnooze });
+
+    fireEvent.click(screen.getByTestId('queue-snooze-older'));
+    expect(onOpenSnooze).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 'older' }),
+      expect.anything(),
+    );
+
+    fireEvent.click(screen.getByTestId('queue-snooze-settled'));
+    expect(onOpenSnooze).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 'settled' }),
+      expect.anything(),
+    );
+  });
+
+  it('does not offer snooze on the chief, which never queues', () => {
+    renderSidebar(sessions, true, { onOpenSnooze: vi.fn() });
+    expect(screen.queryByTestId('queue-snooze-chief')).toBeNull();
+  });
+
+  it('takes a deferred agent out of the bands into its own collapsed section', () => {
+    const deferred: TestSession[] = [
+      ...sessions,
+      { id: 'later', label: 'later', state: 'idle', workspaceId: 'ws-a', turnSnoozedUntil: inAnHour() },
+    ];
+    const { container } = renderSidebar(deferred, true, { onWakeTurn: vi.fn() });
+
+    const bandRows = Array.from(container.querySelectorAll('.queue-bands .queue-row'))
+      .map((row) => row.getAttribute('data-testid'));
+    expect(bandRows).not.toContain('queue-settled-later');
+    expect(bandRows).not.toContain('queue-turn-later');
+
+    // Collapsed by default: a snooze surfaces itself when it wakes, so the
+    // section is for checking on a promise rather than standing room.
+    expect(screen.getByTestId('snoozed-section-header').textContent).toContain('Snoozed (1)');
+    expect(screen.queryByTestId('queue-snoozed-later')).toBeNull();
+  });
+
+  it('shows when each deferred agent comes back, and wakes it without selecting it', () => {
+    const onWakeTurn = vi.fn();
+    const onSelectSession = vi.fn();
+    const deferred: TestSession[] = [
+      { id: 'later', label: 'later', state: 'idle', workspaceId: 'ws-a', turnSnoozedUntil: inAnHour() },
+    ];
+    renderSidebar(deferred, true, { onWakeTurn, onSelectSession });
+
+    fireEvent.click(screen.getByTestId('snoozed-section-header'));
+    const row = screen.getByTestId('queue-snoozed-later');
+    expect(row.querySelector('.queue-row-wake-at')?.textContent).toBeTruthy();
+    // Already closed: waking is the undo, not a second way to dismiss.
+    expect(screen.queryByTestId('queue-settle-later')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('queue-wake-later'));
+    expect(onWakeTurn).toHaveBeenCalledWith('later');
+    expect(onSelectSession).not.toHaveBeenCalled();
+  });
+
+  it('sits above the muted workspaces', () => {
+    // *Not yet* is nearer to your attention than *not ever*.
+    const deferred: TestSession[] = [
+      { id: 'later', label: 'later', state: 'idle', workspaceId: 'ws-a', turnSnoozedUntil: inAnHour() },
+      { id: 'quiet', label: 'quiet', state: 'idle', workspaceId: 'ws-b' },
+    ];
+    const data = sidebarData(deferred, { 'ws-b': { muted: true } });
+    const { container } = render(
+      <Sidebar
+        {...baseProps}
+        {...data}
+        workspaces={data.workspaces.filter((workspace) => !workspace.muted)}
+        mutedWorkspaces={data.workspaces.filter((workspace) => workspace.muted)}
+        onWakeTurn={vi.fn()}
+        queue={buildQueueBands(data.workspaces)}
+      />
+    );
+
+    const sections = Array.from(container.querySelectorAll('.muted-sessions-header'))
+      .map((header) => header.textContent?.trim());
+    expect(sections).toEqual(['▸Snoozed (1)', '▸Muted Workspaces (1)']);
+  });
+
+  it('draws no section at all while nothing is deferred', () => {
+    renderSidebar(sessions, true, { onWakeTurn: vi.fn() });
+    expect(screen.queryByTestId('sidebar-snoozed')).toBeNull();
   });
 });
 

--- a/app/src/components/QueueBands.tsx
+++ b/app/src/components/QueueBands.tsx
@@ -5,6 +5,7 @@ import { SidebarSettlingBar } from './SettlingIndicator';
 import { formatShortcut } from '../shortcuts/formatShortcut';
 import type { UISessionState } from '../types/sessionState';
 import { formatTurnAge, type QueueBands as QueueBandsModel, type QueueRow } from '../utils/queueBands';
+import { formatWakeTime } from '../utils/snoozeDurations';
 import { useNow, TURN_AGE_TICK_MS } from '../hooks/useNow';
 
 export interface QueueBandSessionView {
@@ -15,6 +16,7 @@ export interface QueueBandSessionView {
   chiefOfStaff?: boolean;
   turnOwed?: boolean;
   turnOpenedAt?: string;
+  turnSnoozedUntil?: string;
   autoSettleFiresAt?: string;
 }
 
@@ -43,14 +45,24 @@ interface QueueBandsProps {
    * reach for anything in a band.
    */
   onOpenActions?: (session: { id: string; label: string; chiefOfStaff?: boolean }, event: ReactMouseEvent) => void;
+  /**
+   * Open the duration menu for a row. Offered on turns and on settled rows
+   * alike: deferring a run before it finishes — so the turn it would open never
+   * opens — is the case snooze exists for, and that row is by definition not in
+   * the turns band yet.
+   */
+  onOpenSnooze?: (session: { id: string; label: string }, event: ReactMouseEvent) => void;
 }
 
 function QueueRowView({
   row,
   selected,
   age,
+  wake,
   onSelect,
   onSettle,
+  onSnooze,
+  onWake,
   onPin,
   onOpenActions,
   showSettling,
@@ -59,8 +71,12 @@ function QueueRowView({
   row: QueueRow<QueueBandSessionView>;
   selected: boolean;
   age?: string;
+  /** When a deferred agent comes back. Only snoozed rows carry one. */
+  wake?: string;
   onSelect: () => void;
   onSettle?: () => void;
+  onSnooze?: (event: ReactMouseEvent) => void;
+  onWake?: () => void;
   onPin?: () => void;
   onOpenActions?: (event: ReactMouseEvent) => void;
   showSettling?: boolean;
@@ -103,8 +119,39 @@ function QueueRowView({
       <span className="session-label">{session.label}</span>
       {session.chiefOfStaff && <ChiefOfStaffBadge />}
       {age && <span className="queue-row-age">{age}</span>}
-      {(onOpenActions || onPin || onSettle) && (
+      {wake && <span className="queue-row-wake-at">{wake}</span>}
+      {(onOpenActions || onPin || onSettle || onSnooze || onWake) && (
         <div className="queue-row-controls">
+          {onWake && (
+            <button
+              type="button"
+              className="queue-row-wake"
+              data-testid={`queue-wake-${session.id}`}
+              title="Wake now — bring it back to the queue"
+              aria-label={`Wake ${session.label}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onWake();
+              }}
+            >
+              ↩
+            </button>
+          )}
+          {onSnooze && (
+            <button
+              type="button"
+              className="queue-row-snooze"
+              data-testid={`queue-snooze-${session.id}`}
+              title={`Snooze this agent (${formatShortcut('session.snooze')})`}
+              aria-label={`Snooze ${session.label}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onSnooze(event);
+              }}
+            >
+              ☾
+            </button>
+          )}
           {onOpenActions && (
             <div className="session-actions">
               <button
@@ -170,9 +217,20 @@ function QueueRowView({
  * Only pinned and muted workspaces still render as groups, below; they are
  * places you go and get work rather than a list handed to you.
  */
-export function QueueBands({ bands, selectedId, onSelectSession, onSettleTurn, onScreenSessionIds, onPinWorkspace, onOpenActions }: QueueBandsProps) {
+export function QueueBands({
+  bands,
+  selectedId,
+  onSelectSession,
+  onSettleTurn,
+  onScreenSessionIds,
+  onPinWorkspace,
+  onOpenActions,
+  onOpenSnooze,
+}: QueueBandsProps) {
   const now = useNow(TURN_AGE_TICK_MS);
   const offScreen = (id: string) => !onScreenSessionIds?.has(id);
+  const snoozeHandler = (session: QueueBandSessionView) =>
+    onOpenSnooze && ((event: ReactMouseEvent) => onOpenSnooze(session, event));
 
   return (
     <div className="queue-bands" data-testid="sidebar-queue">
@@ -200,6 +258,7 @@ export function QueueBands({ bands, selectedId, onSelectSession, onSettleTurn, o
             age={formatTurnAge(row.session.turnOpenedAt, now)}
             onSelect={() => onSelectSession(row.session.id)}
             onSettle={() => onSettleTurn(row.session.id)}
+            onSnooze={snoozeHandler(row.session)}
             onPin={onPinWorkspace && (() => onPinWorkspace(row.workspaceId, true))}
             onOpenActions={onOpenActions && ((event) => onOpenActions(row.session, event))}
             showSettling={offScreen(row.session.id)}
@@ -220,12 +279,83 @@ export function QueueBands({ bands, selectedId, onSelectSession, onSettleTurn, o
               row={row}
               selected={selectedId === row.session.id}
               onSelect={() => onSelectSession(row.session.id)}
+              // Snooze is offered here too: deferring an agent that is still
+              // running, so the turn it would open on finishing never opens, is
+              // the reach the verb was designed for — and that agent is settled,
+              // not owed.
+              onSnooze={snoozeHandler(row.session)}
               onPin={onPinWorkspace && (() => onPinWorkspace(row.workspaceId, true))}
               onOpenActions={onOpenActions && ((event) => onOpenActions(row.session, event))}
               testIdPrefix="queue-settled"
             />
           ))}
         </>
+      )}
+    </div>
+  );
+}
+
+interface QueueSnoozedSectionProps {
+  rows: QueueRow<QueueBandSessionView>[];
+  selectedId: string | null;
+  expanded: boolean;
+  onToggleExpanded: () => void;
+  onSelectSession: (id: string) => void;
+  onWakeTurn: (id: string) => void;
+}
+
+/**
+ * Deferred agents, collapsed at the foot of the sidebar above the muted
+ * workspaces.
+ *
+ * Not a band. The bands answer "whose turn is it"; this answers "what did I put
+ * off", which is a different question with a different lifetime — every row here
+ * leaves on its own, at a time the user named. It sits with muted rather than
+ * with settled because both are the quiet end of the sidebar, and it sits above
+ * muted because *not yet* is nearer to your attention than *not ever*.
+ *
+ * Collapsed by default, with a count. A snooze surfaces itself when it wakes, so
+ * the section is for checking on a promise or breaking it early — neither of
+ * which is worth standing room.
+ */
+export function QueueSnoozedSection({
+  rows,
+  selectedId,
+  expanded,
+  onToggleExpanded,
+  onSelectSession,
+  onWakeTurn,
+}: QueueSnoozedSectionProps) {
+  const now = useNow(TURN_AGE_TICK_MS);
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="muted-sessions-section" data-testid="sidebar-snoozed">
+      <button
+        className="muted-sessions-header"
+        onClick={onToggleExpanded}
+        aria-expanded={expanded}
+        data-testid="snoozed-section-header"
+      >
+        <span className={`muted-sessions-chevron ${expanded ? 'expanded' : ''}`}>▸</span>
+        Snoozed ({rows.length})
+      </button>
+      {expanded && (
+        <div className="muted-sessions-list">
+          {rows.map((row) => (
+            // No settle: a snoozed turn is already closed. Waking is the only
+            // act, and it is the undo rather than a second way to dismiss.
+            <QueueRowView
+              key={row.session.id}
+              row={row}
+              selected={selectedId === row.session.id}
+              wake={formatWakeTime(row.session.turnSnoozedUntil, now)}
+              onSelect={() => onSelectSession(row.session.id)}
+              onWake={() => onWakeTurn(row.session.id)}
+              testIdPrefix="queue-snoozed"
+            />
+          ))}
+        </div>
       )}
     </div>
   );

--- a/app/src/components/QueueBands.tsx
+++ b/app/src/components/QueueBands.tsx
@@ -332,6 +332,7 @@ export function QueueSnoozedSection({
   return (
     <div className="muted-sessions-section" data-testid="sidebar-snoozed">
       <button
+        type="button"
         className="muted-sessions-header"
         onClick={onToggleExpanded}
         aria-expanded={expanded}

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -1263,6 +1263,8 @@
    otherwise visible strip. */
 .queue-row-controls .session-actions,
 .queue-row-controls .queue-row-pin,
+.queue-row-controls .queue-row-snooze,
+.queue-row-controls .queue-row-wake,
 .queue-row-controls .queue-row-settle {
   opacity: 1;
   pointer-events: auto;
@@ -1277,6 +1279,8 @@
 }
 
 .queue-row-settle,
+.queue-row-snooze,
+.queue-row-wake,
 .queue-row-pin {
   flex: 0 0 auto;
   background: none;
@@ -1289,13 +1293,30 @@
 }
 
 .queue-row:hover .queue-row-settle,
+.queue-row:hover .queue-row-snooze,
+.queue-row:hover .queue-row-wake,
 .queue-row:hover .queue-row-pin,
 .queue-row-settle:focus-visible,
+.queue-row-snooze:focus-visible,
+.queue-row-wake:focus-visible,
 .queue-row-pin:focus-visible {
   opacity: 1;
 }
 
 .queue-row-settle:hover,
+.queue-row-snooze:hover,
+.queue-row-wake:hover,
 .queue-row-pin:hover {
   color: var(--color-text-primary);
+}
+
+/* When a deferred agent comes back. It sits where the turn age sits on a queued
+   row — same column, same weight — because both answer the row's one question:
+   a turn's is how long you have owed it, a snooze's is when it returns. */
+.queue-row-wake-at {
+  flex: 0 0 auto;
+  margin-left: auto;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-variant-numeric: tabular-nums;
 }

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -8,7 +8,7 @@ import { SessionActionsPopover } from './SessionActionsPopover';
 import { GridLayoutControl } from './grid/GridLayoutControl';
 import type { GridLayout } from './grid/gridLayout';
 import { StateIndicator } from './StateIndicator';
-import { QueueBands } from './QueueBands';
+import { QueueBands, QueueSnoozedSection } from './QueueBands';
 import { SidebarNudgeBar, deriveNudgeMode } from './NudgeIndicator';
 import { SidebarSettlingBar } from './SettlingIndicator';
 import { formatShortcut } from '../shortcuts/formatShortcut';
@@ -141,6 +141,9 @@ interface SidebarProps {
   // tile-only workspaces.
   queue?: QueueBandsModel<LocalSession> | null;
   onSettleTurn?: (id: string) => void;
+  /** Open the snooze duration menu for a row, anchored at the click. */
+  onOpenSnooze?: (session: { id: string; label: string }, event: ReactMouseEvent) => void;
+  onWakeTurn?: (id: string) => void;
   /**
    * Sessions whose terminal tile is on screen right now. The auto-settle
    * countdown lives on the tile, so the sidebar draws it only for the sessions
@@ -348,6 +351,8 @@ export function Sidebar({
   onToggleDockCollapsed,
   queue = null,
   onSettleTurn,
+  onOpenSnooze,
+  onWakeTurn,
   onScreenSessionIds,
   mutedWorkspaces = [],
   mutedExpanded: mutedExpandedProp,
@@ -393,6 +398,10 @@ export function Sidebar({
   );
 
   const [mutedExpandedLocal, setMutedExpandedLocal] = useState(false);
+  // Local, not lifted: unlike muted, nothing outside the sidebar needs to know
+  // whether the snoozed section is open, and it collapses again on its own as
+  // rows wake out of it.
+  const [snoozedExpanded, setSnoozedExpanded] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [displayMode, setDisplayMode] = useState<'open' | 'tight' | 'boxed'>('boxed');
   const [renameTarget, setRenameTarget] = useState<{
@@ -1002,6 +1011,7 @@ export function Sidebar({
           onScreenSessionIds={onScreenSessionIds}
           onPinWorkspace={onPinWorkspace}
           onOpenActions={openSessionActions}
+          onOpenSnooze={onOpenSnooze}
         />
       )}
 
@@ -1215,6 +1225,19 @@ export function Sidebar({
           </div>
         )}
       </div>
+
+      {/* Above muted, below everything else: *not yet* is nearer to your
+          attention than *not ever*. */}
+      {queue && onWakeTurn && (
+        <QueueSnoozedSection
+          rows={queue.snoozed}
+          selectedId={selectedId}
+          expanded={snoozedExpanded}
+          onToggleExpanded={() => setSnoozedExpanded(!snoozedExpanded)}
+          onSelectSession={onSelectSession}
+          onWakeTurn={onWakeTurn}
+        />
+      )}
 
       {mutedWorkspaces.length > 0 && (
         <div className="muted-sessions-section">

--- a/app/src/components/SnoozeMenu.css
+++ b/app/src/components/SnoozeMenu.css
@@ -1,0 +1,55 @@
+.snooze-menu {
+  background: var(--color-bg-panel);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.42);
+  padding: 5px;
+  position: fixed;
+  width: 216px;
+  z-index: 1000;
+}
+
+.snooze-menu-header {
+  color: var(--color-text-tertiary, var(--color-text-secondary));
+  font-size: var(--font-size-xs, 11px);
+  letter-spacing: 0.04em;
+  overflow: hidden;
+  padding: 6px 9px 7px;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.snooze-menu button {
+  align-items: baseline;
+  background: transparent;
+  border: 0;
+  border-radius: 5px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  display: flex;
+  font-size: var(--font-size-sm);
+  gap: 9px;
+  justify-content: space-between;
+  padding: 8px 9px;
+  text-align: left;
+  width: 100%;
+}
+
+.snooze-menu button:hover,
+.snooze-menu button:focus-visible {
+  background: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+  outline: none;
+}
+
+/* The concrete wake time is the supporting half of the row: present on every
+   line so the promise is legible, quiet enough that the durations still scan as
+   a list. */
+.snooze-menu-detail {
+  color: var(--color-text-tertiary, var(--color-text-secondary));
+  flex-shrink: 0;
+  font-size: var(--font-size-xs, 11px);
+  font-variant-numeric: tabular-nums;
+  opacity: 0.75;
+}

--- a/app/src/components/SnoozeMenu.tsx
+++ b/app/src/components/SnoozeMenu.tsx
@@ -26,13 +26,9 @@ const VIEWPORT_MARGIN = 8;
 export function SnoozeMenu({ sessionLabel, anchor, onSnooze, onClose }: SnoozeMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const [position, setPosition] = useState(anchor);
-  // Lazily, so the Date is built once when the menu opens rather than on every
-  // render and thrown away — the frozen instant is the point, and a rebuilt one
-  // would be the very thing this ref exists to avoid if useRef ever took the
-  // second value.
-  const openedAtRef = useRef<Date | null>(null);
-  if (openedAtRef.current === null) openedAtRef.current = new Date();
-  const openedAt = openedAtRef.current;
+  // A lazy initializer rather than a ref: the instant is read during render, so
+  // it belongs to state. Built once when the menu opens, and render stays pure.
+  const [openedAt] = useState(() => new Date());
 
   useEscapeStack(onClose, true);
 

--- a/app/src/components/SnoozeMenu.tsx
+++ b/app/src/components/SnoozeMenu.tsx
@@ -26,7 +26,13 @@ const VIEWPORT_MARGIN = 8;
 export function SnoozeMenu({ sessionLabel, anchor, onSnooze, onClose }: SnoozeMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const [position, setPosition] = useState(anchor);
-  const openedAt = useRef(new Date());
+  // Lazily, so the Date is built once when the menu opens rather than on every
+  // render and thrown away — the frozen instant is the point, and a rebuilt one
+  // would be the very thing this ref exists to avoid if useRef ever took the
+  // second value.
+  const openedAtRef = useRef<Date | null>(null);
+  if (openedAtRef.current === null) openedAtRef.current = new Date();
+  const openedAt = openedAtRef.current;
 
   useEscapeStack(onClose, true);
 
@@ -61,7 +67,7 @@ export function SnoozeMenu({ sessionLabel, anchor, onSnooze, onClose }: SnoozeMe
 
   const choose = (id: SnoozeChoiceId) => {
     onClose();
-    onSnooze(snoozeInstant(id, openedAt.current));
+    onSnooze(snoozeInstant(id, openedAt));
   };
 
   return (
@@ -83,7 +89,7 @@ export function SnoozeMenu({ sessionLabel, anchor, onSnooze, onClose }: SnoozeMe
           onClick={() => choose(choice.id)}
         >
           <span className="snooze-menu-label">{choice.label}</span>
-          <span className="snooze-menu-detail">{choice.detail(openedAt.current)}</span>
+          <span className="snooze-menu-detail">{choice.detail(openedAt)}</span>
         </button>
       ))}
     </div>

--- a/app/src/components/SnoozeMenu.tsx
+++ b/app/src/components/SnoozeMenu.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useEscapeStack } from '../hooks/useEscapeStack';
+import { SNOOZE_CHOICES, snoozeInstant, type SnoozeChoiceId } from '../utils/snoozeDurations';
+import './SnoozeMenu.css';
+
+interface SnoozeMenuProps {
+  sessionLabel: string;
+  anchor: { top: number; left: number };
+  onSnooze: (until: Date) => void;
+  onClose: () => void;
+}
+
+const VIEWPORT_MARGIN = 8;
+
+/**
+ * The durations a turn can be deferred by.
+ *
+ * Each row says the concrete time it resolves to as well as the duration: "Until
+ * Monday" is a promise about when you will be interrupted, and a menu that will
+ * not name the moment is one you have to test before you trust it.
+ *
+ * `now` is frozen when the menu opens, so the instant the user sees beside a row
+ * is the instant that gets sent — a menu left open across a minute boundary must
+ * not send something a minute later than it showed.
+ */
+export function SnoozeMenu({ sessionLabel, anchor, onSnooze, onClose }: SnoozeMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState(anchor);
+  const openedAt = useRef(new Date());
+
+  useEscapeStack(onClose, true);
+
+  useLayoutEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) return;
+    const rect = menu.getBoundingClientRect();
+    setPosition({
+      top: Math.max(
+        VIEWPORT_MARGIN,
+        Math.min(anchor.top, window.innerHeight - rect.height - VIEWPORT_MARGIN),
+      ),
+      left: Math.max(
+        VIEWPORT_MARGIN,
+        Math.min(anchor.left, window.innerWidth - rect.width - VIEWPORT_MARGIN),
+      ),
+    });
+  }, [anchor]);
+
+  useEffect(() => {
+    const handleMouseDown = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    const id = window.setTimeout(() => document.addEventListener('mousedown', handleMouseDown), 0);
+    return () => {
+      window.clearTimeout(id);
+      document.removeEventListener('mousedown', handleMouseDown);
+    };
+  }, [onClose]);
+
+  const choose = (id: SnoozeChoiceId) => {
+    onClose();
+    onSnooze(snoozeInstant(id, openedAt.current));
+  };
+
+  return (
+    <div
+      ref={menuRef}
+      className="snooze-menu"
+      style={{ top: position.top, left: position.left }}
+      role="menu"
+      aria-label={`Snooze ${sessionLabel}`}
+      data-testid="snooze-menu"
+    >
+      <div className="snooze-menu-header">Snooze {sessionLabel}</div>
+      {SNOOZE_CHOICES.map((choice) => (
+        <button
+          key={choice.id}
+          type="button"
+          role="menuitem"
+          data-testid={`snooze-choice-${choice.id}`}
+          onClick={() => choose(choice.id)}
+        >
+          <span className="snooze-menu-label">{choice.label}</span>
+          <span className="snooze-menu-detail">{choice.detail(openedAt.current)}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -177,7 +177,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '200';
+export const PROTOCOL_VERSION = '201';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a
@@ -4941,6 +4941,25 @@ export function useDaemonSocket({
     ws.send(JSON.stringify({ cmd: 'settle_turn', session_id: sessionId }));
   }, []);
 
+  // Defer a session until an instant. Closes any open turn and stops the next
+  // one opening before then, so an agent you cannot act on yet leaves the queue
+  // without being pretended-settled. `until` is absolute and computed here:
+  // "tomorrow" and "Monday" need the user's timezone, which the daemon that owns
+  // a remote session does not share. Fire and forget.
+  const sendSnoozeTurn = useCallback((sessionId: string, until: Date) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify({ cmd: 'snooze_turn', session_id: sessionId, until: until.toISOString() }));
+  }, []);
+
+  // End a snooze early. Whether a turn then opens depends on the state the agent
+  // is in, which is the daemon's call. Fire and forget.
+  const sendWakeTurn = useCallback((sessionId: string) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify({ cmd: 'wake_turn', session_id: sessionId }));
+  }, []);
+
   // Keep a turn auto-settle is about to close. Stops the countdown and leaves the
   // turn owed; the daemon also suppresses re-arming until the session next leaves
   // `working`, so the cancel survives the agent simply carrying on. Fire and
@@ -5507,6 +5526,8 @@ export function useDaemonSocket({
     sendSessionSelected,
     sendTriggerNudge,
     sendSettleTurn,
+    sendSnoozeTurn,
+    sendWakeTurn,
     sendCancelAutoSettle,
     sendWorkspaceSelected,
     sendWorkspaceGet,

--- a/app/src/hooks/useKeyboardShortcuts.ts
+++ b/app/src/hooks/useKeyboardShortcuts.ts
@@ -14,6 +14,7 @@ interface KeyboardShortcutsConfig {
   onJumpToWaiting: () => void;
   /** Undefined while the queue arrangement is off; the keystroke is then unbound. */
   onSettleTurn?: () => void;
+  onSnoozeTurn?: () => void;
   onCancelAutoSettle?: () => void;
   onSelectWorkspaceByIndex: (index: number) => void;
   onPrevSession: () => void;
@@ -44,6 +45,7 @@ export function useKeyboardShortcuts({
   onToggleGridMode,
   onJumpToWaiting,
   onSettleTurn,
+  onSnoozeTurn,
   onCancelAutoSettle,
   onSelectWorkspaceByIndex,
   onPrevSession,
@@ -79,6 +81,9 @@ export function useKeyboardShortcuts({
   // keystroke has nothing visible to act on, and an invisible verb that silently
   // stamps state is worse than no verb.
   useShortcut('session.settle', onSettleTurn ?? (() => {}), enabled && !!onSettleTurn);
+  // Same gate: snooze defers a turn, and there is no queue to defer out of while
+  // the arrangement is off.
+  useShortcut('session.snooze', onSnoozeTurn ?? (() => {}), enabled && !!onSnoozeTurn);
   useShortcut('session.cancelAutoSettle', onCancelAutoSettle ?? (() => {}), enabled && !!onCancelAutoSettle);
   useShortcut('session.toggleSidebar', onToggleSidebar ?? (() => {}), enabled && !!onToggleSidebar);
   useShortcut('session.refreshPRs', onRefreshPRs ?? (() => {}), enabled && !!onRefreshPRs);

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -1868,6 +1868,9 @@ export function useUiAutomationBridge({
             state: row.getAttribute('data-state') || '',
             workspaceId: row.getAttribute('data-workspace-id') || '',
             age: row.querySelector('.queue-row-age')?.textContent?.trim() || '',
+            // When a deferred agent comes back, as the row says it. Empty on
+            // every row that is not snoozed.
+            wake: row.querySelector('.queue-row-wake-at')?.textContent?.trim() || '',
             selected: row.classList.contains('selected'),
             open: open
               ? {
@@ -1879,6 +1882,11 @@ export function useUiAutomationBridge({
           };
         };
         const chiefRow = band?.querySelector('[data-testid^="queue-chief-"]');
+        // The snoozed section is a sibling of the bands, not part of them —
+        // deferred agents answer "what did I put off", not "whose turn is it" —
+        // so it is read from the document rather than from within the band.
+        const snoozedSection = document.querySelector('[data-testid="sidebar-snoozed"]');
+        const snoozedHeader = snoozedSection?.querySelector('[data-testid="snoozed-section-header"]');
         return {
           present: Boolean(band),
           empty: Boolean(band?.querySelector('[data-testid="queue-empty"]')),
@@ -1887,6 +1895,15 @@ export function useUiAutomationBridge({
             .map((row) => readRow(row, 'queue-turn-')),
           settled: Array.from(band?.querySelectorAll('[data-testid^="queue-settled-"]') || [])
             .map((row) => readRow(row, 'queue-settled-')),
+          snoozed: {
+            present: Boolean(snoozedSection),
+            header: snoozedHeader?.textContent?.trim() || '',
+            expanded: snoozedHeader?.getAttribute('aria-expanded') === 'true',
+            // Empty while the section is collapsed, which is a real answer: a
+            // collapsed section is what the user sees.
+            rows: Array.from(snoozedSection?.querySelectorAll('[data-testid^="queue-snoozed-"]') || [])
+              .map((row) => readRow(row, 'queue-snoozed-')),
+          },
           // What is left of the tree while the queue is on: pinned and tile-only
           // workspaces. An agent in a band must not also be here — appearing
           // twice is what made a row look like it moved.

--- a/app/src/shortcuts/cheatsheet.ts
+++ b/app/src/shortcuts/cheatsheet.ts
@@ -45,6 +45,7 @@ export function buildCheatsheet(): CheatsheetCategory[] {
         { label: 'Toggle grid view', combos: [fromId('view.toggleGrid')] },
         { label: 'Jump to next waiting session', combos: [fromId('session.jumpToWaiting')] },
         { label: 'Settle turn, go to next', combos: [fromId('session.settle')] },
+        { label: 'Snooze this agent', combos: [fromId('session.snooze')] },
         { label: 'Keep this turn (stop auto-settle)', combos: [fromId('session.cancelAutoSettle')] },
         { label: 'Toggle sidebar', combos: [fromId('session.toggleSidebar')] },
       ],

--- a/app/src/shortcuts/metadata.ts
+++ b/app/src/shortcuts/metadata.ts
@@ -63,6 +63,7 @@ export const SHORTCUT_META: Record<ShortcutId, ShortcutMeta> = {
   'view.toggleGrid': { label: 'Toggle grid view', category: 'sessions' },
   'session.jumpToWaiting': { label: 'Jump to next waiting session', category: 'sessions' },
   'session.settle': { label: 'Settle turn, go to next', category: 'sessions' },
+  'session.snooze': { label: 'Snooze this agent', category: 'sessions' },
   'session.cancelAutoSettle': { label: 'Keep this turn (stop auto-settle)', category: 'sessions' },
   'session.toggleSidebar': { label: 'Toggle sidebar', category: 'sessions', dockLabel: 'sidebar' },
   'workspace.select1': { label: 'Jump to workspace 1', category: 'sessions' },

--- a/app/src/shortcuts/registry.ts
+++ b/app/src/shortcuts/registry.ts
@@ -77,6 +77,11 @@ export const SHORTCUTS = {
   // and the shortcut editor's chord tests lean on ⌘E being free to record as an
   // exclusive leader.
   'session.settle': { key: 'e', meta: true, shift: true },
+  // Open the snooze duration menu for the selected session. Like session.settle
+  // it is bound only while the queue arrangement is on. ⌘⇧S carries no
+  // Menu::default accelerator (the default menu claims no S at all) and, being a
+  // Cmd chord, never reaches the PTY.
+  'session.snooze': { key: 's', meta: true, shift: true },
   // Keep the turn auto-settle is counting down to close. ⌘. is the macOS cancel
   // idiom, carries no Menu::default accelerator, and — being a Cmd chord — never
   // reaches the PTY, so it is safe to claim globally. Like session.settle it is

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelAutoSettleMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelAutoSettleMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -276,6 +276,7 @@
 //   const settingsUpdatedMessage = Convert.toSettingsUpdatedMessage(json);
 //   const settleTurnMessage = Convert.toSettleTurnMessage(json);
 //   const setWorkspaceRankMessage = Convert.toSetWorkspaceRankMessage(json);
+//   const snoozeTurnMessage = Convert.toSnoozeTurnMessage(json);
 //   const spawnResultMessage = Convert.toSpawnResultMessage(json);
 //   const spawnSessionMessage = Convert.toSpawnSessionMessage(json);
 //   const stateExplainEntry = Convert.toStateExplainEntry(json);
@@ -335,6 +336,7 @@
 //   const unregisterWorkspaceMessage = Convert.toUnregisterWorkspaceMessage(json);
 //   const unsubscribeGitStatusMessage = Convert.toUnsubscribeGitStatusMessage(json);
 //   const updateEndpointMessage = Convert.toUpdateEndpointMessage(json);
+//   const wakeTurnMessage = Convert.toWakeTurnMessage(json);
 //   const webSocketEvent = Convert.toWebSocketEvent(json);
 //   const workflowActionResultMessage = Convert.toWorkflowActionResultMessage(json);
 //   const workflowAgentCall = Convert.toWorkflowAgentCall(json);
@@ -868,6 +870,7 @@ export interface SessionElement {
     todos?:                string[];
     turn_opened_at?:       string;
     turn_owed?:            boolean;
+    turn_snoozed_until?:   string;
     workspace_id:          string;
     workspace_muted?:      boolean;
     [property: string]: any;
@@ -4162,6 +4165,7 @@ export interface Session {
     todos?:                string[];
     turn_opened_at?:       string;
     turn_owed?:            boolean;
+    turn_snoozed_until?:   string;
     workspace_id:          string;
     workspace_muted?:      boolean;
     [property: string]: any;
@@ -4413,6 +4417,17 @@ export interface SetWorkspaceRankMessage {
 
 export enum SetWorkspaceRankMessageCmd {
     SetWorkspaceRank = "set_workspace_rank",
+}
+
+export interface SnoozeTurnMessage {
+    cmd:        SnoozeTurnMessageCmd;
+    session_id: string;
+    until:      string;
+    [property: string]: any;
+}
+
+export enum SnoozeTurnMessageCmd {
+    SnoozeTurn = "snooze_turn",
 }
 
 export interface SpawnResultMessage {
@@ -5039,6 +5054,16 @@ export interface UpdateEndpointMessage {
 
 export enum UpdateEndpointMessageCmd {
     UpdateEndpoint = "update_endpoint",
+}
+
+export interface WakeTurnMessage {
+    cmd:        WakeTurnMessageCmd;
+    session_id: string;
+    [property: string]: any;
+}
+
+export enum WakeTurnMessageCmd {
+    WakeTurn = "wake_turn",
 }
 
 export interface WebSocketEvent {
@@ -7959,6 +7984,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SetWorkspaceRankMessage")), null, 2);
     }
 
+    public static toSnoozeTurnMessage(json: string): SnoozeTurnMessage {
+        return cast(JSON.parse(json), r("SnoozeTurnMessage"));
+    }
+
+    public static snoozeTurnMessageToJson(value: SnoozeTurnMessage): string {
+        return JSON.stringify(uncast(value, r("SnoozeTurnMessage")), null, 2);
+    }
+
     public static toSpawnResultMessage(json: string): SpawnResultMessage {
         return cast(JSON.parse(json), r("SpawnResultMessage"));
     }
@@ -8429,6 +8462,14 @@ export class Convert {
 
     public static updateEndpointMessageToJson(value: UpdateEndpointMessage): string {
         return JSON.stringify(uncast(value, r("UpdateEndpointMessage")), null, 2);
+    }
+
+    public static toWakeTurnMessage(json: string): WakeTurnMessage {
+        return cast(JSON.parse(json), r("WakeTurnMessage"));
+    }
+
+    public static wakeTurnMessageToJson(value: WakeTurnMessage): string {
+        return JSON.stringify(uncast(value, r("WakeTurnMessage")), null, 2);
     }
 
     public static toWebSocketEvent(json: string): WebSocketEvent {
@@ -9335,6 +9376,7 @@ const typeMap: any = {
         { json: "todos", js: "todos", typ: u(undefined, a("")) },
         { json: "turn_opened_at", js: "turn_opened_at", typ: u(undefined, "") },
         { json: "turn_owed", js: "turn_owed", typ: u(undefined, true) },
+        { json: "turn_snoozed_until", js: "turn_snoozed_until", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: "" },
         { json: "workspace_muted", js: "workspace_muted", typ: u(undefined, true) },
     ], "any"),
@@ -11307,6 +11349,7 @@ const typeMap: any = {
         { json: "todos", js: "todos", typ: u(undefined, a("")) },
         { json: "turn_opened_at", js: "turn_opened_at", typ: u(undefined, "") },
         { json: "turn_owed", js: "turn_owed", typ: u(undefined, true) },
+        { json: "turn_snoozed_until", js: "turn_snoozed_until", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: "" },
         { json: "workspace_muted", js: "workspace_muted", typ: u(undefined, true) },
     ], "any"),
@@ -11429,6 +11472,11 @@ const typeMap: any = {
         { json: "next_workspace_id", js: "next_workspace_id", typ: u(undefined, "") },
         { json: "prev_workspace_id", js: "prev_workspace_id", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: "" },
+    ], "any"),
+    "SnoozeTurnMessage": o([
+        { json: "cmd", js: "cmd", typ: r("SnoozeTurnMessageCmd") },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "until", js: "until", typ: "" },
     ], "any"),
     "SpawnResultMessage": o([
         { json: "error", js: "error", typ: u(undefined, "") },
@@ -11792,6 +11840,10 @@ const typeMap: any = {
         { json: "name", js: "name", typ: u(undefined, "") },
         { json: "profile", js: "profile", typ: u(undefined, "") },
         { json: "ssh_target", js: "ssh_target", typ: u(undefined, "") },
+    ], "any"),
+    "WakeTurnMessage": o([
+        { json: "cmd", js: "cmd", typ: r("WakeTurnMessageCmd") },
+        { json: "session_id", js: "session_id", typ: "" },
     ], "any"),
     "WebSocketEvent": o([
         { json: "action", js: "action", typ: u(undefined, "") },
@@ -12951,6 +13003,9 @@ const typeMap: any = {
     "SetWorkspaceRankMessageCmd": [
         "set_workspace_rank",
     ],
+    "SnoozeTurnMessageCmd": [
+        "snooze_turn",
+    ],
     "SpawnResultMessageEvent": [
         "spawn_result",
     ],
@@ -13062,6 +13117,9 @@ const typeMap: any = {
     ],
     "UpdateEndpointMessageCmd": [
         "update_endpoint",
+    ],
+    "WakeTurnMessageCmd": [
+        "wake_turn",
     ],
     "WorkflowActionResultMessageEvent": [
         "workflow_action_result",

--- a/app/src/utils/queueBands.test.ts
+++ b/app/src/utils/queueBands.test.ts
@@ -164,6 +164,71 @@ describe('buildQueueBands', () => {
 
     expect(tree.map((workspace) => workspace.sessions.map((session) => session.id))).toEqual([['a'], ['b']]);
   });
+
+  describe('snoozed', () => {
+    // Fixed clocks: a snooze is a comparison against now, and a test whose
+    // deadlines drift with the wall clock is a test that expires.
+    const now = Date.parse('2026-07-26T12:00:00Z');
+    const laterToday = '2026-07-26T13:00:00Z';
+    const laterStill = '2026-07-26T18:00:00Z';
+
+    it('takes a deferred agent out of both bands into its own list', () => {
+      const bands = buildQueueBands(views([
+        { id: 'owed', label: 'owed', workspaceId: 'ws-a', turnOwed: true, turnOpenedAt: '2026-07-26T09:00:00Z' },
+        { id: 'quiet', label: 'quiet', workspaceId: 'ws-a' },
+        { id: 'deferred', label: 'deferred', workspaceId: 'ws-b', turnSnoozedUntil: laterToday },
+      ]), now);
+
+      expect(bands.turns.map((row) => row.session.id)).toEqual(['owed']);
+      expect(bands.settled.map((row) => row.session.id)).toEqual(['quiet']);
+      expect(bands.snoozed.map((row) => row.session.id)).toEqual(['deferred']);
+    });
+
+    it('orders by when each comes back, soonest first', () => {
+      const bands = buildQueueBands(views([
+        { id: 'late', label: 'late', workspaceId: 'ws-a', turnSnoozedUntil: laterStill },
+        { id: 'soon', label: 'soon', workspaceId: 'ws-b', turnSnoozedUntil: laterToday },
+      ]), now);
+
+      expect(bands.snoozed.map((row) => row.session.id)).toEqual(['soon', 'late']);
+    });
+
+    it('returns a lapsed deadline to the settled band', () => {
+      // The daemon strips a lapsed deadline from the broadcast, but a client
+      // holding a snapshot across the wake must not park the row for as long as
+      // it takes the next one to land.
+      const bands = buildQueueBands(views([
+        { id: 'woken', label: 'woken', workspaceId: 'ws-a', turnSnoozedUntil: '2026-07-26T11:00:00Z' },
+      ]), now);
+
+      expect(bands.snoozed).toEqual([]);
+      expect(bands.settled.map((row) => row.session.id)).toEqual(['woken']);
+    });
+
+    it('keeps a snoozed agent out of the turns band even if a snapshot still says owed', () => {
+      // The daemon settles as it snoozes, so the two never both hold. The order
+      // of the checks is what stops a snapshot taken mid-broadcast from drawing
+      // a deferred agent as a turn the user owes.
+      const bands = buildQueueBands(views([
+        { id: 'both', label: 'both', workspaceId: 'ws-a', turnOwed: true, turnOpenedAt: '2026-07-26T09:00:00Z', turnSnoozedUntil: laterToday },
+      ]), now);
+
+      expect(bands.turns).toEqual([]);
+      expect(bands.snoozed.map((row) => row.session.id)).toEqual(['both']);
+    });
+
+    it('leaves a pinned workspace out of the snoozed list too', () => {
+      // Pinned and muted are in the tree, not the bands, whatever else is true
+      // of them.
+      const pinnedViews = buildWorkspaceViewModels(
+        [{ id: 'ws-p', title: 'P', directory: '/repo/p', rank: 'a', pinned: true }],
+        [{ id: 'pinned', label: 'pinned', workspaceId: 'ws-p', turnSnoozedUntil: laterToday }],
+      );
+
+      expect(buildQueueBands(pinnedViews, now).snoozed).toEqual([]);
+    });
+  });
+
 });
 
 describe('oldestWantedTurn', () => {
@@ -338,6 +403,34 @@ describe('advanceAfterTurnClosed', () => {
     const after = buildQueueBands(views([owed('next', 1)]));
 
     expect(advanceAfterTurnClosed(before.turns, after, 'watched')).toBeNull();
+  });
+
+  it('moves on when the watched turn closed by being snoozed', () => {
+    // A snooze closes the turn on the agent the user is looking at, exactly like
+    // a settle — so leaving them parked in the agent they just deferred is the
+    // bookkeeping this exists to remove.
+    const watched = owed('watched', 0);
+    const before = buildQueueBands(views([watched, owed('next', 1)]));
+    const after = buildQueueBands(views([
+      { ...watched, turnOwed: false, turnSnoozedUntil: '2026-07-26T20:00:00Z' },
+      owed('next', 1),
+    ]), Date.parse('2026-07-26T12:00:00Z'));
+
+    expect(after.snoozed.map((row) => row.session.id)).toEqual(['watched']);
+    expect(advanceAfterTurnClosed(before.turns, after, 'watched')).toEqual({
+      to: 'session',
+      row: expect.objectContaining({ session: expect.objectContaining({ id: 'next' }) }),
+    });
+  });
+
+  it('goes home when the snoozed turn was the last one owed', () => {
+    const only = owed('watched', 0);
+    const before = buildQueueBands(views([only]));
+    const after = buildQueueBands(views([
+      { ...only, turnOwed: false, turnSnoozedUntil: '2026-07-26T20:00:00Z' },
+    ]), Date.parse('2026-07-26T12:00:00Z'));
+
+    expect(advanceAfterTurnClosed(before.turns, after, 'watched')).toEqual({ to: 'dashboard' });
   });
 
   it('stays put with no agent selected, or before any bands exist', () => {

--- a/app/src/utils/queueBands.ts
+++ b/app/src/utils/queueBands.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceWithSessions, WorkspaceViewSession } from './workspaceViewModels';
+import { isSnoozed } from './snoozeDurations';
 
 /**
  * The daemon-owned setting selecting the sidebar arrangement: off (the default)
@@ -56,6 +57,7 @@ export interface QueueBandSession extends WorkspaceViewSession {
   chiefOfStaff?: boolean;
   turnOwed?: boolean;
   turnOpenedAt?: string;
+  turnSnoozedUntil?: string;
 }
 
 export interface QueueRow<TSession extends QueueBandSession> {
@@ -126,6 +128,14 @@ export interface QueueBands<TSession extends QueueBandSession> {
   turns: QueueRow<TSession>[];
   /** Everything else you could go and look at, in a stable order. */
   settled: QueueRow<TSession>[];
+  /**
+   * Agents the user deferred, soonest wake first. They are in neither band: a
+   * snooze is an answer to "whose turn is it" — not yours, not yet — and it has
+   * a return time, which is what the section below the settled band exists to
+   * show. Soonest first because the only question a snoozed row answers is when
+   * it comes back.
+   */
+  snoozed: QueueRow<TSession>[];
 }
 
 /**
@@ -153,10 +163,12 @@ export interface QueueBands<TSession extends QueueBandSession> {
  */
 export function buildQueueBands<TSession extends QueueBandSession>(
   workspaces: WorkspaceWithSessions<TSession>[],
+  now: number = Date.now(),
 ): QueueBands<TSession> {
   let chief: QueueRow<TSession> | null = null;
   const turns: QueueRow<TSession>[] = [];
   const settled: QueueRow<TSession>[] = [];
+  const snoozed: QueueRow<TSession>[] = [];
 
   for (const workspace of workspaces) {
     for (const session of workspace.sessions) {
@@ -174,7 +186,13 @@ export function buildQueueBands<TSession extends QueueBandSession>(
       if (workspace.pinned || workspace.muted) {
         continue;
       }
-      if (session.turnOwed) {
+      // Before the turn check, though the two cannot both be true: the daemon
+      // settles as it snoozes, so a snoozed session never carries turnOwed. The
+      // order makes the row's home independent of that invariant holding in a
+      // snapshot taken mid-broadcast.
+      if (isSnoozed(session.turnSnoozedUntil, now)) {
+        snoozed.push(row);
+      } else if (session.turnOwed) {
         turns.push(row);
       } else {
         settled.push(row);
@@ -183,8 +201,19 @@ export function buildQueueBands<TSession extends QueueBandSession>(
   }
 
   turns.sort((a, b) => compareTurnOrder(a.session, b.session));
+  snoozed.sort((a, b) => compareWakeOrder(a.session, b.session));
 
-  return { chief, turns, settled };
+  return { chief, turns, settled, snoozed };
+}
+
+/** Soonest wake first, tie-broken by id so the order is total. */
+function compareWakeOrder(a: QueueBandSession, b: QueueBandSession): number {
+  const untilA = a.turnSnoozedUntil ?? '';
+  const untilB = b.turnSnoozedUntil ?? '';
+  if (untilA !== untilB) {
+    return untilA < untilB ? -1 : 1;
+  }
+  return a.id < b.id ? -1 : 1;
 }
 
 /**
@@ -237,11 +266,15 @@ export type QueueAdvance<TSession extends QueueBandSession> =
  * was ever there, and the earlier one is also the only place the user's
  * position in the queue still exists.
  *
- * The move that matters is turns → settled specifically. Pinning or muting a
- * workspace clears turn_owed on its sessions too, and those rows leave the
- * bands entirely rather than landing in settled — so requiring the arrival,
+ * The move that matters is turns → settled or turns → snoozed. Pinning or muting
+ * a workspace clears turn_owed on its sessions too, and those rows leave the
+ * bands entirely rather than landing in either — so requiring the arrival,
  * rather than just the departure, is what keeps a pin from carrying the user
  * away from the workspace they pinned to keep in view.
+ *
+ * Snoozed counts because a snooze is a turn-closing act performed on the agent
+ * the user is looking at, exactly like a settle: leaving them parked in an agent
+ * they just deferred is the bookkeeping move-on exists to remove.
  *
  * Only the position comes from the old snapshot; whether a row is still worth
  * going to is always read from `bands`. One broadcast can close several turns —
@@ -263,8 +296,10 @@ export function advanceAfterTurnClosed<TSession extends QueueBandSession>(
 ): QueueAdvance<TSession> | null {
   if (!sessionId || !bands) return null;
   const owedBefore = previousTurns.some((row) => row.session.id === sessionId);
-  const settledNow = bands.settled.some((row) => row.session.id === sessionId);
-  if (!owedBefore || !settledNow) return null;
+  const closedNow =
+    bands.settled.some((row) => row.session.id === sessionId) ||
+    bands.snoozed.some((row) => row.session.id === sessionId);
+  if (!owedBefore || !closedNow) return null;
   const stillOwed = new Set(bands.turns.map((row) => row.session.id));
   const next = nextOwedAfter(previousTurns, sessionId, stillOwed) ?? bands.turns[0] ?? null;
   return next ? { to: 'session', row: next } : { to: 'dashboard' };

--- a/app/src/utils/snoozeDurations.test.ts
+++ b/app/src/utils/snoozeDurations.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { SNOOZE_WAKE_HOUR, snoozeInstant, isSnoozed } from './snoozeDurations';
+
+/** A local-time Date, so the assertions read in the same clock the code uses. */
+function at(year: number, month: number, day: number, hour: number, minute = 0): Date {
+  return new Date(year, month - 1, day, hour, minute, 0, 0);
+}
+
+describe('snoozeInstant', () => {
+  it('adds the plain durations', () => {
+    const now = at(2026, 8, 2, 14, 20);
+    expect(snoozeInstant('30m', now)).toEqual(at(2026, 8, 2, 14, 50));
+    expect(snoozeInstant('1h', now)).toEqual(at(2026, 8, 2, 15, 20));
+    expect(snoozeInstant('8h', now)).toEqual(at(2026, 8, 2, 22, 20));
+  });
+
+  it('wakes tomorrow at the wake hour, not 24 hours later', () => {
+    const now = at(2026, 8, 2, 23, 45);
+    expect(snoozeInstant('tomorrow', now)).toEqual(at(2026, 8, 3, SNOOZE_WAKE_HOUR));
+  });
+
+  it('crosses a month boundary', () => {
+    const now = at(2026, 8, 31, 18, 0);
+    expect(snoozeInstant('tomorrow', now)).toEqual(at(2026, 9, 1, SNOOZE_WAKE_HOUR));
+  });
+
+  it('crosses a year boundary', () => {
+    const now = at(2026, 12, 31, 18, 0);
+    expect(snoozeInstant('tomorrow', now)).toEqual(at(2027, 1, 1, SNOOZE_WAKE_HOUR));
+  });
+
+  // 2026-08-02 is a Sunday.
+  it('finds the next Saturday and the next Monday from a Sunday', () => {
+    const sunday = at(2026, 8, 2, 10, 0);
+    expect(snoozeInstant('saturday', sunday)).toEqual(at(2026, 8, 8, SNOOZE_WAKE_HOUR));
+    expect(snoozeInstant('monday', sunday)).toEqual(at(2026, 8, 3, SNOOZE_WAKE_HOUR));
+  });
+
+  it('finds later the same day when the wake hour has not passed', () => {
+    const mondayEarly = at(2026, 8, 3, 7, 30);
+    expect(snoozeInstant('monday', mondayEarly)).toEqual(at(2026, 8, 3, SNOOZE_WAKE_HOUR));
+  });
+
+  // The one that matters: a deferral has to defer something. "Until Monday"
+  // pressed on a Monday afternoon means next Monday, not an instant already gone.
+  it('skips to next week when the day has already had its wake hour', () => {
+    const mondayAfternoon = at(2026, 8, 3, 15, 0);
+    expect(snoozeInstant('monday', mondayAfternoon)).toEqual(at(2026, 8, 10, SNOOZE_WAKE_HOUR));
+  });
+
+  it('skips a day whose wake hour is exactly now', () => {
+    const mondayAtNine = at(2026, 8, 3, SNOOZE_WAKE_HOUR);
+    expect(snoozeInstant('monday', mondayAtNine)).toEqual(at(2026, 8, 10, SNOOZE_WAKE_HOUR));
+  });
+
+  it('never resolves to the past, whichever choice and whenever it is pressed', () => {
+    const choices = ['30m', '1h', '8h', 'tomorrow', 'saturday', 'monday'] as const;
+    for (let day = 1; day <= 7; day += 1) {
+      for (const hour of [0, 8, 9, 10, 23]) {
+        const now = at(2026, 8, day, hour, 30);
+        for (const choice of choices) {
+          expect(snoozeInstant(choice, now).getTime()).toBeGreaterThan(now.getTime());
+        }
+      }
+    }
+  });
+});
+
+describe('isSnoozed', () => {
+  it('is false without a deadline and for one already past', () => {
+    const now = Date.parse('2026-08-02T14:00:00Z');
+    expect(isSnoozed(undefined, now)).toBe(false);
+    expect(isSnoozed('2026-08-02T13:00:00Z', now)).toBe(false);
+    expect(isSnoozed('not a date', now)).toBe(false);
+  });
+
+  it('is true for a deadline still ahead', () => {
+    const now = Date.parse('2026-08-02T14:00:00Z');
+    expect(isSnoozed('2026-08-02T15:00:00Z', now)).toBe(true);
+  });
+});

--- a/app/src/utils/snoozeDurations.ts
+++ b/app/src/utils/snoozeDurations.ts
@@ -1,0 +1,133 @@
+/**
+ * Snooze durations, and the arithmetic that turns one into an instant.
+ *
+ * The client computes the instant, not the daemon. "Tomorrow" and "Monday" are
+ * calendar questions that need the user's timezone and their idea of a working
+ * day, and the daemon that owns a remote session shares neither — it may not
+ * even be in the same country. The wire carries an absolute instant, which
+ * crosses endpoints without reinterpretation.
+ */
+
+export type SnoozeChoiceId = '30m' | '1h' | '8h' | 'tomorrow' | 'saturday' | 'monday';
+
+export interface SnoozeChoice {
+  id: SnoozeChoiceId;
+  /** What the menu row says. */
+  label: string;
+  /**
+   * The concrete time it resolves to, shown beside the label. A duration is
+   * obvious; "Monday" is not, and a menu that will not say when it means is a
+   * menu you have to test to trust.
+   */
+  detail: (now: Date) => string;
+}
+
+/**
+ * The hour a day-named snooze wakes at. Not configurable: the choice a user
+ * makes is "the start of that day", and a setting for which hour that is would
+ * be a preference nobody has ever asked to hold.
+ */
+export const SNOOZE_WAKE_HOUR = 9;
+
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+
+/** Weekday indices as Date.getDay reports them. */
+const SATURDAY = 6;
+const MONDAY = 1;
+
+/**
+ * The next occurrence of `weekday` at the wake hour, strictly in the future.
+ *
+ * Strictly is what makes "Saturday" pressed on a Saturday morning mean *next*
+ * Saturday rather than a snooze that has already lapsed — the deferral has to
+ * defer something.
+ */
+function nextWeekdayAt(now: Date, weekday: number): Date {
+  const target = startOfWakeHour(now);
+  let days = (weekday - now.getDay() + 7) % 7;
+  if (days === 0 && target.getTime() <= now.getTime()) {
+    days = 7;
+  }
+  target.setDate(target.getDate() + days);
+  return target;
+}
+
+/** Today at the wake hour, as a Date that setDate can be walked forward on. */
+function startOfWakeHour(now: Date): Date {
+  const at = new Date(now.getTime());
+  at.setHours(SNOOZE_WAKE_HOUR, 0, 0, 0);
+  return at;
+}
+
+function tomorrowAtWakeHour(now: Date): Date {
+  const at = startOfWakeHour(now);
+  at.setDate(at.getDate() + 1);
+  return at;
+}
+
+/**
+ * When a choice wakes, as an absolute instant.
+ *
+ * Date arithmetic rather than millisecond addition for the day choices, so a
+ * daylight-saving boundary still lands at 9am local — adding 24 hours across a
+ * DST change lands at 8 or 10.
+ */
+export function snoozeInstant(choice: SnoozeChoiceId, now: Date): Date {
+  switch (choice) {
+    case '30m':
+      return new Date(now.getTime() + 30 * MINUTE);
+    case '1h':
+      return new Date(now.getTime() + HOUR);
+    case '8h':
+      return new Date(now.getTime() + 8 * HOUR);
+    case 'tomorrow':
+      return tomorrowAtWakeHour(now);
+    case 'saturday':
+      return nextWeekdayAt(now, SATURDAY);
+    case 'monday':
+      return nextWeekdayAt(now, MONDAY);
+  }
+}
+
+/** A wake instant as the user reads it: a clock time, plus the day when it is not today. */
+export function formatWakeTime(until: string | undefined, now: number): string {
+  if (!until) return '';
+  const at = new Date(until);
+  if (Number.isNaN(at.getTime())) return '';
+  const time = at.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  const today = new Date(now);
+  if (at.toDateString() === today.toDateString()) return time;
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  if (at.toDateString() === tomorrow.toDateString()) return `tomorrow ${time}`;
+  return `${at.toLocaleDateString(undefined, { weekday: 'short' })} ${time}`;
+}
+
+export const SNOOZE_CHOICES: SnoozeChoice[] = [
+  { id: '30m', label: 'For 30 minutes', detail: (now) => clockTime(snoozeInstant('30m', now)) },
+  { id: '1h', label: 'For an hour', detail: (now) => clockTime(snoozeInstant('1h', now)) },
+  { id: '8h', label: 'For 8 hours', detail: (now) => clockTime(snoozeInstant('8h', now)) },
+  { id: 'tomorrow', label: 'Until tomorrow', detail: (now) => dayAndTime(snoozeInstant('tomorrow', now)) },
+  { id: 'saturday', label: 'Until Saturday', detail: (now) => dayAndTime(snoozeInstant('saturday', now)) },
+  { id: 'monday', label: 'Until Monday', detail: (now) => dayAndTime(snoozeInstant('monday', now)) },
+];
+
+function clockTime(at: Date): string {
+  return at.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+}
+
+function dayAndTime(at: Date): string {
+  return `${at.toLocaleDateString(undefined, { weekday: 'short' })} ${clockTime(at)}`;
+}
+
+/**
+ * Whether a broadcast deadline is still in the future. The daemon leaves a
+ * lapsed deadline off the wire, so this is only the client's own guard against
+ * a snapshot it is holding while the wake lands.
+ */
+export function isSnoozed(until: string | undefined, now: number): boolean {
+  if (!until) return false;
+  const at = Date.parse(until);
+  return Number.isFinite(at) && at > now;
+}

--- a/changelog.d/cranky-narwhal-snooze.yaml
+++ b/changelog.d/cranky-narwhal-snooze.yaml
@@ -1,0 +1,19 @@
+kind: added
+area: queue
+change: >
+  In the agent queue, any agent — one that owes you a turn, or one still
+  working — can be deferred for 30 minutes, an hour, 8 hours, or until
+  tomorrow, Saturday, or Monday morning. Snoozing closes the open turn and
+  stops the next one from opening until then, so an agent you can't act on
+  yet stays out of your queue instead of asking again the moment it stops.
+  Deferred agents collect in a collapsible Snoozed section at the foot of the
+  sidebar, above muted workspaces, each showing when it comes back; a
+  wake-now action wakes one early. Snooze from the row menu, Cmd+Shift+S on
+  the selected agent, or the command menu — and like settling, snoozing
+  hands you the next agent that wants you. A deferral is honoured while it
+  lasts: typing to a snoozed agent, or looking at it, does not cancel it.
+  Only what you couldn't have anticipated breaks through — an agent whose
+  state attn can't explain, or one whose process died — and that ends the
+  snooze and puts the turn back in your queue. When the time arrives the
+  agent returns at the tail of the queue, not the head: the clock on what
+  you owe starts when you said you'd come back.

--- a/docs/plans/2026-08-02-agent-queue-snooze.md
+++ b/docs/plans/2026-08-02-agent-queue-snooze.md
@@ -1,0 +1,249 @@
+# Plan: the agent queue — snooze
+
+## Why / Alignment
+
+Implements the *Deferral* rock of [the agent queue vision](../vision/agent-queue.md):
+snooze with real durations, waking to the tail of the queue, broken early only by
+errors and states the daemon cannot explain.
+
+**Why.** Settle answers *I dealt with this*. Nothing today answers *not now*. The
+gap shows up twice a day: an agent you cannot act on until the build finishes, a
+finished run you want to read after lunch, a long job you kicked off and do not
+want handed back for an hour. Settling those is a lie — the turn comes straight
+back — so they sit in the band and the queue stops meaning "these are the things
+you can do something about". Done for this chunk: any agent can be deferred to a
+named time, it is out of the queue and visibly parked until then, and it comes
+back at the tail when the time arrives.
+
+**Aligned on** (Victor, 2026-08-02):
+
+- **Snooze only.** Indefinite backgrounding — the rock's other half — is a
+  follow-up. It is the same suppression stamp with no deadline and no
+  break-through, and it is a distinct verb (deferral is honoured, muting is
+  absolute), so it does not belong inside this one.
+- **Any agent can be snoozed, not just one that owes a turn.** Pin and mute
+  already apply regardless of turn state, and the useful case — "this run has
+  40 minutes left, do not hand it back before then" — is precisely the one where
+  no turn is open yet. Settled rows carry the affordance too.
+- **Break-through: `unknown`, and `idle` with reason `process_exited`.**
+  `unknown` (reasons `stuck` / `no_evidence`) is the daemon admitting it cannot
+  tell; `process_exited` is the agent's process actually gone. A normal end of
+  run resolves `idle` with `prompt_idle` / `classifier_verdict`, so ordinary
+  finishing does not break through — only dying does. A break-through consumes
+  the snooze: the deferral was interrupted by something the user could not have
+  anticipated, and they are back in the loop with that agent.
+- **Snoozed agents get their own collapsible section at the bottom of the
+  sidebar, above muted workspaces.** They are in neither band. This mirrors the
+  muted section exactly, which is the shape the sidebar already has for "quiet
+  but reachable", and it keeps waking one early findable — the settled band is
+  long, and a deferral you cannot find is one you cannot undo.
+- **Steering a snoozed agent does not wake it.** The vision's wording is that a
+  considered act is not undone by business as usual, and typing into an agent is
+  business as usual. Waking early is its own gesture.
+- **Looking at a snoozed agent does not wake it,** by the vision's standing rule.
+
+**In scope.** The snooze stamp and its wake timers, the duration menu (30m, 1h,
+8h, tomorrow, Saturday, Monday), break-through, the sidebar's snoozed section
+with wake times and a wake-now action, a `session.snooze` shortcut, ⌘K entries,
+and handover on snooze the way settle already hands over.
+
+**Deferred.** Indefinite backgrounding. A custom date/time picker (the vision's
+seventh duration) — it needs a real input surface and the six fixed choices are
+what get used. Any snooze presence on the home dashboard.
+
+**Vision.** Advances the *Deferral* big rock. The rocks already shipped: state
+detection, the queue, settle, the standing order, move-on, and automatic move-on.
+
+## The shape
+
+Snooze is **settle plus a suppression window**. It closes the open turn the way
+settle does, and it stops the next one from opening until the deadline.
+
+```text
+  you snooze for 1h          ->  turn_settled_at = now
+                                 turn_snoozed_until = now+1h
+  agent stops, waiting_input ->  suppressed: no turn opens        [quiet]
+  agent goes unknown         ->  break-through: snooze cleared,
+                                 turn opens now                   [loud]
+  1h elapses                 ->  snooze cleared; if the agent is in a
+                                 turn-opening state, a turn opens stamped
+                                 at the deadline                  -> tail
+```
+
+**Suppressing at open, not filtering at read, is the load-bearing call.** The
+four existing exclusions (shell, chief, pinned, muted) filter at read: the stamp
+keeps accruing and unpinning surfaces the turn at its *original* age. That is
+right for pinning — the queue should not forget what happened while you were not
+looking. It is wrong for snooze, which the vision says wakes to the *tail*: you
+deferred it, so the clock on what you owe starts when you said you would come
+back, not when the agent first asked. Suppressing at open is what makes the wake
+stamp `now` rather than resurrecting an hour-old one straight to the head of the
+band.
+
+Because a snooze always settles first, `attention.Owed` needs no new input: a
+snoozed session simply has no turn open. The stamp rides the wire only so the
+sidebar can put the row in its section and say when it comes back.
+
+## Data model
+
+```sql
+-- migration 85 (MAX(version) across every local profile DB is 84)
+ALTER TABLE sessions ADD COLUMN turn_snoozed_until TEXT NOT NULL DEFAULT '';
+```
+
+```go
+// store
+func (s *Store) SnoozeTurn(id string, until, now time.Time) bool // settles + stamps
+func (s *Store) WakeTurn(id string) bool                         // clears the stamp
+func (s *Store) SnoozedSessions() map[string]time.Time           // boot rescheduling
+
+// TurnStamps carries the deadline alongside the two turn stamps, so the one
+// read the daemon already does for a session answers "is it deferred, and
+// until when" as well.
+type TurnStamps struct{ OpenedAt, SettledAt, SnoozedUntil time.Time }
+```
+
+`SnoozeTurn` writes both stamps in one statement so a turn can never be
+suppressed while still open.
+
+### On the wire
+
+```tsp
+model Session {
+  turn_snoozed_until?: string;   // ISO; present only while a snooze is live
+}
+
+model SnoozeTurnMessage {
+  cmd: "snooze_turn";
+  session_id: string;
+  until: string;                 // ISO instant, computed by the client
+}
+
+model WakeTurnMessage {
+  cmd: "wake_turn";
+  session_id: string;
+}
+```
+
+**The client computes the wake instant.** "Tomorrow", "Saturday", and "Monday"
+are calendar questions and need the *user's* timezone and locale; a remote
+endpoint's daemon may be in neither. The daemon takes an absolute instant and
+schedules against it, which keeps it out of the calendar business entirely.
+
+Two commands rather than one with an empty `until`: waking early is a distinct
+user act and reads as one at every layer.
+
+## Architecture
+
+```text
+Daemon
+
+  ws snooze_turn
+    -> store.SnoozeTurn(id, until)     (settles and stamps in one write)
+    -> cancelAutoSettle                (a countdown would promise a second settle)
+    -> traceSettle                     (a snooze is a settle with a reason)
+    -> scheduleSnoozeWake(id, until)
+    -> broadcastSessionStateChanged
+
+  ws wake_turn / timer fires / break-through
+    -> store.WakeTurn(id)
+    -> if attention.OpensTurn(current state): store.OpenTurnIfClosed(id, at)
+    -> broadcastSessionStateChanged
+
+  applyState  (session_state.go — the one place a turn opens)
+    -> if snoozed && attention.BreaksSnooze(state, reason): wake, then open
+    -> else if snoozed: skip the open            [the suppression]
+    -> else if attention.OpensTurn(state): open  (unchanged)
+
+  start-up: rescheduleSnoozeWakes() from the store; a deadline already past
+            fires immediately and stamps the turn at the *deadline*, not at
+            boot — a snooze that lapsed while the daemon was down has been
+            owed since it lapsed, and the queue should say so.
+
+Frontend
+
+  buildQueueBands -> { chief, turns, settled, snoozed }
+      a live turn_snoozed_until routes the row to `snoozed`, out of both bands
+  Sidebar: collapsible "Snoozed" section, below Settled, above Muted Workspaces
+  SnoozeMenu: the six durations; opened from a row control, the ⌘⇧S shortcut,
+              and ⌘K
+  advanceAfterTurnClosed: arriving in `snoozed` closes a turn the same way
+              arriving in `settled` does, so snoozing hands over the next agent
+```
+
+## Boundaries
+
+- `internal/attention` gains `BreaksSnooze(state, reason)` and nothing else. It
+  stays pure — the break-through set is vocabulary, exactly like `OpensTurn`.
+- `internal/daemon` owns the timers, the suppression branch in `applyState`, and
+  the wake write. It must not re-implement the predicate inline.
+- `internal/store` owns the column and the paired settle+stamp write.
+- The app renders, orders, and computes wake instants. It must not decide
+  membership: `turn_owed` remains the daemon's answer.
+
+## Implementation steps
+
+One slice. Snooze without a way back out is not shippable, and the wake path is
+most of the work, so there is no honest cut here either.
+
+- [x] `attention.BreaksSnooze`, with table tests over the state/reason pairs.
+- [x] Migration 85, guarded on the column already existing.
+- [x] `store.SnoozeTurn` / `WakeTurn` / `SnoozedSessions`, plus the deadline on
+      `TurnStamps`, both branches (SQLite and in-memory), with tests: snoozing settles an open turn
+      in the same write; waking clears; a wake with no snooze is a no-op.
+- [x] The suppression branch in `applyState`, and `decorateSessionWithSnooze`
+      stamping `turn_snoozed_until` (only while live).
+- [x] Wake timers mirroring `auto_settle.go`: schedule, cancel, replace, stop on
+      teardown, reschedule from the store at start-up.
+- [x] Protocol: the field and the two commands; regenerate; bump
+      `ProtocolVersion` in `constants.go` **and** `useDaemonSocket.ts`.
+- [x] Daemon tests: a snoozed agent that stops opens no turn; it wakes to a turn
+      stamped at the deadline; `unknown` and `process_exited` break through and
+      clear the snooze; a normal `idle` finish does not; a snooze survives a
+      daemon restart and a lapsed one fires on boot.
+- [x] `snoozeInstant(choice, now)` in the app — pure, unit-tested across a
+      month/year boundary and each weekday, with the day choices waking at 09:00
+      local.
+- [x] `buildQueueBands` gains `snoozed`; the routing and its tests.
+- [x] The sidebar section, the row controls, wake-now, the duration menu, the
+      `session.snooze` shortcut (⌘⇧S — free in the registry; check
+      `Menu::default`), cheatsheet, and the ⌘K entries.
+- [x] `advanceAfterTurnClosed` treats arrival in `snoozed` as a close.
+- [x] Live verification on a throwaway profile, as
+      `real-app:scenario-agent-queue-snooze` (catalogued as `agent-queue-snooze`):
+      two real Claude agents, snoozed from the row menu for 30 minutes, watched
+      out of the band into the section with its wake time, driven through a
+      second run under the deferral with no turn opening, woken early to the
+      tail, woken again by the timer, carried across a daemon restart, and
+      SIGKILLed to see the break-through. `queue_get_state` gained the snoozed
+      section so the assertions read the rendered DOM.
+
+## Decisions
+
+- **Snooze suppresses turn opening; it does not hide an open turn.** See The
+  shape. The read-filter alternative wakes to the head of the queue, which the
+  vision rejects.
+- **A break-through consumes the snooze rather than pausing it.** The user is
+  back in the loop with that agent; resuming a deferral they have since dealt
+  with would be the system re-asserting an intent the user has moved past.
+- **A lapsed snooze stamps the turn at its deadline, not at boot.** The turn has
+  genuinely been owed since the deadline, and the queue is ordered by how long
+  you have owed something.
+- **Steering does not wake.** "A considered act that business as usual does not
+  undo." The risk — forgetting a snooze and wondering why an agent never queues
+  — is what the visible section with wake times is for.
+- **Snoozing hands over the next agent, like settle.** Snooze is a turn-closing
+  act performed on the agent you are looking at; leaving the user parked in an
+  agent they just deferred would be the exact bookkeeping move-on removes.
+  Pinning still must not hand over — the distinction is arrival in a band, not
+  departure from one.
+
+## Open questions
+
+- Whether the snoozed section should be collapsed or expanded by default. Muted
+  starts collapsed because it is *not ever*; snoozed is *not yet* and comes back
+  on its own. Shipping collapsed with a count, since the wake is what surfaces
+  it.
+- Whether a snooze should show anywhere on the agent's own terminal tile. Left
+  out: the row says it, and the tile is already carrying the auto-settle
+  countdown.

--- a/docs/plans/2026-08-02-agent-queue-snooze.md
+++ b/docs/plans/2026-08-02-agent-queue-snooze.md
@@ -232,6 +232,15 @@ most of the work, so there is no honest cut here either.
 - **Steering does not wake.** "A considered act that business as usual does not
   undo." The risk — forgetting a snooze and wondering why an agent never queues
   — is what the visible section with wake times is for.
+- **A fired timer clears only the deadline it was armed for.** The timer proves
+  it is current against the daemon's map, but it releases that lock before it
+  touches the store, and a second snooze landing in that window has already
+  written a later deadline and armed its own timer. An unconditional clear there
+  cashes a promise the user just replaced — the agent wakes immediately and,
+  because the old callback also cancelled the replacement's timer, never comes
+  back at the time it was given. So the store clear is conditioned on the
+  deadline (`WakeTurnAt`) and the timer path never cancels. Witnessed by
+  `TestAResnoozeInsideAFiringWakeKeepsTheLaterDeadline`.
 - **Snoozing hands over the next agent, like settle.** Snooze is a turn-closing
   act performed on the agent you are looking at; leaving the user parked in an
   agent they just deferred would be the exact bookkeeping move-on removes.

--- a/internal/attention/turn.go
+++ b/internal/attention/turn.go
@@ -6,14 +6,15 @@
 // membership a comparison between two stamps rather than a reading of the
 // current state — state matters only at the instant a turn opens.
 //
-// The package is pure. It derives over protocol values and timestamps and
-// imports neither the store nor the daemon.
+// The package is pure. It derives over protocol values, resolver reasons, and
+// timestamps, and imports neither the store nor the daemon.
 package attention
 
 import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/sessionstate"
 )
 
 // OpensTurn reports whether reaching this state starts a turn the user owes.
@@ -44,6 +45,37 @@ func OpensTurn(state protocol.SessionState) bool {
 		protocol.SessionStateUnknown,
 		protocol.SessionStateIdle:
 		return true
+	default:
+		return false
+	}
+}
+
+// BreaksSnooze reports whether reaching this state cuts a snooze short.
+//
+// Snoozing says *not now*, and business as usual does not undo it: the agent
+// stopping, asking a question, wanting an approval, or finishing its run are all
+// things the user was deferring when they pressed it. What breaks through is what
+// they could not have anticipated.
+//
+//   - unknown is the daemon admitting it cannot explain the session (reasons
+//     "stuck" and "no_evidence"). A deferral is a judgement about an agent the
+//     user understood; this is the daemon saying that judgement no longer has
+//     anything behind it.
+//   - idle with reason "process_exited" is the agent's process actually gone.
+//     A run that merely ended resolves idle through "prompt_idle" or
+//     "classifier_verdict", so ordinary finishing stays deferred and only dying
+//     rings.
+//
+// The reason arrives as a plain string because that is how it rides the wire and
+// sits in the store, but it is compared against the resolver's own constant: the
+// set is defined by what the resolver means, and a renamed reason must not
+// silently stop breaking through.
+func BreaksSnooze(state protocol.SessionState, reason string) bool {
+	switch state {
+	case protocol.SessionStateUnknown:
+		return true
+	case protocol.SessionStateIdle:
+		return reason == string(sessionstate.ReasonProcessExited)
 	default:
 		return false
 	}

--- a/internal/attention/turn_test.go
+++ b/internal/attention/turn_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/sessionstate"
 )
 
 func TestOpensTurn(t *testing.T) {
@@ -27,6 +28,44 @@ func TestOpensTurn(t *testing.T) {
 		if got := OpensTurn(tt.state); got != tt.want {
 			t.Errorf("OpensTurn(%q) = %v, want %v", tt.state, got, tt.want)
 		}
+	}
+}
+
+// Snoozing says "not now", and the set below is everything that overrides it.
+// It is deliberately narrow: every ordinary way an agent asks for the user is a
+// thing the user was deferring when they pressed snooze.
+func TestBreaksSnooze(t *testing.T) {
+	tests := []struct {
+		name   string
+		state  protocol.SessionState
+		reason string
+		want   bool
+	}{
+		{"stuck is the daemon admitting it cannot tell", protocol.SessionStateUnknown, string(sessionstate.ReasonStuck), true},
+		{"no evidence, same admission", protocol.SessionStateUnknown, string(sessionstate.ReasonNoEvidence), true},
+		{"unknown breaks through whatever the reason", protocol.SessionStateUnknown, "", true},
+		{"the agent's process is gone", protocol.SessionStateIdle, string(sessionstate.ReasonProcessExited), true},
+
+		// The deferral holds through every ordinary way an agent stops.
+		{"a run that merely ended", protocol.SessionStateIdle, string(sessionstate.ReasonClassifierVerdict), false},
+		{"a session sitting at its prompt", protocol.SessionStateIdle, string(sessionstate.ReasonAtPrompt), false},
+		{"a question", protocol.SessionStateWaitingInput, string(sessionstate.ReasonQuestionOpen), false},
+		{"an approval", protocol.SessionStatePendingApproval, string(sessionstate.ReasonApprovalOpen), false},
+		{"working", protocol.SessionStateWorking, string(sessionstate.ReasonHeartbeatFresh), false},
+		{"scheduled", protocol.SessionStateScheduled, string(sessionstate.ReasonCronPending), false},
+		{"recoverable, which the daemon revives unattended", protocol.SessionStateRecoverable, "", false},
+
+		// process_exited is idle's alone. The pairing is what keeps a dead agent
+		// from being confused with one that simply finished.
+		{"a waiting session carrying the exited reason", protocol.SessionStateWaitingInput, string(sessionstate.ReasonProcessExited), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BreaksSnooze(tt.state, tt.reason); got != tt.want {
+				t.Errorf("BreaksSnooze(%q, %q) = %v, want %v", tt.state, tt.reason, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -51,6 +51,8 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdTriggerNudge:                          commandMetadata(ScopeSession, false, true),
 	protocol.CmdWorkspaceSelected:                     commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdSettleTurn:                            commandMetadata(ScopeSession, false, true),
+	protocol.CmdSnoozeTurn:                            commandMetadata(ScopeSession, false, true),
+	protocol.CmdWakeTurn:                              commandMetadata(ScopeSession, false, true),
 	protocol.CmdCancelAutoSettle:                      commandMetadata(ScopeSession, false, true),
 	protocol.CmdMuteWorkspace:                         commandMetadata(ScopeEndpoint, false, true),
 	protocol.CmdQueryPRs:                              commandMetadata(ScopeHubLocal, false, true),

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -270,6 +270,10 @@ type Daemon struct {
 	snoozeMu       sync.Mutex
 	snoozeTimers   map[string]*snoozeTimer
 	snoozeWakeHook func(sessionID string) // tests only; nil in production
+	// Called inside a firing wake, after the timer has proved it is current and
+	// released the lock but before it touches the store — the window a second
+	// snooze can land in. Tests only; nil in production. See snooze.go.
+	snoozeWakeGapHook func(sessionID string)
 
 	recoveryMu    sync.RWMutex
 	recovering    bool

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -271,10 +271,10 @@ type Daemon struct {
 	snoozeTimers   map[string]*snoozeTimer
 	snoozeWakeHook func(sessionID string) // tests only; nil in production
 
-	recoveryMu              sync.RWMutex
-	recovering              bool
-	notebookMu              sync.Mutex
-	notebookStore           *notebook.Store
+	recoveryMu    sync.RWMutex
+	recovering    bool
+	notebookMu    sync.Mutex
+	notebookStore *notebook.Store
 	// notebookWatcher observes notebook.root for external edits; guarded by its
 	// own mutex (distinct from notebookMu) so notebookStoreFor can start it
 	// without nesting locks. Lazily started on first notebook use.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -264,6 +264,13 @@ type Daemon struct {
 	// Called inside the fire-time decision, between confirming the turn is still
 	// owed and settling it. Tests only; nil in production. See auto_settle.go.
 	autoSettlePreSettleHook func()
+
+	// snoozeMu guards the pending wake timers. A snooze's deadline lives in the
+	// store; only the timer that fires on it is in memory. See snooze.go.
+	snoozeMu       sync.Mutex
+	snoozeTimers   map[string]*snoozeTimer
+	snoozeWakeHook func(sessionID string) // tests only; nil in production
+
 	recoveryMu              sync.RWMutex
 	recovering              bool
 	notebookMu              sync.Mutex
@@ -962,6 +969,7 @@ func (d *Daemon) Start() error {
 	d.removeLegacyEmbeddedTailscaleState()
 	d.migrateKeeperCompactSettingKey() // one-time settings key rename (workspace_context_janitor -> workspace_keeper_compact)
 	d.migrateNotebookCronSettingKeys() // one-time settings key rename (notebook.dreaming.* -> notebook.cron.*)
+	d.rescheduleSnoozeWakes()          // deadlines are persisted; the timers that fire on them are not
 	go d.ensureTailscaleServeFromSettingsAndBroadcast()
 	d.hubManager.Start(d.doneContext())
 
@@ -1610,6 +1618,7 @@ func (d *Daemon) Stop() {
 	d.stopAllTranscriptWatchers()
 	d.stopNudgeCountdowns()
 	d.stopAutoSettleTimers()
+	d.stopSnoozeTimers()
 	if d.ptyBackend != nil {
 		_ = d.ptyBackend.Shutdown(context.Background())
 	}
@@ -1856,6 +1865,7 @@ func (d *Daemon) dropSessionRecord(sessionID string) {
 	}
 	d.clearNudgeState(sessionID)
 	d.clearAutoSettleState(sessionID)
+	d.clearSnoozeState(sessionID)
 	d.clearPTYWriteFence(sessionID)
 	d.store.Remove(sessionID)
 	// After the row is gone, not before: recordStateObservation gates on the row,
@@ -2934,6 +2944,7 @@ func (d *Daemon) sessionForBroadcastWithChiefOfStaff(
 	d.decorateSessionWithStateReason(clone)
 	d.decorateSessionWithNudge(clone)
 	d.decorateSessionWithAutoSettle(clone)
+	d.decorateSessionWithSnooze(clone)
 	d.decorateChiefOfStaffWithSessionID(clone, chiefOfStaffSessionID)
 	d.decorateDelegatedFromChief(clone, delegatedFromChief)
 	d.decorateSessionWithWorkspace(clone)

--- a/internal/daemon/session_state.go
+++ b/internal/daemon/session_state.go
@@ -152,7 +152,13 @@ func (d *Daemon) applyState(change sessionStateChange) bool {
 	// startup recovery: a session that comes back in a state that wants the user
 	// wants the user regardless of what moved it there. Opening is guarded in the
 	// store, so a state re-reported while a turn is already open changes nothing.
-	if attention.OpensTurn(protocol.SessionState(change.state)) {
+	//
+	// A snooze suppresses that, which is the whole of the deferral: the state is
+	// still committed and still broadcast, it simply does not put the agent back
+	// on the user's plate. A state that breaks through clears the snooze inside
+	// the check and falls through to open the turn it would have opened anyway.
+	if attention.OpensTurn(protocol.SessionState(change.state)) &&
+		!d.snoozeSuppressesTurn(change.sessionID, protocol.SessionState(change.state)) {
 		d.store.OpenTurnIfClosed(change.sessionID, time.Now())
 	}
 

--- a/internal/daemon/snooze.go
+++ b/internal/daemon/snooze.go
@@ -103,6 +103,14 @@ func (d *Daemon) wakeSnooze(sessionID string, at time.Time, cause string) {
 		// lost a race with a hand wake, say — from broadcasting.
 		return
 	}
+	d.finishSnoozeWake(sessionID, at, cause)
+}
+
+// finishSnoozeWake is everything a wake does once the deadline is cleared: open
+// the turn if the agent is sitting in a state that wants the user, record it,
+// and say so. Shared by the hand wake and the timer, which differ only in how
+// they decide the snooze was theirs to end.
+func (d *Daemon) finishSnoozeWake(sessionID string, at time.Time, cause string) {
 	if session := d.store.Get(sessionID); session != nil && attention.OpensTurn(session.State) {
 		d.store.OpenTurnIfClosed(sessionID, d.turnOpensAtOnWake(sessionID, at))
 	}
@@ -220,9 +228,23 @@ func (d *Daemon) scheduleSnoozeWakeLocked(sessionID string, until time.Time) {
 	close(ready)
 }
 
-// fireSnoozeWake is the timer arriving. The identity check keeps a timer that
-// lost a cancel-or-replace race from waking a session that has since been
-// re-snoozed to a later deadline.
+// fireSnoozeWake is the timer arriving.
+//
+// Two checks, because a fired timer can be stale in two different ways. The
+// identity check under the lock keeps a timer that lost a cancel-or-replace race
+// from waking a session at all. The deadline check in the store keeps one that
+// won that race but was replaced *in the gap between* — the lock is dropped
+// before the wake, and a snooze landing in that window has already written a
+// later deadline and armed its own timer. Clearing unconditionally there would
+// cash a promise the user had just replaced, waking the agent immediately
+// instead of at the time they chose; and the cancel wakeSnooze does would take
+// the replacement's timer with it, so the later deadline would never fire
+// either.
+//
+// So the timer path never cancels — its own entry is already gone, and anything
+// in the map now belongs to a newer snooze — and it clears only the deadline it
+// was armed for. Losing either check means someone else owns this session's
+// deferral now, and the right thing to do is nothing.
 func (d *Daemon) fireSnoozeWake(sessionID string, self *time.Timer, deadline time.Time) {
 	d.snoozeMu.Lock()
 	entry, ok := d.snoozeTimers[sessionID]
@@ -233,10 +255,24 @@ func (d *Daemon) fireSnoozeWake(sessionID string, self *time.Timer, deadline tim
 	delete(d.snoozeTimers, sessionID)
 	d.snoozeMu.Unlock()
 
-	d.wakeSnooze(sessionID, deadline, "deadline")
+	// The hook fires however this ends: it means "this timer has finished", which
+	// is the only thing a test can wait on without knowing which snooze won.
 	if d.snoozeWakeHook != nil {
-		d.snoozeWakeHook(sessionID)
+		defer d.snoozeWakeHook(sessionID)
 	}
+	if d.snoozeWakeGapHook != nil {
+		d.snoozeWakeGapHook(sessionID)
+	}
+	if d.store == nil {
+		return
+	}
+	if !d.store.WakeTurnAt(sessionID, deadline) {
+		if d.debugLogging {
+			d.logf("snooze wake superseded: session=%s deadline=%s", sessionID, deadline.UTC().Format(time.RFC3339Nano))
+		}
+		return
+	}
+	d.finishSnoozeWake(sessionID, deadline, "deadline")
 }
 
 // cancelSnoozeWake drops a session's pending wake without touching the store.

--- a/internal/daemon/snooze.go
+++ b/internal/daemon/snooze.go
@@ -1,0 +1,302 @@
+package daemon
+
+import (
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/attention"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/statetrace"
+)
+
+// Snooze is the queue's *not now*.
+//
+// Settle answers "I dealt with this"; nothing else answered "come back later",
+// so an agent you could not act on yet had to be either settled — a lie, since
+// the turn returns the moment it stops again — or left in the band making the
+// queue mean less. Snooze closes the turn and stops the next one from opening
+// until a deadline the user named.
+//
+// It suppresses turns at the moment they would *open*, rather than filtering
+// them out at read the way the shell/chief/pinned/muted exclusions do. The
+// difference is what the user sees when the deadline passes: a read filter keeps
+// stamping, so the turn resurfaces at its original age and lands at the head of
+// the band, while suppression means the turn opens at the wake instant and lands
+// at the tail. The vision asks for the tail — you deferred it, so the clock on
+// what you owe starts when you said you would come back.
+//
+// Because a snooze always settles as it is written, attention.Owed needs to know
+// nothing about it: a snoozed session simply has no turn open. The deadline
+// rides the wire only so the sidebar can park the row and say when it returns.
+//
+// The timers are in memory and the deadline is in the store, which is what makes
+// a snooze survive a restart — see rescheduleSnoozeWakes.
+
+// snoozeTimer is a session's pending wake. firesAt is kept beside the timer
+// because time.Timer exposes no deadline accessor and the reschedule path needs
+// to know whether a stored deadline is the one already armed.
+type snoozeTimer struct {
+	timer   *time.Timer
+	firesAt time.Time
+}
+
+// handleSnoozeTurn defers a session until the instant the client computed.
+//
+// The client owns the arithmetic on purpose: "tomorrow" and "Monday" are
+// calendar questions that need the user's timezone and locale, and a remote
+// endpoint's daemon shares neither. The daemon takes an instant and schedules
+// against it.
+func (d *Daemon) handleSnoozeTurn(msg *protocol.SnoozeTurnMessage) {
+	if d == nil || d.store == nil || msg == nil {
+		return
+	}
+	sessionID := strings.TrimSpace(msg.SessionID)
+	if sessionID == "" {
+		return
+	}
+	until, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(msg.Until))
+	if err != nil {
+		d.logf("snooze rejected: session=%s bad until=%q: %v", sessionID, msg.Until, err)
+		return
+	}
+	if !d.store.SnoozeTurn(sessionID, until, time.Now()) {
+		return
+	}
+	// A snooze settles, so any countdown aimed at the same turn is moot — leaving
+	// one running would promise a second settle on a turn that is already closed.
+	d.cancelAutoSettle(sessionID, "snoozed")
+	// A snooze is a settle with a reason, and the trace is where the pairing with
+	// the state it closed survives.
+	d.traceSettle(sessionID)
+	d.scheduleSnoozeWake(sessionID, until)
+	d.broadcastSessionStateChanged(sessionID)
+}
+
+// handleWakeTurn ends a snooze early because the user asked.
+func (d *Daemon) handleWakeTurn(msg *protocol.WakeTurnMessage) {
+	if d == nil || msg == nil {
+		return
+	}
+	sessionID := strings.TrimSpace(msg.SessionID)
+	if sessionID == "" {
+		return
+	}
+	d.wakeSnooze(sessionID, time.Now(), "user")
+}
+
+// wakeSnooze clears a snooze and opens a turn if the session is sitting in a
+// state that wants the user. `at` is the instant the turn is stamped with, which
+// is the deadline for a timer wake and now for every other cause: a snooze that
+// lapsed while the daemon was down has genuinely been owed since it lapsed, and
+// the queue orders by how long you have owed something.
+//
+// Waking a session that is busy opens nothing. That is not a missed turn — the
+// agent is working, and the next state that wants the user opens one normally,
+// now that nothing is suppressing it.
+func (d *Daemon) wakeSnooze(sessionID string, at time.Time, cause string) {
+	if d == nil || d.store == nil || sessionID == "" {
+		return
+	}
+	d.cancelSnoozeWake(sessionID)
+	if !d.store.WakeTurn(sessionID) {
+		// No snooze was live. Staying silent keeps a redundant wake — a timer that
+		// lost a race with a hand wake, say — from broadcasting.
+		return
+	}
+	if session := d.store.Get(sessionID); session != nil && attention.OpensTurn(session.State) {
+		d.store.OpenTurnIfClosed(sessionID, d.turnOpensAtOnWake(sessionID, at))
+	}
+	if d.debugLogging {
+		d.logf("snooze woken: session=%s cause=%s", sessionID, cause)
+	}
+	d.recordStateObservation(sessionID, statetrace.Observation{
+		Source:  "user",
+		Claim:   d.currentStateClaim(sessionID),
+		Detail:  cause,
+		Cause:   "wake",
+		Outcome: statetrace.OutcomeApplied,
+	})
+	d.broadcastSessionStateChanged(sessionID)
+}
+
+// turnOpensAtOnWake is the instant a woken turn is stamped with.
+//
+// Normally that is the deadline: a snooze that lapsed at 11:00 has been owed
+// since 11:00, whether or not the daemon was running to notice. But membership
+// is `opened > settled`, and the settle that created the deferral is stamped at
+// the moment it was pressed — so a deadline that is not after it produces a turn
+// that reads as already closed, and the agent is silently lost rather than
+// deferred. That happens for a snooze whose deadline was already stale when it
+// arrived: clock skew across endpoints, or a client sending an instant it
+// computed a while ago.
+//
+// Such a deferral was over before it began, so it ends when we notice, and the
+// turn is owed from then.
+func (d *Daemon) turnOpensAtOnWake(sessionID string, deadline time.Time) time.Time {
+	if deadline.After(d.store.TurnStamps(sessionID).SettledAt) {
+		return deadline
+	}
+	return time.Now()
+}
+
+// currentStateClaim is the session's state as a string, or "" if it is gone.
+// The trace wants the state a wake landed on, the same way traceSettle wants the
+// state a settle closed.
+func (d *Daemon) currentStateClaim(sessionID string) string {
+	session := d.store.Get(sessionID)
+	if session == nil {
+		return ""
+	}
+	return string(session.State)
+}
+
+// snoozeSuppressesTurn is the gate applyState consults before opening a turn.
+//
+// It reports whether this session is deferred past the state it just reached. A
+// state that breaks through both returns false *and* clears the snooze, because
+// a deferral interrupted by something the user could not have anticipated is
+// over: they are back in the loop with that agent, and silently resuming the
+// remainder later would re-assert an intent they have since moved past.
+//
+// It is called from inside applyState, after the state is committed and before
+// the turn opens, so the break-through opens the very turn the state would have
+// opened had nothing been deferred. The reason is read from the resolver's own
+// record rather than threaded through sessionStateChange: publishResolution
+// files it immediately before applying, so it already describes the state being
+// committed, and a caller outside the resolver has no reason to supply.
+func (d *Daemon) snoozeSuppressesTurn(sessionID string, state protocol.SessionState) bool {
+	if d == nil || d.store == nil {
+		return false
+	}
+	if d.store.TurnStamps(sessionID).SnoozedUntil.IsZero() {
+		return false
+	}
+	reason := d.stateReasons().get(sessionID)
+	if !attention.BreaksSnooze(state, reason) {
+		return true
+	}
+	d.cancelSnoozeWake(sessionID)
+	d.store.WakeTurn(sessionID)
+	if d.debugLogging {
+		d.logf("snooze broken: session=%s state=%s reason=%s", sessionID, state, reason)
+	}
+	return false
+}
+
+// scheduleSnoozeWake arms (or replaces) a session's wake timer. A deadline
+// already in the past fires immediately, which is what makes a snooze that
+// lapsed during a restart behave like one that lapsed while the daemon was up.
+func (d *Daemon) scheduleSnoozeWake(sessionID string, until time.Time) {
+	if d == nil || sessionID == "" {
+		return
+	}
+	d.snoozeMu.Lock()
+	defer d.snoozeMu.Unlock()
+	d.scheduleSnoozeWakeLocked(sessionID, until)
+}
+
+func (d *Daemon) scheduleSnoozeWakeLocked(sessionID string, until time.Time) {
+	if d.snoozeTimers == nil {
+		d.snoozeTimers = make(map[string]*snoozeTimer)
+	}
+	if existing, ok := d.snoozeTimers[sessionID]; ok {
+		existing.timer.Stop()
+	}
+	window := time.Until(until)
+	if window < 0 {
+		window = 0
+	}
+	// The ready channel is the handshake auto_settle.go and nudge_countdown.go
+	// both use: the closure blocks until `timer` is published, so the identity
+	// check in the fire path reads a fully written value even when a zero window
+	// fires immediately.
+	ready := make(chan struct{})
+	var timer *time.Timer
+	timer = time.AfterFunc(window, func() {
+		<-ready
+		d.fireSnoozeWake(sessionID, timer, until)
+	})
+	d.snoozeTimers[sessionID] = &snoozeTimer{timer: timer, firesAt: until}
+	close(ready)
+}
+
+// fireSnoozeWake is the timer arriving. The identity check keeps a timer that
+// lost a cancel-or-replace race from waking a session that has since been
+// re-snoozed to a later deadline.
+func (d *Daemon) fireSnoozeWake(sessionID string, self *time.Timer, deadline time.Time) {
+	d.snoozeMu.Lock()
+	entry, ok := d.snoozeTimers[sessionID]
+	if !ok || entry.timer != self {
+		d.snoozeMu.Unlock()
+		return
+	}
+	delete(d.snoozeTimers, sessionID)
+	d.snoozeMu.Unlock()
+
+	d.wakeSnooze(sessionID, deadline, "deadline")
+	if d.snoozeWakeHook != nil {
+		d.snoozeWakeHook(sessionID)
+	}
+}
+
+// cancelSnoozeWake drops a session's pending wake without touching the store.
+func (d *Daemon) cancelSnoozeWake(sessionID string) {
+	if d == nil {
+		return
+	}
+	d.snoozeMu.Lock()
+	defer d.snoozeMu.Unlock()
+	if entry, ok := d.snoozeTimers[sessionID]; ok {
+		entry.timer.Stop()
+		delete(d.snoozeTimers, sessionID)
+	}
+}
+
+// clearSnoozeState drops a removed session's timer. The store row goes with the
+// session, so there is nothing to wake and nothing to broadcast.
+func (d *Daemon) clearSnoozeState(sessionID string) {
+	d.cancelSnoozeWake(sessionID)
+}
+
+// stopSnoozeTimers cancels every pending wake so no AfterFunc goroutine outlives
+// daemon teardown.
+func (d *Daemon) stopSnoozeTimers() {
+	if d == nil {
+		return
+	}
+	d.snoozeMu.Lock()
+	defer d.snoozeMu.Unlock()
+	for id, entry := range d.snoozeTimers {
+		entry.timer.Stop()
+		delete(d.snoozeTimers, id)
+	}
+}
+
+// rescheduleSnoozeWakes rebuilds the wake timers from the store at start-up.
+// The deadlines are persisted but the timers are not, so without this a snooze
+// would survive a restart as a session that never comes back — the worst
+// possible failure for a feature whose whole promise is that it returns.
+func (d *Daemon) rescheduleSnoozeWakes() {
+	if d == nil || d.store == nil {
+		return
+	}
+	for sessionID, until := range d.store.SnoozedSessions() {
+		d.scheduleSnoozeWake(sessionID, until)
+	}
+}
+
+// decorateSessionWithSnooze stamps the broadcast clone with a live snooze
+// deadline. A deadline in the past is left off: the wake is racing this
+// broadcast, and announcing a snooze that has already lapsed would park the row
+// in the snoozed section for as long as it took the timer to land.
+func (d *Daemon) decorateSessionWithSnooze(session *protocol.Session) {
+	if session == nil || d.store == nil {
+		return
+	}
+	session.TurnSnoozedUntil = nil
+	until := d.store.TurnStamps(session.ID).SnoozedUntil
+	if until.IsZero() || !until.After(time.Now()) {
+		return
+	}
+	session.TurnSnoozedUntil = protocol.Ptr(until.UTC().Format(time.RFC3339Nano))
+}

--- a/internal/daemon/snooze_test.go
+++ b/internal/daemon/snooze_test.go
@@ -250,6 +250,57 @@ func TestResnoozingReplacesThePendingWake(t *testing.T) {
 	}
 }
 
+// The narrow window the timer's identity check cannot cover: the wake has
+// already proved it is current and let go of the lock, and the second snooze
+// lands before it reaches the store. Nothing in memory can tell the callback it
+// has been superseded by then — only the stored deadline can, which is why the
+// clear is conditioned on it.
+//
+// Without that condition the expired timer clears the deadline the user just
+// chose and cancels the timer armed for it, so the agent comes back immediately
+// and never comes back again.
+func TestAResnoozeInsideAFiringWakeKeepsTheLaterDeadline(t *testing.T) {
+	d := newTurnDaemon(t)
+	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+	moveTo(d, "s1", protocol.StateWaitingInput)
+
+	later := time.Now().Add(time.Hour)
+	var once bool
+	d.snoozeWakeGapHook = func(sessionID string) {
+		if once {
+			return // the replacement's own wake, an hour from now, must not recurse
+		}
+		once = true
+		snoozeUntil(d, sessionID, later)
+	}
+	woken := make(chan string, 1)
+	d.snoozeWakeHook = func(sessionID string) { woken <- sessionID }
+
+	snoozeUntil(d, "s1", time.Now().Add(20*time.Millisecond))
+	select {
+	case <-woken:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the first snooze's timer never fired")
+	}
+
+	if owed(t, d, "s1") {
+		t.Error("the expired timer cashed a promise the user had already replaced")
+	}
+	if got := snoozedUntil(t, d, "s1"); got != later.UTC().Format(time.RFC3339Nano) {
+		t.Errorf("live deadline = %q, want the re-snooze's %q", got, later.UTC().Format(time.RFC3339Nano))
+	}
+	// And the replacement's own timer is still armed, so it does come back.
+	d.snoozeMu.Lock()
+	pending, ok := d.snoozeTimers["s1"]
+	d.snoozeMu.Unlock()
+	if !ok {
+		t.Fatal("the expired timer took the replacement's wake with it; the agent would never return")
+	}
+	if !pending.firesAt.Equal(later) {
+		t.Errorf("pending wake fires at %s, want the re-snooze's %s", pending.firesAt, later)
+	}
+}
+
 // A snooze arriving mid-countdown makes the pending auto-settle moot: the turn
 // it was going to close is already closed, and leaving the deadline on the wire
 // would animate a settle that will never happen.

--- a/internal/daemon/snooze_test.go
+++ b/internal/daemon/snooze_test.go
@@ -1,0 +1,309 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/sessionstate"
+)
+
+func snoozeUntil(d *Daemon, id string, until time.Time) {
+	d.handleSnoozeTurn(&protocol.SnoozeTurnMessage{
+		SessionID: id,
+		Until:     until.Format(time.RFC3339Nano),
+	})
+}
+
+func snoozedUntil(t *testing.T, d *Daemon, id string) string {
+	t.Helper()
+	session := d.sessionForBroadcast(d.store.Get(id))
+	if session == nil {
+		t.Fatalf("session %s not found", id)
+	}
+	return protocol.Deref(session.TurnSnoozedUntil)
+}
+
+// The whole of the deferral: the agent keeps stopping and asking, and none of it
+// puts the session back on the user's plate.
+func TestSnoozeSuppressesTurnsUntilItsDeadline(t *testing.T) {
+	d := newTurnDaemon(t)
+	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+
+	moveTo(d, "s1", protocol.StateWaitingInput)
+	if !owed(t, d, "s1") {
+		t.Fatal("setup: a waiting session owes no turn")
+	}
+
+	snoozeUntil(d, "s1", time.Now().Add(time.Hour))
+	if owed(t, d, "s1") {
+		t.Fatal("the session still owes a turn immediately after snoozing")
+	}
+	if snoozedUntil(t, d, "s1") == "" {
+		t.Fatal("no deadline on the wire, so the row has nothing to park under")
+	}
+
+	// Every ordinary way an agent comes back for the user, while deferred.
+	for _, state := range []string{
+		protocol.StateWorking,
+		protocol.StateWaitingInput,
+		protocol.StatePendingApproval,
+		protocol.StateIdle,
+	} {
+		moveTo(d, "s1", state)
+		if owed(t, d, "s1") {
+			t.Fatalf("state %s opened a turn on a snoozed session", state)
+		}
+	}
+}
+
+// Waking stamps the turn at the instant the user said they would come back, so
+// the row lands at the tail of the queue rather than resurfacing at the age it
+// had when it was deferred.
+func TestWakeOpensTheTurnAtTheWakeInstant(t *testing.T) {
+	d := newTurnDaemon(t)
+	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+
+	moveTo(d, "s1", protocol.StateWaitingInput)
+	original := protocol.Deref(d.sessionForBroadcast(d.store.Get("s1")).TurnOpenedAt)
+
+	snoozeUntil(d, "s1", time.Now().Add(time.Hour))
+	moveTo(d, "s1", protocol.StateIdle)
+
+	wakeAt := time.Now().Add(time.Hour)
+	d.wakeSnooze("s1", wakeAt, "test")
+
+	if !owed(t, d, "s1") {
+		t.Fatal("the woken session owes no turn although it is sitting idle")
+	}
+	opened := protocol.Deref(d.sessionForBroadcast(d.store.Get("s1")).TurnOpenedAt)
+	if opened == original {
+		t.Error("the turn kept its pre-snooze age, so it wakes to the head of the queue")
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, opened)
+	if err != nil {
+		t.Fatalf("turn_opened_at %q does not parse: %v", opened, err)
+	}
+	if !parsed.Equal(wakeAt.UTC()) {
+		t.Errorf("turn opened at %s, want the wake instant %s", parsed, wakeAt.UTC())
+	}
+	if snoozedUntil(t, d, "s1") != "" {
+		t.Error("the deadline survived the wake")
+	}
+}
+
+// Waking a busy agent opens nothing. That is not a missed turn: the suppression
+// is gone, so the next state that wants the user opens one normally.
+func TestWakeOpensNoTurnWhileTheAgentIsWorking(t *testing.T) {
+	d := newTurnDaemon(t)
+	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+
+	moveTo(d, "s1", protocol.StateWorking)
+	snoozeUntil(d, "s1", time.Now().Add(time.Hour))
+	d.wakeSnooze("s1", time.Now(), "test")
+
+	if owed(t, d, "s1") {
+		t.Fatal("waking a working agent opened a turn")
+	}
+	moveTo(d, "s1", protocol.StateWaitingInput)
+	if !owed(t, d, "s1") {
+		t.Error("the session stayed suppressed after the snooze was cleared")
+	}
+}
+
+// What the user could not have anticipated still gets through, and consumes the
+// deferral with it — they are back in the loop with that agent.
+func TestBreakThroughStatesEndTheSnooze(t *testing.T) {
+	tests := []struct {
+		name   string
+		state  string
+		reason sessionstate.Reason
+		breaks bool
+	}{
+		{"stuck", protocol.StateUnknown, sessionstate.ReasonStuck, true},
+		{"process exited", protocol.StateIdle, sessionstate.ReasonProcessExited, true},
+		{"an ordinary finished run", protocol.StateIdle, sessionstate.ReasonClassifierVerdict, false},
+		{"a question", protocol.StateWaitingInput, sessionstate.ReasonQuestionOpen, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := newTurnDaemon(t)
+			addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+
+			moveTo(d, "s1", protocol.StateWorking)
+			snoozeUntil(d, "s1", time.Now().Add(time.Hour))
+
+			// The reason is filed the way publishResolution files it, immediately
+			// before the state it describes is applied.
+			d.recordStateReason("s1", sessionstate.Resolution{
+				State:  protocol.SessionState(tt.state),
+				Reason: tt.reason,
+			})
+			moveTo(d, "s1", tt.state)
+
+			if got := owed(t, d, "s1"); got != tt.breaks {
+				t.Errorf("owed = %v, want %v", got, tt.breaks)
+			}
+			stillSnoozed := snoozedUntil(t, d, "s1") != ""
+			if stillSnoozed == tt.breaks {
+				t.Errorf("snooze live = %v after a state that breaks=%v; a break-through must consume the deferral",
+					stillSnoozed, tt.breaks)
+			}
+		})
+	}
+}
+
+// Snooze reaches any agent, not only one that owes a turn. Deferring a run
+// before it finishes is the case the reach exists for: the turn it would have
+// opened on finishing never opens.
+func TestSnoozingAWorkingAgentSuppressesTheTurnItWouldOpen(t *testing.T) {
+	d := newTurnDaemon(t)
+	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+
+	moveTo(d, "s1", protocol.StateWorking)
+	if owed(t, d, "s1") {
+		t.Fatal("setup: a working session owes a turn")
+	}
+	snoozeUntil(d, "s1", time.Now().Add(time.Hour))
+
+	moveTo(d, "s1", protocol.StateIdle)
+	if owed(t, d, "s1") {
+		t.Error("the finished run opened a turn although the agent was deferred")
+	}
+}
+
+// The deadline is persisted; the timer that fires on it is not. Without the
+// start-up reschedule a snooze would survive a restart as a session that never
+// comes back — the worst failure a deferral can have.
+func TestSnoozeWakesAfterARestart(t *testing.T) {
+	d := newTurnDaemon(t)
+	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+
+	moveTo(d, "s1", protocol.StateIdle)
+	// Written straight to the store, which is the state a restart finds: the
+	// deadline persisted, and no timer in memory to fire on it. Letting it lapse
+	// before the reschedule is the daemon having been down across it.
+	now := time.Now()
+	deadline := now.Add(10 * time.Millisecond)
+	if !d.store.SnoozeTurn("s1", deadline, now) {
+		t.Fatal("setup: the snooze was not stored")
+	}
+	time.Sleep(30 * time.Millisecond)
+	if owed(t, d, "s1") {
+		t.Fatal("setup: the session is not deferred")
+	}
+
+	woken := make(chan string, 1)
+	d.snoozeWakeHook = func(sessionID string) { woken <- sessionID }
+	d.rescheduleSnoozeWakes()
+
+	select {
+	case <-woken:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the lapsed snooze never woke after the reschedule")
+	}
+	if !owed(t, d, "s1") {
+		t.Error("the woken session owes no turn although it is sitting idle")
+	}
+}
+
+func TestSnoozeTimerFiresOnItsDeadline(t *testing.T) {
+	d := newTurnDaemon(t)
+	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+
+	moveTo(d, "s1", protocol.StateWaitingInput)
+	woken := make(chan string, 1)
+	d.snoozeWakeHook = func(sessionID string) { woken <- sessionID }
+
+	snoozeUntil(d, "s1", time.Now().Add(20*time.Millisecond))
+	if owed(t, d, "s1") {
+		t.Fatal("the session still owes a turn immediately after snoozing")
+	}
+
+	select {
+	case <-woken:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the snooze timer never fired")
+	}
+	if !owed(t, d, "s1") {
+		t.Error("the session owes no turn after its snooze elapsed")
+	}
+}
+
+// Re-snoozing to a later deadline must not be woken by the timer the first
+// snooze armed.
+func TestResnoozingReplacesThePendingWake(t *testing.T) {
+	d := newTurnDaemon(t)
+	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+	moveTo(d, "s1", protocol.StateWaitingInput)
+
+	snoozeUntil(d, "s1", time.Now().Add(20*time.Millisecond))
+	snoozeUntil(d, "s1", time.Now().Add(time.Hour))
+
+	time.Sleep(200 * time.Millisecond)
+	if owed(t, d, "s1") {
+		t.Error("the superseded timer woke a session that had been re-snoozed for an hour")
+	}
+	if snoozedUntil(t, d, "s1") == "" {
+		t.Error("the superseded timer cleared the live deadline")
+	}
+}
+
+// A snooze arriving mid-countdown makes the pending auto-settle moot: the turn
+// it was going to close is already closed, and leaving the deadline on the wire
+// would animate a settle that will never happen.
+func TestSnoozeCancelsAPendingAutoSettle(t *testing.T) {
+	d := newTurnDaemon(t)
+	d.store.SetSetting(SettingAutoSettleEnabled, "true")
+	d.store.SetSetting(SettingAutoSettleArmSeconds, "5")
+	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+
+	moveTo(d, "s1", protocol.StateWaitingInput)
+	moveTo(d, "s1", protocol.StateWorking)
+
+	d.autoSettleMu.Lock()
+	pending := len(d.autoSettleTimers)
+	d.autoSettleMu.Unlock()
+	if pending == 0 {
+		t.Fatal("setup: no auto-settle armed")
+	}
+
+	snoozeUntil(d, "s1", time.Now().Add(time.Hour))
+
+	d.autoSettleMu.Lock()
+	pending = len(d.autoSettleTimers)
+	d.autoSettleMu.Unlock()
+	if pending != 0 {
+		t.Error("the auto-settle timer survived the snooze")
+	}
+}
+
+// A deadline that has already passed is not a live snooze on the wire: the wake
+// is racing this broadcast, and announcing it would park the row for as long as
+// the timer took to land.
+func TestALapsedDeadlineIsNotBroadcast(t *testing.T) {
+	d := newTurnDaemon(t)
+	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+	moveTo(d, "s1", protocol.StateWorking)
+
+	d.store.SnoozeTurn("s1", time.Now().Add(-time.Minute), time.Now())
+	if got := snoozedUntil(t, d, "s1"); got != "" {
+		t.Errorf("turn_snoozed_until = %q for a deadline already past, want empty", got)
+	}
+}
+
+func TestSnoozeRejectsAnUnparseableDeadline(t *testing.T) {
+	d := newTurnDaemon(t)
+	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+	moveTo(d, "s1", protocol.StateWaitingInput)
+
+	d.handleSnoozeTurn(&protocol.SnoozeTurnMessage{SessionID: "s1", Until: "next tuesday"})
+
+	if !owed(t, d, "s1") {
+		t.Error("a malformed deadline settled the turn anyway")
+	}
+	if snoozedUntil(t, d, "s1") != "" {
+		t.Error("a malformed deadline was stored")
+	}
+}

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -1013,6 +1013,10 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 	case protocol.CmdWorkspaceSelected: // wire: workspace_selected
 	case protocol.CmdSettleTurn: // wire: settle_turn
 		d.handleSettleTurn(msg.(*protocol.SettleTurnMessage))
+	case protocol.CmdSnoozeTurn: // wire: snooze_turn
+		d.handleSnoozeTurn(msg.(*protocol.SnoozeTurnMessage))
+	case protocol.CmdWakeTurn: // wire: wake_turn
+		d.handleWakeTurn(msg.(*protocol.WakeTurnMessage))
 	case protocol.CmdCancelAutoSettle: // wire: cancel_auto_settle
 		d.handleCancelAutoSettle(msg.(*protocol.CancelAutoSettleMessage))
 	case protocol.CmdTriggerNudge: // wire: trigger_nudge
@@ -1331,6 +1335,17 @@ func remoteCommandSessionID(cmd string, msg interface{}) string {
 		// Same reasoning as settle_turn: the countdown that would close the turn
 		// runs in the daemon that owns the session, so the cancel has to reach it.
 		if typed, ok := msg.(*protocol.CancelAutoSettleMessage); ok {
+			return typed.SessionID
+		}
+	case protocol.CmdSnoozeTurn: // wire: snooze_turn
+		// Same again: the deadline is stored beside the turn stamps and the wake
+		// timer runs in the owning daemon. `until` is already absolute, so it
+		// crosses endpoints without any timezone reinterpretation.
+		if typed, ok := msg.(*protocol.SnoozeTurnMessage); ok {
+			return typed.SessionID
+		}
+	case protocol.CmdWakeTurn: // wire: wake_turn
+		if typed, ok := msg.(*protocol.WakeTurnMessage); ok {
 			return typed.SessionID
 		}
 	}

--- a/internal/hub/manager.go
+++ b/internal/hub/manager.go
@@ -1344,6 +1344,10 @@ func sessionsMatch(left, right protocol.Session) bool {
 		protocol.Deref(left.StateReason) == protocol.Deref(right.StateReason) &&
 		protocol.Deref(left.TurnOwed) == protocol.Deref(right.TurnOwed) &&
 		protocol.Deref(left.TurnOpenedAt) == protocol.Deref(right.TurnOpenedAt) &&
+		// Without this a remote agent snoozed on its own daemon changes nothing
+		// the hub compares, so the re-broadcast is suppressed and the row never
+		// moves into the snoozed section.
+		protocol.Deref(left.TurnSnoozedUntil) == protocol.Deref(right.TurnSnoozedUntil) &&
 		protocol.Deref(left.TicketUnread) == protocol.Deref(right.TicketUnread) &&
 		protocol.Deref(left.NudgeFiresAt) == protocol.Deref(right.NudgeFiresAt) &&
 		strings.Join(left.Todos, "\x00") == strings.Join(right.Todos, "\x00") &&

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "200"
+const ProtocolVersion = "201"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -110,6 +110,8 @@ const (
 	CmdWorkspaceSelected                     = "workspace_selected"
 	CmdTriggerNudge                          = "trigger_nudge"
 	CmdSettleTurn                            = "settle_turn"
+	CmdSnoozeTurn                            = "snooze_turn"
+	CmdWakeTurn                              = "wake_turn"
 	CmdCancelAutoSettle                      = "cancel_auto_settle"
 	CmdMuteWorkspace                         = "mute_workspace"
 	CmdPinWorkspace                          = "pin_workspace"
@@ -962,6 +964,20 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdSettleTurn:
 		var msg SettleTurnMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdSnoozeTurn:
+		var msg SnoozeTurnMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdWakeTurn:
+		var msg WakeTurnMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -3997,6 +3997,9 @@ type Session struct {
 	// TurnOwed corresponds to the JSON schema field "turn_owed".
 	TurnOwed *bool `json:"turn_owed,omitempty,omitzero"`
 
+	// TurnSnoozedUntil corresponds to the JSON schema field "turn_snoozed_until".
+	TurnSnoozedUntil *string `json:"turn_snoozed_until,omitempty,omitzero"`
+
 	// WorkspaceID corresponds to the JSON schema field "workspace_id".
 	WorkspaceID string `json:"workspace_id"`
 
@@ -4286,6 +4289,17 @@ type SettleTurnMessage struct {
 
 	// SessionID corresponds to the JSON schema field "session_id".
 	SessionID string `json:"session_id"`
+}
+
+type SnoozeTurnMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID string `json:"session_id"`
+
+	// Until corresponds to the JSON schema field "until".
+	Until string `json:"until"`
 }
 
 type SpawnResultMessage struct {
@@ -5144,6 +5158,14 @@ type UpdateEndpointMessage struct {
 
 	// SshTarget corresponds to the JSON schema field "ssh_target".
 	SshTarget *string `json:"ssh_target,omitempty,omitzero"`
+}
+
+type WakeTurnMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID string `json:"session_id"`
 }
 
 type WebSocketEvent struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -138,6 +138,7 @@ model Session {
   nudge_fires_at?: string;      // ISO timestamp a pending ticket-nudge countdown will fire; absent when paused (active session) or no countdown
   turn_owed?: boolean;          // True when the user owes this session a turn. Derived at broadcast from the turn stamps plus the queue's exclusions (shell, chief, pinned, muted); never stored, and never recomputed by a client.
   turn_opened_at?: string;      // ISO timestamp the outstanding turn opened; the queue's sort key. Absent when nothing is owed.
+  turn_snoozed_until?: string;  // ISO timestamp a live snooze runs to. Present only while the deferral holds; its presence is what puts the row in the sidebar's snoozed section, and while it is set no state can open a turn for this session except one that breaks through.
   auto_settle_fires_at?: string; // ISO timestamp the auto-settle countdown will close this session's turn. Present only while the countdown is running, which is the whole contract: it is what the terminal tile animates against, and its absence is what says nothing is pending. Absent during the arm delay, when auto-settle is off, and after a cancel.
   todos?: string[];             // Optional: can be empty/absent
   last_seen: string;            // ISO timestamp, always set
@@ -1378,6 +1379,28 @@ model TriggerNudgeMessage {
 // Fire-and-forget; the daemon broadcasts the session afterwards.
 model SettleTurnMessage {
   cmd: "settle_turn";
+  session_id: string;
+}
+
+// SnoozeTurnMessage defers a session until an instant: it closes any open turn
+// and stops the next one from opening before then. Snooze is available on any
+// agent, not only one that currently owes a turn, so a run you already know you
+// do not want handed back can be deferred before it finishes.
+//
+// `until` is an absolute ISO instant computed by the client, because "tomorrow"
+// and "Monday" are calendar questions that need the user's timezone — which a
+// remote endpoint's daemon does not share. Fire-and-forget.
+model SnoozeTurnMessage {
+  cmd: "snooze_turn";
+  session_id: string;
+  until: string;
+}
+
+// WakeTurnMessage ends a snooze early. It clears the deadline; whether a turn
+// then opens depends on the state the agent is in at that instant, which is the
+// daemon's call. Fire-and-forget.
+model WakeTurnMessage {
+  cmd: "wake_turn";
   session_id: string;
 }
 

--- a/internal/store/snooze_test.go
+++ b/internal/store/snooze_test.go
@@ -70,6 +70,56 @@ func TestWakeTurnClearsTheDeadlineOnlyOnce(t *testing.T) {
 	}
 }
 
+// WakeTurnAt is what a fired timer uses, and it clears only the deadline it was
+// armed for. The stored deadline is the record of which snooze is current: a
+// timer that expired before a second snooze landed has no way to know it was
+// replaced except by finding a different deadline there.
+//
+// Both branches, because a daemon without a database is a supported store and a
+// deferral that behaves differently in it is a deferral that behaves differently
+// for that user.
+func TestWakeTurnAtClearsOnlyTheDeadlineItFired(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		build func(t *testing.T) *Store
+	}{
+		{"sqlite", newTurnStore},
+		{"in-memory", func(t *testing.T) *Store { return New() }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := tc.build(t)
+			addTurnSession(t, s, "s1", protocol.SessionStateIdle)
+
+			now := time.Now()
+			fired := now.Add(time.Minute)
+			later := now.Add(time.Hour)
+			s.SnoozeTurn("s1", fired, now)
+
+			// The replacement lands while the first timer is on its way to the store.
+			s.SnoozeTurn("s1", later, now)
+
+			if s.WakeTurnAt("s1", fired) {
+				t.Error("the expired timer cleared a deadline that had already been replaced")
+			}
+			if got := s.TurnStamps("s1").SnoozedUntil; !got.Equal(later) {
+				t.Errorf("live deadline = %s, want the replacement's %s", got, later)
+			}
+
+			// The replacement's own timer still ends it.
+			if !s.WakeTurnAt("s1", later) {
+				t.Fatal("the live deadline's own timer could not clear it")
+			}
+			if !s.TurnStamps("s1").SnoozedUntil.IsZero() {
+				t.Error("deadline survived its own wake")
+			}
+			// And nothing is left to clear, so a redelivered timer stays quiet.
+			if s.WakeTurnAt("s1", later) {
+				t.Error("WakeTurnAt reported a change on a session that was not snoozed")
+			}
+		})
+	}
+}
+
 // A wake must not re-open the turn the snooze closed. Whether one opens is the
 // daemon's call, from the state the agent is actually in.
 func TestWakeTurnDoesNotReopenTheTurn(t *testing.T) {

--- a/internal/store/snooze_test.go
+++ b/internal/store/snooze_test.go
@@ -1,0 +1,158 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// A snooze closes the open turn as it defers. The two are one write because a
+// deadline stamped beside a still-open turn would be a row in the queue that no
+// state change could ever move.
+func TestSnoozeTurnSettlesAsItDefers(t *testing.T) {
+	s := newTurnStore(t)
+	addTurnSession(t, s, "s1", protocol.SessionStateWaitingInput)
+
+	opened := time.Now().Add(-time.Hour)
+	if !s.OpenTurnIfClosed("s1", opened) {
+		t.Fatal("setup: no turn opened")
+	}
+
+	now := time.Now()
+	until := now.Add(30 * time.Minute)
+	if !s.SnoozeTurn("s1", until, now) {
+		t.Fatal("SnoozeTurn reported no write")
+	}
+
+	stamps := s.TurnStamps("s1")
+	if !stamps.SettledAt.After(stamps.OpenedAt) {
+		t.Errorf("settled=%s opened=%s: the snooze left a turn open", stamps.SettledAt, stamps.OpenedAt)
+	}
+	if got := stamps.SnoozedUntil.UTC(); !got.Equal(until.UTC().Truncate(time.Nanosecond)) {
+		t.Errorf("snoozed_until = %s, want %s", got, until.UTC())
+	}
+}
+
+// Snooze reaches any agent, not only one that owes a turn: deferring a run
+// before it finishes is the case the feature exists for.
+func TestSnoozeTurnWithNoOpenTurn(t *testing.T) {
+	s := newTurnStore(t)
+	addTurnSession(t, s, "s1", protocol.SessionStateWorking)
+
+	now := time.Now()
+	if !s.SnoozeTurn("s1", now.Add(time.Hour), now) {
+		t.Fatal("SnoozeTurn reported no write")
+	}
+	if s.TurnStamps("s1").SnoozedUntil.IsZero() {
+		t.Error("no deadline stored for a session that had no turn open")
+	}
+}
+
+func TestWakeTurnClearsTheDeadlineOnlyOnce(t *testing.T) {
+	s := newTurnStore(t)
+	addTurnSession(t, s, "s1", protocol.SessionStateIdle)
+
+	now := time.Now()
+	s.SnoozeTurn("s1", now.Add(time.Hour), now)
+
+	if !s.WakeTurn("s1") {
+		t.Fatal("WakeTurn reported no change on a live snooze")
+	}
+	if !s.TurnStamps("s1").SnoozedUntil.IsZero() {
+		t.Error("deadline survived the wake")
+	}
+	// The second wake reporting false is what lets the daemon stay quiet when a
+	// timer and a hand wake race.
+	if s.WakeTurn("s1") {
+		t.Error("WakeTurn reported a change on a session that was not snoozed")
+	}
+}
+
+// A wake must not re-open the turn the snooze closed. Whether one opens is the
+// daemon's call, from the state the agent is actually in.
+func TestWakeTurnDoesNotReopenTheTurn(t *testing.T) {
+	s := newTurnStore(t)
+	addTurnSession(t, s, "s1", protocol.SessionStateWaitingInput)
+
+	now := time.Now()
+	s.OpenTurnIfClosed("s1", now.Add(-time.Hour))
+	s.SnoozeTurn("s1", now.Add(time.Hour), now)
+	s.WakeTurn("s1")
+
+	stamps := s.TurnStamps("s1")
+	if stamps.OpenedAt.After(stamps.SettledAt) {
+		t.Error("the wake re-opened the turn by itself")
+	}
+}
+
+func TestSnoozedSessionsListsLiveDeadlines(t *testing.T) {
+	s := newTurnStore(t)
+	addTurnSession(t, s, "deferred", protocol.SessionStateIdle)
+	addTurnSession(t, s, "lapsed", protocol.SessionStateIdle)
+	addTurnSession(t, s, "awake", protocol.SessionStateIdle)
+
+	now := time.Now()
+	future := now.Add(time.Hour)
+	past := now.Add(-time.Hour)
+	s.SnoozeTurn("deferred", future, now)
+	// A deadline already past is stored, not rejected: the daemon fires on it
+	// immediately at start-up, which is how a snooze that lapsed while the daemon
+	// was down behaves like one that lapsed while it was up.
+	s.SnoozeTurn("lapsed", past, now)
+
+	snoozed := s.SnoozedSessions()
+	if len(snoozed) != 2 {
+		t.Fatalf("SnoozedSessions returned %d entries, want 2: %+v", len(snoozed), snoozed)
+	}
+	if got := snoozed["deferred"].UTC(); !got.Equal(future.UTC()) {
+		t.Errorf("deferred deadline = %s, want %s", got, future.UTC())
+	}
+	if got := snoozed["lapsed"].UTC(); !got.Equal(past.UTC()) {
+		t.Errorf("lapsed deadline = %s, want %s", got, past.UTC())
+	}
+	if _, ok := snoozed["awake"]; ok {
+		t.Error("a session that was never snoozed is listed")
+	}
+}
+
+// The deadline is in the database, not in the daemon's memory. This is the only
+// thing that makes a snooze survive a restart, so it is pinned against the real
+// SQLite path rather than the in-memory branch.
+func TestSnoozeSurvivesReopeningTheDatabase(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "snooze.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	addTurnSession(t, s, "s1", protocol.SessionStateIdle)
+	now := time.Now()
+	until := now.Add(90 * time.Minute)
+	s.SnoozeTurn("s1", until, now)
+	s.Close()
+
+	reopened, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopened.Close()
+
+	if got := reopened.TurnStamps("s1").SnoozedUntil.UTC(); !got.Equal(until.UTC()) {
+		t.Errorf("deadline after reopen = %s, want %s", got, until.UTC())
+	}
+	if _, ok := reopened.SnoozedSessions()["s1"]; !ok {
+		t.Error("the reopened store does not list the snooze, so no wake timer would be rebuilt")
+	}
+}
+
+func TestSnoozeTurnRejectsUnknownSession(t *testing.T) {
+	s := newTurnStore(t)
+	now := time.Now()
+	if s.SnoozeTurn("nope", now.Add(time.Hour), now) {
+		t.Error("snoozed a session that does not exist")
+	}
+	if s.WakeTurn("nope") {
+		t.Error("woke a session that does not exist")
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -850,6 +850,7 @@ CREATE TABLE IF NOT EXISTS bus_consumers (
     enabled    INTEGER NOT NULL DEFAULT 1,
     updated_at TEXT NOT NULL DEFAULT ''
 );`},
+	{85, "add the snooze deadline to sessions", ""}, // see applyMigration85
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -1110,6 +1111,11 @@ func migrateDB(db *sql.DB, dbPath string) error {
 			}
 		} else if m.version == 81 {
 			if err := applyMigration81(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 85 {
+			if err := applyMigration85(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -2042,6 +2048,19 @@ func applyMigration81(tx *sql.Tx) error {
 	_, err = tx.Exec(`
 		UPDATE sessions SET turn_opened_at = state_since
 		 WHERE state IN ('waiting_input', 'pending_approval', 'unknown')`)
+	return err
+}
+
+// applyMigration85 adds the snooze deadline. Nothing is backfilled: no snooze
+// has ever been expressed, so every existing session is correctly not deferred.
+// Guarded on the column existing so a rewound schema_migrations table re-runs it
+// without erroring on the duplicate.
+func applyMigration85(tx *sql.Tx) error {
+	has, err := columnExists(tx, "sessions", "turn_snoozed_until")
+	if err != nil || has {
+		return err
+	}
+	_, err = tx.Exec("ALTER TABLE sessions ADD COLUMN turn_snoozed_until TEXT NOT NULL DEFAULT ''")
 	return err
 }
 

--- a/internal/store/turn.go
+++ b/internal/store/turn.go
@@ -152,6 +152,46 @@ func (s *Store) WakeTurn(id string) bool {
 	return err == nil && updated == 1
 }
 
+// WakeTurnAt clears a session's snooze only if the deadline it holds is exactly
+// the one given. It is what a fired timer uses instead of WakeTurn.
+//
+// A timer proves its identity against the daemon's map, but that map says
+// nothing about the store: a snooze written after the timer expired and before
+// it finished waking has already replaced the deadline, and an unconditional
+// clear would cash a promise the user had just replaced with a later one. The
+// stored deadline is the record of which snooze is current, so the clear is
+// conditioned on it.
+//
+// It reports whether the snooze it was told to end was still the live one.
+func (s *Store) WakeTurnAt(id string, deadline time.Time) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stamp := deadline.UTC().Format(time.RFC3339Nano)
+
+	if s.db == nil {
+		current, ok := s.turnStamps[id]
+		if !ok || current.SnoozedUntil.IsZero() {
+			return false
+		}
+		if current.SnoozedUntil.UTC().Format(time.RFC3339Nano) != stamp {
+			return false
+		}
+		current.SnoozedUntil = time.Time{}
+		s.setTurnStampsLocked(id, current)
+		return true
+	}
+
+	result, err := s.db.Exec(
+		`UPDATE sessions SET turn_snoozed_until = '' WHERE id = ? AND turn_snoozed_until = ?`, id, stamp)
+	if err != nil {
+		log.Printf("[store] WakeTurnAt: failed for session %s: %v", id, err)
+		return false
+	}
+	updated, err := result.RowsAffected()
+	return err == nil && updated == 1
+}
+
 // SnoozedSessions is every live snooze, by session id. The daemon reads it once
 // at start-up to rebuild its wake timers, which is the only thing that makes a
 // snooze survive a restart — the timers themselves are in memory.

--- a/internal/store/turn.go
+++ b/internal/store/turn.go
@@ -9,9 +9,15 @@ import (
 // TurnStamps is the pair that decides whether a session owes the user a turn:
 // it does iff OpenedAt is after SettledAt. Both are zero for a session that has
 // never opened a turn.
+//
+// SnoozedUntil rides along rather than deciding anything, because a snooze
+// always settles the open turn as it is written — so a snoozed session already
+// reads as owing nothing, and the deadline is only there to say when it comes
+// back and to keep the next turn from opening before then.
 type TurnStamps struct {
-	OpenedAt  time.Time
-	SettledAt time.Time
+	OpenedAt     time.Time
+	SettledAt    time.Time
+	SnoozedUntil time.Time
 }
 
 // OpenTurnIfClosed stamps the start of a turn, but only when no turn is already
@@ -64,7 +70,8 @@ func (s *Store) SettleTurn(id string, now time.Time) bool {
 			return false
 		}
 		current := s.turnStamps[id]
-		s.setTurnStampsLocked(id, TurnStamps{OpenedAt: current.OpenedAt, SettledAt: now.UTC()})
+		current.SettledAt = now.UTC()
+		s.setTurnStampsLocked(id, current)
 		return true
 	}
 
@@ -78,6 +85,110 @@ func (s *Store) SettleTurn(id string, now time.Time) bool {
 	return err == nil && updated == 1
 }
 
+// SnoozeTurn defers a session until `until`: it closes whatever turn is open and
+// records the deadline in the same write.
+//
+// The two halves are one statement on purpose. A snooze that stamped the
+// deadline without settling would leave a turn open *and* suppressed — a row in
+// the queue that no state change can ever move — and the window in which that is
+// true is exactly the window a broadcast can land in.
+//
+// A deadline already in the past is stored as given rather than rejected. The
+// daemon's wake path fires immediately on it, which is what makes a snooze that
+// lapsed while the daemon was down behave like one that lapsed while it was up.
+func (s *Store) SnoozeTurn(id string, until, now time.Time) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		if _, ok := s.sessions[id]; !ok {
+			return false
+		}
+		current := s.turnStamps[id]
+		current.SettledAt = now.UTC()
+		current.SnoozedUntil = until.UTC()
+		s.setTurnStampsLocked(id, current)
+		return true
+	}
+
+	result, err := s.db.Exec(
+		`UPDATE sessions SET turn_settled_at = ?, turn_snoozed_until = ? WHERE id = ?`,
+		now.UTC().Format(time.RFC3339Nano), until.UTC().Format(time.RFC3339Nano), id)
+	if err != nil {
+		log.Printf("[store] SnoozeTurn: failed for session %s: %v", id, err)
+		return false
+	}
+	updated, err := result.RowsAffected()
+	return err == nil && updated == 1
+}
+
+// WakeTurn clears a session's snooze without opening anything. Whether a turn
+// then opens is the daemon's call — it depends on the state the agent is in at
+// that instant — so this stays the narrow write.
+//
+// It reports whether a snooze was actually cleared, which is what lets the
+// caller stay quiet about a wake for a session that was not snoozed.
+func (s *Store) WakeTurn(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		current, ok := s.turnStamps[id]
+		if !ok || current.SnoozedUntil.IsZero() {
+			return false
+		}
+		current.SnoozedUntil = time.Time{}
+		s.setTurnStampsLocked(id, current)
+		return true
+	}
+
+	result, err := s.db.Exec(
+		`UPDATE sessions SET turn_snoozed_until = '' WHERE id = ? AND turn_snoozed_until != ''`, id)
+	if err != nil {
+		log.Printf("[store] WakeTurn: failed for session %s: %v", id, err)
+		return false
+	}
+	updated, err := result.RowsAffected()
+	return err == nil && updated == 1
+}
+
+// SnoozedSessions is every live snooze, by session id. The daemon reads it once
+// at start-up to rebuild its wake timers, which is the only thing that makes a
+// snooze survive a restart — the timers themselves are in memory.
+func (s *Store) SnoozedSessions() map[string]time.Time {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	snoozed := make(map[string]time.Time)
+
+	if s.db == nil {
+		for id, stamps := range s.turnStamps {
+			if !stamps.SnoozedUntil.IsZero() {
+				snoozed[id] = stamps.SnoozedUntil
+			}
+		}
+		return snoozed
+	}
+
+	rows, err := s.db.Query(`SELECT id, turn_snoozed_until FROM sessions WHERE turn_snoozed_until != ''`)
+	if err != nil {
+		log.Printf("[store] SnoozedSessions: failed: %v", err)
+		return snoozed
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, until string
+		if err := rows.Scan(&id, &until); err != nil {
+			log.Printf("[store] SnoozedSessions: scan failed: %v", err)
+			continue
+		}
+		if parsed := parseTurnStamp(until); !parsed.IsZero() {
+			snoozed[id] = parsed
+		}
+	}
+	return snoozed
+}
+
 // TurnStamps reads one session's stamps. Zero values mean no turn has ever
 // opened, which reads as owing nothing.
 func (s *Store) TurnStamps(id string) TurnStamps {
@@ -88,16 +199,21 @@ func (s *Store) TurnStamps(id string) TurnStamps {
 		return s.turnStamps[id]
 	}
 
-	var opened, settled string
-	err := s.db.QueryRow(`SELECT turn_opened_at, turn_settled_at FROM sessions WHERE id = ?`, id).
-		Scan(&opened, &settled)
+	var opened, settled, snoozed string
+	err := s.db.QueryRow(
+		`SELECT turn_opened_at, turn_settled_at, turn_snoozed_until FROM sessions WHERE id = ?`, id).
+		Scan(&opened, &settled, &snoozed)
 	if err != nil {
 		if err != sql.ErrNoRows {
 			log.Printf("[store] TurnStamps: failed for session %s: %v", id, err)
 		}
 		return TurnStamps{}
 	}
-	return TurnStamps{OpenedAt: parseTurnStamp(opened), SettledAt: parseTurnStamp(settled)}
+	return TurnStamps{
+		OpenedAt:     parseTurnStamp(opened),
+		SettledAt:    parseTurnStamp(settled),
+		SnoozedUntil: parseTurnStamp(snoozed),
+	}
 }
 
 func (s *Store) setTurnStampsLocked(id string, stamps TurnStamps) {


### PR DESCRIPTION
## Summary

Implements the *Deferral* rock of [the agent queue vision](docs/vision/agent-queue.md); full design in [the plan](docs/plans/2026-08-02-agent-queue-snooze.md).

Settle answers "I dealt with this". Nothing answered "not now", so an agent you cannot act on yet — a run with 40 minutes left, a finished run you want to read after lunch — either sat in the band or was settled dishonestly and came straight back.

Snooze is settle plus a suppression window, written in one statement so a turn is never both open and suppressed. It suppresses the turn *opening* rather than filtering an open turn at read: that is what makes a woken turn stamped at the wake instant and land at the tail of the queue, instead of resurrecting an hour-old stamp straight to the head of the band. Any agent can be deferred, owed or not — the useful case is precisely the one where no turn is open yet.

The deferral is honoured while it lasts: steering or looking at a snoozed agent does not cancel it. Only what the user could not have anticipated breaks through — a state the daemon cannot explain (`unknown`), or a process that died (`idle`/`process_exited`) — and a break-through consumes the snooze rather than pausing it.

Daemon-owned wake timers mirror auto-settle: armed on snooze, cancelled on wake, rebuilt from persisted deadlines at start-up. A deadline that lapsed while the daemon was down stamps the turn at the deadline, because the turn has genuinely been owed since then.

Deferred agents render in a collapsible Snoozed section at the foot of the sidebar, above muted workspaces, each with its wake time and a wake-now action. Snoozing hands over the next agent that wants the user, exactly as settling does.

- Protocol 201 (`turn_snoozed_until`, `snooze_turn`, `wake_turn`); migration 85.
- Duration menu: 30m, 1h, 8h, tomorrow, Saturday, Monday (day choices wake at 09:00 local).
- Indefinite backgrounding and a custom date/time picker are deliberately out of scope — see the plan's Deferred section.

## Test plan

- [x] Full Go suite green
- [x] Frontend: 197 files / 2179 tests green
- [x] `pnpm --dir app exec tsc --noEmit` clean
- [x] Live-verified twice on a non-production profile via `real-app:scenario-agent-queue-snooze`: two real Claude agents, snoozed from the row menu for 30 minutes, watched out of the band into the section with its wake time, driven through a second run under the deferral with no turn opening, woken early to the tail, woken again by the timer, carried across a daemon restart, and SIGKILLed to see the break-through.

https://claude.ai/code/session_01BzKRr7PFLDU9mERFDUdTv9