### PR TITLE
feat(docstore): namespaced JSON documents with live queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,8 @@ forgets that position and `--since <RFC3339>` replays from an instant.
   `internal/pty`, not inside the daemon
 - `internal/store`: SQLite plus in-memory cache
 - `internal/bus`: durable event bus (domain facts, per-consumer cursors)
+- `internal/docstore`: document-store query semantics and SQL compilation (no DB
+  handle; `internal/store/documents.go` executes what it compiles)
 - `internal/jobs`: durable job queue (retry/backoff, coalescing, commit fence,
   cron entries) — every background duty and every periodic tick runs on it
 - `internal/classifier`: stop-time state classification

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -196,7 +196,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '205';
+export const PROTOCOL_VERSION = '206';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocumentCollectionSchema, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentSort, DocUndefineMessage, DocUndefineResult, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocumentCollectionSchema, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentSort, DocUndefineMessage, DocUndefineResult, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -133,6 +133,7 @@
 //   const getDefaultBranchMessage = Convert.toGetDefaultBranchMessage(json);
 //   const getDefaultBranchResultMessage = Convert.toGetDefaultBranchResultMessage(json);
 //   const getFileDiffMessage = Convert.toGetFileDiffMessage(json);
+//   const getKittyImageMessage = Convert.toGetKittyImageMessage(json);
 //   const getPresentationRoundMessage = Convert.toGetPresentationRoundMessage(json);
 //   const getPresentationRoundResultMessage = Convert.toGetPresentationRoundResultMessage(json);
 //   const getPresentationsMessage = Convert.toGetPresentationsMessage(json);
@@ -167,6 +168,9 @@
 //   const journalAppendMessage = Convert.toJournalAppendMessage(json);
 //   const journalAppendResult = Convert.toJournalAppendResult(json);
 //   const killSessionMessage = Convert.toKillSessionMessage(json);
+//   const kittyImageResultMessage = Convert.toKittyImageResultMessage(json);
+//   const kittyPlacement = Convert.toKittyPlacement(json);
+//   const kittyPlacementsMessage = Convert.toKittyPlacementsMessage(json);
 //   const listBranchesMessage = Convert.toListBranchesMessage(json);
 //   const listEndpointsMessage = Convert.toListEndpointsMessage(json);
 //   const listPluginsMessage = Convert.toListPluginsMessage(json);
