### PR TITLE
docs(agents): how changes ship — standing merge gate, hold list, testing moments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,10 +232,62 @@ Three adopted patterns; full receipts in
   `internal/daemon`). Anything a fake or direct channel write can express
   does not — it costs real seconds.
 
+## How changes ship
+
+The flow is sized by judgment, not a rulebook. When in doubt about which shape
+applies, ask Victor once at kickoff, not mid-flight.
+
+- **Plan docs are the norm.** Non-trivial work gets a plan doc first — often
+  written by the same agent that then implements it in the same session. Only a
+  genuinely small change goes straight to a PR with no plan.
+- **A plan lands as one or several PRs.** When the work changes existing
+  behavior, slice PRs target an `epic/*` branch and the epic gets a whole-review
+  pass when it merges to main. When the work builds a new subsystem that cannot
+  break existing experience, slices may merge directly to main as they land.
+  That criterion — can this slice damage what already works? — decides the
+  shape, not the size of the plan.
+- **A spike answers a question.** It usually does not merge, but that is not a
+  hard rule. The constant: Victor decides what happens after a spike — merging
+  it, discarding it, or building on its conclusion.
+
+### Merging
+
+The standing gate for every PR: figgyster approved on the current head, CI
+green, zero unresolved threads. When it passes, merge — no per-PR authorization
+from Victor needed.
+
+Hold for Victor's explicit go-ahead only for:
+
+- merging an epic branch to main;
+- moving on from a spike;
+- changes that irreversibly destroy or convert existing user state;
+- one-way doors — a way in shipped without its way out;
+- production installs and releases (already covered above).
+
+### Victor's testing
+
+Victor validates **experience**; the harness and figgyster own correctness. His
+pass happens at two moments: very early on spikes (does the idea feel right?)
+and at the end of a substantial series (does the whole feel right?). It is
+never per-PR QA — do not queue an approved PR on his testing.
+
+When a series reaches his checkpoint, stage it: a running profile installed
+from the branch, realistic state, and a short what-to-try list keyed to what
+changed and what you could not judge yourself — feel, latency, keyboard flow.
+His session should be minutes of directed play, not setup.
+
+### Routine mechanics
+
+Protocol version bumps and DB migrations are day-to-day work; their checklists
+are in this file. Do them, verify them, and do not present them as risks,
+blockers, or reasons to pause. Escalate by the hold list above — irreversible
+user-state loss, one-way doors, production lifecycle — never by category.
+
 ## Pull requests
 
-PR policy — ready-for-review, rebase onto main first, who approves — comes from
-the global guide. What is attn-specific is how you wait on one.
+Ready-for-review (not draft) and rebase onto main first, per the global guide;
+merging is governed by "How changes ship" above. What is attn-specific is how
+you wait on one.
 
 To wait on a GitHub PR, run `attn pr wait-ready <pr> --repo <owner/repo>
 --reviewer <login>` once; do not poll checks, reviews, and comments separately.

--- a/changelog.d/zesty-moose-how-changes-ship.yaml
+++ b/changelog.d/zesty-moose-how-changes-ship.yaml
@@ -1,0 +1,10 @@
+kind: internal
+area: docs
+change: >
+  AGENTS.md gains a "How changes ship" section: standing merge-on-approval
+  gate with an explicit hold-for-Victor list (epic-to-main merges, moving on
+  from spikes, irreversible user-state changes, one-way doors, production
+  lifecycle), the epic-branch vs direct-to-main criterion, Victor's two
+  experience-testing moments with a staged-checkpoint convention, and
+  protocol bumps / DB migrations named as routine mechanics rather than
+  risks to escalate.


### PR DESCRIPTION
## What

Adds a "How changes ship" section to AGENTS.md, codifying the development flow that until now lived in Victor's head and per-conversation authorizations:

- **Flow shape by judgment**: plan docs as the norm (often same agent plans then implements; only genuinely small changes skip), and the epic-branch vs direct-to-main criterion — can this slice damage what already works? New subsystems may slice straight to main; changes to existing behavior go through `epic/*` with a whole-review at epic→main.
- **Standing merge gate**: figgyster approved on head + CI green + zero unresolved threads = merge, no per-PR authorization. An explicit hold-for-Victor list: epic→main merges, moving on from spikes, irreversible user-state changes, one-way doors, production lifecycle.
- **Victor's testing = experience validation** at two moments (early on spikes, end of a substantial series), never per-PR QA — with a staged-checkpoint convention: agents hand over a running profile from the branch, realistic state, and a what-to-try list keyed to what they couldn't judge themselves.
- **Routine mechanics**: protocol version bumps and DB migrations are day-to-day work; escalate by the hold-list predicate, never by category.

Also reworded the "Pull requests" opener so merging policy points at the new section instead of deferring wholly to the global guide.

## Why

Agents kept re-deriving the flow: over-flagging migrations and protocol bumps as blockers, queuing approved small PRs on Victor's testing, and asking for merge authorization per conversation. Writing the policy down — including exactly what *does* need Victor's go-ahead — removes that friction without loosening any real gate.

## Verification

Docs-only change; `go run ./cmd/changelog-check` passes for the fragment.

https://claude.ai/code/session_01J8BCiySYrXwydW5J2P38qs