### PR TITLE
feat(docstore): send only what changed on a live query

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -199,7 +199,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '214';
+export const PROTOCOL_VERSION = '215';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, AgentEventMessage, AgentPromptMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentSort, DocUndefineMessage, DocUndefineResult, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, AddEndpointMessage, AgentEventMessage, AgentPromptMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, DocUndefineMessage, DocUndefineResult, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const agentEventMessage = Convert.toAgentEventMessage(json);
@@ -89,6 +89,7 @@
 //   const documentFieldSpec = Convert.toDocumentFieldSpec(json);
 //   const documentFilter = Convert.toDocumentFilter(json);
 //   const documentQuery = Convert.toDocumentQuery(json);
+//   const documentRevision = Convert.toDocumentRevision(json);
 //   const documentSort = Convert.toDocumentSort(json);
 //   const docUndefineMessage = Convert.toDocUndefineMessage(json);
 //   const docUndefineResult = Convert.toDocUndefineResult(json);
@@ -335,6 +336,7 @@
 //   const taskRetryMessage = Convert.toTaskRetryMessage(json);
 //   const taskRetryResultMessage = Convert.toTaskRetryResultMessage(json);
 //   const tasksChangedMessage = Convert.toTasksChangedMessage(json);
+//   const terminalPointerActivityMessage = Convert.toTerminalPointerActivityMessage(json);
 //   const ticket = Convert.toTicket(json);
 //   const ticketActionResultMessage = Convert.toTicketActionResultMessage(json);
 //   const ticketActivity = Convert.toTicketActivity(json);
