### PR TITLE
feat(annotations): 👍 I agree, and labels that stop talking for the user

### DIFF
--- a/app/src/annotations/quickLabels.test.ts
+++ b/app/src/annotations/quickLabels.test.ts
@@ -3,16 +3,12 @@ import {
   LABEL_COLOR_MAP,
   QUICK_LABELS,
   QUICK_LABEL_GROUPS,
-  RETIRED_LABELS,
   labelById,
   labelByEmoji,
 } from './quickLabels';
 
 describe('the shared label set', () => {
   it('is one set, drawn from by both annotation surfaces', async () => {
-    // Terminal marks and document marks resolve the same labels. Two sets is
-    // what this replaced, and an import that quietly forks one back is the way
-    // it would come back.
     const terminal = await import('../components/TerminalAnnotations/quickLabels');
     const markdown = await import('../components/MarkdownReader/annotations/quickLabels');
 
@@ -27,71 +23,18 @@ describe('the shared label set', () => {
   });
 
   it('gives every label a color the reader can actually draw', () => {
-    // The terminal row is emoji-only, so a label added there is easy to ship
-    // with a color the map has never heard of — and the Markdown chip then
-    // renders unstyled, in the other surface, where nobody was looking.
-    for (const label of [...QUICK_LABELS, ...RETIRED_LABELS]) {
+    for (const label of QUICK_LABELS) {
       expect(LABEL_COLOR_MAP[label.color], label.id).toBeDefined();
     }
   });
 });
 
-// Retiring a label leaves its id on documents and its emoji on terminal marks
-// already saved. Reusing either would relabel them into something the user
-// never said, so a retired identity is retired for good — RETIRED_LABELS is the
-// list, and it only ever grows.
-describe('retired labels', () => {
-  it('never come back on a different label', () => {
-    const liveIds = new Set(QUICK_LABELS.map((label) => label.id));
-    const liveEmoji = new Set(QUICK_LABELS.map((label) => label.emoji));
-
-    expect(RETIRED_LABELS.filter((label) => liveIds.has(label.id))).toEqual([]);
-    expect(RETIRED_LABELS.filter((label) => liveEmoji.has(label.emoji))).toEqual([]);
-  });
-
-  it('covers everything the two sets used to offer', () => {
-    const known = new Set([...QUICK_LABELS, ...RETIRED_LABELS].map((label) => label.id));
-    const shipped = [
-      'clarify-this',
-      'missing-overview',
-      'verify-this',
-      'give-me-an-example',
-      'match-existing-patterns',
-      'consider-alternatives',
-      'ensure-no-regression',
-      'out-of-scope',
-      'needs-tests',
-      'nice-approach',
-      'thumbs-up',
-    ];
-
-    expect(shipped.filter((id) => !known.has(id))).toEqual([]);
-  });
-
-  it('still resolve by id, so an old mark renders as what it said', () => {
-    // A withdrawn label that stops resolving does not disappear from a
-    // document — it renders as the raw id, which is the user's own feedback
-    // turned into debug output.
-    expect(labelById('needs-tests')?.text).toBe('Needs tests');
-    expect(labelById('exactly-this')?.text).toBe('Exactly this');
-    expect(labelById('never-existed')).toBeUndefined();
-  });
-
-  it('still resolve by emoji, which is all a terminal mark stores', () => {
-    // A terminal mark persists nothing but the emoji, and drafts outlive the
-    // upgrade that retired a label. Without this, a mark saved as 🧪 comes back
-    // headed "🧪 Comment" with its instruction dropped — the user's own label
-    // turned into an unlabelled one.
-    expect(labelByEmoji('🧪')?.text).toBe('Needs tests');
-    expect(labelByEmoji('🚫')?.text).toBe('Out of scope');
+describe('label lookups', () => {
+  it('resolve a mark back to the label it was made with', () => {
     expect(labelByEmoji('💯')?.id).toBe('exactly-this');
+    expect(labelByEmoji('👍')?.id).toBe('i-agree');
+    expect(labelById('verify-this')?.text).toBe('Verify this');
     expect(labelByEmoji('🦄')).toBeUndefined();
-  });
-
-  it('answer the one ambiguous emoji with the label the picker offered', () => {
-    // 'nice-approach' and 'thumbs-up' both wore 👍. It was never a terminal
-    // emoji, so nothing on disk depends on the answer — but the lookup must
-    // still give one rather than depend on array order by accident.
-    expect(labelByEmoji('👍')?.id).toBe('nice-approach');
+    expect(labelById('never-existed')).toBeUndefined();
   });
 });

--- a/app/src/annotations/quickLabels.ts
+++ b/app/src/annotations/quickLabels.ts
@@ -1,27 +1,14 @@
-// The one label set. Both annotation surfaces draw from it: marks on an
-// agent's terminal output (`components/TerminalAnnotations`) and marks on a
-// document in the Markdown reader (`components/MarkdownReader/annotations`).
-//
-// They were two sets, and the difference was an accident of where each came
-// from rather than a claim that a plan deserves different vocabulary than a
-// message. One set means a label learned in one surface means the same thing in
-// the other, and a new label lands in both at once.
-//
-// A label is a one-click way to say a thing users otherwise retype every turn.
-// Its `tip` is the instruction the agent actually receives; the `text` is what
-// the user sees. Keeping the two separate is what lets the chip stay short
-// ("Verify this") while the agent gets the sentence that makes it actionable.
+// The labels offered by both annotation surfaces: marks on an agent's terminal
+// output (`components/TerminalAnnotations`) and marks on a document in the
+// Markdown reader (`components/MarkdownReader/annotations`).
 
 export interface QuickLabel {
   id: string;
   emoji: string;
   text: string;
-  // Key into LABEL_COLOR_MAP. Only the Markdown reader draws colored chips; the
-  // terminal row is emoji-only. It is required anyway so a label added for one
-  // surface is never half-dressed in the other.
+  // Key into LABEL_COLOR_MAP.
   color: string;
-  // The instruction sent to the agent. Absent when the label's own name says
-  // everything ("Clarify this").
+  // Sent to the agent under the label.
   tip?: string;
 }
 
@@ -39,55 +26,16 @@ export const LABEL_COLOR_MAP: Record<string, { bg: string; text: string; darkTex
   amber: { bg: 'rgba(180,83,9,0.15)', text: '#b45309', darkText: '#fbbf24' },
 };
 
-// The label row, in the groups it is drawn in. A group is what a divider
-// separates, so the grouping lives here as data rather than as an index the
-// popup counts to — reordering a label cannot silently move the divider. The
-// Markdown reader draws the same labels as one vertical list and ignores the
-// grouping.
-//
-// Every label here reacts to a *claim in a span of text*, because that is what
-// a highlight selects — in a message or in a plan alike. Labels about the work
-// rather than the words ("needs tests", "out of scope") had nothing to attach
-// to and were never used; they are in RETIRED_LABELS.
-//
-// An id and an emoji are both identities: a terminal mark stores the emoji and
-// resolves its payload from it, a document mark stores the id. Neither is ever
-// reused for a different label — that would silently relabel marks already on
-// disk into something the user never said. Retire, never recycle.
+// The label row. A group is what the terminal picker draws a divider between;
+// the Markdown reader draws one flat list.
 export const QUICK_LABEL_GROUPS: QuickLabel[][] = [
   [
-    // Its tip is the longest here on purpose: "good" alone tells an agent
-    // nothing to do, and the point of marking a thing right is that it
-    // survives the next revision.
-    {
-      id: 'exactly-this',
-      emoji: '💯',
-      text: 'Exactly this',
-      color: 'green',
-      tip: 'This is right and it matters. Preserve this decision and the reasoning behind it — do not revisit or trade it away, and apply the same reasoning where it belongs elsewhere.',
-    },
+    { id: 'i-agree', emoji: '👍', text: 'I agree', color: 'green' },
+    { id: 'exactly-this', emoji: '💯', text: 'Exactly this', color: 'green' },
   ],
   [
-    // The other end of the same axis. It has to travel the way agreement does:
-    // a wrong claim is rarely wrong only where it was written.
-    {
-      id: 'this-is-wrong',
-      emoji: '❌',
-      text: 'This is wrong',
-      color: 'red',
-      tip: 'This is wrong. Correct it before going further, and check what else you built on it — anything downstream of this claim is suspect too.',
-    },
-    // Doubt with nothing articulate behind it yet. Without this the only way to
-    // say it is to argue a case the user has not made, so it arrives as silence
-    // or as a rewrite. "Do not defend it" is the load-bearing half of the tip:
-    // the reflex it exists to stop is a rebuttal.
-    {
-      id: 'dont-love-this',
-      emoji: '😕',
-      text: "I don't love this",
-      color: 'orange',
-      tip: 'Something here is off. Do not defend it — rework this part. If you cannot see what is wrong with it, say what you think I am reacting to and ask.',
-    },
+    { id: 'this-is-wrong', emoji: '❌', text: 'This is wrong', color: 'red' },
+    { id: 'dont-love-this', emoji: '😕', text: "I don't love this", color: 'orange' },
   ],
   [
     { id: 'clarify-this', emoji: '❓', text: 'Clarify this', color: 'yellow' },
@@ -98,9 +46,6 @@ export const QUICK_LABEL_GROUPS: QuickLabel[][] = [
       color: 'blue',
       tip: 'This seems like an assumption. Verify by reading the actual code before proceeding.',
     },
-    // Verify is "go and check". This is "you already claimed it — show your
-    // work". It catches the failure the others cannot: confident prose written
-    // over a guess, which reads exactly like prose written over a measurement.
     {
       id: 'show-the-receipt',
       emoji: '🧾',
@@ -124,85 +69,22 @@ export const QUICK_LABEL_GROUPS: QuickLabel[][] = [
     },
   ],
   [
-    // Aimed at the writing. "Be concise" as a standing instruction teaches
-    // nothing; a mark on the paragraph that was padding teaches the register.
-    {
-      id: 'cut-this',
-      emoji: '✂️',
-      text: 'Cut this',
-      color: 'amber',
-      tip: 'This is padding. Say what it says in a fraction of the words, or drop it — do not restate it more carefully.',
-    },
-    // Aimed at the proposal.
-    {
-      id: 'simplify-this',
-      emoji: '🪓',
-      text: 'Simplify this',
-      color: 'purple',
-      tip: 'This is more machinery than the problem needs. Find the version with fewer moving parts, even if that means throwing this away.',
-    },
+    { id: 'cut-this', emoji: '✂️', text: 'Cut this', color: 'amber' },
+    { id: 'simplify-this', emoji: '🪓', text: 'Simplify this', color: 'purple' },
   ],
   [
-    // The two halves of getting the asking wrong, marked on the question or the
-    // decision itself rather than delivered as a note about behaviour.
-    {
-      id: 'your-call',
-      emoji: '🪙',
-      text: 'Your call',
-      color: 'green',
-      tip: 'You did not need me for this. Decide it yourself and keep going — ask only when the choice is genuinely mine to make.',
-    },
-    {
-      id: 'ask-me-first',
-      emoji: '🙋',
-      text: 'Ask me first',
-      color: 'yellow',
-      tip: 'You should have asked before deciding this. Stop and ask rather than picking for me.',
-    },
+    { id: 'your-call', emoji: '🪙', text: 'Your call', color: 'green' },
+    { id: 'ask-me-first', emoji: '🙋', text: 'Ask me first', color: 'yellow' },
   ],
 ];
 
-// Every label, in row order. What a payload resolves against; the grouping
-// above is only how the terminal row is drawn.
+// Every label, in row order.
 export const QUICK_LABELS: QuickLabel[] = QUICK_LABEL_GROUPS.flat();
 
-// Labels no longer offered, kept so marks that already carry them still render
-// as what the user said rather than as a raw id. Nothing adds to this except
-// retirement, and nothing is ever removed from it.
-//
-// The first five were the Markdown reader's own: they are about the work rather
-// than the words, and a highlight has nothing to attach them to. 'nice-approach'
-// and 'thumbs-up' are what 💯 Exactly this replaced — same act, and now one
-// label with an instruction behind it instead of two without.
-export const RETIRED_LABELS: QuickLabel[] = [
-  { id: 'missing-overview', emoji: '🗺️', text: 'Missing overview', color: 'purple' },
-  { id: 'match-existing-patterns', emoji: '🧬', text: 'Match existing patterns', color: 'teal' },
-  { id: 'ensure-no-regression', emoji: '📉', text: 'Ensure no regression', color: 'amber' },
-  { id: 'out-of-scope', emoji: '🚫', text: 'Out of scope', color: 'red' },
-  { id: 'needs-tests', emoji: '🧪', text: 'Needs tests', color: 'blue' },
-  { id: 'nice-approach', emoji: '👍', text: 'Nice approach', color: 'green' },
-  { id: 'thumbs-up', emoji: '👍', text: 'Looks good', color: 'green' },
-];
-
-/**
- * Resolves a label by the emoji a terminal mark carries, retired ones included.
- * A terminal mark stores nothing but the emoji, and drafts outlive an upgrade:
- * a mark made with a label that has since been withdrawn still has to render
- * as what the user said and still has to carry its instruction when sent.
- *
- * 👍 is the one ambiguity — two retired labels wore it — and it resolves to the
- * first, which is the one the picker offered. It was never a terminal emoji.
- */
 export function labelByEmoji(emoji: string): QuickLabel | undefined {
-  return QUICK_LABELS.find((label) => label.emoji === emoji)
-    ?? RETIRED_LABELS.find((label) => label.emoji === emoji);
+  return QUICK_LABELS.find((label) => label.emoji === emoji);
 }
 
-/**
- * Resolves a label by the id a document mark carries, retired ones included —
- * this is a display lookup, and an old mark deserves its name back.
- */
 export function labelById(id: string): QuickLabel | undefined {
-  return QUICK_LABELS.find((label) => label.id === id)
-    ?? RETIRED_LABELS.find((label) => label.id === id);
+  return QUICK_LABELS.find((label) => label.id === id);
 }

--- a/app/src/components/MarkdownReader/annotations/SelectionToolbar.test.tsx
+++ b/app/src/components/MarkdownReader/annotations/SelectionToolbar.test.tsx
@@ -83,13 +83,10 @@ describe('SelectionToolbar', () => {
   });
 
   it('the one-click agreement button applies a label from the shared set (E7)', () => {
-    // It used to send its own instruction-less 'thumbs-up' label, so agreeing
-    // in one click and agreeing from the picker said different things to the
-    // agent. Now it is the picker's own agreement label, tip and all.
     const { props } = renderToolbar();
     fireEvent.click(screen.getByTitle(THUMBS_UP_LABEL.text));
     expect(props.onQuickLabel).toHaveBeenCalledWith(THUMBS_UP_LABEL);
-    expect(THUMBS_UP_LABEL.tip).toBeTruthy();
+    expect(THUMBS_UP_LABEL.emoji).toBe('👍');
     expect(QUICK_LABELS).toContain(THUMBS_UP_LABEL);
   });
 

--- a/app/src/components/MarkdownReader/annotations/quickLabels.ts
+++ b/app/src/components/MarkdownReader/annotations/quickLabels.ts
@@ -1,34 +1,17 @@
-/**
- * Quick labels for document annotations.
- *
- * The set is shared with terminal annotations — see
- * `src/annotations/quickLabels.ts`. A label means the same thing whether it
- * lands on a plan or on an agent's message, so there is one set and this module
- * only adapts it to what the reader needs.
- *
- * Annotations reference labels structurally (`quickLabelId` + a snapshotted
- * `quickLabelTip`), never by baking "emoji text" into the comment text. Display
- * resolves the id through `quickLabelById`, which knows retired labels too, so
- * a mark made before a label was withdrawn still renders as what it said.
- */
+// The shared label set (`src/annotations/quickLabels.ts`), adapted to what the
+// Markdown reader needs. A document mark stores `quickLabelId` and the tip it
+// was made with, never the label's text baked into the comment.
 
 import { QUICK_LABELS, labelById, type QuickLabel } from '../../../annotations/quickLabels';
 
 export { LABEL_COLOR_MAP, QUICK_LABELS, type QuickLabel } from '../../../annotations/quickLabels';
 
-/**
- * The fixed toolbar 👍 button. It applies the same "this is right" label the
- * picker offers — a one-click agreement that sent a different, instruction-less
- * label than the list's was the same act saying two different things.
- */
-const AGREEMENT_LABEL_ID = 'exactly-this';
+// What the toolbar's fixed 👍 button applies.
+const AGREEMENT_LABEL_ID = 'i-agree';
 
 export const THUMBS_UP_LABEL: QuickLabel = (() => {
   const label = QUICK_LABELS.find((candidate) => candidate.id === AGREEMENT_LABEL_ID);
   if (!label) {
-    // Retiring this id without repointing the button would otherwise leave an
-    // undefined here and break the toolbar on render, a long way from the edit
-    // that caused it.
     throw new Error(
       `The one-click agreement button points at quick label "${AGREEMENT_LABEL_ID}", which the shared set no longer offers. `
       + `Point it at one of: ${QUICK_LABELS.map((candidate) => candidate.id).join(', ')}.`,

--- a/app/src/components/TerminalAnnotations/quickLabels.payload.test.ts
+++ b/app/src/components/TerminalAnnotations/quickLabels.payload.test.ts
@@ -3,14 +3,9 @@ import { QUICK_LABELS, QUICK_LABEL_GROUPS, buildAnnotationPayload } from './quic
 
 describe('QUICK_LABEL_GROUPS', () => {
   it('keeps agreement in its own group, ahead of everything that asks for a change', () => {
-    // A reviewer who cannot cheaply say "this part is right" files only
-    // objections. Ninth in a run of corrections, the one positive mark reads as
-    // one more complaint — the group is what a divider draws between.
-    expect(QUICK_LABEL_GROUPS[0].map((label) => label.id)).toEqual(['exactly-this']);
+    expect(QUICK_LABEL_GROUPS[0].map((label) => label.id)).toEqual(['i-agree', 'exactly-this']);
     expect(QUICK_LABEL_GROUPS.length).toBeGreaterThan(1);
-    expect(QUICK_LABELS[0].emoji).toBe('💯');
-    // Its opposite leads the next group rather than sharing the first: the two
-    // verdicts are a pair, and a divider is what says they are not the same act.
+    expect(QUICK_LABELS[0].emoji).toBe('👍');
     expect(QUICK_LABEL_GROUPS[1][0].id).toBe('this-is-wrong');
   });
 
@@ -63,15 +58,13 @@ describe('buildAnnotationPayload', () => {
     expect(payload).toContain('this contradicts the paragraph above');
   });
 
-  it('tells the agent what to do with agreement, not just that it got one', () => {
-    // "💯" alone is a pat on the head. What makes marking a thing right worth
-    // the click is that the agent is told to keep it through the next revision.
+  it('sends agreement as the label alone', () => {
     const payload = buildAnnotationPayload([
       { start: 0, emoji: '💯', comment: '', quote: 'the retry only fires on idempotent verbs' },
     ]);
 
     expect(payload).toContain('💯 Exactly this');
-    expect(payload).toContain('Preserve this decision');
+    expect(payload).not.toContain('Preserve this decision');
   });
 
   it('says what the payload is without instructing the agent how to behave', () => {
@@ -118,6 +111,3 @@ describe('buildAnnotationPayload', () => {
     });
   });
 });
-
-// Retired emoji are guarded where the set itself lives:
-// `src/annotations/quickLabels.test.ts`.

--- a/changelog.d/grumpy-newt-annotation-labels.yaml
+++ b/changelog.d/grumpy-newt-annotation-labels.yaml
@@ -5,10 +5,9 @@ change: >
   work. "Match existing patterns", "Ensure no regression", "Out of scope" and
   "Needs tests" are gone — a highlight selects a claim in a sentence, and those
   are about the work, so there was nothing for them to attach to. In their place:
-  "This is wrong", the missing opposite of "Exactly this", which tells the agent
-  to check what else it built on the claim; "I don't love this", for doubt you
-  cannot yet articulate, which tells it to rework rather than argue back; "Show
-  the receipt", for a fact asserted without one; "Cut this" for padding;
+  "This is wrong", the missing opposite of "Exactly this"; "I don't love this",
+  for doubt you cannot yet articulate; "Show the receipt", for a fact asserted
+  without one; "Cut this" for padding;
   "Simplify this" for more machinery than the problem needs; and "Your call" /
   "Ask me first" for the two ways of getting the asking wrong. A line under the
   row now names the label you are pointing at, and names the mark already on an

--- a/changelog.d/jaunty-narwhal-annotation-labels-say-less.yaml
+++ b/changelog.d/jaunty-narwhal-annotation-labels-say-less.yaml
@@ -1,0 +1,11 @@
+kind: changed
+area: terminal
+change: >
+  New annotation label: 👍 "I agree", the everyday version of 💯 "Exactly this",
+  so ordinary agreement no longer has to arrive emphatic. It leads the label row
+  and is what the toolbar's one-click 👍 button sends. Most labels also stop
+  carrying a paragraph of instruction to the agent alongside the mark — the
+  label alone is now the whole message for agreement, "This is wrong", "I don't
+  love this", "Cut this", "Simplify this", "Your call" and "Ask me first". The
+  four that ask for concrete work — "Verify this", "Show the receipt", "Give me
+  an example", "Consider alternatives" — keep theirs.

--- a/changelog.d/jolly-walrus-annotation-agreement-and-refusals.yaml
+++ b/changelog.d/jolly-walrus-annotation-agreement-and-refusals.yaml
@@ -1,11 +1,10 @@
 kind: changed
 area: terminal
 change: >
-  Terminal annotations can now say a thing is right. 💯 "Exactly this" leads the
-  label row, held apart from the seven labels that ask for a change, and tells
-  the agent to preserve the decision and the reasoning behind it rather than
-  revisit it on the next pass. Until now every label was a correction, so the
-  only feedback the surface could carry was an objection. The feedback message
+  Terminal annotations can now say a thing is right. Agreement leads the label
+  row, held apart from the labels that ask for a change. Until now every label
+  was a correction, so the only feedback the surface could carry was an
+  objection. The feedback message
   also stops opening with "Address each annotation" — the annotations are the
   instruction.
 notes: >


### PR DESCRIPTION
## What

Two changes to the annotation label set shared by the terminal annotator and the Markdown reader.

**New label: 👍 "I agree".** The everyday agreement, beside 💯 "Exactly this" for the thing worth defending later. One label for both made every agreement read as emphatic. 👍 leads the row and is what the Markdown toolbar's fixed one-click 👍 button applies — it was pointing at 💯 only because no plain-agreement label existed.

**Most labels stop carrying an instruction.** A label could ship a `tip`, a sentence sent to the agent under the mark. "Exactly this" told it to preserve the decision and apply the reasoning elsewhere; "This is wrong" told it to audit everything downstream. Those sentences put words in the user's mouth — the user clicked a chip, they did not say that. The label alone is now the whole message for 👍 I agree, 💯 Exactly this, ❌ This is wrong, 😕 I don't love this, ✂️ Cut this, 🪓 Simplify this, 🪙 Your call and 🙋 Ask me first.

The four that ask for concrete work keep theirs, because there the sentence is the point: 🔍 Verify this, 🧾 Show the receipt, 🔬 Give me an example, 🔄 Consider alternatives.

## Removed: the retired-label registry

`RETIRED_LABELS` kept every withdrawn id and emoji resolvable forever, with a guard test forbidding reuse of either, so a mark made before a label was withdrawn still rendered and sent as what the user said.

It was insuring a draft carried across an upgrade. That is not how anyone annotates — a mark is made and sent within a turn, so the window it protected is the minutes between highlighting a sentence and hitting send. Gone with it: both lookup fallbacks, the never-recycle rule, and its test. `labelByEmoji`/`labelById` are now one-line searches of the live set, and the label row can be edited freely.

Net: 239 lines deleted, 34 added. Most of the rest is comments — per-label rationale and guidance about what was safe to change, which the data now says by itself.

## Verification

`make dev` install, dev-profile preflight all PASS (protocol 217 CLI/app/daemon).

`real-app:scenario-terminal-annotations` against the packaged dev app, exit 0, 31/31 assertions — twice: once as shipped (🧾 Show the receipt, which keeps its tip), and once with the scenario pointed at the new label, which is the live witness that 👍 renders, is clickable, files with the right emoji, round-trips through the daemon, and reaches the agent. The payload that arrived:

```
Feedback on your last message.

## 1. 👍 I agree

> saw a failure: timeouts,
```

No instruction line under it. The scenario edit was reverted; it is not in this diff.

Frontend suite green (2573 passed), typecheck clean, `changelog-check` clean.

## Changelog

One new fragment. Two existing unreleased fragments described the tips as a feature and 💯 as leading the row, so they were folded to the end state — otherwise the compiled notes would add instructions and remove them in the same version.

https://claude.ai/code/session_01JJ3CZuoPhJdmGpMeiu2byc