### PR TITLE
feat(annotations): send with a key, edit from the panel, find the way out

### DIFF
--- a/app/scripts/real-app-harness/scenario-terminal-annotations.mjs
+++ b/app/scripts/real-app-harness/scenario-terminal-annotations.mjs
@@ -25,6 +25,7 @@ import {
   relaunchAppAndConnect,
 } from './common.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { MacOSDriver } from './macosDriver.mjs';
 import { DaemonObserver } from './daemonObserver.mjs';
 import {
   captureSessionArtifacts,
@@ -254,6 +255,10 @@ async function main() {
 
   const client = new UiAutomationClient({ appPath: options.appPath });
   const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  // ⌘Enter is delivered by the page's keydown listener, and whether it reaches
+  // that listener at all — rather than being eaten by AppKit or handed to the
+  // PTY — is the part only a real keystroke into the packaged app can show.
+  const driver = new MacOSDriver({ appPath: options.appPath });
   let sessionId = null;
   let paneId = null;
   // What the agent said, and where it sits on the grid. Carried through the
@@ -439,13 +444,71 @@ async function main() {
       );
     });
 
-    await runner.step('send_types_it_and_tombstones_it', async () => {
+    // The panel is the list of what you wrote, so a row in it is clicked to
+    // change what it says — and once it says something, the control that
+    // removes it has to still be on the row rather than pushed below it.
+    await runner.step('a_panel_row_opens_its_editor_and_keeps_its_remove_control', async () => {
       // Close the popup the previous step opened; a press outside is how a
       // user dismisses it, and it must not disturb a labelled annotation.
       await client.request('dom_click', { selector: '[data-testid="annotation-panel"] .anno-panel-title' });
       await sleep(300);
 
-      await client.request('dom_click', { selector: '.anno-panel-send' });
+      await client.request('dom_click', { selector: '.anno-card-open' });
+      const opened = await pollFor(
+        async () => {
+          const state = await client.request('get_annotation_state', {});
+          return state.popupOpen && state.popupDraft !== null ? state : null;
+        },
+        'the panel row to open its comment editor',
+        5_000,
+      );
+      runner.assert(
+        opened.commentFocused,
+        'The editor opened without the caret in its comment box, so the next sentence typed goes to the PTY',
+      );
+
+      const comment = 'checked against the real behaviour';
+      await client.request('dom_type', { selector: '.anno-popup-text', text: comment });
+      await client.request('dom_click', { selector: '.anno-popup-save' });
+
+      const withComment = await pollFor(
+        async () => {
+          const state = await client.request('get_annotation_state', {});
+          return state.annotations?.[0]?.comment === comment ? state : null;
+        },
+        'the comment to land on the panel row',
+        5_000,
+      );
+      const [row] = withComment.annotations;
+      runner.assert(
+        row.rect && row.removeRect,
+        `Panel row reported no geometry: ${JSON.stringify(row)}`,
+      );
+      // A comment wraps inside the row. The remove control must still start on
+      // the row's first line — it used to be auto-placed after the comment,
+      // which put it on a line of its own exactly when there was text to
+      // remove. 12px is a tripwire, not a measurement of the real 5px offset.
+      const offset = row.removeRect.top - row.rect.top;
+      runner.assert(
+        offset <= 12,
+        `The remove control starts ${offset}px below the row's top, so a commented row pushed it onto its own line `
+        + `(row ${JSON.stringify(row.rect)}, control ${JSON.stringify(row.removeRect)})`,
+      );
+      runner.assert(
+        row.removeRect.left + row.removeRect.width <= row.rect.left + row.rect.width + 1,
+        `The remove control overflows its row: ${JSON.stringify(row.removeRect)} vs ${JSON.stringify(row.rect)}`,
+      );
+      // Leave the surface as the user would: nothing open over the panel.
+      await client.request('dom_click', { selector: '[data-testid="annotation-panel"] .anno-panel-title' });
+      await sleep(300);
+    });
+
+    await runner.step('send_shortcut_types_it_and_tombstones_it', async () => {
+      // A real ⌘Return, not the button: the button is a click handler any unit
+      // test can drive, while the keystroke has to survive AppKit, reach the
+      // page's capture-phase listener, and be claimed by this pane instead of
+      // going to the PTY.
+      await driver.pressKeyCode(36, { command: true });
       const sent = await pollFor(
         async () => {
           const state = await client.request('get_annotation_state', {});

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -1011,6 +1011,10 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
                   sessionId={agentPane.sessionId}
                   sessionState={paneSession?.state}
                   annotationApi={annotationApi}
+                  // Gates the annotation send shortcut. The focused leaf of the
+                  // visible session, so ⌘Enter belongs to at most one pane and
+                  // stays with the PTY everywhere else.
+                  paneActive={isActiveSession && sessionVisible && activeLeafId === agentPane.id}
                   onSubmitAnnotations={(text) => {
                     // Bracketed paste, not a plain write: the payload is
                     // multi-line, and without the guard every newline submits

--- a/app/src/components/TerminalAnnotations/AnnotatedTerminal.annotate.test.tsx
+++ b/app/src/components/TerminalAnnotations/AnnotatedTerminal.annotate.test.tsx
@@ -28,10 +28,21 @@ interface CapturedProps {
 }
 
 let terminal: CapturedProps = {};
+// The surface calls focus() on the terminal handle to hand the keyboard back.
+// A real handle rather than a spy on the DOM node: that is the seam the
+// component uses, and the count is what proves focus was returned exactly when
+// it should be.
+let terminalFocusCalls = 0;
 
 vi.mock('../GhosttyTerminal', () => ({
-  GhosttyTerminal: React.forwardRef(function MockTerminal(props: CapturedProps, _ref: React.Ref<unknown>) {
+  GhosttyTerminal: React.forwardRef(function MockTerminal(props: CapturedProps, ref: React.Ref<unknown>) {
     terminal = props;
+    React.useImperativeHandle(ref, () => ({
+      focus: () => {
+        terminalFocusCalls += 1;
+        return true;
+      },
+    }), []);
     return <div data-testid="terminal" />;
   }),
 }));
@@ -102,12 +113,14 @@ function props(overrides: {
   state?: UISessionState;
   api?: SessionAnnotationApi;
   submit?: (text: string) => void;
+  paneActive?: boolean;
 }) {
   return {
     sessionId: 'session-1',
     sessionState: overrides.state ?? ('idle' as UISessionState),
     annotationApi: overrides.api,
     onSubmitAnnotations: overrides.submit,
+    paneActive: overrides.paneActive ?? false,
     fontSize: 13,
     debugName: 'test',
     onInput: () => {},
@@ -120,13 +133,19 @@ function renderTerminal(overrides: {
   state?: UISessionState;
   api?: FakeAnnotationDaemon;
   submit?: (text: string) => void;
+  paneActive?: boolean;
 } = {}) {
   const daemon = overrides.api ?? new FakeAnnotationDaemon();
   const submit = overrides.submit ?? vi.fn();
   const view = render(<AnnotatedTerminal {...props({ ...overrides, api: daemon, submit })} />);
-  const rerender = (next: { state?: UISessionState } = {}) =>
+  const rerender = (next: { state?: UISessionState; paneActive?: boolean } = {}) =>
     view.rerender(
-      <AnnotatedTerminal {...props({ state: next.state ?? overrides.state, api: daemon, submit })} />,
+      <AnnotatedTerminal {...props({
+        state: next.state ?? overrides.state,
+        paneActive: next.paneActive ?? overrides.paneActive,
+        api: daemon,
+        submit,
+      })} />,
     );
   return { ...view, rerender, daemon, submit };
 }
@@ -155,8 +174,20 @@ function stored() {
   return terminal.annotations?.list() ?? [];
 }
 
+/** The panel row for the nth annotation, and its two controls. */
+function card(index = 0) {
+  const cards = document.querySelectorAll('.anno-card');
+  const node = cards[index] as HTMLElement;
+  return {
+    node,
+    open: node.querySelector('.anno-card-open') as HTMLElement,
+    remove: node.querySelector('.anno-card-remove') as HTMLElement,
+  };
+}
+
 beforeEach(() => {
   terminal = {};
+  terminalFocusCalls = 0;
 });
 
 afterEach(() => {
@@ -432,6 +463,185 @@ describe('AnnotatedTerminal', () => {
 
     expect(stored()).toHaveLength(0);
     expect(screen.queryByTestId('annotation-panel')).toBeNull();
+  });
+
+  it('keeps the panel row\'s remove control beside the row, not below it', async () => {
+    // A row is two controls side by side. The earlier layout nested the remove
+    // button inside the clickable row and let the grid auto-place it after a
+    // comment that spanned the row, which dropped it onto a line of its own the
+    // moment an annotation carried text.
+    renderTerminal();
+    await windowReady('turn-1');
+
+    anchor('turn-1', 0, 26);
+    fireEvent.click(screen.getByLabelText('Write a comment'));
+    fireEvent.change(screen.getByPlaceholderText('What should change here?'), {
+      target: { value: 'long enough to wrap onto its own line in the row' },
+    });
+    fireEvent.click(screen.getByText('Comment'));
+
+    const { node, open, remove } = card();
+    expect(open).toBeTruthy();
+    expect(remove.parentElement).toBe(node);
+    // The comment lives inside the row's own control, so it can never be a
+    // sibling the remove button has to be placed around.
+    expect(open.querySelector('.anno-card-comment')).toBeTruthy();
+  });
+
+  it('opens the editor when a panel row is clicked, even for a bare reaction', async () => {
+    // A row in a list of what you wrote is clicked to change what it says. A
+    // reaction-only annotation used to reopen into the icon row alone, which
+    // answers a question nobody asked at that moment.
+    renderTerminal();
+    await windowReady('turn-1');
+
+    anchor('turn-1', 0, 26);
+    fireEvent.click(screen.getByLabelText('Verify this'));
+
+    fireEvent.click(card().open);
+
+    const box = screen.getByPlaceholderText('What should change here?') as HTMLTextAreaElement;
+    expect(box.value).toBe('');
+    expect(document.activeElement).toBe(box);
+  });
+
+  it('puts the caret after a prefilled comment rather than at its start', async () => {
+    renderTerminal();
+    await windowReady('turn-1');
+
+    anchor('turn-1', 0, 26);
+    fireEvent.click(screen.getByLabelText('Write a comment'));
+    fireEvent.change(screen.getByPlaceholderText('What should change here?'), {
+      target: { value: 'first take' },
+    });
+    fireEvent.click(screen.getByText('Comment'));
+
+    fireEvent.click(card().open);
+
+    const box = screen.getByPlaceholderText('What should change here?') as HTMLTextAreaElement;
+    expect(document.activeElement).toBe(box);
+    expect(box.selectionStart).toBe('first take'.length);
+  });
+
+  it('removes the annotation from the open editor by name', async () => {
+    // The way out of a comment cannot be an emoji in a row of eight other
+    // emoji; from the editor it is a named button.
+    renderTerminal();
+    await windowReady('turn-1');
+
+    anchor('turn-1', 0, 26);
+    fireEvent.click(screen.getByLabelText('Write a comment'));
+    fireEvent.change(screen.getByPlaceholderText('What should change here?'), {
+      target: { value: 'wrong on reflection' },
+    });
+    fireEvent.click(screen.getByText('Comment'));
+
+    fireEvent.click(card().open);
+    fireEvent.click(screen.getByText('Remove'));
+
+    expect(stored()).toHaveLength(0);
+    expect(screen.queryByTestId('annotation-popup')).toBeNull();
+  });
+
+  it('hands the keyboard back to the terminal when the editor closes', async () => {
+    // The surface borrowed focus from the grid; leaving it typing into nothing
+    // is what makes an overlay feel like a trap.
+    renderTerminal();
+    await windowReady('turn-1');
+
+    anchor('turn-1', 0, 26);
+    fireEvent.click(screen.getByLabelText('Write a comment'));
+    const box = screen.getByPlaceholderText('What should change here?');
+    expect(document.activeElement).toBe(box);
+    fireEvent.change(box, { target: { value: 'say this' } });
+
+    terminalFocusCalls = 0;
+    fireEvent.click(screen.getByText('Comment'));
+    expect(terminalFocusCalls).toBe(1);
+
+    fireEvent.click(card().open);
+    terminalFocusCalls = 0;
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(terminalFocusCalls).toBe(1);
+  });
+
+  it('leaves focus alone when the press that closed the popup landed elsewhere', async () => {
+    // That press decides where focus goes — including a press on another row of
+    // the panel, which is about to open this same popup on a different mark.
+    renderTerminal();
+    await windowReady('turn-1');
+
+    anchor('turn-1', 0, 26);
+    fireEvent.click(screen.getByLabelText('Verify this'));
+    anchor('turn-1', 31, 55);
+    fireEvent.click(screen.getByLabelText('Needs tests'));
+
+    fireEvent.click(card(0).open);
+    terminalFocusCalls = 0;
+    fireEvent.mouseDown(card(1).open);
+
+    expect(terminalFocusCalls).toBe(0);
+  });
+
+  it('sends the set on the send shortcut while the pane holds focus', async () => {
+    const submit = vi.fn();
+    renderTerminal({ submit, paneActive: true });
+    await windowReady('turn-1');
+
+    anchor('turn-1', 0, 26);
+    fireEvent.click(screen.getByLabelText('Verify this'));
+
+    fireEvent.keyDown(window, { key: 'Enter', metaKey: true });
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(submit.mock.calls[0][0]).toContain(TURN_1.slice(0, 26));
+    expect(stored()).toHaveLength(0);
+  });
+
+  it('commits the comment being typed when the send shortcut fires', async () => {
+    // Half-written feedback is still what the user meant to say; dropping it on
+    // the way out would be silent data loss.
+    const submit = vi.fn();
+    renderTerminal({ submit, paneActive: true });
+    await windowReady('turn-1');
+
+    anchor('turn-1', 0, 26);
+    fireEvent.click(screen.getByLabelText('Write a comment'));
+    fireEvent.change(screen.getByPlaceholderText('What should change here?'), {
+      target: { value: 'still typing this' },
+    });
+
+    fireEvent.keyDown(window, { key: 'Enter', metaKey: true });
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(submit.mock.calls[0][0]).toContain('still typing this');
+  });
+
+  it('leaves the send keystroke to the PTY when the pane is not the focused one', async () => {
+    // Registration is the gate: the dispatcher consumes ⌘Enter whenever a
+    // handler exists, so a pane that is merely mounted must not register one.
+    const submit = vi.fn();
+    renderTerminal({ submit, paneActive: false });
+    await windowReady('turn-1');
+
+    anchor('turn-1', 0, 26);
+    fireEvent.click(screen.getByLabelText('Verify this'));
+
+    fireEvent.keyDown(window, { key: 'Enter', metaKey: true });
+
+    expect(submit).not.toHaveBeenCalled();
+    expect(stored()).toHaveLength(1);
+  });
+
+  it('leaves the send keystroke to the PTY when there is nothing to send', async () => {
+    const submit = vi.fn();
+    const { rerender } = renderTerminal({ submit, paneActive: true });
+    await windowReady('turn-1');
+    rerender({ paneActive: true });
+
+    fireEvent.keyDown(window, { key: 'Enter', metaKey: true });
+
+    expect(submit).not.toHaveBeenCalled();
   });
 
   it('offers no annotation surface when the session cannot be sent to', async () => {

--- a/app/src/components/TerminalAnnotations/AnnotatedTerminal.tsx
+++ b/app/src/components/TerminalAnnotations/AnnotatedTerminal.tsx
@@ -25,6 +25,8 @@ import {
 } from '../../utils/terminalAnnotations';
 import { QUICK_LABELS, buildAnnotationPayload } from './quickLabels';
 import { clampToViewport, placePopup, type Placement } from './placement';
+import { useShortcut } from '../../shortcuts/useShortcut';
+import { formatShortcut } from '../../shortcuts/formatShortcut';
 import type { UISessionState } from '../../types/sessionState';
 import './TerminalAnnotations.css';
 
@@ -71,21 +73,26 @@ export interface AnnotatedTerminalProps extends TerminalProps {
   // Types the composed feedback into the session. Absent disables sending, so
   // the surface is never offered when there is nowhere for it to go.
   onSubmitAnnotations?: (text: string) => void;
+  // Whether this pane is the focused leaf of the visible session. Gates the
+  // send shortcut's *registration*: the dispatcher consumes ⌘Enter whenever a
+  // handler exists for it, so registering from every mounted pane would eat the
+  // keystroke in whichever pane the user is actually typing in.
+  paneActive?: boolean;
 }
 
 interface Composer {
   annotationId: string;
   clientX: number;
   clientY: number;
-  // The comment box only opens on 💬 or on reopening an annotation that has
-  // one; the label row alone is a one-click gesture and must not be buried
-  // under a textarea.
+  // The comment box only opens on 💬, on reopening an annotation that has one,
+  // or on a click in the panel; the label row alone is a one-click gesture and
+  // must not be buried under a textarea.
   writing: boolean;
 }
 
 export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerminalProps>(
   function AnnotatedTerminal(
-    { sessionId, sessionState, annotationApi, onSubmitAnnotations, ...terminalProps },
+    { sessionId, sessionState, annotationApi, onSubmitAnnotations, paneActive = false, ...terminalProps },
     ref,
   ) {
     // Built once. A `useRef(new TerminalAnnotationStore())` would construct a
@@ -113,6 +120,16 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
     // one as stale.
     const generationRef = useRef(0);
     const enabled = Boolean(annotationApi && onSubmitAnnotations);
+
+    // The surface borrows the keyboard from the terminal and has to give it
+    // back, so it keeps its own handle on the terminal alongside whatever the
+    // owner asked for.
+    const terminalRef = useRef<GhosttyTerminalHandle | null>(null);
+    const attachTerminal = useCallback((handle: GhosttyTerminalHandle | null) => {
+      terminalRef.current = handle;
+      if (typeof ref === 'function') ref(handle);
+      else if (ref) (ref as React.MutableRefObject<GhosttyTerminalHandle | null>).current = handle;
+    }, [ref]);
 
     const bump = useCallback(() => setVersion((value) => value + 1), []);
 
@@ -185,16 +202,21 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
       };
     }, [annotationApi, bump, enabled, sessionId, sessionState, store]);
 
-    const closeComposer = useCallback(() => {
+    // Closing the popup hands the keyboard back to the terminal: the user came
+    // from the grid, and the next thing they type is meant for the agent. The
+    // one exception is a press that deliberately lands somewhere else — that
+    // press owns where focus goes, and yanking it back would fight the click.
+    const closeComposer = useCallback((restoreFocus = true) => {
       setComposer(null);
       setPopupAt(null);
       setDraft('');
+      if (restoreFocus) terminalRef.current?.focus();
     }, []);
 
     // A highlight with neither a label nor a comment says nothing, so dismissing
     // the popup without choosing either removes it rather than leaving a blank
     // wash on the message.
-    const dismissComposer = useCallback(() => {
+    const dismissComposer = useCallback((restoreFocus = true) => {
       const current = composer;
       if (current) {
         const annotation = store.list().find((entry) => entry.id === current.annotationId);
@@ -204,7 +226,7 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
           bump();
         }
       }
-      closeComposer();
+      closeComposer(restoreFocus);
     }, [bump, closeComposer, composer, persist, store]);
 
     const handleAnchor = useCallback(
@@ -222,8 +244,16 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
     // Reopening an annotation already made. Its comment becomes the draft, and
     // a comment-carrying annotation opens straight into the editor: the user
     // clicked it to change what it says, not to hunt for the box.
+    //
+    // `writing` forces the editor open regardless. The panel passes it: a row in
+    // a list of what you wrote is clicked to edit it, and offering a bare row of
+    // reaction emoji there answers a question nobody asked.
     const openAnnotation = useCallback(
-      (annotationId: string, at: { clientX: number; clientY: number }) => {
+      (
+        annotationId: string,
+        at: { clientX: number; clientY: number },
+        options?: { writing?: boolean },
+      ) => {
         const annotation = store.list().find((entry) => entry.id === annotationId);
         if (!annotation) return;
         setDraft(annotation.comment);
@@ -232,10 +262,10 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
           annotationId,
           clientX: at.clientX,
           clientY: at.clientY,
-          writing: Boolean(annotation.comment),
+          writing: options?.writing || Boolean(annotation.comment),
         });
       },
-      [],
+      [store],
     );
 
     useEffect(() => {
@@ -257,7 +287,9 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
       if (!composer) return;
       const onDown = (event: MouseEvent) => {
         if (popupRef.current?.contains(event.target as Node)) return;
-        dismissComposer();
+        // The press decides where focus lands — including a press in the panel
+        // that is about to open this popup again on another annotation.
+        dismissComposer(false);
       };
       window.addEventListener('mousedown', onDown, true);
       return () => window.removeEventListener('mousedown', onDown, true);
@@ -277,8 +309,15 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
       ));
     }, [composer]);
 
+    // The box is the only reason the editor opened, so it takes the keyboard as
+    // it appears. The caret goes to the end: reopening a comment is for adding
+    // to what is there, and a focus() alone would leave it at the top.
     useEffect(() => {
-      if (composer?.writing) commentRef.current?.focus();
+      if (!composer?.writing) return;
+      const box = commentRef.current;
+      if (!box) return;
+      box.focus();
+      box.setSelectionRange(box.value.length, box.value.length);
     }, [composer?.writing, composer?.annotationId]);
 
     const annotations = store.list();
@@ -307,15 +346,25 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
       closeComposer();
     };
 
-    const removeAnnotation = (id: string) => {
+    // `restoreFocus` false for the panel's own remove: the user is working down
+    // a list and the next click is another row, not the terminal.
+    const removeAnnotation = (id: string, restoreFocus = true) => {
       store.remove(id);
-      if (composer?.annotationId === id) closeComposer();
+      if (composer?.annotationId === id) closeComposer(restoreFocus);
       persist();
       bump();
     };
 
-    const reopen = (annotation: TerminalAnnotation, event: React.MouseEvent) => {
-      openAnnotation(annotation.id, { clientX: event.clientX, clientY: event.clientY });
+    const reopen = (annotation: TerminalAnnotation, at: { clientX: number; clientY: number }) => {
+      openAnnotation(annotation.id, at, { writing: true });
+    };
+
+    // Where a popup opened from the panel points. The card's own top edge, not
+    // the pointer: a row is clicked anywhere along its width, and an editor that
+    // lands in a different place each time reads as a different thing.
+    const reopenFromCard = (annotation: TerminalAnnotation, event: React.MouseEvent) => {
+      const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+      reopen(annotation, { clientX: rect.left + rect.width / 2, clientY: rect.top });
     };
 
     // The panel is dragged by its header. It starts pinned to a corner and only
@@ -332,14 +381,31 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
 
     const send = () => {
       if (annotations.length === 0 || !onSubmitAnnotations) return;
-      const payload = buildAnnotationPayload(annotations.map((entry) => ({
+      // A comment being typed when the send fires is part of what the user
+      // means to say, so commit it rather than dropping it on the floor.
+      if (composed && composer?.writing) {
+        const comment = draft.trim();
+        store.update(composed.id, { comment });
+        if (!comment && !composed.emoji) store.remove(composed.id);
+      }
+      // Re-read after that commit rather than reusing the render's list, which
+      // predates it. Committing an emptied comment can leave nothing to send;
+      // that is still a mutation the daemon has to hear about.
+      const sending = store.list();
+      if (sending.length === 0) {
+        persist();
+        closeComposer();
+        bump();
+        return;
+      }
+      const payload = buildAnnotationPayload(sending.map((entry) => ({
         quote: entry.quote,
         emoji: entry.emoji,
         comment: entry.comment,
         start: entry.start,
       })));
       onSubmitAnnotations(payload);
-      setSentCount(annotations.length);
+      setSentCount(sending.length);
       store.clear();
       closeComposer();
       bump();
@@ -357,6 +423,20 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
           });
       }
     };
+
+    // ⌘Enter sends the set without reaching for the panel — the gesture that
+    // made the marks was keyboard-adjacent and so is the one that spends them.
+    //
+    // Registration-gated, not handler-gated: the dispatcher consumes the
+    // keystroke whenever a handler is registered, so an always-on no-op would
+    // swallow the terminal's ⌘Enter in every pane that has none waiting. The
+    // def's `editableTarget: 'native'` additionally keeps it out of the comment
+    // box, where ⌘Enter already means "commit this comment".
+    useShortcut(
+      'terminal.sendAnnotations',
+      send,
+      enabled && paneActive && annotations.length > 0,
+    );
 
     // The confirmation replaces the panel's footer rather than a toast, and only
     // for as long as it takes to read: the panel is where the user was looking.
@@ -414,7 +494,7 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
       <>
         <GhosttyTerminal
           {...terminalProps}
-          ref={ref}
+          ref={attachTerminal}
           annotations={enabled ? store : undefined}
           annotationsVersion={version}
           onAnnotationAnchor={enabled ? handleAnchor : undefined}
@@ -453,6 +533,9 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
               >
                 💬
               </button>
+              {/* Tinted at rest rather than only on hover: sat among eight
+                  reaction emoji, an untinted glyph reads as a ninth reaction
+                  and the way back out of an annotation stays unfindable. */}
               <button
                 type="button"
                 className="anno-popup-label anno-popup-label--delete"
@@ -483,7 +566,18 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
                   }}
                 />
                 <div className="anno-popup-actions">
-                  <button type="button" className="anno-popup-cancel" onClick={dismissComposer}>
+                  {/* Named, not a glyph. Removing what you wrote is the second
+                      thing anyone wants from an open comment, and it should not
+                      cost a hunt through the icon row above. */}
+                  <button
+                    type="button"
+                    className="anno-popup-remove"
+                    onClick={() => removeAnnotation(composed.id)}
+                  >
+                    Remove
+                  </button>
+                  <span className="anno-popup-actions-gap" />
+                  <button type="button" className="anno-popup-cancel" onClick={() => dismissComposer()}>
                     Cancel
                   </button>
                   <button type="button" className="anno-popup-save" onClick={saveComment}>
@@ -507,29 +601,33 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
               <span className="anno-panel-count">{annotations.length}</span>
             </div>
             <div className="anno-panel-body">
+              {/* The row is two buttons side by side rather than a button
+                  nested in a clickable div: the remove control then sits in its
+                  own grid track instead of being auto-placed after a
+                  comment that spans the row — which is what pushed it onto a
+                  line of its own whenever an annotation carried text. */}
               {annotations.map((annotation) => (
-                <div
-                  key={annotation.id}
-                  className="anno-card"
-                  role="button"
-                  tabIndex={0}
-                  onClick={(event) => reopen(annotation, event)}
-                >
-                  <span className="anno-card-chip">
-                    {annotation.emoji || '💬'}
-                  </span>
-                  <span className="anno-card-quote">{annotation.quote}</span>
-                  {annotation.comment ? (
-                    <span className="anno-card-comment">{annotation.comment}</span>
-                  ) : null}
+                <div key={annotation.id} className="anno-card">
+                  <button
+                    type="button"
+                    className="anno-card-open"
+                    title="Edit this annotation"
+                    onClick={(event) => reopenFromCard(annotation, event)}
+                  >
+                    <span className="anno-card-chip">
+                      {annotation.emoji || '💬'}
+                    </span>
+                    <span className="anno-card-quote">{annotation.quote}</span>
+                    {annotation.comment ? (
+                      <span className="anno-card-comment">{annotation.comment}</span>
+                    ) : null}
+                  </button>
                   <button
                     type="button"
                     className="anno-card-remove"
+                    title="Remove annotation"
                     aria-label="Remove annotation"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      removeAnnotation(annotation.id);
-                    }}
+                    onClick={() => removeAnnotation(annotation.id, false)}
                   >
                     ✕
                   </button>
@@ -546,6 +644,12 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
                   </span>
                   <button type="button" className="anno-panel-send" onClick={send}>
                     Send all
+                    {/* The key is only live while this pane holds focus, so the
+                        hint is only shown then — a printed shortcut that does
+                        nothing where it is printed is worse than none. */}
+                    {paneActive ? (
+                      <span className="anno-panel-send-key">{formatShortcut('terminal.sendAnnotations')}</span>
+                    ) : null}
                   </button>
                 </>
               )}

--- a/app/src/components/TerminalAnnotations/TerminalAnnotations.css
+++ b/app/src/components/TerminalAnnotations/TerminalAnnotations.css
@@ -53,8 +53,18 @@
   background: var(--color-accent);
 }
 
+/* Held apart from the reactions it sits beside: eight emoji in a row train the
+   eye to read every glyph in it as a label to apply, and the one that undoes
+   the annotation cannot be found by looking harder. */
+.anno-popup-label--delete {
+  margin-left: 2px;
+  background: color-mix(in srgb, var(--color-error) 16%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-error) 40%, transparent);
+}
+
 .anno-popup-label--delete:hover {
   background: var(--color-error);
+  box-shadow: none;
 }
 
 .anno-popup-divider {
@@ -100,12 +110,20 @@
 
 .anno-popup-actions {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
   gap: 6px;
+}
+
+/* Pushes Cancel/Comment to the trailing edge, leaving Remove on its own at the
+   leading one — the usual read for a destructive action that must be reachable
+   without being the button a fast hand lands on. */
+.anno-popup-actions-gap {
+  flex: 1;
 }
 
 .anno-popup-cancel,
 .anno-popup-save,
+.anno-popup-remove,
 .anno-panel-send {
   padding: 4px 10px;
   border-radius: 6px;
@@ -116,11 +134,31 @@
   cursor: pointer;
 }
 
+.anno-popup-remove {
+  border-color: transparent;
+  background: transparent;
+  color: var(--color-error);
+}
+
+.anno-popup-remove:hover {
+  background: color-mix(in srgb, var(--color-error) 18%, transparent);
+}
+
 .anno-popup-save,
 .anno-panel-send {
   border-color: transparent;
   background: var(--color-accent);
   color: #fff;
+}
+
+.anno-panel-send {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.anno-panel-send-key {
+  opacity: 0.75;
 }
 
 .anno-panel {
@@ -196,22 +234,38 @@
   padding: 6px;
 }
 
+/* The row splits into "open it" and "remove it", each its own control. The
+   remove button lives in the row's second track, so a comment wrapping to a
+   second line inside the first track can never displace it: the earlier layout
+   auto-placed it after a row-spanning comment, which pushed it to a line of its
+   own exactly when an annotation had text. */
 .anno-card {
   display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 4px 8px;
-  width: 100%;
-  padding: 6px 8px;
+  grid-template-columns: 1fr auto;
+  align-items: start;
+  gap: 4px;
   border-radius: 8px;
   border: 1px solid transparent;
-  background: transparent;
-  text-align: left;
-  cursor: pointer;
 }
 
-.anno-card:hover {
+.anno-card:hover,
+.anno-card:focus-within {
   border-color: var(--color-border);
   background: var(--color-bg-elevated);
+}
+
+.anno-card-open {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 8px;
+  min-width: 0;
+  padding: 6px 2px 6px 8px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
 }
 
 .anno-card-chip {
@@ -228,17 +282,34 @@
 }
 
 .anno-card-comment {
-  grid-column: 2 / 4;
+  grid-column: 2;
   color: var(--color-text-primary);
   font-size: var(--font-size-xs);
 }
 
+/* Dimmed enough to sit behind the text it belongs to, lit enough to be found
+   without hovering for it. A 22px square gives it a hit target the pointer does
+   not have to be precise about. */
 .anno-card-remove {
-  padding: 0 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  margin: 5px 5px 0 0;
+  padding: 0;
   border: none;
+  border-radius: 6px;
   background: transparent;
-  color: var(--color-text-dimmed);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: 1;
   cursor: pointer;
+}
+
+.anno-card-remove:hover {
+  background: color-mix(in srgb, var(--color-error) 20%, transparent);
+  color: var(--color-error);
 }
 
 .anno-panel-n,

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -977,6 +977,14 @@ function annotationSurfaceState() {
     // The comment box's current contents, so a driver can tell "reopened an
     // annotation to edit it" from "opened an empty box beside it".
     popupDraft: (popup?.querySelector('.anno-popup-text') as HTMLTextAreaElement | null)?.value ?? null,
+    // Whether the box the editor opened for is the one taking keystrokes. An
+    // editor that opens without the caret in it sends the next sentence to the
+    // PTY, and nothing else on this surface would show that.
+    commentFocused: Boolean(
+      popup
+      && popup.querySelector('.anno-popup-text')
+      && document.activeElement === popup.querySelector('.anno-popup-text'),
+    ),
     labels: Array.from(popup?.querySelectorAll('.anno-popup-label') ?? [])
       .map((button) => button.getAttribute('aria-label') ?? ''),
     panelOpen: Boolean(panel),
@@ -984,6 +992,12 @@ function annotationSurfaceState() {
       emoji: text(card, '.anno-card-chip'),
       quote: text(card, '.anno-card-quote'),
       comment: text(card, '.anno-card-comment'),
+      // The row and its remove control, so a driver can see the control is
+      // still on the row's first line. A comment that spans the row used to
+      // push it onto a line of its own, which is invisible to every
+      // text-only assertion.
+      rect: box(card),
+      removeRect: box(card.querySelector('.anno-card-remove')),
     })),
     footer: text(panel, '.anno-panel-foot'),
   };

--- a/app/src/shortcuts/cheatsheet.ts
+++ b/app/src/shortcuts/cheatsheet.ts
@@ -74,6 +74,11 @@ export function buildCheatsheet(): CheatsheetCategory[] {
           combos: [fromId('markdown.sendAnnotations')],
           note: 'When a markdown tile has focus and annotations exist.',
         },
+        {
+          label: 'Send terminal annotations to session',
+          combos: [fromId('terminal.sendAnnotations')],
+          note: 'When the annotated pane has focus and marks are waiting.',
+        },
       ],
     },
     {

--- a/app/src/shortcuts/metadata.ts
+++ b/app/src/shortcuts/metadata.ts
@@ -105,6 +105,7 @@ export const SHORTCUT_META: Record<ShortcutId, ShortcutMeta> = {
 
   // Markdown & Annotations
   'markdown.sendAnnotations': { label: 'Send annotations to session', category: 'markdown', dockLabel: 'send notes' },
+  'terminal.sendAnnotations': { label: 'Send terminal annotations to session', category: 'markdown', dockLabel: 'send marks', requiresTerminal: true },
 
   // Review & Git
   'dock.attention': { label: 'PRs drawer', category: 'review', dockLabel: 'PRs' },

--- a/app/src/shortcuts/registry.test.ts
+++ b/app/src/shortcuts/registry.test.ts
@@ -7,7 +7,9 @@ import {
   matchesShortcut,
   bindingsConflict,
   combosConflict,
+  isAllowedConflict,
   isChord,
+  type ShortcutId,
 } from './registry';
 
 function withNavigatorPlatform<T>(platform: string, fn: () => T): T {
@@ -22,10 +24,6 @@ function withNavigatorPlatform<T>(platform: string, fn: () => T): T {
 }
 
 describe('shortcut registry', () => {
-  const isAllowedConflict = (a: string, b: string) => (
-    [a, b].sort().join('|') === 'session.close|terminal.close'
-  );
-
   describe('matchesShortcut', () => {
     it('matches cmd+key shortcut on macOS', () => {
       withNavigatorPlatform('MacIntel', () => {
@@ -199,7 +197,9 @@ describe('shortcut registry', () => {
 
         const existing = seen.get(key);
         if (existing) {
-          if (isAllowedConflict(existing, id)) {
+          // The registry's own exemption list, not a copy of it: a pair added
+          // there must not need this test edited to stay honest.
+          if (isAllowedConflict(existing as ShortcutId, id as ShortcutId)) {
             continue;
           }
           throw new Error(`Duplicate shortcut: "${id}" and "${existing}" both use ${key}`);

--- a/app/src/shortcuts/registry.ts
+++ b/app/src/shortcuts/registry.ts
@@ -34,6 +34,11 @@ export function isChord(b: Binding | null | undefined): b is Chord {
 
 const ALLOWED_CONFLICT_PAIRS = new Set([
   'session.close|terminal.close',
+  // One verb — send the annotations you just made to the session — on one key,
+  // reached from two surfaces. Both registrations are gated on their own
+  // surface having focus, and a focused markdown tile and a focused terminal
+  // pane are mutually exclusive, so only one handler is ever registered.
+  'markdown.sendAnnotations|terminal.sendAnnotations',
 ]);
 
 export const SHORTCUTS = {
@@ -157,6 +162,12 @@ export const SHORTCUTS = {
   // handler is additionally registration-gated on tile focus-within so ⌘Enter
   // still reaches the PTY when a terminal pane is focused.
   'markdown.sendAnnotations': { key: 'Enter', meta: true, editableTarget: 'native' },
+
+  // The same ⌘Enter for the annotations made on an agent's message in the
+  // terminal. Registered only while the annotated pane is the focused leaf and
+  // the panel is holding at least one mark, so ⌘Enter still reaches the PTY
+  // everywhere else — including in a pane with nothing to send.
+  'terminal.sendAnnotations': { key: 'Enter', meta: true, editableTarget: 'native' },
 } as const;
 
 export type ShortcutId = keyof typeof SHORTCUTS;

--- a/changelog.d/jolly-walrus-annotation-polish.yaml
+++ b/changelog.d/jolly-walrus-annotation-polish.yaml
@@ -1,0 +1,18 @@
+kind: changed
+area: terminal
+change: >
+  Terminal annotations answer the keyboard and the second look. ⌘Enter sends the
+  whole set to the session without reaching for the panel, while the pane you
+  annotated has focus and marks are waiting. Clicking a row in the floating
+  panel opens that annotation's comment box with the caret already in it, so a
+  row is edited where it is read. Removing one is now findable from both places:
+  a named "Remove" beside Cancel in the open comment box, and a tinted control
+  in the icon row rather than a ninth glyph among eight reaction emoji. Closing
+  the editor hands the keyboard back to the terminal.
+notes: >
+  The panel row's remove control also stops jumping to a line of its own. The
+  row was one grid, and a comment spanning it pushed the control past the last
+  column into an implicit new row — so it moved exactly when an annotation
+  carried text, which is when it is most wanted. The row is now two controls
+  side by side, which also gives it keyboard reach and stops nesting a button
+  inside a clickable element.


### PR DESCRIPTION
Five gaps in the terminal annotation surface, all about reaching what is already there.

## Send the whole set with the keyboard

`⌘Enter` — the key markdown tiles already use for the same verb — sends every annotation to the session. It is *registration*-gated, not handler-gated: the dispatcher consumes a keystroke whenever a handler exists for it, so the shortcut is only registered while the annotated pane is the focused leaf of the visible session **and** the panel holds at least one mark. Everywhere else, including a pane with nothing waiting, `⌘Enter` still reaches the PTY.

The two ids share the combo through `ALLOWED_CONFLICT_PAIRS`; a focused markdown tile and a focused terminal pane are mutually exclusive, so only one handler is ever registered. A comment being typed when the send fires is committed into the payload rather than dropped.

## Edit an annotation from the panel

A panel row is the list of what you wrote, so clicking it opens that annotation's comment box, with the caret at the end of the existing text. It used to open the bare reaction row whenever the annotation carried no comment — a row of eight emoji answering a question nobody asked at that moment. The popup anchors to the row's top edge rather than the raw pointer, so it lands in the same place every time.

## Find the way out

Removing an annotation was possible from the popup and effectively unfindable: a `🗑` sitting ninth in a row of eight reaction emoji reads as another label to apply. It is now tinted at rest, and the open comment box carries a named **Remove** beside Cancel.

## Hand the keyboard back

The comment box takes focus as the editor opens. Closing the editor returns focus to the terminal — the user came from the grid and the next thing they type is meant for the agent. The exception is a press that deliberately landed elsewhere: that press owns where focus goes, so it is not yanked back.

## Stop the panel row's remove control jumping to a line of its own

Root cause: the row was a single CSS grid, and `.anno-card-comment` declared `grid-column: 2 / 4`. Sparse auto-placement put it on the second row spanning to the last column, which left the auto-placed remove button no free cell after the cursor — so it got an implicit **third** row. That is why it only moved when an annotation carried text, i.e. exactly when it is most wanted.

The row is now two controls side by side (`1fr auto`): a button that opens the annotation, and the remove button in its own track. That also gives the row keyboard reach and stops nesting a `<button>` inside a clickable `role="button"` element.

## Verification

- Frontend suite (2357 tests) and Playwright e2e (192) green; `tsc --noEmit` clean.
- Twelve new unit tests over the surface, including the registration gate in both directions (fires when the pane is focused with marks waiting; silent when it is not the focused pane, and when there is nothing to send).
- Live on a packaged build (throwaway profile, since cleaned up): `real-app:scenario-terminal-annotations` passes with three new legs —
  - clicking a panel row opens its editor and the comment box holds focus,
  - a commented row reports its remove control **6px** below the row top (tripwire at 12px; the old layout put it a full line lower),
  - the set is sent with a real native `⌘Return` rather than the button. The button is a click handler any unit test can drive; the keystroke has to survive AppKit, reach the page's capture-phase listener, and be claimed by the pane instead of the PTY, which only the packaged app can show.

`get_annotation_state` now reports panel-row geometry and whether the comment box holds focus, so both stay measurable tripwires rather than one-off checks.

The registry's duplicate-combo test was reading a hand-copied exemption list; it now calls the registry's own `isAllowedConflict`.

## Note

`⌘Enter` is claimed from the PTY in a pane that has marks waiting. Claude Code binds Option+Enter / Shift+Enter for newlines and nothing to `⌘Enter`, so the cost looked like zero — but it is a real trade and worth naming.

https://claude.ai/code/session_01MmcGPuheR23tr4fP5ReZ16