### PR TITLE
fix(ci): remove a load flake and give the next one a witness

### DIFF
--- a/changelog.d/tipsy-weasel-ci-flake-fixes.yaml
+++ b/changelog.d/tipsy-weasel-ci-flake-fixes.yaml
@@ -1,0 +1,10 @@
+kind: internal
+area: tests
+change: >
+  Removed the top CI flake and gave the next one a witness. The ptyworker reap
+  fixture now waits for its sleeper to signal before reading its argv, since a
+  process's argv is not readable the instant `Start()` returns (14 failures in
+  2000 loaded Linux runs, 0 after). The plugin-driver end-to-end test keeps a
+  daemon log and prints who saw what when a driver.session_closed notification
+  goes missing, and the daemon logs the three paths that used to drop or defer
+  that notification silently.

--- a/internal/daemon/plugin_driver.go
+++ b/internal/daemon/plugin_driver.go
@@ -434,6 +434,10 @@ func (d *Daemon) queueExitDuringPluginLaunch(info ptybackend.ExitInfo) bool {
 	if !ok || info.LifecycleID == "" || launch.RunID != info.LifecycleID {
 		return false
 	}
+	// The exit is deferred, not delivered: finishPluginSessionLaunch replays it
+	// once the launch it raced is done. Say so, because between here and there
+	// the session looks alive to everything that reads the store.
+	d.logf("deferring plugin PTY exit until launch completes: session=%s run=%s", info.ID, info.LifecycleID)
 	d.pluginExits[info.ID] = info
 	return true
 }
@@ -502,13 +506,19 @@ func (r pendingPluginReport) runID() string {
 	}
 }
 
+// closePluginDriverSession tells the plugin that owns this session's run that
+// the run is over. Both ways out without a notification are silent to the
+// plugin, so they say so in the log: a plugin that never hears its run closed
+// leaks whatever it allocated for it, and the only evidence is here.
 func (d *Daemon) closePluginDriverSession(sessionID, reason string, exitCode *int, signal string) {
 	session := d.store.Get(sessionID)
 	if session == nil {
+		d.logf("plugin session close skipped: session=%s reason=%s no longer in store", sessionID, reason)
 		return
 	}
 	run := d.store.EndAgentDriverRun(sessionID)
 	if run.RunID == "" {
+		d.logf("plugin session close skipped: session=%s reason=%s has no active driver run", sessionID, reason)
 		return
 	}
 	d.notifyPluginDriverSessionClosed(run.PluginName, sessionID, run.RunID, reason, exitCode, signal)
@@ -533,7 +543,11 @@ func (d *Daemon) notifyPluginDriverSessionClosed(pluginName, sessionID, runID, r
 		var result pluginDriverSessionClosedResult
 		if err := plugin.request(ctx, "driver.session_closed", params, &result); err != nil {
 			d.logf("plugin session close notification failed: plugin=%s session=%s run=%s err=%v", pluginName, sessionID, runID, err)
+			return
 		}
+		// The one line that separates "the daemon never sent it" from "the
+		// plugin never acted on it" when a close goes missing.
+		d.logf("plugin session close notified: plugin=%s session=%s run=%s reason=%s", pluginName, sessionID, runID, params.Reason)
 	}()
 }
 

--- a/internal/daemon/plugin_driver_e2e_test.go
+++ b/internal/daemon/plugin_driver_e2e_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/victorarias/attn/internal/logging"
 	"github.com/victorarias/attn/internal/protocol"
 	"nhooyr.io/websocket"
 )
@@ -76,6 +77,17 @@ func TestPluginDriverEndToEnd_InstalledProcessLaunchReportAndResumeThroughWorker
 
 	d := NewForTesting(socketPath)
 	d.pluginDir = pluginDir
