### PR TITLE
feat(bus): register and unregister durable consumers at runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,6 +382,12 @@ carries the enumerated exception list.
 - Retention trims past the age window but never past an **enabled** consumer's
   cursor. Disabled consumers do not pin the log; they resume at head with a
   logged gap.
+- A durable consumer can register and unregister while the daemon runs.
+  `Unregister` cancels that consumer alone, waits for its delivery loop to exit,
+  and only then deletes the row: deleting first leaves a live loop reading a
+  registration that disappeared and retrying that error forever. It is
+  idempotent, and every uninstall path must call it — an abandoned enabled row
+  holds the retention floor down against a consumer nobody serves.
 - Operator surface: `attn bus status`, `attn bus disable|enable <consumer>`.
   The enabled bit is database-only on purpose — the kill switch must not depend
   on the daemon it kills.

--- a/changelog.d/bus-consumer-runtime-lifecycle.yaml
+++ b/changelog.d/bus-consumer-runtime-lifecycle.yaml
@@ -1,0 +1,22 @@
+kind: internal
+area: daemon
+change: >
+  Durable bus consumers can now arrive and leave while the daemon runs.
+  `Register` works after `Start` — it persists the registration and starts that
+  consumer's delivery loop immediately, from the log head, so nothing has to wait
+  for a restart to be served. `Unregister` is the way out: it cancels the
+  consumer's own context (interrupting the idle wait and the retry sleep alike, so
+  a consumer stalled at the two-minute retry cap does not delay it), waits for the
+  delivery loop to exit, and only then deletes the row.
+notes: >
+  The order is load-bearing in both directions: deleting the row first would leave
+  a live loop reading a registration that disappeared and retrying that error
+  forever, and returning before the loop exits would hand the caller a consumer
+  that is still delivering. Deleting the row is also what releases the retention
+  floor — an abandoned enabled registration pins the log against trimming and
+  compaction indefinitely. `Unregister` is idempotent and deletes rows this
+  process never registered, so it can clear an orphan an earlier daemon left
+  behind. At-least-once delivery, stall-don't-skip, cursor-after-handler, and the
+  database-only enabled bit are unchanged. Groundwork for stage A4, where each app
+  is its own durable consumer:
+  docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md.

--- a/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
+++ b/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
@@ -154,6 +154,18 @@ At-least-once, stall-don't-skip, cursor-after-handler semantics are untouched
 — apps are the first production durable consumers, and the point is to
 consume that machinery, not fork it.
 
+**Slice 1, as built.** `Register` is callable after `Start` and launches that
+consumer's delivery loop at once; `Unregister(name)` cancels the consumer, waits
+for its loop to exit, and only then deletes the row. Each consumer holds its own
+context, a child of the bus context, and both of the loop's waits — the idle
+select and the retry sleep — watch it, so unregistering a consumer stalled at the
+retry cap does not wait that cap out. The delete-last order is what keeps a live
+loop from reading a registration that disappeared, an error path that would retry
+forever; a handler that completes after the unregister has its cursor advance and
+its failure record dropped silently. `Unregister` is idempotent and deletes rows
+this process never registered, so an orphan an earlier daemon left behind — the
+thing that pins retention against a consumer nobody serves — is clearable.
+
 Per-handler cursors: considered, deferred. Per-app gives up independent
 progress across an app's subscriptions and partial survival of a poisoned
 event. Per-handler costs cross-handler ordering — one cursor means handlers

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -59,11 +59,6 @@ const (
 	DefaultRetryCap  = 2 * time.Minute
 )
 
-// ErrAlreadyStarted is returned by Register once Start has run: the set of
-// durable consumers is fixed at startup, so a delivery loop always exists for
-// every registration.
-var ErrAlreadyStarted = errors.New("bus: consumers must be registered before Start")
-
 // LogFunc matches the daemon's injected logger shape (see internal/jobs,
 // internal/pty). Runtime logging goes through it — never log.Printf, whose stderr
 // is discarded when the daemon runs in the background.
