### PR TITLE
feat(queue): let home wait for the next agent that needs you

### DIFF
--- a/app/scripts/real-app-harness/scenario-agent-queue.mjs
+++ b/app/scripts/real-app-harness/scenario-agent-queue.mjs
@@ -34,7 +34,12 @@
  *      the next agent that owes a turn, the same as settling by hand does,
  *  11. settling by keyboard hands over the next agent that still owes a turn,
  *      and lands on home when nothing does,
- *  12. a settle survives a daemon restart.
+ *  12. a settle survives a daemon restart,
+ *  13. landing on home that way leaves it waiting for the queue to refill — the
+ *      banner says so on a switch the user can throw either way — and the next
+ *      turn to open takes the user to it,
+ *  14. walking to home instead leaves the user there, however many agents start
+ *      asking.
  *
  * Prereqs: `claude` on PATH; a non-production profile install with the
  * automation layer; a built `./attn` (or ATTN_HARNESS_BIN) for the restart step.
@@ -683,6 +688,98 @@ async function main() {
       runner.assert(
         state.activeSessionId === null,
         `no agent is selected once the queue is empty: ${state.activeSessionId}`,
+      );
+
+      // Home reached this way is a wait, not a stop: the user did not choose to
+      // be here, the queue simply ran out. The banner says so on its own switch.
+      const home = await pollFor(
+        async () => {
+          const current = await client.request('home_get_state');
+          return current.allSettled ? current : null;
+        },
+        'home to announce that everything is settled',
+        15_000,
+      );
+      runner.assert(
+        home.followNextTurn === true,
+        `landing on home from a settle arms the wait: ${JSON.stringify(home)}`,
+      );
+
+      // And it is the user's to change, both ways: a switch that only the app
+      // can throw is not a switch.
+      await client.request('dom_click', { selector: '[data-testid="follow-next-turn"] input' });
+      const off = await pollFor(
+        async () => {
+          const current = await client.request('home_get_state');
+          return current.followNextTurn === false ? current : null;
+        },
+        'the wait to be called off from the banner',
+        10_000,
+      );
+      runner.assert(off.followNextTurn === false, 'the wait can be called off from the banner');
+      await client.request('dom_click', { selector: '[data-testid="follow-next-turn"] input' });
+      const backOn = await pollFor(
+        async () => {
+          const current = await client.request('home_get_state');
+          return current.followNextTurn === true ? current : null;
+        },
+        'the wait to be armed again from the banner',
+        10_000,
+      );
+      runner.assert(backOn.followNextTurn === true, 'and armed again from the same switch');
+    });
+
+    await runner.step('waiting_at_home_takes_the_user_to_the_next_turn', async () => {
+      // The other half of the handover. A turn opening while the user waits is
+      // the same event as a turn closing seen from the other side, so it moves
+      // them the same way — without this, home watches an agent start asking and
+      // says nothing.
+      await driveToOwedTurn(client, observer, beta, 'what to do about the wait', 'beta to want the user again');
+      await waitForTurns(client, [beta.sessionId], 'beta back in the band while home waits');
+      const jumped = await pollFor(
+        async () => {
+          const current = await client.request('get_state');
+          return current.activeSessionId === beta.sessionId ? current : null;
+        },
+        'the wait at home to end on the agent that opened a turn',
+        20_000,
+      );
+      runner.assert(
+        jumped.activeSessionId === beta.sessionId,
+        `waiting at home handed over the agent that wants the user: ${jumped.activeSessionId}`,
+      );
+    });
+
+    await runner.step('home_the_user_walked_to_keeps_them', async () => {
+      // The rule the wait exists under: deciding to be on home means staying
+      // there. Going home by hand — from an agent whose turn is still open, so
+      // there is something to be pulled to the whole time — leaves the wait off,
+      // and every agent that starts asking afterwards stays in the queue until
+      // the user goes and takes it.
+      await driver.activateApp();
+      await driver.clickWindow(0.5, 0.5);
+      await driver.pressKey('h', { command: true, shift: true });
+      const home = await pollFor(async () => {
+        const current = await client.request('get_state');
+        return current.activeSessionId === null ? current : null;
+      }, 'Cmd+Shift+H to land on home', 15_000);
+      runner.assert(home.activeSessionId === null, 'the user walked home');
+
+      await driveToOwedTurn(client, observer, alpha, 'whether to stay put', 'alpha to want the user too');
+      await waitForTurns(
+        client,
+        [beta.sessionId, alpha.sessionId],
+        'both agents owed while the user sits on home',
+        30_000,
+      );
+      // Long enough that a jump would have happened: the follow reacts to the
+      // same broadcast that puts the row in the band, which the wait above
+      // already proved lands within seconds.
+      await delay(5_000);
+      const stayed = await client.request('get_state');
+      runner.assert(
+        stayed.activeSessionId === null,
+        `a home the user chose keeps them, however many agents ask: ${stayed.activeSessionId}`,
       );
     });
 

