### PR TITLE
refactor(daemon): extract the process supervisor into internal/supervise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,11 @@ forgets that position and `--since <RFC3339>` replays from an instant.
   field name — never from caller text
 - `internal/jobs`: durable job queue (retry/backoff, coalescing, commit fence,
   cron entries) — every background duty and every periodic tick runs on it
+- `internal/supervise`: process supervision for long-lived daemon children
+  (restart backoff, generation fencing, stability window, disconnect grace,
+  give-up parking, per-child log capture). Consumers name a child and hand over
+  a start function; the package knows nothing about what it supervises. The
+  plugin runtime is one consumer, the app runtime's sidecar is the other
 - `internal/classifier`: stop-time state classification
 - `internal/transcript`: assistant-message extraction from JSONL
 - `app`: Tauri frontend; WebSocket `ws://localhost:9849`

--- a/app/src/components/SettingsModal.css
+++ b/app/src/components/SettingsModal.css
@@ -337,6 +337,7 @@
 .endpoint-status-badge.status-error,
 .endpoint-status-badge.status-disconnected,
 .plugin-health-badge.unhealthy,
+.plugin-status-badge.parked,
 .agent-capability-pill.disabled {
   color: #ff746c;
   border-color: rgba(255, 116, 108, 0.42);

--- a/changelog.d/supervise-package-extraction.yaml
+++ b/changelog.d/supervise-package-extraction.yaml
@@ -1,0 +1,28 @@
+kind: internal
+area: daemon
+change: >
+  Process supervision moved out of the plugin runtime into internal/supervise,
+  a package that knows nothing about what it supervises: a consumer names a
+  child and hands over a start function, and the package owns restart backoff
+  (250ms to 30s over eight steps), generation fencing against stale processes
+  and timers, the 60-second stability window that resets the backoff, and the
+  5-second grace in which a started child must dial the daemon back or be
+  killed. The plugin runtime moves onto it in the same change, so the extraction
+  is proven by a consumer that already worked; the app runtime's Bun sidecar is
+  the second consumer.
+  Two capabilities arrive with the move. A child that keeps dying without ever
+  running stably is now parked instead of retried forever — after ten restarts,
+  roughly two to three minutes of crash-looping — and parking is loud: a daemon
+  log line, a durable notification naming the plugin and its last exit, and a
+  parked runtime phase in the plugins list. Reinstalling or restarting the
+  plugin revives it with a clean restart budget. And a plugin's stdout and
+  stderr, which went to /dev/null, are now captured to an append-only
+  per-plugin log file under the profile's plugin-log directory, with a start
+  marker per generation so a crash loop leaves a readable trail.
+notes: >
+  Slice 2 of docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md. The
+  give-up count is a tripwire, not a receipt: no healthy child restarts twice,
+  let alone ten times, and the plan's estimate is corrected there with the
+  backoff arithmetic (121.75s of waiting plus up to five seconds of grace per
+  attempt that never connects). runtime_phase is a free-form string on the
+  wire, so the new parked value needs no protocol change.

--- a/changelog.d/supervise-package-extraction.yaml
+++ b/changelog.d/supervise-package-extraction.yaml
@@ -14,8 +14,8 @@ change: >
   running stably is now parked instead of retried forever — after ten restarts,
   roughly two to three minutes of crash-looping — and parking is loud: a daemon
   log line, a durable notification naming the plugin and its last exit, and a
-  parked runtime phase in the plugins list. Reinstalling or restarting the
-  plugin revives it with a clean restart budget. And a plugin's stdout and
+  parked runtime phase in the plugins list. Reinstalling the plugin, or
+  restarting attn, revives it with a clean restart budget. And a plugin's stdout and
   stderr, which went to /dev/null, are now captured to an append-only
   per-plugin log file under the profile's plugin-log directory, with a start
   marker per generation so a crash loop leaves a readable trail.

--- a/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
+++ b/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
@@ -189,10 +189,12 @@ The supervisor extracts from `internal/daemon/plugin_supervisor.go` into
 - **Give-up state** (new — today it retries forever): a child that keeps
   dying without reaching stability gets parked, loudly — fact + durable
   notification + `attn app status`. Initial tripwire: parked after 10
-  consecutive restarts with no stability window (~3.5 minutes of
-  crash-looping at the existing backoff numbers). Tripwire, not a receipt —
-  recalibrate during this stage's verification and record the measurement
-  here.
+  consecutive restarts with no stability window. Tripwire, not a receipt —
+  recalibrate if a legitimate child ever reaches it. **Slice 2 correction to
+  the estimate:** ten restarts at the pinned backoff cost 121.75s of waiting
+  (0.25+0.5+1+2+4+8+16+30+30+30), plus up to the 5s disconnect grace per
+  attempt for a child that starts and never calls back — so a crash-looping
+  child is parked after roughly two to three minutes, not ~3.5.
 - **Log capture** (new — plugin stdout/stderr goes to /dev/null today, a
   hole `attn app logs` cannot live with): per-child append-only log file
   (`<data-dir>/apps/log/runtime.log`, the ptyworker per-session pattern),
@@ -281,7 +283,15 @@ fully-CI'd, fully-reviewed merge at the end.
 1. **Bus consumer lifecycle** — post-`Start` register, `Unregister`, row
    deletion, tests for the pin-the-log orphan case.
 2. **Supervisor extraction** — `internal/supervise`, pluginSupervisor moves
-   onto it, give-up state + log capture.
+   onto it, give-up state + log capture. *Shipped:* a consumer names a child
+   and hands over a `StartFunc`, so the package carries no manifest, no
+   environment and no protocol; `Ensure` doubles as the un-park (it revives a
+   parked child with a clean restart budget), which is why no separate restart
+   entry point exists yet. `parked` is a new `runtime_phase` value — the field
+   is a free-form string on the wire, so no protocol bump. Plugin logs land in
+   `<data-dir>/plugin-log/<name>.log`, deliberately outside
+   `<data-dir>/plugins` because everything under there is scanned for
+   manifests.
 3. **Registry + store + CLI skeleton** — `app_*` tables,
    list/status/enable/disable/remove against them, glossary entries (app,
    plugin), `ext/` → `app/` namespace rename.

--- a/internal/daemon/plugin_rpc_test.go
+++ b/internal/daemon/plugin_rpc_test.go
@@ -226,7 +226,7 @@ func TestDaemon_PluginConnectionGenerationDrivesDisconnectRecovery(t *testing.T)
 	<-staleDone
 
 	current, currentDone := startPluginPipeGeneration(t, d, "supervised", nil, restarted.Generation)
-	d.pluginSupervisor.Stop("supervised", pluginStopRemove)
+	d.pluginSupervisor.Stop("supervised")
 	_ = current.Close()
 	<-currentDone
 }

--- a/internal/daemon/plugin_runtime.go
+++ b/internal/daemon/plugin_runtime.go
@@ -2,13 +2,17 @@ package daemon
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/victorarias/attn/internal/plugins"
+	"github.com/victorarias/attn/internal/store"
+	"github.com/victorarias/attn/internal/supervise"
 )
 
 const pluginManifestName = plugins.ManifestName
