### PR TITLE
feat(docstore): a table per collection, with an index per declared field

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,8 +273,12 @@ forgets that position and `--since <RFC3339>` replays from an instant.
   `internal/pty`, not inside the daemon
 - `internal/store`: SQLite plus in-memory cache
 - `internal/bus`: durable event bus (domain facts, per-consumer cursors)
-- `internal/docstore`: document-store query semantics and SQL compilation (no DB
-  handle; `internal/store/documents.go` executes what it compiles)
+- `internal/docstore`: document-store query semantics, SQL compilation, and the
+  physical naming (no DB handle; `internal/store/documents.go` executes what it
+  compiles). A collection is its own table `doc_<id>`, minted from its registry
+  row; a declared field is an indexed generated column over the body. Every
+  identifier the store executes is derived here from an integer or a validated
+  field name — never from caller text
 - `internal/jobs`: durable job queue (retry/backoff, coalescing, commit fence,
   cron entries) — every background duty and every periodic tick runs on it
 - `internal/classifier`: stop-time state classification

--- a/changelog.d/ext-a3.1-doc-store-indexes.yaml
+++ b/changelog.d/ext-a3.1-doc-store-indexes.yaml
@@ -1,0 +1,18 @@
+kind: changed
+area: daemon
+change: >
+  The document store now keeps each collection in its own table, with an
+  indexed column per declared field, so filtering and sorting read an index
+  instead of every document in the collection. Declaring a field still rewrites
+  nothing — the index is built from the bodies already stored — and the query
+  surface, the CLI, and the wire are unchanged. Two behaviours do change: a
+  field's declared type now decides how stored values compare, so a body
+  holding "5" in a number field sorts as the number 5 rather than as text; and
+  a live query whose collection is removed, or redeclared without a field the
+  query uses, now ends with an error saying so instead of quietly reporting an
+  empty result set.
+notes: >
+  The store shipped with no writers, so this replaces its storage rather than
+  migrating it. The measurement that overturned the original scan-first design,
+  and the rejected alternatives including a database file per namespace, are in
+  docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md.

--- a/changelog.d/ext-a3.1-doc-store-indexes.yaml
+++ b/changelog.d/ext-a3.1-doc-store-indexes.yaml
@@ -12,7 +12,8 @@ change: >
   query uses, now ends with an error saying so instead of quietly reporting an
   empty result set.
 notes: >
-  The store shipped with no writers, so this replaces its storage rather than
-  migrating it. The measurement that overturned the original scan-first design,
+  Anything already stored is carried across: declarations, bodies, and
+  timestamps survive, and declared fields come back indexed without being
+  redeclared. The measurement that overturned the original scan-first design,
   and the rejected alternatives including a database file per namespace, are in
   docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md.

--- a/cmd/attn/doc.go
+++ b/cmd/attn/doc.go
@@ -65,17 +65,23 @@ A collection declares which fields may be filtered and sorted on; created_at and
 updated_at are always available and are never declared. Everything else in a
 document body is stored and returned untouched.
 
+A declared field is indexed, so filtering and sorting on it reads an index
+rather than every document. Declaring one rewrites nothing: the index is built
+from the bodies already stored.
+
 commands:
   define <namespace> <collection> [field:type ...]
         declare a collection, replacing any previous declaration. Types are
-        string, number and bool. Redeclaring is how a collection gains a
-        queryable field; no document is rewritten.
+        string, number and bool, and the type decides how stored values compare:
+        a body holding "5" in a number field sorts as the number 5. Redeclaring
+        is how a collection gains or loses a queryable field, and builds or drops
+        that field's index; no document is rewritten.
 
   undefine <namespace> <collection>
         remove a collection's declaration and every document under it.
 
   collections [--json]
-        list every declared collection.
+        list every declared collection, and the indexed field each one offers.
 
   put <namespace> <collection> <id> <body|->
         write a document. The body is a JSON object, or - to read stdin.
