### PR TITLE
feat(notebook): allow disabling journal narration

### DIFF
--- a/app/src/components/SettingsModal.test.tsx
+++ b/app/src/components/SettingsModal.test.tsx
@@ -1017,6 +1017,39 @@ describe('SettingsModal keeper', () => {
     );
   });
 
+  it('toggles journal narration independently and defaults it on', async () => {
+    const onSetSetting = renderModal({});
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    const toggle = await screen.findByTestId('settings-keeper-narrate-toggle');
+    expect(toggle).toHaveTextContent('Disable');
+    expect(toggle).toHaveAccessibleName('Disable journal narration');
+    fireEvent.click(toggle);
+    expect(onSetSetting).toHaveBeenCalledWith(
+      'notebook.narrate_workspace.enabled',
+      'false',
+    );
+  });
+
+  it('re-enables journal narration without losing its model configuration', async () => {
+    const onSetSetting = renderModal({
+      'notebook.narrate_workspace.enabled': 'false',
+      'notebook.narrate_workspace': '{"agent":"codex","model":"gpt-5.4"}',
+    });
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    const toggle = await screen.findByTestId('settings-keeper-narrate-toggle');
+    expect(toggle).toHaveTextContent('Enable');
+    expect(toggle).toHaveAccessibleName('Enable journal narration');
+    expect(screen.getByTestId('settings-keeper-narrate-agent')).toHaveValue('codex');
+    expect(screen.getByTestId('settings-keeper-narrate-model')).toHaveValue('gpt-5.4');
+    fireEvent.click(toggle);
+    expect(onSetSetting).toHaveBeenCalledWith(
+      'notebook.narrate_workspace.enabled',
+      'true',
+    );
+  });
+
   it('seeds default-configured duties with their tier default and saves an override', async () => {
     const onSetSetting = renderModal({});
     fireEvent.click(screen.getByTestId('settings-nav-agents'));

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -308,8 +308,14 @@ export function SettingsModal({
   // The keeper master switch is daemon-normalized to its effective value (default ON),
   // so a missing key reads as enabled rather than off.
   const keeperTasksEnabled = (settings['notebook.tasks_enabled'] ?? 'true') !== 'false';
-  const notebookSummariesEnabled =
-    (settings['notebook.summarize_session.enabled'] ?? 'true') !== 'false';
+  const keeperDutyEnabled = useMemo(() => {
+    const enabled = {} as Record<KeeperDutyKey, boolean>;
+    for (const duty of KEEPER_DUTIES) {
+      enabled[duty.key] = duty.enabledSettingKey === undefined
+        || (settings[duty.enabledSettingKey] ?? 'true') !== 'false';
+    }
+    return enabled;
+  }, [settings]);
   const resolvedDefaultAgent = resolvePreferredAgent(actualDefaultAgent, agentAvailability, 'codex');
   const orderedAgentList = useMemo(
     () => orderedAgents(agentAvailability, resolvedDefaultAgent, 'codex'),
@@ -664,12 +670,11 @@ export function SettingsModal({
     onSetSetting('notebook.tasks_enabled', keeperTasksEnabled ? 'false' : 'true');
   }, [keeperTasksEnabled, onSetSetting]);
 
-  const handleToggleNotebookSummaries = useCallback(() => {
-    onSetSetting(
-      'notebook.summarize_session.enabled',
-      notebookSummariesEnabled ? 'false' : 'true',
-    );
-  }, [notebookSummariesEnabled, onSetSetting]);
+  const handleToggleKeeperDuty = useCallback((dutyKey: KeeperDutyKey) => {
+    const duty = KEEPER_DUTY_BY_KEY[dutyKey];
+    if (!duty.enabledSettingKey) return;
+    onSetSetting(duty.enabledSettingKey, keeperDutyEnabled[dutyKey] ? 'false' : 'true');
+  }, [keeperDutyEnabled, onSetSetting]);
 
   // Switching a duty's agent resets its model to that agent's recommended default
   // (the first preset); choosing the empty "Disabled" agent (opt-in duties only)
@@ -2056,7 +2061,7 @@ export function SettingsModal({
               const agentId = `${duty.testIdPrefix}-agent`;
               const modelId = `${duty.testIdPrefix}-model`;
               const customId = `${duty.testIdPrefix}-model-custom`;
-              const dutyEnabled = duty.key !== 'summarize' || notebookSummariesEnabled;
+              const dutyEnabled = keeperDutyEnabled[duty.key];
               return (
                 <div
                   className={`settings-keeper-duty${dutyEnabled ? '' : ' is-disabled'}`}
@@ -2067,17 +2072,15 @@ export function SettingsModal({
                       <p className="settings-row-title">{duty.title}</p>
                       <p className="settings-row-copy">{duty.description}</p>
                     </div>
-                    {duty.key === 'summarize' && (
+                    {duty.enabledSettingKey && (
                       <button
                         type="button"
                         className="settings-action"
-                        data-testid="settings-keeper-summarize-toggle"
-                        aria-label={notebookSummariesEnabled
-                          ? 'Disable session summaries'
-                          : 'Enable session summaries'}
-                        onClick={handleToggleNotebookSummaries}
+                        data-testid={`${duty.testIdPrefix}-toggle`}
+                        aria-label={`${dutyEnabled ? 'Disable' : 'Enable'} ${duty.title.toLowerCase()}`}
+                        onClick={() => handleToggleKeeperDuty(duty.key)}
                       >
-                        {notebookSummariesEnabled ? 'Disable' : 'Enable'}
+                        {dutyEnabled ? 'Disable' : 'Enable'}
                       </button>
                     )}
                   </div>
@@ -2159,7 +2162,7 @@ export function SettingsModal({
                     </div>
                   ) : (
                     <div className="settings-hint">
-                      {duty.key === 'summarize' && !notebookSummariesEnabled
+                      {duty.enabledSettingKey && !dutyEnabled
                         ? `Disabled. Its ${duty.defaultLabel} model setting is preserved.`
                         : `Defaults to ${duty.defaultLabel} when unset.`}
                     </div>

--- a/app/src/utils/keeperDuties.ts
+++ b/app/src/utils/keeperDuties.ts
@@ -27,6 +27,8 @@ export interface KeeperDutyDescriptor {
   key: KeeperDutyKey;
   /** The persisted settings key the daemon reads for this duty. */
   settingKey: string;
+  /** Optional persisted default-on runtime switch, independent of agent/model config. */
+  enabledSettingKey?: string;
   /** Row title. */
   title: string;
   /** One-line summary of what the duty does. */
@@ -87,6 +89,7 @@ export const KEEPER_DUTIES: readonly KeeperDutyDescriptor[] = [
   {
     key: 'summarize',
     settingKey: 'notebook.summarize_session',
+    enabledSettingKey: 'notebook.summarize_session.enabled',
     title: 'Session summaries',
     description: 'Distills each finished session into a short digest for the journal.',
     testIdPrefix: 'settings-keeper-summarize',
@@ -97,6 +100,7 @@ export const KEEPER_DUTIES: readonly KeeperDutyDescriptor[] = [
   {
     key: 'narrate',
     settingKey: 'notebook.narrate_workspace',
+    enabledSettingKey: 'notebook.narrate_workspace.enabled',
     title: 'Journal narration',
     description: 'Curates per-workspace digests into the running work journal.',
     testIdPrefix: 'settings-keeper-narrate',

--- a/changelog.d/notebook-narration-toggle.yaml
+++ b/changelog.d/notebook-narration-toggle.yaml
@@ -1,0 +1,7 @@
+kind: changed
+area: notebook
+change: >
+  Journal narration can now be switched off independently in Settings. Disabling
+  it stops routine, nightly, final-removal, and already queued narration jobs from
+  launching their agent, without turning off session summaries or context
+  compaction; the selected narration agent and model stay ready for re-enabling.

--- a/docs/notebook-processes.md
+++ b/docs/notebook-processes.md
@@ -144,8 +144,11 @@ narrative.
   (`{agent,model}` JSON; blank uses the tier default). Session summaries are
   default-on and can be disabled independently with
   `notebook.summarize_session.enabled`; queued summaries retire without launching
-  an agent after it is disabled. Workspace narration remains on unless the keeper
-  master switch (`notebook.tasks_enabled`) is disabled.
+  an agent after it is disabled. Workspace narration is also default-on and can be
+  disabled independently with `notebook.narrate_workspace.enabled`; every routine,
+  nightly, final-removal, or already queued narration retires without launching an
+  agent while disabled. The keeper master switch (`notebook.tasks_enabled`) still
+  takes precedence over every duty.
 
 ## The notebook cron (`internal/daemon/notebook_cron.go`)
 

--- a/docs/notebook-uat.md
+++ b/docs/notebook-uat.md
@@ -254,8 +254,9 @@ schema at 52; app connects at protocol 115.
 ## Group B — Agentic narration & compaction (real model spend)
 
 > These spawn **real headless agents**. Keep `tail -f … daemon.log | grep …` (0.4) running.
-> Default tiers: summarize = Claude **Haiku**, narrate = Claude **Sonnet**. Narration is
-> always on (no enable step). Debounce is **2 min** after a session stop.
+> Default tiers: summarize = Claude **Haiku**, narrate = Claude **Sonnet**. Both duties
+> are enabled by default and can be switched off independently. Debounce is **2 min**
+> after a session stop.
 
 ### B1 — Per-session digest (`summarize_session`) **[LLM]**
 **Proves:** a finished session is digested to the raw tier by the cheap-tier agent.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3687,6 +3687,8 @@ func TestDaemon_SettingsValidation(t *testing.T) {
 		{"valid tailscale_enabled false", "tailscale_enabled", "false", false},
 		{"valid summarize enabled false", "notebook.summarize_session.enabled", "false", false},
 		{"invalid summarize enabled", "notebook.summarize_session.enabled", "maybe", true},
+		{"valid narration enabled false", "notebook.narrate_workspace.enabled", "false", false},
+		{"invalid narration enabled", "notebook.narrate_workspace.enabled", "maybe", true},
 		{"empty keybindings_config", "keybindings_config", "", false},
 		{"valid keybindings_config", "keybindings_config", `{"version":1,"overrides":{"session.new":{"key":"m","meta":true}}}`, false},
 		{"invalid keybindings_config json", "keybindings_config", "{not json", true},

--- a/internal/daemon/notebook_cron.go
+++ b/internal/daemon/notebook_cron.go
@@ -155,8 +155,9 @@ func (d *Daemon) notebookCronTick(now time.Time) {
 //
 // The daily narrate fires on the shared notebook-maintenance nightly slot defined by
 // the notebook cron schedule/timezone SETTINGS; a dedicated split can come later.
-// Narration is always on (no enabled gate), so this fires on its own anchor; that is
-// why it uses a SEPARATE state file (NarrateCronState).
+// It advances its own anchor whether narration is enabled or not; the per-duty gate
+// at the enqueue seam suppresses agent work while off. The separate state file
+// (NarrateCronState) keeps that schedule independent.
 //
 // Activity gate: only workspaces that saw a session end or a content-changing context
 // write since the last fire are in the set, so idle workspaces are skipped and never

--- a/internal/daemon/notebook_narration.go
+++ b/internal/daemon/notebook_narration.go
@@ -333,9 +333,9 @@ func notebookWorkspaceSessionsDir(root, workspaceID string) (string, error) {
 // narrate duty's inputs, runs the agent, and verifies the journal now carries this
 // workspace's marker for today (the file is the ledger).
 func (d *Daemon) narrateWorkspaceHandler(ctx context.Context, job *jobs.Job) (any, error) {
-	// Master switch: a run queued before the keeper was disabled must not fire
-	// background work after the toggle is off. No-op success retires the record.
-	if !d.notebookTasksEnabled() {
+	// A run queued before either switch was disabled must not fire background
+	// work after the toggle is off. No-op success retires the record.
+	if !d.notebookTasksEnabled() || !d.notebookWorkspaceNarrationEnabled() {
 		return nil, nil
 	}
 	workspaceID := strings.TrimSpace(jobSubject(job))
@@ -657,7 +657,7 @@ func (d *Daemon) enqueueNarrateWorkspace(workspaceID string) {
 	if workspaceID == "" {
 		return
 	}
-	if !d.notebookTasksEnabled() {
+	if !d.notebookTasksEnabled() || !d.notebookWorkspaceNarrationEnabled() {
 		return
 	}
 	runner := d.jobQueueRef()
@@ -714,7 +714,7 @@ func (d *Daemon) enqueueDailyNarrateWorkspace(workspaceID string) {
 	if workspaceID == "" {
 		return
 	}
-	if !d.notebookTasksEnabled() {
+	if !d.notebookTasksEnabled() || !d.notebookWorkspaceNarrationEnabled() {
 		return
 	}
 	runner := d.jobQueueRef()
@@ -744,7 +744,7 @@ func (d *Daemon) enqueueFinalNarrateWorkspace(workspaceID string) {
 	if workspaceID == "" {
 		return
 	}
-	if !d.notebookTasksEnabled() {
+	if !d.notebookTasksEnabled() || !d.notebookWorkspaceNarrationEnabled() {
 		return
 	}
 	runner := d.jobQueueRef()

--- a/internal/daemon/notebook_narration_config.go
+++ b/internal/daemon/notebook_narration_config.go
@@ -20,8 +20,8 @@ const (
 // Tier-default model ids. Narration model configuration never disables on a blank
 // value (unlike the keeper's compaction duty): an unset setting falls back to a
 // built-in default so session-end and removal-boundary narration work out of the
-// box. The summary duty has a separate boolean runtime switch. Claude is the
-// default agent for BOTH tiers because its native
+// box. Summary and narration each have a separate boolean runtime switch. Claude
+// is the default agent for BOTH tiers because its native
 // Write/Edit enforce read-before-write CAS, which the shared-journal concurrency
 // story depends on (Codex apply-patch CAS is unverified for the installed
 // version — see notebook_narration.go).

--- a/internal/daemon/notebook_tasks_enabled_test.go
+++ b/internal/daemon/notebook_tasks_enabled_test.go
@@ -57,6 +57,29 @@ func TestNotebookSummariesEnabledDefaultsOn(t *testing.T) {
 	}
 }
 
+// TestNotebookWorkspaceNarrationEnabledDefaultsOn proves the curated-journal
+// switch is opt-out and appears as its effective value in every settings snapshot.
+func TestNotebookWorkspaceNarrationEnabledDefaultsOn(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+
+	if !d.notebookWorkspaceNarrationEnabled() {
+		t.Fatal("unset notebook.narrate_workspace.enabled must default to ON")
+	}
+	settings := d.settingsWithAgentAvailability()
+	if got := settings[SettingNotebookNarrateWorkspaceEnabled]; got != "true" {
+		t.Fatalf("effective narration setting = %#v, want true", got)
+	}
+
+	d.store.SetSetting(SettingNotebookNarrateWorkspaceEnabled, "false")
+	if d.notebookWorkspaceNarrationEnabled() {
+		t.Fatal("explicit false must disable workspace narration")
+	}
+	settings = d.settingsWithAgentAvailability()
+	if got := settings[SettingNotebookNarrateWorkspaceEnabled]; got != "false" {
+		t.Fatalf("effective narration setting = %#v, want false", got)
+	}
+}
+
 // TestNotebookSummariesDisabledOnlySkipsSummaries proves the per-duty switch
 // leaves journal narration alone while preventing summary records from being
 // created. Re-enabling restores the enqueue path without changing its model.
@@ -76,6 +99,36 @@ func TestNotebookSummariesDisabledOnlySkipsSummaries(t *testing.T) {
 	d.enqueueSummarizeSession("session-on", "", "")
 	if !taskExists(t, d, notebookSummarizeSessionKind, "session-on") {
 		t.Fatal("summarize must enqueue once its duty switch is on")
+	}
+}
+
+// TestNotebookNarrationDisabledOnlySkipsNarration proves the switch gates every
+// narration enqueue path without disabling session summaries. Re-enabling restores
+// routine narration without changing its agent/model configuration.
+func TestNotebookNarrationDisabledOnlySkipsNarration(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	installNotebookNarrationRunner(t, d)
+
+	d.store.SetSetting(SettingNotebookNarrateWorkspace, `{"agent":"claude","model":"claude-custom"}`)
+	d.store.SetSetting(SettingNotebookNarrateWorkspaceEnabled, "false")
+	d.enqueueNarrateWorkspace("ws-routine-off")
+	d.enqueueDailyNarrateWorkspace("ws-daily-off")
+	d.enqueueFinalNarrateWorkspace("ws-final-off")
+	d.enqueueSummarizeSession("session-on", "", "")
+	assertNoTask(t, d, notebookNarrateWorkspaceKind, "ws-routine-off")
+	assertNoTask(t, d, notebookNarrateWorkspaceKind, "ws-daily-off")
+	assertNoTask(t, d, notebookNarrateWorkspaceKind, "ws-final-off")
+	if !taskExists(t, d, notebookSummarizeSessionKind, "session-on") {
+		t.Fatal("narration switch must not disable session summaries")
+	}
+
+	d.store.SetSetting(SettingNotebookNarrateWorkspaceEnabled, "true")
+	d.enqueueNarrateWorkspace("ws-routine-on")
+	if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-routine-on") {
+		t.Fatal("narration must enqueue once its duty switch is on")
+	}
+	if got := d.store.GetSetting(SettingNotebookNarrateWorkspace); got != `{"agent":"claude","model":"claude-custom"}` {
+		t.Fatalf("narration model config changed across toggle: %s", got)
 	}
 }
 
@@ -142,6 +195,24 @@ func TestNotebookSummariesDisabledExecutorNoOps(t *testing.T) {
 		t.Fatalf("enqueue: %v", err)
 	}
 	waitForTaskState(t, d, notebookSummarizeSessionKind, "session-1", jobs.StateDone)
+}
+
+// TestNotebookNarrationDisabledExecutorNoOps covers the queued-before-toggle
+// case: the durable record completes without spawning a headless agent.
+func TestNotebookNarrationDisabledExecutorNoOps(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	installNotebookNarrationRunner(t, d)
+	d.store.SetSetting(SettingNotebookNarrateWorkspaceEnabled, "false")
+
+	d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		t.Fatal("narrate executor ran the agent while journal narration was off")
+		return agentdriver.HeadlessTaskResult{}, nil
+	}
+
+	if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{UniqueKey: "ws-1"}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	waitForTaskState(t, d, notebookNarrateWorkspaceKind, "ws-1", jobs.StateDone)
 }
 
 // assertNoTask fails if a record exists for the given kind/subject. Unlike

--- a/internal/daemon/testdata/wire/producers.golden
+++ b/internal/daemon/testdata/wire/producers.golden
@@ -210,6 +210,7 @@
     "model_capture.interval_seconds": "10",
     "model_capture.max_gb": "5",
     "model_capture.path": "<tmp>/model-captures",
+    "notebook.narrate_workspace.enabled": "true",
     "notebook.root.effective": "<home>/attn-notebook",
     "notebook.summarize_session.enabled": "true",
     "notebook.tasks_enabled": "true",

--- a/internal/daemon/workspace_keeper.go
+++ b/internal/daemon/workspace_keeper.go
@@ -130,10 +130,23 @@ func (d *Daemon) notebookTasksEnabled() bool {
 // is enabled. It is an independent, default-on opt-out beneath the keeper master
 // switch: callers check both so the master can still stop every duty at once.
 func (d *Daemon) notebookSummariesEnabled() bool {
+	return d.notebookDutyEnabled(SettingNotebookSummarizeSessionEnabled)
+}
+
+// notebookWorkspaceNarrationEnabled reports whether the keeper's curated-journal
+// duty is enabled. Like summaries, it is an independent, default-on opt-out beneath
+// the keeper master switch.
+func (d *Daemon) notebookWorkspaceNarrationEnabled() bool {
+	return d.notebookDutyEnabled(SettingNotebookNarrateWorkspaceEnabled)
+}
+
+// notebookDutyEnabled resolves a per-duty default-on switch. Keeping the default
+// policy here makes every keeper duty treat absent settings identically.
+func (d *Daemon) notebookDutyEnabled(settingKey string) bool {
 	if d.store == nil {
 		return true
 	}
-	raw := strings.TrimSpace(d.store.GetSetting(SettingNotebookSummarizeSessionEnabled))
+	raw := strings.TrimSpace(d.store.GetSetting(settingKey))
 	if raw == "" {
 		return true
 	}

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -126,6 +126,11 @@ const (
 	// because its native Write/Edit enforce read-before-write CAS on the shared
 	// journal; see parseNotebookNarrationConfig.
 	SettingNotebookNarrateWorkspace = "notebook.narrate_workspace"
+	// SettingNotebookNarrateWorkspaceEnabled independently gates every curated-
+	// journal narrate path. Default ON preserves existing installs; only an explicit
+	// "false" stops new narrations and retires queued narrations without launching
+	// their agent. Raw session summaries and context compaction remain independent.
+	SettingNotebookNarrateWorkspaceEnabled = "notebook.narrate_workspace.enabled"
 	// SettingChiefContextWindowCap caps the chief-of-staff session's effective
 	// context window (in tokens): auto-compaction triggers at this threshold
 	// instead of at the model's full window, so each cache-cold chief wake
@@ -352,6 +357,9 @@ func (d *Daemon) settingsWithAgentAvailability() map[string]interface{} {
 	// existing profiles. Surface its effective value for the same reason as the
 	// keeper master switch: the app should never mistake an absent key for off.
 	settings[SettingNotebookSummarizeSessionEnabled] = strconv.FormatBool(d.notebookSummariesEnabled())
+	// The narration duty follows the same default-on, independently opt-out
+	// contract as summaries. Always send its effective value to the app.
+	settings[SettingNotebookNarrateWorkspaceEnabled] = strconv.FormatBool(d.notebookWorkspaceNarrationEnabled())
 	// Surface the EFFECTIVE token caps so the UI shows the concrete default
 	// (128000) rather than an absent key when the operator has not set one.
 	settings[SettingChiefContextWindowCap] = strconv.Itoa(resolveContextWindowCap(stored[SettingChiefContextWindowCap]))
@@ -499,7 +507,7 @@ func (d *Daemon) validateSetting(key, value string) error {
 		return d.validateNewSessionAgent(value)
 	case SettingTheme:
 		return validateTheme(value)
-	case SettingTailscaleEnabled, SettingWorkflowsEnabled, SettingAutoApproveEnabled, SettingNotebookTasksEnabled, SettingNotebookSummarizeSessionEnabled, SettingQueueModeEnabled, SettingAutoSettleEnabled, SettingModelCaptureEnabled:
+	case SettingTailscaleEnabled, SettingWorkflowsEnabled, SettingAutoApproveEnabled, SettingNotebookTasksEnabled, SettingNotebookSummarizeSessionEnabled, SettingNotebookNarrateWorkspaceEnabled, SettingQueueModeEnabled, SettingAutoSettleEnabled, SettingModelCaptureEnabled:
 		return validateBooleanSetting(value)
 	case SettingModelCaptureIntervalSeconds:
 		return validateModelCaptureInterval(value)


### PR DESCRIPTION
## Intent / Why

Journal narration uses the strong-tier background agent and needs an independent pause control for cost-sensitive periods. Turning it off should leave session summaries and context compaction running, while keeping the chosen narration agent and model ready for later.

## Summary

- add the default-on `notebook.narrate_workspace.enabled` setting and surface its effective value to the app
- gate routine, nightly, final-removal, and already queued narration jobs without affecting session summaries or context compaction
- share the Settings toggle rendering across summary and narration duties, preserving each duty configuration while disabled
- document the switch and cover validation, settings snapshots, every enqueue path, queued-job retirement, and UI persistence

## Verification

- full pre-commit gate: Go build/tests, 219 frontend test files (2,455 passed; 15 skipped), production frontend build, Playwright (192 passed; 1 environment-skipped)
- Linux amd64 daemon cross-compile
- isolated packaged-app preflight at protocol 207
- live Settings round trip: disable persisted `false`; fresh relaunch rehydrated the control and enabling persisted `true`; isolated profile cleaned afterward

## Related

- #742 added the independent session-summary switch that this narration control complements