### PR TITLE
fix(docstore): one-transaction read windows, timestamps that sort; A3.3 findings and A3.4 design

### DIFF
--- a/changelog.d/docstore-atomic-read.yaml
+++ b/changelog.d/docstore-atomic-read.yaml
@@ -1,0 +1,11 @@
+kind: fixed
+area: daemon
+change: >
+  Document queries no longer return answers describing a collection that never
+  existed. Answering a query reads the declaration, the pagination anchor and
+  then the rows, and those were three separate reads with the SQL built in
+  between — so a write landing mid-read could silently empty a page whose anchor
+  had just been deleted, hand back the anchor document itself, or make a filter
+  match nothing after a field's declared type changed. None of the three
+  reported an error. All three reads now happen in one transaction, so a query
+  is always answered against a single state of the collection.

--- a/changelog.d/docstore-sortable-timestamps.yaml
+++ b/changelog.d/docstore-sortable-timestamps.yaml
@@ -1,0 +1,11 @@
+kind: fixed
+area: daemon
+change: >
+  Sorting or filtering documents on created_at or updated_at now orders them by
+  time. The stamps are stored as text and compared as text, and the encoding they
+  were written in dropped trailing zeros from the fraction of a second — so
+  within any one second the text order and the time order disagreed. Sorting by
+  newest came back scrambled, and a "changed since" filter written on a whole
+  second silently found none of the documents changed during that second.
+  Existing stamps are rewritten on upgrade, and a timestamp bound may now be
+  written in any RFC3339 form, including one an older version handed back.

--- a/docs/plans/2026-08-04-ext-a3.3-doc-store-review-findings.md
+++ b/docs/plans/2026-08-04-ext-a3.3-doc-store-review-findings.md
@@ -5,8 +5,8 @@ Follow-up to [A3](2026-08-03-ext-a3-doc-store.md),
 [A3.2](2026-08-04-ext-a3.2-document-revisions.md). Roadmap:
 [2026-08-01-extension-platform-roadmap.md](2026-08-01-extension-platform-roadmap.md).
 
-Status: findings recorded 2026-08-04. Item 1 approved and in progress; items 2–7
-are open and none are gated on each other.
+Status: findings recorded 2026-08-04. Item 1 is done (2026-08-05); items 2–7 are
+open and none are gated on each other.
 
 Two independent reviews of the store — one of the API surface, one of the
 testing strategy — ran after the read-window fix (below) landed. They converged
@@ -33,7 +33,7 @@ collection was ever in, and reported no error:
 `QueryDocuments` is unexported so a compiled query cannot be run against a state
 it was not compiled from. Pinned by `internal/store/documents_read_window_test.go`.
 
-## 1. Stored timestamps do not sort — APPROVED, IN PROGRESS
+## 1. Stored timestamps do not sort — DONE
 
 `docstore.TimeFormat = time.RFC3339Nano` (`internal/docstore/docstore.go:715`),
 and the comment beside it claims it "sorts lexicographically, which is what lets
