### PR TITLE
feat(ui): surface generated session names in the rail and the pane header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,23 +22,6 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   and exit code instead of waiting on the once-a-second foreground check. An
   ssh session to a host whose shell emits the marks reports its remote prompt
   and commands the same way. Set `ATTN_NO_SHELL_INTEGRATION=1` to opt out.
-- **Hover a sidebar row to read its whole session name.** Names generated from
-  your conversation are longer than the sidebar is wide, so rows still trim them.
-  Hovering one now unfurls the full name out of the sidebar's edge, on that row's
-  own line and clear of the rail — so the row's `•••` actions, which appear on
-  the same hover, stay visible and clickable. No dwell before it appears, and
-  nothing in the list moves. Rows whose name already fits are left alone.
-
-### Changed
-- **The agent pane header is always on, and always names the session.** It used
-  to appear only in a split view, or when a nudge, ticket, presentation, or
-  settle countdown needed somewhere to sit — so a single agent on screen showed
-  no name at all. It is now permanent, which also makes the chips it hosts
-  permanent. The name is set in sentence case rather than the small-caps heading
-  it used to be, and carries the same state dot the sidebar puts beside that
-  session, so the pane says what its agent is doing without a look back at the
-  rail. The rename control is reachable from it whether or not the view is split,
-  so a title you don't like can be fixed where you read it.
 
 ### Fixed
 - **Interrupting an agent settles its session right away.** Hitting ESC to halt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,23 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   and exit code instead of waiting on the once-a-second foreground check. An
   ssh session to a host whose shell emits the marks reports its remote prompt
   and commands the same way. Set `ATTN_NO_SHELL_INTEGRATION=1` to opt out.
+- **Hover a sidebar row to read its whole session name.** Names generated from
+  your conversation are longer than the sidebar is wide, so rows still trim them.
+  Hovering one now unfurls the full name out of the sidebar's edge, on that row's
+  own line and clear of the rail — so the row's `•••` actions, which appear on
+  the same hover, stay visible and clickable. No dwell before it appears, and
+  nothing in the list moves. Rows whose name already fits are left alone.
+
+### Changed
+- **The agent pane header is always on, and always names the session.** It used
+  to appear only in a split view, or when a nudge, ticket, presentation, or
+  settle countdown needed somewhere to sit — so a single agent on screen showed
+  no name at all. It is now permanent, which also makes the chips it hosts
+  permanent. The name is set in sentence case rather than the small-caps heading
+  it used to be, and carries the same state dot the sidebar puts beside that
+  session, so the pane says what its agent is doing without a look back at the
+  rail. The rename control is reachable from it whether or not the view is split,
+  so a title you don't like can be fixed where you read it.
 
 ### Fixed
 - **Interrupting an agent settles its session right away.** Hitting ESC to halt

--- a/app/e2e/terminal-interactions.spec.ts
+++ b/app/e2e/terminal-interactions.spec.ts
@@ -115,6 +115,31 @@ async function expectTerminalInputCount(
     .toBe(count);
 }
 
