### PR TITLE
docs(garden): vertical-slice plan for seeds, plots, and a server-ready path

### DIFF
--- a/changelog.d/fluffy-otter-garden-plan.yaml
+++ b/changelog.d/fluffy-otter-garden-plan.yaml
@@ -1,0 +1,15 @@
+kind: internal
+area: docs
+change: >
+  Vertical-slice plan for the garden (docs/plans/2026-08-06-the-garden-vertical-slices.md):
+  seeds as docstore-backed fine-grained work items — plant/tend/harvest CLI,
+  live app panel, typed edges with context-inferred ready, seed-attached
+  handoff notes, plots (a crown with children) as dispatch targets, and plans
+  living in the garden as the crown's rendered, annotatable body. One garden
+  lives at the hub daemon (remote sessions reach it over the relay); the plan
+  dogfoods itself as the first plot from slice 1. Packets (templates),
+  gates-as-turns, and sow/distill are designed into the schema now and
+  implemented later. The friendly-home vision gains the grown central-server
+  scope and stance (closed source, operated, optional — sync and recognition,
+  no feature gating), the negative recognition channel, the
+  garden-as-front-door question, and the seat-memory-as-garden-query check.

--- a/docs/plans/2026-08-06-the-garden-vertical-slices.md
+++ b/docs/plans/2026-08-06-the-garden-vertical-slices.md
@@ -1,0 +1,386 @@
+# Plan: the garden (seeds) — vertical slices
+
+## Alignment
+
+First vertical through
+[docs/vision/friendly-home-for-agents.md](../vision/friendly-home-for-agents.md):
+the fine-grained, addressable work graph — **seeds** — for any attn-living
+agent. Chosen over the seat primitive as the opening arc because seats are
+currently covered by the hand-run skill-layer simulation (`~/.attn/seats/`,
+`/wake`, `/handoff`), which is teaching us the seat's real shape before we
+harden it; the garden is the machinery nothing simulates today.
+
+Beads is the UX inspiration, not the spec. Where beads needs flags and
+ceremony because its CLI is context-free, attn knows who is asking — the
+daemon owns the session, its workspace, and its delegation — and the garden
+leans on that everywhere. Aligned 2026-08-06: plots are seeds with children
+(one primitive); `ready` infers its scope from the caller; **plans live in
+the garden** (the crown's body is the plan, rendered and annotated natively);
+packets (reusable templates) are designed into the schema now and implemented
+last.
+
+Slice-based, in the house style: every slice ships a usable behavior end to
+end (CLI → daemon → app); no layer is built ahead of the slice that needs it.
+Plant-and-see first, then expand.
+
+The garden's first load is its own construction (aligned 2026-08-06, held
+firm): this plan is planted as the first plot the day `plant` works, and
+every slice tends and harvests itself as the CLI grows the verbs. Building
+the garden without living in it would repeat the mistake the garden exists
+to fix.
+
+## Grounding (receipts)
+
+- **Beads UX study, 2026-08-06** (per the vision's blindspot gate; UX only,
+  storage explicitly not adopted). Core loop: one-line capture; `ready` =
+  no open blockers, auto-surfacing when a blocker closes; atomic claim;
+  close-with-reason; audit trail in `show`; JSON everywhere. Workflow layer
+  (`docs/workflows/{formulas,molecules}.md` in the beads repo): a **molecule
+  is just an epic** — parent with children plus execution intent, children
+  parallel by default, only explicit dependencies sequence; `ready --mol`
+  scopes to one molecule; **formulas** are declarative templates (steps,
+  typed variables with validation, human gates, cross-cutting aspects)
+  cooked into template epics and poured into instances; **distill** extracts
+  a template from a real epic that proved worth repeating; **bond** connects
+  work graphs. Blocking dependency kinds: `blocks`, `parent-child`,
+  `conditional-blocks`, `waits-for`; non-blocking: `related`,
+  `discovered-from`, `replies-to`. The one UX piece rejected: dotted
+  hierarchical IDs — see design decisions.
+- **Docstore is live** (A3 #745, A3.1 #748, revisions #753, A3.4 Stage 1
+  positioned writes #766): namespaced collections, declared-field indexes,
+  live queries, bus change events, per-document revisions with write
+  expectations. The daemon may use `core/`. Stage 2 (windowed subscriptions)
+  is designed but not started.
+- **Markdown annotation surface exists**: attn natively renders a markdown
+  file and routes user annotations to agents as feedback
+  (`daemonMarkdownAnnotationEvents`, keyed `<op>:<workspaceId>:<path>`,
+  last-writer-wins). Victor named this the target UX for reading and
+  reviewing plans; slice 6 teaches it to render seeds. Foundational work on
+  this surface is in flight and will reshape details — that slice is
+  direction, not frozen design.
+- **Seat simulation is live**: two seats exist (`keel`, `alder`); Keel filed
+  the first real handoff 2026-08-06. Its charter/handoff shapes are the
+  reference for what seed-attached notes must carry.
+- **Chief embryo**: `profile_roles` single-holder table, chief guidance
+  injected at launch, ticket role identity. The chief is out of scope here —
+  both its garden role and the chief→seat migration ride the seat vertical,
+  after the simulation has taught us the primitive.
+
+## Design decisions (cross-slice)
+
+- **Storage: docstore, `core/garden` namespace.** Collections `seeds` and
+  `notes` (audit/progress entries keyed by seed id — a separate collection,
+  not an embedded array, so a long-tended seed never bloats its own
+  document). Live queries, bus change events, and revision-checked writes
+  come free; schema can move fast while the shape settles. Single-writer
+  invariants (one active tender) are enforced in daemon code, the
+  `applyState` way — not by table constraints.
+- **One primitive.** A **plot** is a seed with children and execution
+  intent; its root is the **crown**. A **packet** is a plot flagged as
+  template. No separate entities, no separate lifecycles: plot-blocks-plot
+  is just an edge between crowns, and everything that works on a seed works
+  on all of them.
+- **IDs are identity; edges are structure.** Short, stable, human-sayable
+  seed ids (readable slug, exact shape decided in slice 1). No dotted
+  hierarchy: re-parenting a seed must never rename it. `part-of` edges carry
+  the hierarchy beads encodes in ids. For addressing *within* a plot, every
+  seed carries a **step slug** (auto-derived from title, editable, unique in
+  its plot) — that is what packets, bond points, and narrative
+  cross-references name, and it survives sowing.
+- **One garden, at the hub.** The garden lives in the hub daemon's docstore —
+  the daemon the app talks to. A garden per daemon is a split brain: a remote
+  delegate asking its own daemon would see an empty garden, and remotely
+  planted seeds would never reach the panel. So a remote session's seed
+  commands must reach the hub's garden over the relay, the way PR flows
+  already do. Cross-machine and offline syncing is real and wanted, and rides
+  the central-server arc (see the vision's blindspot) — hub-local is the
+  honest first version, not the end state.
+- **Server-ready, not server-dependent.** The future central server (closed,
+  operated, optional) must bolt on without a rewrite. Exactly two
+  pre-commitments touch these slices; everything else is deferred whole:
+  (1) seed ids are **daemon-prefixed at the boundary** — the stored id is
+  short, stable, sayable, and unique within its hub; the fully qualified
+  form is `<daemon-id>/<local-id>`, minted only where an id leaves its
+  daemon (the server, cross-hub references, recognition routing). Inside a
+  daemon no operation ever sees the prefix. Global uniqueness holds by
+  construction: the daemon already mints a persistent identity at first
+  launch (`daemon-id` in the data root, `internal/daemon/instance_id.go`),
+  and each hub's docstore holds only its own garden. Verified against main
+  2026-08-06: docstore document ids are caller-chosen text
+  (`internal/store/documents.go` `PutDocument`; `id TEXT PRIMARY KEY`) —
+  no imposed shape, and the id charset forbids `/`, which conveniently
+  keeps fully qualified forms out of local storage by force. A sayable
+  alias for the daemon id ("home", "work") is a ground-pass detail: the
+  minted id is the spine, the alias the face.
+  (2) Garden bus facts stay complete enough to serve as a change feed —
+  each fact names its seed, so a future sync engine is just a durable bus
+  consumer with a cursor that re-reads the document and pushes it.
+  Remote writes flow through the hub (the server acts as a client, like the
+  app), so no slice needs merge logic, ever. Hubs that never meet each
+  other (work, home) each meet the server: cross-hub visibility is a
+  **union routed by prefix, never a merge** — identity collisions are
+  impossible by construction and every seed has one home hub that applies
+  its writes. Roles/seats join seeds in the future sync scope.
+- **Every seed belongs somewhere.** A seed is stamped with the workspace of
+  the session that planted it (overridable with `--workspace`); a seed
+  planted outside any workspace context carries none and surfaces only under
+  `--all`. Workspace is the default human scope; the plot is the default
+  delegate scope.
+- **`ready` infers its scope from the caller.** The daemon knows the
+  session: a delegation dispatched at a crown sees its plot's ready seeds; an
+  interactive session sees its workspace's. `--plot`, `--workspace`, `--all`
+  override. Ready = no open `blocks` edges, not dormant, no live tender,
+  not a template, and — once gates exist — not a gate. Truth at query time;
+  nudging a tender when its blocker falls is named-later work.
+- **The crown's body is the plan.** Seed bodies are markdown from slice 1.
+  A chunk plan is a plot: alignment, receipts, and design decisions live in
+  the crown's body; the children are the ledger. The plan and its checkboxes
+  cannot drift because the checkbox *is* the seed. `docs/plans/` keeps
+  visions, gate records, and history; new chunk plans grow as plots once
+  slice 6 makes them readable and annotatable, and the markdown format
+  retires only when the replacement demonstrably covers the itch.
+- **Template-ready schema, implemented last.** Carried from slice 1 so
+  nothing migrates later; inert until their slices: `template` (flags a
+  packet; excludes the subtree from ready and active views), declared
+  variables on a packet's crown (name, description, required, default,
+  pattern/enum; `{{var}}` interpolation in titles and bodies at sow time),
+  the `sown-from` provenance edge, and `gate` (a gate seed never enters
+  agent ready — when unblocked it opens a **turn**, riding attn's existing
+  attention system instead of a bolted-on approval table).
+- **Tending is atomic claim.** `attn seed tend <id>` sets tender + `growing`
+  in one move (the beads `--claim` lesson). The tender is
+  `{session_id, seat?}` — seat is the free-string seat name from the
+  skill-layer simulation for now, snapping to seat ids when the daemon
+  primitive lands. Attribution is stamped from birth: every seed records its
+  planter the same way.
+- **Lifecycle vocabulary** (from the vision): `planted` → `growing` (someone
+  tends it) → `harvested` (done, with a reason) or `withered` (abandoned,
+  with a reason); `dormant` parks a seed deliberately. Every door is
+  two-way: `replant` reopens a harvested/withered seed, tending un-parks a
+  dormant one. Transitions are daemon-validated; an invalid transition names
+  the seed, its state, and the ask.
+- **CLI-first, seconds to plant.** Agents live in the CLI; the app renders.
+  Every command takes `--json`. Planting must cost one line and return the
+  id.
+- **Audit trail = revisions + notes + facts.** Docstore revisions record
+  every mutation; notes carry the human/agent-authored trail; bus facts
+  (`garden.planted`, `garden.tended`, …) drive projections. `attn seed show`
+  assembles all three.
+
+## Slices
+
+### Slice 1 — plant and see
+
+Goal: an agent plants a seed in one line; Victor sees it in the app
+immediately.
+
+Ships:
+
+- [ ] `core/garden` collections registered. The seed document carries the
+      full designed schema — status, markdown body, workspace, planter,
+      tender, step slug, edges, and the inert template/vars/gate fields —
+      even though only a slice of it is behaviorally live.
+- [ ] `attn seed plant "title" [-m body]` → prints the new id;
+      `attn seed ls`, `attn seed show <id>`; `--json` on all three.
+      Workspace stamped from the calling session's context.
+- [ ] Seed id shape decided and documented: short, stable, sayable, unique
+      in its hub; the daemon prefix stays at the boundary (see the
+      server-ready design decision — no local operation ever sees it).
+- [ ] App: a garden panel listing the workspace's seeds live (docstore
+      change events; if the app-side subscription seam wants A3.4 Stage 2,
+      ride a snapshot-projection until it lands — the panel's contract is
+      "planted seed appears without a refresh", not a particular transport).
+- [ ] Bus facts `garden.planted` with the seed as subject.
+- [ ] Glossary: seed, plant, the garden, plot, crown, packet (the vocabulary
+      lands together even though plots arrive in slice 5).
+- [ ] The first planting is this plan: its crown (this document as the body)
+      and one seed per remaining slice, the day `plant` works. Hierarchy is
+      wired as the verbs arrive — edges in slice 3, plot semantics in
+      slice 5 — and from slice 2 onward each slice is tended on start and
+      harvested on completion.
+
+Acceptance:
+
+- [ ] From inside a live session, planting takes one command and the seed is
+      visible in the running app without user action.
+- [ ] `plant` → `ls` → `show` round-trips in JSON.
+- [ ] The garden contains the plan for the garden, visible in the panel.
+
+### Slice 2 — lifecycle and tending
+
+Goal: a seed moves through its life, and the trail is visible.
+
+Ships:
+
+- [ ] `attn seed tend <id>` (atomic claim), `park`, `harvest -m`,
+      `wither [-m]`, `replant` — every transition daemon-validated with loud
+      errors.
+- [ ] `attn seed note <id> -m` appends to the trail; `show` renders states,
+      tender, and notes newest-first.
+- [ ] App panel shows state and tender; state changes arrive live.
+- [ ] Bus facts per transition (`garden.tended`, `garden.harvested`, …).
+
+Acceptance:
+
+- [ ] Full life in CLI: plant → tend → note → harvest, then replant → wither;
+      each state visible in the app as it happens.
+- [ ] A second session trying to tend an actively-tended seed gets a loud,
+      named refusal (and a `--steal` style override is deliberately absent
+      until needed).
+
+### Slice 3 — edges and ready
+
+Goal: seeds relate, and "what can I do now" is one flag-free command.
+
+Ships:
+
+- [ ] `attn seed link <a> blocks <b>` and `attn seed link <a> part-of <b>`
+      (typed edge list on the seed document; new kinds — `sown-from`,
+      `discovered-from`, `relates-to` — are additive), with `unlink`.
+- [ ] `attn seed ready` with inferred scope: the calling session's workspace
+      by default; `--plot <crown>`, `--workspace <id>`, `--all` override.
+- [ ] `attn seed ls --tree` renders `part-of` hierarchy; `show` lists edges
+      both directions (blocks / blocked-by).
+- [ ] Harvesting a blocker makes the dependent ready at the next query (no
+      nudge yet — named later).
+
+Acceptance:
+
+- [ ] A three-seed chain (A blocks B, B part-of C) round-trips: `ready`
+      shows only A; harvesting A surfaces B.
+- [ ] Two sessions in different workspaces get different flag-free `ready`
+      answers.
+- [ ] Cycle creation is refused loudly, naming both seeds.
+
+### Slice 4 — the seed axis of continuity
+
+Goal: whoever next picks up a seed inherits the notes — the vision's
+two-axis rule, seed side.
+
+Ships:
+
+- [ ] A note kind `handoff`: `attn seed note <id> -m --handoff` (or
+      equivalent flag) marking "written to my successor on this seed".
+- [ ] `attn seed show` surfaces the freshest handoff note prominently;
+      `tend` prints it on claim so pickup primes automatically.
+- [ ] The `/handoff` skill (seat side) gains one step: for each seed you
+      tended and are not harvesting, leave a seed handoff note. Seat homes
+      stay untouched otherwise — the axes are additive.
+
+Acceptance:
+
+- [ ] Session A tends a seed, files a handoff note, ends. Session B (fresh,
+      seatless) runs `tend` and the note is in its face before any work.
+
+### Slice 5 — plots and dispatch
+
+Goal: real work flows through a plot — plant a chunk as a crown with
+children, dispatch a delegation at it, watch it drain.
+
+Ships:
+
+- [ ] Planting under a crown: `attn seed plant --part-of <crown>` (or a
+      `plot` convenience that plants crown + children in one JSON payload
+      for agents).
+- [ ] Dispatch-at-plot: a delegation carries its crown; inside it,
+      flag-free `ready` scopes to the plot; children are parallel by
+      default, only `blocks` edges sequence.
+- [ ] App: the panel groups a plot's seeds under its crown and shows
+      progress (done / growing / ready / blocked counts).
+- [ ] `attn seed show <crown>` includes plot progress; a stale-plot query
+      (`attn seed ls --stale`) exists as a *query*, not an automatic reaper
+      — a person (or later a seat) decides what withers.
+
+Acceptance:
+
+- [ ] One real piece of work flows end to end in production use: a plot is
+      planted, a delegate dispatched at it tends and harvests children in
+      dependency order, the panel shows it draining live.
+- [ ] Two delegates on one plot pick up parallel children without collision.
+- [ ] A fresh session re-orients from `ready`/`ls` alone (garden state lives
+      in the daemon, not in anyone's context).
+
+### Slice 6 — the plan lives in the garden
+
+Goal: read and review a plot the way markdown plans are read today —
+rendered, annotated, feedback flowing to the tending agent.
+
+Rides Victor's in-flight foundational work on the rendering/annotation
+surface; this slice is direction, not frozen design — re-align before
+building it.
+
+Ships:
+
+- [ ] The markdown rendering + annotation surface learns a second document
+      source: a seed. The crown's body renders as the plan page; children
+      appear as the live ledger beneath it.
+- [ ] Annotations on a rendered seed route as feedback to its tender's
+      session (the existing annotation→agent path); on an untended seed
+      they land as notes on the trail, so review feedback is never lost.
+- [ ] A chunk plan authored as a plot replaces its would-be
+      `docs/plans/*.md` file for one real chunk — the first plan that never
+      touches git.
+
+Acceptance:
+
+- [ ] Victor opens a crown, reads the plan, annotates a paragraph, and the
+      tending agent receives the feedback — no export, no file.
+- [ ] The same plot's ledger updates live while he reads.
+
+### Later (named, unplanned)
+
+- **Packets: sow and distill** — the template flag, declared variables,
+  interpolation, `sown-from` provenance, and `distill` extraction. The
+  schema is carried from slice 1; the behavior ships when a real plot shape
+  has repeated and earned its packet.
+- **Gates as turns** — `gate` seeds opening turns when unblocked; the
+  schema field exists from slice 1.
+- **Tickets as views over the garden** — the migration the vision promises;
+  starts only after the garden carries real daily load.
+- **Laurels attach to seeds** — the recognition arc; seed ids are the
+  attachment points, nothing in this plan blocks it.
+- **Ready nudges** — waking a tender when its blocker falls (doorbell path).
+- **Seed priming at wake** — the `/wake` skill reading the occupant's tended
+  seeds; belongs to the seat arc.
+- **Daemon seat primitive** — hardened from the skill simulation's lessons;
+  the chief→seat migration and the chief's garden-tender role both ride it.
+- **Seat memory condensation** — deferred with a tripwire per the vision:
+  priming size is logged from the simulation's first days; the lossless-claw
+  DAG gets built when a real seat overflows a measured budget.
+- **Central server / cross-daemon recognition** — behind its ground pass.
+
+## Non-goals
+
+- Yegge's beads tool, Dolt, or git-based storage — UX inspiration only.
+- Dotted hierarchical ids.
+- Automatic fate derivation (a seed withers because someone says so).
+- Replacing or migrating tickets in this plan.
+- Priority fields, deadlines, or any scheduling metadata — until real garden
+  use shows the need, seeds order by readiness and human judgment.
+- Formula aspects, bond points, conditional-blocks, waits-for — named in the
+  beads study, adopted only if real plots demand them; the additive edge
+  list and step slugs keep the door open.
+- Multi-human features.
+
+## Open questions
+
+- The app-side transport for the garden panel: docstore subscription surface
+  vs. classic snapshot projection, and whether A3.4 Stage 2 is worth pulling
+  forward for it. Decide in slice 1 with the code in front of us. The panel
+  itself is the first rendering, not a commitment — whether the garden
+  becomes the app's front door is a named question in the vision, decided
+  with the foundational rendering work.
+- The relay mechanics for remote sessions: how `attn seed …` from a session
+  on a remote daemon reaches the hub's garden (relayed command vs. another
+  path), and what happens when the hub is unreachable. Must be answered
+  before slice 5's dispatch acceptance can include a remote delegate;
+  cross-machine syncing proper stays with the central-server arc.
+- Whether `ready` should exclude seeds whose tender session is dead vs.
+  recoverable (interacts with daemon-owned revive). Slice 3 decides.
+- Seat references: free-string seat names are knowingly un-validated until
+  the seat primitive lands — acceptable for a single-user garden, revisit at
+  the seat arc.
+- The crown/plot naming is Victor-blessed as of 2026-08-06 pending better
+  ideas; the glossary entry in slice 1 is the commitment point.
+- How slice 6's annotation keying generalizes from `<workspaceId>:<path>` to
+  seed ids — designed with the foundational rendering work, not before.