@@ -56,11 +56,16 @@ the encoding is fine — but that is where bursty writes land, and "changed sinc
 is one of the two advertised uses of the reserved fields. The canonical resume
 flow (take the last document's `updated_at` as the next bound) hits it too.
 
-Fix: a fixed-width fraction so text order matches time order, normalization of
-string bounds for reserved fields in `bindValue` so a caller may pass any RFC3339
-form, and a migration rewriting stored stamps. The migration is cheap now — one
-consumer, tiny data — and expensive once A4 grants extensions namespaces they
-write to.
+Fixed 2026-08-05. `TimeFormat` is now a nine-digit fixed-width fraction, so every
+stored stamp is the same 30 characters and text order is time order. A string
+bound on a reserved field is decoded and re-encoded in `bindValue` rather than
+passed through, so a caller may write any RFC3339 spelling — including one an
+older store handed them — and a bound that is not a timestamp is refused instead
+of compared as text. Migration 91 rewrites the stored stamps; it is idempotent by
+construction (decode, re-encode) and leaves a value it cannot decode alone,
+reporting the count. Pinned by `internal/docstore/timestamps_test.go` and
+`internal/store/documents_timestamps_test.go`, both falsified against the three
+halves of the fix separately.
 
 `internal/store/jobs.go:19` uses the same format with the same text comparisons
 (`scheduled_at <=` at :173, retention `updated_at <` at :210). The consequence

--- a/docs/plans/2026-08-04-ext-a3.3-doc-store-review-findings.md
+++ b/docs/plans/2026-08-04-ext-a3.3-doc-store-review-findings.md
@@ -1,0 +1,234 @@
+# A3.3 — Document store review findings
+
+Follow-up to [A3](2026-08-03-ext-a3-doc-store.md),
+[A3.1](2026-08-03-ext-a3.1-doc-store-physical-schema.md) and
+[A3.2](2026-08-04-ext-a3.2-document-revisions.md). Roadmap:
+[2026-08-01-extension-platform-roadmap.md](2026-08-01-extension-platform-roadmap.md).
+
+Status: findings recorded 2026-08-04. Item 1 approved and in progress; items 2–7
+are open and none are gated on each other.
+
+Two independent reviews of the store — one of the API surface, one of the
+testing strategy — ran after the read-window fix (below) landed. They converged
+on the same first finding. This document records everything neither review's
+author will be around to remember, so the items can be picked up in any order by
+someone with no context.
+
+## Background: what already changed
+
+Answering a query used to take three separate transactions — read the
+declaration, read the pagination anchor, run the SELECT — with the SQL compiled
+in between. A write landing mid-read produced answers matching no state the
+collection was ever in, and reported no error:
+
+- the anchor deleted mid-read gave a silently empty page instead of the
+  "cannot page after X, which no longer exists" error that exists for it;
+- the anchor gaining a value for the sort field gave a page containing the
+  anchor document itself;
+- a field's declared type changing gave a filter that silently matched nothing,
+  because the value was bound under the old declared type and compared under the
+  new column's affinity.
+
+`Store.ReadQuery` now does all three reads in one transaction, and
+`QueryDocuments` is unexported so a compiled query cannot be run against a state
+it was not compiled from. Pinned by `internal/store/documents_read_window_test.go`.
+
+## 1. Stored timestamps do not sort — APPROVED, IN PROGRESS
+
+`docstore.TimeFormat = time.RFC3339Nano` (`internal/docstore/docstore.go:715`),
+and the comment beside it claims it "sorts lexicographically, which is what lets
+created_at and updated_at be ordering terms as plain text columns". That receipt
+is false. RFC3339Nano strips trailing zeros, so fraction widths vary, and `Z`
+(0x5A) sorts above `.` and every digit. Stamps are `TEXT` columns compared as
+text.
+
+Measured against the real store, four documents written inside one second:
+
+```
+stored:  t0 "…T10:00:00Z"  t1234 "…:00.1234Z"  t12345 "…:00.12345Z"  t5 "…:00.5Z"
+
+sort by created_at ASC      -> [t12345 t1234 t5 t0]   true order [t0 t1234 t12345 t5]
+updated_at >= "…T10:00:00Z" -> [t0]                   want all four
+```
+
+Both silent. Only stamps within the same second compare wrongly — across seconds
+the encoding is fine — but that is where bursty writes land, and "changed since"
+is one of the two advertised uses of the reserved fields. The canonical resume
+flow (take the last document's `updated_at` as the next bound) hits it too.
+
+Fix: a fixed-width fraction so text order matches time order, normalization of
+string bounds for reserved fields in `bindValue` so a caller may pass any RFC3339
+form, and a migration rewriting stored stamps. The migration is cheap now — one
+consumer, tiny data — and expensive once A4 grants extensions namespaces they
+write to.
+
+`internal/store/jobs.go:19` uses the same format with the same text comparisons
+(`scheduled_at <=` at :173, retention `updated_at <` at :210). The consequence
+there is much milder: a job scheduled on a whole second is not claimed until the
+next second. A scheduling wobble, not data loss. Decide separately.
+
+### Why the test suite did not catch it
+
+This is the important part, and it generalizes past this bug.
+
+The differential harness compares the real compiler against a dumb second path,
+but **both paths read the same stored text**, so they agree and are both wrong.
+The harness validates machinery, never meaning — its header says so, and this is
+the first demonstrated instance.
+
+The stated mitigation is that example tests carry human-reviewed intent. But an
+intent test only pins intent if its fixtures are adversarial, and every timestamp
+fixture in the suite is a whole second, which cannot expose the defect. Worse,
+nothing anywhere runs a filter against a reserved timestamp at all:
+`modelQueries` filters and sorts only on its one declared field; `largeQuery`
+sorts on `created_at`/`updated_at` but draws filters only from `schema.Fields`;
+`TestReservedTimestampsAreQueryableWithoutDeclaration` asserts compiled SQL text
+and never executes.
+
+**Rule to carry forward: for every value class the store compares, at least one
+example test must use values where the encoding could disagree with the
+semantics.**
+
+## 2. Error taxonomy is prose, not a contract
+
+Every error crosses IPC as flattened text — `d.sendError(conn, err.Error())`
+throughout `internal/daemon/documents.go`, wrapped by the client as
+`daemon error: %s` (`internal/client/client.go:179`). `docstore.ConflictError`
+and `IsConflict` die at the socket; they are usable only in-process, and nothing
+in-process needs them.
+
+A3.2 mandates the consumer that breaks this: A4's SDK is to expose
+`update(id, fn)` looping read → modify → write-at-revision and *retrying the
+conflict*. That loop runs in the Bun sidecar, across the wire, and its only way
+to tell "conflict, retry" from "broken, stop" is matching English. A5's UI host
+has the same problem telling "collection undefined, kill the tile" from "daemon
+restarting, resubscribe".
+
+The message text is good and should stay. What is missing is a small
+machine-readable code beside it: `conflict` (carrying expected/actual/found
+structured), `undeclared_collection`, `invalid_query`. Three codes and a protocol
+bump, while exactly one consumer exists. After A4 ships an SDK that string-matches,
+the strings themselves become the frozen contract.
+
+## 3. Live-query coverage
+
+The surface every planned consumer renders from is the least tested. The only
+concurrent subscription test proves writes do not block on a stalled subscriber
+(`internal/daemon/documents_test.go:283`) — non-blocking, not currency. Nothing
+proves that once writes quiesce, the final delivery equals the true state, which
+is what remount-and-rehydrate rests on.
+
+All of the following reuse the enumerable-legal-states pattern that
+`TestAQueryNeverSeesACollectionThatNeverExisted` proved out — a writer flips a
+document between two known states, so every legitimate answer is enumerable. No
+timing, no sleeps.
+
+- **Currency under contention.** Every delivery is one of the legal result sets,
+  and after the writer stops the final delivery equals `ReadQuery`'s answer.
+- **Coalescing as a receipt.** N writes while the subscriber is blocked mid-encode
+  (`net.Pipe` gives this for free); deliveries ≪ N and the last one is current.
+  The one-slot wake channel's justification is currently only a comment.
+- **Multi-subscriber fan-out.** No test has two subscriptions on one collection.
+- **Redeclare-with-a-type-change ending a subscription** at daemon level; only the
+  field-drop path is covered there today.
+
+When A5 moves live queries onto WebSocket envelopes, the same battery should run
+against that transport. Write the assertions in helpers a second transport can
+call; do not build parameterization machinery now.
+
+## 4. Paged live queries: decide the semantics
+
+`handleDocSubscribe` accepts a query carrying `After` and compiles it
+(`internal/daemon/documents.go:470`). No test touches it. The semantics are odd:
+a moving "page 2 as of now", where deleting the anchor kills the subscription
+with a cursor error on the next wake.
+
+Either that is intended and gets pinned by a test, or paged live queries are
+refused at subscribe time — before A5 lets extension UIs discover the behaviour
+by accident. The reviewer leaned toward refusing, on the grounds that a live
+query is a window and a cursor is a walk, and one object doing both jobs is a
+seam consumers file bugs against. This is a semantics decision, not a defect.
+
+## 5. Write ↔ fact atomicity
+
+A3.1 rejected file-per-namespace partly on atomicity grounds, calling the loss of
+a write ↔ `document.changed` fact "lethal once B-track workflows trigger on
+document changes", and A3 calls document-write ↔ job-state commit load-bearing
+for B2's exactly-once story.
+
+The code does not deliver that. `handleDocPut` commits through `PutDocument`
+(its own statement) and then publishes separately
+(`internal/daemon/documents.go:370`); `publishFact` logs and continues on error
+(`internal/daemon/bus.go:523`); and on append failure the bus degrades to
+ephemeral fan-out (`internal/bus/bus.go:245`), so live queries still wake while
+the durable log permanently misses the fact. A crash between the two statements
+is the exact case the plan named.
+
+The pieces are already on one `*Store` (`AppendBusEvent`, `internal/store/bus.go:53`),
+so the fix is a store-level composite — put plus fact append in one transaction —
+that is daemon-internal with no wire impact. Not needed before B2, but the
+contract should be recorded now, because A3.1's single-database rationale is
+currently a receipt for a property the code does not have.
+
+## 6. Small, cheap, and cheaper now than later
+
+- **Undefine publishes a malformed durable fact.**
+  `publishDocumentChanged(ns, coll, "", true)` (`internal/daemon/documents.go:322`)
+  yields a subject with a trailing slash. Facts are durable and replayed; every
+  future consumer would have to special-case an empty id. Collection removal
+  wants its own fact name, while zero durable consumers read these.
+- **No count on the wire.** `CountDocuments` exists in the store; the command set
+  (`internal/protocol/constants.go:74-81`) has no `doc_count`. An A5 badge must
+  otherwise fetch full bodies and count client-side, and is wrong past the limit.
+  Reuses the same filter compile against `SELECT COUNT(*)`.
+- **A duplicate compile path.** `compileDocQuery`
+  (`internal/daemon/documents.go:156`) is the pre-`ReadQuery` three-read shape,
+  surviving as the subscribe preflight. It is validation only, so the worst case
+  is a subscribe accepted that fails on first delivery — but it is a second
+  compile path that will drift. Running the first `ReadQuery` as the acceptance
+  check deletes it and yields the initial result set in the same call.
+- **`attn doc watch` exits 0 silently** when the daemon closes the connection
+  (`internal/client/documents.go:108`). Correct as a library contract (the SDK
+  owns reconnect), wrong as CLI behaviour.
+- **`bindValue` coerces int64 to float64** (`internal/docstore/docstore.go:687`),
+  so number filters lose exactness above 2^53. Epoch-milliseconds is safe, raw
+  nanoseconds is not. Worth a documented sentence, not a code change.
+
+## 7. Testing infrastructure
+
+- **Scoped `-race` in CI.** `scripts/test-go.sh` runs plain `go test`, so every
+  package's concurrency tests run raceless — including the store's two most
+  important ones. The known blocking race is in `internal/daemon`, a different
+  package: `go test -race ./internal/store ./internal/docstore` is green in 20s
+  (measured 2026-08-04). The Go check has roughly 60s of headroom under the
+  Frontend E2E job that paces CI.
+- **One real-socket integration test.** Every daemon document test drives handler
+  functions over `net.Pipe`; nothing exercises the real listener and dispatcher,
+  and `internal/client/documents.go` — including the subscribe read loop the CLI
+  and A4's SDK sit on — has no tests at all. One test running
+  define/put/query/subscribe/teardown through `internal/client` against a real
+  daemon socket closes both gaps.
+- **Pin `document.changed` as a contract.** Its name, subject shape and payload
+  are currently tested only through their effect on subscriptions. One example
+  asserting the published fact directly makes it intentional before B2 consumers
+  exist.
+
+## What is deliberately not being done
+
+Joins, OR/IN filters, patch deltas, opaque cursor tokens, caller-composed batch
+writes, and store-side namespace grants all stay deferred. The collections shape,
+keyset cursor, full-result-set live queries and optional compare-and-swap were
+reviewed against A4/A5/C2/C3 and hold up.
+
+Extraction of the store into its own project stays open, with one constraint now
+clear: the single `attn.db` was chosen deliberately for cross-primitive
+atomicity, so extraction can only ever mean a *library* taking a `*sql.DB` and a
+fact-sink interface — never a separate service. You cannot have both an
+independent data plane and a document write that commits atomically with the bus
+fact. Nothing in these findings makes extraction harder; item 2 makes it easier,
+since a coded error contract survives a repo boundary and prose does not.
+
+Both reviews closed on the same note, recorded here as a check on scope: after
+items 1, 3 and 7, stop adding tests and build A4. The next real coverage this
+store needs will be found by the approval gate consuming it, not by more tests
+written from the inside.

--- a/docs/plans/2026-08-05-ext-a3.4-doc-store-positions-and-windows.md
+++ b/docs/plans/2026-08-05-ext-a3.4-doc-store-positions-and-windows.md
@@ -1,0 +1,495 @@
+# A3.4 — Positions and windows: the document store on the log
+
+Follow-up to [A3](2026-08-03-ext-a3-doc-store.md),
+[A3.1](2026-08-03-ext-a3.1-doc-store-physical-schema.md),
+[A3.2](2026-08-04-ext-a3.2-document-revisions.md) and the
+[A3.3 findings](2026-08-04-ext-a3.3-doc-store-review-findings.md). Roadmap:
+[2026-08-01-extension-platform-roadmap.md](2026-08-01-extension-platform-roadmap.md).
+
+Status: designed 2026-08-05, awaiting sign-off. Gates A4's SDK query surface.
+
+## The decision
+
+A query result today is just rows: nothing says *when* it was true. Every open
+pathology in the A3.3 findings is a symptom of that one missing concept — the
+moving pagination anchor under a live query, the full refetch on every tile
+remount, the write and its `document.changed` fact drifting apart, two pages
+that cannot be read at one instant.
+
+The fix is two primitives, not one:
+
+1. **Writes are positioned.** Every document write commits together with its
+   `document.changed` fact, in one transaction, and the fact's bus seq comes
+   back as the write's position. Every read answer carries `as_of_seq`, the log
+   position it was true at. This is what B-track workflows and audit need: data
+   and the facts about it are provably in lockstep, because they are one commit.
+
+2. **Subscriptions are windows, resumed by content.** A subscription delivers
+   an ordered window plus the bodies the client is missing, and a reconnecting
+   client resumes by declaring what it already holds (`{id: rev}`), not by
+   replaying history. The daemon then sends only what changed. No log replay,
+   no retained versions, no epoch tokens.
+
+The split matters. An earlier sketch of this design overloaded the seq into the
+resume token ("subscribe from seq S") and that pulls in machinery this design
+does not need: replaying facts from the log, checking the resume point against
+retention, and re-deriving window membership for documents the log never
+mentioned (a document can enter a limited window because a *different* document
+was deleted — no fact names it, so log replay cannot reconstruct the window
+without historical reads). Resuming by content (`have`) is exact, needs no
+history, and costs at most one small map on the wire.
+
+## The client contract — one rule
+
+Every subscription delivery has the same shape:
+
+```
+{ delivery, as_of_seq, order: [id...], upsert: [StoredDocument...] }
+```
+
+and the client obeys one rule:
+
+> **Render `order`. Take each body from `upsert` if it is there, else from your
+> cache. Forget every cached document not named in `order`.**
+
+Everything else is a degenerate case of that rule:
+
+- The first delivery on a fresh subscribe: `order` plus every body in `upsert`.
+  A "snapshot" is not a special case the client can even detect.
+- A delivery after one write: `order` (ids only, ≤ limit of them) plus the one
+  changed body.
+- A resume: the client subscribes with `have: {id: rev}`; the daemon runs the
+  query and puts into `upsert` exactly the `order` members whose current rev
+  differs from `have`. Documents that left the window simply are not in
+  `order`, and the forget rule collects them.
+- A document deleted, displaced past the limit, or edited out of the filter:
+  absent from `order`. There is no `remove` field because it would be derivable
+  from `order`, and a derivable field is a field two implementations can
+  disagree about.
+
+The ordering stays server-owned. `order` exists so the client never re-derives
+sort position — document order comes from SQLite's comparison under column
+affinity, including JSON shapes with no clean client-side equivalent, and a
+client re-sorting locally would have to reimplement that exactly. This is the
+same reasoning that made the pagination cursor read the anchor's value through
+the column rather than binding it from Go.
+
+Invariant the daemon must uphold (and a test must pin): every id in `order` is
+either in `upsert` or was declared in `have` at its current rev / delivered in
+an earlier `upsert` on this connection. A client that finds a body it does not
+hold treats the subscription as broken and resubscribes without `have` — the
+SDK's job, invisible to the tile.
+
+### What this looks like to use
+
+The A4 SDK wraps it so a tile author sees none of it:
+
+```ts
+// extension code
+const approvals = useQuery(
+  q("requests").where("status", "==", "pending").sort("updated_at", "desc").limit(20),
+);
+// -> { docs, asOfSeq, live }  — stays current, survives remount for the
+//    cost of one round trip carrying only what changed while unmounted.
+```
+
+```go
+// internal/client (Go SDK seam, the CLI and tests sit on it)
+sub, err := c.SubscribeDocuments(ctx, q, client.Resume(have))
+for w := range sub.Windows() {   // each w is the APPLIED window: []Document
+    render(w.Documents, w.AsOfSeq)
+}
+```
+
+The CLI's `attn doc watch` prints applied windows and exits non-zero when the
+daemon ends the subscription (fixing A3.3 item 6's silent exit-0 on the way,
+since the read loop is being rewritten anyway).
+
+## Wire changes
+
+Stage 1 (one `ProtocolVersion` bump):
+
+- `DocPutResult` and `DocDeleteResult` gain `seq` — the write's position.
+- `DocQueryResult` and `DocGetResult` gain `as_of_seq`, read inside the same
+  transaction as the rows (`MAX(seq)` over `bus_events`), so it is exact, not
+  approximate.
+- Error responses gain a `code` beside the existing message text:
+  `conflict` (carrying expected/actual/found structured), `undeclared_collection`,
+  `invalid_query` — A3.3 item 2, landing while exactly one consumer exists.
+- `doc_count` — A3.3 item 6, same filter compile against `SELECT COUNT(*)`.
+
+Stage 2 (one more bump):
+
+- `DocSubscribeMessage` gains `have?: Record<string, int64>` and **refuses a
+  query carrying `after`** with a coded error naming the alternative
+  (`limit` + windowed delivery). A live query is a window; a cursor is a walk;
+  A3.3 item 4 is decided here, permanently.
+- `DocSubscribeResult` becomes `{delivery, as_of_seq, order, upsert}`.
+- Subscription-ending conditions get codes (`collection_undefined`,
+  `collection_redeclared`), which is what lets A5's UI host tell "kill the
+  tile" from "resubscribe".
+
+One-shot `doc_query` keeps `after` exactly as it is. For a single read the
+anchor-subquery semantics are correct — there is one instant, so "the anchor's
+position" and "the anchor's position now" are the same thing — and the
+affinity-exact subquery is the right mechanism. The moving-anchor pathology
+only ever existed for subscriptions, and subscriptions stop accepting cursors.
+The frozen-cursor rework previously discussed is dead: it patched a combination
+that no longer exists.
+
+What is deliberately **not** offered: cross-request reads at a pinned seq
+("page 2 as of the same instant as page 1"). That requires retained historical
+versions — real time travel — and nothing on the roadmap needs it: the live
+window subsumes the paged-live-tile want, measured list sizes (tickets 7,
+sessions 11, notifications 8, workspaces 8) sit far under one window, and a
+deep one-shot walk that needs cross-page consistency can compare `as_of_seq`
+across pages and restart on drift, loudly, in the client. If a real workload
+ever hits this, the door is open (Rev already exists per document); it is a
+Stage 3 that may never happen.
+
+## Daemon and store changes
+
+### Stage 1 — the positioned write
+
+`internal/store` gains the composite the A3.3 findings (item 5) asked for:
+
+```go
+// One transaction: the document write and its fact are one commit.
+// rev is the document's new revision; seq is the fact's position.
+func (s *Store) CommitDocumentWrite(w DocumentWrite, now time.Time) (rev, seq int64, err error)
+```
+
+covering put and delete (define/undefine follow the same pattern with their own
+facts — see below). `PutDocument`/`DeleteDocument` remain for callers that are
+not fact-bearing (tests, migration paths), but the daemon's write handlers move
+to the composite. The current one-statement conflict-check property is
+preserved: the same single statement runs, now inside the transaction that also
+appends the fact.
+
+This **inverts the failure contract on purpose**: today a doc write succeeds
+and the fact append can fail separately (`publishFact` logs and continues; the
+bus degrades to ephemeral fan-out on append failure). After Stage 1, a fact
+that cannot be made durable fails the whole write — the caller gets an error, a
+retry, and no silent divergence. The bus's degrade-to-fanout path stops
+applying to document facts entirely, because there is no longer a "published
+but not durable" state for them. For B2's exactly-once story this is the load-
+bearing property; A3.1's single-database rationale becomes true instead of
+aspirational.
+
+`internal/bus` gains one entry point:
+
+```go
+// Announce fans out events that were appended to the log outside Publish
+// (e.g. inside a store transaction). It reads forward from the last announced
+// seq under publishMu, so ephemeral subscribers still observe seq order — the
+// log itself is the ordering authority, not the announcer's call order.
+func (b *Bus) Announce()
+```
+
+Rationale: the bus's documented guarantee is that ephemeral subscribers see
+events in seq order, enforced today by assigning the seq under `publishMu`.
+Once the store appends inside its own transaction, "commit order" and "announce
+call order" can race between the store unlocking and the daemon announcing.
+Reading forward from a high-water mark makes announcement idempotent and
+order-correct regardless of who calls it when — a missed announce is repaired
+by the next one (or by the existing durable-consumer poll tick). Publish
+advances the same high-water mark so the two entry points cannot double-deliver.
+
+Also in Stage 1, while the fact vocabulary is still consumer-free:
+
+- **Undefine gets its own fact** (`document.collection.removed`, subject
+  `ns/coll`) instead of today's malformed `document.changed` with an empty id
+  and a trailing-slash subject — A3.3 item 6, done now because facts are
+  durable and replayed, and after B2 every consumer would have to special-case
+  the empty id forever.
+- **`document.changed` gets pinned as a contract** — name, subject shape,
+  payload, and now its transactional coupling to the write — by a direct test
+  (A3.3 item 7). It stops being an implementation detail the moment the seq is
+  load-bearing.
+
+No schema migration in either stage: `bus_events` (migration 84) and the
+`doc_*` tables already hold everything needed.
+
+### Stage 2 — the windowed subscription
+
+`handleDocSubscribe` keeps its shape (register before first query, one-slot
+wake, re-read declaration per delivery) and changes what a delivery is:
+
+- The subscription holds the last delivered `order` and `{id: rev}` — at the
+  100-document default limit this is two small slices per subscriber.
+- Each delivery runs `ReadQuery` (which now returns `as_of_seq`), diffs against
+  the held set, and sends `order` plus changed bodies. First delivery diffs
+  against `have`.
+- The acceptance check becomes the first `ReadQuery` itself, which deletes the
+  duplicate `compileDocQuery` preflight path (A3.3 item 6) — one compile path,
+  and the subscriber gets its first window in the same call that validated it.
+
+The wake path is unchanged: `document.changed` facts (now announced via the
+log follower) nudge the one-slot channel; delivery coalescing keeps its
+existing behavior and finally gets its receipt (below).
+
+## Implementation notes — seams pinned so they are decided once
+
+Decisions an implementer would otherwise have to make alone, made here:
+
+1. **The store stays fact-agnostic.** `CommitDocumentWrite` takes the fact as
+   an argument — the daemon builds the `BusEvent` (it owns fact names and
+   subject shapes; the store must not import them) and the store appends it
+   via the existing `AppendBusEvent` inside the same transaction:
+   `CommitDocumentWrite(w DocumentWrite, fact BusEvent, now time.Time) (rev,
+   seq int64, err error)`. A write that changed nothing — a delete of an
+   absent document, a conflict refusal — appends **no fact and returns no
+   seq**: the fact means "changed", and today's no-wake-on-no-op behavior
+   must survive the move. `PutDocument`'s "EACH FORM IS ONE STATEMENT"
+   comment describes a property the composite deliberately trades for the
+   transaction; update the comment where it moves.
+2. **Compaction policy lives in `internal/bus`; SQL lives in the store.**
+   The bus knows which names are compactable (an option beside retention,
+   set by the daemon) and calls a store method
+   (`CompactBusEvents(names []string, floor int64)`) from the retention
+   tick — the same split as trim: bus owns semantics, store owns
+   persistence.
+3. **Error codes come from typed errors at one choke point.** `docstore`
+   already types the conflict (`ConflictError`); undeclared-collection and
+   invalid-query get sentinel/typed errors beside it, and the daemon maps
+   type → code where `sendError` is called — message text unchanged, code
+   added. No string matching anywhere, including in our own daemon.
+4. **`Announce`'s high-water mark** initializes from `Bounds()` head at
+   `Start`, and `Publish` advances it so the two entry points cannot
+   double-deliver. The nil-bus convention (`publishFact` runs projections
+   directly when a test daemon has no bus) gets a matching path: handlers
+   call the store composite either way, then announce via the bus or run
+   projections directly — a test without a bus must exercise the same write
+   path, minus fan-out only.
+5. **`as_of_seq` is `MAX(seq)` over `bus_events` read inside the same
+   transaction as the rows.** An empty log yields 0, which is a valid
+   position ("before everything"); compaction never lowers `MAX`, so the
+   watermark is immune to it.
+
+## Is the bus solid enough? — audit
+
+Verdict: **yes, with the two additions above and one landmine named.** The
+design holds because the bus was already built log-first; nothing needs a
+rewrite.
+
+What was checked, against `internal/bus/bus.go` and `internal/store/bus.go` as
+of 2026-08-05:
+
+- **Seq space.** `bus_events.seq` is AUTOINCREMENT: monotone, never reused even
+  after retention deletes rows. A valid position space for `as_of_seq`.
+- **Durable delivery.** Ordered, at-least-once, cursor persisted after the
+  handler returns, stall-don't-skip with capped backoff, kill switch re-read on
+  the hot path, trimmed-past-cursor reconciliation that resumes at head and
+  logs the gap. This is exactly what B2's workflow triggers need and nothing
+  Stage 1/2 uses directly — doc subscriptions stay ephemeral wakes.
+- **Ephemeral ordering.** Guaranteed today by seq assignment under `publishMu`;
+  preserved after in-transaction appends by `Announce`'s read-forward design
+  (the log is the ordering authority). This was the one real gap: without it,
+  two racing writes could announce out of order. It is closed structurally, not
+  by convention.
+- **Retention.** Age window (30d) with an enabled-consumer cursor floor.
+  Correct, and *nothing in this design depends on retention* — resume-by-`have`
+  reads no history, which is precisely why that shape won. A trimmed log can
+  cost a durable consumer a gap (existing, logged behavior); it can never cost
+  a subscription correctness.
+- **Failed-append degradation** (`Publish` fans out even when the append
+  fails). Right for state-change projections — the wire must not go quiet
+  because the log had a bad night — and no longer reachable for document facts,
+  which stop flowing through `Publish` at all.
+
+The one structural gap for this usage is volume, and it gets its own section.
+
+## The log must not outgrow the data — compaction
+
+Stage 1 couples log growth to document write volume: every write appends a
+fact, retention keeps 30 days, so a data workload writing in bursts grows
+`bus_events` at write rate × window. Today's log carries session/ticket-grade
+events and the age window is a fine bound for those; for a data primitive it is
+an unbounded multiplier. Watching the number grow is not a fix. The fix is
+structural, and the bus's own philosophy already licenses it: a fact is an
+invalidation, not a business event — the state lives in the store, the fact
+only says "this subject changed". Five facts about one subject carry no more
+information than the newest one. An invalidation log is **compactable**.
+
+The invariant, which is the whole point:
+
+> **The durable log holds at most one fact per subject (plus tombstones inside
+> the retention window). Log size is bounded by the size of the data it
+> describes — proportional to the collection, never to the write rate.**
+
+Mechanics:
+
+- Fact names declare a class. `document.changed` and
+  `document.collection.removed` are *compactable*; session/ticket state facts
+  keep today's age-window behavior unchanged.
+- The existing retention tick gains a compaction pass: per subject, delete
+  every compactable fact except the one with the highest seq
+  (`idx_bus_events_subject (subject, seq)` makes this an index walk). A
+  workload that rewrites the same 10k documents hourly leaves ≤ 10k rows, not
+  7.2M.
+- Compaction honors **the same enabled-consumer cursor floor trim honors**:
+  only facts at or below `MIN(cursor)` of enabled consumers are eligible. Two
+  reasons, both load-bearing. An enabled consumer must never lose a fact it
+  has not read — below the floor, a compacted-away fact is by definition one
+  every enabled consumer already consumed, so delivery semantics for them are
+  *bit-for-bit identical to today*. And `reconcileGap` assumes a cursor below
+  the log's earliest seq means everything missing was trimmed; compacting
+  above the floor would punch holes that assumption misreads, skipping a
+  revived consumer past facts that still exist. The floor keeps the
+  assumption true. Consequence, stated honestly: a stalled enabled consumer
+  pins compaction exactly as it pins trim today — an already-loud condition
+  (`bus status` shows the stall, the kill switch unpins). With no durable
+  consumers registered — today's reality — the floor is the log head and
+  compaction is unrestricted.
+- A `deleted: true` fact is the tombstone. It compacts like any fact (the
+  latest fact for the subject *is* the tombstone) and ages out of the log
+  entirely once past the age window and every enabled consumer's cursor — at
+  which point the subject holds zero rows, matching the zero rows it holds in
+  the collection.
+- Transient burst growth between ticks is bounded by one trim interval of
+  writes and visible in the status receipt below.
+
+The delivery contract changes correspondingly, and the plan says so out loud:
+for compactable facts, durable delivery is **at-least-once per changed
+subject**, not at-least-once per write. A consumer that was behind while a
+document changed five times learns "this changed" once and reads current state
+from the store — which is what the A1 design already tells consumers to do
+("turning a fact into whatever the wire needs is the consumer's job"). This is
+sound for every consumer type this platform plans: wakes, snapshot re-pushes,
+B2 triggers recomputing from current state. A consumer that would need every
+intermediate change as a business event is doing event sourcing, which is a
+different primitive — those events are *data* and belong in a collection the
+workload writes explicitly, where their growth is its own visible cost. The
+bus stays an invalidation spine.
+
+Where compaction deliberately does not save you: a workload that only ever
+creates new subjects grows the log with the collection. That is the invariant
+working, not failing — the log is a constant-factor echo of the data, and the
+data's growth is the workload's own visible cost.
+
+The visibility receipt stays alongside the bound: `attn bus status` gains the
+log's row count and on-disk size, so the invariant is checkable in one command
+and a workload that stresses the transient bound shows up as a measurement.
+
+**The alternative considered, priced, and deferred** (the deeper cut): move
+the position space into the store itself — a one-row counter advanced in every
+write transaction, a `seq` column stamped on each document row, no log row for
+plain writes at all; durable consumers catch up by scanning collections for
+`seq > cursor`, and only deletes need log rows. Zero duplication, the log
+shrinks to a tombstone stream, and "what changed since S" becomes a store
+query. Rejected for now because it rebuilds durable delivery for a consumer
+type that does not exist yet (B2), forks the bus into two delivery paths, and
+adds a migration across every collection table — roughly a week against
+compaction's afternoon, bought with generality nothing on the roadmap needs.
+Compaction's invariant makes the log an echo of the data; the counter design
+would make it disappear, and the step between the two stays open (the
+counter-table half composes with everything in this plan) if a workload ever
+proves the echo too loud.
+
+Deferring it costs roughly nothing, **provided two disciplines hold** — they
+are what keep the retrofit mechanical instead of semantic:
+
+1. **Seq is opaque on the wire.** It is "a monotone position", never "the bus
+   log's rowid". No client may assume density, contiguity, or source; clients
+   only store and compare. This plan's wire shapes already comply.
+2. **One position space, forever.** If the counter design ever lands, the
+   counter subsumes the bus seq (initialized at `MAX(seq)`; `bus_events` takes
+   its seq from the counter instead of AUTOINCREMENT). Two counters would make
+   `as_of_seq` incomparable to consumer cursors, and turn a mechanical swap
+   behind the bus's `Since` seam into a migration of meaning.
+
+Under those rules the later build is the same mechanical half plus a
+merge-`Since` implementation behind the existing `Store` seam — verified then
+against a real B2 consumer instead of a synthetic one, which is the part of
+the cost that actually shrinks by waiting.
+
+## Testing
+
+The A3.3 item-3 battery becomes buildable *and deterministic* because
+deliveries are stamped:
+
+- **Currency under contention.** Writer flips a document between two known
+  states; every delivered window is one of the enumerable legal states; after
+  the writer stops, the final delivery's window equals `ReadQuery`'s answer
+  **and its `as_of_seq` is ≥ the last write's `seq`** — the assertion that was
+  previously unwritable without sleeps is now an inequality between two
+  receipts the wire itself carries.
+- **Coalescing as a receipt.** N writes while the subscriber is blocked
+  mid-encode (`net.Pipe`); deliveries ≪ N, last window current. The one-slot
+  channel's justification stops being a comment.
+- **The window invariant.** Every id in `order` resolvable from `upsert` +
+  declared `have` + prior deliveries — fuzzed alongside the existing
+  differential harness, with adversarial fixtures per the A3.3 rule (ties,
+  NULL sort values, JSON-shaped sort fields, documents entering a window
+  because another left).
+- **Resume.** Subscribe, kill the connection, mutate (edit inside the window,
+  delete, displace past the limit, edit out of the filter), resubscribe with
+  `have`; the first delivery contains exactly the changed bodies and the
+  applied window equals a fresh query. Also: `have` claiming a rev the store
+  never issued (stale beyond recognition) still converges.
+- **Write ↔ fact atomicity.** Inject an append failure inside
+  `CommitDocumentWrite`; the document write must not survive it. The inverse of
+  today's behavior, pinned.
+- **Announce ordering.** Concurrent committed writes announced racily must
+  reach an ephemeral subscriber in seq order.
+- **Compaction receipts.** Churn one subject N times: after a pass, one
+  surviving fact, and a durable consumer whose cursor predates the churn still
+  learns the subject changed (once). Mixed create/rewrite/delete workload: the
+  log never holds more rows than live documents + in-window tombstones — the
+  invariant asserted as an inequality, not observed. A consumer parked below
+  the floor pins every fact it has not read through a compaction pass.
+- **One real-socket integration test** (A3.3 item 7): define/put/query/
+  subscribe/resume/teardown through `internal/client` against a real daemon
+  socket — which also gives `internal/client`'s subscribe read loop its first
+  coverage, before A4's SDK sits on it.
+- **Multi-subscriber fan-out** and **redeclare-ends-subscription with a code**,
+  at daemon level.
+
+`scripts/test-go.sh` grows scoped `-race` for `./internal/store
+./internal/docstore` (A3.3 item 7; measured green in ~20s against ~60s of CI
+headroom).
+
+## Ledger — nothing dropped
+
+Every open item from A3.3 and the surrounding discussion, with where it lands:
+
+| Item | Disposition |
+| --- | --- |
+| Ship the current branch (read-window + findings + timestamp fix) | **First, before any of this.** Locked decision. |
+| 2 — error codes | Stage 1 wire work. |
+| 3 — live-query test battery | Stage 2 testing section, strengthened by seq stamps. |
+| 4 — paged live query semantics | Decided here: subscribe refuses `after`; windows + `have` are the live paging story. Stage 2. |
+| 5 — write ↔ fact atomicity | *Is* Stage 1's core. |
+| 6 — undefine fact rename | Stage 1 (before durable consumers exist). |
+| 6 — `doc_count` | Stage 1 wire work. |
+| 6 — duplicate `compileDocQuery` | Deleted by Stage 2's acceptance-is-first-read. |
+| 6 — `attn doc watch` exit code | Stage 2 CLI update (read loop rewritten anyway). |
+| 6 — `bindValue` int64→float64 note | One documented sentence; ride whichever PR touches `bindValue` next, else Stage 1. |
+| 7 — scoped `-race` in CI | Stage 2 PR (small, independent; earliest PR that touches CI anyway). |
+| 7 — real-socket integration test | Stage 2 testing section. |
+| 7 — pin `document.changed` | Stage 1 (fact becomes load-bearing). |
+| Log volume under data workloads | Bounded structurally: fact-class compaction, Stage 1. Invariant: log ≤ data + in-window tombstones. |
+| `internal/store/jobs.go` timestamp encoding | Untouched by this plan; standalone small item (scheduling wobble, not data loss). Still open. |
+| Frozen-cursor compile rework | **Dead** — subsumed; one-shot keeps the correct subquery form, subscriptions refuse cursors. |
+| Stage 3 (retained versions / read-at-seq) | Explicitly deferred, door left open via Rev. No trigger on the roadmap. |
+
+## Sequencing
+
+1. **PR 0 (now):** ship `fix/docstore-cursor-window` as it stands.
+2. **PR 1 — Stage 1:** store composite + `Announce` + **fact-class compaction
+   in the retention pass** + fact rename + fact contract test + wire
+   seq/codes/`doc_count` + one protocol bump + bus status row-count/size
+   receipt. Live verification: two writes race under a subscriber, facts and
+   rows agree; churn one document a few hundred times, force a trim pass, and
+   `attn bus status` shows the log holding one fact for it.
+3. **PR 2 — Stage 2:** windowed deliveries + `have` resume + refuse `after` at
+   subscribe + client/CLI + the test battery + one protocol bump. Live
+   verification: a real tile-shaped watch across daemon restart resumes with
+   only changed bodies on the wire.
+
+Parallel lane: A4's non-SDK work (registry, manifest, apply pipeline, Bun
+sidecar scaffolding) touches none of these files and can proceed alongside.
+A4's **SDK query surface waits for Stage 2's delivery shape** — that is the
+one-way door this plan exists to get right. Migration numbers: none needed
+here; protocol bumps taken at PR time, conflicts resolved at merge like any
+other.

--- a/internal/daemon/documents.go
+++ b/internal/daemon/documents.go
@@ -167,23 +167,34 @@ func (d *Daemon) compileDocQuery(q docstore.Query, schema docstore.CollectionSch
 	return q.Compile(schema, anchor)
 }
 
-// runDocQuery compiles and runs a query, returning its documents on the wire
-// and how long the statement took. The caller decides what a slow one means:
-// once for a one-shot query, per write for a live one.
-func (d *Daemon) runDocQuery(q docstore.Query, schema docstore.CollectionSchema) ([]protocol.StoredDocument, time.Duration, error) {
+// runDocQuery answers a query, returning its documents on the wire, the
+// declaration they were computed against, and how long the read took. The
+// caller decides what a slow one means: once for a one-shot query, per write
+// for a live one.
+//
+// The declaration comes back from the read rather than being passed in. Reading
+// it separately first is what let a redeclare land between the schema and the
+// SELECT; the store now resolves it inside the same transaction, so the schema
+// returned here is the one the answer actually means.
+func (d *Daemon) runDocQuery(q docstore.Query) ([]protocol.StoredDocument, docstore.CollectionSchema, time.Duration, error) {
 	if d.store == nil {
-		return nil, 0, fmt.Errorf("no database")
+		return nil, docstore.CollectionSchema{}, 0, fmt.Errorf("no database")
 	}
-	compiled, err := d.compileDocQuery(q, schema)
-	if err != nil {
-		return nil, 0, err
+	if err := docstore.ValidateNamespace(q.Namespace); err != nil {
+		return nil, docstore.CollectionSchema{}, 0, err
+	}
+	if err := docstore.ValidateCollection(q.Collection); err != nil {
+		return nil, docstore.CollectionSchema{}, 0, err
 	}
 	started := time.Now()
-	docs, err := d.store.QueryDocuments(compiled)
+	read, found, err := d.store.ReadQuery(q)
 	if err != nil {
-		return nil, 0, err
+		return nil, docstore.CollectionSchema{}, 0, err
 	}
-	return storedDocumentsToProtocol(docs), time.Since(started), nil
+	if !found {
+		return nil, docstore.CollectionSchema{}, 0, undeclaredCollectionError(q.Namespace, q.Collection)
+	}
+	return storedDocumentsToProtocol(read.Documents), read.Schema, time.Since(started), nil
 }
 
 // Two tripwires, because a document query has two costs and only one of them is
@@ -259,10 +270,17 @@ func (d *Daemon) collectionFor(namespace, collection string) (*docstore.Collecti
 		return nil, err
 	}
 	if !ok {
-		return nil, fmt.Errorf("docstore: %s/%s is not declared; declare it with `attn doc define` before reading or writing it",
-			namespace, collection)
+		return nil, undeclaredCollectionError(namespace, collection)
 	}
 	return schema, nil
+}
+
+// undeclaredCollectionError is what every caller reports for a collection that
+// was never declared, whether it read the declaration itself or had a query come
+// back saying there was none.
+func undeclaredCollectionError(namespace, collection string) error {
+	return fmt.Errorf("docstore: %s/%s is not declared; declare it with `attn doc define` before reading or writing it",
+		namespace, collection)
 }
 
 // ---------------------------------------------------------------------------
@@ -421,17 +439,12 @@ func (d *Daemon) handleDocQuery(conn net.Conn, msg *protocol.DocQueryMessage) {
 		d.sendError(conn, err.Error())
 		return
 	}
-	schema, err := d.collectionFor(q.Namespace, q.Collection)
+	docs, schema, took, err := d.runDocQuery(q)
 	if err != nil {
 		d.sendError(conn, err.Error())
 		return
 	}
-	docs, took, err := d.runDocQuery(q, *schema)
-	if err != nil {
-		d.sendError(conn, err.Error())
-		return
-	}
-	d.logSlowDocQuery(*schema, took)
+	d.logSlowDocQuery(schema, took)
 	d.sendDocResponse(conn, protocol.Response{Ok: true, DocQueryResult: &protocol.DocQueryResult{Documents: docs}})
 }
 
@@ -475,26 +488,23 @@ func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMes
 
 	encoder := json.NewEncoder(conn)
 	for delivery := 1; ; delivery++ {
-		// The declaration is re-read per delivery rather than captured, because
-		// it can go out from under a subscription in two ways and both have to
-		// end the subscription rather than mislead it. Undefining drops the
-		// collection's table, and an empty result set would tell a watcher the
-		// collection is still there holding nothing; redeclaring without a field
-		// this query uses drops that field's column, and the query stops meaning
-		// what the caller asked. Either way the caller is told which, and the
-		// subscription ends instead of hanging on a collection it can never
-		// serve again.
-		live, err := d.collectionFor(q.Namespace, q.Collection)
+		// Every delivery re-reads the declaration rather than capturing it,
+		// because it can go out from under a subscription in two ways and both
+		// have to end the subscription rather than mislead it. Undefining drops
+		// the collection's table, and an empty result set would tell a watcher
+		// the collection is still there holding nothing; redeclaring without a
+		// field this query uses drops that field's column, and the query stops
+		// meaning what the caller asked. Either way the caller is told which, and
+		// the subscription ends instead of hanging on a collection it can never
+		// serve again. The re-read happens inside the query's own transaction, so
+		// a redeclare cannot land between reading the declaration and running the
+		// statement compiled from it.
+		docs, live, took, err := d.runDocQuery(q)
 		if err != nil {
 			d.sendError(conn, err.Error())
 			return
 		}
-		docs, took, err := d.runDocQuery(q, *live)
-		if err != nil {
-			d.sendError(conn, err.Error())
-			return
-		}
-		d.logSlowDocFanOut(sub, *live, took)
+		d.logSlowDocFanOut(sub, live, took)
 		resp := protocol.Response{
 			Ok:                 true,
 			DocSubscribeResult: &protocol.DocSubscribeResult{Delivery: delivery, Documents: docs},

--- a/internal/docstore/docstore.go
+++ b/internal/docstore/docstore.go
@@ -657,11 +657,21 @@ func (q Query) bindValue(f Filter, spec FieldSpec) (any, error) {
 	if f.Value == nil {
 		return nil, fmt.Errorf("docstore: %s/%s filter on %q has no value", q.Namespace, q.Collection, f.Field)
 	}
-	// A reserved field is a stored timestamp column, compared as text.
+	// A reserved field is a stored timestamp column, compared as text. The bound
+	// is re-encoded rather than passed through, because text comparison only
+	// means what the caller intends when both sides carry the same encoding: a
+	// bound of "…T10:00:00Z" compared raw against stored stamps sorts above every
+	// stamp in that second. A caller may write any RFC3339 form — including the
+	// one an older store handed them — and get the comparison they asked for.
 	if reservedField[f.Field] {
 		switch v := f.Value.(type) {
 		case string:
-			return v, nil
+			t, err := ParseTime(v)
+			if err != nil {
+				return nil, fmt.Errorf("docstore: %s/%s filter on %q needs an RFC3339 timestamp, got %q",
+					q.Namespace, q.Collection, f.Field, v)
+			}
+			return t.Format(TimeFormat), nil
 		case time.Time:
 			return v.UTC().Format(TimeFormat), nil
 		default:
@@ -709,10 +719,34 @@ func (q Query) bindValue(f Filter, spec FieldSpec) (any, error) {
 	return nil, fmt.Errorf("docstore: %s/%s filter on %q has undeclared type %q", q.Namespace, q.Collection, f.Field, spec.Type)
 }
 
-// TimeFormat is the stored timestamp encoding, matching the job queue's: it
-// keeps sub-second precision and sorts lexicographically, which is what lets
-// created_at and updated_at be ordering terms as plain text columns.
-const TimeFormat = time.RFC3339Nano
+// TimeFormat is the stored timestamp encoding. Stamps live in TEXT columns and
+// are ordered and filtered as text, so the encoding has to make text order and
+// time order the same thing — which takes a fraction of a fixed width, always
+// present and always nine digits.
+//
+// time.RFC3339Nano, which this used to be, does not: it strips trailing zeros,
+// so widths vary and "…:00.5Z" sorts below "…:00.1234Z" while "…:00Z" sorts
+// above both ('Z' is 0x5A, above '.' and every digit). Only stamps inside the
+// same second compared wrongly, which is exactly where bursty writes land, and
+// it made every "changed since" filter drop rows in silence. Migration 91
+// rewrote the stored stamps.
+//
+// Always formatted from a UTC time, so the zone is always "Z" and every stored
+// stamp is the same 30 characters wide.
+const TimeFormat = "2006-01-02T15:04:05.000000000Z07:00"
+
+// ParseTime decodes a stamp in any RFC3339 form — TimeFormat's own, the
+// trailing-zero-stripped form stored before migration 91, a whole second with no
+// fraction at all, or a non-UTC offset — and normalizes it to UTC. Callers hand
+// timestamps in as strings from JSON, and the one they most often hand in is one
+// this store gave them, so the accepted set has to be wider than the stored one.
+func ParseTime(s string) (time.Time, error) {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return t.UTC(), nil
+}
 
 // Target is the subject a change to this collection is published under, and the
 // key a subscription is matched on. Collection-grained rather than

--- a/internal/docstore/timestamps_test.go
+++ b/internal/docstore/timestamps_test.go
@@ -1,0 +1,140 @@
+package docstore
+
+import (
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A stamp lives in a TEXT column and is ordered and filtered as text, so the
+// encoding carries the whole meaning of "before". These are the instants that
+// catch an encoding that does not: all inside one second, with fractions whose
+// trailing zeros differ, plus one on the second with no fraction at all.
+//
+// Under time.RFC3339Nano — what TimeFormat used to be — their text order is
+// [.12345, .1234, .5, no-fraction], which is neither their order nor a rotation
+// of it.
+func raggedInstants() []time.Time {
+	base := time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC)
+	return []time.Time{
+		base,
+		base.Add(123400 * time.Microsecond),
+		base.Add(123450 * time.Microsecond),
+		base.Add(500 * time.Millisecond),
+		base.Add(time.Second),
+	}
+}
+
+func TestStoredStampsSortAsTextInTimeOrder(t *testing.T) {
+	instants := raggedInstants()
+	encoded := make([]string, len(instants))
+	for i, at := range instants {
+		encoded[i] = at.Format(TimeFormat)
+	}
+	sorted := append([]string(nil), encoded...)
+	sort.Strings(sorted)
+	for i := range encoded {
+		if sorted[i] != encoded[i] {
+			t.Fatalf("text order is %v, but these instants are in time order as %v", sorted, encoded)
+		}
+	}
+}
+
+// Fixed width is what makes the text order hold: a fraction that varies in
+// length compares digit against digit at the wrong place, and a stamp with no
+// fraction ends in 'Z', which is above '.' and above every digit.
+func TestEveryStoredStampIsTheSameWidth(t *testing.T) {
+	for _, at := range raggedInstants() {
+		got := at.Format(TimeFormat)
+		if len(got) != 30 {
+			t.Fatalf("%q is %d characters, want the same 30 every stamp has", got, len(got))
+		}
+		if !strings.HasSuffix(got, "Z") {
+			t.Fatalf("%q does not end in Z; stamps are stored in UTC", got)
+		}
+	}
+}
+
+// Callers hand timestamps in as strings, and the ones they hand in come from
+// somewhere else: a store that predates migration 91, a hand-written whole
+// second, a client working in local time. All of them name an instant.
+func TestATimestampIsAcceptedInAnyRFC3339Form(t *testing.T) {
+	want := time.Date(2026, 8, 5, 10, 0, 0, 500000000, time.UTC)
+	for _, form := range []string{
+		"2026-08-05T10:00:00.5Z",
+		"2026-08-05T10:00:00.500Z",
+		"2026-08-05T10:00:00.500000000Z",
+		"2026-08-05T12:00:00.5+02:00",
+	} {
+		got, err := ParseTime(form)
+		if err != nil {
+			t.Fatalf("%q: %v", form, err)
+		}
+		if !got.Equal(want) {
+			t.Fatalf("%q decoded to %v, want %v", form, got, want)
+		}
+		if got.Format(TimeFormat) != want.Format(TimeFormat) {
+			t.Fatalf("%q re-encoded to %q, want %q", form, got.Format(TimeFormat), want.Format(TimeFormat))
+		}
+	}
+}
+
+// The bound a filter carries is re-encoded, not passed through: a bound in one
+// encoding compared as text against stamps in another is the same defect the
+// stored encoding had, moved to the caller's side.
+func TestATimestampBoundIsReEncodedBeforeItIsCompared(t *testing.T) {
+	for _, form := range []string{
+		"2026-08-05T10:00:00Z",
+		"2026-08-05T10:00:00.000Z",
+		"2026-08-05T12:00:00+02:00",
+	} {
+		c := mustCompile(t, Query{
+			Namespace:  "ext/approval-gate",
+			Collection: "requests",
+			Filters:    []Filter{{Field: FieldUpdatedAt, Op: OpGte, Value: form}},
+		})
+		if len(c.Args) != 1 {
+			t.Fatalf("%q compiled to %d arguments, want 1", form, len(c.Args))
+		}
+		if want := "2026-08-05T10:00:00.000000000Z"; c.Args[0] != want {
+			t.Fatalf("%q was bound as %v, want %q", form, c.Args[0], want)
+		}
+	}
+}
+
+// A time.Time bound arrives at the same encoding as a string one, so which type
+// a caller reaches for cannot change the answer.
+func TestATimestampBoundEncodesTheSameFromAStringOrATime(t *testing.T) {
+	at := time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC)
+	fromTime := mustCompile(t, Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Filters:    []Filter{{Field: FieldCreatedAt, Op: OpGte, Value: at}},
+	})
+	fromString := mustCompile(t, Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Filters:    []Filter{{Field: FieldCreatedAt, Op: OpGte, Value: at.Format(time.RFC3339)}},
+	})
+	if fromTime.Args[0] != fromString.Args[0] {
+		t.Fatalf("a time bound is %v and the same instant as a string is %v", fromTime.Args[0], fromString.Args[0])
+	}
+}
+
+// A string that is not a timestamp used to be bound verbatim, where it compared
+// against every stamp as text and quietly matched some prefix of them. It is a
+// caller mistake, and the error has to be enough to fix it.
+func TestATimestampBoundThatIsNotATimestampIsRefused(t *testing.T) {
+	_, err := Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Filters:    []Filter{{Field: FieldUpdatedAt, Op: OpGt, Value: "yesterday"}},
+	}.Compile(requestsSchema(), nil)
+	if err == nil {
+		t.Fatal("a filter on updated_at accepted \"yesterday\"")
+	}
+	if !strings.Contains(err.Error(), "RFC3339") || !strings.Contains(err.Error(), "yesterday") {
+		t.Fatalf("error names neither the expected form nor the value given: %v", err)
+	}
+}

--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -274,13 +274,17 @@ func (s *Store) GetDocument(schema docstore.CollectionSchema, id string) (*docst
 	if err != nil {
 		return nil, false, err
 	}
-	row := s.db.QueryRow(`SELECT `+documentColumns+` FROM `+table+` WHERE id = ?`, id)
+	return getDocumentWith(s.db, schema.Namespace, schema.Collection, table, id)
+}
+
+func getDocumentWith(q rowQuerier, namespace, collection, table, id string) (*docstore.Document, bool, error) {
+	row := q.QueryRow(`SELECT `+documentColumns+` FROM `+table+` WHERE id = ?`, id)
 	doc, err := scanDocument(row)
 	if err == sql.ErrNoRows {
 		return nil, false, nil
 	}
 	if err != nil {
-		return nil, false, fmt.Errorf("store: reading %s/%s/%s: %w", schema.Namespace, schema.Collection, id, err)
+		return nil, false, fmt.Errorf("store: reading %s/%s/%s: %w", namespace, collection, id, err)
 	}
 	return doc, true, nil
 }
@@ -347,14 +351,24 @@ func (s *Store) documentConflict(schema docstore.CollectionSchema, table, id str
 	return conflict
 }
 
-// QueryDocuments runs a compiled query. The compiled fragments are built from a
-// validated query against a stored declaration, so the only strings spliced into
-// the statement are ones docstore produced from identifiers it checked; every
-// caller-supplied value arrives as a bound argument.
-func (s *Store) QueryDocuments(c docstore.Compiled) ([]docstore.Document, error) {
+// queryDocuments runs an already-compiled query. The compiled fragments are
+// built from a validated query against a stored declaration, so the only strings
+// spliced into the statement are ones docstore produced from identifiers it
+// checked; every caller-supplied value arrives as a bound argument.
+//
+// Unexported on purpose. A compiled query carries a table name, a column
+// affinity and a cursor value taken from the declaration it was compiled
+// against, so running one is only correct against the state it was compiled
+// from. Handing that pairing to callers is what produced three silent wrong
+// answers; ReadQuery owns both halves and is the way in from outside.
+func (s *Store) queryDocuments(c docstore.Compiled) ([]docstore.Document, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("store: no database")
 	}
+	return queryDocumentsWith(s.db, c)
+}
+
+func queryDocumentsWith(q rowsQuerier, c docstore.Compiled) ([]docstore.Document, error) {
 	if err := docstore.ValidateTableName(c.Table); err != nil {
 		return nil, err
 	}
@@ -364,7 +378,7 @@ func (s *Store) QueryDocuments(c docstore.Compiled) ([]docstore.Document, error)
 	}
 	stmt += ` ORDER BY ` + c.Order + ` LIMIT ?`
 
-	rows, err := s.db.Query(stmt, append(append([]any{}, c.Args...), c.Limit)...)
+	rows, err := q.Query(stmt, append(append([]any{}, c.Args...), c.Limit)...)
 	if err != nil {
 		return nil, fmt.Errorf("store: querying documents: %w", err)
 	}
@@ -378,6 +392,81 @@ func (s *Store) QueryDocuments(c docstore.Compiled) ([]docstore.Document, error)
 		out = append(out, *doc)
 	}
 	return out, rows.Err()
+}
+
+// QueryRead is one answer to one query: the documents, and the declaration they
+// were computed against. The declaration is returned rather than assumed because
+// the caller's copy may already be out of date by the time it reads this — the
+// one in here is the one the answer actually means.
+type QueryRead struct {
+	Schema    docstore.CollectionSchema
+	Documents []docstore.Document
+}
+
+// ReadQuery answers a query in a single read transaction, and is the only way
+// to run one from outside the store.
+//
+// Answering takes three reads: the declaration, which names the table and the
+// affinity of every column the SQL will compare; the cursor anchor, whose
+// presence and sort value decide which cursor clause gets compiled; and the
+// SELECT itself. Those used to be three separate transactions with the compile
+// in between, so the statement could be built against one state and executed
+// against another. That is not a narrow race — it produced a page that silently
+// came back empty when the anchor was deleted, a page that handed back the
+// anchor document itself when the anchor gained a sort value, and a filter that
+// silently matched nothing when a field's declared type changed underneath it.
+// None of the three reported an error, and each returned an answer that matched
+// no state the collection was ever in.
+//
+// One transaction removes the class rather than narrowing it: compile-time and
+// execute-time are the same instant, so there is no second state to disagree
+// with. Nothing is committed — a read transaction here buys a consistent
+// snapshot, not atomic writes. It costs one contiguous SHARED lock in place of
+// three brief ones, which is the same total work; what it denies a writer is
+// exactly the gap that produced the wrong answers.
+//
+// found reports whether the collection is declared at all, the same way
+// DocumentCollection does.
+func (s *Store) ReadQuery(q docstore.Query) (QueryRead, bool, error) {
+	if s.db == nil {
+		return QueryRead{}, false, fmt.Errorf("store: no database")
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return QueryRead{}, false, fmt.Errorf("store: reading %s/%s: %w", q.Namespace, q.Collection, err)
+	}
+	// Rolled back rather than committed: a read transaction has nothing to
+	// commit, and rolling back is what releases the snapshot.
+	defer func() { _ = tx.Rollback() }()
+
+	schema, table, found, err := readCollectionTx(tx, q.Namespace, q.Collection)
+	if err != nil || !found {
+		return QueryRead{}, false, err
+	}
+
+	var anchor *docstore.Document
+	if q.After != "" {
+		// A missing anchor stays nil, which is the case Compile refuses by name.
+		// Inside this transaction that refusal is now truthful: the anchor really
+		// is absent from the state the SELECT would have run against.
+		doc, ok, err := getDocumentWith(tx, schema.Namespace, schema.Collection, table, q.After)
+		if err != nil {
+			return QueryRead{}, false, err
+		}
+		if ok {
+			anchor = doc
+		}
+	}
+
+	compiled, err := q.Compile(schema, anchor)
+	if err != nil {
+		return QueryRead{}, false, err
+	}
+	docs, err := queryDocumentsWith(tx, compiled)
+	if err != nil {
+		return QueryRead{}, false, err
+	}
+	return QueryRead{Schema: schema, Documents: docs}, true, nil
 }
 
 // CountDocuments reports how many documents a collection holds. It is what the
