### PR TITLE
fix(daemon): make the ws timing knobs per-Daemon fields so eviction tests hold under -race

### DIFF
--- a/changelog.d/dizzy-gecko-ws-timing-knobs-race.yaml
+++ b/changelog.d/dizzy-gecko-ws-timing-knobs-race.yaml
@@ -1,0 +1,8 @@
+kind: internal
+area: daemon
+change: >
+  Moves the WebSocket test timing knobs (write timeout, keepalive ping
+  interval and pong deadline) from package vars to per-Daemon fields resolved
+  once at pump/loop start, so the eviction tests from the silent-eviction fix
+  hold under the race detector. Zero means the shipped defaults; only tests
+  set the fields, before the connection under test is dialed.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -129,25 +129,25 @@ type Daemon struct {
 	wsWriteTimeout time.Duration
 	wsPingInterval time.Duration
 	wsPingTimeout  time.Duration
-	listener               net.Listener
-	httpServer             *http.Server
-	httpListener           net.Listener // bound synchronously in Start(); a failure there is fatal
-	httpHandler            http.Handler
-	diagServer             *diag.Server // opt-in loopback pprof/expvar; nil unless ATTN_PPROF set
-	wsHub                  *wsHub
-	done                   chan struct{}
-	logger                 *logging.Logger
-	debugLogging           bool // cached DEBUG>=debug; gates per-chunk PTY hot-path logs
-	ghRegistry             *github.ClientRegistry
-	hubManager             *hub.Manager
-	classifier             Classifier // Optional, uses package-level classifier.Classify if nil
-	repoCaches             map[string]*repoCache
-	repoCacheMu            sync.RWMutex
-	gitCoordMu             sync.Mutex
-	gitCoord               *gitCoordinator
-	warnings               []protocol.DaemonWarning
-	warningsMu             sync.RWMutex
-	ptyBackend             ptybackend.Backend
+	listener       net.Listener
+	httpServer     *http.Server
+	httpListener   net.Listener // bound synchronously in Start(); a failure there is fatal
+	httpHandler    http.Handler
+	diagServer     *diag.Server // opt-in loopback pprof/expvar; nil unless ATTN_PPROF set
+	wsHub          *wsHub
+	done           chan struct{}
+	logger         *logging.Logger
+	debugLogging   bool // cached DEBUG>=debug; gates per-chunk PTY hot-path logs
+	ghRegistry     *github.ClientRegistry
+	hubManager     *hub.Manager
+	classifier     Classifier // Optional, uses package-level classifier.Classify if nil
+	repoCaches     map[string]*repoCache
+	repoCacheMu    sync.RWMutex
+	gitCoordMu     sync.Mutex
+	gitCoord       *gitCoordinator
+	warnings       []protocol.DaemonWarning
+	warningsMu     sync.RWMutex
+	ptyBackend     ptybackend.Backend
 	// hostSessions runs the conversation sessions — the ones whose agent lives
 	// in a headless host process rather than a PTY. See host_session.go.
 	hostSessions    *hostsession.Manager

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -121,6 +121,14 @@ type Daemon struct {
 	// automationDeliveryHook replaces only the final delivery call in focused
 	// provider-observation tests; production always leaves it nil.
 	automationDeliveryHook func(*store.AutomationRun) error
+	// wsWriteTimeout, wsPingInterval, and wsPingTimeout override the WebSocket
+	// write and keepalive pacing; 0 resolves to the shipped defaults (see
+	// websocket.go). Only tests set them, before the connection under test is
+	// dialed — per-Daemon fields captured at pump/loop start rather than
+	// package vars, so an override cannot race a pump that outlives its test.
+	wsWriteTimeout time.Duration
+	wsPingInterval time.Duration
+	wsPingTimeout  time.Duration
 	listener               net.Listener
 	httpServer             *http.Server
 	httpListener           net.Listener // bound synchronously in Start(); a failure there is fatal

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -789,15 +789,23 @@ func (d *Daemon) sendInitialState(client *wsClient) {
 	go d.fetchAllPRDetails()
 }
 
-// wsWriteTimeout bounds one message hand-off. Carried over unchanged from when
-// this pump was written; a client that cannot take one message in ten seconds
-// is not a slow client, it is a stopped one. Measured against a real app whose
-// socket had been frozen: a 400-session snapshot left 409,117 bytes stuck in
-// the client's receive queue and the pump sat on this deadline for its full
-// length, while the hub's slow-count never reached 2.
+// defaultWSWriteTimeout bounds one message hand-off. Carried over unchanged
+// from when this pump was written; a client that cannot take one message in
+// ten seconds is not a slow client, it is a stopped one. Measured against a
+// real app whose socket had been frozen: a 400-session snapshot left 409,117
+// bytes stuck in the client's receive queue and the pump sat on this deadline
+// for its full length, while the hub's slow-count never reached 2.
 //
-// A variable so tests can shrink it; nothing else writes to it.
-var wsWriteTimeout = 10 * time.Second
+// Tests shrink it per daemon via Daemon.wsWriteTimeout; the pump captures the
+// resolved value once at start.
+const defaultWSWriteTimeout = 10 * time.Second
+
+func (d *Daemon) wsWriteTimeoutDuration() time.Duration {
+	if d.wsWriteTimeout > 0 {
+		return d.wsWriteTimeout
+	}
+	return defaultWSWriteTimeout
+}
 
 // wsWritePump hands one message at a time to a client.
 //
@@ -809,6 +817,7 @@ var wsWriteTimeout = 10 * time.Second
 // itself needs no help here: the library tears it down when its own write
 // deadline expires.
 func (d *Daemon) wsWritePump(client *wsClient) {
+	writeTimeout := d.wsWriteTimeoutDuration()
 	stalled := false
 	defer func() {
 		code, reason := client.closeStatus()
@@ -824,7 +833,7 @@ func (d *Daemon) wsWritePump(client *wsClient) {
 	}()
 
 	for message := range client.send {
-		ctx, cancel := context.WithTimeout(context.Background(), wsWriteTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), writeTimeout)
 		wsType := websocket.MessageText
 		if message.kind != messageKindText {
 			wsType = websocket.MessageBinary
@@ -839,9 +848,9 @@ func (d *Daemon) wsWritePump(client *wsClient) {
 			// The library reports a timed-out write and a write to a connection
 			// closed underneath it through the same error, and which one it
 			// picks is a race. The clock is ours and says which happened.
-			stalled = elapsed >= wsWriteTimeout
+			stalled = elapsed >= writeTimeout
 			if stalled {
-				d.logf("WebSocket client took longer than %s to accept a message, giving up on it", wsWriteTimeout)
+				d.logf("WebSocket client took longer than %s to accept a message, giving up on it", writeTimeout)
 			}
 			return
 		}
@@ -865,12 +874,27 @@ func (d *Daemon) wsMsgPump(client *wsClient) {
 	d.logf("WebSocket message pump exited")
 }
 
-// The keepalive. Variables so tests can shrink them; nothing else writes to
-// them. Both carried over unchanged from when this loop was written.
-var (
-	wsPingInterval = 30 * time.Second
-	wsPingTimeout  = 10 * time.Second
+// The keepalive defaults, both carried over unchanged from when this loop was
+// written. Tests shrink them per daemon via Daemon.wsPingInterval and
+// Daemon.wsPingTimeout; the loop captures the resolved values once at start.
+const (
+	defaultWSPingInterval = 30 * time.Second
+	defaultWSPingTimeout  = 10 * time.Second
 )
+
+func (d *Daemon) wsPingIntervalDuration() time.Duration {
+	if d.wsPingInterval > 0 {
+		return d.wsPingInterval
+	}
+	return defaultWSPingInterval
+}
+
+func (d *Daemon) wsPingTimeoutDuration() time.Duration {
+	if d.wsPingTimeout > 0 {
+		return d.wsPingTimeout
+	}
+	return defaultWSPingTimeout
+}
 
 // wsPingLoop sends periodic pings to keep the connection alive and detect dead
 // clients.
@@ -883,7 +907,8 @@ var (
 // daemon is still holding messages for is one that could not keep up, and that
 // one deserves an answer when it comes back.
 func (d *Daemon) wsPingLoop(client *wsClient, done <-chan struct{}) {
-	ticker := time.NewTicker(wsPingInterval)
+	pingTimeout := d.wsPingTimeoutDuration()
+	ticker := time.NewTicker(d.wsPingIntervalDuration())
 	defer ticker.Stop()
 
 	for {
@@ -891,7 +916,7 @@ func (d *Daemon) wsPingLoop(client *wsClient, done <-chan struct{}) {
 		case <-done:
 			return
 		case <-ticker.C:
-			ctx, cancel := context.WithTimeout(context.Background(), wsPingTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
 			err := client.conn.Ping(ctx)
 			cancel()
 			if err != nil {

--- a/internal/daemon/ws_eviction_test.go
+++ b/internal/daemon/ws_eviction_test.go
@@ -200,14 +200,11 @@ func TestEvictedClientLearnsWhyOnItsNextConnection(t *testing.T) {
 // connection ending is the library's own doing — asserted here because the
 // notice is worthless if the client never gets disconnected in the first place.
 func TestWriteStallEndsTheConnectionAndIsRemembered(t *testing.T) {
-	restore := wsWriteTimeout
-	wsWriteTimeout = 300 * time.Millisecond
-	t.Cleanup(func() { wsWriteTimeout = restore })
-
 	wsPort := useFreeWSPort(t)
 	tmpDir := shortTempDir(t)
 	sockPath := filepath.Join(tmpDir, "test.sock")
 	d := NewForTesting(sockPath)
+	d.wsWriteTimeout = 300 * time.Millisecond
 	go d.Start()
 	defer d.Stop()
 	waitForSocket(t, sockPath, 5*time.Second)
@@ -284,14 +281,11 @@ func TestWriteStallEndsTheConnectionAndIsRemembered(t *testing.T) {
 // an unanswered ping with nothing owed is a connection that died, and a client
 // that comes back from that has nothing to be told.
 func TestUnansweredPingIsAnEvictionOnlyWhenTheDaemonOwesTheClient(t *testing.T) {
-	restoreInterval, restoreTimeout := wsPingInterval, wsPingTimeout
-	wsPingInterval, wsPingTimeout = 200*time.Millisecond, 200*time.Millisecond
-	t.Cleanup(func() { wsPingInterval, wsPingTimeout = restoreInterval, restoreTimeout })
-
 	wsPort := useFreeWSPort(t)
 	tmpDir := shortTempDir(t)
 	sockPath := filepath.Join(tmpDir, "test.sock")
 	d := NewForTesting(sockPath)
+	d.wsPingInterval, d.wsPingTimeout = 200*time.Millisecond, 200*time.Millisecond
 	go d.Start()
 	defer d.Stop()
 	waitForSocket(t, sockPath, 5*time.Second)
@@ -340,8 +334,9 @@ func TestUnansweredPingIsAnEvictionOnlyWhenTheDaemonOwesTheClient(t *testing.T) 
 
 	// Back to the shipped keepalive before reconnecting: a 200ms pong deadline
 	// is a trap for a healthy client too, and this leg is about what the daemon
-	// says, not how fast it pings.
-	wsPingInterval, wsPingTimeout = restoreInterval, restoreTimeout
+	// says, not how fast it pings. The ping loops of the two dropped clients
+	// captured their pacing at start, so this write races nothing.
+	d.wsPingInterval, d.wsPingTimeout = 0, 0
 	second := dialDaemonWSAs(t, ctx, addr, stalledID)
 	defer second.Close(websocket.StatusNormalClosure, "")
 	notice := readEventUntil(t, ctx, second, protocol.EventClientEvictionNotice)


### PR DESCRIPTION
## What

Follow-up queued by #810: the eviction tests it added overrode the package vars `wsWriteTimeout`, `wsPingInterval`, and `wsPingTimeout` around a running daemon, and restored them in a test `Cleanup`. The ping loop read its pong deadline on every iteration, so the restore raced the loop's reads under the race detector (`go test -race -run TestUnansweredPingIsAnEvictionOnlyWhenTheDaemonOwesTheClient ./internal/daemon` failed 2/2). The write-stall test had the same shape.

## How

The three knobs are now per-`Daemon` fields; 0 resolves to the shipped defaults (`defaultWSWriteTimeout` 10s, `defaultWSPingInterval` 30s, `defaultWSPingTimeout` 10s) through small resolver methods. `wsWritePump` and `wsPingLoop` capture the resolved values **once at start** — the capture is the load-bearing part, not the field move: with per-iteration reads, a mid-test write would still race a live loop. Now an override is only observed by pumps/loops that start after it, an ordering the tests already establish by setting the field before dialing the connection under test.

The mid-test "back to shipped keepalive" step in the unanswered-ping test becomes a plain field reset to 0 before the third connection dials; the two dropped clients' ping loops captured their pacing at start, so that write races nothing.

## Verified

- `go test -race -count=2 ./internal/daemon -run 'TestEvictedClient|TestWriteStall|TestUnansweredPing|TestEvictionMemory'` — green (the unanswered-ping repro failed 2/2 before).
- Full `go test ./internal/daemon` — green.
- No live verification: pure test-infrastructure refactor of timing-knob plumbing, fully covered by the package's own tests; production behavior is byte-identical (defaults resolve to the same constants).

https://claude.ai/code/session_01TYxCnEV3XVGgnaWgMxPNK3