--- a/docs/vision/friendly-home-for-agents.md
+++ b/docs/vision/friendly-home-for-agents.md
@@ -79,14 +79,20 @@ for user-defined seats.
 
 - [x] **Chief as proto-seat** — single-holder profile role, durable ticket role
   identity, protected session. The embryo exists.
-- [ ] **Seat primitive** — durable identity + charter + memory home; sessions
+- [~] **Seat primitive** — durable identity + charter + memory home; sessions
   occupy seats; chief migrates to be the first seat, not a special case.
-- [ ] **Handoff & priming** — consented closure flow; agent-authored handoff
-  notes accrue to the seat; next wake primes from them.
-- [ ] **The garden (seeds)** — attn-native fine-grained seeds with audit trail
+  Running today as a hand-run skill-layer simulation (`~/.attn/seats/`,
+  `/wake`, `/handoff`; first real handoff filed 2026-08-06) that teaches the
+  primitive's shape before it hardens into the daemon.
+- [~] **Handoff & priming** — consented closure flow; agent-authored handoff
+  notes accrue to the seat; next wake primes from them. Simulated by the same
+  skills; priming size is logged from the start so the condensation budget
+  gets a receipt.
+- [~] **The garden (seeds)** — attn-native fine-grained seeds with audit trail
   and seat attribution, for any attn-living agent; tickets become views over
   the garden; a planning seat tends it; `/orchestrate-with-fable` and ad-hoc
