### PR TITLE
fix(terminal): stop advertising kitty graphics the terminal cannot render

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,9 +394,12 @@ Design and gate decisions:
   client always writes the dump suppressed.
 - The daemon/worker alone answers CPR, DA1, and OSC 10/11/12; frontend strips
   model replies and sends theme changes via `set_terminal_theme`.
-- Restores are text-only: sixel/kitty images render from the live stream but are
-  not preserved across a restore (accepted; image-preserving restore is a
-  follow-up).
+- No image protocol renders anywhere today. Sixel does not exist in ghostty at
+  all, and kitty graphics are deliberately disabled in the worker terminal
+  (`KittyImageStorageLimit` 0 at construction) so the worker's authoritative
+  grid cannot desync from the client model, which never parses kitty — ghostty
+  hard-disables it on wasm. Worker-authoritative image support is planned in
+  [docs/plans/2026-08-02-terminal-kitty-images.md](docs/plans/2026-08-02-terminal-kitty-images.md).
 - Session switching must retain utility-terminal focus. `App.tsx` may fit the
   main terminal but focuses it only when utility is inactive;
   `SessionTerminalWorkspace` prefers the active `GhosttyTerminal` handle.

--- a/changelog.d/cranky-platypus-kitty-disable.yaml
+++ b/changelog.d/cranky-platypus-kitty-disable.yaml
@@ -1,0 +1,18 @@
+kind: fixed
+area: terminal
+change: >
+  The worker terminal no longer advertises kitty-graphics image support it
+  cannot render. Its native VT core had the protocol live with the library's
+  default 10MB image storage limit, so it answered support queries with an OK
+  and accepted image placements; kitty graphics are now disabled at terminal
+  construction until real image support ships.
+symptom: >
+  Feature-detecting tools (kitten icat, timg, chafa) saw image support and
+  emitted kitty escapes that displayed nothing. Worse, an accepted placement
+  moved the cursor in the worker's authoritative grid but not in the client's,
+  and a detach/reattach restore served that diverged grid — so the visible
+  terminal could come back corrupted after running such a tool.
+notes: >
+  Phase A1 of docs/plans/2026-08-02-terminal-kitty-images.md; the remaining
+  phases add real worker-authoritative rendering. The grid effect requires cell
+  pixel metrics, which every resized production terminal has.

