### PR TITLE
fix(sessions): recover the evidence behind a session, not just its state

### DIFF
--- a/changelog.d/snappy-iguana-recovered-session-state.yaml
+++ b/changelog.d/snappy-iguana-recovered-session-state.yaml
@@ -1,0 +1,28 @@
+kind: fixed
+area: sessions
+change: >
+  Restarting the daemon no longer resets every running agent to "launching".
+  Recovery used to overwrite the state of each live session on the theory that
+  a recovered agent had not proved itself yet, and then had nothing left to
+  correct it with: an agent parked at its prompt writes nothing to its
+  terminal, so no fresh evidence ever arrived and it stayed "launching"
+  indefinitely — measured at over two hours on sessions that were simply
+  waiting to be read. Only busy agents recovered, because they repaint their
+  title within a second. A restart is not news about an agent, so the state
+  attn last concluded now stands, and the evidence behind it is recovered
+  rather than discarded: the worker still holds the agent's latest title
+  heartbeat and reports it back, so the resolver can confirm or correct that
+  state on its first tick instead of having nothing to go on. An agent that
+  finished while the daemon was down settles and reaches your queue; one that
+  was waiting on an approval or a question comes back still waiting, unless it
+  visibly moved on in the meantime.
+---
+kind: fixed
+area: queue
+change: >
+  A snoozed agent now comes back. A snooze only opens a turn if the agent is in
+  a state that wants you, and a daemon restart used to leave every agent in
+  "launching" — so when the deadline arrived the deferral was cashed and
+  nothing was delivered: the agent silently left the Snoozed section without
+  ever reaching your queue. Deadlines already survived a restart; now the state
+  they are delivered against does too.

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -560,15 +560,8 @@ func (c *Claude) RecoverOnMissingPTY() bool {
 // RecoveredRunningState mirrors the default recovered-state mapping. Claude has
 // no special recovery needs; the method exists to satisfy
 // RecoveredStatePolicyProvider.
-func (c *Claude) RecoveredRunningState(ptyState string) protocol.SessionState {
-	switch ptyState {
-	case protocol.StateWaitingInput:
-		return protocol.SessionStateWaitingInput
-	case protocol.StatePendingApproval:
-		return protocol.SessionStatePendingApproval
-	default:
-		return protocol.SessionStateLaunching
-	}
+func (c *Claude) RecoveredRunningState(ptyState string) (protocol.SessionState, bool) {
+	return recoveredStateFromPTYClaim(ptyState)
 }
 
 func (c *Claude) ResolveSpawnResumeSessionID(existingSessionID, requestedResumeID, storedResumeID string) string {

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -484,8 +484,11 @@ func (c *Codex) NewTranscriptWatcherBehavior() TranscriptWatcherBehavior {
 	return &codexTranscriptWatcherBehavior{}
 }
 
-func (c *Codex) RecoveredRunningState(ptyState string) protocol.SessionState {
-	return protocol.SessionStateLaunching
+// RecoveredRunningState is always no-opinion: codex announces its approvals in
+// its title, which is a level the resolver reads as evidence, so nothing inside a
+// codex worker ever caches a protocol state to recover.
+func (c *Codex) RecoveredRunningState(ptyState string) (protocol.SessionState, bool) {
+	return "", false
 }
 
 func (c *Codex) ResolveSpawnResumeSessionID(existingSessionID, requestedResumeID, storedResumeID string) string {

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -91,13 +91,11 @@ func (c *Copilot) NewTranscriptWatcherBehavior() TranscriptWatcherBehavior {
 	return &copilotTranscriptWatcherBehavior{}
 }
 
-func (c *Copilot) RecoveredRunningState(ptyState string) protocol.SessionState {
-	switch ptyState {
-	case protocol.StatePendingApproval:
-		return protocol.SessionStatePendingApproval
-	default:
-		return protocol.SessionStateLaunching
+func (c *Copilot) RecoveredRunningState(ptyState string) (protocol.SessionState, bool) {
+	if ptyState == protocol.StatePendingApproval {
+		return protocol.SessionStatePendingApproval, true
 	}
+	return "", false
 }
 
 // --- ClassifierProvider ---

--- a/internal/agent/daemon_policy.go
+++ b/internal/agent/daemon_policy.go
@@ -19,9 +19,10 @@ type SessionRecoveryPolicyProvider interface {
 }
 
 // RecoveredStatePolicyProvider customizes how a recovered session's PTY state
-// maps onto a session state at startup.
+// maps onto a session state at startup. The second return is whether the driver
+// has an opinion at all; see RecoveredRunningSessionState.
 type RecoveredStatePolicyProvider interface {
-	RecoveredRunningState(ptyState string) protocol.SessionState
+	RecoveredRunningState(ptyState string) (protocol.SessionState, bool)
 }
 
 // ResumePolicyProvider customizes resume ID lifecycle behavior.
@@ -70,19 +71,38 @@ func RecoverOnMissingPTY(d Driver) bool {
 	return false
 }
 
-func RecoveredRunningSessionState(d Driver, ptyState string) protocol.SessionState {
+// RecoveredRunningSessionState maps a recovered worker's cached PTY state onto a
+// session state, and reports false when there is nothing there to map.
+//
+// The false case is the common one and it is not a failure: since the screen
+// scraper was deleted, no observer inside a worker names a protocol state, so a
+// running worker's cached state is empty for every agent. It used to be filled
+// in with `launching` on the theory that a recovered session had not proved
+// itself yet — but a daemon restart does not un-run an agent, and the session's
+// persisted state is the last thing the resolver concluded about it. Overwriting
+// that with `launching` discarded the state of every live session on every
+// restart, and left the quiet ones there indefinitely: an agent parked at its
+// prompt paints nothing, so no evidence ever arrived to move it again.
+//
+// So the rule is now the honest one — say something only when the worker
+// actually observed something, and otherwise leave the persisted state alone.
+func RecoveredRunningSessionState(d Driver, ptyState string) (protocol.SessionState, bool) {
 	if p, ok := d.(RecoveredStatePolicyProvider); ok {
 		return p.RecoveredRunningState(ptyState)
 	}
+	return recoveredStateFromPTYClaim(ptyState)
+}
+
+// recoveredStateFromPTYClaim is the shared mapping: the two states a worker can
+// still claim, and no opinion about anything else.
+func recoveredStateFromPTYClaim(ptyState string) (protocol.SessionState, bool) {
 	switch ptyState {
 	case protocol.StateWaitingInput:
-		return protocol.SessionStateWaitingInput
+		return protocol.SessionStateWaitingInput, true
 	case protocol.StatePendingApproval:
-		return protocol.SessionStatePendingApproval
+		return protocol.SessionStatePendingApproval, true
 	default:
-		// Recovered sessions should default to launching unless we have explicit
-		// runtime evidence that the session is waiting for input/approval.
-		return protocol.SessionStateLaunching
+		return "", false
 	}
 }
 

--- a/internal/agent/daemon_policy_test.go
+++ b/internal/agent/daemon_policy_test.go
@@ -47,17 +47,28 @@ func TestRecoveredRunningSessionState_DefaultAndAgentOverrides(t *testing.T) {
 			},
 		},
 	}
-	if got := RecoveredRunningSessionState(defaultDriver, protocol.StateWaitingInput); got != protocol.SessionStateWaitingInput {
-		t.Fatalf("default recovered waiting_input = %s, want waiting_input", got)
+	if got, ok := RecoveredRunningSessionState(defaultDriver, protocol.StateWaitingInput); !ok || got != protocol.SessionStateWaitingInput {
+		t.Fatalf("default recovered waiting_input = %s (ok=%v), want waiting_input", got, ok)
 	}
-	if got := RecoveredRunningSessionState(Get("codex"), protocol.StateWaitingInput); got != protocol.SessionStateLaunching {
-		t.Fatalf("codex recovered waiting_input = %s, want launching", got)
+	if got, ok := RecoveredRunningSessionState(Get("copilot"), protocol.StatePendingApproval); !ok || got != protocol.SessionStatePendingApproval {
+		t.Fatalf("copilot recovered pending_approval = %s (ok=%v), want pending_approval", got, ok)
 	}
-	if got := RecoveredRunningSessionState(Get("codex"), protocol.StatePendingApproval); got != protocol.SessionStateLaunching {
-		t.Fatalf("codex recovered pending_approval = %s, want launching", got)
+	// No opinion, not a state. Codex announces approvals in its title, which the
+	// resolver reads as evidence, so its worker caches nothing to recover; and a
+	// driver with nothing to say must not have `launching` put in its mouth,
+	// because recovery reads that as permission to overwrite the session's real
+	// state.
+	if got, ok := RecoveredRunningSessionState(Get("codex"), protocol.StateWaitingInput); ok {
+		t.Fatalf("codex recovered waiting_input = %s (ok=%v), want no opinion", got, ok)
 	}
-	if got := RecoveredRunningSessionState(Get("copilot"), protocol.StatePendingApproval); got != protocol.SessionStatePendingApproval {
-		t.Fatalf("copilot recovered pending_approval = %s, want pending_approval", got)
+	if got, ok := RecoveredRunningSessionState(Get("codex"), protocol.StatePendingApproval); ok {
+		t.Fatalf("codex recovered pending_approval = %s (ok=%v), want no opinion", got, ok)
+	}
+	if got, ok := RecoveredRunningSessionState(Get("claude"), protocol.StateWorking); ok {
+		t.Fatalf("claude recovered working = %s (ok=%v), want no opinion", got, ok)
+	}
+	if got, ok := RecoveredRunningSessionState(defaultDriver, protocol.StateWorking); ok {
+		t.Fatalf("default recovered working = %s (ok=%v), want no opinion", got, ok)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1383,7 +1383,14 @@ func (d *Daemon) reconcileSessionsWithWorkerBackend(ctx context.Context, allowId
 				label = sessionID
 			}
 
-			state := sessionStateFromRecoveredInfo(info)
+			// A session attn has no row for is genuinely new to it, so `launching`
+			// is the honest starting point here even though it is the wrong answer
+			// for a session being re-adopted below: nothing has been concluded
+			// about this one yet, and the resolver owns it from its first level.
+			state, ok := sessionStateFromRecoveredInfo(info)
+			if !ok {
+				state = protocol.SessionStateLaunching
+			}
 
 			d.store.Add(&protocol.Session{
 				ID:             sessionID,
@@ -1427,8 +1434,23 @@ func (d *Daemon) reconcileSessionsWithWorkerBackend(ctx context.Context, allowId
 				// Persisted plugin reports remain authoritative across daemon recovery.
 				continue
 			}
-			nextState := sessionStateFromRecoveredInfo(info)
-			if existing.State != nextState {
+			// Recovering the evidence is what recovering the session means. The
+			// state in the store is the last thing the resolver concluded, and a
+			// restart is not new information about the agent — but the evidence
+			// behind that conclusion was in memory and died with the old daemon,
+			// so without this the resolver would have nothing to re-justify it
+			// from, and nothing to correct it with either.
+			d.seedRecoveredEvidence(sessionID, existing, info)
+			nextState, ok := sessionStateFromRecoveredInfo(info)
+			if !ok && !resolverOwnedStates[existing.State] {
+				// A live worker contradicts the persisted state, and the resolver has
+				// no standing to correct it — `recoverable` is the revive path's, set
+				// precisely because the worker was gone. Leaving it would strand the
+				// session there for good, so hand it to the resolver at its own entry
+				// point and let the evidence just seeded decide what it really is.
+				nextState, ok = protocol.SessionStateLaunching, true
+			}
+			if ok && existing.State != nextState {
 				d.applyState(sessionStateChange{
 					sessionID: sessionID,
 					state:     string(nextState),
@@ -1439,20 +1461,8 @@ func (d *Daemon) reconcileSessionsWithWorkerBackend(ctx context.Context, allowId
 			}
 			continue
 		}
-		switch existing.State {
-		case protocol.SessionStateWaitingInput, protocol.SessionStatePendingApproval:
-			// Preserve interactive waiting/approval states during recovery.
-		default:
-			if existing.State != protocol.SessionStateLaunching {
-				d.applyState(sessionStateChange{
-					sessionID: sessionID,
-					state:     protocol.StateLaunching,
-					cause:     startupRecovery{},
-				})
-				report.StateUpdated++
-				report.markChanged(sessionID)
-			}
-		}
+		// The worker is live but did not answer `info`. That says nothing about
+		// the agent, so the persisted state stands untouched.
 	}
 
 	for _, session := range d.store.List("") {
@@ -1615,9 +1625,14 @@ func normalizeStoredSessionAgent(agent string, fallback protocol.SessionAgent) p
 	return protocol.NormalizeSessionAgent(fallback, protocol.SessionAgentCodex)
 }
 
-func sessionStateFromRecoveredInfo(info ptybackend.SessionInfo) protocol.SessionState {
+// sessionStateFromRecoveredInfo is what the worker can prove about a session at
+// recovery, and false when it can prove nothing. A worker whose child has exited
+// is the one unambiguous case; beyond that only a driver that still caches a
+// protocol state has anything to say. Everything else is left to the persisted
+// state and the evidence seeded alongside it.
+func sessionStateFromRecoveredInfo(info ptybackend.SessionInfo) (protocol.SessionState, bool) {
 	if !info.Running {
-		return protocol.SessionStateIdle
+		return protocol.SessionStateIdle, true
 	}
 	agent := normalizeStoredSessionAgent(info.Agent, protocol.SessionAgentCodex)
 	return agentdriver.RecoveredRunningSessionState(agentdriver.Get(string(agent)), info.State)
@@ -1928,14 +1943,20 @@ func (d *Daemon) handlePTYState(sessionID string, obs pty.Observation) {
 		d.traceStateVeto(sessionID, origin, state, "plugin_driver_owns_state")
 		return
 	}
-	if session.Agent == protocol.SessionAgentShell {
-		// The worker poll's job is taking an agent session out of `launching`,
-		// and its cached state defaults to `working` until something sets it —
-		// which for a shell is never: no harness observer ever writes it. A
-		// shell spawns `idle` and the resolver owns it from there on its
-		// foreground heartbeat, so a worker-info claim (the watch-subscribe
-		// replay in particular) would only flip it to a state nothing observed.
-		d.traceStateVeto(sessionID, origin, state, "shell_resolver_owned")
+	if session.State != protocol.SessionStateLaunching {
+		// The worker poll's job is taking a session out of `launching`, and that
+		// is the whole of its authority. Its cached state defaults to `working`
+		// until something sets it — which, since the screen scraper was deleted,
+		// is never for any agent — so applied any wider it does not report an
+		// observation, it invents one. The case that made this load-bearing is
+		// the watch-subscribe replay on a daemon restart, which fires once per
+		// live session and would otherwise stamp every one of them `working`
+		// before recovery had a chance to leave their real states alone.
+		//
+		// A shell is the same story from the other end: it spawns `idle` and the
+		// resolver owns it from there on its foreground heartbeat, so no
+		// worker-info claim was ever wanted for one.
+		d.traceStateVeto(sessionID, origin, state, "resolver_owned")
 		return
 	}
 	agent := session.Agent

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1544,55 +1544,64 @@ func TestDaemon_ReconcileSessionsWithWorkerBackend_SkipsRecentlyUpdatedSessions(
 
 func TestSessionStateFromRecoveredInfo(t *testing.T) {
 	tests := []struct {
-		name string
-		info ptybackend.SessionInfo
-		want protocol.SessionState
+		name   string
+		info   ptybackend.SessionInfo
+		want   protocol.SessionState
+		wantOK bool
 	}{
 		{
-			name: "not running is idle",
-			info: ptybackend.SessionInfo{Running: false, State: protocol.StateWorking},
-			want: protocol.SessionStateIdle,
+			name:   "not running is idle",
+			info:   ptybackend.SessionInfo{Running: false, State: protocol.StateWorking},
+			want:   protocol.SessionStateIdle,
+			wantOK: true,
 		},
 		{
-			name: "waiting input",
-			info: ptybackend.SessionInfo{Running: true, Agent: string(protocol.SessionAgentClaude), State: protocol.StateWaitingInput},
-			want: protocol.SessionStateWaitingInput,
+			name:   "waiting input",
+			info:   ptybackend.SessionInfo{Running: true, Agent: string(protocol.SessionAgentClaude), State: protocol.StateWaitingInput},
+			want:   protocol.SessionStateWaitingInput,
+			wantOK: true,
 		},
 		{
-			name: "codex waiting input normalizes to launching",
+			name: "codex waiting input is no opinion",
 			info: ptybackend.SessionInfo{Running: true, Agent: string(protocol.SessionAgentCodex), State: protocol.StateWaitingInput},
-			want: protocol.SessionStateLaunching,
 		},
 		{
-			name: "codex pending approval normalizes to launching",
-			info: ptybackend.SessionInfo{Running: true, State: protocol.StatePendingApproval},
-			want: protocol.SessionStateLaunching,
+			name:   "claude pending approval",
+			info:   ptybackend.SessionInfo{Running: true, Agent: string(protocol.SessionAgentClaude), State: protocol.StatePendingApproval},
+			want:   protocol.SessionStatePendingApproval,
+			wantOK: true,
 		},
 		{
-			name: "claude pending approval",
-			info: ptybackend.SessionInfo{Running: true, Agent: string(protocol.SessionAgentClaude), State: protocol.StatePendingApproval},
-			want: protocol.SessionStatePendingApproval,
+			name:   "copilot pending approval",
+			info:   ptybackend.SessionInfo{Running: true, Agent: string(protocol.SessionAgentCopilot), State: protocol.StatePendingApproval},
+			want:   protocol.SessionStatePendingApproval,
+			wantOK: true,
 		},
+		// The three below are the whole point of the change: a running worker
+		// with nothing observed must not manufacture a state for the session,
+		// because recovery uses "no opinion" to mean "leave the persisted state
+		// alone". `working` is the case that matters most — it is the string a
+		// worker with no observer of its own reports for every agent.
 		{
-			name: "explicit idle running session normalizes to launching",
-			info: ptybackend.SessionInfo{Running: true, Agent: string(protocol.SessionAgentClaude), State: protocol.StateIdle},
-			want: protocol.SessionStateLaunching,
-		},
-		{
-			name: "copilot explicit idle normalizes to launching",
-			info: ptybackend.SessionInfo{Running: true, Agent: string(protocol.SessionAgentCopilot), State: protocol.StateIdle},
-			want: protocol.SessionStateLaunching,
-		},
-		{
-			name: "default working normalizes to launching",
+			name: "running with the worker's default working is no opinion",
 			info: ptybackend.SessionInfo{Running: true, State: protocol.StateWorking},
-			want: protocol.SessionStateLaunching,
+		},
+		{
+			name: "running with an empty state is no opinion",
+			info: ptybackend.SessionInfo{Running: true, Agent: string(protocol.SessionAgentClaude)},
+		},
+		{
+			name: "explicit idle on a running session is no opinion",
+			info: ptybackend.SessionInfo{Running: true, Agent: string(protocol.SessionAgentClaude), State: protocol.StateIdle},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := sessionStateFromRecoveredInfo(tt.info)
-			if got != tt.want {
+			got, ok := sessionStateFromRecoveredInfo(tt.info)
+			if ok != tt.wantOK {
+				t.Fatalf("sessionStateFromRecoveredInfo() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && got != tt.want {
 				t.Fatalf("sessionStateFromRecoveredInfo() = %s, want %s", got, tt.want)
 			}
 		})

--- a/internal/daemon/session_recovered_evidence.go
+++ b/internal/daemon/session_recovered_evidence.go
@@ -1,0 +1,115 @@
+package daemon
+
+import (
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/ptybackend"
+	"github.com/victorarias/attn/internal/sessionstate"
+)
+
+// Recovering a session's evidence after a daemon restart.
+//
+// The evidence table is in memory, so a new daemon starts knowing nothing about
+// agents that have been running for hours. That is survivable for a busy agent —
+// it repaints its title within a second and the table refills itself — and fatal
+// for a quiet one, which writes nothing at all to its PTY and would therefore
+// never produce a single piece of evidence again. The resolver would then have
+// nothing to say about it for the rest of its life.
+//
+// Two things are recoverable without persisting anything, because both sources
+// outlived the daemon:
+//
+//   - The level. The worker holds the last observation its signal observers
+//     emitted, timestamped. A level is a standing claim, so reading it back is
+//     not a guess about the past — it is what the agent is still saying.
+//   - The outstanding harness edge. An approval or a question is not in the
+//     worker, but the session's own persisted state *is* the record that one was
+//     outstanding, and nothing has happened since to answer it.
+//
+// What is deliberately not reconstructed is the bracket pair (turn open, tool
+// open). Those are hook-driven and genuinely gone, and inventing them would hold
+// a session `working` on a bracket whose closing hook can never arrive.
+
+// seedRecoveredEvidence files what the worker and the store between them still
+// know about a re-adopted session, so the resolver has a basis for its first
+// tick instead of an empty row.
+func (d *Daemon) seedRecoveredEvidence(sessionID string, existing *protocol.Session, info ptybackend.SessionInfo) {
+	if d == nil || existing == nil {
+		return
+	}
+	if info.HasLastSignal {
+		// Routed through the ordinary PTY evidence path rather than written
+		// directly: the translation from a title claim to evidence has a case that
+		// matters here — codex announces approvals in its title — and recovery must
+		// not grow a second, subtly different copy of it.
+		d.recordPTYEvidence(sessionID, info.LastSignal)
+	}
+	d.seedRecoveredHarnessEdge(sessionID, existing, info)
+}
+
+// seedRecoveredHarnessEdge restores the "the agent is blocked on a person" edge
+// for a session that was in one of those states when the daemon went down.
+//
+// Without it the level alone decides, and the level cannot tell an agent waiting
+// on an approval from one that has simply finished: both paint the same not-busy
+// glyph. The resolver would read the restored session as a fresh prompt and
+// settle it to idle, which loses the loudest state attn has.
+//
+// The guard is what keeps that from being a lie in the other direction. If the
+// agent painted a title *after* the daemon concluded the approval, then it moved
+// while nobody was watching — the prompt was answered, the turn ran on — and the
+// edge describes a moment that is over. Only a level no newer than the
+// conclusion still corroborates it.
+func (d *Daemon) seedRecoveredHarnessEdge(sessionID string, existing *protocol.Session, info ptybackend.SessionInfo) {
+	claim, ok := recoveredHarnessClaim(existing.State)
+	if !ok {
+		return
+	}
+	concludedAt, ok := parseSessionStateSince(existing)
+	if !ok {
+		return
+	}
+	if info.HasLastSignal && info.LastSignal.At.After(concludedAt) {
+		return
+	}
+	d.recordEvidence(sessionID, concludedAt, func(e *sessionstate.Evidence) {
+		e.LastHarnessEvent = &sessionstate.Observation{
+			Source:     sessionstate.SourceHarnessEvent,
+			Claim:      claim,
+			Detail:     "recovered from persisted state",
+			ObservedAt: concludedAt,
+		}
+		// A session cannot have reached either of these states without having
+		// taken a turn, and the resolver reads "never took a turn" as a session
+		// sitting at a fresh prompt. Saying so keeps a recovered agent from being
+		// described as one that has not started yet.
+		e.TurnEverOpened = true
+	})
+}
+
+// recoveredHarnessClaim maps the two states that mean an outstanding harness edge
+// onto the claim that produced them. Every other state is either resolvable from
+// the level alone or not the resolver's to begin with.
+func recoveredHarnessClaim(state protocol.SessionState) (sessionstate.Claim, bool) {
+	switch state {
+	case protocol.SessionStatePendingApproval:
+		return sessionstate.ClaimApprovalPending, true
+	case protocol.SessionStateWaitingInput:
+		return sessionstate.ClaimNeedsInput, true
+	default:
+		return "", false
+	}
+}
+
+// parseSessionStateSince is when the daemon last concluded the session's current
+// state. It is the timestamp a recovered edge is stamped with, and the one the
+// level is compared against, so an unparseable stamp means no seeding rather
+// than a made-up instant.
+func parseSessionStateSince(session *protocol.Session) (time.Time, bool) {
+	stamp, err := time.Parse(time.RFC3339Nano, session.StateSince)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return stamp, true
+}

--- a/internal/daemon/session_recovered_evidence_test.go
+++ b/internal/daemon/session_recovered_evidence_test.go
@@ -1,0 +1,286 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/attention"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/pty"
+	"github.com/victorarias/attn/internal/ptybackend"
+	"github.com/victorarias/attn/internal/sessionstate"
+)
+
+// heartbeat builds the level a worker reports back for a session it has been
+// running since before this daemon existed.
+func heartbeat(claim string, at time.Time) pty.Observation {
+	return pty.Observation{Source: pty.SourceHeartbeat, Claim: claim, Detail: "a turn summary", At: at}
+}
+
+func addRecoveredSession(t *testing.T, d *Daemon, id string, state protocol.SessionState, stateSince time.Time) {
+	t.Helper()
+	stamp := stateSince.UTC().Format(time.RFC3339Nano)
+	d.store.Add(&protocol.Session{
+		ID:             id,
+		Label:          id,
+		Agent:          protocol.SessionAgentClaude,
+		Directory:      "/tmp/" + id,
+		State:          state,
+		StateSince:     stamp,
+		StateUpdatedAt: stamp,
+		LastSeen:       stamp,
+	})
+}
+
+func runningInfo(signal *pty.Observation) ptybackend.SessionInfo {
+	info := ptybackend.SessionInfo{
+		Running: true,
+		Agent:   string(protocol.SessionAgentClaude),
+		CWD:     "/tmp/recovered",
+		// The literal string a worker with no observer of its own reports for
+		// every agent. Recovery used to read it as a claim.
+		State: protocol.StateWorking,
+	}
+	if signal != nil {
+		info.LastSignal = *signal
+		info.HasLastSignal = true
+	}
+	return info
+}
+
+// The headline: a daemon restart is not new information about an agent, so it
+// must not overwrite what the last daemon concluded. Every one of these states
+// used to come back as `launching`, and for a quiet agent it stayed there — no
+// evidence ever arrives to move a session that is parked at its prompt.
+func TestReconcileKeepsPersistedStateOfLiveSessions(t *testing.T) {
+	states := []protocol.SessionState{
+		protocol.SessionStateIdle,
+		protocol.SessionStateWorking,
+		protocol.SessionStateWaitingInput,
+		protocol.SessionStatePendingApproval,
+		protocol.SessionStateUnknown,
+	}
+	for _, state := range states {
+		t.Run(string(state), func(t *testing.T) {
+			d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+			addRecoveredSession(t, d, "live", state, time.Now().Add(-time.Hour))
+			d.ptyBackend = &fakeWorkerReconcileBackend{
+				liveIDs: []string{"live"},
+				info:    map[string]ptybackend.SessionInfo{"live": runningInfo(nil)},
+			}
+
+			report := d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+			if report.StateUpdated != 0 {
+				t.Fatalf("state_updated = %d, want 0", report.StateUpdated)
+			}
+			if got := d.store.Get("live").State; got != state {
+				t.Fatalf("recovered state = %q, want %q", got, state)
+			}
+		})
+	}
+}
+
+// The worker's child is gone. That is the one thing recovery can still prove on
+// its own, and it must keep proving it.
+func TestReconcileMarksExitedWorkerIdle(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	addRecoveredSession(t, d, "dead", protocol.SessionStateWorking, time.Now().Add(-time.Hour))
+	info := runningInfo(nil)
+	info.Running = false
+	d.ptyBackend = &fakeWorkerReconcileBackend{
+		liveIDs: []string{"dead"},
+		info:    map[string]ptybackend.SessionInfo{"dead": info},
+	}
+
+	d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+	if got := d.store.Get("dead").State; got != protocol.SessionStateIdle {
+		t.Fatalf("recovered state = %q, want idle", got)
+	}
+}
+
+// The level the worker still holds becomes evidence, so the resolver has a basis
+// for its very first tick instead of an empty row it can say nothing about.
+func TestReconcileSeedsHeartbeatEvidenceFromWorker(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	observedAt := time.Now().Add(-2 * time.Minute)
+	addRecoveredSession(t, d, "live", protocol.SessionStateWorking, time.Now().Add(-time.Hour))
+	signal := heartbeat("not_busy", observedAt)
+	d.ptyBackend = &fakeWorkerReconcileBackend{
+		liveIDs: []string{"live"},
+		info:    map[string]ptybackend.SessionInfo{"live": runningInfo(&signal)},
+	}
+
+	d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+	evidence, ok := d.evidenceTable().snapshot("live")
+	if !ok {
+		t.Fatal("no evidence recorded for the recovered session")
+	}
+	if evidence.Heartbeat == nil {
+		t.Fatal("heartbeat evidence missing")
+	}
+	if evidence.Heartbeat.Claim != sessionstate.ClaimSettled {
+		t.Fatalf("heartbeat claim = %q, want settled", evidence.Heartbeat.Claim)
+	}
+	// The real observation time, not the recovery time: a level's age is what
+	// decides whether the resolver still believes it, and stamping it `now` would
+	// make a two-minute-old glyph look freshly painted.
+	if !evidence.Heartbeat.ObservedAt.Equal(observedAt.UTC()) && !evidence.Heartbeat.ObservedAt.Equal(observedAt) {
+		t.Fatalf("heartbeat observed_at = %s, want %s", evidence.Heartbeat.ObservedAt, observedAt)
+	}
+}
+
+// Seeded evidence has to be enough for the resolver to correct a state that went
+// stale while the daemon was down. The agent was working when the daemon died and
+// finished before it came back: its title now says not-busy, and that has to
+// settle the session rather than leave it green forever.
+func TestRecoveredSessionResolvesOffStaleWorking(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	addRecoveredSession(t, d, "live", protocol.SessionStateWorking, time.Now().Add(-time.Hour))
+	signal := heartbeat("not_busy", time.Now().Add(-30*time.Second))
+	d.ptyBackend = &fakeWorkerReconcileBackend{
+		liveIDs: []string{"live"},
+		info:    map[string]ptybackend.SessionInfo{"live": runningInfo(&signal)},
+	}
+	d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+	d.resolveAllSessions(time.Now())
+
+	if got := d.store.Get("live").State; got != protocol.SessionStateIdle {
+		t.Fatalf("resolved state = %q, want idle", got)
+	}
+}
+
+// An agent blocked on an approval paints exactly the same not-busy glyph as one
+// that has finished, so the level alone would settle a recovered approval to
+// idle. The persisted state is the record that the edge was outstanding.
+func TestRecoveredApprovalSurvivesTheResolver(t *testing.T) {
+	for _, tc := range []struct {
+		state protocol.SessionState
+	}{
+		{protocol.SessionStatePendingApproval},
+		{protocol.SessionStateWaitingInput},
+	} {
+		t.Run(string(tc.state), func(t *testing.T) {
+			d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+			concludedAt := time.Now().Add(-10 * time.Minute)
+			addRecoveredSession(t, d, "blocked", tc.state, concludedAt)
+			// Painted before the daemon concluded the state, i.e. nothing has
+			// happened since — which is exactly what an agent sitting on an
+			// unanswered prompt looks like.
+			signal := heartbeat("not_busy", concludedAt.Add(-time.Second))
+			d.ptyBackend = &fakeWorkerReconcileBackend{
+				liveIDs: []string{"blocked"},
+				info:    map[string]ptybackend.SessionInfo{"blocked": runningInfo(&signal)},
+			}
+			d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+			d.resolveAllSessions(time.Now())
+
+			if got := d.store.Get("blocked").State; got != tc.state {
+				t.Fatalf("resolved state = %q, want %q", got, tc.state)
+			}
+		})
+	}
+}
+
+// The other direction, and the reason the edge is not restored unconditionally:
+// the agent painted a title after the daemon concluded the approval, so the
+// prompt was answered and the turn ran on while nobody was watching. Restoring
+// the edge there would pin a session on a question that is already over.
+func TestRecoveredApprovalDropsWhenTheAgentMovedOn(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	concludedAt := time.Now().Add(-10 * time.Minute)
+	addRecoveredSession(t, d, "answered", protocol.SessionStatePendingApproval, concludedAt)
+	signal := heartbeat("not_busy", concludedAt.Add(time.Minute))
+	d.ptyBackend = &fakeWorkerReconcileBackend{
+		liveIDs: []string{"answered"},
+		info:    map[string]ptybackend.SessionInfo{"answered": runningInfo(&signal)},
+	}
+	d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+	evidence, ok := d.evidenceTable().snapshot("answered")
+	if !ok {
+		t.Fatal("no evidence recorded for the recovered session")
+	}
+	if evidence.LastHarnessEvent != nil {
+		t.Fatalf("harness edge restored for an agent that moved on: %+v", evidence.LastHarnessEvent)
+	}
+
+	d.resolveAllSessions(time.Now())
+
+	if got := d.store.Get("answered").State; got != protocol.SessionStateIdle {
+		t.Fatalf("resolved state = %q, want idle", got)
+	}
+}
+
+// The symptom Victor reported, end to end. A snooze is the promise that an agent
+// comes back at a time the user named; the wake only opens a turn if the session
+// is in a state that wants the user, so a recovery that reset the state to
+// `launching` cashed the deadline and delivered nothing. The row left the snoozed
+// band and was never seen again.
+func TestSnoozeWakeSurvivesDaemonRecovery(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	addRecoveredSession(t, d, "snoozed", protocol.SessionStateIdle, time.Now().Add(-time.Hour))
+	deadline := time.Now().Add(time.Hour)
+	if !d.store.SnoozeTurn("snoozed", deadline, time.Now()) {
+		t.Fatal("failed to snooze the session")
+	}
+	d.ptyBackend = &fakeWorkerReconcileBackend{
+		liveIDs: []string{"snoozed"},
+		info:    map[string]ptybackend.SessionInfo{"snoozed": runningInfo(nil)},
+	}
+	d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+	if !attention.OpensTurn(d.store.Get("snoozed").State) {
+		t.Fatalf("recovered state %q opens no turn, so the wake has nothing to deliver",
+			d.store.Get("snoozed").State)
+	}
+
+	d.wakeSnooze("snoozed", deadline, "deadline")
+
+	stamps := d.store.TurnStamps("snoozed")
+	if !stamps.SnoozedUntil.IsZero() {
+		t.Fatalf("snooze still armed after the wake: %s", stamps.SnoozedUntil)
+	}
+	if !stamps.OpenedAt.After(stamps.SettledAt) {
+		t.Fatalf("wake opened no turn: opened=%s settled=%s", stamps.OpenedAt, stamps.SettledAt)
+	}
+}
+
+// A worker-info claim is the invented `working` default, and its only job is
+// ending `launching`. Applied any wider it overwrites a state something actually
+// observed — which on a restart is every live session at once, via the
+// watch-subscribe replay.
+func TestWorkerInfoClaimOnlyEndsLaunching(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		initial protocol.SessionState
+		want    protocol.SessionState
+	}{
+		{"ends launching", protocol.SessionStateLaunching, protocol.SessionStateWorking},
+		{"leaves idle alone", protocol.SessionStateIdle, protocol.SessionStateIdle},
+		{"leaves pending approval alone", protocol.SessionStatePendingApproval, protocol.SessionStatePendingApproval},
+		{"leaves unknown alone", protocol.SessionStateUnknown, protocol.SessionStateUnknown},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+			addRecoveredSession(t, d, "s", tc.initial, time.Now().Add(-time.Hour))
+
+			d.handlePTYState("s", pty.Observation{
+				Source: pty.SourceWorkerInfo,
+				Claim:  protocol.StateWorking,
+				Detail: "watch subscribe replay",
+				At:     time.Now(),
+			})
+
+			if got := d.store.Get("s").State; got != tc.want {
+				t.Fatalf("state = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/daemon/shell_state_test.go
+++ b/internal/daemon/shell_state_test.go
@@ -15,6 +15,10 @@ import (
 // caches state "working" from birth, nothing ever sets a shell worker's state,
 // and the watch-subscribe replay reports that cache as a worker-info claim —
 // which would flip every freshly spawned shell out of `idle`.
+//
+// The veto is no longer shell-specific: no agent's worker caches a real state
+// any more, so a worker-info claim may only end `launching`. A shell never sits
+// there, which is why it is still the sharpest case to pin.
 func TestShellIgnoresTheWorkerPollsStateClaim(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "shell-veto.sock"))
 	const id = "shell-worker-info"
@@ -31,8 +35,8 @@ func TestShellIgnoresTheWorkerPollsStateClaim(t *testing.T) {
 		t.Fatalf("state=%q: the worker poll moved a shell", got)
 	}
 	got := onlyObservation(t, d, id)
-	if got.Outcome != statetrace.OutcomeVetoed || got.Reason != "shell_resolver_owned" {
-		t.Fatalf("trace = %+v, want vetoed/shell_resolver_owned", got)
+	if got.Outcome != statetrace.OutcomeVetoed || got.Reason != "resolver_owned" {
+		t.Fatalf("trace = %+v, want vetoed/resolver_owned", got)
 	}
 }
 

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -492,6 +492,17 @@ func (m *Manager) SessionInfo(sessionID string) (SessionInfo, error) {
 	}, nil
 }
 
+// LastSignal is one session's most recent level observation. It reports false
+// for a session that has produced none, and for an unknown session — both mean
+// "nothing to recover", which is the only thing the caller does differently.
+func (m *Manager) LastSignal(sessionID string) (Observation, bool) {
+	session, err := m.getSession(sessionID)
+	if err != nil {
+		return Observation{}, false
+	}
+	return session.LastSignal()
+}
+
 func (m *Manager) Remove(sessionID string) {
 	m.mu.Lock()
 	session, ok := m.sessions[sessionID]

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -158,6 +158,15 @@ type Session struct {
 	shellSignals *shellSignalArbiter
 	onState      func(obs Observation)
 
+	// lastSignal is the most recent observation either observer emitted, kept so
+	// the level can be *read* rather than only heard as it goes past. A level says
+	// "this is still true", and a daemon that was not running when it was painted
+	// has no other way to learn it: an agent parked at its prompt writes nothing to
+	// the PTY, so a daemon restart would otherwise leave it with no evidence at all
+	// until the user typed. Written by both emitters, read from the info RPC.
+	lastSignalMu sync.RWMutex
+	lastSignal   *Observation
+
 	exitMu     sync.RWMutex
 	running    bool
 	exitCode   *int
@@ -454,12 +463,12 @@ func (s *Session) readLoop(onExit func(exitCode int, signal string), logf func(s
 				// never touches.
 				if s.harnessSignals != nil && s.onState != nil {
 					for _, obs := range s.harnessSignals.Observe(data, time.Now()) {
-						s.onState(obs)
+						s.emitSignal(obs)
 					}
 				}
 				if s.shellSignals != nil && s.onState != nil {
 					for _, obs := range s.shellSignals.ObserveOutput(data, time.Now()) {
-						s.onState(obs)
+						s.emitSignal(obs)
 					}
 				}
 				if len(data) > 0 {
@@ -631,6 +640,30 @@ func parseExitStatus(waitErr error) (int, string) {
 		return -1, status.Signal().String()
 	}
 	return status.ExitStatus(), ""
+}
+
+// emitSignal is the single exit for both signal observers: it remembers the
+// observation before handing it on, so the level survives in a readable form as
+// well as travelling as an event. Both callers run on their own goroutine (the
+// read loop, the shell foreground poller), which is why the field is guarded.
+func (s *Session) emitSignal(obs Observation) {
+	s.lastSignalMu.Lock()
+	stored := obs
+	s.lastSignal = &stored
+	s.lastSignalMu.Unlock()
+	s.onState(obs)
+}
+
+// LastSignal is the most recent level either observer emitted, and false when
+// the session has not produced one. It is what a reconnecting daemon reads to
+// recover evidence it was not running to hear.
+func (s *Session) LastSignal() (Observation, bool) {
+	s.lastSignalMu.RLock()
+	defer s.lastSignalMu.RUnlock()
+	if s.lastSignal == nil {
+		return Observation{}, false
+	}
+	return *s.lastSignal, true
 }
 
 func (s *Session) markExited(exitCode int, signal string) {

--- a/internal/pty/shell_signals.go
+++ b/internal/pty/shell_signals.go
@@ -226,7 +226,7 @@ func (s *Session) runShellForegroundPoller(interval time.Duration) {
 				continue
 			}
 			if obs, ok := s.shellSignals.ObservePoll(fgPgid, time.Now()); ok {
-				s.onState(obs)
+				s.emitSignal(obs)
 			}
 		}
 	}

--- a/internal/ptybackend/backend.go
+++ b/internal/ptybackend/backend.go
@@ -153,6 +153,14 @@ type SessionInfo struct {
 	Running bool
 	State   string
 
+	// LastSignal is the newest level the session's signal observers emitted, and
+	// false when it has produced none. It is evidence rather than a state claim,
+	// and it is what lets a daemon that restarted learn what a quiet agent's
+	// heartbeat currently says instead of waiting for the next repaint that a
+	// session parked at its prompt will never produce.
+	LastSignal    pty.Observation
+	HasLastSignal bool
+
 	Cols    uint16
 	Rows    uint16
 	PID     int

--- a/internal/ptybackend/embedded.go
+++ b/internal/ptybackend/embedded.go
@@ -173,7 +173,7 @@ func (b *EmbeddedBackend) SessionInfo(_ context.Context, sessionID string) (Sess
 	if err != nil {
 		return SessionInfo{}, err
 	}
-	return SessionInfo{
+	result := SessionInfo{
 		SessionID:  info.SessionID,
 		Agent:      info.Agent,
 		CWD:        info.CWD,
@@ -184,7 +184,9 @@ func (b *EmbeddedBackend) SessionInfo(_ context.Context, sessionID string) (Sess
 		LastSeq:    info.LastSeq,
 		ExitCode:   info.ExitCode,
 		ExitSignal: info.ExitSignal,
-	}, nil
+	}
+	result.LastSignal, result.HasLastSignal = b.manager.LastSignal(sessionID)
+	return result, nil
 }
 
 type embeddedStream struct {

--- a/internal/ptybackend/worker.go
+++ b/internal/ptybackend/worker.go
@@ -1019,7 +1019,7 @@ func (b *WorkerBackend) SessionInfo(ctx context.Context, sessionID string) (Sess
 	if err != nil {
 		return SessionInfo{}, err
 	}
-	return SessionInfo{
+	result := SessionInfo{
 		SessionID:  sessionID,
 		Agent:      info.Agent,
 		CWD:        info.CWD,
@@ -1031,7 +1031,24 @@ func (b *WorkerBackend) SessionInfo(ctx context.Context, sessionID string) (Sess
 		LastSeq:    info.LastSeq,
 		ExitCode:   info.ExitCode,
 		ExitSignal: info.ExitSignal,
-	}, nil
+	}
+	// A worker predating these fields sends nothing, which reads as "no level to
+	// recover" — the daemon then leaves the session's persisted state alone
+	// rather than inventing one, which is the same thing it does for a session
+	// that has genuinely never painted a title.
+	if claim := strings.TrimSpace(info.LastSignalClaim); claim != "" {
+		at, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(info.LastSignalAt))
+		if err == nil {
+			result.LastSignal = pty.Observation{
+				Source: pty.Source(info.LastSignalSource),
+				Claim:  claim,
+				Detail: info.LastSignalDetail,
+				At:     at,
+			}
+			result.HasLastSignal = true
+		}
+	}
+	return result, nil
 }
 
 // SessionLaunchParams returns the launch flags the worker recorded in its

--- a/internal/ptyworker/protocol.go
+++ b/internal/ptyworker/protocol.go
@@ -239,6 +239,18 @@ type InfoResult struct {
 	LastSeq   uint32 `json:"last_seq"`
 	State     string `json:"state"`
 
+	// LastSignal* is the newest level the session's signal observers emitted —
+	// the agent's own title heartbeat, or a shell pane's foreground level. It is
+	// evidence, not a state claim, and it is here because the worker outlives the
+	// daemon: an agent parked at its prompt paints nothing, so a daemon that
+	// restarted has no other way to learn what the level currently says. Empty
+	// claim means the session has never produced one, which is also what a worker
+	// predating these fields reports.
+	LastSignalClaim  string `json:"last_signal_claim,omitempty"`
+	LastSignalDetail string `json:"last_signal_detail,omitempty"`
+	LastSignalSource string `json:"last_signal_source,omitempty"`
+	LastSignalAt     string `json:"last_signal_at,omitempty"`
+
 	ExitCode   *int    `json:"exit_code,omitempty"`
 	ExitSignal *string `json:"exit_signal,omitempty"`
 }

--- a/internal/ptyworker/runtime.go
+++ b/internal/ptyworker/runtime.go
@@ -1181,9 +1181,13 @@ func (r *Runtime) infoResult() (InfoResult, error) {
 	exitSignal := r.exitSignal
 	r.stateMu.RUnlock()
 
-	if state == "" {
-		state = "working"
-	}
+	// State is left empty when nothing ever set it, rather than filled in with
+	// `working`. The invented default was read as a claim by everything
+	// downstream — it is what stamped every recovered session `working` and then
+	// `launching` on a daemon restart — and the worker genuinely has no opinion:
+	// no observer has named a protocol state since the screen scraper was
+	// deleted. Saying nothing is the honest answer, and the level below is what
+	// the daemon actually wants.
 	result := InfoResult{
 		Running:   info.Running,
 		Agent:     r.cfg.Agent,
@@ -1194,6 +1198,12 @@ func (r *Runtime) infoResult() (InfoResult, error) {
 		ChildPID:  info.PID,
 		LastSeq:   info.LastSeq,
 		State:     state,
+	}
+	if signal, ok := r.manager.LastSignal(r.cfg.SessionID); ok {
+		result.LastSignalClaim = signal.Claim
+		result.LastSignalDetail = signal.Detail
+		result.LastSignalSource = string(signal.Source)
+		result.LastSignalAt = signal.At.Format(time.RFC3339Nano)
 	}
 	if exitCode != nil {
 		code := *exitCode


### PR DESCRIPTION
Restarting the daemon reset every live session to `launching` and left it there. Worse, it silently swallowed snoozes: an agent you deferred left the Snoozed section at its deadline without ever reaching the queue.

## What was wrong

Three things compounded.

**Reconcile overwrote the persisted state.** Every live session was stomped to `launching` on the theory that a recovered agent had not proved itself yet.

**Nothing could correct it.** The evidence table is in-memory. An agent parked at its prompt writes nothing to its PTY, so no fresh observation ever arrived and the session stayed `launching` indefinitely — production had sessions stuck for over two hours. Only busy agents recovered, because they repaint their title within a second, which is why the bug looked intermittent.

**The worker invented `working`.** `infoResult()` defaulted a blank cached state to `"working"`, a leftover of the deleted screen scraper. That fabricated claim then competed with real evidence.

The snooze loss is downstream of the first. A snooze only opens a turn if the agent is in a state that wants the user. With every agent in `launching` at the deadline, the deferral was cashed and nothing was delivered. Deadlines already survived a restart; the state they are delivered against did not.

## The fix: recover the evidence, not the state

A restart is not news about an agent. The state attn last concluded now stands, and what gets rebuilt is the evidence behind it — from the two sources that outlived the daemon.

**The level.** The worker outlives the daemon, so it now retains the most recent title-heartbeat observation and hands it back over the info RPC. Recovery replays it through the ordinary `recordPTYEvidence` path — codex announces approvals in its title, and recovery must not grow a second interpretation of that. The resolver can then confirm or correct the state on its first tick instead of having nothing to go on.

**The harness edge.** A session persisted as `pending_approval` or `waiting_input` is itself the record of an outstanding edge, so it is re-seeded at the session's `state_since`. It is dropped when the worker's level is newer, so an agent that visibly moved on while the daemon was down does not come back stuck waiting.

The hook-driven bracket pair is deliberately **not** reconstructed. Inventing an open bracket would pin a session `working` on a closing hook that can never arrive — a worse failure than the one being fixed, because nothing would ever retire it.

Two rules changed as a consequence:

- **Recovery writes state only where it has an opinion.** Worker exited → `idle`. Driver reads a real PTY claim → that claim. A session attn has never seen → `launching`. Otherwise the persisted state is left alone. The one carve-out: a live worker contradicting a state the resolver does not own (`recoverable`) falls back to `launching`, because nothing else can ever move a session out of it.
- **A `worker_info` claim may now only end `launching`.** That veto already existed for shells; no worker caches a real state any more, so it is now general.

## Residual gap

Hook-derived evidence is still not persisted. An agent that hits an approval *while the daemon is down* leaves no record, so recovery can only work from what was persisted before the restart. Not addressed here.

## Verification

Live, on throwaway profile `igu1`, a real claude session, two real daemon restarts:

- **Restart 1** — state and snooze both survived. `worker_info` logged `vetoed reason=resolver_owned`; no `startup_recovery claim=launching` appeared at all.
- **Restart 2** — a staged stale `working` was corrected to `idle` with reason `at_prompt` within one second. The agent was silent throughout, so that transition could only come from the seeded worker heartbeat.

Profile cleaned up afterwards.

8 new tests in `internal/daemon/session_recovered_evidence_test.go`, each mutation-tested to confirm which assert actually catches the regression. `GOOS=linux` cross-build green for `cmd/...` and `internal/...`.

Surfaces walked: daemon and app (state broadcasts), worker RPC (`InfoResult` gained omitempty fields; not the app protocol, so no `ProtocolVersion` bump), both pty backends (worker and embedded), all three agent drivers, Linux cross-build, changelog fragment. No CLI or frontend surface — recovery has no command-line or UI entry point.

https://claude.ai/code/session_016u4HyJxy246ypDNyuTuL6W
