### PR TITLE
docs(agents): when in doubt, ask — drop the timing clause

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,7 +235,7 @@ Three adopted patterns; full receipts in
 ## How changes ship
 
 How much process a change gets is a judgment call, not a rulebook. When in
-doubt, ask the maintainer once before starting, not halfway through.
+doubt, ask the maintainer.
 
 - **Plan docs are the norm.** Non-trivial work gets a plan doc first — often
   written by the same agent that then implements it in the same session. Only a

--- a/changelog.d/agents-guide-ask-when-in-doubt.yaml
+++ b/changelog.d/agents-guide-ask-when-in-doubt.yaml
@@ -1,0 +1,7 @@
+kind: internal
+area: docs
+change: >
+  The "How changes ship" opener in AGENTS.md drops "once before starting,
+  not halfway through" — it read as discouraging a mid-work question, and
+  doubt discovered mid-work is exactly when to ask. Now simply "When in
+  doubt, ask the maintainer."


### PR DESCRIPTION
## What

One line in AGENTS.md's "How changes ship" opener: "When in doubt, ask the maintainer once before starting, not halfway through" becomes "When in doubt, ask the maintainer."

## Why

The timing clause conflated two things: "don't defer a doubt you already have" (right) and "don't ask late" (wrong). Doubt that only appears mid-work — the change turns out riskier than it looked, an existing behavior lands in the blast radius — is exactly when an agent should stop and ask. Saying less removes the misreading; you ask when the doubt exists.

## Verification

Docs-only change; `go run ./cmd/changelog-check` passes for the fragment.

https://claude.ai/code/session_01J8BCiySYrXwydW5J2P38qs