+/**
+ * The vertical centre of the grid's bottom row, in page coordinates.
+ *
+ * The rendered grid is `rows * cellHeight`, which almost never equals the
+ * container's height, so the container carries a leftover strip below the last
+ * row whose size shifts with anything that changes pane height — a permanent
+ * pane header, for one. Deriving the row from the canvas and the model's row
+ * count keeps a click on the last line a click on the last line.
+ */
+async function lastRowCenterY(
+  page: import('@playwright/test').Page,
+  terminal: import('@playwright/test').Locator,
+  sessionId: string,
+) {
+  const canvas = await terminal.locator('canvas').first().boundingBox();
+  expect(canvas).not.toBeNull();
+  const size = await page.evaluate(
+    (id) => window.__TEST_GET_SESSION_PANE_SIZE?.(id) ?? null,
+    sessionId,
+  );
+  expect(size).not.toBeNull();
+  const cellHeight = canvas!.height / size!.rows;
+  return canvas!.y + canvas!.height - cellHeight / 2;
+}
+
 async function openTerminalSession(
   page: import('@playwright/test').Page,
   daemon: { injectSession: (session: { id: string; label: string; state: string; directory?: string; workspace_id?: string }) => Promise<void> },
@@ -787,7 +812,12 @@ test.describe('Ghostty terminal interactions', () => {
 
     const terminalBounds = await terminal.boundingBox();
     expect(terminalBounds).not.toBeNull();
-    const rowY = terminalBounds!.y + terminalBounds!.height - 12;
+    // Aim at the middle of the grid's last row, measured off the canvas rather
+    // than off the container. A whole number of rows rarely fills the container
+    // exactly, so the leftover strip below the grid is dead space of a height
+    // nothing here controls — any fixed offset from the container's bottom edge
+    // is a bet on that leftover staying small.
+    const rowY = await lastRowCenterY(page, terminal, 's-selection-scroll');
     await page.mouse.move(terminalBounds!.x + 2, rowY);
     await page.mouse.down();
     await page.mouse.move(terminalBounds!.x + 220, rowY);

--- a/app/src/components/QueueBands.tsx
+++ b/app/src/components/QueueBands.tsx
@@ -1,5 +1,6 @@
 import { type MouseEvent as ReactMouseEvent } from 'react';
 import { StateIndicator } from './StateIndicator';
+import { SessionLabel } from './SessionLabel';
 import { ChiefOfStaffBadge } from './ChiefOfStaffBadge';
 import { SidebarSettlingBar } from './SettlingIndicator';
 import { formatShortcut } from '../shortcuts/formatShortcut';
@@ -116,7 +117,7 @@ function QueueRowView({
         controls) rather than reserving row width for buttons that are usually
         invisible.
       */}
-      <span className="session-label">{session.label}</span>
+      <SessionLabel label={session.label} />
       {session.chiefOfStaff && <ChiefOfStaffBadge />}
       {age && <span className="queue-row-age">{age}</span>}
       {wake && <span className="queue-row-wake-at">{wake}</span>}

--- a/app/src/components/SessionLabel.css
+++ b/app/src/components/SessionLabel.css
@@ -1,0 +1,91 @@
+/*
+  The hover reveal for a truncated session name. Typography, colour, and
+  position are set inline from the label it stands in for (see SessionLabel.tsx)
+  — everything here is the surface the text is painted on.
+
+  It is shaped as the hovered row breaking out of the rail: the left edge is
+  square and borderless so it welds to the sidebar's edge, and only the outer
+  three sides are rounded and lit. Sits below the sidebar's popovers and drag
+  ghost (z-index 1000), so a rename or actions popover opened over a row covers
+  the reveal, never the reverse.
+*/
+.session-label-reveal {
+  position: fixed;
+  z-index: 900;
+  /* Whatever sits beside the rail keeps its own hover and click. */
+  pointer-events: none;
+  width: max-content;
+  padding: 6px 14px 6px 10px;
+  border: 1px solid var(--color-border);
+  /* The seam back to the row it came from, in place of the border the other
+     three sides wear. */
+  border-left: 2px solid var(--accent);
+  border-radius: 0 8px 8px 0;
+  background-color: var(--color-bg-elevated);
+  background-image:
+    /* Brand tint bleeding out of the rail, matching .sidebar-header's own. */
+    linear-gradient(90deg, rgba(255, 107, 53, 0.13), rgba(255, 107, 53, 0) 84px),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+  box-shadow:
+    0 20px 44px rgba(0, 0, 0, 0.46),
+    0 2px 10px rgba(0, 0, 0, 0.32);
+  /* Undo the ellipsis recipe the label wears at rest. */
+  white-space: normal;
+  overflow-wrap: anywhere;
+  animation: session-label-unfurl 260ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* The name rides in behind its own surface — see the stagger note below. */
+.session-label-reveal-text {
+  display: block;
+  animation: session-label-reveal-text 220ms cubic-bezier(0.16, 1, 0.3, 1) 70ms backwards;
+}
+
+/*
+  The surface leaves the rail, then the name lands on it: two beats over ~290ms
+  rather than one instant appearance. A single fast wipe was the first cut and it
+  read as nothing happening at all — at 150ms across 340px there is no travel for
+  the eye to catch. The wipe now carries the panel bodily out of the rail (that
+  is the 12px of translate, which starts it overlapping the sidebar's edge and
+  slides it clear), and the text is held back 70ms so the arrival has an order to
+  it. Exit is deliberately instant: sweeping a list of rows must stay crisp.
+
+  The insets end negative, not at zero: clip-path clips to the border box, and
+  `inset(0)` would cut the shadow off entirely. Left stays at 0 throughout — that
+  edge is flush against the rail, where its shadow would not be seen anyway.
+
+  Harness note: WebKit pauses CSS animations while the window is in the
+  background, which strands both of these on their 0% frame — a mounted panel
+  that paints nothing. Screenshot the app focused, or a capture will show an
+  empty rail and read as a broken reveal.
+*/
+@keyframes session-label-unfurl {
+  from {
+    opacity: 0;
+    transform: translateX(-12px);
+    clip-path: inset(-60px 100% -60px 0);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+    clip-path: inset(-60px -80px -60px 0);
+  }
+}
+
+@keyframes session-label-reveal-text {
+  from {
+    opacity: 0;
+    transform: translateX(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .session-label-reveal,
+  .session-label-reveal-text {
+    animation: none;
+  }
+}

--- a/app/src/components/SessionLabel.reveal.test.tsx
+++ b/app/src/components/SessionLabel.reveal.test.tsx
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { SessionLabel } from './SessionLabel';
+
+/**
+ * The reveal exists because generated session names outrun the sidebar's width.
+ * What these tests pin is the part that is easy to regress by "simplifying":
+ * the trigger is the whole row, the panel only appears for names that were
+ * actually cut off, and it starts outside the rail so it cannot bury the row's
+ * hover-revealed actions.
+ */
+
+const LONG = 'judge yielded stops so background waits stay green';
+
+const RAIL_RIGHT = 240;
+const ACTIONS_RIGHT = 232;
+
+/** happy-dom reports 0 for every layout box, so the geometry has to be staged. */
+function stageRect(el: HTMLElement, rect: Partial<DOMRect>) {
+  el.getBoundingClientRect = () =>
+    ({ top: 0, left: 0, width: 0, height: 0, right: 0, bottom: 0, x: 0, y: 0, ...rect, toJSON: () => ({}) }) as DOMRect;
+}
+
+function renderRow(label: string, widths: { scrollWidth: number; clientWidth: number }) {
+  const utils = render(
+    <div className="sidebar" data-testid="rail">
+      <div className="session-item" data-testid="row">
+        <SessionLabel label={label} />
+        <div className="session-actions">
+          <button data-testid="actions">•••</button>
+        </div>
+      </div>
+    </div>,
+  );
+  const span = utils.container.querySelector('.session-label') as HTMLElement;
+  Object.defineProperty(span, 'scrollWidth', { value: widths.scrollWidth, configurable: true });
+  Object.defineProperty(span, 'clientWidth', { value: widths.clientWidth, configurable: true });
+  stageRect(span, { top: 40, left: 16, width: widths.clientWidth, height: 18, right: 16 + widths.clientWidth, bottom: 58 });
+  stageRect(screen.getByTestId('rail'), { top: 0, left: 0, width: RAIL_RIGHT, height: 800, right: RAIL_RIGHT, bottom: 800 });
+  stageRect(screen.getByTestId('actions'), { top: 42, left: 216, width: 16, height: 20, right: ACTIONS_RIGHT, bottom: 62 });
+  return { ...utils, row: screen.getByTestId('row'), span };
+}
+
+const panel = () => document.querySelector('[data-testid="session-label-reveal"]');
+
+describe('SessionLabel hover reveal', () => {
+  it('reveals the full name when the row — not just the label — is entered', () => {
+    const { row } = renderRow(LONG, { scrollWidth: 420, clientWidth: 180 });
+
+    expect(panel()).toBeNull();
+    // Entering through the row's vertical padding never touches the label span.
+    // Binding the trigger to the span would drop the reveal for that whole band,
+    // so the row is what must carry it.
+    fireEvent.pointerEnter(row);
+
+    expect(panel()?.textContent).toBe(LONG);
+  });
+
+  it('stays away for a name the row already shows in full', () => {
+    const { row } = renderRow('attn', { scrollWidth: 40, clientWidth: 180 });
+
+    fireEvent.pointerEnter(row);
+
+    expect(panel()).toBeNull();
+  });
+
+  it('withdraws on pointer leave', () => {
+    const { row } = renderRow(LONG, { scrollWidth: 420, clientWidth: 180 });
+    fireEvent.pointerEnter(row);
+    expect(panel()).not.toBeNull();
+
+    fireEvent.pointerLeave(row);
+
+    expect(panel()).toBeNull();
+  });
+
+  it('withdraws on pointer down, since a click can reorder the list under a still pointer', () => {
+    const { row } = renderRow(LONG, { scrollWidth: 420, clientWidth: 180 });
+    fireEvent.pointerEnter(row);
+    expect(panel()).not.toBeNull();
+
+    fireEvent.pointerDown(row);
+
+    expect(panel()).toBeNull();
+  });
+
+  it('withdraws when the sidebar scrolls, because the panel is positioned once', () => {
+    const { row } = renderRow(LONG, { scrollWidth: 420, clientWidth: 180 });
+    fireEvent.pointerEnter(row);
+    expect(panel()).not.toBeNull();
+
+    // Captured at the window, so a scroll on the inner scroller counts too.
+    fireEvent.scroll(row);
+
+    expect(panel()).toBeNull();
+  });
+
+  it('clears the row entirely, leaving the hover-revealed actions visible', () => {
+    // The `•••` button appears on the same hover that opens this panel, so a
+    // panel starting anywhere inside the rail would bury the actions for exactly
+    // as long as they are reachable.
+    const { row } = renderRow(LONG, { scrollWidth: 420, clientWidth: 180 });
+
+    fireEvent.pointerEnter(row);
+
+    expect(parseFloat((panel() as HTMLElement).style.left)).toBeGreaterThanOrEqual(ACTIONS_RIGHT);
+  });
+
+  it("starts at the rail edge on the row's own baseline", () => {
+    const { row } = renderRow(LONG, { scrollWidth: 420, clientWidth: 180 });
+
+    fireEvent.pointerEnter(row);
+
+    const style = (panel() as HTMLElement).style;
+    // Flush against the sidebar, so the panel reads as this row continuing out
+    // of it. Anchored to the rail rather than the row, whose right edge shifts
+    // with nesting depth and would make the panel jitter down the list.
+    expect(style.left).toBe(`${RAIL_RIGHT}px`);
+    // Lifted by the panel's own vertical padding so the revealed glyphs sit on
+    // the same line as the truncated ones.
+    expect(style.top).toBe('34px');
+  });
+
+  it('leaves the clipped label in place as the accessible copy', () => {
+    const { row, span } = renderRow(LONG, { scrollWidth: 420, clientWidth: 180 });
+    fireEvent.pointerEnter(row);
+
+    expect(span.textContent).toBe(LONG);
+    expect(panel()).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/app/src/components/SessionLabel.tsx
+++ b/app/src/components/SessionLabel.tsx
@@ -1,0 +1,175 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import './SessionLabel.css';
+
+/**
+ * A session name that unfurls out of the sidebar while its row is hovered.
+ *
+ * Session names are generated from the conversation and run up to 48 characters,
+ * which no sidebar width fits, so the resting row ellipsizes. Hovering the row
+ * slides the full name out past the rail's edge on its own line, sharing the
+ * row's baseline so it reads as that row continuing into the space beside it.
+ * There is no dwell delay and nothing in the list moves.
+ *
+ * The panel begins at the rail's right edge and never re-enters it. That is the
+ * load-bearing constraint, not a stylistic one: a row's `•••` actions live at
+ * its right end and are themselves hover-revealed, so anything drawn over the
+ * row's own width would black out the actions at precisely the moment they
+ * appear. Anchoring to the rail — rather than to each row's right edge, which
+ * varies with nesting — also keeps the panel's left edge on one vertical line as
+ * the pointer sweeps down the list.
+ *
+ * Two more details make it hold together:
+ *
+ * - The panel is a `document.body` portal. The sidebar's scroll container clips
+ *   overflow, so an in-flow element could not cross the rail's edge at all.
+ * - It copies the label's own computed typography and colour. Portaling escapes
+ *   inheritance, and anything but an exact copy would set the revealed name in a
+ *   different face from the row it belongs to.
+ *
+ * Hover binds to the enclosing `.session-item` row, not to this span. The span
+ * only covers the row's text line, so binding it here would drop the reveal
+ * whenever the pointer crossed in through the row's vertical padding.
+ * `.session-item` is the shared row class behind every call site (workspace tree
+ * rows, muted rows, and agent-queue band rows).
+ */
+
+/** Vertical padding, mirrored as a negative offset so the text keeps the row's baseline. */
+const PAD_Y = 6;
+/** Past this the panel stops being a name and starts being a paragraph. */
+const MAX_PANEL_WIDTH = 460;
+/** Breathing room kept between the panel and the viewport edges. */
+const VIEWPORT_MARGIN = 12;
+
+type RevealStyle = {
+  top: number;
+  left: number;
+  maxWidth: number;
+  fontFamily: string;
+  fontSize: string;
+  fontWeight: string;
+  fontStyle: string;
+  lineHeight: string;
+  letterSpacing: string;
+  color: string;
+};
+
+export function SessionLabel({ label }: { label: string }) {
+  const spanRef = useRef<HTMLSpanElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const [reveal, setReveal] = useState<RevealStyle | null>(null);
+
+  const hide = useCallback(() => setReveal(null), []);
+
+  const show = useCallback(() => {
+    const span = spanRef.current;
+    if (!span) {
+      return;
+    }
+    // Only worth revealing what the row actually cut off. The extra pixel
+    // absorbs sub-pixel rounding on fractional layout widths.
+    if (span.scrollWidth <= span.clientWidth + 1) {
+      return;
+    }
+    const rect = span.getBoundingClientRect();
+    const style = window.getComputedStyle(span);
+    // The rail's edge, or the row's own if this label is used outside one.
+    const rail = span.closest('.sidebar') ?? span.closest('.session-item') ?? span;
+    const left = rail.getBoundingClientRect().right;
+    setReveal({
+      top: rect.top - PAD_Y,
+      left,
+      maxWidth: Math.min(window.innerWidth - left - VIEWPORT_MARGIN, MAX_PANEL_WIDTH),
+      fontFamily: style.fontFamily,
+      fontSize: style.fontSize,
+      fontWeight: style.fontWeight,
+      fontStyle: style.fontStyle,
+      lineHeight: style.lineHeight,
+      letterSpacing: style.letterSpacing,
+      color: style.color,
+    });
+  }, []);
+
+  useEffect(() => {
+    const span = spanRef.current;
+    if (!span) {
+      return;
+    }
+    const row = span.closest('.session-item') ?? span;
+    row.addEventListener('pointerenter', show);
+    row.addEventListener('pointerleave', hide);
+    // A click can reorder or replace the list under a pointer that never moves,
+    // which would leave the panel painted over a row it no longer describes.
+    row.addEventListener('pointerdown', hide);
+    return () => {
+      row.removeEventListener('pointerenter', show);
+      row.removeEventListener('pointerleave', hide);
+      row.removeEventListener('pointerdown', hide);
+    };
+  }, [show, hide]);
+
+  useEffect(() => {
+    if (!reveal) {
+      return;
+    }
+    // Fixed positioning is measured once, so any viewport change invalidates it.
+    // Capture the scroll so the sidebar's own scroller counts, not just window.
+    window.addEventListener('scroll', hide, true);
+    window.addEventListener('resize', hide);
+    return () => {
+      window.removeEventListener('scroll', hide, true);
+      window.removeEventListener('resize', hide);
+    };
+  }, [reveal, hide]);
+
+  useLayoutEffect(() => {
+    const panel = panelRef.current;
+    if (!panel || !reveal) {
+      return;
+    }
+    // A wrapped name on one of the last rows would run off the bottom; lift it
+    // just enough to fit rather than flipping it above the row, which would
+    // break the "it is this row, continued" premise.
+    const rect = panel.getBoundingClientRect();
+    const overflow = rect.bottom - (window.innerHeight - VIEWPORT_MARGIN);
+    if (overflow > 0) {
+      panel.style.top = `${Math.max(VIEWPORT_MARGIN, rect.top - overflow)}px`;
+    }
+  }, [reveal]);
+
+  return (
+    <>
+      <span className="session-label" ref={spanRef}>{label}</span>
+      {reveal
+        ? createPortal(
+            <div
+              ref={panelRef}
+              className="session-label-reveal"
+              data-testid="session-label-reveal"
+              // The clipped span still carries the full name in the accessibility
+              // tree, so this is decoration. It is also pointer-transparent: the
+              // content beside the rail must stay clickable through it.
+              aria-hidden="true"
+              style={{
+                top: reveal.top,
+                left: reveal.left,
+                maxWidth: reveal.maxWidth,
+                fontFamily: reveal.fontFamily,
+                fontSize: reveal.fontSize,
+                fontWeight: reveal.fontWeight,
+                fontStyle: reveal.fontStyle,
+                lineHeight: reveal.lineHeight,
+                letterSpacing: reveal.letterSpacing,
+                color: reveal.color,
+              }}
+            >
+              {/* Its own element so the name can arrive a beat after the surface
+                  it lands on; the panel cannot stagger against itself. */}
+              <span className="session-label-reveal-text">{label}</span>
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}

--- a/app/src/components/SessionTerminalWorkspace.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace.test.tsx
@@ -139,6 +139,10 @@ vi.mock('./GhosttyTerminal', () => ({
   }),
 }));
 
+// Shortcuts are recorded rather than dispatched, so a test can invoke one by
+// id. Both entry points carry it — the barrel for modules that import it, and
+// the direct path the workspace itself uses. The bodies are duplicated because
+// vi.mock factories are hoisted above any shared helper.
 vi.mock('../shortcuts', () => ({
   useShortcut: vi.fn((id: string, handler: () => void, enabled?: boolean) => {
     if (enabled) {
@@ -150,6 +154,13 @@ vi.mock('../shortcuts', () => ({
 }));
 
 vi.mock('../shortcuts/useShortcut', () => ({
+  useShortcut: vi.fn((id: string, handler: () => void, enabled?: boolean) => {
+    if (enabled) {
+      registeredShortcuts.set(id, handler);
+      return;
+    }
+    registeredShortcuts.delete(id);
+  }),
   triggerShortcut: vi.fn(() => false),
 }));
 

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
@@ -295,19 +295,28 @@
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  min-height: 28px;
+  min-height: 30px;
   padding: 4px 8px;
   border-bottom: 1px solid var(--color-border);
-  background: rgba(255, 107, 53, 0.06);
+  /* Lit from the top like a title bar rather than flooded with a flat tint: the
+     header is permanent now and names the session, so it reads as the pane's
+     own chrome instead of a highlight laid over the terminal. */
+  background:
+    linear-gradient(180deg, rgba(255, 107, 53, 0.11), rgba(255, 107, 53, 0.03)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
-/* Shown on a lone tile only to host the incoming-nudge chip — not a drag handle. */
-.workspace-pane-header--nudge {
+/* The header's dot is a label for the name beside it, not a control — keep it
+   from stretching in the header's flex row. */
+.workspace-pane-header .state-indicator {
+  flex-shrink: 0;
+}
+
+/* A lone tile's header: a status bar naming the session and hosting its chips,
+   with nowhere to be dragged to. */
+.workspace-pane-header--static {
   cursor: default;
-}
-
-.workspace-pane-header-hidden {
-  display: none;
 }
 
 /* The header doubles as the drag-to-move handle when the workspace has more than
@@ -326,14 +335,21 @@
   opacity: 0.5;
 }
 
+/* Set in sentence case, not the small-caps heading this used to be: the title is
+   now a generated sentence of up to 48 characters describing what the agent is
+   working on, and caps would both shout it and cost roughly a word of width
+   before the ellipsis.
+
+   Set at the primary text colour and one step up in size: this is the pane's
+   headline, and inactive panes are already dimmed wholesale by
+   `.workspace-pane`'s opacity, so the title does not need to whisper to show
+   which leaf is unfocused. */
 .workspace-pane-title {
   flex: 1;
   min-width: 0;
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-xs);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
   font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.paneHeader.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.paneHeader.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { SessionTerminalWorkspace } from './index';
+import { createPaneRuntimeEventRouterController } from './paneRuntimeEventRouter';
+import type { TerminalWorkspaceState } from '../../types/workspace';
+
+// The terminal surface pulls in the Ghostty WASM model; stub it so the import
+// graph stays light (this spec only cares about the pane header).
+vi.mock('../GhosttyTerminal', async () => {
+  const React = await import('react');
+  return {
+    GhosttyTerminal: React.forwardRef(function MockTerminal() {
+      return null;
+    }),
+  };
+});
+
+/**
+ * The pane header used to be conditional — a split-view drag handle that a
+ * nudge, ticket, presentation, or settle countdown could also summon onto a lone
+ * tile. It is unconditional now, because it carries the session's generated
+ * name, and which agent you are looking at is not a detail to hide behind a
+ * split.
+ */
+
+const GENERATED_NAME = 'judge yielded stops so background waits stay green';
+
+function loneAgentWorkspace(): TerminalWorkspaceState {
+  return {
+    agents: [{ id: 'pane-1', runtimeId: 'rt-1', sessionId: 'sess-1', title: 'shell' }],
+    layoutTree: { type: 'pane', paneId: 'pane-1' },
+  };
+}
+
+function renderLonePane(props: Partial<React.ComponentProps<typeof SessionTerminalWorkspace>> = {}) {
+  return render(
+    <SessionTerminalWorkspace
+      workspaceId="workspace-1"
+      workspaceSessions={[{ id: 'sess-1', label: GENERATED_NAME, agent: 'claude', cwd: '/tmp/project' }]}
+      workspace={loneAgentWorkspace()}
+      activePaneId="pane-1"
+      fontSize={13}
+      enabled
+      isActiveSession
+      eventRouter={createPaneRuntimeEventRouterController()}
+      onSplitPane={vi.fn()}
+      onClosePane={vi.fn()}
+      onFocusPane={vi.fn()}
+      onNavigateOutOfSession={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+describe('SessionTerminalWorkspace pane header', () => {
+  it('names the session on a lone tile with nothing else to show', () => {
+    const { container } = renderLonePane();
+
+    expect(container.querySelector('.workspace-pane-title')?.textContent).toBe(GENERATED_NAME);
+  });
+
+  it('is not a drag handle on a lone tile, which has nowhere to move to', () => {
+    const { container } = renderLonePane();
+
+    const header = container.querySelector('.workspace-pane-header') as HTMLElement;
+    expect(header.className).toContain('workspace-pane-header--static');
+    expect(header.className).not.toContain('workspace-pane-header--draggable');
+    expect(header).not.toHaveAttribute('title');
+  });
+
+  it('offers rename on a lone tile, where a wrong generated name is most visible', () => {
+    // The name is generated, so the place it is shown is exactly the place a bad
+    // one needs correcting — previously this button was split-view only.
+    const onRenameSession = vi.fn();
+    renderLonePane({ onRenameSession });
+
+    const rename = screen.getByTestId('rename-pane-pane-1');
+    fireEvent.click(rename);
+
+    expect(screen.getByDisplayValue(GENERATED_NAME)).toBeInTheDocument();
+  });
+
+  it("shows the session's state beside its name, as the sidebar row does", () => {
+    const { container } = renderLonePane({
+      workspaceSessions: [{ id: 'sess-1', label: GENERATED_NAME, agent: 'claude', cwd: '/tmp/project', state: 'working' }],
+    });
+
+    const dot = container.querySelector('.workspace-pane-header .state-indicator');
+    expect(dot?.className).toContain('state-indicator--working');
+  });
+
+  it('falls back to the pane title when the session carries no label', () => {
+    const { container } = renderLonePane({ workspaceSessions: [] });
+
+    expect(container.querySelector('.workspace-pane-title')?.textContent).toBe('shell');
+  });
+});

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.presentationChip.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.presentationChip.test.tsx
@@ -39,11 +39,10 @@ function makePresentation(overrides: Partial<Presentation> = {}): Presentation {
 }
 
 describe('SessionTerminalWorkspace presentation chip', () => {
-  // A lone (unsplit) pane normally hides its header entirely (it's not a
-  // drag handle when there's nothing to drag against). A session with an
-  // open, unsubmitted presentation must still get its header rectangle to
-  // host the chip, same as the nudge indicator does.
-  it('forces the header visible and renders the chip when the pane session has a presentation', () => {
+  // The header is always present now (see SessionTerminalWorkspace.paneHeader
+  // .test.tsx); what this spec owns is that an open, unsubmitted presentation
+  // puts its chip inside it, on a lone pane as much as a split one.
+  it('renders the chip in the header when the pane session has a presentation', () => {
     const onOpenPresentation = vi.fn();
     render(
       <SessionTerminalWorkspace
@@ -78,7 +77,7 @@ describe('SessionTerminalWorkspace presentation chip', () => {
     expect(onOpenPresentation).toHaveBeenCalledWith('pres-1');
   });
 
-  it('hides the header when the pane session has no presentation and no nudge', () => {
+  it('keeps the header and its session name on a lone tile with no presentation and no nudge', () => {
     render(
       <SessionTerminalWorkspace
         workspaceId="workspace-1"
@@ -96,8 +95,11 @@ describe('SessionTerminalWorkspace presentation chip', () => {
       />,
     );
 
+    // The header is unconditional now: it names the session even with no chip
+    // to host. On a lone tile it is the non-draggable variant.
     const header = document.querySelector('.workspace-pane-header');
-    expect(header?.className).toContain('workspace-pane-header-hidden');
+    expect(header?.className).toContain('workspace-pane-header--static');
+    expect(document.querySelector('.workspace-pane-title')?.textContent).toBe('shell');
     expect(screen.queryByRole('button', { name: /review/i })).not.toBeInTheDocument();
   });
 });

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.ticketOverlay.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.ticketOverlay.test.tsx
@@ -114,20 +114,17 @@ describe('SessionTerminalWorkspace ticket overlay', () => {
     focusState.count = 0;
   });
 
-  it('renders the chip and an ambient header for a session with a bound ticket', () => {
+  it('renders the chip in the header for a session with a bound ticket', () => {
     const { container } = renderWorkspace({ ticket: makeTicket() });
-    // Single-pane workspace: the header is normally hidden, but a bound ticket
-    // makes it ambient.
     expect(container.querySelector('.workspace-pane-header')).not.toBeNull();
-    expect(container.querySelector('.workspace-pane-header-hidden')).toBeNull();
     expect(container.querySelector('[data-testid="ticket-chip-sess-1"]')).not.toBeNull();
   });
 
-  it('does not render the chip for a session without a bound ticket', () => {
+  it('keeps the header without a chip for a session with no bound ticket', () => {
     const { container } = renderWorkspace({ ticket: undefined });
     expect(container.querySelector('[data-testid="ticket-chip-sess-1"]')).toBeNull();
-    // Header stays hidden with nothing ambient to show.
-    expect(container.querySelector('.workspace-pane-header-hidden')).not.toBeNull();
+    // The header survives the chip: it still names the session.
+    expect(container.querySelector('.workspace-pane-header')).not.toBeNull();
   });
 
   it('opens the overlay on chip click and fetches the ticket once', async () => {

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { GhosttyTerminal, type BlockStateSnapshot, type GhosttyTerminalHandle } from '../GhosttyTerminal';
 import { RenamePopover } from '../RenamePopover';
+import { StateIndicator } from '../StateIndicator';
 import { useShortcut } from '../../shortcuts';
 import {
   getNormalizedPaneBounds,
@@ -886,23 +887,17 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
           : null;
         const paneTicket = paneSession?.ticket;
         const ticketOverlayOpen = ticketOverlayPaneId === agentPane.id;
-        // The pane header is the home for the nudge indicator, the presentation
-        // chip, and the bound-ticket chip. It is normally shown only when the
-        // workspace is split; surface it on a lone tile too whenever the session
-        // has any of these to show, so they have their rectangle — a bound ticket
-        // makes the header ambient (always there) so steering is one click. Drag/
-        // rename stay split-only — a nudge/presentation/ticket-only header is a
-        // status bar, not a move handle.
-        // A running auto-settle countdown surfaces the header on a lone tile the
-        // same way a nudge does: the countdown needs its rectangle, and a turn
-        // about to be closed for you is exactly the thing that must not be
-        // invisible.
+        // The pane header is always on for an agent pane. It carries the
+        // session's name — generated from the conversation, so it says what this
+        // agent is actually doing — alongside the presentation chip, the
+        // auto-settle countdown, the nudge indicator, and the bound-ticket chip.
+        // Which agent you are looking at is not something to hide behind a split,
+        // and the chips it hosts (a turn about to be closed for you, an unread
+        // ticket) are exactly the things that must never be invisible.
+        //
+        // Only dragging stays split-only: a lone tile has nowhere to move to, so
+        // it gets the non-draggable variant.
         const autoSettleFiresAt = paneSession?.autoSettleFiresAt;
-        const headerVisible = showPaneHeader
-          || nudgeMode != null
-          || paneSession?.presentation != null
-          || paneTicket != null
-          || autoSettleFiresAt != null;
         return (
           <div
             key={agentPane.id}
@@ -916,18 +911,25 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
           >
             <div
               className={`workspace-pane-header ${
-                headerVisible
-                  ? showPaneHeader
-                    ? 'workspace-pane-header--draggable'
-                    : 'workspace-pane-header--nudge'
-                  : 'workspace-pane-header-hidden'
+                showPaneHeader
+                  ? 'workspace-pane-header--draggable'
+                  : 'workspace-pane-header--static'
               }`.trim()}
-              aria-hidden={headerVisible ? undefined : true}
               onPointerDown={showPaneHeader ? (event) => beginLeafDrag(agentPane.id, event) : undefined}
               title={showPaneHeader ? 'Drag to move' : undefined}
             >
-              {headerVisible ? <span className="workspace-pane-title">{paneTitle}</span> : null}
-              {showPaneHeader && onRenameSession ? (
+              {/* The same dot the sidebar puts beside this session, so the header
+                  reads as that row's counterpart rather than a second, unrelated
+                  naming of the pane. */}
+              {paneSession?.state ? (
+                <StateIndicator
+                  state={paneSession.state}
+                  size="sm"
+                  seed={agentPane.sessionId}
+                />
+              ) : null}
+              <span className="workspace-pane-title">{paneTitle}</span>
+              {onRenameSession ? (
                 <button
                   type="button"
                   className="workspace-pane-rename-btn"

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -2,7 +2,7 @@ import { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffec
 import { GhosttyTerminal, type BlockStateSnapshot, type GhosttyTerminalHandle } from '../GhosttyTerminal';
 import { RenamePopover } from '../RenamePopover';
 import { StateIndicator } from '../StateIndicator';
-import { useShortcut } from '../../shortcuts';
+import { useShortcut } from '../../shortcuts/useShortcut';
 import {
   getNormalizedPaneBounds,
   getSplitDividers,

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import { SessionActionsPopover } from './SessionActionsPopover';
 import { GridLayoutControl } from './grid/GridLayoutControl';
 import type { GridLayout } from './grid/gridLayout';
 import { StateIndicator } from './StateIndicator';
+import { SessionLabel } from './SessionLabel';
 import { QueueBands, QueueSnoozedSection } from './QueueBands';
 import { SidebarNudgeBar, deriveNudgeMode } from './NudgeIndicator';
 import { SidebarSettlingBar } from './SettlingIndicator';
@@ -1151,7 +1152,7 @@ export function Sidebar({
                     title={session.state === 'recoverable' ? 'Session will be recovered when opened' : undefined}
                   >
                     <StateIndicator state={session.state} size="md" seed={session.id} reason={session.state_reason} />
-                    <span className="session-label">{session.label}</span>
+                    <SessionLabel label={session.label} />
                     {session.endpointName && (
                       <span className={`session-endpoint-badge status-${session.endpointStatus || 'connected'}`}>
                         {session.endpointName}
@@ -1332,7 +1333,7 @@ export function Sidebar({
                           onClick={() => onSelectSession(session.id)}
                         >
                           <StateIndicator state={session.state} size="md" seed={session.id} reason={session.state_reason} />
-                          <span className="session-label">{session.label}</span>
+                          <SessionLabel label={session.label} />
                           {session.chiefOfStaff && <ChiefOfStaffBadge />}
                           {session.delegatedFromChief && <DelegatedFromChiefBadge />}
                           {session.endpointName && (

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -1793,6 +1793,46 @@ export function useUiAutomationBridge({
         }
         return { focused: true, tag: element.tagName };
       }
+      case 'dom_hover': {
+        // Pointer-over without a click, for affordances that only exist while
+        // hovered — the sidebar's session-name reveal, hover-revealed row
+        // controls. Victor's rule is no CGEvent HID takeover, so this is the
+        // synthetic-DOM equivalent.
+        //
+        // Both the pointer and mouse families are dispatched because handlers in
+        // this app come from either (React's onMouseEnter and native
+        // pointerenter listeners both appear). enter/leave do not bubble by
+        // spec, so this fires them on the element itself: the selector has to
+        // name the element that actually listens, not an ancestor.
+        const selector = typeof payload.selector === 'string' ? payload.selector : null;
+        if (!selector) throw new Error('dom_hover requires selector');
+        const leave = payload.leave === true;
+        const element = document.querySelector(selector);
+        if (!(element instanceof HTMLElement)) {
+          throw new Error(`dom_hover selector not found in DOM: ${selector}`);
+        }
+        const rect = element.getBoundingClientRect();
+        const init: PointerEventInit = {
+          bubbles: false,
+          cancelable: true,
+          composed: true,
+          pointerId: 1,
+          pointerType: 'mouse',
+          clientX: rect.left + rect.width / 2,
+          clientY: rect.top + rect.height / 2,
+        };
+        if (leave) {
+          element.dispatchEvent(new PointerEvent('pointerleave', init));
+          element.dispatchEvent(new MouseEvent('mouseleave', init));
+          element.dispatchEvent(new PointerEvent('pointerout', { ...init, bubbles: true }));
+        } else {
+          element.dispatchEvent(new PointerEvent('pointerover', { ...init, bubbles: true }));
+          element.dispatchEvent(new PointerEvent('pointerenter', init));
+          element.dispatchEvent(new MouseEvent('mouseenter', init));
+        }
+        await settleUi(2);
+        return { hovered: !leave, bounds: rectSnapshot(element) };
+      }
       case 'dom_type': {
         const selector = typeof payload.selector === 'string' ? payload.selector : null;
         const text = typeof payload.text === 'string' ? payload.text : null;

--- a/changelog.d/jaunty-pangolin-pane-header-always-on.yaml
+++ b/changelog.d/jaunty-pangolin-pane-header-always-on.yaml
@@ -1,0 +1,11 @@
+kind: changed
+area: workspace
+change: >
+  The agent pane header is now always shown and always carries the session's
+  name. It used to appear only in a split view, or when a nudge, ticket,
+  presentation, or auto-settle countdown needed somewhere to sit, so a single
+  agent on screen showed no name at all — and those chips came and went with the
+  header. The name is set in sentence case instead of the previous small-caps
+  heading and sits beside the same state dot the sidebar shows for that session.
+  Rename is reachable from the header whether or not the view is split; only
+  drag-to-move stays split-only, since a lone tile has nowhere to move to.

--- a/changelog.d/jaunty-pangolin-session-name-reveal.yaml
+++ b/changelog.d/jaunty-pangolin-session-name-reveal.yaml
@@ -1,0 +1,14 @@
+kind: added
+area: sidebar
+change: >
+  Hovering a sidebar row whose session name is truncated reveals the full name
+  immediately, with no dwell delay. The panel starts at the sidebar's right edge
+  on that row's own baseline and runs outward into the pane area, wrapping if
+  needed; it never covers the row itself, so the row's ••• actions — revealed by
+  the same hover — stay visible and clickable. Rows whose name already fits are
+  left alone, and nothing in the list moves. It appears with a short two-beat
+  entrance (surface, then name) that is dropped under prefers-reduced-motion.
+notes: >
+  Session names are generated from the conversation, so they are routinely
+  wider than the rail; the reveal is what makes them readable without a rename.
+  Covers the sidebar rows and the queue bands, which share one row renderer.


### PR DESCRIPTION
Session names are generated from the conversation and run up to 48 characters
(`maxSessionTitleRunes`), which the sidebar has never been wide enough to show.
Both places that name a session hid it instead: rows ellipsized with no way to
read the rest, and the pane header — the one spot with room — was hidden unless
the view was split.

## Sidebar reveal

Hovering a row unfurls the full name out of the rail's right edge, on that row's
own baseline, over ~290ms in two beats: the surface slides clear of the rail,
then the name lands on it 70ms later. No dwell delay, no list reflow, and rows
whose name already fits never open a panel. Exit is instant so sweeping the list
stays crisp.

The panel starts at the rail's edge and never re-enters it. That is load-bearing
rather than stylistic: a row's `•••` actions sit at its right end and are
themselves hover-revealed, so a panel drawn across the row's own width buries the
actions for exactly as long as they are reachable. Measured on a running app, the
actions button occupies x=183–207 and the panel now starts at x=240.
`SessionLabel.reveal.test.tsx` pins `panel.left >= actions.right` so it cannot
regress back over them. Anchoring to the rail rather than to each row's right
edge — which shifts with nesting depth — also keeps the panel's left edge on one
vertical line as the pointer sweeps down the list.

Three implementation details are load-bearing and commented as such: the panel is
a `document.body` portal (the sidebar's scroll container clips overflow, so an
in-flow element cannot cross the rail's edge); it copies the label's computed
typography and colour (portaling escapes inheritance); and hover binds to the
enclosing `.session-item`, not to the label span, which covers only the row's
text line and would drop the reveal when the pointer entered through the row's
vertical padding. `.session-item` is the shared class behind all three row types
— workspace tree rows, muted rows, and agent-queue band rows, including the
snoozed section — so one component covers every caller.

## Pane header

The header used to appear only in a split view, or when a nudge, ticket,
presentation, or settle countdown needed somewhere to sit, so a single agent on
screen carried no name at all. It is unconditional now, which also makes the
chips it hosts permanent. The title is set in sentence case at the primary text
colour one size up rather than as a small-caps heading — the title is a generated
sentence now, and caps both shout it and cost roughly a word of width before the
ellipsis. It carries the same state dot the sidebar puts beside that session, so
a pane says what its agent is doing without a look back at the rail. Rename is
reachable from the header whether or not the view is split, since the header is
where a bad generated name gets read.

Inactive panes are already dimmed wholesale by `.workspace-pane`'s opacity, so
promoting the title colour does not cost the active/inactive contrast.

## Automation

Adds a `dom_hover` verb to the UI automation bridge for hover-only affordances —
synthetic pointer and mouse events, not CGEvent input. `enter`/`leave` do not
bubble, so it fires them on the element itself: the selector has to name the
element that listens.

## Verification

Live-verified from this branch's head on an isolated `namereveal` profile
(`make install PROFILE=namereveal`, preflight PASS, protocol 200). Confirmed the
reveal renders clear of the rail with the panel measured at x=240 w=341 while the
actions button sits at x=183–207, and the header names the session with its state
dot on a lone tile.

One gotcha worth knowing, recorded in `SessionLabel.css`: WebKit pauses CSS
animations while the window is in the background, which strands the entrance on
its 0% frame — a mounted panel that paints nothing. A harness screenshot of an
unfocused app will show an empty rail and read as a broken reveal. Screenshot the
app focused.

`tsc --noEmit` clean; full frontend suite green (199 files, 2192 tests) on the
rebased head. New tests: 8 for the reveal, 5 for the pane header; two pre-existing
specs that asserted the old hide-the-header rule were rewritten to the new
contract.

https://claude.ai/code/session_018EQ65A22PfJiMY4AMxdbSi
