### PR TITLE
docs(testing): when to reach for synctest, rapid, and toxiproxy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,25 @@ Tests must never resolve `config.DataDir()` or derived paths to production
 
 See [docs/plans/2026-07-18-db-loss-mitigation.md](docs/plans/2026-07-18-db-loss-mitigation.md).
 
+## Testing tools
+
+Three adopted patterns; full receipts in
+[docs/plans/2026-08-09-testing-spike-synctest-rapid-toxiproxy.md](docs/plans/2026-08-09-testing-spike-synctest-rapid-toxiproxy.md).
+
+- A test that asserts elapsed time (backoff, debounce, recurrence) or that
+  something **never** happens runs under `synctest.Test` — no sleeps, no poll
+  loops. Open stores and DB handles outside the bubble; never bubble real
+  sockets, PTYs, or child processes — a goroutine blocked on a real fd is not
+  durably blocked, so fake time never advances.
+- A unit with a stated invariant and a large input space — especially when the
+  interesting failures need a *sequence* of operations — gets a
+  `pgregory.net/rapid` property beside its example tests. Rapid explores, it
+  does not document. Commit the `testdata/rapid/` seeds it writes on failure.
+- Behavior that *is* the network being bad (backpressure, eviction, reconnect)
+  goes through the embedded Toxiproxy helper (`newToxiProxy(t, upstream)`,
+  `internal/daemon`). Anything a fake or direct channel write can express
+  does not — it costs real seconds.
+
 ## Pull requests
 
 PR policy — ready-for-review, rebase onto main first, who approves — comes from

--- a/changelog.d/dizzy-gecko-testing-tools-guidance.yaml
+++ b/changelog.d/dizzy-gecko-testing-tools-guidance.yaml
@@ -1,0 +1,10 @@
+kind: internal
+area: docs
+change: >
+  AGENTS.md gains a "Testing tools" section: one-line rules for when a test
+  should use `testing/synctest` (elapsed-time or never-happens assertions),
+  `pgregory.net/rapid` (stated invariant over a large input space), or the
+  embedded Toxiproxy helper (behavior that is the network being bad), with the
+  bubble-boundary and seed-committing gotchas from the adoption spike. Also
+  adds the follow-up plan (docs/plans/2026-08-09-testing-adoption-wave.md)
+  mapping where each tool is applied next.