--- a/docs/plans/2026-08-02-terminal-kitty-images.md
+++ b/docs/plans/2026-08-02-terminal-kitty-images.md
@@ -1,0 +1,293 @@
+# Plan: kitty graphics in the attn terminal (worker-authoritative)
+
+## Goal
+
+Render kitty-protocol images (icat, chafa, timg, matplotlib's kitty backend) in
+the attn terminal, with restore across detach/reattach, on local and remote
+sessions — and, before any of that, stop the false capability advertisement
+that desyncs the two terminal grids today.
+
+Companion track: the ghostty WASM crash fix continues under its own plan,
+[2026-07-27-ghostty-wasm-model-crashes.md](2026-07-27-ghostty-wasm-model-crashes.md).
+The tracks are independent; the one interaction is that stripping kitty APC
+from the wire (this plan) means the crash-prone client wasm never parses kitty
+bytes at all.
+
+## Today's behavior (evidence, 2026-08-02)
+
+The daemon worker's native terminal (libghostty-vt, pin `ab0b9da`) compiles
+kitty graphics **in** and the `.lib` artifact defaults
+`kitty_image_storage_limit = 10MB`, so it is live — attn never configures it.
+The frontend's wasm model can **never** parse kitty graphics: ghostty disables
+it on `wasm32-freestanding` at every pin (the implementation needs
+timestamps), so pin convergence does not change this.
+
+Probe (temporary Go test against `internal/ghosttyvt`, darwin/arm64, since
+deleted):
+
+```text
+direct-rgb     cursor 0,1 -> 0,0 | resp=""                    | text="aftere"
+png            cursor 0,1 -> 0,1 | resp=""                    | text="before|after"
+query-support  cursor 0,1 -> 0,1 | resp="\x1b_Gi=31;OK\x1b\\" | text="before|after"
+```
+
+- attn **advertises kitty image support**: the `a=q` reply reaches the program
+  (`drainGhosttyResponses` forwards responses the scanner does not own).
+  Feature-detecting tools will send images.
+- A direct-RGB image is stored worker-side and **moves the cursor**; the
+  client model ignores the APC entirely → the two grids silently desync. The
+  worker grid feeds approval classification and the restore dump, so a restore
+  visibly changes what the user sees.
+- PNG (`f=100`) is dropped worker-side — no `sys.decode_png` host hook — so
+  those stay consistent but invisible.
+- Sixel does not exist anywhere in ghostty; kitty is the only image protocol
+  on the table.
+- The current AGENTS.md claim that "sixel/kitty images render from the live
+  stream" is false on both halves and is corrected in Phase A1.
+
+## Decision: worker-authoritative, one parser
+
+The worker's native ghostty is the **only** kitty parser in the system. It
+already parses today; the client never can. The worker owns image parsing,
+storage, and layout; the client receives (a) a plain-VT byte stream with the
+APC stripped and layout-equivalent bytes substituted, and (b) structured
+placement/image data, rendered as textured quads by the app's own WebGL
+renderer.
+
+Rejected alternatives:
+
+- **Client-side TS kitty parser** (xterm.js image-addon shape): keeps the wire
+  pristine, but the worker must stay enabled for classification and restore,
+  so it means two kitty parsers held in lockstep forever — strictly more
+  machinery than the OSC 133 dual-parser precedent, for a far larger protocol.
+  It also gets `t=f` (file transmission) wrong for remote sessions: the path
+  in the escape names a file on the machine running the PTY, which only the
+  remote worker can read.
+- **attn-native images, no kitty**: cheapest, but third-party emitters get
+  nothing, and the advertise bug still needs the worker-side fix anyway.
+
+Honest costs of the chosen design, and their mitigations:
+
+- **The stream rewrite is a permanently-owned correctness surface.** If the
+  synthesized layout bytes ever diverge from what ghostty did, the grids
+  desync — the same bug class we are fixing, now ours. Mitigations: synthesis
+  observes the authoritative terminal rather than predicting (see below); the
+  cross-runtime parity corpus is a merge gate, not a nice-to-have; and any
+  case synthesis cannot represent degrades to a forced snapshot re-push (the
+  existing server-authoritative restore), which re-syncs by construction —
+  divergence can be healed, never silent.
+- **Daemon memory holds pixels for every session**, attached or not. Bounded
+  by the per-session storage limit; the limit number gets a receipt in A4.
+- **Display latency**: the image quad appears when the placement/blob event
+  lands, a beat after the text reflows. Accepted; pop-in, not corruption.
+
+## What this generalizes to
+
+The worker is already a semantic tap on the byte stream, with two scanner
+classes in production: **look-only** (`oscscan.go`: OSC 0 titles, OSC 777
+notifications — the wire is untouched) and **strip-and-structure**
+(`osc133.go`: markers stripped from the terminal feed, blocks shipped as
+structure). Kitty adds the third class: **keep-for-terminal,
+rewrite-on-wire, structure-out**.
+
+Future tenants that reuse the same seams (scanner slot in the feed path,
+structured event out, app-native surface) and are explicitly *not* built now:
+OSC 9;4 progress → session-tile progress; OSC 9/777 → attention routing;
+OSC 52 clipboard (matters most for remotes); iTerm2 OSC 1337 images (ghostty
+is kitty-only, but an attn-side OSC 1337 parser could feed the same placement
+store — follow-up-sized). Shape the A2/A3 seams so a second tenant is a small
+PR; build none of them speculatively.
+
+## Architecture
+
+```text
+PTY read loop (worker, per chunk, under replayMu):
+  raw chunk
+    ├─ kitty segmenter (outer): split at complete APC `ESC _ G … ST` boundaries,
+    │    buffer partial APC across chunks (findSafeBoundary only protects the
+    │    trailing 64 bytes; payloads run to ~4KB, so spanning is the segmenter's
+    │    job, same as OSC 133)
+    │      non-APC segments ──► blockFeed.feed (existing OSC 133 strip + ghostty write)
+    │      APC bytes ─────────► ghostty term.Write (ghostty parses — the one parser)
+    │                            ├─ observe: placement-set diff via kitty_graphics.h
+    │                            │    iterator (before/after) → add/remove/update
+    │                            ├─ observe: cursor + scroll delta (TrackedRef pin
+    │                            │    before the APC, CursorPos after)
+    │                            └─ synthesize: IND×scroll + CUP into the wire chunk
+    ├─ lastReplaySeq = seq   (unchanged)
+  outside the lock: drain/forward ghostty's `_G` ACKs to the program (unchanged)
+  fanOut(wireChunk, seq)     ← rewritten bytes, same seq
+
+structured side (same replayMu hold as the diff):
+  placement events {server-assigned id, session, buffer-row anchor, grid rect,
+                    z, image ref, seq}
+  image blob events {image ref, pixel data, dims, seq}   (size-capped, see A4)
+
+attach snapshot: atomic {dump, blocks, placements+image refs, watermark}
+  — the existing triple grows one member, read under the same replayMu hold.
+
+frontend:
+  placement store — buffer-row anchored, re-anchored via the block-store
+    contract (dump-coordinates at restore, reanchorDelta thereafter)
+  GhosttyWebGlRenderer — textured-quad pass beside the existing overlay pass;
+    blob cache keyed by image ref
+```
+
+Design rules:
+
+- **Observe, never interpret.** The worker never implements kitty semantics.
+  Deletes (`a=d`), chunked transmissions (`m=1`), ids, z-order, quiet flags —
+  all fall out of diffing ghostty's authoritative placement list before/after
+  the feed. The segmenter's only protocol knowledge is finding APC
+  boundaries. Layout synthesis likewise reproduces *observed* deltas (cursor,
+  scroll), not spec-predicted ones.
+- **Ids are server-assigned and monotonic** per session (the `AttachBlockData.ID`
+  precedent); kitty's client-chosen ids never reach the protocol.
+- **PNG support** = a Go `decode_png` host hook (`image/png` via cgo callback,
+  `GHOSTTY_SYS_OPT_DECODE_PNG`). Ghostty stores decoded pixels; the wire
+  ships ghostty's stored data (RGBA), deflated. If measured sizes make raw
+  pixels too heavy, shipping original encodings is the follow-up (requires
+  retaining originals keyed by image id — light APC key parse, noted, not v1).
+- **Blob transport** rides the existing WebSocket as a dedicated payload
+  (binary-frame or event — decided in A3 by measuring real emitter sizes).
+  The remote relay already carries WS traffic hub→client, so remotes work
+  without a new channel; a per-image size cap with a named, visible error is
+  part of A4's receipts. A daemon HTTP endpoint was considered and rejected:
+  no remote path exists for it, and one image is one WS message — the
+  256-message client buffer is a message-count limit, not a byte limit.
+
+## Replay and attach safety
+
+"Replay" today is not a buffer — raw replay was deleted with the
+server-authoritative restore. It is a dedup contract: an attach serves the
+snapshot plus `LastSeq`; the client applies live chunks with `seq > LastSeq`.
+The invariants that keep images from breaking it:
+
+1. **One rewrite point, upstream of sequencing.** The transform happens in the
+   read loop under `replayMu`, in the same critical section that feeds the
+   terminal and advances `lastReplaySeq`. The rewritten chunk keeps its seq.
+   Nothing downstream (fan-out, dedup, diagnostics of the wire) ever sees raw
+   kitty bytes, so nothing downstream changes.
+2. **The snapshot atomicity contract extends, not bends.** Every byte baked
+   into the dump has `seq <= LastSeq`; every chunk the client will apply has
+   `seq > LastSeq`. Placements join the atomic snapshot read under the same
+   lock, and placement/blob events carry the seq of the chunk that produced
+   them, so the client dedups them against `LastSeq` with the *same rule* as
+   bytes: seed from the snapshot, apply events with `seq > LastSeq`, drop the
+   rest. No hole, no double-apply.
+3. **Mid-APC attach is safe by construction.** A partial APC has no grid
+   effect until its terminator, so a snapshot taken mid-transmission serves
+   the pre-placement grid; the terminator's chunk (grid effect + synthesized
+   bytes + placement event, all in one critical section) necessarily carries
+   `seq > LastSeq` and lands on the restored client. Held wire bytes are
+   bounded (`APC_MAX_BYTES` option, plus segmenter abandon-on-oversize like
+   `osc133MaxPendingBytes`) and flushed through on abandon.
+4. **The VT dump stays image-free and consistent.** Ghostty's formatter emits
+   no image state, and the synthesized bytes reproduce exactly the cursor and
+   scroll the images caused — so a dump written into a fresh client model
+   agrees with a model that lived through the rewritten stream. That
+   equivalence is precisely what the parity corpus asserts.
+5. **The escape hatch is the existing restore.** If synthesis meets a case it
+   cannot represent (lost tracked ref, exotic scroll state), the worker
+   triggers a snapshot re-push instead of guessing. Worst case is a re-sync
+   the user doesn't notice, not a silent desync.
+
+## Verification
+
+The hard gate — **cross-runtime parity corpus**, precedent
+`testdata/osc133_segmenter_corpus.json`:
+
+- `internal/pty/testdata/kitty_rewrite_corpus.json`: each entry holds raw
+  input (captured real emitter output and synthetic cases: chunked `m=1`,
+  deletes, z-layers, images taller than the screen, scroll regions, alt
+  screen, interleaved resizes), and the Go side records the produced wire
+  bytes plus the native ghostty grid text and cursor.
+- The Go test asserts segmenter/synthesis behavior against the native grid;
+  the vitest side replays the recorded wire bytes into the real wasm model
+  and asserts its grid and cursor equal the recording. Grids agreeing across
+  both runtimes *is* the no-desync property. New synthesis code does not
+  merge without corpus coverage of what it synthesizes.
+
+Layers around the gate:
+
+- **Go unit**: segmenter split-at-every-byte-offset property tests (chunking
+  must never change output — the osc133 corpus pattern); synthesis goldens;
+  native-handle leak checks against the `ghosttyvt.LiveTrackedRefs` baseline
+  pattern.
+- **Fuzz** (Go): randomized interleavings of text, images, deletes, resizes,
+  scroll regions, alt-screen flips; any failure is minimized and committed as
+  a corpus entry, which the wasm side then replays too.
+- **Go integration**: a real PTY session end-to-end — placement/blob events
+  emitted with correct seqs, snapshot carries the quadruple atomically
+  (extend the existing `readLoopSeqGapHook` race tests to placements).
+- **Packaged harness**: new `real-app:scenario-terminal-image` — a
+  deterministic emitter script prints a known image; screenshot-verify pixels
+  (app-owned screenshots), then scroll, resize, detach/reattach restore, and
+  a `Cmd+T` focus sanity pass. Rebuild before evidence runs (baked
+  fingerprint).
+- **Live verification** (throwaway profile, never dev for daemon+protocol
+  changes): real emitters — chafa, timg, kitten icat, a matplotlib
+  kitty-backend script — locally and on a remote session via the OrbStack VM
+  (`attn-remote@orb`), plus the A1 negative check (tools stop detecting
+  image support while the feature is dark).
+
+## Phases
+
+### A1 — stop the lie (small PR, ships first)
+
+- [ ] Set the worker terminal's kitty image storage limit to 0
+      (`GHOSTTY_TERMINAL_OPT_KITTY_IMAGE_STORAGE_LIMIT`, plumbed through
+      `ghosttyvt.Options`).
+- [ ] Verify limit-0 silences the `a=q` OK reply; if ghostty still ACKs,
+      filter `_G` responses in the worker's response drain instead. Test:
+      no support reply reaches the program, no cursor movement from a
+      direct-RGB write — the probe scenario, kept this time.
+- [ ] Correct the AGENTS.md terminal section (images do not render today;
+      sixel does not exist in ghostty).
+- [ ] Changelog fragment.
+
+### A2 — worker: segmenter, observation, synthesis (feature dark)
+
+- [ ] `ghosttyvt`: expose the kitty C API — storage-limit/APC-max options, the
+      `decode_png` hook, placement iterator + `image_get`, on the same
+      darwin/linux cgo tuples; stubs degrade like every other ghostty use.
+- [ ] Kitty APC segmenter (wire side) + feed-path composition (kitty outer,
+      OSC 133 inner), under `replayMu`.
+- [ ] Placement-set diff + layout synthesis from observed deltas; forced
+      snapshot re-push fallback.
+- [ ] Parity corpus + fuzz + unit layers above. No protocol change; the wire
+      still carries nothing new (limit stays 0 until A4).
+
+### A3 — protocol + frontend rendering
+
+- [ ] Protocol: placement/blob events + snapshot placements
+      (`main.tsp` → `make generate-types` → `constants.go` ProtocolVersion →
+      `useDaemonSocket.ts` — all three lockstep spots).
+- [ ] Frontend: placement store with block-style anchoring/reanchor, blob
+      cache, textured-quad pass in `GhosttyWebGlRenderer`.
+- [ ] Blob transport decision with measured emitter sizes (the receipt for
+      the cap and for frame-vs-event).
+- [ ] Packaged harness scenario.
+
+### A4 — enable, restore, remote, receipts
+
+- [ ] Flip the storage limit on (measured number, named limit errors surfaced
+      through kitty's own response channel and the daemon log).
+- [ ] Restore path: snapshot placements seed the store after the dump write
+      (blocks precedent); live verification of detach/reattach and revive.
+- [ ] Remote-session verification via the OrbStack VM.
+- [ ] AGENTS.md: write the new truth; changelog fragment (user-visible).
+
+## Open questions
+
+- Alt-screen snapshot semantics: the dump serializes the active screen; do
+  snapshot placements carry a screen flag (blocks are primary-only, images
+  are not)? Decide in A3 with the restore work.
+- Animations (`a=a`): the diff would emit a blob update per frame — a wire
+  flood. V1 declares them out of scope; decide whether to coalesce or drop,
+  with an event-volume tripwire either way.
+- Unicode-placeholder (virtual) placements: rendered via placeholder cells,
+  not cursor placements. Likely excluded from v1 as a named limitation —
+  confirm what the diff exposes for them.
+- Does limit-0 actually silence `a=q`? A1's first verification step; the
+  response-drain filter is the fallback.

--- a/internal/ghosttyvt/ghosttyvt.go
+++ b/internal/ghosttyvt/ghosttyvt.go
@@ -49,6 +49,12 @@ static GhosttyResult ghosttyvt_install(GhosttyTerminal t, void* userdata) {
 	return ghostty_terminal_set(t, GHOSTTY_TERMINAL_OPT_WRITE_PTY, (const void*)goWritePty);
 }
 
+// Set the kitty image storage limit. ghostty_terminal_set reads the value
+// synchronously, so the caller's stack local need not outlive the call.
+static GhosttyResult ghosttyvt_set_kitty_limit(GhosttyTerminal t, uint64_t v) {
+	return ghostty_terminal_set(t, GHOSTTY_TERMINAL_OPT_KITTY_IMAGE_STORAGE_LIMIT, &v);
+}
+
 // Build formatter options: one self-contained VT (or plain) stream with all
 // "extra" state on and unwrap=false so soft-wrap survives the dump. NULL
 // selection = the entire screen including scrollback history.
@@ -164,6 +170,13 @@ const DefaultMaxScrollback = 10000
 type Options struct {
 	// MaxScrollback caps retained scrollback lines. Zero uses DefaultMaxScrollback.
 	MaxScrollback int
+
+	// KittyImageStorageLimit is the kitty graphics image storage cap in
+	// bytes, applied at construction. The zero value disables the kitty
+	// graphics protocol entirely — deliberate: the library's own default is
+	// 10MB, and a silently-live worker-side parser desyncs the grid from the
+	// client model, which never parses kitty.
+	KittyImageStorageLimit uint64
 }
 
 // Snapshot is a self-contained serialization of terminal state suitable for
@@ -224,6 +237,11 @@ func New(cols, rows int, opts Options) (*Terminal, error) {
 	}
 	if rc := C.ghostty_terminal_new(nil, &t.term, copts); rc != C.GHOSTTY_SUCCESS {
 		return nil, fmt.Errorf("ghosttyvt: terminal_new failed: rc=%d", int(rc))
+	}
+	// Written even when zero: zero is what overrides the library's 10MB default.
+	if rc := C.ghosttyvt_set_kitty_limit(t.term, C.uint64_t(opts.KittyImageStorageLimit)); rc != C.GHOSTTY_SUCCESS {
+		C.ghostty_terminal_free(t.term)
+		return nil, fmt.Errorf("ghosttyvt: set kitty image storage limit failed: rc=%d", int(rc))
 	}
 	// The handle references the sink (not t) so it does not pin the Terminal.
 	// C retains the userdata past this call, so give it the *address* of the

--- a/internal/ghosttyvt/kitty_test.go
+++ b/internal/ghosttyvt/kitty_test.go
@@ -1,0 +1,116 @@
+//go:build (darwin && arm64) || (linux && amd64) || (linux && arm64)
+
+package ghosttyvt
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// Kitty graphics probes. kittyQueryAPC is the support query feature-detecting
+// tools send (a=q); kittyTransmitAPC is the smallest write that both stores an
+// image and places it on the grid — 1x1 direct RGB, base64 of 0xFF,0x00,0x00.
+const (
+	kittyQueryAPC    = "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\"
+	kittyTransmitAPC = "\x1b_Ga=T,i=32,f=24,s=1,v=1;/wAA\x1b\\"
+	kittyRespPrefix  = "\x1b_G"
+)
+
+// newKittyT builds a terminal with the given kitty storage limit and resizes
+// it, which is what installs cell pixel metrics. Without them a placed image
+// spans zero cells and never moves the cursor — every grid assertion below
+// would hold no matter what the protocol did. Production terminals are always
+// resized, so this is the honest configuration.
+func newKittyT(t *testing.T, cols, rows int, limit uint64) *Terminal {
+	t.Helper()
+	term, err := New(cols, rows, Options{KittyImageStorageLimit: limit})
+	if err != nil {
+		t.Fatalf("New(%d,%d, limit=%d): %v", cols, rows, limit, err)
+	}
+	t.Cleanup(term.Close)
+	term.Resize(cols, rows)
+	return term
+}
+
+func TestKittyDisabledByDefaultSilencesSupportQuery(t *testing.T) {
+	term := newKittyT(t, 20, 4, 0)
+	term.DrainResponses()
+
+	term.Write([]byte(kittyQueryAPC))
+
+	if resp := term.DrainResponses(); bytes.Contains(resp, []byte(kittyRespPrefix)) {
+		t.Fatalf("kitty support query answered with the protocol disabled: %q", resp)
+	}
+}
+
+func TestKittyDisabledByDefaultPlacementHasNoGridEffect(t *testing.T) {
+	term := newKittyT(t, 20, 4, 0)
+	term.Write([]byte("before"))
+	term.DrainResponses()
+	wantX, wantY := term.CursorPos()
+	wantText := term.PlainText()
+
+	term.Write([]byte(kittyTransmitAPC))
+
+	if x, y := term.CursorPos(); x != wantX || y != wantY {
+		t.Fatalf("cursor moved from (%d,%d) to (%d,%d): the disabled protocol still placed an image", wantX, wantY, x, y)
+	}
+	if got := term.PlainText(); got != wantText {
+		t.Fatalf("grid text changed from %q to %q", wantText, got)
+	}
+	if resp := term.DrainResponses(); bytes.Contains(resp, []byte(kittyRespPrefix)) {
+		t.Fatalf("kitty transmit answered with the protocol disabled: %q", resp)
+	}
+}
+
+// The storage limit is documented as applying to "all initialized screens". A
+// lazily-created alternate screen coming up with the library's own default
+// would resurrect the protocol behind every full-screen TUI.
+func TestKittyDisabledOnAlternateScreen(t *testing.T) {
+	term := newKittyT(t, 20, 4, 0)
+	term.Write([]byte("\x1b[?1049h"))
+	term.Write([]byte("before"))
+	term.DrainResponses()
+	wantX, wantY := term.CursorPos()
+
+	term.Write([]byte(kittyTransmitAPC))
+
+	if x, y := term.CursorPos(); x != wantX || y != wantY {
+		t.Fatalf("alt-screen cursor moved from (%d,%d) to (%d,%d): kitty is live on the alternate screen", wantX, wantY, x, y)
+	}
+	if resp := term.DrainResponses(); bytes.Contains(resp, []byte(kittyRespPrefix)) {
+		t.Fatalf("alt-screen kitty transmit answered with the protocol disabled: %q", resp)
+	}
+}
+
+// A positive limit must leave the protocol fully functional: the value has to
+// reach the right option at the right width, or turning images on later is a
+// silent no-op. The placed 1x1 image occupies one cell and advances the cursor
+// past it — the grid effect the client model can never reproduce, which is why
+// the limit stays zero until the wire carries placements.
+func TestKittyPositiveLimitKeepsProtocolLive(t *testing.T) {
+	term := newKittyT(t, 20, 4, 10<<20)
+	term.DrainResponses()
+
+	term.Write([]byte(kittyQueryAPC))
+	if resp := string(term.DrainResponses()); !strings.Contains(resp, "\x1b_Gi=31;OK") {
+		t.Fatalf("support query response = %q, want an OK for image id 31", resp)
+	}
+
+	term.Write([]byte("before"))
+	beforeX, beforeY := term.CursorPos()
+	beforeText := term.PlainText()
+
+	term.Write([]byte(kittyTransmitAPC))
+
+	if resp := string(term.DrainResponses()); !strings.Contains(resp, "\x1b_Gi=32;OK") {
+		t.Fatalf("transmit response = %q, want an OK for image id 32", resp)
+	}
+	if x, y := term.CursorPos(); x != beforeX+1 || y != beforeY {
+		t.Fatalf("cursor = (%d,%d) after placing a one-cell image at (%d,%d), want (%d,%d)", x, y, beforeX, beforeY, beforeX+1, beforeY)
+	}
+	if got := term.PlainText(); got != beforeText {
+		t.Fatalf("grid text changed from %q to %q: the placement is pixels, not cells", beforeText, got)
+	}
+}

--- a/internal/ghosttyvt/stub.go
+++ b/internal/ghosttyvt/stub.go
@@ -14,6 +14,13 @@ const DefaultMaxScrollback = 10000
 // Options mirrors the real build's construction options.
 type Options struct {
 	MaxScrollback int
+
+	// KittyImageStorageLimit is the kitty graphics image storage cap in
+	// bytes, applied at construction. The zero value disables the kitty
+	// graphics protocol entirely — deliberate: the library's own default is
+	// 10MB, and a silently-live worker-side parser desyncs the grid from the
+	// client model, which never parses kitty.
+	KittyImageStorageLimit uint64
 }
 
 // Snapshot mirrors the real build's serialization result.


### PR DESCRIPTION
## What

Disable kitty graphics in the daemon worker's native ghostty terminal by setting the image storage limit to 0 at construction. New `ghosttyvt.Options.KittyImageStorageLimit` field; the zero value disables the protocol entirely (the C option's own semantics), so every existing `Options{}` call site inherits the fix with no change.

