### PR TITLE
test: rapid properties for the pty scanners, docstore, and layout tree

### DIFF
--- a/changelog.d/rapid-property-wave.yaml
+++ b/changelog.d/rapid-property-wave.yaml
@@ -1,0 +1,17 @@
+kind: internal
+area: testing
+change: >
+  Applies property-based testing (`pgregory.net/rapid`) to three units picked for
+  invariant density: the worker's PTY feed segmenter and OSC scanner, where the
+  property is that generated escape streams produce the same result however the
+  read loop cuts them; the document store's query compiler, where the property is
+  that compiled SQL is built only from identifiers the store derived itself,
+  whatever a caller sends; and the workspace layout tree, where random sequences
+  of split / dock / move / remove / resize / normalize must leave a well-formed
+  tree with the leaves and tile metadata they started with. The example tests
+  stay as they are — properties explore, they do not document.
+notes: >
+  Each property is mutation-checked: the receipts, per-property costs, and the
+  one defect rapid turned up (UpdateTileParams and UpdateTileSessionID write
+  through the caller's layout, unlike every other operation in the package) are
+  in the pull request.

--- a/internal/docstore/compile_property_test.go
+++ b/internal/docstore/compile_property_test.go
@@ -1,0 +1,400 @@
+package docstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"unicode"
+
+	"pgregory.net/rapid"
+)
+
+// This package's stated invariant is a security boundary, not a nicety: "every
+// identifier the store executes is derived from an integer or a validated field
+// name — never from caller text" (AGENTS.md). The example tests in
+// docstore_test.go check that on the queries we thought of. A query, though, is
+// a JSON object that arrives from an extension, a UI tile, or `attn doc`, and
+// the string that breaks the rule is by definition one nobody wrote down.
+//
+// So rapid drives Compile with caller strings drawn from a pool of the things an
+// attacker or a confused caller actually sends — quotes, semicolons, comment
+// introducers, empty, unicode, absurdly long — in every position a caller
+// controls, and the assertion is not "it did not blow up" but a grammar: the SQL
+// that comes out is tokenized, and every token has to be a keyword, a stamped
+// column, the minted table, a `?`, or a quoted `f_<declared field>`. Anything
+// else fails, whatever it happens to say. There is no substring check to
+// out-quote, and no database is involved: Compile is pure.
+
+// hostile is what a caller string can be. Nothing here is legal in any position
+// that reaches an identifier, so a compile that succeeds must have kept every
+// one of them out of the SQL — or bound it as an argument, where it is inert.
+var hostile = []string{
+	"",
+	" ",
+	`"`,
+	`x"; DROP TABLE doc_1; --`,
+	`'; DELETE FROM doc_1; --`,
+	"`backtick`",
+	"[bracketed]",
+	"a/*comment*/b",
+	"a--comment",
+	"f_title",
+	"doc_1",
+	"1",
+	"-",
+	"a b",
+	"a\nb",
+	"a\x00b",
+	"日本語",
+	"ns/coll",
+	"SELECT",
+	"*",
+	strings.Repeat("a", 300),
+}
+
+// declaredFields is the collection under test: names that pass Validate, one of
+// each type, so a filter has somewhere legitimate to land.
+var declaredFields = []FieldSpec{
+	{Name: "title", Type: FieldString},
+	{Name: "count", Type: FieldNumber},
+	{Name: "done", Type: FieldBool},
+	{Name: "_private", Type: FieldString},
+}
+
+// canary values are what a filter bound may be. A bound is caller text with no
+// restriction at all — the whole point of binding it — so the property is that
+// it reaches Args and never the statement.
+var canaryValues = []any{
+	`'); DROP TABLE doc_1; --`,
+	`" OR 1=1 --`,
+	"ordinary",
+	"",
+	float64(42),
+	int(7),
+	true,
+	false,
+	nil,
+	json.Number("3.5"),
+	"2026-08-09T10:00:00Z",
+	"not-a-timestamp",
+	[]string{"array"},
+	map[string]any{"object": true},
+}
+
+var (
+	legalFieldRefs = func() []string {
+		refs := []string{FieldCreatedAt, FieldUpdatedAt}
+		for _, f := range declaredFields {
+			refs = append(refs, f.Name)
+		}
+		return refs
+	}()
+	badOps = []Op{"like", "", "= 1 OR 1", "EQ", "<>"}
+)
+
+// sqlKeywords is every bare word Compile is allowed to write. The list is
+// closed on purpose: a new one has to be added here deliberately, which is the
+// review step that catches a splice added by accident.
+var sqlKeywords = map[string]bool{
+	"SELECT": true, "FROM": true, "WHERE": true,
+	"AND": true, "OR": true, "IS": true, "NOT": true, "NULL": true,
+	"ASC": true, "DESC": true,
+	// The store's own stamped columns, written literally because they are not
+	// caller text.
+	"id": true, FieldCreatedAt: true, FieldUpdatedAt: true,
+}
+
+// checkSQLIdentifiers walks one SQL fragment and reports the first token that is
+// not something Compile is allowed to have written. allowedTable is the minted
+// table name, allowedColumns the generated columns of the declared fields.
+func checkSQLIdentifiers(fragment, allowedTable string, allowedColumns map[string]bool) error {
+	for i := 0; i < len(fragment); {
+		c := fragment[i]
+		switch {
+		case c == '"':
+			// A quoted identifier. Read to the closing quote, undoubling as
+			// SQLite does, and check what it actually names.
+			var ident strings.Builder
+			i++
+			for {
+				if i >= len(fragment) {
+					return fmt.Errorf("unterminated quoted identifier in %q", fragment)
+				}
+				if fragment[i] == '"' {
+					if i+1 < len(fragment) && fragment[i+1] == '"' {
+						ident.WriteByte('"')
+						i += 2
+						continue
+					}
+					i++
+					break
+				}
+				ident.WriteByte(fragment[i])
+				i++
+			}
+			if !allowedColumns[ident.String()] {
+				return fmt.Errorf("quoted identifier %q is not a declared field's column", ident.String())
+			}
+		case c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'):
+			start := i
+			for i < len(fragment) && (fragment[i] == '_' || isASCIIAlnum(fragment[i])) {
+				i++
+			}
+			word := fragment[start:i]
+			if !sqlKeywords[word] && word != allowedTable {
+				return fmt.Errorf("bare identifier %q is neither a keyword, a stamped column, nor the minted table %q", word, allowedTable)
+			}
+		case c >= '0' && c <= '9':
+			return fmt.Errorf("a literal number is spliced into %q; every value belongs in Args", fragment)
+		case strings.IndexByte("?()<>=, ", c) >= 0:
+			i++
+		default:
+			return fmt.Errorf("byte %q has no place in compiled SQL (%q)", string(rune(c)), fragment)
+		}
+	}
+	return nil
+}
+
+func isASCIIAlnum(b byte) bool {
+	return (b >= '0' && b <= '9') || (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
+}
+
+// TestCompiledSQLIsBuiltOnlyFromDerivedIdentifiers is the headline property: for
+// any caller-controlled input, Compile either refuses — as a typed
+// InvalidQueryError, which is what the surfaces above branch on — or produces
+// SQL whose every identifier it derived itself.
+func TestCompiledSQLIsBuiltOnlyFromDerivedIdentifiers(t *testing.T) {
+	allowedColumns := make(map[string]bool, len(declaredFields))
+	for _, f := range declaredFields {
+		allowedColumns[FieldColumn(f.Name)] = true
+	}
+
+	attempts, compiles := 0, 0
+	rapid.Check(t, func(t *rapid.T) {
+		attempts++
+
+		// Draw a query the store would accept, then corrupt exactly one part of
+		// it — or none. Corrupting one position at a time is what keeps the
+		// hostile string reaching the code that handles that position: a query
+		// with a bad namespace AND a bad sort field is refused at the namespace
+		// and says nothing about sorting.
+		corrupt := rapid.SampledFrom([]string{
+			"", "", "", "", // half the draws are left well-formed
+			"table", "namespace", "collection", "limit",
+			"filter_field", "filter_value", "filter_op", "sort_field", "after",
+		}).Draw(t, "corrupt")
+		spoil := func(position, legal string) string {
+			if corrupt != position {
+				return legal
+			}
+			return rapid.SampledFrom(hostile).Draw(t, position)
+		}
+
+		schema := CollectionSchema{
+			Namespace:  "ext/props",
+			Collection: "records",
+			Fields:     declaredFields,
+			Table: spoil("table", rapid.SampledFrom([]string{
+				TableName(1), TableName(12), TableName(9007199254740991),
+			}).Draw(t, "minted_table")),
+		}
+		// The declaration itself is always one the store would have accepted:
+		// field names are validated at declare time, and that is the assumption
+		// the identifier rule rests on. What varies here is everything a caller
+		// sends afterwards.
+		if err := (CollectionSchema{Namespace: schema.Namespace, Collection: schema.Collection, Fields: schema.Fields}).Validate(); err != nil {
+			t.Fatalf("the fixture declaration does not validate: %v", err)
+		}
+
+		limit := rapid.SampledFrom([]int{0, 1, 10, DefaultLimit, MaxLimit}).Draw(t, "legal_limit")
+		if corrupt == "limit" {
+			limit = rapid.IntRange(-1000, MaxLimit*3).Draw(t, "limit")
+		}
+		q := Query{
+			Namespace:  spoil("namespace", schema.Namespace),
+			Collection: spoil("collection", schema.Collection),
+			Limit:      limit,
+			After:      spoil("after", rapid.SampledFrom([]string{"", "doc-1", "A.b_c-9"}).Draw(t, "legal_after")),
+		}
+		for range rapid.IntRange(0, 2).Draw(t, "filters") {
+			field := spoil("filter_field", rapid.SampledFrom(legalFieldRefs).Draw(t, "legal_filter_field"))
+			op := rapid.SampledFrom([]Op{OpEq, OpLt, OpLte, OpGt, OpGte}).Draw(t, "legal_filter_op")
+			if corrupt == "filter_op" {
+				op = rapid.SampledFrom(badOps).Draw(t, "filter_op")
+			}
+			value := typedValue(t, field)
+			if corrupt == "filter_value" {
+				value = rapid.SampledFrom(canaryValues).Draw(t, "filter_value")
+			}
+			q.Filters = append(q.Filters, Filter{Field: field, Op: op, Value: value})
+		}
+		if rapid.Bool().Draw(t, "sorted") {
+			q.Sort = &Sort{
+				Field: spoil("sort_field", rapid.SampledFrom(legalFieldRefs).Draw(t, "legal_sort_field")),
+				Desc:  rapid.Bool().Draw(t, "sort_desc"),
+			}
+		}
+
+		var anchor *Document
+		if q.After != "" {
+			anchor = &Document{
+				ID:   q.After,
+				Body: json.RawMessage(rapid.SampledFrom(anchorBodies).Draw(t, "anchor_body")),
+			}
+		}
+
+		compiled, err := q.Compile(schema, anchor)
+		if err != nil {
+			if !IsInvalidQuery(err) {
+				t.Fatalf("Compile refused the query with an untyped error, which no caller can branch on: %v", err)
+			}
+			return
+		}
+		compiles++
+
+		if err := ValidateTableName(compiled.Table); err != nil {
+			t.Fatalf("compiled against table %q: %v", compiled.Table, err)
+		}
+		for name, fragment := range map[string]string{"where": compiled.Where, "order": compiled.Order} {
+			if err := checkSQLIdentifiers(fragment, compiled.Table, allowedColumns); err != nil {
+				t.Fatalf("the %s fragment %q was compiled from caller text: %v", name, fragment, err)
+			}
+		}
+		if got := strings.Count(compiled.Where, "?"); got != len(compiled.Args) {
+			t.Fatalf("where %q has %d placeholders but %d args; a value was spliced or dropped",
+				compiled.Where, got, len(compiled.Args))
+		}
+		if compiled.Limit < 1 || compiled.Limit > MaxLimit {
+			t.Fatalf("compiled limit is %d, outside 1..%d", compiled.Limit, MaxLimit)
+		}
+	})
+
+	// The tripwire against a vacuous property. Everything above only asserts
+	// anything on a query that compiled; a generator that drifts into refusing
+	// every draw would go green while checking nothing, which is the failure
+	// mode a property test hides best. One in five is far below what the
+	// generators produce and far above zero.
+	if compiles*5 < attempts {
+		t.Fatalf("only %d of %d generated queries compiled; the generators refuse too much to be checking anything",
+			compiles, attempts)
+	}
+}
+
+// typedValue draws a bound the field's declared type accepts, so a well-formed
+// query actually compiles. The bounds are still nasty strings where the type
+// allows one — a string field takes `'); DROP TABLE …` perfectly legitimately,
+// and that is the case worth compiling, because it is the one that proves the
+// value went to Args rather than into the statement.
+func typedValue(t *rapid.T, field string) any {
+	switch field {
+	case "title", "_private":
+		return rapid.SampledFrom([]any{"ordinary", "", `'); DROP TABLE doc_1; --`, `" OR 1=1 --`}).Draw(t, "string_value")
+	case "count":
+		return rapid.SampledFrom([]any{float64(42), int(7), json.Number("3.5")}).Draw(t, "number_value")
+	case "done":
+		return rapid.SampledFrom([]any{true, false}).Draw(t, "bool_value")
+	case FieldCreatedAt, FieldUpdatedAt:
+		return rapid.SampledFrom([]any{"2026-08-09T10:00:00Z", "2026-08-09T10:00:00.000000000Z"}).Draw(t, "time_value")
+	default:
+		// The field name was corrupted; nothing types against it.
+		return rapid.SampledFrom(canaryValues).Draw(t, "filter_value")
+	}
+}
+
+// anchorBodies are the cursor documents a paging query can be compiled against:
+// the sort field present, absent, and explicitly null are three different
+// branches in afterTuple, and a body that is not an object at all is a refusal.
+var anchorBodies = []string{
+	`{"title":"a","count":1,"done":true}`,
+	`{}`,
+	`{"title":null}`,
+	`{"title":["array"]}`,
+	`[]`,
+	`not json`,
+}
+
+// quoteIdent is the one splice defended by quoting rather than by validation, so
+// it has to be safe for a name that never passed a validator — a field declared
+// before a validation rule existed, say. The property is that it round-trips:
+// what SQLite reads back out of the quoted form is exactly the name that went
+// in, so there is no string that closes the quote early and starts meaning
+// something.
+func TestQuotingAnIdentifierRoundTrips(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		name := rapid.String().Draw(t, "name")
+		quoted := quoteIdent(name)
+
+		if len(quoted) < 2 || quoted[0] != '"' || quoted[len(quoted)-1] != '"' {
+			t.Fatalf("quoteIdent(%q) = %q is not a quoted identifier", name, quoted)
+		}
+		got, rest, err := readQuotedIdent(quoted)
+		if err != nil {
+			t.Fatalf("quoteIdent(%q) = %q does not parse back: %v", name, quoted, err)
+		}
+		if rest != "" {
+			t.Fatalf("quoteIdent(%q) = %q ends the identifier early, leaving %q as SQL", name, quoted, rest)
+		}
+		if got != name {
+			t.Fatalf("quoteIdent(%q) reads back as %q", name, got)
+		}
+	})
+}
+
+// readQuotedIdent decodes a SQLite double-quoted identifier: doubled quotes are
+// one literal quote, the first single quote ends it. It returns the name and
+// whatever followed, which is what tells a broken quoting apart from a working
+// one.
+func readQuotedIdent(s string) (string, string, error) {
+	if len(s) == 0 || s[0] != '"' {
+		return "", "", fmt.Errorf("does not start with a quote")
+	}
+	var out strings.Builder
+	for i := 1; i < len(s); {
+		if s[i] != '"' {
+			out.WriteByte(s[i])
+			i++
+			continue
+		}
+		if i+1 < len(s) && s[i+1] == '"' {
+			out.WriteByte('"')
+			i += 2
+			continue
+		}
+		return out.String(), s[i+1:], nil
+	}
+	return "", "", fmt.Errorf("unterminated")
+}
+
+// The two physical names are the whole derivation chain: a table comes from a
+// row id and a column from a validated field name. Neither may produce something
+// that stops being a plain identifier, whatever it is handed.
+func TestPhysicalNamesStayPlainIdentifiers(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		id := rapid.Int64Range(1, 1<<53-1).Draw(t, "row_id")
+		table := TableName(id)
+		if err := ValidateTableName(table); err != nil {
+			t.Fatalf("TableName(%d) = %q is not accepted by its own validator: %v", id, table, err)
+		}
+
+		nonPositive := rapid.Int64Range(-1<<20, 0).Draw(t, "non_positive_row_id")
+		if err := ValidateTableName(TableName(nonPositive)); err == nil {
+			t.Fatalf("TableName(%d) = %q was accepted; only a real row id mints a table",
+				nonPositive, TableName(nonPositive))
+		}
+
+		name := rapid.StringMatching(`[A-Za-z_][A-Za-z0-9_]{0,16}`).Draw(t, "field")
+		column := FieldColumn(name)
+		if !strings.HasPrefix(column, fieldColumnPrefix) {
+			t.Fatalf("FieldColumn(%q) = %q lost its prefix, so it can collide with a column the store owns", name, column)
+		}
+		for _, r := range column {
+			if r != '_' && !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+				t.Fatalf("FieldColumn(%q) = %q holds %q, which needs quoting to be an identifier", name, column, r)
+			}
+		}
+		if expr := FieldExpression(name); strings.ContainsAny(expr, "'\"") != strings.Contains(expr, "'$.") {
+			t.Fatalf("FieldExpression(%q) = %q carries a quote it did not put there", name, expr)
+		}
+	})
+}

