### PR TITLE
test(synctest): triage the paced test suite and convert the bubble-able half

### DIFF
--- a/changelog.d/synctest-triage-and-sweep.yaml
+++ b/changelog.d/synctest-triage-and-sweep.yaml
@@ -1,0 +1,11 @@
+kind: internal
+area: testing
+change: >
+  Time-paced tests across the daemon, job queue, workflow engine and pty
+  worker now run inside `testing/synctest` bubbles, so they execute the
+  shipped schedules — a 12-hour orphan TTL, a 30-second git-status safety
+  interval, the real auto-settle and nudge windows — instead of turned-down
+  stand-ins, and their negative assertions hold against a settled system
+  rather than a tolerance window. Retires the load-sensitive cron-arming
+  flake. The triage map behind the sweep, including what cannot be bubbled
+  and why, is in docs/plans/2026-08-09-testing-adoption-wave.md.

--- a/docs/plans/2026-08-09-testing-adoption-wave.md
+++ b/docs/plans/2026-08-09-testing-adoption-wave.md
@@ -76,15 +76,15 @@ and everything touching a real PTY. Real processes and fds cannot be bubbled.
 
 So the work is triage first, convert second:
 
-- [ ] Triage: for each package above, classify each sleep/poll-paced test as
+- [x] Triage: for each package above, classify each sleep/poll-paced test as
       *bubble-able* (pure logic + store + fake time) or *boundary-bound*
       (real socket/PTY/process). Record the split in this plan — that map is
-      a deliverable, not overhead.
-- [ ] Convert the bubble-able ones: remaining `internal/jobs` tests,
+      a deliverable, not overhead. See "Track B2 triage map" below.
+- [x] Convert the bubble-able ones: remaining `internal/jobs` tests,
       `internal/workflow` (loop/cancel/engine pacing), and the daemon tests
       that are store+logic only (candidates: dwell, countdown, retention,
       auto-settle pacing — triage decides).
-- [ ] Open long-lived resources (stores, DBs) outside the bubble — the spike's
+- [x] Open long-lived resources (stores, DBs) outside the bubble — the spike's
       documented deadlock. `waitFor`/`fakeClock` stay for boundary-bound tests.
 
 Success measure: converted tests keep their assertions, lose their sleeps, and
@@ -169,3 +169,185 @@ Named per the boil-the-ocean rule; each needs an explicit go.
 - Toxiproxy on the hub-transport/remote leg when that code is next touched
   (zero CI coverage today; the helper already takes any upstream).
 - Frontend fast-check, if a frontend invariant bug ever surfaces.
