### PR TITLE
feat(app): registry tables and lifecycle CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,12 @@ forgets that position and `--since <RFC3339>` replays from an instant.
   field name — never from caller text
 - `internal/jobs`: durable job queue (retry/backoff, coalescing, commit fence,
   cron entries) — every background duty and every periodic tick runs on it
+- `internal/apps`: an app's identity — the name rule, and the bus consumer
+  (`app:<name>`) and document namespace (`app/<name>`) derived from it. An app's
+  enabled state IS its consumer's enabled bit; there is no registry column for
+  it, and nothing stores the derived names. Registry tables and the lifecycle
+  handlers live in `internal/store/apps.go` and `internal/daemon/apps.go`; see
+  `docs/glossary.md` for app vs plugin
 - `internal/supervise`: process supervision for long-lived daemon children
   (restart backoff, generation fencing, stability window, disconnect grace,
   give-up parking, per-child log capture). Consumers name a child and hand over

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -201,7 +201,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '216';
+export const PROTOCOL_VERSION = '217';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,11 +1,23 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, AgentEventMessage, AgentPromptMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, DocUndefineMessage, DocUndefineResult, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, AddEndpointMessage, AgentEventMessage, AgentPromptMessage, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppRemoveMessage, AppRemoveResult, ApprovePRMessage, AppSetEnabledMessage, AppSetEnabledResult, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, DocUndefineMessage, DocUndefineResult, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const agentEventMessage = Convert.toAgentEventMessage(json);
 //   const agentPromptMessage = Convert.toAgentPromptMessage(json);
+//   const appConsumerInfo = Convert.toAppConsumerInfo(json);
+//   const appInvocationInfo = Convert.toAppInvocationInfo(json);
+//   const appListMessage = Convert.toAppListMessage(json);
+//   const appListResult = Convert.toAppListResult(json);
+//   const appRemoveMessage = Convert.toAppRemoveMessage(json);
+//   const appRemoveResult = Convert.toAppRemoveResult(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
+//   const appSetEnabledMessage = Convert.toAppSetEnabledMessage(json);
+//   const appSetEnabledResult = Convert.toAppSetEnabledResult(json);
+//   const appStatusMessage = Convert.toAppStatusMessage(json);
+//   const appStatusResult = Convert.toAppStatusResult(json);
+//   const appSummary = Convert.toAppSummary(json);
+//   const appVersionInfo = Convert.toAppVersionInfo(json);
 //   const attachBlock = Convert.toAttachBlock(json);
 //   const attachPolicy = Convert.toAttachPolicy(json);
 //   const attachResultMessage = Convert.toAttachResultMessage(json);
@@ -481,6 +493,88 @@ export enum AgentPromptMessageCmd {
     AgentPrompt = "agent_prompt",
 }
 
