### PR TITLE
feat(sessions): remember where each repo's sessions run

### DIFF
--- a/app/src/components/LocationPicker.test.tsx
+++ b/app/src/components/LocationPicker.test.tsx
@@ -606,6 +606,159 @@ describe('LocationPicker', () => {
     });
   });
 
+  // A repo is habitually branched or habitually not, so the picker remembers the
+  // last destination chosen for it and opens there next time.
+  describe('remembered repo destination', () => {
+    const repoRoot = '/home/remote/projects/exsin';
+    const destinationKey = `new_session_destination_local_${repoRoot}`;
+
+    const inspectRepoRoot = () => vi.fn(async () => ({
+      success: true,
+      inspection: {
+        input_path: '~/projects/exsin',
+        resolved_path: repoRoot,
+        home_path: '/home/remote',
+        exists: true,
+        is_directory: true,
+        repo_root: repoRoot,
+      },
+    }));
+    const repoInfoOf = () => vi.fn(async () => ({ success: true, info: buildRepoInfo() }));
+
+    const openChooser = async () => {
+      const input = screen.getByTestId('location-picker-path-input');
+      fireEvent.change(input, { target: { value: '~/projects/exsin' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      await waitFor(() => expect(screen.getByTestId('repo-options')).toBeInTheDocument());
+    };
+
+    it('records the main repo when a session is started in the checkout', async () => {
+      const setSetting = vi.fn();
+      const { onSelect } = renderPicker(
+        { onInspectPath: inspectRepoRoot(), onGetRepoInfo: repoInfoOf() },
+        { setSetting },
+      );
+
+      await openChooser();
+      fireEvent.click(screen.getByTestId('repo-option-0'));
+
+      expect(setSetting).toHaveBeenCalledWith(destinationKey, 'main_repo');
+      expect(onSelect).toHaveBeenCalledWith(repoRoot, 'claude', undefined, false, false);
+    });
+
+    it('records a new worktree when one is created', async () => {
+      const setSetting = vi.fn();
+      renderPicker(
+        {
+          onInspectPath: inspectRepoRoot(),
+          onGetRepoInfo: repoInfoOf(),
+          onCreateWorktree: vi.fn(async () => ({ success: true, path: '/home/remote/projects/exsin--feat-more' })),
+        },
+        { settings: { [destinationKey]: 'main_repo' }, setSetting },
+      );
+
+      await openChooser();
+      fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'ArrowUp' });
+      fireEvent.change(screen.getByTestId('repo-new-worktree-input'), { target: { value: 'feat-more' } });
+      fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
+
+      await waitFor(() => expect(setSetting).toHaveBeenCalledWith(destinationKey, 'new_worktree'));
+    });
+
+    it('leaves the memory alone when an existing worktree is opened', async () => {
+      const setSetting = vi.fn();
+      const { onSelect } = renderPicker(
+        { onInspectPath: inspectRepoRoot(), onGetRepoInfo: repoInfoOf() },
+        { settings: { [destinationKey]: 'main_repo' }, setSetting },
+      );
+
+      await openChooser();
+      fireEvent.click(screen.getByTestId('repo-option-1'));
+
+      await waitFor(() => {
+        expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/exsin--feat-images', 'claude', undefined, false, false);
+      });
+      expect(setSetting).not.toHaveBeenCalled();
+    });
+
+    it('does not rewrite a choice that already matches what is stored', async () => {
+      const setSetting = vi.fn();
+      renderPicker(
+        { onInspectPath: inspectRepoRoot(), onGetRepoInfo: repoInfoOf() },
+        { settings: { [destinationKey]: 'main_repo' }, setSetting },
+      );
+
+      await openChooser();
+      fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
+
+      expect(setSetting).not.toHaveBeenCalled();
+    });
+
+    it('opens the chooser on the main repo row for a repo remembered as main', async () => {
+      const onCreateWorktree = vi.fn(async () => ({ success: true, path: '/unused' }));
+      const { onSelect } = renderPicker(
+        { onInspectPath: inspectRepoRoot(), onGetRepoInfo: repoInfoOf(), onCreateWorktree },
+        { settings: { [destinationKey]: 'main_repo' } },
+      );
+
+      await openChooser();
+      expect(screen.getByTestId('repo-option-0')).toHaveClass('selected');
+      fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
+
+      expect(onSelect).toHaveBeenCalledWith(repoRoot, 'claude', undefined, false, false);
+      expect(onCreateWorktree).not.toHaveBeenCalled();
+    });
+
+    it('scopes the memory to the endpoint, so the same path on a remote is its own repo', async () => {
+      const setSetting = vi.fn();
+      renderPicker(
+        {
+          onInspectPath: vi.fn(async (inputPath: string, endpointId?: string) => ({
+            success: true,
+            inspection: {
+              input_path: inputPath,
+              resolved_path: repoRoot,
+              home_path: '/home/remote',
+              exists: true,
+              is_directory: true,
+              repo_root: repoRoot,
+            },
+            endpoint_id: endpointId,
+          })),
+          onGetRepoInfo: vi.fn(async (_repo: string, endpointId?: string) => ({
+            success: true,
+            info: buildRepoInfo(),
+            endpoint_id: endpointId,
+          })),
+          endpoints: [{
+            id: 'ep-1',
+            name: 'gpu-box',
+            ssh_target: 'ai-sandbox',
+            status: 'connected',
+            enabled: true,
+            capabilities: {
+              protocol_version: '46',
+              agents_available: ['codex'],
+              projects_directory: '/srv/projects',
+            },
+          }],
+        },
+        // Stored for the LOCAL checkout at the same path: the remote must not
+        // read it, and must write under its own key.
+        { settings: { [destinationKey]: 'main_repo' }, setSetting },
+      );
+
+      fireEvent.click(screen.getByRole('radio', { name: /gpu-box/i }));
+      await openChooser();
+
+      expect(screen.getByTestId('repo-new-worktree-input')).toHaveFocus();
+
+      fireEvent.click(screen.getByTestId('repo-option-0'));
+
+      expect(setSetting).toHaveBeenCalledWith(`new_session_destination_endpoint_ep-1_${repoRoot}`, 'main_repo');
+    });
+  });
+
   it('supports dialog-level shortcuts while focus is in the chooser', async () => {
     const onInspectPath = vi.fn(async () => ({
       success: true,

--- a/app/src/components/LocationPicker.tsx
+++ b/app/src/components/LocationPicker.tsx
@@ -85,6 +85,7 @@ interface LocationPickerProps {
 const MAX_RECENT_LOCATIONS = 10;
 const SESSION_AGENT_KEY = 'new_session_agent';
 const SESSION_YOLO_KEY = 'new_session_yolo';
+const SESSION_DESTINATION_KEY = 'new_session_destination';
 const LOCAL_TARGET = '__local__';
 const TERMINAL_AGENT: SessionAgent = 'shell';
 const TARGET_SHORTCUT_KEYS = ['q', 'w', 'e', 'r', 'a', 's', 'd', 'f', 'g', 'z', 'x', 'c', 'v', 'b'];
@@ -137,6 +138,27 @@ function yoloSettingKeys(targetId: string, daemonInstanceId?: string): string[] 
     keys.push(`${SESSION_YOLO_KEY}_endpoint_${targetId}`);
   }
   return keys;
+}
+
+// A repo is habitually worked on in a fresh worktree or habitually in its main
+// checkout, and which one is a property of the repo, not of the session being
+// started — so the last destination chosen for it is remembered and reopened.
+// Only the two deliberate choices are recorded: opening an existing worktree is
+// a one-off ("resume that one"), not a habit, and leaves the memory alone.
+type RepoDestination = 'new_worktree' | 'main_repo';
+
+// The remembered destination is scoped to the target as well as the repo path,
+// since the same path on this machine and on a remote endpoint are different
+// checkouts worked on in different ways. Mirrors yoloSettingKeys.
+function repoDestinationSettingKey(repoRoot: string, endpointId?: string): string {
+  const endpoint = endpointId?.trim();
+  const scope = endpoint ? `endpoint_${endpoint}` : 'local';
+  return `${SESSION_DESTINATION_KEY}_${scope}_${repoRoot}`;
+}
+
+function parseRepoDestination(value?: string): RepoDestination | undefined {
+  const normalized = value?.trim();
+  return normalized === 'new_worktree' || normalized === 'main_repo' ? normalized : undefined;
 }
 
 function pickerAgentLabel(agent: SessionAgent): string {
@@ -726,15 +748,33 @@ export function LocationPicker({
     void handleSelectPath(pathToOpen);
   }, [handleSelectPath, highlightedItem, inputValue]);
 
+  const repoDestinationKey = useMemo(
+    () => (repoRootPath ? repoDestinationSettingKey(repoRootPath, selectedEndpointId) : null),
+    [repoRootPath, selectedEndpointId],
+  );
+  const rememberedDestination = repoDestinationKey
+    ? parseRepoDestination(settings[repoDestinationKey])
+    : undefined;
+  // Recorded on the way out, and only when it actually moves — the picker is
+  // opened constantly, and re-storing the same value would broadcast a settings
+  // snapshot to every client for nothing.
+  const rememberRepoDestination = useCallback((destination: RepoDestination) => {
+    if (!repoDestinationKey || settings[repoDestinationKey] === destination) {
+      return;
+    }
+    setSetting(repoDestinationKey, destination);
+  }, [repoDestinationKey, setSetting, settings]);
+
   const handleSelectMainRepo = useCallback(() => {
     if (!hasAvailableAgents) {
       onError?.(noAgentsMessage);
       return;
     }
     if (repoRootPath) {
+      rememberRepoDestination('main_repo');
       launchSelection(repoRootPath);
     }
-  }, [hasAvailableAgents, launchSelection, onError, repoRootPath]);
+  }, [hasAvailableAgents, launchSelection, onError, rememberRepoDestination, repoRootPath]);
 
   const handleSelectWorktree = useCallback((path: string) => {
     if (!hasAvailableAgents) {
@@ -752,6 +792,7 @@ export function LocationPicker({
     if (!repoRootPath || !onCreateWorktree) {
       return;
     }
+    rememberRepoDestination('new_worktree');
 
     if (onCreateWorktreeSession) {
       const selectedAgent = resolvePickerAgent(agent, effectiveAgentAvailability, 'codex');
@@ -795,6 +836,7 @@ export function LocationPicker({
     onCreateWorktree,
     onCreateWorktreeSession,
     onError,
+    rememberRepoDestination,
     repoRootPath,
     agent,
     effectiveAgentAvailability,
@@ -1129,6 +1171,7 @@ export function LocationPicker({
           <RepoOptions
             repoInfo={repoInfo}
             selectedPath={selectedPath || repoRootPath || undefined}
+            preferredDestination={rememberedDestination}
             onSelectedPathChange={(path) => {
               setSelectedPathFromPhysical(path);
             }}

--- a/app/src/components/NewSessionDialog/CLAUDE.md
+++ b/app/src/components/NewSessionDialog/CLAUDE.md
@@ -58,7 +58,15 @@ Focus is modelled as two zones rather than one index list:
 - `create` — the name input holds focus. Only `Enter` (create), `Tab` (toggle start point), `↓` (into the destination list), `⌃R`/`⌘R` (reroll the name), and `Escape` (back) are intercepted; every other key must keep reaching the text input, so the destination shortcuts (`D`, `R`, `1`–`9`) are deliberately inert here.
 - `destinations` — the list behaves as it always has: arrow keys commit as they move, `Enter` opens, `D` deletes, `R` refreshes, digits jump. `↑` off the top returns to the create form.
 
-The initial zone is `create` **except** when the incoming `selectedPath` resolves to a specific worktree (index > 0). Typing an exact worktree path is an explicit "open this one", so Enter must still open it.
+The initial zone is `create` **except** in two cases. When the incoming `selectedPath` resolves to a specific worktree (index > 0): typing an exact worktree path is an explicit "open this one", so Enter must still open it. And when `preferredDestination` is `main_repo`: the chooser opens on the main repo row so Enter reuses the checkout.
+
+## Remembered destination
+
+A repo is habitually worked on in a fresh worktree or habitually in its main checkout, so `LocationPicker` records the last deliberate choice per repo and feeds it back as `preferredDestination`. The two recorded values are `new_worktree` (a worktree was created) and `main_repo` (the checkout was opened); opening an *existing* worktree is a one-off and writes nothing.
+
+Storage is the daemon `settings` table, under `new_session_destination_<scope>_<repoRoot>` where scope is `local` or `endpoint_<id>` — the same path on this machine and on a remote endpoint are different checkouts. Unset means `new_worktree`, the default the picker has always had. The daemon validates the value (`validateNewSessionDestination` in `internal/daemon/ws_settings.go`); a new value has to be accepted there too, or `set_setting` rejects it.
+
+The way back is the picker itself: choosing the other destination overwrites the memory, and `↑` from the main repo row returns to the create form.
 
 Regressions to guard:
 - Repo root → Enter creates a worktree without any typing.

--- a/app/src/components/NewSessionDialog/RepoOptions.test.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.test.tsx
@@ -84,6 +84,94 @@ describe('RepoOptions', () => {
     expect(screen.getByTestId('repo-option-0')).not.toHaveClass('selected');
   });
 
+  it('opens on the main repo row when this repo last ran there, and Enter opens it', () => {
+    const onSelectMainRepo = vi.fn();
+    const onCreateWorktree = vi.fn(async () => {});
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo"
+        preferredDestination="main_repo"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={onSelectMainRepo}
+        onSelectWorktree={vi.fn()}
+        onCreateWorktree={onCreateWorktree}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('repo-option-0')).toHaveClass('selected');
+    expect(screen.getByTestId('repo-new-worktree-input')).not.toHaveFocus();
+
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
+
+    expect(onSelectMainRepo).toHaveBeenCalledTimes(1);
+    expect(onCreateWorktree).not.toHaveBeenCalled();
+  });
+
+  it('returns to the create form with ArrowUp from the remembered main repo row', () => {
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo"
+        preferredDestination="main_repo"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={vi.fn()}
+        onSelectWorktree={vi.fn()}
+        onCreateWorktree={vi.fn(async () => {})}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'ArrowUp' });
+
+    expect(screen.getByTestId('repo-new-worktree-input')).toHaveFocus();
+  });
+
+  it('keeps the create form focused for a repo remembered as a worktree repo', () => {
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo"
+        preferredDestination="new_worktree"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={vi.fn()}
+        onSelectWorktree={vi.fn()}
+        onCreateWorktree={vi.fn(async () => {})}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('repo-new-worktree-input')).toHaveFocus();
+    expect(screen.getByTestId('repo-option-0')).not.toHaveClass('selected');
+  });
+
+  it('lets an exact worktree path win over a remembered main repo', () => {
+    const onSelectWorktree = vi.fn();
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo--feature"
+        preferredDestination="main_repo"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={vi.fn()}
+        onSelectWorktree={onSelectWorktree}
+        onCreateWorktree={vi.fn(async () => {})}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('repo-option-1')).toHaveClass('selected');
+
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
+
+    expect(onSelectWorktree).toHaveBeenCalledWith('/tmp/repo--feature');
+  });
+
   it('creates a worktree from the prefilled name with a single Enter', async () => {
     const onCreateWorktree = vi.fn(async () => {});
     render(

--- a/app/src/components/NewSessionDialog/RepoOptions.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.tsx
@@ -15,6 +15,11 @@ interface RepoInfo {
 interface RepoOptionsProps {
   repoInfo: RepoInfo;
   selectedPath?: string;
+  // Where this repo's last session went, remembered by LocationPicker. Only
+  // 'main_repo' changes anything here: it opens the chooser on the main repo
+  // row so Enter reuses the checkout. Absent, or 'new_worktree', keeps the
+  // create form focused.
+  preferredDestination?: 'new_worktree' | 'main_repo';
   onSelectedPathChange: (path: string) => void;
   onSelectMainRepo: () => void;
   onSelectWorktree: (path: string) => void;
@@ -84,14 +89,18 @@ type ForceableError = Error & {
 // the create form is always expanded, pre-named, and focused first — a new
 // worktree off the latest origin/<default> costs a single Enter.
 //
-// The exception is arriving with a specific worktree already selected: that only
-// happens when the typed path resolved to that worktree, which is an explicit
-// "open this one" and must keep Enter meaning "open", not "create".
+// Two things move that first focus onto the destination list instead. Arriving
+// with a specific worktree already selected only happens when the typed path
+// resolved to that worktree, which is an explicit "open this one" and must keep
+// Enter meaning "open", not "create". And a repo whose last session ran in the
+// main checkout (`preferredDestination`) opens on that row, because a repo is
+// habitually branched or habitually not.
 type FocusZone = 'create' | 'destinations';
 
 export const RepoOptions: React.FC<RepoOptionsProps> = ({
   repoInfo,
   selectedPath,
+  preferredDestination,
   onSelectedPathChange,
   onSelectMainRepo,
   onSelectWorktree,
@@ -145,7 +154,7 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
   );
 
   const [focusZone, setFocusZone] = useState<FocusZone>(
-    committedDestinationIndex > 0 ? 'destinations' : 'create',
+    committedDestinationIndex > 0 || preferredDestination === 'main_repo' ? 'destinations' : 'create',
   );
   const [focusIndex, setFocusIndex] = useState(committedDestinationIndex);
   // `generatedName` is the last value the generator produced. The field is

--- a/changelog.d/prickly-marmot-remembered-repo-destination.yaml
+++ b/changelog.d/prickly-marmot-remembered-repo-destination.yaml
@@ -1,0 +1,11 @@
+kind: added
+area: sessions
+change: >
+  The new session picker now remembers, per repository, whether the last
+  session there ran in a fresh worktree or in the main checkout, and opens on
+  that choice next time. Repos you always branch keep costing a single Enter to
+  get a new worktree; repos you always work on directly now cost a single Enter
+  too, instead of an arrow key every time. Opening an existing worktree is
+  treated as a one-off and does not change what the repo is remembered as, and
+  choosing the other destination once is all it takes to change it back. Each
+  remote endpoint remembers its own repos.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3729,6 +3729,10 @@ func TestDaemon_SettingsValidation(t *testing.T) {
 		{"empty default_model_claude", "default_model_claude", "", false},
 		{"valid default_effort_claude", "default_effort_claude", "high", false},
 		{"empty default_effort_claude", "default_effort_claude", "", false},
+		{"remembered destination new worktree", "new_session_destination_local_/Users/v/projects/attn", "new_worktree", false},
+		{"remembered destination main repo", "new_session_destination_endpoint_ep-1_/srv/projects/attn", "main_repo", false},
+		{"forgotten destination", "new_session_destination_local_/Users/v/projects/attn", "", false},
+		{"unknown destination", "new_session_destination_local_/Users/v/projects/attn", "somewhere_else", true},
 	}
 
 	for _, tt := range tests {

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -73,6 +73,17 @@ const (
 	SettingAutoSettleCountdownSeconds = "auto_settle_countdown_seconds"
 	SettingKeybindingsConfig          = "keybindings_config"
 	SettingNewSessionYoloPrefix       = "new_session_yolo_"
+	// SettingNewSessionDestinationPrefix + a scope naming one repository on one
+	// target (e.g. "new_session_destination_local_/Users/v/projects/attn")
+	// remembers where that repository's last new session went: a fresh worktree
+	// or the main checkout. The picker opens on the remembered one, because a
+	// repository is habitually one or the other. Empty/unset => new worktree,
+	// which is what the picker has always defaulted to. Values are
+	// DestinationNewWorktree / DestinationMainRepo; opening an existing worktree
+	// is a one-off and writes nothing.
+	SettingNewSessionDestinationPrefix = "new_session_destination_"
+	DestinationNewWorktree             = "new_worktree"
+	DestinationMainRepo                = "main_repo"
 	// SettingChiefModelPrefix + agent (e.g. "chief_model_claude") pins the model a
 	// chief-of-staff launch uses, passed through as --model. Empty/unset => the
 	// agent's own default model. Only consulted for chief launches.
@@ -539,6 +550,9 @@ func (d *Daemon) validateSetting(key, value string) error {
 		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(key)), SettingNewSessionYoloPrefix) {
 			return validateBooleanSetting(value)
 		}
+		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(key)), SettingNewSessionDestinationPrefix) {
+			return validateNewSessionDestination(value)
+		}
 		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(key)), SettingChiefModelPrefix) {
 			// Model names/aliases are free-form (like the reviewer_model
 			// setting); accept any value and let the agent reject bad ones.
@@ -581,6 +595,18 @@ func validateAutoSettleSeconds(label, value string, minSeconds, maxSeconds int) 
 		return fmt.Errorf("%s must be between %d and %d seconds", label, minSeconds, maxSeconds)
 	}
 	return nil
+}
+
+// validateNewSessionDestination accepts an empty value (no remembered choice,
+// so the picker keeps its new-worktree default) or one of the two destinations
+// the picker can record.
+func validateNewSessionDestination(value string) error {
+	switch strings.TrimSpace(value) {
+	case "", DestinationNewWorktree, DestinationMainRepo:
+		return nil
+	default:
+		return fmt.Errorf("new session destination must be %q or %q: %s", DestinationNewWorktree, DestinationMainRepo, value)
+	}
 }
 
 func validateBooleanSetting(value string) error {


### PR DESCRIPTION
The new session picker always opened focused on the create-worktree form. That is right for a repo you always branch, and wrong for a repo you always work on directly — which cost an arrow key on every launch, forever.

## What changed

The last deliberate destination is now recorded **per repository**, and the chooser opens on it:

- creating a worktree records `new_worktree`
- opening the main checkout records `main_repo`
- opening an *existing* worktree is a one-off ("resume that one"), not a habit — it leaves the memory alone

`main_repo` opens the chooser on the main repo row so Enter reuses the checkout; anything else keeps today's create-form-focused behavior, so a repo you always branch still costs a single Enter. An exact typed worktree path still wins over the memory — that is an explicit "open this one" — and the create form stays one `↑` away from the main repo row.

## Where it lives

The daemon `settings` table, under `new_session_destination_<scope>_<repoRoot>` where scope is `local` or `endpoint_<id>` — the same path on this machine and on a remote endpoint are different checkouts, worked on in different ways. Unset means `new_worktree`, the default the picker has always had, so existing installs behave exactly as before until a choice is made. `set_setting` rejects unknown keys, so the prefix is registered in `validateSetting`, and the value is validated there with both allowed values named in the error.

Writes are skipped when the value has not moved: the picker is opened constantly, and re-storing the same value would broadcast a settings snapshot to every client for nothing.

## Two judgment calls

- **Recorded on intent, not on git's success.** A failed worktree create still records `new_worktree`. The user chose a destination, and the fire-and-forget create-worktree-session path has no result to await. Victor confirmed intent is enough.
- **Two states, not three.** Remembering a specific worktree path was considered and dropped: a worktree is transient, and "resume that one" is not a habit worth reopening on.

## The way out

Choosing the other destination once flips the memory, and `↑` from the main repo row returns to the create form. There is no third state to get stuck in.

## Verification

Live, in a packaged non-production profile (preflight PASS, CLI/app/daemon in protocol lockstep), driven through the UI automation bridge against a scratch git repo:

1. first visit — chooser opens on the create form, main repo row not armed
2. start a session in the main checkout
3. reopen — chooser opens with the main repo row armed
4. create a worktree instead
5. reopen — back to the create form

The daemon logged zero validation failures, and the setting persisted in the profile DB with exactly one write per deliberate choice. Profile cleaned up afterwards.

Automated: 80 picker tests (`LocationPicker`, `RepoOptions`), the daemon settings-validation table, full frontend suite, `tsc --noEmit`, `go build ./...`, `go test ./internal/daemon`. The three load-bearing assertions were mutation-checked — dropping the focus seed fails 2 tests, dropping the recording calls fails 3, widening the Go validator fails its case.

## Surfaces

- **CLI** — no default to remember: `cmd/attn` takes an explicit path or `--no-worktree` per invocation.
- **Protocol** — unchanged; `set_setting` is already free-form key/value, so no `ProtocolVersion` bump.
- **Linux** — the daemon change is pure Go with no platform surface.
- **Docs** — `app/src/components/NewSessionDialog/CLAUDE.md` plus a changelog fragment.

https://claude.ai/code/session_014Qt3hv4NRhBNqLyWcrEH9i