--- a/internal/pty/chunkboundary_property_test.go
+++ b/internal/pty/chunkboundary_property_test.go
@@ -1,0 +1,182 @@
+package pty
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+// Chunk-boundary invariance: what the Go scanners report must not depend on
+// where the read loop happened to cut the stream.
+//
+// This is the invariant behind shipped bug #737. A PTY read returns whatever the
+// kernel had, so an escape routinely straddles a boundary; a scanner that
+// decides differently on either side of one produces a stream the worker's
+// terminal and the client's terminal disagree about, and the two grids drift
+// apart silently from that byte on.
+//
+// The existing batteries already sweep every split point — but only of the
+// inputs somebody wrote down. That is the half these properties add: the inputs
+// themselves are generated, from a grammar of the fragments that make boundaries
+// interesting (a lone ESC, half an introducer, a marker prefix that diverges on
+// its last byte, a UTF-8 character with its continuation bytes elsewhere, the
+// C1 controls that abort a string), and rapid picks the boundaries. Nothing here
+// needs an oracle: the whole-input run IS the expected answer, and every
+// chunking of that input has to match it.
+
+// streamFragments are the pieces a generated stream is built from. Each one is
+// either a complete thing, or deliberately half of one, so concatenating a few
+// of them produces the sequences that only exist across a boundary: an ESC that
+// turns out to introduce nothing, a `133;` prefix that turns out to be a title,
+// an APC that is never terminated.
+var streamFragments = []string{
+	// Ordinary output, including the multi-byte characters whose continuation
+	// bytes must not be separated from their lead by an extraction.
+	"hello",
+	"a",
+	"",
+	"\r\n",
+	"é",            // 2-byte
+	"⠀",            // 3-byte, and the braille blank a spinner prints
+	"🙂",            // 4-byte
+	"\xe1",         // a lead byte with its continuations missing
+	"\xa5",         // an orphaned continuation byte
+	"\x07",         // BEL, which ends an OSC and nothing else
+	"\x18", "\x1a", // CAN and SUB, which abort a string wherever it stands
+	"\x80", "\x9c", // an executed C1, and C1 ST
+	"\x90", "\x9b", "\x9d", "\x9e", "\x9f", // the C1 introducers
+	"\x1b",   // a lone ESC: the byte after it decides everything
+	"\x1b[",  // half a CSI
+	"\x1b]",  // an OSC introducer with nothing after it
+	"\x1b_",  // half an APC introducer
+	"\x1b_G", // a kitty introducer with no payload yet
+	"\x1b(B", // an escape with an intermediate byte
+	"\x1b\\", // ST on its own
+	"\x1b[0m",
+	"\x1b]0;window title\x07",
+	"\x1b]0;title with \x1b in it\x07",
+	"\x1b]777;notify;Claude Code;waiting\x07",
+	"\x1b]13",        // a marker prefix cut mid-way
+	"\x1b]133",       // and one byte further
+	"\x1b]133;",      // the full prefix, body still to come
+	"\x1b]134;x\x07", // an OSC whose code diverges from 133 on its last digit
+	"\x1b]133;A\x07",
+	"\x1b]133;B\x1b\\",
+	"\x1b]133;C;cmdline=ls -la\x07",
+	"\x1b]133;D;0\x07",
+	"\x1b]133;D;127\x1b\\",
+	"\x1b]133;A",      // an unterminated marker
+	"\x1b]133;A\x1b[", // a marker a stray ESC abandons
+	kittyIntro + "a=T,f=24,s=1,v=1;QQ==" + kittyST,
+	kittyIntro + "a=T,f=100,m=1;iVBORw0K" + kittyST,
+	kittyIntro + "a=T,f=24;AA\x07BB" + kittyST, // a BEL inside a kitty payload
+	kittyIntro + "m=1;GgoAAABJ",                // an unterminated APC
+	kittyIntro + "i=1;AA\x9c",                  // one terminated by C1 ST
+	kittyIntro + "i=2;AA\x18",                  // one a control aborts
+	kittyST,
+}
+
+// drawStream builds an input out of fragments. Short on purpose: the boundary
+// cases live in the joins between fragments, not in volume, and every scanner
+// here has a tripwire measured in kilobytes or megabytes that a long generated
+// stream would start bumping into for reasons that have nothing to do with
+// chunking.
+func drawStream(t *rapid.T) string {
+	var b strings.Builder
+	for range rapid.IntRange(0, 8).Draw(t, "fragments") {
+		b.WriteString(rapid.SampledFrom(streamFragments).Draw(t, "fragment"))
+	}
+	return b.String()
+}
+
+// drawChunking cuts input at rapid-chosen offsets. The empty chunking (one
+// whole chunk) is included: a Feed of the whole input has to agree with itself.
+func drawChunking(t *rapid.T, input string) []string {
+	if len(input) < 2 {
+		return []string{input}
+	}
+	cuts := rapid.SliceOfNDistinct(
+		rapid.IntRange(1, len(input)-1),
+		0, min(6, len(input)),
+		func(i int) int { return i },
+	).Draw(t, "cuts")
+	slices.Sort(cuts)
+
+	chunks := make([]string, 0, len(cuts)+1)
+	prev := 0
+	for _, cut := range cuts {
+		chunks = append(chunks, input[prev:cut])
+		prev = cut
+	}
+	return append(chunks, input[prev:])
+}
+
+// TestFeedSegmenterIsChunkBoundaryInvariant is the property the worker's whole
+// extraction story rests on. The segmenter decides where a sequence begins and
+// ends, and it removes bytes from one side of the feed on the strength of that
+// decision; a decision that changes with the boundary is a grid divergence.
+func TestFeedSegmenterIsChunkBoundaryInvariant(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		input := drawStream(t)
+		wantEmissions, wantPending := runKittySegmenter(t, []string{input})
+
+		chunks := drawChunking(t, input)
+		gotEmissions, gotPending := runKittySegmenter(t, chunks)
+
+		if !kittyEmissionsEqual(gotEmissions, wantEmissions) {
+			t.Fatalf("chunked as %q:\n got: %s\nwant: %s",
+				chunks, formatKittyEmissions(gotEmissions), formatKittyEmissions(wantEmissions))
+		}
+		if gotPending != wantPending {
+			t.Fatalf("chunked as %q: holds %q, want %q", chunks, gotPending, wantPending)
+		}
+
+		// The invariant this file's header names: every byte is accounted for
+		// exactly once. Asserted on the chunked run, where a hold can drop or
+		// double one.
+		var rebuilt strings.Builder
+		for _, e := range gotEmissions {
+			rebuilt.WriteString(e.bytes)
+		}
+		rebuilt.WriteString(gotPending)
+		if rebuilt.String() != input {
+			t.Fatalf("chunked as %q: emissions rebuild %q, want %q", chunks, rebuilt.String(), input)
+		}
+	})
+}
+
+// TestOSCScannerIsChunkBoundaryInvariant is the same property for the read-only
+// scanner. It consumes nothing, so a boundary cannot corrupt the stream here —
+// but a sequence it fails to see across one is a window title that never
+// updates, or a notification that never fires.
+//
+// Bounded by oscScanMaxPending on purpose. Past that tripwire the scanner
+// abandons what it is holding, and where the abandon lands DOES depend on the
+// chunking: a whole-input Feed weighs the whole sequence at once, a chunked one
+// weighs it as it arrives. Generated streams stay two orders of magnitude below
+// it, which is also where every real title and notification sits.
+func TestOSCScannerIsChunkBoundaryInvariant(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		input := drawStream(t)
+		if len(input) > oscScanMaxPending/2 {
+			t.Fatalf("a generated stream is %d bytes, past half the scanner's %d-byte abandon tripwire; "+
+				"this property does not hold up there, so the fragment pool has to stay under it",
+				len(input), oscScanMaxPending)
+		}
+		want := scanAll(input)
+
+		chunks := drawChunking(t, input)
+		got := scanAll(chunks...)
+
+		if len(got) != len(want) {
+			t.Fatalf("chunked as %q: got %+v, want %+v", chunks, got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("chunked as %q, sequence %d: got %+v, want %+v", chunks, i, got[i], want[i])
+			}
+		}
+	})
+}

