### PR TITLE
feat(sessions): per-session context-window cap pin from the action menu

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -13,6 +13,7 @@ import { UndoToast } from './components/UndoToast';
 import { WorktreeCleanupPrompt } from './components/WorktreeCleanupPrompt';
 import { CloseSessionPrompt } from './components/CloseSessionPrompt';
 import { ChiefOfStaffTransferPrompt } from './components/ChiefOfStaffTransferPrompt';
+import { SessionContextCapPrompt } from './components/SessionContextCapPrompt';
 import { TicketDetailPanel } from './components/TicketDetailPanel';
 import { TicketBoardSurface } from './components/TicketBoardSurface';
 import { WorkflowRunView } from './components/WorkflowRunView';
@@ -758,6 +759,7 @@ function AppContent({
     sendRenameSession,
     sendRenameWorkspace,
     sendSetChiefOfStaff,
+    sendSetSessionContextWindowCap,
     sendUnregisterSession,
     sendSetSetting,
     sendCreateWorktree,
@@ -1201,6 +1203,7 @@ function AppContent({
       turnOpenedAt: daemonSession?.turn_opened_at,
       turnSnoozedUntil: daemonSession?.turn_snoozed_until,
       pinnedAt: daemonSession?.pinned_at,
+      contextWindowCap: daemonSession?.context_window_cap,
       parentSessionId: daemonSession?.parent_session_id,
       autoSettleFiresAt: daemonSession?.auto_settle_fires_at,
       autoSettleHeld: daemonSession?.auto_settle_held ?? false,
@@ -1505,6 +1508,11 @@ function AppContent({
     currentLabel: string;
   } | null>(null);
   const [chiefTransferSaving, setChiefTransferSaving] = useState(false);
+  const [contextCapPromptSession, setContextCapPromptSession] = useState<{
+    id: string;
+    label: string;
+    currentCap?: number;
+  } | null>(null);
 
   const handleTerminalModelRecovered = useCallback(() => {
     showError(
@@ -1610,6 +1618,7 @@ function AppContent({
     || notebookOpen
     || boardSurfaceOpen
     || chiefTransferTarget !== null
+    || contextCapPromptSession !== null
     || closedWorktree !== null
     || pendingSessionClose !== null
     || sessionCreationJob !== null
@@ -1864,7 +1873,8 @@ function AppContent({
     }
     if (settingsOpen || shortcutsOpen || locationPickerOpen || whatsNew.isOpen
       || workspaceContextsOpen || notebookOpen || boardSurfaceOpen
-      || chiefTransferTarget !== null || closedWorktree !== null || pendingSessionClose !== null
+      || chiefTransferTarget !== null || contextCapPromptSession !== null
+      || closedWorktree !== null || pendingSessionClose !== null
       || sessionCreationJob !== null || openPRLauncherJob !== null) {
       return;
     }
@@ -1872,6 +1882,7 @@ function AppContent({
   }, [
     actionMenuOpen,
     chiefTransferTarget,
+    contextCapPromptSession,
     closedWorktree,
     locationPickerOpen,
     openPRLauncherJob,
@@ -2555,9 +2566,30 @@ function AppContent({
         run: () => sendPinSession(activeSession.id, !activeSession.pinnedAt),
       }]
       : [];
+    // Only claude and codex launches carry the cap to the agent; the daemon
+    // refuses it for anything else, so the entry is not offered there.
+    const sessionCapItems: ActionMenuItem[] = activeSession && ['claude', 'codex'].includes((activeSession.agent ?? '').toLowerCase())
+      ? [{
+        id: 'set-session-context-cap',
+        title: activeSession.contextWindowCap
+          ? `Change ${activeSession.label}'s context window cap`
+          : `Cap ${activeSession.label}'s context window`,
+        description: activeSession.contextWindowCap
+          ? `Compacts at ${activeSession.contextWindowCap.toLocaleString()} tokens — change or clear the cap`
+          : 'Make this agent compact at a token budget you choose',
+        keywords: ['context', 'window', 'cap', 'compact', 'autocompact', 'tokens', 'agent', 'session'],
+        icon: <ContextActionIcon />,
+        run: () => setContextCapPromptSession({
+          id: activeSession.id,
+          label: activeSession.label,
+          currentCap: activeSession.contextWindowCap,
+        }),
+      }]
+      : [];
     return [
       ...actionMenuItems,
       ...sessionPinItems,
+      ...sessionCapItems,
       {
         id: 'pin-active-workspace',
         title: workspace.pinned ? `Unpin ${workspace.title}` : `Pin ${workspace.title}`,
@@ -4057,6 +4089,14 @@ function AppContent({
           }
         }}
       />
+      {contextCapPromptSession && (
+        <SessionContextCapPrompt
+          sessionLabel={contextCapPromptSession.label}
+          currentCap={contextCapPromptSession.currentCap}
+          onSubmit={(cap) => sendSetSessionContextWindowCap(contextCapPromptSession.id, cap)}
+          onClose={() => setContextCapPromptSession(null)}
+        />
+      )}
       <ErrorToast message={errorMessage} durationMs={errorDurationMs} onDone={clearError} />
       <ChordLeaderHud />
       <WorkspaceContextNavigator

--- a/app/src/components/SessionContextCapPrompt.css
+++ b/app/src/components/SessionContextCapPrompt.css
@@ -1,0 +1,102 @@
+.context-cap-prompt {
+  align-items: center;
+  background: var(--color-bg-overlay);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  position: fixed;
+  z-index: 320;
+}
+
+.context-cap-content {
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.42);
+  max-width: min(92vw, 460px);
+  min-width: 380px;
+  padding: 20px 22px;
+  text-align: center;
+}
+
+.context-cap-title {
+  color: var(--color-text-muted);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  margin-bottom: 11px;
+  text-transform: uppercase;
+}
+
+.context-cap-message {
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+  line-height: 1.55;
+  margin-bottom: 14px;
+}
+
+.context-cap-message span {
+  color: #ff9b76;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.context-cap-input {
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border-hover);
+  border-radius: 6px;
+  color: var(--color-text-primary);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-sm);
+  margin-bottom: 14px;
+  padding: 8px 10px;
+  text-align: center;
+  width: 100%;
+}
+
+.context-cap-input:focus-visible {
+  outline: 2px solid rgba(88, 166, 255, 0.6);
+  outline-offset: 1px;
+}
+
+.context-cap-error {
+  color: var(--color-error, #f85149);
+  font-size: var(--font-size-sm);
+  margin-bottom: 12px;
+}
+
+.context-cap-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+.context-cap-actions button {
+  border: 1px solid var(--color-border-hover);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  padding: 8px 16px;
+}
+
+.context-cap-actions button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.context-cap-actions .cancel {
+  background: var(--color-border);
+  color: var(--color-text-primary);
+}
+
+.context-cap-actions .confirm {
+  background: rgba(88, 166, 255, 0.14);
+  border-color: rgba(88, 166, 255, 0.35);
+  color: #79b8ff;
+}
+
+.context-cap-actions button:focus-visible {
+  outline: 2px solid rgba(88, 166, 255, 0.6);
+  outline-offset: 2px;
+}

--- a/app/src/components/SessionContextCapPrompt.test.tsx
+++ b/app/src/components/SessionContextCapPrompt.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '../test/utils';
+import { SessionContextCapPrompt } from './SessionContextCapPrompt';
+
+describe('SessionContextCapPrompt', () => {
+  it('prefills the current cap and submits a changed value as a number', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    render(
+      <SessionContextCapPrompt
+        sessionLabel="trellis"
+        currentCap={300000}
+        onSubmit={onSubmit}
+        onClose={onClose}
+      />,
+    );
+
+    const input = screen.getByTestId('context-cap-input') as HTMLInputElement;
+    expect(input.value).toBe('300000');
+
+    fireEvent.change(input, { target: { value: '800000' } });
+    fireEvent.click(screen.getByTestId('context-cap-save'));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(800000));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('submits 0 for a blank value so the pin clears', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <SessionContextCapPrompt
+        sessionLabel="trellis"
+        currentCap={300000}
+        onSubmit={onSubmit}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('context-cap-input'), { target: { value: '' } });
+    fireEvent.click(screen.getByTestId('context-cap-save'));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(0));
+  });
+
+  it('closes without submitting when the value did not change', () => {
+    const onSubmit = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <SessionContextCapPrompt
+        sessionLabel="trellis"
+        currentCap={300000}
+        onSubmit={onSubmit}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('context-cap-save'));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows the daemon error and stays open when the submit rejects', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('context window cap must be 0 (no cap) or between 10000 and 2000000 tokens; got 5'));
+    const onClose = vi.fn();
+    render(
+      <SessionContextCapPrompt
+        sessionLabel="trellis"
+        onSubmit={onSubmit}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('context-cap-input'), { target: { value: '5' } });
+    fireEvent.click(screen.getByTestId('context-cap-save'));
+
+    await waitFor(() => expect(screen.getByTestId('context-cap-error').textContent).toContain('between 10000 and 2000000'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-integer locally', async () => {
+    const onSubmit = vi.fn();
+    render(
+      <SessionContextCapPrompt
+        sessionLabel="trellis"
+        onSubmit={onSubmit}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('context-cap-input'), { target: { value: '1.5' } });
+    fireEvent.click(screen.getByTestId('context-cap-save'));
+
+    await waitFor(() => expect(screen.getByTestId('context-cap-error')).toBeTruthy());
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/components/SessionContextCapPrompt.tsx
+++ b/app/src/components/SessionContextCapPrompt.tsx
@@ -76,8 +76,8 @@ export function SessionContextCapPrompt({
         </div>
         <div className="context-cap-message" id="context-cap-message">
           Cap <span>{sessionLabel}</span>&rsquo;s context window so it compacts at this
-          many tokens. Blank means no cap. Saving reloads the agent in place;
-          the conversation is resumed.
+          many tokens. Blank means no cap. Saving reloads the agent to apply it:
+          the conversation is resumed, but anything mid-turn is lost.
         </div>
         <input
           ref={inputRef}

--- a/app/src/components/SessionContextCapPrompt.tsx
+++ b/app/src/components/SessionContextCapPrompt.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef, useState } from 'react';
+import { useEscapeStack } from '../hooks/useEscapeStack';
+import './SessionContextCapPrompt.css';
+
+// The action-menu route to a per-session context-window cap: one number input,
+// Enter saves, blank (or 0) clears the pin so the session falls back to the
+// chief / per-agent default settings. Saving a change reloads the agent in
+// place (the cap only applies at launch), which the copy says out loud.
+interface SessionContextCapPromptProps {
+  sessionLabel: string;
+  /** Current pin in tokens; undefined when the session has none. */
+  currentCap?: number;
+  onSubmit: (cap: number) => Promise<void>;
+  onClose: () => void;
+}
+
+export function SessionContextCapPrompt({
+  sessionLabel,
+  currentCap,
+  onSubmit,
+  onClose,
+}: SessionContextCapPromptProps) {
+  const [value, setValue] = useState(currentCap ? String(currentCap) : '');
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEscapeStack(onClose, !isSaving);
+
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input) return;
+    input.focus();
+    input.select();
+  }, []);
+
+  const handleSubmit = async () => {
+    const trimmed = value.trim();
+    const cap = trimmed === '' ? 0 : Number(trimmed);
+    if (!Number.isInteger(cap) || cap < 0) {
+      setError('Enter a whole number of tokens, or leave blank for no cap');
+      return;
+    }
+    if (cap === (currentCap ?? 0)) {
+      onClose();
+      return;
+    }
+    setIsSaving(true);
+    setError(null);
+    try {
+      await onSubmit(cap);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Setting the cap failed');
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="context-cap-prompt"
+      data-testid="context-cap-prompt"
+      role="presentation"
+      onClick={isSaving ? undefined : onClose}
+    >
+      <div
+        className="context-cap-content"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="context-cap-title"
+        aria-describedby="context-cap-message"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="context-cap-title" id="context-cap-title">
+          Context window cap
+        </div>
+        <div className="context-cap-message" id="context-cap-message">
+          Cap <span>{sessionLabel}</span>&rsquo;s context window so it compacts at this
+          many tokens. Blank means no cap. Saving reloads the agent in place;
+          the conversation is resumed.
+        </div>
+        <input
+          ref={inputRef}
+          className="context-cap-input"
+          data-testid="context-cap-input"
+          type="number"
+          min={0}
+          step={1000}
+          inputMode="numeric"
+          placeholder="e.g. 800000 — blank for no cap"
+          value={value}
+          onChange={(event) => {
+            setValue(event.target.value);
+            if (error) setError(null);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              void handleSubmit();
+            }
+          }}
+          disabled={isSaving}
+          aria-label="Context window cap in tokens"
+        />
+        {error ? <div className="context-cap-error" data-testid="context-cap-error">{error}</div> : null}
+        <div className="context-cap-actions">
+          <button
+            type="button"
+            className="cancel"
+            data-testid="context-cap-cancel"
+            onClick={onClose}
+            disabled={isSaving}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="confirm"
+            data-testid="context-cap-save"
+            onClick={handleSubmit}
+            disabled={isSaving}
+          >
+            {isSaving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -201,7 +201,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '216';
+export const PROTOCOL_VERSION = '217';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // AutomationActionTimeoutError distinguishes "the daemon never sent a
@@ -1563,6 +1563,22 @@ export function useDaemonSocket({
                   pending.resolve(undefined);
                 } else {
                   pending.reject(new Error(data.error || 'Chief of staff update failed'));
+                }
+              }
+            }
+            break;
+          }
+
+          case 'session_context_window_cap_result': {
+            if (typeof data.session_id === 'string') {
+              const key = `session_context_cap:${data.session_id}`;
+              const pending = pendingActionsRef.current.get(key);
+              if (pending) {
+                pendingActionsRef.current.delete(key);
+                if (data.success) {
+                  pending.resolve(undefined);
+                } else {
+                  pending.reject(new Error(data.error || 'Setting the context window cap failed'));
                 }
               }
             }
@@ -3901,6 +3917,25 @@ export function useDaemonSocket({
     });
   }, []);
 
+  // Pin (cap > 0) or clear (cap 0) a per-session context-window cap. The daemon
+  // stores the pin and reloads a live agent in place so it applies immediately.
+  // Last-writer-wins per session: a second cap for the same session supersedes
+  // the first rather than queueing behind it, so the key is the session id.
+  const sendSetSessionContextWindowCap = useCallback((sessionId: string, cap: number): Promise<void> => {
+    if (!sessionId) {
+      return Promise.reject(new Error('Session is required'));
+    }
+    if (!hasReceivedInitialStateRef.current) {
+      return Promise.reject(new Error('WebSocket not connected'));
+    }
+    return sendKeyedRequest<void>(
+      `session_context_cap:${sessionId}`,
+      { cmd: 'set_session_context_window_cap', session_id: sessionId, cap },
+      `Context window cap update timed out for session ${sessionId}`,
+      10_000,
+    );
+  }, [sendKeyedRequest]);
+
   // Unregister a single session from daemon
   const sendUnregisterSession = useCallback((sessionId: string): Promise<void> => {
     return new Promise((resolve, reject) => {
@@ -5090,6 +5125,7 @@ export function useDaemonSocket({
     sendRenameSession,
     sendRenameWorkspace,
     sendSetChiefOfStaff,
+    sendSetSessionContextWindowCap,
     sendPRVisited,
     sendListWorktrees,
     sendCreateWorktree,

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, AgentEventMessage, AgentPromptMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, DocUndefineMessage, DocUndefineResult, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, AddEndpointMessage, AgentEventMessage, AgentPromptMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, DocUndefineMessage, DocUndefineResult, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const agentEventMessage = Convert.toAgentEventMessage(json);
@@ -294,6 +294,7 @@
 //   const sessionAnnotationsSaveResultMessage = Convert.toSessionAnnotationsSaveResultMessage(json);
 //   const sessionAnnotationsSubmitMessage = Convert.toSessionAnnotationsSubmitMessage(json);
 //   const sessionAnnotationsSubmitResultMessage = Convert.toSessionAnnotationsSubmitResultMessage(json);
+//   const sessionContextWindowCapResultMessage = Convert.toSessionContextWindowCapResultMessage(json);
 //   const sessionExitedMessage = Convert.toSessionExitedMessage(json);
 //   const sessionInstructionsMessage = Convert.toSessionInstructionsMessage(json);
 //   const sessionInstructionsResult = Convert.toSessionInstructionsResult(json);
@@ -313,6 +314,7 @@
 //   const setChiefOfStaffMessage = Convert.toSetChiefOfStaffMessage(json);
 //   const setEndpointRemoteWebMessage = Convert.toSetEndpointRemoteWebMessage(json);
 //   const setPluginPriorityMessage = Convert.toSetPluginPriorityMessage(json);
+//   const setSessionContextWindowCapMessage = Convert.toSetSessionContextWindowCapMessage(json);
 //   const setSessionResumeIDMessage = Convert.toSetSessionResumeIDMessage(json);
 //   const setSettingMessage = Convert.toSetSettingMessage(json);
 //   const setTerminalThemeMessage = Convert.toSetTerminalThemeMessage(json);
@@ -946,6 +948,7 @@ export interface SessionElement {
     auto_settle_held?:     boolean;
     branch?:               string;
     chief_of_staff?:       boolean;
+    context_window_cap?:   number;
     delegated_from_chief?: boolean;
     directory:             string;
     endpoint_id?:          string;
@@ -4670,6 +4673,7 @@ export interface Session {
     auto_settle_held?:     boolean;
     branch?:               string;
     chief_of_staff?:       boolean;
+    context_window_cap?:   number;
     delegated_from_chief?: boolean;
     directory:             string;
     endpoint_id?:          string;
@@ -4823,6 +4827,19 @@ export interface SessionAnnotationsSubmitResultMessage {
 
 export enum SessionAnnotationsSubmitResultMessageEvent {
     SessionAnnotationsSubmitResult = "session_annotations_submit_result",
+}
+
+export interface SessionContextWindowCapResultMessage {
+    cap:        number;
+    error?:     string;
+    event:      SessionContextWindowCapResultMessageEvent;
+    session_id: string;
+    success:    boolean;
+    [property: string]: any;
+}
+
+export enum SessionContextWindowCapResultMessageEvent {
+    SessionContextWindowCapResult = "session_context_window_cap_result",
 }
 
 export interface SessionExitedMessage {
@@ -5019,6 +5036,17 @@ export interface SetPluginPriorityMessage {
 
 export enum SetPluginPriorityMessageCmd {
     SetPluginPriority = "set_plugin_priority",
+}
+
+export interface SetSessionContextWindowCapMessage {
+    cap:        number;
+    cmd:        SetSessionContextWindowCapMessageCmd;
+    session_id: string;
+    [property: string]: any;
+}
+
+export enum SetSessionContextWindowCapMessageCmd {
+    SetSessionContextWindowCap = "set_session_context_window_cap",
 }
 
 export interface SetSessionResumeIDMessage {
@@ -8843,6 +8871,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SessionAnnotationsSubmitResultMessage")), null, 2);
     }
 
+    public static toSessionContextWindowCapResultMessage(json: string): SessionContextWindowCapResultMessage {
+        return cast(JSON.parse(json), r("SessionContextWindowCapResultMessage"));
+    }
+
+    public static sessionContextWindowCapResultMessageToJson(value: SessionContextWindowCapResultMessage): string {
+        return JSON.stringify(uncast(value, r("SessionContextWindowCapResultMessage")), null, 2);
+    }
+
     public static toSessionExitedMessage(json: string): SessionExitedMessage {
         return cast(JSON.parse(json), r("SessionExitedMessage"));
     }
@@ -8993,6 +9029,14 @@ export class Convert {
 
     public static setPluginPriorityMessageToJson(value: SetPluginPriorityMessage): string {
         return JSON.stringify(uncast(value, r("SetPluginPriorityMessage")), null, 2);
+    }
+
+    public static toSetSessionContextWindowCapMessage(json: string): SetSessionContextWindowCapMessage {
+        return cast(JSON.parse(json), r("SetSessionContextWindowCapMessage"));
+    }
+
+    public static setSessionContextWindowCapMessageToJson(value: SetSessionContextWindowCapMessage): string {
+        return JSON.stringify(uncast(value, r("SetSessionContextWindowCapMessage")), null, 2);
     }
 
     public static toSetSessionResumeIDMessage(json: string): SetSessionResumeIDMessage {
@@ -10475,6 +10519,7 @@ const typeMap: any = {
         { json: "auto_settle_held", js: "auto_settle_held", typ: u(undefined, true) },
         { json: "branch", js: "branch", typ: u(undefined, "") },
         { json: "chief_of_staff", js: "chief_of_staff", typ: u(undefined, true) },
+        { json: "context_window_cap", js: "context_window_cap", typ: u(undefined, 0) },
         { json: "delegated_from_chief", js: "delegated_from_chief", typ: u(undefined, true) },
         { json: "directory", js: "directory", typ: "" },
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
@@ -12731,6 +12776,7 @@ const typeMap: any = {
         { json: "auto_settle_held", js: "auto_settle_held", typ: u(undefined, true) },
         { json: "branch", js: "branch", typ: u(undefined, "") },
         { json: "chief_of_staff", js: "chief_of_staff", typ: u(undefined, true) },
+        { json: "context_window_cap", js: "context_window_cap", typ: u(undefined, 0) },
         { json: "delegated_from_chief", js: "delegated_from_chief", typ: u(undefined, true) },
         { json: "directory", js: "directory", typ: "" },
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
@@ -12830,6 +12876,13 @@ const typeMap: any = {
         { json: "request_id", js: "request_id", typ: "" },
         { json: "session_id", js: "session_id", typ: "" },
         { json: "status", js: "status", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "SessionContextWindowCapResultMessage": o([
+        { json: "cap", js: "cap", typ: 0 },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("SessionContextWindowCapResultMessageEvent") },
+        { json: "session_id", js: "session_id", typ: "" },
         { json: "success", js: "success", typ: true },
     ], "any"),
     "SessionExitedMessage": o([
@@ -12933,6 +12986,11 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("SetPluginPriorityMessageCmd") },
         { json: "name", js: "name", typ: "" },
         { json: "priority", js: "priority", typ: 0 },
+    ], "any"),
+    "SetSessionContextWindowCapMessage": o([
+        { json: "cap", js: "cap", typ: 0 },
+        { json: "cmd", js: "cmd", typ: r("SetSessionContextWindowCapMessageCmd") },
+        { json: "session_id", js: "session_id", typ: "" },
     ], "any"),
     "SetSessionResumeIDMessage": o([
         { json: "cmd", js: "cmd", typ: r("SetSessionResumeIDMessageCmd") },
@@ -14524,6 +14582,9 @@ const typeMap: any = {
     "SessionAnnotationsSubmitResultMessageEvent": [
         "session_annotations_submit_result",
     ],
+    "SessionContextWindowCapResultMessageEvent": [
+        "session_context_window_cap_result",
+    ],
     "SessionExitedMessageEvent": [
         "session_exited",
     ],
@@ -14565,6 +14626,9 @@ const typeMap: any = {
     ],
     "SetPluginPriorityMessageCmd": [
         "set_plugin_priority",
+    ],
+    "SetSessionContextWindowCapMessageCmd": [
+        "set_session_context_window_cap",
     ],
     "SetSessionResumeIDMessageCmd": [
         "set_session_resume_id",

--- a/changelog.d/fluffy-otter-per-session-context-window-cap.yaml
+++ b/changelog.d/fluffy-otter-per-session-context-window-cap.yaml
@@ -1,0 +1,14 @@
+kind: added
+area: sessions
+change: >
+  A single session can now be given its own context-window cap. Select it,
+  open the command menu, and "Cap <agent>'s context window" asks for a token
+  threshold to auto-compact at — 10,000 to 2,000,000 tokens, or blank to
+  remove the pin. The pin outranks both the chief cap and the per-agent
+  default, so one long-lived session can compact later (or earlier) than
+  every other session of the same agent without touching Settings. The cap
+  only reaches an agent when it launches, so setting or clearing it on a
+  running session reloads that agent in place, resuming its conversation the
+  way promoting a session to chief does — anything mid-turn is lost. Only
+  Claude and Codex sessions carry a cap; the menu item is absent elsewhere,
+  and the daemon refuses the pin rather than storing one that never applies.

--- a/internal/daemon/bus.go
+++ b/internal/daemon/bus.go
@@ -90,6 +90,9 @@ const (
 	// released back into it. Distinct from FactWorkspacePinChanged, which moves
 	// a whole workspace and its siblings.
 	FactSessionPinChanged = "session.pin.changed"
+	// FactSessionCapChanged: this session's context-window cap pin was set or
+	// cleared.
+	FactSessionCapChanged = "session.cap.changed"
 
 	// FactWorktreeSessionsRemoved: deleting this worktree took its sessions with
 	// it. Subject is the worktree path.
@@ -290,9 +293,10 @@ func buildWireProjections() []projection {
 		},
 		{
 			// A pin changes what the session says about itself (turn_owed and
-			// pinned_at), and nothing about its workspace, so it re-pushes the one
-			// session rather than recomputing the group around it.
-			filter: bus.Filter{FactSessionPinChanged},
+			// pinned_at, or context_window_cap), and nothing about its workspace,
+			// so it re-pushes the one session rather than recomputing the group
+			// around it.
+			filter: bus.Filter{FactSessionPinChanged, FactSessionCapChanged},
 			apply:  func(d *Daemon, ev bus.Event) { d.projectSessionStateChanged(ev.Subject) },
 		},
 		{

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -52,6 +52,7 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdWorkspaceSelected:                     commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdSettleTurn:                            commandMetadata(ScopeSession, false, true),
 	protocol.CmdPinSession:                            commandMetadata(ScopeSession, false, true),
+	protocol.CmdSetSessionContextWindowCap:            commandMetadata(ScopeSession, false, true),
 	protocol.CmdSnoozeTurn:                            commandMetadata(ScopeSession, false, true),
 	protocol.CmdWakeTurn:                              commandMetadata(ScopeSession, false, true),
 	protocol.CmdCancelCountdown:                       commandMetadata(ScopeSession, false, true),

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2527,6 +2527,13 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 			return
 		}
 		d.sendOK(conn)
+	case protocol.CmdSetSessionContextWindowCap: // wire: set_session_context_window_cap
+		m := msg.(*protocol.SetSessionContextWindowCapMessage)
+		if err := d.setSessionContextWindowCap(m.SessionID, m.Cap); err != nil {
+			d.sendError(conn, err.Error())
+			return
+		}
+		d.sendOK(conn)
 	case protocol.CmdCollapseRepo: // wire: collapse_repo
 		d.handleCollapseRepo(conn, msg.(*protocol.CollapseRepoMessage))
 	case protocol.CmdQueryRepos: // wire: query_repos

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3765,30 +3765,92 @@ func TestDaemon_ContextWindowCapResolutionAndGating(t *testing.T) {
 	// launchContextWindowCap: 0 for a non-chief launch with no per-agent
 	// setting; default for a chief with no setting; the configured values
 	// otherwise, with the chief setting winning on chief launches.
-	if got := d.launchContextWindowCap("claude", false); got != 0 {
+	if got := d.launchContextWindowCap("sess-1", "claude", false); got != 0 {
 		t.Fatalf("non-chief cap with no setting = %d, want 0 (uncapped)", got)
 	}
-	if got := d.launchContextWindowCap("claude", true); got != agentdriver.DefaultContextWindowCap {
+	if got := d.launchContextWindowCap("sess-1", "claude", true); got != agentdriver.DefaultContextWindowCap {
 		t.Fatalf("chief cap with no setting = %d, want default %d", got, agentdriver.DefaultContextWindowCap)
 	}
 	d.store.SetSetting(SettingChiefContextWindowCap, "160000")
-	if got := d.launchContextWindowCap("claude", true); got != 160000 {
+	if got := d.launchContextWindowCap("sess-1", "claude", true); got != 160000 {
 		t.Fatalf("chief cap = %d, want 160000", got)
 	}
 	d.store.SetSetting(SettingDefaultContextWindowCapPrefix+"claude", "800000")
-	if got := d.launchContextWindowCap("claude", false); got != 800000 {
+	if got := d.launchContextWindowCap("sess-1", "claude", false); got != 800000 {
 		t.Fatalf("per-agent default cap = %d, want 800000", got)
 	}
-	if got := d.launchContextWindowCap("Claude", false); got != 800000 {
+	if got := d.launchContextWindowCap("sess-1", "Claude", false); got != 800000 {
 		t.Fatalf("per-agent default cap (case-insensitive) = %d, want 800000", got)
 	}
-	if got := d.launchContextWindowCap("codex", false); got != 0 {
+	if got := d.launchContextWindowCap("sess-1", "codex", false); got != 0 {
 		t.Fatalf("other agent's cap = %d, want 0 (uncapped)", got)
 	}
 	// The chief setting still wins on chief launches even with a per-agent
 	// default configured.
-	if got := d.launchContextWindowCap("claude", true); got != 160000 {
+	if got := d.launchContextWindowCap("sess-1", "claude", true); got != 160000 {
 		t.Fatalf("chief cap with per-agent default also set = %d, want 160000", got)
+	}
+
+	// A per-session pin outranks everything: the chief setting on chief
+	// launches, and the per-agent default on plain ones.
+	d.store.Add(&protocol.Session{ID: "sess-pinned", Label: "pinned", Agent: protocol.SessionAgentClaude, Directory: "/tmp"})
+	if !d.store.SetSessionContextWindowCap("sess-pinned", 300000) {
+		t.Fatalf("SetSessionContextWindowCap failed")
+	}
+	if got := d.launchContextWindowCap("sess-pinned", "claude", false); got != 300000 {
+		t.Fatalf("pinned cap = %d, want 300000", got)
+	}
+	if got := d.launchContextWindowCap("sess-pinned", "claude", true); got != 300000 {
+		t.Fatalf("pinned cap on a chief launch = %d, want 300000 (pin outranks chief setting)", got)
+	}
+	// Clearing the pin falls back to the settings.
+	if !d.store.SetSessionContextWindowCap("sess-pinned", 0) {
+		t.Fatalf("clear SetSessionContextWindowCap failed")
+	}
+	if got := d.launchContextWindowCap("sess-pinned", "claude", false); got != 800000 {
+		t.Fatalf("cleared pin cap = %d, want per-agent default 800000", got)
+	}
+}
+
+// TestDaemon_SetSessionContextWindowCap covers the write path behind
+// set_session_context_window_cap: validation, idempotence, and the pin landing
+// on the session record that broadcasts carry.
+func TestDaemon_SetSessionContextWindowCap(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.store.Add(&protocol.Session{ID: "sess-cap", Label: "capped", Agent: protocol.SessionAgentClaude, Directory: "/tmp"})
+	d.store.Add(&protocol.Session{ID: "sess-shell", Label: "shell", Agent: protocol.SessionAgentShell, Directory: "/tmp"})
+
+	if err := d.setSessionContextWindowCap("", 200000); err == nil {
+		t.Fatalf("missing session_id accepted")
+	}
+	if err := d.setSessionContextWindowCap("sess-missing", 200000); err == nil {
+		t.Fatalf("unknown session accepted")
+	}
+	if err := d.setSessionContextWindowCap("sess-shell", 200000); err == nil {
+		t.Fatalf("shell session accepted a cap it can never apply")
+	}
+	for _, invalid := range []int{-1, 1, contextWindowCapMin - 1, contextWindowCapMax + 1} {
+		if err := d.setSessionContextWindowCap("sess-cap", invalid); err == nil {
+			t.Fatalf("out-of-bounds cap %d accepted", invalid)
+		}
+	}
+
+	if err := d.setSessionContextWindowCap("sess-cap", 500000); err != nil {
+		t.Fatalf("set cap: %v", err)
+	}
+	if got := protocol.Deref(d.store.Get("sess-cap").ContextWindowCap); got != 500000 {
+		t.Fatalf("stored cap = %d, want 500000", got)
+	}
+	// Repeating the same pin is a no-op, not an error.
+	if err := d.setSessionContextWindowCap("sess-cap", 500000); err != nil {
+		t.Fatalf("idempotent set errored: %v", err)
+	}
+	// 0 clears the pin.
+	if err := d.setSessionContextWindowCap("sess-cap", 0); err != nil {
+		t.Fatalf("clear cap: %v", err)
+	}
+	if d.store.Get("sess-cap").ContextWindowCap != nil {
+		t.Fatalf("cleared cap still stored")
 	}
 }
 

--- a/internal/daemon/reload.go
+++ b/internal/daemon/reload.go
@@ -376,11 +376,12 @@ func (d *Daemon) buildReloadSpawnOptionsFromLaunchParams(session *protocol.Sessi
 		WorkflowGuidanceEnabled: parseBooleanSetting(d.store.GetSetting(SettingWorkflowsEnabled)),
 		AutoApprove:             false,
 		// Carry the context-window cap across an in-place reload so a reloaded
-		// session comes back capped the same way a fresh launch would: the chief
-		// from chief_context_window_cap (gate on the persisted chief role, staying
-		// consistent with the NotebookGuide RPC keyed on sessionID), every other
-		// session from default_context_window_cap_<agent>.
-		ContextWindowCap: d.launchContextWindowCap(session.Agent, d.isChiefOfStaffSession(sessionID)),
+		// session comes back capped the same way a fresh launch would: its own
+		// pin first, then the chief from chief_context_window_cap (gate on the
+		// persisted chief role, staying consistent with the NotebookGuide RPC
+		// keyed on sessionID), every other session from
+		// default_context_window_cap_<agent>.
+		ContextWindowCap: d.launchContextWindowCap(sessionID, string(session.Agent), d.isChiefOfStaffSession(sessionID)),
 	}
 	if !params.UnattendedLaunch.IsZero() {
 		if err := params.UnattendedLaunch.Validate(); err != nil {
@@ -565,7 +566,7 @@ func (d *Daemon) preparePluginRoleReload(sessionID string, desiredChief bool) (*
 		lock.Unlock()
 		return nil, true, err
 	}
-	opts.ContextWindowCap = d.launchContextWindowCap(session.Agent, desiredChief)
+	opts.ContextWindowCap = d.launchContextWindowCap(sessionID, string(session.Agent), desiredChief)
 	pluginReload, err := d.preparePluginReload(session, &opts, desiredChief)
 	if err != nil {
 		lock.Unlock()

--- a/internal/daemon/reload_test.go
+++ b/internal/daemon/reload_test.go
@@ -409,6 +409,22 @@ func TestBuildReloadSpawnOptionsCarriesContextWindowCap(t *testing.T) {
 			t.Fatalf("ContextWindowCap = %d, want 800000 (reloaded session must stay capped)", opts.ContextWindowCap)
 		}
 	})
+
+	t.Run("reloaded session keeps its own pin over every setting", func(t *testing.T) {
+		d := newDaemonWithSession(t, "worker")
+		d.store.SetSetting(SettingDefaultContextWindowCapPrefix+"claude", "800000")
+		if !d.store.SetSessionContextWindowCap("worker", 300000) {
+			t.Fatalf("SetSessionContextWindowCap failed")
+		}
+
+		opts, err := d.buildReloadSpawnOptions(d.store.Get("worker"))
+		if err != nil {
+			t.Fatalf("buildReloadSpawnOptions: %v", err)
+		}
+		if opts.ContextWindowCap != 300000 {
+			t.Fatalf("ContextWindowCap = %d, want the 300000 pin (a reload is how the pin takes effect)", opts.ContextWindowCap)
+		}
+	})
 }
 
 func TestBuildReloadSpawnOptionsPreservesUnattendedContractAsUnit(t *testing.T) {

--- a/internal/daemon/session_context_cap.go
+++ b/internal/daemon/session_context_cap.go
@@ -1,0 +1,72 @@
+package daemon
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// handleSetSessionContextWindowCap pins a per-session context-window cap
+// (tokens), or clears the pin with cap 0. The pin outranks the chief and
+// per-agent default settings in launchContextWindowCap, and a changed pin on a
+// live session reloads the agent in place (resume-preserving) so it takes
+// effect now rather than at some future respawn the user cannot see.
+func (d *Daemon) handleSetSessionContextWindowCap(client *wsClient, msg *protocol.SetSessionContextWindowCapMessage) {
+	err := d.setSessionContextWindowCap(msg.SessionID, msg.Cap)
+	result := protocol.SessionContextWindowCapResultMessage{
+		Event:     protocol.EventSessionContextWindowCapResult,
+		SessionID: msg.SessionID,
+		Cap:       msg.Cap,
+		Success:   err == nil,
+	}
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+	}
+	d.sendToClient(client, result)
+}
+
+// setSessionContextWindowCap is the one place the cap pin is written. The cap
+// only reaches the agent at launch (Claude reads CLAUDE_CODE_AUTO_COMPACT_WINDOW
+// from its environment, codex takes a config override), so after storing a
+// changed pin it kicks off the same in-place reload a chief promotion uses —
+// the running process cannot be re-capped, but its resume-respawn can.
+func (d *Daemon) setSessionContextWindowCap(sessionID string, cap int) error {
+	if d == nil || d.store == nil {
+		return fmt.Errorf("store unavailable")
+	}
+	id := strings.TrimSpace(sessionID)
+	if id == "" {
+		return fmt.Errorf("missing session_id")
+	}
+	session := d.store.Get(id)
+	if session == nil {
+		return fmt.Errorf("session not found")
+	}
+	if cap != 0 {
+		if cap < contextWindowCapMin || cap > contextWindowCapMax {
+			return fmt.Errorf("context window cap must be 0 (no cap) or between %d and %d tokens; got %d", contextWindowCapMin, contextWindowCapMax, cap)
+		}
+	}
+	// Only the built-in claude/codex launch paths carry the cap to the agent
+	// (env var / config override). Accepting it for a shell or a plugin driver
+	// would store a pin that silently never applies.
+	switch normalizeSpawnAgent(string(session.Agent)) {
+	case string(protocol.SessionAgentClaude), string(protocol.SessionAgentCodex):
+	default:
+		return fmt.Errorf("agent %q takes no context-window cap; only claude and codex launches carry one", session.Agent)
+	}
+	// Idempotent: a repeated pin neither publishes a fact nothing acts on nor
+	// kill-respawns an innocent agent.
+	if protocol.Deref(session.ContextWindowCap) == cap {
+		return nil
+	}
+	if !d.store.SetSessionContextWindowCap(id, cap) {
+		return fmt.Errorf("persist context-window cap failed")
+	}
+	d.publishFact(FactSessionCapChanged, id, nil)
+	if d.sessionHasLiveWorker(id) {
+		go d.reloadSessionAgent(id)
+	}
+	return nil
+}

--- a/internal/daemon/spawn_pipeline.go
+++ b/internal/daemon/spawn_pipeline.go
@@ -267,10 +267,10 @@ func (d *Daemon) resolveSpawnIntent(req *spawnRequest) (*spawnPlan, *spawnReject
 	} else {
 		plan.spawnOpts.ApprovalRoute = launchcontract.ResolveApprovalRoute(plan.spawnOpts.YoloMode, plan.spawnOpts.AutoApprove, plan.spawnOpts.UnattendedLaunch)
 	}
-	// A chief launch caps its context window (chief_context_window_cap); every
-	// other launch takes default_context_window_cap_<agent>, unset meaning
-	// uncapped.
-	plan.spawnOpts.ContextWindowCap = d.launchContextWindowCap(req.agent, plan.isChief)
+	// A per-session pin wins; otherwise a chief launch caps its context window
+	// (chief_context_window_cap) and every other launch takes
+	// default_context_window_cap_<agent>, unset meaning uncapped.
+	plan.spawnOpts.ContextWindowCap = d.launchContextWindowCap(msg.ID, req.agent, plan.isChief)
 
 	return plan, nil
 }

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -1005,6 +1005,8 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handlePinWorkspaceWS(client, msg.(*protocol.PinWorkspaceMessage))
 	case protocol.CmdPinSession: // wire: pin_session
 		d.handlePinSession(client, msg.(*protocol.PinSessionMessage))
+	case protocol.CmdSetSessionContextWindowCap: // wire: set_session_context_window_cap
+		d.handleSetSessionContextWindowCap(client, msg.(*protocol.SetSessionContextWindowCapMessage))
 	case protocol.CmdRefreshPRs: // wire: refresh_prs
 		d.handleRefreshPRsWS(client)
 	case protocol.CmdFetchPRDetails: // wire: fetch_pr_details
@@ -1374,6 +1376,12 @@ func remoteCommandSessionID(cmd string, msg interface{}) string {
 		// would write to a session the hub does not have and the next snapshot
 		// from the endpoint would put the row straight back in the queue.
 		if typed, ok := msg.(*protocol.PinSessionMessage); ok {
+			return typed.SessionID
+		}
+	case protocol.CmdSetSessionContextWindowCap: // wire: set_session_context_window_cap
+		// Same shape as the queue pin: the cap is a column on the session row,
+		// and the reload that applies it runs where the worker lives.
+		if typed, ok := msg.(*protocol.SetSessionContextWindowCapMessage); ok {
 			return typed.SessionID
 		}
 	case protocol.CmdSessionMessagesGet: // wire: session_messages_get

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -489,13 +489,20 @@ func (d *Daemon) resolveLaunchEffort(agent string, chief bool, requested string)
 }
 
 // launchContextWindowCap returns the effective context-window token cap for an
-// interactive launch of the given agent, or 0 (no cap). Mirrors
+// interactive launch of sessionID's agent, or 0 (no cap). Mirrors
 // resolveLaunchModel: the policy lives here, the driver only applies it. A
-// chief launch takes chief_context_window_cap (which defaults to
+// per-session pin (set_session_context_window_cap) wins outright — it is the
+// user's explicit act on this one session, so it outranks even the chief cap.
+// Otherwise a chief launch takes chief_context_window_cap (which defaults to
 // DefaultContextWindowCap, so the chief is always capped); every other launch
 // takes default_context_window_cap_<agent>, whose unset state means uncapped —
 // the agent's own compaction behavior.
-func (d *Daemon) launchContextWindowCap(agent string, chief bool) int {
+func (d *Daemon) launchContextWindowCap(sessionID, agent string, chief bool) int {
+	if session := d.store.Get(strings.TrimSpace(sessionID)); session != nil {
+		if cap := protocol.Deref(session.ContextWindowCap); cap > 0 {
+			return cap
+		}
+	}
 	if chief {
 		return resolveContextWindowCap(d.store.GetSetting(SettingChiefContextWindowCap))
 	}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "216"
+const ProtocolVersion = "217"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only
@@ -281,6 +281,7 @@ const (
 	CmdRenameWorkspace                       = "rename_workspace"
 	CmdSetWorkspaceRank                      = "set_workspace_rank"
 	CmdSetChiefOfStaff                       = "set_chief_of_staff"
+	CmdSetSessionContextWindowCap            = "set_session_context_window_cap"
 )
 
 // Per-action automations result events (socket + WS share one command set;
@@ -316,6 +317,7 @@ const (
 	EventSessionsUpdated                 = "sessions_updated"
 	EventRenameResult                    = "rename_result"
 	EventChiefOfStaffResult              = "chief_of_staff_result"
+	EventSessionContextWindowCapResult   = "session_context_window_cap_result"
 	EventTicketsUpdated                  = "tickets_updated"
 	EventTicketResult                    = "ticket_result"
 	EventTicketActionResult              = "ticket_action_result"
@@ -1820,6 +1822,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 		var msg SetChiefOfStaffMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, fmt.Errorf("unmarshal set_chief_of_staff: %w", err)
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdSetSessionContextWindowCap:
+		var msg SetSessionContextWindowCapMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, fmt.Errorf("unmarshal set_session_context_window_cap: %w", err)
 		}
 		return peek.Cmd, &msg, nil
 

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -4433,6 +4433,9 @@ type Session struct {
 	// ChiefOfStaff corresponds to the JSON schema field "chief_of_staff".
 	ChiefOfStaff *bool `json:"chief_of_staff,omitempty,omitzero"`
 
+	// ContextWindowCap corresponds to the JSON schema field "context_window_cap".
+	ContextWindowCap *int `json:"context_window_cap,omitempty,omitzero"`
+
 	// DelegatedFromChief corresponds to the JSON schema field "delegated_from_chief".
 	DelegatedFromChief *bool `json:"delegated_from_chief,omitempty,omitzero"`
 
@@ -4671,6 +4674,23 @@ type SessionAnnotationsSubmitResultMessage struct {
 	Success bool `json:"success"`
 }
 
+type SessionContextWindowCapResultMessage struct {
+	// Cap corresponds to the JSON schema field "cap".
+	Cap int `json:"cap"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID string `json:"session_id"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
 type SessionExitedMessage struct {
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -4903,6 +4923,17 @@ type SetPluginPriorityMessage struct {
 
 	// Priority corresponds to the JSON schema field "priority".
 	Priority int `json:"priority"`
+}
+
+type SetSessionContextWindowCapMessage struct {
+	// Cap corresponds to the JSON schema field "cap".
+	Cap int `json:"cap"`
+
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID string `json:"session_id"`
 }
 
 type SetSessionResumeIDMessage struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -142,6 +142,7 @@ model Session {
   auto_settle_fires_at?: string; // ISO timestamp the auto-settle countdown will close this session's turn. Present only while the countdown is running, which is the whole contract: it is what the terminal tile animates against, and its absence is what says nothing is pending. Absent during the arm delay, when auto-settle is off, and after a cancel.
   auto_settle_held?: boolean;   // True while the auto-settle countdown is frozen because the user is typing or moving the pointer in this session. Mutually exclusive with auto_settle_fires_at by construction: a frozen countdown has no deadline to animate against, so the tile draws a full paused bar and waits. It clears on its own five quiet seconds after the last interaction, when a fresh deadline replaces it.
   pinned_at?: string;           // ISO timestamp this session was individually pinned out of the queue. Presence is the pin, and the instant is the pinned band's sort key. Like a pinned workspace it filters at read: the turn stamps keep accruing underneath, so unpinning surfaces whatever was outstanding at its true age.
+  context_window_cap?: int32;   // Per-session context-window cap in tokens, set by the user on this one session. Absent means no pin — the launch falls back to the chief or per-agent default settings. A pin outranks both, and takes effect at the next launch of the agent (the daemon reloads a live session in place when the pin changes).
   parent_session_id?: string;   // The agent session a shell was split from. Spawn-time provenance resolved by the daemon, always an agent id and never another shell's, so there is no chain to walk. Whether the link is live is judged at read (parent present in the same workspace), so the field itself is never cleared.
   todos?: string[];             // Optional: can be empty/absent
   last_seen: string;            // ISO timestamp, always set
@@ -2504,6 +2505,16 @@ model SetWorkspaceRankMessage {
   next_workspace_id?: string;
 }
 
+// Pin or clear a per-session context-window cap (tokens). cap > 0 pins; cap 0
+// clears the pin so the launch falls back to the chief or per-agent default
+// settings. A changed pin on a live claude/codex session reloads the agent in
+// place (resume-preserving) so the cap takes effect immediately.
+model SetSessionContextWindowCapMessage {
+  cmd: "set_session_context_window_cap";
+  session_id: string;
+  cap: int32;
+}
+
 // Assign or remove the profile-wide chief-of-staff role. Assigning a new
 // session transfers the singleton role from the previous holder.
 model SetChiefOfStaffMessage {
@@ -2624,6 +2635,17 @@ model RenameResultMessage {
   event: "rename_result";
   cmd: string;
   id: string;
+  success: boolean;
+  error?: string;
+}
+
+// Reply to set_session_context_window_cap, correlated by session_id. cap
+// echoes the pin that is now stored (0 = cleared). The updated session is also
+// broadcast separately via sessions_updated.
+model SessionContextWindowCapResultMessage {
+  event: "session_context_window_cap_result";
+  session_id: string;
+  cap: int32;
   success: boolean;
   error?: string;
 }
@@ -4423,6 +4445,7 @@ alias DaemonEvent =
   | WorkspaceLayoutActionResultMessage
   | RenameResultMessage
   | ChiefOfStaffResultMessage
+  | SessionContextWindowCapResultMessage
   | TicketsUpdatedMessage
   | TicketResultMessage
   | TicketActionResultMessage

--- a/internal/store/pin.go
+++ b/internal/store/pin.go
@@ -49,3 +49,40 @@ func (s *Store) SetSessionPinned(id string, pinned bool, now time.Time) bool {
 	updated, err := result.RowsAffected()
 	return err == nil && updated == 1
 }
+
+// SetSessionContextWindowCap pins a per-session context-window cap in tokens,
+// or clears the pin with cap 0. Like the queue pin, the column is owned by this
+// setter alone — it is absent from the session upsert, so a respawn or state
+// re-add cannot disturb it. The daemon's launch resolver reads the pin ahead of
+// the chief and per-agent default settings.
+//
+// It returns true when a session was updated.
+func (s *Store) SetSessionContextWindowCap(id string, cap int) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if cap < 0 {
+		cap = 0
+	}
+
+	if s.db == nil {
+		session, ok := s.sessions[id]
+		if !ok {
+			return false
+		}
+		if cap == 0 {
+			session.ContextWindowCap = nil
+		} else {
+			session.ContextWindowCap = protocol.Ptr(cap)
+		}
+		return true
+	}
+
+	result, err := s.db.Exec(`UPDATE sessions SET context_window_cap = ? WHERE id = ?`, cap, id)
+	if err != nil {
+		log.Printf("[store] SetSessionContextWindowCap: failed for session %s: %v", id, err)
+		return false
+	}
+	updated, err := result.RowsAffected()
+	return err == nil && updated == 1
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -951,6 +951,12 @@ CREATE TABLE IF NOT EXISTS document_collections (
 	// delegations, endpoints, workspaces and workspace panes. Applied by
 	// applyMigration95.
 	{95, "store turn, cursor and listing timestamps in an encoding that sorts", ``},
+	// The per-session context-window cap pin, in tokens. 0 means no pin — the
+	// launch falls back to the chief or per-agent default settings. Owned by
+	// SetSessionContextWindowCap, absent from the session upsert, so a respawn
+	// cannot clear it — the same contract as pinned_at. Applied by
+	// applyMigration96.
+	{96, "add the context-window cap pin to sessions", ``},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -1251,6 +1257,11 @@ func migrateDB(db *sql.DB, dbPath string) error {
 			}
 		} else if m.version == 95 {
 			if err := applyMigration95(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 96 {
+			if err := applyMigration96(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -2350,6 +2361,18 @@ func applyMigration92(tx *sql.Tx) error {
 		return err
 	}
 	_, err = tx.Exec("ALTER TABLE sessions ADD COLUMN parent_session_id TEXT NOT NULL DEFAULT ''")
+	return err
+}
+
+// applyMigration96 adds the per-session context-window cap pin. Guarded on the
+// column existing, so a rewound schema_migrations table re-runs it without
+// erroring on the duplicate.
+func applyMigration96(tx *sql.Tx) error {
+	has, err := columnExists(tx, "sessions", "context_window_cap")
+	if err != nil || has {
+		return err
+	}
+	_, err = tx.Exec("ALTER TABLE sessions ADD COLUMN context_window_cap INTEGER NOT NULL DEFAULT 0")
 	return err
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -110,6 +110,9 @@ func cloneSession(session *protocol.Session) *protocol.Session {
 	if session.PinnedAt != nil {
 		cloned.PinnedAt = protocol.Ptr(protocol.Deref(session.PinnedAt))
 	}
+	if session.ContextWindowCap != nil {
+		cloned.ContextWindowCap = protocol.Ptr(protocol.Deref(session.ContextWindowCap))
+	}
 	if session.ParentSessionID != nil {
 		cloned.ParentSessionID = protocol.Ptr(protocol.Deref(session.ParentSessionID))
 	}
@@ -181,8 +184,15 @@ func (s *Store) AddChecked(session *protocol.Session) error {
 		// disturbs it there. Carrying the stored value forward here is what makes
 		// the memory branch say the same thing: the pin is owned by
 		// SetSessionPinned alone, and a respawn cannot silently clear it.
-		if existing := s.sessions[session.ID]; existing != nil && existing.PinnedAt != nil {
-			stored.PinnedAt = protocol.Ptr(protocol.Deref(existing.PinnedAt))
+		if existing := s.sessions[session.ID]; existing != nil {
+			if existing.PinnedAt != nil {
+				stored.PinnedAt = protocol.Ptr(protocol.Deref(existing.PinnedAt))
+			}
+			// Same ownership rule as the pin: the cap belongs to
+			// SetSessionContextWindowCap, so a re-add carries it forward.
+			if existing.ContextWindowCap != nil {
+				stored.ContextWindowCap = protocol.Ptr(protocol.Deref(existing.ContextWindowCap))
+			}
 		}
 		s.sessions[session.ID] = stored
 		return nil
@@ -254,10 +264,11 @@ func (s *Store) Get(id string) *protocol.Session {
 	var todosJSON string
 	var stateSince, stateUpdatedAt, lastSeen string
 	var isWorktree int
+	var contextWindowCap int
 	var endpointID, workspaceID, branch, mainRepo, pinnedAt, parentSessionID sql.NullString
 
 	err := s.db.QueryRow(`
-		SELECT id, label, agent, directory, endpoint_id, workspace_id, branch, is_worktree, main_repo, state, state_since, state_updated_at, pinned_at, parent_session_id, todos, last_seen
+		SELECT id, label, agent, directory, endpoint_id, workspace_id, branch, is_worktree, main_repo, state, state_since, state_updated_at, pinned_at, context_window_cap, parent_session_id, todos, last_seen
 		FROM sessions WHERE id = ?`, id).Scan(
 		&session.ID,
 		&session.Label,
@@ -272,6 +283,7 @@ func (s *Store) Get(id string) *protocol.Session {
 		&stateSince,
 		&stateUpdatedAt,
 		&pinnedAt,
+		&contextWindowCap,
 		&parentSessionID,
 		&todosJSON,
 		&lastSeen,
@@ -282,6 +294,9 @@ func (s *Store) Get(id string) *protocol.Session {
 
 	if pinnedAt.Valid && pinnedAt.String != "" {
 		session.PinnedAt = protocol.Ptr(pinnedAt.String)
+	}
+	if contextWindowCap > 0 {
+		session.ContextWindowCap = protocol.Ptr(contextWindowCap)
 	}
 	if parentSessionID.Valid && parentSessionID.String != "" {
 		session.ParentSessionID = protocol.Ptr(parentSessionID.String)
@@ -394,11 +409,11 @@ func (s *Store) List(stateFilter string) []*protocol.Session {
 
 	if stateFilter == "" {
 		rows, err = s.db.Query(`
-			SELECT id, label, agent, directory, endpoint_id, workspace_id, branch, is_worktree, main_repo, state, state_since, state_updated_at, pinned_at, parent_session_id, todos, last_seen
+			SELECT id, label, agent, directory, endpoint_id, workspace_id, branch, is_worktree, main_repo, state, state_since, state_updated_at, pinned_at, context_window_cap, parent_session_id, todos, last_seen
 			FROM sessions ORDER BY label, id`)
 	} else {
 		rows, err = s.db.Query(`
-			SELECT id, label, agent, directory, endpoint_id, workspace_id, branch, is_worktree, main_repo, state, state_since, state_updated_at, pinned_at, parent_session_id, todos, last_seen
+			SELECT id, label, agent, directory, endpoint_id, workspace_id, branch, is_worktree, main_repo, state, state_since, state_updated_at, pinned_at, context_window_cap, parent_session_id, todos, last_seen
 			FROM sessions WHERE state = ? ORDER BY label, id`, stateFilter)
 	}
 	if err != nil {
@@ -412,6 +427,7 @@ func (s *Store) List(stateFilter string) []*protocol.Session {
 		var todosJSON string
 		var stateSince, stateUpdatedAt, lastSeen string
 		var isWorktree int
+		var contextWindowCap int
 		var endpointID, workspaceID, branch, mainRepo, pinnedAt, parentSessionID sql.NullString
 
 		err := rows.Scan(
@@ -428,6 +444,7 @@ func (s *Store) List(stateFilter string) []*protocol.Session {
 			&stateSince,
 			&stateUpdatedAt,
 			&pinnedAt,
+			&contextWindowCap,
 			&parentSessionID,
 			&todosJSON,
 			&lastSeen,
@@ -438,6 +455,9 @@ func (s *Store) List(stateFilter string) []*protocol.Session {
 
 		if pinnedAt.Valid && pinnedAt.String != "" {
 			session.PinnedAt = protocol.Ptr(pinnedAt.String)
+		}
+		if contextWindowCap > 0 {
+			session.ContextWindowCap = protocol.Ptr(contextWindowCap)
 		}
 		if parentSessionID.Valid && parentSessionID.String != "" {
 			session.ParentSessionID = protocol.Ptr(parentSessionID.String)


### PR DESCRIPTION
## What

A context-window cap could only be set for a whole class of launches — the chief (`chief_context_window_cap`), or every session of an agent (`default_context_window_cap_<agent>`). There was no way to say "this one session should compact later", which is what a long-lived session usually needs.

Selecting a claude or codex session and opening the command menu now offers **"Cap `<label>`'s context window"**. It opens a small prompt for a token threshold — 10,000 to 2,000,000, blank or `0` clears the pin. Once pinned, the entry reads "Change `<label>`'s context window" with "Compacts at 250,000 tokens — change or clear the cap", so the way out and the way to see it are the same entry.

## How it works

**The pin is a real column**, `sessions.context_window_cap` (migration 96, `columnExists`-guarded `ALTER TABLE`). It is owned by `SetSessionContextWindowCap` alone and is absent from the session upsert, so a respawn or state re-add cannot silently clear it — the same ownership contract `pinned_at` already has.

**The daemon owns precedence**, in one resolver (`launchContextWindowCap`) that both the spawn pipeline and the reload path call:

1. the per-session pin — the user's explicit act on this one session, so it outranks even the chief;
2. otherwise a chief launch takes `chief_context_window_cap`;
3. otherwise `default_context_window_cap_<agent>`;
4. unset means uncapped — the agent's own compaction behavior.

**Changing the pin reloads a live agent.** A cap only reaches the agent at launch (Claude reads `CLAUDE_CODE_AUTO_COMPACT_WINDOW` from its environment, Codex takes `-c model_auto_compact_token_limit`), so a running process cannot be re-capped — only its respawn can. Setting or clearing a pin on a session that has a live worker therefore triggers the same resume-preserving kill-and-respawn that chief promotion uses, with the same accepted cost: **an in-flight turn is lost**. This is deliberate and is *not* gated on the session being idle; the alternative is a pin that appears to have taken effect and silently has not. Repeating an unchanged pin is a no-op, so nothing reloads an innocent agent.

**Only claude and codex carry a cap.** The daemon refuses a pin on any other agent rather than storing one that never applies, and the menu entry is hidden for them.

Protocol 217: `Session.context_window_cap`, command `set_session_context_window_cap`, event `session_context_window_cap_result` (correlated by `session_id`, last-writer-wins). The pin publishes `session.cap.changed` on the bus, projected through the existing single-session re-push. Reachable over the unix socket as well as the WebSocket, and relayed to the owning daemon for a remote session (the reload has to run where the worker lives).

## Verification

Live-verified on a throwaway profile (`sesscap`, full `make install PROFILE=sesscap`, bundled preflight PASS — CLI, app and daemon all on protocol 217), since this is a protocol + daemon + UI change. The profile has been cleaned up.

**Daemon leg** — scripted WebSocket client against the profile daemon, driving a claude session whose executable is a stub that dumps its launch environment once per launch:

| Witness | Result |
| --- | --- |
| Baseline launch, no pin | env dump carries no `CLAUDE_CODE_AUTO_COMPACT_WINDOW` |
| Set cap 300000 | `success: true`, `runtime_respawned`, next env dump has `CLAUDE_CODE_AUTO_COMPACT_WINDOW=300000` |
| Clear (cap 0) | `success: true`, `runtime_respawned`, next env dump has no such variable |
| Cap 500 (below minimum) | `success: false`, `context window cap must be 0 (no cap) or between 10000 and 2000000 tokens; got 500` |
| Cap on a `shell` session | `success: false`, `agent "shell" takes no context-window cap; only claude and codex launches carry one` |

The two rejections name the limit, its bounds and the ask, so an agent hitting either can fix it from the message alone.

**UI leg** — driven live in the packaged app through the automation bridge (`ui.actionMenu` shortcut, then real DOM interaction), not simulated:

- filtering the command menu to "context window" leaves exactly the cap entry, and running it opens the prompt;
- typing `250000` and pressing Save lands `context_window_cap=250000` on the session record the daemon broadcasts;
- the prompt closes on success, and reopening the menu shows "Change … — Compacts at 250,000 tokens — change or clear the cap".

**Automated** — `go build ./...`; `go test ./internal/store ./internal/agent`; `go test ./internal/daemon` (see below); `pnpm --dir app test` (2582 passed, including 5 new `SessionContextCapPrompt` tests); `pnpm --dir app exec tsc --noEmit`; `changelog-check`.

One note on `go test ./internal/daemon`: an early full-suite run failed on `TestStartJobQueueArmsThePeriodicTicks` ("notebook_cron is not armed"). It did not reproduce — that test passes 5/5 in isolation, the full suite passed on the two subsequent runs on this branch, and a full run on pristine `main` also passed. The test asserts that `startJobQueue` arms the notebook and automation cron entries; `armCron` logs and swallows a failed `Enqueue`, so a transient SQLite write failure under load leaves the entry unarmed and the assertion is the only symptom. Nothing in this change touches the job queue, cron arming, or the notebook. Flagging it as a pre-existing robustness gap worth its own fix (a heartbeat that fails to arm should be loud), not something introduced here.

## Surfaces walked

- **CLI / unix socket** — `set_session_context_window_cap` is dispatched in `handleConnection`, not only over the WebSocket.
- **Protocol** — `main.tsp` regenerated into `generated.go` + `generated.ts`; `ProtocolVersion` 217 in all three lockstep spots (`constants.go`, `generated`, `useDaemonSocket.ts`).
- **Remote** — `remoteCommandSessionID` routes the command to the daemon owning the session, since the reload runs where the worker lives.
- **Bus** — `session.cap.changed` joins the existing single-session pin projection rather than adding a new wire path.
- **Linux** — pure Go, no platform-specific code.
- **Docs** — changelog fragment added.

https://claude.ai/code/session_012Bu5dMFLdBfrEo4WmQkF53
