### PR TITLE
feat(docstore): commit a document write and its fact together

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -199,7 +199,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '212';
+export const PROTOCOL_VERSION = '213';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, AgentEventMessage, AgentPromptMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocumentCollectionSchema, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentSort, DocUndefineMessage, DocUndefineResult, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, AddEndpointMessage, AgentEventMessage, AgentPromptMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentSort, DocUndefineMessage, DocUndefineResult, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const agentEventMessage = Convert.toAgentEventMessage(json);
@@ -70,6 +70,8 @@
 //   const dispatchWorkState = Convert.toDispatchWorkState(json);
 //   const docCollectionsMessage = Convert.toDocCollectionsMessage(json);
 //   const docCollectionsResult = Convert.toDocCollectionsResult(json);
+//   const docCountMessage = Convert.toDocCountMessage(json);
+//   const docCountResult = Convert.toDocCountResult(json);
 //   const docDefineMessage = Convert.toDocDefineMessage(json);
 //   const docDefineResult = Convert.toDocDefineResult(json);
 //   const docDeleteMessage = Convert.toDocDeleteMessage(json);
@@ -83,6 +85,7 @@
 //   const docSubscribeMessage = Convert.toDocSubscribeMessage(json);
 //   const docSubscribeResult = Convert.toDocSubscribeResult(json);
 //   const documentCollectionSchema = Convert.toDocumentCollectionSchema(json);
+//   const documentConflict = Convert.toDocumentConflict(json);
 //   const documentFieldSpec = Convert.toDocumentFieldSpec(json);
 //   const documentFilter = Convert.toDocumentFilter(json);
 //   const documentQuery = Convert.toDocumentQuery(json);
@@ -1426,6 +1429,45 @@ export interface FieldElement {
     [property: string]: any;
 }
 
