### PR TITLE
chore(release): retroactive changelog fragment for #719

### DIFF
--- a/changelog.d/retro-fragment-719.yaml
+++ b/changelog.d/retro-fragment-719.yaml
@@ -1,0 +1,11 @@
+kind: internal
+area: daemon
+change: >
+  State-change broadcasts now route through the durable event bus (PR #719):
+  producers publish domain facts and the hub projects them into wire traffic
+  via wireProjections, replacing direct broadcast calls. No user-visible
+  behavior change.
+notes: >
+  Retroactive fragment: #719 merged in the minutes between the fragment
+  pipeline landing (#720) and the Changelog check becoming required, so its
+  own CI never ran the gate.


### PR DESCRIPTION
#719 (event-bus broadcast migration) merged in the minutes between the fragment pipeline landing (#720) and the `Changelog` check becoming required in branch protection, so its CI never ran the gate and it carries neither a fragment nor a CHANGELOG.md edit. This adds its `kind: internal` fragment so the release-time changelog compilation sees the full delta. The fragment names #719 explicitly since git attribution of the file points at this PR, not the change it describes.

https://claude.ai/code/session_01WSSv35YUQhgdR35f9zaDJF