### PR TITLE
test(testinv): catalog the states a suite is supposed to reach

### DIFF
--- a/changelog.d/sometimes-assertions-catalog.yaml
+++ b/changelog.d/sometimes-assertions-catalog.yaml
@@ -1,0 +1,16 @@
+kind: internal
+area: testing
+change: >
+  Test suites can now catalog the interesting states they are supposed to reach.
+  A package registers a state with `testinv.Sometimes`, marks the site with
+  `Reached`, and runs its tests through `testinv.Run` from `TestMain`; a
+  cataloged state that stops happening fails the package and names itself, even
+  though every test still passes. It catches the decay line coverage cannot see —
+  a test whose precondition quietly stopped arising, leaving the assertion true
+  and empty. Marks are placed in `internal/bus` and `internal/jobs`, hosted in
+  the test doubles the real code runs through, so production code carries
+  nothing.
+notes: >
+  Adopt-or-drop evidence, including the mutation that leaves every bus test green
+  while only the catalog goes red, and the rule for when a state is worth
+  cataloging, is in docs/plans/2026-08-09-sometimes-assertions-catalog.md.

--- a/docs/plans/2026-08-09-sometimes-assertions-catalog.md
+++ b/docs/plans/2026-08-09-sometimes-assertions-catalog.md
@@ -1,0 +1,273 @@
+# Plan: sometimes-assertions catalog — vacuous-green detection
+
+## Goal
+
+attn has been burned repeatedly by tests that pass without exercising the
+interesting path: a verify gate whose agents had died reporting an empty
+`confirmed` list, mutation tests surviving because another path happened to
+cover the input, harness legs that never reached the state they exist for. The
+common shape is that the assertion still holds while the situation it was
+written about stopped arising. Line coverage cannot see any of it — the lines
+still run. It is a **condition** that went missing, not a location.
+
+Antithesis's *sometimes assertion* is the off-the-shelf idea: a deliberately
+placed mark saying "this interesting state was reached at least once during the
+run", with the run failing when a cataloged mark was never hit.
+
+This spike answers one question: **can that mechanism be small enough to be worth
+having in a Go unit-test suite?** Like the synctest/rapid/Toxiproxy spike
+(PR #799) it ends in adopt or drop; a mechanism that needs heavy plumbing is a
+drop with a written reason.
+
+## Shape
+
+- A tiny `internal/testinv` (test inventory): register a state, mark the site,
+  check at end of run.
+- Marks placed in 2–3 real packages, chosen where a mark would genuinely catch a
+  future vacuous pass.
+- A mutation receipt: show a change that leaves every test green and turns the
+  run red only because a cataloged state stopped happening.
+
+## Design constraints
+
+- **Per-package.** `go test` runs each package in its own process, so a global
+  in-memory registry cannot see the suite. The catalog is per-package and the
+  package's `TestMain` checks it. Cross-package aggregation is optional —
+  sketched below, built only if it stays small.
+- **Zero overhead unused, near-zero used.** A package that registers nothing pays
+  nothing; a mark is one atomic bool.
+- **Reads as a sentence.** `testinv.Sometimes(...)` at package scope,
+  `.Reached()` at the site.
+- **Test-only.** Marks live in test files or test-only helpers. Whether
+  production code should ever carry one is a later decision, not this spike's.
+- **Honest failure.** A state that stops being reached names itself loudly. A
+  silent catalog is worse than none.
+
+## Boundaries
+
+- No new dependencies.
+- No production code changes.
+- Test safety rules apply as everywhere.
+
+## Implementation Steps
+
+- [x] `internal/testinv`: `Sometimes` / `Mark.Reached` / `Run(m)`, with its own
+      tests
+- [x] Place marks in `internal/bus` and `internal/jobs`
+- [x] Mutation receipts: for each mark, what breaks it and what else notices
+- [x] Cost receipts: per-call and per-package
+- [x] Findings + adopt/drop verdict appended here
+- [x] Changelog fragment (`kind: internal`, `area: testing`)
+
+## Decisions
+
+- Two packages carry marks, not three. The third candidate — the daemon's
+  `classifierObservation` staleness rejection — was dropped on purpose, and why
+  is a finding rather than a shortfall (see "The limit that decides where a mark
+  can go").
+
+## Open Questions
+
+- Does the catalog earn its keep against a suite whose assertions are already
+  this thorough, or is every interesting state already asserted somewhere?
+
+---
+
+# Findings
+
+**Verdict: adopt, narrowly.** The mechanism is 200 lines with no dependencies and
+costs nothing measurable, and it catches a class of decay that nothing else in
+the suite can see. But it is a scalpel, not a policy: three of the four marks
+placed here are redundant with assertions that already exist, and only one earned
+its keep on the spot. The rule for reaching for it is at the end.
+
+Measurements are from an M5 Mac, Go 1.25.3, reproducible from the commands
+quoted.
+
+## What was built
+
+`internal/testinv`, imported only by test files:
+
+```go
+// internal/bus/testinv_test.go — the package's whole catalog, in one file
+var sawMultiEventBatch = testinv.Sometimes("the log is read forward into a batch holding more than one event")
+
+func TestMain(m *testing.M) { os.Exit(testinv.Run(m)) }
+
+// internal/bus/bus_test.go — inside memStore.Since, the test double the Bus reads through
+if len(out) > 1 {
+	sawMultiEventBatch.Reached()
+}
+```
+
+`Run` runs the package's tests and then checks the inventory. A state that was
+never reached turns a passing run into a failing one and says so:
+
+```
+PASS
+
+--- FAIL: testinv (1 cataloged state never reached this run)
+    NEVER REACHED: the log is read forward into a batch holding more than one event
+        cataloged at bus/testinv_test.go:24
+    The tests still pass, so nothing else will say this. A cataloged state
+    that stops happening means the suite no longer exercises the path it was
+    written for. Restore the state, or drop the entry and say why.
+```
+
+The `PASS` above the `FAIL` is the whole point: every test in the package passed.
+
+## The receipt
+
+**Change `DefaultBatchSize` from 200 to 1 in `internal/bus/bus.go`.** One token.
+Plausible as a memory tweak. It retires the drain's batch loop — the paging read,
+the per-event cursor advance, the failure streak cleared on each success — and
+`go test ./internal/bus` prints exactly the output above: **every test passes,
+and the catalog is the only thing that notices.**
+
+The test with the most to lose is `TestBackoffDoesNotRatchetAcrossSuccessfulDeliveries`,
+which seeds a 30-event backlog specifically so "the batch loop never sees an
+empty batch, which is the only place the older code cleared the streak" — its own
+comment. With a batch size of 1 that setup is decorative and the test asserts
+nothing it was written to assert. It stays green. Its precondition is exactly the
+kind of thing a test cannot assert about itself, and exactly what a cataloged
+state is for.
+
+## The four marks, and what actually notices when each breaks
+
+| Mark | Mutation | Mark red? | Anything else red? |
+|---|---|---|---|
+| bus: a batch holds more than one event | `DefaultBatchSize` 200 → 1 | yes | **no — nothing** |
+| bus: a handler is given an event it has already been given | advance the cursor on handler error (at-most-once) | yes | yes: `TestFailingHandlerRedeliversAndDoesNotAdvance`, `TestStatusReportsLagAndLiveness` |
+| jobs: dispatch withholds a job whose scheduled time has not arrived | retry at `now` instead of `now + backoff` | no¹ | yes: 3 tests |
+| jobs: a coalescing trigger lands on a running job | drop the `Requeued` flag | n/a² | yes: `TestATriggerArrivingMidRunRunsTheJobAgain` deadlocks |
+
+¹ The mark covers backoff *and* the coalescing debounce, so removing only the
+backoff leaves it reached by the debounce tests. Nothing found removes all
+withholding while the suite stays green.
+
+² The run never finishes, so the inventory is never checked — see the limits
+below.
+
+**Read the table honestly: one mark out of four caught something nothing else
+did.** That is not a disappointment, it is the calibration. In a suite whose
+tests assert as specifically as this repo's, most interesting states are already
+asserted by *some* test. What a cataloged state adds there is durability: the
+claim belongs to the run, not to the test that happens to satisfy it, so it
+survives that test being rewritten, weakened, or deleted. That is real but it is
+insurance, not detection — and insurance you only want on the states that matter.
+
+Where the catalog is not insurance but detection is the first row: a
+**precondition** a test needs and cannot check, whose disappearance leaves the
+assertion technically true and completely empty.
+
+## The limit that decides where a mark can go
+
+Marks are test-only, so a state has to be observable from the test side. In
+practice that means the best host is a **test double the production code calls
+through** — this package's in-memory `Store`, its fake clock, its recording
+handler. All four marks live in one: `memStore.Since` and `recorder.handle` in
+bus, `memStore.Eligible` and `memStore.Save` in jobs. The real code produces the
+condition; the double observes it; production carries nothing.
+
+The third candidate site did not survive that constraint, and it is worth
+recording why. `internal/daemon`'s classifier-staleness path — "a slow classifier
+verdict raced a newer live signal and was dropped" — is a textbook sometimes
+state: timing-dependent, unassertable, and precisely the thing a refactor could
+silently stop exercising. But the drop happens inside the resolver, is not
+visible through any test double, and the daemon's test seams do not surface it.
+Marking it would mean instrumenting production code.
+
+**So the reach of this mechanism is exactly the reach of a package's test
+doubles.** A leaf package with a clean injected seam gets marks for free. A
+package whose interesting states are internal to production code does not, and no
+amount of cleverness in `testinv` changes that. If those states ever need
+covering, that is a separate decision about production marks, with a real cost
+(the mark ships) and a real question (what does it do outside a test run) — not a
+follow-up to this spike.
+
+## Limits worth knowing before placing a mark
+
+- **A filtered run checks nothing, and you will not see it say so.** `-run`,
+  `-skip`, `-short`, and `-list` cannot be expected to reach the whole inventory,
+  so `Run` reports what it skipped rather than failing. The notice is written for
+  all four, but `go test` suppresses a passing binary's output, so a plain
+  `go test ./internal/bus -run Foo` prints a bare `ok` — pair it with `-v` to see
+  the notice. This is the one place the mechanism is quieter than it should be,
+  and it is not fixable from inside `Run`: on a passing run there is no stream
+  that reaches the terminal. So a mark defends CI's unfiltered
+  `scripts/test-go.sh`, and never a developer's inner loop. Plan around that
+  rather than expecting a filtered run to warn you.
+- **A run that never returns is never checked.** `Run` checks after `m.Run()`, so
+  a panic or a test timeout skips the report entirely (row 4 above). The catalog
+  is a check on a completed run, not a diagnostic for a broken one.
+- **Do not catalog a state behind a conditional skip.** A test that skips when a
+  tool is missing takes its state with it, and the run goes red for the
+  environment rather than for the code.
+- **Do not catalog a state the suite reaches only sometimes.** This is a
+  deterministic unit suite, not a fuzzer: a genuinely racy condition — "the
+  publish raced the drain" — would fire the catalog on the runs where the
+  interleaving did not happen, and a flake generator is worse than no catalog at
+  all. Antithesis can make this claim because it controls the schedule; `go test`
+  does not. **Catalog what the suite reaches deterministically but incidentally.**
+  That is the whole target.
+
+## Cost
+
+- **Per call:** `Reached` on an already-reached mark is **3.0 ns/op**
+  (`go test -run XXX -bench BenchmarkReached -benchtime 3s ./internal/testinv`)
+  — an atomic load and a predicted branch. It reads before it writes, so a mark
+  on a hot path does not add a contended store per hit.
+- **Per package:** indistinguishable from noise. Baseline measured on the
+  pre-change files via `go test -overlay`, three runs each:
+  `internal/bus` **0.580–0.766s → 0.606–0.714s**, `internal/jobs`
+  **0.299–0.623s → 0.372–0.598s**.
+- **Unused:** a package that never calls `Sometimes` has an empty catalog and
+  `Run` is `m.Run`. Packages that do not import it pay nothing at all.
+- `go test -race -count=3` on `internal/testinv`, `internal/bus`,
+  `internal/jobs`: clean.
+
+## Not built: suite-level aggregation
+
+Per-package is enough for what this does. A package whose catalog is incomplete
+fails, which fails `make test`, which is the outcome that matters. Aggregation
+would add one thing worth having and one cost:
+
+- **Sketch.** `Run` writes `$ATTN_TESTINV_DIR/<package>.json` (`{what, site,
+  reached}` per entry) when the env var is set. `make test` sets it to a temp dir
+  and a summary step merges the files: total cataloged, total reached, and — the
+  part per-package cannot do — states reached by a *different* package's run than
+  the one that cataloged them, plus a whole-suite view that could re-enable
+  checking for filtered runs.
+- **Cost.** A writer, a reader in `tools/`, a Makefile step, and a temp dir whose
+  absence has to fail open. That is more surface than the mechanism it reports
+  on.
+
+Build it if the catalog grows past a handful of entries across several packages
+and the per-package view stops being enough. Not before.
+
+## The rule, if this is adopted
+
+**Catalog a state when a test depends on a situation it cannot assert about
+itself — a precondition, a delay, a backlog, a collision — and the test would
+still pass if that situation stopped arising.** Put the mark in a test double the
+real code calls through. Do not catalog what an assertion already demands
+(that is redundancy, unless the assertion is one you specifically expect to
+outlive), and do not catalog what the suite reaches only some of the time.
+
+A good check before adding one: *if this condition silently stopped happening
+tomorrow, which test would go red?* If the answer is "none", it belongs in the
+catalog. If the answer names a test, it probably does not.
+
+## Follow-ups
+
+- If the verdict holds, a bullet in AGENTS.md's "Testing tools" section stating
+  the rule above — the same shape PR #802 gave the synctest/rapid/Toxiproxy
+  adoptions, and for the same reason: the receipts live in a plan doc, the rule
+  has to live where an agent will read it.
+- Placing marks opportunistically when a vacuous-green bug is found — the same
+  discipline as adding a regression test, one entry at a time — rather than as a
+  sweep.
+- Production marks (`internal/daemon`'s classifier staleness and friends) remain
+  an open, separate question. This spike deliberately does not open it.
+- Suite-level aggregation, per the sketch above, when the catalog outgrows the
+  per-package view.

--- a/internal/bus/bus_test.go
+++ b/internal/bus/bus_test.go
@@ -55,6 +55,9 @@ func (m *memStore) Since(cursor int64, limit int) ([]Event, error) {
 			}
 		}
 	}
+	if len(out) > 1 {
+		sawMultiEventBatch.Reached()
+	}
 	return out, nil
 }
 
