### PR TITLE
docs: pi headless host vision and vertical-slice plan

### DIFF
--- a/changelog.d/brisk-marmot-pi-headless-host-docs.yaml
+++ b/changelog.d/brisk-marmot-pi-headless-host-docs.yaml
@@ -1,0 +1,7 @@
+kind: internal
+area: docs
+change: >
+  pi vision updated — attn renders the conversation via a headless SDK host
+  (plugin entrypoint, daemon-owned process group, React conversation surface;
+  PTY path stays for claude/codex/shell) — plus a vertical-slice
+  implementation plan grounded in the 2026-08-04 pi SDK spike receipts.

--- a/docs/plans/2026-08-05-pi-headless-host.md
+++ b/docs/plans/2026-08-05-pi-headless-host.md
@@ -1,0 +1,183 @@
+# Plan: pi headless host and rendered conversation — vertical slices
+
+## Alignment
+
+Implements the rendered-conversation shape of
+[docs/vision/pi-attn-plugins.md](../vision/pi-attn-plugins.md): attn renders
+the conversation via pi's SDK through a headless host process. Slice-based:
+every slice ships a usable behavior end to end (host -> daemon -> app); no
+layer is built ahead of the slice that needs it. Chatbox first, then expand.
+
+## Grounding (receipts)
+
+Measured in the 2026-08-04 SDK spike / source read at pi 0.80.10:
+
+- `agent_settled` fires last on every path (success, abort, error,
+  retry-drain); attn's turn = pi run (`agent_start` -> `agent_settled`); pi's
+  turn events are internal steps — one abort produces a phantom second turn
+  pair.
+- `stopReason` `"aborted"` on abort observed live on google and openai;
+  source-verified for anthropic and bedrock. `errorMessage` wording differs
+  per provider — never key on message text.
+- `steer()` drains at turn boundaries; `followUp()` drains only when the whole
+  run would settle.
+- Hard-killing the host orphans running tool subprocesses (3x reproduced) —
+  cooperative cleanup only; the daemon must own the host's process group.
+- No session file exists until the first assistant message; crash before that
+  leaves zero disk trace.
+- Session files are versioned (v3) with automatic in-place migration on open;
+  entries form a parent-linked tree.
+- Thinking-model streams measured ~480 `message_update` events / ~45 KB per
+  ~5 s reply, bursty (observed peaks 250-1,490 events/s); WS clients buffer
+  256 messages -> host coalesces deltas (~30 ms flush) before the wire.
+- Transcript corpus: p50 0.15 MB, p99 11.6 MB, max 128 MB with ~0.4% message
+  text -> attach snapshot is windowed with collapsed tool cards from day one;
+  pi's bash tool already truncates at 2000 lines/50 KB and writes full output
+  to a temp file (`fullOutputPath`).
+- pi releases ~3.6x/week with labeled breaking changes every 1-2 releases plus
+  unlabeled type-level growth of the event union -> exact pin; a pin bump
+  means re-running the spike scenarios; never exhaustively switch on pi's
+  unions.
+- `bindExtensions()` is required or `session_start` (and resource discovery)
+  never fires.
+- Auth is fully headless; a failed OAuth refresh throws with no env fallback.
+
+## Design decisions (cross-slice)
+
+- New session kind beside PTY sessions, not a replacement; the attn-pi plugin
+  gains a host entrypoint; the daemon spawns the host per session as
+  process-group leader and group-kills on teardown (receipt above).
+- Wire: one envelope `{session_id, seq, kind, body}`. Semantic kinds are
+  typed in the protocol (TypeSpec, ProtocolVersion-gated) in attn's
+  vocabulary; render kinds carry opaque bodies typed in a TS package shared by
+  host and app; the daemon routes render bodies without parsing them. Version
+  the render stream in the host handshake; skew fails explicitly.
+- The host maps pi events to attn semantics with a default arm for unknown pi
+  event types (log + drop or forward-opaque); exhaustiveness only on attn's
+  own types.
+- State is declared by the host (it is attn code); the pi-side suite remains
+  for in-loop powers only.
+- Exact pin `@earendil-works/pi-coding-agent` 0.80.10; the committed spike
+  harness is the bump gate.
+
+## Slices
+
+### Slice 1 — live chatbox
+
+Goal: type a prompt in the app, watch the reply stream, send the next prompt.
+
+Ships:
+
+- [ ] Host entrypoint (`createAgentSession`, sessions under attn's data dir,
+      explicit model, `bindExtensions` called, no suite yet).
+- [ ] Daemon spawn/kill of host as pgid leader.
+- [ ] Minimal envelope with semantic kinds `session_ready`/`run_started`/
+      `run_settled` and render kind `message_delta` (coalesced ~30 ms).
+- [ ] Minimal React pane (message list + input, input disabled while running).
+- [ ] `prompt` verb.
+- [ ] Exact pin committed; spike harness committed beside the plugin as the
+      pin-bump gate.
+
+Acceptance:
+
+- [ ] Full round trip in a running dev app.
+- [ ] Killing the session leaves no orphan processes (verify with `ps`).
+- [ ] A second prompt works after settle.
+
+### Slice 2 — a real attn citizen: state and nudges
+
+Goal: the session behaves like every other attn session and nudges become
+first-class.
+
+Ships:
+
+- [ ] Host declares working/idle/waiting on run boundaries (states ride the
+      existing `applyState` path).
+- [ ] Turn integration (turn opens on settle-wanting-user, existing
+      `turn_owed` derivation).
+- [ ] `steer` and `follow_up` verbs on the wire, host picks steer vs new
+      prompt by run state.
+- [ ] `queue_update` surfaced so the UI shows queued -> seen.
+- [ ] Doorbell/ticket nudges routed through these verbs (no PTY typing, no
+      monitors).
+
+Acceptance:
+
+- [ ] Nudging a mid-run session lands at the next turn boundary and the UI
+      shows the delivery.
+- [ ] Nudging an idle session starts a run.
+- [ ] Dashboard/turn behavior matches other harnesses.
+
+### Slice 3 — tool visibility
+
+Goal: see what the agent did.
+
+Ships:
+
+- [ ] Semantic `tool_started`/`tool_finished` (name, status, files).
+- [ ] Render tool detail as collapsed cards, expand fetches detail on demand
+      (`fullOutputPath` for oversized bash output).
+- [ ] Edit-tool patches rendered with the existing diff viewer.
+
+Acceptance:
+
+- [ ] A session that reads/edits/runs shows accurate cards.
+- [ ] Expanding a truncated bash output shows the full text.
+- [ ] A patch renders as a diff.
+
+### Slice 4 — dying and coming back
+
+Goal: crashes and restarts are survivable.
+
+Ships:
+
+- [ ] Revive via reopening the session file through pi's `SessionManager`
+      (migrations come free).
+- [ ] The zero-file early-crash case falls back to fresh session +
+      LaunchIntent prompt.
+- [ ] Attach protocol: windowed conversation snapshot + live stream deduped by
+      seq (mirrors the terminal restore contract).
+
+Acceptance:
+
+- [ ] `kill -9` the host mid-tool-run -> session goes recoverable -> reload
+      resumes with history intact and no orphaned processes.
+- [ ] Early-kill case relaunches cleanly.
+- [ ] Reattaching a second client shows identical state.
+
+### Slice 5 — history and depth
+
+Goal: long sessions and old sessions are first-class.
+
+Ships:
+
+- [ ] Scroll-back paging of older window ranges.
+- [ ] Resume of arbitrary existing session files.
+- [ ] Model switching mid-session.
+- [ ] Compaction/retry surfaced in the UI from their events.
+
+Acceptance:
+
+- [ ] A 100+-turn session scrolls smoothly and pages history on demand.
+- [ ] Resuming an old session works.
+- [ ] Switching model mid-session takes effect next run.
+
+### Later (named, unplanned)
+
+Skills/resource loading through `bindExtensions`, the safety envelope,
+subagents, background eyes — these stay rocks in the vision doc, not slices
+here.
+
+## Non-goals
+
+Replacing the PTY pi driver (it stays until the host path proves out in daily
+use); migrating claude/codex to this pattern; image-preserving restores; a
+day-long memory soak (open item, 15-turn slope measured shallow).
+
+## Open questions
+
+- Remote (Linux) leg: host distribution and fingerprint coherence — same
+  treatment the PTY worker got, deferred until the local path works.
+- Whether the suite keeps any slice-2 role once the host declares state
+  directly (leaning: suite dormant until the envelope/skills rocks need
+  in-loop power).

