### PR TITLE
feat(sessions): delegate a task to a conversation agent

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -92,7 +92,8 @@
     "real-app:scenario-pi-host-conversation": "node scripts/real-app-harness/scenario-pi-host-conversation.mjs",
     "real-app:scenario-pi-host-nudge": "node scripts/real-app-harness/scenario-pi-host-nudge.mjs",
     "real-app:scenario-pi-host-tools": "node scripts/real-app-harness/scenario-pi-host-tools.mjs",
-    "real-app:scenario-pi-host-revive": "node scripts/real-app-harness/scenario-pi-host-revive.mjs"
+    "real-app:scenario-pi-host-revive": "node scripts/real-app-harness/scenario-pi-host-revive.mjs",
+    "real-app:scenario-pi-host-delegate": "node scripts/real-app-harness/scenario-pi-host-delegate.mjs"
   },
   "dependencies": {
     "@codemirror/lang-markdown": "^6.5.0",

--- a/app/scripts/real-app-harness/scenario-pi-host-delegate.mjs
+++ b/app/scripts/real-app-harness/scenario-pi-host-delegate.mjs
@@ -1,0 +1,429 @@
+#!/usr/bin/env node
+
+/**
+ * Real-app scenario: delegating to a conversation agent.
+ *
+ * Delegation is agent-agnostic machinery — a ticket, a worktree, a brief, a
+ * session bound to all three — and the only thing a `pi-host` session was
+ * missing was the brief itself: its driver declared no `initial_prompt`, so the
+ * spawn pipeline refused any launch carrying one. This scenario is what that
+ * capability is FOR, proved end to end in the packaged app against a real agent:
+ *
+ *   1. an ordinary session delegates a real task to a `pi-host` agent, which
+ *      gets its own ticket and its own worktree,
+ *   2. the brief arrives as the conversation's first user message — the agent is
+ *      looking at the task, not at an empty composer,
+ *   3. the agent does the work with its own tools and reports onto its ticket.
+ *      The ticket event is attributed to the DELEGATED SESSION, which is the
+ *      whole identity witness: the environment has to carry the session id from
+ *      the daemon, through the host, through pi, into the tool subprocess that
+ *      runs `attn`,
+ *   4. the agent can read the repository guidance in the worktree it was given —
+ *      the delegated agent's other source of "how do I report here",
+ *   5. a second delegation is `kill -9`ed before its agent has said anything at
+ *      all, which leaves no pi session file (measured, 2026-08-04 spike). Reload
+ *      has to ask the same question again: the brief lives in the session's
+ *      stored launch intent, not in the process that first received it.
+ *
+ * Each kill targets a pid captured when that host appeared, never a pattern.
+ *
+ * Prereqs: a non-production profile install with the attn-pi plugin installed
+ * (`attn plugin install-bundled attn-pi`), pi credentials in ~/.pi, and a built
+ * `./attn` (or ATTN_HARNESS_BIN).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import {
+  createSessionAndWaitForInitialPane,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+} from './common.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { createScenarioRunner } from './scenarioRunner.mjs';
+import { currentHarnessProfile, dataDirForProfile, socketPathForProfile } from './harnessProfile.mjs';
+
+const HARNESS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+// A fact that exists nowhere but the fixture repository's own agent guidance, so
+// an agent that states it can only have read the file in the worktree it was
+// given.
+const GUIDANCE_TOKEN = 'quicksilver-badger';
+
+// The work state an agent reports (`attn ticket status ready_for_review`) and
+// the column the board keeps it in are not the same word.
+const TICKET_COLUMN_FOR_READY = 'in_review';
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const pane = (sessionId) => `[data-testid="conversation-pane-${sessionId}"]`;
+const reloadOf = (sessionId) => `${pane(sessionId)} [data-testid="conversation-reload"]`;
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') args.shift();
+  const options = parseCommonArgs(args);
+  return { options, help: args.includes('--help') || args.includes('-h') };
+}
+
+async function pollFor(fn, description, timeoutMs = 60_000, intervalMs = 400) {
+  const startedAt = Date.now();
+  let last = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    last = await fn();
+    if (last) return last;
+    await delay(intervalMs);
+  }
+  throw new Error(`Timed out waiting for: ${description}. Last value: ${JSON.stringify(last)}`);
+}
+
+function resolveAttnBin() {
+  const candidates = [process.env.ATTN_HARNESS_BIN, path.resolve(HARNESS_DIR, '../../../attn')].filter(Boolean);
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  throw new Error('attn binary not found (build ./attn or set ATTN_HARNESS_BIN)');
+}
+
+// attn's JSON commands print an object or a bare array depending on the command
+// (`ticket show` an object, `ticket list` an array), sometimes after a line of
+// human progress text on the same stream.
+function parseAttnJSON(stdout) {
+  const candidates = [stdout.indexOf('{'), stdout.indexOf('[')].filter((index) => index >= 0);
+  if (candidates.length === 0) return null;
+  try {
+    return JSON.parse(stdout.slice(Math.min(...candidates)));
+  } catch {
+    return null;
+  }
+}
+
+function makeAttnRunner(attnBin, profile) {
+  const socketPath = socketPathForProfile(profile);
+  return function runAttn(args, { allowFailure = false } = {}) {
+    try {
+      const stdout = execFileSync(attnBin, args, {
+        encoding: 'utf8',
+        env: { ...process.env, ATTN_PROFILE: profile, ATTN_SOCKET_PATH: socketPath },
+      });
+      return { stdout, status: 0, stderr: '', json: parseAttnJSON(stdout) };
+    } catch (error) {
+      if (!allowFailure) throw error;
+      const stdout = typeof error.stdout === 'string' ? error.stdout : '';
+      const stderr = typeof error.stderr === 'string' ? error.stderr : '';
+      return { status: error.status ?? 1, stdout, stderr, json: parseAttnJSON(stdout) };
+    }
+  };
+}
+
+function conversationState(client, sessionId) {
+  return client.request('conversation_get_state', { sessionId }, { timeoutMs: 20_000 }).catch(() => null);
+}
+
+// Read-only process table, as (pid, ppid, pgid, command).
+function processTable() {
+  const stdout = execFileSync('/bin/ps', ['-eo', 'pid=,ppid=,pgid=,command='], { encoding: 'utf8' });
+  return stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const match = /^(\d+)\s+(\d+)\s+(\d+)\s+(.*)$/.exec(line);
+      return match ? { pid: Number(match[1]), ppid: Number(match[2]), pgid: Number(match[3]), command: match[4] } : null;
+    })
+    .filter(Boolean);
+}
+
+const hostProcesses = () => processTable().filter((entry) => entry.command.includes('attn-pi-host'));
+
+function waitForHost(known, description, timeoutMs = 90_000) {
+  return pollFor(async () => hostProcesses().find((entry) => !known.includes(entry.pid)) ?? null, description, timeoutMs);
+}
+
+/** The delegation brief: a real task, done with the agent's own tools. */
+function briefFor(token) {
+  return [
+    'Do these three things, in order, using your bash tool. Do not ask for',
+    'confirmation and do nothing else.',
+    '',
+    '1. Read AGENTS.md in the current directory and note the codename it records.',
+    '2. Run this command, with <codename> replaced by what you read in step 1:',
+    `     attn ticket status ready_for_review --comment "${token} codename=<codename>"`,
+    '3. Reply with the single word: done',
+  ].join('\n');
+}
+
+function ticketFor(runAttn, workerId) {
+  return pollFor(
+    async () => {
+      const list = runAttn(['ticket', 'list', '--json'], { allowFailure: true });
+      const tickets = Array.isArray(list.json) ? list.json : [];
+      return tickets.find((ticket) => ticket.assignee === workerId) ?? null;
+    },
+    `a ticket bound to worker ${workerId}`,
+    45_000,
+  );
+}
+
+// `ticket show --json` is one Ticket: its thread is `activity`, each entry
+// carrying the author it was recorded against and an optional comment.
+const activityOf = (ticket) => ticket?.activity ?? [];
+const textOf = (entry) => entry?.comment ?? '';
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-pi-host-delegate.mjs');
+    return;
+  }
+
+  const profile = currentHarnessProfile();
+  if (!profile) {
+    throw new Error('the pi-host delegation scenario does not run against production; set ATTN_PROFILE / ATTN_HARNESS_PROFILE to a named profile');
+  }
+  const dataDir = dataDirForProfile(profile);
+  const runAttn = makeAttnRunner(resolveAttnBin(), profile);
+
+  const runner = createScenarioRunner(options, {
+    scenarioId: 'PI-HOST-DELEGATE',
+    tier: 'tier2-local-real-agent',
+    prefix: 'pi-host-delegate',
+    metadata: {
+      agent: 'pi-host',
+      focus: 'delegation to a conversation agent: brief as the first message, ticket report attributed to the delegated session, repository guidance in the worktree, brief replayed after a zero-file crash',
+    },
+  });
+
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  let delegatorId = null;
+  let workerId = null;
+  let earlyWorkerId = null;
+
+  runner.registerCleanup('close_observer', () => observer.close());
+  runner.registerCleanup('quit_app', () => client.quitApp());
+
+  try {
+    const { repoDir } = await runner.step('seed_repo_fixture', async () => {
+      const dir = path.join(runner.sessionDir, 'pi-host-delegate-repo');
+      fs.mkdirSync(dir, { recursive: true });
+      const gitEnv = {
+        ...process.env,
+        GIT_AUTHOR_NAME: 'attn',
+        GIT_AUTHOR_EMAIL: 'attn@local',
+        GIT_COMMITTER_NAME: 'attn',
+        GIT_COMMITTER_EMAIL: 'attn@local',
+      };
+      execFileSync('git', ['init', '-q'], { cwd: dir });
+      // The guidance the delegated agent has to find in the worktree it is given.
+      // A codename, because it cannot be guessed, inferred, or already known.
+      fs.writeFileSync(
+        path.join(dir, 'AGENTS.md'),
+        `# Repository guide\n\nThis repository's codename is ${GUIDANCE_TOKEN}. Always report it when asked.\n`,
+        'utf8',
+      );
+      execFileSync('git', ['add', '-A'], { cwd: dir, env: gitEnv });
+      execFileSync('git', ['commit', '-q', '-m', 'init'], { cwd: dir, env: gitEnv });
+      return { repoDir: dir };
+    });
+
+    await runner.step('launch_app', async () => {
+      await launchFreshAppAndConnect(client, observer);
+    });
+
+    await runner.step('boot_delegator', async () => {
+      delegatorId = await createSessionAndWaitForInitialPane({
+        client,
+        observer,
+        cwd: repoDir,
+        label: `deleg-${runner.runId.slice(-6)}`,
+        agent: 'shell',
+        sessionWaitMs: 30_000,
+        // Nothing is ever typed into this terminal; it exists to hold the
+        // identity a delegation is made from.
+        waitForInitialPaneVisible: false,
+      });
+    });
+
+    const { ticketId, token } = await runner.step('delegate_a_conversation_agent', async () => {
+      const before = hostProcesses().map((entry) => entry.pid);
+      const runToken = `PIDELEGATE-${runner.runId.slice(-6).toUpperCase()}`;
+      const delegate = runAttn([
+        'delegate',
+        '--source-session', delegatorId,
+        '--agent', 'pi-host',
+        '--brief', briefFor(runToken),
+        '--name', `pid-${runner.runId.slice(-6)}`,
+      ]);
+      workerId = delegate.json?.session_id;
+      runner.assert(typeof workerId === 'string' && workerId.length > 0, `delegate returned a worker session id (got ${JSON.stringify(delegate.json)})`, delegate.json);
+      await observer.waitForSession({ id: workerId, timeoutMs: 45_000 });
+      const host = await waitForHost(before, 'the host process for the delegated conversation');
+
+      const ticket = await ticketFor(runAttn, workerId);
+      runner.assert(
+        (ticket.description ?? '').includes(runToken),
+        'the delegated ticket carries the brief as its description',
+        ticket,
+      );
+      // A delegation with no placement flags puts a Git repository's worker in a
+      // new worktree — the checkout whose guidance the agent reads.
+      const worktree = delegate.json?.directory;
+      runner.assert(
+        delegate.json?.worktree_created === true && worktree !== repoDir,
+        `the delegated agent got its own worktree (got ${worktree}, worktree_created=${delegate.json?.worktree_created})`,
+        delegate.json,
+      );
+      runner.log(`[RealAppHarness] worker=${workerId} ticket=${ticket.id} host=${host.pid} cwd=${worktree}`);
+      return { ticketId: ticket.id, token: runToken, worktree };
+    });
+
+    await runner.step('the_brief_is_the_conversations_first_message', async () => {
+      await client.request('select_session', { sessionId: workerId });
+      const state = await pollFor(
+        async () => {
+          const current = await conversationState(client, workerId);
+          return current && (current.messages || []).length > 0 ? current : null;
+        },
+        'the delegated conversation to draw its first message',
+        90_000,
+      );
+      const first = state.messages[0];
+      runner.assert(first.role === 'user', `the conversation opens with a user message (got ${first.role})`, state.messages);
+      runner.assert(first.text.includes(token), 'the first message is the delegation brief', first);
+      runner.writeJson('delegated-conversation.json', state);
+      return first;
+    });
+
+    // The identity witness AND the guidance witness, in one report: the agent
+    // ran `attn` from its own tool subprocess, and what it wrote into the comment
+    // is a codename that exists only in the worktree's AGENTS.md.
+    await runner.step('the_agent_reports_onto_its_own_ticket', async () => {
+      const settled = await pollFor(
+        async () => {
+          const show = runAttn(['ticket', 'show', ticketId, '--json'], { allowFailure: true });
+          return show.json?.status === TICKET_COLUMN_FOR_READY ? show.json : null;
+        },
+        `the delegated agent to move its ticket to ${TICKET_COLUMN_FOR_READY}`,
+        420_000,
+        2_000,
+      );
+      runner.writeJson('delegated-ticket.json', settled);
+
+      const activity = activityOf(settled);
+      const report = activity.find((entry) => textOf(entry).includes(token));
+      runner.assert(Boolean(report), `the ticket carries the agent's own report (got ${JSON.stringify(activity)})`, activity);
+      // THE IDENTITY WITNESS. `attn ticket status` with no --session resolves the
+      // author from ATTN_SESSION_ID, so an event attributed to the delegated
+      // session is proof the id survived daemon -> host -> pi -> tool subprocess.
+      runner.assert(
+        report.author === workerId,
+        `the report is attributed to the delegated session (author=${report.author}, worker=${workerId})`,
+        report,
+      );
+      // THE GUIDANCE WITNESS. The codename exists nowhere but the worktree's
+      // AGENTS.md, so an agent that reports it read the file it was given.
+      runner.assert(
+        textOf(report).includes(GUIDANCE_TOKEN),
+        `the agent read the repository guidance in its worktree (comment=${JSON.stringify(textOf(report))})`,
+        report,
+      );
+      return report;
+    });
+
+    // The brief belongs to the session, not to the process that received it. A
+    // host killed before its agent has said anything leaves no pi session file at
+    // all, so the replacement opens an empty conversation — and without the
+    // stored launch intent it would come back as an agent with nothing to do.
+    await runner.step('a_brief_survives_a_crash_before_the_first_word', async () => {
+      const before = hostProcesses().map((entry) => entry.pid);
+      const earlyToken = `PIREVIVE-${runner.runId.slice(-6).toUpperCase()}`;
+      const delegate = runAttn([
+        'delegate',
+        '--source-session', delegatorId,
+        '--agent', 'pi-host',
+        // The retry is not padding. A crash puts activity on the ticket — the
+        // reconciliation note and the revival — and `attn ticket status` spends
+        // an agent's first call showing unread activity instead of applying the
+        // update, so on this leg specifically the first attempt always exits
+        // non-zero. What is under test is that the brief was asked again, not
+        // how diligent the agent is about a refused command.
+        '--brief', [
+          'Using your bash tool, run exactly this command:',
+          `attn ticket status ready_for_review --comment "${earlyToken}"`,
+          'If it exits non-zero because it showed you unread ticket activity, run',
+          'the very same command once more — that first call only clears the',
+          'activity. Then reply with the single word: done',
+        ].join('\n'),
+        '--name', `pir-${runner.runId.slice(-6)}`,
+      ]);
+      earlyWorkerId = delegate.json?.session_id;
+      runner.assert(typeof earlyWorkerId === 'string' && earlyWorkerId.length > 0, `the second delegation returned a session id (got ${JSON.stringify(delegate.json)})`, delegate.json);
+      await observer.waitForSession({ id: earlyWorkerId, timeoutMs: 45_000 });
+      const host = await waitForHost(before, 'the host for the second delegation');
+
+      // Kill at once: pi writes nothing to disk until its first assistant
+      // message, and this has to land inside that window.
+      const sessionsDir = path.join(dataDir, 'hosts', 'state', earlyWorkerId);
+      process.kill(host.pid, 'SIGKILL');
+      const filesAtKill = fs.existsSync(sessionsDir) ? fs.readdirSync(sessionsDir) : [];
+      runner.assert(filesAtKill.length === 0, `the kill landed before any session file existed (found ${JSON.stringify(filesAtKill)})`, filesAtKill);
+
+      await client.request('select_session', { sessionId: earlyWorkerId });
+      await pollFor(
+        async () => {
+          const current = await conversationState(client, earlyWorkerId);
+          return current && current.recoverable ? current : null;
+        },
+        'the crashed delegation to park as recoverable',
+        90_000,
+      );
+
+      const known = hostProcesses().map((entry) => entry.pid);
+      await client.request('dom_click', { selector: reloadOf(earlyWorkerId) });
+      await waitForHost(known, 'a replacement host for the crashed delegation');
+
+      const earlyTicket = await ticketFor(runAttn, earlyWorkerId);
+      const settled = await pollFor(
+        async () => {
+          const show = runAttn(['ticket', 'show', earlyTicket.id, '--json'], { allowFailure: true });
+          return show.json?.status === TICKET_COLUMN_FOR_READY ? show.json : null;
+        },
+        'the relaunched delegation to do the work its replayed brief asked for',
+        420_000,
+        2_000,
+      );
+      const activity = activityOf(settled);
+      runner.assert(
+        activity.some((entry) => textOf(entry).includes(earlyToken)),
+        `the replayed brief reached the fresh session (got ${JSON.stringify(activity)})`,
+        activity,
+      );
+      runner.writeJson('replayed-brief-ticket.json', settled);
+      return { killedPid: host.pid, filesAtKill, ticket: earlyTicket.id };
+    });
+
+    const summary = runner.finishSuccess({ profile, delegatorId, workerId, earlyWorkerId, ticketId });
+    console.log('[RealAppHarness] pi-host delegation scenario passed.');
+    console.log(JSON.stringify(summary, null, 2));
+  } catch (error) {
+    const summary = runner.finishFailure(error, { delegatorId, workerId, earlyWorkerId });
+    console.error(summary.error);
+    process.exitCode = 1;
+  } finally {
+    for (const sessionId of [workerId, earlyWorkerId, delegatorId]) {
+      if (!sessionId) continue;
+      await client.request('close_session', { sessionId }).catch(() => {});
+    }
+    await client.quitApp().catch(() => {});
+    await observer.close().catch(() => {});
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/scripts/real-app-harness/scenarioCatalog.mjs
+++ b/app/scripts/real-app-harness/scenarioCatalog.mjs
@@ -291,6 +291,15 @@ export const scenarioCatalog = [
     timeoutMs: 600_000,
   },
   {
+    id: 'pi-host-delegate',
+    label: 'Delegation to a conversation agent: brief as the first message, the agent reports on its own ticket, a brief survives a crash before the first word',
+    command: ['pnpm', 'run', 'real-app:scenario-pi-host-delegate'],
+    // Same prereqs as pi-host-conversation. Two delegations through a real
+    // agent, each of which does a small task and comments on its ticket, plus a
+    // SIGKILL of the second host before pi has written anything down.
+    timeoutMs: 900_000,
+  },
+  {
     id: 'focus-probe',
     label: 'Focus probe (no focus steal on background session create)',
     command: ['pnpm', 'run', 'real-app:focus-probe'],

--- a/changelog.d/pi-host-delegation.yaml
+++ b/changelog.d/pi-host-delegation.yaml
@@ -1,0 +1,16 @@
+kind: added
+area: sessions
+change: >
+  A conversation agent can now be delegated to. `attn delegate --agent pi-host`
+  opens a conversation session the way it opens any other delegated session — its
+  own ticket, its own worktree — and the brief arrives as the first thing the
+  agent is asked, so the pane shows the task and the reply rather than an empty
+  composer. The brief belongs to the session rather than to the process running
+  it: if that process dies before the agent has said anything at all, the
+  relaunch asks the same question again instead of coming back as an agent with
+  nothing to do. A conversation that already has something in it is never asked
+  twice.
+symptom: >
+  Delegating to a conversation agent was refused outright — it could not be
+  launched with a brief — so the whole of attn's delegation, ticket binding and
+  worktrees included, was closed to it.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -325,6 +325,17 @@ reopened history does not end with the agent speaking comes back
 so the difference is not what attn does next but what it tells the user: the
 agent stopped without finishing, and something is owed to it.
 
+A **launch prompt** is the first message a session is opened with rather than
+typed into — a delegation brief, most often. It belongs to the session, not to
+the process that first received it: the daemon stores it and hands the same one
+to every replacement host, and the host decides whether to say it by looking at
+the history it just reopened. An empty history means it was never said, which is
+true on a first launch and on a relaunch after a crash so early the agent had not
+spoken yet; anything else means it was, and it is never said twice. Only
+conversation sessions store one — a PTY agent's relaunch resumes its transcript,
+so replaying the brief there would set it to work on something it had already
+finished.
+
 An agent becomes a conversation agent by its plugin driver registering the
 `conversation` capability. Everything else about launching it — argv, env, cwd —
 comes back from the same `driver.spawn` call a PTY-backed agent uses. That

--- a/docs/plans/2026-08-05-pi-headless-host.md
+++ b/docs/plans/2026-08-05-pi-headless-host.md
@@ -192,11 +192,18 @@ Ships:
       the replacement is spawned from. No parallel mechanism.
 - [x] The zero-file early-crash case falls back to a fresh session — the same
       `continueRecent` call, which is why it needed no code of its own.
-      **Deviation:** the "+ LaunchIntent prompt" half is moot as specified. The
-      `pi-host` driver does not register the `initial_prompt` capability, so the
-      spawn pipeline refuses a pi-host launch that carries one; there is no
-      stored prompt to re-send. Giving pi-host an initial prompt is what
-      delegation to a conversation agent needs, and it belongs with that.
+      **Deviation, since closed:** the "+ LaunchIntent prompt" half was moot
+      when this slice landed — the `pi-host` driver registered no
+      `initial_prompt` capability, so the spawn pipeline refused a pi-host
+      launch that carried one and there was no stored prompt to re-send. It was
+      deferred to the work that needed it, delegation to a conversation agent,
+      and shipped there: the driver declares the capability, the prompt travels
+      to the host in `ATTN_PI_HOST_INITIAL_PROMPT`, and the host says it exactly
+      when its reopened history is empty (`launchPromptIsUndelivered`). The
+      daemon stores it in `LaunchIntent.InitialPrompt` for conversation agents
+      only, so this fallback now relaunches the same task rather than an agent
+      with nothing to do. A PTY agent still stores none: its relaunch resumes a
+      transcript, so replaying the brief would re-run finished work.
 - [x] Attach protocol: windowed conversation snapshot + live stream deduped by
       seq (mirrors the terminal restore contract). `agent_attach` asks;
       `conversation_snapshot` answers on the envelope stream, broadcast and
@@ -255,6 +262,51 @@ Left for slice 5, deliberately:
 - Reaching a tool subprocess a hard kill stranded. `tool_started` carries no pid,
   so procreap has nothing to record; giving it one is the fix, and it belongs
   with whichever slice wants tool cancellation anyway.
+
+### Slice 4b — delegation to a conversation agent
+
+Goal: `attn delegate --agent pi-host` works, which is the first time a
+conversation session is asked to do a job rather than hold a chat.
+
+Ships:
+
+- [x] The `initial_prompt` capability on the `pi-host` driver — delegation
+      refuses any agent that cannot be launched with a brief — and the closing
+      of slice 4's deviation above. The brief travels in the environment, not
+      argv: a brief is multi-line prose, and argv is world-readable text a
+      sibling's `pkill -f` can match on.
+- [x] The host decides delivery, because it is the only party that can. It
+      reopens its own history at startup and says the brief exactly when that
+      history is empty, so the same stored prompt handed to every replacement
+      host is spoken once.
+
+Two findings this slice made, both observed rather than reasoned:
+
+- **A host was carrying no session identity, and worse, someone else's.** The
+  environment chain daemon → host → pi → tool subprocess was assumed to carry
+  it, since environment inherits by default. It does — but nothing was putting
+  it there. `spawnHostSession` set the `ATTN_PI_HOST_*` block and stopped; the
+  PTY path's identity block (`buildSpawnEnv`) had no counterpart. Live, the
+  agent's bash tool printed an empty `ATTN_SESSION_ID`. Under test, where the
+  daemon itself was launched from inside an attn session, the host inherited
+  *that* session's id and agent — so a delegated agent's `attn ticket comment`
+  would have reported as whichever session the daemon got its environment from.
+  Fixed by giving the host the same identity block the PTY path builds.
+- **`attn` on a host's PATH was the wrong install.** Bare `attn` resolved off
+  the login shell's PATH to `~/Applications/attn.app` — production — from a
+  session running on a throwaway profile. `launchenv.WithActiveAttnFirst`, which
+  the PTY path already applied, is the fix; the two runtimes owe an agent the
+  same environment.
+
+Skills reach a delegated pi agent with no delivery mechanism of attn's: pi
+inlines `AGENTS.md`/`CLAUDE.md` from the worktree and its ancestors into the
+system prompt, and it scans `~/.agents/skills/` unconditionally — which is
+exactly where attn already installs its own skill. Noted as a dependency rather
+than a design: that install happens on the codex path, so the attn skill is
+present for pi as a side effect of codex being configured.
+
+Acceptance is the packaged-app scenario `pi-host-delegate`
+(`app/scripts/real-app-harness/scenario-pi-host-delegate.mjs`).
 
 ### Slice 5 — history and depth
 

--- a/internal/daemon/host_session.go
+++ b/internal/daemon/host_session.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/hostsession"
+	"github.com/victorarias/attn/internal/launchenv"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/pty"
 	"github.com/victorarias/attn/internal/ptybackend"
@@ -110,7 +111,22 @@ func (d *Daemon) spawnHostSession(opts ptybackend.SpawnOptions) error {
 	// user has had set for years.
 	env := pty.MergeEnvironment(os.Environ(), d.loginShellEnvForSpawn())
 	env = pty.MergeEnvironment(env, opts.ExternalEnv)
+	// The agent's own tools run as grandchildren of this host, and `attn` is how
+	// they report — a delegated agent comments on its ticket by shelling out.
+	// Two things have to be true for that to land anywhere: the `attn` they find
+	// must be the one that spawned them, and it must know which session is
+	// speaking. Neither is inherited. Without the first, a session on a
+	// non-production profile resolves the production app off the login shell's
+	// PATH; without the second, `attn ticket comment` has no session to attribute
+	// and the delegation reports as nobody. This is the PTY path's identity block
+	// (see buildSpawnEnv in internal/pty/manager.go) — the two runtimes owe the
+	// agent the same environment.
+	env = launchenv.WithActiveAttnFirst(env, launchenv.ActiveAttnExecutable())
 	env = pty.MergeEnvironment(env, []string{
+		"ATTN_INSIDE_APP=1",
+		"ATTN_DAEMON_MANAGED=1",
+		"ATTN_SESSION_ID=" + opts.ID,
+		"ATTN_AGENT=" + opts.Agent,
 		"ATTN_PI_HOST_SESSION_ID=" + opts.ID,
 		"ATTN_PI_HOST_SESSION_DIR=" + hostSessionStateDir(opts.ID),
 		"ATTN_PI_HOST_CWD=" + opts.CWD,

--- a/internal/daemon/host_session_identity_test.go
+++ b/internal/daemon/host_session_identity_test.go
@@ -1,0 +1,115 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// A delegated conversation agent reports by shelling out to `attn`, so the host
+// it runs in owes it the same identity a PTY agent gets. This was observed
+// missing: the agent's tools saw an empty ATTN_SESSION_ID and resolved `attn`
+// to whichever install happened to be on the login shell's PATH.
+
+// envDumpingHostCommand is a host that records its own environment and then
+// stays alive on stdin, so the spawn completes against a real process and the
+// environment asserted on is the one the kernel actually gave it.
+func envDumpingHostCommand(t *testing.T) (argv []string, dumpPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	dumpPath = filepath.Join(dir, "env.txt")
+	script := filepath.Join(dir, "dump-env-host.sh")
+	body := "#!/bin/sh\nenv > " + dumpPath + "\nwhile IFS= read -r line; do :; done\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatalf("write env-dumping host: %v", err)
+	}
+	return []string{script}, dumpPath
+}
+
+func readHostEnv(t *testing.T, dumpPath string) map[string]string {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		data, err := os.ReadFile(dumpPath)
+		if err == nil && len(data) > 0 {
+			env := map[string]string{}
+			for _, line := range strings.Split(string(data), "\n") {
+				name, value, ok := strings.Cut(line, "=")
+				if ok {
+					env[name] = value
+				}
+			}
+			return env
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("the host never wrote its environment to %s", dumpPath)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestConversationHostCarriesTheSessionIdentity(t *testing.T) {
+	// The attn that owns this daemon, standing in for an installed profile's
+	// bundled binary. ActiveAttnExecutable treats the wrapper as authoritative
+	// precisely because it names the running app.
+	activeAttnDir := t.TempDir()
+	activeAttn := filepath.Join(activeAttnDir, "attn")
+	if err := os.WriteFile(activeAttn, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write the active attn: %v", err)
+	}
+	t.Setenv("ATTN_WRAPPER_PATH", activeAttn)
+
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	workspaceID, _, cwd := setupDelegationSource(t, d, backend)
+	pipe, done := startPluginPipe(t, d, "pi-fixture-plugin", nil)
+	defer func() {
+		_ = pipe.Close()
+		<-done
+	}()
+	registerTestPluginDriver(t, pipe, "pi-fixture", map[string]bool{
+		pluginDriverConversationCapability: true,
+		"initial_prompt":                   true,
+	})
+	argv, dumpPath := envDumpingHostCommand(t)
+	serveOneDriverSpawn(t, pipe, argv)
+
+	const sessionID = "conv-identity"
+	client := newWorkspaceProtocolTestClient()
+	d.handleSpawnSession(client, &protocol.SpawnSessionMessage{
+		Cmd:         protocol.CmdSpawnSession,
+		ID:          sessionID,
+		Cwd:         cwd,
+		WorkspaceID: workspaceID,
+		Agent:       "pi-fixture",
+		Cols:        80,
+		Rows:        24,
+	})
+	expectSpawnResult(t, client, sessionID, true)
+	t.Cleanup(func() { _ = d.ensureHostSessions().Kill(sessionID) })
+
+	env := readHostEnv(t, dumpPath)
+	for name, want := range map[string]string{
+		"ATTN_SESSION_ID":     sessionID,
+		"ATTN_AGENT":          "pi-fixture",
+		"ATTN_DAEMON_MANAGED": "1",
+		"ATTN_INSIDE_APP":     "1",
+	} {
+		if env[name] != want {
+			t.Errorf("host env %s = %q, want %q — the agent's tools cannot report as this session", name, env[name], want)
+		}
+	}
+
+	// And the `attn` those tools find must be the one that spawned them. The
+	// login shell's PATH names whichever install the user happens to have on it,
+	// which for a session on a non-production profile is the wrong world
+	// entirely — a delegated agent would report into production.
+	entries := filepath.SplitList(env["PATH"])
+	if len(entries) == 0 || entries[0] != activeAttnDir {
+		t.Errorf("host PATH = %q, want the active attn's directory %q first", env["PATH"], activeAttnDir)
+	}
+}

--- a/internal/daemon/host_session_prompt_test.go
+++ b/internal/daemon/host_session_prompt_test.go
@@ -1,0 +1,159 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// A launch prompt for a conversation session — a delegation brief, most of the
+// time — belongs to the session rather than to the host process that was first
+// handed it. These are the two halves of that: it reaches the driver at spawn,
+// and it is still there for the host that replaces one killed before pi wrote
+// anything down.
+
+const conversationBrief = "Fix the flaky test in internal/store.\nReport on the ticket when it is green."
+
+// serveOneDriverSpawn answers the plugin pipe's next driver.spawn with a host
+// command the daemon can really run, and hands back the params it was called
+// with. Health checks in between are answered so the registration stays alive.
+func serveOneDriverSpawn(t *testing.T, conn net.Conn, argv []string) <-chan pluginDriverSpawnParams {
+	t.Helper()
+	spawned := make(chan pluginDriverSpawnParams, 1)
+	go func() {
+		for {
+			request := decodeJSONRPCMessage(t, conn)
+			if request.Method == pluginHealthMethod {
+				respondPluginRequest(t, conn, request, pluginHealthResult{OK: true})
+				continue
+			}
+			if request.Method != "driver.spawn" {
+				respondPluginRequest(t, conn, request, map[string]any{"ok": true})
+				continue
+			}
+			var params pluginDriverSpawnParams
+			if err := json.Unmarshal(request.Params, &params); err != nil {
+				t.Errorf("decode driver.spawn params: %v", err)
+				return
+			}
+			spawned <- params
+			respondPluginRequest(t, conn, request, pluginDriverSpawnResult{Argv: argv})
+			return
+		}
+	}()
+	return spawned
+}
+
+// idleHostCommand is a host that does nothing but stay alive on its stdin, so
+// the spawn pipeline completes against a real process.
+func idleHostCommand(t *testing.T) []string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "idle-host.sh")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nwhile IFS= read -r line; do :; done\n"), 0o755); err != nil {
+		t.Fatalf("write idle host: %v", err)
+	}
+	return []string{path}
+}
+
+func TestConversationLaunchPromptReachesTheDriverAndOutlivesItsHost(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	workspaceID, _, cwd := setupDelegationSource(t, d, backend)
+	pipe, done := startPluginPipe(t, d, "pi-fixture-plugin", nil)
+	defer func() {
+		_ = pipe.Close()
+		<-done
+	}()
+	registerTestPluginDriver(t, pipe, "pi-fixture", map[string]bool{
+		pluginDriverConversationCapability: true,
+		"initial_prompt":                   true,
+		"state_reporting":                  true,
+	})
+	spawned := serveOneDriverSpawn(t, pipe, idleHostCommand(t))
+
+	const sessionID = "conv-brief"
+	client := newWorkspaceProtocolTestClient()
+	d.handleSpawnSession(client, &protocol.SpawnSessionMessage{
+		Cmd:           protocol.CmdSpawnSession,
+		ID:            sessionID,
+		Cwd:           cwd,
+		WorkspaceID:   workspaceID,
+		Agent:         "pi-fixture",
+		Cols:          80,
+		Rows:          24,
+		InitialPrompt: protocol.Ptr(conversationBrief),
+	})
+	expectSpawnResult(t, client, sessionID, true)
+	t.Cleanup(func() { _ = d.ensureHostSessions().Kill(sessionID) })
+
+	select {
+	case params := <-spawned:
+		if params.InitialPrompt != conversationBrief {
+			t.Fatalf("driver.spawn initial_prompt = %q, want the brief", params.InitialPrompt)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the driver was never asked to spawn")
+	}
+
+	// The durable half. A host killed before pi's first assistant message leaves
+	// no session file, so the replacement starts an empty conversation — and an
+	// empty conversation with no brief is a delegated agent with nothing to do.
+	intent, ok := d.store.LaunchIntent(sessionID)
+	if !ok {
+		t.Fatal("a conversation session spawned with no stored launch intent")
+	}
+	if intent.InitialPrompt != conversationBrief {
+		t.Fatalf("stored launch intent prompt = %q, want the brief", intent.InitialPrompt)
+	}
+	relaunch, _ := buildStoredIntentSpawn(d.store.Get(sessionID), intent, 80, 24)
+	if protocol.Deref(relaunch.InitialPrompt) != conversationBrief {
+		t.Fatalf("relaunch prompt = %q, want the brief", protocol.Deref(relaunch.InitialPrompt))
+	}
+}
+
+// A PTY agent's relaunch resumes its transcript, so replaying the launch prompt
+// there would set a delegated agent to work on a brief it already finished. The
+// prompt is written to a file the wrapper consumes exactly once and is
+// deliberately not part of what a relaunch reconstructs.
+func TestPTYLaunchPromptIsNotStoredForReplay(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	workspaceID, _, cwd := setupDelegationSource(t, d, backend)
+
+	const sessionID = "pty-brief"
+	client := newWorkspaceProtocolTestClient()
+	d.handleSpawnSession(client, &protocol.SpawnSessionMessage{
+		Cmd:           protocol.CmdSpawnSession,
+		ID:            sessionID,
+		Cwd:           cwd,
+		WorkspaceID:   workspaceID,
+		Agent:         string(protocol.SessionAgentClaude),
+		Cols:          80,
+		Rows:          24,
+		InitialPrompt: protocol.Ptr(conversationBrief),
+	})
+	expectSpawnResult(t, client, sessionID, true)
+
+	spawn, ok := backend.LastSpawn()
+	if !ok || spawn.InitialPromptFile == "" {
+		t.Fatalf("a PTY agent's brief did not reach it as a prompt file: %+v", spawn)
+	}
+	_ = os.Remove(spawn.InitialPromptFile)
+
+	intent, ok := d.store.LaunchIntent(sessionID)
+	if !ok {
+		t.Fatal("no stored launch intent for the PTY session")
+	}
+	if intent.InitialPrompt != "" {
+		t.Fatalf("a PTY launch stored a replayable prompt %q; a reload would re-run it", intent.InitialPrompt)
+	}
+	relaunch, _ := buildStoredIntentSpawn(d.store.Get(sessionID), intent, 80, 24)
+	if relaunch.InitialPrompt != nil {
+		t.Fatalf("relaunch carried a prompt %q for a resumed PTY session", protocol.Deref(relaunch.InitialPrompt))
+	}
+}

--- a/internal/daemon/spawn_pipeline.go
+++ b/internal/daemon/spawn_pipeline.go
@@ -364,7 +364,17 @@ func (d *Daemon) executeSpawn(req *spawnRequest, plan *spawnPlan) *spawnOutcome 
 	// death after Spawn but before commit would otherwise leave a recoverable
 	// session with no stored launch intent to revive from.
 	plan.priorIntent, plan.hadPriorIntent = d.store.LaunchIntent(session.ID)
-	d.store.SetLaunchIntent(session.ID, launchIntentFromSpawnOptions(plan.spawnOpts, plan.isChief))
+	intent := launchIntentFromSpawnOptions(plan.spawnOpts, plan.isChief)
+	if req.hasPluginDriver && req.pluginDriver.Capabilities[pluginDriverConversationCapability] {
+		// A conversation session's launch prompt outlives the process that was
+		// given it. The host is handed it again on every relaunch and delivers it
+		// only into a conversation it reopens empty — which is the whole of the
+		// zero-file early crash, where a delegation would otherwise come back as
+		// an agent with no brief. See LaunchIntent.InitialPrompt for why no other
+		// runtime gets this.
+		intent.InitialPrompt = req.initialPrompt
+	}
+	d.store.SetLaunchIntent(session.ID, intent)
 	if err := d.spawnSessionRuntime(req, plan.spawnOpts); err != nil {
 		if req.existingSession == nil {
 			d.store.Remove(msg.ID)

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -315,6 +315,13 @@ func buildStoredIntentSpawn(session *protocol.Session, intent store.LaunchIntent
 	if intent.Effort != "" {
 		spawnMsg.Effort = protocol.Ptr(intent.Effort)
 	}
+	// Only a conversation session ever stored one, and its host is what decides
+	// whether to say it again (LaunchIntent.InitialPrompt). Carrying it here is
+	// what makes a relaunch after a zero-file early crash a relaunch of the same
+	// task rather than of an empty session.
+	if intent.InitialPrompt != "" {
+		spawnMsg.InitialPrompt = protocol.Ptr(intent.InitialPrompt)
+	}
 	launch := intent.UnattendedLaunch
 	if !launch.IsZero() {
 		launch = launch.WithLegacyDefaults()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -71,6 +71,15 @@ type LaunchIntent struct {
 	// the store a sufficient authority to relaunch such a session when the
 	// worker registry is gone (machine restart); zero value = attended.
 	UnattendedLaunch launchcontract.UnattendedLaunchSpec `json:"unattended_launch,omitzero"`
+	// InitialPrompt is the launch's first message to the agent, kept only for
+	// runtimes that can tell whether they already received it — conversation
+	// sessions, whose host reopens its own history and delivers this exactly
+	// when that history is empty. A PTY agent has no such test: its relaunch
+	// resumes a transcript, and replaying the prompt there would re-run a
+	// delegation brief the agent already worked through. So this stays empty
+	// for every PTY session; the spawn pipeline fills it only for an agent
+	// whose driver declares the `conversation` capability.
+	InitialPrompt string `json:"initial_prompt,omitempty"`
 }
 
 // New creates a new in-memory store (backed by SQLite :memory:)

--- a/plugins/attn-pi/AGENTS.md
+++ b/plugins/attn-pi/AGENTS.md
@@ -190,7 +190,22 @@ See `docs/glossary.md` for the vocabulary and
   host wedged past the grace window. Never "simplify" the teardown to a group
   kill.
 - A host gets the same environment a PTY agent gets — the daemon's own plus the
-  user's login shell — because that is where an agent's credentials live.
+  user's login shell — because that is where an agent's credentials live. It
+  gets the PTY path's **identity block** too (`ATTN_SESSION_ID`, `ATTN_AGENT`,
+  `ATTN_DAEMON_MANAGED`, `ATTN_INSIDE_APP`, and the active attn first on PATH),
+  and that half is not cosmetic: the agent's tools shell out to `attn` to report,
+  so without it a delegated agent's `attn ticket comment` is attributed to
+  whichever session the daemon inherited its own environment from, and bare
+  `attn` resolves to whichever install is on the login shell's PATH rather than
+  to the profile that spawned the session. Both were observed, not theorized.
+- **`ATTN_PI_HOST_INITIAL_PROMPT`** carries the launch's own first user message
+  when it had one — today that is a delegation brief. It is
+  in the environment rather than argv because a brief is multi-line prose and
+  argv is world-readable text a sibling's `pkill -f` can match on. The daemon
+  hands the same prompt to every replacement host, so delivery is the host's
+  decision, not the daemon's: it says it exactly when its reopened history is
+  empty (`launchPromptIsUndelivered`), which is true only for a first launch or
+  for a relaunch after a crash so early that pi wrote no session file.
 
 `spike-harness/` drives pi's SDK without attn and is the gate a pi version bump
 has to pass; see its README.

--- a/plugins/attn-pi/host/envelope.ts
+++ b/plugins/attn-pi/host/envelope.ts
@@ -1096,6 +1096,28 @@ export function conversationInterrupted(items: SnapshotItem[]): boolean {
 }
 
 /**
+ * Whether a host that has just reopened its conversation still owes it the
+ * message the launch was given.
+ *
+ * A launch prompt — today that is a delegation brief — belongs to the SESSION,
+ * not to the process that first received it, so the daemon hands
+ * the same one to every replacement host. That is what saves a delegation from
+ * a crash before pi's first assistant message, which leaves no session file at
+ * all: the replacement is a fresh session, and a fresh session with no brief is
+ * an agent with nothing to do.
+ *
+ * Emptiness is the whole test, and it is exact rather than approximate: pi
+ * persists nothing until a message ends, so a conversation that reopens with
+ * items in it is one the prompt already reached — including the interrupted
+ * case, where the prompt is there and the answer is not. Asking again there
+ * would make the agent do the task twice; `waiting_input` and a nudge are the
+ * way out of that one, and they are the user's to spend.
+ */
+export function launchPromptIsUndelivered(prompt: string, reopened: SnapshotItem[]): boolean {
+  return prompt.trim() !== "" && reopened.length === 0;
+}
+
+/**
  * One verb the daemon can send the host over stdin.
  *
  * Three of them carry text, and the difference between them is only WHEN the

--- a/plugins/attn-pi/host/index.ts
+++ b/plugins/attn-pi/host/index.ts
@@ -41,6 +41,7 @@ import {
   ToolDetailStore,
   TranscriptStore,
   conversationInterrupted,
+  launchPromptIsUndelivered,
   parseVerb,
   reconstructTranscript,
   type Envelope,
@@ -162,6 +163,10 @@ async function main(): Promise<void> {
   const sessionDir = requireEnv("ATTN_PI_HOST_SESSION_DIR");
   const cwd = requireEnv("ATTN_PI_HOST_CWD");
   const pinnedModel = requireEnv("ATTN_PI_HOST_MODEL");
+  // The launch's own first user message, when it had one — today that is a
+  // delegation brief. Optional: an ordinary session is opened empty, for a user
+  // who will type into it.
+  const initialPrompt = process.env.ATTN_PI_HOST_INITIAL_PROMPT?.trim() ?? "";
 
   const envelopeOut = createWriteStream("", { fd: ENVELOPE_FD });
   // The host's own transcript is fed the same envelopes the daemon forwards, so
@@ -420,6 +425,20 @@ async function main(): Promise<void> {
         return;
     }
   };
+
+  // The launch's own first message. The daemon hands the same one to every
+  // replacement host and this is where it is decided whether to say it — see
+  // `launchPromptIsUndelivered`. It opens the session's first run exactly as a
+  // typed prompt would, so pi's own events draw it and it lands in the
+  // transcript; nothing here is a special case downstream.
+  if (initialPrompt !== "") {
+    if (launchPromptIsUndelivered(initialPrompt, history.items)) {
+      console.error(`[attn-pi-host] delivering the launch prompt (${initialPrompt.length} chars) into an empty conversation`);
+      void runPrompt(initialPrompt);
+    } else {
+      console.error(`[attn-pi-host] launch prompt already delivered; ${history.items.length} item(s) reopened`);
+    }
+  }
 
   let buffer = "";
   for await (const chunk of process.stdin) {

--- a/plugins/attn-pi/src/host-driver.ts
+++ b/plugins/attn-pi/src/host-driver.ts
@@ -18,6 +18,13 @@ import type { DriverRegisterResult, DriverSpawnParams, DriverSpawnResult } from 
  * this connection, but the consequence is what the capability is for — the
  * evidence resolver must not have an opinion about a session it can see no
  * evidence for.
+ *
+ * `initial_prompt` it declares too, and that is what makes a `pi-host` session
+ * delegable: attn's delegation refuses any agent that cannot be launched with a
+ * brief. The prompt travels in the environment rather than in argv — a brief is
+ * multi-line prose, and argv is world-readable text that a sibling's `pkill -f`
+ * can match on. The host decides when to deliver it; see
+ * ATTN_PI_HOST_INITIAL_PROMPT in `host/index.ts`.
  */
 export const hostAgentName = "pi-host";
 
@@ -47,6 +54,7 @@ export class PiHostDriver {
       agent: hostAgentName,
       capabilities: {
         conversation: true,
+        initial_prompt: true,
         model_pin: true,
         state_reporting: true,
       },
@@ -65,10 +73,14 @@ export class PiHostDriver {
     const health = this.health();
     if (!health.ok) throw new Error(health.message);
     const model = params.model?.trim() || defaultHostModel;
+    const initialPrompt = params.initial_prompt?.trim() ?? "";
     return {
       argv: [...this.hostCommand],
       cwd: params.cwd,
-      env: { ATTN_PI_HOST_MODEL: model },
+      env: {
+        ATTN_PI_HOST_MODEL: model,
+        ...(initialPrompt === "" ? {} : { ATTN_PI_HOST_INITIAL_PROMPT: initialPrompt }),
+      },
     };
   }
 }

--- a/plugins/attn-pi/test/host-driver.test.ts
+++ b/plugins/attn-pi/test/host-driver.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PiHostDriver, defaultHostModel, hostAgentName } from "../src/host-driver";
+import type { DriverSpawnParams } from "../src/types";
+
+/**
+ * The `pi-host` launcher. What it decides is small — the model, and whether the
+ * launch carries a first message — but both are the whole of what a delegated
+ * conversation session is: an agent handed a brief instead of an empty pane.
+ */
+
+class FakeRPC {
+  readonly requests: Array<{ method: string; params: any }> = [];
+
+  async request(method: string, params: any): Promise<any> {
+    this.requests.push({ method, params });
+    return { ok: true };
+  }
+
+  handle(_method: string, _handler: unknown): void {}
+}
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "attn-pi-host-"));
+const hostBinary = join(tmpRoot, "attn-pi-host");
+writeFileSync(hostBinary, "// fake compiled host\n");
+
+function newDriver(rpc: FakeRPC = new FakeRPC()): PiHostDriver {
+  return new PiHostDriver({ rpc, hostCommand: [hostBinary] });
+}
+
+function params(overrides?: Partial<DriverSpawnParams>): DriverSpawnParams {
+  return { session_id: "session-1", run_id: "run-1", cwd: "/tmp/work", ...overrides };
+}
+
+describe("PiHostDriver", () => {
+  test("registers pi-host with the capabilities a delegable conversation agent needs", async () => {
+    const rpc = new FakeRPC();
+    await newDriver(rpc).initialize();
+
+    const register = rpc.requests.find((call) => call.method === "driver.register");
+    expect(register?.params).toEqual({
+      agent: hostAgentName,
+      capabilities: {
+        conversation: true,
+        initial_prompt: true,
+        model_pin: true,
+        state_reporting: true,
+      },
+    });
+  });
+
+  test("a launch with a brief carries it in the environment, not in argv", async () => {
+    const brief = "Fix the flaky test in internal/store\nand report on the ticket.";
+    const result = await newDriver().spawn(params({ initial_prompt: brief }));
+
+    expect(result.argv).toEqual([hostBinary]);
+    expect(result.env).toEqual({
+      ATTN_PI_HOST_MODEL: defaultHostModel,
+      ATTN_PI_HOST_INITIAL_PROMPT: brief,
+    });
+  });
+
+  test("a launch with no brief sets no prompt variable at all", async () => {
+    // Absent rather than empty: the host treats "set" as "there is something to
+    // say", so an empty string would make every ordinary session look like a
+    // delegation whose brief went missing.
+    for (const prompt of [undefined, "", "   "]) {
+      const result = await newDriver().spawn(params({ initial_prompt: prompt }));
+      expect(result.env).toEqual({ ATTN_PI_HOST_MODEL: defaultHostModel });
+    }
+  });
+
+  test("a pinned model wins over the default and travels beside the prompt", async () => {
+    const result = await newDriver().spawn(params({ model: " anthropic/claude-x ", initial_prompt: "go" }));
+    expect(result.env).toEqual({
+      ATTN_PI_HOST_MODEL: "anthropic/claude-x",
+      ATTN_PI_HOST_INITIAL_PROMPT: "go",
+    });
+  });
+
+  test("spawn refuses when the host binary is missing, naming it", async () => {
+    const driver = new PiHostDriver({ rpc: new FakeRPC(), hostCommand: [join(tmpRoot, "not-here")] });
+    expect(driver.health().ok).toBe(false);
+    await expect(driver.spawn(params())).rejects.toThrow(/not-here/);
+  });
+});

--- a/plugins/attn-pi/test/host-revive.test.ts
+++ b/plugins/attn-pi/test/host-revive.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   TranscriptStore,
   conversationInterrupted,
+  launchPromptIsUndelivered,
   parseVerb,
   reconstructTranscript,
   type SessionEntryLike,
@@ -162,6 +163,34 @@ describe("conversationInterrupted", () => {
 
   test("a conversation nobody has spoken in is not interrupted", () => {
     expect(conversationInterrupted([])).toBe(false);
+  });
+});
+
+describe("launchPromptIsUndelivered", () => {
+  const brief = "Fix the flaky test and report on the ticket.";
+
+  test("a host that reopened nothing still owes the launch its brief", () => {
+    // The zero-file early crash: killed before pi's first assistant message, so
+    // the replacement opens a session that never heard the brief.
+    expect(launchPromptIsUndelivered(brief, [])).toBe(true);
+  });
+
+  test("a reopened conversation is never asked the same thing twice", () => {
+    const { items } = reconstructTranscript([userEntry("e1", brief), assistantEntry("e2", "On it.")]);
+    expect(launchPromptIsUndelivered(brief, items)).toBe(false);
+  });
+
+  test("an interrupted conversation already carries the brief, so it is not re-sent", () => {
+    // The prompt was persisted and the answer was not. Re-sending would make the
+    // agent do the work twice; this reopens as `waiting_input` instead.
+    const { items } = reconstructTranscript([userEntry("e1", brief)]);
+    expect(conversationInterrupted(items)).toBe(true);
+    expect(launchPromptIsUndelivered(brief, items)).toBe(false);
+  });
+
+  test("a session launched without a brief is owed nothing", () => {
+    expect(launchPromptIsUndelivered("", [])).toBe(false);
+    expect(launchPromptIsUndelivered("   ", [])).toBe(false);
   });
 });
 


### PR DESCRIPTION
attn's delegation refuses any agent that cannot be launched with a brief, and the `pi-host` driver declared no `initial_prompt` capability. Slice 4 of the pi-headless-host plan recorded that as a deviation: the "zero-file early crash falls back to a fresh session **plus** the LaunchIntent prompt" half was moot, because there was no prompt to store. This closes it, and with it the whole of attn's delegation — ticket binding, worktrees, the board — opens to conversation sessions.

## What ships

**The capability, and a brief that reaches the agent.** `pi-host` declares `initial_prompt`. The brief travels to the host in `ATTN_PI_HOST_INITIAL_PROMPT` rather than in argv: a brief is multi-line prose, and argv is world-readable text that a sibling's `pkill -f` can match on.

**Delivery is the host's decision, not the daemon's**, because the host is the only party that can answer "has this already been said?". It reopens its own history at startup and speaks the brief exactly when that history is empty (`launchPromptIsUndelivered`). That is true on a first launch, and on a relaunch after a crash so early that pi wrote no session file — and false on every other relaunch, so a brief is never asked twice.

**The brief outlives the process that received it.** The daemon stores it in `LaunchIntent.InitialPrompt` and hands the same one to every replacement host. Only conversation agents store one: a PTY agent's relaunch resumes its transcript, so replaying the brief there would set a delegated agent to work on something it had already finished. `TestPTYLaunchPromptIsNotStoredForReplay` is that boundary.

## Two things the acceptance criteria asked me to observe rather than assume

The ticket brief said the environment chain daemon → host → pi → tool subprocess was *assumed* to carry the session identity, because environment inherits by default — and told me to observe it instead. It does inherit; nothing was putting it there.

**A conversation host carried no session identity, and under some conditions carried someone else's.** `spawnHostSession` set its own `ATTN_PI_HOST_*` block and stopped; the PTY path's identity block (`buildSpawnEnv`) had no counterpart. Live on a throwaway profile, the delegated agent's bash tool printed an empty `ATTN_SESSION_ID` — so `attn ticket status`, which resolves its author from exactly that variable, had no session to attribute the report to. Worse under test, where the daemon itself had been launched from inside an attn session: the host inherited *that* session's id and agent, so the report would have been filed against whichever session the daemon got its environment from. The mutation check on the new test prints it plainly.

**Bare `attn` on a host's PATH was the wrong install.** It resolved off the login shell's PATH to `~/Applications/attn.app` — production — from a session running on a non-production profile. `launchenv.WithActiveAttnFirst` is what the PTY path already applies.

Both are one fix: give a host the environment the PTY path already builds. Nothing new was designed for it.

## Verification

Live, packaged app, throwaway profile `pidel1`, real pi agent — the new `pi-host-delegate` scenario, which is the delegation story itself:

- `attn delegate --agent pi-host` binds a ticket carrying the brief and puts the worker in its own worktree;
- the brief is the conversation's first user message;
- **identity witness** — the ticket's `status_change` is attributed to the delegated session's own id, which is only possible if `ATTN_SESSION_ID` survived daemon → host → pi → bash → `attn`;
- **skill/guidance witness** — the same comment carries a codename that exists nowhere but the `AGENTS.md` in the worktree the agent was handed;
- **early-crash leg** — a second delegation is `kill -9`ed before the agent has said anything, leaving zero session files (asserted at kill time); reload starts a fresh session, and the host log records `delivering the launch prompt into an empty conversation`. The replayed brief is in the new session file and the agent acts on it.

Also: `go test ./internal/...`, `pnpm --dir app test`, `bun test` in `plugins/attn-pi`.

## Surfaces walked

- **CLI** — `attn delegate --agent pi-host` is the entry point and is what the scenario drives. No new flag; `--initial-prompt` does not exist as a user-facing flag on any agent.
- **Daemon and app** — the app draws the brief with no change of its own: the host delivers it through `runPrompt`, so pi emits its own `message_start`/`message_end` for it and it lands in the transcript and the snapshot like any typed prompt.
- **Protocol** — untouched. `SpawnSessionMessage.InitialPrompt` already existed for the PTY path; `LaunchIntent` is a store type. No `ProtocolVersion` bump.
- **Linux** — `launchenv` and `host_session.go` are platform-neutral.
- **Docs** — the slice 4 deviation note now points at what shipped, slice 4b records the two findings, `docs/glossary.md` defines *launch prompt*, `plugins/attn-pi/AGENTS.md` corrects the "a host gets the same environment a PTY agent gets" claim that this proved false, and there is a changelog fragment.

## For the epic → main endgame

Two things worth a look, neither of them this PR's to fix:

1. **A revived agent's first `attn ticket status` always fails.** The crash puts three entries on the ticket (crashed, the reconciliation note, revived), and `ticket status` spends a call showing unread activity instead of applying the update — "the requested update did not run — review it and retry", exit 1. The agent in my crash leg ran the right command, got refused, and replied "done" without retrying. Correct behavior in isolation; a trap for every delegated agent that comes back from a crash.
2. **pi discovers the attn skill by luck.** pi scans `~/.agents/skills/` unconditionally, and attn installs its skill there — but only on the codex path (`ensureAttnCodexSkillInstalled`, wired for claude/codex/copilot). A machine with no codex configured would leave a delegated pi agent without it. Repository guidance is solid regardless: pi inlines `AGENTS.md`/`CLAUDE.md` from the worktree and its ancestors into the system prompt, which is what the guidance witness proves.