@@ -231,14 +234,21 @@ type recorder struct {
 	mu     sync.Mutex
 	names  []string
 	seqs   []int64
-	failOn map[int64]int // seq -> remaining failures
+	seen   map[int64]bool // seq -> already handed to this handler once
+	failOn map[int64]int  // seq -> remaining failures
 }
 
-func newRecorder() *recorder { return &recorder{failOn: map[int64]int{}} }
+func newRecorder() *recorder {
+	return &recorder{seen: map[int64]bool{}, failOn: map[int64]int{}}
+}
 
 func (r *recorder) handle(_ context.Context, ev Event) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if r.seen[ev.Seq] {
+		sawRedelivery.Reached()
+	}
+	r.seen[ev.Seq] = true
 	if n := r.failOn[ev.Seq]; n > 0 {
 		r.failOn[ev.Seq] = n - 1
 		r.seqs = append(r.seqs, ev.Seq)

--- a/internal/bus/testinv_test.go
+++ b/internal/bus/testinv_test.go
@@ -1,0 +1,32 @@
+package bus
+
+import (
+	"os"
+	"testing"
+
+	"github.com/victorarias/attn/internal/testinv"
+)
+
+// The states this package's tests must reach at least once per run. Both are
+// preconditions rather than outcomes: every test here asserts what the bus did,
+// none asserts that the situation it was written for actually arose. See
+// internal/testinv for what that buys.
+//
+// Marked from the in-memory Store and the recording handler in bus_test.go —
+// test doubles the real Bus calls through — so production code carries nothing.
+var (
+	// The batch loop in drain exists for a consumer that is behind: it pages the
+	// log, advances the cursor per event, and clears the failure streak on each
+	// success. A bus whose consumers always caught up in one event would run none
+	// of that and every test here would still pass — including
+	// TestBackoffDoesNotRatchetAcrossSuccessfulDeliveries, whose whole reason for
+	// existing is that the loop never sees an empty batch.
+	sawMultiEventBatch = testinv.Sometimes("the log is read forward into a batch holding more than one event")
+
+	// At-least-once is the bus's promise to its handlers, and the reason
+	// wireProjections must tolerate redelivery. It is only a tested promise while
+	// some handler in this package is actually handed an event twice.
+	sawRedelivery = testinv.Sometimes("a consumer handler is given an event it has already been given")
+)
+
+func TestMain(m *testing.M) { os.Exit(testinv.Run(m)) }

--- a/internal/jobs/memstore_test.go
+++ b/internal/jobs/memstore_test.go
@@ -81,6 +81,11 @@ func (m *memStore) Save(j *Job) error {
 		m.saveErr = nil
 		return err
 	}
+	if j.Requeued && j.State == StateRunning {
+		// The flag is only set on a record whose run is still in flight; seeing it
+		// persisted that way is the collision itself, not its aftermath.
+		sawTriggerLandOnARunningJob.Reached()
+	}
 	m.jobs[j.ID] = j.clone()
 	return nil
 }
