### PR TITLE
feat(home): categorise snoozed agents and split your PRs from review requests

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3700,6 +3700,7 @@ function AppContent({
           onToggleFollowNextTurn={() => setFollowNextTurn((armed) => !armed)}
           onSelectSession={handleSelectSession}
           onNewSession={() => handleNewSession('vertical')}
+          onWakeTurn={sendWakeTurn}
           onRefreshPRs={handleRefreshPRs}
           onOpenPR={handleOpenPR}
           onOpenSettings={() => setSettingsOpen(true)}

--- a/app/src/components/Dashboard.css
+++ b/app/src/components/Dashboard.css
@@ -527,20 +527,9 @@
   color: rgba(252, 165, 165, 0.92);
 }
 
-.dashboard-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding-top: 20px;
-  border-top: 1px solid var(--color-border);
-  margin-top: 20px;
-}
-
-.footer-shortcuts {
-  display: flex;
-  gap: 24px;
-}
-
+/* Home no longer carries a shortcut strip, but .shortcut/.shortcut kbd are the
+   app's only definition of a keyboard hint and the LocationPicker and
+   AttentionDrawer footers still render them. They live here for that reason. */
 .shortcut {
   font-size: var(--font-size-sm);
   color: var(--color-text-dimmed);
@@ -964,4 +953,104 @@
   font-family: 'JetBrains Mono', monospace;
   font-size: var(--font-size-xs);
   color: var(--color-text-dimmed);
+}
+
+/* Deferred agents: the quiet end of the card, collapsed, above the muted
+   workspaces it shares a divider style with. */
+.session-group.snoozed-group {
+  border-top: 1px solid var(--color-border);
+  padding-top: 4px;
+  margin-top: 4px;
+}
+
+.group-label.group-toggle {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  font-size: var(--font-size-xs);
+  gap: 6px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  width: 100%;
+}
+
+.group-label.group-toggle:hover {
+  color: var(--color-text-tertiary);
+}
+
+/* When a deferred agent comes back. Takes the age column's place — the turn it
+   would have aged is already closed. */
+.session-wake-at {
+  margin-left: auto;
+  padding-left: 8px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-dimmed);
+}
+
+.session-wake-btn {
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  color: var(--color-text-dimmed);
+  cursor: pointer;
+  flex-shrink: 0;
+  font-size: var(--font-size-sm);
+  line-height: 1;
+  opacity: 0;
+  padding: 3px 5px;
+}
+
+.session-row:hover .session-wake-btn,
+.session-wake-btn:focus-visible {
+  opacity: 1;
+}
+
+.session-wake-btn:hover {
+  background: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+}
+
+/* Heads each half of the PR card. Yours first, review requested below. */
+.pr-section + .pr-section {
+  margin-top: 14px;
+}
+
+.pr-section-header {
+  align-items: center;
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  display: flex;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  gap: 6px;
+  letter-spacing: 0.08em;
+  margin-bottom: 6px;
+  padding: 0 8px 6px;
+  text-transform: uppercase;
+}
+
+.pr-section-count {
+  font-family: 'JetBrains Mono', monospace;
+  letter-spacing: 0;
+}
+
+/* Which repo a flat "Yours" row belongs to. The review side answers this with a
+   group header instead.
+
+   Capped and allowed to shrink: a long repo name (`figgy-pr-review-synthetic`)
+   otherwise takes the width the title needs, and the title is what tells two of
+   your PRs apart. */
+.pr-repo-inline {
+  color: var(--color-text-dimmed);
+  flex-shrink: 1;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  max-width: 30%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/app/src/components/Dashboard.test.tsx
+++ b/app/src/components/Dashboard.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Dashboard } from './Dashboard';
+import type { DaemonPR } from '../hooks/useDaemonSocket';
 
 vi.mock('../contexts/DaemonContext', () => ({
   useDaemonContext: () => ({
@@ -10,14 +11,26 @@ vi.mock('../contexts/DaemonContext', () => ({
   }),
 }));
 
-vi.mock('../hooks/usePRsNeedingAttention', () => ({
-  usePRsNeedingAttention: () => ({
-    activePRs: [],
-    needsAttention: [],
-    reviewRequested: [],
-    yourPRs: [],
-  }),
+// The PR filter is the daemon-facing half of the card and has its own tests;
+// what home is responsible for is how it arranges what comes back, so the hook
+// is stubbed with a list the test controls.
+const prFilter = vi.hoisted(() => ({
+  activePRs: [] as unknown[],
+  needsAttention: [] as unknown[],
+  reviewRequested: [] as unknown[],
+  yourPRs: [] as unknown[],
 }));
+
+vi.mock('../hooks/usePRsNeedingAttention', () => ({
+  usePRsNeedingAttention: () => prFilter,
+}));
+
+beforeEach(() => {
+  prFilter.activePRs = [];
+  prFilter.needsAttention = [];
+  prFilter.reviewRequested = [];
+  prFilter.yourPRs = [];
+});
 
 vi.mock('@tauri-apps/plugin-opener', () => ({
   openUrl: vi.fn(),
@@ -305,5 +318,197 @@ describe('Dashboard in queue mode', () => {
 
       expect(screen.queryByTestId('follow-next-turn')).not.toBeInTheDocument();
     });
+  });
+});
+
+// A snooze is an answer to "whose turn is it" — not yours, not yet — so a
+// deferred agent's state has stopped describing anything the user asked about.
+// Leaving it under Working or Idle is what these cover.
+describe('Dashboard snoozed agents', () => {
+  const later = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+  const props = {
+    prs: [],
+    isLoading: false,
+    onSelectSession: vi.fn(),
+    onNewSession: vi.fn(),
+    onOpenSettings: vi.fn(),
+  };
+
+  it('takes deferred agents out of the state groups and collects them under Snoozed', () => {
+    render(
+      <Dashboard
+        {...props}
+        queueModeEnabled
+        sessions={[
+          { id: 's1', label: 'deferred', state: 'working', cwd: '/a', turnSnoozedUntil: later },
+          { id: 's2', label: 'running', state: 'working', cwd: '/b' },
+        ]}
+      />
+    );
+
+    const working = screen.getByTestId('session-group-working');
+    expect(working).toContainElement(screen.getByTestId('session-s2'));
+    expect(screen.queryByTestId('session-s1')).not.toBeInTheDocument();
+
+    const snoozed = screen.getByTestId('session-group-snoozed');
+    expect(snoozed).toHaveTextContent('Snoozed');
+    expect(snoozed).toHaveTextContent('1');
+  });
+
+  it('is collapsed until asked, then lists each wake time', () => {
+    const soon = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+    render(
+      <Dashboard
+        {...props}
+        queueModeEnabled
+        sessions={[
+          { id: 's1', label: 'wakes-later', state: 'idle', cwd: '/a', turnSnoozedUntil: later },
+          { id: 's2', label: 'wakes-sooner', state: 'idle', cwd: '/b', turnSnoozedUntil: soon },
+        ]}
+      />
+    );
+
+    expect(screen.queryByTestId('session-s1')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('session-group-snoozed-header'));
+
+    const rows = screen.getByTestId('session-group-snoozed');
+    const names = Array.from(rows.querySelectorAll('.session-name')).map((n) => n.textContent);
+    expect(names).toEqual(['wakes-sooner', 'wakes-later']);
+    expect(rows.querySelectorAll('.session-wake-at')).toHaveLength(2);
+  });
+
+  it('wakes one early', () => {
+    const onWakeTurn = vi.fn();
+    render(
+      <Dashboard
+        {...props}
+        queueModeEnabled
+        onWakeTurn={onWakeTurn}
+        sessions={[{ id: 's1', label: 'deferred', state: 'idle', cwd: '/a', turnSnoozedUntil: later }]}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('session-group-snoozed-header'));
+    fireEvent.click(screen.getByTestId('session-wake-s1'));
+    expect(onWakeTurn).toHaveBeenCalledWith('s1');
+  });
+
+  // Every other way to end a snooze early is queue-gated, so with the
+  // arrangement off this section is the deferral's only way out.
+  it('still shows deferred agents, and the way to wake them, with the queue off', () => {
+    const onWakeTurn = vi.fn();
+    render(
+      <Dashboard
+        {...props}
+        queueModeEnabled={false}
+        onWakeTurn={onWakeTurn}
+        sessions={[{ id: 's1', label: 'deferred', state: 'idle', cwd: '/a', turnSnoozedUntil: later }]}
+      />
+    );
+
+    expect(screen.getByTestId('session-group-snoozed')).toBeInTheDocument();
+    expect(screen.queryByTestId('session-group-idle')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('session-group-snoozed-header'));
+    expect(screen.getByTestId('session-wake-s1')).toBeInTheDocument();
+  });
+
+  // The sidebar pulls the chief out of its bands entirely; home lists it with
+  // the rest, so a deferred chief has to land here or it lands nowhere true.
+  it('collects a deferred chief too', () => {
+    render(
+      <Dashboard
+        {...props}
+        queueModeEnabled
+        sessions={[
+          { id: 'chief', label: 'chief', state: 'idle', cwd: '/a', chiefOfStaff: true, turnSnoozedUntil: later },
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('session-group-snoozed-header'));
+    expect(screen.getByTestId('session-group-snoozed')).toContainElement(screen.getByTestId('session-chief'));
+  });
+
+  it('leaves a lapsed deadline alone', () => {
+    const past = new Date(Date.now() - 60 * 1000).toISOString();
+    render(
+      <Dashboard
+        {...props}
+        queueModeEnabled
+        sessions={[{ id: 's1', label: 'awake', state: 'working', cwd: '/a', turnSnoozedUntil: past }]}
+      />
+    );
+
+    expect(screen.queryByTestId('session-group-snoozed')).not.toBeInTheDocument();
+    expect(screen.getByTestId('session-group-working')).toContainElement(screen.getByTestId('session-s1'));
+  });
+
+  it('renders no keyboard-shortcut strip', () => {
+    const { container } = render(<Dashboard {...props} sessions={[]} />);
+    expect(container.querySelector('.dashboard-footer')).toBeNull();
+  });
+});
+
+describe('Dashboard pull requests', () => {
+  const props = {
+    sessions: [],
+    prs: [],
+    isLoading: false,
+    onSelectSession: vi.fn(),
+    onNewSession: vi.fn(),
+    onOpenSettings: vi.fn(),
+  };
+
+  const pr = (over: Partial<DaemonPR> & Pick<DaemonPR, 'id' | 'number' | 'repo' | 'role'>): DaemonPR => ({
+    approved_by_me: false,
+    author: 'someone',
+    details_fetched: true,
+    has_new_changes: false,
+    host: 'github.com',
+    last_polled: '2026-08-05T10:00:00Z',
+    last_updated: '2026-08-05T10:00:00Z',
+    muted: false,
+    reason: 'review_needed',
+    state: 'waiting',
+    title: `PR ${over.number}`,
+    url: `https://github.com/${over.repo}/pull/${over.number}`,
+    ...over,
+  } as DaemonPR);
+
+  it('leads with the PRs you opened, flat and named by repo', () => {
+    prFilter.activePRs = [
+      pr({ id: 'r1', number: 10, repo: 'victorarias/attn', role: 'reviewer' as DaemonPR['role'] }),
+      pr({ id: 'a1', number: 20, repo: 'victorarias/attn', role: 'author' as DaemonPR['role'], author: 'victorarias' }),
+      pr({ id: 'a2', number: 21, repo: 'other/tool', role: 'author' as DaemonPR['role'], author: 'victorarias' }),
+    ];
+    render(<Dashboard {...props} />);
+
+    const yours = screen.getByTestId('pr-section-yours');
+    expect(yours).toHaveTextContent('Yours');
+    expect(yours.querySelectorAll('[data-testid="pr-card"]')).toHaveLength(2);
+    expect(Array.from(yours.querySelectorAll('.pr-repo-inline')).map((n) => n.textContent))
+      .toEqual(['attn', 'tool']);
+    // No repo groups on this side — the repo is on the row.
+    expect(yours.querySelector('.pr-repo-group')).toBeNull();
+
+    const review = screen.getByTestId('pr-section-review');
+    expect(review.querySelectorAll('[data-testid="pr-card"]')).toHaveLength(1);
+    expect(review.querySelector('.repo-name')).toHaveTextContent('attn');
+    expect(review.querySelector('.pr-repo-inline')).toBeNull();
+  });
+
+  it('omits a section with nothing in it', () => {
+    prFilter.activePRs = [
+      pr({ id: 'r1', number: 10, repo: 'victorarias/attn', role: 'reviewer' as DaemonPR['role'] }),
+    ];
+    render(<Dashboard {...props} />);
+
+    expect(screen.queryByTestId('pr-section-yours')).not.toBeInTheDocument();
+    expect(screen.getByTestId('pr-section-review')).toBeInTheDocument();
+  });
+
+  it('says nothing needs attention when both sides are empty', () => {
+    render(<Dashboard {...props} />);
+    expect(screen.getByText('No PRs need attention')).toBeInTheDocument();
   });
 });

--- a/app/src/components/Dashboard.test.tsx
+++ b/app/src/components/Dashboard.test.tsx
@@ -214,6 +214,30 @@ describe('Dashboard in queue mode', () => {
     expect(screen.queryByTestId('all-settled')).not.toBeInTheDocument();
   });
 
+  // `home_get_state` reports which agents are still grouped by what they are
+  // doing, and reads that marker to find them. Only the groups that answer that
+  // question carry it — the turn band and the snoozed section share the testid
+  // prefix and answer a different one.
+  it('marks the state groups so a reader can tell them from the turn band', () => {
+    const later = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    render(
+      <Dashboard
+        {...props}
+        sessions={[
+          { id: 's1', label: 'owed', state: 'waiting_input', cwd: '/a', turnOwed: true, turnOpenedAt: '2026-07-29T09:00:00Z' },
+          { id: 's2', label: 'busy', state: 'working', cwd: '/b', turnOwed: false },
+          { id: 's3', label: 'deferred', state: 'working', cwd: '/c', turnSnoozedUntil: later },
+        ]}
+      />
+    );
+
+    const marked = Array.from(document.querySelectorAll('[data-session-group="state"] .session-row'))
+      .map((row) => row.getAttribute('data-testid'));
+    expect(marked).toEqual(['session-s2']);
+    expect(screen.getByTestId('session-group-turns')).not.toHaveAttribute('data-session-group');
+    expect(screen.getByTestId('session-group-snoozed')).not.toHaveAttribute('data-session-group');
+  });
+
   it('announces all settled with what is still running once nothing is owed', () => {
     render(
       <Dashboard

--- a/app/src/components/Dashboard.tsx
+++ b/app/src/components/Dashboard.tsx
@@ -529,8 +529,18 @@ export function Dashboard({
                     Settled
                   </div>
                 )}
+                {/* data-session-group marks the groups that describe what an
+                    agent is doing, so a reader can ask for them without
+                    matching the turn band or the snoozed section: those share
+                    the testid prefix and answer a different question. A new
+                    group opts in here or is correctly left out. */}
                 {stateGroups.map((group) => (
-                  <div key={group.state} className="session-group" data-testid={group.testId}>
+                  <div
+                    key={group.state}
+                    className="session-group"
+                    data-testid={group.testId}
+                    data-session-group="state"
+                  >
                     <div className="group-label">{group.label}</div>
                     {group.rows.map((s) => renderSessionRow(s))}
                   </div>

--- a/app/src/components/Dashboard.tsx
+++ b/app/src/components/Dashboard.tsx
@@ -9,7 +9,8 @@ import { useDaemonContext } from '../contexts/DaemonContext';
 import { getRepoName } from '../utils/repo';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import type { UISessionState } from '../types/sessionState';
-import { compareTurnOrder, formatTurnAge } from '../utils/queueBands';
+import { compareTurnOrder, compareWakeOrder, formatTurnAge } from '../utils/queueBands';
+import { formatWakeTime, isSnoozed } from '../utils/snoozeDurations';
 import { useNow, TURN_AGE_TICK_MS } from '../hooks/useNow';
 import appIcon from '../assets/icon.png';
 import './Dashboard.css';
@@ -27,6 +28,11 @@ type DashboardSession = {
   // already settled, which is exactly the case grouping by state gets wrong.
   turnOwed?: boolean;
   turnOpenedAt?: string;
+  // When a deferred agent comes back. Its presence is what takes the agent out
+  // of every other group here: a snoozed agent's state is no longer an answer to
+  // anything the user asked, so listing it under Working or Idle says the one
+  // thing that is not true of it — that it is waiting on nothing.
+  turnSnoozedUntil?: string;
 };
 
 /**
@@ -66,6 +72,11 @@ interface DashboardProps {
   onRebootstrapEndpoint?: (endpointId: string) => Promise<void>;
   onSelectSession: (id: string) => void;
   onNewSession: () => void;
+  // Ending a snooze early. Home is the second place a deferral can be undone,
+  // and the only one that does not depend on the queue arrangement being on —
+  // the shortcut and the command menu are both queue-gated, so without this a
+  // snooze made in queue mode would have no way out once it was turned off.
+  onWakeTurn?: (id: string) => void;
   onRefreshPRs?: () => void;
   onOpenPR?: (pr: DaemonPR) => void;
   onOpenSettings: () => void;
@@ -95,6 +106,7 @@ export function Dashboard({
   onRebootstrapEndpoint,
   onSelectSession,
   onNewSession,
+  onWakeTurn,
   onRefreshPRs,
   onOpenPR,
   onOpenSettings,
@@ -104,6 +116,7 @@ export function Dashboard({
   onToggleFollowNextTurn,
 }: DashboardProps) {
   const now = useNow(TURN_AGE_TICK_MS);
+  const [snoozedExpanded, setSnoozedExpanded] = useState(false);
 
   const renderEndpointBadge = (session: DashboardProps['sessions'][number]) => {
     if (!session.endpointName) {
@@ -118,23 +131,46 @@ export function Dashboard({
 
   const chiefSession = sessions.find((session) => session.chiefOfStaff);
 
+  /**
+   * Agents the user deferred, soonest wake first, in queue order and out of
+   * everything below.
+   *
+   * Not gated on the queue arrangement, unlike the sidebar's section. A snooze
+   * can only be *made* with the queue on, but it outlives being turned off, and
+   * every other way to wake one early is queue-gated too — so with the setting
+   * off this list is the deferral's only remaining way out.
+   *
+   * The chief is here like any other agent, which is where home parts from the
+   * sidebar: the sidebar pulls the chief out of its bands entirely, but home's
+   * Sessions card lists it alongside the rest, so leaving it out would put a
+   * deferred chief back under a state group that cannot describe it.
+   */
+  const snoozedSessions = useMemo(() => (
+    sessions.filter((s) => isSnoozed(s.turnSnoozedUntil, now)).sort(compareWakeOrder)
+  ), [sessions, now]);
+
+  const awakeSessions = useMemo(() => {
+    const deferred = new Set(snoozedSessions.map((s) => s.id));
+    return sessions.filter((s) => !deferred.has(s.id));
+  }, [sessions, snoozedSessions]);
+
   // The chief is left out of the turns, exactly as the sidebar band leaves it
   // out: it has its own card here and its own slot there. That does mean home
   // can read "all settled" while the chief wants you — the same thing the
   // sidebar says, which is the lesser of the two surprises.
   const turnSessions = useMemo(() => (
     queueModeEnabled
-      ? sessions.filter((s) => s.turnOwed && !s.chiefOfStaff).sort(compareTurnOrder)
+      ? awakeSessions.filter((s) => s.turnOwed && !s.chiefOfStaff).sort(compareTurnOrder)
       : []
-  ), [queueModeEnabled, sessions]);
+  ), [queueModeEnabled, awakeSessions]);
 
   // With the queue off nothing has been settled, so every session is grouped by
   // state and there is no second band to keep them out of.
   const settledSessions = useMemo(() => (
     queueModeEnabled
-      ? sessions.filter((s) => !(s.turnOwed && !s.chiefOfStaff))
-      : sessions
-  ), [queueModeEnabled, sessions]);
+      ? awakeSessions.filter((s) => !(s.turnOwed && !s.chiefOfStaff))
+      : awakeSessions
+  ), [queueModeEnabled, awakeSessions]);
 
   const stateGroups = useMemo(() => (
     STATE_GROUPS
@@ -160,7 +196,13 @@ export function Dashboard({
     return counts.map((entry) => `${entry.n} ${entry.label}`).join(' · ');
   }, [settledSessions]);
 
-  const renderSessionRow = (s: DashboardSession, age?: string) => (
+  // `wake` replaces the age on a deferred row rather than joining it: the only
+  // question a snoozed row answers is when it comes back, and the turn it would
+  // have aged is already closed.
+  const renderSessionRow = (
+    s: DashboardSession,
+    { age, wake }: { age?: string; wake?: string } = {},
+  ) => (
     <div
       key={s.id}
       className="session-row clickable"
@@ -173,6 +215,22 @@ export function Dashboard({
       {s.chiefOfStaff && <ChiefOfStaffBadge compact />}
       {renderEndpointBadge(s)}
       {age && <span className="session-turn-age">{age}</span>}
+      {wake && <span className="session-wake-at">{wake}</span>}
+      {wake && onWakeTurn && (
+        <button
+          type="button"
+          className="session-wake-btn"
+          data-testid={`session-wake-${s.id}`}
+          title="Wake now — bring it back to the queue"
+          aria-label={`Wake ${s.label}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            onWakeTurn(s.id);
+          }}
+        >
+          ↩
+        </button>
+      )}
     </div>
   );
 
@@ -213,15 +271,86 @@ export function Dashboard({
     return map;
   }, [activePRs]);
 
-  // Group active PRs by repo
+  /**
+   * The PRs you opened, ahead of the ones you were asked to look at.
+   *
+   * Your own are the short list and the one you come here to find, so they lead
+   * and they stay flat — a repo header over two rows is a level of structure
+   * that only costs a click. The review side keeps the repo groups, because that
+   * is where the volume is and where muting a whole repo is the act that helps.
+   */
+  const yourPRs = useMemo(() => activePRs.filter((pr) => pr.role === 'author'), [activePRs]);
+  const reviewPRs = useMemo(() => activePRs.filter((pr) => pr.role !== 'author'), [activePRs]);
+
+  // Group the review side by repo
   const prsByRepo = useMemo(() => {
     const grouped = new Map<string, DaemonPR[]>();
-    for (const pr of activePRs) {
+    for (const pr of reviewPRs) {
       const existing = grouped.get(pr.repo) || [];
       grouped.set(pr.repo, [...existing, pr]);
     }
     return grouped;
-  }, [activePRs]);
+  }, [reviewPRs]);
+
+  // One row, two homes. `showRepo` names the repo inline, which the flat "Yours"
+  // list needs and a repo group already answers above its rows.
+  const renderPRRow = (pr: DaemonPR, { showRepo = false }: { showRepo?: boolean } = {}) => {
+    // Determine if this is an approved PR without changes (should be dimmed)
+    const isApprovedNoChanges = pr.approved_by_me && !pr.has_new_changes;
+    const showHost = (repoHosts.get(pr.repo)?.size || 0) > 1;
+    return (
+      <div
+        key={pr.id}
+        className={`pr-row ${fadingPRs.has(pr.id) ? 'fading-out' : ''} ${isApprovedNoChanges ? 'approved' : ''}`}
+        data-testid="pr-card"
+      >
+        <button
+          type="button"
+          className="pr-link"
+          onClick={(e) => {
+            e.stopPropagation();
+            sendPRVisited(pr.id);
+            openUrl(pr.url).catch((err) =>
+              console.error('[Dashboard] Failed to open PR URL:', err)
+            );
+          }}
+        >
+          <span className={`pr-role ${pr.role}`}>
+            {pr.role === 'reviewer'
+              ? (pr.author?.toLowerCase().includes('bot') ? '🤖' : '👀')
+              : '✏️'}
+          </span>
+          {showRepo && <span className="pr-repo-inline">{getRepoName(pr.repo)}</span>}
+          <span className="pr-number">#{pr.number}</span>
+          {showHost && pr.host && (
+            <span className="pr-host" title={pr.host}>{pr.host}</span>
+          )}
+          <span className="pr-title">{pr.title}</span>
+          {pr.role === 'author' && (
+            <span className="pr-reason">{pr.reason.replace(/_/g, ' ')}</span>
+          )}
+        </button>
+        <div className="pr-badges">
+          {pr.has_new_changes && (
+            <span className="badge-changes" title="New commits/comments since your last visit">updated</span>
+          )}
+          {pr.approved_by_me && (
+            <span className="badge-approved" title="You approved this PR">✓</span>
+          )}
+          {pr.ci_status && pr.ci_status !== 'none' && (
+            <span className={`ci-status ${pr.ci_status}`} title={`CI ${pr.ci_status}`}></span>
+          )}
+        </div>
+        <PRActions
+          number={pr.number}
+          prId={pr.id}
+          author={pr.author}
+          onActionComplete={handleActionComplete}
+          onOpen={onOpenPR ? () => onOpenPR(pr) : undefined}
+        />
+      </div>
+    );
+  };
 
   const toggleRepo = (repo: string) => {
     setCollapsedRepos((prev) => {
@@ -388,7 +517,7 @@ export function Dashboard({
                       <span className="group-count">{turnSessions.length}</span>
                     </div>
                     {turnSessions.map((s) => (
-                      renderSessionRow(s, formatTurnAge(s.turnOpenedAt, now))
+                      renderSessionRow(s, { age: formatTurnAge(s.turnOpenedAt, now) })
                     ))}
                   </div>
                 )}
@@ -406,6 +535,30 @@ export function Dashboard({
                     {group.rows.map((s) => renderSessionRow(s))}
                   </div>
                 ))}
+                {/* Collapsed at the foot of the card, above the muted
+                    workspaces, exactly as the sidebar arranges the same two:
+                    both are the quiet end, and "not yet" sits nearer to your
+                    attention than "not ever". A snooze surfaces itself when it
+                    wakes, so the section is for checking on a promise or
+                    breaking it early — neither worth standing room. */}
+                {snoozedSessions.length > 0 && (
+                  <div className="session-group snoozed-group" data-testid="session-group-snoozed">
+                    <button
+                      type="button"
+                      className="group-label group-toggle"
+                      data-testid="session-group-snoozed-header"
+                      aria-expanded={snoozedExpanded}
+                      onClick={() => setSnoozedExpanded((open) => !open)}
+                    >
+                      <span className={`collapse-icon ${snoozedExpanded ? '' : 'collapsed'}`}>▾</span>
+                      Snoozed
+                      <span className="group-count">{snoozedSessions.length}</span>
+                    </button>
+                    {snoozedExpanded && snoozedSessions.map((s) => (
+                      renderSessionRow(s, { wake: formatWakeTime(s.turnSnoozedUntil, now) })
+                    ))}
+                  </div>
+                )}
                 {mutedWorkspaces.length > 0 && (
                   <div
                     className="session-group muted-summary clickable"
@@ -498,115 +651,68 @@ export function Dashboard({
                   <div className="pr-skeleton-title" />
                 </div>
               </div>
-            ) : prsByRepo.size === 0 ? (
+            ) : activePRs.length === 0 ? (
               <div className="card-empty">No PRs need attention</div>
             ) : (
-              Array.from(prsByRepo.entries()).map(([repo, repoPRs]) => {
-                const repoName = getRepoName(repo);
-                const isCollapsed = collapsedRepos.has(repo);
-                const reviewCount = repoPRs.filter((p) => p.role === 'reviewer').length;
-                const authorCount = repoPRs.filter((p) => p.role === 'author').length;
-                const showHost = (repoHosts.get(repo)?.size || 0) > 1;
-
-                return (
-                  <div key={repo} className="pr-repo-group">
-                    <div className="repo-header">
-                      <div
-                        className="repo-header-content clickable"
-                        onClick={() => toggleRepo(repo)}
-                      >
-                        <span className={`collapse-icon ${isCollapsed ? 'collapsed' : ''}`}>▾</span>
-                        <span className="repo-name">{repoName}</span>
-                        <span className="repo-counts">
-                          {reviewCount > 0 && <span className="count review">{reviewCount} review</span>}
-                          {authorCount > 0 && <span className="count author">{authorCount} yours</span>}
-                        </span>
-                      </div>
-                      <button
-                        className="repo-mute-btn"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          sendMuteRepo(repo);
-                        }}
-                        title="Mute all PRs from this repo"
-                      >
-                        ⊘
-                      </button>
+              <>
+                {yourPRs.length > 0 && (
+                  <div className="pr-section" data-testid="pr-section-yours">
+                    <div className="pr-section-header">
+                      <span>Yours</span>
+                      <span className="pr-section-count">{yourPRs.length}</span>
                     </div>
-                    {!isCollapsed && (
-                      <div className="repo-prs">
-                        {repoPRs.map((pr) => {
-                          // Determine if this is an approved PR without changes (should be dimmed)
-                          const isApprovedNoChanges = pr.approved_by_me && !pr.has_new_changes;
-                          return (
-                          <div
-                            key={pr.id}
-                            className={`pr-row ${fadingPRs.has(pr.id) ? 'fading-out' : ''} ${isApprovedNoChanges ? 'approved' : ''}`}
-                            data-testid="pr-card"
-                          >
+                    {yourPRs.map((pr) => renderPRRow(pr, { showRepo: true }))}
+                  </div>
+                )}
+                {reviewPRs.length > 0 && (
+                  <div className="pr-section" data-testid="pr-section-review">
+                    <div className="pr-section-header">
+                      <span>Review requested</span>
+                      <span className="pr-section-count">{reviewPRs.length}</span>
+                    </div>
+                    {Array.from(prsByRepo.entries()).map(([repo, repoPRs]) => {
+                      const repoName = getRepoName(repo);
+                      const isCollapsed = collapsedRepos.has(repo);
+
+                      return (
+                        <div key={repo} className="pr-repo-group">
+                          <div className="repo-header">
+                            <div
+                              className="repo-header-content clickable"
+                              onClick={() => toggleRepo(repo)}
+                            >
+                              <span className={`collapse-icon ${isCollapsed ? 'collapsed' : ''}`}>▾</span>
+                              <span className="repo-name">{repoName}</span>
+                              <span className="repo-counts">
+                                <span className="count review">{repoPRs.length} review</span>
+                              </span>
+                            </div>
                             <button
-                              type="button"
-                              className="pr-link"
+                              className="repo-mute-btn"
                               onClick={(e) => {
                                 e.stopPropagation();
-                                sendPRVisited(pr.id);
-                                openUrl(pr.url).catch((err) =>
-                                  console.error('[Dashboard] Failed to open PR URL:', err)
-                                );
+                                sendMuteRepo(repo);
                               }}
+                              title="Mute all PRs from this repo"
                             >
-                              <span className={`pr-role ${pr.role}`}>
-                                {pr.role === 'reviewer'
-                                  ? (pr.author?.toLowerCase().includes('bot') ? '🤖' : '👀')
-                                  : '✏️'}
-                              </span>
-                              <span className="pr-number">#{pr.number}</span>
-                              {showHost && pr.host && (
-                                <span className="pr-host" title={pr.host}>{pr.host}</span>
-                              )}
-                              <span className="pr-title">{pr.title}</span>
-                              {pr.role === 'author' && (
-                                <span className="pr-reason">{pr.reason.replace(/_/g, ' ')}</span>
-                              )}
+                              ⊘
                             </button>
-                            <div className="pr-badges">
-                              {pr.has_new_changes && (
-                                <span className="badge-changes" title="New commits/comments since your last visit">updated</span>
-                              )}
-                              {pr.approved_by_me && (
-                                <span className="badge-approved" title="You approved this PR">✓</span>
-                              )}
-                              {pr.ci_status && pr.ci_status !== 'none' && (
-                                <span className={`ci-status ${pr.ci_status}`} title={`CI ${pr.ci_status}`}></span>
-                              )}
-                            </div>
-                            <PRActions
-                              number={pr.number}
-                              prId={pr.id}
-                              author={pr.author}
-                              onActionComplete={handleActionComplete}
-                              onOpen={onOpenPR ? () => onOpenPR(pr) : undefined}
-                            />
                           </div>
-                        );})}
-                      </div>
-                    )}
+                          {!isCollapsed && (
+                            <div className="repo-prs">
+                              {repoPRs.map((pr) => renderPRRow(pr))}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
                   </div>
-                );
-              })
+                )}
+              </>
             )}
           </div>
         </div>
       </div>
-
-      <footer className="dashboard-footer">
-        <div className="footer-shortcuts">
-          <span className="shortcut"><kbd>⌘T</kbd> new workspace</span>
-          <span className="shortcut"><kbd>⌘1-9</kbd> switch workspace</span>
-          <span className="shortcut"><kbd>⌘,</kbd> settings</span>
-          <span className="shortcut"><kbd>⌘/</kbd> shortcuts</span>
-        </div>
-      </footer>
     </div>
   );
 }

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -2135,11 +2135,13 @@ export function useUiAutomationBridge({
           },
           // Which agents home is still grouping by state. A deferred agent
           // appearing here is the defect the snoozed section exists to remove.
+          // Read from the groups that mark themselves, not from the testid
+          // prefix: the turn band and the snoozed section share it and are not
+          // state groups, and an exclusion list would silently gain a hole the
+          // next time a group is added.
           stateGroupSessionIds: Array.from(
-            visible?.querySelectorAll('[data-testid^="session-group-"] .session-row') || [],
-          )
-            .filter((row) => !snoozedGroup?.contains(row))
-            .map((row) => (row.getAttribute('data-testid') || '').slice('session-'.length)),
+            visible?.querySelectorAll('[data-session-group="state"] .session-row') || [],
+          ).map((row) => (row.getAttribute('data-testid') || '').slice('session-'.length)),
           prs: {
             yours: readPRSection('pr-section-yours'),
             review: readPRSection('pr-section-review'),

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -2092,11 +2092,58 @@ export function useUiAutomationBridge({
         const visible = document.querySelector('.view-container.visible');
         const banner = visible?.querySelector('[data-testid="all-settled"]') ?? null;
         const follow = visible?.querySelector('[data-testid="follow-next-turn"] input');
+        const snoozedGroup = visible?.querySelector('[data-testid="session-group-snoozed"]') ?? null;
+        const snoozedHeader = snoozedGroup?.querySelector('[data-testid="session-group-snoozed-header"]');
+        const readPRSection = (testId: string) => {
+          const section = visible?.querySelector(`[data-testid="${testId}"]`) ?? null;
+          if (!section) return null;
+          return {
+            count: section.querySelector('.pr-section-count')?.textContent?.trim() || '',
+            // The repo as the row itself names it: inline on the flat side, on a
+            // group header on the review side. Which one carries it is the whole
+            // difference between the two halves.
+            rows: Array.from(section.querySelectorAll('[data-testid="pr-card"]')).map((row) => ({
+              number: row.querySelector('.pr-number')?.textContent?.trim() || '',
+              repo: row.querySelector('.pr-repo-inline')?.textContent?.trim() || '',
+              title: row.querySelector('.pr-title')?.textContent?.trim() || '',
+            })),
+            repoGroups: Array.from(section.querySelectorAll('.pr-repo-group .repo-name'))
+              .map((name) => name.textContent?.trim() || ''),
+          };
+        };
         return {
           onScreen: Boolean(visible?.querySelector('.dashboard')),
           allSettled: Boolean(banner),
           detail: banner?.querySelector('.all-settled-detail')?.textContent?.trim() || '',
           followNextTurn: follow instanceof HTMLInputElement ? follow.checked : null,
+          // The strip of keyboard hints home used to carry. Reported so its
+          // absence is something a caller can testify to rather than infer.
+          shortcutFooter: Boolean(visible?.querySelector('.dashboard-footer')),
+          // Agents the user deferred. Collapsed by default, so `rows` is empty
+          // until something expands it — which is a real answer, not a gap.
+          snoozed: {
+            present: Boolean(snoozedGroup),
+            header: snoozedHeader?.textContent?.trim() || '',
+            expanded: snoozedHeader?.getAttribute('aria-expanded') === 'true',
+            rows: Array.from(snoozedGroup?.querySelectorAll('.session-row') || []).map((row) => ({
+              id: (row.getAttribute('data-testid') || '').slice('session-'.length),
+              label: row.querySelector('.session-name')?.textContent?.trim() || '',
+              state: row.getAttribute('data-state') || '',
+              wake: row.querySelector('.session-wake-at')?.textContent?.trim() || '',
+              canWake: Boolean(row.querySelector('.session-wake-btn')),
+            })),
+          },
+          // Which agents home is still grouping by state. A deferred agent
+          // appearing here is the defect the snoozed section exists to remove.
+          stateGroupSessionIds: Array.from(
+            visible?.querySelectorAll('[data-testid^="session-group-"] .session-row') || [],
+          )
+            .filter((row) => !snoozedGroup?.contains(row))
+            .map((row) => (row.getAttribute('data-testid') || '').slice('session-'.length)),
+          prs: {
+            yours: readPRSection('pr-section-yours'),
+            review: readPRSection('pr-section-review'),
+          },
         };
       }
       case 'queue_get_state': {

--- a/app/src/utils/queueBands.ts
+++ b/app/src/utils/queueBands.ts
@@ -206,8 +206,12 @@ export function buildQueueBands<TSession extends QueueBandSession>(
   return { chief, turns, settled, snoozed };
 }
 
-/** Soonest wake first, tie-broken by id so the order is total. */
-function compareWakeOrder(a: QueueBandSession, b: QueueBandSession): number {
+/**
+ * Soonest wake first, tie-broken by id so the order is total. Exported for the
+ * same reason as compareTurnOrder: home lists the same deferred agents the
+ * sidebar does, and two orders for one set of promises is two sets of promises.
+ */
+export function compareWakeOrder(a: QueueBandSession, b: QueueBandSession): number {
   const untilA = a.turnSnoozedUntil ?? '';
   const untilB = b.turnSnoozedUntil ?? '';
   if (untilA !== untilB) {

--- a/changelog.d/plucky-moose-home-screen-tidy.yaml
+++ b/changelog.d/plucky-moose-home-screen-tidy.yaml
@@ -1,0 +1,15 @@
+kind: changed
+area: home
+change: >
+  The home screen says three things more honestly. Agents you snoozed now
+  collect in their own collapsible Snoozed section at the foot of the Sessions
+  card, above muted workspaces, each showing when it comes back and offering a
+  wake-now action — until now a deferred agent was listed under Working or
+  Idle, which told you what it was doing but not that you had put it off. That
+  section shows whether or not the queue arrangement is on, so a deferral made
+  in queue mode can always be undone. Pull requests split into two: the ones you
+  opened lead the card as a flat list with the repo named on each row, and the
+  ones you were asked to review follow in the repo groups they were already in,
+  so finding your own no longer means reading past everyone else's. And the row
+  of keyboard hints under the cards is gone; Cmd+/ opens the full, always-correct
+  shortcut list.

--- a/docs/plans/2026-08-05-home-screen-tidy.md
+++ b/docs/plans/2026-08-05-home-screen-tidy.md
@@ -133,6 +133,13 @@ appearing on hover.
       `Yours 11` as flat rows with the repo inline and no repo groups, then
       `Review requested 3` in two repo groups with the mute button intact.
       Profile cleaned afterwards.
+- [x] Narrow `stateGroupSessionIds` to groups that mark themselves
+      (`data-session-group="state"`). Review caught that the original
+      `[data-testid^="session-group-"]` prefix also matched the turn band, so
+      the field named one thing and reported another; an exclusion list would
+      have gained a hole the next time a group was added. Covered by a unit
+      test reading the same DOM the bridge reads, with an owed turn, a settled
+      agent, and a deferred one on screen.
 
 ## Follow-ups
 

--- a/docs/plans/2026-08-05-home-screen-tidy.md
+++ b/docs/plans/2026-08-05-home-screen-tidy.md
@@ -1,0 +1,143 @@
+# Plan: home stops lying about what it is showing
+
+## Why / Alignment
+
+Home is where the queue ends and where a day starts. Three things on it are
+either noise or wrong.
+
+**The shortcut strip.** A hardcoded row of four key hints — `⌘T`, `⌘1-9`, `⌘,`,
+`⌘/` — pinned under the cards. It was never derived from the shortcut registry,
+so it drifts silently whenever a binding moves, and `⌘/` already opens the real
+cheatsheet. It is chrome that costs height on every visit to teach four things
+once.
+
+**Snoozed agents are miscategorised.** Snooze settles as it defers, so a snoozed
+agent carries no `turn_owed` — which is exactly what home's turn/settled split
+reads. A deferred agent therefore lands in a plain state group and renders as
+"Working" or "Idle", the one thing that is not true of it: it is waiting on a
+clock nobody can see from here. The snooze plan deferred any home presence
+explicitly; this is that follow-up.
+
+**Your PRs are buried among the ones you were asked to look at.** The card groups
+strictly by repo, so a PR you opened sits between two review requests with only a
+✏️ against 👀 to tell them apart. The two are different work — one you are
+waiting on, one someone is waiting on you for — and the one you come to home to
+find is the smaller of the two.
+
+**Aligned on** (Victor, 2026-08-05):
+
+- **The strip goes, with nothing in its place.** `⌘/` already opens the shortcut
+  cheatsheet, which is generated from the registry and therefore correct.
+- **Snoozed gets a collapsible section at the foot of the Sessions card, above
+  Muted Workspaces**, with each agent's wake time and a wake-now action —
+  mirroring the sidebar exactly.
+- **The PR card splits into two sections: Yours, then Review requested.** Yours
+  leads and stays flat with the repo named inline; the review side keeps today's
+  collapsible repo groups.
+
+**Deferred.** Persisting the Snoozed section's expanded state. A snooze
+affordance on home (deferring is still done from the sidebar row, the shortcut,
+or the command menu) — home shows deferrals and undoes them; it does not make
+them.
+
+## User-visible shape
+
+```text
+┌─────────────────────────────┐  ┌────────────────────────────────────┐
+│ SESSIONS              + New │  │ PULL REQUESTS                ↻   5 │
+├─────────────────────────────┤  ├────────────────────────────────────┤
+│ Your turn  2                │  │ YOURS  2                           │
+│   ● agent-a            12m  │  │  ✏️ attn #762  speed cold …   ✓  ● │
+│   ● agent-b             4m  │  │  ✏️ attn #761  keep Ghostty …    ● │
+│ Settled                     │  │                                    │
+│  Working                    │  │ REVIEW REQUESTED  3                │
+│   ● agent-c                 │  │ ▾ attn              2 review     ⊘ │
+│  Idle                       │  │   👀 #758  read a cursor's anchor  │
+│   ● agent-d                 │  │   👀 #757  delete stale plans      │
+│ ─────────────────────────── │  │ ▾ pierre/diffs      1 review     ⊘ │
+│ ▸ Snoozed  2                │  │   🤖 #12   bump deps               │
+│ ▸ Muted Workspaces (1)      │  │                                    │
+└─────────────────────────────┘  └────────────────────────────────────┘
+                                                (no shortcut strip below)
+```
+
+Expanded, a snoozed row reads `● agent-e        2:30 PM  ↩`, the wake button
+appearing on hover.
+
+## Boundaries
+
+- `queueBands.ts` owns queue ordering. Home imports `compareWakeOrder` (newly
+  exported, for the same reason `compareTurnOrder` already was) rather than
+  sorting deferrals its own way — two orders for one set of promises is two sets
+  of promises.
+- Snooze membership is read from `turnSnoozedUntil` through `isSnoozed`, never
+  derived from state.
+- The daemon is untouched. `turn_snoozed_until` already rides the wire and
+  already reaches home's props; nothing new is persisted, broadcast, or
+  computed server-side.
+- The PR split reads the existing `role` field. No new wire data.
+
+## Decisions
+
+- **The Snoozed section is not gated on queue mode**, unlike the sidebar's. A
+  snooze can only be *made* with the queue on, but it outlives the setting being
+  turned off — and the shortcut, the command menu, and the sidebar section are
+  all queue-gated. With the arrangement off, this section is the deferral's only
+  remaining way out.
+- **A deferred chief lands in the Snoozed section**, where the sidebar would keep
+  it in its anchored slot. Home's Sessions card lists the chief alongside every
+  other agent, so excluding it would put a deferred chief back under a state
+  group that cannot describe it. The Chief of Staff card is unaffected.
+- **Snoozed agents leave `stillRunning`.** The all-settled banner says what is
+  in flight and coming back to you; a deferred agent is not, and the
+  `Snoozed (n)` count is its own receipt.
+- **Collapsed by default**, matching the sidebar: a snooze surfaces itself when
+  it wakes, so the section is for checking on a promise or breaking it early.
+- **`.shortcut` / `.shortcut kbd` stay in `Dashboard.css`.** They are the app's
+  only definition of a keyboard hint and `LocationPicker` and `AttentionDrawer`
+  still render them; only `.dashboard-footer` and `.footer-shortcuts` go.
+- **"Yours" carries no repo-mute button.** Muting a repo hides your own PRs in
+  it, which is not an act anyone wants; when the repo also has review requests
+  the button is right there, and Settings unmutes either way. Known consequence:
+  a repo where you only ever author PRs can no longer be muted from home.
+
+## Implementation Steps
+
+- [x] Export `compareWakeOrder` from `utils/queueBands.ts`.
+- [x] `Dashboard.tsx`: `turnSnoozedUntil` on `DashboardSession`; partition
+      snoozed out of the turn and state groups; collapsible `Snoozed` section
+      above Muted Workspaces with wake times and a wake-now button.
+- [x] `App.tsx`: pass `onWakeTurn={sendWakeTurn}` to `Dashboard`.
+- [x] `Dashboard.tsx`: split the PR card into `Yours` (flat, repo inline) and
+      `Review requested` (repo groups); extract the shared `renderPRRow`.
+- [x] `Dashboard.tsx`: delete the shortcut footer; `Dashboard.css`: drop
+      `.dashboard-footer` / `.footer-shortcuts`, keep `.shortcut`.
+- [x] `Dashboard.css`: snoozed group, wake time/button, PR section headers,
+      inline repo name.
+- [x] Tests: `Dashboard.test.tsx` for the snooze partition, wake order,
+      wake-now, queue-off reachability, the deferred chief, a lapsed deadline,
+      the absent footer, and the PR split.
+- [x] `changelog.d/` fragment.
+- [x] `home_get_state` reports the new sections — the snoozed group and its
+      rows, which sessions are still grouped by state, both PR sections, and
+      whether the shortcut footer is present — so the change has an automation
+      witness the way the sidebar's snoozed section already does.
+- [x] Live verification on a throwaway `homely` profile (preflight PASS,
+      installed from this branch): five injected agents, two snoozed over the
+      wire, queue mode on, injected PRs beside real GitHub ones.
+      `home_get_state` reported `shortcutFooter: false`; `snoozed` present with
+      count 2, collapsed, expanding to rows carrying wake times
+      (`11:42 PM`, `tomorrow 6:07 PM`) and a wake control;
+      `stateGroupSessionIds` held only the three awake agents, so neither
+      deferred agent appeared under a state group. The PR card read
+      `Yours 11` as flat rows with the repo inline and no repo groups, then
+      `Review requested 3` in two repo groups with the mute button intact.
+      Profile cleaned afterwards.
+
+## Follow-ups
+
+- The Snoozed section's expanded state is local and resets on reload, as the
+  sidebar's does. Worth persisting both together if it annoys.
+- "Review requested" is `role === 'reviewer'`, which the daemon assembles from
+  both `review-requested:@me` and `reviewed-by:@me` — so a PR you reviewed
+  uninvited reads as requested. Splitting them needs a new wire field.


### PR DESCRIPTION
Home is where the queue ends and where a day starts. Three things on it were either noise or wrong.

**The shortcut strip.** A hardcoded row of four key hints (`⌘T`, `⌘1-9`, `⌘,`, `⌘/`) pinned under the cards. It was never derived from the shortcut registry, so it drifted silently whenever a binding moved — and `⌘/` already opens the real cheatsheet, which *is* generated from the registry. It cost height on every visit to teach four things once.

**Snoozed agents were miscategorised.** Snooze settles as it defers (`store.SnoozeTurn` writes `turn_settled_at` and `turn_snoozed_until` in one statement), so a snoozed agent carries no `turn_owed` — which is exactly what home's turn/settled split reads. A deferred agent therefore fell into a plain state group and rendered as "Working" or "Idle": the one thing that is not true of an agent waiting on a clock nobody can see from here. The snooze plan deferred any home presence explicitly; this is that follow-up.

**Your PRs were buried among the ones you were asked to look at.** The card grouped strictly by repo, so a PR you opened sat between two review requests with only a ✏️ against 👀 to tell them apart. The two are different work — one you are waiting on, one someone is waiting on you for — and the one you come to home to find is the smaller of the two.

## What changed

- **The strip is gone**, with nothing in its place.
- **`Snoozed (n)`** — a collapsed-by-default section at the foot of the Sessions card, above Muted Workspaces. Each row carries its wake time and a hover-revealed wake-now button; ordering comes from the sidebar's own `compareWakeOrder` (newly exported for the same reason `compareTurnOrder` already was — two orders for one set of promises is two sets of promises). Membership is read from `turnSnoozedUntil` through `isSnoozed`, never derived from state.
- **The PR card splits into `Yours` then `Review requested`.** Yours leads and stays flat with the repo named inline; the review side keeps today's collapsible repo groups and its mute button. Both render through one extracted `renderPRRow`.

No daemon change. `turn_snoozed_until` and the PR `role` field already ride the wire and already reach home's props; nothing new is persisted, broadcast, or computed server-side.

## Deliberate departures from the sidebar

- **The Snoozed section is not gated on queue mode.** A snooze can only be *made* with the queue on, but it outlives the setting being turned off — and the shortcut, the command menu, and the sidebar's own section are all queue-gated. With the arrangement off, this section is the deferral's only remaining way out.
- **A deferred chief lands in the Snoozed section**, where the sidebar keeps it in its anchored slot. Home's Sessions card lists the chief alongside every other agent, so excluding it would put a deferred chief back under a state group that cannot describe it. The Chief of Staff card is unaffected.
- **Snoozed agents leave the all-settled banner's `stillRunning` line.** That line says what is in flight and coming back to you; a deferred agent is not, and the `Snoozed (n)` count is its own receipt.

## Known consequences

- **A repo where you only ever author PRs can no longer be muted from home.** The ⊘ lives on review-side repo headers; muting a repo hides your own PRs in it, which is not an act anyone wants, and Settings unmutes either way. When the repo also has review requests the button is right there.
- **"Review requested" is `role === 'reviewer'`**, which the daemon assembles from both `review-requested:@me` and `reviewed-by:@me` — so a PR you reviewed uninvited reads as requested. Splitting them needs a new wire field; recorded as a follow-up in the plan.
- `.shortcut` / `.shortcut kbd` stay in `Dashboard.css`. They are the app's only definition of a keyboard hint and `LocationPicker` and `AttentionDrawer` still render them; only `.dashboard-footer` and `.footer-shortcuts` go.

## Verification

- `tsc --noEmit` clean; full vitest suite green (224 files, 2500 passed). `Dashboard.test.tsx` gained 9 tests: the snooze partition out of state groups, collapse/expand with soonest-wake-first ordering, wake-now, reachability with the queue off, a deferred chief, a lapsed deadline left alone, the absent footer, and the PR split (yours flat with inline repo and no repo groups while review keeps them, empty sections omitted, both-empty copy).
- 13 PR e2e tests pass (`e2e/pr-actions.spec.ts`, `e2e/dashboard-prs-harness.spec.ts`).
- `home_get_state` now reports the new sections, so the change has an automation witness the way the sidebar's snoozed section already does: the snoozed group and its rows, which sessions are still grouped by state, both PR sections, and whether the shortcut footer is present.
- **Live run** on a throwaway profile installed from this branch (preflight PASS, protocol 210): five injected agents with two snoozed over the wire, queue mode on, injected PRs beside real GitHub ones. `home_get_state` reported `shortcutFooter: false`; `snoozed` present with count 2, collapsed, expanding to rows carrying wake times (`11:42 PM`, `tomorrow 6:07 PM`) and a wake control; `stateGroupSessionIds` held only the three awake agents, so neither deferred agent appeared under a state group. The card read `Yours 11` as flat rows with the repo inline and no repo groups, then `Review requested 3` in two repo groups with the mute button intact. That run also caught a layout defect — a long repo name (`figgy-pr-review-synthetic`) crowding out PR titles — fixed by capping `.pr-repo-inline` and re-verified. Profile cleaned afterwards.

Design and decisions: `docs/plans/2026-08-05-home-screen-tidy.md`.

https://claude.ai/code/session_013eGAp8cHdGj7Hu7JJFC5pA