-  plan-file choreography retire into it.
+  plan-file choreography retire into it. Vertical-slice plan:
+  [docs/plans/2026-08-06-the-garden-vertical-slices.md](../plans/2026-08-06-the-garden-vertical-slices.md).
 - [ ] **Intentful recognition** — laurels and feedback between human and seats
   and between seats, attached to work items, delivered at wake; a very simple
   central server routes across daemons and machines.
@@ -110,7 +116,13 @@ Known questions:
   seat drill from any summary back to the original detail on demand. Forgetting
   is replaced by condensation plus retrieval. Open: the atom of seat memory,
   the priming budget, and the condensation cadence (the durable jobs queue is
-  the natural home).
+  the natural home). And a prior question, raised 2026-08-06, open but not
+  decided: whether a dedicated store is needed at all. Handoffs and laurels
+  attach to seeds, and work history *is* the seeds a seat tended — so wake
+  priming may be a garden query, and condensation may be `distill` wearing a
+  different hat. Before building a memory store, check whether the garden
+  already covers the itch; what remains may be no more than the charter and
+  non-work learnings.
 - **Seatless sessions stay first-class, for errands.** Continuity has two
   axes: a handoff always attaches to the seed, and additionally to a seat
   when one is occupied. Errand sessions pay no ceremony tax, and whoever next
