### PR TITLE
fix(daemon): store background-work timestamps in an encoding that sorts

### DIFF
--- a/changelog.d/background-work-timestamps-that-sort.yaml
+++ b/changelog.d/background-work-timestamps-that-sort.yaml
@@ -1,0 +1,13 @@
+kind: fixed
+area: daemon
+change: >
+  Background work due on a whole second now starts on that second instead of up
+  to a second late, and background jobs and notifications written moments apart
+  are listed in the order they happened.
+symptom: >
+  Timestamps for background work were stored in a form whose text order was not
+  time order within a single second, and the daemon compares them as text. A job
+  scheduled on an exact second was passed over until the next second came round,
+  and jobs or notifications recorded inside the same second came back in an
+  arbitrary order in the background-work panel and the notifications list.
+  Existing records are rewritten on first launch.

--- a/docs/plans/2026-08-04-ext-a3.3-doc-store-review-findings.md
+++ b/docs/plans/2026-08-04-ext-a3.3-doc-store-review-findings.md
@@ -67,10 +67,24 @@ reporting the count. Pinned by `internal/docstore/timestamps_test.go` and
 `internal/store/documents_timestamps_test.go`, both falsified against the three
 halves of the fix separately.
 
-`internal/store/jobs.go:19` uses the same format with the same text comparisons
-(`scheduled_at <=` at :173, retention `updated_at <` at :210). The consequence
-there is much milder: a job scheduled on a whole second is not claimed until the
-next second. A scheduling wobble, not data loss. Decide separately.
+`internal/store/jobs.go` used the same format with the same text comparisons
+(`scheduled_at <=`, retention `updated_at <`, and both feeds' `ORDER BY` on a
+stamp), and so did the notifications feed beside it, which had been written to
+match the jobs table deliberately. The consequence there was much milder: a job
+scheduled on a whole second was not claimed until the next second, and rows
+written inside one second listed in an arbitrary order. A scheduling wobble, not
+data loss.
+
+Fixed 2026-08-06. Both surfaces now store `sortableTimeFormat`, which *is*
+`docstore.TimeFormat` — the same defect and the same fix, so there is one
+spelling of the encoding in the tree rather than two that have to be kept in
+step — and `parseStoreTime` decodes any RFC3339 spelling, so a stamp written by
+an older store still reads. Migration 93 rewrites the stored job and
+notification stamps with the same `restampTable` helper migration 91 used, which
+now also skips a blank rather than counting it unreadable: an unread
+notification's `read_at` is `''` by design. Pinned by
+`internal/store/jobs_timestamps_test.go`, whose five behavioural tests all go red
+when the format constant alone is reverted.
 
 ### Why the test suite did not catch it
 

--- a/internal/store/jobs.go
+++ b/internal/store/jobs.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"fmt"
 	"time"
+
+	"github.com/victorarias/attn/internal/docstore"
 )
 
 // This is the SQLite persistence for the durable job queue (internal/jobs).