+	// Tests normally run the daemon mute. This one spans three processes and its
+	// only observed failure is a close notification that never arrives, so keep
+	// the daemon's own account of every exit and every dropped notification —
+	// it is what the failure prints instead of a bare deadline.
+	daemonLog := filepath.Join(tmpDir, "daemon.log")
+	if logger, err := logging.New(daemonLog); err == nil {
+		d.logger = logger
+		t.Cleanup(func() { _ = logger.Close() })
+	} else {
+		t.Logf("daemon log unavailable: %v", err)
+	}
 	d.loginShellEnv = []string{"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH")}
 	go func() {
 		if err := d.Start(); err != nil {
@@ -109,6 +121,13 @@ func TestPluginDriverEndToEnd_InstalledProcessLaunchReportAndResumeThroughWorker
 
 	sessionID := "plugin-driver-e2e"
 	workspaceID := "workspace-" + sessionID
+	fixture := pluginFixtureSession{
+		daemon:    d,
+		sessionID: sessionID,
+		closeLog:  fixtureCloseLog,
+		stderr:    fixtureStderr,
+		daemonLog: daemonLog,
+	}
 	if err := writeWS(ws, map[string]interface{}{
 		"cmd":       protocol.CmdRegisterWorkspace,
 		"id":        workspaceID,
@@ -132,7 +151,7 @@ func TestPluginDriverEndToEnd_InstalledProcessLaunchReportAndResumeThroughWorker
 	}
 
 	terminatePluginFixturePTY(t, d, sessionID)
-	firstClose := waitForPluginFixtureCloseRecords(t, fixtureCloseLog, 1)[0]
+	firstClose := waitForPluginFixtureCloseRecords(t, fixture, 1)[0]
 	if firstClose.Params.RunID != records[0].Params.RunID || firstClose.Params.Reason != "exited" {
 		t.Fatalf("first close=%+v, want exited notification for spawned run %q", firstClose.Params, records[0].Params.RunID)
 	}
@@ -154,7 +173,7 @@ func TestPluginDriverEndToEnd_InstalledProcessLaunchReportAndResumeThroughWorker
 	}
 
 	terminatePluginFixturePTY(t, d, sessionID)
-	secondClose := waitForPluginFixtureCloseRecords(t, fixtureCloseLog, 2)[1]
+	secondClose := waitForPluginFixtureCloseRecords(t, fixture, 2)[1]
 	if secondClose.Params.RunID != resume.Params.RunID || secondClose.Params.Reason != "exited" {
 		t.Fatalf("second close=%+v, want exited notification for resumed run %q", secondClose.Params, resume.Params.RunID)
 	}
@@ -354,28 +373,99 @@ func waitForPluginFixtureRecords(t *testing.T, path string, count int) []pluginD
 	return records
 }
 
-func waitForPluginFixtureCloseRecords(t *testing.T, path string, count int) []pluginDriverCloseRecord {
+// pluginFixtureSession is everything the close wait needs to explain itself when
+// the notification never lands.
+type pluginFixtureSession struct {
+	daemon    *Daemon
+	sessionID string
+	closeLog  string
+	stderr    string
+	daemonLog string
+}
+
+// waitForPluginFixtureCloseRecords waits for the fixture plugin to record
+// `count` driver.session_closed notifications.
+//
+// The notification crosses three processes: the worker sees the PTY child exit,
+// the daemon ends the driver run, the plugin gets driver.session_closed, and the
+// fixture appends to the log. Measured on Linux with six copies of this test
+// running in parallel under CPU load, that whole chain finishes in under 50ms
+// (240 samples, worst 48.2ms). The deadline below is therefore a tripwire two
+// orders of magnitude past any healthy run: reaching it means a link went quiet,
+// not that the machine was slow. A CI flake reaching it told us only that, which
+// is unfixable, so failing here prints who saw what — the daemon's account of
+// the exit, the fixture's stderr (a fixture that died takes its connection with
+// it, and the daemon then drops the notification as "owner disconnected"), and
+// the session state the store ended up in.
+func waitForPluginFixtureCloseRecords(t *testing.T, fixture pluginFixtureSession, count int) []pluginDriverCloseRecord {
 	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		records, ok := readPluginFixtureCloseRecords(fixture.closeLog, count)
+		if ok {
+			return records
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d fixture plugin close record(s)\n%s", count, fixture.diagnose())
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func readPluginFixtureCloseRecords(path string, count int) ([]pluginDriverCloseRecord, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
 	var records []pluginDriverCloseRecord
-	waitForCondition(t, 5*time.Second, func() bool {
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return false
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
 		}
-		records = nil
-		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
-			if line == "" {
-				continue
-			}
-			var record pluginDriverCloseRecord
-			if err := json.Unmarshal([]byte(line), &record); err != nil {
-				return false
-			}
-			records = append(records, record)
+		var record pluginDriverCloseRecord
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			return nil, false
 		}
-		return len(records) >= count
-	}, "fixture plugin close log")
-	return records
+		records = append(records, record)
+	}
+	return records, len(records) >= count
+}
+
+func (f pluginFixtureSession) diagnose() string {
+	var out strings.Builder
+	state := "session missing from store"
+	if session := f.daemon.store.Get(f.sessionID); session != nil {
+		state = string(session.State)
+	}
+	run := f.daemon.store.GetAgentDriverRun(f.sessionID)
+	fmt.Fprintf(&out, "session state=%s active_run=%q plugin=%q driver_registered=%t\n",
+		state, run.RunID, run.PluginName, f.driverRegistered())
+	records, _ := readPluginFixtureCloseRecords(f.closeLog, 0)
+	fmt.Fprintf(&out, "close records recorded: %d\n", len(records))
+	out.WriteString(pluginFixtureFileTail("fixture stderr", f.stderr, 40))
+	out.WriteString(pluginFixtureFileTail("daemon log", f.daemonLog, 60))
+	return out.String()
+}
+
+func (f pluginFixtureSession) driverRegistered() bool {
+	_, ok := f.daemon.plugins.driver("fixture")
+	return ok
+}
+
+func pluginFixtureFileTail(label, path string, lines int) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Sprintf("--- %s: unreadable (%v)\n", label, err)
+	}
+	trimmed := strings.TrimRight(string(data), "\n")
+	if trimmed == "" {
+		return fmt.Sprintf("--- %s: empty\n", label)
+	}
+	all := strings.Split(trimmed, "\n")
+	if len(all) > lines {
+		all = all[len(all)-lines:]
+	}
+	return fmt.Sprintf("--- %s (last %d lines):\n%s\n", label, len(all), strings.Join(all, "\n"))
 }
 
 func TestPluginDriverFixtureProcess(t *testing.T) {

--- a/internal/ptyworker/reap_test.go
+++ b/internal/ptyworker/reap_test.go
@@ -114,15 +114,47 @@ func spawnSleeper(t *testing.T, marker string) *exec.Cmd {
 	// `:` matters: with a lone simple command, sh exec's it directly and the
 	// process argv becomes bare `sleep 60`, losing the marker — which made this
 	// helper a race rather than a fixture.
-	cmd := exec.Command("sh", "-c", "sleep 60; :", marker)
+	//
+	// The leading `echo` is the readiness signal, and the helper does not return
+	// until it arrives. `Start()` returning does not mean argv is readable:
+	// Linux closes the exec pipe that unblocks the parent in begin_new_exec,
+	// before create_elf_tables publishes the new argv, so /proc/<pid>/cmdline
+	// can still read back empty when the parent looks straight away. Measured on
+	// Linux under 20 spinning shells, 10 of 400 spawns had no argv on the first
+	// read (worst wait 3.5ms) and 0 of 400 missed once gated on this byte; the
+	// gate took TestProcessHasArgIdentifiesOwnProcess from 14 failures in 2000
+	// runs to 0 in 2000 under the same load. argv is in place before the child
+	// executes its first instruction, so a byte from the child proves it is
+	// published, and proves it without consulting processHasArg, which this file
+	// also has to test honestly.
+	stdout, ready, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("sleeper readiness pipe: %v", err)
+	}
+	cmd := exec.Command("sh", "-c", "echo ready; sleep 60; :", marker)
+	cmd.Stdout = ready
 	if err := cmd.Start(); err != nil {
+		_ = stdout.Close()
+		_ = ready.Close()
 		t.Fatalf("start sleeper: %v", err)
 	}
+	_ = ready.Close()
 	t.Cleanup(func() {
+		_ = stdout.Close()
 		_ = cmd.Process.Kill()
 		_, _ = cmd.Process.Wait()
 	})
 	go func() { _, _ = cmd.Process.Wait() }()
+
+	// A tripwire, not a wait a healthy spawn ever feels: the readiness byte
+	// lands in microseconds, and only a sleeper that never execs at all reaches
+	// this deadline.
+	if err := stdout.SetReadDeadline(time.Now().Add(30 * time.Second)); err != nil {
+		t.Fatalf("sleeper readiness deadline: %v", err)
+	}
+	if _, err := stdout.Read(make([]byte, len("ready\n"))); err != nil {
+		t.Fatalf("sleeper never signalled readiness (marker %q): %v", marker, err)
+	}
 	return cmd
 }
 