@@ -70,7 +74,7 @@ func (d *Daemon) ensurePluginSupervisor() *pluginSupervisor {
 	if d.pluginSupervisor == nil {
 		d.pluginSupervisor = newPluginSupervisor(
 			execPluginProcessLauncher{},
-			realPluginSupervisorClock{},
+			nil,
 			func(manifest pluginManifest, generation uint64) []string {
 				overrides := []string{
 					"ATTN_SOCKET_PATH=" + d.socketPath,
@@ -84,12 +88,57 @@ func (d *Daemon) ensurePluginSupervisor() *pluginSupervisor {
 				}
 				return d.pluginCommandEnv(overrides...)
 			},
-			func(pluginName string) {
-				d.publishFact(FactPluginHealthChanged, pluginName, nil)
+			supervise.Options{
+				LogDir: pluginLogDirForSocket(d.socketPath),
+				OnChange: func(pluginName string) {
+					d.publishFact(FactPluginHealthChanged, pluginName, nil)
+				},
+				OnGiveUp: d.notifyPluginParked,
+				Logf:     d.logf,
 			},
 		)
 	}
 	return d.pluginSupervisor
+}
+
+// pluginLogDirForSocket keeps each plugin's captured stdout/stderr beside the
+// runtime root that owns the plugin, next to the pty workers' own log tree. It
+// deliberately sits outside the plugin discovery directory: anything under
+// there is scanned for manifests.
+func pluginLogDirForSocket(socketPath string) string {
+	return filepath.Join(filepath.Dir(socketPath), "plugin-log")
+}
+
+// notificationKindPluginParked marks a notification produced by a plugin the
+// supervisor gave up restarting.
+const notificationKindPluginParked = "plugin_parked"
+
+// notifyPluginParked is the supervisor's OnGiveUp sink: a plugin that crash-
+// looped past the give-up tripwire stops being retried, so the only way the
+// user learns about it is a loud line in the daemon log plus a durable
+// notification. Reinstalling or restarting the plugin re-enters supervision.
+func (d *Daemon) notifyPluginParked(name string, snapshot pluginRuntimeSnapshot) {
+	detail := ""
+	if snapshot.LastExit != nil {
+		detail = snapshot.LastExit.String()
+	}
+	d.logf("plugin %s parked after %d restarts without a stable connection: %s", name, snapshot.RestartAttempt, detail)
+	if d.store == nil {
+		return
+	}
+	record, err := d.store.AddNotification(store.NotificationRecord{
+		Kind:       notificationKindPluginParked,
+		Title:      fmt.Sprintf("Plugin stopped: %s", name),
+		Body:       fmt.Sprintf("attn restarted it %d times without it ever staying up, and has stopped trying. Reinstall or restart the plugin to try again.", snapshot.RestartAttempt),
+		Detail:     detail,
+		SourceKind: "plugin",
+		SourceID:   name,
+	}, time.Now())
+	if err != nil {
+		d.logf("notifications: add plugin-parked notification for %s: %v", name, err)
+		return
+	}
+	d.publishFact(FactNotificationCreated, record.ID, nil)
 }
 
 func pluginDataDirForSocket(socketPath, pluginName string) string {
@@ -241,5 +290,5 @@ func (d *Daemon) stopInstalledPlugins() {
 }
 
 func (d *Daemon) stopInstalledPlugin(name string) {
-	d.ensurePluginSupervisor().Stop(name, pluginStopRemove)
+	d.ensurePluginSupervisor().Stop(name)
 }

--- a/internal/daemon/plugin_runtime.go
+++ b/internal/daemon/plugin_runtime.go
@@ -116,7 +116,9 @@ const notificationKindPluginParked = "plugin_parked"
 // notifyPluginParked is the supervisor's OnGiveUp sink: a plugin that crash-
 // looped past the give-up tripwire stops being retried, so the only way the
 // user learns about it is a loud line in the daemon log plus a durable
-// notification. Reinstalling or restarting the plugin re-enters supervision.
+// notification. Reinstalling the plugin, or restarting attn, re-enters
+// supervision — there is no per-plugin restart verb yet, so the copy must not
+// promise one.
 func (d *Daemon) notifyPluginParked(name string, snapshot pluginRuntimeSnapshot) {
 	detail := ""
 	if snapshot.LastExit != nil {
@@ -129,7 +131,7 @@ func (d *Daemon) notifyPluginParked(name string, snapshot pluginRuntimeSnapshot)
 	record, err := d.store.AddNotification(store.NotificationRecord{
 		Kind:       notificationKindPluginParked,
 		Title:      fmt.Sprintf("Plugin stopped: %s", name),
-		Body:       fmt.Sprintf("attn restarted it %d times without it ever staying up, and has stopped trying. Reinstall or restart the plugin to try again.", snapshot.RestartAttempt),
+		Body:       fmt.Sprintf("attn restarted it %d times without it ever staying up, and has stopped trying. Reinstall the plugin, or restart attn, to try again.", snapshot.RestartAttempt),
 		Detail:     detail,
 		SourceKind: "plugin",
 		SourceID:   name,

--- a/internal/daemon/plugin_runtime_test.go
+++ b/internal/daemon/plugin_runtime_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/victorarias/attn/internal/supervise"
 )
 
 func TestPluginDirForSocketUsesSocketRuntimeRoot(t *testing.T) {
@@ -179,7 +181,7 @@ func TestDaemon_StartInstalledPlugins_RestartsCleanExitWithNewGeneration(t *test
 	// prewarm so every generation resolves the same fake bun fixture.
 	d.pluginSupervisor = newPluginSupervisor(
 		execPluginProcessLauncher{},
-		realPluginSupervisorClock{},
+		nil,
 		func(manifest pluginManifest, generation uint64) []string {
 			return mergePluginEnvironment(os.Environ(), []string{
 				"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
@@ -188,7 +190,9 @@ func TestDaemon_StartInstalledPlugins_RestartsCleanExitWithNewGeneration(t *test
 				"ATTN_PLUGIN_GENERATION=" + strconv.FormatUint(generation, 10),
 			})
 		},
-		func(pluginName string) { d.publishFact(FactPluginHealthChanged, pluginName, nil) },
+		supervise.Options{
+			OnChange: func(pluginName string) { d.publishFact(FactPluginHealthChanged, pluginName, nil) },
+		},
 	)
 	go d.Start()
 	defer d.Stop()

--- a/internal/daemon/plugin_supervisor.go
+++ b/internal/daemon/plugin_supervisor.go
@@ -1,120 +1,54 @@
 package daemon
 
 import (
-	"errors"
 	"fmt"
+	"io"
 	"os/exec"
 	"path/filepath"
-	"strings"
-	"sync"
-	"syscall"
-	"time"
 
 	"github.com/victorarias/attn/internal/plugins"
+	"github.com/victorarias/attn/internal/supervise"
 )
 
-type pluginDesiredState string
+// The plugin runtime is one consumer of internal/supervise: every installed
+// plugin is a supervised child named by its manifest, launched with the plugin
+// environment the daemon computes for that generation. Restart backoff,
+// generation fencing, the stability window, the disconnect grace and the
+// give-up tripwire all live in the shared package; what stays here is how a
+// plugin manifest becomes a process.
 
 const (
-	pluginDesiredRunning pluginDesiredState = "running"
-	pluginDesiredStopped pluginDesiredState = "stopped"
+	pluginDesiredRunning = supervise.DesiredRunning
+	pluginDesiredStopped = supervise.DesiredStopped
 )
-
-type pluginRuntimePhase string
 
 const (
-	pluginPhaseStarting  pluginRuntimePhase = "starting"
-	pluginPhaseConnected pluginRuntimePhase = "connected"
-	pluginPhaseBackoff   pluginRuntimePhase = "backoff"
-	pluginPhaseStopped   pluginRuntimePhase = "stopped"
+	pluginPhaseStarting  = supervise.PhaseStarting
+	pluginPhaseConnected = supervise.PhaseConnected
+	pluginPhaseBackoff   = supervise.PhaseBackoff
+	pluginPhaseStopped   = supervise.PhaseStopped
+	pluginPhaseParked    = supervise.PhaseParked
 )
 
-type pluginStopReason string
+var pluginRestartBackoff = supervise.RestartBackoff
 
-const (
-	pluginStopRemove   pluginStopReason = "remove"
-	pluginStopShutdown pluginStopReason = "shutdown"
-)
+const pluginDisconnectGrace = supervise.DisconnectGrace
 
-var pluginRestartBackoff = []time.Duration{
-	250 * time.Millisecond,
-	500 * time.Millisecond,
-	time.Second,
-	2 * time.Second,
-	4 * time.Second,
-	8 * time.Second,
-	16 * time.Second,
-	30 * time.Second,
-}
+type pluginExit = supervise.Exit
+type pluginRuntimeSnapshot = supervise.Snapshot
+type pluginProcessHandle = supervise.Process
+type pluginSupervisorTimer = supervise.Timer
+type pluginSupervisorClock = supervise.Clock
 
-const pluginDisconnectGrace = 5 * time.Second
-const pluginStableConnection = 60 * time.Second
-
-type pluginExit struct {
-	At       time.Time
-	ExitCode *int
-	Signal   string
-	Error    string
-}
-
-func (e pluginExit) String() string {
-	detail := strings.TrimSpace(e.Error)
-	if detail == "" && e.Signal != "" {
-		detail = "signal " + e.Signal
-	}
-	if detail == "" && e.ExitCode != nil {
-		detail = fmt.Sprintf("exit code %d", *e.ExitCode)
-	}
-	if detail == "" {
-		detail = "process exited"
-	}
-	if e.At.IsZero() {
-		return detail
-	}
-	return fmt.Sprintf("%s: %s", e.At.Format(time.RFC3339), detail)
-}
-
-type pluginRuntimeSnapshot struct {
-	Desired        pluginDesiredState
-	Phase          pluginRuntimePhase
-	Generation     uint64
-	Running        bool
-	Connected      bool
-	RestartAttempt int
-	StartedAt      time.Time
-	ConnectedAt    time.Time
-	NextRestartAt  time.Time
-	LastExit       *pluginExit
-}
-
-type pluginProcessHandle interface {
-	Wait() pluginExit
-	Kill() error
-}
-
+// pluginProcessLauncher turns one manifest into a running process. Log is the
+// supervisor's per-plugin append-only log file, or nil when capture is off.
 type pluginProcessLauncher interface {
-	Start(manifest pluginManifest, env []string) (pluginProcessHandle, error)
-}
-
-type pluginSupervisorTimer interface {
-	Stop() bool
-}
-
-type pluginSupervisorClock interface {
-	Now() time.Time
-	AfterFunc(time.Duration, func()) pluginSupervisorTimer
-}
-
-type realPluginSupervisorClock struct{}
-
-func (realPluginSupervisorClock) Now() time.Time { return time.Now() }
-func (realPluginSupervisorClock) AfterFunc(delay time.Duration, fn func()) pluginSupervisorTimer {
-	return time.AfterFunc(delay, fn)
+	Start(manifest pluginManifest, env []string, log io.Writer) (pluginProcessHandle, error)
 }
 
 type execPluginProcessLauncher struct{}
 
-func (execPluginProcessLauncher) Start(manifest pluginManifest, env []string) (pluginProcessHandle, error) {
+func (execPluginProcessLauncher) Start(manifest pluginManifest, env []string, log io.Writer) (pluginProcessHandle, error) {
 	var cmd *exec.Cmd
 	switch manifest.Plugin.Kind {
 	case plugins.EntrypointExecutable:
@@ -126,355 +60,43 @@ func (execPluginProcessLauncher) Start(manifest pluginManifest, env []string) (p
 	}
 	cmd.Dir = manifest.Dir
 	cmd.Env = env
-	if err := cmd.Start(); err != nil {
+	process, err := supervise.StartCommand(cmd, log)
+	if err != nil {
 		return nil, fmt.Errorf("start %s plugin process: %w", manifest.Plugin.Kind, err)
 	}
-	return &execPluginProcess{cmd: cmd}, nil
+	return process, nil
 }
 
-type execPluginProcess struct {
-	cmd *exec.Cmd
-}
-
-func (p *execPluginProcess) Wait() pluginExit {
-	err := p.cmd.Wait()
-	exit := pluginExit{}
-	if err != nil {
-		exit.Error = err.Error()
-	}
-	if state := p.cmd.ProcessState; state != nil {
-		if code := state.ExitCode(); code >= 0 {
-			exit.ExitCode = intPtr(code)
-		}
-		if status, ok := state.Sys().(syscall.WaitStatus); ok && status.Signaled() {
-			exit.Signal = status.Signal().String()
-		}
-	}
-	return exit
-}
-
-func (p *execPluginProcess) Kill() error {
-	if p.cmd == nil || p.cmd.Process == nil {
-		return nil
-	}
-	return p.cmd.Process.Kill()
-}
-
-type managedPlugin struct {
-	manifest pluginManifest
-	desired  pluginDesiredState
-	phase    pluginRuntimePhase
-
-	generation     uint64
-	process        pluginProcessHandle
-	restartAttempt int
-	startedAt      time.Time
-	connectedAt    time.Time
-	nextRestartAt  time.Time
-	lastExit       *pluginExit
-
-	restartTimer    pluginSupervisorTimer
-	disconnectTimer pluginSupervisorTimer
-	stabilityTimer  pluginSupervisorTimer
-}
-
+// pluginSupervisor adapts the shared supervisor to plugin manifests.
 type pluginSupervisor struct {
-	mu       sync.Mutex
-	plugins  map[string]*managedPlugin
+	*supervise.Supervisor
 	launcher pluginProcessLauncher
-	clock    pluginSupervisorClock
 	env      func(pluginManifest, uint64) []string
-	onChange func(pluginName string)
-	shutdown bool
 }
 
 func newPluginSupervisor(
 	launcher pluginProcessLauncher,
 	clock pluginSupervisorClock,
 	env func(pluginManifest, uint64) []string,
-	onChange func(pluginName string),
+	options supervise.Options,
 ) *pluginSupervisor {
 	if launcher == nil {
 		launcher = execPluginProcessLauncher{}
 	}
-	if clock == nil {
-		clock = realPluginSupervisorClock{}
-	}
 	if env == nil {
 		env = func(pluginManifest, uint64) []string { return nil }
 	}
+	options.Clock = clock
 	return &pluginSupervisor{
-		plugins:  make(map[string]*managedPlugin),
-		launcher: launcher,
-		clock:    clock,
-		env:      env,
-		onChange: onChange,
+		Supervisor: supervise.New(options),
+		launcher:   launcher,
+		env:        env,
 	}
 }
 
+// Ensure starts the plugin, or adopts the manifest for its next start.
 func (s *pluginSupervisor) Ensure(manifest pluginManifest) error {
-	if strings.TrimSpace(manifest.Name) == "" {
-		return errors.New("plugin process name is required")
-	}
-	s.mu.Lock()
-	if s.shutdown {
-		s.mu.Unlock()
-		return errors.New("plugin supervisor is shut down")
-	}
-	plugin := s.plugins[manifest.Name]
-	if plugin == nil {
-		plugin = &managedPlugin{manifest: manifest, desired: pluginDesiredRunning, phase: pluginPhaseStarting}
-		s.plugins[manifest.Name] = plugin
-	} else {
-		plugin.manifest = manifest
-		plugin.desired = pluginDesiredRunning
-		if plugin.process != nil || plugin.restartTimer != nil {
-			s.mu.Unlock()
-			return nil
-		}
-	}
-	err := s.spawnLocked(plugin)
-	s.mu.Unlock()
-	s.notify(manifest.Name)
-	return err
-}
-
-func (s *pluginSupervisor) Stop(name string, _ pluginStopReason) {
-	s.mu.Lock()
-	plugin := s.plugins[name]
-	if plugin == nil {
-		s.mu.Unlock()
-		return
-	}
-	plugin.desired = pluginDesiredStopped
-	plugin.phase = pluginPhaseStopped
-	plugin.generation++
-	plugin.connectedAt = time.Time{}
-	plugin.nextRestartAt = time.Time{}
-	stopPluginTimer(&plugin.restartTimer)
-	stopPluginTimer(&plugin.disconnectTimer)
-	stopPluginTimer(&plugin.stabilityTimer)
-	process := plugin.process
-	plugin.process = nil
-	s.mu.Unlock()
-	if process != nil {
-		_ = process.Kill()
-	}
-	s.notify(name)
-}
-
-func (s *pluginSupervisor) Shutdown() {
-	s.mu.Lock()
-	if s.shutdown {
-		s.mu.Unlock()
-		return
-	}
-	s.shutdown = true
-	names := make([]string, 0, len(s.plugins))
-	for name := range s.plugins {
-		names = append(names, name)
-	}
-	s.mu.Unlock()
-	for _, name := range names {
-		s.Stop(name, pluginStopShutdown)
-	}
-}
-
-// NoteConnected accepts untracked test/manual connections, but a supervised
-// plugin must present the exact generation injected into its process.
-func (s *pluginSupervisor) NoteConnected(name string, generation uint64) bool {
-	s.mu.Lock()
-	plugin := s.plugins[name]
-	if plugin == nil {
-		s.mu.Unlock()
-		return true
-	}
-	if generation == 0 || generation != plugin.generation || plugin.desired != pluginDesiredRunning || plugin.process == nil {
-		s.mu.Unlock()
-		return false
-	}
-	plugin.phase = pluginPhaseConnected
-	plugin.connectedAt = s.clock.Now()
-	plugin.nextRestartAt = time.Time{}
-	stopPluginTimer(&plugin.disconnectTimer)
-	stopPluginTimer(&plugin.stabilityTimer)
-	capturedGeneration := plugin.generation
-	plugin.stabilityTimer = s.clock.AfterFunc(pluginStableConnection, func() {
-		s.markStable(name, capturedGeneration)
-	})
-	s.mu.Unlock()
-	s.notify(name)
-	return true
-}
-
-func (s *pluginSupervisor) NoteDisconnected(name string, generation uint64) {
-	s.mu.Lock()
-	plugin := s.plugins[name]
-	if plugin == nil || generation != plugin.generation || plugin.desired != pluginDesiredRunning || plugin.process == nil {
-		s.mu.Unlock()
-		return
-	}
-	plugin.phase = pluginPhaseStarting
-	plugin.connectedAt = time.Time{}
-	stopPluginTimer(&plugin.stabilityTimer)
-	stopPluginTimer(&plugin.disconnectTimer)
-	capturedProcess := plugin.process
-	capturedGeneration := plugin.generation
-	plugin.disconnectTimer = s.clock.AfterFunc(pluginDisconnectGrace, func() {
-		s.disconnectExpired(name, capturedGeneration, capturedProcess)
-	})
-	s.mu.Unlock()
-	s.notify(name)
-}
-
-func (s *pluginSupervisor) Snapshot(name string) (pluginRuntimeSnapshot, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	plugin := s.plugins[name]
-	if plugin == nil {
-		return pluginRuntimeSnapshot{}, false
-	}
-	snapshot := pluginRuntimeSnapshot{
-		Desired:        plugin.desired,
-		Phase:          plugin.phase,
-		Generation:     plugin.generation,
-		Running:        plugin.process != nil,
-		Connected:      plugin.phase == pluginPhaseConnected,
-		RestartAttempt: plugin.restartAttempt,
-		StartedAt:      plugin.startedAt,
-		ConnectedAt:    plugin.connectedAt,
-		NextRestartAt:  plugin.nextRestartAt,
-	}
-	if plugin.lastExit != nil {
-		exit := *plugin.lastExit
-		if plugin.lastExit.ExitCode != nil {
-			exit.ExitCode = intPtr(*plugin.lastExit.ExitCode)
-		}
-		snapshot.LastExit = &exit
-	}
-	return snapshot, true
-}
-
-func (s *pluginSupervisor) spawnLocked(plugin *managedPlugin) error {
-	plugin.generation++
-	plugin.phase = pluginPhaseStarting
-	plugin.nextRestartAt = time.Time{}
-	stopPluginTimer(&plugin.restartTimer)
-	generation := plugin.generation
-	process, err := s.launcher.Start(plugin.manifest, s.env(plugin.manifest, generation))
-	if err != nil {
-		exit := pluginExit{At: s.clock.Now(), Error: err.Error()}
-		plugin.lastExit = &exit
-		s.scheduleRestartLocked(plugin)
-		return err
-	}
-	plugin.process = process
-	plugin.startedAt = s.clock.Now()
-	stopPluginTimer(&plugin.disconnectTimer)
-	name := plugin.manifest.Name
-	capturedProcess := process
-	plugin.disconnectTimer = s.clock.AfterFunc(pluginDisconnectGrace, func() {
-		s.disconnectExpired(name, generation, capturedProcess)
-	})
-	go func(name string, generation uint64, process pluginProcessHandle) {
-		exit := process.Wait()
-		s.processExited(name, generation, process, exit)
-	}(name, generation, process)
-	return nil
-}
-
-func (s *pluginSupervisor) processExited(name string, generation uint64, process pluginProcessHandle, exit pluginExit) {
-	s.mu.Lock()
-	plugin := s.plugins[name]
-	if plugin == nil || generation != plugin.generation || plugin.process != process {
-		s.mu.Unlock()
-		return
-	}
-	plugin.process = nil
-	plugin.connectedAt = time.Time{}
-	stopPluginTimer(&plugin.disconnectTimer)
-	stopPluginTimer(&plugin.stabilityTimer)
-	exit.At = s.clock.Now()
-	plugin.lastExit = &exit
-	if plugin.desired == pluginDesiredRunning && !s.shutdown {
-		s.scheduleRestartLocked(plugin)
-	} else {
-		plugin.phase = pluginPhaseStopped
-		plugin.nextRestartAt = time.Time{}
-	}
-	s.mu.Unlock()
-	s.notify(name)
-}
-
-func (s *pluginSupervisor) scheduleRestartLocked(plugin *managedPlugin) {
-	stopPluginTimer(&plugin.restartTimer)
-	plugin.restartAttempt++
-	index := plugin.restartAttempt - 1
-	if index >= len(pluginRestartBackoff) {
-		index = len(pluginRestartBackoff) - 1
-	}
-	delay := pluginRestartBackoff[index]
-	plugin.phase = pluginPhaseBackoff
-	plugin.nextRestartAt = s.clock.Now().Add(delay)
-	capturedGeneration := plugin.generation
-	plugin.restartTimer = s.clock.AfterFunc(delay, func() {
-		s.restart(nameOf(plugin), capturedGeneration)
+	return s.Supervisor.Ensure(manifest.Name, func(req supervise.StartRequest) (supervise.Process, error) {
+		return s.launcher.Start(manifest, s.env(manifest, req.Generation), req.Log)
 	})
 }
-
-func (s *pluginSupervisor) restart(name string, generation uint64) {
-	s.mu.Lock()
-	plugin := s.plugins[name]
-	if plugin == nil || generation != plugin.generation || plugin.desired != pluginDesiredRunning || s.shutdown {
-		s.mu.Unlock()
-		return
-	}
-	plugin.restartTimer = nil
-	_ = s.spawnLocked(plugin)
-	s.mu.Unlock()
-	s.notify(name)
-}
-
-func (s *pluginSupervisor) markStable(name string, generation uint64) {
-	s.mu.Lock()
-	plugin := s.plugins[name]
-	if plugin == nil || generation != plugin.generation || plugin.phase != pluginPhaseConnected {
-		s.mu.Unlock()
-		return
-	}
-	plugin.restartAttempt = 0
-	plugin.stabilityTimer = nil
-	s.mu.Unlock()
-	s.notify(name)
-}
-
-func (s *pluginSupervisor) disconnectExpired(name string, generation uint64, process pluginProcessHandle) {
-	s.mu.Lock()
-	plugin := s.plugins[name]
-	if plugin == nil || generation != plugin.generation || plugin.process != process || plugin.phase == pluginPhaseConnected || plugin.desired != pluginDesiredRunning {
-		s.mu.Unlock()
-		return
-	}
-	plugin.disconnectTimer = nil
-	s.mu.Unlock()
-	_ = process.Kill()
-}
-
-// notify reports one plugin's supervision state moving. The name is required:
-// the daemon turns it into a fact, and a fact needs the entity it is about.
-func (s *pluginSupervisor) notify(pluginName string) {
-	if s.onChange != nil {
-		s.onChange(pluginName)
-	}
-}
-
-func stopPluginTimer(timer *pluginSupervisorTimer) {
-	if *timer != nil {
-		(*timer).Stop()
-		*timer = nil
-	}
-}
-
-func nameOf(plugin *managedPlugin) string { return plugin.manifest.Name }
-
-func intPtr(value int) *int { return &value }

--- a/internal/daemon/plugin_supervisor_test.go
+++ b/internal/daemon/plugin_supervisor_test.go
@@ -1,215 +1,23 @@
 package daemon
 
 import (
-	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/victorarias/attn/internal/supervise"
 )
 
-func TestPluginSupervisorRestartsExitsWithCappedBackoff(t *testing.T) {
-	clock := newFakePluginClock()
-	launcher := &fakePluginLauncher{}
-	supervisor := newTestPluginSupervisor(clock, launcher)
-	manifest := pluginManifest{Name: "fixture"}
-
-	if err := supervisor.Ensure(manifest); err != nil {
-		t.Fatalf("Ensure: %v", err)
-	}
-	for attempt := 1; attempt <= len(pluginRestartBackoff)+2; attempt++ {
-		handle := launcher.handle(attempt - 1)
-		handle.exit(pluginExit{ExitCode: intPtr(0)})
-		waitForSupervisor(t, func() bool {
-			snapshot, _ := supervisor.Snapshot("fixture")
-			return snapshot.Phase == pluginPhaseBackoff && snapshot.RestartAttempt == attempt
-		})
-		snapshot, _ := supervisor.Snapshot("fixture")
-		index := attempt - 1
-		if index >= len(pluginRestartBackoff) {
-			index = len(pluginRestartBackoff) - 1
-		}
-		wantDelay := pluginRestartBackoff[index]
-		if got := snapshot.NextRestartAt.Sub(clock.Now()); got != wantDelay {
-			t.Fatalf("attempt %d delay=%s, want %s", attempt, got, wantDelay)
-		}
-		clock.Advance(wantDelay)
-		waitForSupervisor(t, func() bool { return launcher.count() == attempt+1 })
-	}
-}
-
-func TestPluginSupervisorRetriesStartFailure(t *testing.T) {
-	clock := newFakePluginClock()
-	launcher := &fakePluginLauncher{startErrors: []error{errors.New("bun missing")}}
-	supervisor := newTestPluginSupervisor(clock, launcher)
-
-	if err := supervisor.Ensure(pluginManifest{Name: "fixture"}); err == nil {
-		t.Fatal("Ensure error=nil, want start failure")
-	}
-	snapshot, _ := supervisor.Snapshot("fixture")
-	if snapshot.Phase != pluginPhaseBackoff || snapshot.RestartAttempt != 1 || snapshot.LastExit == nil {
-		t.Fatalf("snapshot=%+v, want first backoff with exit", snapshot)
-	}
-	clock.Advance(250 * time.Millisecond)
-	waitForSupervisor(t, func() bool { return launcher.count() == 2 })
-	snapshot, _ = supervisor.Snapshot("fixture")
-	if snapshot.Phase != pluginPhaseStarting || !snapshot.Running {
-		t.Fatalf("snapshot=%+v, want restarted process", snapshot)
-	}
-}
-
-func TestPluginSupervisorResetsAttemptsOnlyAfterStableConnection(t *testing.T) {
-	clock := newFakePluginClock()
-	launcher := &fakePluginLauncher{}
-	supervisor := newTestPluginSupervisor(clock, launcher)
-	_ = supervisor.Ensure(pluginManifest{Name: "fixture"})
-	launcher.handle(0).exit(pluginExit{Error: "crash"})
-	waitForSupervisor(t, func() bool {
-		snapshot, _ := supervisor.Snapshot("fixture")
-		return snapshot.RestartAttempt == 1
-	})
-	clock.Advance(250 * time.Millisecond)
-	waitForSupervisor(t, func() bool { return launcher.count() == 2 })
-	snapshot, _ := supervisor.Snapshot("fixture")
-	if !supervisor.NoteConnected("fixture", snapshot.Generation) {
-		t.Fatal("NoteConnected rejected current generation")
-	}
-	clock.Advance(pluginStableConnection - time.Millisecond)
-	snapshot, _ = supervisor.Snapshot("fixture")
-	if snapshot.RestartAttempt != 1 {
-		t.Fatalf("attempt=%d before stability window, want 1", snapshot.RestartAttempt)
-	}
-	clock.Advance(time.Millisecond)
-	snapshot, _ = supervisor.Snapshot("fixture")
-	if snapshot.RestartAttempt != 0 || snapshot.Phase != pluginPhaseConnected {
-		t.Fatalf("snapshot=%+v after stability window, want connected attempt 0", snapshot)
-	}
-}
-
-func TestPluginSupervisorDisconnectGraceReconnectAndKill(t *testing.T) {
-	clock := newFakePluginClock()
-	launcher := &fakePluginLauncher{}
-	supervisor := newTestPluginSupervisor(clock, launcher)
-	_ = supervisor.Ensure(pluginManifest{Name: "fixture"})
-	snapshot, _ := supervisor.Snapshot("fixture")
-	generation := snapshot.Generation
-	if !supervisor.NoteConnected("fixture", generation) {
-		t.Fatal("NoteConnected rejected current generation")
-	}
-
-	supervisor.NoteDisconnected("fixture", generation)
-	clock.Advance(pluginDisconnectGrace - time.Millisecond)
-	if got := launcher.handle(0).killCount(); got != 0 {
-		t.Fatalf("kills before grace=%d, want 0", got)
-	}
-	if !supervisor.NoteConnected("fixture", generation) {
-		t.Fatal("same-generation reconnect was rejected")
-	}
-	clock.Advance(time.Millisecond)
-	if got := launcher.handle(0).killCount(); got != 0 {
-		t.Fatalf("kills after canceled grace=%d, want 0", got)
-	}
-
-	supervisor.NoteDisconnected("fixture", generation)
-	clock.Advance(pluginDisconnectGrace)
-	if got := launcher.handle(0).killCount(); got != 1 {
-		t.Fatalf("kills after expired grace=%d, want 1", got)
-	}
-	waitForSupervisor(t, func() bool {
-		snapshot, _ := supervisor.Snapshot("fixture")
-		return snapshot.Phase == pluginPhaseBackoff
-	})
-}
-
-func TestPluginSupervisorRestartsProcessThatNeverConnects(t *testing.T) {
-	clock := newFakePluginClock()
-	launcher := &fakePluginLauncher{}
-	supervisor := newTestPluginSupervisor(clock, launcher)
-	_ = supervisor.Ensure(pluginManifest{Name: "fixture"})
-
-	clock.Advance(pluginDisconnectGrace)
-	if got := launcher.handle(0).killCount(); got != 1 {
-		t.Fatalf("kills after startup grace=%d, want 1", got)
-	}
-	waitForSupervisor(t, func() bool {
-		snapshot, _ := supervisor.Snapshot("fixture")
-		return snapshot.Phase == pluginPhaseBackoff && snapshot.RestartAttempt == 1
-	})
-	clock.Advance(pluginRestartBackoff[0])
-	waitForSupervisor(t, func() bool { return launcher.count() == 2 })
-}
-
-func TestPluginSupervisorIntentionalStopAndShutdownNeverRestart(t *testing.T) {
-	clock := newFakePluginClock()
-	launcher := &fakePluginLauncher{}
-	supervisor := newTestPluginSupervisor(clock, launcher)
-	_ = supervisor.Ensure(pluginManifest{Name: "one"})
-	_ = supervisor.Ensure(pluginManifest{Name: "two"})
-	one, _ := supervisor.Snapshot("one")
-	if !supervisor.NoteConnected("one", one.Generation) {
-		t.Fatal("connect one")
-	}
-	supervisor.NoteDisconnected("one", one.Generation)
-	supervisor.Stop("one", pluginStopRemove)
-
-	stopped, _ := supervisor.Snapshot("one")
-	if stopped.Phase != pluginPhaseStopped || stopped.Running || stopped.Desired != pluginDesiredStopped {
-		t.Fatalf("stopped snapshot=%+v", stopped)
-	}
-	if supervisor.NoteConnected("one", one.Generation) {
-		t.Fatal("stale generation reconnect accepted")
-	}
-	clock.Advance(time.Hour)
-	if got := launcher.count(); got != 2 {
-		t.Fatalf("starts after intentional stop=%d, want 2", got)
-	}
-
-	supervisor.Shutdown()
-	clock.Advance(time.Hour)
-	if got := launcher.count(); got != 2 {
-		t.Fatalf("starts after shutdown=%d, want 2", got)
-	}
-	for _, name := range []string{"one", "two"} {
-		snapshot, _ := supervisor.Snapshot(name)
-		if snapshot.Phase != pluginPhaseStopped || snapshot.Running {
-			t.Fatalf("%s snapshot=%+v after shutdown", name, snapshot)
-		}
-	}
-}
-
-func TestPluginSupervisorSnapshotsStartingConnectedBackoffAndStopped(t *testing.T) {
-	clock := newFakePluginClock()
-	launcher := &fakePluginLauncher{}
-	supervisor := newTestPluginSupervisor(clock, launcher)
-	_ = supervisor.Ensure(pluginManifest{Name: "fixture"})
-
-	snapshot, _ := supervisor.Snapshot("fixture")
-	if snapshot.Phase != pluginPhaseStarting || !snapshot.Running || snapshot.Connected {
-		t.Fatalf("starting snapshot=%+v", snapshot)
-	}
-	if !supervisor.NoteConnected("fixture", snapshot.Generation) {
-		t.Fatal("connect current generation")
-	}
-	snapshot, _ = supervisor.Snapshot("fixture")
-	if snapshot.Phase != pluginPhaseConnected || !snapshot.Connected {
-		t.Fatalf("connected snapshot=%+v", snapshot)
-	}
-	launcher.handle(0).exit(pluginExit{Error: "boom"})
-	waitForSupervisor(t, func() bool {
-		snapshot, _ = supervisor.Snapshot("fixture")
-		return snapshot.Phase == pluginPhaseBackoff
-	})
-	if snapshot.LastExit == nil || snapshot.NextRestartAt.IsZero() {
-		t.Fatalf("backoff snapshot=%+v", snapshot)
-	}
-	supervisor.Stop("fixture", pluginStopRemove)
-	snapshot, _ = supervisor.Snapshot("fixture")
-	if snapshot.Phase != pluginPhaseStopped {
-		t.Fatalf("stopped snapshot=%+v", snapshot)
-	}
-}
+// The supervision behaviors themselves (backoff, generation fencing, stability
+// window, disconnect grace, parking) are covered in internal/supervise. What is
+// tested here is the plugin runtime's own wiring onto it: manifests becoming
+// processes, output landing in the plugin's log file, and a parked plugin
+// reaching the user.
 
 func TestExecPluginProcessLauncherRunsExecutableWithoutBun(t *testing.T) {
 	root := t.TempDir()
@@ -229,7 +37,7 @@ func TestExecPluginProcessLauncherRunsExecutableWithoutBun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load manifest: %v", err)
 	}
-	handle, err := (execPluginProcessLauncher{}).Start(manifest, []string{"PLUGIN_MARKER_PATH=" + marker, "PLUGIN_MARKER_VALUE=direct"})
+	handle, err := (execPluginProcessLauncher{}).Start(manifest, []string{"PLUGIN_MARKER_PATH=" + marker, "PLUGIN_MARKER_VALUE=direct"}, nil)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -245,10 +53,91 @@ func TestExecPluginProcessLauncherRunsExecutableWithoutBun(t *testing.T) {
 	}
 }
 
+// A plugin's stdout and stderr used to go to /dev/null. They now land in the
+// supervisor's per-plugin log file, which is what `attn` has to show when a
+// plugin misbehaves.
+func TestSupervisedPluginWritesStdoutAndStderrToItsLogFile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "bin"), 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	script := "#!/bin/sh\necho plugin-said-hello\necho plugin-complained >&2\n"
+	if err := os.WriteFile(filepath.Join(root, "bin", "provider"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write provider: %v", err)
+	}
+	manifestData := []byte("name = \"noisy\"\nversion = \"0.1.0\"\nattn_api_version = 5\n\n[plugin]\nkind = \"executable\"\npath = \"bin/provider\"\n")
+	if err := os.WriteFile(filepath.Join(root, pluginManifestName), manifestData, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	manifest, err := loadPluginManifest(filepath.Join(root, pluginManifestName))
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+
+	logDir := filepath.Join(t.TempDir(), "plugin-log")
+	supervisor := newPluginSupervisor(execPluginProcessLauncher{}, nil, nil, supervise.Options{LogDir: logDir})
+	t.Cleanup(supervisor.Shutdown)
+	if err := supervisor.Ensure(manifest); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+
+	logPath := filepath.Join(logDir, "noisy.log")
+	var captured string
+	waitForSupervisor(t, func() bool {
+		data, err := os.ReadFile(logPath)
+		if err != nil {
+			return false
+		}
+		captured = string(data)
+		return strings.Contains(captured, "plugin-said-hello") && strings.Contains(captured, "plugin-complained")
+	})
+	if !strings.Contains(captured, "starting noisy generation 1") {
+		t.Fatalf("log missing the start marker:\n%s", captured)
+	}
+}
+
+func TestPluginLogDirSitsOutsideThePluginDiscoveryDirectory(t *testing.T) {
+	socket := filepath.Join(t.TempDir(), "attn.sock")
+	logDir := pluginLogDirForSocket(socket)
+	if within, err := filepath.Rel(pluginDirForSocket(socket), logDir); err == nil && !strings.HasPrefix(within, "..") {
+		t.Fatalf("log dir %s is inside the plugin discovery dir; manifests are scanned there", logDir)
+	}
+}
+
+// Parking is the end of the retry line, so it has to be visible: the daemon
+// turns it into a durable notification pointing back at the plugin.
+func TestParkedPluginRaisesADurableNotification(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "daemon.sock"))
+	exitCode := 9
+	d.notifyPluginParked("looper", pluginRuntimeSnapshot{
+		Phase:          pluginPhaseParked,
+		RestartAttempt: 10,
+		LastExit:       &pluginExit{At: time.Now(), ExitCode: &exitCode},
+	})
+
+	list, err := d.store.ListNotifications()
+	if err != nil {
+		t.Fatalf("list notifications: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("notifications=%d, want 1", len(list))
+	}
+	record := list[0]
+	if record.Kind != notificationKindPluginParked || record.SourceKind != "plugin" || record.SourceID != "looper" {
+		t.Fatalf("notification=%+v, want a plugin-parked record for looper", record)
+	}
+	if !strings.Contains(record.Title, "looper") || !strings.Contains(record.Body, "10") {
+		t.Fatalf("notification title=%q body=%q, want the plugin name and the restart count", record.Title, record.Body)
+	}
+	if !strings.Contains(record.Detail, "exit code 9") {
+		t.Fatalf("notification detail=%q, want the last exit", record.Detail)
+	}
+}
+
 func newTestPluginSupervisor(clock *fakePluginClock, launcher *fakePluginLauncher) *pluginSupervisor {
 	return newPluginSupervisor(launcher, clock, func(manifest pluginManifest, generation uint64) []string {
 		return []string{fmt.Sprintf("ATTN_PLUGIN_NAME=%s", manifest.Name), fmt.Sprintf("ATTN_PLUGIN_GENERATION=%d", generation)}
-	}, nil)
+	}, supervise.Options{})
 }
 
 type fakePluginLauncher struct {
@@ -258,7 +147,7 @@ type fakePluginLauncher struct {
 	envs        [][]string
 }
 
-func (l *fakePluginLauncher) Start(_ pluginManifest, env []string) (pluginProcessHandle, error) {
+func (l *fakePluginLauncher) Start(_ pluginManifest, env []string, _ io.Writer) (pluginProcessHandle, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.envs = append(l.envs, append([]string(nil), env...))
@@ -315,12 +204,6 @@ func (p *fakePluginProcess) exit(exit pluginExit) {
 	p.exited = true
 	p.mu.Unlock()
 	p.wait <- exit
-}
-
-func (p *fakePluginProcess) killCount() int {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.kills
 }
 
 type fakePluginClock struct {
@@ -393,7 +276,7 @@ func (t *fakePluginTimer) Stop() bool {
 
 func waitForSupervisor(t *testing.T, condition func() bool) {
 	t.Helper()
-	deadline := time.Now().Add(time.Second)
+	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if condition() {
 			return
@@ -402,3 +285,5 @@ func waitForSupervisor(t *testing.T, condition func() bool) {
 	}
 	t.Fatal("supervisor condition did not become true")
 }
+
+func intPtr(value int) *int { return &value }

--- a/internal/daemon/ws_plugins.go
+++ b/internal/daemon/ws_plugins.go
@@ -235,7 +235,7 @@ func (d *Daemon) pluginsUpdatedMessage() *protocol.PluginsUpdatedMessage {
 		switch {
 		case !item.Installed:
 			info.RuntimeState = pluginRuntimeStateStopped
-		case healthStatus == "unhealthy" || runtimePhase == pluginPhaseBackoff:
+		case healthStatus == "unhealthy" || runtimePhase == pluginPhaseBackoff || runtimePhase == pluginPhaseParked:
 			info.RuntimeState = pluginRuntimeStateDegraded
 		case connection != nil:
 			info.RuntimeState = pluginRuntimeStateConnected

--- a/internal/daemon/ws_plugins.go
+++ b/internal/daemon/ws_plugins.go
@@ -20,6 +20,7 @@ const (
 	pluginRuntimeStateStarting     = "starting"
 	pluginRuntimeStateConnected    = "connected"
 	pluginRuntimeStateDegraded     = "degraded"
+	pluginRuntimeStateParked       = "parked"
 )
 
 func (d *Daemon) handleListPluginsWS(client *wsClient) {
@@ -235,7 +236,11 @@ func (d *Daemon) pluginsUpdatedMessage() *protocol.PluginsUpdatedMessage {
 		switch {
 		case !item.Installed:
 			info.RuntimeState = pluginRuntimeStateStopped
-		case healthStatus == "unhealthy" || runtimePhase == pluginPhaseBackoff || runtimePhase == pluginPhaseParked:
+		case runtimePhase == pluginPhaseParked:
+			// Parked is not degraded: nothing is being retried, so it must not
+			// read as a plugin that is still coming back on its own.
+			info.RuntimeState = pluginRuntimeStateParked
+		case healthStatus == "unhealthy" || runtimePhase == pluginPhaseBackoff:
 			info.RuntimeState = pluginRuntimeStateDegraded
 		case connection != nil:
 			info.RuntimeState = pluginRuntimeStateConnected

--- a/internal/daemon/ws_plugins_test.go
+++ b/internal/daemon/ws_plugins_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/supervise"
 )
 
 func TestDaemon_SetPluginPriority_PersistsAndReordersProviders(t *testing.T) {
@@ -113,6 +114,53 @@ func TestDaemon_PluginsUpdatedMessageIncludesSupervisorBackoff(t *testing.T) {
 	}
 	if plugin.LastExit == nil || !strings.Contains(*plugin.LastExit, "exit code 17") {
 		t.Fatalf("last exit=%v, want exit code 17", plugin.LastExit)
+	}
+}
+
+// A parked plugin must not read as one that is still coming back: nothing is
+// scheduled for it, so it gets its own runtime state rather than the degraded
+// one shared with backoff.
+func TestDaemon_PluginsUpdatedMessageReportsAParkedPlugin(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "daemon.sock"))
+	d.pluginDir = filepath.Join(t.TempDir(), "plugins")
+	writeTestPluginManifest(t, d.pluginDir, "doomed-provider")
+	manifest, err := loadPluginManifest(filepath.Join(d.pluginDir, "doomed-provider", pluginManifestName))
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+
+	clock := newFakePluginClock()
+	launcher := &fakePluginLauncher{}
+	d.pluginSupervisor = newPluginSupervisor(launcher, clock, nil, supervise.Options{GiveUpAfter: 1})
+	if err := d.pluginSupervisor.Ensure(manifest); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	launcher.handle(0).exit(pluginExit{ExitCode: intPtr(1)})
+	waitForSupervisor(t, func() bool {
+		snapshot, _ := d.pluginSupervisor.Snapshot(manifest.Name)
+		return snapshot.Phase == pluginPhaseBackoff
+	})
+	clock.Advance(pluginRestartBackoff[0])
+	waitForSupervisor(t, func() bool { return launcher.count() == 2 })
+	launcher.handle(1).exit(pluginExit{ExitCode: intPtr(1)})
+	waitForSupervisor(t, func() bool {
+		snapshot, _ := d.pluginSupervisor.Snapshot(manifest.Name)
+		return snapshot.Phase == pluginPhaseParked
+	})
+
+	plugins := d.pluginsUpdatedMessage().Plugins
+	if len(plugins) != 1 {
+		t.Fatalf("plugin count=%d, want 1", len(plugins))
+	}
+	plugin := plugins[0]
+	if got := protocol.Deref(plugin.RuntimePhase); got != string(pluginPhaseParked) {
+		t.Fatalf("runtime phase=%q, want parked", got)
+	}
+	if plugin.RuntimeState != pluginRuntimeStateParked {
+		t.Fatalf("runtime state=%q, want parked", plugin.RuntimeState)
+	}
+	if plugin.NextRestartAt != nil {
+		t.Fatalf("next restart=%v, want nothing scheduled", plugin.NextRestartAt)
 	}
 }
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -445,7 +445,7 @@ model PluginInfo {
   running: boolean;
   availability: string; // "bundled" | "user"
   installation_state: string; // "available" | "installed"
-  runtime_state: string; // "stopped" | "starting" | "connected" | "degraded"
+  runtime_state: string; // "stopped" | "starting" | "connected" | "degraded" | "parked"
   can_install: boolean;
   can_uninstall: boolean;
   // "starting" | "connected" | "backoff" | "stopped". Plain string keeps

--- a/internal/supervise/exec.go
+++ b/internal/supervise/exec.go
@@ -1,0 +1,50 @@
+package supervise
+
+import (
+	"io"
+	"os/exec"
+	"syscall"
+)
+
+// StartCommand starts a prepared command as a supervised process, sending its
+// stdout and stderr to log. A nil log is os/exec's own /dev/null, which is what
+// every child got before log capture existed. The caller owns everything about
+// the command except its output wiring and its exit reporting.
+func StartCommand(cmd *exec.Cmd, log io.Writer) (Process, error) {
+	cmd.Stdout = log
+	cmd.Stderr = log
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return &execProcess{cmd: cmd}, nil
+}
+
+type execProcess struct {
+	cmd *exec.Cmd
+}
+
+// Wait reports how the process ended, keeping the error text, the exit code and
+// the signal apart so a caller can render whichever it has.
+func (p *execProcess) Wait() Exit {
+	err := p.cmd.Wait()
+	exit := Exit{}
+	if err != nil {
+		exit.Error = err.Error()
+	}
+	if state := p.cmd.ProcessState; state != nil {
+		if code := state.ExitCode(); code >= 0 {
+			exit.ExitCode = &code
+		}
+		if status, ok := state.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+			exit.Signal = status.Signal().String()
+		}
+	}
+	return exit
+}
+
+func (p *execProcess) Kill() error {
+	if p.cmd == nil || p.cmd.Process == nil {
+		return nil
+	}
+	return p.cmd.Process.Kill()
+}

--- a/internal/supervise/supervise.go
+++ b/internal/supervise/supervise.go
@@ -1,0 +1,598 @@
+// Package supervise keeps long-lived daemon child processes alive: it starts
+// them, restarts them with capped exponential backoff, fences stale processes
+// and timers behind a generation counter, and parks a child that keeps dying
+// without ever running stably.
+//
+// The supervisor knows nothing about what it supervises. A consumer names a
+// child and hands over a StartFunc; everything the child needs to be launched —
+// binary, arguments, environment — is closed over there. Two consumers exist:
+// the daemon's plugin runtime (one child per installed plugin) and the app
+// runtime's Bun sidecar.
+//
+// A supervised child is expected to dial the daemon back and announce itself,
+// which the consumer reports through NoteConnected/NoteDisconnected. A child
+// that starts but never calls back inside the disconnect grace is killed, which
+// puts it back on the restart path.
+package supervise
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DesiredState is what the consumer asked for, independent of what the child is
+// currently doing.
+type DesiredState string
+
+const (
+	DesiredRunning DesiredState = "running"
+	DesiredStopped DesiredState = "stopped"
+)
+
+// Phase is where one child sits in the supervision cycle. It is reported
+// verbatim on attn's wire, so the strings are part of the observable surface.
+type Phase string
+
+const (
+	PhaseStarting  Phase = "starting"
+	PhaseConnected Phase = "connected"
+	PhaseBackoff   Phase = "backoff"
+	PhaseStopped   Phase = "stopped"
+	// PhaseParked is a child the supervisor has given up restarting. Nothing
+	// is scheduled; only a fresh Ensure brings it back.
+	PhaseParked Phase = "parked"
+)
+
+// RestartBackoff is the delay before restart attempt N (capped at the last
+// entry). Eight steps from 250ms to 30s.
+var RestartBackoff = []time.Duration{
+	250 * time.Millisecond,
+	500 * time.Millisecond,
+	time.Second,
+	2 * time.Second,
+	4 * time.Second,
+	8 * time.Second,
+	16 * time.Second,
+	30 * time.Second,
+}
+
+// DisconnectGrace is how long a started child has to dial back before it is
+// killed, and how long a connected child that drops its connection has to
+// reconnect.
+const DisconnectGrace = 5 * time.Second
+
+// StableConnection is how long a connection must hold before the child counts
+// as healthy and its restart attempts reset.
+const StableConnection = 60 * time.Second
+
+// DefaultGiveUpAfter is how many consecutive restarts a child gets without ever
+// reaching a stability window before it is parked.
+//
+// Tripwire, not a receipt: no healthy child restarts twice, let alone ten
+// times. At the pinned backoff, ten restarts cost 121.75s of waiting
+// (0.25+0.5+1+2+4+8+16+30+30+30), plus up to DisconnectGrace per attempt for a
+// child that starts and never calls back — so a crash-looping child is parked
+// after roughly two to three minutes. Recalibrate against a measurement if a
+// legitimate child ever reaches it.
+const DefaultGiveUpAfter = 10
+
+// Exit is how a child process ended. All fields are best-effort: a process
+// killed by a signal has no exit code, and a launcher that never produced a
+// process reports only Error.
+type Exit struct {
+	At       time.Time
+	ExitCode *int
+	Signal   string
+	Error    string
+}
+
+func (e Exit) String() string {
+	detail := strings.TrimSpace(e.Error)
+	if detail == "" && e.Signal != "" {
+		detail = "signal " + e.Signal
+	}
+	if detail == "" && e.ExitCode != nil {
+		detail = fmt.Sprintf("exit code %d", *e.ExitCode)
+	}
+	if detail == "" {
+		detail = "process exited"
+	}
+	if e.At.IsZero() {
+		return detail
+	}
+	return fmt.Sprintf("%s: %s", e.At.Format(time.RFC3339), detail)
+}
+
+// Snapshot is one child's supervision state at a moment, copied out so the
+// caller holds no supervisor state.
+type Snapshot struct {
+	Desired        DesiredState
+	Phase          Phase
+	Generation     uint64
+	Running        bool
+	Connected      bool
+	RestartAttempt int
+	StartedAt      time.Time
+	ConnectedAt    time.Time
+	NextRestartAt  time.Time
+	LastExit       *Exit
+}
+
+// Process is a started child. Wait blocks until it ends; Kill asks it to die and
+// must be safe to call after it already has.
+type Process interface {
+	Wait() Exit
+	Kill() error
+}
+
+// StartRequest carries what the supervisor knows at launch time. Log is an
+// append-only writer for the child's stdout/stderr — nil when log capture is
+// off or the log file could not be opened, in which case the launcher should
+// discard the child's output as before. The writer is closed once StartFunc
+// returns, so the launcher must hand it to the child rather than keep it.
+type StartRequest struct {
+	Name       string
+	Generation uint64
+	Log        io.Writer
+}
+
+// StartFunc launches one child. It is called on every start, including
+// restarts, so it must be safe to call repeatedly.
+type StartFunc func(StartRequest) (Process, error)
+
+// Timer is the subset of time.Timer the supervisor uses, so tests can drive
+// time.
+type Timer interface {
+	Stop() bool
+}
+
+// Clock is the supervisor's view of time.
+type Clock interface {
+	Now() time.Time
+	AfterFunc(time.Duration, func()) Timer
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+func (realClock) AfterFunc(delay time.Duration, fn func()) Timer {
+	return time.AfterFunc(delay, fn)
+}
+
+// Options configures one supervisor. The zero value is usable: a real clock, the
+// default give-up tripwire, no log capture, and no callbacks.
+type Options struct {
+	Clock Clock
+	// LogDir holds one append-only <name>.log per child, following the
+	// pty-worker pattern. Empty disables log capture.
+	LogDir string
+	// GiveUpAfter overrides DefaultGiveUpAfter. A negative value never parks.
+	GiveUpAfter int
+	// OnChange reports that one child's supervision state moved. The name is
+	// required: the daemon turns it into a fact, and a fact needs the entity
+	// it is about. Called without the supervisor lock held.
+	OnChange func(name string)
+	// OnGiveUp reports a child crossing into PhaseParked, once per parking.
+	// Called without the supervisor lock held.
+	OnGiveUp func(name string, snapshot Snapshot)
+	// Logf receives supervisor-level diagnostics (a log file that would not
+	// open, a parked child). Optional.
+	Logf func(format string, args ...any)
+}
+
+type child struct {
+	name    string
+	start   StartFunc
+	desired DesiredState
+	phase   Phase
+
+	generation     uint64
+	process        Process
+	restartAttempt int
+	startedAt      time.Time
+	connectedAt    time.Time
+	nextRestartAt  time.Time
+	lastExit       *Exit
+
+	restartTimer    Timer
+	disconnectTimer Timer
+	stabilityTimer  Timer
+}
+
+// Supervisor supervises a set of named children.
+type Supervisor struct {
+	mu          sync.Mutex
+	children    map[string]*child
+	clock       Clock
+	logDir      string
+	giveUpAfter int
+	onChange    func(string)
+	onGiveUp    func(string, Snapshot)
+	logf        func(string, ...any)
+	shutdown    bool
+}
+
+func New(opts Options) *Supervisor {
+	clock := opts.Clock
+	if clock == nil {
+		clock = realClock{}
+	}
+	giveUpAfter := opts.GiveUpAfter
+	if giveUpAfter == 0 {
+		giveUpAfter = DefaultGiveUpAfter
+	}
+	logf := opts.Logf
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	return &Supervisor{
+		children:    make(map[string]*child),
+		clock:       clock,
+		logDir:      opts.LogDir,
+		giveUpAfter: giveUpAfter,
+		onChange:    opts.OnChange,
+		onGiveUp:    opts.OnGiveUp,
+		logf:        logf,
+	}
+}
+
+// Ensure declares that a named child should be running, launching it if nothing
+// is running or scheduled for it. Calling it again replaces the StartFunc used
+// by the next start and is otherwise a no-op for a live child — so it is also
+// how a parked child is revived, which resets its restart attempts.
+func (s *Supervisor) Ensure(name string, start StartFunc) error {
+	if err := validateName(name); err != nil {
+		return err
+	}
+	if start == nil {
+		return fmt.Errorf("supervise: child %q needs a start function", name)
+	}
+	s.mu.Lock()
+	if s.shutdown {
+		s.mu.Unlock()
+		return fmt.Errorf("supervise: supervisor is shut down, cannot start %q", name)
+	}
+	c := s.children[name]
+	if c == nil {
+		c = &child{name: name, start: start, desired: DesiredRunning, phase: PhaseStarting}
+		s.children[name] = c
+	} else {
+		c.start = start
+		c.desired = DesiredRunning
+		if c.process != nil || c.restartTimer != nil {
+			s.mu.Unlock()
+			return nil
+		}
+		if c.phase == PhaseParked {
+			c.restartAttempt = 0
+		}
+	}
+	err := s.spawnLocked(c)
+	parked, snapshot := c.phase == PhaseParked, snapshotOf(c)
+	s.mu.Unlock()
+	if parked {
+		s.reportGiveUp(name, snapshot)
+	}
+	s.notify(name)
+	return err
+}
+
+// Stop kills a child and stops supervising it until the next Ensure.
+func (s *Supervisor) Stop(name string) {
+	s.mu.Lock()
+	c := s.children[name]
+	if c == nil {
+		s.mu.Unlock()
+		return
+	}
+	c.desired = DesiredStopped
+	c.phase = PhaseStopped
+	c.generation++
+	c.connectedAt = time.Time{}
+	c.nextRestartAt = time.Time{}
+	stopTimer(&c.restartTimer)
+	stopTimer(&c.disconnectTimer)
+	stopTimer(&c.stabilityTimer)
+	process := c.process
+	c.process = nil
+	s.mu.Unlock()
+	if process != nil {
+		_ = process.Kill()
+	}
+	s.notify(name)
+}
+
+// Shutdown stops every child and refuses further Ensure calls.
+func (s *Supervisor) Shutdown() {
+	s.mu.Lock()
+	if s.shutdown {
+		s.mu.Unlock()
+		return
+	}
+	s.shutdown = true
+	names := make([]string, 0, len(s.children))
+	for name := range s.children {
+		names = append(names, name)
+	}
+	s.mu.Unlock()
+	for _, name := range names {
+		s.Stop(name)
+	}
+}
+
+// NoteConnected reports that a child dialed back. It accepts untracked
+// test/manual connections, but a supervised child must present the exact
+// generation injected into its process.
+func (s *Supervisor) NoteConnected(name string, generation uint64) bool {
+	s.mu.Lock()
+	c := s.children[name]
+	if c == nil {
+		s.mu.Unlock()
+		return true
+	}
+	if generation == 0 || generation != c.generation || c.desired != DesiredRunning || c.process == nil {
+		s.mu.Unlock()
+		return false
+	}
+	c.phase = PhaseConnected
+	c.connectedAt = s.clock.Now()
+	c.nextRestartAt = time.Time{}
+	stopTimer(&c.disconnectTimer)
+	stopTimer(&c.stabilityTimer)
+	capturedGeneration := c.generation
+	c.stabilityTimer = s.clock.AfterFunc(StableConnection, func() {
+		s.markStable(name, capturedGeneration)
+	})
+	s.mu.Unlock()
+	s.notify(name)
+	return true
+}
+
+// NoteDisconnected reports that a child's connection dropped, starting the
+// grace period in which it may reconnect before being killed.
+func (s *Supervisor) NoteDisconnected(name string, generation uint64) {
+	s.mu.Lock()
+	c := s.children[name]
+	if c == nil || generation != c.generation || c.desired != DesiredRunning || c.process == nil {
+		s.mu.Unlock()
+		return
+	}
+	c.phase = PhaseStarting
+	c.connectedAt = time.Time{}
+	stopTimer(&c.stabilityTimer)
+	stopTimer(&c.disconnectTimer)
+	capturedProcess := c.process
+	capturedGeneration := c.generation
+	c.disconnectTimer = s.clock.AfterFunc(DisconnectGrace, func() {
+		s.disconnectExpired(name, capturedGeneration, capturedProcess)
+	})
+	s.mu.Unlock()
+	s.notify(name)
+}
+
+// Snapshot copies out one child's state.
+func (s *Supervisor) Snapshot(name string) (Snapshot, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	c := s.children[name]
+	if c == nil {
+		return Snapshot{}, false
+	}
+	return snapshotOf(c), true
+}
+
+func snapshotOf(c *child) Snapshot {
+	snapshot := Snapshot{
+		Desired:        c.desired,
+		Phase:          c.phase,
+		Generation:     c.generation,
+		Running:        c.process != nil,
+		Connected:      c.phase == PhaseConnected,
+		RestartAttempt: c.restartAttempt,
+		StartedAt:      c.startedAt,
+		ConnectedAt:    c.connectedAt,
+		NextRestartAt:  c.nextRestartAt,
+	}
+	if c.lastExit != nil {
+		exit := *c.lastExit
+		if c.lastExit.ExitCode != nil {
+			code := *c.lastExit.ExitCode
+			exit.ExitCode = &code
+		}
+		snapshot.LastExit = &exit
+	}
+	return snapshot
+}
+
+func (s *Supervisor) spawnLocked(c *child) error {
+	c.generation++
+	c.phase = PhaseStarting
+	c.nextRestartAt = time.Time{}
+	stopTimer(&c.restartTimer)
+	generation := c.generation
+	process, err := s.startChild(c, generation)
+	if err != nil {
+		exit := Exit{At: s.clock.Now(), Error: err.Error()}
+		c.lastExit = &exit
+		s.scheduleRestartLocked(c)
+		return err
+	}
+	c.process = process
+	c.startedAt = s.clock.Now()
+	stopTimer(&c.disconnectTimer)
+	name := c.name
+	capturedProcess := process
+	c.disconnectTimer = s.clock.AfterFunc(DisconnectGrace, func() {
+		s.disconnectExpired(name, generation, capturedProcess)
+	})
+	go func(name string, generation uint64, process Process) {
+		exit := process.Wait()
+		s.processExited(name, generation, process, exit)
+	}(name, generation, process)
+	return nil
+}
+
+// startChild opens this start's log file, launches the child, and closes the
+// supervisor's copy of the file descriptor: the child keeps its own, so nothing
+// here has to outlive the launch.
+func (s *Supervisor) startChild(c *child, generation uint64) (Process, error) {
+	req := StartRequest{Name: c.name, Generation: generation}
+	if file := s.openLog(c.name, generation); file != nil {
+		defer func() { _ = file.Close() }()
+		req.Log = file
+	}
+	return c.start(req)
+}
+
+func (s *Supervisor) openLog(name string, generation uint64) *os.File {
+	if s.logDir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(s.logDir, 0o700); err != nil {
+		s.logf("supervise: log dir %s: %v", s.logDir, err)
+		return nil
+	}
+	path := filepath.Join(s.logDir, name+".log")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		s.logf("supervise: log file %s: %v", path, err)
+		return nil
+	}
+	fmt.Fprintf(file, "\n=== %s starting %s generation %d ===\n", s.clock.Now().Format(time.RFC3339), name, generation)
+	return file
+}
+
+func (s *Supervisor) processExited(name string, generation uint64, process Process, exit Exit) {
+	s.mu.Lock()
+	c := s.children[name]
+	if c == nil || generation != c.generation || c.process != process {
+		s.mu.Unlock()
+		return
+	}
+	c.process = nil
+	c.connectedAt = time.Time{}
+	stopTimer(&c.disconnectTimer)
+	stopTimer(&c.stabilityTimer)
+	exit.At = s.clock.Now()
+	c.lastExit = &exit
+	if c.desired == DesiredRunning && !s.shutdown {
+		s.scheduleRestartLocked(c)
+	} else {
+		c.phase = PhaseStopped
+		c.nextRestartAt = time.Time{}
+	}
+	parked, snapshot := c.phase == PhaseParked, snapshotOf(c)
+	s.mu.Unlock()
+	if parked {
+		s.reportGiveUp(name, snapshot)
+	}
+	s.notify(name)
+}
+
+// scheduleRestartLocked queues the next restart, or parks the child when it has
+// burned through its restarts without ever reaching a stability window.
+func (s *Supervisor) scheduleRestartLocked(c *child) {
+	stopTimer(&c.restartTimer)
+	if s.giveUpAfter > 0 && c.restartAttempt >= s.giveUpAfter {
+		c.phase = PhaseParked
+		c.nextRestartAt = time.Time{}
+		detail := "no exit recorded"
+		if c.lastExit != nil {
+			detail = c.lastExit.String()
+		}
+		s.logf("supervise: giving up on %q after %d restarts with no stable connection; last exit: %s", c.name, c.restartAttempt, detail)
+		return
+	}
+	c.restartAttempt++
+	index := c.restartAttempt - 1
+	if index >= len(RestartBackoff) {
+		index = len(RestartBackoff) - 1
+	}
+	delay := RestartBackoff[index]
+	c.phase = PhaseBackoff
+	c.nextRestartAt = s.clock.Now().Add(delay)
+	name := c.name
+	capturedGeneration := c.generation
+	c.restartTimer = s.clock.AfterFunc(delay, func() {
+		s.restart(name, capturedGeneration)
+	})
+}
+
+func (s *Supervisor) restart(name string, generation uint64) {
+	s.mu.Lock()
+	c := s.children[name]
+	if c == nil || generation != c.generation || c.desired != DesiredRunning || s.shutdown {
+		s.mu.Unlock()
+		return
+	}
+	c.restartTimer = nil
+	_ = s.spawnLocked(c)
+	parked, snapshot := c.phase == PhaseParked, snapshotOf(c)
+	s.mu.Unlock()
+	if parked {
+		s.reportGiveUp(name, snapshot)
+	}
+	s.notify(name)
+}
+
+func (s *Supervisor) markStable(name string, generation uint64) {
+	s.mu.Lock()
+	c := s.children[name]
+	if c == nil || generation != c.generation || c.phase != PhaseConnected {
+		s.mu.Unlock()
+		return
+	}
+	c.restartAttempt = 0
+	c.stabilityTimer = nil
+	s.mu.Unlock()
+	s.notify(name)
+}
+
+func (s *Supervisor) disconnectExpired(name string, generation uint64, process Process) {
+	s.mu.Lock()
+	c := s.children[name]
+	if c == nil || generation != c.generation || c.process != process || c.phase == PhaseConnected || c.desired != DesiredRunning {
+		s.mu.Unlock()
+		return
+	}
+	c.disconnectTimer = nil
+	s.mu.Unlock()
+	_ = process.Kill()
+}
+
+func (s *Supervisor) notify(name string) {
+	if s.onChange != nil {
+		s.onChange(name)
+	}
+}
+
+func (s *Supervisor) reportGiveUp(name string, snapshot Snapshot) {
+	if s.onGiveUp != nil {
+		s.onGiveUp(name, snapshot)
+	}
+}
+
+// validateName keeps a child name usable both as a map key and as a log file
+// name, so a name can never write outside LogDir.
+func validateName(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return errors.New("supervise: child name is required")
+	}
+	if name != filepath.Base(name) || name == "." || name == ".." || strings.ContainsRune(name, os.PathSeparator) {
+		return fmt.Errorf("supervise: child name %q must be a plain file name", name)
+	}
+	return nil
+}
+
+func stopTimer(timer *Timer) {
+	if *timer != nil {
+		(*timer).Stop()
+		*timer = nil
+	}
+}

--- a/internal/supervise/supervise_test.go
+++ b/internal/supervise/supervise_test.go
@@ -1,0 +1,537 @@
+package supervise
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRestartsExitsWithCappedBackoff(t *testing.T) {
+	clock := newFakeClock()
+	launcher := &fakeLauncher{}
+	supervisor := New(Options{Clock: clock})
+
+	if err := supervisor.Ensure("fixture", launcher.start); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	for attempt := 1; attempt <= len(RestartBackoff)+1; attempt++ {
+		handle := launcher.handle(attempt - 1)
+		handle.exit(Exit{ExitCode: intPtr(0)})
+		waitFor(t, func() bool {
+			snapshot, _ := supervisor.Snapshot("fixture")
+			return snapshot.Phase == PhaseBackoff && snapshot.RestartAttempt == attempt
+		})
+		snapshot, _ := supervisor.Snapshot("fixture")
+		index := attempt - 1
+		if index >= len(RestartBackoff) {
+			index = len(RestartBackoff) - 1
+		}
+		wantDelay := RestartBackoff[index]
+		if got := snapshot.NextRestartAt.Sub(clock.Now()); got != wantDelay {
+			t.Fatalf("attempt %d delay=%s, want %s", attempt, got, wantDelay)
+		}
+		clock.Advance(wantDelay)
+		waitFor(t, func() bool { return launcher.count() == attempt+1 })
+	}
+}
+
+func TestRetriesStartFailure(t *testing.T) {
+	clock := newFakeClock()
+	launcher := &fakeLauncher{startErrors: []error{errors.New("bun missing")}}
+	supervisor := New(Options{Clock: clock})
+
+	if err := supervisor.Ensure("fixture", launcher.start); err == nil {
+		t.Fatal("Ensure error=nil, want start failure")
+	}
+	snapshot, _ := supervisor.Snapshot("fixture")
+	if snapshot.Phase != PhaseBackoff || snapshot.RestartAttempt != 1 || snapshot.LastExit == nil {
+		t.Fatalf("snapshot=%+v, want first backoff with exit", snapshot)
+	}
+	clock.Advance(250 * time.Millisecond)
+	waitFor(t, func() bool { return launcher.count() == 2 })
+	snapshot, _ = supervisor.Snapshot("fixture")
+	if snapshot.Phase != PhaseStarting || !snapshot.Running {
+		t.Fatalf("snapshot=%+v, want restarted process", snapshot)
+	}
+}
+
+func TestResetsAttemptsOnlyAfterStableConnection(t *testing.T) {
+	clock := newFakeClock()
+	launcher := &fakeLauncher{}
+	supervisor := New(Options{Clock: clock})
+	_ = supervisor.Ensure("fixture", launcher.start)
+	launcher.handle(0).exit(Exit{Error: "crash"})
+	waitFor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.RestartAttempt == 1
+	})
+	clock.Advance(250 * time.Millisecond)
+	waitFor(t, func() bool { return launcher.count() == 2 })
+	snapshot, _ := supervisor.Snapshot("fixture")
+	if !supervisor.NoteConnected("fixture", snapshot.Generation) {
+		t.Fatal("NoteConnected rejected current generation")
+	}
+	clock.Advance(StableConnection - time.Millisecond)
+	snapshot, _ = supervisor.Snapshot("fixture")
+	if snapshot.RestartAttempt != 1 {
+		t.Fatalf("attempt=%d before stability window, want 1", snapshot.RestartAttempt)
+	}
+	clock.Advance(time.Millisecond)
+	snapshot, _ = supervisor.Snapshot("fixture")
+	if snapshot.RestartAttempt != 0 || snapshot.Phase != PhaseConnected {
+		t.Fatalf("snapshot=%+v after stability window, want connected attempt 0", snapshot)
+	}
+}
+
+func TestDisconnectGraceReconnectAndKill(t *testing.T) {
+	clock := newFakeClock()
+	launcher := &fakeLauncher{}
+	supervisor := New(Options{Clock: clock})
+	_ = supervisor.Ensure("fixture", launcher.start)
+	snapshot, _ := supervisor.Snapshot("fixture")
+	generation := snapshot.Generation
+	if !supervisor.NoteConnected("fixture", generation) {
+		t.Fatal("NoteConnected rejected current generation")
+	}
+
+	supervisor.NoteDisconnected("fixture", generation)
+	clock.Advance(DisconnectGrace - time.Millisecond)
+	if got := launcher.handle(0).killCount(); got != 0 {
+		t.Fatalf("kills before grace=%d, want 0", got)
+	}
+	if !supervisor.NoteConnected("fixture", generation) {
+		t.Fatal("same-generation reconnect was rejected")
+	}
+	clock.Advance(time.Millisecond)
+	if got := launcher.handle(0).killCount(); got != 0 {
+		t.Fatalf("kills after canceled grace=%d, want 0", got)
+	}
+
+	supervisor.NoteDisconnected("fixture", generation)
+	clock.Advance(DisconnectGrace)
+	if got := launcher.handle(0).killCount(); got != 1 {
+		t.Fatalf("kills after expired grace=%d, want 1", got)
+	}
+	waitFor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.Phase == PhaseBackoff
+	})
+}
+
+func TestRestartsProcessThatNeverConnects(t *testing.T) {
+	clock := newFakeClock()
+	launcher := &fakeLauncher{}
+	supervisor := New(Options{Clock: clock})
+	_ = supervisor.Ensure("fixture", launcher.start)
+
+	clock.Advance(DisconnectGrace)
+	if got := launcher.handle(0).killCount(); got != 1 {
+		t.Fatalf("kills after startup grace=%d, want 1", got)
+	}
+	waitFor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.Phase == PhaseBackoff && snapshot.RestartAttempt == 1
+	})
+	clock.Advance(RestartBackoff[0])
+	waitFor(t, func() bool { return launcher.count() == 2 })
+}
+
+func TestIntentionalStopAndShutdownNeverRestart(t *testing.T) {
+	clock := newFakeClock()
+	launcher := &fakeLauncher{}
+	supervisor := New(Options{Clock: clock})
+	_ = supervisor.Ensure("one", launcher.start)
+	_ = supervisor.Ensure("two", launcher.start)
+	one, _ := supervisor.Snapshot("one")
+	if !supervisor.NoteConnected("one", one.Generation) {
+		t.Fatal("connect one")
+	}
+	supervisor.NoteDisconnected("one", one.Generation)
+	supervisor.Stop("one")
+
+	stopped, _ := supervisor.Snapshot("one")
+	if stopped.Phase != PhaseStopped || stopped.Running || stopped.Desired != DesiredStopped {
+		t.Fatalf("stopped snapshot=%+v", stopped)
+	}
+	if supervisor.NoteConnected("one", one.Generation) {
+		t.Fatal("stale generation reconnect accepted")
+	}
+	clock.Advance(time.Hour)
+	if got := launcher.count(); got != 2 {
+		t.Fatalf("starts after intentional stop=%d, want 2", got)
+	}
+
+	supervisor.Shutdown()
+	clock.Advance(time.Hour)
+	if got := launcher.count(); got != 2 {
+		t.Fatalf("starts after shutdown=%d, want 2", got)
+	}
+	for _, name := range []string{"one", "two"} {
+		snapshot, _ := supervisor.Snapshot(name)
+		if snapshot.Phase != PhaseStopped || snapshot.Running {
+			t.Fatalf("%s snapshot=%+v after shutdown", name, snapshot)
+		}
+	}
+	if err := supervisor.Ensure("three", launcher.start); err == nil {
+		t.Fatal("Ensure after shutdown error=nil, want refusal")
+	}
+}
+
+func TestSnapshotsStartingConnectedBackoffAndStopped(t *testing.T) {
+	clock := newFakeClock()
+	launcher := &fakeLauncher{}
+	supervisor := New(Options{Clock: clock})
+	_ = supervisor.Ensure("fixture", launcher.start)
+
+	snapshot, _ := supervisor.Snapshot("fixture")
+	if snapshot.Phase != PhaseStarting || !snapshot.Running || snapshot.Connected {
+		t.Fatalf("starting snapshot=%+v", snapshot)
+	}
+	if !supervisor.NoteConnected("fixture", snapshot.Generation) {
+		t.Fatal("connect current generation")
+	}
+	snapshot, _ = supervisor.Snapshot("fixture")
+	if snapshot.Phase != PhaseConnected || !snapshot.Connected {
+		t.Fatalf("connected snapshot=%+v", snapshot)
+	}
+	launcher.handle(0).exit(Exit{Error: "boom"})
+	waitFor(t, func() bool {
+		snapshot, _ = supervisor.Snapshot("fixture")
+		return snapshot.Phase == PhaseBackoff
+	})
+	if snapshot.LastExit == nil || snapshot.NextRestartAt.IsZero() {
+		t.Fatalf("backoff snapshot=%+v", snapshot)
+	}
+	supervisor.Stop("fixture")
+	snapshot, _ = supervisor.Snapshot("fixture")
+	if snapshot.Phase != PhaseStopped {
+		t.Fatalf("stopped snapshot=%+v", snapshot)
+	}
+}
+
+// A child that keeps dying is parked after the configured number of restarts,
+// and parking is announced once — the daemon turns that into a notification.
+func TestParksAfterGiveUpTripwireAndAnnouncesOnce(t *testing.T) {
+	clock := newFakeClock()
+	launcher := &fakeLauncher{}
+	var mu sync.Mutex
+	var gaveUp []Snapshot
+	supervisor := New(Options{
+		Clock:       clock,
+		GiveUpAfter: 3,
+		OnGiveUp: func(_ string, snapshot Snapshot) {
+			mu.Lock()
+			gaveUp = append(gaveUp, snapshot)
+			mu.Unlock()
+		},
+	})
+	_ = supervisor.Ensure("fixture", launcher.start)
+
+	for attempt := 1; attempt <= 3; attempt++ {
+		launcher.handle(attempt - 1).exit(Exit{Error: "boom"})
+		waitFor(t, func() bool {
+			snapshot, _ := supervisor.Snapshot("fixture")
+			return snapshot.Phase == PhaseBackoff && snapshot.RestartAttempt == attempt
+		})
+		clock.Advance(RestartBackoff[attempt-1])
+		waitFor(t, func() bool { return launcher.count() == attempt+1 })
+	}
+	launcher.handle(3).exit(Exit{Error: "boom"})
+	waitFor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.Phase == PhaseParked
+	})
+
+	snapshot, _ := supervisor.Snapshot("fixture")
+	if snapshot.Running || !snapshot.NextRestartAt.IsZero() || snapshot.RestartAttempt != 3 {
+		t.Fatalf("parked snapshot=%+v, want stopped-with-nothing-scheduled at attempt 3", snapshot)
+	}
+	clock.Advance(time.Hour)
+	if got := launcher.count(); got != 4 {
+		t.Fatalf("starts after parking=%d, want 4", got)
+	}
+	mu.Lock()
+	announced := len(gaveUp)
+	mu.Unlock()
+	if announced != 1 {
+		t.Fatalf("OnGiveUp calls=%d, want 1", announced)
+	}
+}
+
+// Parking is reversible: the consumer's ordinary "this should be running" call
+// revives the child with a clean restart budget.
+func TestEnsureRevivesParkedChild(t *testing.T) {
+	clock := newFakeClock()
+	launcher := &fakeLauncher{}
+	supervisor := New(Options{Clock: clock, GiveUpAfter: 1})
+	_ = supervisor.Ensure("fixture", launcher.start)
+
+	launcher.handle(0).exit(Exit{Error: "boom"})
+	waitFor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.Phase == PhaseBackoff
+	})
+	clock.Advance(RestartBackoff[0])
+	waitFor(t, func() bool { return launcher.count() == 2 })
+	launcher.handle(1).exit(Exit{Error: "boom"})
+	waitFor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.Phase == PhaseParked
+	})
+
+	if err := supervisor.Ensure("fixture", launcher.start); err != nil {
+		t.Fatalf("Ensure on parked child: %v", err)
+	}
+	waitFor(t, func() bool { return launcher.count() == 3 })
+	snapshot, _ := supervisor.Snapshot("fixture")
+	if snapshot.Phase != PhaseStarting || !snapshot.Running || snapshot.RestartAttempt != 0 {
+		t.Fatalf("revived snapshot=%+v, want a running child with a clean restart budget", snapshot)
+	}
+}
+
+func TestNeverParksWithNegativeGiveUpAfter(t *testing.T) {
+	clock := newFakeClock()
+	launcher := &fakeLauncher{}
+	supervisor := New(Options{Clock: clock, GiveUpAfter: -1})
+	_ = supervisor.Ensure("fixture", launcher.start)
+
+	for attempt := 1; attempt <= DefaultGiveUpAfter+2; attempt++ {
+		launcher.handle(attempt - 1).exit(Exit{Error: "boom"})
+		waitFor(t, func() bool {
+			snapshot, _ := supervisor.Snapshot("fixture")
+			return snapshot.Phase == PhaseBackoff && snapshot.RestartAttempt == attempt
+		})
+		index := attempt - 1
+		if index >= len(RestartBackoff) {
+			index = len(RestartBackoff) - 1
+		}
+		clock.Advance(RestartBackoff[index])
+		waitFor(t, func() bool { return launcher.count() == attempt+1 })
+	}
+}
+
+// The child's own output lands in an append-only per-child file that survives
+// restarts, so a crash loop leaves every generation's output behind.
+func TestCapturesChildOutputPerChildAcrossRestarts(t *testing.T) {
+	clock := newFakeClock()
+	logDir := filepath.Join(t.TempDir(), "logs")
+	launcher := &fakeLauncher{}
+	supervisor := New(Options{Clock: clock, LogDir: logDir})
+
+	if err := supervisor.Ensure("fixture", func(req StartRequest) (Process, error) {
+		if req.Log == nil {
+			return nil, errors.New("no log writer")
+		}
+		fmt.Fprintf(req.Log, "generation %d speaking\n", req.Generation)
+		return launcher.start(req)
+	}); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	launcher.handle(0).exit(Exit{Error: "boom"})
+	waitFor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.Phase == PhaseBackoff
+	})
+	clock.Advance(RestartBackoff[0])
+	waitFor(t, func() bool { return launcher.count() == 2 })
+
+	data, err := os.ReadFile(filepath.Join(logDir, "fixture.log"))
+	if err != nil {
+		t.Fatalf("read child log: %v", err)
+	}
+	log := string(data)
+	for _, want := range []string{"generation 1 speaking", "generation 2 speaking", "starting fixture generation 2"} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("child log missing %q:\n%s", want, log)
+		}
+	}
+}
+
+func TestStartsWithoutLogWriterWhenCaptureIsOff(t *testing.T) {
+	launcher := &fakeLauncher{}
+	supervisor := New(Options{Clock: newFakeClock()})
+	var sawWriter bool
+	if err := supervisor.Ensure("fixture", func(req StartRequest) (Process, error) {
+		sawWriter = req.Log != nil
+		return launcher.start(req)
+	}); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if sawWriter {
+		t.Fatal("start received a log writer with capture off")
+	}
+}
+
+// A child name doubles as a log file name, so a name that could write outside
+// the log directory is refused by name rather than sanitized silently.
+func TestEnsureRefusesUnusableNames(t *testing.T) {
+	supervisor := New(Options{Clock: newFakeClock()})
+	launcher := &fakeLauncher{}
+	for _, name := range []string{"", "   ", "..", ".", "nested/child", "../escape"} {
+		if err := supervisor.Ensure(name, launcher.start); err == nil {
+			t.Fatalf("Ensure(%q) error=nil, want refusal", name)
+		}
+	}
+	if got := launcher.count(); got != 0 {
+		t.Fatalf("starts for refused names=%d, want 0", got)
+	}
+}
+
+type fakeLauncher struct {
+	mu          sync.Mutex
+	handles     []*fakeProcess
+	startErrors []error
+	requests    []StartRequest
+}
+
+func (l *fakeLauncher) start(req StartRequest) (Process, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.requests = append(l.requests, req)
+	index := len(l.requests) - 1
+	if index < len(l.startErrors) && l.startErrors[index] != nil {
+		return nil, l.startErrors[index]
+	}
+	handle := &fakeProcess{wait: make(chan Exit, 1)}
+	l.handles = append(l.handles, handle)
+	return handle, nil
+}
+
+func (l *fakeLauncher) count() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.requests)
+}
+
+func (l *fakeLauncher) handle(index int) *fakeProcess {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.handles[index]
+}
+
+type fakeProcess struct {
+	mu     sync.Mutex
+	wait   chan Exit
+	exited bool
+	kills  int
+}
+
+func (p *fakeProcess) Wait() Exit { return <-p.wait }
+
+func (p *fakeProcess) Kill() error {
+	p.mu.Lock()
+	p.kills++
+	alreadyExited := p.exited
+	if !alreadyExited {
+		p.exited = true
+	}
+	p.mu.Unlock()
+	if !alreadyExited {
+		p.wait <- Exit{Signal: "killed"}
+	}
+	return nil
+}
+
+func (p *fakeProcess) exit(exit Exit) {
+	p.mu.Lock()
+	if p.exited {
+		p.mu.Unlock()
+		return
+	}
+	p.exited = true
+	p.mu.Unlock()
+	p.wait <- exit
+}
+
+func (p *fakeProcess) killCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.kills
+}
+
+type fakeClock struct {
+	mu     sync.Mutex
+	now    time.Time
+	timers []*fakeTimer
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) AfterFunc(delay time.Duration, fn func()) Timer {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	timer := &fakeTimer{clock: c, at: c.now.Add(delay), fn: fn}
+	c.timers = append(c.timers, timer)
+	return timer
+}
+
+func (c *fakeClock) Advance(delay time.Duration) {
+	target := c.Now().Add(delay)
+	for {
+		c.mu.Lock()
+		var next *fakeTimer
+		for _, timer := range c.timers {
+			if timer.stopped || timer.fired || timer.at.After(target) {
+				continue
+			}
+			if next == nil || timer.at.Before(next.at) {
+				next = timer
+			}
+		}
+		if next == nil {
+			c.now = target
+			c.mu.Unlock()
+			return
+		}
+		c.now = next.at
+		next.fired = true
+		fn := next.fn
+		c.mu.Unlock()
+		fn()
+	}
+}
+
+type fakeTimer struct {
+	clock   *fakeClock
+	at      time.Time
+	fn      func()
+	stopped bool
+	fired   bool
+}
+
+func (t *fakeTimer) Stop() bool {
+	t.clock.mu.Lock()
+	defer t.clock.mu.Unlock()
+	if t.stopped || t.fired {
+		return false
+	}
+	t.stopped = true
+	return true
+}
+
+func waitFor(t *testing.T, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("supervisor condition did not become true")
+}
+
+func intPtr(value int) *int { return &value }