@@ -13,10 +15,24 @@ import (
 // keeps this package a leaf (internal/store imports neither internal/jobs nor
 // internal/daemon).
 
-// jobTimeFormat is the stored timestamp encoding. RFC3339Nano preserves the
-// sub-second precision the queue's backoff and debounce timing relies on, and it
-// sorts lexicographically, which is what lets scheduled_at be an index term.
-const jobTimeFormat = time.RFC3339Nano
+// sortableTimeFormat is the stored timestamp encoding for the two surfaces in
+// this package that keep their stamps in TEXT columns and compare them there:
+// the job queue (scheduled_at, created_at, updated_at) and the notifications
+// feed (created_at). Text order has to be time order, which takes a fraction of
+// a fixed width, always present and always nine digits.
+//
+// time.RFC3339Nano, which this used to be, does not: it strips trailing zeros,
+// so widths vary and "…:00Z" sorts above "…:00.5Z" ('Z' is 0x5A, above '.' and
+// every digit). Within one second the two orders disagreed, which made a job
+// scheduled on a whole second wait out the rest of that second before
+// `scheduled_at <= now` claimed it, and scrambled both feeds' listings among
+// rows written in the same second. Migration 93 rewrote the stored stamps.
+//
+// It is docstore.TimeFormat: the document store hit the same defect and this is
+// the same fix, so there is one spelling of it rather than two that must be kept
+// in step. Always formatted from a UTC time, so the zone is always "Z" and every
+// stored stamp is the same 30 characters wide.
+const sortableTimeFormat = docstore.TimeFormat
 
 // rowScanner is satisfied by both *sql.Row and *sql.Rows, so one scan helper
 // serves a single-row lookup and a listing. It lives here because the job queue
@@ -84,9 +100,9 @@ func upsertJob(ex execer, rec JobRecord) error {
 		   created_at=excluded.created_at,
 		   updated_at=excluded.updated_at`,
 		rec.ID, rec.Kind, rec.UniqueKey, rec.Priority, rec.Payload, rec.Result, rec.State,
-		rec.Attempts, rec.MaxAttempts, rec.ScheduledAt.UTC().Format(jobTimeFormat),
+		rec.Attempts, rec.MaxAttempts, rec.ScheduledAt.UTC().Format(sortableTimeFormat),
 		rec.LastError, boolToInt(rec.Requeued),
-		rec.CreatedAt.UTC().Format(jobTimeFormat), rec.UpdatedAt.UTC().Format(jobTimeFormat),
+		rec.CreatedAt.UTC().Format(sortableTimeFormat), rec.UpdatedAt.UTC().Format(sortableTimeFormat),
 	)
 	if err != nil {
 		return fmt.Errorf("store: upsert job %s: %w", rec.ID, err)
@@ -170,7 +186,7 @@ func (s *Store) EligibleJobs(now time.Time, limit int) ([]JobRecord, error) {
 		 WHERE state IN ('queued', 'failed') AND scheduled_at <= ?
 		 ORDER BY priority DESC, scheduled_at ASC, created_at ASC
 		 LIMIT ?`,
-		now.UTC().Format(jobTimeFormat), limit)
+		now.UTC().Format(sortableTimeFormat), limit)
 	if err != nil {
 		return nil, fmt.Errorf("store: eligible jobs: %w", err)
 	}