@@ -107,10 +112,13 @@ func (m *memStore) Eligible(now time.Time, limit int) ([]*Job, error) {
 	defer m.mu.Unlock()
 	out := make([]*Job, 0, len(m.jobs))
 	for _, j := range m.jobs {
-		if now.Before(j.ScheduledAt) {
+		if j.State != StateQueued && j.State != StateFailed {
 			continue
 		}
-		if j.State != StateQueued && j.State != StateFailed {
+		if now.Before(j.ScheduledAt) {
+			// The record is in a runnable state and dispatch is asking; the only
+			// reason it is not going out is the clock.
+			sawJobWithheldByItsSchedule.Reached()
 			continue
 		}
 		out = append(out, j.clone())

--- a/internal/jobs/testinv_test.go
+++ b/internal/jobs/testinv_test.go
@@ -1,0 +1,31 @@
+package jobs
+
+import (
+	"os"
+	"testing"
+
+	"github.com/victorarias/attn/internal/testinv"
+)
+
+// The states this package's tests must reach at least once per run. Both are
+// preconditions rather than outcomes: the tests assert where a job ended up,
+// none asserts that the queue was ever in the situation the assertion is about.
+// See internal/testinv.
+//
+// Marked from memStore in memstore_test.go — the test double the real Runner
+// dispatches against — so production code carries nothing.
+var (
+	// Delay is the whole mechanism behind both backoff and the coalescing
+	// debounce, and a delay is invisible to an assertion about the final state:
+	// every test here advances a fake clock and then checks where the job landed.
+	// A runner that scheduled every retry and every debounced trigger at now
+	// would keep all of them green while nothing was ever actually deferred.
+	sawJobWithheldByItsSchedule = testinv.Sometimes("dispatch withholds a job whose scheduled time has not arrived")
+
+	// The requeue-during-run flag is the one path where a coalescing trigger
+	// cannot overwrite the record it targets, so the run it collides with has to
+	// hand the trigger forward instead of dropping it.
+	sawTriggerLandOnARunningJob = testinv.Sometimes("a coalescing trigger lands on a job that is already running")
+)
+
+func TestMain(m *testing.M) { os.Exit(testinv.Run(m)) }

--- a/internal/testinv/testinv.go
+++ b/internal/testinv/testinv.go
@@ -1,0 +1,306 @@
+// Package testinv keeps an inventory of interesting states a package's tests are
+// supposed to reach, and fails the run when one of them stops being reached.
+//
+// The problem it exists for: a test suite can keep passing while it quietly
+// stops exercising the thing it was written for. The assertion still holds, but
+// the state it was meant to hold *about* is no longer produced — a refactor
+// removed the delay a backoff test was pacing on, a faster consumer means the
+// batch loop never sees a batch, a fixture drifted and the race the test provokes
+// no longer happens. Line coverage cannot see any of that: the lines still run.
+// It is a condition, not a location, that went missing.
+//
+// A cataloged state names such a condition and marks the spot where it occurs:
+//
+//	// package-level, in a _test.go file
+//	var sawBacklogBatch = testinv.Sometimes("a drain is handed a batch of more than one event")
+//
+//	func TestMain(m *testing.M) { os.Exit(testinv.Run(m)) }
+//
+//	// wherever the condition can be observed
+//	if len(batch) > 1 {
+//		sawBacklogBatch.Reached()
+//	}
+//
+// Reached says "this happened at least once" — not "this must happen here", and
+// not "this must happen every time". Any test in the package may be the one that
+// reaches it; no test owns it. That is the point: the claim is about the run, so
+// it survives the individual test that happens to satisfy it being rewritten or
+// deleted.
+//
+// # Scope
+//
+// One package, one process. `go test` runs each package in its own binary, so
+// the inventory is per-package and Run checks it when that package's tests are
+// done. Suite-wide aggregation would need a file drop and a summary step; it is
+// not built here.
+//
+// # Where a mark may live
+//
+// Marks belong in test files or test-only helpers. In practice the best host is
+// a test double that production code calls through — the package's in-memory
+// Store, its fake clock, its recording handler — because the condition it
+// observes is produced by the real code under test while the observation itself
+// costs production nothing. A condition that is only visible from inside
+// production code cannot be cataloged this way, and that is a deliberate limit,
+// not an oversight.
+//
+// # When enforcement is off
+//
+// A filtered run (`-run`, `-skip`, `-short`, `-list`) cannot be expected to reach
+// the whole inventory, so Run reports what it skipped and checks nothing. Be
+// aware that go test suppresses a passing binary's output, so that notice only
+// reaches the terminal under -v: a mark defends an unfiltered suite run, and
+// never a developer's inner loop.
+//
+// # What it costs
+//
+// A package that never calls Sometimes registers nothing and Run is m.Run. A
+// mark reads before it writes, so after the first hit it is an atomic load and a
+// predicted branch — 3.0ns, and no contended store per hit. Placing one inside a
+// test double that production code calls on a hot path is not a judgement call.
+//
+// # Reporting
+//
+// ATTN_TESTINV_VERBOSE=1 lists the whole inventory, reached and missing, instead
+// of only reporting what went wrong. `go test` hides a passing binary's output,
+// so pair it with -v.
+package testinv
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// Mark is one cataloged state. Get one from Sometimes; call Reached where the
+// state occurs.
+type Mark struct {
+	what string
+	site string
+	hit  atomic.Bool
+}
+
+// Reached records that the state happened. Safe from any goroutine, and cheap
+// enough to sit on a hot path: after the first hit it is a plain atomic load.
+func (m *Mark) Reached() {
+	if m == nil || m.hit.Load() {
+		return
+	}
+	m.hit.Store(true)
+}
+
+// WasReached reports whether the state has happened yet. Tests that want to
+// assert about the catalog itself use this; ordinary marks do not need it.
+func (m *Mark) WasReached() bool { return m != nil && m.hit.Load() }
+
+// String is the mark's description, so a mark drops into a %s without ceremony.
+func (m *Mark) String() string {
+	if m == nil {
+		return "<nil mark>"
+	}
+	return m.what
+}
+
+// catalog is one package's inventory. There is exactly one per test binary; the
+// type exists so the registry's own rules can be tested without registering into
+// the binary that is doing the testing.
+type catalog struct {
+	mu      sync.Mutex
+	entries []*Mark
+	byWhat  map[string]string // description -> registration site
+}
+
+func newCatalog() *catalog { return &catalog{byWhat: map[string]string{}} }
+
+var defaultCatalog = newCatalog()
+
+// Sometimes registers a state that this package's tests must reach at least once
+// per unfiltered run, and returns the mark to call Reached on.
+//
+// Call it from a package-level var in a _test.go file: registration has to happen
+// before TestMain runs, and a var initializer is the only place that is
+// guaranteed. Descriptions must be unique within the package — a duplicate makes
+// the report ambiguous about which site went quiet, so it panics.
+func Sometimes(what string) *Mark { return defaultCatalog.add(what, callerSite(2)) }
+
+func (c *catalog) add(what, site string) *Mark {
+	what = strings.TrimSpace(what)
+	if what == "" {
+		panic("testinv: a cataloged state needs a description")
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if prev, dup := c.byWhat[what]; dup {
+		panic(fmt.Sprintf("testinv: %q is already cataloged at %s", what, prev))
+	}
+	c.byWhat[what] = site
+	m := &Mark{what: what, site: site}
+	c.entries = append(c.entries, m)
+	return m
+}
+
+// Run runs the package's tests and then checks the inventory. Use it as the whole
+// body of TestMain:
+//
+//	func TestMain(m *testing.M) { os.Exit(testinv.Run(m)) }
+//
+// A package that already has a TestMain wraps its own setup around this call the
+// way it wrapped m.Run — Run substitutes for m.Run, it does not replace TestMain:
+//
+//	func TestMain(m *testing.M) {
+//		dir, _ := os.MkdirTemp("", "attn-test")
+//		config.ScopeTestEnvironment(dir)
+//		code := testinv.Run(m)
+//		os.RemoveAll(dir)
+//		os.Exit(code)
+//	}
+//
+// The returned code is the tests' own when they failed; a complete inventory
+// leaves it alone, and a state that was never reached turns a passing run into a
+// failing one.
+func Run(m *testing.M) int {
+	code := m.Run()
+
+	verbose := os.Getenv("ATTN_TESTINV_VERBOSE") != ""
+	report, incomplete := review(defaultCatalog.snapshot(), filterReason(), code == 0, verbose)
+	if report != "" {
+		fmt.Fprint(os.Stderr, report)
+	}
+	if incomplete && code == 0 {
+		code = 1
+	}
+	return code
+}
+
+// state is one inventory entry as review sees it, so review can be tested
+// without registering marks in the package under test.
+type state struct {
+	what    string
+	site    string
+	reached bool
+}
+
+func (c *catalog) snapshot() []state {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]state, 0, len(c.entries))
+	for _, m := range c.entries {
+		out = append(out, state{what: m.what, site: m.site, reached: m.hit.Load()})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].what < out[j].what })
+	return out
+}
+
+// review turns the inventory into the text the run prints and says whether the
+// run should fail. skipped is the reason enforcement does not apply, or "";
+// testsPassed decides how the advice is worded, because "the tests still pass"
+// is only worth saying when they did.
+func review(states []state, skipped string, testsPassed, verbose bool) (report string, incomplete bool) {
+	if len(states) == 0 {
+		return "", false
+	}
+
+	var b strings.Builder
+	if skipped != "" {
+		fmt.Fprintf(&b, "testinv: not checking %s (%s)\n", plural(len(states)), skipped)
+		if verbose {
+			writeAll(&b, states)
+		}
+		return b.String(), false
+	}
+
+	var missing []state
+	for _, s := range states {
+		if !s.reached {
+			missing = append(missing, s)
+		}
+	}
+	if len(missing) == 0 {
+		if verbose {
+			fmt.Fprintf(&b, "testinv: reached all %s\n", plural(len(states)))
+			writeAll(&b, states)
+		}
+		return b.String(), false
+	}
+
+	fmt.Fprintf(&b, "\n--- FAIL: testinv (%s never reached this run)\n", plural(len(missing)))
+	for _, s := range missing {
+		fmt.Fprintf(&b, "    NEVER REACHED: %s\n", s.what)
+		fmt.Fprintf(&b, "        cataloged at %s\n", s.site)
+	}
+	if testsPassed {
+		b.WriteString("    The tests still pass, so nothing else will say this. A cataloged state\n")
+		b.WriteString("    that stops happening means the suite no longer exercises the path it was\n")
+		b.WriteString("    written for. Restore the state, or drop the entry and say why.\n")
+	} else {
+		b.WriteString("    Tests failed in this run too, so fix those first — a run that stops early\n")
+		b.WriteString("    reaches less, and these may recover on their own.\n")
+	}
+	if verbose {
+		writeAll(&b, states)
+	}
+	return b.String(), true
+}
+
+func writeAll(b *strings.Builder, states []state) {
+	for _, s := range states {
+		mark := "reached"
+		if !s.reached {
+			mark = "MISSING"
+		}
+		fmt.Fprintf(b, "    [%s] %s (%s)\n", mark, s.what, s.site)
+	}
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return "1 cataloged state"
+	}
+	return fmt.Sprintf("%d cataloged states", n)
+}
+
+// filterReason names why this run cannot be expected to reach the whole
+// inventory, or "" when it can. Testing's flags are parsed by m.Run, so this is
+// only meaningful after it returns.
+func filterReason() string {
+	if v := testFlag("test.run"); v != "" {
+		return "this run is filtered by -run " + v
+	}
+	if v := testFlag("test.skip"); v != "" {
+		return "this run is filtered by -skip " + v
+	}
+	if testFlag("test.short") == "true" {
+		return "this run is -short"
+	}
+	if v := testFlag("test.list"); v != "" {
+		return "this run is -list " + v
+	}
+	return ""
+}
+
+func testFlag(name string) string {
+	f := flag.Lookup(name)
+	if f == nil {
+		return ""
+	}
+	return f.Value.String()
+}
+
+// callerSite is the file:line the mark was registered from, so the report can
+// point at the var rather than making someone grep for the description.
+func callerSite(skip int) string {
+	_, file, line, ok := runtime.Caller(skip)
+	if !ok {
+		return "unknown"
+	}
+	// Package-relative is enough to find it and does not leak the build path.
+	return fmt.Sprintf("%s:%d", filepath.Join(filepath.Base(filepath.Dir(file)), filepath.Base(file)), line)
+}

