### PR TITLE
fix(profiles): reap pty-workers before a profile's data dir is removed

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/scripts/claude/attn-profile-nudge.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
               - 'go.sum'
               - 'Makefile'
               - 'scripts/source-fingerprint.sh'
+              - 'scripts/claude/**'
               - '.github/workflows/ci.yml'
             frontend:
               - 'app/src/**'
@@ -96,6 +97,10 @@ jobs:
 
       - name: Test
         run: ./scripts/test-go.sh
+
+      # Repository Claude Code hooks are shell, so the Go suite cannot see them.
+      - name: Test repository hooks
+        run: bash ./scripts/claude/attn-profile-nudge_test.sh
 
   frontend:
     name: Frontend

--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,12 @@ app/src-tauri/binaries/
 app/src-tauri/bundled-plugins/*
 !app/src-tauri/bundled-plugins/.gitkeep
 
-# Claude Code local config
-.claude/
+# Claude Code local config. settings.json is the shared, checked-in part (repo
+# hooks); everything else here is per-machine. The pattern must exclude the
+# directory's contents rather than the directory itself — git cannot re-include a
+# file whose parent directory is excluded.
+.claude/*
+!.claude/settings.json
 
 # Generated per-profile Tauri config overlays (see scripts/build-app-profile.sh)
 app/src-tauri/*.gen.conf.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,13 @@ permissions.
   `[attn profile=…]` banner before acting.
 - Inspect with `attn profile`, `attn profile list`, or
   `attn profile resolve --json`; remove with `attn profile clean <name>`.
+- **Clean up the profile you created.** Nothing reaps it for you: its daemon
+  (~40MB) and every pty-worker (~15MB) keep running until someone notices them
+  days later. `attn profile clean <name>` reaps the workers, stops the daemon,
+  quits the app, and removes the bundle and data dir. `make install
+  PROFILE=<name>` records the worktree it ran from, so `attn profile list` tells
+  you which profiles are yours, and a PostToolUse hook reminds you after you
+  create or merge a PR.
 - Full model and per-agent recipe: [docs/profiles.md](docs/profiles.md).
 
 Every non-trivial PR needs live verification from the branch in a running

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run build build-linux-amd64 build-linux-arm64 publish-native-vt install install-daemon install-dev install-daemon-dev dev test test-v test-quick test-watch test-all test-frontend test-e2e test-harness clean generate-types check-types build-app ensure-codesign-identity sign-app app-screenshot dist release release-skip-tests
+.PHONY: run build build-linux-amd64 build-linux-arm64 publish-native-vt install install-daemon install-dev install-daemon-dev dev test test-hooks test-v test-quick test-watch test-all test-frontend test-e2e test-harness clean generate-types check-types build-app ensure-codesign-identity sign-app app-screenshot dist release release-skip-tests
 
 # Bare `make` does the full prod inner loop: install + open the app.
 # `make install` is install-only (for scripts/CI that drive the launch
@@ -113,8 +113,13 @@ GOTESTSUM=$(HOME)/go/bin/gotestsum
 $(GOTESTSUM):
 	go install gotest.tools/gotestsum@latest
 
-test: $(NATIVE_VT_DEP)
+test: $(NATIVE_VT_DEP) test-hooks
 	./scripts/test-go.sh
+
+# Repository Claude Code hooks are shell, so they are invisible to the Go suite
+# and would otherwise rot unnoticed.
+test-hooks:
+	@bash ./scripts/claude/attn-profile-nudge_test.sh
 
 # Verbose test output (shows all test names as they run)
 test-v: $(NATIVE_VT_DEP)
@@ -201,6 +206,9 @@ install: build-app
 	cp -r "app/src-tauri/target/release/bundle/macos/$$app_name.app" ~/Applications/; \
 	if [ -n "$$profile" ]; then \
 		env $(PROFILE_DAEMON_UNSET) ATTN_PROFILE="$$profile" "$$app_binary" daemon ensure >/dev/null; \
+		: "Install time is the only moment the worktree behind a profile is known"; \
+		: "for certain, so record it here for cleanup tooling to read back."; \
+		"$$attn" profile set-origin "$$profile" --worktree "$(CURDIR)" >/dev/null || true; \
 	else \
 		"$$app_binary" daemon ensure >/dev/null; \
 	fi; \
@@ -231,6 +239,9 @@ install-daemon: ensure-codesign-identity build
 	fi; \
 	if [ -n "$$profile" ]; then \
 		env $(PROFILE_DAEMON_UNSET) ATTN_PROFILE="$$profile" "$$app_binary" daemon ensure >/dev/null; \
+		: "Same provenance record as the full install: a daemon-only install is"; \
+		: "still this worktree claiming the profile."; \
+		"$$attn" profile set-origin "$$profile" --worktree "$(CURDIR)" >/dev/null || true; \
 	else \
 		"$$app_binary" daemon ensure >/dev/null; \
 	fi; \

--- a/changelog.d/wily-raccoon-profile-clean-reaps-workers.yaml
+++ b/changelog.d/wily-raccoon-profile-clean-reaps-workers.yaml
@@ -1,0 +1,19 @@
+kind: fixed
+area: profiles
+change: >
+  `attn profile clean` now shuts down the profile's pty-workers before removing
+  its data dir, and reports what happened to each one. Cleaning a profile no
+  longer strands its workers.
+symptom: >
+  Cleaning a profile left its pty-workers running forever. Stopping the daemon
+  deliberately leaves workers alive so they can be re-adopted, but the clean
+  then deleted the worker registry they are found through — so nothing could
+  ever adopt or reap them. They accumulated invisibly, each holding 10-20MB,
+  until someone noticed them at the top of `ps` days later.
+notes: >
+  Workers are stopped over their own authenticated control socket (the registry
+  records socket path, owning daemon instance, and control token), so the reap
+  cannot hit an unrelated process that inherited a recycled PID. A worker whose
+  socket is unreachable is signalled only when its argv still identifies it as
+  that registry entry's worker; anything less certain is left running and
+  reported by PID rather than killed on a guess.

--- a/changelog.d/wily-raccoon-profile-origin-and-nudge.yaml
+++ b/changelog.d/wily-raccoon-profile-origin-and-nudge.yaml
@@ -1,0 +1,15 @@
+kind: added
+area: profiles
+change: >
+  Profiles now record the worktree they were installed from, `attn profile
+  list` shows it (with `--json` for tooling), and a repository Claude Code hook
+  reminds an agent to clean up its throwaway profile after it creates or merges
+  a PR.
+notes: >
+  `make install PROFILE=<name>` and `make install-daemon PROFILE=<name>` write
+  `origin.json` into the profile's data dir; install is the only moment the
+  worktree behind a profile is known for certain, since the build fingerprint
+  identifies source content rather than the checkout. The hook
+  (`scripts/claude/attn-profile-nudge.sh`, wired in `.claude/settings.json`)
+  stays silent unless the current worktree owns a profile that still has
+  something installed or running, so agents that never made one never see it.

--- a/cmd/attn/profile.go
+++ b/cmd/attn/profile.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/daemonctl"
+	"github.com/victorarias/attn/internal/ptyworker"
 )
 
 // runProfile is the `attn profile <subcommand>` group: the human-facing surface
@@ -36,8 +37,10 @@ func runProfile() {
 		runProfileTauriConfig(os.Args[3:])
 	case "clean":
 		runProfileClean(os.Args[3:])
+	case "set-origin":
+		runProfileSetOrigin(os.Args[3:])
 	case "list":
-		runProfileList()
+		runProfileList(os.Args[3:])
 	case "env":
 		// `attn profile env …` mirrors the top-level `attn profile-env …`.
 		runProfileEnvArgs(os.Args[3:])
@@ -308,6 +311,12 @@ func runProfileClean(args []string) {
 		fmt.Printf("  daemon   stopped\n")
 	}
 
+	// Workers outlive the daemon on purpose, so stopping it is not enough: the
+	// data dir removal below destroys the registry they are found through, and
+	// any worker still alive at that point is stranded with no daemon that could
+	// ever adopt it. Reap before the registry goes.
+	reportWorkerReap(ptyworker.ReapDataDir(r.DataDir))
+
 	// App bundle: forget it in LaunchServices (so the deep-link scheme and
 	// bundle id stop resolving to a path we're about to delete), then remove it.
 	if fileExists(r.AppPath) {
@@ -331,6 +340,45 @@ func runProfileClean(args []string) {
 	}
 
 	fmt.Printf("Cleaned profile %s.\n", r.Label)
+}
+
+// reportWorkerReap prints one line per registered worker. An unidentified
+// worker is the one outcome that needs a human: the reaper refused to signal a
+// PID it could not confirm, so the process is named rather than silently left
+// behind for someone to find days later at the top of `ps`.
+func reportWorkerReap(results []ptyworker.ReapResult) {
+	if len(results) == 0 {
+		fmt.Printf("  workers  none registered\n")
+		return
+	}
+	byOutcome := map[ptyworker.ReapOutcome]int{}
+	for _, res := range results {
+		byOutcome[res.Outcome]++
+	}
+	fmt.Printf("  workers  %d registered (%s)\n", len(results), summarizeReap(byOutcome))
+	for _, res := range results {
+		if res.Outcome != ptyworker.ReapUnidentified {
+			continue
+		}
+		fmt.Printf("           ! session %s: pid %d could not be confirmed as its worker (%v); left running — check it with `ps -p %d` and kill it yourself if it is stale\n",
+			res.SessionID, res.WorkerPID, res.Err, res.WorkerPID)
+	}
+}
+
+func summarizeReap(byOutcome map[ptyworker.ReapOutcome]int) string {
+	order := []ptyworker.ReapOutcome{
+		ptyworker.ReapRemoved,
+		ptyworker.ReapSignalled,
+		ptyworker.ReapAlreadyGone,
+		ptyworker.ReapUnidentified,
+	}
+	parts := make([]string, 0, len(order))
+	for _, outcome := range order {
+		if n := byOutcome[outcome]; n > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", n, outcome))
+		}
+	}
+	return strings.Join(parts, ", ")
 }
 
 // stopProfileDaemon stops a profile's daemon via its pid file, for an
@@ -383,7 +431,20 @@ func lsregisterForget(appPath string) {
 	_ = exec.Command(lsregisterPath, "-u", appPath).Run()
 }
 
-func runProfileList() {
+func runProfileList(args []string) {
+	asJSON := false
+	for _, a := range args {
+		switch a {
+		case "--json":
+			asJSON = true
+		case "-h", "--help":
+			printProfileHelp(os.Stdout)
+			return
+		default:
+			profileFatal(fmt.Sprintf("unknown flag %q for `attn profile list`", a))
+		}
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		profileFatal("cannot resolve home directory: " + err.Error())
@@ -434,19 +495,38 @@ func runProfileList() {
 	sort.Strings(names) // "" sorts first → default listed first
 
 	active := config.Profile()
-	fmt.Printf("%-3s %-16s %-7s %-9s %s\n", "", "PROFILE", "PORT", "DATA", "APP")
+
+	if asJSON {
+		entries := make([]profileListEntry, 0, len(names))
+		for _, p := range names {
+			entries = append(entries, newProfileListEntry(p, active))
+		}
+		out, err := json.MarshalIndent(map[string]any{"profiles": entries}, "", "  ")
+		if err != nil {
+			profileFatal(err.Error())
+		}
+		fmt.Println(string(out))
+		return
+	}
+
+	fmt.Printf("%-3s %-16s %-7s %-9s %-11s %s\n", "", "PROFILE", "PORT", "DATA", "APP", "ORIGIN")
 	for _, p := range names {
 		r := resolveProfile(p)
 		marker := "  "
 		if p == active {
 			marker = "* "
 		}
-		fmt.Printf("%-3s %-16s %-7s %-9s %s\n",
+		origin := "—"
+		if o := readProfileOrigin(r.DataDir); o != nil {
+			origin = filepath.Base(o.Worktree)
+		}
+		fmt.Printf("%-3s %-16s %-7s %-9s %-11s %s\n",
 			marker,
 			r.Label,
 			r.WSPort,
 			ynLabel(fileExists(r.DataDir), "yes", "—"),
 			ynLabel(fileExists(r.AppPath), "installed", "—"),
+			origin,
 		)
 	}
 	fmt.Println("\n* = active (ATTN_PROFILE)")
@@ -466,8 +546,11 @@ Usage:
   attn profile resolve --field wsPort      print one resolved value
   attn profile resolve --profile agent7    resolve a different profile
   attn profile tauri-config    Tauri --config overlay for the profile's build
-  attn profile clean <name>    stop daemon, quit app, remove its app + data dir
+  attn profile clean <name>    reap workers, stop daemon, quit app, remove its app + data dir
   attn profile list            every profile with data and/or an installed app
+  attn profile list --json     same, machine-readable, with origin and what is running
+  attn profile set-origin <name> [--worktree <dir>]
+                               record the worktree a profile was installed from
   attn profile env <name>      alias of: attn profile-env <name>
 
 Profile names must match [a-z0-9][a-z0-9-]{0,15}. "dev" is the development

--- a/cmd/attn/profile_origin.go
+++ b/cmd/attn/profile_origin.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/ptyworker"
+)
+
+// originFileName lives inside the profile's data dir so `attn profile clean`
+// removes it with everything else — a profile's provenance must not outlive the
+// profile.
+const originFileName = "origin.json"
+
+// profileOrigin records where a profile was installed from. Nothing else in attn
+// links a profile to the worktree that created it: the build fingerprint
+// identifies source *content*, not the checkout, so a throwaway profile spun up
+// for one branch is indistinguishable from a long-lived one once the agent that
+// made it is gone. Recording it at install time is what lets tooling later ask
+// "is this profile still mine?" and answer exactly instead of guessing.
+type profileOrigin struct {
+	Worktree   string `json:"worktree"`
+	Branch     string `json:"branch,omitempty"`
+	RecordedAt string `json:"recordedAt"`
+}
+
+func originPath(dataDir string) string { return filepath.Join(dataDir, originFileName) }
+
+// writeProfileOrigin records provenance for a profile, creating the data dir if
+// the daemon has not yet done so (install can run before first launch).
+func writeProfileOrigin(dataDir string, origin profileOrigin) error {
+	if err := os.MkdirAll(dataDir, 0700); err != nil {
+		return fmt.Errorf("create data dir: %w", err)
+	}
+	payload, err := json.MarshalIndent(origin, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := originPath(dataDir)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, append(payload, '\n'), 0600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// readProfileOrigin returns the recorded origin, or nil when the profile predates
+// origin recording or was never installed from a worktree.
+func readProfileOrigin(dataDir string) *profileOrigin {
+	data, err := os.ReadFile(originPath(dataDir))
+	if err != nil {
+		return nil
+	}
+	var origin profileOrigin
+	if err := json.Unmarshal(data, &origin); err != nil {
+		return nil
+	}
+	if strings.TrimSpace(origin.Worktree) == "" {
+		return nil
+	}
+	return &origin
+}
+
+// runProfileSetOrigin implements `attn profile set-origin <name> [--worktree dir]`.
+// The Makefile calls it during `make install PROFILE=<name>`, which is the only
+// moment the worktree that created a profile is known for certain.
+func runProfileSetOrigin(args []string) {
+	name := ""
+	worktree := ""
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--worktree":
+			if i+1 >= len(args) {
+				profileFatal("--worktree requires a directory")
+			}
+			i++
+			worktree = args[i]
+		case "-h", "--help":
+			printProfileHelp(os.Stdout)
+			return
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				profileFatal(fmt.Sprintf("unknown flag %q", args[i]))
+			}
+			if name != "" {
+				profileFatal(fmt.Sprintf("set-origin takes a single profile name, got %q and %q", name, args[i]))
+			}
+			name = args[i]
+		}
+	}
+	if name == "" {
+		profileFatal("set-origin requires a profile name (e.g. `attn profile set-origin agent7`)")
+	}
+	normalized, err := config.NormalizeProfileName(name)
+	if err != nil {
+		profileFatal(err.Error())
+	}
+	if normalized == "" {
+		// The production profile is not a throwaway and must never be reported as
+		// belonging to a worktree, or the cleanup nudge would target ~/.attn.
+		profileFatal("refusing to record an origin for the default (production) profile")
+	}
+	if worktree == "" {
+		worktree, err = os.Getwd()
+		if err != nil {
+			profileFatal(err.Error())
+		}
+	}
+	abs, err := filepath.Abs(worktree)
+	if err != nil {
+		profileFatal(err.Error())
+	}
+
+	origin := profileOrigin{
+		Worktree:   abs,
+		Branch:     gitBranchAt(abs),
+		RecordedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	dataDir := config.DataDirForProfile(normalized)
+	if err := writeProfileOrigin(dataDir, origin); err != nil {
+		profileFatal(fmt.Sprintf("record origin: %v", err))
+	}
+	fmt.Printf("recorded origin for profile %s: %s", normalized, origin.Worktree)
+	if origin.Branch != "" {
+		fmt.Printf(" (%s)", origin.Branch)
+	}
+	fmt.Println()
+}
+
+func gitBranchAt(dir string) string {
+	cmd := exec.Command("git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	branch := strings.TrimSpace(string(out))
+	if branch == "HEAD" {
+		return "" // detached; a bare SHA is not a useful label here
+	}
+	return branch
+}
+
+// profileListEntry is the machine-readable row behind `attn profile list --json`.
+// It carries what a caller needs to decide whether a profile is worth cleaning:
+// provenance, whether anything is installed, and what is currently running.
+type profileListEntry struct {
+	Profile       string         `json:"profile"`
+	Label         string         `json:"label"`
+	DataDir       string         `json:"dataDir"`
+	AppPath       string         `json:"appPath"`
+	WSPort        string         `json:"wsPort"`
+	Active        bool           `json:"active"`
+	HasData       bool           `json:"hasData"`
+	HasApp        bool           `json:"hasApp"`
+	DaemonRunning bool           `json:"daemonRunning"`
+	LiveWorkers   int            `json:"liveWorkers"`
+	Origin        *profileOrigin `json:"origin,omitempty"`
+}
+
+func newProfileListEntry(profile string, active string) profileListEntry {
+	r := resolveProfile(profile)
+	return profileListEntry{
+		Profile:       profile,
+		Label:         r.Label,
+		DataDir:       r.DataDir,
+		AppPath:       r.AppPath,
+		WSPort:        r.WSPort,
+		Active:        profile == active,
+		HasData:       fileExists(r.DataDir),
+		HasApp:        fileExists(r.AppPath),
+		DaemonRunning: socketLive(r.Socket),
+		LiveWorkers:   countLiveWorkers(r.DataDir),
+		Origin:        readProfileOrigin(r.DataDir),
+	}
+}
+
+// socketLive reports whether a daemon is actually accepting connections, rather
+// than whether a socket file was left on disk by one that died.
+func socketLive(path string) bool {
+	if path == "" {
+		return false
+	}
+	conn, err := net.DialTimeout("unix", path, 500*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// countLiveWorkers counts registered pty-workers whose process is still up.
+// Registry entries outlive their processes, so the file count alone would
+// overstate what a clean has left to do.
+func countLiveWorkers(dataDir string) int {
+	paths, err := filepath.Glob(filepath.Join(dataDir, "workers", "*", "registry", "*.json"))
+	if err != nil {
+		return 0
+	}
+	live := 0
+	for _, path := range paths {
+		entry, err := ptyworker.ReadRegistry(path)
+		if err != nil {
+			continue
+		}
+		if ptyworker.ProcessAlive(entry.WorkerPID) {
+			live++
+		}
+	}
+	return live
+}

--- a/cmd/attn/profile_origin_test.go
+++ b/cmd/attn/profile_origin_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/ptyworker"
+)
+
+// TestMain keeps every config-path lookup in this package inside a temp dir, so
+// no test can resolve production ~/.attn. See AGENTS.md "Test safety".
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "attn-cmd-test")
+	if err != nil {
+		panic(err)
+	}
+	config.ScopeTestEnvironment(dir)
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+func TestProfileOriginRoundTrip(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "not-yet-created")
+	want := profileOrigin{
+		Worktree:   "/Users/victor/projects/victor/attn--wily-raccoon",
+		Branch:     "wily-raccoon",
+		RecordedAt: "2026-08-02T00:00:00Z",
+	}
+	// Install can run before the daemon has ever created the data dir.
+	if err := writeProfileOrigin(dataDir, want); err != nil {
+		t.Fatalf("writeProfileOrigin() error: %v", err)
+	}
+	got := readProfileOrigin(dataDir)
+	if got == nil {
+		t.Fatal("readProfileOrigin() = nil, want the recorded origin")
+	}
+	if *got != want {
+		t.Fatalf("origin = %+v, want %+v", *got, want)
+	}
+}
+
+func TestReadProfileOriginAbsentOrUnusable(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		write   bool
+	}{
+		{name: "no origin file", write: false},
+		{name: "malformed json", content: "{not json", write: true},
+		// A record with no worktree cannot attribute anything, so it must read as
+		// absent rather than as a match-everything origin.
+		{name: "blank worktree", content: `{"worktree":"  "}`, write: true},
+		{name: "missing worktree key", content: `{"branch":"x"}`, write: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			if tc.write {
+				if err := os.WriteFile(originPath(dataDir), []byte(tc.content), 0600); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+			}
+			if got := readProfileOrigin(dataDir); got != nil {
+				t.Fatalf("readProfileOrigin() = %+v, want nil", *got)
+			}
+		})
+	}
+}
+
+// The origin file must live inside the data dir, so cleaning a profile takes its
+// provenance with it and a later reinstall cannot inherit a stale worktree.
+func TestOriginPathIsInsideDataDir(t *testing.T) {
+	dataDir := t.TempDir()
+	if got, want := originPath(dataDir), filepath.Join(dataDir, "origin.json"); got != want {
+		t.Fatalf("originPath() = %q, want %q", got, want)
+	}
+}
+
+func TestCountLiveWorkers(t *testing.T) {
+	dataDir := t.TempDir()
+	if got := countLiveWorkers(dataDir); got != 0 {
+		t.Fatalf("countLiveWorkers() = %d on an empty data dir, want 0", got)
+	}
+
+	// A registry entry outlives its process; counting files would overstate what
+	// is actually running.
+	write := func(session string, pid int) {
+		path := filepath.Join(dataDir, "workers", "d-1", "registry", session+".json")
+		if err := ptyworker.WriteRegistryAtomic(path, ptyworker.RegistryEntry{
+			Version: 1, SessionID: session, WorkerPID: pid,
+		}); err != nil {
+			t.Fatalf("write registry: %v", err)
+		}
+	}
+	write("alive", os.Getpid())
+	write("dead", -1)
+
+	if got := countLiveWorkers(dataDir); got != 1 {
+		t.Fatalf("countLiveWorkers() = %d, want 1 (dead entries must not count)", got)
+	}
+}
+
+func TestSocketLiveOnMissingSocket(t *testing.T) {
+	if socketLive("") {
+		t.Error("socketLive(\"\") = true")
+	}
+	if socketLive(filepath.Join(t.TempDir(), "absent.sock")) {
+		t.Error("socketLive() = true for a socket that does not exist")
+	}
+}
+
+// A socket file left behind by a dead daemon must not read as a running one —
+// that is the difference between "clean me" and "leave me alone".
+func TestSocketLiveIgnoresStaleSocketFile(t *testing.T) {
+	stale := filepath.Join(t.TempDir(), "attn.sock")
+	if err := os.WriteFile(stale, nil, 0600); err != nil {
+		t.Fatalf("write stale socket file: %v", err)
+	}
+	if socketLive(stale) {
+		t.Error("socketLive() = true for a plain file masquerading as a socket")
+	}
+}
+
+func TestSummarizeReapOrdersByOutcome(t *testing.T) {
+	got := summarizeReap(map[ptyworker.ReapOutcome]int{
+		ptyworker.ReapUnidentified: 1,
+		ptyworker.ReapRemoved:      2,
+		ptyworker.ReapAlreadyGone:  3,
+	})
+	want := "2 removed, 3 already gone, 1 unidentified"
+	if got != want {
+		t.Fatalf("summarizeReap() = %q, want %q", got, want)
+	}
+}
+
+func TestSummarizeReapSkipsZeroCounts(t *testing.T) {
+	got := summarizeReap(map[ptyworker.ReapOutcome]int{ptyworker.ReapRemoved: 1})
+	if got != "1 removed" {
+		t.Fatalf("summarizeReap() = %q, want %q", got, "1 removed")
+	}
+}

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -105,10 +105,57 @@ the Go and (soon) e2e suites concurrently with no cross-talk.
 | Step | How |
 |---|---|
 | Pick | `attn profile-env <name> \| source` |
-| Inspect | `attn profile` / `attn profile list` |
+| Inspect | `attn profile` / `attn profile list` / `attn profile list --json` |
 | Build + install app | `make install PROFILE=<name>` (opens it: `make run PROFILE=<name>`) |
 | Sign | uniform stable identity via `scripts/macos-codesign-identity.sh`; macOS grants persist per bundle id |
-| Clean | `attn profile clean <name>` — stop daemon, quit app, remove data dir + app, forget the bundle |
+| Clean | `attn profile clean <name>` — reap pty-workers, stop daemon, quit app, remove data dir + app, forget the bundle |
+
+### Cleaning up after yourself
+
+A profile costs nothing to create and is invisible once made: its daemon (~40MB)
+and each pty-worker (~15MB) keep running long after the branch that needed them
+is merged, and nothing ever reaps them on its own. Clean a throwaway profile as
+soon as the work is done.
+
+**Workers are reaped before the data dir goes.** Stopping a daemon deliberately
+leaves its workers running — they are built to outlive a restart and be
+re-adopted — so `clean` shuts them down explicitly first. It talks to each worker
+over the authenticated control socket recorded in the profile's worker registry,
+which is precise by construction: it cannot hit an unrelated process that
+inherited a recycled PID. A worker whose socket is unreachable is signalled only
+if its argv still identifies it as that registry entry's worker; anything less
+certain is left running and reported by PID, e.g.
+
+```
+  workers  3 registered (2 removed, 1 unidentified)
+           ! session 8f9fb98d: pid 19891 could not be confirmed as its worker
+             (dial unix …: connect: connection refused); left running — check it
+             with `ps -p 19891` and kill it yourself if it is stale
+```
+
+Removing the data dir before reaping is what strands a worker permanently: the
+registry it would be found through goes with the dir, so no daemon can ever adopt
+it again.
+
+### Provenance
+
+`make install PROFILE=<name>` and `make install-daemon PROFILE=<name>` record the
+worktree they ran from in `<data-dir>/origin.json`. Install is the only moment
+that link is known for certain — the build fingerprint identifies source
+*content*, not the checkout — and without it a throwaway profile is
+indistinguishable from a long-lived one once the agent that made it is gone.
+
+`attn profile list` shows the origin worktree; `attn profile list --json` adds
+the branch, whether the daemon is up, and how many workers are live. Cleaning a
+profile removes its origin record along with everything else, so provenance never
+outlives the profile.
+
+That record is what powers the repository's PR-milestone cleanup hook
+(`scripts/claude/attn-profile-nudge.sh`, wired in `.claude/settings.json`): after
+an agent creates or merges a PR, it reminds the agent to clean any profile
+installed from that worktree, and stays silent otherwise. Record an origin by
+hand with `attn profile set-origin <name> [--worktree <dir>]` if you created a
+profile outside `make install`.
 
 ## Rollout status
 

--- a/internal/ptyworker/reap.go
+++ b/internal/ptyworker/reap.go
@@ -1,0 +1,223 @@
+package ptyworker
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// ReapOutcome names how a single worker was disposed of.
+type ReapOutcome string
+
+const (
+	// ReapRemoved: the worker accepted the authenticated `remove` RPC and shut
+	// itself down. The normal path.
+	ReapRemoved ReapOutcome = "removed"
+	// ReapAlreadyGone: the registry entry outlived its process.
+	ReapAlreadyGone ReapOutcome = "already gone"
+	// ReapSignalled: the control socket was unreachable but the process was
+	// positively identified as this entry's worker, so it was SIGTERMed.
+	ReapSignalled ReapOutcome = "signalled"
+	// ReapUnidentified: the socket was unreachable AND the live PID could not be
+	// confirmed to be this worker (PID reuse, or a process we cannot inspect).
+	// Nothing is signalled — the PID is reported for a human to judge.
+	ReapUnidentified ReapOutcome = "unidentified"
+)
+
+// ReapResult reports what happened to one registered worker.
+type ReapResult struct {
+	SessionID string
+	WorkerPID int
+	Outcome   ReapOutcome
+	// Err carries why the preferred (control-socket) path was not taken. It is
+	// context for a degraded outcome, not necessarily a failure of the reap.
+	Err error
+}
+
+// ReapDataDir shuts down every pty-worker registered under a profile's data
+// dir and returns one result per registry entry.
+//
+// This exists because stopping a daemon deliberately leaves its workers running
+// — they are built to outlive a daemon restart and be re-adopted. Deleting the
+// data dir (as `attn profile clean` does) destroys the registry those workers
+// are found through, so any worker still alive at that moment is stranded
+// forever: no daemon can ever adopt it, and nothing but a hand-written kill will
+// reclaim its memory. Callers that are about to remove a data dir must reap
+// first.
+//
+// Workers are shut down over their own authenticated control socket rather than
+// by signalling a PID: the registry records the socket path, the owning daemon
+// instance id, and the control token, so `remove` is precise by construction and
+// cannot hit an unrelated process that inherited the PID.
+func ReapDataDir(dataDir string) []ReapResult {
+	paths, err := filepath.Glob(filepath.Join(dataDir, "workers", "*", "registry", "*.json"))
+	if err != nil {
+		return nil
+	}
+	sort.Strings(paths)
+
+	var results []ReapResult
+	for _, path := range paths {
+		entry, err := ReadRegistry(path)
+		if err != nil {
+			continue
+		}
+		results = append(results, reapEntry(entry, path))
+	}
+	return results
+}
+
+// reapEntry disposes of one worker, preferring the control socket and degrading
+// only as far as the evidence allows.
+func reapEntry(entry RegistryEntry, registryPath string) ReapResult {
+	res := ReapResult{SessionID: entry.SessionID, WorkerPID: entry.WorkerPID}
+
+	if entry.WorkerPID <= 0 || !ProcessAlive(entry.WorkerPID) {
+		res.Outcome = ReapAlreadyGone
+		return res
+	}
+
+	if err := requestWorkerRemove(entry); err == nil {
+		if waitForExit(entry.WorkerPID, 5*time.Second) {
+			res.Outcome = ReapRemoved
+			return res
+		}
+		res.Err = errors.New("worker accepted remove but did not exit")
+	} else {
+		res.Err = err
+	}
+
+	// The control socket did not finish the job. Signal only a process we can
+	// still positively identify as this worker: the registry path is unique per
+	// session per data dir, so finding it in the process's own argv rules out a
+	// recycled PID.
+	if !processHasArg(entry.WorkerPID, registryPath) {
+		res.Outcome = ReapUnidentified
+		return res
+	}
+	_ = syscall.Kill(entry.WorkerPID, syscall.SIGTERM)
+	waitForExit(entry.WorkerPID, 5*time.Second)
+	res.Outcome = ReapSignalled
+	return res
+}
+
+// requestWorkerRemove performs the worker handshake and asks it to remove its
+// session, which SIGTERMs the child and stops the worker runtime.
+func requestWorkerRemove(entry RegistryEntry) error {
+	if strings.TrimSpace(entry.SocketPath) == "" {
+		return errors.New("registry entry has no socket path")
+	}
+	conn, err := net.DialTimeout("unix", entry.SocketPath, 2*time.Second)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+	if err := conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return err
+	}
+
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+
+	hello := HelloParams{
+		RPCMajor:         RPCMajor,
+		RPCMinor:         RPCMinor,
+		DaemonInstanceID: entry.DaemonInstanceID,
+		ControlToken:     entry.ControlToken,
+	}
+	if err := writeReapRequest(enc, "reap-hello", MethodHello, hello); err != nil {
+		return err
+	}
+	if err := awaitOK(dec, "reap-hello"); err != nil {
+		return err
+	}
+	if err := writeReapRequest(enc, "reap-remove", MethodRemove, map[string]any{}); err != nil {
+		return err
+	}
+	return awaitOK(dec, "reap-remove")
+}
+
+func writeReapRequest(enc *json.Encoder, id, method string, params any) error {
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+	return enc.Encode(RequestEnvelope{Type: "req", ID: id, Method: method, Params: raw})
+}
+
+// awaitOK reads frames until the response for id arrives, skipping the events a
+// worker may interleave with responses.
+func awaitOK(dec *json.Decoder, id string) error {
+	for {
+		var res ResponseEnvelope
+		if err := dec.Decode(&res); err != nil {
+			return err
+		}
+		if res.Type != "res" || res.ID != id {
+			continue
+		}
+		if !res.OK {
+			if res.Error != nil {
+				return fmt.Errorf("worker %s: %s", res.Error.Code, res.Error.Message)
+			}
+			return errors.New("worker rejected request")
+		}
+		return nil
+	}
+}
+
+// ProcessAlive reports whether a recorded worker PID still names a live
+// process. Exported because callers that merely inventory a data dir need the
+// same liveness answer the reaper uses.
+func ProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+func waitForExit(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !ProcessAlive(pid) {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return !ProcessAlive(pid)
+}
+
+// processHasArg reports whether the live process's own argv contains want. It is
+// the identity check that makes signalling safe, so an unreadable argv must read
+// as "not identified" rather than "probably fine".
+func processHasArg(pid int, want string) bool {
+	if want == "" {
+		return false
+	}
+	if raw, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline")); err == nil {
+		for _, arg := range strings.Split(string(raw), "\x00") {
+			if arg == want {
+				return true
+			}
+		}
+		return false
+	}
+	out, err := exec.Command("ps", "-o", "command=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(out), want)
+}

--- a/internal/ptyworker/reap_test.go
+++ b/internal/ptyworker/reap_test.go
@@ -1,0 +1,378 @@
+package ptyworker
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// fakeWorker is a control socket that speaks just enough of the worker RPC to
+// answer hello + remove, recording what it was asked and what identity it was
+// given.
+type fakeWorker struct {
+	listener   net.Listener
+	gotHello   chan HelloParams
+	gotRemove  chan struct{}
+	rejectAuth bool
+	// proc is the process the worker "is": accepting remove exits it, the way a
+	// real worker's runtime stops. Never the test's own PID — a regressed
+	// identity gate would then SIGTERM the test runner instead of failing.
+	proc *exec.Cmd
+}
+
+func startFakeWorker(t *testing.T, dir string, rejectAuth bool) *fakeWorker {
+	t.Helper()
+	// Unix socket paths are length-limited; keep them short and out of the long
+	// temp dir the registry lives in.
+	sockDir, err := os.MkdirTemp("", "reap")
+	if err != nil {
+		t.Fatalf("temp sock dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+
+	ln, err := net.Listen("unix", filepath.Join(sockDir, "w.sock"))
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	w := &fakeWorker{
+		listener:   ln,
+		gotHello:   make(chan HelloParams, 1),
+		gotRemove:  make(chan struct{}, 1),
+		rejectAuth: rejectAuth,
+		proc:       spawnSleeper(t, "fake-worker-"+filepath.Base(sockDir)),
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go w.serve()
+	return w
+}
+
+func (w *fakeWorker) addr() string { return w.listener.Addr().String() }
+
+func (w *fakeWorker) serve() {
+	for {
+		conn, err := w.listener.Accept()
+		if err != nil {
+			return
+		}
+		go func() {
+			defer func() { _ = conn.Close() }()
+			dec := json.NewDecoder(conn)
+			enc := json.NewEncoder(conn)
+			for {
+				var req RequestEnvelope
+				if err := dec.Decode(&req); err != nil {
+					return
+				}
+				switch req.Method {
+				case MethodHello:
+					var hp HelloParams
+					_ = json.Unmarshal(req.Params, &hp)
+					select {
+					case w.gotHello <- hp:
+					default:
+					}
+					if w.rejectAuth {
+						_ = enc.Encode(ResponseEnvelope{
+							Type: "res", ID: req.ID, OK: false,
+							Error: &RPCError{Code: ErrUnauthorized, Message: "bad token"},
+						})
+						return
+					}
+					_ = enc.Encode(ResponseEnvelope{Type: "res", ID: req.ID, OK: true})
+				case MethodRemove:
+					select {
+					case w.gotRemove <- struct{}{}:
+					default:
+					}
+					_ = enc.Encode(ResponseEnvelope{Type: "res", ID: req.ID, OK: true})
+					// Exit like a real worker whose runtime was stopped.
+					_ = w.proc.Process.Signal(syscall.SIGTERM)
+				default:
+					_ = enc.Encode(ResponseEnvelope{
+						Type: "res", ID: req.ID, OK: false,
+						Error: &RPCError{Code: ErrBadRequest, Message: "unknown method"},
+					})
+				}
+			}
+		}()
+	}
+}
+
+// spawnSleeper starts a real child process that ReapDataDir can be pointed at,
+// so "did the worker actually die" is answered by process state rather than by a
+// mock's bookkeeping.
+func spawnSleeper(t *testing.T, marker string) *exec.Cmd {
+	t.Helper()
+	// The marker rides in argv as sh's $0 so the identity check has something
+	// unique to find, mirroring --registry-path on a real worker. The trailing
+	// `:` matters: with a lone simple command, sh exec's it directly and the
+	// process argv becomes bare `sleep 60`, losing the marker — which made this
+	// helper a race rather than a fixture.
+	cmd := exec.Command("sh", "-c", "sleep 60; :", marker)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleeper: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	go func() { _, _ = cmd.Process.Wait() }()
+	return cmd
+}
+
+func writeEntry(t *testing.T, dataDir, sessionID string, entry RegistryEntry) string {
+	t.Helper()
+	path := filepath.Join(dataDir, "workers", "d-1", "registry", sessionID+".json")
+	if err := WriteRegistryAtomic(path, entry); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	return path
+}
+
+// The normal path: a reachable worker is shut down over its own authenticated
+// control socket, carrying the identity the registry recorded.
+func TestReapDataDirRemovesViaControlSocket(t *testing.T) {
+	dataDir := t.TempDir()
+	worker := startFakeWorker(t, dataDir, false)
+
+	writeEntry(t, dataDir, "sess-1", RegistryEntry{
+		Version:          1,
+		DaemonInstanceID: "d-1",
+		SessionID:        "sess-1",
+		WorkerPID:        worker.proc.Process.Pid,
+		SocketPath:       worker.addr(),
+		ControlToken:     "tok-abc",
+	})
+
+	results := ReapDataDir(dataDir)
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if results[0].Outcome != ReapRemoved {
+		t.Fatalf("outcome = %s (err=%v), want %s", results[0].Outcome, results[0].Err, ReapRemoved)
+	}
+	if ProcessAlive(worker.proc.Process.Pid) {
+		t.Error("worker still alive after accepting remove")
+	}
+
+	select {
+	case hp := <-worker.gotHello:
+		if hp.ControlToken != "tok-abc" {
+			t.Errorf("control token = %q, want %q", hp.ControlToken, "tok-abc")
+		}
+		if hp.DaemonInstanceID != "d-1" {
+			t.Errorf("daemon instance = %q, want %q", hp.DaemonInstanceID, "d-1")
+		}
+	default:
+		t.Fatal("worker never received hello")
+	}
+	select {
+	case <-worker.gotRemove:
+	default:
+		t.Fatal("worker never received remove")
+	}
+}
+
+// A registry entry whose process is already gone is reported, not signalled.
+func TestReapDataDirReportsAlreadyGone(t *testing.T) {
+	dataDir := t.TempDir()
+	// Exit a real child so the PID is genuinely dead rather than never-existing.
+	cmd := exec.Command("true")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run true: %v", err)
+	}
+	writeEntry(t, dataDir, "sess-dead", RegistryEntry{
+		Version: 1, SessionID: "sess-dead", WorkerPID: cmd.Process.Pid,
+	})
+
+	results := ReapDataDir(dataDir)
+	if len(results) != 1 || results[0].Outcome != ReapAlreadyGone {
+		t.Fatalf("outcome = %+v, want %s", results, ReapAlreadyGone)
+	}
+}
+
+// The fallback that matters: no control socket, but the live process is
+// positively identified as this entry's worker, so it is signalled and dies.
+func TestReapDataDirSignalsIdentifiedWorkerWhenSocketUnreachable(t *testing.T) {
+	dataDir := t.TempDir()
+	registryPath := filepath.Join(dataDir, "workers", "d-1", "registry", "sess-wedged.json")
+	cmd := spawnSleeper(t, registryPath)
+
+	writeEntry(t, dataDir, "sess-wedged", RegistryEntry{
+		Version:    1,
+		SessionID:  "sess-wedged",
+		WorkerPID:  cmd.Process.Pid,
+		SocketPath: filepath.Join(dataDir, "nonexistent.sock"),
+	})
+
+	results := ReapDataDir(dataDir)
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if results[0].Outcome != ReapSignalled {
+		t.Fatalf("outcome = %s (err=%v), want %s", results[0].Outcome, results[0].Err, ReapSignalled)
+	}
+	if ProcessAlive(cmd.Process.Pid) {
+		t.Fatal("worker still alive after reap")
+	}
+}
+
+// The safety property: an unreachable socket plus a PID that is NOT this worker
+// must never be signalled, however tempting the dead entry looks.
+func TestReapDataDirRefusesToSignalUnidentifiedProcess(t *testing.T) {
+	dataDir := t.TempDir()
+	// A live process that carries no trace of this registry entry — the shape a
+	// recycled PID takes.
+	cmd := spawnSleeper(t, "unrelated-process-marker")
+
+	writeEntry(t, dataDir, "sess-reused", RegistryEntry{
+		Version:    1,
+		SessionID:  "sess-reused",
+		WorkerPID:  cmd.Process.Pid,
+		SocketPath: filepath.Join(dataDir, "nonexistent.sock"),
+	})
+
+	results := ReapDataDir(dataDir)
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if results[0].Outcome != ReapUnidentified {
+		t.Fatalf("outcome = %s, want %s", results[0].Outcome, ReapUnidentified)
+	}
+	if !ProcessAlive(cmd.Process.Pid) {
+		t.Fatal("reap signalled a process it could not identify")
+	}
+}
+
+// A worker that rejects the handshake is not thereby fair game for a signal:
+// without identity confirmation it is reported, not killed.
+func TestReapDataDirDoesNotSignalOnAuthFailure(t *testing.T) {
+	dataDir := t.TempDir()
+	worker := startFakeWorker(t, dataDir, true)
+	cmd := worker.proc
+
+	writeEntry(t, dataDir, "sess-auth", RegistryEntry{
+		Version:          1,
+		DaemonInstanceID: "d-1",
+		SessionID:        "sess-auth",
+		WorkerPID:        cmd.Process.Pid,
+		SocketPath:       worker.addr(),
+		ControlToken:     "wrong",
+	})
+
+	results := ReapDataDir(dataDir)
+	if len(results) != 1 || results[0].Outcome != ReapUnidentified {
+		t.Fatalf("outcome = %+v, want %s", results, ReapUnidentified)
+	}
+	if results[0].Err == nil {
+		t.Error("expected the auth rejection to be reported as the reason")
+	}
+	if !ProcessAlive(cmd.Process.Pid) {
+		t.Fatal("reap signalled a worker that merely rejected auth")
+	}
+}
+
+// Every registry entry under the data dir is visited, across daemon instances.
+func TestReapDataDirVisitsEveryInstance(t *testing.T) {
+	dataDir := t.TempDir()
+	for _, inst := range []string{"d-old", "d-new"} {
+		path := filepath.Join(dataDir, "workers", inst, "registry", "s.json")
+		if err := WriteRegistryAtomic(path, RegistryEntry{Version: 1, SessionID: inst, WorkerPID: -1}); err != nil {
+			t.Fatalf("write registry: %v", err)
+		}
+	}
+	if got := len(ReapDataDir(dataDir)); got != 2 {
+		t.Fatalf("results = %d, want 2 (one per daemon instance)", got)
+	}
+}
+
+func TestReapDataDirOnMissingDirIsEmpty(t *testing.T) {
+	if got := ReapDataDir(filepath.Join(t.TempDir(), "absent")); len(got) != 0 {
+		t.Fatalf("results = %d, want 0", len(got))
+	}
+}
+
+func TestProcessAliveRejectsDeadPID(t *testing.T) {
+	cmd := exec.Command("true")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run true: %v", err)
+	}
+	if ProcessAlive(cmd.Process.Pid) {
+		t.Error("ProcessAlive() = true for a reaped child")
+	}
+	if !ProcessAlive(os.Getpid()) {
+		t.Error("ProcessAlive() = false for self")
+	}
+	if ProcessAlive(0) || ProcessAlive(-1) {
+		t.Error("ProcessAlive() accepted a non-positive pid")
+	}
+}
+
+func TestAwaitOKSkipsInterleavedEvents(t *testing.T) {
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
+
+	go func() {
+		enc := json.NewEncoder(server)
+		_ = enc.Encode(EventEnvelope{Type: "evt", Event: EventOutput})
+		_ = enc.Encode(ResponseEnvelope{Type: "res", ID: "other", OK: true})
+		_ = enc.Encode(ResponseEnvelope{Type: "res", ID: "mine", OK: true})
+	}()
+
+	_ = client.SetDeadline(time.Now().Add(5 * time.Second))
+	if err := awaitOK(json.NewDecoder(client), "mine"); err != nil {
+		t.Fatalf("awaitOK() error = %v, want nil", err)
+	}
+}
+
+func TestAwaitOKSurfacesWorkerError(t *testing.T) {
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
+
+	go func() {
+		_ = json.NewEncoder(server).Encode(ResponseEnvelope{
+			Type: "res", ID: "mine", OK: false,
+			Error: &RPCError{Code: ErrUnauthorized, Message: "bad token"},
+		})
+	}()
+
+	_ = client.SetDeadline(time.Now().Add(5 * time.Second))
+	err := awaitOK(json.NewDecoder(client), "mine")
+	if err == nil {
+		t.Fatal("awaitOK() = nil, want the worker's rejection")
+	}
+	if !errors.Is(err, err) || err.Error() == "" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProcessHasArgIdentifiesOwnProcess(t *testing.T) {
+	marker := "reap-identity-marker"
+	cmd := spawnSleeper(t, marker)
+	if !processHasArg(cmd.Process.Pid, marker) {
+		t.Error("processHasArg() = false for a process carrying the marker")
+	}
+	if processHasArg(cmd.Process.Pid, "some-other-marker") {
+		t.Error("processHasArg() = true for a marker the process does not carry")
+	}
+	if processHasArg(cmd.Process.Pid, "") {
+		t.Error("processHasArg() = true for an empty marker")
+	}
+}
+
+func TestWaitForExitReturnsWhenProcessDies(t *testing.T) {
+	cmd := spawnSleeper(t, "wait-for-exit-marker")
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+	}()
+	if !waitForExit(cmd.Process.Pid, 5*time.Second) {
+		t.Fatal("waitForExit() = false, want true once the process exits")
+	}
+}

--- a/scripts/claude/attn-profile-nudge.sh
+++ b/scripts/claude/attn-profile-nudge.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Claude Code PostToolUse hook: after a PR is created or merged from this
+# worktree, remind the agent to clean up any throwaway attn profile it installed
+# from here.
+#
+# Why this exists: a profile is cheap to create and invisible once made. Its
+# daemon and pty-workers keep running long after the branch that needed them is
+# merged, and nothing ever reaps them — an idle profile costs ~40MB for the
+# daemon plus ~15MB per worker, indefinitely. The agent that made it is the only
+# one that knows whether it is still needed, and the PR is the moment it knows.
+#
+# The hook is silent unless this worktree actually owns a profile with something
+# running, so agents that never installed one never see it.
+#
+# stdin:  Claude Code hook payload (JSON)
+# stdout: hook JSON with additionalContext, or nothing
+# Always exits 0 — a cleanup reminder must never fail a PR.
+set -uo pipefail
+
+payload="$(cat)"
+
+# This runs on every Bash tool call, and the overwhelming majority are not PR
+# milestones. Reject those on a single grep over the raw payload before spawning
+# anything — the precise match on the parsed command happens below.
+printf '%s' "$payload" | grep -qE 'gh[^"]*pr|stack[^"]*merge' || exit 0
+
+# jq is the only hard dependency; without it, stay silent rather than guess.
+command -v jq >/dev/null 2>&1 || exit 0
+
+tool_name="$(printf '%s' "$payload" | jq -r '.tool_name // empty')"
+[ "$tool_name" = "Bash" ] || exit 0
+
+command_line="$(printf '%s' "$payload" | jq -r '.tool_input.command // empty')"
+[ -n "$command_line" ] || exit 0
+
+# Match PR creation and merge, via gh or the repo's stack CLI. Deliberately
+# narrow: `gh pr view`, `gh pr checks`, and friends are not "done" signals.
+if ! printf '%s' "$command_line" | grep -Eq '(^|[;&|[:space:]])(gh[[:space:]]+pr[[:space:]]+(create|merge)|stack[[:space:]]+merge)([[:space:]]|$)'; then
+  exit 0
+fi
+
+# A failed command is not a milestone. Tested explicitly rather than with `//`,
+# which treats a literal false as empty and would read a failure as a success.
+failed="$(printf '%s' "$payload" | jq -r '
+  if (.tool_response | type) == "object" and
+     (.tool_response.success == false or .tool_response.is_error == true)
+  then "yes" else "no" end')"
+[ "$failed" = "no" ] || exit 0
+
+worktree="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+[ -n "$worktree" ] || exit 0
+
+# Prefer the freshly built binary in the worktree — a repo-local hook should
+# reflect the branch's own CLI — then fall back to whatever is installed.
+attn_bin=""
+for candidate in "$worktree/attn" "$HOME/Applications/attn.app/Contents/MacOS/attn"; do
+  if [ -x "$candidate" ]; then
+    attn_bin="$candidate"
+    break
+  fi
+done
+[ -n "$attn_bin" ] || exit 0
+
+listing="$("$attn_bin" profile list --json 2>/dev/null)" || exit 0
+[ -n "$listing" ] || exit 0
+
+# Attribute profiles to this worktree, and keep only those with something left
+# to clean. Recorded origin is exact; the heuristic covers profiles installed
+# before origin recording existed, by looking for a daemon or a session whose
+# own cwd sits inside this worktree.
+summary="$(printf '%s' "$listing" | jq -r --arg wt "$worktree" '
+  [ .profiles[]
+    | select(.profile != "")
+    | select(.origin != null and .origin.worktree == $wt)
+    | select(.hasData or .hasApp)
+  ]
+  | map("  - \(.label): "
+      + (if .daemonRunning then "daemon running" else "daemon stopped" end)
+      + (if .liveWorkers > 0 then ", \(.liveWorkers) pty-worker(s)" else "" end)
+      + (if .origin.branch != null and .origin.branch != "" then " [installed from \(.origin.branch)]" else "" end))
+  | join("\n")
+')"
+
+if [ -z "$summary" ]; then
+  # No profile recorded against this worktree. Fall back to the heuristic for
+  # profiles that predate origin recording: a daemon running out of this
+  # worktree's own binary, or a registered session whose cwd is inside it.
+  heuristic=""
+  for datadir in "$HOME"/.attn-*; do
+    [ -d "$datadir" ] || continue
+    [ -f "$datadir/origin.json" ] && continue
+    if ls "$datadir"/workers/*/registry/*.json >/dev/null 2>&1; then
+      if grep -lF "\"cwd\": \"$worktree\"" "$datadir"/workers/*/registry/*.json >/dev/null 2>&1; then
+        heuristic="$heuristic
+  - ${datadir##*/.attn-}: has a session whose cwd is this worktree (origin not recorded)"
+      fi
+    fi
+  done
+  summary="$(printf '%s' "$heuristic" | sed '/^$/d')"
+fi
+
+[ -n "$summary" ] || exit 0
+
+verb="created"
+printf '%s' "$command_line" | grep -Eq 'merge' && verb="merged"
+
+context="You just $verb a PR from this worktree, and it still owns attn profile(s):
+
+$summary
+
+If you are done with the profile, clean it up now:
+
+  attn profile clean <name>
+
+That reaps its pty-workers, stops its daemon, quits its app, and removes the app bundle and data dir. Skip this if you still need the profile (CI fixes, live verification, follow-up work) — but do not leave it running after the work is done: nothing else ever reaps it.
+
+Do not clean the default (production) profile."
+
+jq -n --arg ctx "$context" '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: $ctx
+  }
+}'
+exit 0

