### PR TITLE
fix(tests): let the plugin fixture read attn's messages in any order

### DIFF
--- a/changelog.d/plugin-close-notification-flake.yaml
+++ b/changelog.d/plugin-close-notification-flake.yaml
@@ -1,0 +1,14 @@
+kind: internal
+area: tests
+change: >
+  Closed attn's longest-standing CI flake: the plugin-driver end-to-end test's
+  missing driver.session_closed notification. The daemon answers a plugin's
+  state report on its read loop after broadcasting the state change, so a
+  session closing in that gap puts driver.session_closed on the wire ahead of
+  the answer. The test fixture treated an unexpected request as fatal and died,
+  taking its connection with it, and the daemon's close notification came back
+  EOF. The fixture now routes messages by shape the way the shipped SDK does —
+  a method is a request to answer, a bare id is the response being waited for —
+  and a scripted-socket test pins that order on every run instead of leaving it
+  to a scheduling race. The SDK README states the full-duplex rule plugin
+  authors have to honour.

--- a/internal/daemon/plugin_driver_e2e_test.go
+++ b/internal/daemon/plugin_driver_e2e_test.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -478,159 +476,27 @@ func TestPluginDriverFixtureProcess(t *testing.T) {
 		t.Fatalf("dial daemon socket: %v", err)
 	}
 	defer conn.Close()
-	decoder := json.NewDecoder(conn)
 
+	peer := newPluginFixturePeer(t, conn)
 	sendPluginHello(t, conn, os.Getenv("ATTN_PLUGIN_NAME"))
