### PR TITLE
feat(sessions): per-agent context-window caps for every launch

### DIFF
--- a/app/src/components/SettingsModal.test.tsx
+++ b/app/src/components/SettingsModal.test.tsx
@@ -1334,6 +1334,35 @@ describe('SettingsModal chief settings', () => {
     fireEvent.blur(input);
     expect(onSetSetting).not.toHaveBeenCalledWith('chief_context_window_cap', expect.anything());
   });
+
+  it('shows a per-agent context-window cap that is blank when unset', async () => {
+    renderModal({ default_context_window_cap_claude: '800000' });
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    expect(await screen.findByTestId('settings-default-context-cap-claude')).toHaveValue(800000);
+    // Blank means uncapped (the agent's own behavior), not the built-in default.
+    expect(screen.getByTestId('settings-default-context-cap-codex')).toHaveValue(null);
+  });
+
+  it('commits a changed per-agent context-window cap on blur', async () => {
+    const onSetSetting = renderModal({});
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    const input = await screen.findByTestId('settings-default-context-cap-claude');
+    fireEvent.change(input, { target: { value: '800000' } });
+    fireEvent.blur(input);
+    expect(onSetSetting).toHaveBeenCalledWith('default_context_window_cap_claude', '800000');
+  });
+
+  it('clears a per-agent context-window cap back to uncapped', async () => {
+    const onSetSetting = renderModal({ default_context_window_cap_claude: '800000' });
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    const input = await screen.findByTestId('settings-default-context-cap-claude');
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+    expect(onSetSetting).toHaveBeenCalledWith('default_context_window_cap_claude', '');
+  });
 });
 
 describe('SettingsModal font size', () => {

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -226,6 +226,11 @@ export function SettingsModal({
   const [headlessContextCap, setHeadlessContextCap] = useState(
     settings.headless_context_window_cap || String(DEFAULT_CONTEXT_WINDOW_CAP),
   );
+  // Per-agent context-window cap (default_context_window_cap_<agent>) applied to
+  // EVERY session of that agent; a chief launch still takes the chief cap above.
+  // Blank => uncapped (the agent's own compaction behavior), unlike the chief and
+  // headless caps whose blank means the built-in default.
+  const [defaultContextCaps, setDefaultContextCaps] = useState<Record<SessionAgent, string>>({});
   // Auto-settle windows, in seconds. Edited locally and committed on blur/Enter
   // like the context caps; the daemon rejects out-of-range values.
   const [autoSettleArm, setAutoSettleArm] = useState(
@@ -388,6 +393,13 @@ export function SettingsModal({
     }
     return out;
   }, [settings, defaultOverrideAgentList]);
+  const actualDefaultContextCaps = useMemo(() => {
+    const out = {} as Record<SessionAgent, string>;
+    for (const agent of defaultOverrideAgentList) {
+      out[agent] = settings[`default_context_window_cap_${agent}`] || '';
+    }
+    return out;
+  }, [settings, defaultOverrideAgentList]);
   // Agents eligible to run any keeper duty: installed, headless-task capable, and one
   // of claude/codex. Any agent already configured on a duty is kept in the list even
   // if it has since become unavailable, so its row still shows the saved selection.
@@ -441,6 +453,7 @@ export function SettingsModal({
     setReviewerModel(actualReviewerModel);
     setChiefContextCap(actualChiefContextCap);
     setHeadlessContextCap(actualHeadlessContextCap);
+    setDefaultContextCaps(actualDefaultContextCaps);
     // The modal mounts before the daemon's settings broadcast arrives, so these
     // two start on the built-in defaults. Without this resync a saved 60/20
     // policy would still be displayed as 30/15, and the commit-on-blur would
@@ -462,7 +475,7 @@ export function SettingsModal({
     setPluginSourcePath('');
     setPluginError(null);
     setPluginActionName(null);
-  }, [isOpen, actualProjectsDir, actualNotebookRoot, actualAgentExecutables, actualChiefModels, actualChiefEfforts, actualDefaultModels, actualDefaultEfforts, actualEditorExecutable, resolvedDefaultAgent, actualReviewerModel, actualChiefContextCap, actualHeadlessContextCap, actualAutoSettleArm, actualAutoSettleCountdown, actualKeeperConfigs, keeperAgents]);
+  }, [isOpen, actualProjectsDir, actualNotebookRoot, actualAgentExecutables, actualChiefModels, actualChiefEfforts, actualDefaultModels, actualDefaultEfforts, actualDefaultContextCaps, actualEditorExecutable, resolvedDefaultAgent, actualReviewerModel, actualChiefContextCap, actualHeadlessContextCap, actualAutoSettleArm, actualAutoSettleCountdown, actualKeeperConfigs, keeperAgents]);
 
   useEscapeStack(onClose, isOpen);
 
@@ -743,6 +756,18 @@ export function SettingsModal({
       onSetSetting('headless_context_window_cap', next);
     }
   }, [headlessContextCap, actualHeadlessContextCap, onSetSetting]);
+
+  const handleDefaultContextCapChange = useCallback((agent: SessionAgent, value: string) => {
+    setDefaultContextCaps((prev) => ({ ...prev, [agent]: value }));
+  }, []);
+
+  const commitDefaultContextCap = useCallback((agent: SessionAgent) => {
+    const nextValue = (defaultContextCaps[agent] || '').trim();
+    const currentValue = (actualDefaultContextCaps[agent] || '').trim();
+    if (nextValue !== currentValue) {
+      onSetSetting(`default_context_window_cap_${agent}`, nextValue);
+    }
+  }, [actualDefaultContextCaps, defaultContextCaps, onSetSetting]);
 
   const handleAddEndpoint = useCallback(async () => {
     const name = newEndpointName.trim();
@@ -2379,10 +2404,11 @@ export function SettingsModal({
           <p className="settings-description">
             Token thresholds at which auto-compaction fires instead of waiting for the
             model's full window. Lower caps keep the chief cheaper on each cache-cold
-            wake and keep one-shot headless runs from ballooning. Leave at {DEFAULT_CONTEXT_WINDOW_CAP.toLocaleString()} to
-            use the default. Only the chief session and headless runs (keeper narration,
-            reconciliation, workflow subagents) are affected — regular delegated sessions
-            are never capped.
+            wake and keep one-shot headless runs (keeper narration, reconciliation,
+            workflow subagents) from ballooning; leave those at {DEFAULT_CONTEXT_WINDOW_CAP.toLocaleString()} for
+            the default. The per-agent caps apply to every session of that agent —
+            raise one to make long-lived sessions compact later. Blank means the
+            agent's own compaction behavior; a chief launch still takes the chief cap.
           </p>
         </div>
         <div className="settings-block-body">
@@ -2427,6 +2453,32 @@ export function SettingsModal({
                 className="settings-input"
               />
             </div>
+            {defaultOverrideAgentList.map((agent) => {
+              const inputId = `settings-default-context-cap-${agent}`;
+              return (
+                <div className="settings-field" key={agent}>
+                  <label className="settings-label" htmlFor={inputId}>{agentLabel(agent)} sessions</label>
+                  <input
+                    id={inputId}
+                    data-testid={inputId}
+                    type="number"
+                    min={10000}
+                    max={2000000}
+                    step={1000}
+                    value={defaultContextCaps[agent] || ''}
+                    onChange={(e) => handleDefaultContextCapChange(agent, e.target.value)}
+                    onBlur={() => commitDefaultContextCap(agent)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        commitDefaultContextCap(agent);
+                      }
+                    }}
+                    placeholder="blank — agent default"
+                    className="settings-input"
+                  />
+                </div>
+              );
+            })}
           </div>
         </div>
       </section>

--- a/changelog.d/fluffy-otter-per-agent-context-window-cap.yaml
+++ b/changelog.d/fluffy-otter-per-agent-context-window-cap.yaml
@@ -1,0 +1,10 @@
+kind: added
+area: sessions
+change: >
+  Settings gains per-agent context-window caps
+  (default_context_window_cap_<agent>): every session of that agent
+  auto-compacts at the configured token threshold (Claude:
+  CLAUDE_CODE_AUTO_COMPACT_WINDOW; Codex: model_auto_compact_token_limit)
+  instead of the agent's own default — raise it to make long-lived
+  sessions compact later. Blank means uncapped; chief launches still take
+  the chief cap.

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -3058,9 +3058,17 @@ func runAgentDirectly(requestedAgent string) {
 	// reasoning effort (delegate --effort).
 	opts.Model = consumeOneShotEnv("ATTN_MODEL")
 	opts.Effort = consumeOneShotEnv("ATTN_EFFORT")
-	// ATTN_CHIEF_AUTO_COMPACT_WINDOW caps the chief's context window. The worker
-	// exports it only for chief launches, so a delegated agent never sees it.
-	if window := consumeOneShotEnv("ATTN_CHIEF_AUTO_COMPACT_WINDOW"); window != "" {
+	// ATTN_AUTO_COMPACT_WINDOW caps this launch's context window. The daemon
+	// owns the policy: chief_context_window_cap for chief launches,
+	// default_context_window_cap_<agent> for everything else; the worker exports
+	// the resolved value only when a cap applies. The old name is read as a
+	// fallback so a not-yet-restarted daemon still caps its chief through this
+	// newer wrapper binary.
+	window := consumeOneShotEnv("ATTN_AUTO_COMPACT_WINDOW")
+	if window == "" {
+		window = consumeOneShotEnv("ATTN_CHIEF_AUTO_COMPACT_WINDOW")
+	}
+	if window != "" {
 		if n, err := strconv.Atoi(window); err == nil && n > 0 {
 			opts.AutoCompactWindow = n
 		}

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -134,14 +134,14 @@ func (c *Claude) BuildEnv(opts SpawnOpts) []string {
 		// A chief launch injected chief guidance at launch; mark it so the
 		// SessionStart hook does not also emit workspace-context guidance.
 		env = append(env, "ATTN_CHIEF_GUIDANCE=append_system_prompt")
-		// Cap the chief's effective context window so auto-compaction fires at the
-		// configured threshold. Gated on this chief branch so delegated interactive
-		// agents (WorkspaceContextPath, not NotebookRoot) are never capped.
-		if opts.AutoCompactWindow > 0 {
-			env = append(env, "CLAUDE_CODE_AUTO_COMPACT_WINDOW="+strconv.Itoa(opts.AutoCompactWindow))
-		}
 	} else if strings.TrimSpace(opts.WorkspaceContextPath) != "" {
 		env = append(env, "ATTN_WORKSPACE_CONTEXT_GUIDANCE=append_system_prompt")
+	}
+	// Cap the effective context window so auto-compaction fires at the configured
+	// threshold. The daemon owns the policy of who gets a cap (chief setting vs
+	// default_context_window_cap_<agent>); this only applies what it resolved.
+	if opts.AutoCompactWindow > 0 {
+		env = append(env, "CLAUDE_CODE_AUTO_COMPACT_WINDOW="+strconv.Itoa(opts.AutoCompactWindow))
 	}
 	if opts.Executable != "" && opts.Executable != c.DefaultExecutable() {
 		env = append(env, c.ExecutableEnvVar()+"="+opts.Executable)

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -84,13 +84,12 @@ func (c *Codex) BuildCommand(opts SpawnOpts) *exec.Cmd {
 	if model := strings.TrimSpace(opts.Model); model != "" {
 		args = append(args, "--model", model)
 	}
-	if strings.TrimSpace(opts.NotebookRoot) != "" {
-		// Cap the chief's effective context window (model_auto_compact_token_limit
-		// is codex's compaction-trigger knob, the analogue of Claude's
-		// CLAUDE_CODE_AUTO_COMPACT_WINDOW). Gated on the chief branch so delegated
-		// interactive agents are never capped.
-		args = append(args, codexContextWindowCapArgs(opts.AutoCompactWindow)...)
-	}
+	// Cap the effective context window (model_auto_compact_token_limit is
+	// codex's compaction-trigger knob, the analogue of Claude's
+	// CLAUDE_CODE_AUTO_COMPACT_WINDOW). The daemon owns the policy of who gets
+	// a cap (chief setting vs default_context_window_cap_<agent>); this only
+	// applies what it resolved.
+	args = append(args, codexContextWindowCapArgs(opts.AutoCompactWindow)...)
 	if effort := strings.TrimSpace(opts.Effort); effort != "" {
 		// Codex has no dedicated effort flag; model_reasoning_effort is its
 		// native config knob (the -c value is parsed as TOML, hence the quotes).

--- a/internal/agent/context_window_cap_test.go
+++ b/internal/agent/context_window_cap_test.go
@@ -16,13 +16,16 @@ func envHasCap(env []string) bool {
 	return false
 }
 
-// --- Chief (interactive) cap: BuildEnv / BuildCommand emission ---
+// --- Interactive cap: BuildEnv / BuildCommand emission ---
 
-// The chief cap rides SpawnOpts.AutoCompactWindow into the launch. Claude emits
-// the CLAUDE_CODE_AUTO_COMPACT_WINDOW env var; codex emits the
-// model_auto_compact_token_limit config override. Both gate on the chief branch
-// (NotebookRoot set) so delegated interactive agents are never capped.
-func TestClaudeBuildEnv_ChiefContextWindowCap(t *testing.T) {
+// The cap rides SpawnOpts.AutoCompactWindow into the launch. Claude emits the
+// CLAUDE_CODE_AUTO_COMPACT_WINDOW env var; codex emits the
+// model_auto_compact_token_limit config override. The daemon owns the policy
+// of who gets a cap (chief_context_window_cap on chief launches,
+// default_context_window_cap_<agent> on every other launch — see
+// launchContextWindowCap), so the drivers apply whatever it resolved on every
+// launch shape rather than re-gating on the chief branch.
+func TestClaudeBuildEnv_ContextWindowCap(t *testing.T) {
 	t.Run("chief launch emits the cap", func(t *testing.T) {
 		env := (&Claude{}).BuildEnv(SpawnOpts{NotebookRoot: "/nb", AutoCompactWindow: 200000})
 		if !slices.Contains(env, "CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000") {
@@ -30,24 +33,28 @@ func TestClaudeBuildEnv_ChiefContextWindowCap(t *testing.T) {
 		}
 	})
 
-	t.Run("delegated launch is never capped", func(t *testing.T) {
+	t.Run("delegated launch emits the cap too", func(t *testing.T) {
 		// A delegated interactive agent carries WorkspaceContextPath, not
-		// NotebookRoot. Even if AutoCompactWindow is somehow set, it must not leak.
-		env := (&Claude{}).BuildEnv(SpawnOpts{WorkspaceContextPath: "/ws", AutoCompactWindow: 200000})
-		if envHasCap(env) {
-			t.Fatalf("delegated env unexpectedly carried the cap: %#v", env)
+		// NotebookRoot; a resolved cap applies to it all the same.
+		env := (&Claude{}).BuildEnv(SpawnOpts{WorkspaceContextPath: "/ws", AutoCompactWindow: 800000})
+		if !slices.Contains(env, "CLAUDE_CODE_AUTO_COMPACT_WINDOW=800000") {
+			t.Fatalf("delegated env missing the cap: %#v", env)
 		}
 	})
 
-	t.Run("chief launch with no cap emits nothing", func(t *testing.T) {
-		env := (&Claude{}).BuildEnv(SpawnOpts{NotebookRoot: "/nb", AutoCompactWindow: 0})
-		if envHasCap(env) {
-			t.Fatalf("uncapped chief env unexpectedly carried the cap: %#v", env)
+	t.Run("no cap emits nothing", func(t *testing.T) {
+		for _, opts := range []SpawnOpts{
+			{NotebookRoot: "/nb", AutoCompactWindow: 0},
+			{WorkspaceContextPath: "/ws", AutoCompactWindow: 0},
+		} {
+			if env := (&Claude{}).BuildEnv(opts); envHasCap(env) {
+				t.Fatalf("uncapped env unexpectedly carried the cap: %#v", env)
+			}
 		}
 	})
 }
 
-func TestCodexBuildCommand_ChiefContextWindowCap(t *testing.T) {
+func TestCodexBuildCommand_ContextWindowCap(t *testing.T) {
 	t.Run("chief launch emits the cap override", func(t *testing.T) {
 		cmd := (&Codex{}).BuildCommand(SpawnOpts{
 			SessionID:         "sess-1",
@@ -61,17 +68,28 @@ func TestCodexBuildCommand_ChiefContextWindowCap(t *testing.T) {
 		}
 	})
 
-	t.Run("delegated launch is never capped", func(t *testing.T) {
+	t.Run("delegated launch emits the cap override too", func(t *testing.T) {
 		cmd := (&Codex{}).BuildCommand(SpawnOpts{
 			SessionID:            "sess-1",
 			CWD:                  "/tmp/project",
 			Executable:           "codex",
 			WorkspaceContextPath: "/ws",
-			AutoCompactWindow:    200000,
+			AutoCompactWindow:    800000,
+		})
+		if !argvHasPair(cmd.Args, "-c", "model_auto_compact_token_limit=800000") {
+			t.Fatalf("delegated codex args missing the cap override: %#v", cmd.Args)
+		}
+	})
+
+	t.Run("no cap emits nothing", func(t *testing.T) {
+		cmd := (&Codex{}).BuildCommand(SpawnOpts{
+			SessionID:  "sess-1",
+			CWD:        "/tmp/project",
+			Executable: "codex",
 		})
 		for _, arg := range cmd.Args {
-			if arg == "model_auto_compact_token_limit=200000" {
-				t.Fatalf("delegated codex args unexpectedly carried the cap: %#v", cmd.Args)
+			if strings.HasPrefix(arg, "model_auto_compact_token_limit=") {
+				t.Fatalf("uncapped codex args unexpectedly carried a cap override: %#v", cmd.Args)
 			}
 		}
 	})

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -286,10 +286,11 @@ type SpawnOpts struct {
 	// AutoCompactWindow, when > 0, caps this launch's effective context window so
 	// auto-compaction triggers at that token threshold instead of the model's full
 	// window (Claude: CLAUDE_CODE_AUTO_COMPACT_WINDOW env var; Codex:
-	// model_auto_compact_token_limit config override). Sourced from the
-	// chief_context_window_cap setting for chief launches and relayed into the
-	// worker via ATTN_CHIEF_AUTO_COMPACT_WINDOW; 0 means no cap. Only applied on a
-	// chief launch, so delegated interactive agents are never capped.
+	// model_auto_compact_token_limit config override). The daemon resolves the
+	// policy (chief_context_window_cap on chief launches,
+	// default_context_window_cap_<agent> on every other launch — see
+	// launchContextWindowCap) and it rides ATTN_AUTO_COMPACT_WINDOW into the
+	// worker; 0 means no cap, and the drivers apply it on every launch shape.
 	AutoCompactWindow int
 
 	// Executable is the resolved executable path (from ResolveExecutable).

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3720,6 +3720,10 @@ func TestDaemon_SettingsValidation(t *testing.T) {
 		{"chief context cap below min", "chief_context_window_cap", "5000", true},
 		{"chief context cap above max", "chief_context_window_cap", "9000000", true},
 		{"non-numeric chief context cap", "chief_context_window_cap", "lots", true},
+		{"empty per-agent context cap means uncapped", "default_context_window_cap_claude", "", false},
+		{"valid per-agent context cap", "default_context_window_cap_claude", "800000", false},
+		{"per-agent context cap below min", "default_context_window_cap_codex", "5000", true},
+		{"non-numeric per-agent context cap", "default_context_window_cap_claude", "lots", true},
 		{"empty headless context cap uses default", "headless_context_window_cap", "", false},
 		{"valid headless context cap", "headless_context_window_cap", "200000", false},
 		{"headless context cap below min", "headless_context_window_cap", "1", true},
@@ -3758,17 +3762,33 @@ func TestDaemon_ContextWindowCapResolutionAndGating(t *testing.T) {
 		t.Fatalf("resolveContextWindowCap(200000) = %d, want 200000", got)
 	}
 
-	// chiefContextWindowCap: 0 for non-chief; default for a chief with no setting;
-	// the configured value for a chief that set one.
-	if got := d.chiefContextWindowCap(false); got != 0 {
-		t.Fatalf("non-chief cap = %d, want 0 (uncapped)", got)
+	// launchContextWindowCap: 0 for a non-chief launch with no per-agent
+	// setting; default for a chief with no setting; the configured values
+	// otherwise, with the chief setting winning on chief launches.
+	if got := d.launchContextWindowCap("claude", false); got != 0 {
+		t.Fatalf("non-chief cap with no setting = %d, want 0 (uncapped)", got)
 	}
-	if got := d.chiefContextWindowCap(true); got != agentdriver.DefaultContextWindowCap {
+	if got := d.launchContextWindowCap("claude", true); got != agentdriver.DefaultContextWindowCap {
 		t.Fatalf("chief cap with no setting = %d, want default %d", got, agentdriver.DefaultContextWindowCap)
 	}
 	d.store.SetSetting(SettingChiefContextWindowCap, "160000")
-	if got := d.chiefContextWindowCap(true); got != 160000 {
+	if got := d.launchContextWindowCap("claude", true); got != 160000 {
 		t.Fatalf("chief cap = %d, want 160000", got)
+	}
+	d.store.SetSetting(SettingDefaultContextWindowCapPrefix+"claude", "800000")
+	if got := d.launchContextWindowCap("claude", false); got != 800000 {
+		t.Fatalf("per-agent default cap = %d, want 800000", got)
+	}
+	if got := d.launchContextWindowCap("Claude", false); got != 800000 {
+		t.Fatalf("per-agent default cap (case-insensitive) = %d, want 800000", got)
+	}
+	if got := d.launchContextWindowCap("codex", false); got != 0 {
+		t.Fatalf("other agent's cap = %d, want 0 (uncapped)", got)
+	}
+	// The chief setting still wins on chief launches even with a per-agent
+	// default configured.
+	if got := d.launchContextWindowCap("claude", true); got != 160000 {
+		t.Fatalf("chief cap with per-agent default also set = %d, want 160000", got)
 	}
 }
 

--- a/internal/daemon/reload.go
+++ b/internal/daemon/reload.go
@@ -375,13 +375,12 @@ func (d *Daemon) buildReloadSpawnOptionsFromLaunchParams(session *protocol.Sessi
 		LoginShellEnv:           d.cachedLoginShellEnv(),
 		WorkflowGuidanceEnabled: parseBooleanSetting(d.store.GetSetting(SettingWorkflowsEnabled)),
 		AutoApprove:             false,
-		// Carry the chief context-window cap across an in-place reload so a
-		// reloaded chief comes back capped, not just a fresh launch. The wrapper
-		// re-derives the chief's NotebookRoot (and thus emits the cap) via the
-		// NotebookGuide RPC keyed on sessionID, so gate on the persisted chief
-		// role here to stay consistent with that RPC; non-chief sessions resolve
-		// to 0 (uncapped), matching delegated/ordinary reloads.
-		ChiefContextWindowCap: d.chiefContextWindowCap(d.isChiefOfStaffSession(sessionID)),
+		// Carry the context-window cap across an in-place reload so a reloaded
+		// session comes back capped the same way a fresh launch would: the chief
+		// from chief_context_window_cap (gate on the persisted chief role, staying
+		// consistent with the NotebookGuide RPC keyed on sessionID), every other
+		// session from default_context_window_cap_<agent>.
+		ContextWindowCap: d.launchContextWindowCap(session.Agent, d.isChiefOfStaffSession(sessionID)),
 	}
 	if !params.UnattendedLaunch.IsZero() {
 		if err := params.UnattendedLaunch.Validate(); err != nil {
@@ -566,7 +565,7 @@ func (d *Daemon) preparePluginRoleReload(sessionID string, desiredChief bool) (*
 		lock.Unlock()
 		return nil, true, err
 	}
-	opts.ChiefContextWindowCap = d.chiefContextWindowCap(desiredChief)
+	opts.ContextWindowCap = d.launchContextWindowCap(session.Agent, desiredChief)
 	pluginReload, err := d.preparePluginReload(session, &opts, desiredChief)
 	if err != nil {
 		lock.Unlock()

--- a/internal/daemon/reload_test.go
+++ b/internal/daemon/reload_test.go
@@ -339,7 +339,7 @@ func TestReloadSessionAgentAbortsWhenLaunchParamsNotRecorded(t *testing.T) {
 // the wrapper's NotebookGuide RPC uses to decide chief-ness — so the reloaded cap
 // and the reloaded guidance stay consistent. Ordinary/delegated sessions stay
 // uncapped through reload even when a cap is configured.
-func TestBuildReloadSpawnOptionsCarriesChiefContextWindowCap(t *testing.T) {
+func TestBuildReloadSpawnOptionsCarriesContextWindowCap(t *testing.T) {
 	// No transcript on disk → deterministic resume resolution (fresh-spawn), which
 	// keeps buildReloadSpawnOptions from depending on a resumable transcript.
 	t.Setenv(toolhome.EnvVar, t.TempDir())
@@ -363,8 +363,8 @@ func TestBuildReloadSpawnOptionsCarriesChiefContextWindowCap(t *testing.T) {
 		if err != nil {
 			t.Fatalf("buildReloadSpawnOptions: %v", err)
 		}
-		if opts.ChiefContextWindowCap != 160000 {
-			t.Fatalf("ChiefContextWindowCap = %d, want 160000 (reloaded chief must stay capped)", opts.ChiefContextWindowCap)
+		if opts.ContextWindowCap != 160000 {
+			t.Fatalf("ContextWindowCap = %d, want 160000 (reloaded chief must stay capped)", opts.ContextWindowCap)
 		}
 	})
 
@@ -378,12 +378,12 @@ func TestBuildReloadSpawnOptionsCarriesChiefContextWindowCap(t *testing.T) {
 		if err != nil {
 			t.Fatalf("buildReloadSpawnOptions: %v", err)
 		}
-		if opts.ChiefContextWindowCap != agentdriver.DefaultContextWindowCap {
-			t.Fatalf("ChiefContextWindowCap = %d, want default %d", opts.ChiefContextWindowCap, agentdriver.DefaultContextWindowCap)
+		if opts.ContextWindowCap != agentdriver.DefaultContextWindowCap {
+			t.Fatalf("ContextWindowCap = %d, want default %d", opts.ContextWindowCap, agentdriver.DefaultContextWindowCap)
 		}
 	})
 
-	t.Run("reloaded non-chief session stays uncapped even with a cap configured", func(t *testing.T) {
+	t.Run("reloaded non-chief session stays uncapped even with a chief cap configured", func(t *testing.T) {
 		d := newDaemonWithSession(t, "worker")
 		// A configured chief cap must not leak onto a delegated/ordinary reload.
 		d.store.SetSetting(SettingChiefContextWindowCap, "160000")
@@ -392,8 +392,21 @@ func TestBuildReloadSpawnOptionsCarriesChiefContextWindowCap(t *testing.T) {
 		if err != nil {
 			t.Fatalf("buildReloadSpawnOptions: %v", err)
 		}
-		if opts.ChiefContextWindowCap != 0 {
-			t.Fatalf("ChiefContextWindowCap = %d, want 0 (non-chief reload must stay uncapped)", opts.ChiefContextWindowCap)
+		if opts.ContextWindowCap != 0 {
+			t.Fatalf("ContextWindowCap = %d, want 0 (non-chief reload must stay uncapped)", opts.ContextWindowCap)
+		}
+	})
+
+	t.Run("reloaded non-chief session keeps its agent's default cap", func(t *testing.T) {
+		d := newDaemonWithSession(t, "worker")
+		d.store.SetSetting(SettingDefaultContextWindowCapPrefix+"claude", "800000")
+
+		opts, err := d.buildReloadSpawnOptions(d.store.Get("worker"))
+		if err != nil {
+			t.Fatalf("buildReloadSpawnOptions: %v", err)
+		}
+		if opts.ContextWindowCap != 800000 {
+			t.Fatalf("ContextWindowCap = %d, want 800000 (reloaded session must stay capped)", opts.ContextWindowCap)
 		}
 	})
 }

--- a/internal/daemon/spawn_pipeline.go
+++ b/internal/daemon/spawn_pipeline.go
@@ -267,9 +267,10 @@ func (d *Daemon) resolveSpawnIntent(req *spawnRequest) (*spawnPlan, *spawnReject
 	} else {
 		plan.spawnOpts.ApprovalRoute = launchcontract.ResolveApprovalRoute(plan.spawnOpts.YoloMode, plan.spawnOpts.AutoApprove, plan.spawnOpts.UnattendedLaunch)
 	}
-	// A chief launch caps its context window (chief_context_window_cap); non-chief
-	// launches stay uncapped so delegated interactive agents are never affected.
-	plan.spawnOpts.ChiefContextWindowCap = d.chiefContextWindowCap(plan.isChief)
+	// A chief launch caps its context window (chief_context_window_cap); every
+	// other launch takes default_context_window_cap_<agent>, unset meaning
+	// uncapped.
+	plan.spawnOpts.ContextWindowCap = d.launchContextWindowCap(req.agent, plan.isChief)
 
 	return plan, nil
 }

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -153,6 +153,16 @@ const (
 	// one-shot and cache-cold by construction; one that grows past this is treated
 	// as a bug, not accommodated. Empty/unset => DefaultContextWindowCap.
 	SettingHeadlessContextWindowCap = "headless_context_window_cap"
+	// SettingDefaultContextWindowCapPrefix + agent (e.g.
+	// "default_context_window_cap_claude") caps the effective context window of
+	// EVERY interactive launch of that agent (Claude:
+	// CLAUDE_CODE_AUTO_COMPACT_WINDOW; Codex: model_auto_compact_token_limit),
+	// so long-lived sessions compact at a chosen threshold instead of the
+	// agent's own default. Unlike the chief cap there is no built-in fallback:
+	// empty/unset => uncapped, preserving the agent's native behavior. A chief
+	// launch still takes chief_context_window_cap over this; see
+	// launchContextWindowCap.
+	SettingDefaultContextWindowCapPrefix = "default_context_window_cap_"
 	// SettingNotebookTasksEnabled is the master switch for ALL keeper async
 	// background duties (per-session summarize, workspace narrate, context
 	// compaction). Default ON: a blank/unset value means enabled, so existing
@@ -478,15 +488,24 @@ func (d *Daemon) resolveLaunchEffort(agent string, chief bool, requested string)
 	return d.defaultLaunchEffort(agent)
 }
 
-// chiefContextWindowCap returns the effective context-window token cap for a
-// chief-of-staff launch, or 0 (no cap) when this is not a chief launch. Mirrors
-// chiefLaunchModel: the policy (what the cap is, and that only the chief gets
-// one) lives here; the driver decides how to apply it.
-func (d *Daemon) chiefContextWindowCap(chief bool) int {
-	if !chief {
-		return 0
+// launchContextWindowCap returns the effective context-window token cap for an
+// interactive launch of the given agent, or 0 (no cap). Mirrors
+// resolveLaunchModel: the policy lives here, the driver only applies it. A
+// chief launch takes chief_context_window_cap (which defaults to
+// DefaultContextWindowCap, so the chief is always capped); every other launch
+// takes default_context_window_cap_<agent>, whose unset state means uncapped —
+// the agent's own compaction behavior.
+func (d *Daemon) launchContextWindowCap(agent string, chief bool) int {
+	if chief {
+		return resolveContextWindowCap(d.store.GetSetting(SettingChiefContextWindowCap))
 	}
-	return resolveContextWindowCap(d.store.GetSetting(SettingChiefContextWindowCap))
+	key := SettingDefaultContextWindowCapPrefix + strings.ToLower(strings.TrimSpace(agent))
+	if v := strings.TrimSpace(d.store.GetSetting(key)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 0
 }
 
 // applyHeadlessContextWindowCap pushes the headless_context_window_cap setting
@@ -571,6 +590,11 @@ func (d *Daemon) validateSetting(key, value string) error {
 		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(key)), SettingDefaultEffortPrefix) {
 			// Effort levels are agent-native, same as chief_effort_<agent>.
 			return nil
+		}
+		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(key)), SettingDefaultContextWindowCapPrefix) {
+			// Same bounds as the chief/headless caps; blank here means uncapped
+			// rather than DefaultContextWindowCap (see launchContextWindowCap).
+			return validateContextWindowCap(value)
 		}
 		if _, ok := isAgentExecutableSettingKey(key); ok {
 			return validateExecutableSetting(value)

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -69,7 +69,7 @@ type SpawnOptions struct {
 	TrustWorkingDirectory   bool
 	Model                   string
 	Effort                  string
-	ChiefContextWindowCap   int
+	ContextWindowCap        int
 	UnattendedLaunch        launchcontract.UnattendedLaunchSpec
 
 	// Theme seeds the colors the session answers OSC 10/11/12 queries with,
@@ -671,12 +671,12 @@ func buildSpawnEnv(loginShell string, opts SpawnOptions, agent, wrapperPath stri
 		"ATTN_TRUST_WORKING_DIRECTORY",
 		"ATTN_MODEL",
 		"ATTN_EFFORT",
-		"ATTN_CHIEF_AUTO_COMPACT_WINDOW",
+		"ATTN_AUTO_COMPACT_WINDOW",
 	}
 	if os.Getenv("ATTN_PTY_WORKER") == "1" {
 		inheritedKeys := launchKeys
 		if !opts.UnattendedLaunch.IsZero() {
-			inheritedKeys = []string{"ATTN_WORKFLOW_GUIDANCE_ENABLED", "ATTN_CHIEF_AUTO_COMPACT_WINDOW"}
+			inheritedKeys = []string{"ATTN_WORKFLOW_GUIDANCE_ENABLED", "ATTN_AUTO_COMPACT_WINDOW"}
 		}
 		for _, key := range inheritedKeys {
 			if value, ok := os.LookupEnv(key); ok {
@@ -699,8 +699,8 @@ func buildSpawnEnv(loginShell string, opts SpawnOptions, agent, wrapperPath stri
 	if effort := strings.TrimSpace(opts.Effort); effort != "" {
 		launchEnv = append(launchEnv, "ATTN_EFFORT="+effort)
 	}
-	if opts.ChiefContextWindowCap > 0 {
-		launchEnv = append(launchEnv, "ATTN_CHIEF_AUTO_COMPACT_WINDOW="+strconv.Itoa(opts.ChiefContextWindowCap))
+	if opts.ContextWindowCap > 0 {
+		launchEnv = append(launchEnv, "ATTN_AUTO_COMPACT_WINDOW="+strconv.Itoa(opts.ContextWindowCap))
 	}
 	if launch := opts.UnattendedLaunch; !launch.IsZero() {
 		launchEnv = append(launchEnv,

--- a/internal/pty/manager_test.go
+++ b/internal/pty/manager_test.go
@@ -157,7 +157,7 @@ func TestBuildSpawnEnv_UnattendedContractOverridesInheritedWorkerAndLoginValues(
 	for key, value := range map[string]string{
 		"ATTN_AUTO_APPROVE": "parent", "ATTN_TRUST_WORKING_DIRECTORY": "parent",
 		"ATTN_MODEL": "parent-model", "ATTN_EFFORT": "medium",
-		"ATTN_WORKFLOW_GUIDANCE_ENABLED": "1", "ATTN_CHIEF_AUTO_COMPACT_WINDOW": "12345",
+		"ATTN_WORKFLOW_GUIDANCE_ENABLED": "1", "ATTN_AUTO_COMPACT_WINDOW": "12345",
 	} {
 		t.Setenv(key, value)
 	}
@@ -173,7 +173,7 @@ func TestBuildSpawnEnv_UnattendedContractOverridesInheritedWorkerAndLoginValues(
 	for key, want := range map[string]string{
 		"ATTN_AUTO_APPROVE": "1", "ATTN_TRUST_WORKING_DIRECTORY": "1",
 		"ATTN_MODEL": "exact-model", "ATTN_EFFORT": "high",
-		"ATTN_WORKFLOW_GUIDANCE_ENABLED": "1", "ATTN_CHIEF_AUTO_COMPACT_WINDOW": "12345",
+		"ATTN_WORKFLOW_GUIDANCE_ENABLED": "1", "ATTN_AUTO_COMPACT_WINDOW": "12345",
 	} {
 		if got, _ := lookupEnv(env, key); got != want {
 			t.Fatalf("%s = %q, want %q", key, got, want)

--- a/internal/ptybackend/backend.go
+++ b/internal/ptybackend/backend.go
@@ -84,13 +84,13 @@ type SpawnOptions struct {
 	// Empty means the agent's own default.
 	Effort string
 
-	// ChiefContextWindowCap, when > 0, is the token threshold the chief-of-staff
-	// launch caps its context window at; the worker exports it as
-	// ATTN_CHIEF_AUTO_COMPACT_WINDOW and the launched agent applies it (Claude:
+	// ContextWindowCap, when > 0, is the token threshold the launched agent's
+	// context window is capped at; the worker exports it as
+	// ATTN_AUTO_COMPACT_WINDOW and the launched agent applies it (Claude:
 	// CLAUDE_CODE_AUTO_COMPACT_WINDOW; Codex: model_auto_compact_token_limit).
-	// Sourced from the chief_context_window_cap setting and set only for chief
-	// launches, so non-chief sessions stay uncapped.
-	ChiefContextWindowCap int
+	// The daemon owns the policy (chief_context_window_cap for chief launches,
+	// default_context_window_cap_<agent> for everything else); 0 means uncapped.
+	ContextWindowCap int
 
 	// UnattendedLaunch is the daemon-owned launch contract. When set, it is the
 	// sole source for agent, executable, approval, trust, model, effort, and

--- a/internal/ptybackend/embedded.go
+++ b/internal/ptybackend/embedded.go
@@ -68,7 +68,7 @@ func embeddedSpawnOptions(opts SpawnOptions) pty.SpawnOptions {
 		TrustWorkingDirectory:   opts.TrustWorkingDirectory,
 		Model:                   opts.Model,
 		Effort:                  opts.Effort,
-		ChiefContextWindowCap:   opts.ChiefContextWindowCap,
+		ContextWindowCap:        opts.ContextWindowCap,
 		UnattendedLaunch:        opts.UnattendedLaunch,
 	}
 }

--- a/internal/ptybackend/worker.go
+++ b/internal/ptybackend/worker.go
@@ -523,7 +523,7 @@ func (b *WorkerBackend) Spawn(ctx context.Context, opts SpawnOptions) error {
 		"ATTN_TRUST_WORKING_DIRECTORY",
 		"ATTN_MODEL",
 		"ATTN_EFFORT",
-		"ATTN_CHIEF_AUTO_COMPACT_WINDOW",
+		"ATTN_AUTO_COMPACT_WINDOW",
 		"ATTN_CACHED_SHELL_ENV",
 		"ATTN_PTY_EXTERNAL_ENV",
 	)
@@ -543,8 +543,8 @@ func (b *WorkerBackend) Spawn(ctx context.Context, opts SpawnOptions) error {
 	if effort := strings.TrimSpace(opts.Effort); effort != "" {
 		workerEnv = append(workerEnv, "ATTN_EFFORT="+effort)
 	}
-	if opts.ChiefContextWindowCap > 0 {
-		workerEnv = append(workerEnv, "ATTN_CHIEF_AUTO_COMPACT_WINDOW="+strconv.Itoa(opts.ChiefContextWindowCap))
+	if opts.ContextWindowCap > 0 {
+		workerEnv = append(workerEnv, "ATTN_AUTO_COMPACT_WINDOW="+strconv.Itoa(opts.ContextWindowCap))
 	}
 	if len(opts.LoginShellEnv) > 0 {
 		if envJSON, err := json.Marshal(opts.LoginShellEnv); err == nil {


### PR DESCRIPTION
## What

Adds `default_context_window_cap_<agent>` settings (e.g. `default_context_window_cap_claude`) that cap the effective context window of **every** interactive launch of that agent — Claude via the `CLAUDE_CODE_AUTO_COMPACT_WINDOW` env var, Codex via the `model_auto_compact_token_limit` config override. Until now only chief launches could carry a cap (`chief_context_window_cap`); simulating long-lived crew members on plain sessions meant exporting the env var globally in the shell, which caps everything or nothing.

## How

- The daemon owns the whole policy in `launchContextWindowCap(agent, chief)`: chief launches keep taking `chief_context_window_cap` (blank → 128000 default, unchanged), every other launch takes `default_context_window_cap_<agent>` (blank → uncapped, matching today's behavior). Spawn and both reload call sites go through it.
- The agent drivers (`claude.go`, `codex.go`) now emit whatever cap the daemon resolved on every launch shape instead of re-gating on the chief (NotebookRoot) branch — the double-gate is gone.
- The worker↔wrapper env leg is renamed `ATTN_AUTO_COMPACT_WINDOW` (`SpawnOptions.ContextWindowCap`, formerly `ChiefContextWindowCap`); the wrapper still reads the legacy `ATTN_CHIEF_AUTO_COMPACT_WINDOW` name so a new daemon over an old wrapper (or vice versa) mid-install degrades gracefully.
- Settings modal gains per-agent number inputs beside the existing chief/headless caps (commit-on-blur, blank = agent's own behavior). Validation reuses the existing 10k–2M bounds.
- No protocol change: settings ride the existing generic `set_setting`/`get_settings` surface.

## Verification

- Unit: driver emission tests rewritten (chief, delegated, and uncapped shapes for both agents), `launchContextWindowCap` resolution matrix (chief default/override, per-agent, case-insensitive agent key, chief-wins precedence), validation rows, reload carry tests, pty env-key tests, 3 new SettingsModal tests. Touched Go packages + full frontend suite + tsc + changelog-check green on this base.
- Live (throwaway profile `trellis-cap`, full `make install`): set `default_context_window_cap_claude=800000` over WS, spawned a claude session through the app's spawn flow with a stub executable that dumps its env — the process carried `CLAUDE_CODE_AUTO_COMPACT_WINDOW=800000`. Cleared the setting, spawned again — no cap var present. Profile cleaned.

https://claude.ai/code/session_012Bu5dMFLdBfrEo4WmQkF53