### PR TITLE
fix(terminal): speed cold restores and preserve colors

### DIFF
--- a/app/src/App.sessionlessWorkspace.test.tsx
+++ b/app/src/App.sessionlessWorkspace.test.tsx
@@ -390,6 +390,12 @@ describe('tile-only (sessionless) workspace selection and render', () => {
         foreground: '#d4d4d4',
         background: '#1e1e1e',
         cursor: '#d4d4d4',
+        ansi_palette: [
+          '#000000', '#cd3131', '#0dbc79', '#e5e510',
+          '#2472c8', '#bc3fbc', '#11a8cd', '#e5e5e5',
+          '#666666', '#f14c4c', '#23d18b', '#f5f543',
+          '#3b8eea', '#d670d6', '#29b8db', '#ffffff',
+        ],
       });
     });
   });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -121,7 +121,7 @@ import {
 } from './utils/queueBands';
 import { useWorkspaceSelectionController } from './hooks/useWorkspaceSelectionController';
 import { hideBootSplash } from './utils/bootSplash';
-import { getTerminalTheme } from './utils/terminalSizing';
+import { getTerminalAnsiPaletteColors, getTerminalTheme } from './utils/terminalSizing';
 import './App.css';
 
 const RELEASES_LATEST_API = 'https://api.github.com/repos/victorarias/attn/releases/latest';
