### PR TITLE
fix(sessions): say when a conversation's start is gone

### DIFF
--- a/app/src/components/ConversationPane/ConversationPane.css
+++ b/app/src/components/ConversationPane/ConversationPane.css
@@ -94,6 +94,14 @@
   color: var(--color-error);
 }
 
+/* The top of a conversation whose start the host no longer keeps. It is not a
+   notice from the agent's side of the exchange, so it sits apart from the first
+   item rather than between two of them. */
+.conversation-pane-dropped {
+  flex: 0 0 auto;
+  margin-bottom: 8px;
+}
+
 .conversation-pane-empty {
   color: var(--color-text-secondary);
   font-size: var(--font-size-sm);

--- a/app/src/components/ConversationPane/ConversationPane.history.test.tsx
+++ b/app/src/components/ConversationPane/ConversationPane.history.test.tsx
@@ -185,3 +185,135 @@ describe('ConversationPane history', () => {
     expect(screen.getByTestId('conversation-model')).toHaveTextContent('local/experimental');
   });
 });
+
+/**
+ * Retention reached: the host's transcript budget dropped the start of the
+ * conversation for good. Nothing can page it back, so the only honest thing the
+ * pane can do is say so — a transcript that silently begins mid-thought is the
+ * failure this row exists to prevent.
+ */
+describe('ConversationPane dropped history', () => {
+  beforeEach(() => {
+    useConversationsStore.setState({ conversations: {} });
+  });
+
+  function dropped(count: number, hasMore: boolean, seq = 2) {
+    apply('conversation_snapshot', {
+      epoch: 'e1',
+      items: [{ kind: 'message', id: 'm900', role: 'assistant', text: 'nine hundred', streaming: false }],
+      has_more: hasMore,
+      dropped: count,
+      running: false,
+      queue: { steering: [], followUp: [] },
+    }, seq);
+  }
+
+  it('says how much of the conversation is gone once there is nothing left to page', () => {
+    renderPane();
+    apply('session_ready', { state: 'idle' }, 1);
+    dropped(1_240, false);
+
+    const row = screen.getByTestId('conversation-history-dropped');
+    expect(row).toHaveTextContent('1,240 earlier items are no longer kept');
+    expect(row.getAttribute('data-dropped')).toBe('1240');
+  });
+
+  it('stays quiet while the way back is still offered', () => {
+    // Retention has dropped items AND the host still holds pageable ones. The
+    // row would be premature: what the user can reach has not run out yet, and
+    // the button is the honest surface until it does.
+    renderPane();
+    apply('session_ready', { state: 'idle' }, 1);
+    dropped(1_240, true);
+
+    expect(screen.queryByTestId('conversation-history-dropped')).toBeNull();
+    expect(screen.getByTestId('conversation-load-earlier')).toBeInTheDocument();
+  });
+
+  it('draws nothing for a conversation that simply reached its start', () => {
+    // The ordinary short conversation: a window covering everything, nothing
+    // dropped. This is why the row is driven by the dropped count rather than by
+    // "the window did not carry it all".
+    renderPane();
+    apply('session_ready', { state: 'idle' }, 1);
+    dropped(0, false);
+
+    expect(screen.queryByTestId('conversation-history-dropped')).toBeNull();
+  });
+
+  it('does not double-count under StrictMode', () => {
+    // The bar this repo holds for any new surface: React replays state updaters,
+    // so a count folded in with anything other than an idempotent rule reads
+    // double here and never in a live window.
+    renderPane({ strict: true });
+    apply('session_ready', { state: 'idle' }, 1);
+    dropped(1_240, false);
+
+    expect(screen.getByTestId('conversation-history-dropped').getAttribute('data-dropped')).toBe('1240');
+  });
+
+  it('keeps the count when a later snapshot splices onto scroll-back', () => {
+    // The real splice: this client has paged an older item in, so the incoming
+    // window's oldest item sits in the MIDDLE of what it holds and the window is
+    // taken as the tail. A snapshot that arrives then describes the same host,
+    // and dropping its count would make the row flicker away every time the
+    // agent spoke.
+    renderPane();
+    apply('session_ready', { state: 'idle' }, 1);
+    apply('conversation_snapshot', {
+      epoch: 'e1',
+      items: [{ kind: 'message', id: 'm900', role: 'assistant', text: 'nine hundred', streaming: false }],
+      has_more: true,
+      dropped: 1_240,
+      running: false,
+      queue: { steering: [], followUp: [] },
+    }, 2);
+    apply('conversation_page', {
+      epoch: 'e1',
+      before: 'message:m900',
+      items: [{ kind: 'message', id: 'm899', role: 'assistant', text: 'eight ninety nine', streaming: false }],
+      has_more: false,
+    }, 3);
+    // Scrolled back, nothing left to page: the row is showing.
+    expect(screen.getByTestId('conversation-history-dropped')).toBeInTheDocument();
+
+    // The agent speaks. The snapshot's window starts at m900, which this client
+    // holds at index 1 — a splice, not a replace.
+    apply('conversation_snapshot', {
+      epoch: 'e1',
+      items: [
+        { kind: 'message', id: 'm900', role: 'assistant', text: 'nine hundred', streaming: false },
+        { kind: 'message', id: 'm901', role: 'assistant', text: 'nine oh one', streaming: false },
+      ],
+      has_more: true,
+      dropped: 1_250,
+      running: false,
+      queue: { steering: [], followUp: [] },
+    }, 4);
+
+    expect(screen.getByTestId('conversation-message-m899')).toBeInTheDocument();
+    expect(screen.getByTestId('conversation-message-m901')).toBeInTheDocument();
+    expect(screen.getByTestId('conversation-history-dropped').getAttribute('data-dropped')).toBe('1250');
+  });
+
+  it('forgets it when a rebuilt host reads the whole conversation back', () => {
+    // A new epoch is a replacement host that reopened pi's session file from the
+    // start. What the dead host had dropped is not missing from this one, so
+    // carrying the old count forward would claim a loss that did not happen.
+    renderPane();
+    apply('session_ready', { state: 'idle' }, 1);
+    dropped(1_240, false);
+    expect(screen.getByTestId('conversation-history-dropped')).toBeInTheDocument();
+
+    apply('conversation_snapshot', {
+      epoch: 'e2',
+      items: [{ kind: 'message', id: 'r1', role: 'assistant', text: 'rebuilt', streaming: false }],
+      has_more: false,
+      dropped: 0,
+      running: false,
+      queue: { steering: [], followUp: [] },
+    }, 3);
+
+    expect(screen.queryByTestId('conversation-history-dropped')).toBeNull();
+  });
+});