--- a/internal/testinv/testinv_test.go
+++ b/internal/testinv/testinv_test.go
@@ -1,0 +1,177 @@
+package testinv
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The package dogfoods itself: this state is reached by TestReachedIsIdempotent
+// below, so a run of this package exercises registration, Reached, and Run's
+// end-of-run check for real. It is the only mark this file puts in the default
+// catalog — everything else registers into a throwaway one, so -count=N does not
+// trip the duplicate rule on its own tests.
+var selfCheck = Sometimes("testinv's own mark was reached at least once")
+
+func TestMain(m *testing.M) { os.Exit(Run(m)) }
+
+func TestReachedIsIdempotentAndVisible(t *testing.T) {
+	selfCheck.Reached()
+	selfCheck.Reached()
+	if !selfCheck.WasReached() {
+		t.Fatalf("Reached did not stick")
+	}
+	if got := selfCheck.String(); !strings.Contains(got, "testinv's own mark") {
+		t.Errorf("String() = %q, want the description", got)
+	}
+
+	fresh := newCatalog().add("a state nothing has reached", "x_test.go:1")
+	if fresh.WasReached() {
+		t.Errorf("a freshly cataloged state reported itself reached")
+	}
+}
+
+func TestANilMarkIsInert(t *testing.T) {
+	var m *Mark
+	m.Reached() // must not panic: a mark behind a build tag may be nil
+	if m.WasReached() {
+		t.Errorf("a nil mark reported itself reached")
+	}
+}
+
+// Two marks with the same description make the report ambiguous about which site
+// went quiet, which is the one thing the report has to be right about.
+func TestCatalogingTheSameStateTwicePanics(t *testing.T) {
+	const what = "a duplicated description"
+	c := newCatalog()
+	c.add(what, "first_test.go:1")
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("cataloging %q twice did not panic", what)
+		}
+		msg, _ := r.(string)
+		if !strings.Contains(msg, what) || !strings.Contains(msg, "first_test.go:1") {
+			t.Errorf("panic %v names neither the duplicate nor where it came from", r)
+		}
+	}()
+	c.add(what, "second_test.go:2")
+}
+
+func TestAnEmptyDescriptionPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("an empty description did not panic")
+		}
+	}()
+	newCatalog().add("   ", "x_test.go:1")
+}
+
+// The report points at the var so nobody has to grep for the description.
+func TestSometimesRecordsWhereItWasCataloged(t *testing.T) {
+	if !strings.HasPrefix(selfCheck.site, "testinv/testinv_test.go:") {
+		t.Errorf("registration site = %q, want this file", selfCheck.site)
+	}
+}
+
+// review is where the run's verdict is decided, so it is tested directly on
+// synthetic inventories rather than by wrangling a second test binary.
+func TestAnUnreachedStateFailsTheRunAndNamesItself(t *testing.T) {
+	report, incomplete := review([]state{
+		{what: "a batch of more than one event", site: "bus/testinv_test.go:12"},
+		{what: "a redelivery", site: "bus/testinv_test.go:15", reached: true},
+	}, "", true, false)
+
+	if !incomplete {
+		t.Fatalf("an unreached state did not fail the run")
+	}
+	for _, want := range []string{
+		"1 cataloged state never reached",
+		"NEVER REACHED: a batch of more than one event",
+		"bus/testinv_test.go:12",
+	} {
+		if !strings.Contains(report, want) {
+			t.Errorf("report is missing %q:\n%s", want, report)
+		}
+	}
+	if strings.Contains(report, "NEVER REACHED: a redelivery") {
+		t.Errorf("report named a state that was reached:\n%s", report)
+	}
+}
+
+// A run whose tests failed reaches less by construction, so the advice must not
+// tell someone chasing a real failure that their suite is silently rotting.
+func TestAFailedRunIsToldToFixTheTestsFirst(t *testing.T) {
+	report, incomplete := review([]state{
+		{what: "a batch of more than one event", site: "bus/testinv_test.go:12"},
+	}, "", false, false)
+
+	if !incomplete {
+		t.Errorf("an unreached state stopped being reported because tests failed")
+	}
+	if strings.Contains(report, "The tests still pass") {
+		t.Errorf("a failing run was told its tests pass:\n%s", report)
+	}
+	if !strings.Contains(report, "fix those first") {
+		t.Errorf("a failing run was not pointed at the real failures:\n%s", report)
+	}
+}
+
+func TestACompleteInventoryIsSilent(t *testing.T) {
+	report, incomplete := review([]state{
+		{what: "a redelivery", site: "bus/testinv_test.go:15", reached: true},
+	}, "", true, false)
+	if incomplete {
+		t.Errorf("a complete inventory failed the run")
+	}
+	if report != "" {
+		t.Errorf("a complete inventory printed %q, want silence", report)
+	}
+}
+
+func TestAnEmptyInventoryCostsNothing(t *testing.T) {
+	report, incomplete := review(nil, "", true, false)
+	if incomplete || report != "" {
+		t.Errorf("an empty inventory produced (%q, %v), want silent and passing", report, incomplete)
+	}
+}
+
+// A filtered run cannot reach the whole inventory, so it must not fail — but it
+// must say that it checked nothing, or the silence reads as a pass.
+func TestAFilteredRunSaysItCheckedNothing(t *testing.T) {
+	report, incomplete := review([]state{
+		{what: "a batch of more than one event", site: "bus/testinv_test.go:12"},
+	}, "this run is filtered by -run TestFoo", true, false)
+
+	if incomplete {
+		t.Errorf("a filtered run failed on an unreached state")
+	}
+	if !strings.Contains(report, "not checking 1 cataloged state") ||
+		!strings.Contains(report, "-run TestFoo") {
+		t.Errorf("a filtered run did not report what it skipped:\n%s", report)
+	}
+}
+
+// A mark may sit inside a test double that production code calls on a hot path,
+// so the steady-state cost is the number that decides whether placing one is ever
+// a judgement call. It is a plain atomic load once the state has been reached.
+func BenchmarkReachedOnAnAlreadyReachedMark(b *testing.B) {
+	m := newCatalog().add("a state already reached", "x_test.go:1")
+	m.Reached()
+	for b.Loop() {
+		m.Reached()
+	}
+}
+
+func TestVerboseListsTheWholeInventory(t *testing.T) {
+	report, _ := review([]state{
+		{what: "a batch of more than one event", site: "bus/testinv_test.go:12"},
+		{what: "a redelivery", site: "bus/testinv_test.go:15", reached: true},
+	}, "", true, true)
+
+	if !strings.Contains(report, "[MISSING] a batch of more than one event") ||
+		!strings.Contains(report, "[reached] a redelivery") {
+		t.Errorf("verbose report does not list both states:\n%s", report)
+	}
+}


