### PR TITLE
fix(queue): wait for classification before auto-settle

### DIFF
--- a/app/scripts/real-app-harness/scenario-agent-queue.mjs
+++ b/app/scripts/real-app-harness/scenario-agent-queue.mjs
@@ -430,6 +430,58 @@ async function main() {
       );
     });
 
+    await runner.step('classification_suspends_auto_settle', async () => {
+      // The countdown must not treat the resolver's awaiting-verdict hold as
+      // proof that work continues. Give the short run enough time to reach the
+      // visible countdown, but a wide enough countdown that it reliably stops
+      // and starts classification before the settle deadline.
+      await client.request('set_setting', { key: 'auto_settle_arm_seconds', value: '5' });
+      await client.request('set_setting', { key: 'auto_settle_countdown_seconds', value: '60' });
+      await client.request('set_setting', { key: 'auto_settle_enabled', value: 'true' });
+      try {
+        await client.request('select_session', { sessionId: alpha.sessionId });
+        const pane = await waitForFirstWorkspacePane(client, alpha.sessionId, `current pane for ${alpha.sessionId}`, 20_000);
+        await submitPrompt(
+          client,
+          alpha.sessionId,
+          pane.paneId,
+          'Count from 1 to 500, one number per line, nothing else. Do not use any tools.',
+        );
+        await pollFor(
+          () => (observer.getSession(alpha.sessionId)?.state === 'working' ? true : null),
+          'the short run to start',
+          60_000,
+        );
+        await pollFor(
+          () => observer.getSession(alpha.sessionId)?.auto_settle_fires_at || null,
+          'the short run to reach the auto-settle countdown',
+          60_000,
+        );
+        await pollFor(
+          () => (observer.getSession(alpha.sessionId)?.state === 'idle' ? true : null),
+          'classification to resolve the short run to idle',
+          60_000,
+        );
+
+        const session = observer.getSession(alpha.sessionId);
+        runner.assert(
+          !session?.auto_settle_fires_at,
+          `classification removed the countdown (got ${JSON.stringify(session?.auto_settle_fires_at)})`,
+        );
+        const queue = await queueState(client);
+        runner.assert(
+          turnIds(queue).includes(alpha.sessionId),
+          `the classified result still owes its turn: ${JSON.stringify(turnIds(queue))}`,
+        );
+        runner.assert(
+          !settledIds(queue).includes(alpha.sessionId),
+          `classification did not auto-settle the result: ${JSON.stringify(settledIds(queue))}`,
+        );
+      } finally {
+        await client.request('set_setting', { key: 'auto_settle_enabled', value: 'false' }).catch(() => {});
+      }
+    });
+
     await runner.step('auto_settle_hands_over_the_next_agent', async () => {
       // A turn closing hands over the next agent that owes one whoever closed
       // it — a countdown completing is not a lesser settle than the keystroke.
@@ -468,13 +520,14 @@ async function main() {
         const pane = await waitForFirstWorkspacePane(client, watched.sessionId, `current pane for ${watched.sessionId}`, 20_000);
 
         // Steering is what arms it. The prompt asks for enough output to outlast
-        // both windows — anything shorter finishes first, and leaving `working`
-        // cancels the settle, so a one-word reply would test nothing.
+        // both windows — anything shorter finishes first, and the stop-time
+        // classifier correctly suspends the settle, so a short reply would test
+        // the classifier guard instead of continuing work.
         await submitPrompt(
           client,
           watched.sessionId,
           pane.paneId,
-          'Count from 1 to 100, one number per line, nothing else. Do not use any tools.',
+          'Count from 1 to 500, one number per line, nothing else. Do not use any tools.',
         );
         // Both preconditions are polled separately from the handover so a run
         // where the steering never landed, or where the agent finished before

--- a/changelog.d/wily-pangolin-auto-settle-waits-for-classifier.yaml
+++ b/changelog.d/wily-pangolin-auto-settle-waits-for-classifier.yaml
@@ -1,0 +1,7 @@
+kind: fixed
+area: queue
+change: >
+  Auto-settle now waits for a stop-time classification to finish before closing
+  a turn. A session can stay green briefly while attn decides whether the agent
+  finished or needs input; that held green state no longer makes the turn
+  disappear before the verdict arrives.

--- a/internal/daemon/auto_settle.go
+++ b/internal/daemon/auto_settle.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/sessionstate"
 )
 
 // Auto-settle closes a turn the user has already dealt with.
@@ -381,6 +382,19 @@ func (d *Daemon) runAutoSettle(sessionID string, phase, resume autoSettlePhase) 
 	session := d.store.Get(sessionID)
 	if session == nil {
 		return "gone"
+	}
+	// The resolver deliberately holds the last published state while a stop-time
+	// verdict is being computed. That projected `working` prevents a color flicker,
+	// but it is not evidence that the agent is still working and must not close the
+	// turn. recordClassifierStarted normally cancels the timer immediately; this
+	// fire-time check closes the race where the callback already took the timer.
+	if evidence, ok := d.evidenceTable().snapshot(sessionID); ok &&
+		sessionstate.ClassifierVerdictPending(
+			evidence,
+			sessionstate.PolicyFor(string(session.Agent)),
+			time.Now(),
+		) {
+		return "classifying"
 	}
 	// The state gate is re-checked here as well as in syncAutoSettle. The
 	// transition path is the primary guard; this catches a session whose state

--- a/internal/daemon/auto_settle_test.go
+++ b/internal/daemon/auto_settle_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/sessionstate"
 )
 
 // newAutoSettleDaemon builds a daemon with one codex session that already owes the
@@ -323,6 +324,65 @@ func TestAutoSettle_FireTimeRecheckRefusesANonWorkingSession(t *testing.T) {
 	}
 	if !turnIsOwed(d, id) {
 		t.Fatal("turn was settled despite the session no longer working")
+	}
+}
+
+// A stop-time classification deliberately holds the last published state while
+// it decides whether the finished turn is idle or needs input. That held green
+// is presentation stability, not proof the agent is still working, so it must
+// suspend an auto-settle that was armed by the preceding turn.
+func TestAutoSettle_ClassificationSuspendsAndThenReevaluates(t *testing.T) {
+	d, id := newAutoSettleDaemon(t)
+	if !d.applyState(sessionStateChange{sessionID: id, state: protocol.StateWorking, cause: liveSignal{}}) {
+		t.Fatal("applyState(working) = false")
+	}
+	fireAutoSettleNow(t, d, id) // into the visible countdown
+
+	d.recordClassifierStarted(id, time.Now())
+
+	if _, ok := autoSettlePending(d, id); ok {
+		t.Fatal("countdown survived classification start")
+	}
+	if !turnIsOwed(d, id) {
+		t.Fatal("classification start settled the turn")
+	}
+
+	// If classification completes while the persisted state is still working,
+	// re-evaluation starts the ordinary arm delay again. A subsequent idle or
+	// waiting-input resolution will cancel it through applyState.
+	d.recordClassifierFinished(id)
+	entry, ok := autoSettlePending(d, id)
+	if !ok || entry.phase != autoSettleArming {
+		t.Fatalf("after classification: pending=%v entry=%+v, want a fresh arm", ok, entry)
+	}
+}
+
+// recordClassifierStarted normally removes the timer before it can fire. This
+// pins the other ordering: the callback has already claimed the timer when the
+// evidence lands, so its own fire-time gate must still preserve the turn.
+func TestAutoSettle_FireTimeRecheckRefusesHeldWorkingDuringClassification(t *testing.T) {
+	d, id := newAutoSettleDaemon(t)
+	if !d.applyState(sessionStateChange{sessionID: id, state: protocol.StateWorking, cause: liveSignal{}}) {
+		t.Fatal("applyState(working) = false")
+	}
+	fireAutoSettleNow(t, d, id) // into the visible countdown
+
+	d.recordEvidence(id, time.Now(), func(e *sessionstate.Evidence) {
+		e.ClassifyingSince = time.Now()
+	})
+
+	entry, ok := autoSettlePending(d, id)
+	if !ok {
+		t.Fatal("no countdown to exercise the fire-time classification gate")
+	}
+	entry.timer.Stop()
+	d.autoSettleFire(id, entry.timer)
+
+	if !turnIsOwed(d, id) {
+		t.Fatal("turn settled while the working state was held for classification")
+	}
+	if _, ok := autoSettlePending(d, id); ok {
+		t.Fatal("timer survived a classifying fire-time refusal")
 	}
 }
 

