### PR TITLE
perf(terminal): reduce sustained rendering work

### DIFF
--- a/PERF.md
+++ b/PERF.md
@@ -1,0 +1,171 @@
+# Terminal rendering performance log
+
+This log records terminal rendering experiments on `perf/terminal-stream-rendering`.
+It keeps rejected approaches beside accepted ones so later work does not repeat
+measurements or trade away responsiveness for an attractive microbenchmark.
+
+## Guardrails
+
+- Preserve every terminal byte and always paint the newest model state.
+- Keep direct interaction paints immediate. Any frame-rate policy applies only
+  while PTY output is arriving continuously.
+- Do not add a continuous repaint loop.
+- Keep renderer-owned CPU staging bounded. The main vertex buffer starts at
+  128 KiB and a dense 151 x 46 pane grows it to 2 MiB; optimizations should not
+  add another full-frame retained copy without stronger evidence.
+- Run packaged-app measurements only in an isolated named profile and clean it
+  immediately afterwards. Production `~/.attn` remains read-only.
+
+## Measurement methods
+
+### Packaged PTY burst
+
+`bridge-pty-bench.mjs` injects a 2 MiB payload into one utility pane and records
+transport time, process CPU/RSS samples, renderer paint count, and synchronous
+renderer CPU time. This is a no-regression receipt for the complete path, but it
+is too short to attribute small renderer changes reliably.
+
+### Sustained PTY output
+
+The same harness accepts `--chunk-delay-ms` so writes span many display frames.
+This exposes paint cadence and CPU during continuous output instead of collapsing
+the whole payload into one browser frame.
+
+### Focused vertex assembly
+
+A CPU-only benchmark assembles 3,200 quads for 250 frames. It isolates JavaScript
+staging cost from PTY parsing, WebKit scheduling, and GPU submission.
+
+## Experiments
+
+### 1. Reuse typed vertex staging - accepted
+
+Change: replace per-paint `number[]` construction plus `new Float32Array(...)`
+copies with a grow-on-demand reusable `Float32Array` shared by both terminal
+renderers.
+
+Focused result across five runs:
+
+| implementation | 250 frames | relative | saved per frame |
+| --- | ---: | ---: | ---: |
+| `number[]` plus typed copy | 205.85-211.63 ms | 1.0x | - |
+| reused typed buffer | 28.33-29.36 ms | 7.07-7.41x | 0.709-0.732 ms |
+
+Packaged 2 MiB burst result:
+
+| batching | before | after | renderer paints after | renderer CPU after |
+| --- | ---: | ---: | ---: | ---: |
+| x1 | 65 ms | 50 ms | 1 | 7 ms |
+| x8 | 49 ms | 51 ms | 1 | < 0.5 ms |
+| x32 | 49 ms | 50 ms | 1 | < 0.5 ms |
+
+Decision: keep. The focused benchmark isolates the gain; the short packaged run
+shows no transport regression but is intentionally not used to claim the x1
+difference is entirely renderer work.
+
+Memory: 128 KiB initially and about 2 MiB retained for a dense 151 x 46 pane,
+replacing at least about 4.5 MiB of transient JavaScript and typed-array
+allocations on every dense paint.
+
+### 2. Cap sustained output paints - accepted
+
+Hypothesis: output is already coalesced to one animation-frame callback, but
+continuous output still drives a full-grid paint on every 60 Hz browser frame.
+Capping continuous PTY-output paints at 30 Hz should roughly halve renderer and
+GPU submission work while retaining immediate interaction paints and a final
+paint of the newest model state.
+
+Instrumentation change: add delayed chunks to the packaged harness so the same
+payload crosses many frames. Record the baseline before changing scheduling.
+
+Baseline, packaged `terminal-perf` profile, 240 x 4 KiB chunks with a requested
+4 ms inter-chunk delay:
+
+| batching | elapsed | paints | paints/s | renderer CPU | sampled CPU max | RSS max |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| x1 | 1,932 ms | 115 | 59.5 | 27 ms | 110.8% | 597.9 MiB |
+| x8 | 1,917 ms | 31 | 16.2 | 12 ms | 17.1% | 704.2 MiB |
+| x32 | 1,900 ms | 9 | 4.7 | 1 ms | 14.2% | 705.0 MiB |
+
+The timer is clamped to roughly 8 ms in this packaged WebView, so the x1 case
+delivers about two writes per 60 Hz display frame. This is the useful cadence
+baseline; elapsed time is pacing-controlled and not a throughput score.
+
+Paired 8-second binary-path run, 1,000 x 4 KiB chunks:
+
+| output cap | elapsed | paints | paints/s | total CPU avg | WebContent CPU avg | GPU CPU avg |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 60 Hz control | 8,005 ms | 473 | 59.1 | 18.7% | 10.56% | 4.38% |
+| 30 Hz adaptive | 8,015 ms | 231 | 28.8 | 19.1% | 10.60% | 4.02% |
+
+Decision: keep. Paint and GPU submission counts fell by 51% and GPU-process CPU
+fell by about 8%. Whole-process CPU was flat, which shows model writes and other
+PTY work dominate this particular stream. The scheduler adds no frame buffer or
+continuous loop: the first output after idle paints on the next browser frame,
+continuous output keeps only the newest model state at 30 Hz, and the final state
+is painted within the same 33 ms budget. Direct interaction paints bypass it.
+
+### 3. Skip string escape parsing for plain chunks - rejected
+
+Attempt: scan each byte chunk for ESC and avoid UTF-8 decoding plus OSC 52 and
+synchronized-output string scans when no escape protocol could be present.
+
+Focused Node benchmark, 50,000 iterations over a 4,107-byte plain chunk:
+
+| path | five-run range |
+| --- | ---: |
+| fresh `TextDecoder` plus three string searches | 35.32-37.02 ms |
+| reused `TextDecoder` plus three string searches | 30.29-30.68 ms |
+| `Uint8Array.indexOf(ESC)` fast path | 48.78-49.35 ms |
+
+The typed-array scan was 33-40% slower than the existing decoder/string work in
+this runtime. A packaged run was noisy in the same direction (18.7% to 25.8%
+average sampled CPU), so the attempt was removed rather than justified by its
+plausible-looking design.
+
+### 4. Pack cell colors and cache codepoint glyph keys - accepted
+
+Change: represent per-cell foreground/background colors as packed numbers and
+look up ordinary single-codepoint glyphs by a numeric `(codepoint, style)` key.
+This removes two RGB object allocations plus character/style key construction
+for nearly every visible cell. Grapheme clusters keep the string-key path.
+
+Focused 151 x 46 hot-loop benchmark, 500 frames, three five-run invocations:
+
+| implementation | 500 frames | relative |
+| --- | ---: | ---: |
+| RGB objects plus string glyph keys | 26.25-30.52 ms | 1.0x |
+| packed RGB plus numeric glyph keys | 15.32-18.38 ms | 1.55-1.92x |
+
+The final-diff recheck produced paired speedups of 1.92x, 1.68x, 1.66x,
+1.68x, and 1.70x; its absolute times stayed within the earlier envelope.
+
+Decision: keep. The numeric map contains one extra pointer per atlas glyph and
+clears with the atlas, so it is bounded by the existing glyph set rather than by
+frame count or terminal history. It adds no full-frame copy and leaves the 2 MiB
+vertex-staging guardrail unchanged.
+
+Final packaged run with both retained optimizations, 1,000 x 4 KiB binary chunks
+and a requested 4 ms delay:
+
+| elapsed | processed | paints | paints/s | renderer CPU | scheduler requests / coalesced / deferred | RSS max |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 7,993 ms | 4,096,000 bytes | 233 | 29.2 | 37 ms | 1,004 / 772 / 247 | 653.3 MiB |
+
+The whole-process CPU samples in this last run were noisy (23.1% average, 90.0%
+p95, 155.5% maximum), so they are recorded rather than used to claim a delta.
+The paired control in experiment 2 is the defensible CPU comparison.
+
+## Verification
+
+- Packaged `terminal-perf` preflight passed with the final build.
+- The packaged Markdown-link scenario passed plain selection, two Command-click
+  opens, and repeated-link tile reuse.
+- The streaming regression `hovered file link survives unrelated terminal
+  writes (streaming TUI redraws)` passed.
+- The full frontend suite and production frontend build passed; Playwright
+  finished with 192 passed and the expected real-PTY-only case skipped.
+- All benchmark streams verified the expected chunk count and byte count; no
+  terminal output was dropped.
+- The isolated `terminal-perf` app, daemon, and data were removed after the
+  packaged measurements; the production profile was never selected.

--- a/PERF.md
+++ b/PERF.md
@@ -36,6 +36,14 @@ the whole payload into one browser frame.
 A CPU-only benchmark assembles 3,200 quads for 250 frames. It isolates JavaScript
 staging cost from PTY parsing, WebKit scheduling, and GPU submission.
 
+### Dense in-place redraw
+
+`bridge-pty-bench.mjs --payload progress` first fills every terminal row, then
+streams 4 KiB carriage-return/erase-line updates for eight seconds. The harness
+waits past one 30 Hz paint interval after seeding and records the fixture's
+printable-cell count, so a blank or not-yet-painted fixture cannot masquerade as
+a renderer win. Optional window dimensions locate size-dependent crossovers.
+
 ## Experiments
 
 ### 1. Reuse typed vertex staging - accepted
@@ -156,6 +164,90 @@ The whole-process CPU samples in this last run were noisy (23.1% average, 90.0%
 p95, 155.5% maximum), so they are recorded rather than used to claim a delta.
 The paired control in experiment 2 is the defensible CPU comparison.
 
+### 5. Batch model writes until the next frame - rejected
+
+Attempt: apply the first arriving write immediately, then combine subsequent
+writes until the next animation frame, capped at 64 KiB. This reduced scheduler
+requests from about 1,003 to 481, but did not remove the expensive model work and
+delayed terminal state used by selection, queries, blocks, and automation.
+
+Packaged 1,000 x 4 KiB progress run at the default pane size:
+
+| path | CPU avg | paints | renderer CPU | measured write CPU |
+| --- | ---: | ---: | ---: | ---: |
+| direct writes | 25.2% | 228 | 14 ms | 84 ms |
+| frame-batched writes | 20.2% | 227 | 18 ms | 79 ms |
+
+Decision: reject. The five-millisecond write delta is too small and noisy to
+justify making model state asynchronous. The prototype and its tests were
+removed.
+
+### 6. Paint only dirty framebuffer rows - rejected
+
+Attempt: use Ghostty's partial dirty state, expand changed rows by one neighbor
+for cross-row glyph pixels, scissor-clear those rows, and submit only their
+vertices. A real-WASM probe confirmed that progress and cursor movement are
+partial while scrolling, erase-display, and alternate-screen transitions are
+full.
+
+The first benchmark fixture was mostly blank, so its low quad count was not
+accepted as evidence. After adding a dense fixture, the design still failed the
+quality guardrail: WebGL contexts default to `preserveDrawingBuffer: false`, so
+untouched pixels are not guaranteed to survive compositing. Enabling retention
+would add a device-pixel framebuffer—potentially tens of MiB for a large Retina
+pane—rather than the bounded CPU staging memory already allowed here.
+
+Decision: reject. The scissored framebuffer path was removed. The real-WASM
+dirty-state probe remains as a repeatable contract check.
+
+### 7. Rebuild dirty rows into a bounded vertex cache - accepted above 2,048 cells
+
+Change: retain each active-grid row in the existing CPU vertex format. On a
+partial Ghostty update, rebuild the dirty row plus its neighbors, concatenate
+the cached rows, then clear and submit the complete frame. This preserves exact
+pixels without a retained framebuffer. Scrolled views, overlays, images, full
+dirty states, atlas changes, and forced renders take or invalidate the full
+path.
+
+The complete frame still reaches the GPU, so this targets JavaScript cell/glyph
+assembly rather than GPU fill. A size gate avoids paying the cache-copy overhead
+when a small grid is cheaper to rebuild.
+
+Packaged dense-progress A/B, 1,000 x 4 KiB binary chunks:
+
+| split-pane fixture | control rows rebuilt | cached rows rebuilt | control renderer CPU | cached renderer CPU | cache memory | result |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| default, 31 x 25 | 5,500 | 440 | 15 ms | 22 ms | 0.160 MiB | reject cache |
+| 1,785 printable cells | 8,085 | 462 | 57 ms | 33 ms | 0.382 MiB | measured win; below final gate |
+| 3,212 printable cells | 10,252 | 458 | 66 ms | 46 ms | 0.680 MiB | keep cache |
+
+At the medium point, renderer staging fell 42%; at the large point its per-frame
+average fell from 0.283 ms to 0.201 ms (29%). The large run's total CPU average
+also fell from 53.0% to 26.9%, but process sampling and write-stage timings were
+too noisy across runs to attribute that whole delta to the renderer. The exact
+row counts and renderer-local timings are the acceptance evidence.
+
+Four final valid large-pane repetitions reported 16, 27, 43, and 66 ms of
+renderer-local CPU (median 35 ms). All four retained 0.680 MiB, began with
+3,212 printable cells, and rebuilt two rows per partial paint. The timing range
+is wider than the structural work counters, so the median is recorded without
+turning it into a stronger CPU claim. An earlier apparent 9 ms result began
+with only 77 printable cells after late shell output disturbed the fixture; it
+was rejected, and the harness now refuses a progress fixture below 50% density.
+
+Decision: keep behind a conservative 2,048-cell threshold and a 2 MiB retained
+cache ceiling. The measured default pane and a 62 x 25 packaged interaction pane
+stay on the direct path with no
+cache allocation; the latter had inconsistent native Command-click results in
+two validation runs at the earlier 1,536 cutoff, so the performance crossover
+alone was not enough to keep that aggressive gate. Retained memory is
+proportional to the visible grid and rendered quads: 0.680 MiB at the accepted
+large measurement point, and roughly 1.5 MiB for the earlier dense 151 x 46
+reference pane. If real styling grows the rows beyond 2 MiB, the renderer
+releases them and keeps that grid on its existing direct path until resize. The
+full-frame submission keeps the visual result and 30 Hz
+sustained-output policy unchanged.
+
 ## Verification
 
 - Packaged `terminal-perf` preflight passed with the final build.
@@ -163,9 +255,14 @@ The paired control in experiment 2 is the defensible CPU comparison.
   opens, and repeated-link tile reuse.
 - The streaming regression `hovered file link survives unrelated terminal
   writes (streaming TUI redraws)` passed.
+- A styled 3,000-cell unit fixture exceeded the 2 MiB row-cache ceiling,
+  released the cache, and used the direct full-frame path on its next paint.
 - The full frontend suite and production frontend build passed; Playwright
   finished with 192 passed and the expected real-PTY-only case skipped.
 - All benchmark streams verified the expected chunk count and byte count; no
   terminal output was dropped.
 - The isolated `terminal-perf` app, daemon, and data were removed after the
-  packaged measurements; the production profile was never selected.
+  packaged measurements. No install, benchmark, daemon lifecycle action, or
+  mutation targeted production; one initial read-only preflight resolved the
+  production socket before all subsequent work was explicitly routed to the
+  isolated profile.

--- a/app/scripts/bench-terminal-cell-hot-loop.mjs
+++ b/app/scripts/bench-terminal-cell-hot-loop.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+import { performance } from 'node:perf_hooks';
+
+const cols = 151;
+const rows = 46;
+const frames = 500;
+const cells = Array.from({ length: cols * rows }, (_, index) => ({
+  codepoint: 32 + index % 95,
+  flags: index % 19 === 0 ? 1 : index % 31 === 0 ? 2 : 0,
+  fg_r: 224,
+  fg_g: 224,
+  fg_b: 224,
+  bg_r: index % 17 === 0 ? 32 : 0,
+  bg_g: 0,
+  bg_b: 0,
+}));
+
+const stringGlyphs = new Map();
+const numericGlyphs = new Map();
+for (let codepoint = 32; codepoint < 127; codepoint += 1) {
+  for (let style = 0; style < 4; style += 1) {
+    const styleText = `${style & 1 ? 'italic ' : ''}${style & 2 ? 'bold ' : ''}`;
+    stringGlyphs.set(`${styleText}${String.fromCodePoint(codepoint)}`, codepoint);
+    numericGlyphs.set(codepoint * 4 + style, codepoint);
+  }
+}
+
+function oldCellLoop() {
+  let checksum = 0;
+  for (let frame = 0; frame < frames; frame += 1) {
+    for (const cell of cells) {
+      const fg = { r: cell.fg_r, g: cell.fg_g, b: cell.fg_b };
+      const bg = { r: cell.bg_r, g: cell.bg_g, b: cell.bg_b };
+      const style = `${cell.flags & 2 ? 'italic ' : ''}${cell.flags & 1 ? 'bold ' : ''}`;
+      const key = `${style}${String.fromCodePoint(cell.codepoint)}`;
+      checksum += (stringGlyphs.get(key) ?? 0) + fg.r + bg.r;
+    }
+  }
+  return checksum;
+}
+
+function newCellLoop() {
+  let checksum = 0;
+  for (let frame = 0; frame < frames; frame += 1) {
+    for (const cell of cells) {
+      const fg = cell.fg_r << 16 | cell.fg_g << 8 | cell.fg_b;
+      const bg = cell.bg_r << 16 | cell.bg_g << 8 | cell.bg_b;
+      const style = (cell.flags & 2 ? 1 : 0) | (cell.flags & 1 ? 2 : 0);
+      checksum += (numericGlyphs.get(cell.codepoint * 4 + style) ?? 0)
+        + (fg >>> 16 & 0xff)
+        + (bg >>> 16 & 0xff);
+    }
+  }
+  return checksum;
+}
+
+function measure(run) {
+  const startedAt = performance.now();
+  const checksum = run();
+  return { ms: performance.now() - startedAt, checksum };
+}
+
+measure(oldCellLoop);
+measure(newCellLoop);
+
+const runs = Array.from({ length: 5 }, () => {
+  const oldResult = measure(oldCellLoop);
+  const newResult = measure(newCellLoop);
+  if (oldResult.checksum !== newResult.checksum) {
+    throw new Error(`checksum mismatch: ${oldResult.checksum} != ${newResult.checksum}`);
+  }
+  return {
+    oldMs: Number(oldResult.ms.toFixed(2)),
+    newMs: Number(newResult.ms.toFixed(2)),
+    speedup: Number((oldResult.ms / newResult.ms).toFixed(2)),
+  };
+});
+
+console.log(JSON.stringify({ cols, rows, frames, runs }, null, 2));

--- a/app/scripts/bench-terminal-dirty-rows.mjs
+++ b/app/scripts/bench-terminal-dirty-rows.mjs
@@ -47,6 +47,11 @@ write(
   Array.from({ length: 300 }, (_, index) => `\r\x1b[2Kp ${String(index).padStart(6, '0')} xx`).join('').slice(0, 4096),
 );
 write('cursor move only', '\x1b[2;4H');
