### PR TITLE
fix(daemon): refuse to start when the WebSocket port is taken

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -1021,6 +1021,13 @@ export function useDaemonSocket({
       case 'unregister':
         rejectPendingByPredicate((key) => key.startsWith('unregister:'), error);
         return;
+      // command_error carries no correlation id, so this fails every
+      // registration in flight. Registering more than one workspace at a time
+      // is not something the app does, and over-rejecting beats the ten-second
+      // silent timeout that a failure used to surface as.
+      case 'register_workspace':
+        rejectPendingByPredicate((key) => key.startsWith('register_workspace:'), error);
+        return;
       case 'unregister_workspace':
         rejectPendingByPredicate((key) => key.startsWith('unregister_workspace:'), error);
         return;

--- a/app/src/hooks/useDaemonSocket.workspaceRegistration.test.tsx
+++ b/app/src/hooks/useDaemonSocket.workspaceRegistration.test.tsx
@@ -1,0 +1,178 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { isTauri } from '@tauri-apps/api/core';
+import { PROTOCOL_VERSION, useDaemonSocket } from './useDaemonSocket';
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+
+  readonly url: string;
+  readyState = FakeWebSocket.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  sent: string[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+    queueMicrotask(() => {
+      this.readyState = FakeWebSocket.OPEN;
+      this.onopen?.(new Event('open'));
+    });
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.(new CloseEvent('close'));
+  }
+
+  emit(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+}
+
+async function waitForOpenSocket(): Promise<FakeWebSocket> {
+  await waitFor(() => {
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(0);
+  });
+  const ws = FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+  expect(ws).toBeDefined();
+  await waitFor(() => {
+    expect(ws.readyState).toBe(FakeWebSocket.OPEN);
+  });
+  return ws;
+}
+
+function renderSocket() {
+  return renderHook(() =>
+    useDaemonSocket({
+      onSessionsUpdate: vi.fn(),
+      onWorkspacesUpdate: vi.fn(),
+      onPRsUpdate: vi.fn(),
+      onReposUpdate: vi.fn(),
+      onAuthorsUpdate: vi.fn(),
+      wsUrl: 'ws://localhost:9999/ws',
+    }),
+  );
+}
+
+function emitInitialState(ws: FakeWebSocket) {
+  act(() => {
+    ws.emit({
+      event: 'initial_state',
+      protocol_version: PROTOCOL_VERSION,
+      sessions: [],
+      workspaces: [],
+      prs: [],
+      repos: [],
+      authors: [],
+      settings: {},
+    });
+  });
+}
+
+// Registering and unregistering a workspace park a promise that only the daemon
+// can settle. A registration the daemon refuses — a forwarded remote one that
+// failed, say — comes back as `command_error`, which carries no correlation id,
+// so the socket has to match it by command name. Without that the caller waits
+// out the full ten seconds and reports a timeout, hiding what the daemon said.
+describe('useDaemonSocket workspace registration errors', () => {
+  let originalWebSocket: typeof WebSocket;
+
+  beforeEach(() => {
+    originalWebSocket = globalThis.WebSocket;
+    FakeWebSocket.instances = [];
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+    vi.mocked(isTauri).mockReturnValue(false);
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    globalThis.WebSocket = originalWebSocket;
+    vi.clearAllMocks();
+  });
+
+  it('rejects a pending registration with the daemon error instead of timing out', async () => {
+    const { result, unmount } = renderSocket();
+    const ws = await waitForOpenSocket();
+    emitInitialState(ws);
+
+    let registration!: Promise<void>;
+    act(() => {
+      registration = result.current.sendRegisterWorkspace('workspace-1', 'Workspace', '/tmp/repo');
+    });
+    const settled = registration.then(
+      () => 'resolved',
+      (err: Error) => err.message,
+    );
+
+    await waitFor(() => {
+      expect(ws.sent.map((entry) => JSON.parse(entry)).some((entry) => entry.cmd === 'register_workspace')).toBe(true);
+    });
+
+    act(() => {
+      ws.emit({
+        event: 'command_error',
+        cmd: 'register_workspace',
+        error: 'remote endpoint refused the workspace',
+      });
+    });
+
+    // Drain the ten-second registration timeout too: if the command_error branch
+    // is ever dropped, this test fails on the timeout's own wording rather than
+    // hanging on a promise nobody settles.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    await expect(settled).resolves.toBe('remote endpoint refused the workspace');
+
+    unmount();
+  });
+
+  it('rejects a pending unregistration with the daemon error instead of timing out', async () => {
+    const { result, unmount } = renderSocket();
+    const ws = await waitForOpenSocket();
+    emitInitialState(ws);
+
+    let unregistration!: Promise<void>;
+    act(() => {
+      unregistration = result.current.sendUnregisterWorkspace('workspace-1');
+    });
+    const settled = unregistration.then(
+      () => 'resolved',
+      (err: Error) => err.message,
+    );
+
+    await waitFor(() => {
+      expect(ws.sent.map((entry) => JSON.parse(entry)).some((entry) => entry.cmd === 'unregister_workspace')).toBe(true);
+    });
+
+    act(() => {
+      ws.emit({
+        event: 'command_error',
+        cmd: 'unregister_workspace',
+        error: 'workspace is still in use',
+      });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    await expect(settled).resolves.toBe('workspace is still in use');
+
+    unmount();
+  });
+});

--- a/changelog.d/ws-bind-fatal-daemon-refuses-taken-port.yaml
+++ b/changelog.d/ws-bind-fatal-daemon-refuses-taken-port.yaml
@@ -1,0 +1,18 @@
+kind: fixed
+area: daemon
+change: >
+  The daemon now refuses to start when something else already holds its
+  WebSocket port, and says so — naming the address, the profile, the likely
+  owner, and how to get out of it — instead of running on anyway.
+symptom: >
+  A daemon whose WebSocket port was already taken started normally and looked
+  healthy, but was split in two: the app routes by WebSocket port and attached
+  to the foreign listener, while the CLI routes by the unix socket and talked
+  to the local daemon. Commands sent from the app silently went to the wrong
+  daemon and did nothing. The only trace was one line in the daemon log.
+notes: >
+  The port is derived from the profile name, so the realistic way to hit this
+  is the same profile running on a VM whose listener is forwarded onto host
+  localhost — OrbStack does that automatically whenever the host port is free.
+  Diagnosed live after it cost hours; the bind failure had been logged at INFO
+  and ignored since the HTTP server was introduced.

--- a/changelog.d/ws-bind-fatal-registration-error-surfaces.yaml
+++ b/changelog.d/ws-bind-fatal-registration-error-surfaces.yaml
@@ -1,0 +1,11 @@
+kind: fixed
+area: workspaces
+change: >
+  A workspace registration the daemon refuses now fails immediately with the
+  daemon's own reason, instead of waiting ten seconds and reporting a timeout.
+symptom: >
+  Opening a workspace the daemon rejected — a registration forwarded to a
+  remote endpoint that failed, for instance — sat for ten seconds and then said
+  it had timed out. The daemon had answered right away and said why; the app
+  ignored the answer, so the real reason never reached the screen and the
+  failure looked like the daemon was unreachable.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -122,6 +122,7 @@ type Daemon struct {
 	automationDeliveryHook func(*store.AutomationRun) error
 	listener               net.Listener
 	httpServer             *http.Server
+	httpListener           net.Listener // bound synchronously in Start(); a failure there is fatal
 	httpHandler            http.Handler
 	diagServer             *diag.Server // opt-in loopback pprof/expvar; nil unless ATTN_PPROF set
 	wsHub                  *wsHub
@@ -942,6 +943,12 @@ func (d *Daemon) Start() error {
 			_ = d.httpServer.Shutdown(ctx)
 			cancel()
 		}
+		// Shutdown only closes listeners the server is already serving, so a
+		// failure between the bind and Serve() would otherwise leak the port.
+		if d.httpListener != nil {
+			_ = d.httpListener.Close()
+			d.httpListener = nil
+		}
 		if d.listener != nil {
 			_ = d.listener.Close()
 			d.listener = nil
@@ -978,6 +985,12 @@ func (d *Daemon) Start() error {
 
 	// Create HTTP server for WebSocket (must be created synchronously to avoid race with Stop())
 	d.initHTTPServer()
+	if err := d.listenHTTP(); err != nil {
+		// The daemon is usually spawned detached, where stderr goes nowhere;
+		// the log is the only surface that survives.
+		d.logf("%v", err)
+		return err
+	}
 	go d.runHTTPServer()
 	d.maybeStartDiagServer()
 	d.removeLegacyEmbeddedTailscaleState()
@@ -1636,6 +1649,9 @@ func (d *Daemon) Stop() {
 		defer cancel()
 		d.httpServer.Shutdown(ctx)
 	}
+	if d.httpListener != nil {
+		d.httpListener.Close()
+	}
 	if d.diagServer != nil {
 		_ = d.diagServer.Close()
 	}
@@ -1955,10 +1971,33 @@ func (d *Daemon) initHTTPServer() {
 	}
 }
 
-// runHTTPServer starts listening. Must be called after initHTTPServer().
+// listenHTTP binds the WebSocket address before the daemon reports itself
+// started. Must be called after initHTTPServer(), and its error is fatal: the
+// app finds a daemon by its WebSocket port while the CLI finds one by the unix
+// socket, so a daemon that owns the socket but not the port serves two
+// different daemons to its two clients.
+func (d *Daemon) listenHTTP() error {
+	addr := d.httpServer.Addr
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf(
+			"refusing to start: cannot bind the WebSocket address %s for profile %q: %w. "+
+				"attn derives that port from the profile name, so the usual owner is a daemon for the same profile running somewhere else — "+
+				"notably on a VM whose listener OrbStack forwards onto host localhost while the host port is free. "+
+				"Starting anyway would leave this daemon split-brained: the app routes by WebSocket port and would attach to the foreign listener, "+
+				"the CLI routes by the unix socket and would talk to this process, and every command sent from the app would silently miss these sessions. "+
+				"Free %s (stop whatever holds it, including a forwarding VM) or run this daemon under another profile with ATTN_PROFILE",
+			addr, config.ProfileLabel(), err, addr,
+		)
+	}
+	d.httpListener = listener
+	return nil
+}
+
+// runHTTPServer serves the listener bound by listenHTTP().
 func (d *Daemon) runHTTPServer() {
 	d.logf("WebSocket server starting on ws://%s/ws", d.httpServer.Addr)
-	if err := d.httpServer.ListenAndServe(); err != http.ErrServerClosed {
+	if err := d.httpServer.Serve(d.httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		d.logf("HTTP server error: %v", err)
 	}
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -359,6 +359,45 @@ func TestDaemon_SocketCleanup(t *testing.T) {
 	}
 }
 
+// The WebSocket port is derived from the profile name, so a daemon for the same
+// profile running elsewhere — on a VM whose listener is forwarded onto host
+// localhost, say — can already own it. Binding it has to be fatal: a daemon that
+// owns the unix socket but not the port answers the CLI from this process while
+// the app talks to the foreign listener. Fails if the bind ever goes back to a
+// fire-and-forget goroutine that only logs the failure.
+func TestDaemon_Start_FailsWhenWebSocketPortIsAlreadyBound(t *testing.T) {
+	t.Setenv("ATTN_PROFILE", "bindclash")
+	addr := net.JoinHostPort(config.WSBindAddress(), useFreeWSPort(t))
+
+	foreign, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatalf("occupy %s: %v", addr, err)
+	}
+	defer foreign.Close()
+
+	d := NewForTesting(filepath.Join(shortTempDir(t), "test.sock"))
+	t.Cleanup(d.Stop)
+
+	// Start() blocks on its accept loop once it reaches a running daemon, so race
+	// its return against the daemon's own started signal rather than a deadline.
+	startErr := make(chan error, 1)
+	go func() { startErr <- d.Start() }()
+
+	select {
+	case err := <-startErr:
+		if err == nil {
+			t.Fatal("Start() returned nil while another process held the WebSocket port; a split-brained daemon must be refused")
+		}
+		for _, want := range []string{addr, "bindclash"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("Start() error = %q, want it to name %q", err, want)
+			}
+		}
+	case <-d.startedCh:
+		t.Fatal("daemon reported itself started while another process held the WebSocket port; the bind failure must be fatal, not logged")
+	}
+}
+
 func TestDaemon_PrunesSessionsWithoutLivePTYOnStart(t *testing.T) {
 	useFreeWSPort(t)
 	t.Setenv("ATTN_PTY_BACKEND", "embedded")


### PR DESCRIPTION
Two fixes for a failure mode where remote commands silently die and the app times out with no explanation.

## The problem

attn derives a profile's WebSocket port from the profile name, so the same profile on an OrbStack VM derives the same port — and OrbStack forwards the VM's listener onto host localhost whenever the host port is free. When the local daemon then started, its WS bind failed `EADDRINUSE`, but `runHTTPServer` only logged that at INFO and the daemon kept running. The result is a split brain: the app routes by WS port and attaches to the foreign (VM) daemon, while the CLI routes by the unix socket and talks to the local one. Every command sent from the app ran on the wrong daemon, and the app's workspace-registration wait ignored the resulting error events, so the user saw a generic 10-second timeout instead of anything actionable. This cost hours of misdiagnosis during the kitty-images remote leg (#741): the symptom looks like a registration bug, and nothing errors anywhere visible.

## The fix

**Daemon (`fix(daemon)`):** the WebSocket bind is now synchronous and fatal at startup. `Start()` calls `listenHTTP()` before declaring the daemon ready; a failed bind aborts startup with an error that names the address, the profile, the underlying cause, the likely owner (a same-profile daemon whose listener a VM forwards onto host localhost), the split-brain consequence of continuing, and both ways out (free the port, or run under a different `ATTN_PROFILE`). The error is also written to `daemon.log`, because a detached daemon's stderr goes nowhere. `runHTTPServer` serves the pre-bound listener; the startup-failure path and `Stop()` both close it (a `Shutdown` only closes listeners the server is already serving).

**App (`fix(app)`):** `register_workspace` failures forwarded by the daemon as `command_error` now reject the pending registration promise with the daemon's actual error text, instead of falling through to the 10-second "Workspace registration timed out". `command_error` carries no correlation id, so the handler rejects by key prefix (`register_workspace:`), same as the pre-existing `unregister_workspace` case — over-rejecting a concurrent registration beats a silent timeout. Root cause was that keyed pendings never match the exact-match default arm of `rejectPendingForCommand`.

## Verification

- New daemon test `TestDaemon_Start_FailsWhenWebSocketPortIsAlreadyBound`: occupies the derived port with a foreign listener, asserts `Start()` fails with an error naming the address and the profile, and races the error against `startedCh` to catch a fire-and-forget regression. Passes with `-count=1`.
- New frontend suite `useDaemonSocket.workspaceRegistration.test.tsx`: drives the real hook over a fake WebSocket; a `command_error` for `register_workspace` / `unregister_workspace` settles the pending with the daemon's text. Each test drains the 10s timer so a dropped branch fails on the timeout wording rather than hanging. Full frontend suite green (216 files, 2437 tests).
- Live tier (throwaway profile `bindfx`, port 21940): with the port deliberately occupied, `attn daemon ensure` refused to start and `daemon.log` carries the full refusal naming `127.0.0.1:21940` and the profile; with the port freed, the same ensure started cleanly. Profile cleaned afterwards.
- The frontend change had no packaged-app leg: producing a real forwarded registration error requires a parked remote endpoint (the world torn down after #741), and the rejection mechanism the new case routes into is the same code path the pre-existing `unregister_workspace` prefix case already exercises in production. The unit tests drive the exact wire shape through the real hook.

https://claude.ai/code/session_01RW553W5Upx9sQh6gX69kgV