@@ -104,6 +99,9 @@ type Store interface {
 	Bounds() (earliest, head int64, err error)
 	GetConsumer(name string) (Consumer, bool, error)
 	SaveConsumer(c Consumer, now time.Time) error
+	// DeleteConsumer removes a registration. Deleting one that is not there is
+	// success: Unregister is an uninstall path and must be re-runnable.
+	DeleteConsumer(name string) error
 	SetCursor(name string, cursor int64, now time.Time) error
 	ListConsumers() ([]Consumer, error)
 	Trim(cutoff time.Time) (int, error)
@@ -169,11 +167,18 @@ type Bus struct {
 	// transaction in seq order with events this bus appended itself.
 	announced int64
 
+	// mu guards the consumer sets and the lifecycle bits below. Runtime
+	// registration does its two store reads under it: registering is a rare
+	// lifecycle event, and the alternative is a window where a consumer is in the
+	// set with no row behind it, or has a row with nobody serving it.
 	mu        sync.Mutex
 	durables  []*durable
 	ephemeral map[int]*ephemeralSub
 	nextSubID int
 	started   bool
+	// stopped is set before Stop cancels, so a registration racing shutdown does
+	// not add to wg while Stop is already waiting on it.
+	stopped bool
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -187,11 +192,29 @@ type durable struct {
 
 	wake chan struct{}
 
+	// ctx is a child of the bus context, so Stop cancels every consumer and
+	// Unregister cancels exactly one. Both of the delivery loop's waits — the
+	// retry sleep and the idle select — watch it, which is what lets an
+	// unregister interrupt a loop parked behind the two-minute retry cap instead
+	// of waiting it out.
+	ctx    context.Context
+	cancel context.CancelFunc
+	// done is closed when this consumer's delivery loop returns; Unregister waits
+	// on it before deleting the row. launched says a loop was ever started, and
+	// is guarded by the bus mutex — a consumer registered before Start and
+	// unregistered before it has no loop to wait for.
+	done     chan struct{}
+	launched bool
+
 	mu       sync.Mutex
 	cursor   int64
 	enabled  bool
 	stalled  string
 	failures int
+	// retired is set by Unregister before the row goes. It drops a late result
+	// from a handler that was in flight — a cursor advance or a failure record
+	// against a registration that no longer exists is a no-op, not an error.
+	retired bool
 }
 
 type ephemeralSub struct {
@@ -398,12 +421,18 @@ func (b *Bus) wakeDurables() {
 	}
 }
 
-// Register adds a durable consumer. It must be called before Start.
+// Register adds a durable consumer, before or after Start. Called before Start
+// it only records the registration, which Start then persists and serves; called
+// after, it persists the registration and starts that consumer's delivery loop
+// immediately — an app installed while the daemon runs must not wait for a
+// restart to receive facts.
 //
 // A consumer new to the store begins at head: registering a consumer is not a
 // request to replay history. An existing consumer keeps its cursor and its
 // enabled bit — restarting the daemon must neither rewind a consumer nor
-// resurrect one the operator killed.
+// resurrect one the operator killed. A registration that fails to persist leaves
+// nothing behind: the consumer is not in the set and no loop is running, so the
+// caller can retry.
 func (b *Bus) Register(name string, filter Filter, h Handler) error {
 	if strings.TrimSpace(name) == "" {
 		return errors.New("bus: consumer name is required")
@@ -414,22 +443,119 @@ func (b *Bus) Register(name string, filter Filter, h Handler) error {
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if b.started {
-		return ErrAlreadyStarted
-	}
 	for _, d := range b.durables {
 		if d.name == name {
 			return fmt.Errorf("bus: consumer %s already registered", name)
 		}
 	}
-	b.durables = append(b.durables, &durable{
+	d := b.newDurable(name, filter, h)
+
+	// Before Start, the registration is all there is to do: Start persists every
+	// consumer and launches its loop. The same is true for a bus with no store,
+	// which never delivers durably at all.
+	if !b.started || b.store == nil {
+		b.durables = append(b.durables, d)
+		return nil
+	}
+
+	_, head, err := b.store.Bounds()
+	if err != nil {
+		d.cancel()
+		return fmt.Errorf("bus: reading log bounds to register %s: %w", name, err)
+	}
+	if err := b.initConsumer(d, head); err != nil {
+		d.cancel()
+		return err
+	}
+	b.durables = append(b.durables, d)
+	b.launchLocked(d)
+	return nil
+}
+
+// Unregister stops a consumer's delivery loop and deletes its persisted row. It
+// is the way out of Register, and the reason it exists at all: an abandoned
+// enabled row holds the retention floor down forever, against a consumer nobody
+// serves.
+//
+// It is idempotent. A name this process never registered — an orphan row left by
+// an earlier daemon — is still deleted, and a name that does not exist at all is
+// success. The caller is an uninstall path, and an uninstall that fails the
+// second time it runs is a worse surface than one that says nothing.
+//
+// The order is cancel, wait for the loop to exit, then delete the row, and it is
+// load-bearing in both directions. Deleting first would leave the live loop's
+// next drain reading a registration that disappeared — an error path that records
+// a failure and retries forever, a zombie. Returning before the loop exits would
+// hand the caller a consumer that is still delivering. The wait is unbounded for
+// the same reason Stop's is: a handler that ignores its cancelled context is a
+// bug in the handler, and a retired consumer's late cursor advance is already
+// dropped, so waiting costs nothing a correct handler will notice.
+func (b *Bus) Unregister(name string) error {
+	b.mu.Lock()
+	var (
+		found *durable
+		wait  bool
+	)
+	for i, d := range b.durables {
+		if d.name != name {
+			continue
+		}
+		found = d
+		wait = d.launched
+		b.durables = append(b.durables[:i], b.durables[i+1:]...)
+		break
+	}
+	b.mu.Unlock()
+
+	if found != nil {
+		found.retire()
+		found.cancel()
+		if wait {
+			<-found.done
+		}
+	}
+
+	if b.store == nil {
+		return nil
+	}
+	if err := b.store.DeleteConsumer(name); err != nil {
+		return fmt.Errorf("bus: deleting consumer %s: %w", name, err)
+	}
+	return nil
+}
+
+// newDurable builds a consumer and its cancel scope. Callers that also touch the
+// consumer set hold b.mu; the bus context it reads is fixed at construction.
+func (b *Bus) newDurable(name string, filter Filter, h Handler) *durable {
+	ctx, cancel := context.WithCancel(b.ctx)
+	return &durable{
 		name:    name,
 		filter:  filter,
 		handler: h,
 		wake:    make(chan struct{}, 1),
+		ctx:     ctx,
+		cancel:  cancel,
+		done:    make(chan struct{}),
 		enabled: true,
-	})
-	return nil
+	}
+}
+
+// launchLocked starts d's delivery loop. Caller holds b.mu, which is what keeps
+// the WaitGroup increment ordered against Stop: Stop sets stopped under the same
+// lock before it waits, so a registration racing shutdown gets no loop rather
+// than adding to a WaitGroup somebody is already waiting on.
+func (b *Bus) launchLocked(d *durable) {
+	if b.stopped || b.ctx.Err() != nil {
+		close(d.done)
+		return
+	}
+	d.launched = true
+	b.wg.Add(1)
+	go func() {
+		defer b.wg.Done()
+		defer close(d.done)
+		b.deliver(d)
+	}()
 }
 
 // Subscribe adds an ephemeral subscriber and returns its cancel function. The
@@ -462,13 +588,11 @@ func (b *Bus) Subscribe(filter Filter, fn func(Event)) func() {
 // consumer, plus the retention loop.
 func (b *Bus) Start() error {
 	b.mu.Lock()
+	defer b.mu.Unlock()
 	if b.started {
-		b.mu.Unlock()
 		return nil
 	}
 	b.started = true
-	ds := append([]*durable(nil), b.durables...)
-	b.mu.Unlock()
 
 	if b.store == nil {
 		return nil
@@ -479,17 +603,16 @@ func (b *Bus) Start() error {
 		return fmt.Errorf("bus: reading log bounds: %w", err)
 	}
 
-	for _, d := range ds {
+	for _, d := range b.durables {
 		if err := b.initConsumer(d, head); err != nil {
 			return err
 		}
-		b.wg.Add(1)
-		go func(d *durable) {
-			defer b.wg.Done()
-			b.deliver(d)
-		}(d)
+		b.launchLocked(d)
 	}
 
+	if b.stopped {
+		return nil
+	}
 	b.wg.Add(1)
 	go func() {
 		defer b.wg.Done()
@@ -535,11 +658,17 @@ func (b *Bus) initConsumer(d *durable, head int64) error {
 // a cancelled context; their cursor is not advanced, so an interrupted event is
 // redelivered on the next start.
 func (b *Bus) Stop() {
+	b.mu.Lock()
+	b.stopped = true
+	b.mu.Unlock()
+
 	b.cancel()
 	b.wg.Wait()
 }
 
-// deliver is one durable consumer's loop.
+// deliver is one durable consumer's loop. Every wait watches the consumer's own
+// context, a child of the bus context: Stop reaches all of them, Unregister
+// reaches this one, and neither has to wait out a retry sleep to be noticed.
 func (b *Bus) deliver(d *durable) {
 	ticker := time.NewTicker(b.pollInterval)
 	defer ticker.Stop()
@@ -549,7 +678,7 @@ func (b *Bus) deliver(d *durable) {
 		if retry > 0 {
 			timer := time.NewTimer(retry)
 			select {
-			case <-b.ctx.Done():
+			case <-d.ctx.Done():
 				timer.Stop()
 				return
 			case <-timer.C:
@@ -557,7 +686,7 @@ func (b *Bus) deliver(d *durable) {
 			retry = 0
 		} else {
 			select {
-			case <-b.ctx.Done():
+			case <-d.ctx.Done():
 				return
 			case <-d.wake:
 			case <-ticker.C:
@@ -566,7 +695,7 @@ func (b *Bus) deliver(d *durable) {
 
 		failures := d.drainFailures()
 		if err := b.drain(d); err != nil {
-			if b.ctx.Err() != nil {
+			if d.ctx.Err() != nil {
 				return
 			}
 			retry = backoff(b.retryBase, b.retryCap, failures+1)
@@ -619,7 +748,7 @@ func (b *Bus) drain(d *durable) error {
 	}
 
 	for {
-		if b.ctx.Err() != nil {
+		if d.ctx.Err() != nil {
 			return nil
 		}
 		events, err := b.store.Since(d.position(), b.batchSize)
@@ -633,7 +762,7 @@ func (b *Bus) drain(d *durable) error {
 
 		var skipped int64
 		for _, ev := range events {
-			if b.ctx.Err() != nil {
+			if d.ctx.Err() != nil {
 				return nil
 			}
 			stop, err := killed()
@@ -658,8 +787,8 @@ func (b *Bus) drain(d *durable) error {
 				}
 				skipped = 0
 			}
-			if err := d.handler(b.ctx, ev); err != nil {
-				if b.ctx.Err() != nil {
+			if err := d.handler(d.ctx, ev); err != nil {
+				if d.ctx.Err() != nil {
 					return nil
 				}
 				return fmt.Errorf("handling %s (seq %d): %w", ev.Name, ev.Seq, err)
@@ -700,6 +829,13 @@ func (b *Bus) reconcileGap(d *durable) error {
 }
 
 func (b *Bus) advance(d *durable, seq int64) error {
+	// A handler that was in flight when Unregister landed may still be returning
+	// here. Its registration is gone, so there is no cursor to move: dropping the
+	// write is the correct outcome, and reporting it as an error would turn a
+	// clean uninstall into a stall on a consumer nobody serves.
+	if d.isRetired() {
+		return nil
+	}
 	if err := b.store.SetCursor(d.name, seq, b.now()); err != nil {
 		return fmt.Errorf("persisting cursor: %w", err)
 	}
@@ -928,11 +1064,29 @@ func (d *durable) setEnabled(enabled bool) {
 	d.mu.Unlock()
 }
 
+// retire marks the consumer unregistered, which is what makes a late result from
+// an in-flight handler a no-op rather than an error or a failure streak against a
+// registration that no longer exists.
+func (d *durable) retire() {
+	d.mu.Lock()
+	d.retired = true
+	d.mu.Unlock()
+}
+
+func (d *durable) isRetired() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.retired
+}
+
 func (d *durable) recordFailure(reason string, count int) {
 	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.retired {
+		return
+	}
 	d.stalled = reason
 	d.failures = count
-	d.mu.Unlock()
 }
 
 func (d *durable) clearFailure() {

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -179,6 +179,9 @@ type Bus struct {
 	// stopped is set before Stop cancels, so a registration racing shutdown does
 	// not add to wg while Stop is already waiting on it.
 	stopped bool
+	// retiring holds the names Unregister is between removing and deleting the row
+	// for. See Register for what taking one of them back early would cost.
+	retiring map[string]struct{}
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -238,6 +241,7 @@ func New(opts Options) *Bus {
 		retryCap:     nonZeroDuration(opts.RetryCap, DefaultRetryCap),
 		compactable:  append([]string(nil), opts.Compactable...),
 		ephemeral:    map[int]*ephemeralSub{},
+		retiring:     map[string]struct{}{},
 	}
 	if b.now == nil {
 		b.now = time.Now
@@ -448,6 +452,14 @@ func (b *Bus) Register(name string, filter Filter, h Handler) error {
 			return fmt.Errorf("bus: consumer %s already registered", name)
 		}
 	}
+	// A name being unregistered is claimed until its row is gone. Taking it back
+	// inside that window would resume the outgoing consumer's cursor from a row
+	// that is about to be deleted under the new loop — which then drains against a
+	// registration that disappeared and retries that error forever. Same zombie the
+	// delete-last ordering exists to prevent, through the side door.
+	if _, retiring := b.retiring[name]; retiring {
+		return fmt.Errorf("bus: consumer %s is being unregistered; retry once it is gone", name)
+	}
 	d := b.newDurable(name, filter, h)
 
 	// Before Start, the registration is all there is to do: Start persists every
@@ -490,6 +502,10 @@ func (b *Bus) Register(name string, filter Filter, h Handler) error {
 // the same reason Stop's is: a handler that ignores its cancelled context is a
 // bug in the handler, and a retired consumer's late cursor advance is already
 // dropped, so waiting costs nothing a correct handler will notice.
+//
+// The name stays claimed for the whole of it, so a Register that arrives while the
+// loop is winding down is refused rather than served from a row about to be
+// deleted underneath it.
 func (b *Bus) Unregister(name string) error {
 	b.mu.Lock()
 	var (
@@ -505,7 +521,15 @@ func (b *Bus) Unregister(name string) error {
 		b.durables = append(b.durables[:i], b.durables[i+1:]...)
 		break
 	}
+	b.retiring[name] = struct{}{}
 	b.mu.Unlock()
+	// Released whatever happens, including a failed delete: a surviving row is the
+	// ordinary resume-from-cursor case, and the caller already has the error.
+	defer func() {
+		b.mu.Lock()
+		delete(b.retiring, name)
+		b.mu.Unlock()
+	}()
 
 	if found != nil {
 		found.retire()

--- a/internal/bus/bus_test.go
+++ b/internal/bus/bus_test.go
@@ -21,6 +21,10 @@ type memStore struct {
 	sinceErr  error
 	appendErr error
 	boundsErr error
+	deleteErr error
+	// onDelete observes the moment a registration is removed, which is where the
+	// unregister ordering (loop exits, then the row goes) is checkable.
+	onDelete func(name string)
 }
 
 func newMemStore() *memStore {
@@ -91,6 +95,23 @@ func (m *memStore) SaveConsumer(c Consumer, now time.Time) error {
 	return nil
 }
 
+func (m *memStore) DeleteConsumer(name string) error {
+	m.mu.Lock()
+	hook, err := m.onDelete, m.deleteErr
+	if err == nil {
+		delete(m.consumers, name)
+	}
+	m.mu.Unlock()
+
+	if hook != nil {
+		hook(name)
+	}
+	return err
+}
+
+// SetCursor refuses a name it does not know, exactly as an UPDATE that matches no
+// row would leave a cursor unmoved. A cursor write for a deleted consumer must
+// therefore never reach the store — the fake is what proves it does not.
 func (m *memStore) SetCursor(name string, cursor int64, now time.Time) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -109,6 +130,12 @@ func (m *memStore) SetCursor(name string, cursor int64, now time.Time) error {
 func (m *memStore) setBoundsErr(err error) {
 	m.mu.Lock()
 	m.boundsErr = err
+	m.mu.Unlock()
+}
+
+func (m *memStore) setDeleteErr(err error) {
+	m.mu.Lock()
+	m.deleteErr = err
 	m.mu.Unlock()
 }
 
@@ -644,20 +671,6 @@ func TestStatusReportsLagAndLiveness(t *testing.T) {
 	}
 	if !c.Live {
 		t.Fatal("a consumer with a running loop should report Live")
-	}
-}
-
-// A registration is a startup-time decision: every persisted consumer has a
-// delivery loop, so there is no such thing as a registration nobody serves.
-func TestRegisterAfterStartIsRejected(t *testing.T) {
-	b := testBus(t, newMemStore())
-	if err := b.Start(); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-	t.Cleanup(b.Stop)
-
-	if err := b.Register("late", All, func(context.Context, Event) error { return nil }); !errors.Is(err, ErrAlreadyStarted) {
-		t.Fatalf("Register after Start = %v, want ErrAlreadyStarted", err)
 	}
 }
 

--- a/internal/bus/lifecycle_test.go
+++ b/internal/bus/lifecycle_test.go
@@ -3,6 +3,7 @@ package bus
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -178,6 +179,10 @@ func TestUnregisterDeletesTheRowOnlyAfterTheLoopExits(t *testing.T) {
 
 	entered := make(chan struct{})
 	release := make(chan struct{})
+	// Released on cleanup too, so an assertion that fails before the release below
+	// still frees the handler: otherwise Stop would wait on a loop parked inside it
+	// and the failure would read as a hang.
+	releaseHandler := sync.OnceFunc(func() { close(release) })
 	// The handler deliberately ignores cancellation: the case under test is a
 	// handler still running when Unregister lands.
 	handler := func(context.Context, Event) error {
@@ -192,6 +197,9 @@ func TestUnregisterDeletesTheRowOnlyAfterTheLoopExits(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 	t.Cleanup(b.Stop)
+	// Registered after Stop's cleanup so it runs before it: cleanups are LIFO, and
+	// Stop waits for the delivery loop that is parked inside the handler.
+	t.Cleanup(releaseHandler)
 
 	d := b.durables[0]
 	var deletedWhileRunning atomic.Bool
@@ -214,7 +222,7 @@ func TestUnregisterDeletesTheRowOnlyAfterTheLoopExits(t *testing.T) {
 	// Wait for Unregister to have retired the consumer, so releasing the handler
 	// really is a result arriving after the unregister began.
 	waitFor(t, "the consumer to be retired", d.isRetired)
-	close(release)
+	releaseHandler()
 
 	if err := <-done; err != nil {
 		t.Fatalf("Unregister: %v", err)
@@ -232,6 +240,68 @@ func TestUnregisterDeletesTheRowOnlyAfterTheLoopExits(t *testing.T) {
 	if _, ok, err := s.GetConsumer("app:slow"); err != nil || ok {
 		t.Fatalf("a late handler result wrote to the deleted registration (found=%v, err=%v)", ok, err)
 	}
+}
+
+// The name is claimed for the whole of Unregister, not just up to the moment it
+// leaves the in-memory set. Serving a Register inside that window would resume the
+// outgoing consumer's cursor from a row that is deleted underneath the new loop,
+// which then drains against a registration that disappeared and retries that error
+// forever — the zombie the delete-last ordering exists to prevent, through the
+// side door.
+func TestRegisterIsRefusedWhileTheNameIsBeingUnregistered(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	releaseHandler := sync.OnceFunc(func() { close(release) })
+	handler := func(context.Context, Event) error {
+		close(entered)
+		<-release
+		return nil
+	}
+	if err := b.Register("app:notes", All, handler); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+	// After Stop's cleanup, so it runs before it. See the note above.
+	t.Cleanup(releaseHandler)
+
+	d := b.durables[0]
+	if _, err := b.Publish("work.happened", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	<-entered
+
+	done := make(chan error, 1)
+	go func() { done <- b.Unregister("app:notes") }()
+	waitFor(t, "the consumer to be retired", d.isRetired)
+
+	// The row still exists here: the loop has not exited, so the delete has not run.
+	if _, ok, err := s.GetConsumer("app:notes"); err != nil || !ok {
+		t.Fatalf("expected the row to still exist mid-unregister (found=%v, err=%v)", ok, err)
+	}
+	if err := b.Register("app:notes", All, func(context.Context, Event) error { return nil }); err == nil {
+		t.Fatal("Register was served while the name was being unregistered")
+	}
+
+	releaseHandler()
+	if err := <-done; err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+
+	// Once the row is gone the name is free again.
+	rec := newRecorder()
+	if err := b.Register("app:notes", All, rec.handle); err != nil {
+		t.Fatalf("Register after the unregister completed: %v; the name stayed claimed", err)
+	}
+	if _, err := b.Publish("after.reinstall", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	waitFor(t, "the reinstalled consumer to deliver", func() bool { return rec.count() >= 1 })
 }
 
 // A retired consumer writes nothing. Its handler may still be in flight when the
@@ -416,9 +486,11 @@ func TestReinstallAfterUnregisterStartsAtHead(t *testing.T) {
 	}
 }
 
-// A registration that cannot be persisted leaves nothing behind: no consumer in
-// the set, no loop, and the name is free to try again.
-func TestRegisterAfterStartRollsBackWhenThePersistFails(t *testing.T) {
+// A registration that fails anywhere before it is recorded leaves nothing behind:
+// no consumer in the set, no loop, and the name is free to try again. The failure
+// injected here is the log-bounds read, the first of the two store calls; the
+// invariant is the same for either.
+func TestRegisterAfterStartRollsBackWhenRegistrationFails(t *testing.T) {
 	s := newMemStore()
 	b := testBus(t, s)
 	if err := b.Start(); err != nil {

--- a/internal/bus/lifecycle_test.go
+++ b/internal/bus/lifecycle_test.go
@@ -1,0 +1,443 @@
+package bus
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Runtime consumer lifecycle: a durable consumer can arrive and leave while the
+// bus runs, because an app installs and uninstalls while the daemon runs.
+
+// A consumer registered after Start is served immediately — an install must not
+// wait for a daemon restart — and it starts at head, exactly as one registered
+// before Start does. Registration is not a request to replay history.
+func TestRegisterAfterStartDeliversFromHead(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	if _, err := b.Publish("before.install", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	rec := newRecorder()
+	if err := b.Register("app:notes", All, rec.handle); err != nil {
+		t.Fatalf("Register after Start: %v", err)
+	}
+
+	if _, err := b.Publish("after.install", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	waitFor(t, "the post-registration fact", func() bool { return rec.count() >= 1 })
+
+	names, _ := rec.snapshot()
+	if len(names) != 1 || names[0] != "after.install" {
+		t.Fatalf("delivered %v; a consumer installed at runtime must not replay history", names)
+	}
+	if _, ok, err := s.GetConsumer("app:notes"); err != nil || !ok {
+		t.Fatalf("registration was not persisted (found=%v, err=%v)", ok, err)
+	}
+}
+
+// Head is where a consumer NEW to the store starts. One whose row survives — the
+// same daemon re-registering it after a restart, an app whose registration was
+// never removed — resumes from its persisted cursor, so runtime registration
+// carries the same catch-up guarantee startup registration does.
+func TestRegisterAfterStartResumesAnExistingCursor(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	// A row left at cursor 0 by an earlier run, and a backlog it never read.
+	if err := s.SaveConsumer(Consumer{Name: "app:notes", Cursor: 0, Filter: "*", Enabled: true}, time.Now()); err != nil {
+		t.Fatalf("seeding the consumer: %v", err)
+	}
+	for _, name := range []string{"a.happened", "b.happened"} {
+		if _, err := b.Publish(name, "", nil); err != nil {
+			t.Fatalf("Publish(%s): %v", name, err)
+		}
+	}
+
+	rec := newRecorder()
+	if err := b.Register("app:notes", All, rec.handle); err != nil {
+		t.Fatalf("Register after Start: %v", err)
+	}
+	waitFor(t, "the backlog to be delivered", func() bool { return rec.count() >= 2 })
+
+	names, _ := rec.snapshot()
+	if len(names) != 2 || names[0] != "a.happened" || names[1] != "b.happened" {
+		t.Fatalf("delivered %v; a runtime registration must resume its persisted cursor", names)
+	}
+}
+
+// Unregister is the way out: the loop stops and the row goes. The row matters as
+// much as the loop — while it exists and is enabled it holds the retention floor
+// down against a consumer nobody serves.
+func TestUnregisterStopsDeliveryAndDeletesTheRow(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+
+	// A second consumer that stays registered is the signal that the bus has
+	// delivered a later fact, so "the unregistered one received nothing more" is
+	// asserted against a real receipt rather than a wait.
+	witness := newRecorder()
+	if err := b.Register("witness", All, witness.handle); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	rec := newRecorder()
+	if err := b.Register("app:notes", All, rec.handle); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if _, err := b.Publish("one.happened", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	waitFor(t, "the first delivery", func() bool { return rec.count() == 1 })
+
+	if err := b.Unregister("app:notes"); err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+	if _, ok, err := s.GetConsumer("app:notes"); err != nil || ok {
+		t.Fatalf("the consumer row survived Unregister (found=%v, err=%v)", ok, err)
+	}
+
+	if _, err := b.Publish("two.happened", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	waitFor(t, "the witness to receive the later fact", func() bool { return witness.count() == 2 })
+	if n := rec.count(); n != 1 {
+		t.Fatalf("the unregistered consumer received %d events, want 1: its loop is still delivering", n)
+	}
+}
+
+// Unregister must interrupt a loop parked in its retry sleep. A consumer stalled
+// at the retry cap sits in that wait for two minutes; an uninstall that had to
+// wait it out would look like a hang.
+func TestUnregisterInterruptsAConsumerParkedInRetryBackoff(t *testing.T) {
+	s := newMemStore()
+	// A retry sleep far longer than any correct run needs: if Unregister waits for
+	// the timer, this test hangs to its tripwire instead of passing slowly.
+	b := New(Options{
+		Store:        s,
+		Log:          func(string, ...interface{}) {},
+		PollInterval: 5 * time.Millisecond,
+		RetryBase:    time.Hour,
+		RetryCap:     time.Hour,
+		TrimInterval: time.Hour,
+	})
+
+	var attempts atomic.Int64
+	handler := func(context.Context, Event) error {
+		attempts.Add(1)
+		return errors.New("handler boom")
+	}
+	if err := b.Register("app:stuck", All, handler); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	if _, err := b.Publish("work.happened", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	waitFor(t, "the handler to fail once", func() bool { return attempts.Load() >= 1 })
+
+	done := make(chan error, 1)
+	go func() { done <- b.Unregister("app:stuck") }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Unregister: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Unregister blocked behind the consumer's retry sleep")
+	}
+}
+
+// Cancel, wait for the loop to exit, then delete the row — in that order. Deleting
+// first leaves the live loop reading a registration that disappeared, which is an
+// error path that records a failure and retries forever: a zombie consumer.
+func TestUnregisterDeletesTheRowOnlyAfterTheLoopExits(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	// The handler deliberately ignores cancellation: the case under test is a
+	// handler still running when Unregister lands.
+	handler := func(context.Context, Event) error {
+		close(entered)
+		<-release
+		return nil
+	}
+	if err := b.Register("app:slow", All, handler); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	d := b.durables[0]
+	var deletedWhileRunning atomic.Bool
+	s.onDelete = func(string) {
+		select {
+		case <-d.done:
+		default:
+			deletedWhileRunning.Store(true)
+		}
+	}
+
+	if _, err := b.Publish("work.happened", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	<-entered
+
+	done := make(chan error, 1)
+	go func() { done <- b.Unregister("app:slow") }()
+
+	// Wait for Unregister to have retired the consumer, so releasing the handler
+	// really is a result arriving after the unregister began.
+	waitFor(t, "the consumer to be retired", d.isRetired)
+	close(release)
+
+	if err := <-done; err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+	if deletedWhileRunning.Load() {
+		t.Fatal("the row was deleted while the delivery loop was still running")
+	}
+	select {
+	case <-d.done:
+	default:
+		t.Fatal("Unregister returned while the delivery loop was still running")
+	}
+	// The handler completed after the unregister; its cursor advance is dropped,
+	// so nothing recreated or moved the row it no longer owns.
+	if _, ok, err := s.GetConsumer("app:slow"); err != nil || ok {
+		t.Fatalf("a late handler result wrote to the deleted registration (found=%v, err=%v)", ok, err)
+	}
+}
+
+// A retired consumer writes nothing. Its handler may still be in flight when the
+// registration goes, and a cursor advance or failure record against a row that no
+// longer exists is a no-op — not an error, not a failure streak.
+func TestRetiredConsumerDropsLateResults(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+
+	d := b.newDurable("app:gone", All, func(context.Context, Event) error { return nil })
+	t.Cleanup(d.cancel)
+	d.retire()
+
+	if err := b.advance(d, 7); err != nil {
+		t.Fatalf("a late cursor advance must be dropped silently, got %v", err)
+	}
+	if _, ok, err := s.GetConsumer("app:gone"); err != nil || ok {
+		t.Fatalf("a retired consumer moved or recreated its row (found=%v, err=%v)", ok, err)
+	}
+
+	d.recordFailure("handler boom", 3)
+	if reason, failures := d.stallReason(), d.drainFailures(); reason != "" || failures != 0 {
+		t.Fatalf("a retired consumer recorded a stall (%q, %d attempts)", reason, failures)
+	}
+}
+
+// The orphan case the row lifecycle exists for: a stalled enabled consumer pins
+// retention, and nothing above its cursor can be trimmed while it is registered.
+// Unregistering it is what lets the floor move again.
+func TestUnregisteringAStalledConsumerReleasesTheRetentionFloor(t *testing.T) {
+	s := newMemStore()
+	clk := &testClock{now: time.Now()}
+	b := New(Options{
+		Store:        s,
+		Log:          func(string, ...interface{}) {},
+		Now:          clk.get,
+		Retention:    time.Hour,
+		TrimInterval: time.Hour,
+		PollInterval: 5 * time.Millisecond,
+		RetryBase:    5 * time.Millisecond,
+		RetryCap:     20 * time.Millisecond,
+	})
+
+	var attempts atomic.Int64
+	handler := func(context.Context, Event) error {
+		attempts.Add(1)
+		return errors.New("handler boom")
+	}
+	if err := b.Register("app:stuck", All, handler); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	// Two facts well outside the retention window, neither of which the stalled
+	// consumer will ever get past.
+	clk.advance(-4 * time.Hour)
+	for _, name := range []string{"a.happened", "b.happened"} {
+		if _, err := b.Publish(name, "", nil); err != nil {
+			t.Fatalf("Publish(%s): %v", name, err)
+		}
+	}
+	clk.advance(4 * time.Hour)
+	waitFor(t, "the consumer to stall on the first fact", func() bool { return attempts.Load() >= 2 })
+
+	if n, err := b.Trim(); err != nil || n != 0 {
+		t.Fatalf("trimmed %d event(s) (err=%v); a stalled enabled consumer must pin the log", n, err)
+	}
+
+	if err := b.Unregister("app:stuck"); err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+	if n, err := b.Trim(); err != nil || n != 2 {
+		t.Fatalf("trimmed %d event(s) (err=%v) after the consumer was unregistered, want 2: the floor is still pinned", n, err)
+	}
+}
+
+// Unregister is idempotent, and it deletes rows this process never registered —
+// the orphan an earlier daemon left behind is exactly what an uninstall has to be
+// able to clear.
+func TestUnregisterIsIdempotentAndClearsOrphanRows(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	if err := s.SaveConsumer(Consumer{Name: "app:ghost", Cursor: 0, Filter: "*", Enabled: true}, time.Now()); err != nil {
+		t.Fatalf("seeding the orphan row: %v", err)
+	}
+
+	if err := b.Unregister("app:ghost"); err != nil {
+		t.Fatalf("Unregister of an orphan row: %v", err)
+	}
+	if _, ok, err := s.GetConsumer("app:ghost"); err != nil || ok {
+		t.Fatalf("the orphan row survived (found=%v, err=%v)", ok, err)
+	}
+	if err := b.Unregister("app:ghost"); err != nil {
+		t.Fatalf("second Unregister: %v; an uninstall path must be re-runnable", err)
+	}
+	if err := b.Unregister("never-registered"); err != nil {
+		t.Fatalf("Unregister of an unknown name: %v", err)
+	}
+}
+
+// A row that could not be deleted is reported, not swallowed: the loop is already
+// stopped, so the caller is left with an orphan row it has to be able to see and
+// retry.
+func TestUnregisterReportsAFailedRowDelete(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+
+	rec := newRecorder()
+	if err := b.Register("app:notes", All, rec.handle); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+	waitFor(t, "the registration to be persisted", func() bool {
+		_, ok, _ := s.GetConsumer("app:notes")
+		return ok
+	})
+
+	s.setDeleteErr(errors.New("database is having a bad night"))
+	if err := b.Unregister("app:notes"); err == nil {
+		t.Fatal("Unregister reported success while the row could not be deleted")
+	}
+
+	s.setDeleteErr(nil)
+	if err := b.Unregister("app:notes"); err != nil {
+		t.Fatalf("retried Unregister: %v", err)
+	}
+	if _, ok, err := s.GetConsumer("app:notes"); err != nil || ok {
+		t.Fatalf("the row survived the retry (found=%v, err=%v)", ok, err)
+	}
+}
+
+// Reinstalling under the same name starts at head again: the cursor left with the
+// row, so an app that was removed and put back reacts to what happens next rather
+// than to the backlog it missed.
+func TestReinstallAfterUnregisterStartsAtHead(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	first := newRecorder()
+	if err := b.Register("app:notes", All, first.handle); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if _, err := b.Publish("one.happened", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	waitFor(t, "the first delivery", func() bool { return first.count() == 1 })
+	if err := b.Unregister("app:notes"); err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+
+	if _, err := b.Publish("while.gone", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	second := newRecorder()
+	if err := b.Register("app:notes", All, second.handle); err != nil {
+		t.Fatalf("re-Register: %v", err)
+	}
+	if _, err := b.Publish("after.reinstall", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	waitFor(t, "the post-reinstall fact", func() bool { return second.count() >= 1 })
+
+	names, _ := second.snapshot()
+	if len(names) != 1 || names[0] != "after.reinstall" {
+		t.Fatalf("delivered %v; a reinstalled consumer must start at head", names)
+	}
+}
+
+// A registration that cannot be persisted leaves nothing behind: no consumer in
+// the set, no loop, and the name is free to try again.
+func TestRegisterAfterStartRollsBackWhenThePersistFails(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	s.setBoundsErr(errors.New("database is having a bad night"))
+	if err := b.Register("app:notes", All, func(context.Context, Event) error { return nil }); err == nil {
+		t.Fatal("Register reported success while the log could not be read")
+	}
+	s.setBoundsErr(nil)
+
+	rec := newRecorder()
+	if err := b.Register("app:notes", All, rec.handle); err != nil {
+		t.Fatalf("Register after a failed attempt: %v; the name was left claimed", err)
+	}
+	if _, err := b.Publish("after.install", "", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	waitFor(t, "the retried registration to deliver", func() bool { return rec.count() >= 1 })
+}

--- a/internal/daemon/bus_store.go
+++ b/internal/daemon/bus_store.go
@@ -77,6 +77,10 @@ func (a *sqlBusStore) SaveConsumer(c bus.Consumer, now time.Time) error {
 	}, now)
 }
 
+func (a *sqlBusStore) DeleteConsumer(name string) error {
+	return a.store.DeleteBusConsumer(name)
+}
+
 func (a *sqlBusStore) SetCursor(name string, cursor int64, now time.Time) error {
 	return a.store.SetBusConsumerCursor(name, cursor, now)
 }

--- a/internal/store/bus.go
+++ b/internal/store/bus.go
@@ -215,6 +215,24 @@ func (s *Store) SetBusConsumerEnabled(name string, enabled bool, now time.Time) 
 	return err
 }
 
+// DeleteBusConsumer removes a registration. Deleting a row that is not there is
+// success, not an error: the caller is an uninstall path, and an uninstall that
+// fails the second time it runs is a worse surface than one that says nothing.
+//
+// An abandoned row is not harmless. While it exists and is enabled it holds the
+// cursor floor down, so retention and compaction cannot pass it — forever, for a
+// consumer nobody serves. Deleting the row is what ends that.
+func (s *Store) DeleteBusConsumer(name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	_, err := s.db.Exec(`DELETE FROM bus_consumers WHERE name = ?`, name)
+	return err
+}
+
 // ListBusConsumers returns every registration, by name.
 func (s *Store) ListBusConsumers() ([]BusConsumer, error) {
 	s.mu.RLock()

--- a/internal/store/bus_test.go
+++ b/internal/store/bus_test.go
@@ -129,6 +129,46 @@ func TestSaveBusConsumerPreservesCursorAndEnabled(t *testing.T) {
 	}
 }
 
+// Deleting a registration is what ends its hold on the retention floor: while the
+// row exists and is enabled, events it has not read cannot be trimmed, however
+// long ago whoever served it went away.
+func TestDeleteBusConsumerReleasesTheRetentionFloor(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	appendBus(t, s, "a.happened", "", busBase)
+	appendBus(t, s, "b.happened", "", busBase.Add(time.Minute))
+
+	if err := s.SaveBusConsumer(BusConsumer{Name: "app:ghost", Cursor: 0, Filter: "*", Enabled: true}, busBase); err != nil {
+		t.Fatalf("SaveBusConsumer: %v", err)
+	}
+	if n, err := s.TrimBusEvents(busBase.Add(time.Hour)); err != nil || n != 0 {
+		t.Fatalf("trimmed %d event(s) (err=%v); an enabled row must pin the log", n, err)
+	}
+
+	if err := s.DeleteBusConsumer("app:ghost"); err != nil {
+		t.Fatalf("DeleteBusConsumer: %v", err)
+	}
+	if _, ok, err := s.GetBusConsumer("app:ghost"); err != nil || ok {
+		t.Fatalf("the row survived deletion (found=%v, err=%v)", ok, err)
+	}
+	if n, err := s.TrimBusEvents(busBase.Add(time.Hour)); err != nil || n != 2 {
+		t.Fatalf("trimmed %d event(s) (err=%v) after the row went, want 2", n, err)
+	}
+}
+
+// Deleting a row that is not there is success: the caller is an uninstall path,
+// and an uninstall that fails the second time it runs is a worse surface than one
+// that says nothing.
+func TestDeleteBusConsumerMissingIsSuccess(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	if err := s.DeleteBusConsumer("nobody"); err != nil {
+		t.Fatalf("DeleteBusConsumer of an unknown name: %v", err)
+	}
+}
+
 func TestGetBusConsumerMissing(t *testing.T) {
 	s := New()
 	t.Cleanup(func() { _ = s.Close() })


### PR DESCRIPTION
Durable bus consumers can now arrive and leave while the daemon runs. Registration
was startup-only (`ErrAlreadyStarted`) and a consumer row outlived its
registration forever; stage A4 makes every app its own durable consumer
(`app:<name>`), and apps install and uninstall against a running daemon.

Design: `docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md`, "Bus
consumption — real per-app consumers".

## What changed

- **`Register` works after `Start`.** It persists the registration and launches
  that consumer's delivery loop immediately, with the semantics a loop gets at
  startup: from head if the consumer is new to the store, from its persisted
  cursor if a row survives. A registration that fails to persist leaves nothing
  behind — no consumer in the set, no loop, name free to retry.
- **`Unregister(name)`** cancels the consumer, waits for its loop to exit, then
  deletes the row.
- **Per-consumer cancellation.** Each consumer's context is a child of the bus
  context, and both of the delivery loop's waits — the idle select and the retry
  sleep — watch it. Unregistering a consumer stalled at the two-minute retry cap
  no longer waits that cap out. `Stop` is unchanged: cancelling the parent
  cancels every child.
- **Row lifecycle.** `Store` grows `DeleteConsumer`; `internal/store` grows
  `DeleteBusConsumer`.

## The ordering, which is the contract

Cancel → wait for the loop to exit → delete the row. Load-bearing in both
directions:

- Deleting the row first is a zombie generator: the live loop's next drain reads
  "registration for X disappeared", which records a failure and retries forever.
- Returning before the loop exits hands the caller a consumer that is still
  delivering.

The wait is unbounded, for the same reason `Stop`'s is — a handler that ignores
its cancelled context is a bug in the handler. Beyond that, a retired consumer
writes nothing: a handler that completes after `Unregister` began has its cursor
advance and its failure record dropped silently, so a late result can neither
error nor stall a registration that no longer exists.

`Unregister` is idempotent, and deletes rows this process never registered. The
caller is an uninstall path that must be re-runnable, and an orphan row left by an
earlier daemon is precisely what needs clearing: while it exists and is enabled it
holds the retention floor down, so nothing above its cursor can be trimmed or
compacted, forever, for a consumer nobody serves.

## Tests

`internal/bus/lifecycle_test.go`, following the package's existing idioms (in-memory
store mirroring the SQLite semantics, real signals rather than sleeps — the
"nothing more was delivered" assertions wait on a second consumer's receipt):

- runtime registration delivers, from head when new and from the persisted cursor
  when a row survives;
- unregister stops delivery and deletes the row;
- unregister interrupts a consumer parked in its retry sleep (a one-hour retry
  base, so waiting the timer out hits the test's tripwire instead of passing
  slowly);
- the row is deleted only after the loop exits — checked at the moment of
  deletion, against a handler deliberately still running;
- a retired consumer drops late results;
- **the pin-the-log orphan case**: a stalled enabled consumer pins retention
  (`Trim` removes 0), and after `Unregister` the floor advances (`Trim` removes
  both events);
- idempotency, orphan-row clearing, reinstall-starts-at-head, and a failed row
  delete reported rather than swallowed.

Store-level: deleting a row releases the retention floor; deleting a missing row
is success.

Every new test was mutation-checked — each of the five behaviors above was broken
in turn and the corresponding test went red.

Unchanged and verified by the existing suite: at-least-once delivery,
stall-don't-skip, cursor-advance-after-handler, the database-only enabled bit and
its 5-second re-read bound, `consumerFloor` counting enabled consumers only,
retention's age window plus cursor floor, and
`TestWireTrafficComesFromProjections`.

## Verification tier

Daemon-internal: this slice adds a seam with no caller yet — no app registry, no
CLI surface, no protocol change, no wire traffic, no projection. Unit tests
(`-race`) plus the daemon projection guard are the proof; live verification of app
install/uninstall belongs to the slice that adds the caller (A4 slice 6). Linux
cross-compile checked.

## Non-goals

App registry, `attn app` CLI, and the Bun sidecar are later A4 slices. Publish and
fan-out are untouched. Per-handler cursors stay deferred, per the plan.
