### PR TITLE
fix(terminal): keep hovered links stable during output

### DIFF
--- a/app/e2e/terminal-interactions.spec.ts
+++ b/app/e2e/terminal-interactions.spec.ts
@@ -34,6 +34,32 @@ async function writeTerminalOutput(
   }, { id: sessionId, data: output });
 }
 
+async function dispatchStationaryCmdClick(
+  terminal: import('@playwright/test').Locator,
+  position: { x: number; y: number },
+) {
+  const box = await terminal.boundingBox();
+  expect(box).not.toBeNull();
+  await terminal.evaluate((element, point) => {
+    element.dispatchEvent(new MouseEvent('mousedown', {
+      bubbles: true,
+      button: 0,
+      buttons: 1,
+      clientX: point.clientX,
+      clientY: point.clientY,
+      metaKey: true,
+    }));
+    element.dispatchEvent(new MouseEvent('mouseup', {
+      bubbles: true,
+      button: 0,
+      buttons: 0,
+      clientX: point.clientX,
+      clientY: point.clientY,
+      metaKey: true,
+    }));
+  }, { clientX: box!.x + position.x, clientY: box!.y + position.y });
+}
+
 async function installOpenerProbe(page: import('@playwright/test').Page) {
   await page.addInitScript(() => {
     (window as Window & { __OPENED_TERMINAL_URLS?: string[] }).__OPENED_TERMINAL_URLS = [];
@@ -416,6 +442,12 @@ test.describe('Ghostty terminal interactions', () => {
     await page.keyboard.down('Meta');
     await expect(terminal).toHaveCSS('cursor', 'pointer', { timeout: 3000 });
 
+    const renderCountBefore = await page.evaluate((sessionId) => {
+      const snapshots = window.__ATTN_TERMINAL_PERF_DUMP?.() ?? [];
+      return snapshots.find((snapshot) => snapshot.sessionId === sessionId)?.renderCount ?? null;
+    }, 's-file-link-stream');
+    expect(renderCountBefore).not.toBeNull();
+
     // An agent TUI repaints constantly (spinner frames, status line). The
     // pointer does not move while unrelated writes land on another row; the
     // hovered link must stay resolved and clickable.
@@ -428,8 +460,21 @@ test.describe('Ghostty terminal interactions', () => {
       await page.waitForTimeout(120);
     }
 
+    const renderCountAfter = await page.evaluate((sessionId) => {
+      const snapshots = window.__ATTN_TERMINAL_PERF_DUMP?.() ?? [];
+      return snapshots.find((snapshot) => snapshot.sessionId === sessionId)?.renderCount ?? null;
+    }, 's-file-link-stream');
+    expect(renderCountAfter).not.toBeNull();
+    // Revalidation runs inside the output paint. It must not add another paint
+    // per packet on top of the terminal's animation-frame-coalesced renderer.
+    expect(renderCountAfter! - renderCountBefore!).toBeLessThanOrEqual(6);
+
     await expect(terminal).toHaveCSS('cursor', 'pointer');
-    await terminal.click({ position: { x: 55, y: 8 } });
+
+    // Dispatch at the stationary pointer coordinates. locator.click() moves the
+    // synthetic mouse before pressing, which used to hide this regression by
+    // refreshing the stale hover cache immediately before mousedown.
+    await dispatchStationaryCmdClick(terminal, { x: 55, y: 8 });
     await page.keyboard.up('Meta');
 
     await expect
@@ -440,6 +485,28 @@ test.describe('Ghostty terminal interactions', () => {
         { timeout: 3000 },
       )
       .toContain('/tmp/test/terminal-links/src/main.go');
+
+    // Revalidation must still reject a genuinely stale target. Replace the
+    // hovered row without moving the pointer, then prove the old path neither
+    // advertises nor opens.
+    await writeTerminalOutput(page, 's-file-link-stream', '[1;1H[2Kplain text');
+    await expect
+      .poll(
+        async () => page.evaluate(() => window.__TEST_GET_SESSION_PANE_TEXT?.('s-file-link-stream') ?? ''),
+        { timeout: 3000 },
+      )
+      .toContain('plain text');
+    await page.keyboard.down('Meta');
+    await expect(terminal).toHaveCSS('cursor', 'text');
+    await dispatchStationaryCmdClick(terminal, { x: 55, y: 8 });
+    await page.keyboard.up('Meta');
+    await expect
+      .poll(
+        async () => page.evaluate(
+          () => (window as Window & { __OPENED_TERMINAL_PATHS?: string[] }).__OPENED_TERMINAL_PATHS ?? [],
+        ),
+      )
+      .toEqual(['/tmp/test/terminal-links/src/main.go']);
   });
 
   test('does not mark non-existing path-like words as links', async ({ page, daemon }) => {

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useRef,
   useState,
 } from 'react';
@@ -3072,11 +3073,19 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       })();
     }, [cachedPathExists, ensureHomeDir, hyperlinkUriAtViewportCell, isContinuationRow, knownPathExists, lineAtVisibleRow, renderSurface, updateLinkCursor]);
 
-    refreshHoverLinkRef.current = () => {
-      const current = hoverLinkRef.current;
-      if (!current || current.generation === hoverGenerationRef.current) return;
-      detectHoverLink(hoveredCellRef.current, { force: true, repaint: false });
-    };
+    useLayoutEffect(() => {
+      const refreshHoverLink = () => {
+        const current = hoverLinkRef.current;
+        if (!current || current.generation === hoverGenerationRef.current) return;
+        detectHoverLink(hoveredCellRef.current, { force: true, repaint: false });
+      };
+      refreshHoverLinkRef.current = refreshHoverLink;
+      return () => {
+        if (refreshHoverLinkRef.current === refreshHoverLink) {
+          refreshHoverLinkRef.current = null;
+        }
+      };
+    }, [detectHoverLink]);
 
     // Link under a cell for click handling: prefer the resolved hover state
     // (paths require it — existence was already validated), fall back to a

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -663,6 +663,11 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const cwdRef = useRef(cwd);
     const hoverGenerationRef = useRef(0);
     const hoverLinkRef = useRef<HoverLinkState | null>(null);
+    // Model writes and viewport changes happen above the hover-link callbacks in
+    // this module. They invalidate by generation; the next paint (or click)
+    // crosses this seam to re-read the one logical line under the stationary
+    // pointer before trusting or drawing the cached link.
+    const refreshHoverLinkRef = useRef<(() => void) | null>(null);
     // undefined = not fetched yet; null = unavailable (non-Tauri host).
     const homeDirRef = useRef<string | null | undefined>(undefined);
     const pathExistsCacheRef = useRef(new Map<string, boolean | Promise<boolean>>());
@@ -914,6 +919,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       if (!terminal || !renderer) return true;
       if (runtimeMetaRef.current && !runtimeMetaRef.current.isActiveSession) return true;
       try {
+      refreshHoverLinkRef.current?.();
       const range = selectionRef.current ? normalizeSelection(selectionRef.current) : null;
       const scrollbackLength = terminal.getScrollbackLength();
       const overlays: WebGlOverlay[] = [];
@@ -2870,6 +2876,11 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       return pending;
     }, []);
 
+    const knownPathExists = useCallback((absolutePath: string): boolean | undefined => {
+      const cached = pathExistsCacheRef.current.get(absolutePath);
+      return typeof cached === 'boolean' ? cached : undefined;
+    }, []);
+
     const ensureHomeDir = useCallback(async (): Promise<string | null> => {
       if (homeDirRef.current === undefined) {
         try {
@@ -2900,21 +2911,29 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     // hovered row joined with its soft-wrapped neighbors). Movement inside the
     // cached fragment exits immediately; URLs resolve synchronously; file
     // paths are validated asynchronously against the filesystem (cached).
-    const detectHoverLink = useCallback((cell: { row: number; col: number } | null) => {
+    const detectHoverLink = useCallback((
+      cell: { row: number; col: number } | null,
+      options: { force?: boolean; repaint?: boolean } = {},
+    ) => {
+      const force = options.force ?? false;
+      const repaint = options.repaint ?? true;
       const generation = hoverGenerationRef.current;
       const current = hoverLinkRef.current;
-      if (cell && current && current.generation === generation) {
+      if (!force && cell && current && current.generation === generation) {
         const cachedIndex = logicalIndexForCell(current.line, cell.row, cell.col);
         if (cachedIndex !== null && cachedIndex >= current.startIndex && cachedIndex < current.endIndex) {
           return;
         }
       }
-      const hadUnderline = Boolean(current?.link && current.generation === generation);
+      // A stale generation can still be the underline currently painted on the
+      // canvas. Treat it as visible until this revalidation and the following
+      // paint replace it.
+      const hadUnderline = Boolean(current?.link);
       const clearHover = () => {
         hoverLinkRef.current = null;
+        setLinkCursorActive(false);
         if (hadUnderline) {
-          renderSurface(true);
-          setLinkCursorActive(false);
+          if (repaint) renderSurface(true);
         }
       };
       const terminal = terminalRef.current;
@@ -2945,7 +2964,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           link: { kind: 'url', uri: hyperlink.uri, startCol: hyperlink.startCol, endCol: hyperlink.endCol },
           linkSpan: spanFromLogicalRange(logical, hyperlink.startCol, hyperlink.endCol),
         };
-        renderSurface(true);
+        if (repaint) renderSurface(true);
         updateLinkCursor(cell, acceleratorHeldRef.current);
         return;
       }
@@ -2959,7 +2978,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           link: { kind: 'url', uri: url.uri, startCol: url.startCol, endCol: url.endCol },
           linkSpan: spanFromLogicalRange(logical, url.startCol, url.endCol),
         };
-        renderSurface(true);
+        if (repaint) renderSurface(true);
         updateLinkCursor(cell, acceleratorHeldRef.current);
         return;
       }
@@ -2978,21 +2997,65 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       };
       hoverLinkRef.current = entry;
       if (hadUnderline) {
-        renderSurface(true);
         setLinkCursorActive(false);
+        if (repaint) renderSurface(true);
       }
       const candidates = pathCandidatesForFragment(
         logical.text.slice(fragment.startCol, fragment.endCol),
         fragment.startCol,
       );
       if (candidates.length === 0) return;
+
+      // A write elsewhere in the terminal must not turn an already-validated
+      // path back into an asynchronous question. Re-read the candidate beneath
+      // the pointer and carry the resolution forward only when its target and
+      // text range are still identical. A positive filesystem cache answer is
+      // equally safe to promote synchronously.
+      const previousPath = current?.link?.kind === 'path' ? current.link : null;
+      for (const candidate of candidates) {
+        const absolutePath = resolveDetectedPath(
+          candidate.path,
+          cwdRef.current,
+          homeDirRef.current ?? undefined,
+        );
+        if (!absolutePath) continue;
+        const reusesPrevious = Boolean(
+          previousPath
+          && previousPath.absolutePath === absolutePath
+          && previousPath.startCol === candidate.startCol
+          && previousPath.endCol === candidate.endCol,
+        );
+        if (!reusesPrevious && knownPathExists(absolutePath) !== true) continue;
+        entry.link = {
+          kind: 'path',
+          absolutePath,
+          line: candidate.line,
+          column: candidate.column,
+          startCol: candidate.startCol,
+          endCol: candidate.endCol,
+        };
+        entry.linkSpan = spanFromLogicalRange(logical, candidate.startCol, candidate.endCol);
+        if (repaint) renderSurface(true);
+        updateLinkCursor(cell, acceleratorHeldRef.current);
+        return;
+      }
+
       void (async () => {
         const home = await ensureHomeDir();
         for (const candidate of candidates) {
           const absolutePath = resolveDetectedPath(candidate.path, cwdRef.current, home ?? undefined);
           if (!absolutePath) continue;
-          if (!(await cachedPathExists(absolutePath))) continue;
-          if (hoverLinkRef.current !== entry || hoverGenerationRef.current !== generation) return;
+          const known = knownPathExists(absolutePath);
+          if (known === false) continue;
+          if (known !== true && !(await cachedPathExists(absolutePath))) continue;
+          if (hoverLinkRef.current !== entry) return;
+          if (hoverGenerationRef.current !== generation) {
+            // The model changed while validation was in flight. Re-read the
+            // current cell; the now-cached answer is promoted synchronously if
+            // this exact candidate survived the write.
+            refreshHoverLinkRef.current?.();
+            return;
+          }
           entry.link = {
             kind: 'path',
             absolutePath,
@@ -3007,12 +3070,19 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           return;
         }
       })();
-    }, [cachedPathExists, ensureHomeDir, hyperlinkUriAtViewportCell, isContinuationRow, lineAtVisibleRow, renderSurface, updateLinkCursor]);
+    }, [cachedPathExists, ensureHomeDir, hyperlinkUriAtViewportCell, isContinuationRow, knownPathExists, lineAtVisibleRow, renderSurface, updateLinkCursor]);
+
+    refreshHoverLinkRef.current = () => {
+      const current = hoverLinkRef.current;
+      if (!current || current.generation === hoverGenerationRef.current) return;
+      detectHoverLink(hoveredCellRef.current, { force: true, repaint: false });
+    };
 
     // Link under a cell for click handling: prefer the resolved hover state
     // (paths require it — existence was already validated), fall back to a
     // synchronous URL scan for clicks that arrive before any hover.
     const linkAtCell = useCallback((cell: { row: number; col: number } | null): DetectedTerminalLink | null => {
+      refreshHoverLinkRef.current?.();
       const hovered = hoverLinkAtCell(cell);
       if (hovered) return hovered;
       if (!cell) return null;

--- a/changelog.d/bashful-marmot-terminal-link-streaming.yaml
+++ b/changelog.d/bashful-marmot-terminal-link-streaming.yaml
@@ -1,0 +1,14 @@
+kind: fixed
+area: terminal
+change: >
+  Links under the pointer now stay highlighted and clickable while an agent is
+  streaming output elsewhere in the terminal.
+symptom: >
+  Holding Command over a URL or file path made its underline and pointer flash,
+  and file-path clicks could stop working whenever a spinner or status line
+  redrew the terminal.
+notes: >
+  The terminal revalidates the logical line under the stationary pointer inside
+  the existing output paint, retains an unchanged validated path without new
+  filesystem work, and still drops the link immediately when that text moves or
+  changes.


### PR DESCRIPTION
## Intent / Why

Terminal output invalidated the hover generation on every write. When the pointer stayed over a link, unrelated spinner or status-line updates could therefore make the underline and cursor flash, and file-path clicks could lose their validated target.

Keep terminal links stable through streaming output while preserving the rule that changed or moved text is no longer clickable.

## Summary

- revalidate the logical line under the stationary pointer inside the terminal's existing paint, and again at the click boundary
- carry an unchanged validated path forward synchronously, using the existing filesystem cache without adding a second repaint loop
- strengthen the terminal interaction regression with a truly stationary Cmd-click, stale-target rejection, and a render-count bound

## Verification

- pre-commit frontend tests: 2,455 passed, 15 skipped
- production frontend build
- pre-commit Playwright suite: 192 passed, 1 skipped
- isolated packaged-app preflight
- native terminal markdown-link scenario: plain click, Cmd-click for two paths, and tile reuse