### PR DESCRIPTION
Slice 2 of `docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md`. Process
supervision was private to the plugin runtime; it moves into a shared
`internal/supervise`, the plugin runtime moves onto it in the same change, and
two capabilities the plan calls for arrive with the move.

## The package

`internal/supervise` knows nothing about what it supervises. A consumer names a
child and hands over a `StartFunc`; the binary, arguments and environment are
closed over there, so no manifest, environment shape or protocol crosses the
boundary. The app runtime's Bun sidecar (slice 5) is the second consumer. The
one shared launch mechanic — turning an `exec.Cmd` into a supervised process and
mapping its ending onto exit code / signal / error — lives in the package as
`StartCommand`.

`pluginSupervisor` is now a thin adapter: manifest in, `StartFunc` out. What
stayed in `internal/daemon` is how a plugin manifest becomes a process, and the
daemon-side reactions (fact publishing, notification).

## Behaviors that had to survive, and how each is verified

Every one of these was already covered by the plugin supervisor's tests; those
tests moved into `internal/supervise` with generic vocabulary and still pass.
The extraction is verified by a consumer that already works.

| Behavior | Test |
| --- | --- |
| Restart with capped exponential backoff, 250ms→30s over 8 steps | `TestRestartsExitsWithCappedBackoff` (walks nine attempts, so the cap is exercised, not just described) |
| A start that fails outright is retried like an exit | `TestRetriesStartFailure` |
| 60s stability window resets the backoff, and only after it elapses | `TestResetsAttemptsOnlyAfterStableConnection` |
| 5s disconnect grace: reconnect cancels it, expiry kills the child | `TestDisconnectGraceReconnectAndKill` |
| A child that starts and never calls back is killed and restarted | `TestRestartsProcessThatNeverConnects` |
| Generation fencing: a stale generation cannot connect, and stale timers/exits are ignored | `TestIntentionalStopAndShutdownNeverRestart`, plus the generation checks on every path |
| Intentional stop and shutdown never restart | `TestIntentionalStopAndShutdownNeverRestart` |
| Snapshots report starting / connected / backoff / stopped with last exit and next restart | `TestSnapshotsStartingConnectedBackoffAndStopped` |
| The manifest still becomes the right process | `TestExecPluginProcessLauncherRunsExecutableWithoutBun` (daemon) |
| The plugins list still reports supervisor backoff on the wire | `TestDaemon_PluginsUpdatedMessageIncludesSupervisorBackoff` (daemon) |