@@ -574,6 +663,10 @@ func quoteIdent(name string) string {
 
 type rowQuerier interface {
 	QueryRow(query string, args ...any) *sql.Row
+}
+
+type rowsQuerier interface {
+	Query(query string, args ...any) (*sql.Rows, error)
 }
 
 // readCollection reads a declaration and the table minted for it.

--- a/internal/store/documents_model_test.go
+++ b/internal/store/documents_model_test.go
@@ -382,7 +382,7 @@ func (w *modelWorld) realIDs(q docstore.Query) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	docs, err := w.s.QueryDocuments(c)
+	docs, err := w.s.queryDocuments(c)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/documents_read_window_test.go
+++ b/internal/store/documents_read_window_test.go
@@ -1,0 +1,211 @@
+package store
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/docstore"
+)
+
+// Answering a query takes three reads — the declaration, the cursor anchor, and
+// the SELECT — and the statement is compiled from the first two. While those
+// were three separate transactions, a write landing in between produced answers
+// that matched no state the collection was ever in, and reported no error:
+//
+//	anchor deleted mid-read       -> silently empty page, not "cannot page after"
+//	anchor gained a sort value    -> the page handed back the anchor itself
+//	a field's declared type moved -> the filter silently matched nothing
+//
+// ReadQuery does all three inside one transaction. These tests pin each of the
+// three outcomes, and then the invariant underneath them.
+
+func readIDs(t *testing.T, s *Store, q docstore.Query) ([]string, error) {
+	t.Helper()
+	read, found, err := s.ReadQuery(q)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		t.Fatalf("%s/%s is not declared", q.Namespace, q.Collection)
+	}
+	ids := make([]string, 0, len(read.Documents))
+	for _, d := range read.Documents {
+		ids = append(ids, d.ID)
+	}
+	return ids, nil
+}
+
+func pagedByAttempts(after string) docstore.Query {
+	return docstore.Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Sort:       &docstore.Sort{Field: "attempts"},
+		After:      after,
+	}
+}
+
+// A cursor naming a document that is gone is an error with a way forward, not an
+// empty page. An empty page is indistinguishable from "you have reached the end"
+// and silently truncates whatever the caller was walking.
+func TestPagingAfterADeletedAnchorSaysSoRatherThanEmptyingThePage(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{
+		"a": `{"attempts":1}`,
+		"b": `{"attempts":2}`,
+		"c": `{"attempts":3}`,
+	})
+	if _, err := s.DeleteDocument(requestsDecl(t, s), "a", nil); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	got, err := readIDs(t, s, pagedByAttempts("a"))
+	if err == nil {
+		t.Fatalf("paging after a deleted anchor returned %v and no error; it must say the anchor is gone", got)
+	}
+	if !strings.Contains(err.Error(), "no longer exists") {
+		t.Fatalf("error does not name the missing anchor: %v", err)
+	}
+}
+
+// The anchor is a position in the order, so a page after it never contains it.
+func TestAPageNeverContainsItsOwnAnchor(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{
+		"a": `{}`,
+		"b": `{"attempts":3}`,
+		"c": `{"attempts":7}`,
+	})
+
+	// The anchor with no value for the sort field sorts first, so the page after
+	// it is everything else.
+	got, err := readIDs(t, s, pagedByAttempts("a"))
+	if err != nil {
+		t.Fatalf("page after a null-valued anchor: %v", err)
+	}
+	if want := []string{"b", "c"}; !sameIDs(got, want) {
+		t.Fatalf("page after a null-valued anchor is %v, want %v", got, want)
+	}
+
+	// Once it has a value it sorts between b and c, and the page after it shrinks
+	// to c. The anchor appears in neither answer.
+	if _, err := s.PutDocument(requestsDecl(t, s), "a", []byte(`{"attempts":5}`), base.Add(time.Hour), nil); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	got, err = readIDs(t, s, pagedByAttempts("a"))
+	if err != nil {
+		t.Fatalf("page after a valued anchor: %v", err)
+	}
+	if want := []string{"c"}; !sameIDs(got, want) {
+		t.Fatalf("page after a valued anchor is %v, want %v", got, want)
+	}
+}
+
+// A filter bound under one declared type must never be compared against a column
+// that has since been redeclared as another. The affinity changes underneath the
+// same column name, so the comparison silently stops matching instead of failing.
+func TestAFilterIsBoundUnderTheDeclarationItRunsAgainst(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{
+		"a": `{"attempts":1}`,
+		"b": `{"attempts":2}`,
+		"c": `{"attempts":3}`,
+	})
+	numeric := docstore.Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Filters:    []docstore.Filter{{Field: "attempts", Op: docstore.OpEq, Value: float64(2)}},
+	}
+
+	got, err := readIDs(t, s, numeric)
+	if err != nil {
+		t.Fatalf("numeric filter under a number declaration: %v", err)
+	}
+	if want := []string{"b"}; !sameIDs(got, want) {
+		t.Fatalf("numeric filter matched %v, want %v", got, want)
+	}
+
+	next := requestsDeclaration()
+	for i := range next.Fields {
+		if next.Fields[i].Name == "attempts" {
+			next.Fields[i].Type = docstore.FieldString
+		}
+	}
+	if err := s.DefineDocumentCollection(next, base.Add(time.Hour)); err != nil {
+		t.Fatalf("redeclare: %v", err)
+	}
+
+	got, err = readIDs(t, s, numeric)
+	if err == nil {
+		t.Fatalf("a numeric filter on a string field returned %v and no error", got)
+	}
+	if !strings.Contains(err.Error(), "needs a string value") {
+		t.Fatalf("error does not name the type mismatch: %v", err)
+	}
+}
+
+// The invariant the three tests above are instances of, run as the race it
+// protects against: a reader and a writer going at the same collection at once.
+//
+// The writer flips one document between exactly two states, so every answer a
+// reader can legitimately get is enumerable — the page after a null-valued
+// anchor, or the page after that same anchor once it has a value. Any other
+// answer describes a collection that never existed, which is what a read spread
+// across several transactions produces. There is no timing here and nothing to
+// wait for: the assertion holds for every interleaving, so the test only has to
+// run enough of them.
+func TestAQueryNeverSeesACollectionThatNeverExisted(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{
+		"a": `{}`,
+		"b": `{"attempts":3}`,
+		"c": `{"attempts":7}`,
+	})
+	schema := requestsDecl(t, s)
+
+	const reads = 3000
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		bodies := []string{`{}`, `{"attempts":5}`}
+		for i := 0; ; i++ {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			if _, err := s.PutDocument(schema, "a", []byte(bodies[i%2]), base.Add(time.Duration(i)*time.Millisecond), nil); err != nil {
+				t.Errorf("writer: %v", err)
+				return
+			}
+		}
+	}()
+
+	// "a" has no value for attempts, so it sorts first and the page after it is
+	// everything else; with a value it sorts between b and c and the page is just
+	// c. Nothing else is a state this collection passes through.
+	legal := [][]string{{"b", "c"}, {"c"}}
+	for i := 0; i < reads; i++ {
+		got, err := readIDs(t, s, pagedByAttempts("a"))
+		if err != nil {
+			close(done)
+			wg.Wait()
+			t.Fatalf("read %d: %v", i, err)
+		}
+		ok := false
+		for _, want := range legal {
+			if sameIDs(got, want) {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			close(done)
+			wg.Wait()
+			t.Fatalf("read %d answered %v, which is the page after \"a\" in no state this collection was ever in; legal answers are %v",
+				i, got, legal)
+		}
+	}
+	close(done)
+	wg.Wait()
+}

