### PR TITLE
feat(queue): pause settling while the user is typing

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -69,6 +69,7 @@
     "real-app:scenario-agent-queue-snooze": "node scripts/real-app-harness/scenario-agent-queue-snooze.mjs",
     "real-app:scenario-nudge-trigger": "node scripts/real-app-harness/scenario-nudge-trigger.mjs",
     "real-app:scenario-countdown-cancel": "node scripts/real-app-harness/scenario-countdown-cancel.mjs",
+    "real-app:scenario-settle-typing-hold": "node scripts/real-app-harness/scenario-settle-typing-hold.mjs",
     "real-app:scenario-terminal-block-copy": "node scripts/real-app-harness/scenario-terminal-block-copy.mjs",
     "real-app:scenario-terminal-context-menu": "node scripts/real-app-harness/scenario-terminal-context-menu.mjs",
     "real-app:scenario-terminal-osc8-link": "node scripts/real-app-harness/scenario-terminal-osc8-link.mjs",

--- a/app/scripts/real-app-harness/scenario-settle-typing-hold.mjs
+++ b/app/scripts/real-app-harness/scenario-settle-typing-hold.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+
+/**
+ * Real-app scenario: typing to an agent freezes its settling countdown.
+ *
+ * attn closes a turn for the user once they have steered an agent and it has
+ * gone back to work. The countdown that does it used to run regardless of what
+ * the user was doing, so a turn could close while they were still at the
+ * keyboard writing the next thing. A keystroke now freezes it where it stands
+ * and it stays frozen until five quiet seconds have passed.
+ *
+ * The whole mechanism lives between a real keystroke's route into the daemon and
+ * a timer the daemon owns, which is why it is worth a packaged-app run. Two
+ * writes reach a pane and only one of them is a person: the terminal's own input
+ * path arrives untagged and holds, and an automation write is tagged and must
+ * not — otherwise a delegated agent driving a pane would pin every countdown in
+ * the app open. A unit test can assert both sides of that filter, but only the
+ * real app proves the frontend's typing path is still the untagged one.
+ *
+ * The run asserts, in one app lifecycle:
+ *
+ *   1. typing into a running countdown freezes it — `auto_settle_held` rides the
+ *      wire, the deadline is withdrawn, and the turn stays owed,
+ *   2. the freeze outlives continued typing past the quiet window, so a user who
+ *      keeps composing never has the countdown resume under their hands,
+ *   3. going quiet hands back a *whole* countdown rather than the sliver that was
+ *      left when they started typing, and
+ *   4. an automation write to the same pane does not hold anything.
+ *
+ * The countdown window is deliberately long (60s), so "it expired on its own"
+ * cannot explain the freeze, and a resumed deadline more than 50s out cannot be
+ * the remainder of the one that was frozen.
+ *
+ * Prereqs: `claude` on PATH; a built `./attn` (or ATTN_HARNESS_BIN); a
+ * non-production profile install with the automation layer.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  createSessionAndWaitForInitialPane,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+} from './common.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { createScenarioRunner } from './scenarioRunner.mjs';
+import { currentHarnessProfile } from './harnessProfile.mjs';
+import { preTrustClaudeFolder, ensureClaudePromptReadyViaPty } from './scenarioAgents.mjs';
+import { waitForFirstWorkspacePane } from './scenarioAssertions.mjs';
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// The daemon's quiet window. Mirrored here rather than imported because the
+// scenario is asserting the behavior a user sees, not reading the constant that
+// produces it — a change to one should make this run fail, not follow it.
+const QUIET_WINDOW_MS = 5_000;
+const COUNTDOWN_SECONDS = 60;
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') args.shift();
+  const options = parseCommonArgs(args);
+  return { options, help: args.includes('--help') || args.includes('-h') };
+}
+
+async function pollFor(fn, description, timeoutMs = 60_000, intervalMs = 300) {
+  const startedAt = Date.now();
+  let last = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    last = await fn();
+    if (last) return last;
+    await delay(intervalMs);
+  }
+  throw new Error(`Timed out waiting for: ${description}. Last value: ${JSON.stringify(last)}`);
+}
+
+// A person typing: the terminal's own input path, which reaches the daemon
+// untagged. This is the verb under test — write_pane is tagged `automation` and
+// is deliberately a different thing.
+async function typeLikeAPerson(client, sessionId, paneId, text) {
+  await client.request('type_pane_via_ui', { sessionId, paneId, text });
+}
+
+// Claude treats a fast multi-line write as a paste, so the submit has to be a
+// lone carriage return a beat later.
+async function submitPrompt(client, sessionId, paneId, text) {
+  await client.request('write_pane', { sessionId, paneId, text, submit: false });
+  await delay(600);
+  await client.request('write_pane', { sessionId, paneId, text: '\r', submit: false });
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-settle-typing-hold.mjs');
+    return;
+  }
+
+  const profile = currentHarnessProfile();
+  if (!profile) {
+    throw new Error('the settle-typing-hold scenario does not run against production; set ATTN_PROFILE / ATTN_HARNESS_PROFILE to a named profile');
+  }
+
+  const runner = createScenarioRunner(options, {
+    scenarioId: 'SETTLE-TYPING-HOLD',
+    tier: 'tier3-local-agent',
+    prefix: 'settle-typing-hold',
+    metadata: {
+      agent: 'claude',
+      focus: 'typing to an agent freezes its settling countdown, and going quiet hands back a whole one',
+    },
+  });
+
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  const note = (message, extra) => runner.log(message, extra);
+
+  let agentId = null;
+  let agentPaneId = null;
+
+  runner.log('run context', { runDir: runner.runDir, sessionDir: runner.sessionDir, profile });
+
+  try {
+    await runner.step('launch_app', async () => {
+      await launchFreshAppAndConnect(client, observer);
+    });
+
+    await runner.step('boot_agent_owing_a_turn', async () => {
+      const cwd = path.join(runner.sessionDir, 'agent-repo');
+      fs.mkdirSync(cwd, { recursive: true });
+      preTrustClaudeFolder(cwd);
+      agentId = await createSessionAndWaitForInitialPane({
+        client,
+        observer,
+        cwd,
+        label: `settle-hold-${runner.runId.slice(-6)}`,
+        agent: 'claude',
+        sessionWaitMs: 60_000,
+        promptReadyFn: ensureClaudePromptReadyViaPty,
+        promptReadyTimeoutMs: 90_000,
+      });
+      runner.registerCleanup('close_agent_session', () => client.request('close_session', { sessionId: agentId }));
+      const pane = await waitForFirstWorkspacePane(client, agentId, `pane for ${agentId}`, 20_000);
+      agentPaneId = pane.paneId;
+      await client.request('select_session', { sessionId: agentId });
+
+      // An agent booted to its prompt and not yet spoken to already owes a turn.
+      // Auto-settle only arms on a session that owes one, so this is the
+      // precondition for everything below rather than a claim of its own.
+      await pollFor(
+        () => (observer.getSession(agentId)?.turn_owed === true ? true : null),
+        'the booted agent to owe a turn',
+        90_000,
+      );
+      note('agent booted and owes a turn', { agentId });
+    });
+
+    let frozenDeadline = null;
+
+    await runner.step('typing_freezes_the_running_countdown', async () => {
+      // Arm at the floor so the countdown starts promptly; the countdown itself
+      // is long, so nothing below can be explained by it running out.
+      await client.request('set_setting', { key: 'auto_settle_arm_seconds', value: '5' });
+      await client.request('set_setting', { key: 'auto_settle_countdown_seconds', value: String(COUNTDOWN_SECONDS) });
+      await client.request('set_setting', { key: 'auto_settle_enabled', value: 'true' });
+
+      // Steering is what arms it, and the agent has to still be working when the
+      // arm window elapses — leaving `working` cancels the settle by itself.
+      await submitPrompt(
+        client,
+        agentId,
+        agentPaneId,
+        'Count from 1 to 2000, one number per line, nothing else. Do not use any tools.',
+      );
+      await pollFor(
+        () => (observer.getSession(agentId)?.state === 'working' ? true : null),
+        'the steered agent to start working',
+        90_000,
+      );
+      frozenDeadline = await pollFor(
+        () => observer.getSession(agentId)?.auto_settle_fires_at || null,
+        'the auto-settle countdown to arm',
+        90_000,
+      );
+      const remainingMs = Date.parse(frozenDeadline) - Date.now();
+      note('countdown armed', { firesAt: frozenDeadline, remainingMs });
+      runner.assert(
+        remainingMs > 30_000,
+        `the countdown has far more left than this leg needs (${remainingMs}ms), so expiry cannot explain a freeze`,
+      );
+
+      const running = (await client.request('get_session_ui_state', { sessionId: agentId })).settling;
+      runner.assert(
+        running && running.held === false && running.frozenBar === false && running.text.includes('Settling'),
+        `the pane header is drawing a running countdown before anyone types (${JSON.stringify(running)})`,
+        running,
+      );
+
+      await typeLikeAPerson(client, agentId, agentPaneId, 'and then also');
+
+      const held = await pollFor(
+        () => {
+          const session = observer.getSession(agentId);
+          return session?.auto_settle_held === true ? session : null;
+        },
+        'the keystrokes to freeze the countdown',
+        10_000,
+      );
+      // The two fields are mutually exclusive on purpose: a frozen countdown has
+      // no deadline, which is what stops the tile animating toward one.
+      runner.assert(
+        !held.auto_settle_fires_at,
+        `a frozen countdown carries no deadline (got auto_settle_fires_at=${JSON.stringify(held.auto_settle_fires_at)})`,
+        held,
+      );
+      // A settle that ran would have closed the turn, and leaving `working`
+      // would have cancelled the countdown outright. Neither happened, so the
+      // keystrokes are what froze it.
+      runner.assert(
+        held.state === 'working' && held.turn_owed === true,
+        `the agent is still working and still owes the turn while frozen (state=${JSON.stringify(held.state)}, turn_owed=${JSON.stringify(held.turn_owed)})`,
+        held,
+      );
+      // What the wire says is only half of it. The tile is where the user finds
+      // out a turn is about to close, so the freeze has to be drawn, not just
+      // broadcast.
+      const chip = (await client.request('get_session_ui_state', { sessionId: agentId })).settling;
+      runner.assert(
+        chip && chip.held === true && chip.frozenBar === true && chip.text.toLowerCase().includes('paused'),
+        `the pane header says the countdown is paused and stops animating (${JSON.stringify(chip)})`,
+        chip,
+      );
+      note('countdown frozen by typing', { state: held.state, turn_owed: held.turn_owed, chip });
+    });
+
+    await runner.step('the_freeze_outlives_continued_typing', async () => {
+      // Past the quiet window twice over, with the gaps a person leaves between
+      // words. If the quiet check resumed instead of re-holding, the deadline
+      // would be back before this loop ends — under the user's hands, which is
+      // the bug this feature exists to prevent.
+      const deadline = Date.now() + QUIET_WINDOW_MS * 2.5;
+      let keystrokes = 0;
+      while (Date.now() < deadline) {
+        await delay(2_000);
+        await typeLikeAPerson(client, agentId, agentPaneId, ' more');
+        keystrokes += 1;
+        const session = observer.getSession(agentId);
+        runner.assert(
+          session?.auto_settle_held === true && !session?.auto_settle_fires_at,
+          `the countdown is still frozen while the user keeps typing (held=${JSON.stringify(session?.auto_settle_held)}, firesAt=${JSON.stringify(session?.auto_settle_fires_at)})`,
+          session,
+        );
+      }
+      note('freeze survived continued typing', { keystrokes, forMs: QUIET_WINDOW_MS * 2.5 });
+    });
+
+    await runner.step('going_quiet_hands_back_a_whole_countdown', async () => {
+      // An agent that finished its work while we were typing takes its pending
+      // settle with it — leaving `working` cancels one outright, hold or no hold.
+      // That is correct product behavior and a useless run, so it is separated
+      // from the assertion below rather than folded into a timeout.
+      const resumed = await pollFor(
+        () => {
+          const session = observer.getSession(agentId);
+          if (session?.auto_settle_fires_at) return session;
+          if (session && session.state !== 'working') {
+            throw new Error(`the agent stopped working (state=${session.state}) before the hold could release; its steering task was too short for this run to say anything`);
+          }
+          return null;
+        },
+        'the countdown to come back after the user stopped typing',
+        QUIET_WINDOW_MS * 4,
+      );
+      runner.assert(
+        !resumed.auto_settle_held,
+        `the frozen flag is gone once the countdown is running again (got auto_settle_held=${JSON.stringify(resumed.auto_settle_held)})`,
+        resumed,
+      );
+      const remainingMs = Date.parse(resumed.auto_settle_fires_at) - Date.now();
+      // The frozen bar is drawn full, so the countdown it releases into is a
+      // whole one. A remainder would drop the bar the instant typing stopped —
+      // and by now the original 60s deadline is long past.
+      runner.assert(
+        remainingMs > (COUNTDOWN_SECONDS - 10) * 1_000,
+        `the resumed countdown is a whole one, not the remainder of the frozen one (${remainingMs}ms of ${COUNTDOWN_SECONDS}s)`,
+        { remainingMs, frozenDeadline, resumedDeadline: resumed.auto_settle_fires_at },
+      );
+      const resumedChip = (await client.request('get_session_ui_state', { sessionId: agentId })).settling;
+      runner.assert(
+        resumedChip && resumedChip.held === false && resumedChip.frozenBar === false,
+        `the pane header is animating again once the countdown resumed (${JSON.stringify(resumedChip)})`,
+        resumedChip,
+      );
+      note('countdown resumed whole', { remainingMs, chip: resumedChip });
+    });
+
+    await runner.step('automation_writes_do_not_freeze_it', async () => {
+      // attn typing on the user's behalf — a nudge, a delegation brief, a
+      // harness driving a pane — must not hold a countdown open. Same pane, same
+      // daemon command, different source tag.
+      const before = observer.getSession(agentId)?.auto_settle_fires_at;
+      await client.request('write_pane', { sessionId: agentId, paneId: agentPaneId, text: ' automated', submit: false });
+      await delay(2_000);
+      const after = observer.getSession(agentId);
+      runner.assert(
+        after?.auto_settle_held !== true,
+        `an automation write did not freeze the countdown (got auto_settle_held=${JSON.stringify(after?.auto_settle_held)})`,
+        after,
+      );
+      runner.assert(
+        after?.auto_settle_fires_at === before,
+        `the deadline is untouched by an automation write (${JSON.stringify(before)} -> ${JSON.stringify(after?.auto_settle_fires_at)})`,
+        after,
+      );
+      note('automation write left the countdown alone', { firesAt: after?.auto_settle_fires_at });
+    });
+
+    const summary = runner.finishSuccess({ agentId });
+    console.log('[settle-typing-hold] PASS — typing froze the countdown, kept it frozen, and going quiet handed back a whole one.');
+    console.log(JSON.stringify(summary, null, 2));
+  } catch (error) {
+    const summary = runner.finishFailure(error, { agentId });
+    console.error(summary.error);
+    process.exitCode = 1;
+  } finally {
+    await client.request('set_setting', { key: 'auto_settle_enabled', value: 'false' }).catch(() => {});
+    if (agentId) await client.request('close_session', { sessionId: agentId }).catch(() => {});
+    await client.quitApp().catch(() => {});
+    await observer.close().catch(() => {});
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/scripts/real-app-harness/scenarioCatalog.mjs
+++ b/app/scripts/real-app-harness/scenarioCatalog.mjs
@@ -103,6 +103,14 @@ export const scenarioCatalog = [
     timeoutMs: 420_000,
   },
   {
+    id: 'settle-typing-hold',
+    label: 'Settle typing hold: typing to an agent freezes its settling countdown, and going quiet hands back a whole one',
+    command: ['pnpm', 'run', 'real-app:scenario-settle-typing-hold'],
+    // Boots a real Claude agent, waits out an auto-settle arm window, then types
+    // across two quiet windows; more than the default budget.
+    timeoutMs: 300_000,
+  },
+  {
     id: 'agent-queue',
     label: 'Agent queue: a turn opens on a state and closes only when the user settles it',
     command: ['pnpm', 'run', 'real-app:scenario-agent-queue'],

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1182,6 +1182,7 @@ function AppContent({
       turnOpenedAt: daemonSession?.turn_opened_at,
       turnSnoozedUntil: daemonSession?.turn_snoozed_until,
       autoSettleFiresAt: daemonSession?.auto_settle_fires_at,
+      autoSettleHeld: daemonSession?.auto_settle_held ?? false,
       // Dropped when a pane status overrides the state: the reason describes the
       // resolver's answer, and a pane-derived state was not the resolver's.
       state_reason: paneState ? undefined : daemonSession?.state_reason,
@@ -2918,7 +2919,7 @@ function AppContent({
     const ids: string[] = [];
     for (const session of enrichedLocalSessions) {
       if (!onScreenSessionIds.has(session.id)) continue;
-      if (session.autoSettleFiresAt || session.nudgeFiresAt) ids.push(session.id);
+      if (session.autoSettleFiresAt || session.autoSettleHeld || session.nudgeFiresAt) ids.push(session.id);
     }
     return ids;
   }, [enrichedLocalSessions, onScreenSessionIds]);
@@ -3751,6 +3752,7 @@ function AppContent({
                       ticketUnread: entry.ticketUnread,
                       nudgeFiresAt: entry.nudgeFiresAt,
                       autoSettleFiresAt: entry.autoSettleFiresAt,
+                      autoSettleHeld: entry.autoSettleHeld,
                       isActive: entry.id === activeSessionId,
                       presentation: presentationBySessionId.get(entry.id),
                       ticket: boundTicketForSession(tickets ?? [], entry.id),

--- a/app/src/components/QueueBands.tsx
+++ b/app/src/components/QueueBands.tsx
@@ -19,6 +19,7 @@ export interface QueueBandSessionView {
   turnOpenedAt?: string;
   turnSnoozedUntil?: string;
   autoSettleFiresAt?: string;
+  autoSettleHeld?: boolean;
 }
 
 interface QueueBandsProps {
@@ -199,8 +200,8 @@ function QueueRowView({
           )}
         </div>
       )}
-      {showSettling && session.autoSettleFiresAt && (
-        <SidebarSettlingBar firesAt={session.autoSettleFiresAt} />
+      {showSettling && (session.autoSettleFiresAt || session.autoSettleHeld) && (
+        <SidebarSettlingBar firesAt={session.autoSettleFiresAt} held={session.autoSettleHeld} />
       )}
     </div>
   );

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -124,6 +124,9 @@ interface SessionTerminalWorkspaceProps {
     // The deadline an auto-settle countdown will close this session's turn at.
     // Present only while one is running; the daemon owns the timer.
     autoSettleFiresAt?: string;
+    // True while that countdown is frozen because the user is typing into this
+    // session. Mutually exclusive with the deadline above.
+    autoSettleHeld?: boolean;
     isActive?: boolean;
     presentation?: Presentation;
     // The board row for the ticket bound to this session (assignee == id), when
@@ -906,6 +909,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
         // Only dragging stays split-only: a lone tile has nowhere to move to, so
         // it gets the non-draggable variant.
         const autoSettleFiresAt = paneSession?.autoSettleFiresAt;
+        const autoSettleHeld = paneSession?.autoSettleHeld;
         return (
           <div
             key={agentPane.id}
@@ -965,9 +969,10 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
                   onOpen={(presentationId) => onOpenPresentation?.(presentationId)}
                 />
               ) : null}
-              {autoSettleFiresAt ? (
+              {autoSettleFiresAt || autoSettleHeld ? (
                 <HeaderSettlingIndicator
                   firesAt={autoSettleFiresAt}
+                  held={autoSettleHeld}
                   onCancel={() => onCancelCountdown?.(agentPane.sessionId)}
                 />
               ) : null}

--- a/app/src/components/SettlingIndicator.css
+++ b/app/src/components/SettlingIndicator.css
@@ -123,6 +123,30 @@
   box-shadow: 0 0 9px 1px rgba(var(--settling-accent), 0.7);
 }
 
+/* ---- Held: the user is typing, so the countdown is frozen ----
+
+   The bar keeps its full width and stops moving; the chip dims and its dot stops
+   pulsing. Frozen has to read as "still here, not running" rather than as a
+   countdown at 100%, and stillness is what carries that — the pulsing dot is the
+   only thing on the chip that says a clock is going. */
+
+.settling-header--held {
+  background: rgba(var(--settling-accent), 0.1);
+  border-color: rgba(var(--settling-accent), 0.35);
+  color: #c8bcf0;
+}
+
+.settling-header--held .settling-dot {
+  animation: none;
+  opacity: 0.55;
+  box-shadow: none;
+}
+
+.settling-track-fill--held {
+  opacity: 0.45;
+  box-shadow: none;
+}
+
 @keyframes settling-dot-pulse {
   0%, 100% { opacity: 1; transform: scale(1); }
   50% { opacity: 0.4; transform: scale(0.75); }

--- a/app/src/components/SettlingIndicator.test.tsx
+++ b/app/src/components/SettlingIndicator.test.tsx
@@ -51,6 +51,29 @@ describe('HeaderSettlingIndicator', () => {
 
     expect(onPointerDown).not.toHaveBeenCalled();
   });
+
+  describe('held — the user is typing and the daemon has frozen the countdown', () => {
+    it('says it is paused, and animates nothing', () => {
+      const { container } = render(<HeaderSettlingIndicator held />);
+      expect(screen.getByTestId('settling-indicator')).toHaveTextContent('Settling paused');
+      // No deadline arrives while held, so there is nothing to animate against —
+      // a bar still transitioning here would be counting down to a time the
+      // daemon has withdrawn.
+      const fill = container.querySelector('.settling-header-track-fill') as HTMLElement;
+      expect(fill).toBeTruthy();
+      expect(fill.style.transition).toBe('');
+      expect(fill.classList.contains('settling-track-fill--held')).toBe(true);
+    });
+
+    it('still names the key that stops it for good', () => {
+      // A hold expires by itself; ⌘. is how the user says never mind at all.
+      const onCancel = vi.fn();
+      render(<HeaderSettlingIndicator held onCancel={onCancel} />);
+      expect(screen.getByText('keep')).toBeTruthy();
+      fireEvent.click(screen.getByTestId('settling-indicator'));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 describe('SidebarSettlingBar', () => {
@@ -59,6 +82,17 @@ describe('SidebarSettlingBar', () => {
     const bar = screen.getByTestId('settling-sidebar-bar');
     expect(bar).toBeInTheDocument();
     expect(bar.textContent).toBe('');
+  });
+
+  it('holds the bar full and still while the user types, rather than dropping it', () => {
+    // The row is the only thing on screen representing an off-tile session. A bar
+    // that vanished on the first keystroke and reappeared seconds later would read
+    // as the settle being called off, which it is not.
+    const { container } = render(<SidebarSettlingBar held />);
+    expect(screen.getByTestId('settling-sidebar-bar')).toBeInTheDocument();
+    const fill = container.querySelector('.settling-sidebar-bar-fill') as HTMLElement;
+    expect(fill.style.transition).toBe('');
+    expect(fill.classList.contains('settling-track-fill--held')).toBe(true);
   });
 });
 

--- a/app/src/components/SettlingIndicator.tsx
+++ b/app/src/components/SettlingIndicator.tsx
@@ -15,6 +15,12 @@ import { CountdownCancelHint } from './CountdownCancelHint';
  * is something you notice from across the screen, which is the only way an
  * indicator on a tile you are not focused on does its job.
  *
+ * `auto_settle_held` is the same countdown with the user's hands on the keyboard:
+ * the daemon has frozen it and sent no deadline, so the bar draws full and still.
+ * A full bar rather than a partial one because there is nothing to be partial
+ * about — the deadline is gone, and when typing stops the daemon sends a whole new
+ * one, which is exactly what a full frozen bar promises.
+ *
  * Two homes, so a countdown is never invisible. The pane header is the primary
  * one — the tile is where you are looking when you steered the agent. The sidebar
  * row carries it only for sessions with no rendered tile, since an unwatched
@@ -26,16 +32,18 @@ import { CountdownCancelHint } from './CountdownCancelHint';
 
 export function HeaderSettlingIndicator({
   firesAt,
+  held,
   onCancel,
 }: {
-  firesAt: string;
+  firesAt?: string;
+  held?: boolean;
   onCancel?: () => void;
 }) {
   return (
     <>
       <button
         type="button"
-        className="settling-header"
+        className={held ? 'settling-header settling-header--held' : 'settling-header'}
         // Stop the pane header's pointerdown drag from starting on this button:
         // in a split the header is a leaf-drag handle, so a sloppy click that
         // drifts would relocate the pane instead of keeping the turn.
@@ -49,11 +57,15 @@ export function HeaderSettlingIndicator({
         data-testid="settling-indicator"
       >
         <span className="settling-dot" aria-hidden="true" />
-        <span className="settling-header-label">Settling…</span>
+        <span className="settling-header-label">{held ? 'Settling paused' : 'Settling…'}</span>
         <CountdownCancelHint verb="keep" />
       </button>
       <div className="settling-header-track" aria-hidden="true">
-        <CountdownFill firesAt={firesAt} className="settling-header-track-fill" direction="drain" />
+        {firesAt ? (
+          <CountdownFill firesAt={firesAt} className="settling-header-track-fill" direction="drain" />
+        ) : (
+          <div className="settling-header-track-fill settling-track-fill--held" />
+        )}
       </div>
     </>
   );
@@ -64,14 +76,19 @@ export function HeaderSettlingIndicator({
  * bar on the row plus nothing else — the row is small, and the point here is only
  * that a turn about to close somewhere off-screen is not closed silently.
  */
-export function SidebarSettlingBar({ firesAt }: { firesAt: string }) {
+export function SidebarSettlingBar({ firesAt, held }: { firesAt?: string; held?: boolean }) {
   return (
     <div
       className="settling-sidebar-bar"
       aria-hidden="true"
       data-testid="settling-sidebar-bar"
+      data-held={held ? 'true' : undefined}
     >
-      <CountdownFill firesAt={firesAt} className="settling-sidebar-bar-fill" direction="drain" />
+      {firesAt ? (
+        <CountdownFill firesAt={firesAt} className="settling-sidebar-bar-fill" direction="drain" />
+      ) : (
+        <div className="settling-sidebar-bar-fill settling-track-fill--held" />
+      )}
     </div>
   );
 }

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -36,6 +36,7 @@ interface LocalSession {
   ticketUnread?: boolean;
   nudgeFiresAt?: string;
   autoSettleFiresAt?: string;
+  autoSettleHeld?: boolean;
   state_reason?: string;
   turnOwed?: boolean;
   turnOpenedAt?: string;
@@ -1175,8 +1176,8 @@ export function Sidebar({
                         •••
                       </button>
                     </div>
-                    {session.autoSettleFiresAt && !onScreenSessionIds?.has(session.id) ? (
-                      <SidebarSettlingBar firesAt={session.autoSettleFiresAt} />
+                    {(session.autoSettleFiresAt || session.autoSettleHeld) && !onScreenSessionIds?.has(session.id) ? (
+                      <SidebarSettlingBar firesAt={session.autoSettleFiresAt} held={session.autoSettleHeld} />
                     ) : null}
                     {(() => {
                       const nudgeMode = deriveNudgeMode({

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -197,7 +197,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '208';
+export const PROTOCOL_VERSION = '209';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -552,6 +552,13 @@ function collectSessionUiState(
   const firstAgentPane = firstAgentPaneId
     ? document.querySelector(`[data-pane-session-id="${session.id}"][data-pane-id="${firstAgentPaneId}"]`)
     : null;
+  // The auto-settle indicator as the pane header actually drew it. The wire
+  // carries either a deadline or the frozen flag, never both, and only the DOM
+  // can testify that the tile drew the one it was sent — a running countdown
+  // animating against a deadline, or a still full bar that says attn is waiting
+  // for the user to stop typing.
+  const settlingChip = firstAgentPane?.querySelector('[data-testid="settling-indicator"]') ?? null;
+  const settlingFill = firstAgentPane?.querySelector('.settling-header-track-fill') ?? null;
   const workspaceId = session.workspaceId;
   const workspaceDom = collectWorkspaceShellMetrics(workspaceId);
   const workspaceView = collectWorkspaceViewState(workspaceId);
@@ -579,6 +586,16 @@ function collectSessionUiState(
       splits: collectSplitDomMetrics(workspaceId),
     },
     agentPaneBounds: rectSnapshot(firstAgentPane),
+    settling: settlingChip instanceof HTMLElement
+      ? {
+          text: settlingChip.textContent?.trim() || '',
+          held: settlingChip.classList.contains('settling-header--held'),
+          // A frozen bar carries no width transition, because there is no
+          // deadline to animate toward. That absence is the assertion.
+          frozenBar: Boolean(settlingFill instanceof HTMLElement
+            && settlingFill.classList.contains('settling-track-fill--held')),
+        }
+      : null,
   };
 }
 

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -911,6 +911,7 @@ export enum BranchChangedMessageEvent {
 export interface SessionElement {
     agent:                 string;
     auto_settle_fires_at?: string;
+    auto_settle_held?:     boolean;
     branch?:               string;
     chief_of_staff?:       boolean;
     delegated_from_chief?: boolean;
@@ -4551,6 +4552,7 @@ export enum RuntimeRespawnedMessageEvent {
 export interface Session {
     agent:                 string;
     auto_settle_fires_at?: string;
+    auto_settle_held?:     boolean;
     branch?:               string;
     chief_of_staff?:       boolean;
     delegated_from_chief?: boolean;
@@ -10263,6 +10265,7 @@ const typeMap: any = {
     "SessionElement": o([
         { json: "agent", js: "agent", typ: "" },
         { json: "auto_settle_fires_at", js: "auto_settle_fires_at", typ: u(undefined, "") },
+        { json: "auto_settle_held", js: "auto_settle_held", typ: u(undefined, true) },
         { json: "branch", js: "branch", typ: u(undefined, "") },
         { json: "chief_of_staff", js: "chief_of_staff", typ: u(undefined, true) },
         { json: "delegated_from_chief", js: "delegated_from_chief", typ: u(undefined, true) },
@@ -12459,6 +12462,7 @@ const typeMap: any = {
     "Session": o([
         { json: "agent", js: "agent", typ: "" },
         { json: "auto_settle_fires_at", js: "auto_settle_fires_at", typ: u(undefined, "") },
+        { json: "auto_settle_held", js: "auto_settle_held", typ: u(undefined, true) },
         { json: "branch", js: "branch", typ: u(undefined, "") },
         { json: "chief_of_staff", js: "chief_of_staff", typ: u(undefined, true) },
         { json: "delegated_from_chief", js: "delegated_from_chief", typ: u(undefined, true) },

--- a/changelog.d/sneaky-quokka-typing-pauses-settling.yaml
+++ b/changelog.d/sneaky-quokka-typing-pauses-settling.yaml
@@ -1,0 +1,16 @@
+kind: changed
+area: queue
+change: >
+  Typing to an agent pauses its settling countdown. attn closes a turn for you
+  once you've steered an agent and it has gone back to work, but until now the
+  countdown ran regardless of what you were doing — so a turn could close while
+  you were still at the keyboard writing the next thing. Any key you send to an
+  agent now freezes its countdown where it stands, and the indicator says
+  "Settling paused" instead of draining. Five quiet seconds after your last
+  keystroke it releases and you get the whole countdown back, not the sliver
+  that was left. attn can't see inside an agent's interface, so it doesn't try
+  to tell composing from erasing from pressing Escape — a keystroke means your
+  hands are on that session, which is the only thing the countdown was asking.
+  What it does tell apart is you from attn: a nudge, a delegation brief, or a
+  reattach typing into a session doesn't hold anything open. The pause expires
+  on its own, where Cmd+. still keeps the turn for good.

--- a/internal/daemon/auto_settle.go
+++ b/internal/daemon/auto_settle.go
@@ -395,59 +395,71 @@ func (d *Daemon) runAutoSettle(sessionID string, phase, resume autoSettlePhase) 
 		return "not-owed"
 	}
 
-	// The typing hold, at fire time. Two timers arrive here: a held session's own
-	// quiet check, and — the reason this guard is not only in holdAutoSettle — an
-	// arm or countdown timer that fired in the microseconds around a keystroke,
-	// before the hold could stop it. That race is the one interleaving where a
-	// turn would be closed under the user's hands, so the check is repeated where
-	// the settle actually happens rather than trusted upstream.
-	if quiet := d.userInputQuietRemaining(sessionID, autoSettleHoldQuietWindow); quiet > 0 {
+	// A phase that only moves the timer along can take the typing hold as a plain
+	// check: nothing is committed on the far side of it, so a keystroke that
+	// arrives a moment later still meets a pending timer and freezes it there.
+	if phase == autoSettleHeld || phase == autoSettleArming {
 		hold := phase
 		if phase == autoSettleHeld {
 			hold = resume
 		}
-		d.autoSettleMu.Lock()
-		d.startAutoSettleHeldLocked(sessionID, hold, quiet)
-		d.autoSettleMu.Unlock()
-		return "held"
-	}
-
-	if phase == autoSettleHeld {
-		// Quiet again. The window is read fresh from settings and starts full: a
-		// frozen bar is drawn full, so resuming anything less would drop the bar
-		// on release, and the user has just been typing at this agent — the
-		// countdown they get back is the whole one they would have got by
-		// steering it now.
-		window := cfg.arm
-		if resume == autoSettleCounting {
-			window = cfg.countdown
+		if quiet := d.userInputQuietRemaining(sessionID, autoSettleHoldQuietWindow); quiet > 0 {
+			d.holdFromFire(sessionID, hold, quiet)
+			return "held"
 		}
-		d.autoSettleMu.Lock()
-		d.startAutoSettleLocked(sessionID, resume, window)
-		d.autoSettleMu.Unlock()
-		return "resumed"
-	}
-
-	if phase == autoSettleArming {
+		if phase == autoSettleHeld {
+			// Quiet again. The window is read fresh from settings and starts
+			// full: a frozen bar is drawn full, so resuming anything less would
+			// drop the bar on release, and the user has just been typing at this
+			// agent — the countdown they get back is the whole one they would
+			// have got by steering it now.
+			window := cfg.arm
+			if resume == autoSettleCounting {
+				window = cfg.countdown
+			}
+			d.autoSettleMu.Lock()
+			d.startAutoSettleLocked(sessionID, resume, window)
+			d.autoSettleMu.Unlock()
+			return "resumed"
+		}
 		d.autoSettleMu.Lock()
 		d.startAutoSettleLocked(sessionID, autoSettleCounting, cfg.countdown)
 		d.autoSettleMu.Unlock()
 		return "counting"
 	}
 
-	// Test seam: the instant between "this turn is still owed" and the settle.
-	// Nil in production. It exists because the interleaving that makes this
-	// function dangerous is far too narrow to hit by chance, so the regression
-	// test has to stand in it deliberately.
+	// Test seam: the instant before the settle commits. Nil in production. It
+	// exists because the interleaving that makes this function dangerous — a real
+	// keystroke arriving here, with the timer already pulled out of the map so
+	// the hold it triggers has nothing to freeze — is far too narrow to hit by
+	// chance, and the regression has to stand in it deliberately.
 	if d.autoSettlePreSettleHook != nil {
 		d.autoSettlePreSettleHook()
 	}
 
-	if !d.store.SettleTurn(sessionID, time.Now()) {
+	// The countdown ran out, so this is where the turn closes. The typing hold is
+	// re-asked here rather than above because it has to be indivisible from the
+	// write it guards — settleIfQuiet holds the keystroke lock across both — and
+	// because the countdown timer can have fired in the microseconds around a
+	// keystroke, before holdAutoSettle could stop it.
+	quiet, settled := d.settleIfQuiet(sessionID, autoSettleHoldQuietWindow)
+	if quiet > 0 {
+		d.holdFromFire(sessionID, autoSettleCounting, quiet)
+		return "held"
+	}
+	if !settled {
 		return "settle-failed"
 	}
 	d.traceSettle(sessionID)
 	return "settled"
+}
+
+// holdFromFire parks a session the fire path found the user typing into, with a
+// quiet check exactly at the end of the window their last keystroke opened.
+func (d *Daemon) holdFromFire(sessionID string, resume autoSettlePhase, quiet time.Duration) {
+	d.autoSettleMu.Lock()
+	d.startAutoSettleHeldLocked(sessionID, resume, quiet)
+	d.autoSettleMu.Unlock()
 }
 
 // cancelAutoSettleByUser is the user calling off a pending settle: keep this

--- a/internal/daemon/auto_settle.go
+++ b/internal/daemon/auto_settle.go
@@ -38,6 +38,20 @@ const (
 	// before the turn is settled.
 	defaultAutoSettleCountdownSeconds = 15
 
+	// autoSettleHoldQuietWindow is how long a session must go without a keystroke
+	// before a held countdown resumes. It is the whole of the typing hold's
+	// tuning, and it is not a setting: it measures the user's hands, not the
+	// agent's behavior, so it is orthogonal to the two windows above.
+	//
+	// Five seconds rather than the nudge guard's three, and rather than something
+	// generous. It only has to span the gaps *between* keystrokes while composing
+	// — pausing to read the screen mid-prompt — because the countdown it resumes
+	// into is itself the grace period, visible and cancellable. Stacking a long
+	// quiet window on top of that pays twice for the same protection, and being
+	// wrong here does not settle a turn silently: it unfreezes a bar the user
+	// still has the whole countdown to stop.
+	autoSettleHoldQuietWindow = 5 * time.Second
+
 	// Bounds. The floors keep a countdown watchable and an arm delay long enough
 	// to outlast the resolver's own settle latency (`HeartbeatSettleAfter`, 5s),
 	// so a turn is never closed on an agent the resolver has not finished making
@@ -58,16 +72,40 @@ const (
 	autoSettleArming autoSettlePhase = iota
 	// autoSettleCounting: the countdown is running and its deadline is broadcast.
 	autoSettleCounting
+	// autoSettleHeld: the user is typing into this session, so nothing is
+	// counting. The pending timer is a quiet check, not a deadline — it asks
+	// "have the keystrokes stopped?" and either re-holds or resumes. No deadline
+	// rides the wire; `auto_settle_held` does, and the tile freezes on it.
+	autoSettleHeld
 )
 
 // autoSettleTimer is a session's pending auto-settle. firesAt is stored beside
 // the timer because time.Timer exposes no deadline accessor, and in the counting
 // phase the absolute deadline is what rides the wire for clients to animate
 // against.
+//
+// resume is meaningful only while held: it is the phase the hold came from and
+// will return to, so that typing during the invisible arm delay restarts the arm
+// delay rather than promoting the session to a countdown it never earned.
 type autoSettleTimer struct {
 	timer   *time.Timer
 	phase   autoSettlePhase
+	resume  autoSettlePhase
 	firesAt time.Time
+}
+
+// visible reports whether clients can see this entry, and so whether its
+// appearance or removal owes a broadcast. Arming is silent, and so is a hold of
+// an arm delay: freezing something never announced announces it. Only a
+// countdown — running or frozen — is on screen.
+func (e *autoSettleTimer) visible() bool {
+	switch e.phase {
+	case autoSettleCounting:
+		return true
+	case autoSettleHeld:
+		return e.resume == autoSettleCounting
+	}
+	return false
 }
 
 // autoSettleConfig is the resolved policy: whether the feature is on and the two
@@ -162,6 +200,52 @@ func (d *Daemon) armAutoSettle(sessionID string) {
 	// No broadcast: the arming phase is deliberately invisible.
 }
 
+// holdAutoSettle freezes a pending settle because the user just typed into this
+// session. Called for every genuine keystroke, so its cost on a no-op is one map
+// lookup.
+//
+// Typing is the one thing attn can see through a TUI it has no visibility into.
+// It cannot tell composing from erasing from pressing Escape, and it does not
+// need to: every one of them means the user's hands are on this session, which
+// is the whole question a pending settle is asking. What it must tell apart is
+// the user from attn typing on their behalf, and that distinction is already
+// drawn — noteUserInput drops automation and replay writes before this is
+// reached.
+//
+// A hold is not a cancel. ⌘. means "keep this turn" and stands until the session
+// leaves `working` (autoSettleSuppressed); a hold expires on its own, five quiet
+// seconds later, because the user stopping typing is not the user answering.
+func (d *Daemon) holdAutoSettle(sessionID string) {
+	d.autoSettleMu.Lock()
+	entry, ok := d.autoSettleTimers[sessionID]
+	if !ok || entry.phase == autoSettleHeld {
+		// Nothing pending, or already held. The second case is what keeps a burst
+		// of keystrokes free: the quiet check reschedules itself from the recorded
+		// keystroke time, so only the first key of a burst does any work here.
+		d.autoSettleMu.Unlock()
+		return
+	}
+	resume := entry.phase
+	d.startAutoSettleHeldLocked(sessionID, resume, autoSettleHoldQuietWindow)
+	d.autoSettleMu.Unlock()
+
+	if d.debugLogging {
+		d.logf("auto-settle held: session=%s resume_phase=%d", sessionID, resume)
+	}
+	// Only a countdown was on screen; freezing an arm delay changes nothing a
+	// client can see.
+	if resume == autoSettleCounting {
+		d.broadcastSessionStateChanged(sessionID)
+	}
+}
+
+// startAutoSettleHeldLocked parks the session in the held phase with a quiet
+// check `window` away. Caller holds autoSettleMu.
+func (d *Daemon) startAutoSettleHeldLocked(sessionID string, resume autoSettlePhase, window time.Duration) {
+	d.startAutoSettleLocked(sessionID, autoSettleHeld, window)
+	d.autoSettleTimers[sessionID].resume = resume
+}
+
 // startAutoSettleLocked replaces whatever is pending with a fresh timer in the
 // given phase. Caller holds autoSettleMu.
 //
@@ -199,7 +283,7 @@ func (d *Daemon) stopAutoSettleLocked(sessionID string) (removed, wasVisible boo
 	}
 	entry.timer.Stop()
 	delete(d.autoSettleTimers, sessionID)
-	return true, entry.phase == autoSettleCounting
+	return true, entry.visible()
 }
 
 // cancelAutoSettle drops a pending settle. Broadcasts only when a visible
@@ -248,25 +332,34 @@ func (d *Daemon) autoSettleFire(sessionID string, self *time.Timer) {
 		d.autoSettleMu.Unlock()
 		return
 	}
-	phase := entry.phase
+	phase, resume := entry.phase, entry.resume
 	delete(d.autoSettleTimers, sessionID)
 	d.autoSettleMu.Unlock()
 
-	action := d.runAutoSettle(sessionID, phase)
+	action := d.runAutoSettle(sessionID, phase, resume)
 	if d.debugLogging {
 		d.logf("auto-settle fire: session=%s phase=%d outcome=%s", sessionID, phase, action)
 	}
 	if d.autoSettleFireHook != nil {
 		d.autoSettleFireHook(sessionID, action)
 	}
-	// Broadcast either way: the countdown's deadline has either just appeared
-	// (arm elapsed) or just gone (settled, or the preconditions lapsed).
+	// A hold that froze a running countdown is a picture change and rides the
+	// wire. A re-hold, or a hold of the invisible arm delay, is not: while the
+	// user keeps typing this fires every five seconds, and a snapshot push per
+	// quiet check is traffic for a picture that never moved.
+	if action == "held" && phase != autoSettleCounting {
+		return
+	}
+	// Otherwise broadcast either way: the countdown's deadline has just appeared
+	// (arm elapsed, or a hold released), just gone (settled, frozen, or the
+	// preconditions lapsed), or the turn itself has closed.
 	d.broadcastSessionStateChanged(sessionID)
 }
 
 // runAutoSettle is the fire-time decision, separated so its outcome is a single
-// string a test hook can assert.
-func (d *Daemon) runAutoSettle(sessionID string, phase autoSettlePhase) string {
+// string a test hook can assert. `resume` is the phase a held session goes back
+// to, and is read only in that phase.
+func (d *Daemon) runAutoSettle(sessionID string, phase, resume autoSettlePhase) string {
 	// Held across the whole decision — reading the state, confirming the turn is
 	// still owed, and settling it — so no state write can land between the check
 	// and the settle. Without this the timer could settle a turn that a
@@ -300,6 +393,39 @@ func (d *Daemon) runAutoSettle(sessionID string, phase autoSettlePhase) string {
 		// Settled by hand, or excluded (workspace pinned or muted mid-window).
 		// Either way there is nothing left to close.
 		return "not-owed"
+	}
+
+	// The typing hold, at fire time. Two timers arrive here: a held session's own
+	// quiet check, and — the reason this guard is not only in holdAutoSettle — an
+	// arm or countdown timer that fired in the microseconds around a keystroke,
+	// before the hold could stop it. That race is the one interleaving where a
+	// turn would be closed under the user's hands, so the check is repeated where
+	// the settle actually happens rather than trusted upstream.
+	if quiet := d.userInputQuietRemaining(sessionID, autoSettleHoldQuietWindow); quiet > 0 {
+		hold := phase
+		if phase == autoSettleHeld {
+			hold = resume
+		}
+		d.autoSettleMu.Lock()
+		d.startAutoSettleHeldLocked(sessionID, hold, quiet)
+		d.autoSettleMu.Unlock()
+		return "held"
+	}
+
+	if phase == autoSettleHeld {
+		// Quiet again. The window is read fresh from settings and starts full: a
+		// frozen bar is drawn full, so resuming anything less would drop the bar
+		// on release, and the user has just been typing at this agent — the
+		// countdown they get back is the whole one they would have got by
+		// steering it now.
+		window := cfg.arm
+		if resume == autoSettleCounting {
+			window = cfg.countdown
+		}
+		d.autoSettleMu.Lock()
+		d.startAutoSettleLocked(sessionID, resume, window)
+		d.autoSettleMu.Unlock()
+		return "resumed"
 	}
 
 	if phase == autoSettleArming {
@@ -354,8 +480,11 @@ func (d *Daemon) cancelAutoSettleByUser(sessionID string) bool {
 }
 
 // decorateSessionWithAutoSettle stamps the broadcast clone with the countdown
-// deadline, when one is running. Read under autoSettleMu; callers must not
-// already hold it.
+// deadline while one is running, or the held flag while the user is typing. The
+// two are mutually exclusive by construction — a frozen countdown has no
+// deadline to animate against, and that is the point — so a client never has to
+// decide which one wins. Read under autoSettleMu; callers must not already hold
+// it.
 func (d *Daemon) decorateSessionWithAutoSettle(clone *protocol.Session) {
 	if clone == nil {
 		return
@@ -363,8 +492,14 @@ func (d *Daemon) decorateSessionWithAutoSettle(clone *protocol.Session) {
 	d.autoSettleMu.Lock()
 	entry, ok := d.autoSettleTimers[clone.ID]
 	firesAt := ""
-	if ok && entry.phase == autoSettleCounting {
-		firesAt = entry.firesAt.UTC().Format(time.RFC3339Nano)
+	held := false
+	if ok {
+		switch {
+		case entry.phase == autoSettleCounting:
+			firesAt = entry.firesAt.UTC().Format(time.RFC3339Nano)
+		case entry.visible():
+			held = true
+		}
 	}
 	d.autoSettleMu.Unlock()
 
@@ -372,6 +507,11 @@ func (d *Daemon) decorateSessionWithAutoSettle(clone *protocol.Session) {
 		clone.AutoSettleFiresAt = protocol.Ptr(firesAt)
 	} else {
 		clone.AutoSettleFiresAt = nil
+	}
+	if held {
+		clone.AutoSettleHeld = protocol.Ptr(true)
+	} else {
+		clone.AutoSettleHeld = nil
 	}
 }
 
@@ -418,7 +558,7 @@ func (d *Daemon) cancelAllAutoSettle() {
 	visible := make([]string, 0, len(d.autoSettleTimers))
 	for id, entry := range d.autoSettleTimers {
 		entry.timer.Stop()
-		if entry.phase == autoSettleCounting {
+		if entry.visible() {
 			visible = append(visible, id)
 		}
 		delete(d.autoSettleTimers, id)

--- a/internal/daemon/auto_settle_test.go
+++ b/internal/daemon/auto_settle_test.go
@@ -454,3 +454,235 @@ func TestAutoSettle_ConcurrentApprovalKeepsTheTurn(t *testing.T) {
 		t.Fatal("the turn was settled while the session was asking for approval")
 	}
 }
+
+// ---- Typing holds the settle ----
+//
+// attn cannot see inside the agent's TUI, so it cannot tell composing a message
+// from erasing one from pressing Escape. It does not need to: every keystroke
+// means the user's hands are on this session, which is the whole question a
+// pending settle is asking. These cover what that costs and where it stops.
+
+// typeInto is a genuine keystroke arriving from an interactive client, driven
+// through the real pty_input handler so the wiring between typing and the hold
+// is part of what these cover — not just the hold in isolation.
+func typeInto(d *Daemon, sessionID string) {
+	typeIntoAs(d, sessionID, "")
+}
+
+// typeIntoAs is the same with an explicit source tag, for the writes that are
+// attn typing rather than the user.
+func typeIntoAs(d *Daemon, sessionID, source string) {
+	msg := &protocol.PtyInputMessage{Cmd: protocol.CmdPtyInput, ID: sessionID, Data: "x"}
+	if source != "" {
+		msg.Source = protocol.Ptr(source)
+	}
+	d.handlePtyInput(nil, msg)
+}
+
+// goQuiet backdates the session's last keystroke so the quiet window has
+// elapsed, standing in for the user taking their hands off the keyboard.
+func goQuiet(d *Daemon, sessionID string) {
+	d.lastInputMu.Lock()
+	defer d.lastInputMu.Unlock()
+	d.lastUserInputAt[sessionID] = time.Now().Add(-2 * autoSettleHoldQuietWindow)
+}
+
+// The feature in one pass: typing freezes a running countdown, the freeze is
+// what rides the wire in place of a deadline, and going quiet hands back a whole
+// countdown rather than the sliver that was left.
+func TestAutoSettle_TypingFreezesTheCountdownAndQuietResumesIt(t *testing.T) {
+	d, id := newAutoSettleDaemon(t)
+	if !d.applyState(sessionStateChange{sessionID: id, state: protocol.StateWorking, cause: liveSignal{}}) {
+		t.Fatal("applyState(working) = false")
+	}
+	fireAutoSettleNow(t, d, id) // into the visible countdown
+	counting, _ := autoSettlePending(d, id)
+
+	typeInto(d, id)
+
+	held, ok := autoSettlePending(d, id)
+	if !ok || held.phase != autoSettleHeld {
+		t.Fatalf("after a keystroke: pending=%v entry=%+v, want the held phase", ok, held)
+	}
+	if held.resume != autoSettleCounting {
+		t.Fatalf("resume phase = %v, want counting", held.resume)
+	}
+	if held.timer == counting.timer {
+		t.Fatal("the countdown's own timer is still running; it would settle the turn mid-keystroke")
+	}
+	clone := d.sessionForBroadcast(d.store.Get(id))
+	if clone.AutoSettleFiresAt != nil {
+		t.Fatalf("auto_settle_fires_at = %q while held; a frozen countdown has no deadline to animate against", *clone.AutoSettleFiresAt)
+	}
+	if !protocol.Deref(clone.AutoSettleHeld) {
+		t.Fatal("auto_settle_held absent while frozen; the tile has nothing to freeze on")
+	}
+
+	// Still typing when the quiet check comes round: hold again, settle nothing.
+	fireAutoSettleNow(t, d, id)
+	again, ok := autoSettlePending(d, id)
+	if !ok || again.phase != autoSettleHeld {
+		t.Fatalf("quiet check with a fresh keystroke: pending=%v entry=%+v, want still held", ok, again)
+	}
+	if !turnIsOwed(d, id) {
+		t.Fatal("turn settled while the user was still typing")
+	}
+
+	goQuiet(d, id)
+	fireAutoSettleNow(t, d, id)
+
+	resumed, ok := autoSettlePending(d, id)
+	if !ok || resumed.phase != autoSettleCounting {
+		t.Fatalf("after the quiet window: pending=%v entry=%+v, want counting again", ok, resumed)
+	}
+	if window := time.Until(resumed.firesAt); window < 3500*time.Second {
+		// The fixture's countdown is 3600s. A resumed countdown is a whole one:
+		// the frozen bar is drawn full, so releasing into a remainder would drop
+		// the bar the instant the user stopped typing.
+		t.Fatalf("resumed countdown = %v, want the full configured window", window)
+	}
+	clone = d.sessionForBroadcast(d.store.Get(id))
+	if clone.AutoSettleFiresAt == nil {
+		t.Fatal("auto_settle_fires_at absent after the hold released")
+	}
+	if clone.AutoSettleHeld != nil {
+		t.Fatal("auto_settle_held still set after the hold released")
+	}
+
+	fireAutoSettleNow(t, d, id)
+	if turnIsOwed(d, id) {
+		t.Fatal("turn still owed after the resumed countdown elapsed")
+	}
+}
+
+// The race the hold cannot cover on its own: the countdown timer fires in the
+// microseconds around a keystroke, before holdAutoSettle can stop it. This is
+// the one interleaving that would close a turn under the user's hands, so the
+// fire path re-checks rather than trusting that the hold got there first.
+func TestAutoSettle_KeystrokeRacingTheFireHoldsInsteadOfSettling(t *testing.T) {
+	d, id := newAutoSettleDaemon(t)
+	if !d.applyState(sessionStateChange{sessionID: id, state: protocol.StateWorking, cause: liveSignal{}}) {
+		t.Fatal("applyState(working) = false")
+	}
+	fireAutoSettleNow(t, d, id)
+
+	// Record the keystroke without holding: exactly the window in which the timer
+	// has already been pulled out of the map and is on its way to the settle.
+	d.lastInputMu.Lock()
+	if d.lastUserInputAt == nil {
+		d.lastUserInputAt = make(map[string]time.Time)
+	}
+	d.lastUserInputAt[id] = time.Now()
+	d.lastInputMu.Unlock()
+
+	var outcome string
+	d.autoSettleFireHook = func(_, action string) { outcome = action }
+	fireAutoSettleNow(t, d, id)
+
+	if outcome != "held" {
+		t.Fatalf("outcome = %q, want held", outcome)
+	}
+	if !turnIsOwed(d, id) {
+		t.Fatal("turn settled by a countdown that fired into a keystroke")
+	}
+}
+
+// Typing during the arm delay holds it too, but invisibly: the arming phase was
+// never announced, and a paused indicator for a settle nobody has decided on is
+// exactly what the two-phase split exists to avoid. It resumes into arming, not
+// into a countdown it never earned.
+func TestAutoSettle_TypingDuringTheArmDelayHoldsItInvisibly(t *testing.T) {
+	d, id := newAutoSettleDaemon(t)
+	if !d.applyState(sessionStateChange{sessionID: id, state: protocol.StateWorking, cause: liveSignal{}}) {
+		t.Fatal("applyState(working) = false")
+	}
+
+	typeInto(d, id)
+
+	held, ok := autoSettlePending(d, id)
+	if !ok || held.phase != autoSettleHeld || held.resume != autoSettleArming {
+		t.Fatalf("after typing during the arm delay: pending=%v entry=%+v, want held(resume=arming)", ok, held)
+	}
+	clone := d.sessionForBroadcast(d.store.Get(id))
+	if clone.AutoSettleHeld != nil {
+		t.Fatal("auto_settle_held rode the wire for a frozen arm delay; nothing was on screen to freeze")
+	}
+	if clone.AutoSettleFiresAt != nil {
+		t.Fatalf("auto_settle_fires_at = %q during a held arm delay", *clone.AutoSettleFiresAt)
+	}
+
+	goQuiet(d, id)
+	fireAutoSettleNow(t, d, id)
+
+	resumed, ok := autoSettlePending(d, id)
+	if !ok || resumed.phase != autoSettleArming {
+		t.Fatalf("after the quiet window: pending=%v entry=%+v, want the arm delay back", ok, resumed)
+	}
+}
+
+// A hold is not a cancel. The user going quiet is not the user answering, so the
+// countdown comes back on its own — where ⌘. stands until the session leaves
+// `working`.
+func TestAutoSettle_HoldExpiresWhereCancelStands(t *testing.T) {
+	d, id := newAutoSettleDaemon(t)
+	if !d.applyState(sessionStateChange{sessionID: id, state: protocol.StateWorking, cause: liveSignal{}}) {
+		t.Fatal("applyState(working) = false")
+	}
+	fireAutoSettleNow(t, d, id)
+	typeInto(d, id)
+
+	if d.autoSettleSuppressedFor(id) {
+		t.Fatal("typing set the cancel suppression; a hold must expire on its own")
+	}
+	goQuiet(d, id)
+	fireAutoSettleNow(t, d, id)
+	if entry, ok := autoSettlePending(d, id); !ok || entry.phase != autoSettleCounting {
+		t.Fatalf("countdown did not come back after the hold: pending=%v entry=%+v", ok, entry)
+	}
+}
+
+// The agent wanting the user beats everything, including a hold. A held session
+// that leaves `working` drops its timer and its wire flag, the same as a running
+// countdown does.
+func TestAutoSettle_LeavingWorkingClearsAHold(t *testing.T) {
+	d, id := newAutoSettleDaemon(t)
+	if !d.applyState(sessionStateChange{sessionID: id, state: protocol.StateWorking, cause: liveSignal{}}) {
+		t.Fatal("applyState(working) = false")
+	}
+	fireAutoSettleNow(t, d, id)
+	typeInto(d, id)
+
+	if !d.applyState(sessionStateChange{sessionID: id, state: protocol.StatePendingApproval, cause: liveSignal{}}) {
+		t.Fatal("applyState(pending_approval) = false")
+	}
+
+	if _, ok := autoSettlePending(d, id); ok {
+		t.Fatal("a hold survived the session leaving working")
+	}
+	clone := d.sessionForBroadcast(d.store.Get(id))
+	if clone.AutoSettleHeld != nil {
+		t.Fatal("auto_settle_held survived the session leaving working")
+	}
+	if !turnIsOwed(d, id) {
+		t.Fatal("turn was settled on the move to pending_approval")
+	}
+}
+
+// attn typing on the user's behalf is not the user typing. A doorbell, a
+// delegation brief, or an attach replay must not hold a countdown open — the
+// hold exists to notice a human at the keyboard.
+func TestAutoSettle_AutomationInputDoesNotHold(t *testing.T) {
+	d, id := newAutoSettleDaemon(t)
+	if !d.applyState(sessionStateChange{sessionID: id, state: protocol.StateWorking, cause: liveSignal{}}) {
+		t.Fatal("applyState(working) = false")
+	}
+	fireAutoSettleNow(t, d, id)
+
+	for _, source := range []string{"automation", "attach_replay"} {
+		typeIntoAs(d, id, source)
+		entry, ok := autoSettlePending(d, id)
+		if !ok || entry.phase != autoSettleCounting {
+			t.Fatalf("source %q: pending=%v entry=%+v, want the countdown still running", source, ok, entry)
+		}
+	}
+}

--- a/internal/daemon/auto_settle_test.go
+++ b/internal/daemon/auto_settle_test.go
@@ -587,6 +587,49 @@ func TestAutoSettle_KeystrokeRacingTheFireHoldsInsteadOfSettling(t *testing.T) {
 	}
 }
 
+// The narrower half of the same race, and the one a timestamp placed beforehand
+// never reaches: the keystroke arrives *inside* the fire, after the guard has
+// already looked and while the turn is on its way to being closed. The timer is
+// out of the map by then, so the hold the keystroke triggers finds nothing to
+// freeze and the only thing standing between the user and a settled turn is that
+// the check and the write are one step.
+//
+// A whole pty_input, not a hand-placed stamp: the point is that the real path —
+// source filter, stamp, write, hold — cannot slip through the gap.
+func TestAutoSettle_KeystrokeInsideTheSettleStillHoldsIt(t *testing.T) {
+	d, id := newAutoSettleDaemon(t)
+	if !d.applyState(sessionStateChange{sessionID: id, state: protocol.StateWorking, cause: liveSignal{}}) {
+		t.Fatal("applyState(working) = false")
+	}
+	fireAutoSettleNow(t, d, id) // into the visible countdown
+
+	typed := false
+	d.autoSettlePreSettleHook = func() {
+		if typed {
+			return
+		}
+		typed = true
+		typeInto(d, id)
+	}
+	var outcome string
+	d.autoSettleFireHook = func(_, action string) { outcome = action }
+	fireAutoSettleNow(t, d, id)
+
+	if !typed {
+		t.Fatal("the countdown never reached the settle; the test stood in the wrong gap")
+	}
+	if outcome != "held" {
+		t.Fatalf("outcome = %q, want held", outcome)
+	}
+	if !turnIsOwed(d, id) {
+		t.Fatal("turn settled around a keystroke that landed before the settle committed")
+	}
+	held, ok := autoSettlePending(d, id)
+	if !ok || held.phase != autoSettleHeld || held.resume != autoSettleCounting {
+		t.Fatalf("after the racing keystroke: pending=%v entry=%+v, want held(resume=counting)", ok, held)
+	}
+}
+
 // Typing during the arm delay holds it too, but invisibly: the arming phase was
 // never announced, and a paused indicator for a settle nobody has decided on is
 // exactly what the two-phase split exists to avoid. It resumes into arming, not

--- a/internal/daemon/nudge_countdown.go
+++ b/internal/daemon/nudge_countdown.go
@@ -491,11 +491,18 @@ func (d *Daemon) handleTriggerNudge(msg *protocol.TriggerNudgeMessage) {
 	d.broadcastSessionStateChanged(sessionID)
 }
 
-// noteUserInput records a genuine user keystroke for the splice guard. Automation and
-// attach-replay writes are not the user typing, so they do not count.
-func (d *Daemon) noteUserInput(sessionID, source string) {
+// noteUserInput records a genuine user keystroke, and is the only place the
+// source filter is applied — automation and attach-replay writes are not the
+// user typing, so they do not count. It reports whether it recorded one, so a
+// caller can hang further reactions off the same verdict instead of re-deriving
+// who typed.
+//
+// Two mechanisms read the stamp, for opposite reasons: the nudge splice guard,
+// so a doorbell never lands on a half-typed line, and auto-settle's typing hold,
+// so a turn is not closed under the user's hands.
+func (d *Daemon) noteUserInput(sessionID, source string) bool {
 	if sessionID == "" || !isUserKeystrokeSource(source) {
-		return
+		return false
 	}
 	now := time.Now()
 	d.lastInputMu.Lock()
@@ -504,18 +511,31 @@ func (d *Daemon) noteUserInput(sessionID, source string) {
 	}
 	d.lastUserInputAt[sessionID] = now
 	d.lastInputMu.Unlock()
+	return true
 }
 
 // recentUserInput reports whether a genuine user keystroke hit this session within
 // the window.
 func (d *Daemon) recentUserInput(sessionID string, within time.Duration) bool {
+	return d.userInputQuietRemaining(sessionID, within) > 0
+}
+
+// userInputQuietRemaining reports how much of `within` is left to run before this
+// session counts as quiet — zero once the window has elapsed, or when the user
+// has never typed here. It is what lets a waiting timer reschedule exactly to the
+// end of the window instead of re-polling it.
+func (d *Daemon) userInputQuietRemaining(sessionID string, within time.Duration) time.Duration {
 	d.lastInputMu.Lock()
 	defer d.lastInputMu.Unlock()
 	last, ok := d.lastUserInputAt[sessionID]
 	if !ok {
-		return false
+		return 0
 	}
-	return time.Since(last) < within
+	remaining := within - time.Since(last)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
 }
 
 // isUserKeystrokeSource reports whether a pty_input source tag represents the user

--- a/internal/daemon/nudge_countdown.go
+++ b/internal/daemon/nudge_countdown.go
@@ -527,6 +527,13 @@ func (d *Daemon) recentUserInput(sessionID string, within time.Duration) bool {
 func (d *Daemon) userInputQuietRemaining(sessionID string, within time.Duration) time.Duration {
 	d.lastInputMu.Lock()
 	defer d.lastInputMu.Unlock()
+	return d.userInputQuietRemainingLocked(sessionID, within)
+}
+
+// userInputQuietRemainingLocked is the same reading, for a caller that already
+// holds lastInputMu because it needs the answer and its own next step to be
+// indivisible from recording a keystroke. See settleIfQuiet.
+func (d *Daemon) userInputQuietRemainingLocked(sessionID string, within time.Duration) time.Duration {
 	last, ok := d.lastUserInputAt[sessionID]
 	if !ok {
 		return 0
@@ -536,6 +543,35 @@ func (d *Daemon) userInputQuietRemaining(sessionID string, within time.Duration)
 		return 0
 	}
 	return remaining
+}
+
+// settleIfQuiet is auto-settle's commit: the only place a timer closes a turn,
+// and the reason the typing hold is airtight rather than merely likely.
+//
+// The quiet check and the store write happen in one critical section, under the
+// same lock noteUserInput records a keystroke with. That is what makes the two
+// indivisible. Checking first and settling afterwards — however few instructions
+// apart — leaves a gap a real keystroke can land in: it would be stamped after
+// the guard had already looked, and the hold that follows it finds the timer
+// gone from the map and does nothing, so the turn closes with the user's hands
+// on the keyboard. Serialized, a key pressed before the settle commits is always
+// seen by the check that guards it, and a key that loses was pressed after the
+// turn had already closed — which is honest, and unavoidable in any design.
+//
+// The lock spans a store write, so the scope is worth stating plainly: the only
+// way to contend for it is to type in the instant a settle commits, and a settle
+// only commits after `within` of silence. The single keystroke that could ever
+// wait on one primary-key update is the one this exists to protect.
+//
+// Reports the remaining quiet time when it refuses, so the caller can reschedule
+// exactly to the end of the window, and whether the turn was actually settled.
+func (d *Daemon) settleIfQuiet(sessionID string, within time.Duration) (quiet time.Duration, settled bool) {
+	d.lastInputMu.Lock()
+	defer d.lastInputMu.Unlock()
+	if remaining := d.userInputQuietRemainingLocked(sessionID, within); remaining > 0 {
+		return remaining, false
+	}
+	return 0, d.store.SettleTurn(sessionID, time.Now())
 }
 
 // isUserKeystrokeSource reports whether a pty_input source tag represents the user

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -619,7 +619,7 @@ func (d *Daemon) handlePtyInput(client *wsClient, msg *protocol.PtyInputMessage)
 	source := strings.TrimSpace(protocol.Deref(msg.Source))
 	// Record genuine user keystrokes for the nudge splice guard. A doorbell that fires
 	// within userInputGuardWindow of a keystroke would splice onto the half-typed line.
-	d.noteUserInput(msg.ID, source)
+	userTyped := d.noteUserInput(msg.ID, source)
 	if d.debugLogging {
 		d.logf(
 			"pty_input: id=%s bytes=%d preview=%q source=%s",
@@ -637,6 +637,14 @@ func (d *Daemon) handlePtyInput(client *wsClient, msg *protocol.PtyInputMessage)
 		}
 	} else if d.debugLogging {
 		d.logf("pty_input ok: id=%s bytes=%d", msg.ID, len(msg.Data))
+	}
+
+	// After the bytes are away, never before: freezing a pending settle can
+	// broadcast a snapshot, and a keystroke must not wait on one to reach the
+	// agent. Nothing about the hold is ordered against the write — it moves a
+	// deadline seconds out.
+	if userTyped {
+		d.holdAutoSettle(msg.ID)
 	}
 }
 

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "208"
+const ProtocolVersion = "209"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -4309,6 +4309,9 @@ type Session struct {
 	// AutoSettleFiresAt corresponds to the JSON schema field "auto_settle_fires_at".
 	AutoSettleFiresAt *string `json:"auto_settle_fires_at,omitempty,omitzero"`
 
+	// AutoSettleHeld corresponds to the JSON schema field "auto_settle_held".
+	AutoSettleHeld *bool `json:"auto_settle_held,omitempty,omitzero"`
+
 	// Branch corresponds to the JSON schema field "branch".
 	Branch *string `json:"branch,omitempty,omitzero"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -140,6 +140,7 @@ model Session {
   turn_opened_at?: string;      // ISO timestamp the outstanding turn opened; the queue's sort key. Absent when nothing is owed.
   turn_snoozed_until?: string;  // ISO timestamp a live snooze runs to. Present only while the deferral holds; its presence is what puts the row in the sidebar's snoozed section, and while it is set no state can open a turn for this session except one that breaks through.
   auto_settle_fires_at?: string; // ISO timestamp the auto-settle countdown will close this session's turn. Present only while the countdown is running, which is the whole contract: it is what the terminal tile animates against, and its absence is what says nothing is pending. Absent during the arm delay, when auto-settle is off, and after a cancel.
+  auto_settle_held?: boolean;   // True while the auto-settle countdown is frozen because the user is typing into this session. Mutually exclusive with auto_settle_fires_at by construction: a frozen countdown has no deadline to animate against, so the tile draws a full paused bar and waits. It clears on its own five quiet seconds after the last keystroke, when a fresh deadline replaces it.
   todos?: string[];             // Optional: can be empty/absent
   last_seen: string;            // ISO timestamp, always set
 }


### PR DESCRIPTION
## What

attn can close a turn on its own once the user has steered an agent and it has
gone back to work: an invisible arm delay proves the steering took, then a
visible countdown the user can stop with `Cmd+.`. That countdown ran regardless
of what the user was doing, so a turn could close while they were still at the
keyboard writing the next thing.

A genuine keystroke into the session's PTY now **freezes** the countdown where
it stands. The daemon withdraws the deadline and broadcasts `auto_settle_held`
instead; the pane header and the sidebar draw a still, full bar labelled
"Settling paused". Five quiet seconds after the last keystroke the hold releases
into a **whole** countdown, read fresh from settings — not the remainder that
was left when typing began.

## Why this shape

attn has no visibility inside an agent's TUI, so it cannot tell composing from
erasing from pressing Escape — and it does not try. A keystroke means *the
user's hands are on this session*, which is the entire question a pending settle
is asking. The one distinction that does matter — the user versus attn typing on
their behalf — was already drawn: `handlePtyInput` tags automation and
attach-replay writes, and daemon-side writes (doorbells, delegation briefs)
never pass through it at all, so they cannot hold by construction.

Three details carry the design:

- **Typing during the arm delay holds it too, but silently**, and resumes into
  arming rather than into a countdown it never earned. Freezing something that
  was never announced would announce it.
- **The fire-time guard repeats the quiet check where the settle happens**,
  catching a timer that fired in the microseconds around a keystroke before the
  hold could stop it. That interleaving is the only one that closes a turn under
  the user's hands.
- **A hold is not a cancel.** `Cmd+.` keeps the turn and stands until the session
  leaves `working`; a hold expires on its own, because the user stopping typing
  is not the user answering.

## The 5s number

The quiet window is a constant, not a third setting. It measures typing gaps —
pausing to read the screen mid-prompt — not agent behavior, so it is orthogonal
to the two configurable windows. It can afford to be short because the thing it
releases into *is* the grace period: visible, and cancellable for its whole
configured length. Being wrong here does not settle a turn silently.

Cost control: only the first keystroke of a burst does any work. A re-hold, and
a hold of the invisible arm delay, broadcast nothing.

## Verification

Live-verified in a packaged non-production build (isolated profile), plus a new
harness scenario `real-app:scenario-settle-typing-hold` that asserts the wire
and the rendered header together across five legs:

1. countdown running — `auto_settle_fires_at` set, header reads "Settling…";
2. one keystroke — `auto_settle_held`, no deadline, header reads "Settling
   paused" with a frozen bar;
3. typing across two quiet windows — still held, never resumed under the hands;
4. going quiet — resumes with a deadline a **full** countdown out, not the
   remainder;
5. an automation `write_pane` to the same pane — holds nothing.

The rendered-DOM readout it asserts against is a new `settling` field on the UI
automation bridge (`text`, `held`, `frozenBar`), so the header is checked as the
user sees it rather than inferred from state.

Also: 6 daemon tests covering the freeze, the fire-time race, the invisible
arm-delay hold, hold-vs-cancel, hold clearing when the session leaves `working`,
and automation input; frontend tests for both indicators.

Protocol `208 → 209` (`auto_settle_held`, mutually exclusive with
`auto_settle_fires_at`).