### PR TITLE
Integration: docstore Stage 2, sortable background-work and turn timestamps

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -199,7 +199,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '214';
+export const PROTOCOL_VERSION = '215';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, AgentEventMessage, AgentPromptMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentSort, DocUndefineMessage, DocUndefineResult, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, AddEndpointMessage, AgentEventMessage, AgentPromptMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, DocUndefineMessage, DocUndefineResult, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const agentEventMessage = Convert.toAgentEventMessage(json);
@@ -89,6 +89,7 @@
 //   const documentFieldSpec = Convert.toDocumentFieldSpec(json);
 //   const documentFilter = Convert.toDocumentFilter(json);
 //   const documentQuery = Convert.toDocumentQuery(json);
+//   const documentRevision = Convert.toDocumentRevision(json);
 //   const documentSort = Convert.toDocumentSort(json);
 //   const docUndefineMessage = Convert.toDocUndefineMessage(json);
 //   const docUndefineResult = Convert.toDocUndefineResult(json);
@@ -335,6 +336,7 @@
 //   const taskRetryMessage = Convert.toTaskRetryMessage(json);
 //   const taskRetryResultMessage = Convert.toTaskRetryResultMessage(json);
 //   const tasksChangedMessage = Convert.toTasksChangedMessage(json);
+//   const terminalPointerActivityMessage = Convert.toTerminalPointerActivityMessage(json);
 //   const ticket = Convert.toTicket(json);
 //   const ticketActionResultMessage = Convert.toTicketActionResultMessage(json);
 //   const ticketActivity = Convert.toTicketActivity(json);