--- a/app/src/App.followNextTurn.test.tsx
+++ b/app/src/App.followNextTurn.test.tsx
@@ -1,0 +1,307 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { act, render } from '@testing-library/react';
+import App from './App';
+import { WHATS_NEW_ID, WHATS_NEW_STORAGE_KEY } from './hooks/useWhatsNew';
+
+// Home is a stop or a wait, and which one it is depends entirely on how the user
+// got there. Landing on home because the queue ran dry arms the wait: the next
+// turn to open takes the user to it. Walking home — ⌘0, the sidebar's Home —
+// leaves it off, because choosing to be somewhere means staying there.
+//
+// The state machine lives in App and is only observable through what it does to
+// the selection, so these drive the real thing: the daemon's turn_owed flips,
+// App's own handover reacts, and the assertions are on which session App
+// selected. setActiveSession is the store's, so the mock store below tracks it
+// the way the real one does — the follow only ends because selecting a session
+// takes the user off home.
+
+const mockUseSessionStore = vi.fn();
+const mockUseDaemonStore = vi.fn();
+const mockUseDaemonSocket = vi.fn();
+const mockUseKeyboardShortcuts = vi.fn();
+
+const { mockSetActiveSession } = vi.hoisted(() => ({
+  mockSetActiveSession: vi.fn(),
+}));
+
+// The daemon's view of the two agents, mutated per step and re-broadcast.
+let turnOwed: Record<string, boolean>;
+let activeSessionId: string | null;
+
+vi.mock('@tauri-apps/plugin-deep-link', () => ({
+  onOpenUrl: vi.fn(async () => () => {}),
+  getCurrent: vi.fn(async () => []),
+}));
+vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn(async () => {}) }));
+
+vi.mock('./components/GhosttyTerminal', async () => {
+  const React = await import('react');
+  return { GhosttyTerminal: React.forwardRef(function MockTerminal() { return null; }) };
+});
+
+vi.mock('./components/Sidebar', () => ({
+  EditorIcon: () => null,
+  WorkflowIcon: () => null,
+  DiffIcon: () => null,
+  PRsIcon: () => null,
+  NotebookIcon: () => null,
+  MarkdownIcon: () => null,
+  Sidebar: () => null,
+}));
+
+vi.mock('./components/Dashboard', () => ({ Dashboard: () => null }));
+// Grid is a real destination in these tests (the user looks around and comes
+// back); the view itself measures a canvas font, which happy-dom has none of.
+vi.mock('./components/grid/GridView', () => ({ GridView: () => null }));
+vi.mock('./components/AttentionDrawer', () => ({ AttentionDrawer: () => null }));
+vi.mock('./components/LocationPicker', () => ({ LocationPicker: () => null }));
+vi.mock('./components/UndoToast', () => ({ UndoToast: () => null }));
+vi.mock('./components/SessionTerminalWorkspace', () => ({ SessionTerminalWorkspace: () => null }));
+vi.mock('./components/ErrorToast', () => ({
+  ErrorToast: () => null,
+  useErrorToast: () => ({ message: null, showError: vi.fn(), clearError: vi.fn() }),
+}));
+vi.mock('./hooks/useKeyboardShortcuts', () => ({
+  useKeyboardShortcuts: (args: unknown) => mockUseKeyboardShortcuts(args),
+}));
+vi.mock('./hooks/useUIScale', () => ({
+  useUIScale: () => ({ scale: 1, increaseScale: vi.fn(), decreaseScale: vi.fn(), resetScale: vi.fn() }),
+}));
+vi.mock('./hooks/useOpenPR', () => ({ useOpenPR: () => vi.fn() }));
+vi.mock('./hooks/usePRsNeedingAttention', () => ({ usePRsNeedingAttention: () => ({ needsAttention: [] }) }));
+vi.mock('./store/sessions', () => ({ useSessionStore: () => mockUseSessionStore() }));
+vi.mock('./store/daemonSessions', () => ({ useDaemonStore: () => mockUseDaemonStore() }));
+vi.mock('./hooks/useDaemonSocket', () => ({
+  useDaemonSocket: (args: unknown) => mockUseDaemonSocket(args),
+}));
+vi.mock('./pty/bridge', async () => {
+  const actual = await vi.importActual<typeof import('./pty/bridge')>('./pty/bridge');
+  return { ...actual, ptySpawn: vi.fn(async () => {}) };
+});
+
+type SocketArgs = {
+  onWorkspacesUpdate?: (workspaces: unknown[]) => void;
+  onSettingsUpdate?: (settings: Record<string, string>) => void;
+};
+
+function socketArgs(): SocketArgs {
+  const calls = mockUseDaemonSocket.mock.calls;
+  return calls[calls.length - 1]?.[0] as SocketArgs;
+}
+
+/** The shortcut handlers App registered on its last render. */
+function shortcutHandlers<T>(): T {
+  const calls = mockUseKeyboardShortcuts.mock.calls;
+  return calls[calls.length - 1]?.[0] as T;
+}
+
+function workspacePayload() {
+  return ['s1', 's2'].map((id) => ({
+    id: `workspace-${id}`,
+    title: id,
+    directory: `/tmp/${id}`,
+    status: 'active',
+    layout: {
+      active_pane_id: `pane-${id}`,
+      layout_json: JSON.stringify({ type: 'pane', pane_id: `pane-${id}` }),
+      panes: [{
+        workspace_id: `workspace-${id}`,
+        pane_id: `pane-${id}`,
+        kind: 'agent',
+        runtime_id: id,
+        session_id: id,
+        title: id,
+      }],
+    },
+  }));
+}
+
+/**
+ * One daemon broadcast: the workspace payload again (a fresh object, so App
+ * re-renders and the mocked stores are read anew) plus the settings that carry
+ * the queue arrangement. Everything the daemon changed between steps — turn_owed,
+ * the selection the app made itself — is picked up here.
+ */
+function broadcast() {
+  act(() => {
+    socketArgs().onSettingsUpdate?.({ queue_mode_enabled: 'true' });
+    socketArgs().onWorkspacesUpdate?.(workspacePayload());
+  });
+}
+
+function selections(): string[] {
+  return mockSetActiveSession.mock.calls.map((call) => call[0] as string);
+}
+
+/** Selecting the last owed agent and settling it: home, with the wait armed. */
+function workTheQueueDownToHome() {
+  render(<App />);
+  broadcast();
+
+  // The user is on the last owed turn...
+  act(() => { mockSetActiveSession('s1'); });
+  broadcast();
+  expect(activeSessionId).toBe('s1');
+
+  // ...and it settles under them. Nothing else is owed, so home it is.
+  turnOwed.s1 = false;
+  broadcast();
+  expect(activeSessionId).toBeNull();
+}
+
+describe('waiting at home for the next turn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem(WHATS_NEW_STORAGE_KEY, WHATS_NEW_ID);
+    turnOwed = { s1: true, s2: false };
+    activeSessionId = null;
+
+    // The real store owns the selection, so the mock does too: App's handover and
+    // the follow both act by calling setActiveSession, and the view follows it.
+    mockSetActiveSession.mockImplementation((id: string | null) => { activeSessionId = id; });
+
+    mockUseSessionStore.mockImplementation(() => ({
+      sessions: ['s1', 's2'].map((id) => ({
+        id,
+        label: id,
+        state: 'working',
+        cwd: `/tmp/${id}`,
+        workspaceId: `workspace-${id}`,
+        agent: 'claude',
+        transcriptMatched: true,
+        daemonActivePaneId: `pane-${id}`,
+        workspace: {
+          agents: [{ id: `pane-${id}`, runtimeId: id, sessionId: id, title: id }],
+          layoutTree: { type: 'pane', paneId: `pane-${id}` },
+        },
+      })),
+      activeSessionId,
+      connect: vi.fn(async () => {}),
+      connected: true,
+      launcherConfig: { executables: {} },
+      createSession: vi.fn(async () => 's1'),
+      closeSession: vi.fn(),
+      setActiveSession: mockSetActiveSession,
+      takeSessionSpawnArgs: vi.fn(() => null),
+      reloadSession: vi.fn(async () => {}),
+      setLauncherConfig: vi.fn(),
+      syncFromDaemonSessions: vi.fn(),
+      syncFromDaemonWorkspaces: vi.fn(),
+    }));
+
+    mockUseDaemonStore.mockImplementation(() => ({
+      daemonSessions: ['s1', 's2'].map((id) => ({
+        id,
+        label: id,
+        directory: `/tmp/${id}`,
+        state: 'working',
+        turn_owed: turnOwed[id],
+        turn_opened_at: id === 's1' ? '2026-08-03T09:00:00Z' : '2026-08-03T10:00:00Z',
+      })),
+      setDaemonSessions: vi.fn(),
+      prs: [], setPRs: vi.fn(),
+      repoStates: [], setRepoStates: vi.fn(),
+      authorStates: [], setAuthorStates: vi.fn(),
+    }));
+
+    const fn = vi.fn();
+    mockUseDaemonSocket.mockReturnValue({
+      sendPRAction: fn, sendMutePR: fn, sendMuteRepo: fn, sendMuteAuthor: fn, sendPRVisited: fn,
+      sendRefreshPRs: vi.fn(async () => ({ success: true })),
+      sendUnregisterSession: vi.fn(async () => {}),
+      sendRegisterWorkspace: fn,
+      sendUnregisterWorkspace: vi.fn(async () => {}),
+      sendMuteWorkspace: vi.fn(async () => ({ success: true })),
+      sendSetSetting: fn,
+      sendCreateWorktree: vi.fn(async () => ({ success: true, path: '/tmp/new' })),
+      sendDeleteWorktree: vi.fn(async () => ({ success: true })),
+      sendGetRecentLocations: vi.fn(async () => ({ success: true, locations: [] })),
+      sendCreateWorktreeFromBranch: vi.fn(async () => ({ success: true, path: '/tmp/new' })),
+      sendFetchRemotes: vi.fn(async () => ({ success: true })),
+      sendFetchPRDetails: vi.fn(async () => ({ success: true })),
+      sendEnsureRepo: vi.fn(async () => ({ success: true, path: '/tmp/repo' })),
+      sendSubscribeGitStatus: fn, sendUnsubscribeGitStatus: fn,
+      sendSessionSelected: fn, sendWorkspaceSelected: fn,
+      sendWorkspaceClosePane: vi.fn(async () => ({ success: true })),
+      sendWorkspaceAddSessionPane: vi.fn(async () => ({ success: true })),
+      requestTileContent: fn,
+      sendGetFileDiff: vi.fn(async () => ({ success: true, original: '', modified: '' })),
+      getRepoInfo: vi.fn(async () => ({ success: true, is_git_repo: true, branch: 'main' })),
+      listWorkflowRuns: vi.fn(async () => ({ success: true, runs: [] })),
+      getPresentations: vi.fn(async () => []),
+      connectionError: null,
+      hasReceivedInitialState: true,
+      sendNotificationList: vi.fn(async () => ({ notifications: [], unreadCount: 0 })),
+      sendNotificationMarkRead: vi.fn(async () => 0),
+      rateLimit: null,
+      warnings: [],
+      clearWarnings: fn,
+      sendSetTerminalTheme: fn,
+    });
+  });
+
+  it('takes the user to the next turn that opens after the queue ran dry', () => {
+    workTheQueueDownToHome();
+
+    // The wait is armed by that arrival, so the next agent to want the user
+    // comes and gets them.
+    turnOwed.s2 = true;
+    broadcast();
+
+    expect(activeSessionId).toBe('s2');
+  });
+
+  it('leaves the user alone at a home they walked to', () => {
+    render(<App />);
+    broadcast();
+    act(() => { mockSetActiveSession('s1'); });
+    broadcast();
+
+    // ⌘0 while the turn on s1 is still owed: a deliberate stop, not a queue that
+    // ran out.
+    const shortcuts = shortcutHandlers<{ onGoToDashboard: () => void }>();
+    act(() => { shortcuts.onGoToDashboard(); });
+    broadcast();
+    expect(activeSessionId).toBeNull();
+
+    const before = selections().length;
+    turnOwed.s2 = true;
+    broadcast();
+
+    expect(activeSessionId).toBeNull();
+    expect(selections()).toHaveLength(before);
+  });
+
+  it('ends the wait when the user leaves home, however they come back', () => {
+    workTheQueueDownToHome();
+
+    // Waiting, then off to grid for a look around and back again. Home reached
+    // that way was chosen, so the wait that armed on the way in does not survive
+    // the round trip.
+    const shortcuts = shortcutHandlers<{ onToggleGridMode?: () => void }>();
+    act(() => { shortcuts.onToggleGridMode?.(); });
+    broadcast();
+    act(() => { shortcuts.onToggleGridMode?.(); });
+    broadcast();
+
+    const before = selections().length;
+    turnOwed.s2 = true;
+    broadcast();
+
+    expect(activeSessionId).toBeNull();
+    expect(selections()).toHaveLength(before);
+  });
+
+  it('hands over the oldest owed turn when several opened while home waited', () => {
+    workTheQueueDownToHome();
+
+    // s1's turn is the older of the two, so it is the one the wait ends on —
+    // queue order, the same order the band and ⌘J use.
+    turnOwed.s1 = true;
+    turnOwed.s2 = true;
+    broadcast();
+
+    expect(activeSessionId).toBe('s1');
+  });
+});

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -112,6 +112,7 @@ import { buildWorkspaceViewModels, filterSessionsRepresentedInWorkspaceLayouts }
 import {
   advanceAfterTurnClosed,
   buildQueueBands,
+  headOfQueue,
   isQueueModeEnabled,
   oldestWantedTurn,
   QUEUE_MODE_SETTING,
@@ -1315,11 +1316,36 @@ function AppContent({
     };
   }, [sendUnsubscribeGitStatus, clearGitStatus]);
 
