### PR TITLE
feat(annotations): say why a mark cannot be made, and let one mean agreement

### DIFF
--- a/app/scripts/real-app-harness/scenario-terminal-annotations.mjs
+++ b/app/scripts/real-app-harness/scenario-terminal-annotations.mjs
@@ -24,6 +24,7 @@ import {
   printCommonHelp,
   relaunchAppAndConnect,
 } from './common.mjs';
+import { dataDirForProfile } from './harnessProfile.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 import { MacOSDriver } from './macosDriver.mjs';
 import { DaemonObserver } from './daemonObserver.mjs';
@@ -220,6 +221,21 @@ export function proseRow(lines) {
   return best;
 }
 
+// The widest row carrying real text, whatever it is. Used before the agent has
+// said anything, when the point is not which row is dragged over but that a
+// drag over any of them is refused out loud — nothing on the grid at that
+// moment belongs to a transcript message.
+export function anyTextRow(lines) {
+  let best = null;
+  for (let row = 0; row < lines.length; row += 1) {
+    const line = lines[row];
+    const words = line.trim().split(/\s+/).filter((word) => /^[A-Za-z][A-Za-z'-]*[.,;:]?$/.test(word));
+    if (words.length < 5) continue;
+    if (!best || line.trim().length > best.text.trim().length) best = { row, text: line, words };
+  }
+  return best;
+}
+
 // A whole-word column span inside a row, away from both edges so the drag
 // cannot pick up the indent or a wrapped word.
 export function wordSpan(rowText) {
@@ -301,6 +317,86 @@ async function main() {
       await client.request('select_session', { sessionId });
       const pane = await waitForFirstWorkspacePane(client, sessionId, 'agent pane', 20_000);
       paneId = pane.paneId;
+    });
+
+    // Before the agent has said anything there is nothing to annotate, and the
+    // whole failure mode this covers is that the gesture used to do exactly
+    // nothing about it — no popup, no message, no log line, indistinguishable
+    // from the feature being broken. Runs first because "no window yet" is only
+    // deterministic before the first turn.
+    await runner.step('a_refused_drag_says_why', async () => {
+      // Settle first. A session still coming up is refused for a different and
+      // equally correct reason ("annotations open once the agent stops
+      // talking"), and pinning whichever one the timing produced would make
+      // this step a race rather than a check.
+      await pollFor(
+        () => (SETTLED_STATES.has(observer.getSession(sessionId)?.state) ? true : null),
+        'the new session to settle at its prompt',
+        60_000,
+      );
+
+      const refused = await pollFor(
+        async () => {
+          const target = anyTextRow(await readLines(client, sessionId, paneId));
+          if (!target) return null;
+          const span = wordSpan(target.text);
+          if (!span) return null;
+          await client.request('drag_pane_selection', {
+            sessionId,
+            paneId,
+            start: { col: span.startCol, row: target.row },
+            end: { col: span.endCol, row: target.row },
+            altKey: true,
+          });
+          // Read straight away: the notice retires itself after a few seconds,
+          // and polling around this request would race its own dismissal.
+          const state = await client.request('get_annotation_state', {});
+          return state.notice ? { state, target } : null;
+        },
+        'an alt-drag before the first turn to be refused out loud',
+        20_000,
+      );
+
+      runner.assert(
+        !refused.state.popupOpen,
+        `A drag before the agent said anything opened an annotation editor: ${JSON.stringify(refused.state)}`,
+      );
+      // A session that has never taken a turn has no transcript on disk yet, so
+      // the identity ladder resolves nothing — the same outcome as a session
+      // whose transcript was cleaned up, which is what this is standing in for.
+      runner.assert(
+        /No transcript could be read/.test(refused.state.notice),
+        `The refusal did not name its reason: ${JSON.stringify(refused.state.notice)}`,
+      );
+      const { noticeRect: box, viewport } = refused.state;
+      runner.assert(
+        box && box.left >= 0 && box.top >= 0
+        && box.left + box.width <= viewport.width && box.top + box.height <= viewport.height,
+        `The refusal was drawn off-screen, where it explains nothing: `
+        + `${JSON.stringify(box)} in ${JSON.stringify(viewport)}`,
+      );
+      runner.log('refused', { row: refused.target.row, notice: refused.state.notice });
+
+      // The other half of the fix: the daemon used to return this outcome and
+      // log nothing, so a user reporting "I cannot annotate" left no trace to
+      // diagnose from. The line names the session and where it was running.
+      const logPath = path.join(dataDirForProfile(), 'daemon.log');
+      const logged = fs.existsSync(logPath)
+        ? fs.readFileSync(logPath, 'utf8').split('\n').filter((line) => line.includes(sessionId) && line.includes('no transcript resolved'))
+        : [];
+      runner.assert(
+        logged.length > 0,
+        `The daemon refused the message window without logging it, so the cause is invisible outside the app (${logPath})`,
+      );
+
+      // It must retire on its own — it explains a finished gesture, and one
+      // that lingers becomes a thing in the way of the next drag.
+      await sleep(6_000);
+      const after = await client.request('get_annotation_state', {});
+      runner.assert(
+        after.notice === null,
+        `The refusal was still on screen 6s later: ${JSON.stringify(after.notice)}`,
+      );
     });
 
     await runner.step('first_turn_and_annotate', async () => {

--- a/app/scripts/real-app-harness/scenario-terminal-annotations.test.mjs
+++ b/app/scripts/real-app-harness/scenario-terminal-annotations.test.mjs
@@ -4,7 +4,7 @@
 // report a product regression that is really a parsing bug here.
 
 import { describe, expect, it } from 'vitest';
-import { proseRow, wordSpan } from './scenario-terminal-annotations.mjs';
+import { anyTextRow, proseRow, wordSpan } from './scenario-terminal-annotations.mjs';
 
 const PROSE = '  A retry wrapper should only retry operations that are idempotent, since';
 const SHORT_PROSE = '  Yes, exactly.';
@@ -67,6 +67,22 @@ describe('proseRow', () => {
 
   it('returns null before the agent has said anything', () => {
     expect(proseRow(['❯ ', '──────────────'])).toBeNull();
+  });
+});
+
+// The scenario drags over this row before the first turn, to prove a refused
+// annotation says why. Nothing on the grid is annotatable at that point, so any
+// row will do — what matters is that one wide enough to span is found at all.
+describe('anyTextRow', () => {
+  it('takes the widest row carrying real text, whatever it is', () => {
+    // Before the first turn nothing on the grid belongs to a transcript
+    // message, so which row is dragged over does not matter — only that one
+    // wide enough to span exists.
+    expect(anyTextRow(['❯ ', PROSE, SHORT_PROSE])?.row).toBe(1);
+  });
+
+  it('returns null on a grid with nothing to drag across', () => {
+    expect(anyTextRow(['❯ ', '──────', SHORT_PROSE])).toBeNull();
   });
 });
 

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -173,6 +173,15 @@ export interface GhosttyTerminalProps {
     anchor: MessageAnchor,
     at: { clientX: number; clientY: number },
   ) => void;
+  // An alt-drag asked to annotate and resolved to nothing — the store has no
+  // window to align against, or the dragged text is not in one of its messages.
+  // Reported rather than swallowed: the gesture was deliberate, and silence is
+  // indistinguishable from a broken feature. The drag still behaves as an
+  // ordinary selection; the owner only supplies the explanation.
+  onAnnotationMiss?: (
+    reason: 'no-messages' | 'outside-messages',
+    at: { clientX: number; clientY: number },
+  ) => void;
   // An alt-click landed on an existing wash. The owner reopens that annotation
   // for editing; the terminal only says which one was pointed at.
   onAnnotationActivate?: (
@@ -565,7 +574,7 @@ function cellText(
 }
 
 export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminalProps>(
-  function GhosttyTerminal({ fontSize, resolvedTheme = 'dark', debugName, cwd, runtimeLogMeta, onInput, onOpenMarkdown, onReady, onResize, onReplayInterrupted, onTerminalModelRecovered, annotations, annotationsVersion = 0, onAnnotationAnchor, onAnnotationActivate }, ref) {
+  function GhosttyTerminal({ fontSize, resolvedTheme = 'dark', debugName, cwd, runtimeLogMeta, onInput, onOpenMarkdown, onReady, onResize, onReplayInterrupted, onTerminalModelRecovered, annotations, annotationsVersion = 0, onAnnotationAnchor, onAnnotationMiss, onAnnotationActivate }, ref) {
     const containerRef = useRef<HTMLDivElement>(null);
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const terminalRef = useRef<GhosttyModel | null>(null);
@@ -656,6 +665,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const onTerminalModelRecoveredRef = useRef(onTerminalModelRecovered);
     const annotationsRef = useRef(annotations);
     const onAnnotationAnchorRef = useRef(onAnnotationAnchor);
+    const onAnnotationMissRef = useRef(onAnnotationMiss);
     const onAnnotationActivateRef = useRef(onAnnotationActivate);
     // Set on mousedown when alt was held over a pane that has a message under
     // annotation, so the release knows to resolve an anchor instead of just
@@ -717,6 +727,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     onTerminalModelRecoveredRef.current = onTerminalModelRecovered;
     annotationsRef.current = annotations;
     onAnnotationAnchorRef.current = onAnnotationAnchor;
+    onAnnotationMissRef.current = onAnnotationMiss;
     onAnnotationActivateRef.current = onAnnotationActivate;
     runtimeMetaRef.current = runtimeLogMeta;
     debugNameRef.current = debugName;
@@ -2966,6 +2977,10 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       // answers with markdown offsets or refuses — a drag over the TUI's own
       // chrome, a user turn, or a message outside the annotatable window
       // resolves to nothing, and then this is an ordinary selection.
+      //
+      // A refusal is still reported. The two ways to get here look identical on
+      // screen — nothing happens — but mean opposite things: no window to align
+      // against at all, versus a window that does not contain this text.
       if (annotationDrag && selectionRef.current) {
         const store = annotationsRef.current;
         const access = messageRowAccess();
@@ -2979,6 +2994,10 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           onAnnotationAnchorRef.current?.(anchor, { clientX: event.clientX, clientY: event.clientY });
           return;
         }
+        onAnnotationMissRef.current?.(
+          store?.hasMessages() ? 'outside-messages' : 'no-messages',
+          { clientX: event.clientX, clientY: event.clientY },
+        );
       }
       const text = textForSelectionRange(selectionRef.current);
       selectedTextRef.current = text || null;
@@ -3323,9 +3342,14 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           selectedTextRef.current = null;
           applicationSelectionAnchorRef.current = null;
           selectedBlockIdRef.current = null;
-          // Alt claims the drag for annotation only when there is a message to
-          // annotate; otherwise it stays the plain selection it has always been.
-          annotationDragRef.current = event.altKey && Boolean(annotationsRef.current?.hasMessages());
+          // Alt claims the drag for annotation in a pane that has an annotation
+          // surface at all, whether or not there is currently a message to
+          // anchor to. Arming it only when a window exists made "nothing to
+          // annotate" the one case that could not explain itself: the release
+          // saw an ordinary selection and had nothing to report. The drag still
+          // falls through to a plain copy when it resolves to nothing — the
+          // only thing being claimed here is the right to say why.
+          annotationDragRef.current = event.altKey && Boolean(annotationsRef.current);
           annotationClickRef.current = event.altKey ? annotationAtCell(cell) : null;
           selectingRef.current = true;
           selectionPointerStartRef.current = { clientX: event.clientX, clientY: event.clientY };

--- a/app/src/components/TerminalAnnotations/AnnotatedTerminal.annotate.test.tsx
+++ b/app/src/components/TerminalAnnotations/AnnotatedTerminal.annotate.test.tsx
@@ -24,6 +24,10 @@ import type { UISessionState } from '../../types/sessionState';
 interface CapturedProps {
   annotations?: TerminalAnnotationStore;
   onAnnotationAnchor?: (anchor: MessageAnchor, at: { clientX: number; clientY: number }) => void;
+  onAnnotationMiss?: (
+    reason: 'no-messages' | 'outside-messages',
+    at: { clientX: number; clientY: number },
+  ) => void;
   onAnnotationActivate?: (annotationId: string, at: { clientX: number; clientY: number }) => void;
 }
 
@@ -161,6 +165,17 @@ function anchor(messageKey: string, start: number, end: number) {
   act(() => {
     terminal.onAnnotationAnchor?.({ messageKey, start, end, quote }, { clientX: 120, clientY: 200 });
   });
+}
+
+/** Drives an alt-drag the terminal could not resolve to an anchor. */
+function miss(reason: 'no-messages' | 'outside-messages') {
+  act(() => {
+    terminal.onAnnotationMiss?.(reason, { clientX: 120, clientY: 200 });
+  });
+}
+
+function notice(): string | null {
+  return screen.queryByTestId('annotation-notice')?.textContent ?? null;
 }
 
 /** Drives the alt-click the terminal reports over an existing wash. */
@@ -767,5 +782,94 @@ describe('AnnotatedTerminal persistence', () => {
     }], daemon.tombstone);
     expect(late.stale).toBe(true);
     expect(daemon.annotations).toHaveLength(0);
+  });
+
+  // An annotate gesture that resolves to nothing used to do exactly nothing —
+  // no popup, no message, no log line — and the four reasons for it are
+  // indistinguishable from the feature being broken.
+  describe('when a gesture cannot be annotated', () => {
+    it('says the text was not the agent’s when there is a window it missed', async () => {
+      renderTerminal();
+      await windowReady('turn-1');
+
+      miss('outside-messages');
+
+      expect(notice()).toContain('Only what the agent wrote can be annotated');
+    });
+
+    it('names the unreadable transcript rather than blaming the selection', async () => {
+      // The daemon's own path: resolveTranscriptPathForSession found nothing, so
+      // there is no window and never will be for this session.
+      const daemon = new FakeAnnotationDaemon();
+      daemon.fetchMessages = async () => {
+        throw new Error('session_messages_get: no transcript for session session-1');
+      };
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      renderTerminal({ api: daemon });
+      await waitFor(() => expect(warn).toHaveBeenCalled());
+
+      miss('no-messages');
+
+      expect(notice()).toContain('No transcript could be read');
+      // The sentence is for the user; the daemon's wording is what makes the
+      // cause searchable afterwards.
+      expect(warn.mock.calls[0][0]).toContain('no transcript for session session-1');
+      warn.mockRestore();
+    });
+
+    it('points at the running turn when the window was never fetched', async () => {
+      // Not an error at all: nothing is anchored mid-turn by design, and the
+      // user has only to wait.
+      renderTerminal({ state: 'working' });
+
+      miss('no-messages');
+
+      expect(notice()).toContain('once the agent stops talking');
+    });
+
+    it('says the agent has not spoken when the window came back empty', async () => {
+      const daemon = new FakeAnnotationDaemon();
+      daemon.messages = [];
+      renderTerminal({ api: daemon });
+      await waitFor(() => expect(daemon.calls.fetchMessages).toBe(1));
+
+      miss('no-messages');
+
+      expect(notice()).toContain('has not written a message');
+    });
+
+    it('clears itself once an annotation actually lands', async () => {
+      renderTerminal();
+      await windowReady('turn-1');
+      miss('outside-messages');
+      expect(notice()).not.toBeNull();
+
+      anchor('turn-1', 0, 26);
+
+      expect(notice()).toBeNull();
+      expect(screen.getByTestId('annotation-popup')).toBeTruthy();
+    });
+
+    it('goes away on its own rather than becoming something to dismiss', async () => {
+      vi.useFakeTimers();
+      try {
+        renderTerminal();
+        // Settle the hydrate/window fetches inside act so their resolution is
+        // not mistaken for the timer this test is about.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        miss('outside-messages');
+        expect(notice()).not.toBeNull();
+
+        act(() => {
+          vi.advanceTimersByTime(5000);
+        });
+
+        expect(notice()).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/app/src/components/TerminalAnnotations/AnnotatedTerminal.tsx
+++ b/app/src/components/TerminalAnnotations/AnnotatedTerminal.tsx
@@ -11,7 +11,7 @@
 // unmount, a crash, or a quit costs nothing. See
 // docs/decisions/2026-08-02-terminal-annotations-anchor-to-the-transcript.md.
 
-import { forwardRef, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { forwardRef, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import {
   GhosttyTerminal,
   type GhosttyTerminalHandle,
@@ -23,7 +23,7 @@ import {
   type MessageAnchor,
   type TerminalAnnotation,
 } from '../../utils/terminalAnnotations';
-import { QUICK_LABELS, buildAnnotationPayload } from './quickLabels';
+import { QUICK_LABEL_GROUPS, buildAnnotationPayload } from './quickLabels';
 import { clampToViewport, placePopup, type Placement } from './placement';
 import { useShortcut } from '../../shortcuts/useShortcut';
 import { formatShortcut } from '../../shortcuts/formatShortcut';
@@ -80,6 +80,16 @@ export interface AnnotatedTerminalProps extends TerminalProps {
   paneActive?: boolean;
 }
 
+interface Notice {
+  text: string;
+  clientX: number;
+  clientY: number;
+  // Distinguishes one miss from the next at the same spot, so a repeated
+  // gesture restarts the dismiss timer instead of letting the first one expire
+  // under the second.
+  seq: number;
+}
+
 interface Composer {
   annotationId: string;
   clientX: number;
@@ -104,6 +114,17 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
     const [version, setVersion] = useState(0);
     const [composer, setComposer] = useState<Composer | null>(null);
     const [sentCount, setSentCount] = useState(0);
+    // What an annotate gesture that resolved to nothing has to say for itself,
+    // and where it was made. Null the rest of the time — this is not a status
+    // line, it answers a question the user just asked with the pointer.
+    const [notice, setNotice] = useState<Notice | null>(null);
+    const noticeRef = useRef<HTMLDivElement>(null);
+    const [noticeAt, setNoticeAt] = useState<Placement | null>(null);
+    // Why the last window fetch produced nothing, in the daemon's own words.
+    // A ref because nothing renders from it directly: it is read at the moment
+    // a miss needs explaining, and re-rendering the terminal to record a failed
+    // background fetch would be a repaint for no one.
+    const windowErrorRef = useRef<string | null>(null);
     const [draft, setDraft] = useState('');
     const commentRef = useRef<HTMLTextAreaElement>(null);
     const popupRef = useRef<HTMLDivElement>(null);
@@ -184,6 +205,11 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
     // Fetch the annotatable window when the agent settles. Messages already in
     // the window come back unchanged, so this neither disturbs the store nor
     // repaints unless a new turn actually arrived.
+    //
+    // A failure is remembered rather than swallowed. It is the difference
+    // between "this session has no transcript" and "the agent has not spoken
+    // yet", which the user can only be told apart if the reason survives the
+    // fetch that discovered it.
     useEffect(() => {
       if (!enabled || !sessionId) return;
       if (!sessionState || !SETTLED_STATES.includes(sessionState)) return;
@@ -191,11 +217,16 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
       void annotationApi!.fetchMessages(sessionId)
         .then((result) => {
           if (cancelled) return;
+          windowErrorRef.current = null;
           if (store.setMessages(result.messages)) bump();
         })
-        .catch(() => {
-          // A session with no readable transcript simply has nothing to
-          // annotate. Leave whatever is already anchored alone.
+        .catch((error: unknown) => {
+          if (cancelled) return;
+          const detail = error instanceof Error ? error.message : String(error);
+          windowErrorRef.current = detail;
+          // Logged as well as shown: the notice is a sentence a person reads,
+          // and the daemon's own wording is what makes the cause searchable.
+          console.warn(`[annotations] ${sessionId}: message window unavailable: ${detail}`);
         });
       return () => {
         cancelled = true;
@@ -239,6 +270,29 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
         bump();
       },
       [bump],
+    );
+
+    // An annotate gesture that resolved to nothing. Four causes look identical
+    // on screen, and each has a different thing the user can do about it, so
+    // the notice names the one that actually applies rather than a generic
+    // "cannot annotate here".
+    // Read at miss time, not render time, so the handler can stay stable.
+    const sessionStateRef = useRef(sessionState);
+    sessionStateRef.current = sessionState;
+    const missSeqRef = useRef(0);
+    const handleMiss = useCallback(
+      (reason: 'no-messages' | 'outside-messages', at: { clientX: number; clientY: number }) => {
+        const text = reason === 'outside-messages'
+          ? 'Only what the agent wrote can be annotated. This text is the TUI’s own, your own, or from a turn that has scrolled out of the window.'
+          : windowErrorRef.current
+            ? 'No transcript could be read for this session, so there is nothing to annotate. The daemon log names the lookup that failed.'
+            : !sessionStateRef.current || !SETTLED_STATES.includes(sessionStateRef.current)
+              ? 'Annotations open once the agent stops talking. Nothing is anchored while a turn is still running.'
+              : 'The agent has not written a message to annotate yet.';
+        setNoticeAt(null);
+        setNotice({ text, ...at, seq: missSeqRef.current++ });
+      },
+      [],
     );
 
     // Reopening an annotation already made. Its comment becomes the draft, and
@@ -446,6 +500,32 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
       return () => window.clearTimeout(timer);
     }, [sentCount]);
 
+    // Same measure-then-clamp as the popup, for the same reason: the pointer is
+    // routinely near an edge, and a sentence is wider than the popup is.
+    useLayoutEffect(() => {
+      const node = noticeRef.current;
+      if (!notice || !node) return;
+      const rect = node.getBoundingClientRect();
+      setNoticeAt(placePopup(
+        { x: notice.clientX, y: notice.clientY },
+        { width: rect.width, height: rect.height },
+        { width: window.innerWidth, height: window.innerHeight },
+      ));
+    }, [notice]);
+
+    // Long enough to read a sentence, then gone. It explains a gesture that has
+    // already finished, so it must not become something to dismiss.
+    useEffect(() => {
+      if (!notice) return;
+      const timer = window.setTimeout(() => setNotice(null), 5000);
+      return () => window.clearTimeout(timer);
+    }, [notice]);
+
+    // A successful annotation answers the question the notice was asking.
+    useEffect(() => {
+      if (composer) setNotice(null);
+    }, [composer]);
+
     // The drag runs on the window, not the header: the pointer routinely leaves
     // a 300px panel mid-drag, and a header-bound listener would drop it there.
     useEffect(() => {
@@ -498,8 +578,22 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
           annotations={enabled ? store : undefined}
           annotationsVersion={version}
           onAnnotationAnchor={enabled ? handleAnchor : undefined}
+          onAnnotationMiss={enabled ? handleMiss : undefined}
           onAnnotationActivate={enabled ? openAnnotation : undefined}
         />
+        {notice ? (
+          <div
+            ref={noticeRef}
+            className={`anno-notice${noticeAt ? ' anno-notice--placed' : ''}`}
+            data-testid="annotation-notice"
+            role="status"
+            style={noticeAt
+              ? { left: noticeAt.left, top: noticeAt.top }
+              : { left: notice.clientX, top: notice.clientY }}
+          >
+            {notice.text}
+          </div>
+        ) : null}
         {composed && composer ? (
           <div
             ref={popupRef}
@@ -511,17 +605,22 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
             onMouseDown={(event) => event.preventDefault()}
           >
             <div className="anno-popup-labels">
-              {QUICK_LABELS.map((label) => (
-                <button
-                  key={label.id}
-                  type="button"
-                  className={`anno-popup-label${composed.emoji === label.emoji ? ' anno-popup-label--on' : ''}`}
-                  title={label.text}
-                  aria-label={label.text}
-                  onClick={() => applyLabel(label.emoji)}
-                >
-                  {label.emoji}
-                </button>
+              {QUICK_LABEL_GROUPS.map((group, groupIndex) => (
+                <React.Fragment key={group[0].id}>
+                  {groupIndex > 0 ? <span className="anno-popup-divider" /> : null}
+                  {group.map((label) => (
+                    <button
+                      key={label.id}
+                      type="button"
+                      className={`anno-popup-label${composed.emoji === label.emoji ? ' anno-popup-label--on' : ''}`}
+                      title={label.text}
+                      aria-label={label.text}
+                      onClick={() => applyLabel(label.emoji)}
+                    >
+                      {label.emoji}
+                    </button>
+                  ))}
+                </React.Fragment>
               ))}
               <span className="anno-popup-divider" />
               <button

--- a/app/src/components/TerminalAnnotations/AnnotatedTerminal.tsx
+++ b/app/src/components/TerminalAnnotations/AnnotatedTerminal.tsx
@@ -276,9 +276,9 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
     // on screen, and each has a different thing the user can do about it, so
     // the notice names the one that actually applies rather than a generic
     // "cannot annotate here".
-    // Read at miss time, not render time, so the handler can stay stable.
-    const sessionStateRef = useRef(sessionState);
-    sessionStateRef.current = sessionState;
+    // The terminal holds its callbacks in refs, so this changing identity with
+    // the session's state costs a prop write rather than a re-subscription —
+    // which is why `sessionState` is a dependency here instead of a ref read.
     const missSeqRef = useRef(0);
     const handleMiss = useCallback(
       (reason: 'no-messages' | 'outside-messages', at: { clientX: number; clientY: number }) => {
@@ -286,13 +286,13 @@ export const AnnotatedTerminal = forwardRef<GhosttyTerminalHandle, AnnotatedTerm
           ? 'Only what the agent wrote can be annotated. This text is the TUI’s own, your own, or from a turn that has scrolled out of the window.'
           : windowErrorRef.current
             ? 'No transcript could be read for this session, so there is nothing to annotate. The daemon log names the lookup that failed.'
-            : !sessionStateRef.current || !SETTLED_STATES.includes(sessionStateRef.current)
+            : !sessionState || !SETTLED_STATES.includes(sessionState)
               ? 'Annotations open once the agent stops talking. Nothing is anchored while a turn is still running.'
               : 'The agent has not written a message to annotate yet.';
         setNoticeAt(null);
         setNotice({ text, ...at, seq: missSeqRef.current++ });
       },
-      [],
+      [sessionState],
     );
 
     // Reopening an annotation already made. Its comment becomes the draft, and

--- a/app/src/components/TerminalAnnotations/TerminalAnnotations.css
+++ b/app/src/components/TerminalAnnotations/TerminalAnnotations.css
@@ -161,6 +161,31 @@
   opacity: 0.75;
 }
 
+/* Why an annotate gesture did nothing, said where the gesture was made. Not a
+   toast in the corner: the user is looking at the text they just dragged over,
+   and an explanation that appears somewhere else is one they never see. */
+.anno-notice {
+  position: fixed;
+  z-index: 60;
+  transform: translate(-50%, -100%) translateY(-8px);
+  max-width: 340px;
+  padding: 7px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-elevated);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.36);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+  line-height: 1.45;
+  /* It explains a finished gesture and disappears on its own; catching the
+     pointer would make it something in the way. */
+  pointer-events: none;
+}
+
+.anno-notice--placed {
+  transform: none;
+}
+
 .anno-panel {
   position: fixed;
   right: 20px;

--- a/app/src/components/TerminalAnnotations/quickLabels.payload.test.ts
+++ b/app/src/components/TerminalAnnotations/quickLabels.payload.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from 'vitest';
-import { QUICK_LABELS, buildAnnotationPayload } from './quickLabels';
+import { QUICK_LABELS, QUICK_LABEL_GROUPS, buildAnnotationPayload } from './quickLabels';
+
+describe('QUICK_LABEL_GROUPS', () => {
+  it('keeps agreement in its own group, ahead of everything that asks for a change', () => {
+    // A reviewer who cannot cheaply say "this part is right" files only
+    // objections. Ninth in a run of corrections, the one positive mark reads as
+    // one more complaint — the group is what a divider draws between.
+    expect(QUICK_LABEL_GROUPS[0].map((label) => label.id)).toEqual(['exactly-this']);
+    expect(QUICK_LABEL_GROUPS).toHaveLength(2);
+    expect(QUICK_LABELS[0].emoji).toBe('💯');
+  });
+
+  it('flattens to the whole row, so a grouped label is still resolvable', () => {
+    expect(QUICK_LABELS).toEqual(QUICK_LABEL_GROUPS.flat());
+    expect(new Set(QUICK_LABELS.map((label) => label.emoji)).size).toBe(QUICK_LABELS.length);
+  });
+});
 
 describe('buildAnnotationPayload', () => {
   it('leads each item with the words it is about', () => {
@@ -42,6 +58,28 @@ describe('buildAnnotationPayload', () => {
 
     expect(payload).toContain('💬 Comment');
     expect(payload).toContain('this contradicts the paragraph above');
+  });
+
+  it('tells the agent what to do with agreement, not just that it got one', () => {
+    // "💯" alone is a pat on the head. What makes marking a thing right worth
+    // the click is that the agent is told to keep it through the next revision.
+    const payload = buildAnnotationPayload([
+      { start: 0, emoji: '💯', comment: '', quote: 'the retry only fires on idempotent verbs' },
+    ]);
+
+    expect(payload).toContain('💯 Exactly this');
+    expect(payload).toContain('Preserve this decision');
+  });
+
+  it('says what the payload is without instructing the agent how to behave', () => {
+    // The preamble names the thing so the agent knows these are marks on its
+    // own last message. Telling it to "address each annotation" on top of that
+    // is an instruction the annotations already are.
+    const payload = buildAnnotationPayload([
+      { start: 0, emoji: '❓', comment: '', quote: 'always safe' },
+    ]);
+
+    expect(payload.split('\n')[0]).toBe('Feedback on your last message.');
   });
 
   it('is empty with nothing to say', () => {

--- a/app/src/components/TerminalAnnotations/quickLabels.ts
+++ b/app/src/components/TerminalAnnotations/quickLabels.ts
@@ -15,46 +15,71 @@ export interface QuickLabel {
   tip?: string;
 }
 
-export const QUICK_LABELS: QuickLabel[] = [
-  { id: 'clarify-this', emoji: '❓', text: 'Clarify this' },
-  {
-    id: 'verify-this',
-    emoji: '🔍',
-    text: 'Verify this',
-    tip: 'This seems like an assumption. Verify by reading the actual code before proceeding.',
-  },
-  {
-    id: 'give-me-an-example',
-    emoji: '🔬',
-    text: 'Give me an example',
-    tip: 'This is too abstract. Show a before/after, a sample input/output, or a specific scenario.',
-  },
-  {
-    id: 'match-existing-patterns',
-    emoji: '🧬',
-    text: 'Match existing patterns',
-    tip: 'Search the codebase for existing patterns that already solve this. Reuse what exists.',
-  },
-  {
-    id: 'consider-alternatives',
-    emoji: '🔄',
-    text: 'Consider alternatives',
-    tip: 'Propose 2-3 alternative approaches with trade-offs based on the actual codebase.',
-  },
-  {
-    id: 'ensure-no-regression',
-    emoji: '📉',
-    text: 'Ensure no regression',
-    tip: 'Verify this will not break existing behavior. Identify what could regress.',
-  },
-  {
-    id: 'out-of-scope',
-    emoji: '🚫',
-    text: 'Out of scope',
-    tip: 'This is not part of the current task. Remove it and stay focused on what was requested.',
-  },
-  { id: 'needs-tests', emoji: '🧪', text: 'Needs tests' },
+// The label row, in the groups it is drawn in. A group is what a divider
+// separates, so the grouping lives here as data rather than as an index the
+// popup counts to — reordering a label cannot silently move the divider.
+//
+// Agreement is its own group because it is the only mark that says "keep
+// going". Ninth in a run of seven corrections it reads as one more complaint,
+// and a reviewer with no quick way to say "this part is right" only ever files
+// the objections.
+export const QUICK_LABEL_GROUPS: QuickLabel[][] = [
+  [
+    // Its tip is the longest here on purpose: "good" alone tells an agent
+    // nothing to do, and the point of marking a thing right is that it
+    // survives the next revision.
+    {
+      id: 'exactly-this',
+      emoji: '💯',
+      text: 'Exactly this',
+      tip: 'This is right and it matters. Preserve this decision and the reasoning behind it — do not revisit or trade it away, and apply the same reasoning where it belongs elsewhere.',
+    },
+  ],
+  [
+    { id: 'clarify-this', emoji: '❓', text: 'Clarify this' },
+    {
+      id: 'verify-this',
+      emoji: '🔍',
+      text: 'Verify this',
+      tip: 'This seems like an assumption. Verify by reading the actual code before proceeding.',
+    },
+    {
+      id: 'give-me-an-example',
+      emoji: '🔬',
+      text: 'Give me an example',
+      tip: 'This is too abstract. Show a before/after, a sample input/output, or a specific scenario.',
+    },
+    {
+      id: 'match-existing-patterns',
+      emoji: '🧬',
+      text: 'Match existing patterns',
+      tip: 'Search the codebase for existing patterns that already solve this. Reuse what exists.',
+    },
+    {
+      id: 'consider-alternatives',
+      emoji: '🔄',
+      text: 'Consider alternatives',
+      tip: 'Propose 2-3 alternative approaches with trade-offs based on the actual codebase.',
+    },
+    {
+      id: 'ensure-no-regression',
+      emoji: '📉',
+      text: 'Ensure no regression',
+      tip: 'Verify this will not break existing behavior. Identify what could regress.',
+    },
+    {
+      id: 'out-of-scope',
+      emoji: '🚫',
+      text: 'Out of scope',
+      tip: 'This is not part of the current task. Remove it and stay focused on what was requested.',
+    },
+    { id: 'needs-tests', emoji: '🧪', text: 'Needs tests' },
+  ],
 ];
+
+// Every label, in row order. What the payload resolves against; the grouping
+// above is only how the row is drawn.
+export const QUICK_LABELS: QuickLabel[] = QUICK_LABEL_GROUPS.flat();
 
 export function labelByEmoji(emoji: string): QuickLabel | undefined {
   return QUICK_LABELS.find((label) => label.emoji === emoji);
@@ -79,7 +104,7 @@ export interface PayloadAnnotation {
 export function buildAnnotationPayload(annotations: readonly PayloadAnnotation[]): string {
   if (annotations.length === 0) return '';
   const ordered = [...annotations].sort((a, b) => a.start - b.start);
-  const lines: string[] = ['Feedback on your last message. Address each annotation.', ''];
+  const lines: string[] = ['Feedback on your last message.', ''];
   ordered.forEach((annotation, index) => {
     const label = annotation.emoji ? labelByEmoji(annotation.emoji) : undefined;
     const heading = label

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -959,6 +959,7 @@ function paneCellRect(
 function annotationSurfaceState() {
   const popup = document.querySelector('[data-testid="annotation-popup"]');
   const panel = document.querySelector('[data-testid="annotation-panel"]');
+  const notice = document.querySelector('[data-testid="annotation-notice"]');
   const text = (root: Element | null | undefined, selector: string) =>
     root?.querySelector(selector)?.textContent?.trim() ?? '';
   // Reported so a driver can check the surface is actually reachable — a popup
@@ -1000,6 +1001,11 @@ function annotationSurfaceState() {
       removeRect: box(card.querySelector('.anno-card-remove')),
     })),
     footer: text(panel, '.anno-panel-foot'),
+    // What an annotate gesture that resolved to nothing said for itself. The
+    // whole failure mode this covers is silence, so a driver asserting only on
+    // popup/panel presence cannot tell "explained itself" from "did nothing".
+    notice: notice?.textContent?.trim() ?? null,
+    noticeRect: box(notice),
   };
 }
 

--- a/changelog.d/jolly-walrus-annotation-agreement-and-refusals.yaml
+++ b/changelog.d/jolly-walrus-annotation-agreement-and-refusals.yaml
@@ -1,0 +1,18 @@
+kind: changed
+area: terminal
+change: >
+  Terminal annotations can now say a thing is right. 💯 "Exactly this" leads the
+  label row, held apart from the seven labels that ask for a change, and tells
+  the agent to preserve the decision and the reasoning behind it rather than
+  revisit it on the next pass. Until now every label was a correction, so the
+  only feedback the surface could carry was an objection. The feedback message
+  also stops opening with "Address each annotation" — the annotations are the
+  instruction.
+notes: >
+  An annotate gesture that resolves to nothing now says why instead of doing
+  nothing. Four causes looked identical on screen — the text is not the agent's,
+  the session has no readable transcript, the turn is still running, or the
+  agent has not spoken yet — and each has a different answer, so the surface
+  names the one that applies where the gesture was made. The daemon also logs
+  the unresolvable-transcript case with the session's agent and directory, which
+  was previously returned to the app and dropped without a trace on either side.

--- a/internal/daemon/ws_session_message.go
+++ b/internal/daemon/ws_session_message.go
@@ -60,6 +60,13 @@ func (d *Daemon) handleSessionMessagesGet(client *wsClient, msg *protocol.Sessio
 
 	path := strings.TrimSpace(d.resolveTranscriptPathForSession(session, ""))
 	if path == "" {
+		// Logged, not only returned: this is the one outcome a user reads as "the
+		// feature is broken", and the identity ladder that produced it (no
+		// hook-reported path, no resume id, no find by session id) is invisible
+		// from the app. Naming the session and its directory is what makes the
+		// next question answerable — whether a transcript exists at all.
+		d.logf("session_messages_get: %s: no transcript resolved (agent=%s dir=%s); nothing is annotatable in this session",
+			sessionID, session.Agent, session.Directory)
 		result.Error = protocol.Ptr("session_messages_get: no transcript for session " + sessionID)
 		d.sendToClient(client, result)
 		return


### PR DESCRIPTION
## Why

Reported symptom: a session could not be annotated, and there was no way to find out why. Nothing on screen, nothing in the daemon log.

An alt-drag that resolved to nothing did exactly nothing. Four separate causes produced that identical silence, and each has a different answer for the user:

- the dragged text is not the agent's (TUI chrome, the user's own turn, or a turn scrolled out of the annotatable window)
- the session has no readable transcript
- the turn is still running, so nothing is anchored yet
- the agent has not written a message yet

The daemon half was silent too: `session_messages_get` returned `no transcript for session <id>` without a `d.logf`, and the frontend swallowed it with a bare `.catch(() => {})`.

## What changed

**Refusals explain themselves.** The surface names the cause that actually applies, positioned where the gesture was made, and retires on its own after five seconds — it explains a finished gesture, so it must not become something to dismiss.

**The daemon logs the unresolvable-transcript case** with the session's agent and directory, so the identity ladder that produced it (no hook-reported path, no resume id, no find by session id) is diagnosable from outside the app.

**A latent bug this exposed.** `GhosttyTerminal` armed an alt-drag as an annotation drag only when the store already held messages. That made "nothing to annotate at all" — the reported case — the one situation that structurally could not report anything: the release saw an ordinary selection and had nothing to say. Arming now depends only on the pane having an annotation surface. The drag still falls through to a plain copy when it resolves to nothing; the only thing claimed is the right to explain itself.

**💯 "Exactly this".** Every existing label was a correction, so the only feedback the surface could carry was an objection. The new label leads the row, held apart by a divider, and its tip tells the agent to preserve the decision and the reasoning behind it rather than revisit it on the next pass. The row is now grouped data (`QUICK_LABEL_GROUPS`) rather than an index the popup counts to, so reordering a label cannot silently move the divider.

**Payload preamble** drops `Address each annotation.` — the annotations are the instruction. It was previously unpinned by any test; it is pinned now.

## Verification

Packaged-app scenario `TERMINAL-ANNOTATIONS` PASS on a throwaway profile (protocol 203), all 8 steps, including a new `a_refused_drag_says_why` step that reproduces the reported case end to end: a session with no transcript on disk, the notice on screen with a measured in-viewport rect, the daemon log line asserted from the profile's `daemon.log`, and the notice gone six seconds later. Popup label order read back from the running app:

```
["Exactly this","Clarify this","Verify this","Give me an example",
 "Match existing patterns","Consider alternatives","Ensure no regression",
 "Out of scope","Needs tests","Write a comment","Remove this annotation"]
```

Frontend 2369 tests, Playwright e2e 192, `go test ./internal/daemon ./internal/transcript ./internal/agent`, `tsc --noEmit`, `go build ./...` — all green. Both new-test mutations (neutering the transcript-error branch; cutting the `onAnnotationMiss` wiring) killed exactly the expected tests and nothing else.

## Surfaces walked

- **Daemon and app** — both ends of the same refusal; the daemon logs it, the app shows it.
- **Automation bridge** — `get_annotation_state` reports `notice`/`noticeRect`; the failure mode is silence, so a driver asserting only on popup/panel presence could not tell "explained itself" from "did nothing".
- **Protocol** — untouched. No schema change, no `ProtocolVersion` bump.
- **CLI, Linux, plugins/SDK** — not applicable; this is frontend behavior plus one daemon log line.
- **Docs** — changelog fragment added.

## Known gap

The "agent has not written a message yet" branch is unit-tested only. Live it is shadowed by the no-transcript case, which fires first for a session that has never taken a turn.