--- a/internal/daemon/session_evidence.go
+++ b/internal/daemon/session_evidence.go
@@ -515,6 +515,11 @@ func (d *Daemon) recordClassifierStarted(sessionID string, at time.Time) {
 	d.recordEvidence(sessionID, at, func(e *sessionstate.Evidence) {
 		e.ClassifyingSince = at
 	})
+	// A stop means the last published `working` may now be only the resolver's
+	// awaiting-verdict hold. Suspend auto-settle until the verdict tells us
+	// whether work actually continues. The fire path repeats this check to close
+	// the race with a timer callback that already removed itself from the map.
+	d.cancelAutoSettle(sessionID, "classification started")
 }
 
 // recordClassifierFinished clears that mark. It must run on every exit from a
@@ -524,6 +529,13 @@ func (d *Daemon) recordClassifierFinished(sessionID string) {
 	d.recordEvidence(sessionID, time.Now(), func(e *sessionstate.Evidence) {
 		e.ClassifyingSince = time.Time{}
 	})
+	// No state transition is guaranteed here: a background-working verdict can
+	// leave the persisted state as `working`. Re-evaluate explicitly so that real
+	// continuing work gets the normal full arm and countdown again. Idle and
+	// user-wanted verdicts will move state and cancel it before the arm elapses.
+	if session := d.store.Get(sessionID); session != nil {
+		d.syncAutoSettle(sessionID, string(session.State))
+	}
 }
 
 // runEvidenceResolveLoop re-resolves every session on a tick and publishes the

