### PR TITLE
perf(docstore-test): read a cursor's anchor once per corpus

### DIFF
--- a/changelog.d/docstore-harness-anchor-cache.yaml
+++ b/changelog.d/docstore-harness-anchor-cache.yaml
@@ -1,0 +1,8 @@
+kind: internal
+area: daemon
+change: >
+  The document query harness reads a cursor's anchor document once per corpus
+  instead of once per check. Hundreds of queries ask about the same handful of
+  anchors between two writes, and the re-reads were most of the statements the
+  exhaustive leg ran. The cache is cleared wherever the corpus moves, so the
+  moving-corpus leg still sees every write, delete and redeclaration.

--- a/internal/store/documents_model_test.go
+++ b/internal/store/documents_model_test.go
@@ -123,6 +123,14 @@ type modelWorld struct {
 	table  string
 	shadow string
 	ids    []string
+
+	// anchors caches the cursor lookup. Compiling an After cursor needs the
+	// anchor document, and one corpus is asked about the same handful of anchors
+	// by hundreds of queries that cannot have changed it; re-reading each one is
+	// most of the statements the harness runs. Cleared whenever the corpus moves,
+	// which is what refillShadow already marks — every path that writes, deletes
+	// or redeclares goes through it.
+	anchors map[string]*docstore.Document
 }
 
 func newModelWorld(t *testing.T) *modelWorld {
@@ -137,7 +145,7 @@ func newModelWorldFor(t *testing.T, decl docstore.CollectionSchema, ids []string
 		t.Fatalf("define: %v", err)
 	}
 	schema := declOf(t, s, decl.Namespace, decl.Collection)
-	w := &modelWorld{t: t, s: s, schema: schema, table: schema.Table, shadow: "shadow_docs", ids: ids}
+	w := &modelWorld{t: t, s: s, schema: schema, table: schema.Table, shadow: "shadow_docs", ids: ids, anchors: map[string]*docstore.Document{}}
 	w.createShadow()
 	return w
 }
@@ -193,6 +201,7 @@ func (w *modelWorld) loadCorpus(bodies []string) {
 // refillShadow rebuilds the dumb table from the real one.
 func (w *modelWorld) refillShadow() {
 	w.t.Helper()
+	w.anchors = map[string]*docstore.Document{}
 	if _, err := w.s.db.Exec("DELETE FROM " + w.shadow); err != nil {
 		w.t.Fatalf("clear shadow: %v", err)
 	}
@@ -339,18 +348,35 @@ func naivePage(matching, everything []string, q docstore.Query) []string {
 	return append([]string{}, out...)
 }
 
+// anchorFor reads the document a cursor names — the same read the daemon makes
+// before compiling a paged query — and remembers it for as long as the corpus
+// holds still. A cursor naming a document that is not there stays a nil anchor,
+// which is the case the compiler rejects and an example test pins; caching must
+// not turn that into a miss that silently re-reads.
+func (w *modelWorld) anchorFor(after string) (*docstore.Document, error) {
+	if after == "" {
+		return nil, nil
+	}
+	if doc, ok := w.anchors[after]; ok {
+		return doc, nil
+	}
+	doc, found, err := w.s.GetDocument(w.schema, after)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		doc = nil
+	}
+	w.anchors[after] = doc
+	return doc, nil
+}
+
 // realIDs runs the query through the compiler and the store — the path under
 // test, exactly as the daemon drives it.
 func (w *modelWorld) realIDs(q docstore.Query) ([]string, error) {
-	var anchor *docstore.Document
-	if q.After != "" {
-		doc, found, err := w.s.GetDocument(w.schema, q.After)
-		if err != nil {
-			return nil, err
-		}
-		if found {
-			anchor = doc
-		}
+	anchor, err := w.anchorFor(q.After)
+	if err != nil {
+		return nil, err
 	}
 	c, err := q.Compile(w.schema, anchor)
 	if err != nil {
@@ -376,15 +402,9 @@ func (w *modelWorld) realIDs(q docstore.Query) ([]string, error) {
 // support — a class that cannot appear until there is enough data for SQLite to
 // prefer the index at all.
 func (w *modelWorld) unindexedIDs(q docstore.Query) ([]string, error) {
-	var anchor *docstore.Document
-	if q.After != "" {
-		doc, found, err := w.s.GetDocument(w.schema, q.After)
-		if err != nil {
-			return nil, err
-		}
-		if found {
-			anchor = doc
-		}
+	anchor, err := w.anchorFor(q.After)
+	if err != nil {
+		return nil, err
 	}
 	c, err := q.Compile(w.schema, anchor)
 	if err != nil {
@@ -810,15 +830,9 @@ func TestALargeRandomCorpusAgreesWithTheDumbQuery(t *testing.T) {
 // its own plan rather than guessed from the shape of the SQL.
 func (w *modelWorld) usesAnIndex(q docstore.Query) bool {
 	w.t.Helper()
-	var anchor *docstore.Document
-	if q.After != "" {
-		doc, found, err := w.s.GetDocument(w.schema, q.After)
-		if err != nil {
-			w.t.Fatalf("anchor: %v", err)
-		}
-		if found {
-			anchor = doc
-		}
+	anchor, err := w.anchorFor(q.After)
+	if err != nil {
+		w.t.Fatalf("anchor: %v", err)
 	}
 	c, err := q.Compile(w.schema, anchor)
 	if err != nil {


### PR DESCRIPTION
The document query harness ([#758](https://github.com/victorarias/attn/pull/758))
compiles a paged query the way the daemon does: read the document the `After`
cursor names, hand it to the compiler as the anchor. It was doing that read once
per check. One corpus is asked about the same handful of anchors by hundreds of
queries that cannot have changed it, so those re-reads were most of the
statements the exhaustive leg ran.

The anchor is now cached on the harness world, and the cache is cleared in
`refillShadow` — the single place the corpus moves. Every write, delete and
redeclaration in the moving leg already goes through it, so a stale anchor
cannot outlive the corpus it came from. A cursor naming a document that is not
there caches as a *nil* anchor, which is the case the compiler rejects and an
example test pins; caching must not turn that into a miss that quietly re-reads.

## Receipts

Three legs, default corpus size 3: **3.726s → 3.582s**. The default only spends
~1.1s of that in the sweep, so the win there is ~4% and honestly small. It is
the soak where it shows — the sweep alone:

| `ATTN_DOCSTORE_SWEEP` | before | after |
| --- | --- | --- |
| 4 | 13.604s | 11.048s |
| 5 | 125.834s | 101.804s |

## Still falsifiable

Caching an input to the thing under test could in principle hide a bug in it, so
the check was re-run red. The cursor comparison was loosened from `>` to `>=` in
`docstore.Compile` and both legs failed immediately — the sweep on `a={"n":1}
b={"n":1} c={"n":1}`, `sort n asc, limit 1, after a`, real `[a]` against dumb
`[b]`; the moving leg on a page walk that stopped terminating. Reverted.

## Why this is a separate PR

#758's description already claimed this optimization. The change was lost to a
stray `git checkout --` while I was measuring corpus sizes on that branch, and
only the sweep dial — the file I was actively editing — got re-applied. So the
merged harness does not have it and the description says it does. This makes the
record true.

## Verification

Test-only, no product code. `internal/store` passes at 9.9s, `go vet` and
`gofmt` clean. No daemon lifecycle, protocol, PTY, background-runner or UI
surface, and the harness never resolves a config path, so no live app
verification applies.
