### PR TITLE
docs: gate app capability discoverability at C2

### DIFF
--- a/changelog.d/sunny-meerkat-roadmap-discoverability.yaml
+++ b/changelog.d/sunny-meerkat-roadmap-discoverability.yaml
@@ -1,0 +1,10 @@
+kind: internal
+area: docs
+change: >
+  The extension-platform roadmap's C2 gate now includes app capability
+  discoverability: how an agent in an unrelated session learns an installed
+  app's surface exists (leading idea: a manifest-declared agent entry
+  materialized into the harness's skill mechanism at session launch), the
+  CLI shape for invoking app actions, and the context-scoping question for
+  the app index. The teachability ladder covered authoring only; the
+  consumer side is now a named gate question.

--- a/docs/plans/2026-08-01-extension-platform-roadmap.md
+++ b/docs/plans/2026-08-01-extension-platform-roadmap.md
@@ -55,7 +55,18 @@ implementation begins. The stage's detailed plan records the answers.
   claimants per hook; the delegation parked-state UX (what the app shows
   while parked).
 - **C2 (gate):** the approval UX itself (where the panel lives, what
-  reject-with-feedback delivers back to the delegating agent).
+  reject-with-feedback delivers back to the delegating agent); **app
+  capability discoverability** — how an agent in an unrelated session
+  learns an installed app's surface exists. Leading idea: a
+  manifest-declared agent entry (one-liner + instructions doc, frozen in
+  the version snapshot, apply still evaluates nothing) that attn
+  materializes into the harness's native skill mechanism at session launch
+  — one-liner always in context, body on demand, removed on
+  disable/remove. With it, the CLI shape for invoking an app's actions
+  (something like `attn app run <name> <action>`; undesigned), and a
+  scoping question that needs a receipt before apps are numerous: do all
+  enabled apps' one-liners belong in every session's context, or does the
+  index scope per workspace/repo?
 - **C3 (Present v2):** record shapes for presentations/stops; parity
   checklist defining what "the parts actually used" means before old
   Present is deleted.
@@ -210,7 +221,9 @@ Tour/Other/Skipped. Old Present deleted at parity on the actually-used parts.
 
 - **Teachability lands with each stage**, not at the end: SDK types (A5),
   scaffold + repo instructions (A4), teaching errors (every stage), the
-  short `ext` skill reference (C2, once the gate proves the surface).
+  short `ext` skill reference (C2, once the gate proves the surface). All
+  of that teaches *authoring*; how a consuming agent discovers an installed
+  app's capability is its own surface, gated at C2 (see Stage gates).
 - **Verification** per repo policy: every stage that touches daemon
   lifecycle, protocol, or UI needs live verification from a non-production
   profile; A2 additionally needs evidence that wire behavior is unchanged.


### PR DESCRIPTION
Docs-only follow-up to the A4 plan (#789). The roadmap's teachability ladder (SDK types, scaffold, repo instructions, teaching errors, the `ext` skill) covers *authoring* — how agents learn to write apps. It never addressed the consumer side: how an agent working in an unrelated attn session learns that an installed app's capability exists at all — the "how would anyone know Present exists" question, applied to custom apps.

This names it as a C2 gate question, with the leading design direction recorded:

- The manifest declares the agent-facing surface (one-liner + instructions doc), frozen into the version snapshot; apply still evaluates nothing.
- attn materializes it into the harness's native skill mechanism at session launch — one-liner always in context, body on demand, removed on disable/remove. Apps teach through the same channel attn itself uses; no new discovery machinery.
- The CLI shape for invoking an app's actions (something like `attn app run <name> <action>`) is flagged as undesigned.
- The open scoping question is named: whether every enabled app's one-liner belongs in every session's context needs a receipt before apps are numerous.

Deferring the design to C2 is already safe by construction: unknown manifest tables are loud apply-time errors gated by `attn_app_api`, so the agent entry slots in later without touching A4's slices.

https://claude.ai/code/session_01429snMWPwXjv1NeqUdV57c