--- a/scripts/claude/attn-profile-nudge_test.sh
+++ b/scripts/claude/attn-profile-nudge_test.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Tests for the PR-milestone profile-cleanup nudge hook.
+#
+# The hook's whole value is that it stays silent unless there is something to
+# clean, so most of these assert silence. Run: bash scripts/claude/attn-profile-nudge_test.sh
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+hook="$script_dir/attn-profile-nudge.sh"
+
+pass=0
+fail=0
+
+# Each case runs the hook against a fake worktree, a fake `attn` whose
+# `profile list --json` returns a canned listing, and a synthetic hook payload.
+run_hook() {
+  local listing="$1" command_line="$2" tool_name="${3:-Bash}" success="${4:-true}" legacy="${5:-}"
+  local sandbox
+  sandbox="$(mktemp -d)"
+
+  git -C "$sandbox" init -q 2>/dev/null
+  cat >"$sandbox/attn" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "profile" ] && [ "\$2" = "list" ]; then
+  cat <<'LISTING'
+$listing
+LISTING
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$sandbox/attn"
+
+  local worktree
+  worktree="$(cd "$sandbox" && git rev-parse --show-toplevel)"
+  local payload
+  payload="$(jq -n \
+    --arg tool "$tool_name" --arg cmd "$command_line" --argjson ok "$success" \
+    '{tool_name: $tool, tool_input: {command: $cmd}, tool_response: {success: $ok}}')"
+
+  # Rewrite the listing's origin to the sandbox worktree so attribution matches.
+  local resolved
+  resolved="$(printf '%s' "$payload" | sed "s|__WORKTREE__|$worktree|g")"
+  local listing_resolved
+  listing_resolved="$(printf '%s' "$listing" | sed "s|__WORKTREE__|$worktree|g")"
+  cat >"$sandbox/attn" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "profile" ] && [ "\$2" = "list" ]; then
+  cat <<'LISTING'
+$listing_resolved
+LISTING
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$sandbox/attn"
+
+  # A profile that predates origin recording: a data dir under HOME with a
+  # registered session whose cwd is this worktree, and no origin.json.
+  if [ -n "$legacy" ]; then
+    local regdir="$sandbox/.attn-$legacy/workers/d-1/registry"
+    mkdir -p "$regdir"
+    printf '{\n  "session_id": "s1",\n  "cwd": "%s"\n}\n' "$worktree" >"$regdir/s1.json"
+    if [ "$legacy" = "attributed" ]; then
+      printf '{"worktree":"/elsewhere"}\n' >"$sandbox/.attn-$legacy/origin.json"
+    fi
+  fi
+
+  (cd "$sandbox" && printf '%s' "$resolved" | HOME="$sandbox" bash "$hook" 2>/dev/null)
+  local rc=$?
+  rm -rf "$sandbox"
+  return $rc
+}
+
+assert_silent() {
+  local name="$1" out
+  shift
+  out="$(run_hook "$@")"
+  if [ -z "$out" ]; then
+    pass=$((pass + 1))
+    printf '  ok   %s\n' "$name"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL %s — expected no output, got: %s\n' "$name" "$out"
+  fi
+}
+
+assert_nudges() {
+  local name="$1" expect="$2" out
+  shift 2
+  out="$(run_hook "$@")"
+  if printf '%s' "$out" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1 &&
+    printf '%s' "$out" | grep -qF "$expect"; then
+    pass=$((pass + 1))
+    printf '  ok   %s\n' "$name"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL %s — expected a nudge containing %q, got: %s\n' "$name" "$expect" "$out"
+  fi
+}
+
+owned_listing='{"profiles":[
+  {"profile":"","label":"default","hasData":true,"hasApp":true,"daemonRunning":true,"liveWorkers":9},
+  {"profile":"wily1","label":"wily1","hasData":true,"hasApp":true,"daemonRunning":true,"liveWorkers":2,
+   "origin":{"worktree":"__WORKTREE__","branch":"wily-raccoon","recordedAt":"2026-08-02T00:00:00Z"}}
+]}'
+
+foreign_listing='{"profiles":[
+  {"profile":"other","label":"other","hasData":true,"hasApp":true,"daemonRunning":true,"liveWorkers":3,
+   "origin":{"worktree":"/somewhere/else","branch":"other","recordedAt":"2026-08-02T00:00:00Z"}}
+]}'
+
+no_profiles_listing='{"profiles":[
+  {"profile":"","label":"default","hasData":true,"hasApp":true,"daemonRunning":true,"liveWorkers":9}
+]}'
+
+gone_listing='{"profiles":[
+  {"profile":"wily1","label":"wily1","hasData":false,"hasApp":false,"daemonRunning":false,"liveWorkers":0,
+   "origin":{"worktree":"__WORKTREE__","branch":"wily-raccoon","recordedAt":"2026-08-02T00:00:00Z"}}
+]}'
+
+echo "attn-profile-nudge:"
+
+# Fires on the milestones, naming the profile and what is still running.
+assert_nudges "nudges on gh pr create"  "wily1" "$owned_listing" "gh pr create --fill"
+assert_nudges "nudges on gh pr merge"   "wily1" "$owned_listing" "gh pr merge 123 --squash"
+assert_nudges "nudges on stack merge"   "wily1" "$owned_listing" "stack merge"
+assert_nudges "reports live workers"    "2 pty-worker(s)" "$owned_listing" "gh pr create"
+assert_nudges "says merged on a merge"  "merged a PR"     "$owned_listing" "gh pr merge 1"
+assert_nudges "says created on create"  "created a PR"    "$owned_listing" "gh pr create"
+assert_nudges "matches mid-pipeline"    "wily1" "$owned_listing" "cd /tmp && gh pr create --fill"
+
+# Silence is the default. Each of these would be noise.
+assert_silent "silent for other tools"        "$owned_listing" "gh pr create" "Read"
+assert_silent "silent for non-milestone gh"   "$owned_listing" "gh pr view 123"
+assert_silent "silent for gh pr checks"       "$owned_listing" "gh pr checks"
+assert_silent "silent for pr wait-ready"      "$owned_listing" "attn pr wait-ready 123"
+assert_silent "silent when command failed"    "$owned_listing" "gh pr create" "Bash" "false"
+assert_silent "silent when profile is foreign" "$foreign_listing" "gh pr create"
+assert_silent "silent with no owned profile"  "$no_profiles_listing" "gh pr create"
+assert_silent "silent when nothing installed" "$gone_listing" "gh pr create"
+assert_silent "never targets default profile" "$no_profiles_listing" "gh pr merge 1"
+assert_silent "silent on unrelated command"   "$owned_listing" "git commit -m 'gh pr create'"
+
+# Heuristic fallback: profiles created before origin recording existed are still
+# attributed, via a registered session whose cwd is this worktree.
+assert_nudges "heuristic finds legacy profile" "legacy" \
+  "$no_profiles_listing" "gh pr create" "Bash" "true" "legacy"
+assert_nudges "heuristic says origin missing"  "origin not recorded" \
+  "$no_profiles_listing" "gh pr create" "Bash" "true" "legacy"
+# A profile that already carries an origin pointing elsewhere is someone else's;
+# the heuristic must not claim it just because a session once ran here.
+assert_silent "heuristic skips attributed profile" \
+  "$no_profiles_listing" "gh pr create" "Bash" "true" "attributed"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## The bug