--- a/docs/vision/pi-attn-plugins.md
+++ b/docs/vision/pi-attn-plugins.md
@@ -5,8 +5,7 @@
 > the decisions: pi's extension surface ([earendil-works/pi](https://github.com/earendil-works/pi)),
 > openclaw's history of embedding pi ([openclaw/openclaw](https://github.com/openclaw/openclaw)),
 > and attn's plugin system ([docs/plans/2026-04-16-plugin-system.md](../plans/2026-04-16-plugin-system.md),
-> with [2026-04-07-pi-integration.md](../plans/2026-04-07-pi-integration.md) and an
-> earlier pi-plugin plan that has since been deleted; git history has it).
+> with the earlier pi plan [2026-04-07-pi-integration.md](../plans/2026-04-07-pi-integration.md)).
 
 ## End state (the why)
 
@@ -24,6 +23,11 @@ doorbell wakes as in-band steering, links its session to attn's on birth. The
 claude-code integration is attn adapting to a closed harness from the outside;
 pi is the harness attn gets to shape from the inside.
 
+The conversation itself is attn's own surface: it reads with the density of a
+terminal transcript, but it's built from real UI — tool calls that expand,
+diffs that render, images inline, scroll that behaves. The terminal remains
+for harnesses that live there; pi's sessions are drawn by the app itself.
+
 Why it matters: attn's model is many agents, one Victor. Today the harness
 underneath is someone else's product — its roadmap, its model lock-in, its
 opaque state. pi is small, open, and extensible at every seam that matters.