### PR DESCRIPTION
Spike, adopt-or-drop shaped like PR #799. **Verdict: adopt, narrowly.** Present for review — not for merge without a call on the verdict.

## The problem

A test suite can keep passing while it quietly stops exercising what it was written for. The assertion still holds; the situation it was written *about* stopped arising. Line coverage cannot see it — the lines still run. It is a **condition** that went missing, not a location.

attn has been burned by this shape repeatedly: a verify gate reporting an empty `confirmed` list because its agents had died, mutation tests surviving because another path happened to cover the input, harness legs that never reached the state they exist for.

Antithesis's *sometimes assertion* is the off-the-shelf idea: mark a state as "reached at least once this run", fail the run when a cataloged mark was never hit.

## What this adds

`internal/testinv` — a per-package inventory, ~200 lines, no dependencies, imported only by test files.

```go
// internal/bus/testinv_test.go — the package's whole catalog, in one file
var sawMultiEventBatch = testinv.Sometimes("the log is read forward into a batch holding more than one event")

func TestMain(m *testing.M) { os.Exit(testinv.Run(m)) }

// internal/bus/bus_test.go — inside memStore.Since, the double the Bus reads through
if len(out) > 1 {
	sawMultiEventBatch.Reached()
}
```

`Run` runs the package's tests, then checks the inventory:

```
PASS

--- FAIL: testinv (1 cataloged state never reached this run)
    NEVER REACHED: the log is read forward into a batch holding more than one event
        cataloged at bus/testinv_test.go:24
    The tests still pass, so nothing else will say this. A cataloged state
    that stops happening means the suite no longer exercises the path it was
    written for. Restore the state, or drop the entry and say why.
```

The `PASS` above the `FAIL` is the whole point.

## The receipt

**Change `DefaultBatchSize` from 200 to 1 in `internal/bus/bus.go`.** One token. Plausible as a memory tweak. It retires the drain's batch loop — the paging read, the per-event cursor advance, the failure streak cleared on each success — and `go test ./internal/bus` prints exactly the output above: **every test passes, and the catalog is the only thing that notices.**

The test with the most to lose is `TestBackoffDoesNotRatchetAcrossSuccessfulDeliveries`, which seeds a 30-event backlog specifically so "the batch loop never sees an empty batch, which is the only place the older code cleared the streak" — its own comment. With a batch size of 1 that setup is decorative and the test asserts nothing it was written to assert. It stays green.

## Four marks, and what actually notices when each breaks

| Mark | Mutation | Mark red? | Anything else red? |
|---|---|---|---|
| bus: a batch holds more than one event | `DefaultBatchSize` 200 → 1 | yes | **no — nothing** |
| bus: a handler is given an event it already had | advance the cursor on handler error | yes | yes: 2 tests |
| jobs: dispatch withholds a job whose scheduled time has not arrived | retry at `now`, not `now + backoff` | no¹ | yes: 3 tests |
| jobs: a coalescing trigger lands on a running job | drop the `Requeued` flag | n/a² | yes: that test deadlocks |