-	if response := readPluginFixtureResponse(t, conn, decoder, "1"); response.Error != nil {
+	if response := peer.awaitResponse("1"); response.Error != nil {
 		t.Fatalf("fixture hello error=%#v", response.Error)
 	}
-	registerPluginFixtureDriver(t, conn, decoder, "fixture", map[string]bool{
-		"resume":          true,
-		"yolo":            true,
-		"state_reporting": true,
-		"model_pin":       true,
-		"effort_pin":      true,
+	peer.callOK("driver.register", pluginDriverRegisterParams{
+		Agent: "fixture",
+		Capabilities: map[string]bool{
+			"resume":          true,
+			"yolo":            true,
+			"state_reporting": true,
+			"model_pin":       true,
+			"effort_pin":      true,
+		},
 	})
 	if err := os.WriteFile(os.Getenv("ATTN_DRIVER_FIXTURE_READY"), []byte("ready"), 0o644); err != nil {
 		t.Fatalf("write fixture ready marker: %v", err)
 	}
 
-	for {
-		request, err := decodePluginFixtureMessage(decoder)
-		if err != nil {
-			return
-		}
-		if request.Method == "attn.health" {
-			_ = json.NewEncoder(conn).Encode(jsonRPCResult(request.ID, map[string]bool{"ok": true}))
-			continue
-		}
-		if request.Method == "driver.session_closed" {
-			var params pluginDriverSessionClosedParams
-			if err := json.Unmarshal(request.Params, &params); err != nil {
-				t.Fatalf("decode fixture session close params: %v", err)
-			}
-			appendPluginFixtureCloseRecord(t, pluginDriverCloseRecord{Params: params})
-			_ = json.NewEncoder(conn).Encode(jsonRPCResult(request.ID, pluginDriverSessionClosedResult{OK: true}))
-			continue
-		}
-		if request.Method != "driver.spawn" && request.Method != "driver.resume" {
-			continue
-		}
-
-		var params pluginDriverSpawnParams
-		if err := json.Unmarshal(request.Params, &params); err != nil {
-			t.Fatalf("decode fixture launch params: %v", err)
-		}
-		appendPluginFixtureRecord(t, pluginDriverFixtureRecord{Method: request.Method, Params: params})
-		script := `IFS= read -r input; printf 'PLUGIN_RUN method=%s cwd=%s input=%s\n' "$ATTN_PLUGIN_FIXTURE_METHOD" "$PWD" "$input"; trap 'exit 0' TERM INT; while :; do sleep 1; done`
-		respondPluginRequest(t, conn, request, pluginDriverSpawnResult{
-			Argv: []string{"/bin/sh", "-c", script},
-			Env:  map[string]string{"ATTN_PLUGIN_FIXTURE_METHOD": request.Method},
-			CWD:  os.Getenv("ATTN_DRIVER_FIXTURE_CWD"),
-		})
-		sendPluginFixtureMethod(t, conn, decoder, 20, "session.report_state", pluginReportStateParams{
-			SessionID: params.SessionID,
-			RunID:     params.RunID,
-			Seq:       1,
-			State:     protocol.StateWorking,
-		})
-		sendPluginFixtureMethod(t, conn, decoder, 21, "session.report_metadata", pluginReportMetadataParams{
-			SessionID: params.SessionID,
-			RunID:     params.RunID,
-			Seq:       2,
-			Metadata:  json.RawMessage(`{"native_id":"` + request.Method + `-native"}`),
-		})
-		sendPluginFixtureMethod(t, conn, decoder, 22, "session.report_stop", pluginReportStopParams{
-			SessionID: params.SessionID,
-			RunID:     params.RunID,
-			Seq:       3,
-			Verdict:   protocol.StateWaitingInput,
-		})
-		if request.Method == "driver.spawn" {
-			waitForPluginFixtureStateTrigger(t)
-			sendPluginFixtureMethod(t, conn, decoder, 23, "session.report_state", pluginReportStateParams{
-				SessionID: params.SessionID,
-				RunID:     params.RunID,
-				Seq:       4,
-				State:     protocol.StateWorking,
-			})
-			sendPluginFixtureMethod(t, conn, decoder, 24, "session.report_stop", pluginReportStopParams{
-				SessionID: params.SessionID,
-				RunID:     params.RunID,
-				Seq:       5,
-				Verdict:   protocol.StateWaitingInput,
-			})
-		}
-	}
-}
-
-func registerPluginFixtureDriver(t *testing.T, conn net.Conn, decoder *json.Decoder, agent string, capabilities map[string]bool) {
-	t.Helper()
-	response := sendPluginFixtureMethodResponse(t, conn, decoder, 2, "driver.register", pluginDriverRegisterParams{
-		Agent:        agent,
-		Capabilities: capabilities,
-	})
-	if response.Error != nil {
-		t.Fatalf("driver.register error=%#v", response.Error)
-	}
-}
-
-func sendPluginFixtureMethod(t *testing.T, conn net.Conn, decoder *json.Decoder, id int, method string, params interface{}) {
-	t.Helper()
-	response := sendPluginFixtureMethodResponse(t, conn, decoder, id, method, params)
-	if response.Error != nil {
-		t.Fatalf("%s error=%#v", method, response.Error)
-	}
-}
-
-func sendPluginFixtureMethodResponse(t *testing.T, conn net.Conn, decoder *json.Decoder, id int, method string, params interface{}) jsonRPCMessage {
-	t.Helper()
-	payload, err := json.Marshal(params)
-	if err != nil {
-		t.Fatalf("marshal %s params: %v", method, err)
-	}
-	if err := json.NewEncoder(conn).Encode(jsonRPCMessage{
-		JSONRPC: "2.0",
-		ID:      json.RawMessage([]byte(strconv.Itoa(id))),
-		Method:  method,
-		Params:  payload,
-	}); err != nil {
-		t.Fatalf("send %s: %v", method, err)
-	}
-	return readPluginFixtureResponse(t, conn, decoder, strconv.Itoa(id))
-}
-
-func decodePluginFixtureMessage(decoder *json.Decoder) (jsonRPCMessage, error) {
-	var message jsonRPCMessage
-	err := decoder.Decode(&message)
-	return message, err
-}
-
-func decodePluginFixtureMessageWithDecoder(t *testing.T, decoder *json.Decoder) jsonRPCMessage {
-	t.Helper()
-	message, err := decodePluginFixtureMessage(decoder)
-	if err != nil {
-		t.Fatalf("decode JSON-RPC message: %v", err)
-	}
-	return message
-}
-
-func readPluginFixtureResponse(t *testing.T, conn net.Conn, decoder *json.Decoder, wantID string) jsonRPCMessage {
-	t.Helper()
-	for {
-		message := decodePluginFixtureMessageWithDecoder(t, decoder)
-		if message.Method == pluginHealthMethod {
-			_ = json.NewEncoder(conn).Encode(jsonRPCResult(message.ID, map[string]bool{"ok": true}))
-			continue
-		}
-		if message.Method != "" {
-			t.Fatalf("unexpected plugin request %q while waiting for response id=%s", message.Method, wantID)
-		}
-		if jsonRPCIDKey(message.ID) != wantID {
-			t.Fatalf("unexpected plugin response id=%s while waiting for id=%s", jsonRPCIDKey(message.ID), wantID)
-		}
-		return message
-	}
+	peer.serve()
 }
 
 func appendPluginFixtureRecord(t *testing.T, record pluginDriverFixtureRecord) {

--- a/internal/daemon/plugin_fixture_peer_test.go
+++ b/internal/daemon/plugin_fixture_peer_test.go
@@ -1,0 +1,277 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// pluginFixturePeer is the plugin side of the daemon socket, as the end-to-end
+// driver fixture speaks it.
+//
+// attn is a full-duplex JSON-RPC peer: it sends driver.session_closed the
+// instant a session's PTY exits, which can land while one of the plugin's own
+// reports is still waiting for its response — the daemon answers a report on
+// its read loop after broadcasting the state change, so any pause between
+// those two steps lets a close overtake the answer. Every message therefore
+// arrives at one reader that routes by shape: a message carrying a method is a
+// request to handle, a message carrying only an id is the response someone is
+// waiting for. The shipped SDK (sdk/plugin) dispatches the same way. A peer
+// that assumed its response came next would instead lose whichever message
+// attn sent first, and because the ordering is a scheduling race it would lose
+// it rarely — which is what this fixture used to do.
+type pluginFixturePeer struct {
+	t       *testing.T
+	conn    net.Conn
+	decoder *json.Decoder
+	nextID  int
+}
+
+// newPluginFixturePeer takes over reading conn. Nothing else may read from it:
+// the peer is the only place that knows which messages are responses it is
+// waiting for and which are requests to answer.
+func newPluginFixturePeer(t *testing.T, conn net.Conn) *pluginFixturePeer {
+	// Ids 1 and 2 belong to the hello and driver.register handshake the fixture
+	// sends before serving, so the first generated id starts after them.
+	return &pluginFixturePeer{t: t, conn: conn, decoder: json.NewDecoder(conn), nextID: 2}
+}
+
+// call sends a request and returns its response, answering every request attn
+// sends while that response is outstanding.
+func (p *pluginFixturePeer) call(method string, params interface{}) jsonRPCMessage {
+	p.t.Helper()
+	payload, err := json.Marshal(params)
+	if err != nil {
+		p.t.Fatalf("marshal %s params: %v", method, err)
+	}
+	p.nextID++
+	id := strconv.Itoa(p.nextID)
+	if err := p.write(jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(id),
+		Method:  method,
+		Params:  payload,
+	}); err != nil {
+		p.t.Fatalf("send %s: %v", method, err)
+	}
+	return p.awaitResponse(id)
+}
+
+// callOK is call for the requests whose only interesting outcome is that attn
+// accepted them.
+func (p *pluginFixturePeer) callOK(method string, params interface{}) {
+	p.t.Helper()
+	if response := p.call(method, params); response.Error != nil {
+		p.t.Fatalf("%s error=%#v", method, response.Error)
+	}
+}
+
+// awaitResponse returns the response to a request already on the wire.
+func (p *pluginFixturePeer) awaitResponse(id string) jsonRPCMessage {
+	p.t.Helper()
+	for {
+		message, err := p.read()
+		if err != nil {
+			p.t.Fatalf("read response id=%s: %v", id, err)
+		}
+		if message.Method != "" {
+			p.handle(message)
+			continue
+		}
+		if jsonRPCIDKey(message.ID) != id {
+			p.t.Fatalf("plugin response id=%s while waiting for id=%s", jsonRPCIDKey(message.ID), id)
+		}
+		return message
+	}
+}
+
+// serve answers attn's requests until it closes the connection.
+func (p *pluginFixturePeer) serve() {
+	for {
+		message, err := p.read()
+		if err != nil {
+			return
+		}
+		if message.Method == "" {
+			continue
+		}
+		p.handle(message)
+	}
+}
+
+func (p *pluginFixturePeer) handle(request jsonRPCMessage) {
+	p.t.Helper()
+	switch request.Method {
+	case pluginHealthMethod:
+		p.respond(request.ID, pluginHealthResult{OK: true})
+	case "driver.session_closed":
+		var params pluginDriverSessionClosedParams
+		if err := json.Unmarshal(request.Params, &params); err != nil {
+			p.t.Fatalf("decode fixture session close params: %v", err)
+		}
+		appendPluginFixtureCloseRecord(p.t, pluginDriverCloseRecord{Params: params})
+		p.respond(request.ID, pluginDriverSessionClosedResult{OK: true})
+	case "driver.spawn", "driver.resume":
+		p.launch(request)
+	default:
+		// Answering instead of ignoring: an unanswered request holds the daemon's
+		// caller for its full 30s timeout and says nothing about why.
+		_ = p.write(jsonRPCFailure(request.ID, jsonRPCMethodNotFound, fmt.Sprintf("unknown method %q", request.Method)))
+	}
+}
+
+// launch answers a launch request the way a driver plugin does: argv first, so
+// attn can spawn the PTY, then the reports that move the session.
+func (p *pluginFixturePeer) launch(request jsonRPCMessage) {
+	p.t.Helper()
+	var params pluginDriverSpawnParams
+	if err := json.Unmarshal(request.Params, &params); err != nil {
+		p.t.Fatalf("decode fixture launch params: %v", err)
+	}
+	appendPluginFixtureRecord(p.t, pluginDriverFixtureRecord{Method: request.Method, Params: params})
+	script := `IFS= read -r input; printf 'PLUGIN_RUN method=%s cwd=%s input=%s\n' "$ATTN_PLUGIN_FIXTURE_METHOD" "$PWD" "$input"; trap 'exit 0' TERM INT; while :; do sleep 1; done`
+	p.respond(request.ID, pluginDriverSpawnResult{
+		Argv: []string{"/bin/sh", "-c", script},
+		Env:  map[string]string{"ATTN_PLUGIN_FIXTURE_METHOD": request.Method},
+		CWD:  os.Getenv("ATTN_DRIVER_FIXTURE_CWD"),
+	})
+	p.callOK("session.report_state", pluginReportStateParams{
+		SessionID: params.SessionID,
+		RunID:     params.RunID,
+		Seq:       1,
+		State:     protocol.StateWorking,
+	})
+	p.callOK("session.report_metadata", pluginReportMetadataParams{
+		SessionID: params.SessionID,
+		RunID:     params.RunID,
+		Seq:       2,
+		Metadata:  json.RawMessage(`{"native_id":"` + request.Method + `-native"}`),
+	})
+	p.callOK("session.report_stop", pluginReportStopParams{
+		SessionID: params.SessionID,
+		RunID:     params.RunID,
+		Seq:       3,
+		Verdict:   protocol.StateWaitingInput,
+	})
+	if request.Method != "driver.spawn" {
+		return
+	}
+	waitForPluginFixtureStateTrigger(p.t)
+	p.callOK("session.report_state", pluginReportStateParams{
+		SessionID: params.SessionID,
+		RunID:     params.RunID,
+		Seq:       4,
+		State:     protocol.StateWorking,
+	})
+	p.callOK("session.report_stop", pluginReportStopParams{
+		SessionID: params.SessionID,
+		RunID:     params.RunID,
+		Seq:       5,
+		Verdict:   protocol.StateWaitingInput,
+	})
+}
+
+func (p *pluginFixturePeer) respond(id json.RawMessage, result interface{}) {
+	p.t.Helper()
+	if err := p.write(jsonRPCResult(id, result)); err != nil {
+		p.t.Fatalf("respond to request id=%s: %v", jsonRPCIDKey(id), err)
+	}
+}
+
+func (p *pluginFixturePeer) read() (jsonRPCMessage, error) {
+	var message jsonRPCMessage
+	err := p.decoder.Decode(&message)
+	return message, err
+}
+
+func (p *pluginFixturePeer) write(message jsonRPCMessage) error {
+	return json.NewEncoder(p.conn).Encode(message)
+}
+
+// TestPluginFixturePeerAnswersRequestArrivingBeforeItsResponse pins the
+// ordering the end-to-end fixture used to fail on. Under CI load the daemon
+// wrote driver.session_closed before answering the report the fixture was
+// waiting for; the fixture treated that as fatal, died, and the daemon's close
+// notification came back EOF. Here the same order is scripted rather than
+// raced, so the peer's duplex handling is proven on every run.
+func TestPluginFixturePeerAnswersRequestArrivingBeforeItsResponse(t *testing.T) {
+	closeLog := filepath.Join(t.TempDir(), "driver-close.jsonl")
+	t.Setenv("ATTN_DRIVER_FIXTURE_CLOSE_LOG", closeLog)
+
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	scripted := make(chan error, 1)
+	go func() { scripted <- scriptCloseBeforeReportResponse(server) }()
+
+	peer := newPluginFixturePeer(t, client)
+	peer.callOK("session.report_stop", pluginReportStopParams{
+		SessionID: "session-1",
+		RunID:     "run-1",
+		Seq:       3,
+		Verdict:   protocol.StateWaitingInput,
+	})
+	if err := <-scripted; err != nil {
+		t.Fatalf("scripted daemon: %v", err)
+	}
+
+	records, ok := readPluginFixtureCloseRecords(closeLog, 1)
+	if !ok {
+		t.Fatal("peer recorded no close notification, want the one that arrived mid-request")
+	}
+	if records[0].Params.RunID != "run-1" || records[0].Params.Reason != "exited" {
+		t.Fatalf("close record=%+v, want exited notification for run-1", records[0].Params)
+	}
+}
+
+// scriptCloseBeforeReportResponse plays the daemon: read the peer's report,
+// send driver.session_closed before answering it, and answer only once the
+// close is acknowledged.
+func scriptCloseBeforeReportResponse(conn net.Conn) error {
+	decoder := json.NewDecoder(conn)
+	encoder := json.NewEncoder(conn)
+
+	var report jsonRPCMessage
+	if err := decoder.Decode(&report); err != nil {
+		return fmt.Errorf("read plugin report: %w", err)
+	}
+	if report.Method != "session.report_stop" {
+		return fmt.Errorf("first plugin message method=%q, want session.report_stop", report.Method)
+	}
+
+	params, err := json.Marshal(pluginDriverSessionClosedParams{
+		SessionID: "session-1",
+		RunID:     "run-1",
+		Reason:    "exited",
+	})
+	if err != nil {
+		return fmt.Errorf("marshal close params: %w", err)
+	}
+	if err := encoder.Encode(jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage("900"),
+		Method:  "driver.session_closed",
+		Params:  params,
+	}); err != nil {
+		return fmt.Errorf("send close notification: %w", err)
+	}
+
+	var ack jsonRPCMessage
+	if err := decoder.Decode(&ack); err != nil {
+		return fmt.Errorf("read close acknowledgement: %w", err)
+	}
+	if jsonRPCIDKey(ack.ID) != "900" || ack.Method != "" {
+		return fmt.Errorf("close acknowledgement=%+v, want a response to id 900", ack)
+	}
+	if err := encoder.Encode(jsonRPCResult(report.ID, struct{}{})); err != nil {
+		return fmt.Errorf("answer plugin report: %w", err)
+	}
+	return nil
+}

--- a/internal/daemon/plugin_fixture_peer_test.go
+++ b/internal/daemon/plugin_fixture_peer_test.go
@@ -37,9 +37,9 @@ type pluginFixturePeer struct {
 // the peer is the only place that knows which messages are responses it is
 // waiting for and which are requests to answer.
 func newPluginFixturePeer(t *testing.T, conn net.Conn) *pluginFixturePeer {
-	// Ids 1 and 2 belong to the hello and driver.register handshake the fixture
-	// sends before serving, so the first generated id starts after them.
-	return &pluginFixturePeer{t: t, conn: conn, decoder: json.NewDecoder(conn), nextID: 2}
+	// Id 1 is the hello the fixture writes before handing the socket over, so
+	// generated ids start after it.
+	return &pluginFixturePeer{t: t, conn: conn, decoder: json.NewDecoder(conn), nextID: 1}
 }
 
 // call sends a request and returns its response, answering every request attn

--- a/sdk/plugin/README.md
+++ b/sdk/plugin/README.md
@@ -55,6 +55,16 @@ The SDK handles `attn.health` internally and returns `{ ok: true }`. Plugin
 authors do not need to register a health handler for the daemon to distinguish a
 live plugin from a process that merely started.
 
+The connection is full duplex, and attn does not wait its turn. A request from
+attn — a healthcheck, a `driver.session_closed` for a session whose process just
+exited — can arrive while one of the plugin's own requests is still waiting for
+its response, so the next message on the socket is not necessarily the one the
+plugin asked for. The SDK already routes by shape: a message carrying a method
+goes to its handler, a message carrying only an id resolves the pending request.
+Plugin code that talks to the socket directly must do the same; treating an
+unexpected request as an error loses whichever message attn happened to send
+first, and since the ordering is a scheduling race it loses it rarely.
+
 Create lifecycle hooks use the same registration path:
 
 ```ts


### PR DESCRIPTION
attn's longest-standing CI flake was the plugin-driver end-to-end test timing out
on a `driver.session_closed` notification that normally reaches the plugin in
under 50ms. The daemon-log instrumentation added for it caught the failure on
PR #800's CI (run 31313203551) and named the link: the daemon reached the send,
and the write came back `EOF` because the plugin process was already gone.

## The bug

The daemon answers a plugin's `session.report_*` call on that connection's read
loop, and `applyState` broadcasts the state change *before* the answer is
written. Anything that pauses the daemon between those two steps — a loaded CI
runner descheduling that goroutine is enough — leaves the plugin waiting while
the test, which watched for the broadcast, moves on and kills the session's PTY.
The close notification then goes out on a separate goroutine and reaches the
socket ahead of the answer.

That is legal JSON-RPC and exactly what both shipped plugin clients expect: the
SDK (`sdk/plugin`) and attn-pi's own client each route a message by shape — a
method is a request to handle, a bare id resolves a pending call. The end-to-end
test's fixture did not. It treated any request arriving while it awaited a
response as fatal:

```
unexpected plugin request "driver.session_closed" while waiting for response id=24
```

So the fixture died on the very notification the test was waiting for, its
connection went with it, and the notification the daemon had already written came
back `EOF` with nobody left to receive it. The 5s tripwire then fired, the session
sat at `idle`, and the diagnosis printed `driver_registered=false` — the fixture's
supervised restart, whose `hello` raced test teardown and was rejected as a stale
generation. That stale-generation line is teardown noise, not the cause; the
ordering above is.

Why it was rare: the gap between broadcast and answer is normally microseconds,
and the PTY kill it has to lose to takes milliseconds.

## The fix

The fixture now has one reader that routes by shape, the same way the SDK does.
There is no unexpected-request branch left to regress to — an interleaved request
is answered wherever it lands, including in the middle of the fixture's own call.
No product code changes; the daemon was behaving correctly throughout.

## Receipts

Forcing the ordering — a temporary local hook pausing 400ms between the daemon's
broadcast and its answer, not part of this diff — reproduces CI exactly:

| | before | after |
|---|---|---|
| provoked interleave (400ms) | **3/3 fail** | **4/4 pass** |
| 32 loaded parallel runs (4 copies × 8 rounds, 4 spinners) | pass | pass |

The pre-fix failures printed the CI text verbatim: `unexpected plugin request
"driver.session_closed" while waiting for response id=24`, `close records
recorded: 0`, `plugin session close notification failed: … err=plugin
driver.session_closed: EOF`. Load alone never hit the window on this machine,
before or after — the race is too narrow, which is the point.

## The test that pins it

`TestPluginFixturePeerAnswersRequestArrivingBeforeItsResponse` scripts the daemon
side over a `net.Pipe`: read the peer's report, send `driver.session_closed`
first, answer the report only after the close is acknowledged. Deterministic by
construction — no sleeps, no polling, no load — so the ordering that used to be a
rare race is now exercised on every run. It asserts the peer recorded the close
and still got its response.

## Surfaces

- **Plugins and SDK** — checked both shipped clients (`sdk/plugin`,
  `plugins/attn-pi`, `plugins/attn-opencode`); all three already route by shape.
  The fixture was the only offender.
- **Docs** — the SDK README now states the full-duplex rule instead of leaving
  plugin authors to discover it as a flake.
- **Daemon, protocol, CLI, Linux** — untouched; the diff is test code plus a
  README and a changelog fragment.

## Known limitation, deliberately not fixed here

`notifyPluginDriverSessionClosed` is fire-and-forget: when the send fails, the
run has already been ended in the store, so the notification is lost and a
reconnecting plugin will not see that run in `driver.register`'s `active_runs`
either. In practice the only way that send fails is a dead connection, and the
plugin process that owned the run's in-memory state is being restarted with it —
attn-pi's `sessionClosed` only drops two map entries. Adding a redelivery ledger
would be machinery for a leak I have no evidence of, and it would also have
masked this fixture bug. Happy to file it as a ticket if it is worth closing.

## Verification tier

No product code changed, so a profile install would exercise nothing this diff
touches. The integrated evidence is the end-to-end test itself — a supervised
plugin process, the real daemon socket, a real worker PTY — passing under the
provoked ordering that reliably failed before, plus the full `internal/daemon`
package green.