`Stop` lost its `reason` parameter, which every caller passed and the supervisor
discarded. No other signature changed meaning.

## Give-up state

A child that keeps dying without ever reaching a stability window is now parked
instead of retried forever: nothing is scheduled, `Phase` is `parked`, and the
consumer is told once through `OnGiveUp`.

The tripwire is 10 consecutive restarts with no stability window — a tripwire,
not a receipt: no healthy child restarts twice, let alone ten times. **The
plan's "~3.5 minutes" estimate is corrected in the plan doc**: ten restarts at
the pinned backoff cost 121.75s of waiting (0.25+0.5+1+2+4+8+16+30+30+30) plus
up to the 5s grace per attempt that never connects. The live run below parked
after 122s, matching the arithmetic. It is a package option (`GiveUpAfter`;
negative never parks).

Parking is observable and reversible:

- daemon log line naming the plugin, the restart count and the last exit;
- durable notification (`plugin_parked`) with the same, `source_kind: plugin`;
- `runtime_phase: parked` and a new `runtime_state: parked` in the plugins
  list, rendered as a red PARKED badge in Settings. It deliberately does not
  reuse `degraded`: the one case where nothing is coming back must not look
  like the one where something is;
- `Ensure` — the consumer's ordinary "this should be running" call — revives a
  parked child with a clean restart budget, which is why no separate restart
  entry point exists yet (`TestEnsureRevivesParkedChild`).

