### PR TITLE
feat(docstore): give every document a revision, and writes an expectation

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -197,7 +197,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '207';
+export const PROTOCOL_VERSION = '208';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1413,10 +1413,11 @@ export interface DocDefineResult {
 }
 
 export interface DocDeleteMessage {
-    cmd:        DocDeleteMessageCmd;
-    collection: string;
-    id:         string;
-    namespace:  string;
+    cmd:           DocDeleteMessageCmd;
+    collection:    string;
+    expected_rev?: number;
+    id:            string;
+    namespace:     string;
     [property: string]: any;
 }
 
@@ -1454,16 +1455,18 @@ export interface Document {
     body:       string;
     created_at: string;
     id:         string;
+    rev:        number;
     updated_at: string;
     [property: string]: any;
 }
 
 export interface DocPutMessage {
-    body:       string;
-    cmd:        DocPutMessageCmd;
-    collection: string;
-    id:         string;
-    namespace:  string;
+    body:          string;
+    cmd:           DocPutMessageCmd;
+    collection:    string;
+    expected_rev?: number;
+    id:            string;
+    namespace:     string;
     [property: string]: any;
 }
 
@@ -1475,6 +1478,7 @@ export interface DocPutResult {
     collection: string;
     id:         string;
     namespace:  string;
+    rev:        number;
     [property: string]: any;
 }
 
@@ -1527,8 +1531,8 @@ export enum DocSubscribeMessageCmd {
 }
 
 export interface DocSubscribeResult {
+    delivery:  number;
     documents: Document[];
-    revision:  number;
     [property: string]: any;
 }
 
@@ -4272,6 +4276,7 @@ export interface DocPutResultObject {
     collection: string;
     id:         string;
     namespace:  string;
+    rev:        number;
     [property: string]: any;
 }
 
@@ -4281,8 +4286,8 @@ export interface DocQueryResultObject {
 }
 
 export interface DocSubscribeResultObject {
+    delivery:  number;
     documents: Document[];
-    revision:  number;
     [property: string]: any;
 }
 
@@ -5098,6 +5103,7 @@ export interface StoredDocument {
     body:       string;
     created_at: string;
     id:         string;
+    rev:        number;
     updated_at: string;
     [property: string]: any;
 }
@@ -10550,6 +10556,7 @@ const typeMap: any = {
     "DocDeleteMessage": o([
         { json: "cmd", js: "cmd", typ: r("DocDeleteMessageCmd") },
         { json: "collection", js: "collection", typ: "" },
+        { json: "expected_rev", js: "expected_rev", typ: u(undefined, 0) },
         { json: "id", js: "id", typ: "" },
         { json: "namespace", js: "namespace", typ: "" },
     ], "any"),
@@ -10573,12 +10580,14 @@ const typeMap: any = {
         { json: "body", js: "body", typ: "" },
         { json: "created_at", js: "created_at", typ: "" },
         { json: "id", js: "id", typ: "" },
+        { json: "rev", js: "rev", typ: 0 },
         { json: "updated_at", js: "updated_at", typ: "" },
     ], "any"),
     "DocPutMessage": o([
         { json: "body", js: "body", typ: "" },
         { json: "cmd", js: "cmd", typ: r("DocPutMessageCmd") },
         { json: "collection", js: "collection", typ: "" },
+        { json: "expected_rev", js: "expected_rev", typ: u(undefined, 0) },
         { json: "id", js: "id", typ: "" },
         { json: "namespace", js: "namespace", typ: "" },
     ], "any"),