@@ -37,21 +41,21 @@ with a single `pi install`, each capability a piece that stands alone.
 Everything this vision wants maps onto pi's supported extension surface; the
 verified feature-by-feature mapping informs each capability's own doc.
 
-Plugins are the whole bet: attn wants signals, steering, and capabilities —
-never ownership of the agent loop. (Forking pi and RPC-first embedding were
-considered and rejected on exactly that line; openclaw's history of vendoring
-pi is the price list for crossing it.)
+Plugins are the whole bet: attn wants signals, steering, capabilities, and its
+own rendering — never ownership of the agent loop. openclaw's history of
+vendoring pi is the price list for crossing that line.
 
 ## The shape: two plugin systems meet in the middle
 
 Both sides are plugins; neither harness gets forked or patched:
 
-- **attn side** — an agent-driver plugin per attn's own plugin system, like
-  the opencode plugin before it: it launches pi into an attn-owned PTY and
-  carries the session's lifecycle.
-- **pi side** — the attn suite, a pi package the driver stages: it links the
-  session, declares state, delivers doorbells and nudges as steering, and
-  carries the harness capabilities.
+- **attn side** — the driver plugin provides a headless host entrypoint
+  (Bun, in-repo) that runs pi via `createAgentSession`; the daemon spawns it
+  per session and owns its process group and lifecycle.
+- **pi side** — the attn suite, loaded into the host's pi runtime, carrying
+  the in-loop capabilities.
+
+The PTY/terminal path stays for claude, codex, and shell sessions.
 
 State flips from inference to declaration: today attn *deduces* claude's state
 from hooks, heuristics, and a stop-time classifier; the pi extension *reports*
@@ -59,6 +63,13 @@ it — declared state is authoritative, with no classifier fallback. What
 survives of classification is a service, not a guess: when the agent stops,
 the plugin can ask attn to read the last turn and enrich the stop — done, or
 waiting on a reply — so the user understands *why* the session went quiet.
+
+Two streams come out of the host: a small typed semantic stream in attn's own
+vocabulary — session linked, run started/settled, state, tool started/
+finished, message committed — that the daemon understands and every attn
+feature integrates on; and a render stream — streaming deltas, tool detail —
+that the daemon routes without parsing, typed in TypeScript shared between
+host and app.
 
 ## The capabilities (each gets its own doc)
 
@@ -96,26 +107,32 @@ waiting on a reply — so the user understands *why* the session went quiet.
   actually living in pi, not by a claude-code comparison table.
 - **Pin pi like a protocol.** Version the seam, gate on compat — the same
   reflex as attn's `ProtocolVersion`.
-- **The agent stays a guest in attn's house.** attn owns the PTY, the session
-  lifecycle, and the outer harness. pi owns the loop, the models, the context.
-  The seam is the socket.
+- **The agent stays a guest in attn's house.** attn owns the process, the
+  session lifecycle, and the outer harness. pi owns the loop, the models, the
+  context. The seam is the socket.
+- **attn integrates on declarations, never on renderings.** The daemon's
+  picture of a session must be complete without ever reading a render event;
+  deltas exist only so the app can paint.
 
 ## Scope & non-goals
 
 **In scope:** the attn-side driver plugin; the pi-side attn suite carrying the