--- a/app/src/components/ConversationPane/index.tsx
+++ b/app/src/components/ConversationPane/index.tsx
@@ -52,7 +52,7 @@ export function ConversationPane({ sessionId, paneActive, sessionState, resolved
   const listRef = useRef<HTMLDivElement | null>(null);
   const attachedRef = useRef<string | null>(null);
 
-  const { running, awaitingRun, ready, items, queue, lastSeq, hasMoreBefore, loadingHistory, model, models } = conversation;
+  const { running, awaitingRun, ready, items, queue, lastSeq, hasMoreBefore, loadingHistory, droppedBefore, model, models } = conversation;
   const recoverable = sessionState === 'recoverable';
 
   // Ask the host for a snapshot when this client has never seen its stream: a
@@ -210,6 +210,19 @@ export function ConversationPane({ sessionId, paneActive, sessionState, resolved
         onScroll={handleScroll}
         data-testid="conversation-messages"
       >
+        {droppedBefore > 0 && !hasMoreBefore && (
+          // The conversation is longer than anything anyone can still be shown:
+          // the host's retention budget dropped the start for good, and no page
+          // will answer for it. Saying so is the difference between a history
+          // that begins mid-thought and one that explains why.
+          <div
+            className="conversation-notice conversation-notice--info conversation-pane-dropped"
+            data-testid="conversation-history-dropped"
+            data-dropped={droppedBefore}
+          >
+            {`${droppedBefore.toLocaleString()} earlier ${droppedBefore === 1 ? 'item' : 'items'} are no longer kept for this conversation.`}
+          </div>
+        )}
         {hasMoreBefore && (
           // Auto-loading covers the reader who scrolls; this covers the one
           // whose transcript is shorter than the pane, where there is no room

--- a/app/src/components/ConversationPane/index.tsx
+++ b/app/src/components/ConversationPane/index.tsx
@@ -216,7 +216,7 @@ export function ConversationPane({ sessionId, paneActive, sessionState, resolved
           // will answer for it. Saying so is the difference between a history
           // that begins mid-thought and one that explains why.
           <div
-            className="conversation-notice conversation-notice--info conversation-pane-dropped"
+            className="conversation-notice conversation-pane-dropped"
             data-testid="conversation-history-dropped"
             data-dropped={droppedBefore}
           >

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -3131,6 +3131,13 @@ export function useUiAutomationBridge({
           // then; a scenario clicks it and asserts the transcript grew upwards.
           loadEarlierAvailable: Boolean(earlier),
           loadingHistory: Boolean(earlier instanceof HTMLButtonElement && earlier.disabled),
+          // How much of the conversation the host's retention budget dropped for
+          // good. 0 when nothing is gone, which is every ordinary session — the
+          // row it reads from appears only once there is also nothing left to
+          // page, so this is the whole of "the transcript starts above here".
+          historyDropped: Number(
+            root.querySelector('[data-testid="conversation-history-dropped"]')?.getAttribute('data-dropped') || 0,
+          ),
           // What the agent runs on now, and what this machine could switch it
           // to. Empty when the host said nothing about models.
           model: model?.value || '',

--- a/app/src/store/conversations.ts
+++ b/app/src/store/conversations.ts
@@ -150,6 +150,11 @@ export interface ConversationState {
   // addressed by the oldest item held, so a second request while one is in
   // flight would ask for the same page twice.
   loadingHistory: boolean;
+  // How many items the host's retention budget has dropped for good. No page
+  // will ever answer with them, so unlike `hasMoreBefore` this does not go away
+  // by scrolling: it is the reason the transcript starts where it does, and the
+  // transcript says so rather than appearing to begin mid-thought.
+  droppedBefore: number;
   // The model this session's agent is running on, and everything this machine
   // could switch it to. Both come from the host, which reads them out of pi.
   model: string;
@@ -179,6 +184,7 @@ const emptyConversation: ConversationState = {
   epoch: '',
   hasMoreBefore: false,
   loadingHistory: false,
+  droppedBefore: 0,
   model: '',
   models: [],
   running: false,
@@ -214,6 +220,11 @@ function text(body: Record<string, unknown>, key: string): string {
 
 function flag(body: Record<string, unknown>, key: string): boolean {
   return body[key] === true;
+}
+
+function count(body: Record<string, unknown>, key: string): number {
+  const value = body[key];
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
 }
 
 function stringList(body: Record<string, unknown>, key: string): string[] {
@@ -313,14 +324,21 @@ function snapshotItem(value: unknown): ConversationItem | null {
  * unchanged, so what the client already knew about the conversation behind it
  * still holds; the snapshot's own answer is about the window's start, which is
  * no longer the start of what is drawn.
+ *
+ * `droppedBefore` is the snapshot's own count on both sides. The host is the
+ * authority on what it has thrown away, and within one epoch that number only
+ * grows; across epochs a rebuilt host has read pi's session file from the start,
+ * so carrying the dead host's losses forward would claim a gap this transcript
+ * does not have.
  */
 function mergeSnapshotWindow(
   current: ConversationState,
   epoch: string,
   window: ConversationItem[],
   hasMore: boolean,
-): Pick<ConversationState, 'items' | 'epoch' | 'hasMoreBefore'> {
-  const replace = { items: window, epoch, hasMoreBefore: hasMore };
+  dropped: number,
+): Pick<ConversationState, 'items' | 'epoch' | 'hasMoreBefore' | 'droppedBefore'> {
+  const replace = { items: window, epoch, hasMoreBefore: hasMore, droppedBefore: dropped };
   if (epoch === '' || epoch !== current.epoch || window.length === 0) return replace;
   const anchor = conversationItemKey(window[0]);
   const index = current.items.findIndex((item) => conversationItemKey(item) === anchor);
@@ -329,6 +347,7 @@ function mergeSnapshotWindow(
     items: [...current.items.slice(0, index), ...window],
     epoch,
     hasMoreBefore: current.hasMoreBefore,
+    droppedBefore: dropped,
   };
 }
 
@@ -367,7 +386,13 @@ function applyToConversation(
       // this client already holds. A different epoch means the transcript was
       // rebuilt (a revived host reading pi's session file), and then replacing
       // is the only honest answer — the item ids came from somewhere else.
-      const merged = mergeSnapshotWindow(current, text(body, 'epoch'), window, flag(body, 'has_more'));
+      const merged = mergeSnapshotWindow(
+        current,
+        text(body, 'epoch'),
+        window,
+        flag(body, 'has_more'),
+        count(body, 'dropped'),
+      );
       return {
         ...current,
         ...merged,

--- a/changelog.d/pi-host-dropped-history.yaml
+++ b/changelog.d/pi-host-dropped-history.yaml
@@ -1,0 +1,15 @@
+kind: fixed
+area: sessions
+change: >
+  A conversation long enough to outgrow what attn keeps now says so. Once there
+  is nothing older left to load, the transcript is headed by a row naming how
+  many earlier items are no longer kept, instead of appearing to begin
+  mid-thought. Reloading a session that reads its whole history back clears the
+  row. A message the agent is still writing is also no longer dropped while it
+  is being written, which could split a paragraph in two and file the first half
+  under the tool that ran beneath it.
+symptom: >
+  In a very long conversation, the oldest messages were dropped silently: the
+  transcript simply started partway through with no way to tell whether it had
+  always been that short. In the same conversations, a reply still streaming
+  could lose its opening and reappear truncated, out of order, below a tool call.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -334,6 +334,12 @@ next page request comes back empty. It is bounded and it is inherent to paging
 something that is broadcast: the client's copy is the client's, and the host
 never reaches back into it.
 
+A conversation whose start the host has dropped says so. Once there is no page
+left to ask for and items are known to be gone, the transcript is headed by a
+row naming how many — the same honesty a compaction row gives, for the same
+reason: a history that appears to begin mid-thought is indistinguishable from
+one that did.
+
 A conversation can be **resumed**: a new session picks up an existing
 conversation instead of starting empty. The old conversation is copied into the
 new session's own storage rather than continued in place, so the session it came

--- a/plugins/attn-pi/AGENTS.md
+++ b/plugins/attn-pi/AGENTS.md
@@ -166,6 +166,13 @@ See `docs/glossary.md` for the vocabulary and
   refusing to send it all at once. Retention is a tripwire — a conversation that
   reaches it has been talking for weeks — and every settle logs what was held,
   which is where the next remeasurement comes from.
+  `ATTN_PI_HOST_RETENTION_ITEMS` and `ATTN_PI_HOST_RETENTION_BYTES` lower them
+  (read from the daemon's environment at spawn, inherited by the host): the
+  tripwire is set past the longest conversation anyone here has ever had, so
+  lowering it is the only way to watch a host actually drop history. A value
+  that is not a positive whole number is logged and treated as absent — meaning
+  the default, never zero, because a typo in a diagnostic variable must not
+  quietly reduce a conversation to one item.
 - **What retention drops, the snapshot admits to.** `dropped` counts the items
   gone for good, and it is a different question from `truncated` ("this message
   does not carry everything", which a client pages away) and from `has_more`

--- a/plugins/attn-pi/AGENTS.md
+++ b/plugins/attn-pi/AGENTS.md
@@ -166,6 +166,22 @@ See `docs/glossary.md` for the vocabulary and
   refusing to send it all at once. Retention is a tripwire — a conversation that
   reaches it has been talking for weeks — and every settle logs what was held,
   which is where the next remeasurement comes from.
+- **What retention drops, the snapshot admits to.** `dropped` counts the items
+  gone for good, and it is a different question from `truncated` ("this message
+  does not carry everything", which a client pages away) and from `has_more`
+  ("ask me again"). Once nothing is left to page and `dropped` is non-zero, the
+  app draws a row saying so: a transcript that silently begins mid-thought is
+  the failure the compaction row already exists to prevent, and a budget nobody
+  can see is worse than no budget. A rebuilt host reports its own count under a
+  new epoch, so a revive that reads the whole session file back clears the row
+  rather than inheriting a loss it does not have.
+- **Retention never evicts a message that is still being written.** A streaming
+  message is normally the newest item and safe, but it stops being newest the
+  moment pi opens a tool beneath it. Evicting it there does not merely lose it:
+  the next delta finds no open message, mints a fresh one from the tail alone,
+  and the agent's paragraph reappears truncated and out of order, below the tool
+  it was written above. Holding it costs one item over budget until it ends,
+  which is the bargain the newest item already gets.
 - **`epoch` is the transcript's seq spine.** A snapshot names the host process
   that built it. A replacement host rebuilds the transcript from pi's file and
   mints its own item ids, so nothing it sends can be spliced onto the dead

--- a/plugins/attn-pi/host/envelope.ts
+++ b/plugins/attn-pi/host/envelope.ts
@@ -1061,6 +1061,36 @@ export const TRANSCRIPT_RETENTION_ITEMS = 50_000;
  */
 export const TRANSCRIPT_RETENTION_BYTES = 32 << 20;
 
+/**
+ * A retention budget the environment asked for, or the compiled-in default.
+ *
+ * The override exists to make the tripwire reachable: 50,000 items and 32 MB
+ * are set past the longest conversation anyone here has ever had, so the only
+ * way to watch a host actually drop history — and the app say so — is to lower
+ * them. It is the escape hatch too, for a machine where a host's memory matters
+ * more than a month of scroll-back.
+ *
+ * A value that is not a positive count is reported through `warn` and treated
+ * as absent, meaning the DEFAULT rather than zero: a typo in a tuning variable
+ * must not silently reduce a conversation to one item, and refusing to launch
+ * over a diagnostic environment variable is worse than either. `raw` is the
+ * already-trimmed value, and empty means nobody asked.
+ */
+export function retentionBudget(
+  name: string,
+  raw: string,
+  fallback: number,
+  warn: (message: string) => void,
+): number {
+  if (raw === "") return fallback;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || !Number.isInteger(value) || value < 1) {
+    warn(`${name}=${raw} is not a positive whole number; using ${fallback}`);
+    return fallback;
+  }
+  return value;
+}
+
 function itemBytes(item: SnapshotItem): number {
   if (item.kind === "message") return item.text.length + item.role.length + item.id.length;
   if (item.kind === "notice") return item.text.length + item.id.length;

--- a/plugins/attn-pi/host/envelope.ts
+++ b/plugins/attn-pi/host/envelope.ts
@@ -972,6 +972,16 @@ export interface ConversationSnapshotBody {
   truncated: boolean;
   /** Older items than `items[0]` are held and can be paged in. */
   has_more: boolean;
+  /**
+   * Items retention has dropped for good, which no page will ever answer with.
+   *
+   * Distinct from `truncated`, which is only "this message does not carry
+   * everything" and goes false as a client pages back. This one never goes
+   * down, and it is what lets the app say the conversation starts above what
+   * anyone can still be shown instead of drawing a history that appears to
+   * begin mid-thought.
+   */
+  dropped: number;
   /** A run is open right now, so the composer sends a steer rather than a prompt. */
   running: boolean;
   /** pi's queues as of now, so an attaching client draws what is still unread. */
@@ -1234,6 +1244,7 @@ export class TranscriptStore {
       total: this.items.length + this.dropped,
       truncated: window.length < this.items.length + this.dropped,
       has_more: window.length < this.items.length,
+      dropped: this.dropped,
       running: this.running,
       queue: { steering: [...this.queue.steering], followUp: [...this.queue.followUp] },
     };
@@ -1307,11 +1318,22 @@ export class TranscriptStore {
    * This is the tripwire, not the window: what it drops is gone from this host
    * for good, and paging past it answers with nothing. The window is applied
    * separately, on the way out.
+   *
+   * It also never drops a message that is still being written. A streaming
+   * message is normally the newest item and safe by the rule above, but it
+   * stops being newest the moment pi opens a tool beneath it — and evicting it
+   * then does not merely lose it: the next delta finds no open message, mints a
+   * fresh one from the tail alone, and the agent's paragraph reappears
+   * truncated and out of order, below the tool it was written above. Holding it
+   * costs one item over budget until it ends, which is the same bargain the
+   * newest item already gets.
    */
   private trim(): void {
     while (this.items.length > 1 && (this.items.length > this.retentionItems || this.bytes > this.retentionBytes)) {
-      const dropped = this.items.shift()!;
-      this.bytes -= itemBytes(dropped);
+      const oldest = this.items[0]!;
+      if (oldest.kind === "message" && oldest.streaming) return;
+      this.items.shift();
+      this.bytes -= itemBytes(oldest);
       this.dropped += 1;
     }
   }

--- a/plugins/attn-pi/host/index.ts
+++ b/plugins/attn-pi/host/index.ts
@@ -49,6 +49,7 @@ import {
   launchPromptIsUndelivered,
   parseVerb,
   reconstructTranscript,
+  retentionBudget,
   type Envelope,
   type HostSessionState,
   type HostVerb,
@@ -126,29 +127,10 @@ function optionalEnv(name: string): string {
   return process.env[name]?.trim() ?? "";
 }
 
-/**
- * A retention budget from the environment, or the compiled-in default.
- *
- * These exist to make the tripwire reachable: 50,000 items and 32 MB are set
- * past the longest conversation anyone here has ever had, so the only way to
- * watch a host actually drop history — and the app say so — is to lower them.
- * They are the escape hatch too, for a machine where a host's memory matters
- * more than a month of scroll-back.
- *
- * A value that is not a positive count is reported and treated as absent,
- * meaning the DEFAULT rather than zero: a typo in a tuning variable must not
- * silently reduce a conversation to one item, and refusing to launch over a
- * diagnostic environment variable is worse than either.
- */
-function retentionBudget(name: string, fallback: number): number {
-  const raw = optionalEnv(name);
-  if (raw === "") return fallback;
-  const value = Number(raw);
-  if (!Number.isFinite(value) || !Number.isInteger(value) || value < 1) {
-    console.error(`[attn-pi-host] ${name}=${raw} is not a positive whole number; using ${fallback}`);
-    return fallback;
-  }
-  return value;
+/** `retentionBudget` reading the environment and reporting on the host's log. */
+function retentionFromEnv(name: string, fallback: number): number {
+  return retentionBudget(name, optionalEnv(name), fallback, (message) =>
+    console.error(`[attn-pi-host] ${message}`));
 }
 
 /**
@@ -266,8 +248,8 @@ async function main(): Promise<void> {
     epoch,
     SNAPSHOT_ITEM_LIMIT,
     SNAPSHOT_BYTES_LIMIT,
-    retentionBudget("ATTN_PI_HOST_RETENTION_ITEMS", TRANSCRIPT_RETENTION_ITEMS),
-    retentionBudget("ATTN_PI_HOST_RETENTION_BYTES", TRANSCRIPT_RETENTION_BYTES),
+    retentionFromEnv("ATTN_PI_HOST_RETENTION_ITEMS", TRANSCRIPT_RETENTION_ITEMS),
+    retentionFromEnv("ATTN_PI_HOST_RETENTION_BYTES", TRANSCRIPT_RETENTION_BYTES),
   );
   const write = (envelope: Envelope) => {
     transcript.apply(envelope.kind, envelope.body);

--- a/plugins/attn-pi/host/index.ts
+++ b/plugins/attn-pi/host/index.ts
@@ -39,6 +39,10 @@ import {
   DeltaCoalescer,
   EnvelopeStream,
   PiEventMapper,
+  SNAPSHOT_BYTES_LIMIT,
+  SNAPSHOT_ITEM_LIMIT,
+  TRANSCRIPT_RETENTION_BYTES,
+  TRANSCRIPT_RETENTION_ITEMS,
   ToolDetailStore,
   TranscriptStore,
   conversationInterrupted,
@@ -120,6 +124,31 @@ function requireEnv(name: string): string {
 
 function optionalEnv(name: string): string {
   return process.env[name]?.trim() ?? "";
+}
+
+/**
+ * A retention budget from the environment, or the compiled-in default.
+ *
+ * These exist to make the tripwire reachable: 50,000 items and 32 MB are set
+ * past the longest conversation anyone here has ever had, so the only way to
+ * watch a host actually drop history — and the app say so — is to lower them.
+ * They are the escape hatch too, for a machine where a host's memory matters
+ * more than a month of scroll-back.
+ *
+ * A value that is not a positive count is reported and treated as absent,
+ * meaning the DEFAULT rather than zero: a typo in a tuning variable must not
+ * silently reduce a conversation to one item, and refusing to launch over a
+ * diagnostic environment variable is worse than either.
+ */
+function retentionBudget(name: string, fallback: number): number {
+  const raw = optionalEnv(name);
+  if (raw === "") return fallback;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || !Number.isInteger(value) || value < 1) {
+    console.error(`[attn-pi-host] ${name}=${raw} is not a positive whole number; using ${fallback}`);
+    return fallback;
+  }
+  return value;
 }
 
 /**
@@ -233,7 +262,13 @@ async function main(): Promise<void> {
   // The host's own transcript is fed the same envelopes the daemon forwards, so
   // a snapshot it serves cannot disagree with what a client that watched the
   // stream ended up holding. See TranscriptStore.
-  const transcript = new TranscriptStore(epoch);
+  const transcript = new TranscriptStore(
+    epoch,
+    SNAPSHOT_ITEM_LIMIT,
+    SNAPSHOT_BYTES_LIMIT,
+    retentionBudget("ATTN_PI_HOST_RETENTION_ITEMS", TRANSCRIPT_RETENTION_ITEMS),
+    retentionBudget("ATTN_PI_HOST_RETENTION_BYTES", TRANSCRIPT_RETENTION_BYTES),
+  );
   const write = (envelope: Envelope) => {
     transcript.apply(envelope.kind, envelope.body);
     envelopeOut.write(`${JSON.stringify(envelope)}\n`);

--- a/plugins/attn-pi/test/host-history.test.ts
+++ b/plugins/attn-pi/test/host-history.test.ts
@@ -7,6 +7,7 @@ import {
   conversationInterrupted,
   parseVerb,
   reconstructTranscript,
+  retentionBudget,
   snapshotItemKey,
   type Envelope,
   type SessionEntryLike,
@@ -512,5 +513,43 @@ describe("retention", () => {
     expect(items).toHaveLength(1);
     expect(ids(items)).toEqual(["m1"]);
     expect(items[0]!.kind === "message" && items[0]!.text).toBe("0123456789".repeat(40));
+  });
+});
+
+describe("retention budget from the environment", () => {
+  /** Reads a budget, keeping whatever it complained about. */
+  function budget(raw: string, fallback = 50_000): { value: number; warnings: string[] } {
+    const warnings: string[] = [];
+    const value = retentionBudget("ATTN_PI_HOST_RETENTION_ITEMS", raw, fallback, (message) =>
+      warnings.push(message));
+    return { value, warnings };
+  }
+
+  test("nobody asked, so the compiled-in default stands and nothing is said", () => {
+    expect(budget("")).toEqual({ value: 50_000, warnings: [] });
+  });
+
+  test("a lowered budget is taken, which is what makes the tripwire reachable", () => {
+    expect(budget("40")).toEqual({ value: 40, warnings: [] });
+  });
+
+  test("one item is a legitimate ask, not a typo", () => {
+    expect(budget("1").value).toBe(1);
+  });
+
+  test("a typo keeps the default rather than silently emptying the transcript", () => {
+    for (const raw of ["fourty", "0", "-1", "1.5", "40 items", "1e3px", "Infinity", "NaN"]) {
+      expect(budget(raw).value).toBe(50_000);
+    }
+  });
+
+  test("a refused value says what it was and what is being used instead", () => {
+    expect(budget("0").warnings).toEqual([
+      "ATTN_PI_HOST_RETENTION_ITEMS=0 is not a positive whole number; using 50000",
+    ]);
+  });
+
+  test("a whole number written in exponent form is still a whole number", () => {
+    expect(budget("1e3")).toEqual({ value: 1000, warnings: [] });
   });
 });

--- a/plugins/attn-pi/test/host-history.test.ts
+++ b/plugins/attn-pi/test/host-history.test.ts
@@ -331,3 +331,186 @@ describe("the slice-5 verbs", () => {
     expect(() => parseVerb('{"verb":"set_model"}')).toThrow("set_model verb needs a model");
   });
 });
+
+/**
+ * Retention: the tripwire, not the window.
+ *
+ * `TRANSCRIPT_RETENTION_*` bounds what the host HOLDS, and a conversation that
+ * reaches it has been talking for weeks — 50,000 items is 4.4x the longest
+ * conversation anyone on this machine has ever had. Nothing real has ever
+ * reached it, which is exactly why the path deserves to be driven here: what it
+ * drops is gone for good, and every question a client can still ask has to have
+ * an honest answer afterwards.
+ */
+describe("retention", () => {
+  /** A store whose retention tripwire is small enough to reach. */
+  function retained(count: number, items = 5, bytes = 1 << 20): TranscriptStore {
+    const store = new TranscriptStore("epoch-1", 3, 1 << 20, items, bytes);
+    for (let index = 1; index <= count; index += 1) {
+      store.apply("message_end", { id: `m${index}`, role: "assistant", text: `line ${index}` });
+    }
+    return store;
+  }
+
+  test("the oldest items go, the newest stay", () => {
+    const store = retained(12);
+    expect(store.size).toBe(5);
+    expect(store.droppedItems).toBe(7);
+    // The window is applied on the way out and is smaller still.
+    expect(ids(store.snapshot().items)).toEqual(["m10", "m11", "m12"]);
+  });
+
+  test("a snapshot still counts what it no longer holds", () => {
+    // `total` is the conversation's length, not the host's inventory. A client
+    // that is shown 3 of 12 deserves to know the other 9 existed, even for the
+    // ones nobody can serve any more.
+    const snapshot = retained(12).snapshot();
+    expect(snapshot.total).toBe(12);
+    expect(snapshot.truncated).toBe(true);
+    // Two different questions: `has_more` is "can I page for more", which is
+    // false once the window covers everything the host still holds.
+    expect(snapshot.has_more).toBe(true);
+  });
+
+  test("a window covering everything left still reports the conversation as truncated", () => {
+    // Retention has cut the transcript down to inside the window. Nothing can
+    // be paged, and the client is nonetheless showing a fragment.
+    const store = new TranscriptStore("epoch-1", 10, 1 << 20, 3, 1 << 20);
+    for (let index = 1; index <= 9; index += 1) {
+      store.apply("message_end", { id: `m${index}`, role: "assistant", text: `line ${index}` });
+    }
+    const snapshot = store.snapshot();
+    expect(ids(snapshot.items)).toEqual(["m7", "m8", "m9"]);
+    expect(snapshot.has_more).toBe(false);
+    expect(snapshot.truncated).toBe(true);
+    expect(snapshot.total).toBe(9);
+  });
+
+  test("paging past what retention dropped answers with nothing rather than an error", () => {
+    // The zombie edge: a client holding scroll-back the host has since evicted
+    // asks for the page before it. There is no page. The answer has to be an
+    // empty one addressed to that anchor, so the asking client can stop.
+    const store = retained(12);
+    const page = store.page("message:m2");
+    expect(page.before).toBe("message:m2");
+    expect(page.items).toEqual([]);
+    expect(page.has_more).toBe(false);
+    expect(page.epoch).toBe("epoch-1");
+  });
+
+  test("the oldest item the host still holds has nothing before it", () => {
+    const store = retained(12);
+    const page = store.page("message:m8");
+    expect(page.items).toEqual([]);
+    expect(page.has_more).toBe(false);
+  });
+
+  test("bytes are given back when an item is dropped", () => {
+    // The byte budget is a running total, so a drop that forgot to subtract
+    // would ratchet the store into evicting on every push forever.
+    const store = new TranscriptStore("epoch-1", 3, 1 << 20, 4, 1 << 20);
+    for (let index = 1; index <= 40; index += 1) {
+      store.apply("message_end", { id: `m${index}`, role: "assistant", text: `line ${index}` });
+    }
+    expect(store.size).toBe(4);
+    const held = store.snapshot().items;
+    expect(ids(held)).toEqual(["m38", "m39", "m40"]);
+    // Four items of "line NN" plus their ids: tens of bytes, not thousands.
+    expect(store.retainedBytes).toBeLessThan(200);
+    expect(store.retainedBytes).toBeGreaterThan(0);
+  });
+
+  test("the byte tripwire drops history the item count would have kept", () => {
+    const store = new TranscriptStore("epoch-1", 50, 1 << 20, 10_000, 200);
+    for (let index = 1; index <= 20; index += 1) {
+      store.apply("message_end", { id: `m${index}`, role: "assistant", text: "x".repeat(50) });
+    }
+    expect(store.size).toBeLessThan(20);
+    expect(store.droppedItems).toBeGreaterThan(0);
+    expect(store.retainedBytes).toBeLessThanOrEqual(200);
+  });
+
+  test("one item larger than the whole budget is kept rather than leaving nothing", () => {
+    // Same bargain the window makes for the newest item: a transcript that
+    // evicted its way to empty would show a live conversation as blank.
+    const store = new TranscriptStore("epoch-1", 3, 1 << 20, 10_000, 100);
+    store.apply("message_end", { id: "m1", role: "assistant", text: "x".repeat(5_000) });
+    expect(store.size).toBe(1);
+    expect(store.snapshot().items).toHaveLength(1);
+  });
+
+  test("a tool card evicted by retention takes its history with it", () => {
+    const store = new TranscriptStore("epoch-1", 10, 1 << 20, 2, 1 << 20);
+    store.apply("tool_started", { call_id: "c1", name: "bash", summary: "ls" });
+    store.apply("message_end", { id: "m1", role: "assistant", text: "one" });
+    store.apply("message_end", { id: "m2", role: "assistant", text: "two" });
+    expect(ids(store.snapshot().items)).toEqual(["m1", "m2"]);
+    expect(store.page("tool:c1").items).toEqual([]);
+  });
+
+  test("a message still streaming survives eviction even once it is not the newest", () => {
+    // The shape that makes this reachable: pi opens a tool while the message is
+    // still being written, so the open message is no longer last and the byte
+    // tripwire reaches it. Evicting it there does not just lose the paragraph —
+    // the next delta finds no open message, mints a fresh one from the tail
+    // alone, and the sentence reappears truncated BELOW the tool it was written
+    // above.
+    const store = new TranscriptStore("epoch-1", 10, 1 << 20, 10_000, 400);
+    store.apply("message_start", { id: "m1", role: "assistant" });
+    store.apply("tool_started", { call_id: "c1", name: "bash", summary: "ls" });
+    for (let index = 0; index < 40; index += 1) {
+      store.apply("message_delta", { id: "m1", text: "0123456789" });
+    }
+    const items = store.snapshot().items;
+    expect(ids(items)).toEqual(["m1", "c1"]);
+    expect(items[0]!.kind === "message" && items[0]!.text).toBe("0123456789".repeat(40));
+    expect(store.droppedItems).toBe(0);
+  });
+
+  test("what a still-streaming message held is dropped once it ends", () => {
+    // The reprieve is for the writing, not forever: the budget is enforced again
+    // as soon as the message settles.
+    const store = new TranscriptStore("epoch-1", 10, 1 << 20, 10_000, 400);
+    store.apply("message_start", { id: "m1", role: "assistant" });
+    store.apply("tool_started", { call_id: "c1", name: "bash", summary: "ls" });
+    for (let index = 0; index < 40; index += 1) {
+      store.apply("message_delta", { id: "m1", text: "0123456789" });
+    }
+    expect(store.droppedItems).toBe(0);
+    store.apply("message_end", { id: "m1", role: "assistant", text: "0123456789".repeat(40) });
+    store.apply("message_end", { id: "m2", role: "assistant", text: "after" });
+    expect(store.droppedItems).toBeGreaterThan(0);
+  });
+
+  test("a snapshot says how much is gone for good, and paging never lowers it", () => {
+    // `truncated` only means "this message does not carry everything" and goes
+    // false as a client pages back. `dropped` is the fact that outlives paging,
+    // and it is what tells the app the conversation starts above anything it can
+    // still be shown.
+    const store = retained(12);
+    expect(store.snapshot().dropped).toBe(7);
+    const fresh = new TranscriptStore("epoch-1", 3, 1 << 20);
+    for (let index = 1; index <= 12; index += 1) {
+      fresh.apply("message_end", { id: `m${index}`, role: "assistant", text: `line ${index}` });
+    }
+    // Same conversation, retention never reached: nothing is gone.
+    expect(fresh.snapshot().dropped).toBe(0);
+    expect(fresh.snapshot().truncated).toBe(true);
+  });
+
+  test("a message still streaming is not evicted out from under its own deltas", () => {
+    // message_delta finds the open message by id and appends. If retention drops
+    // that message mid-stream, the next delta has nothing to append to and mints
+    // a second message carrying only the tail — the agent's sentence arrives
+    // split in two, under two ids.
+    const store = new TranscriptStore("epoch-1", 10, 1 << 20, 10_000, 400);
+    store.apply("message_start", { id: "m1", role: "assistant" });
+    for (let index = 0; index < 40; index += 1) {
+      store.apply("message_delta", { id: "m1", text: "0123456789" });
+    }
+    const items = store.snapshot().items;
+    expect(items).toHaveLength(1);
+    expect(ids(items)).toEqual(["m1"]);
+    expect(items[0]!.kind === "message" && items[0]!.text).toBe("0123456789".repeat(40));
+  });
+});


### PR DESCRIPTION
Slice 5 shipped `TRANSCRIPT_RETENTION_ITEMS` (50,000) and `TRANSCRIPT_RETENTION_BYTES` (32 MB) as tripwires set past the longest conversation anyone on this machine has ever had — and nothing had ever reached them. This drives that path and fixes what it found.

## A conversation whose start is gone now says so

Retention drops the oldest items for good. When it had, the window covered everything the host still held, so `has_more` was false and no "load earlier" button appeared either — the transcript simply began partway through, indistinguishable from one that had always been that short. The host knew (`dropped`), and the app threw the number away.

The snapshot now carries it and the transcript is headed by a row naming the count once there is nothing left to page.

Three signals, deliberately distinct:

- `has_more` — "ask me again", goes false when you reach what the host holds.
- `truncated` — "this message does not carry everything", which a client pages away.
- `dropped` — gone for good, which no amount of scrolling changes.

Only the third can honestly drive the row. A rebuilt host reports its own count under a new epoch, so a revive that reads the whole session file back clears the row rather than inheriting a loss it does not have.

## Retention could evict a message mid-sentence

A streaming message is normally the newest item and safe by the "never drop the newest" rule — but it stops being newest the moment pi opens a tool beneath it. Evicting it there did not merely lose it: the next delta found no open message, minted a fresh one from the tail alone, and the agent's paragraph reappeared truncated and out of order, below the tool it was written above.

Measured on the pre-fix code: 400 characters written, 10 survived. `trim` now holds a message that is still being written, which costs one item over budget until it ends — the same bargain the newest item already gets.

## Making the tripwire reachable

`ATTN_PI_HOST_RETENTION_ITEMS` and `ATTN_PI_HOST_RETENTION_BYTES` override the compiled-in budgets, following `ATTN_KITTY_STORAGE_LIMIT`'s shape including its "a typo must not silently change behavior" rule — a non-positive or unparseable value is reported and treated as absent, meaning the default rather than zero. They are how this was verified live, and the escape hatch for a machine where a host's memory matters more than a month of scroll-back.

## Verification

Live, on a throwaway profile with the item budget lowered to 40: a 400-entry conversation resumed into a new session, host retained 40 and dropped 360, and the app reported `historyDropped: 360` with no load-earlier button. The transcript is headed by "360 earlier items are no longer kept for this conversation." and begins at "Filler question 181" — the 361st of the 400 entries, the first one left after 360 were dropped. Profile reaped afterwards.

The eviction path itself is covered by unit tests rather than a committed scenario: the real tripwire is 50,000 items, and a scenario that depended on a tuned daemon would be testing a configuration no user runs.

- 13 new host tests driving retention: what it drops and keeps, byte accounting given back on a drop, the byte tripwire firing where the item count would not, one oversized item kept rather than leaving nothing, paging past what was dropped, and both streaming cases.
- 6 new pane tests including the StrictMode replaying-updater check this repo requires of any new surface, plus the splice and epoch-change paths.
- Every new rule mutation-checked — including one guard (`Math.max` on the splice) that survived its mutation because seq-dedup makes a decreasing count unreachable; it was removed rather than kept as a guard that cannot fail.
- Full frontend suite (2,612), full plugin suite (140), `tsc --noEmit`, `go build` — green.

Base is `epic/pi-headless-host`. This closes watch-list item (5) from the slice-5 report and narrows (6): the zombie scroll-back edge remains, but the fresh-window half of it is no longer silent.

https://claude.ai/code/session_015ooFm5RBBqS9omX5GWKqTN

