### PR TITLE
fix(queue): persist approval routing across daemon restarts

### DIFF
--- a/changelog.d/bashful-ibex-persist-approval-route.yaml
+++ b/changelog.d/bashful-ibex-persist-approval-route.yaml
@@ -1,0 +1,6 @@
+kind: fixed
+area: queue
+change: >
+  Automatically reviewed permission requests stay behind the guardian dwell
+  after the daemon restarts, so brief approvals no longer flash as turns that
+  need the user and then disappear through auto-settle.

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/victorarias/attn/internal/daemon"
 	"github.com/victorarias/attn/internal/daemonctl"
 	"github.com/victorarias/attn/internal/hooks"
+	"github.com/victorarias/attn/internal/launchcontract"
 	"github.com/victorarias/attn/internal/pathutil"
 	"github.com/victorarias/attn/internal/present"
 	"github.com/victorarias/attn/internal/probetui"
@@ -389,6 +390,7 @@ func runPTYWorker() {
 	var cfg ptyworker.Config
 	var cols int
 	var rows int
+	var approvalRoute string
 	fs.StringVar(&cfg.DaemonInstanceID, "daemon-instance-id", "", "daemon instance id")
 	fs.StringVar(&cfg.SessionID, "session-id", "", "session id")
 	fs.StringVar(&cfg.Agent, "agent", "", "session agent")
@@ -399,6 +401,7 @@ func runPTYWorker() {
 	fs.StringVar(&cfg.ResumeSessionID, "resume-session-id", "", "resume session id")
 	fs.BoolVar(&cfg.ResumePicker, "resume-picker", false, "resume picker")
 	fs.BoolVar(&cfg.YoloMode, "yolo-mode", false, "launch agent in yolo mode")
+	fs.StringVar(&approvalRoute, "approval-route", "", "effective approval route recorded for daemon recovery")
 	fs.StringVar(&cfg.InitialPromptFile, "initial-prompt-file", "", "file containing the initial agent prompt")
 	fs.StringVar(&cfg.ThemeForeground, "theme-foreground", "", "terminal foreground color seeded for OSC 10/11/12 queries")
 	fs.StringVar(&cfg.ThemeBackground, "theme-background", "", "terminal background color seeded for OSC 10/11/12 queries")
@@ -422,6 +425,13 @@ func runPTYWorker() {
 	fs.StringVar(&cfg.OwnerNonce, "owner-nonce", "", "daemon owner nonce")
 
 	_ = fs.Parse(os.Args[2:])
+	if approvalRoute != "" {
+		cfg.ApprovalRoute = launchcontract.ApprovalRoute(approvalRoute)
+		if !cfg.ApprovalRoute.Valid() {
+			fmt.Fprintf(os.Stderr, "pty-worker error: invalid --approval-route %q\n", approvalRoute)
+			os.Exit(1)
+		}
+	}
 	if themeANSIPaletteJSON != "" {
 		if err := json.Unmarshal([]byte(themeANSIPaletteJSON), &cfg.ThemeANSIPalette); err != nil {
 			fmt.Fprintf(os.Stderr, "pty-worker error: invalid --theme-ansi-palette-json: %v\n", err)

--- a/internal/daemon/approval_route.go
+++ b/internal/daemon/approval_route.go
@@ -1,0 +1,103 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/victorarias/attn/internal/launchcontract"
+	"github.com/victorarias/attn/internal/ptybackend"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// recoveredApprovalRoute reads the surviving worker first because it records
+// what actually launched. The session's launch intent is the durable fallback.
+// A known worker route also repairs a stale intent so a later machine-level
+// revive preserves the same behavior.
+func (d *Daemon) recoveredApprovalRoute(sessionID string) (launchcontract.ApprovalRoute, bool) {
+	if provider, ok := d.ptyBackend.(ptybackend.SessionLaunchParamsProvider); ok {
+		params, err := provider.SessionLaunchParams(context.Background(), sessionID)
+		if err == nil && params.Recorded {
+			route, known, routeErr := recordedApprovalRoute(params.ApprovalRoute, params.YoloMode, params.UnattendedLaunch)
+			if routeErr != nil {
+				d.logf("recovery: ignoring invalid worker approval route for %s: %v", sessionID, routeErr)
+				return "", false
+			}
+			if known {
+				if intent, exists := d.store.LaunchIntent(sessionID); exists && intent.ApprovalRoute != route {
+					intent.ApprovalRoute = route
+					d.store.SetLaunchIntent(sessionID, intent)
+				}
+				return route, true
+			}
+		}
+	}
+	intent, ok := d.store.LaunchIntent(sessionID)
+	if !ok {
+		return "", false
+	}
+	route, known, err := recordedApprovalRoute(intent.ApprovalRoute, intent.YoloMode, intent.UnattendedLaunch)
+	if err != nil {
+		d.logf("recovery: ignoring invalid stored approval route for %s: %v", sessionID, err)
+		return "", false
+	}
+	return route, known
+}
+
+// recordedApprovalRoute interprets a persisted route without consulting mutable
+// daemon settings. Yolo and unattended contracts make legacy records
+// unambiguous; an otherwise empty route remains unknown so callers can try a
+// second durable source before conservatively treating approvals as user-owned.
+func recordedApprovalRoute(route launchcontract.ApprovalRoute, yoloMode bool, unattended launchcontract.UnattendedLaunchSpec) (launchcontract.ApprovalRoute, bool, error) {
+	if route != "" {
+		if !route.Valid() {
+			return "", false, fmt.Errorf("invalid recorded approval route %q", route)
+		}
+		return route, true, nil
+	}
+	if !unattended.IsZero() {
+		if err := unattended.Validate(); err != nil {
+			return "", false, fmt.Errorf("invalid recorded unattended launch contract: %w", err)
+		}
+		return launchcontract.ResolveApprovalRoute(false, false, unattended), true, nil
+	}
+	if yoloMode {
+		return launchcontract.ApprovalRouteBypass, true, nil
+	}
+	return "", false, nil
+}
+
+// applyApprovalRoute makes the persisted effective route authoritative over the
+// mutable settings from which a fresh launch would normally be composed.
+func applyApprovalRoute(opts *ptybackend.SpawnOptions, route launchcontract.ApprovalRoute) error {
+	if opts == nil || !route.Valid() {
+		return fmt.Errorf("invalid approval route %q", route)
+	}
+	opts.YoloMode = false
+	opts.AutoApprove = false
+	opts.ApprovalRoute = route
+	if !opts.UnattendedLaunch.IsZero() {
+		if route != launchcontract.ApprovalRouteReviewer {
+			return fmt.Errorf("unattended launch requires reviewer approval route, got %q", route)
+		}
+		return nil
+	}
+	switch route {
+	case launchcontract.ApprovalRouteReviewer:
+		opts.AutoApprove = true
+	case launchcontract.ApprovalRouteBypass:
+		opts.YoloMode = true
+	}
+	return nil
+}
+
+func launchIntentFromSpawnOptions(opts ptybackend.SpawnOptions, chiefOfStaff bool) store.LaunchIntent {
+	return store.LaunchIntent{
+		YoloMode:         opts.YoloMode,
+		ApprovalRoute:    opts.ApprovalRoute,
+		Executable:       opts.Executable,
+		Model:            opts.Model,
+		Effort:           opts.Effort,
+		ChiefOfStaff:     chiefOfStaff,
+		UnattendedLaunch: opts.UnattendedLaunch,
+	}
+}

--- a/internal/daemon/attach_revive_test.go
+++ b/internal/daemon/attach_revive_test.go
@@ -97,6 +97,28 @@ func TestAttachReviveRespawnsRecoverableSessionFromStoredIntent(t *testing.T) {
 	}
 }
 
+func TestAttachRevivePreservesStoredReviewerRoute(t *testing.T) {
+	intent := store.LaunchIntent{ApprovalRoute: launchcontract.ApprovalRouteReviewer}
+	d, backend, client, _ := newAttachReviveTestDaemon(t, protocol.SessionStateRecoverable, &intent)
+	d.store.SetSetting(SettingAutoApproveEnabled, "false")
+	d.handleAttachSession(client, &protocol.AttachSessionMessage{
+		Cmd:          protocol.CmdAttachSession,
+		ID:           "recoverable",
+		AttachPolicy: protocol.Ptr(protocol.AttachPolicyRevive),
+		Cols:         protocol.Ptr(80),
+		Rows:         protocol.Ptr(24),
+	})
+
+	result := readAttachReviveResult(t, client)
+	if !result.Success || !protocol.Deref(result.Revived) {
+		t.Fatalf("attach result = %+v, want success with revived=true", result)
+	}
+	opts, spawned := backend.LastSpawn()
+	if !spawned || !opts.AutoApprove || opts.YoloMode || opts.ApprovalRoute != launchcontract.ApprovalRouteReviewer {
+		t.Fatalf("spawn options = %+v, want stored reviewer route", opts)
+	}
+}
+
 func TestAttachDoesNotReviveWithoutPolicy(t *testing.T) {
 	d, backend, client, _ := newAttachReviveTestDaemon(t, protocol.SessionStateRecoverable, &store.LaunchIntent{})
 	d.handleAttachSession(client, &protocol.AttachSessionMessage{Cmd: protocol.CmdAttachSession, ID: "recoverable"})

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -613,6 +613,7 @@ func TestDaemon_Start_SelectsEmbeddedBackendWhenRequested(t *testing.T) {
 type fakeWorkerReconcileBackend struct {
 	liveIDs []string
 	info    map[string]ptybackend.SessionInfo
+	params  map[string]ptybackend.SessionLaunchParams
 }
 
 func (b *fakeWorkerReconcileBackend) Spawn(context.Context, ptybackend.SpawnOptions) error {
@@ -643,6 +644,13 @@ func (b *fakeWorkerReconcileBackend) SessionInfo(_ context.Context, sessionID st
 		return ptybackend.SessionInfo{}, fmt.Errorf("missing info for %s", sessionID)
 	}
 	return info, nil
+}
+func (b *fakeWorkerReconcileBackend) SessionLaunchParams(_ context.Context, sessionID string) (ptybackend.SessionLaunchParams, error) {
+	params, ok := b.params[sessionID]
+	if !ok {
+		return ptybackend.SessionLaunchParams{}, pty.ErrSessionNotFound
+	}
+	return params, nil
 }
 
 type fakeDeferredRecoveryBackend struct {

--- a/internal/daemon/launch_intent_test.go
+++ b/internal/daemon/launch_intent_test.go
@@ -59,10 +59,11 @@ func TestLaunchIntentSpawnSuccessPersistsResolvedValues(t *testing.T) {
 		t.Fatal("LaunchIntent() = ok false, want true after successful spawn")
 	}
 	want := store.LaunchIntent{
-		YoloMode:   true,
-		Executable: "/opt/claude",
-		Model:      "claude-opus",
-		Effort:     "high",
+		YoloMode:      true,
+		ApprovalRoute: launchcontract.ApprovalRouteBypass,
+		Executable:    "/opt/claude",
+		Model:         "claude-opus",
+		Effort:        "high",
 	}
 	if got != want {
 		t.Fatalf("LaunchIntent() = %+v, want %+v", got, want)

--- a/internal/daemon/reload.go
+++ b/internal/daemon/reload.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 
 	agentdriver "github.com/victorarias/attn/internal/agent"
+	"github.com/victorarias/attn/internal/launchcontract"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/pty"
 	"github.com/victorarias/attn/internal/ptybackend"
@@ -265,6 +266,8 @@ func (d *Daemon) executePreparedSessionReload(sessionID string, opts ptybackend.
 	// Success. Do NOT clear the flag here — the killed worker's exit consumes it.
 	// AfterFunc is a backstop only (never-arriving exit), so the flag cannot wedge.
 	time.AfterFunc(reloadStuckFlagGrace, func() { d.clearReloading(sessionID) })
+	d.store.SetLaunchIntent(sessionID, launchIntentFromSpawnOptions(opts, d.isChiefOfStaffSession(sessionID)))
+	d.recordReviewerEvidence(sessionID, opts.ApprovalRoute.ReviewerInLoop())
 	d.publishFact(FactSessionRespawned, sessionID, nil)
 	d.logf("reload: respawned %s (agent=%s resume=%t yolo=%t)", sessionID, opts.Agent, opts.ResumeSessionID != "", opts.YoloMode)
 	return nil
@@ -291,6 +294,16 @@ func (d *Daemon) buildReloadSpawnOptions(session *protocol.Session) (ptybackend.
 	if !params.Recorded {
 		return d.buildReloadSpawnOptionsFromStoredIntent(session, fmt.Errorf("launch params not recorded (pre-reload worker)"))
 	}
+	if _, known, routeErr := recordedApprovalRoute(params.ApprovalRoute, params.YoloMode, params.UnattendedLaunch); routeErr != nil {
+		return ptybackend.SpawnOptions{}, fmt.Errorf("read launch params: %w", routeErr)
+	} else if !known {
+		// A route-aware launch intent can fill the one field an older surviving
+		// worker did not record. Do not copy mutable settings or otherwise replace
+		// the live worker's launch params.
+		if intent, exists := d.store.LaunchIntent(sessionID); exists && intent.ApprovalRoute.Valid() {
+			params.ApprovalRoute = intent.ApprovalRoute
+		}
+	}
 	return d.buildReloadSpawnOptionsFromLaunchParams(session, params)
 }
 
@@ -303,6 +316,7 @@ func (d *Daemon) buildReloadSpawnOptionsFromStoredIntent(session *protocol.Sessi
 	return d.buildReloadSpawnOptionsFromLaunchParams(session, ptybackend.SessionLaunchParams{
 		Recorded:         true,
 		YoloMode:         intent.YoloMode,
+		ApprovalRoute:    intent.ApprovalRoute,
 		Executable:       intent.Executable,
 		Model:            intent.Model,
 		Effort:           intent.Effort,
@@ -351,6 +365,7 @@ func (d *Daemon) buildReloadSpawnOptionsFromLaunchParams(session *protocol.Sessi
 		ResumeSessionID:         resumeSessionID,
 		Theme:                   d.currentTerminalTheme(),
 		YoloMode:                params.YoloMode,
+		ApprovalRoute:           params.ApprovalRoute,
 		Executable:              params.Executable,
 		ClaudeExecutable:        params.ClaudeExecutable,
 		CodexExecutable:         params.CodexExecutable,
@@ -359,7 +374,7 @@ func (d *Daemon) buildReloadSpawnOptionsFromLaunchParams(session *protocol.Sessi
 		Effort:                  params.Effort,
 		LoginShellEnv:           d.cachedLoginShellEnv(),
 		WorkflowGuidanceEnabled: parseBooleanSetting(d.store.GetSetting(SettingWorkflowsEnabled)),
-		AutoApprove:             parseBooleanSetting(d.store.GetSetting(SettingAutoApproveEnabled)),
+		AutoApprove:             false,
 		// Carry the chief context-window cap across an in-place reload so a
 		// reloaded chief comes back capped, not just a fresh launch. The wrapper
 		// re-derives the chief's NotebookRoot (and thus emits the cap) via the
@@ -379,8 +394,17 @@ func (d *Daemon) buildReloadSpawnOptionsFromLaunchParams(session *protocol.Sessi
 		opts.Executable = ""
 		opts.Model = ""
 		opts.Effort = ""
-		opts.AutoApprove = false
 		opts.UnattendedLaunch = params.UnattendedLaunch
+	}
+	route, known, err := recordedApprovalRoute(params.ApprovalRoute, params.YoloMode, params.UnattendedLaunch)
+	if err != nil {
+		return ptybackend.SpawnOptions{}, err
+	}
+	if !known {
+		route = launchcontract.ApprovalRouteUser
+	}
+	if err := applyApprovalRoute(&opts, route); err != nil {
+		return ptybackend.SpawnOptions{}, err
 	}
 	return opts, nil
 }

--- a/internal/daemon/reload_test.go
+++ b/internal/daemon/reload_test.go
@@ -423,6 +423,36 @@ func TestBuildReloadSpawnOptionsPreservesUnattendedContractAsUnit(t *testing.T) 
 	}
 }
 
+func TestBuildReloadSpawnOptionsUsesRecordedApprovalRoute(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		setting       string
+		route         launchcontract.ApprovalRoute
+		wantAuto      bool
+		wantYolo      bool
+		wantPersisted launchcontract.ApprovalRoute
+	}{
+		{name: "reviewer survives disabled global setting", setting: "false", route: launchcontract.ApprovalRouteReviewer, wantAuto: true, wantPersisted: launchcontract.ApprovalRouteReviewer},
+		{name: "user survives enabled global setting", setting: "true", route: launchcontract.ApprovalRouteUser, wantPersisted: launchcontract.ApprovalRouteUser},
+		{name: "legacy missing route is conservative", setting: "true", route: "", wantPersisted: launchcontract.ApprovalRouteUser},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := &fakeReloadBackend{params: ptybackend.SessionLaunchParams{Recorded: true, ApprovalRoute: tc.route}}
+			d := newReloadTestDaemon(t, backend)
+			addReloadSession(d, "route", protocol.SessionAgentCodex, protocol.SessionStateWorking)
+			d.store.SetSetting(SettingAutoApproveEnabled, tc.setting)
+
+			opts, err := d.buildReloadSpawnOptions(d.store.Get("route"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if opts.AutoApprove != tc.wantAuto || opts.YoloMode != tc.wantYolo || opts.ApprovalRoute != tc.wantPersisted {
+				t.Fatalf("approval launch = auto:%v yolo:%v route:%q", opts.AutoApprove, opts.YoloMode, opts.ApprovalRoute)
+			}
+		})
+	}
+}
+
 func TestReloadSessionAgentSkipsWhenNoLiveWorker(t *testing.T) {
 	backend := &fakeReloadBackend{liveIDs: nil, params: ptybackend.SessionLaunchParams{Recorded: true}}
 	d := newReloadTestDaemon(t, backend)

--- a/internal/daemon/session_dwell_test.go
+++ b/internal/daemon/session_dwell_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/victorarias/attn/internal/launchcontract"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/pty"
 	"github.com/victorarias/attn/internal/sessionstate"
@@ -74,12 +75,13 @@ func TestSpawnFilesWhoAnswersApprovals(t *testing.T) {
 		autoApprove bool
 		yolo        bool
 		want        bool
+		wantRoute   launchcontract.ApprovalRoute
 	}{
-		{name: "guardian", autoApprove: true, want: true},
-		{name: "user answers", autoApprove: false, want: false},
+		{name: "guardian", autoApprove: true, want: true, wantRoute: launchcontract.ApprovalRouteReviewer},
+		{name: "user answers", autoApprove: false, want: false, wantRoute: launchcontract.ApprovalRouteUser},
 		// Yolo removes the approval gate rather than delegating it, so there is
 		// nothing for a reviewer to answer and nothing to dwell on.
-		{name: "yolo outranks auto-approve", autoApprove: true, yolo: true, want: false},
+		{name: "yolo outranks auto-approve", autoApprove: true, yolo: true, want: false, wantRoute: launchcontract.ApprovalRouteBypass},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
@@ -105,6 +107,10 @@ func TestSpawnFilesWhoAnswersApprovals(t *testing.T) {
 
 			if got := evidenceOf(t, d, msg.ID).ReviewerInLoop; got != tc.want {
 				t.Fatalf("ReviewerInLoop = %v, want %v", got, tc.want)
+			}
+			intent, ok := d.store.LaunchIntent(msg.ID)
+			if !ok || intent.ApprovalRoute != tc.wantRoute {
+				t.Fatalf("ApprovalRoute = %q, ok=%v, want %q", intent.ApprovalRoute, ok, tc.wantRoute)
 			}
 		})
 	}

--- a/internal/daemon/session_evidence.go
+++ b/internal/daemon/session_evidence.go
@@ -8,7 +8,6 @@ import (
 	"github.com/victorarias/attn/internal/classifier"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/pty"
-	"github.com/victorarias/attn/internal/ptybackend"
 	"github.com/victorarias/attn/internal/sessionstate"
 	"github.com/victorarias/attn/internal/statetrace"
 )
@@ -374,17 +373,6 @@ func (d *Daemon) recordReviewerEvidence(sessionID string, inLoop bool) {
 	d.recordEvidence(sessionID, time.Now(), func(e *sessionstate.Evidence) {
 		e.ReviewerInLoop = inLoop
 	})
-}
-
-// reviewerInLoop reads the launch options for the one arrangement that puts
-// something other than the user in front of an approval request.
-//
-// Both agents gate their reviewer on the same option — claude with
-// `--permission-mode auto`, codex with `approvals_reviewer=auto_review` — and
-// yolo outranks it by removing the approval gate altogether, so a yolo session
-// has no reviewer because it has nothing to review.
-func reviewerInLoop(opts ptybackend.SpawnOptions) bool {
-	return opts.AutoApprove && !opts.YoloMode
 }
 
 // recordReviewerEvidenceFromPermissionMode files claude's reported mode.

--- a/internal/daemon/session_recovered_evidence.go
+++ b/internal/daemon/session_recovered_evidence.go
@@ -17,8 +17,7 @@ import (
 // never produce a single piece of evidence again. The resolver would then have
 // nothing to say about it for the rest of its life.
 //
-// Two things are recoverable without persisting anything, because both sources
-// outlived the daemon:
+// Three things are recoverable because their sources outlived the daemon:
 //
 //   - The level. The worker holds the last observation its signal observers
 //     emitted, timestamped. A level is a standing claim, so reading it back is
@@ -26,6 +25,8 @@ import (
 //   - The outstanding harness edge. An approval or a question is not in the
 //     worker, but the session's own persisted state *is* the record that one was
 //     outstanding, and nothing has happened since to answer it.
+//   - The approval route. The surviving worker registry records the effective
+//     launch-time route, with the session's durable launch intent as fallback.
 //
 // What is deliberately not reconstructed is the bracket pair (turn open, tool
 // open). Those are hook-driven and genuinely gone, and inventing them would hold
@@ -37,6 +38,9 @@ import (
 func (d *Daemon) seedRecoveredEvidence(sessionID string, existing *protocol.Session, info ptybackend.SessionInfo) {
 	if d == nil || existing == nil {
 		return
+	}
+	if route, ok := d.recoveredApprovalRoute(sessionID); ok {
+		d.recordReviewerEvidence(sessionID, route.ReviewerInLoop())
 	}
 	if info.HasLastSignal {
 		// Routed through the ordinary PTY evidence path rather than written

--- a/internal/daemon/session_recovered_evidence_test.go
+++ b/internal/daemon/session_recovered_evidence_test.go
@@ -7,16 +7,76 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/attention"
+	"github.com/victorarias/attn/internal/launchcontract"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/pty"
 	"github.com/victorarias/attn/internal/ptybackend"
 	"github.com/victorarias/attn/internal/sessionstate"
+	"github.com/victorarias/attn/internal/store"
 )
 
 // heartbeat builds the level a worker reports back for a session it has been
 // running since before this daemon existed.
 func heartbeat(claim string, at time.Time) pty.Observation {
 	return pty.Observation{Source: pty.SourceHeartbeat, Claim: claim, Detail: "a turn summary", At: at}
+}
+
+// The daemon-restart regression: the guardian route must be reconstructed
+// before the first approval observation is resolved. Otherwise this brief
+// request publishes yellow immediately and opens a turn that auto-settle later
+// closes by accident.
+func TestRecoveredReviewerKeepsBriefApprovalInsideGuardianDwell(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	concludedAt := time.Now().Add(-time.Minute)
+	addRecoveredSession(t, d, "guarded", protocol.SessionStateWorking, concludedAt)
+	d.store.SetLaunchIntent("guarded", store.LaunchIntent{ApprovalRoute: launchcontract.ApprovalRouteReviewer})
+	d.ptyBackend = &fakeWorkerReconcileBackend{
+		liveIDs: []string{"guarded"},
+		info:    map[string]ptybackend.SessionInfo{"guarded": runningInfo(nil)},
+		params: map[string]ptybackend.SessionLaunchParams{
+			"guarded": {Recorded: true, ApprovalRoute: launchcontract.ApprovalRouteReviewer},
+		},
+	}
+	d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+	if !evidenceOf(t, d, "guarded").ReviewerInLoop {
+		t.Fatal("recovery did not reconstruct the reviewer before resolver activity")
+	}
+	now := time.Now()
+	d.recordBracketEvidence("guarded", protocol.StateWorking)
+	d.recordPTYEvidence("guarded", pty.Observation{Source: pty.SourceHeartbeat, Claim: "approval", At: now, Detail: "Action Required"})
+	d.resolveAllSessions(now.Add(time.Second))
+	if got := d.store.Get("guarded").State; got == protocol.SessionStatePendingApproval {
+		t.Fatal("brief guardian-reviewed approval published after daemon recovery")
+	}
+
+	d.recordPTYEvidence("guarded", pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", At: now.Add(2 * time.Second)})
+	d.resolveAllSessions(now.Add(3 * time.Second))
+	if got := d.store.Get("guarded").State; got != protocol.SessionStateWorking {
+		t.Fatalf("state = %q, want working after guardian answered", got)
+	}
+}
+
+func TestRecoveryUsesWorkerApprovalRouteAndRepairsStoredIntent(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	addRecoveredSession(t, d, "route-mismatch", protocol.SessionStateWorking, time.Now().Add(-time.Minute))
+	d.store.SetLaunchIntent("route-mismatch", store.LaunchIntent{ApprovalRoute: launchcontract.ApprovalRouteUser})
+	d.ptyBackend = &fakeWorkerReconcileBackend{
+		liveIDs: []string{"route-mismatch"},
+		info:    map[string]ptybackend.SessionInfo{"route-mismatch": runningInfo(nil)},
+		params: map[string]ptybackend.SessionLaunchParams{
+			"route-mismatch": {Recorded: true, ApprovalRoute: launchcontract.ApprovalRouteReviewer},
+		},
+	}
+	d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+	if !evidenceOf(t, d, "route-mismatch").ReviewerInLoop {
+		t.Fatal("stored route won over the surviving worker")
+	}
+	intent, ok := d.store.LaunchIntent("route-mismatch")
+	if !ok || intent.ApprovalRoute != launchcontract.ApprovalRouteReviewer {
+		t.Fatalf("repaired launch intent = %+v, ok=%v", intent, ok)
+	}
 }
 
 func addRecoveredSession(t *testing.T, d *Daemon, id string, state protocol.SessionState, stateSince time.Time) {

--- a/internal/daemon/spawn_pipeline.go
+++ b/internal/daemon/spawn_pipeline.go
@@ -19,7 +19,9 @@ import (
 )
 
 type internalSpawnPolicy struct {
-	unattendedLaunch launchcontract.UnattendedLaunchSpec
+	unattendedLaunch      launchcontract.UnattendedLaunchSpec
+	approvalRoute         launchcontract.ApprovalRoute
+	preserveApprovalRoute bool
 }
 
 type spawnRequest struct {
@@ -249,6 +251,22 @@ func (d *Daemon) resolveSpawnIntent(req *spawnRequest) (*spawnPlan, *spawnReject
 		}
 		plan.spawnOpts.AutoApprove, plan.spawnOpts.TrustWorkingDirectory, plan.spawnOpts.Model, plan.spawnOpts.Effort, plan.spawnOpts.Executable, plan.spawnOpts.UnattendedLaunch = false, false, "", "", "", launch
 	}
+	if req.policy.preserveApprovalRoute {
+		route, known, err := recordedApprovalRoute(req.policy.approvalRoute, plan.spawnOpts.YoloMode, plan.spawnOpts.UnattendedLaunch)
+		if err != nil {
+			plan.rollback(d, msg.ID)
+			return nil, &spawnRejection{err: err}
+		}
+		if !known {
+			route = launchcontract.ApprovalRouteUser
+		}
+		if err := applyApprovalRoute(&plan.spawnOpts, route); err != nil {
+			plan.rollback(d, msg.ID)
+			return nil, &spawnRejection{err: err}
+		}
+	} else {
+		plan.spawnOpts.ApprovalRoute = launchcontract.ResolveApprovalRoute(plan.spawnOpts.YoloMode, plan.spawnOpts.AutoApprove, plan.spawnOpts.UnattendedLaunch)
+	}
 	// A chief launch caps its context window (chief_context_window_cap); non-chief
 	// launches stay uncapped so delegated interactive agents are never affected.
 	plan.spawnOpts.ChiefContextWindowCap = d.chiefContextWindowCap(plan.isChief)
@@ -330,14 +348,7 @@ func (d *Daemon) executeSpawn(req *spawnRequest, plan *spawnPlan) *spawnOutcome 
 	// death after Spawn but before commit would otherwise leave a recoverable
 	// session with no stored launch intent to revive from.
 	plan.priorIntent, plan.hadPriorIntent = d.store.LaunchIntent(session.ID)
-	d.store.SetLaunchIntent(session.ID, store.LaunchIntent{
-		YoloMode:         plan.spawnOpts.YoloMode,
-		Executable:       plan.spawnOpts.Executable,
-		Model:            plan.spawnOpts.Model,
-		Effort:           plan.spawnOpts.Effort,
-		ChiefOfStaff:     plan.isChief,
-		UnattendedLaunch: plan.spawnOpts.UnattendedLaunch,
-	})
+	d.store.SetLaunchIntent(session.ID, launchIntentFromSpawnOptions(plan.spawnOpts, plan.isChief))
 	if err := d.spawnSessionRuntime(req, plan.spawnOpts); err != nil {
 		if req.existingSession == nil {
 			d.store.Remove(msg.ID)
@@ -360,7 +371,7 @@ func (d *Daemon) executeSpawn(req *spawnRequest, plan *spawnPlan) *spawnOutcome 
 	// else, so it is filed here. Codex reports no permission mode to the daemon at
 	// any point in its life, and without this its guardian would be invisible —
 	// which is the arrangement the dwell exists for.
-	d.recordReviewerEvidence(msg.ID, reviewerInLoop(plan.spawnOpts))
+	d.recordReviewerEvidence(msg.ID, plan.spawnOpts.ApprovalRoute.ReviewerInLoop())
 	if plan.spawnOpts.InitialPromptFile != "" {
 		// The spawned wrapper removes the file after reading it. Keep a fallback
 		// for failures between PTY spawn and wrapper startup.

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -322,7 +322,11 @@ func buildStoredIntentSpawn(session *protocol.Session, intent store.LaunchIntent
 		spawnMsg.Effort = protocol.Ptr(launch.Effort)
 		spawnMsg.Executable = protocol.Ptr(launch.Executable)
 	}
-	return spawnMsg, internalSpawnPolicy{unattendedLaunch: launch}
+	return spawnMsg, internalSpawnPolicy{
+		unattendedLaunch:      launch,
+		approvalRoute:         intent.ApprovalRoute,
+		preserveApprovalRoute: true,
+	}
 }
 
 // reviveSessionForAttach respawns a recoverable session from its durable record

--- a/internal/launchcontract/approval_route.go
+++ b/internal/launchcontract/approval_route.go
@@ -1,0 +1,42 @@
+package launchcontract
+
+// ApprovalRoute records who actually receives an agent's approval requests.
+// The empty value is reserved for launch records written before this field was
+// persisted; it must never be interpreted from a later global setting.
+type ApprovalRoute string
+
+const (
+	ApprovalRouteUser     ApprovalRoute = "user"
+	ApprovalRouteReviewer ApprovalRoute = "reviewer"
+	ApprovalRouteBypass   ApprovalRoute = "bypass"
+)
+
+func (r ApprovalRoute) Valid() bool {
+	switch r {
+	case ApprovalRouteUser, ApprovalRouteReviewer, ApprovalRouteBypass:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r ApprovalRoute) ReviewerInLoop() bool {
+	return r == ApprovalRouteReviewer
+}
+
+// ResolveApprovalRoute derives the effective approval route from a final launch
+// contract. Call it after unattended policy has replaced the attended flags.
+func ResolveApprovalRoute(yoloMode, autoApprove bool, unattended UnattendedLaunchSpec) ApprovalRoute {
+	if !unattended.IsZero() {
+		// Every currently supported unattended driver mode delegates the decision:
+		// Claude's "auto" classifier and Codex's "auto_review" guardian.
+		return ApprovalRouteReviewer
+	}
+	if yoloMode {
+		return ApprovalRouteBypass
+	}
+	if autoApprove {
+		return ApprovalRouteReviewer
+	}
+	return ApprovalRouteUser
+}

--- a/internal/launchcontract/approval_route_test.go
+++ b/internal/launchcontract/approval_route_test.go
@@ -1,0 +1,31 @@
+package launchcontract
+
+import "testing"
+
+func TestResolveApprovalRoute(t *testing.T) {
+	unattended := UnattendedLaunchSpec{
+		Agent:               "codex",
+		ApprovalProductMode: ApprovalAuto,
+		ApprovalDriverMode:  ApprovalAutoReview,
+		DirectoryTrust:      TrustConfiguredDirectory,
+		Recovery:            RecoveryAdoptOrRestartFresh,
+	}
+	for _, tc := range []struct {
+		name        string
+		yolo        bool
+		autoApprove bool
+		unattended  UnattendedLaunchSpec
+		want        ApprovalRoute
+	}{
+		{name: "user", want: ApprovalRouteUser},
+		{name: "reviewer", autoApprove: true, want: ApprovalRouteReviewer},
+		{name: "bypass outranks reviewer", yolo: true, autoApprove: true, want: ApprovalRouteBypass},
+		{name: "unattended reviewer", unattended: unattended, want: ApprovalRouteReviewer},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveApprovalRoute(tc.yolo, tc.autoApprove, tc.unattended); got != tc.want {
+				t.Fatalf("ResolveApprovalRoute() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ptybackend/backend.go
+++ b/internal/ptybackend/backend.go
@@ -64,6 +64,11 @@ type SpawnOptions struct {
 	// worker exports ATTN_AUTO_APPROVE so the launched agent starts in its native
 	// auto-approve mode (Claude --permission-mode auto). Yolo overrides it.
 	AutoApprove bool
+	// ApprovalRoute is the effective, launch-time destination for approval
+	// requests. The worker persists it so a replacement daemon can reconstruct
+	// guardian evidence without consulting a later global setting. Empty is
+	// accepted only for legacy/internal callers that predate route recording.
+	ApprovalRoute launchcontract.ApprovalRoute
 	// TrustWorkingDirectory is set only for unattended daemon-owned launches.
 	TrustWorkingDirectory bool
 
@@ -94,8 +99,16 @@ type SpawnOptions struct {
 }
 
 func validateUnattendedSpawnOptions(opts SpawnOptions) error {
+	if opts.ApprovalRoute != "" && !opts.ApprovalRoute.Valid() {
+		return fmt.Errorf("invalid approval route %q", opts.ApprovalRoute)
+	}
 	launch := opts.UnattendedLaunch
 	if launch.IsZero() {
+		if opts.ApprovalRoute != "" {
+			if want := launchcontract.ResolveApprovalRoute(opts.YoloMode, opts.AutoApprove, launch); opts.ApprovalRoute != want {
+				return fmt.Errorf("approval route %q does not match effective launch route %q", opts.ApprovalRoute, want)
+			}
+		}
 		return nil
 	}
 	if err := launch.Validate(); err != nil {
@@ -107,6 +120,11 @@ func validateUnattendedSpawnOptions(opts SpawnOptions) error {
 	if opts.AutoApprove || opts.TrustWorkingDirectory || strings.TrimSpace(opts.Model) != "" ||
 		strings.TrimSpace(opts.Effort) != "" || strings.TrimSpace(opts.Executable) != "" {
 		return errors.New("unattended launch policy must not be duplicated in spawn options")
+	}
+	if opts.ApprovalRoute != "" {
+		if want := launchcontract.ResolveApprovalRoute(opts.YoloMode, opts.AutoApprove, launch); opts.ApprovalRoute != want {
+			return fmt.Errorf("approval route %q does not match effective launch route %q", opts.ApprovalRoute, want)
+		}
 	}
 	return nil
 }
@@ -216,17 +234,16 @@ type SessionInfoProvider interface {
 	SessionInfo(ctx context.Context, sessionID string) (SessionInfo, error)
 }
 
-// SessionLaunchParams carries the per-spawn launch flags the daemon does not
-// otherwise persist — they arrive per-spawn from the client and otherwise live
-// only in the live worker. Backends that run a per-session worker record them in
-// the worker registry so the daemon can read them back when it re-spawns the
-// agent in place (chief-of-staff assign/demote reload).
+// SessionLaunchParams carries the launch flags recorded by a live worker. The
+// worker registry is authoritative for the process that actually survived a
+// daemon restart; the durable launch intent is the fallback when no worker does.
 type SessionLaunchParams struct {
 	// Recorded is false for sessions whose worker predates launch-param recording.
 	// The daemon must NOT trust the other fields when false and must abort the
 	// reload rather than respawn with defaulted launch flags.
 	Recorded          bool
 	YoloMode          bool
+	ApprovalRoute     launchcontract.ApprovalRoute
 	Executable        string
 	ClaudeExecutable  string
 	CodexExecutable   string

--- a/internal/ptybackend/worker.go
+++ b/internal/ptybackend/worker.go
@@ -389,6 +389,9 @@ func (b *WorkerBackend) spawnArgs(opts SpawnOptions, session *workerSession) ([]
 	if opts.YoloMode {
 		args = append(args, "--yolo-mode")
 	}
+	if opts.ApprovalRoute != "" {
+		args = append(args, "--approval-route", string(opts.ApprovalRoute))
+	}
 	if opts.InitialPromptFile != "" {
 		args = append(args, "--initial-prompt-file", opts.InitialPromptFile)
 	}
@@ -1076,6 +1079,7 @@ func (b *WorkerBackend) SessionLaunchParams(ctx context.Context, sessionID strin
 	return SessionLaunchParams{
 		Recorded:          entry.LaunchParamsRecorded,
 		YoloMode:          entry.YoloMode,
+		ApprovalRoute:     entry.ApprovalRoute,
 		Executable:        entry.Executable,
 		ClaudeExecutable:  entry.ClaudeExecutable,
 		CodexExecutable:   entry.CodexExecutable,

--- a/internal/ptybackend/worker_test.go
+++ b/internal/ptybackend/worker_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/victorarias/attn/internal/launchcontract"
 	"github.com/victorarias/attn/internal/pty"
 	"github.com/victorarias/attn/internal/ptyworker"
 )
@@ -35,6 +36,39 @@ func TestWithoutEnvironmentKeysRemovesInheritedLaunchPins(t *testing.T) {
 	want := []string{"PATH=/bin"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("withoutEnvironmentKeys() = %#v, want %#v", got, want)
+	}
+}
+
+func TestWorkerSpawnArgsCarryApprovalRoute(t *testing.T) {
+	root := newWorkerBackendTestRoot(t)
+	backend, err := NewWorker(WorkerBackendConfig{
+		DataRoot:         root,
+		DaemonInstanceID: "d-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		BinaryPath:       "/bin/true",
+	})
+	if err != nil {
+		t.Fatalf("NewWorker() error: %v", err)
+	}
+	session := &workerSession{
+		SessionID:    "approval-route",
+		RegistryPath: filepath.Join(root, "registry.json"),
+		SocketPath:   filepath.Join(root, "worker.sock"),
+		ControlToken: "test-token",
+	}
+	argv, err := backend.spawnArgs(SpawnOptions{
+		ID:            session.SessionID,
+		Agent:         "codex",
+		CWD:           root,
+		Cols:          80,
+		Rows:          24,
+		AutoApprove:   true,
+		ApprovalRoute: launchcontract.ApprovalRouteReviewer,
+	}, session)
+	if err != nil {
+		t.Fatalf("spawnArgs() error: %v", err)
+	}
+	if got := argAfterFlag(argv, "--approval-route"); got != string(launchcontract.ApprovalRouteReviewer) {
+		t.Fatalf("--approval-route = %q, want %q", got, launchcontract.ApprovalRouteReviewer)
 	}
 }
 

--- a/internal/ptyworker/registry.go
+++ b/internal/ptyworker/registry.go
@@ -25,16 +25,17 @@ type RegistryEntry struct {
 	OwnerStartedAt   string `json:"owner_started_at,omitempty"`
 	OwnerNonce       string `json:"owner_nonce,omitempty"`
 
-	// Launch params for daemon-side agent reload (chief-of-staff assign/demote).
-	// The daemon does NOT otherwise persist these — they arrive per-spawn from the
-	// client — so the worker records them here for the daemon to read back when it
-	// re-spawns the agent in place. LaunchParamsRecorded distinguishes a worker that
-	// records them from an older one that does not (Version stays 1 so recovery,
-	// which hard-requires Version==1, keeps accepting the entry); when it is false
-	// the daemon must NOT trust yolo, executable, model, or effort and must abort
-	// the reload rather than respawn with defaulted launch flags.
+	// Launch params for daemon recovery and in-place agent reload. The worker
+	// registry records what the surviving process actually launched with, while
+	// the session row carries the durable fallback. LaunchParamsRecorded
+	// distinguishes a worker that records them from an older one that does not
+	// (Version stays 1 so recovery, which hard-requires Version==1, keeps accepting
+	// the entry); when it is false the daemon must NOT trust the route, yolo,
+	// executable, model, or effort and must abort the reload rather than respawn
+	// with defaulted launch flags.
 	LaunchParamsRecorded bool                                `json:"launch_params_recorded,omitempty"`
 	YoloMode             bool                                `json:"yolo_mode,omitempty"`
+	ApprovalRoute        launchcontract.ApprovalRoute        `json:"approval_route,omitempty"`
 	Executable           string                              `json:"executable,omitempty"`
 	ClaudeExecutable     string                              `json:"claude_executable,omitempty"`
 	CodexExecutable      string                              `json:"codex_executable,omitempty"`

--- a/internal/ptyworker/registry_test.go
+++ b/internal/ptyworker/registry_test.go
@@ -14,6 +14,7 @@ func TestWriteAndReadRegistry(t *testing.T) {
 	entry.OwnerPID = 333
 	entry.OwnerStartedAt = "2026-02-11T00:00:00Z"
 	entry.OwnerNonce = "nonce-123"
+	entry.ApprovalRoute = launchcontract.ApprovalRouteReviewer
 	entry.UnattendedLaunch = launchcontract.UnattendedLaunchSpec{
 		Agent: "codex", Model: "gpt-test", Effort: "high",
 		ApprovalProductMode: launchcontract.ApprovalAuto, ApprovalDriverMode: launchcontract.ApprovalAutoReview,
@@ -43,6 +44,9 @@ func TestWriteAndReadRegistry(t *testing.T) {
 	}
 	if got.OwnerNonce != entry.OwnerNonce {
 		t.Fatalf("owner_nonce = %q, want %q", got.OwnerNonce, entry.OwnerNonce)
+	}
+	if got.ApprovalRoute != entry.ApprovalRoute {
+		t.Fatalf("approval route = %q, want %q", got.ApprovalRoute, entry.ApprovalRoute)
 	}
 	if !reflect.DeepEqual(got.UnattendedLaunch, entry.UnattendedLaunch) {
 		t.Fatalf("unattended launch = %#v, want %#v", got.UnattendedLaunch, entry.UnattendedLaunch)

--- a/internal/ptyworker/runtime.go
+++ b/internal/ptyworker/runtime.go
@@ -93,6 +93,7 @@ type Config struct {
 	ResumeSessionID   string
 	ResumePicker      bool
 	YoloMode          bool
+	ApprovalRoute     launchcontract.ApprovalRoute
 	InitialPromptFile string
 
 	ThemeForeground  string
@@ -361,6 +362,7 @@ func (r *Runtime) run(ctx context.Context) error {
 	// of defaulting them.
 	entry.LaunchParamsRecorded = true
 	entry.YoloMode = r.cfg.YoloMode
+	entry.ApprovalRoute = r.cfg.ApprovalRoute
 	entry.Executable = r.cfg.Executable
 	entry.ClaudeExecutable = r.cfg.ClaudeExecutable
 	entry.CodexExecutable = r.cfg.CodexExecutable

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -60,11 +60,12 @@ type ActiveAgentDriverRun struct {
 // relaunch a session without a client. Geometry is deliberately absent:
 // the attaching client owns it.
 type LaunchIntent struct {
-	YoloMode     bool   `json:"yolo_mode,omitempty"`
-	Executable   string `json:"executable,omitempty"`
-	Model        string `json:"model,omitempty"`
-	Effort       string `json:"effort,omitempty"`
-	ChiefOfStaff bool   `json:"chief_of_staff,omitempty"`
+	YoloMode      bool                         `json:"yolo_mode,omitempty"`
+	ApprovalRoute launchcontract.ApprovalRoute `json:"approval_route,omitempty"`
+	Executable    string                       `json:"executable,omitempty"`
+	Model         string                       `json:"model,omitempty"`
+	Effort        string                       `json:"effort,omitempty"`
+	ChiefOfStaff  bool                         `json:"chief_of_staff,omitempty"`
 	// UnattendedLaunch is the complete launch contract for sessions launched
 	// unattended (delegation/automations). Persisting the whole contract makes
 	// the store a sufficient authority to relaunch such a session when the

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -589,7 +589,8 @@ func TestStore_LaunchIntentRoundTrip(t *testing.T) {
 	}
 	s.Add(&protocol.Session{ID: "launch-intent", Label: "launch-intent"})
 	want := LaunchIntent{
-		ChiefOfStaff: true,
+		ChiefOfStaff:  true,
+		ApprovalRoute: launchcontract.ApprovalRouteReviewer,
 		UnattendedLaunch: launchcontract.UnattendedLaunchSpec{
 			Agent: "claude", Model: "sonnet", Effort: "high", Executable: "/opt/claude",
 			ApprovalProductMode: launchcontract.ApprovalAuto, ApprovalDriverMode: launchcontract.ApprovalAuto,


### PR DESCRIPTION
## Intent / Why

When the daemon restarts while an agent worker survives, it loses the in-memory fact that a permission reviewer is answering that session’s approval requests. A brief Codex permission hook can then be published as `pending_approval`, flash as a user turn, and disappear when auto-settle runs—even though auto-review handled it.

## Summary

- Resolve an explicit per-session approval route (`user`, `reviewer`, or `bypass`) from the effective launch policy.
- Persist that route in both the durable launch intent and the surviving worker registry.
- Restore reviewer evidence before the first resolver tick after recovery, preferring what the live worker actually launched and repairing stale stored intent.
- Preserve the recorded route across reload and revive instead of consulting a later global auto-approve setting.
- Keep legacy records conservative when their approval route cannot be recovered.

## Verification

- `make test`
- `make build`
- `make build-linux-amd64`
- `make build-linux-arm64`
- Repository pre-commit Go format, build, full Go suite, and Tauri daemon-binary checks
- Signed non-production packaged-app preflight
- Live Codex restart scenario: the worker retained `approval_route: reviewer`; a restricted-network permission request was completed by auto-review; the daemon observed the `pending_approval` hook without applying that state or opening a user turn