¹ The mark covers backoff *and* the coalescing debounce, so removing only the backoff leaves it reached by the debounce tests.
² The run never finishes, so the inventory is never checked — a real limit, noted below.

**One mark out of four caught something nothing else did.** That is the calibration, not a disappointment. In a suite that asserts as specifically as this one, most interesting states are already asserted *somewhere*; what a cataloged state adds there is durability — the claim belongs to the run, not to the test that happens to satisfy it — which is insurance, not detection. The first row is the case where it *is* detection: a precondition a test needs and cannot check, whose disappearance leaves the assertion technically true and completely empty.

## The limit that decides where a mark can go

Marks are test-only, so a state must be observable from the test side. In practice the host is a **test double the production code calls through** — `memStore.Since` / `recorder.handle` in bus, `memStore.Eligible` / `memStore.Save` in jobs. Production carries nothing.

The third candidate site did not survive that constraint, on purpose: `internal/daemon`'s classifier-staleness drop is a textbook sometimes state — timing-dependent, unassertable — but it happens inside the resolver, invisible to any test double. Marking it means instrumenting production code, which is a separate decision with a real cost. **The reach of this mechanism is exactly the reach of a package's test doubles.**

## Limits worth knowing

- **A filtered run checks nothing, and you will not see it say so.** `-run`/`-skip`/`-short`/`-list` cannot reach the whole inventory, so `Run` reports what it skipped rather than failing. But `go test` suppresses a passing binary's output, so a plain `go test ./internal/bus -run Foo` prints a bare `ok` — pair it with `-v` to see the notice. Not fixable from inside `Run`: on a passing run there is no stream that reaches the terminal. A mark defends CI's unfiltered `scripts/test-go.sh`, never the inner loop.
- **A run that never returns is never checked.** The check is after `m.Run()`; a panic or timeout skips it.
- **Do not catalog a state behind a conditional skip**, or one the suite reaches only *sometimes*. This is a deterministic unit suite, not a fuzzer — a genuinely racy condition would fire on the runs where the interleaving did not happen, and a flake generator is worse than no catalog. Antithesis can make that claim because it controls the schedule; `go test` does not. **Catalog what the suite reaches deterministically but incidentally.**