--- a/internal/pty/kittyseg_test.go
+++ b/internal/pty/kittyseg_test.go
@@ -558,11 +558,20 @@ var kittySegBattery = []kittySegCase{
 	},
 }
 
+// segTB is the slice of a test handle the segmenter runner needs. It is an
+// interface rather than *testing.T so the property tests can drive the same
+// runner with rapid's own handle; neither type satisfies the other, and
+// testing.TB cannot be implemented outside the testing package.
+type segTB interface {
+	Helper()
+	Fatalf(format string, args ...any)
+}
+
 // runKittySegmenter feeds chunks through one segmenter and returns the
 // normalized emissions plus whatever it still holds back. It also proves the
 // segmenter never writes into the caller's chunk: the read loop hands over a
 // buffer it reuses, and the same bytes are on their way to the wire.
-func runKittySegmenter(t *testing.T, chunks []string) ([]kittyEmission, string) {
+func runKittySegmenter(t segTB, chunks []string) ([]kittyEmission, string) {
 	t.Helper()
 	seg := &feedSegmenter{}
 	var out []kittyEmission
@@ -574,13 +583,13 @@ func runKittySegmenter(t *testing.T, chunks []string) ([]kittyEmission, string) 
 
 // feedKitty pushes one chunk through seg, appending its emissions to out in
 // normalized form and checking the per-call contract.
-func feedKitty(t *testing.T, seg *feedSegmenter, chunk string, out []kittyEmission) []kittyEmission {
+func feedKitty(t segTB, seg *feedSegmenter, chunk string, out []kittyEmission) []kittyEmission {
 	t.Helper()
 	input := []byte(chunk)
 	seg.Feed(input, func(s feedSegment) {
 		switch {
 		case len(s.Bytes) == 0:
-			t.Fatal("emit called with an empty run")
+			t.Fatalf("emit called with an empty run")
 		case s.Kind != feedSegPlain:
 			out = append(out, kittyEmission{kind: s.Kind, bytes: string(s.Bytes)})
 		default:

--- a/internal/workspacelayout/testdata/rapid/TestLayoutOperationsDoNotModifyTheirInput/TestLayoutOperationsDoNotModifyTheirInput-20260809192735-63520.fail
+++ b/internal/workspacelayout/testdata/rapid/TestLayoutOperationsDoNotModifyTheirInput/TestLayoutOperationsDoNotModifyTheirInput-20260809192735-63520.fail
@@ -1,0 +1,11 @@
+# 2026/08/09 19:27:35.088662 [TestLayoutOperationsDoNotModifyTheirInput] [rapid] draw params: "/tmp/notes.md"
+# 2026/08/09 19:27:35.088673 [TestLayoutOperationsDoNotModifyTheirInput] [rapid] draw session: ""
+# 2026/08/09 19:27:35.088675 [TestLayoutOperationsDoNotModifyTheirInput] UpdateTileParams wrote through its input:
+#  got: {Type:split PaneID: TileID: TileKind: TileParams: TileSessionID: SplitID:s1 Direction:vertical Ratio:0.5 RatioLocked:true Children:[{Type:pane PaneID:p0 TileID: TileKind: TileParams: TileSessionID: SplitID: Direction: Ratio:0 RatioLocked:false Children:[]} {Type:tile PaneID: TileID:t1 TileKind:markdown TileParams:/tmp/notes.md TileSessionID: SplitID: Direction: Ratio:0 RatioLocked:false Children:[]}]}
+# want: {Type:split PaneID: TileID: TileKind: TileParams: TileSessionID: SplitID:s1 Direction:vertical Ratio:0.5 RatioLocked:true Children:[{Type:pane PaneID:p0 TileID: TileKind: TileParams: TileSessionID: SplitID: Direction: Ratio:0 RatioLocked:false Children:[]} {Type:tile PaneID: TileID:t1 TileKind:markdown TileParams: TileSessionID: SplitID: Direction: Ratio:0 RatioLocked:false Children:[]}]}
+# 
+v0.4.8#669243102897586036
+0x0
+0x1
+0x0
+0x0

--- a/internal/workspacelayout/workspacelayout_property_test.go
+++ b/internal/workspacelayout/workspacelayout_property_test.go
@@ -1,0 +1,511 @@
+package workspacelayout
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+// The example tests in workspacelayout_test.go, tile_test.go and moveleaf_test.go
+// pin the shapes we thought of: a split here, a dock there, the three or four
+// move cases that once broke. This one explores the shapes we did not. A real
+// workspace is not one operation, it is a day of them — split, dock a markdown
+// tile, drag a pane across the tree, close something, drag it back — and the
+// layout that wedges is the one reached by a sequence nobody wrote down.
+//
+// rapid drives a random sequence of the real operations and re-checks the whole
+// tree contract after every single one, so a failure names the shortest sequence
+// that reaches the broken tree rather than the tree itself.
+
+// tileMeta is what the model expects a docked tile to still carry. Kind, params
+// and session id are opaque to this package but must survive every move: a tile
+// that loses its params renders the no-selection picker, which reads to the user
+// as the file having been closed.
+type tileMeta struct {
+	kind    string
+	params  string
+	session string
+}
+
+// layoutModel is the shadow state the property checks the tree against: which
+// leaves should exist, and what each tile should still hold.
+type layoutModel struct {
+	tree  Node
+	panes map[string]bool
+	tiles map[string]tileMeta
+	next  int
+}
+
+func (m *layoutModel) mint(prefix string) string {
+	m.next++
+	return fmt.Sprintf("%s%d", prefix, m.next)
+}
+
+// leafIDs is every leaf the model believes is in the tree, in a stable order so
+// a rapid draw over it reproduces.
+func (m *layoutModel) leafIDs() []string {
+	ids := make([]string, 0, len(m.panes)+len(m.tiles))
+	for id := range m.panes {
+		ids = append(ids, id)
+	}
+	for id := range m.tiles {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func (m *layoutModel) paneIDs() []string {
+	ids := make([]string, 0, len(m.panes))
+	for id := range m.panes {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func (m *layoutModel) tileIDs() []string {
+	ids := make([]string, 0, len(m.tiles))
+	for id := range m.tiles {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// cloneNode deep-copies a tree so an operation can be checked for having left
+// its input alone. Every function here takes a Node by value and returns a new
+// one, which only holds if the children slices are copied rather than written
+// through — a caller that still holds the pre-operation layout (the daemon reads
+// a snapshot, edits it, and writes it back) must see what it read.
+func cloneNode(node Node) Node {
+	out := node
+	if node.Children == nil {
+		return out
+	}
+	out.Children = make([]Node, len(node.Children))
+	for i, child := range node.Children {
+		out.Children[i] = cloneNode(child)
+	}
+	return out
+}
+
+// checkWellFormed asserts the structural contract every consumer relies on: the
+// renderer walks this tree, the daemon derives pane bookkeeping from it, and
+// both assume a split is a split.
+func checkWellFormed(t *rapid.T, node Node, path string) {
+	switch node.Type {
+	case "pane":
+		if node.PaneID == "" {
+			t.Fatalf("%s: a pane leaf has no pane id", path)
+		}
+		if len(node.Children) > 0 {
+			t.Fatalf("%s: a pane leaf has %d children", path, len(node.Children))
+		}
+	case "tile":
+		if node.TileID == "" || node.TileKind == "" {
+			t.Fatalf("%s: a tile leaf has id %q and kind %q; both are required", path, node.TileID, node.TileKind)
+		}
+		if len(node.Children) > 0 {
+			t.Fatalf("%s: a tile leaf has %d children", path, len(node.Children))
+		}
+	case "split":
+		if len(node.Children) != 2 {
+			t.Fatalf("%s: a split has %d children, want exactly 2", path, len(node.Children))
+		}
+		if node.Direction != DirectionVertical && node.Direction != DirectionHorizontal {
+			t.Fatalf("%s: a split has direction %q", path, node.Direction)
+		}
+		if !(node.Ratio > 0 && node.Ratio < 1) {
+			t.Fatalf("%s: a split has ratio %v, which collapses a side", path, node.Ratio)
+		}
+		checkWellFormed(t, node.Children[0], path+".0")
+		checkWellFormed(t, node.Children[1], path+".1")
+	default:
+		t.Fatalf("%s: node type %q is not a pane, tile or split", path, node.Type)
+	}
+}
+
+// splitIDs collects every split id in the tree so an op can aim at one.
+func splitIDs(node Node) []string {
+	var ids []string
+	var walk func(Node)
+	walk = func(n Node) {
+		if n.Type != "split" {
+			return
+		}
+		ids = append(ids, n.SplitID)
+		for _, child := range n.Children {
+			walk(child)
+		}
+	}
+	walk(node)
+	sort.Strings(ids)
+	return ids
+}
+
+func findSplit(node Node, splitID string) (Node, bool) {
+	if node.Type != "split" {
+		return Node{}, false
+	}
+	if node.SplitID == splitID {
+		return node, true
+	}
+	for _, child := range node.Children {
+		if found, ok := findSplit(child, splitID); ok {
+			return found, true
+		}
+	}
+	return Node{}, false
+}
+
+var (
+	directions   = []Direction{DirectionVertical, DirectionHorizontal, "", "diagonal"}
+	tileKinds    = []string{string(TileKindMarkdown), string(TileKindBrowser), string(TileKindNotebook), "  markdown  "}
+	tileParams   = []string{"", "/tmp/notes.md", "  /tmp/spaced.md  ", "https://example.test"}
+	tileSessions = []string{"", "sess-a", "  sess-b  "}
+)
+
+// drawRatio spans past both ends so the clamping every constructor does is part
+// of what is under test: a ratio outside (0,1) collapses a pane to nothing.
+func drawRatio(t *rapid.T, label string) float64 {
+	return rapid.Float64Range(-1, 2).Draw(t, label)
+}
+
+func TestLayoutStaysAWellFormedTreeUnderRandomOperations(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		root := "p0"
+		m := &layoutModel{
+			tree:  DefaultLayout(root),
+			panes: map[string]bool{root: true},
+			tiles: map[string]tileMeta{},
+		}
+
+		// apply runs one operation and holds it to the contract every operation
+		// here shares: it returns a new tree and does not write through the one
+		// it was given.
+		apply := func(t *rapid.T, op func(Node) (Node, bool)) (Node, bool) {
+			before := cloneNode(m.tree)
+			next, ok := op(m.tree)
+			if !reflect.DeepEqual(m.tree, before) {
+				t.Fatalf("the operation modified the layout it was given:\n got: %+v\nwant: %+v", m.tree, before)
+			}
+			return next, ok
+		}
+
+		t.Repeat(map[string]func(*rapid.T){
+			// Cmd+D: split a terminal pane in two.
+			"split_pane": func(t *rapid.T) {
+				panes := m.paneIDs()
+				if len(panes) == 0 {
+					t.Skip("every terminal pane is closed; only tiles are left")
+				}
+				target := rapid.SampledFrom(panes).Draw(t, "target")
+				newPane := m.mint("p")
+				splitID := m.mint("s")
+				direction := rapid.SampledFrom(directions).Draw(t, "direction")
+				ratio := drawRatio(t, "ratio")
+
+				next, ok := apply(t, func(n Node) (Node, bool) {
+					return Split(n, target, newPane, splitID, direction, ratio)
+				})
+				if !ok {
+					t.Fatalf("Split on pane %q, which is in the tree, reported no change", target)
+				}
+				m.tree = next
+				m.panes[newPane] = true
+			},
+
+			// Dock a tile beside a leaf — or, for a tile already in the tree,
+			// move it there, since docking doubles as a move.
+			"dock_tile": func(t *rapid.T) {
+				anchor := rapid.SampledFrom(m.leafIDs()).Draw(t, "anchor")
+				candidates := append([]string{""}, m.tileIDs()...)
+				tileID := rapid.SampledFrom(candidates).Draw(t, "tile")
+				if tileID == "" {
+					tileID = m.mint("t")
+				}
+				if tileID == anchor {
+					t.Skip("a tile cannot be docked against itself")
+				}
+				kind := rapid.SampledFrom(tileKinds).Draw(t, "kind")
+				params := rapid.SampledFrom(tileParams).Draw(t, "params")
+				session := rapid.SampledFrom(tileSessions).Draw(t, "session")
+				splitID := m.mint("s")
+				direction := rapid.SampledFrom(directions).Draw(t, "direction")
+				before := rapid.Bool().Draw(t, "before")
+				ratio := drawRatio(t, "ratio")
+
+				next, ok := apply(t, func(n Node) (Node, bool) {
+					return DockTile(n, anchor, direction, before, splitID, tileID, kind, params, session, ratio)
+				})
+				if !ok {
+					t.Fatalf("DockTile of %q against leaf %q, which is in the tree, was refused", tileID, anchor)
+				}
+				m.tree = next
+
+				// An empty session id carries the tile's existing binding
+				// forward, so moving a tile never silently unbinds it.
+				want := tileMeta{kind: strings.TrimSpace(kind), params: strings.TrimSpace(params), session: strings.TrimSpace(session)}
+				if want.session == "" {
+					if prev, ok := m.tiles[tileID]; ok {
+						want.session = prev.session
+					}
+				}
+				m.tiles[tileID] = want
+			},
+
+			// Drag a pane or tile somewhere else in the tree, including onto the
+			// workspace itself (an empty anchor), which re-roots the layout.
+			"move_leaf": func(t *rapid.T) {
+				leaves := m.leafIDs()
+				if len(leaves) < 2 {
+					t.Skip("a move needs something to move against")
+				}
+				leaf := rapid.SampledFrom(leaves).Draw(t, "leaf")
+				anchor := rapid.SampledFrom(append([]string{""}, leaves...)).Draw(t, "anchor")
+				splitID := m.mint("s")
+				direction := rapid.SampledFrom(directions).Draw(t, "direction")
+				before := rapid.Bool().Draw(t, "before")
+				ratio := drawRatio(t, "ratio")
+
+				next, ok := apply(t, func(n Node) (Node, bool) {
+					return MoveLeaf(n, leaf, anchor, splitID, direction, before, ratio)
+				})
+				if leaf == anchor {
+					if ok {
+						t.Fatalf("MoveLeaf dropped leaf %q on itself and reported a change", leaf)
+					}
+					t.Skip("dropping a leaf on itself is a no-op")
+				}
+				if !ok {
+					t.Fatalf("MoveLeaf of %q against %q, both in the tree, was refused", leaf, anchor)
+				}
+				m.tree = next
+			},
+
+			// Close a pane, or undock a tile. The last leaf is left alone: a
+			// layout with nothing in it is the workspace being torn down, which
+			// is the caller's decision and not this tree's state.
+			"remove_leaf": func(t *rapid.T) {
+				leaves := m.leafIDs()
+				if len(leaves) < 2 {
+					t.Skip("keeping the last leaf; an empty layout ends the workspace")
+				}
+				leaf := rapid.SampledFrom(leaves).Draw(t, "leaf")
+
+				next, ok := apply(t, func(n Node) (Node, bool) { return Remove(n, leaf) })
+				if !ok {
+					t.Fatalf("Remove of %q, which is in the tree, reported nothing removed", leaf)
+				}
+				m.tree = next
+				delete(m.panes, leaf)
+				delete(m.tiles, leaf)
+			},
+
+			// A tile consumer rebinds an open tile: the browser tile follows a
+			// navigation, a markdown tile follows the file it was opened from.
+			"update_tile": func(t *rapid.T) {
+				ids := m.tileIDs()
+				if len(ids) == 0 {
+					t.Skip("no tile to rebind yet")
+				}
+				tileID := rapid.SampledFrom(ids).Draw(t, "tile")
+				params := rapid.SampledFrom(tileParams).Draw(t, "params")
+				session := rapid.SampledFrom(tileSessions).Draw(t, "session")
+
+				// Not run through apply: these two write through their input.
+				// See TestLayoutOperationsDoNotModifyTheirInput.
+				next, ok := UpdateTileParams(m.tree, tileID, params)
+				if !ok {
+					t.Fatalf("UpdateTileParams on tile %q, which is in the tree, was refused", tileID)
+				}
+				m.tree = next
+
+				next, ok = UpdateTileSessionID(m.tree, tileID, session)
+				if !ok {
+					t.Fatalf("UpdateTileSessionID on tile %q, which is in the tree, was refused", tileID)
+				}
+				m.tree = next
+
+				meta := m.tiles[tileID]
+				meta.params = strings.TrimSpace(params)
+				meta.session = strings.TrimSpace(session)
+				m.tiles[tileID] = meta
+			},
+
+			// Drag a divider. The ratio is clamped so neither side collapses,
+			// and locked so normalization stops rebalancing that split.
+			"set_ratio": func(t *rapid.T) {
+				ids := splitIDs(m.tree)
+				if len(ids) == 0 {
+					t.Skip("no split to resize yet")
+				}
+				splitID := rapid.SampledFrom(ids).Draw(t, "split")
+				ratio := drawRatio(t, "ratio")
+
+				next, ok := apply(t, func(n Node) (Node, bool) { return SetSplitRatio(n, splitID, ratio) })
+				if !ok {
+					t.Fatalf("SetSplitRatio on split %q, which is in the tree, was refused", splitID)
+				}
+				m.tree = next
+
+				split, found := findSplit(m.tree, splitID)
+				if !found {
+					t.Fatalf("split %q disappeared from the tree when its ratio was set", splitID)
+				}
+				if !split.RatioLocked {
+					t.Fatalf("split %q was resized by hand but is not locked; normalization will rebalance it away", splitID)
+				}
+				if split.Ratio < 0.05 || split.Ratio > 0.95 {
+					t.Fatalf("split %q was set to %v, outside the collapse margin", splitID, split.Ratio)
+				}
+			},
+
+			// The daemon normalizes before persisting and after loading, so
+			// every tree above has to survive a round through it unchanged in
+			// content — and a second round unchanged in full.
+			"normalize": func(t *rapid.T) {
+				snapshot := WorkspaceLayout{
+					WorkspaceID:  "ws",
+					ActivePaneID: rapid.SampledFrom(append([]string{"", "gone"}, m.leafIDs()...)).Draw(t, "active"),
+					Layout:       m.tree,
+					Panes:        modelPanes(m),
+				}
+				normalized := NormalizeWorkspaceLayout(snapshot)
+				again := NormalizeWorkspaceLayout(normalized)
+				if !reflect.DeepEqual(normalized, again) {
+					t.Fatalf("normalization is not idempotent:\nonce: %+v\ntwice: %+v", normalized, again)
+				}
+
+				panes := PaneIDs(normalized.Layout)
+				if normalized.ActivePaneID == "" {
+					if len(panes) > 0 {
+						t.Fatalf("no active pane, but the layout holds %v", panes)
+					}
+				} else if !slices.Contains(panes, normalized.ActivePaneID) {
+					t.Fatalf("active pane %q is not in the layout %v", normalized.ActivePaneID, panes)
+				}
+				if len(normalized.Panes) != len(panes) {
+					t.Fatalf("layout holds %d panes but the record carries %d", len(panes), len(normalized.Panes))
+				}
+				m.tree = normalized.Layout
+			},
+
+			// Runs before and after every action above.
+			"": func(t *rapid.T) {
+				checkWellFormed(t, m.tree, "root")
+
+				panes := PaneIDs(m.tree)
+				tiles := TileIDs(m.tree)
+				seen := make(map[string]bool, len(panes)+len(tiles))
+				for _, id := range append(append([]string{}, panes...), tiles...) {
+					if seen[id] {
+						t.Fatalf("leaf %q appears twice in the tree; panes %v tiles %v", id, panes, tiles)
+					}
+					seen[id] = true
+				}
+
+				sort.Strings(panes)
+				sort.Strings(tiles)
+				if want := m.paneIDs(); !sameIDs(panes, want) {
+					t.Fatalf("tree holds panes %v, want %v", panes, want)
+				}
+				if want := m.tileIDs(); !sameIDs(tiles, want) {
+					t.Fatalf("tree holds tiles %v, want %v", tiles, want)
+				}
+
+				// A tile's kind, params and session survive every move: they are
+				// the tile's whole identity to the consumer that renders it.
+				for _, leaf := range TileLeaves(m.tree) {
+					want := m.tiles[leaf.TileID]
+					got := tileMeta{kind: leaf.TileKind, params: leaf.TileParams, session: leaf.TileSessionID}
+					if got != want {
+						t.Fatalf("tile %q carries %+v, want %+v", leaf.TileID, got, want)
+					}
+				}
+			},
+		})
+	})
+}
+
+// Every operation in this package takes a Node by value and returns a new one.
+// That is only true if the children slices are copied rather than written
+// through — a Node value shares its children's backing array with every copy of
+// itself, so writing into it reaches the caller's tree. Split, Remove,
+// SetSplitRatio, DockTile and MoveLeaf all copy before writing.
+// UpdateTileParams and UpdateTileSessionID do not: they assign into
+// node.Children[index] directly, so the layout the caller handed in comes back
+// changed.
+//
+// SKIPPED, and red. It is a real divergence from the rest of the package, but
+// no shipped call site reads its pre-update snapshot again — internal/daemon's
+// three callers (browser.go, workspacelayout.go, tilecontent.go) all use the
+// returned tree and drop the input — so this is a latent trap rather than a live
+// bug, and fixing it means changing production code, which this test-only change
+// deliberately does not do. Delete the Skip when the two functions copy their
+// children like their neighbours; the seed under testdata/rapid replays the
+// counterexample rapid shrank to.
+func TestLayoutOperationsDoNotModifyTheirInput(t *testing.T) {
+	t.Skip("UpdateTileParams/UpdateTileSessionID write through their input; see the comment above")
+
+	rapid.Check(t, func(t *rapid.T) {
+		tree, _ := DockTile(DefaultLayout("p0"), "p0", DirectionVertical, false, "s1",
+			"t1", string(TileKindMarkdown), "", "", DefaultSplitRatio)
+
+		params := rapid.SampledFrom(tileParams).Draw(t, "params")
+		session := rapid.SampledFrom(tileSessions).Draw(t, "session")
+
+		before := cloneNode(tree)
+		if _, ok := UpdateTileParams(tree, "t1", params); !ok {
+			t.Fatal("UpdateTileParams did not find the tile it was pointed at")
+		}
+		if !reflect.DeepEqual(tree, before) {
+			t.Fatalf("UpdateTileParams wrote through its input:\n got: %+v\nwant: %+v", tree, before)
+		}
+
+		before = cloneNode(tree)
+		if _, ok := UpdateTileSessionID(tree, "t1", session); !ok {
+			t.Fatal("UpdateTileSessionID did not find the tile it was pointed at")
+		}
+		if !reflect.DeepEqual(tree, before) {
+			t.Fatalf("UpdateTileSessionID wrote through its input:\n got: %+v\nwant: %+v", tree, before)
+		}
+	})
+}
+
+// modelPanes builds the pane records the daemon would have stored beside the
+// tree, so normalization has something to reconcile against.
+func modelPanes(m *layoutModel) []Pane {
+	panes := make([]Pane, 0, len(m.panes))
+	for _, id := range m.paneIDs() {
+		panes = append(panes, Pane{
+			PaneID:    id,
+			RuntimeID: "rt-" + id,
+			SessionID: "sess-" + id,
+			Kind:      PaneKindAgent,
+			Title:     DefaultPaneTitle,
+			Status:    PaneStatusReady,
+		})
+	}
+	return panes
+}
+
+// sameIDs compares two sorted id lists, treating a nil list and an empty one as
+// the same thing: a tree with no tiles reports nil, and the model reports empty.
+func sameIDs(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Applies the property-testing pattern the testing spike adopted (#799, and the
rule now written down in AGENTS.md § Testing tools) to three units chosen for
invariant density. Test-only: no production code changes. Example tests are
untouched everywhere — rapid explores, it does not document.

## The three properties

**1. `internal/pty` — chunk-boundary invariance.**
*Statement:* for any input stream, the emissions of `feedSegmenter.Feed` (and
the sequences `oscScanner.Feed` reports) are identical whether the input
arrives whole or cut at arbitrary offsets; and the chunked run's emissions plus
its held tail reconstruct the input byte for byte.

This is the invariant behind shipped bug #737. A PTY read returns whatever the
kernel had, so an escape routinely straddles a boundary, and the segmenter
*removes bytes from one side of the feed* on the strength of where it thinks a
sequence begins — a decision that changes with the boundary is a silent
divergence between the worker grid and the client grid.

`kittyseg_test.go` already sweeps every split point, byte-at-a-time and
cycling chunk sizes. What it sweeps is the inputs somebody wrote down. This
generates the inputs too, from a grammar of the fragments that make a boundary
interesting: a lone `ESC`, half a CSI, half a kitty introducer, an OSC 133
prefix that diverges on its last digit, an unterminated marker, an APC ended by
C1 ST or aborted by a control, multi-byte UTF-8 and orphaned continuation
bytes. There is no oracle — the whole-input run *is* the expected answer.

The OSC scanner property is bounded below `oscScanMaxPending` on purpose: past
that tripwire the scanner abandons what it holds, and where the abandon lands
genuinely does depend on the chunking. The test fails loudly if the fragment
pool ever grows past half the tripwire rather than silently skipping.

Go scanners only; ghostty/wasm untouched.

**2. `internal/docstore` — identifier safety.**
*Statement:* for any caller-controlled input, `Query.Compile` either refuses
with a typed `*InvalidQueryError`, or returns SQL in which every token is a
keyword, one of the store's own stamped columns, the minted table name, a `?`
placeholder, or a quoted `f_<declared field>` — plus one placeholder per arg,
and a limit inside `1..MaxLimit`.

This is the package's stated boundary ("every identifier the store executes is
derived from an integer or a validated field name — never from caller text").
The assertion is a grammar rather than a substring search, so there is nothing
to out-quote: the compiled `Where` and `Order` are tokenized and anything
outside the closed sets fails, whatever it happens to say. Hostile strings
(quotes, `--`, `/* */`, backticks, brackets, NUL, unicode, 300 bytes of `a`)
go into every position a caller controls — namespace, collection, table, field
names, operators, bounds, cursor id, limit — one at a time, so a refusal lands
in the code being tested rather than at the first check.

Two supporting properties: `quoteIdent` round-trips for arbitrary strings
(it is the one splice defended by quoting rather than validation), and
`TableName`/`FieldColumn` stay plain identifiers for any row id and any
validated name.

No database: `Compile` is pure, and this needed no `ScopeTestEnvironment`.

*A note on generator design.* The first version of this property was
**vacuous** — drawing uniformly from a hostile pool in six positions meant
essentially every query was refused at the first check, and three deliberate
mutations to `docstore.go` all went green. The fix is the draw-then-corrupt-one
structure, and the guard against a repeat is a coverage tripwire: the property
fails if fewer than one in five generated queries compiles, since everything it
asserts is downstream of a compile.

**3. `internal/workspacelayout` — tree invariants under random operations.**
*Statement:* after any sequence of `Split` / `DockTile` / `MoveLeaf` /
`Remove` / `SetSplitRatio` / `UpdateTile*` / `NormalizeWorkspaceLayout`, the
layout is a well-formed tree (every node a pane, tile or split; every split
exactly two children, a valid direction and a ratio strictly inside `(0,1)`),
holds exactly the leaves the model expects with no duplicates, and every tile
still carries the kind, params and session binding it was docked with.
Normalization is idempotent and always leaves a valid active pane.

Same shape as the rankkey stateful property, one level up: a shadow model of
the leaves, `t.Repeat` over the real operations, and the whole contract
re-checked after every single one.

## Finding: two operations write through the caller's layout

rapid turned up a real divergence, **left unfixed here** because this change is
test-only.

Every operation in `internal/workspacelayout` takes a `Node` by value and
returns a new one. A `Node` value shares its children's backing array with
every copy of itself, so that only holds if the children slices are copied
before being written. `Split`, `Remove`, `SetSplitRatio`, `DockTile` and
`MoveLeaf` all copy. `UpdateTileParams` and `UpdateTileSessionID` do not — they
assign into `node.Children[index]` directly, so the layout the caller handed in
comes back changed.

rapid shrank it to the minimal sequence: dock one tile, update its params.

```
[rapid] failed after 0 tests: the operation modified the layout it was given
[rapid] draw action: "dock_tile"
[rapid] draw action: "update_tile"
```

It is a latent trap rather than a live bug: `internal/daemon`'s three call
sites (`browser.go:249`, `workspacelayout.go:698`, `tilecontent.go:514`) all
use the returned tree and drop the input, so nothing shipped reads a stale
snapshot. But it is a difference between two functions and their five
neighbours that nothing was watching.

`TestLayoutOperationsDoNotModifyTheirInput` is that property, committed
**skipped** with the reason and a pointer to what fixing it means; the shrunk
counterexample is committed as a regression seed under
`internal/workspacelayout/testdata/rapid/`, so it replays the moment the skip
comes off. The stateful property routes those two operations around its
non-mutation check and says so.

## Every property is mutation-checked

A property that cannot fail is worse than no property. Each was verified
against deliberate breakages of the code under test, which were then reverted:

| target | mutation | caught |
| --- | --- | --- |
| pty | stop holding a partial kitty introducer at end-of-chunk | yes |
| pty | stop holding a marker split at the `ESC` of its `ST` | yes — shrank to `["…\x1b]133;B\x1b", "\\"]` |
| pty | drop the trailing lone-`ESC` hold in `oscScanner` | yes |
| pty | never carry `oscScanner` pending across a `Feed` | yes |
| docstore | emit the field column unquoted | yes |
| docstore | drop the minted-table check | yes |
| docstore | splice the filter bound instead of binding it | yes |
| layout | a removed leaf's split does not collapse | yes |
| layout | re-docking a tile duplicates it | yes |

## Cost

100 checks per property, measured as rapid's own reported check time:

| property | check time |
| --- | --- |
| `TestFeedSegmenterIsChunkBoundaryInvariant` | 0.47 ms |
| `TestOSCScannerIsChunkBoundaryInvariant` | 0.19 ms |
| `TestCompiledSQLIsBuiltOnlyFromDerivedIdentifiers` | 0.56 ms |
| `TestQuotingAnIdentifierRoundTrips` | 0.08 ms |
| `TestPhysicalNamesStayPlainIdentifiers` | 0.20 ms |
| `TestLayoutStaysAWellFormedTreeUnderRandomOperations` | 15.1 ms |

Added wall-clock per package run: ~0.7 ms (`internal/pty`, against a ~10 s
package), ~0.8 ms (`internal/docstore`), ~15 ms (`internal/workspacelayout`).
All well inside the ~100 ms budget; the package-level deltas are below this
machine's run-to-run noise.

Confidence on demand, all clean: `-rapid.checks=200000` passes in 355 ms / 190 ms
(pty), 530 ms / 137 ms / 272 ms (docstore); `-rapid.checks=50000` passes in 4.5 s
(layout). Only the layout write-through defect surfaced at any check count.

## Surfaces

- **Tests only.** No production code, no protocol, no CLI, no app, no
  generated types. `go vet ./...` clean.
- **Test safety.** None of the three packages resolves config paths, so no
  `TestMain`/`ScopeTestEnvironment` was needed; the docstore property
  deliberately needs no DB handle.
- **Shared helper.** `runKittySegmenter`/`feedKitty` in `kittyseg_test.go` now
  take a small `segTB` interface instead of `*testing.T`, so the same runner
  drives both the existing battery and the property. `testing.TB` cannot be
  implemented outside the testing package and `*rapid.T` does not satisfy it.
- **Docs.** Changelog fragment added. AGENTS.md already carries the rule this
  follows (§ Testing tools, #802) — nothing to add.

## Nothing was dropped

All three targets had a clean seam. One property was dropped during
development: a marker-meaning-across-chunks check, which turned out to be
strictly subsumed — a marker's meaning is a pure function of the bytes the
segmenter emits, so it cannot fail unless the segmenter property already has.
