### PR TITLE
fix(plugins): install a bundled plugin's dependencies before building it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       daemon: ${{ steps.filter.outputs.daemon }}
       frontend: ${{ steps.filter.outputs.frontend }}
       tauri: ${{ steps.filter.outputs.tauri }}
+      plugins: ${{ steps.filter.outputs.plugins }}
     steps:
       - uses: actions/checkout@v4
 
@@ -48,6 +49,11 @@ jobs:
               - '.github/workflows/ci.yml'
             tauri:
               - 'app/src-tauri/**'
+              - '.github/workflows/ci.yml'
+            plugins:
+              - 'plugins/**'
+              - 'scripts/build-bundled-plugins.sh'
+              - '.tool-versions'
               - '.github/workflows/ci.yml'
   changelog:
     name: Changelog
@@ -261,3 +267,35 @@ jobs:
 
       - name: Cargo test
         run: cargo test
+
+  # The bundled plugins are compiled by the packaged-app build, which no CI job
+  # runs — so a plugin that only builds on a machine with warm node_modules got
+  # all the way to a contributor's fresh clone. This stages them the way the app
+  # build does, from a checkout that has nothing installed.
+  plugins:
+    name: Plugins
+    needs: changes
+    if: needs.changes.outputs.plugins == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read bun pin
+        id: bun
+        run: echo "version=$(awk '/^bun / { print $2 }' .tool-versions)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ steps.bun.outputs.version }}
+
+      - name: Stage bundled plugins
+        run: ./scripts/build-bundled-plugins.sh "${RUNNER_TEMP}/bundled-plugins"
+
+      - name: Test plugins
+        run: |
+          for plugin in plugins/*/; do
+            [ -f "${plugin}package.json" ] || continue
+            echo ">>> ${plugin}"
+            (cd "$plugin" && bun test)
+          done

--- a/changelog.d/brisk-marmot-plugin-deps-fresh-checkout.yaml
+++ b/changelog.d/brisk-marmot-plugin-deps-fresh-checkout.yaml
@@ -1,0 +1,10 @@
+kind: fixed
+area: plugins
+change: >
+  Building the app from a fresh clone no longer fails while compiling the
+  bundled pi plugin. The plugin's headless host bundles pi's SDK in, and
+  nothing installed the plugin's dependencies, so the build stopped at
+  "Could not resolve @earendil-works/pi-coding-agent" on any machine that had
+  not run `bun install` by hand. The plugin build now installs from the
+  committed lockfile, and CI stages the bundled plugins from a clean checkout
+  so this cannot reach a contributor again.

--- a/scripts/build-bundled-plugins.sh
+++ b/scripts/build-bundled-plugins.sh
@@ -81,6 +81,14 @@ stage_plugin() {
     exit 1
   fi
 
+  # A plugin that bundles a dependency in needs it on disk first: node_modules
+  # is gitignored, so on a fresh checkout `bun build` stops at the first import
+  # with "Could not resolve". Frozen, because the pin a bundled plugin ships is
+  # the one its lockfile records — a build is never the place to move it.
+  if [[ -f "${source_dir}/bun.lock" ]]; then
+    (cd "${source_dir}" && bun install --frozen-lockfile)
+  fi
+
   rm -rf "${stage_dir}"
   mkdir -p "${stage_dir}/bin"
   bun build "${source_dir}/src/index.ts" --compile --minify --outfile "${stage_dir}/bin/${name}"


### PR DESCRIPTION
Building the app from a fresh clone fails while compiling the bundled pi
plugin:

```
error: Could not resolve: "@earendil-works/pi-coding-agent". Maybe you need to "bun install"?
    at plugins/attn-pi/host/index.ts:26:8
```

Nothing installs a plugin's dependencies. `plugins/*/node_modules` is
gitignored and no build step, Makefile target or CI job has ever run `bun
install` there. That was harmless until the headless host landed (#767),
because every earlier plugin import either resolved inside the plugin or was
marked `--external` — the suite's `VERSION` import is external precisely
because pi resolves it as a virtual module at load time. The host is the first
thing that *bundles* pi in, so `bun build --compile` has to resolve it for
real. Any machine with a warm `node_modules` from working on the plugin builds
fine; a clean checkout does not.

## The fix

`stage_plugin` installs from the committed lockfile before compiling, for any
plugin that has a `bun.lock`. Frozen, because the pin a bundled plugin ships is
the one its lockfile records — a build is never the place to move it. It costs
~0.6s cold and is a no-op once warm. `attn-opencode` declares no dependencies
and has no lockfile, so it is untouched.

## Why nothing caught it

No CI job compiles the bundled plugins at all. The only caller of
`scripts/build-bundled-plugins.sh` is `scripts/build-app-profile.sh`, which
runs during a packaged-app build — something CI never does; the Tauri job only
runs `cargo fmt` and `cargo test`. So the build that breaks is the one no
runner performs, and the first machine to see it was a contributor's.

A `Plugins` job now stages both plugins the way the app build does, on a
checkout with nothing installed. It also runs the plugin test suites (114
tests across the two plugins), which were likewise never gated. Its bun version
is read from `.tool-versions` rather than pinned a second time in the workflow.

## Verification

Cloned the merged `main` into an empty directory and ran
`scripts/build-bundled-plugins.sh`: fails with the error above at
`host/index.ts:26`. Cloned this branch the same way: installs 127 packages,
compiles `attn-pi` and `attn-pi-host` (2953 modules), stages both plugins
clean. Both plugin test suites pass locally (64 + 50).

The staging script's macOS-only codesign fixups are already guarded on
`uname -s`, so it runs on the Linux runner.

## Not fixed here

The release workflow never stages bundled plugins either: `release.yml` runs
`make build` (the Go daemon alone) and then `tauri-action` directly, whose
`beforeBuildCommand` is `npm run build`. `build-app-profile.sh` is not in that
path, so a released `.app` appears to ship its `bundled-plugins/ → plugins/`
resource dir containing only `.gitkeep`. That predates the pi host — opencode
would be missing too — and is left for a separate change.

https://claude.ai/code/session_013X61jPjh8UPsEiz2W4xaQV
