### PR TITLE
fix(workspacelayout): copy children before rebinding a tile

### DIFF
--- a/changelog.d/workspacelayout-tile-update-aliasing.yaml
+++ b/changelog.d/workspacelayout-tile-update-aliasing.yaml
@@ -1,0 +1,8 @@
+kind: fixed
+area: daemon
+change: >
+  Rebinding a docked tile's params or session no longer writes into the layout
+  tree it was handed. UpdateTileParams and UpdateTileSessionID assigned into the
+  caller's children array, so a caller that read a workspace layout, updated a
+  tile, and then read its own copy again would see the edit already applied —
+  every other layout operation copies its children first. They now do too.

--- a/internal/workspacelayout/workspacelayout.go
+++ b/internal/workspacelayout/workspacelayout.go
@@ -579,12 +579,15 @@ func UpdateTileSessionID(node Node, tileID, sessionID string) (Node, bool) {
 		node.TileSessionID = strings.TrimSpace(sessionID)
 		return node, true
 	case "split":
-		for index, child := range node.Children {
+		children := make([]Node, len(node.Children))
+		copy(children, node.Children)
+		for index, child := range children {
 			updated, ok := UpdateTileSessionID(child, tileID, sessionID)
 			if !ok {
 				continue
 			}
-			node.Children[index] = updated
+			children[index] = updated
+			node.Children = children
 			return node, true
 		}
 	}
@@ -601,12 +604,15 @@ func UpdateTileParams(node Node, tileID, tileParams string) (Node, bool) {
 		node.TileParams = strings.TrimSpace(tileParams)
 		return node, true
 	case "split":
-		for index, child := range node.Children {
+		children := make([]Node, len(node.Children))
+		copy(children, node.Children)
+		for index, child := range children {
 			updated, ok := UpdateTileParams(child, tileID, tileParams)
 			if !ok {
 				continue
 			}
-			node.Children[index] = updated
+			children[index] = updated
+			node.Children = children
 			return node, true
 		}
 	}

--- a/internal/workspacelayout/workspacelayout_property_test.go
+++ b/internal/workspacelayout/workspacelayout_property_test.go
@@ -319,15 +319,17 @@ func TestLayoutStaysAWellFormedTreeUnderRandomOperations(t *testing.T) {
 				params := rapid.SampledFrom(tileParams).Draw(t, "params")
 				session := rapid.SampledFrom(tileSessions).Draw(t, "session")
 
-				// Not run through apply: these two write through their input.
-				// See TestLayoutOperationsDoNotModifyTheirInput.
-				next, ok := UpdateTileParams(m.tree, tileID, params)
+				next, ok := apply(t, func(n Node) (Node, bool) {
+					return UpdateTileParams(n, tileID, params)
+				})
 				if !ok {
 					t.Fatalf("UpdateTileParams on tile %q, which is in the tree, was refused", tileID)
 				}
 				m.tree = next
 
-				next, ok = UpdateTileSessionID(m.tree, tileID, session)
+				next, ok = apply(t, func(n Node) (Node, bool) {
+					return UpdateTileSessionID(n, tileID, session)
+				})
 				if !ok {
 					t.Fatalf("UpdateTileSessionID on tile %q, which is in the tree, was refused", tileID)
 				}
@@ -437,23 +439,14 @@ func TestLayoutStaysAWellFormedTreeUnderRandomOperations(t *testing.T) {
 // Every operation in this package takes a Node by value and returns a new one.
 // That is only true if the children slices are copied rather than written
 // through — a Node value shares its children's backing array with every copy of
-// itself, so writing into it reaches the caller's tree. Split, Remove,
-// SetSplitRatio, DockTile and MoveLeaf all copy before writing.
-// UpdateTileParams and UpdateTileSessionID do not: they assign into
-// node.Children[index] directly, so the layout the caller handed in comes back
-// changed.
+// itself, so writing into it reaches the caller's tree.
 //
-// SKIPPED, and red. It is a real divergence from the rest of the package, but
-// no shipped call site reads its pre-update snapshot again — internal/daemon's
-// three callers (browser.go, workspacelayout.go, tilecontent.go) all use the
-// returned tree and drop the input — so this is a latent trap rather than a live
-// bug, and fixing it means changing production code, which this test-only change
-// deliberately does not do. Delete the Skip when the two functions copy their
-// children like their neighbours; the seed under testdata/rapid replays the
+// The stateful property above holds every operation to this through apply. This
+// one pins the two that once did not, UpdateTileParams and UpdateTileSessionID,
+// on the smallest tree that shows it: a caller that keeps reading the layout it
+// handed in must see what it read. The seed under testdata/rapid replays the
 // counterexample rapid shrank to.
 func TestLayoutOperationsDoNotModifyTheirInput(t *testing.T) {
-	t.Skip("UpdateTileParams/UpdateTileSessionID write through their input; see the comment above")
-
 	rapid.Check(t, func(t *rapid.T) {
 		tree, _ := DockTile(DefaultLayout("p0"), "p0", DirectionVertical, false, "s1",
 			"t1", string(TileKindMarkdown), "", "", DefaultSplitRatio)


### PR DESCRIPTION
`UpdateTileParams` and `UpdateTileSessionID` in `internal/workspacelayout`
assigned into `node.Children[index]`. A `Node` is taken by value, but its
`Children` slice header still points at the caller's backing array, so the
assignment wrote through the tree the caller handed in — the returned tree and
the input were the same tree. Every other operation in the package (`Split`,
`SetSplitRatio`, `Remove`, `DockTile`, `MoveLeaf`) copies the children slice
before writing into it. These two now do the same, in the same idiom.

This was latent, not live. All three daemon call sites — `browser.go:249`,
`workspacelayout.go:698`, `tilecontent.go:514` — use the returned tree and drop
the input, so nothing shipped observed the aliasing. It is a trap for the next
caller that reads its pre-update snapshot again.

## Where it came from

The package's rapid property suite (#804) found it. That change was test-only,
so it committed the shrunk counterexample as a **skipped** test,
`TestLayoutOperationsDoNotModifyTheirInput`, with its seed under
`internal/workspacelayout/testdata/rapid/`. It also routed the stateful
property's `update_tile` action around the shared non-mutation check for the
same reason.

Both come off here:

- the skip is deleted, and its comment now describes the contract rather than
  the exception;
- `update_tile` goes through `apply`, so both functions are held to the same
  "returns a new tree, does not write through the one it was given" check as
  every other operation in the headline property.

## Receipts

Seed replay, production code unchanged, skip removed — red on the committed
counterexample:

```
--- FAIL: TestLayoutOperationsDoNotModifyTheirInput
    UpdateTileParams wrote through its input:
     got: ... TileID:t1 ... TileParams:/tmp/notes.md ...
    want: ... TileID:t1 ... TileParams: ...
```

With the fix, `go test ./internal/workspacelayout -race -count=3` passes in
**1.4s**; `-rapid.checks=2000` over both properties passes in 0.5s.

Mutation check that the removed bypass is load-bearing: reverting only the
`UpdateTileParams` copy turns the *stateful* property red too, and the assert
that catches it is `apply`'s — "the operation modified the layout it was given"
— not one of the downstream model checks.

## Verification tier

Unit-level. Per AGENTS.md this is the exempt case: a pure isolated change fully
covered by unit tests, with no daemon lifecycle, protocol, PTY,
background-runner, timing, or UI surface. The two functions are pure tree
transforms, their signatures are unchanged, and no call site's behavior moves —
the three daemon callers already ignored the input they were mutating. `go build
./...` and the daemon's workspace-layout/tile-content/browser tests pass
unchanged.

Changelog fragment: `changelog.d/workspacelayout-tile-update-aliasing.yaml`
(kind: fixed, area: daemon).

https://claude.ai/code/session_01JqReHtCcs7z18D72EAa5vc