### PR TITLE
Fix model capture size status

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -751,7 +751,6 @@ function AppContent({
     sendSetChiefOfStaff,
     sendUnregisterSession,
     sendSetSetting,
-    sendGetSettings,
     sendCreateWorktree,
     sendDeleteWorktree,
     sendListPlugins,
@@ -4091,7 +4090,6 @@ function AppContent({
         onRemovePlugin={sendRemovePlugin}
         onSetPluginPriority={sendSetPluginPriority}
         onSetSetting={sendSetSetting}
-        onRefreshSettings={sendGetSettings}
         themePreference={themePreference}
         onSetTheme={setTheme}
         uiScale={scale}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -751,6 +751,7 @@ function AppContent({
     sendSetChiefOfStaff,
     sendUnregisterSession,
     sendSetSetting,
+    sendGetSettings,
     sendCreateWorktree,
     sendDeleteWorktree,
     sendListPlugins,
@@ -4090,6 +4091,7 @@ function AppContent({
         onRemovePlugin={sendRemovePlugin}
         onSetPluginPriority={sendSetPluginPriority}
         onSetSetting={sendSetSetting}
+        onRefreshSettings={sendGetSettings}
         themePreference={themePreference}
         onSetTheme={setTheme}
         uiScale={scale}

--- a/app/src/components/SettingsModal.test.tsx
+++ b/app/src/components/SettingsModal.test.tsx
@@ -786,6 +786,61 @@ describe('SettingsModal model data capture', () => {
     });
     expect(onSetSetting).toHaveBeenCalledWith('model_capture.max_gb', '10');
   });
+
+  it('refreshes captured bytes at the configured cadence only while Data is visible', () => {
+    vi.useFakeTimers();
+    const onRefreshSettings = vi.fn();
+    const { unmount } = render(
+      <SettingsModal
+        isOpen
+        onClose={vi.fn()}
+        mutedRepos={[]}
+        githubHosts={[]}
+        onUnmuteRepo={vi.fn()}
+        mutedAuthors={[]}
+        onUnmuteAuthor={vi.fn()}
+        settings={{
+          'model_capture.enabled': 'true',
+          'model_capture.interval_seconds': '10',
+          'model_capture.max_gb': '5',
+          'model_capture.path': '/Users/me/.attn/model-captures',
+          'model_capture.bytes': '0',
+        }}
+        endpoints={[]}
+        plugins={[]}
+        pluginIssues={[]}
+        onAddEndpoint={vi.fn().mockResolvedValue({ success: true })}
+        onUpdateEndpoint={vi.fn().mockResolvedValue({ success: true })}
+        onRemoveEndpoint={vi.fn().mockResolvedValue({ success: true })}
+        onSetEndpointRemoteWeb={vi.fn().mockResolvedValue({ success: true })}
+        onListPlugins={vi.fn().mockResolvedValue({ plugins: [], issues: [] })}
+        onInstallPlugin={vi.fn().mockResolvedValue({ success: true })}
+        onRemovePlugin={vi.fn().mockResolvedValue({ success: true })}
+        onSetPluginPriority={vi.fn().mockResolvedValue({ success: true })}
+        onSetSetting={vi.fn()}
+        onRefreshSettings={onRefreshSettings}
+        themePreference="system"
+        onSetTheme={vi.fn()}
+      />,
+    );
+
+    try {
+      fireEvent.click(screen.getByTestId('settings-nav-data'));
+      expect(onRefreshSettings).toHaveBeenCalledTimes(1);
+
+      act(() => vi.advanceTimersByTime(9_999));
+      expect(onRefreshSettings).toHaveBeenCalledTimes(1);
+      act(() => vi.advanceTimersByTime(1));
+      expect(onRefreshSettings).toHaveBeenCalledTimes(2);
+
+      fireEvent.click(screen.getByTestId('settings-nav-general'));
+      act(() => vi.advanceTimersByTime(10_000));
+      expect(onRefreshSettings).toHaveBeenCalledTimes(2);
+    } finally {
+      unmount();
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('SettingsModal notebook folder', () => {

--- a/app/src/components/SettingsModal.test.tsx
+++ b/app/src/components/SettingsModal.test.tsx
@@ -3,6 +3,9 @@ import { act, fireEvent, render, screen, waitFor } from '../test/utils';
 import { SettingsModal } from './SettingsModal';
 import { getSettingsAutomationHandle } from './settingsAutomation';
 
+const daemonApi = vi.hoisted(() => ({ sendGetSettings: vi.fn() }));
+vi.mock('../contexts/DaemonApiContext', () => ({ useDaemonApi: () => daemonApi }));
+
 describe('SettingsModal', () => {
   it('closes on escape', async () => {
     const onClose = vi.fn();
@@ -789,7 +792,7 @@ describe('SettingsModal model data capture', () => {
 
   it('refreshes captured bytes at the configured cadence only while Data is visible', () => {
     vi.useFakeTimers();
-    const onRefreshSettings = vi.fn();
+    daemonApi.sendGetSettings.mockClear();
     const { unmount } = render(
       <SettingsModal
         isOpen
@@ -818,7 +821,6 @@ describe('SettingsModal model data capture', () => {
         onRemovePlugin={vi.fn().mockResolvedValue({ success: true })}
         onSetPluginPriority={vi.fn().mockResolvedValue({ success: true })}
         onSetSetting={vi.fn()}
-        onRefreshSettings={onRefreshSettings}
         themePreference="system"
         onSetTheme={vi.fn()}
       />,
@@ -826,16 +828,16 @@ describe('SettingsModal model data capture', () => {
 
     try {
       fireEvent.click(screen.getByTestId('settings-nav-data'));
-      expect(onRefreshSettings).toHaveBeenCalledTimes(1);
+      expect(daemonApi.sendGetSettings).toHaveBeenCalledTimes(1);
 
       act(() => vi.advanceTimersByTime(9_999));
-      expect(onRefreshSettings).toHaveBeenCalledTimes(1);
+      expect(daemonApi.sendGetSettings).toHaveBeenCalledTimes(1);
       act(() => vi.advanceTimersByTime(1));
-      expect(onRefreshSettings).toHaveBeenCalledTimes(2);
+      expect(daemonApi.sendGetSettings).toHaveBeenCalledTimes(2);
 
       fireEvent.click(screen.getByTestId('settings-nav-general'));
       act(() => vi.advanceTimersByTime(10_000));
-      expect(onRefreshSettings).toHaveBeenCalledTimes(2);
+      expect(daemonApi.sendGetSettings).toHaveBeenCalledTimes(2);
     } finally {
       unmount();
       vi.useRealTimers();

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -24,6 +24,7 @@ import {
   AUTO_SETTLE_COUNTDOWN_SETTING,
 } from '../utils/queueBands';
 import type { ThemePreference } from '../hooks/useTheme';
+import { useDaemonApi } from '../contexts/DaemonApiContext';
 import {
   AGENT_CAPABILITY_ORDER,
   agentCapabilityLabel,
@@ -73,7 +74,6 @@ interface SettingsModalProps {
   onRemovePlugin: (name: string) => Promise<{ success: boolean; name?: string }>;
   onSetPluginPriority: (name: string, priority: number) => Promise<{ success: boolean; name?: string }>;
   onSetSetting: (key: string, value: string) => void;
-  onRefreshSettings?: () => void;
   themePreference: ThemePreference;
   onSetTheme: (theme: ThemePreference) => void;
   /** App-wide font scale (uiScale setting). Optional so tests without font-size
@@ -183,7 +183,6 @@ export function SettingsModal({
   onRemovePlugin,
   onSetPluginPriority,
   onSetSetting,
-  onRefreshSettings,
   themePreference,
   onSetTheme,
   uiScale = 1,
@@ -199,6 +198,7 @@ export function SettingsModal({
   retryTask,
   taskChangeSignal,
 }: SettingsModalProps) {
+  const { sendGetSettings } = useDaemonApi();
   const [projectsDir, setProjectsDir] = useState(settings.projects_directory || '');
   const [notebookRoot, setNotebookRoot] = useState(settings['notebook.root'] || '');
   const [agentExecutables, setAgentExecutables] = useState<Record<SessionAgent, string>>({});
@@ -458,17 +458,17 @@ export function SettingsModal({
   useEscapeStack(onClose, isOpen);
 
   useEffect(() => {
-    if (!isOpen || selectedSection !== 'data' || !onRefreshSettings) return;
+    if (!isOpen || selectedSection !== 'data') return;
 
-    onRefreshSettings();
+    sendGetSettings();
     if (!modelCaptureEnabled) return;
 
     const intervalSeconds = Number(modelCaptureInterval);
     if (!Number.isFinite(intervalSeconds) || intervalSeconds <= 0) return;
 
-    const intervalID = window.setInterval(onRefreshSettings, intervalSeconds * 1000);
+    const intervalID = window.setInterval(sendGetSettings, intervalSeconds * 1000);
     return () => window.clearInterval(intervalID);
-  }, [isOpen, selectedSection, modelCaptureEnabled, modelCaptureInterval, onRefreshSettings]);
+  }, [isOpen, selectedSection, modelCaptureEnabled, modelCaptureInterval, sendGetSettings]);
 
   // Publish a read/select handle for the UI automation bridge (testing only).
   // Registered for the component's whole lifetime (not just while open) so the

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -73,6 +73,7 @@ interface SettingsModalProps {
   onRemovePlugin: (name: string) => Promise<{ success: boolean; name?: string }>;
   onSetPluginPriority: (name: string, priority: number) => Promise<{ success: boolean; name?: string }>;
   onSetSetting: (key: string, value: string) => void;
+  onRefreshSettings?: () => void;
   themePreference: ThemePreference;
   onSetTheme: (theme: ThemePreference) => void;
   /** App-wide font scale (uiScale setting). Optional so tests without font-size
@@ -182,6 +183,7 @@ export function SettingsModal({
   onRemovePlugin,
   onSetPluginPriority,
   onSetSetting,
+  onRefreshSettings,
   themePreference,
   onSetTheme,
   uiScale = 1,
@@ -454,6 +456,19 @@ export function SettingsModal({
   }, [isOpen, actualProjectsDir, actualNotebookRoot, actualAgentExecutables, actualChiefModels, actualChiefEfforts, actualDefaultModels, actualDefaultEfforts, actualEditorExecutable, resolvedDefaultAgent, actualReviewerModel, actualChiefContextCap, actualHeadlessContextCap, actualAutoSettleArm, actualAutoSettleCountdown, actualKeeperConfigs, keeperAgents]);
 
   useEscapeStack(onClose, isOpen);
+
+  useEffect(() => {
+    if (!isOpen || selectedSection !== 'data' || !onRefreshSettings) return;
+
+    onRefreshSettings();
+    if (!modelCaptureEnabled) return;
+
+    const intervalSeconds = Number(modelCaptureInterval);
+    if (!Number.isFinite(intervalSeconds) || intervalSeconds <= 0) return;
+
+    const intervalID = window.setInterval(onRefreshSettings, intervalSeconds * 1000);
+    return () => window.clearInterval(intervalID);
+  }, [isOpen, selectedSection, modelCaptureEnabled, modelCaptureInterval, onRefreshSettings]);
 
   // Publish a read/select handle for the UI automation bridge (testing only).
   // Registered for the component's whole lifetime (not just while open) so the

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -2557,6 +2557,40 @@ describe('useDaemonSocket PTY kill sequencing', () => {
 
 });
 
+describe('useDaemonSocket settings refresh', () => {
+  let originalWebSocket: typeof WebSocket;
+
+  beforeEach(() => {
+    originalWebSocket = globalThis.WebSocket;
+    FakeWebSocket.instances = [];
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+  });
+
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket;
+    vi.clearAllMocks();
+  });
+
+  it('requests a fresh settings snapshot', async () => {
+    const { result, unmount } = renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate: vi.fn(),
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        wsUrl: 'ws://localhost:9999/ws',
+      }),
+    );
+
+    const ws = await waitForOpenSocket();
+    act(() => result.current.sendGetSettings());
+
+    expect(ws.sent.map((entry) => JSON.parse(entry))).toContainEqual({ cmd: 'get_settings' });
+    unmount();
+  });
+});
+
 describe('useDaemonSocket workflow runs', () => {
   let originalWebSocket: typeof WebSocket;
 

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -3843,6 +3843,12 @@ export function useDaemonSocket({
     ws.send(JSON.stringify({ cmd: 'set_setting', key, value }));
   }, []);
 
+  const sendGetSettings = useCallback(() => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify({ cmd: 'get_settings' }));
+  }, []);
+
   const sendListPlugins = useCallback((): Promise<PluginListResult> => {
     const key = 'list_plugins';
     return sendKeyedRequest<PluginListResult>(key, { cmd: 'list_plugins' }, 'List plugins timed out');
@@ -4912,6 +4918,7 @@ export function useDaemonSocket({
     sendCreateWorktree,
     sendDeleteWorktree,
     sendSetSetting,
+    sendGetSettings,
     sendListPlugins,
     sendInstallPlugin,
     sendInstallBundledPlugin,

--- a/changelog.d/fix-model-capture-size.yaml
+++ b/changelog.d/fix-model-capture-size.yaml
@@ -1,0 +1,8 @@
+kind: fixed
+area: settings
+change: >
+  The Data settings page now refreshes the model-capture byte count while it is
+  visible, using the configured capture interval.
+symptom: >
+  The capture toggle worked and observations accumulated on disk, but the
+  Captured value stayed at 0 bytes until the app reconnected.


### PR DESCRIPTION
## What changed

- Request a fresh daemon settings snapshot when the Data settings section becomes visible.
- Continue refreshing at the configured model-capture interval while that section is visible and capture is enabled.
- Stop the refresh when the user leaves the section or disables capture.

## Why

The recorder was writing observations correctly, but `model_capture.bytes` was only computed when the daemon happened to send a settings snapshot. Enabling capture sent that snapshot before the first write, so the UI stayed at `0 bytes` even while the corpus grew.

This uses the existing `get_settings` command and scopes refresh work to the visible Data page. It avoids broadcasting the full settings payload after every recorder write to every connected client.

## User impact

The Captured value now reflects corpus growth while the user is looking at it. Capture behavior, retention, privacy boundaries, and the wire contract are unchanged.

## Validation

- Frontend: 211 test files passed; 2,381 tests passed and 4 skipped.
- Frontend production build passed (`tsc` and Vite).
- Changelog validator and gate passed.
- Installed branch as the isolated dev app; bundled preflight passed with protocol 204.
- Live dev verification observed an immediate settings refresh on opening Data, another refresh after the configured 10-second interval, and no continued cadence after disabling capture.