--- a/internal/store/documents_test.go
+++ b/internal/store/documents_test.go
@@ -91,7 +91,7 @@ func queryIDs(t *testing.T, s *Store, q docstore.Query) []string {
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	docs, err := s.QueryDocuments(c)
+	docs, err := s.queryDocuments(c)
 	if err != nil {
 		t.Fatalf("query: %v", err)
 	}
@@ -804,7 +804,7 @@ func TestAnEmptyResultIsAnEmptyList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	docs, err := s.QueryDocuments(c)
+	docs, err := s.queryDocuments(c)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/documents_timestamps_test.go
+++ b/internal/store/documents_timestamps_test.go
@@ -1,0 +1,306 @@
+package store
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/docstore"
+)
+
+// created_at and updated_at are TEXT columns, so every sort and every
+// "changed since" filter on them is a text comparison and the stored encoding
+// is the whole definition of "before". Documents written a second apart cannot
+// tell a working encoding from a broken one: the part that has to be right is
+// what happens inside one second, which is also where bursty writes land.
+//
+// These tests write four documents inside one second, at offsets whose
+// trailing-zero-stripped encodings sort in an order that is not their own.
+
+// raggedSeconds are ids in chronological order with the sub-second offsets that
+// separate them, all within the same second.
+var raggedSeconds = []struct {
+	id     string
+	offset time.Duration
+}{
+	{"t0", 0},
+	{"t1234", 123400 * time.Microsecond},
+	{"t12345", 123450 * time.Microsecond},
+	{"t5", 500 * time.Millisecond},
+}
+
+// storeWithRaggedStamps writes the four documents and returns the store, the
+// declaration, and the instant the first was written at.
+func storeWithRaggedStamps(t *testing.T) (*Store, docstore.CollectionSchema, time.Time) {
+	t.Helper()
+	s := New()
+	base := time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC)
+	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+		t.Fatalf("define: %v", err)
+	}
+	schema := declOf(t, s, "ext/approval-gate", "requests")
+	for _, r := range raggedSeconds {
+		if _, err := s.PutDocument(schema, r.id, []byte(`{"status":"pending"}`), base.Add(r.offset), nil); err != nil {
+			t.Fatalf("put %s: %v", r.id, err)
+		}
+	}
+	return s, schema, base
+}
+
+func chronological() []string {
+	out := make([]string, 0, len(raggedSeconds))
+	for _, r := range raggedSeconds {
+		out = append(out, r.id)
+	}
+	return out
+}
+
+func reversed(ids []string) []string {
+	out := make([]string, len(ids))
+	for i, id := range ids {
+		out[len(ids)-1-i] = id
+	}
+	return out
+}
+
+func sameOrder(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func stampQuery(sort *docstore.Sort, filters ...docstore.Filter) docstore.Query {
+	return docstore.Query{
+		Namespace:  "ext/approval-gate",
+		Collection: "requests",
+		Sort:       sort,
+		Filters:    filters,
+	}
+}
+
+// Sorting on a stamp orders by time, not by the shape of the text it is stored
+// as. This is the assertion the whole encoding exists to satisfy.
+func TestSortingOnAStampOrdersDocumentsByWhenTheyWereWritten(t *testing.T) {
+	s, _, _ := storeWithRaggedStamps(t)
+
+	got, err := readIDs(t, s, stampQuery(&docstore.Sort{Field: docstore.FieldCreatedAt}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := chronological(); !sameOrder(got, want) {
+		t.Fatalf("ascending by created_at gave %v, want %v", got, want)
+	}
+
+	got, err = readIDs(t, s, stampQuery(&docstore.Sort{Field: docstore.FieldCreatedAt, Desc: true}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := reversed(chronological()); !sameOrder(got, want) {
+		t.Fatalf("descending by created_at gave %v, want %v", got, want)
+	}
+}
+
+// "Everything changed since X" is one of the two things the reserved stamps are
+// for. A bound on the second boundary is the ordinary case — it is what a caller
+// writes by hand and what a whole-second clock produces — and it used to sort
+// above every stamp inside that second, so a sweep found one document out of
+// four and said nothing.
+func TestAChangedSinceFilterFindsEverythingChangedSince(t *testing.T) {
+	s, _, base := storeWithRaggedStamps(t)
+
+	got, err := readIDs(t, s, stampQuery(
+		&docstore.Sort{Field: docstore.FieldUpdatedAt},
+		docstore.Filter{Field: docstore.FieldUpdatedAt, Op: docstore.OpGte, Value: base.Format(time.RFC3339)},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := chronological(); !sameOrder(got, want) {
+		t.Fatalf("updated_at >= the second boundary gave %v, want every document: %v", got, want)
+	}
+
+	// Strictly after the first document's stamp excludes it and nothing else.
+	got, err = readIDs(t, s, stampQuery(
+		&docstore.Sort{Field: docstore.FieldUpdatedAt},
+		docstore.Filter{Field: docstore.FieldUpdatedAt, Op: docstore.OpGt, Value: base},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := chronological()[1:]; !sameOrder(got, want) {
+		t.Fatalf("updated_at > the first document's stamp gave %v, want %v", got, want)
+	}
+}
+
+// The canonical way to resume a sweep is to take the last document's stamp off
+// the wire and use it as the next bound. That is a round trip through the stored
+// encoding and back, so it only works if a bound and a stamp mean the same thing.
+func TestASweepResumesFromTheStampItWasHandedBack(t *testing.T) {
+	s, _, _ := storeWithRaggedStamps(t)
+
+	read, found, err := s.ReadQuery(stampQuery(&docstore.Sort{Field: docstore.FieldUpdatedAt}))
+	if err != nil || !found {
+		t.Fatalf("first sweep: found=%v err=%v", found, err)
+	}
+	seen := read.Documents[:2]
+	cursor := seen[len(seen)-1].UpdatedAt.UTC().Format(docstore.TimeFormat)
+
+	got, err := readIDs(t, s, stampQuery(
+		&docstore.Sort{Field: docstore.FieldUpdatedAt},
+		docstore.Filter{Field: docstore.FieldUpdatedAt, Op: docstore.OpGt, Value: cursor},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := chronological()[2:]; !sameOrder(got, want) {
+		t.Fatalf("resuming after %s gave %v, want %v", cursor, got, want)
+	}
+}
+
+// A caller writing a bound by hand does not know the stored encoding and should
+// not have to: every RFC3339 spelling of one instant is the same bound.
+func TestABoundMeansTheSameInEveryRFC3339Spelling(t *testing.T) {
+	s, _, _ := storeWithRaggedStamps(t)
+
+	var first []string
+	for _, form := range []string{
+		"2026-08-05T10:00:00Z",
+		"2026-08-05T10:00:00.0Z",
+		"2026-08-05T10:00:00.000000000Z",
+		"2026-08-05T12:00:00+02:00",
+	} {
+		got, err := readIDs(t, s, stampQuery(
+			&docstore.Sort{Field: docstore.FieldCreatedAt},
+			docstore.Filter{Field: docstore.FieldCreatedAt, Op: docstore.OpGte, Value: form},
+		))
+		if err != nil {
+			t.Fatalf("%s: %v", form, err)
+		}
+		if first == nil {
+			first = got
+			if want := chronological(); !sameOrder(got, want) {
+				t.Fatalf("%s matched %v, want %v", form, got, want)
+			}
+			continue
+		}
+		if !sameOrder(got, first) {
+			t.Fatalf("%s matched %v, but the same instant written differently matched %v", form, got, first)
+		}
+	}
+}
+
+// A stamp that is not a timestamp is a caller mistake that used to compare as
+// text against every stored stamp, matching whatever happened to sort under it.
+func TestAStampFilterRefusesAValueThatIsNotATimestamp(t *testing.T) {
+	s, _, _ := storeWithRaggedStamps(t)
+
+	got, err := readIDs(t, s, stampQuery(nil,
+		docstore.Filter{Field: docstore.FieldUpdatedAt, Op: docstore.OpGt, Value: "last tuesday"}))
+	if err == nil {
+		t.Fatalf("a filter on updated_at accepted \"last tuesday\" and returned %v", got)
+	}
+}
+
+// Migration 91 rewrites what earlier versions stored. Its input is the encoding
+// they wrote, so the test writes that encoding rather than describing it: the
+// stamps go in the way an older store would have written them, the migration
+// runs, and the sort that was scrambled comes back in order.
+func TestMigration91RewritesStampsThatDoNotSort(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB: %v", err)
+	}
+	defer s.Close()
+
+	base := time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC)
+	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+		t.Fatalf("define: %v", err)
+	}
+	schema := declOf(t, s, "ext/approval-gate", "requests")
+	for _, r := range raggedSeconds {
+		if _, err := s.PutDocument(schema, r.id, []byte(`{"status":"pending"}`), base.Add(r.offset), nil); err != nil {
+			t.Fatalf("put %s: %v", r.id, err)
+		}
+	}
+
+	// Roll the stamps back to the encoding migration 91 exists to replace, and
+	// plant one value it cannot read, which it must leave alone rather than
+	// turn into year 1.
+	table := docstore.TableName(collectionID(t, s, "ext/approval-gate", "requests"))
+	for _, r := range raggedSeconds {
+		old := base.Add(r.offset).Format(time.RFC3339Nano)
+		if _, err := s.db.Exec(fmt.Sprintf(`UPDATE %s SET created_at = ?, updated_at = ? WHERE id = ?`, table),
+			old, old, r.id); err != nil {
+			t.Fatalf("plant old stamp for %s: %v", r.id, err)
+		}
+	}
+	if _, err := s.db.Exec(`UPDATE document_collections SET updated_at = 'not a timestamp'`); err != nil {
+		t.Fatalf("plant unreadable stamp: %v", err)
+	}
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version >= 91`); err != nil {
+		t.Fatalf("unrecord migration 91: %v", err)
+	}
+
+	// Sanity: the planted state is the broken one, so a pass here would mean the
+	// test proves nothing.
+	if got, err := readIDs(t, s, stampQuery(&docstore.Sort{Field: docstore.FieldCreatedAt})); err != nil {
+		t.Fatal(err)
+	} else if sameOrder(got, chronological()) {
+		t.Fatalf("the planted stamps already sort correctly as %v; this test would pass without the migration", got)
+	}
+
+	if err := migrateDB(s.db, dbPath); err != nil {
+		t.Fatalf("migrateDB: %v", err)
+	}
+
+	got, err := readIDs(t, s, stampQuery(&docstore.Sort{Field: docstore.FieldCreatedAt}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := chronological(); !sameOrder(got, want) {
+		t.Fatalf("after migration 91 the stamps sort as %v, want %v", got, want)
+	}
+
+	// Re-running finds nothing left to do and changes nothing: the rewrite is a
+	// decode and re-encode, so an already-converted stamp yields itself.
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version >= 91`); err != nil {
+		t.Fatalf("unrecord migration 91 again: %v", err)
+	}
+	if err := migrateDB(s.db, dbPath); err != nil {
+		t.Fatalf("re-run migrateDB: %v", err)
+	}
+	got, err = readIDs(t, s, stampQuery(&docstore.Sort{Field: docstore.FieldCreatedAt}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := chronological(); !sameOrder(got, want) {
+		t.Fatalf("re-running migration 91 left the stamps sorting as %v, want %v", got, want)
+	}
+
+	var unreadable string
+	if err := s.db.QueryRow(`SELECT updated_at FROM document_collections`).Scan(&unreadable); err != nil {
+		t.Fatal(err)
+	}
+	if unreadable != "not a timestamp" {
+		t.Fatalf("the unreadable stamp became %q; it must be left as it was", unreadable)
+	}
+}
+
+func collectionID(t *testing.T, s *Store, namespace, collection string) int64 {
+	t.Helper()
+	var id int64
+	if err := s.db.QueryRow(
+		`SELECT id FROM document_collections WHERE namespace = ? AND collection = ?`,
+		namespace, collection).Scan(&id); err != nil {
+		t.Fatalf("registry id for %s/%s: %v", namespace, collection, err)
+	}
+	return id
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	_ "github.com/mattn/go-sqlite3"
 
@@ -921,6 +922,13 @@ CREATE TABLE IF NOT EXISTS document_collections (
 	// has ever been written against a revision, so there is no earlier history to
 	// preserve. Applied by applyMigration90.
 	{90, "give every document a revision", ``},
+	// Rewrites every stored document stamp into docstore.TimeFormat's
+	// fixed-width encoding. The stamps are TEXT columns ordered and filtered as
+	// text, and the encoding they were written in stripped trailing zeros from
+	// the fraction, so within any one second text order and time order disagreed
+	// — sorts came back scrambled and "changed since" filters dropped rows in
+	// silence. Applied by applyMigration91.
+	{91, "store document timestamps in an encoding that sorts", ``},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -1196,6 +1204,11 @@ func migrateDB(db *sql.DB, dbPath string) error {
 			}
 		} else if m.version == 90 {
 			if err := applyMigration90(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 91 {
+			if err := applyMigration91(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -2263,6 +2276,130 @@ func applyMigration90(tx *sql.Tx) error {
 		}
 	}
 	return nil
+}
+
+// applyMigration91 rewrites every stored document stamp into
+// docstore.TimeFormat's fixed-width encoding, so that comparing the stamps as
+// text — which is the only way a TEXT column is compared, and what every sort
+// and "changed since" filter on created_at/updated_at does — orders them by
+// time. The encoding they were written in stripped trailing zeros, so within one
+// second the two orders disagreed.
+//
+// The rewrite is a decode and re-encode rather than SQL string surgery: the
+// stamps that need fixing are exactly the ones whose shape varies, which is what
+// makes them awkward to recognise in SQL and trivial to normalize in Go.
+//
+// Idempotent by construction — re-encoding an already-converted stamp yields
+// itself — so a rewound schema_migrations table re-runs it harmlessly and a run
+// that stopped part way finishes.
+//
+// A stamp that does not decode is left alone and reported. Nothing the store
+// writes can produce one, so it means a hand-edited database, and turning an
+// unreadable stamp into year 1 loses more than leaving it unreadable does.
+func applyMigration91(tx *sql.Tx) error {
+	ids, err := collectionTableIDs(tx)
+	if err != nil {
+		return err
+	}
+	unreadable := 0
+	for _, id := range ids {
+		table := docstore.TableName(id)
+		n, err := restampTable(tx, table, "id", []string{"created_at", "updated_at"})
+		if err != nil {
+			return fmt.Errorf("restamping %s: %w", table, err)
+		}
+		unreadable += n
+	}
+	n, err := restampTable(tx, "document_collections", "id", []string{"updated_at"})
+	if err != nil {
+		return fmt.Errorf("restamping document_collections: %w", err)
+	}
+	unreadable += n
+	if unreadable > 0 {
+		log.Printf("[store] migration 91: left %d document timestamp(s) as they were; they are not RFC3339 and cannot be re-encoded", unreadable)
+	}
+	return nil
+}
+
+// collectionTableIDs lists the collections the registry knows about. The
+// registry is the only list of them: reading the schema for `doc_%` tables would
+// pick up anything that happened to be named like one.
+func collectionTableIDs(tx *sql.Tx) ([]int64, error) {
+	rows, err := tx.Query(`SELECT id FROM document_collections`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// restampTable re-encodes the named stamp columns of every row, returning how
+// many values it could not decode and therefore did not touch. Rows are read out
+// before any are written back, because the driver holds one connection and a
+// write issued while a read is still streaming deadlocks against it.
+func restampTable(tx *sql.Tx, table, key string, columns []string) (int, error) {
+	rows, err := tx.Query(fmt.Sprintf(`SELECT %s, %s FROM %s`, key, strings.Join(columns, ", "), table))
+	if err != nil {
+		return 0, err
+	}
+	type row struct {
+		key    any
+		stamps []string
+	}
+	var pending []row
+	for rows.Next() {
+		r := row{stamps: make([]string, len(columns))}
+		dest := make([]any, 0, len(columns)+1)
+		dest = append(dest, &r.key)
+		for i := range r.stamps {
+			dest = append(dest, &r.stamps[i])
+		}
+		if err := rows.Scan(dest...); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		pending = append(pending, r)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	unreadable := 0
+	for _, r := range pending {
+		sets := make([]string, 0, len(columns))
+		args := make([]any, 0, len(columns)+1)
+		for i, c := range columns {
+			t, err := docstore.ParseTime(r.stamps[i])
+			if err != nil {
+				unreadable++
+				continue
+			}
+			encoded := t.Format(docstore.TimeFormat)
+			if encoded == r.stamps[i] {
+				continue
+			}
+			sets = append(sets, c+" = ?")
+			args = append(args, encoded)
+		}
+		if len(sets) == 0 {
+			continue
+		}
+		args = append(args, r.key)
+		if _, err := tx.Exec(fmt.Sprintf(`UPDATE %s SET %s WHERE %s = ?`,
+			table, strings.Join(sets, ", "), key), args...); err != nil {
+			return 0, err
+		}
+	}
+	return unreadable, nil
 }
 
 // v88Collection is one collection to carry across: its declaration as v88


### PR DESCRIPTION
## What

Three document-store fixes and two design documents.

**Read windows (one transaction).** Answering a query used to take three separate transactions — declaration, pagination anchor, SELECT — with SQL compiled in between, so a write landing mid-read produced answers matching no state the collection was ever in: a silently empty page when the anchor was deleted mid-read, a page containing the anchor itself when the anchor gained a sort value, a filter that matched nothing after a type redeclare. `Store.ReadQuery` now does all three reads in one transaction and `QueryDocuments` is unexported so a compiled query cannot run against a state it was not compiled from. Pinned by `internal/store/documents_read_window_test.go`.

**Timestamps that sort.** Stored document stamps are TEXT columns compared as text, and the old encoding (`time.RFC3339Nano`) strips trailing zeros — so within any one second, text order and time order disagreed ('Z' sorts above '.' and every digit). Sorting by `created_at` came back scrambled and a changed-since filter on a whole-second bound silently dropped rows. `docstore.TimeFormat` is now a fixed nine-digit fraction (every stamp exactly 30 chars), bounds on reserved fields are decoded and re-encoded so any RFC3339 spelling means the same instant, a non-timestamp bound is refused instead of compared as text, and migration 91 rewrites stored stamps (idempotent by construction; values it cannot decode are left alone and counted). Pinned by `internal/docstore/timestamps_test.go` and `internal/store/documents_timestamps_test.go`, each falsified against the three halves of the fix separately.

**A3.3 findings doc** records both post-fix reviews: why the differential harness could not catch the encoding bug (both paths read the same stored text), the adversarial-fixtures rule that follows, and the open items 2–7.

**A3.4 design doc** is the accepted plan for the next two stages: document writes commit atomically with their `document.changed` fact and every read answer carries `as_of_seq` (Stage 1); subscriptions become windowed deliveries resumed by content (Stage 2); fact-class compaction bounds the durable log by the size of the data it describes.

## Verification

- Full `go test ./...` green; `go test -race ./internal/store ./internal/docstore` green.
- Each fix falsified by mutation: every mutated half turned exactly its pinning tests red.
- Live-verified on a throwaway profile: pathological old-encoding stamps planted into a real v90 profile DB, broken order confirmed in SQLite, migration 91 run by the real daemon, then ASC/DESC/changed-since/paging/+02:00-bound/refusal and a live `doc watch` verified over the real socket.

https://claude.ai/code/session_01429snMWPwXjv1NeqUdV57c