+write('cursor move within one row', '\x1b[2;9H');
+write('cursor back one column', '\x1b[D');
+write('hide cursor', '\x1b[?25l');
+write('cursor move while hidden', '\x1b[4;2H');
+write('show cursor', '\x1b[?25h');
 write('overwrite one row', 'updated');
 write('erase display', '\x1b[2J');
 const denseRows = Array.from({ length: terminal.rows }, (_, row) => (

--- a/app/scripts/bench-terminal-dirty-rows.mjs
+++ b/app/scripts/bench-terminal-dirty-rows.mjs
@@ -1,0 +1,67 @@
+// Inspect the vendored Ghostty model's dirty-row contract with representative
+// terminal updates. This is intentionally a real-WASM probe: renderer tests use
+// fakes and cannot establish which rows libghostty-vt marks dirty.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { Ghostty } from 'ghostty-web';
+
+const APP_ROOT = fileURLToPath(new URL('..', import.meta.url));
+const wasm = await WebAssembly.compile(readFileSync(`${APP_ROOT}/vendor/ghostty-vt/ghostty-vt.wasm`));
+let instance;
+instance = await WebAssembly.instantiate(wasm, {
+  env: {
+    log: (ptr, len) => {
+      const memory = new Uint8Array(instance.exports.memory.buffer, ptr, len);
+      console.error(new TextDecoder().decode(memory));
+    },
+  },
+});
+const ghostty = new Ghostty(instance);
+const terminal = ghostty.createTerminal(20, 6);
+
+function dirtyRows() {
+  const state = terminal.update();
+  const rows = [];
+  for (let row = 0; row < terminal.rows; row += 1) {
+    if (terminal.isRowDirty(row)) rows.push(row);
+  }
+  const printable = terminal.getViewport().slice(0, terminal.cols * terminal.rows)
+    .filter((cell) => cell?.codepoint > 32).length;
+  terminal.markClean();
+  return { state, rows, printable };
+}
+
+function write(label, bytes) {
+  terminal.write(bytes);
+  console.log(JSON.stringify({ label, ...dirtyRows() }));
+}
+
+// Establish the initial FULL state and then measure independent updates.
+console.log(JSON.stringify({ label: 'initial', ...dirtyRows() }));
+write('plain text', 'hello');
+write('carriage-return progress', '\rprogress 42%');
+write('erase-line progress', '\r\x1b[2Kprogress 43%');
+write(
+  '4 KiB erase-line progress',
+  Array.from({ length: 300 }, (_, index) => `\r\x1b[2Kp ${String(index).padStart(6, '0')} xx`).join('').slice(0, 4096),
+);
+write('cursor move only', '\x1b[2;4H');
+write('overwrite one row', 'updated');
+write('erase display', '\x1b[2J');
+const denseRows = Array.from({ length: terminal.rows }, (_, row) => (
+  `\x1b[${row + 1};1H${`${String(row).padStart(3, '0')} ${'.'.repeat(terminal.cols)}`.slice(0, terminal.cols - 1)}`
+)).join('') + '\x1b[1;1H';
+write('dense positioned rows', denseRows);
+write('dense-row progress', '\r\x1b[2Kp 000001 xx');
+write('clear before combined writes', '\x1b[2J');
+terminal.write(denseRows);
+terminal.write('\r\x1b[2Kp 000002 xx');
+console.log(JSON.stringify({ label: 'unpainted seed then progress', ...dirtyRows() }));
+write('fill viewport', Array.from({ length: 6 }, (_, row) => `row ${row}\r\n`).join(''));
+write('scroll one line', 'scroll\r\n');
+write('enter alternate screen', '\x1b[?1049h');
+write('alternate-screen text', 'alternate');
+write('leave alternate screen', '\x1b[?1049l');
+
+terminal.free();

--- a/app/scripts/real-app-harness/bridge-perf.mjs
+++ b/app/scripts/real-app-harness/bridge-perf.mjs
@@ -353,12 +353,12 @@ function formatCheckpointSummary(checkpoint) {
   };
 }
 
-function getShellPanes(workspace) {
-  return (workspace.panes || []).filter((pane) => pane.kind === 'shell' && pane.runtime_id);
-}
-
 async function createUtilityPanes(client, observer, sessionId, count) {
   let workspace = await client.request('get_workspace', { sessionId });
+  const excludedPaneIds = new Set(
+    (observer.getWorkspace(sessionId)?.panes || []).map((pane) => pane.pane_id),
+  );
+  const utilityPanes = [];
   for (let index = 0; index < count; index += 1) {
     const targetPaneId = workspace.activePaneId || workspace.panes?.[0]?.paneId;
     if (!targetPaneId) {
@@ -369,14 +369,19 @@ async function createUtilityPanes(client, observer, sessionId, count) {
       targetPaneId,
       direction: 'vertical',
     });
-    workspace = await observer.waitForWorkspace(
+    const utilityPane = await observer.waitForUtilityPane(
       sessionId,
-      (entry) => getShellPanes(entry).length >= index + 1,
-      `shell pane count >= ${index + 1}`,
       20_000,
+      excludedPaneIds,
     );
+    if (!utilityPane) {
+      throw new Error(`Utility pane ${index + 1} not found for ${sessionId}`);
+    }
+    excludedPaneIds.add(utilityPane.pane_id);
+    utilityPanes.push(utilityPane);
+    workspace = await client.request('get_workspace', { sessionId });
   }
-  return getShellPanes(workspace);
+  return utilityPanes;
 }
 
 function countOccurrences(haystack, needle) {
@@ -422,8 +427,11 @@ async function runTerminalLoad(client, observer, sessionId, shellPanes, lineCoun
   const paneRuns = [];
   for (let index = 0; index < shellPanes.length; index += 1) {
     const pane = shellPanes[index];
-    const token = `__ATTN_PERF_PANE_${index}_${Date.now()}__`;
-    const doneToken = `${token} DONE`;
+    // Keep markers shorter than a deeply split pane. The VT dump preserves
+    // rendered wrapping, so a long logical token can contain a newline in the
+    // snapshot and never match even though the command completed.
+    const token = `P${index}${Date.now().toString(36).slice(-6)}`;
+    const doneToken = `${token}D`;
     const python = [
       `token=${JSON.stringify(token)}`,
       `done=${JSON.stringify(doneToken)}`,

--- a/app/scripts/real-app-harness/bridge-pty-bench.mjs
+++ b/app/scripts/real-app-harness/bridge-pty-bench.mjs
@@ -19,7 +19,13 @@ function parseArgs(argv) {
   const commonArgv = [];
   for (let index = 0; index < filteredArgv.length; index += 1) {
     const arg = filteredArgv[index];
-    if (arg === '--chunk-bytes' || arg === '--chunk-count') {
+    if (
+      arg === '--chunk-bytes'
+      || arg === '--chunk-count'
+      || arg === '--chunk-delay-ms'
+      || arg === '--mode'
+      || arg === '--flush-every'
+    ) {
       index += 1;
       continue;
     }
@@ -29,11 +35,30 @@ function parseArgs(argv) {
   const options = parseCommonArgs(commonArgv);
   options.chunkBytes = 16 * 1024;
   options.chunkCount = 128;
+  options.chunkDelayMs = 0;
+  options.mode = null;
+  options.flushEvery = null;
 
   for (let index = 0; index < filteredArgv.length; index += 1) {
     const arg = filteredArgv[index];
     if (arg === '--chunk-bytes') options.chunkBytes = Number(filteredArgv[index + 1]);
     if (arg === '--chunk-count') options.chunkCount = Number(filteredArgv[index + 1]);
+    if (arg === '--chunk-delay-ms') options.chunkDelayMs = Number(filteredArgv[index + 1]);
+    if (arg === '--mode') options.mode = filteredArgv[index + 1];
+    if (arg === '--flush-every') options.flushEvery = Number(filteredArgv[index + 1]);
+  }
+
+  if (!Number.isFinite(options.chunkBytes) || options.chunkBytes <= 0) {
+    throw new Error('--chunk-bytes must be a positive number');
+  }
+  if (!Number.isFinite(options.chunkCount) || options.chunkCount <= 0) {
+    throw new Error('--chunk-count must be a positive number');
+  }
+  if (!Number.isFinite(options.chunkDelayMs) || options.chunkDelayMs < 0) {
+    throw new Error('--chunk-delay-ms must be a non-negative number');
+  }
+  if (options.flushEvery !== null && (!Number.isFinite(options.flushEvery) || options.flushEvery <= 0)) {
+    throw new Error('--flush-every must be a positive number');
   }
 
   return options;
@@ -148,6 +173,8 @@ function summarizeProcessSamples(samples) {
     totalCpuPct: sample.processes.reduce((sum, processInfo) => sum + processInfo.cpuPct, 0),
     totalRssKb: sample.processes.reduce((sum, processInfo) => sum + processInfo.rssKb, 0),
   }));
+  const cpuTotals = totals.map((item) => item.totalCpuPct).sort((a, b) => a - b);
+  const p95Index = Math.max(0, Math.ceil(cpuTotals.length * 0.95) - 1);
 
   for (const sample of samples) {
     for (const processInfo of sample.processes) {
@@ -168,6 +195,10 @@ function summarizeProcessSamples(samples) {
 
   return {
     totalCpuPctMax: totals.length > 0 ? Math.max(...totals.map((item) => item.totalCpuPct)) : 0,
+    totalCpuPctAvg: totals.length > 0
+      ? totals.reduce((sum, item) => sum + item.totalCpuPct, 0) / totals.length
+      : 0,
+    totalCpuPctP95: cpuTotals.length > 0 ? cpuTotals[p95Index] : 0,
     totalRssKbMax: totals.length > 0 ? Math.max(...totals.map((item) => item.totalRssKb)) : 0,
     byCommand: Object.fromEntries(
       [...byCommand.entries()].map(([label, entry]) => [
@@ -213,6 +244,8 @@ function compactResult(mode, bench, processSummary) {
     totalMs: Number(bench.totalMs.toFixed(2)),
     throughputMiBPerSec: Number((bench.throughputMiBPerSec || 0).toFixed(2)),
     totalCpuPctMax: Number(processSummary.totalCpuPctMax.toFixed(1)),
+    totalCpuPctAvg: Number(processSummary.totalCpuPctAvg.toFixed(1)),
+    totalCpuPctP95: Number(processSummary.totalCpuPctP95.toFixed(1)),
     totalRssMbMax: Number((processSummary.totalRssKbMax / 1024).toFixed(1)),
     wsJsonParseMs: Number((bench.pty.wsJsonParseMs || 0).toFixed(3)),
     ptyJsonParseMs: Number((bench.pty.ptyJsonParseMs || 0).toFixed(3)),
@@ -223,6 +256,9 @@ function compactResult(mode, bench, processSummary) {
     rendererAvgFrameMs: bench.renderer?.renderCount > 0
       ? Number((bench.renderer.cpuSubmitMs / bench.renderer.renderCount).toFixed(3))
       : 0,
+    scheduledRenderRequests: bench.renderer?.scheduledRequests || 0,
+    scheduledRenderCoalesced: bench.renderer?.scheduledCoalesced || 0,
+    scheduledRenderDeferred: bench.renderer?.scheduledDeferred || 0,
     ptyOutputCount: bench.pty.ptyOutputCount || 0,
     terminalWriteCount: bench.pty.terminalWriteCount || 0,
     totalPayloadBytes: bench.totalPayloadBytes,
@@ -235,6 +271,9 @@ async function main() {
     printCommonHelp('scripts/real-app-harness/bridge-pty-bench.mjs');
     console.log('  --chunk-bytes <n>          Payload bytes per chunk (default: 16384)');
     console.log('  --chunk-count <n>          Number of chunks per mode (default: 128)');
+    console.log('  --chunk-delay-ms <n>       Delay between chunks for sustained-output measurements');
+    console.log('  --mode <name>              Run only bytes, base64, or json_base64');
+    console.log('  --flush-every <n>           Run only one batching level');
     return;
   }
 
@@ -296,11 +335,16 @@ async function main() {
       throw new Error('Utility pane not found');
     }
 
-    const modes = [
-      { name: 'json_base64_x1', mode: 'json_base64', flushEvery: 1 },
-      { name: 'json_base64_x8', mode: 'json_base64', flushEvery: 8 },
-      { name: 'json_base64_x32', mode: 'json_base64', flushEvery: 32 },
-    ];
+    const selectedMode = options.mode || 'json_base64';
+    if (!['bytes', 'base64', 'json_base64'].includes(selectedMode)) {
+      throw new Error(`Unsupported benchmark mode: ${selectedMode}`);
+    }
+    const batchSizes = options.flushEvery === null ? [1, 8, 32] : [options.flushEvery];
+    const modes = batchSizes.map((flushEvery) => ({
+      name: `${selectedMode}_x${flushEvery}`,
+      mode: selectedMode,
+      flushEvery,
+    }));
     const results = [];
     for (const entry of modes) {
       const benchPromise = client.request('benchmark_pty_transport', {
@@ -309,6 +353,7 @@ async function main() {
         mode: entry.mode,
         chunkBytes: options.chunkBytes,
         chunkCount: options.chunkCount,
+        interChunkDelayMs: options.chunkDelayMs,
         flushEvery: entry.flushEvery,
       }, { timeoutMs: 120_000 });
       const measured = await sampleWhilePending(manifest.pid, extraPids, benchPromise, 100);
@@ -326,9 +371,9 @@ async function main() {
       name: entry.name,
       ...compactResult(entry.mode, entry.bench, entry.processSummary),
     }));
-    const json1 = compact.find((entry) => entry.name === 'json_base64_x1');
-    const json8 = compact.find((entry) => entry.name === 'json_base64_x8');
-    const json32 = compact.find((entry) => entry.name === 'json_base64_x32');
+    const json1 = compact.find((entry) => entry.flushEvery === 1);
+    const json8 = compact.find((entry) => entry.flushEvery === 8);
+    const json32 = compact.find((entry) => entry.flushEvery === 32);
 
     const deltas = {
       x1VsX8Ms: json1 && json8 ? Number((json1.totalMs - json8.totalMs).toFixed(2)) : null,
@@ -344,6 +389,7 @@ async function main() {
       runtimeId: utilityPane.runtime_id,
       chunkBytes: options.chunkBytes,
       chunkCount: options.chunkCount,
+      chunkDelayMs: options.chunkDelayMs,
       results,
       compact,
       deltas,

--- a/app/scripts/real-app-harness/bridge-pty-bench.mjs
+++ b/app/scripts/real-app-harness/bridge-pty-bench.mjs
@@ -278,6 +278,7 @@ function compactResult(mode, bench, processSummary) {
     rendererRowsPainted: bench.renderer?.rowsPainted || 0,
     rendererSubmittedQuads: bench.renderer?.submittedQuads || 0,
     rendererRetainedRowVertexMb: Number(((bench.renderer?.retainedRowVertexBytes || 0) / (1024 * 1024)).toFixed(3)),
+    rendererRetainedStagingMb: Number(((bench.renderer?.retainedStagingBytes || 0) / (1024 * 1024)).toFixed(3)),
     fixturePrintable: bench.renderer?.fixturePrintable || 0,
     finalModelPrintable: bench.renderer?.finalModelPrintable || 0,
     finalPaintQuads: bench.renderer?.finalPaintQuads || 0,

--- a/app/scripts/real-app-harness/bridge-pty-bench.mjs
+++ b/app/scripts/real-app-harness/bridge-pty-bench.mjs
@@ -218,6 +218,11 @@ function compactResult(mode, bench, processSummary) {
     ptyJsonParseMs: Number((bench.pty.ptyJsonParseMs || 0).toFixed(3)),
     decodeMs: Number((bench.pty.decodeMs || 0).toFixed(3)),
     terminalWriteCallMs: Number((bench.pty.terminalWriteCallMs || 0).toFixed(3)),
+    rendererPaintCount: bench.renderer?.renderCount || 0,
+    rendererCpuSubmitMs: Number((bench.renderer?.cpuSubmitMs || 0).toFixed(3)),
+    rendererAvgFrameMs: bench.renderer?.renderCount > 0
+      ? Number((bench.renderer.cpuSubmitMs / bench.renderer.renderCount).toFixed(3))
+      : 0,
     ptyOutputCount: bench.pty.ptyOutputCount || 0,
     terminalWriteCount: bench.pty.terminalWriteCount || 0,
     totalPayloadBytes: bench.totalPayloadBytes,
@@ -282,13 +287,11 @@ async function main() {
       direction: 'vertical',
     }, { timeoutMs: 30_000 });
 
-    const workspace = await observer.waitForWorkspace(
+    const utilityPane = await observer.waitForUtilityPane(
       sessionId,
-      (entry) => (entry.panes || []).some((pane) => pane.kind === 'shell' && pane.runtime_id),
-      `utility pane for ${sessionId}`,
       20_000,
+      new Set([targetPaneId]),
     );
-    const utilityPane = (workspace.panes || []).find((pane) => pane.kind === 'shell' && pane.runtime_id);
     if (!utilityPane?.runtime_id) {
       throw new Error('Utility pane not found');
     }

--- a/app/scripts/real-app-harness/bridge-pty-bench.mjs
+++ b/app/scripts/real-app-harness/bridge-pty-bench.mjs
@@ -6,6 +6,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { DaemonObserver } from './daemonObserver.mjs';
 import { createRunContext, parseCommonArgs, printCommonHelp } from './common.mjs';
+import { setFrontWindowBounds } from './nativeWindowCapture.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -24,7 +25,10 @@ function parseArgs(argv) {
       || arg === '--chunk-count'
       || arg === '--chunk-delay-ms'
       || arg === '--mode'
+      || arg === '--payload'
       || arg === '--flush-every'
+      || arg === '--window-width'
+      || arg === '--window-height'
     ) {
       index += 1;
       continue;
@@ -37,7 +41,10 @@ function parseArgs(argv) {
   options.chunkCount = 128;
   options.chunkDelayMs = 0;
   options.mode = null;
+  options.payload = 'scroll';
   options.flushEvery = null;
+  options.windowWidth = null;
+  options.windowHeight = null;
 
   for (let index = 0; index < filteredArgv.length; index += 1) {
     const arg = filteredArgv[index];
@@ -45,7 +52,10 @@ function parseArgs(argv) {
     if (arg === '--chunk-count') options.chunkCount = Number(filteredArgv[index + 1]);
     if (arg === '--chunk-delay-ms') options.chunkDelayMs = Number(filteredArgv[index + 1]);
     if (arg === '--mode') options.mode = filteredArgv[index + 1];
+    if (arg === '--payload') options.payload = filteredArgv[index + 1];
     if (arg === '--flush-every') options.flushEvery = Number(filteredArgv[index + 1]);
+    if (arg === '--window-width') options.windowWidth = Number(filteredArgv[index + 1]);
+    if (arg === '--window-height') options.windowHeight = Number(filteredArgv[index + 1]);
   }
 
   if (!Number.isFinite(options.chunkBytes) || options.chunkBytes <= 0) {
@@ -59,6 +69,12 @@ function parseArgs(argv) {
   }
   if (options.flushEvery !== null && (!Number.isFinite(options.flushEvery) || options.flushEvery <= 0)) {
     throw new Error('--flush-every must be a positive number');
+  }
+  if (!['scroll', 'progress'].includes(options.payload)) {
+    throw new Error('--payload must be scroll or progress');
+  }
+  if ((options.windowWidth === null) !== (options.windowHeight === null)) {
+    throw new Error('--window-width and --window-height must be provided together');
   }
 
   return options;
@@ -240,6 +256,7 @@ async function sampleWhilePending(rootPid, extraPids, promise, intervalMs = 100)
 function compactResult(mode, bench, processSummary) {
   return {
     mode,
+    payload: bench.payload || 'scroll',
     flushEvery: bench.flushEvery || 1,
     totalMs: Number(bench.totalMs.toFixed(2)),
     throughputMiBPerSec: Number((bench.throughputMiBPerSec || 0).toFixed(2)),
@@ -256,9 +273,18 @@ function compactResult(mode, bench, processSummary) {
     rendererAvgFrameMs: bench.renderer?.renderCount > 0
       ? Number((bench.renderer.cpuSubmitMs / bench.renderer.renderCount).toFixed(3))
       : 0,
+    rendererFullPaintCount: bench.renderer?.fullPaintCount || 0,
+    rendererPartialPaintCount: bench.renderer?.partialPaintCount || 0,
+    rendererRowsPainted: bench.renderer?.rowsPainted || 0,
+    rendererSubmittedQuads: bench.renderer?.submittedQuads || 0,
+    rendererRetainedRowVertexMb: Number(((bench.renderer?.retainedRowVertexBytes || 0) / (1024 * 1024)).toFixed(3)),
+    fixturePrintable: bench.renderer?.fixturePrintable || 0,
+    finalModelPrintable: bench.renderer?.finalModelPrintable || 0,
+    finalPaintQuads: bench.renderer?.finalPaintQuads || 0,
     scheduledRenderRequests: bench.renderer?.scheduledRequests || 0,
     scheduledRenderCoalesced: bench.renderer?.scheduledCoalesced || 0,
     scheduledRenderDeferred: bench.renderer?.scheduledDeferred || 0,
+    writeParsedCount: bench.renderer?.writeParsedCount || 0,
     ptyOutputCount: bench.pty.ptyOutputCount || 0,
     terminalWriteCount: bench.pty.terminalWriteCount || 0,
     totalPayloadBytes: bench.totalPayloadBytes,
@@ -273,7 +299,10 @@ async function main() {
     console.log('  --chunk-count <n>          Number of chunks per mode (default: 128)');
     console.log('  --chunk-delay-ms <n>       Delay between chunks for sustained-output measurements');
     console.log('  --mode <name>              Run only bytes, base64, or json_base64');
+    console.log('  --payload <name>           Run scrolling output or in-place progress updates');
     console.log('  --flush-every <n>           Run only one batching level');
+    console.log('  --window-width <n>          Resize the isolated benchmark window before creating panes');
+    console.log('  --window-height <n>         Resize the isolated benchmark window before creating panes');
     return;
   }
 
@@ -292,6 +321,13 @@ async function main() {
     await client.waitForManifest(20_000);
     await client.waitForReady(20_000);
     await client.waitForFrontendResponsive(20_000);
+    if (options.windowWidth !== null && options.windowHeight !== null) {
+      await setFrontWindowBounds(
+        { x: 60, y: 60, width: options.windowWidth, height: options.windowHeight },
+        { client },
+      );
+      await client.waitForFrontendResponsive(20_000);
+    }
     await observer.connect();
     await observer.unregisterMatchingSessions(
       (session) => typeof session.label === 'string' && session.label.startsWith('attn-pty-bench-'),
@@ -353,6 +389,7 @@ async function main() {
         mode: entry.mode,
         chunkBytes: options.chunkBytes,
         chunkCount: options.chunkCount,
+        payload: options.payload,
         interChunkDelayMs: options.chunkDelayMs,
         flushEvery: entry.flushEvery,
       }, { timeoutMs: 120_000 });
@@ -390,6 +427,7 @@ async function main() {
       chunkBytes: options.chunkBytes,
       chunkCount: options.chunkCount,
       chunkDelayMs: options.chunkDelayMs,
+      payload: options.payload,
       results,
       compact,
       deltas,

--- a/app/scripts/real-app-harness/daemonObserver.mjs
+++ b/app/scripts/real-app-harness/daemonObserver.mjs
@@ -483,11 +483,11 @@ export async function readScrollback(wsUrl, runtimeId, timeoutMs = 5_000) {
         reject(new Error(data.error || `attach_session failed for ${runtimeId}`));
         return;
       }
-      // Restore is server-authoritative: the daemon now carries the parsed
-      // terminal as a self-contained VT dump instead of the removed raw
-      // scrollback field. The dump still contains the rendered text, which is
-      // what harness completion/token checks need. Keep the old field as a
-      // compatibility fallback for older packaged apps.
+      // Restore is server-authoritative: attach carries the parsed terminal as
+      // a self-contained VT dump, and its rendered text is what the harness
+      // completion/token checks read. `scrollback` is not a product fallback —
+      // the daemon no longer sends it (see AGENTS.md, "Terminal") — it only
+      // lets this script read a packaged build predating that change.
       resolve(attachSnapshotText(data));
     });
 

--- a/app/scripts/real-app-harness/daemonObserver.mjs
+++ b/app/scripts/real-app-harness/daemonObserver.mjs
@@ -12,6 +12,10 @@ function decodeBase64Utf8(value) {
   return Buffer.from(value, 'base64').toString('utf8');
 }
 
+export function attachSnapshotText(message) {
+  return decodeBase64Utf8(message?.snapshot?.vt_dump_b64 ?? message?.scrollback);
+}
+
 function workspacePaneIds(workspace) {
   return (workspace?.panes || []).map((pane) => pane.pane_id);
 }
@@ -479,7 +483,12 @@ export async function readScrollback(wsUrl, runtimeId, timeoutMs = 5_000) {
         reject(new Error(data.error || `attach_session failed for ${runtimeId}`));
         return;
       }
-      resolve(decodeBase64Utf8(data.scrollback));
+      // Restore is server-authoritative: the daemon now carries the parsed
+      // terminal as a self-contained VT dump instead of the removed raw
+      // scrollback field. The dump still contains the rendered text, which is
+      // what harness completion/token checks need. Keep the old field as a
+      // compatibility fallback for older packaged apps.
+      resolve(attachSnapshotText(data));
     });
 
     ws.once('error', (error) => {

--- a/app/scripts/real-app-harness/daemonObserver.test.mjs
+++ b/app/scripts/real-app-harness/daemonObserver.test.mjs
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { attachSnapshotText } from './daemonObserver.mjs';
+
+const encoded = (value) => Buffer.from(value, 'utf8').toString('base64');
+
+describe('attachSnapshotText', () => {
+  it('reads the server-authoritative VT dump', () => {
+    expect(attachSnapshotText({
+      snapshot: { vt_dump_b64: encoded('current terminal') },
+      scrollback: encoded('obsolete raw scrollback'),
+    })).toBe('current terminal');
+  });
+
+  it('keeps compatibility with older attach results', () => {
+    expect(attachSnapshotText({ scrollback: encoded('legacy terminal') })).toBe('legacy terminal');
+  });
+});

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -727,6 +727,9 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const synchronizedOutputRenderTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const scheduledOutputRenderRef = useRef<number | null>(null);
     const renderCountRef = useRef(0);
+    const renderCpuTotalMsRef = useRef(0);
+    const renderCpuMaxMsRef = useRef(0);
+    const lastRenderCpuMsRef = useRef(0);
     const writeCountRef = useRef(0);
     // Diagnostics: model instance (increments on rebuild) and last paint quads,
     // used by the blank-on-split watchdog to tell a fresh empty model and an
@@ -1108,6 +1111,9 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       const sample = renderer.render(terminal, force, getViewportCells(), overlays, viewportOffsetRef.current, imageQuads);
       if (sample) {
         renderCountRef.current += 1;
+        renderCpuTotalMsRef.current += sample.cpuSubmitMs;
+        renderCpuMaxMsRef.current = Math.max(renderCpuMaxMsRef.current, sample.cpuSubmitMs);
+        lastRenderCpuMsRef.current = sample.cpuSubmitMs;
         lastRenderAtRef.current = Date.now();
         lastPaintQuadsRef.current = sample.quads;
       }
@@ -2586,6 +2592,9 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           writeQueueChunks: 0,
           writeQueueBytes: 0,
           renderCount: renderCountRef.current,
+          renderCpuTotalMs: renderCpuTotalMsRef.current,
+          renderCpuMaxMs: renderCpuMaxMsRef.current,
+          lastRenderCpuMs: lastRenderCpuMsRef.current,
           writeParsedCount: writeCountRef.current,
           lastRenderAt: lastRenderAtRef.current,
           lastWriteParsedAt: lastWriteAtRef.current,

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -574,6 +574,27 @@ function colorNumber(value: string): number {
   return Number.parseInt(value.slice(1), 16);
 }
 
+// Count printable cells in the live viewport window. getViewport() returns a
+// fixed-capacity buffer whose tail can hold stale cells from a larger pre-resize
+// grid, so only the first cols*rows entries are counted.
+//
+// This is deliberately a second, renderer-independent witness. The blank-on-
+// split watchdog compares "how much the model holds" against "how many quads
+// the renderer drew"; if both numbers come out of the same render pass they
+// move together and an under-drawing renderer can never be caught. Too
+// expensive for every paint, which is why renderSurface uses the render
+// sample's own count and only the watchdog probe re-scans.
+function countModelPrintable(terminal: GhosttyModel): number {
+  const viewport = terminal.getViewport();
+  const windowLen = terminal.cols * terminal.rows;
+  let printable = 0;
+  for (let i = 0; i < windowLen && i < viewport.length; i += 1) {
+    const cell = viewport[i];
+    if (cell && cell.codepoint > 32) printable += 1;
+  }
+  return printable;
+}
+
 function emptyStartup(): TerminalPerfStartupSnapshot {
   return {
     initialContainer: null,
@@ -724,6 +745,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const renderRowsPaintedRef = useRef(0);
     const renderSubmittedQuadsRef = useRef(0);
     const renderRetainedRowVertexBytesRef = useRef(0);
+    const renderRetainedStagingBytesRef = useRef(0);
     const scheduledRenderRequestsRef = useRef(0);
     const scheduledRenderCoalescedRef = useRef(0);
     const scheduledRenderDeferredRef = useRef(0);
@@ -1115,6 +1137,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         renderRowsPaintedRef.current += sample.paintedRows;
         renderSubmittedQuadsRef.current += sample.submittedQuads;
         renderRetainedRowVertexBytesRef.current = sample.retainedRowVertexBytes;
+        renderRetainedStagingBytesRef.current = sample.retainedStagingBytes;
         if (sample.fullPaint) renderFullCountRef.current += 1;
         else renderPartialCountRef.current += 1;
         lastRenderAtRef.current = Date.now();
@@ -1169,7 +1192,11 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       scheduledOutputRenderForceRef.current = false;
     }, []);
 
-    const scheduleOutputRender = useCallback((force = true) => {
+    // `force` is not optional on purpose. A forced paint repaints a clean model
+    // (what an image placement needs); an unforced one is a no-op when nothing
+    // changed (what streamed output wants, so the row cache can serve it). A
+    // default here would silently pick one for the next caller.
+    const scheduleOutputRender = useCallback((force: boolean) => {
       scheduledRenderRequestsRef.current += 1;
       scheduledOutputRenderForceRef.current ||= force;
       if (scheduledOutputRenderRef.current !== null) {
@@ -1908,7 +1935,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           return;
         }
         requestPlacementBlobs();
-        scheduleOutputRender();
+        scheduleOutputRender(true);
       });
     }, [enqueueOperation, requestPlacementBlobs, scheduleOutputRender]);
 
@@ -1923,7 +1950,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         placementSessionRef.current = sessionId;
         placementStoreRef.current.seed(placements, terminal.getScrollbackLength());
         requestPlacementBlobs();
-        scheduleOutputRender();
+        scheduleOutputRender(true);
       });
     }, [enqueueOperation, requestPlacementBlobs, scheduleOutputRender]);
 
@@ -1933,7 +1960,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     useEffect(() => kittyImageCache.subscribe((sessionId, imageId) => {
       if (sessionId !== placementSessionRef.current) return;
       if (!placementStoreRef.current.placements().some((p) => p.imageId === imageId)) return;
-      scheduleOutputRender();
+      scheduleOutputRender(true);
     }), [scheduleOutputRender]);
 
     // Live placement-store snapshot for the get_pane_placement_state bridge
@@ -2478,7 +2505,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           return {
             cols: model.cols,
             rows: model.rows,
-            modelPrintable: lastModelPrintableRef.current,
+            modelPrintable: countModelPrintable(model),
             lastPaintAt: lastRenderAtRef.current,
             lastPaintQuads: lastPaintQuadsRef.current,
             // Mirrors renderSurface's inactive-session bail: a pane that is
@@ -2625,6 +2652,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           renderRowsPainted: renderRowsPaintedRef.current,
           renderSubmittedQuads: renderSubmittedQuadsRef.current,
           renderRetainedRowVertexBytes: renderRetainedRowVertexBytesRef.current,
+          renderRetainedStagingBytes: renderRetainedStagingBytesRef.current,
           modelPrintable: lastModelPrintableRef.current,
           lastPaintQuads: lastPaintQuadsRef.current,
           scheduledRenderRequests: scheduledRenderRequestsRef.current,

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -574,20 +574,6 @@ function colorNumber(value: string): number {
   return Number.parseInt(value.slice(1), 16);
 }
 
-// Count printable cells in the live viewport window. getViewport() returns a
-// fixed-capacity buffer whose tail can hold stale cells from a larger pre-resize
-// grid, so only the first cols*rows entries are counted.
-function countModelPrintable(terminal: GhosttyModel): number {
-  const viewport = terminal.getViewport();
-  const windowLen = terminal.cols * terminal.rows;
-  let printable = 0;
-  for (let i = 0; i < windowLen && i < viewport.length; i += 1) {
-    const cell = viewport[i];
-    if (cell && cell.codepoint > 32) printable += 1;
-  }
-  return printable;
-}
-
 function emptyStartup(): TerminalPerfStartupSnapshot {
   return {
     initialContainer: null,
@@ -733,6 +719,11 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const renderCpuTotalMsRef = useRef(0);
     const renderCpuMaxMsRef = useRef(0);
     const lastRenderCpuMsRef = useRef(0);
+    const renderFullCountRef = useRef(0);
+    const renderPartialCountRef = useRef(0);
+    const renderRowsPaintedRef = useRef(0);
+    const renderSubmittedQuadsRef = useRef(0);
+    const renderRetainedRowVertexBytesRef = useRef(0);
     const scheduledRenderRequestsRef = useRef(0);
     const scheduledRenderCoalescedRef = useRef(0);
     const scheduledRenderDeferredRef = useRef(0);
@@ -742,6 +733,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     // under-drawn surface apart.
     const modelInstanceRef = useRef(0);
     const lastPaintQuadsRef = useRef(0);
+    const lastModelPrintableRef = useRef(0);
     const lastRenderAtRef = useRef(0);
     const lastWriteAtRef = useRef(0);
     const readyRef = useRef(false);
@@ -1120,8 +1112,14 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         renderCpuTotalMsRef.current += sample.cpuSubmitMs;
         renderCpuMaxMsRef.current = Math.max(renderCpuMaxMsRef.current, sample.cpuSubmitMs);
         lastRenderCpuMsRef.current = sample.cpuSubmitMs;
+        renderRowsPaintedRef.current += sample.paintedRows;
+        renderSubmittedQuadsRef.current += sample.submittedQuads;
+        renderRetainedRowVertexBytesRef.current = sample.retainedRowVertexBytes;
+        if (sample.fullPaint) renderFullCountRef.current += 1;
+        else renderPartialCountRef.current += 1;
         lastRenderAtRef.current = Date.now();
         lastPaintQuadsRef.current = sample.quads;
+        lastModelPrintableRef.current = sample.modelPrintable;
       }
       recordPaint({
         pane: diagKeyRef.current,
@@ -1130,7 +1128,10 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         rows: terminal.rows,
         force,
         offset: viewportOffsetRef.current,
-        modelPrintable: countModelPrintable(terminal),
+        // A clean-model render is a no-op. Preserve the last painted model
+        // count in diagnostics so a later no-op record cannot make a healthy
+        // surface look blank without re-scanning the complete grid.
+        modelPrintable: sample?.modelPrintable ?? lastModelPrintableRef.current,
         quads: sample ? sample.quads : null,
         cellsArrayLen: sample ? sample.cellsArrayLen : null,
         skipNull: sample ? sample.printableSkippedNull : null,
@@ -2477,7 +2478,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           return {
             cols: model.cols,
             rows: model.rows,
-            modelPrintable: countModelPrintable(model),
+            modelPrintable: lastModelPrintableRef.current,
             lastPaintAt: lastRenderAtRef.current,
             lastPaintQuads: lastPaintQuadsRef.current,
             // Mirrors renderSurface's inactive-session bail: a pane that is
@@ -2619,6 +2620,13 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           renderCpuTotalMs: renderCpuTotalMsRef.current,
           renderCpuMaxMs: renderCpuMaxMsRef.current,
           lastRenderCpuMs: lastRenderCpuMsRef.current,
+          renderFullCount: renderFullCountRef.current,
+          renderPartialCount: renderPartialCountRef.current,
+          renderRowsPainted: renderRowsPaintedRef.current,
+          renderSubmittedQuads: renderSubmittedQuadsRef.current,
+          renderRetainedRowVertexBytes: renderRetainedRowVertexBytesRef.current,
+          modelPrintable: lastModelPrintableRef.current,
+          lastPaintQuads: lastPaintQuadsRef.current,
           scheduledRenderRequests: scheduledRenderRequestsRef.current,
           scheduledRenderCoalesced: scheduledRenderCoalescedRef.current,
           scheduledRenderDeferred: scheduledRenderDeferredRef.current,

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -100,6 +100,7 @@ import type { TerminalVisibleContentSnapshot } from '../utils/terminalVisibleCon
 import { analyzeTerminalVisibleLines } from '../utils/terminalVisibleContent';
 import type { TerminalVisibleStyleSnapshot, TerminalVisibleStyleLineSnapshot } from '../utils/terminalStyleSummary';
 import { registerTerminalPerfGetter, type TerminalPerfStartupSnapshot } from '../utils/terminalPerf';
+import { terminalOutputDelayMs } from '../utils/terminalOutputPacing';
 import {
   applicationMouseInput,
   applicationWheelInput,
@@ -726,10 +727,15 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const synchronizedOutputStateRef = useRef<SynchronizedOutputState>({ active: false, pending: '' });
     const synchronizedOutputRenderTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const scheduledOutputRenderRef = useRef<number | null>(null);
+    const scheduledOutputRenderForceRef = useRef(false);
+    const lastScheduledOutputPaintAtRef = useRef<number | null>(null);
     const renderCountRef = useRef(0);
     const renderCpuTotalMsRef = useRef(0);
     const renderCpuMaxMsRef = useRef(0);
     const lastRenderCpuMsRef = useRef(0);
+    const scheduledRenderRequestsRef = useRef(0);
+    const scheduledRenderCoalescedRef = useRef(0);
+    const scheduledRenderDeferredRef = useRef(0);
     const writeCountRef = useRef(0);
     // Diagnostics: model instance (increments on rebuild) and last paint quads,
     // used by the blank-on-split watchdog to tell a fresh empty model and an
@@ -1155,22 +1161,40 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     }, []);
 
     const cancelScheduledOutputRender = useCallback(() => {
-      if (scheduledOutputRenderRef.current === null) return;
-      cancelAnimationFrame(scheduledOutputRenderRef.current);
-      scheduledOutputRenderRef.current = null;
+      if (scheduledOutputRenderRef.current !== null) {
+        cancelAnimationFrame(scheduledOutputRenderRef.current);
+        scheduledOutputRenderRef.current = null;
+      }
+      scheduledOutputRenderForceRef.current = false;
     }, []);
 
-    const scheduleOutputRender = useCallback(() => {
-      if (scheduledOutputRenderRef.current !== null) return;
-      scheduledOutputRenderRef.current = requestAnimationFrame(() => {
+    const scheduleOutputRender = useCallback((force = true) => {
+      scheduledRenderRequestsRef.current += 1;
+      scheduledOutputRenderForceRef.current ||= force;
+      if (scheduledOutputRenderRef.current !== null) {
+        scheduledRenderCoalescedRef.current += 1;
+        return;
+      }
+
+      const requestPaint = (timestamp: number) => {
+        const delayMs = terminalOutputDelayMs(timestamp, lastScheduledOutputPaintAtRef.current);
+        if (delayMs > 1) {
+          scheduledRenderDeferredRef.current += 1;
+          scheduledOutputRenderRef.current = requestAnimationFrame(requestPaint);
+          return;
+        }
         scheduledOutputRenderRef.current = null;
-        renderSurface(true);
-      });
+        lastScheduledOutputPaintAtRef.current = timestamp;
+        const forcePaint = scheduledOutputRenderForceRef.current;
+        scheduledOutputRenderForceRef.current = false;
+        renderSurface(forcePaint);
+      };
+      scheduledOutputRenderRef.current = requestAnimationFrame(requestPaint);
     }, [renderSurface]);
 
     const flushSynchronizedOutputRender = useCallback(() => {
       clearSynchronizedOutputRenderTimer();
-      scheduleOutputRender();
+      scheduleOutputRender(false);
     }, [clearSynchronizedOutputRenderTimer, scheduleOutputRender]);
 
     const scheduleSynchronizedOutputRenderFallback = useCallback(() => {
@@ -1178,7 +1202,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       synchronizedOutputRenderTimerRef.current = setTimeout(() => {
         synchronizedOutputRenderTimerRef.current = null;
         synchronizedOutputStateRef.current = { active: false, pending: '' };
-        scheduleOutputRender();
+        scheduleOutputRender(false);
       }, SYNCHRONIZED_OUTPUT_RENDER_TIMEOUT_MS);
     }, [scheduleOutputRender]);
 
@@ -2595,6 +2619,9 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           renderCpuTotalMs: renderCpuTotalMsRef.current,
           renderCpuMaxMs: renderCpuMaxMsRef.current,
           lastRenderCpuMs: lastRenderCpuMsRef.current,
+          scheduledRenderRequests: scheduledRenderRequestsRef.current,
+          scheduledRenderCoalesced: scheduledRenderCoalescedRef.current,
+          scheduledRenderDeferred: scheduledRenderDeferredRef.current,
           writeParsedCount: writeCountRef.current,
           lastRenderAt: lastRenderAtRef.current,
           lastWriteParsedAt: lastWriteAtRef.current,

--- a/app/src/components/GhosttyWebGlRenderer.test.ts
+++ b/app/src/components/GhosttyWebGlRenderer.test.ts
@@ -627,6 +627,52 @@ describe('WebGlTerminalRenderer dirty rows', () => {
     expect(renderer.render(terminal)).toMatchObject({ fullPaint: false, paintedRows: 6 });
   });
 
+  // A same-row move and a visibility toggle report DIRTY_NONE, so nothing else
+  // wakes the renderer. Without a cursor comparison ahead of the early return,
+  // the old inverted cell survives until unrelated output happens to arrive.
+  it('paints a bare same-row cursor move that the model reports as not dirty', () => {
+    const { renderer } = makeRenderer();
+    const { terminal, state } = makeControllableTerminal(50, 50);
+    renderer.resize(50, 50);
+    state.cursor = { x: 0, y: 10, visible: true };
+    renderer.render(terminal);
+
+    state.dirty = 0;
+    state.rows = new Set();
+    state.cursor = { x: 7, y: 10, visible: true };
+
+    // Rows 9-11: the cursor vacated and arrived on the same row. Partial, not
+    // full — a cursor move must not cost a whole-grid repaint.
+    expect(renderer.render(terminal)).toMatchObject({ fullPaint: false, paintedRows: 3 });
+  });
+
+  it('paints a bare cursor visibility toggle that the model reports as not dirty', () => {
+    const { renderer } = makeRenderer();
+    const { terminal, state } = makeControllableTerminal(50, 50);
+    renderer.resize(50, 50);
+    state.cursor = { x: 4, y: 10, visible: true };
+    renderer.render(terminal);
+
+    state.dirty = 0;
+    state.rows = new Set();
+    state.cursor = { x: 4, y: 10, visible: false };
+
+    expect(renderer.render(terminal)).toMatchObject({ fullPaint: false, paintedRows: 3 });
+  });
+
+  it('still returns null when nothing changed and the cursor stayed put', () => {
+    const { renderer } = makeRenderer();
+    const { terminal, state } = makeControllableTerminal(50, 50);
+    renderer.resize(50, 50);
+    state.cursor = { x: 4, y: 10, visible: true };
+    renderer.render(terminal);
+
+    state.dirty = 0;
+    state.rows = new Set();
+
+    expect(renderer.render(terminal)).toBeNull();
+  });
+
   it('paints nothing extra when a hidden cursor moves', () => {
     const { renderer } = makeRenderer();
     const { terminal, state } = makeControllableTerminal(50, 50);

--- a/app/src/components/GhosttyWebGlRenderer.test.ts
+++ b/app/src/components/GhosttyWebGlRenderer.test.ts
@@ -579,14 +579,17 @@ describe('WebGlTerminalRenderer dirty rows', () => {
     expect(renderer.render(terminal)).toMatchObject({ fullPaint: false, paintedRows: 3 });
   });
 
-  it('repaints the row the cursor left behind, which Ghostty does not mark dirty', () => {
+  // Defensive rather than observed: the real WASM reports a cross-row move as
+  // PARTIAL with *both* rows already in the set. This pins the row selection
+  // against a model that says PARTIAL and names no rows at all. The truly bare
+  // moves — the ones the WASM reports as DIRTY_NONE — are covered further down.
+  it('repaints both cursor rows when a partial frame names no dirty rows', () => {
     const { renderer } = makeRenderer();
     const { terminal, state } = makeControllableTerminal(50, 50);
     renderer.resize(50, 50);
     state.cursor = { x: 0, y: 10, visible: true };
     renderer.render(terminal);
 
-    // A bare reposition: no cell changed, so the model reports no dirty rows.
     state.dirty = 1;
     state.rows = new Set();
     state.cursor = { x: 0, y: 30, visible: true };

--- a/app/src/components/GhosttyWebGlRenderer.test.ts
+++ b/app/src/components/GhosttyWebGlRenderer.test.ts
@@ -676,6 +676,38 @@ describe('WebGlTerminalRenderer dirty rows', () => {
     expect(renderer.render(terminal)).toBeNull();
   });
 
+  // A hidden cursor paints nothing, so moving it changes no pixels. Treating
+  // that as a render reason is worse than missing it: the frame has no row to
+  // mark, so the zero-row guard escalates it to a full-grid paint — on the one
+  // path (a TUI redrawing with the cursor hidden) that must stay cheap.
+  it('does not paint at all when a hidden cursor moves with nothing else dirty', () => {
+    const { renderer } = makeRenderer();
+    const { terminal, state } = makeControllableTerminal(50, 50);
+    renderer.resize(50, 50);
+    state.cursor = { x: 4, y: 10, visible: false };
+    renderer.render(terminal);
+
+    state.dirty = 0;
+    state.rows = new Set();
+    state.cursor = { x: 31, y: 10, visible: false };
+
+    expect(renderer.render(terminal)).toBeNull();
+  });
+
+  it('does not paint when a hidden cursor changes row with nothing else dirty', () => {
+    const { renderer } = makeRenderer();
+    const { terminal, state } = makeControllableTerminal(50, 50);
+    renderer.resize(50, 50);
+    state.cursor = { x: 4, y: 10, visible: false };
+    renderer.render(terminal);
+
+    state.dirty = 0;
+    state.rows = new Set();
+    state.cursor = { x: 4, y: 44, visible: false };
+
+    expect(renderer.render(terminal)).toBeNull();
+  });
+
   it('paints nothing extra when a hidden cursor moves', () => {
     const { renderer } = makeRenderer();
     const { terminal, state } = makeControllableTerminal(50, 50);

--- a/app/src/components/GhosttyWebGlRenderer.test.ts
+++ b/app/src/components/GhosttyWebGlRenderer.test.ts
@@ -490,6 +490,7 @@ function makeControllableTerminal(cols: number, rows: number) {
   const state = {
     dirty: 2,
     rows: new Set(Array.from({ length: rows }, (_, row) => row)),
+    cursor: { x: 0, y: 0, visible: false },
   };
   const markClean = vi.fn();
   const terminal = {
@@ -498,7 +499,7 @@ function makeControllableTerminal(cols: number, rows: number) {
     update: () => state.dirty,
     isRowDirty: (row: number) => state.rows.has(row),
     markClean,
-    getCursor: () => ({ x: 0, y: 0, visible: false }),
+    getCursor: () => state.cursor,
     getViewport: () => cells,
     getScrollbackLength: () => 0,
     getGraphemeString: () => '',
@@ -578,6 +579,67 @@ describe('WebGlTerminalRenderer dirty rows', () => {
     expect(renderer.render(terminal)).toMatchObject({ fullPaint: false, paintedRows: 3 });
   });
 
+  it('repaints the row the cursor left behind, which Ghostty does not mark dirty', () => {
+    const { renderer } = makeRenderer();
+    const { terminal, state } = makeControllableTerminal(50, 50);
+    renderer.resize(50, 50);
+    state.cursor = { x: 0, y: 10, visible: true };
+    renderer.render(terminal);
+
+    // A bare reposition: no cell changed, so the model reports no dirty rows.
+    state.dirty = 1;
+    state.rows = new Set();
+    state.cursor = { x: 0, y: 30, visible: true };
+
+    // Rows 9-11 (vacated) and 29-31 (arrived), each expanded by one neighbor.
+    expect(renderer.render(terminal)).toMatchObject({ fullPaint: false, paintedRows: 6 });
+  });
+
+  // The regressing case: Ghostty reports DIRTY_NONE for a move within one row,
+  // so such a move only reaches the renderer riding along with an unrelated
+  // dirty row. The cursor's own row is absent from that set.
+  it('repaints the cursor row on a same-row move that rides along with another dirty row', () => {
+    const { renderer } = makeRenderer();
+    const { terminal, state } = makeControllableTerminal(50, 50);
+    renderer.resize(50, 50);
+    state.cursor = { x: 0, y: 10, visible: true };
+    renderer.render(terminal);
+
+    state.dirty = 1;
+    state.rows = new Set([40]);
+    state.cursor = { x: 7, y: 10, visible: true };
+
+    // Rows 39-41 for the dirty row, 9-11 for the cursor's unmarked row.
+    expect(renderer.render(terminal)).toMatchObject({ fullPaint: false, paintedRows: 6 });
+  });
+
+  it('repaints the row a hidden cursor was drawn on', () => {
+    const { renderer } = makeRenderer();
+    const { terminal, state } = makeControllableTerminal(50, 50);
+    renderer.resize(50, 50);
+    state.cursor = { x: 0, y: 10, visible: true };
+    renderer.render(terminal);
+
+    state.dirty = 1;
+    state.rows = new Set([40]);
+    state.cursor = { x: 0, y: 10, visible: false };
+
+    expect(renderer.render(terminal)).toMatchObject({ fullPaint: false, paintedRows: 6 });
+  });
+
+  it('paints nothing extra when a hidden cursor moves', () => {
+    const { renderer } = makeRenderer();
+    const { terminal, state } = makeControllableTerminal(50, 50);
+    renderer.resize(50, 50);
+    renderer.render(terminal);
+
+    state.dirty = 1;
+    state.rows = new Set([25]);
+    state.cursor = { x: 40, y: 40, visible: false };
+
+    expect(renderer.render(terminal)).toMatchObject({ fullPaint: false, paintedRows: 3 });
+  });
+
   it('releases a row cache that grows beyond the two MiB guardrail', () => {
     const { renderer } = makeRenderer();
     const { terminal, cells, state } = makeControllableTerminal(100, 30);
@@ -587,7 +649,8 @@ describe('WebGlTerminalRenderer dirty rows', () => {
     }
     renderer.resize(100, 30);
 
-    expect(renderer.render(terminal)).toMatchObject({
+    const built = renderer.render(terminal);
+    expect(built).toMatchObject({
       fullPaint: true,
       retainedRowVertexBytes: 0,
       modelPrintable: 3000,
@@ -595,11 +658,16 @@ describe('WebGlTerminalRenderer dirty rows', () => {
 
     state.dirty = 1;
     state.rows = new Set([15]);
-    expect(renderer.render(terminal)).toMatchObject({
+    const afterRelease = renderer.render(terminal);
+    expect(afterRelease).toMatchObject({
       fullPaint: true,
       paintedRows: 30,
       retainedRowVertexBytes: 0,
     });
+    // The frame buffer is what a direct-path paint stages regardless, so the
+    // reported total stays non-zero after the cache is gone.
+    expect(afterRelease!.retainedRowVertexBytes).toBe(0);
+    expect(afterRelease!.retainedStagingBytes).toBeGreaterThan(0);
   });
 });
 

--- a/app/src/components/GhosttyWebGlRenderer.test.ts
+++ b/app/src/components/GhosttyWebGlRenderer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { GhosttyCell, GhosttyTerminal } from 'ghostty-web';
+import { CellFlags, type GhosttyCell, type GhosttyTerminal } from 'ghostty-web';
+import { TERMINAL_FLOATS_PER_QUAD } from './terminalVertexBuffer';
 import {
   graphemeAtViewportCell,
   nextAtlasSize,
@@ -466,6 +467,139 @@ describe('WebGlTerminalRenderer kitty z layering', () => {
     // of the image the selection was dragged across.
     expect(draws[0].floats).toBe(0);
     expect(draws[2].floats).toBe(FLOATS_PER_QUAD);
+  });
+});
+
+// The row cache keeps a buffer per row per cell pass. This fixture's cells all
+// carry the default background, so every foreground row fills to one quad per
+// column while every background row stays at the one-quad minimum it was
+// allocated with.
+const QUAD_BYTES = TERMINAL_FLOATS_PER_QUAD * Float32Array.BYTES_PER_ELEMENT;
+const ROW_FG_BYTES = 50 * 50 * QUAD_BYTES;
+const ROW_BG_MIN_BYTES = 50 * QUAD_BYTES;
+
+function makeControllableTerminal(cols: number, rows: number) {
+  const cells = Array.from({ length: cols * rows }, () => ({
+    codepoint: 65,
+    grapheme_len: 0,
+    width: 1,
+    flags: 0,
+    fg_r: 255, fg_g: 255, fg_b: 255,
+    bg_r: 0, bg_g: 0, bg_b: 0,
+  }));
+  const state = {
+    dirty: 2,
+    rows: new Set(Array.from({ length: rows }, (_, row) => row)),
+  };
+  const markClean = vi.fn();
+  const terminal = {
+    cols,
+    rows,
+    update: () => state.dirty,
+    isRowDirty: (row: number) => state.rows.has(row),
+    markClean,
+    getCursor: () => ({ x: 0, y: 0, visible: false }),
+    getViewport: () => cells,
+    getScrollbackLength: () => 0,
+    getGraphemeString: () => '',
+    getScrollbackGraphemeString: () => '',
+  } as unknown as GhosttyTerminal;
+  return { terminal, cells, state, markClean };
+}
+
+describe('WebGlTerminalRenderer dirty rows', () => {
+  it('rebuilds small grids directly instead of paying to copy a row cache', () => {
+    const { renderer } = makeRenderer();
+    const { terminal, state } = makeControllableTerminal(4, 5);
+    renderer.resize(4, 5);
+    renderer.render(terminal);
+
+    state.dirty = 1;
+    state.rows = new Set([2]);
+
+    expect(renderer.render(terminal)).toMatchObject({
+      fullPaint: true,
+      paintedRows: 5,
+      retainedRowVertexBytes: 0,
+    });
+  });
+
+  it('rebuilds only a dirty row and its neighbors while submitting a complete cached frame', () => {
+    const { renderer } = makeRenderer();
+    const { terminal, cells, state, markClean } = makeControllableTerminal(50, 50);
+    renderer.resize(50, 50);
+
+    const initial = renderer.render(terminal);
+    expect(initial).toMatchObject({
+      fullPaint: true,
+      paintedRows: 50,
+      submittedQuads: 2500,
+      retainedRowVertexBytes: ROW_FG_BYTES + ROW_BG_MIN_BYTES,
+      modelPrintable: 2500,
+      quads: 2500,
+    });
+
+    // Clear the middle row. Ghostty marks that row dirty; the renderer expands
+    // by one row on either side for cross-row grapheme pixels.
+    for (let col = 0; col < 50; col += 1) cells[25 * 50 + col].codepoint = 0;
+    state.dirty = 1;
+    state.rows = new Set([25]);
+    const partial = renderer.render(terminal);
+
+    expect(partial).toMatchObject({
+      fullPaint: false,
+      paintedRows: 3,
+      paintedCells: 150,
+      submittedQuads: 2450,
+      retainedRowVertexBytes: ROW_FG_BYTES + ROW_BG_MIN_BYTES,
+      modelPrintable: 2450,
+      quads: 2450,
+    });
+    expect(markClean).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps overlays on the full-frame path even when Ghostty is partially dirty', () => {
+    const { renderer } = makeRenderer();
+    const { terminal, state } = makeControllableTerminal(50, 50);
+    renderer.resize(50, 50);
+    renderer.render(terminal);
+
+    state.dirty = 1;
+    state.rows = new Set([25]);
+    const sample = renderer.render(terminal, false, undefined, [
+      { startRow: 25, startCol: 0, endRow: 25, endCol: 1, color: '#ffffff', kind: 'underline' },
+    ]);
+
+    expect(sample).toMatchObject({ fullPaint: true, paintedRows: 50 });
+
+    // Removing an overlay also changes pixels outside the model's dirty set.
+    // One full frame retires that composited surface before partial paints resume.
+    expect(renderer.render(terminal)).toMatchObject({ fullPaint: true, paintedRows: 50 });
+    expect(renderer.render(terminal)).toMatchObject({ fullPaint: false, paintedRows: 3 });
+  });
+
+  it('releases a row cache that grows beyond the two MiB guardrail', () => {
+    const { renderer } = makeRenderer();
+    const { terminal, cells, state } = makeControllableTerminal(100, 30);
+    for (const cell of cells) {
+      cell.bg_r = 64;
+      cell.flags = CellFlags.UNDERLINE | CellFlags.STRIKETHROUGH;
+    }
+    renderer.resize(100, 30);
+
+    expect(renderer.render(terminal)).toMatchObject({
+      fullPaint: true,
+      retainedRowVertexBytes: 0,
+      modelPrintable: 3000,
+    });
+
+    state.dirty = 1;
+    state.rows = new Set([15]);
+    expect(renderer.render(terminal)).toMatchObject({
+      fullPaint: true,
+      paintedRows: 30,
+      retainedRowVertexBytes: 0,
+    });
   });
 });
 

--- a/app/src/components/GhosttyWebGlRenderer.ts
+++ b/app/src/components/GhosttyWebGlRenderer.ts
@@ -12,6 +12,10 @@ import {
   KITTY_FORMAT_BYTES_PER_PIXEL,
   type KittyPixelFormat,
 } from '../utils/kittyImageFormat';
+import {
+  TERMINAL_FLOATS_PER_VERTEX,
+  TerminalVertexBuffer,
+} from './terminalVertexBuffer';
 
 interface RendererTheme {
   background: string;
@@ -172,7 +176,6 @@ export const MAX_ATLAS_SIZE = 2048;
 // fragment path: 0 = tinted coverage (text/box/overlays sample the atlas alpha
 // and paint it in the quad's color), 1 = color glyph (emoji: sample the atlas
 // RGBA directly so the glyph keeps its own colors).
-const FLOATS_PER_VERTEX = 9;
 
 // Next atlas size when the current one fills: double it, but never exceed the
 // cap. Idempotent at the cap, so repeated growth always converges to
@@ -312,9 +315,18 @@ export class WebGlTerminalRenderer {
   private readonly program: WebGLProgram;
   private readonly buffer: WebGLBuffer;
   private readonly texture: WebGLTexture;
+  private readonly uResolution: WebGLUniformLocation | null;
   private readonly atlas: HTMLCanvasElement;
   private readonly atlasContext: CanvasRenderingContext2D;
   private readonly glyphs = new Map<string, AtlasGlyph>();
+  // One buffer per cell pass. They are separate because an image can draw
+  // between them, and staying separate is also what lets each keep its own
+  // grown capacity: backgrounds are one quad per non-default cell, foregrounds
+  // several per styled cell, so a shared buffer would size to their sum.
+  private readonly cellBgVertices = new TerminalVertexBuffer();
+  private readonly cellFgVertices = new TerminalVertexBuffer();
+  private readonly outlineVertices = new TerminalVertexBuffer(256);
+  private readonly imageVertices = new TerminalVertexBuffer(64);
   // Insertion order is LRU order; a texture is re-inserted when it is drawn.
   private readonly imageTextures = new Map<string, WebGLTexture>();
   // Device pixels per CSS pixel, captured once at construction. Read by
@@ -325,7 +337,8 @@ export class WebGlTerminalRenderer {
   private baseline: number;
   private fontSize: number;
   private readonly fontFamily: string;
-  private readonly theme: RendererTheme;
+  private readonly defaultBg: Rgb;
+  private readonly cursorBg: Rgb;
   private atlasSize = INITIAL_ATLAS_SIZE;
   private atlasX = 2;
   private atlasY = 1;
@@ -353,7 +366,8 @@ export class WebGlTerminalRenderer {
     this.canvas = canvas;
     this.fontSize = fontSize;
     this.fontFamily = fontFamily;
-    this.theme = theme;
+    this.defaultBg = parseColor(theme.background);
+    this.cursorBg = parseColor(theme.cursor);
     this.dpr = Math.max(window.devicePixelRatio || 1, 1);
 
     const gl = canvas.getContext('webgl2', { alpha: false, antialias: false });
@@ -398,12 +412,13 @@ export class WebGlTerminalRenderer {
 
     gl.useProgram(this.program);
     gl.bindBuffer(gl.ARRAY_BUFFER, this.buffer);
-    const stride = FLOATS_PER_VERTEX * Float32Array.BYTES_PER_ELEMENT;
+    const stride = TERMINAL_FLOATS_PER_VERTEX * Float32Array.BYTES_PER_ELEMENT;
     this.configureAttribute('a_position', 2, stride, 0);
     this.configureAttribute('a_texcoord', 2, stride, 2 * Float32Array.BYTES_PER_ELEMENT);
     this.configureAttribute('a_color', 4, stride, 4 * Float32Array.BYTES_PER_ELEMENT);
     this.configureAttribute('a_mode', 1, stride, 8 * Float32Array.BYTES_PER_ELEMENT);
     gl.uniform1i(gl.getUniformLocation(this.program, 'u_atlas'), 0);
+    this.uResolution = gl.getUniformLocation(this.program, 'u_resolution');
     gl.enable(gl.BLEND);
     // Premultiplied-alpha blending: the shader emits color already multiplied by
     // coverage, so source factor is ONE. This keeps tinted text identical to the
@@ -448,9 +463,9 @@ export class WebGlTerminalRenderer {
 
     const gl = this.gl;
     const scale = this.dpr;
-    const defaultBg = parseColor(this.theme.background);
-    const cursorBg = parseColor(this.theme.cursor);
-    const cursorFg = parseColor(this.theme.background);
+    const defaultBg = this.defaultBg;
+    const cursorBg = this.cursorBg;
+    const cursorFg = this.defaultBg;
     const cursor = terminal.getCursor();
     const cursorRow = cursor.visible
       ? cursorRowInViewport(cursor.y, viewportOffset, terminal.rows)
@@ -461,8 +476,10 @@ export class WebGlTerminalRenderer {
     // paints — selection/search tints, the cursor block, glyphs, underlines —
     // is foreground, and draws after the under-text images so neither the
     // cursor nor a selection can vanish behind one.
-    const bgVertices: number[] = [];
-    const fgVertices: number[] = [];
+    const bgVertices = this.cellBgVertices;
+    const fgVertices = this.cellFgVertices;
+    bgVertices.reset();
+    fgVertices.reset();
     const glyphCountBefore = this.glyphs.size;
     const atlasGenerationBefore = this.atlasGeneration;
     // Resolve overlays into per-row column spans once per frame so the cell
@@ -558,7 +575,8 @@ export class WebGlTerminalRenderer {
 
     // Outlines are the last thing on the frame, after every image pass, so a
     // selected block's border stays legible over an image drawn above the text.
-    const outlineVertices: number[] = [];
+    const outlineVertices = this.outlineVertices;
+    outlineVertices.reset();
 
     for (const outline of outlines) {
       const top = Math.max(0, outline.startRow) * this.cellHeight * scale;
@@ -602,24 +620,24 @@ export class WebGlTerminalRenderer {
     gl.useProgram(this.program);
     gl.bindTexture(gl.TEXTURE_2D, this.texture);
     gl.bindBuffer(gl.ARRAY_BUFFER, this.buffer);
-    gl.uniform2f(gl.getUniformLocation(this.program, 'u_resolution'), this.canvas.width, this.canvas.height);
+    gl.uniform2f(this.uResolution, this.canvas.width, this.canvas.height);
     let imageQuadsDrawn = 0;
     imageQuadsDrawn += this.drawImages(underBackground, scale);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(bgVertices), gl.DYNAMIC_DRAW);
-    gl.drawArrays(gl.TRIANGLES, 0, bgVertices.length / FLOATS_PER_VERTEX);
+    gl.bufferData(gl.ARRAY_BUFFER, bgVertices.view(), gl.DYNAMIC_DRAW);
+    gl.drawArrays(gl.TRIANGLES, 0, bgVertices.length / TERMINAL_FLOATS_PER_VERTEX);
     imageQuadsDrawn += this.drawImages(underText, scale);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(fgVertices), gl.DYNAMIC_DRAW);
-    gl.drawArrays(gl.TRIANGLES, 0, fgVertices.length / FLOATS_PER_VERTEX);
+    gl.bufferData(gl.ARRAY_BUFFER, fgVertices.view(), gl.DYNAMIC_DRAW);
+    gl.drawArrays(gl.TRIANGLES, 0, fgVertices.length / TERMINAL_FLOATS_PER_VERTEX);
     imageQuadsDrawn += this.drawImages(overText, scale);
     if (outlineVertices.length > 0) {
-      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(outlineVertices), gl.DYNAMIC_DRAW);
-      gl.drawArrays(gl.TRIANGLES, 0, outlineVertices.length / FLOATS_PER_VERTEX);
+      gl.bufferData(gl.ARRAY_BUFFER, outlineVertices.view(), gl.DYNAMIC_DRAW);
+      gl.drawArrays(gl.TRIANGLES, 0, outlineVertices.length / TERMINAL_FLOATS_PER_VERTEX);
     }
     terminal.markClean();
     return {
       cpuSubmitMs: performance.now() - startedAt,
       cells: terminal.cols * terminal.rows,
-      quads: (bgVertices.length + fgVertices.length + outlineVertices.length) / FLOATS_PER_VERTEX / 6 + imageQuadsDrawn,
+      quads: bgVertices.quadCount + fgVertices.quadCount + outlineVertices.quadCount + imageQuadsDrawn,
       glyphUploads: this.glyphs.size - glyphCountBefore,
       cellsArrayLen: cells.length,
       printableSkippedNull,
@@ -658,7 +676,8 @@ export class WebGlTerminalRenderer {
       if (!texture) continue;
       const { width, height } = quad.source;
       if (width <= 0 || height <= 0) continue;
-      const vertices: number[] = [];
+      const vertices = this.imageVertices;
+      vertices.reset();
       this.pushQuad(
         vertices,
         quad.x * scale,
@@ -676,8 +695,8 @@ export class WebGlTerminalRenderer {
         GLYPH_MODE_COLOR,
       );
       gl.bindTexture(gl.TEXTURE_2D, texture);
-      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(vertices), gl.DYNAMIC_DRAW);
-      gl.drawArrays(gl.TRIANGLES, 0, vertices.length / FLOATS_PER_VERTEX);
+      gl.bufferData(gl.ARRAY_BUFFER, vertices.view(), gl.DYNAMIC_DRAW);
+      gl.drawArrays(gl.TRIANGLES, 0, vertices.length / TERMINAL_FLOATS_PER_VERTEX);
       drawn += 1;
     }
     gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
@@ -909,14 +928,14 @@ export class WebGlTerminalRenderer {
     );
   }
 
-  private pushSolidQuad(vertices: number[], x: number, y: number, width: number, height: number, color: Rgb, alpha: number): void {
+  private pushSolidQuad(vertices: TerminalVertexBuffer, x: number, y: number, width: number, height: number, color: Rgb, alpha: number): void {
     // Keep all samples within the white texel. Sampling its edges with LINEAR
     // filtering blends into transparent atlas neighbours and leaves seams. Mode
     // 0: tint the (fully-opaque) texel coverage with the quad color.
     this.pushQuad(vertices, x, y, width, height, this.solidTexelCenter, this.solidTexelCenter, this.solidTexelCenter, this.solidTexelCenter, color, alpha, GLYPH_MODE_TINT);
   }
 
-  private pushBlockElement(vertices: number[], codepoint: number, x: number, y: number, width: number, height: number, color: Rgb, alpha: number): boolean {
+  private pushBlockElement(vertices: TerminalVertexBuffer, codepoint: number, x: number, y: number, width: number, height: number, color: Rgb, alpha: number): boolean {
     const rects = BLOCK_ELEMENT_RECTS[codepoint];
     if (!rects) {
       return false;
@@ -935,14 +954,14 @@ export class WebGlTerminalRenderer {
     return true;
   }
 
-  private pushTexturedQuad(vertices: number[], x: number, y: number, width: number, height: number, glyph: AtlasGlyph, color: Rgb, alpha: number): void {
+  private pushTexturedQuad(vertices: TerminalVertexBuffer, x: number, y: number, width: number, height: number, glyph: AtlasGlyph, color: Rgb, alpha: number): void {
     // Color glyphs (emoji) carry their own colors and use mode 1 so the shader
     // passes the atlas RGBA through; monochrome glyphs use mode 0 and are tinted.
     this.pushQuad(vertices, x, y, width, height, glyph.u0, glyph.v0, glyph.u1, glyph.v1, color, alpha, glyph.colored ? GLYPH_MODE_COLOR : GLYPH_MODE_TINT);
   }
 
   private pushQuad(
-    vertices: number[],
+    vertices: TerminalVertexBuffer,
     x: number,
     y: number,
     width: number,
@@ -955,14 +974,6 @@ export class WebGlTerminalRenderer {
     alpha: number,
     mode: number,
   ): void {
-    const rgba = [color.r / 255, color.g / 255, color.b / 255, alpha];
-    vertices.push(
-      x, y, u0, v0, ...rgba, mode,
-      x + width, y, u1, v0, ...rgba, mode,
-      x, y + height, u0, v1, ...rgba, mode,
-      x, y + height, u0, v1, ...rgba, mode,
-      x + width, y, u1, v0, ...rgba, mode,
-      x + width, y + height, u1, v1, ...rgba, mode,
-    );
+    vertices.pushQuad(x, y, width, height, u0, v0, u1, v1, color, alpha, mode);
   }
 }

--- a/app/src/components/GhosttyWebGlRenderer.ts
+++ b/app/src/components/GhosttyWebGlRenderer.ts
@@ -128,6 +128,12 @@ interface Rgb {
   b: number;
 }
 
+type PackedRgb = number;
+
+function packRgb(r: number, g: number, b: number): PackedRgb {
+  return r << 16 | g << 8 | b;
+}
+
 interface BlockRect {
   x: number;
   y: number;
@@ -319,6 +325,11 @@ export class WebGlTerminalRenderer {
   private readonly atlas: HTMLCanvasElement;
   private readonly atlasContext: CanvasRenderingContext2D;
   private readonly glyphs = new Map<string, AtlasGlyph>();
+  // Single-codepoint cells are overwhelmingly common. Their numeric key avoids
+  // rebuilding a character string plus style-prefixed cache key for every cell
+  // on every paint. It is bounded by the atlas's existing glyph set and clears
+  // whenever that atlas is reseeded.
+  private readonly codepointGlyphs = new Map<number, AtlasGlyph>();
   // One buffer per cell pass. They are separate because an image can draw
   // between them, and staying separate is also what lets each keep its own
   // grown capacity: backgrounds are one quad per non-default cell, foregrounds
@@ -338,7 +349,8 @@ export class WebGlTerminalRenderer {
   private fontSize: number;
   private readonly fontFamily: string;
   private readonly defaultBg: Rgb;
-  private readonly cursorBg: Rgb;
+  private readonly defaultBgPacked: PackedRgb;
+  private readonly cursorBgPacked: PackedRgb;
   private atlasSize = INITIAL_ATLAS_SIZE;
   private atlasX = 2;
   private atlasY = 1;
@@ -367,7 +379,9 @@ export class WebGlTerminalRenderer {
     this.fontSize = fontSize;
     this.fontFamily = fontFamily;
     this.defaultBg = parseColor(theme.background);
-    this.cursorBg = parseColor(theme.cursor);
+    this.defaultBgPacked = packRgb(this.defaultBg.r, this.defaultBg.g, this.defaultBg.b);
+    const cursorBg = parseColor(theme.cursor);
+    this.cursorBgPacked = packRgb(cursorBg.r, cursorBg.g, cursorBg.b);
     this.dpr = Math.max(window.devicePixelRatio || 1, 1);
 
     const gl = canvas.getContext('webgl2', { alpha: false, antialias: false });
@@ -464,8 +478,8 @@ export class WebGlTerminalRenderer {
     const gl = this.gl;
     const scale = this.dpr;
     const defaultBg = this.defaultBg;
-    const cursorBg = this.cursorBg;
-    const cursorFg = this.defaultBg;
+    const cursorBg = this.cursorBgPacked;
+    const cursorFg = this.defaultBgPacked;
     const cursor = terminal.getCursor();
     const cursorRow = cursor.visible
       ? cursorRowInViewport(cursor.y, viewportOffset, terminal.rows)
@@ -534,7 +548,7 @@ export class WebGlTerminalRenderer {
         const fg = isCursor ? cursorFg : this.cellForeground(cell);
         const bg = this.cellBackground(cell);
 
-        if (bg.r !== defaultBg.r || bg.g !== defaultBg.g || bg.b !== defaultBg.b) {
+        if (bg !== this.defaultBgPacked) {
           this.pushSolidQuad(bgVertices, x, y, width, this.cellHeight * scale, bg, 1);
         }
         if (rowSpans) {
@@ -550,10 +564,9 @@ export class WebGlTerminalRenderer {
         if ((cell.flags & CellFlags.INVISIBLE) === 0 && cell.codepoint !== 0 && cell.codepoint !== 32) {
           const alpha = (cell.flags & CellFlags.FAINT) !== 0 ? 0.5 : 1;
           if (!this.pushBlockElement(fgVertices, cell.codepoint, x, y, width, this.cellHeight * scale, fg, alpha)) {
-            const text = cell.grapheme_len > 0
-              ? graphemeAtViewportCell(terminal, row, col, viewportOffset)
-              : String.fromCodePoint(cell.codepoint);
-            const glyph = this.getGlyph(text, cell.flags);
+            const glyph = cell.grapheme_len > 0
+              ? this.getGlyph(graphemeAtViewportCell(terminal, row, col, viewportOffset), cell.flags)
+              : this.getCodepointGlyph(cell.codepoint, cell.flags);
             this.pushTexturedQuad(fgVertices, x, y, glyph.width, glyph.height, glyph, fg, alpha);
           }
         }
@@ -802,22 +815,28 @@ export class WebGlTerminalRenderer {
     this.gl.vertexAttribPointer(location, size, this.gl.FLOAT, false, stride, offset);
   }
 
-  private cellForeground(cell: GhosttyCell): Rgb {
+  private cellForeground(cell: GhosttyCell): PackedRgb {
     if ((cell.flags & CellFlags.INVERSE) !== 0) {
-      return this.readColor(cell.bg_r, cell.bg_g, cell.bg_b);
+      return packRgb(cell.bg_r, cell.bg_g, cell.bg_b);
     }
-    return this.readColor(cell.fg_r, cell.fg_g, cell.fg_b);
+    return packRgb(cell.fg_r, cell.fg_g, cell.fg_b);
   }
 
-  private cellBackground(cell: GhosttyCell): Rgb {
+  private cellBackground(cell: GhosttyCell): PackedRgb {
     if ((cell.flags & CellFlags.INVERSE) !== 0) {
-      return this.readColor(cell.fg_r, cell.fg_g, cell.fg_b);
+      return packRgb(cell.fg_r, cell.fg_g, cell.fg_b);
     }
-    return this.readColor(cell.bg_r, cell.bg_g, cell.bg_b);
+    return packRgb(cell.bg_r, cell.bg_g, cell.bg_b);
   }
 
-  private readColor(r: number, g: number, b: number): Rgb {
-    return { r, g, b };
+  private getCodepointGlyph(codepoint: number, flags: number): AtlasGlyph {
+    const style = (flags & CellFlags.ITALIC ? 1 : 0) | (flags & CellFlags.BOLD ? 2 : 0);
+    const key = codepoint * 4 + style;
+    const existing = this.codepointGlyphs.get(key);
+    if (existing) return existing;
+    const glyph = this.getGlyph(String.fromCodePoint(codepoint), flags);
+    this.codepointGlyphs.set(key, glyph);
+    return glyph;
   }
 
   private getGlyph(text: string, flags: number): AtlasGlyph {
@@ -906,6 +925,7 @@ export class WebGlTerminalRenderer {
   // both before measuring and again after a grow, before drawing.
   private reseedAtlas(): void {
     this.glyphs.clear();
+    this.codepointGlyphs.clear();
     this.atlasX = 2;
     this.atlasY = 1;
     this.atlasRowHeight = 0;
@@ -928,14 +948,14 @@ export class WebGlTerminalRenderer {
     );
   }
 
-  private pushSolidQuad(vertices: TerminalVertexBuffer, x: number, y: number, width: number, height: number, color: Rgb, alpha: number): void {
+  private pushSolidQuad(vertices: TerminalVertexBuffer, x: number, y: number, width: number, height: number, color: Rgb | PackedRgb, alpha: number): void {
     // Keep all samples within the white texel. Sampling its edges with LINEAR
     // filtering blends into transparent atlas neighbours and leaves seams. Mode
     // 0: tint the (fully-opaque) texel coverage with the quad color.
     this.pushQuad(vertices, x, y, width, height, this.solidTexelCenter, this.solidTexelCenter, this.solidTexelCenter, this.solidTexelCenter, color, alpha, GLYPH_MODE_TINT);
   }
 
-  private pushBlockElement(vertices: TerminalVertexBuffer, codepoint: number, x: number, y: number, width: number, height: number, color: Rgb, alpha: number): boolean {
+  private pushBlockElement(vertices: TerminalVertexBuffer, codepoint: number, x: number, y: number, width: number, height: number, color: Rgb | PackedRgb, alpha: number): boolean {
     const rects = BLOCK_ELEMENT_RECTS[codepoint];
     if (!rects) {
       return false;
@@ -954,7 +974,7 @@ export class WebGlTerminalRenderer {
     return true;
   }
 
-  private pushTexturedQuad(vertices: TerminalVertexBuffer, x: number, y: number, width: number, height: number, glyph: AtlasGlyph, color: Rgb, alpha: number): void {
+  private pushTexturedQuad(vertices: TerminalVertexBuffer, x: number, y: number, width: number, height: number, glyph: AtlasGlyph, color: Rgb | PackedRgb, alpha: number): void {
     // Color glyphs (emoji) carry their own colors and use mode 1 so the shader
     // passes the atlas RGBA through; monochrome glyphs use mode 0 and are tinted.
     this.pushQuad(vertices, x, y, width, height, glyph.u0, glyph.v0, glyph.u1, glyph.v1, color, alpha, glyph.colored ? GLYPH_MODE_COLOR : GLYPH_MODE_TINT);
@@ -970,7 +990,7 @@ export class WebGlTerminalRenderer {
     v0: number,
     u1: number,
     v1: number,
-    color: Rgb,
+    color: Rgb | PackedRgb,
     alpha: number,
     mode: number,
   ): void {

--- a/app/src/components/GhosttyWebGlRenderer.ts
+++ b/app/src/components/GhosttyWebGlRenderer.ts
@@ -532,11 +532,17 @@ export class WebGlTerminalRenderer {
       : null;
 
     // The cursor is drawn as an inverted cell, so where it sits is part of the
-    // frame even when no cell content changed. A same-row move, a visibility
-    // toggle, or a move made while hidden all report DIRTY_NONE, so comparing
-    // it against the last frame is the only thing standing between those and a
-    // cursor left painted at its old column until unrelated output arrives.
-    const cursorMoved = cursorRow !== this.lastCursorRow || cursor.x !== this.lastCursorCol;
+    // frame even when no cell content changed. A same-row move and a visibility
+    // toggle both report DIRTY_NONE, and comparing the cursor against the last
+    // frame here is the only thing standing between those and a cursor left
+    // painted at its old column until unrelated output arrives.
+    //
+    // Only the drawn cursor counts. A hidden one paints nothing, so its column
+    // cannot go stale, and a TUI moving a hidden cursor mid-redraw — which they
+    // do constantly — would otherwise pass this check, find no row to mark, and
+    // be escalated to a full-grid paint by the zero-row guard below.
+    const cursorMoved = cursorRow !== this.lastCursorRow
+      || (cursorRow !== null && cursor.x !== this.lastCursorCol);
     if (!force && dirty === DIRTY_NONE && !cursorMoved) {
       return null;
     }

--- a/app/src/components/GhosttyWebGlRenderer.ts
+++ b/app/src/components/GhosttyWebGlRenderer.ts
@@ -13,6 +13,7 @@ import {
   type KittyPixelFormat,
 } from '../utils/kittyImageFormat';
 import {
+  TERMINAL_FLOATS_PER_QUAD,
   TERMINAL_FLOATS_PER_VERTEX,
   TerminalVertexBuffer,
 } from './terminalVertexBuffer';
@@ -109,6 +110,23 @@ export const KITTY_Z_UNDER_BACKGROUND = -1_073_741_824;
 // single upload.
 export const IMAGE_TEXTURE_LIMIT = 16;
 
+// Below this grid size, copying the cached rows into the complete staging
+// buffer costs more than rebuilding the small viewport. Packaged A/Bs put the
+// crossover below a 1,785-printable-cell split pane. Keep a wider safety margin
+// around ordinary interaction-sized panes and enable it only above 2,048 cells;
+// the packaged 3,212-cell case remains a measured win.
+const ROW_VERTEX_CACHE_MIN_CELLS = 2_048;
+const ROW_VERTEX_CACHE_MAX_BYTES = 2 * 1024 * 1024;
+
+// Starting capacity per row, in quads per column, for each cell pass. Every
+// printable cell contributes a foreground quad, so a full row is the honest
+// start for that pass. How many cells carry a non-default background is a
+// property of the content, not something to guess at: the background pass
+// starts at the buffer minimum and grows into whatever the pane turns out to
+// need, which costs a reallocation on a styled row and nothing on a plain one.
+const ROW_FG_QUADS_PER_CELL = 1;
+const ROW_BG_QUADS_PER_CELL = 0;
+
 interface AtlasGlyph {
   u0: number;
   v0: number;
@@ -144,6 +162,12 @@ interface BlockRect {
 export interface WebGlRenderSample {
   cpuSubmitMs: number;
   cells: number;
+  paintedCells: number;
+  paintedRows: number;
+  fullPaint: boolean;
+  submittedQuads: number;
+  retainedRowVertexBytes: number;
+  modelPrintable: number;
   quads: number;
   glyphUploads: number;
   // TEMP (blank-on-split): diagnostics to explain why drawn quads can fall
@@ -356,6 +380,24 @@ export class WebGlTerminalRenderer {
   private atlasY = 1;
   private atlasRowHeight = 0;
   private atlasGeneration = 0;
+  // Ghostty reports dirty rows until markClean(). Cache each rendered row in
+  // the same CPU-side vertex format the complete frame already uses: partial
+  // model updates only rebuild changed rows, then concatenate the row buffers
+  // and still clear/draw a complete frame. That last part is deliberate — a
+  // WebGL drawing buffer is not retained across composites by default, so
+  // scissoring dirty pixels would trade correctness for speed unless we kept a
+  // much larger Retina-sized framebuffer. This cache is visible-grid and
+  // content proportional, with a hard retained-memory ceiling.
+  private dirtyRowMask = new Uint8Array(0);
+  // One entry per row per cell pass. Two arrays rather than one of pairs: the
+  // frame concatenates every row's backgrounds, then every row's foregrounds,
+  // so each is walked whole.
+  private rowBgVertices: Array<TerminalVertexBuffer | null> = [];
+  private rowFgVertices: Array<TerminalVertexBuffer | null> = [];
+  private printableByRow = new Uint32Array(0);
+  private rowCacheValid = false;
+  private rowCacheOverBudget = false;
+  private modelPrintable = 0;
 
   // UV of the center of the 1×1 solid white texel at atlas pixel (0,0). Depends
   // on the current atlas size, so it is recomputed rather than precomputed.
@@ -459,6 +501,13 @@ export class WebGlTerminalRenderer {
     this.canvas.style.width = `${cols * this.cellWidth}px`;
     this.canvas.style.height = `${rows * this.cellHeight}px`;
     this.gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+    this.dirtyRowMask = new Uint8Array(rows);
+    this.rowBgVertices = Array.from({ length: rows }, () => null);
+    this.rowFgVertices = Array.from({ length: rows }, () => null);
+    this.printableByRow = new Uint32Array(rows);
+    this.rowCacheValid = false;
+    this.rowCacheOverBudget = false;
+    this.modelPrintable = 0;
   }
 
   render(
@@ -473,6 +522,52 @@ export class WebGlTerminalRenderer {
     const dirty = terminal.update();
     if (!force && dirty === 0) {
       return null;
+    }
+
+    // DirtyState is intentionally not exported by ghostty-web, but its public
+    // update() contract defines 1 as PARTIAL and 2 as FULL. Scrolled viewports,
+    // overlays, and images are derived surfaces rather than the model's active
+    // grid, so they bypass and invalidate the row cache.
+    if (this.dirtyRowMask.length !== terminal.rows) {
+      this.dirtyRowMask = new Uint8Array(terminal.rows);
+      this.rowBgVertices = Array.from({ length: terminal.rows }, () => null);
+      this.rowFgVertices = Array.from({ length: terminal.rows }, () => null);
+      this.printableByRow = new Uint32Array(terminal.rows);
+      this.rowCacheValid = false;
+      this.rowCacheOverBudget = false;
+      this.modelPrintable = 0;
+    }
+    const gridCells = terminal.cols * terminal.rows;
+    const canCacheRows = gridCells >= ROW_VERTEX_CACHE_MIN_CELLS
+      && gridCells * TERMINAL_FLOATS_PER_QUAD * Float32Array.BYTES_PER_ELEMENT <= ROW_VERTEX_CACHE_MAX_BYTES
+      && !this.rowCacheOverBudget
+      && viewportCells === undefined
+      && viewportOffset === 0
+      && (overlays?.length ?? 0) === 0
+      && (images?.length ?? 0) === 0;
+    let fullPaint = force || dirty !== 1 || !canCacheRows || !this.rowCacheValid;
+    const rowsToPaint = this.dirtyRowMask;
+    rowsToPaint.fill(fullPaint ? 1 : 0);
+    if (!fullPaint) {
+      let dirtyRows = 0;
+      for (let row = 0; row < terminal.rows; row += 1) {
+        if (!terminal.isRowDirty(row)) continue;
+        // Match ghostty-web's own canvas renderer: include neighboring rows so
+        // a grapheme whose pixels cross a row boundary is cleared and rebuilt.
+        rowsToPaint[row] = 1;
+        if (row > 0) rowsToPaint[row - 1] = 1;
+        if (row + 1 < terminal.rows) rowsToPaint[row + 1] = 1;
+        dirtyRows += 1;
+      }
+      // PARTIAL with no rows would leave an unknowable stale surface. It should
+      // not occur, but a full paint is the safe failure mode if the ABI drifts.
+      if (dirtyRows === 0) {
+        fullPaint = true;
+        rowsToPaint.fill(1);
+      }
+    }
+    if (!canCacheRows) {
+      this.rowCacheValid = false;
     }
 
     const gl = this.gl;
@@ -525,10 +620,28 @@ export class WebGlTerminalRenderer {
     gl.clearColor(defaultBg.r / 255, defaultBg.g / 255, defaultBg.b / 255, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
 
+    let paintedRows = 0;
+    let frameModelPrintable = 0;
     for (let row = 0; row < terminal.rows; row += 1) {
+      if (rowsToPaint[row] === 0) continue;
+      paintedRows += 1;
       const rowSpans = spansByRow[row];
+      // A row caches its two passes separately, because the frame concatenates
+      // every row's backgrounds before any row's foregrounds.
+      const rowBgTarget = canCacheRows
+        ? this.rowVertexBuffer(this.rowBgVertices, row, terminal.cols, ROW_BG_QUADS_PER_CELL)
+        : bgVertices;
+      const rowFgTarget = canCacheRows
+        ? this.rowVertexBuffer(this.rowFgVertices, row, terminal.cols, ROW_FG_QUADS_PER_CELL)
+        : fgVertices;
+      if (canCacheRows) {
+        rowBgTarget.reset();
+        rowFgTarget.reset();
+      }
+      let printableInRow = 0;
       for (let col = 0; col < terminal.cols; col += 1) {
         const cell = cells[row * terminal.cols + col];
+        if (cell && cell.codepoint > 32) printableInRow += 1;
         if (!cell || cell.width === 0) {
           if (cell && cell.codepoint > 32) {
             printableSkippedZeroWidth += 1;
@@ -549,40 +662,69 @@ export class WebGlTerminalRenderer {
         const bg = this.cellBackground(cell);
 
         if (bg !== this.defaultBgPacked) {
-          this.pushSolidQuad(bgVertices, x, y, width, this.cellHeight * scale, bg, 1);
+          this.pushSolidQuad(rowBgTarget, x, y, width, this.cellHeight * scale, bg, 1);
         }
         if (rowSpans) {
           for (const span of rowSpans) {
             if (span.kind === 'background' && col >= span.startCol && col < span.endCol) {
-              this.pushSolidQuad(fgVertices, x, y, width, this.cellHeight * scale, span.rgb, span.alpha);
+              this.pushSolidQuad(rowFgTarget, x, y, width, this.cellHeight * scale, span.rgb, span.alpha);
             }
           }
         }
         if (isCursor) {
-          this.pushSolidQuad(fgVertices, x, y, width, this.cellHeight * scale, cursorBg, 1);
+          this.pushSolidQuad(rowFgTarget, x, y, width, this.cellHeight * scale, cursorBg, 1);
         }
         if ((cell.flags & CellFlags.INVISIBLE) === 0 && cell.codepoint !== 0 && cell.codepoint !== 32) {
           const alpha = (cell.flags & CellFlags.FAINT) !== 0 ? 0.5 : 1;
-          if (!this.pushBlockElement(fgVertices, cell.codepoint, x, y, width, this.cellHeight * scale, fg, alpha)) {
+          if (!this.pushBlockElement(rowFgTarget, cell.codepoint, x, y, width, this.cellHeight * scale, fg, alpha)) {
             const glyph = cell.grapheme_len > 0
               ? this.getGlyph(graphemeAtViewportCell(terminal, row, col, viewportOffset), cell.flags)
               : this.getCodepointGlyph(cell.codepoint, cell.flags);
-            this.pushTexturedQuad(fgVertices, x, y, glyph.width, glyph.height, glyph, fg, alpha);
+            this.pushTexturedQuad(rowFgTarget, x, y, glyph.width, glyph.height, glyph, fg, alpha);
           }
         }
         if ((cell.flags & CellFlags.UNDERLINE) !== 0) {
-          this.pushSolidQuad(fgVertices, x, y + (this.baseline + 2) * scale, width, scale, fg, 1);
+          this.pushSolidQuad(rowFgTarget, x, y + (this.baseline + 2) * scale, width, scale, fg, 1);
         }
         if ((cell.flags & CellFlags.STRIKETHROUGH) !== 0) {
-          this.pushSolidQuad(fgVertices, x, y + Math.floor(this.cellHeight / 2) * scale, width, scale, fg, 1);
+          this.pushSolidQuad(rowFgTarget, x, y + Math.floor(this.cellHeight / 2) * scale, width, scale, fg, 1);
         }
         if (rowSpans) {
           for (const span of rowSpans) {
             if (span.kind === 'underline' && col >= span.startCol && col < span.endCol) {
-              this.pushSolidQuad(fgVertices, x, y + (this.baseline + 2) * scale, width, scale, span.rgb, span.alpha);
+              this.pushSolidQuad(rowFgTarget, x, y + (this.baseline + 2) * scale, width, scale, span.rgb, span.alpha);
             }
           }
         }
+      }
+      if (canCacheRows) {
+        this.modelPrintable += printableInRow - this.printableByRow[row];
+        this.printableByRow[row] = printableInRow;
+      } else {
+        frameModelPrintable += printableInRow;
+      }
+    }
+
+    let retainedRowVertexBytes = 0;
+    if (canCacheRows) {
+      // Concatenate in pass order, not row order: every row's backgrounds form
+      // the first draw, every row's foregrounds the second, so an image tier can
+      // be drawn between them exactly as it is on the direct path.
+      bgVertices.reset();
+      fgVertices.reset();
+      for (const row of this.rowBgVertices) {
+        if (row) bgVertices.append(row.view());
+      }
+      for (const row of this.rowFgVertices) {
+        if (row) fgVertices.append(row.view());
+      }
+      retainedRowVertexBytes = this.retainedRowVertexBytes();
+      // A styled cell can emit several quads. If real content grows the cache
+      // past the guardrail, finish this already-built frame, then release the
+      // rows and keep this grid on the direct renderer until its next resize.
+      if (retainedRowVertexBytes > ROW_VERTEX_CACHE_MAX_BYTES) {
+        this.rowCacheOverBudget = true;
+        this.rowCacheValid = false;
       }
     }
 
@@ -646,11 +788,27 @@ export class WebGlTerminalRenderer {
       gl.bufferData(gl.ARRAY_BUFFER, outlineVertices.view(), gl.DYNAMIC_DRAW);
       gl.drawArrays(gl.TRIANGLES, 0, outlineVertices.length / TERMINAL_FLOATS_PER_VERTEX);
     }
+    const submittedQuads = bgVertices.quadCount + fgVertices.quadCount + outlineVertices.quadCount + imageQuadsDrawn;
+    const sampleModelPrintable = canCacheRows ? this.modelPrintable : frameModelPrintable;
+    if (canCacheRows && !this.rowCacheOverBudget) this.rowCacheValid = true;
+    if (this.rowCacheOverBudget) {
+      this.rowBgVertices = Array.from({ length: terminal.rows }, () => null);
+      this.rowFgVertices = Array.from({ length: terminal.rows }, () => null);
+      this.printableByRow = new Uint32Array(terminal.rows);
+      this.modelPrintable = 0;
+      retainedRowVertexBytes = 0;
+    }
     terminal.markClean();
     return {
       cpuSubmitMs: performance.now() - startedAt,
       cells: terminal.cols * terminal.rows,
-      quads: bgVertices.quadCount + fgVertices.quadCount + outlineVertices.quadCount + imageQuadsDrawn,
+      paintedCells: paintedRows * terminal.cols,
+      paintedRows,
+      fullPaint,
+      submittedQuads,
+      retainedRowVertexBytes,
+      modelPrintable: sampleModelPrintable,
+      quads: submittedQuads,
       glyphUploads: this.glyphs.size - glyphCountBefore,
       cellsArrayLen: cells.length,
       printableSkippedNull,
@@ -815,6 +973,36 @@ export class WebGlTerminalRenderer {
     this.gl.vertexAttribPointer(location, size, this.gl.FLOAT, false, stride, offset);
   }
 
+  // `quadsPerCell` is how many quads a cell is expected to contribute to this
+  // pass, and only sets the starting capacity — the buffer grows on demand, so
+  // an underestimate costs one reallocation rather than a wrong frame. The two
+  // passes are estimated differently on purpose: a foreground cell draws a glyph
+  // and can add a tint, an underline, or a strikethrough, while a background
+  // draws at most one quad and only for a non-default color, which most rows
+  // have none of. Sizing both at a full row is what doubled retained bytes.
+  private rowVertexBuffer(
+    rows: Array<TerminalVertexBuffer | null>,
+    row: number,
+    cols: number,
+    quadsPerCell: number,
+  ): TerminalVertexBuffer {
+    const existing = rows[row];
+    if (existing) return existing;
+    const created = new TerminalVertexBuffer(Math.max(
+      TERMINAL_FLOATS_PER_QUAD,
+      Math.ceil(cols * quadsPerCell) * TERMINAL_FLOATS_PER_QUAD,
+    ));
+    rows[row] = created;
+    return created;
+  }
+
+  private retainedRowVertexBytes(): number {
+    let bytes = 0;
+    for (const row of this.rowBgVertices) bytes += row?.capacityBytes ?? 0;
+    for (const row of this.rowFgVertices) bytes += row?.capacityBytes ?? 0;
+    return bytes;
+  }
+
   private cellForeground(cell: GhosttyCell): PackedRgb {
     if ((cell.flags & CellFlags.INVERSE) !== 0) {
       return packRgb(cell.bg_r, cell.bg_g, cell.bg_b);
@@ -926,6 +1114,9 @@ export class WebGlTerminalRenderer {
   private reseedAtlas(): void {
     this.glyphs.clear();
     this.codepointGlyphs.clear();
+    // Cached vertices carry UVs into this atlas. Once it moves, every row has
+    // to be rebuilt before it can be concatenated into another frame.
+    this.rowCacheValid = false;
     this.atlasX = 2;
     this.atlasY = 1;
     this.atlasRowHeight = 0;

--- a/app/src/components/GhosttyWebGlRenderer.ts
+++ b/app/src/components/GhosttyWebGlRenderer.ts
@@ -526,9 +526,25 @@ export class WebGlTerminalRenderer {
   ): WebGlRenderSample | null {
     const startedAt = performance.now();
     const dirty = terminal.update();
-    if (!force && dirty === DIRTY_NONE) {
+    const cursor = terminal.getCursor();
+    const cursorRow = cursor.visible
+      ? cursorRowInViewport(cursor.y, viewportOffset, terminal.rows)
+      : null;
+
+    // The cursor is drawn as an inverted cell, so where it sits is part of the
+    // frame even when no cell content changed. A same-row move, a visibility
+    // toggle, or a move made while hidden all report DIRTY_NONE, so comparing
+    // it against the last frame is the only thing standing between those and a
+    // cursor left painted at its old column until unrelated output arrives.
+    const cursorMoved = cursorRow !== this.lastCursorRow || cursor.x !== this.lastCursorCol;
+    if (!force && dirty === DIRTY_NONE && !cursorMoved) {
       return null;
     }
+    // A frame that exists only because the cursor moved has no dirty cells, but
+    // it is still a two-row repaint rather than a whole-grid one. Without this
+    // it would fall to `dirty !== DIRTY_PARTIAL` below and full-paint the grid
+    // on every arrow key — the exact cost the row cache is here to avoid.
+    const cursorOnlyPaint = dirty === DIRTY_NONE && cursorMoved;
 
     if (this.dirtyRowMask.length !== terminal.rows) {
       this.resetRowCache(terminal.rows);
@@ -543,12 +559,10 @@ export class WebGlTerminalRenderer {
       && (overlays?.length ?? 0) === 0
       && (images?.length ?? 0) === 0;
 
-    const cursor = terminal.getCursor();
-    const cursorRow = cursor.visible
-      ? cursorRowInViewport(cursor.y, viewportOffset, terminal.rows)
-      : null;
-
-    let fullPaint = force || dirty !== DIRTY_PARTIAL || !canCacheRows || !this.rowCacheValid;
+    let fullPaint = force
+      || (dirty !== DIRTY_PARTIAL && !cursorOnlyPaint)
+      || !canCacheRows
+      || !this.rowCacheValid;
     const rowsToPaint = this.dirtyRowMask;
     rowsToPaint.fill(fullPaint ? 1 : 0);
     if (!fullPaint) {
@@ -572,14 +586,13 @@ export class WebGlTerminalRenderer {
       // arrived row, but a move within one row ("\x1b[2;9H", "\x1b[D") and a
       // visibility toggle ("\x1b[?25l") report DIRTY_NONE — no rows at all.
       //
-      // Alone those never reach here, since render() returns early on
-      // DIRTY_NONE. They matter when they ride along with an unrelated dirty
-      // row: the frame is PARTIAL, the cursor's row is not in the set, and the
-      // cursor is baked into the cached row as an inverted cell — so the row
-      // would keep the cursor at its old column. Repainting both rows costs at
-      // most six rows and removes the whole class. ghostty-web's own canvas
-      // renderer compensates the same way.
-      const cursorMoved = cursorRow !== this.lastCursorRow || cursor.x !== this.lastCursorCol;
+      // A bare move (DIRTY_NONE, no other dirty rows) would leave the old
+      // inverted cursor on screen until unrelated output triggers a paint. When
+      // riding along with an unrelated dirty row in a PARTIAL frame, the
+      // cursor's row is not in the set and the cursor stays baked into the
+      // cached row at the old column. Repainting both the vacated and arrived
+      // rows costs at most six rows and covers both cases. ghostty-web's own
+      // canvas renderer compensates the same way.
       if (cursorMoved && (cursorRow !== null || this.lastCursorRow !== null)) {
         if (cursorRow !== null) markRow(cursorRow);
         if (this.lastCursorRow !== null) markRow(this.lastCursorRow);

--- a/app/src/components/GhosttyWebGlRenderer.ts
+++ b/app/src/components/GhosttyWebGlRenderer.ts
@@ -17,6 +17,15 @@ import {
   TERMINAL_FLOATS_PER_VERTEX,
   TerminalVertexBuffer,
 } from './terminalVertexBuffer';
+import {
+  PACKED_WHITE,
+  type PackedRgb,
+  type Rgb,
+  packColor,
+  packRgb,
+  parseColor,
+  parsePackedColor,
+} from './terminalColor';
 
 interface RendererTheme {
   background: string;
@@ -43,7 +52,7 @@ export interface WebGlOverlay {
 interface OverlaySpan {
   startCol: number;
   endCol: number;
-  rgb: Rgb;
+  rgb: PackedRgb;
   alpha: number;
   kind: 'background' | 'underline';
 }
@@ -116,6 +125,17 @@ export const IMAGE_TEXTURE_LIMIT = 16;
 // around ordinary interaction-sized panes and enable it only above 2,048 cells;
 // the packaged 3,212-cell case remains a measured win.
 const ROW_VERTEX_CACHE_MIN_CELLS = 2_048;
+// Ceiling on what the row cache itself retains. This governs the cache's
+// marginal cost only: the frame buffer the rows concatenate into is a second
+// full-frame copy, but a frame has to be staged somewhere whether or not the
+// cache exists, so folding it in here would trip the gate on memory the direct
+// path spends anyway. Both numbers are reported on every sample
+// (retainedRowVertexBytes and retainedStagingBytes) so the receipt stays whole.
+//
+// Styled content emits several quads per cell, so the real cost is
+// content-dependent and only knowable after a frame is built; a grid that
+// crosses the ceiling releases its rows and stays on the direct path until it
+// resizes.
 const ROW_VERTEX_CACHE_MAX_BYTES = 2 * 1024 * 1024;
 
 // Starting capacity per row, in quads per column, for each cell pass. Every
@@ -126,6 +146,12 @@ const ROW_VERTEX_CACHE_MAX_BYTES = 2 * 1024 * 1024;
 // need, which costs a reallocation on a styled row and nothing on a plain one.
 const ROW_FG_QUADS_PER_CELL = 1;
 const ROW_BG_QUADS_PER_CELL = 0;
+
+// ghostty-web does not export DirtyState, but its update() contract defines
+// these values. PARTIAL is the only one the row cache can serve; anything else
+// rebuilds the whole grid.
+const DIRTY_NONE = 0;
+const DIRTY_PARTIAL = 1;
 
 interface AtlasGlyph {
   u0: number;
@@ -138,18 +164,6 @@ interface AtlasGlyph {
   // as Apple Color Emoji). Such glyphs are drawn directly from the atlas
   // instead of being tinted with the cell's foreground color.
   colored: boolean;
-}
-
-interface Rgb {
-  r: number;
-  g: number;
-  b: number;
-}
-
-type PackedRgb = number;
-
-function packRgb(r: number, g: number, b: number): PackedRgb {
-  return r << 16 | g << 8 | b;
 }
 
 interface BlockRect {
@@ -167,6 +181,9 @@ export interface WebGlRenderSample {
   fullPaint: boolean;
   submittedQuads: number;
   retainedRowVertexBytes: number;
+  // Rows plus the frame buffer they concatenate into: everything this renderer
+  // holds between paints, including the staging a pane pays on the direct path.
+  retainedStagingBytes: number;
   modelPrintable: number;
   quads: number;
   glyphUploads: number;
@@ -287,15 +304,6 @@ function imageUpload(
   return { format: gl.RGBA, pixels: rgba };
 }
 
-function parseColor(value: string): Rgb {
-  const normalized = value.replace('#', '');
-  return {
-    r: Number.parseInt(normalized.slice(0, 2), 16),
-    g: Number.parseInt(normalized.slice(2, 4), 16),
-    b: Number.parseInt(normalized.slice(4, 6), 16),
-  };
-}
-
 function compileShader(gl: WebGL2RenderingContext, type: number, source: string): WebGLShader {
   const shader = gl.createShader(type);
   if (!shader) {
@@ -398,6 +406,10 @@ export class WebGlTerminalRenderer {
   private rowCacheValid = false;
   private rowCacheOverBudget = false;
   private modelPrintable = 0;
+  // Cursor position as the last frame drew it, so a partial paint can repaint
+  // the row it left behind. null row means the cursor was hidden.
+  private lastCursorRow: number | null = null;
+  private lastCursorCol = -1;
 
   // UV of the center of the 1×1 solid white texel at atlas pixel (0,0). Depends
   // on the current atlas size, so it is recomputed rather than precomputed.
@@ -420,10 +432,10 @@ export class WebGlTerminalRenderer {
     this.canvas = canvas;
     this.fontSize = fontSize;
     this.fontFamily = fontFamily;
+    // defaultBg stays unpacked for gl.clearColor, which wants normalized floats.
     this.defaultBg = parseColor(theme.background);
-    this.defaultBgPacked = packRgb(this.defaultBg.r, this.defaultBg.g, this.defaultBg.b);
-    const cursorBg = parseColor(theme.cursor);
-    this.cursorBgPacked = packRgb(cursorBg.r, cursorBg.g, cursorBg.b);
+    this.defaultBgPacked = packColor(this.defaultBg);
+    this.cursorBgPacked = parsePackedColor(theme.cursor);
     this.dpr = Math.max(window.devicePixelRatio || 1, 1);
 
     const gl = canvas.getContext('webgl2', { alpha: false, antialias: false });
@@ -501,13 +513,7 @@ export class WebGlTerminalRenderer {
     this.canvas.style.width = `${cols * this.cellWidth}px`;
     this.canvas.style.height = `${rows * this.cellHeight}px`;
     this.gl.viewport(0, 0, this.canvas.width, this.canvas.height);
-    this.dirtyRowMask = new Uint8Array(rows);
-    this.rowBgVertices = Array.from({ length: rows }, () => null);
-    this.rowFgVertices = Array.from({ length: rows }, () => null);
-    this.printableByRow = new Uint32Array(rows);
-    this.rowCacheValid = false;
-    this.rowCacheOverBudget = false;
-    this.modelPrintable = 0;
+    this.resetRowCache(rows);
   }
 
   render(
@@ -520,43 +526,63 @@ export class WebGlTerminalRenderer {
   ): WebGlRenderSample | null {
     const startedAt = performance.now();
     const dirty = terminal.update();
-    if (!force && dirty === 0) {
+    if (!force && dirty === DIRTY_NONE) {
       return null;
     }
 
-    // DirtyState is intentionally not exported by ghostty-web, but its public
-    // update() contract defines 1 as PARTIAL and 2 as FULL. Scrolled viewports,
-    // overlays, and images are derived surfaces rather than the model's active
-    // grid, so they bypass and invalidate the row cache.
     if (this.dirtyRowMask.length !== terminal.rows) {
-      this.dirtyRowMask = new Uint8Array(terminal.rows);
-      this.rowBgVertices = Array.from({ length: terminal.rows }, () => null);
-      this.rowFgVertices = Array.from({ length: terminal.rows }, () => null);
-      this.printableByRow = new Uint32Array(terminal.rows);
-      this.rowCacheValid = false;
-      this.rowCacheOverBudget = false;
-      this.modelPrintable = 0;
+      this.resetRowCache(terminal.rows);
     }
+    // Scrolled viewports, overlays, and images are derived surfaces rather than
+    // the model's active grid, so they bypass and invalidate the row cache.
     const gridCells = terminal.cols * terminal.rows;
     const canCacheRows = gridCells >= ROW_VERTEX_CACHE_MIN_CELLS
-      && gridCells * TERMINAL_FLOATS_PER_QUAD * Float32Array.BYTES_PER_ELEMENT <= ROW_VERTEX_CACHE_MAX_BYTES
       && !this.rowCacheOverBudget
       && viewportCells === undefined
       && viewportOffset === 0
       && (overlays?.length ?? 0) === 0
       && (images?.length ?? 0) === 0;
-    let fullPaint = force || dirty !== 1 || !canCacheRows || !this.rowCacheValid;
+
+    const cursor = terminal.getCursor();
+    const cursorRow = cursor.visible
+      ? cursorRowInViewport(cursor.y, viewportOffset, terminal.rows)
+      : null;
+
+    let fullPaint = force || dirty !== DIRTY_PARTIAL || !canCacheRows || !this.rowCacheValid;
     const rowsToPaint = this.dirtyRowMask;
     rowsToPaint.fill(fullPaint ? 1 : 0);
     if (!fullPaint) {
       let dirtyRows = 0;
-      for (let row = 0; row < terminal.rows; row += 1) {
-        if (!terminal.isRowDirty(row)) continue;
+      const markRow = (row: number) => {
+        if (row < 0 || row >= terminal.rows) return;
         // Match ghostty-web's own canvas renderer: include neighboring rows so
         // a grapheme whose pixels cross a row boundary is cleared and rebuilt.
         rowsToPaint[row] = 1;
         if (row > 0) rowsToPaint[row - 1] = 1;
         if (row + 1 < terminal.rows) rowsToPaint[row + 1] = 1;
+      };
+      for (let row = 0; row < terminal.rows; row += 1) {
+        if (!terminal.isRowDirty(row)) continue;
+        markRow(row);
+        dirtyRows += 1;
+      }
+      // The model's dirty set covers the cursor only when it changes row.
+      // Measured with scripts/bench-terminal-dirty-rows.mjs against the
+      // vendored WASM: a cross-row CUP reports both the vacated and the
+      // arrived row, but a move within one row ("\x1b[2;9H", "\x1b[D") and a
+      // visibility toggle ("\x1b[?25l") report DIRTY_NONE — no rows at all.
+      //
+      // Alone those never reach here, since render() returns early on
+      // DIRTY_NONE. They matter when they ride along with an unrelated dirty
+      // row: the frame is PARTIAL, the cursor's row is not in the set, and the
+      // cursor is baked into the cached row as an inverted cell — so the row
+      // would keep the cursor at its old column. Repainting both rows costs at
+      // most six rows and removes the whole class. ghostty-web's own canvas
+      // renderer compensates the same way.
+      const cursorMoved = cursorRow !== this.lastCursorRow || cursor.x !== this.lastCursorCol;
+      if (cursorMoved && (cursorRow !== null || this.lastCursorRow !== null)) {
+        if (cursorRow !== null) markRow(cursorRow);
+        if (this.lastCursorRow !== null) markRow(this.lastCursorRow);
         dirtyRows += 1;
       }
       // PARTIAL with no rows would leave an unknowable stale surface. It should
@@ -566,6 +592,8 @@ export class WebGlTerminalRenderer {
         rowsToPaint.fill(1);
       }
     }
+    this.lastCursorRow = cursorRow;
+    this.lastCursorCol = cursor.x;
     if (!canCacheRows) {
       this.rowCacheValid = false;
     }
@@ -575,10 +603,6 @@ export class WebGlTerminalRenderer {
     const defaultBg = this.defaultBg;
     const cursorBg = this.cursorBgPacked;
     const cursorFg = this.defaultBgPacked;
-    const cursor = terminal.getCursor();
-    const cursorRow = cursor.visible
-      ? cursorRowInViewport(cursor.y, viewportOffset, terminal.rows)
-      : null;
     const cells = viewportCells ?? terminal.getViewport();
     // Two cell passes, so an image can be drawn between them. bgVertices holds
     // ONLY the per-cell non-default background fills; everything else a cell
@@ -595,9 +619,9 @@ export class WebGlTerminalRenderer {
     // loop only checks the (typically 0-2) spans on its own row. Outlines are
     // geometric borders and render in a dedicated pass after the cells.
     const spansByRow: Array<OverlaySpan[] | undefined> = new Array(terminal.rows);
-    const outlines: Array<{ startRow: number; startCol: number; endRow: number; endCol: number; rgb: Rgb; alpha: number }> = [];
+    const outlines: Array<{ startRow: number; startCol: number; endRow: number; endCol: number; rgb: PackedRgb; alpha: number }> = [];
     for (const overlay of overlays ?? []) {
-      const rgb = parseColor(overlay.color);
+      const rgb = parsePackedColor(overlay.color);
       const alpha = overlay.alpha ?? 1;
       if (overlay.kind === 'outline') {
         outlines.push({ ...overlay, rgb, alpha });
@@ -705,7 +729,12 @@ export class WebGlTerminalRenderer {
       }
     }
 
+    // Settle the printable count before the budget check below can release the
+    // per-row totals it is derived from.
+    const sampleModelPrintable = canCacheRows ? this.modelPrintable : frameModelPrintable;
+
     let retainedRowVertexBytes = 0;
+    let retainedStagingBytes = this.cellBgVertices.capacityBytes + this.cellFgVertices.capacityBytes;
     if (canCacheRows) {
       // Concatenate in pass order, not row order: every row's backgrounds form
       // the first draw, every row's foregrounds the second, so an image tier can
@@ -719,12 +748,19 @@ export class WebGlTerminalRenderer {
         if (row) fgVertices.append(row.view());
       }
       retainedRowVertexBytes = this.retainedRowVertexBytes();
+      retainedStagingBytes = this.retainedStagingBytes();
       // A styled cell can emit several quads. If real content grows the cache
-      // past the guardrail, finish this already-built frame, then release the
-      // rows and keep this grid on the direct renderer until its next resize.
+      // past the guardrail, release the rows and keep this grid on the direct
+      // renderer until its next resize. The frame already built above is
+      // unaffected: it was concatenated into the two cell buffers the draw
+      // reads from. Releasing here rather than after the draw is what makes it
+      // happen exactly once — canCacheRows requires !rowCacheOverBudget, so
+      // this branch is unreachable on every later frame of the episode.
       if (retainedRowVertexBytes > ROW_VERTEX_CACHE_MAX_BYTES) {
         this.rowCacheOverBudget = true;
-        this.rowCacheValid = false;
+        this.releaseRowCache(terminal.rows);
+        retainedRowVertexBytes = 0;
+        retainedStagingBytes = this.cellBgVertices.capacityBytes + this.cellFgVertices.capacityBytes;
       }
     }
 
@@ -789,15 +825,7 @@ export class WebGlTerminalRenderer {
       gl.drawArrays(gl.TRIANGLES, 0, outlineVertices.length / TERMINAL_FLOATS_PER_VERTEX);
     }
     const submittedQuads = bgVertices.quadCount + fgVertices.quadCount + outlineVertices.quadCount + imageQuadsDrawn;
-    const sampleModelPrintable = canCacheRows ? this.modelPrintable : frameModelPrintable;
     if (canCacheRows && !this.rowCacheOverBudget) this.rowCacheValid = true;
-    if (this.rowCacheOverBudget) {
-      this.rowBgVertices = Array.from({ length: terminal.rows }, () => null);
-      this.rowFgVertices = Array.from({ length: terminal.rows }, () => null);
-      this.printableByRow = new Uint32Array(terminal.rows);
-      this.modelPrintable = 0;
-      retainedRowVertexBytes = 0;
-    }
     terminal.markClean();
     return {
       cpuSubmitMs: performance.now() - startedAt,
@@ -807,6 +835,7 @@ export class WebGlTerminalRenderer {
       fullPaint,
       submittedQuads,
       retainedRowVertexBytes,
+      retainedStagingBytes,
       modelPrintable: sampleModelPrintable,
       quads: submittedQuads,
       glyphUploads: this.glyphs.size - glyphCountBefore,
@@ -861,7 +890,7 @@ export class WebGlTerminalRenderer {
         (quad.sourceY + quad.sourceHeight) / height,
         // The color-glyph path passes the texel through, scaled by quad alpha:
         // exactly "draw this texture" once the alpha is 1.
-        { r: 255, g: 255, b: 255 },
+        PACKED_WHITE,
         1,
         GLYPH_MODE_COLOR,
       );
@@ -964,6 +993,11 @@ export class WebGlTerminalRenderer {
     this.cellHeight = Math.max(1, Math.ceil(fontSize * 1.45));
     this.baseline = Math.ceil(fontSize * 1.1);
     this.metricsDirty = true;
+    // Cached row vertices carry pixel geometry built from the old cell metrics.
+    // invalidateGlyphCache() happens to drop them too (a reseeded atlas moves
+    // every UV), but geometry is its own reason and has to survive someone
+    // making the atlas survivable.
+    this.rowCacheValid = false;
     this.invalidateGlyphCache();
   }
 
@@ -996,11 +1030,40 @@ export class WebGlTerminalRenderer {
     return created;
   }
 
+  // What the row cache itself retains: zero on the direct path, so this stays
+  // the legible "is the cache allocated" signal.
   private retainedRowVertexBytes(): number {
     let bytes = 0;
     for (const row of this.rowBgVertices) bytes += row?.capacityBytes ?? 0;
     for (const row of this.rowFgVertices) bytes += row?.capacityBytes ?? 0;
     return bytes;
+  }
+
+  // Everything this renderer keeps alive between paints: the retained rows plus
+  // the frame buffers they concatenate into, which hold a second full-frame
+  // copy of the same content. Reported, not gated — see
+  // ROW_VERTEX_CACHE_MAX_BYTES — so a memory receipt covers both halves instead
+  // of the rows alone.
+  private retainedStagingBytes(): number {
+    return this.cellBgVertices.capacityBytes
+      + this.cellFgVertices.capacityBytes
+      + this.retainedRowVertexBytes();
+  }
+
+  private resetRowCache(rows: number): void {
+    this.dirtyRowMask = new Uint8Array(rows);
+    this.rowCacheOverBudget = false;
+    this.releaseRowCache(rows);
+  }
+
+  // Drop the retained rows but keep the over-budget verdict, so a grid that
+  // crossed the ceiling stays on the direct path until it resizes.
+  private releaseRowCache(rows: number): void {
+    this.rowBgVertices = Array.from({ length: rows }, () => null);
+    this.rowFgVertices = Array.from({ length: rows }, () => null);
+    this.printableByRow = new Uint32Array(rows);
+    this.rowCacheValid = false;
+    this.modelPrintable = 0;
   }
 
   private cellForeground(cell: GhosttyCell): PackedRgb {
@@ -1139,14 +1202,14 @@ export class WebGlTerminalRenderer {
     );
   }
 
-  private pushSolidQuad(vertices: TerminalVertexBuffer, x: number, y: number, width: number, height: number, color: Rgb | PackedRgb, alpha: number): void {
+  private pushSolidQuad(vertices: TerminalVertexBuffer, x: number, y: number, width: number, height: number, color: PackedRgb, alpha: number): void {
     // Keep all samples within the white texel. Sampling its edges with LINEAR
     // filtering blends into transparent atlas neighbours and leaves seams. Mode
     // 0: tint the (fully-opaque) texel coverage with the quad color.
     this.pushQuad(vertices, x, y, width, height, this.solidTexelCenter, this.solidTexelCenter, this.solidTexelCenter, this.solidTexelCenter, color, alpha, GLYPH_MODE_TINT);
   }
 
-  private pushBlockElement(vertices: TerminalVertexBuffer, codepoint: number, x: number, y: number, width: number, height: number, color: Rgb | PackedRgb, alpha: number): boolean {
+  private pushBlockElement(vertices: TerminalVertexBuffer, codepoint: number, x: number, y: number, width: number, height: number, color: PackedRgb, alpha: number): boolean {
     const rects = BLOCK_ELEMENT_RECTS[codepoint];
     if (!rects) {
       return false;
@@ -1165,7 +1228,7 @@ export class WebGlTerminalRenderer {
     return true;
   }
 
-  private pushTexturedQuad(vertices: TerminalVertexBuffer, x: number, y: number, width: number, height: number, glyph: AtlasGlyph, color: Rgb | PackedRgb, alpha: number): void {
+  private pushTexturedQuad(vertices: TerminalVertexBuffer, x: number, y: number, width: number, height: number, glyph: AtlasGlyph, color: PackedRgb, alpha: number): void {
     // Color glyphs (emoji) carry their own colors and use mode 1 so the shader
     // passes the atlas RGBA through; monochrome glyphs use mode 0 and are tinted.
     this.pushQuad(vertices, x, y, width, height, glyph.u0, glyph.v0, glyph.u1, glyph.v1, color, alpha, glyph.colored ? GLYPH_MODE_COLOR : GLYPH_MODE_TINT);
@@ -1181,7 +1244,7 @@ export class WebGlTerminalRenderer {
     v0: number,
     u1: number,
     v1: number,
-    color: Rgb | PackedRgb,
+    color: PackedRgb,
     alpha: number,
     mode: number,
   ): void {

--- a/app/src/components/grid/UnifiedGridRenderer.ts
+++ b/app/src/components/grid/UnifiedGridRenderer.ts
@@ -20,6 +20,10 @@ import {
   isColorGlyphBitmap,
 } from '../terminalGlyphProgram';
 import { terminalGlyphFont } from '../terminalGlyphFont';
+import {
+  TERMINAL_FLOATS_PER_VERTEX,
+  TerminalVertexBuffer,
+} from '../terminalVertexBuffer';
 import type { UISessionState } from '../../types/sessionState';
 import type {
   GridRenderer,
@@ -56,9 +60,6 @@ interface BlockRect {
 }
 
 const ATLAS_SIZE = 2048;
-// position(2) + texcoord(2) + color(4) + mode(1); see terminalGlyphProgram.
-const FLOATS_PER_VERTEX = 9;
-const FLOATS_PER_QUAD = FLOATS_PER_VERTEX * 6;
 const SOLID_TEXEL_CENTER = 0.5 / ATLAS_SIZE;
 // Blue accent for the focused (zoomed/input-target) tile, so it is obvious which
 // tile keyboard input is going to. Distinct from the semantic session state.
@@ -210,9 +211,7 @@ export class UnifiedGridRenderer implements GridRenderer {
   private models = new Map<string, GhosttyTerminal>();
 
   // The single shared vertex scratch. Grown (rarely) on demand; reused forever.
-  private scratch = new Float32Array(1 << 18);
-  private p = 0;
-  private quads = 0;
+  private readonly vertices = new TerminalVertexBuffer(1 << 18);
   private glyphUploads = 0;
   private atlasResets = 0;
   private canvasW = 0;
@@ -279,7 +278,7 @@ export class UnifiedGridRenderer implements GridRenderer {
 
     gl.useProgram(this.program);
     gl.bindBuffer(gl.ARRAY_BUFFER, this.buffer);
-    const stride = FLOATS_PER_VERTEX * Float32Array.BYTES_PER_ELEMENT;
+    const stride = TERMINAL_FLOATS_PER_VERTEX * Float32Array.BYTES_PER_ELEMENT;
     this.configureAttribute('a_position', 2, stride, 0);
     this.configureAttribute('a_texcoord', 2, stride, 2 * Float32Array.BYTES_PER_ELEMENT);
     this.configureAttribute('a_color', 4, stride, 4 * Float32Array.BYTES_PER_ELEMENT);
@@ -327,13 +326,13 @@ export class UnifiedGridRenderer implements GridRenderer {
     gl.useProgram(this.program);
     gl.bindTexture(gl.TEXTURE_2D, this.texture);
     gl.bindBuffer(gl.ARRAY_BUFFER, this.buffer);
-    gl.bufferData(gl.ARRAY_BUFFER, this.scratch.subarray(0, this.p), gl.DYNAMIC_DRAW);
+    gl.bufferData(gl.ARRAY_BUFFER, this.vertices.view(), gl.DYNAMIC_DRAW);
     gl.uniform2f(this.uResolution, canvas.width, canvas.height);
-    gl.drawArrays(gl.TRIANGLES, 0, this.p / FLOATS_PER_VERTEX);
+    gl.drawArrays(gl.TRIANGLES, 0, this.vertices.length / TERMINAL_FLOATS_PER_VERTEX);
 
     return {
       drawCalls: 1,
-      quads: this.quads,
+      quads: this.vertices.quadCount,
       atlasUploads: this.glyphUploads,
       atlasResets: this.atlasResets,
       liveContexts: 1,
@@ -372,8 +371,7 @@ export class UnifiedGridRenderer implements GridRenderer {
   }
 
   private walkAll(frames: TileFrame[], now: number): void {
-    this.p = 0;
-    this.quads = 0;
+    this.vertices.reset();
     for (const frame of frames) {
       if (frame.hidden || frame.alpha <= 0.001) continue;
       const model = this.models.get(frame.id);
@@ -648,8 +646,6 @@ export class UnifiedGridRenderer implements GridRenderer {
     return true;
   }
 
-  // The hot path: write 54 floats (6 verts × 9) straight into the preallocated
-  // scratch. The trailing float per vertex is a_mode (see terminalGlyphProgram).
   private pushQuad(
     x: number,
     y: number,
@@ -663,27 +659,6 @@ export class UnifiedGridRenderer implements GridRenderer {
     alpha: number,
     mode: number,
   ): void {
-    if (this.p + FLOATS_PER_QUAD > this.scratch.length) {
-      const next = new Float32Array(this.scratch.length * 2);
-      next.set(this.scratch.subarray(0, this.p));
-      this.scratch = next;
-    }
-    const s = this.scratch;
-    const r = color.r / 255;
-    const g = color.g / 255;
-    const b = color.b / 255;
-    const a = alpha;
-    const e = mode;
-    let p = this.p;
-    // tri 1
-    s[p++] = x; s[p++] = y; s[p++] = u0; s[p++] = v0; s[p++] = r; s[p++] = g; s[p++] = b; s[p++] = a; s[p++] = e;
-    s[p++] = x + w; s[p++] = y; s[p++] = u1; s[p++] = v0; s[p++] = r; s[p++] = g; s[p++] = b; s[p++] = a; s[p++] = e;
-    s[p++] = x; s[p++] = y + h; s[p++] = u0; s[p++] = v1; s[p++] = r; s[p++] = g; s[p++] = b; s[p++] = a; s[p++] = e;
-    // tri 2
-    s[p++] = x; s[p++] = y + h; s[p++] = u0; s[p++] = v1; s[p++] = r; s[p++] = g; s[p++] = b; s[p++] = a; s[p++] = e;
-    s[p++] = x + w; s[p++] = y; s[p++] = u1; s[p++] = v0; s[p++] = r; s[p++] = g; s[p++] = b; s[p++] = a; s[p++] = e;
-    s[p++] = x + w; s[p++] = y + h; s[p++] = u1; s[p++] = v1; s[p++] = r; s[p++] = g; s[p++] = b; s[p++] = a; s[p++] = e;
-    this.p = p;
-    this.quads += 1;
+    this.vertices.pushQuad(x, y, w, h, u0, v0, u1, v1, color, alpha, mode);
   }
 }

--- a/app/src/components/grid/UnifiedGridRenderer.ts
+++ b/app/src/components/grid/UnifiedGridRenderer.ts
@@ -24,6 +24,7 @@ import {
   TERMINAL_FLOATS_PER_VERTEX,
   TerminalVertexBuffer,
 } from '../terminalVertexBuffer';
+import { type Rgb, packColor, parseColor } from '../terminalColor';
 import type { UISessionState } from '../../types/sessionState';
 import type {
   GridRenderer,
@@ -32,12 +33,6 @@ import type {
   TileModel,
 } from './GridRenderer';
 import type { CellMetrics } from './gridConfig';
-
-interface Rgb {
-  r: number;
-  g: number;
-  b: number;
-}
 
 interface AtlasGlyph {
   u0: number;
@@ -141,15 +136,6 @@ const BLOCK_ELEMENT_RECTS: Readonly<Record<number, readonly BlockRect[]>> = {
     { x: 0, y: 1 / 2, width: 1 / 2, height: 1 / 2 },
   ],
 };
-
-function parseColor(value: string): Rgb {
-  const normalized = value.replace('#', '');
-  return {
-    r: Number.parseInt(normalized.slice(0, 2), 16),
-    g: Number.parseInt(normalized.slice(2, 4), 16),
-    b: Number.parseInt(normalized.slice(4, 6), 16),
-  };
-}
 
 function compileShader(gl: WebGL2RenderingContext, type: number, source: string): WebGLShader {
   const shader = gl.createShader(type);
@@ -659,6 +645,6 @@ export class UnifiedGridRenderer implements GridRenderer {
     alpha: number,
     mode: number,
   ): void {
-    this.vertices.pushQuad(x, y, w, h, u0, v0, u1, v1, color, alpha, mode);
+    this.vertices.pushQuad(x, y, w, h, u0, v0, u1, v1, packColor(color), alpha, mode);
   }
 }

--- a/app/src/components/terminalColor.ts
+++ b/app/src/components/terminalColor.ts
@@ -1,0 +1,36 @@
+// Colors shared by the terminal and mission-control grid renderers. Both stage
+// vertices through TerminalVertexBuffer, which stores a color as a single
+// packed integer: a per-cell {r,g,b} object allocates on the hottest loop in
+// the app, and the GPU only ever sees three normalized floats anyway.
+
+export interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+// 0xRRGGBB. Channels are 0-255; the buffer normalizes on write.
+export type PackedRgb = number;
+
+export function packRgb(r: number, g: number, b: number): PackedRgb {
+  return r << 16 | g << 8 | b;
+}
+
+export function packColor(color: Rgb): PackedRgb {
+  return packRgb(color.r, color.g, color.b);
+}
+
+export function parseColor(value: string): Rgb {
+  const normalized = value.replace('#', '');
+  return {
+    r: Number.parseInt(normalized.slice(0, 2), 16),
+    g: Number.parseInt(normalized.slice(2, 4), 16),
+    b: Number.parseInt(normalized.slice(4, 6), 16),
+  };
+}
+
+export function parsePackedColor(value: string): PackedRgb {
+  return packColor(parseColor(value));
+}
+
+export const PACKED_WHITE: PackedRgb = 0xffffff;

--- a/app/src/components/terminalVertexBuffer.test.ts
+++ b/app/src/components/terminalVertexBuffer.test.ts
@@ -19,6 +19,16 @@ describe('TerminalVertexBuffer', () => {
     ]);
   });
 
+  it('accepts packed RGB without a color object', () => {
+    const vertices = new TerminalVertexBuffer(TERMINAL_FLOATS_PER_QUAD);
+
+    vertices.pushQuad(0, 0, 1, 1, 0, 0, 1, 1, 0xff8000, 0.5, 1);
+
+    expect(Array.from(vertices.view().slice(4, 9))).toEqual([
+      1, expect.closeTo(128 / 255), 0, 0.5, 1,
+    ]);
+  });
+
   it('reuses its allocation after reset', () => {
     const vertices = new TerminalVertexBuffer();
     vertices.pushQuad(0, 0, 1, 1, 0, 0, 1, 1, { r: 0, g: 0, b: 0 }, 1, 0);

--- a/app/src/components/terminalVertexBuffer.test.ts
+++ b/app/src/components/terminalVertexBuffer.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { packRgb } from './terminalColor';
 import {
   TERMINAL_FLOATS_PER_QUAD,
   TerminalVertexBuffer,
@@ -7,7 +8,7 @@ import {
 describe('TerminalVertexBuffer', () => {
   it('writes the two triangles of a quad in GPU-ready layout', () => {
     const vertices = new TerminalVertexBuffer();
-    vertices.pushQuad(10, 20, 30, 40, 0.1, 0.2, 0.7, 0.8, { r: 255, g: 128, b: 0 }, 0.5, 1);
+    vertices.pushQuad(10, 20, 30, 40, 0.1, 0.2, 0.7, 0.8, packRgb(255, 128, 0), 0.5, 1);
 
     expect(vertices.length).toBe(TERMINAL_FLOATS_PER_QUAD);
     expect(vertices.quadCount).toBe(1);
@@ -19,7 +20,7 @@ describe('TerminalVertexBuffer', () => {
     ]);
   });
 
-  it('accepts packed RGB without a color object', () => {
+  it('normalizes each packed channel onto its own float', () => {
     const vertices = new TerminalVertexBuffer(TERMINAL_FLOATS_PER_QUAD);
 
     vertices.pushQuad(0, 0, 1, 1, 0, 0, 1, 1, 0xff8000, 0.5, 1);
@@ -31,11 +32,11 @@ describe('TerminalVertexBuffer', () => {
 
   it('reuses its allocation after reset', () => {
     const vertices = new TerminalVertexBuffer();
-    vertices.pushQuad(0, 0, 1, 1, 0, 0, 1, 1, { r: 0, g: 0, b: 0 }, 1, 0);
+    vertices.pushQuad(0, 0, 1, 1, 0, 0, 1, 1, packRgb(0, 0, 0), 1, 0);
     const allocation = vertices.view().buffer;
 
     vertices.reset();
-    vertices.pushQuad(1, 1, 2, 2, 0, 0, 1, 1, { r: 255, g: 255, b: 255 }, 1, 0);
+    vertices.pushQuad(1, 1, 2, 2, 0, 0, 1, 1, packRgb(255, 255, 255), 1, 0);
 
     expect(vertices.view().buffer).toBe(allocation);
     expect(vertices.quadCount).toBe(1);
@@ -43,9 +44,9 @@ describe('TerminalVertexBuffer', () => {
 
   it('grows without losing vertices already written in the frame', () => {
     const vertices = new TerminalVertexBuffer(TERMINAL_FLOATS_PER_QUAD);
-    vertices.pushQuad(1, 2, 3, 4, 0, 0, 1, 1, { r: 1, g: 2, b: 3 }, 1, 0);
+    vertices.pushQuad(1, 2, 3, 4, 0, 0, 1, 1, packRgb(1, 2, 3), 1, 0);
     const firstQuad = Array.from(vertices.view());
-    vertices.pushQuad(5, 6, 7, 8, 0, 0, 1, 1, { r: 4, g: 5, b: 6 }, 1, 0);
+    vertices.pushQuad(5, 6, 7, 8, 0, 0, 1, 1, packRgb(4, 5, 6), 1, 0);
 
     expect(vertices.quadCount).toBe(2);
     expect(Array.from(vertices.view().slice(0, TERMINAL_FLOATS_PER_QUAD))).toEqual(firstQuad);

--- a/app/src/components/terminalVertexBuffer.test.ts
+++ b/app/src/components/terminalVertexBuffer.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  TERMINAL_FLOATS_PER_QUAD,
+  TerminalVertexBuffer,
+} from './terminalVertexBuffer';
+
+describe('TerminalVertexBuffer', () => {
+  it('writes the two triangles of a quad in GPU-ready layout', () => {
+    const vertices = new TerminalVertexBuffer();
+    vertices.pushQuad(10, 20, 30, 40, 0.1, 0.2, 0.7, 0.8, { r: 255, g: 128, b: 0 }, 0.5, 1);
+
+    expect(vertices.length).toBe(TERMINAL_FLOATS_PER_QUAD);
+    expect(vertices.quadCount).toBe(1);
+    expect(Array.from(vertices.view().slice(0, 9))).toEqual([
+      10, 20, expect.closeTo(0.1), expect.closeTo(0.2), 1, expect.closeTo(128 / 255), 0, 0.5, 1,
+    ]);
+    expect(Array.from(vertices.view().slice(-9))).toEqual([
+      40, 60, expect.closeTo(0.7), expect.closeTo(0.8), 1, expect.closeTo(128 / 255), 0, 0.5, 1,
+    ]);
+  });
+
+  it('reuses its allocation after reset', () => {
+    const vertices = new TerminalVertexBuffer();
+    vertices.pushQuad(0, 0, 1, 1, 0, 0, 1, 1, { r: 0, g: 0, b: 0 }, 1, 0);
+    const allocation = vertices.view().buffer;
+
+    vertices.reset();
+    vertices.pushQuad(1, 1, 2, 2, 0, 0, 1, 1, { r: 255, g: 255, b: 255 }, 1, 0);
+
+    expect(vertices.view().buffer).toBe(allocation);
+    expect(vertices.quadCount).toBe(1);
+  });
+
+  it('grows without losing vertices already written in the frame', () => {
+    const vertices = new TerminalVertexBuffer(TERMINAL_FLOATS_PER_QUAD);
+    vertices.pushQuad(1, 2, 3, 4, 0, 0, 1, 1, { r: 1, g: 2, b: 3 }, 1, 0);
+    const firstQuad = Array.from(vertices.view());
+    vertices.pushQuad(5, 6, 7, 8, 0, 0, 1, 1, { r: 4, g: 5, b: 6 }, 1, 0);
+
+    expect(vertices.quadCount).toBe(2);
+    expect(Array.from(vertices.view().slice(0, TERMINAL_FLOATS_PER_QUAD))).toEqual(firstQuad);
+  });
+});

--- a/app/src/components/terminalVertexBuffer.test.ts
+++ b/app/src/components/terminalVertexBuffer.test.ts
@@ -50,4 +50,17 @@ describe('TerminalVertexBuffer', () => {
     expect(vertices.quadCount).toBe(2);
     expect(Array.from(vertices.view().slice(0, TERMINAL_FLOATS_PER_QUAD))).toEqual(firstQuad);
   });
+
+  it('appends an existing row without rebuilding its quads', () => {
+    const row = new TerminalVertexBuffer(TERMINAL_FLOATS_PER_QUAD);
+    row.pushQuad(1, 2, 3, 4, 0, 0, 1, 1, 0x010203, 1, 0);
+    const frame = new TerminalVertexBuffer(TERMINAL_FLOATS_PER_QUAD);
+
+    frame.append(row.view());
+    frame.append(row.view());
+
+    expect(frame.quadCount).toBe(2);
+    expect(Array.from(frame.view().slice(0, TERMINAL_FLOATS_PER_QUAD))).toEqual(Array.from(row.view()));
+    expect(Array.from(frame.view().slice(TERMINAL_FLOATS_PER_QUAD))).toEqual(Array.from(row.view()));
+  });
 });

--- a/app/src/components/terminalVertexBuffer.ts
+++ b/app/src/components/terminalVertexBuffer.ts
@@ -7,6 +7,8 @@ interface Rgb {
   b: number;
 }
 
+type TerminalVertexColor = Rgb | number;
+
 // Reusable CPU-side vertex staging for terminal glyphs and solid quads. A
 // number[] plus `new Float32Array(vertices)` allocates and copies the complete
 // frame on every paint; this buffer writes the GPU's native representation once
@@ -44,15 +46,15 @@ export class TerminalVertexBuffer {
     v0: number,
     u1: number,
     v1: number,
-    color: Rgb,
+    color: TerminalVertexColor,
     alpha: number,
     mode: number,
   ): void {
     this.ensureCapacity(TERMINAL_FLOATS_PER_QUAD);
     const vertices = this.scratch;
-    const r = color.r / 255;
-    const g = color.g / 255;
-    const b = color.b / 255;
+    const r = (typeof color === 'number' ? color >>> 16 & 0xff : color.r) / 255;
+    const g = (typeof color === 'number' ? color >>> 8 & 0xff : color.g) / 255;
+    const b = (typeof color === 'number' ? color & 0xff : color.b) / 255;
     let offset = this.cursor;
 
     vertices[offset++] = x; vertices[offset++] = y; vertices[offset++] = u0; vertices[offset++] = v0; vertices[offset++] = r; vertices[offset++] = g; vertices[offset++] = b; vertices[offset++] = alpha; vertices[offset++] = mode;

--- a/app/src/components/terminalVertexBuffer.ts
+++ b/app/src/components/terminalVertexBuffer.ts
@@ -29,12 +29,23 @@ export class TerminalVertexBuffer {
     return this.cursor / TERMINAL_FLOATS_PER_QUAD;
   }
 
+  get capacityBytes(): number {
+    return this.scratch.byteLength;
+  }
+
   reset(): void {
     this.cursor = 0;
   }
 
   view(): Float32Array {
     return this.scratch.subarray(0, this.cursor);
+  }
+
+  append(vertices: Float32Array): void {
+    if (vertices.length === 0) return;
+    this.ensureCapacity(vertices.length);
+    this.scratch.set(vertices, this.cursor);
+    this.cursor += vertices.length;
   }
 
   pushQuad(

--- a/app/src/components/terminalVertexBuffer.ts
+++ b/app/src/components/terminalVertexBuffer.ts
@@ -1,13 +1,7 @@
+import type { PackedRgb } from './terminalColor';
+
 export const TERMINAL_FLOATS_PER_VERTEX = 9;
 export const TERMINAL_FLOATS_PER_QUAD = TERMINAL_FLOATS_PER_VERTEX * 6;
-
-interface Rgb {
-  r: number;
-  g: number;
-  b: number;
-}
-
-type TerminalVertexColor = Rgb | number;
 
 // Reusable CPU-side vertex staging for terminal glyphs and solid quads. A
 // number[] plus `new Float32Array(vertices)` allocates and copies the complete
@@ -57,15 +51,15 @@ export class TerminalVertexBuffer {
     v0: number,
     u1: number,
     v1: number,
-    color: TerminalVertexColor,
+    color: PackedRgb,
     alpha: number,
     mode: number,
   ): void {
     this.ensureCapacity(TERMINAL_FLOATS_PER_QUAD);
     const vertices = this.scratch;
-    const r = (typeof color === 'number' ? color >>> 16 & 0xff : color.r) / 255;
-    const g = (typeof color === 'number' ? color >>> 8 & 0xff : color.g) / 255;
-    const b = (typeof color === 'number' ? color & 0xff : color.b) / 255;
+    const r = (color >>> 16 & 0xff) / 255;
+    const g = (color >>> 8 & 0xff) / 255;
+    const b = (color & 0xff) / 255;
     let offset = this.cursor;
 
     vertices[offset++] = x; vertices[offset++] = y; vertices[offset++] = u0; vertices[offset++] = v0; vertices[offset++] = r; vertices[offset++] = g; vertices[offset++] = b; vertices[offset++] = alpha; vertices[offset++] = mode;

--- a/app/src/components/terminalVertexBuffer.ts
+++ b/app/src/components/terminalVertexBuffer.ts
@@ -1,0 +1,77 @@
+export const TERMINAL_FLOATS_PER_VERTEX = 9;
+export const TERMINAL_FLOATS_PER_QUAD = TERMINAL_FLOATS_PER_VERTEX * 6;
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+// Reusable CPU-side vertex staging for terminal glyphs and solid quads. A
+// number[] plus `new Float32Array(vertices)` allocates and copies the complete
+// frame on every paint; this buffer writes the GPU's native representation once
+// and only grows when a larger frame actually needs it.
+export class TerminalVertexBuffer {
+  private scratch: Float32Array;
+  private cursor = 0;
+
+  constructor(initialCapacity = 1 << 15) {
+    this.scratch = new Float32Array(Math.max(initialCapacity, TERMINAL_FLOATS_PER_QUAD));
+  }
+
+  get length(): number {
+    return this.cursor;
+  }
+
+  get quadCount(): number {
+    return this.cursor / TERMINAL_FLOATS_PER_QUAD;
+  }
+
+  reset(): void {
+    this.cursor = 0;
+  }
+
+  view(): Float32Array {
+    return this.scratch.subarray(0, this.cursor);
+  }
+
+  pushQuad(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    u0: number,
+    v0: number,
+    u1: number,
+    v1: number,
+    color: Rgb,
+    alpha: number,
+    mode: number,
+  ): void {
+    this.ensureCapacity(TERMINAL_FLOATS_PER_QUAD);
+    const vertices = this.scratch;
+    const r = color.r / 255;
+    const g = color.g / 255;
+    const b = color.b / 255;
+    let offset = this.cursor;
+
+    vertices[offset++] = x; vertices[offset++] = y; vertices[offset++] = u0; vertices[offset++] = v0; vertices[offset++] = r; vertices[offset++] = g; vertices[offset++] = b; vertices[offset++] = alpha; vertices[offset++] = mode;
+    vertices[offset++] = x + width; vertices[offset++] = y; vertices[offset++] = u1; vertices[offset++] = v0; vertices[offset++] = r; vertices[offset++] = g; vertices[offset++] = b; vertices[offset++] = alpha; vertices[offset++] = mode;
+    vertices[offset++] = x; vertices[offset++] = y + height; vertices[offset++] = u0; vertices[offset++] = v1; vertices[offset++] = r; vertices[offset++] = g; vertices[offset++] = b; vertices[offset++] = alpha; vertices[offset++] = mode;
+    vertices[offset++] = x; vertices[offset++] = y + height; vertices[offset++] = u0; vertices[offset++] = v1; vertices[offset++] = r; vertices[offset++] = g; vertices[offset++] = b; vertices[offset++] = alpha; vertices[offset++] = mode;
+    vertices[offset++] = x + width; vertices[offset++] = y; vertices[offset++] = u1; vertices[offset++] = v0; vertices[offset++] = r; vertices[offset++] = g; vertices[offset++] = b; vertices[offset++] = alpha; vertices[offset++] = mode;
+    vertices[offset++] = x + width; vertices[offset++] = y + height; vertices[offset++] = u1; vertices[offset++] = v1; vertices[offset++] = r; vertices[offset++] = g; vertices[offset++] = b; vertices[offset++] = alpha; vertices[offset++] = mode;
+
+    this.cursor = offset;
+  }
+
+  private ensureCapacity(additional: number): void {
+    const required = this.cursor + additional;
+    if (required <= this.scratch.length) return;
+    let capacity = this.scratch.length;
+    while (capacity < required) capacity *= 2;
+    const grown = new Float32Array(capacity);
+    grown.set(this.scratch.subarray(0, this.cursor));
+    this.scratch = grown;
+  }
+}

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -172,8 +172,15 @@ async function waitForPaneWriteQuiescence(
   }
 }
 
+// Let `frames` frames actually elapse, so a React commit, the layout it
+// triggers, and the paint that follows each get their own frame to happen in.
+// The awaits have to be sequential: nextAnimationFrame() registers its callback
+// when it is constructed, so building them all up front queues them onto the
+// same frame and Promise.all would return after one, whatever `frames` says.
 async function settleUi(frames = 2) {
-  await Promise.all(Array.from({ length: frames }, () => nextAnimationFrame()));
+  for (let index = 0; index < frames; index += 1) {
+    await nextAnimationFrame();
+  }
 }
 
 function resolvePaneId(

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -173,9 +173,7 @@ async function waitForPaneWriteQuiescence(
 }
 
 async function settleUi(frames = 2) {
-  for (let index = 0; index < frames; index += 1) {
-    await nextAnimationFrame();
-  }
+  await Promise.all(Array.from({ length: frames }, () => nextAnimationFrame()));
 }
 
 function resolvePaneId(

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -1685,16 +1685,28 @@ async function capturePerfSnapshot(
   };
 }
 
-function buildBenchmarkBytes(chunkBytes: number): Uint8Array {
+function buildBenchmarkBytes(chunkBytes: number, payload: 'scroll' | 'progress'): Uint8Array {
   const safeChunkBytes = Math.max(64, Math.floor(chunkBytes));
-  const linePayloadWidth = 112;
   let output = '';
   let lineNumber = 0;
   while (output.length < safeChunkBytes) {
-    output += `bench ${String(lineNumber).padStart(6, '0')} ${'x'.repeat(linePayloadWidth)}\r\n`;
+    output += payload === 'progress'
+      ? `\r\x1b[2Kp ${String(lineNumber).padStart(6, '0')} xx`
+      : `bench ${String(lineNumber).padStart(6, '0')} ${'x'.repeat(112)}\r\n`;
     lineNumber += 1;
   }
   return new TextEncoder().encode(output.slice(0, safeChunkBytes));
+}
+
+function buildBenchmarkProgressSeed(cols: number, rows: number): Uint8Array {
+  const width = Math.max(1, cols - 1);
+  let output = '';
+  for (let row = 0; row < rows; row += 1) {
+    const prefix = `${String(row).padStart(3, '0')} `;
+    output += `\x1b[${row + 1};1H${(prefix + '.'.repeat(width)).slice(0, width)}`;
+  }
+  output += '\x1b[1;1H';
+  return new TextEncoder().encode(output);
 }
 
 function encodeBytesToBase64(bytes: Uint8Array): string {
@@ -3193,6 +3205,7 @@ export function useUiAutomationBridge({
           : 'json_base64';
         const chunkBytes = typeof payload.chunkBytes === 'number' ? payload.chunkBytes : 16 * 1024;
         const chunkCount = typeof payload.chunkCount === 'number' ? payload.chunkCount : 128;
+        const benchmarkPayload = payload.payload === 'progress' ? 'progress' : 'scroll';
         const flushEvery = typeof payload.flushEvery === 'number' && payload.flushEvery > 0
           ? Math.floor(payload.flushEvery)
           : 1;
@@ -3202,7 +3215,7 @@ export function useUiAutomationBridge({
         const runtimeId =
           session.workspace.agents.find((entry) => entry.id === paneId)?.runtimeId ||
           `bench:${paneId}`;
-        const bytes = buildBenchmarkBytes(chunkBytes);
+        const bytes = buildBenchmarkBytes(chunkBytes, benchmarkPayload);
         const base64Payload = encodeBytesToBase64(bytes);
 
         selectSession(sessionId);
@@ -3211,12 +3224,54 @@ export function useUiAutomationBridge({
         if (!resetSessionPaneTerminal(sessionId, paneId)) {
           throw new Error(`Pane terminal not ready for ${paneId}`);
         }
+        // A freshly created utility shell can still emit its prompt after the
+        // reset request returns. Let that output arrive before constructing a
+        // deterministic benchmark fixture; otherwise it can move the cursor or
+        // erase rows immediately after the seed.
+        if (benchmarkPayload === 'progress') {
+          await waitForBenchmarkDelay(100);
+          await drainSessionPaneTerminal(sessionId, paneId);
+        }
+        await settleUi(2);
+        const terminalBeforeSeed = getTerminalPerfSnapshot().find(
+          (terminal) => terminal.runtimeId === runtimeId || (
+            terminal.sessionId === sessionId && terminal.paneId === paneId
+          ),
+        );
+        if (benchmarkPayload === 'progress' && !terminalBeforeSeed) {
+          throw new Error(`Pane terminal disappeared before seeding ${paneId}`);
+        }
+        if (benchmarkPayload === 'progress' && terminalBeforeSeed) {
+          const seed = buildBenchmarkProgressSeed(terminalBeforeSeed.cols, terminalBeforeSeed.rows);
+          if (!(await injectSessionPaneBytes(sessionId, paneId, seed))) {
+            throw new Error(`Failed to seed progress fixture in pane ${paneId}`);
+          }
+          if (!(await drainSessionPaneTerminal(sessionId, paneId))) {
+            throw new Error(`Failed to drain progress fixture in pane ${paneId}`);
+          }
+          // Output paints are intentionally paced at 30 Hz. Two display frames
+          // can finish before that timer fires on a 60 Hz panel, which would
+          // let the measured writes overwrite the seed before its dense surface
+          // has ever rendered. Wait past one paint interval, then let React and
+          // the compositor settle before taking the baseline counters.
+          await waitForBenchmarkDelay(50);
+          await settleUi(2);
+        }
         clearPtyPerfSnapshot();
         const rendererBefore = getTerminalPerfSnapshot().find(
           (terminal) => terminal.runtimeId === runtimeId || (
             terminal.sessionId === sessionId && terminal.paneId === paneId
           ),
         );
+        if (
+          benchmarkPayload === 'progress'
+          && rendererBefore
+          && rendererBefore.modelPrintable < rendererBefore.cols * rendererBefore.rows * 0.5
+        ) {
+          throw new Error(
+            `Progress fixture is not dense: ${rendererBefore.modelPrintable} printable cells in ${rendererBefore.cols}x${rendererBefore.rows}`,
+          );
+        }
 
         const startedAt = performance.now();
         let bufferedByteChunks: Uint8Array[] = [];
@@ -3309,6 +3364,7 @@ export function useUiAutomationBridge({
           paneId,
           runtimeId,
           mode,
+          payload: benchmarkPayload,
           flushEvery,
           interChunkDelayMs,
           chunkBytes: bytes.length,
@@ -3324,9 +3380,18 @@ export function useUiAutomationBridge({
                 renderCount: rendererAfter.renderCount - rendererBefore.renderCount,
                 cpuSubmitMs: rendererAfter.renderCpuTotalMs - rendererBefore.renderCpuTotalMs,
                 lastFrameMs: rendererAfter.lastRenderCpuMs,
+                fullPaintCount: rendererAfter.renderFullCount - rendererBefore.renderFullCount,
+                partialPaintCount: rendererAfter.renderPartialCount - rendererBefore.renderPartialCount,
+                rowsPainted: rendererAfter.renderRowsPainted - rendererBefore.renderRowsPainted,
+                submittedQuads: rendererAfter.renderSubmittedQuads - rendererBefore.renderSubmittedQuads,
+                retainedRowVertexBytes: rendererAfter.renderRetainedRowVertexBytes,
+                fixturePrintable: rendererBefore.modelPrintable,
+                finalModelPrintable: rendererAfter.modelPrintable,
+                finalPaintQuads: rendererAfter.lastPaintQuads,
                 scheduledRequests: rendererAfter.scheduledRenderRequests - rendererBefore.scheduledRenderRequests,
                 scheduledCoalesced: rendererAfter.scheduledRenderCoalesced - rendererBefore.scheduledRenderCoalesced,
                 scheduledDeferred: rendererAfter.scheduledRenderDeferred - rendererBefore.scheduledRenderDeferred,
+                writeParsedCount: rendererAfter.writeParsedCount - rendererBefore.writeParsedCount,
               }
             : null,
           pane: {

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -133,6 +133,12 @@ function nextAnimationFrame() {
   });
 }
 
+function waitForBenchmarkDelay(delayMs: number) {
+  return new Promise<void>((resolve) => {
+    window.setTimeout(resolve, delayMs);
+  });
+}
+
 async function settleUi(frames = 2) {
   for (let index = 0; index < frames; index += 1) {
     await nextAnimationFrame();
@@ -3190,6 +3196,9 @@ export function useUiAutomationBridge({
         const flushEvery = typeof payload.flushEvery === 'number' && payload.flushEvery > 0
           ? Math.floor(payload.flushEvery)
           : 1;
+        const interChunkDelayMs = typeof payload.interChunkDelayMs === 'number'
+          ? Math.max(0, payload.interChunkDelayMs)
+          : 0;
         const runtimeId =
           session.workspace.agents.find((entry) => entry.id === paneId)?.runtimeId ||
           `bench:${paneId}`;
@@ -3235,6 +3244,9 @@ export function useUiAutomationBridge({
                 await flushBufferedBytes();
               }
             }
+            if (interChunkDelayMs > 0) {
+              await waitForBenchmarkDelay(interChunkDelayMs);
+            }
             continue;
           }
 
@@ -3249,6 +3261,9 @@ export function useUiAutomationBridge({
               if (bufferedByteChunks.length >= flushEvery) {
                 await flushBufferedBytes();
               }
+            }
+            if (interChunkDelayMs > 0) {
+              await waitForBenchmarkDelay(interChunkDelayMs);
             }
             continue;
           }
@@ -3273,6 +3288,9 @@ export function useUiAutomationBridge({
               await flushBufferedBytes();
             }
           }
+          if (interChunkDelayMs > 0) {
+            await waitForBenchmarkDelay(interChunkDelayMs);
+          }
         }
         await flushBufferedBytes();
         if (!(await drainSessionPaneTerminal(sessionId, paneId))) {
@@ -3292,6 +3310,7 @@ export function useUiAutomationBridge({
           runtimeId,
           mode,
           flushEvery,
+          interChunkDelayMs,
           chunkBytes: bytes.length,
           chunkCount,
           totalPayloadBytes: bytes.length * chunkCount,
@@ -3305,6 +3324,9 @@ export function useUiAutomationBridge({
                 renderCount: rendererAfter.renderCount - rendererBefore.renderCount,
                 cpuSubmitMs: rendererAfter.renderCpuTotalMs - rendererBefore.renderCpuTotalMs,
                 lastFrameMs: rendererAfter.lastRenderCpuMs,
+                scheduledRequests: rendererAfter.scheduledRenderRequests - rendererBefore.scheduledRenderRequests,
+                scheduledCoalesced: rendererAfter.scheduledRenderCoalesced - rendererBefore.scheduledRenderCoalesced,
+                scheduledDeferred: rendererAfter.scheduledRenderDeferred - rendererBefore.scheduledRenderDeferred,
               }
             : null,
           pane: {

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -3203,6 +3203,11 @@ export function useUiAutomationBridge({
           throw new Error(`Pane terminal not ready for ${paneId}`);
         }
         clearPtyPerfSnapshot();
+        const rendererBefore = getTerminalPerfSnapshot().find(
+          (terminal) => terminal.runtimeId === runtimeId || (
+            terminal.sessionId === sessionId && terminal.paneId === paneId
+          ),
+        );
 
         const startedAt = performance.now();
         let bufferedByteChunks: Uint8Array[] = [];
@@ -3276,6 +3281,11 @@ export function useUiAutomationBridge({
 
         await settleUi(2);
         const totalMs = performance.now() - startedAt;
+        const rendererAfter = getTerminalPerfSnapshot().find(
+          (terminal) => terminal.runtimeId === runtimeId || (
+            terminal.sessionId === sessionId && terminal.paneId === paneId
+          ),
+        );
         return {
           sessionId,
           paneId,
@@ -3290,6 +3300,13 @@ export function useUiAutomationBridge({
             ? ((bytes.length * chunkCount) / (1024 * 1024)) / (totalMs / 1000)
             : null,
           pty: getPtyPerfSnapshot(),
+          renderer: rendererBefore && rendererAfter
+            ? {
+                renderCount: rendererAfter.renderCount - rendererBefore.renderCount,
+                cpuSubmitMs: rendererAfter.renderCpuTotalMs - rendererBefore.renderCpuTotalMs,
+                lastFrameMs: rendererAfter.lastRenderCpuMs,
+              }
+            : null,
           pane: {
             size: getPaneSize(sessionId, paneId),
             textLength: getPaneText(sessionId, paneId).length,

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -139,6 +139,39 @@ function waitForBenchmarkDelay(delayMs: number) {
   });
 }
 
+// The seed is written to the model, but output paints are paced at 30 Hz, so
+// the dense surface may not have reached the GPU yet. Wait for a paint that
+// happened after the seed instead of for a fixed interval.
+async function waitForSeededPaint(
+  readPerf: () => { renderCount: number } | undefined,
+  renderCountBeforeSeed: number,
+  maxFrames = 120,
+): Promise<void> {
+  for (let frame = 0; frame < maxFrames; frame += 1) {
+    if ((readPerf()?.renderCount ?? 0) > renderCountBeforeSeed) return;
+    await nextAnimationFrame();
+  }
+}
+
+// A freshly created utility shell keeps emitting its prompt after the reset
+// request returns, and there is no event for "the shell is done talking". Wait
+// on the real signal instead of a fixed sleep: the pane's parsed-write counter
+// going unchanged across consecutive frames means nothing more arrived.
+async function waitForPaneWriteQuiescence(
+  readWriteCount: () => number | null,
+  quietFrames = 3,
+  maxFrames = 120,
+): Promise<void> {
+  let last = readWriteCount();
+  let quiet = 0;
+  for (let frame = 0; frame < maxFrames && quiet < quietFrames; frame += 1) {
+    await nextAnimationFrame();
+    const current = readWriteCount();
+    quiet = current === last ? quiet + 1 : 0;
+    last = current;
+  }
+}
+
 async function settleUi(frames = 2) {
   for (let index = 0; index < frames; index += 1) {
     await nextAnimationFrame();
@@ -3224,45 +3257,40 @@ export function useUiAutomationBridge({
         if (!resetSessionPaneTerminal(sessionId, paneId)) {
           throw new Error(`Pane terminal not ready for ${paneId}`);
         }
-        // A freshly created utility shell can still emit its prompt after the
-        // reset request returns. Let that output arrive before constructing a
-        // deterministic benchmark fixture; otherwise it can move the cursor or
-        // erase rows immediately after the seed.
-        if (benchmarkPayload === 'progress') {
-          await waitForBenchmarkDelay(100);
-          await drainSessionPaneTerminal(sessionId, paneId);
-        }
-        await settleUi(2);
-        const terminalBeforeSeed = getTerminalPerfSnapshot().find(
+        const paneTerminalPerf = () => getTerminalPerfSnapshot().find(
           (terminal) => terminal.runtimeId === runtimeId || (
             terminal.sessionId === sessionId && terminal.paneId === paneId
           ),
         );
-        if (benchmarkPayload === 'progress' && !terminalBeforeSeed) {
-          throw new Error(`Pane terminal disappeared before seeding ${paneId}`);
-        }
-        if (benchmarkPayload === 'progress' && terminalBeforeSeed) {
-          const seed = buildBenchmarkProgressSeed(terminalBeforeSeed.cols, terminalBeforeSeed.rows);
+
+        if (benchmarkPayload === 'progress') {
+          // The shell's own prompt can move the cursor or erase rows right
+          // after the seed, so let it finish before building the fixture.
+          await waitForPaneWriteQuiescence(() => paneTerminalPerf()?.writeParsedCount ?? null);
+          await drainSessionPaneTerminal(sessionId, paneId);
+          await settleUi(2);
+
+          const beforeSeed = paneTerminalPerf();
+          if (!beforeSeed) {
+            throw new Error(`Pane terminal disappeared before seeding ${paneId}`);
+          }
+          const seed = buildBenchmarkProgressSeed(beforeSeed.cols, beforeSeed.rows);
           if (!(await injectSessionPaneBytes(sessionId, paneId, seed))) {
             throw new Error(`Failed to seed progress fixture in pane ${paneId}`);
           }
           if (!(await drainSessionPaneTerminal(sessionId, paneId))) {
             throw new Error(`Failed to drain progress fixture in pane ${paneId}`);
           }
-          // Output paints are intentionally paced at 30 Hz. Two display frames
-          // can finish before that timer fires on a 60 Hz panel, which would
-          // let the measured writes overwrite the seed before its dense surface
-          // has ever rendered. Wait past one paint interval, then let React and
-          // the compositor settle before taking the baseline counters.
-          await waitForBenchmarkDelay(50);
+          // Output paints are paced at 30 Hz, so the seed is written but not
+          // necessarily painted yet. Wait for a paint that actually covers it
+          // rather than for a fixed interval, or the measured writes overwrite
+          // a fixture whose dense surface never rendered.
+          await waitForSeededPaint(paneTerminalPerf, beforeSeed.renderCount);
           await settleUi(2);
         }
+        await settleUi(2);
         clearPtyPerfSnapshot();
-        const rendererBefore = getTerminalPerfSnapshot().find(
-          (terminal) => terminal.runtimeId === runtimeId || (
-            terminal.sessionId === sessionId && terminal.paneId === paneId
-          ),
-        );
+        const rendererBefore = paneTerminalPerf();
         if (
           benchmarkPayload === 'progress'
           && rendererBefore
@@ -3354,11 +3382,7 @@ export function useUiAutomationBridge({
 
         await settleUi(2);
         const totalMs = performance.now() - startedAt;
-        const rendererAfter = getTerminalPerfSnapshot().find(
-          (terminal) => terminal.runtimeId === runtimeId || (
-            terminal.sessionId === sessionId && terminal.paneId === paneId
-          ),
-        );
+        const rendererAfter = paneTerminalPerf();
         return {
           sessionId,
           paneId,
@@ -3385,6 +3409,7 @@ export function useUiAutomationBridge({
                 rowsPainted: rendererAfter.renderRowsPainted - rendererBefore.renderRowsPainted,
                 submittedQuads: rendererAfter.renderSubmittedQuads - rendererBefore.renderSubmittedQuads,
                 retainedRowVertexBytes: rendererAfter.renderRetainedRowVertexBytes,
+                retainedStagingBytes: rendererAfter.renderRetainedStagingBytes,
                 fixturePrintable: rendererBefore.modelPrintable,
                 finalModelPrintable: rendererAfter.modelPrintable,
                 finalPaintQuads: rendererAfter.lastPaintQuads,

--- a/app/src/utils/terminalOutputPacing.test.ts
+++ b/app/src/utils/terminalOutputPacing.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import {
+  TERMINAL_OUTPUT_FRAME_MS,
+  TERMINAL_OUTPUT_IDLE_RESET_MS,
+  terminalOutputDelayMs,
+} from './terminalOutputPacing';
+
+describe('terminalOutputDelayMs', () => {
+  it('paints the first output after idle without an added timer delay', () => {
+    expect(terminalOutputDelayMs(100, null)).toBe(0);
+    expect(terminalOutputDelayMs(100, 100 - TERMINAL_OUTPUT_IDLE_RESET_MS)).toBe(0);
+  });
+
+  it('paces continuous output to the configured frame interval', () => {
+    expect(terminalOutputDelayMs(110, 100)).toBeCloseTo(TERMINAL_OUTPUT_FRAME_MS - 10);
+    expect(terminalOutputDelayMs(100 + TERMINAL_OUTPUT_FRAME_MS, 100)).toBe(0);
+  });
+
+  it('never returns a negative delay', () => {
+    expect(terminalOutputDelayMs(200, 100)).toBe(0);
+  });
+});

--- a/app/src/utils/terminalOutputPacing.ts
+++ b/app/src/utils/terminalOutputPacing.ts
@@ -1,0 +1,14 @@
+export const TERMINAL_OUTPUT_MAX_FPS = 30;
+export const TERMINAL_OUTPUT_FRAME_MS = 1000 / TERMINAL_OUTPUT_MAX_FPS;
+
+// A new burst should feel immediate. Once output has been quiet for longer than
+// two capped frame intervals, forget the old cadence and paint on the next
+// browser frame instead of waiting behind a stale timestamp.
+export const TERMINAL_OUTPUT_IDLE_RESET_MS = TERMINAL_OUTPUT_FRAME_MS * 2;
+
+export function terminalOutputDelayMs(now: number, lastPaintAt: number | null): number {
+  if (lastPaintAt === null) return 0;
+  const elapsed = now - lastPaintAt;
+  if (elapsed >= TERMINAL_OUTPUT_IDLE_RESET_MS) return 0;
+  return Math.max(0, TERMINAL_OUTPUT_FRAME_MS - elapsed);
+}

--- a/app/src/utils/terminalPerf.ts
+++ b/app/src/utils/terminalPerf.ts
@@ -52,6 +52,9 @@ export interface TerminalPerfSnapshot {
   renderCpuTotalMs: number;
   renderCpuMaxMs: number;
   lastRenderCpuMs: number;
+  scheduledRenderRequests: number;
+  scheduledRenderCoalesced: number;
+  scheduledRenderDeferred: number;
   writeParsedCount: number;
   lastRenderAt: number;
   lastWriteParsedAt: number;

--- a/app/src/utils/terminalPerf.ts
+++ b/app/src/utils/terminalPerf.ts
@@ -52,6 +52,13 @@ export interface TerminalPerfSnapshot {
   renderCpuTotalMs: number;
   renderCpuMaxMs: number;
   lastRenderCpuMs: number;
+  renderFullCount: number;
+  renderPartialCount: number;
+  renderRowsPainted: number;
+  renderSubmittedQuads: number;
+  renderRetainedRowVertexBytes: number;
+  modelPrintable: number;
+  lastPaintQuads: number;
   scheduledRenderRequests: number;
   scheduledRenderCoalesced: number;
   scheduledRenderDeferred: number;

--- a/app/src/utils/terminalPerf.ts
+++ b/app/src/utils/terminalPerf.ts
@@ -49,6 +49,9 @@ export interface TerminalPerfSnapshot {
   writeQueueChunks: number;
   writeQueueBytes: number;
   renderCount: number;
+  renderCpuTotalMs: number;
+  renderCpuMaxMs: number;
+  lastRenderCpuMs: number;
   writeParsedCount: number;
   lastRenderAt: number;
   lastWriteParsedAt: number;

--- a/app/src/utils/terminalPerf.ts
+++ b/app/src/utils/terminalPerf.ts
@@ -57,6 +57,7 @@ export interface TerminalPerfSnapshot {
   renderRowsPainted: number;
   renderSubmittedQuads: number;
   renderRetainedRowVertexBytes: number;
+  renderRetainedStagingBytes: number;
   modelPrintable: number;
   lastPaintQuads: number;
   scheduledRenderRequests: number;

--- a/changelog.d/bashful-marmot-terminal-rendering-performance.yaml
+++ b/changelog.d/bashful-marmot-terminal-rendering-performance.yaml
@@ -1,0 +1,9 @@
+kind: changed
+area: terminal
+change: >
+  Streaming terminal output now reuses GPU-ready vertex buffers between paints,
+  reducing the allocation and copying work required to draw each frame.
+notes: >
+  The main terminal renderer and mission-control grid renderer now share the
+  same reusable typed vertex buffer. Terminal performance snapshots also expose
+  renderer CPU time so packaged-app benchmarks can measure paint cost directly.

--- a/changelog.d/bashful-marmot-terminal-rendering-performance.yaml
+++ b/changelog.d/bashful-marmot-terminal-rendering-performance.yaml
@@ -12,8 +12,10 @@ notes: >
   first output after idle, direct input, and the final state are still rendered
   promptly. Large active grids cache bounded CPU-side row vertices while still
   clearing and submitting a complete frame, so WebGL framebuffer retention is
-  not required. A partial paint also repaints the cursor's row and the row it
-  moved from, which the model's dirty set does not cover. Small grids,
+  not required. The cursor is drawn as an inverted cell, so a moved cursor now
+  paints on its own: a same-row move or a visibility toggle reports no dirty
+  rows at all, and a partial paint repaints both the row it left and the row it
+  arrived on rather than the whole grid. Small grids,
   scrolling, overlays, and images keep the direct full-render path. Terminal
   performance snapshots expose renderer CPU, scheduling counters, and both
   retained-memory figures for packaged-app measurements.

--- a/changelog.d/bashful-marmot-terminal-rendering-performance.yaml
+++ b/changelog.d/bashful-marmot-terminal-rendering-performance.yaml
@@ -2,11 +2,15 @@ kind: changed
 area: terminal
 change: >
   Streaming terminal output now reuses GPU-ready vertex buffers between paints,
-  avoids repeated per-cell color and glyph-key allocations, and limits sustained
-  output to 30 paints per second while preserving immediate interaction paints.
+  avoids repeated per-cell color and glyph-key allocations, rebuilds only dirty
+  rows in large in-place redraws, and limits sustained output to 30 paints per
+  second while preserving immediate interaction paints.
 notes: >
   The main terminal renderer and mission-control grid renderer now share the
   same reusable typed vertex buffer. Continuous output keeps only the newest
   model state for the next paint; the first output after idle, direct input, and
-  the final state are still rendered promptly. Terminal performance snapshots
+  the final state are still rendered promptly. Large active grids cache bounded
+  CPU-side row vertices while still clearing and submitting a complete frame, so
+  WebGL framebuffer retention is not required. Small grids, scrolling, overlays,
+  and images keep the direct full-render path. Terminal performance snapshots
   expose renderer CPU and scheduling counters for packaged-app measurements.

--- a/changelog.d/bashful-marmot-terminal-rendering-performance.yaml
+++ b/changelog.d/bashful-marmot-terminal-rendering-performance.yaml
@@ -7,10 +7,13 @@ change: >
   second while preserving immediate interaction paints.
 notes: >
   The main terminal renderer and mission-control grid renderer now share the
-  same reusable typed vertex buffer. Continuous output keeps only the newest
-  model state for the next paint; the first output after idle, direct input, and
-  the final state are still rendered promptly. Large active grids cache bounded
-  CPU-side row vertices while still clearing and submitting a complete frame, so
-  WebGL framebuffer retention is not required. Small grids, scrolling, overlays,
-  and images keep the direct full-render path. Terminal performance snapshots
-  expose renderer CPU and scheduling counters for packaged-app measurements.
+  same reusable typed vertex buffer and a single packed color representation.
+  Continuous output keeps only the newest model state for the next paint; the
+  first output after idle, direct input, and the final state are still rendered
+  promptly. Large active grids cache bounded CPU-side row vertices while still
+  clearing and submitting a complete frame, so WebGL framebuffer retention is
+  not required. A partial paint also repaints the cursor's row and the row it
+  moved from, which the model's dirty set does not cover. Small grids,
+  scrolling, overlays, and images keep the direct full-render path. Terminal
+  performance snapshots expose renderer CPU, scheduling counters, and both
+  retained-memory figures for packaged-app measurements.

--- a/changelog.d/bashful-marmot-terminal-rendering-performance.yaml
+++ b/changelog.d/bashful-marmot-terminal-rendering-performance.yaml
@@ -2,8 +2,11 @@ kind: changed
 area: terminal
 change: >
   Streaming terminal output now reuses GPU-ready vertex buffers between paints,
-  reducing the allocation and copying work required to draw each frame.
+  avoids repeated per-cell color and glyph-key allocations, and limits sustained
+  output to 30 paints per second while preserving immediate interaction paints.
 notes: >
   The main terminal renderer and mission-control grid renderer now share the
-  same reusable typed vertex buffer. Terminal performance snapshots also expose
-  renderer CPU time so packaged-app benchmarks can measure paint cost directly.
+  same reusable typed vertex buffer. Continuous output keeps only the newest
+  model state for the next paint; the first output after idle, direct input, and
+  the final state are still rendered promptly. Terminal performance snapshots
+  expose renderer CPU and scheduling counters for packaged-app measurements.

--- a/docs/plans/2026-08-04-terminal-render-perf.md
+++ b/docs/plans/2026-08-04-terminal-render-perf.md
@@ -1,20 +1,27 @@
-# Terminal rendering performance log
+# Terminal rendering performance
 
-This log records terminal rendering experiments on `perf/terminal-stream-rendering`.
-It keeps rejected approaches beside accepted ones so later work does not repeat
-measurements or trade away responsiveness for an attractive microbenchmark.
+Streaming terminal output rebuilt and submitted the full visible grid at display
+refresh rate even when a TUI changed only a progress row. Terminal panes stay
+open all day, so that repeated work is a standing CPU, GPU, and battery cost.
+
+This is the design record for reducing it: what was measured, what was kept, and
+what was tried and rejected. The rejected entries are here so later work does not
+repeat the measurements or trade responsiveness for an attractive microbenchmark.
 
 ## Guardrails
 
+Any future change to this path is held to the same rules:
+
 - Preserve every terminal byte and always paint the newest model state.
-- Keep direct interaction paints immediate. Any frame-rate policy applies only
+- Keep direct interaction paints immediate. A frame-rate policy applies only
   while PTY output is arriving continuously.
 - Do not add a continuous repaint loop.
-- Keep renderer-owned CPU staging bounded. The main vertex buffer starts at
-  128 KiB and a dense 151 x 46 pane grows it to 2 MiB; optimizations should not
-  add another full-frame retained copy without stronger evidence.
+- Keep renderer-owned CPU staging bounded and reported. Every renderer sample
+  carries both `retainedRowVertexBytes` (what the row cache adds) and
+  `retainedStagingBytes` (that plus the frame buffer it concatenates into). A
+  receipt that names only one of them understates the pane by roughly half.
 - Run packaged-app measurements only in an isolated named profile and clean it
-  immediately afterwards. Production `~/.attn` remains read-only.
+  up afterwards. Production `~/.attn` stays read-only.
 
 ## Measurement methods
 
@@ -39,10 +46,13 @@ staging cost from PTY parsing, WebKit scheduling, and GPU submission.
 ### Dense in-place redraw
 
 `bridge-pty-bench.mjs --payload progress` first fills every terminal row, then
-streams 4 KiB carriage-return/erase-line updates for eight seconds. The harness
-waits past one 30 Hz paint interval after seeding and records the fixture's
-printable-cell count, so a blank or not-yet-painted fixture cannot masquerade as
-a renderer win. Optional window dimensions locate size-dependent crossovers.
+streams 4 KiB carriage-return/erase-line updates for eight seconds. Because
+output paints are paced, the harness waits for a paint that actually covers the
+seed (a renderer paint count past the pre-seed value) rather than for a fixed
+interval, and records the fixture's printable-cell count. A blank or
+not-yet-painted fixture therefore cannot masquerade as a renderer win: the run
+fails outright below 50% density. Optional window dimensions locate
+size-dependent crossovers.
 
 ## Experiments
 
@@ -186,16 +196,16 @@ removed.
 
 Attempt: use Ghostty's partial dirty state, expand changed rows by one neighbor
 for cross-row glyph pixels, scissor-clear those rows, and submit only their
-vertices. A real-WASM probe confirmed that progress and cursor movement are
-partial while scrolling, erase-display, and alternate-screen transitions are
-full.
+vertices. A real-WASM probe (`scripts/bench-terminal-dirty-rows.mjs`) confirmed
+that progress redraws are partial while scrolling, erase-display, and
+alternate-screen transitions are full. That probe survived the rejection and is
+the source of the cursor contract recorded in experiment 7.
 
-The first benchmark fixture was mostly blank, so its low quad count was not
-accepted as evidence. After adding a dense fixture, the design still failed the
-quality guardrail: WebGL contexts default to `preserveDrawingBuffer: false`, so
-untouched pixels are not guaranteed to survive compositing. Enabling retention
-would add a device-pixel framebuffer—potentially tens of MiB for a large Retina
-pane—rather than the bounded CPU staging memory already allowed here.
+Measured against a dense fixture, the design failed the quality guardrail rather
+than the performance one: WebGL contexts default to `preserveDrawingBuffer:
+false`, so untouched pixels are not guaranteed to survive compositing. Enabling
+retention would add a device-pixel framebuffer — potentially tens of MiB for a
+large Retina pane — rather than the bounded CPU staging memory allowed here.
 
 Decision: reject. The scissored framebuffer path was removed. The real-WASM
 dirty-state probe remains as a repeatable contract check.
@@ -227,26 +237,72 @@ also fell from 53.0% to 26.9%, but process sampling and write-stage timings were
 too noisy across runs to attribute that whole delta to the renderer. The exact
 row counts and renderer-local timings are the acceptance evidence.
 
-Four final valid large-pane repetitions reported 16, 27, 43, and 66 ms of
-renderer-local CPU (median 35 ms). All four retained 0.680 MiB, began with
-3,212 printable cells, and rebuilt two rows per partial paint. The timing range
-is wider than the structural work counters, so the median is recorded without
-turning it into a stronger CPU claim. An earlier apparent 9 ms result began
-with only 77 printable cells after late shell output disturbed the fixture; it
-was rejected, and the harness now refuses a progress fixture below 50% density.
+Four large-pane repetitions reported 16, 27, 43, and 66 ms of renderer-local CPU
+(median 35 ms). All four retained 0.680 MiB, began with 3,212 printable cells,
+and rebuilt two rows per partial paint. The timing range is wider than the
+structural work counters, so the median is recorded without being turned into a
+stronger CPU claim.
 
-Decision: keep behind a conservative 2,048-cell threshold and a 2 MiB retained
-cache ceiling. The measured default pane and a 62 x 25 packaged interaction pane
-stay on the direct path with no
-cache allocation; the latter had inconsistent native Command-click results in
-two validation runs at the earlier 1,536 cutoff, so the performance crossover
-alone was not enough to keep that aggressive gate. Retained memory is
-proportional to the visible grid and rendered quads: 0.680 MiB at the accepted
-large measurement point, and roughly 1.5 MiB for the earlier dense 151 x 46
-reference pane. If real styling grows the rows beyond 2 MiB, the renderer
-releases them and keeps that grid on its existing direct path until resize. The
-full-frame submission keeps the visual result and 30 Hz
-sustained-output policy unchanged.
+A faster-looking 9 ms result was discarded on inspection: its fixture held only
+77 printable cells, because late shell output had overwritten the seed. That is
+why the harness now waits for a paint covering the seed and fails any progress
+run below 50% density — a benchmark that measures an empty screen reports a
+large win for doing nothing.
+
+The wide timing range earlier in this section is why the structural counters
+(rows rebuilt, quads submitted, bytes retained) are the acceptance evidence and
+the CPU numbers are recorded rather than claimed.
+
+Decision: keep behind a 2,048-cell threshold and a 2 MiB row-cache ceiling. The
+measured default pane and a 62 x 25 packaged interaction pane stay on the direct
+path with no cache allocation; the latter had inconsistent native Command-click
+results in two validation runs at an earlier 1,536 cutoff, so the performance
+crossover alone was not enough to justify the more aggressive gate.
+
+Two limits, deliberately: the 2,048-cell floor is a performance gate (below it,
+copying the rows costs more than rebuilding them) and the 2 MiB ceiling is a
+memory gate. There is no size *cap* — an earlier draft also refused to cache any
+grid whose cell count times one quad exceeded the ceiling, which excluded the
+largest panes (above ~9,700 cells) on an estimate that assumed exactly one quad
+per cell and so was wrong in both directions. The ceiling is enforced against
+what a built frame actually retained.
+
+The ceiling governs the cache's marginal cost — the retained rows — not the
+frame buffer they concatenate into. A frame has to be staged somewhere whether
+or not the cache exists: a dense styled 100 x 30 grid emitting four quads per
+cell grows that buffer to 4 MiB on the direct path alone. Folding it into the
+gate would trip the cache on memory the direct path spends anyway, so both
+numbers are reported on every sample and only the rows are gated.
+
+Retained rows are proportional to the visible grid and rendered quads: 0.680 MiB
+at the accepted large measurement point, roughly 1.5 MiB for the dense 151 x 46
+reference pane. If real styling pushes them past 2 MiB the renderer releases
+them at that transition and keeps the grid on the direct path until it resizes.
+Full-frame submission keeps the visual result and the 30 Hz sustained-output
+policy unchanged.
+
+**The model's dirty set covers the cursor only across rows.** Measured with
+`scripts/bench-terminal-dirty-rows.mjs` against the vendored WASM:
+
+| cursor change | reported dirty state | reported rows |
+| --- | --- | --- |
+| `\x1b[2;4H` (row 0 → row 1) | PARTIAL | both rows |
+| `\x1b[2;9H` (within one row) | NONE | — |
+| `\x1b[D` (back one column) | NONE | — |
+| `\x1b[?25l` / `\x1b[?25h` | NONE | — |
+
+A same-row move or a visibility toggle on its own never reaches the row
+selection, because `render()` returns early on a NONE dirty state — that is
+pre-existing behavior and the cursor simply stays put until the next paint. The
+row cache is what makes them matter: when one rides along with an *unrelated*
+dirty row the frame is PARTIAL, the cursor's own row is absent from the set, and
+the cursor is baked into that cached row as an inverted cell, so the row would
+keep the cursor at its old column until a full paint.
+
+So a partial paint marks the cursor's row and the row it was last drawn on, on
+top of `isRowDirty()` — at most six rows, and it removes the class. ghostty-web's
+own canvas renderer compensates the same way, and future partial-paint work has
+to keep doing so.
 
 ## Verification
 
@@ -261,8 +317,5 @@ sustained-output policy unchanged.
   finished with 192 passed and the expected real-PTY-only case skipped.
 - All benchmark streams verified the expected chunk count and byte count; no
   terminal output was dropped.
-- The isolated `terminal-perf` app, daemon, and data were removed after the
-  packaged measurements. No install, benchmark, daemon lifecycle action, or
-  mutation targeted production; one initial read-only preflight resolved the
-  production socket before all subsequent work was explicitly routed to the
-  isolated profile.
+- Cursor movement with no dirty rows repaints both the vacated and the arrived
+  row; a hidden cursor moving adds no work.

--- a/docs/plans/2026-08-04-terminal-render-perf.md
+++ b/docs/plans/2026-08-04-terminal-render-perf.md
@@ -291,18 +291,29 @@ policy unchanged.
 | `\x1b[D` (back one column) | NONE | — |
 | `\x1b[?25l` / `\x1b[?25h` | NONE | — |
 
-A same-row move or a visibility toggle on its own never reaches the row
-selection, because `render()` returns early on a NONE dirty state — that is
-pre-existing behavior and the cursor simply stays put until the next paint. The
-row cache is what makes them matter: when one rides along with an *unrelated*
-dirty row the frame is PARTIAL, the cursor's own row is absent from the set, and
-the cursor is baked into that cached row as an inverted cell, so the row would
-keep the cursor at its old column until a full paint.
+The cursor is drawn as an inverted cell, so where it sits is part of the frame
+even when no cell content changed. The table says the model will not tell us
+that on its own, in two different ways:
 
-So a partial paint marks the cursor's row and the row it was last drawn on, on
-top of `isRowDirty()` — at most six rows, and it removes the class. ghostty-web's
-own canvas renderer compensates the same way, and future partial-paint work has
-to keep doing so.
+*Nothing else wakes the renderer.* A same-row move or a visibility toggle
+reports NONE, and `render()` returns early on NONE — so the old inverted cell
+survives until unrelated output happens to arrive. Comparing the cursor against
+the last frame *before* that early return is the only thing standing between a
+user pressing `←` and a cursor that visibly does not move.
+
+*Nothing marks the row.* When such a move rides along with an unrelated dirty
+row the frame is PARTIAL, the cursor's own row is absent from the set, and the
+cursor is baked into that cached row, so the row keeps the cursor at its old
+column until a full paint.
+
+So the renderer compares the cursor position ahead of the early return, and a
+partial paint marks the cursor's row and the row it was last drawn on on top of
+`isRowDirty()`. A frame that exists *only* because the cursor moved has no dirty
+cells but is still a partial paint — otherwise it would fall through to
+`dirty !== DIRTY_PARTIAL` and full-paint the grid on every arrow key, which is
+the cost this whole document exists to remove. At most six rows either way.
+ghostty-web's own canvas renderer compensates the same way, and future
+partial-paint work has to keep doing so.
 
 ## Verification
 
@@ -319,3 +330,12 @@ to keep doing so.
   terminal output was dropped.
 - Cursor movement with no dirty rows repaints both the vacated and the arrived
   row; a hidden cursor moving adds no work.
+- A bare same-row move and a bare visibility toggle — both NONE dirty states —
+  each produce a three-row partial paint rather than no paint or a full one.
+  A frame where nothing at all changed still returns null.
+- Live on the packaged build (profile `cursorpaint`, 155x46 = 7,130-cell pane):
+  every paint partial, 1.54 MB retained row vertices under the 2 MiB ceiling,
+  and the `bridge-pty-bench` progress payload rebuilt 2 rows per frame with
+  `retainedRowVertexMb` 0.726 / `retainedStagingMb` 1.726. The renderer's
+  `modelPrintable` and `paintQuads` witnesses agreed (3,367 / 3,368, the extra
+  quad being the cursor).

--- a/docs/plans/2026-08-04-terminal-render-perf.md
+++ b/docs/plans/2026-08-04-terminal-render-perf.md
@@ -306,6 +306,14 @@ row the frame is PARTIAL, the cursor's own row is absent from the set, and the
 cursor is baked into that cached row, so the row keeps the cursor at its old
 column until a full paint.
 
+Only the *drawn* cursor counts. A hidden cursor paints nothing, so its column
+cannot go stale, and treating a hidden-to-hidden column move as a render reason
+is worse than missing it: the frame has no row to mark, so the zero-row guard
+escalates it to a whole-grid paint — on exactly the path that must stay cheap,
+since a TUI redrawing hides the cursor and moves it constantly. The comparison
+therefore looks at the row always and the column only while the cursor is
+visible.
+
 So the renderer compares the cursor position ahead of the early return, and a
 partial paint marks the cursor's row and the row it was last drawn on on top of
 `isRowDirty()`. A frame that exists *only* because the cursor moved has no dirty
@@ -333,6 +341,8 @@ partial-paint work has to keep doing so.
 - A bare same-row move and a bare visibility toggle — both NONE dirty states —
   each produce a three-row partial paint rather than no paint or a full one.
   A frame where nothing at all changed still returns null.
+- A hidden cursor moving by column or by row under a NONE dirty state produces
+  no paint at all, so a hidden-cursor redraw never escalates to a full grid.
 - Live on the packaged build (profile `cursorpaint`, 155x46 = 7,130-cell pane):
   every paint partial, 1.54 MB retained row vertices under the 2 MiB ceiling,
   and the `bridge-pty-bench` progress payload rebuilt 2 rows per frame with


### PR DESCRIPTION
## Intent / Why

Streaming terminal output can rebuild and submit the full visible grid at the
display refresh rate even when a TUI changes only a progress row. Because
terminal panes stay open all day, that repeated work becomes a meaningful CPU,
GPU, and battery cost.

Following #751, reduce sustained rendering work without dropping PTY bytes,
changing pixels, delaying direct interaction, or allowing renderer memory to
grow without a hard bound.

## Summary

- reuse grow-on-demand typed vertex staging across the terminal and grid
  renderers, and avoid common per-cell color and glyph-key allocations
- pace only sustained PTY-output paints at 30 Hz; the first output after idle,
  direct interaction, and the newest final state still paint promptly, without
  a continuous repaint loop
- cache CPU-side row vertices for active grids above 2,048 cells so partial
  updates rebuild only the dirty row and its neighbors, while still clearing
  and submitting a complete WebGL frame
- cap retained row data at 2 MiB; styled grids that exceed the limit release the
  cache and return to the direct full-render path
- add repeatable packaged-app and focused benchmarks, renderer work counters,
  regression coverage, and `PERF.md` with both accepted and rejected experiments

## Measurements

- reusable vertex staging reduced a focused 3,200-quad assembly benchmark from
  205.85–211.63 ms to 28.33–29.36 ms across 250 frames
- sustained-output paints fell from 473 to 231 in a paired eight-second run;
  GPU-process CPU moved from 4.38% to 4.02%, while total sampled CPU remained
  effectively flat for that workload
- on a dense 3,212-cell pane, dirty-row caching reduced rebuilt rows from 10,252
  to 458 and renderer-local staging from 66 ms to 46 ms, retaining 0.680 MiB
- small panes were slower with row caching, so they remain on the direct path;
  timing variance and rejected approaches are recorded in `PERF.md`

## Verification

- frontend suite: 2,468 passed, 15 skipped
- production frontend build
- Playwright suite: 192 passed, 1 expected real-PTY-only case skipped
- isolated packaged-app preflight
- native terminal Markdown-link scenario: plain selection, two Command-click
  opens, and repeated-link tile reuse
- packaged dense-progress benchmark: 4,096,000 bytes processed, 233 partial
  paints, 466 rows rebuilt, 0 full rebuilds, and 0.680 MiB retained
- 3,000-cell styled fixture verifies the 2 MiB cache guard releases retained
  rows and falls back to a direct full-frame paint