## Cost

- `Reached` on an already-reached mark: **3.0 ns/op** (`go test -run XXX -bench BenchmarkReached -benchtime 3s ./internal/testinv`) — it reads before it writes, so no contended store per hit.
- Per package, baseline measured on the pre-change files via `go test -overlay`, three runs each: `internal/bus` **0.580–0.766s → 0.606–0.714s**, `internal/jobs` **0.299–0.623s → 0.372–0.598s**. Indistinguishable from noise.
- Unused: a package that never calls `Sometimes` has an empty catalog and `Run` is `m.Run`.
- `go test -race -count=3` on all three packages: clean. Full `make test`: green.

## Not built: suite-level aggregation

Per-package is enough — an incomplete catalog fails its package, which fails `make test`. The sketch, for when the catalog outgrows it: `Run` writes `$ATTN_TESTINV_DIR/<package>.json` when the env var is set; `make test` points it at a temp dir and a summary step merges. That buys a whole-suite view (and could re-enable checking for filtered runs) at the cost of a writer, a reader in `tools/`, and a Makefile step — more surface than the mechanism it reports on. Rationale in the plan doc.

## The rule, if adopted

**Catalog a state when a test depends on a situation it cannot assert about itself — a precondition, a delay, a backlog, a collision — and the test would still pass if that situation stopped arising.** Check before adding one: *if this condition silently stopped happening tomorrow, which test would go red?* "None" means it belongs in the catalog. A named test means it probably does not.

## Surfaces

- **CLI / daemon / app / protocol / Linux / plugins / SDK:** none touched. The diff is one new test-only package, two catalog files, and five lines inside two existing in-memory test doubles. Zero production code changes (`git diff --stat` confirms).
- **Docs:** plan doc with the full findings, `changelog.d/` fragment (`kind: internal`, `area: testing`).
- **Live verification:** exempt under AGENTS.md — a pure isolated change fully covered by unit tests, with no daemon lifecycle, protocol, PTY, background-runner, timing, or UI surface. Nothing in this diff can reach a running app or daemon.

Full findings: `docs/plans/2026-08-09-sometimes-assertions-catalog.md`.

https://claude.ai/code/session_01Jr2VnH5ZHcgPnNDXEaC8Wt
