### PR TITLE
feat(notebook): allow disabling session summaries

### DIFF
--- a/app/src/components/SettingsModal.css
+++ b/app/src/components/SettingsModal.css
@@ -537,7 +537,16 @@
 
 .settings-keeper-duty-head {
   display: grid;
-  gap: 4px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+}
+
+/* A duty can be independently off while its model remains editable, just like
+   the master switch leaves all duty configuration reachable. */
+.settings-keeper-duty.is-disabled > :not(.settings-keeper-duty-head),
+.settings-keeper-duty.is-disabled .settings-keeper-duty-head > div {
+  opacity: 0.6;
 }
 
 .settings-token-list {

--- a/app/src/components/SettingsModal.test.tsx
+++ b/app/src/components/SettingsModal.test.tsx
@@ -927,7 +927,40 @@ describe('SettingsModal keeper', () => {
     expect(onSetSetting).toHaveBeenCalledWith('notebook.tasks_enabled', 'true');
   });
 
-  it('seeds always-on duties with their tier default and saves an override', async () => {
+  it('toggles session summaries independently and defaults them on', async () => {
+    const onSetSetting = renderModal({});
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    const toggle = await screen.findByTestId('settings-keeper-summarize-toggle');
+    expect(toggle).toHaveTextContent('Disable');
+    expect(toggle).toHaveAccessibleName('Disable session summaries');
+    fireEvent.click(toggle);
+    expect(onSetSetting).toHaveBeenCalledWith(
+      'notebook.summarize_session.enabled',
+      'false',
+    );
+  });
+
+  it('re-enables session summaries without losing their model configuration', async () => {
+    const onSetSetting = renderModal({
+      'notebook.summarize_session.enabled': 'false',
+      'notebook.summarize_session': '{"agent":"codex","model":"gpt-5.4-mini"}',
+    });
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    const toggle = await screen.findByTestId('settings-keeper-summarize-toggle');
+    expect(toggle).toHaveTextContent('Enable');
+    expect(toggle).toHaveAccessibleName('Enable session summaries');
+    expect(screen.getByTestId('settings-keeper-summarize-agent')).toHaveValue('codex');
+    expect(screen.getByTestId('settings-keeper-summarize-model')).toHaveValue('gpt-5.4-mini');
+    fireEvent.click(toggle);
+    expect(onSetSetting).toHaveBeenCalledWith(
+      'notebook.summarize_session.enabled',
+      'true',
+    );
+  });
+
+  it('seeds default-configured duties with their tier default and saves an override', async () => {
     const onSetSetting = renderModal({});
     fireEvent.click(screen.getByTestId('settings-nav-agents'));
 
@@ -949,7 +982,7 @@ describe('SettingsModal keeper', () => {
     );
   });
 
-  it('offers no Disabled agent for always-on duties but does for compaction', async () => {
+  it('offers no Disabled agent for default-configured duties but does for compaction', async () => {
     renderModal({});
     fireEvent.click(screen.getByTestId('settings-nav-agents'));
 
@@ -964,7 +997,7 @@ describe('SettingsModal keeper', () => {
     ).toContain('Disabled');
   });
 
-  it('reverts an always-on duty to its default by clearing the override', async () => {
+  it('reverts a default-configured duty to its default by clearing the override', async () => {
     const onSetSetting = renderModal({
       'notebook.narrate_workspace': '{"agent":"claude","model":"opus"}',
     });

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -144,10 +144,10 @@ const emptyKeeperDrafts: Record<KeeperDutyKey, KeeperDraft> = {
   compact: { agent: '', model: '' },
 };
 
-// initialKeeperDraft seeds a row's editable draft from the saved config. An always-on
-// duty with no override pre-selects its built-in default agent (or the first eligible
-// one) plus that agent's recommended model, so the row shows what "unset" resolves to;
-// an opt-in duty with no override starts blank (the Disabled state).
+// initialKeeperDraft seeds a row's editable draft from the saved config. A
+// default-configured duty with no override pre-selects its built-in default agent (or
+// the first eligible one) plus that agent's recommended model, so the row shows what
+// "unset" resolves to; an opt-in duty with no override starts blank (Disabled).
 function initialKeeperDraft(
   duty: KeeperDutyDescriptor,
   saved: KeeperConfig | null,
@@ -294,7 +294,8 @@ export function SettingsModal({
   const actualAutoSettleArm = String(autoSettleSeconds(settings, AUTO_SETTLE_ARM_SETTING));
   const actualAutoSettleCountdown = String(autoSettleSeconds(settings, AUTO_SETTLE_COUNTDOWN_SETTING));
   // The saved (persisted) config for every keeper duty, keyed by duty. A null entry
-  // means the setting is blank (default for always-on duties, disabled for opt-in).
+  // means the setting is blank (built-in model for default-configured duties,
+  // disabled for opt-in duties).
   const actualKeeperConfigs = useMemo(() => {
     const configs = {} as Record<KeeperDutyKey, KeeperConfig | null>;
     for (const duty of KEEPER_DUTIES) {
@@ -305,6 +306,8 @@ export function SettingsModal({
   // The keeper master switch is daemon-normalized to its effective value (default ON),
   // so a missing key reads as enabled rather than off.
   const keeperTasksEnabled = (settings['notebook.tasks_enabled'] ?? 'true') !== 'false';
+  const notebookSummariesEnabled =
+    (settings['notebook.summarize_session.enabled'] ?? 'true') !== 'false';
   const resolvedDefaultAgent = resolvePreferredAgent(actualDefaultAgent, agentAvailability, 'codex');
   const orderedAgentList = useMemo(
     () => orderedAgents(agentAvailability, resolvedDefaultAgent, 'codex'),
@@ -646,6 +649,13 @@ export function SettingsModal({
     onSetSetting('notebook.tasks_enabled', keeperTasksEnabled ? 'false' : 'true');
   }, [keeperTasksEnabled, onSetSetting]);
 
+  const handleToggleNotebookSummaries = useCallback(() => {
+    onSetSetting(
+      'notebook.summarize_session.enabled',
+      notebookSummariesEnabled ? 'false' : 'true',
+    );
+  }, [notebookSummariesEnabled, onSetSetting]);
+
   // Switching a duty's agent resets its model to that agent's recommended default
   // (the first preset); choosing the empty "Disabled" agent (opt-in duties only)
   // clears the model so Save stays disabled.
@@ -682,9 +692,9 @@ export function SettingsModal({
     );
   }, [keeperDrafts, onSetSetting]);
 
-  // Clearing writes a blank override. For an opt-in duty that disables it; for an
-  // always-on duty it reverts to the built-in tier default. Either way the draft
-  // re-seeds to its unset starting point.
+  // Clearing writes a blank override. For an opt-in duty that disables it; for a
+  // default-configured duty it reverts to the built-in tier default. Either way the
+  // draft re-seeds to its unset starting point.
   const clearKeeperDuty = useCallback((dutyKey: KeeperDutyKey) => {
     const duty = KEEPER_DUTY_BY_KEY[dutyKey];
     onSetSetting(duty.settingKey, '');
@@ -997,7 +1007,7 @@ export function SettingsModal({
           title: 'Agent runtime',
           description: 'Agent executable paths, defaults, context maintenance, capabilities, and PTY runtime mode.',
           count: orderedAgentList.length + 8,
-          keywords: 'agents executables claude codex cursor default capabilities pty backend editor context keeper compact model workflows auto-approve unattended chief context window cap tokens compaction auto-compact headless',
+          keywords: 'agents executables claude codex cursor default capabilities pty backend editor context keeper compact model summaries summarize haiku costs workflows auto-approve unattended chief context window cap tokens compaction auto-compact headless',
         },
       ],
     },
@@ -2031,11 +2041,30 @@ export function SettingsModal({
               const agentId = `${duty.testIdPrefix}-agent`;
               const modelId = `${duty.testIdPrefix}-model`;
               const customId = `${duty.testIdPrefix}-model-custom`;
+              const dutyEnabled = duty.key !== 'summarize' || notebookSummariesEnabled;
               return (
-                <div className="settings-keeper-duty" key={duty.key}>
+                <div
+                  className={`settings-keeper-duty${dutyEnabled ? '' : ' is-disabled'}`}
+                  key={duty.key}
+                >
                   <div className="settings-keeper-duty-head">
-                    <p className="settings-row-title">{duty.title}</p>
-                    <p className="settings-row-copy">{duty.description}</p>
+                    <div>
+                      <p className="settings-row-title">{duty.title}</p>
+                      <p className="settings-row-copy">{duty.description}</p>
+                    </div>
+                    {duty.key === 'summarize' && (
+                      <button
+                        type="button"
+                        className="settings-action"
+                        data-testid="settings-keeper-summarize-toggle"
+                        aria-label={notebookSummariesEnabled
+                          ? 'Disable session summaries'
+                          : 'Enable session summaries'}
+                        onClick={handleToggleNotebookSummaries}
+                      >
+                        {notebookSummariesEnabled ? 'Disable' : 'Enable'}
+                      </button>
+                    )}
                   </div>
                   <div className="settings-field-grid two-column">
                     <div className="settings-field">
@@ -2114,7 +2143,11 @@ export function SettingsModal({
                       `attn workspace context compact` to run it immediately.
                     </div>
                   ) : (
-                    <div className="settings-hint">Defaults to {duty.defaultLabel} when unset.</div>
+                    <div className="settings-hint">
+                      {duty.key === 'summarize' && !notebookSummariesEnabled
+                        ? `Disabled. Its ${duty.defaultLabel} model setting is preserved.`
+                        : `Defaults to ${duty.defaultLabel} when unset.`}
+                    </div>
                   )}
                 </div>
               );

--- a/app/src/utils/keeperDuties.ts
+++ b/app/src/utils/keeperDuties.ts
@@ -8,7 +8,8 @@ import {
 // The keeper runs three async background duties off one durable runner. They share
 // the same {agent, model} config shape (parsed/serialized by workspaceContextKeeper)
 // and differ only in their persisted settings key, their model presets, and whether
-// a blank config means "use a built-in default" (always-on) or "disabled" (opt-in).
+// a blank config means "use a built-in default" (default-configured) or "disabled"
+// (opt-in).
 // This module is the single source of truth the Settings UI reads to render one row
 // per duty.
 
@@ -34,13 +35,14 @@ export interface KeeperDutyDescriptor {
   testIdPrefix: string;
   /**
    * opt-in duties (compaction) treat a blank config as DISABLED and expose a
-   * "Disabled" agent option plus a Disable button. always-on duties (summarize,
-   * narrate) fall back to a built-in tier default when blank, so they offer no
-   * Disabled option and a "Use default" reset instead.
+   * "Disabled" agent option plus a Disable button. Default-configured duties
+   * (summarize, narrate) fall back to a built-in tier default when blank, so
+   * they offer no Disabled agent and a "Use default" reset instead. Runtime
+   * enable switches are separate from this agent/model config behavior.
    */
   optInOnly: boolean;
   /**
-   * Human label for the built-in default an always-on duty resolves to when unset,
+   * Human label for the built-in default a default-configured duty resolves to when unset,
    * shown in the row hint. Empty for opt-in duties (blank means off, not a default).
    */
   defaultLabel: string;

--- a/changelog.d/crispy-heron-session-summary-toggle.yaml
+++ b/changelog.d/crispy-heron-session-summary-toggle.yaml
@@ -1,0 +1,7 @@
+kind: changed
+area: notebook
+change: >
+  Session summaries can now be switched off independently in Settings. Disabling
+  them stops new transcript-summary jobs and prevents already queued jobs from
+  launching their agent, without turning off journal narration or context
+  compaction; the selected summary agent and model stay ready for re-enabling.

--- a/docs/notebook-processes.md
+++ b/docs/notebook-processes.md
@@ -141,7 +141,11 @@ narrative.
     — a mechanical, literal whole-line match tidy-up; promotion into `areas/`
     stays the chief's higher-judgment call.
 - **Settings**: `notebook.summarize_session` / `notebook.narrate_workspace`
-  (`{agent,model}` JSON; blank uses the tier default). Narration is always on.
+  (`{agent,model}` JSON; blank uses the tier default). Session summaries are
+  default-on and can be disabled independently with
+  `notebook.summarize_session.enabled`; queued summaries retire without launching
+  an agent after it is disabled. Workspace narration remains on unless the keeper
+  master switch (`notebook.tasks_enabled`) is disabled.
 
 ## The notebook cron (`internal/daemon/notebook_cron.go`)
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3644,6 +3644,8 @@ func TestDaemon_SettingsValidation(t *testing.T) {
 		{"ticketBoardScale not a number", "ticketBoardScale", "big", true},
 		{"valid tailscale_enabled true", "tailscale_enabled", "true", false},
 		{"valid tailscale_enabled false", "tailscale_enabled", "false", false},
+		{"valid summarize enabled false", "notebook.summarize_session.enabled", "false", false},
+		{"invalid summarize enabled", "notebook.summarize_session.enabled", "maybe", true},
 		{"empty keybindings_config", "keybindings_config", "", false},
 		{"valid keybindings_config", "keybindings_config", `{"version":1,"overrides":{"session.new":{"key":"m","meta":true}}}`, false},
 		{"invalid keybindings_config json", "keybindings_config", "{not json", true},

--- a/internal/daemon/notebook_narration.go
+++ b/internal/daemon/notebook_narration.go
@@ -138,9 +138,9 @@ var notebookNarrationAllowedTools = []string{"Read", "Write", "Edit", "Grep", "G
 // success, if the workspace has since been removed it re-enqueues the retrospective
 // narrate so the late digest lands in it (see the re-narrate hook below).
 func (d *Daemon) summarizeSessionHandler(ctx context.Context, job *jobs.Job) (any, error) {
-	// Master switch: a run queued before the keeper was disabled must not fire
-	// background work after the toggle is off. No-op success retires the record.
-	if !d.notebookTasksEnabled() {
+	// A run queued before either switch was disabled must not fire background
+	// work after the toggle is off. No-op success retires the record.
+	if !d.notebookTasksEnabled() || !d.notebookSummariesEnabled() {
 		return nil, nil
 	}
 	sessionID := strings.TrimSpace(jobSubject(job))
@@ -629,7 +629,7 @@ func (d *Daemon) enqueueSummarizeSession(sessionID, transcriptPath, workspaceID 
 	if sessionID == "" {
 		return
 	}
-	if !d.notebookTasksEnabled() {
+	if !d.notebookTasksEnabled() || !d.notebookSummariesEnabled() {
 		return
 	}
 	runner := d.jobQueueRef()

--- a/internal/daemon/notebook_narration_config.go
+++ b/internal/daemon/notebook_narration_config.go
@@ -17,10 +17,11 @@ const (
 	notebookNarrateWorkspaceKind = "narrate_workspace"
 )
 
-// Tier-default model ids. Narration ALWAYS runs (unlike the keeper's compaction
-// duty, which disables on a blank setting): when a setting is unset/blank we fall back to a
+// Tier-default model ids. Narration model configuration never disables on a blank
+// value (unlike the keeper's compaction duty): an unset setting falls back to a
 // built-in default so session-end and removal-boundary narration work out of the
-// box. Claude is the default agent for BOTH tiers because its native
+// box. The summary duty has a separate boolean runtime switch. Claude is the
+// default agent for BOTH tiers because its native
 // Write/Edit enforce read-before-write CAS, which the shared-journal concurrency
 // story depends on (Codex apply-patch CAS is unverified for the installed
 // version — see notebook_narration.go).
@@ -37,8 +38,9 @@ const (
 )
 
 // notebookNarrationConfig is the resolved {agent, model} for a narration kind. It
-// is never "disabled": parseNotebookNarrationConfig substitutes the tier default
-// for a blank setting, so Agent/Model are always populated for a valid config.
+// is never "disabled" by its model config: parseNotebookNarrationConfig
+// substitutes the tier default for a blank setting, so Agent/Model are always
+// populated for a valid config. Runtime enablement is checked separately.
 type notebookNarrationConfig struct {
 	Agent string `json:"agent"`
 	Model string `json:"model"`
@@ -60,7 +62,7 @@ func narrationTierDefault(kind string) (agent, model string) {
 // resolves the provider, validating at config/enqueue time so a misconfigured
 // agent/model fails fast into failed->dead with a surfaced last_error rather than
 // hanging an executor mid-run. Unlike parseKeeperCompactConfig, a BLANK
-// value yields the tier DEFAULT (narration is always-on), not a disabled config.
+// value yields the tier DEFAULT, not a disabled config.
 // A non-blank value must specify both agent and model.
 func parseNotebookNarrationConfig(kind, raw string) (notebookNarrationConfig, error) {
 	raw = strings.TrimSpace(raw)

--- a/internal/daemon/notebook_tasks_enabled_test.go
+++ b/internal/daemon/notebook_tasks_enabled_test.go
@@ -33,6 +33,52 @@ func TestNotebookTasksEnabledDefaultsOn(t *testing.T) {
 	}
 }
 
+// TestNotebookSummariesEnabledDefaultsOn proves the per-duty switch is also
+// opt-out and that its effective value is present in the settings payload even
+// when no row has been persisted yet.
+func TestNotebookSummariesEnabledDefaultsOn(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+
+	if !d.notebookSummariesEnabled() {
+		t.Fatal("unset notebook.summarize_session.enabled must default to ON")
+	}
+	settings := d.settingsWithAgentAvailability()
+	if got := settings[SettingNotebookSummarizeSessionEnabled]; got != "true" {
+		t.Fatalf("effective summary setting = %#v, want true", got)
+	}
+
+	d.store.SetSetting(SettingNotebookSummarizeSessionEnabled, "false")
+	if d.notebookSummariesEnabled() {
+		t.Fatal("explicit false must disable session summaries")
+	}
+	settings = d.settingsWithAgentAvailability()
+	if got := settings[SettingNotebookSummarizeSessionEnabled]; got != "false" {
+		t.Fatalf("effective summary setting = %#v, want false", got)
+	}
+}
+
+// TestNotebookSummariesDisabledOnlySkipsSummaries proves the per-duty switch
+// leaves journal narration alone while preventing summary records from being
+// created. Re-enabling restores the enqueue path without changing its model.
+func TestNotebookSummariesDisabledOnlySkipsSummaries(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	installNotebookNarrationRunner(t, d)
+
+	d.store.SetSetting(SettingNotebookSummarizeSessionEnabled, "false")
+	d.enqueueSummarizeSession("session-off", "", "")
+	d.enqueueNarrateWorkspace("ws-on")
+	assertNoTask(t, d, notebookSummarizeSessionKind, "session-off")
+	if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-on") {
+		t.Fatal("summary switch must not disable journal narration")
+	}
+
+	d.store.SetSetting(SettingNotebookSummarizeSessionEnabled, "true")
+	d.enqueueSummarizeSession("session-on", "", "")
+	if !taskExists(t, d, notebookSummarizeSessionKind, "session-on") {
+		t.Fatal("summarize must enqueue once its duty switch is on")
+	}
+}
+
 // TestNotebookTasksDisabledSkipsEnqueue proves the master switch gates the
 // BACKGROUND enqueue chokepoints: with the toggle off, a session-stop summarize and
 // a workspace narrate create no durable record at all; flipping it back on (here via
@@ -71,6 +117,24 @@ func TestNotebookTasksDisabledExecutorNoOps(t *testing.T) {
 
 	d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
 		t.Fatal("summarize executor ran the agent while the master switch was off")
+		return agentdriver.HeadlessTaskResult{}, nil
+	}
+
+	if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{UniqueKey: "session-1"}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	waitForTaskState(t, d, notebookSummarizeSessionKind, "session-1", jobs.StateDone)
+}
+
+// TestNotebookSummariesDisabledExecutorNoOps covers the queued-before-toggle
+// case: the durable record completes without spawning a headless agent.
+func TestNotebookSummariesDisabledExecutorNoOps(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	installNotebookNarrationRunner(t, d)
+	d.store.SetSetting(SettingNotebookSummarizeSessionEnabled, "false")
+
+	d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		t.Fatal("summarize executor ran the agent while session summaries were off")
 		return agentdriver.HeadlessTaskResult{}, nil
 	}
 

--- a/internal/daemon/testdata/wire/producers.golden
+++ b/internal/daemon/testdata/wire/producers.golden
@@ -211,6 +211,7 @@
     "model_capture.max_gb": "5",
     "model_capture.path": "<tmp>/model-captures",
     "notebook.root.effective": "<home>/attn-notebook",
+    "notebook.summarize_session.enabled": "true",
     "notebook.tasks_enabled": "true",
     "pty_backend_mode": "embedded",
     "queue_mode_enabled": "false",

--- a/internal/daemon/workspace_keeper.go
+++ b/internal/daemon/workspace_keeper.go
@@ -126,6 +126,20 @@ func (d *Daemon) notebookTasksEnabled() bool {
 	return parseBooleanSetting(raw)
 }
 
+// notebookSummariesEnabled reports whether the keeper's per-session digest duty
+// is enabled. It is an independent, default-on opt-out beneath the keeper master
+// switch: callers check both so the master can still stop every duty at once.
+func (d *Daemon) notebookSummariesEnabled() bool {
+	if d.store == nil {
+		return true
+	}
+	raw := strings.TrimSpace(d.store.GetSetting(SettingNotebookSummarizeSessionEnabled))
+	if raw == "" {
+		return true
+	}
+	return parseBooleanSetting(raw)
+}
+
 // legacyKeeperCompactSettingKey is the pre-rename persisted settings key. It is
 // retained ONLY so migrateKeeperCompactSettingKey can copy a user's configured
 // agent/model forward to SettingKeeperCompact. Never read it anywhere else.

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -115,6 +115,11 @@ const (
 	// (the CHEAP tier). JSON {"agent":"claude"|"codex","model":"<id>"}; empty =>
 	// the built-in cheap default (Claude Haiku). See parseNotebookNarrationConfig.
 	SettingNotebookSummarizeSession = "notebook.summarize_session"
+	// SettingNotebookSummarizeSessionEnabled independently gates the per-session
+	// summarize pass. Default ON preserves existing installs; only an explicit
+	// "false" stops new summaries and retires queued summaries without launching
+	// their agent. The keeper master switch still takes precedence over every duty.
+	SettingNotebookSummarizeSessionEnabled = "notebook.summarize_session.enabled"
 	// SettingNotebookNarrateWorkspace configures the curated-journal narrate pass (the
 	// STRONG tier). JSON {"agent":"claude"|"codex","model":"<id>"}; empty => the
 	// built-in strong default (Claude Sonnet). Claude is the default narrate agent
@@ -343,6 +348,10 @@ func (d *Daemon) settingsWithAgentAvailability() map[string]interface{} {
 	// reflects the default-ON semantics (blank/unset => "true") rather than an
 	// absent key the frontend would read as off.
 	settings[SettingNotebookTasksEnabled] = strconv.FormatBool(d.notebookTasksEnabled())
+	// The summary duty is independently opt-out while remaining default-on for
+	// existing profiles. Surface its effective value for the same reason as the
+	// keeper master switch: the app should never mistake an absent key for off.
+	settings[SettingNotebookSummarizeSessionEnabled] = strconv.FormatBool(d.notebookSummariesEnabled())
 	// Surface the EFFECTIVE token caps so the UI shows the concrete default
 	// (128000) rather than an absent key when the operator has not set one.
 	settings[SettingChiefContextWindowCap] = strconv.Itoa(resolveContextWindowCap(stored[SettingChiefContextWindowCap]))
@@ -490,7 +499,7 @@ func (d *Daemon) validateSetting(key, value string) error {
 		return d.validateNewSessionAgent(value)
 	case SettingTheme:
 		return validateTheme(value)
-	case SettingTailscaleEnabled, SettingWorkflowsEnabled, SettingAutoApproveEnabled, SettingNotebookTasksEnabled, SettingQueueModeEnabled, SettingAutoSettleEnabled, SettingModelCaptureEnabled:
+	case SettingTailscaleEnabled, SettingWorkflowsEnabled, SettingAutoApproveEnabled, SettingNotebookTasksEnabled, SettingNotebookSummarizeSessionEnabled, SettingQueueModeEnabled, SettingAutoSettleEnabled, SettingModelCaptureEnabled:
 		return validateBooleanSetting(value)
 	case SettingModelCaptureIntervalSeconds:
 		return validateModelCaptureInterval(value)


### PR DESCRIPTION
## Intent

Automatic session summaries can repeatedly read full transcripts and accumulate substantial Haiku spend. The keeper master switch is too broad when journal narration and context compaction should keep running. This adds a narrow way to stop summary generation without discarding the configured summary agent or model.

## Summary

- add a default-on notebook.summarize_session.enabled setting
- stop creating new summary jobs while disabled and retire queued jobs without launching an agent
- add an independent Session summaries control in Settings while preserving model configuration
- document the setting and cover default, toggle, enqueue, executor, validation, and wire-payload behavior

## Verification

- repository pre-commit gate: Go build and tests; 211 frontend test files; production frontend build; Playwright 192 passed, 1 environment-skipped
- Linux amd64 daemon compilation
- isolated packaged-app preflight and live Settings verification: disable, confirm persisted value, relaunch, and confirm the control remains disabled
- git diff --check