--- a/internal/sessionstate/sessionstate.go
+++ b/internal/sessionstate/sessionstate.go
@@ -405,7 +405,7 @@ func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
 		if parkedVerdict(e) {
 			return Resolution{State: protocol.SessionStateWorking, Reason: ReasonBackgroundParked}
 		}
-		if verdictPending(e, policy, now) {
+		if ClassifierVerdictPending(e, policy, now) {
 			return Resolution{State: protocol.SessionStateWorking, Reason: ReasonBackgroundWork}
 		}
 		if promptIdleConfirmed(e) {
@@ -524,15 +524,17 @@ func settled(e Evidence, fallback Reason, policy Policy, now time.Time) Resoluti
 	if r, ok := classifierVerdict(e); ok {
 		return r
 	}
-	if verdictPending(e, policy, now) {
+	if ClassifierVerdictPending(e, policy, now) {
 		return Resolution{Hold: true, Reason: ReasonAwaitingVerdict}
 	}
 	return Resolution{State: protocol.SessionStateIdle, Reason: fallback}
 }
 
-// verdictPending reports whether a classification is running and still worth
-// waiting for.
-func verdictPending(e Evidence, policy Policy, now time.Time) bool {
+// ClassifierVerdictPending reports whether a classification is running and
+// still worth waiting for. Consumers outside the resolver use the same bounded
+// definition when they must distinguish confirmed work from a working state the
+// resolver is temporarily holding while the verdict arrives.
+func ClassifierVerdictPending(e Evidence, policy Policy, now time.Time) bool {
 	if e.ClassifyingSince.IsZero() {
 		return false
 	}


### PR DESCRIPTION
## Intent / Why

A session can remain visibly working while its stop-time classifier decides whether the finished turn is idle or needs input. Auto-settle treated that held state as proof that work was continuing, so it could close the turn before the classifier returned and then reopen it when the verdict landed.

## Summary

- suspend an armed auto-settle while stop-time classification is in flight
- repeat the classifier-pending check at timer fire time to close the callback race
- re-evaluate auto-settle after classification so genuine continuing work still gets the normal arm and countdown
- cover both timer/classifier orderings and both live outcomes without changing auto-settle settings or timing policy

## Verification

- full Go test suite
- frontend unit tests: 2,533 passed; 15 skipped
- frontend production build
- Playwright E2E: 191 passed and 1 skipped; one unrelated terminal-rendering case transiently failed, then all 4 cases in that spec passed on an isolated rerun
- packaged-app verification: a classified finished turn kept its owed turn after the countdown appeared; a session that remained working through the full arm and countdown still auto-settled and handed over the next owed turn