## Why

The worker's libghostty-vt build compiles kitty graphics in and the library defaults `kitty_image_storage_limit` to 10MB. attn never configured it, so the worker terminal falsely advertised kitty image support:

- `a=q` support queries were answered with `ESC _ G i=31;OK ST`, and the reply was forwarded to the program — feature-detecting tools (kitten icat, timg, chafa) saw support and emitted kitty escapes that displayed nothing.
- An accepted placement moved the cursor in the worker's authoritative grid but not in the client's wasm model, which never parses kitty (ghostty hard-disables it on wasm). The grids silently desynced, and a detach/reattach restore then served the diverged grid — visible corruption after running such a tool.

This is Phase A1 of [docs/plans/2026-08-02-terminal-kitty-images.md](https://github.com/victorarias/attn/blob/cranky-platypus/docs/plans/2026-08-02-terminal-kitty-images.md) (included in this PR), which adds real worker-authoritative image rendering in later phases and flips the limit back on.

## Tests

New `internal/ghosttyvt/kitty_test.go` against the real native library: the zero limit silences the support query and the transmit reply, a direct-RGB placement has no grid effect (cursor, text) on both the primary and the alternate screen, and a positive limit keeps the protocol fully live (OK replies + one-cell cursor advance) so later phases cannot regress into a silent no-op. Falsifiability was mutation-verified: reverting the option write makes each disabled-path test fail on its load-bearing assertion.

Note: grid assertions require a resized terminal — cell pixel metrics only arrive via `Resize`, and without them a placed image spans zero cells. The tests resize first (every production terminal is resized), which is also what proved the desync was live in production.

## Live verification

Dev profile, real shell sessions via the daemon worker PTY, before/after:

- Pre-fix daemon: probe received `$'\\E_Gi=31;OK\\E\\\\'` — the advertisement reached the program.
- This branch (`make install-daemon-dev`): probe reports SILENT.

https://claude.ai/code/session_01RW553W5Upx9sQh6gX69kgV