### PR TITLE
fix(harness): refuse to drive input against a dark display

### DIFF
--- a/app/scripts/real-app-harness/AGENTS.md
+++ b/app/scripts/real-app-harness/AGENTS.md
@@ -2,6 +2,25 @@
 
 This policy applies to packaged-app scenarios in this directory.
 
+## The Display Must Be Awake
+
+Scenarios that drive input need a live display. Against a dark display or a
+locked screen the input still reaches the app, but the window-server work the
+app's handling depends on — menu-bar key equivalents, first responder,
+rendering — does not run, so some keystrokes take effect and others silently do
+nothing, and the run fails on a product assertion instead of on the display.
+
+`InputDriver.swift` refuses every input-posting command in that state and names
+which condition it found, so the failure describes itself. Read the same
+findings without touching the app via `driver.displayState()` (the driver's
+observation-only `display_state` command): `{ screenLocked, displayCount,
+asleepCount, blockReason }`.
+
+If a run fails on an assertion that looks like a product regression, check
+whether the display was awake before believing it — `pmset -g log | grep
+"Display is turned"` gives the history. A failed window screenshot in the
+failure artifacts is the same symptom wearing another hat.
+
 ## Profiles (which world a run targets)
 
 The harness honors the **one knob**, `ATTN_PROFILE`, like every other entrypoint