@@ -999,7 +999,12 @@ function AppContent({
   useEffect(() => {
     if (!hasReceivedInitialState) return;
     const theme = getTerminalTheme(resolvedTheme);
-    sendSetTerminalTheme({ foreground: theme.foreground, background: theme.background, cursor: theme.cursor });
+    sendSetTerminalTheme({
+      foreground: theme.foreground,
+      background: theme.background,
+      cursor: theme.cursor,
+      ansi_palette: getTerminalAnsiPaletteColors(resolvedTheme),
+    });
   }, [hasReceivedInitialState, resolvedTheme, sendSetTerminalTheme]);
 
   // Settings modal (lifted from Dashboard for Cmd+, access)

--- a/app/src/components/GhosttyTerminal.modelFault.test.tsx
+++ b/app/src/components/GhosttyTerminal.modelFault.test.tsx
@@ -103,7 +103,7 @@ vi.mock('ghostty-web', () => ({
   },
 }));
 
-vi.mock('../ghostty/wasm', () => ({ ghosttyWasmUrl: 'mock-wasm-url' }));
+vi.mock('../ghostty/wasm', () => ({ loadGhostty: async () => ({ createTerminal: mocks.createTerminal }) }));
 vi.mock('./GhosttyWebGlRenderer', () => ({ WebGlTerminalRenderer: mocks.MockRenderer }));
 vi.mock('../utils/terminalIconFont', () => ({
   ensureTerminalIconFont: () => new Promise<void>(() => undefined),

--- a/app/src/components/GhosttyTerminal.modelOpCapture.test.tsx
+++ b/app/src/components/GhosttyTerminal.modelOpCapture.test.tsx
@@ -91,7 +91,7 @@ vi.mock('ghostty-web', () => ({
   Ghostty: { load: async () => ({ createTerminal: mocks.createTerminal }) },
   InputHandler: class { dispose() {} },
 }));
-vi.mock('../ghostty/wasm', () => ({ ghosttyWasmUrl: 'mock-wasm-url' }));
+vi.mock('../ghostty/wasm', () => ({ loadGhostty: async () => ({ createTerminal: mocks.createTerminal }) }));
 vi.mock('./GhosttyWebGlRenderer', () => ({ WebGlTerminalRenderer: mocks.MockRenderer }));
 vi.mock('../utils/terminalIconFont', () => ({
   ensureTerminalIconFont: () => new Promise<void>(() => undefined),

--- a/app/src/components/GhosttyTerminal.noReflowResize.test.tsx
+++ b/app/src/components/GhosttyTerminal.noReflowResize.test.tsx
@@ -78,7 +78,7 @@ vi.mock('ghostty-web', () => ({
   Ghostty: { load: async () => ({ createTerminal: mocks.createTerminal }) },
   InputHandler: class { dispose() {} },
 }));
-vi.mock('../ghostty/wasm', () => ({ ghosttyWasmUrl: 'mock-wasm-url' }));
+vi.mock('../ghostty/wasm', () => ({ loadGhostty: async () => ({ createTerminal: mocks.createTerminal }) }));
 vi.mock('./GhosttyWebGlRenderer', () => ({ WebGlTerminalRenderer: mocks.MockRenderer }));
 vi.mock('../utils/terminalIconFont', () => ({
   ensureTerminalIconFont: () => new Promise<void>(() => undefined),

--- a/app/src/components/GhosttyTerminal.pixelGeometry.test.tsx
+++ b/app/src/components/GhosttyTerminal.pixelGeometry.test.tsx
@@ -66,7 +66,7 @@ vi.mock('ghostty-web', () => ({
   Ghostty: { load: async () => ({ createTerminal: mocks.createTerminal }) },
   InputHandler: class { dispose() {} },
 }));
-vi.mock('../ghostty/wasm', () => ({ ghosttyWasmUrl: 'mock-wasm-url' }));
+vi.mock('../ghostty/wasm', () => ({ loadGhostty: async () => ({ createTerminal: mocks.createTerminal }) }));
 vi.mock('./GhosttyWebGlRenderer', () => ({ WebGlTerminalRenderer: mocks.MockRenderer }));
 vi.mock('../utils/terminalIconFont', () => ({
   ensureTerminalIconFont: () => new Promise<void>(() => undefined),

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -717,7 +717,10 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const [modelOpRing] = useState(createGhosttyModelOpRing);
     const modelOpRingRef = useRef(modelOpRing);
     const historicalReplayGenerationRef = useRef(0);
-    const cooperativeReplayBudgetRef = useRef(new CooperativeReplayBudget());
+    // Allocated once per pane through useState's lazy initializer, like the op
+    // ring above; the ref only carries it.
+    const [cooperativeReplayBudget] = useState(() => new CooperativeReplayBudget());
+    const cooperativeReplayBudgetRef = useRef(cooperativeReplayBudget);
     const pendingReplayGeometryRef = useRef<PendingReplayGeometry | null>(null);
     // Queued historical-replay operations (writes + resizes) not yet applied.
     // Used to detect that a generation bump actually discarded history.

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -7,8 +7,9 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Ghostty, InputHandler, CellFlags, type GhosttyCell, type GhosttyTerminal as GhosttyModel } from 'ghostty-web';
-import { ghosttyWasmUrl } from '../ghostty/wasm';
+import { InputHandler, CellFlags, type GhosttyCell, type GhosttyTerminal as GhosttyModel } from 'ghostty-web';
+import { loadGhostty } from '../ghostty/wasm';
+import { CooperativeReplayBudget } from '../utils/cooperativeReplay';
 import { openPath, openUrl } from '@tauri-apps/plugin-opener';
 import { exists } from '@tauri-apps/plugin-fs';
 import { homeDir } from '@tauri-apps/api/path';
@@ -214,7 +215,6 @@ export interface GhosttyTerminalHandle {
     data: string | Uint8Array,
     options?: {
       suppressResponses?: boolean;
-      yieldBefore?: boolean;
       deferRender?: boolean;
       historicalReplay?: boolean;
     },
@@ -717,6 +717,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const [modelOpRing] = useState(createGhosttyModelOpRing);
     const modelOpRingRef = useRef(modelOpRing);
     const historicalReplayGenerationRef = useRef(0);
+    const cooperativeReplayBudgetRef = useRef(new CooperativeReplayBudget());
     const pendingReplayGeometryRef = useRef<PendingReplayGeometry | null>(null);
     // Queued historical-replay operations (writes + resizes) not yet applied.
     // Used to detect that a generation bump actually discarded history.
@@ -1705,7 +1706,6 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       data: string | Uint8Array,
       options?: {
         suppressResponses?: boolean;
-        yieldBefore?: boolean;
         deferRender?: boolean;
         historicalReplay?: boolean;
       },
@@ -1730,15 +1730,23 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           options?.historicalReplay
           && historicalReplayGeneration !== historicalReplayGenerationRef.current
         ) {
+          if (pendingReplayOpsRef.current === 0) {
+            cooperativeReplayBudgetRef.current.reset();
+          }
           return;
         }
-        if (options?.yieldBefore) {
-          await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
+        if (options?.historicalReplay) {
+          await cooperativeReplayBudgetRef.current.beforeOperation();
+        } else {
+          cooperativeReplayBudgetRef.current.reset();
         }
         if (
           options?.historicalReplay
           && historicalReplayGeneration !== historicalReplayGenerationRef.current
         ) {
+          if (pendingReplayOpsRef.current === 0) {
+            cooperativeReplayBudgetRef.current.reset();
+          }
           return;
         }
         const terminal = terminalRef.current;
@@ -1876,6 +1884,9 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           cols: terminal.cols,
           rows: terminal.rows,
         });
+        if (options?.historicalReplay && pendingReplayOpsRef.current === 0) {
+          cooperativeReplayBudgetRef.current.reset();
+        }
         if (options?.deferRender && synchronizedOutput.shouldRender) {
           return;
         }
@@ -2116,6 +2127,9 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       return enqueueOperation('resizeLocal', () => {
         if (options?.historicalReplay) {
           pendingReplayOpsRef.current = Math.max(0, pendingReplayOpsRef.current - 1);
+          if (pendingReplayOpsRef.current === 0) {
+            cooperativeReplayBudgetRef.current.reset();
+          }
           if (pendingReplayGeometryRef.current) {
             pendingReplayGeometryRef.current.resizes = Math.max(
               0,
@@ -2430,7 +2444,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           setRendererEpoch((value) => value + 1);
         }, delay);
       };
-      void Ghostty.load(ghosttyWasmUrl).then((ghostty) => {
+      void loadGhostty().then((ghostty) => {
         if (!active) return;
         const theme = getTerminalTheme(resolvedTheme);
         const initialSize = modelSizeRef.current;

--- a/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.test.ts
+++ b/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.test.ts
@@ -153,7 +153,6 @@ describe('useGhosttyPaneRuntime', () => {
       expect.any(Uint8Array),
       {
         suppressResponses: true,
-        yieldBefore: true,
         deferRender: true,
         historicalReplay: true,
       },
@@ -189,13 +188,11 @@ describe('useGhosttyPaneRuntime', () => {
     expect((secondWrite[0] as Uint8Array)).toEqual(Uint8Array.of(66));
     expect(firstWrite[1]).toEqual({
       suppressResponses: true,
-      yieldBefore: true,
       deferRender: true,
       historicalReplay: true,
     });
     expect(secondWrite[1]).toEqual({
       suppressResponses: true,
-      yieldBefore: true,
       deferRender: true,
       historicalReplay: true,
     });

--- a/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.ts
+++ b/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.ts
@@ -122,7 +122,6 @@ export function useGhosttyPaneRuntime(
               bytes.subarray(offset, offset + HISTORICAL_REPLAY_CHUNK_BYTES),
               {
                 suppressResponses,
-                yieldBefore: true,
                 deferRender: true,
                 historicalReplay: true,
               },

--- a/app/src/components/grid/GridView.tsx
+++ b/app/src/components/grid/GridView.tsx
@@ -19,8 +19,8 @@
 // We grab stage focus on open/zoom so input follows the zoom instead of leaking
 // to whichever pane held focus when the grid opened.
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Ghostty, InputHandler } from 'ghostty-web';
-import { ghosttyWasmUrl } from '../../ghostty/wasm';
+import { InputHandler } from 'ghostty-web';
+import { loadGhostty } from '../../ghostty/wasm';
 import { listenPtyEvents, ptyWrite } from '../../pty/bridge';
 import { installTerminalKeyHandler } from '../SessionTerminalWorkspace/terminalKeyHandler';
 import type { ScreenSnapshotResult } from '../../hooks/useDaemonSocket';
@@ -186,7 +186,7 @@ export function GridView({
       cursor: theme.cursor,
     });
 
-    void Ghostty.load(ghosttyWasmUrl).then((ghostty) => {
+    void loadGhostty().then((ghostty) => {
       if (disposed) return;
       const comp = new GridCompositor(renderer, ghostty, stage, metrics, {
         scrollbackLimit: TERMINAL_SCROLLBACK_BYTES,

--- a/app/src/ghostty/wasm.test.ts
+++ b/app/src/ghostty/wasm.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  constructedWith: [] as WebAssembly.Instance[],
+}));
+
+vi.mock('ghostty-web', () => ({
+  Ghostty: class {
+    constructor(instance: WebAssembly.Instance) {
+      mocks.constructedWith.push(instance);
+    }
+  },
+}));
+
+import { loadGhostty, resetGhosttyModuleCacheForTests } from './wasm';
+
+describe('loadGhostty', () => {
+  beforeEach(() => {
+    resetGhosttyModuleCacheForTests();
+    mocks.constructedWith.length = 0;
+  });
+
+  it('compiles once and creates a separate WASM instance per caller', async () => {
+    const module = {} as WebAssembly.Module;
+    const instances = [
+      { exports: { memory: new WebAssembly.Memory({ initial: 1 }) } },
+      { exports: { memory: new WebAssembly.Memory({ initial: 1 }) } },
+    ] as WebAssembly.Instance[];
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      arrayBuffer: async () => new ArrayBuffer(8),
+    })));
+    const compile = vi.spyOn(WebAssembly, 'compile').mockResolvedValue(module);
+    const instantiate = vi.spyOn(WebAssembly, 'instantiate')
+      .mockResolvedValueOnce(instances[0])
+      .mockResolvedValueOnce(instances[1]);
+
+    await Promise.all([loadGhostty(), loadGhostty()]);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(compile).toHaveBeenCalledTimes(1);
+    expect(instantiate).toHaveBeenCalledTimes(2);
+    expect(mocks.constructedWith).toEqual(instances);
+  });
+});

--- a/app/src/ghostty/wasm.ts
+++ b/app/src/ghostty/wasm.ts
@@ -1,3 +1,53 @@
 import ghosttyWasmUrl from '../../vendor/ghostty-vt/ghostty-vt.wasm?url';
+import { Ghostty } from 'ghostty-web';
 
 export { ghosttyWasmUrl };
+
+let compiledGhosttyModule: Promise<WebAssembly.Module> | null = null;
+
+async function compileGhosttyModule(): Promise<WebAssembly.Module> {
+  const response = await fetch(ghosttyWasmUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Ghostty WASM: ${response.status} ${response.statusText}`);
+  }
+  const bytes = await response.arrayBuffer();
+  if (bytes.byteLength === 0) {
+    throw new Error(`Ghostty WASM file is empty: ${ghosttyWasmUrl}`);
+  }
+  return WebAssembly.compile(bytes);
+}
+
+async function getCompiledGhosttyModule(): Promise<WebAssembly.Module> {
+  if (!compiledGhosttyModule) {
+    compiledGhosttyModule = compileGhosttyModule().catch((error) => {
+      compiledGhosttyModule = null;
+      throw error;
+    });
+  }
+  return compiledGhosttyModule;
+}
+
+// Compile the app's one vendored module once, then instantiate a fresh runtime
+// for every terminal. Separate instances retain pane-level crash isolation;
+// sharing only the immutable WebAssembly.Module removes cold-remount compile
+// work without letting one corrupt model take another pane down with it.
+export async function loadGhostty(): Promise<Ghostty> {
+  const module = await getCompiledGhosttyModule();
+  let instance: WebAssembly.Instance | null = null;
+  const instantiated = await WebAssembly.instantiate(module, {
+    env: {
+      log: (ptr: number, len: number) => {
+        if (!instance) return;
+        const memory = instance.exports.memory as WebAssembly.Memory;
+        const bytes = new Uint8Array(memory.buffer, ptr, len);
+        console.log('[ghostty-vt]', new TextDecoder().decode(bytes));
+      },
+    },
+  });
+  instance = instantiated;
+  return new Ghostty(instance);
+}
+
+export function resetGhosttyModuleCacheForTests(): void {
+  compiledGhosttyModule = null;
+}

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -2451,7 +2451,10 @@ describe('useDaemonSocket PTY kill sequencing', () => {
 
     // Sent before the daemon handshake completes: must queue, not drop.
     act(() => {
-      result.current.sendSetTerminalTheme({ foreground: '#d4d4d4', background: '#1e1e1e', cursor: '#d4d4d4' });
+      result.current.sendSetTerminalTheme({
+        foreground: '#d4d4d4', background: '#1e1e1e', cursor: '#d4d4d4',
+        ansi_palette: Array(16).fill('#000000'),
+      });
     });
     expect(ws.sent.map((entry) => JSON.parse(entry))).not.toContainEqual(
       expect.objectContaining({ cmd: 'set_terminal_theme' }),
@@ -2475,6 +2478,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
         foreground: '#d4d4d4',
         background: '#1e1e1e',
         cursor: '#d4d4d4',
+        ansi_palette: Array(16).fill('#000000'),
       });
     });
 
@@ -2507,7 +2511,10 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     });
 
     act(() => {
-      result.current.sendSetTerminalTheme({ foreground: '#d4d4d4', background: '#1e1e1e', cursor: '#d4d4d4' });
+      result.current.sendSetTerminalTheme({
+        foreground: '#d4d4d4', background: '#1e1e1e', cursor: '#d4d4d4',
+        ansi_palette: Array(16).fill('#000000'),
+      });
     });
     await waitFor(() => {
       expect(ws.sent.map((entry) => JSON.parse(entry))).toContainEqual({
@@ -2515,6 +2522,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
         foreground: '#d4d4d4',
         background: '#1e1e1e',
         cursor: '#d4d4d4',
+        ansi_palette: Array(16).fill('#000000'),
       });
     });
 
@@ -2549,6 +2557,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
         foreground: '#d4d4d4',
         background: '#1e1e1e',
         cursor: '#d4d4d4',
+        ansi_palette: Array(16).fill('#000000'),
       });
     });
 

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -197,7 +197,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '209';
+export const PROTOCOL_VERSION = '210';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a
@@ -927,7 +927,12 @@ export function useDaemonSocket({
   const hasReceivedInitialStateRef = useRef(false);
   // The daemon holds the terminal theme in memory only (no persistence), so
   // every (re)connect must re-seed it — see the initial_state handler below.
-  const lastTerminalThemeRef = useRef<{ foreground: string; background: string; cursor: string } | null>(null);
+  const lastTerminalThemeRef = useRef<{
+    foreground: string;
+    background: string;
+    cursor: string;
+    ansi_palette: string[];
+  } | null>(null);
   // Once we detect a profile mismatch, we refuse to operate forever — the
   // user must quit and launch the matching app. Never clears inside the
   // session.
@@ -1466,6 +1471,7 @@ export function useDaemonSocket({
                 foreground: theme.foreground,
                 background: theme.background,
                 cursor: theme.cursor,
+                ansi_palette: theme.ansi_palette,
               }));
             }
             if (ws.readyState === WebSocket.OPEN) {
@@ -2975,16 +2981,28 @@ export function useDaemonSocket({
   }, [sendOrQueueCommand]);
 
   // Pushes the app's resolved terminal theme colors to the daemon, which uses
-  // them to answer OSC 10/11/12 (foreground/background/cursor) color queries
-  // on behalf of every session — see stripDaemonOwnedResponses in
+  // them to seed the worker's authoritative color model and answer OSC
+  // 10/11/12 (foreground/background/cursor) queries on behalf of every session
+  // — see stripDaemonOwnedResponses in
   // terminalQueryResponses.ts for why the frontend no longer answers these
   // itself. Fire-and-forget like sendPtyResize: a dropped send just means the
   // daemon answers with a stale theme until the next push (on reconnect or
   // theme change), which self-heals.
-  const sendSetTerminalTheme = useCallback((theme: { foreground: string; background: string; cursor: string }) => {
+  const sendSetTerminalTheme = useCallback((theme: {
+    foreground: string;
+    background: string;
+    cursor: string;
+    ansi_palette: string[];
+  }) => {
     lastTerminalThemeRef.current = theme;
     sendOrQueueCommand(
-      { cmd: 'set_terminal_theme', foreground: theme.foreground, background: theme.background, cursor: theme.cursor },
+      {
+        cmd: 'set_terminal_theme',
+        foreground: theme.foreground,
+        background: theme.background,
+        cursor: theme.cursor,
+        ansi_palette: theme.ansi_palette,
+      },
       { waitForInitialState: true },
     );
   }, [sendOrQueueCommand]);

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -4925,10 +4925,11 @@ export enum SetSettingMessageCmd {
 }
 
 export interface SetTerminalThemeMessage {
-    background: string;
-    cmd:        SetTerminalThemeMessageCmd;
-    cursor:     string;
-    foreground: string;
+    ansi_palette: string[];
+    background:   string;
+    cmd:          SetTerminalThemeMessageCmd;
+    cursor:       string;
+    foreground:   string;
     [property: string]: any;
 }
 
@@ -12675,6 +12676,7 @@ const typeMap: any = {
         { json: "value", js: "value", typ: "" },
     ], "any"),
     "SetTerminalThemeMessage": o([
+        { json: "ansi_palette", js: "ansi_palette", typ: a("") },
         { json: "background", js: "background", typ: "" },
         { json: "cmd", js: "cmd", typ: r("SetTerminalThemeMessageCmd") },
         { json: "cursor", js: "cursor", typ: "" },

--- a/app/src/utils/cooperativeReplay.test.ts
+++ b/app/src/utils/cooperativeReplay.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { CooperativeReplayBudget } from './cooperativeReplay';
+
+describe('CooperativeReplayBudget', () => {
+  it('keeps cheap restore writes in one browser task', async () => {
+    let now = 10;
+    const yieldTask = vi.fn(async () => {});
+    const budget = new CooperativeReplayBudget(6, () => now, yieldTask);
+
+    await expect(budget.beforeOperation()).resolves.toBe(false);
+    now += 2;
+    await expect(budget.beforeOperation()).resolves.toBe(false);
+    now += 3;
+    await expect(budget.beforeOperation()).resolves.toBe(false);
+
+    expect(yieldTask).not.toHaveBeenCalled();
+  });
+
+  it('yields once after accumulated model work consumes the slice', async () => {
+    let now = 20;
+    const yieldTask = vi.fn(async () => {
+      now += 1;
+    });
+    const budget = new CooperativeReplayBudget(6, () => now, yieldTask);
+
+    await budget.beforeOperation();
+    now += 7;
+    await expect(budget.beforeOperation()).resolves.toBe(true);
+    now += 5;
+    await expect(budget.beforeOperation()).resolves.toBe(false);
+
+    expect(yieldTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts a fresh slice after replay drains', async () => {
+    let now = 30;
+    const yieldTask = vi.fn(async () => {});
+    const budget = new CooperativeReplayBudget(6, () => now, yieldTask);
+
+    await budget.beforeOperation();
+    now += 20;
+    budget.reset();
+    await expect(budget.beforeOperation()).resolves.toBe(false);
+
+    expect(yieldTask).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/utils/cooperativeReplay.ts
+++ b/app/src/utils/cooperativeReplay.ts
@@ -1,0 +1,65 @@
+const DEFAULT_REPLAY_SLICE_BUDGET_MS = 6;
+
+type YieldTask = () => Promise<void>;
+
+let messageChannel: MessageChannel | null = null;
+const pendingMessageChannelYields: Array<() => void> = [];
+
+function yieldWithMessageChannel(): Promise<void> {
+  if (!messageChannel) {
+    messageChannel = new MessageChannel();
+    messageChannel.port1.onmessage = () => {
+      pendingMessageChannelYields.shift()?.();
+    };
+  }
+  return new Promise<void>((resolve) => {
+    pendingMessageChannelYields.push(resolve);
+    messageChannel?.port2.postMessage(undefined);
+  });
+}
+
+export function yieldToMainThread(): Promise<void> {
+  const scheduler = (globalThis as typeof globalThis & {
+    scheduler?: { yield?: () => Promise<void> };
+  }).scheduler;
+  if (scheduler?.yield) {
+    return scheduler.yield();
+  }
+  if (typeof MessageChannel !== 'undefined') {
+    return yieldWithMessageChannel();
+  }
+  return new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+// Historical restore is already segmented into bounded Ghostty writes so a
+// resize can cancel it between chunks. This budget decides when those queued
+// writes actually need to give the browser a task boundary: the old path
+// yielded before every 16 KiB chunk and paid WKWebView's timer clamp even when
+// parsing the preceding chunk took only a fraction of the frame budget.
+export class CooperativeReplayBudget {
+  private sliceStartedAt: number | null = null;
+
+  constructor(
+    private readonly budgetMs = DEFAULT_REPLAY_SLICE_BUDGET_MS,
+    private readonly now: () => number = () => performance.now(),
+    private readonly yieldTask: YieldTask = yieldToMainThread,
+  ) {}
+
+  reset(): void {
+    this.sliceStartedAt = null;
+  }
+
+  async beforeOperation(): Promise<boolean> {
+    const now = this.now();
+    if (this.sliceStartedAt === null) {
+      this.sliceStartedAt = now;
+      return false;
+    }
+    if (now - this.sliceStartedAt < this.budgetMs) {
+      return false;
+    }
+    await this.yieldTask();
+    this.sliceStartedAt = this.now();
+    return true;
+  }
+}

--- a/app/src/utils/terminalSizing.ts
+++ b/app/src/utils/terminalSizing.ts
@@ -68,6 +68,11 @@ export function getTerminalTheme(resolvedTheme: ResolvedTheme) {
 }
 
 export function getTerminalAnsiPalette(resolvedTheme: ResolvedTheme): number[] {
+  return getTerminalAnsiPaletteColors(resolvedTheme)
+    .map((color) => Number.parseInt(color.slice(1), 16));
+}
+
+export function getTerminalAnsiPaletteColors(resolvedTheme: ResolvedTheme): string[] {
   const theme = getTerminalTheme(resolvedTheme);
   return [
     theme.black,
@@ -86,5 +91,5 @@ export function getTerminalAnsiPalette(resolvedTheme: ResolvedTheme): number[] {
     theme.brightMagenta,
     theme.brightCyan,
     theme.brightWhite,
-  ].map((color) => Number.parseInt(color.slice(1), 16));
+  ];
 }

--- a/changelog.d/terminal-cold-remount-and-palette.yaml
+++ b/changelog.d/terminal-cold-remount-and-palette.yaml
@@ -1,0 +1,14 @@
+kind: fixed
+area: terminal
+change: >
+  Returning to a terminal that was released from the three-pane warm cache is
+  faster, and restored ANSI colors now match the app theme.
+symptom: >
+  Cold terminal remounts could leave the pane blank for one to two seconds, and
+  terminal colors looked muted after the Ghostty VT upgrade.
+notes: >
+  Historical replay now yields only when it consumes its frame budget, and all
+  panes share one compiled WASM module while keeping separate runtime instances.
+  The app also sends its ANSI 0-15 palette to the daemon so server-authored
+  restore snapshots use the same defaults as the browser terminal without
+  overriding colors explicitly selected by terminal programs.

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -403,6 +403,8 @@ func runPTYWorker() {
 	fs.StringVar(&cfg.ThemeForeground, "theme-foreground", "", "terminal foreground color seeded for OSC 10/11/12 queries")
 	fs.StringVar(&cfg.ThemeBackground, "theme-background", "", "terminal background color seeded for OSC 10/11/12 queries")
 	fs.StringVar(&cfg.ThemeCursor, "theme-cursor", "", "terminal cursor color seeded for OSC 10/11/12 queries")
+	var themeANSIPaletteJSON string
+	fs.StringVar(&themeANSIPaletteJSON, "theme-ansi-palette-json", "", "JSON array of the 16 terminal ANSI palette colors")
 	fs.StringVar(&cfg.Executable, "executable", "", "selected agent executable override")
 	fs.StringVar(&cfg.ClaudeExecutable, "claude-executable", "", "claude executable override")
 	fs.StringVar(&cfg.CodexExecutable, "codex-executable", "", "codex executable override")
@@ -420,6 +422,12 @@ func runPTYWorker() {
 	fs.StringVar(&cfg.OwnerNonce, "owner-nonce", "", "daemon owner nonce")
 
 	_ = fs.Parse(os.Args[2:])
+	if themeANSIPaletteJSON != "" {
+		if err := json.Unmarshal([]byte(themeANSIPaletteJSON), &cfg.ThemeANSIPalette); err != nil {
+			fmt.Fprintf(os.Stderr, "pty-worker error: invalid --theme-ansi-palette-json: %v\n", err)
+			os.Exit(1)
+		}
+	}
 	if externalCommandJSON != "" {
 		if err := json.Unmarshal([]byte(externalCommandJSON), &cfg.ExternalCommand); err != nil {
 			fmt.Fprintf(os.Stderr, "pty-worker error: invalid --external-command-json: %v\n", err)

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -723,18 +723,33 @@ func sanitizeThemeColor(value string) string {
 	return ""
 }
 
+func sanitizeANSIPalette(values []string) (palette [16]string, ok bool) {
+	if len(values) != len(palette) {
+		return palette, false
+	}
+	for i, value := range values {
+		if !hexColorPattern.MatchString(value) {
+			return [16]string{}, false
+		}
+		palette[i] = value
+	}
+	return palette, true
+}
+
 // handleSetTerminalTheme stores the daemon-global terminal theme and fans it
 // out best-effort to every live session so already-running agents answer OSC
 // 10/11/12 color queries with the new colors immediately. Fire-and-forget, no
 // result event — mirrors pty_resize.
 func (d *Daemon) handleSetTerminalTheme(client *wsClient, msg *protocol.SetTerminalThemeMessage) {
+	ansiPalette, paletteOK := sanitizeANSIPalette(msg.AnsiPalette)
 	theme := pty.TerminalTheme{
-		Foreground: sanitizeThemeColor(msg.Foreground),
-		Background: sanitizeThemeColor(msg.Background),
-		Cursor:     sanitizeThemeColor(msg.Cursor),
+		Foreground:  sanitizeThemeColor(msg.Foreground),
+		Background:  sanitizeThemeColor(msg.Background),
+		Cursor:      sanitizeThemeColor(msg.Cursor),
+		ANSIPalette: ansiPalette,
 	}
-	if theme.Foreground != msg.Foreground || theme.Background != msg.Background || theme.Cursor != msg.Cursor {
-		d.logf("set_terminal_theme: invalid color field(s) blanked, got fg=%q bg=%q cursor=%q", msg.Foreground, msg.Background, msg.Cursor)
+	if theme.Foreground != msg.Foreground || theme.Background != msg.Background || theme.Cursor != msg.Cursor || !paletteOK {
+		d.logf("set_terminal_theme: invalid color field(s) blanked, got fg=%q bg=%q cursor=%q palette_len=%d", msg.Foreground, msg.Background, msg.Cursor, len(msg.AnsiPalette))
 	}
 	d.setCurrentTerminalTheme(theme)
 

--- a/internal/daemon/ws_pty_theme_test.go
+++ b/internal/daemon/ws_pty_theme_test.go
@@ -18,13 +18,21 @@ func TestHandleSetTerminalTheme_StoresAndFansOutToLiveSessions(t *testing.T) {
 	backend := &fakeSpawnBackend{sessionIDs: []string{"sess-a", "sess-b"}}
 	d.ptyBackend = backend
 
+	palette := []string{
+		"#000000", "#cd3131", "#0dbc79", "#e5e510",
+		"#2472c8", "#bc3fbc", "#11a8cd", "#e5e5e5",
+		"#666666", "#f14c4c", "#23d18b", "#f5f543",
+		"#3b8eea", "#d670d6", "#29b8db", "#ffffff",
+	}
 	d.handleSetTerminalTheme(nil, &protocol.SetTerminalThemeMessage{
-		Foreground: "#aabbcc",
-		Background: "#001122",
-		Cursor:     "#334455",
+		Foreground:  "#aabbcc",
+		Background:  "#001122",
+		Cursor:      "#334455",
+		AnsiPalette: palette,
 	})
 
 	want := pty.TerminalTheme{Foreground: "#aabbcc", Background: "#001122", Cursor: "#334455"}
+	copy(want.ANSIPalette[:], palette)
 	if got := d.currentTerminalTheme(); got != want {
 		t.Fatalf("currentTerminalTheme() = %+v, want %+v", got, want)
 	}
@@ -70,9 +78,10 @@ func TestHandleSetTerminalTheme_BlanksInvalidColors(t *testing.T) {
 	d.ptyBackend = &fakeSpawnBackend{}
 
 	d.handleSetTerminalTheme(nil, &protocol.SetTerminalThemeMessage{
-		Foreground: "red",
-		Background: "#001122",
-		Cursor:     "not-a-color",
+		Foreground:  "red",
+		Background:  "#001122",
+		Cursor:      "not-a-color",
+		AnsiPalette: []string{"#000000"},
 	})
 
 	want := pty.TerminalTheme{Foreground: "", Background: "#001122", Cursor: ""}

--- a/internal/ghosttyvt/ghosttyvt.go
+++ b/internal/ghosttyvt/ghosttyvt.go
@@ -55,6 +55,52 @@ static GhosttyResult ghosttyvt_set_kitty_limit(GhosttyTerminal t, uint64_t v) {
 	return ghostty_terminal_set(t, GHOSTTY_TERMINAL_OPT_KITTY_IMAGE_STORAGE_LIMIT, &v);
 }
 
+static GhosttyColorRgb ghosttyvt_rgb(uint32_t value) {
+	GhosttyColorRgb color = {
+		.r = (uint8_t)(value >> 16),
+		.g = (uint8_t)(value >> 8),
+		.b = (uint8_t)value,
+	};
+	return color;
+}
+
+// Set embedder defaults while preserving any program-owned OSC overrides.
+// Ghostty's palette setter takes all 256 entries, so begin with its current
+// default palette and replace only the 16 ANSI colors attn configures.
+static GhosttyResult ghosttyvt_set_color_theme(
+	GhosttyTerminal t,
+	bool has_foreground, uint32_t foreground,
+	bool has_background, uint32_t background,
+	bool has_cursor, uint32_t cursor,
+	bool has_ansi_palette, const uint32_t* ansi_palette
+) {
+	GhosttyResult rc;
+	if (has_foreground) {
+		GhosttyColorRgb color = ghosttyvt_rgb(foreground);
+		rc = ghostty_terminal_set(t, GHOSTTY_TERMINAL_OPT_COLOR_FOREGROUND, &color);
+		if (rc != GHOSTTY_SUCCESS) return rc;
+	}
+	if (has_background) {
+		GhosttyColorRgb color = ghosttyvt_rgb(background);
+		rc = ghostty_terminal_set(t, GHOSTTY_TERMINAL_OPT_COLOR_BACKGROUND, &color);
+		if (rc != GHOSTTY_SUCCESS) return rc;
+	}
+	if (has_cursor) {
+		GhosttyColorRgb color = ghosttyvt_rgb(cursor);
+		rc = ghostty_terminal_set(t, GHOSTTY_TERMINAL_OPT_COLOR_CURSOR, &color);
+		if (rc != GHOSTTY_SUCCESS) return rc;
+	}
+	if (has_ansi_palette) {
+		GhosttyColorRgb palette[256];
+		rc = ghostty_terminal_get(t, GHOSTTY_TERMINAL_DATA_COLOR_PALETTE_DEFAULT, palette);
+		if (rc != GHOSTTY_SUCCESS) return rc;
+		for (size_t i = 0; i < 16; i++) palette[i] = ghosttyvt_rgb(ansi_palette[i]);
+		rc = ghostty_terminal_set(t, GHOSTTY_TERMINAL_OPT_COLOR_PALETTE, palette);
+		if (rc != GHOSTTY_SUCCESS) return rc;
+	}
+	return GHOSTTY_SUCCESS;
+}
+
 // Build formatter options: one self-contained VT (or plain) stream with all
 // "extra" state on and unwrap=false so soft-wrap survives the dump. NULL
 // selection = the entire screen including scrollback history.
@@ -302,6 +348,32 @@ func (t *Terminal) Write(p []byte) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.writeLocked(p)
+}
+
+// SetColorTheme replaces the embedder-owned color defaults. Ghostty preserves
+// program-issued OSC overrides, so a later theme change does not erase an
+// application's deliberate palette mutation.
+func (t *Terminal) SetColorTheme(theme ColorTheme) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.closed {
+		return nil
+	}
+	palette := [16]C.uint32_t{}
+	for i, color := range theme.ANSIPalette {
+		palette[i] = C.uint32_t(color)
+	}
+	rc := C.ghosttyvt_set_color_theme(
+		t.term,
+		C.bool(theme.HasForeground), C.uint32_t(theme.Foreground),
+		C.bool(theme.HasBackground), C.uint32_t(theme.Background),
+		C.bool(theme.HasCursor), C.uint32_t(theme.Cursor),
+		C.bool(theme.HasANSIPalette), &palette[0],
+	)
+	if rc != C.GHOSTTY_SUCCESS {
+		return fmt.Errorf("ghosttyvt: set color theme failed: rc=%d", int(rc))
+	}
+	return nil
 }
 
 // Resize changes the terminal dimensions; the primary screen reflows when

--- a/internal/ghosttyvt/stub.go
+++ b/internal/ghosttyvt/stub.go
@@ -42,6 +42,8 @@ func New(cols, rows int, _ Options) (*Terminal, error) {
 
 func (t *Terminal) Write(_ []byte) {}
 
+func (t *Terminal) SetColorTheme(_ ColorTheme) error { return nil }
+
 func (t *Terminal) Resize(cols, rows int) {
 	if cols > 0 && rows > 0 {
 		t.cols, t.rows = cols, rows

--- a/internal/ghosttyvt/theme.go
+++ b/internal/ghosttyvt/theme.go
@@ -1,0 +1,14 @@
+package ghosttyvt
+
+// ColorTheme is the embedder-owned default color state. Programs may layer OSC
+// overrides on top; updating these defaults must preserve those overrides.
+type ColorTheme struct {
+	Foreground     uint32
+	Background     uint32
+	Cursor         uint32
+	ANSIPalette    [16]uint32
+	HasForeground  bool
+	HasBackground  bool
+	HasCursor      bool
+	HasANSIPalette bool
+}

--- a/internal/ghosttyvt/theme_test.go
+++ b/internal/ghosttyvt/theme_test.go
@@ -1,0 +1,45 @@
+package ghosttyvt
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestSetColorThemeSerializesEmbedderANSIPalette(t *testing.T) {
+	term, err := New(20, 4, Options{})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(term.Close)
+
+	theme := ColorTheme{HasANSIPalette: true}
+	theme.ANSIPalette[2] = 0x0dbc79
+	if err := term.SetColorTheme(theme); err != nil {
+		t.Fatalf("SetColorTheme() error = %v", err)
+	}
+
+	dump := term.Serialize().VTDump
+	if !bytes.Contains(dump, []byte("\x1b]4;2;rgb:0d/bc/79\x1b\\")) {
+		t.Fatalf("serialized palette does not contain attn green: %q", dump)
+	}
+}
+
+func TestSetColorThemePreservesProgramPaletteOverride(t *testing.T) {
+	term, err := New(20, 4, Options{})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(term.Close)
+
+	term.Write([]byte("\x1b]4;2;rgb:12/34/56\x1b\\"))
+	theme := ColorTheme{HasANSIPalette: true}
+	theme.ANSIPalette[2] = 0x0dbc79
+	if err := term.SetColorTheme(theme); err != nil {
+		t.Fatalf("SetColorTheme() error = %v", err)
+	}
+
+	dump := term.Serialize().VTDump
+	if !bytes.Contains(dump, []byte("\x1b]4;2;rgb:12/34/56\x1b\\")) {
+		t.Fatalf("serialized palette lost the OSC 4 override: %q", dump)
+	}
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "209"
+const ProtocolVersion = "210"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -4801,6 +4801,9 @@ type SetSettingMessage struct {
 }
 
 type SetTerminalThemeMessage struct {
+	// AnsiPalette corresponds to the JSON schema field "ansi_palette".
+	AnsiPalette []string `json:"ansi_palette"`
+
 	// Background corresponds to the JSON schema field "background".
 	Background string `json:"background"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -1906,6 +1906,7 @@ model SetTerminalThemeMessage {
   foreground: string; // "#rrggbb"
   background: string; // "#rrggbb"
   cursor: string; // "#rrggbb"
+  ansi_palette: string[]; // Exactly 16 "#rrggbb" entries, ANSI 0-15.
 }
 
 model KillSessionMessage {

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -330,6 +330,20 @@ func (m *Manager) Spawn(opts SpawnOptions) error {
 		return fmt.Errorf("ghostty terminal construction failed: %w", err)
 	}
 	session.ghostty = gt
+	if err := session.SetTheme(opts.Theme); err != nil {
+		gt.Close()
+		if ptmx != nil {
+			_ = ptmx.Close()
+		}
+		if cmd != nil && cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+		if deferCleanup != nil {
+			deferCleanup()
+		}
+		return fmt.Errorf("ghostty terminal theme failed: %w", err)
+	}
 	// One epoch per terminal, held by both halves that hand a generation out:
 	// the placement read and the image serve. A worker that replaces another
 	// under the same session id gets a different one, which is what keeps a
@@ -406,14 +420,14 @@ func (m *Manager) KittyImage(sessionID string, imageID uint32) (KittyImage, erro
 	return session.kittyImage(imageID)
 }
 
-// SetTheme replaces the colors sessionID answers OSC 10/11/12 queries with.
+// SetTheme replaces the embedder-owned terminal colors and the colors sessionID
+// answers OSC 10/11/12 queries with.
 func (m *Manager) SetTheme(sessionID string, theme TerminalTheme) error {
 	session, err := m.getSession(sessionID)
 	if err != nil {
 		return err
 	}
-	session.SetTheme(theme)
-	return nil
+	return session.SetTheme(theme)
 }
 
 // Snapshot returns the current rendered screen and sequence watermark for a

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -20,9 +21,10 @@ import (
 // TerminalTheme carries the frontend's resolved terminal colors as "#rrggbb"
 // hex strings. Zero-value fields fall back to built-in dark defaults.
 type TerminalTheme struct {
-	Foreground string
-	Background string
-	Cursor     string
+	Foreground  string
+	Background  string
+	Cursor      string
+	ANSIPalette [16]string
 }
 
 // Default OSC 10/11/12 colors, used for any TerminalTheme field that is empty
@@ -1050,10 +1052,50 @@ func detectTerminalQueries(data []byte) terminalQueries {
 
 // SetTheme replaces the colors used to answer OSC 10/11/12 queries. Safe to
 // call concurrently with the read loop.
-func (s *Session) SetTheme(theme TerminalTheme) {
+func (s *Session) SetTheme(theme TerminalTheme) error {
+	if s.ghostty != nil {
+		if err := s.ghostty.SetColorTheme(ghosttyColorTheme(theme)); err != nil {
+			return err
+		}
+	}
 	s.themeMu.Lock()
 	s.theme = theme
 	s.themeMu.Unlock()
+	return nil
+}
+
+func parseThemeColor(value, fallback string) uint32 {
+	if len(value) != 7 || value[0] != '#' {
+		value = fallback
+	}
+	parsed, err := strconv.ParseUint(value[1:], 16, 32)
+	if err != nil {
+		parsed, _ = strconv.ParseUint(fallback[1:], 16, 32)
+	}
+	return uint32(parsed)
+}
+
+func ghosttyColorTheme(theme TerminalTheme) ghosttyvt.ColorTheme {
+	result := ghosttyvt.ColorTheme{
+		Foreground:    parseThemeColor(theme.Foreground, defaultThemeForeground),
+		Background:    parseThemeColor(theme.Background, defaultThemeBackground),
+		Cursor:        parseThemeColor(theme.Cursor, defaultThemeCursor),
+		HasForeground: true,
+		HasBackground: true,
+		HasCursor:     true,
+	}
+	for i, value := range theme.ANSIPalette {
+		if len(value) != 7 || value[0] != '#' {
+			return result
+		}
+		parsed, err := strconv.ParseUint(value[1:], 16, 32)
+		if err != nil {
+			return result
+		}
+		result.ANSIPalette[i] = uint32(parsed)
+	}
+	result.HasANSIPalette = true
+	return result
 }
 
 func (s *Session) currentTheme() TerminalTheme {

--- a/internal/ptybackend/worker.go
+++ b/internal/ptybackend/worker.go
@@ -401,6 +401,13 @@ func (b *WorkerBackend) spawnArgs(opts SpawnOptions, session *workerSession) ([]
 	if opts.Theme.Cursor != "" {
 		args = append(args, "--theme-cursor", opts.Theme.Cursor)
 	}
+	if opts.Theme.ANSIPalette != ([16]string{}) {
+		paletteJSON, err := json.Marshal(opts.Theme.ANSIPalette)
+		if err != nil {
+			return nil, fmt.Errorf("marshal terminal ANSI palette: %w", err)
+		}
+		args = append(args, "--theme-ansi-palette-json", string(paletteJSON))
+	}
 	if opts.Executable != "" {
 		args = append(args, "--executable", opts.Executable)
 	}
@@ -769,9 +776,10 @@ func (b *WorkerBackend) SetTheme(ctx context.Context, sessionID string, theme pt
 		return err
 	}
 	err = b.callSimple(ctx, session, ptyworker.MethodSetTheme, ptyworker.SetThemeParams{
-		Foreground: theme.Foreground,
-		Background: theme.Background,
-		Cursor:     theme.Cursor,
+		Foreground:  theme.Foreground,
+		Background:  theme.Background,
+		Cursor:      theme.Cursor,
+		ANSIPalette: theme.ANSIPalette,
 	})
 	if err == nil {
 		return nil

--- a/internal/ptybackend/worker_test.go
+++ b/internal/ptybackend/worker_test.go
@@ -1336,13 +1336,19 @@ func TestWorkerBackend_Spawn_PassesThemeFlagsOnlyWhenSet(t *testing.T) {
 		ControlToken: "test-token",
 	}
 
+	palette := [16]string{
+		"#000000", "#cd3131", "#0dbc79", "#e5e510",
+		"#2472c8", "#bc3fbc", "#11a8cd", "#e5e5e5",
+		"#666666", "#f14c4c", "#23d18b", "#f5f543",
+		"#3b8eea", "#d670d6", "#29b8db", "#ffffff",
+	}
 	argv, err := backend.spawnArgs(SpawnOptions{
 		ID:    "sess-theme-set",
 		Agent: "shell",
 		CWD:   root,
 		Cols:  80,
 		Rows:  24,
-		Theme: pty.TerminalTheme{Foreground: "#aabbcc", Background: "#001122", Cursor: "#334455"},
+		Theme: pty.TerminalTheme{Foreground: "#aabbcc", Background: "#001122", Cursor: "#334455", ANSIPalette: palette},
 	}, session)
 	if err != nil {
 		t.Fatalf("spawnArgs(theme set) error: %v", err)
@@ -1357,6 +1363,9 @@ func TestWorkerBackend_Spawn_PassesThemeFlagsOnlyWhenSet(t *testing.T) {
 			t.Fatalf("argv flag %s = %q, want %q (argv=%v)", flag, got, want, argv)
 		}
 	}
+	if got, want := argAfterFlag(argv, "--theme-ansi-palette-json"), `["#000000","#cd3131","#0dbc79","#e5e510","#2472c8","#bc3fbc","#11a8cd","#e5e5e5","#666666","#f14c4c","#23d18b","#f5f543","#3b8eea","#d670d6","#29b8db","#ffffff"]`; got != want {
+		t.Fatalf("ANSI palette flag = %q, want %q", got, want)
+	}
 
 	argv, err = backend.spawnArgs(SpawnOptions{
 		ID:    "sess-theme-unset",
@@ -1368,7 +1377,7 @@ func TestWorkerBackend_Spawn_PassesThemeFlagsOnlyWhenSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("spawnArgs(theme unset) error: %v", err)
 	}
-	for _, flag := range []string{"--theme-foreground", "--theme-background", "--theme-cursor"} {
+	for _, flag := range []string{"--theme-foreground", "--theme-background", "--theme-cursor", "--theme-ansi-palette-json"} {
 		for _, arg := range argv {
 			if arg == flag {
 				t.Fatalf("argv unexpectedly contains %s when Theme is unset (argv=%v)", flag, argv)

--- a/internal/ptyworker/protocol.go
+++ b/internal/ptyworker/protocol.go
@@ -336,9 +336,10 @@ type SignalParams struct {
 }
 
 type SetThemeParams struct {
-	Foreground string `json:"foreground"`
-	Background string `json:"background"`
-	Cursor     string `json:"cursor"`
+	Foreground  string     `json:"foreground"`
+	Background  string     `json:"background"`
+	Cursor      string     `json:"cursor"`
+	ANSIPalette [16]string `json:"ansi_palette"`
 }
 
 type KittyImageParams struct {

--- a/internal/ptyworker/runtime.go
+++ b/internal/ptyworker/runtime.go
@@ -95,9 +95,10 @@ type Config struct {
 	YoloMode          bool
 	InitialPromptFile string
 
-	ThemeForeground string
-	ThemeBackground string
-	ThemeCursor     string
+	ThemeForeground  string
+	ThemeBackground  string
+	ThemeCursor      string
+	ThemeANSIPalette [16]string
 
 	Executable string
 
@@ -294,9 +295,10 @@ func (r *Runtime) run(ctx context.Context) error {
 		YoloMode:          r.cfg.YoloMode,
 		InitialPromptFile: r.cfg.InitialPromptFile,
 		Theme: pty.TerminalTheme{
-			Foreground: r.cfg.ThemeForeground,
-			Background: r.cfg.ThemeBackground,
-			Cursor:     r.cfg.ThemeCursor,
+			Foreground:  r.cfg.ThemeForeground,
+			Background:  r.cfg.ThemeBackground,
+			Cursor:      r.cfg.ThemeCursor,
+			ANSIPalette: r.cfg.ThemeANSIPalette,
 		},
 		Executable:        r.cfg.Executable,
 		ClaudeExecutable:  r.cfg.ClaudeExecutable,
@@ -1005,9 +1007,10 @@ func (c *connCtx) handleRequest(req RequestEnvelope) {
 			return
 		}
 		if err := c.runtime.manager.SetTheme(c.runtime.cfg.SessionID, pty.TerminalTheme{
-			Foreground: params.Foreground,
-			Background: params.Background,
-			Cursor:     params.Cursor,
+			Foreground:  params.Foreground,
+			Background:  params.Background,
+			Cursor:      params.Cursor,
+			ANSIPalette: params.ANSIPalette,
 		}); err != nil {
 			if errors.Is(err, pty.ErrSessionNotFound) {
 				c.sendError(req.ID, ErrSessionNotFound, err.Error())


### PR DESCRIPTION
## Intent

Cold terminal workspaces could take one to two seconds to become usable after falling out of the warm cache, and restored terminals used Ghostty's muted default ANSI palette instead of the app theme. This keeps virtualization's memory savings while restoring terminals quickly and with the same colors they had before unmounting.

## Summary

- replace the timer before every 16 KiB restore write with a cancellable 6 ms cooperative replay budget
- compile the vendored Ghostty WASM module once while retaining a separate runtime instance per pane
- carry the resolved ANSI 0-15 palette through protocol 210 and seed the daemon-owned Ghostty model
- preserve terminal-program OSC 4 overrides when the app theme changes
- add focused replay, WASM cache, protocol, worker, and native palette coverage

## Verification

- pre-commit repository gate: Go formatting, build, and tests; 2,490 frontend tests; production frontend build; and 192 E2E tests
- isolated packaged app: six cold remounts of an approximately 2 MiB history with the warm cache disabled completed in 46.0-50.9 ms (47.8 ms median)
- pre/post-remount terminal style summaries matched; native tests verify exact ANSI palette serialization and OSC 4 override precedence