### PR DESCRIPTION
Two CI flakes: one closed at the cause, one instrumented so the next occurrence says something actionable.

## ptyworker reap fixture — argv is not readable when `Start()` returns

`spawnSleeper` started a shell and immediately let the test read its argv. On Linux the exec pipe that unblocks the parent is closed in `begin_new_exec`, *before* `create_elf_tables` publishes the new argv, so `/proc/<pid>/cmdline` can read back empty when the parent looks straight away — and `processHasArg` then honestly reports "no such process".

The sleeper now echoes a readiness byte and the helper blocks on it. argv is in place before the child executes its first instruction, so a byte from the child proves argv is published — and proves it *without* consulting `processHasArg`, which this file also has to test honestly.

Receipts, measured on Linux under 20 spinning shells:

| | first-read miss | `TestProcessHasArgIdentifiesOwnProcess` |
|---|---|---|
| before | 10 of 400 spawns (worst wait 3.5ms) | 14 failures in 2000 runs |
| after | 0 of 400 | 0 in 2000 |

The 30s read deadline is a tripwire past every healthy spawn — only a sleeper that never execs at all reaches it.

## plugin-driver end-to-end — the flake now explains itself

This one is not fixed, because a bare deadline never said enough to fix it. Its only observed failure is a `driver.session_closed` notification that never arrives, across a chain that spans three processes: the worker sees the PTY child exit, the daemon ends the driver run, the plugin receives the notification, the fixture appends to its log.