@@ -185,7 +201,7 @@ func (s *Store) RecoverRunningJobs(now time.Time) (int, error) {
 	if s.db == nil {
 		return 0, fmt.Errorf("store: no database")
 	}
-	ts := now.UTC().Format(jobTimeFormat)
+	ts := now.UTC().Format(sortableTimeFormat)
 	res, err := s.db.Exec(
 		`UPDATE jobs SET state='queued', scheduled_at=?, updated_at=? WHERE state='running'`, ts, ts)
 	if err != nil {
@@ -207,7 +223,7 @@ func (s *Store) TrimDoneJobs(cutoff time.Time) (int, error) {
 		return 0, fmt.Errorf("store: no database")
 	}
 	res, err := s.db.Exec(
-		`DELETE FROM jobs WHERE state='done' AND updated_at < ?`, cutoff.UTC().Format(jobTimeFormat))
+		`DELETE FROM jobs WHERE state='done' AND updated_at < ?`, cutoff.UTC().Format(sortableTimeFormat))
 	if err != nil {
 		return 0, fmt.Errorf("store: trim done jobs: %w", err)
 	}
@@ -249,19 +265,16 @@ func scanJobRow(sc rowScanner) (*JobRecord, error) {
 	return &rec, nil
 }
 
-// parseStoreTime decodes a stored timestamp, tolerating the plain RFC3339 form as
-// well as RFC3339Nano. A blank/garbage value yields the zero time rather than an
-// error — a job with an unreadable timestamp is still a real record, and the
-// queue treats a zero scheduled_at as "eligible now".
+// parseStoreTime decodes a stored timestamp in any RFC3339 form — the
+// fixed-width one written today, the trailing-zero-stripped one written before
+// migration 93, or a whole second with no fraction at all. A blank/garbage value
+// yields the zero time rather than an error: a job with an unreadable timestamp
+// is still a real record, and the queue treats a zero scheduled_at as
+// "eligible now".
 func parseStoreTime(s string) time.Time {
-	if s == "" {
+	t, err := docstore.ParseTime(s)
+	if err != nil {
 		return time.Time{}
 	}
-	if t, err := time.Parse(jobTimeFormat, s); err == nil {
-		return t.UTC()
-	}
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t.UTC()
-	}
-	return time.Time{}
+	return t
 }

--- a/internal/store/jobs_timestamps_test.go
+++ b/internal/store/jobs_timestamps_test.go
@@ -1,0 +1,281 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// scheduled_at, created_at and updated_at are TEXT columns, so every comparison
+// the queue makes on them — claiming (`scheduled_at <= now`), listing
+// (`ORDER BY updated_at DESC`), retention (`updated_at < cutoff`) — is a text
+// comparison, and the stored encoding is the whole definition of "before". Rows
+// a second apart cannot tell a working encoding from a broken one: what has to
+// be right is what happens inside one second, which is where a burst of enqueues
+// and a whole-second schedule both land.
+//
+// Every fixture here therefore uses sub-second offsets whose
+// trailing-zero-stripped encodings sort in an order that is not their own,
+// including the whole second itself — under RFC3339Nano "…:00Z" sorts above
+// every stamp in its own second, because 'Z' is 0x5A and '.' and the digits are
+// below it.
+
+// raggedJobOffsets are ids in chronological order with the sub-second offsets
+// that separate them, all inside one second.
+var raggedJobOffsets = []struct {
+	id     string
+	offset time.Duration
+}{
+	{"j0", 0},
+	{"j1234", 123400 * time.Microsecond},
+	{"j12345", 123450 * time.Microsecond},
+	{"j5", 500 * time.Millisecond},
+}
+
+func jobBase() time.Time { return time.Date(2026, 8, 6, 10, 0, 0, 0, time.UTC) }
+
+func jobIDs(recs []JobRecord) []string {
+	out := make([]string, 0, len(recs))
+	for _, r := range recs {
+		out = append(out, r.ID)
+	}
+	return out
+}
+
+func chronologicalJobIDs() []string {
+	out := make([]string, 0, len(raggedJobOffsets))
+	for _, r := range raggedJobOffsets {
+		out = append(out, r.id)
+	}
+	return out
+}
+
+// storeWithRaggedJobs writes the four jobs, each scheduled, created and updated
+// at its own instant inside one second.
+func storeWithRaggedJobs(t *testing.T) *Store {
+	t.Helper()
+	s := New()
+	for _, r := range raggedJobOffsets {
+		if err := s.UpsertJob(newJobRecord(r.id, "compact_context", jobBase().Add(r.offset))); err != nil {
+			t.Fatalf("upsert %s: %v", r.id, err)
+		}
+	}
+	return s
+}
+
+// The claim boundary. A job scheduled on a whole second is the ordinary case —
+// it is what a whole-second clock and a hand-written schedule both produce — and
+// under the old encoding it sorted above every stamp inside that second, so
+// `scheduled_at <= now` refused it until the next second ticked over. A second
+// of wobble on every such job, reported nowhere.
+func TestAJobScheduledOnAWholeSecondIsClaimableAtThatSecond(t *testing.T) {
+	s := New()
+	at := jobBase()
+	if err := s.UpsertJob(newJobRecord("whole", "compact_context", at)); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	for _, now := range []time.Time{at, at.Add(time.Millisecond), at.Add(500 * time.Millisecond)} {
+		got, err := s.EligibleJobs(now, 10)
+		if err != nil {
+			t.Fatalf("eligible jobs at %v: %v", now, err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("a job scheduled at %s was not claimable at %s: got %v",
+				at.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano), jobIDs(got))
+		}
+	}
+}
+
+// Claiming order is what decides which job runs first when more are eligible
+// than the sweep will take, and the tie-break within one priority is
+// scheduled_at. Four jobs enqueued inside one second must come back in the order
+// they were scheduled for, not in the order their text happens to sort.
+func TestEligibleJobsComeBackInScheduledOrderWithinASecond(t *testing.T) {
+	s := storeWithRaggedJobs(t)
+
+	got, err := s.EligibleJobs(jobBase().Add(time.Second), 10)
+	if err != nil {
+		t.Fatalf("eligible jobs: %v", err)
+	}
+	if want := chronologicalJobIDs(); !sameOrder(jobIDs(got), want) {
+		t.Fatalf("eligible jobs came back as %v, want %v", jobIDs(got), want)
+	}
+}
+
+// ListJobs is the queue's inspection surface (`attn jobs`), and it promises
+// newest-updated first.
+func TestListJobsIsNewestUpdatedFirstWithinASecond(t *testing.T) {
+	s := storeWithRaggedJobs(t)
+
+	got, err := s.ListJobs()
+	if err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	if want := reversed(chronologicalJobIDs()); !sameOrder(jobIDs(got), want) {
+		t.Fatalf("list jobs came back as %v, want %v", jobIDs(got), want)
+	}
+}
+
+// Retention deletes done rows updated before a cutoff. With the cutoff inside a
+// second, the rows updated before it must go and the ones updated after it must
+// stay — under the old encoding the row updated exactly on the second survived a
+// cutoff later than it, because its text sorted above the cutoff's.
+func TestTrimDoneJobsDeletesByTimeWithinASecond(t *testing.T) {
+	s := New()
+	for _, r := range raggedJobOffsets {
+		rec := newJobRecord(r.id, "compact_context", jobBase().Add(r.offset))
+		rec.State = "done"
+		if err := s.UpsertJob(rec); err != nil {
+			t.Fatalf("upsert %s: %v", r.id, err)
+		}
+	}
+
+	n, err := s.TrimDoneJobs(jobBase().Add(200 * time.Millisecond))
+	if err != nil {
+		t.Fatalf("trim: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("trimmed %d jobs, want the 3 updated before the cutoff", n)
+	}
+	left, err := s.ListJobs()
+	if err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	if want := []string{"j5"}; !sameOrder(jobIDs(left), want) {
+		t.Fatalf("trim left %v, want %v", jobIDs(left), want)
+	}
+}
+
+// The notifications feed stores its stamps in the same encoding and lists by
+// created_at, so a burst of failures inside one second is where its order breaks.
+func TestNotificationsListNewestFirstWithinASecond(t *testing.T) {
+	s := New()
+	for _, r := range raggedJobOffsets {
+		if _, err := s.AddNotification(
+			NotificationRecord{Kind: "task_failed", Title: r.id}, jobBase().Add(r.offset)); err != nil {
+			t.Fatalf("add notification %s: %v", r.id, err)
+		}
+	}
+
+	got, err := s.ListNotifications()
+	if err != nil {
+		t.Fatalf("list notifications: %v", err)
+	}
+	titles := make([]string, 0, len(got))
+	for _, n := range got {
+		titles = append(titles, n.Title)
+	}
+	if want := reversed(chronologicalJobIDs()); !sameOrder(titles, want) {
+		t.Fatalf("notifications came back as %v, want %v", titles, want)
+	}
+}
+
+// Migration 93 rewrites what earlier versions stored. Its input is the encoding
+// they wrote, so the test writes that encoding rather than describing it: the
+// stamps go in the way an older store would have written them, the migration
+// runs, and the claim and the order that were wrong come back right.
+func TestMigration93RewritesJobAndNotificationStampsThatDoNotSort(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB: %v", err)
+	}
+	defer s.Close()
+
+	for _, r := range raggedJobOffsets {
+		if err := s.UpsertJob(newJobRecord(r.id, "compact_context", jobBase().Add(r.offset))); err != nil {
+			t.Fatalf("upsert %s: %v", r.id, err)
+		}
+		if _, err := s.AddNotification(
+			NotificationRecord{Kind: "task_failed", Title: r.id}, jobBase().Add(r.offset)); err != nil {
+			t.Fatalf("add notification %s: %v", r.id, err)
+		}
+	}
+
+	// Roll the stamps back to the encoding migration 93 exists to replace, and
+	// plant one value it cannot read, which it must leave alone rather than turn
+	// into year 1. read_at stays '' on every notification: an unread row's
+	// sentinel is not a stamp that failed to parse, and the migration must leave
+	// it as it is too.
+	for _, r := range raggedJobOffsets {
+		old := jobBase().Add(r.offset).Format(time.RFC3339Nano)
+		if _, err := s.db.Exec(
+			`UPDATE jobs SET scheduled_at = ?, created_at = ?, updated_at = ? WHERE id = ?`,
+			old, old, old, r.id); err != nil {
+			t.Fatalf("plant old job stamp for %s: %v", r.id, err)
+		}
+		if _, err := s.db.Exec(
+			`UPDATE notifications SET created_at = ? WHERE title = ?`, old, r.id); err != nil {
+			t.Fatalf("plant old notification stamp for %s: %v", r.id, err)
+		}
+	}
+	if _, err := s.db.Exec(
+		`UPDATE jobs SET created_at = 'not a timestamp' WHERE id = ?`, "j5"); err != nil {
+		t.Fatalf("plant unreadable stamp: %v", err)
+	}
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version >= 93`); err != nil {
+		t.Fatalf("unrecord migration 93: %v", err)
+	}
+
+	// Sanity: the planted state is the broken one, so a pass here would mean the
+	// test proves nothing.
+	if got, err := s.EligibleJobs(jobBase(), 10); err != nil {
+		t.Fatal(err)
+	} else if len(got) != 0 {
+		t.Fatalf("the planted stamps already claim correctly (%v); this test would pass without the migration", jobIDs(got))
+	}
+
+	if err := migrateDB(s.db, dbPath); err != nil {
+		t.Fatalf("migrateDB: %v", err)
+	}
+	assertMigration93Applied(t, s)
+
+	// Re-running finds nothing left to do and changes nothing: the rewrite is a
+	// decode and re-encode, so an already-converted stamp yields itself.
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version >= 93`); err != nil {
+		t.Fatalf("unrecord migration 93 again: %v", err)
+	}
+	if err := migrateDB(s.db, dbPath); err != nil {
+		t.Fatalf("re-run migrateDB: %v", err)
+	}
+	assertMigration93Applied(t, s)
+}
+
+// assertMigration93Applied is the post-migration state: the whole-second job is
+// claimable at its own second, both feeds order by time, the stamp that does not
+// decode is untouched, and an unread notification is still unread.
+func assertMigration93Applied(t *testing.T, s *Store) {
+	t.Helper()
+	got, err := s.EligibleJobs(jobBase(), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"j0"}; !sameOrder(jobIDs(got), want) {
+		t.Fatalf("after migration 93 the jobs claimable at the whole second are %v, want %v", jobIDs(got), want)
+	}
+
+	notes, err := s.ListNotifications()
+	if err != nil {
+		t.Fatal(err)
+	}
+	titles := make([]string, 0, len(notes))
+	for _, n := range notes {
+		titles = append(titles, n.Title)
+	}
+	if want := reversed(chronologicalJobIDs()); !sameOrder(titles, want) {
+		t.Fatalf("after migration 93 the notifications list as %v, want %v", titles, want)
+	}
+	for _, n := range notes {
+		if !n.ReadAt.IsZero() {
+			t.Fatalf("notification %q came back read; read_at must stay the unread sentinel", n.Title)
+		}
+	}
+	var unreadable string
+	if err := s.db.QueryRow(`SELECT created_at FROM jobs WHERE id = ?`, "j5").Scan(&unreadable); err != nil {
+		t.Fatal(err)
+	}
+	if unreadable != "not a timestamp" {
+		t.Fatalf("the unreadable stamp became %q; it must be left as it was", unreadable)
+	}
+}