@@ -1575,6 +1577,7 @@ export interface DocQueryResult {
 
 export interface DocSubscribeMessage {
     cmd:   DocSubscribeMessageCmd;
+    have?: HasElement[];
     query: Query;
     [property: string]: any;
 }
@@ -1583,9 +1586,17 @@ export enum DocSubscribeMessageCmd {
     DocSubscribe = "doc_subscribe",
 }
 
+export interface HasElement {
+    id:  string;
+    rev: number;
+    [property: string]: any;
+}
+
 export interface DocSubscribeResult {
+    as_of_seq: number;
     delivery:  number;
-    documents: Document[];
+    order:     string[];
+    upsert:    Document[];
     [property: string]: any;
 }
 
@@ -1626,6 +1637,12 @@ export interface DocumentQuery {
     limit?:     number;
     namespace:  string;
     sort?:      Sort;
+    [property: string]: any;
+}
+
+export interface DocumentRevision {
+    id:  string;
+    rev: number;
     [property: string]: any;
 }
 
@@ -4373,8 +4390,10 @@ export interface DocQueryResultObject {
 }
 
 export interface DocSubscribeResultObject {
+    as_of_seq: number;
     delivery:  number;
-    documents: Document[];
+    order:     string[];
+    upsert:    Document[];
     [property: string]: any;
 }
 
@@ -5300,6 +5319,16 @@ export interface TasksChangedMessage {
 
 export enum TasksChangedMessageEvent {
     TasksChanged = "tasks_changed",
+}
+
+export interface TerminalPointerActivityMessage {
+    cmd: TerminalPointerActivityMessageCmd;
+    id:  string;
+    [property: string]: any;
+}
+
+export enum TerminalPointerActivityMessageCmd {
+    TerminalPointerActivity = "terminal_pointer_activity",
 }
 
 export interface Ticket {
@@ -7170,6 +7199,14 @@ export class Convert {
 
     public static documentQueryToJson(value: DocumentQuery): string {
         return JSON.stringify(uncast(value, r("DocumentQuery")), null, 2);
+    }
+
+    public static toDocumentRevision(json: string): DocumentRevision {
+        return cast(JSON.parse(json), r("DocumentRevision"));
+    }
+
+    public static documentRevisionToJson(value: DocumentRevision): string {
+        return JSON.stringify(uncast(value, r("DocumentRevision")), null, 2);
     }
 
     public static toDocumentSort(json: string): DocumentSort {
@@ -9140,6 +9177,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("TasksChangedMessage")), null, 2);
     }
 
+    public static toTerminalPointerActivityMessage(json: string): TerminalPointerActivityMessage {
+        return cast(JSON.parse(json), r("TerminalPointerActivityMessage"));
+    }
+
+    public static terminalPointerActivityMessageToJson(value: TerminalPointerActivityMessage): string {
+        return JSON.stringify(uncast(value, r("TerminalPointerActivityMessage")), null, 2);
+    }
+
     public static toTicket(json: string): Ticket {
         return cast(JSON.parse(json), r("Ticket"));
     }
@@ -10800,11 +10845,18 @@ const typeMap: any = {
     ], "any"),
     "DocSubscribeMessage": o([
         { json: "cmd", js: "cmd", typ: r("DocSubscribeMessageCmd") },
+        { json: "have", js: "have", typ: u(undefined, a(r("HasElement"))) },
         { json: "query", js: "query", typ: r("Query") },
     ], "any"),
+    "HasElement": o([
+        { json: "id", js: "id", typ: "" },
+        { json: "rev", js: "rev", typ: 0 },
+    ], "any"),
     "DocSubscribeResult": o([
+        { json: "as_of_seq", js: "as_of_seq", typ: 0 },
         { json: "delivery", js: "delivery", typ: 0 },
-        { json: "documents", js: "documents", typ: a(r("Document")) },
+        { json: "order", js: "order", typ: a("") },
+        { json: "upsert", js: "upsert", typ: a(r("Document")) },
     ], "any"),
     "DocumentCollectionSchema": o([
         { json: "collection", js: "collection", typ: "" },
@@ -10835,6 +10887,10 @@ const typeMap: any = {
         { json: "limit", js: "limit", typ: u(undefined, 0) },
         { json: "namespace", js: "namespace", typ: "" },
         { json: "sort", js: "sort", typ: u(undefined, r("Sort")) },
+    ], "any"),
+    "DocumentRevision": o([
+        { json: "id", js: "id", typ: "" },
+        { json: "rev", js: "rev", typ: 0 },
     ], "any"),
     "DocumentSort": o([
         { json: "desc", js: "desc", typ: u(undefined, true) },
@@ -12471,8 +12527,10 @@ const typeMap: any = {
         { json: "documents", js: "documents", typ: a(r("Document")) },
     ], "any"),
     "DocSubscribeResultObject": o([
+        { json: "as_of_seq", js: "as_of_seq", typ: 0 },
         { json: "delivery", js: "delivery", typ: 0 },
-        { json: "documents", js: "documents", typ: a(r("Document")) },
+        { json: "order", js: "order", typ: a("") },
+        { json: "upsert", js: "upsert", typ: a(r("Document")) },
     ], "any"),
     "DocUndefineResultObject": o([
         { json: "collection", js: "collection", typ: "" },
@@ -13041,6 +13099,10 @@ const typeMap: any = {
     ], "any"),
     "TasksChangedMessage": o([
         { json: "event", js: "event", typ: r("TasksChangedMessageEvent") },
+    ], "any"),
+    "TerminalPointerActivityMessage": o([
+        { json: "cmd", js: "cmd", typ: r("TerminalPointerActivityMessageCmd") },
+        { json: "id", js: "id", typ: "" },
     ], "any"),
     "Ticket": o([
         { json: "activity", js: "activity", typ: a(r("ActivityElement")) },
@@ -14563,6 +14625,9 @@ const typeMap: any = {
     ],
     "TasksChangedMessageEvent": [
         "tasks_changed",
+    ],
+    "TerminalPointerActivityMessageCmd": [
+        "terminal_pointer_activity",
     ],
     "TicketActionResultMessageEvent": [
         "ticket_action_result",

--- a/changelog.d/docstore-windowed-subscriptions.yaml
+++ b/changelog.d/docstore-windowed-subscriptions.yaml
@@ -1,0 +1,13 @@
+kind: added
+area: daemon
+change: >
+  A live document query now sends only what changed. Every delivery carries the
+  window's order, the log position it was true at, and bodies for the documents
+  the subscriber does not already hold — so a busy collection stops re-sending
+  the same unchanged rows on every write. A subscriber can also resume by
+  content: it declares the revisions it kept, and the first delivery diffs
+  against them, which makes reconnecting after a daemon restart cost the
+  documents that actually moved rather than the whole window. `attn doc watch`
+  prints each applied window, takes `--resume` to reconnect that way, and exits
+  non-zero when the daemon ends the subscription, naming whether the collection
+  was removed or redeclared underneath it.

--- a/cmd/attn/doc.go
+++ b/cmd/attn/doc.go
@@ -393,11 +393,13 @@ func runDocWatch(args []string) {
 			printDocWindow(window, opts.asJSON)
 			return true
 		})
-		code, ended := client.DocSubscriptionCode(err)
+		_, ended := client.DocSubscriptionCode(err)
 		switch {
-		case opts.resume && ended && code == "":
+		case opts.resume && client.DocConnectionLost(err):
 			// The connection went, not the collection. Everything held stays
-			// held, and the resubscribe declares it.
+			// held, and the resubscribe declares it. Only this ending retries:
+			// every other one recurs on the next attempt, and a watch that
+			// resubscribed through one would spin reporting nothing.
 		case opts.resume && watching && !ended:
 			// The daemon is not answering the door yet. Restarting one takes
 			// long enough that a watch which gave up here would not survive the

--- a/cmd/attn/doc.go
+++ b/cmd/attn/doc.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/victorarias/attn/internal/client"
 	"github.com/victorarias/attn/internal/config"
@@ -111,9 +112,21 @@ commands:
         --limit are ignored: they decide which matches come back, never how
         many there are.
 
-  watch <namespace> <collection> [query flags] [--json]
-        run a live query: print the current results, then print them again every
-        time a write changes them. Runs until interrupted.
+  watch <namespace> <collection> [query flags] [--json] [--resume]
+        run a live query: print the current window, then print it again every
+        time a write changes it. Runs until interrupted, and exits non-zero if
+        the subscription ends — a watch that has stopped watching must not look
+        like a watch that finished.
+
+        What is printed is the whole window; what travels is the order plus only
+        the bodies this watcher does not already hold, which --json reports as
+        "changed". A live query takes no --after: it is a window, not a walk.
+
+        --resume resubscribes when the connection goes — a daemon restart, for
+        instance — waiting for the daemon to come back and declaring what it
+        holds, so only what changed while it was away comes back. A collection
+        that is removed or redeclared without a field the query uses ends the
+        watch either way, and so does a daemon that was never there.
 
 query flags:
   --where <expr>    repeatable. field=value, or field<value, field<=value,
@@ -329,23 +342,23 @@ func runDocDelete(args []string) {
 
 func runDocQuery(args []string) {
 	namespace, collection, rest := docTarget("query", args)
-	query, asJSON := parseDocQueryFlags("query", namespace, collection, rest)
+	query, opts := parseDocQueryFlags("query", namespace, collection, rest)
 	result, err := docClient().DocQuery(query)
 	if err != nil {
 		docFail("query", err)
 	}
-	printDocuments(result.Documents, asJSON)
-	printPosition(asJSON, result.AsOfSeq)
+	printDocuments(result.Documents, opts.asJSON)
+	printPosition(opts.asJSON, result.AsOfSeq)
 }
 
 func runDocCount(args []string) {
 	namespace, collection, rest := docTarget("count", args)
-	query, asJSON := parseDocQueryFlags("count", namespace, collection, rest)
+	query, opts := parseDocQueryFlags("count", namespace, collection, rest)
 	result, err := docClient().DocCount(query)
 	if err != nil {
 		docFail("count", err)
 	}
-	if asJSON {
+	if opts.asJSON {
 		writeJSON(struct {
 			Count   int `json:"count"`
 			AsOfSeq int `json:"as_of_seq"`
@@ -355,30 +368,79 @@ func runDocCount(args []string) {
 	fmt.Println(result.Count)
 }
 
+// runDocWatch prints applied windows: what the query holds right now, printed
+// again whenever a write changes it. What travels is smaller than what is
+// printed — a delivery carries ids plus only the bodies this watcher does not
+// already hold — and `changed` is that receipt.
+//
+// It never exits 0 while it has stopped watching. A live query that ends has
+// stopped reporting changes, and a watcher that returns success there leaves
+// whoever ran it looking at a list frozen at the moment the subscription broke.
+// --resume is the way to survive a daemon restart: it resubscribes carrying the
+// revisions it holds, so the daemon sends back only what changed while it was
+// away. A collection that was removed or redeclared out from under the query
+// ends the watch anyway, because resubscribing would fail the same way.
 func runDocWatch(args []string) {
 	namespace, collection, rest := docTarget("watch", args)
-	query, asJSON := parseDocQueryFlags("watch", namespace, collection, rest)
-	err := docClient().DocSubscribe(query, func(result *protocol.DocSubscribeResult) bool {
-		if asJSON {
-			writeJSON(struct {
-				Delivery  int            `json:"delivery"`
-				Documents []jsonDocument `json:"documents"`
-			}{result.Delivery, docsForJSON(result.Documents)})
-		} else {
-			fmt.Printf("--- delivery %d (%d document(s)) ---\n", result.Delivery, len(result.Documents))
-			printDocuments(result.Documents, false)
+	query, opts := parseDocQueryFlags("watch", namespace, collection, rest)
+
+	var held []protocol.StoredDocument
+	watching := false
+	for {
+		err := docClient().DocSubscribe(query, held, func(window client.DocWindow) bool {
+			watching = true
+			held = window.Documents
+			printDocWindow(window, opts.asJSON)
+			return true
+		})
+		code, ended := client.DocSubscriptionCode(err)
+		switch {
+		case opts.resume && ended && code == "":
+			// The connection went, not the collection. Everything held stays
+			// held, and the resubscribe declares it.
+		case opts.resume && watching && !ended:
+			// The daemon is not answering the door yet. Restarting one takes
+			// long enough that a watch which gave up here would not survive the
+			// thing --resume exists for; a watch that has never connected still
+			// fails immediately, because that is a wrong socket, not an outage.
+			time.Sleep(daemonReconnectInterval)
+		default:
+			docFail("watch", err)
 		}
-		return true
-	})
-	if err != nil {
-		docFail("watch", err)
 	}
 }
 
-// parseDocQueryFlags reads the query flags shared by query and watch.
-func parseDocQueryFlags(verb, namespace, collection string, args []string) (protocol.DocumentQuery, bool) {
+// daemonReconnectInterval is how often a resuming watch retries a daemon that
+// is not accepting connections. Measured: a stop plus ensure returns the socket
+// in 0.49s, so this polls twice inside the outage it exists for, and costs one
+// connect attempt per tick when the daemon is simply gone.
+const daemonReconnectInterval = 200 * time.Millisecond
+
+func printDocWindow(window client.DocWindow, asJSON bool) {
+	if asJSON {
+		writeJSON(struct {
+			Delivery  int            `json:"delivery"`
+			AsOfSeq   int64          `json:"as_of_seq"`
+			Documents []jsonDocument `json:"documents"`
+			Changed   []string       `json:"changed"`
+		}{window.Delivery, window.AsOfSeq, docsForJSON(window.Documents), window.Changed})
+		return
+	}
+	fmt.Printf("--- delivery %d (%d document(s), %d body(s) sent, as of seq %d) ---\n",
+		window.Delivery, len(window.Documents), len(window.Changed), window.AsOfSeq)
+	printDocuments(window.Documents, false)
+}
+
+// docQueryOptions are the flags that shape the output rather than the query.
+type docQueryOptions struct {
+	asJSON bool
+	resume bool
+}
+
+// parseDocQueryFlags reads the query flags shared by query, count and watch.
+func parseDocQueryFlags(verb, namespace, collection string, args []string) (protocol.DocumentQuery, docQueryOptions) {
 	query := protocol.DocumentQuery{Namespace: namespace, Collection: collection}
-	asJSON := false
+	var opts docQueryOptions
 	for i := 0; i < len(args); i++ {
 		next := func() string {
 			if i+1 >= len(args) {
@@ -389,7 +451,12 @@ func parseDocQueryFlags(verb, namespace, collection string, args []string) (prot
 		}
 		switch args[i] {
 		case "--json":
-			asJSON = true
+			opts.asJSON = true
+		case "--resume":
+			if verb != "watch" {
+				docFail(verb, fmt.Errorf("--resume is only for watch; a one-shot read has nothing to resume"))
+			}
+			opts.resume = true
 		case "--desc":
 			desc := true
 			if query.Sort == nil {
@@ -425,7 +492,7 @@ func parseDocQueryFlags(verb, namespace, collection string, args []string) (prot
 	if query.Sort != nil && query.Sort.Field == "" {
 		docFail(verb, fmt.Errorf("--desc needs --sort <field>"))
 	}
-	return query, asJSON
+	return query, opts
 }
 
 // docWhereOps are matched longest-first so ">=" is not read as ">".

--- a/cmd/attn/doc_test.go
+++ b/cmd/attn/doc_test.go
@@ -61,14 +61,14 @@ func TestWhereRejectsAnExpressionWithNoOperator(t *testing.T) {
 // the advance still carries to the next iteration — otherwise a flag's value
 // would be parsed again as if it were a flag.
 func TestQueryFlagsConsumeTheirValues(t *testing.T) {
-	query, asJSON := parseDocQueryFlags("query", "ext/approval-gate", "requests", []string{
+	query, opts := parseDocQueryFlags("query", "ext/approval-gate", "requests", []string{
 		"--where", "status=pending",
 		"--sort", "created_at",
 		"--desc",
 		"--limit", "7",
 		"--json",
 	})
-	if !asJSON {
+	if !opts.asJSON {
 		t.Fatal("--json not seen")
 	}
 	if query.Namespace != "ext/approval-gate" || query.Collection != "requests" {
@@ -82,6 +82,15 @@ func TestQueryFlagsConsumeTheirValues(t *testing.T) {
 	}
 	if query.Limit == nil || *query.Limit != 7 {
 		t.Fatalf("limit = %v", query.Limit)
+	}
+}
+
+// --resume is a watch flag. A one-shot read that accepted it would silently
+// ignore it, and the caller would believe it had asked for something.
+func TestResumeBelongsToWatch(t *testing.T) {
+	_, opts := parseDocQueryFlags("watch", "ext/a", "c", []string{"--resume"})
+	if !opts.resume {
+		t.Fatal("--resume not seen on watch")
 	}
 }
 

--- a/internal/client/documents.go
+++ b/internal/client/documents.go
@@ -134,6 +134,13 @@ func revisions(held []protocol.StoredDocument) []protocol.DocumentRevision {
 type DocSubscriptionEnded struct {
 	Code    string
 	Message string
+
+	// lost distinguishes the one ending that is safe to retry — the connection
+	// went — from every other one. It is not the same fact as an empty Code: a
+	// delivery this client cannot apply also carries no daemon code, and
+	// resubscribing after one repeats it with the same declared revisions,
+	// forever. Set here rather than exported so no caller can claim it.
+	lost bool
 }
 
 func (e *DocSubscriptionEnded) Error() string {
@@ -151,6 +158,15 @@ func DocSubscriptionCode(err error) (string, bool) {
 		return ended.Code, true
 	}
 	return "", false
+}
+
+// DocConnectionLost reports whether a subscription ended because the connection
+// went. That is the only ending worth resubscribing to: a daemon that refused
+// the query and a delivery this client could not apply both recur on the next
+// attempt, so retrying either is a loop that reports nothing.
+func DocConnectionLost(err error) bool {
+	var ended *DocSubscriptionEnded
+	return errors.As(err, &ended) && ended.lost
 }
 
 // DocSubscribe opens a live query and calls onWindow for every delivery,
@@ -189,7 +205,7 @@ func (c *Client) DocSubscribe(query protocol.DocumentQuery, held []protocol.Stor
 	for {
 		var resp protocol.Response
 		if err := decoder.Decode(&resp); err != nil {
-			return &DocSubscriptionEnded{Message: "the daemon closed the connection"}
+			return &DocSubscriptionEnded{Message: "the daemon closed the connection", lost: true}
 		}
 		if !resp.Ok {
 			return &DocSubscriptionEnded{

--- a/internal/client/documents.go
+++ b/internal/client/documents.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 
@@ -94,41 +95,157 @@ func (c *Client) DocCount(query protocol.DocumentQuery) (*protocol.DocCountResul
 	return resp.DocCountResult, nil
 }
 
-// DocSubscribe opens a live query and calls onResult for every delivery,
-// beginning with the current result set. Unlike every other call here it holds
-// its connection open, so it returns only when onResult asks it to stop, the
-// daemon closes the connection, or a delivery cannot be read.
+// DocWindow is one delivery of a live query, already applied. The daemon sends
+// an order plus the bodies the subscriber is missing; this is the result of
+// following the client rule, so a caller renders Documents and holds no
+// delivery-merging logic of its own. That rule lives here once, because the CLI,
+// the tests and A4's SDK are all callers of this seam.
 //
-// Each delivery is the whole current result set; a caller renders what it is
-// handed and never accumulates state across deliveries.
-func (c *Client) DocSubscribe(query protocol.DocumentQuery, onResult func(*protocol.DocSubscribeResult) bool) error {
+// AsOfSeq is the log position the window was true at — comparable against the
+// seq a write reported, which is how a caller knows a delivery already includes
+// its own write. Changed names the ids whose bodies arrived in this delivery,
+// so a caller can see what actually travelled rather than infer it.
+type DocWindow struct {
+	Delivery  int
+	AsOfSeq   int64
+	Documents []protocol.StoredDocument
+	Changed   []string
+}
+
+// revisions is what this window declares to a resuming subscription. The wire
+// carries revisions alone, but DocSubscribe takes whole documents: a subscriber
+// that declares a revision without holding its body has told the daemon not to
+// send something it cannot render, and no caller should be able to express that
+// by accident.
+func revisions(held []protocol.StoredDocument) []protocol.DocumentRevision {
+	out := make([]protocol.DocumentRevision, 0, len(held))
+	for _, doc := range held {
+		out = append(out, protocol.DocumentRevision{ID: doc.ID, Rev: doc.Rev})
+	}
+	return out
+}
+
+// DocSubscriptionEnded is a live query the daemon stopped serving. Code is the
+// protocol error code when the daemon named one — `collection_undefined` and
+// `collection_redeclared` are the two that mean the collection moved out from
+// under an accepted subscription — and is empty when the connection simply went
+// away. It is a type rather than a message because a UI host has to tell "kill
+// this tile" from "reconnect", and must not do it by matching English.
+type DocSubscriptionEnded struct {
+	Code    string
+	Message string
+}
+
+func (e *DocSubscriptionEnded) Error() string {
+	if e.Code == "" {
+		return "document subscription ended: " + e.Message
+	}
+	return "document subscription ended (" + e.Code + "): " + e.Message
+}
+
+// DocSubscriptionCode returns the protocol error code a subscription ended with,
+// and whether the error was a subscription ending at all.
+func DocSubscriptionCode(err error) (string, bool) {
+	var ended *DocSubscriptionEnded
+	if errors.As(err, &ended) {
+		return ended.Code, true
+	}
+	return "", false
+}
+
+// DocSubscribe opens a live query and calls onWindow for every delivery,
+// beginning with the query's current window. Unlike every other call here it
+// holds its connection open, so it returns only when onWindow asks it to stop,
+// or when the subscription ends.
+//
+// held is what the caller already holds — nil for a fresh subscribe, and a
+// previous window's Documents to resume one. The daemon is told their revisions
+// and sends bodies only for what has changed since; everything else is carried
+// by order and taken from the cache seeded here.
+//
+// Ending is always an error, including the plain end-of-connection case. A live
+// query that stops is a caller who has stopped seeing changes, and returning
+// success there is how a watcher exits 0 while showing a frozen list.
+func (c *Client) DocSubscribe(query protocol.DocumentQuery, held []protocol.StoredDocument, onWindow func(DocWindow) bool) error {
 	conn, err := net.Dial("unix", c.socketPath)
 	if err != nil {
 		return explainConnectError(c.socketPath, err)
 	}
 	defer conn.Close()
 
-	msg := protocol.DocSubscribeMessage{Cmd: protocol.CmdDocSubscribe, Query: query}
+	msg := protocol.DocSubscribeMessage{Cmd: protocol.CmdDocSubscribe, Query: query, Have: revisions(held)}
 	if err := json.NewEncoder(conn).Encode(msg); err != nil {
 		return fmt.Errorf("send subscribe: %w", err)
 	}
 
+	// The cache the client rule reads from, seeded with what the caller declared.
+	// An id the daemon believes is held and that is not here is a broken
+	// subscription, reported rather than rendered with a hole in it.
+	cache := make(map[string]protocol.StoredDocument, len(held))
+	for _, doc := range held {
+		cache[doc.ID] = doc
+	}
 	decoder := json.NewDecoder(conn)
 	for {
 		var resp protocol.Response
 		if err := decoder.Decode(&resp); err != nil {
-			// The daemon closing the connection ends the subscription; it is not
-			// the caller's error to report.
-			return nil
+			return &DocSubscriptionEnded{Message: "the daemon closed the connection"}
 		}
 		if !resp.Ok {
-			return fmt.Errorf("daemon error: %s", protocol.Deref(resp.Error))
+			return &DocSubscriptionEnded{
+				Code:    protocol.Deref(resp.ErrorCode),
+				Message: protocol.Deref(resp.Error),
+			}
 		}
 		if resp.DocSubscribeResult == nil {
 			continue
 		}
-		if !onResult(resp.DocSubscribeResult) {
+		window, err := applyDocDelivery(cache, resp.DocSubscribeResult)
+		if err != nil {
+			return err
+		}
+		if !onWindow(window) {
 			return nil
 		}
 	}
+}
+
+// applyDocDelivery is the client rule: render order, take each body from upsert
+// if it is there and from the cache otherwise, forget everything not in order.
+// The cache is replaced rather than added to, which is what keeps a long-lived
+// subscription's memory bounded by the window rather than by its history.
+func applyDocDelivery(cache map[string]protocol.StoredDocument, result *protocol.DocSubscribeResult) (DocWindow, error) {
+	window := DocWindow{
+		Delivery:  result.Delivery,
+		AsOfSeq:   int64(result.AsOfSeq),
+		Documents: make([]protocol.StoredDocument, 0, len(result.Order)),
+		Changed:   make([]string, 0, len(result.Upsert)),
+	}
+	arrived := make(map[string]protocol.StoredDocument, len(result.Upsert))
+	for _, doc := range result.Upsert {
+		arrived[doc.ID] = doc
+		window.Changed = append(window.Changed, doc.ID)
+	}
+	next := make(map[string]protocol.StoredDocument, len(result.Order))
+	for _, id := range result.Order {
+		doc, ok := arrived[id]
+		if !ok {
+			doc, ok = cache[id]
+		}
+		if !ok {
+			// The daemon believes this subscriber holds a body it does not. The
+			// subscription cannot be applied, and continuing would render a
+			// window with a hole in it.
+			return DocWindow{}, &DocSubscriptionEnded{Message: fmt.Sprintf(
+				"delivery %d ordered %q without sending its body, and it is not held; resubscribe without a resume token",
+				result.Delivery, id)}
+		}
+		next[id] = doc
+		window.Documents = append(window.Documents, doc)
+	}
+	clear(cache)
+	for id, doc := range next {
+		cache[id] = doc
+	}
+	return window, nil
 }

--- a/internal/client/documents_test.go
+++ b/internal/client/documents_test.go
@@ -89,6 +89,44 @@ func TestASubscriptionEndingWithoutAnErrorIsStillAnError(t *testing.T) {
 	if code != "" {
 		t.Fatalf("a lost connection carried code %q, and there is nothing for a caller to branch on", code)
 	}
+	if !DocConnectionLost(err) {
+		t.Fatal("a lost connection is the one ending worth resubscribing to, and it did not say so")
+	}
+}
+
+// The three endings that are NOT worth retrying, kept together because what
+// separates them from a lost connection is one bit that is easy to conflate
+// with an empty code. A resuming watcher that retried any of them would spin:
+// the daemon refuses the same query again, and an unapplicable delivery repeats
+// with the same declared revisions.
+func TestOnlyALostConnectionIsWorthResubscribing(t *testing.T) {
+	unapplicable := docServer(t, func(conn net.Conn, _ protocol.DocSubscribeMessage) {
+		// Orders a document whose body it never sent and the client never held.
+		sendDelivery(t, conn, protocol.DocSubscribeResult{Delivery: 1, Order: []string{"ghost"}})
+	})
+	err := New(unapplicable).DocSubscribe(protocol.DocumentQuery{}, nil, func(DocWindow) bool { return true })
+	if _, ended := DocSubscriptionCode(err); !ended {
+		t.Fatalf("an unapplicable delivery reported %v", err)
+	}
+	if DocConnectionLost(err) {
+		t.Fatal("an unapplicable delivery claimed the connection went; resubscribing repeats it forever")
+	}
+
+	coded := docServer(t, func(conn net.Conn, _ protocol.DocSubscribeMessage) {
+		json.NewEncoder(conn).Encode(protocol.Response{
+			Ok:        false,
+			Error:     protocol.Ptr("collection undefined while subscribed"),
+			ErrorCode: protocol.Ptr(protocol.ErrorCodeCollectionUndefined),
+		})
+	})
+	err = New(coded).DocSubscribe(protocol.DocumentQuery{}, nil, func(DocWindow) bool { return true })
+	if DocConnectionLost(err) {
+		t.Fatal("a collection that was removed claimed the connection went")
+	}
+
+	if DocConnectionLost(errString("connection refused")) {
+		t.Fatal("an ordinary error claimed to be a lost subscription")
+	}
 }
 
 // The daemon's coded ending has to survive the read loop as a code, because a UI

--- a/internal/client/documents_test.go
+++ b/internal/client/documents_test.go
@@ -1,0 +1,218 @@
+package client
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// Unix socket paths are length-limited (notably on macOS), and the default
+// t.TempDir() path is long enough to blow the limit.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "attn-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}
+
+func doc(id, body string, rev int) protocol.StoredDocument {
+	return protocol.StoredDocument{ID: id, Body: body, Rev: rev}
+}
+
+// docServer is a unix socket that answers one doc_subscribe with the deliveries
+// it is handed and then does whatever the test asked of it. The daemon's own
+// handler is covered in internal/daemon; what is under test here is the client's
+// read loop, so the server side is scripted rather than real.
+func docServer(t *testing.T, serve func(conn net.Conn, subscribe protocol.DocSubscribeMessage)) string {
+	t.Helper()
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { listener.Close() })
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var msg protocol.DocSubscribeMessage
+		if err := json.NewDecoder(conn).Decode(&msg); err != nil {
+			return
+		}
+		serve(conn, msg)
+	}()
+	return sockPath
+}
+
+func sendDelivery(t *testing.T, conn net.Conn, result protocol.DocSubscribeResult) {
+	t.Helper()
+	if err := json.NewEncoder(conn).Encode(protocol.Response{Ok: true, DocSubscribeResult: &result}); err != nil {
+		t.Errorf("send delivery: %v", err)
+	}
+}
+
+// A live query that ends because the connection went reports it as an error too.
+// Nothing distinguishes "the daemon stopped" from "nothing has changed lately"
+// except this, and a watcher that cannot tell them apart shows a frozen list
+// forever.
+func TestASubscriptionEndingWithoutAnErrorIsStillAnError(t *testing.T) {
+	sockPath := docServer(t, func(conn net.Conn, _ protocol.DocSubscribeMessage) {
+		sendDelivery(t, conn, protocol.DocSubscribeResult{
+			Delivery: 1, AsOfSeq: 7, Order: []string{"a"},
+			Upsert: []protocol.StoredDocument{doc("a", `{}`, 1)},
+		})
+		// and then simply goes away, the way a daemon that was restarted does.
+	})
+
+	var seen int
+	err := New(sockPath).DocSubscribe(protocol.DocumentQuery{}, nil, func(DocWindow) bool {
+		seen++
+		return true
+	})
+	if seen != 1 {
+		t.Fatalf("the subscriber saw %d windows, want the one that was sent", seen)
+	}
+	code, ended := DocSubscriptionCode(err)
+	if !ended {
+		t.Fatalf("a daemon that went away reported %v", err)
+	}
+	if code != "" {
+		t.Fatalf("a lost connection carried code %q, and there is nothing for a caller to branch on", code)
+	}
+}
+
+// The daemon's coded ending has to survive the read loop as a code, because a UI
+// host branches on it: `collection_undefined` kills the tile, an empty code
+// reconnects.
+func TestACodedEndingKeepsItsCode(t *testing.T) {
+	sockPath := docServer(t, func(conn net.Conn, _ protocol.DocSubscribeMessage) {
+		json.NewEncoder(conn).Encode(protocol.Response{
+			Ok:        false,
+			Error:     protocol.Ptr("collection undefined while subscribed"),
+			ErrorCode: protocol.Ptr(protocol.ErrorCodeCollectionUndefined),
+		})
+	})
+
+	err := New(sockPath).DocSubscribe(protocol.DocumentQuery{}, nil, func(DocWindow) bool { return true })
+	code, ended := DocSubscriptionCode(err)
+	if !ended || code != protocol.ErrorCodeCollectionUndefined {
+		t.Fatalf("ended=%v code=%q, want the daemon's %q", ended, code, protocol.ErrorCodeCollectionUndefined)
+	}
+	if got := err.Error(); got == "" {
+		t.Fatalf("the ending carried no message")
+	}
+}
+
+// Resuming declares revisions, not bodies. The wire carries the pairs; the
+// caller hands over whole documents so that everything it declared is also
+// something it can render.
+func TestResumingDeclaresTheRevisionsOfWhatIsHeld(t *testing.T) {
+	declared := make(chan []protocol.DocumentRevision, 1)
+	sockPath := docServer(t, func(conn net.Conn, msg protocol.DocSubscribeMessage) {
+		declared <- msg.Have
+		sendDelivery(t, conn, protocol.DocSubscribeResult{Delivery: 1, Order: []string{"a"}})
+	})
+
+	held := []protocol.StoredDocument{doc("a", `{"n":1}`, 4)}
+	window := make(chan DocWindow, 1)
+	err := New(sockPath).DocSubscribe(protocol.DocumentQuery{}, held, func(w DocWindow) bool {
+		window <- w
+		return false
+	})
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	have := <-declared
+	if len(have) != 1 || have[0].ID != "a" || have[0].Rev != 4 {
+		t.Fatalf("declared %+v, want a@4", have)
+	}
+	// And the body it never re-sent came out of the cache the caller seeded.
+	got := <-window
+	if len(got.Documents) != 1 || got.Documents[0].Body != `{"n":1}` {
+		t.Fatalf("resumed window is %+v, want the held body", got.Documents)
+	}
+	if len(got.Changed) != 0 {
+		t.Fatalf("the resumed window reported %v as changed, and nothing did", got.Changed)
+	}
+}
+
+func TestApplyingADeliveryFollowsTheClientRule(t *testing.T) {
+	cache := map[string]protocol.StoredDocument{
+		"a": doc("a", `{"v":"old"}`, 1),
+		"b": doc("b", `{"v":"kept"}`, 1),
+		"c": doc("c", `{"v":"gone"}`, 1),
+	}
+	window, err := applyDocDelivery(cache, &protocol.DocSubscribeResult{
+		Delivery: 3,
+		AsOfSeq:  42,
+		Order:    []string{"b", "a"},
+		Upsert:   []protocol.StoredDocument{doc("a", `{"v":"new"}`, 2)},
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if window.Delivery != 3 || window.AsOfSeq != 42 {
+		t.Fatalf("window is delivery %d as of %d", window.Delivery, window.AsOfSeq)
+	}
+	// Order decides the order, an upsert overrides the cache, and the cached
+	// body is used untouched for what did not travel.
+	if len(window.Documents) != 2 ||
+		window.Documents[0].Body != `{"v":"kept"}` ||
+		window.Documents[1].Body != `{"v":"new"}` {
+		t.Fatalf("applied %+v", window.Documents)
+	}
+	if len(window.Changed) != 1 || window.Changed[0] != "a" {
+		t.Fatalf("changed is %v, want only the body that travelled", window.Changed)
+	}
+	// Forget everything not named in order: the cache is the window, not a
+	// history, which is what bounds a long-lived subscription's memory.
+	if _, still := cache["c"]; still {
+		t.Fatalf("a document that left the window is still cached")
+	}
+	if len(cache) != 2 {
+		t.Fatalf("cache holds %d documents after a 2-document window", len(cache))
+	}
+}
+
+// The one case a subscriber cannot render: the daemon believes it holds a body
+// it does not. Reporting it beats drawing a window with a hole in it, and the
+// message says how to recover.
+func TestADeliveryOrderingAnUnheldDocumentEndsTheSubscription(t *testing.T) {
+	_, err := applyDocDelivery(map[string]protocol.StoredDocument{}, &protocol.DocSubscribeResult{
+		Delivery: 1,
+		Order:    []string{"ghost"},
+	})
+	code, ended := DocSubscriptionCode(err)
+	if !ended {
+		t.Fatalf("apply returned %v, want a subscription ending", err)
+	}
+	if code != "" {
+		t.Fatalf("a client-side failure carried daemon code %q", code)
+	}
+	if !strings.Contains(err.Error(), "ghost") || !strings.Contains(err.Error(), "resubscribe") {
+		t.Fatalf("the ending does not say what is missing or what to do: %v", err)
+	}
+}
+
+func TestDocSubscriptionCodeIgnoresOtherErrors(t *testing.T) {
+	if _, ended := DocSubscriptionCode(nil); ended {
+		t.Fatalf("nil is a subscription ending")
+	}
+	if _, ended := DocSubscriptionCode(errString("connection refused")); ended {
+		t.Fatalf("an ordinary error is a subscription ending")
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/internal/daemon/documents.go
+++ b/internal/daemon/documents.go
@@ -18,16 +18,25 @@ import (
 // The document store's daemon half: the fact a write publishes, the live queries
 // that fact wakes, and the IPC surface `attn doc` speaks.
 //
-// WHY A SUBSCRIPTION RE-RUNS RATHER THAN PATCHES. Every delivery is the query's
-// current full result set. A patch stream would be smaller and it is where live
-// query systems grow their bugs: a document falling out of a `limit 20` window
-// forces a re-query to find the 21st anyway, so a patch path needs the re-run
-// path underneath it and only some of the time. Re-running always is one path.
+// WHY A SUBSCRIPTION RE-RUNS RATHER THAN PATCHES. Every delivery re-runs the
+// whole query. A patch stream would avoid the re-run and it is where live query
+// systems grow their bugs: a document falling out of a `limit 20` window forces
+// a re-query to find the 21st anyway, so a patch path needs the re-run path
+// underneath it and only some of the time. Re-running always is one path.
 //
-// That also makes a delivery safe to drop. Because each one supersedes the last,
-// a subscriber that has not drained loses nothing when a newer result set
-// replaces a queued one — which is how the one-slot wake channel below collapses
-// a burst of writes into a single delivery with no coalescing window to manage.
+// What a delivery carries is a different question from how it is computed. The
+// re-run answers "which documents, in what order"; the bodies are then diffed
+// against what this subscriber is known to hold, so a window of a hundred
+// documents whose first one changed is one body and a hundred ids. That diff is
+// pure bookkeeping over one map — no second notion of what changed, and nothing
+// a patch stream's ordering hazards can reach.
+//
+// A delivery is still safe to drop, which is what the one-slot wake channel
+// below relies on: each delivery is computed from current state at the moment it
+// is sent, so a subscriber that has not drained loses nothing when a burst of
+// writes collapses into one delivery. What it must NOT lose is the record of
+// what it holds — that lives beside the connection, advances only when a
+// delivery is actually encoded, and is what makes dropping the rest correct.
 //
 // WHY THE BUS FAN-OUT DOES NOT WRITE THE SOCKET. The bus holds its publish lock
 // across the inline fan-out, so anything slow inside a handler stalls every
@@ -208,24 +217,6 @@ func (d *Daemon) documentSubscriptionCount() int {
 	return len(d.docSubs)
 }
 
-// compileDocQuery resolves the query's after cursor and compiles it. The cursor
-// is a document id, so the anchor has to be read here: docstore holds no
-// database handle, and it needs the anchor's sort value to compare against the
-// whole ordering tuple.
-func (d *Daemon) compileDocQuery(q docstore.Query, schema docstore.CollectionSchema) (docstore.Compiled, error) {
-	var anchor *docstore.Document
-	if q.After != "" {
-		doc, found, err := d.store.GetDocument(schema, q.After)
-		if err != nil {
-			return docstore.Compiled{}, err
-		}
-		if found {
-			anchor = doc
-		}
-	}
-	return q.Compile(schema, anchor)
-}
-
 // runDocQuery answers a query, returning the store's read — documents, the
 // declaration they were computed against, and the log position they were true
 // at — plus how long it took. The caller decides what a slow one means: once
@@ -351,11 +342,46 @@ func undeclaredCollectionError(namespace, collection string) error {
 //
 // The message text is unchanged and stays the part a human or an agent reads.
 func (d *Daemon) sendDocError(conn net.Conn, err error) {
-	resp := protocol.Response{Ok: false, Error: protocol.Ptr(err.Error())}
-	var conflict *docstore.ConflictError
+	d.sendDocErrorAs(conn, err, docErrorCode(err))
+}
+
+// docErrorCode is the code a docstore error answers a request with.
+func docErrorCode(err error) string {
 	switch {
-	case errors.As(err, &conflict):
-		resp.ErrorCode = protocol.Ptr(protocol.ErrorCodeConflict)
+	case docstore.IsConflict(err):
+		return protocol.ErrorCodeConflict
+	case docstore.IsUndeclaredCollection(err):
+		return protocol.ErrorCodeUndeclaredCollection
+	case docstore.IsInvalidQuery(err):
+		return protocol.ErrorCodeInvalidQuery
+	}
+	return ""
+}
+
+// subscriptionEndCode is the code the SAME errors carry once a subscription has
+// been accepted, where they mean something different. Answering a request,
+// "this collection is not declared" and "this query is wrong" are both things
+// the caller got wrong. Ending an accepted subscription they are things that
+// happened TO it — the collection was removed, or redeclared without a field
+// the query uses — and a UI host has to tell those apart to know whether to
+// kill the tile or rewrite its query.
+func subscriptionEndCode(err error) string {
+	switch {
+	case docstore.IsUndeclaredCollection(err):
+		return protocol.ErrorCodeCollectionUndefined
+	case docstore.IsInvalidQuery(err):
+		return protocol.ErrorCodeCollectionRedeclared
+	}
+	return docErrorCode(err)
+}
+
+func (d *Daemon) sendDocErrorAs(conn net.Conn, err error, code string) {
+	resp := protocol.Response{Ok: false, Error: protocol.Ptr(err.Error())}
+	if code != "" {
+		resp.ErrorCode = protocol.Ptr(code)
+	}
+	var conflict *docstore.ConflictError
+	if errors.As(err, &conflict) {
 		resp.ErrorConflict = &protocol.DocumentConflict{
 			Namespace:  conflict.Namespace,
 			Collection: conflict.Collection,
@@ -364,10 +390,6 @@ func (d *Daemon) sendDocError(conn net.Conn, err error) {
 			Found:      conflict.Found,
 			Actual:     int(conflict.Actual),
 		}
-	case docstore.IsUndeclaredCollection(err):
-		resp.ErrorCode = protocol.Ptr(protocol.ErrorCodeUndeclaredCollection)
-	case docstore.IsInvalidQuery(err):
-		resp.ErrorCode = protocol.Ptr(protocol.ErrorCodeInvalidQuery)
 	}
 	if err := json.NewEncoder(conn).Encode(resp); err != nil {
 		d.logf("docstore: writing error response: %v", err)
@@ -610,32 +632,32 @@ func (d *Daemon) handleDocCount(conn net.Conn, msg *protocol.DocCountMessage) {
 }
 
 // handleDocSubscribe is the only handler that keeps its connection. It writes
-// the current result set immediately — a subscriber must be able to render from
-// one round trip, which is what makes an extension UI's remount cheap — and then
-// a fresh one every time a write to the collection could have changed it. It
-// ends when the caller disconnects, or when the collection stops being able to
-// answer the query at all.
+// the query's current window immediately — a subscriber must be able to render
+// from one round trip, which is what makes an extension UI's remount cheap — and
+// then a fresh one every time a write to the collection could have changed it.
+// It ends when the caller disconnects, or when the collection stops being able
+// to answer the query at all.
+//
+// A delivery is a window, not a result set: the ids in order, plus only the
+// bodies the subscriber does not already hold. What it holds comes from `have`
+// on the way in and from what has been delivered since, tracked below as one
+// {id: rev} map. See DocSubscribeResult on the wire for the client's one rule.
 func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMessage) {
 	q, err := documentQueryFromProtocol(msg.Query)
 	if err != nil {
 		d.sendDocError(conn, err)
 		return
 	}
-	schema, err := d.collectionFor(q.Namespace, q.Collection)
-	if err != nil {
-		d.sendDocError(conn, err)
-		return
-	}
-	// Compile once up front. A query that cannot compile must fail the subscribe
-	// rather than fail on every delivery of a subscription that looked accepted.
-	if _, err := d.compileDocQuery(q, *schema); err != nil {
-		d.sendDocError(conn, err)
+	if q.After != "" {
+		d.sendDocError(conn, docstore.InvalidQuery(fmt.Errorf(
+			"docstore: %s/%s cannot subscribe with the after cursor %q: a live query is a window and a cursor is a walk, so the document the cursor names moves out from under the subscription. Set a limit instead and render each delivery's window; a delivery already carries only what changed.",
+			q.Namespace, q.Collection, q.After)))
 		return
 	}
 
 	// Registered before the first query runs. The other order drops a write that
-	// lands in between; this order can only cause one redundant delivery, and a
-	// delivery is the whole result set, so a redundant one costs nothing.
+	// lands in between; this order can only cause one redundant delivery, which
+	// costs the subscriber an ids-only message.
 	sub := d.addDocSubscription(q)
 	defer d.removeDocSubscription(sub.id)
 
@@ -646,6 +668,12 @@ func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMes
 		defer close(gone)
 		_, _ = io.Copy(io.Discard, conn)
 	}()
+
+	// What the subscriber holds. Seeded from `have`, then replaced by each
+	// delivered window: the client's forget rule means anything absent from a
+	// window's order is gone from its cache too, so this map is the window and
+	// never grows past the query's limit.
+	held := heldRevisions(msg.Have)
 
 	encoder := json.NewEncoder(conn)
 	for delivery := 1; ; delivery++ {
@@ -660,28 +688,70 @@ func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMes
 		// serve again. The re-read happens inside the query's own transaction, so
 		// a redeclare cannot land between reading the declaration and running the
 		// statement compiled from it.
+		//
+		// The first of these reads is also the acceptance check: a query that
+		// cannot be answered fails the subscribe, in the same call that would
+		// have served it. There is no separate compile up front, because a second
+		// compile path is a second place for the rules to be applied differently.
 		read, took, err := d.runDocQuery(q)
 		if err != nil {
-			d.sendDocError(conn, err)
+			code := docErrorCode(err)
+			if delivery > 1 {
+				code = subscriptionEndCode(err)
+			}
+			d.sendDocErrorAs(conn, err, code)
 			return
 		}
 		d.logSlowDocFanOut(sub, read.Schema, took)
-		resp := protocol.Response{
-			Ok: true,
-			DocSubscribeResult: &protocol.DocSubscribeResult{
-				Delivery:  delivery,
-				Documents: storedDocumentsToProtocol(read.Documents),
-			},
-		}
-		if err := encoder.Encode(resp); err != nil {
+		window, next := windowDelivery(delivery, read, held)
+		if err := encoder.Encode(protocol.Response{Ok: true, DocSubscribeResult: window}); err != nil {
 			return
 		}
+		held = next
 		select {
 		case <-sub.wake:
 		case <-gone:
 			return
 		}
 	}
+}
+
+// heldRevisions turns the subscriber's declared `have` into the map the
+// delivery loop diffs against. A resume is exact rather than approximate: an id
+// claiming a revision the store never issued simply differs from the one it
+// finds, so that body is sent and the subscriber converges on the next delivery
+// however stale its claim was.
+func heldRevisions(have []protocol.DocumentRevision) map[string]int64 {
+	if len(have) == 0 {
+		return nil
+	}
+	held := make(map[string]int64, len(have))
+	for _, entry := range have {
+		held[entry.ID] = int64(entry.Rev)
+	}
+	return held
+}
+
+// windowDelivery turns a read into one delivery and the revisions the subscriber
+// holds once it applies it. A body travels only when the subscriber's revision
+// for that id differs from the stored one; everything else is carried by order,
+// which the client renders from its cache.
+func windowDelivery(delivery int, read store.QueryRead, held map[string]int64) (*protocol.DocSubscribeResult, map[string]int64) {
+	out := &protocol.DocSubscribeResult{
+		Delivery: delivery,
+		AsOfSeq:  int(read.AsOfSeq),
+		Order:    make([]string, 0, len(read.Documents)),
+		Upsert:   make([]protocol.StoredDocument, 0),
+	}
+	next := make(map[string]int64, len(read.Documents))
+	for _, doc := range read.Documents {
+		out.Order = append(out.Order, doc.ID)
+		next[doc.ID] = doc.Rev
+		if rev, ok := held[doc.ID]; !ok || rev != doc.Rev {
+			out.Upsert = append(out.Upsert, storedDocumentToProtocol(doc))
+		}
+	}
+	return out, next
 }
 
 func (d *Daemon) sendDocResponse(conn net.Conn, resp protocol.Response) {

--- a/internal/daemon/documents_socket_test.go
+++ b/internal/daemon/documents_socket_test.go
@@ -1,0 +1,162 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/client"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// The document store end to end over a real unix socket, through the same
+// internal/client every other caller uses.
+//
+// Every other test in this package calls a handler with a net.Pipe on both ends,
+// which proves the handler and proves nothing about the seam. This one is the
+// only place where the wire encoding, the client's own read loop and its
+// application of the window rule are exercised together — and A4's SDK sits
+// directly on that read loop, so it stops being untested before anything is
+// built on it.
+func TestDocumentsOverARealSocket(t *testing.T) {
+	useFreeWSPort(t)
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
+
+	d := NewForTesting(sockPath)
+	go d.Start()
+	defer d.Stop()
+	waitForSocket(t, sockPath, 5*time.Second)
+
+	c := client.New(sockPath)
+
+	if _, err := c.DocDefine(protocol.DocumentCollectionSchema{
+		Namespace:  testDocNS,
+		Collection: testDocColl,
+		Fields:     []protocol.DocumentFieldSpec{{Name: "status", Type: "string"}},
+	}); err != nil {
+		t.Fatalf("define: %v", err)
+	}
+	for _, id := range []string{"a", "b"} {
+		if _, err := c.DocPut(testDocNS, testDocColl, id, `{"status":"pending"}`, nil); err != nil {
+			t.Fatalf("put %s: %v", id, err)
+		}
+	}
+
+	q := protocol.DocumentQuery{Namespace: testDocNS, Collection: testDocColl}
+	read, err := c.DocQuery(q)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(read.Documents) != 2 {
+		t.Fatalf("query returned %d documents, want 2", len(read.Documents))
+	}
+	if read.AsOfSeq <= 0 {
+		t.Fatalf("query answered as of seq %d; two writes have landed", read.AsOfSeq)
+	}
+
+	// A fresh subscription: the first window carries every body, and a write
+	// made while it is open carries only the body that changed. The write is
+	// made from inside the callback so it lands while the read loop is running,
+	// which is the only way to observe a delivery that is not the first.
+	var windows []client.DocWindow
+	var putSeq int
+	err = c.DocSubscribe(q, nil, func(w client.DocWindow) bool {
+		windows = append(windows, w)
+		if len(windows) == 1 {
+			go func() {
+				result, err := c.DocPut(testDocNS, testDocColl, "c", `{"status":"pending"}`, nil)
+				if err == nil {
+					putSeq = result.Seq
+				}
+			}()
+		}
+		return len(windows) < 2
+	})
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	if got := len(windows[0].Changed); got != 2 {
+		t.Fatalf("the first window sent %d bodies, want 2 — a fresh subscriber holds nothing", got)
+	}
+	live := windows[1]
+	if len(live.Documents) != 3 {
+		t.Fatalf("the live window holds %d documents, want 3", len(live.Documents))
+	}
+	if len(live.Changed) != 1 || live.Changed[0] != "c" {
+		t.Fatalf("the live window sent %v, want only the document that was written", live.Changed)
+	}
+	if live.AsOfSeq < int64(putSeq) {
+		t.Fatalf("the live window is as of seq %d, below the write it reflects at %d", live.AsOfSeq, putSeq)
+	}
+
+	// Resume. Between the two subscriptions a document is removed and another is
+	// edited, so the resumed window must carry exactly one body — and the client
+	// must be able to render the two it kept.
+	held := live.Documents
+	if _, err := c.DocDelete(testDocNS, testDocColl, "a", nil); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := c.DocPut(testDocNS, testDocColl, "b", `{"status":"approved"}`, nil); err != nil {
+		t.Fatalf("edit: %v", err)
+	}
+
+	var resumed client.DocWindow
+	err = c.DocSubscribe(q, held, func(w client.DocWindow) bool {
+		resumed = w
+		return false
+	})
+	if err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if len(resumed.Documents) != 2 {
+		t.Fatalf("resumed window holds %d documents, want 2", len(resumed.Documents))
+	}
+	if len(resumed.Changed) != 1 || resumed.Changed[0] != "b" {
+		t.Fatalf("resume sent %v, want only the document edited while away", resumed.Changed)
+	}
+	for _, doc := range resumed.Documents {
+		switch doc.ID {
+		case "b":
+			if doc.Body != `{"status":"approved"}` {
+				t.Fatalf("b applied as %s", doc.Body)
+			}
+		case "c":
+			// Never re-sent; this body came out of the client's own cache,
+			// which is the whole point of resuming by content.
+			if doc.Body != `{"status":"pending"}` {
+				t.Fatalf("c applied as %s", doc.Body)
+			}
+		default:
+			t.Fatalf("resumed window holds %q", doc.ID)
+		}
+	}
+
+	// Teardown. Removing the collection ends the live query with the code a UI
+	// host branches on, and the client reports it as an error rather than as a
+	// clean end — a watcher that exits 0 here is a watcher that stopped watching
+	// without saying so.
+	ended := make(chan error, 1)
+	opened := make(chan struct{})
+	go func() {
+		first := true
+		ended <- c.DocSubscribe(q, nil, func(client.DocWindow) bool {
+			if first {
+				first = false
+				close(opened)
+			}
+			return true
+		})
+	}()
+	<-opened
+	if _, err := c.DocUndefine(testDocNS, testDocColl); err != nil {
+		t.Fatalf("undefine: %v", err)
+	}
+	err = <-ended
+	code, isEnd := client.DocSubscriptionCode(err)
+	if !isEnd {
+		t.Fatalf("the subscription ended with %v, which is not a subscription ending", err)
+	}
+	if code != protocol.ErrorCodeCollectionUndefined {
+		t.Fatalf("subscription ended with code %q, want %q", code, protocol.ErrorCodeCollectionUndefined)
+	}
+}

--- a/internal/daemon/documents_test.go
+++ b/internal/daemon/documents_test.go
@@ -73,24 +73,58 @@ func deleteDoc(t *testing.T, d *Daemon, id string) bool {
 	return resp.DocDeleteResult.Existed
 }
 
+// window is one delivery as the subscriber sees it once the client rule has been
+// applied: the wire's own order and upsert, plus the documents those resolve to.
+type window struct {
+	delivery  int
+	asOfSeq   int64
+	order     []string
+	upsert    []protocol.StoredDocument
+	documents []protocol.StoredDocument
+}
+
 // liveQuery subscribes and returns a reader for its deliveries plus a stop that
 // disconnects the caller and waits for the handler to finish — the real signal
 // that the subscription has been torn down.
+//
+// It applies the client rule itself rather than calling internal/client's
+// applier: this is a second implementation of the same three sentences, and two
+// implementations disagreeing is the thing the invariant exists to catch. The
+// resolution below is also where the invariant is checked — every id in order
+// must resolve from the bodies this connection has been sent — so every test in
+// this file that reads a delivery is asserting it.
 type liveQuery struct {
 	dec  *json.Decoder
 	stop func()
+	held map[string]protocol.StoredDocument
 }
 
 func subscribe(t *testing.T, d *Daemon, q protocol.DocumentQuery) *liveQuery {
 	t.Helper()
+	return subscribeResuming(t, d, q, nil)
+}
+
+// subscribeResuming subscribes declaring what the caller already holds. held
+// seeds the applier's cache so a resumed subscription's deliveries resolve the
+// same way a reconnecting client's would.
+func subscribeResuming(t *testing.T, d *Daemon, q protocol.DocumentQuery, held []protocol.StoredDocument) *liveQuery {
+	t.Helper()
+	have := make([]protocol.DocumentRevision, 0, len(held))
+	cache := make(map[string]protocol.StoredDocument, len(held))
+	for _, doc := range held {
+		have = append(have, protocol.DocumentRevision{ID: doc.ID, Rev: doc.Rev})
+		cache[doc.ID] = doc
+	}
 	client, server := net.Pipe()
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		d.handleDocSubscribe(server, &protocol.DocSubscribeMessage{Cmd: protocol.CmdDocSubscribe, Query: q})
+		d.handleDocSubscribe(server, &protocol.DocSubscribeMessage{
+			Cmd: protocol.CmdDocSubscribe, Query: q, Have: have,
+		})
 		_ = server.Close()
 	}()
-	lq := &liveQuery{dec: json.NewDecoder(client)}
+	lq := &liveQuery{dec: json.NewDecoder(client), held: cache}
 	lq.stop = func() {
 		_ = client.Close()
 		<-done
@@ -99,9 +133,10 @@ func subscribe(t *testing.T, d *Daemon, q protocol.DocumentQuery) *liveQuery {
 	return lq
 }
 
-// next reads one delivery. It blocks until the daemon sends, which is what makes
-// these tests wait on a real signal rather than on a duration.
-func (lq *liveQuery) next(t *testing.T) *protocol.DocSubscribeResult {
+// next reads one delivery and applies it. It blocks until the daemon sends,
+// which is what makes these tests wait on a real signal rather than on a
+// duration.
+func (lq *liveQuery) next(t *testing.T) window {
 	t.Helper()
 	resp := lq.nextRaw(t)
 	if !resp.Ok {
@@ -110,7 +145,38 @@ func (lq *liveQuery) next(t *testing.T) *protocol.DocSubscribeResult {
 	if resp.DocSubscribeResult == nil {
 		t.Fatal("delivery carried no result")
 	}
-	return resp.DocSubscribeResult
+	return lq.apply(t, resp.DocSubscribeResult)
+}
+
+// apply is the client rule: render order, take each body from upsert if it is
+// there and from the cache otherwise, forget everything not in order.
+func (lq *liveQuery) apply(t *testing.T, result *protocol.DocSubscribeResult) window {
+	t.Helper()
+	arrived := make(map[string]protocol.StoredDocument, len(result.Upsert))
+	for _, doc := range result.Upsert {
+		arrived[doc.ID] = doc
+	}
+	out := window{
+		delivery: result.Delivery,
+		asOfSeq:  int64(result.AsOfSeq),
+		order:    result.Order,
+		upsert:   result.Upsert,
+	}
+	next := make(map[string]protocol.StoredDocument, len(result.Order))
+	for _, id := range result.Order {
+		doc, ok := arrived[id]
+		if !ok {
+			doc, ok = lq.held[id]
+		}
+		if !ok {
+			t.Fatalf("delivery %d ordered %q but neither sent its body nor had this subscriber been given one: %v",
+				result.Delivery, id, result.Order)
+		}
+		next[id] = doc
+		out.documents = append(out.documents, doc)
+	}
+	lq.held = next
+	return out
 }
 
 // nextRaw reads one delivery without requiring it to have succeeded, for the
@@ -124,39 +190,44 @@ func (lq *liveQuery) nextRaw(t *testing.T) protocol.Response {
 	return resp
 }
 
-func ids(result *protocol.DocSubscribeResult) []string {
-	out := make([]string, 0, len(result.Documents))
-	for _, doc := range result.Documents {
+// changed names the ids whose bodies travelled in this delivery.
+func (w window) changed() []string {
+	out := make([]string, 0, len(w.upsert))
+	for _, doc := range w.upsert {
 		out = append(out, doc.ID)
 	}
 	return out
 }
 
+func ids(w window) []string { return w.order }
+
 func testQuery() protocol.DocumentQuery {
 	return protocol.DocumentQuery{Namespace: testDocNS, Collection: testDocColl}
 }
 
-// Subscribing delivers the current result set straight away, in the same round
-// trip. An extension UI remounts by re-subscribing, so a subscription that only
-// promised future updates would render empty until something happened to change.
-func TestSubscribingDeliversTheCurrentResultSetImmediately(t *testing.T) {
+// Subscribing delivers the query's current window straight away, in the same
+// round trip. An extension UI remounts by re-subscribing, so a subscription that
+// only promised future updates would render empty until something happened to
+// change.
+func TestSubscribingDeliversTheCurrentWindowImmediately(t *testing.T) {
 	d := newDaemonForTest(t)
 	defineTestCollection(t, d)
 	putDoc(t, d, "already-here", `{"status":"pending"}`)
 
 	lq := subscribe(t, d, testQuery())
 	first := lq.next(t)
-	if first.Delivery != 1 {
-		t.Fatalf("first delivery = %d, want 1", first.Delivery)
+	if first.delivery != 1 {
+		t.Fatalf("first delivery = %d, want 1", first.delivery)
 	}
 	if got := ids(first); len(got) != 1 || got[0] != "already-here" {
 		t.Fatalf("first delivery = %v", got)
 	}
 }
 
-// A write wakes the subscription, and what arrives is the whole current result
-// set rather than a description of what changed.
-func TestAWriteWakesTheSubscriptionWithTheWholeResultSet(t *testing.T) {
+// A write wakes the subscription, and what arrives is the query's whole current
+// order — never a patch the subscriber has to merge — plus the one body it does
+// not hold.
+func TestAWriteWakesTheSubscriptionWithTheCurrentWindow(t *testing.T) {
 	d := newDaemonForTest(t)
 	defineTestCollection(t, d)
 	lq := subscribe(t, d, testQuery())
@@ -166,14 +237,17 @@ func TestAWriteWakesTheSubscriptionWithTheWholeResultSet(t *testing.T) {
 
 	putDoc(t, d, "a", `{"status":"pending"}`)
 	second := lq.next(t)
-	if second.Delivery != 2 {
-		t.Fatalf("delivery = %d, want 2", second.Delivery)
+	if second.delivery != 2 {
+		t.Fatalf("delivery = %d, want 2", second.delivery)
 	}
 	if got := ids(second); len(got) != 1 || got[0] != "a" {
 		t.Fatalf("after write = %v", got)
 	}
-	if body := second.Documents[0].Body; body != `{"status":"pending"}` {
+	if body := second.documents[0].Body; body != `{"status":"pending"}` {
 		t.Fatalf("body = %s", body)
+	}
+	if got := second.changed(); len(got) != 1 || got[0] != "a" {
+		t.Fatalf("bodies sent = %v, want just the document that changed", got)
 	}
 }
 
@@ -193,8 +267,8 @@ func TestANoOpDeleteDoesNotWakeSubscribers(t *testing.T) {
 	putDoc(t, d, "a", `{"status":"pending"}`)
 
 	next := lq.next(t)
-	if next.Delivery != 2 {
-		t.Fatalf("delivery = %d, want 2 — the no-op delete delivered", next.Delivery)
+	if next.delivery != 2 {
+		t.Fatalf("delivery = %d, want 2 — the no-op delete delivered", next.delivery)
 	}
 	if got := ids(next); len(got) != 1 || got[0] != "a" {
 		t.Fatalf("delivery = %v", got)
@@ -253,8 +327,8 @@ func TestASubscriptionOnlyWakesForItsOwnCollection(t *testing.T) {
 	putDoc(t, d, "ours", `{"status":"pending"}`)
 
 	next := lq.next(t)
-	if next.Delivery != 2 {
-		t.Fatalf("delivery = %d, want 2 — the neighbouring namespace woke this subscription", next.Delivery)
+	if next.delivery != 2 {
+		t.Fatalf("delivery = %d, want 2 — the neighbouring namespace woke this subscription", next.delivery)
 	}
 	if got := ids(next); len(got) != 1 || got[0] != "ours" {
 		t.Fatalf("delivery = %v — it crossed the namespace boundary", got)
@@ -312,19 +386,32 @@ func TestReadingAnUndeclaredCollectionSaysHowToDeclareIt(t *testing.T) {
 	}
 }
 
-// A subscription whose query cannot compile is refused at subscribe time. The
-// alternative is a subscription that looks accepted and fails on every delivery.
+// A subscription whose query cannot be answered is refused at subscribe time,
+// by the same read that would have served it. The alternative is a subscription
+// that looks accepted and fails on every delivery.
+//
+// The refusal carries invalid_query rather than either subscription-ending code:
+// nothing happened to this subscription, the caller asked for something the
+// collection does not offer, and resubscribing with a corrected query works.
 func TestASubscriptionWithAnUnqueryableFieldIsRefusedUpFront(t *testing.T) {
 	d := newDaemonForTest(t)
 	defineTestCollection(t, d)
 	q := testQuery()
 	q.Sort = &protocol.DocumentSort{Field: "undeclared"}
-	resp := docCall(t, func(c net.Conn) {
-		d.handleDocSubscribe(c, &protocol.DocSubscribeMessage{Cmd: protocol.CmdDocSubscribe, Query: q})
-	})
+
+	lq := subscribe(t, d, q)
+	resp := lq.nextRaw(t)
 	if resp.Ok {
 		t.Fatal("subscribing with an undeclared sort field succeeded")
 	}
+	if code := protocol.Deref(resp.ErrorCode); code != protocol.ErrorCodeInvalidQuery {
+		t.Fatalf("error code = %q, want %q", code, protocol.ErrorCodeInvalidQuery)
+	}
+	// stop waits for the handler to return, which is when a registered
+	// subscription would have been removed. Registering before the first read is
+	// deliberate — it is what keeps a write landing mid-subscribe from being
+	// missed — so what has to hold is that a refusal still leaves nothing behind.
+	lq.stop()
 	if n := d.documentSubscriptionCount(); n != 0 {
 		t.Fatalf("a refused subscribe left %d subscriptions behind", n)
 	}
@@ -390,6 +477,11 @@ func TestRemovingACollectionReachesItsLiveQueries(t *testing.T) {
 	}
 	if msg := protocol.Deref(final.Error); !strings.Contains(msg, "is not declared") {
 		t.Fatalf("error does not say the collection is gone: %q", msg)
+	}
+	// The code is what a UI host branches on: collection_undefined means the
+	// tile is dead, not that its query was wrong.
+	if code := protocol.Deref(final.ErrorCode); code != protocol.ErrorCodeCollectionUndefined {
+		t.Fatalf("error code = %q, want %q", code, protocol.ErrorCodeCollectionUndefined)
 	}
 }
 
@@ -488,6 +580,11 @@ func TestRedeclaringWithoutAFieldEndsTheLiveQueriesUsingIt(t *testing.T) {
 	}
 	if msg := protocol.Deref(final.Error); !strings.Contains(msg, "status") {
 		t.Fatalf("error does not name the field that went: %q", msg)
+	}
+	// collection_redeclared rather than collection_undefined: the collection is
+	// still there, and it is the query that can never be answered again.
+	if code := protocol.Deref(final.ErrorCode); code != protocol.ErrorCodeCollectionRedeclared {
+		t.Fatalf("error code = %q, want %q", code, protocol.ErrorCodeCollectionRedeclared)
 	}
 }
 
@@ -592,8 +689,8 @@ func TestARefusedWriteDoesNotWakeSubscribers(t *testing.T) {
 	if got := ids(next); len(got) != 2 {
 		t.Fatalf("first delivery after the refused write = %v, want both documents", got)
 	}
-	if next.Delivery != 2 {
-		t.Fatalf("delivery = %d, want 2 — something delivered in between", next.Delivery)
+	if next.delivery != 2 {
+		t.Fatalf("delivery = %d, want 2 — something delivered in between", next.delivery)
 	}
 }
 

--- a/internal/daemon/documents_windowed_test.go
+++ b/internal/daemon/documents_windowed_test.go
@@ -1,0 +1,607 @@
+package daemon
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// The windowed subscription's battery.
+//
+// Every assertion here is an inequality or an equality between two receipts the
+// wire itself carries — a write's seq against a delivery's as_of_seq, a delivered
+// window against a fresh query's answer. None of them waits on a duration,
+// because a subscription test that needs a sleep is a subscription test that has
+// stopped proving anything about the case where the machine is slow.
+//
+// See docs/plans/2026-08-05-ext-a3.4-doc-store-positions-and-windows.md.
+
+// ---------------------------------------------------------------------------
+// Receipts the tests below compare
+// ---------------------------------------------------------------------------
+
+// putDocSeq writes and returns the position the write landed at.
+func putDocSeq(t *testing.T, d *Daemon, id, body string) int64 {
+	t.Helper()
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocPut(c, &protocol.DocPutMessage{
+			Cmd: protocol.CmdDocPut, Namespace: testDocNS, Collection: testDocColl, ID: id, Body: body,
+		})
+	})
+	if !resp.Ok {
+		t.Fatalf("put %s: %v", id, protocol.Deref(resp.Error))
+	}
+	return int64(resp.DocPutResult.Seq)
+}
+
+// deleteDocSeq removes and returns the position, which is 0 when the delete
+// removed nothing — nothing changed, so nothing was announced.
+func deleteDocSeq(t *testing.T, d *Daemon, id string) int64 {
+	t.Helper()
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocDelete(c, &protocol.DocDeleteMessage{
+			Cmd: protocol.CmdDocDelete, Namespace: testDocNS, Collection: testDocColl, ID: id,
+		})
+	})
+	if !resp.Ok {
+		t.Fatalf("delete %s: %v", id, protocol.Deref(resp.Error))
+	}
+	return int64(resp.DocDeleteResult.Seq)
+}
+
+// queryIDs answers the same query one-shot, which is what a delivered window is
+// checked against: the subscription must never show a state a fresh read
+// disagrees with.
+func queryIDs(t *testing.T, d *Daemon, q protocol.DocumentQuery) []string {
+	t.Helper()
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocQuery(c, &protocol.DocQueryMessage{Cmd: protocol.CmdDocQuery, Query: q})
+	})
+	if !resp.Ok {
+		t.Fatalf("query: %v", protocol.Deref(resp.Error))
+	}
+	out := make([]string, 0, len(resp.DocQueryResult.Documents))
+	for _, doc := range resp.DocQueryResult.Documents {
+		out = append(out, doc.ID)
+	}
+	return out
+}
+
+// settle reads deliveries until one is at least as current as seq, and returns
+// it. This is the whole reason writes report a position: "the subscription has
+// caught up" used to be unwritable without waiting on a duration, and is now an
+// inequality between two numbers the protocol already carries.
+//
+// It cannot hang. A delivery is computed after the wake it consumed, and a wake
+// is set after the write commits, so a delivery reporting a position below seq
+// consumed a wake older than that write — which means that write's own wake is
+// still pending and another delivery follows.
+func (lq *liveQuery) settle(t *testing.T, seq int64) window {
+	t.Helper()
+	for {
+		w := lq.next(t)
+		if w.asOfSeq >= seq {
+			return w
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Subscribe refuses a cursor
+// ---------------------------------------------------------------------------
+
+// A live query is a window and a cursor is a walk: the document an after cursor
+// names moves out from under a subscription, so the page it named is not the
+// page it names a write later. The refusal has to name the alternative, because
+// the reader fixing it is an agent with only the error to go on.
+func TestSubscribingWithAnAfterCursorIsRefused(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+
+	after := "a"
+	q := testQuery()
+	q.After = &after
+
+	lq := subscribe(t, d, q)
+	resp := lq.nextRaw(t)
+	if resp.Ok {
+		t.Fatal("subscribing with an after cursor was accepted")
+	}
+	if code := protocol.Deref(resp.ErrorCode); code != protocol.ErrorCodeInvalidQuery {
+		t.Fatalf("error code = %q, want %q", code, protocol.ErrorCodeInvalidQuery)
+	}
+	msg := protocol.Deref(resp.Error)
+	for _, want := range []string{"limit", "window"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("refusal %q does not name the alternative (%q)", msg, want)
+		}
+	}
+	lq.stop()
+	if n := d.documentSubscriptionCount(); n != 0 {
+		t.Fatalf("a refused subscribe left %d subscriptions behind", n)
+	}
+}
+
+// The one-shot read keeps its cursor. There is one instant in a single query, so
+// nothing moves under the anchor and the walk is correct; the refusal above is
+// about subscriptions only, and the two must not be conflated.
+func TestOneShotQueryStillTakesAnAfterCursor(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+	putDoc(t, d, "b", `{"status":"pending"}`)
+
+	after := "a"
+	q := testQuery()
+	q.After = &after
+	if got := queryIDs(t, d, q); !equalStrings(got, []string{"b"}) {
+		t.Fatalf("page after a = %v, want [b]", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Only what changed travels
+// ---------------------------------------------------------------------------
+
+// The point of the window: a delivery names every document in order and carries
+// only the bodies the subscriber does not hold. A collection where one of many
+// documents changed must not re-send the rest.
+func TestADeliveryCarriesOnlyTheBodiesThatChanged(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	for _, id := range []string{"a", "b", "c"} {
+		putDoc(t, d, id, `{"status":"pending"}`)
+	}
+
+	lq := subscribe(t, d, testQuery())
+	first := lq.next(t)
+	if got := first.changed(); len(got) != 3 {
+		t.Fatalf("the first delivery sent %d bodies, want all 3 — a fresh subscriber holds nothing", len(got))
+	}
+
+	seq := putDocSeq(t, d, "b", `{"status":"approved"}`)
+	next := lq.settle(t, seq)
+	if got := ids(next); !equalStrings(got, []string{"a", "b", "c"}) {
+		t.Fatalf("order = %v, want every document still named", got)
+	}
+	if got := next.changed(); !equalStrings(got, []string{"b"}) {
+		t.Fatalf("bodies sent = %v, want only the one that changed", got)
+	}
+	// The bodies the subscriber did not receive are the ones it kept, which is
+	// what the applied window proves.
+	for _, doc := range next.documents {
+		want := `{"status":"pending"}`
+		if doc.ID == "b" {
+			want = `{"status":"approved"}`
+		}
+		if doc.Body != want {
+			t.Fatalf("%s applied as %s, want %s", doc.ID, doc.Body, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Resume by content
+// ---------------------------------------------------------------------------
+
+// The four ways a document can differ from what a resuming subscriber holds, each
+// checked the same way: the first delivery after resuming carries exactly the
+// bodies that changed, and the applied window equals a fresh query's answer. A
+// resume that sent one body too few would render a stale document; one body too
+// many is the full refetch this design exists to avoid.
+func TestResumingSendsExactlyWhatChangedWhileAway(t *testing.T) {
+	limit := 2
+	sorted := func() protocol.DocumentQuery {
+		q := testQuery()
+		q.Sort = &protocol.DocumentSort{Field: "status"}
+		q.Limit = &limit
+		return q
+	}
+
+	cases := []struct {
+		name string
+		// mutate runs while nobody is subscribed, and reports the position of
+		// the last write it made.
+		mutate func(t *testing.T, d *Daemon) int64
+		// order is the window the resumed subscription must show.
+		order []string
+		// changed is exactly the set of bodies that must travel.
+		changed []string
+	}{
+		{
+			name:    "edited inside the window",
+			mutate:  func(t *testing.T, d *Daemon) int64 { return putDocSeq(t, d, "a", `{"status":"aa"}`) },
+			order:   []string{"a", "b"},
+			changed: []string{"a"},
+		},
+		{
+			name:    "deleted",
+			mutate:  func(t *testing.T, d *Daemon) int64 { return deleteDocSeq(t, d, "a") },
+			order:   []string{"b", "c"},
+			changed: []string{"c"},
+		},
+		{
+			name: "displaced past the limit",
+			// A new document sorting first pushes the last one out of the
+			// window. Nothing about the displaced document changed, and no fact
+			// names it — it leaves the window only because another arrived,
+			// which is the case log replay could never have reconstructed.
+			mutate:  func(t *testing.T, d *Daemon) int64 { return putDocSeq(t, d, "z", `{"status":"a0"}`) },
+			order:   []string{"z", "a"},
+			changed: []string{"z"},
+		},
+		{
+			name:    "edited out of the filter",
+			mutate:  func(t *testing.T, d *Daemon) int64 { return putDocSeq(t, d, "b", `{"status":"zz"}`) },
+			order:   []string{"a", "c"},
+			changed: []string{"c"},
+		},
+		{
+			name: "nothing changed at all",
+			// The degenerate case, and the one that proves the resume is worth
+			// having: no body travels, and the window is still complete.
+			mutate:  func(t *testing.T, d *Daemon) int64 { return 0 },
+			order:   []string{"a", "b"},
+			changed: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newDaemonForTest(t)
+			defineTestCollection(t, d)
+			putDoc(t, d, "a", `{"status":"a1"}`)
+			putDoc(t, d, "b", `{"status":"b1"}`)
+			putDoc(t, d, "c", `{"status":"c1"}`)
+
+			lq := subscribe(t, d, sorted())
+			held := lq.next(t).documents
+			if got := idsOf(held); !equalStrings(got, []string{"a", "b"}) {
+				t.Fatalf("initial window = %v, want [a b]", got)
+			}
+			lq.stop()
+
+			seq := tc.mutate(t, d)
+
+			resumed := subscribeResuming(t, d, sorted(), held)
+			first := resumed.next(t)
+			if first.asOfSeq < seq {
+				t.Fatalf("resumed at seq %d, below the write at %d", first.asOfSeq, seq)
+			}
+			if got := ids(first); !equalStrings(got, tc.order) {
+				t.Fatalf("resumed window = %v, want %v", got, tc.order)
+			}
+			if got := first.changed(); !equalStrings(got, tc.changed) {
+				t.Fatalf("bodies sent on resume = %v, want %v", got, tc.changed)
+			}
+			if got, want := ids(first), queryIDs(t, d, sorted()); !equalStrings(got, want) {
+				t.Fatalf("resumed window = %v, but a fresh query says %v", got, want)
+			}
+		})
+	}
+}
+
+// A resume token the store never issued — a revision from a subscriber that has
+// been away so long its claim is meaningless, or simply a wrong one — must
+// converge rather than mislead. The claim differs from what is stored, so the
+// body travels; the only way to get this wrong is to trust the claim.
+func TestResumingWithARevisionTheStoreNeverIssuedStillConverges(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+
+	stale := []protocol.StoredDocument{{ID: "a", Body: `{"status":"whatever this was"}`, Rev: 4242}}
+	lq := subscribeResuming(t, d, testQuery(), stale)
+	first := lq.next(t)
+	if got := first.changed(); !equalStrings(got, []string{"a"}) {
+		t.Fatalf("bodies sent = %v, want the document whose claimed revision was never issued", got)
+	}
+	if len(first.documents) != 1 || first.documents[0].Body != `{"status":"pending"}` {
+		t.Fatalf("applied window = %+v, want the stored body", first.documents)
+	}
+}
+
+// A resume that names a document the query no longer returns simply does not see
+// it: it is absent from order, and the client's forget rule collects it. There is
+// no removal field to get wrong.
+func TestResumingForgetsWhatIsNoLongerInTheWindow(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+
+	lq := subscribe(t, d, testQuery())
+	held := lq.next(t).documents
+	lq.stop()
+
+	deleteDocSeq(t, d, "a")
+
+	resumed := subscribeResuming(t, d, testQuery(), held)
+	first := resumed.next(t)
+	if len(first.order) != 0 {
+		t.Fatalf("resumed window = %v, want empty", first.order)
+	}
+	if len(first.upsert) != 0 {
+		t.Fatalf("a body travelled for a document that is not in the window: %v", first.changed())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Currency, coalescing, fan-out
+// ---------------------------------------------------------------------------
+
+// Currency under contention. A writer flips one document between two known
+// states as fast as it can; every window a subscriber sees must be one of those
+// two, and once the writer stops the subscription must reach a delivery at least
+// as current as the last write, showing what a fresh query shows.
+func TestASubscriptionStaysCurrentUnderContention(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+
+	lq := subscribe(t, d, testQuery())
+	lq.next(t)
+
+	const flips = 40
+	bodies := []string{`{"status":"pending"}`, `{"status":"approved"}`}
+
+	// The writer's last act is a sentinel document, and its arrival in a window
+	// is what ends the read loop. Reading "until the writer is done" cannot work
+	// from here: the reader would learn that only after consuming the delivery
+	// the last write caused, and would then block waiting for one that is never
+	// coming. The sentinel makes the stop condition something the wire carries.
+	var sentinelSeq int64
+	var writer sync.WaitGroup
+	writer.Add(1)
+	go func() {
+		defer writer.Done()
+		for i := range flips {
+			putDocSeq(t, d, "a", bodies[i%2])
+		}
+		sentinelSeq = putDocSeq(t, d, "sentinel", `{"status":"pending"}`)
+	}()
+
+	// Read alongside the writer. Every window is a state the collection was
+	// really in — the enumerable legal set is two bodies — and nothing here
+	// waits on a duration to say so.
+	var final window
+	for {
+		w := lq.next(t)
+		holds := false
+		for _, doc := range w.documents {
+			if doc.ID != "a" {
+				continue
+			}
+			holds = true
+			if doc.Body != bodies[0] && doc.Body != bodies[1] {
+				t.Fatalf("window showed %s, which the collection was never in", doc.Body)
+			}
+		}
+		if !holds {
+			t.Fatalf("window = %v, and the flipped document is not in it", ids(w))
+		}
+		if len(w.order) == 2 {
+			final = w
+			break
+		}
+	}
+	writer.Wait()
+
+	if final.asOfSeq < sentinelSeq {
+		t.Fatalf("the delivery carrying the last write reports seq %d, below the write's own %d",
+			final.asOfSeq, sentinelSeq)
+	}
+	if got, want := ids(final), queryIDs(t, d, testQuery()); !equalStrings(got, want) {
+		t.Fatalf("final window = %v, fresh query = %v", got, want)
+	}
+}
+
+// The one-slot wake channel's receipt. A subscriber blocked mid-encode — net.Pipe
+// gives no buffer at all, so the daemon is stuck in Write until this test reads —
+// must not accumulate one delivery per write. What arrives instead is the
+// delivery it was blocked on plus one more, current.
+//
+// The bound is exact rather than approximate: the handler can only be in one of
+// two places when the writes land, and the slot holds one nudge.
+func TestABurstOfWritesCollapsesIntoAFewDeliveries(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+
+	lq := subscribe(t, d, testQuery())
+	lq.next(t) // delivery 1, drained; the handler now waits on its wake channel
+
+	const writes = 40
+	var last int64
+	want := make([]string, 0, writes)
+	for i := range writes {
+		id := fmt.Sprintf("d%02d", i)
+		last = putDocSeq(t, d, id, `{"status":"pending"}`)
+		want = append(want, id)
+	}
+
+	deliveries := 0
+	var final window
+	for {
+		final = lq.next(t)
+		deliveries++
+		if final.asOfSeq >= last {
+			break
+		}
+		if deliveries > 4 {
+			t.Fatalf("%d writes produced %d deliveries before catching up; the wake slot is not collapsing them",
+				writes, deliveries)
+		}
+	}
+	if deliveries > 2 {
+		t.Fatalf("%d writes produced %d deliveries, want at most 2 — one in flight plus one current",
+			writes, deliveries)
+	}
+	if got := ids(final); !equalStrings(got, want) {
+		t.Fatalf("final window = %v, want every written document", got)
+	}
+}
+
+// Two subscribers on one collection each get their own window, and each one's
+// bodies are diffed against what IT holds. The second subscriber joining late
+// must not make the first one re-receive anything.
+func TestEverySubscriberGetsItsOwnWindow(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+
+	first := subscribe(t, d, testQuery())
+	if got := first.next(t).changed(); !equalStrings(got, []string{"a"}) {
+		t.Fatalf("first subscriber's initial bodies = %v", got)
+	}
+
+	second := subscribe(t, d, testQuery())
+	if got := second.next(t).changed(); !equalStrings(got, []string{"a"}) {
+		t.Fatalf("second subscriber's initial bodies = %v — a fresh subscriber holds nothing", got)
+	}
+
+	seq := putDocSeq(t, d, "b", `{"status":"pending"}`)
+	for name, lq := range map[string]*liveQuery{"first": first, "second": second} {
+		w := lq.settle(t, seq)
+		if got := ids(w); !equalStrings(got, []string{"a", "b"}) {
+			t.Fatalf("%s subscriber's window = %v, want [a b]", name, got)
+		}
+		if got := w.changed(); !equalStrings(got, []string{"b"}) {
+			t.Fatalf("%s subscriber received %v, want only the new document", name, got)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The window invariant, fuzzed
+// ---------------------------------------------------------------------------
+
+// windowFuzzBodies is the alphabet the fuzz draws from, and every entry is a case
+// where the encoding could disagree with the ordering the query means. Ties on
+// the sort field decide whether the id tiebreaker is really applied; a missing
+// field and a JSON null are what SQLite sorts as NULL, which compares as nothing
+// at all; text that looks numeric and a value with no numeric reading are what
+// the column's NUMERIC affinity does and does not convert.
+//
+// A differential harness validates machinery, never meaning: these are the
+// values where a window built from the wrong comparison would still look
+// plausible.
+var windowFuzzBodies = []string{
+	`{"n":1}`,
+	`{"n":1}`,
+	`{"n":2}`,
+	`{"n":"1"}`,
+	`{"n":"apple"}`,
+	`{"n":null}`,
+	`{}`,
+	`{"n":[1,2]}`,
+	`{"n":{"deep":1}}`,
+}
+
+// Fuzzed over a corpus small enough that a limit really bites: every applied
+// window must equal what a fresh query answers, and — checked inside the applier
+// on every delivery in this package — every id in order must resolve from a body
+// this connection was actually sent.
+//
+// Deterministic by seed, so a failure is reproducible and a green run is not
+// luck about which arrangement came up.
+func TestTheWindowInvariantHoldsOverAFuzzedCorpus(t *testing.T) {
+	const (
+		documents = 7
+		limit     = 3
+		rounds    = 120
+	)
+
+	d := newDaemonForTest(t)
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocDefine(c, &protocol.DocDefineMessage{
+			Cmd: protocol.CmdDocDefine,
+			Schema: protocol.DocumentCollectionSchema{
+				Namespace: testDocNS, Collection: testDocColl,
+				Fields: []protocol.DocumentFieldSpec{{Name: "n", Type: "number"}},
+			},
+		})
+	})
+	if !resp.Ok {
+		t.Fatalf("define: %v", protocol.Deref(resp.Error))
+	}
+
+	ids := make([]string, documents)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("d%d", i)
+	}
+
+	cap := limit
+	q := testQuery()
+	q.Sort = &protocol.DocumentSort{Field: "n", Desc: protocol.Ptr(true)}
+	q.Limit = &cap
+
+	lq := subscribe(t, d, q)
+	lq.next(t)
+
+	rng := rand.New(rand.NewSource(20260805))
+	for round := range rounds {
+		id := ids[rng.Intn(len(ids))]
+		var seq int64
+		if rng.Intn(4) == 0 {
+			seq = deleteDocSeq(t, d, id)
+		} else {
+			seq = putDocSeq(t, d, id, windowFuzzBodies[rng.Intn(len(windowFuzzBodies))])
+		}
+		if seq == 0 {
+			// A delete that removed nothing changed nothing, so it wakes
+			// nobody and there is no delivery to wait for.
+			continue
+		}
+		w := lq.settle(t, seq)
+		if got, want := w.order, queryIDs(t, d, q); !equalStrings(got, want) {
+			t.Fatalf("round %d: window = %v, fresh query = %v", round, got, want)
+		}
+		if len(w.order) > limit {
+			t.Fatalf("round %d: window holds %d documents, above the limit of %d", round, len(w.order), limit)
+		}
+	}
+}
+
+// The named fixture behind the fuzz's hardest case, pinned on its own because a
+// differential run can only tell you the two answers agreed. A document enters a
+// limited window because a DIFFERENT document left it: no fact names the one that
+// entered, so nothing derived from the change log alone could have found it.
+func TestADocumentEntersTheWindowBecauseAnotherLeft(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"1"}`)
+	putDoc(t, d, "b", `{"status":"2"}`)
+	putDoc(t, d, "c", `{"status":"3"}`)
+
+	limit := 2
+	q := testQuery()
+	q.Sort = &protocol.DocumentSort{Field: "status"}
+	q.Limit = &limit
+
+	lq := subscribe(t, d, q)
+	if got := ids(lq.next(t)); !equalStrings(got, []string{"a", "b"}) {
+		t.Fatalf("initial window = %v, want [a b]", got)
+	}
+
+	seq := deleteDocSeq(t, d, "a")
+	w := lq.settle(t, seq)
+	if got := ids(w); !equalStrings(got, []string{"b", "c"}) {
+		t.Fatalf("window after the delete = %v, want [b c]", got)
+	}
+	if got := w.changed(); !equalStrings(got, []string{"c"}) {
+		t.Fatalf("bodies sent = %v, want only the document that entered", got)
+	}
+}
+
+func idsOf(docs []protocol.StoredDocument) []string {
+	out := make([]string, 0, len(docs))
+	for _, doc := range docs {
+		out = append(out, doc.ID)
+	}
+	return out
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "214"
+const ProtocolVersion = "215"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only
@@ -32,6 +32,18 @@ const (
 	// operator that does not exist, a bound of the wrong type, a cursor pointing
 	// at a document that is gone. The message says which.
 	ErrorCodeInvalidQuery = "invalid_query"
+	// ErrorCodeCollectionUndefined ends a live subscription because the
+	// collection it watches was removed. Distinct from
+	// ErrorCodeUndeclaredCollection, which answers a request against a
+	// collection that was never there: this one says an accepted subscription's
+	// target went away underneath it, which is a UI host's "kill the tile"
+	// rather than "the caller asked for the wrong thing".
+	ErrorCodeCollectionUndefined = "collection_undefined"
+	// ErrorCodeCollectionRedeclared ends a live subscription because the
+	// collection was redeclared without a field the query uses. The query can
+	// never be answered again as written, so the tile's query is what has to
+	// change; resubscribing unchanged would fail the same way.
+	ErrorCodeCollectionRedeclared = "collection_redeclared"
 )
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1236,16 +1236,25 @@ type DocSubscribeMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
 
+	// Have corresponds to the JSON schema field "have".
+	Have []DocumentRevision `json:"have,omitempty,omitzero"`
+
 	// Query corresponds to the JSON schema field "query".
 	Query DocumentQuery `json:"query"`
 }
 
 type DocSubscribeResult struct {
+	// AsOfSeq corresponds to the JSON schema field "as_of_seq".
+	AsOfSeq int `json:"as_of_seq"`
+
 	// Delivery corresponds to the JSON schema field "delivery".
 	Delivery int `json:"delivery"`
 
-	// Documents corresponds to the JSON schema field "documents".
-	Documents []StoredDocument `json:"documents"`
+	// Order corresponds to the JSON schema field "order".
+	Order []string `json:"order"`
+
+	// Upsert corresponds to the JSON schema field "upsert".
+	Upsert []StoredDocument `json:"upsert"`
 }
 
 type DocUndefineMessage struct {
@@ -1338,6 +1347,14 @@ type DocumentQuery struct {
 
 	// Sort corresponds to the JSON schema field "sort".
 	Sort *DocumentSort `json:"sort,omitempty,omitzero"`
+}
+
+type DocumentRevision struct {
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
+
+	// Rev corresponds to the JSON schema field "rev".
+	Rev int `json:"rev"`
 }
 
 type DocumentSort struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -3681,29 +3681,70 @@ model DocumentConflict {
   "actual": safeint;
 }
 
+// One document a resuming subscriber already holds, and at which revision.
+//
+// A pair list rather than a map because the generated Go types erase a record's
+// value type to `any`, and a revision that decodes as an untyped number is
+// exactly the value this resume must not get wrong.
+model DocumentRevision {
+  "id": string;
+  "rev": safeint;
+}
+
 // Subscribe to a live query. Unlike every other command here, this one keeps the
 // connection open: the daemon writes a DocSubscribeResult immediately carrying
-// the current result set, then writes a fresh one every time a write to the
-// collection changes what the query returns. The subscription ends when the
-// caller closes the connection.
+// the query's current window, then writes a fresh one every time a write to the
+// collection could have changed it. The subscription ends when the caller closes
+// the connection, or when the collection stops being able to answer the query.
+//
+// `have` is what the subscriber already holds, and is how a reconnecting client
+// resumes without replaying history: the first delivery then carries only the
+// window members whose revision differs from what is declared here. Everything
+// else about that delivery is unchanged, so a fresh subscribe is simply the case
+// where `have` is empty.
+//
+// A query carrying `after` is REFUSED. A live query is a window and a cursor is
+// a walk: the anchor moves under a subscription, so the page it names is not the
+// page it named a write ago. Use `limit` and let each delivery carry the current
+// window. One-shot doc_query keeps `after` exactly as it is, because a single
+// read has one instant and nothing to move under it.
 model DocSubscribeMessage {
   "cmd": "doc_subscribe";
   "query": DocumentQuery;
+  "have"?: DocumentRevision[];
 }
 
-// One delivery of a live query's results. `documents` is always the CURRENT full
-// result set, never a patch — a subscriber renders what it is given and never
-// reconstructs state from a sequence of deliveries. `delivery` counts deliveries
-// on this subscription, starting at 1 for the initial one; it is named for what
-// it counts because a document carries its own `rev` and one word for both would
-// read as though they were related.
+// One delivery of a live query's window, and the whole client contract is one
+// rule:
 //
-// int32 rather than the safeint a document's revision uses: this counter is
-// bounded by how long one connection stays open, not by a document's whole
-// history.
+//   Render `order`. Take each body from `upsert` if it is there, else from your
+//   cache. Forget every cached document not named in `order`.
+//
+// `order` is the query's current result, in the server's own order — the client
+// never re-derives sort position, because document order comes from SQLite's
+// comparison under column affinity and a client re-sorting locally would have to
+// reimplement that exactly. `upsert` carries only the bodies the subscriber does
+// not already hold: the ones it declared at a different revision in `have`, and
+// the ones that have changed since a previous delivery on this connection.
+// There is no `remove` field because removal is derivable from `order`, and a
+// derivable field is a field two implementations can disagree about.
+//
+// The daemon upholds — and a test pins — that every id in `order` is either in
+// `upsert`, or was declared in `have` at its current revision, or arrived in an
+// earlier delivery on this connection. A client that finds a body it does not
+// hold must treat the subscription as broken and resubscribe with no `have`.
+//
+// `as_of_seq` is the log position this window was true at, read in the same
+// transaction as the rows. `delivery` counts deliveries on this subscription,
+// starting at 1; it is named for what it counts because a document carries its
+// own `rev` and one word for both would read as though they were related. int32
+// rather than safeint because the counter is bounded by how long one connection
+// stays open, not by a document's whole history.
 model DocSubscribeResult {
   "delivery": int32;
-  "documents": StoredDocument[];
+  "as_of_seq": safeint;
+  "order": string[];
+  "upsert": StoredDocument[];
 }
 
 // ============================================================================
@@ -3717,9 +3758,12 @@ model Response {
   // `error` text. Present only where a caller has to branch on the answer:
   // `conflict` (retry after re-reading — `error_conflict` carries which
   // revisions disagreed), `undeclared_collection` (the collection is not
-  // there), `invalid_query` (the query itself is wrong). Everything else
-  // carries no code, and a client must treat an unknown code as "broken, stop"
-  // rather than matching the message text.
+  // there), `invalid_query` (the query itself is wrong), and the two that end a
+  // live subscription — `collection_undefined` (the collection was removed;
+  // kill the tile) and `collection_redeclared` (it no longer declares a field
+  // the query used; the tile's query needs rewriting). Everything else carries
+  // no code, and a client must treat an unknown code as "broken, stop" rather
+  // than matching the message text.
   error_code?: string;
   error_conflict?: DocumentConflict;
   data?: string;

--- a/scripts/test-go.sh
+++ b/scripts/test-go.sh
@@ -8,6 +8,12 @@ shard_count="${ATTN_GO_TEST_SHARDS:-5}"
 package_parallelism="${ATTN_GO_TEST_PACKAGE_PARALLELISM:-4}"
 test_gomaxprocs="${ATTN_GO_TEST_GOMAXPROCS:-${GOMAXPROCS:-3}}"
 test_timeout="${ATTN_GO_TEST_TIMEOUT:-90s}"
+# The race job runs the same packages a second time under -race, which costs
+# roughly an order of magnitude. Measured: `go test -race ./internal/store
+# ./internal/docstore` takes 22s on an M-series laptop, and CI runs SQLite work
+# 3-4x slower, so ~90s is the real ceiling. 300s is a tripwire — only a hang
+# reaches it.
+race_timeout="${ATTN_GO_TEST_RACE_TIMEOUT:-300s}"
 
 if ! [[ "$shard_count" =~ ^[1-9][0-9]*$ ]]; then
   echo "ATTN_GO_TEST_SHARDS must be a positive integer, got: $shard_count" >&2
@@ -136,6 +142,15 @@ while IFS= read -r package; do
   packages+=("$package")
 done <"$packages_file"
 run_job packages "$go_bin" test -timeout "$test_timeout" -p "$package_parallelism" "$@" "${packages[@]}"
+
+# A live document query re-reads on a wake set by the very write it is
+# reporting, so the store's own concurrency is load-bearing in a way a wrong
+# answer hides better than a crash does: a lost wake or a torn read looks like a
+# stale window, not a panic. Race detection is too slow to spend on every
+# package on every push, so it is scoped to the two that compile and execute
+# those queries. These packages therefore run twice — once for the answers,
+# once for the memory model.
+run_job race "$go_bin" test -timeout "$race_timeout" -race "$@" ./internal/store ./internal/docstore
 
 shard=0
 while [ "$shard" -lt "$shard_count" ]; do


### PR DESCRIPTION
Stage 2 of the A3.4 doc-store plan
([docs/plans/2026-08-05-ext-a3.4-doc-store-positions-and-windows.md](docs/plans/2026-08-05-ext-a3.4-doc-store-positions-and-windows.md),
section "Stage 2 — the windowed subscription"). Stage 1 landed in #766.

## What changes

A document subscription used to answer every wake with the query's whole result
set. A hundred-row window whose first document changed re-sent a hundred bodies,
and reconnecting after a daemon restart re-sent all of them again — the cost of a
live query scaled with the window rather than with what moved.

A delivery is now a **window**: the ids in order, the log position the window was
true at, and bodies only for the documents the subscriber does not already hold.

```
{ "delivery": 3, "as_of_seq": 53, "order": ["req-1","req-2","req-4"],
  "upsert": [ {...req-1...}, {...req-4...} ] }
```

The re-run is unchanged — it still answers *which documents, in what order*,
which is what keeps one code path instead of a patch stream with a re-query
underneath it — and the diff against what the subscriber holds is bookkeeping
over one map beside the connection.

**The client rule is one sentence.** Render `order`. Take each body from
`upsert` if it is there, else from your cache. Forget every document not named
in `order`. `internal/client` implements it once, so the CLI, the tests and A4's
SDK are callers rather than re-implementers.

**Resume by content.** `doc_subscribe` accepts `have` — the `{id, rev}` pairs the
subscriber already holds — and the first delivery diffs against those. A watch
that survives a daemon restart pays for the documents that actually changed while
it was away. A claimed revision the store never issued simply differs from the
stored one, so a stale resume converges rather than sticking.

Three smaller things fall out of that shape:

- **Subscribing with `after` is refused**, with a coded error naming `limit` plus
  windowed delivery as the thing to use instead. A cursor is a walk and a live
  query is a window: the document the cursor names moves out from under the
  subscription. One-shot `doc_query` keeps `after` untouched.
- **The first read IS the acceptance check**, which deletes the duplicate compile
  path a subscribe used to run up front. A second compile is a second place for
  the query rules to be applied differently.
- **Ending an accepted subscription has its own codes.** The same errors mean
  something different once a subscription exists: `collection_undefined` when the
  collection was removed, `collection_redeclared` when it came back without a
  field the query uses. A UI host branches on those to decide between killing a
  tile and rewriting its query.

`attn doc watch` prints applied windows with a `changed` receipt, takes
`--resume` to reconnect across a daemon restart declaring what it holds, and
exits non-zero when the subscription ends — a watch that has stopped watching
must not look like a watch that finished.

`scripts/test-go.sh` grows a scoped `-race` job over `./internal/store` and
`./internal/docstore`. A live query re-reads on a wake set by the very write it
is reporting, and a race there surfaces as a stale window rather than a crash.

**Protocol 215.**

## One deliberate deviation from the plan

The plan writes the resume token as `have?: Record<string, int64>`. `go-jsonschema`
renders a TypeSpec `Record<T>` as `map[string]interface{}` (see `RecordString` in
`generated.go`), so a revision would decode as an untyped number on the Go side.
The wire carries `have?: DocumentRevision[]` instead — `{id, rev}` pairs, the same
information, typed on both sides. The rationale is written into `main.tsp` beside
the model.

The client API took a second, smaller turn during implementation: `DocSubscribe`
takes the whole documents a caller holds, not their revisions, and derives `have`
itself. A subscriber that declares a revision without holding its body has told
the daemon not to send something it cannot render, and no caller should be able to
express that by accident. The real-socket test found this before the API had any
other caller.

## Receipts

**Tests.** Full `go test ./...` green via `scripts/test-go.sh` (which now includes
the `-race` job: `internal/store` 37s, `internal/docstore` 1.5s under `-race`).
Frontend: 227 files / 2530 tests passed, 20 skipped. `tsc --noEmit` clean.

Every item of the plan's Stage-2 testing battery, and what pins it:

| Battery item | Test |
| --- | --- |
| Currency under contention (`as_of_seq` ≥ last write's seq, no sleeps) | `TestASubscriptionStaysCurrentUnderContention` |
| Coalescing as a receipt (`net.Pipe`, deliveries ≪ N) | `TestABurstOfWritesCollapsesIntoAFewDeliveries` |
| Window invariant, fuzzed with adversarial fixtures | `TestTheWindowInvariantHoldsOverAFuzzedCorpus` (ties, NULL sort values, JSON-shaped sort fields), `TestADocumentEntersTheWindowBecauseAnotherLeft` |
| Resume matrix: edit in window / delete / displace past the limit / edit out of the filter / nothing changed | `TestResumingSendsExactlyWhatChangedWhileAway` (5 sub-cases) |
| `have` claiming a rev the store never issued still converges | `TestResumingWithARevisionTheStoreNeverIssuedStillConverges` |
| Forget rule | `TestResumingForgetsWhatIsNoLongerInTheWindow` |
| Multi-subscriber fan-out | `TestEverySubscriberGetsItsOwnWindow` |
| Redeclare / undefine end with a code | `TestRedeclaringWithoutAQueriedFieldEndsTheSubscription`, `TestUndefiningACollectionEndsItsSubscriptions` |
| `after` refused at subscribe, kept on one-shot | `TestSubscribingWithAnAfterCursorIsRefused`, `TestOneShotQueryStillTakesAnAfterCursor` |
| Only changed bodies travel | `TestADeliveryCarriesOnlyTheBodiesThatChanged` |
| One real-socket integration test through `internal/client` | `TestDocumentsOverARealSocket` |
| Client read loop: connection-loss ending, coded ending, the client rule, the unheld-body failure | `internal/client/documents_test.go` |

Two mutations of `windowDelivery` went red on the intended assertions:
always-send-every-body fails `TestADeliveryCarriesOnlyTheBodiesThatChanged`
("bodies sent = [a b c], want only the one that changed") plus three others;
trust-the-held-id-and-ignore-its-revision fails the same test with "bodies sent
= []" plus the two resume tests.

**Live verification.** Throwaway profile `docwin2`, full `make install
PROFILE=docwin2`, preflight PASS (protocol 215 across CLI, app and daemon). A
tile-shaped watch — `attn doc watch ext/approval-gate requests --where
status=pending --sort rank --limit 3 --json --resume` — over 5 documents:

```
#1 delivery 1 as_of_seq 38 order [req-1 req-2 req-3] changed [req-1 req-2 req-3]
#2 delivery 2 as_of_seq 39 order [req-1 req-2 req-3] changed [req-2]
   (edit of req-2 landed at seq 39)
   -- SIGSTOP the watcher; daemon stop + ensure (0.49s); edit req-1 (seq 52),
      delete req-3 (seq 53); SIGCONT --
#3 delivery 1 as_of_seq 53 order [req-1 req-2 req-4] changed [req-1 req-4]
      req-1 rev 2 | request 1 (edited while the watcher was away)
      req-2 rev 2 | request 2 (edited live)      <- never re-sent, from cache
      req-4 rev 1 | request 4                    <- entered because req-3 left
```

The resumed window changed shape across a daemon restart and only the two bodies
that moved crossed the wire. Then: `doc query --after` still answers; `doc watch
--after` exits 1 with the coded refusal; `doc undefine` ends the live watch with
`collection_undefined` and a non-zero exit. Profile cleaned with `attn profile
clean docwin2` (daemon stopped, app and data dir removed, confirmed absent from
`attn profile list`).

## Surfaces walked

- **CLI** — `attn doc watch` rewritten around windows; `--resume`; non-zero exit
  on a subscription ending; `--after` rejected for `watch` only.
- **Daemon and app** — `handleDocSubscribe`; protocol 215 bumped in
  `constants.go`, `useDaemonSocket.ts` and `generated.ts`/`generated.go` from one
  `main.tsp` edit.
- **Protocol** — regenerated, never hand-edited.
- **Linux** — no platform-specific code; pure Go.
- **SDK** — `internal/client` is the seam A4 sits on, and it gets its first tests
  here.
- **Docs** — changelog fragment `changelog.d/docstore-windowed-subscriptions.yaml`.

## Not in this PR

Stage 3 (retained versions / read-at-seq), any change to Stage 1 semantics,
`internal/store/jobs.go` timestamps, cross-request pinned-seq reads.