- The test keeps the daemon's own log, and on timeout prints who saw what: session state, active driver run, whether the driver is still registered, fixture stderr (a fixture that died takes its connection with it, and the daemon then drops the notification as "owner disconnected"), and the daemon log tail.
- The daemon logs the three points that were silent: a PTY exit deferred until a racing launch completes, the two early returns in `closePluginDriverSession` that skip the notification, and the successful notification itself — the one line separating "the daemon never sent it" from "the plugin never acted on it".

The 5s deadline stays, now as a tripwire rather than a wait: the whole chain finishes in under 50ms across 240 samples on Linux with six copies of the test running in parallel under CPU load (worst 48.2ms). Reaching 5s means a link went quiet, not that the machine was slow.

## Dropped in rebase: the split-blank e2e gate

This branch also carried a fix for `split-blank-repro.spec.ts`, whose setup gate polled `trace[trace.length - 1]` and so read a renderer skip (`quads: null`) as a blank surface. #777 landed a byte-identical fix first, so the change is gone from this branch and only its comment wording differed. Recording the receipt here since that fix shipped without one: 1 of 10 local runs finished setup on a skip, with the trace `[1, null, 6302, null]`.

## Verification

- `go test ./internal/ptyworker -run 'TestProcessHasArg|Reap' -count=3`, `go test ./internal/daemon -run TestPluginDriver` — green before and after the rebase.
- `gofmt`, `go build ./...`, `go vet`, `go run ./cmd/changelog-check` — clean.
- The new diagnostics were exercised for real, not just compiled: an overlay copy of the test with an unreachable close-record count forced the timeout, and the failure printed the full daemon log for a live daemon + worker + plugin-fixture run, including the new `plugin session close notified` line. The production change here is log lines only, so this three-process run is the integrated evidence; there is no app-observable behavior to verify in a running app.