@@ -129,16 +141,61 @@ Known questions:
   norm — is what keeps laurels worth receiving. Specificity is the sycophancy
   filter: counterfeit admiration cannot name its trigger. Expect iteration on
   the wording.
+- **The negative channel.** Recognition needs an opposite as deliberate as the
+  laurel — the flag that work went wrong, attached to the work it names,
+  project-scoped like the fruit it mirrors. Working names float in the garden
+  register (rot, weeds, blight) and none is chosen. The same intentfulness
+  rules bind it: never derived, never gamified, and specificity is still the
+  filter — a complaint that cannot name its trigger is noise. Design owed with
+  the recognition arc; it lives wherever the fruits live.
+- **The garden as the front door.** Today attn's home screen is sessions and
+  workspaces. The vision says an agent "finds its work waiting" — and so
+  should the user. Named here so it cannot silently default to a side panel
+  forever: whether the garden becomes the app's primary navigation — sessions
+  reached through the seeds they tend, the session list demoted to a
+  secondary view — is decided together with the in-flight foundational
+  rendering work, not by drift.
 
 Blindspots — flag for a `ground` pass before their first chunk:
 
 - **The central server.** Identity and addressing of seats across daemons and
   machines, relationship to the existing hub/relay, auth, and the smallest
-  honest first version. Unfamiliar territory; ground before designing.
-- **Seed grain and schema.** How fine is fine — seed shape, dependency
-  model, audit-trail contract, lifecycle vocabulary (planted, growing,
-  dormant, harvested, withered). Study the beads *UX* specifically (not its
-  implementation) before committing a schema.
+  honest first version. Unfamiliar territory; ground before designing. Its
+  scope grew on 2026-08-06: recognition routing was the founding reason, but
+  the garden itself needs a home the moment remote daemons are in play — a
+  garden per daemon is a split brain, so seeds, plans, fruits, and the
+  negative channel all converge on one hub. The garden plan takes the interim
+  stance (one garden, at the hub daemon, remote sessions reaching it over the
+  relay); syncing that hub with a central server across machines is a known
+  unknown Victor already wants solved — how is entirely open. Stance set
+  2026-08-06, ahead of the ground pass: the server is **closed source**,
+  **operated by Victor**, and **optional, never required** — attn is complete
+  standalone; the service adds cross-computer garden syncing and recognition
+  routing and gates no feature. The moat is operational gravity (the hosted
+  network is the convenient path), not a lock — the Tailscale shape: open
+  clients, closed coordination plane. Closed keeps monetization optionality
+  and freedom to move fast at zero cost today, and is the reversible door
+  (closed can open later; open cannot close). The server will not be fully
+  opaque: the foreseen future includes viewing and editing seeds from the
+  web, and controlling agents remotely — or a server-side agent directing
+  the daemon's agents — so the server understands the garden model. The
+  shape that reconciles that with "optional": the hub stays the **sole
+  applier** of garden mutations; the server is a privileged remote client —
+  it renders, forwards intents, and routes recognition, but never writes as
+  a peer. That keeps "optional" true and multi-master sync permanently off
+  the table. Auth stays as simple as possible for as long as possible — a
+  minted API key in the config; Victor is the sole user for a long time.
+  Sync scope includes roles/seats alongside seeds. Hubs that never meet each
+  other (work, home) still each meet the server: cross-hub garden visibility
+  is a union routed by daemon prefix, never a merge — fully qualified seed
+  ids (`<daemon-id>/<local-id>`, prefix minted only at the boundary) make
+  identity collisions impossible by construction, and every seed has one
+  home hub that applies its writes. The ground pass owns the sync and
+  transport mechanics and the smallest honest first version.
+- **Seed grain and schema.** ~~Study the beads *UX* specifically (not its
+  implementation) before committing a schema.~~ Ground pass done 2026-08-06;
+  findings and the resulting schema decisions (ids are identity, edges are
+  structure; atomic tend; ready-as-query) live in the garden plan.
 
 ## References
 


