### PR TITLE
fix(daemon): store turn, cursor and listing timestamps in an encoding that sorts

### DIFF
--- a/changelog.d/turn-timestamps-that-sort.yaml
+++ b/changelog.d/turn-timestamps-that-sort.yaml
@@ -1,0 +1,15 @@
+kind: fixed
+area: daemon
+change: >
+  An agent that finishes a turn in the same second the turn began no longer goes
+  quiet: it comes back to the queue the next time it wants you. Delegations,
+  workspaces and workspace panes created moments apart are also listed in the
+  order they were created.
+symptom: >
+  attn recorded these timestamps in a form whose text order was not time order
+  within a single second, and it compares them as text. The turn a session owes
+  you is decided by comparing when it opened against when you settled it, so a
+  turn settled inside the second it opened in still read as open — and no new
+  turn opened, with nothing said about it. Waking from a "until tomorrow" or
+  "until Monday" snooze was the way in, because those wake on an exact second.
+  Existing records are rewritten on first launch.

--- a/internal/store/automations.go
+++ b/internal/store/automations.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/victorarias/attn/internal/docstore"
 )
 
 func parseOptionalAutomationTime(value string) *time.Time {
@@ -221,7 +222,7 @@ func clearAutomationReviewRequestEdgesTx(tx *sql.Tx, definitionID string, now ti
 // refresh started before this fence cannot launch work under the newly
 // enabled/reapplied revision.
 func fenceAutomationProviderCursorsTx(tx *sql.Tx, definitionID string, now time.Time) error {
-	fence := now.UTC().Format(time.RFC3339Nano)
+	fence := now.UTC().Format(sortableTimeFormat)
 	_, err := tx.Exec(`INSERT INTO automation_provider_cursors(definition_id,provider,scope,observed_at) VALUES(?,'github_review_requested','*',?) ON CONFLICT(definition_id,provider,scope) DO UPDATE SET observed_at=excluded.observed_at`, definitionID, fence)
 	return err
 }
@@ -720,7 +721,7 @@ func (s *Store) GetAutomationScheduleCursor(definitionID string) (time.Time, boo
 	if err != nil {
 		return time.Time{}, false, err
 	}
-	at, err := time.Parse(time.RFC3339Nano, raw)
+	at, err := docstore.ParseTime(raw)
 	if err != nil {
 		return time.Time{}, false, fmt.Errorf("parse automation schedule cursor: %w", err)
 	}
@@ -735,7 +736,7 @@ func (s *Store) SetAutomationScheduleCursor(definitionID string, at time.Time) e
 	if s.db == nil {
 		return errors.New("automation persistence unavailable")
 	}
-	_, err := s.db.Exec(`INSERT INTO automation_provider_cursors(definition_id,provider,scope,observed_at) VALUES(?,'schedule','*',?) ON CONFLICT(definition_id,provider,scope) DO UPDATE SET observed_at=excluded.observed_at`, definitionID, at.UTC().Format(time.RFC3339Nano))
+	_, err := s.db.Exec(`INSERT INTO automation_provider_cursors(definition_id,provider,scope,observed_at) VALUES(?,'schedule','*',?) ON CONFLICT(definition_id,provider,scope) DO UPDATE SET observed_at=excluded.observed_at`, definitionID, at.UTC().Format(sortableTimeFormat))
 	return err
 }
 
@@ -755,12 +756,12 @@ func (s *Store) ReconcileAutomationReviewRequests(definitionID, host string, sub
 		return nil, err
 	}
 	defer tx.Rollback()
-	observedRaw := observedAt.UTC().Format(time.RFC3339Nano)
+	observedRaw := observedAt.UTC().Format(sortableTimeFormat)
 	updatedRaw := formatTicketTime(observedAt)
 	var enableFenceRaw string
 	err = tx.QueryRow(`SELECT observed_at FROM automation_provider_cursors WHERE definition_id=? AND provider='github_review_requested' AND scope='*'`, definitionID).Scan(&enableFenceRaw)
 	if err == nil {
-		enableFence, parseErr := time.Parse(time.RFC3339Nano, enableFenceRaw)
+		enableFence, parseErr := docstore.ParseTime(enableFenceRaw)
 		if parseErr != nil {
 			return nil, fmt.Errorf("parse automation enable fence: %w", parseErr)
 		}
@@ -774,7 +775,7 @@ func (s *Store) ReconcileAutomationReviewRequests(definitionID, host string, sub
 	var cursorRaw string
 	err = tx.QueryRow(`SELECT observed_at FROM automation_provider_cursors WHERE definition_id=? AND provider='github_review_requested' AND scope=?`, definitionID, host).Scan(&cursorRaw)
 	if err == nil {
-		cursorAt, parseErr := time.Parse(time.RFC3339Nano, cursorRaw)
+		cursorAt, parseErr := docstore.ParseTime(cursorRaw)
 		if parseErr != nil {
 			return nil, fmt.Errorf("parse automation provider cursor: %w", parseErr)
 		}

--- a/internal/store/delegation_operations.go
+++ b/internal/store/delegation_operations.go
@@ -36,7 +36,7 @@ func (s *Store) ClaimDelegationOperation(requestID, operationID, sessionID, chie
 	if s.db == nil {
 		return nil, false, errors.New("delegation idempotency requires a database")
 	}
-	stamp := now.UTC().Format(time.RFC3339Nano)
+	stamp := now.UTC().Format(sortableTimeFormat)
 	result, err := s.db.Exec(`INSERT INTO delegation_operations
 		(request_id, operation_id, request_json, state, progress, session_id, chief_session_id, ticket_id, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -113,7 +113,7 @@ func getDelegationOperation(db *sql.DB, id string) (*DelegationOperationRecord, 
 func (s *Store) MarkDelegationWorktreeOwned(id, path, token string, now time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	stamp := now.UTC().Format(time.RFC3339Nano)
+	stamp := now.UTC().Format(sortableTimeFormat)
 	_, err := s.db.Exec(`UPDATE delegation_operations SET worktree_path = ?, worktree_owned = 1, worktree_token = ?, updated_at = ?
 		WHERE request_id = ? OR operation_id = ?`, path, token, stamp, id, id)
 	return err
@@ -137,7 +137,7 @@ func (s *Store) UpdateDelegationOperation(id string, state protocol.DelegationOp
 	if operationErr != nil {
 		errorText = operationErr.Error()
 	}
-	stamp := now.UTC().Format(time.RFC3339Nano)
+	stamp := now.UTC().Format(sortableTimeFormat)
 	_, err := s.db.Exec(`UPDATE delegation_operations SET state = ?, progress = ?,
 		workspace_id = CASE WHEN ? = '' THEN workspace_id ELSE ? END,
 		ticket_id = CASE WHEN ? = '' THEN ticket_id ELSE ? END,

--- a/internal/store/endpoints.go
+++ b/internal/store/endpoints.go
@@ -4,11 +4,22 @@ import (
 	"database/sql"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/victorarias/attn/internal/config"
-	"github.com/victorarias/attn/internal/protocol"
 )
+
+// endpointStamp is the instant an endpoint row was written, in the encoding the
+// listing orders by. It is deliberately not protocol.TimestampNow(): that renders
+// time.Now() in the local zone with a trailing-zero-stripped fraction, and
+// created_at is ORDER BY'd as text, so two rows written either side of a DST
+// change or in different fraction widths came back in an order that was not
+// theirs. sortableTimeFormat is UTC and fixed-width, so text order is time order.
+//
+// The value stays an RFC3339 string on the same protocol.Timestamp wire field —
+// this narrows which RFC3339 spelling is written, it does not change the type.
+func endpointStamp() string { return time.Now().UTC().Format(sortableTimeFormat) }
 
 type EndpointRecord struct {
 	ID        string
@@ -41,7 +52,7 @@ func (s *Store) AddEndpoint(name, sshTarget, profile string) (*EndpointRecord, e
 		return nil, sql.ErrConnDone
 	}
 
-	now := string(protocol.TimestampNow())
+	now := endpointStamp()
 	record := &EndpointRecord{
 		ID:        uuid.NewString(),
 		Name:      strings.TrimSpace(name),
@@ -186,7 +197,7 @@ func (s *Store) UpdateEndpoint(id string, update EndpointUpdate) (*EndpointRecor
 	if update.Profile != nil {
 		record.Profile = *update.Profile
 	}
-	record.UpdatedAt = string(protocol.TimestampNow())
+	record.UpdatedAt = endpointStamp()
 
 	if _, err := s.db.Exec(`
 		UPDATE endpoints

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -940,6 +940,13 @@ CREATE TABLE IF NOT EXISTS document_collections (
 	// held a job scheduled on a whole second back until the next second and
 	// scrambled rows written inside one second. Applied by applyMigration93.
 	{93, "store job and notification timestamps in an encoding that sorts", ``},
+	// The last of the rewrite migrations 91 and 93 began, for every remaining TEXT
+	// stamp this package compares or orders as text: the turn stamps that decide
+	// whether a session owes the user a turn, the automation provider cursor that
+	// gates a review-request observation, and the created_at that orders
+	// delegations, endpoints, workspaces and workspace panes. Applied by
+	// applyMigration94.
+	{94, "store turn, cursor and listing timestamps in an encoding that sorts", ``},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -1230,6 +1237,11 @@ func migrateDB(db *sql.DB, dbPath string) error {
 			}
 		} else if m.version == 93 {
 			if err := applyMigration93(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 94 {
+			if err := applyMigration94(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -2425,6 +2437,81 @@ func applyMigration93(tx *sql.Tx) error {
 	unreadable += n
 	if unreadable > 0 {
 		log.Printf("[store] migration 93: left %d job/notification timestamp(s) as they were; they are not RFC3339 and cannot be re-encoded", unreadable)
+	}
+	return nil
+}
+
+// applyMigration94 finishes what migrations 91 and 93 started: after it, no TEXT
+// stamp this package compares or orders as text is written in an encoding whose
+// text order is not time order.
+//
+// What each column cost while it was wrong:
+//
+//   - sessions.turn_opened_at / turn_settled_at are compared against each other
+//     ("a turn is open iff opened > settled"), so a turn settled inside the
+//     second it was opened in read as still open and the next turn silently never
+//     opened. Whole-second opens are routine, not a coincidence: a day-named
+//     snooze wakes on an exact second and the woken turn is stamped with that
+//     deadline. turn_snoozed_until is only ever compared for equality, but it
+//     rides along because WakeTurnAt matches the stored deadline against a
+//     freshly formatted one — restamping it in the same breath as changing the
+//     writer is what keeps a snooze written before this migration wakeable after
+//     it.
+//   - automation_provider_cursors.observed_at gates the cursor advance
+//     (`excluded.observed_at >= ...observed_at`), so an observation could fail to
+//     advance the cursor past one taken microseconds earlier.
+//   - delegation_operations.created_at, workspaces.created_at and
+//     workspace_layout_panes.created_at each order a listing, so rows written
+//     together came back in an arbitrary order.
+//   - endpoints.created_at / updated_at were the worst of them: written through
+//     protocol.TimestampNow(), which renders the local zone, so the stored values
+//     carry an offset like "+02:00" and the listing misordered across a zone or
+//     DST change as well as across a fraction width. Restamping normalizes them
+//     to UTC, which is why the decode has to be the tolerant one.
+//
+// Idempotent by construction — re-encoding an already-converted stamp yields
+// itself — and an undecodable stamp is left alone and reported, both inherited
+// from restampTable, which also skips the ” that means "no stamp here" on the
+// turn columns and on an unclaimed cursor.
+//
+// The composite-key tables are keyed by rowid: every table here is an ordinary
+// rowid table, and restampTable needs one column that names a row, not the
+// primary key it happens to have.
+func applyMigration94(tx *sql.Tx) error {
+	restamps := []struct {
+		table   string
+		key     string
+		columns []string
+	}{
+		{"sessions", "id", []string{"turn_opened_at", "turn_settled_at", "turn_snoozed_until"}},
+		{"automation_provider_cursors", "rowid", []string{"observed_at"}},
+		{"automation_review_request_edges", "rowid", []string{"last_observed_at"}},
+		{"delegation_operations", "request_id", []string{"created_at", "updated_at"}},
+		{"endpoints", "id", []string{"created_at", "updated_at"}},
+		{"workspaces", "id", []string{"created_at"}},
+		{"workspace_layout_panes", "rowid", []string{"created_at", "updated_at"}},
+	}
+	unreadable := 0
+	for _, r := range restamps {
+		// A table the base schema creates rather than a migration is absent from a
+		// database built up from an older hand-written schema. There is nothing to
+		// rewrite in a table that does not exist yet, and whatever creates it later
+		// writes the new encoding from the start.
+		present, err := tableExists(tx, r.table)
+		if err != nil {
+			return fmt.Errorf("checking for %s: %w", r.table, err)
+		}
+		if !present {
+			continue
+		}
+		n, err := restampTable(tx, r.table, r.key, r.columns)
+		if err != nil {
+			return fmt.Errorf("restamping %s: %w", r.table, err)
+		}
+		unreadable += n
+	}
+	if unreadable > 0 {
+		log.Printf("[store] migration 94: left %d turn/cursor/listing timestamp(s) as they were; they are not RFC3339 and cannot be re-encoded", unreadable)
 	}
 	return nil
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -2463,6 +2463,10 @@ func applyMigration93(tx *sql.Tx) error {
 //   - delegation_operations.created_at, workspaces.created_at and
 //     workspace_layout_panes.created_at each order a listing, so rows written
 //     together came back in an arbitrary order.
+//   - workflow_runs.created_at orders the run listing and is written by the CLI
+//     rather than by this package, so the store normalizes whatever spelling a
+//     caller hands it (normalizeWorkflowStamp) instead of the writers being asked
+//     to agree. Its callers reach it through protocol.TimestampNow() too.
 //   - endpoints.created_at / updated_at were the worst of them: written through
 //     protocol.TimestampNow(), which renders the local zone, so the stored values
 //     carry an offset like "+02:00" and the listing misordered across a zone or
@@ -2490,6 +2494,7 @@ func applyMigration94(tx *sql.Tx) error {
 		{"endpoints", "id", []string{"created_at", "updated_at"}},
 		{"workspaces", "id", []string{"created_at"}},
 		{"workspace_layout_panes", "rowid", []string{"created_at", "updated_at"}},
+		{"workflow_runs", "run_id", []string{"created_at"}},
 	}
 	unreadable := 0
 	for _, r := range restamps {

--- a/internal/store/turn.go
+++ b/internal/store/turn.go
@@ -25,12 +25,23 @@ type TurnStamps struct {
 // age it was opened at, so a row never moves in the queue while the user works
 // with the agent, and a re-reported state cannot disturb it.
 //
+// The guard is a text comparison — turn_opened_at and turn_settled_at are TEXT
+// columns — so the stored encoding is the whole definition of "still open", and
+// it has to be one whose text order is time order within a second. That is
+// sortableTimeFormat. Under the RFC3339Nano this used to write, a stamp whose
+// fraction another stamp extends sorted above it ('Z' is 0x5A, above '.' and
+// every digit), so a turn settled inside the second it was opened in read as
+// still open and the next turn silently never opened. Whole-second opens are the
+// ordinary case, not a coincidence: a day-named snooze wakes on an exact second
+// and the woken turn is stamped with that deadline. Migration 94 rewrote the
+// stored stamps.
+//
 // It returns true when a turn was opened.
 func (s *Store) OpenTurnIfClosed(id string, now time.Time) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	stamp := now.UTC().Format(time.RFC3339Nano)
+	stamp := now.UTC().Format(sortableTimeFormat)
 
 	if s.db == nil {
 		if _, ok := s.sessions[id]; !ok {
@@ -76,7 +87,7 @@ func (s *Store) SettleTurn(id string, now time.Time) bool {
 	}
 
 	result, err := s.db.Exec(`UPDATE sessions SET turn_settled_at = ? WHERE id = ?`,
-		now.UTC().Format(time.RFC3339Nano), id)
+		now.UTC().Format(sortableTimeFormat), id)
 	if err != nil {
 		log.Printf("[store] SettleTurn: failed for session %s: %v", id, err)
 		return false
@@ -113,7 +124,7 @@ func (s *Store) SnoozeTurn(id string, until, now time.Time) bool {
 
 	result, err := s.db.Exec(
 		`UPDATE sessions SET turn_settled_at = ?, turn_snoozed_until = ? WHERE id = ?`,
-		now.UTC().Format(time.RFC3339Nano), until.UTC().Format(time.RFC3339Nano), id)
+		now.UTC().Format(sortableTimeFormat), until.UTC().Format(sortableTimeFormat), id)
 	if err != nil {
 		log.Printf("[store] SnoozeTurn: failed for session %s: %v", id, err)
 		return false
@@ -167,14 +178,14 @@ func (s *Store) WakeTurnAt(id string, deadline time.Time) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	stamp := deadline.UTC().Format(time.RFC3339Nano)
+	stamp := deadline.UTC().Format(sortableTimeFormat)
 
 	if s.db == nil {
 		current, ok := s.turnStamps[id]
 		if !ok || current.SnoozedUntil.IsZero() {
 			return false
 		}
-		if current.SnoozedUntil.UTC().Format(time.RFC3339Nano) != stamp {
+		if current.SnoozedUntil.UTC().Format(sortableTimeFormat) != stamp {
 			return false
 		}
 		current.SnoozedUntil = time.Time{}
@@ -263,13 +274,10 @@ func (s *Store) setTurnStampsLocked(id string, stamps TurnStamps) {
 	s.turnStamps[id] = stamps
 }
 
-func parseTurnStamp(value string) time.Time {
-	if value == "" {
-		return time.Time{}
-	}
-	parsed, err := time.Parse(time.RFC3339Nano, value)
-	if err != nil {
-		return time.Time{}
-	}
-	return parsed
-}
+// parseTurnStamp decodes a stored turn stamp in any RFC3339 spelling — the
+// fixed-width one written today and the trailing-zero-stripped one written
+// before migration 94 — and yields the zero time for the ” that means "no turn
+// here" as well as for anything it cannot read. It is parseStoreTime, which the
+// job queue and the notifications feed already decode with: the columns hold one
+// encoding, so they get one decoder.
+func parseTurnStamp(value string) time.Time { return parseStoreTime(value) }

--- a/internal/store/turn_timestamps_test.go
+++ b/internal/store/turn_timestamps_test.go
@@ -201,6 +201,36 @@ func TestPendingDelegationOperationsAreInClaimOrderWithinASecond(t *testing.T) {
 	}
 }
 
+// ListWorkflowRuns promises newest-first, in `ORDER BY created_at DESC`. Its
+// stamps come from the CLI through protocol.TimestampNow(), so the store
+// normalizes them on write — this is the assert that the normalizing happens at
+// all, rather than the column inheriting whatever spelling a caller chose.
+func TestWorkflowRunsAreNewestFirstWithinASecond(t *testing.T) {
+	s := newTurnStore(t)
+
+	for _, r := range raggedOffsets {
+		at := turnBase().Add(r.offset).Format(time.RFC3339Nano)
+		if err := s.UpsertWorkflowRun(&WorkflowRunRow{
+			RunID: r.id, ScriptPath: "s.js", ScriptHash: "h", Status: "running",
+			CreatedAt: at, UpdatedAt: at,
+		}); err != nil {
+			t.Fatalf("upsert run %s: %v", r.id, err)
+		}
+	}
+
+	runs, err := s.ListWorkflowRuns("")
+	if err != nil {
+		t.Fatalf("list workflow runs: %v", err)
+	}
+	ids := make([]string, 0, len(runs))
+	for _, r := range runs {
+		ids = append(ids, r.RunID)
+	}
+	if want := reversed(chronologicalRaggedIDs()); !sameOrder(ids, want) {
+		t.Fatalf("workflow runs came back as %v, want %v", ids, want)
+	}
+}
+
 // Migration 94 rewrites what earlier versions stored. Its input is the encoding
 // they wrote, so the test writes that encoding rather than describing it: the
 // stamps go in the way an older store would have written them, the migration

--- a/internal/store/turn_timestamps_test.go
+++ b/internal/store/turn_timestamps_test.go
@@ -1,0 +1,331 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/docstore"
+)
+
+// turn_opened_at, turn_settled_at, automation_provider_cursors.observed_at and
+// the created_at columns that order the delegation, workspace and pane listings
+// are TEXT, so every comparison SQL makes on them is a text comparison and the
+// stored encoding is the whole definition of "before". Rows a second apart
+// cannot tell a working encoding from a broken one; what has to be right is what
+// happens inside one second.
+//
+// Every fixture here therefore uses sub-second offsets whose
+// trailing-zero-stripped encodings sort in an order that is not their own. Two
+// shapes do it, and both are in raggedOffsets: a whole second, which under
+// RFC3339Nano sorts above every stamp inside itself because 'Z' is 0x5A and '.'
+// and the digits are below it; and a fraction that another fraction extends
+// (".1234" against ".12345"), where the shorter one's 'Z' again lands above the
+// longer one's next digit.
+
+// raggedOffsets are ids in chronological order with the sub-second offsets that
+// separate them, all inside one second.
+var raggedOffsets = []struct {
+	id     string
+	offset time.Duration
+}{
+	{"r0", 0},
+	{"r1234", 123400 * time.Microsecond},
+	{"r12345", 123450 * time.Microsecond},
+	{"r5", 500 * time.Millisecond},
+}
+
+func turnBase() time.Time { return time.Date(2026, 8, 6, 10, 0, 0, 0, time.UTC) }
+
+func chronologicalRaggedIDs() []string {
+	out := make([]string, 0, len(raggedOffsets))
+	for _, r := range raggedOffsets {
+		out = append(out, r.id)
+	}
+	return out
+}
+
+// The turn guard, and the reason this change exists. A turn that was settled is
+// closed, and the next attention-wanting state has to open a new one — that is
+// the loop the whole queue rests on. The guard asks it as
+// `turn_opened_at <= turn_settled_at`, in text, so a settle landing in the same
+// second as the open it closes read as "a turn is already open" and
+// OpenTurnIfClosed returned false. Nothing logged it: the session simply stopped
+// appearing in the queue until some later turn happened to open.
+//
+// The whole-second case is the one that reaches users. A day-named snooze
+// ("tomorrow", "Saturday", "Monday") resolves to an exact second — the client
+// zeroes the milliseconds — and the woken turn is stamped with that deadline, so
+// a whole-second turn_opened_at is what every such wake produces.
+func TestATurnSettledInTheSecondItOpenedInCanReopen(t *testing.T) {
+	cases := []struct {
+		name            string
+		opened, settled time.Duration
+	}{
+		{"opened on a whole second", 0, 500 * time.Millisecond},
+		{"settled fraction extends the opened one", 123400 * time.Microsecond, 123450 * time.Microsecond},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := newTurnStore(t)
+			addTurnSession(t, s, "s1", "working")
+
+			if !s.OpenTurnIfClosed("s1", turnBase().Add(c.opened)) {
+				t.Fatalf("the first turn did not open")
+			}
+			if !s.SettleTurn("s1", turnBase().Add(c.settled)) {
+				t.Fatalf("settle failed")
+			}
+			if stamps := s.TurnStamps("s1"); !stamps.SettledAt.After(stamps.OpenedAt) {
+				t.Fatalf("fixture is wrong: settled %s is not after opened %s",
+					stamps.SettledAt, stamps.OpenedAt)
+			}
+
+			// The load-bearing assert: the turn is settled, so the next
+			// attention-wanting state must open a new one.
+			if !s.OpenTurnIfClosed("s1", turnBase().Add(c.settled+time.Millisecond)) {
+				t.Fatalf("no turn opened after a settle in the same second; the session is silently out of the queue")
+			}
+		})
+	}
+}
+
+// turn_snoozed_until is matched for equality (`turn_snoozed_until = ?`), not
+// ordered, so changing the encoding cannot misorder it — it can only stop a
+// stored deadline from matching the one a fired timer re-formats. That is what
+// makes the migration load-bearing here rather than the format: a snooze written
+// before it, in the old encoding, has to still be wakeable after it.
+//
+// A whole second is the case that matters, because every day-named snooze
+// resolves to one — the client zeroes the milliseconds — and it is exactly where
+// the two encodings disagree ("…:00Z" against "…:00.000000000Z").
+func TestASnoozeWrittenInTheOldEncodingIsStillWakeable(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB: %v", err)
+	}
+	defer s.Close()
+	addTurnSession(t, s, "s1", "working")
+
+	until := turnBase().Add(time.Hour)
+	if _, err := s.db.Exec(`UPDATE sessions SET turn_snoozed_until = ? WHERE id = 's1'`,
+		until.Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("plant old snooze stamp: %v", err)
+	}
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version >= 94`); err != nil {
+		t.Fatalf("unrecord migration 94: %v", err)
+	}
+
+	// Sanity: without the rewrite the timer cannot cash the deadline it holds.
+	if s.WakeTurnAt("s1", until) {
+		t.Fatalf("the planted stamp already matches; this test would pass without the migration")
+	}
+
+	if err := migrateDB(s.db, dbPath); err != nil {
+		t.Fatalf("migrateDB: %v", err)
+	}
+	if got := s.SnoozedSessions()["s1"]; !got.Equal(until) {
+		t.Fatalf("stored deadline reads back as %s, want %s", got, until)
+	}
+	if !s.WakeTurnAt("s1", until) {
+		t.Fatalf("after migration 94 the fired timer still could not cash its deadline")
+	}
+}
+
+// The review-request cursor advance is guarded in SQL —
+// `DO UPDATE SET observed_at=excluded.observed_at WHERE excluded.observed_at >=
+// automation_provider_cursors.observed_at` — and it is the only observed_at
+// comparison the store makes. A poll loop produces observations inside one
+// second, and a later one that fails to advance the cursor leaves the fence
+// standing on a stale instant.
+//
+// The schedule cursor deliberately is not the subject here: its upsert carries no
+// WHERE, so it advances whatever the encoding does and proves nothing.
+func TestAReviewRequestCursorAdvancesWithinASecond(t *testing.T) {
+	s := newTurnStore(t)
+	def, err := s.UpsertAutomationDefinition("reviews", "Reviews", `{"id":"reviews"}`, turnBase())
+	if err != nil {
+		t.Fatalf("upsert definition: %v", err)
+	}
+
+	first := turnBase()
+	second := turnBase().Add(500 * time.Millisecond)
+	for _, at := range []time.Time{first, second} {
+		if _, err := s.ReconcileAutomationReviewRequests(
+			def.ID, "github.com", []string{"github.com/owner/repo#1"}, at); err != nil {
+			t.Fatalf("reconcile at %s: %v", at, err)
+		}
+	}
+
+	var raw string
+	if err := s.db.QueryRow(
+		`SELECT observed_at FROM automation_provider_cursors
+		  WHERE definition_id = ? AND provider = 'github_review_requested' AND scope = 'github.com'`,
+		def.ID).Scan(&raw); err != nil {
+		t.Fatalf("read cursor: %v", err)
+	}
+	got, err := docstore.ParseTime(raw)
+	if err != nil {
+		t.Fatalf("parse cursor %q: %v", raw, err)
+	}
+	if !got.Equal(second) {
+		t.Fatalf("cursor is at %s, want the later observation %s", got, second)
+	}
+}
+
+// PendingDelegationOperations feeds the daemon's recovery of delegations it
+// still owes work for, in `ORDER BY created_at`. A burst of claims inside one
+// second is the ordinary case — a chief fires several delegations at once — and
+// they have to come back in the order they were claimed.
+func TestPendingDelegationOperationsAreInClaimOrderWithinASecond(t *testing.T) {
+	s := newTurnStore(t)
+
+	for _, r := range raggedOffsets {
+		if _, _, err := s.ClaimDelegationOperation(
+			r.id, "op-"+r.id, "sess-"+r.id, "chief", "", `{}`, turnBase().Add(r.offset)); err != nil {
+			t.Fatalf("claim %s: %v", r.id, err)
+		}
+	}
+
+	got, err := s.PendingDelegationOperations()
+	if err != nil {
+		t.Fatalf("pending delegation operations: %v", err)
+	}
+	ids := make([]string, 0, len(got))
+	for _, rec := range got {
+		ids = append(ids, rec.Operation.RequestID)
+	}
+	if want := chronologicalRaggedIDs(); !sameOrder(ids, want) {
+		t.Fatalf("pending delegations came back as %v, want %v", ids, want)
+	}
+}
+
+// Migration 94 rewrites what earlier versions stored. Its input is the encoding
+// they wrote, so the test writes that encoding rather than describing it: the
+// stamps go in the way an older store would have written them, the migration
+// runs, and the guard and the order that were wrong come back right.
+func TestMigration94RewritesTurnCursorAndListingStampsThatDoNotSort(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB: %v", err)
+	}
+	defer s.Close()
+
+	addTurnSession(t, s, "s1", "working")
+	for _, r := range raggedOffsets {
+		if _, _, err := s.ClaimDelegationOperation(
+			r.id, "op-"+r.id, "sess-"+r.id, "chief", "", `{}`, turnBase().Add(r.offset)); err != nil {
+			t.Fatalf("claim %s: %v", r.id, err)
+		}
+	}
+
+	// Roll the stamps back to the encoding migration 94 exists to replace: a turn
+	// opened on a whole second and settled half a second later, and delegation
+	// rows whose fractions extend one another. One value the migration cannot read
+	// is planted too, which it must leave alone rather than turn into year 1, and
+	// turn_snoozed_until stays '' — a session that is not snoozed holds a sentinel,
+	// not a stamp that failed to parse.
+	if _, err := s.db.Exec(
+		`UPDATE sessions SET turn_opened_at = ?, turn_settled_at = ? WHERE id = 's1'`,
+		turnBase().Format(time.RFC3339Nano),
+		turnBase().Add(500*time.Millisecond).Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("plant old turn stamps: %v", err)
+	}
+	for _, r := range raggedOffsets {
+		old := turnBase().Add(r.offset).Format(time.RFC3339Nano)
+		if _, err := s.db.Exec(
+			`UPDATE delegation_operations SET created_at = ? WHERE request_id = ?`, old, r.id); err != nil {
+			t.Fatalf("plant old delegation stamp for %s: %v", r.id, err)
+		}
+	}
+	if _, err := s.db.Exec(
+		`UPDATE delegation_operations SET updated_at = 'not a timestamp' WHERE request_id = ?`, "r5"); err != nil {
+		t.Fatalf("plant unreadable stamp: %v", err)
+	}
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version >= 94`); err != nil {
+		t.Fatalf("unrecord migration 94: %v", err)
+	}
+
+	// Sanity: the planted state is the broken one, so a pass here would mean the
+	// test proves nothing.
+	if s.OpenTurnIfClosed("s1", turnBase().Add(time.Second)) {
+		t.Fatalf("the planted turn stamps already reopen correctly; this test would pass without the migration")
+	}
+
+	if err := migrateDB(s.db, dbPath); err != nil {
+		t.Fatalf("migrateDB: %v", err)
+	}
+	assertMigration94Applied(t, s)
+
+	// Re-running finds nothing left to do and changes nothing: the rewrite is a
+	// decode and re-encode, so an already-converted stamp yields itself.
+	before := stampDigest(t, s)
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version >= 94`); err != nil {
+		t.Fatalf("unrecord migration 94 again: %v", err)
+	}
+	if err := migrateDB(s.db, dbPath); err != nil {
+		t.Fatalf("re-run migrateDB: %v", err)
+	}
+	if after := stampDigest(t, s); after != before {
+		t.Fatalf("a second run changed the stamps:\n%s\nto\n%s", before, after)
+	}
+}
+
+// assertMigration94Applied is the post-migration state: the settled turn reopens,
+// the delegation listing is in claim order, the stamp that does not decode is
+// untouched, and the unsnoozed sentinel is still the sentinel.
+func assertMigration94Applied(t *testing.T, s *Store) {
+	t.Helper()
+
+	if !s.OpenTurnIfClosed("s1", turnBase().Add(time.Second)) {
+		t.Fatalf("after migration 94 a settled turn still did not reopen")
+	}
+
+	got, err := s.PendingDelegationOperations()
+	if err != nil {
+		t.Fatalf("pending delegation operations: %v", err)
+	}
+	ids := make([]string, 0, len(got))
+	for _, rec := range got {
+		ids = append(ids, rec.Operation.RequestID)
+	}
+	if want := chronologicalRaggedIDs(); !sameOrder(ids, want) {
+		t.Fatalf("after migration 94 the delegations came back as %v, want %v", ids, want)
+	}
+
+	var unreadable string
+	if err := s.db.QueryRow(
+		`SELECT updated_at FROM delegation_operations WHERE request_id = 'r5'`).Scan(&unreadable); err != nil {
+		t.Fatal(err)
+	}
+	if unreadable != "not a timestamp" {
+		t.Fatalf("the unreadable stamp became %q; it must be left as it was", unreadable)
+	}
+
+	var snoozed string
+	if err := s.db.QueryRow(`SELECT turn_snoozed_until FROM sessions WHERE id = 's1'`).Scan(&snoozed); err != nil {
+		t.Fatal(err)
+	}
+	if snoozed != "" {
+		t.Fatalf("turn_snoozed_until became %q; the unsnoozed sentinel must be left as it is", snoozed)
+	}
+}
+
+// stampDigest is every stamp migration 94 touches, in a stable order, so a
+// second run can be compared byte for byte against the first.
+func stampDigest(t *testing.T, s *Store) string {
+	t.Helper()
+	var digest string
+	if err := s.db.QueryRow(`
+		SELECT (SELECT group_concat(turn_opened_at || '|' || turn_settled_at || '|' || turn_snoozed_until, ';')
+		          FROM (SELECT * FROM sessions ORDER BY id))
+		    || '#' ||
+		       (SELECT group_concat(created_at || '|' || updated_at, ';')
+		          FROM (SELECT * FROM delegation_operations ORDER BY request_id))
+	`).Scan(&digest); err != nil {
+		t.Fatalf("stamp digest: %v", err)
+	}
+	return digest
+}

--- a/internal/store/workflow_runs.go
+++ b/internal/store/workflow_runs.go
@@ -2,7 +2,30 @@ package store
 
 import (
 	"database/sql"
+
+	"github.com/victorarias/attn/internal/docstore"
 )
+
+// normalizeWorkflowStamp re-encodes a caller-supplied stamp into the encoding the
+// run listing orders by, and leaves anything it cannot read alone.
+//
+// The normalizing happens here rather than at the writers because created_at is
+// ORDER BY'd as text, so this column's order is the store's promise, not the
+// caller's. The callers reach it through protocol.TimestampNow(), which renders
+// time.Now() in the local zone with a trailing-zero-stripped fraction — two runs
+// started inside one second, or either side of a DST change, came back in an
+// order that was not theirs. That helper is the wire's spelling and is left as
+// it is; this is the one column whose order depends on it.
+func normalizeWorkflowStamp(s string) string {
+	if s == "" {
+		return s
+	}
+	t, err := docstore.ParseTime(s)
+	if err != nil {
+		return s
+	}
+	return t.Format(sortableTimeFormat)
+}
 
 // workflowScanner abstracts *sql.Row and *sql.Rows so a single scanner func can
 // serve both QueryRow and Query loops.
@@ -96,7 +119,7 @@ func (s *Store) UpsertWorkflowRun(run *WorkflowRunRow) error {
 		nullPtrString(run.ResultJSON),
 		nullPtrString(run.LastError),
 		boolToInt(run.Resumable),
-		run.CreatedAt,
+		normalizeWorkflowStamp(run.CreatedAt),
 		run.UpdatedAt,
 		nullPtrString(run.CompletedAt),
 	)

--- a/internal/store/workspace.go
+++ b/internal/store/workspace.go
@@ -18,7 +18,7 @@ func (s *Store) AddWorkspace(ws *protocol.Workspace) {
 	if s.db == nil {
 		return
 	}
-	createdAt := time.Now().UTC().Format(time.RFC3339Nano)
+	createdAt := time.Now().UTC().Format(sortableTimeFormat)
 	// rank is set on INSERT only. On re-register (ON CONFLICT) the stored rank is
 	// the durable authority for ordering and must survive — like title, it is not
 	// re-derived from the incoming struct so a user reorder sticks.

--- a/internal/store/workspacelayout.go
+++ b/internal/store/workspacelayout.go
@@ -25,7 +25,7 @@ func (s *Store) SaveWorkspaceLayout(snapshot workspacelayout.WorkspaceLayout) er
 		return err
 	}
 
-	now := time.Now().Format(time.RFC3339Nano)
+	now := time.Now().UTC().Format(sortableTimeFormat)
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err


### PR DESCRIPTION
A timestamp written with `time.RFC3339Nano` into a TEXT column and then compared
or ordered as text is wrong within a second: the fraction's trailing zeros are
stripped so widths vary, and `Z` (0x5A) sorts above `.` and every digit. The
document store fixed this for itself (migration 91) and the job queue and
notifications feed followed (migration 93). This closes the class.

## The one that matters: a turn that never opened

A session owes the user a turn iff it opened after it was last settled, and
`OpenTurnIfClosed` asks that in SQL: `turn_opened_at = '' OR turn_opened_at <=
turn_settled_at`. Both stamps were RFC3339Nano in TEXT columns, so a turn
settled inside the second it opened in still read as open — the guard refused,
`OpenTurnIfClosed` returned false, and no turn opened. Nothing logged it. The
session simply stopped appearing in the queue until some later turn happened to
open.

The brief recorded this as a read finding, so the first commit is the failing
test. It reproduces on two fixture shapes, and the trigger is not a nanosecond
coincidence:

`app/src/utils/snoozeDurations.ts:59` builds a day-named snooze with
`at.setHours(SNOOZE_WAKE_HOUR, 0, 0, 0)` — milliseconds zeroed. So "Until
tomorrow", "Until Saturday" and "Until Monday" all wake on an exact second, and
`turnOpensAtOnWake` (`internal/daemon/snooze.go:143`) stamps the woken turn with
that deadline. A whole-second `turn_opened_at` is what every one of those wakes
produces, and it sorts above *every* stamp inside its own second. Any settle
landing in that second wedges the session silently.

## The rest of the class

| column | how it was wrong |
| --- | --- |
| `sessions.turn_opened_at` / `turn_settled_at` | the guard above |
| `sessions.turn_snoozed_until` | equality-matched, not ordered — but `WakeTurnAt` matches the stored deadline against a freshly formatted one, so restamping it is what keeps a snooze written before this change wakeable after it |
| `automation_provider_cursors.observed_at` | `excluded.observed_at >= automation_provider_cursors.observed_at` — the cursor could fail to advance past an observation taken microseconds earlier |
| `delegation_operations.created_at` | `ORDER BY created_at` on the pending-delegation recovery listing |
| `workspaces.created_at`, `workspace_layout_panes.created_at` | ordered listings; **not in the brief's list**, found by sweeping every write site |
| `endpoints.created_at` / `updated_at` | the worst: written through `protocol.TimestampNow()`, which renders `time.Now()` in the **local zone**, so stored values carried an offset like `+02:00` and `ORDER BY created_at ASC` misordered across a zone or DST change as well as a fraction width |
| `workflow_runs.created_at` | same `TimestampNow()` trap, writer in `cmd/attn` rather than the store — see below |

`protocol.TimestampNow()` itself is untouched: it is the wire's spelling, and its
other callers write columns nothing compares (checked each — session state
stamps, PR `last_updated`/`last_polled`, workflow CLI). `endpoints` gets a
store-local `endpointStamp()`; `workflow_runs.created_at` is normalized inside
`UpsertWorkflowRun`, because that column's order is the store's promise and a
future writer would otherwise inherit the same trap. `created_at` only there —
`updated_at` and `completed_at` are never compared and a caller reads back the
stamp it wrote, which an existing CRUD test asserts.

## Sites deliberately left, and why

The brief asked for one timestamp spelling everywhere in `internal/store`. That
is not reachable at this scope and would not be an improvement:
`formatTicketTime` (`t.UTC().Format(time.RFC3339)`) is fixed width, seconds, and
always `Z` — its text order **is** time order. It is the encoding for tickets,
automation runs/occurrences/definitions/bindings, present and the bus, and
converting it would churn values four more domains put on the wire to satisfy a
slogan. Specifically **not** broken, contrary to the brief's item 3 and item 4:

- `automation_runs.created_at` (7 `ORDER BY` sites + an index),
  `automation_occurrences`, `automation_definitions`,
  `automation_continuity_bindings` — all `formatTicketTime`.
- `presentations.created_at` and `presentation_comments.created_at`
  (`present.go:205`, `:435`) — plain `time.RFC3339`.
- `bus_events.created_at` — `formatTicketTime` written *and* compared against a
  `formatTicketTime` cutoff (`bus.go:70` vs `:268`). It already sorts.

Also left: columns still written `RFC3339Nano` that are never compared or
ordered — `sessions.pinned_at` (presence sentinel), `sessions.state_since` /
`state_updated_at` / `last_seen` / `closed_intentionally_at`,
`workspace_contexts.updated_at`, `annotation_drafts.updated_at`,
`file_activity.last_at` (ranked in Go), `prs.details_fetched_at`,
`worktrees.created_at`, `automation_review_request_edges.updated_at`. Grep for
`RFC3339Nano` under `internal/store` and every remaining hit is one of these or
a comment.

## Migration 94

One migration, restamping through the `restampTable` helper migrations 91 and 93
used — decode and re-encode, idempotent by construction, blanks skipped,
undecodable values left alone and reported. Composite-key tables are keyed by
`rowid`. A table the base schema creates rather than a migration is skipped when
absent, which is what lets a database built from an older hand-written schema
migrate through.

`MAX(version)` checked before numbering: production is 92, and the highest
across all 14 local profile databases is 93, so 94 is free. Other in-flight
lanes may collide; resolve at merge by taking the next number.

## Receipts

**Tests.** `go test ./...` green. `go test -race ./internal/store` green.

**Falsification.** Reverting `sortableTimeFormat` to `time.RFC3339Nano` and
changing nothing else turns all six new behavioral tests red, each on its
load-bearing assert:

- `TestATurnSettledInTheSecondItOpenedInCanReopen` — "no turn opened after a
  settle in the same second" (both fixture shapes)
- `TestASnoozeWrittenInTheOldEncodingIsStillWakeable` — its pre-migration sanity
  guard fires, i.e. the test would prove nothing
- `TestAReviewRequestCursorAdvancesWithinASecond` — "cursor is at 10:00:00, want
  the later observation 10:00:00.5"
- `TestPendingDelegationOperationsAreInClaimOrderWithinASecond` — order is
  `[r12345 r1234 r5 r0]`, want `[r0 r1234 r12345 r5]`
- `TestWorkflowRunsAreNewestFirstWithinASecond` — order is `[r0 r5 r1234
  r12345]`, want the reverse
- `TestMigration94RewritesTurnCursorAndListingStampsThatDoNotSort` — the second
  run changes the stamps

The cursor test initially survived falsification because it exercised
`SetAutomationScheduleCursor`, whose upsert carries no `WHERE` and therefore
advances under any encoding. It was moved onto
`ReconcileAutomationReviewRequests`, the only guarded path.

**Migration witness**, on a sandbox copy of production `~/.attn/attn.db` (copied
out; production never opened read-write):

- schema 92 → 94; every non-blank stamp in every restamped column is 30
  characters after (`turn_opened_at` 7, `turn_settled_at` 7,
  `turn_snoozed_until` 1, `delegation_operations` 26×2, `workspaces` 6,
  `workspace_layout_panes` 8×2)
- blanks preserved: 4 blank `turn_opened_at`, 10 blank `turn_snoozed_until`
- an undecodable value planted alongside is left byte-identical and reported
  ("left 1 … cannot be re-encoded")
- second run byte-identical over 54 rows of stamps
- production holds no `workflow_runs` rows, so that table was witnessed with
  planted rows in the same real database, written the way
  `protocol.TimestampNow()` writes them. A run at `10:00:00+02:00` outranked one
  at `09:30:00+01:00` that is genuinely 30 minutes later; correct after, and the
  local offsets normalized to UTC.

**Live verification**, throwaway profile `tsfix` (cleaned afterwards), protocol
215, preflight PASS:

- `real-app:scenario-agent-queue` 3/3 green on a fresh profile, including
  `auto_settle_hands_over_the_next_agent` and `a_settle_survives_a_daemon_restart`
  — the turn open → settle → restart → rebuild-from-persisted-stamps loop this
  change touches
- `real-app:scenario-agent-queue-snooze` green — the snooze/wake path where the
  `turn_snoozed_until` equality match is load-bearing
- stamps written by the running daemon confirmed in the new encoding
  (`2026-08-06T22:55:06.101216000Z`)

On a profile carrying residue from ~10 earlier scenario runs those two steps
flaked hard (`a_settle_survives_a_daemon_restart` timing out at 64s versus 3.8s
fresh). A profile built from the unmodified base commit `82dfb928` showed the
same `auto_settle_hands_over_the_next_agent` failure, so that mode is
pre-existing and state-dependent, not from this change.

## Delivery

Based on and targeting `epic/integration` while GitHub Actions is degraded;
`sortableTimeFormat` and `restampTable` exist only there. Review of the combined
diff happens once on the `epic/integration` → `main` PR — deferred, not skipped.