@@ -1575,6 +1577,7 @@ export interface DocQueryResult {
 
 export interface DocSubscribeMessage {
     cmd:   DocSubscribeMessageCmd;
+    have?: HasElement[];
     query: Query;
     [property: string]: any;
 }
@@ -1583,9 +1586,17 @@ export enum DocSubscribeMessageCmd {
     DocSubscribe = "doc_subscribe",
 }
 
+export interface HasElement {
+    id:  string;
+    rev: number;
+    [property: string]: any;
+}
+
 export interface DocSubscribeResult {
+    as_of_seq: number;
     delivery:  number;
-    documents: Document[];
+    order:     string[];
+    upsert:    Document[];
     [property: string]: any;
 }
 
@@ -1626,6 +1637,12 @@ export interface DocumentQuery {
     limit?:     number;
     namespace:  string;
     sort?:      Sort;
+    [property: string]: any;
+}
+
+export interface DocumentRevision {
+    id:  string;
+    rev: number;
     [property: string]: any;
 }
 
@@ -4373,8 +4390,10 @@ export interface DocQueryResultObject {
 }
 
 export interface DocSubscribeResultObject {
+    as_of_seq: number;
     delivery:  number;
-    documents: Document[];
+    order:     string[];
+    upsert:    Document[];
     [property: string]: any;
 }
 
@@ -5300,6 +5319,16 @@ export interface TasksChangedMessage {
 
 export enum TasksChangedMessageEvent {
     TasksChanged = "tasks_changed",
+}
+
+export interface TerminalPointerActivityMessage {
+    cmd: TerminalPointerActivityMessageCmd;
+    id:  string;
+    [property: string]: any;
+}
+
+export enum TerminalPointerActivityMessageCmd {
+    TerminalPointerActivity = "terminal_pointer_activity",
 }
 
 export interface Ticket {
@@ -7170,6 +7199,14 @@ export class Convert {
 
     public static documentQueryToJson(value: DocumentQuery): string {
         return JSON.stringify(uncast(value, r("DocumentQuery")), null, 2);
+    }
+
+    public static toDocumentRevision(json: string): DocumentRevision {
+        return cast(JSON.parse(json), r("DocumentRevision"));
+    }
+
+    public static documentRevisionToJson(value: DocumentRevision): string {
+        return JSON.stringify(uncast(value, r("DocumentRevision")), null, 2);
     }
 
     public static toDocumentSort(json: string): DocumentSort {
@@ -9140,6 +9177,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("TasksChangedMessage")), null, 2);
     }
 
+    public static toTerminalPointerActivityMessage(json: string): TerminalPointerActivityMessage {
+        return cast(JSON.parse(json), r("TerminalPointerActivityMessage"));
+    }
+
+    public static terminalPointerActivityMessageToJson(value: TerminalPointerActivityMessage): string {
+        return JSON.stringify(uncast(value, r("TerminalPointerActivityMessage")), null, 2);
+    }
+
     public static toTicket(json: string): Ticket {
         return cast(JSON.parse(json), r("Ticket"));
     }
@@ -10800,11 +10845,18 @@ const typeMap: any = {
     ], "any"),
     "DocSubscribeMessage": o([
         { json: "cmd", js: "cmd", typ: r("DocSubscribeMessageCmd") },
+        { json: "have", js: "have", typ: u(undefined, a(r("HasElement"))) },
         { json: "query", js: "query", typ: r("Query") },
     ], "any"),
+    "HasElement": o([
+        { json: "id", js: "id", typ: "" },
+        { json: "rev", js: "rev", typ: 0 },
+    ], "any"),
     "DocSubscribeResult": o([
+        { json: "as_of_seq", js: "as_of_seq", typ: 0 },
         { json: "delivery", js: "delivery", typ: 0 },
-        { json: "documents", js: "documents", typ: a(r("Document")) },
+        { json: "order", js: "order", typ: a("") },
+        { json: "upsert", js: "upsert", typ: a(r("Document")) },
     ], "any"),
     "DocumentCollectionSchema": o([
         { json: "collection", js: "collection", typ: "" },
@@ -10835,6 +10887,10 @@ const typeMap: any = {
         { json: "limit", js: "limit", typ: u(undefined, 0) },
         { json: "namespace", js: "namespace", typ: "" },
         { json: "sort", js: "sort", typ: u(undefined, r("Sort")) },
+    ], "any"),
+    "DocumentRevision": o([
+        { json: "id", js: "id", typ: "" },
+        { json: "rev", js: "rev", typ: 0 },
     ], "any"),
     "DocumentSort": o([
         { json: "desc", js: "desc", typ: u(undefined, true) },
@@ -12471,8 +12527,10 @@ const typeMap: any = {
         { json: "documents", js: "documents", typ: a(r("Document")) },
     ], "any"),
     "DocSubscribeResultObject": o([
+        { json: "as_of_seq", js: "as_of_seq", typ: 0 },
         { json: "delivery", js: "delivery", typ: 0 },
-        { json: "documents", js: "documents", typ: a(r("Document")) },
+        { json: "order", js: "order", typ: a("") },
+        { json: "upsert", js: "upsert", typ: a(r("Document")) },
     ], "any"),
     "DocUndefineResultObject": o([
         { json: "collection", js: "collection", typ: "" },
@@ -13041,6 +13099,10 @@ const typeMap: any = {
     ], "any"),
     "TasksChangedMessage": o([
         { json: "event", js: "event", typ: r("TasksChangedMessageEvent") },
+    ], "any"),
+    "TerminalPointerActivityMessage": o([
+        { json: "cmd", js: "cmd", typ: r("TerminalPointerActivityMessageCmd") },
+        { json: "id", js: "id", typ: "" },
     ], "any"),
     "Ticket": o([
         { json: "activity", js: "activity", typ: a(r("ActivityElement")) },
@@ -14563,6 +14625,9 @@ const typeMap: any = {
     ],
     "TasksChangedMessageEvent": [
         "tasks_changed",
+    ],
+    "TerminalPointerActivityMessageCmd": [
+        "terminal_pointer_activity",
     ],
     "TicketActionResultMessageEvent": [
         "ticket_action_result",

--- a/changelog.d/background-work-timestamps-that-sort.yaml
+++ b/changelog.d/background-work-timestamps-that-sort.yaml
@@ -1,0 +1,13 @@
+kind: fixed
+area: daemon
+change: >
+  Background work due on a whole second now starts on that second instead of up
+  to a second late, and background jobs and notifications written moments apart
+  are listed in the order they happened.
+symptom: >
+  Timestamps for background work were stored in a form whose text order was not
+  time order within a single second, and the daemon compares them as text. A job
+  scheduled on an exact second was passed over until the next second came round,
+  and jobs or notifications recorded inside the same second came back in an
+  arbitrary order in the background-work panel and the notifications list.
+  Existing records are rewritten on first launch.

--- a/changelog.d/docstore-windowed-subscriptions.yaml
+++ b/changelog.d/docstore-windowed-subscriptions.yaml
@@ -1,0 +1,13 @@
+kind: added
+area: daemon
+change: >
+  A live document query now sends only what changed. Every delivery carries the
+  window's order, the log position it was true at, and bodies for the documents
+  the subscriber does not already hold — so a busy collection stops re-sending
+  the same unchanged rows on every write. A subscriber can also resume by
+  content: it declares the revisions it kept, and the first delivery diffs
+  against them, which makes reconnecting after a daemon restart cost the
+  documents that actually moved rather than the whole window. `attn doc watch`
+  prints each applied window, takes `--resume` to reconnect that way, and exits
+  non-zero when the daemon ends the subscription, naming whether the collection
+  was removed or redeclared underneath it.

--- a/changelog.d/turn-timestamps-that-sort.yaml
+++ b/changelog.d/turn-timestamps-that-sort.yaml
@@ -1,0 +1,15 @@
+kind: fixed
+area: daemon
+change: >
+  An agent that finishes a turn in the same second the turn began no longer goes
+  quiet: it comes back to the queue the next time it wants you. Delegations,
+  workspaces and workspace panes created moments apart are also listed in the
+  order they were created.
+symptom: >
+  attn recorded these timestamps in a form whose text order was not time order
+  within a single second, and it compares them as text. The turn a session owes
+  you is decided by comparing when it opened against when you settled it, so a
+  turn settled inside the second it opened in still read as open — and no new
+  turn opened, with nothing said about it. Waking from a "until tomorrow" or
+  "until Monday" snooze was the way in, because those wake on an exact second.
+  Existing records are rewritten on first launch.

--- a/cmd/attn/doc.go
+++ b/cmd/attn/doc.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/victorarias/attn/internal/client"
 	"github.com/victorarias/attn/internal/config"
@@ -111,9 +112,21 @@ commands:
         --limit are ignored: they decide which matches come back, never how
         many there are.
 
-  watch <namespace> <collection> [query flags] [--json]
-        run a live query: print the current results, then print them again every
-        time a write changes them. Runs until interrupted.
+  watch <namespace> <collection> [query flags] [--json] [--resume]
+        run a live query: print the current window, then print it again every
+        time a write changes it. Runs until interrupted, and exits non-zero if
+        the subscription ends — a watch that has stopped watching must not look
+        like a watch that finished.
+
+        What is printed is the whole window; what travels is the order plus only
+        the bodies this watcher does not already hold, which --json reports as
+        "changed". A live query takes no --after: it is a window, not a walk.
+
+        --resume resubscribes when the connection goes — a daemon restart, for
+        instance — waiting for the daemon to come back and declaring what it
+        holds, so only what changed while it was away comes back. A collection
+        that is removed or redeclared without a field the query uses ends the
+        watch either way, and so does a daemon that was never there.
 
 query flags:
   --where <expr>    repeatable. field=value, or field<value, field<=value,
@@ -329,23 +342,23 @@ func runDocDelete(args []string) {
 
 func runDocQuery(args []string) {
 	namespace, collection, rest := docTarget("query", args)
-	query, asJSON := parseDocQueryFlags("query", namespace, collection, rest)
+	query, opts := parseDocQueryFlags("query", namespace, collection, rest)
 	result, err := docClient().DocQuery(query)
 	if err != nil {
 		docFail("query", err)
 	}
-	printDocuments(result.Documents, asJSON)
-	printPosition(asJSON, result.AsOfSeq)
+	printDocuments(result.Documents, opts.asJSON)
+	printPosition(opts.asJSON, result.AsOfSeq)
 }
 
 func runDocCount(args []string) {
 	namespace, collection, rest := docTarget("count", args)
-	query, asJSON := parseDocQueryFlags("count", namespace, collection, rest)
+	query, opts := parseDocQueryFlags("count", namespace, collection, rest)
 	result, err := docClient().DocCount(query)
 	if err != nil {
 		docFail("count", err)
 	}
-	if asJSON {
+	if opts.asJSON {
 		writeJSON(struct {
 			Count   int `json:"count"`
 			AsOfSeq int `json:"as_of_seq"`
@@ -355,30 +368,81 @@ func runDocCount(args []string) {
 	fmt.Println(result.Count)
 }
 
+// runDocWatch prints applied windows: what the query holds right now, printed
+// again whenever a write changes it. What travels is smaller than what is
+// printed — a delivery carries ids plus only the bodies this watcher does not
+// already hold — and `changed` is that receipt.
+//
+// It never exits 0 while it has stopped watching. A live query that ends has
+// stopped reporting changes, and a watcher that returns success there leaves
+// whoever ran it looking at a list frozen at the moment the subscription broke.
+// --resume is the way to survive a daemon restart: it resubscribes carrying the
+// revisions it holds, so the daemon sends back only what changed while it was
+// away. A collection that was removed or redeclared out from under the query
+// ends the watch anyway, because resubscribing would fail the same way.
 func runDocWatch(args []string) {
 	namespace, collection, rest := docTarget("watch", args)
-	query, asJSON := parseDocQueryFlags("watch", namespace, collection, rest)
-	err := docClient().DocSubscribe(query, func(result *protocol.DocSubscribeResult) bool {
-		if asJSON {
-			writeJSON(struct {
-				Delivery  int            `json:"delivery"`
-				Documents []jsonDocument `json:"documents"`
-			}{result.Delivery, docsForJSON(result.Documents)})
-		} else {
-			fmt.Printf("--- delivery %d (%d document(s)) ---\n", result.Delivery, len(result.Documents))
-			printDocuments(result.Documents, false)
+	query, opts := parseDocQueryFlags("watch", namespace, collection, rest)
+
+	var held []protocol.StoredDocument
+	watching := false
+	for {
+		err := docClient().DocSubscribe(query, held, func(window client.DocWindow) bool {
+			watching = true
+			held = window.Documents
+			printDocWindow(window, opts.asJSON)
+			return true
+		})
+		_, ended := client.DocSubscriptionCode(err)
+		switch {
+		case opts.resume && client.DocConnectionLost(err):
+			// The connection went, not the collection. Everything held stays
+			// held, and the resubscribe declares it. Only this ending retries:
+			// every other one recurs on the next attempt, and a watch that
+			// resubscribed through one would spin reporting nothing.
+		case opts.resume && watching && !ended:
+			// The daemon is not answering the door yet. Restarting one takes
+			// long enough that a watch which gave up here would not survive the
+			// thing --resume exists for; a watch that has never connected still
+			// fails immediately, because that is a wrong socket, not an outage.
+			time.Sleep(daemonReconnectInterval)
+		default:
+			docFail("watch", err)
 		}
-		return true
-	})
-	if err != nil {
-		docFail("watch", err)
 	}
 }
 
-// parseDocQueryFlags reads the query flags shared by query and watch.
-func parseDocQueryFlags(verb, namespace, collection string, args []string) (protocol.DocumentQuery, bool) {
+// daemonReconnectInterval is how often a resuming watch retries a daemon that
+// is not accepting connections. Measured: a stop plus ensure returns the socket
+// in 0.49s, so this polls twice inside the outage it exists for, and costs one
+// connect attempt per tick when the daemon is simply gone.
+const daemonReconnectInterval = 200 * time.Millisecond
+
+func printDocWindow(window client.DocWindow, asJSON bool) {
+	if asJSON {
+		writeJSON(struct {
+			Delivery  int            `json:"delivery"`
+			AsOfSeq   int64          `json:"as_of_seq"`
+			Documents []jsonDocument `json:"documents"`
+			Changed   []string       `json:"changed"`
+		}{window.Delivery, window.AsOfSeq, docsForJSON(window.Documents), window.Changed})
+		return
+	}
+	fmt.Printf("--- delivery %d (%d document(s), %d body(s) sent, as of seq %d) ---\n",
+		window.Delivery, len(window.Documents), len(window.Changed), window.AsOfSeq)
+	printDocuments(window.Documents, false)
+}
+
+// docQueryOptions are the flags that shape the output rather than the query.
+type docQueryOptions struct {
+	asJSON bool
+	resume bool
+}
+
+// parseDocQueryFlags reads the query flags shared by query, count and watch.
+func parseDocQueryFlags(verb, namespace, collection string, args []string) (protocol.DocumentQuery, docQueryOptions) {
 	query := protocol.DocumentQuery{Namespace: namespace, Collection: collection}
-	asJSON := false
+	var opts docQueryOptions
 	for i := 0; i < len(args); i++ {
 		next := func() string {
 			if i+1 >= len(args) {
@@ -389,7 +453,12 @@ func parseDocQueryFlags(verb, namespace, collection string, args []string) (prot
 		}
 		switch args[i] {
 		case "--json":
-			asJSON = true
+			opts.asJSON = true
+		case "--resume":
+			if verb != "watch" {
+				docFail(verb, fmt.Errorf("--resume is only for watch; a one-shot read has nothing to resume"))
+			}
+			opts.resume = true
 		case "--desc":
 			desc := true
 			if query.Sort == nil {
@@ -425,7 +494,7 @@ func parseDocQueryFlags(verb, namespace, collection string, args []string) (prot
 	if query.Sort != nil && query.Sort.Field == "" {
 		docFail(verb, fmt.Errorf("--desc needs --sort <field>"))
 	}
-	return query, asJSON
+	return query, opts
 }
 
 // docWhereOps are matched longest-first so ">=" is not read as ">".

--- a/cmd/attn/doc_test.go
+++ b/cmd/attn/doc_test.go
@@ -61,14 +61,14 @@ func TestWhereRejectsAnExpressionWithNoOperator(t *testing.T) {
 // the advance still carries to the next iteration — otherwise a flag's value
 // would be parsed again as if it were a flag.
 func TestQueryFlagsConsumeTheirValues(t *testing.T) {
-	query, asJSON := parseDocQueryFlags("query", "ext/approval-gate", "requests", []string{
+	query, opts := parseDocQueryFlags("query", "ext/approval-gate", "requests", []string{
 		"--where", "status=pending",
 		"--sort", "created_at",
 		"--desc",
 		"--limit", "7",
 		"--json",
 	})
-	if !asJSON {
+	if !opts.asJSON {
 		t.Fatal("--json not seen")
 	}
 	if query.Namespace != "ext/approval-gate" || query.Collection != "requests" {
@@ -82,6 +82,15 @@ func TestQueryFlagsConsumeTheirValues(t *testing.T) {
 	}
 	if query.Limit == nil || *query.Limit != 7 {
 		t.Fatalf("limit = %v", query.Limit)
+	}
+}
+
+// --resume is a watch flag. A one-shot read that accepted it would silently
+// ignore it, and the caller would believe it had asked for something.
+func TestResumeBelongsToWatch(t *testing.T) {
+	_, opts := parseDocQueryFlags("watch", "ext/a", "c", []string{"--resume"})
+	if !opts.resume {
+		t.Fatal("--resume not seen on watch")
 	}
 }
 

--- a/docs/plans/2026-08-04-ext-a3.3-doc-store-review-findings.md
+++ b/docs/plans/2026-08-04-ext-a3.3-doc-store-review-findings.md
@@ -67,10 +67,24 @@ reporting the count. Pinned by `internal/docstore/timestamps_test.go` and
 `internal/store/documents_timestamps_test.go`, both falsified against the three
 halves of the fix separately.
 
-`internal/store/jobs.go:19` uses the same format with the same text comparisons
-(`scheduled_at <=` at :173, retention `updated_at <` at :210). The consequence
-there is much milder: a job scheduled on a whole second is not claimed until the
-next second. A scheduling wobble, not data loss. Decide separately.
+`internal/store/jobs.go` used the same format with the same text comparisons
+(`scheduled_at <=`, retention `updated_at <`, and both feeds' `ORDER BY` on a
+stamp), and so did the notifications feed beside it, which had been written to
+match the jobs table deliberately. The consequence there was much milder: a job
+scheduled on a whole second was not claimed until the next second, and rows
+written inside one second listed in an arbitrary order. A scheduling wobble, not
+data loss.
+
+Fixed 2026-08-06. Both surfaces now store `sortableTimeFormat`, which *is*
+`docstore.TimeFormat` — the same defect and the same fix, so there is one
+spelling of the encoding in the tree rather than two that have to be kept in
+step — and `parseStoreTime` decodes any RFC3339 spelling, so a stamp written by
+an older store still reads. Migration 93 rewrites the stored job and
+notification stamps with the same `restampTable` helper migration 91 used, which
+now also skips a blank rather than counting it unreadable: an unread
+notification's `read_at` is `''` by design. Pinned by
+`internal/store/jobs_timestamps_test.go`, whose five behavioural tests all go red
+when the format constant alone is reverted.
 
 ### Why the test suite did not catch it
 

--- a/internal/client/documents.go
+++ b/internal/client/documents.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 
@@ -94,41 +95,173 @@ func (c *Client) DocCount(query protocol.DocumentQuery) (*protocol.DocCountResul
 	return resp.DocCountResult, nil
 }
 
-// DocSubscribe opens a live query and calls onResult for every delivery,
-// beginning with the current result set. Unlike every other call here it holds
-// its connection open, so it returns only when onResult asks it to stop, the
-// daemon closes the connection, or a delivery cannot be read.
+// DocWindow is one delivery of a live query, already applied. The daemon sends
+// an order plus the bodies the subscriber is missing; this is the result of
+// following the client rule, so a caller renders Documents and holds no
+// delivery-merging logic of its own. That rule lives here once, because the CLI,
+// the tests and A4's SDK are all callers of this seam.
 //
-// Each delivery is the whole current result set; a caller renders what it is
-// handed and never accumulates state across deliveries.
-func (c *Client) DocSubscribe(query protocol.DocumentQuery, onResult func(*protocol.DocSubscribeResult) bool) error {
+// AsOfSeq is the log position the window was true at — comparable against the
+// seq a write reported, which is how a caller knows a delivery already includes
+// its own write. Changed names the ids whose bodies arrived in this delivery,
+// so a caller can see what actually travelled rather than infer it.
+type DocWindow struct {
+	Delivery  int
+	AsOfSeq   int64
+	Documents []protocol.StoredDocument
+	Changed   []string
+}
+
+// revisions is what this window declares to a resuming subscription. The wire
+// carries revisions alone, but DocSubscribe takes whole documents: a subscriber
+// that declares a revision without holding its body has told the daemon not to
+// send something it cannot render, and no caller should be able to express that
+// by accident.
+func revisions(held []protocol.StoredDocument) []protocol.DocumentRevision {
+	out := make([]protocol.DocumentRevision, 0, len(held))
+	for _, doc := range held {
+		out = append(out, protocol.DocumentRevision{ID: doc.ID, Rev: doc.Rev})
+	}
+	return out
+}
+
+// DocSubscriptionEnded is a live query the daemon stopped serving. Code is the
+// protocol error code when the daemon named one — `collection_undefined` and
+// `collection_redeclared` are the two that mean the collection moved out from
+// under an accepted subscription — and is empty when the connection simply went
+// away. It is a type rather than a message because a UI host has to tell "kill
+// this tile" from "reconnect", and must not do it by matching English.
+type DocSubscriptionEnded struct {
+	Code    string
+	Message string
+
+	// lost distinguishes the one ending that is safe to retry — the connection
+	// went — from every other one. It is not the same fact as an empty Code: a
+	// delivery this client cannot apply also carries no daemon code, and
+	// resubscribing after one repeats it with the same declared revisions,
+	// forever. Set here rather than exported so no caller can claim it.
+	lost bool
+}
+
+func (e *DocSubscriptionEnded) Error() string {
+	if e.Code == "" {
+		return "document subscription ended: " + e.Message
+	}
+	return "document subscription ended (" + e.Code + "): " + e.Message
+}
+
+// DocSubscriptionCode returns the protocol error code a subscription ended with,
+// and whether the error was a subscription ending at all.
+func DocSubscriptionCode(err error) (string, bool) {
+	var ended *DocSubscriptionEnded
+	if errors.As(err, &ended) {
+		return ended.Code, true
+	}
+	return "", false
+}
+
+// DocConnectionLost reports whether a subscription ended because the connection
+// went. That is the only ending worth resubscribing to: a daemon that refused
+// the query and a delivery this client could not apply both recur on the next
+// attempt, so retrying either is a loop that reports nothing.
+func DocConnectionLost(err error) bool {
+	var ended *DocSubscriptionEnded
+	return errors.As(err, &ended) && ended.lost
+}
+
+// DocSubscribe opens a live query and calls onWindow for every delivery,
+// beginning with the query's current window. Unlike every other call here it
+// holds its connection open, so it returns only when onWindow asks it to stop,
+// or when the subscription ends.
+//
+// held is what the caller already holds — nil for a fresh subscribe, and a
+// previous window's Documents to resume one. The daemon is told their revisions
+// and sends bodies only for what has changed since; everything else is carried
+// by order and taken from the cache seeded here.
+//
+// Ending is always an error, including the plain end-of-connection case. A live
+// query that stops is a caller who has stopped seeing changes, and returning
+// success there is how a watcher exits 0 while showing a frozen list.
+func (c *Client) DocSubscribe(query protocol.DocumentQuery, held []protocol.StoredDocument, onWindow func(DocWindow) bool) error {
 	conn, err := net.Dial("unix", c.socketPath)
 	if err != nil {
 		return explainConnectError(c.socketPath, err)
 	}
 	defer conn.Close()
 
-	msg := protocol.DocSubscribeMessage{Cmd: protocol.CmdDocSubscribe, Query: query}
+	msg := protocol.DocSubscribeMessage{Cmd: protocol.CmdDocSubscribe, Query: query, Have: revisions(held)}
 	if err := json.NewEncoder(conn).Encode(msg); err != nil {
 		return fmt.Errorf("send subscribe: %w", err)
 	}
 
+	// The cache the client rule reads from, seeded with what the caller declared.
+	// An id the daemon believes is held and that is not here is a broken
+	// subscription, reported rather than rendered with a hole in it.
+	cache := make(map[string]protocol.StoredDocument, len(held))
+	for _, doc := range held {
+		cache[doc.ID] = doc
+	}
 	decoder := json.NewDecoder(conn)
 	for {
 		var resp protocol.Response
 		if err := decoder.Decode(&resp); err != nil {
-			// The daemon closing the connection ends the subscription; it is not
-			// the caller's error to report.
-			return nil
+			return &DocSubscriptionEnded{Message: "the daemon closed the connection", lost: true}
 		}
 		if !resp.Ok {
-			return fmt.Errorf("daemon error: %s", protocol.Deref(resp.Error))
+			return &DocSubscriptionEnded{
+				Code:    protocol.Deref(resp.ErrorCode),
+				Message: protocol.Deref(resp.Error),
+			}
 		}
 		if resp.DocSubscribeResult == nil {
 			continue
 		}
-		if !onResult(resp.DocSubscribeResult) {
+		window, err := applyDocDelivery(cache, resp.DocSubscribeResult)
+		if err != nil {
+			return err
+		}
+		if !onWindow(window) {
 			return nil
 		}
 	}
+}
+
+// applyDocDelivery is the client rule: render order, take each body from upsert
+// if it is there and from the cache otherwise, forget everything not in order.
+// The cache is replaced rather than added to, which is what keeps a long-lived
+// subscription's memory bounded by the window rather than by its history.
+func applyDocDelivery(cache map[string]protocol.StoredDocument, result *protocol.DocSubscribeResult) (DocWindow, error) {
+	window := DocWindow{
+		Delivery:  result.Delivery,
+		AsOfSeq:   int64(result.AsOfSeq),
+		Documents: make([]protocol.StoredDocument, 0, len(result.Order)),
+		Changed:   make([]string, 0, len(result.Upsert)),
+	}
+	arrived := make(map[string]protocol.StoredDocument, len(result.Upsert))
+	for _, doc := range result.Upsert {
+		arrived[doc.ID] = doc
+		window.Changed = append(window.Changed, doc.ID)
+	}
+	next := make(map[string]protocol.StoredDocument, len(result.Order))
+	for _, id := range result.Order {
+		doc, ok := arrived[id]
+		if !ok {
+			doc, ok = cache[id]
+		}
+		if !ok {
+			// The daemon believes this subscriber holds a body it does not. The
+			// subscription cannot be applied, and continuing would render a
+			// window with a hole in it.
+			return DocWindow{}, &DocSubscriptionEnded{Message: fmt.Sprintf(
+				"delivery %d ordered %q without sending its body, and it is not held; resubscribe without a resume token",
+				result.Delivery, id)}
+		}
+		next[id] = doc
+		window.Documents = append(window.Documents, doc)
+	}
+	clear(cache)
+	for id, doc := range next {
+		cache[id] = doc
+	}
+	return window, nil
 }

--- a/internal/client/documents_test.go
+++ b/internal/client/documents_test.go
@@ -1,0 +1,256 @@
+package client
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// Unix socket paths are length-limited (notably on macOS), and the default
+// t.TempDir() path is long enough to blow the limit.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "attn-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}
+
+func doc(id, body string, rev int) protocol.StoredDocument {
+	return protocol.StoredDocument{ID: id, Body: body, Rev: rev}
+}
+
+// docServer is a unix socket that answers one doc_subscribe with the deliveries
+// it is handed and then does whatever the test asked of it. The daemon's own
+// handler is covered in internal/daemon; what is under test here is the client's
+// read loop, so the server side is scripted rather than real.
+func docServer(t *testing.T, serve func(conn net.Conn, subscribe protocol.DocSubscribeMessage)) string {
+	t.Helper()
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { listener.Close() })
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var msg protocol.DocSubscribeMessage
+		if err := json.NewDecoder(conn).Decode(&msg); err != nil {
+			return
+		}
+		serve(conn, msg)
+	}()
+	return sockPath
+}
+
+func sendDelivery(t *testing.T, conn net.Conn, result protocol.DocSubscribeResult) {
+	t.Helper()
+	if err := json.NewEncoder(conn).Encode(protocol.Response{Ok: true, DocSubscribeResult: &result}); err != nil {
+		t.Errorf("send delivery: %v", err)
+	}
+}
+
+// A live query that ends because the connection went reports it as an error too.
+// Nothing distinguishes "the daemon stopped" from "nothing has changed lately"
+// except this, and a watcher that cannot tell them apart shows a frozen list
+// forever.
+func TestASubscriptionEndingWithoutAnErrorIsStillAnError(t *testing.T) {
+	sockPath := docServer(t, func(conn net.Conn, _ protocol.DocSubscribeMessage) {
+		sendDelivery(t, conn, protocol.DocSubscribeResult{
+			Delivery: 1, AsOfSeq: 7, Order: []string{"a"},
+			Upsert: []protocol.StoredDocument{doc("a", `{}`, 1)},
+		})
+		// and then simply goes away, the way a daemon that was restarted does.
+	})
+
+	var seen int
+	err := New(sockPath).DocSubscribe(protocol.DocumentQuery{}, nil, func(DocWindow) bool {
+		seen++
+		return true
+	})
+	if seen != 1 {
+		t.Fatalf("the subscriber saw %d windows, want the one that was sent", seen)
+	}
+	code, ended := DocSubscriptionCode(err)
+	if !ended {
+		t.Fatalf("a daemon that went away reported %v", err)
+	}
+	if code != "" {
+		t.Fatalf("a lost connection carried code %q, and there is nothing for a caller to branch on", code)
+	}
+	if !DocConnectionLost(err) {
+		t.Fatal("a lost connection is the one ending worth resubscribing to, and it did not say so")
+	}
+}
+
+// The three endings that are NOT worth retrying, kept together because what
+// separates them from a lost connection is one bit that is easy to conflate
+// with an empty code. A resuming watcher that retried any of them would spin:
+// the daemon refuses the same query again, and an unapplicable delivery repeats
+// with the same declared revisions.
+func TestOnlyALostConnectionIsWorthResubscribing(t *testing.T) {
+	unapplicable := docServer(t, func(conn net.Conn, _ protocol.DocSubscribeMessage) {
+		// Orders a document whose body it never sent and the client never held.
+		sendDelivery(t, conn, protocol.DocSubscribeResult{Delivery: 1, Order: []string{"ghost"}})
+	})
+	err := New(unapplicable).DocSubscribe(protocol.DocumentQuery{}, nil, func(DocWindow) bool { return true })
+	if _, ended := DocSubscriptionCode(err); !ended {
+		t.Fatalf("an unapplicable delivery reported %v", err)
+	}
+	if DocConnectionLost(err) {
+		t.Fatal("an unapplicable delivery claimed the connection went; resubscribing repeats it forever")
+	}
+
+	coded := docServer(t, func(conn net.Conn, _ protocol.DocSubscribeMessage) {
+		json.NewEncoder(conn).Encode(protocol.Response{
+			Ok:        false,
+			Error:     protocol.Ptr("collection undefined while subscribed"),
+			ErrorCode: protocol.Ptr(protocol.ErrorCodeCollectionUndefined),
+		})
+	})
+	err = New(coded).DocSubscribe(protocol.DocumentQuery{}, nil, func(DocWindow) bool { return true })
+	if DocConnectionLost(err) {
+		t.Fatal("a collection that was removed claimed the connection went")
+	}
+
+	if DocConnectionLost(errString("connection refused")) {
+		t.Fatal("an ordinary error claimed to be a lost subscription")
+	}
+}
+
+// The daemon's coded ending has to survive the read loop as a code, because a UI
+// host branches on it: `collection_undefined` kills the tile, an empty code
+// reconnects.
+func TestACodedEndingKeepsItsCode(t *testing.T) {
+	sockPath := docServer(t, func(conn net.Conn, _ protocol.DocSubscribeMessage) {
+		json.NewEncoder(conn).Encode(protocol.Response{
+			Ok:        false,
+			Error:     protocol.Ptr("collection undefined while subscribed"),
+			ErrorCode: protocol.Ptr(protocol.ErrorCodeCollectionUndefined),
+		})
+	})
+
+	err := New(sockPath).DocSubscribe(protocol.DocumentQuery{}, nil, func(DocWindow) bool { return true })
+	code, ended := DocSubscriptionCode(err)
+	if !ended || code != protocol.ErrorCodeCollectionUndefined {
+		t.Fatalf("ended=%v code=%q, want the daemon's %q", ended, code, protocol.ErrorCodeCollectionUndefined)
+	}
+	if got := err.Error(); got == "" {
+		t.Fatalf("the ending carried no message")
+	}
+}
+
+// Resuming declares revisions, not bodies. The wire carries the pairs; the
+// caller hands over whole documents so that everything it declared is also
+// something it can render.
+func TestResumingDeclaresTheRevisionsOfWhatIsHeld(t *testing.T) {
+	declared := make(chan []protocol.DocumentRevision, 1)
+	sockPath := docServer(t, func(conn net.Conn, msg protocol.DocSubscribeMessage) {
+		declared <- msg.Have
+		sendDelivery(t, conn, protocol.DocSubscribeResult{Delivery: 1, Order: []string{"a"}})
+	})
+
+	held := []protocol.StoredDocument{doc("a", `{"n":1}`, 4)}
+	window := make(chan DocWindow, 1)
+	err := New(sockPath).DocSubscribe(protocol.DocumentQuery{}, held, func(w DocWindow) bool {
+		window <- w
+		return false
+	})
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	have := <-declared
+	if len(have) != 1 || have[0].ID != "a" || have[0].Rev != 4 {
+		t.Fatalf("declared %+v, want a@4", have)
+	}
+	// And the body it never re-sent came out of the cache the caller seeded.
+	got := <-window
+	if len(got.Documents) != 1 || got.Documents[0].Body != `{"n":1}` {
+		t.Fatalf("resumed window is %+v, want the held body", got.Documents)
+	}
+	if len(got.Changed) != 0 {
+		t.Fatalf("the resumed window reported %v as changed, and nothing did", got.Changed)
+	}
+}
+
+func TestApplyingADeliveryFollowsTheClientRule(t *testing.T) {
+	cache := map[string]protocol.StoredDocument{
+		"a": doc("a", `{"v":"old"}`, 1),
+		"b": doc("b", `{"v":"kept"}`, 1),
+		"c": doc("c", `{"v":"gone"}`, 1),
+	}
+	window, err := applyDocDelivery(cache, &protocol.DocSubscribeResult{
+		Delivery: 3,
+		AsOfSeq:  42,
+		Order:    []string{"b", "a"},
+		Upsert:   []protocol.StoredDocument{doc("a", `{"v":"new"}`, 2)},
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if window.Delivery != 3 || window.AsOfSeq != 42 {
+		t.Fatalf("window is delivery %d as of %d", window.Delivery, window.AsOfSeq)
+	}
+	// Order decides the order, an upsert overrides the cache, and the cached
+	// body is used untouched for what did not travel.
+	if len(window.Documents) != 2 ||
+		window.Documents[0].Body != `{"v":"kept"}` ||
+		window.Documents[1].Body != `{"v":"new"}` {
+		t.Fatalf("applied %+v", window.Documents)
+	}
+	if len(window.Changed) != 1 || window.Changed[0] != "a" {
+		t.Fatalf("changed is %v, want only the body that travelled", window.Changed)
+	}
+	// Forget everything not named in order: the cache is the window, not a
+	// history, which is what bounds a long-lived subscription's memory.
+	if _, still := cache["c"]; still {
+		t.Fatalf("a document that left the window is still cached")
+	}
+	if len(cache) != 2 {
+		t.Fatalf("cache holds %d documents after a 2-document window", len(cache))
+	}
+}
+
+// The one case a subscriber cannot render: the daemon believes it holds a body
+// it does not. Reporting it beats drawing a window with a hole in it, and the
+// message says how to recover.
+func TestADeliveryOrderingAnUnheldDocumentEndsTheSubscription(t *testing.T) {
+	_, err := applyDocDelivery(map[string]protocol.StoredDocument{}, &protocol.DocSubscribeResult{
+		Delivery: 1,
+		Order:    []string{"ghost"},
+	})
+	code, ended := DocSubscriptionCode(err)
+	if !ended {
+		t.Fatalf("apply returned %v, want a subscription ending", err)
+	}
+	if code != "" {
+		t.Fatalf("a client-side failure carried daemon code %q", code)
+	}
+	if !strings.Contains(err.Error(), "ghost") || !strings.Contains(err.Error(), "resubscribe") {
+		t.Fatalf("the ending does not say what is missing or what to do: %v", err)
+	}
+}
+
+func TestDocSubscriptionCodeIgnoresOtherErrors(t *testing.T) {
+	if _, ended := DocSubscriptionCode(nil); ended {
+		t.Fatalf("nil is a subscription ending")
+	}
+	if _, ended := DocSubscriptionCode(errString("connection refused")); ended {
+		t.Fatalf("an ordinary error is a subscription ending")
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/internal/daemon/bus.go
+++ b/internal/daemon/bus.go
@@ -235,6 +235,14 @@ const (
 	// and saying so with an empty document id would leave every future consumer
 	// special-casing an address that points at nothing.
 	FactDocumentCollectionRemoved = "document.collection.removed"
+	// FactDocumentCollectionRedeclared: a collection's declaration was rewritten
+	// in place. Subject is the collection, like a removal, and for the same
+	// reason: the entity that moved is the declaration, not any document. Its
+	// consumer is the live-query fan-out — a redeclare that drops a queried
+	// field must end the subscriptions using it at redeclare time, not at the
+	// next arbitrary write. Like the other document facts it has no entry in
+	// wireProjections.
+	FactDocumentCollectionRedeclared = "document.collection.redeclared"
 )
 
 // CompactableFacts are the fact classes the retention pass may reduce to one
@@ -242,7 +250,7 @@ const (
 // invalidations about a subject whose state lives in the store, so only the
 // newest carries information. Session and ticket facts are deliberately absent
 // — they keep the age window's behavior unchanged.
-var CompactableFacts = []string{FactDocumentChanged, FactDocumentCollectionRemoved}
+var CompactableFacts = []string{FactDocumentChanged, FactDocumentCollectionRemoved, FactDocumentCollectionRedeclared}
 
 // projection maps facts to the wire traffic they produce.
 type projection struct {

--- a/internal/daemon/documents.go
+++ b/internal/daemon/documents.go
@@ -18,16 +18,25 @@ import (
 // The document store's daemon half: the fact a write publishes, the live queries
 // that fact wakes, and the IPC surface `attn doc` speaks.
 //
-// WHY A SUBSCRIPTION RE-RUNS RATHER THAN PATCHES. Every delivery is the query's
-// current full result set. A patch stream would be smaller and it is where live
-// query systems grow their bugs: a document falling out of a `limit 20` window
-// forces a re-query to find the 21st anyway, so a patch path needs the re-run
-// path underneath it and only some of the time. Re-running always is one path.
+// WHY A SUBSCRIPTION RE-RUNS RATHER THAN PATCHES. Every delivery re-runs the
+// whole query. A patch stream would avoid the re-run and it is where live query
+// systems grow their bugs: a document falling out of a `limit 20` window forces
+// a re-query to find the 21st anyway, so a patch path needs the re-run path
+// underneath it and only some of the time. Re-running always is one path.
 //
-// That also makes a delivery safe to drop. Because each one supersedes the last,
-// a subscriber that has not drained loses nothing when a newer result set
-// replaces a queued one — which is how the one-slot wake channel below collapses
-// a burst of writes into a single delivery with no coalescing window to manage.
+// What a delivery carries is a different question from how it is computed. The
+// re-run answers "which documents, in what order"; the bodies are then diffed
+// against what this subscriber is known to hold, so a window of a hundred
+// documents whose first one changed is one body and a hundred ids. That diff is
+// pure bookkeeping over one map — no second notion of what changed, and nothing
+// a patch stream's ordering hazards can reach.
+//
+// A delivery is still safe to drop, which is what the one-slot wake channel
+// below relies on: each delivery is computed from current state at the moment it
+// is sent, so a subscriber that has not drained loses nothing when a burst of
+// writes collapses into one delivery. What it must NOT lose is the record of
+// what it holds — that lives beside the connection, advances only when a
+// delivery is actually encoded, and is what makes dropping the rest correct.
 //
 // WHY THE BUS FAN-OUT DOES NOT WRITE THE SOCKET. The bus holds its publish lock
 // across the inline fan-out, so anything slow inside a handler stalls every
@@ -208,24 +217,6 @@ func (d *Daemon) documentSubscriptionCount() int {
 	return len(d.docSubs)
 }
 
-// compileDocQuery resolves the query's after cursor and compiles it. The cursor
-// is a document id, so the anchor has to be read here: docstore holds no
-// database handle, and it needs the anchor's sort value to compare against the
-// whole ordering tuple.
-func (d *Daemon) compileDocQuery(q docstore.Query, schema docstore.CollectionSchema) (docstore.Compiled, error) {
-	var anchor *docstore.Document
-	if q.After != "" {
-		doc, found, err := d.store.GetDocument(schema, q.After)
-		if err != nil {
-			return docstore.Compiled{}, err
-		}
-		if found {
-			anchor = doc
-		}
-	}
-	return q.Compile(schema, anchor)
-}
-
 // runDocQuery answers a query, returning the store's read — documents, the
 // declaration they were computed against, and the log position they were true
 // at — plus how long it took. The caller decides what a slow one means: once
@@ -351,11 +342,46 @@ func undeclaredCollectionError(namespace, collection string) error {
 //
 // The message text is unchanged and stays the part a human or an agent reads.
 func (d *Daemon) sendDocError(conn net.Conn, err error) {
-	resp := protocol.Response{Ok: false, Error: protocol.Ptr(err.Error())}
-	var conflict *docstore.ConflictError
+	d.sendDocErrorAs(conn, err, docErrorCode(err))
+}
+
+// docErrorCode is the code a docstore error answers a request with.
+func docErrorCode(err error) string {
 	switch {
-	case errors.As(err, &conflict):
-		resp.ErrorCode = protocol.Ptr(protocol.ErrorCodeConflict)
+	case docstore.IsConflict(err):
+		return protocol.ErrorCodeConflict
+	case docstore.IsUndeclaredCollection(err):
+		return protocol.ErrorCodeUndeclaredCollection
+	case docstore.IsInvalidQuery(err):
+		return protocol.ErrorCodeInvalidQuery
+	}
+	return ""
+}
+
+// subscriptionEndCode is the code the SAME errors carry once a subscription has
+// been accepted, where they mean something different. Answering a request,
+// "this collection is not declared" and "this query is wrong" are both things
+// the caller got wrong. Ending an accepted subscription they are things that
+// happened TO it — the collection was removed, or redeclared without a field
+// the query uses — and a UI host has to tell those apart to know whether to
+// kill the tile or rewrite its query.
+func subscriptionEndCode(err error) string {
+	switch {
+	case docstore.IsUndeclaredCollection(err):
+		return protocol.ErrorCodeCollectionUndefined
+	case docstore.IsInvalidQuery(err):
+		return protocol.ErrorCodeCollectionRedeclared
+	}
+	return docErrorCode(err)
+}
+
+func (d *Daemon) sendDocErrorAs(conn net.Conn, err error, code string) {
+	resp := protocol.Response{Ok: false, Error: protocol.Ptr(err.Error())}
+	if code != "" {
+		resp.ErrorCode = protocol.Ptr(code)
+	}
+	var conflict *docstore.ConflictError
+	if errors.As(err, &conflict) {
 		resp.ErrorConflict = &protocol.DocumentConflict{
 			Namespace:  conflict.Namespace,
 			Collection: conflict.Collection,
@@ -364,10 +390,6 @@ func (d *Daemon) sendDocError(conn net.Conn, err error) {
 			Found:      conflict.Found,
 			Actual:     int(conflict.Actual),
 		}
-	case docstore.IsUndeclaredCollection(err):
-		resp.ErrorCode = protocol.Ptr(protocol.ErrorCodeUndeclaredCollection)
-	case docstore.IsInvalidQuery(err):
-		resp.ErrorCode = protocol.Ptr(protocol.ErrorCodeInvalidQuery)
 	}
 	if err := json.NewEncoder(conn).Encode(resp); err != nil {
 		d.logf("docstore: writing error response: %v", err)
@@ -610,32 +632,32 @@ func (d *Daemon) handleDocCount(conn net.Conn, msg *protocol.DocCountMessage) {
 }
 
 // handleDocSubscribe is the only handler that keeps its connection. It writes
-// the current result set immediately — a subscriber must be able to render from
-// one round trip, which is what makes an extension UI's remount cheap — and then
-// a fresh one every time a write to the collection could have changed it. It
-// ends when the caller disconnects, or when the collection stops being able to
-// answer the query at all.
+// the query's current window immediately — a subscriber must be able to render
+// from one round trip, which is what makes an extension UI's remount cheap — and
+// then a fresh one every time a write to the collection could have changed it.
+// It ends when the caller disconnects, or when the collection stops being able
+// to answer the query at all.
+//
+// A delivery is a window, not a result set: the ids in order, plus only the
+// bodies the subscriber does not already hold. What it holds comes from `have`
+// on the way in and from what has been delivered since, tracked below as one
+// {id: rev} map. See DocSubscribeResult on the wire for the client's one rule.
 func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMessage) {
 	q, err := documentQueryFromProtocol(msg.Query)
 	if err != nil {
 		d.sendDocError(conn, err)
 		return
 	}
-	schema, err := d.collectionFor(q.Namespace, q.Collection)
-	if err != nil {
-		d.sendDocError(conn, err)
-		return
-	}
-	// Compile once up front. A query that cannot compile must fail the subscribe
-	// rather than fail on every delivery of a subscription that looked accepted.
-	if _, err := d.compileDocQuery(q, *schema); err != nil {
-		d.sendDocError(conn, err)
+	if q.After != "" {
+		d.sendDocError(conn, docstore.InvalidQuery(fmt.Errorf(
+			"docstore: %s/%s cannot subscribe with the after cursor %q: a live query is a window and a cursor is a walk, so the document the cursor names moves out from under the subscription. Set a limit instead and render each delivery's window; a delivery already carries only what changed.",
+			q.Namespace, q.Collection, q.After)))
 		return
 	}
 
 	// Registered before the first query runs. The other order drops a write that
-	// lands in between; this order can only cause one redundant delivery, and a
-	// delivery is the whole result set, so a redundant one costs nothing.
+	// lands in between; this order can only cause one redundant delivery, which
+	// costs the subscriber an ids-only message.
 	sub := d.addDocSubscription(q)
 	defer d.removeDocSubscription(sub.id)
 
@@ -646,6 +668,12 @@ func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMes
 		defer close(gone)
 		_, _ = io.Copy(io.Discard, conn)
 	}()
+
+	// What the subscriber holds. Seeded from `have`, then replaced by each
+	// delivered window: the client's forget rule means anything absent from a
+	// window's order is gone from its cache too, so this map is the window and
+	// never grows past the query's limit.
+	held := heldRevisions(msg.Have)
 
 	encoder := json.NewEncoder(conn)
 	for delivery := 1; ; delivery++ {
@@ -660,28 +688,70 @@ func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMes
 		// serve again. The re-read happens inside the query's own transaction, so
 		// a redeclare cannot land between reading the declaration and running the
 		// statement compiled from it.
+		//
+		// The first of these reads is also the acceptance check: a query that
+		// cannot be answered fails the subscribe, in the same call that would
+		// have served it. There is no separate compile up front, because a second
+		// compile path is a second place for the rules to be applied differently.
 		read, took, err := d.runDocQuery(q)
 		if err != nil {
-			d.sendDocError(conn, err)
+			code := docErrorCode(err)
+			if delivery > 1 {
+				code = subscriptionEndCode(err)
+			}
+			d.sendDocErrorAs(conn, err, code)
 			return
 		}
 		d.logSlowDocFanOut(sub, read.Schema, took)
-		resp := protocol.Response{
-			Ok: true,
-			DocSubscribeResult: &protocol.DocSubscribeResult{
-				Delivery:  delivery,
-				Documents: storedDocumentsToProtocol(read.Documents),
-			},
-		}
-		if err := encoder.Encode(resp); err != nil {
+		window, next := windowDelivery(delivery, read, held)
+		if err := encoder.Encode(protocol.Response{Ok: true, DocSubscribeResult: window}); err != nil {
 			return
 		}
+		held = next
 		select {
 		case <-sub.wake:
 		case <-gone:
 			return
 		}
 	}
+}
+
+// heldRevisions turns the subscriber's declared `have` into the map the
+// delivery loop diffs against. A resume is exact rather than approximate: an id
+// claiming a revision the store never issued simply differs from the one it
+// finds, so that body is sent and the subscriber converges on the next delivery
+// however stale its claim was.
+func heldRevisions(have []protocol.DocumentRevision) map[string]int64 {
+	if len(have) == 0 {
+		return nil
+	}
+	held := make(map[string]int64, len(have))
+	for _, entry := range have {
+		held[entry.ID] = int64(entry.Rev)
+	}
+	return held
+}
+
+// windowDelivery turns a read into one delivery and the revisions the subscriber
+// holds once it applies it. A body travels only when the subscriber's revision
+// for that id differs from the stored one; everything else is carried by order,
+// which the client renders from its cache.
+func windowDelivery(delivery int, read store.QueryRead, held map[string]int64) (*protocol.DocSubscribeResult, map[string]int64) {
+	out := &protocol.DocSubscribeResult{
+		Delivery: delivery,
+		AsOfSeq:  int(read.AsOfSeq),
+		Order:    make([]string, 0, len(read.Documents)),
+		Upsert:   make([]protocol.StoredDocument, 0),
+	}
+	next := make(map[string]int64, len(read.Documents))
+	for _, doc := range read.Documents {
+		out.Order = append(out.Order, doc.ID)
+		next[doc.ID] = doc.Rev
+		if rev, ok := held[doc.ID]; !ok || rev != doc.Rev {
+			out.Upsert = append(out.Upsert, storedDocumentToProtocol(doc))
+		}
+	}
+	return out, next
 }
 
 func (d *Daemon) sendDocResponse(conn net.Conn, resp protocol.Response) {

--- a/internal/daemon/documents.go
+++ b/internal/daemon/documents.go
@@ -83,6 +83,11 @@ type documentCollectionRemoved struct {
 	Documents  int    `json:"documents"`
 }
 
+type documentCollectionRedeclared struct {
+	Namespace  string `json:"namespace"`
+	Collection string `json:"collection"`
+}
+
 // subscribeDocumentFacts registers the live-query fan-out as its own ephemeral
 // bus consumer, beside the WebSocket hub's. It is deliberately not a projection:
 // wireProjections maps facts to WebSocket traffic, and these deliveries go to
@@ -92,7 +97,8 @@ func (d *Daemon) subscribeDocumentFacts() {
 		return
 	}
 	d.docUnsubHooks = d.eventBus.Subscribe(
-		bus.Filter{FactDocumentChanged, FactDocumentCollectionRemoved}, d.wakeDocumentSubscriptions)
+		bus.Filter{FactDocumentChanged, FactDocumentCollectionRemoved, FactDocumentCollectionRedeclared},
+		d.wakeDocumentSubscriptions)
 }
 
 func (d *Daemon) unsubscribeDocumentFacts() {
@@ -147,13 +153,29 @@ func (d *Daemon) publishCollectionRemoved(namespace, collection string, document
 		documentCollectionRemoved{Namespace: namespace, Collection: collection, Documents: documents})
 }
 
-// wakeDocumentSubscriptions is the fact handler for both document facts. It does
+// publishCollectionRedeclared announces that a collection's declaration was
+// rewritten. The delivery loop re-reads the declaration on every wake, so this
+// is all a redeclare needs to publish: a subscription whose queried fields
+// survived pays one redundant delivery, and one whose field went gets its
+// collection_redeclared ending now instead of at the next arbitrary write.
+func (d *Daemon) publishCollectionRedeclared(namespace, collection string) {
+	d.publishFact(FactDocumentCollectionRedeclared, docstore.Target(namespace, collection),
+		documentCollectionRedeclared{Namespace: namespace, Collection: collection})
+}
+
+// wakeDocumentSubscriptions is the fact handler for every document fact. It does
 // no I/O.
 func (d *Daemon) wakeDocumentSubscriptions(ev bus.Event) {
 	var namespace, collection string
 	switch ev.Name {
 	case FactDocumentCollectionRemoved:
 		fact, ok := decodeFact[documentCollectionRemoved](d, ev)
+		if !ok {
+			return
+		}
+		namespace, collection = fact.Namespace, fact.Collection
+	case FactDocumentCollectionRedeclared:
+		fact, ok := decodeFact[documentCollectionRedeclared](d, ev)
 		if !ok {
 			return
 		}
@@ -410,9 +432,17 @@ func (d *Daemon) handleDocDefine(conn net.Conn, msg *protocol.DocDefineMessage) 
 		d.sendError(conn, "no database")
 		return
 	}
-	if err := d.store.DefineDocumentCollection(schema, time.Now()); err != nil {
+	redeclared, err := d.store.DefineDocumentCollection(schema, time.Now())
+	if err != nil {
 		d.sendDocError(conn, err)
 		return
+	}
+	// A first declaration has no watchers — nothing could subscribe to a
+	// collection that did not exist. A redeclare can, and they must hear about
+	// it now: a live query parked on its wake channel would otherwise hold a
+	// stale window until an unrelated write happened to land, or forever.
+	if redeclared {
+		d.publishCollectionRedeclared(schema.Namespace, schema.Collection)
 	}
 	d.sendDocResponse(conn, protocol.Response{
 		Ok:              true,

--- a/internal/daemon/documents_socket_test.go
+++ b/internal/daemon/documents_socket_test.go
@@ -1,0 +1,162 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/client"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// The document store end to end over a real unix socket, through the same
+// internal/client every other caller uses.
+//
+// Every other test in this package calls a handler with a net.Pipe on both ends,
+// which proves the handler and proves nothing about the seam. This one is the
+// only place where the wire encoding, the client's own read loop and its
+// application of the window rule are exercised together — and A4's SDK sits
+// directly on that read loop, so it stops being untested before anything is
+// built on it.
+func TestDocumentsOverARealSocket(t *testing.T) {
+	useFreeWSPort(t)
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
+
+	d := NewForTesting(sockPath)
+	go d.Start()
+	defer d.Stop()
+	waitForSocket(t, sockPath, 5*time.Second)
+
+	c := client.New(sockPath)
+
+	if _, err := c.DocDefine(protocol.DocumentCollectionSchema{
+		Namespace:  testDocNS,
+		Collection: testDocColl,
+		Fields:     []protocol.DocumentFieldSpec{{Name: "status", Type: "string"}},
+	}); err != nil {
+		t.Fatalf("define: %v", err)
+	}
+	for _, id := range []string{"a", "b"} {
+		if _, err := c.DocPut(testDocNS, testDocColl, id, `{"status":"pending"}`, nil); err != nil {
+			t.Fatalf("put %s: %v", id, err)
+		}
+	}
+
+	q := protocol.DocumentQuery{Namespace: testDocNS, Collection: testDocColl}
+	read, err := c.DocQuery(q)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(read.Documents) != 2 {
+		t.Fatalf("query returned %d documents, want 2", len(read.Documents))
+	}
+	if read.AsOfSeq <= 0 {
+		t.Fatalf("query answered as of seq %d; two writes have landed", read.AsOfSeq)
+	}
+
+	// A fresh subscription: the first window carries every body, and a write
+	// made while it is open carries only the body that changed. The write is
+	// made from inside the callback so it lands while the read loop is running,
+	// which is the only way to observe a delivery that is not the first.
+	var windows []client.DocWindow
+	var putSeq int
+	err = c.DocSubscribe(q, nil, func(w client.DocWindow) bool {
+		windows = append(windows, w)
+		if len(windows) == 1 {
+			go func() {
+				result, err := c.DocPut(testDocNS, testDocColl, "c", `{"status":"pending"}`, nil)
+				if err == nil {
+					putSeq = result.Seq
+				}
+			}()
+		}
+		return len(windows) < 2
+	})
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	if got := len(windows[0].Changed); got != 2 {
+		t.Fatalf("the first window sent %d bodies, want 2 — a fresh subscriber holds nothing", got)
+	}
+	live := windows[1]
+	if len(live.Documents) != 3 {
+		t.Fatalf("the live window holds %d documents, want 3", len(live.Documents))
+	}
+	if len(live.Changed) != 1 || live.Changed[0] != "c" {
+		t.Fatalf("the live window sent %v, want only the document that was written", live.Changed)
+	}
+	if live.AsOfSeq < int64(putSeq) {
+		t.Fatalf("the live window is as of seq %d, below the write it reflects at %d", live.AsOfSeq, putSeq)
+	}
+
+	// Resume. Between the two subscriptions a document is removed and another is
+	// edited, so the resumed window must carry exactly one body — and the client
+	// must be able to render the two it kept.
+	held := live.Documents
+	if _, err := c.DocDelete(testDocNS, testDocColl, "a", nil); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := c.DocPut(testDocNS, testDocColl, "b", `{"status":"approved"}`, nil); err != nil {
+		t.Fatalf("edit: %v", err)
+	}
+
+	var resumed client.DocWindow
+	err = c.DocSubscribe(q, held, func(w client.DocWindow) bool {
+		resumed = w
+		return false
+	})
+	if err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if len(resumed.Documents) != 2 {
+		t.Fatalf("resumed window holds %d documents, want 2", len(resumed.Documents))
+	}
+	if len(resumed.Changed) != 1 || resumed.Changed[0] != "b" {
+		t.Fatalf("resume sent %v, want only the document edited while away", resumed.Changed)
+	}
+	for _, doc := range resumed.Documents {
+		switch doc.ID {
+		case "b":
+			if doc.Body != `{"status":"approved"}` {
+				t.Fatalf("b applied as %s", doc.Body)
+			}
+		case "c":
+			// Never re-sent; this body came out of the client's own cache,
+			// which is the whole point of resuming by content.
+			if doc.Body != `{"status":"pending"}` {
+				t.Fatalf("c applied as %s", doc.Body)
+			}
+		default:
+			t.Fatalf("resumed window holds %q", doc.ID)
+		}
+	}
+
+	// Teardown. Removing the collection ends the live query with the code a UI
+	// host branches on, and the client reports it as an error rather than as a
+	// clean end — a watcher that exits 0 here is a watcher that stopped watching
+	// without saying so.
+	ended := make(chan error, 1)
+	opened := make(chan struct{})
+	go func() {
+		first := true
+		ended <- c.DocSubscribe(q, nil, func(client.DocWindow) bool {
+			if first {
+				first = false
+				close(opened)
+			}
+			return true
+		})
+	}()
+	<-opened
+	if _, err := c.DocUndefine(testDocNS, testDocColl); err != nil {
+		t.Fatalf("undefine: %v", err)
+	}
+	err = <-ended
+	code, isEnd := client.DocSubscriptionCode(err)
+	if !isEnd {
+		t.Fatalf("the subscription ended with %v, which is not a subscription ending", err)
+	}
+	if code != protocol.ErrorCodeCollectionUndefined {
+		t.Fatalf("subscription ended with code %q, want %q", code, protocol.ErrorCodeCollectionUndefined)
+	}
+}

--- a/internal/daemon/documents_socket_test.go
+++ b/internal/daemon/documents_socket_test.go
@@ -59,15 +59,21 @@ func TestDocumentsOverARealSocket(t *testing.T) {
 	// made from inside the callback so it lands while the read loop is running,
 	// which is the only way to observe a delivery that is not the first.
 	var windows []client.DocWindow
-	var putSeq int
+	// The daemon delivers the second window the moment the write commits, which
+	// can be before the writer's own RPC response arrives — so the seq travels
+	// over a channel rather than a variable the subscribe loop would race.
+	putSeq := make(chan int, 1)
 	err = c.DocSubscribe(q, nil, func(w client.DocWindow) bool {
 		windows = append(windows, w)
 		if len(windows) == 1 {
 			go func() {
 				result, err := c.DocPut(testDocNS, testDocColl, "c", `{"status":"pending"}`, nil)
-				if err == nil {
-					putSeq = result.Seq
+				if err != nil {
+					t.Errorf("live put: %v", err)
+					putSeq <- 0
+					return
 				}
+				putSeq <- result.Seq
 			}()
 		}
 		return len(windows) < 2
@@ -85,8 +91,8 @@ func TestDocumentsOverARealSocket(t *testing.T) {
 	if len(live.Changed) != 1 || live.Changed[0] != "c" {
 		t.Fatalf("the live window sent %v, want only the document that was written", live.Changed)
 	}
-	if live.AsOfSeq < int64(putSeq) {
-		t.Fatalf("the live window is as of seq %d, below the write it reflects at %d", live.AsOfSeq, putSeq)
+	if seq := <-putSeq; live.AsOfSeq < int64(seq) {
+		t.Fatalf("the live window is as of seq %d, below the write it reflects at %d", live.AsOfSeq, seq)
 	}
 
 	// Resume. Between the two subscriptions a document is removed and another is

--- a/internal/daemon/documents_test.go
+++ b/internal/daemon/documents_test.go
@@ -73,24 +73,58 @@ func deleteDoc(t *testing.T, d *Daemon, id string) bool {
 	return resp.DocDeleteResult.Existed
 }
 
+// window is one delivery as the subscriber sees it once the client rule has been
+// applied: the wire's own order and upsert, plus the documents those resolve to.
+type window struct {
+	delivery  int
+	asOfSeq   int64
+	order     []string
+	upsert    []protocol.StoredDocument
+	documents []protocol.StoredDocument
+}
+
 // liveQuery subscribes and returns a reader for its deliveries plus a stop that
 // disconnects the caller and waits for the handler to finish — the real signal
 // that the subscription has been torn down.
+//
+// It applies the client rule itself rather than calling internal/client's
+// applier: this is a second implementation of the same three sentences, and two
+// implementations disagreeing is the thing the invariant exists to catch. The
+// resolution below is also where the invariant is checked — every id in order
+// must resolve from the bodies this connection has been sent — so every test in
+// this file that reads a delivery is asserting it.
 type liveQuery struct {
 	dec  *json.Decoder
 	stop func()
+	held map[string]protocol.StoredDocument
 }
 
 func subscribe(t *testing.T, d *Daemon, q protocol.DocumentQuery) *liveQuery {
 	t.Helper()
+	return subscribeResuming(t, d, q, nil)
+}
+
+// subscribeResuming subscribes declaring what the caller already holds. held
+// seeds the applier's cache so a resumed subscription's deliveries resolve the
+// same way a reconnecting client's would.
+func subscribeResuming(t *testing.T, d *Daemon, q protocol.DocumentQuery, held []protocol.StoredDocument) *liveQuery {
+	t.Helper()
+	have := make([]protocol.DocumentRevision, 0, len(held))
+	cache := make(map[string]protocol.StoredDocument, len(held))
+	for _, doc := range held {
+		have = append(have, protocol.DocumentRevision{ID: doc.ID, Rev: doc.Rev})
+		cache[doc.ID] = doc
+	}
 	client, server := net.Pipe()
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		d.handleDocSubscribe(server, &protocol.DocSubscribeMessage{Cmd: protocol.CmdDocSubscribe, Query: q})
+		d.handleDocSubscribe(server, &protocol.DocSubscribeMessage{
+			Cmd: protocol.CmdDocSubscribe, Query: q, Have: have,
+		})
 		_ = server.Close()
 	}()
-	lq := &liveQuery{dec: json.NewDecoder(client)}
+	lq := &liveQuery{dec: json.NewDecoder(client), held: cache}
 	lq.stop = func() {
 		_ = client.Close()
 		<-done
@@ -99,9 +133,10 @@ func subscribe(t *testing.T, d *Daemon, q protocol.DocumentQuery) *liveQuery {
 	return lq
 }
 
-// next reads one delivery. It blocks until the daemon sends, which is what makes
-// these tests wait on a real signal rather than on a duration.
-func (lq *liveQuery) next(t *testing.T) *protocol.DocSubscribeResult {
+// next reads one delivery and applies it. It blocks until the daemon sends,
+// which is what makes these tests wait on a real signal rather than on a
+// duration.
+func (lq *liveQuery) next(t *testing.T) window {
 	t.Helper()
 	resp := lq.nextRaw(t)
 	if !resp.Ok {
@@ -110,7 +145,38 @@ func (lq *liveQuery) next(t *testing.T) *protocol.DocSubscribeResult {
 	if resp.DocSubscribeResult == nil {
 		t.Fatal("delivery carried no result")
 	}
-	return resp.DocSubscribeResult
+	return lq.apply(t, resp.DocSubscribeResult)
+}
+
+// apply is the client rule: render order, take each body from upsert if it is
+// there and from the cache otherwise, forget everything not in order.
+func (lq *liveQuery) apply(t *testing.T, result *protocol.DocSubscribeResult) window {
+	t.Helper()
+	arrived := make(map[string]protocol.StoredDocument, len(result.Upsert))
+	for _, doc := range result.Upsert {
+		arrived[doc.ID] = doc
+	}
+	out := window{
+		delivery: result.Delivery,
+		asOfSeq:  int64(result.AsOfSeq),
+		order:    result.Order,
+		upsert:   result.Upsert,
+	}
+	next := make(map[string]protocol.StoredDocument, len(result.Order))
+	for _, id := range result.Order {
+		doc, ok := arrived[id]
+		if !ok {
+			doc, ok = lq.held[id]
+		}
+		if !ok {
+			t.Fatalf("delivery %d ordered %q but neither sent its body nor had this subscriber been given one: %v",
+				result.Delivery, id, result.Order)
+		}
+		next[id] = doc
+		out.documents = append(out.documents, doc)
+	}
+	lq.held = next
+	return out
 }
 
 // nextRaw reads one delivery without requiring it to have succeeded, for the
@@ -124,39 +190,44 @@ func (lq *liveQuery) nextRaw(t *testing.T) protocol.Response {
 	return resp
 }
 
-func ids(result *protocol.DocSubscribeResult) []string {
-	out := make([]string, 0, len(result.Documents))
-	for _, doc := range result.Documents {
+// changed names the ids whose bodies travelled in this delivery.
+func (w window) changed() []string {
+	out := make([]string, 0, len(w.upsert))
+	for _, doc := range w.upsert {
 		out = append(out, doc.ID)
 	}
 	return out
 }
 
+func ids(w window) []string { return w.order }
+
 func testQuery() protocol.DocumentQuery {
 	return protocol.DocumentQuery{Namespace: testDocNS, Collection: testDocColl}
 }
 
-// Subscribing delivers the current result set straight away, in the same round
-// trip. An extension UI remounts by re-subscribing, so a subscription that only
-// promised future updates would render empty until something happened to change.
-func TestSubscribingDeliversTheCurrentResultSetImmediately(t *testing.T) {
+// Subscribing delivers the query's current window straight away, in the same
+// round trip. An extension UI remounts by re-subscribing, so a subscription that
+// only promised future updates would render empty until something happened to
+// change.
+func TestSubscribingDeliversTheCurrentWindowImmediately(t *testing.T) {
 	d := newDaemonForTest(t)
 	defineTestCollection(t, d)
 	putDoc(t, d, "already-here", `{"status":"pending"}`)
 
 	lq := subscribe(t, d, testQuery())
 	first := lq.next(t)
-	if first.Delivery != 1 {
-		t.Fatalf("first delivery = %d, want 1", first.Delivery)
+	if first.delivery != 1 {
+		t.Fatalf("first delivery = %d, want 1", first.delivery)
 	}
 	if got := ids(first); len(got) != 1 || got[0] != "already-here" {
 		t.Fatalf("first delivery = %v", got)
 	}
 }
 
-// A write wakes the subscription, and what arrives is the whole current result
-// set rather than a description of what changed.
-func TestAWriteWakesTheSubscriptionWithTheWholeResultSet(t *testing.T) {
+// A write wakes the subscription, and what arrives is the query's whole current
+// order — never a patch the subscriber has to merge — plus the one body it does
+// not hold.
+func TestAWriteWakesTheSubscriptionWithTheCurrentWindow(t *testing.T) {
 	d := newDaemonForTest(t)
 	defineTestCollection(t, d)
 	lq := subscribe(t, d, testQuery())
@@ -166,14 +237,17 @@ func TestAWriteWakesTheSubscriptionWithTheWholeResultSet(t *testing.T) {
 
 	putDoc(t, d, "a", `{"status":"pending"}`)
 	second := lq.next(t)
-	if second.Delivery != 2 {
-		t.Fatalf("delivery = %d, want 2", second.Delivery)
+	if second.delivery != 2 {
+		t.Fatalf("delivery = %d, want 2", second.delivery)
 	}
 	if got := ids(second); len(got) != 1 || got[0] != "a" {
 		t.Fatalf("after write = %v", got)
 	}
-	if body := second.Documents[0].Body; body != `{"status":"pending"}` {
+	if body := second.documents[0].Body; body != `{"status":"pending"}` {
 		t.Fatalf("body = %s", body)
+	}
+	if got := second.changed(); len(got) != 1 || got[0] != "a" {
+		t.Fatalf("bodies sent = %v, want just the document that changed", got)
 	}
 }
 
@@ -193,8 +267,8 @@ func TestANoOpDeleteDoesNotWakeSubscribers(t *testing.T) {
 	putDoc(t, d, "a", `{"status":"pending"}`)
 
 	next := lq.next(t)
-	if next.Delivery != 2 {
-		t.Fatalf("delivery = %d, want 2 — the no-op delete delivered", next.Delivery)
+	if next.delivery != 2 {
+		t.Fatalf("delivery = %d, want 2 — the no-op delete delivered", next.delivery)
 	}
 	if got := ids(next); len(got) != 1 || got[0] != "a" {
 		t.Fatalf("delivery = %v", got)
@@ -253,8 +327,8 @@ func TestASubscriptionOnlyWakesForItsOwnCollection(t *testing.T) {
 	putDoc(t, d, "ours", `{"status":"pending"}`)
 
 	next := lq.next(t)
-	if next.Delivery != 2 {
-		t.Fatalf("delivery = %d, want 2 — the neighbouring namespace woke this subscription", next.Delivery)
+	if next.delivery != 2 {
+		t.Fatalf("delivery = %d, want 2 — the neighbouring namespace woke this subscription", next.delivery)
 	}
 	if got := ids(next); len(got) != 1 || got[0] != "ours" {
 		t.Fatalf("delivery = %v — it crossed the namespace boundary", got)
@@ -312,19 +386,32 @@ func TestReadingAnUndeclaredCollectionSaysHowToDeclareIt(t *testing.T) {
 	}
 }
 
-// A subscription whose query cannot compile is refused at subscribe time. The
-// alternative is a subscription that looks accepted and fails on every delivery.
+// A subscription whose query cannot be answered is refused at subscribe time,
+// by the same read that would have served it. The alternative is a subscription
+// that looks accepted and fails on every delivery.
+//
+// The refusal carries invalid_query rather than either subscription-ending code:
+// nothing happened to this subscription, the caller asked for something the
+// collection does not offer, and resubscribing with a corrected query works.
 func TestASubscriptionWithAnUnqueryableFieldIsRefusedUpFront(t *testing.T) {
 	d := newDaemonForTest(t)
 	defineTestCollection(t, d)
 	q := testQuery()
 	q.Sort = &protocol.DocumentSort{Field: "undeclared"}
-	resp := docCall(t, func(c net.Conn) {
-		d.handleDocSubscribe(c, &protocol.DocSubscribeMessage{Cmd: protocol.CmdDocSubscribe, Query: q})
-	})
+
+	lq := subscribe(t, d, q)
+	resp := lq.nextRaw(t)
 	if resp.Ok {
 		t.Fatal("subscribing with an undeclared sort field succeeded")
 	}
+	if code := protocol.Deref(resp.ErrorCode); code != protocol.ErrorCodeInvalidQuery {
+		t.Fatalf("error code = %q, want %q", code, protocol.ErrorCodeInvalidQuery)
+	}
+	// stop waits for the handler to return, which is when a registered
+	// subscription would have been removed. Registering before the first read is
+	// deliberate — it is what keeps a write landing mid-subscribe from being
+	// missed — so what has to hold is that a refusal still leaves nothing behind.
+	lq.stop()
 	if n := d.documentSubscriptionCount(); n != 0 {
 		t.Fatalf("a refused subscribe left %d subscriptions behind", n)
 	}
@@ -390,6 +477,11 @@ func TestRemovingACollectionReachesItsLiveQueries(t *testing.T) {
 	}
 	if msg := protocol.Deref(final.Error); !strings.Contains(msg, "is not declared") {
 		t.Fatalf("error does not say the collection is gone: %q", msg)
+	}
+	// The code is what a UI host branches on: collection_undefined means the
+	// tile is dead, not that its query was wrong.
+	if code := protocol.Deref(final.ErrorCode); code != protocol.ErrorCodeCollectionUndefined {
+		t.Fatalf("error code = %q, want %q", code, protocol.ErrorCodeCollectionUndefined)
 	}
 }
 
@@ -488,6 +580,11 @@ func TestRedeclaringWithoutAFieldEndsTheLiveQueriesUsingIt(t *testing.T) {
 	}
 	if msg := protocol.Deref(final.Error); !strings.Contains(msg, "status") {
 		t.Fatalf("error does not name the field that went: %q", msg)
+	}
+	// collection_redeclared rather than collection_undefined: the collection is
+	// still there, and it is the query that can never be answered again.
+	if code := protocol.Deref(final.ErrorCode); code != protocol.ErrorCodeCollectionRedeclared {
+		t.Fatalf("error code = %q, want %q", code, protocol.ErrorCodeCollectionRedeclared)
 	}
 }
 
@@ -592,8 +689,8 @@ func TestARefusedWriteDoesNotWakeSubscribers(t *testing.T) {
 	if got := ids(next); len(got) != 2 {
 		t.Fatalf("first delivery after the refused write = %v, want both documents", got)
 	}
-	if next.Delivery != 2 {
-		t.Fatalf("delivery = %d, want 2 — something delivered in between", next.Delivery)
+	if next.delivery != 2 {
+		t.Fatalf("delivery = %d, want 2 — something delivered in between", next.delivery)
 	}
 }
 

--- a/internal/daemon/documents_test.go
+++ b/internal/daemon/documents_test.go
@@ -570,10 +570,9 @@ func TestRedeclaringWithoutAFieldEndsTheLiveQueriesUsingIt(t *testing.T) {
 	if !resp.Ok {
 		t.Fatalf("redeclare: %v", protocol.Deref(resp.Error))
 	}
-	// A write is what wakes the subscription; the redeclare alone is not a
-	// document change.
-	putDoc(t, d, "b", `{"status":"pending"}`)
-
+	// No write follows: the redeclare itself must wake the subscription and end
+	// it. A quiet collection whose declaration moved is exactly the case where
+	// waiting for the next document change would mean waiting forever.
 	final := lq.nextRaw(t)
 	if final.Ok {
 		t.Fatalf("delivery after the field went = %+v, want an error", final)

--- a/internal/daemon/documents_windowed_test.go
+++ b/internal/daemon/documents_windowed_test.go
@@ -1,0 +1,607 @@
+package daemon
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// The windowed subscription's battery.
+//
+// Every assertion here is an inequality or an equality between two receipts the
+// wire itself carries — a write's seq against a delivery's as_of_seq, a delivered
+// window against a fresh query's answer. None of them waits on a duration,
+// because a subscription test that needs a sleep is a subscription test that has
+// stopped proving anything about the case where the machine is slow.
+//
+// See docs/plans/2026-08-05-ext-a3.4-doc-store-positions-and-windows.md.
+
+// ---------------------------------------------------------------------------
+// Receipts the tests below compare
+// ---------------------------------------------------------------------------
+
+// putDocSeq writes and returns the position the write landed at.
+func putDocSeq(t *testing.T, d *Daemon, id, body string) int64 {
+	t.Helper()
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocPut(c, &protocol.DocPutMessage{
+			Cmd: protocol.CmdDocPut, Namespace: testDocNS, Collection: testDocColl, ID: id, Body: body,
+		})
+	})
+	if !resp.Ok {
+		t.Fatalf("put %s: %v", id, protocol.Deref(resp.Error))
+	}
+	return int64(resp.DocPutResult.Seq)
+}
+
+// deleteDocSeq removes and returns the position, which is 0 when the delete
+// removed nothing — nothing changed, so nothing was announced.
+func deleteDocSeq(t *testing.T, d *Daemon, id string) int64 {
+	t.Helper()
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocDelete(c, &protocol.DocDeleteMessage{
+			Cmd: protocol.CmdDocDelete, Namespace: testDocNS, Collection: testDocColl, ID: id,
+		})
+	})
+	if !resp.Ok {
+		t.Fatalf("delete %s: %v", id, protocol.Deref(resp.Error))
+	}
+	return int64(resp.DocDeleteResult.Seq)
+}
+
+// queryIDs answers the same query one-shot, which is what a delivered window is
+// checked against: the subscription must never show a state a fresh read
+// disagrees with.
+func queryIDs(t *testing.T, d *Daemon, q protocol.DocumentQuery) []string {
+	t.Helper()
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocQuery(c, &protocol.DocQueryMessage{Cmd: protocol.CmdDocQuery, Query: q})
+	})
+	if !resp.Ok {
+		t.Fatalf("query: %v", protocol.Deref(resp.Error))
+	}
+	out := make([]string, 0, len(resp.DocQueryResult.Documents))
+	for _, doc := range resp.DocQueryResult.Documents {
+		out = append(out, doc.ID)
+	}
+	return out
+}
+
+// settle reads deliveries until one is at least as current as seq, and returns
+// it. This is the whole reason writes report a position: "the subscription has
+// caught up" used to be unwritable without waiting on a duration, and is now an
+// inequality between two numbers the protocol already carries.
+//
+// It cannot hang. A delivery is computed after the wake it consumed, and a wake
+// is set after the write commits, so a delivery reporting a position below seq
+// consumed a wake older than that write — which means that write's own wake is
+// still pending and another delivery follows.
+func (lq *liveQuery) settle(t *testing.T, seq int64) window {
+	t.Helper()
+	for {
+		w := lq.next(t)
+		if w.asOfSeq >= seq {
+			return w
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Subscribe refuses a cursor
+// ---------------------------------------------------------------------------
+
+// A live query is a window and a cursor is a walk: the document an after cursor
+// names moves out from under a subscription, so the page it named is not the
+// page it names a write later. The refusal has to name the alternative, because
+// the reader fixing it is an agent with only the error to go on.
+func TestSubscribingWithAnAfterCursorIsRefused(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+
+	after := "a"
+	q := testQuery()
+	q.After = &after
+
+	lq := subscribe(t, d, q)
+	resp := lq.nextRaw(t)
+	if resp.Ok {
+		t.Fatal("subscribing with an after cursor was accepted")
+	}
+	if code := protocol.Deref(resp.ErrorCode); code != protocol.ErrorCodeInvalidQuery {
+		t.Fatalf("error code = %q, want %q", code, protocol.ErrorCodeInvalidQuery)
+	}
+	msg := protocol.Deref(resp.Error)
+	for _, want := range []string{"limit", "window"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("refusal %q does not name the alternative (%q)", msg, want)
+		}
+	}
+	lq.stop()
+	if n := d.documentSubscriptionCount(); n != 0 {
+		t.Fatalf("a refused subscribe left %d subscriptions behind", n)
+	}
+}
+
+// The one-shot read keeps its cursor. There is one instant in a single query, so
+// nothing moves under the anchor and the walk is correct; the refusal above is
+// about subscriptions only, and the two must not be conflated.
+func TestOneShotQueryStillTakesAnAfterCursor(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+	putDoc(t, d, "b", `{"status":"pending"}`)
+
+	after := "a"
+	q := testQuery()
+	q.After = &after
+	if got := queryIDs(t, d, q); !equalStrings(got, []string{"b"}) {
+		t.Fatalf("page after a = %v, want [b]", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Only what changed travels
+// ---------------------------------------------------------------------------
+
+// The point of the window: a delivery names every document in order and carries
+// only the bodies the subscriber does not hold. A collection where one of many
+// documents changed must not re-send the rest.
+func TestADeliveryCarriesOnlyTheBodiesThatChanged(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	for _, id := range []string{"a", "b", "c"} {
+		putDoc(t, d, id, `{"status":"pending"}`)
+	}
+
+	lq := subscribe(t, d, testQuery())
+	first := lq.next(t)
+	if got := first.changed(); len(got) != 3 {
+		t.Fatalf("the first delivery sent %d bodies, want all 3 — a fresh subscriber holds nothing", len(got))
+	}
+
+	seq := putDocSeq(t, d, "b", `{"status":"approved"}`)
+	next := lq.settle(t, seq)
+	if got := ids(next); !equalStrings(got, []string{"a", "b", "c"}) {
+		t.Fatalf("order = %v, want every document still named", got)
+	}
+	if got := next.changed(); !equalStrings(got, []string{"b"}) {
+		t.Fatalf("bodies sent = %v, want only the one that changed", got)
+	}
+	// The bodies the subscriber did not receive are the ones it kept, which is
+	// what the applied window proves.
+	for _, doc := range next.documents {
+		want := `{"status":"pending"}`
+		if doc.ID == "b" {
+			want = `{"status":"approved"}`
+		}
+		if doc.Body != want {
+			t.Fatalf("%s applied as %s, want %s", doc.ID, doc.Body, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Resume by content
+// ---------------------------------------------------------------------------
+
+// The four ways a document can differ from what a resuming subscriber holds, each
+// checked the same way: the first delivery after resuming carries exactly the
+// bodies that changed, and the applied window equals a fresh query's answer. A
+// resume that sent one body too few would render a stale document; one body too
+// many is the full refetch this design exists to avoid.
+func TestResumingSendsExactlyWhatChangedWhileAway(t *testing.T) {
+	limit := 2
+	sorted := func() protocol.DocumentQuery {
+		q := testQuery()
+		q.Sort = &protocol.DocumentSort{Field: "status"}
+		q.Limit = &limit
+		return q
+	}
+
+	cases := []struct {
+		name string
+		// mutate runs while nobody is subscribed, and reports the position of
+		// the last write it made.
+		mutate func(t *testing.T, d *Daemon) int64
+		// order is the window the resumed subscription must show.
+		order []string
+		// changed is exactly the set of bodies that must travel.
+		changed []string
+	}{
+		{
+			name:    "edited inside the window",
+			mutate:  func(t *testing.T, d *Daemon) int64 { return putDocSeq(t, d, "a", `{"status":"aa"}`) },
+			order:   []string{"a", "b"},
+			changed: []string{"a"},
+		},
+		{
+			name:    "deleted",
+			mutate:  func(t *testing.T, d *Daemon) int64 { return deleteDocSeq(t, d, "a") },
+			order:   []string{"b", "c"},
+			changed: []string{"c"},
+		},
+		{
+			name: "displaced past the limit",
+			// A new document sorting first pushes the last one out of the
+			// window. Nothing about the displaced document changed, and no fact
+			// names it — it leaves the window only because another arrived,
+			// which is the case log replay could never have reconstructed.
+			mutate:  func(t *testing.T, d *Daemon) int64 { return putDocSeq(t, d, "z", `{"status":"a0"}`) },
+			order:   []string{"z", "a"},
+			changed: []string{"z"},
+		},
+		{
+			name:    "edited out of the filter",
+			mutate:  func(t *testing.T, d *Daemon) int64 { return putDocSeq(t, d, "b", `{"status":"zz"}`) },
+			order:   []string{"a", "c"},
+			changed: []string{"c"},
+		},
+		{
+			name: "nothing changed at all",
+			// The degenerate case, and the one that proves the resume is worth
+			// having: no body travels, and the window is still complete.
+			mutate:  func(t *testing.T, d *Daemon) int64 { return 0 },
+			order:   []string{"a", "b"},
+			changed: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newDaemonForTest(t)
+			defineTestCollection(t, d)
+			putDoc(t, d, "a", `{"status":"a1"}`)
+			putDoc(t, d, "b", `{"status":"b1"}`)
+			putDoc(t, d, "c", `{"status":"c1"}`)
+
+			lq := subscribe(t, d, sorted())
+			held := lq.next(t).documents
+			if got := idsOf(held); !equalStrings(got, []string{"a", "b"}) {
+				t.Fatalf("initial window = %v, want [a b]", got)
+			}
+			lq.stop()
+
+			seq := tc.mutate(t, d)
+
+			resumed := subscribeResuming(t, d, sorted(), held)
+			first := resumed.next(t)
+			if first.asOfSeq < seq {
+				t.Fatalf("resumed at seq %d, below the write at %d", first.asOfSeq, seq)
+			}
+			if got := ids(first); !equalStrings(got, tc.order) {
+				t.Fatalf("resumed window = %v, want %v", got, tc.order)
+			}
+			if got := first.changed(); !equalStrings(got, tc.changed) {
+				t.Fatalf("bodies sent on resume = %v, want %v", got, tc.changed)
+			}
+			if got, want := ids(first), queryIDs(t, d, sorted()); !equalStrings(got, want) {
+				t.Fatalf("resumed window = %v, but a fresh query says %v", got, want)
+			}
+		})
+	}
+}
+
+// A resume token the store never issued — a revision from a subscriber that has
+// been away so long its claim is meaningless, or simply a wrong one — must
+// converge rather than mislead. The claim differs from what is stored, so the
+// body travels; the only way to get this wrong is to trust the claim.
+func TestResumingWithARevisionTheStoreNeverIssuedStillConverges(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+
+	stale := []protocol.StoredDocument{{ID: "a", Body: `{"status":"whatever this was"}`, Rev: 4242}}
+	lq := subscribeResuming(t, d, testQuery(), stale)
+	first := lq.next(t)
+	if got := first.changed(); !equalStrings(got, []string{"a"}) {
+		t.Fatalf("bodies sent = %v, want the document whose claimed revision was never issued", got)
+	}
+	if len(first.documents) != 1 || first.documents[0].Body != `{"status":"pending"}` {
+		t.Fatalf("applied window = %+v, want the stored body", first.documents)
+	}
+}
+
+// A resume that names a document the query no longer returns simply does not see
+// it: it is absent from order, and the client's forget rule collects it. There is
+// no removal field to get wrong.
+func TestResumingForgetsWhatIsNoLongerInTheWindow(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+
+	lq := subscribe(t, d, testQuery())
+	held := lq.next(t).documents
+	lq.stop()
+
+	deleteDocSeq(t, d, "a")
+
+	resumed := subscribeResuming(t, d, testQuery(), held)
+	first := resumed.next(t)
+	if len(first.order) != 0 {
+		t.Fatalf("resumed window = %v, want empty", first.order)
+	}
+	if len(first.upsert) != 0 {
+		t.Fatalf("a body travelled for a document that is not in the window: %v", first.changed())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Currency, coalescing, fan-out
+// ---------------------------------------------------------------------------
+
+// Currency under contention. A writer flips one document between two known
+// states as fast as it can; every window a subscriber sees must be one of those
+// two, and once the writer stops the subscription must reach a delivery at least
+// as current as the last write, showing what a fresh query shows.
+func TestASubscriptionStaysCurrentUnderContention(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+
+	lq := subscribe(t, d, testQuery())
+	lq.next(t)
+
+	const flips = 40
+	bodies := []string{`{"status":"pending"}`, `{"status":"approved"}`}
+
+	// The writer's last act is a sentinel document, and its arrival in a window
+	// is what ends the read loop. Reading "until the writer is done" cannot work
+	// from here: the reader would learn that only after consuming the delivery
+	// the last write caused, and would then block waiting for one that is never
+	// coming. The sentinel makes the stop condition something the wire carries.
+	var sentinelSeq int64
+	var writer sync.WaitGroup
+	writer.Add(1)
+	go func() {
+		defer writer.Done()
+		for i := range flips {
+			putDocSeq(t, d, "a", bodies[i%2])
+		}
+		sentinelSeq = putDocSeq(t, d, "sentinel", `{"status":"pending"}`)
+	}()
+
+	// Read alongside the writer. Every window is a state the collection was
+	// really in — the enumerable legal set is two bodies — and nothing here
+	// waits on a duration to say so.
+	var final window
+	for {
+		w := lq.next(t)
+		holds := false
+		for _, doc := range w.documents {
+			if doc.ID != "a" {
+				continue
+			}
+			holds = true
+			if doc.Body != bodies[0] && doc.Body != bodies[1] {
+				t.Fatalf("window showed %s, which the collection was never in", doc.Body)
+			}
+		}
+		if !holds {
+			t.Fatalf("window = %v, and the flipped document is not in it", ids(w))
+		}
+		if len(w.order) == 2 {
+			final = w
+			break
+		}
+	}
+	writer.Wait()
+
+	if final.asOfSeq < sentinelSeq {
+		t.Fatalf("the delivery carrying the last write reports seq %d, below the write's own %d",
+			final.asOfSeq, sentinelSeq)
+	}
+	if got, want := ids(final), queryIDs(t, d, testQuery()); !equalStrings(got, want) {
+		t.Fatalf("final window = %v, fresh query = %v", got, want)
+	}
+}
+
+// The one-slot wake channel's receipt. A subscriber blocked mid-encode — net.Pipe
+// gives no buffer at all, so the daemon is stuck in Write until this test reads —
+// must not accumulate one delivery per write. What arrives instead is the
+// delivery it was blocked on plus one more, current.
+//
+// The bound is exact rather than approximate: the handler can only be in one of
+// two places when the writes land, and the slot holds one nudge.
+func TestABurstOfWritesCollapsesIntoAFewDeliveries(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+
+	lq := subscribe(t, d, testQuery())
+	lq.next(t) // delivery 1, drained; the handler now waits on its wake channel
+
+	const writes = 40
+	var last int64
+	want := make([]string, 0, writes)
+	for i := range writes {
+		id := fmt.Sprintf("d%02d", i)
+		last = putDocSeq(t, d, id, `{"status":"pending"}`)
+		want = append(want, id)
+	}
+
+	deliveries := 0
+	var final window
+	for {
+		final = lq.next(t)
+		deliveries++
+		if final.asOfSeq >= last {
+			break
+		}
+		if deliveries > 4 {
+			t.Fatalf("%d writes produced %d deliveries before catching up; the wake slot is not collapsing them",
+				writes, deliveries)
+		}
+	}
+	if deliveries > 2 {
+		t.Fatalf("%d writes produced %d deliveries, want at most 2 — one in flight plus one current",
+			writes, deliveries)
+	}
+	if got := ids(final); !equalStrings(got, want) {
+		t.Fatalf("final window = %v, want every written document", got)
+	}
+}
+
+// Two subscribers on one collection each get their own window, and each one's
+// bodies are diffed against what IT holds. The second subscriber joining late
+// must not make the first one re-receive anything.
+func TestEverySubscriberGetsItsOwnWindow(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"pending"}`)
+
+	first := subscribe(t, d, testQuery())
+	if got := first.next(t).changed(); !equalStrings(got, []string{"a"}) {
+		t.Fatalf("first subscriber's initial bodies = %v", got)
+	}
+
+	second := subscribe(t, d, testQuery())
+	if got := second.next(t).changed(); !equalStrings(got, []string{"a"}) {
+		t.Fatalf("second subscriber's initial bodies = %v — a fresh subscriber holds nothing", got)
+	}
+
+	seq := putDocSeq(t, d, "b", `{"status":"pending"}`)
+	for name, lq := range map[string]*liveQuery{"first": first, "second": second} {
+		w := lq.settle(t, seq)
+		if got := ids(w); !equalStrings(got, []string{"a", "b"}) {
+			t.Fatalf("%s subscriber's window = %v, want [a b]", name, got)
+		}
+		if got := w.changed(); !equalStrings(got, []string{"b"}) {
+			t.Fatalf("%s subscriber received %v, want only the new document", name, got)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The window invariant, fuzzed
+// ---------------------------------------------------------------------------
+
+// windowFuzzBodies is the alphabet the fuzz draws from, and every entry is a case
+// where the encoding could disagree with the ordering the query means. Ties on
+// the sort field decide whether the id tiebreaker is really applied; a missing
+// field and a JSON null are what SQLite sorts as NULL, which compares as nothing
+// at all; text that looks numeric and a value with no numeric reading are what
+// the column's NUMERIC affinity does and does not convert.
+//
+// A differential harness validates machinery, never meaning: these are the
+// values where a window built from the wrong comparison would still look
+// plausible.
+var windowFuzzBodies = []string{
+	`{"n":1}`,
+	`{"n":1}`,
+	`{"n":2}`,
+	`{"n":"1"}`,
+	`{"n":"apple"}`,
+	`{"n":null}`,
+	`{}`,
+	`{"n":[1,2]}`,
+	`{"n":{"deep":1}}`,
+}
+
+// Fuzzed over a corpus small enough that a limit really bites: every applied
+// window must equal what a fresh query answers, and — checked inside the applier
+// on every delivery in this package — every id in order must resolve from a body
+// this connection was actually sent.
+//
+// Deterministic by seed, so a failure is reproducible and a green run is not
+// luck about which arrangement came up.
+func TestTheWindowInvariantHoldsOverAFuzzedCorpus(t *testing.T) {
+	const (
+		documents = 7
+		limit     = 3
+		rounds    = 120
+	)
+
+	d := newDaemonForTest(t)
+	resp := docCall(t, func(c net.Conn) {
+		d.handleDocDefine(c, &protocol.DocDefineMessage{
+			Cmd: protocol.CmdDocDefine,
+			Schema: protocol.DocumentCollectionSchema{
+				Namespace: testDocNS, Collection: testDocColl,
+				Fields: []protocol.DocumentFieldSpec{{Name: "n", Type: "number"}},
+			},
+		})
+	})
+	if !resp.Ok {
+		t.Fatalf("define: %v", protocol.Deref(resp.Error))
+	}
+
+	ids := make([]string, documents)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("d%d", i)
+	}
+
+	cap := limit
+	q := testQuery()
+	q.Sort = &protocol.DocumentSort{Field: "n", Desc: protocol.Ptr(true)}
+	q.Limit = &cap
+
+	lq := subscribe(t, d, q)
+	lq.next(t)
+
+	rng := rand.New(rand.NewSource(20260805))
+	for round := range rounds {
+		id := ids[rng.Intn(len(ids))]
+		var seq int64
+		if rng.Intn(4) == 0 {
+			seq = deleteDocSeq(t, d, id)
+		} else {
+			seq = putDocSeq(t, d, id, windowFuzzBodies[rng.Intn(len(windowFuzzBodies))])
+		}
+		if seq == 0 {
+			// A delete that removed nothing changed nothing, so it wakes
+			// nobody and there is no delivery to wait for.
+			continue
+		}
+		w := lq.settle(t, seq)
+		if got, want := w.order, queryIDs(t, d, q); !equalStrings(got, want) {
+			t.Fatalf("round %d: window = %v, fresh query = %v", round, got, want)
+		}
+		if len(w.order) > limit {
+			t.Fatalf("round %d: window holds %d documents, above the limit of %d", round, len(w.order), limit)
+		}
+	}
+}
+
+// The named fixture behind the fuzz's hardest case, pinned on its own because a
+// differential run can only tell you the two answers agreed. A document enters a
+// limited window because a DIFFERENT document left it: no fact names the one that
+// entered, so nothing derived from the change log alone could have found it.
+func TestADocumentEntersTheWindowBecauseAnotherLeft(t *testing.T) {
+	d := newDaemonForTest(t)
+	defineTestCollection(t, d)
+	putDoc(t, d, "a", `{"status":"1"}`)
+	putDoc(t, d, "b", `{"status":"2"}`)
+	putDoc(t, d, "c", `{"status":"3"}`)
+
+	limit := 2
+	q := testQuery()
+	q.Sort = &protocol.DocumentSort{Field: "status"}
+	q.Limit = &limit
+
+	lq := subscribe(t, d, q)
+	if got := ids(lq.next(t)); !equalStrings(got, []string{"a", "b"}) {
+		t.Fatalf("initial window = %v, want [a b]", got)
+	}
+
+	seq := deleteDocSeq(t, d, "a")
+	w := lq.settle(t, seq)
+	if got := ids(w); !equalStrings(got, []string{"b", "c"}) {
+		t.Fatalf("window after the delete = %v, want [b c]", got)
+	}
+	if got := w.changed(); !equalStrings(got, []string{"c"}) {
+		t.Fatalf("bodies sent = %v, want only the document that entered", got)
+	}
+}
+
+func idsOf(docs []protocol.StoredDocument) []string {
+	out := make([]string, 0, len(docs))
+	for _, doc := range docs {
+		out = append(out, doc.ID)
+	}
+	return out
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "214"
+const ProtocolVersion = "215"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only
@@ -32,6 +32,18 @@ const (
 	// operator that does not exist, a bound of the wrong type, a cursor pointing
 	// at a document that is gone. The message says which.
 	ErrorCodeInvalidQuery = "invalid_query"
+	// ErrorCodeCollectionUndefined ends a live subscription because the
+	// collection it watches was removed. Distinct from
+	// ErrorCodeUndeclaredCollection, which answers a request against a
+	// collection that was never there: this one says an accepted subscription's
+	// target went away underneath it, which is a UI host's "kill the tile"
+	// rather than "the caller asked for the wrong thing".
+	ErrorCodeCollectionUndefined = "collection_undefined"
+	// ErrorCodeCollectionRedeclared ends a live subscription because the
+	// collection was redeclared without a field the query uses. The query can
+	// never be answered again as written, so the tile's query is what has to
+	// change; resubscribing unchanged would fail the same way.
+	ErrorCodeCollectionRedeclared = "collection_redeclared"
 )
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1236,16 +1236,25 @@ type DocSubscribeMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
 
+	// Have corresponds to the JSON schema field "have".
+	Have []DocumentRevision `json:"have,omitempty,omitzero"`
+
 	// Query corresponds to the JSON schema field "query".
 	Query DocumentQuery `json:"query"`
 }
 
 type DocSubscribeResult struct {
+	// AsOfSeq corresponds to the JSON schema field "as_of_seq".
+	AsOfSeq int `json:"as_of_seq"`
+
 	// Delivery corresponds to the JSON schema field "delivery".
 	Delivery int `json:"delivery"`
 
-	// Documents corresponds to the JSON schema field "documents".
-	Documents []StoredDocument `json:"documents"`
+	// Order corresponds to the JSON schema field "order".
+	Order []string `json:"order"`
+
+	// Upsert corresponds to the JSON schema field "upsert".
+	Upsert []StoredDocument `json:"upsert"`
 }
 
 type DocUndefineMessage struct {
@@ -1338,6 +1347,14 @@ type DocumentQuery struct {
 
 	// Sort corresponds to the JSON schema field "sort".
 	Sort *DocumentSort `json:"sort,omitempty,omitzero"`
+}
+
+type DocumentRevision struct {
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
+
+	// Rev corresponds to the JSON schema field "rev".
+	Rev int `json:"rev"`
 }
 
 type DocumentSort struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -3681,29 +3681,70 @@ model DocumentConflict {
   "actual": safeint;
 }
 
+// One document a resuming subscriber already holds, and at which revision.
+//
+// A pair list rather than a map because the generated Go types erase a record's
+// value type to `any`, and a revision that decodes as an untyped number is
+// exactly the value this resume must not get wrong.
+model DocumentRevision {
+  "id": string;
+  "rev": safeint;
+}
+
 // Subscribe to a live query. Unlike every other command here, this one keeps the
 // connection open: the daemon writes a DocSubscribeResult immediately carrying
-// the current result set, then writes a fresh one every time a write to the
-// collection changes what the query returns. The subscription ends when the
-// caller closes the connection.
+// the query's current window, then writes a fresh one every time a write to the
+// collection could have changed it. The subscription ends when the caller closes
+// the connection, or when the collection stops being able to answer the query.
+//
+// `have` is what the subscriber already holds, and is how a reconnecting client
+// resumes without replaying history: the first delivery then carries only the
+// window members whose revision differs from what is declared here. Everything
+// else about that delivery is unchanged, so a fresh subscribe is simply the case
+// where `have` is empty.
+//
+// A query carrying `after` is REFUSED. A live query is a window and a cursor is
+// a walk: the anchor moves under a subscription, so the page it names is not the
+// page it named a write ago. Use `limit` and let each delivery carry the current
+// window. One-shot doc_query keeps `after` exactly as it is, because a single
+// read has one instant and nothing to move under it.
 model DocSubscribeMessage {
   "cmd": "doc_subscribe";
   "query": DocumentQuery;
+  "have"?: DocumentRevision[];
 }
 
-// One delivery of a live query's results. `documents` is always the CURRENT full
-// result set, never a patch — a subscriber renders what it is given and never
-// reconstructs state from a sequence of deliveries. `delivery` counts deliveries
-// on this subscription, starting at 1 for the initial one; it is named for what
-// it counts because a document carries its own `rev` and one word for both would
-// read as though they were related.
+// One delivery of a live query's window, and the whole client contract is one
+// rule:
 //
-// int32 rather than the safeint a document's revision uses: this counter is
-// bounded by how long one connection stays open, not by a document's whole
-// history.
+//   Render `order`. Take each body from `upsert` if it is there, else from your
+//   cache. Forget every cached document not named in `order`.
+//
+// `order` is the query's current result, in the server's own order — the client
+// never re-derives sort position, because document order comes from SQLite's
+// comparison under column affinity and a client re-sorting locally would have to
+// reimplement that exactly. `upsert` carries only the bodies the subscriber does
+// not already hold: the ones it declared at a different revision in `have`, and
+// the ones that have changed since a previous delivery on this connection.
+// There is no `remove` field because removal is derivable from `order`, and a
+// derivable field is a field two implementations can disagree about.
+//
+// The daemon upholds — and a test pins — that every id in `order` is either in
+// `upsert`, or was declared in `have` at its current revision, or arrived in an
+// earlier delivery on this connection. A client that finds a body it does not
+// hold must treat the subscription as broken and resubscribe with no `have`.
+//
+// `as_of_seq` is the log position this window was true at, read in the same
+// transaction as the rows. `delivery` counts deliveries on this subscription,
+// starting at 1; it is named for what it counts because a document carries its
+// own `rev` and one word for both would read as though they were related. int32
+// rather than safeint because the counter is bounded by how long one connection
+// stays open, not by a document's whole history.
 model DocSubscribeResult {
   "delivery": int32;
-  "documents": StoredDocument[];
+  "as_of_seq": safeint;
+  "order": string[];
+  "upsert": StoredDocument[];
 }
 
 // ============================================================================
@@ -3717,9 +3758,12 @@ model Response {
   // `error` text. Present only where a caller has to branch on the answer:
   // `conflict` (retry after re-reading — `error_conflict` carries which
   // revisions disagreed), `undeclared_collection` (the collection is not
-  // there), `invalid_query` (the query itself is wrong). Everything else
-  // carries no code, and a client must treat an unknown code as "broken, stop"
-  // rather than matching the message text.
+  // there), `invalid_query` (the query itself is wrong), and the two that end a
+  // live subscription — `collection_undefined` (the collection was removed;
+  // kill the tile) and `collection_redeclared` (it no longer declares a field
+  // the query used; the tile's query needs rewriting). Everything else carries
+  // no code, and a client must treat an unknown code as "broken, stop" rather
+  // than matching the message text.
   error_code?: string;
   error_conflict?: DocumentConflict;
   data?: string;

--- a/internal/store/automations.go
+++ b/internal/store/automations.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/victorarias/attn/internal/docstore"
 )
 
 func parseOptionalAutomationTime(value string) *time.Time {
@@ -221,7 +222,7 @@ func clearAutomationReviewRequestEdgesTx(tx *sql.Tx, definitionID string, now ti
 // refresh started before this fence cannot launch work under the newly
 // enabled/reapplied revision.
 func fenceAutomationProviderCursorsTx(tx *sql.Tx, definitionID string, now time.Time) error {
-	fence := now.UTC().Format(time.RFC3339Nano)
+	fence := now.UTC().Format(sortableTimeFormat)
 	_, err := tx.Exec(`INSERT INTO automation_provider_cursors(definition_id,provider,scope,observed_at) VALUES(?,'github_review_requested','*',?) ON CONFLICT(definition_id,provider,scope) DO UPDATE SET observed_at=excluded.observed_at`, definitionID, fence)
 	return err
 }
@@ -720,7 +721,7 @@ func (s *Store) GetAutomationScheduleCursor(definitionID string) (time.Time, boo
 	if err != nil {
 		return time.Time{}, false, err
 	}
-	at, err := time.Parse(time.RFC3339Nano, raw)
+	at, err := docstore.ParseTime(raw)
 	if err != nil {
 		return time.Time{}, false, fmt.Errorf("parse automation schedule cursor: %w", err)
 	}
@@ -735,7 +736,7 @@ func (s *Store) SetAutomationScheduleCursor(definitionID string, at time.Time) e
 	if s.db == nil {
 		return errors.New("automation persistence unavailable")
 	}
-	_, err := s.db.Exec(`INSERT INTO automation_provider_cursors(definition_id,provider,scope,observed_at) VALUES(?,'schedule','*',?) ON CONFLICT(definition_id,provider,scope) DO UPDATE SET observed_at=excluded.observed_at`, definitionID, at.UTC().Format(time.RFC3339Nano))
+	_, err := s.db.Exec(`INSERT INTO automation_provider_cursors(definition_id,provider,scope,observed_at) VALUES(?,'schedule','*',?) ON CONFLICT(definition_id,provider,scope) DO UPDATE SET observed_at=excluded.observed_at`, definitionID, at.UTC().Format(sortableTimeFormat))
 	return err
 }
 
@@ -755,12 +756,12 @@ func (s *Store) ReconcileAutomationReviewRequests(definitionID, host string, sub
 		return nil, err
 	}
 	defer tx.Rollback()
-	observedRaw := observedAt.UTC().Format(time.RFC3339Nano)
+	observedRaw := observedAt.UTC().Format(sortableTimeFormat)
 	updatedRaw := formatTicketTime(observedAt)
 	var enableFenceRaw string
 	err = tx.QueryRow(`SELECT observed_at FROM automation_provider_cursors WHERE definition_id=? AND provider='github_review_requested' AND scope='*'`, definitionID).Scan(&enableFenceRaw)
 	if err == nil {
-		enableFence, parseErr := time.Parse(time.RFC3339Nano, enableFenceRaw)
+		enableFence, parseErr := docstore.ParseTime(enableFenceRaw)
 		if parseErr != nil {
 			return nil, fmt.Errorf("parse automation enable fence: %w", parseErr)
 		}
@@ -774,7 +775,7 @@ func (s *Store) ReconcileAutomationReviewRequests(definitionID, host string, sub
 	var cursorRaw string
 	err = tx.QueryRow(`SELECT observed_at FROM automation_provider_cursors WHERE definition_id=? AND provider='github_review_requested' AND scope=?`, definitionID, host).Scan(&cursorRaw)
 	if err == nil {
-		cursorAt, parseErr := time.Parse(time.RFC3339Nano, cursorRaw)
+		cursorAt, parseErr := docstore.ParseTime(cursorRaw)
 		if parseErr != nil {
 			return nil, fmt.Errorf("parse automation provider cursor: %w", parseErr)
 		}

--- a/internal/store/delegation_operations.go
+++ b/internal/store/delegation_operations.go
@@ -36,7 +36,7 @@ func (s *Store) ClaimDelegationOperation(requestID, operationID, sessionID, chie
 	if s.db == nil {
 		return nil, false, errors.New("delegation idempotency requires a database")
 	}
-	stamp := now.UTC().Format(time.RFC3339Nano)
+	stamp := now.UTC().Format(sortableTimeFormat)
 	result, err := s.db.Exec(`INSERT INTO delegation_operations
 		(request_id, operation_id, request_json, state, progress, session_id, chief_session_id, ticket_id, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -113,7 +113,7 @@ func getDelegationOperation(db *sql.DB, id string) (*DelegationOperationRecord, 
 func (s *Store) MarkDelegationWorktreeOwned(id, path, token string, now time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	stamp := now.UTC().Format(time.RFC3339Nano)
+	stamp := now.UTC().Format(sortableTimeFormat)
 	_, err := s.db.Exec(`UPDATE delegation_operations SET worktree_path = ?, worktree_owned = 1, worktree_token = ?, updated_at = ?
 		WHERE request_id = ? OR operation_id = ?`, path, token, stamp, id, id)
 	return err
@@ -137,7 +137,7 @@ func (s *Store) UpdateDelegationOperation(id string, state protocol.DelegationOp
 	if operationErr != nil {
 		errorText = operationErr.Error()
 	}
-	stamp := now.UTC().Format(time.RFC3339Nano)
+	stamp := now.UTC().Format(sortableTimeFormat)
 	_, err := s.db.Exec(`UPDATE delegation_operations SET state = ?, progress = ?,
 		workspace_id = CASE WHEN ? = '' THEN workspace_id ELSE ? END,
 		ticket_id = CASE WHEN ? = '' THEN ticket_id ELSE ? END,

--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -51,28 +51,34 @@ const documentColumns = `id, body, rev, created_at, updated_at`
 // Registry row and DDL commit together. A declaration whose table did not get
 // built, or a table no declaration names, would each be a collection that
 // cannot be queried or cannot be found.
-func (s *Store) DefineDocumentCollection(schema docstore.CollectionSchema, now time.Time) error {
+//
+// The returned bool reports whether this was a redeclaration of an existing
+// collection. Only the define's own transaction can tell — a caller checking
+// existence first would race a concurrent define — and the caller needs the
+// distinction because a redeclare has watchers to wake and a first declaration
+// cannot.
+func (s *Store) DefineDocumentCollection(schema docstore.CollectionSchema, now time.Time) (bool, error) {
 	if s.db == nil {
-		return fmt.Errorf("store: no database")
+		return false, fmt.Errorf("store: no database")
 	}
 	if err := schema.Validate(); err != nil {
-		return err
+		return false, err
 	}
 	fields, err := json.Marshal(schema.Fields)
 	if err != nil {
-		return fmt.Errorf("store: encoding fields for %s/%s: %w", schema.Namespace, schema.Collection, err)
+		return false, fmt.Errorf("store: encoding fields for %s/%s: %w", schema.Namespace, schema.Collection, err)
 	}
 	ts := now.UTC().Format(docstore.TimeFormat)
 
 	tx, err := s.db.Begin()
 	if err != nil {
-		return fmt.Errorf("store: defining %s/%s: %w", schema.Namespace, schema.Collection, err)
+		return false, fmt.Errorf("store: defining %s/%s: %w", schema.Namespace, schema.Collection, err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
 	existing, table, found, err := readCollectionTx(tx, schema.Namespace, schema.Collection)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if !found {
@@ -80,31 +86,31 @@ func (s *Store) DefineDocumentCollection(schema docstore.CollectionSchema, now t
 			`INSERT INTO document_collections (namespace, collection, fields_json, updated_at) VALUES (?, ?, ?, ?)`,
 			schema.Namespace, schema.Collection, string(fields), ts)
 		if err != nil {
-			return fmt.Errorf("store: defining %s/%s: %w", schema.Namespace, schema.Collection, err)
+			return false, fmt.Errorf("store: defining %s/%s: %w", schema.Namespace, schema.Collection, err)
 		}
 		id, err := res.LastInsertId()
 		if err != nil {
-			return fmt.Errorf("store: defining %s/%s: %w", schema.Namespace, schema.Collection, err)
+			return false, fmt.Errorf("store: defining %s/%s: %w", schema.Namespace, schema.Collection, err)
 		}
 		table = docstore.TableName(id)
 		if err := createCollectionTable(tx, table, schema.Fields); err != nil {
-			return fmt.Errorf("store: creating storage for %s/%s: %w", schema.Namespace, schema.Collection, err)
+			return false, fmt.Errorf("store: creating storage for %s/%s: %w", schema.Namespace, schema.Collection, err)
 		}
 	} else {
 		if err := alterCollectionTable(tx, table, existing.Fields, schema.Fields); err != nil {
-			return fmt.Errorf("store: redeclaring %s/%s: %w", schema.Namespace, schema.Collection, err)
+			return false, fmt.Errorf("store: redeclaring %s/%s: %w", schema.Namespace, schema.Collection, err)
 		}
 		if _, err := tx.Exec(
 			`UPDATE document_collections SET fields_json = ?, updated_at = ? WHERE namespace = ? AND collection = ?`,
 			string(fields), ts, schema.Namespace, schema.Collection); err != nil {
-			return fmt.Errorf("store: redeclaring %s/%s: %w", schema.Namespace, schema.Collection, err)
+			return false, fmt.Errorf("store: redeclaring %s/%s: %w", schema.Namespace, schema.Collection, err)
 		}
 	}
 
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("store: committing declaration of %s/%s: %w", schema.Namespace, schema.Collection, err)
+		return false, fmt.Errorf("store: committing declaration of %s/%s: %w", schema.Namespace, schema.Collection, err)
 	}
-	return nil
+	return found, nil
 }
 
 // DocumentCollection returns a collection's declaration with its table filled

--- a/internal/store/documents_model_test.go
+++ b/internal/store/documents_model_test.go
@@ -141,7 +141,7 @@ func newModelWorldFor(t *testing.T, decl docstore.CollectionSchema, ids []string
 	t.Helper()
 	s := New()
 	base := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
-	if err := s.DefineDocumentCollection(decl, base); err != nil {
+	if _, err := s.DefineDocumentCollection(decl, base); err != nil {
 		t.Fatalf("define: %v", err)
 	}
 	schema := declOf(t, s, decl.Namespace, decl.Collection)
@@ -1007,7 +1007,7 @@ func (w *modelWorld) checkFullPagination(context string, rng *rand.Rand, ids []s
 // match, since the dumb table's columns mirror the declared fields.
 func (w *modelWorld) redeclare(decl docstore.CollectionSchema, now time.Time) {
 	w.t.Helper()
-	if err := w.s.DefineDocumentCollection(decl, now); err != nil {
+	if _, err := w.s.DefineDocumentCollection(decl, now); err != nil {
 		w.t.Fatalf("redeclare: %v", err)
 	}
 	w.schema = declOf(w.t, w.s, decl.Namespace, decl.Collection)

--- a/internal/store/documents_positioned_test.go
+++ b/internal/store/documents_positioned_test.go
@@ -229,7 +229,7 @@ func TestReadingAnUndeclaredCollectionSaysSo(t *testing.T) {
 func TestACountAgreesWithTheQueryItCounts(t *testing.T) {
 	s := New()
 	base := time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC)
-	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+	if _, err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
 		t.Fatalf("define: %v", err)
 	}
 	schema := requestsDecl(t, s)

--- a/internal/store/documents_read_window_test.go
+++ b/internal/store/documents_read_window_test.go
@@ -129,7 +129,7 @@ func TestAFilterIsBoundUnderTheDeclarationItRunsAgainst(t *testing.T) {
 			next.Fields[i].Type = docstore.FieldString
 		}
 	}
-	if err := s.DefineDocumentCollection(next, base.Add(time.Hour)); err != nil {
+	if _, err := s.DefineDocumentCollection(next, base.Add(time.Hour)); err != nil {
 		t.Fatalf("redeclare: %v", err)
 	}
 

--- a/internal/store/documents_test.go
+++ b/internal/store/documents_test.go
@@ -31,7 +31,7 @@ func storeWithRequests(t *testing.T, bodies map[string]string) (*Store, time.Tim
 	t.Helper()
 	s := New()
 	base := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
-	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+	if _, err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
 		t.Fatalf("define: %v", err)
 	}
 	i := 0
@@ -107,7 +107,7 @@ func queryIDs(t *testing.T, s *Store, q docstore.Query) []string {
 func TestADeclarationRoundTripsThroughTheDatabase(t *testing.T) {
 	s := New()
 	now := time.Now().UTC()
-	if err := s.DefineDocumentCollection(requestsDeclaration(), now); err != nil {
+	if _, err := s.DefineDocumentCollection(requestsDeclaration(), now); err != nil {
 		t.Fatalf("define: %v", err)
 	}
 	got, ok, err := s.DocumentCollection("ext/approval-gate", "requests")
@@ -132,7 +132,7 @@ func TestRedeclaringAddsAQueryableFieldWithoutTouchingDocuments(t *testing.T) {
 	})
 	schema := requestsDeclaration()
 	schema.Fields = append(schema.Fields, docstore.FieldSpec{Name: "note", Type: docstore.FieldString})
-	if err := s.DefineDocumentCollection(schema, base); err != nil {
+	if _, err := s.DefineDocumentCollection(schema, base); err != nil {
 		t.Fatalf("redefine: %v", err)
 	}
 	ids := queryIDs(t, s, docstore.Query{
@@ -371,7 +371,7 @@ func TestPagingAnUnsortedQuery(t *testing.T) {
 func TestPagingByCreatedAtWithIdenticalTimestamps(t *testing.T) {
 	s := New()
 	base := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
-	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+	if _, err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
 		t.Fatalf("define: %v", err)
 	}
 	for _, id := range []string{"a", "b", "c"} {
@@ -418,7 +418,7 @@ func TestTwoNamespacesWithTheSameCollectionNameStaySeparate(t *testing.T) {
 	s, base := storeWithRequests(t, map[string]string{"shared-id": `{"status":"pending"}`})
 	other := requestsDeclaration()
 	other.Namespace = "ext/other"
-	if err := s.DefineDocumentCollection(other, base); err != nil {
+	if _, err := s.DefineDocumentCollection(other, base); err != nil {
 		t.Fatalf("define other: %v", err)
 	}
 	if _, err := s.PutDocument(declOf(t, s, "ext/other", "requests"), "shared-id", []byte(`{"status":"approved"}`), base, nil); err != nil {
@@ -666,7 +666,7 @@ func TestConcurrentReadModifyWritesLoseNoUpdate(t *testing.T) {
 		t.Fatalf("open: %v", err)
 	}
 	defer s.Close()
-	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+	if _, err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
 		t.Fatalf("define: %v", err)
 	}
 	schema := requestsDecl(t, s)
@@ -780,7 +780,7 @@ func TestCountIsScopedToTheCollection(t *testing.T) {
 	s, base := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`, "b": `{"status":"pending"}`})
 	other := requestsDeclaration()
 	other.Namespace = "ext/other"
-	if err := s.DefineDocumentCollection(other, base); err != nil {
+	if _, err := s.DefineDocumentCollection(other, base); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := s.PutDocument(declOf(t, s, "ext/other", "requests"), "z", []byte(`{"status":"x"}`), base, nil); err != nil {
@@ -839,7 +839,7 @@ func TestDocumentsSurviveReopeningTheDatabase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	if err := first.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+	if _, err := first.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
 		t.Fatalf("define: %v", err)
 	}
 	if _, err := first.PutDocument(declOf(t, first, "ext/approval-gate", "requests"), "a", []byte(`{"status":"pending"}`), base, nil); err != nil {
@@ -1082,7 +1082,7 @@ func TestCollectionsWithTheSameFieldNameDoNotShareStorage(t *testing.T) {
 			Namespace: "ext/approval-gate", Collection: coll,
 			Fields: []docstore.FieldSpec{{Name: "status", Type: docstore.FieldString}},
 		}
-		if err := s.DefineDocumentCollection(schema, now); err != nil {
+		if _, err := s.DefineDocumentCollection(schema, now); err != nil {
 			t.Fatalf("define %s: %v", coll, err)
 		}
 		if _, err := s.PutDocument(declOf(t, s, "ext/approval-gate", coll), coll+"-1",
@@ -1107,7 +1107,7 @@ func TestRedeclaringRemovesAFieldAndCanBringItBack(t *testing.T) {
 	})
 	withoutUrgent := requestsDeclaration()
 	withoutUrgent.Fields = withoutUrgent.Fields[:2]
-	if err := s.DefineDocumentCollection(withoutUrgent, base); err != nil {
+	if _, err := s.DefineDocumentCollection(withoutUrgent, base); err != nil {
 		t.Fatalf("redeclare without urgent: %v", err)
 	}
 
@@ -1120,7 +1120,7 @@ func TestRedeclaringRemovesAFieldAndCanBringItBack(t *testing.T) {
 		t.Fatal("filtering on an undeclared field compiled; it must be rejected")
 	}
 
-	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+	if _, err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
 		t.Fatalf("redeclare with urgent: %v", err)
 	}
 	got := queryIDs(t, s, docstore.Query{
@@ -1142,7 +1142,7 @@ func TestRedeclaringAFieldsTypeChangesHowItCompares(t *testing.T) {
 	})
 	asText := requestsDeclaration()
 	asText.Fields[1] = docstore.FieldSpec{Name: "attempts", Type: docstore.FieldString}
-	if err := s.DefineDocumentCollection(asText, base); err != nil {
+	if _, err := s.DefineDocumentCollection(asText, base); err != nil {
 		t.Fatalf("redeclare attempts as string: %v", err)
 	}
 	got := queryIDs(t, s, docstore.Query{
@@ -1175,7 +1175,7 @@ func TestUndefiningDropsTheStorageAndRedeclaringStartsEmpty(t *testing.T) {
 		t.Fatalf("declaration after undefine: ok=%v err=%v", ok, err)
 	}
 
-	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+	if _, err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
 		t.Fatalf("redefine: %v", err)
 	}
 	after := declOf(t, s, "ext/approval-gate", "requests")
@@ -1356,7 +1356,7 @@ func seedPreRevisionDocuments(t *testing.T, dbPath string) {
 		t.Fatalf("open for seeding: %v", err)
 	}
 	base := time.Date(2026, 8, 3, 9, 0, 0, 0, time.UTC)
-	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+	if _, err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
 		t.Fatalf("seed declaration: %v", err)
 	}
 	schema := declOf(t, s, "ext/approval-gate", "requests")

--- a/internal/store/documents_timestamps_test.go
+++ b/internal/store/documents_timestamps_test.go
@@ -36,7 +36,7 @@ func storeWithRaggedStamps(t *testing.T) (*Store, docstore.CollectionSchema, tim
 	t.Helper()
 	s := New()
 	base := time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC)
-	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+	if _, err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
 		t.Fatalf("define: %v", err)
 	}
 	schema := declOf(t, s, "ext/approval-gate", "requests")
@@ -221,7 +221,7 @@ func TestMigration91RewritesStampsThatDoNotSort(t *testing.T) {
 	defer s.Close()
 
 	base := time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC)
-	if err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
+	if _, err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
 		t.Fatalf("define: %v", err)
 	}
 	schema := declOf(t, s, "ext/approval-gate", "requests")

--- a/internal/store/endpoints.go
+++ b/internal/store/endpoints.go
@@ -4,11 +4,22 @@ import (
 	"database/sql"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/victorarias/attn/internal/config"
-	"github.com/victorarias/attn/internal/protocol"
 )
+
+// endpointStamp is the instant an endpoint row was written, in the encoding the
+// listing orders by. It is deliberately not protocol.TimestampNow(): that renders
+// time.Now() in the local zone with a trailing-zero-stripped fraction, and
+// created_at is ORDER BY'd as text, so two rows written either side of a DST
+// change or in different fraction widths came back in an order that was not
+// theirs. sortableTimeFormat is UTC and fixed-width, so text order is time order.
+//
+// The value stays an RFC3339 string on the same protocol.Timestamp wire field —
+// this narrows which RFC3339 spelling is written, it does not change the type.
+func endpointStamp() string { return time.Now().UTC().Format(sortableTimeFormat) }
 
 type EndpointRecord struct {
 	ID        string
@@ -41,7 +52,7 @@ func (s *Store) AddEndpoint(name, sshTarget, profile string) (*EndpointRecord, e
 		return nil, sql.ErrConnDone
 	}
 
-	now := string(protocol.TimestampNow())
+	now := endpointStamp()
 	record := &EndpointRecord{
 		ID:        uuid.NewString(),
 		Name:      strings.TrimSpace(name),
@@ -186,7 +197,7 @@ func (s *Store) UpdateEndpoint(id string, update EndpointUpdate) (*EndpointRecor
 	if update.Profile != nil {
 		record.Profile = *update.Profile
 	}
-	record.UpdatedAt = string(protocol.TimestampNow())
+	record.UpdatedAt = endpointStamp()
 
 	if _, err := s.db.Exec(`
 		UPDATE endpoints

--- a/internal/store/jobs.go
+++ b/internal/store/jobs.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"fmt"
 	"time"
+
+	"github.com/victorarias/attn/internal/docstore"
 )
 
 // This is the SQLite persistence for the durable job queue (internal/jobs).
@@ -13,10 +15,24 @@ import (
 // keeps this package a leaf (internal/store imports neither internal/jobs nor
 // internal/daemon).
 
-// jobTimeFormat is the stored timestamp encoding. RFC3339Nano preserves the
-// sub-second precision the queue's backoff and debounce timing relies on, and it
-// sorts lexicographically, which is what lets scheduled_at be an index term.
-const jobTimeFormat = time.RFC3339Nano
+// sortableTimeFormat is the stored timestamp encoding for the two surfaces in
+// this package that keep their stamps in TEXT columns and compare them there:
+// the job queue (scheduled_at, created_at, updated_at) and the notifications
+// feed (created_at). Text order has to be time order, which takes a fraction of
+// a fixed width, always present and always nine digits.
+//
+// time.RFC3339Nano, which this used to be, does not: it strips trailing zeros,
+// so widths vary and "…:00Z" sorts above "…:00.5Z" ('Z' is 0x5A, above '.' and
+// every digit). Within one second the two orders disagreed, which made a job
+// scheduled on a whole second wait out the rest of that second before
+// `scheduled_at <= now` claimed it, and scrambled both feeds' listings among
+// rows written in the same second. Migration 93 rewrote the stored stamps.
+//
+// It is docstore.TimeFormat: the document store hit the same defect and this is
+// the same fix, so there is one spelling of it rather than two that must be kept
+// in step. Always formatted from a UTC time, so the zone is always "Z" and every
+// stored stamp is the same 30 characters wide.
+const sortableTimeFormat = docstore.TimeFormat
 
 // rowScanner is satisfied by both *sql.Row and *sql.Rows, so one scan helper
 // serves a single-row lookup and a listing. It lives here because the job queue
@@ -84,9 +100,9 @@ func upsertJob(ex execer, rec JobRecord) error {
 		   created_at=excluded.created_at,
 		   updated_at=excluded.updated_at`,
 		rec.ID, rec.Kind, rec.UniqueKey, rec.Priority, rec.Payload, rec.Result, rec.State,
-		rec.Attempts, rec.MaxAttempts, rec.ScheduledAt.UTC().Format(jobTimeFormat),
+		rec.Attempts, rec.MaxAttempts, rec.ScheduledAt.UTC().Format(sortableTimeFormat),
 		rec.LastError, boolToInt(rec.Requeued),
-		rec.CreatedAt.UTC().Format(jobTimeFormat), rec.UpdatedAt.UTC().Format(jobTimeFormat),
+		rec.CreatedAt.UTC().Format(sortableTimeFormat), rec.UpdatedAt.UTC().Format(sortableTimeFormat),
 	)
 	if err != nil {
 		return fmt.Errorf("store: upsert job %s: %w", rec.ID, err)
@@ -170,7 +186,7 @@ func (s *Store) EligibleJobs(now time.Time, limit int) ([]JobRecord, error) {
 		 WHERE state IN ('queued', 'failed') AND scheduled_at <= ?
 		 ORDER BY priority DESC, scheduled_at ASC, created_at ASC
 		 LIMIT ?`,
-		now.UTC().Format(jobTimeFormat), limit)
+		now.UTC().Format(sortableTimeFormat), limit)
 	if err != nil {
 		return nil, fmt.Errorf("store: eligible jobs: %w", err)
 	}
@@ -185,7 +201,7 @@ func (s *Store) RecoverRunningJobs(now time.Time) (int, error) {
 	if s.db == nil {
 		return 0, fmt.Errorf("store: no database")
 	}
-	ts := now.UTC().Format(jobTimeFormat)
+	ts := now.UTC().Format(sortableTimeFormat)
 	res, err := s.db.Exec(
 		`UPDATE jobs SET state='queued', scheduled_at=?, updated_at=? WHERE state='running'`, ts, ts)
 	if err != nil {
@@ -207,7 +223,7 @@ func (s *Store) TrimDoneJobs(cutoff time.Time) (int, error) {
 		return 0, fmt.Errorf("store: no database")
 	}
 	res, err := s.db.Exec(
-		`DELETE FROM jobs WHERE state='done' AND updated_at < ?`, cutoff.UTC().Format(jobTimeFormat))
+		`DELETE FROM jobs WHERE state='done' AND updated_at < ?`, cutoff.UTC().Format(sortableTimeFormat))
 	if err != nil {
 		return 0, fmt.Errorf("store: trim done jobs: %w", err)
 	}
@@ -249,19 +265,16 @@ func scanJobRow(sc rowScanner) (*JobRecord, error) {
 	return &rec, nil
 }
 
-// parseStoreTime decodes a stored timestamp, tolerating the plain RFC3339 form as
-// well as RFC3339Nano. A blank/garbage value yields the zero time rather than an
-// error — a job with an unreadable timestamp is still a real record, and the
-// queue treats a zero scheduled_at as "eligible now".
+// parseStoreTime decodes a stored timestamp in any RFC3339 form — the
+// fixed-width one written today, the trailing-zero-stripped one written before
+// migration 93, or a whole second with no fraction at all. A blank/garbage value
+// yields the zero time rather than an error: a job with an unreadable timestamp
+// is still a real record, and the queue treats a zero scheduled_at as
+// "eligible now".
 func parseStoreTime(s string) time.Time {
-	if s == "" {
+	t, err := docstore.ParseTime(s)
+	if err != nil {
 		return time.Time{}
 	}
-	if t, err := time.Parse(jobTimeFormat, s); err == nil {
-		return t.UTC()
-	}
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t.UTC()
-	}
-	return time.Time{}
+	return t
 }

--- a/internal/store/jobs_timestamps_test.go
+++ b/internal/store/jobs_timestamps_test.go
@@ -1,0 +1,281 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// scheduled_at, created_at and updated_at are TEXT columns, so every comparison
+// the queue makes on them — claiming (`scheduled_at <= now`), listing
+// (`ORDER BY updated_at DESC`), retention (`updated_at < cutoff`) — is a text
+// comparison, and the stored encoding is the whole definition of "before". Rows
+// a second apart cannot tell a working encoding from a broken one: what has to
+// be right is what happens inside one second, which is where a burst of enqueues
+// and a whole-second schedule both land.
+//
+// Every fixture here therefore uses sub-second offsets whose
+// trailing-zero-stripped encodings sort in an order that is not their own,
+// including the whole second itself — under RFC3339Nano "…:00Z" sorts above
+// every stamp in its own second, because 'Z' is 0x5A and '.' and the digits are
+// below it.
+
+// raggedJobOffsets are ids in chronological order with the sub-second offsets
+// that separate them, all inside one second.
+var raggedJobOffsets = []struct {
+	id     string
+	offset time.Duration
+}{
+	{"j0", 0},
+	{"j1234", 123400 * time.Microsecond},
+	{"j12345", 123450 * time.Microsecond},
+	{"j5", 500 * time.Millisecond},
+}
+
+func jobBase() time.Time { return time.Date(2026, 8, 6, 10, 0, 0, 0, time.UTC) }
+
+func jobIDs(recs []JobRecord) []string {
+	out := make([]string, 0, len(recs))
+	for _, r := range recs {
+		out = append(out, r.ID)
+	}
+	return out
+}
+
+func chronologicalJobIDs() []string {
+	out := make([]string, 0, len(raggedJobOffsets))
+	for _, r := range raggedJobOffsets {
+		out = append(out, r.id)
+	}
+	return out
+}
+
+// storeWithRaggedJobs writes the four jobs, each scheduled, created and updated
+// at its own instant inside one second.
+func storeWithRaggedJobs(t *testing.T) *Store {
+	t.Helper()
+	s := New()
+	for _, r := range raggedJobOffsets {
+		if err := s.UpsertJob(newJobRecord(r.id, "compact_context", jobBase().Add(r.offset))); err != nil {
+			t.Fatalf("upsert %s: %v", r.id, err)
+		}
+	}
+	return s
+}
+
+// The claim boundary. A job scheduled on a whole second is the ordinary case —
+// it is what a whole-second clock and a hand-written schedule both produce — and
+// under the old encoding it sorted above every stamp inside that second, so
+// `scheduled_at <= now` refused it until the next second ticked over. A second
+// of wobble on every such job, reported nowhere.
+func TestAJobScheduledOnAWholeSecondIsClaimableAtThatSecond(t *testing.T) {
+	s := New()
+	at := jobBase()
+	if err := s.UpsertJob(newJobRecord("whole", "compact_context", at)); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	for _, now := range []time.Time{at, at.Add(time.Millisecond), at.Add(500 * time.Millisecond)} {
+		got, err := s.EligibleJobs(now, 10)
+		if err != nil {
+			t.Fatalf("eligible jobs at %v: %v", now, err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("a job scheduled at %s was not claimable at %s: got %v",
+				at.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano), jobIDs(got))
+		}
+	}
+}
+
+// Claiming order is what decides which job runs first when more are eligible
+// than the sweep will take, and the tie-break within one priority is
+// scheduled_at. Four jobs enqueued inside one second must come back in the order
+// they were scheduled for, not in the order their text happens to sort.
+func TestEligibleJobsComeBackInScheduledOrderWithinASecond(t *testing.T) {
+	s := storeWithRaggedJobs(t)
+
+	got, err := s.EligibleJobs(jobBase().Add(time.Second), 10)
+	if err != nil {
+		t.Fatalf("eligible jobs: %v", err)
+	}
+	if want := chronologicalJobIDs(); !sameOrder(jobIDs(got), want) {
+		t.Fatalf("eligible jobs came back as %v, want %v", jobIDs(got), want)
+	}
+}
+
+// ListJobs is the queue's inspection surface (`attn jobs`), and it promises
+// newest-updated first.
+func TestListJobsIsNewestUpdatedFirstWithinASecond(t *testing.T) {
+	s := storeWithRaggedJobs(t)
+
+	got, err := s.ListJobs()
+	if err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	if want := reversed(chronologicalJobIDs()); !sameOrder(jobIDs(got), want) {
+		t.Fatalf("list jobs came back as %v, want %v", jobIDs(got), want)
+	}
+}
+
+// Retention deletes done rows updated before a cutoff. With the cutoff inside a
+// second, the rows updated before it must go and the ones updated after it must
+// stay — under the old encoding the row updated exactly on the second survived a
+// cutoff later than it, because its text sorted above the cutoff's.
+func TestTrimDoneJobsDeletesByTimeWithinASecond(t *testing.T) {
+	s := New()
+	for _, r := range raggedJobOffsets {
+		rec := newJobRecord(r.id, "compact_context", jobBase().Add(r.offset))
+		rec.State = "done"
+		if err := s.UpsertJob(rec); err != nil {
+			t.Fatalf("upsert %s: %v", r.id, err)
+		}
+	}
+
+	n, err := s.TrimDoneJobs(jobBase().Add(200 * time.Millisecond))
+	if err != nil {
+		t.Fatalf("trim: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("trimmed %d jobs, want the 3 updated before the cutoff", n)
+	}
+	left, err := s.ListJobs()
+	if err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	if want := []string{"j5"}; !sameOrder(jobIDs(left), want) {
+		t.Fatalf("trim left %v, want %v", jobIDs(left), want)
+	}
+}
+
+// The notifications feed stores its stamps in the same encoding and lists by
+// created_at, so a burst of failures inside one second is where its order breaks.
+func TestNotificationsListNewestFirstWithinASecond(t *testing.T) {
+	s := New()
+	for _, r := range raggedJobOffsets {
+		if _, err := s.AddNotification(
+			NotificationRecord{Kind: "task_failed", Title: r.id}, jobBase().Add(r.offset)); err != nil {
+			t.Fatalf("add notification %s: %v", r.id, err)
+		}
+	}
+
+	got, err := s.ListNotifications()
+	if err != nil {
+		t.Fatalf("list notifications: %v", err)
+	}
+	titles := make([]string, 0, len(got))
+	for _, n := range got {
+		titles = append(titles, n.Title)
+	}
+	if want := reversed(chronologicalJobIDs()); !sameOrder(titles, want) {
+		t.Fatalf("notifications came back as %v, want %v", titles, want)
+	}
+}
+
+// Migration 93 rewrites what earlier versions stored. Its input is the encoding
+// they wrote, so the test writes that encoding rather than describing it: the
+// stamps go in the way an older store would have written them, the migration
+// runs, and the claim and the order that were wrong come back right.
+func TestMigration93RewritesJobAndNotificationStampsThatDoNotSort(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB: %v", err)
+	}
+	defer s.Close()
+
+	for _, r := range raggedJobOffsets {
+		if err := s.UpsertJob(newJobRecord(r.id, "compact_context", jobBase().Add(r.offset))); err != nil {
+			t.Fatalf("upsert %s: %v", r.id, err)
+		}
+		if _, err := s.AddNotification(
+			NotificationRecord{Kind: "task_failed", Title: r.id}, jobBase().Add(r.offset)); err != nil {
+			t.Fatalf("add notification %s: %v", r.id, err)
+		}
+	}
+
+	// Roll the stamps back to the encoding migration 93 exists to replace, and
+	// plant one value it cannot read, which it must leave alone rather than turn
+	// into year 1. read_at stays '' on every notification: an unread row's
+	// sentinel is not a stamp that failed to parse, and the migration must leave
+	// it as it is too.
+	for _, r := range raggedJobOffsets {
+		old := jobBase().Add(r.offset).Format(time.RFC3339Nano)
+		if _, err := s.db.Exec(
+			`UPDATE jobs SET scheduled_at = ?, created_at = ?, updated_at = ? WHERE id = ?`,
+			old, old, old, r.id); err != nil {
+			t.Fatalf("plant old job stamp for %s: %v", r.id, err)
+		}
+		if _, err := s.db.Exec(
+			`UPDATE notifications SET created_at = ? WHERE title = ?`, old, r.id); err != nil {
+			t.Fatalf("plant old notification stamp for %s: %v", r.id, err)
+		}
+	}
+	if _, err := s.db.Exec(
+		`UPDATE jobs SET created_at = 'not a timestamp' WHERE id = ?`, "j5"); err != nil {
+		t.Fatalf("plant unreadable stamp: %v", err)
+	}
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version >= 93`); err != nil {
+		t.Fatalf("unrecord migration 93: %v", err)
+	}
+
+	// Sanity: the planted state is the broken one, so a pass here would mean the
+	// test proves nothing.
+	if got, err := s.EligibleJobs(jobBase(), 10); err != nil {
+		t.Fatal(err)
+	} else if len(got) != 0 {
+		t.Fatalf("the planted stamps already claim correctly (%v); this test would pass without the migration", jobIDs(got))
+	}
+
+	if err := migrateDB(s.db, dbPath); err != nil {
+		t.Fatalf("migrateDB: %v", err)
+	}
+	assertMigration93Applied(t, s)
+
+	// Re-running finds nothing left to do and changes nothing: the rewrite is a
+	// decode and re-encode, so an already-converted stamp yields itself.
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version >= 93`); err != nil {
+		t.Fatalf("unrecord migration 93 again: %v", err)
+	}
+	if err := migrateDB(s.db, dbPath); err != nil {
+		t.Fatalf("re-run migrateDB: %v", err)
+	}
+	assertMigration93Applied(t, s)
+}
+
+// assertMigration93Applied is the post-migration state: the whole-second job is
+// claimable at its own second, both feeds order by time, the stamp that does not
+// decode is untouched, and an unread notification is still unread.
+func assertMigration93Applied(t *testing.T, s *Store) {
+	t.Helper()
+	got, err := s.EligibleJobs(jobBase(), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"j0"}; !sameOrder(jobIDs(got), want) {
+		t.Fatalf("after migration 93 the jobs claimable at the whole second are %v, want %v", jobIDs(got), want)
+	}
+
+	notes, err := s.ListNotifications()
+	if err != nil {
+		t.Fatal(err)
+	}
+	titles := make([]string, 0, len(notes))
+	for _, n := range notes {
+		titles = append(titles, n.Title)
+	}
+	if want := reversed(chronologicalJobIDs()); !sameOrder(titles, want) {
+		t.Fatalf("after migration 93 the notifications list as %v, want %v", titles, want)
+	}
+	for _, n := range notes {
+		if !n.ReadAt.IsZero() {
+			t.Fatalf("notification %q came back read; read_at must stay the unread sentinel", n.Title)
+		}
+	}
+	var unreadable string
+	if err := s.db.QueryRow(`SELECT created_at FROM jobs WHERE id = ?`, "j5").Scan(&unreadable); err != nil {
+		t.Fatal(err)
+	}
+	if unreadable != "not a timestamp" {
+		t.Fatalf("the unreadable stamp became %q; it must be left as it was", unreadable)
+	}
+}

--- a/internal/store/legacy_tasks_test.go
+++ b/internal/store/legacy_tasks_test.go
@@ -12,8 +12,8 @@ func seedLegacyTask(t *testing.T, s *Store, id, kind, subject, state, meta strin
 	_, err := s.db.Exec(
 		`INSERT INTO tasks (id, kind, subject, state, attempts, next_attempt_at, last_error, meta_json, requeued, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		id, kind, subject, state, 2, at.Format(jobTimeFormat), "boom", meta, 1,
-		at.Format(jobTimeFormat), at.Format(jobTimeFormat))
+		id, kind, subject, state, 2, at.Format(sortableTimeFormat), "boom", meta, 1,
+		at.Format(sortableTimeFormat), at.Format(sortableTimeFormat))
 	if err != nil {
 		t.Fatalf("seed legacy task %s: %v", id, err)
 	}

--- a/internal/store/notifications.go
+++ b/internal/store/notifications.go
@@ -15,8 +15,9 @@ import (
 // daemon owns the mapping to the protocol shape — keeping this package a leaf.
 //
 // read_at is persisted as '' while unread and as a timestamp once read. Timestamps
-// reuse the jobs table's RFC3339Nano encoding and parseStoreTime decoder (same
-// package), so a blank/garbage value decodes to the zero time.
+// reuse the jobs table's sortableTimeFormat encoding and parseStoreTime decoder
+// (same package), so a blank/garbage value decodes to the zero time. The encoding
+// is the fixed-width one because created_at orders this feed as text.
 
 // NotificationRecord is one durable notification row. ReadAt is the zero time
 // while unread; a non-zero ReadAt marks it read.
@@ -47,7 +48,7 @@ func (s *Store) AddNotification(rec NotificationRecord, now time.Time) (Notifica
 		`INSERT INTO notifications (id, kind, title, body, detail, source_kind, source_id, created_at, read_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, '')`,
 		rec.ID, rec.Kind, rec.Title, rec.Body, rec.Detail, rec.SourceKind, rec.SourceID,
-		rec.CreatedAt.Format(notificationTimeFormat),
+		rec.CreatedAt.Format(sortableTimeFormat),
 	)
 	if err != nil {
 		return NotificationRecord{}, fmt.Errorf("store: add notification: %w", err)
@@ -101,7 +102,7 @@ func (s *Store) MarkNotificationRead(id string, now time.Time) error {
 	}
 	if _, err := s.db.Exec(
 		`UPDATE notifications SET read_at = ? WHERE id = ? AND read_at = ''`,
-		now.UTC().Format(notificationTimeFormat), id); err != nil {
+		now.UTC().Format(sortableTimeFormat), id); err != nil {
 		return fmt.Errorf("store: mark notification read %s: %w", id, err)
 	}
 	return nil
@@ -115,7 +116,7 @@ func (s *Store) MarkAllNotificationsRead(now time.Time) (int, error) {
 	}
 	res, err := s.db.Exec(
 		`UPDATE notifications SET read_at = ? WHERE read_at = ''`,
-		now.UTC().Format(notificationTimeFormat))
+		now.UTC().Format(sortableTimeFormat))
 	if err != nil {
 		return 0, fmt.Errorf("store: mark all notifications read: %w", err)
 	}
@@ -125,10 +126,6 @@ func (s *Store) MarkAllNotificationsRead(now time.Time) (int, error) {
 	}
 	return int(n), nil
 }
-
-// notificationTimeFormat matches the jobs table so both surfaces round-trip
-// timestamps identically.
-const notificationTimeFormat = time.RFC3339Nano
 
 func scanNotificationRow(sc rowScanner) (*NotificationRecord, error) {
 	var (

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -933,6 +933,13 @@ CREATE TABLE IF NOT EXISTS document_collections (
 	// the queue without dragging its workspace along, and the satellite link
 	// from a shell to the agent it was split from. Applied by applyMigration92.
 	{92, "add the session pin and the satellite parent to sessions", ``},
+	// The same rewrite migration 91 did for documents, for the two other TEXT
+	// stamp columns this package compares as text: the job queue's and the
+	// notifications feed's. A job's scheduled_at is compared against now on every
+	// dispatch sweep, and both feeds list by a stamp, so a variable-width fraction
+	// held a job scheduled on a whole second back until the next second and
+	// scrambled rows written inside one second. Applied by applyMigration93.
+	{93, "store job and notification timestamps in an encoding that sorts", ``},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -1218,6 +1225,11 @@ func migrateDB(db *sql.DB, dbPath string) error {
 			}
 		} else if m.version == 92 {
 			if err := applyMigration92(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 93 {
+			if err := applyMigration93(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -2383,10 +2395,46 @@ func collectionTableIDs(tx *sql.Tx) ([]int64, error) {
 	return ids, rows.Err()
 }
 
+// applyMigration93 rewrites the job queue's and the notifications feed's stored
+// stamps into sortableTimeFormat, for the same reason migration 91 rewrote the
+// document store's: they are TEXT columns compared as text, and the encoding
+// they were written in stripped trailing zeros from the fraction, so text order
+// was not time order inside any one second.
+//
+// The two surfaces move together because they always shared one encoding, and
+// what the wrong one cost them differed: a job scheduled on a whole second sorted
+// above every stamp within that second, so `scheduled_at <= now` did not claim it
+// until the next second, and both feeds' listings (jobs by updated_at,
+// notifications by created_at) came back out of order among rows written
+// together.
+//
+// Idempotent by construction — re-encoding an already-converted stamp yields
+// itself — and an undecodable stamp is left alone and reported, both properties
+// inherited from restampTable. An unread notification's read_at is ” by design;
+// restampTable skips a blank without counting it.
+func applyMigration93(tx *sql.Tx) error {
+	unreadable, err := restampTable(tx, "jobs", "id",
+		[]string{"scheduled_at", "created_at", "updated_at"})
+	if err != nil {
+		return fmt.Errorf("restamping jobs: %w", err)
+	}
+	n, err := restampTable(tx, "notifications", "id", []string{"created_at", "read_at"})
+	if err != nil {
+		return fmt.Errorf("restamping notifications: %w", err)
+	}
+	unreadable += n
+	if unreadable > 0 {
+		log.Printf("[store] migration 93: left %d job/notification timestamp(s) as they were; they are not RFC3339 and cannot be re-encoded", unreadable)
+	}
+	return nil
+}
+
 // restampTable re-encodes the named stamp columns of every row, returning how
-// many values it could not decode and therefore did not touch. Rows are read out
-// before any are written back, because the driver holds one connection and a
-// write issued while a read is still streaming deadlocks against it.
+// many values it could not decode and therefore did not touch. A blank value is
+// skipped and not counted: it is a column's own "no time here" sentinel, not a
+// timestamp that failed to parse. Rows are read out before any are written back,
+// because the driver holds one connection and a write issued while a read is
+// still streaming deadlocks against it.
 func restampTable(tx *sql.Tx, table, key string, columns []string) (int, error) {
 	rows, err := tx.Query(fmt.Sprintf(`SELECT %s, %s FROM %s`, key, strings.Join(columns, ", "), table))
 	if err != nil {
@@ -2420,6 +2468,9 @@ func restampTable(tx *sql.Tx, table, key string, columns []string) (int, error) 
 		sets := make([]string, 0, len(columns))
 		args := make([]any, 0, len(columns)+1)
 		for i, c := range columns {
+			if r.stamps[i] == "" {
+				continue
+			}
 			t, err := docstore.ParseTime(r.stamps[i])
 			if err != nil {
 				unreadable++

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -940,6 +940,13 @@ CREATE TABLE IF NOT EXISTS document_collections (
 	// held a job scheduled on a whole second back until the next second and
 	// scrambled rows written inside one second. Applied by applyMigration93.
 	{93, "store job and notification timestamps in an encoding that sorts", ``},
+	// The last of the rewrite migrations 91 and 93 began, for every remaining TEXT
+	// stamp this package compares or orders as text: the turn stamps that decide
+	// whether a session owes the user a turn, the automation provider cursor that
+	// gates a review-request observation, and the created_at that orders
+	// delegations, endpoints, workspaces and workspace panes. Applied by
+	// applyMigration94.
+	{94, "store turn, cursor and listing timestamps in an encoding that sorts", ``},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -1230,6 +1237,11 @@ func migrateDB(db *sql.DB, dbPath string) error {
 			}
 		} else if m.version == 93 {
 			if err := applyMigration93(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 94 {
+			if err := applyMigration94(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -2425,6 +2437,86 @@ func applyMigration93(tx *sql.Tx) error {
 	unreadable += n
 	if unreadable > 0 {
 		log.Printf("[store] migration 93: left %d job/notification timestamp(s) as they were; they are not RFC3339 and cannot be re-encoded", unreadable)
+	}
+	return nil
+}
+
+// applyMigration94 finishes what migrations 91 and 93 started: after it, no TEXT
+// stamp this package compares or orders as text is written in an encoding whose
+// text order is not time order.
+//
+// What each column cost while it was wrong:
+//
+//   - sessions.turn_opened_at / turn_settled_at are compared against each other
+//     ("a turn is open iff opened > settled"), so a turn settled inside the
+//     second it was opened in read as still open and the next turn silently never
+//     opened. Whole-second opens are routine, not a coincidence: a day-named
+//     snooze wakes on an exact second and the woken turn is stamped with that
+//     deadline. turn_snoozed_until is only ever compared for equality, but it
+//     rides along because WakeTurnAt matches the stored deadline against a
+//     freshly formatted one — restamping it in the same breath as changing the
+//     writer is what keeps a snooze written before this migration wakeable after
+//     it.
+//   - automation_provider_cursors.observed_at gates the cursor advance
+//     (`excluded.observed_at >= ...observed_at`), so an observation could fail to
+//     advance the cursor past one taken microseconds earlier.
+//   - delegation_operations.created_at, workspaces.created_at and
+//     workspace_layout_panes.created_at each order a listing, so rows written
+//     together came back in an arbitrary order.
+//   - workflow_runs.created_at orders the run listing and is written by the CLI
+//     rather than by this package, so the store normalizes whatever spelling a
+//     caller hands it (normalizeWorkflowStamp) instead of the writers being asked
+//     to agree. Its callers reach it through protocol.TimestampNow() too.
+//   - endpoints.created_at / updated_at were the worst of them: written through
+//     protocol.TimestampNow(), which renders the local zone, so the stored values
+//     carry an offset like "+02:00" and the listing misordered across a zone or
+//     DST change as well as across a fraction width. Restamping normalizes them
+//     to UTC, which is why the decode has to be the tolerant one.
+//
+// Idempotent by construction — re-encoding an already-converted stamp yields
+// itself — and an undecodable stamp is left alone and reported, both inherited
+// from restampTable, which also skips the ” that means "no stamp here" on the
+// turn columns and on an unclaimed cursor.
+//
+// The composite-key tables are keyed by rowid: every table here is an ordinary
+// rowid table, and restampTable needs one column that names a row, not the
+// primary key it happens to have.
+func applyMigration94(tx *sql.Tx) error {
+	restamps := []struct {
+		table   string
+		key     string
+		columns []string
+	}{
+		{"sessions", "id", []string{"turn_opened_at", "turn_settled_at", "turn_snoozed_until"}},
+		{"automation_provider_cursors", "rowid", []string{"observed_at"}},
+		{"automation_review_request_edges", "rowid", []string{"last_observed_at"}},
+		{"delegation_operations", "request_id", []string{"created_at", "updated_at"}},
+		{"endpoints", "id", []string{"created_at", "updated_at"}},
+		{"workspaces", "id", []string{"created_at"}},
+		{"workspace_layout_panes", "rowid", []string{"created_at", "updated_at"}},
+		{"workflow_runs", "run_id", []string{"created_at"}},
+	}
+	unreadable := 0
+	for _, r := range restamps {
+		// A table the base schema creates rather than a migration is absent from a
+		// database built up from an older hand-written schema. There is nothing to
+		// rewrite in a table that does not exist yet, and whatever creates it later
+		// writes the new encoding from the start.
+		present, err := tableExists(tx, r.table)
+		if err != nil {
+			return fmt.Errorf("checking for %s: %w", r.table, err)
+		}
+		if !present {
+			continue
+		}
+		n, err := restampTable(tx, r.table, r.key, r.columns)
+		if err != nil {
+			return fmt.Errorf("restamping %s: %w", r.table, err)
+		}
+		unreadable += n
+	}
+	if unreadable > 0 {
+		log.Printf("[store] migration 94: left %d turn/cursor/listing timestamp(s) as they were; they are not RFC3339 and cannot be re-encoded", unreadable)
 	}
 	return nil
 }

--- a/internal/store/turn.go
+++ b/internal/store/turn.go
@@ -25,12 +25,23 @@ type TurnStamps struct {
 // age it was opened at, so a row never moves in the queue while the user works
 // with the agent, and a re-reported state cannot disturb it.
 //
+// The guard is a text comparison — turn_opened_at and turn_settled_at are TEXT
+// columns — so the stored encoding is the whole definition of "still open", and
+// it has to be one whose text order is time order within a second. That is
+// sortableTimeFormat. Under the RFC3339Nano this used to write, a stamp whose
+// fraction another stamp extends sorted above it ('Z' is 0x5A, above '.' and
+// every digit), so a turn settled inside the second it was opened in read as
+// still open and the next turn silently never opened. Whole-second opens are the
+// ordinary case, not a coincidence: a day-named snooze wakes on an exact second
+// and the woken turn is stamped with that deadline. Migration 94 rewrote the
+// stored stamps.
+//
 // It returns true when a turn was opened.
 func (s *Store) OpenTurnIfClosed(id string, now time.Time) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	stamp := now.UTC().Format(time.RFC3339Nano)
+	stamp := now.UTC().Format(sortableTimeFormat)
 
 	if s.db == nil {
 		if _, ok := s.sessions[id]; !ok {
@@ -76,7 +87,7 @@ func (s *Store) SettleTurn(id string, now time.Time) bool {
 	}
 
 	result, err := s.db.Exec(`UPDATE sessions SET turn_settled_at = ? WHERE id = ?`,
-		now.UTC().Format(time.RFC3339Nano), id)
+		now.UTC().Format(sortableTimeFormat), id)
 	if err != nil {
 		log.Printf("[store] SettleTurn: failed for session %s: %v", id, err)
 		return false
@@ -113,7 +124,7 @@ func (s *Store) SnoozeTurn(id string, until, now time.Time) bool {
 
 	result, err := s.db.Exec(
 		`UPDATE sessions SET turn_settled_at = ?, turn_snoozed_until = ? WHERE id = ?`,
-		now.UTC().Format(time.RFC3339Nano), until.UTC().Format(time.RFC3339Nano), id)
+		now.UTC().Format(sortableTimeFormat), until.UTC().Format(sortableTimeFormat), id)
 	if err != nil {
 		log.Printf("[store] SnoozeTurn: failed for session %s: %v", id, err)
 		return false
@@ -167,14 +178,14 @@ func (s *Store) WakeTurnAt(id string, deadline time.Time) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	stamp := deadline.UTC().Format(time.RFC3339Nano)
+	stamp := deadline.UTC().Format(sortableTimeFormat)
 
 	if s.db == nil {
 		current, ok := s.turnStamps[id]
 		if !ok || current.SnoozedUntil.IsZero() {
 			return false
 		}
-		if current.SnoozedUntil.UTC().Format(time.RFC3339Nano) != stamp {
+		if current.SnoozedUntil.UTC().Format(sortableTimeFormat) != stamp {
 			return false
 		}
 		current.SnoozedUntil = time.Time{}
@@ -263,13 +274,10 @@ func (s *Store) setTurnStampsLocked(id string, stamps TurnStamps) {
 	s.turnStamps[id] = stamps
 }
 
-func parseTurnStamp(value string) time.Time {
-	if value == "" {
-		return time.Time{}
-	}
-	parsed, err := time.Parse(time.RFC3339Nano, value)
-	if err != nil {
-		return time.Time{}
-	}
-	return parsed
-}
+// parseTurnStamp decodes a stored turn stamp in any RFC3339 spelling — the
+// fixed-width one written today and the trailing-zero-stripped one written
+// before migration 94 — and yields the zero time for the ” that means "no turn
+// here" as well as for anything it cannot read. It is parseStoreTime, which the
+// job queue and the notifications feed already decode with: the columns hold one
+// encoding, so they get one decoder.
+func parseTurnStamp(value string) time.Time { return parseStoreTime(value) }

--- a/internal/store/turn_timestamps_test.go
+++ b/internal/store/turn_timestamps_test.go
@@ -1,0 +1,361 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/docstore"
+)
+
+// turn_opened_at, turn_settled_at, automation_provider_cursors.observed_at and
+// the created_at columns that order the delegation, workspace and pane listings
+// are TEXT, so every comparison SQL makes on them is a text comparison and the
+// stored encoding is the whole definition of "before". Rows a second apart
+// cannot tell a working encoding from a broken one; what has to be right is what
+// happens inside one second.
+//
+// Every fixture here therefore uses sub-second offsets whose
+// trailing-zero-stripped encodings sort in an order that is not their own. Two
+// shapes do it, and both are in raggedOffsets: a whole second, which under
+// RFC3339Nano sorts above every stamp inside itself because 'Z' is 0x5A and '.'
+// and the digits are below it; and a fraction that another fraction extends
+// (".1234" against ".12345"), where the shorter one's 'Z' again lands above the
+// longer one's next digit.
+
+// raggedOffsets are ids in chronological order with the sub-second offsets that
+// separate them, all inside one second.
+var raggedOffsets = []struct {
+	id     string
+	offset time.Duration
+}{
+	{"r0", 0},
+	{"r1234", 123400 * time.Microsecond},
+	{"r12345", 123450 * time.Microsecond},
+	{"r5", 500 * time.Millisecond},
+}
+
+func turnBase() time.Time { return time.Date(2026, 8, 6, 10, 0, 0, 0, time.UTC) }
+
+func chronologicalRaggedIDs() []string {
+	out := make([]string, 0, len(raggedOffsets))
+	for _, r := range raggedOffsets {
+		out = append(out, r.id)
+	}
+	return out
+}
+
+// The turn guard, and the reason this change exists. A turn that was settled is
+// closed, and the next attention-wanting state has to open a new one — that is
+// the loop the whole queue rests on. The guard asks it as
+// `turn_opened_at <= turn_settled_at`, in text, so a settle landing in the same
+// second as the open it closes read as "a turn is already open" and
+// OpenTurnIfClosed returned false. Nothing logged it: the session simply stopped
+// appearing in the queue until some later turn happened to open.
+//
+// The whole-second case is the one that reaches users. A day-named snooze
+// ("tomorrow", "Saturday", "Monday") resolves to an exact second — the client
+// zeroes the milliseconds — and the woken turn is stamped with that deadline, so
+// a whole-second turn_opened_at is what every such wake produces.
+func TestATurnSettledInTheSecondItOpenedInCanReopen(t *testing.T) {
+	cases := []struct {
+		name            string
+		opened, settled time.Duration
+	}{
+		{"opened on a whole second", 0, 500 * time.Millisecond},
+		{"settled fraction extends the opened one", 123400 * time.Microsecond, 123450 * time.Microsecond},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := newTurnStore(t)
+			addTurnSession(t, s, "s1", "working")
+
+			if !s.OpenTurnIfClosed("s1", turnBase().Add(c.opened)) {
+				t.Fatalf("the first turn did not open")
+			}
+			if !s.SettleTurn("s1", turnBase().Add(c.settled)) {
+				t.Fatalf("settle failed")
+			}
+			if stamps := s.TurnStamps("s1"); !stamps.SettledAt.After(stamps.OpenedAt) {
+				t.Fatalf("fixture is wrong: settled %s is not after opened %s",
+					stamps.SettledAt, stamps.OpenedAt)
+			}
+
+			// The load-bearing assert: the turn is settled, so the next
+			// attention-wanting state must open a new one.
+			if !s.OpenTurnIfClosed("s1", turnBase().Add(c.settled+time.Millisecond)) {
+				t.Fatalf("no turn opened after a settle in the same second; the session is silently out of the queue")
+			}
+		})
+	}
+}
+
+// turn_snoozed_until is matched for equality (`turn_snoozed_until = ?`), not
+// ordered, so changing the encoding cannot misorder it — it can only stop a
+// stored deadline from matching the one a fired timer re-formats. That is what
+// makes the migration load-bearing here rather than the format: a snooze written
+// before it, in the old encoding, has to still be wakeable after it.
+//
+// A whole second is the case that matters, because every day-named snooze
+// resolves to one — the client zeroes the milliseconds — and it is exactly where
+// the two encodings disagree ("…:00Z" against "…:00.000000000Z").
+func TestASnoozeWrittenInTheOldEncodingIsStillWakeable(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB: %v", err)
+	}
+	defer s.Close()
+	addTurnSession(t, s, "s1", "working")
+
+	until := turnBase().Add(time.Hour)
+	if _, err := s.db.Exec(`UPDATE sessions SET turn_snoozed_until = ? WHERE id = 's1'`,
+		until.Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("plant old snooze stamp: %v", err)
+	}
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version >= 94`); err != nil {
+		t.Fatalf("unrecord migration 94: %v", err)
+	}
+
+	// Sanity: without the rewrite the timer cannot cash the deadline it holds.
+	if s.WakeTurnAt("s1", until) {
+		t.Fatalf("the planted stamp already matches; this test would pass without the migration")
+	}
+
+	if err := migrateDB(s.db, dbPath); err != nil {
+		t.Fatalf("migrateDB: %v", err)
+	}
+	if got := s.SnoozedSessions()["s1"]; !got.Equal(until) {
+		t.Fatalf("stored deadline reads back as %s, want %s", got, until)
+	}
+	if !s.WakeTurnAt("s1", until) {
+		t.Fatalf("after migration 94 the fired timer still could not cash its deadline")
+	}
+}
+
+// The review-request cursor advance is guarded in SQL —
+// `DO UPDATE SET observed_at=excluded.observed_at WHERE excluded.observed_at >=
+// automation_provider_cursors.observed_at` — and it is the only observed_at
+// comparison the store makes. A poll loop produces observations inside one
+// second, and a later one that fails to advance the cursor leaves the fence
+// standing on a stale instant.
+//
+// The schedule cursor deliberately is not the subject here: its upsert carries no
+// WHERE, so it advances whatever the encoding does and proves nothing.
+func TestAReviewRequestCursorAdvancesWithinASecond(t *testing.T) {
+	s := newTurnStore(t)
+	def, err := s.UpsertAutomationDefinition("reviews", "Reviews", `{"id":"reviews"}`, turnBase())
+	if err != nil {
+		t.Fatalf("upsert definition: %v", err)
+	}
+
+	first := turnBase()
+	second := turnBase().Add(500 * time.Millisecond)
+	for _, at := range []time.Time{first, second} {
+		if _, err := s.ReconcileAutomationReviewRequests(
+			def.ID, "github.com", []string{"github.com/owner/repo#1"}, at); err != nil {
+			t.Fatalf("reconcile at %s: %v", at, err)
+		}
+	}
+
+	var raw string
+	if err := s.db.QueryRow(
+		`SELECT observed_at FROM automation_provider_cursors
+		  WHERE definition_id = ? AND provider = 'github_review_requested' AND scope = 'github.com'`,
+		def.ID).Scan(&raw); err != nil {
+		t.Fatalf("read cursor: %v", err)
+	}
+	got, err := docstore.ParseTime(raw)
+	if err != nil {
+		t.Fatalf("parse cursor %q: %v", raw, err)
+	}
+	if !got.Equal(second) {
+		t.Fatalf("cursor is at %s, want the later observation %s", got, second)
+	}
+}
+
+// PendingDelegationOperations feeds the daemon's recovery of delegations it
+// still owes work for, in `ORDER BY created_at`. A burst of claims inside one
+// second is the ordinary case — a chief fires several delegations at once — and
+// they have to come back in the order they were claimed.
+func TestPendingDelegationOperationsAreInClaimOrderWithinASecond(t *testing.T) {
+	s := newTurnStore(t)
+
+	for _, r := range raggedOffsets {
+		if _, _, err := s.ClaimDelegationOperation(
+			r.id, "op-"+r.id, "sess-"+r.id, "chief", "", `{}`, turnBase().Add(r.offset)); err != nil {
+			t.Fatalf("claim %s: %v", r.id, err)
+		}
+	}
+
+	got, err := s.PendingDelegationOperations()
+	if err != nil {
+		t.Fatalf("pending delegation operations: %v", err)
+	}
+	ids := make([]string, 0, len(got))
+	for _, rec := range got {
+		ids = append(ids, rec.Operation.RequestID)
+	}
+	if want := chronologicalRaggedIDs(); !sameOrder(ids, want) {
+		t.Fatalf("pending delegations came back as %v, want %v", ids, want)
+	}
+}
+
+// ListWorkflowRuns promises newest-first, in `ORDER BY created_at DESC`. Its
+// stamps come from the CLI through protocol.TimestampNow(), so the store
+// normalizes them on write — this is the assert that the normalizing happens at
+// all, rather than the column inheriting whatever spelling a caller chose.
+func TestWorkflowRunsAreNewestFirstWithinASecond(t *testing.T) {
+	s := newTurnStore(t)
+
+	for _, r := range raggedOffsets {
+		at := turnBase().Add(r.offset).Format(time.RFC3339Nano)
+		if err := s.UpsertWorkflowRun(&WorkflowRunRow{
+			RunID: r.id, ScriptPath: "s.js", ScriptHash: "h", Status: "running",
+			CreatedAt: at, UpdatedAt: at,
+		}); err != nil {
+			t.Fatalf("upsert run %s: %v", r.id, err)
+		}
+	}
+
+	runs, err := s.ListWorkflowRuns("")
+	if err != nil {
+		t.Fatalf("list workflow runs: %v", err)
+	}
+	ids := make([]string, 0, len(runs))
+	for _, r := range runs {
+		ids = append(ids, r.RunID)
+	}
+	if want := reversed(chronologicalRaggedIDs()); !sameOrder(ids, want) {
+		t.Fatalf("workflow runs came back as %v, want %v", ids, want)
+	}
+}
+
+// Migration 94 rewrites what earlier versions stored. Its input is the encoding
+// they wrote, so the test writes that encoding rather than describing it: the
+// stamps go in the way an older store would have written them, the migration
+// runs, and the guard and the order that were wrong come back right.
+func TestMigration94RewritesTurnCursorAndListingStampsThatDoNotSort(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB: %v", err)
+	}
+	defer s.Close()
+
+	addTurnSession(t, s, "s1", "working")
+	for _, r := range raggedOffsets {
+		if _, _, err := s.ClaimDelegationOperation(
+			r.id, "op-"+r.id, "sess-"+r.id, "chief", "", `{}`, turnBase().Add(r.offset)); err != nil {
+			t.Fatalf("claim %s: %v", r.id, err)
+		}
+	}
+
+	// Roll the stamps back to the encoding migration 94 exists to replace: a turn
+	// opened on a whole second and settled half a second later, and delegation
+	// rows whose fractions extend one another. One value the migration cannot read
+	// is planted too, which it must leave alone rather than turn into year 1, and
+	// turn_snoozed_until stays '' — a session that is not snoozed holds a sentinel,
+	// not a stamp that failed to parse.
+	if _, err := s.db.Exec(
+		`UPDATE sessions SET turn_opened_at = ?, turn_settled_at = ? WHERE id = 's1'`,
+		turnBase().Format(time.RFC3339Nano),
+		turnBase().Add(500*time.Millisecond).Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("plant old turn stamps: %v", err)
+	}
+	for _, r := range raggedOffsets {
+		old := turnBase().Add(r.offset).Format(time.RFC3339Nano)
+		if _, err := s.db.Exec(
+			`UPDATE delegation_operations SET created_at = ? WHERE request_id = ?`, old, r.id); err != nil {
+			t.Fatalf("plant old delegation stamp for %s: %v", r.id, err)
+		}
+	}
+	if _, err := s.db.Exec(
+		`UPDATE delegation_operations SET updated_at = 'not a timestamp' WHERE request_id = ?`, "r5"); err != nil {
+		t.Fatalf("plant unreadable stamp: %v", err)
+	}
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version >= 94`); err != nil {
+		t.Fatalf("unrecord migration 94: %v", err)
+	}
+
+	// Sanity: the planted state is the broken one, so a pass here would mean the
+	// test proves nothing.
+	if s.OpenTurnIfClosed("s1", turnBase().Add(time.Second)) {
+		t.Fatalf("the planted turn stamps already reopen correctly; this test would pass without the migration")
+	}
+
+	if err := migrateDB(s.db, dbPath); err != nil {
+		t.Fatalf("migrateDB: %v", err)
+	}
+	assertMigration94Applied(t, s)
+
+	// Re-running finds nothing left to do and changes nothing: the rewrite is a
+	// decode and re-encode, so an already-converted stamp yields itself.
+	before := stampDigest(t, s)
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version >= 94`); err != nil {
+		t.Fatalf("unrecord migration 94 again: %v", err)
+	}
+	if err := migrateDB(s.db, dbPath); err != nil {
+		t.Fatalf("re-run migrateDB: %v", err)
+	}
+	if after := stampDigest(t, s); after != before {
+		t.Fatalf("a second run changed the stamps:\n%s\nto\n%s", before, after)
+	}
+}
+
+// assertMigration94Applied is the post-migration state: the settled turn reopens,
+// the delegation listing is in claim order, the stamp that does not decode is
+// untouched, and the unsnoozed sentinel is still the sentinel.
+func assertMigration94Applied(t *testing.T, s *Store) {
+	t.Helper()
+
+	if !s.OpenTurnIfClosed("s1", turnBase().Add(time.Second)) {
+		t.Fatalf("after migration 94 a settled turn still did not reopen")
+	}
+
+	got, err := s.PendingDelegationOperations()
+	if err != nil {
+		t.Fatalf("pending delegation operations: %v", err)
+	}
+	ids := make([]string, 0, len(got))
+	for _, rec := range got {
+		ids = append(ids, rec.Operation.RequestID)
+	}
+	if want := chronologicalRaggedIDs(); !sameOrder(ids, want) {
+		t.Fatalf("after migration 94 the delegations came back as %v, want %v", ids, want)
+	}
+
+	var unreadable string
+	if err := s.db.QueryRow(
+		`SELECT updated_at FROM delegation_operations WHERE request_id = 'r5'`).Scan(&unreadable); err != nil {
+		t.Fatal(err)
+	}
+	if unreadable != "not a timestamp" {
+		t.Fatalf("the unreadable stamp became %q; it must be left as it was", unreadable)
+	}
+
+	var snoozed string
+	if err := s.db.QueryRow(`SELECT turn_snoozed_until FROM sessions WHERE id = 's1'`).Scan(&snoozed); err != nil {
+		t.Fatal(err)
+	}
+	if snoozed != "" {
+		t.Fatalf("turn_snoozed_until became %q; the unsnoozed sentinel must be left as it is", snoozed)
+	}
+}
+
+// stampDigest is every stamp migration 94 touches, in a stable order, so a
+// second run can be compared byte for byte against the first.
+func stampDigest(t *testing.T, s *Store) string {
+	t.Helper()
+	var digest string
+	if err := s.db.QueryRow(`
+		SELECT (SELECT group_concat(turn_opened_at || '|' || turn_settled_at || '|' || turn_snoozed_until, ';')
+		          FROM (SELECT * FROM sessions ORDER BY id))
+		    || '#' ||
+		       (SELECT group_concat(created_at || '|' || updated_at, ';')
+		          FROM (SELECT * FROM delegation_operations ORDER BY request_id))
+	`).Scan(&digest); err != nil {
+		t.Fatalf("stamp digest: %v", err)
+	}
+	return digest
+}

--- a/internal/store/workflow_runs.go
+++ b/internal/store/workflow_runs.go
@@ -2,7 +2,30 @@ package store
 
 import (
 	"database/sql"
+
+	"github.com/victorarias/attn/internal/docstore"
 )
+
+// normalizeWorkflowStamp re-encodes a caller-supplied stamp into the encoding the
+// run listing orders by, and leaves anything it cannot read alone.
+//
+// The normalizing happens here rather than at the writers because created_at is
+// ORDER BY'd as text, so this column's order is the store's promise, not the
+// caller's. The callers reach it through protocol.TimestampNow(), which renders
+// time.Now() in the local zone with a trailing-zero-stripped fraction — two runs
+// started inside one second, or either side of a DST change, came back in an
+// order that was not theirs. That helper is the wire's spelling and is left as
+// it is; this is the one column whose order depends on it.
+func normalizeWorkflowStamp(s string) string {
+	if s == "" {
+		return s
+	}
+	t, err := docstore.ParseTime(s)
+	if err != nil {
+		return s
+	}
+	return t.Format(sortableTimeFormat)
+}
 
 // workflowScanner abstracts *sql.Row and *sql.Rows so a single scanner func can
 // serve both QueryRow and Query loops.
@@ -96,7 +119,7 @@ func (s *Store) UpsertWorkflowRun(run *WorkflowRunRow) error {
 		nullPtrString(run.ResultJSON),
 		nullPtrString(run.LastError),
 		boolToInt(run.Resumable),
-		run.CreatedAt,
+		normalizeWorkflowStamp(run.CreatedAt),
 		run.UpdatedAt,
 		nullPtrString(run.CompletedAt),
 	)

--- a/internal/store/workspace.go
+++ b/internal/store/workspace.go
@@ -18,7 +18,7 @@ func (s *Store) AddWorkspace(ws *protocol.Workspace) {
 	if s.db == nil {
 		return
 	}
-	createdAt := time.Now().UTC().Format(time.RFC3339Nano)
+	createdAt := time.Now().UTC().Format(sortableTimeFormat)
 	// rank is set on INSERT only. On re-register (ON CONFLICT) the stored rank is
 	// the durable authority for ordering and must survive — like title, it is not
 	// re-derived from the incoming struct so a user reorder sticks.

--- a/internal/store/workspacelayout.go
+++ b/internal/store/workspacelayout.go
@@ -25,7 +25,7 @@ func (s *Store) SaveWorkspaceLayout(snapshot workspacelayout.WorkspaceLayout) er
 		return err
 	}
 
-	now := time.Now().Format(time.RFC3339Nano)
+	now := time.Now().UTC().Format(sortableTimeFormat)
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err

--- a/scripts/test-go.sh
+++ b/scripts/test-go.sh
@@ -8,6 +8,12 @@ shard_count="${ATTN_GO_TEST_SHARDS:-5}"
 package_parallelism="${ATTN_GO_TEST_PACKAGE_PARALLELISM:-4}"
 test_gomaxprocs="${ATTN_GO_TEST_GOMAXPROCS:-${GOMAXPROCS:-3}}"
 test_timeout="${ATTN_GO_TEST_TIMEOUT:-90s}"
+# The race job runs the same packages a second time under -race, which costs
+# roughly an order of magnitude. Measured: `go test -race ./internal/store
+# ./internal/docstore` takes 22s on an M-series laptop, and CI runs SQLite work
+# 3-4x slower, so ~90s is the real ceiling. 300s is a tripwire — only a hang
+# reaches it.
+race_timeout="${ATTN_GO_TEST_RACE_TIMEOUT:-300s}"
 
 if ! [[ "$shard_count" =~ ^[1-9][0-9]*$ ]]; then
   echo "ATTN_GO_TEST_SHARDS must be a positive integer, got: $shard_count" >&2
@@ -136,6 +142,15 @@ while IFS= read -r package; do
   packages+=("$package")
 done <"$packages_file"
 run_job packages "$go_bin" test -timeout "$test_timeout" -p "$package_parallelism" "$@" "${packages[@]}"
+
+# A live document query re-reads on a wake set by the very write it is
+# reporting, so the store's own concurrency is load-bearing in a way a wrong
+# answer hides better than a crash does: a lost wake or a torn read looks like a
+# stale window, not a panic. Race detection is too slow to spend on every
+# package on every push, so it is scoped to the two that compile and execute
+# those queries. These packages therefore run twice — once for the answers,
+# once for the memory model.
+run_job race "$go_bin" test -timeout "$race_timeout" -race "$@" ./internal/store ./internal/docstore
 
 shard=0
 while [ "$shard" -lt "$shard_count" ]; do

--- a/scripts/test-go.sh
+++ b/scripts/test-go.sh
@@ -7,12 +7,16 @@ daemon_package="github.com/victorarias/attn/internal/daemon"
 shard_count="${ATTN_GO_TEST_SHARDS:-5}"
 package_parallelism="${ATTN_GO_TEST_PACKAGE_PARALLELISM:-4}"
 test_gomaxprocs="${ATTN_GO_TEST_GOMAXPROCS:-${GOMAXPROCS:-3}}"
-test_timeout="${ATTN_GO_TEST_TIMEOUT:-90s}"
+# Measured 2026-08-07: `go test ./internal/store` alone takes ~23s on an
+# M-series laptop after the doc-store windowed-subscription battery and the
+# two timestamp-migration suites landed, and CI runs SQLite work 3-4x slower
+# — the package hit the old 90s ceiling on a healthy run (run 31133211867).
+# 300s is a tripwire: only a hang reaches it.
+test_timeout="${ATTN_GO_TEST_TIMEOUT:-300s}"
 # The race job runs the same packages a second time under -race, which costs
 # roughly an order of magnitude. Measured: `go test -race ./internal/store
 # ./internal/docstore` takes 22s on an M-series laptop, and CI runs SQLite work
-# 3-4x slower, so ~90s is the real ceiling. 300s is a tripwire — only a hang
-# reaches it.
+# 3-4x slower. 300s is the same tripwire — only a hang reaches it.
 race_timeout="${ATTN_GO_TEST_RACE_TIMEOUT:-300s}"
 
 if ! [[ "$shard_count" =~ ^[1-9][0-9]*$ ]]; then


### PR DESCRIPTION
## What this is

During the 2026-08-06 GitHub Actions outage, in-flight lanes stopped targeting main and merged onto an integration branch (`epic/integration`, cut from main at 01ab976a) on the strength of their local receipts, with review and CI deferred to this PR. This is that PR: full CI and review of the combined diff, then a merge commit preserving the three already-squashed changes.

## The three changes

**`4e4c47e8` — fix(daemon): store background-work timestamps in an encoding that sorts (#774).** Jobs and notifications wrote `time.RFC3339Nano` into TEXT columns compared as text; variable fraction widths mean text order is not time order within a second (a job scheduled on a whole second was not claimed until the next). Both now write the fixed-width `docstore.TimeFormat` under the shared name `sortableTimeFormat`; reads decode any RFC3339 spelling; migration 93 restamps stored rows (idempotent, blanks preserved).

**`82dfb928` — feat(docstore): send only what changed on a live query (#776).** A3.4 Stage 2: live-query deliveries become windowed — `{delivery, as_of_seq, order, upsert}` with changed bodies only; resume by content via `have` (`DocumentRevision[]` pairs — deliberate deviation from the plan's `Record<string, int64>`, which decodes untyped on the Go side; rationale in main.tsp); subscribe refuses `after` cursors with a coded error; subscription-ending codes (`collection_undefined`, `collection_redeclared`); the duplicate `compileDocQuery` preflight is deleted (acceptance is the first read); `internal/client` and `attn doc watch` updated (watch now exits non-zero when the daemon ends the subscription, and reconnects on connection loss only — a mid-flight fix for a silent resubscribe loop). Adds the plan's full test battery plus scoped `-race` (store+docstore) to CI. ProtocolVersion 215.

**`e44a1325` — fix(daemon): store turn, cursor and listing timestamps in an encoding that sorts (#782).** The same defect class swept across the rest of `internal/store`: sessions turn stamps (the serious one — the turn-open guard compared text, and day-named snoozes zero milliseconds so `turn_opened_at` systematically lands on whole seconds, which sort above every stamp in their own second: a settle in that second silently prevented the next turn from opening), automation provider cursors, delegation operations, endpoints (previously written with a local zone offset — misordered across zones/DST), workspaces, workspace layout panes, and workflow runs (normalized at the store boundary). Migration 94 restamps existing rows. Deliberately left, with reasoning in #782: all `formatTicketTime`/`time.RFC3339` columns (tickets, automation runs, present, bus events) — fixed-width, already sorting correctly.

## Verification

Each change carried its own receipts at merge time (full Go suite, `-race` on touched packages, falsification tests that go red when the format constant alone is reverted, migration witnesses on sandbox copies of the production DB with idempotence verified byte-identically, and live verification on throwaway profiles — Stage 2 on a full `make install` at protocol 215; the timestamp fix with the queue scenarios green on a fresh profile, including settle-survives-daemon-restart). The combined branch was additionally verified after each later merge: full Go suite green at `82dfb928`-on-`4e4c47e8`, and PR #782's CI ran green once Actions recovered (Daemon, Changelog, Changes, react-doctor; the rest path-skipped).

Migrations 93 and 94; ProtocolVersion 213 → 215; three changelog fragments ride along.

https://claude.ai/code/session_01429snMWPwXjv1NeqUdV57c