@@ -490,6 +494,7 @@ export enum AttachResultMessageEvent {
 export interface Snapshot {
     blocks?:              BlockElement[];
     cols:                 number;
+    placements?:          PlacementElement[];
     rows:                 number;
     scrollback_truncated: boolean;
     vt_dump_b64:          string;
@@ -506,6 +511,26 @@ export interface BlockElement {
     output_start_row?: number;
     pending:           boolean;
     prompt_row:        number;
+    [property: string]: any;
+}
+
+export interface PlacementElement {
+    grid_cols:        number;
+    grid_rows:        number;
+    image_generation: number;
+    image_id:         number;
+    pixel_height:     number;
+    pixel_width:      number;
+    placement_id:     number;
+    source_height:    number;
+    source_width:     number;
+    source_x:         number;
+    source_y:         number;
+    viewport_col:     number;
+    viewport_row:     number;
+    viewport_visible: boolean;
+    virtual:          boolean;
+    z:                number;
     [property: string]: any;
 }
 
@@ -532,6 +557,7 @@ export enum AttachSessionMessageCmd {
 export interface AttachSnapshot {
     blocks?:              BlockElement[];
     cols:                 number;
+    placements?:          PlacementElement[];
     rows:                 number;
     scrollback_truncated: boolean;
     vt_dump_b64:          string;
@@ -2199,6 +2225,17 @@ export enum GetFileDiffMessageCmd {
     GetFileDiff = "get_file_diff",
 }
 
+export interface GetKittyImageMessage {
+    cmd:      GetKittyImageMessageCmd;
+    id:       string;
+    image_id: number;
+    [property: string]: any;
+}
+
+export enum GetKittyImageMessageCmd {
+    GetKittyImage = "get_kitty_image",
+}
+
 export interface GetPresentationRoundMessage {
     cmd:             GetPresentationRoundMessageCmd;
     presentation_id: string;
@@ -2806,6 +2843,56 @@ export interface KillSessionMessage {
 
 export enum KillSessionMessageCmd {
     KillSession = "kill_session",
+}
+
+export interface KittyImageResultMessage {
+    data_b64?:   string;
+    error?:      string;
+    event:       KittyImageResultMessageEvent;
+    format?:     string;
+    generation?: number;
+    height?:     number;
+    id:          string;
+    image_id:    number;
+    success:     boolean;
+    width?:      number;
+    [property: string]: any;
+}
+
+export enum KittyImageResultMessageEvent {
+    KittyImageResult = "kitty_image_result",
+}
+
+export interface KittyPlacement {
+    grid_cols:        number;
+    grid_rows:        number;
+    image_generation: number;
+    image_id:         number;
+    pixel_height:     number;
+    pixel_width:      number;
+    placement_id:     number;
+    source_height:    number;
+    source_width:     number;
+    source_x:         number;
+    source_y:         number;
+    viewport_col:     number;
+    viewport_row:     number;
+    viewport_visible: boolean;
+    virtual:          boolean;
+    z:                number;
+    [property: string]: any;
+}
+
+export interface KittyPlacementsMessage {
+    event:      KittyPlacementsMessageEvent;
+    id:         string;
+    placements: PlacementElement[];
+    seq:        number;
+    [property: string]: any;
+}
+
+export enum KittyPlacementsMessageEvent {
+    KittyPlacements = "kitty_placements",
 }
 
 export interface ListBranchesMessage {
@@ -7323,6 +7410,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("GetFileDiffMessage")), null, 2);
     }
 
+    public static toGetKittyImageMessage(json: string): GetKittyImageMessage {
+        return cast(JSON.parse(json), r("GetKittyImageMessage"));
+    }
+
+    public static getKittyImageMessageToJson(value: GetKittyImageMessage): string {
+        return JSON.stringify(uncast(value, r("GetKittyImageMessage")), null, 2);
+    }
+
     public static toGetPresentationRoundMessage(json: string): GetPresentationRoundMessage {
         return cast(JSON.parse(json), r("GetPresentationRoundMessage"));
     }
@@ -7593,6 +7688,30 @@ export class Convert {
 
     public static killSessionMessageToJson(value: KillSessionMessage): string {
         return JSON.stringify(uncast(value, r("KillSessionMessage")), null, 2);
+    }
+
+    public static toKittyImageResultMessage(json: string): KittyImageResultMessage {
+        return cast(JSON.parse(json), r("KittyImageResultMessage"));
+    }
+
+    public static kittyImageResultMessageToJson(value: KittyImageResultMessage): string {
+        return JSON.stringify(uncast(value, r("KittyImageResultMessage")), null, 2);
+    }
+
+    public static toKittyPlacement(json: string): KittyPlacement {
+        return cast(JSON.parse(json), r("KittyPlacement"));
+    }
+
+    public static kittyPlacementToJson(value: KittyPlacement): string {
+        return JSON.stringify(uncast(value, r("KittyPlacement")), null, 2);
+    }
+
+    public static toKittyPlacementsMessage(json: string): KittyPlacementsMessage {
+        return cast(JSON.parse(json), r("KittyPlacementsMessage"));
+    }
+
+    public static kittyPlacementsMessageToJson(value: KittyPlacementsMessage): string {
+        return JSON.stringify(uncast(value, r("KittyPlacementsMessage")), null, 2);
     }
 
     public static toListBranchesMessage(json: string): ListBranchesMessage {
@@ -9882,6 +10001,7 @@ const typeMap: any = {
     "Snapshot": o([
         { json: "blocks", js: "blocks", typ: u(undefined, a(r("BlockElement"))) },
         { json: "cols", js: "cols", typ: 0 },
+        { json: "placements", js: "placements", typ: u(undefined, a(r("PlacementElement"))) },
         { json: "rows", js: "rows", typ: 0 },
         { json: "scrollback_truncated", js: "scrollback_truncated", typ: true },
         { json: "vt_dump_b64", js: "vt_dump_b64", typ: "" },
@@ -9897,6 +10017,24 @@ const typeMap: any = {
         { json: "pending", js: "pending", typ: true },
         { json: "prompt_row", js: "prompt_row", typ: 0 },
     ], "any"),
+    "PlacementElement": o([
+        { json: "grid_cols", js: "grid_cols", typ: 0 },
+        { json: "grid_rows", js: "grid_rows", typ: 0 },
+        { json: "image_generation", js: "image_generation", typ: 0 },
+        { json: "image_id", js: "image_id", typ: 0 },
+        { json: "pixel_height", js: "pixel_height", typ: 0 },
+        { json: "pixel_width", js: "pixel_width", typ: 0 },
+        { json: "placement_id", js: "placement_id", typ: 0 },
+        { json: "source_height", js: "source_height", typ: 0 },
+        { json: "source_width", js: "source_width", typ: 0 },
+        { json: "source_x", js: "source_x", typ: 0 },
+        { json: "source_y", js: "source_y", typ: 0 },
+        { json: "viewport_col", js: "viewport_col", typ: 0 },
+        { json: "viewport_row", js: "viewport_row", typ: 0 },
+        { json: "viewport_visible", js: "viewport_visible", typ: true },
+        { json: "virtual", js: "virtual", typ: true },
+        { json: "z", js: "z", typ: 0 },
+    ], "any"),
     "AttachSessionMessage": o([
         { json: "attach_policy", js: "attach_policy", typ: u(undefined, r("AttachPolicy")) },
         { json: "cmd", js: "cmd", typ: r("AttachSessionMessageCmd") },
@@ -9907,6 +10045,7 @@ const typeMap: any = {
     "AttachSnapshot": o([
         { json: "blocks", js: "blocks", typ: u(undefined, a(r("BlockElement"))) },
         { json: "cols", js: "cols", typ: 0 },
+        { json: "placements", js: "placements", typ: u(undefined, a(r("PlacementElement"))) },
         { json: "rows", js: "rows", typ: 0 },
         { json: "scrollback_truncated", js: "scrollback_truncated", typ: true },
         { json: "vt_dump_b64", js: "vt_dump_b64", typ: "" },
@@ -10886,6 +11025,11 @@ const typeMap: any = {
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
         { json: "staged", js: "staged", typ: u(undefined, true) },
     ], "any"),
+    "GetKittyImageMessage": o([
+        { json: "cmd", js: "cmd", typ: r("GetKittyImageMessageCmd") },
+        { json: "id", js: "id", typ: "" },
+        { json: "image_id", js: "image_id", typ: 0 },
+    ], "any"),
     "GetPresentationRoundMessage": o([
         { json: "cmd", js: "cmd", typ: r("GetPresentationRoundMessageCmd") },
         { json: "presentation_id", js: "presentation_id", typ: "" },
@@ -11240,6 +11384,42 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("KillSessionMessageCmd") },
         { json: "id", js: "id", typ: "" },
         { json: "signal", js: "signal", typ: u(undefined, "") },
+    ], "any"),
+    "KittyImageResultMessage": o([
+        { json: "data_b64", js: "data_b64", typ: u(undefined, "") },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("KittyImageResultMessageEvent") },
+        { json: "format", js: "format", typ: u(undefined, "") },
+        { json: "generation", js: "generation", typ: u(undefined, 0) },
+        { json: "height", js: "height", typ: u(undefined, 0) },
+        { json: "id", js: "id", typ: "" },
+        { json: "image_id", js: "image_id", typ: 0 },
+        { json: "success", js: "success", typ: true },
+        { json: "width", js: "width", typ: u(undefined, 0) },
+    ], "any"),
+    "KittyPlacement": o([
+        { json: "grid_cols", js: "grid_cols", typ: 0 },
+        { json: "grid_rows", js: "grid_rows", typ: 0 },
+        { json: "image_generation", js: "image_generation", typ: 0 },
+        { json: "image_id", js: "image_id", typ: 0 },
+        { json: "pixel_height", js: "pixel_height", typ: 0 },
+        { json: "pixel_width", js: "pixel_width", typ: 0 },
+        { json: "placement_id", js: "placement_id", typ: 0 },
+        { json: "source_height", js: "source_height", typ: 0 },
+        { json: "source_width", js: "source_width", typ: 0 },
+        { json: "source_x", js: "source_x", typ: 0 },
+        { json: "source_y", js: "source_y", typ: 0 },
+        { json: "viewport_col", js: "viewport_col", typ: 0 },
+        { json: "viewport_row", js: "viewport_row", typ: 0 },
+        { json: "viewport_visible", js: "viewport_visible", typ: true },
+        { json: "virtual", js: "virtual", typ: true },
+        { json: "z", js: "z", typ: 0 },
+    ], "any"),
+    "KittyPlacementsMessage": o([
+        { json: "event", js: "event", typ: r("KittyPlacementsMessageEvent") },
+        { json: "id", js: "id", typ: "" },
+        { json: "placements", js: "placements", typ: a(r("PlacementElement")) },
+        { json: "seq", js: "seq", typ: 0 },
     ], "any"),
     "ListBranchesMessage": o([
         { json: "cmd", js: "cmd", typ: r("ListBranchesMessageCmd") },
@@ -13626,6 +13806,9 @@ const typeMap: any = {
     "GetFileDiffMessageCmd": [
         "get_file_diff",
     ],
+    "GetKittyImageMessageCmd": [
+        "get_kitty_image",
+    ],
     "GetPresentationRoundMessageCmd": [
         "get_presentation_round",
     ],
@@ -13745,6 +13928,12 @@ const typeMap: any = {
     ],
     "KillSessionMessageCmd": [
         "kill_session",
+    ],
+    "KittyImageResultMessageEvent": [
+        "kitty_image_result",
+    ],
+    "KittyPlacementsMessageEvent": [
+        "kitty_placements",
     ],
     "ListBranchesMessageCmd": [
         "list_branches",

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1463,6 +1463,7 @@ export enum DocQueryMessageCmd {
 }
 
 export interface Query {
+    after?:     string;
     collection: string;
     filters?:   FilterElement[];
     limit?:     number;
@@ -1526,6 +1527,7 @@ export interface DocumentFilter {
 }
 
 export interface DocumentQuery {
+    after?:     string;
     collection: string;
     filters?:   FilterElement[];
     limit?:     number;
@@ -10445,6 +10447,7 @@ const typeMap: any = {
         { json: "query", js: "query", typ: r("Query") },
     ], "any"),
     "Query": o([
+        { json: "after", js: "after", typ: u(undefined, "") },
         { json: "collection", js: "collection", typ: "" },
         { json: "filters", js: "filters", typ: u(undefined, a(r("FilterElement"))) },
         { json: "limit", js: "limit", typ: u(undefined, 0) },
@@ -10486,6 +10489,7 @@ const typeMap: any = {
         { json: "value_json", js: "value_json", typ: "" },
     ], "any"),
     "DocumentQuery": o([
+        { json: "after", js: "after", typ: u(undefined, "") },
         { json: "collection", js: "collection", typ: "" },
         { json: "filters", js: "filters", typ: u(undefined, a(r("FilterElement"))) },
         { json: "limit", js: "limit", typ: u(undefined, 0) },

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocumentCollectionSchema, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentSort, DocUndefineMessage, DocUndefineResult, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -66,6 +66,27 @@
 //   const detachSessionMessage = Convert.toDetachSessionMessage(json);
 //   const directoryEntry = Convert.toDirectoryEntry(json);
 //   const dispatchWorkState = Convert.toDispatchWorkState(json);
+//   const docCollectionsMessage = Convert.toDocCollectionsMessage(json);
+//   const docCollectionsResult = Convert.toDocCollectionsResult(json);
+//   const docDefineMessage = Convert.toDocDefineMessage(json);
+//   const docDefineResult = Convert.toDocDefineResult(json);
+//   const docDeleteMessage = Convert.toDocDeleteMessage(json);
+//   const docDeleteResult = Convert.toDocDeleteResult(json);
+//   const docGetMessage = Convert.toDocGetMessage(json);
+//   const docGetResult = Convert.toDocGetResult(json);
+//   const docPutMessage = Convert.toDocPutMessage(json);
+//   const docPutResult = Convert.toDocPutResult(json);
+//   const docQueryMessage = Convert.toDocQueryMessage(json);
+//   const docQueryResult = Convert.toDocQueryResult(json);
+//   const docSubscribeMessage = Convert.toDocSubscribeMessage(json);
+//   const docSubscribeResult = Convert.toDocSubscribeResult(json);
+//   const documentCollectionSchema = Convert.toDocumentCollectionSchema(json);
+//   const documentFieldSpec = Convert.toDocumentFieldSpec(json);
+//   const documentFilter = Convert.toDocumentFilter(json);
+//   const documentQuery = Convert.toDocumentQuery(json);
+//   const documentSort = Convert.toDocumentSort(json);
+//   const docUndefineMessage = Convert.toDocUndefineMessage(json);
+//   const docUndefineResult = Convert.toDocUndefineResult(json);
 //   const endpointActionResultMessage = Convert.toEndpointActionResultMessage(json);
 //   const endpointCapabilities = Convert.toEndpointCapabilities(json);
 //   const endpointInfo = Convert.toEndpointInfo(json);
@@ -112,7 +133,6 @@
 //   const getDefaultBranchMessage = Convert.toGetDefaultBranchMessage(json);
 //   const getDefaultBranchResultMessage = Convert.toGetDefaultBranchResultMessage(json);
 //   const getFileDiffMessage = Convert.toGetFileDiffMessage(json);
-//   const getKittyImageMessage = Convert.toGetKittyImageMessage(json);
 //   const getPresentationRoundMessage = Convert.toGetPresentationRoundMessage(json);
 //   const getPresentationRoundResultMessage = Convert.toGetPresentationRoundResultMessage(json);
 //   const getPresentationsMessage = Convert.toGetPresentationsMessage(json);
@@ -147,9 +167,6 @@
 //   const journalAppendMessage = Convert.toJournalAppendMessage(json);
 //   const journalAppendResult = Convert.toJournalAppendResult(json);
 //   const killSessionMessage = Convert.toKillSessionMessage(json);
-//   const kittyImageResultMessage = Convert.toKittyImageResultMessage(json);
-//   const kittyPlacement = Convert.toKittyPlacement(json);
-//   const kittyPlacementsMessage = Convert.toKittyPlacementsMessage(json);
 //   const listBranchesMessage = Convert.toListBranchesMessage(json);
 //   const listEndpointsMessage = Convert.toListEndpointsMessage(json);
 //   const listPluginsMessage = Convert.toListPluginsMessage(json);
@@ -300,6 +317,7 @@
 //   const stateExplainResult = Convert.toStateExplainResult(json);
 //   const stateMessage = Convert.toStateMessage(json);
 //   const stopMessage = Convert.toStopMessage(json);
+//   const storedDocument = Convert.toStoredDocument(json);
 //   const subscribeGitStatusMessage = Convert.toSubscribeGitStatusMessage(json);
 //   const task = Convert.toTask(json);
 //   const taskListMessage = Convert.toTaskListMessage(json);
@@ -472,7 +490,6 @@ export enum AttachResultMessageEvent {
 export interface Snapshot {
     blocks?:              BlockElement[];
     cols:                 number;
-    placements?:          PlacementElement[];
     rows:                 number;
     scrollback_truncated: boolean;
     vt_dump_b64:          string;
@@ -489,26 +506,6 @@ export interface BlockElement {
     output_start_row?: number;
     pending:           boolean;
     prompt_row:        number;
-    [property: string]: any;
-}
-
-export interface PlacementElement {
-    grid_cols:        number;
-    grid_rows:        number;
-    image_generation: number;
-    image_id:         number;
-    pixel_height:     number;
-    pixel_width:      number;
-    placement_id:     number;
-    source_height:    number;
-    source_width:     number;
-    source_x:         number;
-    source_y:         number;
-    viewport_col:     number;
-    viewport_row:     number;
-    viewport_visible: boolean;
-    virtual:          boolean;
-    z:                number;
     [property: string]: any;
 }
 
@@ -535,7 +532,6 @@ export enum AttachSessionMessageCmd {
 export interface AttachSnapshot {
     blocks?:              BlockElement[];
     cols:                 number;
-    placements?:          PlacementElement[];
     rows:                 number;
     scrollback_truncated: boolean;
     vt_dump_b64:          string;
@@ -1347,6 +1343,221 @@ export interface DirectoryEntry {
     [property: string]: any;
 }
 
+export interface DocCollectionsMessage {
+    cmd: DocCollectionsMessageCmd;
+    [property: string]: any;
+}
+
+export enum DocCollectionsMessageCmd {
+    DocCollections = "doc_collections",
+}
+
+export interface DocCollectionsResult {
+    collections: Schema[];
+    [property: string]: any;
+}
+
+export interface Schema {
+    collection: string;
+    fields:     FieldElement[];
+    namespace:  string;
+    [property: string]: any;
+}
+
+export interface FieldElement {
+    name: string;
+    type: string;
+    [property: string]: any;
+}
+
+export interface DocDefineMessage {
+    cmd:    DocDefineMessageCmd;
+    schema: Schema;
+    [property: string]: any;
+}
+
+export enum DocDefineMessageCmd {
+    DocDefine = "doc_define",
+}
+
+export interface DocDefineResult {
+    collection: string;
+    namespace:  string;
+    [property: string]: any;
+}
+
+export interface DocDeleteMessage {
+    cmd:        DocDeleteMessageCmd;
+    collection: string;
+    id:         string;
+    namespace:  string;
+    [property: string]: any;
+}
+
+export enum DocDeleteMessageCmd {
+    DocDelete = "doc_delete",
+}
+
+export interface DocDeleteResult {
+    collection: string;
+    existed:    boolean;
+    id:         string;
+    namespace:  string;
+    [property: string]: any;
+}
+
+export interface DocGetMessage {
+    cmd:        DocGetMessageCmd;
+    collection: string;
+    id:         string;
+    namespace:  string;
+    [property: string]: any;
+}
+
+export enum DocGetMessageCmd {
+    DocGet = "doc_get",
+}
+
+export interface DocGetResult {
+    document?: Document;
+    found:     boolean;
+    [property: string]: any;
+}
+
+export interface Document {
+    body:       string;
+    created_at: string;
+    id:         string;
+    updated_at: string;
+    [property: string]: any;
+}
+
+export interface DocPutMessage {
+    body:       string;
+    cmd:        DocPutMessageCmd;
+    collection: string;
+    id:         string;
+    namespace:  string;
+    [property: string]: any;
+}
+
+export enum DocPutMessageCmd {
+    DocPut = "doc_put",
+}
+
+export interface DocPutResult {
+    collection: string;
+    id:         string;
+    namespace:  string;
+    [property: string]: any;
+}
+
+export interface DocQueryMessage {
+    cmd:   DocQueryMessageCmd;
+    query: Query;
+    [property: string]: any;
+}
+
+export enum DocQueryMessageCmd {
+    DocQuery = "doc_query",
+}
+
+export interface Query {
+    collection: string;
+    filters?:   FilterElement[];
+    limit?:     number;
+    namespace:  string;
+    sort?:      Sort;
+    [property: string]: any;
+}
+
+export interface FilterElement {
+    field:      string;
+    op:         string;
+    value_json: string;
+    [property: string]: any;
+}
+
+export interface Sort {
+    desc?: boolean;
+    field: string;
+    [property: string]: any;
+}
+
+export interface DocQueryResult {
+    documents: Document[];
+    [property: string]: any;
+}
+
+export interface DocSubscribeMessage {
+    cmd:   DocSubscribeMessageCmd;
+    query: Query;
+    [property: string]: any;
+}
+
+export enum DocSubscribeMessageCmd {
+    DocSubscribe = "doc_subscribe",
+}
+
+export interface DocSubscribeResult {
+    documents: Document[];
+    revision:  number;
+    [property: string]: any;
+}
+
+export interface DocumentCollectionSchema {
+    collection: string;
+    fields:     FieldElement[];
+    namespace:  string;
+    [property: string]: any;
+}
+
+export interface DocumentFieldSpec {
+    name: string;
+    type: string;
+    [property: string]: any;
+}
+
+export interface DocumentFilter {
+    field:      string;
+    op:         string;
+    value_json: string;
+    [property: string]: any;
+}
+
+export interface DocumentQuery {
+    collection: string;
+    filters?:   FilterElement[];
+    limit?:     number;
+    namespace:  string;
+    sort?:      Sort;
+    [property: string]: any;
+}
+
+export interface DocumentSort {
+    desc?: boolean;
+    field: string;
+    [property: string]: any;
+}
+
+export interface DocUndefineMessage {
+    cmd:        DocUndefineMessageCmd;
+    collection: string;
+    namespace:  string;
+    [property: string]: any;
+}
+
+export enum DocUndefineMessageCmd {
+    DocUndefine = "doc_undefine",
+}
+
+export interface DocUndefineResult {
+    collection:        string;
+    documents_removed: number;
+    namespace:         string;
+    [property: string]: any;
+}
+
 export interface EndpointActionResultMessage {
     action:       string;
     endpoint_id?: string;
@@ -1986,17 +2197,6 @@ export enum GetFileDiffMessageCmd {
     GetFileDiff = "get_file_diff",
 }
 
-export interface GetKittyImageMessage {
-    cmd:      GetKittyImageMessageCmd;
-    id:       string;
-    image_id: number;
-    [property: string]: any;
-}
-
-export enum GetKittyImageMessageCmd {
-    GetKittyImage = "get_kitty_image",
-}
-
 export interface GetPresentationRoundMessage {
     cmd:             GetPresentationRoundMessageCmd;
     presentation_id: string;
@@ -2604,56 +2804,6 @@ export interface KillSessionMessage {
 
 export enum KillSessionMessageCmd {
     KillSession = "kill_session",
-}
-
-export interface KittyImageResultMessage {
-    data_b64?:   string;
-    error?:      string;
-    event:       KittyImageResultMessageEvent;
-    format?:     string;
-    generation?: number;
-    height?:     number;
-    id:          string;
-    image_id:    number;
-    success:     boolean;
-    width?:      number;
-    [property: string]: any;
-}
-
-export enum KittyImageResultMessageEvent {
-    KittyImageResult = "kitty_image_result",
-}
-
-export interface KittyPlacement {
-    grid_cols:        number;
-    grid_rows:        number;
-    image_generation: number;
-    image_id:         number;
-    pixel_height:     number;
-    pixel_width:      number;
-    placement_id:     number;
-    source_height:    number;
-    source_width:     number;
-    source_x:         number;
-    source_y:         number;
-    viewport_col:     number;
-    viewport_row:     number;
-    viewport_visible: boolean;
-    virtual:          boolean;
-    z:                number;
-    [property: string]: any;
-}
-
-export interface KittyPlacementsMessage {
-    event:      KittyPlacementsMessageEvent;
-    id:         string;
-    placements: PlacementElement[];
-    seq:        number;
-    [property: string]: any;
-}
-
-export enum KittyPlacementsMessageEvent {
-    KittyPlacements = "kitty_placements",
 }
 
 export interface ListBranchesMessage {
@@ -3960,6 +4110,14 @@ export interface Response {
     data?:                                 string;
     delegate_result?:                      DelegateResultObject;
     delegation_operation?:                 DelegationOperationObject;
+    doc_collections_result?:               DocCollectionsResultObject;
+    doc_define_result?:                    DocDefineResultObject;
+    doc_delete_result?:                    DocDeleteResultObject;
+    doc_get_result?:                       DocGetResultObject;
+    doc_put_result?:                       DocPutResultObject;
+    doc_query_result?:                     DocQueryResultObject;
+    doc_subscribe_result?:                 DocSubscribeResultObject;
+    doc_undefine_result?:                  DocUndefineResultObject;
     error?:                                string;
     journal_append_result?:                JournalAppendResultObject;
     notebook_entries?:                     NotebookEntryElement[];
@@ -3989,6 +4147,56 @@ export interface Response {
     workspace_context_result?:             WorkspaceContextResultObject;
     workspace_contexts?:                   WorkspaceContextElement[];
     workspaces?:                           WorkspaceElement[];
+    [property: string]: any;
+}
+
+export interface DocCollectionsResultObject {
+    collections: Schema[];
+    [property: string]: any;
+}
+
+export interface DocDefineResultObject {
+    collection: string;
+    namespace:  string;
+    [property: string]: any;
+}
+
+export interface DocDeleteResultObject {
+    collection: string;
+    existed:    boolean;
+    id:         string;
+    namespace:  string;
+    [property: string]: any;
+}
+
+export interface DocGetResultObject {
+    document?: Document;
+    found:     boolean;
+    [property: string]: any;
+}
+
+export interface DocPutResultObject {
+    collection: string;
+    id:         string;
+    namespace:  string;
+    [property: string]: any;
+}
+
+export interface DocQueryResultObject {
+    documents: Document[];
+    [property: string]: any;
+}
+
+export interface DocSubscribeResultObject {
+    documents: Document[];
+    revision:  number;
+    [property: string]: any;
+}
+
+export interface DocUndefineResultObject {
+    collection:        string;
+    documents_removed: number;
+    namespace:         string;
     [property: string]: any;
 }
 
@@ -4791,6 +4999,14 @@ export interface StopMessage {
 
 export enum StopMessageCmd {
     Stop = "stop",
+}
+
+export interface StoredDocument {
+    body:       string;
+    created_at: string;
+    id:         string;
+    updated_at: string;
+    [property: string]: any;
 }
 
 export interface SubscribeGitStatusMessage {
@@ -6569,6 +6785,174 @@ export class Convert {
         return JSON.stringify(uncast(value, r("DispatchWorkState")), null, 2);
     }
 
+    public static toDocCollectionsMessage(json: string): DocCollectionsMessage {
+        return cast(JSON.parse(json), r("DocCollectionsMessage"));
+    }
+
+    public static docCollectionsMessageToJson(value: DocCollectionsMessage): string {
+        return JSON.stringify(uncast(value, r("DocCollectionsMessage")), null, 2);
+    }
+
+    public static toDocCollectionsResult(json: string): DocCollectionsResult {
+        return cast(JSON.parse(json), r("DocCollectionsResult"));
+    }
+
+    public static docCollectionsResultToJson(value: DocCollectionsResult): string {
+        return JSON.stringify(uncast(value, r("DocCollectionsResult")), null, 2);
+    }
+
+    public static toDocDefineMessage(json: string): DocDefineMessage {
+        return cast(JSON.parse(json), r("DocDefineMessage"));
+    }
+
+    public static docDefineMessageToJson(value: DocDefineMessage): string {
+        return JSON.stringify(uncast(value, r("DocDefineMessage")), null, 2);
+    }
+
+    public static toDocDefineResult(json: string): DocDefineResult {
+        return cast(JSON.parse(json), r("DocDefineResult"));
+    }
+
+    public static docDefineResultToJson(value: DocDefineResult): string {
+        return JSON.stringify(uncast(value, r("DocDefineResult")), null, 2);
+    }
+
+    public static toDocDeleteMessage(json: string): DocDeleteMessage {
+        return cast(JSON.parse(json), r("DocDeleteMessage"));
+    }
+
+    public static docDeleteMessageToJson(value: DocDeleteMessage): string {
+        return JSON.stringify(uncast(value, r("DocDeleteMessage")), null, 2);
+    }
+
+    public static toDocDeleteResult(json: string): DocDeleteResult {
+        return cast(JSON.parse(json), r("DocDeleteResult"));
+    }
+
+    public static docDeleteResultToJson(value: DocDeleteResult): string {
+        return JSON.stringify(uncast(value, r("DocDeleteResult")), null, 2);
+    }
+
+    public static toDocGetMessage(json: string): DocGetMessage {
+        return cast(JSON.parse(json), r("DocGetMessage"));
+    }
+
+    public static docGetMessageToJson(value: DocGetMessage): string {
+        return JSON.stringify(uncast(value, r("DocGetMessage")), null, 2);
+    }
+
+    public static toDocGetResult(json: string): DocGetResult {
+        return cast(JSON.parse(json), r("DocGetResult"));
+    }
+
+    public static docGetResultToJson(value: DocGetResult): string {
+        return JSON.stringify(uncast(value, r("DocGetResult")), null, 2);
+    }
+
+    public static toDocPutMessage(json: string): DocPutMessage {
+        return cast(JSON.parse(json), r("DocPutMessage"));
+    }
+
+    public static docPutMessageToJson(value: DocPutMessage): string {
+        return JSON.stringify(uncast(value, r("DocPutMessage")), null, 2);
+    }
+
+    public static toDocPutResult(json: string): DocPutResult {
+        return cast(JSON.parse(json), r("DocPutResult"));
+    }
+
+    public static docPutResultToJson(value: DocPutResult): string {
+        return JSON.stringify(uncast(value, r("DocPutResult")), null, 2);
+    }
+
+    public static toDocQueryMessage(json: string): DocQueryMessage {
+        return cast(JSON.parse(json), r("DocQueryMessage"));
+    }
+
+    public static docQueryMessageToJson(value: DocQueryMessage): string {
+        return JSON.stringify(uncast(value, r("DocQueryMessage")), null, 2);
+    }
+
+    public static toDocQueryResult(json: string): DocQueryResult {
+        return cast(JSON.parse(json), r("DocQueryResult"));
+    }
+
+    public static docQueryResultToJson(value: DocQueryResult): string {
+        return JSON.stringify(uncast(value, r("DocQueryResult")), null, 2);
+    }
+
+    public static toDocSubscribeMessage(json: string): DocSubscribeMessage {
+        return cast(JSON.parse(json), r("DocSubscribeMessage"));
+    }
+
+    public static docSubscribeMessageToJson(value: DocSubscribeMessage): string {
+        return JSON.stringify(uncast(value, r("DocSubscribeMessage")), null, 2);
+    }
+
+    public static toDocSubscribeResult(json: string): DocSubscribeResult {
+        return cast(JSON.parse(json), r("DocSubscribeResult"));
+    }
+
+    public static docSubscribeResultToJson(value: DocSubscribeResult): string {
+        return JSON.stringify(uncast(value, r("DocSubscribeResult")), null, 2);
+    }
+
+    public static toDocumentCollectionSchema(json: string): DocumentCollectionSchema {
+        return cast(JSON.parse(json), r("DocumentCollectionSchema"));
+    }
+
+    public static documentCollectionSchemaToJson(value: DocumentCollectionSchema): string {
+        return JSON.stringify(uncast(value, r("DocumentCollectionSchema")), null, 2);
+    }
+
+    public static toDocumentFieldSpec(json: string): DocumentFieldSpec {
+        return cast(JSON.parse(json), r("DocumentFieldSpec"));
+    }
+
+    public static documentFieldSpecToJson(value: DocumentFieldSpec): string {
+        return JSON.stringify(uncast(value, r("DocumentFieldSpec")), null, 2);
+    }
+
+    public static toDocumentFilter(json: string): DocumentFilter {
+        return cast(JSON.parse(json), r("DocumentFilter"));
+    }
+
+    public static documentFilterToJson(value: DocumentFilter): string {
+        return JSON.stringify(uncast(value, r("DocumentFilter")), null, 2);
+    }
+
+    public static toDocumentQuery(json: string): DocumentQuery {
+        return cast(JSON.parse(json), r("DocumentQuery"));
+    }
+
+    public static documentQueryToJson(value: DocumentQuery): string {
+        return JSON.stringify(uncast(value, r("DocumentQuery")), null, 2);
+    }
+
+    public static toDocumentSort(json: string): DocumentSort {
+        return cast(JSON.parse(json), r("DocumentSort"));
+    }
+
+    public static documentSortToJson(value: DocumentSort): string {
+        return JSON.stringify(uncast(value, r("DocumentSort")), null, 2);
+    }
+
+    public static toDocUndefineMessage(json: string): DocUndefineMessage {
+        return cast(JSON.parse(json), r("DocUndefineMessage"));
+    }
+
+    public static docUndefineMessageToJson(value: DocUndefineMessage): string {
+        return JSON.stringify(uncast(value, r("DocUndefineMessage")), null, 2);
+    }
+
+    public static toDocUndefineResult(json: string): DocUndefineResult {
+        return cast(JSON.parse(json), r("DocUndefineResult"));
+    }
+
+    public static docUndefineResultToJson(value: DocUndefineResult): string {
+        return JSON.stringify(uncast(value, r("DocUndefineResult")), null, 2);
+    }
+
     public static toEndpointActionResultMessage(json: string): EndpointActionResultMessage {
         return cast(JSON.parse(json), r("EndpointActionResultMessage"));
     }
@@ -6937,14 +7321,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("GetFileDiffMessage")), null, 2);
     }
 
-    public static toGetKittyImageMessage(json: string): GetKittyImageMessage {
-        return cast(JSON.parse(json), r("GetKittyImageMessage"));
-    }
-
-    public static getKittyImageMessageToJson(value: GetKittyImageMessage): string {
-        return JSON.stringify(uncast(value, r("GetKittyImageMessage")), null, 2);
-    }
-
     public static toGetPresentationRoundMessage(json: string): GetPresentationRoundMessage {
         return cast(JSON.parse(json), r("GetPresentationRoundMessage"));
     }
@@ -7215,30 +7591,6 @@ export class Convert {
 
     public static killSessionMessageToJson(value: KillSessionMessage): string {
         return JSON.stringify(uncast(value, r("KillSessionMessage")), null, 2);
-    }
-
-    public static toKittyImageResultMessage(json: string): KittyImageResultMessage {
-        return cast(JSON.parse(json), r("KittyImageResultMessage"));
-    }
-
-    public static kittyImageResultMessageToJson(value: KittyImageResultMessage): string {
-        return JSON.stringify(uncast(value, r("KittyImageResultMessage")), null, 2);
-    }
-
-    public static toKittyPlacement(json: string): KittyPlacement {
-        return cast(JSON.parse(json), r("KittyPlacement"));
-    }
-
-    public static kittyPlacementToJson(value: KittyPlacement): string {
-        return JSON.stringify(uncast(value, r("KittyPlacement")), null, 2);
-    }
-
-    public static toKittyPlacementsMessage(json: string): KittyPlacementsMessage {
-        return cast(JSON.parse(json), r("KittyPlacementsMessage"));
-    }
-
-    public static kittyPlacementsMessageToJson(value: KittyPlacementsMessage): string {
-        return JSON.stringify(uncast(value, r("KittyPlacementsMessage")), null, 2);
     }
 
     public static toListBranchesMessage(json: string): ListBranchesMessage {
@@ -8441,6 +8793,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("StopMessage")), null, 2);
     }
 
+    public static toStoredDocument(json: string): StoredDocument {
+        return cast(JSON.parse(json), r("StoredDocument"));
+    }
+
+    public static storedDocumentToJson(value: StoredDocument): string {
+        return JSON.stringify(uncast(value, r("StoredDocument")), null, 2);
+    }
+
     public static toSubscribeGitStatusMessage(json: string): SubscribeGitStatusMessage {
         return cast(JSON.parse(json), r("SubscribeGitStatusMessage"));
     }
@@ -9520,7 +9880,6 @@ const typeMap: any = {
     "Snapshot": o([
         { json: "blocks", js: "blocks", typ: u(undefined, a(r("BlockElement"))) },
         { json: "cols", js: "cols", typ: 0 },
-        { json: "placements", js: "placements", typ: u(undefined, a(r("PlacementElement"))) },
         { json: "rows", js: "rows", typ: 0 },
         { json: "scrollback_truncated", js: "scrollback_truncated", typ: true },
         { json: "vt_dump_b64", js: "vt_dump_b64", typ: "" },
@@ -9536,24 +9895,6 @@ const typeMap: any = {
         { json: "pending", js: "pending", typ: true },
         { json: "prompt_row", js: "prompt_row", typ: 0 },
     ], "any"),
-    "PlacementElement": o([
-        { json: "grid_cols", js: "grid_cols", typ: 0 },
-        { json: "grid_rows", js: "grid_rows", typ: 0 },
-        { json: "image_generation", js: "image_generation", typ: 0 },
-        { json: "image_id", js: "image_id", typ: 0 },
-        { json: "pixel_height", js: "pixel_height", typ: 0 },
-        { json: "pixel_width", js: "pixel_width", typ: 0 },
-        { json: "placement_id", js: "placement_id", typ: 0 },
-        { json: "source_height", js: "source_height", typ: 0 },
-        { json: "source_width", js: "source_width", typ: 0 },
-        { json: "source_x", js: "source_x", typ: 0 },
-        { json: "source_y", js: "source_y", typ: 0 },
-        { json: "viewport_col", js: "viewport_col", typ: 0 },
-        { json: "viewport_row", js: "viewport_row", typ: 0 },
-        { json: "viewport_visible", js: "viewport_visible", typ: true },
-        { json: "virtual", js: "virtual", typ: true },
-        { json: "z", js: "z", typ: 0 },
-    ], "any"),
     "AttachSessionMessage": o([
         { json: "attach_policy", js: "attach_policy", typ: u(undefined, r("AttachPolicy")) },
         { json: "cmd", js: "cmd", typ: r("AttachSessionMessageCmd") },
@@ -9564,7 +9905,6 @@ const typeMap: any = {
     "AttachSnapshot": o([
         { json: "blocks", js: "blocks", typ: u(undefined, a(r("BlockElement"))) },
         { json: "cols", js: "cols", typ: 0 },
-        { json: "placements", js: "placements", typ: u(undefined, a(r("PlacementElement"))) },
         { json: "rows", js: "rows", typ: 0 },
         { json: "scrollback_truncated", js: "scrollback_truncated", typ: true },
         { json: "vt_dump_b64", js: "vt_dump_b64", typ: "" },
@@ -10037,6 +10377,135 @@ const typeMap: any = {
         { json: "name", js: "name", typ: "" },
         { json: "path", js: "path", typ: "" },
     ], "any"),
+    "DocCollectionsMessage": o([
+        { json: "cmd", js: "cmd", typ: r("DocCollectionsMessageCmd") },
+    ], "any"),
+    "DocCollectionsResult": o([
+        { json: "collections", js: "collections", typ: a(r("Schema")) },
+    ], "any"),
+    "Schema": o([
+        { json: "collection", js: "collection", typ: "" },
+        { json: "fields", js: "fields", typ: a(r("FieldElement")) },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
+    "FieldElement": o([
+        { json: "name", js: "name", typ: "" },
+        { json: "type", js: "type", typ: "" },
+    ], "any"),
+    "DocDefineMessage": o([
+        { json: "cmd", js: "cmd", typ: r("DocDefineMessageCmd") },
+        { json: "schema", js: "schema", typ: r("Schema") },
+    ], "any"),
+    "DocDefineResult": o([
+        { json: "collection", js: "collection", typ: "" },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
+    "DocDeleteMessage": o([
+        { json: "cmd", js: "cmd", typ: r("DocDeleteMessageCmd") },
+        { json: "collection", js: "collection", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
+    "DocDeleteResult": o([
+        { json: "collection", js: "collection", typ: "" },
+        { json: "existed", js: "existed", typ: true },
+        { json: "id", js: "id", typ: "" },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
+    "DocGetMessage": o([
+        { json: "cmd", js: "cmd", typ: r("DocGetMessageCmd") },
+        { json: "collection", js: "collection", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
+    "DocGetResult": o([
+        { json: "document", js: "document", typ: u(undefined, r("Document")) },
+        { json: "found", js: "found", typ: true },
+    ], "any"),
+    "Document": o([
+        { json: "body", js: "body", typ: "" },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "updated_at", js: "updated_at", typ: "" },
+    ], "any"),
+    "DocPutMessage": o([
+        { json: "body", js: "body", typ: "" },
+        { json: "cmd", js: "cmd", typ: r("DocPutMessageCmd") },
+        { json: "collection", js: "collection", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
+    "DocPutResult": o([
+        { json: "collection", js: "collection", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
+    "DocQueryMessage": o([
+        { json: "cmd", js: "cmd", typ: r("DocQueryMessageCmd") },
+        { json: "query", js: "query", typ: r("Query") },
+    ], "any"),
+    "Query": o([
+        { json: "collection", js: "collection", typ: "" },
+        { json: "filters", js: "filters", typ: u(undefined, a(r("FilterElement"))) },
+        { json: "limit", js: "limit", typ: u(undefined, 0) },
+        { json: "namespace", js: "namespace", typ: "" },
+        { json: "sort", js: "sort", typ: u(undefined, r("Sort")) },
+    ], "any"),
+    "FilterElement": o([
+        { json: "field", js: "field", typ: "" },
+        { json: "op", js: "op", typ: "" },
+        { json: "value_json", js: "value_json", typ: "" },
+    ], "any"),
+    "Sort": o([
+        { json: "desc", js: "desc", typ: u(undefined, true) },
+        { json: "field", js: "field", typ: "" },
+    ], "any"),
+    "DocQueryResult": o([
+        { json: "documents", js: "documents", typ: a(r("Document")) },
+    ], "any"),
+    "DocSubscribeMessage": o([
+        { json: "cmd", js: "cmd", typ: r("DocSubscribeMessageCmd") },
+        { json: "query", js: "query", typ: r("Query") },
+    ], "any"),
+    "DocSubscribeResult": o([
+        { json: "documents", js: "documents", typ: a(r("Document")) },
+        { json: "revision", js: "revision", typ: 0 },
+    ], "any"),
+    "DocumentCollectionSchema": o([
+        { json: "collection", js: "collection", typ: "" },
+        { json: "fields", js: "fields", typ: a(r("FieldElement")) },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
+    "DocumentFieldSpec": o([
+        { json: "name", js: "name", typ: "" },
+        { json: "type", js: "type", typ: "" },
+    ], "any"),
+    "DocumentFilter": o([
+        { json: "field", js: "field", typ: "" },
+        { json: "op", js: "op", typ: "" },
+        { json: "value_json", js: "value_json", typ: "" },
+    ], "any"),
+    "DocumentQuery": o([
+        { json: "collection", js: "collection", typ: "" },
+        { json: "filters", js: "filters", typ: u(undefined, a(r("FilterElement"))) },
+        { json: "limit", js: "limit", typ: u(undefined, 0) },
+        { json: "namespace", js: "namespace", typ: "" },
+        { json: "sort", js: "sort", typ: u(undefined, r("Sort")) },
+    ], "any"),
+    "DocumentSort": o([
+        { json: "desc", js: "desc", typ: u(undefined, true) },
+        { json: "field", js: "field", typ: "" },
+    ], "any"),
+    "DocUndefineMessage": o([
+        { json: "cmd", js: "cmd", typ: r("DocUndefineMessageCmd") },
+        { json: "collection", js: "collection", typ: "" },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
+    "DocUndefineResult": o([
+        { json: "collection", js: "collection", typ: "" },
+        { json: "documents_removed", js: "documents_removed", typ: 0 },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
     "EndpointActionResultMessage": o([
         { json: "action", js: "action", typ: "" },
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
@@ -10413,11 +10882,6 @@ const typeMap: any = {
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
         { json: "staged", js: "staged", typ: u(undefined, true) },
     ], "any"),
-    "GetKittyImageMessage": o([
-        { json: "cmd", js: "cmd", typ: r("GetKittyImageMessageCmd") },
-        { json: "id", js: "id", typ: "" },
-        { json: "image_id", js: "image_id", typ: 0 },
-    ], "any"),
     "GetPresentationRoundMessage": o([
         { json: "cmd", js: "cmd", typ: r("GetPresentationRoundMessageCmd") },
         { json: "presentation_id", js: "presentation_id", typ: "" },
@@ -10772,42 +11236,6 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("KillSessionMessageCmd") },
         { json: "id", js: "id", typ: "" },
         { json: "signal", js: "signal", typ: u(undefined, "") },
-    ], "any"),
-    "KittyImageResultMessage": o([
-        { json: "data_b64", js: "data_b64", typ: u(undefined, "") },
-        { json: "error", js: "error", typ: u(undefined, "") },
-        { json: "event", js: "event", typ: r("KittyImageResultMessageEvent") },
-        { json: "format", js: "format", typ: u(undefined, "") },
-        { json: "generation", js: "generation", typ: u(undefined, 0) },
-        { json: "height", js: "height", typ: u(undefined, 0) },
-        { json: "id", js: "id", typ: "" },
-        { json: "image_id", js: "image_id", typ: 0 },
-        { json: "success", js: "success", typ: true },
-        { json: "width", js: "width", typ: u(undefined, 0) },
-    ], "any"),
-    "KittyPlacement": o([
-        { json: "grid_cols", js: "grid_cols", typ: 0 },
-        { json: "grid_rows", js: "grid_rows", typ: 0 },
-        { json: "image_generation", js: "image_generation", typ: 0 },
-        { json: "image_id", js: "image_id", typ: 0 },
-        { json: "pixel_height", js: "pixel_height", typ: 0 },
-        { json: "pixel_width", js: "pixel_width", typ: 0 },
-        { json: "placement_id", js: "placement_id", typ: 0 },
-        { json: "source_height", js: "source_height", typ: 0 },
-        { json: "source_width", js: "source_width", typ: 0 },
-        { json: "source_x", js: "source_x", typ: 0 },
-        { json: "source_y", js: "source_y", typ: 0 },
-        { json: "viewport_col", js: "viewport_col", typ: 0 },
-        { json: "viewport_row", js: "viewport_row", typ: 0 },
-        { json: "viewport_visible", js: "viewport_visible", typ: true },
-        { json: "virtual", js: "virtual", typ: true },
-        { json: "z", js: "z", typ: 0 },
-    ], "any"),
-    "KittyPlacementsMessage": o([
-        { json: "event", js: "event", typ: r("KittyPlacementsMessageEvent") },
-        { json: "id", js: "id", typ: "" },
-        { json: "placements", js: "placements", typ: a(r("PlacementElement")) },
-        { json: "seq", js: "seq", typ: 0 },
     ], "any"),
     "ListBranchesMessage": o([
         { json: "cmd", js: "cmd", typ: r("ListBranchesMessageCmd") },
@@ -11573,6 +12001,14 @@ const typeMap: any = {
         { json: "data", js: "data", typ: u(undefined, "") },
         { json: "delegate_result", js: "delegate_result", typ: u(undefined, r("DelegateResultObject")) },
         { json: "delegation_operation", js: "delegation_operation", typ: u(undefined, r("DelegationOperationObject")) },
+        { json: "doc_collections_result", js: "doc_collections_result", typ: u(undefined, r("DocCollectionsResultObject")) },
+        { json: "doc_define_result", js: "doc_define_result", typ: u(undefined, r("DocDefineResultObject")) },
+        { json: "doc_delete_result", js: "doc_delete_result", typ: u(undefined, r("DocDeleteResultObject")) },
+        { json: "doc_get_result", js: "doc_get_result", typ: u(undefined, r("DocGetResultObject")) },
+        { json: "doc_put_result", js: "doc_put_result", typ: u(undefined, r("DocPutResultObject")) },
+        { json: "doc_query_result", js: "doc_query_result", typ: u(undefined, r("DocQueryResultObject")) },
+        { json: "doc_subscribe_result", js: "doc_subscribe_result", typ: u(undefined, r("DocSubscribeResultObject")) },
+        { json: "doc_undefine_result", js: "doc_undefine_result", typ: u(undefined, r("DocUndefineResultObject")) },
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "journal_append_result", js: "journal_append_result", typ: u(undefined, r("JournalAppendResultObject")) },
         { json: "notebook_entries", js: "notebook_entries", typ: u(undefined, a(r("NotebookEntryElement"))) },
@@ -11602,6 +12038,40 @@ const typeMap: any = {
         { json: "workspace_context_result", js: "workspace_context_result", typ: u(undefined, r("WorkspaceContextResultObject")) },
         { json: "workspace_contexts", js: "workspace_contexts", typ: u(undefined, a(r("WorkspaceContextElement"))) },
         { json: "workspaces", js: "workspaces", typ: u(undefined, a(r("WorkspaceElement"))) },
+    ], "any"),
+    "DocCollectionsResultObject": o([
+        { json: "collections", js: "collections", typ: a(r("Schema")) },
+    ], "any"),
+    "DocDefineResultObject": o([
+        { json: "collection", js: "collection", typ: "" },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
+    "DocDeleteResultObject": o([
+        { json: "collection", js: "collection", typ: "" },
+        { json: "existed", js: "existed", typ: true },
+        { json: "id", js: "id", typ: "" },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
+    "DocGetResultObject": o([
+        { json: "document", js: "document", typ: u(undefined, r("Document")) },
+        { json: "found", js: "found", typ: true },
+    ], "any"),
+    "DocPutResultObject": o([
+        { json: "collection", js: "collection", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
+    "DocQueryResultObject": o([
+        { json: "documents", js: "documents", typ: a(r("Document")) },
+    ], "any"),
+    "DocSubscribeResultObject": o([
+        { json: "documents", js: "documents", typ: a(r("Document")) },
+        { json: "revision", js: "revision", typ: 0 },
+    ], "any"),
+    "DocUndefineResultObject": o([
+        { json: "collection", js: "collection", typ: "" },
+        { json: "documents_removed", js: "documents_removed", typ: 0 },
+        { json: "namespace", js: "namespace", typ: "" },
     ], "any"),
     "JournalAppendResultObject": o([
         { json: "hash", js: "hash", typ: "" },
@@ -12093,6 +12563,12 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "pending_session_crons", js: "pending_session_crons", typ: u(undefined, 0) },
         { json: "transcript_path", js: "transcript_path", typ: "" },
+    ], "any"),
+    "StoredDocument": o([
+        { json: "body", js: "body", typ: "" },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "updated_at", js: "updated_at", typ: "" },
     ], "any"),
     "SubscribeGitStatusMessage": o([
         { json: "cmd", js: "cmd", typ: r("SubscribeGitStatusMessageCmd") },
@@ -13008,6 +13484,30 @@ const typeMap: any = {
     "DetachSessionMessageCmd": [
         "detach_session",
     ],
+    "DocCollectionsMessageCmd": [
+        "doc_collections",
+    ],
+    "DocDefineMessageCmd": [
+        "doc_define",
+    ],
+    "DocDeleteMessageCmd": [
+        "doc_delete",
+    ],
+    "DocGetMessageCmd": [
+        "doc_get",
+    ],
+    "DocPutMessageCmd": [
+        "doc_put",
+    ],
+    "DocQueryMessageCmd": [
+        "doc_query",
+    ],
+    "DocSubscribeMessageCmd": [
+        "doc_subscribe",
+    ],
+    "DocUndefineMessageCmd": [
+        "doc_undefine",
+    ],
     "EndpointActionResultMessageEvent": [
         "endpoint_action_result",
     ],
@@ -13121,9 +13621,6 @@ const typeMap: any = {
     ],
     "GetFileDiffMessageCmd": [
         "get_file_diff",
-    ],
-    "GetKittyImageMessageCmd": [
-        "get_kitty_image",
     ],
     "GetPresentationRoundMessageCmd": [
         "get_presentation_round",
@@ -13244,12 +13741,6 @@ const typeMap: any = {
     ],
     "KillSessionMessageCmd": [
         "kill_session",
-    ],
-    "KittyImageResultMessageEvent": [
-        "kitty_image_result",
-    ],
-    "KittyPlacementsMessageEvent": [
-        "kitty_placements",
     ],
     "ListBranchesMessageCmd": [
         "list_branches",

--- a/changelog.d/ext-a3-doc-store.yaml
+++ b/changelog.d/ext-a3-doc-store.yaml
@@ -1,0 +1,16 @@
+kind: added
+area: daemon
+change: >
+  A document store extensions can keep their own data in. A namespace
+  (`owner/name`) holds collections, a collection holds JSON documents under
+  caller-chosen ids, and a collection declares which fields are queryable.
+  Documents are stored byte for byte and nothing rewrites them, so adding a
+  queryable field is a declaration change rather than a migration. A query is
+  one JSON object — namespace, collection, filters, sort, limit — and can be
+  left open as a live query, where every delivery is the whole current result
+  set. `attn doc` is the first consumer: define, put, get, delete, query, and
+  watch.
+notes: >
+  Nothing user-visible in the app yet; the store is the spine the extension
+  runtime and its UI host build on. Design and gate decisions are in
+  docs/plans/2026-08-03-ext-a3-doc-store.md.

--- a/changelog.d/ext-a3-doc-store.yaml
+++ b/changelog.d/ext-a3-doc-store.yaml
@@ -6,9 +6,9 @@ change: >
   caller-chosen ids, and a collection declares which fields are queryable.
   Documents are stored byte for byte and nothing rewrites them, so adding a
   queryable field is a declaration change rather than a migration. A query is
-  one JSON object — namespace, collection, filters, sort, limit — and can be
-  left open as a live query, where every delivery is the whole current result
-  set. `attn doc` is the first consumer: define, put, get, delete, query, and
+  one JSON object — namespace, collection, filters, sort, limit, and an after
+  cursor for the next page — and can be left open as a live query, where every
+  delivery is the whole current result set. `attn doc` is the first consumer: define, put, get, delete, query, and
   watch.
 notes: >
   Nothing user-visible in the app yet; the store is the spine the extension

--- a/cmd/attn/doc.go
+++ b/cmd/attn/doc.go
@@ -98,6 +98,11 @@ query flags:
   --sort <field>    order by a declared field, or created_at / updated_at.
   --desc            reverse the sort.
   --limit <n>       at most n documents (default %d, maximum %d).
+  --after <id>      the next page: documents that come after this one in the
+                    same order. Pass the id of the last document of the previous
+                    page. Use this rather than a --where on the sort field —
+                    documents sharing a sort value would otherwise be skipped or
+                    repeated.
 `, docstore.DefaultLimit, docstore.MaxLimit)
 }
 
@@ -290,6 +295,9 @@ func parseDocQueryFlags(verb, namespace, collection string, args []string) (prot
 				query.Sort = &protocol.DocumentSort{}
 			}
 			query.Sort.Field = field
+		case "--after":
+			after := next()
+			query.After = &after
 		case "--limit":
 			raw := next()
 			n, err := strconv.Atoi(raw)

--- a/cmd/attn/doc.go
+++ b/cmd/attn/doc.go
@@ -211,7 +211,7 @@ func runDocGet(args []string) {
 		os.Exit(1)
 	}
 	if hasFlag(rest, "--json") {
-		writeJSON(result.Document)
+		writeJSON(docsForJSON([]protocol.StoredDocument{*result.Document})[0])
 		return
 	}
 	fmt.Println(result.Document.Body)
@@ -248,7 +248,10 @@ func runDocWatch(args []string) {
 	query, asJSON := parseDocQueryFlags("watch", namespace, collection, rest)
 	err := docClient().DocSubscribe(query, func(result *protocol.DocSubscribeResult) bool {
 		if asJSON {
-			writeJSON(result)
+			writeJSON(struct {
+				Revision  int            `json:"revision"`
+				Documents []jsonDocument `json:"documents"`
+			}{result.Revision, docsForJSON(result.Documents)})
 		} else {
 			fmt.Printf("--- revision %d (%d document(s)) ---\n", result.Revision, len(result.Documents))
 			printDocuments(result.Documents, false)
@@ -353,9 +356,32 @@ func docBoundAsJSON(raw string) string {
 	return string(encoded)
 }
 
+// jsonDocument is what --json prints. The wire carries a body as a string
+// because the protocol has no "arbitrary JSON" type, but a caller piping this
+// into jq wants `.body.status`, not a string it has to decode a second time.
+type jsonDocument struct {
+	ID        string          `json:"id"`
+	Body      json.RawMessage `json:"body"`
+	CreatedAt string          `json:"created_at"`
+	UpdatedAt string          `json:"updated_at"`
+}
+
+func docsForJSON(docs []protocol.StoredDocument) []jsonDocument {
+	out := make([]jsonDocument, 0, len(docs))
+	for _, doc := range docs {
+		out = append(out, jsonDocument{
+			ID:        doc.ID,
+			Body:      json.RawMessage(doc.Body),
+			CreatedAt: doc.CreatedAt,
+			UpdatedAt: doc.UpdatedAt,
+		})
+	}
+	return out
+}
+
 func printDocuments(docs []protocol.StoredDocument, asJSON bool) {
 	if asJSON {
-		writeJSON(docs)
+		writeJSON(docsForJSON(docs))
 		return
 	}
 	if len(docs) == 0 {

--- a/cmd/attn/doc.go
+++ b/cmd/attn/doc.go
@@ -1,0 +1,389 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/victorarias/attn/internal/client"
+	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/docstore"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// `attn doc` is the document store's operator surface, and until the extension
+// runtime exists it is also its only consumer.
+//
+// Everything here goes through the daemon rather than opening the database
+// directly, which is the opposite of `attn bus`. The reason is the change fact: a
+// write that reached the table without publishing one would leave every live
+// query rendering a result set the store no longer agrees with. `attn bus` can
+// take the direct path precisely because its job is to work when the daemon does
+// not.
+
+func runDoc() {
+	if len(os.Args) < 3 || os.Args[2] == "-h" || os.Args[2] == "--help" {
+		writeDocHelp(os.Stdout)
+		return
+	}
+	args := os.Args[3:]
+	switch os.Args[2] {
+	case "define":
+		runDocDefine(args)
+	case "undefine":
+		runDocUndefine(args)
+	case "collections":
+		runDocCollections(args)
+	case "put":
+		runDocPut(args)
+	case "get":
+		runDocGet(args)
+	case "delete":
+		runDocDelete(args)
+	case "query":
+		runDocQuery(args)
+	case "watch":
+		runDocWatch(args)
+	default:
+		fmt.Fprintf(os.Stderr, "doc: unknown command %q\n", os.Args[2])
+		writeDocHelp(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+func writeDocHelp(w io.Writer) {
+	fmt.Fprintf(w, `usage: attn doc <command>
+
+Documents are JSON objects addressed by <namespace> <collection> <id>. A
+namespace is owner/name (for example ext/approval-gate).
+
+A collection declares which fields may be filtered and sorted on; created_at and
+updated_at are always available and are never declared. Everything else in a
+document body is stored and returned untouched.
+
+commands:
+  define <namespace> <collection> [field:type ...]
+        declare a collection, replacing any previous declaration. Types are
+        string, number and bool. Redeclaring is how a collection gains a
+        queryable field; no document is rewritten.
+
+  undefine <namespace> <collection>
+        remove a collection's declaration and every document under it.
+
+  collections [--json]
+        list every declared collection.
+
+  put <namespace> <collection> <id> <body|->
+        write a document. The body is a JSON object, or - to read stdin.
+
+  get <namespace> <collection> <id> [--json]
+  delete <namespace> <collection> <id>
+
+  query <namespace> <collection> [query flags] [--json]
+        run a query once.
+
+  watch <namespace> <collection> [query flags] [--json]
+        run a live query: print the current results, then print them again every
+        time a write changes them. Runs until interrupted.
+
+query flags:
+  --where <expr>    repeatable. field=value, or field<value, field<=value,
+                    field>value, field>=value. The value is read as JSON when it
+                    parses as one, and as a string otherwise, so --where
+                    status=pending sends "pending" and --where attempts>=5 sends 5.
+  --sort <field>    order by a declared field, or created_at / updated_at.
+  --desc            reverse the sort.
+  --limit <n>       at most n documents (default %d, maximum %d).
+`, docstore.DefaultLimit, docstore.MaxLimit)
+}
+
+func docClient() *client.Client {
+	return client.New(config.SocketPath())
+}
+
+func docFail(verb string, err error) {
+	fmt.Fprintf(os.Stderr, "doc %s: %v\n", verb, err)
+	os.Exit(1)
+}
+
+// docTarget reads the leading <namespace> <collection> every command starts with.
+func docTarget(verb string, args []string) (string, string, []string) {
+	if len(args) < 2 {
+		fmt.Fprintf(os.Stderr, "doc %s: needs <namespace> <collection>\n", verb)
+		os.Exit(2)
+	}
+	return args[0], args[1], args[2:]
+}
+
+func runDocDefine(args []string) {
+	namespace, collection, rest := docTarget("define", args)
+	schema := protocol.DocumentCollectionSchema{
+		Namespace:  namespace,
+		Collection: collection,
+		Fields:     []protocol.DocumentFieldSpec{},
+	}
+	for _, spec := range rest {
+		name, kind, ok := strings.Cut(spec, ":")
+		if !ok {
+			docFail("define", fmt.Errorf("field %q is not name:type (types: string, number, bool)", spec))
+		}
+		schema.Fields = append(schema.Fields, protocol.DocumentFieldSpec{Name: name, Type: kind})
+	}
+	result, err := docClient().DocDefine(schema)
+	if err != nil {
+		docFail("define", err)
+	}
+	fmt.Printf("declared %s/%s with %d queryable field(s)\n", result.Namespace, result.Collection, len(schema.Fields))
+}
+
+func runDocUndefine(args []string) {
+	namespace, collection, _ := docTarget("undefine", args)
+	result, err := docClient().DocUndefine(namespace, collection)
+	if err != nil {
+		docFail("undefine", err)
+	}
+	fmt.Printf("removed %s/%s and %d document(s)\n", result.Namespace, result.Collection, result.DocumentsRemoved)
+}
+
+func runDocCollections(args []string) {
+	asJSON := hasFlag(args, "--json")
+	result, err := docClient().DocCollections()
+	if err != nil {
+		docFail("collections", err)
+	}
+	if asJSON {
+		writeJSON(result.Collections)
+		return
+	}
+	if len(result.Collections) == 0 {
+		fmt.Println("no collections declared")
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAMESPACE\tCOLLECTION\tQUERYABLE FIELDS")
+	for _, c := range result.Collections {
+		names := make([]string, 0, len(c.Fields))
+		for _, f := range c.Fields {
+			names = append(names, f.Name+":"+f.Type)
+		}
+		if len(names) == 0 {
+			names = append(names, "-")
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n", c.Namespace, c.Collection, strings.Join(names, " "))
+	}
+	w.Flush()
+}
+
+func runDocPut(args []string) {
+	namespace, collection, rest := docTarget("put", args)
+	if len(rest) < 2 {
+		docFail("put", fmt.Errorf("needs <id> and a JSON body (or - for stdin)"))
+	}
+	id, body := rest[0], rest[1]
+	if body == "-" {
+		raw, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			docFail("put", fmt.Errorf("reading stdin: %w", err))
+		}
+		body = string(raw)
+	}
+	if _, err := docClient().DocPut(namespace, collection, id, body); err != nil {
+		docFail("put", err)
+	}
+	fmt.Printf("wrote %s/%s/%s\n", namespace, collection, id)
+}
+
+func runDocGet(args []string) {
+	namespace, collection, rest := docTarget("get", args)
+	if len(rest) < 1 {
+		docFail("get", fmt.Errorf("needs <id>"))
+	}
+	result, err := docClient().DocGet(namespace, collection, rest[0])
+	if err != nil {
+		docFail("get", err)
+	}
+	if !result.Found {
+		fmt.Fprintf(os.Stderr, "doc get: %s/%s/%s does not exist\n", namespace, collection, rest[0])
+		os.Exit(1)
+	}
+	if hasFlag(rest, "--json") {
+		writeJSON(result.Document)
+		return
+	}
+	fmt.Println(result.Document.Body)
+}
+
+func runDocDelete(args []string) {
+	namespace, collection, rest := docTarget("delete", args)
+	if len(rest) < 1 {
+		docFail("delete", fmt.Errorf("needs <id>"))
+	}
+	result, err := docClient().DocDelete(namespace, collection, rest[0])
+	if err != nil {
+		docFail("delete", err)
+	}
+	if !result.Existed {
+		fmt.Printf("%s/%s/%s did not exist\n", namespace, collection, rest[0])
+		return
+	}
+	fmt.Printf("deleted %s/%s/%s\n", namespace, collection, rest[0])
+}
+
+func runDocQuery(args []string) {
+	namespace, collection, rest := docTarget("query", args)
+	query, asJSON := parseDocQueryFlags("query", namespace, collection, rest)
+	result, err := docClient().DocQuery(query)
+	if err != nil {
+		docFail("query", err)
+	}
+	printDocuments(result.Documents, asJSON)
+}
+
+func runDocWatch(args []string) {
+	namespace, collection, rest := docTarget("watch", args)
+	query, asJSON := parseDocQueryFlags("watch", namespace, collection, rest)
+	err := docClient().DocSubscribe(query, func(result *protocol.DocSubscribeResult) bool {
+		if asJSON {
+			writeJSON(result)
+		} else {
+			fmt.Printf("--- revision %d (%d document(s)) ---\n", result.Revision, len(result.Documents))
+			printDocuments(result.Documents, false)
+		}
+		return true
+	})
+	if err != nil {
+		docFail("watch", err)
+	}
+}
+
+// parseDocQueryFlags reads the query flags shared by query and watch.
+func parseDocQueryFlags(verb, namespace, collection string, args []string) (protocol.DocumentQuery, bool) {
+	query := protocol.DocumentQuery{Namespace: namespace, Collection: collection}
+	asJSON := false
+	for i := 0; i < len(args); i++ {
+		next := func() string {
+			if i+1 >= len(args) {
+				docFail(verb, fmt.Errorf("%s needs a value", args[i]))
+			}
+			i++
+			return args[i]
+		}
+		switch args[i] {
+		case "--json":
+			asJSON = true
+		case "--desc":
+			desc := true
+			if query.Sort == nil {
+				query.Sort = &protocol.DocumentSort{}
+			}
+			query.Sort.Desc = &desc
+		case "--sort":
+			field := next()
+			if query.Sort == nil {
+				query.Sort = &protocol.DocumentSort{}
+			}
+			query.Sort.Field = field
+		case "--limit":
+			raw := next()
+			n, err := strconv.Atoi(raw)
+			if err != nil {
+				docFail(verb, fmt.Errorf("--limit %q is not a number", raw))
+			}
+			query.Limit = &n
+		case "--where":
+			filter, err := parseDocWhere(next())
+			if err != nil {
+				docFail(verb, err)
+			}
+			query.Filters = append(query.Filters, filter)
+		default:
+			docFail(verb, fmt.Errorf("unknown flag %q", args[i]))
+		}
+	}
+	if query.Sort != nil && query.Sort.Field == "" {
+		docFail(verb, fmt.Errorf("--desc needs --sort <field>"))
+	}
+	return query, asJSON
+}
+
+// docWhereOps are matched longest-first so ">=" is not read as ">".
+var docWhereOps = []struct {
+	token string
+	op    docstore.Op
+}{
+	{">=", docstore.OpGte},
+	{"<=", docstore.OpLte},
+	{"=", docstore.OpEq},
+	{">", docstore.OpGt},
+	{"<", docstore.OpLt},
+}
+
+// parseDocWhere reads one --where expression. The bound is taken as JSON when it
+// parses as JSON and as a string otherwise, so `status=pending` and
+// `attempts>=5` both mean what they look like without any quoting ceremony. A
+// string that looks like a number can still be written as status='"5"'.
+func parseDocWhere(expr string) (protocol.DocumentFilter, error) {
+	for _, candidate := range docWhereOps {
+		field, value, ok := strings.Cut(expr, candidate.token)
+		if !ok {
+			continue
+		}
+		if field == "" {
+			return protocol.DocumentFilter{}, fmt.Errorf("--where %q has no field name", expr)
+		}
+		return protocol.DocumentFilter{
+			Field:     field,
+			Op:        string(candidate.op),
+			ValueJson: docBoundAsJSON(value),
+		}, nil
+	}
+	return protocol.DocumentFilter{}, fmt.Errorf("--where %q needs one of = < <= > >= (for example status=pending)", expr)
+}
+
+func docBoundAsJSON(raw string) string {
+	var probe any
+	if err := json.Unmarshal([]byte(raw), &probe); err == nil {
+		return raw
+	}
+	encoded, _ := json.Marshal(raw)
+	return string(encoded)
+}
+
+func printDocuments(docs []protocol.StoredDocument, asJSON bool) {
+	if asJSON {
+		writeJSON(docs)
+		return
+	}
+	if len(docs) == 0 {
+		fmt.Println("no documents")
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tUPDATED\tBODY")
+	for _, doc := range docs {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", doc.ID, doc.UpdatedAt, doc.Body)
+	}
+	w.Flush()
+}
+
+func hasFlag(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+func writeJSON(v any) {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(v); err != nil {
+		fmt.Fprintf(os.Stderr, "doc: encoding output: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/attn/doc_test.go
+++ b/cmd/attn/doc_test.go
@@ -105,3 +105,12 @@ func TestWhereRepeatsToAccumulateFilters(t *testing.T) {
 		t.Fatalf("second filter = %+v", query.Filters[1])
 	}
 }
+
+// --after carries the cursor, which is the only correct way to page: a --where
+// on the sort field skips or repeats documents that share a sort value.
+func TestAfterFlagCarriesTheCursor(t *testing.T) {
+	query, _ := parseDocQueryFlags("query", "ext/a", "c", []string{"--sort", "attempts", "--after", "b7"})
+	if query.After == nil || *query.After != "b7" {
+		t.Fatalf("after = %v", query.After)
+	}
+}

--- a/cmd/attn/doc_test.go
+++ b/cmd/attn/doc_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/victorarias/attn/internal/docstore"
+)
+
+// A --where bound is read as JSON when it parses as JSON, and as a string
+// otherwise, so the common cases need no quoting ceremony.
+func TestWhereReadsTheBoundAsJSONWhenItIsJSON(t *testing.T) {
+	for _, tc := range []struct {
+		expr  string
+		field string
+		op    docstore.Op
+		value string
+	}{
+		{"status=pending", "status", docstore.OpEq, `"pending"`},
+		{"attempts>=5", "attempts", docstore.OpGte, "5"},
+		{"attempts>2", "attempts", docstore.OpGt, "2"},
+		{"attempts<=9", "attempts", docstore.OpLte, "9"},
+		{"attempts<9", "attempts", docstore.OpLt, "9"},
+		{"urgent=true", "urgent", docstore.OpEq, "true"},
+		{`status="5"`, "status", docstore.OpEq, `"5"`},
+		{"updated_at>2026-08-03T00:00:00Z", "updated_at", docstore.OpGt, `"2026-08-03T00:00:00Z"`},
+	} {
+		t.Run(tc.expr, func(t *testing.T) {
+			got, err := parseDocWhere(tc.expr)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got.Field != tc.field || got.Op != string(tc.op) || got.ValueJson != tc.value {
+				t.Fatalf("parsed %+v, want field=%s op=%s value=%s", got, tc.field, tc.op, tc.value)
+			}
+		})
+	}
+}
+
+// ">=" must not be read as ">" with a value of "=5".
+func TestWhereMatchesTheLongestOperatorFirst(t *testing.T) {
+	got, err := parseDocWhere("attempts>=5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Op != string(docstore.OpGte) || got.ValueJson != "5" {
+		t.Fatalf("parsed %+v", got)
+	}
+}
+
+func TestWhereRejectsAnExpressionWithNoOperator(t *testing.T) {
+	if _, err := parseDocWhere("status"); err == nil {
+		t.Fatal("an expression with no operator was accepted")
+	}
+	if _, err := parseDocWhere("=pending"); err == nil {
+		t.Fatal("an expression with no field was accepted")
+	}
+}
+
+// The flag parser consumes values by advancing the index from inside a closure.
+// Go 1.22 gave three-clause loops a per-iteration variable, so this pins that
+// the advance still carries to the next iteration — otherwise a flag's value
+// would be parsed again as if it were a flag.
+func TestQueryFlagsConsumeTheirValues(t *testing.T) {
+	query, asJSON := parseDocQueryFlags("query", "ext/approval-gate", "requests", []string{
+		"--where", "status=pending",
+		"--sort", "created_at",
+		"--desc",
+		"--limit", "7",
+		"--json",
+	})
+	if !asJSON {
+		t.Fatal("--json not seen")
+	}
+	if query.Namespace != "ext/approval-gate" || query.Collection != "requests" {
+		t.Fatalf("target = %s/%s", query.Namespace, query.Collection)
+	}
+	if len(query.Filters) != 1 || query.Filters[0].Field != "status" || query.Filters[0].ValueJson != `"pending"` {
+		t.Fatalf("filters = %+v", query.Filters)
+	}
+	if query.Sort == nil || query.Sort.Field != "created_at" || query.Sort.Desc == nil || !*query.Sort.Desc {
+		t.Fatalf("sort = %+v", query.Sort)
+	}
+	if query.Limit == nil || *query.Limit != 7 {
+		t.Fatalf("limit = %v", query.Limit)
+	}
+}
+
+// --desc before --sort still applies to the sort that follows.
+func TestDescBeforeSortStillReversesIt(t *testing.T) {
+	query, _ := parseDocQueryFlags("query", "ext/a", "c", []string{"--desc", "--sort", "updated_at"})
+	if query.Sort == nil || query.Sort.Field != "updated_at" || query.Sort.Desc == nil || !*query.Sort.Desc {
+		t.Fatalf("sort = %+v", query.Sort)
+	}
+}
+
+// Repeating --where accumulates, which is how a range on the sort field pages.
+func TestWhereRepeatsToAccumulateFilters(t *testing.T) {
+	query, _ := parseDocQueryFlags("query", "ext/a", "c", []string{
+		"--where", "status=pending", "--where", "attempts>=2",
+	})
+	if len(query.Filters) != 2 {
+		t.Fatalf("filters = %+v", query.Filters)
+	}
+	if query.Filters[1].Op != string(docstore.OpGte) || query.Filters[1].ValueJson != "2" {
+		t.Fatalf("second filter = %+v", query.Filters[1])
+	}
+}

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -236,6 +236,9 @@ func main() {
 	case "bus":
 		maybePrintProfileBanner()
 		runBus()
+	case "doc":
+		maybePrintProfileBanner()
+		runDoc()
 	case "journal":
 		maybePrintProfileBanner()
 		runJournal()
@@ -617,6 +620,7 @@ commands:
   debug <command>                   probe debug artifacts (incidents, logs)
   db <command>                      database maintenance (restore from backup)
   bus <command>                     event bus: consumer cursors, lag, kill switch
+  doc <command>                     document store: collections, documents, live queries
   vision-check <image> <question>   answer a question about an image (single LLM call)
   daemon <command>                  manage the daemon
 	  daemon ensure|stop                ensure the daemon is running, or stop it

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -184,9 +184,12 @@ contain — undeclared keys are stored and returned untouched — it only says w
 query may name. `created_at` and `updated_at` are always queryable and are never
 declared.
 
-A **query** is one JSON object: namespace, collection, filters, sort, limit. It
-returns a whole result set, never a page cursor; a range filter on the sort field
-is how a caller pages.
+A **query** is one JSON object: namespace, collection, filters, sort, limit, and
+an optional **after cursor** — the id of the last document of the previous page.
+The cursor is part of the query rather than a filter a caller writes, because the
+visible order is (sort field, id) and a filter can only constrain one of those:
+with documents tied on the sort field, `sort > value` skips the tied ones and
+`sort >= value` returns the anchor again.
 
 A **live query** is that same query left open. Every delivery is the whole
 current result set, so a subscriber renders what it is handed and never

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -163,3 +163,33 @@ The raw tier is physically unreachable through the user-facing notebook APIs
 (`CleanPath` rejects dotdir segments). Capture into it is deterministic and always
 happens; the keeper's narration is best-effort on top of it, so nothing is lost if
 narration never runs.
+
+## The document store
+
+attn's **document store** is where an extension keeps its own data. Three names
+locate every record:
+
+- **Namespace** — `owner/name`, e.g. `ext/approval-gate`. A namespace is granted
+  to exactly one author and is the isolation boundary: nothing an extension does
+  can read or write another namespace, and two namespaces may use the same
+  collection name without meeting.
+- **Collection** — a named set of documents inside a namespace, e.g. `requests`.
+- **Document** — one JSON object with a caller-chosen **id**, unique within its
+  collection. The body is stored byte for byte and nothing ever rewrites it, so
+  an author never writes a migration.
+
+A collection carries a **declaration**: the fields it promises are queryable,
+each with a type. Declaring a field does not constrain what a document may
+contain — undeclared keys are stored and returned untouched — it only says what a
+query may name. `created_at` and `updated_at` are always queryable and are never
+declared.
+
+A **query** is one JSON object: namespace, collection, filters, sort, limit. It
+returns a whole result set, never a page cursor; a range filter on the sort field
+is how a caller pages.
+
+A **live query** is that same query left open. Every delivery is the whole
+current result set, so a subscriber renders what it is handed and never
+accumulates state across deliveries; the daemon re-runs the query when a write to
+the collection says the answer may have moved. A skipped delivery is not a lost
+update — the next one supersedes it.

--- a/docs/plans/2026-08-01-extension-platform-roadmap.md
+++ b/docs/plans/2026-08-01-extension-platform-roadmap.md
@@ -86,13 +86,17 @@ tracked stage.
 
 ### A3. Document store + live queries
 
-Per-extension namespaced JSON document store with secondary indexes. Writes
-emit change events on the bus. Live-query subscription surface: a client (or
-extension UI) subscribes to a query and receives updates on change.
+Per-extension namespaced JSON document store. Writes emit change events on the
+bus. Live-query subscription surface: a client (or extension UI) subscribes to
+a query and receives updates on change.
 
 - Depends on: A1 (change events ride the bus).
 - Exit: write → change event → subscribed query update, durable across
   restart; namespace isolation enforced.
+- Plan: [2026-08-03-ext-a3-doc-store.md](2026-08-03-ext-a3-doc-store.md). The
+  gate answered indexes with **declared fields, scanned** — a collection
+  declares what is queryable, and indexes become an invisible optimization
+  later rather than part of the surface.
 
 ### A4. Extension registry + shared runtime
 

--- a/docs/plans/2026-08-03-ext-a3-doc-store.md
+++ b/docs/plans/2026-08-03-ext-a3-doc-store.md
@@ -175,9 +175,28 @@ workspaces 8. The default is an order of magnitude past that working set and the
 ceiling two — a tripwire. Asking past the ceiling is an error naming the limit
 and the ask, never a silent truncation.
 
-Every sort is made total by an `id ASC` tiebreaker, so a range filter on the
-sort field is a correct cursor. That is the whole pagination story; there is no
-offset and no opaque page token.
+Every sort is made total by an id tiebreaker running in the sort's own
+direction, so the visible order is one uniformly directed `(sort field, id)`
+tuple. Pagination is `Query.After`, the id of the previous page's last document,
+compiled to a comparison against that whole tuple:
+
+```
+sort <cmp> value OR (sort = value AND id <cmp> anchor)
+```
+
+A caller-written range filter is **not** a correct cursor and the query language
+deliberately does not present it as one — it can constrain only the first half of
+the tuple, so `sort > value` skips every document tied with the anchor and `sort
+>= value` returns the anchor forever. Documents missing the sort field are a real
+case, since a declaration says what may be queried rather than what a document
+must carry, so the NULL side of the tuple is branched on explicitly: SQLite sorts
+NULL first ascending and last descending, and the cursor agrees in both
+directions. A cursor naming a document that no longer exists is an error, not an
+empty page, because an empty page reads as the end of the walk.
+
+The daemon resolves the anchor document before compiling — `docstore` holds no
+database handle and needs the anchor's sort value. There is no offset and no
+opaque page token.
 
 ### Live queries
 

--- a/docs/plans/2026-08-03-ext-a3-doc-store.md
+++ b/docs/plans/2026-08-03-ext-a3-doc-store.md
@@ -194,9 +194,19 @@ NULL first ascending and last descending, and the cursor agrees in both
 directions. A cursor naming a document that no longer exists is an error, not an
 empty page, because an empty page reads as the end of the walk.
 
-The daemon resolves the anchor document before compiling — `docstore` holds no
-database handle and needs the anchor's sort value. There is no offset and no
-opaque page token.
+The anchor's sort value is not bound from Go: the cursor reads it back out of
+the table through the same expression the `ORDER BY` uses, as an uncorrelated
+scalar subquery. A field declared `number` may hold an array or an object —
+the declaration is not a storage schema — and those have no bindable Go
+equivalent; the driver rejects the statement outright. Reading the value through
+`json_extract` makes the cursor compare exactly what the ordering compares, for
+every JSON shape and for values that disagree with the declared type, with no
+Go-side reconstruction that could disagree with SQLite's rendering or its type
+ordering. The daemon still reads the anchor document before compiling, because
+whether the sort value is absent is a structural question about the body and
+decides which branch compiles.
+
+There is no offset and no opaque page token.
 
 ### Live queries
 

--- a/docs/plans/2026-08-03-ext-a3-doc-store.md
+++ b/docs/plans/2026-08-03-ext-a3-doc-store.md
@@ -1,0 +1,212 @@
+# A3 — Document store + live queries
+
+Stage A3 of the [extension platform roadmap](2026-08-01-extension-platform-roadmap.md).
+North star: [docs/vision/extension-platform.md](../vision/extension-platform.md).
+
+Status: gate approved by Victor 2026-08-03. Implemented 2026-08-03.
+
+The store is a generic daemon primitive — namespaced JSON documents, change
+events on the bus, live queries — that extensions happen to be the first big
+consumer of. The store itself does not know what an extension is.
+
+An open-source survey preceded the gate; the conclusion was to build the thin
+layer on our SQLite rather than adopt a dependency. SQLite remains the
+database — durability, transactions, and indexing are its job. What this
+stage writes is a query translator, a bus producer, and a subscription map.
+
+## Gate answers
+
+### 1. Shape: namespace → collection → document
+
+Not in the roadmap's gate list, but it decides everything downstream. Every
+real consumer stores more than one record kind (the approval gate alone has
+requests and settings), so collections are first-class rather than a `type`
+field convention inside one bucket. Indexes, queries, and subscriptions are
+all per-collection. This is the Firestore/Convex shape.
+
+### 2. Namespace naming: two-part `owner/name`
+
+`ext/approval-gate`, `core/…`. The store treats the namespace as an opaque
+string; **who may write where is enforced at grant time**, not by the store —
+A4's registry hands an extension exactly its own `ext/<id>` prefix, and the
+daemon may use `core/`. The hierarchy costs nothing now and gives isolation
+classes without the store knowing what an extension is.
+
+The flat alternative (`approval-gate`) was rejected because core and
+extensions would share one namespace pool — a collision waiting for A4.
+
+### 3. Index design: declared fields as the contract, scan-first as the implementation
+
+A collection declares the fields that may be filtered and sorted on. That
+declaration is the API contract and is what keeps the query surface honest.
+Physically, v1 executes with a scan inside `(namespace, collection)` — no
+secondary index structures yet.
+
+Receipt: attn is single-user; a collection holds thousands of documents, not
+millions, and a `json_extract` scan over that is milliseconds. We have no
+measurement saying indexes are needed, so building them now would be a number
+without a receipt. The tripwire: slow queries are logged with the collection
+size, so the day a real consumer crosses it we have the measurement to design
+against.
+
+When that day comes, the upgrade is invisible — SQLite expression indexes on
+`json_extract(body, '$.field')`, created by the store from the same
+declaration. No author-facing change, no migration. The rejected alternative
+was a generic `(namespace, collection, field, value) → doc id` side table,
+which pays its write cost from day one and still needs intersection joins for
+multi-predicate queries.
+
+Record-shape evolution stays at the read boundary (zod parse, tolerant
+rendering, per the vision). A document missing a declared field simply does
+not match filters on it and sorts last.
+
+### 4. Query surface: equality + range on declared fields, one sort field, limit
+
+`{namespace, collection, filters, sort, limit}` as one JSON object. Filters
+are equality and range (`<`, `<=`, `>`, `>=`) on declared fields only; sort
+is a single declared field plus direction; limit is mandatory-bounded. Range
+on the sort field gives cursor pagination for free.
+
+The receipt is the two proof compositions: the approval gate's panel is
+"requests where status=pending, newest first" (equality + sort + limit);
+Present v2's records add "for presentation X after cursor Y" (equality +
+range on the sort field). Both fit; neither needs anything richer. Operator
+soup (contains, or-groups, joins) is speculative until a real extension asks.
+
+**One query representation for every doorway.** Three surfaces will
+eventually carry queries — workflow/handler code in the Bun sidecar (SDK →
+IPC), extension UI in the app (live-query hooks → the generic WebSocket
+envelopes), and the CLI. All three carry the same JSON query object; A4/A5
+add transport, not semantics. Defining the query as Go function parameters
+instead would force A4 to invent the serialization later.
+
+### 5. Live-query contract: server re-runs, pushes the full result set
+
+Subscribe returns the initial result set with the subscription — not
+"subscribed, results will arrive" — because the vision's remount-not-HMR
+story depends on re-hydration in milliseconds, which means subscriptions must
+be cheap to create, serve immediately, and destroy. After that, any committed
+write to the collection re-runs matching subscriptions (coalesced per
+subscription, like `coalesceSnapshots`) and pushes fresh results. The
+contract is "you receive the current result set."
+
+Wiring is the existing A1/A2 architecture doing its job: a write publishes a
+`doc.changed` fact (subject names the namespace/collection); the hub — an
+ephemeral consumer — re-runs affected subscriptions in a projection and
+pushes to the wire. The same fact gives B2 workflows durable at-least-once
+wake-on-document-change later, with no new machinery.
+
+Rejected alternatives: incremental patching (fast and subtly wrong at the
+edges — a document falling out of a `limit 20` window forces a re-query to
+find the 21st anyway; this is where live-query systems grow bugs) and
+change-feed-only (every consumer reimplements re-run-and-race handling).
+Because the contract is "current result set," patching can hide behind it
+later if a measurement ever says it matters.
+
+### Assumptions accepted alongside the gate
+
+- **Main `attn.db`, not a separate file.** A workflow activity writing a
+  document atomically with its job-state commit is load-bearing for B2's
+  exactly-once story. Separate-file isolation solves a bloat problem we do
+  not have.
+- **First consumer: a thin `attn doc` CLI** (put/get/query/watch). It makes
+  the exit criteria live-verifiable before A4 exists, and it is the operator
+  surface the bus got with `attn bus status`. Migrating a core feature onto
+  the store is a door left open, not an A3 goal.
+- The vision keeps namespaced SQL tables as a documented escape hatch for
+  later; nothing in A3 touches that.
+
+## Sequence note
+
+Depends on A1 (change events ride the bus), already live. A4 depends on this
+stage; B2 depends on A4. A3 is the only stage that can start and it unblocks
+both tracks.
+
+## Exit criteria
+
+From the roadmap: write → change event → subscribed query update, durable
+across restart; namespace isolation enforced.
+
+## Implementation plan
+
+Written during implementation (2026-08-03), after A1, A2, and B1 merged.
+
+### Where the pieces live
+
+The stage splits along the seam `internal/bus` ↔ `internal/store/bus.go`
+already established: meaning in a leaf package, execution next to the database.
+
+- `internal/docstore` — the query language. Field types, operators, the `Query`
+  object, and `Query.Compile(schema) → Compiled{Where, Args, Order, Limit}`.
+  It holds no database handle, so every rule about what a query means is
+  testable without one.
+- `internal/store/documents.go` — the two tables (migration **88**), the CRUD,
+  and `QueryDocuments(Compiled)`. It executes SQL it did not decide.
+- `internal/daemon/documents.go` — the IPC handlers, the change fact, and the
+  live-query subscriptions.
+- `internal/client/documents.go`, `cmd/attn/doc.go` — the operator surface.
+
+### Storage
+
+Two tables, both keyed by `(namespace, collection, …)`:
+
+```
+documents            (namespace, collection, id, body, created_at, updated_at)
+document_collections (namespace, collection, fields_json, updated_at)
+```
+
+The declaration is a row, not a schema: redeclaring replaces `fields_json` and
+touches no document. That is what "no migrations for authors" means concretely
+— adding a queryable field is a write to one row, and every stored document is
+queryable by it immediately, because filters read the body through
+`json_extract` at query time rather than a materialized column.
+
+Scan-first, as the gate decided. A declared field compiles to
+`json_extract(body, '$.<name>')`; `created_at`/`updated_at` compile to their
+columns and are queryable without being declared (declaring either is an
+error — the name is taken). Index-per-declared-field is the door left open, and
+nothing about the query surface changes when it opens.
+
+### Bounds
+
+`DefaultLimit` 100, `MaxLimit` 1000. Receipt (2026-08-03, production `~/.attn`):
+the lists attn already pushes whole are tickets 7, sessions 11, notifications 8,
+workspaces 8. The default is an order of magnitude past that working set and the
+ceiling two — a tripwire. Asking past the ceiling is an error naming the limit
+and the ask, never a silent truncation.
+
+Every sort is made total by an `id ASC` tiebreaker, so a range filter on the
+sort field is a correct cursor. That is the whole pagination story; there is no
+offset and no opaque page token.
+
+### Live queries
+
+A change to a collection publishes `document.changed` on the bus, subject
+`namespace/collection/id`. It is deliberately **not** in `wireProjections`: it
+produces no WebSocket traffic. An ephemeral bus subscriber beside the hub reads
+it and pokes the subscriptions whose target matches.
+
+Each subscription owns a goroutine and a one-slot `wake chan struct{}`. A full
+channel means "already told, not yet served", and dropping the extra poke is
+correct because every delivery is a whole result set that supersedes the last —
+so coalescing is free and the bus's publish lock is never held across a socket
+write. `TestWritesDoNotBlockOnASubscriberThatIsNotReading` is the guard: if the
+fan-out ever writes the socket directly, that test hangs rather than fails.
+
+`doc_subscribe` registers before running its first query. That order can only
+produce one redundant delivery; the other order can miss a write.
+
+### Transport
+
+The IPC socket, with `doc_subscribe` holding its connection open. A5 owns the
+generic protocol envelopes, and nothing here pre-empts that gate: no document
+traffic reaches the WebSocket in this stage.
+
+### Deliberately not built
+
+- **Indexes.** Scan-first was the gate's answer; the working set above is the
+  receipt. The declaration is what makes adding them later invisible to callers.
+- **Grants.** Namespaces are `owner/name` and enforced as a shape; *who* may
+  claim one is A4's registry, which is the thing that knows about authors.
+- **A frontend surface.** A5 owns the UI host. The store's consumers today are
+  the CLI and, next, the extension runtime.

--- a/internal/client/documents.go
+++ b/internal/client/documents.go
@@ -1,0 +1,118 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// The document store's client surface. Every call goes through the daemon rather
+// than opening the database, unlike `attn bus`: a write has to publish its change
+// fact, and a write that reached the table without one would leave every live
+// query showing a result set the store no longer agrees with. One path, so there
+// is no way to take the quiet one by accident.
+
+func (c *Client) DocDefine(schema protocol.DocumentCollectionSchema) (*protocol.DocDefineResult, error) {
+	resp, err := c.send(protocol.DocDefineMessage{Cmd: protocol.CmdDocDefine, Schema: schema})
+	if err != nil {
+		return nil, err
+	}
+	return resp.DocDefineResult, nil
+}
+
+func (c *Client) DocUndefine(namespace, collection string) (*protocol.DocUndefineResult, error) {
+	resp, err := c.send(protocol.DocUndefineMessage{
+		Cmd: protocol.CmdDocUndefine, Namespace: namespace, Collection: collection,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.DocUndefineResult, nil
+}
+
+func (c *Client) DocCollections() (*protocol.DocCollectionsResult, error) {
+	resp, err := c.send(protocol.DocCollectionsMessage{Cmd: protocol.CmdDocCollections})
+	if err != nil {
+		return nil, err
+	}
+	return resp.DocCollectionsResult, nil
+}
+
+func (c *Client) DocPut(namespace, collection, id, body string) (*protocol.DocPutResult, error) {
+	resp, err := c.send(protocol.DocPutMessage{
+		Cmd: protocol.CmdDocPut, Namespace: namespace, Collection: collection, ID: id, Body: body,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.DocPutResult, nil
+}
+
+func (c *Client) DocGet(namespace, collection, id string) (*protocol.DocGetResult, error) {
+	resp, err := c.send(protocol.DocGetMessage{
+		Cmd: protocol.CmdDocGet, Namespace: namespace, Collection: collection, ID: id,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.DocGetResult, nil
+}
+
+func (c *Client) DocDelete(namespace, collection, id string) (*protocol.DocDeleteResult, error) {
+	resp, err := c.send(protocol.DocDeleteMessage{
+		Cmd: protocol.CmdDocDelete, Namespace: namespace, Collection: collection, ID: id,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.DocDeleteResult, nil
+}
+
+func (c *Client) DocQuery(query protocol.DocumentQuery) (*protocol.DocQueryResult, error) {
+	resp, err := c.send(protocol.DocQueryMessage{Cmd: protocol.CmdDocQuery, Query: query})
+	if err != nil {
+		return nil, err
+	}
+	return resp.DocQueryResult, nil
+}
+
+// DocSubscribe opens a live query and calls onResult for every delivery,
+// beginning with the current result set. Unlike every other call here it holds
+// its connection open, so it returns only when onResult asks it to stop, the
+// daemon closes the connection, or a delivery cannot be read.
+//
+// Each delivery is the whole current result set; a caller renders what it is
+// handed and never accumulates state across deliveries.
+func (c *Client) DocSubscribe(query protocol.DocumentQuery, onResult func(*protocol.DocSubscribeResult) bool) error {
+	conn, err := net.Dial("unix", c.socketPath)
+	if err != nil {
+		return explainConnectError(c.socketPath, err)
+	}
+	defer conn.Close()
+
+	msg := protocol.DocSubscribeMessage{Cmd: protocol.CmdDocSubscribe, Query: query}
+	if err := json.NewEncoder(conn).Encode(msg); err != nil {
+		return fmt.Errorf("send subscribe: %w", err)
+	}
+
+	decoder := json.NewDecoder(conn)
+	for {
+		var resp protocol.Response
+		if err := decoder.Decode(&resp); err != nil {
+			// The daemon closing the connection ends the subscription; it is not
+			// the caller's error to report.
+			return nil
+		}
+		if !resp.Ok {
+			return fmt.Errorf("daemon error: %s", protocol.Deref(resp.Error))
+		}
+		if resp.DocSubscribeResult == nil {
+			continue
+		}
+		if !onResult(resp.DocSubscribeResult) {
+			return nil
+		}
+	}
+}

--- a/internal/daemon/bus.go
+++ b/internal/daemon/bus.go
@@ -211,6 +211,16 @@ const (
 	// between a fact and an invalidation — but a sharper name is preferred
 	// wherever the producer knows one.
 	FactTicketChanged = "ticket.changed"
+
+	// FactDocumentChanged: a document store record was written or removed.
+	// Subject is the document's address (namespace/collection/id); the payload
+	// carries the address in parts plus whether it was a removal.
+	//
+	// This fact has no entry in wireProjections, and that is not an omission: it
+	// produces no WebSocket traffic. Its consumer is the live-query fan-out in
+	// documents.go, an ephemeral subscriber beside the hub that delivers result
+	// sets to IPC callers over their own connections.
+	FactDocumentChanged = "document.changed"
 )
 
 // projection maps facts to the wire traffic they produce.
@@ -455,6 +465,7 @@ func (d *Daemon) ensureEventBus() {
 	}
 	d.eventBus = bus.New(bus.Options{Store: backing, Log: d.logf})
 	d.busUnsubscribe = d.eventBus.Subscribe(bus.All, d.projectToClients)
+	d.subscribeDocumentFacts()
 }
 
 // startEventBus begins durable delivery. It runs early in Start, before any
@@ -465,6 +476,7 @@ func (d *Daemon) startEventBus() error {
 }
 
 func (d *Daemon) stopEventBus() {
+	d.unsubscribeDocumentFacts()
 	if d.busUnsubscribe != nil {
 		d.busUnsubscribe()
 		d.busUnsubscribe = nil

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -142,6 +142,17 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdRenameSession:            commandMetadata(ScopeSession, false, true),
 	protocol.CmdRenameWorkspace:          commandMetadata(ScopeEndpoint, false, true),
 	protocol.CmdSetChiefOfStaff:          commandMetadata(ScopeHubLocal, false, true),
+	// The document store is the daemon's own database, so a hub answers these
+	// itself rather than routing them to the endpoint owning some session. None
+	// of them touches a PTY, so none blocks during recovery.
+	protocol.CmdDocDefine:      commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdDocUndefine:    commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdDocCollections: commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdDocPut:         commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdDocGet:         commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdDocDelete:      commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdDocQuery:       commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdDocSubscribe:   commandMetadata(ScopeHubLocal, false, true),
 }
 
 func shouldLogWSCommand(cmd string) bool {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -403,6 +403,15 @@ type Daemon struct {
 	eventBus       *bus.Bus
 	busUnsubscribe func()
 
+	// Live document-store queries. Each entry is one caller subscribed to one
+	// query; a document write wakes every subscription whose collection it
+	// touched, and the subscription re-runs its query and delivers the current
+	// result set. See documents.go.
+	docSubsMu     sync.Mutex
+	docSubs       map[string]*docSubscription
+	docSubsSeq    int64
+	docUnsubHooks func()
+
 	// Paths accumulated by the notebook_changed projection while a bulk change
 	// is coalescing, keyed by origin. See projectNotebookChanged.
 	notebookPendingMu    sync.Mutex
@@ -2316,6 +2325,24 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleTicketUnsubscribe(conn, msg.(*protocol.TicketUnsubscribeMessage))
 	case protocol.CmdTicketAttach: // wire: ticket_attach
 		d.handleTicketAttach(conn, msg.(*protocol.TicketAttachMessage))
+	case protocol.CmdDocDefine: // wire: doc_define
+		d.handleDocDefine(conn, msg.(*protocol.DocDefineMessage))
+	case protocol.CmdDocUndefine: // wire: doc_undefine
+		d.handleDocUndefine(conn, msg.(*protocol.DocUndefineMessage))
+	case protocol.CmdDocCollections: // wire: doc_collections
+		d.handleDocCollections(conn, msg.(*protocol.DocCollectionsMessage))
+	case protocol.CmdDocPut: // wire: doc_put
+		d.handleDocPut(conn, msg.(*protocol.DocPutMessage))
+	case protocol.CmdDocGet: // wire: doc_get
+		d.handleDocGet(conn, msg.(*protocol.DocGetMessage))
+	case protocol.CmdDocDelete: // wire: doc_delete
+		d.handleDocDelete(conn, msg.(*protocol.DocDeleteMessage))
+	case protocol.CmdDocQuery: // wire: doc_query
+		d.handleDocQuery(conn, msg.(*protocol.DocQueryMessage))
+	// doc_subscribe keeps the connection: it streams result sets until the
+	// caller disconnects, rather than answering once.
+	case protocol.CmdDocSubscribe: // wire: doc_subscribe
+		d.handleDocSubscribe(conn, msg.(*protocol.DocSubscribeMessage))
 	case protocol.CmdTicketCreate: // wire: ticket_create
 		d.handleTicketCreate(conn, msg.(*protocol.TicketCreateMessage))
 	case protocol.CmdTicketComment: // wire: ticket_comment

--- a/internal/daemon/documents.go
+++ b/internal/daemon/documents.go
@@ -1,0 +1,482 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"github.com/victorarias/attn/internal/bus"
+	"github.com/victorarias/attn/internal/docstore"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// The document store's daemon half: the fact a write publishes, the live queries
+// that fact wakes, and the IPC surface `attn doc` speaks.
+//
+// WHY A SUBSCRIPTION RE-RUNS RATHER THAN PATCHES. Every delivery is the query's
+// current full result set. A patch stream would be smaller and it is where live
+// query systems grow their bugs: a document falling out of a `limit 20` window
+// forces a re-query to find the 21st anyway, so a patch path needs the re-run
+// path underneath it and only some of the time. Re-running always is one path.
+//
+// That also makes a delivery safe to drop. Because each one supersedes the last,
+// a subscriber that has not drained loses nothing when a newer result set
+// replaces a queued one — which is how the one-slot wake channel below collapses
+// a burst of writes into a single delivery with no coalescing window to manage.
+//
+// WHY THE BUS FAN-OUT DOES NOT WRITE THE SOCKET. The bus holds its publish lock
+// across the inline fan-out, so anything slow inside a handler stalls every
+// publisher in the daemon. A subscription therefore owns its goroutine: the fact
+// handler only pokes the channel, and the goroutine runs the query and writes.
+//
+// See docs/plans/2026-08-03-ext-a3-doc-store.md.
+
+// docSubscription is one caller watching one query.
+type docSubscription struct {
+	id     string
+	query  docstore.Query
+	schema docstore.CollectionSchema
+	target string
+	// wake holds at most one pending nudge. A full channel means "already told,
+	// not yet served", and dropping the extra is correct because the delivery it
+	// would have caused is the same delivery the pending one will cause.
+	wake chan struct{}
+}
+
+// documentChanged is the fact's payload. It carries the address in parts so a
+// consumer never parses the subject, and `deleted` so a future consumer can tell
+// a removal from a write without reading the store to find nothing there.
+type documentChanged struct {
+	Namespace  string `json:"namespace"`
+	Collection string `json:"collection"`
+	ID         string `json:"id"`
+	Deleted    bool   `json:"deleted,omitempty"`
+}
+
+// subscribeDocumentFacts registers the live-query fan-out as its own ephemeral
+// bus consumer, beside the WebSocket hub's. It is deliberately not a projection:
+// wireProjections maps facts to WebSocket traffic, and these deliveries go to
+// IPC callers over their own connections.
+func (d *Daemon) subscribeDocumentFacts() {
+	if d.eventBus == nil || d.docUnsubHooks != nil {
+		return
+	}
+	d.docUnsubHooks = d.eventBus.Subscribe(bus.Filter{FactDocumentChanged}, d.wakeDocumentSubscriptions)
+}
+
+func (d *Daemon) unsubscribeDocumentFacts() {
+	if d.docUnsubHooks != nil {
+		d.docUnsubHooks()
+		d.docUnsubHooks = nil
+	}
+}
+
+// publishDocumentChanged announces one document write or removal. The subject is
+// the document's own address, so the log reads as a history of documents rather
+// than of collections; subscriptions match on the collection carried in the
+// payload.
+func (d *Daemon) publishDocumentChanged(namespace, collection, id string, deleted bool) {
+	d.publishFact(FactDocumentChanged, docstore.Address(namespace, collection, id),
+		documentChanged{Namespace: namespace, Collection: collection, ID: id, Deleted: deleted})
+}
+
+// wakeDocumentSubscriptions is the fact handler. It does no I/O.
+func (d *Daemon) wakeDocumentSubscriptions(ev bus.Event) {
+	fact, ok := decodeFact[documentChanged](d, ev)
+	if !ok {
+		return
+	}
+	target := docstore.Target(fact.Namespace, fact.Collection)
+
+	d.docSubsMu.Lock()
+	woken := make([]*docSubscription, 0, len(d.docSubs))
+	for _, sub := range d.docSubs {
+		if sub.target == target {
+			woken = append(woken, sub)
+		}
+	}
+	d.docSubsMu.Unlock()
+
+	for _, sub := range woken {
+		select {
+		case sub.wake <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (d *Daemon) addDocSubscription(q docstore.Query, schema docstore.CollectionSchema) *docSubscription {
+	d.docSubsMu.Lock()
+	defer d.docSubsMu.Unlock()
+	if d.docSubs == nil {
+		d.docSubs = map[string]*docSubscription{}
+	}
+	d.docSubsSeq++
+	sub := &docSubscription{
+		id:     fmt.Sprintf("docsub-%d", d.docSubsSeq),
+		query:  q,
+		schema: schema,
+		target: q.Target(),
+		wake:   make(chan struct{}, 1),
+	}
+	d.docSubs[sub.id] = sub
+	return sub
+}
+
+func (d *Daemon) removeDocSubscription(id string) {
+	d.docSubsMu.Lock()
+	delete(d.docSubs, id)
+	d.docSubsMu.Unlock()
+}
+
+// documentSubscriptionCount reports how many live queries are registered. Tests
+// use it to prove a subscription is gone once its caller disconnects; a leaked
+// subscription would keep re-running a query nobody reads.
+func (d *Daemon) documentSubscriptionCount() int {
+	d.docSubsMu.Lock()
+	defer d.docSubsMu.Unlock()
+	return len(d.docSubs)
+}
+
+// runDocQuery compiles and runs a query, returning its documents on the wire.
+func (d *Daemon) runDocQuery(q docstore.Query, schema docstore.CollectionSchema) ([]protocol.StoredDocument, error) {
+	if d.store == nil {
+		return nil, fmt.Errorf("no database")
+	}
+	compiled, err := q.Compile(schema)
+	if err != nil {
+		return nil, err
+	}
+	started := time.Now()
+	docs, err := d.store.QueryDocuments(compiled)
+	if err != nil {
+		return nil, err
+	}
+	d.logSlowDocQuery(q, time.Since(started))
+	return storedDocumentsToProtocol(docs), nil
+}
+
+// slowDocQuery is the point past which a query's duration is worth a line in the
+// log. v1 answers queries by scanning a collection, deliberately, because
+// nothing has measured a need for secondary indexes. This is the tripwire that
+// produces that measurement: it names the collection and how many documents were
+// scanned, so the case for an index arrives with its receipt instead of a hunch.
+const slowDocQuery = 50 * time.Millisecond
+
+func (d *Daemon) logSlowDocQuery(q docstore.Query, took time.Duration) {
+	if took < slowDocQuery {
+		return
+	}
+	count, err := d.store.CountDocuments(q.Namespace, q.Collection)
+	if err != nil {
+		count = -1
+	}
+	d.logf("docstore: %s/%s query took %s over %d documents (slow past %s) — a collection this size may want an index",
+		q.Namespace, q.Collection, took.Round(time.Millisecond), count, slowDocQuery)
+}
+
+// collectionFor reads a collection's declaration, turning "never declared" into
+// the error every caller wants to report.
+func (d *Daemon) collectionFor(namespace, collection string) (*docstore.CollectionSchema, error) {
+	if d.store == nil {
+		return nil, fmt.Errorf("no database")
+	}
+	if err := docstore.ValidateNamespace(namespace); err != nil {
+		return nil, err
+	}
+	if err := docstore.ValidateCollection(collection); err != nil {
+		return nil, err
+	}
+	schema, ok, err := d.store.DocumentCollection(namespace, collection)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("docstore: %s/%s is not declared; declare it with `attn doc define` before reading or writing it",
+			namespace, collection)
+	}
+	return schema, nil
+}
+
+// ---------------------------------------------------------------------------
+// IPC handlers
+// ---------------------------------------------------------------------------
+
+func (d *Daemon) handleDocDefine(conn net.Conn, msg *protocol.DocDefineMessage) {
+	schema := collectionSchemaFromProtocol(msg.Schema)
+	if err := schema.Validate(); err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	if d.store == nil {
+		d.sendError(conn, "no database")
+		return
+	}
+	if err := d.store.DefineDocumentCollection(schema, time.Now()); err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	d.sendDocResponse(conn, protocol.Response{
+		Ok:              true,
+		DocDefineResult: &protocol.DocDefineResult{Namespace: schema.Namespace, Collection: schema.Collection},
+	})
+}
+
+func (d *Daemon) handleDocUndefine(conn net.Conn, msg *protocol.DocUndefineMessage) {
+	if _, err := d.collectionFor(msg.Namespace, msg.Collection); err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	removed, err := d.store.DeleteDocumentCollection(msg.Namespace, msg.Collection)
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	// Every removed document is a change its watchers must see; without this a
+	// live query would keep showing records the store no longer holds.
+	d.coalesceSnapshots(func() {
+		d.publishDocumentChanged(msg.Namespace, msg.Collection, "", true)
+	})
+	d.sendDocResponse(conn, protocol.Response{
+		Ok: true,
+		DocUndefineResult: &protocol.DocUndefineResult{
+			Namespace: msg.Namespace, Collection: msg.Collection, DocumentsRemoved: removed,
+		},
+	})
+}
+
+func (d *Daemon) handleDocCollections(conn net.Conn, _ *protocol.DocCollectionsMessage) {
+	if d.store == nil {
+		d.sendError(conn, "no database")
+		return
+	}
+	schemas, err := d.store.ListDocumentCollections()
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	out := make([]protocol.DocumentCollectionSchema, 0, len(schemas))
+	for _, s := range schemas {
+		out = append(out, collectionSchemaToProtocol(s))
+	}
+	d.sendDocResponse(conn, protocol.Response{
+		Ok:                   true,
+		DocCollectionsResult: &protocol.DocCollectionsResult{Collections: out},
+	})
+}
+
+func (d *Daemon) handleDocPut(conn net.Conn, msg *protocol.DocPutMessage) {
+	if _, err := d.collectionFor(msg.Namespace, msg.Collection); err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	if err := docstore.ValidateDocumentID(msg.ID); err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	if err := docstore.ValidateBody([]byte(msg.Body)); err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	if err := d.store.PutDocument(msg.Namespace, msg.Collection, msg.ID, []byte(msg.Body), time.Now()); err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	d.publishDocumentChanged(msg.Namespace, msg.Collection, msg.ID, false)
+	d.sendDocResponse(conn, protocol.Response{
+		Ok:           true,
+		DocPutResult: &protocol.DocPutResult{Namespace: msg.Namespace, Collection: msg.Collection, ID: msg.ID},
+	})
+}
+
+func (d *Daemon) handleDocGet(conn net.Conn, msg *protocol.DocGetMessage) {
+	if _, err := d.collectionFor(msg.Namespace, msg.Collection); err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	doc, found, err := d.store.GetDocument(msg.Namespace, msg.Collection, msg.ID)
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	result := &protocol.DocGetResult{Found: found}
+	if found {
+		wire := storedDocumentToProtocol(*doc)
+		result.Document = &wire
+	}
+	d.sendDocResponse(conn, protocol.Response{Ok: true, DocGetResult: result})
+}
+
+func (d *Daemon) handleDocDelete(conn net.Conn, msg *protocol.DocDeleteMessage) {
+	if _, err := d.collectionFor(msg.Namespace, msg.Collection); err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	existed, err := d.store.DeleteDocument(msg.Namespace, msg.Collection, msg.ID)
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	// A delete that removed nothing changed nothing, and must not wake a
+	// subscription with a result set identical to the one it already has.
+	if existed {
+		d.publishDocumentChanged(msg.Namespace, msg.Collection, msg.ID, true)
+	}
+	d.sendDocResponse(conn, protocol.Response{
+		Ok: true,
+		DocDeleteResult: &protocol.DocDeleteResult{
+			Namespace: msg.Namespace, Collection: msg.Collection, ID: msg.ID, Existed: existed,
+		},
+	})
+}
+
+func (d *Daemon) handleDocQuery(conn net.Conn, msg *protocol.DocQueryMessage) {
+	q, err := documentQueryFromProtocol(msg.Query)
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	schema, err := d.collectionFor(q.Namespace, q.Collection)
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	docs, err := d.runDocQuery(q, *schema)
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	d.sendDocResponse(conn, protocol.Response{Ok: true, DocQueryResult: &protocol.DocQueryResult{Documents: docs}})
+}
+
+// handleDocSubscribe is the only handler that keeps its connection. It writes
+// the current result set immediately — a subscriber must be able to render from
+// one round trip, which is what makes an extension UI's remount cheap — and then
+// a fresh one every time a write to the collection could have changed it.
+func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMessage) {
+	q, err := documentQueryFromProtocol(msg.Query)
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	schema, err := d.collectionFor(q.Namespace, q.Collection)
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	// Compile once up front. A query that cannot compile must fail the subscribe
+	// rather than fail on every delivery of a subscription that looked accepted.
+	if _, err := q.Compile(*schema); err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+
+	// Registered before the first query runs. The other order drops a write that
+	// lands in between; this order can only cause one redundant delivery, and a
+	// delivery is the whole result set, so a redundant one costs nothing.
+	sub := d.addDocSubscription(q, *schema)
+	defer d.removeDocSubscription(sub.id)
+
+	// The caller never speaks again after subscribing, so anything the read
+	// returns — EOF, reset, the daemon closing the listener — means it is gone.
+	gone := make(chan struct{})
+	go func() {
+		defer close(gone)
+		_, _ = io.Copy(io.Discard, conn)
+	}()
+
+	encoder := json.NewEncoder(conn)
+	for revision := 1; ; revision++ {
+		docs, err := d.runDocQuery(q, *schema)
+		if err != nil {
+			d.sendError(conn, err.Error())
+			return
+		}
+		resp := protocol.Response{
+			Ok:                 true,
+			DocSubscribeResult: &protocol.DocSubscribeResult{Revision: revision, Documents: docs},
+		}
+		if err := encoder.Encode(resp); err != nil {
+			return
+		}
+		select {
+		case <-sub.wake:
+		case <-gone:
+			return
+		}
+	}
+}
+
+func (d *Daemon) sendDocResponse(conn net.Conn, resp protocol.Response) {
+	if err := json.NewEncoder(conn).Encode(resp); err != nil {
+		d.logf("docstore: writing response: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Wire mapping
+// ---------------------------------------------------------------------------
+
+func collectionSchemaFromProtocol(s protocol.DocumentCollectionSchema) docstore.CollectionSchema {
+	out := docstore.CollectionSchema{Namespace: s.Namespace, Collection: s.Collection}
+	for _, f := range s.Fields {
+		out.Fields = append(out.Fields, docstore.FieldSpec{Name: f.Name, Type: docstore.FieldType(f.Type)})
+	}
+	return out
+}
+
+func collectionSchemaToProtocol(s docstore.CollectionSchema) protocol.DocumentCollectionSchema {
+	out := protocol.DocumentCollectionSchema{
+		Namespace:  s.Namespace,
+		Collection: s.Collection,
+		Fields:     make([]protocol.DocumentFieldSpec, 0, len(s.Fields)),
+	}
+	for _, f := range s.Fields {
+		out.Fields = append(out.Fields, protocol.DocumentFieldSpec{Name: f.Name, Type: string(f.Type)})
+	}
+	return out
+}
+
+// documentQueryFromProtocol decodes a wire query. A filter's bound arrives as
+// JSON text because it is the one polymorphic leaf; decoding it here is what
+// lets docstore check it against the field's declared type.
+func documentQueryFromProtocol(q protocol.DocumentQuery) (docstore.Query, error) {
+	out := docstore.Query{Namespace: q.Namespace, Collection: q.Collection}
+	for _, f := range q.Filters {
+		var value any
+		if err := json.Unmarshal([]byte(f.ValueJson), &value); err != nil {
+			return docstore.Query{}, fmt.Errorf("docstore: filter on %q carries %q, which is not JSON: %w", f.Field, f.ValueJson, err)
+		}
+		out.Filters = append(out.Filters, docstore.Filter{Field: f.Field, Op: docstore.Op(f.Op), Value: value})
+	}
+	if q.Sort != nil {
+		sort := docstore.Sort{Field: q.Sort.Field}
+		if q.Sort.Desc != nil {
+			sort.Desc = *q.Sort.Desc
+		}
+		out.Sort = &sort
+	}
+	if q.Limit != nil {
+		out.Limit = *q.Limit
+	}
+	return out, nil
+}
+
+func storedDocumentToProtocol(doc docstore.Document) protocol.StoredDocument {
+	return protocol.StoredDocument{
+		ID:        doc.ID,
+		Body:      string(doc.Body),
+		CreatedAt: doc.CreatedAt.UTC().Format(docstore.TimeFormat),
+		UpdatedAt: doc.UpdatedAt.UTC().Format(docstore.TimeFormat),
+	}
+}
+
+func storedDocumentsToProtocol(docs []docstore.Document) []protocol.StoredDocument {
+	out := make([]protocol.StoredDocument, 0, len(docs))
+	for _, doc := range docs {
+		out = append(out, storedDocumentToProtocol(doc))
+	}
+	return out
+}

--- a/internal/daemon/documents.go
+++ b/internal/daemon/documents.go
@@ -140,12 +140,30 @@ func (d *Daemon) documentSubscriptionCount() int {
 	return len(d.docSubs)
 }
 
+// compileDocQuery resolves the query's after cursor and compiles it. The cursor
+// is a document id, so the anchor has to be read here: docstore holds no
+// database handle, and it needs the anchor's sort value to compare against the
+// whole ordering tuple.
+func (d *Daemon) compileDocQuery(q docstore.Query, schema docstore.CollectionSchema) (docstore.Compiled, error) {
+	var anchor *docstore.Document
+	if q.After != "" {
+		doc, found, err := d.store.GetDocument(q.Namespace, q.Collection, q.After)
+		if err != nil {
+			return docstore.Compiled{}, err
+		}
+		if found {
+			anchor = doc
+		}
+	}
+	return q.Compile(schema, anchor)
+}
+
 // runDocQuery compiles and runs a query, returning its documents on the wire.
 func (d *Daemon) runDocQuery(q docstore.Query, schema docstore.CollectionSchema) ([]protocol.StoredDocument, error) {
 	if d.store == nil {
 		return nil, fmt.Errorf("no database")
 	}
-	compiled, err := q.Compile(schema)
+	compiled, err := d.compileDocQuery(q, schema)
 	if err != nil {
 		return nil, err
 	}
@@ -368,7 +386,7 @@ func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMes
 	}
 	// Compile once up front. A query that cannot compile must fail the subscribe
 	// rather than fail on every delivery of a subscription that looked accepted.
-	if _, err := q.Compile(*schema); err != nil {
+	if _, err := d.compileDocQuery(q, *schema); err != nil {
 		d.sendError(conn, err.Error())
 		return
 	}
@@ -460,6 +478,9 @@ func documentQueryFromProtocol(q protocol.DocumentQuery) (docstore.Query, error)
 	}
 	if q.Limit != nil {
 		out.Limit = *q.Limit
+	}
+	if q.After != nil {
+		out.After = *q.After
 	}
 	return out, nil
 }

--- a/internal/daemon/documents_test.go
+++ b/internal/daemon/documents_test.go
@@ -1,0 +1,379 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+const (
+	testDocNS   = "ext/approval-gate"
+	testDocColl = "requests"
+)
+
+// docCall runs a one-shot handler over a pipe and returns its response, the way
+// an `attn doc` invocation reaches the daemon.
+func docCall(t *testing.T, run func(net.Conn)) protocol.Response {
+	t.Helper()
+	client, server := net.Pipe()
+	go func() {
+		run(server)
+		_ = server.Close()
+	}()
+	defer client.Close()
+	var resp protocol.Response
+	if err := json.NewDecoder(client).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return resp
+}
+
+func defineTestCollection(t *testing.T, d *Daemon) {
+	t.Helper()
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocDefine(c, &protocol.DocDefineMessage{
+			Cmd: protocol.CmdDocDefine,
+			Schema: protocol.DocumentCollectionSchema{
+				Namespace:  testDocNS,
+				Collection: testDocColl,
+				Fields:     []protocol.DocumentFieldSpec{{Name: "status", Type: "string"}},
+			},
+		})
+	})
+	if !resp.Ok {
+		t.Fatalf("define: %v", protocol.Deref(resp.Error))
+	}
+}
+
+func putDoc(t *testing.T, d *Daemon, id, body string) {
+	t.Helper()
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocPut(c, &protocol.DocPutMessage{
+			Cmd: protocol.CmdDocPut, Namespace: testDocNS, Collection: testDocColl, ID: id, Body: body,
+		})
+	})
+	if !resp.Ok {
+		t.Fatalf("put %s: %v", id, protocol.Deref(resp.Error))
+	}
+}
+
+func deleteDoc(t *testing.T, d *Daemon, id string) bool {
+	t.Helper()
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocDelete(c, &protocol.DocDeleteMessage{
+			Cmd: protocol.CmdDocDelete, Namespace: testDocNS, Collection: testDocColl, ID: id,
+		})
+	})
+	if !resp.Ok {
+		t.Fatalf("delete %s: %v", id, protocol.Deref(resp.Error))
+	}
+	return resp.DocDeleteResult.Existed
+}
+
+// liveQuery subscribes and returns a reader for its deliveries plus a stop that
+// disconnects the caller and waits for the handler to finish — the real signal
+// that the subscription has been torn down.
+type liveQuery struct {
+	dec  *json.Decoder
+	stop func()
+}
+
+func subscribe(t *testing.T, d *Daemon, q protocol.DocumentQuery) *liveQuery {
+	t.Helper()
+	client, server := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.handleDocSubscribe(server, &protocol.DocSubscribeMessage{Cmd: protocol.CmdDocSubscribe, Query: q})
+		_ = server.Close()
+	}()
+	lq := &liveQuery{dec: json.NewDecoder(client)}
+	lq.stop = func() {
+		_ = client.Close()
+		<-done
+	}
+	t.Cleanup(lq.stop)
+	return lq
+}
+
+// next reads one delivery. It blocks until the daemon sends, which is what makes
+// these tests wait on a real signal rather than on a duration.
+func (lq *liveQuery) next(t *testing.T) *protocol.DocSubscribeResult {
+	t.Helper()
+	var resp protocol.Response
+	if err := lq.dec.Decode(&resp); err != nil {
+		t.Fatalf("decode delivery: %v", err)
+	}
+	if !resp.Ok {
+		t.Fatalf("delivery carried an error: %v", protocol.Deref(resp.Error))
+	}
+	if resp.DocSubscribeResult == nil {
+		t.Fatal("delivery carried no result")
+	}
+	return resp.DocSubscribeResult
+}
+
+func ids(result *protocol.DocSubscribeResult) []string {
+	out := make([]string, 0, len(result.Documents))
+	for _, doc := range result.Documents {
+		out = append(out, doc.ID)
+	}
+	return out
+}
+
+func testQuery() protocol.DocumentQuery {
+	return protocol.DocumentQuery{Namespace: testDocNS, Collection: testDocColl}
+}
+
+// Subscribing delivers the current result set straight away, in the same round
+// trip. An extension UI remounts by re-subscribing, so a subscription that only
+// promised future updates would render empty until something happened to change.
+func TestSubscribingDeliversTheCurrentResultSetImmediately(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "already-here", `{"status":"pending"}`)
+
+	lq := subscribe(t, d, testQuery())
+	first := lq.next(t)
+	if first.Revision != 1 {
+		t.Fatalf("first delivery revision = %d, want 1", first.Revision)
+	}
+	if got := ids(first); len(got) != 1 || got[0] != "already-here" {
+		t.Fatalf("first delivery = %v", got)
+	}
+}
+
+// A write wakes the subscription, and what arrives is the whole current result
+// set rather than a description of what changed.
+func TestAWriteWakesTheSubscriptionWithTheWholeResultSet(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	lq := subscribe(t, d, testQuery())
+	if got := ids(lq.next(t)); len(got) != 0 {
+		t.Fatalf("initial delivery = %v, want empty", got)
+	}
+
+	putDoc(t, d, "a", `{"status":"pending"}`)
+	second := lq.next(t)
+	if second.Revision != 2 {
+		t.Fatalf("revision = %d, want 2", second.Revision)
+	}
+	if got := ids(second); len(got) != 1 || got[0] != "a" {
+		t.Fatalf("after write = %v", got)
+	}
+	if body := second.Documents[0].Body; body != `{"status":"pending"}` {
+		t.Fatalf("body = %s", body)
+	}
+}
+
+// A delete that removed nothing changed nothing, so it must not wake anybody.
+// Proven without waiting on the absence of a message: the next delivery after a
+// no-op delete plus a real write is revision 2, which it could not be if the
+// no-op had also delivered.
+func TestANoOpDeleteDoesNotWakeSubscribers(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	lq := subscribe(t, d, testQuery())
+	lq.next(t)
+
+	if existed := deleteDoc(t, d, "never-existed"); existed {
+		t.Fatal("deleting a missing document reported it existed")
+	}
+	putDoc(t, d, "a", `{"status":"pending"}`)
+
+	next := lq.next(t)
+	if next.Revision != 2 {
+		t.Fatalf("revision = %d, want 2 — the no-op delete delivered", next.Revision)
+	}
+	if got := ids(next); len(got) != 1 || got[0] != "a" {
+		t.Fatalf("delivery = %v", got)
+	}
+}
+
+// A removal reaches a live query: what it renders must never outlive the store.
+func TestARemovalReachesTheLiveQuery(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+	lq := subscribe(t, d, testQuery())
+	if got := ids(lq.next(t)); len(got) != 1 {
+		t.Fatalf("initial = %v", got)
+	}
+	if existed := deleteDoc(t, d, "a"); !existed {
+		t.Fatal("delete reported nothing was there")
+	}
+	if got := ids(lq.next(t)); len(got) != 0 {
+		t.Fatalf("after removal = %v, want empty", got)
+	}
+}
+
+// A subscription belongs to one collection. A write next door must not wake it —
+// otherwise every extension pays for every other extension's write traffic, and
+// namespace isolation stops meaning anything on the live path.
+func TestASubscriptionOnlyWakesForItsOwnCollection(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocDefine(c, &protocol.DocDefineMessage{
+			Cmd: protocol.CmdDocDefine,
+			Schema: protocol.DocumentCollectionSchema{
+				Namespace: "ext/other", Collection: testDocColl,
+				Fields: []protocol.DocumentFieldSpec{{Name: "status", Type: "string"}},
+			},
+		})
+	})
+	if !resp.Ok {
+		t.Fatalf("define neighbour: %v", protocol.Deref(resp.Error))
+	}
+
+	lq := subscribe(t, d, testQuery())
+	lq.next(t)
+
+	// A write to the neighbouring namespace, then one to ours. If the neighbour
+	// had woken us, this delivery would be revision 3.
+	if r := docCall(t, func(c net.Conn) {
+		d.handleDocPut(c, &protocol.DocPutMessage{
+			Cmd: protocol.CmdDocPut, Namespace: "ext/other", Collection: testDocColl,
+			ID: "theirs", Body: `{"status":"pending"}`,
+		})
+	}); !r.Ok {
+		t.Fatalf("put neighbour: %v", protocol.Deref(r.Error))
+	}
+	putDoc(t, d, "ours", `{"status":"pending"}`)
+
+	next := lq.next(t)
+	if next.Revision != 2 {
+		t.Fatalf("revision = %d, want 2 — the neighbouring namespace woke this subscription", next.Revision)
+	}
+	if got := ids(next); len(got) != 1 || got[0] != "ours" {
+		t.Fatalf("delivery = %v — it crossed the namespace boundary", got)
+	}
+}
+
+// A caller that disconnects takes its subscription with it. A leaked one would
+// re-run its query on every write for the life of the daemon.
+func TestASubscriptionIsGoneWhenItsCallerDisconnects(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	lq := subscribe(t, d, testQuery())
+	lq.next(t)
+	if n := d.documentSubscriptionCount(); n != 1 {
+		t.Fatalf("subscriptions = %d, want 1", n)
+	}
+	lq.stop() // closes the caller and waits for the handler to return
+	if n := d.documentSubscriptionCount(); n != 0 {
+		t.Fatalf("subscriptions after disconnect = %d, want 0", n)
+	}
+}
+
+// The bus holds its publish lock across fan-out, so a subscriber that is not
+// draining must never be able to hold up a writer. This test would hang rather
+// than fail if the fan-out ever wrote to the socket itself.
+func TestWritesDoNotBlockOnASubscriberThatIsNotReading(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	lq := subscribe(t, d, testQuery())
+	lq.next(t)
+
+	// Nothing reads from here on; every one of these must still return.
+	for _, id := range []string{"a", "b", "c", "d", "e", "f", "g", "h"} {
+		putDoc(t, d, id, `{"status":"pending"}`)
+	}
+}
+
+// A query against a collection nobody declared names the collection and the way
+// out, because the reader fixing it is an agent with only the error to go on.
+func TestReadingAnUndeclaredCollectionSaysHowToDeclareIt(t *testing.T) {
+	d := newDaemonForTest(t)
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocQuery(c, &protocol.DocQueryMessage{
+			Cmd: protocol.CmdDocQuery, Query: protocol.DocumentQuery{Namespace: testDocNS, Collection: "nope"},
+		})
+	})
+	if resp.Ok {
+		t.Fatal("querying an undeclared collection succeeded")
+	}
+	msg := protocol.Deref(resp.Error)
+	for _, want := range []string{testDocNS, "nope", "doc define"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q does not mention %q", msg, want)
+		}
+	}
+}
+
+// A subscription whose query cannot compile is refused at subscribe time. The
+// alternative is a subscription that looks accepted and fails on every delivery.
+func TestASubscriptionWithAnUnqueryableFieldIsRefusedUpFront(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	q := testQuery()
+	q.Sort = &protocol.DocumentSort{Field: "undeclared"}
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocSubscribe(c, &protocol.DocSubscribeMessage{Cmd: protocol.CmdDocSubscribe, Query: q})
+	})
+	if resp.Ok {
+		t.Fatal("subscribing with an undeclared sort field succeeded")
+	}
+	if n := d.documentSubscriptionCount(); n != 0 {
+		t.Fatalf("a refused subscribe left %d subscriptions behind", n)
+	}
+}
+
+// A filter's bound travels as JSON text and is decoded against the field's
+// declared type, so the wire form reaches the same rules the Go form does.
+func TestAFilterBoundArrivesAsJSONAndIsTypeChecked(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+	putDoc(t, d, "b", `{"status":"approved"}`)
+
+	q := testQuery()
+	q.Filters = []protocol.DocumentFilter{{Field: "status", Op: "eq", ValueJson: `"pending"`}}
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocQuery(c, &protocol.DocQueryMessage{Cmd: protocol.CmdDocQuery, Query: q})
+	})
+	if !resp.Ok {
+		t.Fatalf("query: %v", protocol.Deref(resp.Error))
+	}
+	if docs := resp.DocQueryResult.Documents; len(docs) != 1 || docs[0].ID != "a" {
+		t.Fatalf("documents = %+v", docs)
+	}
+
+	// A number against a string field is refused rather than matching nothing.
+	q.Filters = []protocol.DocumentFilter{{Field: "status", Op: "eq", ValueJson: `5`}}
+	if r := docCall(t, func(c net.Conn) {
+		d.handleDocQuery(c, &protocol.DocQueryMessage{Cmd: protocol.CmdDocQuery, Query: q})
+	}); r.Ok {
+		t.Fatal("a number bound against a string field was accepted")
+	}
+}
+
+// Removing a collection tells its live queries, so nothing keeps rendering
+// records the store no longer holds.
+func TestRemovingACollectionReachesItsLiveQueries(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+	lq := subscribe(t, d, testQuery())
+	if got := ids(lq.next(t)); len(got) != 1 {
+		t.Fatalf("initial = %v", got)
+	}
+
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocUndefine(c, &protocol.DocUndefineMessage{
+			Cmd: protocol.CmdDocUndefine, Namespace: testDocNS, Collection: testDocColl,
+		})
+	})
+	if !resp.Ok {
+		t.Fatalf("undefine: %v", protocol.Deref(resp.Error))
+	}
+	if n := resp.DocUndefineResult.DocumentsRemoved; n != 1 {
+		t.Fatalf("removed %d documents, want 1", n)
+	}
+	if got := ids(lq.next(t)); len(got) != 0 {
+		t.Fatalf("after the collection went = %v, want empty", got)
+	}
+}

--- a/internal/daemon/documents_test.go
+++ b/internal/daemon/documents_test.go
@@ -377,3 +377,60 @@ func TestRemovingACollectionReachesItsLiveQueries(t *testing.T) {
 		t.Fatalf("after the collection went = %v, want empty", got)
 	}
 }
+
+// The after cursor survives the wire and pages a real tie. `attn doc query
+// --after` is the reachable form of the only pagination the store offers, so it
+// has to be proven from the message in rather than from the compiler alone.
+func TestPagingWithTheAfterCursorOverTheWire(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	for _, id := range []string{"a", "b", "c"} {
+		putDoc(t, d, id, `{"status":"pending"}`)
+	}
+
+	limit := 1
+	q := testQuery()
+	q.Sort = &protocol.DocumentSort{Field: "status"}
+	q.Limit = &limit
+
+	var walked []string
+	for range []string{"a", "b", "c"} {
+		resp := docCall(t, func(c net.Conn) {
+			d.handleDocQuery(c, &protocol.DocQueryMessage{Cmd: protocol.CmdDocQuery, Query: q})
+		})
+		if !resp.Ok {
+			t.Fatalf("query after %v: %v", q.After, protocol.Deref(resp.Error))
+		}
+		docs := resp.DocQueryResult.Documents
+		if len(docs) != 1 {
+			t.Fatalf("page after %v = %d documents, want 1", q.After, len(docs))
+		}
+		walked = append(walked, docs[0].ID)
+		next := docs[0].ID
+		q.After = &next
+	}
+	if strings.Join(walked, ",") != "a,b,c" {
+		t.Fatalf("walked %v, want [a b c]", walked)
+	}
+}
+
+// A cursor to a document that has been deleted fails the query rather than
+// returning an empty page that reads as the end of the walk.
+func TestAnAfterCursorToADeletedDocumentIsReported(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+
+	gone := "b"
+	q := testQuery()
+	q.After = &gone
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocQuery(c, &protocol.DocQueryMessage{Cmd: protocol.CmdDocQuery, Query: q})
+	})
+	if resp.Ok {
+		t.Fatal("a cursor to a missing document was accepted")
+	}
+	if err := protocol.Deref(resp.Error); !strings.Contains(err, "b") || !strings.Contains(err, "no longer exists") {
+		t.Fatalf("error = %q", err)
+	}
+}

--- a/internal/docstore/docstore.go
+++ b/internal/docstore/docstore.go
@@ -67,9 +67,8 @@ const (
 )
 
 // Op is a filter comparison. Equality plus the four range operators is the whole
-// surface: it covers both proof compositions (a pending-requests panel, and
-// records after a cursor), and range on the sort field is what makes cursor
-// pagination work.
+// surface: it covers a pending-requests panel and a changed-since sweep.
+// Pagination is deliberately not built out of these — see Query.After.
 type Op string
 
 const (
@@ -111,8 +110,8 @@ type Filter struct {
 }
 
 // Sort names the ordering field. Results always carry a stable total order —
-// Compile appends the document id as a tiebreaker — so paging through a sort
-// with ties cannot skip or repeat a document.
+// Compile appends the document id as a tiebreaker, in the same direction as the
+// sort — so two documents sharing a sort value have a defined relative position.
 type Sort struct {
 	Field string `json:"field"`
 	Desc  bool   `json:"desc,omitempty"`
@@ -122,12 +121,21 @@ type Sort struct {
 //
 // A zero Limit means DefaultLimit rather than "unbounded": a query with no
 // ceiling is a wire message with no ceiling.
+//
+// After is the id of the last document of the previous page, and is how a
+// caller gets the next one. It has to be part of the query rather than a filter
+// a caller writes by hand: the visible order is (sort field, id), and a filter
+// can only constrain one of those, so `sort > value` skips every document tied
+// with the anchor and `sort >= value` returns the anchor again. Compile turns
+// After into a comparison against the whole ordering tuple, which is the only
+// form that neither skips nor repeats.
 type Query struct {
 	Namespace  string   `json:"namespace"`
 	Collection string   `json:"collection"`
 	Filters    []Filter `json:"filters,omitempty"`
 	Sort       *Sort    `json:"sort,omitempty"`
 	Limit      int      `json:"limit,omitempty"`
+	After      string   `json:"after,omitempty"`
 }
 
 // Document is one stored record. Body is the document as written, byte for byte
@@ -261,7 +269,13 @@ func (s CollectionSchema) declaredNames() string {
 // SQL. Every rejection names the collection, the offending part, and what is
 // available — the reader is an agent that must fix the query from the error
 // alone.
-func (q Query) Compile(schema CollectionSchema) (Compiled, error) {
+//
+// anchor is the document q.After names, which the caller reads before compiling
+// because this package holds no database handle. It is nil when q.After is
+// empty, and its absence when q.After is set is an error rather than an empty
+// page: a cursor pointing at a document that no longer exists is a caller
+// mistake worth hearing about, not a silent end of results.
+func (q Query) Compile(schema CollectionSchema, anchor *Document) (Compiled, error) {
 	if err := ValidateNamespace(q.Namespace); err != nil {
 		return Compiled{}, err
 	}
@@ -294,20 +308,34 @@ func (q Query) Compile(schema CollectionSchema) (Compiled, error) {
 		args = append(args, val)
 	}
 
+	sortExpr := ""
+	desc := false
 	order := "id ASC"
 	if q.Sort != nil {
 		expr, _, err := q.fieldExpr(schema, q.Sort.Field, "sort")
 		if err != nil {
 			return Compiled{}, err
 		}
+		sortExpr, desc = expr, q.Sort.Desc
 		dir := "ASC"
-		if q.Sort.Desc {
+		if desc {
 			dir = "DESC"
 		}
 		// The id tiebreaker is what makes the order total. Without it two
 		// documents sharing a sort value have no defined relative position, and
-		// a paginating reader can see one twice and the other never.
-		order = expr + " " + dir + ", id ASC"
+		// a paginating reader can see one twice and the other never. It runs in
+		// the sort's own direction so the visible order is one uniformly
+		// directed tuple, which is what the After cursor compares against.
+		order = expr + " " + dir + ", id " + dir
+	}
+
+	if q.After != "" || anchor != nil {
+		clause, cursorArgs, err := q.afterTuple(schema, sortExpr, desc, anchor)
+		if err != nil {
+			return Compiled{}, err
+		}
+		where = append(where, clause)
+		args = append(args, cursorArgs...)
 	}
 
 	limit := q.Limit
@@ -317,11 +345,107 @@ func (q Query) Compile(schema CollectionSchema) (Compiled, error) {
 	case limit < 0:
 		return Compiled{}, fmt.Errorf("docstore: %s/%s limit is %d; a limit must be positive", q.Namespace, q.Collection, limit)
 	case limit > MaxLimit:
-		return Compiled{}, fmt.Errorf("docstore: %s/%s limit is %d, above the maximum of %d; page with a range filter on the sort field instead",
+		return Compiled{}, fmt.Errorf("docstore: %s/%s limit is %d, above the maximum of %d; page instead, passing the last document's id as the query's after cursor",
 			q.Namespace, q.Collection, limit, MaxLimit)
 	}
 
 	return Compiled{Where: strings.Join(where, " AND "), Args: args, Order: order, Limit: limit}, nil
+}
+
+// afterTuple compiles the After cursor: "strictly past the anchor in the
+// visible order". The visible order is (sort field, id) both running the same
+// direction, so past-the-anchor is the tuple comparison
+//
+//	sort <cmp> value OR (sort = value AND id <cmp> anchorID)
+//
+// A range filter cannot express that second branch, which is why After exists:
+// with ties on the sort field, `sort > value` loses every document that shares
+// the anchor's value and `sort >= value` hands the anchor back.
+//
+// A missing or JSON-null sort value is a real case — a declared field says what
+// may be queried, not what a document must contain — and NULL compares as
+// nothing at all, so it is branched on rather than bound. SQLite sorts NULL
+// first, so in ASC every non-NULL row is past a NULL anchor and in DESC none is.
+func (q Query) afterTuple(schema CollectionSchema, sortExpr string, desc bool, anchor *Document) (string, []any, error) {
+	if q.After == "" {
+		return "", nil, fmt.Errorf("docstore: %s/%s was compiled with a cursor document but no after id", q.Namespace, q.Collection)
+	}
+	if err := ValidateDocumentID(q.After); err != nil {
+		return "", nil, err
+	}
+	if anchor == nil {
+		return "", nil, fmt.Errorf("docstore: %s/%s cannot page after %q, which no longer exists; page again from the start, or use the id of a document that is still stored",
+			q.Namespace, q.Collection, q.After)
+	}
+	if anchor.ID != q.After {
+		return "", nil, fmt.Errorf("docstore: %s/%s was compiled to page after %q but given document %q", q.Namespace, q.Collection, q.After, anchor.ID)
+	}
+
+	cmp := ">"
+	if desc {
+		cmp = "<"
+	}
+	if sortExpr == "" {
+		// No sort: the whole order is id ASC, so the cursor is one comparison.
+		return "id " + cmp + " ?", []any{q.After}, nil
+	}
+
+	value, err := q.anchorSortValue(schema, anchor)
+	if err != nil {
+		return "", nil, err
+	}
+	if value == nil {
+		if desc {
+			return "(" + sortExpr + " IS NULL AND id < ?)", []any{q.After}, nil
+		}
+		return "(" + sortExpr + " IS NOT NULL OR id > ?)", []any{q.After}, nil
+	}
+	clause := "(" + sortExpr + " " + cmp + " ? OR (" + sortExpr + " = ? AND id " + cmp + " ?))"
+	if desc {
+		// Descending puts NULLs last, so they are past any non-NULL anchor.
+		clause = "(" + sortExpr + " IS NULL OR " + sortExpr + " < ? OR (" + sortExpr + " = ? AND id < ?))"
+	}
+	return clause, []any{value, value, q.After}, nil
+}
+
+// anchorSortValue reads the cursor document's value for the sort field, bound
+// the way the compiled expression compares. It returns nil for a document that
+// does not carry the field, which is the NULL branch above.
+func (q Query) anchorSortValue(schema CollectionSchema, anchor *Document) (any, error) {
+	field := q.Sort.Field
+	switch field {
+	case FieldCreatedAt:
+		return anchor.CreatedAt.UTC().Format(TimeFormat), nil
+	case FieldUpdatedAt:
+		return anchor.UpdatedAt.UTC().Format(TimeFormat), nil
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(anchor.Body, &body); err != nil {
+		return nil, fmt.Errorf("docstore: %s/%s cannot page after %q: its body is not a JSON object (%w)", q.Namespace, q.Collection, anchor.ID, err)
+	}
+	raw, ok := body[field]
+	if !ok {
+		return nil, nil
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("docstore: %s/%s cannot page after %q: its %q is not valid JSON (%w)", q.Namespace, q.Collection, anchor.ID, field, err)
+	}
+	// Bound the way json_extract yields it, so the comparison and the ORDER BY
+	// agree: booleans come back as 1/0, everything else as itself. The stored
+	// value is bound whatever its type, even if it disagrees with the
+	// declaration — the ordering it participates in is the stored one.
+	switch v := value.(type) {
+	case nil:
+		return nil, nil
+	case bool:
+		if v {
+			return 1, nil
+		}
+		return 0, nil
+	default:
+		return v, nil
+	}
 }
 
 // fieldExpr resolves a field reference to SQL. A reserved name is a real column;

--- a/internal/docstore/docstore.go
+++ b/internal/docstore/docstore.go
@@ -1,0 +1,448 @@
+// Package docstore is attn's document primitive: JSON documents addressed by
+// (namespace, collection, id), read through one JSON-serializable query object,
+// with a collection's declared fields as the contract for what may be filtered
+// and sorted.
+//
+// This package owns what a query MEANS — the vocabulary, the validation, and
+// the SQL a validated query compiles to. It owns no database handle:
+// internal/store executes what is compiled here and scans the rows. That is the
+// same split internal/bus and internal/store/bus.go already use, semantics here
+// and persistence there, and it is what lets the query rules be tested without
+// a database.
+//
+// The query object is deliberately serializable end to end. Three surfaces will
+// eventually carry it — the Bun sidecar's SDK, extension UI, and `attn doc` —
+// and all three must carry the same thing, so a later transport adds transport
+// and not semantics.
+//
+// The store knows nothing about extensions. A namespace is an opaque
+// `owner/name` string; who may write under which owner is enforced where the
+// namespace is granted, not here.
+//
+// See docs/plans/2026-08-03-ext-a3-doc-store.md.
+package docstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Limits on a result set. A live query's results are pushed as one message and
+// rendered as one list, so the bound that matters is "how big is a list a person
+// looks at".
+//
+// Receipt (2026-08-03, production ~/.attn): the lists attn already pushes whole
+// are tickets 7, sessions 11, notifications 8, workspaces 8. DefaultLimit is an
+// order of magnitude past that working set, MaxLimit two orders — a tripwire, so
+// only something broken or something that means to paginate ever feels it.
+const (
+	DefaultLimit = 100
+	MaxLimit     = 1000
+)
+
+// Reserved field names. Both are real columns the store stamps, so they are
+// always available for filtering and sorting without being declared — "newest
+// first" and "changed since" need no schema. A collection may not declare a body
+// field under either name; the column would win and the declaration would be a
+// lie.
+const (
+	FieldCreatedAt = "created_at"
+	FieldUpdatedAt = "updated_at"
+)
+
+// FieldType is what a declared field holds. The type is not decoration: it
+// decides how a filter's bound is bound to the statement, and comparing a number
+// field against a string bound would otherwise match nothing at all rather than
+// failing.
+type FieldType string
+
+const (
+	FieldString FieldType = "string"
+	FieldNumber FieldType = "number"
+	FieldBool   FieldType = "bool"
+)
+
+// Op is a filter comparison. Equality plus the four range operators is the whole
+// surface: it covers both proof compositions (a pending-requests panel, and
+// records after a cursor), and range on the sort field is what makes cursor
+// pagination work.
+type Op string
+
+const (
+	OpEq  Op = "eq"
+	OpLt  Op = "lt"
+	OpLte Op = "lte"
+	OpGt  Op = "gt"
+	OpGte Op = "gte"
+)
+
+var opSQL = map[Op]string{OpEq: "=", OpLt: "<", OpLte: "<=", OpGt: ">", OpGte: ">="}
+
+// FieldSpec declares one queryable field of a collection.
+type FieldSpec struct {
+	Name string    `json:"name"`
+	Type FieldType `json:"type"`
+}
+
+// CollectionSchema is a collection's declaration: which fields may be filtered
+// and sorted on. It is the API contract, and it is deliberately not a storage
+// schema — a document's body is arbitrary JSON, and an undeclared field is
+// stored and read back untouched. Declaring a field says "you may query this",
+// not "this must exist".
+//
+// v1 executes queries by scanning within a collection, so a declaration creates
+// no index today. It is still the contract, because it is what lets indexes
+// appear later without any author-facing change.
+type CollectionSchema struct {
+	Namespace  string      `json:"namespace"`
+	Collection string      `json:"collection"`
+	Fields     []FieldSpec `json:"fields"`
+}
+
+// Filter is one comparison against a declared or reserved field.
+type Filter struct {
+	Field string `json:"field"`
+	Op    Op     `json:"op"`
+	Value any    `json:"value"`
+}
+
+// Sort names the ordering field. Results always carry a stable total order —
+// Compile appends the document id as a tiebreaker — so paging through a sort
+// with ties cannot skip or repeat a document.
+type Sort struct {
+	Field string `json:"field"`
+	Desc  bool   `json:"desc,omitempty"`
+}
+
+// Query is the one representation every surface carries.
+//
+// A zero Limit means DefaultLimit rather than "unbounded": a query with no
+// ceiling is a wire message with no ceiling.
+type Query struct {
+	Namespace  string   `json:"namespace"`
+	Collection string   `json:"collection"`
+	Filters    []Filter `json:"filters,omitempty"`
+	Sort       *Sort    `json:"sort,omitempty"`
+	Limit      int      `json:"limit,omitempty"`
+}
+
+// Document is one stored record. Body is the document as written, byte for byte
+// — record-shape evolution is handled by the reader (parse tolerantly, render
+// tolerantly), never by migrating stored documents.
+type Document struct {
+	ID        string          `json:"id"`
+	Body      json.RawMessage `json:"body"`
+	CreatedAt time.Time       `json:"created_at"`
+	UpdatedAt time.Time       `json:"updated_at"`
+}
+
+// Compiled is a validated query as SQL. Where and Order are fragments the store
+// splices into its own SELECT; Args binds Where's placeholders in order.
+type Compiled struct {
+	Where string
+	Args  []any
+	Order string
+	Limit int
+}
+
+var (
+	// A namespace is `owner/name`: the owner segment is the isolation class a
+	// grant hands out (`ext`, `core`), the name segment identifies the holder.
+	namePart      = `[a-z0-9][a-z0-9_-]*`
+	namespaceRe   = regexp.MustCompile(`^` + namePart + `/` + namePart + `$`)
+	collectionRe  = regexp.MustCompile(`^` + namePart + `$`)
+	documentIDRe  = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+	fieldNameRe   = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+	reservedField = map[string]bool{FieldCreatedAt: true, FieldUpdatedAt: true}
+)
+
+// ValidateNamespace accepts an `owner/name` namespace. The store does not care
+// which owners exist; it cares that the string is a well-formed two-part name it
+// can index and a person can read.
+func ValidateNamespace(ns string) error {
+	if ns == "" {
+		return fmt.Errorf("docstore: namespace is required, as owner/name (for example ext/approval-gate)")
+	}
+	if !namespaceRe.MatchString(ns) {
+		return fmt.Errorf("docstore: namespace %q is not owner/name, where each part is lowercase letters, digits, - or _ (for example ext/approval-gate)", ns)
+	}
+	return nil
+}
+
+// ValidateCollection accepts a collection name.
+func ValidateCollection(name string) error {
+	if name == "" {
+		return fmt.Errorf("docstore: collection is required")
+	}
+	if !collectionRe.MatchString(name) {
+		return fmt.Errorf("docstore: collection %q must be lowercase letters, digits, - or _", name)
+	}
+	return nil
+}
+
+// ValidateDocumentID accepts a document id. Ids are caller-chosen so a workflow
+// can address the record it owns by a name it already has, rather than storing a
+// generated id somewhere to find it again.
+func ValidateDocumentID(id string) error {
+	if id == "" {
+		return fmt.Errorf("docstore: document id is required")
+	}
+	if !documentIDRe.MatchString(id) {
+		return fmt.Errorf("docstore: document id %q must start alphanumeric and contain only letters, digits, ., - or _", id)
+	}
+	return nil
+}
+
+// Validate checks a collection declaration. Field names are restricted to plain
+// identifiers, which is also what makes the compiled JSON path safe to build by
+// concatenation: there is no quoting to get wrong because there is nothing to
+// quote.
+func (s CollectionSchema) Validate() error {
+	if err := ValidateNamespace(s.Namespace); err != nil {
+		return err
+	}
+	if err := ValidateCollection(s.Collection); err != nil {
+		return err
+	}
+	seen := make(map[string]bool, len(s.Fields))
+	for _, f := range s.Fields {
+		switch {
+		case f.Name == "":
+			return fmt.Errorf("docstore: %s/%s declares a field with no name", s.Namespace, s.Collection)
+		case reservedField[f.Name]:
+			return fmt.Errorf("docstore: %s/%s declares %q, which is reserved — %s and %s are always queryable and must not be declared",
+				s.Namespace, s.Collection, f.Name, FieldCreatedAt, FieldUpdatedAt)
+		case !fieldNameRe.MatchString(f.Name):
+			return fmt.Errorf("docstore: %s/%s declares field %q, which must start with a letter or _ and contain only letters, digits or _",
+				s.Namespace, s.Collection, f.Name)
+		case seen[f.Name]:
+			return fmt.Errorf("docstore: %s/%s declares field %q twice", s.Namespace, s.Collection, f.Name)
+		}
+		switch f.Type {
+		case FieldString, FieldNumber, FieldBool:
+		default:
+			return fmt.Errorf("docstore: %s/%s declares field %q with type %q; use %s, %s or %s",
+				s.Namespace, s.Collection, f.Name, f.Type, FieldString, FieldNumber, FieldBool)
+		}
+		seen[f.Name] = true
+	}
+	return nil
+}
+
+// field returns the declared spec for name, or false when the collection does
+// not declare it.
+func (s CollectionSchema) field(name string) (FieldSpec, bool) {
+	for _, f := range s.Fields {
+		if f.Name == name {
+			return f, true
+		}
+	}
+	return FieldSpec{}, false
+}
+
+// declaredNames lists the collection's queryable fields for an error message,
+// reserved names included, so a rejected query says what it could have asked
+// for instead of only what it could not.
+func (s CollectionSchema) declaredNames() string {
+	names := make([]string, 0, len(s.Fields)+2)
+	for _, f := range s.Fields {
+		names = append(names, f.Name)
+	}
+	sort.Strings(names)
+	names = append(names, FieldCreatedAt, FieldUpdatedAt)
+	return strings.Join(names, ", ")
+}
+
+// Compile validates q against the collection's declaration and returns it as
+// SQL. Every rejection names the collection, the offending part, and what is
+// available — the reader is an agent that must fix the query from the error
+// alone.
+func (q Query) Compile(schema CollectionSchema) (Compiled, error) {
+	if err := ValidateNamespace(q.Namespace); err != nil {
+		return Compiled{}, err
+	}
+	if err := ValidateCollection(q.Collection); err != nil {
+		return Compiled{}, err
+	}
+	if schema.Namespace != q.Namespace || schema.Collection != q.Collection {
+		return Compiled{}, fmt.Errorf("docstore: query targets %s/%s but was compiled against the declaration for %s/%s",
+			q.Namespace, q.Collection, schema.Namespace, schema.Collection)
+	}
+
+	where := []string{"namespace = ?", "collection = ?"}
+	args := []any{q.Namespace, q.Collection}
+
+	for _, f := range q.Filters {
+		op, ok := opSQL[f.Op]
+		if !ok {
+			return Compiled{}, fmt.Errorf("docstore: %s/%s filter on %q uses operator %q; use %s, %s, %s, %s or %s",
+				q.Namespace, q.Collection, f.Field, f.Op, OpEq, OpLt, OpLte, OpGt, OpGte)
+		}
+		expr, spec, err := q.fieldExpr(schema, f.Field, "filter")
+		if err != nil {
+			return Compiled{}, err
+		}
+		val, err := q.bindValue(f, spec)
+		if err != nil {
+			return Compiled{}, err
+		}
+		where = append(where, expr+" "+op+" ?")
+		args = append(args, val)
+	}
+
+	order := "id ASC"
+	if q.Sort != nil {
+		expr, _, err := q.fieldExpr(schema, q.Sort.Field, "sort")
+		if err != nil {
+			return Compiled{}, err
+		}
+		dir := "ASC"
+		if q.Sort.Desc {
+			dir = "DESC"
+		}
+		// The id tiebreaker is what makes the order total. Without it two
+		// documents sharing a sort value have no defined relative position, and
+		// a paginating reader can see one twice and the other never.
+		order = expr + " " + dir + ", id ASC"
+	}
+
+	limit := q.Limit
+	switch {
+	case limit == 0:
+		limit = DefaultLimit
+	case limit < 0:
+		return Compiled{}, fmt.Errorf("docstore: %s/%s limit is %d; a limit must be positive", q.Namespace, q.Collection, limit)
+	case limit > MaxLimit:
+		return Compiled{}, fmt.Errorf("docstore: %s/%s limit is %d, above the maximum of %d; page with a range filter on the sort field instead",
+			q.Namespace, q.Collection, limit, MaxLimit)
+	}
+
+	return Compiled{Where: strings.Join(where, " AND "), Args: args, Order: order, Limit: limit}, nil
+}
+
+// fieldExpr resolves a field reference to SQL. A reserved name is a real column;
+// anything else must be declared, and reads out of the body. use names what the
+// reference was for, so the error says whether the filter or the sort is wrong.
+func (q Query) fieldExpr(schema CollectionSchema, name, use string) (string, FieldSpec, error) {
+	if name == "" {
+		return "", FieldSpec{}, fmt.Errorf("docstore: %s/%s has a %s with no field name", q.Namespace, q.Collection, use)
+	}
+	if reservedField[name] {
+		return name, FieldSpec{Name: name, Type: FieldString}, nil
+	}
+	spec, ok := schema.field(name)
+	if !ok {
+		return "", FieldSpec{}, fmt.Errorf("docstore: %s/%s cannot %s on %q, which the collection does not declare (queryable: %s)",
+			q.Namespace, q.Collection, use, name, schema.declaredNames())
+	}
+	return "json_extract(body, '$." + name + "')", spec, nil
+}
+
+// bindValue converts a filter bound to what the statement should carry, and
+// refuses a bound whose type cannot compare with the field's. A number field
+// compared against "5" would silently match nothing — JSON numbers and text
+// never compare equal in SQLite — which is the worst outcome of the three.
+func (q Query) bindValue(f Filter, spec FieldSpec) (any, error) {
+	mismatch := func(want string) error {
+		return fmt.Errorf("docstore: %s/%s filter on %q needs a %s value, got %T (%v)",
+			q.Namespace, q.Collection, f.Field, want, f.Value, f.Value)
+	}
+	if f.Value == nil {
+		return nil, fmt.Errorf("docstore: %s/%s filter on %q has no value", q.Namespace, q.Collection, f.Field)
+	}
+	// A reserved field is a stored timestamp column, compared as text.
+	if reservedField[f.Field] {
+		switch v := f.Value.(type) {
+		case string:
+			return v, nil
+		case time.Time:
+			return v.UTC().Format(TimeFormat), nil
+		default:
+			return nil, mismatch("timestamp or string")
+		}
+	}
+	switch spec.Type {
+	case FieldString:
+		s, ok := f.Value.(string)
+		if !ok {
+			return nil, mismatch("string")
+		}
+		return s, nil
+	case FieldNumber:
+		// JSON decoding yields float64; Go callers may pass any numeric kind.
+		switch v := f.Value.(type) {
+		case float64:
+			return v, nil
+		case float32:
+			return float64(v), nil
+		case int:
+			return float64(v), nil
+		case int64:
+			return float64(v), nil
+		case json.Number:
+			n, err := v.Float64()
+			if err != nil {
+				return nil, mismatch("number")
+			}
+			return n, nil
+		default:
+			return nil, mismatch("number")
+		}
+	case FieldBool:
+		b, ok := f.Value.(bool)
+		if !ok {
+			return nil, mismatch("bool")
+		}
+		// json_extract yields 1/0 for JSON booleans.
+		if b {
+			return 1, nil
+		}
+		return 0, nil
+	}
+	return nil, fmt.Errorf("docstore: %s/%s filter on %q has undeclared type %q", q.Namespace, q.Collection, f.Field, spec.Type)
+}
+
+// TimeFormat is the stored timestamp encoding, matching the job queue's: it
+// keeps sub-second precision and sorts lexicographically, which is what lets
+// created_at and updated_at be ordering terms as plain text columns.
+const TimeFormat = time.RFC3339Nano
+
+// Target is the subject a change to this collection is published under, and the
+// key a subscription is matched on. Collection-grained rather than
+// document-grained: a live query's result set can change because a document it
+// does not currently contain started matching, so a subscriber has to hear about
+// the collection, not about the documents it happens to hold right now.
+func Target(namespace, collection string) string {
+	return namespace + "/" + collection
+}
+
+// Target is the subject changes to the query's collection arrive under.
+func (q Query) Target() string { return Target(q.Namespace, q.Collection) }
+
+// Address is one document's full name, and the subject a change to it is
+// published under. The log then reads as a history of documents; matching a
+// change to the subscriptions that care about it uses Target, carried alongside.
+func Address(namespace, collection, id string) string {
+	return Target(namespace, collection) + "/" + id
+}
+
+// ValidateBody accepts a document body: any JSON object. Objects only, because
+// a declared field is read with a JSON path and a bare array or scalar has no
+// place for one to live.
+func ValidateBody(body []byte) error {
+	if len(body) == 0 {
+		return fmt.Errorf("docstore: document body is required")
+	}
+	var probe any
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return fmt.Errorf("docstore: document body is not valid JSON: %w", err)
+	}
+	if _, ok := probe.(map[string]any); !ok {
+		return fmt.Errorf("docstore: document body must be a JSON object, got %T", probe)
+	}
+	return nil
+}

--- a/internal/docstore/docstore.go
+++ b/internal/docstore/docstore.go
@@ -157,6 +157,12 @@ type Compiled struct {
 	Limit int
 }
 
+// documentsTable is the table the compiled fragments belong to. Compile already
+// names that table's columns — body, id, namespace, collection — and the after
+// cursor additionally reads one row back out of it, so the name lives here
+// beside them rather than being threaded in from the store.
+const documentsTable = "documents"
+
 var (
 	// A namespace is `owner/name`: the owner segment is the isolation class a
 	// grant hands out (`ext`, `core`), the name segment identifies the holder.
@@ -330,7 +336,7 @@ func (q Query) Compile(schema CollectionSchema, anchor *Document) (Compiled, err
 	}
 
 	if q.After != "" || anchor != nil {
-		clause, cursorArgs, err := q.afterTuple(schema, sortExpr, desc, anchor)
+		clause, cursorArgs, err := q.afterTuple(sortExpr, desc, anchor)
 		if err != nil {
 			return Compiled{}, err
 		}
@@ -366,7 +372,7 @@ func (q Query) Compile(schema CollectionSchema, anchor *Document) (Compiled, err
 // may be queried, not what a document must contain — and NULL compares as
 // nothing at all, so it is branched on rather than bound. SQLite sorts NULL
 // first, so in ASC every non-NULL row is past a NULL anchor and in DESC none is.
-func (q Query) afterTuple(schema CollectionSchema, sortExpr string, desc bool, anchor *Document) (string, []any, error) {
+func (q Query) afterTuple(sortExpr string, desc bool, anchor *Document) (string, []any, error) {
 	if q.After == "" {
 		return "", nil, fmt.Errorf("docstore: %s/%s was compiled with a cursor document but no after id", q.Namespace, q.Collection)
 	}
@@ -390,62 +396,63 @@ func (q Query) afterTuple(schema CollectionSchema, sortExpr string, desc bool, a
 		return "id " + cmp + " ?", []any{q.After}, nil
 	}
 
-	value, err := q.anchorSortValue(schema, anchor)
+	isNull, err := q.anchorSortIsNull(anchor)
 	if err != nil {
 		return "", nil, err
 	}
-	if value == nil {
+	if isNull {
 		if desc {
 			return "(" + sortExpr + " IS NULL AND id < ?)", []any{q.After}, nil
 		}
 		return "(" + sortExpr + " IS NOT NULL OR id > ?)", []any{q.After}, nil
 	}
-	clause := "(" + sortExpr + " " + cmp + " ? OR (" + sortExpr + " = ? AND id " + cmp + " ?))"
+
+	// The anchor's sort value is read back out of the table rather than bound
+	// from Go. A declared field says what may be queried, not what a document
+	// must hold, so a "number" field may legitimately contain an array or an
+	// object — values that have no bindable Go equivalent, and that json_extract
+	// yields as JSON text. Reading the value through the same expression the
+	// ORDER BY uses makes the cursor compare exactly what the ordering compares,
+	// for every JSON shape, with no Go-side reconstruction to disagree with
+	// SQLite's own rendering or type ordering. The subquery is uncorrelated, so
+	// it is evaluated once per statement.
+	value := "(SELECT " + sortExpr + " FROM " + documentsTable + " WHERE namespace = ? AND collection = ? AND id = ?)"
+	valueArgs := []any{q.Namespace, q.Collection, q.After}
+
+	clause := "(" + sortExpr + " > " + value + " OR (" + sortExpr + " = " + value + " AND id > ?))"
 	if desc {
 		// Descending puts NULLs last, so they are past any non-NULL anchor.
-		clause = "(" + sortExpr + " IS NULL OR " + sortExpr + " < ? OR (" + sortExpr + " = ? AND id < ?))"
+		clause = "(" + sortExpr + " IS NULL OR " + sortExpr + " < " + value + " OR (" + sortExpr + " = " + value + " AND id < ?))"
 	}
-	return clause, []any{value, value, q.After}, nil
+	args := make([]any, 0, len(valueArgs)*2+1)
+	args = append(args, valueArgs...)
+	args = append(args, valueArgs...)
+	args = append(args, q.After)
+	return clause, args, nil
 }
 
-// anchorSortValue reads the cursor document's value for the sort field, bound
-// the way the compiled expression compares. It returns nil for a document that
-// does not carry the field, which is the NULL branch above.
-func (q Query) anchorSortValue(schema CollectionSchema, anchor *Document) (any, error) {
-	field := q.Sort.Field
-	switch field {
-	case FieldCreatedAt:
-		return anchor.CreatedAt.UTC().Format(TimeFormat), nil
-	case FieldUpdatedAt:
-		return anchor.UpdatedAt.UTC().Format(TimeFormat), nil
+// anchorSortIsNull reports whether the cursor document has no value for the sort
+// field — the field is absent, or is JSON null — which is what json_extract
+// yields as SQL NULL and what the branches above handle separately. It is a
+// structural question about the body, so it needs no type mapping.
+func (q Query) anchorSortIsNull(anchor *Document) (bool, error) {
+	if reservedField[q.Sort.Field] {
+		// Both are stamped columns and are never NULL.
+		return false, nil
 	}
 	var body map[string]json.RawMessage
 	if err := json.Unmarshal(anchor.Body, &body); err != nil {
-		return nil, fmt.Errorf("docstore: %s/%s cannot page after %q: its body is not a JSON object (%w)", q.Namespace, q.Collection, anchor.ID, err)
+		return false, fmt.Errorf("docstore: %s/%s cannot page after %q: its body is not a JSON object (%w)", q.Namespace, q.Collection, anchor.ID, err)
 	}
-	raw, ok := body[field]
+	raw, ok := body[q.Sort.Field]
 	if !ok {
-		return nil, nil
+		return true, nil
 	}
 	var value any
 	if err := json.Unmarshal(raw, &value); err != nil {
-		return nil, fmt.Errorf("docstore: %s/%s cannot page after %q: its %q is not valid JSON (%w)", q.Namespace, q.Collection, anchor.ID, field, err)
+		return false, fmt.Errorf("docstore: %s/%s cannot page after %q: its %q is not valid JSON (%w)", q.Namespace, q.Collection, anchor.ID, q.Sort.Field, err)
 	}
-	// Bound the way json_extract yields it, so the comparison and the ORDER BY
-	// agree: booleans come back as 1/0, everything else as itself. The stored
-	// value is bound whatever its type, even if it disagrees with the
-	// declaration — the ordering it participates in is the stored one.
-	switch v := value.(type) {
-	case nil:
-		return nil, nil
-	case bool:
-		if v {
-			return 1, nil
-		}
-		return 0, nil
-	default:
-		return v, nil
-	}
+	return value == nil, nil
 }
 
 // fieldExpr resolves a field reference to SQL. A reserved name is a real column;

--- a/internal/docstore/docstore_test.go
+++ b/internal/docstore/docstore_test.go
@@ -299,11 +299,14 @@ func TestTheAfterCursorComparesTheWholeOrderingTuple(t *testing.T) {
 		Sort:       &Sort{Field: "attempts"},
 		After:      "b",
 	}, anchor)
-	want := "(json_extract(body, '$.attempts') > ? OR (json_extract(body, '$.attempts') = ? AND id > ?))"
+	value := "(SELECT json_extract(body, '$.attempts') FROM documents WHERE namespace = ? AND collection = ? AND id = ?)"
+	want := "(json_extract(body, '$.attempts') > " + value + " OR (json_extract(body, '$.attempts') = " + value + " AND id > ?))"
 	if !strings.HasSuffix(c.Where, want) {
 		t.Fatalf("where = %q, want it to end with %q", c.Where, want)
 	}
-	if got := c.Args[len(c.Args)-3:]; !equalArgs(got, []any{float64(7), float64(7), "b"}) {
+	// The anchor's value is read back through the same expression the ORDER BY
+	// uses, so the only cursor arguments are the anchor's address.
+	if got := c.Args[len(c.Args)-7:]; !equalArgs(got, []any{"ext/approval-gate", "requests", "b", "ext/approval-gate", "requests", "b", "b"}) {
 		t.Fatalf("cursor args = %v", got)
 	}
 
@@ -315,7 +318,7 @@ func TestTheAfterCursorComparesTheWholeOrderingTuple(t *testing.T) {
 		Sort:       &Sort{Field: "attempts", Desc: true},
 		After:      "b",
 	}, anchor)
-	want = "(json_extract(body, '$.attempts') IS NULL OR json_extract(body, '$.attempts') < ? OR (json_extract(body, '$.attempts') = ? AND id < ?))"
+	want = "(json_extract(body, '$.attempts') IS NULL OR json_extract(body, '$.attempts') < " + value + " OR (json_extract(body, '$.attempts') = " + value + " AND id < ?))"
 	if !strings.HasSuffix(c.Where, want) {
 		t.Fatalf("descending where = %q, want it to end with %q", c.Where, want)
 	}

--- a/internal/docstore/docstore_test.go
+++ b/internal/docstore/docstore_test.go
@@ -18,9 +18,13 @@ func requestsSchema() CollectionSchema {
 	}
 }
 
-func mustCompile(t *testing.T, q Query) Compiled {
+func mustCompile(t *testing.T, q Query, anchor ...*Document) Compiled {
 	t.Helper()
-	c, err := q.Compile(requestsSchema())
+	var after *Document
+	if len(anchor) == 1 {
+		after = anchor[0]
+	}
+	c, err := q.Compile(requestsSchema(), after)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
@@ -44,7 +48,7 @@ func TestPendingRequestsNewestFirstCompiles(t *testing.T) {
 	if got := []any{"ext/approval-gate", "requests", "pending"}; !equalArgs(c.Args, got) {
 		t.Fatalf("args = %v, want %v", c.Args, got)
 	}
-	if c.Order != "created_at DESC, id ASC" {
+	if c.Order != "created_at DESC, id DESC" {
 		t.Fatalf("order = %q", c.Order)
 	}
 	if c.Limit != 20 {
@@ -52,8 +56,10 @@ func TestPendingRequestsNewestFirstCompiles(t *testing.T) {
 	}
 }
 
-// Every sort carries the document id as a tiebreaker, so documents sharing a
-// sort value have a defined relative position and paging cannot skip or repeat.
+// Every sort carries the document id as a tiebreaker, in the sort's own
+// direction, so documents sharing a sort value have a defined relative position
+// and the visible order is one uniformly directed tuple the cursor can compare
+// against.
 func TestEverySortIsMadeTotalByTheDocumentID(t *testing.T) {
 	c := mustCompile(t, Query{
 		Namespace:  "ext/approval-gate",
@@ -62,6 +68,14 @@ func TestEverySortIsMadeTotalByTheDocumentID(t *testing.T) {
 	})
 	if c.Order != "json_extract(body, '$.status') ASC, id ASC" {
 		t.Fatalf("order = %q", c.Order)
+	}
+	c = mustCompile(t, Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Sort:       &Sort{Field: "status", Desc: true},
+	})
+	if c.Order != "json_extract(body, '$.status') DESC, id DESC" {
+		t.Fatalf("descending order = %q", c.Order)
 	}
 	// And an unsorted query is still deterministic.
 	if c := mustCompile(t, Query{Namespace: "ext/approval-gate", Collection: "requests"}); c.Order != "id ASC" {
@@ -103,7 +117,7 @@ func TestQueryingAnUndeclaredFieldSaysWhatIsQueryable(t *testing.T) {
 		Namespace:  "ext/approval-gate",
 		Collection: "requests",
 		Filters:    []Filter{{Field: "priority", Op: OpEq, Value: "high"}},
-	}.Compile(requestsSchema())
+	}.Compile(requestsSchema(), nil)
 	if err == nil {
 		t.Fatal("filtering an undeclared field was accepted")
 	}
@@ -117,7 +131,7 @@ func TestQueryingAnUndeclaredFieldSaysWhatIsQueryable(t *testing.T) {
 		Namespace:  "ext/approval-gate",
 		Collection: "requests",
 		Sort:       &Sort{Field: "priority"},
-	}.Compile(requestsSchema())
+	}.Compile(requestsSchema(), nil)
 	if err == nil || !strings.Contains(err.Error(), "sort") {
 		t.Fatalf("sort on an undeclared field: %v", err)
 	}
@@ -141,7 +155,7 @@ func TestAFilterBoundMustMatchTheDeclaredType(t *testing.T) {
 				Namespace:  "ext/approval-gate",
 				Collection: "requests",
 				Filters:    []Filter{{Field: tc.field, Op: OpEq, Value: tc.value}},
-			}.Compile(requestsSchema())
+			}.Compile(requestsSchema(), nil)
 			if err == nil {
 				t.Fatal("mismatched bound was accepted")
 			}
@@ -181,11 +195,11 @@ func TestAQueryRoundTripsThroughJSON(t *testing.T) {
 	if err := json.Unmarshal([]byte(raw), &q); err != nil {
 		t.Fatal(err)
 	}
-	c, err := q.Compile(requestsSchema())
+	c, err := q.Compile(requestsSchema(), nil)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	if c.Limit != 5 || c.Order != "created_at DESC, id ASC" {
+	if c.Limit != 5 || c.Order != "created_at DESC, id DESC" {
 		t.Fatalf("compiled = %+v", c)
 	}
 	if got := c.Args[2]; got != float64(2) {
@@ -200,7 +214,7 @@ func TestLimitDefaultsAndItsCeilingNamesTheAsk(t *testing.T) {
 	if c := mustCompile(t, Query{Namespace: "ext/approval-gate", Collection: "requests"}); c.Limit != DefaultLimit {
 		t.Fatalf("default limit = %d, want %d", c.Limit, DefaultLimit)
 	}
-	_, err := Query{Namespace: "ext/approval-gate", Collection: "requests", Limit: MaxLimit + 1}.Compile(requestsSchema())
+	_, err := Query{Namespace: "ext/approval-gate", Collection: "requests", Limit: MaxLimit + 1}.Compile(requestsSchema(), nil)
 	if err == nil {
 		t.Fatal("a limit above the maximum was accepted")
 	}
@@ -256,7 +270,7 @@ func TestBodyMustBeAJSONObject(t *testing.T) {
 // and refusing it is what keeps a caller from reading one collection under
 // another's rules.
 func TestAQueryWillNotCompileAgainstAnotherCollectionsDeclaration(t *testing.T) {
-	_, err := Query{Namespace: "ext/other", Collection: "requests"}.Compile(requestsSchema())
+	_, err := Query{Namespace: "ext/other", Collection: "requests"}.Compile(requestsSchema(), nil)
 	if err == nil {
 		t.Fatal("mismatched declaration was accepted")
 	}
@@ -272,4 +286,91 @@ func equalArgs(got, want []any) bool {
 		}
 	}
 	return true
+}
+
+// The after cursor compiles to a comparison against the whole ordering tuple.
+// The second branch — equal sort value, greater id — is the one a filter cannot
+// express, and is why After is part of the query rather than caller-written.
+func TestTheAfterCursorComparesTheWholeOrderingTuple(t *testing.T) {
+	anchor := &Document{ID: "b", Body: []byte(`{"attempts":7}`)}
+	c := mustCompile(t, Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Sort:       &Sort{Field: "attempts"},
+		After:      "b",
+	}, anchor)
+	want := "(json_extract(body, '$.attempts') > ? OR (json_extract(body, '$.attempts') = ? AND id > ?))"
+	if !strings.HasSuffix(c.Where, want) {
+		t.Fatalf("where = %q, want it to end with %q", c.Where, want)
+	}
+	if got := c.Args[len(c.Args)-3:]; !equalArgs(got, []any{float64(7), float64(7), "b"}) {
+		t.Fatalf("cursor args = %v", got)
+	}
+
+	// Descending flips both comparisons, and admits the NULLs the descending
+	// order puts last.
+	c = mustCompile(t, Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Sort:       &Sort{Field: "attempts", Desc: true},
+		After:      "b",
+	}, anchor)
+	want = "(json_extract(body, '$.attempts') IS NULL OR json_extract(body, '$.attempts') < ? OR (json_extract(body, '$.attempts') = ? AND id < ?))"
+	if !strings.HasSuffix(c.Where, want) {
+		t.Fatalf("descending where = %q, want it to end with %q", c.Where, want)
+	}
+}
+
+// An unsorted query's whole order is the id, so its cursor is that one column.
+func TestTheAfterCursorOfAnUnsortedQueryIsTheID(t *testing.T) {
+	c := mustCompile(t, Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		After:      "b",
+	}, &Document{ID: "b", Body: []byte(`{}`)})
+	if !strings.HasSuffix(c.Where, "id > ?") {
+		t.Fatalf("where = %q", c.Where)
+	}
+}
+
+// A cursor whose document is gone fails loudly. An empty page would read as
+// "end of results", which is a silent truncation of the caller's walk.
+func TestAnAfterCursorWithNoDocumentIsAnError(t *testing.T) {
+	_, err := Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Sort:       &Sort{Field: "attempts"},
+		After:      "vanished",
+	}.Compile(requestsSchema(), nil)
+	if err == nil {
+		t.Fatal("a cursor to a missing document was accepted")
+	}
+	for _, want := range []string{"vanished", "no longer exists"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not mention %q", err, want)
+		}
+	}
+	// And an anchor that is not the document the cursor named is a caller bug,
+	// not a page: it would silently return the wrong slice.
+	_, err = Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		After:      "b",
+	}.Compile(requestsSchema(), &Document{ID: "c", Body: []byte(`{}`)})
+	if err == nil || !strings.Contains(err.Error(), "\"c\"") {
+		t.Fatalf("mismatched anchor: %v", err)
+	}
+}
+
+// The over-limit error points at the cursor, because the range filter it used
+// to suggest is exactly the thing that breaks on ties.
+func TestTheLimitCeilingPointsAtTheCursor(t *testing.T) {
+	_, err := Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Limit:      MaxLimit + 1,
+	}.Compile(requestsSchema(), nil)
+	if err == nil || !strings.Contains(err.Error(), "after cursor") {
+		t.Fatalf("over-limit error = %v", err)
+	}
 }

--- a/internal/docstore/docstore_test.go
+++ b/internal/docstore/docstore_test.go
@@ -1,0 +1,275 @@
+package docstore
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func requestsSchema() CollectionSchema {
+	return CollectionSchema{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Fields: []FieldSpec{
+			{Name: "status", Type: FieldString},
+			{Name: "attempts", Type: FieldNumber},
+			{Name: "urgent", Type: FieldBool},
+		},
+	}
+}
+
+func mustCompile(t *testing.T, q Query) Compiled {
+	t.Helper()
+	c, err := q.Compile(requestsSchema())
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return c
+}
+
+// The proof composition's panel query — pending requests, newest first —
+// compiles to a bounded scan within one collection.
+func TestPendingRequestsNewestFirstCompiles(t *testing.T) {
+	c := mustCompile(t, Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Filters:    []Filter{{Field: "status", Op: OpEq, Value: "pending"}},
+		Sort:       &Sort{Field: FieldCreatedAt, Desc: true},
+		Limit:      20,
+	})
+	want := "namespace = ? AND collection = ? AND json_extract(body, '$.status') = ?"
+	if c.Where != want {
+		t.Fatalf("where = %q, want %q", c.Where, want)
+	}
+	if got := []any{"ext/approval-gate", "requests", "pending"}; !equalArgs(c.Args, got) {
+		t.Fatalf("args = %v, want %v", c.Args, got)
+	}
+	if c.Order != "created_at DESC, id ASC" {
+		t.Fatalf("order = %q", c.Order)
+	}
+	if c.Limit != 20 {
+		t.Fatalf("limit = %d", c.Limit)
+	}
+}
+
+// Every sort carries the document id as a tiebreaker, so documents sharing a
+// sort value have a defined relative position and paging cannot skip or repeat.
+func TestEverySortIsMadeTotalByTheDocumentID(t *testing.T) {
+	c := mustCompile(t, Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Sort:       &Sort{Field: "status"},
+	})
+	if c.Order != "json_extract(body, '$.status') ASC, id ASC" {
+		t.Fatalf("order = %q", c.Order)
+	}
+	// And an unsorted query is still deterministic.
+	if c := mustCompile(t, Query{Namespace: "ext/approval-gate", Collection: "requests"}); c.Order != "id ASC" {
+		t.Fatalf("default order = %q", c.Order)
+	}
+}
+
+// created_at and updated_at are real columns, always queryable, never declared —
+// "newest first" and "changed since" need no schema.
+func TestReservedTimestampsAreQueryableWithoutDeclaration(t *testing.T) {
+	c := mustCompile(t, Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Filters:    []Filter{{Field: FieldUpdatedAt, Op: OpGt, Value: "2026-08-03T00:00:00Z"}},
+	})
+	if !strings.HasSuffix(c.Where, "updated_at > ?") {
+		t.Fatalf("where = %q, want a bare column comparison", c.Where)
+	}
+}
+
+// Declaring a field that shadows a reserved column is refused: the column would
+// win every query, so the declaration would be a lie.
+func TestACollectionCannotDeclareAReservedName(t *testing.T) {
+	s := requestsSchema()
+	s.Fields = append(s.Fields, FieldSpec{Name: FieldCreatedAt, Type: FieldString})
+	err := s.Validate()
+	if err == nil {
+		t.Fatal("declaring created_at was accepted")
+	}
+	if !strings.Contains(err.Error(), "reserved") {
+		t.Fatalf("error does not explain the collision: %v", err)
+	}
+}
+
+// An undeclared field is refused, and the refusal lists what the collection does
+// offer — the reader has to be able to fix the query from the error alone.
+func TestQueryingAnUndeclaredFieldSaysWhatIsQueryable(t *testing.T) {
+	_, err := Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Filters:    []Filter{{Field: "priority", Op: OpEq, Value: "high"}},
+	}.Compile(requestsSchema())
+	if err == nil {
+		t.Fatal("filtering an undeclared field was accepted")
+	}
+	for _, want := range []string{"priority", "attempts", "status", "urgent", FieldCreatedAt, FieldUpdatedAt} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not mention %q", err, want)
+		}
+	}
+	// The same rule applies to sorting, and the error says which one was wrong.
+	_, err = Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Sort:       &Sort{Field: "priority"},
+	}.Compile(requestsSchema())
+	if err == nil || !strings.Contains(err.Error(), "sort") {
+		t.Fatalf("sort on an undeclared field: %v", err)
+	}
+}
+
+// A bound whose type cannot compare with the field's is refused rather than
+// silently matching nothing, which is what SQLite would do with a number
+// compared against text.
+func TestAFilterBoundMustMatchTheDeclaredType(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		field string
+		value any
+	}{
+		{"number field, string bound", "attempts", "5"},
+		{"string field, number bound", "status", 5},
+		{"bool field, string bound", "urgent", "true"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Query{
+				Namespace:  "ext/approval-gate",
+				Collection: "requests",
+				Filters:    []Filter{{Field: tc.field, Op: OpEq, Value: tc.value}},
+			}.Compile(requestsSchema())
+			if err == nil {
+				t.Fatal("mismatched bound was accepted")
+			}
+			if !strings.Contains(err.Error(), tc.field) {
+				t.Fatalf("error does not name the field: %v", err)
+			}
+		})
+	}
+}
+
+// Numbers arrive as float64 over the wire and as int from Go callers; booleans
+// bind as the 1/0 json_extract yields.
+func TestBoundsBindTheWayJSONExtractCompares(t *testing.T) {
+	c := mustCompile(t, Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Filters: []Filter{
+			{Field: "attempts", Op: OpGte, Value: 3},
+			{Field: "urgent", Op: OpEq, Value: true},
+		},
+	})
+	if got := c.Args[2]; got != float64(3) {
+		t.Fatalf("int bound = %#v, want float64(3)", got)
+	}
+	if got := c.Args[3]; got != 1 {
+		t.Fatalf("true bound = %#v, want 1", got)
+	}
+}
+
+// A query decoded from JSON is the same query — this is the representation the
+// sidecar, the UI, and the CLI all carry.
+func TestAQueryRoundTripsThroughJSON(t *testing.T) {
+	raw := `{"namespace":"ext/approval-gate","collection":"requests",
+	         "filters":[{"field":"attempts","op":"gte","value":2}],
+	         "sort":{"field":"created_at","desc":true},"limit":5}`
+	var q Query
+	if err := json.Unmarshal([]byte(raw), &q); err != nil {
+		t.Fatal(err)
+	}
+	c, err := q.Compile(requestsSchema())
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if c.Limit != 5 || c.Order != "created_at DESC, id ASC" {
+		t.Fatalf("compiled = %+v", c)
+	}
+	if got := c.Args[2]; got != float64(2) {
+		t.Fatalf("json number bound = %#v", got)
+	}
+}
+
+// An unset limit is the default, not "unbounded" — a query with no ceiling is a
+// wire message with no ceiling. Asking past the maximum names both numbers and
+// the way out.
+func TestLimitDefaultsAndItsCeilingNamesTheAsk(t *testing.T) {
+	if c := mustCompile(t, Query{Namespace: "ext/approval-gate", Collection: "requests"}); c.Limit != DefaultLimit {
+		t.Fatalf("default limit = %d, want %d", c.Limit, DefaultLimit)
+	}
+	_, err := Query{Namespace: "ext/approval-gate", Collection: "requests", Limit: MaxLimit + 1}.Compile(requestsSchema())
+	if err == nil {
+		t.Fatal("a limit above the maximum was accepted")
+	}
+	for _, want := range []string{"1001", "1000"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not carry %s", err, want)
+		}
+	}
+}
+
+// The namespace is an opaque owner/name string. The store validates its shape,
+// not which owners exist — who may write under an owner is enforced where the
+// namespace is granted.
+func TestNamespaceShapeIsTwoParts(t *testing.T) {
+	for _, ok := range []string{"ext/approval-gate", "core/tickets", "ext/a"} {
+		if err := ValidateNamespace(ok); err != nil {
+			t.Fatalf("%q rejected: %v", ok, err)
+		}
+	}
+	for _, bad := range []string{"", "approval-gate", "ext/", "/name", "Ext/Name", "ext/a/b", "ext name/x"} {
+		if err := ValidateNamespace(bad); err == nil {
+			t.Fatalf("%q accepted", bad)
+		}
+	}
+}
+
+// A field name is a plain identifier, which is also what makes the compiled JSON
+// path safe: there is no quoting to get wrong because there is nothing to quote.
+func TestFieldNamesAreIdentifiersSoThePathNeedsNoQuoting(t *testing.T) {
+	for _, bad := range []string{"has space", "with'quote", "a.b", "$x", ""} {
+		s := requestsSchema()
+		s.Fields = []FieldSpec{{Name: bad, Type: FieldString}}
+		if err := s.Validate(); err == nil {
+			t.Fatalf("field name %q accepted", bad)
+		}
+	}
+}
+
+// A body is any JSON object. Objects only: a declared field is read with a JSON
+// path, and an array or scalar has nowhere for one to live.
+func TestBodyMustBeAJSONObject(t *testing.T) {
+	if err := ValidateBody([]byte(`{"status":"pending"}`)); err != nil {
+		t.Fatalf("object rejected: %v", err)
+	}
+	for _, bad := range []string{``, `[1,2]`, `"text"`, `7`, `{oops}`} {
+		if err := ValidateBody([]byte(bad)); err == nil {
+			t.Fatalf("body %q accepted", bad)
+		}
+	}
+}
+
+// A query compiled against another collection's declaration is a wiring mistake,
+// and refusing it is what keeps a caller from reading one collection under
+// another's rules.
+func TestAQueryWillNotCompileAgainstAnotherCollectionsDeclaration(t *testing.T) {
+	_, err := Query{Namespace: "ext/other", Collection: "requests"}.Compile(requestsSchema())
+	if err == nil {
+		t.Fatal("mismatched declaration was accepted")
+	}
+}
+
+func equalArgs(got, want []any) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -71,6 +71,14 @@ const (
 	CmdTicketAttach                          = "ticket_attach"
 	CmdTicketCreate                          = "ticket_create"
 	CmdTicketComment                         = "ticket_comment"
+	CmdDocDefine                             = "doc_define"
+	CmdDocUndefine                           = "doc_undefine"
+	CmdDocCollections                        = "doc_collections"
+	CmdDocPut                                = "doc_put"
+	CmdDocGet                                = "doc_get"
+	CmdDocDelete                             = "doc_delete"
+	CmdDocQuery                              = "doc_query"
+	CmdDocSubscribe                          = "doc_subscribe"
 	CmdGetTicket                             = "get_ticket"
 	CmdTicketChangeStatus                    = "ticket_change_status"
 	CmdTicketAddComment                      = "ticket_add_comment"
@@ -588,6 +596,62 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdTicketAttach:
 		var msg TicketAttachMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdDocDefine:
+		var msg DocDefineMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdDocUndefine:
+		var msg DocUndefineMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdDocCollections:
+		var msg DocCollectionsMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdDocPut:
+		var msg DocPutMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdDocGet:
+		var msg DocGetMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdDocDelete:
+		var msg DocDeleteMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdDocQuery:
+		var msg DocQueryMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdDocSubscribe:
+		var msg DocSubscribeMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "205"
+const ProtocolVersion = "206"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1050,6 +1050,216 @@ const DispatchWorkStateInProgress DispatchWorkState = "in_progress"
 const DispatchWorkStateNeedsInput DispatchWorkState = "needs_input"
 const DispatchWorkStateReadyForReview DispatchWorkState = "ready_for_review"
 
+type DocCollectionsMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+}
+
+type DocCollectionsResult struct {
+	// Collections corresponds to the JSON schema field "collections".
+	Collections []DocumentCollectionSchema `json:"collections"`
+}
+
+type DocDefineMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Schema corresponds to the JSON schema field "schema".
+	Schema DocumentCollectionSchema `json:"schema"`
+}
+
+type DocDefineResult struct {
+	// Collection corresponds to the JSON schema field "collection".
+	Collection string `json:"collection"`
+
+	// Namespace corresponds to the JSON schema field "namespace".
+	Namespace string `json:"namespace"`
+}
+
+type DocDeleteMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Collection corresponds to the JSON schema field "collection".
+	Collection string `json:"collection"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
+
+	// Namespace corresponds to the JSON schema field "namespace".
+	Namespace string `json:"namespace"`
+}
+
+type DocDeleteResult struct {
+	// Collection corresponds to the JSON schema field "collection".
+	Collection string `json:"collection"`
+
+	// Existed corresponds to the JSON schema field "existed".
+	Existed bool `json:"existed"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
+
+	// Namespace corresponds to the JSON schema field "namespace".
+	Namespace string `json:"namespace"`
+}
+
+type DocGetMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Collection corresponds to the JSON schema field "collection".
+	Collection string `json:"collection"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
+
+	// Namespace corresponds to the JSON schema field "namespace".
+	Namespace string `json:"namespace"`
+}
+
+type DocGetResult struct {
+	// Document corresponds to the JSON schema field "document".
+	Document *StoredDocument `json:"document,omitempty,omitzero"`
+
+	// Found corresponds to the JSON schema field "found".
+	Found bool `json:"found"`
+}
+
+type DocPutMessage struct {
+	// Body corresponds to the JSON schema field "body".
+	Body string `json:"body"`
+
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Collection corresponds to the JSON schema field "collection".
+	Collection string `json:"collection"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
+
+	// Namespace corresponds to the JSON schema field "namespace".
+	Namespace string `json:"namespace"`
+}
+
+type DocPutResult struct {
+	// Collection corresponds to the JSON schema field "collection".
+	Collection string `json:"collection"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
+
+	// Namespace corresponds to the JSON schema field "namespace".
+	Namespace string `json:"namespace"`
+}
+
+type DocQueryMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Query corresponds to the JSON schema field "query".
+	Query DocumentQuery `json:"query"`
+}
+
+type DocQueryResult struct {
+	// Documents corresponds to the JSON schema field "documents".
+	Documents []StoredDocument `json:"documents"`
+}
+
+type DocSubscribeMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Query corresponds to the JSON schema field "query".
+	Query DocumentQuery `json:"query"`
+}
+
+type DocSubscribeResult struct {
+	// Documents corresponds to the JSON schema field "documents".
+	Documents []StoredDocument `json:"documents"`
+
+	// Revision corresponds to the JSON schema field "revision".
+	Revision int `json:"revision"`
+}
+
+type DocUndefineMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Collection corresponds to the JSON schema field "collection".
+	Collection string `json:"collection"`
+
+	// Namespace corresponds to the JSON schema field "namespace".
+	Namespace string `json:"namespace"`
+}
+
+type DocUndefineResult struct {
+	// Collection corresponds to the JSON schema field "collection".
+	Collection string `json:"collection"`
+
+	// DocumentsRemoved corresponds to the JSON schema field "documents_removed".
+	DocumentsRemoved int `json:"documents_removed"`
+
+	// Namespace corresponds to the JSON schema field "namespace".
+	Namespace string `json:"namespace"`
+}
+
+type DocumentCollectionSchema struct {
+	// Collection corresponds to the JSON schema field "collection".
+	Collection string `json:"collection"`
+
+	// Fields corresponds to the JSON schema field "fields".
+	Fields []DocumentFieldSpec `json:"fields"`
+
+	// Namespace corresponds to the JSON schema field "namespace".
+	Namespace string `json:"namespace"`
+}
+
+type DocumentFieldSpec struct {
+	// Name corresponds to the JSON schema field "name".
+	Name string `json:"name"`
+
+	// Type corresponds to the JSON schema field "type".
+	Type string `json:"type"`
+}
+
+type DocumentFilter struct {
+	// Field corresponds to the JSON schema field "field".
+	Field string `json:"field"`
+
+	// Op corresponds to the JSON schema field "op".
+	Op string `json:"op"`
+
+	// ValueJson corresponds to the JSON schema field "value_json".
+	ValueJson string `json:"value_json"`
+}
+
+type DocumentQuery struct {
+	// Collection corresponds to the JSON schema field "collection".
+	Collection string `json:"collection"`
+
+	// Filters corresponds to the JSON schema field "filters".
+	Filters []DocumentFilter `json:"filters,omitempty,omitzero"`
+
+	// Limit corresponds to the JSON schema field "limit".
+	Limit *int `json:"limit,omitempty,omitzero"`
+
+	// Namespace corresponds to the JSON schema field "namespace".
+	Namespace string `json:"namespace"`
+
+	// Sort corresponds to the JSON schema field "sort".
+	Sort *DocumentSort `json:"sort,omitempty,omitzero"`
+}
+
+type DocumentSort struct {
+	// Desc corresponds to the JSON schema field "desc".
+	Desc *bool `json:"desc,omitempty,omitzero"`
+
+	// Field corresponds to the JSON schema field "field".
+	Field string `json:"field"`
+}
+
 type EndpointActionResultMessage struct {
 	// Action corresponds to the JSON schema field "action".
 	Action string `json:"action"`
@@ -3903,6 +4113,31 @@ type Response struct {
 	// "delegation_operation".
 	DelegationOperation *DelegationOperation `json:"delegation_operation,omitempty,omitzero"`
 
+	// DocCollectionsResult corresponds to the JSON schema field
+	// "doc_collections_result".
+	DocCollectionsResult *DocCollectionsResult `json:"doc_collections_result,omitempty,omitzero"`
+
+	// DocDefineResult corresponds to the JSON schema field "doc_define_result".
+	DocDefineResult *DocDefineResult `json:"doc_define_result,omitempty,omitzero"`
+
+	// DocDeleteResult corresponds to the JSON schema field "doc_delete_result".
+	DocDeleteResult *DocDeleteResult `json:"doc_delete_result,omitempty,omitzero"`
+
+	// DocGetResult corresponds to the JSON schema field "doc_get_result".
+	DocGetResult *DocGetResult `json:"doc_get_result,omitempty,omitzero"`
+
+	// DocPutResult corresponds to the JSON schema field "doc_put_result".
+	DocPutResult *DocPutResult `json:"doc_put_result,omitempty,omitzero"`
+
+	// DocQueryResult corresponds to the JSON schema field "doc_query_result".
+	DocQueryResult *DocQueryResult `json:"doc_query_result,omitempty,omitzero"`
+
+	// DocSubscribeResult corresponds to the JSON schema field "doc_subscribe_result".
+	DocSubscribeResult *DocSubscribeResult `json:"doc_subscribe_result,omitempty,omitzero"`
+
+	// DocUndefineResult corresponds to the JSON schema field "doc_undefine_result".
+	DocUndefineResult *DocUndefineResult `json:"doc_undefine_result,omitempty,omitzero"`
+
 	// Error corresponds to the JSON schema field "error".
 	Error *string `json:"error,omitempty,omitzero"`
 
@@ -4783,6 +5018,20 @@ type StopMessage struct {
 
 	// TranscriptPath corresponds to the JSON schema field "transcript_path".
 	TranscriptPath string `json:"transcript_path"`
+}
+
+type StoredDocument struct {
+	// Body corresponds to the JSON schema field "body".
+	Body string `json:"body"`
+
+	// CreatedAt corresponds to the JSON schema field "created_at".
+	CreatedAt string `json:"created_at"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
+
+	// UpdatedAt corresponds to the JSON schema field "updated_at".
+	UpdatedAt string `json:"updated_at"`
 }
 
 type SubscribeGitStatusMessage struct {

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1236,6 +1236,9 @@ type DocumentFilter struct {
 }
 
 type DocumentQuery struct {
+	// After corresponds to the JSON schema field "after".
+	After *string `json:"after,omitempty,omitzero"`
+
 	// Collection corresponds to the JSON schema field "collection".
 	Collection string `json:"collection"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -3391,6 +3391,172 @@ model BrowserControlRequestMessage {
 }
 
 // ============================================================================
+// Document store
+// ============================================================================
+//
+// The document store's IPC surface. The query's STRUCTURE is typed here and is
+// as rigid as the rest of the protocol; only a filter's bound travels as JSON
+// text, because it is the one genuinely polymorphic leaf (a string, a number, or
+// a boolean, decided by the field's declared type). Typing it as a union here
+// would still not express the rule that matters — a bound must match the type
+// the collection declared for its field — which is checked in internal/docstore
+// where the declaration lives.
+
+// One queryable field of a collection. `type` is string, number or bool.
+model DocumentFieldSpec {
+  "name": string;
+  "type": string;
+}
+
+// A collection's declaration: which fields may be filtered and sorted on. It is
+// a query contract, not a storage schema — document bodies are arbitrary JSON
+// and an undeclared field is stored and read back untouched.
+model DocumentCollectionSchema {
+  "namespace": string;
+  "collection": string;
+  "fields": DocumentFieldSpec[];
+}
+
+// One comparison. `op` is eq, lt, lte, gt or gte. `value_json` is the bound
+// encoded as JSON ("\"pending\"", "5", "true").
+model DocumentFilter {
+  "field": string;
+  "op": string;
+  "value_json": string;
+}
+
+model DocumentSort {
+  "field": string;
+  "desc"?: boolean;
+}
+
+// A query. `created_at` and `updated_at` are always available to filter and sort
+// on; every other field must be declared. An absent limit means the store's
+// default rather than "unbounded".
+model DocumentQuery {
+  "namespace": string;
+  "collection": string;
+  "filters"?: DocumentFilter[];
+  "sort"?: DocumentSort;
+  "limit"?: int32;
+}
+
+// One stored document. `body` is the document's JSON as written, byte for byte.
+model StoredDocument {
+  "id": string;
+  "body": string;
+  "created_at": string;
+  "updated_at": string;
+}
+
+// Declare a collection, replacing any previous declaration. Redeclaring is how a
+// collection gains a queryable field; documents are never rewritten.
+model DocDefineMessage {
+  "cmd": "doc_define";
+  "schema": DocumentCollectionSchema;
+}
+
+model DocDefineResult {
+  "namespace": string;
+  "collection": string;
+}
+
+// Remove a collection's declaration and every document under it.
+model DocUndefineMessage {
+  "cmd": "doc_undefine";
+  "namespace": string;
+  "collection": string;
+}
+
+model DocUndefineResult {
+  "namespace": string;
+  "collection": string;
+  "documents_removed": int32;
+}
+
+// Every declared collection — the operator's index of what exists.
+model DocCollectionsMessage {
+  "cmd": "doc_collections";
+}
+
+model DocCollectionsResult {
+  "collections": DocumentCollectionSchema[];
+}
+
+// Write a document, creating or fully replacing it. `body` is JSON object text.
+model DocPutMessage {
+  "cmd": "doc_put";
+  "namespace": string;
+  "collection": string;
+  "id": string;
+  "body": string;
+}
+
+model DocPutResult {
+  "namespace": string;
+  "collection": string;
+  "id": string;
+}
+
+model DocGetMessage {
+  "cmd": "doc_get";
+  "namespace": string;
+  "collection": string;
+  "id": string;
+}
+
+// `found` separates an absent document from a failed read; `document` is present
+// only when found.
+model DocGetResult {
+  "found": boolean;
+  "document"?: StoredDocument;
+}
+
+model DocDeleteMessage {
+  "cmd": "doc_delete";
+  "namespace": string;
+  "collection": string;
+  "id": string;
+}
+
+// `existed` is false when the delete removed nothing, so a caller does not
+// report a change that did not happen.
+model DocDeleteResult {
+  "namespace": string;
+  "collection": string;
+  "id": string;
+  "existed": boolean;
+}
+
+model DocQueryMessage {
+  "cmd": "doc_query";
+  "query": DocumentQuery;
+}
+
+model DocQueryResult {
+  "documents": StoredDocument[];
+}
+
+// Subscribe to a live query. Unlike every other command here, this one keeps the
+// connection open: the daemon writes a DocSubscribeResult immediately carrying
+// the current result set, then writes a fresh one every time a write to the
+// collection changes what the query returns. The subscription ends when the
+// caller closes the connection.
+model DocSubscribeMessage {
+  "cmd": "doc_subscribe";
+  "query": DocumentQuery;
+}
+
+// One delivery of a live query's results. `documents` is always the CURRENT full
+// result set, never a patch — a subscriber renders what it is given and never
+// reconstructs state from a sequence of deliveries. `revision` counts deliveries
+// on this subscription, starting at 1 for the initial one.
+model DocSubscribeResult {
+  "revision": int32;
+  "documents": StoredDocument[];
+}
+
+// ============================================================================
 // Response Types
 // ============================================================================
 
@@ -3428,6 +3594,14 @@ model Response {
   session_instructions_result?: SessionInstructionsResult;
   session_transcript_result?: SessionTranscriptResult;
   state_explain_result?: StateExplainResult;
+  doc_define_result?: DocDefineResult;
+  doc_undefine_result?: DocUndefineResult;
+  doc_collections_result?: DocCollectionsResult;
+  doc_put_result?: DocPutResult;
+  doc_get_result?: DocGetResult;
+  doc_delete_result?: DocDeleteResult;
+  doc_query_result?: DocQueryResult;
+  doc_subscribe_result?: DocSubscribeResult;
 }
 
 // One recorded state observation and its fate. Outcome separates the ways an

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -3439,6 +3439,11 @@ model DocumentQuery {
   "filters"?: DocumentFilter[];
   "sort"?: DocumentSort;
   "limit"?: int32;
+  // The id of the last document of the previous page. The visible order is
+  // (sort field, id), and a filter can only constrain one of those, so a tie on
+  // the sort field makes range-filter paging skip or repeat. This compares
+  // against the whole tuple.
+  "after"?: string;
 }
 
 // One stored document. `body` is the document's JSON as written, byte for byte.

--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -1,0 +1,255 @@
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/victorarias/attn/internal/docstore"
+)
+
+// SQLite persistence for the document store (migration 88). This file is only
+// persistence: what a query means, and the SQL a validated one compiles to, live
+// in internal/docstore, which reaches nothing — the same split internal/bus and
+// bus.go use.
+//
+// Two tables. `documents` holds the records; `document_collections` holds each
+// collection's declaration, durable so that every surface — the daemon, the CLI,
+// and later an extension's manifest apply — agrees on what a collection allows
+// without one of them being the live owner of that knowledge.
+//
+// Isolation is structural rather than a check: namespace and collection are part
+// of the primary key and of every statement below, so there is no read or write
+// that is not already scoped to one namespace.
+
+// documentColumns is the read projection; body is returned byte for byte.
+const documentColumns = `id, body, created_at, updated_at`
+
+// DefineDocumentCollection records a collection's declaration, replacing any
+// previous one. Redeclaring is how a collection gains a queryable field, and it
+// is deliberately not a migration: documents are untouched, an added field
+// becomes queryable for documents that happen to carry it, and a removed one
+// stops being queryable without anything being rewritten.
+func (s *Store) DefineDocumentCollection(schema docstore.CollectionSchema, now time.Time) error {
+	if s.db == nil {
+		return fmt.Errorf("store: no database")
+	}
+	if err := schema.Validate(); err != nil {
+		return err
+	}
+	fields, err := json.Marshal(schema.Fields)
+	if err != nil {
+		return fmt.Errorf("store: encoding fields for %s/%s: %w", schema.Namespace, schema.Collection, err)
+	}
+	_, err = s.db.Exec(
+		`INSERT INTO document_collections (namespace, collection, fields_json, updated_at)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(namespace, collection) DO UPDATE SET
+		   fields_json=excluded.fields_json,
+		   updated_at=excluded.updated_at`,
+		schema.Namespace, schema.Collection, string(fields), now.UTC().Format(docstore.TimeFormat))
+	if err != nil {
+		return fmt.Errorf("store: defining %s/%s: %w", schema.Namespace, schema.Collection, err)
+	}
+	return nil
+}
+
+// DocumentCollection returns a collection's declaration. The bool is false with
+// a nil error when the collection was never declared — a caller must tell "no
+// such collection" apart from a read failure, because the first is what every
+// query against an undeclared collection has to report.
+func (s *Store) DocumentCollection(namespace, collection string) (*docstore.CollectionSchema, bool, error) {
+	if s.db == nil {
+		return nil, false, fmt.Errorf("store: no database")
+	}
+	row := s.db.QueryRow(
+		`SELECT fields_json FROM document_collections WHERE namespace = ? AND collection = ?`,
+		namespace, collection)
+	var fields string
+	switch err := row.Scan(&fields); {
+	case err == sql.ErrNoRows:
+		return nil, false, nil
+	case err != nil:
+		return nil, false, fmt.Errorf("store: reading %s/%s: %w", namespace, collection, err)
+	}
+	schema := docstore.CollectionSchema{Namespace: namespace, Collection: collection}
+	if err := json.Unmarshal([]byte(fields), &schema.Fields); err != nil {
+		return nil, false, fmt.Errorf("store: decoding fields for %s/%s: %w", namespace, collection, err)
+	}
+	return &schema, true, nil
+}
+
+// ListDocumentCollections returns every declaration, namespace-major. It is the
+// operator's index of what exists.
+func (s *Store) ListDocumentCollections() ([]docstore.CollectionSchema, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("store: no database")
+	}
+	rows, err := s.db.Query(
+		`SELECT namespace, collection, fields_json FROM document_collections ORDER BY namespace, collection`)
+	if err != nil {
+		return nil, fmt.Errorf("store: listing document collections: %w", err)
+	}
+	defer rows.Close()
+	var out []docstore.CollectionSchema
+	for rows.Next() {
+		var schema docstore.CollectionSchema
+		var fields string
+		if err := rows.Scan(&schema.Namespace, &schema.Collection, &fields); err != nil {
+			return nil, fmt.Errorf("store: scanning document collection: %w", err)
+		}
+		if err := json.Unmarshal([]byte(fields), &schema.Fields); err != nil {
+			return nil, fmt.Errorf("store: decoding fields for %s/%s: %w", schema.Namespace, schema.Collection, err)
+		}
+		out = append(out, schema)
+	}
+	return out, rows.Err()
+}
+
+// DeleteDocumentCollection removes a declaration and every document under it,
+// reporting how many documents went. Both halves in one transaction: a
+// declaration without its documents would leave records nothing can name, and
+// documents without their declaration would leave records nothing can query.
+func (s *Store) DeleteDocumentCollection(namespace, collection string) (int, error) {
+	if s.db == nil {
+		return 0, fmt.Errorf("store: no database")
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, fmt.Errorf("store: deleting %s/%s: %w", namespace, collection, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := tx.Exec(`DELETE FROM documents WHERE namespace = ? AND collection = ?`, namespace, collection)
+	if err != nil {
+		return 0, fmt.Errorf("store: deleting documents in %s/%s: %w", namespace, collection, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	if _, err := tx.Exec(
+		`DELETE FROM document_collections WHERE namespace = ? AND collection = ?`, namespace, collection); err != nil {
+		return 0, fmt.Errorf("store: deleting declaration for %s/%s: %w", namespace, collection, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("store: committing deletion of %s/%s: %w", namespace, collection, err)
+	}
+	return int(n), nil
+}
+
+// PutDocument writes a document, creating or fully replacing it. created_at
+// survives a replacement — it is when the record first appeared, which is what a
+// "newest first" query means by it — while updated_at moves on every write.
+func (s *Store) PutDocument(namespace, collection, id string, body []byte, now time.Time) error {
+	if s.db == nil {
+		return fmt.Errorf("store: no database")
+	}
+	ts := now.UTC().Format(docstore.TimeFormat)
+	_, err := s.db.Exec(
+		`INSERT INTO documents (namespace, collection, id, body, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(namespace, collection, id) DO UPDATE SET
+		   body=excluded.body,
+		   updated_at=excluded.updated_at`,
+		namespace, collection, id, string(body), ts, ts)
+	if err != nil {
+		return fmt.Errorf("store: writing %s/%s/%s: %w", namespace, collection, id, err)
+	}
+	return nil
+}
+
+// GetDocument returns one document by its address.
+func (s *Store) GetDocument(namespace, collection, id string) (*docstore.Document, bool, error) {
+	if s.db == nil {
+		return nil, false, fmt.Errorf("store: no database")
+	}
+	row := s.db.QueryRow(
+		`SELECT `+documentColumns+` FROM documents WHERE namespace = ? AND collection = ? AND id = ?`,
+		namespace, collection, id)
+	doc, err := scanDocument(row)
+	if err == sql.ErrNoRows {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("store: reading %s/%s/%s: %w", namespace, collection, id, err)
+	}
+	return doc, true, nil
+}
+
+// DeleteDocument removes a document, reporting whether one was there. The caller
+// needs the difference: a delete that removed nothing must not announce a change
+// that did not happen.
+func (s *Store) DeleteDocument(namespace, collection, id string) (bool, error) {
+	if s.db == nil {
+		return false, fmt.Errorf("store: no database")
+	}
+	res, err := s.db.Exec(
+		`DELETE FROM documents WHERE namespace = ? AND collection = ? AND id = ?`, namespace, collection, id)
+	if err != nil {
+		return false, fmt.Errorf("store: deleting %s/%s/%s: %w", namespace, collection, id, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+// QueryDocuments runs a compiled query. The compiled fragments are built from a
+// validated query against a stored declaration, so the only strings spliced into
+// the statement are ones docstore produced from identifiers it checked; every
+// caller-supplied value arrives as a bound argument.
+func (s *Store) QueryDocuments(c docstore.Compiled) ([]docstore.Document, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("store: no database")
+	}
+	rows, err := s.db.Query(
+		`SELECT `+documentColumns+` FROM documents WHERE `+c.Where+` ORDER BY `+c.Order+` LIMIT ?`,
+		append(append([]any{}, c.Args...), c.Limit)...)
+	if err != nil {
+		return nil, fmt.Errorf("store: querying documents: %w", err)
+	}
+	defer rows.Close()
+	out := []docstore.Document{}
+	for rows.Next() {
+		doc, err := scanDocument(rows)
+		if err != nil {
+			return nil, fmt.Errorf("store: scanning document: %w", err)
+		}
+		out = append(out, *doc)
+	}
+	return out, rows.Err()
+}
+
+// CountDocuments reports how many documents a collection holds. It is what the
+// slow-query log reports alongside a duration, so the day a scan gets slow the
+// receipt for adding an index is already written down.
+func (s *Store) CountDocuments(namespace, collection string) (int, error) {
+	if s.db == nil {
+		return 0, fmt.Errorf("store: no database")
+	}
+	var n int
+	err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM documents WHERE namespace = ? AND collection = ?`, namespace, collection).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("store: counting %s/%s: %w", namespace, collection, err)
+	}
+	return n, nil
+}
+
+func scanDocument(sc rowScanner) (*docstore.Document, error) {
+	var (
+		doc                    docstore.Document
+		body                   string
+		createdStr, updatedStr string
+	)
+	if err := sc.Scan(&doc.ID, &body, &createdStr, &updatedStr); err != nil {
+		return nil, err
+	}
+	doc.Body = json.RawMessage(body)
+	doc.CreatedAt = parseStoreTime(createdStr)
+	doc.UpdatedAt = parseStoreTime(updatedStr)
+	return &doc, nil
+}

--- a/internal/store/documents_test.go
+++ b/internal/store/documents_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -61,7 +62,17 @@ func queryIDs(t *testing.T, s *Store, q docstore.Query) []string {
 	if err != nil || !ok {
 		t.Fatalf("declaration for %s/%s: ok=%v err=%v", q.Namespace, q.Collection, ok, err)
 	}
-	c, err := q.Compile(*schema)
+	var anchor *docstore.Document
+	if q.After != "" {
+		doc, found, err := s.GetDocument(q.Namespace, q.Collection, q.After)
+		if err != nil {
+			t.Fatalf("anchor %s: %v", q.After, err)
+		}
+		if found {
+			anchor = doc
+		}
+	}
+	c, err := q.Compile(*schema, anchor)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
@@ -195,9 +206,8 @@ func TestFiltersSortAndLimitExecuteAgainstRealJSON(t *testing.T) {
 	}
 }
 
-// A range filter on the sort field is what paginates: the last id of a page is
-// the cursor for the next, and the id tiebreaker keeps the order total.
-func TestARangeFilterOnTheSortFieldPaginates(t *testing.T) {
+// The after cursor paginates: the last id of a page names the start of the next.
+func TestTheAfterCursorPaginates(t *testing.T) {
 	s, _ := storeWithRequests(t, map[string]string{
 		"a": `{"status":"pending","attempts":1}`,
 		"b": `{"status":"pending","attempts":2}`,
@@ -207,13 +217,182 @@ func TestARangeFilterOnTheSortFieldPaginates(t *testing.T) {
 		Namespace: "ext/approval-gate", Collection: "requests",
 		Sort: &docstore.Sort{Field: "attempts"}, Limit: 2,
 	}
-	first := queryIDs(t, s, q)
-	if !equalStrings(first, []string{"a", "b"}) {
-		t.Fatalf("first page = %v", first)
+	if got := queryIDs(t, s, q); !equalStrings(got, []string{"a", "b"}) {
+		t.Fatalf("first page = %v", got)
 	}
-	q.Filters = []docstore.Filter{{Field: "attempts", Op: docstore.OpGt, Value: 2}}
+	q.After = "b"
 	if got := queryIDs(t, s, q); !equalStrings(got, []string{"c"}) {
 		t.Fatalf("second page = %v", got)
+	}
+}
+
+// The boundary a range filter cannot express: every document shares one sort
+// value, so the whole ordering is the id tiebreaker. Paged one at a time, the
+// cursor must walk every document exactly once — `sort > value` would return
+// nothing after the first page and `sort >= value` would return the same
+// document forever.
+func TestPagingAcrossDocumentsThatShareASortValue(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{
+		"a": `{"status":"pending","attempts":7}`,
+		"b": `{"status":"pending","attempts":7}`,
+		"c": `{"status":"pending","attempts":7}`,
+	})
+	for _, tc := range []struct {
+		name string
+		desc bool
+		want []string
+	}{
+		{"ascending", false, []string{"a", "b", "c"}},
+		{"descending", true, []string{"c", "b", "a"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := docstore.Query{
+				Namespace: "ext/approval-gate", Collection: "requests",
+				Sort: &docstore.Sort{Field: "attempts", Desc: tc.desc}, Limit: 1,
+			}
+			var walked []string
+			for range tc.want {
+				page := queryIDs(t, s, q)
+				if len(page) != 1 {
+					t.Fatalf("page after %q = %v, want exactly one document", q.After, page)
+				}
+				walked = append(walked, page[0])
+				q.After = page[0]
+			}
+			if !equalStrings(walked, tc.want) {
+				t.Fatalf("walked %v, want %v", walked, tc.want)
+			}
+			if rest := queryIDs(t, s, q); len(rest) != 0 {
+				t.Fatalf("page past the last document = %v, want none", rest)
+			}
+		})
+	}
+}
+
+// Ties on a partially shared sort value: the cursor has to cross from one group
+// into the next without losing the tied documents on either side of the seam.
+func TestPagingCrossesATieGroupBoundary(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{
+		"a": `{"status":"pending","attempts":1}`,
+		"b": `{"status":"pending","attempts":2}`,
+		"c": `{"status":"pending","attempts":2}`,
+		"d": `{"status":"pending","attempts":3}`,
+	})
+	q := docstore.Query{
+		Namespace: "ext/approval-gate", Collection: "requests",
+		Sort: &docstore.Sort{Field: "attempts"}, Limit: 2, After: "b",
+	}
+	// "b" is the first of the pair sharing attempts=2, so its tie partner "c"
+	// must survive the page break.
+	if got := queryIDs(t, s, q); !equalStrings(got, []string{"c", "d"}) {
+		t.Fatalf("page after the first of a tied pair = %v, want [c d]", got)
+	}
+	q.After = "c"
+	if got := queryIDs(t, s, q); !equalStrings(got, []string{"d"}) {
+		t.Fatalf("page after the last of a tied pair = %v, want [d]", got)
+	}
+}
+
+// A declared field says what may be queried, not what a document must carry, so
+// a document missing the sort field is a real row in the ordering. SQLite sorts
+// its NULL first ascending and last descending, and the cursor has to agree in
+// both directions or the missing-field documents vanish from paging.
+func TestPagingOverDocumentsMissingTheSortField(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{
+		"a": `{"status":"pending"}`,
+		"b": `{"status":"pending"}`,
+		"c": `{"status":"pending","attempts":5}`,
+	})
+	for _, tc := range []struct {
+		name string
+		desc bool
+		want []string
+	}{
+		{"ascending puts the missing field first", false, []string{"a", "b", "c"}},
+		{"descending puts it last", true, []string{"c", "b", "a"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := docstore.Query{
+				Namespace: "ext/approval-gate", Collection: "requests",
+				Sort: &docstore.Sort{Field: "attempts", Desc: tc.desc}, Limit: 1,
+			}
+			var walked []string
+			for range tc.want {
+				page := queryIDs(t, s, q)
+				if len(page) != 1 {
+					t.Fatalf("page after %q = %v, want exactly one document", q.After, page)
+				}
+				walked = append(walked, page[0])
+				q.After = page[0]
+			}
+			if !equalStrings(walked, tc.want) {
+				t.Fatalf("walked %v, want %v", walked, tc.want)
+			}
+			if rest := queryIDs(t, s, q); len(rest) != 0 {
+				t.Fatalf("page past the last document = %v, want none", rest)
+			}
+		})
+	}
+}
+
+// An unsorted query is ordered by id alone, and the cursor is that one column.
+func TestPagingAnUnsortedQuery(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{
+		"a": `{"status":"pending"}`,
+		"b": `{"status":"pending"}`,
+		"c": `{"status":"pending"}`,
+	})
+	q := docstore.Query{
+		Namespace: "ext/approval-gate", Collection: "requests",
+		Limit: 2, After: "a",
+	}
+	if got := queryIDs(t, s, q); !equalStrings(got, []string{"b", "c"}) {
+		t.Fatalf("page after a = %v", got)
+	}
+}
+
+// Timestamps are the sort a live panel actually uses, and two documents written
+// in the same instant tie there too.
+func TestPagingByCreatedAtWithIdenticalTimestamps(t *testing.T) {
+	s := New()
+	base := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+		t.Fatalf("define: %v", err)
+	}
+	for _, id := range []string{"a", "b", "c"} {
+		if err := s.PutDocument("ext/approval-gate", "requests", id, []byte(`{"status":"pending"}`), base); err != nil {
+			t.Fatalf("put %s: %v", id, err)
+		}
+	}
+	q := docstore.Query{
+		Namespace: "ext/approval-gate", Collection: "requests",
+		Sort: &docstore.Sort{Field: docstore.FieldCreatedAt, Desc: true}, Limit: 1,
+	}
+	var walked []string
+	for i := 0; i < 3; i++ {
+		page := queryIDs(t, s, q)
+		if len(page) != 1 {
+			t.Fatalf("page after %q = %v, want exactly one document", q.After, page)
+		}
+		walked = append(walked, page[0])
+		q.After = page[0]
+	}
+	if !equalStrings(walked, []string{"c", "b", "a"}) {
+		t.Fatalf("walked %v, want [c b a]", walked)
+	}
+}
+
+// A cursor pointing at a document that is gone is an error, not an empty page:
+// silently returning nothing reads as "end of results" and quietly truncates.
+func TestPagingAfterADeletedDocumentSaysSo(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
+	schema, _, err := s.DocumentCollection("ext/approval-gate", "requests")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := docstore.Query{Namespace: "ext/approval-gate", Collection: "requests", After: "gone"}
+	if _, err := q.Compile(*schema, nil); err == nil || !strings.Contains(err.Error(), "gone") {
+		t.Fatalf("cursor to a missing document: %v", err)
 	}
 }
 
@@ -315,7 +494,7 @@ func TestAnEmptyResultIsAnEmptyList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err := docstore.Query{Namespace: "ext/approval-gate", Collection: "requests"}.Compile(*schema)
+	c, err := docstore.Query{Namespace: "ext/approval-gate", Collection: "requests"}.Compile(*schema, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/documents_test.go
+++ b/internal/store/documents_test.go
@@ -1,0 +1,392 @@
+package store
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/docstore"
+)
+
+func requestsDeclaration() docstore.CollectionSchema {
+	return docstore.CollectionSchema{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Fields: []docstore.FieldSpec{
+			{Name: "status", Type: docstore.FieldString},
+			{Name: "attempts", Type: docstore.FieldNumber},
+			{Name: "urgent", Type: docstore.FieldBool},
+		},
+	}
+}
+
+// storeWithRequests returns a store holding the declaration and the documents,
+// each written a second apart so created_at ordering is unambiguous.
+func storeWithRequests(t *testing.T, bodies map[string]string) (*Store, time.Time) {
+	t.Helper()
+	s := New()
+	base := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+		t.Fatalf("define: %v", err)
+	}
+	i := 0
+	for _, id := range sortedKeys(bodies) {
+		if err := s.PutDocument("ext/approval-gate", "requests", id, []byte(bodies[id]), base.Add(time.Duration(i)*time.Second)); err != nil {
+			t.Fatalf("put %s: %v", id, err)
+		}
+		i++
+	}
+	return s, base
+}
+
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	for i := range out {
+		for j := i + 1; j < len(out); j++ {
+			if out[j] < out[i] {
+				out[i], out[j] = out[j], out[i]
+			}
+		}
+	}
+	return out
+}
+
+func queryIDs(t *testing.T, s *Store, q docstore.Query) []string {
+	t.Helper()
+	schema, ok, err := s.DocumentCollection(q.Namespace, q.Collection)
+	if err != nil || !ok {
+		t.Fatalf("declaration for %s/%s: ok=%v err=%v", q.Namespace, q.Collection, ok, err)
+	}
+	c, err := q.Compile(*schema)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	docs, err := s.QueryDocuments(c)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	ids := make([]string, 0, len(docs))
+	for _, d := range docs {
+		ids = append(ids, d.ID)
+	}
+	return ids
+}
+
+// The declaration survives a round trip, which is what lets a surface that did
+// not write it — the CLI, later an extension apply — compile a query against it.
+func TestADeclarationRoundTripsThroughTheDatabase(t *testing.T) {
+	s := New()
+	now := time.Now().UTC()
+	if err := s.DefineDocumentCollection(requestsDeclaration(), now); err != nil {
+		t.Fatalf("define: %v", err)
+	}
+	got, ok, err := s.DocumentCollection("ext/approval-gate", "requests")
+	if err != nil || !ok {
+		t.Fatalf("read back: ok=%v err=%v", ok, err)
+	}
+	if len(got.Fields) != 3 || got.Fields[0].Name != "status" || got.Fields[1].Type != docstore.FieldNumber {
+		t.Fatalf("declaration = %+v", got)
+	}
+	// An undeclared collection is absent, not an error: that is the difference a
+	// query against a collection nobody declared has to report.
+	if _, ok, err := s.DocumentCollection("ext/approval-gate", "nothing"); err != nil || ok {
+		t.Fatalf("undeclared collection: ok=%v err=%v", ok, err)
+	}
+}
+
+// A declaration is replaced, not migrated: adding a queryable field leaves every
+// stored document untouched and immediately queryable by the new field.
+func TestRedeclaringAddsAQueryableFieldWithoutTouchingDocuments(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{
+		"a": `{"status":"pending","attempts":1,"urgent":false,"note":"hi"}`,
+	})
+	schema := requestsDeclaration()
+	schema.Fields = append(schema.Fields, docstore.FieldSpec{Name: "note", Type: docstore.FieldString})
+	if err := s.DefineDocumentCollection(schema, base); err != nil {
+		t.Fatalf("redefine: %v", err)
+	}
+	ids := queryIDs(t, s, docstore.Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Filters:    []docstore.Filter{{Field: "note", Op: docstore.OpEq, Value: "hi"}},
+	})
+	if len(ids) != 1 || ids[0] != "a" {
+		t.Fatalf("ids = %v, want [a]", ids)
+	}
+}
+
+// A body is stored byte for byte, undeclared fields included. Nothing rewrites a
+// stored document, which is what "no migrations for authors" rests on.
+func TestABodyComesBackExactlyAsWritten(t *testing.T) {
+	body := `{"status":"pending","nested":{"deep":[1,2,{"x":null}]},"undeclared":"kept"}`
+	s, _ := storeWithRequests(t, map[string]string{"a": body})
+	doc, ok, err := s.GetDocument("ext/approval-gate", "requests", "a")
+	if err != nil || !ok {
+		t.Fatalf("get: ok=%v err=%v", ok, err)
+	}
+	if string(doc.Body) != body {
+		t.Fatalf("body = %s, want %s", doc.Body, body)
+	}
+}
+
+// created_at is when the record appeared and survives a replacement; updated_at
+// moves. A "newest first" query means the first of those.
+func TestReplacingADocumentKeepsCreatedAtAndMovesUpdatedAt(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
+	later := base.Add(time.Hour)
+	if err := s.PutDocument("ext/approval-gate", "requests", "a", []byte(`{"status":"approved"}`), later); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	doc, _, err := s.GetDocument("ext/approval-gate", "requests", "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !doc.CreatedAt.Equal(base) {
+		t.Fatalf("created_at = %s, want %s", doc.CreatedAt, base)
+	}
+	if !doc.UpdatedAt.Equal(later) {
+		t.Fatalf("updated_at = %s, want %s", doc.UpdatedAt, later)
+	}
+}
+
+// The compiled query actually executes: filters read the body through
+// json_extract, the sort orders, and the limit bounds.
+func TestFiltersSortAndLimitExecuteAgainstRealJSON(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{
+		"a": `{"status":"pending","attempts":1,"urgent":false}`,
+		"b": `{"status":"pending","attempts":5,"urgent":true}`,
+		"c": `{"status":"approved","attempts":2,"urgent":false}`,
+		"d": `{"status":"pending","attempts":9,"urgent":true}`,
+	})
+	ns, coll := "ext/approval-gate", "requests"
+
+	if got := queryIDs(t, s, docstore.Query{
+		Namespace: ns, Collection: coll,
+		Filters: []docstore.Filter{{Field: "status", Op: docstore.OpEq, Value: "pending"}},
+		Sort:    &docstore.Sort{Field: docstore.FieldCreatedAt, Desc: true},
+	}); !equalStrings(got, []string{"d", "b", "a"}) {
+		t.Fatalf("pending newest-first = %v", got)
+	}
+
+	if got := queryIDs(t, s, docstore.Query{
+		Namespace: ns, Collection: coll,
+		Filters: []docstore.Filter{{Field: "attempts", Op: docstore.OpGte, Value: 5}},
+		Sort:    &docstore.Sort{Field: "attempts"},
+	}); !equalStrings(got, []string{"b", "d"}) {
+		t.Fatalf("attempts >= 5 = %v", got)
+	}
+
+	if got := queryIDs(t, s, docstore.Query{
+		Namespace: ns, Collection: coll,
+		Filters: []docstore.Filter{{Field: "urgent", Op: docstore.OpEq, Value: true}},
+	}); !equalStrings(got, []string{"b", "d"}) {
+		t.Fatalf("urgent = %v", got)
+	}
+
+	if got := queryIDs(t, s, docstore.Query{
+		Namespace: ns, Collection: coll,
+		Sort: &docstore.Sort{Field: docstore.FieldCreatedAt}, Limit: 2,
+	}); !equalStrings(got, []string{"a", "b"}) {
+		t.Fatalf("limit 2 = %v", got)
+	}
+}
+
+// A range filter on the sort field is what paginates: the last id of a page is
+// the cursor for the next, and the id tiebreaker keeps the order total.
+func TestARangeFilterOnTheSortFieldPaginates(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{
+		"a": `{"status":"pending","attempts":1}`,
+		"b": `{"status":"pending","attempts":2}`,
+		"c": `{"status":"pending","attempts":3}`,
+	})
+	q := docstore.Query{
+		Namespace: "ext/approval-gate", Collection: "requests",
+		Sort: &docstore.Sort{Field: "attempts"}, Limit: 2,
+	}
+	first := queryIDs(t, s, q)
+	if !equalStrings(first, []string{"a", "b"}) {
+		t.Fatalf("first page = %v", first)
+	}
+	q.Filters = []docstore.Filter{{Field: "attempts", Op: docstore.OpGt, Value: 2}}
+	if got := queryIDs(t, s, q); !equalStrings(got, []string{"c"}) {
+		t.Fatalf("second page = %v", got)
+	}
+}
+
+// Namespace isolation is structural: two namespaces holding the same collection
+// name never see each other's documents, because namespace is part of every
+// address and every statement.
+func TestTwoNamespacesWithTheSameCollectionNameStaySeparate(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{"shared-id": `{"status":"pending"}`})
+	other := requestsDeclaration()
+	other.Namespace = "ext/other"
+	if err := s.DefineDocumentCollection(other, base); err != nil {
+		t.Fatalf("define other: %v", err)
+	}
+	if err := s.PutDocument("ext/other", "requests", "shared-id", []byte(`{"status":"approved"}`), base); err != nil {
+		t.Fatalf("put other: %v", err)
+	}
+
+	mine, _, err := s.GetDocument("ext/approval-gate", "requests", "shared-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(mine.Body) != `{"status":"pending"}` {
+		t.Fatalf("the other namespace's write reached this one: %s", mine.Body)
+	}
+	if got := queryIDs(t, s, docstore.Query{
+		Namespace: "ext/approval-gate", Collection: "requests",
+		Filters: []docstore.Filter{{Field: "status", Op: docstore.OpEq, Value: "approved"}},
+	}); len(got) != 0 {
+		t.Fatalf("query crossed the namespace boundary: %v", got)
+	}
+	// Deleting one namespace's document leaves the other's alone.
+	if _, err := s.DeleteDocument("ext/other", "requests", "shared-id"); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := s.GetDocument("ext/approval-gate", "requests", "shared-id"); !ok {
+		t.Fatal("deleting in one namespace removed the other's document")
+	}
+}
+
+// A delete reports whether anything was there, so a caller does not announce a
+// change that did not happen.
+func TestDeleteReportsWhetherADocumentWasThere(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
+	existed, err := s.DeleteDocument("ext/approval-gate", "requests", "a")
+	if err != nil || !existed {
+		t.Fatalf("first delete: existed=%v err=%v", existed, err)
+	}
+	existed, err = s.DeleteDocument("ext/approval-gate", "requests", "a")
+	if err != nil || existed {
+		t.Fatalf("second delete: existed=%v err=%v", existed, err)
+	}
+}
+
+// Removing a collection takes its documents with it, in one transaction: a
+// declaration without documents names nothing, and documents without a
+// declaration cannot be queried.
+func TestRemovingACollectionTakesItsDocuments(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{
+		"a": `{"status":"pending"}`,
+		"b": `{"status":"pending"}`,
+	})
+	n, err := s.DeleteDocumentCollection("ext/approval-gate", "requests")
+	if err != nil {
+		t.Fatalf("delete collection: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("removed %d documents, want 2", n)
+	}
+	if _, ok, _ := s.DocumentCollection("ext/approval-gate", "requests"); ok {
+		t.Fatal("declaration survived")
+	}
+	if _, ok, _ := s.GetDocument("ext/approval-gate", "requests", "a"); ok {
+		t.Fatal("document survived its collection")
+	}
+}
+
+// The count behind the slow-query receipt is per collection, not per table.
+func TestCountIsScopedToTheCollection(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`, "b": `{"status":"pending"}`})
+	other := requestsDeclaration()
+	other.Namespace = "ext/other"
+	if err := s.DefineDocumentCollection(other, base); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PutDocument("ext/other", "requests", "z", []byte(`{"status":"x"}`), base); err != nil {
+		t.Fatal(err)
+	}
+	n, err := s.CountDocuments("ext/approval-gate", "requests")
+	if err != nil || n != 2 {
+		t.Fatalf("count = %d err = %v, want 2", n, err)
+	}
+}
+
+// A collection with no matching documents returns an empty result, never nil:
+// the wire carries an empty list, not a null.
+func TestAnEmptyResultIsAnEmptyList(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{})
+	schema, _, err := s.DocumentCollection("ext/approval-gate", "requests")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := docstore.Query{Namespace: "ext/approval-gate", Collection: "requests"}.Compile(*schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	docs, err := s.QueryDocuments(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if docs == nil {
+		t.Fatal("nil result set")
+	}
+	if raw, _ := json.Marshal(docs); string(raw) != "[]" {
+		t.Fatalf("marshalled empty result = %s", raw)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Documents and their declarations survive the daemon that wrote them: reopening
+// the same database returns both, which is what makes a live query's contents
+// durable across a restart rather than an in-memory projection.
+func TestDocumentsSurviveReopeningTheDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "attn.db")
+	base := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+
+	first, err := NewWithDB(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := first.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+		t.Fatalf("define: %v", err)
+	}
+	if err := first.PutDocument("ext/approval-gate", "requests", "a", []byte(`{"status":"pending"}`), base); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	first.Close()
+
+	second, err := NewWithDB(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer second.Close()
+
+	schema, ok, err := second.DocumentCollection("ext/approval-gate", "requests")
+	if err != nil || !ok {
+		t.Fatalf("declaration after reopen: ok=%v err=%v", ok, err)
+	}
+	if len(schema.Fields) != 3 {
+		t.Fatalf("declaration lost fields: %+v", schema.Fields)
+	}
+	if got := queryIDs(t, second, docstore.Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Filters:    []docstore.Filter{{Field: "status", Op: docstore.OpEq, Value: "pending"}},
+	}); !equalStrings(got, []string{"a"}) {
+		t.Fatalf("query after reopen = %v, want [a]", got)
+	}
+	doc, _, err := second.GetDocument("ext/approval-gate", "requests", "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !doc.CreatedAt.Equal(base) {
+		t.Fatalf("created_at after reopen = %s, want %s", doc.CreatedAt, base)
+	}
+}

--- a/internal/store/documents_test.go
+++ b/internal/store/documents_test.go
@@ -569,3 +569,113 @@ func TestDocumentsSurviveReopeningTheDatabase(t *testing.T) {
 		t.Fatalf("created_at after reopen = %s, want %s", doc.CreatedAt, base)
 	}
 }
+
+// A declaration says what may be queried, not what a document must hold, so a
+// field declared `number` may legitimately contain an array or an object.
+// json_extract yields those as JSON text and orders them with everything else,
+// and the cursor has to walk them the same way — binding such a value from Go
+// has no bindable equivalent and fails the statement outright.
+func TestPagingOverCompoundValuesInADeclaredField(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{
+		"a": `{"status":"pending","attempts":[1]}`,
+		"b": `{"status":"pending","attempts":[1]}`,
+		"c": `{"status":"pending","attempts":{"tries":2}}`,
+		"d": `{"status":"pending","attempts":3}`,
+	})
+	for _, desc := range []bool{false, true} {
+		name := "ascending"
+		if desc {
+			name = "descending"
+		}
+		t.Run(name, func(t *testing.T) {
+			q := docstore.Query{
+				Namespace: "ext/approval-gate", Collection: "requests",
+				Sort: &docstore.Sort{Field: "attempts", Desc: desc}, Limit: 1,
+			}
+			// Whatever order SQLite gives these four, the walk has to visit each
+			// exactly once and then stop — the ordering is SQLite's, the
+			// completeness is the cursor's.
+			seen := map[string]bool{}
+			for i := 0; i < 4; i++ {
+				page := queryIDs(t, s, q)
+				if len(page) != 1 {
+					t.Fatalf("page after %q = %v, want exactly one document", q.After, page)
+				}
+				if seen[page[0]] {
+					t.Fatalf("page after %q returned %q again", q.After, page[0])
+				}
+				seen[page[0]] = true
+				q.After = page[0]
+			}
+			if len(seen) != 4 {
+				t.Fatalf("walked %v, want all four documents", seen)
+			}
+			if rest := queryIDs(t, s, q); len(rest) != 0 {
+				t.Fatalf("page past the last document = %v, want none", rest)
+			}
+		})
+	}
+}
+
+// The same for the tie: two documents holding the identical compound value are
+// separated by the id half of the tuple, which is the branch a bound value made
+// unreachable by failing the statement first.
+func TestPagingBetweenTwoIdenticalCompoundValues(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{
+		"a": `{"status":"pending","attempts":[1,2]}`,
+		"b": `{"status":"pending","attempts":[1,2]}`,
+	})
+	q := docstore.Query{
+		Namespace: "ext/approval-gate", Collection: "requests",
+		Sort: &docstore.Sort{Field: "attempts"}, Limit: 1, After: "a",
+	}
+	if got := queryIDs(t, s, q); !equalStrings(got, []string{"b"}) {
+		t.Fatalf("page after the first of an identical pair = %v, want [b]", got)
+	}
+}
+
+// A stored value that disagrees with the declared type is also ordinary: the
+// declaration is not a storage schema. The cursor compares whatever json_extract
+// yields, so the walk is complete regardless of how SQLite orders the mix.
+func TestPagingWhenStoredValuesDisagreeWithTheDeclaredType(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{
+		"a": `{"status":"pending","attempts":"seven"}`,
+		"b": `{"status":"pending","attempts":7}`,
+		"c": `{"status":"pending","attempts":true}`,
+	})
+	q := docstore.Query{
+		Namespace: "ext/approval-gate", Collection: "requests",
+		Sort: &docstore.Sort{Field: "attempts"}, Limit: 1,
+	}
+	seen := map[string]bool{}
+	for i := 0; i < 3; i++ {
+		page := queryIDs(t, s, q)
+		if len(page) != 1 {
+			t.Fatalf("page after %q = %v, want exactly one document", q.After, page)
+		}
+		if seen[page[0]] {
+			t.Fatalf("page after %q returned %q again", q.After, page[0])
+		}
+		seen[page[0]] = true
+		q.After = page[0]
+	}
+	if rest := queryIDs(t, s, q); len(rest) != 0 {
+		t.Fatalf("page past the last document = %v, want none", rest)
+	}
+}
+
+// A JSON null is the same absence as a missing key: json_extract yields SQL NULL
+// for both, so the cursor's NULL branch has to cover it.
+func TestPagingOverAnExplicitJSONNull(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{
+		"a": `{"status":"pending","attempts":null}`,
+		"b": `{"status":"pending","attempts":2}`,
+	})
+	q := docstore.Query{
+		Namespace: "ext/approval-gate", Collection: "requests",
+		Sort: &docstore.Sort{Field: "attempts"}, Limit: 1, After: "a",
+	}
+	if got := queryIDs(t, s, q); !equalStrings(got, []string{"b"}) {
+		t.Fatalf("page after a null-valued document = %v, want [b]", got)
+	}
+}

--- a/internal/store/jobs.go
+++ b/internal/store/jobs.go
@@ -243,17 +243,17 @@ func scanJobRow(sc rowScanner) (*JobRecord, error) {
 		return nil, err
 	}
 	rec.Requeued = requeued != 0
-	rec.ScheduledAt = parseJobTime(scheduledStr)
-	rec.CreatedAt = parseJobTime(createdStr)
-	rec.UpdatedAt = parseJobTime(updateStr)
+	rec.ScheduledAt = parseStoreTime(scheduledStr)
+	rec.CreatedAt = parseStoreTime(createdStr)
+	rec.UpdatedAt = parseStoreTime(updateStr)
 	return &rec, nil
 }
 
-// parseJobTime decodes a stored timestamp, tolerating the plain RFC3339 form as
+// parseStoreTime decodes a stored timestamp, tolerating the plain RFC3339 form as
 // well as RFC3339Nano. A blank/garbage value yields the zero time rather than an
 // error — a job with an unreadable timestamp is still a real record, and the
 // queue treats a zero scheduled_at as "eligible now".
-func parseJobTime(s string) time.Time {
+func parseStoreTime(s string) time.Time {
 	if s == "" {
 		return time.Time{}
 	}

--- a/internal/store/notifications.go
+++ b/internal/store/notifications.go
@@ -15,7 +15,7 @@ import (
 // daemon owns the mapping to the protocol shape — keeping this package a leaf.
 //
 // read_at is persisted as '' while unread and as a timestamp once read. Timestamps
-// reuse the jobs table's RFC3339Nano encoding and parseJobTime decoder (same
+// reuse the jobs table's RFC3339Nano encoding and parseStoreTime decoder (same
 // package), so a blank/garbage value decodes to the zero time.
 
 // NotificationRecord is one durable notification row. ReadAt is the zero time
@@ -139,7 +139,7 @@ func scanNotificationRow(sc rowScanner) (*NotificationRecord, error) {
 		&rec.SourceKind, &rec.SourceID, &createdStr, &readStr); err != nil {
 		return nil, err
 	}
-	rec.CreatedAt = parseJobTime(createdStr)
-	rec.ReadAt = parseJobTime(readStr)
+	rec.CreatedAt = parseStoreTime(createdStr)
+	rec.ReadAt = parseStoreTime(readStr)
 	return &rec, nil
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -885,6 +885,26 @@ CREATE TABLE IF NOT EXISTS bus_consumers (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_unique_key ON jobs(kind, unique_key) WHERE unique_key <> '';
 -- The dispatch selection: claimable rows in the order they are claimed.
 CREATE INDEX IF NOT EXISTS idx_jobs_eligible ON jobs(state, scheduled_at, priority DESC);`},
+	{88, "create the document store", `CREATE TABLE IF NOT EXISTS documents (
+    namespace  TEXT NOT NULL,
+    collection TEXT NOT NULL,
+    id         TEXT NOT NULL,
+    body       TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (namespace, collection, id)
+);
+-- Every query is scoped to one collection, so the primary key is also the
+-- access path: a query scans the (namespace, collection) prefix and no further.
+-- Declared fields carry no index of their own in v1 (see the A3 plan) — the
+-- declaration is the contract, and the physical index waits for a measurement.
+CREATE TABLE IF NOT EXISTS document_collections (
+    namespace   TEXT NOT NULL,
+    collection  TEXT NOT NULL,
+    fields_json TEXT NOT NULL,
+    updated_at  TEXT NOT NULL,
+    PRIMARY KEY (namespace, collection)
+);`},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -81,9 +81,9 @@ func (s *Store) MigrateLegacyTasks(translate func(LegacyTaskRecord) JobRecord) (
 			return 0, fmt.Errorf("store: scan legacy task: %w", err)
 		}
 		rec.Requeued = requeued != 0
-		rec.NextAttemptAt = parseJobTime(nextStr)
-		rec.CreatedAt = parseJobTime(createdStr)
-		rec.UpdatedAt = parseJobTime(updatedStr)
+		rec.NextAttemptAt = parseStoreTime(nextStr)
+		rec.CreatedAt = parseStoreTime(createdStr)
+		rec.UpdatedAt = parseStoreTime(updatedStr)
 		owed = append(owed, rec)
 	}
 	rows.Close()


### PR DESCRIPTION
A3 of the [extension platform roadmap](docs/plans/2026-08-01-extension-platform-roadmap.md): the store an extension keeps its own data in. Gate answers and the implementation notes are in [docs/plans/2026-08-03-ext-a3-doc-store.md](docs/plans/2026-08-03-ext-a3-doc-store.md).

## What it is

A namespace (`owner/name`, e.g. `ext/approval-gate`) holds collections, a collection holds JSON documents under caller-chosen ids, and a collection carries a **declaration** naming which fields are queryable and with what type.

Documents are stored byte for byte and nothing rewrites them, so adding a queryable field is a declaration change rather than a migration: filters read the body through `json_extract` at query time. `created_at` and `updated_at` are always queryable and must not be declared.

A query is one JSON object — namespace, collection, filters, sort, limit, and an **after cursor**: the id of the previous page's last document. The visible order is `(sort field, id)`, with the id tiebreaker running in the sort's own direction, and the cursor compiles to a comparison against that whole tuple (`sort <cmp> value OR (sort = value AND id <cmp> anchor)`). It is part of the query rather than a filter a caller writes, because a filter can constrain only the first half of the tuple: with documents tied on the sort field, `sort > value` skips the tied ones and `sort >= value` returns the anchor forever. There is no offset and no opaque token. Left open as a **live query**, it re-runs when a write to the collection says the answer may have moved, and every delivery is the whole current result set.

## Shape

- `internal/docstore` — the query language and `Query.Compile(schema) → Compiled`. It holds no database handle, so every rule about what a query means is testable without one. Same seam as `internal/bus` ↔ `internal/store/bus.go`.
- `internal/store/documents.go` — two tables (migration **88**), the CRUD, and `QueryDocuments(Compiled)`. It executes SQL it did not decide.
- `internal/daemon/documents.go` — IPC handlers, the change fact, live-query subscriptions.
- `internal/client/documents.go`, `cmd/attn/doc.go` — the operator surface: define, undefine, collections, put, get, delete, query, watch.

Writes publish `document.changed` on the bus, deliberately **without** a `wireProjections` entry: no WebSocket traffic in this stage. An ephemeral subscriber beside the hub pokes a one-slot channel per subscription, so the bus's publish lock is never held across a socket write — `TestWritesDoNotBlockOnASubscriberThatIsNotReading` hangs rather than fails if that regresses. `doc_subscribe` registers before its first query, because that order can only produce one redundant delivery while the other can miss a write.

## Bounds

`DefaultLimit` 100, `MaxLimit` 1000. Receipt (2026-08-03, production `~/.attn`): the lists attn already pushes whole are tickets 7, sessions 11, notifications 8, workspaces 8 — an order of magnitude and two orders of magnitude past the working set. Asking past the ceiling is an error naming the limit, the ask, and the cursor to page with — never a silent truncation.

## Deliberately not built

- **Indexes.** Scan-first was the gate's answer; the working set above is the receipt, and the declaration is what makes adding them later invisible to callers. The roadmap line that said "with secondary indexes" is updated to match.
- **Grants.** Namespaces are `owner/name` and enforced as a shape; *who* may claim one is A4's registry, which is the thing that knows about authors.
- **A frontend surface.** A5 owns the UI host and the generic protocol envelopes; nothing here pre-empts that gate.

## Verification

`make test` and `make test-frontend` green; `tsc --noEmit` clean after the protocol regen (**206**, both constants moved).

Live on a throwaway profile (`docstore1`, full `make install` since `generated.ts` moved; preflight PASS, app and daemon both protocol 205; profile cleaned up after):

- define → put → query with filters, sort, limit; an undeclared key in the body survives the round trip.
- `attn doc watch --where status=pending` delivered revision 1 on subscribe, revision 2 on a put, revision 3 on a delete. A no-op delete and a write to another namespace produced no revision — proven because the delete landed at revision 3, not 5.
- Documents written before a daemon restart were still queryable after it.
- Namespace isolation: `ext/other/requests` and `ext/approval-gate/requests` hold different documents under the same id and neither query sees the other.
- Every error names the limit, the ask, and the way out — over-limit, undeclared filter field, type mismatch, malformed namespace, reserved field name, undeclared collection.
- `undefine` removes the declaration and its documents, and the collection is gone from `collections`.
- Four documents all at `attempts=7` — a total tie — paged one at a time walked `a b c d` ascending and `d c b a` descending, each exactly once, with the next page empty in both directions. A cursor to a deleted document errors by name.

## Surfaces walked

CLI (`attn doc`, plus the help listing), daemon (IPC dispatch, `CommandMeta`, wire annotations), protocol (`main.tsp` → regen → `ProtocolVersion` 205 in both places), docs (glossary entry for namespace/collection/document/live query, `internal/docstore` in the AGENTS.md architecture list, changelog fragment). Linux is unaffected — no build constraints and no platform-specific code. No plugin or SDK surface consumes the store yet; A4 is the first.