`attn profile clean` stopped the profile's daemon and then deleted its data dir.
Workers outlive a daemon on purpose — they are built to be re-adopted after a
restart — but the data dir holds the **registry they are found through**, so
every worker still alive at that moment was stranded permanently: no daemon
could ever adopt it, and nothing but a hand-written kill would reclaim it.

They accumulate invisibly at 10-20MB each. One sweep of a working machine found
16 such workers holding 216MB, the oldest almost seven days old, belonging to
three profiles that no longer existed.

## The fix

`clean` reaps before the registry goes. Workers are shut down over the
authenticated control socket the registry records — socket path, owning daemon
instance id, control token — so the reap is precise by construction and cannot
hit an unrelated process that inherited a recycled PID.

A worker whose socket is unreachable is signalled **only** when its argv still
identifies it as that registry entry's worker. Anything less certain is left
running and reported by PID for a human to judge, rather than killed on a guess:

```
  workers  3 registered (2 removed, 1 unidentified)
           ! session 8f9fb98d: pid 19891 could not be confirmed as its worker
             (dial unix …: connection refused); left running — check it with
             `ps -p 19891` and kill it yourself if it is stale
```

## Making the cleanup routine

A profile is cheap to create and invisible once made, and nothing reaps it on its
own. Two additions so this stops recurring:

**Provenance.** `make install PROFILE=<name>` and `make install-daemon
PROFILE=<name>` record the worktree they ran from in `<data-dir>/origin.json`.
Install is the only moment that link is known for certain — the build fingerprint
identifies source *content*, not the checkout. `attn profile list` shows it;
`attn profile list --json` adds branch, daemon liveness, and live worker count.
`attn profile set-origin` records one by hand. Cleaning a profile removes its
origin, so provenance never outlives the profile.

**A cleanup nudge.** `scripts/claude/attn-profile-nudge.sh` (wired in
`.claude/settings.json`) is a PostToolUse hook: after an agent creates or merges
a PR, it names any profile installed from that worktree and what is still running
under it. It stays silent unless there is something to clean, so agents that
never made a profile never see it. Attribution is exact via `origin.json`, with a
registry-cwd heuristic covering profiles that predate the record. Cost on the
common (non-matching) path is 8.2ms, behind a single-grep pre-filter.

`.gitignore` changes from `.claude/` to `.claude/*` + `!.claude/settings.json`:
git cannot re-include a file whose parent directory is excluded, and the shared
hook config needs to be tracked while local settings stay ignored.

## Verification

Live, end-to-end on throwaway profiles (`reapchk`, `hooklive`, `mkorigin`), all
cleaned up afterwards:

- `make install PROFILE=mkorigin` → `origin.json` recorded with worktree +
  branch, surfaced by `attn profile list`.
- Real daemon + spawned sessions → the hook, fed an actual `gh pr merge`
  PostToolUse payload, reported `mkorigin: daemon running, 1 pty-worker(s)
  [installed from wily-raccoon]`.
- `attn profile clean mkorigin` → `workers 1 registered (1 removed)`, the worker
  PID confirmed dead, app bundle and data dir gone, hook silent afterwards.

Automated: 20 hook tests, new Go tests for the reaper and the origin/list
surfaces, full Go suite green. `internal/ptyworker` compiles for Linux (verified
the cross type-check genuinely runs, not silently skipped).

Both safety properties were mutation-tested: disabling the identity gate turns
exactly the two "must not signal" tests red, and bypassing the control socket
turns the "removed" test red.

## Note on a flake found on the way

The first full-suite run failed a test that passed in isolation. Root cause was
in the new test helper, not the product: `sh -c 'sleep 60' marker` is
exec-optimized into bare `sleep 60`, dropping the marker from argv, so the
identity tests were winning a race rather than passing reliably. Fixed with a
trailing `; :`, then confirmed stable across 45 runs and under parallel load.