-capabilities above; multi-model daily use; living in it.
+capabilities above; multi-model daily use; attn-rendered conversations via the
+pi SDK; living in it.
 
-**Non-goals:** forking or vendoring pi; RPC-mode embedding and attn-rendered
-conversations; a click-to-approve permissioning system; MCP support before
-something needs it; migrating claude/codex/copilot integrations to this
-pattern; parity for claude-code features Victor doesn't actually use.
+**Non-goals:** forking or vendoring pi; a click-to-approve permissioning
+system; MCP support before something needs it; migrating claude/codex/copilot
+integrations to this pattern; parity for claude-code features Victor doesn't
+actually use.
 
 ## Big rocks (the arc)
 
 Each rock opens with its own alignment + implementation doc.
 
-- [ ] **Driver plugin** — pi launches, resumes, and lives as an attn session.
-- [ ] **attn citizenship** — linking, declared state, doorbell/nudge steering.
+- [x] **Driver plugin** — pi launches, resumes, and lives as an attn session.
+- [x] **attn citizenship** — linking, declared state, doorbell/nudge steering.
+- [ ] **Headless host + rendered conversation** — the SDK host process and the
+      React conversation surface, built in vertical slices (own plan doc).
 - [ ] **Safety envelope + auto mode** — the autonomy dial.
 - [ ] **Subagents** — adapted from ecosystem prior art.
 - [ ] **Background eyes** — monitors that wake the agent.
@@ -129,10 +146,3 @@ Each rock opens with its own alignment + implementation doc.
 
 - The safety envelope's exact policy vocabulary — designed fresh in its own
   doc, not inherited from claude's permission modes.
-- The shape of the stop-enrichment service (how the plugin asks attn to
-  classify a stop as done vs. waiting on a reply) — designed in the
-  citizenship doc.
-- **Blindspots (ground before the first chunk):** pi's extension runtime under
-  long-lived real sessions; pi's release cadence and API stability in
-  practice; how pi's TUI behaves under attn's PTY geometry rules compared to
-  claude/codex.


### PR DESCRIPTION
## What

Two documents, no code changes.

**`docs/vision/pi-attn-plugins.md`** — the pi vision now includes attn rendering the conversation. The attn-pi plugin provides a headless host entrypoint (Bun, in-repo) running pi via `createAgentSession`; the daemon spawns it per session and owns its process group; the app renders the conversation in React with terminal-transcript density built from real UI (expandable tool calls, rendered diffs, inline images). The PTY/terminal path stays for claude/codex/shell sessions. New north-star principle: **attn integrates on declarations, never on renderings** — the host emits a typed semantic stream in attn's own vocabulary (session linked, run started/settled, state, tool started/finished, message committed) that the daemon and every attn feature integrate on, plus a render stream the daemon routes without parsing. Loop ownership is unchanged: pi owns the loop, models, and context. Also: the two landed rocks (driver plugin, citizenship) are checked off, and stale open questions were settled or removed.

**`docs/plans/2026-08-05-pi-headless-host.md`** (new) — the implementation plan as vertical slices, each shipping end to end (host → daemon → app): (1) live chatbox, (2) state + first-class nudges via pi's steer/followUp verbs with visible queued→seen delivery, (3) tool visibility with collapsed cards and on-demand detail, (4) crash/revive with windowed attach snapshots, (5) history/resume/model switching. Skills, safety envelope, subagents, and background eyes remain vision rocks, not slices.

## Grounding

The plan's design decisions carry receipts from a 2026-08-04 source read and instrumented live spike against pi 0.80.10 (two providers), summarized in the plan's Grounding section: `agent_settled` semantics and abort event tails, steer/followUp drain points, orphaned-tool-subprocesses on hard kill (hence daemon-owned process groups), session-file format/versioning and the no-file-before-first-assistant-message trap, streaming delta rates (hence host-side coalescing), transcript-size distribution (hence windowed snapshots), and pi's measured release cadence (hence the exact pin with a committed spike harness as the bump gate).

## Verification

Docs-only; no runtime surface. Cross-doc links audited against main after the #757 plan triage (one dangling link to a deleted plan fixed in the header note).

https://claude.ai/code/session_01VBeTK9W76BS9DxwXfhzBh4