-  // Function to go to dashboard
-  const goToDashboard = useCallback(() => {
+  // Home is reached two ways, and which one it was decides whether home is a
+  // stop or a wait. Walking here — ⌘0, the sidebar's Home, leaving grid with no
+  // agent selected — is a decision to be here, so nothing may take the user
+  // away again. Being handed here because the queue ran dry is not a decision at
+  // all: there was simply nothing left to go to, and the user is waiting for
+  // work rather than choosing to stop. Only the second arms the latch below.
+  //
+  // The latch is deliberately not a setting. It answers "am I waiting right
+  // now", which is true of one visit to home and false of the next; a
+  // remembered preference would keep pulling the user out of a home they walked
+  // to on purpose, which is the one thing this must never do.
+  const [followNextTurn, setFollowNextTurn] = useState(false);
+  const enterHome = useCallback((awaitingNextTurn: boolean) => {
     setActiveSession(null);
     setView('dashboard');
+    setFollowNextTurn(awaitingNextTurn);
   }, [setActiveSession]);
+
+  // Home because the user asked for it: every button, shortcut and menu route.
+  const goToDashboard = useCallback(() => enterHome(false), [enterHome]);
+
+  // Home because the queue ran dry under the user, not because they asked.
+  const goHomeAwaitingNextTurn = useCallback(() => enterHome(true), [enterHome]);
+
+  // Leaving home ends the wait, whatever took the user out — the follow itself,
+  // ⌘J, a click in the sidebar, grid. Coming back has to arm it again, so the
+  // latch can never outlive the visit it belongs to.
+  useEffect(() => {
+    if (view !== 'dashboard') setFollowNextTurn(false);
+  }, [view]);
 
   // Cmd+G toggles the global grid view on/off; leaving grid returns to wherever
   // the user was (a session if one is active, otherwise the dashboard).
@@ -2726,9 +2752,31 @@ function AppContent({
     if (advance.to === 'session') {
       handleSelectSession(advance.row.session.id);
     } else {
-      goToDashboard();
+      goHomeAwaitingNextTurn();
     }
-  }, [queueBands, queueModeEnabled, view, activeSessionId, handleSelectSession, goToDashboard]);
+  }, [queueBands, queueModeEnabled, view, activeSessionId, handleSelectSession, goHomeAwaitingNextTurn]);
+
+  // Waiting at home: the next turn to open comes and gets the user.
+  //
+  // This is the other half of the handover. Closing the last turn lands the user
+  // on home, and the queue refilling is the same event as a turn closing seen
+  // from the other side — an agent's claim on the user changed while they were
+  // looking somewhere else. Without this, working the queue to the end parks the
+  // user on a screen that watches the next turn open and says nothing.
+  //
+  // Gated on the latch rather than on being home, which is what keeps a home the
+  // user walked to quiet. It is armed by the handover above, or by the user
+  // ticking the box on the banner; either way the box says which it is, so the
+  // jump is never a surprise.
+  //
+  // The head of the queue, not whichever turn happened to open — a wait that
+  // ends on the oldest owed turn is the same order as the band, ⌘J, and the
+  // handover, and picking by arrival time would make it its own fourth order.
+  useEffect(() => {
+    if (!followNextTurn || !queueModeEnabled || view !== 'dashboard') return;
+    const next = headOfQueue(queueBands);
+    if (next) handleSelectSession(next.session.id);
+  }, [followNextTurn, queueModeEnabled, view, queueBands, handleSelectSession]);
 
   // Keyboard shortcut handlers
   const handleJumpToWaiting = useCallback(() => {
@@ -3640,6 +3688,8 @@ function AppContent({
           endpoints={daemonEndpoints}
           onRebootstrapEndpoint={handleRebootstrapEndpoint}
           queueModeEnabled={queueModeEnabled}
+          followNextTurn={followNextTurn}
+          onToggleFollowNextTurn={() => setFollowNextTurn((armed) => !armed)}
           onSelectSession={handleSelectSession}
           onNewSession={() => handleNewSession('vertical')}
           onRefreshPRs={handleRefreshPRs}

--- a/app/src/components/Dashboard.css
+++ b/app/src/components/Dashboard.css
@@ -108,6 +108,25 @@
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
 }
+/* Quieter than the detail line above it: it is a switch, not news. */
+.all-settled-follow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+.all-settled-follow input {
+  accent-color: #78c88c;
+  cursor: pointer;
+  margin: 0;
+}
+.all-settled-follow:hover {
+  color: var(--color-text-secondary);
+}
 
 .rate-limit-banner {
   display: flex;

--- a/app/src/components/Dashboard.test.tsx
+++ b/app/src/components/Dashboard.test.tsx
@@ -259,4 +259,51 @@ describe('Dashboard in queue mode', () => {
     expect(screen.queryByTestId('all-settled')).not.toBeInTheDocument();
     expect(screen.getByTestId('session-group-waiting')).toContainElement(screen.getByTestId('session-s1'));
   });
+
+  // The wait has to be visible and reversible from the screen it happens on:
+  // being moved to another agent without having been told is the surprise the
+  // switch exists to remove, and an armed latch with no way off is a one-way
+  // door.
+  describe('the follow-next-turn switch', () => {
+    const settled = [{ id: 's1', label: 'busy', state: 'working' as const, cwd: '/a', turnOwed: false }];
+
+    it('shows what the wait is set to and turns it off from the banner', () => {
+      const onToggleFollowNextTurn = vi.fn();
+      render(
+        <Dashboard
+          {...props}
+          sessions={settled}
+          followNextTurn
+          onToggleFollowNextTurn={onToggleFollowNextTurn}
+        />
+      );
+
+      const box = screen.getByTestId('follow-next-turn').querySelector('input') as HTMLInputElement;
+      expect(box.checked).toBe(true);
+      fireEvent.click(box);
+      expect(onToggleFollowNextTurn).toHaveBeenCalledTimes(1);
+    });
+
+    it('is off, and still offered, when the user walked home themselves', () => {
+      render(
+        <Dashboard {...props} sessions={settled} onToggleFollowNextTurn={vi.fn()} />
+      );
+
+      const box = screen.getByTestId('follow-next-turn').querySelector('input') as HTMLInputElement;
+      expect(box.checked).toBe(false);
+    });
+
+    it('is absent while a turn is owed, since there is nothing to wait for', () => {
+      render(
+        <Dashboard
+          {...props}
+          sessions={[{ id: 's1', label: 'asking', state: 'waiting_input', cwd: '/a', turnOwed: true, turnOpenedAt: '2026-07-29T09:00:00Z' }]}
+          followNextTurn
+          onToggleFollowNextTurn={vi.fn()}
+        />
+      );
+
+      expect(screen.queryByTestId('follow-next-turn')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/app/src/components/Dashboard.tsx
+++ b/app/src/components/Dashboard.tsx
@@ -74,6 +74,13 @@ interface DashboardProps {
   // first with the settled rest below, or the plain state grouping that is all
   // there is to say when nothing tracks turns.
   queueModeEnabled?: boolean;
+  // Whether home is waiting for the queue to refill: on, the next turn to open
+  // takes the user to it. Owned by App, which arms it when it hands the user
+  // here after the last turn closed and clears it when they walk here
+  // themselves. Home's job is to say which of the two happened and let the user
+  // change it — an app that moves you on its own has to show you the switch.
+  followNextTurn?: boolean;
+  onToggleFollowNextTurn?: () => void;
 }
 
 export function Dashboard({
@@ -93,6 +100,8 @@ export function Dashboard({
   onOpenSettings,
   onMutedGroupClick,
   queueModeEnabled = false,
+  followNextTurn = false,
+  onToggleFollowNextTurn,
 }: DashboardProps) {
   const now = useNow(TURN_AGE_TICK_MS);
 
@@ -298,6 +307,20 @@ export function Dashboard({
           <div className="all-settled-body">
             <span className="all-settled-title">All settled</span>
             <span className="all-settled-detail">{stillRunning}</span>
+            {/* The wait, stated and reversible. It sits inside the banner
+                because it only means anything while nothing is owed: the moment
+                a turn opens it has either taken the user there or it has not,
+                and that is the whole promise. */}
+            {onToggleFollowNextTurn && (
+              <label className="all-settled-follow" data-testid="follow-next-turn">
+                <input
+                  type="checkbox"
+                  checked={followNextTurn}
+                  onChange={onToggleFollowNextTurn}
+                />
+                <span>Take me to the next agent that needs you</span>
+              </label>
+            )}
           </div>
         </div>
       )}

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -2004,6 +2004,26 @@ export function useUiAutomationBridge({
         });
         return session ? serializeSession(session, getActivePaneIdForSession) : null;
       }
+      case 'home_get_state': {
+        // What home is saying about the queue, read off the banner the user is
+        // looking at. `allSettled: false` is a real answer — the banner is drawn
+        // only while nothing is owed — and `followNextTurn` is the switch that
+        // decides whether the next turn to open comes and gets the user, so a
+        // caller can testify both to how it was set and to who set it.
+        //
+        // Scoped to the view that is actually on screen: home stays mounted
+        // behind the session view, so an unscoped query would report the banner
+        // to a caller looking at an agent.
+        const visible = document.querySelector('.view-container.visible');
+        const banner = visible?.querySelector('[data-testid="all-settled"]') ?? null;
+        const follow = visible?.querySelector('[data-testid="follow-next-turn"] input');
+        return {
+          onScreen: Boolean(visible?.querySelector('.dashboard')),
+          allSettled: Boolean(banner),
+          detail: banner?.querySelector('.all-settled-detail')?.textContent?.trim() || '',
+          followNextTurn: follow instanceof HTMLInputElement ? follow.checked : null,
+        };
+      }
       case 'queue_get_state': {
         // Read the rendered band, not the model behind it: ordering, membership,
         // and the live state dot are the whole claim of the queue arrangement,

--- a/app/src/utils/queueBands.test.ts
+++ b/app/src/utils/queueBands.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   advanceAfterTurnClosed,
   buildQueueBands,
+  headOfQueue,
   oldestWantedTurn,
   type QueueBandSession,
 } from './queueBands';
@@ -438,5 +439,27 @@ describe('advanceAfterTurnClosed', () => {
 
     expect(advanceAfterTurnClosed(bands.turns, bands, null)).toBeNull();
     expect(advanceAfterTurnClosed(bands.turns, null, 'a')).toBeNull();
+  });
+});
+
+describe('headOfQueue', () => {
+  it('is the turn owed longest, not the first one listed by the workspace tree', () => {
+    // Home waits on this while the queue is empty, so it must answer with the
+    // same row the band and ⌘J lead with — the oldest turn, wherever it lives.
+    const bands = buildQueueBands(views([
+      { id: 'newer', label: 'newer', workspaceId: 'ws-a', turnOwed: true, turnOpenedAt: '2026-07-26T12:00:00Z' },
+      { id: 'older', label: 'older', workspaceId: 'ws-b', turnOwed: true, turnOpenedAt: '2026-07-26T09:00:00Z' },
+    ]));
+
+    expect(headOfQueue(bands)?.session.id).toBe('older');
+  });
+
+  it('is null while nothing is owed, and with no bands at all', () => {
+    const settled = buildQueueBands(views([
+      { id: 'a', label: 'a', workspaceId: 'ws-a', turnOwed: false },
+    ]));
+
+    expect(headOfQueue(settled)).toBeNull();
+    expect(headOfQueue(null)).toBeNull();
   });
 });

--- a/app/src/utils/queueBands.ts
+++ b/app/src/utils/queueBands.ts
@@ -249,6 +249,19 @@ function nextOwedAfter<TSession extends QueueBandSession>(
   return null;
 }
 
+/**
+ * The turn at the head of the queue: the one owed longest, which is the row the
+ * band lists first and the agent ⌘J jumps to. Exported because two places send
+ * the user there and they must not disagree about which agent "next" means —
+ * the handover when it runs off the end of the old snapshot, and home when it is
+ * waiting for the queue to refill.
+ */
+export function headOfQueue<TSession extends QueueBandSession>(
+  bands: QueueBands<TSession> | null,
+): QueueRow<TSession> | null {
+  return bands?.turns[0] ?? null;
+}
+
 /** Where selection goes when a turn closes: the next agent, or home. */
 export type QueueAdvance<TSession extends QueueBandSession> =
   | { to: 'session'; row: QueueRow<TSession> }
@@ -301,6 +314,6 @@ export function advanceAfterTurnClosed<TSession extends QueueBandSession>(
     bands.snoozed.some((row) => row.session.id === sessionId);
   if (!owedBefore || !closedNow) return null;
   const stillOwed = new Set(bands.turns.map((row) => row.session.id));
-  const next = nextOwedAfter(previousTurns, sessionId, stillOwed) ?? bands.turns[0] ?? null;
+  const next = nextOwedAfter(previousTurns, sessionId, stillOwed) ?? headOfQueue(bands);
   return next ? { to: 'session', row: next } : { to: 'dashboard' };
 }

--- a/changelog.d/rugged-pigeon-home-waits-for-the-next-turn.yaml
+++ b/changelog.d/rugged-pigeon-home-waits-for-the-next-turn.yaml
@@ -1,0 +1,17 @@
+kind: added
+area: queue
+change: >
+  Home can wait for the next agent instead of just sitting there. Working the
+  queue down to nothing lands you on the home screen, and until now the next
+  turn to open would sit in the queue until you went and took it — so an
+  auto-settle that moved you on quietly ended with you watching a screen that
+  knew an agent wanted you and said nothing. The all-settled banner now carries
+  "Take me to the next agent that needs you", and arriving because the queue ran
+  dry — from an auto-settle countdown, a settle from the sidebar, Cmd+Shift+E,
+  or a snooze — ticks it for you. The next turn to open takes you to it: the one
+  owed longest, the same agent the queue's first row and Cmd+J lead with.
+  Walking home yourself leaves the box unticked and leaves you there, however
+  many agents start asking; choosing to be on the home screen is a decision, not
+  a gap between turns. The box is yours either way — tick it to wait, untick it
+  to stay — and the wait belongs to that visit alone, so leaving home ends it
+  and coming back starts over.


### PR DESCRIPTION
Working the agent queue down to nothing lands you on home. Until now the next turn to open would sit in the queue until you went and took it, so an auto-settle that moved you on ended with you watching a screen that knew an agent wanted you and said nothing.

## What changes

Home is now either a **stop** or a **wait**, decided by how you got there.

- **Handed there because the queue ran dry** — an auto-settle countdown, a settle from a sidebar row, Cmd+Shift+E, a snooze — arms a latch, announced on the all-settled banner as *"Take me to the next agent that needs you"*. The next turn to open hands you that agent: the head of the queue, the same row the band lists first and Cmd+J jumps to.
- **Walked there yourself** — Cmd+Shift+H, the sidebar's Home, leaving grid with nothing selected — leaves the latch off and leaves you there, however many agents start asking. Choosing to be somewhere is a decision.
- The switch is yours either way, and the wait belongs to one visit: leaving home ends it, coming back starts it over.

The latch is app state, not a setting. It answers "am I waiting right now", which is true of one visit to home and false of the next; a remembered preference would keep pulling you out of a home you walked to on purpose, which is the one thing this must not do.

`headOfQueue` is now shared by the handover's fallback and the wait, so the two cannot disagree about which agent "next" means.

## Surfaces

Client navigation policy only — no daemon, protocol, CLI, Linux, plugin or SDK surface is involved. No new keyboard shortcut: the control sits on the screen it governs.

## Proof

- **Unit** — `queueBands.test.ts` (head-of-queue order), `Dashboard.test.tsx` (the switch is shown, reversible, and absent while a turn is owed), and a new `App.followNextTurn.test.tsx` driving the arm/disarm state machine through real broadcasts. Mutation-checked: removing the arm reddens three tests, removing the disarm reddens exactly the grid-round-trip one, on its load-bearing assert. Full frontend suite green (212 files, 2388 tests), `tsc` clean.
- **Live** — `scenario-agent-queue.mjs` grows three steps and was run on a throwaway profile against two real Claude agents: **19/19 steps, `ok: true`**. It witnessed the banner arming on arrival (`followNextTurn: true`), the switch toggling both ways from the banner, the wait handing over the agent that opened a turn, and Cmd+Shift+H leaving the user on home with both agents owed.
- `home_get_state` is a new UI-automation bridge verb, scoped to the visible view because home stays mounted behind the session view.

https://claude.ai/code/session_011BGBqtNFETpfY2toGpVk2T