--- a/internal/store/legacy_tasks_test.go
+++ b/internal/store/legacy_tasks_test.go
@@ -12,8 +12,8 @@ func seedLegacyTask(t *testing.T, s *Store, id, kind, subject, state, meta strin
 	_, err := s.db.Exec(
 		`INSERT INTO tasks (id, kind, subject, state, attempts, next_attempt_at, last_error, meta_json, requeued, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		id, kind, subject, state, 2, at.Format(jobTimeFormat), "boom", meta, 1,
-		at.Format(jobTimeFormat), at.Format(jobTimeFormat))
+		id, kind, subject, state, 2, at.Format(sortableTimeFormat), "boom", meta, 1,
+		at.Format(sortableTimeFormat), at.Format(sortableTimeFormat))
 	if err != nil {
 		t.Fatalf("seed legacy task %s: %v", id, err)
 	}

--- a/internal/store/notifications.go
+++ b/internal/store/notifications.go
@@ -15,8 +15,9 @@ import (
 // daemon owns the mapping to the protocol shape — keeping this package a leaf.
 //
 // read_at is persisted as '' while unread and as a timestamp once read. Timestamps
-// reuse the jobs table's RFC3339Nano encoding and parseStoreTime decoder (same
-// package), so a blank/garbage value decodes to the zero time.
+// reuse the jobs table's sortableTimeFormat encoding and parseStoreTime decoder
+// (same package), so a blank/garbage value decodes to the zero time. The encoding
+// is the fixed-width one because created_at orders this feed as text.
 
 // NotificationRecord is one durable notification row. ReadAt is the zero time
 // while unread; a non-zero ReadAt marks it read.
@@ -47,7 +48,7 @@ func (s *Store) AddNotification(rec NotificationRecord, now time.Time) (Notifica
 		`INSERT INTO notifications (id, kind, title, body, detail, source_kind, source_id, created_at, read_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, '')`,
 		rec.ID, rec.Kind, rec.Title, rec.Body, rec.Detail, rec.SourceKind, rec.SourceID,
-		rec.CreatedAt.Format(notificationTimeFormat),
+		rec.CreatedAt.Format(sortableTimeFormat),
 	)
 	if err != nil {
 		return NotificationRecord{}, fmt.Errorf("store: add notification: %w", err)
@@ -101,7 +102,7 @@ func (s *Store) MarkNotificationRead(id string, now time.Time) error {
 	}
 	if _, err := s.db.Exec(
 		`UPDATE notifications SET read_at = ? WHERE id = ? AND read_at = ''`,
-		now.UTC().Format(notificationTimeFormat), id); err != nil {
+		now.UTC().Format(sortableTimeFormat), id); err != nil {
 		return fmt.Errorf("store: mark notification read %s: %w", id, err)
 	}
 	return nil
@@ -115,7 +116,7 @@ func (s *Store) MarkAllNotificationsRead(now time.Time) (int, error) {
 	}
 	res, err := s.db.Exec(
 		`UPDATE notifications SET read_at = ? WHERE read_at = ''`,
-		now.UTC().Format(notificationTimeFormat))
+		now.UTC().Format(sortableTimeFormat))
 	if err != nil {
 		return 0, fmt.Errorf("store: mark all notifications read: %w", err)
 	}
@@ -125,10 +126,6 @@ func (s *Store) MarkAllNotificationsRead(now time.Time) (int, error) {
 	}
 	return int(n), nil
 }
-
-// notificationTimeFormat matches the jobs table so both surfaces round-trip
-// timestamps identically.
-const notificationTimeFormat = time.RFC3339Nano
 
 func scanNotificationRow(sc rowScanner) (*NotificationRecord, error) {
 	var (

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -933,6 +933,13 @@ CREATE TABLE IF NOT EXISTS document_collections (
 	// the queue without dragging its workspace along, and the satellite link
 	// from a shell to the agent it was split from. Applied by applyMigration92.
 	{92, "add the session pin and the satellite parent to sessions", ``},
+	// The same rewrite migration 91 did for documents, for the two other TEXT
+	// stamp columns this package compares as text: the job queue's and the
+	// notifications feed's. A job's scheduled_at is compared against now on every
+	// dispatch sweep, and both feeds list by a stamp, so a variable-width fraction
+	// held a job scheduled on a whole second back until the next second and
+	// scrambled rows written inside one second. Applied by applyMigration93.
+	{93, "store job and notification timestamps in an encoding that sorts", ``},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -1218,6 +1225,11 @@ func migrateDB(db *sql.DB, dbPath string) error {
 			}
 		} else if m.version == 92 {
 			if err := applyMigration92(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 93 {
+			if err := applyMigration93(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -2383,10 +2395,46 @@ func collectionTableIDs(tx *sql.Tx) ([]int64, error) {
 	return ids, rows.Err()
 }
 
+// applyMigration93 rewrites the job queue's and the notifications feed's stored
+// stamps into sortableTimeFormat, for the same reason migration 91 rewrote the
+// document store's: they are TEXT columns compared as text, and the encoding
+// they were written in stripped trailing zeros from the fraction, so text order
+// was not time order inside any one second.
+//
+// The two surfaces move together because they always shared one encoding, and
+// what the wrong one cost them differed: a job scheduled on a whole second sorted
+// above every stamp within that second, so `scheduled_at <= now` did not claim it
+// until the next second, and both feeds' listings (jobs by updated_at,
+// notifications by created_at) came back out of order among rows written
+// together.
+//
+// Idempotent by construction — re-encoding an already-converted stamp yields
+// itself — and an undecodable stamp is left alone and reported, both properties
+// inherited from restampTable. An unread notification's read_at is ” by design;
+// restampTable skips a blank without counting it.
+func applyMigration93(tx *sql.Tx) error {
+	unreadable, err := restampTable(tx, "jobs", "id",
+		[]string{"scheduled_at", "created_at", "updated_at"})
+	if err != nil {
+		return fmt.Errorf("restamping jobs: %w", err)
+	}
+	n, err := restampTable(tx, "notifications", "id", []string{"created_at", "read_at"})
+	if err != nil {
+		return fmt.Errorf("restamping notifications: %w", err)
+	}
+	unreadable += n
+	if unreadable > 0 {
+		log.Printf("[store] migration 93: left %d job/notification timestamp(s) as they were; they are not RFC3339 and cannot be re-encoded", unreadable)
+	}
+	return nil
+}
+
 // restampTable re-encodes the named stamp columns of every row, returning how
-// many values it could not decode and therefore did not touch. Rows are read out
-// before any are written back, because the driver holds one connection and a
-// write issued while a read is still streaming deadlocks against it.
+// many values it could not decode and therefore did not touch. A blank value is
+// skipped and not counted: it is a column's own "no time here" sentinel, not a
+// timestamp that failed to parse. Rows are read out before any are written back,
+// because the driver holds one connection and a write issued while a read is
+// still streaming deadlocks against it.
 func restampTable(tx *sql.Tx, table, key string, columns []string) (int, error) {
 	rows, err := tx.Query(fmt.Sprintf(`SELECT %s, %s FROM %s`, key, strings.Join(columns, ", "), table))
 	if err != nil {
@@ -2420,6 +2468,9 @@ func restampTable(tx *sql.Tx, table, key string, columns []string) (int, error) 
 		sets := make([]string, 0, len(columns))
 		args := make([]any, 0, len(columns)+1)
 		for i, c := range columns {
+			if r.stamps[i] == "" {
+				continue
+			}
 			t, err := docstore.ParseTime(r.stamps[i])
 			if err != nil {
 				unreadable++


### PR DESCRIPTION
## The defect

`internal/store/jobs.go` and `internal/store/notifications.go` keep their
timestamps in TEXT columns and compare them there — the job queue's claim sweep
(`scheduled_at <= now`), retention (`updated_at < cutoff`), and both feeds'
listings (`ORDER BY updated_at DESC`, `ORDER BY created_at DESC`). They stored
them as `time.RFC3339Nano`, which strips trailing zeros from the fraction, so
widths vary and `…:00Z` sorts above `…:00.5Z` (`Z` is 0x5A, above `.` and every
digit). Within any one second, text order was not time order.

Two consequences, both silent:

- a job scheduled on a whole second was not claimed until the next second — up
  to a second of scheduling wobble on every such job;
- jobs and notifications written inside one second came back in an arbitrary
  order in the background-work panel and the notifications list.

This is the leftover recorded in section 1 of
`docs/plans/2026-08-04-ext-a3.3-doc-store-review-findings.md`. The document
store had the same defect and was fixed on 2026-08-05 (PR #763, migration 91);
this applies the same fix to the two remaining surfaces.

## The fix

- Both surfaces store `sortableTimeFormat`, which **is** `docstore.TimeFormat`
  — a nine-digit fixed-width fraction, always 30 characters. Same defect, same
  fix, one spelling of the encoding in the tree rather than two that have to be
  kept in step. The notifications feed shared the jobs table's constant on
  purpose already, so the two move together.
- `parseStoreTime` decodes any RFC3339 spelling (`docstore.ParseTime`), so a
  stamp written by an older store still reads.
- **Migration 93** rewrites the stored job and notification stamps through the
  same `restampTable` helper migration 91 used: a decode and re-encode,
  idempotent by construction, leaving an undecodable value alone and reporting
  the count. That helper now skips a blank rather than counting it unreadable —
  an unread notification's `read_at` is `''` by design, not a stamp that failed
  to parse.

No queue semantics changed (retry, backoff, coalescing, the commit fence are
untouched), and no wire or protocol change.

## Tests

`internal/store/jobs_timestamps_test.go`. Following the A3.3 adversarial-fixture
rule, every fixture uses sub-second offsets whose trailing-zero-stripped
encodings sort in an order that is not their own — including the whole second
itself, which is where the claim boundary lives:

- a job scheduled on a whole second is claimable at that second;
- `EligibleJobs` returns four jobs scheduled inside one second in scheduled
  order;
- `ListJobs` is newest-updated first within a second;
- `TrimDoneJobs` deletes by time across a cutoff inside a second;
- notifications list newest-first within a second;
- migration 93 rewrites planted RFC3339Nano stamps (with a built-in sanity
  check that the planted state is the broken one), leaves an undecodable stamp
  and an unread `read_at` alone, and re-running changes nothing.

Falsified: reverting the format constant alone turns all five behavioural tests
red, each on its load-bearing assertion —

```
--- FAIL: TestAJobScheduledOnAWholeSecondIsClaimableAtThatSecond
    a job scheduled at 2026-08-06T10:00:00Z was not claimable at 2026-08-06T10:00:00.001Z: got []
--- FAIL: TestEligibleJobsComeBackInScheduledOrderWithinASecond
    eligible jobs came back as [j12345 j1234 j5 j0], want [j0 j1234 j12345 j5]
--- FAIL: TestListJobsIsNewestUpdatedFirstWithinASecond
    list jobs came back as [j0 j5 j1234 j12345], want [j5 j12345 j1234 j0]
--- FAIL: TestTrimDoneJobsDeletesByTimeWithinASecond
    trimmed 2 jobs, want the 3 updated before the cutoff
--- FAIL: TestNotificationsListNewestFirstWithinASecond
    notifications came back as [j0 j5 j1234 j12345], want [j5 j12345 j1234 j0]
```

## Verification

- `go test ./internal/store`, `go test -race ./internal/store`, and
  `go test ./...` green.
- **Migration witness on real data.** A copy of the production `~/.attn/attn.db`
  (read-only source, copied into a sandbox), at schema 92 with 29 job rows and 8
  notifications: 101 of 101 non-blank stamps were not fixed-width before, 0
  after; the two unread notifications kept `read_at = ''`. Opening the same
  database a second time left every stamp byte-identical (SHA-256 over all
  stamps unchanged), so the rewrite is idempotent on real data and not only by
  construction.
- **Tier.** Store-internal change with no app-observable surface beyond job
  claim timing and two list orderings, no daemon lifecycle, protocol, PTY or UI
  involvement, and no wire change — unit tests plus the migration witness on a
  real database are the right tier. The app renders whatever order the daemon
  hands it.

## Surfaces walked

- **CLI / daemon / app** — behaviour is the same code path for all three; the
  panel and the notifications list simply receive correctly ordered rows.
- **Protocol** — no shape change, no version bump.
- **Linux** — pure Go, no platform-specific code.
- **Migration numbering** — 93 is the next free number, checked against
  `MAX(version)` in a copy of the production database (92). If an in-flight lane
  takes 93 first, this renumbers at merge.
- **Docs** — the A3.3 findings doc's section 1 now records the fix; changelog
  fragment added.

https://claude.ai/code/session_01Ch4xURK7M3FqDKQCQBn8oK