### PR TITLE
fix(release): ship the bundled plugins with the released app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,22 @@ jobs:
           mkdir -p app/src-tauri/binaries
           cp /tmp/attn "app/src-tauri/binaries/attn-aarch64-apple-darwin"
 
+      - name: Read bun pin
+        id: bun
+        run: echo "version=$(awk '/^bun / { print $2 }' .tool-versions)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ steps.bun.outputs.version }}
+
+      # tauri bundles `bundled-plugins/` as the app's `Resources/plugins`, and a
+      # checkout has only a .gitkeep there — the compiled plugins are build
+      # output. A source install gets them from scripts/build-app-profile.sh;
+      # this is the release's equivalent step.
+      - name: Stage bundled plugins
+        run: ./scripts/build-bundled-plugins.sh
+
       - name: Import Apple signing credentials
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -126,6 +142,37 @@ jobs:
           releaseDraft: false
           prerelease: false
           args: --target aarch64-apple-darwin
+
+      # A bundle that lost its plugins looks healthy and simply offers no agents
+      # from them, which nobody notices until someone tries to launch one. Fail
+      # here, before notarization spends twenty minutes on it. The expected set
+      # is whatever was staged, so a new plugin is covered without editing this.
+      - name: Verify the bundled plugins reached the app
+        run: |
+          app_path="$(find app/src-tauri/target -type d -name 'attn.app' | head -n1)"
+          if [ -z "$app_path" ]; then
+            echo "No attn.app bundle found in build output"
+            exit 1
+          fi
+
+          missing=0
+          for staged in app/src-tauri/bundled-plugins/*/; do
+            name="$(basename "$staged")"
+            for required in "attn-plugin.toml" "bin/${name}"; do
+              bundled="$app_path/Contents/Resources/plugins/$name/$required"
+              if [ ! -e "$bundled" ]; then
+                echo "missing from the app bundle: Contents/Resources/plugins/$name/$required"
+                missing=1
+              fi
+            done
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "staged plugins did not reach $app_path"
+            exit 1
+          fi
+
+          echo "bundled plugins present:"
+          ls "$app_path/Contents/Resources/plugins"
 
       - name: Repackage notarized app and replace release assets
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,12 @@ jobs:
           tagName: ${{ env.RELEASE_TAG }}
           releaseName: attn ${{ env.RELEASE_TAG }}
           releaseBody: See CHANGELOG.md for details.
-          releaseDraft: false
+          # Draft until every gate below has run and every asset is attached.
+          # tauri-action's own upload is the un-notarized build, which the
+          # repackage step replaces; publishing here would put that build, and
+          # any bundle the verification is about to reject, in front of users.
+          # The `publish` job at the end flips it.
+          releaseDraft: true
           prerelease: false
           args: --target aarch64-apple-darwin
 
@@ -338,3 +343,39 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${RELEASE_TAG}" /tmp/attn-linux-arm64 --clobber
+
+  # Nothing is public until every gate above has passed and every asset is
+  # attached. A failure anywhere leaves the draft for inspection: fix it, re-run
+  # the workflow on the same tag, and the draft is published only once the whole
+  # set is right.
+  publish:
+    name: Publish release
+    needs: [tauri, linux-amd64, linux-arm64]
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve release tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RELEASE_TAG="${{ inputs.tag }}"
+          else
+            RELEASE_TAG="${{ github.ref_name }}"
+          fi
+
+          if ! [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid release tag: $RELEASE_TAG"
+            exit 1
+          fi
+
+          echo "RELEASE_TAG=$RELEASE_TAG" >> "$GITHUB_ENV"
+
+      - name: Publish the release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release edit "${RELEASE_TAG}" --draft=false --latest
+          gh release view "${RELEASE_TAG}" --json isDraft,assets \
+            --jq '"published draft=\(.isDraft) assets:\n" + (.assets | map("  " + .name) | join("\n"))'

--- a/changelog.d/brisk-marmot-release-bundles-plugins.yaml
+++ b/changelog.d/brisk-marmot-release-bundles-plugins.yaml
@@ -1,0 +1,9 @@
+kind: fixed
+area: plugins
+change: >
+  Released builds now carry the bundled plugins. The release workflow compiled
+  the app without ever staging them, so the shipped bundle's plugin directory
+  held nothing and a release install offered no OpenCode or pi agents — while a
+  source install, which stages them, looked fine. The release now stages the
+  plugins the same way and refuses to publish an app that is missing any of
+  them.

--- a/docs/making-a-release.md
+++ b/docs/making-a-release.md
@@ -82,6 +82,14 @@ With the compilation PR merged and `main` clean of pending fragments:
 It bumps versions, opens a `release/<tag>` PR, waits for CI, merges, tags the
 merge commit, and the tag triggers `.github/workflows/release.yml`.
 
+That workflow builds the app, stages the bundled plugins into it, checks they
+survived into the bundle, notarizes and staples, and builds the Linux daemons —
+all against a **draft** release. It is published only after every one of those
+has passed. So a failed release run leaves a draft, not a half-built public
+release: fix the cause and re-run the workflow on the same tag
+(`gh workflow run release.yml -f tag=<tag>`), which replaces the assets and
+publishes when the whole set is right.
+
 ## What's New modal
 
 The in-app What's New modal (`app/src/components/WhatsNewModal.tsx`,


### PR DESCRIPTION
`tauri.conf.json` maps `bundled-plugins/ → plugins/`, so the app's
`Contents/Resources/plugins` is whatever that directory held at build time. In
a checkout it holds one `.gitkeep`: the compiled plugins are build output, and
`app/src-tauri/bundled-plugins/*` is gitignored.

A source install stages them — `scripts/build-app-profile.sh` runs
`scripts/build-bundled-plugins.sh` before Tauri collects resources. The release
workflow does not go through that script: it runs `make build` for the Go
daemon and then `tauri-action` directly, whose `beforeBuildCommand` is
`npm run build`. Nothing ever staged the plugins, so a released app would ship
an empty plugin directory and offer none of their agents, while every
maintainer's own build looked correct.

## Staging, and a check that it worked

The release job installs bun (version read from `.tool-versions`, not pinned a
second time) and runs the same staging script before the Tauri build. It then
verifies the plugins reached the built bundle. A bundle that lost them looks
healthy and simply offers no agents from them — nobody notices until someone
tries to launch one. The expected set is whatever was staged, so adding a
plugin needs no edit to the check.

## Nothing public until every gate has passed

That check was standing in the wrong place: `tauri-action` was configured with
`releaseDraft: false`, so the GitHub release went public the moment the build
finished — before the verification, before notarization, and before the Linux
daemons were attached. A rejected bundle would have failed the job with the bad
release already downloadable. The same window exposed `tauri-action`'s own
**un-notarized** dmg and app tarball, which the repackage step replaces with
the stapled ones.

The build now produces a draft, and a final `publish` job — gated on the mac
build and both Linux daemon builds — flips it once every asset is attached. A
failed run leaves a draft rather than a half-built public release: fix the
cause and re-run the workflow on the same tag. `docs/making-a-release.md` says
so, since "the tag triggers the release workflow" no longer tells the whole
story.

## Evidence

- No release has shipped since bundled plugins existed: the resource landed in
  #569 (2026-07-16) and the last release is v0.11.1 (2026-06-05). Its dmg has
  no `Resources/plugins` at all, which is consistent but proves nothing on its
  own — the gap is proven by construction instead. The staged output is
  gitignored (`.gitignore:19`), a checkout carries only
  `app/src-tauri/bundled-plugins/.gitkeep`, and no step in `release.yml` wrote
  to that directory.
- The path shape the check asserts is the one the daemon looks for —
  `bundledPluginDirForExecutable` resolves `Contents/Resources/plugins` and
  `discoverPluginManifests` wants `<name>/attn-plugin.toml` — and it matches a
  real Tauri-built bundle: run against an installed non-production app, the
  check passes; run against a bundle with the directory removed, it names every
  missing file and fails.

https://claude.ai/code/session_013X61jPjh8UPsEiz2W4xaQV