+
+## Track B2 triage map (2026-08-09)
+
+Measured on `test/synctest-sweep`. A test counts as **paced** when its body
+sleeps, waits on `time.After`, or spins a deadline-bounded poll loop. Tags are
+resolved through the fixtures a test calls, two levels deep, so a test inherits
+the boundary its helper crosses.
+
+| package | paced | converted here | boundary-bound | candidate, not converted |
+|---|---|---|---|---|
+| `internal/daemon` | 199 | 20 | 59 | 120 |
+| `internal/jobs` | 21 | 17 | 0 | 2 |
+| `internal/pty` | 14 | 0 | 9 | 5 |
+| `internal/ptybackend` | 11 | 0 | 8 | 3 |
+| `internal/ptyworker` | 9 | 7 | 2 | 0 |
+| `internal/daemonctl` | 6 | 0 | 6 | 0 |
+| `internal/workflow` | 4 | 3 | 1 | 0 |
+| **total** | **264** | **47** | **85** | **130** |
+
+"Paced" and "boundary-bound" are measured against this branch's merge base;
+"converted here" counts the `synctest.Test` call sites this PR adds. The two
+`internal/jobs` tests the spike had already bubbled are not counted as
+converted here.
+
+(The brief's raw `grep` counts — daemon 194, ptybackend 22, pty 21, ptyworker
+12, jobs 10, daemonctl 7, workflow 6 — count *lines*, including sleeps inside
+shared helpers and inside tests that are not otherwise paced. The table counts
+tests.)
+
+### The boundary rule, corrected
+
+The plan assumed "most daemon sleeps sit behind real sockets/PTYs where the
+bubble cannot go". That is not what the code says. Of the 48 daemon test
+files containing paced tests, 34 carry no socket, PTY, or child-process signal
+at all, and the ones that do are concentrated in `daemon_test.go`,
+`testharness_test.go` and `plugin_worktree_test.go`.
+The parallel D1 investigation (`docs/plans/2026-08-09-daemon-in-a-bubble.md`)
+measured the same thing independently.
+
+What actually pins a bubble to real time:
+
+1. **A child process.** An outstanding `exec.Command` is a real fd nobody is
+   durably blocked on; the fake clock stops advancing and the test silently
+   runs at wall-clock speed (D1 measured 30.01s against 0.00s).
+2. **fsnotify.** The watcher goroutine parks in `epoll`/`kqueue`, which is not
+   durable blocking. Same failure.
+3. **A real socket or PTY.** Same reason, and the case the plan named.
+4. **Filesystem mtime.** A test that writes a file and needs the *real* clock
+   to move for the mtime to differ (`tilecontent_test.go`) cannot use a fake
+   one — the sleep is buying a wall-clock nanosecond, not a schedule.
+5. **A CPU-bound goroutine.** `internal/workflow`'s `while(true){}` watchdog
+   test spins in goja; a spinning goroutine is never durably blocked.
+
+Three house rules make a daemon fit inside a bubble; all three are written up
+where they are used, in `internal/daemon/synctest_test.go`:
+
+1. Build the daemon **outside** the bubble (`database/sql`'s `connectionOpener`
+   goroutine never exits — the spike's documented deadlock).
+2. Stop its background subsystems **inside** it, via a cleanup registered on the
+   bubble's `T`.
+3. Seed anything time-stamped **inside** it. The bubble clock starts at
+   2000-01-01, so a fixture row stamped with real `time.Now` is dated decades
+   ahead: a turn opened outside and settled inside settles *before* it opened
+   and still reads as owed. This cost an hour of debugging on
+   `TestAutoSettle_RealTimersSettleTheTurn`.
+
+One more, from D1 and worth repeating: `synctest.Wait()` is a happens-before
+edge for the race detector, `time.Sleep` is **not**. State a timer writes still
+needs its own lock.
+
+### Converted in this PR
+
+- `internal/jobs` — all 9 remaining paced tests (`runner_test.go` ×6 beyond the
+  spike's three, `cron_test.go` ×3). `waitFor` deleted.
+- `internal/workflow` — `cancel_test.go`, `concurrency_test.go` (the cap
+  saturation probe, previously a 5s deadline poll over an atomic),
+  `ordinal_test.go`. `waitForInFlight` deleted.
+- `internal/ptyworker` — the seven `Runtime` self-stop tests. These now run the
+  shipped TTLs: `exitedSessionCleanupTTL` 45s and `orphanedWorkerTTL` **12
+  hours**, where the tests previously substituted 15–50ms and then waited a
+  tolerance window on top.
+- `internal/daemon` — 20 tests: `snooze_test.go` ×4, `nudge_countdown_test.go`
+  ×4, `auto_settle_test.go` ×1, `gitstatus_test.go` ×6 (the whole scheduler
+  family, now on the production 1s debounce / 30s safety / 2min slow-safety /
+  5s slow threshold), `cancel_countdown_test.go` ×2, `ticket_notify_test.go`
+  ×2, `periodic_cron_test.go` ×1.
+
+`overrideGitStatusSchedulerForTesting`, `waitForGitStatusTestCondition`,
+`waitForNudge`, `waitFor` and `waitForInFlight` are gone: the production
+intervals no longer need turning down, so nothing needs to outrun them.
+
+### Flake classes retired
+
+- **`TestStartJobQueueArmsThePeriodicTicks`** ("`notebook_cron` is not armed",
+  full-suite load only). `startJobQueue` hands the cron entries to the runner,
+  whose dispatch goroutine writes them; the test read them straight afterwards
+  and won that race only on an idle machine. `synctest.Wait()` makes the read
+  happen after the write by construction. 20/20 clean.
+- **Tolerance-window negatives.** Every "X must not happen" that was asserted
+  by waiting 20–60ms — git-status refresh sharing, orphan-watch suppression,
+  auto-settle arm phase, workflow cap saturation — now asserts against a
+  settled system. These were not flaking loudly, but they were passing for the
+  wrong reason on a fast machine and were the load-sensitive class.
+
+### Boundary-bound, with reasons
+
+- `internal/daemonctl` (6/6) — every `stop_test.go` case forks a helper
+  process to hold or release the pid lock. Child process.
+- `internal/pty` (10/14) — real PTYs and read loops over real fds.
+- `internal/ptybackend` (9/11) — worker child processes and the control socket.
+- `internal/daemon/daemon_test.go` (25 of 35 paced) and `testharness_test.go`
+  (5/5) — a started daemon: listener, WebSocket hub, spawned sessions.
+- `internal/daemon/plugin_worktree_test.go` (14) — `exec.Command` per case.
+- `internal/daemon/fs_watch_test.go`, `transcript_watcher_abort_test.go`,
+  `notebook_test.go` — fsnotify.
+- `internal/daemon/tilecontent_test.go` — real mtime granularity (see rule 4).
+- `internal/daemon/reload_test.go` — `ptybackend` worker processes.
+- `internal/workflow/loop_test.go::TestContextCancelInterrupts` — CPU-bound
+  goja loop by design.
+- `internal/daemon/ticket_notify_test.go::TestChiefTicketContinuityAcrossRoleTransfer`
+  — mechanically bubble-able, deliberately left alone. Its final assertion
+  ("the retired chief received no role nudge") holds only while the nudge
+  window is parked; run the window out for real and the retired chief *is*
+  doorbelled, because the fixture leaves it a personal participant on the
+  ticket and `nudgeCount` cannot tell a personal nudge from a role one. Fixing
+  that needs either a narrower probe or a product answer, both outside a
+  test-only sweep. The reason is recorded above the test.
+
+### Candidates not converted (the honest remainder)
+
+120 paced daemon tests carry no boundary signal and were not converted here.
+They are not a backlog of known-good conversions — they are unverified
+candidates, and the classification is static analysis, not a passing bubble.
+The largest clusters, in the order worth taking them:
+
+- `notebook_narration_test.go` (16) and `notebook_daily_narrate_test.go` (6) —
+  poll the job queue for executor task state against a stubbed executable. If
+  the stub really never execs, these are `synctest.Wait()` one-liners and the
+  single biggest remaining win.
+- `plugin_rpc_test.go` (9), `plugin_supervisor_test.go` (7) — need a check for
+  whether the plugin runtime spawns a real interpreter.
+- `fs_test.go` (7) — separate the fsnotify cases from the pure-logic ones.
+- `workspace_keeper_test.go` (5), `ticket_buffer_test.go` (3),
+  `ws_tasks_test.go` (3) — store+queue polling, same shape as the jobs work.
+
+### Timings
+
+`go test -count=3`, same machine, sequential, `test/synctest-sweep` against its
+merge base.
+
+Whole packages:
+
+| package | before | after |
+|---|---|---|
+| `internal/jobs` | 0.43 / 0.46 / 0.57s | 0.53 / 0.54 / 0.60s |
+| `internal/workflow` | 4.15 / 5.00s | 3.76 / 4.01s |
+| `internal/ptyworker` | 3.66s | 2.86s |
+| `internal/daemon` | 425.6s | 457.5s |
+
+The whole-package daemon number is noise: 19 converted tests out of ~1200, and
+the run-to-run spread on a 7-minute package swamps the delta. The number that
+means something is the converted subset alone:
+
+| subset | before | after |
+|---|---|---|
+| the 20 converted daemon tests | 9.43s | 2.09s |
+| the 7 converted ptyworker tests | 1.70s | 0.33s |
+
+`internal/jobs` is flat because its paced tests already ran on an injected
+`fakeClock` — the spike traded a fake clock for a fake *world*, not for speed.
+That is the honest summary of the whole sweep: it buys determinism and
+fidelity (production intervals actually execute), not wall-clock.
+
+### Finding: the retention pass had never run in a test
+
+`TestRetentionTrimsCompletedJobsAndKeepsDeadOnes` went red on conversion. The
+runner's own hourly retention ticker really fires under a fake clock — 48 times
+across the test's 48-hour window — and trimmed the record before the manual
+`Trim` under test could. Under the old `fakeClock` that ticker ran on *real*
+time and never fired at all. The conversion parks it (`TrimInterval` 30 days)
+to keep the subject singular, but the discovery stands: the periodic retention
+pass has no test of its own. Worth one.

--- a/internal/daemon/auto_settle_test.go
+++ b/internal/daemon/auto_settle_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"path/filepath"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
@@ -17,12 +18,23 @@ import (
 func newAutoSettleDaemon(t *testing.T) (*Daemon, string) {
 	t.Helper()
 	d := NewForTesting(filepath.Join(t.TempDir(), "auto-settle.sock"))
+	return d, seedAutoSettleSession(t, d, t.TempDir())
+}
+
+// seedAutoSettleSession installs the fixture's session and settings. It is split
+// out of newAutoSettleDaemon because the turn it opens is stamped with time.Now,
+// and a synctest bubble's clock starts at 2000-01-01: a turn opened outside the
+// bubble is stamped decades AHEAD of every settle made inside it, so the settle
+// lands before the open and the turn reads as still owed. A bubbled test builds
+// the daemon outside (see synctest_test.go) and calls this inside.
+func seedAutoSettleSession(t *testing.T, d *Daemon, dir string) string {
+	t.Helper()
 	id := "session"
 	d.store.Add(&protocol.Session{
 		ID:             id,
 		Label:          id,
 		Agent:          protocol.SessionAgentCodex,
-		Directory:      t.TempDir(),
+		Directory:      dir,
 		State:          protocol.SessionStateWaitingInput,
 		StateSince:     characterizationOldTimestamp,
 		StateUpdatedAt: characterizationOldTimestamp,
@@ -37,7 +49,7 @@ func newAutoSettleDaemon(t *testing.T) (*Daemon, string) {
 	if !d.store.OpenTurnIfClosed(id, time.Now()) {
 		t.Fatal("OpenTurnIfClosed() = false; the fixture owes no turn")
 	}
-	return d, id
+	return id
 }
 
 func autoSettlePending(d *Daemon, sessionID string) (*autoSettleTimer, bool) {
@@ -386,25 +398,44 @@ func TestAutoSettle_FireTimeRecheckRefusesHeldWorkingDuringClassification(t *tes
 	}
 }
 
-// End to end on real timers, with the windows turned down: the feature works
-// without the hand-fire the other tests use.
+// End to end on real timers: the feature works without the hand-fire the other
+// tests use.
+//
+// Converted to synctest. The windows no longer need turning down — this runs the
+// production 30s arm and 15s countdown and sleeps exactly them at no wall-clock
+// cost — and the two phases are now separately observable, so a policy that
+// settles too early fails here rather than passing a "within 5 seconds" poll.
 func TestAutoSettle_RealTimersSettleTheTurn(t *testing.T) {
-	d, id := newAutoSettleDaemon(t)
-	d.store.SetSetting(SettingAutoSettleArmSeconds, "1")
-	d.store.SetSetting(SettingAutoSettleCountdownSeconds, "1")
+	d := newBubbleDaemon(t)
+	dir := t.TempDir()
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		// Seeded inside the bubble so the turn is opened on the bubble's clock; see
+		// seedAutoSettleSession.
+		id := seedAutoSettleSession(t, d, dir)
+		// The fixture pins hour-long windows so hand-fired tests never race a real
+		// timer. This one is about the real timers, so it takes the defaults.
+		d.store.SetSetting(SettingAutoSettleArmSeconds, "")
+		d.store.SetSetting(SettingAutoSettleCountdownSeconds, "")
 
-	if !d.applyState(sessionStateChange{sessionID: id, state: protocol.StateWorking, cause: liveSignal{}}) {
-		t.Fatal("applyState(working) = false")
-	}
-
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if !turnIsOwed(d, id) {
-			return
+		if !d.applyState(sessionStateChange{sessionID: id, state: protocol.StateWorking, cause: liveSignal{}}) {
+			t.Fatal("applyState(working) = false")
 		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatal("turn was never auto-settled within 5s of a 1s+1s policy")
+
+		// Through the invisible arm delay and into the countdown, with the turn still
+		// owed: settling here would bury the session while the countdown is on screen.
+		time.Sleep(defaultAutoSettleArmSeconds * time.Second)
+		synctest.Wait()
+		if !turnIsOwed(d, id) {
+			t.Fatal("the turn settled at the end of the arm delay, before its countdown ran")
+		}
+
+		time.Sleep(defaultAutoSettleCountdownSeconds * time.Second)
+		synctest.Wait()
+		if turnIsOwed(d, id) {
+			t.Fatal("the turn was never auto-settled although both windows elapsed")
+		}
+	})
 }
 
 func TestValidateAutoSettleSeconds(t *testing.T) {

--- a/internal/daemon/cancel_countdown_test.go
+++ b/internal/daemon/cancel_countdown_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"path/filepath"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
@@ -74,57 +75,62 @@ func TestCancelCountdown_NoCountdownIsHarmless(t *testing.T) {
 // from the same unread events — so without a standing cancel the nudge the user
 // just called off comes straight back.
 func TestCancelCountdown_NudgeStaysCancelledAcrossSelectionChange(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.nudgeWindowOverride = time.Hour
-	t.Cleanup(d.stopNudgeCountdowns)
-	chiefID, agentID, _ := delegateForNotify(t, d, "codex")
-	ticketID := boundTicketID(t, d, agentID)
-	d.store.UpdateState(agentID, protocol.StateIdle)
-	commentOnTicket(t, d, ticketID, "take a look at the failing test")
-	if currentNudgeTimer(d, agentID) == nil {
-		t.Fatal("precondition: no nudge countdown armed")
-	}
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		chiefID, agentID, _ := delegateForNotify(t, d, "codex")
+		ticketID := boundTicketID(t, d, agentID)
+		d.store.UpdateState(agentID, protocol.StateIdle)
+		commentOnTicket(t, d, ticketID, "take a look at the failing test")
+		if currentNudgeTimer(d, agentID) == nil {
+			t.Fatal("precondition: no nudge countdown armed")
+		}
 
-	d.handleCancelCountdown(&protocol.CancelCountdownMessage{SessionID: agentID})
+		d.handleCancelCountdown(&protocol.CancelCountdownMessage{SessionID: agentID})
 
-	// Select the cancelled session and then leave it: the pause/resume pair is
-	// the path that re-arms.
-	d.setSelectedSession(agentID)
-	d.setSelectedSession(chiefID)
-	time.Sleep(50 * time.Millisecond) // the resume runs on its own goroutine
+		// Select the cancelled session and then leave it: the pause/resume pair is
+		// the path that re-arms.
+		d.setSelectedSession(agentID)
+		d.setSelectedSession(chiefID)
+		// The resume runs on its own goroutine. synctest.Wait returns once it has
+		// finished and every other bubble goroutine is parked, so "no timer" is a
+		// statement about the settled daemon rather than about a 50ms window.
+		synctest.Wait()
 
-	if currentNudgeTimer(d, agentID) != nil {
-		t.Fatal("the cancelled nudge re-armed on a selection change")
-	}
-	// The activity did not go away, and neither did the way back to it.
-	clone := d.sessionForBroadcast(d.store.Get(agentID))
-	if !protocol.Deref(clone.TicketUnread) {
-		t.Fatal("cancelling the countdown also cleared the unread indicator")
-	}
+		if currentNudgeTimer(d, agentID) != nil {
+			t.Fatal("the cancelled nudge re-armed on a selection change")
+		}
+		// The activity did not go away, and neither did the way back to it.
+		clone := d.sessionForBroadcast(d.store.Get(agentID))
+		if !protocol.Deref(clone.TicketUnread) {
+			t.Fatal("cancelling the countdown also cleared the unread indicator")
+		}
+	})
 }
 
 // "Not now" is an answer about what is pending, not a mute. Ticket activity that
 // arrives after the cancel is new information and gets to ask again.
 func TestCancelCountdown_NewerTicketActivityReArmsTheNudge(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.nudgeWindowOverride = time.Hour
-	t.Cleanup(d.stopNudgeCountdowns)
-	_, agentID, _ := delegateForNotify(t, d, "codex")
-	ticketID := boundTicketID(t, d, agentID)
-	d.store.UpdateState(agentID, protocol.StateIdle)
-	commentOnTicket(t, d, ticketID, "take a look at the failing test")
-	if currentNudgeTimer(d, agentID) == nil {
-		t.Fatal("precondition: no nudge countdown armed")
-	}
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		_, agentID, _ := delegateForNotify(t, d, "codex")
+		ticketID := boundTicketID(t, d, agentID)
+		d.store.UpdateState(agentID, protocol.StateIdle)
+		commentOnTicket(t, d, ticketID, "take a look at the failing test")
+		if currentNudgeTimer(d, agentID) == nil {
+			t.Fatal("precondition: no nudge countdown armed")
+		}
 
-	d.handleCancelCountdown(&protocol.CancelCountdownMessage{SessionID: agentID})
-	if currentNudgeTimer(d, agentID) != nil {
-		t.Fatal("precondition: cancel did not stop the countdown")
-	}
+		d.handleCancelCountdown(&protocol.CancelCountdownMessage{SessionID: agentID})
+		if currentNudgeTimer(d, agentID) != nil {
+			t.Fatal("precondition: cancel did not stop the countdown")
+		}
 
-	commentOnTicket(t, d, ticketID, "actually, this is now blocking the release")
+		commentOnTicket(t, d, ticketID, "actually, this is now blocking the release")
 
-	waitForNudgeDeadline(t, d, agentID)
+		settledNudgeDeadline(t, d, agentID)
+	})
 }
 
 // Cancelling the settle half keeps the turn owed. This is the behavior the whole

--- a/internal/daemon/gitstatus_test.go
+++ b/internal/daemon/gitstatus_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
@@ -159,219 +160,252 @@ func TestParseGitDiffNumstat(t *testing.T) {
 	}
 }
 
+// The scheduler tests below run inside synctest bubbles at the production
+// debounce and safety intervals. They used to turn those intervals down to tens
+// of milliseconds so a test could outrun them; under a fake clock a 30-second
+// safety window costs nothing to wait out, so the schedule under test is the
+// shipped one. Nothing here touches a real repo — getGitStatusForDaemon is
+// stubbed and the client's send channel is buffered — so the whole scheduler
+// fits in a bubble.
 func TestGitStatusSchedulerCoalescesDirtyRefreshes(t *testing.T) {
-	restore := overrideGitStatusSchedulerForTesting(10*time.Millisecond, time.Hour, time.Hour, time.Hour)
-	defer restore()
+	synctest.Test(t, func(t *testing.T) {
+		var calls atomic.Int32
+		var inFlight atomic.Int32
+		var overlapped atomic.Bool
+		firstStarted := make(chan struct{})
+		releaseFirst := make(chan struct{})
 
-	var calls atomic.Int32
-	var inFlight atomic.Int32
-	var overlapped atomic.Bool
-	firstStarted := make(chan struct{})
-	releaseFirst := make(chan struct{})
+		previousGetGitStatus := getGitStatusForDaemon
+		getGitStatusForDaemon = func(dir string, _ gitStatusMode) (*protocol.GitStatusUpdateMessage, error) {
+			if inFlight.Add(1) > 1 {
+				overlapped.Store(true)
+			}
+			defer inFlight.Add(-1)
 
-	previousGetGitStatus := getGitStatusForDaemon
-	getGitStatusForDaemon = func(dir string, _ gitStatusMode) (*protocol.GitStatusUpdateMessage, error) {
-		if inFlight.Add(1) > 1 {
-			overlapped.Store(true)
+			call := calls.Add(1)
+			if call == 1 {
+				close(firstStarted)
+				<-releaseFirst
+			}
+			return testGitStatus(dir, fmt.Sprintf("file-%d.txt", call)), nil
 		}
-		defer inFlight.Add(-1)
+		defer func() {
+			getGitStatusForDaemon = previousGetGitStatus
+		}()
 
-		call := calls.Add(1)
-		if call == 1 {
-			close(firstStarted)
-			<-releaseFirst
+		d := &Daemon{}
+		client := &wsClient{send: make(chan outboundMessage, 10)}
+		d.handleSubscribeGitStatus(client, &protocol.SubscribeGitStatusMessage{
+			Cmd:       protocol.CmdSubscribeGitStatus,
+			Directory: "/repo",
+		})
+		t.Cleanup(client.stopGitStatusPoll)
+
+		<-firstStarted
+		for i := 0; i < 5; i++ {
+			client.requestGitStatusRefresh(gitStatusRefreshRequest{reason: gitStatusRefreshReasonDirty})
 		}
-		return testGitStatus(dir, fmt.Sprintf("file-%d.txt", call)), nil
-	}
-	defer func() {
-		getGitStatusForDaemon = previousGetGitStatus
-	}()
+		close(releaseFirst)
 
-	d := &Daemon{}
-	client := &wsClient{send: make(chan outboundMessage, 10)}
-	d.handleSubscribeGitStatus(client, &protocol.SubscribeGitStatusMessage{
-		Cmd:       protocol.CmdSubscribeGitStatus,
-		Directory: "/repo",
+		// One debounce later the whole burst has collapsed into a single refresh,
+		// and several debounces after that nothing more has run.
+		time.Sleep(gitStatusRefreshDebounce)
+		synctest.Wait()
+		if got := calls.Load(); got != 2 {
+			t.Fatalf("git status calls = %d, want 2", got)
+		}
+		time.Sleep(5 * gitStatusRefreshDebounce)
+		synctest.Wait()
+
+		if got := calls.Load(); got != 2 {
+			t.Fatalf("git status calls = %d, want 2", got)
+		}
+		if overlapped.Load() {
+			t.Fatal("git status refreshes overlapped")
+		}
 	})
-	defer client.stopGitStatusPoll()
-
-	<-firstStarted
-	for i := 0; i < 5; i++ {
-		client.requestGitStatusRefresh(gitStatusRefreshRequest{reason: gitStatusRefreshReasonDirty})
-	}
-	close(releaseFirst)
-
-	waitForGitStatusTestCondition(t, 500*time.Millisecond, func() bool {
-		return calls.Load() == 2
-	})
-	time.Sleep(50 * time.Millisecond)
-
-	if got := calls.Load(); got != 2 {
-		t.Fatalf("git status calls = %d, want 2", got)
-	}
-	if overlapped.Load() {
-		t.Fatal("git status refreshes overlapped")
-	}
 }
 
 func TestGitOperationMarksMatchingStatusSubscriptionDirty(t *testing.T) {
-	restore := overrideGitStatusSchedulerForTesting(10*time.Millisecond, time.Hour, time.Hour, time.Hour)
-	defer restore()
+	synctest.Test(t, func(t *testing.T) {
+		var calls atomic.Int32
+		previousGetGitStatus := getGitStatusForDaemon
+		getGitStatusForDaemon = func(dir string, _ gitStatusMode) (*protocol.GitStatusUpdateMessage, error) {
+			call := calls.Add(1)
+			return testGitStatus(dir, fmt.Sprintf("file-%d.txt", call)), nil
+		}
+		defer func() {
+			getGitStatusForDaemon = previousGetGitStatus
+		}()
 
-	var calls atomic.Int32
-	previousGetGitStatus := getGitStatusForDaemon
-	getGitStatusForDaemon = func(dir string, _ gitStatusMode) (*protocol.GitStatusUpdateMessage, error) {
-		call := calls.Add(1)
-		return testGitStatus(dir, fmt.Sprintf("file-%d.txt", call)), nil
-	}
-	defer func() {
-		getGitStatusForDaemon = previousGetGitStatus
-	}()
+		hub := newWSHub()
+		d := &Daemon{wsHub: hub}
+		client := &wsClient{send: make(chan outboundMessage, 10)}
+		hub.clients[client] = true
 
-	hub := newWSHub()
-	d := &Daemon{wsHub: hub}
-	client := &wsClient{send: make(chan outboundMessage, 10)}
-	hub.clients[client] = true
+		d.handleSubscribeGitStatus(client, &protocol.SubscribeGitStatusMessage{
+			Cmd:       protocol.CmdSubscribeGitStatus,
+			Directory: "/repo",
+		})
+		t.Cleanup(client.stopGitStatusPoll)
+		synctest.Wait()
+		if got := calls.Load(); got != 1 {
+			t.Fatalf("git status calls after subscribing = %d, want 1", got)
+		}
 
-	d.handleSubscribeGitStatus(client, &protocol.SubscribeGitStatusMessage{
-		Cmd:       protocol.CmdSubscribeGitStatus,
-		Directory: "/repo",
-	})
-	defer client.stopGitStatusPoll()
-	waitForGitStatusTestCondition(t, 500*time.Millisecond, func() bool {
-		return calls.Load() == 1
-	})
+		finish := d.beginGitOperation(protocol.GitOperationKindDeleteWorktree, "/repo/worktree", nil)
+		finish(nil)
 
-	finish := d.beginGitOperation(protocol.GitOperationKindDeleteWorktree, "/repo/worktree", nil)
-	finish(nil)
-
-	waitForGitStatusTestCondition(t, 500*time.Millisecond, func() bool {
-		return calls.Load() == 2
+		time.Sleep(gitStatusRefreshDebounce)
+		synctest.Wait()
+		if got := calls.Load(); got != 2 {
+			t.Fatalf("git status calls after the git operation = %d, want 2", got)
+		}
 	})
 }
 
 func TestGitStatusSchedulerDelaysSafetyRefreshAfterSlowRun(t *testing.T) {
-	restore := overrideGitStatusSchedulerForTesting(10*time.Millisecond, 20*time.Millisecond, time.Hour, time.Millisecond)
-	defer restore()
+	synctest.Test(t, func(t *testing.T) {
+		var calls atomic.Int32
+		previousGetGitStatus := getGitStatusForDaemon
+		getGitStatusForDaemon = func(dir string, _ gitStatusMode) (*protocol.GitStatusUpdateMessage, error) {
+			call := calls.Add(1)
+			// Slower than gitStatusSlowRefreshDuration, so the scheduler classifies
+			// the repo as slow and backs its safety refresh off.
+			time.Sleep(gitStatusSlowRefreshDuration + time.Second)
+			return testGitStatus(dir, fmt.Sprintf("file-%d.txt", call)), nil
+		}
+		defer func() {
+			getGitStatusForDaemon = previousGetGitStatus
+		}()
 
-	var calls atomic.Int32
-	previousGetGitStatus := getGitStatusForDaemon
-	getGitStatusForDaemon = func(dir string, _ gitStatusMode) (*protocol.GitStatusUpdateMessage, error) {
-		call := calls.Add(1)
-		time.Sleep(5 * time.Millisecond)
-		return testGitStatus(dir, fmt.Sprintf("file-%d.txt", call)), nil
-	}
-	defer func() {
-		getGitStatusForDaemon = previousGetGitStatus
-	}()
+		d := &Daemon{}
+		client := &wsClient{send: make(chan outboundMessage, 10)}
+		d.handleSubscribeGitStatus(client, &protocol.SubscribeGitStatusMessage{
+			Cmd:       protocol.CmdSubscribeGitStatus,
+			Directory: "/repo",
+		})
+		t.Cleanup(client.stopGitStatusPoll)
 
-	d := &Daemon{}
-	client := &wsClient{send: make(chan outboundMessage, 10)}
-	d.handleSubscribeGitStatus(client, &protocol.SubscribeGitStatusMessage{
-		Cmd:       protocol.CmdSubscribeGitStatus,
-		Directory: "/repo",
+		synctest.Wait()
+		if got := calls.Load(); got != 1 {
+			t.Fatalf("git status calls after subscribing = %d, want 1", got)
+		}
+
+		// Past the normal safety interval, which a slow repo must not be polled on.
+		time.Sleep(2 * gitStatusSafetyInterval)
+		synctest.Wait()
+		if got := calls.Load(); got != 1 {
+			t.Fatalf("git status calls = %d, want 1 slow run without normal safety refresh", got)
+		}
+
+		// Delayed, not abandoned: the slow interval still comes around.
+		time.Sleep(gitStatusSlowSafetyInterval)
+		synctest.Wait()
+		if got := calls.Load(); got != 2 {
+			t.Fatalf("git status calls after the slow safety interval = %d, want 2", got)
+		}
 	})
-	defer client.stopGitStatusPoll()
-
-	waitForGitStatusTestCondition(t, 500*time.Millisecond, func() bool {
-		return calls.Load() == 1
-	})
-	time.Sleep(60 * time.Millisecond)
-
-	if got := calls.Load(); got != 1 {
-		t.Fatalf("git status calls = %d, want 1 slow run without normal safety refresh", got)
-	}
 }
 
 func TestGitStatusSchedulerUsesTrackedOnlyAfterLimitedRefresh(t *testing.T) {
-	restore := overrideGitStatusSchedulerForTesting(10*time.Millisecond, time.Hour, time.Hour, time.Hour)
-	defer restore()
-
-	var calls atomic.Int32
-	modes := make(chan gitStatusMode, 2)
-	previousGetGitStatus := getGitStatusForDaemon
-	getGitStatusForDaemon = func(dir string, mode gitStatusMode) (*protocol.GitStatusUpdateMessage, error) {
-		modes <- mode
-		call := calls.Add(1)
-		status := testGitStatus(dir, fmt.Sprintf("file-%d.txt", call))
-		if call == 1 {
-			status.Limited = protocol.Ptr(true)
-			status.Mode = protocol.Ptr(string(gitStatusModeTrackedOnly))
+	synctest.Test(t, func(t *testing.T) {
+		var calls atomic.Int32
+		modes := make(chan gitStatusMode, 2)
+		previousGetGitStatus := getGitStatusForDaemon
+		getGitStatusForDaemon = func(dir string, mode gitStatusMode) (*protocol.GitStatusUpdateMessage, error) {
+			modes <- mode
+			call := calls.Add(1)
+			status := testGitStatus(dir, fmt.Sprintf("file-%d.txt", call))
+			if call == 1 {
+				status.Limited = protocol.Ptr(true)
+				status.Mode = protocol.Ptr(string(gitStatusModeTrackedOnly))
+			}
+			return status, nil
 		}
-		return status, nil
-	}
-	defer func() {
-		getGitStatusForDaemon = previousGetGitStatus
-	}()
+		defer func() {
+			getGitStatusForDaemon = previousGetGitStatus
+		}()
 
-	d := &Daemon{}
-	client := &wsClient{send: make(chan outboundMessage, 10)}
-	d.handleSubscribeGitStatus(client, &protocol.SubscribeGitStatusMessage{
-		Cmd:       protocol.CmdSubscribeGitStatus,
-		Directory: "/repo",
-	})
-	defer client.stopGitStatusPoll()
+		d := &Daemon{}
+		client := &wsClient{send: make(chan outboundMessage, 10)}
+		d.handleSubscribeGitStatus(client, &protocol.SubscribeGitStatusMessage{
+			Cmd:       protocol.CmdSubscribeGitStatus,
+			Directory: "/repo",
+		})
+		t.Cleanup(client.stopGitStatusPoll)
 
-	waitForGitStatusTestCondition(t, 500*time.Millisecond, func() bool {
-		return calls.Load() == 1
-	})
-	client.requestGitStatusRefresh(gitStatusRefreshRequest{reason: gitStatusRefreshReasonDirty})
-	waitForGitStatusTestCondition(t, 500*time.Millisecond, func() bool {
-		return calls.Load() == 2
-	})
+		synctest.Wait()
+		if got := calls.Load(); got != 1 {
+			t.Fatalf("git status calls after subscribing = %d, want 1", got)
+		}
+		client.requestGitStatusRefresh(gitStatusRefreshRequest{reason: gitStatusRefreshReasonDirty})
+		time.Sleep(gitStatusRefreshDebounce)
+		synctest.Wait()
+		if got := calls.Load(); got != 2 {
+			t.Fatalf("git status calls after the dirty refresh = %d, want 2", got)
+		}
 
-	first := <-modes
-	second := <-modes
-	if first != gitStatusModeFull {
-		t.Fatalf("first mode = %q, want %q", first, gitStatusModeFull)
-	}
-	if second != gitStatusModeTrackedOnly {
-		t.Fatalf("second mode = %q, want %q", second, gitStatusModeTrackedOnly)
-	}
+		first := <-modes
+		second := <-modes
+		if first != gitStatusModeFull {
+			t.Fatalf("first mode = %q, want %q", first, gitStatusModeFull)
+		}
+		if second != gitStatusModeTrackedOnly {
+			t.Fatalf("second mode = %q, want %q", second, gitStatusModeTrackedOnly)
+		}
+	})
 }
 
 func TestGitStatusCoordinatorSharesInFlightStatusForRepoAndMode(t *testing.T) {
-	var calls atomic.Int32
-	started := make(chan struct{})
-	release := make(chan struct{})
-	previousGetGitStatus := getGitStatusForDaemon
-	getGitStatusForDaemon = func(dir string, _ gitStatusMode) (*protocol.GitStatusUpdateMessage, error) {
-		call := calls.Add(1)
-		if call == 1 {
-			close(started)
-			<-release
-		}
-		return testGitStatus(dir, "src/shared.ts"), nil
-	}
-	defer func() {
-		getGitStatusForDaemon = previousGetGitStatus
-	}()
-
-	d := &Daemon{}
-	results := make(chan *protocol.GitStatusUpdateMessage, 2)
-	for i := 0; i < 2; i++ {
-		go func() {
-			status, _, err := d.coordinator().Status("/repo", gitStatusModeFull)
-			if err != nil {
-				t.Errorf("Status failed: %v", err)
+	synctest.Test(t, func(t *testing.T) {
+		var calls atomic.Int32
+		started := make(chan struct{})
+		release := make(chan struct{})
+		previousGetGitStatus := getGitStatusForDaemon
+		getGitStatusForDaemon = func(dir string, _ gitStatusMode) (*protocol.GitStatusUpdateMessage, error) {
+			call := calls.Add(1)
+			if call == 1 {
+				close(started)
+				<-release
 			}
-			results <- status
-		}()
-	}
-
-	<-started
-	time.Sleep(20 * time.Millisecond)
-	if got := calls.Load(); got != 1 {
-		t.Fatalf("git status calls while first refresh is in flight = %d, want 1", got)
-	}
-	close(release)
-
-	for i := 0; i < 2; i++ {
-		status := <-results
-		if status == nil || len(status.Unstaged) != 1 || status.Unstaged[0].Path != "src/shared.ts" {
-			t.Fatalf("status = %+v, want shared status result", status)
+			return testGitStatus(dir, "src/shared.ts"), nil
 		}
-	}
+		defer func() {
+			getGitStatusForDaemon = previousGetGitStatus
+		}()
+
+		d := &Daemon{}
+		results := make(chan *protocol.GitStatusUpdateMessage, 2)
+		for i := 0; i < 2; i++ {
+			go func() {
+				status, _, err := d.coordinator().Status("/repo", gitStatusModeFull)
+				if err != nil {
+					t.Errorf("Status failed: %v", err)
+				}
+				results <- status
+			}()
+		}
+
+		<-started
+		// The sharing claim is a negative one, and this is where a bubble pays: the
+		// old 20ms sleep could only say "no second call had started yet by the time
+		// I looked". synctest.Wait returns when both callers are durably blocked —
+		// one inside the stub, one parked on the shared refresh's done channel — so
+		// the count is of a system that has finished deciding.
+		synctest.Wait()
+		if got := calls.Load(); got != 1 {
+			t.Fatalf("git status calls while first refresh is in flight = %d, want 1", got)
+		}
+		close(release)
+
+		for i := 0; i < 2; i++ {
+			status := <-results
+			if status == nil || len(status.Unstaged) != 1 || status.Unstaged[0].Path != "src/shared.ts" {
+				t.Fatalf("status = %+v, want shared status result", status)
+			}
+		}
+	})
 }
 
 func TestTrackedOnlyStatusResultStaysLimited(t *testing.T) {
@@ -467,47 +501,49 @@ func TestSameOrNestedPath(t *testing.T) {
 }
 
 func TestGitCoordinatorSharesInFlightFileDiff(t *testing.T) {
-	previousReadFileDiff := readFileDiffForDaemon
-	var calls atomic.Int32
-	started := make(chan struct{})
-	release := make(chan struct{})
-	readFileDiffForDaemon = func(_, _, _, _ string, _ bool) (fileDiffContent, error) {
-		call := calls.Add(1)
-		if call == 1 {
-			close(started)
-			<-release
-		}
-		return fileDiffContent{original: "before", modified: "after"}, nil
-	}
-	defer func() {
-		readFileDiffForDaemon = previousReadFileDiff
-	}()
-
-	d := &Daemon{}
-	results := make(chan fileDiffContent, 2)
-	for i := 0; i < 2; i++ {
-		go func() {
-			content, err := d.coordinator().FileDiff("/repo", "src/file.ts", "HEAD", "", false)
-			if err != nil {
-				t.Errorf("FileDiff failed: %v", err)
+	synctest.Test(t, func(t *testing.T) {
+		previousReadFileDiff := readFileDiffForDaemon
+		var calls atomic.Int32
+		started := make(chan struct{})
+		release := make(chan struct{})
+		readFileDiffForDaemon = func(_, _, _, _ string, _ bool) (fileDiffContent, error) {
+			call := calls.Add(1)
+			if call == 1 {
+				close(started)
+				<-release
 			}
-			results <- content
-		}()
-	}
-
-	<-started
-	time.Sleep(20 * time.Millisecond)
-	if got := calls.Load(); got != 1 {
-		t.Fatalf("file diff calls while first refresh is in flight = %d, want 1", got)
-	}
-	close(release)
-
-	for i := 0; i < 2; i++ {
-		content := <-results
-		if content.original != "before" || content.modified != "after" {
-			t.Fatalf("file diff content = %+v, want shared content", content)
+			return fileDiffContent{original: "before", modified: "after"}, nil
 		}
-	}
+		defer func() {
+			readFileDiffForDaemon = previousReadFileDiff
+		}()
+
+		d := &Daemon{}
+		results := make(chan fileDiffContent, 2)
+		for i := 0; i < 2; i++ {
+			go func() {
+				content, err := d.coordinator().FileDiff("/repo", "src/file.ts", "HEAD", "", false)
+				if err != nil {
+					t.Errorf("FileDiff failed: %v", err)
+				}
+				results <- content
+			}()
+		}
+
+		<-started
+		synctest.Wait()
+		if got := calls.Load(); got != 1 {
+			t.Fatalf("file diff calls while first refresh is in flight = %d, want 1", got)
+		}
+		close(release)
+
+		for i := 0; i < 2; i++ {
+			content := <-results
+			if content.original != "before" || content.modified != "after" {
+				t.Fatalf("file diff content = %+v, want shared content", content)
+			}
+		}
+	})
 }
 
 func containsArg(args []string, want string) bool {
@@ -519,25 +555,6 @@ func containsArg(args []string, want string) bool {
 	return false
 }
 
-func overrideGitStatusSchedulerForTesting(debounce, safety, slowSafety, slowThreshold time.Duration) func() {
-	previousDebounce := gitStatusRefreshDebounce
-	previousSafety := gitStatusSafetyInterval
-	previousSlowSafety := gitStatusSlowSafetyInterval
-	previousSlowThreshold := gitStatusSlowRefreshDuration
-
-	gitStatusRefreshDebounce = debounce
-	gitStatusSafetyInterval = safety
-	gitStatusSlowSafetyInterval = slowSafety
-	gitStatusSlowRefreshDuration = slowThreshold
-
-	return func() {
-		gitStatusRefreshDebounce = previousDebounce
-		gitStatusSafetyInterval = previousSafety
-		gitStatusSlowSafetyInterval = previousSlowSafety
-		gitStatusSlowRefreshDuration = previousSlowThreshold
-	}
-}
-
 func testGitStatus(dir, path string) *protocol.GitStatusUpdateMessage {
 	return &protocol.GitStatusUpdateMessage{
 		Event:     protocol.EventGitStatusUpdate,
@@ -546,16 +563,4 @@ func testGitStatus(dir, path string) *protocol.GitStatusUpdateMessage {
 		Unstaged:  []protocol.GitFileChange{{Path: path, Status: "modified"}},
 		Untracked: []protocol.GitFileChange{},
 	}
-}
-
-func waitForGitStatusTestCondition(t *testing.T, timeout time.Duration, condition func() bool) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if condition() {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatal("timed out waiting for condition")
 }

--- a/internal/daemon/nudge_countdown_test.go
+++ b/internal/daemon/nudge_countdown_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
@@ -43,6 +44,20 @@ func waitForNudgeDeadline(t *testing.T, d *Daemon, sessionID string) time.Time {
 	return time.Time{}
 }
 
+// settledNudgeDeadline is waitForNudgeDeadline for a synctest bubble: arming can
+// happen on another goroutine, so settle the bubble first and then read the
+// deadline once. A missing deadline here means nothing is going to arm one, not
+// that the poll was early.
+func settledNudgeDeadline(t *testing.T, d *Daemon, sessionID string) time.Time {
+	t.Helper()
+	synctest.Wait()
+	deadline := currentNudgeDeadline(d, sessionID)
+	if deadline.IsZero() {
+		t.Fatalf("no nudge deadline armed for %s once the daemon settled", sessionID)
+	}
+	return deadline
+}
+
 // fireNudgeNow simulates the countdown timer firing immediately, by invoking the fire
 // callback with the live timer handle — the faithful deterministic path. Tests that
 // use it set an hour-long window override so the real timer never races this
@@ -57,20 +72,6 @@ func fireNudgeNow(t *testing.T, d *Daemon, sessionID string) {
 	d.nudgeCountdownFire(sessionID, timer)
 }
 
-// waitForNudge polls until the session received a doorbell, failing on timeout. Used
-// only by the end-to-end real-timer test; the rest fire deterministically.
-func waitForNudge(t *testing.T, inputs func(string) []string, sessionID string) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if wasNudged(inputs(sessionID)) {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatalf("session %s was never doorbelled", sessionID)
-}
-
 // armForTest gives an idle codex agent an unread chief steer, which arms its shared
 // nudge countdown. Returns the agent id and inputs accessor.
 func armForTest(t *testing.T, d *Daemon) (agentID string, inputs func(string) []string) {
@@ -83,14 +84,32 @@ func armForTest(t *testing.T, d *Daemon) (agentID string, inputs func(string) []
 }
 
 // The end-to-end real-timer path: an idle, inactive codex with unread activity arms a
-// countdown that, on its own, fires after the (tiny) window and doorbells.
+// countdown that, on its own, fires after the window and doorbells.
+//
+// Converted to synctest. This test used to shorten the countdown to 15ms and poll
+// for the doorbell over two seconds; it now runs the production 30s window and
+// sleeps exactly it, at no wall-clock cost. The negative half is what the bubble
+// really buys: one tick short of the deadline nothing has been doorbelled, on a
+// daemon with nothing left to do — a claim the polling version could not make at
+// all.
 func TestNudgeCountdownFiresWhenInactive(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.nudgeWindowOverride = 15 * time.Millisecond
-	t.Cleanup(d.stopNudgeCountdowns)
-	agentID, inputs := armForTest(t, d)
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		agentID, inputs := armForTest(t, d)
 
-	waitForNudge(t, inputs, agentID)
+		time.Sleep(defaultNudgeCountdownWindow - time.Second)
+		synctest.Wait()
+		if wasNudged(inputs(agentID)) {
+			t.Fatal("the doorbell rang before the countdown window elapsed")
+		}
+
+		time.Sleep(time.Second)
+		synctest.Wait()
+		if !wasNudged(inputs(agentID)) {
+			t.Fatalf("session %s was never doorbelled", agentID)
+		}
+	})
 }
 
 // The active (currently-selected) session never auto-fires: its countdown is paused
@@ -125,68 +144,74 @@ func TestNudgeCountdownPausedWhileActive(t *testing.T) {
 // Switching away from the active session resumes its paused countdown so attn
 // delivers the nudge later.
 func TestNudgeCountdownResumesOnSwitchAway(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.nudgeWindowOverride = time.Hour
-	t.Cleanup(d.stopNudgeCountdowns)
-	chiefID, agentID, _ := delegateForNotify(t, d, "codex")
-	ticketID := boundTicketID(t, d, agentID)
-	d.store.UpdateState(agentID, protocol.StateIdle)
-	d.setSelectedSession(agentID)
-	commentOnTicket(t, d, ticketID, "take a look") // paused while active
-	if currentNudgeTimer(d, agentID) != nil {
-		t.Fatal("countdown ran while the session was active")
-	}
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		d.nudgeWindowOverride = time.Hour
+		stopDaemonBackground(t, d)
+		chiefID, agentID, _ := delegateForNotify(t, d, "codex")
+		ticketID := boundTicketID(t, d, agentID)
+		d.store.UpdateState(agentID, protocol.StateIdle)
+		d.setSelectedSession(agentID)
+		commentOnTicket(t, d, ticketID, "take a look") // paused while active
+		if currentNudgeTimer(d, agentID) != nil {
+			t.Fatal("countdown ran while the session was active")
+		}
 
-	d.setSelectedSession(chiefID) // switch away
+		d.setSelectedSession(chiefID) // switch away
 
-	waitForNudgeDeadline(t, d, agentID)
+		settledNudgeDeadline(t, d, agentID)
+	})
 }
 
 func TestBufferedNudgePreservesDeadlineAcrossSelectionPause(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.nudgeWindowOverride = time.Second
-	d.ticketBufferWindowOverride = time.Hour
-	t.Cleanup(d.stopNudgeCountdowns)
-	chiefID, agentID, _ := delegateForNotify(t, d, "codex")
-	ticketID := boundTicketID(t, d, agentID)
-	if _, err := ticketnotify.ConsumeAll(d.store, d.ticketObserversForSession(chiefID), time.Now()); err != nil {
-		t.Fatal(err)
-	}
-	attentionAt := time.Now().Add(-10 * time.Minute)
-	if err := d.store.SetTicketDeliveryAttention(d.ticketAttentionKey(chiefID), attentionAt); err != nil {
-		t.Fatal(err)
-	}
-	d.setSelectedSession(chiefID)
-	commentOnTicket(t, d, ticketID, "buffer this")
-	if deadline := currentNudgeDeadline(d, chiefID); !deadline.IsZero() {
-		t.Fatalf("selected chief armed deadline %s", deadline)
-	}
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		d.nudgeWindowOverride = time.Second
+		d.ticketBufferWindowOverride = time.Hour
+		stopDaemonBackground(t, d)
+		chiefID, agentID, _ := delegateForNotify(t, d, "codex")
+		ticketID := boundTicketID(t, d, agentID)
+		if _, err := ticketnotify.ConsumeAll(d.store, d.ticketObserversForSession(chiefID), time.Now()); err != nil {
+			t.Fatal(err)
+		}
+		attentionAt := time.Now().Add(-10 * time.Minute)
+		if err := d.store.SetTicketDeliveryAttention(d.ticketAttentionKey(chiefID), attentionAt); err != nil {
+			t.Fatal(err)
+		}
+		d.setSelectedSession(chiefID)
+		commentOnTicket(t, d, ticketID, "buffer this")
+		if deadline := currentNudgeDeadline(d, chiefID); !deadline.IsZero() {
+			t.Fatalf("selected chief armed deadline %s", deadline)
+		}
 
-	d.setSelectedSession(agentID)
-	deadline := waitForNudgeDeadline(t, d, chiefID)
-	want := attentionAt.Add(time.Hour)
-	// Store timestamps use RFC3339 second precision, so the durable round-trip
-	// may trim the sub-second component.
-	if delta := deadline.Sub(want); delta < -time.Second || delta > time.Second {
-		t.Fatalf("resumed deadline = %s, want %s", deadline, want)
-	}
+		d.setSelectedSession(agentID)
+		deadline := settledNudgeDeadline(t, d, chiefID)
+		want := attentionAt.Add(time.Hour)
+		// Store timestamps use RFC3339 second precision, so the durable round-trip
+		// may trim the sub-second component.
+		if delta := deadline.Sub(want); delta < -time.Second || delta > time.Second {
+			t.Fatalf("resumed deadline = %s, want %s", deadline, want)
+		}
+	})
 }
 
 func TestRebuildTicketDeliverySchedulesRearmsUnread(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.nudgeWindowOverride = time.Hour
-	t.Cleanup(d.stopNudgeCountdowns)
-	_, agentID, _ := delegateForNotify(t, d, "codex")
-	ticketID := boundTicketID(t, d, agentID)
-	d.store.UpdateState(agentID, protocol.StateIdle)
-	commentOnTicket(t, d, ticketID, "survive restart")
-	d.cancelNudgeCountdown(agentID, "simulate daemon restart")
-	if currentNudgeTimer(d, agentID) != nil {
-		t.Fatal("countdown still armed before rebuild")
-	}
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		d.nudgeWindowOverride = time.Hour
+		stopDaemonBackground(t, d)
+		_, agentID, _ := delegateForNotify(t, d, "codex")
+		ticketID := boundTicketID(t, d, agentID)
+		d.store.UpdateState(agentID, protocol.StateIdle)
+		commentOnTicket(t, d, ticketID, "survive restart")
+		d.cancelNudgeCountdown(agentID, "simulate daemon restart")
+		if currentNudgeTimer(d, agentID) != nil {
+			t.Fatal("countdown still armed before rebuild")
+		}
 
-	d.rebuildTicketDeliverySchedules()
-	waitForNudgeDeadline(t, d, agentID)
+		d.rebuildTicketDeliverySchedules()
+		settledNudgeDeadline(t, d, agentID)
+	})
 }
 
 // Switching TO a session with a running countdown pauses it (no auto-fire while the

--- a/internal/daemon/periodic_cron_test.go
+++ b/internal/daemon/periodic_cron_test.go
@@ -1,8 +1,8 @@
 package daemon
 
 import (
-	"path/filepath"
 	"testing"
+	"testing/synctest"
 
 	"github.com/victorarias/attn/internal/jobs"
 )
@@ -12,33 +12,43 @@ import (
 // They are cron entries on the job queue now, so startJobQueue is what arms
 // them: if this breaks, nothing ticks and nothing says so.
 func TestStartJobQueueArmsThePeriodicTicks(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.store.SetSetting(SettingNotebookRoot, t.TempDir())
-	d.startJobQueue()
-	runner := d.jobQueueRef()
-	t.Cleanup(runner.Stop)
+	d := newBubbleDaemon(t)
+	notebookRoot := t.TempDir()
+	// In a bubble because arming is asynchronous: startJobQueue hands the two cron
+	// entries to the runner, whose dispatch goroutine writes them. Reading the
+	// entries straight afterwards used to be a race the test won on an idle
+	// machine and lost under full-suite load, reported as "notebook_cron is not
+	// armed". synctest.Wait returns only once that goroutine has parked, so the
+	// read happens after the write by construction.
+	synctest.Test(t, func(t *testing.T) {
+		d.store.SetSetting(SettingNotebookRoot, notebookRoot)
+		d.startJobQueue()
+		runner := d.jobQueueRef()
+		t.Cleanup(runner.Stop)
+		synctest.Wait()
 
-	for _, kind := range []string{notebookCronKind, automationScheduleKind} {
-		entry, err := runner.CronEntry(kind)
+		for _, kind := range []string{notebookCronKind, automationScheduleKind} {
+			entry, err := runner.CronEntry(kind)
+			if err != nil {
+				t.Fatalf("cron entry for %s: %v", kind, err)
+			}
+			if entry == nil {
+				t.Fatalf("%s is not armed", kind)
+			}
+			if entry.State != jobs.StateQueued {
+				t.Fatalf("%s entry state = %s, want queued", kind, entry.State)
+			}
+		}
+
+		// The panel lists work the daemon owes, so the two heartbeats must not be in it.
+		list, err := runner.List()
 		if err != nil {
-			t.Fatalf("cron entry for %s: %v", kind, err)
+			t.Fatalf("list: %v", err)
 		}
-		if entry == nil {
-			t.Fatalf("%s is not armed", kind)
+		for _, job := range list {
+			if job.Kind == notebookCronKind || job.Kind == automationScheduleKind {
+				t.Fatalf("the work list included the %s heartbeat: %+v", job.Kind, job)
+			}
 		}
-		if entry.State != jobs.StateQueued {
-			t.Fatalf("%s entry state = %s, want queued", kind, entry.State)
-		}
-	}
-
-	// The panel lists work the daemon owes, so the two heartbeats must not be in it.
-	list, err := runner.List()
-	if err != nil {
-		t.Fatalf("list: %v", err)
-	}
-	for _, job := range list {
-		if job.Kind == notebookCronKind || job.Kind == automationScheduleKind {
-			t.Fatalf("the work list included the %s heartbeat: %+v", job.Kind, job)
-		}
-	}
+	})
 }

--- a/internal/daemon/snooze_test.go
+++ b/internal/daemon/snooze_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
@@ -178,76 +179,97 @@ func TestSnoozingAWorkingAgentSuppressesTheTurnItWouldOpen(t *testing.T) {
 // comes back — the worst failure a deferral can have.
 func TestSnoozeWakesAfterARestart(t *testing.T) {
 	d := newTurnDaemon(t)
-	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
 
-	moveTo(d, "s1", protocol.StateIdle)
-	// Written straight to the store, which is the state a restart finds: the
-	// deadline persisted, and no timer in memory to fire on it. Letting it lapse
-	// before the reschedule is the daemon having been down across it.
-	now := time.Now()
-	deadline := now.Add(10 * time.Millisecond)
-	if !d.store.SnoozeTurn("s1", deadline, now) {
-		t.Fatal("setup: the snooze was not stored")
-	}
-	time.Sleep(30 * time.Millisecond)
-	if owed(t, d, "s1") {
-		t.Fatal("setup: the session is not deferred")
-	}
+		moveTo(d, "s1", protocol.StateIdle)
+		// Written straight to the store, which is the state a restart finds: the
+		// deadline persisted, and no timer in memory to fire on it. Letting it lapse
+		// before the reschedule is the daemon having been down across it — an hour
+		// of downtime here costs no wall-clock time.
+		now := time.Now()
+		if !d.store.SnoozeTurn("s1", now.Add(time.Minute), now) {
+			t.Fatal("setup: the snooze was not stored")
+		}
+		time.Sleep(time.Hour)
+		if owed(t, d, "s1") {
+			t.Fatal("setup: the session is not deferred")
+		}
 
-	woken := make(chan string, 1)
-	d.snoozeWakeHook = func(sessionID string) { woken <- sessionID }
-	d.rescheduleSnoozeWakes()
+		woken := make(chan string, 1)
+		d.snoozeWakeHook = func(sessionID string) { woken <- sessionID }
+		d.rescheduleSnoozeWakes()
 
-	select {
-	case <-woken:
-	case <-time.After(2 * time.Second):
-		t.Fatal("the lapsed snooze never woke after the reschedule")
-	}
-	if !owed(t, d, "s1") {
-		t.Error("the woken session owes no turn although it is sitting idle")
-	}
+		synctest.Wait()
+		select {
+		case <-woken:
+		default:
+			t.Fatal("the lapsed snooze never woke after the reschedule")
+		}
+		if !owed(t, d, "s1") {
+			t.Error("the woken session owes no turn although it is sitting idle")
+		}
+	})
 }
 
 func TestSnoozeTimerFiresOnItsDeadline(t *testing.T) {
 	d := newTurnDaemon(t)
-	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
 
-	moveTo(d, "s1", protocol.StateWaitingInput)
-	woken := make(chan string, 1)
-	d.snoozeWakeHook = func(sessionID string) { woken <- sessionID }
+		moveTo(d, "s1", protocol.StateWaitingInput)
+		woken := make(chan string, 1)
+		d.snoozeWakeHook = func(sessionID string) { woken <- sessionID }
 
-	snoozeUntil(d, "s1", time.Now().Add(20*time.Millisecond))
-	if owed(t, d, "s1") {
-		t.Fatal("the session still owes a turn immediately after snoozing")
-	}
+		snoozeUntil(d, "s1", time.Now().Add(time.Hour))
+		if owed(t, d, "s1") {
+			t.Fatal("the session still owes a turn immediately after snoozing")
+		}
 
-	select {
-	case <-woken:
-	case <-time.After(2 * time.Second):
-		t.Fatal("the snooze timer never fired")
-	}
-	if !owed(t, d, "s1") {
-		t.Error("the session owes no turn after its snooze elapsed")
-	}
+		// The deadline itself, at its real length: the AfterFunc the snooze armed
+		// fires when the bubble's clock reaches it, not when a test-sized window
+		// happens to elapse.
+		time.Sleep(time.Hour)
+		synctest.Wait()
+		select {
+		case <-woken:
+		default:
+			t.Fatal("the snooze timer never fired")
+		}
+		if !owed(t, d, "s1") {
+			t.Error("the session owes no turn after its snooze elapsed")
+		}
+	})
 }
 
 // Re-snoozing to a later deadline must not be woken by the timer the first
 // snooze armed.
+// Converted to synctest. The claim is a negative — the first snooze's timer must
+// not wake the session — and a 200ms sleep could only make it likely. The bubble
+// runs the superseded deadline's whole window and then settles, so "it did not
+// wake" is a fact about a daemon with nothing left to do.
 func TestResnoozingReplacesThePendingWake(t *testing.T) {
 	d := newTurnDaemon(t)
-	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
-	moveTo(d, "s1", protocol.StateWaitingInput)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+		moveTo(d, "s1", protocol.StateWaitingInput)
 
-	snoozeUntil(d, "s1", time.Now().Add(20*time.Millisecond))
-	snoozeUntil(d, "s1", time.Now().Add(time.Hour))
+		snoozeUntil(d, "s1", time.Now().Add(time.Minute))
+		snoozeUntil(d, "s1", time.Now().Add(time.Hour))
 
-	time.Sleep(200 * time.Millisecond)
-	if owed(t, d, "s1") {
-		t.Error("the superseded timer woke a session that had been re-snoozed for an hour")
-	}
-	if snoozedUntil(t, d, "s1") == "" {
-		t.Error("the superseded timer cleared the live deadline")
-	}
+		// Well past the superseded deadline, and still well short of the live one.
+		time.Sleep(30 * time.Minute)
+		synctest.Wait()
+		if owed(t, d, "s1") {
+			t.Error("the superseded timer woke a session that had been re-snoozed for an hour")
+		}
+		if snoozedUntil(t, d, "s1") == "" {
+			t.Error("the superseded timer cleared the live deadline")
+		}
+	})
 }
 
 // The narrow window the timer's identity check cannot cover: the wake has
@@ -261,44 +283,49 @@ func TestResnoozingReplacesThePendingWake(t *testing.T) {
 // and never comes back again.
 func TestAResnoozeInsideAFiringWakeKeepsTheLaterDeadline(t *testing.T) {
 	d := newTurnDaemon(t)
-	addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
-	moveTo(d, "s1", protocol.StateWaitingInput)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		addTurnSession(t, d, "s1", protocol.SessionAgentCodex, "ws1")
+		moveTo(d, "s1", protocol.StateWaitingInput)
 
-	later := time.Now().Add(time.Hour)
-	var once bool
-	d.snoozeWakeGapHook = func(sessionID string) {
-		if once {
-			return // the replacement's own wake, an hour from now, must not recurse
+		later := time.Now().Add(time.Hour)
+		var once bool
+		d.snoozeWakeGapHook = func(sessionID string) {
+			if once {
+				return // the replacement's own wake, an hour from now, must not recurse
+			}
+			once = true
+			snoozeUntil(d, sessionID, later)
 		}
-		once = true
-		snoozeUntil(d, sessionID, later)
-	}
-	woken := make(chan string, 1)
-	d.snoozeWakeHook = func(sessionID string) { woken <- sessionID }
+		woken := make(chan string, 1)
+		d.snoozeWakeHook = func(sessionID string) { woken <- sessionID }
 
-	snoozeUntil(d, "s1", time.Now().Add(20*time.Millisecond))
-	select {
-	case <-woken:
-	case <-time.After(2 * time.Second):
-		t.Fatal("the first snooze's timer never fired")
-	}
+		snoozeUntil(d, "s1", time.Now().Add(time.Minute))
+		time.Sleep(time.Minute)
+		synctest.Wait()
+		select {
+		case <-woken:
+		default:
+			t.Fatal("the first snooze's timer never fired")
+		}
 
-	if owed(t, d, "s1") {
-		t.Error("the expired timer cashed a promise the user had already replaced")
-	}
-	if got := snoozedUntil(t, d, "s1"); got != later.UTC().Format(time.RFC3339Nano) {
-		t.Errorf("live deadline = %q, want the re-snooze's %q", got, later.UTC().Format(time.RFC3339Nano))
-	}
-	// And the replacement's own timer is still armed, so it does come back.
-	d.snoozeMu.Lock()
-	pending, ok := d.snoozeTimers["s1"]
-	d.snoozeMu.Unlock()
-	if !ok {
-		t.Fatal("the expired timer took the replacement's wake with it; the agent would never return")
-	}
-	if !pending.firesAt.Equal(later) {
-		t.Errorf("pending wake fires at %s, want the re-snooze's %s", pending.firesAt, later)
-	}
+		if owed(t, d, "s1") {
+			t.Error("the expired timer cashed a promise the user had already replaced")
+		}
+		if got := snoozedUntil(t, d, "s1"); got != later.UTC().Format(time.RFC3339Nano) {
+			t.Errorf("live deadline = %q, want the re-snooze's %q", got, later.UTC().Format(time.RFC3339Nano))
+		}
+		// And the replacement's own timer is still armed, so it does come back.
+		d.snoozeMu.Lock()
+		pending, ok := d.snoozeTimers["s1"]
+		d.snoozeMu.Unlock()
+		if !ok {
+			t.Fatal("the expired timer took the replacement's wake with it; the agent would never return")
+		}
+		if !pending.firesAt.Equal(later) {
+			t.Errorf("pending wake fires at %s, want the re-snooze's %s", pending.firesAt, later)
+		}
+	})
 }
 
 // A snooze arriving mid-countdown makes the pending auto-settle moot: the turn

--- a/internal/daemon/synctest_test.go
+++ b/internal/daemon/synctest_test.go
@@ -1,0 +1,55 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// Support for running daemon tests inside a `testing/synctest` bubble, where
+// time.Now is a fake clock that advances only when every goroutine in the bubble
+// is durably blocked. Two rules make a daemon fit inside one, and both are
+// consequences of the same thing — the bubble is the boundary.
+//
+// 1. Build the daemon OUTSIDE the bubble. store.New opens a database/sql handle,
+//    whose connectionOpener goroutine lives as long as the DB; opened inside, it
+//    joins the bubble and never exits, and synctest reports a deadlock even
+//    though the test passed.
+//
+// 2. Stop the daemon's background subsystems from INSIDE it. Watchers, timers
+//    and countdowns started by the code under test are bubble goroutines; a
+//    watcher still parked on its select when the test body returns is reported
+//    as "blocked goroutines remain".
+//
+// 3. Seed anything time-stamped INSIDE the bubble. The bubble's clock starts at
+//    2000-01-01, so a row a fixture stamps with time.Now outside it is dated
+//    decades in the future. A turn opened outside and settled inside settles
+//    BEFORE it opened, and reads as still owed.
+//
+// What cannot come inside at all: a real socket, a real PTY, a child process, an
+// fsnotify watcher. A goroutine blocked on a real file descriptor is not
+// durably blocked, so the fake clock never advances and the bubble hangs. Those
+// tests keep their poll helpers.
+
+// newBubbleDaemon builds a daemon for a synctest bubble. Call it ABOVE
+// synctest.Test with the outer T — see rule 1.
+func newBubbleDaemon(t *testing.T) *Daemon {
+	t.Helper()
+	return NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+}
+
+// stopDaemonBackground registers a cleanup that stops every daemon subsystem
+// owning a goroutine or a timer. Call it INSIDE the bubble with the bubble's T,
+// whose cleanups run inside the bubble — see rule 2. It mirrors the subsystem
+// list in Daemon.Stop, minus everything that only a started daemon owns
+// (listener, HTTP server, PID lock).
+func stopDaemonBackground(t *testing.T, d *Daemon) {
+	t.Helper()
+	t.Cleanup(func() {
+		d.stopAllTranscriptWatchers()
+		d.stopNudgeCountdowns()
+		d.stopAutoSettleTimers()
+		d.stopSnoozeTimers()
+		d.stopNotebookWatcher()
+		d.stopFsWatchers()
+	})
+}

--- a/internal/daemon/ticket_notify_test.go
+++ b/internal/daemon/ticket_notify_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
@@ -195,34 +196,36 @@ func TestCodexNudgeRoundtrip(t *testing.T) {
 // Approval prompts are the sole deferral state. Once the prompt clears, unread
 // activity is rechecked and armed even when the agent returns to active/green.
 func TestNotifyDefersPendingApprovalThenFlushesOnWorking(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.nudgeWindowOverride = time.Hour
-	t.Cleanup(d.stopNudgeCountdowns)
-	_, agentID, inputs := delegateForNotify(t, d, "codex")
-	ticketID := boundTicketID(t, d, agentID)
-	d.store.UpdateState(agentID, protocol.StatePendingApproval)
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		_, agentID, inputs := delegateForNotify(t, d, "codex")
+		ticketID := boundTicketID(t, d, agentID)
+		d.store.UpdateState(agentID, protocol.StatePendingApproval)
 
-	commentOnTicket(t, d, ticketID, "take a look")
-	if wasNudged(inputs(agentID)) {
-		t.Fatal("approval-waiting codex agent was nudged")
-	}
-	if currentNudgeTimer(d, agentID) != nil {
-		t.Fatal("approval-waiting codex agent armed a countdown")
-	}
+		commentOnTicket(t, d, ticketID, "take a look")
+		if wasNudged(inputs(agentID)) {
+			t.Fatal("approval-waiting codex agent was nudged")
+		}
+		if currentNudgeTimer(d, agentID) != nil {
+			t.Fatal("approval-waiting codex agent armed a countdown")
+		}
 
-	d.applyState(sessionStateChange{
-		sessionID: agentID,
-		state:     protocol.StateWorking,
-		cause:     resolverObservation{},
+		d.applyState(sessionStateChange{
+			sessionID: agentID,
+			state:     protocol.StateWorking,
+			cause:     resolverObservation{},
+		})
+		// The countdown the cleared approval arms, run at its production length
+		// rather than hand-fired: what the user gets is a doorbell one window
+		// after the prompt clears, and that is what is asserted.
+		settledNudgeDeadline(t, d, agentID)
+		time.Sleep(defaultNudgeCountdownWindow)
+		synctest.Wait()
+		if !wasNudged(inputs(agentID)) {
+			t.Fatal("deferred nudge was not flushed when approval cleared")
+		}
 	})
-	deadline := time.Now().Add(time.Second)
-	for currentNudgeTimer(d, agentID) == nil && time.Now().Before(deadline) {
-		time.Sleep(time.Millisecond)
-	}
-	fireNudgeNow(t, d, agentID)
-	if !wasNudged(inputs(agentID)) {
-		t.Fatal("deferred nudge was not flushed when approval cleared")
-	}
 }
 
 // A chief that fans work out to siblings must not cross-wire their doorbells: when
@@ -292,26 +295,26 @@ func commentOnTicket(t *testing.T, d *Daemon, ticketID, comment string) {
 func TestTicketNudgesActiveChiefAcrossRuntimes(t *testing.T) {
 	for _, runtime := range []protocol.SessionAgent{protocol.SessionAgentCodex, protocol.SessionAgentClaude} {
 		t.Run(string(runtime), func(t *testing.T) {
-			d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-			d.nudgeWindowOverride = time.Hour
-			t.Cleanup(d.stopNudgeCountdowns)
-			chiefID, agentID, inputs := delegateForNotify(t, d, "codex")
-			setSessionAgent(t, d, chiefID, runtime)
-			d.store.UpdateState(chiefID, protocol.StateWorking)
-			d.setSelectedSession(agentID) // preserve the focused-session anti-splice pause
+			d := newBubbleDaemon(t)
+			synctest.Test(t, func(t *testing.T) {
+				stopDaemonBackground(t, d)
+				chiefID, agentID, inputs := delegateForNotify(t, d, "codex")
+				setSessionAgent(t, d, chiefID, runtime)
+				d.store.UpdateState(chiefID, protocol.StateWorking)
+				d.setSelectedSession(agentID) // preserve the focused-session anti-splice pause
 
-			callSetTicketStatus(t, d, agentID, string(protocol.DispatchWorkStateReadyForReview), "done, please review")
-			deadline := time.Now().Add(time.Second)
-			for currentNudgeTimer(d, chiefID) == nil && time.Now().Before(deadline) {
-				time.Sleep(time.Millisecond)
-			}
-			fireNudgeNow(t, d, chiefID)
-			if !wasNudged(inputs(chiefID)) {
-				t.Fatalf("active %s chief was not nudged", runtime)
-			}
-			if wasNudged(inputs(agentID)) {
-				t.Fatal("the reporting agent was nudged about its own status change")
-			}
+				callSetTicketStatus(t, d, agentID, string(protocol.DispatchWorkStateReadyForReview), "done, please review")
+				// The chief's own countdown, run out at whatever length the policy
+				// picked for it instead of hand-fired.
+				time.Sleep(time.Until(settledNudgeDeadline(t, d, chiefID)) + time.Second)
+				synctest.Wait()
+				if !wasNudged(inputs(chiefID)) {
+					t.Fatalf("active %s chief was not nudged", runtime)
+				}
+				if wasNudged(inputs(agentID)) {
+					t.Fatal("the reporting agent was nudged about its own status change")
+				}
+			})
 		})
 	}
 }
@@ -320,6 +323,13 @@ func TestTicketNudgesActiveChiefAcrossRuntimes(t *testing.T) {
 // delegate. A consumes one report, the role transfers to B, and the next report
 // reaches only B. The role cursor means B receives exactly the post-transfer
 // unread event: nothing A consumed is replayed and nothing new is skipped.
+// Left unconverted deliberately. Mechanically this test fits in a bubble, but its
+// windows are parked (nudgeWindowOverride) and its final assertion only holds
+// while they are: run the nudge window out for real and the retired chief is
+// doorbelled too, because delegateForNotify leaves it a personal participant on
+// the ticket and nudgeCount cannot tell a personal nudge from a role one. Making
+// it honest means either a narrower probe or a product answer about what a
+// retired chief still hears, and both are outside a test-only sweep.
 func TestChiefTicketContinuityAcrossRoleTransfer(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.nudgeWindowOverride = time.Hour

--- a/internal/jobs/cron_test.go
+++ b/internal/jobs/cron_test.go
@@ -66,39 +66,46 @@ func TestACronEntryFiresOnItsIntervalAndRearms(t *testing.T) {
 // A failing fire never retires the entry: it records the error and stays armed,
 // because a heartbeat that gives up is a silent outage.
 func TestAFailingCronEntryStaysArmed(t *testing.T) {
-	r, _, clock := newTestRunner(t, func(o *Options) { o.MaxAttempts = 1 })
-	var fires atomic.Int64
-	if err := r.RegisterCron(cronKind, time.Minute, func(context.Context, *Job) (any, error) {
-		fires.Add(1)
-		return nil, errors.New("tick failed")
-	}, HandlerConfig{}); err != nil {
-		t.Fatalf("register cron: %v", err)
-	}
-	mustStart(t, r)
+	synctest.Test(t, func(t *testing.T) {
+		r, _ := newBubbleRunner(t, func(o *Options) { o.MaxAttempts = 1 })
+		var fires atomic.Int64
+		if err := r.RegisterCron(cronKind, time.Minute, func(context.Context, *Job) (any, error) {
+			fires.Add(1)
+			return nil, errors.New("tick failed")
+		}, HandlerConfig{}); err != nil {
+			t.Fatalf("register cron: %v", err)
+		}
+		mustStart(t, r)
 
-	// The handler counts its fire on entry, so counting to `want` says the fire
-	// started, not that it finished and re-armed. Wait for the re-arm before
-	// advancing again: the next fire is scheduled an interval past the moment the
-	// last one finished, so advancing first would push the schedule out from under
-	// the very clock move meant to trigger it.
-	for want := int64(1); want <= 3; want++ {
-		clock.advance(time.Minute)
-		waitFor(t, "the failing cron entry to fire", func() bool { return fires.Load() == want })
-		waitFor(t, "the failing cron entry to re-arm", func() bool {
+		// Three intervals at their real length. synctest.Wait settles each fire and
+		// its re-arm before the clock moves again, so the sequencing the fake-clock
+		// version had to reason about explicitly — never advance past a schedule the
+		// last fire has not written yet — is now a property of the bubble.
+		for want := int64(1); want <= 3; want++ {
+			time.Sleep(time.Minute)
+			synctest.Wait()
+			if got := fires.Load(); got != want {
+				t.Fatalf("cron fired %d times after %d intervals, want %d", got, want, want)
+			}
 			next, err := r.CronEntry(cronKind)
-			return err == nil && next != nil && next.State == StateQueued && next.ScheduledAt.After(clock.now())
-		})
-	}
-	entry, err := r.CronEntry(cronKind)
-	if err != nil || entry == nil {
-		t.Fatalf("cron entry: %v (%+v)", err, entry)
-	}
-	if entry.State != StateQueued {
-		t.Fatalf("failing cron entry state = %s, want queued (attempt cap must not retire it)", entry.State)
-	}
-	if entry.LastError != "tick failed" {
-		t.Fatalf("failing cron entry last_error = %q, want the fire's error", entry.LastError)
-	}
+			if err != nil || next == nil {
+				t.Fatalf("cron entry after fire %d: %v (%+v)", want, err, next)
+			}
+			if next.State != StateQueued || !next.ScheduledAt.After(time.Now()) {
+				t.Fatalf("cron entry did not re-arm after fire %d: state %s scheduled %s", want, next.State, next.ScheduledAt)
+			}
+		}
+		entry, err := r.CronEntry(cronKind)
+		if err != nil || entry == nil {
+			t.Fatalf("cron entry: %v (%+v)", err, entry)
+		}
+		if entry.State != StateQueued {
+			t.Fatalf("failing cron entry state = %s, want queued (attempt cap must not retire it)", entry.State)
+		}
+		if entry.LastError != "tick failed" {
+			t.Fatalf("failing cron entry last_error = %q, want the fire's error", entry.LastError)
+		}
+	})
 }
 
 // A restart re-registers the same cron kind against a store that already holds
@@ -149,60 +156,62 @@ func TestRestartKeepsAnExistingCronSchedule(t *testing.T) {
 // row and List hides cron entries, so unless arming revives it the heartbeat is
 // gone for good — silently — even after the kind comes back.
 func TestArmingRevivesACronEntryAPriorBuildKilled(t *testing.T) {
-	store := newMemStore()
-	clock := newFakeClock()
-	opts := func() Options {
-		return Options{Store: store, Now: clock.now, PollInterval: testPoll, Log: func(string, ...interface{}) {}}
-	}
-	noop := func(context.Context, *Job) (any, error) { return nil, nil }
+	synctest.Test(t, func(t *testing.T) {
+		store := newMemStore()
+		opts := func() Options {
+			return Options{Store: store, Log: func(string, ...any) {}}
+		}
+		noop := func(context.Context, *Job) (any, error) { return nil, nil }
 
-	armed := New(opts())
-	if err := armed.RegisterCron(cronKind, time.Hour, noop, HandlerConfig{}); err != nil {
-		t.Fatalf("register cron: %v", err)
-	}
-	mustStart(t, armed)
-	armed.Stop()
+		armed := New(opts())
+		if err := armed.RegisterCron(cronKind, time.Hour, noop, HandlerConfig{}); err != nil {
+			t.Fatalf("register cron: %v", err)
+		}
+		mustStart(t, armed)
+		armed.Stop()
 
-	// A build with no handler for the kind: the due entry is retired.
-	clock.advance(2 * time.Hour)
-	stranger := New(opts())
-	if err := stranger.Register("something-else", noop); err != nil {
-		t.Fatalf("register other kind: %v", err)
-	}
-	mustStart(t, stranger)
-	waitFor(t, "the unregistered cron entry to be retired", func() bool {
-		j, _ := store.LoadByKey(cronKind, CronKey)
-		return j != nil && j.State.Terminal()
+		// A build with no handler for the kind: the due entry is retired.
+		time.Sleep(2 * time.Hour)
+		stranger := New(opts())
+		if err := stranger.Register("something-else", noop); err != nil {
+			t.Fatalf("register other kind: %v", err)
+		}
+		mustStart(t, stranger)
+		synctest.Wait()
+		if j, _ := store.LoadByKey(cronKind, CronKey); j == nil || !j.State.Terminal() {
+			t.Fatalf("the unregistered cron entry was not retired (%+v)", j)
+		}
+		stranger.Stop()
+
+		// The kind is back. The heartbeat must be beating again.
+		time.Sleep(2 * time.Hour)
+		fired := make(chan struct{}, 4)
+		revived := New(opts())
+		if err := revived.RegisterCron(cronKind, time.Hour, func(context.Context, *Job) (any, error) {
+			fired <- struct{}{}
+			return nil, nil
+		}, HandlerConfig{}); err != nil {
+			t.Fatalf("re-register cron: %v", err)
+		}
+		mustStart(t, revived)
+		t.Cleanup(revived.Stop)
+
+		entry, err := revived.CronEntry(cronKind)
+		if err != nil || entry == nil {
+			t.Fatalf("cron entry after revive: %v (%+v)", err, entry)
+		}
+		if entry.State.Terminal() {
+			t.Fatalf("cron entry left in a terminal state (%s); the heartbeat is dead for good", entry.State)
+		}
+		time.Sleep(time.Hour)
+		synctest.Wait()
+		select {
+		case <-fired:
+		default:
+			j, _ := store.LoadByKey(cronKind, CronKey)
+			t.Fatalf("the revived cron entry never fired; it sits at state=%q scheduled=%s", j.State, j.ScheduledAt)
+		}
 	})
-	stranger.Stop()
-
-	// The kind is back. The heartbeat must be beating again.
-	clock.advance(2 * time.Hour)
-	fired := make(chan struct{}, 4)
-	revived := New(opts())
-	if err := revived.RegisterCron(cronKind, time.Hour, func(context.Context, *Job) (any, error) {
-		fired <- struct{}{}
-		return nil, nil
-	}, HandlerConfig{}); err != nil {
-		t.Fatalf("re-register cron: %v", err)
-	}
-	mustStart(t, revived)
-	t.Cleanup(revived.Stop)
-
-	entry, err := revived.CronEntry(cronKind)
-	if err != nil || entry == nil {
-		t.Fatalf("cron entry after revive: %v (%+v)", err, entry)
-	}
-	if entry.State.Terminal() {
-		t.Fatalf("cron entry left in a terminal state (%s); the heartbeat is dead for good", entry.State)
-	}
-	clock.advance(time.Hour)
-	select {
-	case <-fired:
-	case <-time.After(2 * time.Second):
-		j, _ := store.LoadByKey(cronKind, CronKey)
-		t.Fatalf("the revived cron entry never fired; it sits at state=%q scheduled=%s", j.State, j.ScheduledAt)
-	}
 }
 
 // Enqueueing ordinary work onto a recurring kind would mint a second record that
@@ -284,24 +293,31 @@ func TestListExcludesCronEntries(t *testing.T) {
 // reporting: routing it through the change hook would publish a durable event and
 // re-push a snapshot every minute for as long as the daemon runs.
 func TestCronFiringDoesNotReportAChange(t *testing.T) {
-	r, _, clock := newTestRunner(t, nil)
-	var changes atomic.Int64
-	r.OnChange(func(string) { changes.Add(1) })
-	var fires atomic.Int64
-	if err := r.RegisterCron(cronKind, time.Minute, func(context.Context, *Job) (any, error) {
-		fires.Add(1)
-		return nil, nil
-	}, HandlerConfig{}); err != nil {
-		t.Fatalf("register cron: %v", err)
-	}
-	mustStart(t, r)
+	synctest.Test(t, func(t *testing.T) {
+		r, _ := newBubbleRunner(t, nil)
+		var changes atomic.Int64
+		r.OnChange(func(string) { changes.Add(1) })
+		var fires atomic.Int64
+		if err := r.RegisterCron(cronKind, time.Minute, func(context.Context, *Job) (any, error) {
+			fires.Add(1)
+			return nil, nil
+		}, HandlerConfig{}); err != nil {
+			t.Fatalf("register cron: %v", err)
+		}
+		mustStart(t, r)
 
-	clock.advance(time.Minute)
-	waitFor(t, "the cron entry to fire", func() bool { return fires.Load() == 1 })
-	clock.advance(time.Minute)
-	waitFor(t, "the cron entry to fire again", func() bool { return fires.Load() == 2 })
+		for want := int64(1); want <= 2; want++ {
+			time.Sleep(time.Minute)
+			synctest.Wait()
+			if got := fires.Load(); got != want {
+				t.Fatalf("cron fired %d times after %d intervals, want %d", got, want, want)
+			}
+		}
 
-	if got := changes.Load(); got != 0 {
-		t.Fatalf("cron firing reported %d change(s), want 0", got)
-	}
+		// The negative that matters: no change was reported, on a system that has
+		// nothing left to do rather than one that has merely not got round to it.
+		if got := changes.Load(); got != 0 {
+			t.Fatalf("cron firing reported %d change(s), want 0", got)
+		}
+	})
 }

--- a/internal/jobs/runner_test.go
+++ b/internal/jobs/runner_test.go
@@ -57,21 +57,6 @@ func newBubbleRunner(t *testing.T, tune func(*Options)) (*Runner, *memStore) {
 	return r, store
 }
 
-// waitFor polls cond until it holds or the deadline passes. Every wait in this
-// file is on the dispatch loop reacting, never on wall-clock duration under
-// test, so a generous deadline costs nothing when things work.
-func waitFor(t *testing.T, what string, cond func() bool) {
-	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		if cond() {
-			return
-		}
-		time.Sleep(testPoll)
-	}
-	t.Fatalf("timed out waiting for %s", what)
-}
-
 func mustStart(t *testing.T, r *Runner) {
 	t.Helper()
 	if err := r.Start(); err != nil {
@@ -99,168 +84,189 @@ func mustGet(t *testing.T, r *Runner, id string) *Job {
 }
 
 func TestRunsAJobAndPersistsItsResult(t *testing.T) {
-	r, _, _ := newTestRunner(t, nil)
-	type in struct {
-		Name string `json:"name"`
-	}
-	var seen in
-	mustRegister(t, r, "greet", func(_ context.Context, job *Job) (any, error) {
-		if err := job.DecodePayload(&seen); err != nil {
-			return nil, err
+	synctest.Test(t, func(t *testing.T) {
+		r, _ := newBubbleRunner(t, nil)
+		type in struct {
+			Name string `json:"name"`
 		}
-		return map[string]string{"greeting": "hello " + seen.Name}, nil
-	})
-	mustStart(t, r)
+		var seen in
+		mustRegister(t, r, "greet", func(_ context.Context, job *Job) (any, error) {
+			if err := job.DecodePayload(&seen); err != nil {
+				return nil, err
+			}
+			return map[string]string{"greeting": "hello " + seen.Name}, nil
+		})
+		mustStart(t, r)
 
-	job, err := r.Enqueue("greet", EnqueueOptions{Payload: in{Name: "victor"}})
-	if err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	waitFor(t, "the job to finish", func() bool {
-		return mustGet(t, r, job.ID).State == StateDone
-	})
+		job, err := r.Enqueue("greet", EnqueueOptions{Payload: in{Name: "victor"}})
+		if err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		synctest.Wait()
 
-	done := mustGet(t, r, job.ID)
-	if seen.Name != "victor" {
-		t.Errorf("handler saw payload name %q, want victor", seen.Name)
-	}
-	if got, want := string(done.Result), `{"greeting":"hello victor"}`; got != want {
-		t.Errorf("persisted result = %s, want %s", got, want)
-	}
-	if done.Attempts != 1 {
-		t.Errorf("attempts = %d, want 1", done.Attempts)
-	}
+		done := mustGet(t, r, job.ID)
+		if done.State != StateDone {
+			t.Fatalf("state after dispatch settled = %s, want done", done.State)
+		}
+		if seen.Name != "victor" {
+			t.Errorf("handler saw payload name %q, want victor", seen.Name)
+		}
+		if got, want := string(done.Result), `{"greeting":"hello victor"}`; got != want {
+			t.Errorf("persisted result = %s, want %s", got, want)
+		}
+		if done.Attempts != 1 {
+			t.Errorf("attempts = %d, want 1", done.Attempts)
+		}
+	})
 }
 
 func TestJobsWithoutAUniqueKeyAreDistinct(t *testing.T) {
-	r, store, _ := newTestRunner(t, nil)
-	var mu sync.Mutex
-	var payloads []string
-	release := make(chan struct{})
-	if err := r.RegisterWith("activity", func(_ context.Context, job *Job) (any, error) {
-		var arg string
-		if err := job.DecodePayload(&arg); err != nil {
-			return nil, err
+	synctest.Test(t, func(t *testing.T) {
+		r, store := newBubbleRunner(t, nil)
+		var mu sync.Mutex
+		var payloads []string
+		release := make(chan struct{})
+		if err := r.RegisterWith("activity", func(_ context.Context, job *Job) (any, error) {
+			var arg string
+			if err := job.DecodePayload(&arg); err != nil {
+				return nil, err
+			}
+			mu.Lock()
+			payloads = append(payloads, arg)
+			mu.Unlock()
+			<-release
+			return nil, nil
+		}, HandlerConfig{MaxConcurrent: 2}); err != nil {
+			t.Fatalf("register: %v", err)
 		}
+		mustStart(t, r)
+
+		if _, err := r.Enqueue("activity", EnqueueOptions{Payload: "a"}); err != nil {
+			t.Fatalf("enqueue a: %v", err)
+		}
+		if _, err := r.Enqueue("activity", EnqueueOptions{Payload: "b"}); err != nil {
+			t.Fatalf("enqueue b: %v", err)
+		}
+
+		// Both must be in flight together: this is the property coalescing-by-default
+		// would have made impossible, and the one durable activities need. Once
+		// dispatch has settled, both handlers are parked on `release` — so this counts
+		// concurrent runs rather than runs that happened to overlap.
+		synctest.Wait()
 		mu.Lock()
-		payloads = append(payloads, arg)
+		inFlight := len(payloads)
 		mu.Unlock()
-		<-release
-		return nil, nil
-	}, HandlerConfig{MaxConcurrent: 2}); err != nil {
-		t.Fatalf("register: %v", err)
-	}
-	mustStart(t, r)
-
-	if _, err := r.Enqueue("activity", EnqueueOptions{Payload: "a"}); err != nil {
-		t.Fatalf("enqueue a: %v", err)
-	}
-	if _, err := r.Enqueue("activity", EnqueueOptions{Payload: "b"}); err != nil {
-		t.Fatalf("enqueue b: %v", err)
-	}
-
-	// Both must be in flight together: this is the property coalescing-by-default
-	// would have made impossible, and the one durable activities need.
-	waitFor(t, "both distinct jobs to be running", func() bool {
-		mu.Lock()
-		defer mu.Unlock()
-		return len(payloads) == 2
+		if inFlight != 2 {
+			t.Fatalf("%d distinct jobs running once dispatch settled, want 2", inFlight)
+		}
+		if store.count() != 2 {
+			t.Errorf("store holds %d records, want 2 distinct jobs", store.count())
+		}
+		close(release)
 	})
-	if store.count() != 2 {
-		t.Errorf("store holds %d records, want 2 distinct jobs", store.count())
-	}
-	close(release)
 }
 
 func TestUniqueKeyCoalescesABurstIntoOneRun(t *testing.T) {
-	r, store, clock := newTestRunner(t, nil)
-	var runs atomic.Int32
-	mustRegister(t, r, "narrate", func(context.Context, *Job) (any, error) {
-		runs.Add(1)
-		return nil, nil
-	})
-	mustStart(t, r)
+	synctest.Test(t, func(t *testing.T) {
+		r, store := newBubbleRunner(t, nil)
+		var runs atomic.Int32
+		mustRegister(t, r, "narrate", func(context.Context, *Job) (any, error) {
+			runs.Add(1)
+			return nil, nil
+		})
+		mustStart(t, r)
 
-	// Three triggers inside the debounce window, each pushing the run later.
-	var last *Job
-	for i := 0; i < 3; i++ {
-		job, err := r.Enqueue("narrate", EnqueueOptions{UniqueKey: "ws-1", Delay: time.Minute})
-		if err != nil {
-			t.Fatalf("enqueue %d: %v", i, err)
+		// Three triggers inside the debounce window, each pushing the run later.
+		var last *Job
+		for i := 0; i < 3; i++ {
+			job, err := r.Enqueue("narrate", EnqueueOptions{UniqueKey: "ws-1", Delay: time.Minute})
+			if err != nil {
+				t.Fatalf("enqueue %d: %v", i, err)
+			}
+			last = job
 		}
-		last = job
-	}
-	if store.count() != 1 {
-		t.Fatalf("store holds %d records, want 1 coalesced record", store.count())
-	}
-	if runs.Load() != 0 {
-		t.Fatalf("job ran %d times before its debounce elapsed", runs.Load())
-	}
+		if store.count() != 1 {
+			t.Fatalf("store holds %d records, want 1 coalesced record", store.count())
+		}
+		// Not "has not run yet" but "will not run": dispatch has settled and the
+		// debounce window is still open.
+		synctest.Wait()
+		if runs.Load() != 0 {
+			t.Fatalf("job ran %d times before its debounce elapsed", runs.Load())
+		}
 
-	clock.advance(time.Minute)
-	waitFor(t, "the coalesced job to run", func() bool {
-		return mustGet(t, r, last.ID).State == StateDone
+		time.Sleep(time.Minute)
+		synctest.Wait()
+		if got := mustGet(t, r, last.ID).State; got != StateDone {
+			t.Fatalf("state after the debounce elapsed = %s, want done", got)
+		}
+		if got := runs.Load(); got != 1 {
+			t.Errorf("handler ran %d times, want 1 — the burst should collapse", got)
+		}
 	})
-	if got := runs.Load(); got != 1 {
-		t.Errorf("handler ran %d times, want 1 — the burst should collapse", got)
-	}
 }
 
 func TestRunNowOverridesAPendingDebounce(t *testing.T) {
-	r, _, _ := newTestRunner(t, nil)
-	mustRegister(t, r, "narrate", func(context.Context, *Job) (any, error) { return nil, nil })
-	mustStart(t, r)
+	synctest.Test(t, func(t *testing.T) {
+		r, _ := newBubbleRunner(t, nil)
+		mustRegister(t, r, "narrate", func(context.Context, *Job) (any, error) { return nil, nil })
+		mustStart(t, r)
 
-	if _, err := r.Enqueue("narrate", EnqueueOptions{UniqueKey: "ws-1", Delay: time.Hour}); err != nil {
-		t.Fatalf("enqueue debounced: %v", err)
-	}
-	job, err := r.Enqueue("narrate", EnqueueOptions{UniqueKey: "ws-1", RunNow: true})
-	if err != nil {
-		t.Fatalf("enqueue run-now: %v", err)
-	}
-	// Without the override this would wait an hour of fake time, which never
-	// arrives in this test.
-	waitFor(t, "the run-now job to run", func() bool {
-		return mustGet(t, r, job.ID).State == StateDone
+		if _, err := r.Enqueue("narrate", EnqueueOptions{UniqueKey: "ws-1", Delay: time.Hour}); err != nil {
+			t.Fatalf("enqueue debounced: %v", err)
+		}
+		job, err := r.Enqueue("narrate", EnqueueOptions{UniqueKey: "ws-1", RunNow: true})
+		if err != nil {
+			t.Fatalf("enqueue run-now: %v", err)
+		}
+		// Without the override this would wait an hour of fake time, which never
+		// arrives in this test.
+		synctest.Wait()
+		if got := mustGet(t, r, job.ID).State; got != StateDone {
+			t.Fatalf("run-now job state = %s, want done", got)
+		}
 	})
 }
 
 func TestATriggerArrivingMidRunRunsTheJobAgain(t *testing.T) {
-	r, _, _ := newTestRunner(t, nil)
-	var runs atomic.Int32
-	entered := make(chan struct{}, 4)
-	release := make(chan struct{})
-	mustRegister(t, r, "narrate", func(context.Context, *Job) (any, error) {
-		runs.Add(1)
-		entered <- struct{}{}
-		<-release
-		return nil, nil
+	synctest.Test(t, func(t *testing.T) {
+		r, _ := newBubbleRunner(t, nil)
+		var runs atomic.Int32
+		entered := make(chan struct{}, 4)
+		release := make(chan struct{})
+		mustRegister(t, r, "narrate", func(context.Context, *Job) (any, error) {
+			runs.Add(1)
+			entered <- struct{}{}
+			<-release
+			return nil, nil
+		})
+		mustStart(t, r)
+
+		job, err := r.Enqueue("narrate", EnqueueOptions{UniqueKey: "ws-1"})
+		if err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		<-entered // the first run is in the handler
+
+		// The trigger lands while the run is in flight. It must not be dropped, and it
+		// must not tear the in-flight run.
+		if _, err := r.Enqueue("narrate", EnqueueOptions{UniqueKey: "ws-1", RunNow: true}); err != nil {
+			t.Fatalf("mid-run enqueue: %v", err)
+		}
+		if got := mustGet(t, r, job.ID); !got.Requeued {
+			t.Fatalf("mid-run enqueue did not mark the record requeued (state %s)", got.State)
+		}
+		close(release)
+
+		<-entered // the second run, honoring the coalesced trigger
+		synctest.Wait()
+		if got := mustGet(t, r, job.ID).State; got != StateDone {
+			t.Fatalf("state after the re-run = %s, want done", got)
+		}
+		if got := runs.Load(); got != 2 {
+			t.Errorf("handler ran %d times, want 2 (the run plus the coalesced re-run)", got)
+		}
 	})
-	mustStart(t, r)
-
-	job, err := r.Enqueue("narrate", EnqueueOptions{UniqueKey: "ws-1"})
-	if err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	<-entered // the first run is in the handler
-
-	// The trigger lands while the run is in flight. It must not be dropped, and it
-	// must not tear the in-flight run.
-	if _, err := r.Enqueue("narrate", EnqueueOptions{UniqueKey: "ws-1", RunNow: true}); err != nil {
-		t.Fatalf("mid-run enqueue: %v", err)
-	}
-	if got := mustGet(t, r, job.ID); !got.Requeued {
-		t.Fatalf("mid-run enqueue did not mark the record requeued (state %s)", got.State)
-	}
-	close(release)
-
-	<-entered // the second run, honoring the coalesced trigger
-	waitFor(t, "the re-run to finish", func() bool {
-		return mustGet(t, r, job.ID).State == StateDone
-	})
-	if got := runs.Load(); got != 2 {
-		t.Errorf("handler ran %d times, want 2 (the run plus the coalesced re-run)", got)
-	}
 }
 
 // Converted to synctest (spike leg 1). time.Sleep moves the bubble's fake clock,
@@ -346,113 +352,128 @@ func TestFailuresBackOffThenGoDeadOnce(t *testing.T) {
 }
 
 func TestAJobCanRaiseItsOwnAttemptCap(t *testing.T) {
-	r, _, clock := newTestRunner(t, func(o *Options) {
-		o.MaxAttempts = 1
-		o.BackoffBase = time.Minute
-	})
-	mustRegister(t, r, "flaky", func(context.Context, *Job) (any, error) {
-		return nil, errors.New("boom")
-	})
-	mustStart(t, r)
+	synctest.Test(t, func(t *testing.T) {
+		r, _ := newBubbleRunner(t, func(o *Options) {
+			o.MaxAttempts = 1
+			o.BackoffBase = time.Minute
+		})
+		mustRegister(t, r, "flaky", func(context.Context, *Job) (any, error) {
+			return nil, errors.New("boom")
+		})
+		mustStart(t, r)
 
-	job, err := r.Enqueue("flaky", EnqueueOptions{MaxAttempts: 2})
-	if err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	// With the runner default of 1 this would already be dead.
-	waitFor(t, "the first attempt to fail", func() bool {
-		return mustGet(t, r, job.ID).State == StateFailed
+		job, err := r.Enqueue("flaky", EnqueueOptions{MaxAttempts: 2})
+		if err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		// With the runner default of 1 this would already be dead.
+		synctest.Wait()
+		if got := mustGet(t, r, job.ID).State; got != StateFailed {
+			t.Fatalf("state after the first attempt = %s, want failed", got)
+		}
+		time.Sleep(time.Minute)
+		synctest.Wait()
+		if got := mustGet(t, r, job.ID).State; got != StateDead {
+			t.Fatalf("state after the retry = %s, want dead", got)
+		}
+		if got := mustGet(t, r, job.ID).Attempts; got != 2 {
+			t.Errorf("attempts = %d, want 2 (the job's own cap)", got)
+		}
 	})
-	clock.advance(time.Minute)
-	waitFor(t, "the job to die at its own cap", func() bool {
-		return mustGet(t, r, job.ID).State == StateDead
-	})
-	if got := mustGet(t, r, job.ID).Attempts; got != 2 {
-		t.Errorf("attempts = %d, want 2 (the job's own cap)", got)
-	}
 }
 
 func TestRetryRevivesADeadJob(t *testing.T) {
-	r, _, _ := newTestRunner(t, func(o *Options) { o.MaxAttempts = 1 })
-	var fail atomic.Bool
-	fail.Store(true)
-	mustRegister(t, r, "flaky", func(context.Context, *Job) (any, error) {
-		if fail.Load() {
-			return nil, errors.New("boom")
+	synctest.Test(t, func(t *testing.T) {
+		r, _ := newBubbleRunner(t, func(o *Options) { o.MaxAttempts = 1 })
+		var fail atomic.Bool
+		fail.Store(true)
+		mustRegister(t, r, "flaky", func(context.Context, *Job) (any, error) {
+			if fail.Load() {
+				return nil, errors.New("boom")
+			}
+			return nil, nil
+		})
+		mustStart(t, r)
+
+		job, err := r.Enqueue("flaky", EnqueueOptions{})
+		if err != nil {
+			t.Fatalf("enqueue: %v", err)
 		}
-		return nil, nil
-	})
-	mustStart(t, r)
+		synctest.Wait()
+		if got := mustGet(t, r, job.ID).State; got != StateDead {
+			t.Fatalf("state at the attempt cap = %s, want dead", got)
+		}
 
-	job, err := r.Enqueue("flaky", EnqueueOptions{})
-	if err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	waitFor(t, "the job to die", func() bool {
-		return mustGet(t, r, job.ID).State == StateDead
+		fail.Store(false)
+		if _, err := r.Retry(job.ID); err != nil {
+			t.Fatalf("retry: %v", err)
+		}
+		synctest.Wait()
+		if got := mustGet(t, r, job.ID).State; got != StateDone {
+			t.Fatalf("state after the retry = %s, want done", got)
+		}
+		if got := mustGet(t, r, job.ID).LastError; got != "" {
+			t.Errorf("last error = %q, want it cleared by the successful retry", got)
+		}
 	})
-
-	fail.Store(false)
-	if _, err := r.Retry(job.ID); err != nil {
-		t.Fatalf("retry: %v", err)
-	}
-	waitFor(t, "the retried job to succeed", func() bool {
-		return mustGet(t, r, job.ID).State == StateDone
-	})
-	if got := mustGet(t, r, job.ID).LastError; got != "" {
-		t.Errorf("last error = %q, want it cleared by the successful retry", got)
-	}
 }
 
+// Converted to synctest. The load-bearing assertion is a negative — Cancel must
+// still be blocked — which a fixed window can only make probable. synctest.Wait
+// returns when Cancel is parked on the run's done channel with nothing else left
+// to run, so "it did not return" is a fact about a settled system.
 func TestCancelWaitsForTheCommitFence(t *testing.T) {
-	r, _, _ := newTestRunner(t, nil)
-	committing := make(chan struct{})
-	finishCommit := make(chan struct{})
-	var wrote atomic.Bool
-	mustRegister(t, r, "commits", func(ctx context.Context, job *Job) (any, error) {
-		if !job.CommitGuard.Enter() {
-			return nil, errors.New("fenced before commit")
+	synctest.Test(t, func(t *testing.T) {
+		r, _ := newBubbleRunner(t, nil)
+		committing := make(chan struct{})
+		finishCommit := make(chan struct{})
+		var wrote atomic.Bool
+		mustRegister(t, r, "commits", func(ctx context.Context, job *Job) (any, error) {
+			if !job.CommitGuard.Enter() {
+				return nil, errors.New("fenced before commit")
+			}
+			defer job.CommitGuard.Leave()
+			close(committing)
+			<-finishCommit
+			// A cancel that arrived while we were inside the fence must not have
+			// cancelled the context out from under the write.
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			wrote.Store(true)
+			return nil, nil
+		})
+		mustStart(t, r)
+
+		job, err := r.Enqueue("commits", EnqueueOptions{})
+		if err != nil {
+			t.Fatalf("enqueue: %v", err)
 		}
-		defer job.CommitGuard.Leave()
-		close(committing)
-		<-finishCommit
-		// A cancel that arrived while we were inside the fence must not have
-		// cancelled the context out from under the write.
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
+		<-committing
+
+		cancelReturned := make(chan struct{})
+		go func() {
+			r.Cancel(job.ID)
+			close(cancelReturned)
+		}()
+
+		// Cancel must still be blocked: the run is inside its commit.
+		synctest.Wait()
+		select {
+		case <-cancelReturned:
+			t.Fatal("Cancel returned while the handler was inside its commit fence")
+		default:
 		}
-		wrote.Store(true)
-		return nil, nil
+
+		close(finishCommit)
+		<-cancelReturned
+		if !wrote.Load() {
+			t.Error("the durable write was torn by the cancel")
+		}
+		if got := mustGet(t, r, job.ID).State; got != StateDone {
+			t.Errorf("state = %s, want done — the fenced run completed", got)
+		}
 	})
-	mustStart(t, r)
-
-	job, err := r.Enqueue("commits", EnqueueOptions{})
-	if err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	<-committing
-
-	cancelReturned := make(chan struct{})
-	go func() {
-		r.Cancel(job.ID)
-		close(cancelReturned)
-	}()
-
-	// Cancel must still be blocked: the run is inside its commit.
-	select {
-	case <-cancelReturned:
-		t.Fatal("Cancel returned while the handler was inside its commit fence")
-	case <-time.After(20 * testPoll):
-	}
-
-	close(finishCommit)
-	<-cancelReturned
-	if !wrote.Load() {
-		t.Error("the durable write was torn by the cancel")
-	}
-	if got := mustGet(t, r, job.ID).State; got != StateDone {
-		t.Errorf("state = %s, want done — the fenced run completed", got)
-	}
 }
 
 func TestCancelBeforeTheFenceStopsTheWrite(t *testing.T) {
@@ -510,78 +531,84 @@ func TestRemoveByKeyForgetsTheJob(t *testing.T) {
 }
 
 func TestStartRequeuesAJobLeftRunningByACrash(t *testing.T) {
-	store := newMemStore()
-	clock := newFakeClock()
-	// A record left mid-run by a daemon that died.
-	orphan := &Job{
-		ID:          "orphan",
-		Kind:        "compact",
-		State:       StateRunning,
-		Attempts:    1,
-		ScheduledAt: clock.now().Add(-time.Hour),
-		CreatedAt:   clock.now().Add(-time.Hour),
-		UpdatedAt:   clock.now().Add(-time.Hour),
-	}
-	if err := store.Save(orphan); err != nil {
-		t.Fatalf("seed orphan: %v", err)
-	}
+	synctest.Test(t, func(t *testing.T) {
+		store := newMemStore()
+		// A record left mid-run by a daemon that died.
+		stale := time.Now().Add(-time.Hour)
+		orphan := &Job{
+			ID:          "orphan",
+			Kind:        "compact",
+			State:       StateRunning,
+			Attempts:    1,
+			ScheduledAt: stale,
+			CreatedAt:   stale,
+			UpdatedAt:   stale,
+		}
+		if err := store.Save(orphan); err != nil {
+			t.Fatalf("seed orphan: %v", err)
+		}
 
-	r := New(Options{Store: store, Now: clock.now, PollInterval: testPoll, Log: func(string, ...interface{}) {}})
-	t.Cleanup(r.Stop)
-	var ran atomic.Bool
-	mustRegister(t, r, "compact", func(context.Context, *Job) (any, error) {
-		ran.Store(true)
-		return nil, nil
-	})
-	mustStart(t, r)
+		r := New(Options{Store: store, Log: func(string, ...any) {}})
+		t.Cleanup(r.Stop)
+		var ran atomic.Bool
+		mustRegister(t, r, "compact", func(context.Context, *Job) (any, error) {
+			ran.Store(true)
+			return nil, nil
+		})
+		mustStart(t, r)
 
-	waitFor(t, "the recovered job to run", func() bool { return ran.Load() })
-	waitFor(t, "the recovered job to finish", func() bool {
-		return mustGet(t, r, "orphan").State == StateDone
+		synctest.Wait()
+		if !ran.Load() {
+			t.Fatal("the recovered job never ran")
+		}
+		if got := mustGet(t, r, "orphan").State; got != StateDone {
+			t.Fatalf("recovered job state = %s, want done", got)
+		}
 	})
 }
 
 func TestPriorityOrdersTheQueue(t *testing.T) {
-	r, _, _ := newTestRunner(t, nil)
-	var mu sync.Mutex
-	var order []string
-	mustRegister(t, r, "ordered", func(_ context.Context, job *Job) (any, error) {
-		var name string
-		if err := job.DecodePayload(&name); err != nil {
-			return nil, err
+	synctest.Test(t, func(t *testing.T) {
+		r, _ := newBubbleRunner(t, nil)
+		var mu sync.Mutex
+		var order []string
+		mustRegister(t, r, "ordered", func(_ context.Context, job *Job) (any, error) {
+			var name string
+			if err := job.DecodePayload(&name); err != nil {
+				return nil, err
+			}
+			mu.Lock()
+			order = append(order, name)
+			mu.Unlock()
+			return nil, nil
+		})
+
+		// Enqueue before starting so all three are eligible in the same first pass;
+		// the per-kind cap of 1 then serializes them in selection order.
+		if _, err := r.Enqueue("ordered", EnqueueOptions{Payload: "low", Priority: 1}); err != nil {
+			t.Fatalf("enqueue low: %v", err)
 		}
-		mu.Lock()
-		order = append(order, name)
-		mu.Unlock()
-		return nil, nil
-	})
+		if _, err := r.Enqueue("ordered", EnqueueOptions{Payload: "high", Priority: 10}); err != nil {
+			t.Fatalf("enqueue high: %v", err)
+		}
+		if _, err := r.Enqueue("ordered", EnqueueOptions{Payload: "mid", Priority: 5}); err != nil {
+			t.Fatalf("enqueue mid: %v", err)
+		}
+		mustStart(t, r)
 
-	// Enqueue before starting so all three are eligible in the same first pass;
-	// the per-kind cap of 1 then serializes them in selection order.
-	if _, err := r.Enqueue("ordered", EnqueueOptions{Payload: "low", Priority: 1}); err != nil {
-		t.Fatalf("enqueue low: %v", err)
-	}
-	if _, err := r.Enqueue("ordered", EnqueueOptions{Payload: "high", Priority: 10}); err != nil {
-		t.Fatalf("enqueue high: %v", err)
-	}
-	if _, err := r.Enqueue("ordered", EnqueueOptions{Payload: "mid", Priority: 5}); err != nil {
-		t.Fatalf("enqueue mid: %v", err)
-	}
-	mustStart(t, r)
-
-	waitFor(t, "all three jobs to run", func() bool {
+		synctest.Wait()
 		mu.Lock()
 		defer mu.Unlock()
-		return len(order) == 3
-	})
-	mu.Lock()
-	defer mu.Unlock()
-	want := []string{"high", "mid", "low"}
-	for i := range want {
-		if order[i] != want[i] {
-			t.Fatalf("ran in order %v, want %v", order, want)
+		if len(order) != 3 {
+			t.Fatalf("%d of 3 jobs ran once dispatch settled: %v", len(order), order)
 		}
-	}
+		want := []string{"high", "mid", "low"}
+		for i := range want {
+			if order[i] != want[i] {
+				t.Fatalf("ran in order %v, want %v", order, want)
+			}
+		}
+	})
 }
 
 // Converted to synctest (spike leg 1). The load-bearing assertion here is a
@@ -647,32 +674,35 @@ func TestAKindIsSerializedWithItselfButNotWithOthers(t *testing.T) {
 }
 
 func TestAnUnregisteredKindFailsInPlace(t *testing.T) {
-	store := newMemStore()
-	clock := newFakeClock()
-	// A record from an older build whose kind this binary no longer knows.
-	stale := &Job{
-		ID:          "stale",
-		Kind:        "retired_kind",
-		State:       StateQueued,
-		ScheduledAt: clock.now(),
-		CreatedAt:   clock.now(),
-		UpdatedAt:   clock.now(),
-	}
-	if err := store.Save(stale); err != nil {
-		t.Fatalf("seed stale: %v", err)
-	}
+	synctest.Test(t, func(t *testing.T) {
+		store := newMemStore()
+		// A record from an older build whose kind this binary no longer knows.
+		now := time.Now()
+		stale := &Job{
+			ID:          "stale",
+			Kind:        "retired_kind",
+			State:       StateQueued,
+			ScheduledAt: now,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		if err := store.Save(stale); err != nil {
+			t.Fatalf("seed stale: %v", err)
+		}
 
-	r := New(Options{Store: store, Now: clock.now, PollInterval: testPoll, MaxAttempts: 1, Log: func(string, ...interface{}) {}})
-	t.Cleanup(r.Stop)
-	mustStart(t, r)
+		r := New(Options{Store: store, MaxAttempts: 1, Log: func(string, ...any) {}})
+		t.Cleanup(r.Stop)
+		mustStart(t, r)
 
-	// It must surface as a failure rather than being silently re-selected forever.
-	waitFor(t, "the unknown-kind job to die", func() bool {
-		return mustGet(t, r, "stale").State == StateDead
+		// It must surface as a failure rather than being silently re-selected forever.
+		synctest.Wait()
+		if got := mustGet(t, r, "stale").State; got != StateDead {
+			t.Fatalf("unknown-kind job state = %s, want dead", got)
+		}
+		if got := mustGet(t, r, "stale").LastError; got == "" {
+			t.Error("unknown-kind failure recorded no error to read")
+		}
 	})
-	if got := mustGet(t, r, "stale").LastError; got == "" {
-		t.Error("unknown-kind failure recorded no error to read")
-	}
 }
 
 func TestEnqueueRejectsAnUnregisteredKind(t *testing.T) {
@@ -684,95 +714,124 @@ func TestEnqueueRejectsAnUnregisteredKind(t *testing.T) {
 }
 
 func TestAnUnmarshallableResultFailsTheRun(t *testing.T) {
-	r, _, _ := newTestRunner(t, func(o *Options) { o.MaxAttempts = 1 })
-	mustRegister(t, r, "bad_result", func(context.Context, *Job) (any, error) {
-		// math.Inf has no JSON representation. The work "succeeded", but a result
-		// nobody can read must not be reported as success.
-		return math.Inf(1), nil
-	})
-	mustStart(t, r)
+	synctest.Test(t, func(t *testing.T) {
+		r, _ := newBubbleRunner(t, func(o *Options) { o.MaxAttempts = 1 })
+		mustRegister(t, r, "bad_result", func(context.Context, *Job) (any, error) {
+			// math.Inf has no JSON representation. The work "succeeded", but a result
+			// nobody can read must not be reported as success.
+			return math.Inf(1), nil
+		})
+		mustStart(t, r)
 
-	job, err := r.Enqueue("bad_result", EnqueueOptions{})
-	if err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	waitFor(t, "the run to fail on its result", func() bool {
-		return mustGet(t, r, job.ID).State == StateDead
+		job, err := r.Enqueue("bad_result", EnqueueOptions{})
+		if err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		synctest.Wait()
+		if got := mustGet(t, r, job.ID).State; got != StateDead {
+			t.Fatalf("state after an unmarshallable result = %s, want dead", got)
+		}
+		if got := mustGet(t, r, job.ID).LastError; got == "" {
+			t.Error("the marshal failure was not recorded")
+		}
 	})
-	if got := mustGet(t, r, job.ID).LastError; got == "" {
-		t.Error("the marshal failure was not recorded")
-	}
 }
 
 func TestRetentionTrimsCompletedJobsAndKeepsDeadOnes(t *testing.T) {
-	r, store, clock := newTestRunner(t, func(o *Options) {
-		o.MaxAttempts = 1
-		o.Retention = 24 * time.Hour
-	})
-	mustRegister(t, r, "ok", func(context.Context, *Job) (any, error) { return nil, nil })
-	mustRegister(t, r, "bad", func(context.Context, *Job) (any, error) {
-		return nil, errors.New("boom")
-	})
-	mustStart(t, r)
+	synctest.Test(t, func(t *testing.T) {
+		r, store := newBubbleRunner(t, func(o *Options) {
+			o.MaxAttempts = 1
+			o.Retention = 24 * time.Hour
+			// This test is about the manual Trim call. The runner's own hourly
+			// retention pass is a real ticker, and in a bubble it really fires — 48
+			// times over the window below — so it would trim the record before the
+			// call under test ever ran. Parking it past the window keeps the subject
+			// singular. (Under a fake clock the pass never fired at all, because its
+			// ticker was on real time; that it now runs is the bubble working.)
+			o.TrimInterval = 30 * 24 * time.Hour
+		})
+		mustRegister(t, r, "ok", func(context.Context, *Job) (any, error) { return nil, nil })
+		mustRegister(t, r, "bad", func(context.Context, *Job) (any, error) {
+			return nil, errors.New("boom")
+		})
+		mustStart(t, r)
 
-	done, err := r.Enqueue("ok", EnqueueOptions{})
-	if err != nil {
-		t.Fatalf("enqueue ok: %v", err)
-	}
-	dead, err := r.Enqueue("bad", EnqueueOptions{})
-	if err != nil {
-		t.Fatalf("enqueue bad: %v", err)
-	}
-	waitFor(t, "both jobs to settle", func() bool {
-		return mustGet(t, r, done.ID).State == StateDone && mustGet(t, r, dead.ID).State == StateDead
+		done, err := r.Enqueue("ok", EnqueueOptions{})
+		if err != nil {
+			t.Fatalf("enqueue ok: %v", err)
+		}
+		dead, err := r.Enqueue("bad", EnqueueOptions{})
+		if err != nil {
+			t.Fatalf("enqueue bad: %v", err)
+		}
+		synctest.Wait()
+		if got := mustGet(t, r, done.ID).State; got != StateDone {
+			t.Fatalf("the succeeding job settled at %s, want done", got)
+		}
+		if got := mustGet(t, r, dead.ID).State; got != StateDead {
+			t.Fatalf("the failing job settled at %s, want dead", got)
+		}
+
+		if got := r.Trim(); got != 0 {
+			t.Errorf("trimmed %d fresh jobs, want 0", got)
+		}
+
+		// The retention window itself, at its real length.
+		time.Sleep(48 * time.Hour)
+		if got := r.Trim(); got != 1 {
+			t.Errorf("trimmed %d jobs, want 1 (the completed one)", got)
+		}
+		if j, _ := r.Get(done.ID); j != nil {
+			t.Error("the completed job survived retention")
+		}
+		// The dead job is the record a failure notification points at, and it only
+		// exists because nobody acted on it. Retention must not swallow it.
+		if j, _ := r.Get(dead.ID); j == nil {
+			t.Error("the dead job was trimmed; it is the actionable record")
+		}
+		if store.count() != 1 {
+			t.Errorf("store holds %d records, want 1", store.count())
+		}
 	})
-
-	if got := r.Trim(); got != 0 {
-		t.Errorf("trimmed %d fresh jobs, want 0", got)
-	}
-
-	clock.advance(48 * time.Hour)
-	if got := r.Trim(); got != 1 {
-		t.Errorf("trimmed %d jobs, want 1 (the completed one)", got)
-	}
-	if j, _ := r.Get(done.ID); j != nil {
-		t.Error("the completed job survived retention")
-	}
-	// The dead job is the record a failure notification points at, and it only
-	// exists because nobody acted on it. Retention must not swallow it.
-	if j, _ := r.Get(dead.ID); j == nil {
-		t.Error("the dead job was trimmed; it is the actionable record")
-	}
-	if store.count() != 1 {
-		t.Errorf("store holds %d records, want 1", store.count())
-	}
 }
 
 func TestAFailedClaimReleasesItsConcurrencySlot(t *testing.T) {
-	r, store, clock := newTestRunner(t, nil)
-	var runs atomic.Int32
-	mustRegister(t, r, "compact", func(context.Context, *Job) (any, error) {
-		runs.Add(1)
-		return nil, nil
-	})
-	mustStart(t, r)
+	synctest.Test(t, func(t *testing.T) {
+		r, store := newBubbleRunner(t, nil)
+		var runs atomic.Int32
+		mustRegister(t, r, "compact", func(context.Context, *Job) (any, error) {
+			runs.Add(1)
+			return nil, nil
+		})
+		mustStart(t, r)
 
-	// Park the job behind a debounce so the enqueue's own write lands first and
-	// the armed failure is guaranteed to hit the dispatch claim instead.
-	job, err := r.Enqueue("compact", EnqueueOptions{UniqueKey: "ws-1", Delay: time.Minute})
-	if err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	// The claim write fails once. If the reserved per-kind slot leaked, the kind
-	// would be saturated forever and nothing of it would ever run again.
-	store.failNextSave(errors.New("disk on fire"))
-	clock.advance(time.Minute)
-	waitFor(t, "the job to run despite the failed claim", func() bool {
-		return mustGet(t, r, job.ID).State == StateDone
+		// Park the job behind a debounce so the enqueue's own write lands first and
+		// the armed failure is guaranteed to hit the dispatch claim instead.
+		job, err := r.Enqueue("compact", EnqueueOptions{UniqueKey: "ws-1", Delay: time.Minute})
+		if err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		// The claim write fails once. If the reserved per-kind slot leaked, the kind
+		// would be saturated forever and nothing of it would ever run again — which
+		// the bubble proves by letting a further hour of dispatch passes run.
+		store.failNextSave(errors.New("disk on fire"))
+		time.Sleep(time.Minute)
+		synctest.Wait()
+		if got := mustGet(t, r, job.ID).State; got != StateQueued {
+			t.Fatalf("state after the claim write failed = %s, want queued (the job is still owed a run)", got)
+		}
+		// The recovery is the point: the very next dispatch pass must be able to
+		// claim it. If the reserved per-kind slot leaked, the kind would be
+		// saturated forever and no sleep here would ever produce a run.
+		time.Sleep(defaultPollInterval)
+		synctest.Wait()
+		if got := mustGet(t, r, job.ID).State; got != StateDone {
+			t.Fatalf("state after the next dispatch pass = %s, want done", got)
+		}
+		if got := runs.Load(); got != 1 {
+			t.Errorf("handler ran %d times, want 1", got)
+		}
 	})
-	if got := runs.Load(); got != 1 {
-		t.Errorf("handler ran %d times, want 1", got)
-	}
 }
 
 func TestASecondRunnerRefusesTheSameStore(t *testing.T) {

--- a/internal/ptyworker/runtime_test.go
+++ b/internal/ptyworker/runtime_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/pty"
@@ -118,136 +119,172 @@ func TestConnCtx_HandleRequest_SetThemeReachesSession(t *testing.T) {
 	}
 }
 
+// The runtime's two self-stop clocks — exit cleanup and the orphan watch — run
+// inside synctest bubbles at their shipped lengths. Under real time these tests
+// had to swap 45 seconds and 12 hours for tens of milliseconds and then wait a
+// tolerance window on top; the numbers under test were the test's, not the
+// product's. A bubble's fake clock makes 12 hours free, so the shipped TTL is
+// what fires, and a negative ("this must NOT stop") holds across the whole
+// window rather than across whatever slice the test could afford to wait.
+//
+// The Runtime here owns no socket, no PTY and no child process — it is a struct
+// with timers and a stop channel — so nothing pins the bubble to real time.
+
 func TestRuntime_ExitedSessionCleansUpAfterTTLWithoutConnections(t *testing.T) {
-	origTTL := exitedSessionCleanupTTL
-	exitedSessionCleanupTTL = 15 * time.Millisecond
-	defer func() { exitedSessionCleanupTTL = origTTL }()
+	synctest.Test(t, func(t *testing.T) {
+		r := &Runtime{stopCh: make(chan struct{})}
+		r.noteSessionExited()
 
-	r := &Runtime{stopCh: make(chan struct{})}
-	r.noteSessionExited()
-
-	select {
-	case <-r.stopCh:
-		// expected
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("timed out waiting for runtime stop after exit TTL")
-	}
+		time.Sleep(exitedSessionCleanupTTL)
+		synctest.Wait()
+		select {
+		case <-r.stopCh:
+			// expected
+		default:
+			t.Fatal("the runtime did not stop when the exit TTL elapsed")
+		}
+	})
 }
 
 func TestRuntime_ExitCleanupWaitsForConnectionsToClose(t *testing.T) {
-	origTTL := exitedSessionCleanupTTL
-	exitedSessionCleanupTTL = 15 * time.Millisecond
-	defer func() { exitedSessionCleanupTTL = origTTL }()
+	synctest.Test(t, func(t *testing.T) {
+		r := &Runtime{stopCh: make(chan struct{})}
+		r.noteConnAuthed()
+		r.noteSessionExited()
 
-	r := &Runtime{stopCh: make(chan struct{})}
-	r.noteConnAuthed()
-	r.noteSessionExited()
+		// Well past the TTL, which an authed connection must hold off entirely.
+		time.Sleep(4 * exitedSessionCleanupTTL)
+		synctest.Wait()
+		select {
+		case <-r.stopCh:
+			t.Fatal("runtime stopped while authed connection was still active")
+		default:
+		}
 
-	select {
-	case <-r.stopCh:
-		t.Fatal("runtime stopped while authed connection was still active")
-	case <-time.After(50 * time.Millisecond):
-		// expected
-	}
+		r.noteConnClosed()
 
-	r.noteConnClosed()
-
-	select {
-	case <-r.stopCh:
-		// expected
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("timed out waiting for runtime stop after connection close")
-	}
+		time.Sleep(exitedSessionCleanupTTL)
+		synctest.Wait()
+		select {
+		case <-r.stopCh:
+			// expected
+		default:
+			t.Fatal("the runtime did not stop once the last connection closed")
+		}
+	})
 }
 
 func TestRuntime_OrphanWatchStopsIdleUnownedWorker(t *testing.T) {
-	r := &Runtime{stopCh: make(chan struct{}), orphanTTL: 15 * time.Millisecond}
-	r.noteOutputActivity()
-	r.armOrphanWatch()
+	synctest.Test(t, func(t *testing.T) {
+		r := &Runtime{stopCh: make(chan struct{}), orphanTTL: orphanedWorkerTTL}
+		r.noteOutputActivity()
+		r.armOrphanWatch()
 
-	select {
-	case <-r.stopCh:
-		// expected
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("timed out waiting for orphan watch to stop idle unowned worker")
-	}
+		time.Sleep(orphanedWorkerTTL)
+		synctest.Wait()
+		select {
+		case <-r.stopCh:
+			// expected
+		default:
+			t.Fatal("the orphan watch did not stop an idle unowned worker at its TTL")
+		}
+	})
 }
 
 func TestRuntime_OrphanWatchCanceledByAuthedConn(t *testing.T) {
-	r := &Runtime{stopCh: make(chan struct{}), orphanTTL: 15 * time.Millisecond}
-	r.noteOutputActivity()
-	r.armOrphanWatch()
-	r.noteConnAuthed()
+	synctest.Test(t, func(t *testing.T) {
+		r := &Runtime{stopCh: make(chan struct{}), orphanTTL: orphanedWorkerTTL}
+		r.noteOutputActivity()
+		r.armOrphanWatch()
+		r.noteConnAuthed()
 
-	select {
-	case <-r.stopCh:
-		t.Fatal("orphan watch stopped runtime while a daemon connection was authed")
-	case <-time.After(60 * time.Millisecond):
-		// expected
-	}
+		time.Sleep(4 * orphanedWorkerTTL)
+		synctest.Wait()
+		select {
+		case <-r.stopCh:
+			t.Fatal("orphan watch stopped runtime while a daemon connection was authed")
+		default:
+		}
 
-	r.noteConnClosed()
+		r.noteConnClosed()
 
-	select {
-	case <-r.stopCh:
-		// expected: watch re-armed when the last authed connection dropped
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("timed out waiting for orphan stop after last connection closed")
-	}
+		time.Sleep(orphanedWorkerTTL)
+		synctest.Wait()
+		select {
+		case <-r.stopCh:
+			// expected: watch re-armed when the last authed connection dropped
+		default:
+			t.Fatal("the orphan watch did not stop the worker after the last connection closed")
+		}
+	})
 }
 
 func TestRuntime_OrphanWatchDeferredByOutputActivity(t *testing.T) {
-	r := &Runtime{stopCh: make(chan struct{}), orphanTTL: 50 * time.Millisecond}
-	r.noteOutputActivity()
-	r.armOrphanWatch()
-
-	// Keep the child "busy" past the first deadline; the watch must defer.
-	deadline := time.Now().Add(120 * time.Millisecond)
-	for time.Now().Before(deadline) {
+	synctest.Test(t, func(t *testing.T) {
+		r := &Runtime{stopCh: make(chan struct{}), orphanTTL: orphanedWorkerTTL}
 		r.noteOutputActivity()
+		r.armOrphanWatch()
+
+		// Keep the child "busy" well past the first deadline; the watch must defer
+		// every time output arrives, however long the TTL is.
+		for i := 0; i < 4; i++ {
+			r.noteOutputActivity()
+			time.Sleep(orphanedWorkerTTL / 2)
+			synctest.Wait()
+			select {
+			case <-r.stopCh:
+				t.Fatal("orphan watch stopped runtime while output was still flowing")
+			default:
+			}
+		}
+
+		// Once output goes quiet, the worker stops after a full idle TTL.
+		time.Sleep(orphanedWorkerTTL)
+		synctest.Wait()
 		select {
 		case <-r.stopCh:
-			t.Fatal("orphan watch stopped runtime while output was still flowing")
-		case <-time.After(10 * time.Millisecond):
+			// expected
+		default:
+			t.Fatal("the orphan watch did not stop the worker once output went quiet")
 		}
-	}
-
-	// Once output goes quiet, the worker stops after a full idle TTL.
-	select {
-	case <-r.stopCh:
-		// expected
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("timed out waiting for orphan stop after output went quiet")
-	}
+	})
 }
 
 func TestRuntime_OrphanWatchDisabledByZeroTTL(t *testing.T) {
-	r := &Runtime{stopCh: make(chan struct{}), orphanTTL: 0}
-	r.armOrphanWatch()
+	synctest.Test(t, func(t *testing.T) {
+		r := &Runtime{stopCh: make(chan struct{}), orphanTTL: 0}
+		r.armOrphanWatch()
 
-	select {
-	case <-r.stopCh:
-		t.Fatal("orphan watch fired despite zero TTL")
-	case <-time.After(60 * time.Millisecond):
-		// expected
-	}
+		time.Sleep(4 * orphanedWorkerTTL)
+		synctest.Wait()
+		select {
+		case <-r.stopCh:
+			t.Fatal("orphan watch fired despite zero TTL")
+		default:
+		}
+	})
 }
 
 func TestRuntime_OrphanWatchNotArmedAfterExit(t *testing.T) {
-	origTTL := exitedSessionCleanupTTL
-	exitedSessionCleanupTTL = time.Hour
-	defer func() { exitedSessionCleanupTTL = origTTL }()
+	synctest.Test(t, func(t *testing.T) {
+		origTTL := exitedSessionCleanupTTL
+		exitedSessionCleanupTTL = 10 * orphanedWorkerTTL
+		defer func() { exitedSessionCleanupTTL = origTTL }()
 
-	r := &Runtime{stopCh: make(chan struct{}), orphanTTL: 15 * time.Millisecond}
-	r.noteSessionExited()
-	r.armOrphanWatch()
+		r := &Runtime{stopCh: make(chan struct{}), orphanTTL: orphanedWorkerTTL}
+		r.noteSessionExited()
+		r.armOrphanWatch()
 
-	select {
-	case <-r.stopCh:
-		t.Fatal("orphan watch fired for an exited session (exit cleanup owns that path)")
-	case <-time.After(60 * time.Millisecond):
-		// expected
-	}
+		// Past the orphan TTL but short of the exit cleanup this test parked, so a
+		// stop here could only have come from the watch that must not be armed.
+		time.Sleep(2 * orphanedWorkerTTL)
+		synctest.Wait()
+		select {
+		case <-r.stopCh:
+			t.Fatal("orphan watch fired for an exited session (exit cleanup owns that path)")
+		default:
+		}
+	})
 }
 
 func TestConnCtx_NextReadTimeout(t *testing.T) {

--- a/internal/workflow/cancel_test.go
+++ b/internal/workflow/cancel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -21,55 +22,65 @@ import (
 // ctx — `<-el.jobs` and the stub's gate both ignored it — so `attn workflow cancel`
 // hung forever on any run awaiting a live agent(). The 5s deadline guards below
 // turn that regression into a clear failure instead of a hung test.
+// Converted to synctest. Every wait here was a deadline guard standing in for a
+// state the test could not otherwise observe: "in flight", "settled", "torn
+// down". synctest.Wait blocks until every goroutine in the bubble is durably
+// blocked, so each of those is now read off a settled system — and the deadlock
+// this test regresses shows up as a bubble that never settles rather than as a
+// 5s timeout.
 func TestCancelWhileAwaitingLiveAgentSettlesAndTearsDownAgent(t *testing.T) {
-	// blockingStub parks every Run until released. We NEVER release it here, so the
-	// only way Run can return is by honoring ctx.Done() — exactly the path under test.
-	stub := newBlockingStub(echoPrompt)
-	eng := New(Config{Stub: stub, WatchdogTimeout: 30 * time.Second})
+	synctest.Test(t, func(t *testing.T) {
+		// blockingStub parks every Run until released. We NEVER release it here, so the
+		// only way Run can return is by honoring ctx.Done() — exactly the path under test.
+		stub := newBlockingStub(echoPrompt)
+		eng := New(Config{Stub: stub, WatchdogTimeout: 30 * time.Second})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	type outcome struct {
-		res RunResult
-		err error
-	}
-	done := make(chan outcome, 1)
-	go func() {
-		r, err := eng.Run(ctx, `return await agent("x");`, nil)
-		done <- outcome{r, err}
-	}()
-
-	// Wait until the agent is genuinely in flight (parked inside the stub): the loop
-	// is now parked on <-el.jobs and the dispatch is parked inside Run. This is the
-	// precise state where the watchdog's vm.Interrupt is a no-op.
-	if !stub.waitForInFlight(1, 5*time.Second) {
-		stub.releaseAll() // let the run unwind before failing
-		<-done
-		t.Fatalf("agent never reached in-flight; inFlight=%d", stub.inFlight.Load())
-	}
-
-	// Cancel mid-await. Settling now depends ENTIRELY on the pump's ctx.Done() select
-	// and the stub honoring ctx — neither the watchdog nor a stub release is involved.
-	cancel()
-
-	select {
-	case got := <-done:
-		if got.res.Status != StatusInterrupted {
-			t.Fatalf("status = %s (err=%v), want interrupted", got.res.Status, got.res.Err)
+		type outcome struct {
+			res RunResult
+			err error
 		}
-		var ie *ErrInterrupted
-		if !errors.As(got.err, &ie) {
-			t.Fatalf("err = %v (%T), want *ErrInterrupted", got.err, got.err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatalf("run did not settle within 5s of cancel — event loop stayed parked on <-el.jobs (cancel deadlock regression)")
-	}
+		done := make(chan outcome, 1)
+		go func() {
+			r, err := eng.Run(ctx, `return await agent("x");`, nil)
+			done <- outcome{r, err}
+		}()
 
-	// The run context must have reached AgentStub.Run: the parked stub observed
-	// ctx.Done() and unwound, dropping in-flight back to 0. If ctx were not threaded
-	// into Run, this goroutine would still be parked on the stub's gate.
-	if !stub.waitForInFlight(0, 5*time.Second) {
-		t.Fatalf("in-flight agent was not torn down after cancel (inFlight=%d); run ctx was not threaded into AgentStub.Run", stub.inFlight.Load())
-	}
+		// The agent is genuinely in flight (parked inside the stub): the loop is now
+		// parked on <-el.jobs and the dispatch is parked inside Run. This is the
+		// precise state where the watchdog's vm.Interrupt is a no-op.
+		synctest.Wait()
+		if got := stub.inFlight.Load(); got != 1 {
+			stub.releaseAll() // let the run unwind before failing
+			<-done
+			t.Fatalf("agent never reached in-flight; inFlight=%d", got)
+		}
+
+		// Cancel mid-await. Settling now depends ENTIRELY on the pump's ctx.Done() select
+		// and the stub honoring ctx — neither the watchdog nor a stub release is involved.
+		cancel()
+
+		synctest.Wait()
+		select {
+		case got := <-done:
+			if got.res.Status != StatusInterrupted {
+				t.Fatalf("status = %s (err=%v), want interrupted", got.res.Status, got.res.Err)
+			}
+			var ie *ErrInterrupted
+			if !errors.As(got.err, &ie) {
+				t.Fatalf("err = %v (%T), want *ErrInterrupted", got.err, got.err)
+			}
+		default:
+			t.Fatal("run did not settle after cancel — event loop stayed parked on <-el.jobs (cancel deadlock regression)")
+		}
+
+		// The run context must have reached AgentStub.Run: the parked stub observed
+		// ctx.Done() and unwound, dropping in-flight back to 0. If ctx were not threaded
+		// into Run, this goroutine would still be parked on the stub's gate.
+		if got := stub.inFlight.Load(); got != 0 {
+			t.Fatalf("in-flight agent was not torn down after cancel (inFlight=%d); run ctx was not threaded into AgentStub.Run", got)
+		}
+	})
 }

--- a/internal/workflow/concurrency_test.go
+++ b/internal/workflow/concurrency_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -69,22 +70,6 @@ func (s *blockingStub) Run(ctx context.Context, call AgentCall) (json.RawMessage
 // releaseAll lets every currently-parked and future Run proceed.
 func (s *blockingStub) releaseAll() { close(s.release) }
 
-// waitForInFlight blocks until inFlight reaches want (the cap is fully saturated)
-// or the deadline elapses. Returning true proves the cap was REACHED; the caller
-// separately asserts it was never EXCEEDED via maxInFlight. Polling an atomic is
-// the deterministic substitute for sleeping: we make a positive observation that
-// exactly `want` goroutines are simultaneously inside Run, rather than guessing.
-func (s *blockingStub) waitForInFlight(want int64, timeout time.Duration) bool {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if s.inFlight.Load() == want {
-			return true
-		}
-		time.Sleep(time.Millisecond)
-	}
-	return false
-}
-
 func echoPrompt(prompt string) json.RawMessage {
 	b, _ := json.Marshal("R:" + prompt)
 	return b
@@ -109,53 +94,64 @@ func boomOrEchoStub() AgentStub {
 //
 // Determinism: the run goroutine launches N agents whose Run() all park inside
 // the stub. With a cap of `cap`, the semaphore admits exactly `cap` of them; the
-// rest block on `rs.sem <- struct{}{}` and never enter Run. We poll until exactly
-// `cap` are in flight (a positive observation, not a sleep), then release. As each
-// finishes it frees a slot, admitting the next, so the high-water-mark can never
-// exceed `cap`. If the semaphore were broken (e.g. unbounded), inFlight would
-// blow past `cap` and maxInFlight would record it — failing the test.
+// rest block on `rs.sem <- struct{}{}` and never enter Run. As each finishes it
+// frees a slot, admitting the next, so the high-water-mark can never exceed
+// `cap`. If the semaphore were broken (e.g. unbounded), inFlight would blow past
+// `cap` and maxInFlight would record it — failing the test.
+//
+// Runs in a synctest bubble: the saturation check used to poll an atomic against
+// a 5s deadline, which could only ever say "capN were in flight at some moment I
+// happened to look". synctest.Wait returns when every goroutine in the bubble is
+// durably blocked — the admitted agents parked in the stub, the rest parked on
+// the semaphore — so the reading is of a system that has finished admitting.
+// "Exactly capN, and no more are coming" is now the claim rather than the hope.
 func assertCapSaturatedAndBounded(t *testing.T, script string, capN, wantLive int) RunResult {
 	t.Helper()
-	stub := newBlockingStub(echoPrompt)
-	eng := New(Config{
-		Stub:            stub,
-		ConcurrencyCap:  capN,
-		WatchdogTimeout: 10 * time.Second,
-	})
+	var result RunResult
+	synctest.Test(t, func(t *testing.T) {
+		stub := newBlockingStub(echoPrompt)
+		eng := New(Config{
+			Stub:            stub,
+			ConcurrencyCap:  capN,
+			WatchdogTimeout: 10 * time.Second,
+		})
 
-	done := make(chan RunResult, 1)
-	go func() {
-		r, _ := eng.Run(context.Background(), script, nil)
-		done <- r
-	}()
+		done := make(chan RunResult, 1)
+		go func() {
+			r, _ := eng.Run(context.Background(), script, nil)
+			done <- r
+		}()
 
-	// Wait until the cap is fully saturated: exactly `capN` goroutines inside Run.
-	if !stub.waitForInFlight(int64(capN), 5*time.Second) {
-		// Release so the run goroutine can unwind before we fail.
+		// Dispatch has settled: exactly `capN` goroutines are inside Run.
+		synctest.Wait()
+		if got := stub.inFlight.Load(); got != int64(capN) {
+			// Release so the run goroutine can unwind before we fail.
+			stub.releaseAll()
+			<-done
+			t.Fatalf("cap never saturated: inFlight settled at %d, want %d (semaphore not admitting up to the cap?)",
+				got, capN)
+		}
+
+		// The cap is saturated. Now release everything and let the run finish.
 		stub.releaseAll()
-		<-done
-		t.Fatalf("cap never saturated: inFlight reached %d, want %d (semaphore not admitting up to the cap?)",
-			stub.inFlight.Load(), capN)
-	}
+		r := <-done
 
-	// The cap is saturated. Now release everything and let the run finish.
-	stub.releaseAll()
-	r := <-done
-
-	if r.Status != StatusCompleted {
-		t.Fatalf("status=%s err=%v", r.Status, r.Err)
-	}
-	if got := stub.maxInFlight.Load(); got != int64(capN) {
-		t.Fatalf("max in-flight = %d, want exactly the cap %d (cap was %s)",
-			got, capN, capVerdict(got, int64(capN)))
-	}
-	if int(stub.calls.Load()) != wantLive {
-		t.Fatalf("total live Run calls = %d, want %d (some agents never dispatched)", stub.calls.Load(), wantLive)
-	}
-	if r.LiveCalls != wantLive {
-		t.Fatalf("LiveCalls = %d, want %d", r.LiveCalls, wantLive)
-	}
-	return r
+		if r.Status != StatusCompleted {
+			t.Fatalf("status=%s err=%v", r.Status, r.Err)
+		}
+		if got := stub.maxInFlight.Load(); got != int64(capN) {
+			t.Fatalf("max in-flight = %d, want exactly the cap %d (cap was %s)",
+				got, capN, capVerdict(got, int64(capN)))
+		}
+		if int(stub.calls.Load()) != wantLive {
+			t.Fatalf("total live Run calls = %d, want %d (some agents never dispatched)", stub.calls.Load(), wantLive)
+		}
+		if r.LiveCalls != wantLive {
+			t.Fatalf("LiveCalls = %d, want %d", r.LiveCalls, wantLive)
+		}
+		result = r
+	})
+	return result
 }
 
 func capVerdict(got, capN int64) string {

--- a/internal/workflow/ordinal_test.go
+++ b/internal/workflow/ordinal_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -79,37 +80,43 @@ func TestPipelineOrdinalStabilityUnderReorder(t *testing.T) {
 		t.Fatalf("expected 2 stage-1 ordinals, got %v (all=%v)", st1, baseline)
 	}
 
+	// Runs in a synctest bubble. The separation between the two stage-1 releases
+	// used to be a 15ms sleep hoping the first resolution landed first;
+	// synctest.Wait returns only when the engine has nothing left to do, so the
+	// releases are genuinely serialized and the two orders are genuinely opposite.
 	runWithReleaseOrder := func(order []string) map[string]string {
-		stub := NewScriptedStub(scriptedDeterministicResult)
-		eng := New(Config{Stub: stub, WatchdogTimeout: 5 * time.Second})
-		done := make(chan RunResult, 1)
-		go func() {
-			r, _ := eng.Run(context.Background(), script, nil)
-			done <- r
-		}()
-		// Release stage-0 calls so the pipeline can reach stage 1.
-		for ord := range baseline {
-			if !containsSeg(ord, "st1") {
+		out := map[string]string{}
+		synctest.Test(t, func(t *testing.T) {
+			stub := NewScriptedStub(scriptedDeterministicResult)
+			eng := New(Config{Stub: stub, WatchdogTimeout: 5 * time.Second})
+			done := make(chan RunResult, 1)
+			go func() {
+				r, _ := eng.Run(context.Background(), script, nil)
+				done <- r
+			}()
+			// Release stage-0 calls so the pipeline can reach stage 1.
+			for ord := range baseline {
+				if !containsSeg(ord, "st1") {
+					stub.Release(ord)
+				}
+			}
+			// Now release the two stage-1 calls in the requested order, each fully
+			// resolved before the next, so the resolutions truly interleave differently.
+			for _, ord := range order {
+				synctest.Wait()
 				stub.Release(ord)
 			}
-		}
-		// Now release the two stage-1 calls in the requested order, with a gap so
-		// the resolutions truly interleave differently.
-		for _, ord := range order {
-			time.Sleep(15 * time.Millisecond)
-			stub.Release(ord)
-		}
-		stub.ReleaseAll()
-		r := <-done
-		if r.Status != StatusCompleted {
-			t.Fatalf("status=%s err=%v", r.Status, r.Err)
-		}
-		out := map[string]string{}
-		for _, e := range r.Journal.Entries() {
-			var s string
-			_ = json.Unmarshal(e.Result, &s)
-			out[e.Ordinal] = s
-		}
+			stub.ReleaseAll()
+			r := <-done
+			if r.Status != StatusCompleted {
+				t.Fatalf("status=%s err=%v", r.Status, r.Err)
+			}
+			for _, e := range r.Journal.Entries() {
+				var s string
+				_ = json.Unmarshal(e.Result, &s)
+				out[e.Ordinal] = s
+			}
+		})
 		return out
 	}
 
@@ -141,36 +148,42 @@ func TestPipelineOrdinalStabilityUnderReorder(t *testing.T) {
 }
 
 // releaseOrderedMap runs script under a fresh ScriptedStub, releases the given
-// ordinals (in order, with a gap so resolutions truly interleave) and then opens
-// all remaining gates. It returns the ordinal->result mapping. The phased release
+// ordinals (in order, each fully resolved before the next) and then opens all
+// remaining gates. It returns the ordinal->result mapping. The phased release
 // lets a test drive the post-await continuations to resolve in a chosen order.
+//
+// Runs in a synctest bubble: the second wave's separation was a 15ms sleep, and
+// is now synctest.Wait — the engine having nothing left to do, which is what the
+// sleep was standing in for.
 func releaseOrderedMap(t *testing.T, script string, firstWave, secondWave []string) map[string]string {
 	t.Helper()
-	stub := NewScriptedStub(scriptedDeterministicResult)
-	eng := New(Config{Stub: stub, WatchdogTimeout: 5 * time.Second})
-	done := make(chan RunResult, 1)
-	go func() {
-		r, _ := eng.Run(context.Background(), script, nil)
-		done <- r
-	}()
-	for _, ord := range firstWave {
-		stub.Release(ord)
-	}
-	for _, ord := range secondWave {
-		time.Sleep(15 * time.Millisecond)
-		stub.Release(ord)
-	}
-	stub.ReleaseAll()
-	r := <-done
-	if r.Status != StatusCompleted {
-		t.Fatalf("status=%s err=%v", r.Status, r.Err)
-	}
 	out := map[string]string{}
-	for _, e := range r.Journal.Entries() {
-		var s string
-		_ = json.Unmarshal(e.Result, &s)
-		out[e.Ordinal] = s
-	}
+	synctest.Test(t, func(t *testing.T) {
+		stub := NewScriptedStub(scriptedDeterministicResult)
+		eng := New(Config{Stub: stub, WatchdogTimeout: 5 * time.Second})
+		done := make(chan RunResult, 1)
+		go func() {
+			r, _ := eng.Run(context.Background(), script, nil)
+			done <- r
+		}()
+		for _, ord := range firstWave {
+			stub.Release(ord)
+		}
+		for _, ord := range secondWave {
+			synctest.Wait()
+			stub.Release(ord)
+		}
+		stub.ReleaseAll()
+		r := <-done
+		if r.Status != StatusCompleted {
+			t.Fatalf("status=%s err=%v", r.Status, r.Err)
+		}
+		for _, e := range r.Journal.Entries() {
+			var s string
+			_ = json.Unmarshal(e.Result, &s)
+			out[e.Ordinal] = s
+		}
+	})
 	return out
 }
 
@@ -321,26 +334,30 @@ func TestParallelOrdinalStabilityUnderReorder(t *testing.T) {
 	}
 	sort.Strings(ords)
 
+	// Runs in a synctest bubble; see runWithReleaseOrder in
+	// TestPipelineOrdinalStabilityUnderReorder for why the sleeps are gone.
 	runWithReleaseOrder := func(order []string) map[string]string {
-		stub := NewScriptedStub(scriptedDeterministicResult)
-		eng := New(Config{Stub: stub, WatchdogTimeout: 5 * time.Second})
-		done := make(chan RunResult, 1)
-		go func() {
-			r, _ := eng.Run(context.Background(), script, nil)
-			done <- r
-		}()
-		for _, ord := range order {
-			time.Sleep(10 * time.Millisecond)
-			stub.Release(ord)
-		}
-		stub.ReleaseAll()
-		r := <-done
 		out := map[string]string{}
-		for _, e := range r.Journal.Entries() {
-			var s string
-			_ = json.Unmarshal(e.Result, &s)
-			out[e.Ordinal] = s
-		}
+		synctest.Test(t, func(t *testing.T) {
+			stub := NewScriptedStub(scriptedDeterministicResult)
+			eng := New(Config{Stub: stub, WatchdogTimeout: 5 * time.Second})
+			done := make(chan RunResult, 1)
+			go func() {
+				r, _ := eng.Run(context.Background(), script, nil)
+				done <- r
+			}()
+			for _, ord := range order {
+				synctest.Wait()
+				stub.Release(ord)
+			}
+			stub.ReleaseAll()
+			r := <-done
+			for _, e := range r.Journal.Entries() {
+				var s string
+				_ = json.Unmarshal(e.Result, &s)
+				out[e.Ordinal] = s
+			}
+		})
 		return out
 	}
 


### PR DESCRIPTION
Track B2 of the testing adoption wave: triage every time-paced test in the seven
candidate packages, then convert the half that fits in a `testing/synctest`
bubble. Test-only — no production code changes.

## The map

| package | paced | converted here | boundary-bound | candidate, not converted |
|---|---|---|---|---|
| `internal/daemon` | 199 | 20 | 59 | 120 |
| `internal/jobs` | 21 | 17 | 0 | 2 |
| `internal/pty` | 14 | 0 | 9 | 5 |
| `internal/ptybackend` | 11 | 0 | 8 | 3 |
| `internal/ptyworker` | 9 | 7 | 2 | 0 |
| `internal/daemonctl` | 6 | 0 | 6 | 0 |
| `internal/workflow` | 4 | 3 | 1 | 0 |
| **total** | **264** | **47** | **85** | **130** |

The full map — every boundary-bound test with its reason, the remaining
candidates ranked, and the house rules — is a new section in
`docs/plans/2026-08-09-testing-adoption-wave.md`.

**The plan's boundary assumption was wrong.** It expected "most daemon sleeps
sit behind real sockets/PTYs". They do not: 34 of the 48 daemon test files
containing paced tests carry no socket, PTY or child-process signal at all.
What actually pins a bubble to real time is a **child process**, **fsnotify**,
a real socket or PTY, **filesystem mtime** (a sleep buying a wall-clock
nanosecond, not a schedule), and a **CPU-bound goroutine**. The parallel D1
investigation measured the child-process case independently at 30.01s against
0.00s.

Three house rules make a daemon fit inside a bubble; all three are written up
in `internal/daemon/synctest_test.go` where they are used:

1. Build the daemon **outside** the bubble — `database/sql`'s
   `connectionOpener` goroutine never exits (the spike's documented deadlock).
2. Stop its background subsystems **inside** it, from a cleanup on the bubble's
   `T`.
3. Seed anything time-stamped **inside** it. The bubble clock starts at
   2000-01-01, so a fixture row stamped with real `time.Now` is dated decades
   ahead: a turn opened outside and settled inside settles *before* it opened
   and still reads as owed.

## What the conversions buy

Not speed — fidelity. Inside a bubble a production interval costs no wall
clock, so the tests now run the shipped schedule instead of a turned-down
stand-in:

- `internal/ptyworker` orphan watch at its real **12-hour** TTL and exit
  cleanup at its real 45s, where the tests substituted 15–50ms and then waited
  a tolerance window on top.
- The whole git-status scheduler family on the production 1s debounce, 30s
  safety interval, 2min slow-safety and 5s slow threshold. The slow-repo test
  now also proves the refresh is *delayed*, not abandoned — it was only
  asserting the negative before.
- Auto-settle across its real arm and countdown windows, in two phases, so a
  policy that settles early fails.
- The nudge countdown at `defaultNudgeCountdownWindow` instead of a 15ms
  override, and the deferred-approval nudge now fires on its own instead of
  being hand-fired.

And the negatives — "no second refresh", "no overlap", "no doorbell yet",
"cap N in flight" — assert against a system `synctest.Wait` has settled rather
than against whatever happened inside a 20ms window.

`overrideGitStatusSchedulerForTesting`, `waitForGitStatusTestCondition`,
`waitForNudge`, `waitFor` and `waitForInFlight` are deleted: nothing needs to
outrun a production interval any more.

## Flake classes retired

- **`TestStartJobQueueArmsThePeriodicTicks`** — "`notebook_cron` is not armed",
  full-suite load only. `startJobQueue` hands the cron entries to the runner,
  whose dispatch goroutine writes them; the test read them straight afterwards
  and won that race only on an idle machine. `synctest.Wait()` makes the read
  happen after the write by construction. 20/20 clean.
- **Tolerance-window negatives** across git-status sharing, orphan-watch
  suppression, auto-settle arming and workflow cap saturation — the
  load-sensitive class, now asserted structurally.

## Findings worth acting on

- **The job queue's periodic retention pass has never been under test.**
  `TestRetentionTrimsCompletedJobsAndKeepsDeadOnes` went red on conversion: the
  runner's hourly retention ticker really fires under a fake clock — 48 times
  across the test's 48-hour window — and trimmed the record before the manual
  `Trim` under test could. Under the old `fakeClock` that ticker ran on *real*
  time and never fired at all. The conversion parks it to keep the subject
  singular; the pass still deserves a test of its own.
- **`TestChiefTicketContinuityAcrossRoleTransfer` is left unconverted on
  purpose.** Its final assertion ("the retired chief received no role nudge")
  holds only while the nudge window is parked. Run the window out for real and
  the retired chief *is* doorbelled, because the fixture leaves it a personal
  participant on the ticket and `nudgeCount` cannot tell a personal nudge from
  a role one. That needs a narrower probe or a product answer, both outside a
  test-only sweep. The reason is recorded above the test.

## Verification

`go test -race -count=20` on every converted test — clean: the 20 daemon tests
(53.99s), `internal/jobs` (21.99s), `internal/workflow` (37.38s),
`internal/ptyworker` (14.49s). Full `-count=1` pass across all seven triaged
packages.

`go test -count=3` timings, same machine, sequential, against the merge base:

| package | before | after |
|---|---|---|
| `internal/jobs` | 0.43 / 0.46 / 0.57s | 0.53 / 0.54 / 0.60s |
| `internal/workflow` | 4.15 / 5.00s | 3.76 / 4.01s |
| `internal/ptyworker` | 3.66s | 2.86s |
| `internal/daemon` | 425.6s | 457.5s |

The whole-package daemon number is noise — 20 converted tests out of ~1200,
and the run-to-run spread on a 7-minute package swamps the delta. The number
that means something is the converted subset alone:

| subset | before | after |
|---|---|---|
| the 20 converted daemon tests | 9.43s | 2.09s |
| the 7 converted ptyworker tests | 1.70s | 0.33s |

`internal/jobs` is flat because its paced tests already ran on an injected
`fakeClock` — the spike traded a fake clock for a fake *world*, not for speed.

## Verification tier

Test-only change with no daemon lifecycle, protocol, PTY, background-runner or
UI surface: no production code is touched, so there is nothing for a running
app to show. Verified by the suites above.

https://claude.ai/code/session_01VJNiWQV5u8ocr9yXeVX3K5