@@ -169,7 +175,10 @@ func runDocCollections(args []string) {
 		return
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "NAMESPACE\tCOLLECTION\tQUERYABLE FIELDS")
+	// "indexed" rather than "queryable": everything in a body can be read, and
+	// what declaring buys is that these are the ones a query may name — and the
+	// ones it reaches through an index rather than a scan.
+	fmt.Fprintln(w, "NAMESPACE\tCOLLECTION\tINDEXED FIELDS")
 	for _, c := range result.Collections {
 		names := make([]string, 0, len(c.Fields))
 		for _, f := range c.Fields {

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -181,8 +181,16 @@ locate every record:
 A collection carries a **declaration**: the fields it promises are queryable,
 each with a type. Declaring a field does not constrain what a document may
 contain — undeclared keys are stored and returned untouched — it only says what a
-query may name. `created_at` and `updated_at` are always queryable and are never
+query may name, and it is what the store indexes that field by. The type decides
+how stored values compare, so a body holding `"5"` in a `number` field sorts as
+the number 5. `created_at` and `updated_at` are always queryable and are never
 declared.
+
+Physically a collection is its own table and a declared field an indexed column
+computed from the body, so a declaration is built rather than merely recorded —
+without any document being rewritten. A **live query** therefore ends, with an
+error saying which, when its collection is removed or redeclared without a field
+it uses: the collection can no longer answer the question that was asked.
 
 A **query** is one JSON object: namespace, collection, filters, sort, limit, and
 an optional **after cursor** — the id of the last document of the previous page.

--- a/docs/plans/2026-08-01-extension-platform-roadmap.md
+++ b/docs/plans/2026-08-01-extension-platform-roadmap.md
@@ -94,9 +94,14 @@ a query and receives updates on change.
 - Exit: write → change event → subscribed query update, durable across
   restart; namespace isolation enforced.
 - Plan: [2026-08-03-ext-a3-doc-store.md](2026-08-03-ext-a3-doc-store.md). The
-  gate answered indexes with **declared fields, scanned** — a collection
-  declares what is queryable, and indexes become an invisible optimization
-  later rather than part of the surface.
+  gate answered indexes with **declared fields, scanned**; measurement then
+  overturned scan-first before anything wrote to the store, and
+  **A3.1** rebuilds the physical schema — a table per collection with an
+  indexed virtual column per declared field, inside `attn.db` — with the
+  query surface unchanged:
+  [2026-08-03-ext-a3.1-doc-store-physical-schema.md](2026-08-03-ext-a3.1-doc-store-physical-schema.md).
+  A3.1 lands before A4, because A4 is where extensions start declaring
+  collections.
 
 ### A4. Extension registry + shared runtime
 

--- a/docs/plans/2026-08-03-ext-a3-doc-store.md
+++ b/docs/plans/2026-08-03-ext-a3-doc-store.md
@@ -37,6 +37,14 @@ extensions would share one namespace pool — a collision waiting for A4.
 
 ### 3. Index design: declared fields as the contract, scan-first as the implementation
 
+> **Superseded 2026-08-03 by
+> [A3.1](2026-08-03-ext-a3.1-doc-store-physical-schema.md)** before anything
+> wrote to the store. Measurement showed the 50ms tripwire could never fire at
+> realistic sizes while the real cost — live-query re-runs, per write × per
+> subscription — grew invisibly. The declaration-as-contract half of this
+> answer stands; the scan-first half does not. The paragraphs below record the
+> gate as it was decided.
+
 A collection declares the fields that may be filtered and sorted on. That
 declaration is the API contract and is what keeps the query surface honest.
 Physically, v1 executes with a scan inside `(namespace, collection)` — no
@@ -234,7 +242,10 @@ traffic reaches the WebSocket in this stage.
 ### Deliberately not built
 
 - **Indexes.** Scan-first was the gate's answer; the working set above is the
-  receipt. The declaration is what makes adding them later invisible to callers.
+  receipt. The declaration is what makes adding them later invisible to
+  callers. *Later arrived immediately:*
+  [A3.1](2026-08-03-ext-a3.1-doc-store-physical-schema.md) rebuilds the
+  physical schema with indexes before the store gains its first writer.
 - **Grants.** Namespaces are `owner/name` and enforced as a shape; *who* may
   claim one is A4's registry, which is the thing that knows about authors.
 - **A frontend surface.** A5 owns the UI host. The store's consumers today are

--- a/docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md
+++ b/docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md
@@ -2,8 +2,9 @@
 
 Follow-up to [A3](2026-08-03-ext-a3-doc-store.md), which shipped the document
 store scan-first on one shared `documents` table (migration 88, merged
-2026-08-03 with zero writers). This stage replaces the physical schema before
-anything writes to it. Roadmap:
+2026-08-03 with no attn feature writing to it). This stage replaces the
+physical schema before anything does, carrying across whatever the CLI has
+already stored. Roadmap:
 [2026-08-01-extension-platform-roadmap.md](2026-08-01-extension-platform-roadmap.md).
 
 Status: design approved by Victor 2026-08-03. Implemented 2026-08-03. Lands
@@ -169,10 +170,20 @@ gate; unchanged.
   subscription's schema, a compiled query. Undefine-then-define is an ordinary
   thing to do, so reuse has to be impossible rather than unlikely. Found by
   `TestUndefiningDropsTheStorageAndRedeclaringStartsEmpty`.
-- **Migration 89** drops the unused `documents` table and rebuilds
-  `document_collections` with its minting id. Migration 88 is burned, not
-  renumbered. Zero writers means this is a replace, not a data migration —
-  confirmed against production `~/.attn`, which had not even reached 88.
+- **Migration 89 is an upgrade, not a replace.** No attn feature had reached
+  the v88 store, but `attn doc define` and `attn doc put` shipped with it, so
+  any installed or named profile may hold records someone wrote by hand;
+  "production had not reached migration 88" covers one profile out of an
+  unbounded set. So 89 renames the v88 registry aside, mints a row per
+  declaration, builds each collection's table from the declaration it already
+  had, and moves the bodies in unchanged — a document's body, id, and both
+  timestamps survive, and its declared fields come back queryable and indexed
+  without anyone redeclaring them. Documents stored under an address no
+  declaration names cannot arise through the API (a put resolves the
+  declaration first) but are carried anyway under an empty declaration, since
+  the alternative is deleting them. The carry then checks that every v88
+  document landed somewhere and fails the migration rather than dropping the
+  remainder. Migration 88 is burned, not renumbered.
 - **`internal/docstore` still owns meaning, and still holds no DB handle.**
   `Compile` takes the schema (which now carries the table name) and emits
   column references instead of `json_extract`. The keyset cursor, the
@@ -197,6 +208,8 @@ gate; unchanged.
 Same observable surface as A3 with the type-affinity change above: the full
 A3 test suite green (expectations updated where declared-type normalization
 changes ordering), a planner test asserting an indexed path for
-filter+sort+limit, and live verification of `attn doc`
+filter+sort+limit, an upgrade witness that migrates a populated v88 database
+and finds its declarations, bodies, timestamps, and indexes intact, and live
+verification of `attn doc`
 put/get/query/watch plus define → redeclare → undefine on a throwaway
 profile.

--- a/docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md
+++ b/docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md
@@ -1,0 +1,202 @@
+# A3.1 — Document store physical schema: a table per collection
+
+Follow-up to [A3](2026-08-03-ext-a3-doc-store.md), which shipped the document
+store scan-first on one shared `documents` table (migration 88, merged
+2026-08-03 with zero writers). This stage replaces the physical schema before
+anything writes to it. Roadmap:
+[2026-08-01-extension-platform-roadmap.md](2026-08-01-extension-platform-roadmap.md).
+
+Status: design approved by Victor 2026-08-03. Implemented 2026-08-03. Lands
+before A4, because A4 is where extensions start calling `doc_define`.
+
+## Why the scan-first answer did not survive
+
+A3's gate deferred indexes behind a tripwire: queries past 50ms log the
+collection size, so the case for an index would arrive with its receipt. Two
+measurements broke that reasoning (sqlite 3.51, 40k-row table, 20k documents
+in the target collection, warm):
+
+- A filtered, sorted, limited query scans in **~2ms at 20k documents**. The
+  50ms tripwire would not fire until roughly 100k documents in one
+  collection. The receipt was never going to arrive.
+- The cost that grows is not per-query, it is **per write × per
+  subscription**: a live query re-runs every matching subscription on every
+  committed write. 20 subscriptions on a 20k-document collection make one
+  write cost ~40ms of CPU — every millisecond of it invisible to a per-query
+  threshold. That term scales with exactly what A4/A5 add: more extensions,
+  more subscriptions.
+
+So indexes move from "later, invisibly" to "now, before writers exist". The
+question became what physical shape to index.
+
+## Decision: table per collection, virtual columns per declared field, all inside `attn.db`
+
+```
+attn.db
+├── document_collections            registry: address → minted table name + declaration
+└── doc_<seq> (one per collection)  id TEXT PRIMARY KEY, body TEXT,
+                                    created_at TEXT, updated_at TEXT,
+                                    "f_<field>" GENERATED ALWAYS AS
+                                        (json_extract(body,'$.<field>')) VIRTUAL,
+                                    …one per declared field, each indexed (field, id)
+```
+
+The declaration is still the query contract, and declaring is still not a
+migration for the author — but now the declaration also *is* the physical
+schema, applied by the store as DDL:
+
+- `doc_define` (new collection): `CREATE TABLE` + one virtual column and one
+  `(field, id)` index per declared field, plus the registry row — one
+  transaction (SQLite DDL is transactional).
+- Redeclare: diff old vs new fields; `ALTER TABLE ADD COLUMN … VIRTUAL` and
+  `CREATE INDEX` for arrivals, `DROP INDEX` then `DROP COLUMN` for
+  departures. Virtual columns compute on read, so adding one is O(1); only
+  the index build scans. Documents are never rewritten.
+- `doc_undefine`: `DROP TABLE` + registry delete, one transaction — the
+  space actually returns, instantly.
+
+`created_at`/`updated_at` stay real columns, indexed the same way, queryable
+without declaration as in A3.
+
+### Receipts behind the shape (all sqlite 3.51, measured 2026-08-03)
+
+- **Virtual column + index is used by the planner with plain bound
+  parameters**, as a covering path: `SEARCH … USING INDEX (f_status=?)`. The
+  `DESC` ordering tuple is served by scanning the same index backwards, so
+  one index covers both directions.
+- **Partial indexes on a shared table are dead on arrival**: an expression
+  index with `WHERE namespace=… AND collection=…` is not used, whether the
+  scope arrives as bound parameters or inlined literals.
+- **Indexed query: 0.4ms vs 2ms scan** (filter+sort+limit at 20k docs);
+  sort-only drops from 4ms to ~0.01ms. Write cost with the index present:
+  2000 puts in 3ms total — noise.
+- **`ALTER TABLE ADD COLUMN … STORED` is rejected by SQLite**; only VIRTUAL
+  columns can be added to a populated table. VIRTUAL is what we want anyway —
+  the index stores the computed values, so STORED would pay twice.
+
+### What it does not buy
+
+A query that filters on one field and sorts by a *different* one uses its
+filter's index and then sorts the matches in a temp B-tree — there is no
+composite index, because one index per (filter, sort) pair is combinatorial in
+the number of declared fields. That is still far better than before (the sort
+sees only the matched rows, not the collection), and it is the shape to
+remember if a real consumer ever measures slow: the fix would be a composite
+index for that specific pair, added from the same declaration.
+
+### What the rebuild buys beyond the index (a VIRTUAL column + index is byte-for-byte the same storage as an expression index — raw speed is *not* the differentiator)
+
+- **Blast-radius isolation.** Each collection is its own B-tree. One
+  extension dumping millions of rows cannot bloat another collection's scans
+  or its index.
+- **Per-collection planner statistics.** `ANALYZE` sees each collection's
+  real shape instead of a blend of every extension's data; one skewed
+  collection cannot poison the plans of the rest.
+- **Readable plans, named columns.** Compiled SQL is `WHERE "f_status" = ?`,
+  and `EXPLAIN QUERY PLAN` names the index it used.
+- **Room expression indexes cannot reach**: per-field UNIQUE and CHECK,
+  partial indexes (literals work in DDL where they failed as bound
+  parameters), an FTS5 shadow table per collection if search ever comes.
+
+### Contract change 1: declared type now means type
+
+A virtual column carries its declared affinity, so a body storing
+`"attempts": "5"` in a field declared `number` reads, compares, and sorts as
+the number 5. Under A3 it compared under SQLite's cross-type ordering, which
+put `"10"` before `9`. This is deliberate — the declaration finally means
+something for comparisons — and redeclaring a field's type moves its column so
+the new affinity applies.
+
+`TestPagingWhenStoredValuesDisagreeWithTheDeclaredType` does *not* change: it
+asserts that a paging walk sees each document exactly once and terminates,
+which holds under either ordering. The new behaviour needed its own witness,
+`TestADeclaredTypeDecidesHowStoredValuesCompare`.
+
+### Contract change 2: a live query ends when its collection can no longer answer
+
+The delivery loop re-reads the declaration per delivery instead of capturing
+it, because it can go stale in two ways that both used to mislead the caller.
+Undefining a collection drops its table, and A3 answered the watcher with an
+empty result set — which says "this collection is here and holds nothing" to
+someone whose collection is gone. Redeclaring without a field a live query
+filters on drops that field's column, and the query silently stops meaning
+what was asked. Both now end the subscription with the error naming what
+happened, which is the way out that `undefine` was missing.
+
+## Rejected alternatives
+
+**Expression indexes on the shared A3 table** — works (measured above), and
+is the smallest diff. Rejected because it keeps the shared B-tree and blended
+`ANALYZE` statistics, partial indexes are unusable, and it spends the
+one-time zero-writers window on a patch instead of the shape we want under
+the platform. This was the fallback, not the goal.
+
+**One database file per namespace** — real attractions (file-level blast
+radius, `attn.db` never bloats, uninstall ≈ `rm`, per-file write locking),
+rejected for one decisive cost: **atomicity with the daemon's core**. SQLite
+commits atomically across attached files only in rollback-journal mode; under
+WAL, cross-file transactions decay to per-file atomicity. Production
+`attn.db` runs `journal_mode=delete` today, but WAL is the standard next move
+for a daemon with concurrent readers — building the primitive's integrity on
+"we promise never to enable WAL" is a landmine. The loss bites in three
+places: registry ↔ DDL (repairable with reconcile-on-open), write ↔
+`document.changed` fact (lethal once B-track workflows trigger on document
+changes — a crash yields a write whose workflow never fires), and write ↔ job
+enqueue (documents could never join the jobs queue's commit fence). Even the
+showcase uninstall is two-phase cross-file, where single-file uninstall is
+one transaction. The problems the split solves — contention, bloat — are
+measurable and boundable later; the problem it creates is not.
+
+The door stays open without paying for it now: the registry maps a namespace
+to its tables, so evicting one convicted namespace to its own file later is a
+contained migration done with a receipt in hand.
+
+**Generic `(field, value) → id` side table** — already rejected at the A3
+gate; unchanged.
+
+## Implementation notes
+
+- **Registry-minted table names.** A collection's table is `doc_<id>`, derived
+  from its `document_collections` row id — never by mangling the address, since
+  namespaces contain `/`. Identifiers spliced into SQL come only from that
+  integer or from validated field names (`^[A-Za-z_][A-Za-z0-9_]*$` since A3,
+  prefixed `f_` and quoted). `Compile` refuses a table name that is not minted,
+  which is what makes a schema that did not come from a read of the registry
+  fail loudly instead of composing SQL.
+- **The registry id is `AUTOINCREMENT`.** A plain rowid hands the next
+  declaration the id a dropped one just freed, so `doc_1` can come back naming
+  a different collection while something still holds it — an in-flight
+  subscription's schema, a compiled query. Undefine-then-define is an ordinary
+  thing to do, so reuse has to be impossible rather than unlikely. Found by
+  `TestUndefiningDropsTheStorageAndRedeclaringStartsEmpty`.
+- **Migration 89** drops the unused `documents` table and rebuilds
+  `document_collections` with its minting id. Migration 88 is burned, not
+  renumbered. Zero writers means this is a replace, not a data migration —
+  confirmed against production `~/.attn`, which had not even reached 88.
+- **`internal/docstore` still owns meaning, and still holds no DB handle.**
+  `Compile` takes the schema (which now carries the table name) and emits
+  column references instead of `json_extract`. The keyset cursor, the
+  NULL-branch rules, and the anchor-value subquery survive unchanged — the
+  subquery reads the collection's own table.
+- **Everything above the store is untouched**: wire surface, CLI,
+  `document.changed` fact, one-slot wake channels, `doc_subscribe`
+  register-then-query order. No protocol bump.
+- **Tripwire re-pointed.** The per-query 50ms log stays for one-shot queries,
+  and a second one prices what a live query actually costs: the query's
+  duration times the number of subscriptions the last write woke on that
+  collection, budgeted at one 60Hz frame (16ms). The fan-out already counts
+  the subscriptions it wakes, so it stamps the count on each one rather than
+  having every delivery re-count under a lock — which would make a log line
+  that almost never fires quadratic in the term it exists to watch. Skipping
+  re-runs whose result provably cannot have changed is the door this opens
+  later; it needs Go-side filter evaluation, a second implementation of filter
+  semantics, so it stays shut until this tripwire says otherwise.
+
+## Exit criteria
+
+Same observable surface as A3 with the type-affinity change above: the full
+A3 test suite green (expectations updated where declared-type normalization
+changes ordering), a planner test asserting an indexed path for
+filter+sort+limit, and live verification of `attn doc`
+put/get/query/watch plus define → redeclare → undefine on a throwaway
+profile.

--- a/internal/daemon/documents.go
+++ b/internal/daemon/documents.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync/atomic"
 	"time"
 
 	"github.com/victorarias/attn/internal/bus"
@@ -34,15 +35,23 @@ import (
 // See docs/plans/2026-08-03-ext-a3-doc-store.md.
 
 // docSubscription is one caller watching one query.
+// It deliberately holds no declaration: the delivery loop re-reads it, because
+// a captured one goes stale exactly when it matters — when the collection is
+// undefined or redeclared out from under the query.
 type docSubscription struct {
 	id     string
 	query  docstore.Query
-	schema docstore.CollectionSchema
 	target string
 	// wake holds at most one pending nudge. A full channel means "already told,
 	// not yet served", and dropping the extra is correct because the delivery it
 	// would have caused is the same delivery the pending one will cause.
 	wake chan struct{}
+	// siblings is how many subscriptions the last write woke on this collection,
+	// stamped by the fan-out because that is the one place already counting them.
+	// The delivery goroutine reads it to price the write, and reading it from
+	// here rather than counting again keeps a log line that almost never fires
+	// off the delivery path's lock.
+	siblings atomic.Int64
 }
 
 // documentChanged is the fact's payload. It carries the address in parts so a
@@ -100,6 +109,7 @@ func (d *Daemon) wakeDocumentSubscriptions(ev bus.Event) {
 	d.docSubsMu.Unlock()
 
 	for _, sub := range woken {
+		sub.siblings.Store(int64(len(woken)))
 		select {
 		case sub.wake <- struct{}{}:
 		default:
@@ -107,7 +117,7 @@ func (d *Daemon) wakeDocumentSubscriptions(ev bus.Event) {
 	}
 }
 
-func (d *Daemon) addDocSubscription(q docstore.Query, schema docstore.CollectionSchema) *docSubscription {
+func (d *Daemon) addDocSubscription(q docstore.Query) *docSubscription {
 	d.docSubsMu.Lock()
 	defer d.docSubsMu.Unlock()
 	if d.docSubs == nil {
@@ -117,7 +127,6 @@ func (d *Daemon) addDocSubscription(q docstore.Query, schema docstore.Collection
 	sub := &docSubscription{
 		id:     fmt.Sprintf("docsub-%d", d.docSubsSeq),
 		query:  q,
-		schema: schema,
 		target: q.Target(),
 		wake:   make(chan struct{}, 1),
 	}
@@ -147,7 +156,7 @@ func (d *Daemon) documentSubscriptionCount() int {
 func (d *Daemon) compileDocQuery(q docstore.Query, schema docstore.CollectionSchema) (docstore.Compiled, error) {
 	var anchor *docstore.Document
 	if q.After != "" {
-		doc, found, err := d.store.GetDocument(q.Namespace, q.Collection, q.After)
+		doc, found, err := d.store.GetDocument(schema, q.After)
 		if err != nil {
 			return docstore.Compiled{}, err
 		}
@@ -158,41 +167,79 @@ func (d *Daemon) compileDocQuery(q docstore.Query, schema docstore.CollectionSch
 	return q.Compile(schema, anchor)
 }
 
-// runDocQuery compiles and runs a query, returning its documents on the wire.
-func (d *Daemon) runDocQuery(q docstore.Query, schema docstore.CollectionSchema) ([]protocol.StoredDocument, error) {
+// runDocQuery compiles and runs a query, returning its documents on the wire
+// and how long the statement took. The caller decides what a slow one means:
+// once for a one-shot query, per write for a live one.
+func (d *Daemon) runDocQuery(q docstore.Query, schema docstore.CollectionSchema) ([]protocol.StoredDocument, time.Duration, error) {
 	if d.store == nil {
-		return nil, fmt.Errorf("no database")
+		return nil, 0, fmt.Errorf("no database")
 	}
 	compiled, err := d.compileDocQuery(q, schema)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	started := time.Now()
 	docs, err := d.store.QueryDocuments(compiled)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	d.logSlowDocQuery(q, time.Since(started))
-	return storedDocumentsToProtocol(docs), nil
+	return storedDocumentsToProtocol(docs), time.Since(started), nil
 }
 
-// slowDocQuery is the point past which a query's duration is worth a line in the
-// log. v1 answers queries by scanning a collection, deliberately, because
-// nothing has measured a need for secondary indexes. This is the tripwire that
-// produces that measurement: it names the collection and how many documents were
-// scanned, so the case for an index arrives with its receipt instead of a hunch.
-const slowDocQuery = 50 * time.Millisecond
+// Two tripwires, because a document query has two costs and only one of them is
+// visible in a single query's duration.
+//
+// slowDocQuery is the coarse one: a one-shot query that takes this long is
+// pathological now that every declared field is indexed, and the log names the
+// collection size so the diagnosis starts with the receipt.
+//
+// slowDocFanOut is the one that matters. A live query re-runs on every committed
+// write to its collection, so the daemon's real cost is one query multiplied by
+// the number of subscriptions watching — a term no per-query threshold can see,
+// because each of those queries is individually fast. The budget is one 60Hz
+// frame: attn renders GPU terminals beside agents that run all day, so a single
+// document write quietly costing a frame's worth of CPU in background query work
+// is a defect worth a line in the log. A healthy fan-out is microseconds, which
+// makes this a tripwire rather than a threshold — only something broken, or
+// something that has outgrown this design, ever feels it.
+const (
+	slowDocQuery  = 50 * time.Millisecond
+	slowDocFanOut = 16 * time.Millisecond
+)
 
-func (d *Daemon) logSlowDocQuery(q docstore.Query, took time.Duration) {
+func (d *Daemon) logSlowDocQuery(schema docstore.CollectionSchema, took time.Duration) {
 	if took < slowDocQuery {
 		return
 	}
-	count, err := d.store.CountDocuments(q.Namespace, q.Collection)
-	if err != nil {
-		count = -1
+	d.logf("docstore: %s/%s query took %s over %d documents (slow past %s)",
+		schema.Namespace, schema.Collection, took.Round(time.Millisecond),
+		d.documentCountFor(schema), slowDocQuery)
+}
+
+// logSlowDocFanOut reports what one write to this collection costs across every
+// subscription watching it, which is the number that grows as extensions arrive.
+func (d *Daemon) logSlowDocFanOut(sub *docSubscription, schema docstore.CollectionSchema, took time.Duration) {
+	// The first delivery answers the subscribe rather than a write, so it has
+	// woken nobody and prices as one.
+	subs := sub.siblings.Load()
+	if subs < 1 {
+		subs = 1
 	}
-	d.logf("docstore: %s/%s query took %s over %d documents (slow past %s) — a collection this size may want an index",
-		q.Namespace, q.Collection, took.Round(time.Millisecond), count, slowDocQuery)
+	perWrite := took * time.Duration(subs)
+	if perWrite < slowDocFanOut {
+		return
+	}
+	d.logf("docstore: %s/%s live query took %s over %d documents; %d subscription(s) make one write to this collection cost about %s (slow past %s)",
+		schema.Namespace, schema.Collection, took.Round(time.Millisecond),
+		d.documentCountFor(schema), subs, perWrite.Round(time.Millisecond), slowDocFanOut)
+}
+
+func (d *Daemon) documentCountFor(schema docstore.CollectionSchema) int {
+	count, err := d.store.CountDocuments(schema)
+	if err != nil {
+		return -1
+	}
+	return count
 }
 
 // collectionFor reads a collection's declaration, turning "never declared" into
@@ -286,7 +333,8 @@ func (d *Daemon) handleDocCollections(conn net.Conn, _ *protocol.DocCollectionsM
 }
 
 func (d *Daemon) handleDocPut(conn net.Conn, msg *protocol.DocPutMessage) {
-	if _, err := d.collectionFor(msg.Namespace, msg.Collection); err != nil {
+	schema, err := d.collectionFor(msg.Namespace, msg.Collection)
+	if err != nil {
 		d.sendError(conn, err.Error())
 		return
 	}
@@ -298,7 +346,7 @@ func (d *Daemon) handleDocPut(conn net.Conn, msg *protocol.DocPutMessage) {
 		d.sendError(conn, err.Error())
 		return
 	}
-	if err := d.store.PutDocument(msg.Namespace, msg.Collection, msg.ID, []byte(msg.Body), time.Now()); err != nil {
+	if err := d.store.PutDocument(*schema, msg.ID, []byte(msg.Body), time.Now()); err != nil {
 		d.sendError(conn, err.Error())
 		return
 	}
@@ -310,11 +358,12 @@ func (d *Daemon) handleDocPut(conn net.Conn, msg *protocol.DocPutMessage) {
 }
 
 func (d *Daemon) handleDocGet(conn net.Conn, msg *protocol.DocGetMessage) {
-	if _, err := d.collectionFor(msg.Namespace, msg.Collection); err != nil {
+	schema, err := d.collectionFor(msg.Namespace, msg.Collection)
+	if err != nil {
 		d.sendError(conn, err.Error())
 		return
 	}
-	doc, found, err := d.store.GetDocument(msg.Namespace, msg.Collection, msg.ID)
+	doc, found, err := d.store.GetDocument(*schema, msg.ID)
 	if err != nil {
 		d.sendError(conn, err.Error())
 		return
@@ -328,11 +377,12 @@ func (d *Daemon) handleDocGet(conn net.Conn, msg *protocol.DocGetMessage) {
 }
 
 func (d *Daemon) handleDocDelete(conn net.Conn, msg *protocol.DocDeleteMessage) {
-	if _, err := d.collectionFor(msg.Namespace, msg.Collection); err != nil {
+	schema, err := d.collectionFor(msg.Namespace, msg.Collection)
+	if err != nil {
 		d.sendError(conn, err.Error())
 		return
 	}
-	existed, err := d.store.DeleteDocument(msg.Namespace, msg.Collection, msg.ID)
+	existed, err := d.store.DeleteDocument(*schema, msg.ID)
 	if err != nil {
 		d.sendError(conn, err.Error())
 		return
@@ -361,18 +411,21 @@ func (d *Daemon) handleDocQuery(conn net.Conn, msg *protocol.DocQueryMessage) {
 		d.sendError(conn, err.Error())
 		return
 	}
-	docs, err := d.runDocQuery(q, *schema)
+	docs, took, err := d.runDocQuery(q, *schema)
 	if err != nil {
 		d.sendError(conn, err.Error())
 		return
 	}
+	d.logSlowDocQuery(*schema, took)
 	d.sendDocResponse(conn, protocol.Response{Ok: true, DocQueryResult: &protocol.DocQueryResult{Documents: docs}})
 }
 
 // handleDocSubscribe is the only handler that keeps its connection. It writes
 // the current result set immediately — a subscriber must be able to render from
 // one round trip, which is what makes an extension UI's remount cheap — and then
-// a fresh one every time a write to the collection could have changed it.
+// a fresh one every time a write to the collection could have changed it. It
+// ends when the caller disconnects, or when the collection stops being able to
+// answer the query at all.
 func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMessage) {
 	q, err := documentQueryFromProtocol(msg.Query)
 	if err != nil {
@@ -394,7 +447,7 @@ func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMes
 	// Registered before the first query runs. The other order drops a write that
 	// lands in between; this order can only cause one redundant delivery, and a
 	// delivery is the whole result set, so a redundant one costs nothing.
-	sub := d.addDocSubscription(q, *schema)
+	sub := d.addDocSubscription(q)
 	defer d.removeDocSubscription(sub.id)
 
 	// The caller never speaks again after subscribing, so anything the read
@@ -407,11 +460,26 @@ func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMes
 
 	encoder := json.NewEncoder(conn)
 	for revision := 1; ; revision++ {
-		docs, err := d.runDocQuery(q, *schema)
+		// The declaration is re-read per delivery rather than captured, because
+		// it can go out from under a subscription in two ways and both have to
+		// end the subscription rather than mislead it. Undefining drops the
+		// collection's table, and an empty result set would tell a watcher the
+		// collection is still there holding nothing; redeclaring without a field
+		// this query uses drops that field's column, and the query stops meaning
+		// what the caller asked. Either way the caller is told which, and the
+		// subscription ends instead of hanging on a collection it can never
+		// serve again.
+		live, err := d.collectionFor(q.Namespace, q.Collection)
 		if err != nil {
 			d.sendError(conn, err.Error())
 			return
 		}
+		docs, took, err := d.runDocQuery(q, *live)
+		if err != nil {
+			d.sendError(conn, err.Error())
+			return
+		}
+		d.logSlowDocFanOut(sub, *live, took)
 		resp := protocol.Response{
 			Ok:                 true,
 			DocSubscribeResult: &protocol.DocSubscribeResult{Revision: revision, Documents: docs},

--- a/internal/daemon/documents_test.go
+++ b/internal/daemon/documents_test.go
@@ -103,10 +103,7 @@ func subscribe(t *testing.T, d *Daemon, q protocol.DocumentQuery) *liveQuery {
 // these tests wait on a real signal rather than on a duration.
 func (lq *liveQuery) next(t *testing.T) *protocol.DocSubscribeResult {
 	t.Helper()
-	var resp protocol.Response
-	if err := lq.dec.Decode(&resp); err != nil {
-		t.Fatalf("decode delivery: %v", err)
-	}
+	resp := lq.nextRaw(t)
 	if !resp.Ok {
 		t.Fatalf("delivery carried an error: %v", protocol.Deref(resp.Error))
 	}
@@ -114,6 +111,17 @@ func (lq *liveQuery) next(t *testing.T) *protocol.DocSubscribeResult {
 		t.Fatal("delivery carried no result")
 	}
 	return resp.DocSubscribeResult
+}
+
+// nextRaw reads one delivery without requiring it to have succeeded, for the
+// cases where the end of a subscription is the thing under test.
+func (lq *liveQuery) nextRaw(t *testing.T) protocol.Response {
+	t.Helper()
+	var resp protocol.Response
+	if err := lq.dec.Decode(&resp); err != nil {
+		t.Fatalf("decode delivery: %v", err)
+	}
+	return resp
 }
 
 func ids(result *protocol.DocSubscribeResult) []string {
@@ -373,8 +381,15 @@ func TestRemovingACollectionReachesItsLiveQueries(t *testing.T) {
 	if n := resp.DocUndefineResult.DocumentsRemoved; n != 1 {
 		t.Fatalf("removed %d documents, want 1", n)
 	}
-	if got := ids(lq.next(t)); len(got) != 0 {
-		t.Fatalf("after the collection went = %v, want empty", got)
+	// The watcher is told the collection is gone, not handed an empty list: an
+	// empty result set claims the collection is still there holding nothing, and
+	// leaves the caller watching an address that can never answer again.
+	final := lq.nextRaw(t)
+	if final.Ok {
+		t.Fatalf("after the collection went, delivery = %+v, want an error", final)
+	}
+	if msg := protocol.Deref(final.Error); !strings.Contains(msg, "is not declared") {
+		t.Fatalf("error does not say the collection is gone: %q", msg)
 	}
 }
 
@@ -432,5 +447,46 @@ func TestAnAfterCursorToADeletedDocumentIsReported(t *testing.T) {
 	}
 	if err := protocol.Deref(resp.Error); !strings.Contains(err, "b") || !strings.Contains(err, "no longer exists") {
 		t.Fatalf("error = %q", err)
+	}
+}
+
+// The other way a subscription's collection can move under it: a redeclare that
+// drops a field the live query filters on. The field's column goes with it, so
+// continuing would mean answering a question the collection no longer offers.
+// The watcher is told which field, the same way a fresh query would be.
+func TestRedeclaringWithoutAFieldEndsTheLiveQueriesUsingIt(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+
+	q := testQuery()
+	q.Filters = []protocol.DocumentFilter{{Field: "status", Op: "eq", ValueJson: `"pending"`}}
+	lq := subscribe(t, d, q)
+	if got := ids(lq.next(t)); !equalStrings(got, []string{"a"}) {
+		t.Fatalf("initial = %v, want [a]", got)
+	}
+
+	// Redeclared with no queryable fields at all.
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocDefine(c, &protocol.DocDefineMessage{
+			Cmd: protocol.CmdDocDefine,
+			Schema: protocol.DocumentCollectionSchema{
+				Namespace: testDocNS, Collection: testDocColl,
+			},
+		})
+	})
+	if !resp.Ok {
+		t.Fatalf("redeclare: %v", protocol.Deref(resp.Error))
+	}
+	// A write is what wakes the subscription; the redeclare alone is not a
+	// document change.
+	putDoc(t, d, "b", `{"status":"pending"}`)
+
+	final := lq.nextRaw(t)
+	if final.Ok {
+		t.Fatalf("delivery after the field went = %+v, want an error", final)
+	}
+	if msg := protocol.Deref(final.Error); !strings.Contains(msg, "status") {
+		t.Fatalf("error does not name the field that went: %q", msg)
 	}
 }

--- a/internal/docstore/docstore.go
+++ b/internal/docstore/docstore.go
@@ -19,6 +19,12 @@
 // `owner/name` string; who may write under which owner is enforced where the
 // namespace is granted, not here.
 //
+// A collection is physically its own table, and a declared field an indexed
+// generated column in it, so this package also owns the naming those identifiers
+// use — see TableName and FieldColumn, and
+// docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md. The store builds
+// its DDL from those names; it does not invent any.
+//
 // See docs/plans/2026-08-03-ext-a3-doc-store.md.
 package docstore
 
@@ -55,9 +61,10 @@ const (
 )
 
 // FieldType is what a declared field holds. The type is not decoration: it
-// decides how a filter's bound is bound to the statement, and comparing a number
+// decides how a filter's bound is bound to the statement — comparing a number
 // field against a string bound would otherwise match nothing at all rather than
-// failing.
+// failing — and it is the affinity of the column the field is stored through,
+// so it also decides how two stored values compare with each other.
 type FieldType string
 
 const (
@@ -88,18 +95,26 @@ type FieldSpec struct {
 }
 
 // CollectionSchema is a collection's declaration: which fields may be filtered
-// and sorted on. It is the API contract, and it is deliberately not a storage
-// schema — a document's body is arbitrary JSON, and an undeclared field is
-// stored and read back untouched. Declaring a field says "you may query this",
-// not "this must exist".
+// and sorted on. It is the API contract for queries, and it is deliberately not
+// a schema the body must satisfy — a document's body is arbitrary JSON, an
+// undeclared key is stored and read back untouched, and a declared field the
+// body omits is simply absent. Declaring a field says "you may query this", not
+// "this must exist".
 //
-// v1 executes queries by scanning within a collection, so a declaration creates
-// no index today. It is still the contract, because it is what lets indexes
-// appear later without any author-facing change.
+// Physically a declared field is an indexed generated column over the body, so
+// the declaration is also what the store builds. Adding one is DDL and rewrites
+// no document; see docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md.
+//
+// Table is the collection's own table, minted by the store from the
+// declaration's row id and filled in on read. It is not part of the declaration
+// a caller writes, and Compile refuses a schema whose Table is not a minted
+// name — that check is the whole defence for the one identifier in the compiled
+// SQL that does not come from a validated field name.
 type CollectionSchema struct {
 	Namespace  string      `json:"namespace"`
 	Collection string      `json:"collection"`
 	Fields     []FieldSpec `json:"fields"`
+	Table      string      `json:"-"`
 }
 
 // Filter is one comparison against a declared or reserved field.
@@ -148,20 +163,18 @@ type Document struct {
 	UpdatedAt time.Time       `json:"updated_at"`
 }
 
-// Compiled is a validated query as SQL. Where and Order are fragments the store
-// splices into its own SELECT; Args binds Where's placeholders in order.
+// Compiled is a validated query as SQL. Table is the collection's table, Where
+// and Order are fragments the store splices into its own SELECT, and Args binds
+// Where's placeholders in order. Where is empty when nothing constrains the
+// query: the table already holds exactly one collection, so "everything" needs
+// no predicate at all.
 type Compiled struct {
+	Table string
 	Where string
 	Args  []any
 	Order string
 	Limit int
 }
-
-// documentsTable is the table the compiled fragments belong to. Compile already
-// names that table's columns — body, id, namespace, collection — and the after
-// cursor additionally reads one row back out of it, so the name lives here
-// beside them rather than being threaded in from the store.
-const documentsTable = "documents"
 
 var (
 	// A namespace is `owner/name`: the owner segment is the isolation class a
@@ -171,8 +184,82 @@ var (
 	collectionRe  = regexp.MustCompile(`^` + namePart + `$`)
 	documentIDRe  = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
 	fieldNameRe   = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+	tableNameRe   = regexp.MustCompile(`^doc_[1-9][0-9]*$`)
 	reservedField = map[string]bool{FieldCreatedAt: true, FieldUpdatedAt: true}
 )
+
+// Physical naming. A collection is one table and a declared field is one
+// generated column in it, so these names end up spliced into SQL as
+// identifiers. Every one of them is derived here from something already
+// checked — an integer row id, or a field name matching fieldNameRe — so there
+// is no caller-supplied text in any identifier the store executes.
+const (
+	// tablePrefix keeps minted tables recognisable in a schema dump and out of
+	// the way of attn's own tables.
+	tablePrefix = "doc_"
+	// fieldColumnPrefix keeps a declared field from colliding with the columns
+	// the store owns: a collection may declare a field called `id` or `body`
+	// without shadowing either.
+	fieldColumnPrefix = "f_"
+)
+
+// TableName is the table holding a collection's documents, derived from its
+// declaration's row id. Derived rather than built from the address because a
+// namespace contains a slash and a collection name is caller-chosen: minting
+// from an integer means no identifier is ever a function of caller text.
+func TableName(id int64) string {
+	return fmt.Sprintf("%s%d", tablePrefix, id)
+}
+
+// ValidateTableName accepts a minted table name. Compile calls it before
+// splicing, so a schema that reached the compiler from anywhere but the store's
+// own read path fails loudly instead of composing SQL.
+func ValidateTableName(name string) error {
+	if name == "" {
+		return fmt.Errorf("docstore: collection has no table; a declaration must be read from the store before it can be queried")
+	}
+	if !tableNameRe.MatchString(name) {
+		return fmt.Errorf("docstore: %q is not a minted table name", name)
+	}
+	return nil
+}
+
+// FieldColumn is the generated column a declared field is queried through.
+func FieldColumn(field string) string {
+	return fieldColumnPrefix + field
+}
+
+// FieldExpression is what that column computes: the field read out of the body.
+// The store builds its DDL from this, and it is the reason a declaration
+// rewrites no document — the column is VIRTUAL, so it exists for every document
+// already stored the moment it is added.
+func FieldExpression(field string) string {
+	return "json_extract(body, '$." + field + "')"
+}
+
+// ColumnAffinity is the SQLite affinity a declared type maps to. This is where
+// the declared type stops being decoration: a body storing "5" in a number
+// field reads, compares, and orders as the number 5, because the column that
+// carries it is NUMERIC. A value with no such reading — an array, an object —
+// keeps its JSON text, which is what makes those still orderable rather than an
+// error.
+func ColumnAffinity(t FieldType) string {
+	switch t {
+	case FieldNumber:
+		return "NUMERIC"
+	case FieldBool:
+		return "INTEGER"
+	default:
+		return "TEXT"
+	}
+}
+
+// quoteIdent renders an identifier for SQL. Every identifier here already
+// matches a validating pattern, so this is belt-and-braces rather than the
+// defence — but it is what makes a field named like a keyword harmless.
+func quoteIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
 
 // ValidateNamespace accepts an `owner/name` namespace. The store does not care
 // which owners exist; it cares that the string is a well-formed two-part name it
@@ -212,9 +299,9 @@ func ValidateDocumentID(id string) error {
 }
 
 // Validate checks a collection declaration. Field names are restricted to plain
-// identifiers, which is also what makes the compiled JSON path safe to build by
-// concatenation: there is no quoting to get wrong because there is nothing to
-// quote.
+// identifiers because a declared field becomes both a JSON path and a column
+// name in the collection's table: this is the check that keeps every identifier
+// the store goes on to execute free of caller-shaped text.
 func (s CollectionSchema) Validate() error {
 	if err := ValidateNamespace(s.Namespace); err != nil {
 		return err
@@ -292,9 +379,15 @@ func (q Query) Compile(schema CollectionSchema, anchor *Document) (Compiled, err
 		return Compiled{}, fmt.Errorf("docstore: query targets %s/%s but was compiled against the declaration for %s/%s",
 			q.Namespace, q.Collection, schema.Namespace, schema.Collection)
 	}
+	if err := ValidateTableName(schema.Table); err != nil {
+		return Compiled{}, err
+	}
 
-	where := []string{"namespace = ?", "collection = ?"}
-	args := []any{q.Namespace, q.Collection}
+	// No namespace or collection predicate: the table is the collection. That
+	// isolation is structural — there is no statement here that could reach
+	// another namespace's documents even if it were built wrong.
+	var where []string
+	var args []any
 
 	for _, f := range q.Filters {
 		op, ok := opSQL[f.Op]
@@ -336,7 +429,7 @@ func (q Query) Compile(schema CollectionSchema, anchor *Document) (Compiled, err
 	}
 
 	if q.After != "" || anchor != nil {
-		clause, cursorArgs, err := q.afterTuple(sortExpr, desc, anchor)
+		clause, cursorArgs, err := q.afterTuple(schema.Table, sortExpr, desc, anchor)
 		if err != nil {
 			return Compiled{}, err
 		}
@@ -355,7 +448,13 @@ func (q Query) Compile(schema CollectionSchema, anchor *Document) (Compiled, err
 			q.Namespace, q.Collection, limit, MaxLimit)
 	}
 
-	return Compiled{Where: strings.Join(where, " AND "), Args: args, Order: order, Limit: limit}, nil
+	return Compiled{
+		Table: schema.Table,
+		Where: strings.Join(where, " AND "),
+		Args:  args,
+		Order: order,
+		Limit: limit,
+	}, nil
 }
 
 // afterTuple compiles the After cursor: "strictly past the anchor in the
@@ -372,7 +471,7 @@ func (q Query) Compile(schema CollectionSchema, anchor *Document) (Compiled, err
 // may be queried, not what a document must contain — and NULL compares as
 // nothing at all, so it is branched on rather than bound. SQLite sorts NULL
 // first, so in ASC every non-NULL row is past a NULL anchor and in DESC none is.
-func (q Query) afterTuple(sortExpr string, desc bool, anchor *Document) (string, []any, error) {
+func (q Query) afterTuple(table, sortExpr string, desc bool, anchor *Document) (string, []any, error) {
 	if q.After == "" {
 		return "", nil, fmt.Errorf("docstore: %s/%s was compiled with a cursor document but no after id", q.Namespace, q.Collection)
 	}
@@ -410,14 +509,14 @@ func (q Query) afterTuple(sortExpr string, desc bool, anchor *Document) (string,
 	// The anchor's sort value is read back out of the table rather than bound
 	// from Go. A declared field says what may be queried, not what a document
 	// must hold, so a "number" field may legitimately contain an array or an
-	// object — values that have no bindable Go equivalent, and that json_extract
-	// yields as JSON text. Reading the value through the same expression the
-	// ORDER BY uses makes the cursor compare exactly what the ordering compares,
-	// for every JSON shape, with no Go-side reconstruction to disagree with
-	// SQLite's own rendering or type ordering. The subquery is uncorrelated, so
+	// object — values that have no bindable Go equivalent, and that the column
+	// carries as JSON text. Reading the value through the same column the ORDER
+	// BY uses makes the cursor compare exactly what the ordering compares, for
+	// every JSON shape and under the column's own affinity, with no Go-side
+	// reconstruction to disagree with either. The subquery is uncorrelated, so
 	// it is evaluated once per statement.
-	value := "(SELECT " + sortExpr + " FROM " + documentsTable + " WHERE namespace = ? AND collection = ? AND id = ?)"
-	valueArgs := []any{q.Namespace, q.Collection, q.After}
+	value := "(SELECT " + sortExpr + " FROM " + table + " WHERE id = ?)"
+	valueArgs := []any{q.After}
 
 	clause := "(" + sortExpr + " > " + value + " OR (" + sortExpr + " = " + value + " AND id > ?))"
 	if desc {
@@ -455,9 +554,11 @@ func (q Query) anchorSortIsNull(anchor *Document) (bool, error) {
 	return value == nil, nil
 }
 
-// fieldExpr resolves a field reference to SQL. A reserved name is a real column;
-// anything else must be declared, and reads out of the body. use names what the
-// reference was for, so the error says whether the filter or the sort is wrong.
+// fieldExpr resolves a field reference to SQL. A reserved name is one of the
+// store's own stamped columns and is written literally; anything else must be
+// declared, and resolves to that field's generated column, quoted because its
+// name descends from caller text. use names what the reference was for, so the
+// error says whether the filter or the sort is wrong.
 func (q Query) fieldExpr(schema CollectionSchema, name, use string) (string, FieldSpec, error) {
 	if name == "" {
 		return "", FieldSpec{}, fmt.Errorf("docstore: %s/%s has a %s with no field name", q.Namespace, q.Collection, use)
@@ -470,7 +571,7 @@ func (q Query) fieldExpr(schema CollectionSchema, name, use string) (string, Fie
 		return "", FieldSpec{}, fmt.Errorf("docstore: %s/%s cannot %s on %q, which the collection does not declare (queryable: %s)",
 			q.Namespace, q.Collection, use, name, schema.declaredNames())
 	}
-	return "json_extract(body, '$." + name + "')", spec, nil
+	return quoteIdent(FieldColumn(name)), spec, nil
 }
 
 // bindValue converts a filter bound to what the statement should carry, and

--- a/internal/docstore/docstore_test.go
+++ b/internal/docstore/docstore_test.go
@@ -15,6 +15,9 @@ func requestsSchema() CollectionSchema {
 			{Name: "attempts", Type: FieldNumber},
 			{Name: "urgent", Type: FieldBool},
 		},
+		// As the store hands a declaration back: a minted table, without which
+		// nothing compiles.
+		Table: "doc_12",
 	}
 }
 
@@ -41,12 +44,17 @@ func TestPendingRequestsNewestFirstCompiles(t *testing.T) {
 		Sort:       &Sort{Field: FieldCreatedAt, Desc: true},
 		Limit:      20,
 	})
-	want := "namespace = ? AND collection = ? AND json_extract(body, '$.status') = ?"
+	want := `"f_status" = ?`
 	if c.Where != want {
 		t.Fatalf("where = %q, want %q", c.Where, want)
 	}
-	if got := []any{"ext/approval-gate", "requests", "pending"}; !equalArgs(c.Args, got) {
+	// No namespace or collection predicate: the table is the collection, so the
+	// only argument left is the caller's bound.
+	if got := []any{"pending"}; !equalArgs(c.Args, got) {
 		t.Fatalf("args = %v, want %v", c.Args, got)
+	}
+	if c.Table != "doc_12" {
+		t.Fatalf("table = %q", c.Table)
 	}
 	if c.Order != "created_at DESC, id DESC" {
 		t.Fatalf("order = %q", c.Order)
@@ -66,7 +74,7 @@ func TestEverySortIsMadeTotalByTheDocumentID(t *testing.T) {
 		Collection: "requests",
 		Sort:       &Sort{Field: "status"},
 	})
-	if c.Order != "json_extract(body, '$.status') ASC, id ASC" {
+	if c.Order != `"f_status" ASC, id ASC` {
 		t.Fatalf("order = %q", c.Order)
 	}
 	c = mustCompile(t, Query{
@@ -74,7 +82,7 @@ func TestEverySortIsMadeTotalByTheDocumentID(t *testing.T) {
 		Collection: "requests",
 		Sort:       &Sort{Field: "status", Desc: true},
 	})
-	if c.Order != "json_extract(body, '$.status') DESC, id DESC" {
+	if c.Order != `"f_status" DESC, id DESC` {
 		t.Fatalf("descending order = %q", c.Order)
 	}
 	// And an unsorted query is still deterministic.
@@ -177,10 +185,10 @@ func TestBoundsBindTheWayJSONExtractCompares(t *testing.T) {
 			{Field: "urgent", Op: OpEq, Value: true},
 		},
 	})
-	if got := c.Args[2]; got != float64(3) {
+	if got := c.Args[0]; got != float64(3) {
 		t.Fatalf("int bound = %#v, want float64(3)", got)
 	}
-	if got := c.Args[3]; got != 1 {
+	if got := c.Args[1]; got != 1 {
 		t.Fatalf("true bound = %#v, want 1", got)
 	}
 }
@@ -202,7 +210,7 @@ func TestAQueryRoundTripsThroughJSON(t *testing.T) {
 	if c.Limit != 5 || c.Order != "created_at DESC, id DESC" {
 		t.Fatalf("compiled = %+v", c)
 	}
-	if got := c.Args[2]; got != float64(2) {
+	if got := c.Args[0]; got != float64(2) {
 		t.Fatalf("json number bound = %#v", got)
 	}
 }
@@ -241,8 +249,8 @@ func TestNamespaceShapeIsTwoParts(t *testing.T) {
 	}
 }
 
-// A field name is a plain identifier, which is also what makes the compiled JSON
-// path safe: there is no quoting to get wrong because there is nothing to quote.
+// A field name is a plain identifier, which is what keeps both things it becomes
+// safe: a JSON path in the column's expression, and the column's own name.
 func TestFieldNamesAreIdentifiersSoThePathNeedsNoQuoting(t *testing.T) {
 	for _, bad := range []string{"has space", "with'quote", "a.b", "$x", ""} {
 		s := requestsSchema()
@@ -299,14 +307,15 @@ func TestTheAfterCursorComparesTheWholeOrderingTuple(t *testing.T) {
 		Sort:       &Sort{Field: "attempts"},
 		After:      "b",
 	}, anchor)
-	value := "(SELECT json_extract(body, '$.attempts') FROM documents WHERE namespace = ? AND collection = ? AND id = ?)"
-	want := "(json_extract(body, '$.attempts') > " + value + " OR (json_extract(body, '$.attempts') = " + value + " AND id > ?))"
+	value := `(SELECT "f_attempts" FROM doc_12 WHERE id = ?)`
+	want := `("f_attempts" > ` + value + ` OR ("f_attempts" = ` + value + ` AND id > ?))`
 	if !strings.HasSuffix(c.Where, want) {
 		t.Fatalf("where = %q, want it to end with %q", c.Where, want)
 	}
-	// The anchor's value is read back through the same expression the ORDER BY
-	// uses, so the only cursor arguments are the anchor's address.
-	if got := c.Args[len(c.Args)-7:]; !equalArgs(got, []any{"ext/approval-gate", "requests", "b", "ext/approval-gate", "requests", "b", "b"}) {
+	// The anchor's value is read back through the same column the ORDER BY uses,
+	// so the only cursor arguments are the anchor's id — once per read of its
+	// value, once for the tiebreaker.
+	if got := c.Args[len(c.Args)-3:]; !equalArgs(got, []any{"b", "b", "b"}) {
 		t.Fatalf("cursor args = %v", got)
 	}
 
@@ -318,7 +327,7 @@ func TestTheAfterCursorComparesTheWholeOrderingTuple(t *testing.T) {
 		Sort:       &Sort{Field: "attempts", Desc: true},
 		After:      "b",
 	}, anchor)
-	want = "(json_extract(body, '$.attempts') IS NULL OR json_extract(body, '$.attempts') < " + value + " OR (json_extract(body, '$.attempts') = " + value + " AND id < ?))"
+	want = `("f_attempts" IS NULL OR "f_attempts" < ` + value + ` OR ("f_attempts" = ` + value + ` AND id < ?))`
 	if !strings.HasSuffix(c.Where, want) {
 		t.Fatalf("descending where = %q, want it to end with %q", c.Where, want)
 	}
@@ -375,5 +384,67 @@ func TestTheLimitCeilingPointsAtTheCursor(t *testing.T) {
 	}.Compile(requestsSchema(), nil)
 	if err == nil || !strings.Contains(err.Error(), "after cursor") {
 		t.Fatalf("over-limit error = %v", err)
+	}
+}
+
+// Compiling needs a minted table, and refusing anything else is the whole
+// defence for the one identifier in the compiled SQL that is not derived from a
+// validated field name. A schema that reached the compiler from anywhere but a
+// read of the registry has to fail rather than compose a statement.
+func TestAQueryWillNotCompileWithoutAMintedTable(t *testing.T) {
+	bare := requestsSchema()
+	bare.Table = ""
+	if _, err := (Query{Namespace: "ext/approval-gate", Collection: "requests"}).Compile(bare, nil); err == nil {
+		t.Fatal("a declaration with no table compiled")
+	}
+	for _, forged := range []string{
+		"documents",
+		"doc_1; DROP TABLE sessions",
+		"doc_0x1",
+		"doc_",
+		`doc_1" --`,
+	} {
+		s := requestsSchema()
+		s.Table = forged
+		if _, err := (Query{Namespace: "ext/approval-gate", Collection: "requests"}).Compile(s, nil); err == nil {
+			t.Fatalf("table name %q compiled", forged)
+		}
+	}
+}
+
+// The physical names are derived from something already checked — an integer row
+// id, a field name that matched the identifier pattern — so no identifier the
+// store executes is ever a function of caller text.
+func TestPhysicalNamesAreDerivedFromCheckedInput(t *testing.T) {
+	if got := TableName(12); got != "doc_12" {
+		t.Fatalf("TableName(12) = %q", got)
+	}
+	if err := ValidateTableName(TableName(12)); err != nil {
+		t.Fatalf("a minted name was rejected: %v", err)
+	}
+	if got := FieldColumn("status"); got != "f_status" {
+		t.Fatalf("FieldColumn = %q", got)
+	}
+	// The prefix is what lets a collection declare a field named like one of the
+	// store's own columns without shadowing it.
+	if FieldColumn("id") == "id" || FieldColumn("body") == "body" {
+		t.Fatal("a declared field can shadow a stored column")
+	}
+	if got := FieldExpression("status"); got != "json_extract(body, '$.status')" {
+		t.Fatalf("FieldExpression = %q", got)
+	}
+	// Affinity is how two stored values compare, so each declared type has to map
+	// to one that reads its values the way the declaration promises.
+	for _, tc := range []struct {
+		typ  FieldType
+		want string
+	}{
+		{FieldString, "TEXT"},
+		{FieldNumber, "NUMERIC"},
+		{FieldBool, "INTEGER"},
+	} {
+		if got := ColumnAffinity(tc.typ); got != tc.want {
+			t.Fatalf("ColumnAffinity(%s) = %q, want %q", tc.typ, got, tc.want)
+		}
 	}
 }

--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -4,33 +4,49 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/victorarias/attn/internal/docstore"
 )
 
-// SQLite persistence for the document store (migration 88). This file is only
-// persistence: what a query means, and the SQL a validated one compiles to, live
-// in internal/docstore, which reaches nothing — the same split internal/bus and
+// SQLite persistence for the document store. This file is only persistence:
+// what a query means, and the SQL a validated one compiles to, live in
+// internal/docstore, which reaches nothing — the same split internal/bus and
 // bus.go use.
 //
-// Two tables. `documents` holds the records; `document_collections` holds each
-// collection's declaration, durable so that every surface — the daemon, the CLI,
-// and later an extension's manifest apply — agrees on what a collection allows
-// without one of them being the live owner of that knowledge.
+// ONE TABLE PER COLLECTION. `document_collections` is the registry: one row per
+// declared collection, whose row id mints the name of the table holding its
+// documents (`doc_<id>`). A declared field is an indexed VIRTUAL generated
+// column over the body in that table, so a query reads an index instead of
+// scanning, while the body is still stored and returned byte for byte and
+// declaring a field rewrites no document. The measurement behind the shape is
+// in docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md.
 //
-// Isolation is structural rather than a check: namespace and collection are part
-// of the primary key and of every statement below, so there is no read or write
-// that is not already scoped to one namespace.
+// Isolation is structural rather than a check: a collection's documents are the
+// only rows in its table, so there is no read or write here that could reach
+// another namespace even if its predicate were wrong.
+//
+// Every identifier spliced into the SQL below comes from docstore — a table
+// name derived from an integer, a column name derived from a field name that
+// matched a validating pattern. None of it is caller text.
 
-// documentColumns is the read projection; body is returned byte for byte.
+// documentColumns is the read projection; body is returned byte for byte. The
+// generated columns are never selected: they exist to be filtered and ordered
+// on, and the body already carries what they compute.
 const documentColumns = `id, body, created_at, updated_at`
 
-// DefineDocumentCollection records a collection's declaration, replacing any
-// previous one. Redeclaring is how a collection gains a queryable field, and it
-// is deliberately not a migration: documents are untouched, an added field
-// becomes queryable for documents that happen to carry it, and a removed one
-// stops being queryable without anything being rewritten.
+// DefineDocumentCollection records a collection's declaration and brings its
+// table into line with it, creating the table on first declaration. Redeclaring
+// is how a collection gains or loses a queryable field: an added field is a new
+// generated column plus its index, a removed one drops both, and a field whose
+// type changed is replaced so its column carries the new affinity. Documents are
+// never rewritten — a VIRTUAL column computes from the body, so it applies to
+// every document already stored the moment it exists.
+//
+// Registry row and DDL commit together. A declaration whose table did not get
+// built, or a table no declaration names, would each be a collection that
+// cannot be queried or cannot be found.
 func (s *Store) DefineDocumentCollection(schema docstore.CollectionSchema, now time.Time) error {
 	if s.db == nil {
 		return fmt.Errorf("store: no database")
@@ -42,41 +58,64 @@ func (s *Store) DefineDocumentCollection(schema docstore.CollectionSchema, now t
 	if err != nil {
 		return fmt.Errorf("store: encoding fields for %s/%s: %w", schema.Namespace, schema.Collection, err)
 	}
-	_, err = s.db.Exec(
-		`INSERT INTO document_collections (namespace, collection, fields_json, updated_at)
-		 VALUES (?, ?, ?, ?)
-		 ON CONFLICT(namespace, collection) DO UPDATE SET
-		   fields_json=excluded.fields_json,
-		   updated_at=excluded.updated_at`,
-		schema.Namespace, schema.Collection, string(fields), now.UTC().Format(docstore.TimeFormat))
+	ts := now.UTC().Format(docstore.TimeFormat)
+
+	tx, err := s.db.Begin()
 	if err != nil {
 		return fmt.Errorf("store: defining %s/%s: %w", schema.Namespace, schema.Collection, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	existing, table, found, err := readCollectionTx(tx, schema.Namespace, schema.Collection)
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		res, err := tx.Exec(
+			`INSERT INTO document_collections (namespace, collection, fields_json, updated_at) VALUES (?, ?, ?, ?)`,
+			schema.Namespace, schema.Collection, string(fields), ts)
+		if err != nil {
+			return fmt.Errorf("store: defining %s/%s: %w", schema.Namespace, schema.Collection, err)
+		}
+		id, err := res.LastInsertId()
+		if err != nil {
+			return fmt.Errorf("store: defining %s/%s: %w", schema.Namespace, schema.Collection, err)
+		}
+		table = docstore.TableName(id)
+		if err := createCollectionTable(tx, table, schema.Fields); err != nil {
+			return fmt.Errorf("store: creating storage for %s/%s: %w", schema.Namespace, schema.Collection, err)
+		}
+	} else {
+		if err := alterCollectionTable(tx, table, existing.Fields, schema.Fields); err != nil {
+			return fmt.Errorf("store: redeclaring %s/%s: %w", schema.Namespace, schema.Collection, err)
+		}
+		if _, err := tx.Exec(
+			`UPDATE document_collections SET fields_json = ?, updated_at = ? WHERE namespace = ? AND collection = ?`,
+			string(fields), ts, schema.Namespace, schema.Collection); err != nil {
+			return fmt.Errorf("store: redeclaring %s/%s: %w", schema.Namespace, schema.Collection, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("store: committing declaration of %s/%s: %w", schema.Namespace, schema.Collection, err)
 	}
 	return nil
 }
 
-// DocumentCollection returns a collection's declaration. The bool is false with
-// a nil error when the collection was never declared — a caller must tell "no
-// such collection" apart from a read failure, because the first is what every
-// query against an undeclared collection has to report.
+// DocumentCollection returns a collection's declaration with its table filled
+// in. The bool is false with a nil error when the collection was never declared
+// — a caller must tell "no such collection" apart from a read failure, because
+// the first is what every query against an undeclared collection has to report.
 func (s *Store) DocumentCollection(namespace, collection string) (*docstore.CollectionSchema, bool, error) {
 	if s.db == nil {
 		return nil, false, fmt.Errorf("store: no database")
 	}
-	row := s.db.QueryRow(
-		`SELECT fields_json FROM document_collections WHERE namespace = ? AND collection = ?`,
-		namespace, collection)
-	var fields string
-	switch err := row.Scan(&fields); {
-	case err == sql.ErrNoRows:
-		return nil, false, nil
-	case err != nil:
-		return nil, false, fmt.Errorf("store: reading %s/%s: %w", namespace, collection, err)
+	schema, table, found, err := readCollection(s.db, namespace, collection)
+	if err != nil || !found {
+		return nil, false, err
 	}
-	schema := docstore.CollectionSchema{Namespace: namespace, Collection: collection}
-	if err := json.Unmarshal([]byte(fields), &schema.Fields); err != nil {
-		return nil, false, fmt.Errorf("store: decoding fields for %s/%s: %w", namespace, collection, err)
-	}
+	schema.Table = table
 	return &schema, true, nil
 }
 
@@ -87,30 +126,35 @@ func (s *Store) ListDocumentCollections() ([]docstore.CollectionSchema, error) {
 		return nil, fmt.Errorf("store: no database")
 	}
 	rows, err := s.db.Query(
-		`SELECT namespace, collection, fields_json FROM document_collections ORDER BY namespace, collection`)
+		`SELECT id, namespace, collection, fields_json FROM document_collections ORDER BY namespace, collection`)
 	if err != nil {
 		return nil, fmt.Errorf("store: listing document collections: %w", err)
 	}
 	defer rows.Close()
 	var out []docstore.CollectionSchema
 	for rows.Next() {
-		var schema docstore.CollectionSchema
-		var fields string
-		if err := rows.Scan(&schema.Namespace, &schema.Collection, &fields); err != nil {
+		var (
+			id     int64
+			schema docstore.CollectionSchema
+			fields string
+		)
+		if err := rows.Scan(&id, &schema.Namespace, &schema.Collection, &fields); err != nil {
 			return nil, fmt.Errorf("store: scanning document collection: %w", err)
 		}
 		if err := json.Unmarshal([]byte(fields), &schema.Fields); err != nil {
 			return nil, fmt.Errorf("store: decoding fields for %s/%s: %w", schema.Namespace, schema.Collection, err)
 		}
+		schema.Table = docstore.TableName(id)
 		out = append(out, schema)
 	}
 	return out, rows.Err()
 }
 
 // DeleteDocumentCollection removes a declaration and every document under it,
-// reporting how many documents went. Both halves in one transaction: a
-// declaration without its documents would leave records nothing can name, and
-// documents without their declaration would leave records nothing can query.
+// reporting how many documents went. Dropping the table is what returns the
+// space, and it happens in the same transaction as the registry delete: a
+// declaration without its table would leave a collection nothing can query, and
+// a table without its declaration would leave rows nothing can name.
 func (s *Store) DeleteDocumentCollection(namespace, collection string) (int, error) {
 	if s.db == nil {
 		return 0, fmt.Errorf("store: no database")
@@ -121,13 +165,20 @@ func (s *Store) DeleteDocumentCollection(namespace, collection string) (int, err
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	res, err := tx.Exec(`DELETE FROM documents WHERE namespace = ? AND collection = ?`, namespace, collection)
-	if err != nil {
-		return 0, fmt.Errorf("store: deleting documents in %s/%s: %w", namespace, collection, err)
-	}
-	n, err := res.RowsAffected()
+	_, table, found, err := readCollectionTx(tx, namespace, collection)
 	if err != nil {
 		return 0, err
+	}
+	if !found {
+		return 0, nil
+	}
+
+	var n int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM ` + table).Scan(&n); err != nil {
+		return 0, fmt.Errorf("store: counting %s/%s: %w", namespace, collection, err)
+	}
+	if _, err := tx.Exec(`DROP TABLE ` + table); err != nil {
+		return 0, fmt.Errorf("store: dropping storage for %s/%s: %w", namespace, collection, err)
 	}
 	if _, err := tx.Exec(
 		`DELETE FROM document_collections WHERE namespace = ? AND collection = ?`, namespace, collection); err != nil {
@@ -136,44 +187,48 @@ func (s *Store) DeleteDocumentCollection(namespace, collection string) (int, err
 	if err := tx.Commit(); err != nil {
 		return 0, fmt.Errorf("store: committing deletion of %s/%s: %w", namespace, collection, err)
 	}
-	return int(n), nil
+	return n, nil
 }
 
 // PutDocument writes a document, creating or fully replacing it. created_at
 // survives a replacement — it is when the record first appeared, which is what a
 // "newest first" query means by it — while updated_at moves on every write.
-func (s *Store) PutDocument(namespace, collection, id string, body []byte, now time.Time) error {
-	if s.db == nil {
-		return fmt.Errorf("store: no database")
+//
+// The schema names the table, which is why every caller reads the declaration
+// first: an undeclared collection has no storage, and that has to be an error a
+// caller reports rather than a table appearing by surprise.
+func (s *Store) PutDocument(schema docstore.CollectionSchema, id string, body []byte, now time.Time) error {
+	table, err := s.documentTable(schema)
+	if err != nil {
+		return err
 	}
 	ts := now.UTC().Format(docstore.TimeFormat)
-	_, err := s.db.Exec(
-		`INSERT INTO documents (namespace, collection, id, body, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?)
-		 ON CONFLICT(namespace, collection, id) DO UPDATE SET
+	_, err = s.db.Exec(
+		`INSERT INTO `+table+` (id, body, created_at, updated_at)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(id) DO UPDATE SET
 		   body=excluded.body,
 		   updated_at=excluded.updated_at`,
-		namespace, collection, id, string(body), ts, ts)
+		id, string(body), ts, ts)
 	if err != nil {
-		return fmt.Errorf("store: writing %s/%s/%s: %w", namespace, collection, id, err)
+		return fmt.Errorf("store: writing %s/%s/%s: %w", schema.Namespace, schema.Collection, id, err)
 	}
 	return nil
 }
 
 // GetDocument returns one document by its address.
-func (s *Store) GetDocument(namespace, collection, id string) (*docstore.Document, bool, error) {
-	if s.db == nil {
-		return nil, false, fmt.Errorf("store: no database")
+func (s *Store) GetDocument(schema docstore.CollectionSchema, id string) (*docstore.Document, bool, error) {
+	table, err := s.documentTable(schema)
+	if err != nil {
+		return nil, false, err
 	}
-	row := s.db.QueryRow(
-		`SELECT `+documentColumns+` FROM documents WHERE namespace = ? AND collection = ? AND id = ?`,
-		namespace, collection, id)
+	row := s.db.QueryRow(`SELECT `+documentColumns+` FROM `+table+` WHERE id = ?`, id)
 	doc, err := scanDocument(row)
 	if err == sql.ErrNoRows {
 		return nil, false, nil
 	}
 	if err != nil {
-		return nil, false, fmt.Errorf("store: reading %s/%s/%s: %w", namespace, collection, id, err)
+		return nil, false, fmt.Errorf("store: reading %s/%s/%s: %w", schema.Namespace, schema.Collection, id, err)
 	}
 	return doc, true, nil
 }
@@ -181,14 +236,14 @@ func (s *Store) GetDocument(namespace, collection, id string) (*docstore.Documen
 // DeleteDocument removes a document, reporting whether one was there. The caller
 // needs the difference: a delete that removed nothing must not announce a change
 // that did not happen.
-func (s *Store) DeleteDocument(namespace, collection, id string) (bool, error) {
-	if s.db == nil {
-		return false, fmt.Errorf("store: no database")
-	}
-	res, err := s.db.Exec(
-		`DELETE FROM documents WHERE namespace = ? AND collection = ? AND id = ?`, namespace, collection, id)
+func (s *Store) DeleteDocument(schema docstore.CollectionSchema, id string) (bool, error) {
+	table, err := s.documentTable(schema)
 	if err != nil {
-		return false, fmt.Errorf("store: deleting %s/%s/%s: %w", namespace, collection, id, err)
+		return false, err
+	}
+	res, err := s.db.Exec(`DELETE FROM `+table+` WHERE id = ?`, id)
+	if err != nil {
+		return false, fmt.Errorf("store: deleting %s/%s/%s: %w", schema.Namespace, schema.Collection, id, err)
 	}
 	n, err := res.RowsAffected()
 	if err != nil {
@@ -205,9 +260,16 @@ func (s *Store) QueryDocuments(c docstore.Compiled) ([]docstore.Document, error)
 	if s.db == nil {
 		return nil, fmt.Errorf("store: no database")
 	}
-	rows, err := s.db.Query(
-		`SELECT `+documentColumns+` FROM documents WHERE `+c.Where+` ORDER BY `+c.Order+` LIMIT ?`,
-		append(append([]any{}, c.Args...), c.Limit)...)
+	if err := docstore.ValidateTableName(c.Table); err != nil {
+		return nil, err
+	}
+	stmt := `SELECT ` + documentColumns + ` FROM ` + c.Table
+	if c.Where != "" {
+		stmt += ` WHERE ` + c.Where
+	}
+	stmt += ` ORDER BY ` + c.Order + ` LIMIT ?`
+
+	rows, err := s.db.Query(stmt, append(append([]any{}, c.Args...), c.Limit)...)
 	if err != nil {
 		return nil, fmt.Errorf("store: querying documents: %w", err)
 	}
@@ -224,19 +286,222 @@ func (s *Store) QueryDocuments(c docstore.Compiled) ([]docstore.Document, error)
 }
 
 // CountDocuments reports how many documents a collection holds. It is what the
-// slow-query log reports alongside a duration, so the day a scan gets slow the
-// receipt for adding an index is already written down.
-func (s *Store) CountDocuments(namespace, collection string) (int, error) {
-	if s.db == nil {
-		return 0, fmt.Errorf("store: no database")
+// slow-query log reports alongside a duration.
+func (s *Store) CountDocuments(schema docstore.CollectionSchema) (int, error) {
+	table, err := s.documentTable(schema)
+	if err != nil {
+		return 0, err
 	}
 	var n int
-	err := s.db.QueryRow(
-		`SELECT COUNT(*) FROM documents WHERE namespace = ? AND collection = ?`, namespace, collection).Scan(&n)
-	if err != nil {
-		return 0, fmt.Errorf("store: counting %s/%s: %w", namespace, collection, err)
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM ` + table).Scan(&n); err != nil {
+		return 0, fmt.Errorf("store: counting %s/%s: %w", schema.Namespace, schema.Collection, err)
 	}
 	return n, nil
+}
+
+// QueryPlan returns SQLite's plan for a compiled query, one row per step. It
+// exists so a test can assert that a filtered or sorted query reaches an index
+// rather than scanning the collection — the property this whole physical schema
+// is for, and one that no timing assertion could check without being flaky.
+func (s *Store) QueryPlan(c docstore.Compiled) ([]string, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("store: no database")
+	}
+	if err := docstore.ValidateTableName(c.Table); err != nil {
+		return nil, err
+	}
+	stmt := `SELECT ` + documentColumns + ` FROM ` + c.Table
+	if c.Where != "" {
+		stmt += ` WHERE ` + c.Where
+	}
+	stmt += ` ORDER BY ` + c.Order + ` LIMIT ?`
+
+	rows, err := s.db.Query(`EXPLAIN QUERY PLAN `+stmt, append(append([]any{}, c.Args...), c.Limit)...)
+	if err != nil {
+		return nil, fmt.Errorf("store: explaining query: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notUsed, &detail); err != nil {
+			return nil, fmt.Errorf("store: scanning query plan: %w", err)
+		}
+		out = append(out, detail)
+	}
+	return out, rows.Err()
+}
+
+// documentTable resolves the table a document operation runs against, refusing
+// a schema that did not come from a read of the registry.
+func (s *Store) documentTable(schema docstore.CollectionSchema) (string, error) {
+	if s.db == nil {
+		return "", fmt.Errorf("store: no database")
+	}
+	if err := docstore.ValidateTableName(schema.Table); err != nil {
+		return "", fmt.Errorf("store: %s/%s: %w", schema.Namespace, schema.Collection, err)
+	}
+	return schema.Table, nil
+}
+
+// ---------------------------------------------------------------------------
+// DDL
+// ---------------------------------------------------------------------------
+
+// createCollectionTable builds a collection's storage: the four stored columns,
+// an index for each reserved ordering column, and a generated column plus index
+// for every declared field.
+//
+// WITHOUT ROWID because a document is addressed by its id and never by position:
+// clustering the row on the id it is looked up by removes a whole B-tree and the
+// hop through it.
+func createCollectionTable(tx *sql.Tx, table string, fields []docstore.FieldSpec) error {
+	if err := docstore.ValidateTableName(table); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`CREATE TABLE ` + table + ` (
+    id         TEXT NOT NULL PRIMARY KEY,
+    body       TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+) WITHOUT ROWID`); err != nil {
+		return err
+	}
+	// created_at and updated_at are queryable without being declared, so they
+	// are indexed unconditionally. Each index carries the id tiebreaker, which
+	// is what makes it serve the whole ordering tuple rather than only its
+	// first half — the same tuple the after cursor compares against.
+	for _, col := range []string{docstore.FieldCreatedAt, docstore.FieldUpdatedAt} {
+		if err := createFieldIndex(tx, table, col); err != nil {
+			return err
+		}
+	}
+	for _, f := range fields {
+		if err := addFieldColumn(tx, table, f); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// alterCollectionTable brings an existing table into line with a new
+// declaration. A field whose type changed is dropped and re-added rather than
+// left alone: its column's affinity is how two stored values compare, so a
+// declaration that says "number" must not keep comparing as text.
+func alterCollectionTable(tx *sql.Tx, table string, before, after []docstore.FieldSpec) error {
+	if err := docstore.ValidateTableName(table); err != nil {
+		return err
+	}
+	old := make(map[string]docstore.FieldSpec, len(before))
+	for _, f := range before {
+		old[f.Name] = f
+	}
+	want := make(map[string]docstore.FieldSpec, len(after))
+	for _, f := range after {
+		want[f.Name] = f
+	}
+
+	for _, f := range before {
+		next, kept := want[f.Name]
+		if kept && next.Type == f.Type {
+			continue
+		}
+		if err := dropFieldColumn(tx, table, f); err != nil {
+			return err
+		}
+	}
+	for _, f := range after {
+		prev, existed := old[f.Name]
+		if existed && prev.Type == f.Type {
+			continue
+		}
+		if err := addFieldColumn(tx, table, f); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func addFieldColumn(tx *sql.Tx, table string, f docstore.FieldSpec) error {
+	col := quoteIdent(docstore.FieldColumn(f.Name))
+	// VIRTUAL, not STORED: the index materialises the values that get compared,
+	// so storing them in the row as well would pay for them twice. SQLite also
+	// refuses to add a STORED column to an existing table, which is what would
+	// make redeclaring a rewrite instead of a one-statement change.
+	_, err := tx.Exec(fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s %s GENERATED ALWAYS AS (%s) VIRTUAL`,
+		table, col, docstore.ColumnAffinity(f.Type), docstore.FieldExpression(f.Name)))
+	if err != nil {
+		return err
+	}
+	return createFieldIndex(tx, table, docstore.FieldColumn(f.Name))
+}
+
+func dropFieldColumn(tx *sql.Tx, table string, f docstore.FieldSpec) error {
+	column := docstore.FieldColumn(f.Name)
+	// The index goes first: SQLite refuses to drop an indexed column.
+	if _, err := tx.Exec(`DROP INDEX IF EXISTS ` + quoteIdent(fieldIndexName(table, column))); err != nil {
+		return err
+	}
+	_, err := tx.Exec(fmt.Sprintf(`ALTER TABLE %s DROP COLUMN %s`, table, quoteIdent(column)))
+	return err
+}
+
+// createFieldIndex indexes one column with the id tiebreaker beside it, which is
+// the order every query asks for. One index serves both directions: SQLite walks
+// it backwards for a DESC ordering.
+func createFieldIndex(tx *sql.Tx, table, column string) error {
+	_, err := tx.Exec(fmt.Sprintf(`CREATE INDEX %s ON %s (%s, id)`,
+		quoteIdent(fieldIndexName(table, column)), table, quoteIdent(column)))
+	return err
+}
+
+// fieldIndexName is unique across the database because the table name is.
+func fieldIndexName(table, column string) string {
+	return table + "_" + column
+}
+
+// quoteIdent renders an identifier for SQL. Every identifier reaching it is
+// already derived from a validated name; the quoting is what makes a field named
+// like a keyword harmless.
+func quoteIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+// ---------------------------------------------------------------------------
+// Registry reads
+// ---------------------------------------------------------------------------
+
+type rowQuerier interface {
+	QueryRow(query string, args ...any) *sql.Row
+}
+
+// readCollection reads a declaration and the table minted for it.
+func readCollection(q rowQuerier, namespace, collection string) (docstore.CollectionSchema, string, bool, error) {
+	schema := docstore.CollectionSchema{Namespace: namespace, Collection: collection}
+	var (
+		id     int64
+		fields string
+	)
+	err := q.QueryRow(
+		`SELECT id, fields_json FROM document_collections WHERE namespace = ? AND collection = ?`,
+		namespace, collection).Scan(&id, &fields)
+	switch {
+	case err == sql.ErrNoRows:
+		return schema, "", false, nil
+	case err != nil:
+		return schema, "", false, fmt.Errorf("store: reading %s/%s: %w", namespace, collection, err)
+	}
+	if err := json.Unmarshal([]byte(fields), &schema.Fields); err != nil {
+		return schema, "", false, fmt.Errorf("store: decoding fields for %s/%s: %w", namespace, collection, err)
+	}
+	table := docstore.TableName(id)
+	schema.Table = table
+	return schema, table, true, nil
+}
+
+func readCollectionTx(tx *sql.Tx, namespace, collection string) (docstore.CollectionSchema, string, bool, error) {
+	return readCollection(tx, namespace, collection)
 }
 
 func scanDocument(sc rowScanner) (*docstore.Document, error) {

--- a/internal/store/documents_test.go
+++ b/internal/store/documents_test.go
@@ -33,12 +33,24 @@ func storeWithRequests(t *testing.T, bodies map[string]string) (*Store, time.Tim
 	}
 	i := 0
 	for _, id := range sortedKeys(bodies) {
-		if err := s.PutDocument("ext/approval-gate", "requests", id, []byte(bodies[id]), base.Add(time.Duration(i)*time.Second)); err != nil {
+		if err := s.PutDocument(declOf(t, s, "ext/approval-gate", "requests"), id, []byte(bodies[id]), base.Add(time.Duration(i)*time.Second)); err != nil {
 			t.Fatalf("put %s: %v", id, err)
 		}
 		i++
 	}
 	return s, base
+}
+
+// declOf reads a collection's declaration. Every document operation takes one,
+// because the declaration is what names the table the documents live in — the
+// same read the daemon does before touching a collection.
+func declOf(t *testing.T, s *Store, namespace, collection string) docstore.CollectionSchema {
+	t.Helper()
+	schema, ok, err := s.DocumentCollection(namespace, collection)
+	if err != nil || !ok {
+		t.Fatalf("declaration for %s/%s: ok=%v err=%v", namespace, collection, ok, err)
+	}
+	return *schema
 }
 
 func sortedKeys(m map[string]string) []string {
@@ -64,7 +76,7 @@ func queryIDs(t *testing.T, s *Store, q docstore.Query) []string {
 	}
 	var anchor *docstore.Document
 	if q.After != "" {
-		doc, found, err := s.GetDocument(q.Namespace, q.Collection, q.After)
+		doc, found, err := s.GetDocument(*schema, q.After)
 		if err != nil {
 			t.Fatalf("anchor %s: %v", q.After, err)
 		}
@@ -135,7 +147,7 @@ func TestRedeclaringAddsAQueryableFieldWithoutTouchingDocuments(t *testing.T) {
 func TestABodyComesBackExactlyAsWritten(t *testing.T) {
 	body := `{"status":"pending","nested":{"deep":[1,2,{"x":null}]},"undeclared":"kept"}`
 	s, _ := storeWithRequests(t, map[string]string{"a": body})
-	doc, ok, err := s.GetDocument("ext/approval-gate", "requests", "a")
+	doc, ok, err := s.GetDocument(declOf(t, s, "ext/approval-gate", "requests"), "a")
 	if err != nil || !ok {
 		t.Fatalf("get: ok=%v err=%v", ok, err)
 	}
@@ -149,10 +161,10 @@ func TestABodyComesBackExactlyAsWritten(t *testing.T) {
 func TestReplacingADocumentKeepsCreatedAtAndMovesUpdatedAt(t *testing.T) {
 	s, base := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
 	later := base.Add(time.Hour)
-	if err := s.PutDocument("ext/approval-gate", "requests", "a", []byte(`{"status":"approved"}`), later); err != nil {
+	if err := s.PutDocument(declOf(t, s, "ext/approval-gate", "requests"), "a", []byte(`{"status":"approved"}`), later); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
-	doc, _, err := s.GetDocument("ext/approval-gate", "requests", "a")
+	doc, _, err := s.GetDocument(declOf(t, s, "ext/approval-gate", "requests"), "a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -360,7 +372,7 @@ func TestPagingByCreatedAtWithIdenticalTimestamps(t *testing.T) {
 		t.Fatalf("define: %v", err)
 	}
 	for _, id := range []string{"a", "b", "c"} {
-		if err := s.PutDocument("ext/approval-gate", "requests", id, []byte(`{"status":"pending"}`), base); err != nil {
+		if err := s.PutDocument(declOf(t, s, "ext/approval-gate", "requests"), id, []byte(`{"status":"pending"}`), base); err != nil {
 			t.Fatalf("put %s: %v", id, err)
 		}
 	}
@@ -406,11 +418,11 @@ func TestTwoNamespacesWithTheSameCollectionNameStaySeparate(t *testing.T) {
 	if err := s.DefineDocumentCollection(other, base); err != nil {
 		t.Fatalf("define other: %v", err)
 	}
-	if err := s.PutDocument("ext/other", "requests", "shared-id", []byte(`{"status":"approved"}`), base); err != nil {
+	if err := s.PutDocument(declOf(t, s, "ext/other", "requests"), "shared-id", []byte(`{"status":"approved"}`), base); err != nil {
 		t.Fatalf("put other: %v", err)
 	}
 
-	mine, _, err := s.GetDocument("ext/approval-gate", "requests", "shared-id")
+	mine, _, err := s.GetDocument(declOf(t, s, "ext/approval-gate", "requests"), "shared-id")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -424,10 +436,10 @@ func TestTwoNamespacesWithTheSameCollectionNameStaySeparate(t *testing.T) {
 		t.Fatalf("query crossed the namespace boundary: %v", got)
 	}
 	// Deleting one namespace's document leaves the other's alone.
-	if _, err := s.DeleteDocument("ext/other", "requests", "shared-id"); err != nil {
+	if _, err := s.DeleteDocument(declOf(t, s, "ext/other", "requests"), "shared-id"); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok, _ := s.GetDocument("ext/approval-gate", "requests", "shared-id"); !ok {
+	if _, ok, _ := s.GetDocument(declOf(t, s, "ext/approval-gate", "requests"), "shared-id"); !ok {
 		t.Fatal("deleting in one namespace removed the other's document")
 	}
 }
@@ -436,11 +448,11 @@ func TestTwoNamespacesWithTheSameCollectionNameStaySeparate(t *testing.T) {
 // change that did not happen.
 func TestDeleteReportsWhetherADocumentWasThere(t *testing.T) {
 	s, _ := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
-	existed, err := s.DeleteDocument("ext/approval-gate", "requests", "a")
+	existed, err := s.DeleteDocument(declOf(t, s, "ext/approval-gate", "requests"), "a")
 	if err != nil || !existed {
 		t.Fatalf("first delete: existed=%v err=%v", existed, err)
 	}
-	existed, err = s.DeleteDocument("ext/approval-gate", "requests", "a")
+	existed, err = s.DeleteDocument(declOf(t, s, "ext/approval-gate", "requests"), "a")
 	if err != nil || existed {
 		t.Fatalf("second delete: existed=%v err=%v", existed, err)
 	}
@@ -454,6 +466,10 @@ func TestRemovingACollectionTakesItsDocuments(t *testing.T) {
 		"a": `{"status":"pending"}`,
 		"b": `{"status":"pending"}`,
 	})
+	// Held from before the removal: reading through it afterwards is what proves
+	// the storage went, rather than only the registry row that names it.
+	schema := declOf(t, s, "ext/approval-gate", "requests")
+
 	n, err := s.DeleteDocumentCollection("ext/approval-gate", "requests")
 	if err != nil {
 		t.Fatalf("delete collection: %v", err)
@@ -464,12 +480,14 @@ func TestRemovingACollectionTakesItsDocuments(t *testing.T) {
 	if _, ok, _ := s.DocumentCollection("ext/approval-gate", "requests"); ok {
 		t.Fatal("declaration survived")
 	}
-	if _, ok, _ := s.GetDocument("ext/approval-gate", "requests", "a"); ok {
-		t.Fatal("document survived its collection")
+	if _, ok, err := s.GetDocument(schema, "a"); ok || err == nil {
+		t.Fatalf("document survived its collection: ok=%v err=%v", ok, err)
 	}
 }
 
-// The count behind the slow-query receipt is per collection, not per table.
+// The count behind the slow-query receipt sees one collection: two collections
+// sharing a name under different namespaces are two tables, and neither counts
+// the other's documents.
 func TestCountIsScopedToTheCollection(t *testing.T) {
 	s, base := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`, "b": `{"status":"pending"}`})
 	other := requestsDeclaration()
@@ -477,10 +495,10 @@ func TestCountIsScopedToTheCollection(t *testing.T) {
 	if err := s.DefineDocumentCollection(other, base); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.PutDocument("ext/other", "requests", "z", []byte(`{"status":"x"}`), base); err != nil {
+	if err := s.PutDocument(declOf(t, s, "ext/other", "requests"), "z", []byte(`{"status":"x"}`), base); err != nil {
 		t.Fatal(err)
 	}
-	n, err := s.CountDocuments("ext/approval-gate", "requests")
+	n, err := s.CountDocuments(declOf(t, s, "ext/approval-gate", "requests"))
 	if err != nil || n != 2 {
 		t.Fatalf("count = %d err = %v, want 2", n, err)
 	}
@@ -536,7 +554,7 @@ func TestDocumentsSurviveReopeningTheDatabase(t *testing.T) {
 	if err := first.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
 		t.Fatalf("define: %v", err)
 	}
-	if err := first.PutDocument("ext/approval-gate", "requests", "a", []byte(`{"status":"pending"}`), base); err != nil {
+	if err := first.PutDocument(declOf(t, first, "ext/approval-gate", "requests"), "a", []byte(`{"status":"pending"}`), base); err != nil {
 		t.Fatalf("put: %v", err)
 	}
 	first.Close()
@@ -561,7 +579,7 @@ func TestDocumentsSurviveReopeningTheDatabase(t *testing.T) {
 	}); !equalStrings(got, []string{"a"}) {
 		t.Fatalf("query after reopen = %v, want [a]", got)
 	}
-	doc, _, err := second.GetDocument("ext/approval-gate", "requests", "a")
+	doc, _, err := second.GetDocument(*schema, "a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -677,5 +695,222 @@ func TestPagingOverAnExplicitJSONNull(t *testing.T) {
 	}
 	if got := queryIDs(t, s, q); !equalStrings(got, []string{"b"}) {
 		t.Fatalf("page after a null-valued document = %v, want [b]", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Physical schema: a table per collection, an indexed column per declared field
+// ---------------------------------------------------------------------------
+
+// The point of the whole physical schema: a filtered and sorted query reaches an
+// index rather than reading every document. Asserted through the query planner
+// because the alternative — timing the query — is the kind of test that passes
+// on a fast machine and fails in CI without either result meaning anything.
+func TestAQueryOnADeclaredFieldUsesItsIndex(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{
+		"a": `{"status":"pending","attempts":1}`,
+		"b": `{"status":"approved","attempts":2}`,
+	})
+	schema := declOf(t, s, "ext/approval-gate", "requests")
+
+	for _, tc := range []struct {
+		name  string
+		query docstore.Query
+	}{
+		{"filter", docstore.Query{
+			Namespace: "ext/approval-gate", Collection: "requests",
+			Filters: []docstore.Filter{{Field: "status", Op: docstore.OpEq, Value: "pending"}},
+		}},
+		{"sort", docstore.Query{
+			Namespace: "ext/approval-gate", Collection: "requests",
+			Sort: &docstore.Sort{Field: "attempts"},
+		}},
+		{"sort descending", docstore.Query{
+			Namespace: "ext/approval-gate", Collection: "requests",
+			Sort: &docstore.Sort{Field: "attempts", Desc: true},
+		}},
+		{"reserved sort", docstore.Query{
+			Namespace: "ext/approval-gate", Collection: "requests",
+			Sort: &docstore.Sort{Field: docstore.FieldCreatedAt, Desc: true},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := tc.query.Compile(schema, nil)
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			plan, err := s.QueryPlan(c)
+			if err != nil {
+				t.Fatalf("plan: %v", err)
+			}
+			joined := strings.Join(plan, " | ")
+			if !strings.Contains(joined, "USING INDEX") && !strings.Contains(joined, "USING COVERING INDEX") {
+				t.Fatalf("plan does not use an index: %s", joined)
+			}
+			// A sort served by an index needs no sorting pass. The temp B-tree is
+			// what this schema exists to remove, so its absence is the assertion
+			// that matters for an ordered query.
+			if tc.query.Sort != nil && strings.Contains(joined, "TEMP B-TREE") {
+				t.Fatalf("ordered query still sorts in a temp B-tree: %s", joined)
+			}
+		})
+	}
+}
+
+// The declared type is not decoration: it is the affinity of the column the
+// field is compared through, so a body that stores a number as text still
+// compares as a number. Under the shared-table schema this compared as text
+// against every real number, which put "10" before 9.
+func TestADeclaredTypeDecidesHowStoredValuesCompare(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{
+		"a": `{"status":"pending","attempts":9}`,
+		"b": `{"status":"pending","attempts":"10"}`,
+	})
+	got := queryIDs(t, s, docstore.Query{
+		Namespace: "ext/approval-gate", Collection: "requests",
+		Sort: &docstore.Sort{Field: "attempts"},
+	})
+	if !equalStrings(got, []string{"a", "b"}) {
+		t.Fatalf("ascending by attempts = %v, want [a b] — \"10\" must order as the number 10", got)
+	}
+	// And the same value is reachable by a numeric filter, which is the half a
+	// caller notices first.
+	got = queryIDs(t, s, docstore.Query{
+		Namespace: "ext/approval-gate", Collection: "requests",
+		Filters: []docstore.Filter{{Field: "attempts", Op: docstore.OpGt, Value: 9}},
+	})
+	if !equalStrings(got, []string{"b"}) {
+		t.Fatalf("attempts > 9 = %v, want [b]", got)
+	}
+}
+
+// Two collections are two tables, so a field name means whatever each of them
+// declared it to mean. Sharing one table made every declared name global.
+func TestCollectionsWithTheSameFieldNameDoNotShareStorage(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	for _, coll := range []string{"requests", "settings"} {
+		schema := docstore.CollectionSchema{
+			Namespace: "ext/approval-gate", Collection: coll,
+			Fields: []docstore.FieldSpec{{Name: "status", Type: docstore.FieldString}},
+		}
+		if err := s.DefineDocumentCollection(schema, now); err != nil {
+			t.Fatalf("define %s: %v", coll, err)
+		}
+		if err := s.PutDocument(declOf(t, s, "ext/approval-gate", coll), coll+"-1",
+			[]byte(`{"status":"`+coll+`"}`), now); err != nil {
+			t.Fatalf("put into %s: %v", coll, err)
+		}
+	}
+	for _, coll := range []string{"requests", "settings"} {
+		got := queryIDs(t, s, docstore.Query{Namespace: "ext/approval-gate", Collection: coll})
+		if !equalStrings(got, []string{coll + "-1"}) {
+			t.Fatalf("%s holds %v, want only its own document", coll, got)
+		}
+	}
+}
+
+// Redeclaring is DDL, so it has to remove as well as add. A field that leaves
+// the declaration stops being queryable; the documents that carried it are
+// untouched and it works again the moment it is redeclared.
+func TestRedeclaringRemovesAFieldAndCanBringItBack(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{
+		"a": `{"status":"pending","attempts":1,"urgent":true}`,
+	})
+	withoutUrgent := requestsDeclaration()
+	withoutUrgent.Fields = withoutUrgent.Fields[:2]
+	if err := s.DefineDocumentCollection(withoutUrgent, base); err != nil {
+		t.Fatalf("redeclare without urgent: %v", err)
+	}
+
+	schema := declOf(t, s, "ext/approval-gate", "requests")
+	_, err := docstore.Query{
+		Namespace: "ext/approval-gate", Collection: "requests",
+		Filters: []docstore.Filter{{Field: "urgent", Op: docstore.OpEq, Value: true}},
+	}.Compile(schema, nil)
+	if err == nil {
+		t.Fatal("filtering on an undeclared field compiled; it must be rejected")
+	}
+
+	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+		t.Fatalf("redeclare with urgent: %v", err)
+	}
+	got := queryIDs(t, s, docstore.Query{
+		Namespace: "ext/approval-gate", Collection: "requests",
+		Filters: []docstore.Filter{{Field: "urgent", Op: docstore.OpEq, Value: true}},
+	})
+	if !equalStrings(got, []string{"a"}) {
+		t.Fatalf("after redeclaring urgent = %v, want [a] — the stored body never changed", got)
+	}
+}
+
+// Changing a declared field's type has to move its column, because the column's
+// affinity is how two stored values compare. Leaving the old column in place
+// would keep comparing numbers as text while the declaration said otherwise.
+func TestRedeclaringAFieldsTypeChangesHowItCompares(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{
+		"a": `{"status":"pending","attempts":9}`,
+		"b": `{"status":"pending","attempts":10}`,
+	})
+	asText := requestsDeclaration()
+	asText.Fields[1] = docstore.FieldSpec{Name: "attempts", Type: docstore.FieldString}
+	if err := s.DefineDocumentCollection(asText, base); err != nil {
+		t.Fatalf("redeclare attempts as string: %v", err)
+	}
+	got := queryIDs(t, s, docstore.Query{
+		Namespace: "ext/approval-gate", Collection: "requests",
+		Sort: &docstore.Sort{Field: "attempts"},
+	})
+	if !equalStrings(got, []string{"b", "a"}) {
+		t.Fatalf("attempts declared string sorts %v, want [b a] — \"10\" sorts before \"9\" as text", got)
+	}
+}
+
+// Undefining drops the collection's table, which is what returns the space, and
+// declaring the same address again starts empty on a fresh table rather than
+// finding the old documents.
+func TestUndefiningDropsTheStorageAndRedeclaringStartsEmpty(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{
+		"a": `{"status":"pending"}`,
+		"b": `{"status":"pending"}`,
+	})
+	before := declOf(t, s, "ext/approval-gate", "requests")
+
+	removed, err := s.DeleteDocumentCollection("ext/approval-gate", "requests")
+	if err != nil {
+		t.Fatalf("undefine: %v", err)
+	}
+	if removed != 2 {
+		t.Fatalf("undefine removed %d documents, want 2", removed)
+	}
+	if _, ok, err := s.DocumentCollection("ext/approval-gate", "requests"); err != nil || ok {
+		t.Fatalf("declaration after undefine: ok=%v err=%v", ok, err)
+	}
+
+	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+		t.Fatalf("redefine: %v", err)
+	}
+	after := declOf(t, s, "ext/approval-gate", "requests")
+	if after.Table == before.Table {
+		t.Fatalf("redeclared collection reuses table %s; a dropped table's name must not come back", after.Table)
+	}
+	if got := queryIDs(t, s, docstore.Query{Namespace: "ext/approval-gate", Collection: "requests"}); len(got) != 0 {
+		t.Fatalf("redeclared collection holds %v, want nothing", got)
+	}
+}
+
+// A schema that did not come from a read of the registry has no table, and must
+// fail loudly rather than reach a statement. This is the check standing between
+// the registry and every identifier the store executes.
+func TestAnUnmintedSchemaIsRefused(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
+	unminted := requestsDeclaration() // Table is empty: never read back.
+	if _, _, err := s.GetDocument(unminted, "a"); err == nil {
+		t.Fatal("a schema with no table was accepted")
+	}
+	forged := requestsDeclaration()
+	forged.Table = "documents; DROP TABLE sessions"
+	if _, _, err := s.GetDocument(forged, "a"); err == nil {
+		t.Fatal("a forged table name was accepted")
 	}
 }

--- a/internal/store/documents_test.go
+++ b/internal/store/documents_test.go
@@ -914,3 +914,142 @@ func TestAnUnmintedSchemaIsRefused(t *testing.T) {
 		t.Fatal("a forged table name was accepted")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Migration 89: carrying a populated v88 store across
+// ---------------------------------------------------------------------------
+
+// seedV88DocumentStore reshapes a head-schema database back into migration 88's
+// document store — one shared `documents` table, a registry with no minting id —
+// and rewinds the migration watermark so reopening replays 89 over real rows.
+func seedV88DocumentStore(t *testing.T, dbPath string) {
+	t.Helper()
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("open for seeding: %v", err)
+	}
+	if _, err := db.Exec(`
+		DROP TABLE document_collections;
+		CREATE TABLE documents (
+		    namespace  TEXT NOT NULL,
+		    collection TEXT NOT NULL,
+		    id         TEXT NOT NULL,
+		    body       TEXT NOT NULL,
+		    created_at TEXT NOT NULL,
+		    updated_at TEXT NOT NULL,
+		    PRIMARY KEY (namespace, collection, id)
+		);
+		CREATE TABLE document_collections (
+		    namespace   TEXT NOT NULL,
+		    collection  TEXT NOT NULL,
+		    fields_json TEXT NOT NULL,
+		    updated_at  TEXT NOT NULL,
+		    PRIMARY KEY (namespace, collection)
+		);
+		INSERT INTO document_collections VALUES
+		    ('ext/approval-gate', 'requests',
+		     '[{"name":"status","type":"string"},{"name":"attempts","type":"number"}]',
+		     '2026-08-02T09:00:00Z'),
+		    ('ext/notes', 'scratch', '[]', '2026-08-02T09:30:00Z');
+		INSERT INTO documents VALUES
+		    ('ext/approval-gate', 'requests', 'r1', '{"status":"open","attempts":2,"note":"kept"}',
+		     '2026-08-02T10:00:00Z', '2026-08-02T10:00:00Z'),
+		    ('ext/approval-gate', 'requests', 'r2', '{"status":"done","attempts":"10"}',
+		     '2026-08-02T10:01:00Z', '2026-08-02T10:05:00Z'),
+		    ('ext/approval-gate', 'requests', 'r3', '{"status":"open","attempts":7}',
+		     '2026-08-02T10:02:00Z', '2026-08-02T10:02:00Z'),
+		    ('ext/notes', 'scratch', 'n1', '{"anything":true}',
+		     '2026-08-02T11:00:00Z', '2026-08-02T11:00:00Z'),
+		    ('ext/ghost', 'lost', 'g1', '{"orphaned":true}',
+		     '2026-08-02T12:00:00Z', '2026-08-02T12:00:00Z');
+		DELETE FROM schema_migrations WHERE version >= 89;
+	`); err != nil {
+		t.Fatalf("seed v88 document store: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close seeded database: %v", err)
+	}
+}
+
+// TestAPopulatedV88StoreIsCarriedIntoItsOwnTables is migration 89's upgrade
+// witness. `attn doc define` and `attn doc put` shipped with migration 88, so a
+// populated v88 database is something an installed profile can already hold, and
+// the rebuild has to bring it forward rather than start it over.
+func TestAPopulatedV88StoreIsCarriedIntoItsOwnTables(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "migration-89.db")
+	seedV88DocumentStore(t, dbPath)
+
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	defer s.Close()
+
+	schema := declOf(t, s, "ext/approval-gate", "requests")
+	if len(schema.Fields) != 2 || schema.Fields[0].Name != "status" || schema.Fields[1].Type != docstore.FieldNumber {
+		t.Fatalf("declaration did not survive: %+v", schema.Fields)
+	}
+
+	doc, found, err := s.GetDocument(schema, "r1")
+	if err != nil || !found {
+		t.Fatalf("r1 after migration: found=%v err=%v", found, err)
+	}
+	if string(doc.Body) != `{"status":"open","attempts":2,"note":"kept"}` {
+		t.Fatalf("body was rewritten: %s", doc.Body)
+	}
+	want := time.Date(2026, 8, 2, 10, 0, 0, 0, time.UTC)
+	if !doc.CreatedAt.Equal(want) || !doc.UpdatedAt.Equal(want) {
+		t.Fatalf("timestamps moved: created=%s updated=%s", doc.CreatedAt, doc.UpdatedAt)
+	}
+
+	// The carry builds the collection's columns and indexes from its declaration,
+	// so a field declared under v88 is queryable — and indexed — without anyone
+	// redeclaring it.
+	q := docstore.Query{
+		Namespace: "ext/approval-gate", Collection: "requests",
+		Filters: []docstore.Filter{{Field: "status", Op: docstore.OpEq, Value: "open"}},
+		Sort:    &docstore.Sort{Field: "attempts"},
+	}
+	if got := queryIDs(t, s, q); strings.Join(got, ",") != "r1,r3" {
+		t.Fatalf("query over carried documents = %v, want [r1 r3]", got)
+	}
+	c, err := q.Compile(schema, nil)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	plan, err := s.QueryPlan(c)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	if joined := strings.Join(plan, " | "); !strings.Contains(joined, "INDEX") {
+		t.Fatalf("carried collection has no index: %s", joined)
+	}
+
+	// A collection declaring no fields still gets its table.
+	notes := declOf(t, s, "ext/notes", "scratch")
+	if _, found, err := s.GetDocument(notes, "n1"); err != nil || !found {
+		t.Fatalf("n1 after migration: found=%v err=%v", found, err)
+	}
+
+	// Documents stored under an address no declaration named cannot happen
+	// through the API, but deleting them would be the wrong answer if they ever
+	// did: they arrive under an empty declaration, readable and one doc_define
+	// away from queryable by field.
+	ghost, ok, err := s.DocumentCollection("ext/ghost", "lost")
+	if err != nil || !ok {
+		t.Fatalf("undeclared address was not carried: ok=%v err=%v", ok, err)
+	}
+	if len(ghost.Fields) != 0 {
+		t.Fatalf("undeclared address arrived with fields: %+v", ghost.Fields)
+	}
+	if _, found, err := s.GetDocument(*ghost, "g1"); err != nil || !found {
+		t.Fatalf("g1 after migration: found=%v err=%v", found, err)
+	}
+
+	if collections, err := s.ListDocumentCollections(); err != nil || len(collections) != 3 {
+		t.Fatalf("collections after migration = %d (err=%v), want 3", len(collections), err)
+	}
+	if _, err := s.db.Exec(`SELECT 1 FROM documents LIMIT 1`); err == nil {
+		t.Fatal("the shared v88 table is still there")
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -9,6 +10,7 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 
+	"github.com/victorarias/attn/internal/docstore"
 	"github.com/victorarias/attn/internal/rankkey"
 )
 
@@ -907,31 +909,12 @@ CREATE TABLE IF NOT EXISTS document_collections (
 );`},
 	// Migration 88's shared table is replaced by a table per collection: the
 	// measurement that overturned it, and the shape that replaces it, are in
-	// docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md. This is a
-	// replace and not a data migration because the store shipped with no
-	// writers — no attn feature and no extension had reached it, so there is
-	// nothing stored to carry across. The per-collection tables are created by
-	// DefineDocumentCollection rather than here; this migration only leaves
-	// behind the registry they are minted from.
-	{89, "rebuild the document store as a table per collection", `DROP TABLE IF EXISTS documents;
-DROP TABLE IF EXISTS document_collections;
--- id is the mint: a collection's table is doc_<id>, so no identifier the store
--- executes is ever a function of a namespace or collection name.
---
--- AUTOINCREMENT, so an id is never reused. A plain rowid hands the next
--- declaration the id a dropped one just freed, which would point a table name
--- that is still held somewhere — an in-flight subscription's schema, a compiled
--- query — at a different collection's documents. Undefine then define is a
--- normal thing to do, so that has to be impossible rather than unlikely.
-CREATE TABLE document_collections (
-    id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    namespace   TEXT NOT NULL,
-    collection  TEXT NOT NULL,
-    fields_json TEXT NOT NULL,
-    updated_at  TEXT NOT NULL
-);
-CREATE UNIQUE INDEX idx_document_collections_address
-    ON document_collections(namespace, collection);`},
+	// docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md. It carries
+	// v88's declarations and documents across rather than dropping them — the
+	// CLI's `attn doc define` and `attn doc put` shipped with migration 88, so
+	// any installed profile may already hold records a user put there by hand.
+	// Applied by applyMigration89.
+	{89, "rebuild the document store as a table per collection", ``},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -1197,6 +1180,11 @@ func migrateDB(db *sql.DB, dbPath string) error {
 			}
 		} else if m.version == 85 {
 			if err := applyMigration85(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 89 {
+			if err := applyMigration89(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -2143,6 +2131,181 @@ func applyMigration85(tx *sql.Tx) error {
 	}
 	_, err = tx.Exec("ALTER TABLE sessions ADD COLUMN turn_snoozed_until TEXT NOT NULL DEFAULT ''")
 	return err
+}
+
+// applyMigration89 rebuilds the document store as a table per collection and
+// carries migration 88's contents across. `attn doc define` and `attn doc put`
+// shipped together with 88, so an installed profile can already hold
+// declarations and documents someone wrote by hand: this is an upgrade, not a
+// replace. The shape it upgrades to, and the measurement that chose it, are in
+// docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md.
+//
+// Every v88 document lands in exactly one new table or the migration fails
+// rather than committing a partial carry — the count is checked, not assumed.
+//
+// Guarded on the new registry's minting column, so a rewound schema_migrations
+// table re-runs it without erroring on work already done.
+func applyMigration89(tx *sql.Tx) error {
+	migrated, err := columnExists(tx, "document_collections", "id")
+	if err != nil || migrated {
+		return err
+	}
+
+	if _, err := tx.Exec(`ALTER TABLE document_collections RENAME TO document_collections_v88`); err != nil {
+		return err
+	}
+	// id is the mint: a collection's table is doc_<id>, so no identifier the
+	// store executes is ever a function of a namespace or collection name.
+	//
+	// AUTOINCREMENT, so an id is never reused. A plain rowid hands the next
+	// declaration the id a dropped one just freed, which would point a table name
+	// that is still held somewhere — an in-flight subscription's schema, a
+	// compiled query — at a different collection's documents. Undefine then
+	// define is a normal thing to do, so that has to be impossible rather than
+	// unlikely.
+	if _, err := tx.Exec(`CREATE TABLE document_collections (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    namespace   TEXT NOT NULL,
+    collection  TEXT NOT NULL,
+    fields_json TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+)`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`CREATE UNIQUE INDEX idx_document_collections_address
+    ON document_collections(namespace, collection)`); err != nil {
+		return err
+	}
+
+	collections, err := readV88Collections(tx)
+	if err != nil {
+		return err
+	}
+	carried := 0
+	for _, c := range collections {
+		n, err := carryV88Collection(tx, c)
+		if err != nil {
+			return fmt.Errorf("carrying %s/%s across: %w", c.namespace, c.collection, err)
+		}
+		carried += n
+	}
+
+	var stored int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM documents`).Scan(&stored); err != nil {
+		return err
+	}
+	if carried != stored {
+		return fmt.Errorf("carried %d of %d stored documents; refusing to drop the rest", carried, stored)
+	}
+
+	if _, err := tx.Exec(`DROP TABLE documents`); err != nil {
+		return err
+	}
+	_, err = tx.Exec(`DROP TABLE document_collections_v88`)
+	return err
+}
+
+// v88Collection is one collection to carry across: its declaration as v88
+// recorded it, and the address its documents are stored under.
+type v88Collection struct {
+	namespace  string
+	collection string
+	fields     []docstore.FieldSpec
+	fieldsJSON string
+	updatedAt  string
+}
+
+// readV88Collections lists what migration 89 has to carry: every declared
+// collection, plus any address holding documents that no declaration names.
+//
+// The second group cannot arise through the API — a put resolves the
+// declaration before it writes — but carrying it costs one query and the
+// alternative is deleting documents. Such an address arrives with an empty
+// declaration, which leaves its documents readable by id and queryable on
+// created_at/updated_at, and one `doc_define` away from queryable by field.
+func readV88Collections(tx *sql.Tx) ([]v88Collection, error) {
+	rows, err := tx.Query(`SELECT namespace, collection, fields_json, updated_at
+        FROM document_collections_v88 ORDER BY namespace, collection`)
+	if err != nil {
+		return nil, err
+	}
+	var out []v88Collection
+	for rows.Next() {
+		var c v88Collection
+		if err := rows.Scan(&c.namespace, &c.collection, &c.fieldsJSON, &c.updatedAt); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		if err := json.Unmarshal([]byte(c.fieldsJSON), &c.fields); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("reading the declaration of %s/%s: %w", c.namespace, c.collection, err)
+		}
+		out = append(out, c)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// An undeclared address is dated by its newest document: the migration has no
+	// clock, and that timestamp is both real and already in the stored format.
+	orphans, err := tx.Query(`SELECT d.namespace, d.collection, MAX(d.updated_at)
+        FROM documents d
+       WHERE NOT EXISTS (SELECT 1 FROM document_collections_v88 c
+                          WHERE c.namespace = d.namespace AND c.collection = d.collection)
+       GROUP BY d.namespace, d.collection
+       ORDER BY d.namespace, d.collection`)
+	if err != nil {
+		return nil, err
+	}
+	defer orphans.Close()
+	for orphans.Next() {
+		c := v88Collection{fieldsJSON: "[]"}
+		if err := orphans.Scan(&c.namespace, &c.collection, &c.updatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, orphans.Err()
+}
+
+// carryV88Collection mints a collection's registry row, builds its table from
+// the declaration, and moves its documents in. It returns how many it moved, so
+// the caller can prove nothing was left behind.
+//
+// The declaration is validated before any of its field names reach DDL. They
+// were validated when they were written, so a failure here means the database
+// was edited outside attn — worth stopping for, since the alternative is
+// splicing unchecked text into a CREATE TABLE.
+func carryV88Collection(tx *sql.Tx, c v88Collection) (int, error) {
+	schema := docstore.CollectionSchema{Namespace: c.namespace, Collection: c.collection, Fields: c.fields}
+	if err := schema.Validate(); err != nil {
+		return 0, err
+	}
+	res, err := tx.Exec(
+		`INSERT INTO document_collections (namespace, collection, fields_json, updated_at) VALUES (?, ?, ?, ?)`,
+		c.namespace, c.collection, c.fieldsJSON, c.updatedAt)
+	if err != nil {
+		return 0, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+	table := docstore.TableName(id)
+	if err := createCollectionTable(tx, table, c.fields); err != nil {
+		return 0, err
+	}
+	// The bodies move byte for byte; the generated columns compute from them on
+	// read, so this is the whole of the carry.
+	moved, err := tx.Exec(`INSERT INTO `+table+` (id, body, created_at, updated_at)
+        SELECT id, body, created_at, updated_at FROM documents WHERE namespace = ? AND collection = ?`,
+		c.namespace, c.collection)
+	if err != nil {
+		return 0, err
+	}
+	n, err := moved.RowsAffected()
+	return int(n), err
 }
 
 func columnExists(tx *sql.Tx, table, column string) (bool, error) {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -905,6 +905,33 @@ CREATE TABLE IF NOT EXISTS document_collections (
     updated_at  TEXT NOT NULL,
     PRIMARY KEY (namespace, collection)
 );`},
+	// Migration 88's shared table is replaced by a table per collection: the
+	// measurement that overturned it, and the shape that replaces it, are in
+	// docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md. This is a
+	// replace and not a data migration because the store shipped with no
+	// writers — no attn feature and no extension had reached it, so there is
+	// nothing stored to carry across. The per-collection tables are created by
+	// DefineDocumentCollection rather than here; this migration only leaves
+	// behind the registry they are minted from.
+	{89, "rebuild the document store as a table per collection", `DROP TABLE IF EXISTS documents;
+DROP TABLE IF EXISTS document_collections;
+-- id is the mint: a collection's table is doc_<id>, so no identifier the store
+-- executes is ever a function of a namespace or collection name.
+--
+-- AUTOINCREMENT, so an id is never reused. A plain rowid hands the next
+-- declaration the id a dropped one just freed, which would point a table name
+-- that is still held somewhere — an in-flight subscription's schema, a compiled
+-- query — at a different collection's documents. Undefine then define is a
+-- normal thing to do, so that has to be impossible rather than unlikely.
+CREATE TABLE document_collections (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    namespace   TEXT NOT NULL,
+    collection  TEXT NOT NULL,
+    fields_json TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+CREATE UNIQUE INDEX idx_document_collections_address
+    ON document_collections(namespace, collection);`},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.


### PR DESCRIPTION
The document store (#745) shipped scan-first behind a tripwire: a query past
50ms would log its collection size, so the case for indexes would arrive with a
receipt. Two measurements broke that reasoning, so this replaces the physical
schema before anything writes to it.

## Why scan-first did not survive

Measured on sqlite 3.51, 20k documents in the target collection, warm:

- A filtered, sorted, limited query scans in **~2ms at 20k documents**. The
  50ms tripwire would not fire until roughly 100k documents in one collection.
  The receipt was never going to arrive.
- The cost that grows is not per-query, it is **per write × per subscription**.
  A live query re-runs every matching subscription on every committed write, so
  20 subscriptions on a 20k-document collection make one write cost ~40ms of
  CPU — every millisecond of it invisible to a per-query threshold. That term
  scales with exactly what the extension platform adds next.

Indexed, the same query is 0.4ms and the sort-only case drops from 4ms to
~0.01ms. Write cost with the index present is noise: 2000 puts in 3ms.

## What changed

Each collection gets its own table, minted as `doc_<registry id>`, with a
`VIRTUAL` generated column per declared field and a `(field, id)` index on
each. The declaration is still the query contract, and declaring still rewrites
no documents — a virtual column computes on read, so only the index build
scans. Redeclaring diffs the fields and alters the table; undefining drops it,
so the space returns immediately.

Everything stays in `attn.db`, which keeps a document write in the same
transaction as the registry, the `document.changed` fact, and any job enqueued
alongside it.

The registry id is `AUTOINCREMENT` on purpose: a reused rowid would let `doc_1`
come back naming a different collection while an in-flight subscription still
holds it. Undefine-then-define is an ordinary thing to do, so reuse has to be
impossible rather than unlikely.

Migration 89 replaces the storage rather than migrating it — the store shipped
with zero writers, confirmed against production `~/.attn`, which had not even
reached migration 88.

## Two behaviour changes

**A declared type now decides how stored values compare.** The column carries
its declared affinity, so a body holding `"attempts": "5"` in a field declared
`number` reads, compares, and sorts as the number 5. Before, it compared under
SQLite's cross-type ordering, which put `"10"` before `9`.

**A live query ends when its collection can no longer answer.** The delivery
loop re-reads the declaration per delivery instead of capturing it. Undefining
a collection drops its table, and the old behaviour answered the watcher with
an empty result set — which says "this collection is here and holds nothing" to
someone whose collection is gone. Redeclaring without a field a live query
filters on drops that field's column, and the query silently stops meaning what
was asked. Both now end the subscription with an error naming what happened,
which is the way out that `undefine` was missing.

The wire surface, the CLI, and `ProtocolVersion` are unchanged.

## Also here

A second tripwire prices what a live query actually costs: query duration times
the number of subscriptions the last write woke on that collection, budgeted at
one 60Hz frame (16ms). The fan-out already counts the subscriptions it wakes,
so it stamps the count on each one rather than having every delivery re-count
under a lock — which would make a log line that almost never fires quadratic in
the term it exists to watch.

## Known bound

A query that filters on one field and sorts by a *different* one uses the
filter's index and then sorts the matches in a temp B-tree. There is no
composite index, because one per (filter, sort) pair is combinatorial in the
number of declared fields. The sort still sees only the matched rows rather
than the collection, and if a real consumer measures slow, the fix is a
composite index for that specific pair built from the same declaration.

## Rejected alternatives

**Expression indexes on the shared table** — works, and is the smallest diff.
Rejected because it keeps the shared B-tree and blended `ANALYZE` statistics,
partial indexes on it are unusable (measured: not used, with bound parameters
or inlined literals), and it spends the one-time zero-writers window on a patch.

**One database file per namespace** — real attractions, rejected for one
decisive cost: SQLite commits atomically across attached files only in
rollback-journal mode; under WAL, cross-file transactions decay to per-file.
`attn.db` runs `journal_mode=delete` today, but WAL is the standard next move
for a daemon with concurrent readers, and building this primitive's integrity
on "we promise never to enable WAL" is a landmine. The loss bites at registry ↔
DDL, at write ↔ `document.changed` fact (lethal once workflows trigger on
document changes), and at write ↔ job enqueue. The registry maps a namespace to
its tables, so evicting one convicted namespace to its own file later stays a
contained migration — done with a receipt in hand.

Full design, receipts, and reasoning:
`docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md`.

## Verification

`go build ./...` plus `internal/store`, `internal/docstore`, `internal/daemon`,
`cmd/attn` green on the rebased branch. New tests include a planner test
asserting `USING INDEX` and no `TEMP B-TREE` for filter+sort+limit, a witness
for the type-affinity change, one proving two collections with the same field
name do not share storage, and both new daemon subscription-termination cases —
whose falsifiability was checked by reverting the per-delivery re-read and
confirming they fail for the right reason.

Live-verified on a throwaway profile (`a31store`): define / collections / put /
get / query, affinity ordering, the exact built DDL and its five indexes, the
old `documents` table gone, watch deliveries and their termination on undefine,
pagination across three pages of tied documents, the dead-cursor error,
redeclare in both directions, and restart durability with the index surviving.
`doc_3` after several undefine/define cycles confirmed `AUTOINCREMENT` live.
Profile cleaned up afterwards.

https://claude.ai/code/session_01429snMWPwXjv1NeqUdV57c