### PR TITLE
feat(queue): pause settling during pointer movement

### DIFF
--- a/app/scripts/real-app-harness/InputDriver.swift
+++ b/app/scripts/real-app-harness/InputDriver.swift
@@ -56,7 +56,7 @@ func parseOptions() throws -> Options {
     while index < args.count {
         let arg = args[index]
         switch arg {
-        case "activate", "activate_background", "frontmost", "display_state", "windowid", "windowlist", "text", "key", "keycode", "click", "right_click", "drag", "menu", "window_park", "scroll":
+        case "activate", "activate_background", "frontmost", "display_state", "windowid", "windowlist", "text", "key", "keycode", "move", "click", "right_click", "drag", "menu", "window_park", "scroll":
             options.command = arg
         case "--window-title":
             index += 1
@@ -168,6 +168,7 @@ func parseOptions() throws -> Options {
               InputDriver.swift text --text "hello" [--bundle-id ...] [--prompt-accessibility]
               InputDriver.swift key --key d [--modifiers command,option]
               InputDriver.swift keycode --key-code 36 [--modifiers command]
+              InputDriver.swift move --relative-x 0.75 --relative-y 0.5 [--window-title <substring>]
               InputDriver.swift click --relative-x 0.75 --relative-y 0.5 [--modifiers command] [--window-title <substring>]
               InputDriver.swift menu --path "File>New Session" [--bundle-id ...]
               InputDriver.swift window_park --visible-px 200 [--bundle-id ...] [--window-title <substring>]
@@ -194,7 +195,7 @@ func parseOptions() throws -> Options {
     }
 
     guard options.command != nil else {
-        throw DriverError.usage("Missing command. Use activate, activate_background, frontmost, display_state, windowid, windowlist, text, key, keycode, click, or menu.")
+        throw DriverError.usage("Missing command. Use activate, activate_background, frontmost, display_state, windowid, windowlist, text, key, keycode, move, click, or menu.")
     }
 
     return options
@@ -768,6 +769,30 @@ func clickWindow(bundleId: String, relativeX: Double, relativeY: Double, right: 
     up.post(tap: .cghidEventTap)
 }
 
+func movePointerInWindow(bundleId: String, relativeX: Double, relativeY: Double, titleSubstring: String? = nil) throws {
+    let bounds = try mainWindowBounds(bundleId: bundleId, titleSubstring: titleSubstring)
+    let target = CGPoint(
+        x: bounds.origin.x + bounds.width * min(max(relativeX, 0), 1),
+        y: bounds.origin.y + bounds.height * min(max(relativeY, 0), 1)
+    )
+    let start = CGEvent(source: nil)?.location ?? target
+    // WebKit may coalesce a single teleported mouseMoved event. A short stream
+    // follows the same physical path a real mouse or trackpad would and makes
+    // this command suitable for testing movement itself, not just hover state.
+    for i in 1...6 {
+        let progress = Double(i) / 6.0
+        let point = CGPoint(
+            x: start.x + (target.x - start.x) * progress,
+            y: start.y + (target.y - start.y) * progress
+        )
+        guard let move = CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left) else {
+            throw DriverError.eventCreationFailed("Failed to create mouse move event.")
+        }
+        move.post(tap: .cghidEventTap)
+        Thread.sleep(forTimeInterval: 0.016)
+    }
+}
+
 // Presses the left button at (relativeX, relativeY), drags to
 // (toRelativeX, toRelativeY) in `steps` interpolated leftMouseDragged events
 // ~16ms apart (WebKit ignores teleporting drags for text selection), and
@@ -887,7 +912,7 @@ do {
     // and observation-only commands work fine against a sleeping display and
     // are deliberately left alone.
     switch options.command {
-    case "activate", "text", "key", "keycode", "click", "right_click", "scroll", "drag":
+    case "activate", "text", "key", "keycode", "move", "click", "right_click", "scroll", "drag":
         try requireLiveDisplay()
     default:
         break
@@ -896,7 +921,7 @@ do {
     // HID-based commands must run against a frontmost app; AX-based and
     // observation-only commands must NOT activate (that is the whole point).
     switch options.command {
-    case "activate", "text", "key", "keycode", "click", "right_click", "scroll":
+    case "activate", "text", "key", "keycode", "move", "click", "right_click", "scroll":
         try activateApp(bundleId: options.bundleId)
     default:
         break
@@ -942,6 +967,12 @@ do {
             throw DriverError.invalidArgument("Missing --key-code value")
         }
         try postKeyCode(CGKeyCode(keyCode), modifiers: options.modifiers, targetPid: try runningPID(bundleId: options.bundleId))
+    case "move":
+        try ensureAccessibility(prompt: options.promptAccessibility)
+        guard let relativeX = options.relativeX, let relativeY = options.relativeY else {
+            throw DriverError.invalidArgument("Missing --relative-x/--relative-y for move")
+        }
+        try movePointerInWindow(bundleId: options.bundleId, relativeX: relativeX, relativeY: relativeY, titleSubstring: options.windowTitle)
     case "click":
         try ensureAccessibility(prompt: options.promptAccessibility)
         guard let relativeX = options.relativeX, let relativeY = options.relativeY else {

--- a/app/scripts/real-app-harness/macosDriver.mjs
+++ b/app/scripts/real-app-harness/macosDriver.mjs
@@ -194,6 +194,18 @@ export class MacOSDriver {
     await this.pressKeyCode(36);
   }
 
+  async movePointerInWindow(relativeX, relativeY, opts = {}) {
+    await this.runInputDriver(withWindowTitleArgs([
+      'move',
+      '--relative-x',
+      String(relativeX),
+      '--relative-y',
+      String(relativeY),
+      '--prompt-accessibility',
+    ], opts));
+    await delay(this.actionDelayMs);
+  }
+
   async clickWindow(relativeX, relativeY, opts = {}) {
     const args = [
       'click',

--- a/app/scripts/real-app-harness/scenario-settle-typing-hold.mjs
+++ b/app/scripts/real-app-harness/scenario-settle-typing-hold.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Real-app scenario: typing to an agent freezes its settling countdown.
+ * Real-app scenario: keyboard and pointer activity freeze settling.
  *
  * attn closes a turn for the user once they have steered an agent and it has
  * gone back to work. The countdown that does it used to run regardless of what
@@ -48,6 +48,7 @@ import { DaemonObserver } from './daemonObserver.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 import { createScenarioRunner } from './scenarioRunner.mjs';
 import { currentHarnessProfile } from './harnessProfile.mjs';
+import { MacOSDriver } from './macosDriver.mjs';
 import { preTrustClaudeFolder, ensureClaudePromptReadyViaPty } from './scenarioAgents.mjs';
 import { waitForFirstWorkspacePane } from './scenarioAssertions.mjs';
 
@@ -58,6 +59,16 @@ const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 // produces it — a change to one should make this run fail, not follow it.
 const QUIET_WINDOW_MS = 5_000;
 const COUNTDOWN_SECONDS = 60;
+
+function windowRelativePoint(pageX, pageY, windowBounds, innerWidth, innerHeight) {
+  const { width, height } = windowBounds.logicalBounds;
+  const chromeX = Math.max(0, width - innerWidth);
+  const chromeY = Math.max(0, height - innerHeight);
+  return {
+    relativeX: (chromeX / 2 + pageX) / width,
+    relativeY: (chromeY + pageY) / height,
+  };
+}
 
 function parseArgs(argv) {
   const args = [...argv];
@@ -104,6 +115,10 @@ async function main() {
     throw new Error('the settle-typing-hold scenario does not run against production; set ATTN_PROFILE / ATTN_HARNESS_PROFILE to a named profile');
   }
 
+  if (process.env.ATTN_HARNESS_PARK_VISIBLE_PX === undefined) {
+    process.env.ATTN_HARNESS_PARK_VISIBLE_PX = '800';
+  }
+
   const runner = createScenarioRunner(options, {
     scenarioId: 'SETTLE-TYPING-HOLD',
     tier: 'tier3-local-agent',
@@ -116,6 +131,7 @@ async function main() {
 
   const client = new UiAutomationClient({ appPath: options.appPath });
   const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  const driver = new MacOSDriver({ appPath: options.appPath });
   const note = (message, extra) => runner.log(message, extra);
 
   let agentId = null;
@@ -297,6 +313,60 @@ async function main() {
       note('countdown resumed whole', { remainingMs, chip: resumedChip });
     });
 
+    await runner.step('pointer_movement_freezes_and_extends_the_countdown', async () => {
+      const windowBounds = await client.request('get_window_bounds', {});
+      runner.assert(Boolean(windowBounds?.logicalBounds), `window bounds available: ${JSON.stringify(windowBounds)}`);
+      const cellA = await client.request('get_pane_cell_rect', {
+        sessionId: agentId,
+        paneId: agentPaneId,
+        cell: { row: 2, col: 4 },
+      });
+      const cellB = await client.request('get_pane_cell_rect', {
+        sessionId: agentId,
+        paneId: agentPaneId,
+        cell: { row: 15, col: 40 },
+      });
+      const points = [cellA, cellB].map((cell) => windowRelativePoint(
+        cell.centerX,
+        cell.centerY,
+        windowBounds,
+        cell.innerWidth,
+        cell.innerHeight,
+      ));
+      note('pointer movement targets', { points });
+
+      const until = Date.now() + QUIET_WINDOW_MS * 2.5;
+      let moves = 0;
+      while (Date.now() < until) {
+        // Visit both targets so the step never depends on where the cursor was
+        // left by a previous scenario run. Each pair contains real movement.
+        for (const point of points) {
+          await driver.movePointerInWindow(point.relativeX, point.relativeY);
+          moves += 1;
+        }
+        await delay(2_000);
+        const session = observer.getSession(agentId);
+        runner.assert(
+          session?.auto_settle_held === true && !session?.auto_settle_fires_at,
+          `the countdown stays frozen while the pointer keeps moving (held=${JSON.stringify(session?.auto_settle_held)}, firesAt=${JSON.stringify(session?.auto_settle_fires_at)})`,
+          session,
+        );
+      }
+      note('freeze survived continued pointer movement', { moves, forMs: QUIET_WINDOW_MS * 2.5 });
+
+      const resumed = await pollFor(
+        () => observer.getSession(agentId)?.auto_settle_fires_at ? observer.getSession(agentId) : null,
+        'the countdown to return after pointer movement stopped',
+        QUIET_WINDOW_MS * 4,
+      );
+      const remainingMs = Date.parse(resumed.auto_settle_fires_at) - Date.now();
+      runner.assert(
+        remainingMs > (COUNTDOWN_SECONDS - 10) * 1_000,
+        `pointer quiet returns a whole countdown (${remainingMs}ms of ${COUNTDOWN_SECONDS}s)`,
+        resumed,
+      );
+    });
+
     await runner.step('automation_writes_do_not_freeze_it', async () => {
       // attn typing on the user's behalf — a nudge, a delegation brief, a
       // harness driving a pane — must not hold a countdown open. Same pane, same
@@ -319,7 +389,7 @@ async function main() {
     });
 
     const summary = runner.finishSuccess({ agentId });
-    console.log('[settle-typing-hold] PASS — typing froze the countdown, kept it frozen, and going quiet handed back a whole one.');
+    console.log('[settle-typing-hold] PASS — typing and pointer movement froze the countdown, and going quiet handed back a whole one.');
     console.log(JSON.stringify(summary, null, 2));
   } catch (error) {
     const summary = runner.finishFailure(error, { agentId });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -825,6 +825,7 @@ function AppContent({
     tileContents,
     requestTileContent,
     sendRuntimeInput,
+    sendTerminalPointerActivity,
     sendSetTerminalTheme,
     isRuntimeAttached,
     getRepoInfo,
@@ -3806,6 +3807,7 @@ function AppContent({
                     annotationApi={annotationApi}
                     onTriggerNudge={sendTriggerNudge}
                     onCancelCountdown={sendCancelCountdown}
+                    onTerminalPointerActivity={sendTerminalPointerActivity}
                     onOpenPresentation={handleOpenPresentationWindow}
                     onOpenMarkdown={(path, sessionId) => {
                       void sendOpenMarkdown(path, sessionId).catch((error) => {

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -152,6 +152,10 @@ export interface GhosttyTerminalProps {
     paneCount: number;
   };
   onInput: (data: string) => void;
+  // User pointer movement inside this terminal. Kept separate from onInput:
+  // application-mouse bytes belong to the TUI, while this signal only keeps an
+  // auto-settle countdown from closing under an engaged user.
+  onPointerActivity?: () => void;
   // Cmd+click on a markdown file path routes here (docking an in-app markdown
   // tile) instead of opening the OS default app. sessionId is the pane's
   // session, or '' when the pane has none (the daemon falls back to the
@@ -645,7 +649,7 @@ function cellText(
 }
 
 export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminalProps>(
-  function GhosttyTerminal({ fontSize, resolvedTheme = 'dark', debugName, cwd, runtimeLogMeta, onInput, onOpenMarkdown, onReady, onResize, onReplayInterrupted, onTerminalModelRecovered, annotations, annotationsVersion = 0, onAnnotationAnchor, onAnnotationMiss, onAnnotationActivate }, ref) {
+  function GhosttyTerminal({ fontSize, resolvedTheme = 'dark', debugName, cwd, runtimeLogMeta, onInput, onPointerActivity, onOpenMarkdown, onReady, onResize, onReplayInterrupted, onTerminalModelRecovered, annotations, annotationsVersion = 0, onAnnotationAnchor, onAnnotationMiss, onAnnotationActivate }, ref) {
     const containerRef = useRef<HTMLDivElement>(null);
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const terminalRef = useRef<GhosttyModel | null>(null);
@@ -765,6 +769,8 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const readyRef = useRef(false);
     const startupRef = useRef(emptyStartup());
     const onInputRef = useRef(onInput);
+    const onPointerActivityRef = useRef(onPointerActivity);
+    const lastPointerActivityAtRef = useRef(Number.NEGATIVE_INFINITY);
     const onOpenMarkdownRef = useRef(onOpenMarkdown);
     const onReadyRef = useRef(onReady);
     const onResizeRef = useRef(onResize);
@@ -827,6 +833,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const fontSizeRef = useRef(fontSize);
 
     onInputRef.current = onInput;
+    onPointerActivityRef.current = onPointerActivity;
     onOpenMarkdownRef.current = onOpenMarkdown;
     onReadyRef.current = onReady;
     onResizeRef.current = onResize;
@@ -3781,6 +3788,15 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           startSelectionDrag();
         }}
         onMouseMove={(event) => {
+          // Pointer activity is intentionally sampled rather than sent for
+          // every pixel. The daemon's five-second quiet window only needs a
+          // recent proof of engagement; four samples a second keeps its edge
+          // accurate without turning ordinary mouse movement into wire spam.
+          const pointerActivityAt = performance.now();
+          if (pointerActivityAt - lastPointerActivityAtRef.current >= 250) {
+            lastPointerActivityAtRef.current = pointerActivityAt;
+            onPointerActivityRef.current?.();
+          }
           if (isWorkspaceResizeActive(containerRef.current)) {
             event.preventDefault();
             event.stopPropagation();

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -833,7 +833,6 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const fontSizeRef = useRef(fontSize);
 
     onInputRef.current = onInput;
-    onPointerActivityRef.current = onPointerActivity;
     onOpenMarkdownRef.current = onOpenMarkdown;
     onReadyRef.current = onReady;
     onResizeRef.current = onResize;
@@ -852,6 +851,10 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     // debugName can change (its agent/title segment is reassigned on relabel).
     // A ref keeps the key out of callback dependency arrays.
     diagKeyRef.current = runtimeLogMeta?.paneId ?? runtimeLogMeta?.sessionId ?? debugName;
+
+    useEffect(() => {
+      onPointerActivityRef.current = onPointerActivity;
+    }, [onPointerActivity]);
 
     const recoverFromModelFault = useCallback((operation: string, reason: unknown) => {
       // An invalid model can make several queued render/write operations fail

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.pointerActivity.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.pointerActivity.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { SessionTerminalWorkspace } from './index';
+import { createPaneRuntimeEventRouterController } from './paneRuntimeEventRouter';
+import type { TerminalWorkspaceState } from '../../types/workspace';
+
+vi.mock('../GhosttyTerminal', async () => {
+  const React = await import('react');
+  return {
+    GhosttyTerminal: React.forwardRef(function MockTerminal(
+      props: { onPointerActivity?: () => void },
+      _ref: React.Ref<unknown>,
+    ) {
+      return <div data-testid="terminal" onMouseMove={props.onPointerActivity} />;
+    }),
+  };
+});
+
+const workspace: TerminalWorkspaceState = {
+  agents: [{ id: 'pane-1', runtimeId: 'rt-1', sessionId: 'sess-1', title: 'agent' }],
+  layoutTree: { type: 'pane', paneId: 'pane-1' },
+};
+
+describe('SessionTerminalWorkspace pointer activity', () => {
+  it('attributes terminal movement to that pane session', () => {
+    const onTerminalPointerActivity = vi.fn();
+    render(
+      <SessionTerminalWorkspace
+        workspaceId="workspace-1"
+        workspaceSessions={[{ id: 'sess-1', label: 'agent', agent: 'claude', cwd: '/tmp/project' }]}
+        workspace={workspace}
+        activePaneId="pane-1"
+        fontSize={13}
+        enabled
+        isActiveSession
+        eventRouter={createPaneRuntimeEventRouterController()}
+        onSplitPane={vi.fn()}
+        onClosePane={vi.fn()}
+        onFocusPane={vi.fn()}
+        onNavigateOutOfSession={vi.fn()}
+        onTerminalPointerActivity={onTerminalPointerActivity}
+      />,
+    );
+
+    fireEvent.mouseMove(screen.getByTestId('terminal'));
+
+    expect(onTerminalPointerActivity).toHaveBeenCalledWith('sess-1');
+  });
+});

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -125,8 +125,8 @@ interface SessionTerminalWorkspaceProps {
     // The deadline an auto-settle countdown will close this session's turn at.
     // Present only while one is running; the daemon owns the timer.
     autoSettleFiresAt?: string;
-    // True while that countdown is frozen because the user is typing into this
-    // session. Mutually exclusive with the deadline above.
+    // True while that countdown is frozen because the user is typing or moving
+    // the pointer in this session. Mutually exclusive with the deadline above.
     autoSettleHeld?: boolean;
     isActive?: boolean;
     presentation?: Presentation;
@@ -179,6 +179,7 @@ interface SessionTerminalWorkspaceProps {
   // Keep the turn an auto-settle countdown is about to close. Clicking the chip
   // is the pointer equivalent of the ⌘. shortcut.
   onCancelCountdown?: (sessionId: string) => void;
+  onTerminalPointerActivity?: (sessionId: string) => void;
   onOpenPresentation?: (presentationId: string) => void;
   // Cmd+click on a markdown path inside a pane's terminal: dock it as a
   // markdown tile bound to that pane's session (empty sessionId = let the
@@ -236,6 +237,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     onRenameSession,
     onTriggerNudge,
     onCancelCountdown,
+    onTerminalPointerActivity,
     onOpenPresentation,
     onOpenMarkdown,
     onTerminalModelRecovered,
@@ -1052,6 +1054,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
                   debugName={`agent:${paneTitle}:${paneSession?.agent ?? 'shell'}:${agentPane.sessionId}`}
                   runtimeLogMeta={{ sessionId: agentPane.sessionId, paneId: agentPane.id, runtimeId: agentPane.runtimeId, paneKind: 'agent', isActivePane: activePaneId === agentPane.id, isActiveSession, paneCount: paneIds.length }}
                   onInput={runtime.handleTerminalInput(agentPane.id)}
+                  onPointerActivity={() => onTerminalPointerActivity?.(agentPane.sessionId)}
                   onOpenMarkdown={onOpenMarkdown}
                   onReady={handleGhosttyTerminalReady(agentPane.id)}
                   onResize={runtime.handleTerminalResize(agentPane.id)}

--- a/app/src/components/SettlingIndicator.css
+++ b/app/src/components/SettlingIndicator.css
@@ -123,7 +123,7 @@
   box-shadow: 0 0 9px 1px rgba(var(--settling-accent), 0.7);
 }
 
-/* ---- Held: the user is typing, so the countdown is frozen ----
+/* ---- Held: the user is interacting, so the countdown is frozen ----
 
    The bar keeps its full width and stops moving; the chip dims and its dot stops
    pulsing. Frozen has to read as "still here, not running" rather than as a

--- a/app/src/components/SettlingIndicator.test.tsx
+++ b/app/src/components/SettlingIndicator.test.tsx
@@ -52,7 +52,7 @@ describe('HeaderSettlingIndicator', () => {
     expect(onPointerDown).not.toHaveBeenCalled();
   });
 
-  describe('held — the user is typing and the daemon has frozen the countdown', () => {
+  describe('held — the user is interacting and the daemon has frozen the countdown', () => {
     it('says it is paused, and animates nothing', () => {
       const { container } = render(<HeaderSettlingIndicator held />);
       expect(screen.getByTestId('settling-indicator')).toHaveTextContent('Settling paused');

--- a/app/src/components/SettlingIndicator.tsx
+++ b/app/src/components/SettlingIndicator.tsx
@@ -15,11 +15,11 @@ import { CountdownCancelHint } from './CountdownCancelHint';
  * is something you notice from across the screen, which is the only way an
  * indicator on a tile you are not focused on does its job.
  *
- * `auto_settle_held` is the same countdown with the user's hands on the keyboard:
- * the daemon has frozen it and sent no deadline, so the bar draws full and still.
- * A full bar rather than a partial one because there is nothing to be partial
- * about — the deadline is gone, and when typing stops the daemon sends a whole new
- * one, which is exactly what a full frozen bar promises.
+ * `auto_settle_held` is the same countdown while the user is interacting with the
+ * terminal: the daemon has frozen it and sent no deadline, so the bar draws full
+ * and still. A full bar rather than a partial one because there is nothing to be
+ * partial about — the deadline is gone, and after the user goes quiet the daemon
+ * sends a whole new one, which is exactly what a full frozen bar promises.
  *
  * Two homes, so a countdown is never invisible. The pane header is the primary
  * one — the tile is where you are looking when you steered the agent. The sidebar

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -1627,6 +1627,53 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     unmount();
   });
 
+  it('drops terminal pointer activity until the daemon is ready', async () => {
+    const { result, unmount } = renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate: vi.fn(),
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        wsUrl: 'ws://localhost:9999/ws',
+      }),
+    );
+    const ws = await waitForOpenSocket();
+
+    result.current.sendTerminalPointerActivity('session-pointer');
+    expect(ws.sent.map((entry) => JSON.parse(entry))).not.toContainEqual({
+      cmd: 'terminal_pointer_activity',
+      id: 'session-pointer',
+    });
+
+    act(() => {
+      ws.emit({
+        event: 'initial_state',
+        protocol_version: PROTOCOL_VERSION,
+        sessions: [],
+        workspaces: [],
+        prs: [],
+        repos: [],
+        authors: [],
+        settings: {},
+      });
+    });
+    expect(ws.sent.map((entry) => JSON.parse(entry))).not.toContainEqual({
+      cmd: 'terminal_pointer_activity',
+      id: 'session-pointer',
+    });
+
+    act(() => {
+      result.current.sendTerminalPointerActivity('session-pointer');
+    });
+    expect(ws.sent.map((entry) => JSON.parse(entry))).toContainEqual({
+      cmd: 'terminal_pointer_activity',
+      id: 'session-pointer',
+    });
+
+    unmount();
+  });
+
   it('correlates overlapping resize results for the same split by request id', async () => {
     const { result, unmount } = renderHook(() =>
       useDaemonSocket({

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -199,7 +199,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '213';
+export const PROTOCOL_VERSION = '214';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a
@@ -2998,6 +2998,17 @@ export function useDaemonSocket({
     );
   }, [sendOrQueueCommand]);
 
+  const sendTerminalPointerActivity = useCallback((id: string) => {
+    // This is an ephemeral recency signal, not input that must be replayed.
+    // Dropping it while disconnected avoids an idle reconnect accumulating and
+    // later flushing a burst of stale mouse movements.
+    const ws = wsRef.current;
+    if (!hasReceivedInitialStateRef.current || !ws || ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    ws.send(JSON.stringify({ cmd: 'terminal_pointer_activity', id }));
+  }, []);
+
   // Sends a prompt to a conversation session's host. Fire-and-forget in the
   // same sense as pty_input: the answer is not a result message but the
   // envelope stream the host starts producing, which lands in the conversations
@@ -5159,6 +5170,7 @@ export function useDaemonSocket({
     requestTileContent,
     sendOpenMarkdown,
     sendRuntimeInput: sendPtyInput,
+    sendTerminalPointerActivity,
     sendSetTerminalTheme,
     isRuntimeAttached,
     sendGetFileDiff,

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -600,7 +600,7 @@ function collectSessionUiState(
   // carries either a deadline or the frozen flag, never both, and only the DOM
   // can testify that the tile drew the one it was sent — a running countdown
   // animating against a deadline, or a still full bar that says attn is waiting
-  // for the user to stop typing.
+  // for the user to stop interacting.
   const settlingChip = firstAgentPane?.querySelector('[data-testid="settling-indicator"]') ?? null;
   const settlingFill = firstAgentPane?.querySelector('.settling-header-track-fill') ?? null;
   const workspaceId = session.workspaceId;

--- a/changelog.d/frosty-tapir-pointer-pauses-settling.yaml
+++ b/changelog.d/frosty-tapir-pointer-pauses-settling.yaml
@@ -1,0 +1,8 @@
+kind: changed
+area: queue
+change: >
+  Moving the pointer over an agent now pauses its settling countdown just like
+  typing does. Keep interacting and the paused indicator stays put; five quiet
+  seconds after the last movement, the whole countdown returns. The new settling
+  signal adds no terminal input for the agent and does not delay ticket nudges
+  meant to avoid half-typed prompts.

--- a/internal/daemon/auto_settle.go
+++ b/internal/daemon/auto_settle.go
@@ -39,14 +39,14 @@ const (
 	// before the turn is settled.
 	defaultAutoSettleCountdownSeconds = 15
 
-	// autoSettleHoldQuietWindow is how long a session must go without a keystroke
-	// before a held countdown resumes. It is the whole of the typing hold's
-	// tuning, and it is not a setting: it measures the user's hands, not the
+	// autoSettleHoldQuietWindow is how long a session must go without user activity
+	// before a held countdown resumes. It is the whole of the interaction hold's
+	// tuning, and it is not a setting: it measures the user's attention, not the
 	// agent's behavior, so it is orthogonal to the two windows above.
 	//
 	// Five seconds rather than the nudge guard's three, and rather than something
-	// generous. It only has to span the gaps *between* keystrokes while composing
-	// — pausing to read the screen mid-prompt — because the countdown it resumes
+	// generous. It only has to span gaps in active keyboard or pointer interaction
+	// because the countdown it resumes
 	// into is itself the grace period, visible and cancellable. Stacking a long
 	// quiet window on top of that pays twice for the same protection, and being
 	// wrong here does not settle a turn silently: it unfreezes a bar the user
@@ -73,9 +73,9 @@ const (
 	autoSettleArming autoSettlePhase = iota
 	// autoSettleCounting: the countdown is running and its deadline is broadcast.
 	autoSettleCounting
-	// autoSettleHeld: the user is typing into this session, so nothing is
+	// autoSettleHeld: the user is interacting with this session, so nothing is
 	// counting. The pending timer is a quiet check, not a deadline — it asks
-	// "have the keystrokes stopped?" and either re-holds or resumes. No deadline
+	// "has the interaction stopped?" and either re-holds or resumes. No deadline
 	// rides the wire; `auto_settle_held` does, and the tile freezes on it.
 	autoSettleHeld
 )
@@ -86,8 +86,8 @@ const (
 // against.
 //
 // resume is meaningful only while held: it is the phase the hold came from and
-// will return to, so that typing during the invisible arm delay restarts the arm
-// delay rather than promoting the session to a countdown it never earned.
+// will return to, so that activity during the invisible arm delay restarts the
+// arm delay rather than promoting the session to a countdown it never earned.
 type autoSettleTimer struct {
 	timer   *time.Timer
 	phase   autoSettlePhase
@@ -201,8 +201,9 @@ func (d *Daemon) armAutoSettle(sessionID string) {
 	// No broadcast: the arming phase is deliberately invisible.
 }
 
-// holdAutoSettle freezes a pending settle because the user just typed into this
-// session. Called for every genuine keystroke, so its cost on a no-op is one map
+// holdAutoSettle freezes a pending settle because the user just interacted with
+// this session. Called for genuine keyboard and throttled pointer activity, so
+// its cost on a no-op is one map
 // lookup.
 //
 // Typing is the one thing attn can see through a TUI it has no visibility into.
@@ -409,15 +410,15 @@ func (d *Daemon) runAutoSettle(sessionID string, phase, resume autoSettlePhase) 
 		return "not-owed"
 	}
 
-	// A phase that only moves the timer along can take the typing hold as a plain
-	// check: nothing is committed on the far side of it, so a keystroke that
+	// A phase that only moves the timer along can take the interaction hold as a
+	// plain check: nothing is committed on the far side of it, so activity that
 	// arrives a moment later still meets a pending timer and freezes it there.
 	if phase == autoSettleHeld || phase == autoSettleArming {
 		hold := phase
 		if phase == autoSettleHeld {
 			hold = resume
 		}
-		if quiet := d.userInputQuietRemaining(sessionID, autoSettleHoldQuietWindow); quiet > 0 {
+		if quiet := d.autoSettleActivityQuietRemaining(sessionID, autoSettleHoldQuietWindow); quiet > 0 {
 			d.holdFromFire(sessionID, hold, quiet)
 			return "held"
 		}
@@ -451,12 +452,12 @@ func (d *Daemon) runAutoSettle(sessionID string, phase, resume autoSettlePhase) 
 		d.autoSettlePreSettleHook()
 	}
 
-	// The countdown ran out, so this is where the turn closes. The typing hold is
+	// The countdown ran out, so this is where the turn closes. The activity hold is
 	// re-asked here rather than above because it has to be indivisible from the
-	// write it guards — settleIfQuiet holds the keystroke lock across both — and
-	// because the countdown timer can have fired in the microseconds around a
-	// keystroke, before holdAutoSettle could stop it.
-	quiet, settled := d.settleIfQuiet(sessionID, autoSettleHoldQuietWindow)
+	// write it guards — settleIfAutoSettleQuiet holds the activity lock across both — and
+	// because the countdown timer can have fired in the microseconds around an
+	// activity report, before holdAutoSettle could stop it.
+	quiet, settled := d.settleIfAutoSettleQuiet(sessionID, autoSettleHoldQuietWindow)
 	if quiet > 0 {
 		d.holdFromFire(sessionID, autoSettleCounting, quiet)
 		return "held"
@@ -468,8 +469,8 @@ func (d *Daemon) runAutoSettle(sessionID string, phase, resume autoSettlePhase) 
 	return "settled"
 }
 
-// holdFromFire parks a session the fire path found the user typing into, with a
-// quiet check exactly at the end of the window their last keystroke opened.
+// holdFromFire parks a session the fire path found the user interacting with,
+// with a quiet check exactly at the end of the window their last activity opened.
 func (d *Daemon) holdFromFire(sessionID string, resume autoSettlePhase, quiet time.Duration) {
 	d.autoSettleMu.Lock()
 	d.startAutoSettleHeldLocked(sessionID, resume, quiet)
@@ -506,7 +507,7 @@ func (d *Daemon) cancelAutoSettleByUser(sessionID string) bool {
 }
 
 // decorateSessionWithAutoSettle stamps the broadcast clone with the countdown
-// deadline while one is running, or the held flag while the user is typing. The
+// deadline while one is running, or the held flag while the user is interacting.
 // two are mutually exclusive by construction — a frozen countdown has no
 // deadline to animate against, and that is the point — so a client never has to
 // decide which one wins. Read under autoSettleMu; callers must not already hold

--- a/internal/daemon/auto_settle_test.go
+++ b/internal/daemon/auto_settle_test.go
@@ -539,12 +539,19 @@ func typeIntoAs(d *Daemon, sessionID, source string) {
 	d.handlePtyInput(nil, msg)
 }
 
-// goQuiet backdates the session's last keystroke so the quiet window has
-// elapsed, standing in for the user taking their hands off the keyboard.
+// goQuiet backdates the session's last auto-settle activity so the quiet window
+// has elapsed, standing in for the user taking their hands off the session.
 func goQuiet(d *Daemon, sessionID string) {
 	d.lastInputMu.Lock()
 	defer d.lastInputMu.Unlock()
-	d.lastUserInputAt[sessionID] = time.Now().Add(-2 * autoSettleHoldQuietWindow)
+	d.lastAutoSettleActivityAt[sessionID] = time.Now().Add(-2 * autoSettleHoldQuietWindow)
+}
+
+func movePointerIn(d *Daemon, sessionID string) {
+	d.handleTerminalPointerActivity(&protocol.TerminalPointerActivityMessage{
+		Cmd: protocol.CmdTerminalPointerActivity,
+		ID:  sessionID,
+	})
 }
 
 // The feature in one pass: typing freezes a running countdown, the freeze is
@@ -629,10 +636,10 @@ func TestAutoSettle_KeystrokeRacingTheFireHoldsInsteadOfSettling(t *testing.T) {
 	// Record the keystroke without holding: exactly the window in which the timer
 	// has already been pulled out of the map and is on its way to the settle.
 	d.lastInputMu.Lock()
-	if d.lastUserInputAt == nil {
-		d.lastUserInputAt = make(map[string]time.Time)
+	if d.lastAutoSettleActivityAt == nil {
+		d.lastAutoSettleActivityAt = make(map[string]time.Time)
 	}
-	d.lastUserInputAt[id] = time.Now()
+	d.lastAutoSettleActivityAt[id] = time.Now()
 	d.lastInputMu.Unlock()
 
 	var outcome string
@@ -644,6 +651,66 @@ func TestAutoSettle_KeystrokeRacingTheFireHoldsInsteadOfSettling(t *testing.T) {
 	}
 	if !turnIsOwed(d, id) {
 		t.Fatal("turn settled by a countdown that fired into a keystroke")
+	}
+}
+
+func TestAutoSettle_PointerMovementFreezesTheCountdownWithoutClaimingTyping(t *testing.T) {
+	d, id := newAutoSettleDaemon(t)
+	if !d.applyState(sessionStateChange{sessionID: id, state: protocol.StateWorking, cause: liveSignal{}}) {
+		t.Fatal("applyState(working) = false")
+	}
+	fireAutoSettleNow(t, d, id)
+
+	movePointerIn(d, id)
+
+	held, ok := autoSettlePending(d, id)
+	if !ok || held.phase != autoSettleHeld || held.resume != autoSettleCounting {
+		t.Fatalf("after pointer movement: pending=%v entry=%+v, want held(resume=counting)", ok, held)
+	}
+	if d.recentUserInput(id, time.Hour) {
+		t.Fatal("pointer movement was recorded as keyboard input; it would delay ticket nudges")
+	}
+	if !protocol.Deref(d.sessionForBroadcast(d.store.Get(id)).AutoSettleHeld) {
+		t.Fatal("auto_settle_held absent after pointer movement")
+	}
+
+	movePointerIn(d, id)
+	fireAutoSettleNow(t, d, id)
+	if pending, ok := autoSettlePending(d, id); !ok || pending.phase != autoSettleHeld {
+		t.Fatalf("fresh pointer movement did not extend the hold: pending=%v entry=%+v", ok, pending)
+	}
+
+	goQuiet(d, id)
+	fireAutoSettleNow(t, d, id)
+	if resumed, ok := autoSettlePending(d, id); !ok || resumed.phase != autoSettleCounting {
+		t.Fatalf("after pointer quiet: pending=%v entry=%+v, want counting", ok, resumed)
+	}
+}
+
+func TestAutoSettle_PointerMovementInsideTheSettleStillHoldsIt(t *testing.T) {
+	d, id := newAutoSettleDaemon(t)
+	if !d.applyState(sessionStateChange{sessionID: id, state: protocol.StateWorking, cause: liveSignal{}}) {
+		t.Fatal("applyState(working) = false")
+	}
+	fireAutoSettleNow(t, d, id)
+
+	moved := false
+	d.autoSettlePreSettleHook = func() {
+		if moved {
+			return
+		}
+		moved = true
+		movePointerIn(d, id)
+	}
+	var outcome string
+	d.autoSettleFireHook = func(_, action string) { outcome = action }
+	fireAutoSettleNow(t, d, id)
+
+	if !moved || outcome != "held" {
+		t.Fatalf("pointer race: moved=%v outcome=%q, want true/held", moved, outcome)
+	}
+	if !turnIsOwed(d, id) {
+		t.Fatal("turn settled around pointer activity that landed before the settle committed")
 	}
 }
 

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -109,6 +109,7 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdDetachSession:                         commandMetadata(ScopeSession, true, true),
 	protocol.CmdGetKittyImage:                         commandMetadata(ScopeSession, false, true),
 	protocol.CmdPtyInput:                              commandMetadata(ScopeSession, true, false),
+	protocol.CmdTerminalPointerActivity:               commandMetadata(ScopeSession, false, false),
 	protocol.CmdAgentPrompt:                           commandMetadata(ScopeSession, true, false),
 	protocol.CmdPtyResize:                             commandMetadata(ScopeSession, true, true),
 	protocol.CmdKillSession:                           commandMetadata(ScopeSession, true, true),

--- a/internal/daemon/command_meta_test.go
+++ b/internal/daemon/command_meta_test.go
@@ -10,6 +10,9 @@ func TestCommandMetaExamples(t *testing.T) {
 	if meta := CommandMeta[protocol.CmdPtyInput]; meta.Scope != ScopeSession {
 		t.Fatalf("pty_input scope = %v, want %v", meta.Scope, ScopeSession)
 	}
+	if meta := CommandMeta[protocol.CmdTerminalPointerActivity]; meta.Scope != ScopeSession {
+		t.Fatalf("terminal_pointer_activity scope = %v, want %v", meta.Scope, ScopeSession)
+	}
 	if meta := CommandMeta[protocol.CmdSpawnSession]; meta.Scope != ScopeEndpoint {
 		t.Fatalf("spawn_session scope = %v, want %v", meta.Scope, ScopeEndpoint)
 	}
@@ -24,6 +27,9 @@ func TestCommandMetaExamples(t *testing.T) {
 	}
 	if shouldLogWSCommand(protocol.CmdPtyInput) {
 		t.Fatal("pty_input should be excluded from normal websocket command logging")
+	}
+	if shouldLogWSCommand(protocol.CmdTerminalPointerActivity) {
+		t.Fatal("terminal_pointer_activity should be excluded from normal websocket command logging")
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -254,6 +254,7 @@ type Daemon struct {
 	ticketRebuildBeforeArmHook func(sessionID string, deadline time.Time) // tests only: invoked while deliveryMu is held
 	lastInputMu                sync.Mutex
 	lastUserInputAt            map[string]time.Time // per-session keystroke recency — the fire-time splice guard
+	lastAutoSettleActivityAt   map[string]time.Time // per-session keyboard/pointer recency — the auto-settle hold
 	// autoSettleFireMu serializes the auto-settle timer's fire-time decision
 	// against the state write in applyState. Without it the timer can read a
 	// `working`, owed turn, have a transition into waiting_input commit

--- a/internal/daemon/nudge_countdown.go
+++ b/internal/daemon/nudge_countdown.go
@@ -299,6 +299,7 @@ func (d *Daemon) clearNudgeState(sessionID string) {
 	d.nudgeMu.Unlock()
 	d.lastInputMu.Lock()
 	delete(d.lastUserInputAt, sessionID)
+	delete(d.lastAutoSettleActivityAt, sessionID)
 	d.lastInputMu.Unlock()
 	d.deliveryMu.Lock()
 	delete(d.watchLeaseUntil, sessionID)
@@ -497,9 +498,9 @@ func (d *Daemon) handleTriggerNudge(msg *protocol.TriggerNudgeMessage) {
 // caller can hang further reactions off the same verdict instead of re-deriving
 // who typed.
 //
-// Two mechanisms read the stamp, for opposite reasons: the nudge splice guard,
-// so a doorbell never lands on a half-typed line, and auto-settle's typing hold,
-// so a turn is not closed under the user's hands.
+// It also records the same instant as auto-settle activity. Pointer movement
+// records only that second stamp: it means the user is engaged with the agent,
+// but cannot splice a doorbell onto a half-typed line.
 func (d *Daemon) noteUserInput(sessionID, source string) bool {
 	if sessionID == "" || !isUserKeystrokeSource(source) {
 		return false
@@ -509,7 +510,28 @@ func (d *Daemon) noteUserInput(sessionID, source string) bool {
 	if d.lastUserInputAt == nil {
 		d.lastUserInputAt = make(map[string]time.Time)
 	}
+	if d.lastAutoSettleActivityAt == nil {
+		d.lastAutoSettleActivityAt = make(map[string]time.Time)
+	}
 	d.lastUserInputAt[sessionID] = now
+	d.lastAutoSettleActivityAt[sessionID] = now
+	d.lastInputMu.Unlock()
+	return true
+}
+
+// noteAutoSettleActivity records user engagement that should freeze a pending
+// settle without claiming that the user typed into the PTY. It shares
+// lastInputMu with settleIfAutoSettleQuiet so activity arriving before the turn
+// closes always wins the race.
+func (d *Daemon) noteAutoSettleActivity(sessionID string) bool {
+	if sessionID == "" {
+		return false
+	}
+	d.lastInputMu.Lock()
+	if d.lastAutoSettleActivityAt == nil {
+		d.lastAutoSettleActivityAt = make(map[string]time.Time)
+	}
+	d.lastAutoSettleActivityAt[sessionID] = time.Now()
 	d.lastInputMu.Unlock()
 	return true
 }
@@ -531,8 +553,7 @@ func (d *Daemon) userInputQuietRemaining(sessionID string, within time.Duration)
 }
 
 // userInputQuietRemainingLocked is the same reading, for a caller that already
-// holds lastInputMu because it needs the answer and its own next step to be
-// indivisible from recording a keystroke. See settleIfQuiet.
+// holds lastInputMu.
 func (d *Daemon) userInputQuietRemainingLocked(sessionID string, within time.Duration) time.Duration {
 	last, ok := d.lastUserInputAt[sessionID]
 	if !ok {
@@ -545,30 +566,48 @@ func (d *Daemon) userInputQuietRemainingLocked(sessionID string, within time.Dur
 	return remaining
 }
 
-// settleIfQuiet is auto-settle's commit: the only place a timer closes a turn,
-// and the reason the typing hold is airtight rather than merely likely.
+func (d *Daemon) autoSettleActivityQuietRemaining(sessionID string, within time.Duration) time.Duration {
+	d.lastInputMu.Lock()
+	defer d.lastInputMu.Unlock()
+	return d.autoSettleActivityQuietRemainingLocked(sessionID, within)
+}
+
+func (d *Daemon) autoSettleActivityQuietRemainingLocked(sessionID string, within time.Duration) time.Duration {
+	last, ok := d.lastAutoSettleActivityAt[sessionID]
+	if !ok {
+		return 0
+	}
+	remaining := within - time.Since(last)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+// settleIfAutoSettleQuiet is auto-settle's commit: the only place a timer closes
+// a turn, and the reason the activity hold is airtight rather than merely likely.
 //
 // The quiet check and the store write happen in one critical section, under the
-// same lock noteUserInput records a keystroke with. That is what makes the two
+// same lock keyboard and pointer activity use. That is what makes the two
 // indivisible. Checking first and settling afterwards — however few instructions
-// apart — leaves a gap a real keystroke can land in: it would be stamped after
+// apart — leaves a gap a real interaction can land in: it would be stamped after
 // the guard had already looked, and the hold that follows it finds the timer
 // gone from the map and does nothing, so the turn closes with the user's hands
-// on the keyboard. Serialized, a key pressed before the settle commits is always
-// seen by the check that guards it, and a key that loses was pressed after the
-// turn had already closed — which is honest, and unavoidable in any design.
+// on the session. Serialized, activity before the settle commits is always seen
+// by the check that guards it, and activity that loses happened after the turn
+// had already closed — which is honest, and unavoidable in any design.
 //
 // The lock spans a store write, so the scope is worth stating plainly: the only
-// way to contend for it is to type in the instant a settle commits, and a settle
-// only commits after `within` of silence. The single keystroke that could ever
-// wait on one primary-key update is the one this exists to protect.
+// way to contend for it is to interact in the instant a settle commits, and a
+// settle only commits after `within` of silence. The single activity report that
+// could ever wait on one primary-key update is the one this exists to protect.
 //
 // Reports the remaining quiet time when it refuses, so the caller can reschedule
 // exactly to the end of the window, and whether the turn was actually settled.
-func (d *Daemon) settleIfQuiet(sessionID string, within time.Duration) (quiet time.Duration, settled bool) {
+func (d *Daemon) settleIfAutoSettleQuiet(sessionID string, within time.Duration) (quiet time.Duration, settled bool) {
 	d.lastInputMu.Lock()
 	defer d.lastInputMu.Unlock()
-	if remaining := d.userInputQuietRemainingLocked(sessionID, within); remaining > 0 {
+	if remaining := d.autoSettleActivityQuietRemainingLocked(sessionID, within); remaining > 0 {
 		return remaining, false
 	}
 	return 0, d.store.SettleTurn(sessionID, time.Now())

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -1135,6 +1135,8 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleGetKittyImage(client, msg.(*protocol.GetKittyImageMessage))
 	case protocol.CmdPtyInput: // wire: pty_input
 		d.handlePtyInput(client, msg.(*protocol.PtyInputMessage))
+	case protocol.CmdTerminalPointerActivity: // wire: terminal_pointer_activity
+		d.handleTerminalPointerActivity(msg.(*protocol.TerminalPointerActivityMessage))
 	case protocol.CmdAgentPrompt: // wire: agent_prompt
 		d.handleAgentPrompt(client, msg.(*protocol.AgentPromptMessage))
 	case protocol.CmdPtyResize: // wire: pty_resize
@@ -1548,6 +1550,10 @@ func remoteCommandPTYTargetID(cmd string, msg interface{}) string {
 		}
 	case protocol.CmdPtyInput: // wire: pty_input
 		if typed, ok := msg.(*protocol.PtyInputMessage); ok {
+			return typed.ID
+		}
+	case protocol.CmdTerminalPointerActivity: // wire: terminal_pointer_activity
+		if typed, ok := msg.(*protocol.TerminalPointerActivityMessage); ok {
 			return typed.ID
 		}
 	case protocol.CmdAgentPrompt: // wire: agent_prompt

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -654,6 +654,12 @@ func (d *Daemon) handlePtyInput(client *wsClient, msg *protocol.PtyInputMessage)
 	}
 }
 
+func (d *Daemon) handleTerminalPointerActivity(msg *protocol.TerminalPointerActivityMessage) {
+	if d.noteAutoSettleActivity(msg.ID) {
+		d.holdAutoSettle(msg.ID)
+	}
+}
+
 // ptyGeometry is the payload of FactSessionPTYResized. The new size is not
 // derivable from the store, so the fact carries it. XPixel/YPixel are the
 // pane's total size in device pixels, 0 when the resizing client reported none.

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "213"
+const ProtocolVersion = "214"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only
@@ -231,6 +231,7 @@ const (
 	CmdGetScreenSnapshot                     = "get_screen_snapshot"
 	CmdGetKittyImage                         = "get_kitty_image"
 	CmdPtyInput                              = "pty_input"
+	CmdTerminalPointerActivity               = "terminal_pointer_activity"
 	CmdAgentPrompt                           = "agent_prompt"
 	CmdPtyResize                             = "pty_resize"
 	CmdKillSession                           = "kill_session"
@@ -1541,6 +1542,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 		var msg PtyInputMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, fmt.Errorf("unmarshal pty_input: %w", err)
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdTerminalPointerActivity:
+		var msg TerminalPointerActivityMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, fmt.Errorf("unmarshal terminal_pointer_activity: %w", err)
 		}
 		return peek.Cmd, &msg, nil
 

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -5269,6 +5269,14 @@ type TasksChangedMessage struct {
 	Event string `json:"event"`
 }
 
+type TerminalPointerActivityMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
+}
+
 type Ticket struct {
 	// Activity corresponds to the JSON schema field "activity".
 	Activity []TicketActivity `json:"activity"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -140,7 +140,7 @@ model Session {
   turn_opened_at?: string;      // ISO timestamp the outstanding turn opened; the queue's sort key. Absent when nothing is owed.
   turn_snoozed_until?: string;  // ISO timestamp a live snooze runs to. Present only while the deferral holds; its presence is what puts the row in the sidebar's snoozed section, and while it is set no state can open a turn for this session except one that breaks through.
   auto_settle_fires_at?: string; // ISO timestamp the auto-settle countdown will close this session's turn. Present only while the countdown is running, which is the whole contract: it is what the terminal tile animates against, and its absence is what says nothing is pending. Absent during the arm delay, when auto-settle is off, and after a cancel.
-  auto_settle_held?: boolean;   // True while the auto-settle countdown is frozen because the user is typing into this session. Mutually exclusive with auto_settle_fires_at by construction: a frozen countdown has no deadline to animate against, so the tile draws a full paused bar and waits. It clears on its own five quiet seconds after the last keystroke, when a fresh deadline replaces it.
+  auto_settle_held?: boolean;   // True while the auto-settle countdown is frozen because the user is typing or moving the pointer in this session. Mutually exclusive with auto_settle_fires_at by construction: a frozen countdown has no deadline to animate against, so the tile draws a full paused bar and waits. It clears on its own five quiet seconds after the last interaction, when a fresh deadline replaces it.
   pinned_at?: string;           // ISO timestamp this session was individually pinned out of the queue. Presence is the pin, and the instant is the pinned band's sort key. Like a pinned workspace it filters at read: the turn stamps keep accruing underneath, so unpinning surfaces whatever was outstanding at its true age.
   parent_session_id?: string;   // The agent session a shell was split from. Spawn-time provenance resolved by the daemon, always an agent id and never another shell's, so there is no chain to walk. Whether the link is live is judged at read (parent present in the same workspace), so the field itself is never cleared.
   todos?: string[];             // Optional: can be empty/absent
@@ -1894,6 +1894,14 @@ model PtyInputMessage {
   id: string;
   data: string;
   source?: string;
+}
+
+// Reports genuine pointer movement inside a terminal pane. No bytes are written
+// to the PTY: this is user engagement for auto-settle only, and deliberately
+// does not participate in the keyboard-only ticket-nudge splice guard.
+model TerminalPointerActivityMessage {
+  cmd: "terminal_pointer_activity";
+  id: string;
 }
 
 // Sends a prompt to a conversation session — one whose agent runs in a headless


### PR DESCRIPTION
## Intent / Why

Auto-settle already pauses while someone types into an agent, but it could still resume and close the turn while they were actively reading or inspecting the terminal with the mouse or trackpad. Pointer movement should count as engagement with the same quiet-window behavior.

## Summary

- sample pointer movement inside terminal panes and send a session-scoped activity signal without adding PTY input
- fold pointer activity into the five-second auto-settle quiet hold while keeping ticket-nudge typing protection keyboard-only
- drop ephemeral pointer activity during socket disconnects instead of replaying stale movement
- extend protocol 214 and the packaged-app harness to cover sustained physical pointer movement

## Verification

- pre-commit gate: Go build and tests, 2,535 frontend tests, frontend production build, and 192 passing Playwright E2E tests with one skipped
- focused daemon and protocol tests after rebasing onto current main
- signed named-profile app and daemon preflight on protocol 214
- packaged-app settle scenario with real macOS keyboard and pointer input:
  - repeated pointer movement keeps settling paused beyond the quiet window
  - five quiet seconds restore a fresh full countdown
  - automation writes do not pause settling