`attn app status` surfacing is slice 5's job.

## Log capture

Plugin stdout/stderr went to `/dev/null`. Each start now opens
`<data-dir>/plugin-log/<name>.log` (append-only, 0600, the pty-worker pattern),
writes a `=== <time> starting <name> generation <n> ===` marker and hands the
file to the child; the supervisor's own descriptor is closed as soon as the
launch returns, since the child holds its own. No rotation machinery, matching
ptyworker.

The path sits outside `<data-dir>/plugins` on purpose — everything under there
is scanned for manifests (`TestPluginLogDirSitsOutsideThePluginDiscoveryDirectory`).
A child name doubles as a log file name, so a name that is not a plain file name
is refused loudly at `Ensure` rather than sanitized silently
(`TestEnsureRefusesUnusableNames`).

## Live verification

Throwaway profile `sup2` (never dev, never prod; `attn profile clean sup2`
afterwards, data dir removed), daemon built from this branch, with a user
plugin whose executable prints to both streams and exits 3.

- Restart with backoff, live: `restart_attempt` climbing with
  `next_restart_at` moving out per the schedule.
- Parked at 13:13:31 after starting at 13:11:29 — **122s for 10 restarts**,
  against 121.75s computed.
- `runtime_phase: parked`, `runtime_state: parked`, `next_restart_at` absent,
  and no further starts.