### PR DESCRIPTION
## What

The vertical-slice plan for the garden — the friendly-home vision's fine-grained work graph — plus the vision updates that came out of planning it.

**New: `docs/plans/2026-08-06-the-garden-vertical-slices.md`.** Six slices, each shipping end to end (CLI → daemon → app):

1. **Plant and see** — one-line `attn seed plant`, live workspace-scoped garden panel, full schema carried from day 1. The plan plants *itself* as the first plot: the garden's first load is its own construction.
2. **Lifecycle and tending** — atomic `tend`, `park`/`harvest`/`wither`/`replant`, notes; every door two-way, every refusal loud.
3. **Edges and ready** — typed `blocks`/`part-of` edges and a flag-free `ready` whose scope is *inferred from the caller* (the daemon knows who asks — a delegate sees its plot, an interactive session its workspace).
4. **Seed axis of continuity** — handoff notes attached to seeds; `tend` primes the successor automatically.
5. **Plots and dispatch** — a crown with children as a dispatch target; children parallel by default, only `blocks` edges sequence.
6. **The plan lives in the garden** — the markdown annotation surface learns to render seeds; the crown's body is the plan; annotations route to the tender. Rides in-flight foundational rendering work; explicitly re-align before building.

Key design decisions: docstore storage (`core/garden`); one primitive (a plot is a seed with children, its root the crown, a packet a plot flagged as template); ids are identity, edges are structure (no dotted hierarchy); one garden at the hub daemon; server-ready pre-commitments (daemon-prefixed fully qualified ids minted only at the boundary, bus facts as the future sync change feed). Packets, gates-as-turns, and sow/distill are designed into the schema now, implemented last.

**Updated: `docs/vision/friendly-home-for-agents.md`.** The central-server blindspot records its grown scope and stance: closed source, operated, **optional never required** — cross-computer garden sync and recognition routing, no feature gating; the server acts as a client and the hub stays the sole applier of its garden's writes, so multi-master sync stays permanently off the table. Also new: the negative recognition channel (the laurel's opposite, name undecided), the garden-as-front-door question, and a check that seat memory may be a garden query before any dedicated store is built.

## Why

Beads is the UX inspiration, not the spec: where beads needs flags because its CLI is context-free, attn knows who is asking, and the garden leans on that everywhere. The plan grounds every schema decision in the beads study (formulas/molecules included) and in what already exists — the docstore, the bus, the markdown annotation surface, the live seat simulation.

## Verification

Docs-only. `go run ./cmd/changelog-check` passes; changelog fragment included.

https://claude.ai/code/session_01H2VkptxELz23a1Hd55Mo7U