--- a/docs/plans/2026-08-09-testing-adoption-wave.md
+++ b/docs/plans/2026-08-09-testing-adoption-wave.md
@@ -1,0 +1,171 @@
+# Plan: testing adoption wave — apply the spike's tools
+
+## Goal
+
+The spike (#799, `docs/plans/2026-08-09-testing-spike-synctest-rapid-toxiproxy.md`)
+adopted synctest, rapid, and embedded Toxiproxy. This wave turns the adoption
+into practice: fix the product issue the spike found, apply each tool where it
+pays today, and write the guidance that makes the patterns the default reflex
+for future agents. Four tracks, independently executable; A, B1, B2 can run as
+parallel delegations, C is small enough to do inline.
+
+## Track A — fix the silent eviction (product bug)
+
+The spike's finding: when the hub evicts a slow WebSocket client
+(`internal/daemon/websocket.go`, `maxSlowCount = 3`), the
+`StatusPolicyViolation "client too slow"` close frame queues behind the very
+backlog that caused the eviction. On a degraded link the client sees ~45s of
+silence while the daemon hung up after 1s — eviction is indistinguishable from
+a dead network, at the exact moment it matters.
+
+Two independent fixes, both in scope:
+
+1. **Die promptly.** The close frame cannot outrun the backlog on the same TCP
+   stream — physics, not a bug. So stop pretending: on eviction, write the
+   close frame with a short deadline, then hard-close the connection
+   (`CloseNow`). The client's read fails in ~1s instead of its own timeout.
+   The frontend's reconnect logic (`useDaemonSocket`) already treats abrupt
+   close correctly; verify, don't assume.
+2. **Explain on return.** The daemon remembers the eviction and the next
+   `client_hello` response carries it (e.g. `evicted_at` + reason), so the app
+   can log it or surface "connection dropped: too slow" instead of a generic
+   reconnect. Needs a protocol change (main.tsp, `make generate-types`,
+   `ProtocolVersion` bump, plus the third lockstep spot in
+   `useDaemonSocket.ts`). If client identity across reconnects turns out not
+   to exist cheaply, ship fix 1 alone and record why.
+
+Verification: extend the spike's own
+`internal/daemon/toxiproxy_slow_client_test.go` — the throttled client must
+observe connection death promptly *while still degraded* (that is the whole
+point; the current test heals the link first). Protocol change ⇒ live
+verification in a non-production app per AGENTS.md.
+
+## Track B1 — rapid: three new property targets
+
+Chosen for invariant density; each has a stated invariant the current tests
+don't explore. Keep example tests; rapid explores, it does not document.
+
+1. **`internal/pty` OSC/kitty scanners — chunk-boundary invariance.** The
+   invariant behind bug #737 (UTF-8 abort leaking through the OSC 133 strip):
+   output must not depend on where the byte stream was split. Property: take
+   corpus inputs (real ones exist in `internal/pty/testdata`), let rapid choose
+   arbitrary split points, feed the chunks through the scanner, assert output
+   is byte-identical to the unsplit run. This directly targets the defect class
+   we have already shipped once.
+2. **`internal/docstore` — identifier safety.** Stated invariant (AGENTS.md):
+   every identifier the store executes is derived from an integer or a
+   validated field name, never from caller text. Property: arbitrary caller
+   strings (field names, collection names, query values) never appear verbatim
+   in compiled SQL identifiers; hostile names are rejected at validation, not
+   quoted around.
+3. **`internal/workspacelayout` — tree invariants under random ops.** Random
+   sequences of tile/moveleaf/remove operations; after every op the layout is
+   still a well-formed tree (no orphans, no duplicate leaves, ranks strictly
+   ordered). Same shape as the rankkey stateful property, one level up.
+
+Each target: one property file, default 100 checks, commit any
+`testdata/rapid/` regression seeds rapid produces.
+
+## Track B2 — synctest: triage-then-convert sweep
+
+Raw counts of `time.Sleep`/`time.After` in tests: daemon 194, ptybackend 22,
+pty 21, ptyworker 12, jobs 10, daemonctl 7, workflow 6. **The counts
+over-state the sweep**: the bubble boundary rule from the spike (no real
+sockets, no real PTYs, no DB opened inside) excludes most daemon harness tests
+and everything touching a real PTY. Real processes and fds cannot be bubbled.
+
+So the work is triage first, convert second:
+
+- [ ] Triage: for each package above, classify each sleep/poll-paced test as
+      *bubble-able* (pure logic + store + fake time) or *boundary-bound*
+      (real socket/PTY/process). Record the split in this plan — that map is
+      a deliverable, not overhead.
+- [ ] Convert the bubble-able ones: remaining `internal/jobs` tests,
+      `internal/workflow` (loop/cancel/engine pacing), and the daemon tests
+      that are store+logic only (candidates: dwell, countdown, retention,
+      auto-settle pacing — triage decides).
+- [ ] Open long-lived resources (stores, DBs) outside the bubble — the spike's
+      documented deadlock. `waitFor`/`fakeClock` stay for boundary-bound tests.
+
+Success measure: converted tests keep their assertions, lose their sleeps, and
+the flake classes they carried (load-sensitive poll loops like
+`TestStartJobQueueArmsThePeriodicTicks`) are retired by construction.
+
+## Track C — guidance for future agents (inline, small)
+
+Add a short **Testing tools** note to AGENTS.md (near "Test safety") — the
+rules exist and are validated; this makes them load-bearing (plan docs rot,
+AGENTS.md is read every session):
+
+- elapsed-time assertion or "this never happens" ⇒ `synctest.Test`; open
+  DBs/stores outside the bubble; never bubble real sockets, PTYs, processes.
+- stated invariant + large input space (especially sequence-dependent) ⇒
+  `pgregory.net/rapid`; keep example tests; commit rapid's regression seeds.
+- behavior that *is* the network being bad ⇒ embedded Toxiproxy helper
+  (`newToxiProxy(t, upstream)`); never for what a fake can express.
+- pointer to the spike plan's Findings for the full receipts.
+
+~12 lines, no ceremony. Ship with whichever track lands first.
+
+## Track D — insane options (priced, opt-in, not started)
+
+Named per the boil-the-ocean rule; each needs an explicit go.
+
+1. **Daemon-in-a-bubble.** Abstract the daemon's transport seam so harness
+   tests run entirely in-memory, then run whole-daemon logic tests (state
+   machine, turn lifecycle, bus projections) under synctest at production tick
+   rates — deterministic integration tests, minutes of fake time in
+   milliseconds. Unknown: whether `net.Pipe`-style in-memory conns count as
+   durably blocked (they are channel-backed; a cheap probe answers it). Cost:
+   a real seam through daemon startup — days, touches wiring. Payoff:
+   the daemon's 194 sleep sites stop being the untestable majority.
+2. **rr chaos mode on the orb VM for the open plugin-driver flake.** The
+   close-notification drop (instrumented in #784, still unexplained) is
+   exactly rr's shape: `rr record -h` randomizes scheduling to provoke the
+   race, then replays it deterministically under a debugger. Cost: a
+   half-day probe (does the VM expose perf counters?), then either gold or a
+   documented dead end.
+3. **Sometimes-assertions catalog.** Tiny `internal/testinv` helper: tests
+   register "interesting state reached" marks; the suite reports marks never
+   hit across a full run — vacuous-green detection as infrastructure. Cheap
+   to build; the cost is the discipline of placing marks. Parked unless
+   wanted.
+
+## Boundaries
+
+- Tracks are independent; no track blocks another. A/B1/B2 are delegation-
+  sized; C is inline.
+- Track A is the only one that changes production code; it follows full
+  protocol/live-verification discipline. B1/B2 are test-only.
+- No new dependencies anywhere (rapid and toxiproxy are already in).
+- Test safety as always: `config.ScopeTestEnvironment`, never production
+  `~/.attn`.
+
+## Implementation Steps
+
+- [ ] Track A: prompt-death fix + eviction-reason-on-reconnect (or documented
+      fallback to fix 1 alone); extended toxiproxy test; live verification
+- [ ] Track B1: three rapid property files (pty scanners, docstore,
+      workspacelayout)
+- [ ] Track B2: triage map, then bubble-able conversions
+- [ ] Track C: AGENTS.md testing-tools note
+- [ ] Track D: none until explicitly picked
+- [ ] Changelog fragments per PR
+
+## Decisions
+
+- Toxiproxy's next target is Track A's verification, not the remote leg — the
+  remote leg needs a second daemon to proxy to and stays a follow-up until we
+  next touch hub/remote code.
+- The synctest sweep is triage-first because raw sleep counts over-state it;
+  the daemon's sleeps mostly sit behind real sockets where the bubble cannot
+  go (that ocean is Track D option 1, priced separately).
+- Frontend property testing (fast-check on `useDaemonSocket` correlation or
+  reconnect logic) deferred — nothing there is currently flaking, and the Go
+  side has higher invariant density per test written.
+
+## Follow-ups
+
+- Toxiproxy on the hub-transport/remote leg when that code is next touched
+  (zero CI coverage today; the helper already takes any upstream).
+- Frontend fast-check, if a frontend invariant bug ever surfaces.


### PR DESCRIPTION
Adds a short **Testing tools** section to AGENTS.md so the patterns adopted in the testing spike (#799) become standing guidance agents read every session, instead of findings in a plan doc:

- elapsed-time or never-happens assertions → `synctest.Test`, with the bubble-boundary rules (open stores outside; never bubble real sockets/PTYs/processes)
- stated invariant over a large input space → `pgregory.net/rapid` beside the example tests, committing regression seeds
- behavior that *is* the network being bad → the embedded Toxiproxy helper, never for what a fake can express

Also adds `docs/plans/2026-08-09-testing-adoption-wave.md` — the follow-up plan mapping where each tool is applied next (silent-eviction fix, three rapid targets, synctest triage-then-convert sweep, and priced moonshot options).

Docs-only: no code changes, exempt from live verification per AGENTS.md.

https://claude.ai/code/session_01TYxCnEV3XVGgnaWgMxPNK3