+export interface DocCountMessage {
+    cmd:   DocCountMessageCmd;
+    query: Query;
+    [property: string]: any;
+}
+
+export enum DocCountMessageCmd {
+    DocCount = "doc_count",
+}
+
+export interface Query {
+    after?:     string;
+    collection: string;
+    filters?:   FilterElement[];
+    limit?:     number;
+    namespace:  string;
+    sort?:      Sort;
+    [property: string]: any;
+}
+
+export interface FilterElement {
+    field:      string;
+    op:         string;
+    value_json: string;
+    [property: string]: any;
+}
+
+export interface Sort {
+    desc?: boolean;
+    field: string;
+    [property: string]: any;
+}
+
+export interface DocCountResult {
+    as_of_seq: number;
+    count:     number;
+    [property: string]: any;
+}
+
 export interface DocDefineMessage {
     cmd:    DocDefineMessageCmd;
     schema: Schema;
@@ -1460,6 +1502,7 @@ export interface DocDeleteResult {
     existed:    boolean;
     id:         string;
     namespace:  string;
+    seq:        number;
     [property: string]: any;
 }
 
@@ -1476,6 +1519,7 @@ export enum DocGetMessageCmd {
 }
 
 export interface DocGetResult {
+    as_of_seq: number;
     document?: Document;
     found:     boolean;
     [property: string]: any;
@@ -1509,6 +1553,7 @@ export interface DocPutResult {
     id:         string;
     namespace:  string;
     rev:        number;
+    seq:        number;
     [property: string]: any;
 }
 
@@ -1522,30 +1567,8 @@ export enum DocQueryMessageCmd {
     DocQuery = "doc_query",
 }
 
-export interface Query {
-    after?:     string;
-    collection: string;
-    filters?:   FilterElement[];
-    limit?:     number;
-    namespace:  string;
-    sort?:      Sort;
-    [property: string]: any;
-}
-
-export interface FilterElement {
-    field:      string;
-    op:         string;
-    value_json: string;
-    [property: string]: any;
-}
-
-export interface Sort {
-    desc?: boolean;
-    field: string;
-    [property: string]: any;
-}
-
 export interface DocQueryResult {
+    as_of_seq: number;
     documents: Document[];
     [property: string]: any;
 }
@@ -1569,6 +1592,16 @@ export interface DocSubscribeResult {
 export interface DocumentCollectionSchema {
     collection: string;
     fields:     FieldElement[];
+    namespace:  string;
+    [property: string]: any;
+}
+
+export interface DocumentConflict {
+    actual:     number;
+    collection: string;
+    expected:   number;
+    found:      boolean;
+    id:         string;
     namespace:  string;
     [property: string]: any;
 }
@@ -4249,6 +4282,7 @@ export interface Response {
     delegate_result?:                      DelegateResultObject;
     delegation_operation?:                 DelegationOperationObject;
     doc_collections_result?:               DocCollectionsResultObject;
+    doc_count_result?:                     DocCountResultObject;
     doc_define_result?:                    DocDefineResultObject;
     doc_delete_result?:                    DocDeleteResultObject;
     doc_get_result?:                       DocGetResultObject;
@@ -4257,6 +4291,8 @@ export interface Response {
     doc_subscribe_result?:                 DocSubscribeResultObject;
     doc_undefine_result?:                  DocUndefineResultObject;
     error?:                                string;
+    error_code?:                           string;
+    error_conflict?:                       Conflict;
     journal_append_result?:                JournalAppendResultObject;
     notebook_entries?:                     NotebookEntryElement[];
     notebook_guide?:                       NotebookGuide;
@@ -4293,6 +4329,12 @@ export interface DocCollectionsResultObject {
     [property: string]: any;
 }
 
+export interface DocCountResultObject {
+    as_of_seq: number;
+    count:     number;
+    [property: string]: any;
+}
+
 export interface DocDefineResultObject {
     collection: string;
     namespace:  string;
@@ -4304,10 +4346,12 @@ export interface DocDeleteResultObject {
     existed:    boolean;
     id:         string;
     namespace:  string;
+    seq:        number;
     [property: string]: any;
 }
 
 export interface DocGetResultObject {
+    as_of_seq: number;
     document?: Document;
     found:     boolean;
     [property: string]: any;
@@ -4318,10 +4362,12 @@ export interface DocPutResultObject {
     id:         string;
     namespace:  string;
     rev:        number;
+    seq:        number;
     [property: string]: any;
 }
 
 export interface DocQueryResultObject {
+    as_of_seq: number;
     documents: Document[];
     [property: string]: any;
 }
@@ -4336,6 +4382,16 @@ export interface DocUndefineResultObject {
     collection:        string;
     documents_removed: number;
     namespace:         string;
+    [property: string]: any;
+}
+
+export interface Conflict {
+    actual:     number;
+    collection: string;
+    expected:   number;
+    found:      boolean;
+    id:         string;
+    namespace:  string;
     [property: string]: any;
 }
 
@@ -6964,6 +7020,22 @@ export class Convert {
         return JSON.stringify(uncast(value, r("DocCollectionsResult")), null, 2);
     }
 
+    public static toDocCountMessage(json: string): DocCountMessage {
+        return cast(JSON.parse(json), r("DocCountMessage"));
+    }
+
+    public static docCountMessageToJson(value: DocCountMessage): string {
+        return JSON.stringify(uncast(value, r("DocCountMessage")), null, 2);
+    }
+
+    public static toDocCountResult(json: string): DocCountResult {
+        return cast(JSON.parse(json), r("DocCountResult"));
+    }
+
+    public static docCountResultToJson(value: DocCountResult): string {
+        return JSON.stringify(uncast(value, r("DocCountResult")), null, 2);
+    }
+
     public static toDocDefineMessage(json: string): DocDefineMessage {
         return cast(JSON.parse(json), r("DocDefineMessage"));
     }
@@ -7066,6 +7138,14 @@ export class Convert {
 
     public static documentCollectionSchemaToJson(value: DocumentCollectionSchema): string {
         return JSON.stringify(uncast(value, r("DocumentCollectionSchema")), null, 2);
+    }
+
+    public static toDocumentConflict(json: string): DocumentConflict {
+        return cast(JSON.parse(json), r("DocumentConflict"));
+    }
+
+    public static documentConflictToJson(value: DocumentConflict): string {
+        return JSON.stringify(uncast(value, r("DocumentConflict")), null, 2);
     }
 
     public static toDocumentFieldSpec(json: string): DocumentFieldSpec {
@@ -10630,6 +10710,31 @@ const typeMap: any = {
         { json: "name", js: "name", typ: "" },
         { json: "type", js: "type", typ: "" },
     ], "any"),
+    "DocCountMessage": o([
+        { json: "cmd", js: "cmd", typ: r("DocCountMessageCmd") },
+        { json: "query", js: "query", typ: r("Query") },
+    ], "any"),
+    "Query": o([
+        { json: "after", js: "after", typ: u(undefined, "") },
+        { json: "collection", js: "collection", typ: "" },
+        { json: "filters", js: "filters", typ: u(undefined, a(r("FilterElement"))) },
+        { json: "limit", js: "limit", typ: u(undefined, 0) },
+        { json: "namespace", js: "namespace", typ: "" },
+        { json: "sort", js: "sort", typ: u(undefined, r("Sort")) },
+    ], "any"),
+    "FilterElement": o([
+        { json: "field", js: "field", typ: "" },
+        { json: "op", js: "op", typ: "" },
+        { json: "value_json", js: "value_json", typ: "" },
+    ], "any"),
+    "Sort": o([
+        { json: "desc", js: "desc", typ: u(undefined, true) },
+        { json: "field", js: "field", typ: "" },
+    ], "any"),
+    "DocCountResult": o([
+        { json: "as_of_seq", js: "as_of_seq", typ: 0 },
+        { json: "count", js: "count", typ: 0 },
+    ], "any"),
     "DocDefineMessage": o([
         { json: "cmd", js: "cmd", typ: r("DocDefineMessageCmd") },
         { json: "schema", js: "schema", typ: r("Schema") },
@@ -10650,6 +10755,7 @@ const typeMap: any = {
         { json: "existed", js: "existed", typ: true },
         { json: "id", js: "id", typ: "" },
         { json: "namespace", js: "namespace", typ: "" },
+        { json: "seq", js: "seq", typ: 0 },
     ], "any"),
     "DocGetMessage": o([
         { json: "cmd", js: "cmd", typ: r("DocGetMessageCmd") },
@@ -10658,6 +10764,7 @@ const typeMap: any = {
         { json: "namespace", js: "namespace", typ: "" },
     ], "any"),
     "DocGetResult": o([
+        { json: "as_of_seq", js: "as_of_seq", typ: 0 },
         { json: "document", js: "document", typ: u(undefined, r("Document")) },
         { json: "found", js: "found", typ: true },
     ], "any"),
@@ -10681,29 +10788,14 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "namespace", js: "namespace", typ: "" },
         { json: "rev", js: "rev", typ: 0 },
+        { json: "seq", js: "seq", typ: 0 },
     ], "any"),
     "DocQueryMessage": o([
         { json: "cmd", js: "cmd", typ: r("DocQueryMessageCmd") },
         { json: "query", js: "query", typ: r("Query") },
     ], "any"),
-    "Query": o([
-        { json: "after", js: "after", typ: u(undefined, "") },
-        { json: "collection", js: "collection", typ: "" },
-        { json: "filters", js: "filters", typ: u(undefined, a(r("FilterElement"))) },
-        { json: "limit", js: "limit", typ: u(undefined, 0) },
-        { json: "namespace", js: "namespace", typ: "" },
-        { json: "sort", js: "sort", typ: u(undefined, r("Sort")) },
-    ], "any"),
-    "FilterElement": o([
-        { json: "field", js: "field", typ: "" },
-        { json: "op", js: "op", typ: "" },
-        { json: "value_json", js: "value_json", typ: "" },
-    ], "any"),
-    "Sort": o([
-        { json: "desc", js: "desc", typ: u(undefined, true) },
-        { json: "field", js: "field", typ: "" },
-    ], "any"),
     "DocQueryResult": o([
+        { json: "as_of_seq", js: "as_of_seq", typ: 0 },
         { json: "documents", js: "documents", typ: a(r("Document")) },
     ], "any"),
     "DocSubscribeMessage": o([
@@ -10717,6 +10809,14 @@ const typeMap: any = {
     "DocumentCollectionSchema": o([
         { json: "collection", js: "collection", typ: "" },
         { json: "fields", js: "fields", typ: a(r("FieldElement")) },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
+    "DocumentConflict": o([
+        { json: "actual", js: "actual", typ: 0 },
+        { json: "collection", js: "collection", typ: "" },
+        { json: "expected", js: "expected", typ: 0 },
+        { json: "found", js: "found", typ: true },
+        { json: "id", js: "id", typ: "" },
         { json: "namespace", js: "namespace", typ: "" },
     ], "any"),
     "DocumentFieldSpec": o([
@@ -12296,6 +12396,7 @@ const typeMap: any = {
         { json: "delegate_result", js: "delegate_result", typ: u(undefined, r("DelegateResultObject")) },
         { json: "delegation_operation", js: "delegation_operation", typ: u(undefined, r("DelegationOperationObject")) },
         { json: "doc_collections_result", js: "doc_collections_result", typ: u(undefined, r("DocCollectionsResultObject")) },
+        { json: "doc_count_result", js: "doc_count_result", typ: u(undefined, r("DocCountResultObject")) },
         { json: "doc_define_result", js: "doc_define_result", typ: u(undefined, r("DocDefineResultObject")) },
         { json: "doc_delete_result", js: "doc_delete_result", typ: u(undefined, r("DocDeleteResultObject")) },
         { json: "doc_get_result", js: "doc_get_result", typ: u(undefined, r("DocGetResultObject")) },
@@ -12304,6 +12405,8 @@ const typeMap: any = {
         { json: "doc_subscribe_result", js: "doc_subscribe_result", typ: u(undefined, r("DocSubscribeResultObject")) },
         { json: "doc_undefine_result", js: "doc_undefine_result", typ: u(undefined, r("DocUndefineResultObject")) },
         { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "error_code", js: "error_code", typ: u(undefined, "") },
+        { json: "error_conflict", js: "error_conflict", typ: u(undefined, r("Conflict")) },
         { json: "journal_append_result", js: "journal_append_result", typ: u(undefined, r("JournalAppendResultObject")) },
         { json: "notebook_entries", js: "notebook_entries", typ: u(undefined, a(r("NotebookEntryElement"))) },
         { json: "notebook_guide", js: "notebook_guide", typ: u(undefined, r("NotebookGuide")) },
@@ -12336,6 +12439,10 @@ const typeMap: any = {
     "DocCollectionsResultObject": o([
         { json: "collections", js: "collections", typ: a(r("Schema")) },
     ], "any"),
+    "DocCountResultObject": o([
+        { json: "as_of_seq", js: "as_of_seq", typ: 0 },
+        { json: "count", js: "count", typ: 0 },
+    ], "any"),
     "DocDefineResultObject": o([
         { json: "collection", js: "collection", typ: "" },
         { json: "namespace", js: "namespace", typ: "" },
@@ -12345,8 +12452,10 @@ const typeMap: any = {
         { json: "existed", js: "existed", typ: true },
         { json: "id", js: "id", typ: "" },
         { json: "namespace", js: "namespace", typ: "" },
+        { json: "seq", js: "seq", typ: 0 },
     ], "any"),
     "DocGetResultObject": o([
+        { json: "as_of_seq", js: "as_of_seq", typ: 0 },
         { json: "document", js: "document", typ: u(undefined, r("Document")) },
         { json: "found", js: "found", typ: true },
     ], "any"),
@@ -12355,8 +12464,10 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "namespace", js: "namespace", typ: "" },
         { json: "rev", js: "rev", typ: 0 },
+        { json: "seq", js: "seq", typ: 0 },
     ], "any"),
     "DocQueryResultObject": o([
+        { json: "as_of_seq", js: "as_of_seq", typ: 0 },
         { json: "documents", js: "documents", typ: a(r("Document")) },
     ], "any"),
     "DocSubscribeResultObject": o([
@@ -12366,6 +12477,14 @@ const typeMap: any = {
     "DocUndefineResultObject": o([
         { json: "collection", js: "collection", typ: "" },
         { json: "documents_removed", js: "documents_removed", typ: 0 },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
+    "Conflict": o([
+        { json: "actual", js: "actual", typ: 0 },
+        { json: "collection", js: "collection", typ: "" },
+        { json: "expected", js: "expected", typ: 0 },
+        { json: "found", js: "found", typ: true },
+        { json: "id", js: "id", typ: "" },
         { json: "namespace", js: "namespace", typ: "" },
     ], "any"),
     "JournalAppendResultObject": o([
@@ -13795,6 +13914,9 @@ const typeMap: any = {
     ],
     "DocCollectionsMessageCmd": [
         "doc_collections",
+    ],
+    "DocCountMessageCmd": [
+        "doc_count",
     ],
     "DocDefineMessageCmd": [
         "doc_define",

--- a/changelog.d/docstore-positioned-writes.yaml
+++ b/changelog.d/docstore-positioned-writes.yaml
@@ -1,0 +1,14 @@
+kind: changed
+area: daemon
+change: >
+  Document-store writes now commit the document and the fact describing it in
+  one transaction, so a change can no longer land without being announced, and
+  every write reports the log position it landed at. Reads answer with the
+  position they were true at, so a caller can tell whether its own write is
+  already in the answer. New `attn doc count` answers how many documents match
+  a query without fetching them, failures carry a machine-readable code beside
+  their text (`conflict` bringing the expected and actual revisions with it,
+  `undeclared_collection`, `invalid_query`), and `attn bus status` reports how
+  many events the log holds and what they weigh — which retention now keeps
+  bounded by collapsing repeated document facts about the same document to the
+  newest one.

--- a/changelog.d/docstore-positioned-writes.yaml
+++ b/changelog.d/docstore-positioned-writes.yaml
@@ -11,4 +11,5 @@ change: >
   `undeclared_collection`, `invalid_query`), and `attn bus status` reports how
   many events the log holds and what they weigh — which retention now keeps
   bounded by collapsing repeated document facts about the same document to the
-  newest one.
+  newest one. `attn bus trim` runs one retention pass on demand instead of
+  waiting for the hourly tick, and exits non-zero if the pass could not run.

--- a/cmd/attn/bus.go
+++ b/cmd/attn/bus.go
@@ -50,8 +50,9 @@ func writeBusHelp(w io.Writer) {
 
 commands:
   status [--json]
-        show the event log's live window and every registered consumer's
-        cursor, filter, enabled bit, and lag (head - cursor).
+        show the event log's live window, how many events it holds and what
+        they weigh, and every registered consumer's cursor, filter, enabled
+        bit, and lag (head - cursor).
 
   disable <consumer>
         stop delivering to a consumer. Its cursor is preserved, but a disabled
@@ -64,8 +65,16 @@ commands:
 }
 
 type busStatusJSON struct {
-	Earliest  int64               `json:"earliest"`
-	Head      int64               `json:"head"`
+	Earliest int64 `json:"earliest"`
+	Head     int64 `json:"head"`
+	// Rows and Bytes are what the log actually holds, as opposed to the span of
+	// the seq space. They are the receipt for the invariant compaction upholds:
+	// the log stays proportional to the data it describes, never to how often
+	// that data is written. Bytes counts the event text — name, subject, payload,
+	// source, stamp — not the size of the database file, which is shared with
+	// every other table and would answer a different question.
+	Rows      int64               `json:"rows"`
+	Bytes     int64               `json:"bytes"`
 	Consumers []busConsumerReport `json:"consumers"`
 }
 
@@ -106,8 +115,13 @@ func runBusStatus(args []string) {
 		fmt.Fprintf(os.Stderr, "bus status: listing consumers: %v\n", err)
 		os.Exit(1)
 	}
+	logRows, logBytes, err := s.BusLogSize()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bus status: measuring the log: %v\n", err)
+		os.Exit(1)
+	}
 
-	report := busStatusJSON{Earliest: earliest, Head: head}
+	report := busStatusJSON{Earliest: earliest, Head: head, Rows: logRows, Bytes: logBytes}
 	for _, r := range rows {
 		lag := head - r.Cursor
 		if lag < 0 {
@@ -133,7 +147,7 @@ func runBusStatus(args []string) {
 		return
 	}
 
-	fmt.Printf("log: seq %d..%d (%d event(s) retained)\n", earliest, head, retainedCount(earliest, head))
+	fmt.Printf("log: seq %d..%d, %d event(s) holding %s\n", earliest, head, logRows, humanBytes(logBytes))
 	if len(report.Consumers) == 0 {
 		fmt.Println("no registered consumers")
 		return
@@ -146,15 +160,16 @@ func runBusStatus(args []string) {
 	_ = tw.Flush()
 }
 
-// retainedCount is a display-only approximation: seq is monotonic but trimming
-// removes rows from the middle of the space only at the low end, so head-earliest
-// overstates nothing except across a gap-free window. It is reported as a hint,
-// not a count of rows.
-func retainedCount(earliest, head int64) int64 {
-	if earliest == 0 || head < earliest {
-		return 0
+// humanBytes renders the log's weight at the scale an operator reads it at.
+func humanBytes(n int64) string {
+	switch {
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1f MB", float64(n)/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.1f KB", float64(n)/(1<<10))
+	default:
+		return fmt.Sprintf("%d B", n)
 	}
-	return head - earliest + 1
 }
 
 func runBusSetEnabled(args []string, enabled bool) {

--- a/cmd/attn/bus.go
+++ b/cmd/attn/bus.go
@@ -9,7 +9,9 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/victorarias/attn/internal/bus"
 	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/daemon"
 	"github.com/victorarias/attn/internal/store"
 )
 
@@ -34,6 +36,8 @@ func runBus() {
 	switch os.Args[2] {
 	case "status":
 		runBusStatus(os.Args[3:])
+	case "trim":
+		runBusTrim(os.Args[3:])
 	case "enable":
 		runBusSetEnabled(os.Args[3:], true)
 	case "disable":
@@ -53,6 +57,13 @@ commands:
         show the event log's live window, how many events it holds and what
         they weigh, and every registered consumer's cursor, filter, enabled
         bit, and lag (head - cursor).
+
+  trim
+        run one retention pass now instead of waiting for the daemon's hourly
+        tick: drop events past the age window, and reduce the compactable fact
+        classes to the newest event per subject. Both stop at the cursor floor,
+        so nothing an enabled consumer has yet to read is removed — a lagging
+        consumer pins the log, and bus status shows the lag.
 
   disable <consumer>
         stop delivering to a consumer. Its cursor is preserved, but a disabled
@@ -158,6 +169,47 @@ func runBusStatus(args []string) {
 		fmt.Fprintf(tw, "%s\t%d\t%d\t%t\t%s\n", c.Name, c.Cursor, c.Lag, c.Enabled, c.Filter)
 	}
 	_ = tw.Flush()
+}
+
+// runBusTrim runs one retention pass against the profile database.
+//
+// It builds a bus over the same store rather than reimplementing the pass, so
+// there is exactly one definition of what a pass does, which classes it may
+// compact, and where the cursor floor sits. The bus is never started: Trim is a
+// database operation, and the goroutines Start would raise are for delivery.
+func runBusTrim(args []string) {
+	for _, a := range args {
+		switch a {
+		case "-h", "--help":
+			writeBusHelp(os.Stdout)
+			return
+		default:
+			fmt.Fprintf(os.Stderr, "bus trim: unknown flag %q\n", a)
+			os.Exit(2)
+		}
+	}
+
+	s, closeStore := openBusStore()
+	defer closeStore()
+
+	before, _, err := s.BusLogSize()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bus trim: measuring the log: %v\n", err)
+		os.Exit(1)
+	}
+	b := bus.New(bus.Options{
+		Store:       daemon.NewBusStore(s),
+		Compactable: daemon.CompactableFacts,
+		Log:         func(format string, args ...interface{}) { fmt.Fprintf(os.Stderr, format+"\n", args...) },
+	})
+	removed := b.Trim()
+	after, bytes, err := s.BusLogSize()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bus trim: measuring the log: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("removed %d event(s); log now holds %d of %d, weighing %s\n",
+		removed, after, before, humanBytes(bytes))
 }
 
 // humanBytes renders the log's weight at the scale an operator reads it at.

--- a/cmd/attn/bus.go
+++ b/cmd/attn/bus.go
@@ -202,7 +202,7 @@ func runBusTrim(args []string) {
 		Compactable: daemon.CompactableFacts,
 		Log:         func(format string, args ...interface{}) { fmt.Fprintf(os.Stderr, format+"\n", args...) },
 	})
-	removed := b.Trim()
+	removed, passErr := b.Trim()
 	after, bytes, err := s.BusLogSize()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "bus trim: measuring the log: %v\n", err)
@@ -210,6 +210,12 @@ func runBusTrim(args []string) {
 	}
 	fmt.Printf("removed %d event(s); log now holds %d of %d, weighing %s\n",
 		removed, after, before, humanBytes(bytes))
+	// A pass that could not run exits non-zero. "removed 0" is also what a
+	// clean log prints, so without this a script cannot tell the two apart.
+	if passErr != nil {
+		fmt.Fprintf(os.Stderr, "bus trim: %v\n", passErr)
+		os.Exit(1)
+	}
 }
 
 // humanBytes renders the log's weight at the scale an operator reads it at.

--- a/cmd/attn/doc.go
+++ b/cmd/attn/doc.go
@@ -46,6 +46,8 @@ func runDoc() {
 		runDocDelete(args)
 	case "query":
 		runDocQuery(args)
+	case "count":
+		runDocCount(args)
 	case "watch":
 		runDocWatch(args)
 	default:
@@ -100,6 +102,11 @@ commands:
 
   query <namespace> <collection> [query flags] [--json]
         run a query once.
+
+  count <namespace> <collection> [query flags]
+        how many documents match, without fetching them. --sort, --desc and
+        --limit are ignored: they decide which matches come back, never how
+        many there are.
 
   watch <namespace> <collection> [query flags] [--json]
         run a live query: print the current results, then print them again every
@@ -219,7 +226,10 @@ func runDocPut(args []string) {
 	if err != nil {
 		docFail("put", err)
 	}
-	fmt.Printf("wrote %s/%s/%s (rev %d)\n", namespace, collection, id, result.Rev)
+	// The seq is the write's position on the durable log, printed because it is
+	// what a caller compares against a later read to know the read includes this
+	// write.
+	fmt.Printf("wrote %s/%s/%s (rev %d, seq %d)\n", namespace, collection, id, result.Rev, result.Seq)
 }
 
 // takeExpectFlag pulls `--expect <rev|absent>` out of a command's arguments and
@@ -296,7 +306,7 @@ func runDocDelete(args []string) {
 		fmt.Printf("%s/%s/%s did not exist\n", namespace, collection, rest[0])
 		return
 	}
-	fmt.Printf("deleted %s/%s/%s\n", namespace, collection, rest[0])
+	fmt.Printf("deleted %s/%s/%s (seq %d)\n", namespace, collection, rest[0], result.Seq)
 }
 
 func runDocQuery(args []string) {
@@ -307,6 +317,23 @@ func runDocQuery(args []string) {
 		docFail("query", err)
 	}
 	printDocuments(result.Documents, asJSON)
+}
+
+func runDocCount(args []string) {
+	namespace, collection, rest := docTarget("count", args)
+	query, asJSON := parseDocQueryFlags("count", namespace, collection, rest)
+	result, err := docClient().DocCount(query)
+	if err != nil {
+		docFail("count", err)
+	}
+	if asJSON {
+		writeJSON(struct {
+			Count   int `json:"count"`
+			AsOfSeq int `json:"as_of_seq"`
+		}{result.Count, result.AsOfSeq})
+		return
+	}
+	fmt.Println(result.Count)
 }
 
 func runDocWatch(args []string) {

--- a/cmd/attn/doc.go
+++ b/cmd/attn/doc.go
@@ -101,7 +101,10 @@ commands:
         --expect removes the document only if it is still at that revision.
 
   query <namespace> <collection> [query flags] [--json]
-        run a query once.
+        run a query once. Reports, beside the results, the log position the
+        answer was true at: put and delete print the position their write
+        landed at, so comparing the two tells you whether an answer already
+        includes a write you made.
 
   count <namespace> <collection> [query flags]
         how many documents match, without fetching them. --sort, --desc and
@@ -290,6 +293,21 @@ func runDocGet(args []string) {
 		return
 	}
 	fmt.Println(result.Document.Body)
+	printPosition(false, result.AsOfSeq)
+}
+
+// printPosition reports the log position a read was true at, which is what a
+// caller compares against the seq its own write returned to know whether the
+// answer already includes it.
+//
+// It goes to stderr so it does not land in a body someone is piping into jq,
+// and it is skipped under --json for the same reason: a machine reader gets the
+// position from the wire, or from `doc count --json`, which carries it in band.
+func printPosition(asJSON bool, seq int) {
+	if asJSON {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "as of seq %d\n", seq)
 }
 
 func runDocDelete(args []string) {
@@ -317,6 +335,7 @@ func runDocQuery(args []string) {
 		docFail("query", err)
 	}
 	printDocuments(result.Documents, asJSON)
+	printPosition(asJSON, result.AsOfSeq)
 }
 
 func runDocCount(args []string) {

--- a/internal/bus/announce_test.go
+++ b/internal/bus/announce_test.go
@@ -1,6 +1,7 @@
 package bus
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -199,7 +200,10 @@ func TestTrimCompactsTheNamesTheBusDeclared(t *testing.T) {
 		s.appendOutOfBand("session.state.changed", "sess-1", now)
 	}
 
-	removed := b.Trim()
+	removed, err := b.Trim()
+	if err != nil {
+		t.Fatalf("trim: %v", err)
+	}
 	if removed != 9 {
 		t.Fatalf("trim removed %d fact(s), want the 9 redundant ones", removed)
 	}
@@ -228,7 +232,7 @@ func TestTrimCompactsNothingWhenNoNameWasDeclared(t *testing.T) {
 		s.appendOutOfBand("document.changed", "ext/x/requests/a", now)
 	}
 
-	if removed := b.Trim(); removed != 0 {
+	if removed, err := b.Trim(); err != nil || removed != 0 {
 		t.Fatalf("a bus with no compactable names removed %d fact(s)", removed)
 	}
 	status, err := b.Status()
@@ -237,5 +241,86 @@ func TestTrimCompactsNothingWhenNoNameWasDeclared(t *testing.T) {
 	}
 	if status.Rows != 10 {
 		t.Fatalf("log holds %d row(s), want all 10", status.Rows)
+	}
+}
+
+// A bus that could not learn where the log stands must not announce. The mark's
+// zero value means "everything after seq 0", so announcing on an unplaced mark
+// replays the entire log into every live client — the failure the mark exists to
+// prevent, arriving through the door meant to prevent it.
+func TestABusThatCouldNotFindTheHeadDoesNotReplayTheLog(t *testing.T) {
+	s := newMemStore()
+	now := time.Now()
+	for range 5 {
+		s.appendOutOfBand("document.changed", "ext/x/requests/old", now)
+	}
+	s.setBoundsErr(errors.New("the log would not say where it stands"))
+
+	b := testBus(t, s)
+	seen, stop := watchAll(b)
+	defer stop()
+
+	b.Announce()
+	if got := seen(); len(got) != 0 {
+		t.Fatalf("a bus with no mark announced %d historical fact(s)", len(got))
+	}
+
+	// A publish still reaches subscribers while the mark is unplaced: losing the
+	// mark must not silence the wire.
+	if _, err := b.Publish("session.state.changed", "s-1", nil); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if got := seen(); len(got) != 1 {
+		t.Fatalf("a publish under an unplaced mark delivered %d event(s), want 1", len(got))
+	}
+
+	// Once the log answers, the mark is placed from head and only what happens
+	// next is announced — the history stays unreplayed.
+	s.setBoundsErr(nil)
+	b.Announce()
+	if got := seen(); len(got) != 1 {
+		t.Fatalf("placing the mark replayed history: %d event(s) delivered", len(got))
+	}
+	fresh := s.appendOutOfBand("document.changed", "ext/x/requests/new", now)
+	b.Announce()
+	got := seen()
+	if len(got) != 2 || got[1].Seq != fresh {
+		t.Fatalf("after the mark was placed, delivered %v", seqsOf(got))
+	}
+}
+
+// A pass that could not run is not a pass that found nothing. `attn bus trim`
+// exits on this, and "removed 0" is what a clean log prints too.
+func TestTrimReportsAPassThatCouldNotRun(t *testing.T) {
+	s := newMemStore()
+	b := New(Options{
+		Store:       s,
+		Log:         func(string, ...interface{}) {},
+		Compactable: []string{"document.changed"},
+		Retention:   time.Hour,
+	})
+	now := time.Now()
+	for range 4 {
+		s.appendOutOfBand("document.changed", "ext/x/requests/a", now)
+	}
+
+	// consumerFloor reads the bounds when no enabled consumer is registered, so
+	// a log that will not say where it stands cannot be compacted safely.
+	s.setBoundsErr(errors.New("the log would not say where it stands"))
+	removed, err := b.Trim()
+	if err == nil {
+		t.Fatal("a pass that could not run reported success")
+	}
+	if removed != 0 {
+		t.Fatalf("a failed pass reported removing %d event(s)", removed)
+	}
+
+	s.setBoundsErr(nil)
+	removed, err = b.Trim()
+	if err != nil {
+		t.Fatalf("trim: %v", err)
+	}
+	if removed != 3 {
+		t.Fatalf("the recovered pass removed %d event(s), want 3", removed)
 	}
 }

--- a/internal/bus/announce_test.go
+++ b/internal/bus/announce_test.go
@@ -1,0 +1,241 @@
+package bus
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// Announce is the entry point for facts the bus did not append itself — a store
+// transaction that committed a change together with the fact describing it. The
+// contract it has to hold is ordering: whoever wrote to the log, subscribers see
+// it in seq order, exactly once.
+
+// A subscriber that watches the same names.
+func watchAll(b *Bus) (func() []Event, func()) {
+	var (
+		mu   sync.Mutex
+		seen []Event
+	)
+	stop := b.Subscribe(Filter{}, func(ev Event) {
+		mu.Lock()
+		seen = append(seen, ev)
+		mu.Unlock()
+	})
+	snapshot := func() []Event {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]Event(nil), seen...)
+	}
+	return snapshot, stop
+}
+
+func seqsOf(events []Event) []int64 {
+	out := make([]int64, 0, len(events))
+	for _, e := range events {
+		out = append(out, e.Seq)
+	}
+	return out
+}
+
+func inOrder(seqs []int64) bool {
+	for i := 1; i < len(seqs); i++ {
+		if seqs[i] <= seqs[i-1] {
+			return false
+		}
+	}
+	return true
+}
+
+// The plain case: a fact that arrived on the log without going through Publish
+// still reaches subscribers, carrying the seq it was appended at.
+func TestAnnounceDeliversWhatTheLogGainedWithoutPublish(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+	seen, stop := watchAll(b)
+	defer stop()
+
+	now := time.Now()
+	first := s.appendOutOfBand("document.changed", "ext/x/requests/a", now)
+	second := s.appendOutOfBand("document.changed", "ext/x/requests/b", now)
+
+	b.Announce()
+
+	got := seqsOf(seen())
+	if len(got) != 2 || got[0] != first || got[1] != second {
+		t.Fatalf("announce delivered %v, want [%d %d]", got, first, second)
+	}
+}
+
+// Announcing is reading forward from a mark, so announcing twice delivers once.
+// This is what lets a caller announce unconditionally after a commit without
+// knowing whether anyone else already did.
+func TestAnnouncingTwiceDeliversOnce(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+	seen, stop := watchAll(b)
+	defer stop()
+
+	s.appendOutOfBand("document.changed", "ext/x/requests/a", time.Now())
+	b.Announce()
+	b.Announce()
+	b.Announce()
+
+	if got := seen(); len(got) != 1 {
+		t.Fatalf("three announces of one fact delivered %d time(s)", len(got))
+	}
+}
+
+// A bus attached to a log that already has history announces what happens next,
+// not the history — otherwise every daemon start would replay the log at every
+// live subscriber.
+func TestAnnounceDoesNotReplayWhatWasThereBeforeTheBus(t *testing.T) {
+	s := newMemStore()
+	now := time.Now()
+	s.appendOutOfBand("document.changed", "ext/x/requests/old", now)
+	s.appendOutOfBand("document.changed", "ext/x/requests/older", now)
+
+	b := testBus(t, s)
+	seen, stop := watchAll(b)
+	defer stop()
+
+	b.Announce()
+	if got := seen(); len(got) != 0 {
+		t.Fatalf("a fresh bus replayed %d historical fact(s)", len(got))
+	}
+
+	fresh := s.appendOutOfBand("document.changed", "ext/x/requests/new", now)
+	b.Announce()
+	got := seqsOf(seen())
+	if len(got) != 1 || got[0] != fresh {
+		t.Fatalf("announce delivered %v, want only the new fact at %d", got, fresh)
+	}
+}
+
+// The ordering property, under the race it exists for: writers commit their
+// facts and then race to announce, and Publish runs against the same mark. Every
+// subscriber must see the log's own order, and see each fact once — never a
+// later seq before an earlier one because its announcer won the race.
+func TestRacingWritersDeliverTheLogsOrderExactlyOnce(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+	seen, stop := watchAll(b)
+	defer stop()
+
+	const writers = 8
+	const each = 25
+
+	var (
+		start sync.WaitGroup
+		done  sync.WaitGroup
+	)
+	start.Add(1)
+	for w := range writers {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			start.Wait()
+			for i := range each {
+				// Commit, then announce — the shape of a composite write. The
+				// gap between the two is where the ordering race lives.
+				if w%2 == 0 {
+					s.appendOutOfBand("document.changed", "ext/x/requests/a", time.Now())
+					b.Announce()
+					continue
+				}
+				// Publishes interleave with committed writes on the same mark.
+				if _, err := b.Publish("session.state.changed", "s", map[string]int{"i": i}); err != nil {
+					t.Errorf("publish: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	start.Done()
+	done.Wait()
+	// A commit whose announce lost every race is repaired by the next announce;
+	// one final call stands in for the retention tick that would do it anyway.
+	b.Announce()
+
+	got := seqsOf(seen())
+	if want := writers * each; len(got) != want {
+		t.Fatalf("delivered %d fact(s), want %d — a fact was dropped or doubled", len(got), want)
+	}
+	if !inOrder(got) {
+		t.Fatalf("delivered out of the log's order: %v", got)
+	}
+}
+
+// A bus with no store has no log to read forward from, so Announce is a no-op
+// rather than a panic: the same degradation Publish already makes, and the
+// shape every test daemon runs in.
+func TestAnnounceWithoutAStoreDoesNothing(t *testing.T) {
+	b := New(Options{Log: func(string, ...interface{}) {}})
+	seen, stop := watchAll(b)
+	defer stop()
+
+	b.Announce()
+	if got := seen(); len(got) != 0 {
+		t.Fatalf("a store-less bus announced %d fact(s)", len(got))
+	}
+}
+
+// Compaction is driven from here — the bus decides which names are compactable
+// and where the floor is; the store only runs the SQL. Trim reports both.
+func TestTrimCompactsTheNamesTheBusDeclared(t *testing.T) {
+	s := newMemStore()
+	b := New(Options{
+		Store:       s,
+		Log:         func(string, ...interface{}) {},
+		Compactable: []string{"document.changed"},
+		Retention:   time.Hour,
+	})
+
+	now := time.Now()
+	for range 10 {
+		s.appendOutOfBand("document.changed", "ext/x/requests/a", now)
+	}
+	for range 3 {
+		s.appendOutOfBand("session.state.changed", "sess-1", now)
+	}
+
+	removed := b.Trim()
+	if removed != 9 {
+		t.Fatalf("trim removed %d fact(s), want the 9 redundant ones", removed)
+	}
+
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status.Rows != 4 {
+		t.Fatalf("log holds %d row(s) after compaction, want 4", status.Rows)
+	}
+	if status.Bytes <= 0 {
+		t.Fatalf("a non-empty log reports %d byte(s)", status.Bytes)
+	}
+}
+
+// A bus that declared nothing compactable compacts nothing, however much churn
+// the log holds. Compaction is opt-in per fact class because it is only sound
+// for facts that are pure invalidations.
+func TestTrimCompactsNothingWhenNoNameWasDeclared(t *testing.T) {
+	s := newMemStore()
+	b := New(Options{Store: s, Log: func(string, ...interface{}) {}, Retention: time.Hour})
+
+	now := time.Now()
+	for range 10 {
+		s.appendOutOfBand("document.changed", "ext/x/requests/a", now)
+	}
+
+	if removed := b.Trim(); removed != 0 {
+		t.Fatalf("a bus with no compactable names removed %d fact(s)", removed)
+	}
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status.Rows != 10 {
+		t.Fatalf("log holds %d row(s), want all 10", status.Rows)
+	}
+}

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -107,6 +107,14 @@ type Store interface {
 	SetCursor(name string, cursor int64, now time.Time) error
 	ListConsumers() ([]Consumer, error)
 	Trim(cutoff time.Time) (int, error)
+	// Compact keeps only the newest fact per subject among the named ones, and
+	// only at or below floor. Which names those are is decided here (Options.
+	// Compactable); the SQL lives in the store, the same split Trim uses.
+	Compact(names []string, floor int64) (int, error)
+	// Size reports how many facts the log holds and how many bytes of event text
+	// they carry — the receipt that says whether the log is outgrowing the data
+	// it describes.
+	Size() (rows, bytes int64, err error)
 }
 
 // Handler receives one event. Returning an error stalls the consumer on that
@@ -126,6 +134,10 @@ type Options struct {
 	PollInterval time.Duration
 	RetryBase    time.Duration
 	RetryCap     time.Duration
+	// Compactable names the fact classes whose log rows are pure invalidations,
+	// so the retention pass may keep only the newest one per subject. See
+	// Bus.Trim for what that costs a consumer and why it is sound.
+	Compactable []string
 }
 
 // Bus is the event bus. The zero value is not usable; construct with New.
@@ -141,10 +153,17 @@ type Bus struct {
 	retryBase    time.Duration
 	retryCap     time.Duration
 
+	compactable []string
+
 	// publishMu serializes append + ephemeral fan-out so ephemeral subscribers
 	// observe events in seq order. Durable consumers get ordering from their
 	// cursor and do not need it.
 	publishMu sync.Mutex
+	// announced is the highest seq already fanned out to ephemeral subscribers,
+	// guarded by publishMu. Both entry points — Publish and Announce — read
+	// forward from it, which is what keeps events appended by somebody else's
+	// transaction in seq order with events this bus appended itself.
+	announced int64
 
 	mu        sync.Mutex
 	durables  []*durable
@@ -190,6 +209,7 @@ func New(opts Options) *Bus {
 		pollInterval: nonZeroDuration(opts.PollInterval, DefaultPollInterval),
 		retryBase:    nonZeroDuration(opts.RetryBase, DefaultRetryBase),
 		retryCap:     nonZeroDuration(opts.RetryCap, DefaultRetryCap),
+		compactable:  append([]string(nil), opts.Compactable...),
 		ephemeral:    map[int]*ephemeralSub{},
 	}
 	if b.now == nil {
@@ -199,6 +219,19 @@ func New(opts Options) *Bus {
 		b.log = func(string, ...interface{}) {}
 	}
 	b.ctx, b.cancel = context.WithCancel(context.Background())
+	// The announce mark starts at head, so a bus attached to an existing log
+	// announces what happens next rather than replaying its history. It is set
+	// here rather than in Start because a Bus that is never started still
+	// publishes and announces — that is the shape of every test daemon — and one
+	// that replayed a month of facts into the wire on its first write would be a
+	// worse failure than a missed one.
+	if b.store != nil {
+		if _, head, err := b.store.Bounds(); err != nil {
+			b.log("bus: reading log bounds at construction: %v", err)
+		} else {
+			b.announced = head
+		}
+	}
 	return b
 }
 
@@ -253,9 +286,62 @@ func (b *Bus) publish(ev Event, payload any) (int64, error) {
 	}
 	ev.Seq = seq
 
-	b.fanoutEphemeral(ev)
+	// Fan out by reading the log forward rather than by handing subscribers the
+	// event in hand. The two are the same message whenever this publish is the
+	// only writer, and they are not the same ORDER when they are not: a fact
+	// appended inside somebody else's transaction (see the document store's
+	// composite write) may sit below this seq and still be unannounced, and
+	// delivering this one first would show subscribers the log out of order.
+	// Reading forward makes the log the ordering authority, whoever wrote to it.
+	b.announceLocked(&ev)
 	b.wakeDurables()
 	return seq, nil
+}
+
+// Announce fans out facts appended to the log outside Publish — by a store
+// transaction that committed a change and its fact together — so ephemeral
+// subscribers see them in seq order beside everything else.
+//
+// It reads forward from the announce mark under the same lock Publish holds,
+// which makes it idempotent and order-correct no matter who calls it when: two
+// writers that commit and then race to announce cannot deliver out of order,
+// and an announce that never happens is repaired by the next one. Callers
+// therefore need no coordination beyond calling it after their commit.
+func (b *Bus) Announce() {
+	if b.store == nil {
+		return
+	}
+	b.publishMu.Lock()
+	defer b.publishMu.Unlock()
+	b.announceLocked(nil)
+	b.wakeDurables()
+}
+
+// announceLocked delivers everything above the announce mark. fallback is the
+// event the caller just appended, delivered directly if the log cannot be read
+// — losing durability must not also silence the wire.
+func (b *Bus) announceLocked(fallback *Event) {
+	for {
+		events, err := b.store.Since(b.announced, b.batchSize)
+		if err != nil {
+			b.log("bus: reading the log forward from seq %d to announce: %v", b.announced, err)
+			if fallback != nil && fallback.Seq > b.announced {
+				b.fanoutEphemeral(*fallback)
+				b.announced = fallback.Seq
+			}
+			return
+		}
+		if len(events) == 0 {
+			return
+		}
+		for _, ev := range events {
+			b.fanoutEphemeral(ev)
+			b.announced = ev.Seq
+		}
+		if len(events) < b.batchSize {
+			return
+		}
+	}
 }
 
 func (b *Bus) fanoutEphemeral(ev Event) {
@@ -609,21 +695,97 @@ func (b *Bus) retain() {
 	}
 }
 
-// Trim runs one retention pass and reports how many events were removed. It is
-// exported so the daemon and tests can force a pass without waiting for a tick.
+// Trim runs one retention pass and reports how many events it removed, by both
+// halves: the age window, and compaction of the fact classes that carry no
+// history. It is exported so the daemon and tests can force a pass without
+// waiting for a tick.
 func (b *Bus) Trim() int {
 	if b.store == nil {
 		return 0
 	}
+	var removed int
 	n, err := b.store.Trim(b.now().Add(-b.retention))
 	if err != nil {
 		b.log("bus: retention pass failed: %v", err)
+	} else {
+		removed += n
+		if n > 0 {
+			b.log("bus: trimmed %d event(s) older than %s", n, b.retention)
+		}
+	}
+	return removed + b.compact()
+}
+
+// compact keeps at most one fact per subject for every compactable name, which
+// is what bounds the log by the size of the data it describes rather than by
+// how often that data is written.
+//
+// A compactable fact is an invalidation: it says a subject changed, and the
+// state itself lives in the store, so five of them about one subject carry no
+// more than the newest. The consequence, stated rather than hidden: for these
+// names durable delivery is at-least-once PER CHANGED SUBJECT, not per write. A
+// consumer that was behind while a document changed five times learns once that
+// it changed, and reads current state — which is what a consumer of this bus is
+// told to do anyway. A workload that needs every intermediate change as a
+// business event is doing event sourcing, and those events are data: they
+// belong in a collection the workload writes, where their growth is its own
+// visible cost.
+//
+// The cursor floor is the same one trimming honors, for two load-bearing
+// reasons. An enabled consumer must never lose a fact it has not read, and
+// below the floor every enabled consumer has read everything, so their delivery
+// is bit-for-bit what it is today. And reconcileGap reads "cursor below the
+// earliest surviving seq" as "everything missing was trimmed"; compacting above
+// the floor would punch holes that assumption misreads and skip a revived
+// consumer past facts that still exist. A stalled enabled consumer therefore
+// pins compaction exactly as it pins trimming — a loud condition already, with
+// `attn bus status` showing the stall and the kill switch to unpin it.
+func (b *Bus) compact() int {
+	if len(b.compactable) == 0 {
+		return 0
+	}
+	floor, err := b.consumerFloor()
+	if err != nil {
+		b.log("bus: compaction pass failed: %v", err)
+		return 0
+	}
+	n, err := b.store.Compact(b.compactable, floor)
+	if err != nil {
+		b.log("bus: compaction pass failed: %v", err)
 		return 0
 	}
 	if n > 0 {
-		b.log("bus: trimmed %d event(s) older than %s", n, b.retention)
+		b.log("bus: compacted %d superseded event(s) at or below seq %d", n, floor)
 	}
 	return n
+}
+
+// consumerFloor is the lowest position every enabled consumer has passed. With
+// no enabled consumer registered it is the log head: nobody is owed anything, so
+// nothing is pinned. Disabled consumers are excluded for the same reason they
+// are excluded from trimming — a killed consumer must not pin the log.
+func (b *Bus) consumerFloor() (int64, error) {
+	rows, err := b.store.ListConsumers()
+	if err != nil {
+		return 0, fmt.Errorf("listing consumers: %w", err)
+	}
+	floor := int64(-1)
+	for _, c := range rows {
+		if !c.Enabled {
+			continue
+		}
+		if floor < 0 || c.Cursor < floor {
+			floor = c.Cursor
+		}
+	}
+	if floor >= 0 {
+		return floor, nil
+	}
+	_, head, err := b.store.Bounds()
+	if err != nil {
+		return 0, fmt.Errorf("reading log bounds: %w", err)
+	}
+	return head, nil
 }
 
 // ConsumerStatus is one row of Status.
@@ -641,9 +803,17 @@ type ConsumerStatus struct {
 }
 
 // Status reports the log head and every registration, for operator inspection.
+//
+// Rows and Bytes are the log's actual weight rather than head-minus-earliest,
+// which only ever described the seq space. They are the receipt for the
+// invariant compaction upholds — the log stays proportional to the data it
+// describes, never to how often that data is written — so a workload that
+// stresses it shows up as a measurement instead of a suspicion.
 type Status struct {
 	Head      int64
 	Earliest  int64
+	Rows      int64
+	Bytes     int64
 	Consumers []ConsumerStatus
 }
 
@@ -660,6 +830,10 @@ func (b *Bus) Status() (Status, error) {
 	if err != nil {
 		return Status{}, err
 	}
+	logRows, logBytes, err := b.store.Size()
+	if err != nil {
+		return Status{}, err
+	}
 
 	b.mu.Lock()
 	live := make(map[string]*durable, len(b.durables))
@@ -668,7 +842,7 @@ func (b *Bus) Status() (Status, error) {
 	}
 	b.mu.Unlock()
 
-	out := Status{Head: head, Earliest: earliest}
+	out := Status{Head: head, Earliest: earliest, Rows: logRows, Bytes: logBytes}
 	for _, r := range rows {
 		cs := ConsumerStatus{
 			Name:    r.Name,

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -159,6 +159,10 @@ type Bus struct {
 	// observe events in seq order. Durable consumers get ordering from their
 	// cursor and do not need it.
 	publishMu sync.Mutex
+	// marked says the announce mark has been placed from a real log head. Until
+	// it is, the mark's zero value would mean "announce the whole log", so
+	// announcing is held back rather than replaying history at every client.
+	marked bool
 	// announced is the highest seq already fanned out to ephemeral subscribers,
 	// guarded by publishMu. Both entry points — Publish and Announce — read
 	// forward from it, which is what keeps events appended by somebody else's
@@ -226,11 +230,7 @@ func New(opts Options) *Bus {
 	// that replayed a month of facts into the wire on its first write would be a
 	// worse failure than a missed one.
 	if b.store != nil {
-		if _, head, err := b.store.Bounds(); err != nil {
-			b.log("bus: reading log bounds at construction: %v", err)
-		} else {
-			b.announced = head
-		}
+		b.markHead()
 	}
 	return b
 }
@@ -317,10 +317,36 @@ func (b *Bus) Announce() {
 	b.wakeDurables()
 }
 
+// markHead sets the announce mark to the log's head and reports whether it
+// learned where the log stands. A mark that was never set is 0, which means
+// "announce everything" — so until this succeeds the bus must not announce at
+// all, or the first write would replay the whole log into every live client.
+// Construction calls it once; announceLocked retries it, because a database
+// that could not be read at construction is usually readable a moment later.
+func (b *Bus) markHead() bool {
+	_, head, err := b.store.Bounds()
+	if err != nil {
+		b.log("bus: reading log bounds to place the announce mark: %v", err)
+		return false
+	}
+	b.announced = head
+	b.marked = true
+	return true
+}
+
 // announceLocked delivers everything above the announce mark. fallback is the
 // event the caller just appended, delivered directly if the log cannot be read
 // — losing durability must not also silence the wire.
 func (b *Bus) announceLocked(fallback *Event) {
+	// Without a mark there is no "everything after here" to deliver, only the
+	// whole log. Deliver the caller's own event, which is what it would have
+	// gotten before reading forward existed, and try again next time.
+	if !b.marked && !b.markHead() {
+		if fallback != nil {
+			b.fanoutEphemeral(*fallback)
+		}
+		return
+	}
 	for {
 		events, err := b.store.Since(b.announced, b.batchSize)
 		if err != nil {
@@ -690,7 +716,8 @@ func (b *Bus) retain() {
 		case <-b.ctx.Done():
 			return
 		case <-ticker.C:
-			b.Trim()
+			// A failed pass is already logged; the next tick retries it.
+			_, _ = b.Trim()
 		}
 	}
 }
@@ -699,13 +726,22 @@ func (b *Bus) retain() {
 // halves: the age window, and compaction of the fact classes that carry no
 // history. It is exported so the daemon and tests can force a pass without
 // waiting for a tick.
-func (b *Bus) Trim() int {
+// It reports what it removed and whether either half failed. The daemon's tick
+// logs the failure and carries on — a pass that could not run is retried an hour
+// later — but a caller that ASKED for a pass has to be able to tell a pass that
+// removed nothing from one that never happened, or a script reads "removed 0"
+// and concludes the log is already clean.
+func (b *Bus) Trim() (int, error) {
 	if b.store == nil {
-		return 0
+		return 0, nil
 	}
-	var removed int
+	var (
+		removed int
+		failed  error
+	)
 	n, err := b.store.Trim(b.now().Add(-b.retention))
 	if err != nil {
+		failed = fmt.Errorf("retention pass: %w", err)
 		b.log("bus: retention pass failed: %v", err)
 	} else {
 		removed += n
@@ -713,7 +749,11 @@ func (b *Bus) Trim() int {
 			b.log("bus: trimmed %d event(s) older than %s", n, b.retention)
 		}
 	}
-	return removed + b.compact()
+	compacted, err := b.compact()
+	if err != nil && failed == nil {
+		failed = err
+	}
+	return removed + compacted, failed
 }
 
 // compact keeps at most one fact per subject for every compactable name, which
@@ -740,24 +780,24 @@ func (b *Bus) Trim() int {
 // consumer past facts that still exist. A stalled enabled consumer therefore
 // pins compaction exactly as it pins trimming — a loud condition already, with
 // `attn bus status` showing the stall and the kill switch to unpin it.
-func (b *Bus) compact() int {
+func (b *Bus) compact() (int, error) {
 	if len(b.compactable) == 0 {
-		return 0
+		return 0, nil
 	}
 	floor, err := b.consumerFloor()
 	if err != nil {
 		b.log("bus: compaction pass failed: %v", err)
-		return 0
+		return 0, fmt.Errorf("compaction pass: %w", err)
 	}
 	n, err := b.store.Compact(b.compactable, floor)
 	if err != nil {
 		b.log("bus: compaction pass failed: %v", err)
-		return 0
+		return 0, fmt.Errorf("compaction pass: %w", err)
 	}
 	if n > 0 {
 		b.log("bus: compacted %d superseded event(s) at or below seq %d", n, floor)
 	}
-	return n
+	return n, nil
 }
 
 // consumerFloor is the lowest position every enabled consumer has passed. With

--- a/internal/bus/bus_test.go
+++ b/internal/bus/bus_test.go
@@ -20,6 +20,7 @@ type memStore struct {
 
 	sinceErr  error
 	appendErr error
+	boundsErr error
 }
 
 func newMemStore() *memStore {
@@ -60,6 +61,9 @@ func (m *memStore) Since(cursor int64, limit int) ([]Event, error) {
 func (m *memStore) Bounds() (int64, int64, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.boundsErr != nil {
+		return 0, 0, m.boundsErr
+	}
 	if len(m.events) == 0 {
 		return 0, 0, nil
 	}
@@ -98,6 +102,14 @@ func (m *memStore) SetCursor(name string, cursor int64, now time.Time) error {
 	c.UpdatedAt = now
 	m.consumers[name] = c
 	return nil
+}
+
+// setBoundsErr makes the log refuse to say where it stands, which is the state
+// a bus must not mistake for "the log is empty, announce everything".
+func (m *memStore) setBoundsErr(err error) {
+	m.mu.Lock()
+	m.boundsErr = err
+	m.mu.Unlock()
 }
 
 func (m *memStore) setAppendErr(err error) {
@@ -769,7 +781,7 @@ func TestTrimIsCursorAware(t *testing.T) {
 	clk.advance(4 * time.Hour)
 
 	waitFor(t, "both events to be consumed", func() bool { return rec.count() == 2 })
-	if n := b.Trim(); n != 2 {
+	if n, err := b.Trim(); err != nil || n != 2 {
 		t.Fatalf("trimmed %d events after they were consumed, want 2", n)
 	}
 }

--- a/internal/bus/bus_test.go
+++ b/internal/bus/bus_test.go
@@ -152,6 +152,54 @@ func (m *memStore) Trim(cutoff time.Time) (int, error) {
 	return removed, nil
 }
 
+// Compact mirrors the SQLite implementation: for the named fact classes, keep
+// only the newest row per subject, and only touch rows at or below the floor.
+func (m *memStore) Compact(names []string, floor int64) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	compactable := map[string]bool{}
+	for _, n := range names {
+		compactable[n] = true
+	}
+	newest := map[string]int64{}
+	for _, e := range m.events {
+		if compactable[e.Name] && e.Seq > newest[e.Subject] {
+			newest[e.Subject] = e.Seq
+		}
+	}
+	kept := m.events[:0]
+	removed := 0
+	for _, e := range m.events {
+		if compactable[e.Name] && e.Seq <= floor && e.Seq < newest[e.Subject] {
+			removed++
+			continue
+		}
+		kept = append(kept, e)
+	}
+	m.events = kept
+	return removed, nil
+}
+
+func (m *memStore) Size() (int64, int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var bytes int64
+	for _, e := range m.events {
+		bytes += int64(len(e.Name) + len(e.Subject) + len(e.Payload) + len(e.Source))
+	}
+	return int64(len(m.events)), bytes, nil
+}
+
+// appendOutOfBand puts an event on the log the way a store transaction does:
+// committed, with no fan-out — which is what Announce is for.
+func (m *memStore) appendOutOfBand(name, subject string, now time.Time) int64 {
+	seq, err := m.Append(Event{Name: name, Subject: subject}, now)
+	if err != nil {
+		panic(err)
+	}
+	return seq
+}
+
 // dropEventsBelow simulates retention having already trimmed the log, without
 // consulting cursors — the state a killed consumer wakes up into.
 func (m *memStore) dropEventsBelow(seq int64) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -177,14 +177,37 @@ func (c *Client) send(msg interface{}) (*protocol.Response, error) {
 	}
 
 	if !resp.Ok {
-		errMsg := ""
-		if resp.Error != nil {
-			errMsg = *resp.Error
+		return nil, &DaemonError{
+			Code:     protocol.Deref(resp.ErrorCode),
+			Message:  protocol.Deref(resp.Error),
+			Conflict: resp.ErrorConflict,
 		}
-		return nil, fmt.Errorf("daemon error: %s", errMsg)
 	}
 
 	return &resp, nil
+}
+
+// DaemonError is a refused command. It carries the daemon's message text
+// unchanged — that is what a human or an agent reads — plus the code beside it,
+// so a caller can branch on the answer without matching English. Code is empty
+// for the failures nobody has to branch on.
+type DaemonError struct {
+	Code     string
+	Message  string
+	Conflict *protocol.DocumentConflict
+}
+
+func (e *DaemonError) Error() string { return fmt.Sprintf("daemon error: %s", e.Message) }
+
+// ErrorCode reports the code a refusal carried, or "" for anything else. It is
+// what a retry loop asks: protocol.ErrorCodeConflict means read again and
+// retry, and everything else means stop.
+func ErrorCode(err error) string {
+	var daemonErr *DaemonError
+	if errors.As(err, &daemonErr) {
+		return daemonErr.Code
+	}
+	return ""
 }
 
 // Register registers a new session

--- a/internal/client/documents.go
+++ b/internal/client/documents.go
@@ -83,6 +83,17 @@ func (c *Client) DocQuery(query protocol.DocumentQuery) (*protocol.DocQueryResul
 	return resp.DocQueryResult, nil
 }
 
+// DocCount reports how many documents a query matches, without fetching their
+// bodies. Sort and limit are ignored: they decide which matches come back,
+// never how many there are.
+func (c *Client) DocCount(query protocol.DocumentQuery) (*protocol.DocCountResult, error) {
+	resp, err := c.send(protocol.DocCountMessage{Cmd: protocol.CmdDocCount, Query: query})
+	if err != nil {
+		return nil, err
+	}
+	return resp.DocCountResult, nil
+}
+
 // DocSubscribe opens a live query and calls onResult for every delivery,
 // beginning with the current result set. Unlike every other call here it holds
 // its connection open, so it returns only when onResult asks it to stop, the

--- a/internal/daemon/bus.go
+++ b/internal/daemon/bus.go
@@ -237,12 +237,12 @@ const (
 	FactDocumentCollectionRemoved = "document.collection.removed"
 )
 
-// compactableFacts are the fact classes the retention pass may reduce to one
+// CompactableFacts are the fact classes the retention pass may reduce to one
 // row per subject. Both document facts qualify for the same reason: they are
 // invalidations about a subject whose state lives in the store, so only the
 // newest carries information. Session and ticket facts are deliberately absent
 // — they keep the age window's behavior unchanged.
-var compactableFacts = []string{FactDocumentChanged, FactDocumentCollectionRemoved}
+var CompactableFacts = []string{FactDocumentChanged, FactDocumentCollectionRemoved}
 
 // projection maps facts to the wire traffic they produce.
 type projection struct {
@@ -491,7 +491,7 @@ func (d *Daemon) ensureEventBus() {
 	if d.store != nil {
 		backing = d.newSQLBusStore()
 	}
-	d.eventBus = bus.New(bus.Options{Store: backing, Log: d.logf, Compactable: compactableFacts})
+	d.eventBus = bus.New(bus.Options{Store: backing, Log: d.logf, Compactable: CompactableFacts})
 	d.busUnsubscribe = d.eventBus.Subscribe(bus.All, d.projectToClients)
 	d.subscribeDocumentFacts()
 }

--- a/internal/daemon/bus.go
+++ b/internal/daemon/bus.go
@@ -220,12 +220,29 @@ const (
 	// Subject is the document's address (namespace/collection/id); the payload
 	// carries the address in parts plus whether it was a removal.
 	//
+	// It is appended by the store, inside the transaction that made the change,
+	// and announced afterwards — see CommitDocumentWrite. That is what makes the
+	// seq it lands at usable as the write's position.
+	//
 	// This fact has no entry in wireProjections, and that is not an omission: it
 	// produces no WebSocket traffic. Its consumer is the live-query fan-out in
 	// documents.go, an ephemeral subscriber beside the hub that delivers result
 	// sets to IPC callers over their own connections.
 	FactDocumentChanged = "document.changed"
+	// FactDocumentCollectionRemoved: a document collection was undefined, taking
+	// every document under it. Subject is the collection (namespace/collection),
+	// because that is the entity that went — a removal has no document to name,
+	// and saying so with an empty document id would leave every future consumer
+	// special-casing an address that points at nothing.
+	FactDocumentCollectionRemoved = "document.collection.removed"
 )
+
+// compactableFacts are the fact classes the retention pass may reduce to one
+// row per subject. Both document facts qualify for the same reason: they are
+// invalidations about a subject whose state lives in the store, so only the
+// newest carries information. Session and ticket facts are deliberately absent
+// — they keep the age window's behavior unchanged.
+var compactableFacts = []string{FactDocumentChanged, FactDocumentCollectionRemoved}
 
 // projection maps facts to the wire traffic they produce.
 type projection struct {
@@ -474,7 +491,7 @@ func (d *Daemon) ensureEventBus() {
 	if d.store != nil {
 		backing = d.newSQLBusStore()
 	}
-	d.eventBus = bus.New(bus.Options{Store: backing, Log: d.logf})
+	d.eventBus = bus.New(bus.Options{Store: backing, Log: d.logf, Compactable: compactableFacts})
 	d.busUnsubscribe = d.eventBus.Subscribe(bus.All, d.projectToClients)
 	d.subscribeDocumentFacts()
 }

--- a/internal/daemon/bus_store.go
+++ b/internal/daemon/bus_store.go
@@ -23,6 +23,13 @@ type sqlBusStore struct{ store *store.Store }
 
 func (d *Daemon) newSQLBusStore() *sqlBusStore { return &sqlBusStore{store: d.store} }
 
+// NewBusStore adapts a store the caller opened itself. `attn bus trim` uses it
+// to run the same retention pass the daemon's tick runs, against the same
+// policy, without a daemon: the pass is a database operation, and an operator
+// must be able to run one whether or not the daemon is listening — the reason
+// the whole `attn bus` surface is database-direct.
+func NewBusStore(s *store.Store) bus.Store { return &sqlBusStore{store: s} }
+
 func (a *sqlBusStore) Append(e bus.Event, now time.Time) (int64, error) {
 	return a.store.AppendBusEvent(store.BusEvent{
 		Name:    e.Name,

--- a/internal/daemon/bus_store.go
+++ b/internal/daemon/bus_store.go
@@ -88,6 +88,12 @@ func (a *sqlBusStore) ListConsumers() ([]bus.Consumer, error) {
 
 func (a *sqlBusStore) Trim(cutoff time.Time) (int, error) { return a.store.TrimBusEvents(cutoff) }
 
+func (a *sqlBusStore) Compact(names []string, floor int64) (int, error) {
+	return a.store.CompactBusEvents(names, floor)
+}
+
+func (a *sqlBusStore) Size() (int64, int64, error) { return a.store.BusLogSize() }
+
 func busConsumerFromRow(r store.BusConsumer) bus.Consumer {
 	return bus.Consumer{
 		Name:      r.Name,

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -154,6 +154,7 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdDocGet:         commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdDocDelete:      commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdDocQuery:       commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdDocCount:       commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdDocSubscribe:   commandMetadata(ScopeHubLocal, false, true),
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2421,6 +2421,8 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleDocDelete(conn, msg.(*protocol.DocDeleteMessage))
 	case protocol.CmdDocQuery: // wire: doc_query
 		d.handleDocQuery(conn, msg.(*protocol.DocQueryMessage))
+	case protocol.CmdDocCount: // wire: doc_count
+		d.handleDocCount(conn, msg.(*protocol.DocCountMessage))
 	// doc_subscribe keeps the connection: it streams result sets until the
 	// caller disconnects, rather than answering once.
 	case protocol.CmdDocSubscribe: // wire: doc_subscribe

--- a/internal/daemon/documents.go
+++ b/internal/daemon/documents.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -11,6 +12,7 @@ import (
 	"github.com/victorarias/attn/internal/bus"
 	"github.com/victorarias/attn/internal/docstore"
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
 )
 
 // The document store's daemon half: the fact a write publishes, the live queries
@@ -64,6 +66,14 @@ type documentChanged struct {
 	Deleted    bool   `json:"deleted,omitempty"`
 }
 
+// documentCollectionRemoved is the undefine fact's payload: the collection that
+// went, in parts, and how many documents went with it.
+type documentCollectionRemoved struct {
+	Namespace  string `json:"namespace"`
+	Collection string `json:"collection"`
+	Documents  int    `json:"documents"`
+}
+
 // subscribeDocumentFacts registers the live-query fan-out as its own ephemeral
 // bus consumer, beside the WebSocket hub's. It is deliberately not a projection:
 // wireProjections maps facts to WebSocket traffic, and these deliveries go to
@@ -72,7 +82,8 @@ func (d *Daemon) subscribeDocumentFacts() {
 	if d.eventBus == nil || d.docUnsubHooks != nil {
 		return
 	}
-	d.docUnsubHooks = d.eventBus.Subscribe(bus.Filter{FactDocumentChanged}, d.wakeDocumentSubscriptions)
+	d.docUnsubHooks = d.eventBus.Subscribe(
+		bus.Filter{FactDocumentChanged, FactDocumentCollectionRemoved}, d.wakeDocumentSubscriptions)
 }
 
 func (d *Daemon) unsubscribeDocumentFacts() {
@@ -82,22 +93,70 @@ func (d *Daemon) unsubscribeDocumentFacts() {
 	}
 }
 
-// publishDocumentChanged announces one document write or removal. The subject is
-// the document's own address, so the log reads as a history of documents rather
-// than of collections; subscriptions match on the collection carried in the
-// payload.
-func (d *Daemon) publishDocumentChanged(namespace, collection, id string, deleted bool) {
-	d.publishFact(FactDocumentChanged, docstore.Address(namespace, collection, id),
-		documentChanged{Namespace: namespace, Collection: collection, ID: id, Deleted: deleted})
+// documentChangedFact builds the fact for one document write or removal. The
+// subject is the document's own address, so the log reads as a history of
+// documents rather than of collections; subscriptions match on the collection
+// carried in the payload.
+//
+// It is built here and appended by the store, inside the write's own
+// transaction: the store must not know what attn's facts are called, and the
+// write must not be able to land without one.
+func documentChangedFact(namespace, collection, id string, deleted bool) store.BusEvent {
+	payload, _ := json.Marshal(documentChanged{
+		Namespace: namespace, Collection: collection, ID: id, Deleted: deleted,
+	})
+	return store.BusEvent{
+		Name:    FactDocumentChanged,
+		Subject: docstore.Address(namespace, collection, id),
+		Payload: string(payload),
+	}
 }
 
-// wakeDocumentSubscriptions is the fact handler. It does no I/O.
-func (d *Daemon) wakeDocumentSubscriptions(ev bus.Event) {
-	fact, ok := decodeFact[documentChanged](d, ev)
-	if !ok {
+// announceCommittedWrite fans out a fact the store already made durable.
+//
+// The bus reads the log forward rather than taking the event from here, so two
+// writes that commit concurrently reach subscribers in seq order however their
+// announce calls race. Without a bus — a Daemon assembled in a test — the
+// matching path runs the projections directly, exactly as publishFact's
+// bus-less path does, so a test exercises the same write with only the fan-out
+// missing.
+func (d *Daemon) announceCommittedWrite(fact store.BusEvent, seq int64) {
+	if d.eventBus == nil {
+		d.projectToClients(bus.Event{
+			Seq: seq, Name: fact.Name, Subject: fact.Subject, Payload: json.RawMessage(fact.Payload),
+		})
 		return
 	}
-	target := docstore.Target(fact.Namespace, fact.Collection)
+	d.eventBus.Announce()
+}
+
+// publishCollectionRemoved announces that a collection and everything in it is
+// gone. Its subject is the collection rather than a document, so it goes through
+// the ordinary publish path: there is no document write to commit it with.
+func (d *Daemon) publishCollectionRemoved(namespace, collection string, documents int) {
+	d.publishFact(FactDocumentCollectionRemoved, docstore.Target(namespace, collection),
+		documentCollectionRemoved{Namespace: namespace, Collection: collection, Documents: documents})
+}
+
+// wakeDocumentSubscriptions is the fact handler for both document facts. It does
+// no I/O.
+func (d *Daemon) wakeDocumentSubscriptions(ev bus.Event) {
+	var namespace, collection string
+	switch ev.Name {
+	case FactDocumentCollectionRemoved:
+		fact, ok := decodeFact[documentCollectionRemoved](d, ev)
+		if !ok {
+			return
+		}
+		namespace, collection = fact.Namespace, fact.Collection
+	default:
+		fact, ok := decodeFact[documentChanged](d, ev)
+		if !ok {
+			return
+		}
+		namespace, collection = fact.Namespace, fact.Collection
+	}
+	target := docstore.Target(namespace, collection)
 
 	d.docSubsMu.Lock()
 	woken := make([]*docSubscription, 0, len(d.docSubs))
@@ -167,34 +226,34 @@ func (d *Daemon) compileDocQuery(q docstore.Query, schema docstore.CollectionSch
 	return q.Compile(schema, anchor)
 }
 
-// runDocQuery answers a query, returning its documents on the wire, the
-// declaration they were computed against, and how long the read took. The
-// caller decides what a slow one means: once for a one-shot query, per write
-// for a live one.
+// runDocQuery answers a query, returning the store's read — documents, the
+// declaration they were computed against, and the log position they were true
+// at — plus how long it took. The caller decides what a slow one means: once
+// for a one-shot query, per write for a live one.
 //
 // The declaration comes back from the read rather than being passed in. Reading
 // it separately first is what let a redeclare land between the schema and the
 // SELECT; the store now resolves it inside the same transaction, so the schema
 // returned here is the one the answer actually means.
-func (d *Daemon) runDocQuery(q docstore.Query) ([]protocol.StoredDocument, docstore.CollectionSchema, time.Duration, error) {
+func (d *Daemon) runDocQuery(q docstore.Query) (store.QueryRead, time.Duration, error) {
 	if d.store == nil {
-		return nil, docstore.CollectionSchema{}, 0, fmt.Errorf("no database")
+		return store.QueryRead{}, 0, fmt.Errorf("no database")
 	}
 	if err := docstore.ValidateNamespace(q.Namespace); err != nil {
-		return nil, docstore.CollectionSchema{}, 0, err
+		return store.QueryRead{}, 0, docstore.InvalidQuery(err)
 	}
 	if err := docstore.ValidateCollection(q.Collection); err != nil {
-		return nil, docstore.CollectionSchema{}, 0, err
+		return store.QueryRead{}, 0, docstore.InvalidQuery(err)
 	}
 	started := time.Now()
 	read, found, err := d.store.ReadQuery(q)
 	if err != nil {
-		return nil, docstore.CollectionSchema{}, 0, err
+		return store.QueryRead{}, 0, err
 	}
 	if !found {
-		return nil, docstore.CollectionSchema{}, 0, undeclaredCollectionError(q.Namespace, q.Collection)
+		return store.QueryRead{}, 0, undeclaredCollectionError(q.Namespace, q.Collection)
 	}
-	return storedDocumentsToProtocol(read.Documents), read.Schema, time.Since(started), nil
+	return read, time.Since(started), nil
 }
 
 // Two tripwires, because a document query has two costs and only one of them is
@@ -277,10 +336,42 @@ func (d *Daemon) collectionFor(namespace, collection string) (*docstore.Collecti
 
 // undeclaredCollectionError is what every caller reports for a collection that
 // was never declared, whether it read the declaration itself or had a query come
-// back saying there was none.
+// back saying there was none. It is typed so sendDocError can put a code beside
+// the text without matching on the text.
 func undeclaredCollectionError(namespace, collection string) error {
-	return fmt.Errorf("docstore: %s/%s is not declared; declare it with `attn doc define` before reading or writing it",
-		namespace, collection)
+	return &docstore.UndeclaredCollectionError{Namespace: namespace, Collection: collection}
+}
+
+// sendDocError is the document store's one error path. It turns the typed
+// errors docstore raises into the machine-readable code beside the message —
+// which is the whole point of them being types: an SDK retry loop must be able
+// to tell "conflict, read it again" from "broken, stop", and a UI host must be
+// able to tell "this collection is gone, kill the tile" from "that query was
+// wrong". Neither may do it by matching English, including here.
+//
+// The message text is unchanged and stays the part a human or an agent reads.
+func (d *Daemon) sendDocError(conn net.Conn, err error) {
+	resp := protocol.Response{Ok: false, Error: protocol.Ptr(err.Error())}
+	var conflict *docstore.ConflictError
+	switch {
+	case errors.As(err, &conflict):
+		resp.ErrorCode = protocol.Ptr(protocol.ErrorCodeConflict)
+		resp.ErrorConflict = &protocol.DocumentConflict{
+			Namespace:  conflict.Namespace,
+			Collection: conflict.Collection,
+			ID:         conflict.ID,
+			Expected:   int(conflict.Expected),
+			Found:      conflict.Found,
+			Actual:     int(conflict.Actual),
+		}
+	case docstore.IsUndeclaredCollection(err):
+		resp.ErrorCode = protocol.Ptr(protocol.ErrorCodeUndeclaredCollection)
+	case docstore.IsInvalidQuery(err):
+		resp.ErrorCode = protocol.Ptr(protocol.ErrorCodeInvalidQuery)
+	}
+	if err := json.NewEncoder(conn).Encode(resp); err != nil {
+		d.logf("docstore: writing error response: %v", err)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -290,7 +381,7 @@ func undeclaredCollectionError(namespace, collection string) error {
 func (d *Daemon) handleDocDefine(conn net.Conn, msg *protocol.DocDefineMessage) {
 	schema := collectionSchemaFromProtocol(msg.Schema)
 	if err := schema.Validate(); err != nil {
-		d.sendError(conn, err.Error())
+		d.sendDocError(conn, err)
 		return
 	}
 	if d.store == nil {
@@ -298,7 +389,7 @@ func (d *Daemon) handleDocDefine(conn net.Conn, msg *protocol.DocDefineMessage) 
 		return
 	}
 	if err := d.store.DefineDocumentCollection(schema, time.Now()); err != nil {
-		d.sendError(conn, err.Error())
+		d.sendDocError(conn, err)
 		return
 	}
 	d.sendDocResponse(conn, protocol.Response{
@@ -309,18 +400,18 @@ func (d *Daemon) handleDocDefine(conn net.Conn, msg *protocol.DocDefineMessage) 
 
 func (d *Daemon) handleDocUndefine(conn net.Conn, msg *protocol.DocUndefineMessage) {
 	if _, err := d.collectionFor(msg.Namespace, msg.Collection); err != nil {
-		d.sendError(conn, err.Error())
+		d.sendDocError(conn, err)
 		return
 	}
 	removed, err := d.store.DeleteDocumentCollection(msg.Namespace, msg.Collection)
 	if err != nil {
-		d.sendError(conn, err.Error())
+		d.sendDocError(conn, err)
 		return
 	}
 	// Every removed document is a change its watchers must see; without this a
 	// live query would keep showing records the store no longer holds.
 	d.coalesceSnapshots(func() {
-		d.publishDocumentChanged(msg.Namespace, msg.Collection, "", true)
+		d.publishCollectionRemoved(msg.Namespace, msg.Collection, removed)
 	})
 	d.sendDocResponse(conn, protocol.Response{
 		Ok: true,
@@ -337,7 +428,7 @@ func (d *Daemon) handleDocCollections(conn net.Conn, _ *protocol.DocCollectionsM
 	}
 	schemas, err := d.store.ListDocumentCollections()
 	if err != nil {
-		d.sendError(conn, err.Error())
+		d.sendDocError(conn, err)
 		return
 	}
 	out := make([]protocol.DocumentCollectionSchema, 0, len(schemas))
@@ -353,29 +444,39 @@ func (d *Daemon) handleDocCollections(conn net.Conn, _ *protocol.DocCollectionsM
 func (d *Daemon) handleDocPut(conn net.Conn, msg *protocol.DocPutMessage) {
 	schema, err := d.collectionFor(msg.Namespace, msg.Collection)
 	if err != nil {
-		d.sendError(conn, err.Error())
+		d.sendDocError(conn, err)
 		return
 	}
 	if err := docstore.ValidateDocumentID(msg.ID); err != nil {
-		d.sendError(conn, err.Error())
+		d.sendDocError(conn, err)
 		return
 	}
 	if err := docstore.ValidateBody([]byte(msg.Body)); err != nil {
-		d.sendError(conn, err.Error())
+		d.sendDocError(conn, err)
 		return
 	}
+	// The write and its fact are one commit, so the seq that comes back is the
+	// write's position: a caller can compare it against the `as_of_seq` of any
+	// later read and know whether that read includes this write.
+	//
 	// A refused write publishes nothing: the store did not change, and waking
 	// every live query on the collection to re-render an identical result set is
 	// exactly the cost the conditional write exists to avoid.
-	rev, err := d.store.PutDocument(*schema, msg.ID, []byte(msg.Body), time.Now(), expectedRev(msg.ExpectedRev))
+	fact := documentChangedFact(msg.Namespace, msg.Collection, msg.ID, false)
+	written, err := d.store.CommitDocumentWrite(store.DocumentWrite{
+		Schema: *schema, ID: msg.ID, Body: []byte(msg.Body), Expected: expectedRev(msg.ExpectedRev),
+	}, fact, time.Now())
 	if err != nil {
-		d.sendError(conn, err.Error())
+		d.sendDocError(conn, err)
 		return
 	}
-	d.publishDocumentChanged(msg.Namespace, msg.Collection, msg.ID, false)
+	d.announceCommittedWrite(fact, written.Seq)
 	d.sendDocResponse(conn, protocol.Response{
-		Ok:           true,
-		DocPutResult: &protocol.DocPutResult{Namespace: msg.Namespace, Collection: msg.Collection, ID: msg.ID, Rev: int(rev)},
+		Ok: true,
+		DocPutResult: &protocol.DocPutResult{
+			Namespace: msg.Namespace, Collection: msg.Collection, ID: msg.ID,
+			Rev: int(written.Rev), Seq: int(written.Seq),
+		},
 	})
 }
 
@@ -391,19 +492,33 @@ func expectedRev(wire *int) *int64 {
 }
 
 func (d *Daemon) handleDocGet(conn net.Conn, msg *protocol.DocGetMessage) {
-	schema, err := d.collectionFor(msg.Namespace, msg.Collection)
-	if err != nil {
-		d.sendError(conn, err.Error())
+	if d.store == nil {
+		d.sendError(conn, "no database")
 		return
 	}
-	doc, found, err := d.store.GetDocument(*schema, msg.ID)
-	if err != nil {
-		d.sendError(conn, err.Error())
+	if err := docstore.ValidateNamespace(msg.Namespace); err != nil {
+		d.sendDocError(conn, err)
 		return
 	}
-	result := &protocol.DocGetResult{Found: found}
-	if found {
-		wire := storedDocumentToProtocol(*doc)
+	if err := docstore.ValidateCollection(msg.Collection); err != nil {
+		d.sendDocError(conn, err)
+		return
+	}
+	// One transaction for the declaration, the row and the log position, so the
+	// position names the state the document was read from rather than whatever
+	// the log reached by the time a second read got there.
+	read, declared, err := d.store.ReadDocument(msg.Namespace, msg.Collection, msg.ID)
+	if err != nil {
+		d.sendDocError(conn, err)
+		return
+	}
+	if !declared {
+		d.sendDocError(conn, undeclaredCollectionError(msg.Namespace, msg.Collection))
+		return
+	}
+	result := &protocol.DocGetResult{Found: read.Found, AsOfSeq: int(read.AsOfSeq)}
+	if read.Found {
+		wire := storedDocumentToProtocol(*read.Document)
 		result.Document = &wire
 	}
 	d.sendDocResponse(conn, protocol.Response{Ok: true, DocGetResult: result})
@@ -412,23 +527,28 @@ func (d *Daemon) handleDocGet(conn net.Conn, msg *protocol.DocGetMessage) {
 func (d *Daemon) handleDocDelete(conn net.Conn, msg *protocol.DocDeleteMessage) {
 	schema, err := d.collectionFor(msg.Namespace, msg.Collection)
 	if err != nil {
-		d.sendError(conn, err.Error())
+		d.sendDocError(conn, err)
 		return
 	}
-	existed, err := d.store.DeleteDocument(*schema, msg.ID, expectedRev(msg.ExpectedRev))
+	// A delete that removed nothing changed nothing: the store appends no fact
+	// for it, so it must not wake a subscription with a result set identical to
+	// the one it already has, and it has no position to report.
+	fact := documentChangedFact(msg.Namespace, msg.Collection, msg.ID, true)
+	written, err := d.store.CommitDocumentWrite(store.DocumentWrite{
+		Schema: *schema, ID: msg.ID, Delete: true, Expected: expectedRev(msg.ExpectedRev),
+	}, fact, time.Now())
 	if err != nil {
-		d.sendError(conn, err.Error())
+		d.sendDocError(conn, err)
 		return
 	}
-	// A delete that removed nothing changed nothing, and must not wake a
-	// subscription with a result set identical to the one it already has.
-	if existed {
-		d.publishDocumentChanged(msg.Namespace, msg.Collection, msg.ID, true)
+	if written.Changed {
+		d.announceCommittedWrite(fact, written.Seq)
 	}
 	d.sendDocResponse(conn, protocol.Response{
 		Ok: true,
 		DocDeleteResult: &protocol.DocDeleteResult{
-			Namespace: msg.Namespace, Collection: msg.Collection, ID: msg.ID, Existed: existed,
+			Namespace: msg.Namespace, Collection: msg.Collection, ID: msg.ID,
+			Existed: written.Changed, Seq: int(written.Seq),
 		},
 	})
 }
@@ -436,16 +556,57 @@ func (d *Daemon) handleDocDelete(conn net.Conn, msg *protocol.DocDeleteMessage) 
 func (d *Daemon) handleDocQuery(conn net.Conn, msg *protocol.DocQueryMessage) {
 	q, err := documentQueryFromProtocol(msg.Query)
 	if err != nil {
-		d.sendError(conn, err.Error())
+		d.sendDocError(conn, err)
 		return
 	}
-	docs, schema, took, err := d.runDocQuery(q)
+	read, took, err := d.runDocQuery(q)
 	if err != nil {
-		d.sendError(conn, err.Error())
+		d.sendDocError(conn, err)
 		return
 	}
-	d.logSlowDocQuery(schema, took)
-	d.sendDocResponse(conn, protocol.Response{Ok: true, DocQueryResult: &protocol.DocQueryResult{Documents: docs}})
+	d.logSlowDocQuery(read.Schema, took)
+	d.sendDocResponse(conn, protocol.Response{Ok: true, DocQueryResult: &protocol.DocQueryResult{
+		Documents: storedDocumentsToProtocol(read.Documents),
+		AsOfSeq:   int(read.AsOfSeq),
+	}})
+}
+
+// handleDocCount answers how many documents match, using the same compile the
+// query itself uses. A caller that only wants the number — a badge, a "showing
+// 20 of N" — must not have to fetch bodies to count them, and cannot count
+// past the limit if it does.
+func (d *Daemon) handleDocCount(conn net.Conn, msg *protocol.DocCountMessage) {
+	q, err := documentQueryFromProtocol(msg.Query)
+	if err != nil {
+		d.sendDocError(conn, err)
+		return
+	}
+	if d.store == nil {
+		d.sendError(conn, "no database")
+		return
+	}
+	if err := docstore.ValidateNamespace(q.Namespace); err != nil {
+		d.sendDocError(conn, docstore.InvalidQuery(err))
+		return
+	}
+	if err := docstore.ValidateCollection(q.Collection); err != nil {
+		d.sendDocError(conn, docstore.InvalidQuery(err))
+		return
+	}
+	started := time.Now()
+	read, found, err := d.store.CountQuery(q)
+	if err != nil {
+		d.sendDocError(conn, err)
+		return
+	}
+	if !found {
+		d.sendDocError(conn, undeclaredCollectionError(q.Namespace, q.Collection))
+		return
+	}
+	d.logSlowDocQuery(read.Schema, time.Since(started))
+	d.sendDocResponse(conn, protocol.Response{Ok: true, DocCountResult: &protocol.DocCountResult{
+		Count: read.Count, AsOfSeq: int(read.AsOfSeq),
+	}})
 }
 
 // handleDocSubscribe is the only handler that keeps its connection. It writes
@@ -457,18 +618,18 @@ func (d *Daemon) handleDocQuery(conn net.Conn, msg *protocol.DocQueryMessage) {
 func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMessage) {
 	q, err := documentQueryFromProtocol(msg.Query)
 	if err != nil {
-		d.sendError(conn, err.Error())
+		d.sendDocError(conn, err)
 		return
 	}
 	schema, err := d.collectionFor(q.Namespace, q.Collection)
 	if err != nil {
-		d.sendError(conn, err.Error())
+		d.sendDocError(conn, err)
 		return
 	}
 	// Compile once up front. A query that cannot compile must fail the subscribe
 	// rather than fail on every delivery of a subscription that looked accepted.
 	if _, err := d.compileDocQuery(q, *schema); err != nil {
-		d.sendError(conn, err.Error())
+		d.sendDocError(conn, err)
 		return
 	}
 
@@ -499,15 +660,18 @@ func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMes
 		// serve again. The re-read happens inside the query's own transaction, so
 		// a redeclare cannot land between reading the declaration and running the
 		// statement compiled from it.
-		docs, live, took, err := d.runDocQuery(q)
+		read, took, err := d.runDocQuery(q)
 		if err != nil {
-			d.sendError(conn, err.Error())
+			d.sendDocError(conn, err)
 			return
 		}
-		d.logSlowDocFanOut(sub, live, took)
+		d.logSlowDocFanOut(sub, read.Schema, took)
 		resp := protocol.Response{
-			Ok:                 true,
-			DocSubscribeResult: &protocol.DocSubscribeResult{Delivery: delivery, Documents: docs},
+			Ok: true,
+			DocSubscribeResult: &protocol.DocSubscribeResult{
+				Delivery:  delivery,
+				Documents: storedDocumentsToProtocol(read.Documents),
+			},
 		}
 		if err := encoder.Encode(resp); err != nil {
 			return
@@ -558,7 +722,8 @@ func documentQueryFromProtocol(q protocol.DocumentQuery) (docstore.Query, error)
 	for _, f := range q.Filters {
 		var value any
 		if err := json.Unmarshal([]byte(f.ValueJson), &value); err != nil {
-			return docstore.Query{}, fmt.Errorf("docstore: filter on %q carries %q, which is not JSON: %w", f.Field, f.ValueJson, err)
+			return docstore.Query{}, docstore.InvalidQuery(
+				fmt.Errorf("docstore: filter on %q carries %q, which is not JSON: %w", f.Field, f.ValueJson, err))
 		}
 		out.Filters = append(out.Filters, docstore.Filter{Field: f.Field, Op: docstore.Op(f.Op), Value: value})
 	}

--- a/internal/daemon/documents_facts_test.go
+++ b/internal/daemon/documents_facts_test.go
@@ -229,7 +229,7 @@ func TestDocumentFailuresCarryTheirOwnCodes(t *testing.T) {
 
 	undeclared := docCall(t, func(c net.Conn) {
 		d.handleDocQuery(c, &protocol.DocQueryMessage{
-			Cmd: protocol.CmdDocQuery,
+			Cmd:   protocol.CmdDocQuery,
 			Query: protocol.DocumentQuery{Namespace: testDocNS, Collection: "nothing-here"},
 		})
 	})

--- a/internal/daemon/documents_facts_test.go
+++ b/internal/daemon/documents_facts_test.go
@@ -1,0 +1,346 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// The document store's facts are a contract: extensions read this log, and a
+// consumer that parses `document.changed` must keep working across releases.
+// These pin the name, the subject's shape, the payload, and — the part that is
+// not visible from either side alone — that the fact and the write it describes
+// are one commit.
+
+func factsOf(t *testing.T, d *Daemon) []store.BusEvent {
+	t.Helper()
+	events, err := d.store.BusEventsSince(0, 1000)
+	if err != nil {
+		t.Fatalf("reading the log: %v", err)
+	}
+	return events
+}
+
+func docFacts(t *testing.T, d *Daemon, name string) []store.BusEvent {
+	t.Helper()
+	var out []store.BusEvent
+	for _, e := range factsOf(t, d) {
+		if e.Name == name {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// The wire contract of a document write's fact, asserted literally rather than
+// through what it happens to wake up.
+func TestAWriteAppendsTheDocumentChangedFact(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocPut(c, &protocol.DocPutMessage{
+			Cmd: protocol.CmdDocPut, Namespace: testDocNS, Collection: testDocColl,
+			ID: "a", Body: `{"status":"pending"}`,
+		})
+	})
+	if !resp.Ok {
+		t.Fatalf("put: %v", protocol.Deref(resp.Error))
+	}
+
+	facts := docFacts(t, d, "document.changed")
+	if len(facts) != 1 {
+		t.Fatalf("one write appended %d fact(s)", len(facts))
+	}
+	fact := facts[0]
+	if fact.Subject != testDocNS+"/"+testDocColl+"/a" {
+		t.Fatalf("subject = %q, want the document's address", fact.Subject)
+	}
+
+	var payload struct {
+		Namespace  string `json:"namespace"`
+		Collection string `json:"collection"`
+		ID         string `json:"id"`
+		Deleted    bool   `json:"deleted"`
+	}
+	if err := json.Unmarshal([]byte(fact.Payload), &payload); err != nil {
+		t.Fatalf("payload %q does not decode: %v", fact.Payload, err)
+	}
+	if payload.Namespace != testDocNS || payload.Collection != testDocColl || payload.ID != "a" {
+		t.Fatalf("payload names %+v", payload)
+	}
+	if payload.Deleted {
+		t.Fatal("a write was announced as a removal")
+	}
+
+	// The write's reported position is where its fact landed, which is what
+	// makes a caller able to tell whether a later read already includes it.
+	if resp.DocPutResult.Seq != int(fact.Seq) {
+		t.Fatalf("the put reported seq %d, the fact is at %d", resp.DocPutResult.Seq, fact.Seq)
+	}
+}
+
+// A removal is the same fact with deleted set, so a consumer can tell one from
+// the other without reading the store to find nothing there.
+func TestARemovalIsAnnouncedAsADeletion(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+
+	if !deleteDoc(t, d, "a") {
+		t.Fatal("delete reported the document was not there")
+	}
+
+	facts := docFacts(t, d, "document.changed")
+	if len(facts) != 2 {
+		t.Fatalf("a write and a removal appended %d fact(s), want 2", len(facts))
+	}
+	var payload struct {
+		ID      string `json:"id"`
+		Deleted bool   `json:"deleted"`
+	}
+	if err := json.Unmarshal([]byte(facts[1].Payload), &payload); err != nil {
+		t.Fatalf("payload does not decode: %v", err)
+	}
+	if payload.ID != "a" || !payload.Deleted {
+		t.Fatalf("removal announced as %+v", payload)
+	}
+}
+
+// The behavior that must survive the move to a composite write: a write that
+// changed nothing wakes nobody, because it appended nothing.
+func TestAWriteThatChangedNothingAppendsNoFact(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+	before := len(docFacts(t, d, "document.changed"))
+
+	if deleteDoc(t, d, "gone-already") {
+		t.Fatal("deleting a document that was never there reported it existed")
+	}
+
+	stale := 99
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocPut(c, &protocol.DocPutMessage{
+			Cmd: protocol.CmdDocPut, Namespace: testDocNS, Collection: testDocColl,
+			ID: "a", Body: `{"status":"approved"}`, ExpectedRev: &stale,
+		})
+	})
+	if resp.Ok {
+		t.Fatal("a stale conditional write was accepted")
+	}
+
+	if after := len(docFacts(t, d, "document.changed")); after != before {
+		t.Fatalf("writes that changed nothing appended %d fact(s)", after-before)
+	}
+}
+
+// Undefining a collection announces the collection, not a document. The old
+// code reached for document.changed with an empty id, which is a subject no
+// consumer can address and no compaction can group.
+func TestUndefiningACollectionAnnouncesTheCollection(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+	putDoc(t, d, "b", `{"status":"pending"}`)
+
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocUndefine(c, &protocol.DocUndefineMessage{
+			Cmd: protocol.CmdDocUndefine, Namespace: testDocNS, Collection: testDocColl,
+		})
+	})
+	if !resp.Ok {
+		t.Fatalf("undefine: %v", protocol.Deref(resp.Error))
+	}
+
+	removals := docFacts(t, d, "document.collection.removed")
+	if len(removals) != 1 {
+		t.Fatalf("undefine appended %d removal fact(s), want 1", len(removals))
+	}
+	if removals[0].Subject != testDocNS+"/"+testDocColl {
+		t.Fatalf("subject = %q, want the collection's address", removals[0].Subject)
+	}
+	var payload struct {
+		Namespace  string `json:"namespace"`
+		Collection string `json:"collection"`
+		Documents  int    `json:"documents"`
+	}
+	if err := json.Unmarshal([]byte(removals[0].Payload), &payload); err != nil {
+		t.Fatalf("payload %q does not decode: %v", removals[0].Payload, err)
+	}
+	if payload.Namespace != testDocNS || payload.Collection != testDocColl || payload.Documents != 2 {
+		t.Fatalf("removal payload = %+v", payload)
+	}
+
+	for _, fact := range docFacts(t, d, "document.changed") {
+		if fact.Subject == testDocNS+"/"+testDocColl+"/" {
+			t.Fatalf("undefine announced a document with no id: %+v", fact)
+		}
+	}
+}
+
+// A failure the caller has to branch on carries a code, so nobody matches on
+// message text. The conflict's code brings the structured detail with it: what
+// the caller expected, what is actually there, and whether anything is there
+// at all — enough to retry without a second round trip.
+func TestARefusedWriteCarriesAConflictCode(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+
+	stale := 99
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocPut(c, &protocol.DocPutMessage{
+			Cmd: protocol.CmdDocPut, Namespace: testDocNS, Collection: testDocColl,
+			ID: "a", Body: `{"status":"approved"}`, ExpectedRev: &stale,
+		})
+	})
+	if resp.Ok {
+		t.Fatal("a stale conditional write was accepted")
+	}
+	if got := protocol.Deref(resp.ErrorCode); got != protocol.ErrorCodeConflict {
+		t.Fatalf("error code = %q, want %q", got, protocol.ErrorCodeConflict)
+	}
+	if resp.ErrorConflict == nil {
+		t.Fatal("a conflict carried no structured detail")
+	}
+	c := resp.ErrorConflict
+	if c.Namespace != testDocNS || c.Collection != testDocColl || c.ID != "a" {
+		t.Fatalf("conflict names %+v", c)
+	}
+	if c.Expected != stale || !c.Found || c.Actual != 1 {
+		t.Fatalf("conflict reports expected=%d actual=%d found=%v, want 99/1/true",
+			c.Expected, c.Actual, c.Found)
+	}
+	if protocol.Deref(resp.Error) == "" {
+		t.Fatal("a coded error dropped its human text")
+	}
+}
+
+// The other two codes a caller branches on. Reading an undeclared collection is
+// a different problem from writing a query the declaration cannot answer, and
+// the difference must be readable without parsing prose.
+func TestDocumentFailuresCarryTheirOwnCodes(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+
+	undeclared := docCall(t, func(c net.Conn) {
+		d.handleDocQuery(c, &protocol.DocQueryMessage{
+			Cmd: protocol.CmdDocQuery,
+			Query: protocol.DocumentQuery{Namespace: testDocNS, Collection: "nothing-here"},
+		})
+	})
+	if undeclared.Ok {
+		t.Fatal("querying an undeclared collection succeeded")
+	}
+	if got := protocol.Deref(undeclared.ErrorCode); got != protocol.ErrorCodeUndeclaredCollection {
+		t.Fatalf("error code = %q, want %q", got, protocol.ErrorCodeUndeclaredCollection)
+	}
+
+	invalid := docCall(t, func(c net.Conn) {
+		d.handleDocQuery(c, &protocol.DocQueryMessage{
+			Cmd: protocol.CmdDocQuery,
+			Query: protocol.DocumentQuery{
+				Namespace: testDocNS, Collection: testDocColl,
+				Filters: []protocol.DocumentFilter{{Field: "not-declared", Op: "eq", ValueJson: `"x"`}},
+			},
+		})
+	})
+	if invalid.Ok {
+		t.Fatal("a query against an undeclared field succeeded")
+	}
+	if got := protocol.Deref(invalid.ErrorCode); got != protocol.ErrorCodeInvalidQuery {
+		t.Fatalf("error code = %q, want %q", got, protocol.ErrorCodeInvalidQuery)
+	}
+}
+
+// doc_count answers "how many" without paying for the bodies, and it answers the
+// same question the query would: it compiles the caller's own filters.
+func TestCountingMatchesWithoutFetchingThem(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+	putDoc(t, d, "b", `{"status":"pending"}`)
+	putDoc(t, d, "c", `{"status":"approved"}`)
+
+	count := func(q protocol.DocumentQuery) *protocol.DocCountResult {
+		t.Helper()
+		resp := docCall(t, func(c net.Conn) {
+			d.handleDocCount(c, &protocol.DocCountMessage{Cmd: protocol.CmdDocCount, Query: q})
+		})
+		if !resp.Ok {
+			t.Fatalf("count: %v", protocol.Deref(resp.Error))
+		}
+		if resp.DocCountResult == nil {
+			t.Fatal("count returned no result")
+		}
+		return resp.DocCountResult
+	}
+
+	if got := count(testQuery()); got.Count != 3 {
+		t.Fatalf("counted %d, want 3", got.Count)
+	}
+
+	filtered := testQuery()
+	filtered.Filters = []protocol.DocumentFilter{{Field: "status", Op: "eq", ValueJson: `"pending"`}}
+	if got := count(filtered); got.Count != 2 {
+		t.Fatalf("counted %d pending, want 2", got.Count)
+	}
+
+	// A limit decides which matches come back, never how many there are — a
+	// count that respected it would answer a question nobody asked.
+	limited := testQuery()
+	limited.Limit = protocol.Ptr(1)
+	if got := count(limited); got.Count != 3 {
+		t.Fatalf("counted %d under a limit of 1, want all 3", got.Count)
+	}
+
+	if got := count(testQuery()); got.AsOfSeq <= 0 {
+		t.Fatalf("a count over a written collection stands at seq %d", got.AsOfSeq)
+	}
+}
+
+// Every read says where it stands, so a caller that just wrote can tell whether
+// the answer already includes its write.
+func TestReadsReportThePositionTheyWereTrueAt(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+
+	put := docCall(t, func(c net.Conn) {
+		d.handleDocPut(c, &protocol.DocPutMessage{
+			Cmd: protocol.CmdDocPut, Namespace: testDocNS, Collection: testDocColl,
+			ID: "a", Body: `{"status":"pending"}`,
+		})
+	})
+	if !put.Ok {
+		t.Fatalf("put: %v", protocol.Deref(put.Error))
+	}
+	writtenAt := put.DocPutResult.Seq
+
+	query := docCall(t, func(c net.Conn) {
+		d.handleDocQuery(c, &protocol.DocQueryMessage{Cmd: protocol.CmdDocQuery, Query: testQuery()})
+	})
+	if !query.Ok {
+		t.Fatalf("query: %v", protocol.Deref(query.Error))
+	}
+	if query.DocQueryResult.AsOfSeq < writtenAt {
+		t.Fatalf("a query returning the write stands at %d, before the write at %d",
+			query.DocQueryResult.AsOfSeq, writtenAt)
+	}
+
+	get := docCall(t, func(c net.Conn) {
+		d.handleDocGet(c, &protocol.DocGetMessage{
+			Cmd: protocol.CmdDocGet, Namespace: testDocNS, Collection: testDocColl, ID: "a",
+		})
+	})
+	if !get.Ok {
+		t.Fatalf("get: %v", protocol.Deref(get.Error))
+	}
+	if get.DocGetResult.AsOfSeq < writtenAt {
+		t.Fatalf("a get returning the write stands at %d, before the write at %d",
+			get.DocGetResult.AsOfSeq, writtenAt)
+	}
+}

--- a/internal/docstore/docstore.go
+++ b/internal/docstore/docstore.go
@@ -234,6 +234,57 @@ func IsConflict(err error) bool {
 	return errors.As(err, &conflict)
 }
 
+// UndeclaredCollectionError is every read or write against a collection nobody
+// declared. It is a type for the same reason ConflictError is: the surfaces
+// above have to tell "declare it first" from "something is broken", and a UI
+// host has to tell "kill this tile" from "retry".
+type UndeclaredCollectionError struct {
+	Namespace  string
+	Collection string
+}
+
+func (e *UndeclaredCollectionError) Error() string {
+	return fmt.Sprintf("docstore: %s/%s is not declared; declare it with `attn doc define` before reading or writing it",
+		e.Namespace, e.Collection)
+}
+
+// IsUndeclaredCollection reports whether an error is a missing declaration.
+func IsUndeclaredCollection(err error) bool {
+	var undeclared *UndeclaredCollectionError
+	return errors.As(err, &undeclared)
+}
+
+// InvalidQueryError is a query this collection cannot answer: an unknown field,
+// an operator that does not exist, a bound of the wrong type, a cursor pointing
+// at a document that is gone. It wraps the specific refusal rather than
+// replacing it — the message is the part an agent fixes the query from, and the
+// type is the part a program branches on.
+type InvalidQueryError struct{ Err error }
+
+func (e *InvalidQueryError) Error() string { return e.Err.Error() }
+func (e *InvalidQueryError) Unwrap() error { return e.Err }
+
+// IsInvalidQuery reports whether an error is a query this store refused to
+// compile.
+func IsInvalidQuery(err error) bool {
+	var invalid *InvalidQueryError
+	return errors.As(err, &invalid)
+}
+
+// InvalidQuery marks an error as a refusal to run a caller's query. It is
+// exported because a query can also be refused before it reaches Compile —
+// decoding one off the wire, for instance — and those refusals are the same
+// class to whoever asked.
+func InvalidQuery(err error) error {
+	if err == nil {
+		return nil
+	}
+	if IsInvalidQuery(err) {
+		return err
+	}
+	return &InvalidQueryError{Err: err}
+}
+
 // Compiled is a validated query as SQL. Table is the collection's table, Where
 // and Order are fragments the store splices into its own SELECT, and Args binds
 // Where's placeholders in order. Where is empty when nothing constrains the
@@ -439,7 +490,18 @@ func (s CollectionSchema) declaredNames() string {
 // empty, and its absence when q.After is set is an error rather than an empty
 // page: a cursor pointing at a document that no longer exists is a caller
 // mistake worth hearing about, not a silent end of results.
+// Every rejection is an *InvalidQueryError, typed once here rather than at each
+// return below: the callers above turn the type into an error code, and one
+// choke point is what keeps that mapping from becoming string matching.
 func (q Query) Compile(schema CollectionSchema, anchor *Document) (Compiled, error) {
+	compiled, err := q.compile(schema, anchor)
+	if err != nil {
+		return Compiled{}, InvalidQuery(err)
+	}
+	return compiled, nil
+}
+
+func (q Query) compile(schema CollectionSchema, anchor *Document) (Compiled, error) {
 	if err := ValidateNamespace(q.Namespace); err != nil {
 		return Compiled{}, err
 	}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,29 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "212"
+const ProtocolVersion = "213"
+
+// Error codes. A failed response may carry one beside its message text, naming
+// what a caller can do about it rather than leaving it to match English. Only
+// the document store issues them today; the field is on Response because the
+// question — "is this worth retrying, or is it broken?" — is not specific to it.
+//
+// A client that does not recognise a code must treat the failure as broken
+// rather than guessing, which is what keeps adding one from being a breaking
+// change.
+const (
+	// ErrorCodeConflict: a conditional write was refused because the document is
+	// not at the revision the caller asserted. Response.ErrorConflict names both
+	// revisions. Re-read and apply the change to the version that won.
+	ErrorCodeConflict = "conflict"
+	// ErrorCodeUndeclaredCollection: the collection was never declared, or is no
+	// longer declared. Nothing to retry — declare it, or stop.
+	ErrorCodeUndeclaredCollection = "undeclared_collection"
+	// ErrorCodeInvalidQuery: the query itself is wrong — an unknown field, an
+	// operator that does not exist, a bound of the wrong type, a cursor pointing
+	// at a document that is gone. The message says which.
+	ErrorCodeInvalidQuery = "invalid_query"
+)
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -78,6 +100,7 @@ const (
 	CmdDocGet                                = "doc_get"
 	CmdDocDelete                             = "doc_delete"
 	CmdDocQuery                              = "doc_query"
+	CmdDocCount                              = "doc_count"
 	CmdDocSubscribe                          = "doc_subscribe"
 	CmdGetTicket                             = "get_ticket"
 	CmdTicketChangeStatus                    = "ticket_change_status"
@@ -648,6 +671,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdDocQuery:
 		var msg DocQueryMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdDocCount:
+		var msg DocCountMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1088,6 +1088,22 @@ type DocCollectionsResult struct {
 	Collections []DocumentCollectionSchema `json:"collections"`
 }
 
+type DocCountMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Query corresponds to the JSON schema field "query".
+	Query DocumentQuery `json:"query"`
+}
+
+type DocCountResult struct {
+	// AsOfSeq corresponds to the JSON schema field "as_of_seq".
+	AsOfSeq int `json:"as_of_seq"`
+
+	// Count corresponds to the JSON schema field "count".
+	Count int `json:"count"`
+}
+
 type DocDefineMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -1133,6 +1149,9 @@ type DocDeleteResult struct {
 
 	// Namespace corresponds to the JSON schema field "namespace".
 	Namespace string `json:"namespace"`
+
+	// Seq corresponds to the JSON schema field "seq".
+	Seq int `json:"seq"`
 }
 
 type DocGetMessage struct {
@@ -1150,6 +1169,9 @@ type DocGetMessage struct {
 }
 
 type DocGetResult struct {
+	// AsOfSeq corresponds to the JSON schema field "as_of_seq".
+	AsOfSeq int `json:"as_of_seq"`
+
 	// Document corresponds to the JSON schema field "document".
 	Document *StoredDocument `json:"document,omitempty,omitzero"`
 
@@ -1189,6 +1211,9 @@ type DocPutResult struct {
 
 	// Rev corresponds to the JSON schema field "rev".
 	Rev int `json:"rev"`
+
+	// Seq corresponds to the JSON schema field "seq".
+	Seq int `json:"seq"`
 }
 
 type DocQueryMessage struct {
@@ -1200,6 +1225,9 @@ type DocQueryMessage struct {
 }
 
 type DocQueryResult struct {
+	// AsOfSeq corresponds to the JSON schema field "as_of_seq".
+	AsOfSeq int `json:"as_of_seq"`
+
 	// Documents corresponds to the JSON schema field "documents".
 	Documents []StoredDocument `json:"documents"`
 }
@@ -1248,6 +1276,26 @@ type DocumentCollectionSchema struct {
 
 	// Fields corresponds to the JSON schema field "fields".
 	Fields []DocumentFieldSpec `json:"fields"`
+
+	// Namespace corresponds to the JSON schema field "namespace".
+	Namespace string `json:"namespace"`
+}
+
+type DocumentConflict struct {
+	// Actual corresponds to the JSON schema field "actual".
+	Actual int `json:"actual"`
+
+	// Collection corresponds to the JSON schema field "collection".
+	Collection string `json:"collection"`
+
+	// Expected corresponds to the JSON schema field "expected".
+	Expected int `json:"expected"`
+
+	// Found corresponds to the JSON schema field "found".
+	Found bool `json:"found"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
 
 	// Namespace corresponds to the JSON schema field "namespace".
 	Namespace string `json:"namespace"`
@@ -4182,6 +4230,9 @@ type Response struct {
 	// "doc_collections_result".
 	DocCollectionsResult *DocCollectionsResult `json:"doc_collections_result,omitempty,omitzero"`
 
+	// DocCountResult corresponds to the JSON schema field "doc_count_result".
+	DocCountResult *DocCountResult `json:"doc_count_result,omitempty,omitzero"`
+
 	// DocDefineResult corresponds to the JSON schema field "doc_define_result".
 	DocDefineResult *DocDefineResult `json:"doc_define_result,omitempty,omitzero"`
 
@@ -4205,6 +4256,12 @@ type Response struct {
 
 	// Error corresponds to the JSON schema field "error".
 	Error *string `json:"error,omitempty,omitzero"`
+
+	// ErrorCode corresponds to the JSON schema field "error_code".
+	ErrorCode *string `json:"error_code,omitempty,omitzero"`
+
+	// ErrorConflict corresponds to the JSON schema field "error_conflict".
+	ErrorConflict *DocumentConflict `json:"error_conflict,omitempty,omitzero"`
 
 	// JournalAppendResult corresponds to the JSON schema field
 	// "journal_append_result".

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -3575,11 +3575,18 @@ model DocPutMessage {
 
 // `rev` is the revision the document now has, so a create-then-update sequence
 // needs no read in between.
+//
+// `seq` is the write's POSITION: the document write and the fact describing it
+// are one commit, and this is where that fact landed on the durable log. Compare
+// it against a later read's `as_of_seq` to know whether that read includes this
+// write. It is an opaque monotone position — never a row id, never dense, never
+// contiguous — and clients only store and compare it.
 model DocPutResult {
   "namespace": string;
   "collection": string;
   "id": string;
   "rev": safeint;
+  "seq": safeint;
 }
 
 model DocGetMessage {
@@ -3591,9 +3598,14 @@ model DocGetMessage {
 
 // `found` separates an absent document from a failed read; `document` is present
 // only when found.
+//
+// `as_of_seq` is the log position this answer was true at, read in the same
+// transaction as the document. 0 means "before everything" — a valid position on
+// a log that has never been written to, not a missing answer.
 model DocGetResult {
   "found": boolean;
   "document"?: StoredDocument;
+  "as_of_seq": safeint;
 }
 
 // `expected_rev` removes the document only if it is still at that revision —
@@ -3610,11 +3622,16 @@ model DocDeleteMessage {
 
 // `existed` is false when the delete removed nothing, so a caller does not
 // report a change that did not happen.
+//
+// `seq` is the removal's position on the durable log, as DocPutResult describes.
+// It is 0 when `existed` is false: nothing changed, so nothing was announced and
+// there is no position to report.
 model DocDeleteResult {
   "namespace": string;
   "collection": string;
   "id": string;
   "existed": boolean;
+  "seq": safeint;
 }
 
 model DocQueryMessage {
@@ -3622,8 +3639,38 @@ model DocQueryMessage {
   "query": DocumentQuery;
 }
 
+// `as_of_seq` is the log position these documents were true at, read in the same
+// transaction as the rows themselves.
 model DocQueryResult {
   "documents": StoredDocument[];
+  "as_of_seq": safeint;
+}
+
+// Count the documents a query matches, without fetching their bodies. The
+// filters (and the after cursor, if any) mean exactly what they mean for
+// doc_query; sort and limit are ignored, because they decide which matches come
+// back and never how many there are.
+model DocCountMessage {
+  "cmd": "doc_count";
+  "query": DocumentQuery;
+}
+
+model DocCountResult {
+  "count": int32;
+  "as_of_seq": safeint;
+}
+
+// The revisions a refused write disagreed about. `expected` is what the caller
+// asserted (0 meaning "must not exist"); `found` reports whether a document was
+// there at all when the store looked, and `actual` is its revision, meaningless
+// when `found` is false. Together they say which write this one lost to.
+model DocumentConflict {
+  "namespace": string;
+  "collection": string;
+  "id": string;
+  "expected": safeint;
+  "found": boolean;
+  "actual": safeint;
 }
 
 // Subscribe to a live query. Unlike every other command here, this one keeps the
@@ -3658,6 +3705,15 @@ model DocSubscribeResult {
 model Response {
   ok: boolean;
   error?: string;
+  // A machine-readable name for what went wrong, beside the human-readable
+  // `error` text. Present only where a caller has to branch on the answer:
+  // `conflict` (retry after re-reading — `error_conflict` carries which
+  // revisions disagreed), `undeclared_collection` (the collection is not
+  // there), `invalid_query` (the query itself is wrong). Everything else
+  // carries no code, and a client must treat an unknown code as "broken, stop"
+  // rather than matching the message text.
+  error_code?: string;
+  error_conflict?: DocumentConflict;
   data?: string;
   delegate_result?: DelegateResult;
   delegation_operation?: DelegationOperation;
@@ -3696,6 +3752,7 @@ model Response {
   doc_get_result?: DocGetResult;
   doc_delete_result?: DocDeleteResult;
   doc_query_result?: DocQueryResult;
+  doc_count_result?: DocCountResult;
   doc_subscribe_result?: DocSubscribeResult;
 }
 

--- a/internal/store/bus.go
+++ b/internal/store/bus.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"strings"
 	"time"
 )
 
@@ -57,7 +58,15 @@ func (s *Store) AppendBusEvent(e BusEvent, now time.Time) (int64, error) {
 	if s.db == nil {
 		return 0, nil
 	}
-	res, err := s.db.Exec(`
+	return appendBusEventWith(s.db, e, now)
+}
+
+// appendBusEventWith is the append itself, taking whatever runs the statement.
+// A composite write (see CommitDocumentWrite) passes its transaction so the fact
+// and the change it describes are one commit; AppendBusEvent passes the database
+// and gets SQLite's implicit single-statement transaction.
+func appendBusEventWith(x execer, e BusEvent, now time.Time) (int64, error) {
+	res, err := x.Exec(`
 		INSERT INTO bus_events (name, subject, payload, source, created_at)
 		VALUES (?, ?, ?, ?, ?)
 	`, e.Name, e.Subject, e.Payload, e.Source, formatTicketTime(now))
@@ -267,4 +276,82 @@ func (s *Store) TrimBusEvents(cutoff time.Time) (int, error) {
 	}
 	n, err := res.RowsAffected()
 	return int(n), err
+}
+
+// CompactBusEvents keeps only the newest fact per subject among the named ones,
+// and only below floor. It reports how many rows went.
+//
+// Which names may be compacted is a semantic question and is answered in
+// internal/bus; this is the SQL, the same split trimming uses. A compactable
+// name is one whose facts are pure invalidations — five of them about one
+// subject carry no more information than the newest, because the state itself
+// lives in the store and every consumer reads it from there.
+//
+// floor is the caller's cursor floor and is what makes this safe: a row at or
+// below it has been read by every enabled consumer, so removing it cannot cost
+// anyone a delivery, and reconcileGap's "below the earliest surviving seq means
+// trimmed" assumption stays true because no holes are punched above the floor.
+//
+// An empty name list is not "compact everything": it compacts nothing, because
+// a caller that named nothing asked for nothing.
+func (s *Store) CompactBusEvents(names []string, floor int64) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil || len(names) == 0 {
+		return 0, nil
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(names)), ",")
+	args := make([]any, 0, len(names)*2+1)
+	for _, n := range names {
+		args = append(args, n)
+	}
+	args = append(args, floor)
+	for _, n := range names {
+		args = append(args, n)
+	}
+	// The correlated MAX is an index walk over idx_bus_events_subject (subject,
+	// seq): for each candidate row, the newest fact about the same subject is the
+	// last entry of that subject's index range.
+	res, err := s.db.Exec(`
+		DELETE FROM bus_events
+		WHERE name IN (`+placeholders+`)
+		  AND seq <= ?
+		  AND seq < (
+		      SELECT MAX(newer.seq) FROM bus_events AS newer
+		      WHERE newer.subject = bus_events.subject
+		        AND newer.name IN (`+placeholders+`)
+		  )
+	`, args...)
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	return int(n), err
+}
+
+// BusLogSize reports how many facts the log holds and how many bytes of event
+// text they carry.
+//
+// Bytes is the weight of the rows themselves — name, subject, payload, source
+// and stamp — not the size of the database file: SQLite pages are shared with
+// every other table, so a file size would answer a different question than "is
+// the log outgrowing the data it describes". That is the question `attn bus
+// status` asks, and the one fact-class compaction exists to keep answerable.
+func (s *Store) BusLogSize() (rows int64, bytes int64, err error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return 0, 0, nil
+	}
+	err = s.db.QueryRow(`
+		SELECT COUNT(*),
+		       COALESCE(SUM(LENGTH(name) + LENGTH(subject) + LENGTH(payload) + LENGTH(source) + LENGTH(created_at)), 0)
+		FROM bus_events
+	`).Scan(&rows, &bytes)
+	if err != nil {
+		return 0, 0, err
+	}
+	return rows, bytes, nil
 }

--- a/internal/store/bus_compaction_test.go
+++ b/internal/store/bus_compaction_test.go
@@ -1,0 +1,285 @@
+package store
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// Fact-class compaction: a log of pure invalidations must not grow with how
+// often a subject changed, only with how many subjects there are. These pin the
+// two halves of that — what it removes, and what it must never remove.
+
+func changeOf(subject string) BusEvent {
+	return BusEvent{Name: "document.changed", Subject: subject, Payload: `{}`, Source: "test"}
+}
+
+func seqsOnLog(t *testing.T, s *Store) []int64 {
+	t.Helper()
+	events, err := s.BusEventsSince(0, 100000)
+	if err != nil {
+		t.Fatalf("reading the log: %v", err)
+	}
+	seqs := make([]int64, 0, len(events))
+	for _, e := range events {
+		seqs = append(seqs, e.Seq)
+	}
+	return seqs
+}
+
+func headOf(t *testing.T, s *Store) int64 {
+	t.Helper()
+	_, head, err := s.BusBounds()
+	if err != nil {
+		t.Fatalf("bounds: %v", err)
+	}
+	return head
+}
+
+// The point of the whole mechanism: a document churned N times leaves one fact,
+// and it is the newest one — the only one that still says anything, since the
+// state itself lives in the table.
+func TestChurningOneSubjectLeavesOneFact(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 8, 5, 9, 0, 0, 0, time.UTC)
+
+	var last int64
+	for i := range 200 {
+		seq, err := s.AppendBusEvent(changeOf("ext/x/requests/a"), now.Add(time.Duration(i)*time.Second))
+		if err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+		last = seq
+	}
+
+	removed, err := s.CompactBusEvents([]string{"document.changed"}, headOf(t, s))
+	if err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	if removed != 199 {
+		t.Fatalf("compaction removed %d fact(s), want 199", removed)
+	}
+	if got := seqsOnLog(t, s); len(got) != 1 || got[0] != last {
+		t.Fatalf("log holds %v, want only the newest fact at %d", got, last)
+	}
+}
+
+// Compaction is per subject, not per name: two documents churning at the same
+// time keep one fact each, and a fact of an uncompactable name is untouched
+// however many of them share a subject.
+func TestCompactionKeepsTheNewestOfEverySubjectItTouches(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 8, 5, 9, 0, 0, 0, time.UTC)
+
+	newest := map[string]int64{}
+	for i := range 30 {
+		for _, subject := range []string{"ext/x/requests/a", "ext/x/requests/b"} {
+			seq, err := s.AppendBusEvent(changeOf(subject), now.Add(time.Duration(i)*time.Second))
+			if err != nil {
+				t.Fatalf("append: %v", err)
+			}
+			newest[subject] = seq
+		}
+		// A fact nobody declared compactable, on a subject that also carries
+		// compactable ones — the name is what decides, not the subject.
+		if _, err := s.AppendBusEvent(BusEvent{
+			Name: "session.state.changed", Subject: "ext/x/requests/a", Source: "test",
+		}, now.Add(time.Duration(i)*time.Second)); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+
+	if _, err := s.CompactBusEvents([]string{"document.changed"}, headOf(t, s)); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+
+	events, err := s.BusEventsSince(0, 100000)
+	if err != nil {
+		t.Fatalf("reading the log: %v", err)
+	}
+	changes, others := map[string]int64{}, 0
+	for _, e := range events {
+		if e.Name == "document.changed" {
+			if _, dup := changes[e.Subject]; dup {
+				t.Fatalf("subject %s kept more than one fact", e.Subject)
+			}
+			changes[e.Subject] = e.Seq
+			continue
+		}
+		others++
+	}
+	if len(changes) != 2 {
+		t.Fatalf("compaction left facts for %d subject(s), want 2", len(changes))
+	}
+	for subject, seq := range changes {
+		if seq != newest[subject] {
+			t.Fatalf("subject %s kept seq %d, want the newest at %d", subject, seq, newest[subject])
+		}
+	}
+	if others != 30 {
+		t.Fatalf("compaction touched an unnamed fact class: %d survived, want 30", others)
+	}
+}
+
+// The floor is the safety property. A consumer parked below it has not read what
+// sits above it, so nothing above the floor may go — even facts that compaction
+// would otherwise consider redundant. Without this a lagging consumer would
+// wake to a log missing the very changes it was behind on.
+func TestAConsumerParkedBelowTheFloorPinsEveryFactItHasNotRead(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 8, 5, 9, 0, 0, 0, time.UTC)
+
+	var seqs []int64
+	for i := range 10 {
+		seq, err := s.AppendBusEvent(changeOf("ext/x/requests/a"), now.Add(time.Duration(i)*time.Second))
+		if err != nil {
+			t.Fatalf("append: %v", err)
+		}
+		seqs = append(seqs, seq)
+	}
+
+	// Read the first three, then stop — a consumer that is behind, not gone.
+	floor := seqs[2]
+	if err := s.SaveBusConsumer(BusConsumer{Name: "slowpoke", Cursor: floor, Enabled: true}, now); err != nil {
+		t.Fatalf("registering the consumer: %v", err)
+	}
+
+	if _, err := s.CompactBusEvents([]string{"document.changed"}, floor); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+
+	got := seqsOnLog(t, s)
+	// Everything it has not read survives, in order. What it already read goes
+	// entirely rather than collapsing to one, because the surviving newest fact
+	// about the subject sits above the floor — a consumer reading forward from
+	// here still sees every change it was behind on.
+	want := seqs[3:]
+	if len(got) != len(want) {
+		t.Fatalf("log holds %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("log holds %v, want %v", got, want)
+		}
+	}
+}
+
+// A caller that named no compactable class asked for nothing, which is not the
+// same as asking for everything. Getting this backwards would empty the log.
+func TestCompactingNoNamesRemovesNothing(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 8, 5, 9, 0, 0, 0, time.UTC)
+	for range 5 {
+		if _, err := s.AppendBusEvent(changeOf("ext/x/requests/a"), now); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+	removed, err := s.CompactBusEvents(nil, headOf(t, s))
+	if err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	if removed != 0 || len(seqsOnLog(t, s)) != 5 {
+		t.Fatalf("compacting no names removed %d fact(s), leaving %d", removed, len(seqsOnLog(t, s)))
+	}
+}
+
+// The property that says the mechanism actually bounds growth, stated the way it
+// has to hold rather than as a count the fixture happens to produce: after a
+// churning workload the log is no larger than the live documents plus the
+// removals still in the window. It is an inequality because a document may be
+// created and deleted with both facts collapsing to the tombstone, and because
+// nothing forces every live document to have been written at all.
+func TestACompactedLogIsNoLargerThanWhatItDescribes(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 8, 5, 9, 0, 0, 0, time.UTC)
+
+	const documents = 20
+	live := map[string]bool{}
+	tombstones := map[string]bool{}
+	step := 0
+	appendChange := func(id string, deleted bool) {
+		step++
+		if _, err := s.AppendBusEvent(changeOf("ext/x/requests/"+id), now.Add(time.Duration(step)*time.Second)); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+		if deleted {
+			delete(live, id)
+			tombstones[id] = true
+			return
+		}
+		live[id] = true
+		delete(tombstones, id)
+	}
+
+	// Create everything, rewrite each a few times, then delete a third: the
+	// mixed workload, not a single-shaped one.
+	for i := range documents {
+		appendChange(fmt.Sprintf("d%02d", i), false)
+	}
+	for range 8 {
+		for i := range documents {
+			appendChange(fmt.Sprintf("d%02d", i), false)
+		}
+	}
+	for i := 0; i < documents; i += 3 {
+		appendChange(fmt.Sprintf("d%02d", i), true)
+	}
+
+	before := len(seqsOnLog(t, s))
+	if _, err := s.CompactBusEvents([]string{"document.changed"}, headOf(t, s)); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	after := len(seqsOnLog(t, s))
+
+	if bound := len(live) + len(tombstones); after > bound {
+		t.Fatalf("compacted log holds %d fact(s) for %d live document(s) and %d tombstone(s)",
+			after, len(live), len(tombstones))
+	}
+	if after >= before {
+		t.Fatalf("compaction of %d fact(s) about %d document(s) removed nothing", before, documents)
+	}
+}
+
+// `attn bus status` reports the log's weight, so the numbers have to move with
+// the log rather than being a constant nobody notices is wrong.
+func TestTheLogReportsItsOwnWeight(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 8, 5, 9, 0, 0, 0, time.UTC)
+
+	rows, bytes, err := s.BusLogSize()
+	if err != nil {
+		t.Fatalf("size: %v", err)
+	}
+	if rows != 0 || bytes != 0 {
+		t.Fatalf("an empty log weighs %d row(s), %d byte(s)", rows, bytes)
+	}
+
+	for range 4 {
+		if _, err := s.AppendBusEvent(changeOf("ext/x/requests/a"), now); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+	rows, bytes, err = s.BusLogSize()
+	if err != nil {
+		t.Fatalf("size: %v", err)
+	}
+	if rows != 4 {
+		t.Fatalf("log holds %d row(s), want 4", rows)
+	}
+	one := changeOf("ext/x/requests/a")
+	if want := int64(4 * (len(one.Name) + len(one.Subject) + len(one.Payload) + len(one.Source))); bytes <= want {
+		t.Fatalf("4 facts weigh %d byte(s), want more than the %d of their own text", bytes, want)
+	}
+
+	if _, err := s.CompactBusEvents([]string{"document.changed"}, headOf(t, s)); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	compacted, compactedBytes, err := s.BusLogSize()
+	if err != nil {
+		t.Fatalf("size: %v", err)
+	}
+	if compacted != 1 || compactedBytes >= bytes {
+		t.Fatalf("after compaction the log reports %d row(s), %d byte(s); was %d/%d",
+			compacted, compactedBytes, rows, bytes)
+	}
+}

--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -208,16 +208,23 @@ func (s *Store) DeleteDocumentCollection(namespace, collection string) (int, err
 // revision writes only if the document is still at it. A failed assertion is a
 // *docstore.ConflictError and nothing is written.
 //
-// EACH FORM IS ONE STATEMENT, which is what makes the check atomic without a
-// transaction: SQLite runs a bare statement in its own. Reading the revision and
-// then writing would be two, and the whole point of this is the window between
-// them. The re-read below happens only on the failure path, to say what the
-// write lost to.
+// THE WRITE ITSELF IS ONE STATEMENT, which is what makes the check atomic: each
+// form below refuses in the same statement that would have written. Reading the
+// revision and then writing would be two, and the whole point of this is the
+// window between them. Whether that statement runs in SQLite's implicit
+// transaction (here) or inside one that also appends a fact
+// (CommitDocumentWrite) changes nothing about the check — the same statement
+// runs either way. The re-read below happens only on the failure path, to say
+// what the write lost to.
 func (s *Store) PutDocument(schema docstore.CollectionSchema, id string, body []byte, now time.Time, expected *int64) (int64, error) {
 	table, err := s.documentTable(schema)
 	if err != nil {
 		return 0, err
 	}
+	return putDocumentWith(s.db, schema, table, id, body, now, expected)
+}
+
+func putDocumentWith(q rowQuerier, schema docstore.CollectionSchema, table, id string, body []byte, now time.Time, expected *int64) (int64, error) {
 	ts := now.UTC().Format(docstore.TimeFormat)
 
 	var (
@@ -254,13 +261,13 @@ func (s *Store) PutDocument(schema docstore.CollectionSchema, id string, body []
 	}
 
 	var rev int64
-	err = s.db.QueryRow(stmt, args...).Scan(&rev)
+	err := q.QueryRow(stmt, args...).Scan(&rev)
 	// No row came back is how every refusal arrives — but only an expectation can
 	// refuse one. The unconditional upsert always writes a row, so no row from it
 	// is a broken statement rather than a conflict, and reporting it as one would
 	// tell a caller to retry something that will never succeed.
 	if err == sql.ErrNoRows && expected != nil {
-		return 0, s.documentConflict(schema, table, id, *expected)
+		return 0, documentConflictWith(q, schema, table, id, *expected)
 	}
 	if err != nil {
 		return 0, fmt.Errorf("store: writing %s/%s/%s: %w", schema.Namespace, schema.Collection, id, err)
@@ -302,6 +309,10 @@ func (s *Store) DeleteDocument(schema docstore.CollectionSchema, id string, expe
 	if err != nil {
 		return false, err
 	}
+	return deleteDocumentWith(s.db, schema, table, id, expected)
+}
+
+func deleteDocumentWith(x execQuerier, schema docstore.CollectionSchema, table, id string, expected *int64) (bool, error) {
 	if expected != nil && *expected == docstore.ExpectAbsent {
 		// "Delete this if it is not there" is not an assertion a delete can act
 		// on, and silently treating it as unconditional would delete a document
@@ -316,7 +327,7 @@ func (s *Store) DeleteDocument(schema docstore.CollectionSchema, id string, expe
 		stmt += ` AND rev = ?`
 		args = append(args, *expected)
 	}
-	res, err := s.db.Exec(stmt, args...)
+	res, err := x.Exec(stmt, args...)
 	if err != nil {
 		return false, fmt.Errorf("store: deleting %s/%s/%s: %w", schema.Namespace, schema.Collection, id, err)
 	}
@@ -325,22 +336,25 @@ func (s *Store) DeleteDocument(schema docstore.CollectionSchema, id string, expe
 		return false, err
 	}
 	if n == 0 && expected != nil {
-		return false, s.documentConflict(schema, table, id, *expected)
+		return false, documentConflictWith(x, schema, table, id, *expected)
 	}
 	return n > 0, nil
 }
 
-// documentConflict describes a refused write. It reads the document again to
+// documentConflictWith describes a refused write. It reads the document again to
 // name the revision that won, because "your write was refused" without that is
 // an error a caller cannot act on. A read failure here is not worth losing the
 // conflict over — the refusal is the fact, the revision is the detail — so it
 // degrades to reporting the document as absent.
-func (s *Store) documentConflict(schema docstore.CollectionSchema, table, id string, expected int64) error {
+//
+// The re-read runs on whatever refused the write, which inside a composite is
+// its transaction: reading around it would read a state the refusal never saw.
+func documentConflictWith(q rowQuerier, schema docstore.CollectionSchema, table, id string, expected int64) error {
 	conflict := &docstore.ConflictError{
 		Namespace: schema.Namespace, Collection: schema.Collection, ID: id, Expected: expected,
 	}
 	var rev int64
-	switch err := s.db.QueryRow(`SELECT rev FROM `+table+` WHERE id = ?`, id).Scan(&rev); {
+	switch err := q.QueryRow(`SELECT rev FROM `+table+` WHERE id = ?`, id).Scan(&rev); {
 	case err == nil:
 		conflict.Found = true
 		conflict.Actual = rev
@@ -349,6 +363,100 @@ func (s *Store) documentConflict(schema docstore.CollectionSchema, table, id str
 			schema.Namespace, schema.Collection, id, err)
 	}
 	return conflict
+}
+
+// DocumentWrite is one document mutation: a put of Body, or a removal when
+// Delete is set. Expected is the caller's assertion about the version being
+// replaced or removed, exactly as PutDocument and DeleteDocument take it.
+type DocumentWrite struct {
+	Schema   docstore.CollectionSchema
+	ID       string
+	Body     []byte
+	Delete   bool
+	Expected *int64
+}
+
+// DocumentWriteResult is what a committed write is worth telling a caller.
+//
+// Changed reports whether the store actually moved, and is what separates a
+// delete that removed a document from one that found nothing there. Seq is the
+// fact's position on the durable log and is 0 exactly when Changed is false —
+// nothing changed, so nothing was announced. Rev is the document's new revision
+// and is 0 for a delete, which has no version to report.
+type DocumentWriteResult struct {
+	Rev     int64
+	Seq     int64
+	Changed bool
+}
+
+// CommitDocumentWrite writes a document and appends the fact describing it in
+// ONE transaction, and is how every fact-bearing writer reaches the store.
+//
+// The composite exists because the two halves used to be separate commits: a
+// document write landed, and its fact was published afterwards and could fail
+// on its own (the bus logged and carried on). A crash between them left the
+// data changed and the log silent — permanently, since nothing re-derives facts
+// — which is the divergence B-track workflows would trigger on. After this,
+// a fact that cannot be made durable fails the whole write: the caller gets an
+// error and a retry instead of a store nobody was told about.
+//
+// The store stays fact-agnostic. It does not know what `document.changed` means
+// or how a subject is spelled; the caller builds the fact and this appends it.
+//
+// A write that changed nothing appends NO fact and returns no seq: a delete
+// that found nothing, or a refusal, is not a change, and waking every live
+// query on the collection to re-render an identical result set is the cost the
+// conditional write exists to avoid.
+func (s *Store) CommitDocumentWrite(w DocumentWrite, fact BusEvent, now time.Time) (DocumentWriteResult, error) {
+	table, err := s.documentTable(w.Schema)
+	if err != nil {
+		return DocumentWriteResult{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return DocumentWriteResult{}, fmt.Errorf("store: writing %s/%s/%s: %w",
+			w.Schema.Namespace, w.Schema.Collection, w.ID, err)
+	}
+	// Rolled back on every path that does not commit, including the ones that
+	// return no error: a delete that removed nothing has nothing to commit.
+	defer func() { _ = tx.Rollback() }()
+
+	var out DocumentWriteResult
+	if w.Delete {
+		existed, err := deleteDocumentWith(tx, w.Schema, table, w.ID, w.Expected)
+		if err != nil {
+			return DocumentWriteResult{}, err
+		}
+		out.Changed = existed
+	} else {
+		rev, err := putDocumentWith(tx, w.Schema, table, w.ID, w.Body, now, w.Expected)
+		if err != nil {
+			return DocumentWriteResult{}, err
+		}
+		out.Rev = rev
+		out.Changed = true
+	}
+
+	if !out.Changed {
+		return out, nil
+	}
+
+	seq, err := appendBusEventWith(tx, fact, now)
+	if err != nil {
+		return DocumentWriteResult{}, fmt.Errorf("store: announcing the write to %s/%s/%s: %w",
+			w.Schema.Namespace, w.Schema.Collection, w.ID, err)
+	}
+	out.Seq = seq
+
+	if err := tx.Commit(); err != nil {
+		return DocumentWriteResult{}, fmt.Errorf("store: committing the write to %s/%s/%s: %w",
+			w.Schema.Namespace, w.Schema.Collection, w.ID, err)
+	}
+	return out, nil
 }
 
 // queryDocuments runs an already-compiled query. The compiled fragments are
@@ -394,13 +502,131 @@ func queryDocumentsWith(q rowsQuerier, c docstore.Compiled) ([]docstore.Document
 	return out, rows.Err()
 }
 
-// QueryRead is one answer to one query: the documents, and the declaration they
-// were computed against. The declaration is returned rather than assumed because
-// the caller's copy may already be out of date by the time it reads this — the
-// one in here is the one the answer actually means.
+// QueryRead is one answer to one query: the documents, the declaration they
+// were computed against, and the log position they were true at. The
+// declaration is returned rather than assumed because the caller's copy may
+// already be out of date by the time it reads this — the one in here is the one
+// the answer actually means.
 type QueryRead struct {
 	Schema    docstore.CollectionSchema
 	Documents []docstore.Document
+	AsOfSeq   int64
+}
+
+// readAsOfSeq is the log position an answer was true at: the highest seq in
+// bus_events, read inside the same transaction as the rows.
+//
+// Every document write commits its fact into that log, so this is exactly "the
+// last change this answer includes". Same transaction, not a second read: read
+// outside it and the number names a state the rows were never in.
+//
+// An empty log yields 0, which is a valid position meaning "before everything"
+// rather than a missing answer. Compaction removes rows but never the newest,
+// so it cannot lower MAX(seq) and the watermark is immune to it.
+func readAsOfSeq(q rowQuerier) (int64, error) {
+	var seq int64
+	if err := q.QueryRow(`SELECT COALESCE(MAX(seq), 0) FROM bus_events`).Scan(&seq); err != nil {
+		return 0, fmt.Errorf("store: reading the log position of this answer: %w", err)
+	}
+	return seq, nil
+}
+
+// DocumentRead is one answer to one document read: the document if it is there,
+// and the log position the answer was true at.
+type DocumentRead struct {
+	Document *docstore.Document
+	Found    bool
+	AsOfSeq  int64
+}
+
+// ReadDocument answers a get in a single read transaction — the declaration,
+// the row, and the log position, all against one state of the database, for the
+// same reason ReadQuery does. The bool is false with a nil error when the
+// collection was never declared.
+func (s *Store) ReadDocument(namespace, collection, id string) (DocumentRead, bool, error) {
+	if s.db == nil {
+		return DocumentRead{}, false, fmt.Errorf("store: no database")
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return DocumentRead{}, false, fmt.Errorf("store: reading %s/%s/%s: %w", namespace, collection, id, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	schema, table, found, err := readCollectionTx(tx, namespace, collection)
+	if err != nil || !found {
+		return DocumentRead{}, false, err
+	}
+	doc, ok, err := getDocumentWith(tx, schema.Namespace, schema.Collection, table, id)
+	if err != nil {
+		return DocumentRead{}, false, err
+	}
+	asOf, err := readAsOfSeq(tx)
+	if err != nil {
+		return DocumentRead{}, false, err
+	}
+	return DocumentRead{Document: doc, Found: ok, AsOfSeq: asOf}, true, nil
+}
+
+// CountRead is one answer to a count: how many documents match, and the log
+// position that was true at.
+type CountRead struct {
+	Schema  docstore.CollectionSchema
+	Count   int
+	AsOfSeq int64
+}
+
+// CountQuery answers "how many match" with the same compile the query itself
+// uses, so a count and the page it describes cannot disagree about what
+// matches. Only the filter half of the compiled query is used: ordering and the
+// limit decide which matches come back, never how many there are.
+//
+// A query carrying an after cursor counts what follows the anchor, which is the
+// same thing paging through the rest of the answer would find.
+func (s *Store) CountQuery(q docstore.Query) (CountRead, bool, error) {
+	if s.db == nil {
+		return CountRead{}, false, fmt.Errorf("store: no database")
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return CountRead{}, false, fmt.Errorf("store: counting %s/%s: %w", q.Namespace, q.Collection, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	schema, table, found, err := readCollectionTx(tx, q.Namespace, q.Collection)
+	if err != nil || !found {
+		return CountRead{}, false, err
+	}
+	var anchor *docstore.Document
+	if q.After != "" {
+		doc, ok, err := getDocumentWith(tx, schema.Namespace, schema.Collection, table, q.After)
+		if err != nil {
+			return CountRead{}, false, err
+		}
+		if ok {
+			anchor = doc
+		}
+	}
+	compiled, err := q.Compile(schema, anchor)
+	if err != nil {
+		return CountRead{}, false, err
+	}
+	if err := docstore.ValidateTableName(compiled.Table); err != nil {
+		return CountRead{}, false, err
+	}
+	stmt := `SELECT COUNT(*) FROM ` + compiled.Table
+	if compiled.Where != "" {
+		stmt += ` WHERE ` + compiled.Where
+	}
+	var n int
+	if err := tx.QueryRow(stmt, compiled.Args...).Scan(&n); err != nil {
+		return CountRead{}, false, fmt.Errorf("store: counting %s/%s: %w", q.Namespace, q.Collection, err)
+	}
+	asOf, err := readAsOfSeq(tx)
+	if err != nil {
+		return CountRead{}, false, err
+	}
+	return CountRead{Schema: schema, Count: n, AsOfSeq: asOf}, true, nil
 }
 
 // ReadQuery answers a query in a single read transaction, and is the only way
@@ -466,7 +692,11 @@ func (s *Store) ReadQuery(q docstore.Query) (QueryRead, bool, error) {
 	if err != nil {
 		return QueryRead{}, false, err
 	}
-	return QueryRead{Schema: schema, Documents: docs}, true, nil
+	asOf, err := readAsOfSeq(tx)
+	if err != nil {
+		return QueryRead{}, false, err
+	}
+	return QueryRead{Schema: schema, Documents: docs, AsOfSeq: asOf}, true, nil
 }
 
 // CountDocuments reports how many documents a collection holds. It is what the
@@ -667,6 +897,13 @@ type rowQuerier interface {
 
 type rowsQuerier interface {
 	Query(query string, args ...any) (*sql.Rows, error)
+}
+
+// execQuerier is a write that may have to read to explain itself: a refused
+// delete re-reads the revision that won.
+type execQuerier interface {
+	execer
+	rowQuerier
 }
 
 // readCollection reads a declaration and the table minted for it.

--- a/internal/store/documents_positioned_test.go
+++ b/internal/store/documents_positioned_test.go
@@ -1,0 +1,305 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/docstore"
+)
+
+// A document write and the fact describing it are one commit, and the fact's
+// seq is the write's position. These tests pin both halves of that, including
+// the failure direction — which is the inverse of what the code did before:
+// a fact that cannot be made durable now fails the write instead of being
+// logged and forgotten.
+
+func changeFact(id string, deleted bool) BusEvent {
+	payload := fmt.Sprintf(`{"namespace":"ext/approval-gate","collection":"requests","id":%q,"deleted":%t}`, id, deleted)
+	return BusEvent{
+		Name:    "document.changed",
+		Subject: "ext/approval-gate/requests/" + id,
+		Payload: payload,
+	}
+}
+
+func factsOnLog(t *testing.T, s *Store) []BusEvent {
+	t.Helper()
+	events, err := s.BusEventsSince(0, 1000)
+	if err != nil {
+		t.Fatalf("reading the log: %v", err)
+	}
+	return events
+}
+
+// The write's position is the seq its fact landed at, and the fact is really on
+// the log — not a number the store made up for the caller.
+func TestACommittedWriteReportsWhereItsFactLanded(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{})
+	schema := requestsDecl(t, s)
+
+	written, err := s.CommitDocumentWrite(
+		DocumentWrite{Schema: schema, ID: "a", Body: []byte(`{"status":"pending"}`)},
+		changeFact("a", false), base)
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if written.Rev != docstore.FirstRev {
+		t.Fatalf("rev = %d, want %d", written.Rev, docstore.FirstRev)
+	}
+	if written.Seq == 0 || !written.Changed {
+		t.Fatalf("write reported no position: %+v", written)
+	}
+
+	events := factsOnLog(t, s)
+	if len(events) != 1 {
+		t.Fatalf("log holds %d event(s), want 1", len(events))
+	}
+	if events[0].Seq != written.Seq {
+		t.Fatalf("fact is at seq %d, write reported %d", events[0].Seq, written.Seq)
+	}
+	if events[0].Subject != "ext/approval-gate/requests/a" {
+		t.Fatalf("subject = %q", events[0].Subject)
+	}
+}
+
+// The inverse of the old behavior, and the reason the composite exists: a fact
+// that cannot be made durable fails the whole write. The caller gets an error
+// and a retry rather than a store nobody was told about.
+//
+// The failure is injected through the real path — a trigger that refuses every
+// insert into bus_events — rather than through a seam, so what is proven is
+// that the two statements share a transaction rather than that a fake said so.
+func TestAWriteDoesNotSurviveTheFactItCouldNotAppend(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
+	schema := requestsDecl(t, s)
+
+	if _, err := s.db.Exec(`CREATE TRIGGER refuse_facts BEFORE INSERT ON bus_events
+	                        BEGIN SELECT RAISE(ABORT, 'the log had a bad night'); END`); err != nil {
+		t.Fatalf("installing the failing append: %v", err)
+	}
+
+	_, err := s.CommitDocumentWrite(
+		DocumentWrite{Schema: schema, ID: "a", Body: []byte(`{"status":"approved"}`)},
+		changeFact("a", false), base.Add(time.Second))
+	if err == nil {
+		t.Fatal("a write whose fact could not be appended reported success")
+	}
+	if !strings.Contains(err.Error(), "bad night") {
+		t.Fatalf("error does not name the append failure: %v", err)
+	}
+
+	doc, found, err := s.GetDocument(schema, "a")
+	if err != nil || !found {
+		t.Fatalf("re-reading a: found=%v err=%v", found, err)
+	}
+	if got := string(doc.Body); got != `{"status":"pending"}` {
+		t.Fatalf("the document survived a write whose fact did not: body = %s", got)
+	}
+	if doc.Rev != docstore.FirstRev {
+		t.Fatalf("rev = %d, want the write to have left it at %d", doc.Rev, docstore.FirstRev)
+	}
+}
+
+// The delete half of the same contract: a removal that failed to announce must
+// leave the document there.
+func TestADeleteDoesNotSurviveTheFactItCouldNotAppend(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
+	schema := requestsDecl(t, s)
+
+	if _, err := s.db.Exec(`CREATE TRIGGER refuse_facts BEFORE INSERT ON bus_events
+	                        BEGIN SELECT RAISE(ABORT, 'the log had a bad night'); END`); err != nil {
+		t.Fatalf("installing the failing append: %v", err)
+	}
+
+	if _, err := s.CommitDocumentWrite(
+		DocumentWrite{Schema: schema, ID: "a", Delete: true},
+		changeFact("a", true), base.Add(time.Second)); err == nil {
+		t.Fatal("a delete whose fact could not be appended reported success")
+	}
+	if _, found, err := s.GetDocument(schema, "a"); err != nil || !found {
+		t.Fatalf("the document went with a removal that was never announced: found=%v err=%v", found, err)
+	}
+}
+
+// "Changed" is the whole meaning of the fact, so a write that changed nothing
+// must not append one. Two ways to change nothing: remove what is not there,
+// and be refused.
+func TestAWriteThatChangedNothingAnnouncesNothing(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
+	schema := requestsDecl(t, s)
+
+	written, err := s.CommitDocumentWrite(
+		DocumentWrite{Schema: schema, ID: "never-existed", Delete: true},
+		changeFact("never-existed", true), base.Add(time.Second))
+	if err != nil {
+		t.Fatalf("deleting a missing document: %v", err)
+	}
+	if written.Changed || written.Seq != 0 {
+		t.Fatalf("a delete that removed nothing reported %+v", written)
+	}
+
+	stale := docstore.FirstRev + 7
+	if _, err := s.CommitDocumentWrite(
+		DocumentWrite{Schema: schema, ID: "a", Body: []byte(`{"status":"approved"}`), Expected: &stale},
+		changeFact("a", false), base.Add(2*time.Second)); !docstore.IsConflict(err) {
+		t.Fatalf("a refused write returned %v, want a conflict", err)
+	}
+
+	if events := factsOnLog(t, s); len(events) != 0 {
+		t.Fatalf("the log holds %d event(s) for writes that changed nothing", len(events))
+	}
+}
+
+// A read says where it stands. as_of_seq is at least the position of every
+// write it includes, which is the comparison a caller makes to know its own
+// write is in the answer.
+func TestAnAnswerCarriesThePositionItWasTrueAt(t *testing.T) {
+	s, base := storeWithRequests(t, map[string]string{})
+	schema := requestsDecl(t, s)
+
+	// An empty log is position 0 — "before everything", a valid answer rather
+	// than a missing one.
+	read, found, err := s.ReadQuery(docstore.Query{Namespace: schema.Namespace, Collection: schema.Collection})
+	if err != nil || !found {
+		t.Fatalf("query: found=%v err=%v", found, err)
+	}
+	if read.AsOfSeq != 0 {
+		t.Fatalf("as_of_seq over an empty log = %d, want 0", read.AsOfSeq)
+	}
+
+	written, err := s.CommitDocumentWrite(
+		DocumentWrite{Schema: schema, ID: "a", Body: []byte(`{"status":"pending"}`)},
+		changeFact("a", false), base)
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	read, _, err = s.ReadQuery(docstore.Query{Namespace: schema.Namespace, Collection: schema.Collection})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if read.AsOfSeq < written.Seq {
+		t.Fatalf("a query that returned the write stands at %d, before the write at %d", read.AsOfSeq, written.Seq)
+	}
+	if len(read.Documents) != 1 {
+		t.Fatalf("query returned %d document(s)", len(read.Documents))
+	}
+
+	got, declared, err := s.ReadDocument(schema.Namespace, schema.Collection, "a")
+	if err != nil || !declared {
+		t.Fatalf("get: declared=%v err=%v", declared, err)
+	}
+	if !got.Found || got.AsOfSeq < written.Seq {
+		t.Fatalf("get stands at %d for a write at %d (found=%v)", got.AsOfSeq, written.Seq, got.Found)
+	}
+
+	count, declared, err := s.CountQuery(docstore.Query{Namespace: schema.Namespace, Collection: schema.Collection})
+	if err != nil || !declared {
+		t.Fatalf("count: declared=%v err=%v", declared, err)
+	}
+	if count.Count != 1 || count.AsOfSeq < written.Seq {
+		t.Fatalf("count = %d as of %d, for a write at %d", count.Count, count.AsOfSeq, written.Seq)
+	}
+}
+
+// Reading an undeclared collection is not a failure to read, it is an answer:
+// the collection is not there.
+func TestReadingAnUndeclaredCollectionSaysSo(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{})
+
+	if _, declared, err := s.ReadDocument("ext/approval-gate", "nothing-here", "a"); err != nil || declared {
+		t.Fatalf("get on an undeclared collection: declared=%v err=%v", declared, err)
+	}
+	if _, declared, err := s.CountQuery(docstore.Query{
+		Namespace: "ext/approval-gate", Collection: "nothing-here",
+	}); err != nil || declared {
+		t.Fatalf("count on an undeclared collection: declared=%v err=%v", declared, err)
+	}
+}
+
+// A count is the query's own compile against COUNT(*), so it has to agree with
+// the query on every value class the store compares — including the ones where
+// the encoding could disagree with the meaning.
+//
+// The fixtures are chosen for exactly that: stamps inside one second (whose
+// stored text sorts wrongly under a naive encoding), a numeric string beside a
+// number under a declared number field, and a boolean beside the string "true".
+func TestACountAgreesWithTheQueryItCounts(t *testing.T) {
+	s := New()
+	base := time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC)
+	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+		t.Fatalf("define: %v", err)
+	}
+	schema := requestsDecl(t, s)
+
+	// Written inside one second, at fraction widths that a variable-width
+	// encoding renders in the wrong order.
+	stamps := []time.Duration{0, 123400 * time.Microsecond, 123450 * time.Microsecond, 500 * time.Millisecond}
+	bodies := []string{
+		`{"status":"pending","attempts":5,"urgent":true}`,
+		`{"status":"pending","attempts":"5","urgent":"true"}`,
+		`{"status":"approved","attempts":10,"urgent":false}`,
+		`{"status":"pending","attempts":[1,2],"urgent":true}`,
+	}
+	for i, body := range bodies {
+		if _, err := s.PutDocument(schema, fmt.Sprintf("d%d", i), []byte(body), base.Add(stamps[i]), nil); err != nil {
+			t.Fatalf("put d%d: %v", i, err)
+		}
+	}
+
+	queries := []docstore.Query{
+		{Namespace: schema.Namespace, Collection: schema.Collection},
+		{Namespace: schema.Namespace, Collection: schema.Collection,
+			Filters: []docstore.Filter{{Field: "status", Op: docstore.OpEq, Value: "pending"}}},
+		{Namespace: schema.Namespace, Collection: schema.Collection,
+			Filters: []docstore.Filter{{Field: "attempts", Op: docstore.OpGte, Value: float64(5)}}},
+		{Namespace: schema.Namespace, Collection: schema.Collection,
+			Filters: []docstore.Filter{{Field: "urgent", Op: docstore.OpEq, Value: true}}},
+		{Namespace: schema.Namespace, Collection: schema.Collection,
+			Filters: []docstore.Filter{{
+				Field: docstore.FieldCreatedAt, Op: docstore.OpGte,
+				Value: base.Add(123400 * time.Microsecond).Format(time.RFC3339Nano),
+			}}},
+	}
+	for i, q := range queries {
+		// The query is asked for everything it matches, so the two answers are
+		// comparable: a limit would make the query's length the limit, not the
+		// number of matches.
+		q.Limit = docstore.MaxLimit
+		read, found, err := s.ReadQuery(q)
+		if err != nil || !found {
+			t.Fatalf("query %d: found=%v err=%v", i, found, err)
+		}
+		count, found, err := s.CountQuery(q)
+		if err != nil || !found {
+			t.Fatalf("count %d: found=%v err=%v", i, found, err)
+		}
+		if count.Count != len(read.Documents) {
+			t.Fatalf("query %d matched %d document(s) but counted %d", i, len(read.Documents), count.Count)
+		}
+	}
+}
+
+// Counting after a cursor counts what paging through the rest of the answer
+// would find, which is the only reading of "how many are left" that a caller
+// walking pages can use.
+func TestACountAfterACursorCountsWhatIsLeft(t *testing.T) {
+	s, _ := storeWithRequests(t, map[string]string{
+		"a": `{"attempts":1}`,
+		"b": `{"attempts":2}`,
+		"c": `{"attempts":3}`,
+	})
+	q := docstore.Query{
+		Namespace: "ext/approval-gate", Collection: "requests",
+		Sort: &docstore.Sort{Field: "attempts"}, After: "a", Limit: docstore.MaxLimit,
+	}
+	count, found, err := s.CountQuery(q)
+	if err != nil || !found {
+		t.Fatalf("count: found=%v err=%v", found, err)
+	}
+	if count.Count != 2 {
+		t.Fatalf("count after a = %d, want 2", count.Count)
+	}
+}


### PR DESCRIPTION
Stage 1 of the A3.4 document-store design
([docs/plans/2026-08-05-ext-a3.4-doc-store-positions-and-windows.md](docs/plans/2026-08-05-ext-a3.4-doc-store-positions-and-windows.md)):
positioned writes. Stage 2 — windowed subscriptions — is not in this PR, and
`doc_subscribe`'s wire shape is untouched.

## The problem

A document write and the fact announcing it were two separate operations. The
write committed, then the daemon published. If the publish failed, the document
had changed and nobody was told: every live query kept showing a result set the
store no longer agreed with, indefinitely, with no error anyone could act on.

Nothing in the system carried a position either. A caller that wrote and then
read had no way to tell whether the answer it got already included its own
write, and an extension holding a result set had no way to say what it was a
result set *of*.

And the log grew with writes rather than with data. A document written a
thousand times left a thousand facts, all saying the same thing — that it
changed — while the state itself lived in the table the whole time.

## What changed

**One commit.** `Store.CommitDocumentWrite` runs the document statement and the
fact's append in one transaction and returns where the fact landed. A fact that
cannot be made durable now fails the write, which is the inverse of the old
behavior and the point of the change. The store stays fact-agnostic: the daemon
builds the `store.BusEvent` and hands it over, so `internal/store` still knows
nothing about what attn's facts are called.

A write that changed nothing still appends nothing — deleting an absent document
and a refused conditional write wake nobody, exactly as before.

**Ordered announce.** Facts appended inside somebody else's transaction are not
delivered by whoever wrote them. `bus.Announce()` reads the log forward from a
high-water mark held under the publish lock, and `Publish` now does the same
instead of handing subscribers the event in hand. Two writers that commit and
then race to announce therefore cannot deliver out of order, announcing twice
delivers once, and an announce that never happened is repaired by the next one —
so a caller needs no coordination beyond calling it after its commit.

**Positions on the wire.** `doc_put`/`doc_delete` return `seq`;
`doc_get`/`doc_query`/the new `doc_count` return `as_of_seq`, read inside the
same transaction as the rows. Comparing the two is how a caller knows whether an
answer includes its write. `as_of_seq` 0 over an empty log is a valid position,
not a missing one.

**Codes, not prose.** Failures a caller must branch on carry a machine-readable
`code` beside their human text, mapped from typed errors
(`docstore.ConflictError`, `UndeclaredCollectionError`, `InvalidQueryError`) at
one choke point — `sendDocError` — with no string matching anywhere. `conflict`
brings the expected and actual revisions and whether the document is there at
all, so a retry needs no second round trip.

**`doc_count`.** How many documents match, without their bodies. It reuses the
query's own compile against `SELECT COUNT(*)`, so it cannot drift from what the
query would return; `--sort`, `--desc` and `--limit` are ignored, because they
decide which matches come back and never how many there are.

**Compaction.** The existing retention tick now also reduces the compactable
fact classes to the newest fact per subject. Which names those are is the bus's
policy; the SQL is the store's. It runs only at or below the enabled-consumer
cursor floor, for two load-bearing reasons: below the floor every enabled
consumer has already read everything, so delivery is bit-for-bit unchanged; and
`reconcileGap` reads "cursor below the earliest surviving seq" as "everything
missing was trimmed", which compacting above the floor would turn into a lie.

The consequence, stated rather than hidden: for these names durable delivery is
at-least-once *per changed subject*, not per write. A consumer of this bus reads
current state anyway. A workload that needs every intermediate change as a
business event is doing event sourcing, and those events are data — they belong
in a collection it writes, where their growth is its own visible cost.

**Undefine announces the collection.** It published `document.changed` with an
empty id, which is an address that points at nothing — no consumer can match it
and no compaction can group it. It now publishes `document.collection.removed`
with the collection as its subject, and live queries wake on either fact.

## Operator surface

`attn bus status` reports how many events the log holds and what they weigh —
the receipt for the invariant compaction upholds. Bytes is event text, not file
size: SQLite pages are shared with every other table and would answer a
different question.

`attn bus trim` runs one retention pass on demand. Without it compaction only
fired on an hourly in-daemon tick, so there was no way to see it work or to
reclaim a log that grew between ticks. It builds a bus over the same store
rather than reimplementing the pass, so the pass, the compactable classes and
the floor have one definition; and it is database-direct like the rest of `attn
bus`, which must keep working whether or not the daemon is listening.

`attn doc count` is new. `attn doc put`/`delete` print the seq their write
landed at, and `query`/`get` print the position their answer was true at (to
stderr, so it stays out of a body being piped into `jq`; `--json` shapes are
unchanged, and `doc count --json` carries the position in band).

## Two deviations from the plan, both deliberate

- `CommitDocumentWrite` returns a `DocumentWriteResult` rather than the plan's
  bare `(rev, seq)`. A delete needs to report whether anything existed, and
  overloading seq to carry that would be the kind of encoding that reads fine
  until someone deletes an absent document.
- The announce mark is initialized at construction rather than at `Start`. A bus
  that is never started still publishes and announces — that is the shape of
  every test daemon — and a mark initialized lazily would swallow the first
  committed write's fact.

## No migration

Stage 1 adds no schema. `bus_events`, `bus_consumers` and the per-collection
tables are unchanged; compaction is a DELETE over rows already there.

## Verification

`go test ./...` green. `go test -race ./internal/store ./internal/docstore
./internal/bus` green.

New receipts, each checked against a mutant that should break it:

- **Atomicity.** A trigger that refuses every insert into `bus_events` — the
  real path, not a seam — must take the document write down with it, for both a
  put and a delete. Ignoring the append error makes it fail.
- **No fact on no change.** An absent delete and a refused conditional write
  leave the log untouched.
- **Announce ordering.** Eight goroutines commit-then-announce while publishes
  interleave on the same mark; every subscriber sees the log's own order,
  exactly once. Reverting `Publish` to direct fan-out drops facts on every run.
- **Compaction.** Churning one subject 200 times leaves one fact, and it is the
  newest; a consumer parked below the floor keeps every fact above it; a mixed
  create/rewrite/delete workload leaves a log no larger than its live documents
  plus in-window tombstones, asserted as the inequality it is; an empty name
  list compacts nothing rather than everything.
- **`document.changed` as a contract.** Name, subject shape, payload fields, and
  that the seq the write reported is the seq the fact is at.
- Adversarial count fixtures per the A3.3 rule: writes inside one second at
  fraction widths a variable-width encoding renders out of order, a numeric
  string beside a number under a declared number field, and a boolean beside the
  string `"true"` — the count must agree with the query on every one.

Live, on a throwaway `posw` profile (preflight PASS, protocol 211 end to end;
never `dev`, never production):

- Two writers racing 25 writes each under a live `doc watch`, plus one more:
  revisions 26 and 25, last write at seq 94, the subscriber woken throughout,
  `doc count` agreeing with the query.
- 300 writes to one document: the log went 105 → 415 events (9.8 KB → 46.2 KB).
  One `attn bus trim` removed 348, leaving 67 events at 4.6 KB. The surviving
  `document%` rows were exactly three — one per live document — while
  `pr.updated`, which is not compactable, kept all four facts per subject. The
  document itself was untouched at rev 300, and a write after the pass still
  woke a live subscription at seq 416.

## Surfaces walked

CLI (`attn doc count`, `attn bus trim|status`, seq/position output), daemon and
app (protocol 211 in `constants.go` and `useDaemonSocket.ts`; `generated.go` and
`generated.ts` regenerated from `main.tsp`, never hand-edited), Linux (no
platform-specific code added), docs (changelog fragment). No plugin or SDK
surface consumes these commands yet.