+export interface AppConsumerInfo {
+    cursor:  number;
+    enabled: boolean;
+    filter:  string;
+    lag:     number;
+    name:    string;
+    [property: string]: any;
+}
+
+export interface AppInvocationInfo {
+    duration_ms:   number;
+    error:         string;
+    event_name:    string;
+    event_seq:     number;
+    event_subject: string;
+    handler:       string;
+    id:            number;
+    started_at:    string;
+    status:        string;
+    version_id:    number;
+    [property: string]: any;
+}
+
+export interface AppListMessage {
+    cmd: AppListMessageCmd;
+    [property: string]: any;
+}
+
+export enum AppListMessageCmd {
+    AppList = "app_list",
+}
+
+export interface AppListResult {
+    apps: App[];
+    [property: string]: any;
+}
+
+export interface App {
+    consumer?:        Consumer;
+    created_at:       string;
+    current_version?: CurrentVersion;
+    name:             string;
+    updated_at:       string;
+    [property: string]: any;
+}
+
+export interface Consumer {
+    cursor:  number;
+    enabled: boolean;
+    filter:  string;
+    lag:     number;
+    name:    string;
+    [property: string]: any;
+}
+
+export interface CurrentVersion {
+    artifact_path: string;
+    content_hash:  string;
+    created_at:    string;
+    id:            number;
+    [property: string]: any;
+}
+
+export interface AppRemoveMessage {
+    cmd:  AppRemoveMessageCmd;
+    name: string;
+    [property: string]: any;
+}
+
+export enum AppRemoveMessageCmd {
+    AppRemove = "app_remove",
+}
+
+export interface AppRemoveResult {
+    consumer_removed: boolean;
+    invocations_kept: number;
+    name:             string;
+    namespace_kept:   string;
+    versions_kept:    number;
+    [property: string]: any;
+}
+
 export interface ApprovePRMessage {
     cmd: ApprovePRMessageCmd;
     id:  string;
@@ -489,6 +583,73 @@ export interface ApprovePRMessage {
 
 export enum ApprovePRMessageCmd {
     ApprovePR = "approve_pr",
+}
+
+export interface AppSetEnabledMessage {
+    cmd:     AppSetEnabledMessageCmd;
+    enabled: boolean;
+    name:    string;
+    [property: string]: any;
+}
+
+export enum AppSetEnabledMessageCmd {
+    AppSetEnabled = "app_set_enabled",
+}
+
+export interface AppSetEnabledResult {
+    consumer: string;
+    enabled:  boolean;
+    name:     string;
+    [property: string]: any;
+}
+
+export interface AppStatusMessage {
+    cmd:  AppStatusMessageCmd;
+    name: string;
+    [property: string]: any;
+}
+
+export enum AppStatusMessageCmd {
+    AppStatus = "app_status",
+}
+
+export interface AppStatusResult {
+    app:         App;
+    invocations: number;
+    recent?:     RecentElement[];
+    versions:    number;
+    [property: string]: any;
+}
+
+export interface RecentElement {
+    duration_ms:   number;
+    error:         string;
+    event_name:    string;
+    event_seq:     number;
+    event_subject: string;
+    handler:       string;
+    id:            number;
+    started_at:    string;
+    status:        string;
+    version_id:    number;
+    [property: string]: any;
+}
+
+export interface AppSummary {
+    consumer?:        Consumer;
+    created_at:       string;
+    current_version?: CurrentVersion;
+    name:             string;
+    updated_at:       string;
+    [property: string]: any;
+}
+
+export interface AppVersionInfo {
+    artifact_path: string;
+    content_hash:  string;
+    created_at:    string;
+    id:            number;
+    [property: string]: any;
 }
 
 export interface AttachBlock {
@@ -4294,6 +4455,10 @@ export enum ReposUpdatedMessageEvent {
 }
 
 export interface Response {
+    app_list_result?:                      AppListResultObject;
+    app_remove_result?:                    AppRemoveResultObject;
+    app_set_enabled_result?:               AppSetEnabledResultObject;
+    app_status_result?:                    AppStatusResultObject;
     authors?:                              AuthorElement[];
     data?:                                 string;
     delegate_result?:                      DelegateResultObject;
@@ -4338,6 +4503,35 @@ export interface Response {
     workspace_context_result?:             WorkspaceContextResultObject;
     workspace_contexts?:                   WorkspaceContextElement[];
     workspaces?:                           WorkspaceElement[];
+    [property: string]: any;
+}
+
+export interface AppListResultObject {
+    apps: App[];
+    [property: string]: any;
+}
+
+export interface AppRemoveResultObject {
+    consumer_removed: boolean;
+    invocations_kept: number;
+    name:             string;
+    namespace_kept:   string;
+    versions_kept:    number;
+    [property: string]: any;
+}
+
+export interface AppSetEnabledResultObject {
+    consumer: string;
+    enabled:  boolean;
+    name:     string;
+    [property: string]: any;
+}
+
+export interface AppStatusResultObject {
+    app:         App;
+    invocations: number;
+    recent?:     RecentElement[];
+    versions:    number;
     [property: string]: any;
 }
 
@@ -6531,12 +6725,108 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AgentPromptMessage")), null, 2);
     }
 
+    public static toAppConsumerInfo(json: string): AppConsumerInfo {
+        return cast(JSON.parse(json), r("AppConsumerInfo"));
+    }
+
+    public static appConsumerInfoToJson(value: AppConsumerInfo): string {
+        return JSON.stringify(uncast(value, r("AppConsumerInfo")), null, 2);
+    }
+
+    public static toAppInvocationInfo(json: string): AppInvocationInfo {
+        return cast(JSON.parse(json), r("AppInvocationInfo"));
+    }
+
+    public static appInvocationInfoToJson(value: AppInvocationInfo): string {
+        return JSON.stringify(uncast(value, r("AppInvocationInfo")), null, 2);
+    }
+
+    public static toAppListMessage(json: string): AppListMessage {
+        return cast(JSON.parse(json), r("AppListMessage"));
+    }
+
+    public static appListMessageToJson(value: AppListMessage): string {
+        return JSON.stringify(uncast(value, r("AppListMessage")), null, 2);
+    }
+
+    public static toAppListResult(json: string): AppListResult {
+        return cast(JSON.parse(json), r("AppListResult"));
+    }
+
+    public static appListResultToJson(value: AppListResult): string {
+        return JSON.stringify(uncast(value, r("AppListResult")), null, 2);
+    }
+
+    public static toAppRemoveMessage(json: string): AppRemoveMessage {
+        return cast(JSON.parse(json), r("AppRemoveMessage"));
+    }
+
+    public static appRemoveMessageToJson(value: AppRemoveMessage): string {
+        return JSON.stringify(uncast(value, r("AppRemoveMessage")), null, 2);
+    }
+
+    public static toAppRemoveResult(json: string): AppRemoveResult {
+        return cast(JSON.parse(json), r("AppRemoveResult"));
+    }
+
+    public static appRemoveResultToJson(value: AppRemoveResult): string {
+        return JSON.stringify(uncast(value, r("AppRemoveResult")), null, 2);
+    }
+
     public static toApprovePRMessage(json: string): ApprovePRMessage {
         return cast(JSON.parse(json), r("ApprovePRMessage"));
     }
 
     public static approvePRMessageToJson(value: ApprovePRMessage): string {
         return JSON.stringify(uncast(value, r("ApprovePRMessage")), null, 2);
+    }
+
+    public static toAppSetEnabledMessage(json: string): AppSetEnabledMessage {
+        return cast(JSON.parse(json), r("AppSetEnabledMessage"));
+    }
+
+    public static appSetEnabledMessageToJson(value: AppSetEnabledMessage): string {
+        return JSON.stringify(uncast(value, r("AppSetEnabledMessage")), null, 2);
+    }
+
+    public static toAppSetEnabledResult(json: string): AppSetEnabledResult {
+        return cast(JSON.parse(json), r("AppSetEnabledResult"));
+    }
+
+    public static appSetEnabledResultToJson(value: AppSetEnabledResult): string {
+        return JSON.stringify(uncast(value, r("AppSetEnabledResult")), null, 2);
+    }
+
+    public static toAppStatusMessage(json: string): AppStatusMessage {
+        return cast(JSON.parse(json), r("AppStatusMessage"));
+    }
+
+    public static appStatusMessageToJson(value: AppStatusMessage): string {
+        return JSON.stringify(uncast(value, r("AppStatusMessage")), null, 2);
+    }
+
+    public static toAppStatusResult(json: string): AppStatusResult {
+        return cast(JSON.parse(json), r("AppStatusResult"));
+    }
+
+    public static appStatusResultToJson(value: AppStatusResult): string {
+        return JSON.stringify(uncast(value, r("AppStatusResult")), null, 2);
+    }
+
+    public static toAppSummary(json: string): AppSummary {
+        return cast(JSON.parse(json), r("AppSummary"));
+    }
+
+    public static appSummaryToJson(value: AppSummary): string {
+        return JSON.stringify(uncast(value, r("AppSummary")), null, 2);
+    }
+
+    public static toAppVersionInfo(json: string): AppVersionInfo {
+        return cast(JSON.parse(json), r("AppVersionInfo"));
+    }
+
+    public static appVersionInfoToJson(value: AppVersionInfo): string {
+        return JSON.stringify(uncast(value, r("AppVersionInfo")), null, 2);
     }
 
     public static toAttachBlock(json: string): AttachBlock {
@@ -10191,9 +10481,110 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "text", js: "text", typ: "" },
     ], "any"),
+    "AppConsumerInfo": o([
+        { json: "cursor", js: "cursor", typ: 0 },
+        { json: "enabled", js: "enabled", typ: true },
+        { json: "filter", js: "filter", typ: "" },
+        { json: "lag", js: "lag", typ: 0 },
+        { json: "name", js: "name", typ: "" },
+    ], "any"),
+    "AppInvocationInfo": o([
+        { json: "duration_ms", js: "duration_ms", typ: 0 },
+        { json: "error", js: "error", typ: "" },
+        { json: "event_name", js: "event_name", typ: "" },
+        { json: "event_seq", js: "event_seq", typ: 0 },
+        { json: "event_subject", js: "event_subject", typ: "" },
+        { json: "handler", js: "handler", typ: "" },
+        { json: "id", js: "id", typ: 0 },
+        { json: "started_at", js: "started_at", typ: "" },
+        { json: "status", js: "status", typ: "" },
+        { json: "version_id", js: "version_id", typ: 0 },
+    ], "any"),
+    "AppListMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AppListMessageCmd") },
+    ], "any"),
+    "AppListResult": o([
+        { json: "apps", js: "apps", typ: a(r("App")) },
+    ], "any"),
+    "App": o([
+        { json: "consumer", js: "consumer", typ: u(undefined, r("Consumer")) },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "current_version", js: "current_version", typ: u(undefined, r("CurrentVersion")) },
+        { json: "name", js: "name", typ: "" },
+        { json: "updated_at", js: "updated_at", typ: "" },
+    ], "any"),
+    "Consumer": o([
+        { json: "cursor", js: "cursor", typ: 0 },
+        { json: "enabled", js: "enabled", typ: true },
+        { json: "filter", js: "filter", typ: "" },
+        { json: "lag", js: "lag", typ: 0 },
+        { json: "name", js: "name", typ: "" },
+    ], "any"),
+    "CurrentVersion": o([
+        { json: "artifact_path", js: "artifact_path", typ: "" },
+        { json: "content_hash", js: "content_hash", typ: "" },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "id", js: "id", typ: 0 },
+    ], "any"),
+    "AppRemoveMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AppRemoveMessageCmd") },
+        { json: "name", js: "name", typ: "" },
+    ], "any"),
+    "AppRemoveResult": o([
+        { json: "consumer_removed", js: "consumer_removed", typ: true },
+        { json: "invocations_kept", js: "invocations_kept", typ: 0 },
+        { json: "name", js: "name", typ: "" },
+        { json: "namespace_kept", js: "namespace_kept", typ: "" },
+        { json: "versions_kept", js: "versions_kept", typ: 0 },
+    ], "any"),
     "ApprovePRMessage": o([
         { json: "cmd", js: "cmd", typ: r("ApprovePRMessageCmd") },
         { json: "id", js: "id", typ: "" },
+    ], "any"),
+    "AppSetEnabledMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AppSetEnabledMessageCmd") },
+        { json: "enabled", js: "enabled", typ: true },
+        { json: "name", js: "name", typ: "" },
+    ], "any"),
+    "AppSetEnabledResult": o([
+        { json: "consumer", js: "consumer", typ: "" },
+        { json: "enabled", js: "enabled", typ: true },
+        { json: "name", js: "name", typ: "" },
+    ], "any"),
+    "AppStatusMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AppStatusMessageCmd") },
+        { json: "name", js: "name", typ: "" },
+    ], "any"),
+    "AppStatusResult": o([
+        { json: "app", js: "app", typ: r("App") },
+        { json: "invocations", js: "invocations", typ: 0 },
+        { json: "recent", js: "recent", typ: u(undefined, a(r("RecentElement"))) },
+        { json: "versions", js: "versions", typ: 0 },
+    ], "any"),
+    "RecentElement": o([
+        { json: "duration_ms", js: "duration_ms", typ: 0 },
+        { json: "error", js: "error", typ: "" },
+        { json: "event_name", js: "event_name", typ: "" },
+        { json: "event_seq", js: "event_seq", typ: 0 },
+        { json: "event_subject", js: "event_subject", typ: "" },
+        { json: "handler", js: "handler", typ: "" },
+        { json: "id", js: "id", typ: 0 },
+        { json: "started_at", js: "started_at", typ: "" },
+        { json: "status", js: "status", typ: "" },
+        { json: "version_id", js: "version_id", typ: 0 },
+    ], "any"),
+    "AppSummary": o([
+        { json: "consumer", js: "consumer", typ: u(undefined, r("Consumer")) },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "current_version", js: "current_version", typ: u(undefined, r("CurrentVersion")) },
+        { json: "name", js: "name", typ: "" },
+        { json: "updated_at", js: "updated_at", typ: "" },
+    ], "any"),
+    "AppVersionInfo": o([
+        { json: "artifact_path", js: "artifact_path", typ: "" },
+        { json: "content_hash", js: "content_hash", typ: "" },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "id", js: "id", typ: 0 },
     ], "any"),
     "AttachBlock": o([
         { json: "command", js: "command", typ: u(undefined, "") },
@@ -12449,6 +12840,10 @@ const typeMap: any = {
         { json: "repos", js: "repos", typ: u(undefined, a(r("RepoElement"))) },
     ], "any"),
     "Response": o([
+        { json: "app_list_result", js: "app_list_result", typ: u(undefined, r("AppListResultObject")) },
+        { json: "app_remove_result", js: "app_remove_result", typ: u(undefined, r("AppRemoveResultObject")) },
+        { json: "app_set_enabled_result", js: "app_set_enabled_result", typ: u(undefined, r("AppSetEnabledResultObject")) },
+        { json: "app_status_result", js: "app_status_result", typ: u(undefined, r("AppStatusResultObject")) },
         { json: "authors", js: "authors", typ: u(undefined, a(r("AuthorElement"))) },
         { json: "data", js: "data", typ: u(undefined, "") },
         { json: "delegate_result", js: "delegate_result", typ: u(undefined, r("DelegateResultObject")) },
@@ -12493,6 +12888,27 @@ const typeMap: any = {
         { json: "workspace_context_result", js: "workspace_context_result", typ: u(undefined, r("WorkspaceContextResultObject")) },
         { json: "workspace_contexts", js: "workspace_contexts", typ: u(undefined, a(r("WorkspaceContextElement"))) },
         { json: "workspaces", js: "workspaces", typ: u(undefined, a(r("WorkspaceElement"))) },
+    ], "any"),
+    "AppListResultObject": o([
+        { json: "apps", js: "apps", typ: a(r("App")) },
+    ], "any"),
+    "AppRemoveResultObject": o([
+        { json: "consumer_removed", js: "consumer_removed", typ: true },
+        { json: "invocations_kept", js: "invocations_kept", typ: 0 },
+        { json: "name", js: "name", typ: "" },
+        { json: "namespace_kept", js: "namespace_kept", typ: "" },
+        { json: "versions_kept", js: "versions_kept", typ: 0 },
+    ], "any"),
+    "AppSetEnabledResultObject": o([
+        { json: "consumer", js: "consumer", typ: "" },
+        { json: "enabled", js: "enabled", typ: true },
+        { json: "name", js: "name", typ: "" },
+    ], "any"),
+    "AppStatusResultObject": o([
+        { json: "app", js: "app", typ: r("App") },
+        { json: "invocations", js: "invocations", typ: 0 },
+        { json: "recent", js: "recent", typ: u(undefined, a(r("RecentElement"))) },
+        { json: "versions", js: "versions", typ: 0 },
     ], "any"),
     "DocCollectionsResultObject": o([
         { json: "collections", js: "collections", typ: a(r("Schema")) },
@@ -13803,8 +14219,20 @@ const typeMap: any = {
     "AgentPromptMessageCmd": [
         "agent_prompt",
     ],
+    "AppListMessageCmd": [
+        "app_list",
+    ],
+    "AppRemoveMessageCmd": [
+        "app_remove",
+    ],
     "ApprovePRMessageCmd": [
         "approve_pr",
+    ],
+    "AppSetEnabledMessageCmd": [
+        "app_set_enabled",
+    ],
+    "AppStatusMessageCmd": [
+        "app_status",
     ],
     "AttachResultMessageEvent": [
         "attach_result",

--- a/changelog.d/app-registry-and-lifecycle-cli.yaml
+++ b/changelog.d/app-registry-and-lifecycle-cli.yaml
@@ -1,0 +1,21 @@
+kind: added
+area: cli
+change: >
+  `attn app` is the operator surface for apps — automations attn runs for you,
+  each consuming facts from the event bus as `app:<name>` and keeping its own
+  documents under `app/<name>`. `attn app list` shows every installed app with
+  the version it runs, whether it is enabled, and how far behind the event log it
+  is; `attn app status <name>` adds its consumer, its version and invocation
+  history, and its most recent runs; `enable`/`disable` start and stop delivery;
+  `remove` uninstalls.
+notes: >
+  Removing an app stops and deletes its bus consumer and deletes its registry
+  row, and nothing else: version history, the invocation log and every document
+  under `app/<name>` survive, and the command says so. Deleting your data is a
+  separate act and this is not it. An app's enabled state IS its bus consumer's
+  bit — there is no second copy — so `attn bus disable app:<name>` still kills an
+  app straight against the database when the daemon is not running. Status
+  reports only what exists: an app whose consumer has never been registered says
+  so rather than showing a default. This is stage A4's registry half; applying,
+  rolling back and scaffolding an app come with the pipeline that builds one.
+  Design: docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md.

--- a/cmd/attn/app.go
+++ b/cmd/attn/app.go
@@ -1,0 +1,294 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/victorarias/attn/internal/apps"
+	"github.com/victorarias/attn/internal/client"
+	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// `attn app` is the app registry's operator surface: what is installed, what
+// state each app is in, and the three verbs that change it — enable, disable,
+// remove.
+//
+// An app is a manifest-declared automation running in attn's shared runtime: it
+// consumes facts from the durable bus as `app:<name>`, keeps its state in the
+// document namespace `app/<name>`, and is versioned by the content hash of its
+// built artifact. A plugin is a different thing — an integration with its own
+// supervised process — and shares no surface with this one.
+//
+// Everything here goes through the daemon, like `attn doc` and unlike `attn
+// bus`: removing an app has to stop a delivery loop before its row goes, and
+// flipping the enabled bit publishes a fact the runtime hears. The
+// daemon-independent kill switch still exists one level down, on purpose: an
+// app's enabled bit IS its bus consumer's, so `attn bus disable app:<name>`
+// kills an app straight against the database, whether or not a daemon is up.
+
+func runApp() {
+	if len(os.Args) < 3 || os.Args[2] == "-h" || os.Args[2] == "--help" {
+		writeAppHelp(os.Stdout)
+		return
+	}
+	args := os.Args[3:]
+	switch os.Args[2] {
+	case "list":
+		runAppList(args)
+	case "status":
+		runAppStatus(args)
+	case "enable":
+		runAppSetEnabled(args, true)
+	case "disable":
+		runAppSetEnabled(args, false)
+	case "remove":
+		runAppRemove(args)
+	default:
+		fmt.Fprintf(os.Stderr, "app: unknown command %q\n", os.Args[2])
+		writeAppHelp(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+func writeAppHelp(w io.Writer) {
+	fmt.Fprint(w, `usage: attn app <command>
+
+An app is an automation attn runs for you: it reacts to facts from the event
+bus as the consumer app:<name>, and keeps its own documents under app/<name>.
+
+commands:
+  list [--json]
+        every registered app: the version it runs, whether it is enabled, and
+        how far behind the event log its consumer is.
+
+  status <name> [--json]
+        one app in full — its current version, its bus consumer, how many
+        versions and invocations it has recorded, and its most recent runs.
+        Reports only what exists: an app with no consumer says so rather than
+        showing a default.
+
+  enable <name>
+        resume delivery to the app, from wherever its consumer's cursor stands.
+
+  disable <name>
+        stop delivering facts to the app. Its cursor is preserved, but a
+        disabled consumer no longer holds the event log's retention window open:
+        once trimming passes its cursor, enabling resumes it at head.
+
+        This flips the app's bus consumer bit, which IS its enabled state. When
+        the daemon is not running, attn bus disable app:<name> does the same
+        thing straight against the database.
+
+  remove <name>
+        uninstall the app: stop and delete its bus consumer, delete its registry
+        row. Version history, the invocation log and every document under
+        app/<name> survive — deleting your data is a separate act, and this is
+        not it.
+`)
+}
+
+func appClient() *client.Client { return client.New(config.SocketPath()) }
+
+func appFail(verb string, err error) {
+	fmt.Fprintf(os.Stderr, "app %s: %v\n", verb, err)
+	os.Exit(1)
+}
+
+// appName reads the single <name> argument the per-app commands take, and
+// validates it here rather than only at the daemon: a typo should not need a
+// round trip to be told it is one.
+func appName(verb string, args []string) (string, []string) {
+	rest := make([]string, 0, len(args))
+	name := ""
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			rest = append(rest, a)
+			continue
+		}
+		if name != "" {
+			appFail(verb, fmt.Errorf("takes one app name; got %q and %q", name, a))
+		}
+		name = a
+	}
+	if name == "" {
+		fmt.Fprintf(os.Stderr, "usage: attn app %s <name>\n", verb)
+		os.Exit(2)
+	}
+	if err := apps.ValidateName(name); err != nil {
+		appFail(verb, err)
+	}
+	return name, rest
+}
+
+func runAppList(args []string) {
+	asJSON := appOutputFlags("list", args)
+	result, err := appClient().AppList()
+	if err != nil {
+		appFail("list", err)
+	}
+	if asJSON {
+		writeJSON(result.Apps)
+		return
+	}
+	if len(result.Apps) == 0 {
+		fmt.Println("no apps installed")
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "APP\tVERSION\tENABLED\tLAG\tCONSUMER")
+	for _, app := range result.Apps {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			app.Name, appVersionCell(app), appEnabledCell(app), appLagCell(app), appConsumerCell(app))
+	}
+	w.Flush()
+}
+
+// The four cells `list` renders say "none" rather than a blank or a guess: an
+// app without a version and an app without a consumer are both real states, and
+// an empty column reads as a rendering bug.
+func appVersionCell(app protocol.AppSummary) string {
+	if app.CurrentVersion == nil {
+		return "none"
+	}
+	return fmt.Sprintf("%d", app.CurrentVersion.ID)
+}
+
+func appEnabledCell(app protocol.AppSummary) string {
+	if app.Consumer == nil {
+		return "no consumer"
+	}
+	if app.Consumer.Enabled {
+		return "yes"
+	}
+	return "no"
+}
+
+func appLagCell(app protocol.AppSummary) string {
+	if app.Consumer == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d", app.Consumer.Lag)
+}
+
+func appConsumerCell(app protocol.AppSummary) string {
+	if app.Consumer == nil {
+		return apps.ConsumerName(app.Name) + " (not registered)"
+	}
+	return app.Consumer.Name
+}
+
+func runAppStatus(args []string) {
+	name, rest := appName("status", args)
+	asJSON := appOutputFlags("status", rest)
+	result, err := appClient().AppStatus(name)
+	if err != nil {
+		appFail("status", err)
+	}
+	if asJSON {
+		writeJSON(result)
+		return
+	}
+	app := result.App
+	fmt.Printf("app %s\n", app.Name)
+	if app.CurrentVersion != nil {
+		fmt.Printf("  version:    %d (%s)\n", app.CurrentVersion.ID, app.CurrentVersion.ContentHash)
+		fmt.Printf("  artifact:   %s\n", app.CurrentVersion.ArtifactPath)
+	} else {
+		fmt.Printf("  version:    none applied yet\n")
+	}
+	if app.Consumer != nil {
+		state := "disabled"
+		if app.Consumer.Enabled {
+			state = "enabled"
+		}
+		filter := app.Consumer.Filter
+		if filter == "" {
+			filter = "everything"
+		}
+		fmt.Printf("  consumer:   %s — %s, cursor %d, %d event(s) behind\n",
+			app.Consumer.Name, state, app.Consumer.Cursor, app.Consumer.Lag)
+		fmt.Printf("  subscribes: %s\n", filter)
+	} else {
+		// Naming the consumer that is missing is what makes this actionable:
+		// `attn bus status` is where the reader looks next.
+		fmt.Printf("  consumer:   none — %s is not registered, so no facts are delivered to this app\n",
+			apps.ConsumerName(app.Name))
+	}
+	fmt.Printf("  documents:  %s\n", apps.Namespace(app.Name))
+	fmt.Printf("  history:    %d version(s), %d invocation(s)\n", result.Versions, result.Invocations)
+	if len(result.Recent) == 0 {
+		fmt.Println("  recent:     no invocations recorded")
+		return
+	}
+	fmt.Println("  recent:")
+	w := tabwriter.NewWriter(os.Stdout, 4, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "\tSTARTED\tVERSION\tSEQ\tEVENT\tHANDLER\tSTATUS\tMS\tERROR")
+	for _, inv := range result.Recent {
+		fmt.Fprintf(w, "\t%s\t%d\t%d\t%s\t%s\t%s\t%d\t%s\n",
+			inv.StartedAt, inv.VersionID, inv.EventSeq, inv.EventName, inv.Handler,
+			inv.Status, inv.DurationMs, inv.Error)
+	}
+	w.Flush()
+}
+
+func runAppSetEnabled(args []string, enabled bool) {
+	verb := "disable"
+	if enabled {
+		verb = "enable"
+	}
+	name, rest := appName(verb, args)
+	appOutputFlags(verb, rest)
+	result, err := appClient().AppSetEnabled(name, enabled)
+	if err != nil {
+		appFail(verb, err)
+	}
+	if enabled {
+		fmt.Printf("app %s enabled: %s resumes from its cursor\n", result.Name, result.Consumer)
+		return
+	}
+	fmt.Printf("app %s disabled: %s stops receiving facts and no longer holds the event log open\n",
+		result.Name, result.Consumer)
+}
+
+func runAppRemove(args []string) {
+	name, rest := appName("remove", args)
+	appOutputFlags("remove", rest)
+	result, err := appClient().AppRemove(name)
+	if err != nil {
+		appFail("remove", err)
+	}
+	consumer := "it had no bus consumer"
+	if result.ConsumerRemoved {
+		consumer = "stopped and deleted its bus consumer " + apps.ConsumerName(result.Name)
+	}
+	fmt.Printf("removed app %s: %s\n", result.Name, consumer)
+	// Saying what survived is the point: removal is not a data-deleting act, and
+	// a reader who wanted it to be needs to know it did not happen.
+	fmt.Printf("kept: %d version(s), %d invocation(s), and every document under %s\n",
+		result.VersionsKept, result.InvocationsKept, result.NamespaceKept)
+}
+
+// appOutputFlags reads the flags shared by these commands. There is one, and it
+// is rejected loudly where it means nothing rather than being ignored.
+func appOutputFlags(verb string, args []string) bool {
+	asJSON := false
+	for _, a := range args {
+		switch a {
+		case "--json":
+			if verb != "list" && verb != "status" {
+				appFail(verb, fmt.Errorf("--json is only for list and status; %s reports what it did", verb))
+			}
+			asJSON = true
+		case "-h", "--help":
+			writeAppHelp(os.Stdout)
+			os.Exit(0)
+		default:
+			appFail(verb, fmt.Errorf("unknown flag %q", a))
+		}
+	}
+	return asJSON
+}

--- a/cmd/attn/bus.go
+++ b/cmd/attn/bus.go
@@ -251,8 +251,13 @@ func runBusSetEnabled(args []string, enabled bool) {
 		fmt.Fprintf(os.Stderr, "bus %s: no consumer named %q (see `attn bus status`)\n", verb, name)
 		os.Exit(1)
 	}
-	if err := s.SetBusConsumerEnabled(name, enabled, time.Now()); err != nil {
+	flipped, err := s.SetBusConsumerEnabled(name, enabled, time.Now())
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "bus %s: %v\n", verb, err)
+		os.Exit(1)
+	}
+	if !flipped {
+		fmt.Fprintf(os.Stderr, "bus %s: consumer %q was removed while this command ran, so nothing was changed (see `attn bus status`)\n", verb, name)
 		os.Exit(1)
 	}
 	fmt.Printf("consumer %q %sd\n", name, verb)

--- a/cmd/attn/doc.go
+++ b/cmd/attn/doc.go
@@ -16,7 +16,7 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-// `attn doc` is the document store's operator surface, and until the extension
+// `attn doc` is the document store's operator surface, and until the app
 // runtime exists it is also its only consumer.
 //
 // Everything here goes through the daemon rather than opening the database
@@ -62,7 +62,7 @@ func writeDocHelp(w io.Writer) {
 	fmt.Fprintf(w, `usage: attn doc <command>
 
 Documents are JSON objects addressed by <namespace> <collection> <id>. A
-namespace is owner/name (for example ext/approval-gate).
+namespace is owner/name (for example app/approval-gate).
 
 A collection declares which fields may be filtered and sorted on; created_at and
 updated_at are always available and are never declared. Everything else in a

--- a/cmd/attn/doc_test.go
+++ b/cmd/attn/doc_test.go
@@ -61,7 +61,7 @@ func TestWhereRejectsAnExpressionWithNoOperator(t *testing.T) {
 // the advance still carries to the next iteration — otherwise a flag's value
 // would be parsed again as if it were a flag.
 func TestQueryFlagsConsumeTheirValues(t *testing.T) {
-	query, opts := parseDocQueryFlags("query", "ext/approval-gate", "requests", []string{
+	query, opts := parseDocQueryFlags("query", "app/approval-gate", "requests", []string{
 		"--where", "status=pending",
 		"--sort", "created_at",
 		"--desc",
@@ -71,7 +71,7 @@ func TestQueryFlagsConsumeTheirValues(t *testing.T) {
 	if !opts.asJSON {
 		t.Fatal("--json not seen")
 	}
-	if query.Namespace != "ext/approval-gate" || query.Collection != "requests" {
+	if query.Namespace != "app/approval-gate" || query.Collection != "requests" {
 		t.Fatalf("target = %s/%s", query.Namespace, query.Collection)
 	}
 	if len(query.Filters) != 1 || query.Filters[0].Field != "status" || query.Filters[0].ValueJson != `"pending"` {
@@ -88,7 +88,7 @@ func TestQueryFlagsConsumeTheirValues(t *testing.T) {
 // --resume is a watch flag. A one-shot read that accepted it would silently
 // ignore it, and the caller would believe it had asked for something.
 func TestResumeBelongsToWatch(t *testing.T) {
-	_, opts := parseDocQueryFlags("watch", "ext/a", "c", []string{"--resume"})
+	_, opts := parseDocQueryFlags("watch", "app/a", "c", []string{"--resume"})
 	if !opts.resume {
 		t.Fatal("--resume not seen on watch")
 	}
@@ -96,7 +96,7 @@ func TestResumeBelongsToWatch(t *testing.T) {
 
 // --desc before --sort still applies to the sort that follows.
 func TestDescBeforeSortStillReversesIt(t *testing.T) {
-	query, _ := parseDocQueryFlags("query", "ext/a", "c", []string{"--desc", "--sort", "updated_at"})
+	query, _ := parseDocQueryFlags("query", "app/a", "c", []string{"--desc", "--sort", "updated_at"})
 	if query.Sort == nil || query.Sort.Field != "updated_at" || query.Sort.Desc == nil || !*query.Sort.Desc {
 		t.Fatalf("sort = %+v", query.Sort)
 	}
@@ -104,7 +104,7 @@ func TestDescBeforeSortStillReversesIt(t *testing.T) {
 
 // Repeating --where accumulates, which is how a range on the sort field pages.
 func TestWhereRepeatsToAccumulateFilters(t *testing.T) {
-	query, _ := parseDocQueryFlags("query", "ext/a", "c", []string{
+	query, _ := parseDocQueryFlags("query", "app/a", "c", []string{
 		"--where", "status=pending", "--where", "attempts>=2",
 	})
 	if len(query.Filters) != 2 {
@@ -118,7 +118,7 @@ func TestWhereRepeatsToAccumulateFilters(t *testing.T) {
 // --after carries the cursor, which is the only correct way to page: a --where
 // on the sort field skips or repeats documents that share a sort value.
 func TestAfterFlagCarriesTheCursor(t *testing.T) {
-	query, _ := parseDocQueryFlags("query", "ext/a", "c", []string{"--sort", "attempts", "--after", "b7"})
+	query, _ := parseDocQueryFlags("query", "app/a", "c", []string{"--sort", "attempts", "--after", "b7"})
 	if query.After == nil || *query.After != "b7" {
 		t.Fatalf("after = %v", query.After)
 	}

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -240,6 +240,9 @@ func main() {
 	case "doc":
 		maybePrintProfileBanner()
 		runDoc()
+	case "app":
+		maybePrintProfileBanner()
+		runApp()
 	case "journal":
 		maybePrintProfileBanner()
 		runJournal()
@@ -639,6 +642,7 @@ commands:
   db <command>                      database maintenance (restore from backup)
   bus <command>                     event bus: consumer cursors, lag, kill switch
   doc <command>                     document store: collections, documents, live queries
+  app <command>                     apps: list, status, enable, disable, remove
   vision-check <image> <question>   answer a question about an image (single LLM call)
   daemon <command>                  manage the daemon
 	  daemon ensure|stop                ensure the daemon is running, or stop it

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -192,15 +192,59 @@ The raw tier is physically unreachable through the user-facing notebook APIs
 happens; the keeper's narration is best-effort on top of it, so nothing is lost if
 narration never runs.
 
+## App
+
+An **app** is automation built on attn's platform: it declares what it does in a
+manifest, consumes domain facts from the event bus, keeps its state in its own
+document-store namespace, and runs inside attn's one shared supervised runtime.
+Apps are written by agents, applied while attn runs, and are meant to be cheap
+and numerous.
+
+An app has exactly one name, and that name is its whole identity: registry key,
+bus consumer `app:<name>`, document namespace `app/<name>`, directory
+convention. Nothing stores those separately, so they cannot drift apart.
+
+Two consequences of that single identity are worth stating outright, because
+they are what the lifecycle verbs mean:
+
+- An app's **enabled** state *is* its bus consumer's enabled bit. There is no
+  second copy. Flipping it is the one act that both stops delivery and releases
+  the event log's retention floor, and because the bit lives in the database,
+  `attn bus disable app:<name>` kills an app whether or not the daemon is
+  listening.
+- **Removing** an app stops and deletes its bus consumer and deletes its
+  registry row — and nothing else. Its version history, its invocation log, and
+  every document under `app/<name>` survive. Deleting a user's data is a
+  separate, explicit act, and uninstalling is not it.
+
+A **version** is one built artifact, identified by its content hash and frozen
+together with the declaration the manifest carried when it was built. Versions
+are never rewritten: applying is an insert plus a pointer move, and rolling back
+is the same pointer move to an older row. Re-applying byte-identical content
+reuses the version that is already there, which is what keeps "which version
+actually ran" answerable in the invocation log after a long editing session.
+
+## Plugin
+
+A **plugin** integrates the outside world into attn: agent drivers, worktree
+hooks. It runs as its own supervised process, dials the daemon, is installed
+rarely, and is effectively part of the platform — a device driver.
+
+App and plugin are deliberately different mechanisms, not two words for one. A
+failing plugin takes an integration down; a failing app is disabled while
+everything else keeps running. Different trust, different rate of change,
+different blast radius.
+
 ## The document store
 
-attn's **document store** is where an extension keeps its own data. Three names
+attn's **document store** is where an app keeps its own data. Three names
 locate every record:
 
-- **Namespace** — `owner/name`, e.g. `ext/approval-gate`. A namespace is granted
-  to exactly one author and is the isolation boundary: nothing an extension does
+- **Namespace** — `owner/name`, e.g. `app/approval-gate`. A namespace is granted
+  to exactly one author and is the isolation boundary: nothing an app does
   can read or write another namespace, and two namespaces may use the same
-  collection name without meeting.
+  collection name without meeting. `app/` is the owner segment apps are granted;
+  `core/` is attn's own.
 - **Collection** — a named set of documents inside a namespace, e.g. `requests`.
 - **Document** — one JSON object with a caller-chosen **id**, unique within its
   collection. The body is stored byte for byte and nothing ever rewrites it, so

--- a/internal/apps/apps.go
+++ b/internal/apps/apps.go
@@ -1,0 +1,64 @@
+// Package apps holds an app's identity: the one name an app has, and the three
+// places that name appears.
+//
+// An app is a manifest-declared automation running in attn's shared runtime.
+// Its name is its registry key, and mechanically also its bus consumer
+// (`app:<name>`) and its document namespace (`app/<name>`). Deriving both from
+// the name rather than storing them is what keeps them from drifting: there is
+// no second field anyone can set to something else.
+//
+// It is deliberately tiny and dependency-free — the manifest parser, the daemon
+// handlers and the CLI all need the same rule, and a rule that lives in one of
+// them ends up copied into the others.
+//
+// See docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md.
+package apps
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// nameRe is the app-name rule: lowercase letters, digits and dashes, starting
+// with a letter or digit. It has to survive being a bus consumer name after the
+// `app:` prefix, a document-store owner segment after `app/`, and a directory
+// name, so it is the intersection of what all three accept.
+var nameRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+// MaxNameLength bounds an app name. The tripwire is the document namespace: the
+// store validates `owner/name` and an app's namespace is `app/<name>`, so a name
+// nobody could address is refused here, where the error can say so, rather than
+// deeper where it reads as a store failure. 64 is far past any real name —
+// attn's longest today is "approval-gate" at 13.
+const MaxNameLength = 64
+
+// ValidateName reports whether a string can be an app name, and says what is
+// wrong when it cannot.
+func ValidateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("an app name is required, as lowercase letters, digits and dashes (for example approval-gate)")
+	}
+	if len(name) > MaxNameLength {
+		return fmt.Errorf("app name %q is %d characters, over the %d-character limit", name, len(name), MaxNameLength)
+	}
+	if !nameRe.MatchString(name) {
+		return fmt.Errorf("app name %q must be lowercase letters, digits and dashes, starting with a letter or digit (for example approval-gate)", name)
+	}
+	return nil
+}
+
+// ConsumerName is the app's durable bus consumer. The prefix is what keeps an
+// app from colliding with a platform consumer, and what makes `attn bus status`
+// readable at a glance.
+func ConsumerName(name string) string { return ConsumerPrefix + name }
+
+// ConsumerPrefix is shared with anything that has to recognise an app's consumer
+// among the platform's own.
+const ConsumerPrefix = "app:"
+
+// Namespace is the app's document-store namespace. It survives the app's removal
+// on purpose: documents are the user's data, not the installation.
+func Namespace(name string) string { return NamespacePrefix + name }
+
+// NamespacePrefix is the reserved document-store owner segment for apps.
+const NamespacePrefix = "app/"

--- a/internal/apps/apps_test.go
+++ b/internal/apps/apps_test.go
@@ -1,0 +1,55 @@
+package apps
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/docstore"
+)
+
+func TestValidateName(t *testing.T) {
+	for _, ok := range []string{"approval-gate", "a", "app2", "standup-digest-v2", "9lives"} {
+		if err := ValidateName(ok); err != nil {
+			t.Errorf("ValidateName(%q) = %v, want nil", ok, err)
+		}
+	}
+	for _, bad := range []string{"", "-leading", "Approval", "with_underscore", "with space", "app/name", "app:name", strings.Repeat("a", MaxNameLength+1)} {
+		if err := ValidateName(bad); err == nil {
+			t.Errorf("ValidateName(%q) = nil, want an error", bad)
+		}
+	}
+}
+
+// The name rule exists to serve three surfaces; the document namespace is the
+// strictest, so a name this package accepts must be one the store can address.
+func TestAcceptedNamesMakeValidNamespaces(t *testing.T) {
+	for _, name := range []string{"approval-gate", "a", "9lives", strings.Repeat("a", MaxNameLength)} {
+		if err := ValidateName(name); err != nil {
+			t.Fatalf("ValidateName(%q): %v", name, err)
+		}
+		if err := docstore.ValidateNamespace(Namespace(name)); err != nil {
+			t.Errorf("docstore rejects the namespace for app %q: %v", name, err)
+		}
+	}
+}
+
+func TestNameErrorsSayWhatIsWrong(t *testing.T) {
+	err := ValidateName(strings.Repeat("a", MaxNameLength+1))
+	if err == nil {
+		t.Fatal("an over-long name was accepted")
+	}
+	// A limit someone can hit is a limit they must see: the message names the
+	// limit and the ask.
+	if !strings.Contains(err.Error(), "65") || !strings.Contains(err.Error(), "64") {
+		t.Fatalf("error does not name the ask and the limit: %v", err)
+	}
+}
+
+func TestDerivedIdentities(t *testing.T) {
+	if got := ConsumerName("approval-gate"); got != "app:approval-gate" {
+		t.Errorf("ConsumerName = %q", got)
+	}
+	if got := Namespace("approval-gate"); got != "app/approval-gate" {
+		t.Errorf("Namespace = %q", got)
+	}
+}

--- a/internal/bus/announce_test.go
+++ b/internal/bus/announce_test.go
@@ -57,8 +57,8 @@ func TestAnnounceDeliversWhatTheLogGainedWithoutPublish(t *testing.T) {
 	defer stop()
 
 	now := time.Now()
-	first := s.appendOutOfBand("document.changed", "ext/x/requests/a", now)
-	second := s.appendOutOfBand("document.changed", "ext/x/requests/b", now)
+	first := s.appendOutOfBand("document.changed", "app/x/requests/a", now)
+	second := s.appendOutOfBand("document.changed", "app/x/requests/b", now)
 
 	b.Announce()
 
@@ -77,7 +77,7 @@ func TestAnnouncingTwiceDeliversOnce(t *testing.T) {
 	seen, stop := watchAll(b)
 	defer stop()
 
-	s.appendOutOfBand("document.changed", "ext/x/requests/a", time.Now())
+	s.appendOutOfBand("document.changed", "app/x/requests/a", time.Now())
 	b.Announce()
 	b.Announce()
 	b.Announce()
@@ -93,8 +93,8 @@ func TestAnnouncingTwiceDeliversOnce(t *testing.T) {
 func TestAnnounceDoesNotReplayWhatWasThereBeforeTheBus(t *testing.T) {
 	s := newMemStore()
 	now := time.Now()
-	s.appendOutOfBand("document.changed", "ext/x/requests/old", now)
-	s.appendOutOfBand("document.changed", "ext/x/requests/older", now)
+	s.appendOutOfBand("document.changed", "app/x/requests/old", now)
+	s.appendOutOfBand("document.changed", "app/x/requests/older", now)
 
 	b := testBus(t, s)
 	seen, stop := watchAll(b)
@@ -105,7 +105,7 @@ func TestAnnounceDoesNotReplayWhatWasThereBeforeTheBus(t *testing.T) {
 		t.Fatalf("a fresh bus replayed %d historical fact(s)", len(got))
 	}
 
-	fresh := s.appendOutOfBand("document.changed", "ext/x/requests/new", now)
+	fresh := s.appendOutOfBand("document.changed", "app/x/requests/new", now)
 	b.Announce()
 	got := seqsOf(seen())
 	if len(got) != 1 || got[0] != fresh {
@@ -140,7 +140,7 @@ func TestRacingWritersDeliverTheLogsOrderExactlyOnce(t *testing.T) {
 				// Commit, then announce — the shape of a composite write. The
 				// gap between the two is where the ordering race lives.
 				if w%2 == 0 {
-					s.appendOutOfBand("document.changed", "ext/x/requests/a", time.Now())
+					s.appendOutOfBand("document.changed", "app/x/requests/a", time.Now())
 					b.Announce()
 					continue
 				}
@@ -194,7 +194,7 @@ func TestTrimCompactsTheNamesTheBusDeclared(t *testing.T) {
 
 	now := time.Now()
 	for range 10 {
-		s.appendOutOfBand("document.changed", "ext/x/requests/a", now)
+		s.appendOutOfBand("document.changed", "app/x/requests/a", now)
 	}
 	for range 3 {
 		s.appendOutOfBand("session.state.changed", "sess-1", now)
@@ -229,7 +229,7 @@ func TestTrimCompactsNothingWhenNoNameWasDeclared(t *testing.T) {
 
 	now := time.Now()
 	for range 10 {
-		s.appendOutOfBand("document.changed", "ext/x/requests/a", now)
+		s.appendOutOfBand("document.changed", "app/x/requests/a", now)
 	}
 
 	if removed, err := b.Trim(); err != nil || removed != 0 {
@@ -252,7 +252,7 @@ func TestABusThatCouldNotFindTheHeadDoesNotReplayTheLog(t *testing.T) {
 	s := newMemStore()
 	now := time.Now()
 	for range 5 {
-		s.appendOutOfBand("document.changed", "ext/x/requests/old", now)
+		s.appendOutOfBand("document.changed", "app/x/requests/old", now)
 	}
 	s.setBoundsErr(errors.New("the log would not say where it stands"))
 
@@ -281,7 +281,7 @@ func TestABusThatCouldNotFindTheHeadDoesNotReplayTheLog(t *testing.T) {
 	if got := seen(); len(got) != 1 {
 		t.Fatalf("placing the mark replayed history: %d event(s) delivered", len(got))
 	}
-	fresh := s.appendOutOfBand("document.changed", "ext/x/requests/new", now)
+	fresh := s.appendOutOfBand("document.changed", "app/x/requests/new", now)
 	b.Announce()
 	got := seen()
 	if len(got) != 2 || got[1].Seq != fresh {
@@ -301,7 +301,7 @@ func TestTrimReportsAPassThatCouldNotRun(t *testing.T) {
 	})
 	now := time.Now()
 	for range 4 {
-		s.appendOutOfBand("document.changed", "ext/x/requests/a", now)
+		s.appendOutOfBand("document.changed", "app/x/requests/a", now)
 	}
 
 	// consumerFloor reads the bounds when no enabled consumer is registered, so

--- a/internal/client/apps.go
+++ b/internal/client/apps.go
@@ -1,0 +1,46 @@
+package client
+
+import "github.com/victorarias/attn/internal/protocol"
+
+// The app registry's client surface. Everything goes through the daemon, like
+// the document store's and unlike `attn bus`: removing an app has to stop a
+// delivery loop before deleting its row, and flipping the enabled bit publishes
+// a fact the runtime hears.
+//
+// The daemon-independent path still exists, deliberately, one level down: an
+// app's enabled bit is its bus consumer's, so `attn bus disable app:<name>` is
+// the kill switch that works when the daemon does not.
+
+func (c *Client) AppList() (*protocol.AppListResult, error) {
+	resp, err := c.send(protocol.AppListMessage{Cmd: protocol.CmdAppList})
+	if err != nil {
+		return nil, err
+	}
+	return resp.AppListResult, nil
+}
+
+func (c *Client) AppStatus(name string) (*protocol.AppStatusResult, error) {
+	resp, err := c.send(protocol.AppStatusMessage{Cmd: protocol.CmdAppStatus, Name: name})
+	if err != nil {
+		return nil, err
+	}
+	return resp.AppStatusResult, nil
+}
+
+func (c *Client) AppSetEnabled(name string, enabled bool) (*protocol.AppSetEnabledResult, error) {
+	resp, err := c.send(protocol.AppSetEnabledMessage{
+		Cmd: protocol.CmdAppSetEnabled, Name: name, Enabled: enabled,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.AppSetEnabledResult, nil
+}
+
+func (c *Client) AppRemove(name string) (*protocol.AppRemoveResult, error) {
+	resp, err := c.send(protocol.AppRemoveMessage{Cmd: protocol.CmdAppRemove, Name: name})
+	if err != nil {
+		return nil, err
+	}
+	return resp.AppRemoveResult, nil
+}

--- a/internal/daemon/apps.go
+++ b/internal/daemon/apps.go
@@ -175,8 +175,18 @@ func (d *Daemon) handleAppSetEnabled(conn net.Conn, msg *protocol.AppSetEnabledM
 			name, consumer, verb, name))
 		return
 	}
-	if err := d.store.SetBusConsumerEnabled(consumer, msg.Enabled, time.Now()); err != nil {
+	// Between the read above and this write the consumer may have been
+	// unregistered — `attn app remove` running beside this one. Reporting success
+	// then would answer for a consumer that is gone and publish a fact about it.
+	flipped, err := d.store.SetBusConsumerEnabled(consumer, msg.Enabled, time.Now())
+	if err != nil {
 		d.sendError(conn, fmt.Sprintf("%s app %q: %v", verb, name, err))
+		return
+	}
+	if !flipped {
+		d.sendError(conn, fmt.Sprintf(
+			"app %q: its bus consumer %s was removed while %s was running, so nothing was changed. "+
+				"`attn app status %s` shows what is left.", name, consumer, verb, name))
 		return
 	}
 	d.publishFact(FactAppEnabledChanged, name, appEnabledChanged{

--- a/internal/daemon/apps.go
+++ b/internal/daemon/apps.go
@@ -1,0 +1,365 @@
+package daemon
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/apps"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// The app registry's daemon half: the IPC surface `attn app` speaks.
+//
+// This is the read-and-flip side of the registry. What it deliberately does NOT
+// do is invent state: an app's enabled bit is its bus consumer's and is read
+// from there, and an app with no consumer reports that rather than a default.
+// Everything a running app runtime knows — is it loaded, is it stalled, what did
+// it last fail on — is absent here because nothing observes it yet, and a status
+// that answers a question it cannot answer is worse than one that says so.
+//
+// See docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md.
+
+// recentInvocationLimit is how many invocations `attn app status` carries back.
+// Enough to see a failure pattern, small enough that a status call never hauls
+// an app's whole history over the socket; `attn app logs` is the surface for
+// more.
+const recentInvocationLimit = 10
+
+// appEnabledChanged is FactAppEnabledChanged's payload.
+type appEnabledChanged struct {
+	Name     string `json:"name"`
+	Consumer string `json:"consumer"`
+	Enabled  bool   `json:"enabled"`
+}
+
+// appRemoved is FactAppRemoved's payload. It names the consumer and namespace
+// because a consumer of this fact cannot look them up: the registry row is gone.
+type appRemoved struct {
+	Name      string `json:"name"`
+	Consumer  string `json:"consumer"`
+	Namespace string `json:"namespace"`
+}
+
+func (d *Daemon) handleAppList(conn net.Conn, _ *protocol.AppListMessage) {
+	if d.store == nil {
+		d.sendError(conn, "no database")
+		return
+	}
+	rows, err := d.store.ListApps()
+	if err != nil {
+		d.sendError(conn, fmt.Sprintf("listing apps: %v", err))
+		return
+	}
+	head, err := d.busHead()
+	if err != nil {
+		d.sendError(conn, fmt.Sprintf("reading the event log: %v", err))
+		return
+	}
+	summaries := make([]protocol.AppSummary, 0, len(rows))
+	for _, row := range rows {
+		summary, err := d.appSummary(row, head)
+		if err != nil {
+			d.sendError(conn, err.Error())
+			return
+		}
+		summaries = append(summaries, summary)
+	}
+	d.sendDocResponse(conn, protocol.Response{
+		Ok:            true,
+		AppListResult: &protocol.AppListResult{Apps: summaries},
+	})
+}
+
+func (d *Daemon) handleAppStatus(conn net.Conn, msg *protocol.AppStatusMessage) {
+	name := strings.TrimSpace(msg.Name)
+	if err := apps.ValidateName(name); err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	if d.store == nil {
+		d.sendError(conn, "no database")
+		return
+	}
+	row, ok, err := d.store.GetApp(name)
+	if err != nil {
+		d.sendError(conn, fmt.Sprintf("reading app %q: %v", name, err))
+		return
+	}
+	if !ok {
+		d.sendError(conn, d.unknownAppError("status", name))
+		return
+	}
+	head, err := d.busHead()
+	if err != nil {
+		d.sendError(conn, fmt.Sprintf("reading the event log: %v", err))
+		return
+	}
+	summary, err := d.appSummary(row, head)
+	if err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	versions, err := d.store.CountAppVersions(name)
+	if err != nil {
+		d.sendError(conn, fmt.Sprintf("counting versions of app %q: %v", name, err))
+		return
+	}
+	invocations, err := d.store.CountAppInvocations(name)
+	if err != nil {
+		d.sendError(conn, fmt.Sprintf("counting invocations of app %q: %v", name, err))
+		return
+	}
+	recent, err := d.store.ListAppInvocations(name, recentInvocationLimit)
+	if err != nil {
+		d.sendError(conn, fmt.Sprintf("reading invocations of app %q: %v", name, err))
+		return
+	}
+	result := protocol.AppStatusResult{App: summary, Versions: versions, Invocations: invocations}
+	for _, inv := range recent {
+		result.Recent = append(result.Recent, protocol.AppInvocationInfo{
+			ID:           int(inv.ID),
+			VersionID:    int(inv.VersionID),
+			EventSeq:     int(inv.EventSeq),
+			EventName:    inv.EventName,
+			EventSubject: inv.EventSubject,
+			Handler:      inv.Handler,
+			Status:       inv.Status,
+			Error:        inv.Error,
+			DurationMs:   int(inv.Duration.Milliseconds()),
+			StartedAt:    stampForWire(inv.StartedAt),
+		})
+	}
+	d.sendDocResponse(conn, protocol.Response{Ok: true, AppStatusResult: &result})
+}
+
+// handleAppSetEnabled flips the app's bus consumer bit, which IS the app's
+// enabled state — there is no second bit anywhere, by design.
+//
+// It refuses an app with no consumer instead of creating one. A consumer carries
+// a cursor, and minting one here would silently decide where an app that has
+// never run should start reading from; that decision belongs to whatever loads
+// the app, not to the enable verb.
+func (d *Daemon) handleAppSetEnabled(conn net.Conn, msg *protocol.AppSetEnabledMessage) {
+	name := strings.TrimSpace(msg.Name)
+	verb := "disable"
+	if msg.Enabled {
+		verb = "enable"
+	}
+	if err := apps.ValidateName(name); err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	if d.store == nil {
+		d.sendError(conn, "no database")
+		return
+	}
+	if _, ok, err := d.store.GetApp(name); err != nil {
+		d.sendError(conn, fmt.Sprintf("reading app %q: %v", name, err))
+		return
+	} else if !ok {
+		d.sendError(conn, d.unknownAppError(verb, name))
+		return
+	}
+	consumer := apps.ConsumerName(name)
+	if _, ok, err := d.store.GetBusConsumer(consumer); err != nil {
+		d.sendError(conn, fmt.Sprintf("reading the bus consumer for app %q: %v", name, err))
+		return
+	} else if !ok {
+		d.sendError(conn, fmt.Sprintf(
+			"app %q has no bus consumer (%s), so there is no enabled bit to %s: nothing is delivering facts to it. "+
+				"A consumer is registered when the app runtime loads a version of the app; `attn app status %s` shows what exists.",
+			name, consumer, verb, name))
+		return
+	}
+	if err := d.store.SetBusConsumerEnabled(consumer, msg.Enabled, time.Now()); err != nil {
+		d.sendError(conn, fmt.Sprintf("%s app %q: %v", verb, name, err))
+		return
+	}
+	d.publishFact(FactAppEnabledChanged, name, appEnabledChanged{
+		Name: name, Consumer: consumer, Enabled: msg.Enabled,
+	})
+	d.sendDocResponse(conn, protocol.Response{
+		Ok: true,
+		AppSetEnabledResult: &protocol.AppSetEnabledResult{
+			Name: name, Consumer: consumer, Enabled: msg.Enabled,
+		},
+	})
+}
+
+// handleAppRemove uninstalls an app: the consumer's delivery loop stops and its
+// row goes, then the registry row goes.
+//
+// The consumer is unregistered through the bus rather than deleted from the
+// store, because the row is not the whole of it — a live delivery loop reading a
+// registration that vanished underneath it retries that error forever. Bus
+// Unregister is the one place that stops the loop first and deletes second.
+//
+// It works on a half-installed app: a stray consumer with no registry row, or a
+// registry row with no consumer, is exactly the state that needs a way out, and
+// refusing to clean it would leave an orphaned enabled consumer pinning the
+// event log's retention floor against a consumer nobody serves.
+func (d *Daemon) handleAppRemove(conn net.Conn, msg *protocol.AppRemoveMessage) {
+	name := strings.TrimSpace(msg.Name)
+	if err := apps.ValidateName(name); err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	if d.store == nil {
+		d.sendError(conn, "no database")
+		return
+	}
+	_, appExists, err := d.store.GetApp(name)
+	if err != nil {
+		d.sendError(conn, fmt.Sprintf("reading app %q: %v", name, err))
+		return
+	}
+	consumer := apps.ConsumerName(name)
+	_, consumerExists, err := d.store.GetBusConsumer(consumer)
+	if err != nil {
+		d.sendError(conn, fmt.Sprintf("reading the bus consumer for app %q: %v", name, err))
+		return
+	}
+	if !appExists && !consumerExists {
+		d.sendError(conn, d.unknownAppError("remove", name))
+		return
+	}
+
+	if consumerExists {
+		if err := d.unregisterConsumer(consumer); err != nil {
+			d.sendError(conn, fmt.Sprintf("removing app %q: stopping its bus consumer %s: %v", name, consumer, err))
+			return
+		}
+	}
+	if _, err := d.store.DeleteApp(name); err != nil {
+		d.sendError(conn, fmt.Sprintf("removing app %q: %v", name, err))
+		return
+	}
+
+	versions, err := d.store.CountAppVersions(name)
+	if err != nil {
+		d.sendError(conn, fmt.Sprintf("counting versions of app %q: %v", name, err))
+		return
+	}
+	invocations, err := d.store.CountAppInvocations(name)
+	if err != nil {
+		d.sendError(conn, fmt.Sprintf("counting invocations of app %q: %v", name, err))
+		return
+	}
+	namespace := apps.Namespace(name)
+	d.publishFact(FactAppRemoved, name, appRemoved{Name: name, Consumer: consumer, Namespace: namespace})
+	d.sendDocResponse(conn, protocol.Response{
+		Ok: true,
+		AppRemoveResult: &protocol.AppRemoveResult{
+			Name:            name,
+			ConsumerRemoved: consumerExists,
+			VersionsKept:    versions,
+			InvocationsKept: invocations,
+			NamespaceKept:   namespace,
+		},
+	})
+}
+
+// unregisterConsumer stops and deletes a durable consumer. It goes through the
+// bus when there is one; a daemon assembled without a bus (tests, and a store
+// opened for a one-shot command) still has to delete the row, or the uninstall
+// would leave the orphan the whole verb exists to remove.
+func (d *Daemon) unregisterConsumer(consumer string) error {
+	if d.eventBus != nil {
+		return d.eventBus.Unregister(consumer)
+	}
+	return d.store.DeleteBusConsumer(consumer)
+}
+
+// appSummary joins a registry row to the two things that are not in it: the
+// version it points at, and the consumer carrying its enabled state.
+func (d *Daemon) appSummary(row store.App, head int64) (protocol.AppSummary, error) {
+	summary := protocol.AppSummary{
+		Name:      row.Name,
+		CreatedAt: stampForWire(row.CreatedAt),
+		UpdatedAt: stampForWire(row.UpdatedAt),
+	}
+	if row.CurrentVersionID != 0 {
+		version, ok, err := d.store.GetAppVersion(row.CurrentVersionID)
+		if err != nil {
+			return protocol.AppSummary{}, fmt.Errorf("reading version %d of app %q: %w", row.CurrentVersionID, row.Name, err)
+		}
+		if ok {
+			summary.CurrentVersion = &protocol.AppVersionInfo{
+				ID:           int(version.ID),
+				ContentHash:  version.ContentHash,
+				ArtifactPath: version.ArtifactPath,
+				CreatedAt:    stampForWire(version.CreatedAt),
+			}
+		}
+	}
+	consumer, ok, err := d.store.GetBusConsumer(apps.ConsumerName(row.Name))
+	if err != nil {
+		return protocol.AppSummary{}, fmt.Errorf("reading the bus consumer for app %q: %w", row.Name, err)
+	}
+	if ok {
+		lag := head - consumer.Cursor
+		if lag < 0 {
+			lag = 0
+		}
+		summary.Consumer = &protocol.AppConsumerInfo{
+			Name:    consumer.Name,
+			Enabled: consumer.Enabled,
+			Cursor:  int(consumer.Cursor),
+			Lag:     int(lag),
+			Filter:  consumer.Filter,
+		}
+	}
+	return summary, nil
+}
+
+func (d *Daemon) busHead() (int64, error) {
+	_, head, err := d.store.BusBounds()
+	return head, err
+}
+
+// unknownAppError names what is there instead of what is not. An agent reading
+// "no app named x" and nothing else has to go find another command to learn what
+// the alternatives are; this answers that in the same breath, and calls out the
+// half-installed case rather than letting it read as "never existed".
+func (d *Daemon) unknownAppError(verb, name string) string {
+	msg := fmt.Sprintf("app %s: no app named %q is registered", verb, name)
+	if rows, err := d.store.ListApps(); err == nil {
+		if len(rows) == 0 {
+			msg += "; no apps are registered"
+		} else {
+			names := make([]string, 0, len(rows))
+			for _, row := range rows {
+				names = append(names, row.Name)
+			}
+			sort.Strings(names)
+			msg += "; registered apps: " + strings.Join(names, ", ")
+		}
+	}
+	// A name with history or a stray consumer is a different situation from a
+	// name that never existed, and saying which is what tells the reader whether
+	// there is anything left to clean up.
+	var leftovers []string
+	if versions, err := d.store.CountAppVersions(name); err == nil && versions > 0 {
+		leftovers = append(leftovers, fmt.Sprintf("%d version(s) of it remain as history", versions))
+	}
+	if _, ok, err := d.store.GetBusConsumer(apps.ConsumerName(name)); err == nil && ok {
+		leftovers = append(leftovers, fmt.Sprintf("its bus consumer %s still exists (`attn app remove %s` deletes it)", apps.ConsumerName(name), name))
+	}
+	if len(leftovers) > 0 {
+		msg += ". " + strings.Join(leftovers, "; ")
+	}
+	return msg
+}
+
+// stampForWire renders a stored timestamp for the protocol. Zero means "not
+// recorded", which travels as the empty string rather than year 1.
+func stampForWire(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}

--- a/internal/daemon/apps_test.go
+++ b/internal/daemon/apps_test.go
@@ -1,0 +1,383 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/apps"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// The app registry's IPC surface. What these pin is mostly what the handlers
+// refuse to invent: an app with no consumer has no enabled state, an unknown
+// name is answered with what does exist, and removing an app keeps everything
+// that is history or data.
+
+// seedApp writes the rows a real profile holds after one apply: a registry row
+// pointing at a version, and the app's own bus consumer sitting behind a log
+// that has moved on.
+func seedApp(t *testing.T, d *Daemon, name string, enabled bool) store.AppVersion {
+	t.Helper()
+	now := time.Now().UTC()
+	version, err := d.store.CommitAppVersion(store.AppVersion{
+		AppName:      name,
+		ContentHash:  "sha256:" + name,
+		Declaration:  `{"name":"` + name + `","subscribe":[{"events":["ticket.*"]}]}`,
+		ArtifactPath: "apps/" + name + "/bundle.js",
+	}, now)
+	if err != nil {
+		t.Fatalf("seed version for %s: %v", name, err)
+	}
+	seedAppConsumer(t, d, name, enabled, 0)
+	return version
+}
+
+func seedAppConsumer(t *testing.T, d *Daemon, name string, enabled bool, cursor int64) {
+	t.Helper()
+	if err := d.store.SaveBusConsumer(store.BusConsumer{
+		Name:    apps.ConsumerName(name),
+		Cursor:  cursor,
+		Filter:  "ticket.*",
+		Enabled: enabled,
+	}, time.Now()); err != nil {
+		t.Fatalf("seed consumer for %s: %v", name, err)
+	}
+	// SaveBusConsumer deliberately never rewrites an existing row's cursor or
+	// enabled bit — re-registering at startup must neither rewind a consumer nor
+	// resurrect one the operator killed — so the seed sets both explicitly.
+	if err := d.store.SetBusConsumerEnabled(apps.ConsumerName(name), enabled, time.Now()); err != nil {
+		t.Fatalf("seed consumer bit for %s: %v", name, err)
+	}
+	if err := d.store.SetBusConsumerCursor(apps.ConsumerName(name), cursor, time.Now()); err != nil {
+		t.Fatalf("seed consumer cursor for %s: %v", name, err)
+	}
+}
+
+func appFacts(t *testing.T, d *Daemon, name string) []store.BusEvent {
+	t.Helper()
+	var out []store.BusEvent
+	for _, e := range factsOf(t, d) {
+		if e.Name == name {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func appList(t *testing.T, d *Daemon) *protocol.AppListResult {
+	t.Helper()
+	resp := docCall(t, func(c net.Conn) {
+		d.handleAppList(c, &protocol.AppListMessage{Cmd: protocol.CmdAppList})
+	})
+	if !resp.Ok {
+		t.Fatalf("app list: %v", protocol.Deref(resp.Error))
+	}
+	return resp.AppListResult
+}
+
+func appStatus(t *testing.T, d *Daemon, name string) protocol.Response {
+	t.Helper()
+	return docCall(t, func(c net.Conn) {
+		d.handleAppStatus(c, &protocol.AppStatusMessage{Cmd: protocol.CmdAppStatus, Name: name})
+	})
+}
+
+func appSetEnabled(t *testing.T, d *Daemon, name string, enabled bool) protocol.Response {
+	t.Helper()
+	return docCall(t, func(c net.Conn) {
+		d.handleAppSetEnabled(c, &protocol.AppSetEnabledMessage{
+			Cmd: protocol.CmdAppSetEnabled, Name: name, Enabled: enabled,
+		})
+	})
+}
+
+func appRemove(t *testing.T, d *Daemon, name string) protocol.Response {
+	t.Helper()
+	return docCall(t, func(c net.Conn) {
+		d.handleAppRemove(c, &protocol.AppRemoveMessage{Cmd: protocol.CmdAppRemove, Name: name})
+	})
+}
+
+func TestAppListReportsVersionAndConsumer(t *testing.T) {
+	d := newDaemonForTest(t)
+	if got := appList(t, d); len(got.Apps) != 0 {
+		t.Fatalf("a fresh profile listed %d app(s)", len(got.Apps))
+	}
+
+	version := seedApp(t, d, "approval-gate", true)
+	// Two facts on the log with the consumer parked at 1: lag is what the app
+	// has yet to be delivered, which is the number an operator acts on.
+	for i := 0; i < 2; i++ {
+		if _, err := d.store.AppendBusEvent(store.BusEvent{Name: "ticket.created", Subject: "t-1"}, time.Now()); err != nil {
+			t.Fatalf("append event: %v", err)
+		}
+	}
+	seedAppConsumer(t, d, "approval-gate", true, 1)
+
+	got := appList(t, d)
+	if len(got.Apps) != 1 {
+		t.Fatalf("apps = %d, want 1", len(got.Apps))
+	}
+	app := got.Apps[0]
+	if app.Name != "approval-gate" {
+		t.Fatalf("name = %q", app.Name)
+	}
+	if app.CurrentVersion == nil || app.CurrentVersion.ID != int(version.ID) {
+		t.Fatalf("current version = %+v, want %d", app.CurrentVersion, version.ID)
+	}
+	if app.CurrentVersion.ContentHash != version.ContentHash {
+		t.Fatalf("content hash = %q, want %q", app.CurrentVersion.ContentHash, version.ContentHash)
+	}
+	if app.Consumer == nil {
+		t.Fatal("app reported no consumer")
+	}
+	if !app.Consumer.Enabled || app.Consumer.Name != "app:approval-gate" {
+		t.Fatalf("consumer = %+v", app.Consumer)
+	}
+	if app.Consumer.Cursor != 1 || app.Consumer.Lag != 1 {
+		t.Fatalf("cursor/lag = %d/%d, want 1/1", app.Consumer.Cursor, app.Consumer.Lag)
+	}
+}
+
+// An app whose runtime has never registered a consumer is a real state, and the
+// answer says so rather than defaulting it to enabled or to disabled.
+func TestAppWithNoConsumerReportsNoneAndCannotBeFlipped(t *testing.T) {
+	d := newDaemonForTest(t)
+	if err := d.store.SaveApp("half-installed", time.Now()); err != nil {
+		t.Fatalf("save app: %v", err)
+	}
+
+	listed := appList(t, d)
+	if len(listed.Apps) != 1 || listed.Apps[0].Consumer != nil {
+		t.Fatalf("apps = %+v, want one with no consumer", listed.Apps)
+	}
+	if listed.Apps[0].CurrentVersion != nil {
+		t.Fatalf("an app with no applied version reported %+v", listed.Apps[0].CurrentVersion)
+	}
+
+	for _, enabled := range []bool{true, false} {
+		resp := appSetEnabled(t, d, "half-installed", enabled)
+		if resp.Ok {
+			t.Fatalf("flipping an app with no consumer succeeded (enabled=%t)", enabled)
+		}
+		msg := protocol.Deref(resp.Error)
+		// The error names the consumer that is missing and where to look — an
+		// agent reading it can act without reading the code.
+		if !strings.Contains(msg, "app:half-installed") || !strings.Contains(msg, "attn app status") {
+			t.Fatalf("error does not say what is missing or what to run: %q", msg)
+		}
+	}
+	if facts := appFacts(t, d, FactAppEnabledChanged); len(facts) != 0 {
+		t.Fatalf("a refused flip published %d fact(s)", len(facts))
+	}
+}
+
+func TestAppEnableDisableFlipsTheConsumerBitAndPublishes(t *testing.T) {
+	d := newDaemonForTest(t)
+	seedApp(t, d, "approval-gate", true)
+
+	resp := appSetEnabled(t, d, "approval-gate", false)
+	if !resp.Ok {
+		t.Fatalf("disable: %v", protocol.Deref(resp.Error))
+	}
+	if resp.AppSetEnabledResult.Consumer != "app:approval-gate" || resp.AppSetEnabledResult.Enabled {
+		t.Fatalf("disable result = %+v", resp.AppSetEnabledResult)
+	}
+	consumer, ok, err := d.store.GetBusConsumer("app:approval-gate")
+	if err != nil || !ok {
+		t.Fatalf("consumer: %v ok=%t", err, ok)
+	}
+	if consumer.Enabled {
+		t.Fatal("disable did not flip the consumer bit")
+	}
+
+	if resp := appSetEnabled(t, d, "approval-gate", true); !resp.Ok {
+		t.Fatalf("enable: %v", protocol.Deref(resp.Error))
+	}
+	if consumer, _, _ := d.store.GetBusConsumer("app:approval-gate"); !consumer.Enabled {
+		t.Fatal("enable did not flip the consumer bit back")
+	}
+
+	facts := appFacts(t, d, FactAppEnabledChanged)
+	if len(facts) != 2 {
+		t.Fatalf("published %d enabled facts, want 2", len(facts))
+	}
+	if facts[0].Subject != "approval-gate" {
+		t.Fatalf("subject = %q, want the app name", facts[0].Subject)
+	}
+	// The payload carries which way it went: a consumer of this fact must not
+	// have to read back a bit that may already have moved again.
+	var payload appEnabledChanged
+	if err := json.Unmarshal([]byte(facts[0].Payload), &payload); err != nil {
+		t.Fatalf("decoding payload %q: %v", facts[0].Payload, err)
+	}
+	if payload.Enabled || payload.Consumer != "app:approval-gate" || payload.Name != "approval-gate" {
+		t.Fatalf("payload = %+v, want the disable", payload)
+	}
+}
+
+func TestAppRemoveKeepsHistoryAndDocuments(t *testing.T) {
+	d := newDaemonForTest(t)
+	version := seedApp(t, d, "approval-gate", true)
+	if _, err := d.store.AppendAppInvocation(store.AppInvocation{
+		AppName: "approval-gate", VersionID: version.ID, EventSeq: 12,
+		EventName: "ticket.created", Status: "ok", StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("append invocation: %v", err)
+	}
+
+	resp := appRemove(t, d, "approval-gate")
+	if !resp.Ok {
+		t.Fatalf("remove: %v", protocol.Deref(resp.Error))
+	}
+	result := resp.AppRemoveResult
+	if !result.ConsumerRemoved || result.VersionsKept != 1 || result.InvocationsKept != 1 {
+		t.Fatalf("remove result = %+v", result)
+	}
+	if result.NamespaceKept != "app/approval-gate" {
+		t.Fatalf("namespace = %q", result.NamespaceKept)
+	}
+	if _, ok, err := d.store.GetApp("approval-gate"); err != nil || ok {
+		t.Fatalf("registry row survived: ok=%t err=%v", ok, err)
+	}
+	// The consumer row going is what releases the retention floor; an orphaned
+	// enabled row would pin the whole event log against trimming.
+	if _, ok, err := d.store.GetBusConsumer("app:approval-gate"); err != nil || ok {
+		t.Fatalf("consumer row survived: ok=%t err=%v", ok, err)
+	}
+	if n, err := d.store.CountAppVersions("approval-gate"); err != nil || n != 1 {
+		t.Fatalf("versions after removal = %d (%v)", n, err)
+	}
+	facts := appFacts(t, d, FactAppRemoved)
+	if len(facts) != 1 || facts[0].Subject != "approval-gate" {
+		t.Fatalf("removal facts = %+v", facts)
+	}
+	var payload appRemoved
+	if err := json.Unmarshal([]byte(facts[0].Payload), &payload); err != nil {
+		t.Fatalf("decoding payload: %v", err)
+	}
+	if payload.Namespace != "app/approval-gate" || payload.Consumer != "app:approval-gate" {
+		t.Fatalf("payload = %+v", payload)
+	}
+}
+
+// A stray consumer with no registry row is exactly the state that needs a way
+// out: it is an enabled registration nobody serves, holding the log's retention
+// floor down.
+func TestAppRemoveCleansAConsumerWithNoRegistryRow(t *testing.T) {
+	d := newDaemonForTest(t)
+	seedAppConsumer(t, d, "orphan", true, 0)
+
+	resp := appRemove(t, d, "orphan")
+	if !resp.Ok {
+		t.Fatalf("remove: %v", protocol.Deref(resp.Error))
+	}
+	if !resp.AppRemoveResult.ConsumerRemoved {
+		t.Fatal("remove reported no consumer removed")
+	}
+	if _, ok, _ := d.store.GetBusConsumer("app:orphan"); ok {
+		t.Fatal("the stray consumer survived")
+	}
+}
+
+func TestAppCommandsOnAnUnknownNameSayWhatExists(t *testing.T) {
+	d := newDaemonForTest(t)
+	seedApp(t, d, "approval-gate", true)
+
+	for _, tc := range []struct {
+		verb string
+		resp protocol.Response
+	}{
+		{"status", appStatus(t, d, "never-installed")},
+		{"enable", appSetEnabled(t, d, "never-installed", true)},
+		{"remove", appRemove(t, d, "never-installed")},
+	} {
+		if tc.resp.Ok {
+			t.Fatalf("app %s on an unknown name succeeded", tc.verb)
+		}
+		msg := protocol.Deref(tc.resp.Error)
+		if !strings.Contains(msg, "never-installed") || !strings.Contains(msg, "approval-gate") {
+			t.Fatalf("app %s error does not name the ask and what exists: %q", tc.verb, msg)
+		}
+	}
+}
+
+// A name whose registry row is gone but whose history survives is a different
+// situation from a name that never existed, and the error says which.
+func TestAppStatusOnARemovedAppPointsAtItsRemains(t *testing.T) {
+	d := newDaemonForTest(t)
+	seedApp(t, d, "approval-gate", true)
+	if resp := appRemove(t, d, "approval-gate"); !resp.Ok {
+		t.Fatalf("remove: %v", protocol.Deref(resp.Error))
+	}
+
+	resp := appStatus(t, d, "approval-gate")
+	if resp.Ok {
+		t.Fatal("status on a removed app succeeded")
+	}
+	msg := protocol.Deref(resp.Error)
+	if !strings.Contains(msg, "1 version(s)") {
+		t.Fatalf("error does not mention the surviving history: %q", msg)
+	}
+	if !strings.Contains(msg, "no apps are registered") {
+		t.Fatalf("error does not say what is registered instead: %q", msg)
+	}
+}
+
+func TestAppStatusReportsHistoryAndRecentInvocations(t *testing.T) {
+	d := newDaemonForTest(t)
+	version := seedApp(t, d, "approval-gate", false)
+	base := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	for i, status := range []string{"ok", "error"} {
+		failure := ""
+		if status == "error" {
+			failure = "TypeError: undefined is not a function"
+		}
+		if _, err := d.store.AppendAppInvocation(store.AppInvocation{
+			AppName: "approval-gate", VersionID: version.ID, EventSeq: int64(10 + i),
+			EventName: "ticket.created", EventSubject: "t-1", Handler: "ticket.*",
+			Status: status, Error: failure, Duration: 5 * time.Millisecond,
+			StartedAt: base.Add(time.Duration(i) * time.Second),
+		}); err != nil {
+			t.Fatalf("append invocation: %v", err)
+		}
+	}
+
+	resp := appStatus(t, d, "approval-gate")
+	if !resp.Ok {
+		t.Fatalf("status: %v", protocol.Deref(resp.Error))
+	}
+	result := resp.AppStatusResult
+	if result.Versions != 1 || result.Invocations != 2 {
+		t.Fatalf("history = %d version(s), %d invocation(s)", result.Versions, result.Invocations)
+	}
+	if len(result.Recent) != 2 || result.Recent[0].Status != "error" {
+		t.Fatalf("recent = %+v, want the newest first", result.Recent)
+	}
+	if result.Recent[0].VersionID != int(version.ID) || result.Recent[0].EventSeq != 11 {
+		t.Fatalf("recent[0] = %+v", result.Recent[0])
+	}
+	if result.App.Consumer == nil || result.App.Consumer.Enabled {
+		t.Fatalf("consumer = %+v, want a disabled one", result.App.Consumer)
+	}
+}
+
+func TestAppCommandsRefuseAnInvalidName(t *testing.T) {
+	d := newDaemonForTest(t)
+	for _, resp := range []protocol.Response{
+		appStatus(t, d, "Approval Gate"),
+		appSetEnabled(t, d, "Approval Gate", true),
+		appRemove(t, d, "Approval Gate"),
+	} {
+		if resp.Ok {
+			t.Fatal("an invalid app name was accepted")
+		}
+		if !strings.Contains(protocol.Deref(resp.Error), "lowercase") {
+			t.Fatalf("error does not say what a name may contain: %q", protocol.Deref(resp.Error))
+		}
+	}
+}

--- a/internal/daemon/apps_test.go
+++ b/internal/daemon/apps_test.go
@@ -49,7 +49,7 @@ func seedAppConsumer(t *testing.T, d *Daemon, name string, enabled bool, cursor 
 	// SaveBusConsumer deliberately never rewrites an existing row's cursor or
 	// enabled bit — re-registering at startup must neither rewind a consumer nor
 	// resurrect one the operator killed — so the seed sets both explicitly.
-	if err := d.store.SetBusConsumerEnabled(apps.ConsumerName(name), enabled, time.Now()); err != nil {
+	if _, err := d.store.SetBusConsumerEnabled(apps.ConsumerName(name), enabled, time.Now()); err != nil {
 		t.Fatalf("seed consumer bit for %s: %v", name, err)
 	}
 	if err := d.store.SetBusConsumerCursor(apps.ConsumerName(name), cursor, time.Now()); err != nil {

--- a/internal/daemon/bus.go
+++ b/internal/daemon/bus.go
@@ -243,6 +243,24 @@ const (
 	// next arbitrary write. Like the other document facts it has no entry in
 	// wireProjections.
 	FactDocumentCollectionRedeclared = "document.collection.redeclared"
+
+	// App registry facts; subject is the app's name.
+	//
+	// Neither has an entry in wireProjections, and that is not an omission: the
+	// app registry has no UI surface, so these produce no WebSocket traffic. They
+	// exist because the runtime has to hear about a state change it did not make
+	// — an app disabled from the CLI, or by the auto-disable clock, has to reach
+	// the loop that dispatches its handlers, and the log is how one part of the
+	// daemon tells another something happened.
+	//
+	// FactAppEnabledChanged: the app's bus consumer bit was flipped. The payload
+	// carries which way, so a consumer of this fact does not have to read back a
+	// bit that may already have moved again.
+	FactAppEnabledChanged = "app.enabled.changed"
+	// FactAppRemoved: the app was uninstalled — consumer stopped and deleted,
+	// registry row gone. It carries a payload rather than only a subject because
+	// the entity it describes no longer exists to be read.
+	FactAppRemoved = "app.removed"
 )
 
 // CompactableFacts are the fact classes the retention pass may reduce to one

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -157,6 +157,12 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdDocQuery:       commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdDocCount:       commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdDocSubscribe:   commandMetadata(ScopeHubLocal, false, true),
+	// The app registry is the daemon's own database and its own bus, so a hub
+	// answers these itself. None touches a PTY, so none blocks during recovery.
+	protocol.CmdAppList:       commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdAppStatus:     commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdAppSetEnabled: commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdAppRemove:     commandMetadata(ScopeHubLocal, false, true),
 }
 
 func shouldLogWSCommand(cmd string) bool {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2428,6 +2428,14 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 	// caller disconnects, rather than answering once.
 	case protocol.CmdDocSubscribe: // wire: doc_subscribe
 		d.handleDocSubscribe(conn, msg.(*protocol.DocSubscribeMessage))
+	case protocol.CmdAppList: // wire: app_list
+		d.handleAppList(conn, msg.(*protocol.AppListMessage))
+	case protocol.CmdAppStatus: // wire: app_status
+		d.handleAppStatus(conn, msg.(*protocol.AppStatusMessage))
+	case protocol.CmdAppSetEnabled: // wire: app_set_enabled
+		d.handleAppSetEnabled(conn, msg.(*protocol.AppSetEnabledMessage))
+	case protocol.CmdAppRemove: // wire: app_remove
+		d.handleAppRemove(conn, msg.(*protocol.AppRemoveMessage))
 	case protocol.CmdTicketCreate: // wire: ticket_create
 		d.handleTicketCreate(conn, msg.(*protocol.TicketCreateMessage))
 	case protocol.CmdTicketComment: // wire: ticket_comment

--- a/internal/daemon/documents_facts_test.go
+++ b/internal/daemon/documents_facts_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/victorarias/attn/internal/store"
 )
 
-// The document store's facts are a contract: extensions read this log, and a
+// The document store's facts are a contract: apps read this log, and a
 // consumer that parses `document.changed` must keep working across releases.
 // These pin the name, the subject's shape, the payload, and — the part that is
 // not visible from either side alone — that the fact and the write it describes

--- a/internal/daemon/documents_test.go
+++ b/internal/daemon/documents_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	testDocNS   = "ext/approval-gate"
+	testDocNS   = "app/approval-gate"
 	testDocColl = "requests"
 )
 
@@ -302,7 +302,7 @@ func TestASubscriptionOnlyWakesForItsOwnCollection(t *testing.T) {
 		d.handleDocDefine(c, &protocol.DocDefineMessage{
 			Cmd: protocol.CmdDocDefine,
 			Schema: protocol.DocumentCollectionSchema{
-				Namespace: "ext/other", Collection: testDocColl,
+				Namespace: "app/other", Collection: testDocColl,
 				Fields: []protocol.DocumentFieldSpec{{Name: "status", Type: "string"}},
 			},
 		})
@@ -318,7 +318,7 @@ func TestASubscriptionOnlyWakesForItsOwnCollection(t *testing.T) {
 	// had woken us, this delivery would be revision 3.
 	if r := docCall(t, func(c net.Conn) {
 		d.handleDocPut(c, &protocol.DocPutMessage{
-			Cmd: protocol.CmdDocPut, Namespace: "ext/other", Collection: testDocColl,
+			Cmd: protocol.CmdDocPut, Namespace: "app/other", Collection: testDocColl,
 			ID: "theirs", Body: `{"status":"pending"}`,
 		})
 	}); !r.Ok {

--- a/internal/docstore/docstore.go
+++ b/internal/docstore/docstore.go
@@ -11,11 +11,11 @@
 // a database.
 //
 // The query object is deliberately serializable end to end. Three surfaces will
-// eventually carry it — the Bun sidecar's SDK, extension UI, and `attn doc` —
+// eventually carry it — the Bun sidecar's SDK, app UI, and `attn doc` —
 // and all three must carry the same thing, so a later transport adds transport
 // and not semantics.
 //
-// The store knows nothing about extensions. A namespace is an opaque
+// The store knows nothing about apps. A namespace is an opaque
 // `owner/name` string; who may write under which owner is enforced where the
 // namespace is granted, not here.
 //
@@ -300,7 +300,7 @@ type Compiled struct {
 
 var (
 	// A namespace is `owner/name`: the owner segment is the isolation class a
-	// grant hands out (`ext`, `core`), the name segment identifies the holder.
+	// grant hands out (`app`, `core`), the name segment identifies the holder.
 	namePart      = `[a-z0-9][a-z0-9_-]*`
 	namespaceRe   = regexp.MustCompile(`^` + namePart + `/` + namePart + `$`)
 	collectionRe  = regexp.MustCompile(`^` + namePart + `$`)
@@ -388,10 +388,10 @@ func quoteIdent(name string) string {
 // can index and a person can read.
 func ValidateNamespace(ns string) error {
 	if ns == "" {
-		return fmt.Errorf("docstore: namespace is required, as owner/name (for example ext/approval-gate)")
+		return fmt.Errorf("docstore: namespace is required, as owner/name (for example app/approval-gate)")
 	}
 	if !namespaceRe.MatchString(ns) {
-		return fmt.Errorf("docstore: namespace %q is not owner/name, where each part is lowercase letters, digits, - or _ (for example ext/approval-gate)", ns)
+		return fmt.Errorf("docstore: namespace %q is not owner/name, where each part is lowercase letters, digits, - or _ (for example app/approval-gate)", ns)
 	}
 	return nil
 }

--- a/internal/docstore/docstore_test.go
+++ b/internal/docstore/docstore_test.go
@@ -8,7 +8,7 @@ import (
 
 func requestsSchema() CollectionSchema {
 	return CollectionSchema{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Fields: []FieldSpec{
 			{Name: "status", Type: FieldString},
@@ -38,7 +38,7 @@ func mustCompile(t *testing.T, q Query, anchor ...*Document) Compiled {
 // compiles to a bounded scan within one collection.
 func TestPendingRequestsNewestFirstCompiles(t *testing.T) {
 	c := mustCompile(t, Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Filters:    []Filter{{Field: "status", Op: OpEq, Value: "pending"}},
 		Sort:       &Sort{Field: FieldCreatedAt, Desc: true},
@@ -70,7 +70,7 @@ func TestPendingRequestsNewestFirstCompiles(t *testing.T) {
 // against.
 func TestEverySortIsMadeTotalByTheDocumentID(t *testing.T) {
 	c := mustCompile(t, Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Sort:       &Sort{Field: "status"},
 	})
@@ -78,7 +78,7 @@ func TestEverySortIsMadeTotalByTheDocumentID(t *testing.T) {
 		t.Fatalf("order = %q", c.Order)
 	}
 	c = mustCompile(t, Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Sort:       &Sort{Field: "status", Desc: true},
 	})
@@ -86,7 +86,7 @@ func TestEverySortIsMadeTotalByTheDocumentID(t *testing.T) {
 		t.Fatalf("descending order = %q", c.Order)
 	}
 	// And an unsorted query is still deterministic.
-	if c := mustCompile(t, Query{Namespace: "ext/approval-gate", Collection: "requests"}); c.Order != "id ASC" {
+	if c := mustCompile(t, Query{Namespace: "app/approval-gate", Collection: "requests"}); c.Order != "id ASC" {
 		t.Fatalf("default order = %q", c.Order)
 	}
 }
@@ -95,7 +95,7 @@ func TestEverySortIsMadeTotalByTheDocumentID(t *testing.T) {
 // "newest first" and "changed since" need no schema.
 func TestReservedTimestampsAreQueryableWithoutDeclaration(t *testing.T) {
 	c := mustCompile(t, Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Filters:    []Filter{{Field: FieldUpdatedAt, Op: OpGt, Value: "2026-08-03T00:00:00Z"}},
 	})
@@ -122,7 +122,7 @@ func TestACollectionCannotDeclareAReservedName(t *testing.T) {
 // offer — the reader has to be able to fix the query from the error alone.
 func TestQueryingAnUndeclaredFieldSaysWhatIsQueryable(t *testing.T) {
 	_, err := Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Filters:    []Filter{{Field: "priority", Op: OpEq, Value: "high"}},
 	}.Compile(requestsSchema(), nil)
@@ -136,7 +136,7 @@ func TestQueryingAnUndeclaredFieldSaysWhatIsQueryable(t *testing.T) {
 	}
 	// The same rule applies to sorting, and the error says which one was wrong.
 	_, err = Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Sort:       &Sort{Field: "priority"},
 	}.Compile(requestsSchema(), nil)
@@ -160,7 +160,7 @@ func TestAFilterBoundMustMatchTheDeclaredType(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := Query{
-				Namespace:  "ext/approval-gate",
+				Namespace:  "app/approval-gate",
 				Collection: "requests",
 				Filters:    []Filter{{Field: tc.field, Op: OpEq, Value: tc.value}},
 			}.Compile(requestsSchema(), nil)
@@ -178,7 +178,7 @@ func TestAFilterBoundMustMatchTheDeclaredType(t *testing.T) {
 // bind as the 1/0 json_extract yields.
 func TestBoundsBindTheWayJSONExtractCompares(t *testing.T) {
 	c := mustCompile(t, Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Filters: []Filter{
 			{Field: "attempts", Op: OpGte, Value: 3},
@@ -196,7 +196,7 @@ func TestBoundsBindTheWayJSONExtractCompares(t *testing.T) {
 // A query decoded from JSON is the same query — this is the representation the
 // sidecar, the UI, and the CLI all carry.
 func TestAQueryRoundTripsThroughJSON(t *testing.T) {
-	raw := `{"namespace":"ext/approval-gate","collection":"requests",
+	raw := `{"namespace":"app/approval-gate","collection":"requests",
 	         "filters":[{"field":"attempts","op":"gte","value":2}],
 	         "sort":{"field":"created_at","desc":true},"limit":5}`
 	var q Query
@@ -219,10 +219,10 @@ func TestAQueryRoundTripsThroughJSON(t *testing.T) {
 // wire message with no ceiling. Asking past the maximum names both numbers and
 // the way out.
 func TestLimitDefaultsAndItsCeilingNamesTheAsk(t *testing.T) {
-	if c := mustCompile(t, Query{Namespace: "ext/approval-gate", Collection: "requests"}); c.Limit != DefaultLimit {
+	if c := mustCompile(t, Query{Namespace: "app/approval-gate", Collection: "requests"}); c.Limit != DefaultLimit {
 		t.Fatalf("default limit = %d, want %d", c.Limit, DefaultLimit)
 	}
-	_, err := Query{Namespace: "ext/approval-gate", Collection: "requests", Limit: MaxLimit + 1}.Compile(requestsSchema(), nil)
+	_, err := Query{Namespace: "app/approval-gate", Collection: "requests", Limit: MaxLimit + 1}.Compile(requestsSchema(), nil)
 	if err == nil {
 		t.Fatal("a limit above the maximum was accepted")
 	}
@@ -237,12 +237,12 @@ func TestLimitDefaultsAndItsCeilingNamesTheAsk(t *testing.T) {
 // not which owners exist — who may write under an owner is enforced where the
 // namespace is granted.
 func TestNamespaceShapeIsTwoParts(t *testing.T) {
-	for _, ok := range []string{"ext/approval-gate", "core/tickets", "ext/a"} {
+	for _, ok := range []string{"app/approval-gate", "core/tickets", "app/a"} {
 		if err := ValidateNamespace(ok); err != nil {
 			t.Fatalf("%q rejected: %v", ok, err)
 		}
 	}
-	for _, bad := range []string{"", "approval-gate", "ext/", "/name", "Ext/Name", "ext/a/b", "ext name/x"} {
+	for _, bad := range []string{"", "approval-gate", "app/", "/name", "App/Name", "app/a/b", "ext name/x"} {
 		if err := ValidateNamespace(bad); err == nil {
 			t.Fatalf("%q accepted", bad)
 		}
@@ -278,7 +278,7 @@ func TestBodyMustBeAJSONObject(t *testing.T) {
 // and refusing it is what keeps a caller from reading one collection under
 // another's rules.
 func TestAQueryWillNotCompileAgainstAnotherCollectionsDeclaration(t *testing.T) {
-	_, err := Query{Namespace: "ext/other", Collection: "requests"}.Compile(requestsSchema(), nil)
+	_, err := Query{Namespace: "app/other", Collection: "requests"}.Compile(requestsSchema(), nil)
 	if err == nil {
 		t.Fatal("mismatched declaration was accepted")
 	}
@@ -302,7 +302,7 @@ func equalArgs(got, want []any) bool {
 func TestTheAfterCursorComparesTheWholeOrderingTuple(t *testing.T) {
 	anchor := &Document{ID: "b", Body: []byte(`{"attempts":7}`)}
 	c := mustCompile(t, Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Sort:       &Sort{Field: "attempts"},
 		After:      "b",
@@ -322,7 +322,7 @@ func TestTheAfterCursorComparesTheWholeOrderingTuple(t *testing.T) {
 	// Descending flips both comparisons, and admits the NULLs the descending
 	// order puts last.
 	c = mustCompile(t, Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Sort:       &Sort{Field: "attempts", Desc: true},
 		After:      "b",
@@ -336,7 +336,7 @@ func TestTheAfterCursorComparesTheWholeOrderingTuple(t *testing.T) {
 // An unsorted query's whole order is the id, so its cursor is that one column.
 func TestTheAfterCursorOfAnUnsortedQueryIsTheID(t *testing.T) {
 	c := mustCompile(t, Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		After:      "b",
 	}, &Document{ID: "b", Body: []byte(`{}`)})
@@ -349,7 +349,7 @@ func TestTheAfterCursorOfAnUnsortedQueryIsTheID(t *testing.T) {
 // "end of results", which is a silent truncation of the caller's walk.
 func TestAnAfterCursorWithNoDocumentIsAnError(t *testing.T) {
 	_, err := Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Sort:       &Sort{Field: "attempts"},
 		After:      "vanished",
@@ -365,7 +365,7 @@ func TestAnAfterCursorWithNoDocumentIsAnError(t *testing.T) {
 	// And an anchor that is not the document the cursor named is a caller bug,
 	// not a page: it would silently return the wrong slice.
 	_, err = Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		After:      "b",
 	}.Compile(requestsSchema(), &Document{ID: "c", Body: []byte(`{}`)})
@@ -378,7 +378,7 @@ func TestAnAfterCursorWithNoDocumentIsAnError(t *testing.T) {
 // to suggest is exactly the thing that breaks on ties.
 func TestTheLimitCeilingPointsAtTheCursor(t *testing.T) {
 	_, err := Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Limit:      MaxLimit + 1,
 	}.Compile(requestsSchema(), nil)
@@ -394,7 +394,7 @@ func TestTheLimitCeilingPointsAtTheCursor(t *testing.T) {
 func TestAQueryWillNotCompileWithoutAMintedTable(t *testing.T) {
 	bare := requestsSchema()
 	bare.Table = ""
-	if _, err := (Query{Namespace: "ext/approval-gate", Collection: "requests"}).Compile(bare, nil); err == nil {
+	if _, err := (Query{Namespace: "app/approval-gate", Collection: "requests"}).Compile(bare, nil); err == nil {
 		t.Fatal("a declaration with no table compiled")
 	}
 	for _, forged := range []string{
@@ -406,7 +406,7 @@ func TestAQueryWillNotCompileWithoutAMintedTable(t *testing.T) {
 	} {
 		s := requestsSchema()
 		s.Table = forged
-		if _, err := (Query{Namespace: "ext/approval-gate", Collection: "requests"}).Compile(s, nil); err == nil {
+		if _, err := (Query{Namespace: "app/approval-gate", Collection: "requests"}).Compile(s, nil); err == nil {
 			t.Fatalf("table name %q compiled", forged)
 		}
 	}

--- a/internal/docstore/timestamps_test.go
+++ b/internal/docstore/timestamps_test.go
@@ -90,7 +90,7 @@ func TestATimestampBoundIsReEncodedBeforeItIsCompared(t *testing.T) {
 		"2026-08-05T12:00:00+02:00",
 	} {
 		c := mustCompile(t, Query{
-			Namespace:  "ext/approval-gate",
+			Namespace:  "app/approval-gate",
 			Collection: "requests",
 			Filters:    []Filter{{Field: FieldUpdatedAt, Op: OpGte, Value: form}},
 		})
@@ -108,12 +108,12 @@ func TestATimestampBoundIsReEncodedBeforeItIsCompared(t *testing.T) {
 func TestATimestampBoundEncodesTheSameFromAStringOrATime(t *testing.T) {
 	at := time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC)
 	fromTime := mustCompile(t, Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Filters:    []Filter{{Field: FieldCreatedAt, Op: OpGte, Value: at}},
 	})
 	fromString := mustCompile(t, Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Filters:    []Filter{{Field: FieldCreatedAt, Op: OpGte, Value: at.Format(time.RFC3339)}},
 	})
@@ -127,7 +127,7 @@ func TestATimestampBoundEncodesTheSameFromAStringOrATime(t *testing.T) {
 // caller mistake, and the error has to be enough to fix it.
 func TestATimestampBoundThatIsNotATimestampIsRefused(t *testing.T) {
 	_, err := Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Filters:    []Filter{{Field: FieldUpdatedAt, Op: OpGt, Value: "yesterday"}},
 	}.Compile(requestsSchema(), nil)

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "216"
+const ProtocolVersion = "217"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only
@@ -114,6 +114,10 @@ const (
 	CmdDocQuery                              = "doc_query"
 	CmdDocCount                              = "doc_count"
 	CmdDocSubscribe                          = "doc_subscribe"
+	CmdAppList                               = "app_list"
+	CmdAppStatus                             = "app_status"
+	CmdAppSetEnabled                         = "app_set_enabled"
+	CmdAppRemove                             = "app_remove"
 	CmdGetTicket                             = "get_ticket"
 	CmdTicketChangeStatus                    = "ticket_change_status"
 	CmdTicketAddComment                      = "ticket_add_comment"
@@ -698,6 +702,34 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdDocSubscribe:
 		var msg DocSubscribeMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAppList:
+		var msg AppListMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAppStatus:
+		var msg AppStatusMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAppSetEnabled:
+		var msg AppSetEnabledMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAppRemove:
+		var msg AppRemoveMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -44,6 +44,165 @@ type AgentPromptMessage struct {
 	Text string `json:"text"`
 }
 
+type AppConsumerInfo struct {
+	// Cursor corresponds to the JSON schema field "cursor".
+	Cursor int `json:"cursor"`
+
+	// Enabled corresponds to the JSON schema field "enabled".
+	Enabled bool `json:"enabled"`
+
+	// Filter corresponds to the JSON schema field "filter".
+	Filter string `json:"filter"`
+
+	// Lag corresponds to the JSON schema field "lag".
+	Lag int `json:"lag"`
+
+	// Name corresponds to the JSON schema field "name".
+	Name string `json:"name"`
+}
+
+type AppInvocationInfo struct {
+	// DurationMs corresponds to the JSON schema field "duration_ms".
+	DurationMs int `json:"duration_ms"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error string `json:"error"`
+
+	// EventName corresponds to the JSON schema field "event_name".
+	EventName string `json:"event_name"`
+
+	// EventSeq corresponds to the JSON schema field "event_seq".
+	EventSeq int `json:"event_seq"`
+
+	// EventSubject corresponds to the JSON schema field "event_subject".
+	EventSubject string `json:"event_subject"`
+
+	// Handler corresponds to the JSON schema field "handler".
+	Handler string `json:"handler"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID int `json:"id"`
+
+	// StartedAt corresponds to the JSON schema field "started_at".
+	StartedAt string `json:"started_at"`
+
+	// Status corresponds to the JSON schema field "status".
+	Status string `json:"status"`
+
+	// VersionID corresponds to the JSON schema field "version_id".
+	VersionID int `json:"version_id"`
+}
+
+type AppListMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+}
+
+type AppListResult struct {
+	// Apps corresponds to the JSON schema field "apps".
+	Apps []AppSummary `json:"apps"`
+}
+
+type AppRemoveMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Name corresponds to the JSON schema field "name".
+	Name string `json:"name"`
+}
+
+type AppRemoveResult struct {
+	// ConsumerRemoved corresponds to the JSON schema field "consumer_removed".
+	ConsumerRemoved bool `json:"consumer_removed"`
+
+	// InvocationsKept corresponds to the JSON schema field "invocations_kept".
+	InvocationsKept int `json:"invocations_kept"`
+
+	// Name corresponds to the JSON schema field "name".
+	Name string `json:"name"`
+
+	// NamespaceKept corresponds to the JSON schema field "namespace_kept".
+	NamespaceKept string `json:"namespace_kept"`
+
+	// VersionsKept corresponds to the JSON schema field "versions_kept".
+	VersionsKept int `json:"versions_kept"`
+}
+
+type AppSetEnabledMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Enabled corresponds to the JSON schema field "enabled".
+	Enabled bool `json:"enabled"`
+
+	// Name corresponds to the JSON schema field "name".
+	Name string `json:"name"`
+}
+
+type AppSetEnabledResult struct {
+	// Consumer corresponds to the JSON schema field "consumer".
+	Consumer string `json:"consumer"`
+
+	// Enabled corresponds to the JSON schema field "enabled".
+	Enabled bool `json:"enabled"`
+
+	// Name corresponds to the JSON schema field "name".
+	Name string `json:"name"`
+}
+
+type AppStatusMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Name corresponds to the JSON schema field "name".
+	Name string `json:"name"`
+}
+
+type AppStatusResult struct {
+	// App corresponds to the JSON schema field "app".
+	App AppSummary `json:"app"`
+
+	// Invocations corresponds to the JSON schema field "invocations".
+	Invocations int `json:"invocations"`
+
+	// Recent corresponds to the JSON schema field "recent".
+	Recent []AppInvocationInfo `json:"recent,omitempty,omitzero"`
+
+	// Versions corresponds to the JSON schema field "versions".
+	Versions int `json:"versions"`
+}
+
+type AppSummary struct {
+	// Consumer corresponds to the JSON schema field "consumer".
+	Consumer *AppConsumerInfo `json:"consumer,omitempty,omitzero"`
+
+	// CreatedAt corresponds to the JSON schema field "created_at".
+	CreatedAt string `json:"created_at"`
+
+	// CurrentVersion corresponds to the JSON schema field "current_version".
+	CurrentVersion *AppVersionInfo `json:"current_version,omitempty,omitzero"`
+
+	// Name corresponds to the JSON schema field "name".
+	Name string `json:"name"`
+
+	// UpdatedAt corresponds to the JSON schema field "updated_at".
+	UpdatedAt string `json:"updated_at"`
+}
+
+type AppVersionInfo struct {
+	// ArtifactPath corresponds to the JSON schema field "artifact_path".
+	ArtifactPath string `json:"artifact_path"`
+
+	// ContentHash corresponds to the JSON schema field "content_hash".
+	ContentHash string `json:"content_hash"`
+
+	// CreatedAt corresponds to the JSON schema field "created_at".
+	CreatedAt string `json:"created_at"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID int `json:"id"`
+}
+
 type ApprovePRMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -4230,6 +4389,19 @@ type ReposUpdatedMessage struct {
 }
 
 type Response struct {
+	// AppListResult corresponds to the JSON schema field "app_list_result".
+	AppListResult *AppListResult `json:"app_list_result,omitempty,omitzero"`
+
+	// AppRemoveResult corresponds to the JSON schema field "app_remove_result".
+	AppRemoveResult *AppRemoveResult `json:"app_remove_result,omitempty,omitzero"`
+
+	// AppSetEnabledResult corresponds to the JSON schema field
+	// "app_set_enabled_result".
+	AppSetEnabledResult *AppSetEnabledResult `json:"app_set_enabled_result,omitempty,omitzero"`
+
+	// AppStatusResult corresponds to the JSON schema field "app_status_result".
+	AppStatusResult *AppStatusResult `json:"app_status_result,omitempty,omitzero"`
+
 	// Authors corresponds to the JSON schema field "authors".
 	Authors []AuthorState `json:"authors,omitempty,omitzero"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -3755,6 +3755,128 @@ model DocSubscribeResult {
 }
 
 // ============================================================================
+// App registry
+// ============================================================================
+//
+// An app is a manifest-declared automation running in attn's shared runtime: it
+// consumes facts from the durable bus as its own consumer `app:<name>`, keeps
+// state in the document namespace `app/<name>`, and is versioned by the content
+// hash of its built artifact. A plugin is the other thing entirely — an
+// integration with its own process — and the two never share a surface.
+//
+// These commands are the half that reads and flips the registry. Applying,
+// rolling back and scaffolding an app arrive with the pipeline that builds one.
+
+// One app as `attn app list` shows it: the registry row, plus the consumer that
+// carries its enabled state. There is no enabled field on the app itself —
+// enabled IS the consumer's bit, and a second copy here would be a value that
+// can disagree with the one the bus actually reads.
+model AppSummary {
+  "name": string;
+  // The version this app currently runs. Absent when no version has been
+  // applied yet: a registry row can exist ahead of its first successful build.
+  "current_version"?: AppVersionInfo;
+  "created_at": string;
+  "updated_at": string;
+  // Absent when the app has no `app:<name>` consumer registered. That is a real
+  // state, not a gap in the answer: it means nothing is delivering facts to
+  // this app.
+  "consumer"?: AppConsumerInfo;
+}
+
+model AppVersionInfo {
+  "id": safeint;
+  // The content hash of the built artifact — the version's identity, which is
+  // why re-applying byte-identical content reports this same version.
+  "content_hash": string;
+  "artifact_path": string;
+  "created_at": string;
+}
+
+// The bus consumer behind an app. `enabled` is the app's enabled state, `lag` is
+// head minus cursor: how many facts the app has yet to be delivered.
+model AppConsumerInfo {
+  "name": string;
+  "enabled": boolean;
+  "cursor": safeint;
+  "lag": safeint;
+  "filter": string;
+}
+
+model AppListMessage {
+  "cmd": "app_list";
+}
+
+model AppListResult {
+  "apps": AppSummary[];
+}
+
+model AppStatusMessage {
+  "cmd": "app_status";
+  "name": string;
+}
+
+// What is known about one app, and only what is known: the registry row, the
+// consumer if there is one, and the invocations recorded so far. Fields the
+// runtime owns are absent until the runtime exists — an app's status must not
+// claim a health it cannot observe.
+model AppStatusResult {
+  "app": AppSummary;
+  "versions": safeint;
+  "invocations": safeint;
+  // The most recent invocations, newest first, when any have been recorded.
+  "recent"?: AppInvocationInfo[];
+}
+
+model AppInvocationInfo {
+  "id": safeint;
+  // The version that actually ran, which is not necessarily the one the app
+  // points at now — a rollback does not rewrite what happened.
+  "version_id": safeint;
+  "event_seq": safeint;
+  "event_name": string;
+  "event_subject": string;
+  "handler": string;
+  "status": string;
+  "error": string;
+  "duration_ms": safeint;
+  "started_at": string;
+}
+
+// Flip an app's enabled state, which is its bus consumer's enabled bit and
+// nothing else. Refused when the app has no consumer: there is no state to flip,
+// and inventing one would leave the app looking enabled while nothing delivers
+// to it.
+model AppSetEnabledMessage {
+  "cmd": "app_set_enabled";
+  "name": string;
+  "enabled": boolean;
+}
+
+model AppSetEnabledResult {
+  "name": string;
+  "consumer": string;
+  "enabled": boolean;
+}
+
+// Uninstall an app: stop and delete its bus consumer, then delete its registry
+// row. What survives is deliberate — version history, the invocation log, and
+// every document under `app/<name>`. The result counts them so the answer says
+// what was kept rather than leaving the caller to guess.
+model AppRemoveMessage {
+  "cmd": "app_remove";
+  "name": string;
+}
+
+model AppRemoveResult {
+  "name": string;
+  "consumer_removed": boolean;
+  "versions_kept": safeint;
+  "invocations_kept": safeint;
+  "namespace_kept": string;
+}
+
+// ============================================================================
 // Response Types
 // ============================================================================
 
@@ -3813,6 +3935,10 @@ model Response {
   doc_query_result?: DocQueryResult;
   doc_count_result?: DocCountResult;
   doc_subscribe_result?: DocSubscribeResult;
+  app_list_result?: AppListResult;
+  app_status_result?: AppStatusResult;
+  app_set_enabled_result?: AppSetEnabledResult;
+  app_remove_result?: AppRemoveResult;
 }
 
 // One recorded state observation and its fate. Outcome separates the ways an

--- a/internal/store/apps.go
+++ b/internal/store/apps.go
@@ -1,0 +1,421 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// The app registry's persistence (migration 96). An app is a manifest-declared,
+// bus-consuming automation running in the shared runtime; this file is the three
+// tables it lives in and nothing else — the lifecycle that stops a delivery loop
+// and the pipeline that builds an artifact are the daemon's.
+//
+// Two absences carry meaning and are load-bearing here:
+//
+//   - There is no enabled bit. An app's enabled state is its bus consumer's
+//     (`app:<name>`), because that one bit both stops delivery and releases the
+//     retention floor. Nothing in this file reads or writes it.
+//   - Removing an app removes its registry row and nothing else. Versions and
+//     invocations are history, and the documents under `app/<name>` are the
+//     user's data; deleting either is a separate, explicit act that does not
+//     exist yet, deliberately.
+//
+// See docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md.
+
+// App is one registered app. CurrentVersionID is 0 until a version has been
+// applied — a registry row can exist ahead of its first successful build.
+type App struct {
+	Name             string
+	CurrentVersionID int64
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+}
+
+// AppVersion is an immutable record of one built artifact. ContentHash is the
+// version's identity: applying byte-identical content again reuses this row
+// rather than minting a second one, which is what keeps the invocation log's
+// "which version actually ran" answerable after a long dev session.
+//
+// Declaration is the manifest's frozen snapshot as JSON text, stored rather than
+// re-read from disk so what an old version declared survives editing the
+// manifest — the automation_runs pattern.
+type AppVersion struct {
+	ID           int64
+	AppName      string
+	ContentHash  string
+	Declaration  string
+	ArtifactPath string
+	CreatedAt    time.Time
+}
+
+// AppInvocation is one handler run. VersionID is what actually ran, not the
+// pointer the app is on now, so a rollback does not rewrite history.
+//
+// The writer is the runtime (a later stage); this file gives it the append and
+// the read `attn app status` uses. Retention arrives with that writer: an age
+// window has to be measured against real invocation rates, and a number written
+// before there is anything to measure would be a limit with no receipt.
+type AppInvocation struct {
+	ID           int64
+	AppName      string
+	VersionID    int64
+	EventSeq     int64
+	EventName    string
+	EventSubject string
+	Handler      string
+	Status       string
+	Error        string
+	Duration     time.Duration
+	StartedAt    time.Time
+}
+
+// SaveApp creates a registry row, or touches an existing one. It never moves
+// current_version_id: the pointer moves only through CommitAppVersion and
+// SetAppCurrentVersion, so no caller can flip an app onto a version by accident.
+func (s *Store) SaveApp(name string, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	stamp := now.UTC().Format(sortableTimeFormat)
+	_, err := s.db.Exec(`
+		INSERT INTO apps (name, current_version_id, created_at, updated_at)
+		VALUES (?, NULL, ?, ?)
+		ON CONFLICT(name) DO UPDATE SET updated_at = excluded.updated_at
+	`, name, stamp, stamp)
+	return err
+}
+
+// GetApp loads one registry row.
+func (s *Store) GetApp(name string) (App, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return App{}, false, nil
+	}
+	app, err := scanApp(s.db.QueryRow(`
+		SELECT name, current_version_id, created_at, updated_at FROM apps WHERE name = ?
+	`, name))
+	switch err {
+	case nil:
+		return app, true, nil
+	case sql.ErrNoRows:
+		return App{}, false, nil
+	default:
+		return App{}, false, err
+	}
+}
+
+// ListApps returns every registered app, by name.
+func (s *Store) ListApps() ([]App, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.Query(`
+		SELECT name, current_version_id, created_at, updated_at FROM apps ORDER BY name ASC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []App
+	for rows.Next() {
+		app, err := scanApp(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, app)
+	}
+	return out, rows.Err()
+}
+
+// DeleteApp removes a registry row and reports whether one was there. Versions
+// and invocations are untouched: they are the record of what ran, and an
+// uninstall does not rewrite history.
+func (s *Store) DeleteApp(name string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return false, nil
+	}
+	res, err := s.db.Exec(`DELETE FROM apps WHERE name = ?`, name)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	return n > 0, err
+}
+
+// CommitAppVersion records a built version and points the app at it, in one
+// transaction. It is the whole of what apply changes: everything before it —
+// parse, codegen, typecheck, build — either produced this artifact or failed
+// having changed nothing.
+//
+// A version already recorded for this app under the same content hash is reused
+// rather than duplicated, and the returned row is that existing one. Two
+// consequences worth naming: a dev loop that rebuilds identical output leaves
+// one row, and re-applying an old build is indistinguishable from rolling back
+// to it, which is correct — they are the same artifact.
+func (s *Store) CommitAppVersion(v AppVersion, now time.Time) (AppVersion, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return AppVersion{}, nil
+	}
+	if v.AppName == "" || v.ContentHash == "" {
+		return AppVersion{}, fmt.Errorf("store: an app version needs both an app name and a content hash (got name %q, hash %q)", v.AppName, v.ContentHash)
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return AppVersion{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stamp := now.UTC().Format(sortableTimeFormat)
+	if _, err := tx.Exec(`
+		INSERT INTO apps (name, current_version_id, created_at, updated_at)
+		VALUES (?, NULL, ?, ?)
+		ON CONFLICT(name) DO UPDATE SET updated_at = excluded.updated_at
+	`, v.AppName, stamp, stamp); err != nil {
+		return AppVersion{}, err
+	}
+
+	existing, err := scanAppVersion(tx.QueryRow(`
+		SELECT id, app_name, content_hash, declaration, artifact_path, created_at
+		FROM app_versions WHERE app_name = ? AND content_hash = ?
+	`, v.AppName, v.ContentHash))
+	switch err {
+	case nil:
+		v = existing
+	case sql.ErrNoRows:
+		v.CreatedAt = now.UTC()
+		res, err := tx.Exec(`
+			INSERT INTO app_versions (app_name, content_hash, declaration, artifact_path, created_at)
+			VALUES (?, ?, ?, ?, ?)
+		`, v.AppName, v.ContentHash, v.Declaration, v.ArtifactPath, stamp)
+		if err != nil {
+			return AppVersion{}, err
+		}
+		if v.ID, err = res.LastInsertId(); err != nil {
+			return AppVersion{}, err
+		}
+	default:
+		return AppVersion{}, err
+	}
+
+	if _, err := tx.Exec(`
+		UPDATE apps SET current_version_id = ?, updated_at = ? WHERE name = ?
+	`, v.ID, stamp, v.AppName); err != nil {
+		return AppVersion{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return AppVersion{}, err
+	}
+	return v, nil
+}
+
+// SetAppCurrentVersion moves an app onto a version it already has — the pointer
+// move a rollback is. It refuses a version belonging to another app rather than
+// leaving one app pointing into another's history.
+func (s *Store) SetAppCurrentVersion(name string, versionID int64, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	var owner string
+	err := s.db.QueryRow(`SELECT app_name FROM app_versions WHERE id = ?`, versionID).Scan(&owner)
+	switch {
+	case err == sql.ErrNoRows:
+		return fmt.Errorf("store: no app version %d", versionID)
+	case err != nil:
+		return err
+	case owner != name:
+		return fmt.Errorf("store: app version %d belongs to app %q, not %q", versionID, owner, name)
+	}
+	res, err := s.db.Exec(`
+		UPDATE apps SET current_version_id = ?, updated_at = ? WHERE name = ?
+	`, versionID, now.UTC().Format(sortableTimeFormat), name)
+	if err != nil {
+		return err
+	}
+	if n, err := res.RowsAffected(); err != nil {
+		return err
+	} else if n == 0 {
+		return fmt.Errorf("store: no app named %q", name)
+	}
+	return nil
+}
+
+// GetAppVersion loads one version row.
+func (s *Store) GetAppVersion(id int64) (AppVersion, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return AppVersion{}, false, nil
+	}
+	v, err := scanAppVersion(s.db.QueryRow(`
+		SELECT id, app_name, content_hash, declaration, artifact_path, created_at
+		FROM app_versions WHERE id = ?
+	`, id))
+	switch err {
+	case nil:
+		return v, true, nil
+	case sql.ErrNoRows:
+		return AppVersion{}, false, nil
+	default:
+		return AppVersion{}, false, err
+	}
+}
+
+// ListAppVersions returns an app's versions, newest first.
+func (s *Store) ListAppVersions(name string) ([]AppVersion, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.Query(`
+		SELECT id, app_name, content_hash, declaration, artifact_path, created_at
+		FROM app_versions WHERE app_name = ? ORDER BY id DESC
+	`, name)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []AppVersion
+	for rows.Next() {
+		v, err := scanAppVersion(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return out, rows.Err()
+}
+
+// CountAppVersions reports how many versions an app has, including after its
+// registry row is gone — which is what lets `attn app remove` say what it kept.
+func (s *Store) CountAppVersions(name string) (int, error) {
+	return s.countAppRows(`SELECT COUNT(*) FROM app_versions WHERE app_name = ?`, name)
+}
+
+// CountAppInvocations reports how many invocations an app has recorded.
+func (s *Store) CountAppInvocations(name string) (int, error) {
+	return s.countAppRows(`SELECT COUNT(*) FROM app_invocations WHERE app_name = ?`, name)
+}
+
+func (s *Store) countAppRows(query, name string) (int, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return 0, nil
+	}
+	var n int
+	if err := s.db.QueryRow(query, name).Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// AppendAppInvocation records one handler run and returns its id.
+func (s *Store) AppendAppInvocation(inv AppInvocation) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return 0, nil
+	}
+	res, err := s.db.Exec(`
+		INSERT INTO app_invocations
+			(app_name, version_id, event_seq, event_name, event_subject, handler, status, error, duration_ms, started_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, inv.AppName, inv.VersionID, inv.EventSeq, inv.EventName, inv.EventSubject, inv.Handler,
+		inv.Status, inv.Error, inv.Duration.Milliseconds(), inv.StartedAt.UTC().Format(sortableTimeFormat))
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// ListAppInvocations returns an app's most recent invocations, newest first.
+func (s *Store) ListAppInvocations(name string, limit int) ([]AppInvocation, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := s.db.Query(`
+		SELECT id, app_name, version_id, event_seq, event_name, event_subject, handler,
+		       status, error, duration_ms, started_at
+		FROM app_invocations WHERE app_name = ? ORDER BY started_at DESC, id DESC LIMIT ?
+	`, name, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []AppInvocation
+	for rows.Next() {
+		var (
+			inv       AppInvocation
+			durMillis int64
+			startedAt string
+		)
+		if err := rows.Scan(&inv.ID, &inv.AppName, &inv.VersionID, &inv.EventSeq, &inv.EventName,
+			&inv.EventSubject, &inv.Handler, &inv.Status, &inv.Error, &durMillis, &startedAt); err != nil {
+			return nil, err
+		}
+		inv.Duration = time.Duration(durMillis) * time.Millisecond
+		inv.StartedAt = parseStoreTime(startedAt)
+		out = append(out, inv)
+	}
+	return out, rows.Err()
+}
+
+func scanApp(row rowScanner) (App, error) {
+	var (
+		app       App
+		versionID sql.NullInt64
+		createdAt string
+		updatedAt string
+	)
+	if err := row.Scan(&app.Name, &versionID, &createdAt, &updatedAt); err != nil {
+		return App{}, err
+	}
+	app.CurrentVersionID = versionID.Int64
+	app.CreatedAt = parseStoreTime(createdAt)
+	app.UpdatedAt = parseStoreTime(updatedAt)
+	return app, nil
+}
+
+func scanAppVersion(row rowScanner) (AppVersion, error) {
+	var (
+		v         AppVersion
+		createdAt string
+	)
+	if err := row.Scan(&v.ID, &v.AppName, &v.ContentHash, &v.Declaration, &v.ArtifactPath, &createdAt); err != nil {
+		return AppVersion{}, err
+	}
+	v.CreatedAt = parseStoreTime(createdAt)
+	return v, nil
+}

--- a/internal/store/apps_test.go
+++ b/internal/store/apps_test.go
@@ -1,0 +1,277 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// seedApps writes the registry a live profile would hold after a few applies:
+// two apps, one of them rolled back onto an older version, plus invocations
+// stamped inside one second so ordering is actually exercised.
+func seedApps(t *testing.T, s *Store, now time.Time) (older, newer AppVersion) {
+	t.Helper()
+
+	older, err := s.CommitAppVersion(AppVersion{
+		AppName:      "approval-gate",
+		ContentHash:  "sha256:1111",
+		Declaration:  `{"name":"approval-gate","subscribe":[{"events":["delegation.*"]}]}`,
+		ArtifactPath: "apps/approval-gate/1111/bundle.js",
+	}, now)
+	if err != nil {
+		t.Fatalf("commit older version: %v", err)
+	}
+	newer, err = s.CommitAppVersion(AppVersion{
+		AppName:      "approval-gate",
+		ContentHash:  "sha256:2222",
+		Declaration:  `{"name":"approval-gate","subscribe":[{"events":["delegation.*","session.state.changed"]}]}`,
+		ArtifactPath: "apps/approval-gate/2222/bundle.js",
+	}, now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("commit newer version: %v", err)
+	}
+	if _, err := s.CommitAppVersion(AppVersion{
+		AppName:      "standup-digest",
+		ContentHash:  "sha256:3333",
+		Declaration:  `{"name":"standup-digest","subscribe":[{"events":["ticket.*"]}]}`,
+		ArtifactPath: "apps/standup-digest/3333/bundle.js",
+	}, now.Add(2*time.Minute)); err != nil {
+		t.Fatalf("commit other app version: %v", err)
+	}
+	return older, newer
+}
+
+func TestApps_CommitVersionPointsTheAppAtIt(t *testing.T) {
+	s := New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	_, newer := seedApps(t, s, now)
+
+	app, ok, err := s.GetApp("approval-gate")
+	if err != nil || !ok {
+		t.Fatalf("get app: %v ok=%t", err, ok)
+	}
+	if app.CurrentVersionID != newer.ID {
+		t.Fatalf("current version = %d, want %d", app.CurrentVersionID, newer.ID)
+	}
+	if app.CreatedAt.IsZero() || app.UpdatedAt.Before(app.CreatedAt) {
+		t.Fatalf("stamps: created=%v updated=%v", app.CreatedAt, app.UpdatedAt)
+	}
+
+	versions, err := s.ListAppVersions("approval-gate")
+	if err != nil {
+		t.Fatalf("list versions: %v", err)
+	}
+	if len(versions) != 2 || versions[0].ID != newer.ID {
+		t.Fatalf("versions = %+v, want newest first", versions)
+	}
+	if versions[0].Declaration == "" || versions[0].ArtifactPath == "" {
+		t.Fatalf("version lost its snapshot: %+v", versions[0])
+	}
+}
+
+// Byte-identical content is the same version, so a dev loop that rebuilds the
+// same output leaves one row and the pointer lands back on it.
+func TestApps_IdenticalContentReusesTheVersionRow(t *testing.T) {
+	s := New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	older, _ := seedApps(t, s, now)
+
+	again, err := s.CommitAppVersion(AppVersion{
+		AppName:      "approval-gate",
+		ContentHash:  older.ContentHash,
+		Declaration:  `{"declaration":"rewritten, and ignored"}`,
+		ArtifactPath: "apps/approval-gate/1111/rebuilt.js",
+	}, now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("re-commit: %v", err)
+	}
+	if again.ID != older.ID {
+		t.Fatalf("re-apply minted version %d, want the existing %d", again.ID, older.ID)
+	}
+	// The row is immutable: what came back is what was stored the first time,
+	// not the snapshot this call carried.
+	if again.Declaration != older.Declaration || again.ArtifactPath != older.ArtifactPath {
+		t.Fatalf("re-apply rewrote the version row: %+v", again)
+	}
+	if n, err := s.CountAppVersions("approval-gate"); err != nil || n != 2 {
+		t.Fatalf("versions = %d (%v), want 2", n, err)
+	}
+	app, _, err := s.GetApp("approval-gate")
+	if err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if app.CurrentVersionID != older.ID {
+		t.Fatalf("current version = %d, want the reused %d", app.CurrentVersionID, older.ID)
+	}
+}
+
+func TestApps_RollbackMovesThePointerOnly(t *testing.T) {
+	s := New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	older, newer := seedApps(t, s, now)
+
+	if err := s.SetAppCurrentVersion("approval-gate", older.ID, now.Add(time.Hour)); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	app, _, err := s.GetApp("approval-gate")
+	if err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if app.CurrentVersionID != older.ID {
+		t.Fatalf("current version = %d, want %d", app.CurrentVersionID, older.ID)
+	}
+	if n, err := s.CountAppVersions("approval-gate"); err != nil || n != 2 {
+		t.Fatalf("rollback changed the history: %d versions (%v)", n, err)
+	}
+
+	// A version belonging to another app is refused rather than leaving one app
+	// pointing into another's history.
+	otherVersions, err := s.ListAppVersions("standup-digest")
+	if err != nil || len(otherVersions) != 1 {
+		t.Fatalf("other app versions: %v %+v", err, otherVersions)
+	}
+	if err := s.SetAppCurrentVersion("approval-gate", otherVersions[0].ID, now); err == nil {
+		t.Fatal("rollback onto another app's version was accepted")
+	}
+	if err := s.SetAppCurrentVersion("approval-gate", newer.ID+9999, now); err == nil {
+		t.Fatal("rollback onto a version that does not exist was accepted")
+	}
+}
+
+// Removal takes the registry row and nothing else: versions and invocations are
+// history, and `attn app remove` says so by counting what it kept.
+func TestApps_DeleteKeepsVersionsAndInvocations(t *testing.T) {
+	s := New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	_, newer := seedApps(t, s, now)
+
+	if _, err := s.AppendAppInvocation(AppInvocation{
+		AppName: "approval-gate", VersionID: newer.ID, EventSeq: 4201,
+		EventName: "delegation.requested", EventSubject: "del-7", Handler: "delegation.*",
+		Status: "ok", Duration: 12 * time.Millisecond, StartedAt: now,
+	}); err != nil {
+		t.Fatalf("append invocation: %v", err)
+	}
+
+	existed, err := s.DeleteApp("approval-gate")
+	if err != nil || !existed {
+		t.Fatalf("delete: %v existed=%t", err, existed)
+	}
+	if _, ok, err := s.GetApp("approval-gate"); err != nil || ok {
+		t.Fatalf("app survived removal: ok=%t err=%v", ok, err)
+	}
+	if n, err := s.CountAppVersions("approval-gate"); err != nil || n != 2 {
+		t.Fatalf("versions after removal = %d (%v), want 2", n, err)
+	}
+	if n, err := s.CountAppInvocations("approval-gate"); err != nil || n != 1 {
+		t.Fatalf("invocations after removal = %d (%v), want 1", n, err)
+	}
+	if existed, err := s.DeleteApp("approval-gate"); err != nil || existed {
+		t.Fatalf("second delete reported existed=%t (%v)", existed, err)
+	}
+}
+
+// Invocations come back newest first even when several land inside one second:
+// started_at is stored fixed-width, so text order is time order.
+func TestApps_InvocationsListNewestFirstWithinOneSecond(t *testing.T) {
+	s := New()
+	base := time.Date(2026, 8, 9, 10, 30, 0, 0, time.UTC)
+	_, newer := seedApps(t, s, base)
+
+	for i, offset := range []time.Duration{0, 250 * time.Millisecond, 900 * time.Millisecond} {
+		status, failure := "ok", ""
+		if i == 2 {
+			status, failure = "error", "TypeError: cannot read property 'id' of undefined"
+		}
+		if _, err := s.AppendAppInvocation(AppInvocation{
+			AppName: "approval-gate", VersionID: newer.ID, EventSeq: int64(100 + i),
+			EventName: "delegation.requested", EventSubject: "del-" + string(rune('a'+i)),
+			Handler: "delegation.*", Status: status, Error: failure,
+			Duration: time.Duration(i+1) * 7 * time.Millisecond, StartedAt: base.Add(offset),
+		}); err != nil {
+			t.Fatalf("append invocation %d: %v", i, err)
+		}
+	}
+	// Another app's invocations must not leak into this app's log.
+	if _, err := s.AppendAppInvocation(AppInvocation{
+		AppName: "standup-digest", VersionID: 3, EventSeq: 999, Status: "ok", StartedAt: base,
+	}); err != nil {
+		t.Fatalf("append other app invocation: %v", err)
+	}
+
+	got, err := s.ListAppInvocations("approval-gate", 10)
+	if err != nil {
+		t.Fatalf("list invocations: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("invocations = %d, want 3", len(got))
+	}
+	if got[0].EventSeq != 102 || got[2].EventSeq != 100 {
+		t.Fatalf("order = %d,%d,%d, want 102,101,100", got[0].EventSeq, got[1].EventSeq, got[2].EventSeq)
+	}
+	if got[0].Status != "error" || got[0].Error == "" {
+		t.Fatalf("failure detail lost: %+v", got[0])
+	}
+	if got[0].Duration != 21*time.Millisecond {
+		t.Fatalf("duration = %v, want 21ms", got[0].Duration)
+	}
+	if !got[0].StartedAt.Equal(base.Add(900 * time.Millisecond)) {
+		t.Fatalf("started_at = %v, want %v", got[0].StartedAt, base.Add(900*time.Millisecond))
+	}
+	if limited, err := s.ListAppInvocations("approval-gate", 2); err != nil || len(limited) != 2 {
+		t.Fatalf("limit ignored: %d (%v)", len(limited), err)
+	}
+}
+
+func TestApps_ListAndSaveApp(t *testing.T) {
+	s := New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	_, newer := seedApps(t, s, now)
+
+	// A registry row can exist before any version has been applied.
+	if err := s.SaveApp("half-installed", now); err != nil {
+		t.Fatalf("save app: %v", err)
+	}
+	apps, err := s.ListApps()
+	if err != nil {
+		t.Fatalf("list apps: %v", err)
+	}
+	if len(apps) != 3 || apps[0].Name != "approval-gate" || apps[1].Name != "half-installed" {
+		t.Fatalf("apps = %+v, want three by name", apps)
+	}
+	if apps[1].CurrentVersionID != 0 {
+		t.Fatalf("an app with no version reported version %d", apps[1].CurrentVersionID)
+	}
+
+	// Saving again touches the row without moving the pointer.
+	if err := s.SaveApp("approval-gate", now.Add(time.Hour)); err != nil {
+		t.Fatalf("re-save: %v", err)
+	}
+	app, _, err := s.GetApp("approval-gate")
+	if err != nil {
+		t.Fatalf("get app: %v", err)
+	}
+	if app.CurrentVersionID != newer.ID {
+		t.Fatalf("save moved the version pointer to %d", app.CurrentVersionID)
+	}
+	if !app.UpdatedAt.After(app.CreatedAt) {
+		t.Fatalf("save did not touch updated_at: created=%v updated=%v", app.CreatedAt, app.UpdatedAt)
+	}
+
+	if _, ok, err := s.GetApp("never-installed"); err != nil || ok {
+		t.Fatalf("unknown app reported ok=%t (%v)", ok, err)
+	}
+}
+
+func TestApps_CommitVersionRefusesAnIncompleteRow(t *testing.T) {
+	s := New()
+	now := time.Now().UTC()
+	if _, err := s.CommitAppVersion(AppVersion{ContentHash: "sha256:1"}, now); err == nil {
+		t.Fatal("a version with no app name was accepted")
+	}
+	if _, err := s.CommitAppVersion(AppVersion{AppName: "x"}, now); err == nil {
+		t.Fatal("a version with no content hash was accepted")
+	}
+	if apps, err := s.ListApps(); err != nil || len(apps) != 0 {
+		t.Fatalf("a refused commit left rows behind: %+v (%v)", apps, err)
+	}
+}

--- a/internal/store/bus.go
+++ b/internal/store/bus.go
@@ -197,22 +197,33 @@ func (s *Store) SetBusConsumerCursor(name string, cursor int64, now time.Time) e
 	return err
 }
 
-// SetBusConsumerEnabled flips the kill switch for a consumer.
-func (s *Store) SetBusConsumerEnabled(name string, enabled bool, now time.Time) error {
+// SetBusConsumerEnabled flips the kill switch for a consumer, and reports
+// whether there was a row to flip.
+//
+// The report is what a caller checks a moment after reading the registration:
+// between the read and this write the consumer may have been unregistered, and
+// an UPDATE that matches nothing is indistinguishable from a successful flip
+// without it. A caller that answers "disabled" for a consumer that no longer
+// exists has told its user something untrue.
+func (s *Store) SetBusConsumerEnabled(name string, enabled bool, now time.Time) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.db == nil {
-		return nil
+		return false, nil
 	}
 	flag := 0
 	if enabled {
 		flag = 1
 	}
-	_, err := s.db.Exec(`
+	res, err := s.db.Exec(`
 		UPDATE bus_consumers SET enabled = ?, updated_at = ? WHERE name = ?
 	`, flag, formatTicketTime(now), name)
-	return err
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	return n > 0, err
 }
 
 // DeleteBusConsumer removes a registration. Deleting a row that is not there is

--- a/internal/store/bus.go
+++ b/internal/store/bus.go
@@ -271,7 +271,7 @@ func (s *Store) ListBusConsumers() ([]BusConsumer, error) {
 // age window bounds growth, and the cursor floor keeps a live-but-lagging
 // consumer from losing events it has not read.
 //
-// Disabled consumers are excluded from the floor on purpose. A killed extension
+// Disabled consumers are excluded from the floor on purpose. A killed app
 // must not pin the log indefinitely; when it comes back below the floor,
 // internal/bus resumes it at head and logs the gap.
 func (s *Store) TrimBusEvents(cutoff time.Time) (int, error) {

--- a/internal/store/bus_compaction_test.go
+++ b/internal/store/bus_compaction_test.go
@@ -45,7 +45,7 @@ func TestChurningOneSubjectLeavesOneFact(t *testing.T) {
 
 	var last int64
 	for i := range 200 {
-		seq, err := s.AppendBusEvent(changeOf("ext/x/requests/a"), now.Add(time.Duration(i)*time.Second))
+		seq, err := s.AppendBusEvent(changeOf("app/x/requests/a"), now.Add(time.Duration(i)*time.Second))
 		if err != nil {
 			t.Fatalf("append %d: %v", i, err)
 		}
@@ -73,7 +73,7 @@ func TestCompactionKeepsTheNewestOfEverySubjectItTouches(t *testing.T) {
 
 	newest := map[string]int64{}
 	for i := range 30 {
-		for _, subject := range []string{"ext/x/requests/a", "ext/x/requests/b"} {
+		for _, subject := range []string{"app/x/requests/a", "app/x/requests/b"} {
 			seq, err := s.AppendBusEvent(changeOf(subject), now.Add(time.Duration(i)*time.Second))
 			if err != nil {
 				t.Fatalf("append: %v", err)
@@ -83,7 +83,7 @@ func TestCompactionKeepsTheNewestOfEverySubjectItTouches(t *testing.T) {
 		// A fact nobody declared compactable, on a subject that also carries
 		// compactable ones — the name is what decides, not the subject.
 		if _, err := s.AppendBusEvent(BusEvent{
-			Name: "session.state.changed", Subject: "ext/x/requests/a", Source: "test",
+			Name: "session.state.changed", Subject: "app/x/requests/a", Source: "test",
 		}, now.Add(time.Duration(i)*time.Second)); err != nil {
 			t.Fatalf("append: %v", err)
 		}
@@ -131,7 +131,7 @@ func TestAConsumerParkedBelowTheFloorPinsEveryFactItHasNotRead(t *testing.T) {
 
 	var seqs []int64
 	for i := range 10 {
-		seq, err := s.AppendBusEvent(changeOf("ext/x/requests/a"), now.Add(time.Duration(i)*time.Second))
+		seq, err := s.AppendBusEvent(changeOf("app/x/requests/a"), now.Add(time.Duration(i)*time.Second))
 		if err != nil {
 			t.Fatalf("append: %v", err)
 		}
@@ -170,7 +170,7 @@ func TestCompactingNoNamesRemovesNothing(t *testing.T) {
 	s := New()
 	now := time.Date(2026, 8, 5, 9, 0, 0, 0, time.UTC)
 	for range 5 {
-		if _, err := s.AppendBusEvent(changeOf("ext/x/requests/a"), now); err != nil {
+		if _, err := s.AppendBusEvent(changeOf("app/x/requests/a"), now); err != nil {
 			t.Fatalf("append: %v", err)
 		}
 	}
@@ -199,7 +199,7 @@ func TestACompactedLogIsNoLargerThanWhatItDescribes(t *testing.T) {
 	step := 0
 	appendChange := func(id string, deleted bool) {
 		step++
-		if _, err := s.AppendBusEvent(changeOf("ext/x/requests/"+id), now.Add(time.Duration(step)*time.Second)); err != nil {
+		if _, err := s.AppendBusEvent(changeOf("app/x/requests/"+id), now.Add(time.Duration(step)*time.Second)); err != nil {
 			t.Fatalf("append: %v", err)
 		}
 		if deleted {
@@ -255,7 +255,7 @@ func TestTheLogReportsItsOwnWeight(t *testing.T) {
 	}
 
 	for range 4 {
-		if _, err := s.AppendBusEvent(changeOf("ext/x/requests/a"), now); err != nil {
+		if _, err := s.AppendBusEvent(changeOf("app/x/requests/a"), now); err != nil {
 			t.Fatalf("append: %v", err)
 		}
 	}
@@ -266,7 +266,7 @@ func TestTheLogReportsItsOwnWeight(t *testing.T) {
 	if rows != 4 {
 		t.Fatalf("log holds %d row(s), want 4", rows)
 	}
-	one := changeOf("ext/x/requests/a")
+	one := changeOf("app/x/requests/a")
 	if want := int64(4 * (len(one.Name) + len(one.Subject) + len(one.Payload) + len(one.Source))); bytes <= want {
 		t.Fatalf("4 facts weigh %d byte(s), want more than the %d of their own text", bytes, want)
 	}

--- a/internal/store/bus_test.go
+++ b/internal/store/bus_test.go
@@ -91,6 +91,37 @@ func TestBusBoundsTracksTheLiveWindow(t *testing.T) {
 	}
 }
 
+// A caller flips the kill switch a moment after reading the registration, and in
+// that gap the consumer can be unregistered — one operator disabling an app while
+// another removes it. The write must say it found nothing, or the caller reports
+// a state change that never happened.
+func TestSetBusConsumerEnabledReportsAVanishedConsumer(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	if err := s.SaveBusConsumer(BusConsumer{Name: "app:approval-gate", Cursor: 0, Filter: "*", Enabled: true}, busBase); err != nil {
+		t.Fatalf("SaveBusConsumer: %v", err)
+	}
+	flipped, err := s.SetBusConsumerEnabled("app:approval-gate", false, busBase.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("SetBusConsumerEnabled: %v", err)
+	}
+	if !flipped {
+		t.Fatal("flipping a registered consumer reported no row")
+	}
+
+	if err := s.DeleteBusConsumer("app:approval-gate"); err != nil {
+		t.Fatalf("DeleteBusConsumer: %v", err)
+	}
+	flipped, err = s.SetBusConsumerEnabled("app:approval-gate", true, busBase.Add(2*time.Minute))
+	if err != nil {
+		t.Fatalf("SetBusConsumerEnabled after delete: %v", err)
+	}
+	if flipped {
+		t.Fatal("flipping a consumer that no longer exists reported success")
+	}
+}
+
 // Re-registering an existing consumer refreshes its filter but must not rewind
 // its cursor or resurrect it after the kill switch — daemon restart re-registers
 // every consumer, and neither of those may be a side effect of starting up.
@@ -104,7 +135,7 @@ func TestSaveBusConsumerPreservesCursorAndEnabled(t *testing.T) {
 	if err := s.SetBusConsumerCursor("wshub", 42, busBase.Add(time.Minute)); err != nil {
 		t.Fatalf("SetBusConsumerCursor: %v", err)
 	}
-	if err := s.SetBusConsumerEnabled("wshub", false, busBase.Add(2*time.Minute)); err != nil {
+	if _, err := s.SetBusConsumerEnabled("wshub", false, busBase.Add(2*time.Minute)); err != nil {
 		t.Fatalf("SetBusConsumerEnabled: %v", err)
 	}
 
@@ -264,7 +295,7 @@ func TestTrimBusEventsIgnoresDisabledConsumers(t *testing.T) {
 	if err := s.SaveBusConsumer(BusConsumer{Name: "killed", Cursor: 0, Filter: "*", Enabled: true}, busBase); err != nil {
 		t.Fatalf("SaveBusConsumer: %v", err)
 	}
-	if err := s.SetBusConsumerEnabled("killed", false, busBase); err != nil {
+	if _, err := s.SetBusConsumerEnabled("killed", false, busBase); err != nil {
 		t.Fatalf("SetBusConsumerEnabled: %v", err)
 	}
 

--- a/internal/store/documents_model_test.go
+++ b/internal/store/documents_model_test.go
@@ -54,7 +54,7 @@ const modelField = "n"
 
 func modelDeclaration() docstore.CollectionSchema {
 	return docstore.CollectionSchema{
-		Namespace:  "ext/model",
+		Namespace:  "app/model",
 		Collection: "docs",
 		Fields:     []docstore.FieldSpec{{Name: modelField, Type: docstore.FieldNumber}},
 	}
@@ -467,7 +467,7 @@ func modelQueries() []docstore.Query {
 			for limit := 1; limit <= len(modelIDs); limit++ {
 				for _, after := range afters {
 					out = append(out, docstore.Query{
-						Namespace:  "ext/model",
+						Namespace:  "app/model",
 						Collection: "docs",
 						Filters:    filters,
 						Sort:       s,
@@ -688,7 +688,7 @@ const (
 
 func largeDeclaration() docstore.CollectionSchema {
 	return docstore.CollectionSchema{
-		Namespace:  "ext/model",
+		Namespace:  "app/model",
 		Collection: "large",
 		Fields: []docstore.FieldSpec{
 			{Name: "n", Type: docstore.FieldNumber},

--- a/internal/store/documents_positioned_test.go
+++ b/internal/store/documents_positioned_test.go
@@ -16,10 +16,10 @@ import (
 // logged and forgotten.
 
 func changeFact(id string, deleted bool) BusEvent {
-	payload := fmt.Sprintf(`{"namespace":"ext/approval-gate","collection":"requests","id":%q,"deleted":%t}`, id, deleted)
+	payload := fmt.Sprintf(`{"namespace":"app/approval-gate","collection":"requests","id":%q,"deleted":%t}`, id, deleted)
 	return BusEvent{
 		Name:    "document.changed",
-		Subject: "ext/approval-gate/requests/" + id,
+		Subject: "app/approval-gate/requests/" + id,
 		Payload: payload,
 	}
 }
@@ -59,7 +59,7 @@ func TestACommittedWriteReportsWhereItsFactLanded(t *testing.T) {
 	if events[0].Seq != written.Seq {
 		t.Fatalf("fact is at seq %d, write reported %d", events[0].Seq, written.Seq)
 	}
-	if events[0].Subject != "ext/approval-gate/requests/a" {
+	if events[0].Subject != "app/approval-gate/requests/a" {
 		t.Fatalf("subject = %q", events[0].Subject)
 	}
 }
@@ -209,11 +209,11 @@ func TestAnAnswerCarriesThePositionItWasTrueAt(t *testing.T) {
 func TestReadingAnUndeclaredCollectionSaysSo(t *testing.T) {
 	s, _ := storeWithRequests(t, map[string]string{})
 
-	if _, declared, err := s.ReadDocument("ext/approval-gate", "nothing-here", "a"); err != nil || declared {
+	if _, declared, err := s.ReadDocument("app/approval-gate", "nothing-here", "a"); err != nil || declared {
 		t.Fatalf("get on an undeclared collection: declared=%v err=%v", declared, err)
 	}
 	if _, declared, err := s.CountQuery(docstore.Query{
-		Namespace: "ext/approval-gate", Collection: "nothing-here",
+		Namespace: "app/approval-gate", Collection: "nothing-here",
 	}); err != nil || declared {
 		t.Fatalf("count on an undeclared collection: declared=%v err=%v", declared, err)
 	}
@@ -292,7 +292,7 @@ func TestACountAfterACursorCountsWhatIsLeft(t *testing.T) {
 		"c": `{"attempts":3}`,
 	})
 	q := docstore.Query{
-		Namespace: "ext/approval-gate", Collection: "requests",
+		Namespace: "app/approval-gate", Collection: "requests",
 		Sort: &docstore.Sort{Field: "attempts"}, After: "a", Limit: docstore.MaxLimit,
 	}
 	count, found, err := s.CountQuery(q)

--- a/internal/store/documents_read_window_test.go
+++ b/internal/store/documents_read_window_test.go
@@ -39,7 +39,7 @@ func readIDs(t *testing.T, s *Store, q docstore.Query) ([]string, error) {
 
 func pagedByAttempts(after string) docstore.Query {
 	return docstore.Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Sort:       &docstore.Sort{Field: "attempts"},
 		After:      after,
@@ -110,7 +110,7 @@ func TestAFilterIsBoundUnderTheDeclarationItRunsAgainst(t *testing.T) {
 		"c": `{"attempts":3}`,
 	})
 	numeric := docstore.Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Filters:    []docstore.Filter{{Field: "attempts", Op: docstore.OpEq, Value: float64(2)}},
 	}

--- a/internal/store/documents_test.go
+++ b/internal/store/documents_test.go
@@ -15,7 +15,7 @@ import (
 
 func requestsDeclaration() docstore.CollectionSchema {
 	return docstore.CollectionSchema{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Fields: []docstore.FieldSpec{
 			{Name: "status", Type: docstore.FieldString},
@@ -36,7 +36,7 @@ func storeWithRequests(t *testing.T, bodies map[string]string) (*Store, time.Tim
 	}
 	i := 0
 	for _, id := range sortedKeys(bodies) {
-		if _, err := s.PutDocument(declOf(t, s, "ext/approval-gate", "requests"), id, []byte(bodies[id]), base.Add(time.Duration(i)*time.Second), nil); err != nil {
+		if _, err := s.PutDocument(declOf(t, s, "app/approval-gate", "requests"), id, []byte(bodies[id]), base.Add(time.Duration(i)*time.Second), nil); err != nil {
 			t.Fatalf("put %s: %v", id, err)
 		}
 		i++
@@ -110,7 +110,7 @@ func TestADeclarationRoundTripsThroughTheDatabase(t *testing.T) {
 	if _, err := s.DefineDocumentCollection(requestsDeclaration(), now); err != nil {
 		t.Fatalf("define: %v", err)
 	}
-	got, ok, err := s.DocumentCollection("ext/approval-gate", "requests")
+	got, ok, err := s.DocumentCollection("app/approval-gate", "requests")
 	if err != nil || !ok {
 		t.Fatalf("read back: ok=%v err=%v", ok, err)
 	}
@@ -119,7 +119,7 @@ func TestADeclarationRoundTripsThroughTheDatabase(t *testing.T) {
 	}
 	// An undeclared collection is absent, not an error: that is the difference a
 	// query against a collection nobody declared has to report.
-	if _, ok, err := s.DocumentCollection("ext/approval-gate", "nothing"); err != nil || ok {
+	if _, ok, err := s.DocumentCollection("app/approval-gate", "nothing"); err != nil || ok {
 		t.Fatalf("undeclared collection: ok=%v err=%v", ok, err)
 	}
 }
@@ -136,7 +136,7 @@ func TestRedeclaringAddsAQueryableFieldWithoutTouchingDocuments(t *testing.T) {
 		t.Fatalf("redefine: %v", err)
 	}
 	ids := queryIDs(t, s, docstore.Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Filters:    []docstore.Filter{{Field: "note", Op: docstore.OpEq, Value: "hi"}},
 	})
@@ -150,7 +150,7 @@ func TestRedeclaringAddsAQueryableFieldWithoutTouchingDocuments(t *testing.T) {
 func TestABodyComesBackExactlyAsWritten(t *testing.T) {
 	body := `{"status":"pending","nested":{"deep":[1,2,{"x":null}]},"undeclared":"kept"}`
 	s, _ := storeWithRequests(t, map[string]string{"a": body})
-	doc, ok, err := s.GetDocument(declOf(t, s, "ext/approval-gate", "requests"), "a")
+	doc, ok, err := s.GetDocument(declOf(t, s, "app/approval-gate", "requests"), "a")
 	if err != nil || !ok {
 		t.Fatalf("get: ok=%v err=%v", ok, err)
 	}
@@ -164,10 +164,10 @@ func TestABodyComesBackExactlyAsWritten(t *testing.T) {
 func TestReplacingADocumentKeepsCreatedAtAndMovesUpdatedAt(t *testing.T) {
 	s, base := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
 	later := base.Add(time.Hour)
-	if _, err := s.PutDocument(declOf(t, s, "ext/approval-gate", "requests"), "a", []byte(`{"status":"approved"}`), later, nil); err != nil {
+	if _, err := s.PutDocument(declOf(t, s, "app/approval-gate", "requests"), "a", []byte(`{"status":"approved"}`), later, nil); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
-	doc, _, err := s.GetDocument(declOf(t, s, "ext/approval-gate", "requests"), "a")
+	doc, _, err := s.GetDocument(declOf(t, s, "app/approval-gate", "requests"), "a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +188,7 @@ func TestFiltersSortAndLimitExecuteAgainstRealJSON(t *testing.T) {
 		"c": `{"status":"approved","attempts":2,"urgent":false}`,
 		"d": `{"status":"pending","attempts":9,"urgent":true}`,
 	})
-	ns, coll := "ext/approval-gate", "requests"
+	ns, coll := "app/approval-gate", "requests"
 
 	if got := queryIDs(t, s, docstore.Query{
 		Namespace: ns, Collection: coll,
@@ -229,7 +229,7 @@ func TestTheAfterCursorPaginates(t *testing.T) {
 		"c": `{"status":"pending","attempts":3}`,
 	})
 	q := docstore.Query{
-		Namespace: "ext/approval-gate", Collection: "requests",
+		Namespace: "app/approval-gate", Collection: "requests",
 		Sort: &docstore.Sort{Field: "attempts"}, Limit: 2,
 	}
 	if got := queryIDs(t, s, q); !equalStrings(got, []string{"a", "b"}) {
@@ -262,7 +262,7 @@ func TestPagingAcrossDocumentsThatShareASortValue(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			q := docstore.Query{
-				Namespace: "ext/approval-gate", Collection: "requests",
+				Namespace: "app/approval-gate", Collection: "requests",
 				Sort: &docstore.Sort{Field: "attempts", Desc: tc.desc}, Limit: 1,
 			}
 			var walked []string
@@ -294,7 +294,7 @@ func TestPagingCrossesATieGroupBoundary(t *testing.T) {
 		"d": `{"status":"pending","attempts":3}`,
 	})
 	q := docstore.Query{
-		Namespace: "ext/approval-gate", Collection: "requests",
+		Namespace: "app/approval-gate", Collection: "requests",
 		Sort: &docstore.Sort{Field: "attempts"}, Limit: 2, After: "b",
 	}
 	// "b" is the first of the pair sharing attempts=2, so its tie partner "c"
@@ -328,7 +328,7 @@ func TestPagingOverDocumentsMissingTheSortField(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			q := docstore.Query{
-				Namespace: "ext/approval-gate", Collection: "requests",
+				Namespace: "app/approval-gate", Collection: "requests",
 				Sort: &docstore.Sort{Field: "attempts", Desc: tc.desc}, Limit: 1,
 			}
 			var walked []string
@@ -358,7 +358,7 @@ func TestPagingAnUnsortedQuery(t *testing.T) {
 		"c": `{"status":"pending"}`,
 	})
 	q := docstore.Query{
-		Namespace: "ext/approval-gate", Collection: "requests",
+		Namespace: "app/approval-gate", Collection: "requests",
 		Limit: 2, After: "a",
 	}
 	if got := queryIDs(t, s, q); !equalStrings(got, []string{"b", "c"}) {
@@ -375,12 +375,12 @@ func TestPagingByCreatedAtWithIdenticalTimestamps(t *testing.T) {
 		t.Fatalf("define: %v", err)
 	}
 	for _, id := range []string{"a", "b", "c"} {
-		if _, err := s.PutDocument(declOf(t, s, "ext/approval-gate", "requests"), id, []byte(`{"status":"pending"}`), base, nil); err != nil {
+		if _, err := s.PutDocument(declOf(t, s, "app/approval-gate", "requests"), id, []byte(`{"status":"pending"}`), base, nil); err != nil {
 			t.Fatalf("put %s: %v", id, err)
 		}
 	}
 	q := docstore.Query{
-		Namespace: "ext/approval-gate", Collection: "requests",
+		Namespace: "app/approval-gate", Collection: "requests",
 		Sort: &docstore.Sort{Field: docstore.FieldCreatedAt, Desc: true}, Limit: 1,
 	}
 	var walked []string
@@ -401,11 +401,11 @@ func TestPagingByCreatedAtWithIdenticalTimestamps(t *testing.T) {
 // silently returning nothing reads as "end of results" and quietly truncates.
 func TestPagingAfterADeletedDocumentSaysSo(t *testing.T) {
 	s, _ := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
-	schema, _, err := s.DocumentCollection("ext/approval-gate", "requests")
+	schema, _, err := s.DocumentCollection("app/approval-gate", "requests")
 	if err != nil {
 		t.Fatal(err)
 	}
-	q := docstore.Query{Namespace: "ext/approval-gate", Collection: "requests", After: "gone"}
+	q := docstore.Query{Namespace: "app/approval-gate", Collection: "requests", After: "gone"}
 	if _, err := q.Compile(*schema, nil); err == nil || !strings.Contains(err.Error(), "gone") {
 		t.Fatalf("cursor to a missing document: %v", err)
 	}
@@ -417,15 +417,15 @@ func TestPagingAfterADeletedDocumentSaysSo(t *testing.T) {
 func TestTwoNamespacesWithTheSameCollectionNameStaySeparate(t *testing.T) {
 	s, base := storeWithRequests(t, map[string]string{"shared-id": `{"status":"pending"}`})
 	other := requestsDeclaration()
-	other.Namespace = "ext/other"
+	other.Namespace = "app/other"
 	if _, err := s.DefineDocumentCollection(other, base); err != nil {
 		t.Fatalf("define other: %v", err)
 	}
-	if _, err := s.PutDocument(declOf(t, s, "ext/other", "requests"), "shared-id", []byte(`{"status":"approved"}`), base, nil); err != nil {
+	if _, err := s.PutDocument(declOf(t, s, "app/other", "requests"), "shared-id", []byte(`{"status":"approved"}`), base, nil); err != nil {
 		t.Fatalf("put other: %v", err)
 	}
 
-	mine, _, err := s.GetDocument(declOf(t, s, "ext/approval-gate", "requests"), "shared-id")
+	mine, _, err := s.GetDocument(declOf(t, s, "app/approval-gate", "requests"), "shared-id")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,16 +433,16 @@ func TestTwoNamespacesWithTheSameCollectionNameStaySeparate(t *testing.T) {
 		t.Fatalf("the other namespace's write reached this one: %s", mine.Body)
 	}
 	if got := queryIDs(t, s, docstore.Query{
-		Namespace: "ext/approval-gate", Collection: "requests",
+		Namespace: "app/approval-gate", Collection: "requests",
 		Filters: []docstore.Filter{{Field: "status", Op: docstore.OpEq, Value: "approved"}},
 	}); len(got) != 0 {
 		t.Fatalf("query crossed the namespace boundary: %v", got)
 	}
 	// Deleting one namespace's document leaves the other's alone.
-	if _, err := s.DeleteDocument(declOf(t, s, "ext/other", "requests"), "shared-id", nil); err != nil {
+	if _, err := s.DeleteDocument(declOf(t, s, "app/other", "requests"), "shared-id", nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok, _ := s.GetDocument(declOf(t, s, "ext/approval-gate", "requests"), "shared-id"); !ok {
+	if _, ok, _ := s.GetDocument(declOf(t, s, "app/approval-gate", "requests"), "shared-id"); !ok {
 		t.Fatal("deleting in one namespace removed the other's document")
 	}
 }
@@ -451,11 +451,11 @@ func TestTwoNamespacesWithTheSameCollectionNameStaySeparate(t *testing.T) {
 // change that did not happen.
 func TestDeleteReportsWhetherADocumentWasThere(t *testing.T) {
 	s, _ := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`})
-	existed, err := s.DeleteDocument(declOf(t, s, "ext/approval-gate", "requests"), "a", nil)
+	existed, err := s.DeleteDocument(declOf(t, s, "app/approval-gate", "requests"), "a", nil)
 	if err != nil || !existed {
 		t.Fatalf("first delete: existed=%v err=%v", existed, err)
 	}
-	existed, err = s.DeleteDocument(declOf(t, s, "ext/approval-gate", "requests"), "a", nil)
+	existed, err = s.DeleteDocument(declOf(t, s, "app/approval-gate", "requests"), "a", nil)
 	if err != nil || existed {
 		t.Fatalf("second delete: existed=%v err=%v", existed, err)
 	}
@@ -470,7 +470,7 @@ func rev(n int64) *int64 { return &n }
 // requestsDecl is the declaration every conditional-write test writes through.
 func requestsDecl(t *testing.T, s *Store) docstore.CollectionSchema {
 	t.Helper()
-	return declOf(t, s, "ext/approval-gate", "requests")
+	return declOf(t, s, "app/approval-gate", "requests")
 }
 
 // A revision is what a reader is handed and what a writer hands back, so it has
@@ -756,16 +756,16 @@ func TestRemovingACollectionTakesItsDocuments(t *testing.T) {
 	})
 	// Held from before the removal: reading through it afterwards is what proves
 	// the storage went, rather than only the registry row that names it.
-	schema := declOf(t, s, "ext/approval-gate", "requests")
+	schema := declOf(t, s, "app/approval-gate", "requests")
 
-	n, err := s.DeleteDocumentCollection("ext/approval-gate", "requests")
+	n, err := s.DeleteDocumentCollection("app/approval-gate", "requests")
 	if err != nil {
 		t.Fatalf("delete collection: %v", err)
 	}
 	if n != 2 {
 		t.Fatalf("removed %d documents, want 2", n)
 	}
-	if _, ok, _ := s.DocumentCollection("ext/approval-gate", "requests"); ok {
+	if _, ok, _ := s.DocumentCollection("app/approval-gate", "requests"); ok {
 		t.Fatal("declaration survived")
 	}
 	if _, ok, err := s.GetDocument(schema, "a"); ok || err == nil {
@@ -779,14 +779,14 @@ func TestRemovingACollectionTakesItsDocuments(t *testing.T) {
 func TestCountIsScopedToTheCollection(t *testing.T) {
 	s, base := storeWithRequests(t, map[string]string{"a": `{"status":"pending"}`, "b": `{"status":"pending"}`})
 	other := requestsDeclaration()
-	other.Namespace = "ext/other"
+	other.Namespace = "app/other"
 	if _, err := s.DefineDocumentCollection(other, base); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.PutDocument(declOf(t, s, "ext/other", "requests"), "z", []byte(`{"status":"x"}`), base, nil); err != nil {
+	if _, err := s.PutDocument(declOf(t, s, "app/other", "requests"), "z", []byte(`{"status":"x"}`), base, nil); err != nil {
 		t.Fatal(err)
 	}
-	n, err := s.CountDocuments(declOf(t, s, "ext/approval-gate", "requests"))
+	n, err := s.CountDocuments(declOf(t, s, "app/approval-gate", "requests"))
 	if err != nil || n != 2 {
 		t.Fatalf("count = %d err = %v, want 2", n, err)
 	}
@@ -796,11 +796,11 @@ func TestCountIsScopedToTheCollection(t *testing.T) {
 // the wire carries an empty list, not a null.
 func TestAnEmptyResultIsAnEmptyList(t *testing.T) {
 	s, _ := storeWithRequests(t, map[string]string{})
-	schema, _, err := s.DocumentCollection("ext/approval-gate", "requests")
+	schema, _, err := s.DocumentCollection("app/approval-gate", "requests")
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err := docstore.Query{Namespace: "ext/approval-gate", Collection: "requests"}.Compile(*schema, nil)
+	c, err := docstore.Query{Namespace: "app/approval-gate", Collection: "requests"}.Compile(*schema, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -842,7 +842,7 @@ func TestDocumentsSurviveReopeningTheDatabase(t *testing.T) {
 	if _, err := first.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
 		t.Fatalf("define: %v", err)
 	}
-	if _, err := first.PutDocument(declOf(t, first, "ext/approval-gate", "requests"), "a", []byte(`{"status":"pending"}`), base, nil); err != nil {
+	if _, err := first.PutDocument(declOf(t, first, "app/approval-gate", "requests"), "a", []byte(`{"status":"pending"}`), base, nil); err != nil {
 		t.Fatalf("put: %v", err)
 	}
 	first.Close()
@@ -853,7 +853,7 @@ func TestDocumentsSurviveReopeningTheDatabase(t *testing.T) {
 	}
 	defer second.Close()
 
-	schema, ok, err := second.DocumentCollection("ext/approval-gate", "requests")
+	schema, ok, err := second.DocumentCollection("app/approval-gate", "requests")
 	if err != nil || !ok {
 		t.Fatalf("declaration after reopen: ok=%v err=%v", ok, err)
 	}
@@ -861,7 +861,7 @@ func TestDocumentsSurviveReopeningTheDatabase(t *testing.T) {
 		t.Fatalf("declaration lost fields: %+v", schema.Fields)
 	}
 	if got := queryIDs(t, second, docstore.Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Filters:    []docstore.Filter{{Field: "status", Op: docstore.OpEq, Value: "pending"}},
 	}); !equalStrings(got, []string{"a"}) {
@@ -895,7 +895,7 @@ func TestPagingOverCompoundValuesInADeclaredField(t *testing.T) {
 		}
 		t.Run(name, func(t *testing.T) {
 			q := docstore.Query{
-				Namespace: "ext/approval-gate", Collection: "requests",
+				Namespace: "app/approval-gate", Collection: "requests",
 				Sort: &docstore.Sort{Field: "attempts", Desc: desc}, Limit: 1,
 			}
 			// Whatever order SQLite gives these four, the walk has to visit each
@@ -932,7 +932,7 @@ func TestPagingBetweenTwoIdenticalCompoundValues(t *testing.T) {
 		"b": `{"status":"pending","attempts":[1,2]}`,
 	})
 	q := docstore.Query{
-		Namespace: "ext/approval-gate", Collection: "requests",
+		Namespace: "app/approval-gate", Collection: "requests",
 		Sort: &docstore.Sort{Field: "attempts"}, Limit: 1, After: "a",
 	}
 	if got := queryIDs(t, s, q); !equalStrings(got, []string{"b"}) {
@@ -950,7 +950,7 @@ func TestPagingWhenStoredValuesDisagreeWithTheDeclaredType(t *testing.T) {
 		"c": `{"status":"pending","attempts":true}`,
 	})
 	q := docstore.Query{
-		Namespace: "ext/approval-gate", Collection: "requests",
+		Namespace: "app/approval-gate", Collection: "requests",
 		Sort: &docstore.Sort{Field: "attempts"}, Limit: 1,
 	}
 	seen := map[string]bool{}
@@ -978,7 +978,7 @@ func TestPagingOverAnExplicitJSONNull(t *testing.T) {
 		"b": `{"status":"pending","attempts":2}`,
 	})
 	q := docstore.Query{
-		Namespace: "ext/approval-gate", Collection: "requests",
+		Namespace: "app/approval-gate", Collection: "requests",
 		Sort: &docstore.Sort{Field: "attempts"}, Limit: 1, After: "a",
 	}
 	if got := queryIDs(t, s, q); !equalStrings(got, []string{"b"}) {
@@ -999,26 +999,26 @@ func TestAQueryOnADeclaredFieldUsesItsIndex(t *testing.T) {
 		"a": `{"status":"pending","attempts":1}`,
 		"b": `{"status":"approved","attempts":2}`,
 	})
-	schema := declOf(t, s, "ext/approval-gate", "requests")
+	schema := declOf(t, s, "app/approval-gate", "requests")
 
 	for _, tc := range []struct {
 		name  string
 		query docstore.Query
 	}{
 		{"filter", docstore.Query{
-			Namespace: "ext/approval-gate", Collection: "requests",
+			Namespace: "app/approval-gate", Collection: "requests",
 			Filters: []docstore.Filter{{Field: "status", Op: docstore.OpEq, Value: "pending"}},
 		}},
 		{"sort", docstore.Query{
-			Namespace: "ext/approval-gate", Collection: "requests",
+			Namespace: "app/approval-gate", Collection: "requests",
 			Sort: &docstore.Sort{Field: "attempts"},
 		}},
 		{"sort descending", docstore.Query{
-			Namespace: "ext/approval-gate", Collection: "requests",
+			Namespace: "app/approval-gate", Collection: "requests",
 			Sort: &docstore.Sort{Field: "attempts", Desc: true},
 		}},
 		{"reserved sort", docstore.Query{
-			Namespace: "ext/approval-gate", Collection: "requests",
+			Namespace: "app/approval-gate", Collection: "requests",
 			Sort: &docstore.Sort{Field: docstore.FieldCreatedAt, Desc: true},
 		}},
 	} {
@@ -1055,7 +1055,7 @@ func TestADeclaredTypeDecidesHowStoredValuesCompare(t *testing.T) {
 		"b": `{"status":"pending","attempts":"10"}`,
 	})
 	got := queryIDs(t, s, docstore.Query{
-		Namespace: "ext/approval-gate", Collection: "requests",
+		Namespace: "app/approval-gate", Collection: "requests",
 		Sort: &docstore.Sort{Field: "attempts"},
 	})
 	if !equalStrings(got, []string{"a", "b"}) {
@@ -1064,7 +1064,7 @@ func TestADeclaredTypeDecidesHowStoredValuesCompare(t *testing.T) {
 	// And the same value is reachable by a numeric filter, which is the half a
 	// caller notices first.
 	got = queryIDs(t, s, docstore.Query{
-		Namespace: "ext/approval-gate", Collection: "requests",
+		Namespace: "app/approval-gate", Collection: "requests",
 		Filters: []docstore.Filter{{Field: "attempts", Op: docstore.OpGt, Value: 9}},
 	})
 	if !equalStrings(got, []string{"b"}) {
@@ -1079,19 +1079,19 @@ func TestCollectionsWithTheSameFieldNameDoNotShareStorage(t *testing.T) {
 	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
 	for _, coll := range []string{"requests", "settings"} {
 		schema := docstore.CollectionSchema{
-			Namespace: "ext/approval-gate", Collection: coll,
+			Namespace: "app/approval-gate", Collection: coll,
 			Fields: []docstore.FieldSpec{{Name: "status", Type: docstore.FieldString}},
 		}
 		if _, err := s.DefineDocumentCollection(schema, now); err != nil {
 			t.Fatalf("define %s: %v", coll, err)
 		}
-		if _, err := s.PutDocument(declOf(t, s, "ext/approval-gate", coll), coll+"-1",
+		if _, err := s.PutDocument(declOf(t, s, "app/approval-gate", coll), coll+"-1",
 			[]byte(`{"status":"`+coll+`"}`), now, nil); err != nil {
 			t.Fatalf("put into %s: %v", coll, err)
 		}
 	}
 	for _, coll := range []string{"requests", "settings"} {
-		got := queryIDs(t, s, docstore.Query{Namespace: "ext/approval-gate", Collection: coll})
+		got := queryIDs(t, s, docstore.Query{Namespace: "app/approval-gate", Collection: coll})
 		if !equalStrings(got, []string{coll + "-1"}) {
 			t.Fatalf("%s holds %v, want only its own document", coll, got)
 		}
@@ -1111,9 +1111,9 @@ func TestRedeclaringRemovesAFieldAndCanBringItBack(t *testing.T) {
 		t.Fatalf("redeclare without urgent: %v", err)
 	}
 
-	schema := declOf(t, s, "ext/approval-gate", "requests")
+	schema := declOf(t, s, "app/approval-gate", "requests")
 	_, err := docstore.Query{
-		Namespace: "ext/approval-gate", Collection: "requests",
+		Namespace: "app/approval-gate", Collection: "requests",
 		Filters: []docstore.Filter{{Field: "urgent", Op: docstore.OpEq, Value: true}},
 	}.Compile(schema, nil)
 	if err == nil {
@@ -1124,7 +1124,7 @@ func TestRedeclaringRemovesAFieldAndCanBringItBack(t *testing.T) {
 		t.Fatalf("redeclare with urgent: %v", err)
 	}
 	got := queryIDs(t, s, docstore.Query{
-		Namespace: "ext/approval-gate", Collection: "requests",
+		Namespace: "app/approval-gate", Collection: "requests",
 		Filters: []docstore.Filter{{Field: "urgent", Op: docstore.OpEq, Value: true}},
 	})
 	if !equalStrings(got, []string{"a"}) {
@@ -1146,7 +1146,7 @@ func TestRedeclaringAFieldsTypeChangesHowItCompares(t *testing.T) {
 		t.Fatalf("redeclare attempts as string: %v", err)
 	}
 	got := queryIDs(t, s, docstore.Query{
-		Namespace: "ext/approval-gate", Collection: "requests",
+		Namespace: "app/approval-gate", Collection: "requests",
 		Sort: &docstore.Sort{Field: "attempts"},
 	})
 	if !equalStrings(got, []string{"b", "a"}) {
@@ -1162,27 +1162,27 @@ func TestUndefiningDropsTheStorageAndRedeclaringStartsEmpty(t *testing.T) {
 		"a": `{"status":"pending"}`,
 		"b": `{"status":"pending"}`,
 	})
-	before := declOf(t, s, "ext/approval-gate", "requests")
+	before := declOf(t, s, "app/approval-gate", "requests")
 
-	removed, err := s.DeleteDocumentCollection("ext/approval-gate", "requests")
+	removed, err := s.DeleteDocumentCollection("app/approval-gate", "requests")
 	if err != nil {
 		t.Fatalf("undefine: %v", err)
 	}
 	if removed != 2 {
 		t.Fatalf("undefine removed %d documents, want 2", removed)
 	}
-	if _, ok, err := s.DocumentCollection("ext/approval-gate", "requests"); err != nil || ok {
+	if _, ok, err := s.DocumentCollection("app/approval-gate", "requests"); err != nil || ok {
 		t.Fatalf("declaration after undefine: ok=%v err=%v", ok, err)
 	}
 
 	if _, err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
 		t.Fatalf("redefine: %v", err)
 	}
-	after := declOf(t, s, "ext/approval-gate", "requests")
+	after := declOf(t, s, "app/approval-gate", "requests")
 	if after.Table == before.Table {
 		t.Fatalf("redeclared collection reuses table %s; a dropped table's name must not come back", after.Table)
 	}
-	if got := queryIDs(t, s, docstore.Query{Namespace: "ext/approval-gate", Collection: "requests"}); len(got) != 0 {
+	if got := queryIDs(t, s, docstore.Query{Namespace: "app/approval-gate", Collection: "requests"}); len(got) != 0 {
 		t.Fatalf("redeclared collection holds %v, want nothing", got)
 	}
 }
@@ -1235,20 +1235,20 @@ func seedV88DocumentStore(t *testing.T, dbPath string) {
 		    PRIMARY KEY (namespace, collection)
 		);
 		INSERT INTO document_collections VALUES
-		    ('ext/approval-gate', 'requests',
+		    ('app/approval-gate', 'requests',
 		     '[{"name":"status","type":"string"},{"name":"attempts","type":"number"}]',
 		     '2026-08-02T09:00:00Z'),
-		    ('ext/notes', 'scratch', '[]', '2026-08-02T09:30:00Z');
+		    ('app/notes', 'scratch', '[]', '2026-08-02T09:30:00Z');
 		INSERT INTO documents VALUES
-		    ('ext/approval-gate', 'requests', 'r1', '{"status":"open","attempts":2,"note":"kept"}',
+		    ('app/approval-gate', 'requests', 'r1', '{"status":"open","attempts":2,"note":"kept"}',
 		     '2026-08-02T10:00:00Z', '2026-08-02T10:00:00Z'),
-		    ('ext/approval-gate', 'requests', 'r2', '{"status":"done","attempts":"10"}',
+		    ('app/approval-gate', 'requests', 'r2', '{"status":"done","attempts":"10"}',
 		     '2026-08-02T10:01:00Z', '2026-08-02T10:05:00Z'),
-		    ('ext/approval-gate', 'requests', 'r3', '{"status":"open","attempts":7}',
+		    ('app/approval-gate', 'requests', 'r3', '{"status":"open","attempts":7}',
 		     '2026-08-02T10:02:00Z', '2026-08-02T10:02:00Z'),
-		    ('ext/notes', 'scratch', 'n1', '{"anything":true}',
+		    ('app/notes', 'scratch', 'n1', '{"anything":true}',
 		     '2026-08-02T11:00:00Z', '2026-08-02T11:00:00Z'),
-		    ('ext/ghost', 'lost', 'g1', '{"orphaned":true}',
+		    ('app/ghost', 'lost', 'g1', '{"orphaned":true}',
 		     '2026-08-02T12:00:00Z', '2026-08-02T12:00:00Z');
 		DELETE FROM schema_migrations WHERE version >= 89;
 	`); err != nil {
@@ -1273,7 +1273,7 @@ func TestAPopulatedV88StoreIsCarriedIntoItsOwnTables(t *testing.T) {
 	}
 	defer s.Close()
 
-	schema := declOf(t, s, "ext/approval-gate", "requests")
+	schema := declOf(t, s, "app/approval-gate", "requests")
 	if len(schema.Fields) != 2 || schema.Fields[0].Name != "status" || schema.Fields[1].Type != docstore.FieldNumber {
 		t.Fatalf("declaration did not survive: %+v", schema.Fields)
 	}
@@ -1294,7 +1294,7 @@ func TestAPopulatedV88StoreIsCarriedIntoItsOwnTables(t *testing.T) {
 	// so a field declared under v88 is queryable — and indexed — without anyone
 	// redeclaring it.
 	q := docstore.Query{
-		Namespace: "ext/approval-gate", Collection: "requests",
+		Namespace: "app/approval-gate", Collection: "requests",
 		Filters: []docstore.Filter{{Field: "status", Op: docstore.OpEq, Value: "open"}},
 		Sort:    &docstore.Sort{Field: "attempts"},
 	}
@@ -1314,7 +1314,7 @@ func TestAPopulatedV88StoreIsCarriedIntoItsOwnTables(t *testing.T) {
 	}
 
 	// A collection declaring no fields still gets its table.
-	notes := declOf(t, s, "ext/notes", "scratch")
+	notes := declOf(t, s, "app/notes", "scratch")
 	if _, found, err := s.GetDocument(notes, "n1"); err != nil || !found {
 		t.Fatalf("n1 after migration: found=%v err=%v", found, err)
 	}
@@ -1323,7 +1323,7 @@ func TestAPopulatedV88StoreIsCarriedIntoItsOwnTables(t *testing.T) {
 	// through the API, but deleting them would be the wrong answer if they ever
 	// did: they arrive under an empty declaration, readable and one doc_define
 	// away from queryable by field.
-	ghost, ok, err := s.DocumentCollection("ext/ghost", "lost")
+	ghost, ok, err := s.DocumentCollection("app/ghost", "lost")
 	if err != nil || !ok {
 		t.Fatalf("undeclared address was not carried: ok=%v err=%v", ok, err)
 	}
@@ -1359,7 +1359,7 @@ func seedPreRevisionDocuments(t *testing.T, dbPath string) {
 	if _, err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
 		t.Fatalf("seed declaration: %v", err)
 	}
-	schema := declOf(t, s, "ext/approval-gate", "requests")
+	schema := declOf(t, s, "app/approval-gate", "requests")
 	for _, doc := range []struct{ id, body string }{
 		{"r1", `{"status":"open","attempts":2}`},
 		{"r2", `{"status":"done","attempts":9}`},
@@ -1391,7 +1391,7 @@ func TestDocumentsStoredBeforeRevisionsGetTheFirstOne(t *testing.T) {
 	}
 	defer s.Close()
 
-	schema := declOf(t, s, "ext/approval-gate", "requests")
+	schema := declOf(t, s, "app/approval-gate", "requests")
 	doc, found, err := s.GetDocument(schema, "r1")
 	if err != nil || !found {
 		t.Fatalf("r1 after migration: found=%v err=%v", found, err)
@@ -1419,7 +1419,7 @@ func TestDocumentsStoredBeforeRevisionsGetTheFirstOne(t *testing.T) {
 	}
 
 	// Every document in the collection came across, not just the one read above.
-	if got := queryIDs(t, s, docstore.Query{Namespace: "ext/approval-gate", Collection: "requests"}); len(got) != 2 {
+	if got := queryIDs(t, s, docstore.Query{Namespace: "app/approval-gate", Collection: "requests"}); len(got) != 2 {
 		t.Fatalf("documents after migration = %v, want both", got)
 	}
 }

--- a/internal/store/documents_timestamps_test.go
+++ b/internal/store/documents_timestamps_test.go
@@ -39,7 +39,7 @@ func storeWithRaggedStamps(t *testing.T) (*Store, docstore.CollectionSchema, tim
 	if _, err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
 		t.Fatalf("define: %v", err)
 	}
-	schema := declOf(t, s, "ext/approval-gate", "requests")
+	schema := declOf(t, s, "app/approval-gate", "requests")
 	for _, r := range raggedSeconds {
 		if _, err := s.PutDocument(schema, r.id, []byte(`{"status":"pending"}`), base.Add(r.offset), nil); err != nil {
 			t.Fatalf("put %s: %v", r.id, err)
@@ -78,7 +78,7 @@ func sameOrder(got, want []string) bool {
 
 func stampQuery(sort *docstore.Sort, filters ...docstore.Filter) docstore.Query {
 	return docstore.Query{
-		Namespace:  "ext/approval-gate",
+		Namespace:  "app/approval-gate",
 		Collection: "requests",
 		Sort:       sort,
 		Filters:    filters,
@@ -224,7 +224,7 @@ func TestMigration91RewritesStampsThatDoNotSort(t *testing.T) {
 	if _, err := s.DefineDocumentCollection(requestsDeclaration(), base); err != nil {
 		t.Fatalf("define: %v", err)
 	}
-	schema := declOf(t, s, "ext/approval-gate", "requests")
+	schema := declOf(t, s, "app/approval-gate", "requests")
 	for _, r := range raggedSeconds {
 		if _, err := s.PutDocument(schema, r.id, []byte(`{"status":"pending"}`), base.Add(r.offset), nil); err != nil {
 			t.Fatalf("put %s: %v", r.id, err)
@@ -234,7 +234,7 @@ func TestMigration91RewritesStampsThatDoNotSort(t *testing.T) {
 	// Roll the stamps back to the encoding migration 91 exists to replace, and
 	// plant one value it cannot read, which it must leave alone rather than
 	// turn into year 1.
-	table := docstore.TableName(collectionID(t, s, "ext/approval-gate", "requests"))
+	table := docstore.TableName(collectionID(t, s, "app/approval-gate", "requests"))
 	for _, r := range raggedSeconds {
 		old := base.Add(r.offset).Format(time.RFC3339Nano)
 		if _, err := s.db.Exec(fmt.Sprintf(`UPDATE %s SET created_at = ?, updated_at = ? WHERE id = ?`, table),

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -951,6 +951,63 @@ CREATE TABLE IF NOT EXISTS document_collections (
 	// delegations, endpoints, workspaces and workspace panes. Applied by
 	// applyMigration95.
 	{95, "store turn, cursor and listing timestamps in an encoding that sorts", ``},
+	// The app registry (A4). Three tables, and their absences are as decided as
+	// their columns:
+	//
+	//   - apps has NO enabled column. An app's enabled state IS its bus
+	//     consumer's enabled bit, which is what both stops delivery and releases
+	//     the retention floor. A mirrored column here would be a drift class
+	//     with no job to do.
+	//   - app_versions rows are immutable. Apply inserts, rollback moves
+	//     apps.current_version_id; nothing rewrites a version, and removing an
+	//     app leaves its versions behind as history.
+	//   - app_invocations records the version that actually ran, not the pointer
+	//     the app happens to be on now, so the log stays honest across a
+	//     rollback.
+	//
+	// UNIQUE(app_name, content_hash) is what makes "re-applying byte-identical
+	// content mints no new row" a property of the database rather than a
+	// convention in the apply pipeline.
+	//
+	// Numbered 96 against a database whose highest applied migration is 95 (main
+	// and this epic branch both). Merging the epic into main after another lane
+	// claims 96 means renumbering this one — never reusing a number, per the note
+	// on migration 86.
+	{96, "create the app registry", `CREATE TABLE IF NOT EXISTS apps (
+    name               TEXT PRIMARY KEY,
+    current_version_id INTEGER,
+    created_at         TEXT NOT NULL,
+    updated_at         TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS app_versions (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    app_name      TEXT NOT NULL,
+    content_hash  TEXT NOT NULL,
+    declaration   TEXT NOT NULL,
+    artifact_path TEXT NOT NULL,
+    created_at    TEXT NOT NULL,
+    UNIQUE(app_name, content_hash)
+);
+-- History for one app, newest first: the rollback picker's access path.
+CREATE INDEX IF NOT EXISTS idx_app_versions_app ON app_versions(app_name, id DESC);
+CREATE TABLE IF NOT EXISTS app_invocations (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    app_name      TEXT NOT NULL,
+    version_id    INTEGER NOT NULL,
+    event_seq     INTEGER NOT NULL,
+    event_name    TEXT NOT NULL DEFAULT '',
+    event_subject TEXT NOT NULL DEFAULT '',
+    handler       TEXT NOT NULL DEFAULT '',
+    status        TEXT NOT NULL,
+    error         TEXT NOT NULL DEFAULT '',
+    duration_ms   INTEGER NOT NULL DEFAULT 0,
+    started_at    TEXT NOT NULL
+);
+-- One app's recent invocations, and the age window retention trims by. Both
+-- read this index; started_at is written fixed-width so text order is time
+-- order.
+CREATE INDEX IF NOT EXISTS idx_app_invocations_app ON app_invocations(app_name, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_app_invocations_started ON app_invocations(started_at);`},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.


### PR DESCRIPTION
Stage A4 slice 3 of the extension platform: the app registry, the half of `attn app` that reads and flips it, the glossary entries that keep app and plugin apart, and the `ext/` → `app/` namespace rename. Targets `epic/ext-a4`.

Design: [docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md](docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md) — "The rename", "Registry and versions", "CLI".

## What an app is

Automation built on attn's platform: it declares what it does in a manifest, consumes domain facts from the durable bus as its own consumer `app:<name>`, keeps state in the document namespace `app/<name>`, and is versioned by the content hash of its built artifact. A plugin is the other thing — an integration with its own supervised process — and the two share no surface. Both nouns now have glossary entries.

## Registry (migration 96)

Three tables, and the absences are as decided as the columns:

- **`apps`** has **no enabled column**. An app's enabled state *is* its bus consumer's bit — the one flip that both stops delivery and releases the event log's retention floor. A mirrored column would be a drift class with no job.
- **`app_versions`** rows are immutable, `UNIQUE(app_name, content_hash)`. That is what makes "re-applying byte-identical content mints no new row" a property of the database rather than a convention in a pipeline that does not exist yet.
- **`app_invocations`** stamps the version that actually ran, not the pointer, so a rollback does not rewrite history.

`CommitAppVersion` is the whole of what an apply changes: upsert the app, reuse-or-insert the version by hash, move the pointer — one transaction. Rollback is `SetAppCurrentVersion`, which refuses a version belonging to another app.

Numbered against a database whose highest applied migration is 95 (main and this epic); a comment says renumbering is expected if another lane claims 96 before the epic merges.

## CLI and RPCs

`attn app list | status <name> | enable <name> | disable <name> | remove <name>`, thin RPCs to the daemon like `attn doc` — removing an app has to stop a delivery loop before its row goes, and a flip publishes a fact. The daemon-independent kill switch survives one level down, deliberately: `attn bus disable app:<name>` works whether or not a daemon is listening.

Two things the surface refuses to do:

- **Invent state.** Before the runtime exists there is nothing to observe, so `status` reports the registry row, the consumer if there is one, cursor lag, and the invocations recorded so far — and nothing else. An app with no consumer says so.
- **Delete data.** `remove` deletes the bus consumer and the registry row. Version history, the invocation log and every document under `app/<name>` survive, and the command counts what it kept. It also cleans a *stray* consumer with no registry row, which is the orphan that would otherwise pin the log's retention floor forever.

`internal/apps` owns the one name an app has and derives the consumer and namespace from it, so the manifest parser (slice 4), the daemon and the CLI cannot disagree.

## Errors that teach

```
$ attn app enable standup-digest
app enable: daemon error: app "standup-digest" has no bus consumer (app:standup-digest),
so there is no enabled bit to enable: nothing is delivering facts to it. A consumer is
registered when the app runtime loads a version of the app; `attn app status standup-digest`
shows what exists.

$ attn app status approval-gate        # after removing it
app status: daemon error: app status: no app named "approval-gate" is registered;
registered apps: standup-digest. 1 version(s) of it remain as history
```

## The `ext/` → `app/` rename

The reserved owner segment shipped as `ext/` in A3 was never a validator constant — it lives in examples, error-message hints, every test namespace, the CLI help, and the glossary. All of them moved, while zero real namespaces exist. Dated plan docs keep their historical text.

## Protocol

`app_list`, `app_status`, `app_set_enabled`, `app_remove` via `main.tsp` → `make generate-types`; **ProtocolVersion 216 → 217** in `constants.go` and `useDaemonSocket.ts`. No UI surface beyond the generated types.

## Live verification

Throwaway profile `a4reg7`, full install (protocol changed), cleaned up afterwards. Preflight PASS, 0 failures — `protocol.cli_app` and `protocol.app_daemon` both at 217. Migration 96 applied on a real daemon (`SELECT MAX(version)` = 96, all three tables present). Registry rows seeded directly, standing in for slice 4's apply:

```
$ attn app list
APP             VERSION  ENABLED      LAG  CONSUMER
approval-gate   1        yes          16   app:approval-gate
standup-digest  none     no consumer  -    app:standup-digest (not registered)

$ attn app status approval-gate
app approval-gate
  version:    1 (sha256:aaa1)
  artifact:   apps/approval-gate/aaa1/bundle.js
  consumer:   app:approval-gate — enabled, cursor 3, 16 event(s) behind
  subscribes: ticket.*
  documents:  app/approval-gate
  history:    1 version(s), 2 invocation(s)
  recent:
    STARTED               VERSION  SEQ  EVENT                  HANDLER   STATUS  MS  ERROR
    2026-08-09T12:01:02Z  1        42   ticket.status_changed  ticket.*  error   3   TypeError: cannot read status of undefined
    2026-08-09T12:01:00Z  1        41   ticket.created         ticket.*  ok      7

$ attn app disable approval-gate
app approval-gate disabled: app:approval-gate stops receiving facts and no longer holds the event log open
# bus_consumers: app:approval-gate|0
# bus_events:    app.enabled.changed|approval-gate|{"name":"approval-gate","consumer":"app:approval-gate","enabled":false}

$ attn app remove approval-gate
removed app approval-gate: stopped and deleted its bus consumer app:approval-gate
kept: 1 version(s), 2 invocation(s), and every document under app/approval-gate
# app_versions=1, app_invocations=2, bus_consumers rows for app:approval-gate = 0
# bus_events: app.removed|approval-gate|{...,"namespace":"app/approval-gate"}
```

Documents survive removal, verified end to end through the renamed namespace:

```
$ attn doc put app/standup-digest notes n1 '{"status":"kept"}'   # wrote … (rev 1, seq 23)
$ attn app remove standup-digest
removed app standup-digest: it had no bus consumer
kept: 0 version(s), 0 invocation(s), and every document under app/standup-digest
$ attn doc get app/standup-digest notes n1
{"status":"kept"}
```

## Tests

New: `internal/store/apps_test.go` (version reuse by hash, rollback pointer-only, removal keeps history, invocations ordered inside one second — the fixed-width stamp), `internal/apps/apps_test.go` (name rule, and that every accepted name makes a namespace the docstore accepts), `internal/daemon/apps_test.go` (list/status/enable/disable/remove over the IPC handlers, fact payloads, the no-consumer and unknown-name errors, the stray-consumer cleanup).

`-race` on the touched packages, `GOOS=linux go build ./...` clean, frontend `tsc --noEmit` clean after the generated-types move.

## Surfaces walked

- **CLI** — `attn app` plus the top-level help entry.
- **Daemon and app** — handlers, `command_meta` (hub-local, non-blocking), the two new facts. No `wireProjections` entries: the registry produces no WebSocket traffic, and the comment says why.
- **Protocol** — regenerated, version bumped in both lockstep spots.
- **Linux** — no platform-specific code; cross build clean.
- **Docs** — glossary (app, plugin, and the `app/` owner segment), `AGENTS.md` architecture map, changelog fragment.
- **Plugins/SDK** — untouched; nothing there consumes the registry yet.

## Deferred, on purpose

No apply/new/dev/rollback CLI (slice 4), no sidecar or dispatch or auto-disable (slice 5), no `wipe`/`--purge-data` verb — the deferral is the decision, and `remove` never grows a data-deleting default. Invocation retention lands with the writer that fills the table, so its age window can be set against a measured rate rather than guessed.

https://claude.ai/code/session_01VjE5Yp9S2ThR7YkNgKjyqi