--- a/app/scripts/real-app-harness/InputDriver.swift
+++ b/app/scripts/real-app-harness/InputDriver.swift
@@ -6,6 +6,7 @@ enum DriverError: Error, CustomStringConvertible {
     case usage(String)
     case appNotRunning(String)
     case accessibilityDenied
+    case displayUnavailable(String)
     case invalidArgument(String)
     case eventCreationFailed(String)
 
@@ -17,6 +18,8 @@ enum DriverError: Error, CustomStringConvertible {
             return "App is not running for bundle id \(bundleId)"
         case .accessibilityDenied:
             return "Accessibility permission is required for the real app harness input driver."
+        case let .displayUnavailable(reason):
+            return "Input cannot be delivered: \(reason). Wake the display (and unlock the screen) before running packaged-app scenarios."
         case let .invalidArgument(message):
             return message
         case let .eventCreationFailed(message):
@@ -53,7 +56,7 @@ func parseOptions() throws -> Options {
     while index < args.count {
         let arg = args[index]
         switch arg {
-        case "activate", "activate_background", "frontmost", "windowid", "windowlist", "text", "key", "keycode", "click", "right_click", "drag", "menu", "window_park", "scroll":
+        case "activate", "activate_background", "frontmost", "display_state", "windowid", "windowlist", "text", "key", "keycode", "click", "right_click", "drag", "menu", "window_park", "scroll":
             options.command = arg
         case "--window-title":
             index += 1
@@ -159,6 +162,7 @@ func parseOptions() throws -> Options {
               InputDriver.swift activate [--bundle-id com.attn.manager]
               InputDriver.swift activate_background [--bundle-id ...]
               InputDriver.swift frontmost
+              InputDriver.swift display_state
               InputDriver.swift windowid [--bundle-id ...] [--window-title <substring>]
               InputDriver.swift windowlist [--bundle-id ...]
               InputDriver.swift text --text "hello" [--bundle-id ...] [--prompt-accessibility]
@@ -190,7 +194,7 @@ func parseOptions() throws -> Options {
     }
 
     guard options.command != nil else {
-        throw DriverError.usage("Missing command. Use activate, activate_background, frontmost, windowid, windowlist, text, key, keycode, click, or menu.")
+        throw DriverError.usage("Missing command. Use activate, activate_background, frontmost, display_state, windowid, windowlist, text, key, keycode, click, or menu.")
     }
 
     return options
@@ -292,6 +296,76 @@ func axPressMenuItem(bundleId: String, path: [String]) throws {
 
 func frontmostBundleIdentifier() -> String {
     NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? ""
+}
+
+// Whether synthetic input can be delivered right now, and if not, why. Printed
+// verbatim by the `display_state` command so a run can record what the display
+// was doing without anyone having to reproduce it.
+//
+// `CGSSessionScreenIsLocked` is the reading that actually moves: it goes true
+// the moment the display goes dark, well before any password grace period
+// expires, so it covers display-off and a truly locked screen alike.
+// `CGDisplayIsAsleep` was measured against `pmset displaysleepnow` on the
+// built-in display and never flips, so it cannot carry this on its own; it
+// stays as the signal for an external display that reports sleep properly.
+struct DisplayState {
+    var screenLocked: Bool
+    var displayCount: Int
+    var asleepCount: Int
+    var awakeCount: Int { displayCount - asleepCount }
+
+    var blockReason: String? {
+        if screenLocked { return "the screen is locked or the display is off" }
+        if displayCount == 0 { return "no display is active" }
+        // Any awake display is enough: the app's window lives on one of them,
+        // and a multi-display setup routinely sleeps the ones nobody is
+        // looking at.
+        if awakeCount == 0 { return "every display is asleep (\(displayCount))" }
+        return nil
+    }
+
+    var asJSON: [String: Any] {
+        [
+            "screenLocked": screenLocked,
+            "displayCount": displayCount,
+            "asleepCount": asleepCount,
+            "blockReason": blockReason ?? NSNull(),
+        ]
+    }
+}
+
+func readDisplayState() -> DisplayState {
+    let session = CGSessionCopyCurrentDictionary() as? [String: Any]
+    let locked = (session?["CGSSessionScreenIsLocked"] as? Bool) ?? false
+
+    var displayCount: UInt32 = 0
+    guard CGGetActiveDisplayList(0, nil, &displayCount) == .success, displayCount > 0 else {
+        return DisplayState(screenLocked: locked, displayCount: 0, asleepCount: 0)
+    }
+    var displays = [CGDirectDisplayID](repeating: 0, count: Int(displayCount))
+    guard CGGetActiveDisplayList(displayCount, &displays, &displayCount) == .success else {
+        return DisplayState(screenLocked: locked, displayCount: 0, asleepCount: 0)
+    }
+    let asleep = displays.prefix(Int(displayCount)).filter { CGDisplayIsAsleep($0) != 0 }.count
+    return DisplayState(screenLocked: locked, displayCount: Int(displayCount), asleepCount: asleep)
+}
+
+// A dark display accepts synthetic input without delivering it the way a live
+// session does: the event reaches the app, but the window-server work the app's
+// own handling depends on (menu-bar key equivalents, first responder,
+// rendering) does not run, so only some of a scenario's keystrokes take effect.
+// The scenario then fails on a product assertion that the product did not
+// break. Three TERMINAL-BLOCK-COPY runs failed exactly that way on 2026-08-02
+// between 22:31 and 22:35 local, inside a display-off window that `pmset -g log`
+// records as 22:21:57 to 22:48:33: ⇧⌘C copied, and ⌘C — the one the native
+// Edit > Copy item claims — silently did nothing, and the run could not capture
+// a window screenshot either. The same scenario is green on the same build with
+// the display awake. Refuse to post input instead of producing evidence nobody
+// can trust.
+func requireLiveDisplay() throws {
+    if let reason = readDisplayState().blockReason {
+        throw DriverError.displayUnavailable(reason)
+    }
 }
 
 func ensureAccessibility(prompt: Bool) throws {
@@ -807,6 +881,18 @@ func scrollWindow(
 do {
     let options = try parseOptions()
 
+    // Every command that posts synthetic input needs a live display, including
+    // `drag` (which never activates) and `activate` itself — failing on the
+    // scenario's first driver call is the clearest place to say so. AX-based
+    // and observation-only commands work fine against a sleeping display and
+    // are deliberately left alone.
+    switch options.command {
+    case "activate", "text", "key", "keycode", "click", "right_click", "scroll", "drag":
+        try requireLiveDisplay()
+    default:
+        break
+    }
+
     // HID-based commands must run against a frontmost app; AX-based and
     // observation-only commands must NOT activate (that is the whole point).
     switch options.command {
@@ -825,6 +911,9 @@ do {
         _ = try axApplication(bundleId: options.bundleId)
     case "frontmost":
         print(frontmostBundleIdentifier())
+    case "display_state":
+        let data = try JSONSerialization.data(withJSONObject: readDisplayState().asJSON, options: [.sortedKeys])
+        print(String(data: data, encoding: .utf8) ?? "{}")
     case "windowid":
         let wid = try mainWindowID(bundleId: options.bundleId, titleSubstring: options.windowTitle)
         print(wid)

--- a/app/scripts/real-app-harness/macosDriver.mjs
+++ b/app/scripts/real-app-harness/macosDriver.mjs
@@ -21,6 +21,19 @@ function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// First line of a driver failure: names the condition a human has to fix, so
+// the fix is visible without reading the driver's own message underneath.
+// Pure so it can be unit-tested without spawning the compiled driver binary.
+export function describeInputDriverFailure(stderr = '') {
+  if (stderr.includes('Accessibility permission is required')) {
+    return 'Grant Accessibility access to the attn real-app input driver when macOS prompts, then rerun the harness.';
+  }
+  if (stderr.includes('Input cannot be delivered')) {
+    return 'The display was off or the screen was locked, so input could not be delivered. This is not a product failure — wake the display and rerun.';
+  }
+  return 'macOS automation failed.';
+}
+
 // Appends `--window-title <substring>` when opts.windowTitle is set, so
 // callers can target a secondary Tauri window (e.g. "attn — present") that
 // Accessibility never enumerates. Pure so it can be unit-tested without
@@ -83,6 +96,15 @@ export class MacOSDriver {
 
   async frontmostBundleId() {
     return this.runInputDriverCapture(['frontmost']);
+  }
+
+  // Whether a scenario's synthetic input can actually be delivered right now:
+  // `{ screenLocked, displayCount, asleepCount, blockReason }`, where a
+  // non-null blockReason is the same sentence the driver refuses input with.
+  // Observation-only — reading it never activates the app and works fine while
+  // the display is off, which is the point.
+  async displayState() {
+    return JSON.parse(await this.runInputDriverCapture(['display_state']));
   }
 
   // Returns the CGWindowID of the driver's bundle's largest layer-0 onscreen
@@ -323,9 +345,7 @@ export class MacOSDriver {
       });
     } catch (error) {
       const stderr = error?.stderr?.toString?.() || '';
-      const hint = stderr.includes('Accessibility permission is required')
-        ? 'Grant Accessibility access to the attn real-app input driver when macOS prompts, then rerun the harness.'
-        : 'macOS automation failed.';
+      const hint = describeInputDriverFailure(stderr);
       throw new Error(`${hint}\n${stderr || error.message}`);
     }
   }

--- a/app/scripts/real-app-harness/macosDriver.test.mjs
+++ b/app/scripts/real-app-harness/macosDriver.test.mjs
@@ -1,5 +1,26 @@
 import { describe, expect, it } from 'vitest';
-import { withWindowTitleArgs } from './macosDriver.mjs';
+import { describeInputDriverFailure, withWindowTitleArgs } from './macosDriver.mjs';
+
+describe('describeInputDriverFailure', () => {
+  it('names a dark display as the cause, and says it is not the product', () => {
+    const hint = describeInputDriverFailure(
+      '[RealAppHarness] Input cannot be delivered: the screen is locked or the display is off. Wake the display (and unlock the screen) before running packaged-app scenarios.',
+    );
+    expect(hint).toContain('display was off');
+    expect(hint).toContain('not a product failure');
+  });
+
+  it('still names the accessibility grant when that is what failed', () => {
+    expect(
+      describeInputDriverFailure('[RealAppHarness] Accessibility permission is required for the real app harness input driver.'),
+    ).toContain('Grant Accessibility access');
+  });
+
+  it('falls back to the generic hint for anything else', () => {
+    expect(describeInputDriverFailure('[RealAppHarness] App is not running for bundle id x')).toBe('macOS automation failed.');
+    expect(describeInputDriverFailure()).toBe('macOS automation failed.');
+  });
+});
 
 describe('withWindowTitleArgs', () => {
   it('returns the input args unchanged when no windowTitle is given', () => {

--- a/changelog.d/dim-heron-harness-refuses-a-dark-display.yaml
+++ b/changelog.d/dim-heron-harness-refuses-a-dark-display.yaml
@@ -1,0 +1,27 @@
+kind: fixed
+area: harness
+change: >
+  The packaged-app harness input driver now refuses to post synthetic input
+  while the display is off or the screen is locked, and says which of the two it
+  found. A new observation-only `display_state` command (`driver.displayState()`)
+  reports the same readings without touching the app.
+symptom: >
+  A scenario run against a dark display failed on a product assertion instead of
+  on the display. Input still reaches the app, but the window-server work the
+  app's handling depends on — menu-bar key equivalents, first responder,
+  rendering — does not run, so some keystrokes take effect and others silently
+  do nothing. Three TERMINAL-BLOCK-COPY runs failed this way and read as a
+  regression in terminal block copy: Cmd+Shift+C copied the command, Cmd+C
+  copied nothing, and the failure artifacts could not capture a window
+  screenshot either. The same scenario is green on the same build with the
+  display awake. Disproving it cost a full baseline build of the default branch.
+notes: >
+  `CGSSessionScreenIsLocked` is the reading that moves: it goes true the moment
+  the display goes dark, well before any password grace period expires.
+  `CGDisplayIsAsleep` was measured against `pmset displaysleepnow` on the
+  built-in display and never flips, so it cannot carry the check alone and stays
+  only as the signal for an external display that reports sleep properly. The
+  guard covers every command that posts synthetic input, including `drag` (which
+  never activates) and `activate` itself, so a scenario fails on its first
+  driver call. AX-based and observation-only commands work fine against a dark
+  display and are deliberately left alone.


### PR DESCRIPTION
Terminal block copy is not broken. This makes the harness stop saying it is.

## What happened

Three `TERMINAL-BLOCK-COPY` runs failed on 2026-08-02 with a clean, plausible product signature: inside one step, `Cmd+Shift+C` copied the command to the real clipboard, and `Cmd+C` — the shortcut the native Edit > Copy item claims — left the sentinel untouched. That reads as a regression in the plain-`Cmd+C` copy path.

It was not one. All three runs fall inside a display-off window that `pmset -g log` records as 22:21:57 to 22:48:33 local; the runs were at 22:31:57, 22:33:03, and 22:34:49. Every one of them also failed to capture a window screenshot for its failure artifacts, which is the same condition wearing another hat. With the display awake, the same scenario is green on the same build — verified four times, including once with attn deliberately not the frontmost app.

Against a dark display or a locked screen the input still reaches the app, but the window-server work the app's own handling depends on — menu-bar key equivalents, first responder, rendering — does not run. Some keystrokes take effect and others silently do nothing, so a scenario fails on a product assertion the product did not break.

Disproving it cost a full baseline build of the default branch. That is the cost this change removes.

## The guard

`InputDriver.swift` now refuses every command that posts synthetic input and names which condition it found:

```
Input cannot be delivered: the screen is locked or the display is off.
Wake the display (and unlock the screen) before running packaged-app scenarios.
```

It covers `drag` (which never activates) and `activate` itself, so a scenario fails on its first driver call rather than partway through a step. AX-based and observation-only commands work fine against a dark display and are deliberately left alone.

A driver failure's first line now names a dark display as the cause and says it is not a product failure, next to the existing Accessibility-grant hint.

## The reading

`CGSSessionScreenIsLocked` is the one that moves. It goes true the moment the display goes dark, well before any password grace period expires, so it covers display-off and a genuinely locked screen alike.

`CGDisplayIsAsleep` was measured against `pmset displaysleepnow` on the built-in display and never flips — sampling across the transition showed `asleepCount: 0` throughout while `screenLocked` went true. It cannot carry the check on its own, and stays only as the signal for an external display that reports sleep properly. The comment at the call site records that measurement so the next reader does not reach for it.

## Seeing it without reproducing it

A new observation-only `display_state` command, reached as `driver.displayState()`, returns `{ screenLocked, displayCount, asleepCount, blockReason }` — the same readings the guard decides on, with `blockReason` being the exact sentence it would refuse with. Reading it never activates the app and works while the display is off, which is the point.

## Verification

Live on an isolated packaged-app profile at this head:

- With the display slept via `pmset displaysleepnow`, four consecutive `key --key c --modifiers command,shift` calls all exited 1 with the named reason (three caught `screenLocked`, one caught the `no display is active` transition). Before this change the same calls exited 0 and posted the keystroke.
- With the display awake, `TERMINAL-BLOCK-COPY` and `WORKSPACE-SWITCHING` both pass, `failureCount: 0` — the guard produces no false positives on the paths that use keys, clicks, and activation.
- `display_state` reports `blockReason: null` while awake.

`describeInputDriverFailure` is unit-tested and was mutated to confirm the tests are falsifiable: disabling the dark-display branch reddens exactly the one test that asserts it, and nothing else. All 185 harness unit tests pass.