- Daemon log: `plugin crasher parked after 10 restarts without a stable
  connection: 2026-08-08T13:13:31+02:00: exit status 3`.
- Notification row: `plugin_parked | Plugin stopped: crasher | attn restarted
  it 10 times without it ever staying up, and has stopped trying. … |
  2026-08-08T13:13:31+02:00: exit status 3 | plugin | crasher`.
- `~/.attn-sup2/plugin-log/crasher.log` carrying every generation's stdout and
  stderr under its own start marker.
- Restarting the daemon put the parked plugin back under supervision (fresh
  `Ensure`); the in-process un-park is covered by unit test rather than live.

## Surfaces walked

- **CLI**: `attn plugin list` carries the new phase and state (used for the
  receipts above).
- **Daemon and app**: parked reaches the plugins list and the Settings badge.
- **Protocol**: none. `runtime_phase` and `runtime_state` are free-form strings
  in `main.tsp`; only their documenting comments changed, so `generated.go` and
  `generated.ts` are byte-identical and `ProtocolVersion` is untouched.
- **Linux**: `GOOS=linux GOARCH=arm64 go build ./...` clean; nothing
  platform-specific was added (`syscall.WaitStatus` is what the code already
  used).
- **Plugins and SDK**: no plugin-facing contract changed — a plugin now has its
  output kept instead of discarded.
- **Docs**: `internal/supervise` added to the AGENTS.md architecture map; plan
  doc records the shipped shape and the corrected tripwire arithmetic;
  changelog fragment (`kind: internal`).

## Tests

`go test ./...` green, `-race` on `internal/supervise` and `internal/daemon`,
`pnpm vitest run src/components/SettingsModal.test.tsx` green.

https://claude.ai/code/session_01Met1xZ39ZXGRSN3mLHBprn