@@ -10586,6 +10595,7 @@ const typeMap: any = {
         { json: "collection", js: "collection", typ: "" },
         { json: "id", js: "id", typ: "" },
         { json: "namespace", js: "namespace", typ: "" },
+        { json: "rev", js: "rev", typ: 0 },
     ], "any"),
     "DocQueryMessage": o([
         { json: "cmd", js: "cmd", typ: r("DocQueryMessageCmd") },
@@ -10616,8 +10626,8 @@ const typeMap: any = {
         { json: "query", js: "query", typ: r("Query") },
     ], "any"),
     "DocSubscribeResult": o([
+        { json: "delivery", js: "delivery", typ: 0 },
         { json: "documents", js: "documents", typ: a(r("Document")) },
-        { json: "revision", js: "revision", typ: 0 },
     ], "any"),
     "DocumentCollectionSchema": o([
         { json: "collection", js: "collection", typ: "" },
@@ -12254,13 +12264,14 @@ const typeMap: any = {
         { json: "collection", js: "collection", typ: "" },
         { json: "id", js: "id", typ: "" },
         { json: "namespace", js: "namespace", typ: "" },
+        { json: "rev", js: "rev", typ: 0 },
     ], "any"),
     "DocQueryResultObject": o([
         { json: "documents", js: "documents", typ: a(r("Document")) },
     ], "any"),
     "DocSubscribeResultObject": o([
+        { json: "delivery", js: "delivery", typ: 0 },
         { json: "documents", js: "documents", typ: a(r("Document")) },
-        { json: "revision", js: "revision", typ: 0 },
     ], "any"),
     "DocUndefineResultObject": o([
         { json: "collection", js: "collection", typ: "" },
@@ -12762,6 +12773,7 @@ const typeMap: any = {
         { json: "body", js: "body", typ: "" },
         { json: "created_at", js: "created_at", typ: "" },
         { json: "id", js: "id", typ: "" },
+        { json: "rev", js: "rev", typ: 0 },
         { json: "updated_at", js: "updated_at", typ: "" },
     ], "any"),
     "SubscribeGitStatusMessage": o([

--- a/changelog.d/ext-a3.2-document-revisions.yaml
+++ b/changelog.d/ext-a3.2-document-revisions.yaml
@@ -1,0 +1,18 @@
+kind: added
+area: daemon
+change: >
+  Every document in the document store now carries a revision, reported by every
+  read and returned by every write. Handing that revision back as `--expect`
+  makes a write conditional: `attn doc put ... --expect 4` lands only if the
+  document is still at revision 4, and is otherwise refused with both revisions
+  named rather than overwriting an edit somebody else made in between.
+  `--expect absent` writes only if the document does not exist yet, and
+  `attn doc delete ... --expect 4` removes it only at that revision. Writes with
+  no expectation still always land, which is what setting a value rather than
+  editing one wants.
+notes: >
+  This closes the one place the store could lose data silently: two writers that
+  each read a document, changed it and wrote it back would leave only the second
+  change, with no error on either side. A refused write also no longer wakes the
+  collection's live queries, since nothing changed. Documents stored before this
+  start at revision 1, so a conditional write works against them immediately.

--- a/cmd/attn/doc.go
+++ b/cmd/attn/doc.go
@@ -83,11 +83,20 @@ commands:
   collections [--json]
         list every declared collection, and the indexed field each one offers.
 
-  put <namespace> <collection> <id> <body|->
+  put <namespace> <collection> <id> <body|-> [--expect <rev|absent>]
         write a document. The body is a JSON object, or - to read stdin.
+        Prints the revision the document now has.
+
+        --expect makes the write conditional. Every read reports a document's
+        revision, so pass the one you read to change a document only if nobody
+        has changed it since; the write is refused, naming both revisions, if
+        they have. --expect absent writes only if the document does not exist
+        yet. Without --expect the write always wins, which is what you want for
+        a value you are setting rather than editing.
 
   get <namespace> <collection> <id> [--json]
-  delete <namespace> <collection> <id>
+  delete <namespace> <collection> <id> [--expect <rev>]
+        --expect removes the document only if it is still at that revision.
 
   query <namespace> <collection> [query flags] [--json]
         run a query once.
@@ -194,6 +203,7 @@ func runDocCollections(args []string) {
 
 func runDocPut(args []string) {
 	namespace, collection, rest := docTarget("put", args)
+	rest, expect := takeExpectFlag("put", rest, true)
 	if len(rest) < 2 {
 		docFail("put", fmt.Errorf("needs <id> and a JSON body (or - for stdin)"))
 	}
@@ -205,10 +215,51 @@ func runDocPut(args []string) {
 		}
 		body = string(raw)
 	}
-	if _, err := docClient().DocPut(namespace, collection, id, body); err != nil {
+	result, err := docClient().DocPut(namespace, collection, id, body, expect)
+	if err != nil {
 		docFail("put", err)
 	}
-	fmt.Printf("wrote %s/%s/%s\n", namespace, collection, id)
+	fmt.Printf("wrote %s/%s/%s (rev %d)\n", namespace, collection, id, result.Rev)
+}
+
+// takeExpectFlag pulls `--expect <rev|absent>` out of a command's arguments and
+// returns what is left, so the positional arguments can still be read by
+// position. absent is offered only where "must not exist" is something the
+// command can act on.
+func takeExpectFlag(verb string, args []string, allowAbsent bool) ([]string, *int) {
+	rest := make([]string, 0, len(args))
+	var expect *int
+	for i := 0; i < len(args); i++ {
+		if args[i] != "--expect" {
+			rest = append(rest, args[i])
+			continue
+		}
+		if i+1 >= len(args) {
+			docFail(verb, fmt.Errorf("--expect needs a revision%s", expectAbsentHint(allowAbsent)))
+		}
+		i++
+		if args[i] == "absent" {
+			if !allowAbsent {
+				docFail(verb, fmt.Errorf("--expect absent asks to act on a document that is not there, which %s cannot do", verb))
+			}
+			absent := int(docstore.ExpectAbsent)
+			expect = &absent
+			continue
+		}
+		rev, err := strconv.Atoi(args[i])
+		if err != nil || rev < int(docstore.FirstRev) {
+			docFail(verb, fmt.Errorf("--expect %q is not a revision%s", args[i], expectAbsentHint(allowAbsent)))
+		}
+		expect = &rev
+	}
+	return rest, expect
+}
+
+func expectAbsentHint(allowAbsent bool) string {
+	if allowAbsent {
+		return ` (a number from a previous read, or "absent")`
+	}
+	return " (a number from a previous read)"
 }
 
 func runDocGet(args []string) {
@@ -233,10 +284,11 @@ func runDocGet(args []string) {
 
 func runDocDelete(args []string) {
 	namespace, collection, rest := docTarget("delete", args)
+	rest, expect := takeExpectFlag("delete", rest, false)
 	if len(rest) < 1 {
 		docFail("delete", fmt.Errorf("needs <id>"))
 	}
-	result, err := docClient().DocDelete(namespace, collection, rest[0])
+	result, err := docClient().DocDelete(namespace, collection, rest[0], expect)
 	if err != nil {
 		docFail("delete", err)
 	}
@@ -263,11 +315,11 @@ func runDocWatch(args []string) {
 	err := docClient().DocSubscribe(query, func(result *protocol.DocSubscribeResult) bool {
 		if asJSON {
 			writeJSON(struct {
-				Revision  int            `json:"revision"`
+				Delivery  int            `json:"delivery"`
 				Documents []jsonDocument `json:"documents"`
-			}{result.Revision, docsForJSON(result.Documents)})
+			}{result.Delivery, docsForJSON(result.Documents)})
 		} else {
-			fmt.Printf("--- revision %d (%d document(s)) ---\n", result.Revision, len(result.Documents))
+			fmt.Printf("--- delivery %d (%d document(s)) ---\n", result.Delivery, len(result.Documents))
 			printDocuments(result.Documents, false)
 		}
 		return true
@@ -379,6 +431,7 @@ func docBoundAsJSON(raw string) string {
 type jsonDocument struct {
 	ID        string          `json:"id"`
 	Body      json.RawMessage `json:"body"`
+	Rev       int             `json:"rev"`
 	CreatedAt string          `json:"created_at"`
 	UpdatedAt string          `json:"updated_at"`
 }
@@ -389,6 +442,7 @@ func docsForJSON(docs []protocol.StoredDocument) []jsonDocument {
 		out = append(out, jsonDocument{
 			ID:        doc.ID,
 			Body:      json.RawMessage(doc.Body),
+			Rev:       doc.Rev,
 			CreatedAt: doc.CreatedAt,
 			UpdatedAt: doc.UpdatedAt,
 		})
@@ -406,9 +460,9 @@ func printDocuments(docs []protocol.StoredDocument, asJSON bool) {
 		return
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "ID\tUPDATED\tBODY")
+	fmt.Fprintln(w, "ID\tREV\tUPDATED\tBODY")
 	for _, doc := range docs {
-		fmt.Fprintf(w, "%s\t%s\t%s\n", doc.ID, doc.UpdatedAt, doc.Body)
+		fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", doc.ID, doc.Rev, doc.UpdatedAt, doc.Body)
 	}
 	w.Flush()
 }

--- a/cmd/attn/doc_test.go
+++ b/cmd/attn/doc_test.go
@@ -114,3 +114,34 @@ func TestAfterFlagCarriesTheCursor(t *testing.T) {
 		t.Fatalf("after = %v", query.After)
 	}
 }
+
+// --expect is pulled out of the arguments before the positional ones are read,
+// so `put ns coll id body --expect 3` still finds its id and body.
+func TestExpectFlagLeavesThePositionalArgumentsAlone(t *testing.T) {
+	rest, expect := takeExpectFlag("put", []string{"r1", `{"a":1}`, "--expect", "3"}, true)
+	if len(rest) != 2 || rest[0] != "r1" || rest[1] != `{"a":1}` {
+		t.Fatalf("positional arguments = %v", rest)
+	}
+	if expect == nil || *expect != 3 {
+		t.Fatalf("expect = %v, want 3", expect)
+	}
+}
+
+// "absent" is how the CLI spells the create-only expectation, so a caller never
+// has to know that the wire encodes it as revision zero.
+func TestExpectAbsentIsTheZeroRevision(t *testing.T) {
+	_, expect := takeExpectFlag("put", []string{"r1", `{"a":1}`, "--expect", "absent"}, true)
+	if expect == nil || int64(*expect) != docstore.ExpectAbsent {
+		t.Fatalf("expect = %v, want %d", expect, docstore.ExpectAbsent)
+	}
+}
+
+func TestWithoutExpectTheWriteIsUnconditional(t *testing.T) {
+	rest, expect := takeExpectFlag("put", []string{"r1", `{"a":1}`}, true)
+	if expect != nil {
+		t.Fatalf("expect = %v, want none", *expect)
+	}
+	if len(rest) != 2 {
+		t.Fatalf("positional arguments = %v", rest)
+	}
+}

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -178,6 +178,15 @@ locate every record:
   collection. The body is stored byte for byte and nothing ever rewrites it, so
   an author never writes a migration.
 
+Every document also carries a **revision**: a count of the writes to it, starting
+at 1, reported by every read and by every write. Handing a revision back as a
+write's **expectation** makes that write conditional — it lands only if the
+document is still at that revision, and is otherwise refused with both revisions
+named. That is what makes a read-modify-write safe between writers who cannot see
+each other; without an expectation a write always lands, which is what a caller
+setting a value rather than editing one wants. Expecting revision 0 means
+expecting no document at all, and is how a write becomes create-only.
+
 A collection carries a **declaration**: the fields it promises are queryable,
 each with a type. Declaring a field does not constrain what a document may
 contain — undeclared keys are stored and returned untouched — it only says what a

--- a/docs/plans/2026-08-04-ext-a3.2-document-revisions.md
+++ b/docs/plans/2026-08-04-ext-a3.2-document-revisions.md
@@ -1,0 +1,117 @@
+# A3.2 — Document revisions and conditional writes
+
+Follow-up to [A3](2026-08-03-ext-a3-doc-store.md) and
+[A3.1](2026-08-03-ext-a3.1-doc-store-physical-schema.md). Roadmap:
+[2026-08-01-extension-platform-roadmap.md](2026-08-01-extension-platform-roadmap.md).
+
+Status: design approved by Victor 2026-08-04. Implemented 2026-08-04. Lands
+before A4, because A4 is where a sidecar starts writing concurrently.
+
+## The gap
+
+`PutDocument` was a blind upsert. Read-modify-write is the natural shape for
+much of what will be built on the store — flip a status, append to a list, bump
+a counter — and two writers doing it at once left only the second change, with
+no error on either side. Every other refusal in the store is loud: an undeclared
+collection, a filter on a field that is not declared, a live query whose
+collection can no longer answer it. This was the one silent one, and it lost
+data rather than a render.
+
+It is also the cheapest thing in the store to fix while it is young: a column
+and a `WHERE` clause now, versus a change to every caller later.
+
+## The shape
+
+A document carries a **revision**, counting writes to it, starting at 1. Every
+read reports it, every write returns the new one. A write may carry an
+**expectation**:
+
+| expectation | meaning |
+| --- | --- |
+| absent | write unconditionally |
+| a revision | write only if the document is still at it |
+| 0 | write only if the document does not exist |
+
+A failed expectation writes nothing and returns a `docstore.ConflictError`
+naming both revisions. `doc_delete` takes the same expectation, minus 0 —
+"delete this if it is not there" is not an assertion a delete can act on, and
+silently reading it as unconditional would delete the document the caller was
+protecting.
+
+Each form is **one statement**, which is what makes the check atomic without a
+transaction: SQLite runs a bare statement in its own. An unconditional write is
+an upsert, a create-only write is an insert with `ON CONFLICT DO NOTHING`, and a
+write at a revision is an `UPDATE ... WHERE rev = ?` with no insert path at all.
+All three use `RETURNING rev`, so a refusal arrives the same way in every form —
+no row came back — and the store re-reads only on that failure path, to say
+which write the caller lost to.
+
+## Decisions
+
+**Optional, not mandatory.** An absent expectation still writes unconditionally.
+Forcing every write to declare one would make "set this to that" — a projection
+push, a first write — read the document first for no safety. Safety by default
+belongs one layer up: A4's SDK should expose an `update(id, fn)` that loops
+read → modify → write-at-revision and retries the conflict, so sidecar code gets
+this without knowing the word. The store's job is to make the safe write
+*possible* and its refusal loud.
+
+**Revision 0 means "must not exist".** Revisions start at 1, so 0 is
+unambiguous, and create-only falls out of the same field rather than needing a
+second one. It is the one magic value in the surface; the alternative was a
+separate `expect_absent` boolean, which spends a field to avoid a sentence of
+documentation.
+
+**safeint on the wire, not int32 or int64.** `int64` codegens as a TypeScript
+*string* in this pipeline — `main.tsp` already says so where epoch-ms uses
+safeint — and a revision arriving as `"5"` is one somebody compares with `<` and
+gets wrong. `int32` is 2.1 billion writes to *one* document: about seven years
+at ten writes a second, which attn's uptime can reach, and a wrapped revision
+makes a stale check *pass*, which is the exact failure this exists to prevent.
+safeint is 2^53-1 — ~285,000 years at a thousand writes a second to one document
+— and costs nothing: SQLite's INTEGER is up to 8 bytes whatever it is declared
+as, and safeint generates Go `int` (64-bit on every platform attn builds) and
+TypeScript `number`.
+
+**`DocSubscribeResult.revision` renamed to `delivery`.** It counts deliveries on
+a subscription, which is unrelated to a document's revision, and one word for
+both would read as though they were connected. Nothing consumed it — it reached
+`generated.ts` and no app code — so it was free to rename now and permanent
+later. It stays `int32`: bounded by how long one connection is open, not by a
+document's whole history.
+
+**A refused write publishes no change fact.** Nothing changed, so waking every
+live query on the collection to re-render an identical result set is exactly the
+cost the conditional write exists to avoid.
+
+## Migration 90
+
+One `ALTER TABLE doc_<id> ADD COLUMN rev INTEGER NOT NULL DEFAULT 1` per
+registry row. The registry is walked rather than the schema, because scanning
+`sqlite_master` for `doc_%` would pick up any table that happened to be named
+like one. Guarded per table, so a rewound `schema_migrations` finishes a run
+that stopped part way.
+
+Documents already stored start at revision 1 rather than 0: a revision is the
+version a reader was handed, and every stored document has been readable all
+along at what is now its first.
+
+## Exit criteria
+
+- [x] A revision advances on every write and is visible on every read, at the
+      store, over IPC, and in `attn doc` output.
+- [x] A write or delete at a stale revision is refused, names both revisions,
+      and leaves the document byte-identical.
+- [x] Expecting a revision on a missing document refuses rather than creates.
+- [x] A contention test: concurrent read-modify-writes against a database file
+      lose no update, and go red when the expectation is removed.
+- [x] A refused write does not wake the collection's live queries.
+- [x] An upgrade witness: documents written before migration 90 come back at
+      revision 1 and accept a conditional write immediately.
+- [x] Live verification against a non-production profile.
+
+## Known bound
+
+Carried from A3.1: a query filtering on one field and sorting by a different one
+still uses a temp B-tree over the matched rows. One composite index per
+(filter, sort) pair is combinatorial, so it waits for a receipt.

--- a/internal/client/documents.go
+++ b/internal/client/documents.go
@@ -40,9 +40,13 @@ func (c *Client) DocCollections() (*protocol.DocCollectionsResult, error) {
 	return resp.DocCollectionsResult, nil
 }
 
-func (c *Client) DocPut(namespace, collection, id, body string) (*protocol.DocPutResult, error) {
+// DocPut writes a document. expectedRev is the revision the caller believes it
+// is replacing — nil writes unconditionally, and see DocPutMessage for what a
+// value means.
+func (c *Client) DocPut(namespace, collection, id, body string, expectedRev *int) (*protocol.DocPutResult, error) {
 	resp, err := c.send(protocol.DocPutMessage{
 		Cmd: protocol.CmdDocPut, Namespace: namespace, Collection: collection, ID: id, Body: body,
+		ExpectedRev: expectedRev,
 	})
 	if err != nil {
 		return nil, err
@@ -60,9 +64,10 @@ func (c *Client) DocGet(namespace, collection, id string) (*protocol.DocGetResul
 	return resp.DocGetResult, nil
 }
 
-func (c *Client) DocDelete(namespace, collection, id string) (*protocol.DocDeleteResult, error) {
+func (c *Client) DocDelete(namespace, collection, id string, expectedRev *int) (*protocol.DocDeleteResult, error) {
 	resp, err := c.send(protocol.DocDeleteMessage{
 		Cmd: protocol.CmdDocDelete, Namespace: namespace, Collection: collection, ID: id,
+		ExpectedRev: expectedRev,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/daemon/documents.go
+++ b/internal/daemon/documents.go
@@ -346,15 +346,30 @@ func (d *Daemon) handleDocPut(conn net.Conn, msg *protocol.DocPutMessage) {
 		d.sendError(conn, err.Error())
 		return
 	}
-	if err := d.store.PutDocument(*schema, msg.ID, []byte(msg.Body), time.Now()); err != nil {
+	// A refused write publishes nothing: the store did not change, and waking
+	// every live query on the collection to re-render an identical result set is
+	// exactly the cost the conditional write exists to avoid.
+	rev, err := d.store.PutDocument(*schema, msg.ID, []byte(msg.Body), time.Now(), expectedRev(msg.ExpectedRev))
+	if err != nil {
 		d.sendError(conn, err.Error())
 		return
 	}
 	d.publishDocumentChanged(msg.Namespace, msg.Collection, msg.ID, false)
 	d.sendDocResponse(conn, protocol.Response{
 		Ok:           true,
-		DocPutResult: &protocol.DocPutResult{Namespace: msg.Namespace, Collection: msg.Collection, ID: msg.ID},
+		DocPutResult: &protocol.DocPutResult{Namespace: msg.Namespace, Collection: msg.Collection, ID: msg.ID, Rev: int(rev)},
 	})
+}
+
+// expectedRev converts the wire's optional revision to the store's. The wire
+// carries safeint, which generates as int; the store keeps int64 so the SQL side
+// is the same width on every platform.
+func expectedRev(wire *int) *int64 {
+	if wire == nil {
+		return nil
+	}
+	rev := int64(*wire)
+	return &rev
 }
 
 func (d *Daemon) handleDocGet(conn net.Conn, msg *protocol.DocGetMessage) {
@@ -382,7 +397,7 @@ func (d *Daemon) handleDocDelete(conn net.Conn, msg *protocol.DocDeleteMessage) 
 		d.sendError(conn, err.Error())
 		return
 	}
-	existed, err := d.store.DeleteDocument(*schema, msg.ID)
+	existed, err := d.store.DeleteDocument(*schema, msg.ID, expectedRev(msg.ExpectedRev))
 	if err != nil {
 		d.sendError(conn, err.Error())
 		return
@@ -459,7 +474,7 @@ func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMes
 	}()
 
 	encoder := json.NewEncoder(conn)
-	for revision := 1; ; revision++ {
+	for delivery := 1; ; delivery++ {
 		// The declaration is re-read per delivery rather than captured, because
 		// it can go out from under a subscription in two ways and both have to
 		// end the subscription rather than mislead it. Undefining drops the
@@ -482,7 +497,7 @@ func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMes
 		d.logSlowDocFanOut(sub, *live, took)
 		resp := protocol.Response{
 			Ok:                 true,
-			DocSubscribeResult: &protocol.DocSubscribeResult{Revision: revision, Documents: docs},
+			DocSubscribeResult: &protocol.DocSubscribeResult{Delivery: delivery, Documents: docs},
 		}
 		if err := encoder.Encode(resp); err != nil {
 			return
@@ -557,6 +572,7 @@ func storedDocumentToProtocol(doc docstore.Document) protocol.StoredDocument {
 	return protocol.StoredDocument{
 		ID:        doc.ID,
 		Body:      string(doc.Body),
+		Rev:       int(doc.Rev),
 		CreatedAt: doc.CreatedAt.UTC().Format(docstore.TimeFormat),
 		UpdatedAt: doc.UpdatedAt.UTC().Format(docstore.TimeFormat),
 	}

--- a/internal/daemon/documents_test.go
+++ b/internal/daemon/documents_test.go
@@ -146,8 +146,8 @@ func TestSubscribingDeliversTheCurrentResultSetImmediately(t *testing.T) {
 
 	lq := subscribe(t, d, testQuery())
 	first := lq.next(t)
-	if first.Revision != 1 {
-		t.Fatalf("first delivery revision = %d, want 1", first.Revision)
+	if first.Delivery != 1 {
+		t.Fatalf("first delivery = %d, want 1", first.Delivery)
 	}
 	if got := ids(first); len(got) != 1 || got[0] != "already-here" {
 		t.Fatalf("first delivery = %v", got)
@@ -166,8 +166,8 @@ func TestAWriteWakesTheSubscriptionWithTheWholeResultSet(t *testing.T) {
 
 	putDoc(t, d, "a", `{"status":"pending"}`)
 	second := lq.next(t)
-	if second.Revision != 2 {
-		t.Fatalf("revision = %d, want 2", second.Revision)
+	if second.Delivery != 2 {
+		t.Fatalf("delivery = %d, want 2", second.Delivery)
 	}
 	if got := ids(second); len(got) != 1 || got[0] != "a" {
 		t.Fatalf("after write = %v", got)
@@ -193,8 +193,8 @@ func TestANoOpDeleteDoesNotWakeSubscribers(t *testing.T) {
 	putDoc(t, d, "a", `{"status":"pending"}`)
 
 	next := lq.next(t)
-	if next.Revision != 2 {
-		t.Fatalf("revision = %d, want 2 — the no-op delete delivered", next.Revision)
+	if next.Delivery != 2 {
+		t.Fatalf("delivery = %d, want 2 — the no-op delete delivered", next.Delivery)
 	}
 	if got := ids(next); len(got) != 1 || got[0] != "a" {
 		t.Fatalf("delivery = %v", got)
@@ -253,8 +253,8 @@ func TestASubscriptionOnlyWakesForItsOwnCollection(t *testing.T) {
 	putDoc(t, d, "ours", `{"status":"pending"}`)
 
 	next := lq.next(t)
-	if next.Revision != 2 {
-		t.Fatalf("revision = %d, want 2 — the neighbouring namespace woke this subscription", next.Revision)
+	if next.Delivery != 2 {
+		t.Fatalf("delivery = %d, want 2 — the neighbouring namespace woke this subscription", next.Delivery)
 	}
 	if got := ids(next); len(got) != 1 || got[0] != "ours" {
 		t.Fatalf("delivery = %v — it crossed the namespace boundary", got)
@@ -488,5 +488,151 @@ func TestRedeclaringWithoutAFieldEndsTheLiveQueriesUsingIt(t *testing.T) {
 	}
 	if msg := protocol.Deref(final.Error); !strings.Contains(msg, "status") {
 		t.Fatalf("error does not name the field that went: %q", msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Conditional writes over the wire
+// ---------------------------------------------------------------------------
+
+// putDocExpecting writes with an expectation and returns the raw response, so a
+// test can assert on a refusal rather than fail on one.
+func putDocExpecting(t *testing.T, d *Daemon, id, body string, expected int) protocol.Response {
+	t.Helper()
+	return docCall(t, func(c net.Conn) {
+		d.handleDocPut(c, &protocol.DocPutMessage{
+			Cmd: protocol.CmdDocPut, Namespace: testDocNS, Collection: testDocColl,
+			ID: id, Body: body, ExpectedRev: &expected,
+		})
+	})
+}
+
+func getDoc(t *testing.T, d *Daemon, id string) *protocol.StoredDocument {
+	t.Helper()
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocGet(c, &protocol.DocGetMessage{
+			Cmd: protocol.CmdDocGet, Namespace: testDocNS, Collection: testDocColl, ID: id,
+		})
+	})
+	if !resp.Ok {
+		t.Fatalf("get %s: %v", id, protocol.Deref(resp.Error))
+	}
+	if !resp.DocGetResult.Found {
+		return nil
+	}
+	return resp.DocGetResult.Document
+}
+
+// A write reports the revision it produced, and a read reports the revision it
+// read, so a caller never has to ask for one separately.
+func TestAWriteAndAReadAgreeOnTheRevision(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocPut(c, &protocol.DocPutMessage{
+			Cmd: protocol.CmdDocPut, Namespace: testDocNS, Collection: testDocColl,
+			ID: "a", Body: `{"status":"pending"}`,
+		})
+	})
+	if !resp.Ok {
+		t.Fatalf("put: %v", protocol.Deref(resp.Error))
+	}
+	if resp.DocPutResult.Rev != 1 {
+		t.Fatalf("put reported rev %d, want 1", resp.DocPutResult.Rev)
+	}
+	if doc := getDoc(t, d, "a"); doc == nil || doc.Rev != 1 {
+		t.Fatalf("get reported %+v, want rev 1", doc)
+	}
+}
+
+// The refusal has to arrive as an error a caller can act on, and the document it
+// would have replaced has to be exactly as it was.
+func TestAStaleConditionalWriteIsRefusedOverTheWire(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+	putDoc(t, d, "a", `{"status":"approved"}`)
+
+	resp := putDocExpecting(t, d, "a", `{"status":"rejected"}`, 1)
+	if resp.Ok {
+		t.Fatal("a write against a replaced revision was accepted")
+	}
+	msg := protocol.Deref(resp.Error)
+	if !strings.Contains(msg, "rev 1") || !strings.Contains(msg, "rev 2") {
+		t.Fatalf("refusal does not name both revisions: %s", msg)
+	}
+
+	doc := getDoc(t, d, "a")
+	if doc == nil || doc.Body != `{"status":"approved"}` || doc.Rev != 2 {
+		t.Fatalf("the refused write changed the document: %+v", doc)
+	}
+}
+
+// A refused write changed nothing, so it must not wake the collection's live
+// queries: a delivery means "this result set is new", and re-rendering an
+// identical one on every rejected write is the cost the conditional write exists
+// to avoid.
+func TestARefusedWriteDoesNotWakeSubscribers(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+	lq := subscribe(t, d, testQuery())
+	lq.next(t)
+
+	if resp := putDocExpecting(t, d, "a", `{"status":"rejected"}`, 99); resp.Ok {
+		t.Fatal("a write against a revision that never existed was accepted")
+	}
+	putDoc(t, d, "b", `{"status":"pending"}`)
+
+	// The next delivery is the one the accepted write caused, so it carries both
+	// documents. A delivery holding only the first means the refused write woke
+	// the subscription and this is its result set, with the real one still queued.
+	next := lq.next(t)
+	if got := ids(next); len(got) != 2 {
+		t.Fatalf("first delivery after the refused write = %v, want both documents", got)
+	}
+	if next.Delivery != 2 {
+		t.Fatalf("delivery = %d, want 2 — something delivered in between", next.Delivery)
+	}
+}
+
+// Create-only, over the wire: the second create loses and the first document
+// survives it.
+func TestCreateOnlyIsRefusedWhenTheDocumentIsAlreadyThere(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+
+	if resp := putDocExpecting(t, d, "a", `{"status":"first"}`, 0); !resp.Ok {
+		t.Fatalf("first create: %v", protocol.Deref(resp.Error))
+	}
+	resp := putDocExpecting(t, d, "a", `{"status":"second"}`, 0)
+	if resp.Ok {
+		t.Fatal("a second create was accepted")
+	}
+	if doc := getDoc(t, d, "a"); doc == nil || doc.Body != `{"status":"first"}` {
+		t.Fatalf("the losing create overwrote the winner: %+v", doc)
+	}
+}
+
+// A conditional delete refuses the same way, and leaves the document behind.
+func TestAStaleConditionalDeleteIsRefusedOverTheWire(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+	putDoc(t, d, "a", `{"status":"approved"}`)
+
+	stale := 1
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocDelete(c, &protocol.DocDeleteMessage{
+			Cmd: protocol.CmdDocDelete, Namespace: testDocNS, Collection: testDocColl,
+			ID: "a", ExpectedRev: &stale,
+		})
+	})
+	if resp.Ok {
+		t.Fatal("a delete against a replaced revision was accepted")
+	}
+	if doc := getDoc(t, d, "a"); doc == nil {
+		t.Fatal("the refused delete removed the document")
 	}
 }

--- a/internal/docstore/docstore.go
+++ b/internal/docstore/docstore.go
@@ -30,6 +30,7 @@ package docstore
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -156,11 +157,81 @@ type Query struct {
 // Document is one stored record. Body is the document as written, byte for byte
 // — record-shape evolution is handled by the reader (parse tolerantly, render
 // tolerantly), never by migrating stored documents.
+//
+// Rev is what makes a read-modify-write safe. It comes back on every read, so a
+// caller that read a document already holds the token that names the version it
+// read; handing that token back to a write is how the store can refuse an edit
+// built on a version somebody else has since replaced.
 type Document struct {
 	ID        string          `json:"id"`
 	Body      json.RawMessage `json:"body"`
+	Rev       int64           `json:"rev"`
 	CreatedAt time.Time       `json:"created_at"`
 	UpdatedAt time.Time       `json:"updated_at"`
+}
+
+// Revisions.
+//
+// A document's revision counts writes to that document, starting at FirstRev.
+// It is per document rather than per collection or per store: what a caller
+// needs to know is whether the record they read is the record they are about to
+// overwrite, and a global counter would make every unrelated write look like a
+// conflict.
+//
+// ExpectAbsent is the one magic value, and it is unambiguous because revisions
+// start at 1: a caller that expects revision zero is a caller that expects no
+// document at all. That makes create-only fall out of the same field rather
+// than needing a second one.
+//
+// Width: the wire carries a revision as safeint (2^53-1) and the store as
+// SQLite INTEGER, which is 8 bytes whatever it is declared as. int32 would have
+// been 2.1 billion writes to ONE document — roughly seven years at ten writes a
+// second, which attn's uptime can reach — and overflowing it would silently make
+// a stale check pass, which is the exact failure this exists to prevent.
+const (
+	FirstRev     int64 = 1
+	ExpectAbsent int64 = 0
+)
+
+// ConflictError is a write refused because the document was not at the revision
+// the caller expected. It is a distinct type, not a string, because every
+// surface above has to be able to tell it apart from a failure: a conflict means
+// "read it again and retry", and everything else means "something is broken".
+//
+// Found and Actual describe what was there when the store looked, which is after
+// the write was refused — so they name the version that won rather than the
+// version that will still be current by the time the caller reads this. That is
+// what the caller wants: it says which write it lost to.
+type ConflictError struct {
+	Namespace  string
+	Collection string
+	ID         string
+	// Expected is the revision the caller asserted, or ExpectAbsent when the
+	// caller asserted the document did not exist.
+	Expected int64
+	// Found reports whether a document was there at all; Actual is its revision
+	// and is meaningless when Found is false.
+	Found  bool
+	Actual int64
+}
+
+func (e *ConflictError) Error() string {
+	addr := Address(e.Namespace, e.Collection, e.ID)
+	switch {
+	case e.Expected == ExpectAbsent:
+		return fmt.Sprintf("docstore: %s already exists at rev %d, and this write expected it not to exist yet", addr, e.Actual)
+	case !e.Found:
+		return fmt.Sprintf("docstore: %s expected rev %d but no document is there; it was removed since you read it", addr, e.Expected)
+	default:
+		return fmt.Sprintf("docstore: %s expected rev %d but is at rev %d; re-read it and apply your change to that version", addr, e.Expected, e.Actual)
+	}
+}
+
+// IsConflict reports whether an error is a lost-update refusal. It is the check
+// a retry loop makes.
+func IsConflict(err error) bool {
+	var conflict *ConflictError
+	return errors.As(err, &conflict)
 }
 
 // Compiled is a validated query as SQL. Table is the collection's table, Where

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "207"
+const ProtocolVersion = "208"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1083,6 +1083,9 @@ type DocDeleteMessage struct {
 	// Collection corresponds to the JSON schema field "collection".
 	Collection string `json:"collection"`
 
+	// ExpectedRev corresponds to the JSON schema field "expected_rev".
+	ExpectedRev *int `json:"expected_rev,omitempty,omitzero"`
+
 	// ID corresponds to the JSON schema field "id".
 	ID string `json:"id"`
 
@@ -1136,6 +1139,9 @@ type DocPutMessage struct {
 	// Collection corresponds to the JSON schema field "collection".
 	Collection string `json:"collection"`
 
+	// ExpectedRev corresponds to the JSON schema field "expected_rev".
+	ExpectedRev *int `json:"expected_rev,omitempty,omitzero"`
+
 	// ID corresponds to the JSON schema field "id".
 	ID string `json:"id"`
 
@@ -1152,6 +1158,9 @@ type DocPutResult struct {
 
 	// Namespace corresponds to the JSON schema field "namespace".
 	Namespace string `json:"namespace"`
+
+	// Rev corresponds to the JSON schema field "rev".
+	Rev int `json:"rev"`
 }
 
 type DocQueryMessage struct {
@@ -1176,11 +1185,11 @@ type DocSubscribeMessage struct {
 }
 
 type DocSubscribeResult struct {
+	// Delivery corresponds to the JSON schema field "delivery".
+	Delivery int `json:"delivery"`
+
 	// Documents corresponds to the JSON schema field "documents".
 	Documents []StoredDocument `json:"documents"`
-
-	// Revision corresponds to the JSON schema field "revision".
-	Revision int `json:"revision"`
 }
 
 type DocUndefineMessage struct {
@@ -5044,6 +5053,9 @@ type StoredDocument struct {
 
 	// ID corresponds to the JSON schema field "id".
 	ID string `json:"id"`
+
+	// Rev corresponds to the JSON schema field "rev".
+	Rev int `json:"rev"`
 
 	// UpdatedAt corresponds to the JSON schema field "updated_at".
 	UpdatedAt string `json:"updated_at"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -3459,9 +3459,16 @@ model DocumentQuery {
 }
 
 // One stored document. `body` is the document's JSON as written, byte for byte.
+//
+// `rev` counts writes to this document, starting at 1. Hand it back as a put's
+// or delete's `expected_rev` to make the write conditional on nobody having
+// changed the document since this read. safeint rather than int32 because int32
+// is only about two billion writes to one document, and a wrapped revision would
+// make a stale check pass — the exact failure it guards against.
 model StoredDocument {
   "id": string;
   "body": string;
+  "rev": safeint;
   "created_at": string;
   "updated_at": string;
 }
@@ -3501,18 +3508,29 @@ model DocCollectionsResult {
 }
 
 // Write a document, creating or fully replacing it. `body` is JSON object text.
+//
+// `expected_rev` is the caller's assertion about what it is overwriting: absent
+// writes unconditionally, 0 writes only if the document does not exist yet, and
+// any other value writes only if the document is still at that revision. A
+// failed assertion writes nothing and answers with an error naming both
+// revisions. Revisions start at 1, which is what makes 0 unambiguous as "must
+// not exist".
 model DocPutMessage {
   "cmd": "doc_put";
   "namespace": string;
   "collection": string;
   "id": string;
   "body": string;
+  "expected_rev"?: safeint;
 }
 
+// `rev` is the revision the document now has, so a create-then-update sequence
+// needs no read in between.
 model DocPutResult {
   "namespace": string;
   "collection": string;
   "id": string;
+  "rev": safeint;
 }
 
 model DocGetMessage {
@@ -3529,11 +3547,16 @@ model DocGetResult {
   "document"?: StoredDocument;
 }
 
+// `expected_rev` removes the document only if it is still at that revision —
+// deleting on the strength of a body you read is the same lost-update hazard as
+// overwriting one. Absent deletes unconditionally. Unlike a put, 0 is refused:
+// "delete this if it does not exist" is not an assertion a delete can act on.
 model DocDeleteMessage {
   "cmd": "doc_delete";
   "namespace": string;
   "collection": string;
   "id": string;
+  "expected_rev"?: safeint;
 }
 
 // `existed` is false when the delete removed nothing, so a caller does not
@@ -3566,10 +3589,16 @@ model DocSubscribeMessage {
 
 // One delivery of a live query's results. `documents` is always the CURRENT full
 // result set, never a patch — a subscriber renders what it is given and never
-// reconstructs state from a sequence of deliveries. `revision` counts deliveries
-// on this subscription, starting at 1 for the initial one.
+// reconstructs state from a sequence of deliveries. `delivery` counts deliveries
+// on this subscription, starting at 1 for the initial one; it is named for what
+// it counts because a document carries its own `rev` and one word for both would
+// read as though they were related.
+//
+// int32 rather than the safeint a document's revision uses: this counter is
+// bounded by how long one connection stays open, not by a document's whole
+// history.
 model DocSubscribeResult {
-  "revision": int32;
+  "delivery": int32;
   "documents": StoredDocument[];
 }
 

--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -34,7 +34,11 @@ import (
 // documentColumns is the read projection; body is returned byte for byte. The
 // generated columns are never selected: they exist to be filtered and ordered
 // on, and the body already carries what they compute.
-const documentColumns = `id, body, created_at, updated_at`
+//
+// rev is in the projection rather than fetched on demand because it is the token
+// a read-modify-write hands back, and a caller that had to ask for it separately
+// would be reading a version it did not read the body of.
+const documentColumns = `id, body, rev, created_at, updated_at`
 
 // DefineDocumentCollection records a collection's declaration and brings its
 // table into line with it, creating the table on first declaration. Redeclaring
@@ -190,30 +194,78 @@ func (s *Store) DeleteDocumentCollection(namespace, collection string) (int, err
 	return n, nil
 }
 
-// PutDocument writes a document, creating or fully replacing it. created_at
-// survives a replacement — it is when the record first appeared, which is what a
-// "newest first" query means by it — while updated_at moves on every write.
+// PutDocument writes a document, creating or fully replacing it, and returns the
+// revision it now has. created_at survives a replacement — it is when the record
+// first appeared, which is what a "newest first" query means by it — while
+// updated_at and rev move on every write.
 //
 // The schema names the table, which is why every caller reads the declaration
 // first: an undeclared collection has no storage, and that has to be an error a
 // caller reports rather than a table appearing by surprise.
-func (s *Store) PutDocument(schema docstore.CollectionSchema, id string, body []byte, now time.Time) error {
+//
+// expected is the caller's assertion about what it is overwriting: nil writes
+// unconditionally, docstore.ExpectAbsent writes only if nothing is there, and a
+// revision writes only if the document is still at it. A failed assertion is a
+// *docstore.ConflictError and nothing is written.
+//
+// EACH FORM IS ONE STATEMENT, which is what makes the check atomic without a
+// transaction: SQLite runs a bare statement in its own. Reading the revision and
+// then writing would be two, and the whole point of this is the window between
+// them. The re-read below happens only on the failure path, to say what the
+// write lost to.
+func (s *Store) PutDocument(schema docstore.CollectionSchema, id string, body []byte, now time.Time, expected *int64) (int64, error) {
 	table, err := s.documentTable(schema)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	ts := now.UTC().Format(docstore.TimeFormat)
-	_, err = s.db.Exec(
-		`INSERT INTO `+table+` (id, body, created_at, updated_at)
-		 VALUES (?, ?, ?, ?)
-		 ON CONFLICT(id) DO UPDATE SET
-		   body=excluded.body,
-		   updated_at=excluded.updated_at`,
-		id, string(body), ts, ts)
-	if err != nil {
-		return fmt.Errorf("store: writing %s/%s/%s: %w", schema.Namespace, schema.Collection, id, err)
+
+	var (
+		stmt string
+		args []any
+	)
+	switch {
+	case expected == nil:
+		// Upsert: the insert path starts at FirstRev, the update path advances.
+		stmt = `INSERT INTO ` + table + ` (id, body, rev, created_at, updated_at)
+		        VALUES (?, ?, ?, ?, ?)
+		        ON CONFLICT(id) DO UPDATE SET
+		          body=excluded.body,
+		          rev=` + table + `.rev + 1,
+		          updated_at=excluded.updated_at
+		        RETURNING rev`
+		args = []any{id, string(body), docstore.FirstRev, ts, ts}
+	case *expected == docstore.ExpectAbsent:
+		// DO NOTHING rather than letting the primary key raise: a conflicting
+		// insert then returns no row, which is the same "no row came back" signal
+		// the conditional update gives, so both refusals arrive one way.
+		stmt = `INSERT INTO ` + table + ` (id, body, rev, created_at, updated_at)
+		        VALUES (?, ?, ?, ?, ?)
+		        ON CONFLICT(id) DO NOTHING
+		        RETURNING rev`
+		args = []any{id, string(body), docstore.FirstRev, ts, ts}
+	default:
+		// No insert path at all: expecting a revision is expecting a document,
+		// so a missing one must be refused rather than created.
+		stmt = `UPDATE ` + table + ` SET body = ?, rev = rev + 1, updated_at = ?
+		        WHERE id = ? AND rev = ?
+		        RETURNING rev`
+		args = []any{string(body), ts, id, *expected}
 	}
-	return nil
+
+	var rev int64
+	err = s.db.QueryRow(stmt, args...).Scan(&rev)
+	// No row came back is how every refusal arrives — but only an expectation can
+	// refuse one. The unconditional upsert always writes a row, so no row from it
+	// is a broken statement rather than a conflict, and reporting it as one would
+	// tell a caller to retry something that will never succeed.
+	if err == sql.ErrNoRows && expected != nil {
+		return 0, s.documentConflict(schema, table, id, *expected)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("store: writing %s/%s/%s: %w", schema.Namespace, schema.Collection, id, err)
+	}
+	return rev, nil
 }
 
 // GetDocument returns one document by its address.
@@ -236,12 +288,31 @@ func (s *Store) GetDocument(schema docstore.CollectionSchema, id string) (*docst
 // DeleteDocument removes a document, reporting whether one was there. The caller
 // needs the difference: a delete that removed nothing must not announce a change
 // that did not happen.
-func (s *Store) DeleteDocument(schema docstore.CollectionSchema, id string) (bool, error) {
+//
+// expected asserts which version is being removed, the same way PutDocument's
+// does — removing a record on the strength of a body you read is the same
+// lost-update hazard as overwriting one. A revision that no longer matches is a
+// *docstore.ConflictError and nothing is deleted.
+func (s *Store) DeleteDocument(schema docstore.CollectionSchema, id string, expected *int64) (bool, error) {
 	table, err := s.documentTable(schema)
 	if err != nil {
 		return false, err
 	}
-	res, err := s.db.Exec(`DELETE FROM `+table+` WHERE id = ?`, id)
+	if expected != nil && *expected == docstore.ExpectAbsent {
+		// "Delete this if it is not there" is not an assertion a delete can act
+		// on, and silently treating it as unconditional would delete a document
+		// the caller was trying to protect.
+		return false, fmt.Errorf("store: deleting %s/%s/%s: rev %d means the document must not exist, which a delete cannot expect; pass the revision you read, or none to delete unconditionally",
+			schema.Namespace, schema.Collection, id, docstore.ExpectAbsent)
+	}
+
+	stmt := `DELETE FROM ` + table + ` WHERE id = ?`
+	args := []any{id}
+	if expected != nil {
+		stmt += ` AND rev = ?`
+		args = append(args, *expected)
+	}
+	res, err := s.db.Exec(stmt, args...)
 	if err != nil {
 		return false, fmt.Errorf("store: deleting %s/%s/%s: %w", schema.Namespace, schema.Collection, id, err)
 	}
@@ -249,7 +320,31 @@ func (s *Store) DeleteDocument(schema docstore.CollectionSchema, id string) (boo
 	if err != nil {
 		return false, err
 	}
+	if n == 0 && expected != nil {
+		return false, s.documentConflict(schema, table, id, *expected)
+	}
 	return n > 0, nil
+}
+
+// documentConflict describes a refused write. It reads the document again to
+// name the revision that won, because "your write was refused" without that is
+// an error a caller cannot act on. A read failure here is not worth losing the
+// conflict over — the refusal is the fact, the revision is the detail — so it
+// degrades to reporting the document as absent.
+func (s *Store) documentConflict(schema docstore.CollectionSchema, table, id string, expected int64) error {
+	conflict := &docstore.ConflictError{
+		Namespace: schema.Namespace, Collection: schema.Collection, ID: id, Expected: expected,
+	}
+	var rev int64
+	switch err := s.db.QueryRow(`SELECT rev FROM `+table+` WHERE id = ?`, id).Scan(&rev); {
+	case err == nil:
+		conflict.Found = true
+		conflict.Actual = rev
+	case err != sql.ErrNoRows:
+		return fmt.Errorf("store: %s/%s/%s was refused, and re-reading it to say why also failed: %w",
+			schema.Namespace, schema.Collection, id, err)
+	}
+	return conflict
 }
 
 // QueryDocuments runs a compiled query. The compiled fragments are built from a
@@ -349,23 +444,28 @@ func (s *Store) documentTable(schema docstore.CollectionSchema) (string, error) 
 // DDL
 // ---------------------------------------------------------------------------
 
-// createCollectionTable builds a collection's storage: the four stored columns,
+// createCollectionTable builds a collection's storage: the five stored columns,
 // an index for each reserved ordering column, and a generated column plus index
 // for every declared field.
 //
 // WITHOUT ROWID because a document is addressed by its id and never by position:
 // clustering the row on the id it is looked up by removes a whole B-tree and the
 // hop through it.
+//
+// rev is stored and not indexed. It is only ever read for a document already
+// being looked up by its primary key, or compared inside a write to that same
+// row, so an index over it would serve no query and cost every write.
 func createCollectionTable(tx *sql.Tx, table string, fields []docstore.FieldSpec) error {
 	if err := docstore.ValidateTableName(table); err != nil {
 		return err
 	}
-	if _, err := tx.Exec(`CREATE TABLE ` + table + ` (
+	if _, err := tx.Exec(fmt.Sprintf(`CREATE TABLE %s (
     id         TEXT NOT NULL PRIMARY KEY,
     body       TEXT NOT NULL,
+    rev        INTEGER NOT NULL DEFAULT %d,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
-) WITHOUT ROWID`); err != nil {
+) WITHOUT ROWID`, table, docstore.FirstRev)); err != nil {
 		return err
 	}
 	// created_at and updated_at are queryable without being declared, so they
@@ -510,7 +610,7 @@ func scanDocument(sc rowScanner) (*docstore.Document, error) {
 		body                   string
 		createdStr, updatedStr string
 	)
-	if err := sc.Scan(&doc.ID, &body, &createdStr, &updatedStr); err != nil {
+	if err := sc.Scan(&doc.ID, &body, &doc.Rev, &createdStr, &updatedStr); err != nil {
 		return nil, err
 	}
 	doc.Body = json.RawMessage(body)

--- a/internal/store/documents_test.go
+++ b/internal/store/documents_test.go
@@ -2,8 +2,11 @@ package store
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -33,7 +36,7 @@ func storeWithRequests(t *testing.T, bodies map[string]string) (*Store, time.Tim
 	}
 	i := 0
 	for _, id := range sortedKeys(bodies) {
-		if err := s.PutDocument(declOf(t, s, "ext/approval-gate", "requests"), id, []byte(bodies[id]), base.Add(time.Duration(i)*time.Second)); err != nil {
+		if _, err := s.PutDocument(declOf(t, s, "ext/approval-gate", "requests"), id, []byte(bodies[id]), base.Add(time.Duration(i)*time.Second), nil); err != nil {
 			t.Fatalf("put %s: %v", id, err)
 		}
 		i++
@@ -161,7 +164,7 @@ func TestABodyComesBackExactlyAsWritten(t *testing.T) {
 func TestReplacingADocumentKeepsCreatedAtAndMovesUpdatedAt(t *testing.T) {
 	s, base := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
 	later := base.Add(time.Hour)
-	if err := s.PutDocument(declOf(t, s, "ext/approval-gate", "requests"), "a", []byte(`{"status":"approved"}`), later); err != nil {
+	if _, err := s.PutDocument(declOf(t, s, "ext/approval-gate", "requests"), "a", []byte(`{"status":"approved"}`), later, nil); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 	doc, _, err := s.GetDocument(declOf(t, s, "ext/approval-gate", "requests"), "a")
@@ -372,7 +375,7 @@ func TestPagingByCreatedAtWithIdenticalTimestamps(t *testing.T) {
 		t.Fatalf("define: %v", err)
 	}
 	for _, id := range []string{"a", "b", "c"} {
-		if err := s.PutDocument(declOf(t, s, "ext/approval-gate", "requests"), id, []byte(`{"status":"pending"}`), base); err != nil {
+		if _, err := s.PutDocument(declOf(t, s, "ext/approval-gate", "requests"), id, []byte(`{"status":"pending"}`), base, nil); err != nil {
 			t.Fatalf("put %s: %v", id, err)
 		}
 	}
@@ -418,7 +421,7 @@ func TestTwoNamespacesWithTheSameCollectionNameStaySeparate(t *testing.T) {
 	if err := s.DefineDocumentCollection(other, base); err != nil {
 		t.Fatalf("define other: %v", err)
 	}
-	if err := s.PutDocument(declOf(t, s, "ext/other", "requests"), "shared-id", []byte(`{"status":"approved"}`), base); err != nil {
+	if _, err := s.PutDocument(declOf(t, s, "ext/other", "requests"), "shared-id", []byte(`{"status":"approved"}`), base, nil); err != nil {
 		t.Fatalf("put other: %v", err)
 	}
 
@@ -436,7 +439,7 @@ func TestTwoNamespacesWithTheSameCollectionNameStaySeparate(t *testing.T) {
 		t.Fatalf("query crossed the namespace boundary: %v", got)
 	}
 	// Deleting one namespace's document leaves the other's alone.
-	if _, err := s.DeleteDocument(declOf(t, s, "ext/other", "requests"), "shared-id"); err != nil {
+	if _, err := s.DeleteDocument(declOf(t, s, "ext/other", "requests"), "shared-id", nil); err != nil {
 		t.Fatal(err)
 	}
 	if _, ok, _ := s.GetDocument(declOf(t, s, "ext/approval-gate", "requests"), "shared-id"); !ok {
@@ -448,13 +451,298 @@ func TestTwoNamespacesWithTheSameCollectionNameStaySeparate(t *testing.T) {
 // change that did not happen.
 func TestDeleteReportsWhetherADocumentWasThere(t *testing.T) {
 	s, _ := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
-	existed, err := s.DeleteDocument(declOf(t, s, "ext/approval-gate", "requests"), "a")
+	existed, err := s.DeleteDocument(declOf(t, s, "ext/approval-gate", "requests"), "a", nil)
 	if err != nil || !existed {
 		t.Fatalf("first delete: existed=%v err=%v", existed, err)
 	}
-	existed, err = s.DeleteDocument(declOf(t, s, "ext/approval-gate", "requests"), "a")
+	existed, err = s.DeleteDocument(declOf(t, s, "ext/approval-gate", "requests"), "a", nil)
 	if err != nil || existed {
 		t.Fatalf("second delete: existed=%v err=%v", existed, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Revisions and conditional writes
+// ---------------------------------------------------------------------------
+
+func rev(n int64) *int64 { return &n }
+
+// requestsDecl is the declaration every conditional-write test writes through.
+func requestsDecl(t *testing.T, s *Store) docstore.CollectionSchema {
+	t.Helper()
+	return declOf(t, s, "ext/approval-gate", "requests")
+}
+
+// A revision is what a reader is handed and what a writer hands back, so it has
+// to advance on every write and be visible on every read.
+func TestARevisionAdvancesWithEveryWrite(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
+	schema := requestsDecl(t, s)
+
+	doc, _, err := s.GetDocument(schema, "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc.Rev != docstore.FirstRev {
+		t.Fatalf("a freshly written document is at rev %d, want %d", doc.Rev, docstore.FirstRev)
+	}
+
+	next, err := s.PutDocument(schema, "a", []byte(`{"status":"approved"}`), base.Add(time.Second), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next != docstore.FirstRev+1 {
+		t.Fatalf("put returned rev %d, want %d", next, docstore.FirstRev+1)
+	}
+	doc, _, err = s.GetDocument(schema, "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc.Rev != next {
+		t.Fatalf("read back rev %d, want the %d the write reported", doc.Rev, next)
+	}
+}
+
+// The whole point: a write built on a version somebody else has replaced is
+// refused, and the document it would have clobbered is untouched.
+func TestAWriteExpectingAStaleRevisionIsRefused(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
+	schema := requestsDecl(t, s)
+
+	read, _, err := s.GetDocument(schema, "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Somebody else writes between that read and the write below.
+	if _, err := s.PutDocument(schema, "a", []byte(`{"status":"approved"}`), base.Add(time.Second), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = s.PutDocument(schema, "a", []byte(`{"status":"rejected"}`), base.Add(2*time.Second), rev(read.Rev))
+	if !docstore.IsConflict(err) {
+		t.Fatalf("stale write returned %v, want a conflict", err)
+	}
+	var conflict *docstore.ConflictError
+	errors.As(err, &conflict)
+	if conflict.Expected != read.Rev || !conflict.Found || conflict.Actual != read.Rev+1 {
+		t.Fatalf("conflict does not name both revisions: %+v", conflict)
+	}
+	if !strings.Contains(err.Error(), "rev 1") || !strings.Contains(err.Error(), "rev 2") {
+		t.Fatalf("conflict message names neither revision: %s", err)
+	}
+
+	doc, _, err := s.GetDocument(schema, "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(doc.Body) != `{"status":"approved"}` {
+		t.Fatalf("the refused write landed anyway: %s", doc.Body)
+	}
+	if doc.Rev != read.Rev+1 {
+		t.Fatalf("the refused write moved the revision to %d", doc.Rev)
+	}
+}
+
+func TestAWriteExpectingTheCurrentRevisionIsAccepted(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
+	schema := requestsDecl(t, s)
+
+	read, _, err := s.GetDocument(schema, "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	next, err := s.PutDocument(schema, "a", []byte(`{"status":"approved"}`), base.Add(time.Second), rev(read.Rev))
+	if err != nil {
+		t.Fatalf("write at the current revision: %v", err)
+	}
+	if next != read.Rev+1 {
+		t.Fatalf("accepted write returned rev %d, want %d", next, read.Rev+1)
+	}
+}
+
+// Expecting a revision expects a document. A missing one has to be refused
+// rather than created: the caller asked to edit something, not to write it.
+func TestExpectingARevisionOnAMissingDocumentCreatesNothing(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
+	schema := requestsDecl(t, s)
+
+	_, err := s.PutDocument(schema, "gone", []byte(`{"status":"pending"}`), base, rev(1))
+	if !docstore.IsConflict(err) {
+		t.Fatalf("writing a missing document at a revision returned %v, want a conflict", err)
+	}
+	var conflict *docstore.ConflictError
+	errors.As(err, &conflict)
+	if conflict.Found {
+		t.Fatalf("conflict claims a document was there: %+v", conflict)
+	}
+	if _, found, err := s.GetDocument(schema, "gone"); err != nil || found {
+		t.Fatalf("the refused write created the document: found=%v err=%v", found, err)
+	}
+}
+
+// Create-only, out of the same field: revisions start at 1, so expecting 0 is
+// expecting nothing to be there.
+func TestExpectingAbsentCreatesOnlyOnce(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{})
+	schema := requestsDecl(t, s)
+
+	first, err := s.PutDocument(schema, "a", []byte(`{"status":"first"}`), base, rev(docstore.ExpectAbsent))
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	if first != docstore.FirstRev {
+		t.Fatalf("create returned rev %d, want %d", first, docstore.FirstRev)
+	}
+
+	_, err = s.PutDocument(schema, "a", []byte(`{"status":"second"}`), base.Add(time.Second), rev(docstore.ExpectAbsent))
+	if !docstore.IsConflict(err) {
+		t.Fatalf("second create returned %v, want a conflict", err)
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("conflict does not say the document is already there: %s", err)
+	}
+	doc, _, err := s.GetDocument(schema, "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(doc.Body) != `{"status":"first"}` {
+		t.Fatalf("the losing create overwrote the winner: %s", doc.Body)
+	}
+}
+
+func TestDeleteExpectingAStaleRevisionKeepsTheDocument(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
+	schema := requestsDecl(t, s)
+
+	if _, err := s.PutDocument(schema, "a", []byte(`{"status":"approved"}`), base.Add(time.Second), nil); err != nil {
+		t.Fatal(err)
+	}
+	existed, err := s.DeleteDocument(schema, "a", rev(docstore.FirstRev))
+	if !docstore.IsConflict(err) {
+		t.Fatalf("stale delete returned existed=%v err=%v, want a conflict", existed, err)
+	}
+	if _, found, _ := s.GetDocument(schema, "a"); !found {
+		t.Fatal("the refused delete removed the document anyway")
+	}
+
+	if _, err := s.DeleteDocument(schema, "a", rev(docstore.FirstRev+1)); err != nil {
+		t.Fatalf("delete at the current revision: %v", err)
+	}
+	if _, found, _ := s.GetDocument(schema, "a"); found {
+		t.Fatal("delete at the current revision left the document")
+	}
+}
+
+// "Delete this if it is not there" cannot be honoured, and must not quietly
+// become an unconditional delete of the document the caller was protecting.
+func TestDeleteCannotExpectTheDocumentToBeAbsent(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
+	schema := requestsDecl(t, s)
+
+	_, err := s.DeleteDocument(schema, "a", rev(docstore.ExpectAbsent))
+	if err == nil {
+		t.Fatal("delete accepted an expectation it cannot act on")
+	}
+	if docstore.IsConflict(err) {
+		t.Fatalf("a nonsensical expectation was reported as a conflict: %v", err)
+	}
+	if _, found, _ := s.GetDocument(schema, "a"); !found {
+		t.Fatal("the refused delete removed the document")
+	}
+}
+
+// The reason revisions exist, run as the race it protects against: several
+// writers reading, changing and writing back the same document at once. Each one
+// retries on conflict, and the counter has to end at the number of increments —
+// a lost update shows up as a number that is short.
+//
+// Against a database file rather than the in-memory store the other tests use.
+// The in-memory one is pinned to a single connection, so it would serialise the
+// writers at the driver and never exercise two of them reaching SQLite at once.
+func TestConcurrentReadModifyWritesLoseNoUpdate(t *testing.T) {
+	base := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	s, err := NewWithDB(filepath.Join(t.TempDir(), "contention.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+		t.Fatalf("define: %v", err)
+	}
+	schema := requestsDecl(t, s)
+	if _, err := s.PutDocument(schema, "counter", []byte(`{"status":"pending","attempts":0}`), base, nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	const (
+		writers    = 8
+		perWriter  = 25
+		maxRetries = 1000 // A tripwire: contention this deep means the loop is wrong.
+	)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, writers)
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				var attempt int
+				for attempt = 0; attempt < maxRetries; attempt++ {
+					doc, found, err := s.GetDocument(schema, "counter")
+					if err != nil || !found {
+						errs <- fmt.Errorf("writer %d read: found=%v err=%w", w, found, err)
+						return
+					}
+					var body map[string]any
+					if err := json.Unmarshal(doc.Body, &body); err != nil {
+						errs <- fmt.Errorf("writer %d decode: %w", w, err)
+						return
+					}
+					body["attempts"] = body["attempts"].(float64) + 1
+					next, err := json.Marshal(body)
+					if err != nil {
+						errs <- fmt.Errorf("writer %d encode: %w", w, err)
+						return
+					}
+					_, err = s.PutDocument(schema, "counter", next, base.Add(time.Second), rev(doc.Rev))
+					if err == nil {
+						break
+					}
+					if !docstore.IsConflict(err) {
+						errs <- fmt.Errorf("writer %d write: %w", w, err)
+						return
+					}
+				}
+				if attempt == maxRetries {
+					errs <- fmt.Errorf("writer %d gave up after %d conflicts on one increment", w, maxRetries)
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+
+	doc, _, err := s.GetDocument(schema, "counter")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(doc.Body, &body); err != nil {
+		t.Fatal(err)
+	}
+	if got := int(body["attempts"].(float64)); got != writers*perWriter {
+		t.Fatalf("counter ended at %d after %d increments; %d update(s) were lost",
+			got, writers*perWriter, writers*perWriter-got)
+	}
+	// Every accepted write advanced the revision exactly once, so the revision is
+	// an independent count of the writes that landed.
+	if want := int64(writers*perWriter) + docstore.FirstRev; doc.Rev != want {
+		t.Fatalf("document is at rev %d after %d accepted writes, want %d", doc.Rev, writers*perWriter, want)
 	}
 }
 
@@ -495,7 +783,7 @@ func TestCountIsScopedToTheCollection(t *testing.T) {
 	if err := s.DefineDocumentCollection(other, base); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.PutDocument(declOf(t, s, "ext/other", "requests"), "z", []byte(`{"status":"x"}`), base); err != nil {
+	if _, err := s.PutDocument(declOf(t, s, "ext/other", "requests"), "z", []byte(`{"status":"x"}`), base, nil); err != nil {
 		t.Fatal(err)
 	}
 	n, err := s.CountDocuments(declOf(t, s, "ext/approval-gate", "requests"))
@@ -554,7 +842,7 @@ func TestDocumentsSurviveReopeningTheDatabase(t *testing.T) {
 	if err := first.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
 		t.Fatalf("define: %v", err)
 	}
-	if err := first.PutDocument(declOf(t, first, "ext/approval-gate", "requests"), "a", []byte(`{"status":"pending"}`), base); err != nil {
+	if _, err := first.PutDocument(declOf(t, first, "ext/approval-gate", "requests"), "a", []byte(`{"status":"pending"}`), base, nil); err != nil {
 		t.Fatalf("put: %v", err)
 	}
 	first.Close()
@@ -797,8 +1085,8 @@ func TestCollectionsWithTheSameFieldNameDoNotShareStorage(t *testing.T) {
 		if err := s.DefineDocumentCollection(schema, now); err != nil {
 			t.Fatalf("define %s: %v", coll, err)
 		}
-		if err := s.PutDocument(declOf(t, s, "ext/approval-gate", coll), coll+"-1",
-			[]byte(`{"status":"`+coll+`"}`), now); err != nil {
+		if _, err := s.PutDocument(declOf(t, s, "ext/approval-gate", coll), coll+"-1",
+			[]byte(`{"status":"`+coll+`"}`), now, nil); err != nil {
 			t.Fatalf("put into %s: %v", coll, err)
 		}
 	}
@@ -1051,5 +1339,87 @@ func TestAPopulatedV88StoreIsCarriedIntoItsOwnTables(t *testing.T) {
 	}
 	if _, err := s.db.Exec(`SELECT 1 FROM documents LIMIT 1`); err == nil {
 		t.Fatal("the shared v88 table is still there")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Migration 90: giving documents already stored a revision
+// ---------------------------------------------------------------------------
+
+// seedPreRevisionDocuments builds a database at migration 89's shape — tables
+// per collection, but no revision column — with documents in it, and rewinds the
+// watermark so reopening replays 90 over real rows.
+func seedPreRevisionDocuments(t *testing.T, dbPath string) {
+	t.Helper()
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("open for seeding: %v", err)
+	}
+	base := time.Date(2026, 8, 3, 9, 0, 0, 0, time.UTC)
+	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+		t.Fatalf("seed declaration: %v", err)
+	}
+	schema := declOf(t, s, "ext/approval-gate", "requests")
+	for _, doc := range []struct{ id, body string }{
+		{"r1", `{"status":"open","attempts":2}`},
+		{"r2", `{"status":"done","attempts":9}`},
+	} {
+		if _, err := s.PutDocument(schema, doc.id, []byte(doc.body), base, nil); err != nil {
+			t.Fatalf("seed %s: %v", doc.id, err)
+		}
+	}
+	// Back to 89: drop the column this migration adds, and forget having run it.
+	if _, err := s.db.Exec(`ALTER TABLE ` + schema.Table + ` DROP COLUMN rev;
+		DELETE FROM schema_migrations WHERE version >= 90;`); err != nil {
+		t.Fatalf("rewind to migration 89: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close seeded database: %v", err)
+	}
+}
+
+// Documents written before revisions existed have to come back with one, and be
+// usable as the token a conditional write hands in — otherwise the first
+// read-modify-write against an upgraded profile is refused forever.
+func TestDocumentsStoredBeforeRevisionsGetTheFirstOne(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "migration-90.db")
+	seedPreRevisionDocuments(t, dbPath)
+
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	defer s.Close()
+
+	schema := declOf(t, s, "ext/approval-gate", "requests")
+	doc, found, err := s.GetDocument(schema, "r1")
+	if err != nil || !found {
+		t.Fatalf("r1 after migration: found=%v err=%v", found, err)
+	}
+	if doc.Rev != docstore.FirstRev {
+		t.Fatalf("a carried document is at rev %d, want %d", doc.Rev, docstore.FirstRev)
+	}
+	if string(doc.Body) != `{"status":"open","attempts":2}` {
+		t.Fatalf("the migration rewrote a body: %s", doc.Body)
+	}
+
+	// The carried revision is a real one: writing against it is accepted, and
+	// writing against the revision it replaces is then refused.
+	next, err := s.PutDocument(schema, "r1", []byte(`{"status":"closed","attempts":2}`),
+		time.Date(2026, 8, 4, 9, 0, 0, 0, time.UTC), rev(doc.Rev))
+	if err != nil {
+		t.Fatalf("conditional write against a carried revision: %v", err)
+	}
+	if next != docstore.FirstRev+1 {
+		t.Fatalf("write returned rev %d, want %d", next, docstore.FirstRev+1)
+	}
+	if _, err := s.PutDocument(schema, "r1", []byte(`{"status":"stale"}`),
+		time.Date(2026, 8, 4, 9, 1, 0, 0, time.UTC), rev(doc.Rev)); !docstore.IsConflict(err) {
+		t.Fatalf("a second write at the carried revision returned %v, want a conflict", err)
+	}
+
+	// Every document in the collection came across, not just the one read above.
+	if got := queryIDs(t, s, docstore.Query{Namespace: "ext/approval-gate", Collection: "requests"}); len(got) != 2 {
+		t.Fatalf("documents after migration = %v, want both", got)
 	}
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -915,6 +915,12 @@ CREATE TABLE IF NOT EXISTS document_collections (
 	// any installed profile may already hold records a user put there by hand.
 	// Applied by applyMigration89.
 	{89, "rebuild the document store as a table per collection", ``},
+	// Gives every document a revision, so a caller can say which version it
+	// meant to overwrite and a write built on a stale read is refused instead of
+	// silently winning. Existing documents start at the first revision: nothing
+	// has ever been written against a revision, so there is no earlier history to
+	// preserve. Applied by applyMigration90.
+	{90, "give every document a revision", ``},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -1185,6 +1191,11 @@ func migrateDB(db *sql.DB, dbPath string) error {
 			}
 		} else if m.version == 89 {
 			if err := applyMigration89(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 90 {
+			if err := applyMigration90(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -2203,6 +2214,55 @@ func applyMigration89(tx *sql.Tx) error {
 	}
 	_, err = tx.Exec(`DROP TABLE document_collections_v88`)
 	return err
+}
+
+// applyMigration90 gives every document a revision, so a write can say which
+// version it meant to replace. Each collection is its own table, so this walks
+// the registry and alters them one by one — the registry is the only list of
+// them, and reading the schema for `doc_%` tables would pick up any table that
+// happened to be named like one.
+//
+// Existing documents start at docstore.FirstRev rather than at zero: a revision
+// is the version a reader was handed, and every document already stored has been
+// readable all along at whatever version it is on now, which is its first.
+//
+// Guarded per table rather than once, so a rewound schema_migrations table
+// finishes a run that stopped part way instead of erroring on the first table it
+// already did.
+func applyMigration90(tx *sql.Tx) error {
+	rows, err := tx.Query(`SELECT id FROM document_collections`)
+	if err != nil {
+		return err
+	}
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return err
+		}
+		ids = append(ids, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	for _, id := range ids {
+		table := docstore.TableName(id)
+		has, err := columnExists(tx, table, "rev")
+		if err != nil {
+			return fmt.Errorf("checking %s for a revision column: %w", table, err)
+		}
+		if has {
+			continue
+		}
+		if _, err := tx.Exec(fmt.Sprintf(
+			`ALTER TABLE %s ADD COLUMN rev INTEGER NOT NULL DEFAULT %d`, table, docstore.FirstRev)); err != nil {
+			return fmt.Errorf("adding a revision column to %s: %w", table, err)
+		}
+	}
+	return nil
 }
 
 // v88Collection is one collection to carry across: its declaration as v88


### PR DESCRIPTION
Closes the one place the document store could lose data silently.

`PutDocument` was a blind upsert. Read-modify-write is the natural shape for much
of what will be built on the store — flip a status, append to a list, bump a
counter — and two writers doing it at once left only the second change, with no
error on either side. Every other refusal in the store is loud: an undeclared
collection, a filter on a field nobody declared, a live query whose collection
can no longer answer it. This was the one silent one, and it lost data rather
than a render. It is also the cheapest thing in the store to fix while it is
young: a column and a `WHERE` clause now, versus a change to every caller later.

## What this adds

Every document carries a **revision**, counting writes to it, starting at 1.
Every read reports it and every write returns the new one, so a caller that read
a document already holds the token naming the version it read. A put or delete
may hand that token back as an expectation:

| `expected_rev` | meaning |
| --- | --- |
| absent | write unconditionally |
| a revision | write only if the document is still at it |
| `0` | write only if the document does not exist |

A failed expectation writes nothing and answers with an error naming both
revisions. Delete takes the same expectation minus `0`: "delete this if it is not
there" is not an assertion a delete can act on, and reading it as unconditional
would delete the document the caller was protecting.

From the CLI:

```
$ attn doc put ext/approval-gate requests r1 '{"status":"open"}'
wrote ext/approval-gate/requests/r1 (rev 1)
$ attn doc put ext/approval-gate requests r1 '{"status":"done"}' --expect 1
wrote ext/approval-gate/requests/r1 (rev 2)
$ attn doc put ext/approval-gate requests r1 '{"status":"other"}' --expect 1
doc put: docstore: ext/approval-gate/requests/r1 expected rev 1 but is at rev 2;
re-read it and apply your change to that version
```

`--expect absent` is create-only. `attn doc get`, `query` and `watch` all report
the revision.

## How the check is atomic

Each form is **one statement**, so SQLite runs it in its own transaction and
there is no read-then-write window to lose: an upsert when there is no
expectation, an insert with `ON CONFLICT DO NOTHING` for create-only, and an
`UPDATE ... WHERE rev = ?` with no insert path when a revision is expected. All
three use `RETURNING rev`, so every refusal arrives the same way — no row came
back — and the store re-reads only on that failure path, to name the write the
caller lost to.

A refused write publishes no change fact, so it does not wake the collection's
live queries to re-render a result set that did not change.

## Decisions worth knowing

**Optional, not mandatory.** A write with no expectation still always lands.
Forcing one would make "set this to that" read the document first for no safety.
Safety by default belongs one layer up: the sidecar SDK should expose an
`update(id, fn)` that loops read → modify → write-at-revision and retries the
conflict, so extension code gets this without knowing the word.

**`safeint`, not `int32` or `int64`.** `int64` codegens as a TypeScript *string*
in this pipeline — `main.tsp` already says so where epoch-ms uses `safeint` — and
a revision arriving as `"5"` is one somebody compares with `<` and gets wrong.
`int32` is 2.1 billion writes to *one* document: about seven years at ten writes
a second, which attn's uptime can reach, and a wrapped revision makes a stale
check *pass*, which is the exact failure this exists to prevent. `safeint` is
2^53-1 and costs nothing — SQLite's INTEGER is up to 8 bytes whatever it is
declared as, and it generates Go `int` and TypeScript `number`.

**`DocSubscribeResult.revision` is renamed `delivery`.** It counts deliveries on
a subscription, unrelated to a document's revision, and one word for both reads
as though they were connected. Nothing consumed it — it reached `generated.ts`
and no app code — so it was free now and permanent later. It stays `int32`:
bounded by how long one connection is open.

## Migration 90

One `ALTER TABLE doc_<id> ADD COLUMN rev INTEGER NOT NULL DEFAULT 1` per registry
row, walking the registry rather than the schema so a table merely *named* like a
collection's is not picked up, and guarded per table so a rewound
`schema_migrations` finishes a partial run. Documents already stored start at
revision 1 — a revision is the version a reader was handed, and every stored
document has been readable all along at what is now its first.

## Verification

Both mutations below were applied, seen red, and reverted.

- **Contention, against a database file** (not the in-memory store, which is
  pinned to one connection and would serialise the writers at the driver): 8
  goroutines × 25 read-modify-writes on one document, each retrying on conflict.
  The counter must end at 200. Removing the expectation loses 103–163 updates per
  run.
- **Migration witness**: a database seeded at migration 89's shape with documents
  in it, watermark rewound, reopened. Documents come back at revision 1, bodies
  unrewritten, and a conditional write against the carried revision is accepted
  while a second one at the same revision is refused. Defaulting the column to 0
  instead fails with `a carried document is at rev 0, want 1`.
- **Live**, on a throwaway `docrev` profile built from this branch (preflight
  PASS, protocol matched across CLI, app and daemon): every row of the table
  above through the real CLI, schema at migration 90 on disk, and a `doc watch`
  that saw exactly 2 deliveries across one refused and one accepted write — the
  refused one did not wake it. Profile cleaned up; production `~/.attn` stayed at
  schema 87 throughout.
- Store, docstore, daemon, client, CLI and protocol suites; frontend `tsc` and
  2455 unit tests.

## Surfaces

CLI (`--expect` on put and delete, revision in get/query/watch output), daemon
handlers, protocol (`ProtocolVersion` 208 in both places, `generated.*`
regenerated), glossary, changelog, and a plan doc. No SDK, plugin, harness or
frontend consumer of the document store exists yet, so there was nothing else to
move.

## Known bound

Carried from A3.1: a query filtering on one field and sorting by a different one
still uses a temp B-tree over the matched rows. One composite index per
(filter, sort) pair is combinatorial, so it waits for a receipt.
