### PR TITLE
feat(terminal): draw negative-z kitty images under the text

### DIFF
--- a/app/scripts/real-app-harness/scenario-terminal-kitty-image.mjs
+++ b/app/scripts/real-app-harness/scenario-terminal-kitty-image.mjs
@@ -64,6 +64,11 @@ const IMAGE_HEIGHT = 48;
 // multi-escape path rather than a single-escape shape no real emitter sends.
 const PAYLOAD_CHUNK = 4096;
 const IMAGE_ID = 8801;
+// A negative z-index, which kitty defines as "draw this under the text". It is
+// the one placement field that is a SIGNED int32 all the way from ghostty's
+// storage through the protocol to the client's store, so asserting it comes
+// back as -1 is what proves nothing on that path widened or truncated it.
+const IMAGE_Z = -1;
 
 const BLOB_TIMEOUT_MS = 20_000;
 const PLACEMENT_TIMEOUT_MS = 20_000;
@@ -130,7 +135,7 @@ function checkerboardRGB(width, height) {
 // and eats the next command. That is faithful terminal behavior, not a defect
 // (kitty does the same); real emitters either set q or read the reply
 // themselves. Silencing it keeps the assertions about placements.
-function kittyTransmitAndDisplay(id, width, height) {
+function kittyTransmitAndDisplay(id, width, height, z) {
   const encoded = checkerboardRGB(width, height).toString('base64');
   let out = '';
   let offset = 0;
@@ -140,7 +145,7 @@ function kittyTransmitAndDisplay(id, width, height) {
     offset += part.length;
     const more = offset < encoded.length ? 1 : 0;
     out += first
-      ? `\x1b_Ga=T,i=${id},f=24,t=d,s=${width},v=${height},q=2,m=${more};${part}\x1b\\`
+      ? `\x1b_Ga=T,i=${id},f=24,t=d,s=${width},v=${height},z=${z},q=2,m=${more};${part}\x1b\\`
       : `\x1b_Gm=${more};${part}\x1b\\`;
     first = false;
   }
@@ -231,7 +236,7 @@ async function main() {
   // ESC through shell quoting is how these escapes get silently corrupted.
   const imageFile = path.join(runner.sessionDir, 'kitty-image.bin');
   const deleteFile = path.join(runner.sessionDir, 'kitty-delete.bin');
-  fs.writeFileSync(imageFile, `\n${kittyTransmitAndDisplay(IMAGE_ID, IMAGE_WIDTH, IMAGE_HEIGHT)}\n`, 'binary');
+  fs.writeFileSync(imageFile, `\n${kittyTransmitAndDisplay(IMAGE_ID, IMAGE_WIDTH, IMAGE_HEIGHT, IMAGE_Z)}\n`, 'binary');
   fs.writeFileSync(deleteFile, '\x1b_Ga=d,q=2\x1b\\\n', 'binary');
 
   const defaultEnv = profileEnv(profile);
@@ -355,6 +360,11 @@ async function main() {
         placed.placement,
       );
       runner.assert(placed.placement.visible === true, 'placement is not inside the grid rectangle', placed.placement);
+      runner.assert(
+        placed.placement.z === IMAGE_Z,
+        `placement z = ${placed.placement.z}, want ${IMAGE_Z} — a negative z-index survives ghostty's storage, the wire, and the client's store as a signed int32, and the renderer draws it under the text`,
+        placed.placement,
+      );
       runner.assert(
         placed.state.placements.length === 1,
         `placement set carries ${placed.state.placements.length} entries, want exactly the one image`,

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -1101,6 +1101,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
             sourceY: rect.y,
             sourceWidth: rect.width,
             sourceHeight: rect.height,
+            z: placement.z,
           });
         }
       }

--- a/app/src/components/GhosttyWebGlRenderer.test.ts
+++ b/app/src/components/GhosttyWebGlRenderer.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { GhosttyTerminal } from 'ghostty-web';
+import type { GhosttyCell, GhosttyTerminal } from 'ghostty-web';
 import {
   graphemeAtViewportCell,
   nextAtlasSize,
   visibleOutlineEdges,
   INITIAL_ATLAS_SIZE,
+  KITTY_Z_UNDER_BACKGROUND,
   MAX_ATLAS_SIZE,
   WebGlTerminalRenderer,
+  type WebGlImageQuad,
 } from './GhosttyWebGlRenderer';
 
 function terminalWithHistory(history: number) {
@@ -139,22 +141,96 @@ function makeRecordingContext() {
 
 type RecordingContext = ReturnType<typeof makeRecordingContext>;
 
+// An ordered log of the GL calls that tell the render passes apart. The glyph
+// atlas texture is the first one the renderer creates, so a draw is an image
+// draw exactly when a different texture is bound in front of it — which is how
+// a test reads the pass order out of a frame without owning renderer internals.
+interface RecordedDraw {
+  kind: 'atlas' | 'image';
+  floats: number;
+  vertices: number;
+  firstFloat: number | null;
+}
+
+function makeGlRecorder() {
+  const textures: object[] = [];
+  const calls: Array<
+    | { op: 'bufferData'; floats: number; firstFloat: number | null }
+    | { op: 'drawArrays'; vertices: number }
+    | { op: 'bindTexture'; atlas: boolean }
+  > = [];
+  return {
+    textures,
+    calls,
+    reset() {
+      calls.length = 0;
+    },
+    // One entry per drawArrays, tagged with the texture bound at the time and
+    // the buffer uploaded just before it.
+    draws(): RecordedDraw[] {
+      const draws: RecordedDraw[] = [];
+      let atlasBound = true;
+      let pending: { floats: number; firstFloat: number | null } = { floats: 0, firstFloat: null };
+      for (const call of calls) {
+        if (call.op === 'bindTexture') atlasBound = call.atlas;
+        else if (call.op === 'bufferData') pending = { floats: call.floats, firstFloat: call.firstFloat };
+        else {
+          draws.push({
+            kind: atlasBound ? 'atlas' : 'image',
+            floats: pending.floats,
+            vertices: call.vertices,
+            firstFloat: pending.firstFloat,
+          });
+        }
+      }
+      return draws;
+    },
+  };
+}
+
+type GlRecorder = ReturnType<typeof makeGlRecorder>;
+
 // Any property accessed as a constant (gl.TEXTURE_2D) or called as a no-op
 // method resolves to a throwaway function; only the handful of calls whose
 // return value the renderer actually inspects get real-ish values.
-function makeFakeGl() {
+function makeFakeGl(recorder?: GlRecorder) {
   const truthy = new Set(['getShaderParameter', 'getProgramParameter']);
   const handles = new Set([
     'createShader',
     'createProgram',
     'createBuffer',
-    'createTexture',
     'getUniformLocation',
   ]);
   return new Proxy(
     {},
     {
       get(_target, prop: string) {
+        if (prop === 'createTexture') {
+          return () => {
+            const texture = {};
+            recorder?.textures.push(texture);
+            return texture;
+          };
+        }
+        if (recorder && prop === 'bufferData') {
+          return (_target2: unknown, data: Float32Array) => {
+            recorder.calls.push({
+              op: 'bufferData',
+              floats: data.length,
+              firstFloat: data.length > 0 ? data[0] : null,
+            });
+          };
+        }
+        if (recorder && prop === 'drawArrays') {
+          return (_mode: unknown, _first: number, count: number) => {
+            recorder.calls.push({ op: 'drawArrays', vertices: count });
+          };
+        }
+        if (recorder && prop === 'bindTexture') {
+          return (_target2: unknown, texture: object) => {
+            recorder.calls.push({ op: 'bindTexture', atlas: texture === recorder.textures[0] });
+          };
+        }
         if (truthy.has(prop)) return () => true;
         if (handles.has(prop)) return () => ({});
         if (prop === 'getAttribLocation') return () => 0;
@@ -164,7 +240,7 @@ function makeFakeGl() {
   );
 }
 
-function makeFakeCanvas() {
+function makeFakeCanvas(recorder?: GlRecorder) {
   let ctx2d: RecordingContext | null = null;
   return {
     _w: 0,
@@ -190,7 +266,7 @@ function makeFakeCanvas() {
         return ctx2d;
       }
       if (type === 'webgl2') {
-        return makeFakeGl();
+        return makeFakeGl(recorder);
       }
       return null;
     },
@@ -200,7 +276,7 @@ function makeFakeCanvas() {
   };
 }
 
-function makeRenderer(fontSize = 14, fontFamily = 'monospace') {
+function makeRenderer(fontSize = 14, fontFamily = 'monospace', recorder?: GlRecorder) {
   // Constructor creates two canvases via document.createElement: [0] metrics,
   // [1] atlas. Intercept those; the main canvas is supplied directly.
   const created: ReturnType<typeof makeFakeCanvas>[] = [];
@@ -217,7 +293,7 @@ function makeRenderer(fontSize = 14, fontFamily = 'monospace') {
 
   let renderer: WebGlTerminalRenderer;
   try {
-    const mainCanvas = makeFakeCanvas() as unknown as HTMLCanvasElement;
+    const mainCanvas = makeFakeCanvas(recorder) as unknown as HTMLCanvasElement;
     renderer = new WebGlTerminalRenderer(mainCanvas, fontSize, fontFamily, {
       background: '#000000',
       foreground: '#ffffff',
@@ -232,7 +308,14 @@ function makeRenderer(fontSize = 14, fontFamily = 'monospace') {
   return { renderer: renderer as any, atlasContext };
 }
 
-function makeFakeTerminal(cols: number, rows: number) {
+function makeFakeTerminal(
+  cols: number,
+  rows: number,
+  options: {
+    cell?: (row: number, col: number) => Partial<GhosttyCell>;
+    cursor?: { x: number; y: number; visible: boolean };
+  } = {},
+) {
   const cell = () => ({
     codepoint: 0,
     grapheme_len: 0,
@@ -246,13 +329,145 @@ function makeFakeTerminal(cols: number, rows: number) {
     rows,
     update: () => 1,
     markClean: () => {},
-    getCursor: () => ({ x: 0, y: 0, visible: false }),
-    getViewport: () => Array.from({ length: cols * rows }, cell),
+    getCursor: () => options.cursor ?? { x: 0, y: 0, visible: false },
+    getViewport: () => Array.from({ length: cols * rows }, (_unused, index) => ({
+      ...cell(),
+      ...(options.cell?.(Math.floor(index / cols), index % cols) ?? {}),
+    })),
     getScrollbackLength: () => 0,
     getGraphemeString: () => '',
     getScrollbackGraphemeString: () => '',
   } as unknown as GhosttyTerminal;
 }
+
+// Floats one quad contributes to a vertex buffer: 6 vertices of
+// position(2) + texcoord(2) + color(4) + mode(1).
+const FLOATS_PER_QUAD = 6 * 9;
+
+function makeImageQuad(z: number, x: number, imageId: number): WebGlImageQuad {
+  const width = 2;
+  const height = 2;
+  return {
+    source: {
+      imageId,
+      generation: 1,
+      width,
+      height,
+      format: 'rgba',
+      // byteLength has to match width*height*bytes-per-pixel or the renderer
+      // refuses the blob instead of uploading a texture with a wrong stride.
+      pixels: new Uint8Array(width * height * 4),
+    },
+    x,
+    y: 0,
+    width: 8,
+    height: 8,
+    sourceX: 0,
+    sourceY: 0,
+    sourceWidth: width,
+    sourceHeight: height,
+    z,
+  };
+}
+
+// Kitty's three z layers, read off the frame's draw order. Each case names the
+// bug it catches; all of them are invisible to a quad-count assertion, because
+// the same quads are drawn either way — only the order differs.
+describe('WebGlTerminalRenderer kitty z layering', () => {
+  it('draws a z<0 image between the cell backgrounds and the text', () => {
+    const recorder = makeGlRecorder();
+    const { renderer } = makeRenderer(14, 'monospace', recorder);
+    // One glyph cell and one cell with a non-default background, so both cell
+    // passes carry exactly one quad and the image has to land between them.
+    const terminal = makeFakeTerminal(2, 1, {
+      cell: (_row, col) => (col === 0 ? { codepoint: 65 } : { bg_r: 40, bg_g: 40, bg_b: 40 }),
+    });
+    renderer.resize(2, 1);
+    recorder.reset();
+
+    renderer.render(terminal, true, undefined, undefined, 0, [makeImageQuad(-1, 7, 1)]);
+
+    const draws = recorder.draws();
+    expect(draws.map((draw) => draw.kind)).toEqual(['atlas', 'image', 'atlas']);
+    expect(draws[0].floats).toBe(FLOATS_PER_QUAD); // background pass: the colored cell
+    expect(draws[2].floats).toBe(FLOATS_PER_QUAD); // foreground pass: the glyph
+  });
+
+  it('splits the two deepest layers at the spec constant, exclusive', () => {
+    const recorder = makeGlRecorder();
+    const { renderer } = makeRenderer(14, 'monospace', recorder);
+    const terminal = makeFakeTerminal(1, 1);
+    renderer.resize(1, 1);
+    recorder.reset();
+
+    // Distinct x per quad so the two image draws are told apart by their
+    // vertex data rather than by the order under test.
+    renderer.render(terminal, true, undefined, undefined, 0, [
+      makeImageQuad(KITTY_Z_UNDER_BACKGROUND - 1, 11, 1),
+      makeImageQuad(KITTY_Z_UNDER_BACKGROUND, 22, 2),
+    ]);
+
+    const draws = recorder.draws();
+    expect(draws.map((draw) => draw.kind)).toEqual(['image', 'atlas', 'image', 'atlas']);
+    // Only the one strictly BELOW the constant goes under the backgrounds; the
+    // one at it draws over them, like any other negative z.
+    expect(draws[0].firstFloat).toBe(11 * renderer.dpr);
+    expect(draws[2].firstFloat).toBe(22 * renderer.dpr);
+  });
+
+  it('keeps a z>=0 image above both cell passes', () => {
+    const recorder = makeGlRecorder();
+    const { renderer } = makeRenderer(14, 'monospace', recorder);
+    const terminal = makeFakeTerminal(1, 1);
+    renderer.resize(1, 1);
+    recorder.reset();
+
+    renderer.render(terminal, true, undefined, undefined, 0, [makeImageQuad(0, 0, 1)]);
+
+    expect(recorder.draws().map((draw) => draw.kind)).toEqual(['atlas', 'atlas', 'image']);
+  });
+
+  it('draws the cursor after an under-text image covering its cell', () => {
+    const recorder = makeGlRecorder();
+    const { renderer } = makeRenderer(14, 'monospace', recorder);
+    const terminal = makeFakeTerminal(1, 1, { cursor: { x: 0, y: 0, visible: true } });
+    renderer.resize(1, 1);
+    recorder.reset();
+
+    renderer.render(terminal, true, undefined, undefined, 0, [makeImageQuad(-1, 0, 1)]);
+
+    const draws = recorder.draws();
+    expect(draws.map((draw) => draw.kind)).toEqual(['atlas', 'image', 'atlas']);
+    // The cursor block is a foreground quad, not a cell background: in the
+    // background buffer it would be painted over by the image and disappear.
+    expect(draws[0].floats).toBe(0);
+    expect(draws[2].floats).toBe(FLOATS_PER_QUAD);
+  });
+
+  it('draws a selection tint after an under-text image covering the selection', () => {
+    const recorder = makeGlRecorder();
+    const { renderer } = makeRenderer(14, 'monospace', recorder);
+    const terminal = makeFakeTerminal(1, 1);
+    renderer.resize(1, 1);
+    recorder.reset();
+
+    renderer.render(
+      terminal,
+      true,
+      undefined,
+      [{ startRow: 0, startCol: 0, endRow: 0, endCol: 1, color: '#3366ff', alpha: 0.4, kind: 'background' }],
+      0,
+      [makeImageQuad(-1, 0, 1)],
+    );
+
+    const draws = recorder.draws();
+    expect(draws.map((draw) => draw.kind)).toEqual(['atlas', 'image', 'atlas']);
+    // The tint is an overlay, not a cell background — it has to survive on top
+    // of the image the selection was dragged across.
+    expect(draws[0].floats).toBe(0);
+    expect(draws[2].floats).toBe(FLOATS_PER_QUAD);
+  });
+});
 
 describe('WebGlTerminalRenderer overlays', () => {
   it('emits one background quad per covered cell with full-width middle rows', () => {

--- a/app/src/components/GhosttyWebGlRenderer.ts
+++ b/app/src/components/GhosttyWebGlRenderer.ts
@@ -85,7 +85,17 @@ export interface WebGlImageQuad {
   sourceY: number;
   sourceWidth: number;
   sourceHeight: number;
+  // The placement's kitty z-index, which picks the pass this quad draws in:
+  // over the text at z >= 0, under it below that, and under the cell
+  // backgrounds too past KITTY_Z_UNDER_BACKGROUND.
+  z: number;
 }
+
+// Kitty's deepest layer: "Negative z-index values below INT32_MIN/2
+// (-1,073,741,824) will be drawn under cells with non-default background
+// colors." Below is strict — a placement AT this value draws over the cell
+// backgrounds and under the text, like any other negative z.
+export const KITTY_Z_UNDER_BACKGROUND = -1_073_741_824;
 
 // Live GPU textures per renderer. Receipt: a stored image measured 1.9-6.5MB of
 // decoded pixels, so 16 textures is ~100MB of VRAM worst case and holds every
@@ -446,7 +456,13 @@ export class WebGlTerminalRenderer {
       ? cursorRowInViewport(cursor.y, viewportOffset, terminal.rows)
       : null;
     const cells = viewportCells ?? terminal.getViewport();
-    const vertices: number[] = [];
+    // Two cell passes, so an image can be drawn between them. bgVertices holds
+    // ONLY the per-cell non-default background fills; everything else a cell
+    // paints — selection/search tints, the cursor block, glyphs, underlines —
+    // is foreground, and draws after the under-text images so neither the
+    // cursor nor a selection can vanish behind one.
+    const bgVertices: number[] = [];
+    const fgVertices: number[] = [];
     const glyphCountBefore = this.glyphs.size;
     const atlasGenerationBefore = this.atlasGeneration;
     // Resolve overlays into per-row column spans once per frame so the cell
@@ -502,52 +518,47 @@ export class WebGlTerminalRenderer {
         const bg = this.cellBackground(cell);
 
         if (bg.r !== defaultBg.r || bg.g !== defaultBg.g || bg.b !== defaultBg.b) {
-          this.pushSolidQuad(vertices, x, y, width, this.cellHeight * scale, bg, 1);
+          this.pushSolidQuad(bgVertices, x, y, width, this.cellHeight * scale, bg, 1);
         }
         if (rowSpans) {
           for (const span of rowSpans) {
             if (span.kind === 'background' && col >= span.startCol && col < span.endCol) {
-              this.pushSolidQuad(vertices, x, y, width, this.cellHeight * scale, span.rgb, span.alpha);
+              this.pushSolidQuad(fgVertices, x, y, width, this.cellHeight * scale, span.rgb, span.alpha);
             }
           }
         }
         if (isCursor) {
-          this.pushSolidQuad(vertices, x, y, width, this.cellHeight * scale, cursorBg, 1);
+          this.pushSolidQuad(fgVertices, x, y, width, this.cellHeight * scale, cursorBg, 1);
         }
         if ((cell.flags & CellFlags.INVISIBLE) === 0 && cell.codepoint !== 0 && cell.codepoint !== 32) {
           const alpha = (cell.flags & CellFlags.FAINT) !== 0 ? 0.5 : 1;
-          if (!this.pushBlockElement(vertices, cell.codepoint, x, y, width, this.cellHeight * scale, fg, alpha)) {
+          if (!this.pushBlockElement(fgVertices, cell.codepoint, x, y, width, this.cellHeight * scale, fg, alpha)) {
             const text = cell.grapheme_len > 0
               ? graphemeAtViewportCell(terminal, row, col, viewportOffset)
               : String.fromCodePoint(cell.codepoint);
             const glyph = this.getGlyph(text, cell.flags);
-            this.pushTexturedQuad(vertices, x, y, glyph.width, glyph.height, glyph, fg, alpha);
+            this.pushTexturedQuad(fgVertices, x, y, glyph.width, glyph.height, glyph, fg, alpha);
           }
         }
         if ((cell.flags & CellFlags.UNDERLINE) !== 0) {
-          this.pushSolidQuad(vertices, x, y + (this.baseline + 2) * scale, width, scale, fg, 1);
+          this.pushSolidQuad(fgVertices, x, y + (this.baseline + 2) * scale, width, scale, fg, 1);
         }
         if ((cell.flags & CellFlags.STRIKETHROUGH) !== 0) {
-          this.pushSolidQuad(vertices, x, y + Math.floor(this.cellHeight / 2) * scale, width, scale, fg, 1);
+          this.pushSolidQuad(fgVertices, x, y + Math.floor(this.cellHeight / 2) * scale, width, scale, fg, 1);
         }
         if (rowSpans) {
           for (const span of rowSpans) {
             if (span.kind === 'underline' && col >= span.startCol && col < span.endCol) {
-              this.pushSolidQuad(vertices, x, y + (this.baseline + 2) * scale, width, scale, span.rgb, span.alpha);
+              this.pushSolidQuad(fgVertices, x, y + (this.baseline + 2) * scale, width, scale, span.rgb, span.alpha);
             }
           }
         }
       }
     }
 
-    // Images draw between the cells and the outlines, so a selected block's
-    // border stays legible over one. That ordering is the only reason the two
-    // are ever separate arrays: with no images the outlines go straight into
-    // the cell vertices and the frame is the same single draw call it has
-    // always been.
-    const imageQuads = images ?? [];
+    // Outlines are the last thing on the frame, after every image pass, so a
+    // selected block's border stays legible over an image drawn above the text.
     const outlineVertices: number[] = [];
-    const outlineTarget = imageQuads.length > 0 ? outlineVertices : vertices;
 
     for (const outline of outlines) {
       const top = Math.max(0, outline.startRow) * this.cellHeight * scale;
@@ -562,13 +573,13 @@ export class WebGlTerminalRenderer {
       // look like a box wrapping the whole terminal.
       const { drawTop, drawBottom } = visibleOutlineEdges(outline.startRow, outline.endRow, terminal.rows);
       if (drawTop) {
-        this.pushSolidQuad(outlineTarget, left, top, right - left, thickness, outline.rgb, outline.alpha);
+        this.pushSolidQuad(outlineVertices, left, top, right - left, thickness, outline.rgb, outline.alpha);
       }
       if (drawBottom) {
-        this.pushSolidQuad(outlineTarget, left, bottom - thickness, right - left, thickness, outline.rgb, outline.alpha);
+        this.pushSolidQuad(outlineVertices, left, bottom - thickness, right - left, thickness, outline.rgb, outline.alpha);
       }
-      this.pushSolidQuad(outlineTarget, left, top, thickness, bottom - top, outline.rgb, outline.alpha);
-      this.pushSolidQuad(outlineTarget, right - thickness, top, thickness, bottom - top, outline.rgb, outline.alpha);
+      this.pushSolidQuad(outlineVertices, left, top, thickness, bottom - top, outline.rgb, outline.alpha);
+      this.pushSolidQuad(outlineVertices, right - thickness, top, thickness, bottom - top, outline.rgb, outline.alpha);
     }
 
     if (this.atlasGeneration !== atlasGenerationBefore && !this.retryingAtlasFrame) {
@@ -580,15 +591,27 @@ export class WebGlTerminalRenderer {
       }
     }
 
+    // Kitty's three z tiers, in draw order. The set is tiny (0 to a handful),
+    // so it is filtered rather than assumed sorted; within a tier the caller's
+    // order is kept, which is the placement store's z-then-id order.
+    const imageQuads = images ?? [];
+    const underBackground = imageQuads.filter((q) => q.z < KITTY_Z_UNDER_BACKGROUND);
+    const underText = imageQuads.filter((q) => q.z >= KITTY_Z_UNDER_BACKGROUND && q.z < 0);
+    const overText = imageQuads.filter((q) => q.z >= 0);
+
     gl.useProgram(this.program);
     gl.bindTexture(gl.TEXTURE_2D, this.texture);
     gl.bindBuffer(gl.ARRAY_BUFFER, this.buffer);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(vertices), gl.DYNAMIC_DRAW);
     gl.uniform2f(gl.getUniformLocation(this.program, 'u_resolution'), this.canvas.width, this.canvas.height);
-    gl.drawArrays(gl.TRIANGLES, 0, vertices.length / FLOATS_PER_VERTEX);
     let imageQuadsDrawn = 0;
-    if (imageQuads.length > 0) {
-      imageQuadsDrawn = this.drawImages(imageQuads, scale);
+    imageQuadsDrawn += this.drawImages(underBackground, scale);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(bgVertices), gl.DYNAMIC_DRAW);
+    gl.drawArrays(gl.TRIANGLES, 0, bgVertices.length / FLOATS_PER_VERTEX);
+    imageQuadsDrawn += this.drawImages(underText, scale);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(fgVertices), gl.DYNAMIC_DRAW);
+    gl.drawArrays(gl.TRIANGLES, 0, fgVertices.length / FLOATS_PER_VERTEX);
+    imageQuadsDrawn += this.drawImages(overText, scale);
+    if (outlineVertices.length > 0) {
       gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(outlineVertices), gl.DYNAMIC_DRAW);
       gl.drawArrays(gl.TRIANGLES, 0, outlineVertices.length / FLOATS_PER_VERTEX);
     }
@@ -596,7 +619,7 @@ export class WebGlTerminalRenderer {
     return {
       cpuSubmitMs: performance.now() - startedAt,
       cells: terminal.cols * terminal.rows,
-      quads: (vertices.length + outlineVertices.length) / FLOATS_PER_VERTEX / 6 + imageQuadsDrawn,
+      quads: (bgVertices.length + fgVertices.length + outlineVertices.length) / FLOATS_PER_VERTEX / 6 + imageQuadsDrawn,
       glyphUploads: this.glyphs.size - glyphCountBefore,
       cellsArrayLen: cells.length,
       printableSkippedNull,
@@ -615,16 +638,18 @@ export class WebGlTerminalRenderer {
     this.glyphs.clear();
   }
 
-  // One textured quad per image, each with its own texture, drawn after the
-  // single cell call. Placements are rare (0 to a handful), so a few extra tiny
-  // draw calls cost less than threading a second sampler through the shader the
-  // grid renderer shares. Returns how many actually drew.
+  // One textured quad per image, each with its own texture. Called once per z
+  // tier, so it must leave the GL state exactly as it found it — the cell and
+  // outline passes run between the calls. Placements are rare (0 to a handful),
+  // so a few extra tiny draw calls cost less than threading a second sampler
+  // through the shader the grid renderer shares. Returns how many actually drew.
   //
   // The image pass composites with STRAIGHT alpha: the glyph pipeline is
   // premultiplied, but UNPACK_PREMULTIPLY_ALPHA_WEBGL only applies to uploads
-  // from DOM elements, and these pixels arrive as a raw byte view. The blend is
-  // restored before returning so the outline pass that follows is unaffected.
+  // from DOM elements, and these pixels arrive as a raw byte view. The blend and
+  // the bound atlas are both restored before returning.
   private drawImages(quads: readonly WebGlImageQuad[], scale: number): number {
+    if (quads.length === 0) return 0;
     const gl = this.gl;
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
     let drawn = 0;
@@ -656,8 +681,8 @@ export class WebGlTerminalRenderer {
       drawn += 1;
     }
     gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
-    // The outline pass samples the glyph atlas's solid texel, so hand the unit
-    // back before returning.
+    // The cell and outline passes sample the glyph atlas, so hand the unit back
+    // before returning.
     gl.bindTexture(gl.TEXTURE_2D, this.texture);
     return drawn;
   }

--- a/app/src/utils/kittyPlacements.ts
+++ b/app/src/utils/kittyPlacements.ts
@@ -115,11 +115,13 @@ function mapPlacements(
       sourceHeight: p.source_height,
     });
   }
-  // Draw order, and the order every report of the set uses. Every image renders
-  // above the text in v1 (kitty's z<0 "under text" is deferred — it needs the
-  // cell pass split into background and glyph calls), so z only orders images
-  // against each other; the placement id breaks ties so the order never depends
-  // on how the worker's iterator happened to walk the storage.
+  // Draw order, and the order every report of the set uses. The renderer reads
+  // z again to pick which of kitty's three layers an image lands in — over the
+  // text at z >= 0, under the text below that, under non-default cell
+  // backgrounds too past KITTY_Z_UNDER_BACKGROUND — so this sort is what orders
+  // images against each other within a layer; the placement id breaks ties so
+  // the order never depends on how the worker's iterator happened to walk the
+  // storage.
   placed.sort((a, b) => (a.z - b.z) || (a.placementId - b.placementId));
   return placed;
 }

--- a/changelog.d/cranky-platypus-kitty-z-layering.yaml
+++ b/changelog.d/cranky-platypus-kitty-z-layering.yaml
@@ -1,0 +1,13 @@
+kind: added
+area: terminal
+change: >
+  Kitty images now honor their z-index. An image sent with a negative z draws
+  under the terminal's text instead of on top of it, and one sent below
+  -1073741824 draws under colored cell backgrounds too, matching the kitty
+  spec's three layers. Selections and the cursor stay visible over an image
+  that sits under the text.
+notes: >
+  The wire already carried each placement's z and the client already sorted by
+  it; only the renderer's draw order was missing. The cell pass is now two
+  passes — cell backgrounds, then everything else — so images can be drawn
+  between them.

--- a/docs/plans/2026-08-02-terminal-kitty-images.md
+++ b/docs/plans/2026-08-02-terminal-kitty-images.md
@@ -1157,6 +1157,20 @@ three resync rows, resyncing on every delta reddens the two silent ones).
       already full". The saved fuzz input `62f19a45d7a5c8c7` replays green, and
       `FuzzKittyWireMirror` soaked 15m / 42.5M execs green with the tripwire in
       (the class had been reached 97s into the previous soak).
+- [x] **Kitty z layering, which A3 shipped without.** Every image drew above the
+      text: the wire carried each placement's `z` and the store sorted by it, but
+      the renderer had one cell draw call with nothing to slot an image into.
+      **Fixed by splitting that call in two** — non-default cell backgrounds,
+      then everything else (selection tints, the cursor block, glyphs,
+      underlines) — and drawing the three z tiers around them: below
+      `KITTY_Z_UNDER_BACKGROUND` (-1,073,741,824, the spec's INT32_MIN/2, and
+      "below" is strict) under the backgrounds, `[that, 0)` under the text, and
+      `z >= 0` above it as before. Outlines stay last. The cursor and the
+      selection tint sit in the foreground pass deliberately: in the background
+      pass an under-text image would paint over both. Pinned by the ordering
+      tests in `GhosttyWebGlRenderer.test.ts`, which read the pass order off a
+      recorded GL call log, and by the packaged scenario, which now transmits at
+      `z=-1` so the signed int32 is proved across worker → protocol → store.
 
 #### A4 verification record
 


### PR DESCRIPTION
Kitty images shipped in #749 with a named v1 limitation: every image drew above the text, because the renderer had a single cell draw call with nowhere to slot an image under the glyphs. This removes that limitation.

## What changed

The WebGL renderer's cell pass is now two passes — non-default cell backgrounds, then everything else (glyphs, underlines, selection tints, the cursor block) — and each frame draws image placements in kitty's three z tiers around them:

- `z >= 0`: above the text (unchanged behavior).
- negative `z` down to INT32_MIN/2: under the text, over cell backgrounds.
- below `KITTY_Z_UNDER_BACKGROUND` (−1,073,741,824, the spec's INT32_MIN/2; "below" is strict): under non-default cell backgrounds too.

Two placement decisions are deliberate: the cursor block and overlay tints (selection, search) ride the foreground pass, because in the background pass an under-text image would paint over them — an invisible cursor or a vanishing selection.

No protocol or worker change: the wire has carried each placement's `z` (signed int32) and the client store has sorted by it since A3. `WebGlImageQuad` gains the `z` field and the renderer partitions by it; outlines still draw last.

## Verification

- Five new pass-ordering tests read the frame's draw order off a recording GL stub (image draws are the ones with a non-atlas texture bound): under-text ordering, the strict threshold boundary at ±1, z=0 unchanged, cursor drawn after an under-text image, selection tint drawn after an under-text image. Full frontend suite (2460 tests) and tsc green.
- The packaged scenario `real-app:scenario-terminal-kitty-image` now transmits its image at `z=-1` and asserts the placement reports `z === -1`, proving the signed int32 survives worker → protocol → store. Green on a throwaway profile at this head (both legs, including the `ATTN_KITTY_STORAGE_LIMIT=0` dark leg).
- Live visual proof on the same profile: the same five lines of bold text and the same checkerboard captured twice, differing only in `z`. At `z=-1` the text is readable on top of the image; at `z=0` the image hides it.

https://claude.ai/code/session_01RW553W5Upx9sQh6gX69kgV
