### PR TITLE
chore(comments): compress comment prose to constraints and receipts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,8 +336,12 @@ forgets that position and `--since <RFC3339>` replays from an instant.
 - No continuously repainting animations. attn renders GPU terminals, often on
   high-refresh displays, beside agents that run all day — a permanent repaint
   loop is a battery and thermal bug no test will catch.
-- Comments describe how a thing is used, and move when the code moves. Mostly on
-  functions and seams, not annotating every line.
+- Comments state what the code cannot show — a constraint, an invariant, a
+  measured receipt — in one or two lines, and move when the code moves. Godoc
+  on an exported symbol is one line. A package header is a few lines plus a
+  link to the design doc, never a retelling of it. Never narrate the next line
+  or argue that the change is correct: that talk belongs in the PR, and a
+  comment addressed to the reviewer is a defect.
 - Conventional commit titles with a scope, in plain language:
   `fix(queue): hand over the next agent however a turn closes`.
 

--- a/changelog.d/feral-ibex-comment-sweep.yaml
+++ b/changelog.d/feral-ibex-comment-sweep.yaml
@@ -1,0 +1,8 @@
+kind: internal
+area: docs
+change: >
+  Comment sweep across the Go source: design-doc retellings, narration, and
+  review-directed justification are cut; invariants and measured receipts stay,
+  compressed to a line or two. AGENTS.md now states the policy — comments say
+  what the code cannot show, package headers link to the design doc instead of
+  retelling it.

--- a/cmd/attn/db.go
+++ b/cmd/attn/db.go
@@ -17,9 +17,8 @@ import (
 	"github.com/victorarias/attn/internal/store"
 )
 
-// runDB routes `attn db <command>`: operator-facing database maintenance that
-// sits alongside the daemon's own automatic rotating backups (BackupNow /
-// backupPreMigration in internal/store).
+// runDB routes `attn db <command>`: operator-facing maintenance beside the
+// daemon's automatic rotating backups (internal/store).
 func runDB() {
 	if len(os.Args) < 3 || os.Args[2] == "-h" || os.Args[2] == "--help" {
 		writeDBHelp(os.Stdout)
@@ -81,39 +80,15 @@ func runDBRestore(args []string) {
 	fmt.Println("start the daemon when ready (e.g. `attn daemon ensure`, or reopen the app)")
 }
 
-// restoreDatabase implements `attn db restore` against explicit paths so it
-// is fully unit-testable against temp dirs: it never resolves config's real
-// data dir itself.
-//
-// source is either "" or "latest" (pick the newest rotating attn-<ts>.db
-// snapshot in backupsDir) or an explicit path to any snapshot file, including
-// a pre-migration one.
-//
-// On success it (a) preserves the existing dbPath by renaming it (and its
-// -wal/-shm sidecars, if any) to dbPath+".pre-restore-<UTC ts>" (a no-op, not
-// an error, if dbPath does not currently exist), then (b) copies (not moves
-// — the source backup remains) the resolved snapshot into place as dbPath.
-// Returns the resolved source path and the preserved-db path (empty if there
-// was nothing to preserve).
-//
-// pidPath is the daemon's pid-file lock (see acquireDaemonLock). The lock is
-// acquired before anything else and held for the entire restore, including
-// staging, preserving, and the final swap — not just probed and released up
-// front. A point-in-time-only probe would leave a window in which a daemon
-// could start (or a second `attn db restore` could run) between the probe
-// and the file swap; holding the lock for the whole critical section closes
-// that window, mirroring how the daemon itself holds the same lock for its
-// entire lifetime (daemon.acquirePIDLock).
-//
-// The live dbPath is only ever mutated after the source has been fully and
-// successfully staged, so a bad source (a directory, an unreadable file, or
-// dbPath itself) is rejected before anything at dbPath is touched. Staging
-// happens into a uniquely-named temp file in dbPath's own directory, which
-// also makes the final swap a same-filesystem os.Rename instead of a
-// copy/truncate directly onto the live path — so the live path is either the
-// fully-old file or the fully-new one, never a partially-written one. If the
-// final swap still fails after a preserve-rename has already happened, the
-// preserved copy is rolled back into place so dbPath is never left missing.
+// restoreDatabase implements `attn db restore` against explicit paths so it is
+// unit-testable. source is ""/"latest" (newest rotating snapshot in backupsDir)
+// or an explicit snapshot path. The pid-file flock is held for the ENTIRE
+// restore — a probe-and-release would leave a window for a daemon or a second
+// restore to start before the swap. The live dbPath is mutated only after the
+// source is fully staged into dbPath's own directory (making the swap an
+// atomic same-filesystem rename); the existing db and sidecars are preserved
+// (renamed, never deleted), and a failed swap rolls the preserved copy back so
+// dbPath is never left missing.
 func restoreDatabase(dbPath, backupsDir, source, pidPath string) (restoredFrom, preservedAs string, err error) {
 	release, err := acquireDaemonLock(pidPath)
 	if err != nil {
@@ -147,9 +122,8 @@ func restoreDatabase(dbPath, backupsDir, source, pidPath string) (restoredFrom, 
 		return "", "", fmt.Errorf("stat existing db %s: %w", dbPath, statErr)
 	}
 
-	// Fully materialize the source before touching the live path at all:
-	// this is what turns a bad source (directory, unreadable file, disk
-	// full mid-copy) into a no-op failure instead of a stranded db.
+	// Stage fully before touching the live path: a bad source is a no-op
+	// failure, never a stranded db.
 	stagedPath, err := stageBackupCopy(srcPath, dbPath)
 	if err != nil {
 		return "", "", fmt.Errorf("stage backup %s: %w", srcPath, err)
@@ -167,8 +141,7 @@ func restoreDatabase(dbPath, backupsDir, source, pidPath string) (restoredFrom, 
 			return "", "", err
 		}
 	} else {
-		// Nothing existed at dbPath to preserve; any stray sidecars are not
-		// tied to a preserved copy, so remove them as before.
+		// Nothing to preserve; stray sidecars are removed.
 		for _, suffix := range []string{"-wal", "-shm"} {
 			_ = os.Remove(dbPath + suffix)
 		}
@@ -176,9 +149,8 @@ func restoreDatabase(dbPath, backupsDir, source, pidPath string) (restoredFrom, 
 
 	if err := os.Rename(stagedPath, dbPath); err != nil {
 		if preservedAs != "" {
-			// The live path is now missing because the preserve-rename
-			// already happened; put the preserved copy back rather than
-			// leaving dbPath gone.
+			// The preserve-rename already happened; put the preserved copy
+			// back rather than leaving dbPath gone.
 			_ = os.Rename(preservedAs, dbPath)
 			for _, suffix := range []string{"-wal", "-shm"} {
 				_ = os.Rename(preservedAs+suffix, dbPath+suffix)
@@ -191,34 +163,18 @@ func restoreDatabase(dbPath, backupsDir, source, pidPath string) (restoredFrom, 
 	return srcPath, preservedAs, nil
 }
 
-// preserveExistingDB renames dbPath (and its -wal/-shm sidecars, if any) to a
-// collision-proof dbPath+".pre-restore-<UTC ts>[-N]" path, never deleting
-// them: they can hold uncheckpointed data that only exists there. SQLite
-// derives sidecar names by appending to the main filename, so renaming both
-// to preservedAs+suffix keeps the preserved copy openable and consistent.
-//
-// The timestamp alone is only second-resolution, so two restores within the
-// same second would otherwise collide; the -N suffix loop makes the chosen
-// name unique regardless of how many restores land in the same second. The
-// loop checks the main file AND both sidecar targets before accepting a
-// candidate — a candidate whose main-file path is free but whose -wal or
-// -shm path is already taken (e.g. from an earlier restore that had no
-// sidecars to preserve, leaving that name's main-file slot free) would
-// otherwise let a later rename silently replace that stray file.
-//
-// If the main-file rename succeeds but a sidecar rename then fails, every
-// earlier move in this call is rolled back (in reverse order) before
-// returning, so a sidecar-only filesystem error never strands dbPath
-// missing; a rollback failure is wrapped alongside the original error
-// instead of being discarded.
+// preserveExistingDB renames dbPath and its -wal/-shm sidecars to a
+// collision-proof dbPath+".pre-restore-<UTC ts>[-N]" — never deleting them,
+// since sidecars can hold uncheckpointed data. The -N loop checks the main
+// file AND both sidecar targets, so a stray sidecar under a free main-file
+// name is never silently replaced. A failed sidecar rename rolls back every
+// earlier move so dbPath is never left missing.
 func preserveExistingDB(dbPath string) (string, error) {
 	return preserveExistingDBAt(dbPath, time.Now, os.Rename)
 }
 
-// preserveExistingDBAt is preserveExistingDB with the clock and the rename
-// operation injected, so tests can force a same-second collision
-// deterministically and force a specific rename in the sequence to fail
-// without relying on real filesystem-permission tricks.
+// preserveExistingDBAt injects the clock and rename so tests can force
+// same-second collisions and mid-sequence rename failures deterministically.
 func preserveExistingDBAt(dbPath string, now func() time.Time, rename func(oldpath, newpath string) error) (preservedAs string, err error) {
 	base := dbPath + ".pre-restore-" + now().UTC().Format("20060102-150405")
 	preservedAs = base
@@ -266,9 +222,8 @@ func preserveExistingDBAt(dbPath string, now func() time.Time, rename func(oldpa
 	return preservedAs, nil
 }
 
-// preserveTargetFree reports whether candidate is available to become a
-// preserve-rename destination: neither the main file nor either -wal/-shm
-// sidecar target may already exist there.
+// preserveTargetFree reports whether candidate is free as a preserve-rename
+// destination: neither the main file nor either sidecar target may exist.
 func preserveTargetFree(candidate string) (bool, error) {
 	for _, suffix := range []string{"", "-wal", "-shm"} {
 		if _, err := os.Stat(candidate + suffix); err == nil {
@@ -280,13 +235,10 @@ func preserveTargetFree(candidate string) (bool, error) {
 	return true, nil
 }
 
-// latestRotatingBackup returns the newest canonical rotating backup
-// (attn-<timestamp>.db) in dir, by lexical (== chronological, fixed-width
-// timestamp) sort. It defers to store.IsRotatingBackupName for the canonical
-// filename check (validated timestamp suffix, not just a prefix/suffix
-// match), so a stray non-canonical attn-*.db file cannot be mistaken for the
-// latest backup. Pre-migration snapshots (attn-premigration-*.db) are
-// excluded — "latest" only ever means the newest routine rotation.
+// latestRotatingBackup returns the newest rotating backup (attn-<timestamp>.db)
+// in dir by lexical (== chronological) sort. store.IsRotatingBackupName
+// validates the name, excluding stray attn-*.db files and pre-migration
+// snapshots — "latest" only ever means the newest routine rotation.
 func latestRotatingBackup(dir string) (string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -311,16 +263,10 @@ func latestRotatingBackup(dir string) (string, error) {
 	return filepath.Join(dir, names[len(names)-1]), nil
 }
 
-// stageBackupCopy copies src's bytes into a new, uniquely-named temp file in
-// dstPath's own directory (never dstPath itself), preserving src's file
-// mode, and fsyncs it before returning. It never removes src — the backup
-// being restored from is left in place. On any error the temp file is
-// removed and the caller gets no path to clean up.
-//
-// Staging in dstPath's directory (rather than copying straight onto dstPath)
-// is what makes the final move a same-filesystem os.Rename: atomic, and safe
-// to attempt even if the source turns out to be bad, because nothing at
-// dstPath has been touched yet.
+// stageBackupCopy copies src into a uniquely-named, fsynced temp file in
+// dstPath's own directory, preserving src's mode; src is never removed and on
+// error the temp file is. Staging there makes the final move a same-filesystem
+// atomic os.Rename, with nothing at dstPath touched if the source is bad.
 func stageBackupCopy(src, dstPath string) (stagedPath string, err error) {
 	in, err := os.Open(src)
 	if err != nil {
@@ -365,28 +311,15 @@ func stageBackupCopy(src, dstPath string) (stagedPath string, err error) {
 	return tmpPath, nil
 }
 
-// acquireDaemonLock acquires and holds the exclusive advisory flock on
-// pidPath, creating the file if it does not yet exist, and returns a release
-// func the caller must call exactly once (a second call is a no-op) when the
-// held section is over.
+// acquireDaemonLock holds the exclusive advisory flock on pidPath until the
+// returned release is called (a second call is a no-op). Acquiring proves no
+// live daemon owns it — the daemon holds this same lock for its whole lifetime
+// (daemon.acquirePIDLock) — and HOLDING it, not probe-then-release, keeps a
+// daemon or a second caller out for the whole critical section. The lock file
+// is never unlinked, so contenders always meet on the same inode.
 //
-// This mirrors the liveness+ownership technique stopProfileDaemon
-// (profile.go) uses: the daemon holds this same exclusive lock on its pid
-// file for its whole lifetime (daemon.acquirePIDLock), so successfully
-// acquiring it ourselves proves no live daemon owns it — the pid on disk, if
-// any, is stale. Unlike a probe-then-release check, the caller keeps holding
-// the lock (via the returned release func) for as long as it needs mutual
-// exclusion, so a daemon cannot start, and a second caller of
-// acquireDaemonLock cannot proceed, until release is called.
-//
-// The lock file is never unlinked here — only unlocked and closed — so a
-// second acquireDaemonLock always contends on the same inode rather than
-// racing a delete-then-recreate against a concurrent acquirer.
-//
-// flockFn is indirected to syscall.Flock so tests can inject a non-EWOULDBLOCK
-// failure (e.g. standing in for ENOLCK) without needing real OS-level
-// conditions to trigger it — EWOULDBLOCK is the only signal that means a live
-// daemon actually holds the lock.
+// flockFn is indirected so tests can inject a non-EWOULDBLOCK failure; only
+// EWOULDBLOCK means a live daemon actually holds the lock.
 var flockFn = syscall.Flock
 
 func acquireDaemonLock(pidPath string) (release func(), err error) {
@@ -399,19 +332,13 @@ func acquireDaemonLock(pidPath string) (release func(), err error) {
 		if errors.Is(flockErr, syscall.EWOULDBLOCK) {
 			return nil, fmt.Errorf("the attn daemon is running; stop it first (quit the app, or `attn daemon stop`) before restoring the database")
 		}
-		// Any other flock failure means we cannot determine whether a
-		// daemon holds the lock. Fail closed rather than risk racing a
-		// live daemon: never proceed with the restore on an inconclusive
-		// lock result.
+		// Indeterminate flock result: fail closed, never restore over a
+		// possibly live daemon.
 		return nil, fmt.Errorf("cannot determine daemon state: %w", flockErr)
 	}
-	// We now hold the lock, but the pid file may still contain a stale pid
-	// left by the last daemon to hold it. Stamp a sentinel over that content
-	// so a concurrent `attn daemon stop` (daemonctl.Stop), which trusts only
-	// content written by the current holder, never signals that stale pid.
-	// The sentinel is never restored on release — content is only
-	// meaningful while the lock is held, and the next daemon to acquire the
-	// lock overwrites it with its own pid as it always has.
+	// Stamp the sentinel over any stale pid so a concurrent `attn daemon stop`,
+	// which trusts only holder-written content, never signals it. Not restored
+	// on release: content only means anything while the lock is held.
 	if err := lockFile.Truncate(0); err != nil {
 		_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
 		lockFile.Close()

--- a/cmd/attn/pr_cursor.go
+++ b/cmd/attn/pr_cursor.go
@@ -11,33 +11,14 @@ import (
 	"time"
 )
 
-// prWaitCursor is what a previous wait on this pull request already reported.
-//
-// Without it, every call baselines from the pull request's current state, so
-// anything that happened between one wait returning and the next one starting is
-// absorbed into the new baseline and never reported: the agent answers a comment,
-// waits again, and a remark that landed while it was working is now "already
-// there". The wait then blocks for its whole timeout as if the PR were quiet.
-// That is the failure this file exists to prevent, and it is worse than a wrong
-// exit code because a swallowed event is invisible.
-//
-// It therefore records the three different shapes an event comes in, because
-// "seen" means something different for each:
-//
-//   - comments are discrete, so their IDs are the record, and one already
-//     reported is never news again;
-//   - a verdict supersedes itself, so the record is when it was submitted. It is
-//     the baseline a later wait measures a re-review against, not a suppression:
-//     an approval or changes-requested that still stands is the pull request's
-//     current answer and every wait should say so;
-//   - a failing check is a condition that stays true, so the record is which
-//     checks failed on which commit — the same failure on the same commit is not
-//     news twice, while a different one, or the same one after a push, is.
-//
-// The cursor advances to what a wait reported, plus the state a first-ever wait
-// deliberately treats as pre-existing context — in other words, exactly what the
-// caller need not be told again. Advancing it to everything a poll saw would lose
-// events permanently, silently.
+// prWaitCursor is what a previous wait on this pull request already reported,
+// so an event landing between two waits is never absorbed into the next
+// baseline and silently swallowed. "Seen" differs per event shape: comments
+// are discrete (IDs); a verdict supersedes itself (record its submit time — a
+// standing verdict is still reported, a re-review is measured against it); a
+// failing check is a condition (which checks on which commit — same failure on
+// the same commit is not news twice). The cursor advances only to what a wait
+// reported; advancing to everything a poll saw would lose events permanently.
 type prWaitCursor struct {
 	CommentIDs    []string  `json:"comment_ids,omitempty"`
 	VerdictAt     time.Time `json:"verdict_at,omitempty"`
@@ -46,10 +27,8 @@ type prWaitCursor struct {
 	UpdatedAt     time.Time `json:"updated_at,omitempty"`
 }
 
-// MarshalJSON keeps zero timestamps out of the encoded cursor. `omitempty` does
-// not apply to time.Time, and a cursor echoed to a caller with
-// "verdict_at":"0001-01-01T00:00:00Z" reads as a bug rather than as "no verdict
-// has been reported".
+// MarshalJSON keeps zero timestamps out of the encoded cursor — `omitempty`
+// does not apply to time.Time, and an encoded zero verdict_at reads as a bug.
 func (c prWaitCursor) MarshalJSON() ([]byte, error) {
 	type payload struct {
 		CommentIDs    []string   `json:"comment_ids,omitempty"`
@@ -93,19 +72,16 @@ func (c prWaitCursor) sameFailure(head string, checks []prCheck) bool {
 	return strings.Join(names, "\n") == strings.Join(previous, "\n")
 }
 
-// prCursorFileLimit caps how many comment IDs a cursor carries. A PR's comment
-// surfaces are queried newest-100 anyway, so an ID older than that window can
-// never come back as unseen and keeping it would grow the file forever.
+// prCursorFileLimit caps stored comment IDs. Comment surfaces are queried
+// newest-100, so an ID older than that window can never come back as unseen.
 const prCursorFileLimit = 500
 
-// prCursorMaxAge is how long a cursor outlives its last use. Each file is a few
-// hundred bytes, but one per pull request ever waited on is unbounded, and
-// nothing else would ever clean the directory.
+// prCursorMaxAge is how long a cursor outlives its last use; nothing else
+// cleans the directory.
 const prCursorMaxAge = 30 * 24 * time.Hour
 
 // cursorPath locates one pull request's cursor. Every segment is a legal
-// filename without escaping: a GitHub owner or repository name cannot contain a
-// slash and the host is a domain, which also keeps the tree readable by hand.
+// filename without escaping: owner/repo cannot contain a slash, host is a domain.
 func cursorPath(dir string, opts prWaitOptions) string {
 	host := opts.Host
 	if host == "" {
@@ -114,10 +90,8 @@ func cursorPath(dir string, opts prWaitOptions) string {
 	return filepath.Join(dir, host, opts.Owner, opts.Name, fmt.Sprintf("%d.json", opts.Number))
 }
 
-// loadPRWaitCursor reads the cursor for this pull request. A missing file is the
-// normal first call, not an error. A file that cannot be parsed is treated the
-// same way: the cursor is an optimization over re-baselining, and refusing to
-// wait because of a corrupt one would be worse than losing its history.
+// loadPRWaitCursor reads the cursor for this pull request. A missing file is
+// the normal first call, not an error.
 func loadPRWaitCursor(dir string, opts prWaitOptions) (prWaitCursor, error) {
 	if dir == "" {
 		return prWaitCursor{}, nil
@@ -136,10 +110,8 @@ func loadPRWaitCursor(dir string, opts prWaitOptions) (prWaitCursor, error) {
 	return cursor, nil
 }
 
-// savePRWaitCursor writes the cursor atomically — temp file in the same
-// directory, then rename — so a wait killed mid-write leaves either the old
-// cursor or the new one. A half-written file would be unparseable and would drop
-// the whole history for that pull request.
+// savePRWaitCursor writes the cursor atomically (temp file, then rename) so a
+// wait killed mid-write leaves either the old cursor or the new one.
 func savePRWaitCursor(dir string, opts prWaitOptions, cursor prWaitCursor, now time.Time) error {
 	if dir == "" {
 		return nil

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -1,30 +1,7 @@
-// Package agent defines the Driver interface and optional capability interfaces
-// for coding agents managed by attn. Adding a new agent (e.g. pi, gemini-cli)
-// requires implementing Driver and whichever optional interfaces the agent supports.
-//
-// Core interface (required):
-//
-//	Driver — name, executable resolution, command building, env vars
-//
-// Optional capability interfaces (implement only what the agent supports):
-//
-//	HookProvider                    — generates hook/settings configs (e.g. Claude Code hooks)
-//	TranscriptFinder                — locates transcript files on disk
-//	TranscriptWatcherBehaviorProvider — custom real-time transcript state policy
-//	ClassifierProvider              — custom classification backend
-//	LaunchPreparer                  — best-effort setup before launch (e.g. resume copy)
-//	SessionRecoveryPolicyProvider   — startup missing-PTY recovery policy
-//	RecoveredStatePolicyProvider    — recovered-state mapping at startup
-//	PTYStateFilterProvider          — live PTY state filtering
-//	ResumePolicyProvider            — resume ID lifecycle policy
-//	TranscriptClassificationExtractor — stop-time transcript extraction policy
-//	ExecutableClassifierProvider    — classifier hook with explicit executable path
-//	HeadlessTaskProvider            — scoped non-interactive agent execution
-//
-// Agents that don't implement an optional interface get sensible defaults:
-//   - No hooks: no hook-driven state updates
-//   - No transcript finder: classifier skipped on stop
-//   - No classifier: session falls back to idle after stop
+// Package agent defines the Driver interface and optional capability
+// interfaces for coding agents managed by attn. A new agent implements Driver
+// plus whichever optional interfaces it supports; missing ones get defaults
+// (no hook-driven state, classifier skipped on stop, idle after stop).
 package agent
 
 import (
@@ -40,96 +17,72 @@ import (
 )
 
 // Driver is the core interface every agent must implement.
-// It provides the minimum needed to spawn and manage an agent process.
 type Driver interface {
-	// Name returns the canonical agent identifier (e.g. "claude", "pi", "gemini-cli").
-	// Must match the SessionAgent enum value in the protocol.
+	// Name returns the canonical agent id; must match the protocol's SessionAgent enum.
 	Name() string
 
-	// DisplayName returns a human-friendly name for UI display (e.g. "Claude Code", "Pi").
+	// DisplayName returns a human-friendly name for UI display.
 	DisplayName() string
 
-	// DefaultExecutable returns the default binary name (e.g. "claude", "pi").
+	// DefaultExecutable returns the default binary name.
 	DefaultExecutable() string
 
-	// ExecutableEnvVar returns the env var name that overrides the executable
-	// (e.g. "ATTN_CLAUDE_EXECUTABLE"). Return "" if no override is supported.
+	// ExecutableEnvVar returns the executable-override env var, or "" when unsupported.
 	ExecutableEnvVar() string
 
-	// ResolveExecutable returns the executable path, checking env var override,
-	// configured value, and falling back to DefaultExecutable.
+	// ResolveExecutable returns the path: env override, configured, then DefaultExecutable.
 	ResolveExecutable(configured string) string
 
-	// BuildCommand builds the exec.Cmd to launch the agent.
-	// The command should NOT be started — the caller handles that.
+	// BuildCommand builds the exec.Cmd to launch the agent, not started.
 	BuildCommand(opts SpawnOpts) *exec.Cmd
 
-	// BuildEnv returns agent-specific environment variables to merge into
-	// the spawned process environment. The caller handles ATTN_INSIDE_APP,
-	// ATTN_SESSION_ID, etc. — this method only returns agent-specific extras
-	// (e.g. executable overrides).
+	// BuildEnv returns agent-specific env extras only; the caller handles ATTN_* basics.
 	BuildEnv(opts SpawnOpts) []string
 
 	// Capabilities returns which optional features this agent supports.
-	// Used by the daemon to decide which code paths to activate.
 	Capabilities() Capabilities
 }
 
 // Capabilities declares which optional features an agent supports.
-// This allows the daemon to skip code paths that don't apply to an agent
-// without requiring stub implementations.
 type Capabilities struct {
-	// HasHooks indicates the agent supports a hook/settings system
-	// (e.g. Claude Code hooks that report state changes via IPC).
-	// If true, the driver should implement HookProvider or ConfigOverrideProvider.
+	// HasHooks: hook/settings system; implement HookProvider or ConfigOverrideProvider.
 	HasHooks bool
 
-	// HasTranscript indicates the agent writes transcript files that attn
-	// can discover and parse. If true, implement TranscriptFinder.
+	// HasTranscript: discoverable transcript files; implement TranscriptFinder.
 	HasTranscript bool
 
-	// HasTranscriptWatcher indicates the daemon should run real-time transcript
-	// watching for state updates. Requires HasTranscript.
+	// HasTranscriptWatcher: real-time transcript watching. Requires HasTranscript.
 	HasTranscriptWatcher bool
 
-	// HasClassifier indicates the agent provides its own classification
-	// backend via ClassifierProvider.
+	// HasClassifier: the agent provides its own ClassifierProvider backend.
 	HasClassifier bool
 
-	// HarnessSignals names which harness-owned PTY signals this agent emits (the
-	// OSC 0 title heartbeat, OSC 777 notifications), or HarnessSignalsNone. They
-	// come from the agent itself rather than from reading its rendered TUI, which
-	// is why they are the only PTY state signals left: the scrapers they replaced
-	// broke on every redraw change and, for copilot, were confirmed silent
-	// through a whole live turn before being deleted.
+	// HarnessSignals names the harness-owned PTY signals this agent emits (OSC
+	// 0 title heartbeat, OSC 777), or HarnessSignalsNone. They come from the
+	// agent itself, not from scraping its rendered TUI.
 	HarnessSignals HarnessSignalKind
 
-	// HasResume indicates the agent supports resuming previous sessions.
+	// HasResume: the agent supports resuming previous sessions.
 	HasResume bool
 
-	// HasYolo indicates the agent supports launching with approvals bypassed.
+	// HasYolo: the agent supports launching with approvals bypassed.
 	HasYolo bool
 
-	// HasInitialPrompt indicates the agent can start an interactive session and
-	// immediately submit a prompt supplied by attn.
+	// HasInitialPrompt: can start interactive and immediately submit a prompt.
 	HasInitialPrompt bool
 
-	// HasWorkspaceContext indicates attn can give the agent hidden launch
-	// instructions for using a workspace context checkout.
+	// HasWorkspaceContext: accepts hidden launch instructions for a workspace
+	// context checkout.
 	HasWorkspaceContext bool
 
-	// HasSelfMonitor indicates the agent can optionally watch its own ticket/event
-	// stream via a live Monitor. It selects chief guidance only; daemon nudge
-	// eligibility is shared across runtimes. Only Claude supports this today.
+	// HasSelfMonitor: the agent can watch its own ticket/event stream via a
+	// live Monitor. Selects chief guidance only; nudge eligibility is shared.
 	HasSelfMonitor bool
 
-	// HasModelPin indicates the agent's launch command accepts a per-session
-	// model pin (SpawnOpts.Model). Delegation rejects --model for agents without it.
+	// HasModelPin: launch accepts SpawnOpts.Model; delegation rejects --model without it.
 	HasModelPin bool
 
-	// HasEffortPin indicates the agent's launch command accepts a per-session
-	// reasoning-effort pin (SpawnOpts.Effort). Delegation rejects --effort for
-	// agents without it.
+	// HasEffortPin: launch accepts SpawnOpts.Effort; delegation rejects --effort without it.
 	HasEffortPin bool
 }
 
@@ -150,24 +103,9 @@ const (
 
 var capabilityEnvNameSanitizer = regexp.MustCompile(`[^A-Za-z0-9]+`)
 
-// EffectiveCapabilities returns driver capabilities after applying env overrides.
-//
-// Env format (per agent, optional):
-//   - ATTN_AGENT_<AGENT>_HOOKS=0|1
-//   - ATTN_AGENT_<AGENT>_TRANSCRIPT=0|1
-//   - ATTN_AGENT_<AGENT>_TRANSCRIPT_WATCHER=0|1
-//   - ATTN_AGENT_<AGENT>_CLASSIFIER=0|1
-//   - ATTN_AGENT_<AGENT>_HARNESS_SIGNALS=0|1
-//   - ATTN_AGENT_<AGENT>_RESUME=0|1
-//   - ATTN_AGENT_<AGENT>_YOLO=0|1
-//   - ATTN_AGENT_<AGENT>_INITIAL_PROMPT=0|1
-//   - ATTN_AGENT_<AGENT>_WORKSPACE_CONTEXT=0|1
-//   - ATTN_AGENT_<AGENT>_SELF_MONITOR=0|1
-//   - ATTN_AGENT_<AGENT>_MODEL_PIN=0|1
-//   - ATTN_AGENT_<AGENT>_EFFORT_PIN=0|1
-//
-// <AGENT> is uppercased with non-alphanumeric chars replaced by underscores
-// (e.g. "gemini-cli" -> "GEMINI_CLI").
+// EffectiveCapabilities returns driver capabilities after applying optional
+// env overrides ATTN_AGENT_<AGENT>_<CAP>=0|1 (suffixes below); <AGENT> is the
+// uppercased name with non-alphanumerics as underscores ("gemini-cli" -> "GEMINI_CLI").
 func EffectiveCapabilities(d Driver) Capabilities {
 	if d == nil {
 		return Capabilities{}
@@ -187,8 +125,8 @@ func EffectiveCapabilities(d Driver) Capabilities {
 	if v, ok := boolEnv(prefix + "CLASSIFIER"); ok {
 		caps.HasClassifier = v
 	}
-	// HARNESS_SIGNALS=0 disables them; =1 keeps the driver's kind: there is no
-	// dialect for =1 to invent for an agent whose driver declares none.
+	// HARNESS_SIGNALS=0 disables; =1 keeps the driver's kind (there is no
+	// dialect for =1 to invent).
 	if v, ok := boolEnv(prefix + "HARNESS_SIGNALS"); ok && !v {
 		caps.HarnessSignals = HarnessSignalsNone
 	}
@@ -214,7 +152,7 @@ func EffectiveCapabilities(d Driver) Capabilities {
 		caps.HasEffortPin = v
 	}
 
-	// Consistency: transcript watcher requires transcript support.
+	// Transcript watcher requires transcript support.
 	if !caps.HasTranscript {
 		caps.HasTranscriptWatcher = false
 	}
@@ -261,36 +199,20 @@ type SpawnOpts struct {
 	ResumePicker    bool
 	YoloMode        bool
 
-	// AutoApprove, when true (and not YoloMode), launches the agent in its native
-	// auto-approve mode (Claude --permission-mode auto, Codex
-	// approvals_reviewer=auto_review) so it runs unattended without stalling on
-	// permission gates. Gated by the daemon's auto_approve_enabled setting and
-	// threaded into the worker via ATTN_AUTO_APPROVE. Yolo takes precedence.
+	// AutoApprove launches the agent in its native auto-approve mode (Claude
+	// --permission-mode auto, Codex approvals_reviewer=auto_review). Yolo wins.
 	AutoApprove bool
 
-	// Model, when set, pins the interactive agent's model via --model (an alias
-	// like "opus"/"sonnet" or a full model id). Empty means the agent's own
-	// default. Sourced from a delegation's --model flag, or else the daemon's
-	// chief_model_<agent> setting (chief launches only) or default_model_<agent>
-	// setting (every launch), and threaded into the worker via ATTN_MODEL.
+	// Model, when set, pins the agent's model via --model; empty means default.
 	Model string
 
-	// Effort, when set, pins the interactive agent's reasoning effort using the
-	// agent's native mechanism (Claude --effort, Codex model_reasoning_effort).
-	// Empty means the agent's own default. Sourced from a delegation's --effort
-	// flag, or else the daemon's chief_effort_<agent> setting (chief launches
-	// only) or default_effort_<agent> setting (every launch), and threaded into
-	// the worker via ATTN_EFFORT. Only meaningful for drivers with HasEffortPin.
+	// Effort, when set, pins reasoning effort via the agent's native mechanism;
+	// only meaningful for drivers with HasEffortPin.
 	Effort string
 
-	// AutoCompactWindow, when > 0, caps this launch's effective context window so
-	// auto-compaction triggers at that token threshold instead of the model's full
-	// window (Claude: CLAUDE_CODE_AUTO_COMPACT_WINDOW env var; Codex:
-	// model_auto_compact_token_limit config override). The daemon resolves the
-	// policy (chief_context_window_cap on chief launches,
-	// default_context_window_cap_<agent> on every other launch — see
-	// launchContextWindowCap) and it rides ATTN_AUTO_COMPACT_WINDOW into the
-	// worker; 0 means no cap, and the drivers apply it on every launch shape.
+	// AutoCompactWindow, when > 0, triggers auto-compaction at that token
+	// threshold (Claude: CLAUDE_CODE_AUTO_COMPACT_WINDOW; Codex:
+	// model_auto_compact_token_limit); applied on every launch shape.
 	AutoCompactWindow int
 
 	// Executable is the resolved executable path (from ResolveExecutable).
@@ -302,41 +224,35 @@ type SpawnOpts struct {
 	// WrapperPath is the resolved path to the attn binary.
 	WrapperPath string
 
-	// SettingsPath is a generated settings/hooks file path for agents that
-	// support it (e.g. Claude's --settings <path>).
+	// SettingsPath is a generated settings/hooks file path (Claude --settings).
 	SettingsPath string
 
 	// WorkspaceContextPath is this session's local checkout of the workspace's
-	// shared context. It may become stale after launch.
+	// shared context; may become stale after launch.
 	WorkspaceContextPath string
 
-	// InjectWorkflowGuidance, when true, appends the workflow-trigger guidance to
-	// this session's launch instructions (system prompt / developer instructions).
-	// It is gated by the daemon's workflows_enabled setting and is never set for
-	// workflow subagents, which spawn through the headless path instead.
+	// InjectWorkflowGuidance appends the workflow-trigger guidance to the
+	// launch instructions. Never set for workflow subagents.
 	InjectWorkflowGuidance bool
 
-	// NotebookRoot, when set, makes this a chief-of-staff launch: the agent
-	// receives Notebook guidance (its profile-wide durable home) instead of the
-	// workspace-context checkout guidance. In practice the launch path sets at
-	// most one of NotebookRoot and WorkspaceContextPath.
+	// NotebookRoot, when set, makes this a chief-of-staff launch (Notebook
+	// guidance); at most one of NotebookRoot and WorkspaceContextPath is set.
 	NotebookRoot string
 
 	// ConfigOverrides are agent CLI config overrides generated for this launch.
 	ConfigOverrides []string
 
-	// TrustWorkingDirectory allows an unattended, daemon-owned launch to pass
-	// the driver's repository trust gate. Interactive launches leave this false.
+	// TrustWorkingDirectory lets an unattended daemon-owned launch pass the
+	// driver's repository trust gate; interactive launches leave it false.
 	TrustWorkingDirectory bool
 }
 
 // --- Optional capability interfaces ---
 
 // HookProvider generates hook/settings configurations for agents that support them.
-// Some agents consume these through a generated settings file.
 type HookProvider interface {
-	// GenerateHooksConfig returns the content of a settings/hooks config file.
-	// The caller writes it to a temp file and passes --settings to the agent.
+	// GenerateHooksConfig returns settings/hooks config file content; the
+	// caller writes it to a temp file and passes --settings to the agent.
 	GenerateHooksConfig(sessionID, socketPath, wrapperPath string) string
 }
 
@@ -345,16 +261,13 @@ type ConfigOverrideProvider interface {
 	GenerateConfigOverrides(opts SpawnOpts) []string
 }
 
-// HeadlessTaskRequest describes a daemon-owned non-interactive task. The task
-// must not create an interactive attn session. The agent runs in native-tools
-// mode: it gets its OWN file tools and a writable working dir (WorkDir). The
-// daemon writes inputs into WorkDir and reads the agent's output file back;
-// validation + commit stay daemon-owned.
+// HeadlessTaskRequest describes a daemon-owned non-interactive task; it must
+// not create an interactive attn session. Validation + commit stay daemon-owned.
 type HeadlessTaskRequest struct {
 	Executable string
 	Model      string
-	// ReasoningEffort selects the provider's reasoning setting for this one
-	// bounded headless request. Empty preserves the provider default.
+	// ReasoningEffort selects the provider's reasoning setting; empty preserves
+	// the provider default.
 	ReasoningEffort  string
 	Prompt           string
 	WorkDir          string
@@ -362,101 +275,52 @@ type HeadlessTaskRequest struct {
 	MCPServerCommand string
 	MCPServerArgs    []string
 
-	// --- E2 additive (all optional; the janitor sets none of these) ---
-
-	// ToolName overrides the single MCP tool name threaded through the driver
-	// argv. Empty => the janitor default tool set {read_context, replace_context}
-	// (back-compat). Non-empty => exactly that one tool is enabled.
+	// ToolName overrides the single MCP tool name in the driver argv; empty =>
+	// the janitor default set {read_context, replace_context}.
 	ToolName string
-	// Schema, when non-empty, is the per-call JSON Schema the result sink
-	// advertises as the tool inputSchema. It is NOT consumed by the driver; it
-	// travels to the sink via MCPServerArgs (the caller builds those argv).
-	// Stored on the request for documentation/threading symmetry; drivers ignore it.
+	// Schema is the per-call JSON Schema the result sink advertises as the tool
+	// inputSchema. NOT consumed by the driver; it travels via MCPServerArgs.
 	Schema json.RawMessage
 	// ResultPath is the per-call file the sink writes the validated payload to.
-	// Like Schema, the caller bakes it into MCPServerArgs; drivers ignore it.
+	// Like Schema, baked into MCPServerArgs by the caller; drivers ignore it.
 	ResultPath string
 
-	// --- E3 additive (all optional; the janitor sets none of these) ---
-
-	// Sandbox selects the OS sandbox posture of the headless run. Accepted values:
-	//   - ""               => read-only (DEFAULT, byte-identical to the janitor):
-	//                         Codex `--sandbox read-only` + every feature stripped;
-	//                         Claude locked to the MCP tool allowlist only.
-	//   - "workspace-write" => writable: the agent may edit files and run shell,
-	//                          confined by the macOS seatbelt to cwd + TMPDIR with
-	//                          network disabled by default. NO other features are
-	//                          re-enabled, and no approval bypass is used.
-	// Any UNRECOGNIZED value is treated as read-only (fail closed).
+	// Sandbox selects the OS sandbox posture: "" => read-only; "workspace-write"
+	// => edits + shell, seatbelt-confined to cwd + TMPDIR, network off, no
+	// approval bypass. Any unrecognized value is read-only (fail closed).
 	Sandbox string
-	// CWD is the process working directory for the run. Empty => fall back to
-	// WorkDir (back-compat). The writable engine path sets this to the run's
-	// working tree so edits land where the workflow expects them; scratch files
-	// (last-message, schema, result) stay rooted at WorkDir to keep the tree clean.
+	// CWD is the process working directory; empty falls back to WorkDir.
+	// Scratch files stay rooted at WorkDir to keep the tree clean.
 	CWD string
-	// ExtraMCPServers are attached IN ADDITION to the primary MCPServer* triple
-	// (not instead of it), so a workflow session's MCP tools reach the subagent
-	// alongside return_result. The janitor sets none.
+	// ExtraMCPServers are attached IN ADDITION to the primary MCPServer*
+	// triple, not instead of it.
 	ExtraMCPServers []MCPServerSpec
 
-	// AllowedTools optionally overrides the default native tool set
-	// (Claude: Read,Write,Edit,Grep,Glob). Empty => provider default. (Codex
-	// ignores this field; its native tooling comes from the workspace-write
-	// sandbox defaults, not a CLI list.) Used by the native-tools headless path
-	// (the keeper/notebook tasks), which wires no MCP server.
+	// AllowedTools overrides the default native tool set; empty => provider
+	// default. Codex ignores it.
 	AllowedTools []string
 
-	// DisableTools, when true, runs the native-tools headless path with NO
-	// tools at all — a pure single-shot completion. This overrides
-	// AllowedTools entirely: an empty AllowedTools alone still falls back to
-	// the provider's native default tool set, so DisableTools is the explicit
-	// way to get a truly tool-less run. Empty/false is byte-for-byte identical
-	// to today's behavior. Used by the ticket reconciliation classifier, which
-	// judges a pre-extracted transcript slice with no need to touch disk.
-	//
-	// It makes the tools uncallable, not free: their definitions still ship in
-	// the billed prefix. See claudeHeadlessArgs for why they are not also
-	// stripped.
+	// DisableTools runs with NO tools at all — the explicit tool-less switch,
+	// since empty AllowedTools still falls back to the provider default set.
+	// Uncallable but not free: the definitions still ship in the billed
+	// prefix (see claudeHeadlessArgs).
 	DisableTools bool
 
-	// ExtraWritableRoots optionally widens the set of directories the agent may
-	// WRITE to, beyond the scratch WorkDir. The notebook narration tasks use this
-	// so a headless agent can write the curated journal / raw tier under the
-	// notebook root (which lives outside the scratch tempdir).
-	//
-	// Provider behavior:
-	//   - Claude: IGNORED. Claude headless runs with --permission-mode dontAsk,
-	//     which is NOT filesystem-sandboxed — it can already write anywhere the OS
-	//     user can, given absolute paths. No widening is needed or applied.
-	//   - Codex: each root is passed as `--add-dir <root>` so the
-	//     workspace-write sandbox (which otherwise confines writes to the cwd
-	//     WorkDir) also permits writes under these roots. Reads are unrestricted
-	//     under workspace-write, so transcript dirs need no widening.
-	//
-	// Empty (the keeper's compaction case) leaves both providers' existing
-	// scratch-only behavior unchanged.
+	// ExtraWritableRoots widens WRITE access beyond the scratch WorkDir.
+	// Claude: IGNORED (dontAsk is not fs-sandboxed, writes anywhere already).
+	// Codex: each root becomes `--add-dir <root>`.
 	ExtraWritableRoots []string
 
-	// --- reconciliation additive (all optional; the keeper/workflow set none) ---
-	// Runaway caps + structured output for judgment-style runs (the ticket
-	// reconciliation classifier). Claude-only: Claude Code is the one agent CLI
-	// with enforceable turn/dollar caps and schema-validated output, which is why
-	// reconciliation always runs `claude -p` regardless of the judged agent (see
-	// docs/plans/2026-07-01-orphaned-ticket-reconciliation.md). Codex ignores all
-	// three, like AllowedTools — `codex exec` has no equivalent flag to translate
-	// them into, so a caller that must be bounded on both drivers has to get its
-	// ceiling from something the caller owns: the run's context deadline, and
-	// DisableTools, which leaves a run with nothing to loop over.
+	// MaxTurns/MaxBudgetUSD/OutputSchema are Claude-only runaway caps +
+	// structured output; Codex ignores all three. See
+	// docs/plans/2026-07-01-orphaned-ticket-reconciliation.md.
 
 	// MaxTurns caps agentic turns (claude: --max-turns). 0 => uncapped.
 	MaxTurns int
-	// MaxBudgetUSD caps API spend, as a decimal string (claude: --max-budget-usd).
-	// Empty => uncapped.
+	// MaxBudgetUSD caps API spend, decimal string (claude: --max-budget-usd).
 	MaxBudgetUSD string
-	// OutputSchema, when non-empty, is passed inline as a JSON Schema the final
-	// answer must validate against (claude: --json-schema). Unlike Schema (the
-	// MCP result-sink path), this IS consumed by the driver argv; the validated
-	// object comes back in HeadlessTaskResult.StructuredOutput.
+	// OutputSchema is an inline JSON Schema the final answer must validate
+	// against (claude: --json-schema); returns HeadlessTaskResult.StructuredOutput.
 	OutputSchema json.RawMessage
 
 	// SystemPrompt REPLACES the agent CLI's own system prompt (claude:
@@ -477,13 +341,9 @@ type HeadlessTaskRequest struct {
 	SystemPrompt string
 }
 
-// usesNativeToolsPath reports whether this request runs through the native-tools
-// headless path (the keeper / notebook narration tasks) rather than the
-// MCP-config / writable-tree path (the workflow engine). The keeper sets none of
-// the MCP-server fields and neither CWD nor Sandbox; the workflow engine always
-// sets at least a writable CWD+Sandbox, and additionally an MCP result sink when
-// a call needs a schema-validated return. Any one of those markers selects the
-// MCP-config path.
+// usesNativeToolsPath reports whether this request runs the native-tools
+// headless path (keeper/notebook tasks) rather than the MCP-config path; any
+// MCP-server, CWD, or Sandbox marker selects the latter.
 func (r HeadlessTaskRequest) usesNativeToolsPath() bool {
 	return strings.TrimSpace(r.MCPServerName) == "" &&
 		strings.TrimSpace(r.MCPServerCommand) == "" &&
@@ -492,40 +352,33 @@ func (r HeadlessTaskRequest) usesNativeToolsPath() bool {
 		strings.TrimSpace(r.Sandbox) == ""
 }
 
-// MCPServerSpec describes one MCP server to attach to a headless run. It mirrors
-// the primary MCPServer* triple as a value so a list of additional servers can
-// be threaded through HeadlessTaskRequest.ExtraMCPServers.
+// MCPServerSpec describes one MCP server to attach to a headless run
+// (HeadlessTaskRequest.ExtraMCPServers).
 type MCPServerSpec struct {
 	// Name is the server identifier; tool names are prefixed with it for Claude
 	// (mcp__<Name>__<tool>) and keyed under mcp_servers.<Name> for Codex.
 	Name string
-	// Command is the executable that hosts the MCP server (stdio transport).
+	// Command is the executable hosting the MCP server (stdio transport).
 	Command string
 	// Args are the command arguments.
 	Args []string
-	// EnabledTools is the explicit tool allowlist exposed by this server. Each is
-	// added to the driver's enabled_tools / --allowedTools (prefixed for Claude).
+	// EnabledTools is the explicit tool allowlist added to the driver's
+	// enabled_tools / --allowedTools (prefixed for Claude).
 	EnabledTools []string
 }
 
 type HeadlessTaskResult struct {
 	Diagnostics string
-	// FailureOutput is the bounded raw tail of the failed child's stderr and
-	// stdout — the ground truth behind the Diagnostics keyword bucket. Set only
-	// on a failed run. It can echo prompt/workspace text, so callers choose
-	// whether their surface may show it (the reconcile failure comment does;
-	// keeper journal surfaces stick to Diagnostics).
+	// FailureOutput is the bounded raw tail of a failed child's stderr/stdout.
+	// It can echo prompt/workspace text, so callers choose whether their
+	// surface may show it.
 	FailureOutput string
-	// Text is the child's captured final assistant text (the no-schema path).
-	// Drivers populate this on a successful run.
+	// Text is the child's final assistant text (no-schema path), set on success.
 	Text string
-	// StructuredOutput is the schema-validated result object when the request
-	// set OutputSchema (claude: the result envelope's structured_output field).
-	// Empty when no schema was requested or the run ended before producing one
-	// (cap-hit, error) — callers must treat empty as "no verdict".
+	// StructuredOutput is the schema-validated result object when OutputSchema
+	// was set; empty means "no verdict" (no schema, cap-hit, or error).
 	StructuredOutput json.RawMessage
-	// TotalCostUSD / NumTurns are spend telemetry from the result envelope
-	// (claude --output-format json). Zero when the provider doesn't report them.
+	// TotalCostUSD / NumTurns are spend telemetry; zero when unreported.
 	TotalCostUSD float64
 	NumTurns     int
 }
@@ -556,29 +409,27 @@ func HeadlessTaskAvailability(driver Driver) (bool, string) {
 
 // TranscriptFinder locates transcript files written by the agent.
 type TranscriptFinder interface {
-	// FindTranscript returns the path to the transcript file for a session.
-	// Returns "" if not found. For agents without a session ID in the filename
-	// (e.g. Codex, Copilot), cwd and startedAt help narrow the search.
+	// FindTranscript returns the session's transcript path, "" if not found;
+	// cwd/startedAt narrow the search for agents without session-ID filenames.
 	FindTranscript(sessionID, cwd string, startedAt time.Time) string
 
-	// FindTranscriptForResume returns the transcript for a resumed session.
-	// Returns "" if not applicable or not found.
+	// FindTranscriptForResume returns the transcript for a resumed session,
+	// "" if not applicable or not found.
 	FindTranscriptForResume(resumeID string) string
 
-	// BootstrapBytes returns how many bytes to read from the end of a transcript
-	// when starting to watch mid-session (to catch recent context).
+	// BootstrapBytes is how many bytes to read from a transcript's end when
+	// starting to watch mid-session.
 	BootstrapBytes() int64
 }
 
 // ClassifierProvider provides a custom classification backend.
 type ClassifierProvider interface {
-	// Classify determines whether the agent is waiting for input or done.
-	// Returns "waiting_input", "idle", or "unknown".
+	// Classify returns "waiting_input", "idle", or "unknown".
 	Classify(text string, timeout time.Duration) (string, error)
 }
 
 // LaunchPreparer performs best-effort agent-specific setup before launch
-// (e.g. Claude resume transcript copy for session handoff).
+// (e.g. Claude resume transcript copy).
 type LaunchPreparer interface {
 	PrepareLaunch(opts SpawnOpts) error
 }
@@ -590,8 +441,7 @@ var (
 	registry   = make(map[string]Driver)
 )
 
-// Register adds a driver to the global registry.
-// Panics if a driver with the same name is already registered.
+// Register adds a driver to the global registry; panics on a duplicate name.
 func Register(d Driver) {
 	registryMu.Lock()
 	defer registryMu.Unlock()
@@ -667,9 +517,8 @@ func GetClassifier(d Driver) (ClassifierProvider, bool) {
 	return cp, ok
 }
 
-// GetTranscriptWatcherBehavior returns a transcript watcher behavior for drivers
-// that support transcript watching. Drivers may provide a custom behavior via
-// TranscriptWatcherBehaviorProvider; otherwise a default behavior is used.
+// GetTranscriptWatcherBehavior returns a transcript watcher behavior — custom
+// via TranscriptWatcherBehaviorProvider, else the default.
 func GetTranscriptWatcherBehavior(d Driver) (TranscriptWatcherBehavior, bool) {
 	if d == nil {
 		return nil, false

--- a/internal/attention/turn.go
+++ b/internal/attention/turn.go
@@ -1,13 +1,8 @@
-// Package attention decides whose turn it is.
-//
-// A turn opens on a state and closes only when the user settles it. Nothing the
-// agent does afterwards removes it: an agent you prompt goes back to work still
-// on your list, because it went back to work at your instruction. That makes
-// membership a comparison between two stamps rather than a reading of the
-// current state — state matters only at the instant a turn opens.
-//
-// The package is pure. It derives over protocol values, resolver reasons, and
-// timestamps, and imports neither the store nor the daemon.
+// Package attention decides whose turn it is. A turn opens on a state and
+// closes only when the user settles it — nothing the agent does afterwards
+// removes it, so membership is a comparison of two stamps, not a reading of
+// current state. The package is pure: it derives over protocol values,
+// resolver reasons, and timestamps, importing neither store nor daemon.
 package attention
 
 import (
@@ -18,26 +13,15 @@ import (
 )
 
 // OpensTurn reports whether reaching this state starts a turn the user owes.
+// Opening is guarded on the turn being closed, so re-opening changes nothing.
 //
-// It is the state vocabulary and nothing else: a state that opens a turn while
-// one is already open changes nothing, because opening is guarded on the turn
-// being closed.
-//
-//   - waiting_input, pending_approval, unknown open a turn. The first two are
-//     the agent asking; unknown is the daemon admitting it cannot tell, which is
-//     equally the user's problem.
-//   - idle opens one too, and it covers two cases that are indistinguishable
-//     here on purpose. A run you asked for finished and nobody has read the
-//     result; that it ended without a question makes it no less yours. And a
-//     session you launched and have not yet spoken to sits at its prompt in the
-//     same state — the purest turn there is, since nothing will ever happen in
-//     it until you type.
-//   - launching, working, scheduled never open one: the agent is busy or waiting
-//     on a clock. A session parked on a cron is not among them — see
-//     sessionstate.settled — so a loop you want left alone is silenced by pinning
-//     its workspace, which is filtered below.
-//   - recoverable never opens one either. The daemon revives it unattended, so
-//     surfacing it would hand the user work the daemon is already doing.
+//   - waiting_input, pending_approval, unknown open one (unknown is the daemon
+//     admitting it cannot tell — equally the user's problem).
+//   - idle opens one too, covering both a finished unread run and a
+//     never-spoken-to session at its prompt, indistinguishable on purpose.
+//   - launching, working, scheduled never do (see sessionstate.settled for
+//     cron-parked sessions); recoverable never does — the daemon revives it
+//     unattended.
 func OpensTurn(state protocol.SessionState) bool {
 	switch state {
 	case protocol.SessionStateWaitingInput,
@@ -51,25 +35,12 @@ func OpensTurn(state protocol.SessionState) bool {
 }
 
 // BreaksSnooze reports whether reaching this state cuts a snooze short.
-//
-// Snoozing says *not now*, and business as usual does not undo it: the agent
-// stopping, asking a question, wanting an approval, or finishing its run are all
-// things the user was deferring when they pressed it. What breaks through is what
-// they could not have anticipated.
-//
-//   - unknown is the daemon admitting it cannot explain the session (reasons
-//     "stuck" and "no_evidence"). A deferral is a judgement about an agent the
-//     user understood; this is the daemon saying that judgement no longer has
-//     anything behind it.
-//   - idle with reason "process_exited" is the agent's process actually gone.
-//     A run that merely ended resolves idle through "prompt_idle" or
-//     "classifier_verdict", so ordinary finishing stays deferred and only dying
-//     rings.
-//
-// The reason arrives as a plain string because that is how it rides the wire and
-// sits in the store, but it is compared against the resolver's own constant: the
-// set is defined by what the resolver means, and a renamed reason must not
-// silently stop breaking through.
+// Business as usual stays deferred; only what the user could not have
+// anticipated breaks through: unknown (the daemon can no longer explain the
+// session), and idle with reason "process_exited" (the process actually died —
+// ordinary finishing resolves idle via other reasons). The reason rides the
+// wire as a string but is compared against the resolver's own constant, so a
+// renamed reason cannot silently stop breaking through.
 func BreaksSnooze(state protocol.SessionState, reason string) bool {
 	switch state {
 	case protocol.SessionStateUnknown:
@@ -86,23 +57,19 @@ type Input struct {
 	OpenedAt  time.Time
 	SettledAt time.Time
 
-	// IsShell excludes terminal panes. A shell is a real store session
-	// registered idle at birth and left there forever, so without this it would
-	// sit in the queue permanently with nothing able to settle it.
+	// IsShell excludes terminal panes: a shell is registered idle at birth and
+	// left there forever, so it would sit in the queue with nothing to settle it.
 	IsShell bool
 
-	// ChiefOfStaff excludes the chief, which has its own anchored slot above the
-	// queue rather than a place in it.
+	// ChiefOfStaff excludes the chief, which has its own anchored slot.
 	ChiefOfStaff bool
 
-	// SessionPinned excludes one individually pinned session, leaving its
-	// workspace and its siblings in the queue. It is the finer-grained half of
-	// WorkspacePinned and filters the same way, for the same reason.
+	// SessionPinned excludes one pinned session, leaving its workspace and
+	// siblings in the queue; the finer-grained half of WorkspacePinned.
 	SessionPinned bool
 
-	// WorkspacePinned and WorkspaceMuted filter at read, not at open: a pinned or
-	// muted session still accumulates OpenedAt, so un-pinning surfaces whatever
-	// was outstanding at its true age instead of starting it from nothing.
+	// WorkspacePinned and WorkspaceMuted filter at read, not at open: OpenedAt
+	// still accumulates, so un-pinning surfaces the turn at its true age.
 	WorkspacePinned bool
 	WorkspaceMuted  bool
 }

--- a/internal/automation/engine.go
+++ b/internal/automation/engine.go
@@ -2,72 +2,46 @@ package automation
 
 import "time"
 
-// ticketSweptReleaseReason mirrors store.AutomationBindingReleasedTicketSwept.
-// The automation package cannot import internal/store (store is the
-// dependency-inverted caller here, adapting *store.Store to BindingStore), so
-// the reason string is duplicated rather than shared — see BindingStore.
+// ticketSweptReleaseReason mirrors store.AutomationBindingReleasedTicketSwept;
+// duplicated because this package cannot import internal/store (see BindingStore).
 const ticketSweptReleaseReason = "ticket_swept"
 
 // Binding is a continuity thread's stable identity, as durably recorded by
-// store.AutomationContinuityBinding. It carries only what a continuation
-// decision needs; ResolveContinuation deliberately learns nothing else about
-// the definition, ticket, or session.
+// store.AutomationContinuityBinding; only what a continuation decision needs.
 type Binding struct {
 	TicketID, SessionID, WorkspaceID, PaneID string
 }
 
-// Continuation is ResolveContinuation's decision: either deliver fresh
-// (Fresh, no Binding) or continue the given Binding's thread. If a dangling
-// active binding was found (its ticket gone) and released to make Fresh
-// delivery safe, SelfHealedDanglingBinding records that so the caller can log
-// it — the caller has more context (definition, continuity key) to make a
-// useful warning than this package does.
+// Continuation is ResolveContinuation's decision: deliver fresh (Fresh, no
+// Binding) or continue the given Binding's thread. SelfHealedDanglingBinding
+// records a released dangling binding so the caller can log it with context.
 type Continuation struct {
 	Fresh                     bool
 	Binding                   *Binding
 	SelfHealedDanglingBinding bool
 }
 
-// BindingStore is the durable-state seam ResolveContinuation depends on
-// instead of touching tickets, git, or PTYs directly. The daemon adapts
+// BindingStore is ResolveContinuation's durable-state seam. The daemon adapts
 // *store.Store to it; internal/automation never imports internal/store or
-// internal/daemon, keeping this package's continuation logic testable against
-// an in-memory fake.
+// internal/daemon, keeping the logic testable against an in-memory fake.
 type BindingStore interface {
 	// GetActiveContinuityBinding returns the active binding for
 	// (definitionID, continuityKey), or (nil, nil) when there is none.
 	GetActiveContinuityBinding(definitionID, continuityKey string) (*Binding, error)
 	// ReleaseContinuityBinding releases the active binding for
-	// (definitionID, continuityKey) with reason, or is a no-op if there is no
-	// active binding.
+	// (definitionID, continuityKey) with reason; no-op when none is active.
 	ReleaseContinuityBinding(definitionID, continuityKey, reason string, now time.Time) error
 	// TicketExists reports whether ticketID still exists.
 	TicketExists(ticketID string) (bool, error)
 }
 
-// ResolveContinuation decides whether a claimed automation occurrence should
-// continue an existing thread or start fresh, from binding status alone.
-// ownTicketID is the calling run's own reserved ticket ID (WorkRequest.IDs.
-// TicketID) — the caller always knows this before its ticket exists, since
-// ticket IDs are stable-reserved at claim time, before ticket creation.
-//
-//   - no active binding: Fresh delivery — either the first occurrence under
-//     this continuity key, or a previously active binding was already
-//     released (contract rotation, explicit ticket sweep, definition delete).
-//   - an active binding whose ticket is ownTicketID: Fresh delivery, and the
-//     binding is NOT released. The claim that reserved this run's IDs already
-//     created this binding pointing at its own not-yet-created ticket — the
-//     thread is being born right now, not dangling. Treating "ticket doesn't
-//     exist yet" as "ticket is gone" here would self-heal (release) a binding
-//     the instant it is born, breaking continuity for every next occurrence.
-//   - an active binding whose ticket exists (and is not ownTicketID): continue
-//     that thread.
-//   - an active binding whose ticket is gone (e.g. store.SweepExpiredTickets
-//     removed it without going through the ordinary release paths) and is not
-//     ownTicketID: this is a genuinely dangling binding. ResolveContinuation
-//     self-heals it — releases the binding with reason ticket_swept, then
-//     reports Fresh delivery — rather than refusing, since there is nothing
-//     left to continue.
+// ResolveContinuation decides whether a claimed automation occurrence
+// continues an existing thread or starts fresh, from binding status alone.
+// ownTicketID is the run's own claim-time reserved ticket ID (known before the
+// ticket exists). A binding pointing at ownTicketID is a thread being born,
+// NOT dangling — releasing it would break continuity at birth. A binding whose
+// ticket exists is continued; one whose ticket is genuinely gone (swept) is
+// self-healed: released with reason ticket_swept, then Fresh.
 func ResolveContinuation(s BindingStore, definitionID, continuityKey, ownTicketID string, now time.Time) (Continuation, error) {
 	binding, err := s.GetActiveContinuityBinding(definitionID, continuityKey)
 	if err != nil {

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -1,33 +1,9 @@
-// Package bus is attn's durable event bus: the internal spine that carries
-// domain facts from whatever produced them to everything that reacts.
-//
-// A fact is a name, a subject, and a small payload — "this session changed
-// state", "this ticket was commented on". It is NOT a WebSocket message. Most of
-// what the daemon currently pushes to clients is a whole-list snapshot, and a log
-// of snapshots would be a fat stream of UI invalidations that tells a subscriber
-// only that something changed. Facts stay small, stay durable, and are worth
-// subscribing to. Turning a fact into whatever the wire needs — frequently a
-// snapshot re-push — is the consumer's job, not the publisher's.
-//
-// Two kinds of consumer:
-//
-//   - Durable consumers register by name and hold a persisted cursor. Delivery is
-//     strict seq order, one event in flight, cursor advanced after the handler
-//     returns: at-least-once. A consumer that was down catches up from its
-//     bookmark. A handler that keeps failing stalls its own consumer loudly
-//     rather than skipping the event.
-//   - Ephemeral subscribers hold no cursor and start at head. The WebSocket hub
-//     is one: clients already refetch on reconnect, so replaying history into a
-//     hub would duplicate work the frontend already does.
-//
-// What does NOT belong here: byte streams. PTY output, attach traffic, and tile
-// content keep their direct paths. They are high volume, and attach routing is
-// per-client predicate matching, which pub/sub cannot express.
-//
-// The package accepts a Store and a LogFunc at construction and MUST NOT import
-// internal/daemon (the daemon imports this package and adapts internal/store to
-// the Store seam, exactly as it does for internal/jobs).
-//
+// Package bus is attn's durable event bus, carrying domain facts (name,
+// subject, small payload — never byte streams like PTY output or attach
+// traffic). Durable consumers get strict seq order, at-least-once delivery from
+// a persisted cursor; ephemeral subscribers start at head with no cursor.
+// MUST NOT import internal/daemon (the daemon imports this package and adapts
+// internal/store to the Store seam).
 // See docs/plans/2026-08-01-ext-a1-event-bus.md.
 package bus
 
@@ -42,16 +18,14 @@ import (
 )
 
 const (
-	// DefaultRetention is the age window for the durable log. Events older than
-	// this are eligible for trimming, subject to the enabled-consumer cursor floor.
+	// DefaultRetention is the trim age window, floored by enabled-consumer cursors.
 	DefaultRetention = 30 * 24 * time.Hour
 	// DefaultTrimInterval is how often retention runs.
 	DefaultTrimInterval = time.Hour
 	// DefaultBatchSize bounds one read of the forward stream.
 	DefaultBatchSize = 200
-	// DefaultPollInterval is the safety-net wake for a durable consumer. Delivery
-	// is normally driven by publish notifications; this bounds how long a missed
-	// notification, or an externally flipped enabled bit, can go unnoticed.
+	// DefaultPollInterval bounds how long a missed publish notification, or an
+	// externally flipped enabled bit, can go unnoticed.
 	DefaultPollInterval = 5 * time.Second
 	// DefaultRetryBase / DefaultRetryCap bound the capped-exponential retry of a
 	// failing handler.
@@ -60,13 +34,11 @@ const (
 )
 
 // ErrAlreadyStarted is returned by Register once Start has run: the set of
-// durable consumers is fixed at startup, so a delivery loop always exists for
-// every registration.
+// durable consumers is fixed at startup.
 var ErrAlreadyStarted = errors.New("bus: consumers must be registered before Start")
 
-// LogFunc matches the daemon's injected logger shape (see internal/jobs,
-// internal/pty). Runtime logging goes through it — never log.Printf, whose stderr
-// is discarded when the daemon runs in the background.
+// LogFunc is the daemon's injected logger shape. All runtime logging goes
+// through it — never log.Printf, whose stderr is discarded in the background.
 type LogFunc func(format string, args ...interface{})
 
 // Event is one fact on the log.
@@ -96,8 +68,8 @@ type Consumer struct {
 	UpdatedAt time.Time
 }
 
-// Store is the persistence seam. internal/store implements the equivalent
-// methods; the daemon adapts them so neither package imports the other.
+// Store is the persistence seam; the daemon adapts internal/store to it so
+// neither package imports the other.
 type Store interface {
 	Append(e Event, now time.Time) (int64, error)
 	Since(cursor int64, limit int) ([]Event, error)
@@ -107,23 +79,18 @@ type Store interface {
 	SetCursor(name string, cursor int64, now time.Time) error
 	ListConsumers() ([]Consumer, error)
 	Trim(cutoff time.Time) (int, error)
-	// Compact keeps only the newest fact per subject among the named ones, and
-	// only at or below floor. Which names those are is decided here (Options.
-	// Compactable); the SQL lives in the store, the same split Trim uses.
+	// Compact keeps only the newest fact per subject among the named ones, at or
+	// below floor.
 	Compact(names []string, floor int64) (int, error)
-	// Size reports how many facts the log holds and how many bytes of event text
-	// they carry — the receipt that says whether the log is outgrowing the data
-	// it describes.
+	// Size reports the log's row count and event-text bytes.
 	Size() (rows, bytes int64, err error)
 }
 
-// Handler receives one event. Returning an error stalls the consumer on that
-// event and retries with backoff; the cursor does not advance, so the event is
-// redelivered. Handlers must therefore tolerate redelivery.
+// Handler receives one event. An error stalls the consumer with backoff and
+// redelivers the event; handlers must tolerate redelivery.
 type Handler func(ctx context.Context, ev Event) error
 
-// Options configures a Bus. Every duration is optional and falls back to the
-// package defaults.
+// Options configures a Bus; zero durations fall back to the package defaults.
 type Options struct {
 	Store        Store
 	Log          LogFunc
@@ -134,9 +101,8 @@ type Options struct {
 	PollInterval time.Duration
 	RetryBase    time.Duration
 	RetryCap     time.Duration
-	// Compactable names the fact classes whose log rows are pure invalidations,
-	// so the retention pass may keep only the newest one per subject. See
-	// Bus.Trim for what that costs a consumer and why it is sound.
+	// Compactable names fact classes that are pure invalidations, so retention
+	// may keep only the newest per subject (see compact for the cost).
 	Compactable []string
 }
 
@@ -156,17 +122,14 @@ type Bus struct {
 	compactable []string
 
 	// publishMu serializes append + ephemeral fan-out so ephemeral subscribers
-	// observe events in seq order. Durable consumers get ordering from their
-	// cursor and do not need it.
+	// observe events in seq order.
 	publishMu sync.Mutex
-	// marked says the announce mark has been placed from a real log head. Until
-	// it is, the mark's zero value would mean "announce the whole log", so
-	// announcing is held back rather than replaying history at every client.
+	// marked says the announce mark was placed from a real log head. An unset
+	// mark reads as "announce the whole log", so announcing is held back until it
+	// is placed.
 	marked bool
-	// announced is the highest seq already fanned out to ephemeral subscribers,
-	// guarded by publishMu. Both entry points — Publish and Announce — read
-	// forward from it, which is what keeps events appended by somebody else's
-	// transaction in seq order with events this bus appended itself.
+	// announced is the highest seq fanned out to ephemeral subscribers, guarded
+	// by publishMu; both Publish and Announce read the log forward from it.
 	announced int64
 
 	mu        sync.Mutex
@@ -199,9 +162,8 @@ type ephemeralSub struct {
 	fn     func(Event)
 }
 
-// New builds a Bus. A nil Store yields a bus that accepts publishes and drops
-// them, mirroring the store's own nil-db convention so a daemon without a
-// database still runs.
+// New builds a Bus. A nil Store yields a bus that fans out publishes without
+// durability, mirroring the store's nil-db convention.
 func New(opts Options) *Bus {
 	b := &Bus{
 		store:        opts.Store,
@@ -223,24 +185,17 @@ func New(opts Options) *Bus {
 		b.log = func(string, ...interface{}) {}
 	}
 	b.ctx, b.cancel = context.WithCancel(context.Background())
-	// The announce mark starts at head, so a bus attached to an existing log
-	// announces what happens next rather than replaying its history. It is set
-	// here rather than in Start because a Bus that is never started still
-	// publishes and announces — that is the shape of every test daemon — and one
-	// that replayed a month of facts into the wire on its first write would be a
-	// worse failure than a missed one.
+	// Mark at construction, not Start: a never-started Bus still publishes and
+	// announces, and an unplaced mark would replay the whole log on first write.
 	if b.store != nil {
 		b.markHead()
 	}
 	return b
 }
 
-// Publish appends a fact and returns its seq. Payload may be nil (a fact whose
-// subject says everything) or any JSON-marshalable value.
-//
-// The write is synchronous: the caller learns the fact is durable, and the seq is
-// assigned under the same lock that orders ephemeral delivery. This is affordable
-// because the bus carries facts, not streams.
+// Publish appends a fact and returns its seq. Payload may be nil or any
+// JSON-marshalable value. The write is synchronous: the caller learns the fact
+// is durable.
 func (b *Bus) Publish(name, subject string, payload any) (int64, error) {
 	return b.publish(Event{Name: name, Subject: subject}, payload)
 }
@@ -267,9 +222,7 @@ func (b *Bus) publish(ev Event, payload any) (int64, error) {
 	now := b.now()
 	ev.CreatedAt = now
 
-	// Without a store the fact still HAPPENED — only its durability is missing.
-	// Live subscribers are delivered to either way, so a bus configured without a
-	// database degrades to fan-out rather than to silence.
+	// No store: degrade to fan-out rather than silence.
 	if b.store == nil {
 		b.fanoutEphemeral(ev)
 		return 0, nil
@@ -277,36 +230,25 @@ func (b *Bus) publish(ev Event, payload any) (int64, error) {
 
 	seq, err := b.store.Append(ev, now)
 	if err != nil {
-		// Same degradation as the store-less case above, and for the same reason.
-		// These projections were direct broadcasts before the bus existed; a client
-		// must not miss a state change because the durable log had a bad night. The
-		// caller still learns durability was lost.
+		// A failed append must not silence the wire; the caller still learns
+		// durability was lost.
 		b.fanoutEphemeral(ev)
 		return 0, fmt.Errorf("bus: appending %s: %w", ev.Name, err)
 	}
 	ev.Seq = seq
 
-	// Fan out by reading the log forward rather than by handing subscribers the
-	// event in hand. The two are the same message whenever this publish is the
-	// only writer, and they are not the same ORDER when they are not: a fact
-	// appended inside somebody else's transaction (see the document store's
-	// composite write) may sit below this seq and still be unannounced, and
-	// delivering this one first would show subscribers the log out of order.
-	// Reading forward makes the log the ordering authority, whoever wrote to it.
+	// Fan out by reading the log forward, not by delivering the event in hand: a
+	// fact appended by somebody else's transaction may sit below this seq still
+	// unannounced, and delivering this one first would break seq order.
 	b.announceLocked(&ev)
 	b.wakeDurables()
 	return seq, nil
 }
 
-// Announce fans out facts appended to the log outside Publish — by a store
-// transaction that committed a change and its fact together — so ephemeral
-// subscribers see them in seq order beside everything else.
-//
-// It reads forward from the announce mark under the same lock Publish holds,
-// which makes it idempotent and order-correct no matter who calls it when: two
-// writers that commit and then race to announce cannot deliver out of order,
-// and an announce that never happens is repaired by the next one. Callers
-// therefore need no coordination beyond calling it after their commit.
+// Announce fans out facts appended to the log outside Publish (store
+// transactions that commit a change and its fact together). Idempotent and
+// order-correct: callers just call it after their commit, and a missed announce
+// is repaired by the next one.
 func (b *Bus) Announce() {
 	if b.store == nil {
 		return
@@ -318,11 +260,9 @@ func (b *Bus) Announce() {
 }
 
 // markHead sets the announce mark to the log's head and reports whether it
-// learned where the log stands. A mark that was never set is 0, which means
-// "announce everything" — so until this succeeds the bus must not announce at
-// all, or the first write would replay the whole log into every live client.
-// Construction calls it once; announceLocked retries it, because a database
-// that could not be read at construction is usually readable a moment later.
+// succeeded. Until it does the bus must not announce at all — an unset mark
+// would replay the whole log. announceLocked retries it after a failed
+// construction-time call.
 func (b *Bus) markHead() bool {
 	_, head, err := b.store.Bounds()
 	if err != nil {
@@ -338,9 +278,6 @@ func (b *Bus) markHead() bool {
 // event the caller just appended, delivered directly if the log cannot be read
 // — losing durability must not also silence the wire.
 func (b *Bus) announceLocked(fallback *Event) {
-	// Without a mark there is no "everything after here" to deliver, only the
-	// whole log. Deliver the caller's own event, which is what it would have
-	// gotten before reading forward existed, and try again next time.
 	if !b.marked && !b.markHead() {
 		if fallback != nil {
 			b.fanoutEphemeral(*fallback)
@@ -398,12 +335,9 @@ func (b *Bus) wakeDurables() {
 	}
 }
 
-// Register adds a durable consumer. It must be called before Start.
-//
-// A consumer new to the store begins at head: registering a consumer is not a
-// request to replay history. An existing consumer keeps its cursor and its
-// enabled bit — restarting the daemon must neither rewind a consumer nor
-// resurrect one the operator killed.
+// Register adds a durable consumer; must be called before Start. A new
+// consumer begins at head; an existing one keeps its cursor and enabled bit —
+// a restart must neither rewind a consumer nor resurrect a killed one.
 func (b *Bus) Register(name string, filter Filter, h Handler) error {
 	if strings.TrimSpace(name) == "" {
 		return errors.New("bus: consumer name is required")
@@ -433,14 +367,9 @@ func (b *Bus) Register(name string, filter Filter, h Handler) error {
 }
 
 // Subscribe adds an ephemeral subscriber and returns its cancel function. The
-// subscriber holds no cursor, starts at head, and is invoked inline on the
-// publishing goroutine in seq order — so its function must be cheap and must not
-// publish back onto the bus.
-//
-// Seq is 0 when the fact could not be made durable (no store, or a failed
-// append). Ephemeral delivery is deliberately not conditional on durability:
-// these subscribers project onto the wire, and the wire must not go quiet
-// because the log did. A subscriber that cares must check Seq.
+// function runs inline on the publishing goroutine — it must be cheap and must
+// not publish back onto the bus (publishMu is held: deadlock). Seq is 0 when
+// the fact could not be made durable; a subscriber that cares must check.
 func (b *Bus) Subscribe(filter Filter, fn func(Event)) func() {
 	if fn == nil {
 		return func() {}
@@ -506,7 +435,6 @@ func (b *Bus) initConsumer(d *durable, head int64) error {
 	}
 	now := b.now()
 	if !ok {
-		// From now: a fresh consumer is not asking for the backlog.
 		if err := b.store.SaveConsumer(Consumer{
 			Name:    d.name,
 			Cursor:  head,
@@ -579,8 +507,8 @@ func (b *Bus) deliver(d *durable) {
 
 // drain reads forward from the consumer's cursor until the log is exhausted.
 func (b *Bus) drain(d *durable) error {
-	// The enabled bit is the kill switch and lives only in the database, so it is
-	// re-read here rather than cached for the process lifetime.
+	// The enabled bit is the kill switch and lives only in the database; re-read
+	// it, never cache it for the process lifetime.
 	rec, ok, err := b.store.GetConsumer(d.name)
 	if err != nil {
 		return fmt.Errorf("reading registration: %w", err)
@@ -597,10 +525,8 @@ func (b *Bus) drain(d *durable) error {
 		return err
 	}
 
-	// A consumer that is behind a busy producer never leaves the loop below, so
-	// re-reading the kill switch once per drain would leave it unreachable for as
-	// long as the burst lasts. Re-read it on the poll interval instead, which is
-	// the bound DefaultPollInterval documents.
+	// A lagging consumer never leaves the loop below, so the kill switch is
+	// re-read on the poll interval, not once per drain.
 	lastCheck := b.now()
 	killed := func() (bool, error) {
 		if b.now().Sub(lastCheck) < b.pollInterval {
@@ -647,8 +573,7 @@ func (b *Bus) drain(d *durable) error {
 				return nil
 			}
 			if !d.filter.Matches(ev.Name) {
-				// Unwanted events still advance the cursor, batched into one write
-				// at the next matching event or at the end of the batch.
+				// Unwanted events still advance the cursor, batched into one write.
 				skipped = ev.Seq
 				continue
 			}
@@ -667,10 +592,8 @@ func (b *Bus) drain(d *durable) error {
 			if err := b.advance(d, ev.Seq); err != nil {
 				return err
 			}
-			// Backoff escalates for an event the handler cannot get past, not over
-			// a consumer's lifetime: a delivery that succeeds ends the streak, so a
-			// consumer that is merely lagging does not ratchet to the retry cap on
-			// occasional transient failures.
+			// A successful delivery ends the failure streak, so a lagging consumer
+			// does not ratchet to the retry cap on transient failures.
 			d.clearFailure()
 		}
 		if skipped != 0 {
@@ -681,10 +604,8 @@ func (b *Bus) drain(d *durable) error {
 	}
 }
 
-// reconcileGap handles a consumer whose cursor sits below the oldest surviving
-// event: retention trimmed past it while it was disabled or dead. It resumes at
-// head — replaying a month of backlog into a just-revived consumer would be worse
-// than the gap — and says so.
+// reconcileGap handles a cursor below the oldest surviving event (retention
+// trimmed past it while disabled or dead): resume at head, with a logged gap.
 func (b *Bus) reconcileGap(d *durable) error {
 	earliest, head, err := b.store.Bounds()
 	if err != nil {
@@ -716,21 +637,14 @@ func (b *Bus) retain() {
 		case <-b.ctx.Done():
 			return
 		case <-ticker.C:
-			// A failed pass is already logged; the next tick retries it.
 			_, _ = b.Trim()
 		}
 	}
 }
 
-// Trim runs one retention pass and reports how many events it removed, by both
-// halves: the age window, and compaction of the fact classes that carry no
-// history. It is exported so the daemon and tests can force a pass without
-// waiting for a tick.
-// It reports what it removed and whether either half failed. The daemon's tick
-// logs the failure and carries on — a pass that could not run is retried an hour
-// later — but a caller that ASKED for a pass has to be able to tell a pass that
-// removed nothing from one that never happened, or a script reads "removed 0"
-// and concludes the log is already clean.
+// Trim runs one retention pass (age window plus compaction) and reports how
+// many events it removed and whether either half failed — a caller must be able
+// to tell "removed 0" from "never ran".
 func (b *Bus) Trim() (int, error) {
 	if b.store == nil {
 		return 0, nil
@@ -756,30 +670,13 @@ func (b *Bus) Trim() (int, error) {
 	return removed + compacted, failed
 }
 
-// compact keeps at most one fact per subject for every compactable name, which
-// is what bounds the log by the size of the data it describes rather than by
-// how often that data is written.
-//
-// A compactable fact is an invalidation: it says a subject changed, and the
-// state itself lives in the store, so five of them about one subject carry no
-// more than the newest. The consequence, stated rather than hidden: for these
-// names durable delivery is at-least-once PER CHANGED SUBJECT, not per write. A
-// consumer that was behind while a document changed five times learns once that
-// it changed, and reads current state — which is what a consumer of this bus is
-// told to do anyway. A workload that needs every intermediate change as a
-// business event is doing event sourcing, and those events are data: they
-// belong in a collection the workload writes, where their growth is its own
-// visible cost.
-//
-// The cursor floor is the same one trimming honors, for two load-bearing
-// reasons. An enabled consumer must never lose a fact it has not read, and
-// below the floor every enabled consumer has read everything, so their delivery
-// is bit-for-bit what it is today. And reconcileGap reads "cursor below the
-// earliest surviving seq" as "everything missing was trimmed"; compacting above
-// the floor would punch holes that assumption misreads and skip a revived
-// consumer past facts that still exist. A stalled enabled consumer therefore
-// pins compaction exactly as it pins trimming — a loud condition already, with
-// `attn bus status` showing the stall and the kill switch to unpin it.
+// compact keeps at most one fact per subject for every compactable name,
+// bounding the log by the data it describes rather than by write frequency.
+// For these names durable delivery is at-least-once PER CHANGED SUBJECT, not
+// per write. Compaction honors the same cursor floor as trimming: an enabled
+// consumer must never lose an unread fact, and compacting above the floor would
+// punch holes that reconcileGap misreads as trimmed history. A stalled enabled
+// consumer pins compaction exactly as it pins trimming.
 func (b *Bus) compact() (int, error) {
 	if len(b.compactable) == 0 {
 		return 0, nil
@@ -800,10 +697,8 @@ func (b *Bus) compact() (int, error) {
 	return n, nil
 }
 
-// consumerFloor is the lowest position every enabled consumer has passed. With
-// no enabled consumer registered it is the log head: nobody is owed anything, so
-// nothing is pinned. Disabled consumers are excluded for the same reason they
-// are excluded from trimming — a killed consumer must not pin the log.
+// consumerFloor is the lowest position every enabled consumer has passed; with
+// none enabled it is the log head. A killed consumer must not pin the log.
 func (b *Bus) consumerFloor() (int64, error) {
 	rows, err := b.store.ListConsumers()
 	if err != nil {
@@ -835,20 +730,15 @@ type ConsumerStatus struct {
 	Lag     int64
 	Filter  string
 	Enabled bool
-	// Live is true when this process has a delivery loop for the consumer. A
-	// registered-but-not-live consumer is one whose owner is gone.
+	// Live is true when this process has a delivery loop for the consumer.
 	Live bool
 	// Stalled carries the current failure message when a handler is failing.
 	Stalled string
 }
 
 // Status reports the log head and every registration, for operator inspection.
-//
-// Rows and Bytes are the log's actual weight rather than head-minus-earliest,
-// which only ever described the seq space. They are the receipt for the
-// invariant compaction upholds — the log stays proportional to the data it
-// describes, never to how often that data is written — so a workload that
-// stresses it shows up as a measurement instead of a suspicion.
+// Rows and Bytes are the log's actual weight — the receipt that it stays
+// proportional to the data it describes, not to write frequency.
 type Status struct {
 	Head      int64
 	Earliest  int64

--- a/internal/client/documents.go
+++ b/internal/client/documents.go
@@ -9,12 +9,10 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-// The document store's client surface. Every call goes through the daemon rather
-// than opening the database, unlike `attn bus`: a write has to publish its change
-// fact, and a write that reached the table without one would leave every live
-// query showing a result set the store no longer agrees with. One path, so there
-// is no way to take the quiet one by accident.
+// The document store's client surface. Every call goes through the daemon, never
+// the database directly: a write must publish its change fact or live queries drift.
 
+// DocDefine declares a collection from its schema.
 func (c *Client) DocDefine(schema protocol.DocumentCollectionSchema) (*protocol.DocDefineResult, error) {
 	resp, err := c.send(protocol.DocDefineMessage{Cmd: protocol.CmdDocDefine, Schema: schema})
 	if err != nil {
@@ -23,6 +21,7 @@ func (c *Client) DocDefine(schema protocol.DocumentCollectionSchema) (*protocol.
 	return resp.DocDefineResult, nil
 }
 
+// DocUndefine removes a collection.
 func (c *Client) DocUndefine(namespace, collection string) (*protocol.DocUndefineResult, error) {
 	resp, err := c.send(protocol.DocUndefineMessage{
 		Cmd: protocol.CmdDocUndefine, Namespace: namespace, Collection: collection,
@@ -33,6 +32,7 @@ func (c *Client) DocUndefine(namespace, collection string) (*protocol.DocUndefin
 	return resp.DocUndefineResult, nil
 }
 
+// DocCollections lists the defined collections.
 func (c *Client) DocCollections() (*protocol.DocCollectionsResult, error) {
 	resp, err := c.send(protocol.DocCollectionsMessage{Cmd: protocol.CmdDocCollections})
 	if err != nil {
@@ -41,9 +41,8 @@ func (c *Client) DocCollections() (*protocol.DocCollectionsResult, error) {
 	return resp.DocCollectionsResult, nil
 }
 
-// DocPut writes a document. expectedRev is the revision the caller believes it
-// is replacing — nil writes unconditionally, and see DocPutMessage for what a
-// value means.
+// DocPut writes a document. expectedRev nil writes unconditionally; see
+// DocPutMessage for what a value means.
 func (c *Client) DocPut(namespace, collection, id, body string, expectedRev *int) (*protocol.DocPutResult, error) {
 	resp, err := c.send(protocol.DocPutMessage{
 		Cmd: protocol.CmdDocPut, Namespace: namespace, Collection: collection, ID: id, Body: body,
@@ -55,6 +54,7 @@ func (c *Client) DocPut(namespace, collection, id, body string, expectedRev *int
 	return resp.DocPutResult, nil
 }
 
+// DocGet fetches one document by id.
 func (c *Client) DocGet(namespace, collection, id string) (*protocol.DocGetResult, error) {
 	resp, err := c.send(protocol.DocGetMessage{
 		Cmd: protocol.CmdDocGet, Namespace: namespace, Collection: collection, ID: id,
@@ -65,6 +65,7 @@ func (c *Client) DocGet(namespace, collection, id string) (*protocol.DocGetResul
 	return resp.DocGetResult, nil
 }
 
+// DocDelete deletes a document; expectedRev nil deletes unconditionally.
 func (c *Client) DocDelete(namespace, collection, id string, expectedRev *int) (*protocol.DocDeleteResult, error) {
 	resp, err := c.send(protocol.DocDeleteMessage{
 		Cmd: protocol.CmdDocDelete, Namespace: namespace, Collection: collection, ID: id,
@@ -76,6 +77,7 @@ func (c *Client) DocDelete(namespace, collection, id string, expectedRev *int) (
 	return resp.DocDeleteResult, nil
 }
 
+// DocQuery runs a one-shot document query.
 func (c *Client) DocQuery(query protocol.DocumentQuery) (*protocol.DocQueryResult, error) {
 	resp, err := c.send(protocol.DocQueryMessage{Cmd: protocol.CmdDocQuery, Query: query})
 	if err != nil {
@@ -84,9 +86,8 @@ func (c *Client) DocQuery(query protocol.DocumentQuery) (*protocol.DocQueryResul
 	return resp.DocQueryResult, nil
 }
 
-// DocCount reports how many documents a query matches, without fetching their
-// bodies. Sort and limit are ignored: they decide which matches come back,
-// never how many there are.
+// DocCount reports how many documents a query matches, without fetching
+// bodies. Sort and limit are ignored.
 func (c *Client) DocCount(query protocol.DocumentQuery) (*protocol.DocCountResult, error) {
 	resp, err := c.send(protocol.DocCountMessage{Cmd: protocol.CmdDocCount, Query: query})
 	if err != nil {
@@ -95,16 +96,9 @@ func (c *Client) DocCount(query protocol.DocumentQuery) (*protocol.DocCountResul
 	return resp.DocCountResult, nil
 }
 
-// DocWindow is one delivery of a live query, already applied. The daemon sends
-// an order plus the bodies the subscriber is missing; this is the result of
-// following the client rule, so a caller renders Documents and holds no
-// delivery-merging logic of its own. That rule lives here once, because the CLI,
-// the tests and A4's SDK are all callers of this seam.
-//
-// AsOfSeq is the log position the window was true at — comparable against the
-// seq a write reported, which is how a caller knows a delivery already includes
-// its own write. Changed names the ids whose bodies arrived in this delivery,
-// so a caller can see what actually travelled rather than infer it.
+// DocWindow is one delivery of a live query, already applied — a caller renders
+// Documents with no merging logic of its own. AsOfSeq is the log position the
+// window was true at (comparable to a write's seq); Changed names arrived bodies.
 type DocWindow struct {
 	Delivery  int
 	AsOfSeq   int64
@@ -112,11 +106,8 @@ type DocWindow struct {
 	Changed   []string
 }
 
-// revisions is what this window declares to a resuming subscription. The wire
-// carries revisions alone, but DocSubscribe takes whole documents: a subscriber
-// that declares a revision without holding its body has told the daemon not to
-// send something it cannot render, and no caller should be able to express that
-// by accident.
+// revisions is what a window declares to a resuming subscription. DocSubscribe
+// takes whole documents so no caller can declare a revision without its body.
 func revisions(held []protocol.StoredDocument) []protocol.DocumentRevision {
 	out := make([]protocol.DocumentRevision, 0, len(held))
 	for _, doc := range held {
@@ -126,20 +117,15 @@ func revisions(held []protocol.StoredDocument) []protocol.DocumentRevision {
 }
 
 // DocSubscriptionEnded is a live query the daemon stopped serving. Code is the
-// protocol error code when the daemon named one — `collection_undefined` and
-// `collection_redeclared` are the two that mean the collection moved out from
-// under an accepted subscription — and is empty when the connection simply went
-// away. It is a type rather than a message because a UI host has to tell "kill
-// this tile" from "reconnect", and must not do it by matching English.
+// protocol error code (`collection_undefined`, `collection_redeclared`), empty
+// when the connection went; a type so hosts don't route by matching English.
 type DocSubscriptionEnded struct {
 	Code    string
 	Message string
 
-	// lost distinguishes the one ending that is safe to retry — the connection
-	// went — from every other one. It is not the same fact as an empty Code: a
-	// delivery this client cannot apply also carries no daemon code, and
-	// resubscribing after one repeats it with the same declared revisions,
-	// forever. Set here rather than exported so no caller can claim it.
+	// lost marks the one ending safe to retry — the connection went. Not the
+	// same as an empty Code: an unappliable delivery also carries no code, and
+	// resubscribing after one repeats it forever. Unexported on purpose.
 	lost bool
 }
 
@@ -160,28 +146,17 @@ func DocSubscriptionCode(err error) (string, bool) {
 	return "", false
 }
 
-// DocConnectionLost reports whether a subscription ended because the connection
-// went. That is the only ending worth resubscribing to: a daemon that refused
-// the query and a delivery this client could not apply both recur on the next
-// attempt, so retrying either is a loop that reports nothing.
+// DocConnectionLost reports whether a subscription ended because the
+// connection went — the only ending worth resubscribing to; the others recur.
 func DocConnectionLost(err error) bool {
 	var ended *DocSubscriptionEnded
 	return errors.As(err, &ended) && ended.lost
 }
 
-// DocSubscribe opens a live query and calls onWindow for every delivery,
-// beginning with the query's current window. Unlike every other call here it
-// holds its connection open, so it returns only when onWindow asks it to stop,
-// or when the subscription ends.
-//
-// held is what the caller already holds — nil for a fresh subscribe, and a
-// previous window's Documents to resume one. The daemon is told their revisions
-// and sends bodies only for what has changed since; everything else is carried
-// by order and taken from the cache seeded here.
-//
-// Ending is always an error, including the plain end-of-connection case. A live
-// query that stops is a caller who has stopped seeing changes, and returning
-// success there is how a watcher exits 0 while showing a frozen list.
+// DocSubscribe opens a live query and calls onWindow per delivery, returning
+// when onWindow says stop or the subscription ends. held resumes from a prior
+// window's Documents (nil for fresh). Ending is always an error — a stopped
+// live query returning success is a watcher exiting 0 over a frozen list.
 func (c *Client) DocSubscribe(query protocol.DocumentQuery, held []protocol.StoredDocument, onWindow func(DocWindow) bool) error {
 	conn, err := net.Dial("unix", c.socketPath)
 	if err != nil {
@@ -194,7 +169,6 @@ func (c *Client) DocSubscribe(query protocol.DocumentQuery, held []protocol.Stor
 		return fmt.Errorf("send subscribe: %w", err)
 	}
 
-	// The cache the client rule reads from, seeded with what the caller declared.
 	// An id the daemon believes is held and that is not here is a broken
 	// subscription, reported rather than rendered with a hole in it.
 	cache := make(map[string]protocol.StoredDocument, len(held))
@@ -226,10 +200,9 @@ func (c *Client) DocSubscribe(query protocol.DocumentQuery, held []protocol.Stor
 	}
 }
 
-// applyDocDelivery is the client rule: render order, take each body from upsert
-// if it is there and from the cache otherwise, forget everything not in order.
-// The cache is replaced rather than added to, which is what keeps a long-lived
-// subscription's memory bounded by the window rather than by its history.
+// applyDocDelivery is the client rule: render order, body from upsert else
+// cache, forget everything not in order. Replacing the cache bounds a
+// subscription's memory by the window, not its history.
 func applyDocDelivery(cache map[string]protocol.StoredDocument, result *protocol.DocSubscribeResult) (DocWindow, error) {
 	window := DocWindow{
 		Delivery:  result.Delivery,
@@ -249,9 +222,8 @@ func applyDocDelivery(cache map[string]protocol.StoredDocument, result *protocol
 			doc, ok = cache[id]
 		}
 		if !ok {
-			// The daemon believes this subscriber holds a body it does not. The
-			// subscription cannot be applied, and continuing would render a
-			// window with a hole in it.
+			// The daemon believes this subscriber holds a body it does not;
+			// continuing would render a window with a hole in it.
 			return DocWindow{}, &DocSubscriptionEnded{Message: fmt.Sprintf(
 				"delivery %d ordered %q without sending its body, and it is not held; resubscribe without a resume token",
 				result.Delivery, id)}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,13 +18,8 @@ var binaryName string
 
 func init() {
 	binaryName = filepath.Base(os.Args[0])
-	// Deliberately does NOT call loadConfig() here: package init() runs
-	// before any test's TestMain, so an eager load would hit attnDir()'s
-	// go-test backstop before a package ever gets a chance to set
-	// ATTN_DATA_DIR. Config loading is instead lazy — see
-	// ensureConfigLoaded — triggered by the first call to a function that
-	// actually needs it (DBPath, SocketPath), which by then runs inside a
-	// test body/TestMain, not package init.
+	// No loadConfig() here: package init runs before any TestMain, so an eager
+	// load would trip attnDir()'s go-test backstop. Loading is lazy instead.
 }
 
 // BinaryName returns the name of the running binary (e.g., "attn")
@@ -37,7 +32,6 @@ func SetBinaryName(name string) {
 	binaryName = name
 }
 
-// Config file structure
 type configFile struct {
 	DBPath     string `json:"db_path"`
 	SocketPath string `json:"socket_path"`
@@ -49,14 +43,8 @@ var (
 	configMu     sync.RWMutex
 )
 
-// ensureConfigLoaded performs the first, lazy load of config.json, unless it
-// has already been loaded (by this or an explicit reloadConfig() call).
-// Callers that read loadedConfig (DBPath, SocketPath) must call this before
-// reading it. Lazy rather than init()-time so the first load happens inside
-// a test body/TestMain (after ATTN_DATA_DIR is set) rather than at package
-// init, which runs before any TestMain and would otherwise trip the
-// attnDir() test backstop unconditionally, in every package that merely
-// imports config.
+// ensureConfigLoaded lazily loads config.json on first use. Callers that read
+// loadedConfig (DBPath, SocketPath) must call this first.
 func ensureConfigLoaded() {
 	configMu.RLock()
 	loaded := configLoaded
@@ -71,7 +59,6 @@ func loadConfig() {
 	configMu.Lock()
 	defer configMu.Unlock()
 
-	// Reset to empty
 	loadedConfig = configFile{}
 	configLoaded = true
 
@@ -82,7 +69,7 @@ func loadConfig() {
 
 	data, err := os.ReadFile(configPath)
 	if err != nil {
-		return // Config file doesn't exist, use defaults
+		return // missing config file → defaults
 	}
 
 	json.Unmarshal(data, &loadedConfig)
@@ -93,8 +80,8 @@ func reloadConfig() {
 	loadConfig()
 }
 
-// ReloadForTesting reloads configuration from disk. Exported for tests that
-// manipulate ATTN_PROFILE or ATTN_CONFIG_PATH between subtests.
+// ReloadForTesting reloads configuration from disk, for tests that change
+// ATTN_PROFILE or ATTN_CONFIG_PATH between subtests.
 func ReloadForTesting() {
 	loadConfig()
 }
@@ -102,8 +89,7 @@ func ReloadForTesting() {
 var profileNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,15}$`)
 
 // Profile returns the active profile name (from ATTN_PROFILE), or "" for the
-// default profile. Invalid profile names return "" — callers that need to
-// validate should use ValidateProfile.
+// default profile; invalid names return "" (use ValidateProfile to reject them).
 func Profile() string {
 	raw := strings.TrimSpace(os.Getenv("ATTN_PROFILE"))
 	if raw == "" {
@@ -117,7 +103,6 @@ func Profile() string {
 }
 
 // ValidateProfile returns an error if ATTN_PROFILE is set to an invalid name.
-// Use this from CLI entry points to fail loudly on typos.
 func ValidateProfile() error {
 	raw := os.Getenv("ATTN_PROFILE")
 	if err := ValidateProfileName(raw); err != nil {
@@ -135,20 +120,13 @@ func ProfileLabel() string {
 }
 
 // DeepLinkScheme returns the macOS URL scheme the running profile's .app is
-// registered under: default → "attn", dev → "attn-dev", agent7 → "attn-agent7".
-// It is the per-profile authority (DeepLinkSchemeForProfile) applied to the
-// active profile, so the scheme a profile's bundle registers at build time and
-// the scheme the CLI opens at runtime can never diverge.
-//
-// Used by the CLI wrapper so `attn` in a profile-scoped shell opens that
-// profile's app, never another profile's.
+// registered under (DeepLinkSchemeForProfile applied to the active profile).
 func DeepLinkScheme() string {
 	return DeepLinkSchemeForProfile(Profile())
 }
 
-// normalizeProfileForDerivation lowercases/trims a profile name and maps the
-// literal "default" and any invalid name to "" so every per-profile derivation
-// helper (bundle id, app name, ports) shares exactly one rule.
+// normalizeProfileForDerivation lowercases/trims and maps "default" and any
+// invalid name to "" — the single rule shared by all per-profile derivations.
 func normalizeProfileForDerivation(profile string) string {
 	p := strings.ToLower(strings.TrimSpace(profile))
 	if p == "" || p == "default" || !profileNamePattern.MatchString(p) {
@@ -157,11 +135,9 @@ func normalizeProfileForDerivation(profile string) string {
 	return p
 }
 
-// BundleIdentifierForProfile returns the macOS bundle identifier for a profile:
-// default → com.attn.manager, dev → com.attn.manager.dev, agent7 →
-// com.attn.manager.agent7. Single source of truth — the Makefile, Rust build,
-// and real-app harness all derive from this (via `attn profile resolve`) instead
-// of re-encoding the mapping.
+// BundleIdentifierForProfile returns the macOS bundle identifier for a profile
+// (com.attn.manager[.<profile>]). Single source of truth: Makefile, Rust build,
+// and harness derive from this via `attn profile resolve`.
 func BundleIdentifierForProfile(profile string) string {
 	p := normalizeProfileForDerivation(profile)
 	if p == "" {
@@ -171,8 +147,7 @@ func BundleIdentifierForProfile(profile string) string {
 }
 
 // AppNameForProfile returns the .app bundle folder name (without ".app") for a
-// profile: default → attn, dev → attn-dev, agent7 → attn-agent7. Must match the
-// Tauri productName the build produces.
+// profile: attn, or attn-<profile>. Must match the Tauri productName.
 func AppNameForProfile(profile string) string {
 	p := normalizeProfileForDerivation(profile)
 	if p == "" {
@@ -192,11 +167,8 @@ func AppPathForProfile(profile string) string {
 }
 
 // DeepLinkSchemeForProfile returns the macOS URL scheme a profile's .app
-// registers: default → attn, dev → attn-dev, agent7 → attn-agent7. Each profile
-// bundle registers a distinct scheme so macOS never cross-routes a spawn deep
-// link to the wrong app. The per-profile build (`make install PROFILE=<name>`)
-// bakes this scheme into the bundle, and DeepLinkScheme() reports it at runtime,
-// so the registered and opened schemes are derived from this one function.
+// registers (attn, or attn-<profile>): a distinct scheme per bundle so macOS
+// never cross-routes a spawn deep link to the wrong app.
 func DeepLinkSchemeForProfile(profile string) string {
 	p := normalizeProfileForDerivation(profile)
 	if p == "" {
@@ -207,8 +179,6 @@ func DeepLinkSchemeForProfile(profile string) string {
 
 // ValidateProfileName validates a profile name against the same rules
 // Profile()/ValidateProfile() apply, without consulting the environment.
-// Use this when you have a profile name from a non-env source (e.g. a
-// CLI argument) and want to reuse the validation logic.
 func ValidateProfileName(name string) error {
 	trimmed := strings.TrimSpace(name)
 	if trimmed == "" {
@@ -221,25 +191,10 @@ func ValidateProfileName(name string) error {
 	return nil
 }
 
-// NormalizeProfileName validates and returns the canonical profile name.
-// Use this at every persistence/wire boundary.
-//
-// Two normalization rules:
-//
-//  1. Lowercase + trim, so the value the remote daemon sees in
-//     $ATTN_PROFILE matches the value stored in the local DB — Profile()
-//     on the remote lowercases, so writing a mixed-case form here would
-//     split data dirs (~/.attn-DEV referenced in scripts vs ~/.attn-dev
-//     written by the daemon).
-//
-//  2. The literal "default" maps to "". WSPortForProfile and
-//     DataDirForProfile already treat "default" as the default profile;
-//     hub helpers (remoteBinaryName, ATTN_PROFILE export, log/data dir
-//     scripts) do not. Letting "default" reach those would build
-//     ~/.local/bin/attn-default and ~/.attn-default/ on the remote while
-//     reusing port 9849 — colliding with any real default-profile daemon
-//     on the same host. Canonicalizing here keeps every downstream code
-//     path on a single representation of "the default profile".
+// NormalizeProfileName validates and returns the canonical profile name; use
+// it at every persistence/wire boundary. Lowercase+trim (a mixed-case form
+// would split data dirs on the remote), and the literal "default" maps to ""
+// (letting it through would build ~/.attn-default while reusing port 9849).
 func NormalizeProfileName(name string) (string, error) {
 	if err := ValidateProfileName(name); err != nil {
 		return "", err
@@ -251,16 +206,9 @@ func NormalizeProfileName(name string) (string, error) {
 	return canonical, nil
 }
 
-// attnDir returns the base directory for attn files. This is the single
-// chokepoint every derived path (socket, DB, plugins, logs, PID, workers,
-// ...) funnels through, so ATTN_DATA_DIR and the test backstop below only
-// need to live in one place.
-//
-// Precedence:
-//  1. ATTN_DATA_DIR env var, if set and non-empty — highest precedence,
-//     above ATTN_PROFILE derivation. Returned verbatim (filepath.Clean'd).
-//  2. Profile-aware default: ~/.attn, or ~/.attn-<profile> for a named
-//     profile.
+// attnDir returns the base directory for attn files — the single chokepoint
+// every derived path funnels through, so ATTN_DATA_DIR (highest precedence,
+// above profile derivation) and the test backstop live in one place.
 func attnDir() string {
 	if override := strings.TrimSpace(os.Getenv("ATTN_DATA_DIR")); override != "" {
 		return filepath.Clean(override)
@@ -269,20 +217,11 @@ func attnDir() string {
 	return defaultAttnDir(Profile())
 }
 
-// requireExplicitDataDirUnderTest panics if called from a test binary
-// (testing.Testing()) without ATTN_DATA_DIR set. This is the backstop for
-// the 2026-07-18 incident where a daemon test resolved config.DataDir()
-// straight to the real ~/.attn and destroyed the production database.
-//
-// It is a presence check only — no path comparison, no HOME inspection —
-// so it can't be fooled by symlinks or unusual HOMEs, and it catches every
-// package (including ones that don't exist yet) that forgets to scope its
-// data dir.
-//
-// If you hit this panic: set ATTN_DATA_DIR to a temp dir, either in a
-// package TestMain (os.Setenv, so it applies to the whole package) or in an
-// individual test via t.Setenv for extra per-test isolation. Never redirect
-// HOME to work around this — see docs/plans/2026-07-18-db-loss-mitigation.md.
+// requireExplicitDataDirUnderTest panics if a test binary resolves the data
+// dir without ATTN_DATA_DIR set — a presence-only check (immune to symlinks
+// and odd HOMEs) backstopping the 2026-07-18 production-DB loss. Fix by
+// setting ATTN_DATA_DIR to a temp dir; never redirect HOME — see
+// docs/plans/2026-07-18-db-loss-mitigation.md.
 func requireExplicitDataDirUnderTest() {
 	if testing.Testing() && strings.TrimSpace(os.Getenv("ATTN_DATA_DIR")) == "" {
 		panic("config: ATTN_DATA_DIR is not set under go test — tests must never resolve the real data dir. " +
@@ -291,30 +230,13 @@ func requireExplicitDataDirUnderTest() {
 	}
 }
 
-// ScopeTestEnvironment sets ATTN_DATA_DIR to dataDir and clears
-// ATTN_DB_PATH, ATTN_SOCKET_PATH, ATTN_CONFIG_PATH, and ATTN_PLUGIN_DIR.
-// Call it from a package TestMain (or an individual test) instead of
-// setting ATTN_DATA_DIR directly.
-//
-// Why clear the other four: DBPath, SocketPath, PluginDir, and the
-// config-file path all check their own env-var override before ever
-// reaching the attnDir() chokepoint, so ATTN_DATA_DIR alone does not bound
-// them. A developer's shell can carry an inherited ATTN_DB_PATH pointing at
-// the real ~/.attn/attn.db (e.g. from a scoped profile) even while
-// ATTN_DATA_DIR is set to a temp dir for the current test run; without this
-// clearing, that inherited override would still route test I/O at the real
-// database. This is the same incident class documented in
-// docs/plans/2026-07-18-db-loss-mitigation.md, one step removed: the
-// backstop in requireExplicitDataDirUnderTest only guards attnDir() itself,
-// not these four overrides that sit above it in precedence.
-//
-// It does not touch HOME or ATTN_PROFILE: ATTN_DATA_DIR already outranks
-// profile derivation, and HOME is off-limits for test scoping (see the
-// Decisions section of the plan above).
-//
-// Test-only: panics if called outside testing.Testing(), since it mutates
-// process-global environment and must never be reachable from a production
-// binary.
+// ScopeTestEnvironment sets ATTN_DATA_DIR to dataDir and clears ATTN_DB_PATH,
+// ATTN_SOCKET_PATH, ATTN_CONFIG_PATH, and ATTN_PLUGIN_DIR; call it from a
+// package TestMain instead of setting ATTN_DATA_DIR directly. Those four
+// overrides outrank the attnDir() chokepoint, so an inherited one could still
+// route test I/O at the real database — same incident class as
+// docs/plans/2026-07-18-db-loss-mitigation.md. Test-only: panics outside
+// testing.Testing().
 func ScopeTestEnvironment(dataDir string) {
 	if !testing.Testing() {
 		panic("config.ScopeTestEnvironment is test-only")
@@ -327,10 +249,7 @@ func ScopeTestEnvironment(dataDir string) {
 }
 
 // defaultAttnDir computes the profile-aware default data dir from the real
-// $HOME, ignoring ATTN_DATA_DIR and the test backstop entirely. It is a pure
-// function of (HOME, profile) with no I/O, so it's safe to call directly
-// from tests that want to assert the default-derivation formula without
-// tripping requireExplicitDataDirUnderTest.
+// $HOME, ignoring ATTN_DATA_DIR and the test backstop entirely.
 func defaultAttnDir(profile string) string {
 	home, err := os.UserHomeDir()
 	base := "/tmp/.attn"
@@ -357,16 +276,10 @@ func PluginDir() string {
 	return filepath.Join(attnDir(), "plugins")
 }
 
-// DataDirForProfile computes the canonical data directory for a given
-// profile name (without reading ATTN_PROFILE). Pass "" for the default
-// profile. Callers use this to probe whether the *other* profile's
-// daemon is running, for friendlier error messages.
-//
-// This function deliberately bypasses the attnDir() chokepoint and therefore
-// does not honor ATTN_DATA_DIR overrides or the go-test backstop. The
-// *ForProfile helpers must probe other profiles' directories for cross-profile
-// error messages and must not honor the current process's ATTN_DATA_DIR override.
-// Tests must never write through this path.
+// DataDirForProfile computes the canonical data directory for a profile name
+// ("" for default), without reading ATTN_PROFILE. Deliberately bypasses the
+// attnDir() chokepoint — no ATTN_DATA_DIR override, no go-test backstop — so
+// cross-profile probing works; tests must never write through this path.
 func DataDirForProfile(profile string) string {
 	home, err := os.UserHomeDir()
 	base := "/tmp/.attn"
@@ -383,27 +296,19 @@ func DataDirForProfile(profile string) string {
 	return base + "-" + p
 }
 
-// SocketPathForProfile returns the default socket path for a given profile
-// name, independent of the current process's ATTN_PROFILE. Used for
-// cross-profile probing in error messages; does not consult env overrides
-// or the config file.
-//
-// This function deliberately bypasses the attnDir() chokepoint and therefore
-// does not honor ATTN_DATA_DIR overrides or the go-test backstop. It must not
-// honor the current process's override. Tests must never write through this path.
+// SocketPathForProfile returns the default socket path for a profile name.
+// Same chokepoint bypass as DataDirForProfile; tests must never write here.
 func SocketPathForProfile(profile string) string {
 	return filepath.Join(DataDirForProfile(profile), "attn.sock")
 }
 
-// DBPath returns the SQLite database path
-// Priority: ATTN_DB_PATH env var > config file > default
+// DBPath returns the SQLite database path.
+// Priority: ATTN_DB_PATH env var > config file > default.
 func DBPath() string {
-	// 1. Environment variable (highest priority)
 	if envPath := os.Getenv("ATTN_DB_PATH"); envPath != "" {
 		return envPath
 	}
 
-	// 2. Config file
 	ensureConfigLoaded()
 	configMu.RLock()
 	configPath := loadedConfig.DBPath
@@ -412,19 +317,16 @@ func DBPath() string {
 		return configPath
 	}
 
-	// 3. Default
 	return filepath.Join(attnDir(), "attn.db")
 }
 
-// SocketPath returns the unix socket path
-// Priority: ATTN_SOCKET_PATH env var > config file > default
+// SocketPath returns the unix socket path.
+// Priority: ATTN_SOCKET_PATH env var > config file > default.
 func SocketPath() string {
-	// 1. Environment variable (highest priority)
 	if envPath := os.Getenv("ATTN_SOCKET_PATH"); envPath != "" {
 		return envPath
 	}
 
-	// 2. Config file
 	ensureConfigLoaded()
 	configMu.RLock()
 	configPath := loadedConfig.SocketPath
@@ -433,16 +335,12 @@ func SocketPath() string {
 		return configPath
 	}
 
-	// 3. Default
 	return filepath.Join(attnDir(), "attn.sock")
 }
 
-// ValidateDaemonIsolation rejects daemon configurations that split the
-// runtime root (socket/PID/workers) away from the active profile's data dir
-// while still pointing at that profile's default durable store.
-//
-// That combination lets an auxiliary daemon reconcile the shared session DB
-// against a different worker registry and mistakenly reap live sessions.
+// ValidateDaemonIsolation rejects configurations whose runtime root
+// (socket/PID/workers) is split from the profile's data dir while still using
+// its default DB — an auxiliary daemon on that combination can reap live sessions.
 func ValidateDaemonIsolation(socketPath string) error {
 	socketDir, err := comparableDaemonIsolationPath(filepath.Dir(strings.TrimSpace(socketPath)))
 	if err != nil {
@@ -480,11 +378,9 @@ func comparableDaemonIsolationPath(path string) (string, error) {
 	return CanonicalRuntimePath(path)
 }
 
-// CanonicalRuntimePath returns one absolute representation of a runtime path.
-// It resolves symlinks through the deepest existing ancestor, so a not-yet-
-// created socket or database below a symlinked data directory still compares by
-// its real location. CLI/daemon routing checks must use this instead of comparing
-// raw environment or config strings, which may be relative to different CWDs.
+// CanonicalRuntimePath returns one absolute representation of a runtime path,
+// resolving symlinks through the deepest existing ancestor. Routing checks must
+// compare through this, never raw env/config strings (which may be CWD-relative).
 func CanonicalRuntimePath(path string) (string, error) {
 	trimmed := strings.TrimSpace(path)
 	if trimmed == "" {
@@ -519,10 +415,7 @@ func CanonicalRuntimePath(path string) (string, error) {
 }
 
 // StatePath returns the legacy state file path (for migration/cleanup).
-//
-// This function deliberately bypasses the attnDir() chokepoint and therefore
-// does not honor ATTN_DATA_DIR overrides or the go-test backstop. Tests must
-// never write through this path.
+// Bypasses the attnDir() chokepoint; tests must never write through this path.
 func StatePath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -535,12 +428,9 @@ func StatePath() string {
 	return filepath.Join(home, "."+binaryName+"-state"+suffix+".json")
 }
 
-// AppSupportDirForProfile returns the macOS app-support directory a profile's
-// frontend writes into: ~/Library/Application Support/<bundle identifier>.
-// This mirrors Tauri's BaseDirectory.AppLocalData resolution on macOS, so it
-// is the same directory the frontend's disk-based debug logs (see
-// app/src/utils/terminalDiagnosticsLog.ts) land in. macOS only, matching the
-// rest of this package's platform scope.
+// AppSupportDirForProfile returns ~/Library/Application Support/<bundle id> —
+// mirrors Tauri's BaseDirectory.AppLocalData resolution on macOS, where the
+// frontend's disk-based debug logs land.
 func AppSupportDirForProfile(profile string) string {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -572,10 +462,8 @@ func WSPort() string {
 	return WSPortForProfile(Profile())
 }
 
-// WSPortForProfile returns the default WebSocket port for a given profile name,
-// independent of the current process's ATTN_PROFILE / ATTN_WS_PORT. Pass "" for
-// the default profile. Used by the hub to compute the right port to talk to a
-// profile-scoped remote daemon.
+// WSPortForProfile returns the default WebSocket port for a profile name ("" for
+// default), independent of the current process's ATTN_PROFILE / ATTN_WS_PORT.
 func WSPortForProfile(profile string) string {
 	p := strings.ToLower(strings.TrimSpace(profile))
 	switch p {
@@ -591,8 +479,8 @@ func WSPortForProfile(profile string) string {
 	}
 }
 
-// profileFNV hashes a profile name with FNV-1a (32-bit). Shared by every
-// per-profile port derivation so the algorithm lives in exactly one place.
+// profileFNV hashes a profile name with FNV-1a (32-bit), shared by every
+// per-profile port derivation.
 func profileFNV(profile string) uint32 {
 	h := fnv.New32a()
 	h.Write([]byte(profile))
@@ -606,11 +494,9 @@ func derivedProfilePort(profile string) string {
 	return fmt.Sprintf("%d", port)
 }
 
-// E2EDaemonPortForProfile returns the throwaway-daemon WS port the Playwright
-// e2e harness should use for a profile. Default → 19849 (unchanged). Named
-// profiles hash into [30000,30999] — disjoint from prod 9849, dev 29849, the
-// real-profile band [20000,29848], and Vite 1420/1421 — so an e2e daemon never
-// collides with a *real* daemon of the same profile.
+// E2EDaemonPortForProfile returns the e2e-harness throwaway-daemon WS port:
+// default → 19849, named profiles hash into [30000,30999] — disjoint from prod
+// 9849, dev 29849, the real-profile band [20000,29848], and Vite 1420/1421.
 func E2EDaemonPortForProfile(profile string) string {
 	p := normalizeProfileForDerivation(profile)
 	if p == "" {
@@ -619,9 +505,8 @@ func E2EDaemonPortForProfile(profile string) string {
 	return fmt.Sprintf("%d", 30000+int(profileFNV(p)%1000))
 }
 
-// E2EVitePortForProfile returns the Vite dev-server port the e2e harness should
-// use for a profile. Default → 1421 (unchanged). Named profiles hash into
-// [31000,31999]. strictPort makes a rare cross-profile collision fail loudly.
+// E2EVitePortForProfile returns the e2e Vite dev-server port: default → 1421,
+// named profiles hash into [31000,31999]; strictPort makes collisions fail loudly.
 func E2EVitePortForProfile(profile string) string {
 	p := normalizeProfileForDerivation(profile)
 	if p == "" {
@@ -696,9 +581,8 @@ func DebugLevel() int {
 const DefaultPprofPort = 6060
 
 // PprofAddr reports whether the opt-in diagnostics endpoint (pprof + expvar) is
-// enabled and, if so, the loopback address to bind. It is strictly off unless
-// ATTN_PPROF is set, and always binds 127.0.0.1 so it adds no remote attack
-// surface (any host in the value is ignored on purpose).
+// enabled and the loopback address to bind. Always 127.0.0.1 — any host in the
+// value is ignored on purpose.
 //
 //	unset / "0" / "off" / "false" / "no" → disabled
 //	"1" / "on" / "true" / "yes"          → enabled on DefaultPprofPort
@@ -714,8 +598,7 @@ func PprofAddr() (addr string, enabled bool) {
 	case "1", "on", "true", "yes":
 		return fmt.Sprintf("127.0.0.1:%d", DefaultPprofPort), true
 	}
-	// Accept "host:port", ":port", or a bare port; ignore the host and force
-	// loopback so the endpoint can never be exposed off the machine.
+	// Force loopback so the endpoint can never be exposed off the machine.
 	portPart := raw
 	if i := strings.LastIndex(portPart, ":"); i >= 0 {
 		portPart = portPart[i+1:]

--- a/internal/daemon/auto_settle.go
+++ b/internal/daemon/auto_settle.go
@@ -9,28 +9,10 @@ import (
 	"github.com/victorarias/attn/internal/sessionstate"
 )
 
-// Auto-settle closes a turn the user has already dealt with.
-//
-// Settling is how a turn ends, and it is otherwise always manual. But steering an
-// agent and watching it go back to work *is* dealing with the turn — the user
-// simply never said so, and the queue fills up with turns they already handled.
-// This says it for them, after a delay long enough to prove the agent really did
-// go back to work, and with a visible countdown that makes the settle both
-// announced and reversible.
-//
-// Two windows, not one, because they answer different questions. The arm delay
-// asks "did the steering take?" — an agent that pops straight back out of
-// `working` was not steered, it was interrupted, and nothing should have been
-// counting down in the first place. The countdown asks "does the user want to
-// stop this?" and is the only part they see. Collapsing them into one number
-// would force a single duration to be both long enough to trust and short enough
-// to watch.
-//
-// The timers live here rather than in the app because settling is daemon state
-// and a state transition is what starts and stops them: a client-side timer would
-// race the broadcast that feeds it, and would stop existing the moment the window
-// closed. It mirrors nudge_countdown.go, which arms per-session timers on the same
-// terms.
+// Auto-settle closes a turn the user has already dealt with by steering the
+// agent back to work: an invisible arm delay ("did the steering take?"), then a
+// visible countdown ("does the user want to stop this?"). Timers live in the
+// daemon because a client-side one would race the broadcast that feeds it.
 const (
 	// defaultAutoSettleArmSeconds is how long a session must hold `working`
 	// before the countdown starts.
@@ -39,24 +21,14 @@ const (
 	// before the turn is settled.
 	defaultAutoSettleCountdownSeconds = 15
 
-	// autoSettleHoldQuietWindow is how long a session must go without user activity
-	// before a held countdown resumes. It is the whole of the interaction hold's
-	// tuning, and it is not a setting: it measures the user's attention, not the
-	// agent's behavior, so it is orthogonal to the two windows above.
-	//
-	// Five seconds rather than the nudge guard's three, and rather than something
-	// generous. It only has to span gaps in active keyboard or pointer interaction
-	// because the countdown it resumes
-	// into is itself the grace period, visible and cancellable. Stacking a long
-	// quiet window on top of that pays twice for the same protection, and being
-	// wrong here does not settle a turn silently: it unfreezes a bar the user
-	// still has the whole countdown to stop.
+	// autoSettleHoldQuietWindow is the quiet time before a held countdown
+	// resumes. Deliberately not a setting: it only has to span gaps in active
+	// typing, and it resumes into a visible, cancellable countdown.
 	autoSettleHoldQuietWindow = 5 * time.Second
 
-	// Bounds. The floors keep a countdown watchable and an arm delay long enough
-	// to outlast the resolver's own settle latency (`HeartbeatSettleAfter`, 5s),
-	// so a turn is never closed on an agent the resolver has not finished making
-	// its mind up about. The ceilings are fat-finger guards.
+	// Floors keep the arm delay past the resolver's own settle latency
+	// (HeartbeatSettleAfter, 5s), so no turn closes on an agent it is still
+	// deciding about; ceilings are fat-finger guards.
 	autoSettleArmMinSeconds       = 5
 	autoSettleArmMaxSeconds       = 3600
 	autoSettleCountdownMinSeconds = 3
@@ -67,27 +39,18 @@ const (
 type autoSettlePhase int
 
 const (
-	// autoSettleArming: the session is holding `working` and nothing is visible
-	// yet. No deadline rides the wire in this phase — an indicator here would
-	// announce a settle that has not been decided on.
+	// autoSettleArming: holding `working`, nothing visible, no deadline on the wire.
 	autoSettleArming autoSettlePhase = iota
 	// autoSettleCounting: the countdown is running and its deadline is broadcast.
 	autoSettleCounting
-	// autoSettleHeld: the user is interacting with this session, so nothing is
-	// counting. The pending timer is a quiet check, not a deadline — it asks
-	// "has the interaction stopped?" and either re-holds or resumes. No deadline
-	// rides the wire; `auto_settle_held` does, and the tile freezes on it.
+	// autoSettleHeld: the user is interacting; the pending timer is a quiet check
+	// that re-holds or resumes. No deadline rides the wire, `auto_settle_held` does.
 	autoSettleHeld
 )
 
-// autoSettleTimer is a session's pending auto-settle. firesAt is stored beside
-// the timer because time.Timer exposes no deadline accessor, and in the counting
-// phase the absolute deadline is what rides the wire for clients to animate
-// against.
-//
-// resume is meaningful only while held: it is the phase the hold came from and
-// will return to, so that activity during the invisible arm delay restarts the
-// arm delay rather than promoting the session to a countdown it never earned.
+// autoSettleTimer is a session's pending auto-settle. firesAt exists because
+// time.Timer exposes no deadline accessor; resume is the phase a hold came from
+// and returns to, so activity during the arm delay cannot promote to counting.
 type autoSettleTimer struct {
 	timer   *time.Timer
 	phase   autoSettlePhase
@@ -95,10 +58,8 @@ type autoSettleTimer struct {
 	firesAt time.Time
 }
 
-// visible reports whether clients can see this entry, and so whether its
-// appearance or removal owes a broadcast. Arming is silent, and so is a hold of
-// an arm delay: freezing something never announced announces it. Only a
-// countdown — running or frozen — is on screen.
+// visible reports whether clients can see this entry — only a countdown,
+// running or frozen — and so whether it owes a broadcast.
 func (e *autoSettleTimer) visible() bool {
 	switch e.phase {
 	case autoSettleCounting:
@@ -109,9 +70,8 @@ func (e *autoSettleTimer) visible() bool {
 	return false
 }
 
-// autoSettleConfig is the resolved policy: whether the feature is on and the two
-// windows. Read from settings on every arm so a settings change takes effect on
-// the next transition without any invalidation bookkeeping.
+// autoSettleConfig is the resolved policy. Read from settings on every arm so a
+// change takes effect on the next transition without invalidation bookkeeping.
 type autoSettleConfig struct {
 	enabled   bool
 	arm       time.Duration
@@ -129,9 +89,8 @@ func (d *Daemon) autoSettleConfig() autoSettleConfig {
 	}
 }
 
-// resolveAutoSettleSeconds turns a stored setting into a duration, falling back
-// to the default for blank or unparseable values. Validation rejects out-of-range
-// values at write time; this only has to be total.
+// resolveAutoSettleSeconds turns a stored setting into a duration. Validation
+// rejects out-of-range values at write time; this only has to be total.
 func resolveAutoSettleSeconds(stored string, fallbackSeconds int) time.Duration {
 	if n, err := strconv.Atoi(strings.TrimSpace(stored)); err == nil && n > 0 {
 		return time.Duration(n) * time.Second
@@ -139,24 +98,10 @@ func resolveAutoSettleSeconds(stored string, fallbackSeconds int) time.Duration 
 	return time.Duration(fallbackSeconds) * time.Second
 }
 
-// syncAutoSettle is the single reaction to a session's state. applyState calls it
-// on every committed transition, which is what makes the rule below exhaustive:
-// there is no path into or out of `working` that skips it.
-//
-// The rule is that only `working` sustains a pending settle. Every other state —
-// a question, an approval, an error, a finished run, a dead worker — means the
-// agent wants the user back, and settling one of those buries precisely the thing
-// the user needs to see. That is the one behavior this feature cannot get wrong,
-// so it is expressed as "anything but working cancels" rather than as a list of
-// states to watch for; a state added to the vocabulary later is safe by default.
-//
-// Nothing here smooths over a brief dip out of `working`. It would be the wrong
-// layer: internal/sessionstate already holds a session working across every
-// flicker it knows about — repaint gaps (ReasonHeartbeatGap), compaction, a turn
-// that yielded with background work, the grace window after a stale bracket — so
-// by the time a transition reaches applyState, leaving `working` is a considered
-// verdict and not a stutter. A second debounce here would be re-deciding a
-// question the resolver has already answered, with less evidence.
+// syncAutoSettle runs from applyState on every committed transition, so the
+// rule is exhaustive: only `working` sustains a pending settle, anything else
+// cancels — which keeps a future state safe by default. No debounce:
+// internal/sessionstate already absorbs the flickers it knows about.
 func (d *Daemon) syncAutoSettle(sessionID, state string) {
 	if state != protocol.StateWorking {
 		d.clearAutoSettleSuppression(sessionID)
@@ -166,12 +111,9 @@ func (d *Daemon) syncAutoSettle(sessionID, state string) {
 	d.armAutoSettle(sessionID)
 }
 
-// armAutoSettle starts the arm delay, if this session is one the feature applies
-// to and nothing is already pending for it.
-//
-// Leaving an existing timer alone is what makes a re-reported `working` harmless:
-// the resolver can commit the same state repeatedly, and restarting the delay each
-// time would mean it never elapses.
+// armAutoSettle starts the arm delay if the feature applies and nothing is
+// pending. Leaving an existing timer alone makes a re-reported `working`
+// harmless — restarting the delay each time would mean it never elapses.
 func (d *Daemon) armAutoSettle(sessionID string) {
 	if sessionID == "" || d.store == nil {
 		return
@@ -181,13 +123,11 @@ func (d *Daemon) armAutoSettle(sessionID string) {
 		return
 	}
 	if d.autoSettleSuppressedFor(sessionID) {
-		// The user cancelled this session's countdown and it has not left
-		// `working` since. Their answer stands.
+		// The user cancelled and the session has not left `working` since.
 		return
 	}
-	// Only a turn the user actually owes can be auto-settled. turnOwed carries
-	// the shell/chief/pinned/muted exclusions too, so a shell pane or a pinned
-	// workspace is out for the same reason it is out of the queue.
+	// turnOwed carries the shell/chief/pinned/muted exclusions too, so those are
+	// out for the same reason they are out of the queue.
 	if !d.turnOwed(sessionID) {
 		return
 	}
@@ -201,29 +141,15 @@ func (d *Daemon) armAutoSettle(sessionID string) {
 	// No broadcast: the arming phase is deliberately invisible.
 }
 
-// holdAutoSettle freezes a pending settle because the user just interacted with
-// this session. Called for genuine keyboard and throttled pointer activity, so
-// its cost on a no-op is one map
-// lookup.
-//
-// Typing is the one thing attn can see through a TUI it has no visibility into.
-// It cannot tell composing from erasing from pressing Escape, and it does not
-// need to: every one of them means the user's hands are on this session, which
-// is the whole question a pending settle is asking. What it must tell apart is
-// the user from attn typing on their behalf, and that distinction is already
-// drawn — noteUserInput drops automation and replay writes before this is
-// reached.
-//
-// A hold is not a cancel. ⌘. means "keep this turn" and stands until the session
-// leaves `working` (autoSettleSuppressed); a hold expires on its own, five quiet
-// seconds later, because the user stopping typing is not the user answering.
+// holdAutoSettle freezes a pending settle on user interaction. Any keystroke
+// counts — noteUserInput already drops attn's own automation and replay writes.
+// A hold is not a cancel: it expires on its own after the quiet window.
 func (d *Daemon) holdAutoSettle(sessionID string) {
 	d.autoSettleMu.Lock()
 	entry, ok := d.autoSettleTimers[sessionID]
 	if !ok || entry.phase == autoSettleHeld {
-		// Nothing pending, or already held. The second case is what keeps a burst
-		// of keystrokes free: the quiet check reschedules itself from the recorded
-		// keystroke time, so only the first key of a burst does any work here.
+		// Already-held keeps a keystroke burst free: the quiet check reschedules
+		// from the recorded keystroke time, so only the first key does work here.
 		d.autoSettleMu.Unlock()
 		return
 	}
@@ -234,8 +160,7 @@ func (d *Daemon) holdAutoSettle(sessionID string) {
 	if d.debugLogging {
 		d.logf("auto-settle held: session=%s resume_phase=%d", sessionID, resume)
 	}
-	// Only a countdown was on screen; freezing an arm delay changes nothing a
-	// client can see.
+	// Freezing an arm delay changes nothing a client can see.
 	if resume == autoSettleCounting {
 		d.broadcastSessionStateChanged(sessionID)
 	}
@@ -249,11 +174,9 @@ func (d *Daemon) startAutoSettleHeldLocked(sessionID string, resume autoSettlePh
 }
 
 // startAutoSettleLocked replaces whatever is pending with a fresh timer in the
-// given phase. Caller holds autoSettleMu.
-//
-// The ready channel is the same handshake nudge_countdown.go uses: the closure
-// blocks until `timer` is published, so the identity check in the fire path reads
-// a fully written value even when a short (test) window fires immediately.
+// given phase. Caller holds autoSettleMu. The ready channel (same handshake as
+// nudge_countdown.go) blocks the closure until `timer` is published, so the fire
+// path's identity check reads a fully written value on a zero-length window.
 func (d *Daemon) startAutoSettleLocked(sessionID string, phase autoSettlePhase, window time.Duration) {
 	if d.autoSettleTimers == nil {
 		d.autoSettleTimers = make(map[string]*autoSettleTimer)
@@ -275,9 +198,9 @@ func (d *Daemon) startAutoSettleLocked(sessionID string, phase autoSettlePhase, 
 	close(ready)
 }
 
-// stopAutoSettleLocked cancels and forgets a session's pending settle, reporting
-// whether the removed entry was visible to clients — i.e. whether the broadcast
-// deadline just disappeared and a rebroadcast is owed. Caller holds autoSettleMu.
+// stopAutoSettleLocked cancels and forgets a session's pending settle,
+// reporting whether the removed entry was visible (a rebroadcast is owed).
+// Caller holds autoSettleMu.
 func (d *Daemon) stopAutoSettleLocked(sessionID string) (removed, wasVisible bool) {
 	entry, ok := d.autoSettleTimers[sessionID]
 	if !ok {
@@ -321,12 +244,9 @@ func (d *Daemon) stopAutoSettleTimers() {
 	}
 }
 
-// autoSettleFire advances or completes a pending settle.
-//
-// The identity check against the map entry is what keeps a timer that lost a
-// cancel/replace race from acting: it finds a different (or absent) entry and
-// bails. Both phases re-check the preconditions rather than trusting the state
-// that armed them — the window is seconds long and the session can have moved.
+// autoSettleFire advances or completes a pending settle. The identity check
+// against the map entry keeps a timer that lost a cancel/replace race from
+// acting; both phases re-check their preconditions rather than trust them.
 func (d *Daemon) autoSettleFire(sessionID string, self *time.Timer) {
 	d.autoSettleMu.Lock()
 	entry, ok := d.autoSettleTimers[sessionID]
@@ -345,36 +265,27 @@ func (d *Daemon) autoSettleFire(sessionID string, self *time.Timer) {
 	if d.autoSettleFireHook != nil {
 		d.autoSettleFireHook(sessionID, action)
 	}
-	// A hold that froze a running countdown is a picture change and rides the
-	// wire. A re-hold, or a hold of the invisible arm delay, is not: while the
-	// user keeps typing this fires every five seconds, and a snapshot push per
-	// quiet check is traffic for a picture that never moved.
+	// A re-hold, or a hold of the invisible arm delay, fires every five seconds
+	// while the user types — no broadcast for a picture that never moved.
 	if action == "held" && phase != autoSettleCounting {
 		return
 	}
-	// Otherwise broadcast either way: the countdown's deadline has just appeared
-	// (arm elapsed, or a hold released), just gone (settled, frozen, or the
-	// preconditions lapsed), or the turn itself has closed.
+	// Otherwise the deadline appeared, went, or the turn closed: broadcast.
 	d.broadcastSessionStateChanged(sessionID)
 }
 
 // runAutoSettle is the fire-time decision, separated so its outcome is a single
-// string a test hook can assert. `resume` is the phase a held session goes back
-// to, and is read only in that phase.
+// string a test hook can assert. `resume` is read only in the held phase.
 func (d *Daemon) runAutoSettle(sessionID string, phase, resume autoSettlePhase) string {
-	// Held across the whole decision — reading the state, confirming the turn is
-	// still owed, and settling it — so no state write can land between the check
-	// and the settle. Without this the timer could settle a turn that a
-	// transition committed microseconds earlier had just opened: exactly the
-	// turn the user has not dealt with yet. applyState takes the same lock
-	// around its store write.
+	// Held across the whole decision so no state write lands between the check
+	// and the settle — otherwise the timer could settle a turn a transition had
+	// just opened. applyState takes the same lock around its store write.
 	d.autoSettleFireMu.Lock()
 	defer d.autoSettleFireMu.Unlock()
 
 	cfg := d.autoSettleConfig()
 	if !cfg.enabled {
-		// Turned off during the window. Dropping it is the honest reading of
-		// "off": the user does not want turns closed for them.
+		// Turned off during the window: drop it.
 		return "disabled"
 	}
 	if d.store == nil {
@@ -384,11 +295,9 @@ func (d *Daemon) runAutoSettle(sessionID string, phase, resume autoSettlePhase) 
 	if session == nil {
 		return "gone"
 	}
-	// The resolver deliberately holds the last published state while a stop-time
-	// verdict is being computed. That projected `working` prevents a color flicker,
-	// but it is not evidence that the agent is still working and must not close the
-	// turn. recordClassifierStarted normally cancels the timer immediately; this
-	// fire-time check closes the race where the callback already took the timer.
+	// The resolver projects `working` while a stop-time verdict is computed, and
+	// that must not close the turn. recordClassifierStarted usually cancels the
+	// timer; this closes the race where the callback already took it.
 	if evidence, ok := d.evidenceTable().snapshot(sessionID); ok &&
 		sessionstate.ClassifierVerdictPending(
 			evidence,
@@ -397,22 +306,18 @@ func (d *Daemon) runAutoSettle(sessionID string, phase, resume autoSettlePhase) 
 		) {
 		return "classifying"
 	}
-	// The state gate is re-checked here as well as in syncAutoSettle. The
-	// transition path is the primary guard; this catches a session whose state
-	// moved without a committed transition reaching us (a restart mid-window, a
-	// store write from a path outside applyState).
+	// Re-checked here as well as in syncAutoSettle: catches a state that moved
+	// without a committed transition (restart mid-window, a write outside applyState).
 	if string(session.State) != protocol.StateWorking {
 		return "not-working"
 	}
 	if !d.turnOwed(sessionID) {
-		// Settled by hand, or excluded (workspace pinned or muted mid-window).
-		// Either way there is nothing left to close.
+		// Settled by hand, or excluded mid-window. Nothing left to close.
 		return "not-owed"
 	}
 
 	// A phase that only moves the timer along can take the interaction hold as a
-	// plain check: nothing is committed on the far side of it, so activity that
-	// arrives a moment later still meets a pending timer and freezes it there.
+	// plain check: nothing commits on the far side of it.
 	if phase == autoSettleHeld || phase == autoSettleArming {
 		hold := phase
 		if phase == autoSettleHeld {
@@ -423,11 +328,8 @@ func (d *Daemon) runAutoSettle(sessionID string, phase, resume autoSettlePhase) 
 			return "held"
 		}
 		if phase == autoSettleHeld {
-			// Quiet again. The window is read fresh from settings and starts
-			// full: a frozen bar is drawn full, so resuming anything less would
-			// drop the bar on release, and the user has just been typing at this
-			// agent — the countdown they get back is the whole one they would
-			// have got by steering it now.
+			// Quiet again. The window restarts full: a frozen bar is drawn full,
+			// so resuming anything less would drop the bar on release.
 			window := cfg.arm
 			if resume == autoSettleCounting {
 				window = cfg.countdown
@@ -443,20 +345,16 @@ func (d *Daemon) runAutoSettle(sessionID string, phase, resume autoSettlePhase) 
 		return "counting"
 	}
 
-	// Test seam: the instant before the settle commits. Nil in production. It
-	// exists because the interleaving that makes this function dangerous — a real
-	// keystroke arriving here, with the timer already pulled out of the map so
-	// the hold it triggers has nothing to freeze — is far too narrow to hit by
-	// chance, and the regression has to stand in it deliberately.
+	// Test seam for the instant before the settle commits: the dangerous
+	// interleaving (a keystroke arriving with the timer already out of the map)
+	// is too narrow to hit by chance. Nil in production.
 	if d.autoSettlePreSettleHook != nil {
 		d.autoSettlePreSettleHook()
 	}
 
-	// The countdown ran out, so this is where the turn closes. The activity hold is
-	// re-asked here rather than above because it has to be indivisible from the
-	// write it guards — settleIfAutoSettleQuiet holds the activity lock across both — and
-	// because the countdown timer can have fired in the microseconds around an
-	// activity report, before holdAutoSettle could stop it.
+	// The activity hold is re-asked because it must be indivisible from the write
+	// it guards (settleIfAutoSettleQuiet holds the activity lock across both):
+	// the timer can fire in the microseconds around an activity report.
 	quiet, settled := d.settleIfAutoSettleQuiet(sessionID, autoSettleHoldQuietWindow)
 	if quiet > 0 {
 		d.holdFromFire(sessionID, autoSettleCounting, quiet)
@@ -477,20 +375,14 @@ func (d *Daemon) holdFromFire(sessionID string, resume autoSettlePhase, quiet ti
 	d.autoSettleMu.Unlock()
 }
 
-// cancelAutoSettleByUser is the user calling off a pending settle: keep this
-// turn. It stops the countdown and does not re-arm — see CancelCountdownMessage
-// for why a cancel has to survive the session simply continuing to work. Reports
-// whether anything was pending, so the caller can log what the cancel reached.
+// cancelAutoSettleByUser stops the countdown and does not re-arm (see
+// CancelCountdownMessage), reporting whether anything was pending.
 func (d *Daemon) cancelAutoSettleByUser(sessionID string) bool {
 	d.autoSettleMu.Lock()
 	removed, _ := d.stopAutoSettleLocked(sessionID)
 	if removed {
-		// The suppression is what makes the cancel stick. Without it the very
-		// next `working` transition — or the resolver re-reporting the state the
-		// session is already in — re-arms, and the user's cancel buys them thirty
-		// seconds. It is cleared when the session leaves `working`, so steering
-		// the agent again arms a fresh countdown, which is the intent: the user
-		// dealt with it, then dealt with it again.
+		// Suppression makes the cancel stick: without it the next `working`
+		// re-report re-arms. Cleared when the session leaves `working`.
 		if d.autoSettleSuppressed == nil {
 			d.autoSettleSuppressed = make(map[string]bool)
 		}
@@ -500,18 +392,13 @@ func (d *Daemon) cancelAutoSettleByUser(sessionID string) bool {
 	if d.debugLogging {
 		d.logf("auto-settle canceled by user: session=%s had_pending=%v", sessionID, removed)
 	}
-	// No broadcast here: handleCancelCountdown makes exactly one, after every
-	// countdown on the session has been called off, so a cancel that reaches both
-	// does not push two snapshots.
+	// No broadcast here: handleCancelCountdown makes exactly one after every
+	// countdown on the session is called off.
 	return removed
 }
 
 // decorateSessionWithAutoSettle stamps the broadcast clone with the countdown
-// deadline while one is running, or the held flag while the user is interacting.
-// two are mutually exclusive by construction — a frozen countdown has no
-// deadline to animate against, and that is the point — so a client never has to
-// decide which one wins. Read under autoSettleMu; callers must not already hold
-// it.
+// deadline or the held flag, never both. Callers must not hold autoSettleMu.
 func (d *Daemon) decorateSessionWithAutoSettle(clone *protocol.Session) {
 	if clone == nil {
 		return
@@ -542,9 +429,8 @@ func (d *Daemon) decorateSessionWithAutoSettle(clone *protocol.Session) {
 	}
 }
 
-// turnOwed reports whether the user owes this session a turn, by the same rule
-// the broadcast decoration uses. It reads the decorated clone rather than
-// re-deriving, so the timer and the queue can never disagree about who is owed.
+// turnOwed reads the decorated clone rather than re-deriving, so the timer and
+// the queue can never disagree about who is owed.
 func (d *Daemon) turnOwed(sessionID string) bool {
 	if d.store == nil {
 		return false
@@ -570,8 +456,8 @@ func (d *Daemon) autoSettleSuppressedFor(sessionID string) bool {
 	return d.autoSettleSuppressed[sessionID]
 }
 
-// clearAutoSettleSuppression lifts a standing cancel. Called when the session
-// leaves `working`, which is the edge that makes the next steer a new decision.
+// clearAutoSettleSuppression lifts a standing cancel when the session leaves
+// `working` — the edge that makes the next steer a new decision.
 func (d *Daemon) clearAutoSettleSuppression(sessionID string) {
 	d.autoSettleMu.Lock()
 	delete(d.autoSettleSuppressed, sessionID)
@@ -597,10 +483,8 @@ func (d *Daemon) cancelAllAutoSettle() {
 	}
 }
 
-// armAutoSettleForRunningSessions arms every session that already qualifies.
-// Turning the feature on is the one moment there is no transition to react to:
-// the sessions it applies to are already sitting in `working`, and without this
-// none of them would arm until their agent next changed state.
+// armAutoSettleForRunningSessions arms every already-qualifying session when
+// the feature is turned on — the one moment there is no transition to react to.
 func (d *Daemon) armAutoSettleForRunningSessions() {
 	if d.store == nil {
 		return

--- a/internal/daemon/automation_retention.go
+++ b/internal/daemon/automation_retention.go
@@ -16,12 +16,9 @@ import (
 	"github.com/victorarias/attn/internal/store"
 )
 
-// A3's fixed retention policy: per definition, keep the newest N runs
-// unconditionally; a run is prunable only once it is outside that window,
-// terminal (delivered/failed), and older than the age floor. All three are
-// env-overridable so tests can shrink them without touching real time.Sleep
-// or minting hundreds of runs — mirrors ticketReconcileSweepInterval's idiom
-// in ticket_reconcile.go.
+// A3's retention policy: per definition, keep the newest N runs; a run is
+// prunable only once outside that window, terminal, and older than the age
+// floor. All three are env-overridable so tests can shrink them.
 const (
 	defaultAutomationRetentionKeep          = 200
 	defaultAutomationRetentionMinAge        = 14 * 24 * time.Hour
@@ -55,12 +52,8 @@ func automationRetentionSweepInterval() time.Duration {
 	return defaultAutomationRetentionSweepInterval
 }
 
-// runAutomationRetentionSweep is the dedicated periodic backstop for A3: it
-// does not piggyback the schedule-observation tick, since that tick's
-// interval is driven by cron granularity, not retention policy. Mirrors
-// runTicketReconcileSweep's shape exactly (ticket_reconcile.go) — no initial
-// pass at boot (retention is not urgent enough to compete with startup
-// churn), select on d.done to stop cleanly at shutdown.
+// runAutomationRetentionSweep is A3's periodic backstop. No initial pass at
+// boot — retention must not compete with startup churn.
 func (d *Daemon) runAutomationRetentionSweep() {
 	ticker := time.NewTicker(automationRetentionSweepInterval())
 	defer ticker.Stop()
@@ -75,11 +68,8 @@ func (d *Daemon) runAutomationRetentionSweep() {
 }
 
 // automationRetentionSweepPass prunes every definition's (including
-// soft-deleted definitions', per ListAutomationDefinitionIDsIncludingDeleted's
-// doc comment) prunable runs: for each candidate, a shared safety predicate
-// (automationRunCleanupSafety, factored so A4's automationCleanup reuses it)
-// decides whether it's safe to touch disk; only then are the worktree,
-// occurrence artifact, and run+occurrence rows removed.
+// soft-deleted) prunable runs; automationRunCleanupSafety gates each before the
+// worktree, occurrence artifact, and run+occurrence rows are removed.
 func (d *Daemon) automationRetentionSweepPass(now time.Time) {
 	if d.store == nil {
 		return
@@ -91,11 +81,8 @@ func (d *Daemon) automationRetentionSweepPass(now time.Time) {
 	}
 	keep := automationRetentionKeep()
 	cutoff := now.Add(-automationRetentionMinAge())
-	// boundThread is counted separately from the (deliberately unlogged)
-	// live-session skip: a bound thread outliving one of its own runs is
-	// still routine, but without this counter a sweep that examined
-	// candidates and skipped every one of them for that reason logs nothing
-	// at all, which reads identically to "nothing to do".
+	// boundThread is counted so a sweep that skipped everything for that reason
+	// does not read as "nothing to do".
 	pruned, keptDirty, boundThread := 0, 0, 0
 	for _, defID := range ids {
 		candidates, err := d.store.ListPrunableAutomationRuns(defID, keep, cutoff)
@@ -147,33 +134,21 @@ type automationRunCleanupBlock int
 const (
 	// automationRunCleanupOK: safe to remove (or nothing to remove).
 	automationRunCleanupOK automationRunCleanupBlock = iota
-	// automationRunCleanupLiveSession: the run's session still exists —
-	// permanently skip until that changes. Not logged per-run; a live
-	// session is the routine, expected state for most terminal runs.
+	// automationRunCleanupLiveSession: the run's session still exists; skip
+	// until that changes. Routine, so not logged per-run.
 	automationRunCleanupLiveSession
-	// automationRunCleanupBoundThread: the run's session id is still
-	// referenced by a continuity binding, even though its own session row is
-	// gone. A continuity thread reuses one session id and one shared
-	// worktree (worktrees/<sessionID>/<repo>) across every occurrence, so an
-	// old terminal run and the thread's live current run resolve to the same
-	// on-disk directory — removing it here would brick the thread the next
-	// time it's asked to continue. Not logged per-run, same reasoning as
-	// automationRunCleanupLiveSession: a bound thread outliving one of its
-	// own runs is the routine case this exists to protect, not an anomaly.
-	// The sweep still counts it in aggregate (see automationRetentionSweepPass's
-	// boundThread counter) and A4's cleanup reports it per-run-id in
-	// kept_active — both callers must surface it as "examined and kept", not
-	// silently skip it, which is what made this block invisible in the first
-	// place.
+	// automationRunCleanupBoundThread: the session row is gone but a continuity
+	// binding still references its id — a thread reuses one session id and shared
+	// worktree across occurrences, so removing it bricks the next continue.
+	// Callers must surface it as "examined and kept", never silently skip it.
 	automationRunCleanupBoundThread
-	// automationRunCleanupDirtyWorktree: the worktree has uncommitted
-	// changes. Dirty evidence is never deleted — logged so it's visible.
+	// automationRunCleanupDirtyWorktree: uncommitted changes. Dirty evidence is
+	// never deleted — logged so it's visible.
 	automationRunCleanupDirtyWorktree
 )
 
-// automationRunCleanupSafety is the shared safety predicate A3's retention
-// sweep and A4's explicit cleanup both use before touching a run's disk
-// footprint. It never mutates anything.
+// automationRunCleanupSafety is the shared safety predicate the sweep and the
+// explicit cleanup both use before touching a run's disk footprint; never mutates.
 func (d *Daemon) automationRunCleanupSafety(run store.AutomationRun) (automationRunCleanupBlock, error) {
 	if run.SessionID != "" && d.store.Get(run.SessionID) != nil {
 		return automationRunCleanupLiveSession, nil
@@ -210,11 +185,9 @@ func (d *Daemon) automationRunCleanupSafety(run store.AutomationRun) (automation
 	return automationRunCleanupOK, nil
 }
 
-// automationRunWorktreePath resolves a run's worktree directory (if any)
-// from its persisted ResolvedLocationJSON — automation.ResolvedLocation, not
-// the transient automation.PreparedLocation returned by prepareAutomationLocation.
-// Never re-derived by path convention: an absent resolved worktree means
-// nothing to remove, not a signal to guess the path.
+// automationRunWorktreePath resolves a run's worktree from its persisted
+// ResolvedLocationJSON, never by path convention: an absent resolved worktree
+// means nothing to remove, not a signal to guess.
 func automationRunWorktreePath(run store.AutomationRun) (string, error) {
 	if strings.TrimSpace(run.ResolvedLocationJSON) == "" {
 		return "", nil
@@ -226,14 +199,10 @@ func automationRunWorktreePath(run store.AutomationRun) (string, error) {
 	return resolved.Worktree, nil
 }
 
-// removeAutomationRunWorktree removes a run's worktree from disk, assuming
-// automationRunCleanupSafety already returned automationRunCleanupOK.
-// Automation worktrees are created via git.EnsureAutomationSessionWorktree
-// (prepareAutomationLocation/PrepareGitHubReviewLocation in automations.go) without
-// ever calling store.AddWorktree, so — unlike interactive-session worktrees —
-// they are never registered in the store's worktree registry; this always
-// goes through git.DeleteWorktree directly rather than Daemon.doDeleteWorktree's
-// registry-aware path, which would be a no-op discovery-fallback for these.
+// removeAutomationRunWorktree removes a run's worktree, assuming the safety
+// predicate returned OK. Automation worktrees are never registered in the
+// store's worktree registry, so this goes through git.DeleteWorktree directly —
+// Daemon.doDeleteWorktree's registry-aware path would no-op on them.
 func (d *Daemon) removeAutomationRunWorktree(run store.AutomationRun) error {
 	if strings.TrimSpace(run.ResolvedLocationJSON) == "" {
 		return nil
@@ -254,11 +223,9 @@ func (d *Daemon) removeAutomationRunWorktree(run store.AutomationRun) error {
 	return git.DeleteWorktree(resolved.MainRepository, resolved.Worktree, false)
 }
 
-// removeAutomationOccurrenceArtifact removes a run's durable occurrence
-// payload at <dataRoot>/automation/occurrences/<runID>.json (see
-// ensureAutomationOccurrenceInput), ignoring not-exist. Mirrors that
-// function's dataRoot-or-socketPath-dir fallback exactly so the sweep and
-// the writer never disagree about where the file lives.
+// removeAutomationOccurrenceArtifact removes a run's durable occurrence payload,
+// ignoring not-exist. Must mirror ensureAutomationOccurrenceInput's dataRoot
+// fallback exactly, or the sweep and the writer disagree about the file's home.
 func (d *Daemon) removeAutomationOccurrenceArtifact(runID string) error {
 	root := strings.TrimSpace(d.dataRoot)
 	if root == "" {
@@ -271,26 +238,10 @@ func (d *Daemon) removeAutomationOccurrenceArtifact(runID string) error {
 	return nil
 }
 
-// automationCleanup is A4's explicit, on-demand counterpart to A3's
-// automationRetentionSweepPass. Two differences from the sweep: it walks
-// every terminal run for id right now, with no keep-window or age-floor
-// filter, and it is disk-only — a cleaned run's worktree is removed, but its
-// occurrence artifact and run/occurrence rows are left alone, so run history
-// stays intact and only reclaims worktree disk space. Uses
-// GetAutomationDefinitionIncludingDeleted (not GetAutomationDefinition) so a
-// user can reclaim a deleted automation's leftover worktrees without waiting
-// for the retention sweep to eventually reach it.
-//
-// The result is a three-way partition of every terminal run examined:
-// cleaned (worktree removed), keptDirty (uncommitted changes), and
-// keptActive (the run's thread is still in use — live session or bound
-// continuity thread — so its worktree is off limits). keptActive merges two
-// distinct safety-predicate blocks on purpose: from the caller's side, "a
-// live session" and "a session row that's gone but still bound to a
-// continuity thread" both mean the same thing, a worktree the user asked to
-// reclaim that isn't reclaimable yet. Runs skipped for any other reason (an
-// already-gone worktree, an empty resolved location, a stat/parse error) stay
-// out of all three buckets — those aren't things the user asked about.
+// automationCleanup is the on-demand counterpart to the sweep: every terminal run
+// for id, no keep-window or age floor, and disk-only, so run history survives.
+// keptActive merges live-session and bound-thread — both mean "not reclaimable
+// yet" — and runs skipped for any other reason land in no bucket.
 func (d *Daemon) automationCleanup(ctx context.Context, id string) (cleaned, keptDirty, keptActive []string, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, nil, nil, fmt.Errorf("deadline exceeded waiting to run automation cleanup: %w", err)
@@ -326,10 +277,8 @@ func (d *Daemon) automationCleanup(ctx context.Context, id string) (cleaned, kep
 		}
 		switch block {
 		case automationRunCleanupLiveSession:
-			// Both cases below merge into the keptActive bucket the caller
-			// sees (main.tsp's kept_active) — a user asking "why is this
-			// still here" only cares that it's protected, not which reason.
-			// The daemon log is where the two reasons are told apart.
+			// Both reasons merge into kept_active on the wire; the daemon log is
+			// where they are told apart.
 			d.logf("automation cleanup %s: run %s: kept active (live session)", id, run.ID)
 			keptActive = append(keptActive, run.ID)
 			continue

--- a/internal/daemon/automations_definitions.go
+++ b/internal/daemon/automations_definitions.go
@@ -13,9 +13,8 @@ import (
 	"github.com/victorarias/attn/internal/store"
 )
 
-// automationRefusal tags an apply refusal with the machine-readable
-// error_code the WS form uses to route the failure (banner vs. field).
-// Unknown/transient errors are deliberately not tagged.
+// automationRefusal tags an apply refusal with the error_code the WS form uses
+// to route the failure. Unknown/transient errors are deliberately not tagged.
 type automationRefusal struct {
 	Code string
 	Err  error
@@ -32,18 +31,14 @@ const (
 	automationErrCodeValidation       = "validation"
 )
 
-// defaultWSAutomationMutationTimeout is the fallback for
-// Daemon.wsAutomationMutationTimeout (see wsAutomationMutationTimeoutDuration).
-// 25s is deliberately strictly inside the frontend's 30s client timeout
-// (useDaemonSocket.ts) so a WS set_enabled mutation either completes or
-// aborts with a definitive error before the client gives up waiting — the
-// client's timer can never observe a flip that happens after it already
-// reported failure.
+// defaultWSAutomationMutationTimeout is deliberately strictly inside the
+// frontend's 30s client timeout (useDaemonSocket.ts): a WS mutation completes or
+// aborts before the client gives up, so a flip after a reported failure is
+// impossible.
 const defaultWSAutomationMutationTimeout = 25 * time.Second
 
-// wsAutomationMutationTimeoutDuration resolves the effective deadline for a
-// WS-originated automation mutation: the configured override if set, else
-// defaultWSAutomationMutationTimeout.
+// wsAutomationMutationTimeoutDuration is the deadline for a WS-originated
+// automation mutation: the configured override, else the default.
 func (d *Daemon) wsAutomationMutationTimeoutDuration() time.Duration {
 	if d.wsAutomationMutationTimeout > 0 {
 		return d.wsAutomationMutationTimeout
@@ -51,17 +46,9 @@ func (d *Daemon) wsAutomationMutationTimeoutDuration() time.Duration {
 	return defaultWSAutomationMutationTimeout
 }
 
-// validateAutomationSpec is the single seam every surface that judges
-// automation definition YAML must call: automation_validate (validate-only,
-// nothing persisted) and automationApply (validate-then-persist) both run
-// through this, so a YAML document that validate accepts is guaranteed to be
-// one apply also accepts — the two cannot drift apart by one of them
-// forgetting a check. It runs ParseDefinitionYAML's schema validation plus
-// every check automationApply used to run inline: the delegation agent must
-// resolve, --model/--effort must be supported by it, the driver must be one
-// of the automations subset that supports unattended automatic approval
-// (codex|claude), and every repository_sources override must be a valid,
-// reachable local clone.
+// validateAutomationSpec is the single seam every judge of definition YAML must
+// call: automation_validate and automationApply both run through it, so a
+// document validate accepts is one apply also accepts — they cannot drift.
 func (d *Daemon) validateAutomationSpec(raw string) (automation.DefinitionSpec, []byte, error) {
 	spec, canonical, err := automation.ParseDefinitionYAML([]byte(raw))
 	if err != nil {
@@ -84,44 +71,21 @@ func (d *Daemon) validateAutomationSpec(raw string) (automation.DefinitionSpec, 
 	return spec, canonical, nil
 }
 
-// automationApply applies definition YAML unconditionally: parse, validate,
-// upsert. This is the unguarded shape used by test fixtures and — via
-// actionAutomationApply passing nil/nil for expectedID/expectedRevision — the
-// unix-socket/CLI/agent surface (attn automation apply): "last writer wins."
-// Thin wrapper over automationApplyWithGuards with both guards off; kept
-// separate only because so many tests use it as fixture setup.
+// automationApply applies definition YAML unguarded (last writer wins): the
+// unix-socket/CLI shape, also widely used as test fixture setup.
 func (d *Daemon) automationApply(raw string) (*store.AutomationDefinition, error) {
 	return d.automationApplyWithGuards(context.Background(), raw, nil, nil)
 }
 
-// automationApplyWithGuards is the one apply path shared by both transports
-// (see actionAutomationApply). expectedID and expectedRevision implement
-// D4/D5 from the design: apply is an upsert keyed on the id *inside* the
-// YAML, so an edited id would silently fork the definition and leave the
-// original enabled and running (D4) — a non-nil expectedID that mismatches
-// refuses. And a stale expectedRevision would silently clobber a concurrent
-// apply from the CLI or another app window (D5) — the caller sees "changed
-// elsewhere — reload" instead.
-//
-// Both guards are keyed on POINTER PRESENCE, not on the zero value: nil means
-// "this caller does not want this guard enforced at all" — the socket/CLI
-// path (attn automation apply) never sets either field, so it gets true
-// last-writer-wins, unguarded, exactly as the old unconditional automationApply
-// did. The WS editor's Save always sends both fields (zero-valued for a
-// create — expectedID "" / expectedRevision 0, matching AutomationEditor's
-// loadedId/revision state before a first save), so its guards apply exactly
-// as before this unification: expectedRevision 0 means "creating" (refuse a
-// collision with a live definition) and a non-zero expectedRevision must
-// match the stored one. Using the dereferenced zero value here instead of
-// pointer presence would force EVERY caller — including the CLI's unguarded
-// edits of existing definitions — through the "0 means creating" branch,
-// wrongly rejecting a CLI apply of an existing definition as "already
-// exists".
-//
-// Both guards run inside automationApplyLocked's automationMu, atomically
-// with the pre-upsert existing-row read they depend on, so there is no
-// window between the check and the write where a concurrent apply could
-// slip through.
+// automationApplyWithGuards is the one apply path shared by both transports.
+// Apply is an upsert keyed on the id inside the YAML, so expectedID catches an
+// edited id silently forking the definition and expectedRevision catches a
+// stale editor clobbering a concurrent apply. Guards are keyed on POINTER
+// PRESENCE, not zero value: nil means unguarded (the socket/CLI path), while
+// the WS editor sends both, with expectedRevision 0 meaning "creating". Using
+// the dereferenced zero value would wrongly reject a CLI apply of an existing
+// definition as "already exists". Both guards run inside automationMu,
+// atomically with the pre-upsert existing-row read they depend on.
 func (d *Daemon) automationApplyWithGuards(ctx context.Context, raw string, expectedID *string, expectedRevision *int) (*store.AutomationDefinition, error) {
 	spec, canonical, err := d.validateAutomationSpec(raw)
 	if err != nil {
@@ -132,25 +96,14 @@ func (d *Daemon) automationApplyWithGuards(ctx context.Context, raw string, expe
 	}
 	guard := func(existing *store.AutomationDefinition) error {
 		if expectedRevision == nil {
-			// No revision guard requested at all (the unguarded socket/CLI path).
+			// No revision guard requested (the unguarded socket/CLI path).
 			return nil
 		}
 		if *expectedRevision == 0 {
-			// Create. Revisions start at 1 (see UpsertAutomationDefinition), so
-			// this is unambiguous — it is never an edit of a revision-0 row.
-			//
-			// Apply is keyed on the id inside the YAML, so a create whose id
-			// happens to match a live definition would UPDATE that definition
-			// in place: the user typing an id that already exists would replace
-			// someone else's automation wholesale, from a form that said
-			// "New automation" and never mentioned it. Refuse instead. The
-			// socket/CLI path keeps its unconditional last-writer-wins
-			// semantics — it passes no guard at all.
-			//
-			// A soft-deleted row is deliberately NOT a collision: re-applying a
-			// deleted definition's id is how resurrect works, and the editor's
-			// list only shows live definitions, so the user cannot be
-			// overwriting anything they can see.
+			// Create (revisions start at 1, so 0 is unambiguous). A create whose id
+			// matches a live definition would replace it wholesale from a form that
+			// said "New automation" — refuse. A soft-deleted row is deliberately NOT
+			// a collision: re-applying a deleted id is how resurrect works.
 			if existing != nil && existing.DeletedAt == nil {
 				return &automationRefusal{Code: automationErrCodeIDCollision, Err: fmt.Errorf("an automation with id %q already exists — edit it instead of creating a second one", spec.ID)}
 			}
@@ -160,15 +113,10 @@ func (d *Daemon) automationApplyWithGuards(ctx context.Context, raw string, expe
 			return &automationRefusal{Code: automationErrCodeRevisionConflict, Err: errors.New("automation definition changed elsewhere — reload before saving")}
 		}
 		if existing.DeletedAt != nil {
-			// DeleteAutomationDefinition sets deleted_at without touching
-			// revision, so a stale editor's expectedRevision can still match a
-			// row that was soft-deleted out from under it. Unlike the create
-			// path above, an edit must never resurrect: automationDelete already
-			// failed this definition's pending runs, fenced its provider
-			// cursors, and purged its continuity bindings and review-request
-			// edges on the assumption it is gone, so a Save silently bringing it
-			// back live would restart an unattended cron the user deliberately
-			// deleted, with "saved successfully" as the only feedback.
+			// Soft-delete leaves revision untouched, so a stale editor's revision can
+			// still match. An edit must never resurrect: delete already failed the
+			// pending runs, fenced cursors, and purged bindings/edges — a silent Save
+			// would restart an unattended cron the user deliberately deleted.
 			return &automationRefusal{Code: automationErrCodeDeletedElsewhere, Err: fmt.Errorf("automation %q was deleted elsewhere while you were editing it — your changes were not saved; close this editor and use New if you want to bring it back", spec.ID)}
 		}
 		return nil
@@ -176,15 +124,10 @@ func (d *Daemon) automationApplyWithGuards(ctx context.Context, raw string, expe
 	return d.automationApplyLocked(ctx, spec, canonical, guard)
 }
 
-// automationApplyLocked is the locked validate-then-persist step shared by
-// automationApply and automationApplyWithGuards. ctx bounds how long the
-// caller is willing to wait to acquire automationMu (mirroring
-// automationSetEnabled/automationDelete's contract): once locked, ctx.Err()
-// is checked before any store mutation, so a caller whose deadline already
-// passed aborts without writing anything. guard (nil for the unconditional
-// socket/CLI path) runs after the pre-upsert existing-row read but still
-// inside automationMu, so a WS caller's expected_id/expected_revision check
-// is atomic with the write it gates.
+// automationApplyLocked is the locked validate-then-persist step. ctx bounds
+// the wait for automationMu; ctx.Err() is checked once locked so an expired
+// caller aborts without writing. guard (nil for the socket/CLI path) runs
+// inside automationMu, atomic with the write it gates.
 func (d *Daemon) automationApplyLocked(ctx context.Context, spec automation.DefinitionSpec, canonical []byte, guard func(*store.AutomationDefinition) error) (*store.AutomationDefinition, error) {
 	d.automationMu.Lock()
 	defer d.automationMu.Unlock()
@@ -215,18 +158,10 @@ func (d *Daemon) automationApplyLocked(ctx context.Context, spec automation.Defi
 }
 
 // rotateContinuityBindingsIfContractChanged drops definitionID's continuity
-// bindings (see "Data Model" in
-// docs/plans/2026-07-21-automations-v2-simplification.md, where
-// released_reason=contract_rotated is defined and ContinuationContract is named
-// as what drives rotation) when this apply changed what a resumed session would
-// be asked to do:
-// resurrecting a soft-deleted definition always rotates (its old bindings
-// may point at threads built under an arbitrarily stale contract), and
-// otherwise rotates only when the new effective spec's
-// automation.ContinuationContract (Prompt/Launch/Location) differs from the
-// previous one — a cron/catch_up-only edit leaves bindings alone so an
-// in-flight thread survives. existing is nil for a brand-new definition,
-// which never has bindings to rotate.
+// bindings when this apply changed what a resumed session would be asked to do:
+// a resurrect always rotates, otherwise only a ContinuationContract change does
+// — a cron/catch_up-only edit leaves an in-flight thread alive. See "Data Model"
+// in docs/plans/2026-07-21-automations-v2-simplification.md.
 func (d *Daemon) rotateContinuityBindingsIfContractChanged(existing *store.AutomationDefinition, spec automation.DefinitionSpec, updated *store.AutomationDefinition) error {
 	if existing == nil {
 		return nil
@@ -235,8 +170,7 @@ func (d *Daemon) rotateContinuityBindingsIfContractChanged(existing *store.Autom
 	if !rotate && existing.Revision != updated.Revision {
 		var oldSpec automation.DefinitionSpec
 		if err := json.Unmarshal([]byte(existing.SpecJSON), &oldSpec); err != nil {
-			// Can't prove the old contract was unchanged; rotate rather than risk
-			// reusing a session under an instruction set we can no longer compare.
+			// Can't prove the old contract was unchanged; rotate rather than risk it.
 			rotate = true
 		} else if old, oldErr := automation.Effective(oldSpec, existing.Revision); oldErr != nil {
 			rotate = true
@@ -252,14 +186,10 @@ func (d *Daemon) rotateContinuityBindingsIfContractChanged(existing *store.Autom
 	return d.store.ReleaseAutomationContinuityBindings(spec.ID, store.AutomationBindingReleasedContractRotated, time.Now())
 }
 
-// cancelPendingAutomationRuns cancels every pending run for definitionID with
-// reason, e.g. when a definition is disabled or deleted before its pending
-// occurrences were delivered. These runs never got a chance to run — that's
-// cancelled, not failed, in the v2 state model (see
-// docs/plans/2026-07-21-automations-v2-simplification.md). One run's
-// cancellation does not stop the rest; errors are joined. Shared by
-// automationApply's disable path, automationSetEnabled's disable path, and
-// automationDelete, each with its own reason.
+// cancelPendingAutomationRuns cancels every pending run for definitionID.
+// Never-delivered runs are cancelled, not failed, in the v2 state model
+// (docs/plans/2026-07-21-automations-v2-simplification.md). One run's
+// cancellation does not stop the rest; errors are joined.
 func (d *Daemon) cancelPendingAutomationRuns(definitionID, reason string) error {
 	pending, err := d.store.ListPendingAutomationRuns()
 	if err != nil {
@@ -281,19 +211,11 @@ func (d *Daemon) cancelPendingAutomationRuns(definitionID, reason string) error 
 	return err
 }
 
-// automationSetEnabled flips definitionID's enabled flag, reusing the store's
-// shared enable-transition side effects (review-edge clear + provider-cursor
-// fence — see store.SetAutomationEnabled) and, on a disable transition,
-// failing any pending runs through the same path automationApply uses. It is
-// a no-op (success, no broadcast) when the definition already has the
-// requested state, and errors for an unknown or soft-deleted definition.
-//
-// ctx bounds how long the caller is willing to wait to acquire automationMu:
-// once locked, ctx.Err() is checked before any store mutation, so a caller
-// whose deadline already passed aborts without flipping the flag (see
-// wsAutomationMutationTimeoutDuration for the WS caller's deadline). The
-// unix-socket caller passes context.Background() — the CLI/agent path waits
-// synchronously with no deadline of its own, so behavior there is unchanged.
+// automationSetEnabled flips the enabled flag (side effects in
+// store.SetAutomationEnabled), cancelling pending runs on disable. No-op when
+// already in the requested state; errors for unknown or soft-deleted. ctx
+// bounds the wait for automationMu, checked once locked so an expired caller
+// aborts without flipping; the unix-socket caller passes context.Background().
 func (d *Daemon) automationSetEnabled(ctx context.Context, definitionID string, enabled bool) (*store.AutomationDefinition, error) {
 	d.automationMu.Lock()
 	defer d.automationMu.Unlock()
@@ -317,21 +239,11 @@ func (d *Daemon) automationSetEnabled(ctx context.Context, definitionID string, 
 	return definition, err
 }
 
-// automationDelete soft-deletes definitionID (see A2): fails any pending
-// runs (the same mechanism automationSetEnabled's disable path uses), clears
-// review-request edges and continuity bindings, fences provider cursors so
-// an in-flight stale observation can't act on it, then soft-deletes the row
-// and broadcasts. Runs, occurrences, tickets, sessions, and on-disk
-// worktrees/artifacts are untouched and remain fully listable/inspectable —
-// A3/A4 govern their eventual cleanup. automationApply resurrects a
-// soft-deleted definition by reapplying the same id.
-//
-// Mirrors automationSetEnabled's lock/deadline contract exactly: ctx bounds
-// how long the caller is willing to wait for automationMu, checked
-// immediately after acquiring it and before any store write, so a caller
-// whose deadline already passed aborts without deleting anything (see
-// wsAutomationMutationTimeoutDuration for the WS caller's deadline; the
-// unix-socket caller passes context.Background()).
+// automationDelete soft-deletes definitionID: cancels pending runs, clears
+// review-request edges and continuity bindings, fences provider cursors, then
+// soft-deletes and broadcasts. Runs, tickets, sessions, and on-disk artifacts
+// are untouched. Reapplying the same id resurrects. Mirrors
+// automationSetEnabled's lock/deadline contract.
 func (d *Daemon) automationDelete(ctx context.Context, definitionID string) error {
 	d.automationMu.Lock()
 	defer d.automationMu.Unlock()

--- a/internal/daemon/automations_schedule.go
+++ b/internal/daemon/automations_schedule.go
@@ -10,51 +10,36 @@ import (
 	"github.com/victorarias/attn/internal/store"
 )
 
-// scheduleDueInstantCap bounds DueInstants' backlog walk. A cursor left far
-// behind (e.g. the daemon was off for a long time on a minutely schedule)
-// must never fire an unbounded burst of catch-up occurrences in one tick.
-// A var, not a const, so tests can shrink it instead of constructing
-// million-instant backlogs.
+// scheduleDueInstantCap bounds DueInstants' backlog walk so a far-behind cursor
+// never fires an unbounded catch-up burst. A var so tests can shrink it.
 var scheduleDueInstantCap = 1_000_000
 
 // scheduleSkipGrace is how long after an intended instant a "skip" catch-up
-// policy will still fire it. Past this window the instant is considered
-// missed and is never delivered.
+// policy will still fire it; past this the instant is never delivered.
 const scheduleSkipGrace = 5 * time.Minute
 
-// automationScheduleKind is the queue kind for the per-minute scheduled-automation
-// observation tick.
+// automationScheduleKind is the queue kind for the observation tick.
 const automationScheduleKind = "automation_schedule"
 
-// automationScheduleInterval is how often the observation runs. Schedules are
-// minutely-grade at finest, so a finer tick would only re-read the same cursors.
+// automationScheduleInterval matches the minutely-grade schedule floor.
 const automationScheduleInterval = time.Minute
 
-// automationScheduleTickTimeout is a tripwire, not a budget. One observation walks
-// the enabled definitions and, at most, claims and delivers one run per definition
-// — store reads and writes, no agent work. It is set far past any healthy pass so
-// only a wedged one (a store that never returns, a delivery that never completes)
-// touches it, freeing the slot for the next minute rather than stalling the kind.
+// automationScheduleTickTimeout is a tripwire: far past any healthy pass, so
+// only a wedged one frees the slot instead of stalling the kind.
 const automationScheduleTickTimeout = 2 * time.Minute
 
-// automationScheduleHandler is the queue handler for the observation tick.
-//
-// It never returns an error. Every per-definition step already logs and skips its
-// own failure, and the decision is cursor-driven, so the next tick re-decides from
-// durable state rather than needing this one retried.
+// automationScheduleHandler is the queue handler for the observation tick. It
+// never errors: the decision is cursor-driven, so the next tick re-decides.
 func (d *Daemon) automationScheduleHandler(_ context.Context, _ *jobs.Job) (any, error) {
 	d.observeDueSchedules(time.Now())
 	return nil, nil
 }
 
-// observeDueSchedules is the per-tick fan-out over enabled scheduled
-// automation definitions, deciding and claiming at most one due occurrence
-// per definition. now is param-injected for testability.
+// observeDueSchedules fans out over enabled scheduled definitions, claiming at
+// most one due occurrence per definition per tick.
 func (d *Daemon) observeDueSchedules(now time.Time) {
 	if d.isRecovering() {
-		// Startup recovery has not yet decided existing pending runs; a fresh
-		// observation racing ahead of it could double-claim or misjudge a
-		// definition's cursor before recovery has settled prior state.
+		// Racing ahead of startup recovery could double-claim or misjudge cursors.
 		return
 	}
 	definitions, err := d.store.ListAutomationDefinitions()
@@ -83,13 +68,11 @@ func (d *Daemon) observeDueSchedules(now time.Time) {
 // occurrence owed to one scheduled definition this tick.
 func (d *Daemon) observeDueSchedule(definition store.AutomationDefinition, spec automation.DefinitionSpec, now time.Time) {
 	if spec.Trigger.Schedule == nil {
-		// Definition validation should have prevented this at apply time.
 		d.logf("automation schedule observation %s: scheduled trigger has no schedule", definition.ID)
 		return
 	}
 	compiled, err := automation.CompileSchedule(*spec.Trigger.Schedule)
 	if err != nil {
-		// Definition validation should have prevented this at apply time.
 		d.logf("automation schedule observation compile %s: %v", definition.ID, err)
 		return
 	}
@@ -99,8 +82,7 @@ func (d *Daemon) observeDueSchedule(definition store.AutomationDefinition, spec 
 		return
 	}
 	if !ok {
-		// First observation anchors the cursor at now instead of firing
-		// retroactively: only instants strictly after this point are due.
+		// First observation anchors the cursor at now — never fires retroactively.
 		if err := d.store.SetAutomationScheduleCursor(definition.ID, now); err != nil {
 			d.logf("automation schedule observation anchor %s: %v", definition.ID, err)
 		}
@@ -108,9 +90,7 @@ func (d *Daemon) observeDueSchedule(definition store.AutomationDefinition, spec 
 	}
 	instants, ok := compiled.DueInstants(cursor, now, scheduleDueInstantCap)
 	if !ok {
-		// Replay-storm guard: an enormous backlog must never fire an unbounded
-		// catch-up burst. Jump the cursor to now and resume normal observation
-		// on the next tick.
+		// Replay-storm guard: jump the cursor to now instead of bursting.
 		d.logf("automation schedule observation %s: replay storm guard hit, cursor advanced to now", definition.ID)
 		if err := d.store.SetAutomationScheduleCursor(definition.ID, now); err != nil {
 			d.logf("automation schedule observation advance %s: %v", definition.ID, err)
@@ -118,12 +98,10 @@ func (d *Daemon) observeDueSchedule(definition store.AutomationDefinition, spec 
 		return
 	}
 	if len(instants) == 0 {
-		// Nothing due: leave the cursor untouched so anchor semantics survive
-		// a run of empty ticks between scheduled slots.
 		return
 	}
-	// Only the newest due instant is ever a fire candidate; older due instants
-	// never fire, so at most one claim happens per definition per tick.
+	// Only the newest due instant ever fires: at most one claim per definition
+	// per tick.
 	intended := instants[len(instants)-1]
 	fire := true
 	if spec.Trigger.CatchUp == "skip" {
@@ -131,38 +109,24 @@ func (d *Daemon) observeDueSchedule(definition store.AutomationDefinition, spec 
 	}
 	if fire {
 		if claimErr := d.claimAndDeliverScheduledRun(definition, spec, intended, now); claimErr != nil {
-			// The claim was rejected (revision mismatch, a singleton's
-			// undelivered-predecessor guard, or a transient store error): hold
-			// the cursor behind intended so the missed instant stays eligible
-			// and the next tick re-reads the definition and re-decides. The
-			// retry fires the newest instant due at that time under the normal
-			// newest-due-wins rule — the identical instant unless a newer one
-			// has become due meanwhile (minutely-grade schedules) — so a claim
-			// failure delays the definition's appointment; it never silently
-			// drops it, and it never prefers a stale instant over a fresher
-			// due one.
+			// Claim rejected or failed: hold the cursor behind intended so the
+			// instant stays eligible and the next tick re-decides — delayed,
+			// never silently dropped.
 			return
 		}
 	}
-	// Cursor advances after a successful claim decision (fire or skip), not
-	// unconditionally: a crash between claim and this write is safe because
-	// the next tick recomputes the same intended instant and the claim is
-	// idempotent; a claim error must not advance (handled above), keeping the
-	// missed instant eligible until a retry succeeds or a newer due instant
-	// supersedes it.
+	// Advance only after a successful claim decision. A crash before this write
+	// is safe: the claim is idempotent and the next tick recomputes intended.
 	if err := d.store.SetAutomationScheduleCursor(definition.ID, now); err != nil {
 		d.logf("automation schedule observation advance %s: %v", definition.ID, err)
 	}
 }
 
-// claimAndDeliverScheduledRun claims the occurrence for intended (idempotent
-// on definition + occurrence key) and, on a freshly pending run, delivers it
-// exactly like the GitHub review-request observation path. It returns a
-// non-nil error when no run row was claimed — claim rejection/failure or any
-// pre-claim preparation failure; the caller uses that to withhold the cursor
-// advance. Delivery failures after a successful claim always return nil: the
-// run row already exists and is owned by delivery/recovery from here, not by
-// re-claiming.
+// claimAndDeliverScheduledRun claims the occurrence for intended (idempotent on
+// definition + occurrence key) and delivers a freshly pending run. Non-nil error
+// means no run row was claimed (caller withholds the cursor advance); delivery
+// failures after a successful claim return nil — the run belongs to
+// delivery/recovery from there.
 func (d *Daemon) claimAndDeliverScheduledRun(definition store.AutomationDefinition, spec automation.DefinitionSpec, intended, observedAt time.Time) error {
 	observationLock := d.automationObservationLock(definition.ID, "schedule", 0)
 	observationLock.Lock()
@@ -195,10 +159,7 @@ func (d *Daemon) claimAndDeliverScheduledRun(definition store.AutomationDefiniti
 		d.logf("automation schedule observation claim %s: %v", definition.ID, claimErr)
 		return claimErr
 	}
-	// A run now exists for this definition (freshly claimed, or the
-	// idempotent dedup of an already-claimed one) whether or not delivery
-	// below succeeds; broadcast so a WS client watching this definition's
-	// runs sees it appear without waiting on the delivery outcome.
+	// A run row now exists regardless of delivery; broadcast so watchers see it.
 	d.broadcastAutomationsChanged(definition.ID)
 	d.automationMu.Lock()
 	current, loadErr := d.store.GetAutomationRun(run.ID)

--- a/internal/daemon/bus.go
+++ b/internal/daemon/bus.go
@@ -9,60 +9,27 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-// The daemon's side of the event bus: the fact vocabulary, the lifecycle, and the
-// projection table that turns facts into what WebSocket clients see.
-//
-// The migration pattern for A2 is the two halves below.
-//
-// PRODUCER. A `broadcastXxx` method stops touching the hub and publishes a fact
-// instead. The fact must carry a subject — the entity it is about — because a
-// subject-less "the list changed" fact is the snapshot invalidation this design
-// exists to avoid. When the existing method already receives the entity id, it
-// becomes a one-line publish and no call site changes (see
-// broadcastSessionStateChanged). When it does not — broadcastTicketsUpdated took
-// no arguments because it re-pushed the whole board — the call sites are the ones
-// that know which fact occurred, and they are what changes.
-//
-// PROJECTION. The old broadcaster body moves into a `projectXxx` method and is
-// registered in wireProjections. The hub subscribes ephemerally to every fact and
-// runs the matching projections inline on the publishing goroutine, so a fact
-// still produces exactly the same wire traffic, in the same order, as the direct
-// call it replaced.
-//
-// A projection writes to the wire and does nothing else. It must not mutate
-// state and it must not publish: the bus holds its publish lock across the
-// inline fan-out, so a fact published from inside a projection deadlocks. When
-// the old broadcaster body did something beyond pushing bytes — recomputing a
-// workspace's rolled-up status, say — that part stays on the producer side,
-// where it is a fact of its own.
-//
-// WHAT DOES NOT MOVE. Every state change goes through the bus. The exceptions
-// are enumerated, and the list is enforced by TestWireTrafficComesFromProjections
-// (bus_wire_boundary_test.go), which fails on a new broadcaster that skips the
-// bus:
-//
-//   - Byte streams. PTY output, PTY desync, attach results, and workspace tile
-//     content are high volume and carry no entity worth subscribing to. Attach
-//     and tile traffic is also routed by a per-client predicate
-//     (SendRawTextToMatchingClients), which pub/sub cannot express.
-//   - Filesystem change bursts (broadcastFsChanged), coalesced per watcher
-//     rather than per file.
-//   - The remote relay (broadcastRawWSMessage). Those events were already
-//     published as facts on the remote daemon's own bus; re-publishing them
-//     here would duplicate them.
-//
+// The daemon's side of the event bus: the fact vocabulary and the projection
+// table that turns facts into what WebSocket clients see.
 // See docs/plans/2026-08-01-ext-a1-event-bus.md.
+//
+// Every fact carries a subject; a subject-less "the list changed" fact is the
+// snapshot invalidation this design exists to avoid. The hub runs matching
+// projections inline on the publishing goroutine.
+//
+// A projection writes to the wire and does nothing else: it must not mutate
+// state and must not publish — the bus holds its publish lock across the inline
+// fan-out, so a nested publish deadlocks.
+//
+// Byte streams (PTY output/desync, attach, tile content), fs bursts, and the
+// remote relay stay off the bus; TestWireTrafficComesFromProjections enforces
+// the enumerated exception list.
 
 // Fact names are dotted `domain.verb`. `ext.<extension>.*` is reserved for facts
 // published by extensions.
 const (
-	// Session facts; subject is the session id.
-	//
-	// Registered and reregistered are separate facts rather than one fact with a
-	// flag, because they are separate things: a session appearing for the first
-	// time and a live session being re-announced by a reconnecting client. They
-	// project to different wire events, which is how the daemon has always
-	// treated them.
+	// Session facts; subject is the session id. Registered (first appearance) and
+	// reregistered (re-announcement) produce different wire events.
 	FactSessionRegistered   = "session.registered"
 	FactSessionReregistered = "session.reregistered"
 	FactSessionStateChanged = "session.state.changed"
@@ -71,10 +38,8 @@ const (
 	FactSessionTodosChanged = "session.todos.changed"
 	FactSessionRespawned    = "session.respawned"
 	FactSessionPTYResized   = "session.pty.resized"
-	// FactSessionTerminated is a session going away as part of a bulk operation
-	// (clear-all, a worktree deletion taking its sessions with it). It is not
-	// FactSessionUnregistered: unregistering announces the individual session to
-	// clients, while these paths have only ever re-pushed the list.
+	// FactSessionTerminated: a session going away in a bulk operation. Not
+	// FactSessionUnregistered — these paths only ever re-push the list.
 	FactSessionTerminated = "session.terminated"
 	// FactSessionBranchChanged: the branch monitor saw this session's checkout move.
 	FactSessionBranchChanged = "session.branch.changed"
@@ -86,12 +51,10 @@ const (
 	FactSessionPTYExited = "session.pty.exited"
 	// FactSessionWorkspaceChanged: this session moved to another workspace.
 	FactSessionWorkspaceChanged = "session.workspace.changed"
-	// FactSessionPinChanged: this session was pinned out of the queue, or
-	// released back into it. Distinct from FactWorkspacePinChanged, which moves
-	// a whole workspace and its siblings.
+	// FactSessionPinChanged: pinned out of the queue or released back. Distinct
+	// from FactWorkspacePinChanged, which moves a whole workspace.
 	FactSessionPinChanged = "session.pin.changed"
-	// FactSessionCapChanged: this session's context-window cap pin was set or
-	// cleared.
+	// FactSessionCapChanged: context-window cap pin set or cleared.
 	FactSessionCapChanged = "session.cap.changed"
 	// FactSessionActivityChanged: the generator wrote a new activity line for
 	// this session. Subject-only — the projection re-reads the session, which is
@@ -103,18 +66,12 @@ const (
 	// it. Subject is the worktree path.
 	FactWorktreeSessionsRemoved = "worktree.sessions.removed"
 
-	// FactEndpointSessionsChanged: a remote endpoint's session set changed.
-	// Subject is the endpoint id — the entity the hub manager knows about, and
-	// the one an extension watching a remote fleet would filter on.
+	// FactEndpointSessionsChanged: a remote endpoint's session set changed;
+	// subject is the endpoint id.
 	FactEndpointSessionsChanged = "endpoint.sessions.changed"
 
-	// Workspace facts; subject is the workspace id.
-	//
-	// Eight of these project to the same wire event. They are still eight facts:
-	// "the workspace was muted" and "a session joined it" are different things to
-	// subscribe to, and only the producer knows which happened. Collapsing them
-	// into one workspace.changed would hand every consumer the diffing problem
-	// the bus exists to remove.
+	// Workspace facts; subject is the workspace id. Eight project to one wire event
+	// but stay separate facts — collapsing them re-creates the diffing problem.
 	FactWorkspaceRegistered         = "workspace.registered"
 	FactWorkspaceReregistered       = "workspace.reregistered"
 	FactWorkspaceRenamed            = "workspace.renamed"
@@ -129,12 +86,8 @@ const (
 	FactWorkspaceLayoutRepublished  = "workspace.layout.republished"
 	FactWorkspaceContextChanged     = "workspace.context.changed"
 
-	// PR facts; subject is the PR id.
-	//
-	// The three set facts come from diffing the PR list around a bulk refresh.
-	// The daemon replaces the whole set on every poll, so the diff is what
-	// recovers the facts: without it a poll could only say "the list changed",
-	// which is the invalidation this design removes.
+	// PR facts; subject is the PR id. The three set facts come from diffing the
+	// list around a bulk refresh, which replaces the whole set.
 	FactPRAppeared    = "pr.appeared"
 	FactPRUpdated     = "pr.updated"
 	FactPRDisappeared = "pr.disappeared"
@@ -145,8 +98,7 @@ const (
 	FactPRDetailsChanged = "pr.details.changed"
 
 	// Worktree facts. Subject is the worktree path, except the reconcile, whose
-	// subject is the main repo: reading git prunes worktrees that are gone and
-	// adopts ones created outside attn, and the resulting list is per repo.
+	// subject is the main repo (the resulting list is per repo).
 	FactWorktreeCreated        = "worktree.created"
 	FactWorktreeDeleted        = "worktree.deleted"
 	FactWorktreeListReconciled = "worktree.list.reconciled"
@@ -180,18 +132,17 @@ const (
 	FactPluginConnected       = "plugin.connected"
 	FactPluginDisconnected    = "plugin.disconnected"
 	FactPluginHealthChanged   = "plugin.health.changed"
-	// FactPluginDriverRegistered changes which agents are available, which is
-	// part of settings, so it is the one plugin fact that does not re-push the
-	// plugin list.
+	// FactPluginDriverRegistered changes which agents are available (settings),
+	// so it is the one plugin fact that does not re-push the plugin list.
 	FactPluginDriverRegistered = "plugin.driver.registered"
 
 	// FactSettingChanged: subject is the setting key.
 	FactSettingChanged = "setting.changed"
-	// FactBackupWritten: subject is the backup file path. Clients learn about it
-	// through settings, which carry db.last_backup_at.
+	// FactBackupWritten: subject is the backup file path; clients learn of it
+	// through settings (db.last_backup_at).
 	FactBackupWritten = "backup.written"
-	// FactTailscaleServeChanged: subject is the profile. There is one tailscale
-	// serve per daemon and one daemon per profile, so the profile is its id.
+	// FactTailscaleServeChanged: subject is the profile (one serve per daemon,
+	// one daemon per profile).
 	FactTailscaleServeChanged = "tailscale.serve.changed"
 
 	// Notification facts; subject is the notification id.
@@ -218,46 +169,27 @@ const (
 	FactTicketCommented     = "ticket.commented"
 	FactTicketAssigned      = "ticket.assigned"
 	FactTicketAttached      = "ticket.attached"
-	// FactTicketChanged is the fallback for a mutation whose call site cannot
-	// name a sharper fact. It is still about one ticket — that is the line
-	// between a fact and an invalidation — but a sharper name is preferred
-	// wherever the producer knows one.
+	// FactTicketChanged is the fallback when the call site cannot name a sharper
+	// fact; still about one ticket, never a list invalidation.
 	FactTicketChanged = "ticket.changed"
 
-	// FactDocumentChanged: a document store record was written or removed.
-	// Subject is the document's address (namespace/collection/id); the payload
-	// carries the address in parts plus whether it was a removal.
-	//
-	// It is appended by the store, inside the transaction that made the change,
-	// and announced afterwards — see CommitDocumentWrite. That is what makes the
-	// seq it lands at usable as the write's position.
-	//
-	// This fact has no entry in wireProjections, and that is not an omission: it
-	// produces no WebSocket traffic. Its consumer is the live-query fan-out in
-	// documents.go, an ephemeral subscriber beside the hub that delivers result
-	// sets to IPC callers over their own connections.
+	// FactDocumentChanged: subject is the address (namespace/collection/id).
+	// Appended inside the write's transaction (CommitDocumentWrite), so its seq is
+	// the write's position. No wireProjections entry: its consumer is the
+	// live-query fan-out in documents.go, not WebSocket clients.
 	FactDocumentChanged = "document.changed"
-	// FactDocumentCollectionRemoved: a document collection was undefined, taking
-	// every document under it. Subject is the collection (namespace/collection),
-	// because that is the entity that went — a removal has no document to name,
-	// and saying so with an empty document id would leave every future consumer
-	// special-casing an address that points at nothing.
+	// FactDocumentCollectionRemoved: a collection was undefined, taking every
+	// document under it. Subject is the collection — a removal has no document
+	// to name.
 	FactDocumentCollectionRemoved = "document.collection.removed"
-	// FactDocumentCollectionRedeclared: a collection's declaration was rewritten
-	// in place. Subject is the collection, like a removal, and for the same
-	// reason: the entity that moved is the declaration, not any document. Its
-	// consumer is the live-query fan-out — a redeclare that drops a queried
-	// field must end the subscriptions using it at redeclare time, not at the
-	// next arbitrary write. Like the other document facts it has no entry in
-	// wireProjections.
+	// FactDocumentCollectionRedeclared: subject is the collection. A redeclare that
+	// drops a queried field must end the subscriptions using it. No wire entry.
 	FactDocumentCollectionRedeclared = "document.collection.redeclared"
 )
 
-// CompactableFacts are the fact classes the retention pass may reduce to one
-// row per subject. Both document facts qualify for the same reason: they are
-// invalidations about a subject whose state lives in the store, so only the
-// newest carries information. Session and ticket facts are deliberately absent
-// — they keep the age window's behavior unchanged.
+// CompactableFacts are the fact classes retention may reduce to one row per
+// subject — store-backed invalidations where only the newest carries
+// information. Session and ticket facts are deliberately absent.
 var CompactableFacts = []string{FactDocumentChanged, FactDocumentCollectionRemoved, FactDocumentCollectionRedeclared}
 
 // projection maps facts to the wire traffic they produce.
@@ -266,14 +198,9 @@ type projection struct {
 	apply  func(*Daemon, bus.Event)
 }
 
-// wireProjections is the whole fact -> WebSocket mapping. A2 grows this table as
-// each broadcaster migrates.
-//
-// Built once on first use rather than at package init: the table's closures call
-// projections, projections publish further facts (a session state change
-// recomputes its workspace), and publishing reads the table — a cycle the
-// compiler rejects in a package-level initializer even though it is fine at
-// runtime.
+// wireProjections is the whole fact -> WebSocket mapping. Built on first use,
+// not package init: projections publish further facts and publishing reads the
+// table — a cycle the compiler rejects in a package-level initializer.
 var (
 	wireProjectionsOnce  sync.Once
 	wireProjectionsTable []projection
@@ -297,26 +224,18 @@ func buildWireProjections() []projection {
 			},
 		},
 		{
-			// A pin changes what the session says about itself (turn_owed and
-			// pinned_at, or context_window_cap), and nothing about its workspace,
-			// so it re-pushes the one session rather than recomputing the group
-			// around it.
+			// A pin changes only what the session says about itself.
 			filter: bus.Filter{FactSessionPinChanged, FactSessionCapChanged},
 			apply:  func(d *Daemon, ev bus.Event) { d.projectSessionStateChanged(ev.Subject) },
 		},
 		{
-			// A new activity line changes one field on one session and nothing about
-			// its workspace, so it re-pushes that session alone. It reaches clients
-			// as a state change because there is no separate activity event: the
-			// line rides on the session snapshot, which is what a client renders
-			// anyway.
+			// An activity line has no event of its own: it rides on the session
+			// snapshot, so it re-pushes that session alone.
 			filter: bus.Filter{FactSessionActivityChanged},
 			apply:  func(d *Daemon, ev bus.Event) { d.projectSessionStateChanged(ev.Subject) },
 		},
 		{
-			// A re-announced session and a renamed one both reach clients as a state
-			// change carrying the session; neither recomputes the workspace, which is
-			// what separates them from FactSessionStateChanged.
+			// Neither recomputes the workspace, unlike FactSessionStateChanged.
 			filter: bus.Filter{FactSessionReregistered, FactSessionRenamed},
 			apply: func(d *Daemon, ev bus.Event) {
 				d.projectSessionEvent(protocol.EventSessionStateChanged, ev.Subject)
@@ -346,8 +265,7 @@ func buildWireProjections() []projection {
 			apply:  func(d *Daemon, ev bus.Event) { d.projectSessionPTYResized(ev) },
 		},
 		{
-			// Everything whose only client-visible effect is "the session list moved".
-			// Each is a real fact about one session; the wire sees one list push.
+			// Facts whose only client-visible effect is one session-list push.
 			filter: bus.Filter{
 				FactSessionTerminated,
 				FactSessionBranchChanged,
@@ -365,8 +283,6 @@ func buildWireProjections() []projection {
 			},
 		},
 		{
-			// Eight distinct facts, one wire event: clients have always been told
-			// "this workspace changed, here it is" whatever the reason.
 			filter: bus.Filter{
 				FactWorkspaceReregistered,
 				FactWorkspaceRenamed,
@@ -398,9 +314,7 @@ func buildWireProjections() []projection {
 			apply:  func(d *Daemon, ev bus.Event) { d.projectWorkspaceContextChanged(ev) },
 		},
 		{
-			// Every ticket fact re-pushes the board. The board push is the wire
-			// shape clients already expect; the facts are what a consumer can
-			// actually reason about.
+			// Every ticket fact re-pushes the board — the wire shape clients expect.
 			filter: bus.Filter{"ticket.*"},
 			apply:  func(d *Daemon, _ bus.Event) { d.projectTicketsUpdated() },
 		},
@@ -466,9 +380,8 @@ func buildWireProjections() []projection {
 			apply: func(d *Daemon, _ bus.Event) { d.projectPluginsUpdated() },
 		},
 		{
-			// A plugin going away and a driver registering both change which agents
-			// are available, so both re-push settings — without a changed key,
-			// because no setting was set.
+			// All change which agents are available, so re-push settings — with no
+			// changed key, because no setting was set.
 			filter: bus.Filter{FactPluginDisconnected, FactPluginDriverRegistered,
 				FactBackupWritten, FactTailscaleServeChanged},
 			apply: func(d *Daemon, _ bus.Event) { d.projectSettingsUpdated("") },
@@ -504,11 +417,9 @@ func buildWireProjections() []projection {
 	}
 }
 
-// ensureEventBus constructs the bus over the profile store and registers the hub
-// as an ephemeral consumer. It is idempotent and runs at construction rather than
-// at Start, because the hub subscription is what makes a published fact reach
-// clients: a daemon that publishes without having started (every test that
-// exercises a broadcaster directly) must still project.
+// ensureEventBus constructs the bus and registers the hub as an ephemeral
+// consumer. Idempotent, and run at construction: a daemon that publishes without
+// having started (tests) must still project.
 func (d *Daemon) ensureEventBus() {
 	if d.eventBus != nil {
 		return
@@ -522,7 +433,7 @@ func (d *Daemon) ensureEventBus() {
 	d.subscribeDocumentFacts()
 }
 
-// startEventBus begins durable delivery. It runs early in Start, before any
+// startEventBus begins durable delivery; runs early in Start, before any
 // subsystem that publishes.
 func (d *Daemon) startEventBus() error {
 	d.ensureEventBus()
@@ -549,14 +460,8 @@ func (d *Daemon) projectToClients(ev bus.Event) {
 	}
 }
 
-// publishFact is the producer half. It is nil-safe: a Daemon assembled in a test
-// without a bus still runs its projections directly, so migrating a broadcaster
-// does not silently disconnect the behavior every existing test asserts on.
-//
-// The bus-less path marshals the payload exactly as Publish would, because a
-// projection that reads its payload must behave the same either way — otherwise
-// a fact whose data lives in the payload rather than in the store would project
-// an empty message in every test that skips the bus.
+// publishFact is the producer half. Nil-safe: a bus-less test Daemon runs its
+// projections directly, marshalling the payload exactly as Publish would.
 func (d *Daemon) publishFact(name, subject string, payload any) {
 	if d == nil {
 		return
@@ -590,21 +495,10 @@ func decodeFact[T any](d *Daemon, ev bus.Event) (T, bool) {
 	return out, true
 }
 
-// Snapshot projections re-push a whole list — every session, every ticket. A
-// bulk operation publishes one fact per entity, because that is what makes the
-// log worth subscribing to, but the wire must not carry one full list per
-// entity: clearing twenty sessions was one message before the bus and has to
-// stay one message after it.
-//
-// coalesceSnapshots runs fn with snapshot projections deferred and de-duplicated
-// by key, then flushes each one once, in first-request order. Per-entity
-// projections (the ones that name the entity on the wire) are unaffected and
-// still fire inline, in publish order.
-//
-// The window is process-wide rather than goroutine-scoped, so a snapshot pushed
-// by an unrelated goroutine during a bulk operation is deferred to the flush
-// too. That is a few microseconds of delay for one message, and it is still
-// delivered exactly once, in order relative to the batch.
+// coalesceSnapshots runs fn with snapshot (whole-list) projections deferred and
+// de-duplicated by key, so a bulk operation does not put one full list per entity
+// on the wire. Per-entity projections still fire inline. The window is
+// process-wide: an unrelated goroutine's snapshot defers to the flush too.
 func (d *Daemon) coalesceSnapshots(fn func()) {
 	d.snapshotMu.Lock()
 	d.snapshotDepth++
@@ -631,9 +525,8 @@ func (d *Daemon) coalesceSnapshots(fn func()) {
 	fn()
 }
 
-// projectSnapshot runs a whole-list re-push, or records it for the end of the
-// enclosing coalesceSnapshots window. Every projection that re-pushes a list
-// goes through this rather than broadcasting directly.
+// projectSnapshot runs a whole-list re-push, or defers it to the end of the
+// enclosing coalesceSnapshots window. Every list re-push goes through this.
 func (d *Daemon) projectSnapshot(key string, push func()) {
 	d.snapshotMu.Lock()
 	if d.snapshotDepth == 0 {
@@ -667,9 +560,8 @@ const (
 	snapshotTasks       = "tasks_changed"
 )
 
-// wireEqual reports whether two values reach clients as the same JSON. It is the
-// equality a diff-driven producer wants: "changed" should mean the client would
-// see something different, not that some unexported or unserialized field moved.
+// wireEqual reports whether two values reach clients as the same JSON —
+// "changed" means the client would see something different.
 func wireEqual(a, b any) bool {
 	rawA, errA := json.Marshal(a)
 	rawB, errB := json.Marshal(b)

--- a/internal/daemon/classify_decision.go
+++ b/internal/daemon/classify_decision.go
@@ -10,14 +10,9 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-// Deciding what a settled turn means is a sequence of rules interleaved with two
-// slow, fallible steps: reading the transcript off disk and asking an LLM. The
-// rules are here as pure functions so they can be read and tested as rules,
-// beside classifySessionState — the shell that performs the IO between them and
-// files the verdict.
-//
-// Each function answers with a classifyDecision: apply this state, or take the
-// next IO step, or leave the state alone.
+// Stop classification as pure rules, testable without IO; classifyStop is the
+// shell that reads the transcript and calls the LLM between them. Each rule
+// answers with a classifyDecision: apply, take the next IO step, or skip.
 
 type classifyAction int
 
@@ -36,37 +31,24 @@ type classifyDecision struct {
 	action classifyAction
 	// state is meaningful only for classifyApply.
 	state string
-	// reason is the diagnostic label logged with the decision. The names match the
-	// ones the previous inline log lines used ("transcript_parse_error",
-	// "classifier_error", "classifier_unknown_response"), so a log search for a
-	// past incident still finds them.
+	// reason is the diagnostic label logged with the decision; names are kept
+	// stable so log searches for past incidents still find them.
 	reason string
 }
 
 // stopClassification is what handleStop knew about the stop being judged.
-//
-// yielded marks a stop whose payload reported background work still running, so
-// the turn can resume on its own. A yielded stop is still judged — its last
-// message is the only thing separating "waiting on my build" from "done, but a
-// process I started is still running" — but with two differences: the judge sees
-// the yield (the harness-facts line the PARKED verdict keys on), and every
-// no-answer outcome files nothing instead of settling, because an unjudgeable
-// message must not put a turn that may be about to resume into the user's queue.
+// yielded marks a stop with background work still running: still judged, but
+// the judge sees the yield (the PARKED verdict's precondition), and every
+// no-answer outcome files nothing — a turn that may resume must not settle.
 type stopClassification struct {
 	yielded                bool
 	runningBackgroundTasks int
 }
 
-// classifyPreTranscript decides from what the daemon already holds, before paying
-// for any IO.
-//
-// pendingTodos outranks everything on a terminal stop: a turn that stopped with
-// unfinished todos is waiting on the user. On a yield it decides nothing — an
-// agent sitting out its own build mid-plan has open todos precisely because it is
-// not finished. transcriptEnabled / classifierEnabled are the per-agent
-// capability gates; an agent with either disabled settles idle rather than being
-// left in whatever state it was — except on a yield, where no judgment means no
-// filing and the resolver's fallback ladder decides.
+// classifyPreTranscript decides from what the daemon already holds, before any
+// IO. pendingTodos outranks everything on a terminal stop but decides nothing on
+// a yield; a disabled capability settles idle — except on a yield, where no
+// judgment means no filing and the resolver's fallback ladder decides.
 func classifyPreTranscript(pendingTodos int, transcriptEnabled, classifierEnabled bool, stop stopClassification) classifyDecision {
 	switch {
 	case stop.yielded && (!transcriptEnabled || !classifierEnabled):
@@ -82,15 +64,10 @@ func classifyPreTranscript(pendingTodos int, transcriptEnabled, classifierEnable
 	}
 }
 
-// classifyPostTranscript decides from the transcript read.
-//
-// ErrNoNewAssistantTurn means the turn we would classify has already been
-// classified, so there is nothing to say — importantly not "unknown", which would
-// overwrite a good state with a bad one. Any other read error is genuinely
-// unknown. An empty last message means the agent said nothing, which settles idle
-// without paying for a classifier call. A yield files nothing in every non-answer
-// case, empty message included: silence is not evidence the turn is over when the
-// payload says it will resume.
+// classifyPostTranscript decides from the transcript read. ErrNoNewAssistantTurn
+// means already classified — a skip, NOT "unknown", which would overwrite a good
+// state. An empty message settles idle without a classifier call. A yield files
+// nothing in every non-answer case, empty message included.
 func classifyPostTranscript(lastMessage string, err error, stop stopClassification) classifyDecision {
 	if err != nil {
 		if errors.Is(err, agentdriver.ErrNoNewAssistantTurn) {
@@ -110,16 +87,10 @@ func classifyPostTranscript(lastMessage string, err error, stop stopClassificati
 	return classifyDecision{action: classifyRunClassifier}
 }
 
-// classifyVerdict maps the classifier's answer to a state. A failed call and an
-// unknown answer both land on unknown, but they are separate reasons: one is our
-// plumbing failing, the other is the classifier declining to decide. (Neither
-// files any evidence — there is no unknown claim — so on a yield the resolver's
-// fallback ladder still decides.)
-//
-// A parked verdict outside a yield is the judge misapplying a rule whose
-// precondition — the harness-facts line — was never in its input. Filed as
-// nothing rather than remapped: the session settles on its own fallback, and the
-// trace says what the judge actually answered.
+// classifyVerdict maps the classifier's answer to a state. Failed call and
+// unknown answer both land on unknown under separate reasons. A parked verdict
+// outside a yield is the judge misapplying a rule whose precondition was never
+// in its input: filed as nothing, and the trace keeps what it actually answered.
 func classifyVerdict(state string, err error, stop stopClassification) classifyDecision {
 	if err != nil {
 		return classifyDecision{action: classifyApply, state: protocol.StateUnknown, reason: "classifier_error"}
@@ -138,15 +109,11 @@ func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
 	d.classifyStop(sessionID, transcriptPath, stopClassification{})
 }
 
-// classifyStop decides what a stopped turn means and files the result.
-// It is the IO shell around the rules in classify_decision.go: it gathers inputs,
-// performs the transcript read and the classifier call between rules, and owns the
-// single store write. The rules themselves make no decision about when to pay for
-// IO — they say what is still needed.
+// classifyStop is the IO shell around the rules above: it gathers inputs, reads
+// the transcript, calls the classifier, and owns the single store write.
 func (d *Daemon) classifyStop(sessionID, transcriptPath string, stop stopClassification) {
-	// Capture the timestamp BEFORE any classification work: applyState rejects a
-	// classifierObservation older than the state it would overwrite, so a slow
-	// classifier cannot clobber a newer live signal.
+	// Captured BEFORE any work: applyState rejects an older classifierObservation,
+	// so a slow classifier cannot clobber a newer live signal.
 	classificationStartTime := time.Now()
 	d.logf("classifySessionState: starting for session=%s, transcript=%s", sessionID, transcriptPath)
 
@@ -156,11 +123,8 @@ func (d *Daemon) classifyStop(sessionID, transcriptPath string, stop stopClassif
 		return
 	}
 
-	// Tell the resolver a verdict is coming, so its tick holds the pre-settle
-	// state instead of publishing idle and being corrected seconds later. The
-	// deferred clear covers every exit, including the early returns below: a
-	// classification that ends without a verdict is precisely when the session
-	// must be free to settle on its own.
+	// Tell the resolver a verdict is coming so its tick holds the pre-settle
+	// state; the deferred clear covers every exit, early returns included.
 	d.recordClassifierStarted(sessionID, classificationStartTime)
 	defer d.recordClassifierFinished(sessionID)
 
@@ -171,12 +135,8 @@ func (d *Daemon) classifyStop(sessionID, transcriptPath string, stop stopClassif
 			return
 		}
 		d.logf("classifySessionState: session=%s state=%s reason=%s", sessionID, decision.state, decision.reason)
-		// Filed, not applied. The verdict is one witness to how a turn ended and
-		// the weakest-timed of them: it describes the transcript as of
-		// classificationStartTime and lands seconds later, which is why it used to
-		// need a timestamp guard to stop it overwriting a newer state. As evidence
-		// it gets a stronger version of the same guard for free — the resolver drops
-		// a verdict the agent has since gone busy past, whatever the clock says.
+		// Filed as evidence, not applied: the resolver drops a verdict the agent
+		// has since gone busy past, whatever the clock says.
 		d.recordClassifierEvidence(sessionID, decision.state, classificationStartTime)
 		d.traceStateEvidence(
 			sessionID,
@@ -189,8 +149,6 @@ func (d *Daemon) classifyStop(sessionID, transcriptPath string, stop stopClassif
 		)
 	}
 
-	// Capability gates: agents can independently disable transcript parsing and
-	// classification.
 	transcriptEnabled := true
 	classifierEnabled := true
 	if driver := agentdriver.Get(string(session.Agent)); driver != nil {
@@ -199,8 +157,7 @@ func (d *Daemon) classifyStop(sessionID, transcriptPath string, stop stopClassif
 		classifierEnabled = caps.HasClassifier
 	}
 
-	// Todos are stored as "[✓] task" (completed), "[→] task" (in_progress),
-	// "[ ] task" (pending).
+	// Todos are stored as "[✓] task", "[→] task", "[ ] task".
 	pendingTodos := 0
 	for _, todo := range session.Todos {
 		if !strings.HasPrefix(todo, "[✓]") {
@@ -251,9 +208,7 @@ func (d *Daemon) classifyStop(sessionID, transcriptPath string, stop stopClassif
 	}
 	d.logf("classifySessionState: last message for session %s: %s", sessionID, logMsg)
 
-	// On a yield the judge must see the yield: the harness-facts line is the
-	// precondition of the PARKED verdict, and without it the same message reads
-	// as a plain ending.
+	// On a yield the judge must see the yield — the PARKED verdict's precondition.
 	classifierInput := lastMessage
 	if stop.yielded {
 		classifierInput = classifier.ComposeYieldInput(lastMessage, stop.runningBackgroundTasks)
@@ -288,8 +243,7 @@ func (d *Daemon) runClassifier(session *protocol.Session, text string, timeout t
 			return state, err
 		}
 	}
-	// Fallback for a session whose driver has no classifier (and for a nil
-	// session): judge with headless Claude, the same backend Claude sessions use.
+	// Fallback when the driver has no classifier (or session is nil): headless Claude.
 	claude := agentdriver.Get("claude")
 	if state, err, ok := agentdriver.ClassifyWithDriver(
 		claude,

--- a/internal/daemon/delegate_ticket.go
+++ b/internal/daemon/delegate_ticket.go
@@ -15,10 +15,9 @@ import (
 // ticketSlugStrip collapses every run of non-slug characters to a single dash.
 var ticketSlugStrip = regexp.MustCompile(`[^a-z0-9]+`)
 
-// ticketSlug derives a human-friendly slug id from a label (e.g. "Migrate store
-// to X" -> "migrate-store-to-x"). Delegation creates the ticket before the agent
-// runs, so attn names it from the label rather than the agent. The result is
-// always a non-empty, bounded slug; collisions are resolved by the caller.
+// ticketSlug derives a slug id from a label ("Migrate store to X" ->
+// "migrate-store-to-x"). Always non-empty and bounded; collisions are the
+// caller's to resolve.
 func ticketSlug(label string) string {
 	s := ticketSlugStrip.ReplaceAllString(strings.ToLower(strings.TrimSpace(label)), "-")
 	s = strings.Trim(s, "-")
@@ -31,32 +30,12 @@ func ticketSlug(label string) string {
 	return s
 }
 
-// createDelegatedTicket creates and binds the ticket for a delegated session —
-// every delegation, not only the chief's. The brief is the description (the
-// delegation prompt); the session id is the assignee (its observer identity, so
-// assignee == session is the binding); the delegating session is the event author.
-// The ticket starts in Working since the agent begins immediately. The slug is
-// derived from the label, with a numeric suffix on collision. Returns the created
-// ticket id.
-//
-// Three identities end up on the ticket, each exactly once (see
-// store.TicketParticipants): the assignee by binding, the creator by an explicit
-// subscription, and the chief of staff — always, so its organizational overview
-// covers every delegation in the system whoever started it.
-//
-// The chief reaches the ticket through its durable ROLE identity, either as owner
-// or as subscriber, so its view survives the session filling the role changing:
-//
-//   - chief-initiated delegation: the chief role OWNS the ticket. Ownership is
-//     also what marks the delegated session `delegated_from_chief` in the sidebar
-//     (see delegatedFromChiefSessionIDs), so it stays reserved for work the chief
-//     actually started.
-//   - ordinary delegation: the chief role SUBSCRIBES. Same routing guarantee, no
-//     claim of ownership over work another session started.
-//
-// When the creator IS the chief, it holds both its session subscription and the
-// role identity; ticketnotify.ConsumeAll merges the two queues by event seq, so
-// the activity is still delivered once. No extra guard is needed for that case.
+// createDelegatedTicket creates and binds the ticket for every delegated
+// session, starting in Working. The chief of staff is always a participant via
+// its durable ROLE identity — owner when it initiated (which is also what marks
+// the session `delegated_from_chief`), subscriber otherwise — so its view
+// survives the session filling the role changing. A creator that IS the chief
+// holds both identities; ticketnotify.ConsumeAll merges them by event seq.
 func (d *Daemon) createDelegatedTicket(creatorSessionID string, ownedByChiefRole bool, session *protocol.Session, brief, label, agent string) (string, error) {
 	if d.delegationTicketCreateHook != nil {
 		if err := d.delegationTicketCreateHook(); err != nil {
@@ -86,9 +65,9 @@ func (d *Daemon) createDelegatedTicket(creatorSessionID string, ownedByChiefRole
 }
 
 // adoptDelegatedTicket binds an existing ticket instead of minting a duplicate.
-// Its description has already been delivered in the spawn prompt, so the store
-// advances the new assignee's cursor through the adoption events. The previous
-// assignee remains subscribed so a deliberate takeover is visible to it.
+// The store advances the new assignee's cursor past the adoption events (the
+// description already went out in the spawn prompt); the previous assignee stays
+// subscribed.
 func (d *Daemon) adoptDelegatedTicket(creatorSessionID string, ownedByChiefRole bool, session *protocol.Session, ticketID, agent string, confirm bool) (string, error) {
 	ownerRole := ""
 	chiefRoleIdentity := store.TicketRoleIdentity(store.TicketRoleChiefOfStaff)
@@ -108,27 +87,20 @@ func (d *Daemon) adoptDelegatedTicket(creatorSessionID string, ownedByChiefRole 
 	return adopted.ID, nil
 }
 
-// ticketSlugSequentialAttempts bounds the readable base-2, base-3, ... walk before
-// the allocator switches to random suffixes. Now that EVERY delegation creates a
-// ticket, one popular base (a repo's directory basename, the common default label)
-// accumulates ids fast, and a full board must never be able to fail a delegation
-// that has already spawned a session. The sequential walk keeps ids readable while
-// the board is small; past that the random tail keeps allocation effectively
-// unbounded at the cost of a less pretty id.
+// ticketSlugSequentialAttempts bounds the readable base-2, base-3, ... walk
+// before random suffixes: a full board must never fail a delegation that has
+// already spawned a session, so past this the random tail keeps allocation
+// effectively unbounded.
 const ticketSlugSequentialAttempts = 50
 
-// ticketSlugRandomSuffixLen is the width of the random tail. Fixed width is what
-// distinguishes a fallback id from the sequential walk at a glance, and it is what
-// the fallback test asserts on — the tail is hex, so it is sometimes all digits.
+// ticketSlugRandomSuffixLen is the width of the random tail. Fixed width is
+// what the fallback test asserts on — the tail is hex, so sometimes all digits.
 const ticketSlugRandomSuffixLen = 6
 
-// createTicketWithUniqueSlug inserts template under base, falling back to base-2,
-// base-3, ... on slug collision, then to base-<random> once the sequential range is
-// exhausted. The template's ID field is ignored — the slug is allocated here. It
-// returns the created ticket, a non-collision CreateTicket error verbatim, or a
-// "could not allocate" error only if even the random suffixes collide. Both
-// createDelegatedTicket (bound, working) and the standalone ticket_create handler
-// (unbound, todo) share this so the auto-suffix behavior is identical.
+// createTicketWithUniqueSlug inserts template under base, falling back to
+// base-2, base-3, ... on collision, then base-<random>. The template's ID is
+// ignored — the slug is allocated here. Shared by createDelegatedTicket and the
+// standalone ticket_create handler so auto-suffix behavior is identical.
 func (d *Daemon) createTicketWithUniqueSlug(template store.Ticket, base, author, ownerRole string, subscribers []string, now time.Time) (*store.Ticket, error) {
 	for attempt := 0; attempt < ticketSlugSequentialAttempts+5; attempt++ {
 		switch {

--- a/internal/daemon/documents.go
+++ b/internal/daemon/documents.go
@@ -15,59 +15,35 @@ import (
 	"github.com/victorarias/attn/internal/store"
 )
 
-// The document store's daemon half: the fact a write publishes, the live queries
-// that fact wakes, and the IPC surface `attn doc` speaks.
+// The document store's daemon half: the fact a write publishes, the live
+// queries that fact wakes, and the IPC surface `attn doc` speaks.
 //
-// WHY A SUBSCRIPTION RE-RUNS RATHER THAN PATCHES. Every delivery re-runs the
-// whole query. A patch stream would avoid the re-run and it is where live query
-// systems grow their bugs: a document falling out of a `limit 20` window forces
-// a re-query to find the 21st anyway, so a patch path needs the re-run path
-// underneath it and only some of the time. Re-running always is one path.
-//
-// What a delivery carries is a different question from how it is computed. The
-// re-run answers "which documents, in what order"; the bodies are then diffed
-// against what this subscriber is known to hold, so a window of a hundred
-// documents whose first one changed is one body and a hundred ids. That diff is
-// pure bookkeeping over one map — no second notion of what changed, and nothing
-// a patch stream's ordering hazards can reach.
-//
-// A delivery is still safe to drop, which is what the one-slot wake channel
-// below relies on: each delivery is computed from current state at the moment it
-// is sent, so a subscriber that has not drained loses nothing when a burst of
-// writes collapses into one delivery. What it must NOT lose is the record of
-// what it holds — that lives beside the connection, advances only when a
-// delivery is actually encoded, and is what makes dropping the rest correct.
-//
-// WHY THE BUS FAN-OUT DOES NOT WRITE THE SOCKET. The bus holds its publish lock
-// across the inline fan-out, so anything slow inside a handler stalls every
-// publisher in the daemon. A subscription therefore owns its goroutine: the fact
-// handler only pokes the channel, and the goroutine runs the query and writes.
+// A subscription re-runs the whole query per delivery — never patches — and
+// diffs bodies against what the subscriber holds. A delivery is safe to drop
+// (each is computed from current state), which the one-slot wake channel relies
+// on; the held-revisions record beside the connection is what must not be lost.
+// The bus fan-out must not write the socket — the bus holds its publish lock
+// across the inline fan-out — so the fact handler only pokes the wake channel.
 //
 // See docs/plans/2026-08-03-ext-a3-doc-store.md.
 
-// docSubscription is one caller watching one query.
-// It deliberately holds no declaration: the delivery loop re-reads it, because
-// a captured one goes stale exactly when it matters — when the collection is
-// undefined or redeclared out from under the query.
+// docSubscription is one caller watching one query. It holds no declaration on
+// purpose: the delivery loop re-reads it, since a captured one goes stale
+// exactly when it matters.
 type docSubscription struct {
 	id     string
 	query  docstore.Query
 	target string
-	// wake holds at most one pending nudge. A full channel means "already told,
-	// not yet served", and dropping the extra is correct because the delivery it
-	// would have caused is the same delivery the pending one will cause.
+	// wake holds at most one pending nudge; dropping extras is correct because
+	// the delivery they would cause is the one the pending nudge will cause.
 	wake chan struct{}
 	// siblings is how many subscriptions the last write woke on this collection,
-	// stamped by the fan-out because that is the one place already counting them.
-	// The delivery goroutine reads it to price the write, and reading it from
-	// here rather than counting again keeps a log line that almost never fires
-	// off the delivery path's lock.
+	// stamped by the fan-out so the slow-fan-out log line stays off the lock.
 	siblings atomic.Int64
 }
 
-// documentChanged is the fact's payload. It carries the address in parts so a
-// consumer never parses the subject, and `deleted` so a future consumer can tell
-// a removal from a write without reading the store to find nothing there.
+// documentChanged is the fact's payload: the address in parts (consumers never
+// parse the subject) plus `deleted`.
 type documentChanged struct {
 	Namespace  string `json:"namespace"`
 	Collection string `json:"collection"`
@@ -75,8 +51,7 @@ type documentChanged struct {
 	Deleted    bool   `json:"deleted,omitempty"`
 }
 
-// documentCollectionRemoved is the undefine fact's payload: the collection that
-// went, in parts, and how many documents went with it.
+// documentCollectionRemoved is the undefine fact's payload.
 type documentCollectionRemoved struct {
 	Namespace  string `json:"namespace"`
 	Collection string `json:"collection"`
@@ -89,9 +64,8 @@ type documentCollectionRedeclared struct {
 }
 
 // subscribeDocumentFacts registers the live-query fan-out as its own ephemeral
-// bus consumer, beside the WebSocket hub's. It is deliberately not a projection:
-// wireProjections maps facts to WebSocket traffic, and these deliveries go to
-// IPC callers over their own connections.
+// bus consumer — deliberately not a projection, since deliveries go to IPC
+// callers, not WebSocket clients.
 func (d *Daemon) subscribeDocumentFacts() {
 	if d.eventBus == nil || d.docUnsubHooks != nil {
 		return
@@ -108,14 +82,9 @@ func (d *Daemon) unsubscribeDocumentFacts() {
 	}
 }
 
-// documentChangedFact builds the fact for one document write or removal. The
-// subject is the document's own address, so the log reads as a history of
-// documents rather than of collections; subscriptions match on the collection
-// carried in the payload.
-//
-// It is built here and appended by the store, inside the write's own
-// transaction: the store must not know what attn's facts are called, and the
-// write must not be able to land without one.
+// documentChangedFact builds the fact for one write or removal; subject is the
+// document's address. Built here, appended by the store inside the write's own
+// transaction, so the store never learns attn's fact names.
 func documentChangedFact(namespace, collection, id string, deleted bool) store.BusEvent {
 	payload, _ := json.Marshal(documentChanged{
 		Namespace: namespace, Collection: collection, ID: id, Deleted: deleted,
@@ -127,14 +96,9 @@ func documentChangedFact(namespace, collection, id string, deleted bool) store.B
 	}
 }
 
-// announceCommittedWrite fans out a fact the store already made durable.
-//
-// The bus reads the log forward rather than taking the event from here, so two
-// writes that commit concurrently reach subscribers in seq order however their
-// announce calls race. Without a bus — a Daemon assembled in a test — the
-// matching path runs the projections directly, exactly as publishFact's
-// bus-less path does, so a test exercises the same write with only the fan-out
-// missing.
+// announceCommittedWrite fans out a fact the store already made durable. The bus
+// reads the log forward, so concurrent commits reach subscribers in seq order
+// however the announce calls race.
 func (d *Daemon) announceCommittedWrite(fact store.BusEvent, seq int64) {
 	if d.eventBus == nil {
 		d.projectToClients(bus.Event{
@@ -145,19 +109,16 @@ func (d *Daemon) announceCommittedWrite(fact store.BusEvent, seq int64) {
 	d.eventBus.Announce()
 }
 
-// publishCollectionRemoved announces that a collection and everything in it is
-// gone. Its subject is the collection rather than a document, so it goes through
-// the ordinary publish path: there is no document write to commit it with.
+// publishCollectionRemoved announces a collection and everything in it is gone;
+// no document write to commit with, so it takes the ordinary publish path.
 func (d *Daemon) publishCollectionRemoved(namespace, collection string, documents int) {
 	d.publishFact(FactDocumentCollectionRemoved, docstore.Target(namespace, collection),
 		documentCollectionRemoved{Namespace: namespace, Collection: collection, Documents: documents})
 }
 
-// publishCollectionRedeclared announces that a collection's declaration was
-// rewritten. The delivery loop re-reads the declaration on every wake, so this
-// is all a redeclare needs to publish: a subscription whose queried fields
-// survived pays one redundant delivery, and one whose field went gets its
-// collection_redeclared ending now instead of at the next arbitrary write.
+// publishCollectionRedeclared announces a rewritten declaration. The delivery
+// loop re-reads it per wake, so a surviving subscription pays one redundant
+// delivery and a broken one ends now instead of at the next arbitrary write.
 func (d *Daemon) publishCollectionRedeclared(namespace, collection string) {
 	d.publishFact(FactDocumentCollectionRedeclared, docstore.Target(namespace, collection),
 		documentCollectionRedeclared{Namespace: namespace, Collection: collection})
@@ -230,24 +191,18 @@ func (d *Daemon) removeDocSubscription(id string) {
 	d.docSubsMu.Unlock()
 }
 
-// documentSubscriptionCount reports how many live queries are registered. Tests
-// use it to prove a subscription is gone once its caller disconnects; a leaked
-// subscription would keep re-running a query nobody reads.
+// documentSubscriptionCount reports how many live queries are registered; tests
+// use it to prove a subscription dies with its caller.
 func (d *Daemon) documentSubscriptionCount() int {
 	d.docSubsMu.Lock()
 	defer d.docSubsMu.Unlock()
 	return len(d.docSubs)
 }
 
-// runDocQuery answers a query, returning the store's read — documents, the
-// declaration they were computed against, and the log position they were true
-// at — plus how long it took. The caller decides what a slow one means: once
-// for a one-shot query, per write for a live one.
-//
-// The declaration comes back from the read rather than being passed in. Reading
-// it separately first is what let a redeclare land between the schema and the
-// SELECT; the store now resolves it inside the same transaction, so the schema
-// returned here is the one the answer actually means.
+// runDocQuery answers a query, returning the store's read plus how long it
+// took. The declaration comes back FROM the read: reading it separately first
+// let a redeclare land between schema and SELECT; the store now resolves it
+// inside the same transaction.
 func (d *Daemon) runDocQuery(q docstore.Query) (store.QueryRead, time.Duration, error) {
 	if d.store == nil {
 		return store.QueryRead{}, 0, fmt.Errorf("no database")
@@ -269,22 +224,11 @@ func (d *Daemon) runDocQuery(q docstore.Query) (store.QueryRead, time.Duration, 
 	return read, time.Since(started), nil
 }
 
-// Two tripwires, because a document query has two costs and only one of them is
-// visible in a single query's duration.
-//
-// slowDocQuery is the coarse one: a one-shot query that takes this long is
-// pathological now that every declared field is indexed, and the log names the
-// collection size so the diagnosis starts with the receipt.
-//
-// slowDocFanOut is the one that matters. A live query re-runs on every committed
-// write to its collection, so the daemon's real cost is one query multiplied by
-// the number of subscriptions watching — a term no per-query threshold can see,
-// because each of those queries is individually fast. The budget is one 60Hz
-// frame: attn renders GPU terminals beside agents that run all day, so a single
-// document write quietly costing a frame's worth of CPU in background query work
-// is a defect worth a line in the log. A healthy fan-out is microseconds, which
-// makes this a tripwire rather than a threshold — only something broken, or
-// something that has outgrown this design, ever feels it.
+// Two tripwires. slowDocQuery: a one-shot query this slow is pathological with
+// every declared field indexed. slowDocFanOut matters more — a live query re-runs
+// per committed write, so the cost is one query times the watching subscriptions,
+// invisible to any per-query threshold. Its budget is one 60Hz frame; a healthy
+// fan-out is microseconds.
 const (
 	slowDocQuery  = 50 * time.Millisecond
 	slowDocFanOut = 16 * time.Millisecond
@@ -299,11 +243,10 @@ func (d *Daemon) logSlowDocQuery(schema docstore.CollectionSchema, took time.Dur
 		d.documentCountFor(schema), slowDocQuery)
 }
 
-// logSlowDocFanOut reports what one write to this collection costs across every
-// subscription watching it, which is the number that grows as extensions arrive.
+// logSlowDocFanOut reports what one write costs across every subscription
+// watching this collection.
 func (d *Daemon) logSlowDocFanOut(sub *docSubscription, schema docstore.CollectionSchema, took time.Duration) {
-	// The first delivery answers the subscribe rather than a write, so it has
-	// woken nobody and prices as one.
+	// The first delivery answers the subscribe, not a write; prices as one.
 	subs := sub.siblings.Load()
 	if subs < 1 {
 		subs = 1
@@ -347,22 +290,15 @@ func (d *Daemon) collectionFor(namespace, collection string) (*docstore.Collecti
 	return schema, nil
 }
 
-// undeclaredCollectionError is what every caller reports for a collection that
-// was never declared, whether it read the declaration itself or had a query come
-// back saying there was none. It is typed so sendDocError can put a code beside
-// the text without matching on the text.
+// undeclaredCollectionError is the one error every caller reports for a
+// never-declared collection; typed so sendDocError codes it without text matching.
 func undeclaredCollectionError(namespace, collection string) error {
 	return &docstore.UndeclaredCollectionError{Namespace: namespace, Collection: collection}
 }
 
-// sendDocError is the document store's one error path. It turns the typed
-// errors docstore raises into the machine-readable code beside the message —
-// which is the whole point of them being types: an SDK retry loop must be able
-// to tell "conflict, read it again" from "broken, stop", and a UI host must be
-// able to tell "this collection is gone, kill the tile" from "that query was
-// wrong". Neither may do it by matching English, including here.
-//
-// The message text is unchanged and stays the part a human or an agent reads.
+// sendDocError is the document store's one error path: typed docstore errors
+// become machine-readable codes beside the message. Consumers must never match
+// on the English — including here.
 func (d *Daemon) sendDocError(conn net.Conn, err error) {
 	d.sendDocErrorAs(conn, err, docErrorCode(err))
 }
@@ -380,13 +316,9 @@ func docErrorCode(err error) string {
 	return ""
 }
 
-// subscriptionEndCode is the code the SAME errors carry once a subscription has
-// been accepted, where they mean something different. Answering a request,
-// "this collection is not declared" and "this query is wrong" are both things
-// the caller got wrong. Ending an accepted subscription they are things that
-// happened TO it — the collection was removed, or redeclared without a field
-// the query uses — and a UI host has to tell those apart to know whether to
-// kill the tile or rewrite its query.
+// subscriptionEndCode is the code the SAME errors carry once a subscription is
+// accepted: no longer "you got it wrong" but "this happened TO it" — removed vs
+// redeclared — which a UI host must tell apart.
 func subscriptionEndCode(err error) string {
 	switch {
 	case docstore.IsUndeclaredCollection(err):
@@ -418,9 +350,7 @@ func (d *Daemon) sendDocErrorAs(conn net.Conn, err error, code string) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// IPC handlers
-// ---------------------------------------------------------------------------
+// IPC handlers.
 
 func (d *Daemon) handleDocDefine(conn net.Conn, msg *protocol.DocDefineMessage) {
 	schema := collectionSchemaFromProtocol(msg.Schema)
@@ -437,10 +367,8 @@ func (d *Daemon) handleDocDefine(conn net.Conn, msg *protocol.DocDefineMessage) 
 		d.sendDocError(conn, err)
 		return
 	}
-	// A first declaration has no watchers — nothing could subscribe to a
-	// collection that did not exist. A redeclare can, and they must hear about
-	// it now: a live query parked on its wake channel would otherwise hold a
-	// stale window until an unrelated write happened to land, or forever.
+	// A first declaration has no watchers; a redeclare can, and they must hear
+	// now or hold a stale window until an unrelated write — or forever.
 	if redeclared {
 		d.publishCollectionRedeclared(schema.Namespace, schema.Collection)
 	}
@@ -460,8 +388,7 @@ func (d *Daemon) handleDocUndefine(conn net.Conn, msg *protocol.DocUndefineMessa
 		d.sendDocError(conn, err)
 		return
 	}
-	// Every removed document is a change its watchers must see; without this a
-	// live query would keep showing records the store no longer holds.
+	// Watchers must see the removal or keep showing records the store no longer holds.
 	d.coalesceSnapshots(func() {
 		d.publishCollectionRemoved(msg.Namespace, msg.Collection, removed)
 	})
@@ -507,13 +434,9 @@ func (d *Daemon) handleDocPut(conn net.Conn, msg *protocol.DocPutMessage) {
 		d.sendDocError(conn, err)
 		return
 	}
-	// The write and its fact are one commit, so the seq that comes back is the
-	// write's position: a caller can compare it against the `as_of_seq` of any
-	// later read and know whether that read includes this write.
-	//
-	// A refused write publishes nothing: the store did not change, and waking
-	// every live query on the collection to re-render an identical result set is
-	// exactly the cost the conditional write exists to avoid.
+	// The write and its fact are one commit, so the returned seq is the write's
+	// position (comparable against any later read's as_of_seq). A refused write
+	// publishes nothing — the store did not change.
 	fact := documentChangedFact(msg.Namespace, msg.Collection, msg.ID, false)
 	written, err := d.store.CommitDocumentWrite(store.DocumentWrite{
 		Schema: *schema, ID: msg.ID, Body: []byte(msg.Body), Expected: expectedRev(msg.ExpectedRev),
@@ -532,9 +455,7 @@ func (d *Daemon) handleDocPut(conn net.Conn, msg *protocol.DocPutMessage) {
 	})
 }
 
-// expectedRev converts the wire's optional revision to the store's. The wire
-// carries safeint, which generates as int; the store keeps int64 so the SQL side
-// is the same width on every platform.
+// expectedRev converts the wire's optional int revision to the store's int64.
 func expectedRev(wire *int) *int64 {
 	if wire == nil {
 		return nil
@@ -556,9 +477,8 @@ func (d *Daemon) handleDocGet(conn net.Conn, msg *protocol.DocGetMessage) {
 		d.sendDocError(conn, err)
 		return
 	}
-	// One transaction for the declaration, the row and the log position, so the
-	// position names the state the document was read from rather than whatever
-	// the log reached by the time a second read got there.
+	// One transaction for declaration, row, and log position, so the position
+	// names the state the document was read from.
 	read, declared, err := d.store.ReadDocument(msg.Namespace, msg.Collection, msg.ID)
 	if err != nil {
 		d.sendDocError(conn, err)
@@ -582,9 +502,8 @@ func (d *Daemon) handleDocDelete(conn net.Conn, msg *protocol.DocDeleteMessage) 
 		d.sendDocError(conn, err)
 		return
 	}
-	// A delete that removed nothing changed nothing: the store appends no fact
-	// for it, so it must not wake a subscription with a result set identical to
-	// the one it already has, and it has no position to report.
+	// A delete that removed nothing appends no fact, wakes nobody, and has no
+	// position to report.
 	fact := documentChangedFact(msg.Namespace, msg.Collection, msg.ID, true)
 	written, err := d.store.CommitDocumentWrite(store.DocumentWrite{
 		Schema: *schema, ID: msg.ID, Delete: true, Expected: expectedRev(msg.ExpectedRev),
@@ -623,10 +542,9 @@ func (d *Daemon) handleDocQuery(conn net.Conn, msg *protocol.DocQueryMessage) {
 	}})
 }
 
-// handleDocCount answers how many documents match, using the same compile the
-// query itself uses. A caller that only wants the number — a badge, a "showing
-// 20 of N" — must not have to fetch bodies to count them, and cannot count
-// past the limit if it does.
+// handleDocCount answers how many documents match, via the same compile the
+// query uses — a badge must not fetch bodies to count, and cannot count past
+// the limit if it does.
 func (d *Daemon) handleDocCount(conn net.Conn, msg *protocol.DocCountMessage) {
 	q, err := documentQueryFromProtocol(msg.Query)
 	if err != nil {
@@ -661,17 +579,10 @@ func (d *Daemon) handleDocCount(conn net.Conn, msg *protocol.DocCountMessage) {
 	}})
 }
 
-// handleDocSubscribe is the only handler that keeps its connection. It writes
-// the query's current window immediately — a subscriber must be able to render
-// from one round trip, which is what makes an extension UI's remount cheap — and
-// then a fresh one every time a write to the collection could have changed it.
-// It ends when the caller disconnects, or when the collection stops being able
-// to answer the query at all.
-//
-// A delivery is a window, not a result set: the ids in order, plus only the
-// bodies the subscriber does not already hold. What it holds comes from `have`
-// on the way in and from what has been delivered since, tracked below as one
-// {id: rev} map. See DocSubscribeResult on the wire for the client's one rule.
+// handleDocSubscribe is the only handler that keeps its connection: the current
+// window immediately, then a fresh one per relevant write, ending on disconnect
+// or when the collection can no longer answer. A delivery is ids in order plus
+// only the bodies the subscriber does not hold, tracked as one {id: rev} map.
 func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMessage) {
 	q, err := documentQueryFromProtocol(msg.Query)
 	if err != nil {
@@ -685,44 +596,27 @@ func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMes
 		return
 	}
 
-	// Registered before the first query runs. The other order drops a write that
-	// lands in between; this order can only cause one redundant delivery, which
-	// costs the subscriber an ids-only message.
+	// Registered before the first query: the other order drops a write landing
+	// in between; this one only risks a redundant ids-only delivery.
 	sub := d.addDocSubscription(q)
 	defer d.removeDocSubscription(sub.id)
 
-	// The caller never speaks again after subscribing, so anything the read
-	// returns — EOF, reset, the daemon closing the listener — means it is gone.
+	// The caller never speaks again, so anything the read returns means gone.
 	gone := make(chan struct{})
 	go func() {
 		defer close(gone)
 		_, _ = io.Copy(io.Discard, conn)
 	}()
 
-	// What the subscriber holds. Seeded from `have`, then replaced by each
-	// delivered window: the client's forget rule means anything absent from a
-	// window's order is gone from its cache too, so this map is the window and
-	// never grows past the query's limit.
+	// What the subscriber holds: seeded from `have`, replaced by each delivered
+	// window, never growing past the query's limit.
 	held := heldRevisions(msg.Have)
 
 	encoder := json.NewEncoder(conn)
 	for delivery := 1; ; delivery++ {
-		// Every delivery re-reads the declaration rather than capturing it,
-		// because it can go out from under a subscription in two ways and both
-		// have to end the subscription rather than mislead it. Undefining drops
-		// the collection's table, and an empty result set would tell a watcher
-		// the collection is still there holding nothing; redeclaring without a
-		// field this query uses drops that field's column, and the query stops
-		// meaning what the caller asked. Either way the caller is told which, and
-		// the subscription ends instead of hanging on a collection it can never
-		// serve again. The re-read happens inside the query's own transaction, so
-		// a redeclare cannot land between reading the declaration and running the
-		// statement compiled from it.
-		//
-		// The first of these reads is also the acceptance check: a query that
-		// cannot be answered fails the subscribe, in the same call that would
-		// have served it. There is no separate compile up front, because a second
-		// compile path is a second place for the rules to be applied differently.
+		// Re-read the declaration per delivery (inside the query's transaction): an
+		// undefine or a field-dropping redeclare must END the subscription, told
+		// apart by code, rather than answer an empty or silently changed window.
 		read, took, err := d.runDocQuery(q)
 		if err != nil {
 			code := docErrorCode(err)
@@ -746,11 +640,9 @@ func (d *Daemon) handleDocSubscribe(conn net.Conn, msg *protocol.DocSubscribeMes
 	}
 }
 
-// heldRevisions turns the subscriber's declared `have` into the map the
-// delivery loop diffs against. A resume is exact rather than approximate: an id
-// claiming a revision the store never issued simply differs from the one it
-// finds, so that body is sent and the subscriber converges on the next delivery
-// however stale its claim was.
+// heldRevisions turns the subscriber's declared `have` into the diff map. A
+// stale or invented claim simply differs from what the store finds, so the body
+// is re-sent and the subscriber converges.
 func heldRevisions(have []protocol.DocumentRevision) map[string]int64 {
 	if len(have) == 0 {
 		return nil
@@ -762,10 +654,8 @@ func heldRevisions(have []protocol.DocumentRevision) map[string]int64 {
 	return held
 }
 
-// windowDelivery turns a read into one delivery and the revisions the subscriber
-// holds once it applies it. A body travels only when the subscriber's revision
-// for that id differs from the stored one; everything else is carried by order,
-// which the client renders from its cache.
+// windowDelivery turns a read into one delivery plus the revisions held after
+// applying it; a body travels only when the subscriber's revision differs.
 func windowDelivery(delivery int, read store.QueryRead, held map[string]int64) (*protocol.DocSubscribeResult, map[string]int64) {
 	out := &protocol.DocSubscribeResult{
 		Delivery: delivery,
@@ -790,9 +680,7 @@ func (d *Daemon) sendDocResponse(conn net.Conn, resp protocol.Response) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Wire mapping
-// ---------------------------------------------------------------------------
+// Wire mapping.
 
 func collectionSchemaFromProtocol(s protocol.DocumentCollectionSchema) docstore.CollectionSchema {
 	out := docstore.CollectionSchema{Namespace: s.Namespace, Collection: s.Collection}
@@ -814,9 +702,9 @@ func collectionSchemaToProtocol(s docstore.CollectionSchema) protocol.DocumentCo
 	return out
 }
 
-// documentQueryFromProtocol decodes a wire query. A filter's bound arrives as
-// JSON text because it is the one polymorphic leaf; decoding it here is what
-// lets docstore check it against the field's declared type.
+// documentQueryFromProtocol decodes a wire query; a filter's bound arrives as
+// JSON text (the one polymorphic leaf) and is decoded here so docstore can
+// type-check it.
 func documentQueryFromProtocol(q protocol.DocumentQuery) (docstore.Query, error) {
 	out := docstore.Query{Namespace: q.Namespace, Collection: q.Collection}
 	for _, f := range q.Filters {

--- a/internal/daemon/fs_index.go
+++ b/internal/daemon/fs_index.go
@@ -12,20 +12,13 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-// maxFsIndexEntries bounds a single fs_index walk. It is a server-side
-// constant, not a client-controlled limit — the ⌘P finder needs a bound that
-// cannot be widened by a request, so a walk that would exceed it stops early
-// and reports truncated=true instead of returning a partial-but-unbounded
-// list.
+// maxFsIndexEntries bounds a single fs_index walk. Server-side on purpose — no
+// request may widen it; an over-cap walk stops early and reports truncated=true.
 const maxFsIndexEntries = 25000
 
-// handleFsIndex resolves rawRoot through resolveFsRoot — the same chokepoint
-// every other fs_* command uses, so fs_index inherits the auth gate (an
-// explicit root is honored only for the authenticated app client; an
-// omitted/empty root always resolves to the notebook root) with no separate
-// check here — then enumerates it bounded by maxFsIndexEntries. extensions
-// filters the result server-side (see indexRoot). Replies with an
-// fs_index_result event correlated by requestID.
+// handleFsIndex resolves rawRoot through resolveFsRoot — the chokepoint every
+// fs_* command uses, so it inherits the auth gate with no separate check here —
+// then enumerates it. Replies with fs_index_result correlated by requestID.
 func (d *Daemon) handleFsIndex(client *wsClient, requestID, rawRoot string, extensions []string) {
 	var files []string
 	var truncated bool
@@ -79,12 +72,9 @@ func matchesExtension(name string, extensions []string) bool {
 	return false
 }
 
-// skippedPath reports whether a root-relative slash path lives inside a
-// directory no file surface should ever offer. Only git's own metadata
-// qualifies: dot-prefixed documents like .claude/notes.md are real files a user
-// can open, and path mode (listDirectoryEntries) lists them, so fuzzy mode
-// hiding them would make the same file reachable one way and invisible the
-// other. See skippedDirName for the shared rule.
+// skippedPath reports whether a root-relative slash path lives inside a skipped
+// directory. Only .git qualifies: path mode (listDirectoryEntries) lists
+// dot-prefixed documents, so fuzzy mode hiding them would break surface parity.
 func skippedPath(rel string) bool {
 	for _, segment := range strings.Split(rel, "/") {
 		if skippedDirName(segment) {
@@ -94,36 +84,20 @@ func skippedPath(rel string) bool {
 	return false
 }
 
-// skippedDirName is the one rule both file surfaces apply: .git holds git's
-// object database, not documents, and listing it is noise at best. Everything
-// else — including dot-directories — stays visible.
+// skippedDirName is the one rule both file surfaces apply; everything else —
+// including dot-directories — stays visible.
 func skippedDirName(name string) bool {
 	return name == ".git"
 }
 
-// indexRoot enumerates the files under root, returning their root-relative
-// slash paths sorted lexicographically plus whether the enumeration was
-// truncated at cap entries. extensions (dotless, case-insensitive) filter the
-// result, and the cap applies AFTER filtering — otherwise a large repository
-// exhausts the cap on files nobody asked for and the documents being searched
-// for silently vanish from the tail of the alphabet.
+// indexRoot enumerates files under root as sorted root-relative slash paths,
+// git-first with a tree-walk fallback. The cap applies AFTER extension
+// filtering — otherwise unasked-for files exhaust it and matches silently
+// vanish; cap is injected so tests can exercise truncation cheaply.
 //
-// Inside a git repository the file list comes from git (tracked files plus
-// untracked-but-not-ignored ones), which honors .gitignore and reads an index
-// git already maintains instead of stat-ing the whole tree. Outside one — or
-// if git fails for any reason — it falls back to walking the tree.
-//
-// cap is injected so tests can exercise truncation with a tiny value instead
-// of the real maxFsIndexEntries.
-//
-// normalizeExternalRoot only canonicalizes the deepest EXISTING ancestor, so a
-// root that does not exist (or a root that is a file, not a directory) can
-// still pass resolveFsRoot. Without an explicit check here, WalkDir's first
-// callback invocation for such a root fires with a non-nil err and a nil
-// DirEntry, the generic "skip and continue" branch below treats that as
-// nothing-to-walk, and the whole call silently succeeds with zero files —
-// fs_index would report success+empty for a root fs_list correctly errors on.
-// Stat first and fail loudly instead.
+// The Stat is load-bearing: a nonexistent or non-directory root can pass
+// resolveFsRoot, and WalkDir's skip-and-continue branch would turn it into a
+// silent success with zero files. Fail loudly instead.
 func indexRoot(root string, cap int, extensions []string) ([]string, bool, error) {
 	info, err := os.Stat(root)
 	if err != nil {
@@ -139,13 +113,10 @@ func indexRoot(root string, cap int, extensions []string) ([]string, bool, error
 	return indexRootViaWalk(root, cap, wanted)
 }
 
-// indexRootViaGit lists root's files through `git ls-files`, run inside root so
-// paths come back relative to it. ok=false means git could not answer (root is
-// not in a repository, git is missing, the command failed or timed out) and the
-// caller should fall back to walking.
+// indexRootViaGit lists root's files through `git ls-files`; ok=false means git
+// could not answer and the caller should fall back to walking.
 func indexRootViaGit(root string, cap int, extensions []string) (files []string, truncated bool, ok bool) {
-	// -z: NUL-separated, so paths with spaces, newlines, or non-ASCII bytes
-	// come back verbatim instead of git's quoted form.
+	// -z: NUL-separated, so odd bytes come back verbatim, not git-quoted.
 	out, err := git.Output(git.OpMetadata, root,
 		"ls-files", "-z", "--cached", "--others", "--exclude-standard")
 	if err != nil {
@@ -160,9 +131,8 @@ func indexRootViaGit(root string, cap int, extensions []string) (files []string,
 		if _, dup := seen[rel]; dup {
 			continue
 		}
-		// git lists index entries, which include symlinks, submodule gitlinks,
-		// and files deleted from the working tree. fs_read only serves regular
-		// files, so drop anything else rather than advertising it as openable.
+		// Index entries include symlinks, gitlinks, and deleted files; fs_read
+		// only serves regular files, so drop anything else.
 		info, statErr := os.Lstat(filepath.Join(root, filepath.FromSlash(rel)))
 		if statErr != nil || !info.Mode().IsRegular() {
 			continue
@@ -178,22 +148,15 @@ func indexRootViaGit(root string, cap int, extensions []string) (files []string,
 	return files, truncated, true
 }
 
-// indexRootViaWalk walks root recursively. It skips .git (see skippedDirName)
-// and node_modules — not descended at all, since a dependency tree's documents
-// are not the user's — plus any non-regular-file entry — symlinks, FIFOs,
-// sockets, device nodes — via DirEntry.Type().IsRegular(), a no-syscall
-// type-bits check (a symlinked dir is also never descended by WalkDir). This
-// matters beyond symlinks: a FIFO or socket that slipped into the list would be
-// advertised as an openable file when fs_read rejects anything that isn't a
-// regular file. A per-entry walk error (e.g. permission denied) skips that
+// indexRootViaWalk walks root recursively, skipping .git and node_modules and
+// every non-regular entry — a FIFO or socket in the list would be advertised as
+// openable when fs_read rejects it. A per-entry walk error skips that
 // entry/subtree without failing the whole index.
 func indexRootViaWalk(root string, cap int, extensions []string) ([]string, bool, error) {
 	var files []string
 	truncated := false
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			// Skip the entry (and, for a directory, its subtree) rather than
-			// aborting the whole walk on one permission-denied or similar error.
 			if d != nil && d.IsDir() {
 				return fs.SkipDir
 			}

--- a/internal/daemon/host_session.go
+++ b/internal/daemon/host_session.go
@@ -15,16 +15,9 @@ import (
 	"github.com/victorarias/attn/internal/ptybackend"
 )
 
-// Conversation sessions: attn sessions whose agent runs in a headless host
-// process instead of a PTY. The daemon owns the host's lifetime exactly as it
-// owns a PTY worker's; what changes is the surface. There are no bytes, no
-// grid, and no attach — there is an envelope stream the app draws from and a
-// prompt verb going the other way.
-//
-// A plugin driver opts its agent in by registering the "conversation"
-// capability. Everything else about the spawn — argv, env, cwd — comes back
-// from the same driver.spawn call a PTY-backed plugin agent uses, so a
-// conversation agent is configured, listed, and launched like any other.
+// Conversation sessions: the agent runs in a headless host process instead of a
+// PTY — no bytes, grid, or attach, just an envelope stream out and a prompt verb
+// in. A plugin driver opts in via the "conversation" capability.
 
 // pluginDriverConversationCapability is the driver capability that routes an
 // agent's sessions to the host runtime instead of the PTY backend.
@@ -50,11 +43,8 @@ func (d *Daemon) isHostSession(sessionID string) bool {
 	return d.ensureHostSessions().Has(sessionID)
 }
 
-// liveRuntimeSessionIDs is every session with a runtime behind it, PTY-backed
-// or host-backed. Anything that asks "is this session still alive?" — pruning
-// dead rows, reconciling workspace panes, tearing everything down — must ask
-// this and not the PTY backend alone, or a live conversation session reads as
-// abandoned.
+// liveRuntimeSessionIDs is every session with a runtime behind it, PTY- or
+// host-backed. Liveness checks must ask this, never the PTY backend alone.
 func (d *Daemon) liveRuntimeSessionIDs(ctx context.Context) []string {
 	var ids []string
 	if d.ptyBackend != nil {
@@ -63,24 +53,19 @@ func (d *Daemon) liveRuntimeSessionIDs(ctx context.Context) []string {
 	return append(ids, d.ensureHostSessions().SessionIDs()...)
 }
 
-// hostSessionLogPath keeps a host's own stdout/stderr beside the PTY worker
-// logs, one file per session, so a wedged host is diagnosable the same way a
-// wedged worker is.
+// hostSessionLogPath keeps a host's stdout/stderr beside the PTY worker logs,
+// one file per session.
 func hostSessionLogPath(sessionID string) string {
 	return filepath.Join(config.DataDir(), "hosts", "log", sessionID+".log")
 }
 
-// hostSessionStateDir is where a host keeps whatever it persists for the
-// session — for pi, its own session file. Under attn's data dir, never the
-// agent's own home, so attn owns what it spawned.
+// hostSessionStateDir is under attn's data dir, never the agent's own home.
 func hostSessionStateDir(sessionID string) string {
 	return filepath.Join(config.DataDir(), "hosts", "state", sessionID)
 }
 
 // loginShellEnvForSpawn is the user's login shell environment, captured now if
-// the daemon's pre-warm has not landed yet. The PTY path makes the same
-// fallback, for the same reason: the first session of a daemon's life must not
-// get a thinner environment than the second.
+// the pre-warm has not landed, so the first session matches the second.
 func (d *Daemon) loginShellEnvForSpawn() []string {
 	if cached := d.cachedLoginShellEnv(); len(cached) > 0 {
 		return cached
@@ -97,16 +82,10 @@ func (d *Daemon) loginShellEnvForSpawn() []string {
 	return env
 }
 
-// spawnHostSession starts the host for a conversation session. It takes the
-// same launch description the PTY path would have run.
+// spawnHostSession starts the host for a conversation session.
 func (d *Daemon) spawnHostSession(opts ptybackend.SpawnOptions) error {
-	// A host gets the same environment a PTY agent gets, layered the same way:
-	// the daemon's own environment, then the user's login shell on top. Agents
-	// read credentials from there — an API key exported in a shell profile is
-	// the ordinary way pi is authenticated — and a host launched from the app
-	// (which the window server starts with almost no environment) would
-	// otherwise fail its first prompt with "no API key found" for a key the
-	// user has had set for years.
+	// Daemon env, then login shell on top: credentials live in shell profiles and
+	// an app-launched host would otherwise fail its first prompt with "no API key".
 	env := pty.MergeEnvironment(os.Environ(), d.loginShellEnvForSpawn())
 	env = pty.MergeEnvironment(env, opts.ExternalEnv)
 	env = pty.MergeEnvironment(env, []string{
@@ -129,9 +108,6 @@ func (d *Daemon) spawnHostSession(opts ptybackend.SpawnOptions) error {
 }
 
 // spawnSessionRuntime starts whichever runtime this session's agent asked for.
-// It is the one fork in the spawn pipeline: everything before it (validation,
-// launch intent, the driver's argv) and everything after it (the session row,
-// panes, facts) is identical for both kinds.
 func (d *Daemon) spawnSessionRuntime(req *spawnRequest, opts ptybackend.SpawnOptions) error {
 	if req.hasPluginDriver && req.pluginDriver.Capabilities[pluginDriverConversationCapability] {
 		return d.spawnHostSession(opts)
@@ -139,8 +115,7 @@ func (d *Daemon) spawnSessionRuntime(req *spawnRequest, opts ptybackend.SpawnOpt
 	return d.ptyBackend.Spawn(context.Background(), opts)
 }
 
-// killSessionRuntime stops a session's runtime, whichever kind it is. Used by
-// the spawn pipeline's rollbacks, where the session may be either.
+// killSessionRuntime stops a session's runtime, whichever kind it is.
 func (d *Daemon) killSessionRuntime(sessionID string) error {
 	if d.isHostSession(sessionID) {
 		if err := d.ensureHostSessions().Kill(sessionID); err != nil && !errors.Is(err, hostsession.ErrNotFound) {
@@ -160,12 +135,8 @@ func (d *Daemon) removeSessionRuntime(sessionID string) error {
 	return d.ptyBackend.Remove(context.Background(), sessionID)
 }
 
-// handleHostEvent forwards one envelope to every connected client.
-//
-// This is a stream, not a state change: it takes the same direct path
-// pty_output does rather than riding the event bus. The daemon's picture of a
-// session must be complete without reading one of these, which is why nothing
-// here writes to the store.
+// handleHostEvent forwards one envelope to every connected client. A stream, not
+// a state change: pty_output's direct path, not the bus, and no store writes.
 func (d *Daemon) handleHostEvent(event hostsession.Event) {
 	d.wsHub.BroadcastValue(&protocol.AgentEventMessage{
 		Event: protocol.EventAgentEvent,
@@ -176,8 +147,7 @@ func (d *Daemon) handleHostEvent(event hostsession.Event) {
 	})
 }
 
-// handleHostExit routes a dead host into the same exit path a dead PTY worker
-// takes: the session's end is the session's end, whatever was running it.
+// handleHostExit routes a dead host into the same exit path a dead PTY worker takes.
 func (d *Daemon) handleHostExit(info hostsession.ExitInfo) {
 	d.handlePTYExit(ptybackend.ExitInfo{
 		ID:          info.SessionID,
@@ -202,10 +172,8 @@ func (d *Daemon) handleAgentPrompt(client *wsClient, msg *protocol.AgentPromptMe
 	if err := d.ensureHostSessions().Prompt(sessionID, text); err != nil {
 		d.logf("agent_prompt for session %s failed: %v", sessionID, err)
 		d.sendCommandError(client, protocol.CmdAgentPrompt, "no live conversation host for session "+sessionID)
-		// The app closes its composer the moment it sends, so a prompt that
-		// never reached a host has to come back as the run it will never open.
-		// seq 0 says this is the daemon's own envelope rather than a point on
-		// the host's spine, which is why it cannot collide with one.
+		// The app closed its composer on send, so a prompt that never reached a host
+		// comes back as the run it will never open; seq 0 marks a daemon envelope.
 		d.handleHostEvent(hostsession.Event{
 			SessionID: sessionID,
 			Kind:      "run_settled",

--- a/internal/daemon/legacy_task_import.go
+++ b/internal/daemon/legacy_task_import.go
@@ -8,17 +8,10 @@ import (
 	"github.com/victorarias/attn/internal/store"
 )
 
-// One-time handover from the retired durable task runner (internal/tasks) to the
-// job queue. The task runner stored its records in the `tasks` table with a
-// `kind:subject` id and a flat map[string]string of inputs; the queue stores a
-// uuid id, a coalescing key, and a typed JSON payload. This carries anything the
-// old runner still owed onto the new table and empties the old one, so the whole
-// path is a no-op on every boot after the first.
-//
-// Legacy meta keys are written out literally here rather than shared with the
-// enqueue sites. They describe a format nothing writes anymore, so pinning them
-// to this file is what lets the live payload types change without silently
-// breaking the import.
+// One-time handover from the retired task runner's `tasks` table to the job
+// queue; a no-op on every boot after the first. The legacy meta keys are pinned
+// here literally, not shared with the enqueue sites: they describe a format
+// nothing writes anymore, so live payload types can change without breaking this.
 const (
 	legacyMetaTranscript      = "transcript"
 	legacyMetaWorkspace       = "workspace"
@@ -26,13 +19,10 @@ const (
 	legacyMetaReconcileInputs = "reconcile_inputs"
 )
 
-// importLegacyTasks hands the task table's remaining rows to the jobs table. It
-// runs before the queue is constructed, so nothing races it.
-//
-// The move is atomic in the store (see MigrateLegacyTasks): a failure anywhere
-// leaves every old row where it was, and the next start tries again. That
-// matters more here than anywhere else in the queue — this path runs exactly
-// once per installation, and the work it carries has no other copy.
+// importLegacyTasks hands the task table's remaining rows to the jobs table.
+// Runs before the queue is constructed, so nothing races it; the move is atomic
+// in the store (MigrateLegacyTasks), so any failure leaves every old row intact
+// for the next start to retry.
 func (d *Daemon) importLegacyTasks() {
 	if d.store == nil {
 		return
@@ -48,19 +38,11 @@ func (d *Daemon) importLegacyTasks() {
 	}
 }
 
-// legacyTaskToJob is the job one legacy row becomes. It runs inside the
-// handover's transaction and always returns a record, because a row it cannot
-// fully read is still owed work.
-//
-// The legacy id is PRESERVED as the job id. A dead task's failure notification
-// records that id as its SourceID, and the panel's Retry deep-links through it —
-// minting a fresh uuid would leave every pre-upgrade failure notification
-// pointing at nothing.
-//
-// A row whose meta cannot be translated becomes a job without a payload rather
-// than being dropped: the record stays visible in the panel and its handler
-// reports the missing inputs, which is a diagnosable outcome. Silently
-// discarding owed work is not.
+// legacyTaskToJob is the job one legacy row becomes; it always returns a record,
+// because a row it cannot fully read is still owed work. The legacy id is
+// PRESERVED as the job id — failure notifications record it as SourceID and the
+// panel's Retry deep-links through it. Untranslatable meta yields a payload-less
+// job, never a dropped row: its handler reports the missing inputs.
 func (d *Daemon) legacyTaskToJob(rec store.LegacyTaskRecord) store.JobRecord {
 	payload, err := legacyTaskPayload(rec)
 	if err != nil {
@@ -86,9 +68,7 @@ func (d *Daemon) legacyTaskToJob(rec store.LegacyTaskRecord) store.JobRecord {
 }
 
 // legacyTaskPayload translates one legacy meta blob into the payload its kind's
-// handler now decodes. An empty string means "carries nothing", which every
-// handler already tolerates. Kinds with no meta (compact_context) and rows that
-// stored none return that empty payload with no error.
+// handler now decodes; empty string means "carries nothing", which handlers tolerate.
 func legacyTaskPayload(rec store.LegacyTaskRecord) (string, error) {
 	raw := strings.TrimSpace(rec.MetaJSON)
 	if raw == "" || raw == "null" {
@@ -102,9 +82,8 @@ func legacyTaskPayload(rec store.LegacyTaskRecord) (string, error) {
 	switch rec.Kind {
 	case notebookSummarizeSessionKind:
 		p := summarizeSessionPayload{Transcript: meta[legacyMetaTranscript]}
-		// The pointer distinguishes "carried, and it is empty" (a solo session,
-		// bound for the _solo bucket) from "carried nothing" (fall back to the live
-		// session row), so it is set only when the key was actually present.
+		// Pointer set only when the key was present: "carried empty" (solo bucket)
+		// vs "carried nothing" (fall back to the live session row).
 		if ws, ok := meta[legacyMetaWorkspace]; ok {
 			p.WorkspaceID = &ws
 		}
@@ -115,9 +94,7 @@ func legacyTaskPayload(rec store.LegacyTaskRecord) (string, error) {
 		}
 		payload = narrateWorkspacePayload{DailyPass: true}
 	case reconcileKind:
-		// The reconcile inputs were already a JSON object nested inside the meta
-		// map, and the payload is that same object — carry it across verbatim
-		// rather than decoding and re-encoding it.
+		// Already the payload's JSON object; carry it across verbatim.
 		return meta[legacyMetaReconcileInputs], nil
 	default:
 		return "", nil

--- a/internal/daemon/notebook_cron.go
+++ b/internal/daemon/notebook_cron.go
@@ -10,66 +10,47 @@ import (
 	"github.com/victorarias/attn/internal/notebook"
 )
 
-// Notebook cron.
-//
-// A single per-minute, timezone-aware tick drives the notebook's scheduled
-// background work. The tick is a thin schedule-and-dispatch step: it decides what
-// is due and enqueues onto the durable queue (internal/jobs), which owns
-// execution, single-flight, retry/backoff, and crash recovery. Today it dispatches
-// the daily per-workspace narrate backstop (enqueueDueDailyNarrates). The minute
-// granularity is ample for a nightly pass and keeps catch-up logic trivial.
-//
-// The tick itself is a cron entry on that same queue, so its next fire is durable
-// and visible in the background-work panel rather than living in a goroutine.
+// Notebook cron: a single per-minute, timezone-aware tick that decides what is
+// due and enqueues onto the durable queue (internal/jobs), which owns execution.
+// The tick itself is a cron entry on that same queue, so its next fire is
+// durable and visible rather than living in a goroutine.
 
 const (
 	// notebookCronKind is the queue kind for the per-minute notebook tick.
 	notebookCronKind = "notebook_cron"
 
-	// defaultNotebookCronFrequency is the nightly slot (03:00 in the configured
-	// timezone — quiet hours, after a day's journals and dispatches have landed)
-	// the notebook cron fires on by default.
+	// defaultNotebookCronFrequency is the default nightly slot (03:00 in the
+	// configured timezone — quiet hours).
 	defaultNotebookCronFrequency = "0 3 * * *"
 
-	// defaultNotebookCronInterval is how often the cron checks whether work is
-	// due. A daily pass does not need finer granularity.
+	// defaultNotebookCronInterval is how often the cron checks whether work is due.
 	defaultNotebookCronInterval = time.Minute
 
-	// notebookCronTickTimeout is a tripwire, not a budget. The tick reads a few
-	// settings, one small state file, and enqueues; it is sub-millisecond work.
-	// A tick still running after this is wedged on something (a hung filesystem,
-	// a store that never returns), and killing it frees the slot for the next
-	// minute's tick instead of stalling the kind forever.
+	// notebookCronTickTimeout is a tripwire, not a budget: the tick is
+	// sub-millisecond work, so a tick still running here is wedged, and killing it
+	// frees the slot for the next minute instead of stalling the kind forever.
 	notebookCronTickTimeout = 30 * time.Second
 )
 
-// legacyNotebookDreaming*Key are the pre-rename persisted settings keys.
-// frequency/timezone are retained ONLY so migrateNotebookCronSettingKeys can copy a
-// user's configured schedule forward to the notebook.cron.* keys; the enabled gate
-// has no cron successor (it died with the dreaming feature) and is only reaped.
-// Never read any of these anywhere else.
+// legacyNotebookDreaming*Key exist ONLY for migrateNotebookCronSettingKeys to
+// copy forward / reap. Never read them anywhere else.
 const (
 	legacyNotebookDreamingFrequencyKey = "notebook.dreaming.frequency"
 	legacyNotebookDreamingTimezoneKey  = "notebook.dreaming.timezone"
 	legacyNotebookDreamingEnabledKey   = "notebook.dreaming.enabled"
 )
 
-// migrateNotebookCronSettingKeys performs the one-time rename of the persisted
-// notebook.dreaming.{frequency,timezone} settings to notebook.cron.* (the schedule
-// outlived the removed dreaming feature) and reaps the orphaned
-// notebook.dreaming.enabled gate (which has no successor). Each rename uses
-// renameSettingKey for the idempotent copy-forward-then-reap contract; it runs at
-// daemon start (and thus again after every app rebuild, since the daemon survives
-// them), so it MUST stay idempotent. This is a plain settings-value copy, NOT a
-// schema migration.
+// migrateNotebookCronSettingKeys renames the persisted notebook.dreaming.*
+// schedule settings to notebook.cron.* and reaps the orphaned enabled gate. It
+// runs at every daemon start, so it MUST stay idempotent. A plain settings-value
+// copy, NOT a schema migration.
 func (d *Daemon) migrateNotebookCronSettingKeys() {
 	if d.store == nil {
 		return
 	}
 	d.renameSettingKey(legacyNotebookDreamingFrequencyKey, SettingNotebookCronFrequency)
 	d.renameSettingKey(legacyNotebookDreamingTimezoneKey, SettingNotebookCronTimezone)
-	// The enabled gate has no cron equivalent — just drop any stale row so it stops
-	// being broadcast in the settings map. DeleteSetting is a no-op when absent.
+	// The enabled gate has no cron equivalent; DeleteSetting is a no-op when absent.
 	d.store.DeleteSetting(legacyNotebookDreamingEnabledKey)
 }
 
@@ -126,50 +107,26 @@ func parseNotebookCronTime(s string) (time.Time, bool) {
 	return time.Time{}, false
 }
 
-// notebookCronHandler is the queue handler for the per-minute notebook tick: the
-// fan-out over whatever the notebook schedules. Today that is the daily
-// per-workspace narrate backstop for long-lived (never-removed) workspaces.
-//
-// It never returns an error. Every step already logs and skips its own failure,
-// and a tick has nothing worth retrying — the next one is a minute away and
-// re-decides from the persisted anchor.
+// notebookCronHandler is the queue handler for the per-minute notebook tick. It
+// never returns an error: a tick has nothing worth retrying — the next one is a
+// minute away and re-decides from the persisted anchor.
 func (d *Daemon) notebookCronHandler(_ context.Context, _ *jobs.Job) (any, error) {
 	d.notebookCronTick(time.Now())
 	return nil, nil
 }
 
-// notebookCronTick is the per-tick fan-out of the single notebook cron. It enqueues
-// a per-active-workspace narrate for long-lived (never-removed) workspaces on the
-// nightly slot.
+// notebookCronTick is the per-tick fan-out of the single notebook cron.
 func (d *Daemon) notebookCronTick(now time.Time) {
 	d.enqueueDueDailyNarrates(now)
 }
 
-// enqueueDueDailyNarrates decides, from the timezone-aware cron and the persisted
-// NarrateCronState anchor, whether the daily per-workspace narrate pass is due now;
-// when it is, it advances the anchor on a SINGLE state write, then drains the
-// activity set and enqueues a coalesced narrate_workspace for each STILL-LIVE
-// workspace that saw activity since the last fire. This is the backstop for the
-// never-removed long-lived workspace, which gets no session-end narrate on a day it
-// had no session stop.
-//
-// The daily narrate fires on the shared notebook-maintenance nightly slot defined by
-// the notebook cron schedule/timezone SETTINGS; a dedicated split can come later.
-// It advances its own anchor whether narration is enabled or not; the per-duty gate
-// at the enqueue seam suppresses agent work while off. The separate state file
-// (NarrateCronState) keeps that schedule independent.
-//
-// Activity gate: only workspaces that saw a session end or a content-changing context
-// write since the last fire are in the set, so idle workspaces are skipped and never
-// burn a strong-tier pass. A removed workspace in the set is skipped too — its
-// removal-boundary final retrospective already ran. An empty set still advances the
-// anchor (consumes the day's slot) and enqueues nothing.
-//
-// Anchoring + catch-up: a first observation with no anchor records "now" and returns
-// (so enabling never fires immediately at startup); a fire advances the anchor to
-// "now" on one write BEFORE draining, so a rare enqueue failure skips one idempotent
-// day rather than re-firing every tick, and missed slots collapse into a single
-// catch-up.
+// enqueueDueDailyNarrates fires the daily per-workspace narrate backstop for
+// long-lived workspaces that saw activity since the last fire; idle workspaces
+// never burn a strong-tier pass. Anchor-FIRST ordering: when due, it advances
+// the persisted anchor on ONE write BEFORE draining/enqueueing, so a rare
+// enqueue failure skips one idempotent day rather than re-firing every tick,
+// and missed slots collapse into a single catch-up. A first observation with no
+// anchor records "now" and returns, so enabling never fires at startup.
 func (d *Daemon) enqueueDueDailyNarrates(now time.Time) {
 	sched, raw, err := d.notebookCronSchedule()
 	if err != nil {
@@ -182,8 +139,8 @@ func (d *Daemon) enqueueDueDailyNarrates(now time.Time) {
 		return
 	}
 
-	// Resolve the runner BEFORE touching state, so a missing/disabled runner never
-	// advances the anchor (which would silently skip the day with no work done).
+	// Resolve the runner BEFORE touching state: a missing/disabled runner must not
+	// advance the anchor and silently skip the day.
 	runner := d.jobQueueRef()
 	if runner == nil || runner.Disabled() {
 		return
@@ -197,8 +154,7 @@ func (d *Daemon) enqueueDueDailyNarrates(now time.Time) {
 
 	anchor, ok := parseNotebookCronTime(state.ScheduledFrom)
 	if !ok {
-		// First observation (or a corrupt anchor): anchor at now so the first pass
-		// lands at the next scheduled slot instead of immediately at startup.
+		// First observation (or corrupt anchor): anchor at now, fire at the next slot.
 		state.ScheduledFrom = now.UTC().Format(time.RFC3339)
 		if err := notebook.SaveNarrateCronState(root, state); err != nil {
 			d.logf("daily narrate: anchor schedule: %v", err)
@@ -209,9 +165,8 @@ func (d *Daemon) enqueueDueDailyNarrates(now time.Time) {
 	loc := d.notebookCronLocation()
 	next := sched.Next(anchor.In(loc))
 	if next.IsZero() {
-		// An unsatisfiable schedule has no next occurrence. Validation rejects these,
-		// but a value persisted by an older daemon could slip through — treat it as
-		// never-due rather than always-due (which would re-narrate every tick).
+		// Unsatisfiable schedule (persisted by an older daemon): treat as never-due
+		// rather than always-due, which would re-narrate every tick.
 		d.logf("daily narrate: frequency %q never occurs; skipping", raw)
 		return
 	}
@@ -219,10 +174,7 @@ func (d *Daemon) enqueueDueDailyNarrates(now time.Time) {
 		return // not due yet
 	}
 
-	// Due: anchor-FIRST ordering. Advance the anchor on ONE state write, THEN drain
-	// and enqueue. If a rare enqueue fails, the advanced anchor skips one day rather
-	// than re-firing every tick; the daily narrate is idempotent (the next trigger
-	// re-narrates), so a skipped day is benign.
+	// Due: advance the anchor on ONE write, THEN drain and enqueue.
 	state.ScheduledFrom = now.UTC().Format(time.RFC3339)
 	if err := notebook.SaveNarrateCronState(root, state); err != nil {
 		d.logf("daily narrate: advance anchor: %v", err)
@@ -230,8 +182,7 @@ func (d *Daemon) enqueueDueDailyNarrates(now time.Time) {
 
 	for _, workspaceID := range d.drainNotebookNarrateActivity() {
 		if d.store.GetWorkspace(workspaceID) == nil {
-			// Removed since it was marked active: its removal-boundary final
-			// retrospective already ran. Skip it.
+			// Removed since marked active: its final retrospective already ran.
 			continue
 		}
 		d.enqueueDailyNarrateWorkspace(workspaceID)
@@ -239,9 +190,7 @@ func (d *Daemon) enqueueDueDailyNarrates(now time.Time) {
 }
 
 // drainNotebookNarrateActivity atomically snapshots and clears the daily-narrate
-// activity set (swapping in a fresh map under the mutex), returning the workspace ids
-// that saw activity since the last fire. Clearing on drain is what makes a later
-// no-activity day enqueue nothing.
+// activity set; clearing on drain is what makes a no-activity day enqueue nothing.
 func (d *Daemon) drainNotebookNarrateActivity() []string {
 	d.notebookNarrateActivityMu.Lock()
 	defer d.notebookNarrateActivityMu.Unlock()

--- a/internal/daemon/notebook_narration.go
+++ b/internal/daemon/notebook_narration.go
@@ -16,21 +16,10 @@ import (
 	"github.com/victorarias/attn/internal/notebook"
 )
 
-// headlessScratchCwd returns a stable, attn-owned working directory used as the
-// cwd for the utility headless agent runs (summarize_session, narrate_workspace).
-//
-// Why a shared stable dir instead of a fresh os.MkdirTemp per run: Claude maps a
-// run's cwd to a ~/.claude/projects/<cwd-hash> entry and, even under
-// --no-session-persistence (which suppresses the .jsonl transcript), still spills
-// large tool outputs there. A unique temp cwd per run therefore minted a new
-// orphaned project dir + tool-results spill on every summarize — they accumulate
-// unboundedly and attn must never reach into ~/.claude to clean them. Reusing one
-// cwd collapses all of these runs onto a single reused project dir.
-//
-// This is collision-free under concurrent runs because these tasks never write
-// into the cwd: their inputs and outputs are all absolute paths (the transcript,
-// the raw digest, the journal — see ExtraWritableRoots at the call sites), and
-// each Claude run still gets its own session-scoped subdir under the project dir.
+// headlessScratchCwd is the stable shared cwd for headless narration runs.
+// Stable, not per-run temp: Claude spills tool outputs under
+// ~/.claude/projects/<cwd-hash>, so unique cwds accumulate orphaned dirs attn
+// must never reach in to clean. Safe to share — these tasks use absolute paths.
 func headlessScratchCwd() (string, error) {
 	dir := filepath.Join(config.DataDir(), "headless-cwd")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -39,107 +28,57 @@ func headlessScratchCwd() (string, error) {
 	return dir, nil
 }
 
-// Notebook narration: two headless agent tasks that turn raw session work into a
-// curated daily work-journal.
-//
-//   - summarize_session (cheap tier): per-session. Reads ONE session transcript and
-//     writes a faithful digest to the raw tier, partitioned by workspace
-//     (RawSessionsDir/<wsID>/<sessionID>.md). Pure machine input for the narrate duty;
-//     high frequency, so it runs on the cheap model.
-//   - narrate_workspace (strong tier): per-workspace, coalesced. Reads the workspace's
-//     digests + context snapshot and writes/refreshes the curated
-//     journal entry for today (journal/<today>.md). The load-bearing product surface.
-//
-// Both are NATIVE-TOOLS tasks: the agent uses its own file tools and writes the
-// target file itself. Unlike the keeper's compaction duty (which reads a candidate
-// back and commits it under a CommitGuard), THE FILE IS THE LEDGER here — the
-// executor's success gate is "did the agent write the target file?" (digest exists /
-// journal contains the workspace marker), not a daemon read-back-and-commit. This is
-// deliberate: the journal is shared and concurrently written by sibling narrate passes and
-// the human, so the daemon must not own a serialize-and-overwrite commit; the agents'
-// native read-before-write CAS is the concurrency control (see the prompt briefs).
-//
-// CONCURRENCY CAVEAT (Codex-backed narrate): Claude's Write/Edit enforce read-before-write
-// staleness rejection, which the shared-journal story depends on. Codex's apply-patch
-// CAS is UNVERIFIED for the installed version, so Claude is the built-in default for
-// both tiers (see notebook_narration_config.go). Codex is NOT hard-gated out — a user
-// may configure it — but a concurrent Codex narrate could in principle clobber a
-// sibling's same-day entry if its patch tooling does not detect the on-disk change.
+// Notebook narration: two headless agent tasks. summarize_session (cheap tier)
+// writes a per-session digest to RawSessionsDir/<wsID>/<sessionID>.md;
+// narrate_workspace (strong tier, coalesced) writes today's curated journal
+// entry. THE FILE IS THE LEDGER — the success gate is "did the agent write the
+// target file", and the agents' read-before-write CAS is the concurrency
+// control over a journal shared with siblings and the human. Codex's
+// apply-patch CAS is UNVERIFIED, so Claude is the built-in default.
 
 const (
-	// notebookSummarizeSessionTimeout bounds one per-session digest run. Reading and
-	// summarizing a single transcript is cheap; a few minutes is ample headroom.
+	// notebookSummarizeSessionTimeout bounds one per-session digest run.
 	notebookSummarizeSessionTimeout = 4 * time.Minute
-	// notebookNarrateWorkspaceTimeout bounds one curated-journal run. The narrate pass
-	// reads many digests + prior entries and writes prose on the strong model, so it
-	// gets a wider budget than the per-session digest.
+	// notebookNarrateWorkspaceTimeout bounds one curated-journal run; wider because
+	// the narrate pass reads many digests and writes prose on the strong model.
 	notebookNarrateWorkspaceTimeout = 8 * time.Minute
-	// notebookNarrationDebounce coalesces the burst of session stops in an active
-	// workspace into a single narrate pass (and collapses a chatty session's repeated
-	// stops into one digest run). The removal-boundary final narrate overrides this
-	// with ZeroDebounce.
+	// notebookNarrationDebounce coalesces a burst of session stops into a single
+	// pass. The removal-boundary final narrate overrides this with ZeroDebounce.
 	notebookNarrationDebounce = 2 * time.Minute
-	// notebookSoloSessionBucket is the RawSessionsDir subdir holding digests for
-	// solo (non-workspace) sessions. It is a reserved name (leading underscore) so
-	// it can never collide with a real workspace id bucket, and rawTierSegment
-	// rejects any workspace id that begins with "." — workspace ids are not allowed
-	// to start with "_" either way in practice, but the underscore keeps the bucket
-	// visually distinct from a workspace dir.
+	// notebookSoloSessionBucket holds digests for solo (non-workspace) sessions.
+	// Reserved name: it can never collide with a real workspace id bucket.
 	notebookSoloSessionBucket = "_solo"
 )
 
-// summarizeSessionPayload carries the summarize_session run's inputs onto the
-// durable job at enqueue time (handleStop), where BOTH the session row and the
-// workspace row still exist. They MUST be carried because the debounced run
-// fires AFTER a single-session-workspace teardown has deleted both rows, so the
-// handler can no longer re-derive the transcript path or the workspace bucket
-// from a live row. The transcript file itself survives under ~/.claude/~/.codex.
-//
-// WorkspaceID is a pointer because "carried, and it is empty" is a genuinely
-// different fact from "carried nothing": an empty id means a solo session whose
-// digest belongs in the _solo bucket, while an absent one means fall back to the
-// live session row.
+// summarizeSessionPayload carries the run's inputs at enqueue time, while the
+// session and workspace rows still exist — the debounced run can fire after a
+// teardown deleted both. WorkspaceID is a pointer: carried-but-empty is a solo
+// session, absent falls back to the live row.
 type summarizeSessionPayload struct {
 	Transcript  string  `json:"transcript,omitempty"`
 	WorkspaceID *string `json:"workspace,omitempty"`
 }
 
-// narrateWorkspacePayload marks a narrate_workspace job enqueued by the
-// daily-narrate cron (the long-lived-workspace backstop) rather than by
-// session-end or the removal boundary. It relaxes the handler's success gate so
-// a no-op daily refresh (nothing new to narrate) is a CLEAN DONE instead of a
-// retried failure (see narrateWorkspaceHandler's dailyPass branch). Session-end
-// and removal passes carry no daily flag and keep strict "must have written"
-// gating.
+// narrateWorkspacePayload marks a job enqueued by the daily-narrate cron, which
+// relaxes the success gate so a no-op daily refresh is a clean done. Session-end
+// and removal passes carry no flag and keep strict "must have written" gating.
 type narrateWorkspacePayload struct {
 	DailyPass bool `json:"daily_pass,omitempty"`
 }
 
-// notebookNarrationAllowedTools is the native tool set both narration agents get.
-// Unlike the keeper's compaction duty (file tools only), the narrate duty may run read-only shell to
-// grep large transcripts and locate prior journal markers, so Bash is included
-// (the briefs explicitly tell them to use Read/Grep/Bash). Claude consumes this as
-// --allowedTools; Codex ignores it (its tooling comes from the workspace-write
-// sandbox), so the Codex-backed narrate's writability is governed by ExtraWritableRoots.
+// notebookNarrationAllowedTools is the native tool set both narration agents
+// get. Claude consumes it as --allowedTools; Codex ignores it, so Codex
+// writability is governed by ExtraWritableRoots instead.
 var notebookNarrationAllowedTools = []string{"Read", "Write", "Edit", "Grep", "Glob", "Bash"}
 
 // --- summarize_session ---
 
-// summarizeSessionExecutor is the runner-registered ExecutorFunc for
-// summarize_session. task.Subject is the session id. It resolves the transcript path
-// and the workspace bucket PREFERRING the inputs carried on task.Meta (stashed at
-// enqueue time, where both the session row and the workspace row still existed) and
-// falling back to the live session row — so the run stays correct after a
-// single-session-workspace teardown has deleted both rows (the transcript file
-// itself survives under ~/.claude/~/.codex). It assembles the digest prompt with
-// absolute paths, runs the agent, and verifies the digest file was (re)written. The
-// written digest is the only success evidence (the file is the ledger): a run that
-// returns without writing it is an error so the runner backs off and retries. On
-// success, if the workspace has since been removed it re-enqueues the retrospective
-// narrate so the late digest lands in it (see the re-narrate hook below).
+// summarizeSessionHandler runs one per-session digest (job subject: the session
+// id). It prefers the carried payload over the live row, which a teardown may
+// have deleted, and verifies the digest was (re)written.
 func (d *Daemon) summarizeSessionHandler(ctx context.Context, job *jobs.Job) (any, error) {
-	// A run queued before either switch was disabled must not fire background
-	// work after the toggle is off. No-op success retires the record.
+	// A run queued before the toggle was turned off must not fire; no-op success
+	// retires the record.
 	if !d.notebookTasksEnabled() || !d.notebookSummariesEnabled() {
 		return nil, nil
 	}
@@ -169,14 +108,8 @@ func (d *Daemon) summarizeSessionHandler(ctx context.Context, job *jobs.Job) (an
 		return nil, err
 	}
 
-	// Resolve the transcript path and workspace id, PREFERRING the inputs carried on
-	// the job (stashed at enqueue time, where both the session row and workspace row
-	// still existed) and falling back to the live session row. The carried inputs are
-	// what make this run correct AFTER a single-session-workspace teardown: by the
-	// time the debounced run fires both rows are gone, but the transcript file
-	// survives on disk and the carried workspace id still routes the digest to the
-	// right per-workspace bucket. The fallback covers a manually-enqueued job
-	// (no payload) whose row still exists.
+	// Prefer the carried inputs (correct after teardown deleted the rows); the
+	// live-row fallback covers a manually-enqueued job with no payload.
 	carriedTranscript := strings.TrimSpace(carried.Transcript)
 	carriedWorkspace := ""
 	hasCarriedWorkspace := carried.WorkspaceID != nil
@@ -186,8 +119,7 @@ func (d *Daemon) summarizeSessionHandler(ctx context.Context, job *jobs.Job) (an
 
 	session := d.store.Get(sessionID)
 	if session == nil && carriedTranscript == "" {
-		// No row AND nothing carried: the session is genuinely gone with no transcript
-		// to summarize. That is a no-op success, not a failure (nothing to retry).
+		// Genuinely gone with nothing to summarize: no-op success, nothing to retry.
 		d.logf("summarize_session: session %s no longer present and no carried transcript, skipping", sessionID)
 		return nil, nil
 	}
@@ -197,23 +129,14 @@ func (d *Daemon) summarizeSessionHandler(ctx context.Context, job *jobs.Job) (an
 		transcriptPath = d.resolveTranscriptPathForSession(session, "")
 	}
 
-	// Workspace id for the per-session digest bucket: prefer the carried id (which
-	// survives the row deletion) and fall back to the live row's. The carried id is
-	// empty for a genuinely solo session, which keeps the digest in the _solo bucket.
 	workspaceID := carriedWorkspace
 	if !hasCarriedWorkspace && session != nil {
 		workspaceID = strings.TrimSpace(session.WorkspaceID)
 	}
 
-	// Partition the per-session digest dir by the session's workspace so the
-	// narrate pass for a workspace reads ONLY its own members' digests, not a flat
-	// dir holding every workspace's (and every solo session's) digest. The bucket
-	// survives workspace removal on disk, so the removal-pass narrate still finds the
-	// scoped digests. Both segments route through the raw-tier guard so a crafted
-	// session/workspace id cannot escape the raw tier and steer the agent's native
-	// Write at the curated journal (the hole the base raw-floor PR closed for the
-	// daemon's own snapshot write). The carried wsID is just as client-controlled as
-	// the row's was, so it is guarded identically.
+	// Both id segments route through the raw-tier guard: the carried wsID is just
+	// as client-controlled as the row's, so a crafted id cannot escape the raw tier
+	// and steer the agent's Write at the curated journal.
 	digestPath, err := notebookSessionDigestPath(root, workspaceID, sessionID)
 	if err != nil {
 		return nil, fmt.Errorf("summarize_session: %w", err)
@@ -227,11 +150,8 @@ func (d *Daemon) summarizeSessionHandler(ctx context.Context, job *jobs.Job) (an
 		return nil, fmt.Errorf("summarize_session: resolve scratch cwd: %w", err)
 	}
 
-	// Snapshot the digest's pre-run identity so the success gate can require the run
-	// to have actually (re)written it. A coalesced re-run (Enqueue resets a done
-	// record back to queued) on a session whose digest already exists must not be
-	// reported done just because the PRIOR run's file is still there — a no-op agent
-	// would otherwise silently leave a stale digest while reporting success.
+	// Pre-run fingerprint: a coalesced re-run must not be reported done off the
+	// PRIOR run's file, silently leaving a stale digest.
 	before := fileFingerprintOf(digestPath)
 
 	request := agentdriver.HeadlessTaskRequest{
@@ -240,8 +160,7 @@ func (d *Daemon) summarizeSessionHandler(ctx context.Context, job *jobs.Job) (an
 		Prompt:       buildSummarizeSessionPrompt(transcriptPath, sessionID, digestPath),
 		WorkDir:      workDir,
 		AllowedTools: notebookNarrationAllowedTools,
-		// The digest lives under the notebook raw tier, outside the scratch WorkDir,
-		// so a Codex-backed narrate needs that dir made writable (Claude ignores this).
+		// The digest is outside the scratch WorkDir; Codex needs it writable.
 		ExtraWritableRoots: []string{filepath.Dir(digestPath)},
 	}
 
@@ -256,10 +175,8 @@ func (d *Daemon) summarizeSessionHandler(ctx context.Context, job *jobs.Job) (an
 		return nil, fmt.Errorf("summarize_session: run agent: %w (%s)", err, result.Diagnostics)
 	}
 
-	// The file is the ledger: a run that returned without (re)writing the digest
-	// failed, regardless of what the agent claimed. Require the digest to exist AND
-	// to have changed since the pre-run snapshot, so a no-op run over a prior run's
-	// stale digest is a failure (requeued with backoff), not a false done.
+	// The file is the ledger: the digest must exist AND have changed since the
+	// pre-run snapshot, whatever the agent claimed.
 	after := fileFingerprintOf(digestPath)
 	if !after.exists {
 		return nil, fmt.Errorf("summarize_session: agent did not write digest %s (%s)", digestPath, result.Diagnostics)
@@ -269,18 +186,9 @@ func (d *Daemon) summarizeSessionHandler(ctx context.Context, job *jobs.Job) (an
 	}
 	d.logf("summarize_session: session=%s agent=%s model=%s digest=%s", sessionID, config.Agent, config.Model, digestPath)
 
-	// Re-narrate hook (closes the removal/debounce timing gap). On a
-	// single-session-workspace teardown the removal-boundary final narrate already
-	// ran almost immediately (zero debounce) over an EMPTY digest bucket, because
-	// this summarize was still debounced. Now that the grounded digest exists, the
-	// removal retrospective is stale (built from the context snapshot alone). If we
-	// know a non-empty workspace id AND its row is gone (the workspace was removed),
-	// re-enqueue a zero-debounce narrate so the retrospective is rewritten WITH the
-	// final session's work — the narrate freshness-guard makes it actually rewrite
-	// the block (the body changes). Only on removal: an active workspace's pending
-	// narrate already covers a fresh digest, and re-narrating it would burn an extra
-	// strong-tier run. LOOP-SAFETY: narrate completion never enqueues summarize, so
-	// there is no cycle; multiple member summaries coalesce to one narrate per wsID.
+	// On a teardown the zero-debounce removal narrate ran over an EMPTY digest
+	// bucket while this summarize was still debounced, so re-enqueue the
+	// retrospective now. Loop-safe: narrate completion never enqueues summarize.
 	if workspaceID != "" && d.store.GetWorkspace(workspaceID) == nil {
 		d.logf("summarize_session: workspace %s removed, re-narrating retrospective with fresh digest", workspaceID)
 		d.enqueueFinalNarrateWorkspace(workspaceID)
@@ -288,13 +196,9 @@ func (d *Daemon) summarizeSessionHandler(ctx context.Context, job *jobs.Job) (an
 	return nil, nil
 }
 
-// notebookSessionDigestPath builds the absolute path of a session's raw digest,
-// partitioned by the session's workspace so a workspace's narrate pass reads only
-// its own members' digests. A workspace session lands at
-// RawSessionsDir/<wsID>/<sessionID>.md; a solo session (no workspace) lands at
-// RawSessionsDir/<soloBucket>/<sessionID>.md. Both id segments route through the
-// raw-tier guard, so a crafted session or workspace id is rejected (a hard error)
-// rather than allowed to climb out of the raw tier via filepath.Join's "..".
+// notebookSessionDigestPath builds the absolute path of a session's raw digest:
+// RawSessionsDir/<wsID or _solo>/<sessionID>.md. Both id segments route through
+// the raw-tier guard, so a crafted id errors instead of climbing out via "..".
 func notebookSessionDigestPath(root, workspaceID, sessionID string) (string, error) {
 	name, err := rawTierFilename(sessionID)
 	if err != nil {
@@ -303,9 +207,6 @@ func notebookSessionDigestPath(root, workspaceID, sessionID string) (string, err
 	if workspaceID == "" {
 		return filepath.Join(notebook.RawSessionsDir(root), notebookSoloSessionBucket, name), nil
 	}
-	// Non-solo sessions land in the same per-workspace bucket the narrate pass reads;
-	// notebookWorkspaceSessionsDir is the single source of that bucket path (and it
-	// already returns the identical "unsafe workspace id" error, so pass it through).
 	dir, err := notebookWorkspaceSessionsDir(root, workspaceID)
 	if err != nil {
 		return "", err
@@ -313,9 +214,8 @@ func notebookSessionDigestPath(root, workspaceID, sessionID string) (string, err
 	return filepath.Join(dir, name), nil
 }
 
-// notebookWorkspaceSessionsDir is the per-workspace digest subdir the narrate pass
-// hands the narrate pass as RAW_SESSIONS_DIR, so it reads only this workspace's member
-// digests. It mirrors the bucket notebookSessionDigestPath writes to.
+// notebookWorkspaceSessionsDir is the per-workspace digest subdir handed to the
+// narrate pass as RAW_SESSIONS_DIR; it mirrors notebookSessionDigestPath's bucket.
 func notebookWorkspaceSessionsDir(root, workspaceID string) (string, error) {
 	bucket, err := rawTierSegment(workspaceID)
 	if err != nil {
@@ -326,15 +226,13 @@ func notebookWorkspaceSessionsDir(root, workspaceID string) (string, error) {
 
 // --- narrate_workspace ---
 
-// narrateWorkspaceHandler is the runner-registered handler for
-// narrate_workspace. The job's subject is the workspace id. It derives IS_REMOVAL_PASS
-// at RUN TIME from whether the workspace row still exists (an absent row means the
-// workspace was removed and this is the final retrospective pass), gathers the
-// narrate duty's inputs, runs the agent, and verifies the journal now carries this
-// workspace's marker for today (the file is the ledger).
+// narrateWorkspaceHandler runs one curated-journal pass; the job subject is the
+// workspace id. IS_REMOVAL_PASS is derived at RUN TIME from workspace-row
+// absence, and success is the journal carrying today's workspace marker (the
+// file is the ledger).
 func (d *Daemon) narrateWorkspaceHandler(ctx context.Context, job *jobs.Job) (any, error) {
-	// A run queued before either switch was disabled must not fire background
-	// work after the toggle is off. No-op success retires the record.
+	// A run queued before the toggle was turned off must not fire; no-op success
+	// retires the record.
 	if !d.notebookTasksEnabled() || !d.notebookWorkspaceNarrationEnabled() {
 		return nil, nil
 	}
@@ -372,19 +270,14 @@ func (d *Daemon) narrateWorkspaceHandler(ctx context.Context, job *jobs.Job) (an
 	if err := os.MkdirAll(inputs.JournalDir, 0o755); err != nil {
 		return nil, fmt.Errorf("narrate_workspace: create journal dir: %w", err)
 	}
-	// MkdirAll the per-workspace sessions bucket so the narrate agent's "Read every digest
-	// in RAW_SESSIONS_DIR" step does not fault on a missing dir when no member ever
-	// summarized (e.g. a workspace removed before any session stopped).
+	// MkdirAll so the agent's "read every digest" step does not fault when no
+	// member ever summarized.
 	if err := os.MkdirAll(inputs.RawSessionsDir, 0o755); err != nil {
 		return nil, fmt.Errorf("narrate_workspace: create raw sessions dir: %w", err)
 	}
 
-	// Snapshot this workspace's marker block before the run so the success gate can
-	// require it to have actually changed. Without this a coalesced re-run (the
-	// removal-boundary final narrate firing after an active-day narrate already
-	// wrote today's marker) would be falsely marked done off the PRIOR run's block,
-	// silently dropping the removal retrospective even when this run's agent wrote
-	// nothing for the workspace.
+	// Pre-run snapshot of the marker block: a coalesced re-run must not be marked
+	// done off the PRIOR run's block, silently dropping the removal retrospective.
 	before, err := workspaceNarrationBlock(inputs.JournalPath, workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("narrate_workspace: read journal: %w", err)
@@ -401,11 +294,8 @@ func (d *Daemon) narrateWorkspaceHandler(ctx context.Context, job *jobs.Job) (an
 		Prompt:       buildNarrateWorkspacePrompt(inputs),
 		WorkDir:      workDir,
 		AllowedTools: notebookNarrationAllowedTools,
-		// The journal and raw tier live under the notebook root, outside the scratch
-		// WorkDir; widen the Codex sandbox to the whole root so it can read the raw
-		// inputs and write the curated journal (Claude ignores this — dontAsk is not
-		// sandboxed). Reads are unrestricted under workspace-write, but transcript
-		// dirs live under $HOME outside the root, so we add the root for the write.
+		// Widen the Codex sandbox to the whole notebook root so it can write the
+		// curated journal (Claude ignores this).
 		ExtraWritableRoots: []string{root},
 	}
 
@@ -420,25 +310,16 @@ func (d *Daemon) narrateWorkspaceHandler(ctx context.Context, job *jobs.Job) (an
 		return nil, fmt.Errorf("narrate_workspace: run agent: %w (%s)", err, result.Diagnostics)
 	}
 
-	// The file is the ledger: success means today's journal now carries THIS
-	// workspace's entry block (delimited by `<!-- attn:wsnarr:<wsID> -->`) AND that
-	// block changed since the pre-run snapshot. Requiring a change (not mere
-	// presence) means a coalesced re-run whose agent no-ops over a prior run's block
-	// fails and is retried, instead of being falsely marked done off stale content.
+	// The file is the ledger: this workspace's entry block must be present AND
+	// changed since the pre-run snapshot.
 	after, err := workspaceNarrationBlock(inputs.JournalPath, workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("narrate_workspace: verify journal: %w", err)
 	}
 
-	// dailyPass relaxes the success gate for the daily-cron backstop ONLY. A daily
-	// refresh legitimately finds nothing new — the workspace was already narrated
-	// today, or only old material is on disk — and forcing a write would spam the
-	// runner's backoff straight to dead. The raw material persists, so a no-op daily
-	// pass loses nothing: the next trigger re-narrates. So when this is a daily pass
-	// (and NOT a removal pass), "agent left the block absent" and "agent left the
-	// block unchanged" are both a CLEAN DONE. Removal passes (the full retrospective)
-	// and session-end routine passes (no daily flag) keep STRICT gating, which
-	// preserves the retry-until-the-digest-lands property they depend on.
+	// dailyPass relaxes the gate for the daily-cron backstop ONLY: a refresh that
+	// legitimately finds nothing new would otherwise ride the backoff to dead.
+	// Removal and session-end passes keep retry-until-the-digest-lands.
 	dailyPass := !inputs.IsRemovalPass && carried.DailyPass
 
 	if !after.present {
@@ -462,27 +343,19 @@ func (d *Daemon) narrateWorkspaceHandler(ctx context.Context, job *jobs.Job) (an
 	return nil, nil
 }
 
-// gatherNarrateWorkspaceInputs assembles the absolute-path inputs the narrate
-// agent needs. IS_REMOVAL_PASS is derived from workspace-row absence (the removal
-// boundary deleted the row before this run); WORKSPACE_TITLE falls back to the
-// removal snapshot or the id when the row is gone. TRANSCRIPT_PATHS are the live
-// member sessions' transcripts (best-effort — they may be gone after removal, which
-// is fine: the digests are the durable record and the brief only consults
-// transcripts to chase a divergence).
+// gatherNarrateWorkspaceInputs assembles the absolute-path inputs for the
+// narrate agent. TRANSCRIPT_PATHS are best-effort: the digests are the durable
+// record and the brief only consults transcripts to chase a divergence.
 func (d *Daemon) gatherNarrateWorkspaceInputs(root, workspaceID string) (narrateWorkspacePromptInputs, error) {
 	today := d.narrationToday()
 
-	// Build the context-snapshot READ path through the same guard the WRITER
-	// (snapshotWorkspaceContextOnRemove -> writeRawAtomic -> rawTierFilename) uses,
-	// so the read path can never address a different file than the write path and a
-	// crafted workspace id is rejected (failing the run) instead of pointing the
-	// narrate agent's "read CONTEXT_SNAPSHOT_PATH first" step at an attacker-chosen file.
+	// The READ path uses the same guard as the writer, so it can never address a
+	// different file, and a crafted id fails the run rather than pointing the
+	// agent at an attacker-chosen file.
 	snapshotName, err := rawTierFilename(workspaceID)
 	if err != nil {
 		return narrateWorkspacePromptInputs{}, fmt.Errorf("narrate_workspace: unsafe workspace id: %w", err)
 	}
-	// Per-workspace digest bucket — the narrate pass reads ONLY this workspace's member
-	// digests, not a flat dir holding every workspace's and every solo session's.
 	sessionsDir, err := notebookWorkspaceSessionsDir(root, workspaceID)
 	if err != nil {
 		return narrateWorkspacePromptInputs{}, fmt.Errorf("narrate_workspace: %w", err)
@@ -506,8 +379,7 @@ func (d *Daemon) gatherNarrateWorkspaceInputs(root, workspaceID string) (narrate
 		inputs.WorkspaceTitle = workspaceID
 	}
 
-	// Collect the transcripts of sessions still associated with this workspace. On a
-	// removal pass the member rows are gone, so this is typically empty — expected.
+	// On a removal pass the member rows are gone, so this is typically empty.
 	for _, session := range d.store.List("") {
 		if session == nil || session.WorkspaceID != workspaceID {
 			continue
@@ -520,9 +392,8 @@ func (d *Daemon) gatherNarrateWorkspaceInputs(root, workspaceID string) (narrate
 	return inputs, nil
 }
 
-// narrationToday returns today's date in YYYY-MM-DD for the journal filename. The
-// narrationNowOverride test hook pins the clock so date-boundary behavior is
-// deterministic.
+// narrationToday returns today's date in YYYY-MM-DD for the journal filename;
+// narrationNowOverride pins the clock in tests.
 func (d *Daemon) narrationToday() string {
 	now := time.Now
 	if d.narrationNowOverride != nil {
@@ -531,13 +402,9 @@ func (d *Daemon) narrationToday() string {
 	return now().Format("2006-01-02")
 }
 
-// workspaceNarrationMarker is the FULL hidden HTML-comment marker line the narrate agent
-// writes to delimit (and dedup) this workspace's entry in a day's journal file. It
-// MUST match the exact line the prompt brief tells the agent to write
-// (`<!-- attn:wsnarr:<wsID> -->`). The full delimited form is load-bearing for the
-// success ledger: the bare `attn:wsnarr:ws-1` substring is also contained in
-// `<!-- attn:wsnarr:ws-10 -->`, so a prefix-related sibling's entry would falsely
-// verify ws-1's run. Matching the delimited line removes that collision.
+// workspaceNarrationMarker MUST match the exact line the prompt brief tells the
+// agent to write. The full delimited form is load-bearing: bare `attn:wsnarr:ws-1`
+// is a substring of `<!-- attn:wsnarr:ws-10 -->`, so a sibling would falsely verify.
 func workspaceNarrationMarker(workspaceID string) string {
 	return fmt.Sprintf("<!-- attn:wsnarr:%s -->", strings.TrimSpace(workspaceID))
 }
@@ -549,12 +416,10 @@ type workspaceNarrationEntry struct {
 	body    string // the entry block from the marker line to the next "## "/EOF
 }
 
-// workspaceNarrationBlock reads the journal at path and returns this workspace's
-// entry block: whether its marker line is present and, if so, the text from the
-// marker line through the line just before the next workspace's "## " header (or
-// end of file). A missing file is not an error (the agent simply wrote nothing):
-// it reports an absent entry. The body is scoped to the workspace's own marker so
-// the freshness check ignores a concurrent sibling's edit elsewhere in the file.
+// workspaceNarrationBlock returns this workspace's entry block from the journal
+// at path. A missing file reports an absent entry, not an error. The body is
+// scoped to the workspace's own marker so the freshness check ignores a
+// concurrent sibling's edit elsewhere in the file.
 func workspaceNarrationBlock(path, workspaceID string) (workspaceNarrationEntry, error) {
 	content, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
@@ -585,12 +450,8 @@ func workspaceNarrationBlock(path, workspaceID string) (workspaceNarrationEntry,
 	return workspaceNarrationEntry{present: true, body: strings.Join(lines[start:end], "\n")}, nil
 }
 
-// fileFingerprint captures a file's identity for the digest freshness ledger: its
-// existence and a content hash. A run that left a digest byte-identical to its
-// pre-run state is treated as a no-op (not a success), so a coalesced re-run whose
-// agent did nothing is retried rather than recorded as a false done. Content (not
-// mtime) so a same-second rewrite of identical size can never read as fresh, and a
-// no-op is never missed by coarse filesystem mtime granularity.
+// fileFingerprint is the digest freshness ledger: existence plus a content hash.
+// Content, not mtime, so a no-op is never missed by coarse mtime granularity.
 type fileFingerprint struct {
 	exists bool
 	hash   [sha256.Size]byte
@@ -610,20 +471,9 @@ func fileFingerprintOf(path string) fileFingerprint {
 
 // --- triggers ---
 
-// enqueueSummarizeSession queues a per-session digest run. It is enqueued on every
-// session Stop (the cheap tier), coalesced per session so a chatty session does not
-// pile up runs. Nil/Disabled-guarded so it is safe before the runner is constructed
-// and when the notebook root cannot resolve.
-//
-// The transcript path and workspace id are STASHED on the task (via Meta) at enqueue
-// time, where both the session row and the workspace row still exist. They are
-// carried because the debounced run fires AFTER a single-session-workspace teardown
-// has deleted both rows: without the carried inputs the executor would resolve an
-// empty workspace id and write the digest to the _solo bucket (wrong) or find no row
-// at all and no-op, so the removal retrospective's per-workspace dir never sees the
-// final session's grounded digest. The transcript file itself survives on disk, so
-// summarize remains runnable post-removal. wsID is empty for a genuinely solo
-// session, which keeps the digest in the _solo bucket exactly as before.
+// enqueueSummarizeSession queues a per-session digest run on session Stop,
+// coalesced per session. The transcript path and workspace id are stashed on
+// the payload here, while both rows still exist — see summarizeSessionPayload.
 func (d *Daemon) enqueueSummarizeSession(sessionID, transcriptPath, workspaceID string) {
 	sessionID = strings.TrimSpace(sessionID)
 	if sessionID == "" {
@@ -650,8 +500,7 @@ func (d *Daemon) enqueueSummarizeSession(sessionID, transcriptPath, workspaceID 
 }
 
 // enqueueNarrateWorkspace queues a coalesced curated-journal run for a live
-// workspace. The debounce collapses the burst of session stops in an active
-// workspace into a single narrate pass. Nil/Disabled-guarded.
+// workspace.
 func (d *Daemon) enqueueNarrateWorkspace(workspaceID string) {
 	workspaceID = strings.TrimSpace(workspaceID)
 	if workspaceID == "" {
@@ -674,10 +523,7 @@ func (d *Daemon) enqueueNarrateWorkspace(workspaceID string) {
 
 // markNotebookWorkspaceActivity records that a workspace saw real activity (a
 // session end or a content-changing context write) since the last daily-narrate
-// cron fire. It feeds the daily-narrate activity gate: the cron drains this set and
-// only narrates workspaces that appear in it, so idle long-lived workspaces never
-// burn a strong-tier pass. The set is in-memory, best-effort, and lazily initialized
-// under the mutex (so the Daemon constructor needs no edit); an empty id is ignored.
+// fire, feeding the cron's activity gate. In-memory and best-effort.
 func (d *Daemon) markNotebookWorkspaceActivity(workspaceID string) {
 	workspaceID = strings.TrimSpace(workspaceID)
 	if workspaceID == "" {
@@ -691,24 +537,10 @@ func (d *Daemon) markNotebookWorkspaceActivity(workspaceID string) {
 	d.notebookNarrateActivity[workspaceID] = struct{}{}
 }
 
-// enqueueDailyNarrateWorkspace queues the daily-cron per-workspace narrate for a
-// live, active workspace. It mirrors enqueueNarrateWorkspace (nil/Disabled guard,
-// notebookNarrationDebounce so it coalesces with any concurrent session-end narrate)
-// but stamps notebookNarrateMetaDailyPass so the executor's success gate relaxes for
-// a no-op daily refresh (see narrateWorkspaceExecutor). Nil/Disabled-guarded.
-//
-// Known coalescing edge (low severity, self-healing): if a session-end narrate and
-// this daily narrate land on the same narrate_workspace:<ws> task within the debounce
-// window — i.e. a session stops within notebookNarrationDebounce of the nightly slot —
-// the merged record ends up daily-flagged in BOTH enqueue orderings (the runner's Meta
-// is REPLACE-on-non-nil / leave-on-nil, so daily's flag either wins by replacing or
-// survives because session-end carries no Meta). The coalesced run then takes the
-// relaxed gate, so a no-op is marked DONE rather than retried. This only matters if
-// the agent ALSO no-ops on a real session-end digest (a transient flake — real work
-// always writes), and even then nothing is lost: the raw digest persists and the next
-// trigger re-narrates. Closing it fully would require flipping the executor default to
-// relaxed (a sticky "strict-wins" marker), trading this rare timing edge for a less
-// safe default on the primary session-end path; not worth it.
+// enqueueDailyNarrateWorkspace queues the daily-cron narrate, stamped DailyPass
+// so the executor's success gate relaxes for a no-op refresh. Known self-healing
+// edge: a session-end narrate coalescing into this window inherits the daily
+// flag either ordering, so its no-op is marked done rather than retried.
 func (d *Daemon) enqueueDailyNarrateWorkspace(workspaceID string) {
 	workspaceID = strings.TrimSpace(workspaceID)
 	if workspaceID == "" {
@@ -730,15 +562,10 @@ func (d *Daemon) enqueueDailyNarrateWorkspace(workspaceID string) {
 	}
 }
 
-// enqueueFinalNarrateWorkspace queues the removal-boundary final narrate with a
-// zero debounce so it overrides any pending active-day debounce and runs as soon as
-// eligible — the workspace is gone, so this is the last chance to write its
-// retrospective. It must be called AFTER the context snapshot is taken and the
-// workspace row is removed, so the executor derives IS_REMOVAL_PASS=true and the
-// snapshot is on disk for the narrate pass to read. Nil/Disabled-guarded: a caller
-// that runs before startJobQueue constructs the runner is a safe no-op, which
-// is why the startup-reconciliation reaper defers its enqueue to Start (after the
-// runner exists) rather than calling this inline.
+// enqueueFinalNarrateWorkspace queues the removal-boundary final narrate with
+// zero debounce. MUST run AFTER the context snapshot and the workspace-row
+// removal, so IS_REMOVAL_PASS derives true and the snapshot is on disk. A no-op
+// before the runner exists, so the startup reaper defers its enqueue to Start.
 func (d *Daemon) enqueueFinalNarrateWorkspace(workspaceID string) {
 	workspaceID = strings.TrimSpace(workspaceID)
 	if workspaceID == "" {
@@ -759,11 +586,9 @@ func (d *Daemon) enqueueFinalNarrateWorkspace(workspaceID string) {
 	}
 }
 
-// resolveStopWorkspaceID returns the workspace id for a stopped session, read from
-// the PERSISTED store row (not the in-memory registry). The registry can race a
-// concurrent dissociate-on-close, but the persisted workspace_id survives until the
-// session row itself is removed, so it is the authoritative trigger source for
-// "which workspace did this stop belong to".
+// resolveStopWorkspaceID reads the stopped session's workspace id from the
+// PERSISTED row, not the in-memory registry, which can race a concurrent
+// dissociate-on-close.
 func (d *Daemon) resolveStopWorkspaceID(sessionID string) string {
 	session := d.store.Get(sessionID)
 	if session == nil {

--- a/internal/daemon/notebook_raw_tier.go
+++ b/internal/daemon/notebook_raw_tier.go
@@ -10,54 +10,27 @@ import (
 	"github.com/victorarias/attn/internal/notebook"
 )
 
-// The raw tier is the deterministic capture floor for the notebook narration
-// pipeline. It holds machine inputs the narrate pass later consumes, under
-// <notebook.root>/.attn/raw/ — physically unreachable through the user-facing
-// notebook APIs (CleanPath rejects dotdir segments) and skipped by the watcher,
-// so raw writes emit no external-edit broadcast. The deterministic context-snapshot
-// write lands here through this one atomic writer + the one neutralizeJournalMarkers
-// step:
-//
-//   - context-snapshots/<wsID>.md — the synchronous context.md snapshot taken at
-//     every workspace-removal site, BEFORE store.RemoveWorkspace runs its
-//     DELETE FROM workspace_contexts (an async writer cannot win that race).
-//
-// The snapshot body passes through neutralizeJournalMarkers so no free-text field
-// can forge a journal marker.
+// The raw tier holds machine inputs for the narration pipeline under
+// <notebook.root>/.attn/raw/ — unreachable through the user-facing notebook APIs
+// (CleanPath rejects dotdir segments) and skipped by the watcher, so raw writes
+// emit no external-edit broadcast.
 
-// rawTierFilename turns a raw-tier item id (a workspace id) into a
-// single safe "<id>.md" filename, or errors if the id cannot be a single path
-// segment. This is the load-bearing guard that keeps a CLIENT-CONTROLLED id (the
-// workspace id from register_workspace is accepted verbatim over the socket, with
-// no UUID/segment validation) from escaping its raw-tier subdir: filepath.Join
-// cleans ".." segments, so an unvalidated id like "../../../journal/2026-06-15"
-// would resolve OUT of context-snapshots/ and overwrite the curated journal (or,
-// with enough "..", any .md file the daemon can write outside the notebook root).
-// The raw tier is supposed to be physically unreachable through the user-facing
-// notebook APIs, and the daemon must never write the curated journal; an id that
-// is not a plain filename violates both, so we reject it rather than join it.
-//
-// Centralizing the guard here keeps the invariant in one place instead of resting
-// on a per-call-site property a future caller could quietly break.
+// rawTierFilename turns a raw-tier item id into a single safe "<id>.md"
+// filename. Load-bearing guard: ids are CLIENT-CONTROLLED (register_workspace
+// accepts them verbatim), and a ".." id joined into a path would climb out of
+// the raw tier and overwrite the curated journal.
 func rawTierFilename(id string) (string, error) {
 	return rawTierName(id, ".md")
 }
 
-// rawTierSegment validates a raw-tier id as a single safe path *segment* (no
-// extension), for callers that need a directory name rather than a "<id>.md"
-// file — e.g. partitioning the per-session digest dir by workspace id
-// (RawSessionsDir/<wsID>/). It applies the same containment guard as
-// rawTierFilename so a crafted id (workspace id from register_workspace is
-// accepted verbatim over the socket) can never climb out of the raw tier.
+// rawTierSegment validates a raw-tier id as a single safe directory segment
+// (no extension), with the same containment guard as rawTierFilename.
 func rawTierSegment(id string) (string, error) {
 	return rawTierName(id, "")
 }
 
-// rawTierName is the shared single-safe-segment guard. It trims, rejects path
-// separators / dotdir / control characters, optionally appends an extension, and
-// asserts the result round-trips through filepath.Base/Clean so an escaping id
-// cannot slip through. suffix is "" for a bare directory segment or ".md" for a
-// raw-tier file.
+// rawTierName is the shared single-safe-segment guard. suffix is "" for a bare
+// directory segment or ".md" for a raw-tier file.
 func rawTierName(id, suffix string) (string, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
@@ -66,33 +39,25 @@ func rawTierName(id, suffix string) (string, error) {
 	if strings.ContainsAny(id, `/\`) || id == "." || id == ".." || strings.HasPrefix(id, ".") {
 		return "", fmt.Errorf("raw-tier id %q is not a single safe path segment", id)
 	}
-	// Reject control characters (newlines especially): an id is interpolated into
-	// the file's plaintext "source:" footer, so a newline would let it inject a
-	// forged grounding line, and a control char has no place in a filename anyway.
+	// Control chars rejected: an id is interpolated into the plaintext "source:"
+	// footer, so a newline could inject a forged grounding line.
 	for _, r := range id {
 		if r < 0x20 || r == 0x7f {
 			return "", fmt.Errorf("raw-tier id %q contains a control character", id)
 		}
 	}
 	name := id + suffix
-	// Belt-and-suspenders: a Clean of the bare name must be the name itself (no
-	// separator, no dotdir reintroduced). filepath.Base of an escaping id would not
-	// round-trip to it.
+	// Belt-and-suspenders: an escaping id would not round-trip Base/Clean.
 	if filepath.Base(name) != name || name != filepath.Clean(name) {
 		return "", fmt.Errorf("raw-tier id %q does not produce a safe filename", id)
 	}
 	return name, nil
 }
 
-// writeRawAtomic writes content to a raw-tier file built from dir + a validated
-// "<id>.md" filename, via a temp+rename so a reader never observes a half-written
-// file, MkdirAll'ing the parent first so a write never fails on a missing raw-tier
-// subdir. It mirrors notebook.writeAtomic / tasks.writeAtomic (no fsync, matching
-// the repo idiom). This is the one writer both deterministic raw-tier writes use,
-// and the single chokepoint that validates the id: callers pass the raw id and the
-// intended subdir, and the path is only ever dir/<safe-name> — never a join that
-// ".." could climb out of. A second containment assertion verifies the final path
-// stays under dir even if rawTierFilename is ever weakened.
+// writeRawAtomic writes a raw-tier file via temp+rename (no fsync, matching the
+// repo idiom). It is the single chokepoint that validates the id, and a second
+// containment assertion keeps the final path under dir even if rawTierFilename
+// is ever weakened.
 func writeRawAtomic(root, dir, id string, content []byte) error {
 	name, err := rawTierFilename(id)
 	if err != nil {
@@ -103,12 +68,9 @@ func writeRawAtomic(root, dir, id string, content []byte) error {
 	if filepath.Dir(absPath) != cleanDir {
 		return fmt.Errorf("raw-tier write for %q escapes %q", id, dir)
 	}
-	// The lexical checks above only prove the string join stayed under dir. The
-	// root is externally syncable, so a user/sync client could turn a raw-tier
-	// ancestor (e.g. .attn/raw/sessions) into a symlink pointing outside the
-	// notebook root, and MkdirAll/Rename would then write through it. Resolve the
-	// deepest existing ancestor and require it within the resolved root before we
-	// create any directory or write — the same guard Store.Read/Write/List apply.
+	// Lexical checks only prove the string join. The root is externally syncable,
+	// so a raw-tier ancestor could be a symlink pointing outside it; resolve the
+	// deepest existing ancestor first — the same guard Store.Read/Write/List apply.
 	if err := notebook.EnsureWithinResolvedRoot(root, absPath); err != nil {
 		return err
 	}
@@ -128,23 +90,11 @@ func writeRawAtomic(root, dir, id string, content []byte) error {
 }
 
 // snapshotWorkspaceContextOnRemove synchronously captures a workspace's
-// context.md overlay into the raw tier before the workspace row (and its
-// context.md) is deleted. It is the deterministic data-safety floor: context.md
-// is erased by store.RemoveWorkspace's DELETE FROM workspace_contexts, which an
-// async writer cannot win, so this MUST run at every removal site AFTER the
-// keeper compaction cancel/forget (commit-fence: no in-flight keeper compaction
-// write is still racing the context row) and BEFORE store.RemoveWorkspace.
-//
-// Best-effort: it never returns an error and never blocks or fails a teardown.
-// Every failure — read error, unresolvable/unconfigured notebook root, write
-// error — is logged and swallowed. An empty or revision-0 context (a workspace
-// that never had an overlay) is a silent no-op.
-//
-// The file is keyed 1:1 on the workspace id, so a replayed removal is a harmless
-// identical overwrite; existence of <wsID>.md plus the
-// "source: workspace-context:<id>@<revision>" footer is the exactly-once ledger
-// (no HTML-comment dedup marker is needed). title is used only for logging — the
-// file is keyed on id, so a blank title never breaks the write or the ledger.
+// context.md overlay into the raw tier. It MUST run at every removal site AFTER
+// the keeper compaction cancel/forget and BEFORE store.RemoveWorkspace, whose
+// DELETE FROM workspace_contexts an async writer cannot win. Best-effort: every
+// failure is logged and swallowed, never failing a teardown. Keyed 1:1 on the
+// workspace id, so a replayed removal is a harmless identical overwrite.
 func (d *Daemon) snapshotWorkspaceContextOnRemove(id, title string) {
 	id = strings.TrimSpace(id)
 	if id == "" {
@@ -169,9 +119,8 @@ func (d *Daemon) snapshotWorkspaceContextOnRemove(id, title string) {
 		return // notebook disabled — silent no-op
 	}
 
-	// Neutralize the verbatim overlay BEFORE appending the genuine source footer,
-	// so no free-text field in the body can forge a journal marker while the real
-	// footer stays intact.
+	// Neutralize BEFORE appending the genuine footer, so free text cannot forge a
+	// journal marker while the real footer stays intact.
 	var doc strings.Builder
 	doc.WriteString(neutralizeJournalMarkers(canonical.Content))
 	fmt.Fprintf(&doc, "\nsource: workspace-context:%s@%d\n", id, canonical.Revision)

--- a/internal/daemon/nudge_countdown.go
+++ b/internal/daemon/nudge_countdown.go
@@ -7,23 +7,17 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-// defaultNudgeCountdownWindow is how long an armed ticket nudge waits — visible to
-// the user as a countdown — before the daemon doorbells an eligible session. The user
-// can switch to the session and trigger it early, or let it elapse so attn delivers
-// it. It gates every ticket doorbell so a nudge is never a silent surprise.
+// defaultNudgeCountdownWindow is how long an armed ticket nudge waits, visible
+// as a countdown, before the daemon doorbells an eligible session.
 const defaultNudgeCountdownWindow = 30 * time.Second
 
-// userInputGuardWindow is the anti-splice guarantee. At fire time the daemon refuses
-// to doorbell a session that received a genuine user keystroke within this window,
-// because the doorbell prompt + Enter would splice onto the user's half-typed line
-// and submit the garbled combination — the original bug. This is per-session and so
-// is immune to which tile is "selected"; selection only drives the paused-while-
-// active UX, this drives correctness.
+// userInputGuardWindow is the anti-splice guarantee: a session with a genuine
+// keystroke this recent is never doorbelled, or the prompt + Enter would splice
+// onto a half-typed line.
 const userInputGuardWindow = 3 * time.Second
 
-// nudgeCountdown is a per-session armed countdown. firesAt is stored alongside the
-// timer because time.Timer exposes no deadline accessor and the absolute deadline is
-// what rides the wire (nudge_fires_at) for the client to animate against.
+// nudgeCountdown is a per-session armed countdown. firesAt is stored beside the
+// timer because time.Timer has no deadline accessor.
 type nudgeCountdown struct {
 	timer   *time.Timer
 	firesAt time.Time
@@ -37,20 +31,15 @@ func (d *Daemon) nudgeWindow() time.Duration {
 	return defaultNudgeCountdownWindow
 }
 
-// armNudgeCountdown is the single entry every ticket doorbell now routes through.
-// Instead of injecting immediately it marks the session's ticket activity unread and
-// starts a visible countdown; the timer fire (nudgeCountdownFire) is the only place a
-// real doorbell happens. The currently-selected session never auto-fires: its
-// countdown is paused (no timer, no nudge_fires_at) and the UI offers click-to-
-// trigger; switching away resumes it via setSelectedSession.
+// armNudgeCountdown is the single entry every ticket doorbell routes through:
+// mark unread, start a visible countdown. The selected session never auto-fires
+// — its countdown is paused and switching away resumes it.
 func (d *Daemon) armNudgeCountdown(sessionID string) {
 	d.armNudgeCountdownAt(sessionID, time.Now().Add(d.nudgeWindow()))
 }
 
-// armNudgeCountdownAt marks ticket activity unread and asks the existing
-// countdown to fire no later than deadline. A burst never pushes an already
-// armed countdown later; an immediate assignee update can pull a buffered
-// observer's deadline forward.
+// armNudgeCountdownAt fires no later than deadline: a burst never pushes an
+// armed countdown later, an assignee update can pull it forward.
 func (d *Daemon) armNudgeCountdownAt(sessionID string, deadline time.Time) {
 	if sessionID == "" {
 		return
@@ -60,13 +49,10 @@ func (d *Daemon) armNudgeCountdownAt(sessionID string, deadline time.Time) {
 	}
 	active := d.currentlySelectedSession() == sessionID
 
-	// A standing user cancel is checked before the lock because clearing it needs
-	// a store read, and nudgeMu must never be held across one.
+	// Checked before the lock: nudgeMu must never be held across a store read.
 	if d.nudgeSuppressedFor(sessionID) {
 		if d.nudgeSuppressionStillStands(sessionID) {
-			// The user said "not now" to everything pending, and nothing newer has
-			// arrived. Keep the unread marker — the activity is still there, and
-			// the indicator is how they get back to it — but arm nothing.
+			// "Not now" still stands: keep the unread marker, arm nothing.
 			d.nudgeMu.Lock()
 			changed := d.setUnreadLocked(sessionID, true)
 			changed = d.stopCountdownLocked(sessionID) || changed
@@ -82,11 +68,10 @@ func (d *Daemon) armNudgeCountdownAt(sessionID string, deadline time.Time) {
 	d.nudgeMu.Lock()
 	changed := d.setUnreadLocked(sessionID, true)
 	if active {
-		// Paused while active: ensure no running timer and no deadline on the wire.
+		// Paused while active: no running timer, no deadline on the wire.
 		changed = d.stopCountdownLocked(sessionID) || changed
 	} else if existing, running := d.nudgeCountdowns[sessionID]; !running || deadline.Before(existing.firesAt) {
-		// Keep the earliest deadline. This is both the existing non-sliding burst
-		// debounce and the assignee-over-buffered precedence rule.
+		// Keep the earliest deadline: the debounce never slides.
 		d.startCountdownAtLocked(sessionID, deadline)
 		changed = true
 	}
@@ -97,11 +82,9 @@ func (d *Daemon) armNudgeCountdownAt(sessionID string, deadline time.Time) {
 	}
 }
 
-// startCountdownLocked creates the AfterFunc and records {timer, firesAt}. Caller
-// holds nudgeMu. The ready channel is the synchronization edge: the closure blocks
-// until we publish `timer`, so the identity check in nudgeCountdownFire reads a fully
-// written value even if a tiny (test) window fires the timer immediately — the same
-// handshake scheduleTicketBackstop uses.
+// startCountdownLocked creates the AfterFunc; caller holds nudgeMu. The ready
+// channel blocks the closure until `timer` is published, so the identity check
+// in nudgeCountdownFire never reads a half-written value.
 func (d *Daemon) startCountdownLocked(sessionID string, window time.Duration) {
 	d.startCountdownAtLocked(sessionID, time.Now().Add(window))
 }
@@ -127,10 +110,8 @@ func (d *Daemon) startCountdownAtLocked(sessionID string, firesAt time.Time) {
 	close(ready)
 }
 
-// stopCountdownLocked cancels and forgets a session's running countdown. Caller holds
-// nudgeMu. Returns whether there was one (so the caller knows to rebroadcast the now-
-// absent nudge_fires_at). It does NOT touch unread — a paused/working session keeps
-// its indicator until the agent actually reads its inbox.
+// stopCountdownLocked cancels a session's running countdown (caller holds
+// nudgeMu). It does NOT touch unread — that survives until the inbox is read.
 func (d *Daemon) stopCountdownLocked(sessionID string) bool {
 	c, ok := d.nudgeCountdowns[sessionID]
 	if !ok {
@@ -158,16 +139,14 @@ func (d *Daemon) setUnreadLocked(sessionID string, unread bool) bool {
 	return true
 }
 
-// markTicketUnread sets the session's unread indicator and broadcasts on change.
-// Clearing it (unread=false) also cancels any running countdown — there is nothing
-// left to nudge.
+// markTicketUnread sets the session's unread indicator and broadcasts on change;
+// clearing also cancels any running countdown.
 func (d *Daemon) markTicketUnread(sessionID string, unread bool) {
 	d.nudgeMu.Lock()
 	changed := d.setUnreadLocked(sessionID, unread)
 	if !unread {
 		changed = d.stopCountdownLocked(sessionID) || changed
-		// The queue this cancel was an answer about is drained, so the answer has
-		// nothing left to apply to. Anything arriving now is new and gets to ask.
+		// The queue the cancel answered is drained; anything new gets to ask.
 		delete(d.nudgeSuppressedThrough, sessionID)
 	}
 	d.nudgeMu.Unlock()
@@ -176,8 +155,7 @@ func (d *Daemon) markTicketUnread(sessionID string, unread bool) {
 	}
 }
 
-// cancelNudgeCountdown stops a running countdown (e.g. the session left idle) without
-// touching unread, so the indicator survives as the static working+unread marker.
+// cancelNudgeCountdown stops a running countdown without touching unread.
 func (d *Daemon) cancelNudgeCountdown(sessionID, reason string) {
 	d.nudgeMu.Lock()
 	changed := d.stopCountdownLocked(sessionID)
@@ -190,27 +168,14 @@ func (d *Daemon) cancelNudgeCountdown(sessionID, reason string) {
 	}
 }
 
-// cancelNudgeCountdownByUser is the user calling off an incoming ticket nudge.
-//
-// It differs from cancelNudgeCountdown in one way that matters: it also records a
-// standing cancel, so the countdown does not simply come back. Without that it
-// would, and quickly — merely selecting another session runs the resume in
-// updateNudgeSelection, and the nudge the user just called off would re-arm a
-// beat later.
-//
-// The cancel is recorded as the newest unread ticket event seq at cancel time,
-// which is what makes it expire on its own. "Not now" is an answer about the
-// activity that is pending; a later event is new information and gets to ask
-// again. Nothing is marked read, so the unread indicator survives and clicking it
-// still delivers the doorbell on demand — the cancel removes the automatic
-// interruption, not the user's way in.
+// cancelNudgeCountdownByUser also records a standing cancel, stamped with the
+// newest unread seq so it expires on its own: a later event gets to ask again.
 func (d *Daemon) cancelNudgeCountdownByUser(sessionID string) bool {
 	// Read before taking nudgeMu: a store read must never happen under it.
 	newest, err := d.newestUnreadTicketSeq(sessionID)
 	if err != nil {
 		d.logf("nudge cancel unread scan %s: %v", sessionID, err)
-		// Fall back to suppressing everything currently pending. Failing open
-		// here would re-arm the countdown the user just cancelled.
+		// Fail closed rather than re-arm what the user just cancelled.
 		newest = nudgeSuppressAllSeq
 	}
 
@@ -219,7 +184,7 @@ func (d *Daemon) cancelNudgeCountdownByUser(sessionID string) bool {
 	if d.nudgeSuppressedThrough == nil {
 		d.nudgeSuppressedThrough = make(map[string]int64)
 	}
-	// Only ever widen. Two cancels in a row must not narrow the standing answer.
+	// Only ever widen: two cancels in a row must not narrow the standing answer.
 	if existing, ok := d.nudgeSuppressedThrough[sessionID]; !ok || newest > existing {
 		d.nudgeSuppressedThrough[sessionID] = newest
 	}
@@ -231,9 +196,8 @@ func (d *Daemon) cancelNudgeCountdownByUser(sessionID string) bool {
 	return stopped
 }
 
-// nudgeSuppressAllSeq stands in for "every event that could be pending", used
-// when the unread scan fails and the safe reading is that the cancel covers
-// everything already queued.
+// nudgeSuppressAllSeq stands in for "every event that could be pending" when
+// the unread scan fails.
 const nudgeSuppressAllSeq = int64(1<<63 - 1)
 
 // nudgeSuppressedFor reports whether a user cancel is still on record.
@@ -245,8 +209,7 @@ func (d *Daemon) nudgeSuppressedFor(sessionID string) bool {
 }
 
 // nudgeSuppressionStillStands reports whether everything currently unread was
-// already pending when the user cancelled. A scan error keeps the cancel — the
-// same fail-closed reading as recording it.
+// already pending at cancel time; a scan error keeps the cancel (fail closed).
 func (d *Daemon) nudgeSuppressionStillStands(sessionID string) bool {
 	newest, err := d.newestUnreadTicketSeq(sessionID)
 	if err != nil {
@@ -266,10 +229,8 @@ func (d *Daemon) clearNudgeSuppression(sessionID string) {
 	d.nudgeMu.Unlock()
 }
 
-// newestUnreadTicketSeq is the highest seq among the ticket events this session's
-// observers have not read. Zero when nothing is unread — which makes an empty
-// queue suppress nothing, so a cancel recorded against no activity expires the
-// moment any event arrives.
+// newestUnreadTicketSeq is the highest unread ticket-event seq for this session's
+// observers. Zero when nothing is unread, so a cancel against it expires at once.
 func (d *Daemon) newestUnreadTicketSeq(sessionID string) (int64, error) {
 	if d.store == nil {
 		return 0, nil
@@ -289,8 +250,8 @@ func (d *Daemon) newestUnreadTicketSeq(sessionID string) (int64, error) {
 	return newest, nil
 }
 
-// clearNudgeState drops all per-session nudge bookkeeping when a session is removed.
-// No broadcast: a sessions-updated for the removal follows on its own.
+// clearNudgeState drops all per-session nudge bookkeeping on session removal;
+// no broadcast, the removal's own follows.
 func (d *Daemon) clearNudgeState(sessionID string) {
 	d.nudgeMu.Lock()
 	d.stopCountdownLocked(sessionID)
@@ -306,7 +267,7 @@ func (d *Daemon) clearNudgeState(sessionID string) {
 	d.deliveryMu.Unlock()
 }
 
-// stopNudgeCountdowns cancels every armed countdown. Daemon.Stop() calls it so no
+// stopNudgeCountdowns cancels every armed countdown at Daemon.Stop() so no
 // AfterFunc goroutine outlives teardown.
 func (d *Daemon) stopNudgeCountdowns() {
 	d.nudgeMu.Lock()
@@ -318,9 +279,7 @@ func (d *Daemon) stopNudgeCountdowns() {
 }
 
 // nudgeCountdownFire is the deferred delivery. The identity check against the map
-// entry keeps a countdown that lost a reschedule/cancel race from delivering twice:
-// finds a different (or absent) timer and bails, keeping delivery to a single
-// doorbell. The entry is consumed here; deliverNudgeOrReArm decides what to do.
+// entry keeps a countdown that lost a reschedule/cancel race from firing twice.
 func (d *Daemon) nudgeCountdownFire(sessionID string, self *time.Timer) {
 	d.nudgeMu.Lock()
 	entry, ok := d.nudgeCountdowns[sessionID]
@@ -335,9 +294,8 @@ func (d *Daemon) nudgeCountdownFire(sessionID string, self *time.Timer) {
 	d.deliverNudgeOrReArm(sessionID)
 }
 
-// deliverNudgeOrReArm runs the fire-time re-check and acts on it, then notifies the
-// test hook and rebroadcasts (the countdown's nudge_fires_at is now gone, or a fresh
-// one was armed on re-arm).
+// deliverNudgeOrReArm runs the fire-time re-check, notifies the test hook, and
+// rebroadcasts.
 func (d *Daemon) deliverNudgeOrReArm(sessionID string) {
 	action := d.runNudgeDelivery(sessionID)
 	if d.debugLogging {
@@ -349,13 +307,9 @@ func (d *Daemon) deliverNudgeOrReArm(sessionID string) {
 	d.broadcastSessionStateChanged(sessionID)
 }
 
-// runNudgeDelivery is the fire-time decision, separated so its outcome is a single
-// string the test hook can assert. It doorbells only when the session is not waiting
-// for approval, is not the active session, still has unread ticket activity, and —
-// the splice guard —
-// has not received a genuine user keystroke within userInputGuardWindow. A keystroke
-// re-arms a fresh countdown rather than dropping the nudge: the user is mid-keystroke,
-// not gone.
+// runNudgeDelivery doorbells only when not pending approval, not the active
+// session, still unread, and past the splice guard — a recent keystroke re-arms
+// rather than drops.
 func (d *Daemon) runNudgeDelivery(sessionID string) string {
 	if d.ptyBackend == nil || d.store == nil {
 		return "noop"
@@ -365,14 +319,11 @@ func (d *Daemon) runNudgeDelivery(sessionID string) string {
 		return "blocked"
 	}
 	if d.currentlySelectedSession() == sessionID {
-		// Became the active session during the window; switching away re-arms it.
 		return "active"
 	}
 	d.deliveryMu.Lock()
 	defer d.deliveryMu.Unlock()
 	if until := d.watchLeaseUntil[sessionID]; until.After(time.Now()) {
-		// A live watch gets the next polling opportunity first. If it disappears,
-		// the short lease expires and this rearmed countdown becomes the backstop.
 		d.nudgeMu.Lock()
 		d.startCountdownAtLocked(sessionID, until)
 		d.nudgeMu.Unlock()
@@ -403,10 +354,8 @@ func (d *Daemon) runNudgeDelivery(sessionID string) string {
 	return "doorbell"
 }
 
-// updateNudgeSelection pauses the newly selected session's countdown and resumes the
-// previously selected one. Selection drives only this UX; the splice guard above is
-// what protects a second visible tile the user types into. The store read for the
-// approval check is done before taking nudgeMu to keep the lock ordering one-way.
+// updateNudgeSelection pauses the newly selected session's countdown and resumes
+// the previous one. The approval store read precedes nudgeMu: lock order is one-way.
 func (d *Daemon) updateNudgeSelection(oldID, newID string) {
 	resumeOld := false
 	if oldID != "" && oldID != newID && d.store != nil {
@@ -427,17 +376,14 @@ func (d *Daemon) updateNudgeSelection(oldID, newID string) {
 		d.broadcastSessionStateChanged(id)
 	}
 	if resumeUnread {
-		// The paused timer intentionally carries no deadline. Re-derive the
-		// assignee/buffered deadline from durable unread events and attention so
-		// switching away cannot collapse a long observer buffer to 30 seconds.
+		// Re-derive the deadline from durable unread events so switching away
+		// cannot collapse a long observer buffer to 30 seconds.
 		go d.notifyUnreadTicketSession(oldID, time.Now())
 	}
 }
 
 // refreshTicketUnread recomputes a session's unread ticket count and updates the
-// indicator. Called after an inbox consume (handleTicketInbox) and on each notify so
-// the indicator reflects reality for every agent — including self-monitoring Claude,
-// whose optional watch can drain the queue before the countdown doorbells.
+// indicator; an agent's own watch can drain the queue before the doorbell.
 func (d *Daemon) refreshTicketUnread(sessionID string) {
 	if d.store == nil {
 		return
@@ -450,19 +396,15 @@ func (d *Daemon) refreshTicketUnread(sessionID string) {
 	d.markTicketUnread(sessionID, unread > 0)
 }
 
-// isNudgeDeliveryAllowed is the sole session-state gate for every doorbell. A
-// pending approval is the only unsafe target because a trailing Enter could answer
-// it. Active, launching, unknown, idle, waiting-input, and scheduled sessions all
-// remain eligible; selection and recent-keypress checks are separate user-safety
-// mechanisms, not state policy.
+// isNudgeDeliveryAllowed is the sole session-state gate for every doorbell:
+// pending approval is the only unsafe target, because a trailing Enter could
+// answer it.
 func isNudgeDeliveryAllowed(state string) bool {
 	return state != protocol.StatePendingApproval
 }
 
-// handleTriggerNudge is the user clicking the incoming-nudge indicator: deliver the
-// pending doorbell now, on demand, in any nudge-eligible state. It is exempt
-// from the keystroke guard — an explicit click is unambiguous intent — and respects
-// only unread (a click on a stale, already-drained indicator is a harmless no-op).
+// handleTriggerNudge is the user clicking the indicator: deliver now, exempt from
+// the keystroke guard, respecting only unread.
 func (d *Daemon) handleTriggerNudge(msg *protocol.TriggerNudgeMessage) {
 	sessionID := strings.TrimSpace(msg.SessionID)
 	if sessionID == "" {
@@ -480,7 +422,7 @@ func (d *Daemon) handleTriggerNudge(msg *protocol.TriggerNudgeMessage) {
 	defer d.deliveryMu.Unlock()
 	unread, err := d.ticketUnreadForSession(sessionID)
 	if err != nil || unread == 0 {
-		// Nothing to deliver; clear a stale indicator rather than doorbell into nothing.
+		// Clear a stale indicator rather than doorbell into nothing.
 		d.markTicketUnread(sessionID, false)
 		return
 	}
@@ -492,15 +434,9 @@ func (d *Daemon) handleTriggerNudge(msg *protocol.TriggerNudgeMessage) {
 	d.broadcastSessionStateChanged(sessionID)
 }
 
-// noteUserInput records a genuine user keystroke, and is the only place the
-// source filter is applied — automation and attach-replay writes are not the
-// user typing, so they do not count. It reports whether it recorded one, so a
-// caller can hang further reactions off the same verdict instead of re-deriving
-// who typed.
-//
-// It also records the same instant as auto-settle activity. Pointer movement
-// records only that second stamp: it means the user is engaged with the agent,
-// but cannot splice a doorbell onto a half-typed line.
+// noteUserInput records a genuine user keystroke — the only place the source
+// filter is applied — and stamps auto-settle activity. Pointer movement records
+// only the second stamp, since it cannot splice a doorbell.
 func (d *Daemon) noteUserInput(sessionID, source string) bool {
 	if sessionID == "" || !isUserKeystrokeSource(source) {
 		return false
@@ -519,10 +455,8 @@ func (d *Daemon) noteUserInput(sessionID, source string) bool {
 	return true
 }
 
-// noteAutoSettleActivity records user engagement that should freeze a pending
-// settle without claiming that the user typed into the PTY. It shares
-// lastInputMu with settleIfAutoSettleQuiet so activity arriving before the turn
-// closes always wins the race.
+// noteAutoSettleActivity freezes a pending settle without claiming a PTY
+// keystroke. Shares lastInputMu with settleIfAutoSettleQuiet so activity wins.
 func (d *Daemon) noteAutoSettleActivity(sessionID string) bool {
 	if sessionID == "" {
 		return false
@@ -542,10 +476,8 @@ func (d *Daemon) recentUserInput(sessionID string, within time.Duration) bool {
 	return d.userInputQuietRemaining(sessionID, within) > 0
 }
 
-// userInputQuietRemaining reports how much of `within` is left to run before this
-// session counts as quiet — zero once the window has elapsed, or when the user
-// has never typed here. It is what lets a waiting timer reschedule exactly to the
-// end of the window instead of re-polling it.
+// userInputQuietRemaining reports how much of `within` is left before this
+// session counts as quiet, so a waiting timer reschedules instead of polling.
 func (d *Daemon) userInputQuietRemaining(sessionID string, within time.Duration) time.Duration {
 	d.lastInputMu.Lock()
 	defer d.lastInputMu.Unlock()
@@ -584,26 +516,10 @@ func (d *Daemon) autoSettleActivityQuietRemainingLocked(sessionID string, within
 	return remaining
 }
 
-// settleIfAutoSettleQuiet is auto-settle's commit: the only place a timer closes
-// a turn, and the reason the activity hold is airtight rather than merely likely.
-//
-// The quiet check and the store write happen in one critical section, under the
-// same lock keyboard and pointer activity use. That is what makes the two
-// indivisible. Checking first and settling afterwards — however few instructions
-// apart — leaves a gap a real interaction can land in: it would be stamped after
-// the guard had already looked, and the hold that follows it finds the timer
-// gone from the map and does nothing, so the turn closes with the user's hands
-// on the session. Serialized, activity before the settle commits is always seen
-// by the check that guards it, and activity that loses happened after the turn
-// had already closed — which is honest, and unavoidable in any design.
-//
-// The lock spans a store write, so the scope is worth stating plainly: the only
-// way to contend for it is to interact in the instant a settle commits, and a
-// settle only commits after `within` of silence. The single activity report that
-// could ever wait on one primary-key update is the one this exists to protect.
-//
-// Reports the remaining quiet time when it refuses, so the caller can reschedule
-// exactly to the end of the window, and whether the turn was actually settled.
+// settleIfAutoSettleQuiet is the only place a timer closes a turn. The quiet
+// check and the store write must share one critical section under the lock
+// activity stamps use, or a real interaction lands in the gap and the turn closes
+// with the user's hands on the session. Returns remaining quiet time on refusal.
 func (d *Daemon) settleIfAutoSettleQuiet(sessionID string, within time.Duration) (quiet time.Duration, settled bool) {
 	d.lastInputMu.Lock()
 	defer d.lastInputMu.Unlock()
@@ -613,10 +529,8 @@ func (d *Daemon) settleIfAutoSettleQuiet(sessionID string, within time.Duration)
 	return 0, d.store.SettleTurn(sessionID, time.Now())
 }
 
-// isUserKeystrokeSource reports whether a pty_input source tag represents the user
-// typing. Genuine keystrokes arrive untagged (empty source); automation and replay
-// are explicitly tagged and excluded. The lone "user" tag (insert-reference) is the
-// user composing, so it counts.
+// isUserKeystrokeSource: genuine keystrokes arrive untagged, automation and
+// replay are tagged and excluded, and "user" (insert-reference) counts.
 func isUserKeystrokeSource(source string) bool {
 	switch source {
 	case "automation", "attach_replay":
@@ -626,9 +540,8 @@ func isUserKeystrokeSource(source string) bool {
 	}
 }
 
-// decorateSessionWithNudge stamps the broadcast clone with the live nudge state so
-// every session broadcast (state change, sessions-updated, reconnect rehydration)
-// carries the current indicator. Read under nudgeMu; callers must not already hold it.
+// decorateSessionWithNudge stamps the broadcast clone with the live nudge state.
+// Takes nudgeMu; callers must not already hold it.
 func (d *Daemon) decorateSessionWithNudge(clone *protocol.Session) {
 	if clone == nil {
 		return

--- a/internal/daemon/session_evidence.go
+++ b/internal/daemon/session_evidence.go
@@ -12,20 +12,13 @@ import (
 	"github.com/victorarias/attn/internal/statetrace"
 )
 
-// The evidence table: what each source has said about a session, kept so the
-// resolver can weigh them instead of the last writer winning.
-//
-// Sources write here and nowhere else. The tick resolves the table and is what
-// publishes state, which is the point of the whole design: a state now has to be
-// re-justified from live evidence every second, so it cannot outlive the
-// evidence behind it. That is the structural difference from the edge-triggered
-// scheme it replaces, where a state persisted until some source happened to
-// contradict it and got stuck forever when none did.
+// The evidence table: what each source has said about a session, so the resolver
+// can weigh them instead of the last writer winning. Sources write here and
+// nowhere else, and the tick re-justifies state from live evidence every second,
+// so no state gets stuck when its sources go quiet.
 
 // evidenceTickInterval is how often every session's evidence is re-resolved.
-// The tick is what makes evidence expire: without it a resolution would only be
-// recomputed when a source spoke, which is precisely the case that fails when a
-// source stops speaking.
+// The tick is what makes evidence expire when a source stops speaking.
 const evidenceTickInterval = time.Second
 
 // sessionEvidenceTable holds one evidence record per live session.
@@ -38,18 +31,9 @@ func newSessionEvidenceTable() *sessionEvidenceTable {
 	return &sessionEvidenceTable{sessions: make(map[string]*sessionstate.Evidence)}
 }
 
-// updateIf mutates one session's evidence, creating the record on first use, but
-// only when admit says the session is live. It stamps LastMovement, so stuck
-// detection cannot drift out of sync with the writes it is watching.
-//
-// admit runs while holding the table's lock, which is the whole point: the
-// caller's liveness check and the write have to be one atomic step. Removal
-// deletes the store row and then forgets the table, so with admission inside the
-// lock the two possible interleavings are "the writer wins and its entry is then
-// forgotten" and "removal wins and the writer is refused". Checking liveness
-// outside the lock leaves a third: the writer passes the check, removal deletes
-// and forgets, and the writer then recreates an entry for an id nothing will
-// ever clean up again.
+// updateIf mutates one session's evidence when admit says it is live, stamping
+// LastMovement. admit runs INSIDE the table's lock: checked outside, a writer
+// could pass liveness, lose to a removal, and recreate an orphan entry.
 func (t *sessionEvidenceTable) updateIf(sessionID string, at time.Time, admit func() bool, mutate func(*sessionstate.Evidence)) {
 	if t == nil || strings.TrimSpace(sessionID) == "" {
 		return
@@ -69,8 +53,7 @@ func (t *sessionEvidenceTable) updateIf(sessionID string, at time.Time, admit fu
 }
 
 // snapshot returns a copy of one session's evidence, or false when nothing has
-// been recorded for it. The copy matters: the resolver must not read a table
-// that is being mutated underneath it.
+// been recorded — a copy, so the resolver never reads a table being mutated.
 func (t *sessionEvidenceTable) snapshot(sessionID string) (sessionstate.Evidence, bool) {
 	if t == nil {
 		return sessionstate.Evidence{}, false
@@ -106,9 +89,8 @@ func (t *sessionEvidenceTable) forget(sessionID string) {
 	delete(t.sessions, sessionID)
 }
 
-// evidenceRecordGateHook runs inside the evidence table's lock, between the
-// live-row check and the write. Tests only: it is the seam where a concurrent
-// removal would have to interleave for an orphan entry to appear.
+// evidenceRecordGateHook (tests only) runs inside the table's lock, between the
+// live-row check and the write — the seam a removal must interleave into.
 var evidenceRecordGateHook func(sessionID string)
 
 // recordEvidence is the single write path into the evidence table. Every source
@@ -116,8 +98,6 @@ var evidenceRecordGateHook func(sessionID string)
 func (d *Daemon) recordEvidence(sessionID string, at time.Time, mutate func(*sessionstate.Evidence)) {
 	d.evidenceTable().updateIf(sessionID, at, func() bool {
 		live := d.store != nil && d.store.Get(sessionID) != nil
-		// The hook runs after the check on purpose: check-then-write is the
-		// sequence that leaks when the two are not atomic.
 		if hook := evidenceRecordGateHook; hook != nil {
 			hook(sessionID)
 		}
@@ -139,9 +119,8 @@ func (d *Daemon) dwellGate() *dwellGate {
 	return d.sessionDwell
 }
 
-// recordPTYEvidence files an observation from the PTY layer. Sources that only
-// report a level (the heartbeat) and sources that report an edge (approval) land
-// in different fields, because the resolver ages them differently.
+// recordPTYEvidence files an observation from the PTY layer; levels (heartbeat)
+// and edges (approval) land in different fields and age differently.
 func (d *Daemon) recordPTYEvidence(sessionID string, obs pty.Observation) {
 	at := obs.At
 	if at.IsZero() {
@@ -149,9 +128,8 @@ func (d *Daemon) recordPTYEvidence(sessionID string, obs pty.Observation) {
 	}
 	switch obs.Source {
 	case pty.SourceHeartbeat:
-		// Codex announces an approval in its title, so the heartbeat channel
-		// carries three claims rather than two. It is still a level: the
-		// approval title holds, unrepainted, until the prompt is answered.
+		// Codex announces an approval in its title — still a level: the title
+		// holds, unrepainted, until the prompt is answered.
 		if obs.Claim == "approval" {
 			d.recordEvidence(sessionID, at, func(e *sessionstate.Evidence) {
 				e.LastHarnessEvent = &sessionstate.Observation{
@@ -180,10 +158,9 @@ func (d *Daemon) recordPTYEvidence(sessionID string, obs pty.Observation) {
 				Detail:     obs.Detail,
 				ObservedAt: at,
 			}
-			// LastBusyAt only advances on a busy frame: staleness is measured
-			// from the last time the turn was seen running, not from the last
-			// time the agent said anything. A non-busy frame mid-turn is a blip,
-			// not a settle.
+			// LastBusyAt only advances on a busy frame: staleness is measured from
+			// the last time the turn was seen running, not the last time the agent
+			// said anything.
 			if claim == sessionstate.ClaimBusy {
 				e.LastBusyAt = at
 			}
@@ -191,9 +168,9 @@ func (d *Daemon) recordPTYEvidence(sessionID string, obs pty.Observation) {
 	}
 }
 
-// recordBracketEvidence files a hook opening or closing a turn. The brackets are
-// the primary level: they are the only signal that survives the multi-second
-// title silence claude produces inside a blocking tool call.
+// recordBracketEvidence files a hook opening or closing a turn. The brackets
+// are the only signal that survives claude's multi-second title silence inside
+// a blocking tool call.
 func (d *Daemon) recordBracketEvidence(sessionID, state string) {
 	at := time.Now()
 	d.recordEvidence(sessionID, at, func(e *sessionstate.Evidence) {
@@ -201,16 +178,11 @@ func (d *Daemon) recordBracketEvidence(sessionID, state string) {
 		case protocol.StateWorking:
 			e.TurnOpen = true
 			e.TurnEverOpened = true
-			// A verdict judged the turn that just ended. Once the next one opens
-			// it is an answer to a question nobody asked any more, and leaving it
-			// in the table lets the resolver report it as this turn's state the
-			// moment this turn settles.
+			// A stale verdict judged the previous turn; left in the table the
+			// resolver would report it the moment this turn settles.
 			e.LastClassifier = nil
-			// The same holds for an unanswered approval or question: a turn cannot
-			// open while the one before it is still blocked on a person, so an edge
-			// still sitting here was answered. This is what retires the question
-			// claude's PostToolUse hook answers — it reports `working` the moment
-			// the user picks an option.
+			// A turn cannot open while the previous one is blocked on a person, so
+			// an edge still sitting here was answered.
 			if e.LastHarnessEvent != nil {
 				switch e.LastHarnessEvent.Claim {
 				case sessionstate.ClaimApprovalPending,
@@ -220,30 +192,20 @@ func (d *Daemon) recordBracketEvidence(sessionID, state string) {
 					e.LastHarnessEvent = nil
 				}
 			}
-			// Compaction cannot still be running while a turn is being worked:
-			// nothing else in the session moves until it finishes. So this is the
-			// backstop for a lost PostCompact, which would otherwise leave the
-			// session claiming to be compacting with only total silence left to
-			// contradict it.
+			// Backstop for a lost PostCompact: compaction cannot still be running
+			// while a turn is being worked.
 			e.Compacting = false
-			// And for how the last turn yielded. These describe a turn that has
-			// ended; a turn is open again, so whatever was going to resume it did.
-			// Left behind, outstanding background work pins the session working
-			// with nothing but total silence left to unpin it.
+			// These describe how the LAST turn yielded; left behind, outstanding
+			// background work pins the session working with only silence to unpin it.
 			e.BackgroundWork = false
 			e.PendingCron = false
 		case protocol.StateIdle:
 			e.TurnOpen = false
 			e.ToolOpen = false
 		case protocol.StateWaitingInput:
-			// The agent put a question to the user. It is an announcement of the
-			// same shape as an approval request — the turn is alive but blocked on a
-			// person, and nothing but the user answering ends it — so it is filed as
-			// one, and the resolver retires it the same way.
-			//
-			// Filing it is what lets the hook stop applying state itself. The
-			// brackets alone cannot express this: closing them says only that
-			// nothing is outstanding, which resolves to idle and loses the question.
+			// A question to the user is filed like an approval request — blocked on
+			// a person — and retired the same way. The brackets alone cannot express
+			// it: closing them resolves to idle and loses the question.
 			e.TurnOpen = false
 			e.ToolOpen = false
 			e.LastHarnessEvent = &sessionstate.Observation{
@@ -262,16 +224,8 @@ func (d *Daemon) recordBracketEvidence(sessionID, state string) {
 }
 
 // recordTranscriptEvidence files what the transcript watcher read. Copilot only:
-// it is the one agent with no hooks, so its transcript is where its turn and tool
-// brackets come from, and the states its behavior reports are those brackets by
-// another name — a turn opening, a turn ending, an approval appearing in the tool
-// lifecycle and later leaving it.
-//
-// The behavior still phrases them as states, and as states they were applied
-// directly, which is why several of its rules are written against whatever the
-// session currently shows rather than against what it saw. Filed as evidence they
-// no longer race the resolver; unpicking the phrasing is the copilot work this
-// phase deferred.
+// it has no hooks, so its transcript is where its brackets come from, phrased as
+// states.
 func (d *Daemon) recordTranscriptEvidence(sessionID, state, detail string, at time.Time) {
 	d.recordBracketEvidence(sessionID, state)
 	d.traceStateEvidence(
@@ -282,18 +236,9 @@ func (d *Daemon) recordTranscriptEvidence(sessionID, state, detail string, at ti
 }
 
 // recordTurnAbortedEvidence files the transcript's record that the user halted
-// the turn.
-//
-// The brackets are closed here as well as the edge filed, because the two expire
-// differently: the edge is retired by the next turn, while a bracket left open
-// would outlive it and resolve as a session stuck mid-turn. Closing them says the
-// true thing anyway — the turn this bracket described is over.
-// abortedAt is when the agent says the halt happened and observedAt is when attn
-// read it. They are recorded separately on purpose: the observation is dated by
-// the agent, so a halt read late — out of a replayed transcript, or behind a poll
-// the user has already typed past — is outranked by every busy frame that came
-// after it, while the table's movement clock still advances to now so a late read
-// cannot make a live session look stuck.
+// the turn. Brackets are closed too — an open one outlives the edge and resolves
+// as stuck mid-turn. abortedAt (agent-dated) and observedAt (read time) stay
+// separate so a late-read halt is outranked by later busy frames.
 func (d *Daemon) recordTurnAbortedEvidence(sessionID, detail string, abortedAt, observedAt time.Time) {
 	if observedAt.IsZero() {
 		observedAt = time.Now()
@@ -314,15 +259,8 @@ func (d *Daemon) recordTurnAbortedEvidence(sessionID, detail string, abortedAt, 
 	})
 }
 
-// recordTurnBracketClosedEvidence closes the brackets and says nothing else.
-//
-// It exists for the turn that ended in a way nobody needs reported: copilot
-// abandoning a turn for its own reasons, where filing a halt would put a user
-// action in the diagnosis that no user took, and asserting a state would guess at
-// what the session is doing before the classifier has looked. Closing the
-// brackets on their own is the whole true statement — the turn they described is
-// over — and it leaves the settle to the same quiet-window classification that
-// ends every other copilot turn.
+// recordTurnBracketClosedEvidence closes the brackets and says nothing else: for
+// copilot abandoning a turn, where a halt would invent a user action.
 func (d *Daemon) recordTurnBracketClosedEvidence(sessionID string, at time.Time) {
 	if at.IsZero() {
 		at = time.Now()
@@ -352,8 +290,6 @@ func (d *Daemon) recordClassifierEvidence(sessionID, state string, observedAt ti
 }
 
 // recordStopFacts files what the Stop hook reported about why a turn yielded.
-// These are the facts the CLI used to collapse into a state string before they
-// crossed the socket, which is why the resolver could not see them.
 func (d *Daemon) recordStopFacts(sessionID string, backgroundWork, pendingCron bool) {
 	d.recordEvidence(sessionID, time.Now(), func(e *sessionstate.Evidence) {
 		e.BackgroundWork = backgroundWork
@@ -361,30 +297,19 @@ func (d *Daemon) recordStopFacts(sessionID string, backgroundWork, pendingCron b
 	})
 }
 
-// recordReviewerEvidence files who answers approval requests. It is a level, not
-// an edge: it holds until something reports a different arrangement.
-//
-// It has two sources because the agents differ in what they will tell us. Both
-// are launched with a reviewer under the same condition, so the spawn is the
-// reliable one and the only one codex has — it reports no permission mode at all.
-// Claude's hook then carries the mode on every turn, which is what catches a user
-// changing it mid-session.
+// recordReviewerEvidence files who answers approval requests — a level, holding
+// until a different arrangement is reported. Two sources: the spawn route
+// (codex's only one) and claude's per-turn permission mode.
 func (d *Daemon) recordReviewerEvidence(sessionID string, inLoop bool) {
 	d.recordEvidence(sessionID, time.Now(), func(e *sessionstate.Evidence) {
 		e.ReviewerInLoop = inLoop
 	})
 }
 
-// recordReviewerEvidenceFromPermissionMode files claude's reported mode.
-//
-// Two things must not reach the evidence table through here. An absent mode is
-// not a report of "no reviewer" — it is an older CLI, or a payload that omitted
-// the field — and any mode at all from an agent that does not route approvals
-// by permission mode is not a report about approvals. Codex is the second case
-// concretely: its hooks send `default` on every turn as a payload filler while
-// its actual reviewer comes from the `approvals_reviewer` flag, so believing it
-// would retire the spawn-time fact on the first turn of every codex session and
-// take the dwell with it.
+// recordReviewerEvidenceFromPermissionMode files claude's reported mode. An
+// absent mode (older CLI) is not a report, and a mode from an agent whose mode
+// does not govern approvals must be ignored: codex sends `default` as filler,
+// which would retire the spawn-time fact on its first turn.
 func (d *Daemon) recordReviewerEvidenceFromPermissionMode(sessionID, permissionMode string) {
 	mode := strings.TrimSpace(permissionMode)
 	if mode == "" {
@@ -396,9 +321,8 @@ func (d *Daemon) recordReviewerEvidenceFromPermissionMode(sessionID, permissionM
 	d.recordReviewerEvidence(sessionID, mode != "default")
 }
 
-// permissionModeGovernsApprovals reports whether an agent's permission mode is
-// what decides who answers its approval requests. Claude's is; the others state
-// their arrangement at launch and never revise it.
+// permissionModeGovernsApprovals: claude's mode decides who answers approvals;
+// the others state their arrangement at launch and never revise it.
 func permissionModeGovernsApprovals(agent protocol.SessionAgent) bool {
 	return agent == protocol.SessionAgentClaude
 }
@@ -414,21 +338,16 @@ func (d *Daemon) sessionAgent(sessionID string) protocol.SessionAgent {
 	return session.Agent
 }
 
-// Notification types claude reports. Both are typed fields on the hook payload,
-// which is why attn reads them rather than the English message beside them.
+// Notification types claude reports as typed fields on the hook payload.
 const (
 	notifyPermissionPrompt = "permission_prompt"
 	notifyIdlePrompt       = "idle_prompt"
 )
 
 // recordNotificationEvidence files claude's Notification hook.
-//
-// The two types are not two flavors of one signal and do not land in the same
-// place. permission_prompt is a leading edge — the agent asked a question and is
-// blocked on the answer — so it becomes an approval claim. idle_prompt is a late
-// confirmation that the agent is parked at its prompt, 60s after a settle, and
-// it deliberately does not become a claim at all: it fires for finished turns
-// and for questions alike, so it can say "not working" but not what instead.
+// permission_prompt is a leading edge and becomes an approval claim.
+// idle_prompt deliberately becomes no claim: it fires for finished turns and
+// questions alike, so it can say "not working" but not what instead.
 func (d *Daemon) recordNotificationEvidence(sessionID, notificationType, message string) {
 	at := time.Now()
 	switch strings.TrimSpace(notificationType) {
@@ -448,14 +367,9 @@ func (d *Daemon) recordNotificationEvidence(sessionID, notificationType, message
 	}
 }
 
-// recordStopFailureEvidence files claude's StopFailure hook: the turn ended on
-// an API error instead of on an answer.
-//
-// It is filed as a harness edge rather than a stop, because it is not one. No
-// turn ended in the sense the Stop path means — there is no transcript worth
-// classifying and no result to report — and the session cannot make progress
-// until a person acts on the error. Filing it here also means the agent going
-// busy again retires it, which is exactly the edge that says the problem is over.
+// recordStopFailureEvidence files claude's StopFailure hook (turn ended on an
+// API error) as a harness edge, not a stop: nothing to classify, the session is
+// blocked on a person, and the agent going busy again retires it.
 func (d *Daemon) recordStopFailureEvidence(sessionID, errorType, message string) {
 	at := time.Now()
 	detail := strings.TrimSpace(errorType)
@@ -472,8 +386,8 @@ func (d *Daemon) recordStopFailureEvidence(sessionID, errorType, message string)
 	})
 }
 
-// recordCompactionEvidence files claude's PreCompact/PostCompact pair as a level:
-// the agent is rewriting its own context, and no other source reports it.
+// recordCompactionEvidence files claude's PreCompact/PostCompact pair as a
+// level; no other source reports compaction.
 func (d *Daemon) recordCompactionEvidence(sessionID string, active bool) {
 	d.recordEvidence(sessionID, time.Now(), func(e *sessionstate.Evidence) {
 		e.Compacting = active
@@ -496,40 +410,33 @@ func (d *Daemon) recordProcessEvidence(sessionID string, exited bool) {
 	})
 }
 
-// recordClassifierStarted marks a stop-time classification as running, so a
-// settle can wait for its verdict instead of publishing idle and correcting it
-// seconds later.
+// recordClassifierStarted marks a classification as running, so a settle waits
+// for the verdict instead of publishing idle and correcting it seconds later.
 func (d *Daemon) recordClassifierStarted(sessionID string, at time.Time) {
 	d.recordEvidence(sessionID, at, func(e *sessionstate.Evidence) {
 		e.ClassifyingSince = at
 	})
-	// A stop means the last published `working` may now be only the resolver's
-	// awaiting-verdict hold. Suspend auto-settle until the verdict tells us
-	// whether work actually continues. The fire path repeats this check to close
-	// the race with a timer callback that already removed itself from the map.
+	// Suspend auto-settle until the verdict lands; the fire path repeats this
+	// check to close the race with a timer that already left the map.
 	d.cancelAutoSettle(sessionID, "classification started")
 }
 
 // recordClassifierFinished clears that mark. It must run on every exit from a
-// classification, verdict or not: a classification that ends without applying
-// anything is exactly the case where the session has to settle on its own.
+// classification, verdict or not — one that applies nothing is exactly when the
+// session has to settle on its own.
 func (d *Daemon) recordClassifierFinished(sessionID string) {
 	d.recordEvidence(sessionID, time.Now(), func(e *sessionstate.Evidence) {
 		e.ClassifyingSince = time.Time{}
 	})
-	// No state transition is guaranteed here: a background-working verdict can
-	// leave the persisted state as `working`. Re-evaluate explicitly so that real
-	// continuing work gets the normal full arm and countdown again. Idle and
-	// user-wanted verdicts will move state and cancel it before the arm elapses.
+	// No transition is guaranteed here (a background-working verdict can leave
+	// `working` persisted), so re-evaluate auto-settle explicitly.
 	if session := d.store.Get(sessionID); session != nil {
 		d.syncAutoSettle(sessionID, string(session.State))
 	}
 }
 
 // runEvidenceResolveLoop re-resolves every session on a tick and publishes the
-// verdict. The tick is what makes evidence expire, and therefore what makes a
-// stuck state impossible: a session whose sources have all gone quiet is still
-// re-decided every second.
+// verdict, including sessions whose sources have gone quiet.
 func (d *Daemon) runEvidenceResolveLoop() {
 	ticker := time.NewTicker(evidenceTickInterval)
 	defer ticker.Stop()
@@ -562,19 +469,10 @@ func (d *Daemon) resolveAllSessions(now time.Time) {
 	}
 }
 
-// resolverOwnedStates are the states the resolver decides. A state outside this
-// set describes the session's lifecycle rather than what its agent is doing, and
-// the resolver has no evidence bearing on it: `recoverable` is owned by the revive
-// path, which sets it precisely because the worker is gone and its evidence is
-// therefore meaningless. Resolving that would let a stale process observation
-// stomp a state the resolver knows nothing about.
-//
-// `launching` is here because evidence is the definition of the agent having
-// spoken. It used to be excluded, with the first hook or worker poll writing a
-// state directly to end it; now that neither writes state, a session whose agent
-// is demonstrably running — hooks arriving, a title being painted — would sit in
-// `launching` for the rest of its life. A session registered from the user's own
-// terminal, which has no worker to poll at all, would never leave it.
+// resolverOwnedStates are the states the resolver decides; the rest describe
+// lifecycle, not agent activity (`recoverable` is the revive path's, and
+// resolving it would let a stale process observation stomp it). `launching` IS
+// owned: no source writes state directly, so excluding it strands the session.
 var resolverOwnedStates = map[protocol.SessionState]bool{
 	protocol.SessionStateLaunching:       true,
 	protocol.SessionStateWorking:         true,
@@ -585,44 +483,24 @@ var resolverOwnedStates = map[protocol.SessionState]bool{
 	protocol.SessionStateUnknown:         true,
 }
 
-// publishResolution applies the resolver's verdict, or records why it did not.
-//
-// Three verdicts do not move a session, and the difference between them is the
-// diagnosis a wrong color needs: Hold means the evidence is still arriving,
-// no-evidence means nothing has been recorded at all, and an unowned current
-// state means the resolver was not entitled to an opinion.
+// publishResolution applies the resolver's verdict, or records why it did not:
+// Hold means evidence is still arriving, no-evidence means nothing recorded,
+// and an unowned current state means the resolver had no standing.
 func (d *Daemon) publishResolution(sessionID string, current protocol.SessionState, resolution sessionstate.Resolution, dwell time.Duration, now time.Time) {
-	// A hold is traced, and it is the only non-application that is. It is the one
-	// that is both bounded and surprising: bounded because every hold clause
-	// expires, so the rows cannot accumulate, and surprising because a held
-	// session looks exactly like a stuck one from outside. The other three
-	// non-applications are the steady state of a quiet daemon — they would log
-	// once per session per second, forever, and say nothing.
+	// Only a hold is traced: it is bounded and looks stuck from outside, while the
+	// other non-applications would log once per session per second forever. The
+	// specific reason is traced, not the word "hold".
 	if resolution.Hold {
-		// The specific hold, not the word "hold": settle_grace and
-		// awaiting_verdict are held for different reasons and clear on different
-		// evidence, and a trace that collapses them cannot tell a session waiting
-		// on a classifier from one waiting on an approval announcement.
 		d.traceResolutionSkip(sessionID, resolution, string(resolution.Reason))
 		return
 	}
-	// ReasonNoEvidence is not a finding, it is the absence of one, and it
-	// resolves to unknown. Publishing it would repaint every session the
-	// evidence table has not heard about yet — including ones a hook is about to
-	// describe perfectly well.
-	//
-	// Stuck is the opposite: a session whose evidence stopped moving entirely is
-	// the one case where `unknown` is the honest answer rather than a shrug, and
-	// leaving it in whatever color it last showed is the failure this whole plan
-	// exists to remove.
+	// ReasonNoEvidence is the absence of a finding; publishing it would repaint
+	// every session the table has not heard about yet. Stuck is the opposite.
 	if resolution.Reason == sessionstate.ReasonNoEvidence {
 		return
 	}
 	// An external driver owns its session's state through sequenced report_*
-	// calls, and its evidence table fills up anyway — a plugin-driven session has
-	// a PTY like any other. The veto used to sit on each source's own write path;
-	// now that the resolver is the writer, it belongs here, or the tick would
-	// overwrite a report the driver considers current.
+	// calls; without this veto the tick would overwrite a current report.
 	if run := d.store.GetAgentDriverRun(sessionID); run.RunID != "" {
 		if session := d.store.Get(sessionID); session != nil && d.pluginDriverReportsState(session.Agent) {
 			d.traceResolutionSkip(sessionID, resolution, "plugin_driver_owns_state")
@@ -630,36 +508,25 @@ func (d *Daemon) publishResolution(sessionID string, current protocol.SessionSta
 		}
 	}
 	if !resolverOwnedStates[current] || resolution.State == current {
-		// No transition is on the table, so nothing is waiting out a dwell.
-		// Dropping the wait here is what keeps a later transition from
-		// inheriting a clock that started before an unrelated one.
+		// No transition: drop the dwell wait so a later one cannot inherit a clock
+		// that started before an unrelated transition.
 		d.dwellGate().clear(sessionID)
-		// The reason is recorded even though the state did not move: a session
-		// that is already `unknown` still needs to say why, and the reason is the
-		// difference between a badge the user can act on and one that only says
-		// "something". It still has to reach the client, and it rides on session
-		// broadcasts, which otherwise only happen when the state itself moves —
-		// so a session that is already `unknown` and then goes silent would keep
-		// its old tooltip while the daemon knew it was stuck. Gated on the delta
-		// because the reason is recomputed every tick and almost never changes.
+		// Recorded even without a move (an already-`unknown` session that goes
+		// silent still needs its tooltip updated), broadcast only on delta.
 		if d.recordStateReason(sessionID, resolution) && resolverOwnedStates[current] {
 			d.broadcastSessionStateChanged(sessionID)
 		}
 		return
 	}
-	// Last gate before publication on purpose: everything above decides what is
-	// true, and this decides whether it has been true long enough to be worth
-	// showing. Putting it earlier would let a transition serve out its dwell and
-	// then be discarded for a reason that had nothing to do with timing.
+	// Last gate on purpose: everything above decides what is true, this decides
+	// whether it has been true long enough to show.
 	if !d.dwellGate().ready(sessionID, resolution.State, dwell, now) {
 		d.traceResolutionSkip(sessionID, resolution, "dwell")
 		return
 	}
-	// Below the dwell, not above it: the reason explains the state the session is
-	// showing, and recording it for a transition still serving out its dwell
-	// publishes a pair that contradicts itself — `working`, because a guardian may
-	// yet answer, alongside `approval_open`, because one is outstanding. Witnessed
-	// on a live guardian session before the move.
+	// Below the dwell, not above: recording the reason for a transition still
+	// serving its dwell publishes a self-contradicting pair (`working` alongside
+	// `approval_open`), witnessed on a live session.
 	d.recordStateReason(sessionID, resolution)
 	d.applyState(sessionStateChange{
 		sessionID: sessionID,
@@ -672,9 +539,8 @@ func (d *Daemon) publishResolution(sessionID string, current protocol.SessionSta
 	})
 }
 
-// resolutionDetail is what `attn state explain` shows for a resolver row. The
-// reason is the useful half — it names the clause that won — so it leads, and
-// the winning observation's own detail follows when it has one.
+// resolutionDetail is what `attn state explain` shows for a resolver row: the
+// winning clause's reason first, its own detail after.
 func resolutionDetail(resolution sessionstate.Resolution) string {
 	if resolution.Detail == "" {
 		return string(resolution.Reason)
@@ -694,11 +560,8 @@ func (d *Daemon) traceResolutionSkip(sessionID string, resolution sessionstate.R
 	})
 }
 
-// classifierClaim reads a verdict. The classifier judges how a stopped turn
-// ended — the user is waited on, nothing is, or (on a yield) the turn waits on
-// its own background work — and anything else, including the `unknown` a failed
-// classification used to publish, is no verdict at all rather than a fourth
-// answer.
+// classifierClaim reads a verdict. Anything outside the three answers — the
+// `unknown` a failed classification publishes included — is no verdict at all.
 func classifierClaim(state string) sessionstate.Claim {
 	switch state {
 	case protocol.StateWaitingInput:

--- a/internal/daemon/session_recovered_evidence.go
+++ b/internal/daemon/session_recovered_evidence.go
@@ -8,33 +8,17 @@ import (
 	"github.com/victorarias/attn/internal/sessionstate"
 )
 
-// Recovering a session's evidence after a daemon restart.
-//
-// The evidence table is in memory, so a new daemon starts knowing nothing about
-// agents that have been running for hours. That is survivable for a busy agent —
-// it repaints its title within a second and the table refills itself — and fatal
-// for a quiet one, which writes nothing at all to its PTY and would therefore
-// never produce a single piece of evidence again. The resolver would then have
-// nothing to say about it for the rest of its life.
-//
-// Three things are recoverable because their sources outlived the daemon:
-//
-//   - The level. The worker holds the last observation its signal observers
-//     emitted, timestamped. A level is a standing claim, so reading it back is
-//     not a guess about the past — it is what the agent is still saying.
-//   - The outstanding harness edge. An approval or a question is not in the
-//     worker, but the session's own persisted state *is* the record that one was
-//     outstanding, and nothing has happened since to answer it.
-//   - The approval route. The surviving worker registry records the effective
-//     launch-time route, with the session's durable launch intent as fallback.
-//
-// What is deliberately not reconstructed is the bracket pair (turn open, tool
-// open). Those are hook-driven and genuinely gone, and inventing them would hold
-// a session `working` on a bracket whose closing hook can never arrive.
+// Recovering a session's evidence after a daemon restart. The in-memory
+// evidence table starts empty, which is fatal for a quiet agent that never
+// writes to its PTY again. Three sources outlived the daemon and are re-seeded:
+// the worker's last signal level, the persisted-state record of an outstanding
+// approval/question edge, and the worker registry's approval route. The bracket
+// pair (turn/tool open) is deliberately NOT reconstructed: it is hook-driven and
+// gone, and inventing it would hold a session `working` on a bracket whose
+// closing hook can never arrive.
 
-// seedRecoveredEvidence files what the worker and the store between them still
-// know about a re-adopted session, so the resolver has a basis for its first
-// tick instead of an empty row.
+// seedRecoveredEvidence files what the worker and store still know about a
+// re-adopted session, so the resolver's first tick has a basis.
 func (d *Daemon) seedRecoveredEvidence(sessionID string, existing *protocol.Session, info ptybackend.SessionInfo) {
 	if d == nil || existing == nil {
 		return
@@ -43,28 +27,18 @@ func (d *Daemon) seedRecoveredEvidence(sessionID string, existing *protocol.Sess
 		d.recordReviewerEvidence(sessionID, route.ReviewerInLoop())
 	}
 	if info.HasLastSignal {
-		// Routed through the ordinary PTY evidence path rather than written
-		// directly: the translation from a title claim to evidence has a case that
-		// matters here — codex announces approvals in its title — and recovery must
-		// not grow a second, subtly different copy of it.
+		// Via the ordinary PTY evidence path: codex announces approvals in its
+		// title, and recovery must not grow a second copy of that translation.
 		d.recordPTYEvidence(sessionID, info.LastSignal)
 	}
 	d.seedRecoveredHarnessEdge(sessionID, existing, info)
 }
 
-// seedRecoveredHarnessEdge restores the "the agent is blocked on a person" edge
-// for a session that was in one of those states when the daemon went down.
-//
-// Without it the level alone decides, and the level cannot tell an agent waiting
-// on an approval from one that has simply finished: both paint the same not-busy
-// glyph. The resolver would read the restored session as a fresh prompt and
-// settle it to idle, which loses the loudest state attn has.
-//
-// The guard is what keeps that from being a lie in the other direction. If the
-// agent painted a title *after* the daemon concluded the approval, then it moved
-// while nobody was watching — the prompt was answered, the turn ran on — and the
-// edge describes a moment that is over. Only a level no newer than the
-// conclusion still corroborates it.
+// seedRecoveredHarnessEdge restores the blocked-on-a-person edge for a session
+// that was in such a state at shutdown; without it the resolver settles the
+// session to idle, losing the loudest state attn has. Guard: a title painted
+// after the state was concluded means the prompt was answered while nobody was
+// watching, so only a level no newer than the conclusion corroborates the edge.
 func (d *Daemon) seedRecoveredHarnessEdge(sessionID string, existing *protocol.Session, info ptybackend.SessionInfo) {
 	claim, ok := recoveredHarnessClaim(existing.State)
 	if !ok {
@@ -84,17 +58,14 @@ func (d *Daemon) seedRecoveredHarnessEdge(sessionID string, existing *protocol.S
 			Detail:     "recovered from persisted state",
 			ObservedAt: concludedAt,
 		}
-		// A session cannot have reached either of these states without having
-		// taken a turn, and the resolver reads "never took a turn" as a session
-		// sitting at a fresh prompt. Saying so keeps a recovered agent from being
-		// described as one that has not started yet.
+		// These states imply a turn was taken; without this the resolver reads the
+		// session as sitting at a fresh prompt.
 		e.TurnEverOpened = true
 	})
 }
 
-// recoveredHarnessClaim maps the two states that mean an outstanding harness edge
-// onto the claim that produced them. Every other state is either resolvable from
-// the level alone or not the resolver's to begin with.
+// recoveredHarnessClaim maps the two outstanding-harness-edge states onto the
+// claim that produced them.
 func recoveredHarnessClaim(state protocol.SessionState) (sessionstate.Claim, bool) {
 	switch state {
 	case protocol.SessionStatePendingApproval:
@@ -106,10 +77,8 @@ func recoveredHarnessClaim(state protocol.SessionState) (sessionstate.Claim, boo
 	}
 }
 
-// parseSessionStateSince is when the daemon last concluded the session's current
-// state. It is the timestamp a recovered edge is stamped with, and the one the
-// level is compared against, so an unparseable stamp means no seeding rather
-// than a made-up instant.
+// parseSessionStateSince is when the daemon last concluded the current state.
+// An unparseable stamp means no seeding rather than a made-up instant.
 func parseSessionStateSince(session *protocol.Session) (time.Time, bool) {
 	stamp, err := time.Parse(time.RFC3339Nano, session.StateSince)
 	if err != nil {

--- a/internal/daemon/session_state.go
+++ b/internal/daemon/session_state.go
@@ -14,25 +14,13 @@ type sessionStateCause interface {
 	isSessionStateCause()
 }
 
-// liveSignal is the worker poll reporting the state a worker was spawned into.
-// It is what takes a session out of `launching`, and the only claim from outside
-// the resolver about what an agent is doing that still commits — see
-// pty.Source.AppliesState.
-//
-// It used to be the vocabulary of every hook and PTY observation. Those are
-// evidence now: they record what they saw, and the resolver decides what it
-// means. The causes that went with them (a synchronous daemon observation, a
-// timestamped classifier verdict, a process exit) went with them.
+// liveSignal is the worker poll reporting the state a worker was spawned into —
+// what takes a session out of `launching`, and the only claim from outside the
+// resolver that still commits; see pty.Source.AppliesState.
 type liveSignal struct{}
 
-// resolverObservation is the evidence resolver's verdict on its tick. Unlike
-// every other cause it is not an edge reported by a source: it is a re-reading
-// of all the evidence at once, which is what lets it move a session no source
-// spoke about.
-//
-// It carries no timestamp. A resolution is a statement about now, computed from
-// evidence whose own ages the resolver has already weighed, so there is nothing
-// for the store to compare it against.
+// resolverObservation is the resolver's verdict on its tick: all evidence re-read
+// at once, so it can move a session no source spoke about. No timestamp.
 type resolverObservation struct{}
 
 // pluginReport carries the active driver run cursor used for ordered state CAS.
@@ -54,17 +42,13 @@ type sessionStateChange struct {
 	sessionID string
 	state     string
 	cause     sessionStateCause
-	// origin describes the evidence behind the change for the diagnostic trace.
-	// It is optional: a caller that leaves it zero is traced under its cause
-	// name, which is all a daemon-internal transition has to say about itself.
-	// It never affects whether the change commits.
+	// origin describes the evidence behind the change for the diagnostic trace;
+	// optional (zero traces under the cause name) and never affects the commit.
 	origin stateOrigin
 }
 
-// stateOrigin is where a state claim came from, as distinct from the commit rule
-// it travels under. Several sources share one cause — every trusted PTY
-// observation is a liveSignal — so the cause alone cannot tell a screen scrape
-// from an approval edge when a color turns out wrong.
+// stateOrigin is where a state claim came from, as distinct from the commit
+// rule it travels under; several sources share one cause.
 type stateOrigin struct {
 	source     string
 	detail     string
@@ -126,9 +110,8 @@ func (d *Daemon) applyState(change sessionStateChange) bool {
 	if profile.syncNudge {
 		d.doorbellMu.Lock()
 	}
-	// Unconditional, unlike the nudge lock above: syncAutoSettle runs for every
-	// cause, so every state write has to be ordered against a timer that may be
-	// deciding to settle right now. See autoSettleFireMu.
+	// Unconditional: every state write must be ordered against a timer that may
+	// be deciding to settle right now. See autoSettleFireMu.
 	d.autoSettleFireMu.Lock()
 	applied := d.commitSessionState(change)
 	d.autoSettleFireMu.Unlock()
@@ -147,16 +130,9 @@ func (d *Daemon) applyState(change sessionStateChange) bool {
 	}
 	d.traceStateChange(change, statetrace.OutcomeApplied, "")
 
-	// A turn opens on a state and closes only when the user settles it, so this
-	// is the one place a turn ever opens. It runs for every cause, including
-	// startup recovery: a session that comes back in a state that wants the user
-	// wants the user regardless of what moved it there. Opening is guarded in the
-	// store, so a state re-reported while a turn is already open changes nothing.
-	//
-	// A snooze suppresses that, which is the whole of the deferral: the state is
-	// still committed and still broadcast, it simply does not put the agent back
-	// on the user's plate. A state that breaks through clears the snooze inside
-	// the check and falls through to open the turn it would have opened anyway.
+	// The one place a turn ever opens; runs for every cause and the store guards
+	// re-opens. A snooze suppresses only this — the state is still committed and
+	// broadcast — and a state that breaks through clears the snooze in the check.
 	if attention.OpensTurn(protocol.SessionState(change.state)) &&
 		!d.snoozeSuppressesTurn(change.sessionID, protocol.SessionState(change.state)) {
 		d.store.OpenTurnIfClosed(change.sessionID, time.Now())
@@ -174,10 +150,8 @@ func (d *Daemon) applyState(change sessionStateChange) bool {
 	if profile.syncNudge {
 		d.syncNudgeForState(change.sessionID, change.state)
 	}
-	// After the turn is opened above, so a state that both opens a turn and is
-	// `working` is impossible to see half-applied. It runs for every cause,
-	// including startup recovery: a session restored into `working` with a turn
-	// still owed is exactly the case auto-settle exists for.
+	// After the turn open above, so a state that both opens a turn and is
+	// `working` is never seen half-applied; runs for every cause.
 	d.syncAutoSettle(change.sessionID, change.state)
 	if profile.broadcast {
 		d.broadcastSessionStateChanged(change.sessionID)

--- a/internal/daemon/snooze.go
+++ b/internal/daemon/snooze.go
@@ -9,43 +9,23 @@ import (
 	"github.com/victorarias/attn/internal/statetrace"
 )
 
-// Snooze is the queue's *not now*.
-//
-// Settle answers "I dealt with this"; nothing else answered "come back later",
-// so an agent you could not act on yet had to be either settled — a lie, since
-// the turn returns the moment it stops again — or left in the band making the
-// queue mean less. Snooze closes the turn and stops the next one from opening
-// until a deadline the user named.
-//
-// It suppresses turns at the moment they would *open*, rather than filtering
-// them out at read the way the shell/chief/pinned/muted exclusions do. The
-// difference is what the user sees when the deadline passes: a read filter keeps
-// stamping, so the turn resurfaces at its original age and lands at the head of
-// the band, while suppression means the turn opens at the wake instant and lands
-// at the tail. The vision asks for the tail — you deferred it, so the clock on
-// what you owe starts when you said you would come back.
-//
-// Because a snooze always settles as it is written, attention.Owed needs to know
-// nothing about it: a snoozed session simply has no turn open. The deadline
-// rides the wire only so the sidebar can park the row and say when it returns.
-//
-// The timers are in memory and the deadline is in the store, which is what makes
-// a snooze survive a restart — see rescheduleSnoozeWakes.
+// Snooze is the queue's *not now*: it closes the turn and stops the next one
+// from opening until a user-named deadline. It suppresses turns as they would
+// OPEN, not at read like the shell/chief/pinned/muted exclusions, so a lapsed
+// snooze resurfaces at the tail of the band and attention.Owed needs to know
+// nothing about it. Timers are in memory, the deadline is in the store — see
+// rescheduleSnoozeWakes.
 
-// snoozeTimer is a session's pending wake. firesAt is kept beside the timer
-// because time.Timer exposes no deadline accessor and the reschedule path needs
-// to know whether a stored deadline is the one already armed.
+// snoozeTimer is a session's pending wake. firesAt exists because time.Timer
+// exposes no deadline accessor.
 type snoozeTimer struct {
 	timer   *time.Timer
 	firesAt time.Time
 }
 
-// handleSnoozeTurn defers a session until the instant the client computed.
-//
-// The client owns the arithmetic on purpose: "tomorrow" and "Monday" are
-// calendar questions that need the user's timezone and locale, and a remote
-// endpoint's daemon shares neither. The daemon takes an instant and schedules
-// against it.
+// handleSnoozeTurn defers a session until the instant the client computed. The
+// client owns the arithmetic on purpose: "tomorrow" needs the user's timezone
+// and locale, which a remote endpoint's daemon shares neither of.
 func (d *Daemon) handleSnoozeTurn(msg *protocol.SnoozeTurnMessage) {
 	if d == nil || d.store == nil || msg == nil {
 		return
@@ -62,11 +42,8 @@ func (d *Daemon) handleSnoozeTurn(msg *protocol.SnoozeTurnMessage) {
 	if !d.store.SnoozeTurn(sessionID, until, time.Now()) {
 		return
 	}
-	// A snooze settles, so any countdown aimed at the same turn is moot — leaving
-	// one running would promise a second settle on a turn that is already closed.
+	// A snooze settles, so a countdown aimed at the same turn is moot.
 	d.cancelAutoSettle(sessionID, "snoozed")
-	// A snooze is a settle with a reason, and the trace is where the pairing with
-	// the state it closed survives.
 	d.traceSettle(sessionID)
 	d.scheduleSnoozeWake(sessionID, until)
 	d.broadcastSessionStateChanged(sessionID)
@@ -84,32 +61,23 @@ func (d *Daemon) handleWakeTurn(msg *protocol.WakeTurnMessage) {
 	d.wakeSnooze(sessionID, time.Now(), "user")
 }
 
-// wakeSnooze clears a snooze and opens a turn if the session is sitting in a
-// state that wants the user. `at` is the instant the turn is stamped with, which
-// is the deadline for a timer wake and now for every other cause: a snooze that
-// lapsed while the daemon was down has genuinely been owed since it lapsed, and
-// the queue orders by how long you have owed something.
-//
-// Waking a session that is busy opens nothing. That is not a missed turn — the
-// agent is working, and the next state that wants the user opens one normally,
-// now that nothing is suppressing it.
+// wakeSnooze clears a snooze and opens a turn if the state wants the user. `at`
+// stamps it: the deadline for a timer wake (one that lapsed while the daemon was
+// down has been owed since then), now otherwise.
 func (d *Daemon) wakeSnooze(sessionID string, at time.Time, cause string) {
 	if d == nil || d.store == nil || sessionID == "" {
 		return
 	}
 	d.cancelSnoozeWake(sessionID)
 	if !d.store.WakeTurn(sessionID) {
-		// No snooze was live. Staying silent keeps a redundant wake — a timer that
-		// lost a race with a hand wake, say — from broadcasting.
+		// No snooze was live; a redundant wake must not broadcast.
 		return
 	}
 	d.finishSnoozeWake(sessionID, at, cause)
 }
 
-// finishSnoozeWake is everything a wake does once the deadline is cleared: open
-// the turn if the agent is sitting in a state that wants the user, record it,
-// and say so. Shared by the hand wake and the timer, which differ only in how
-// they decide the snooze was theirs to end.
+// finishSnoozeWake is everything a wake does once the deadline is cleared,
+// shared by the hand wake and the timer.
 func (d *Daemon) finishSnoozeWake(sessionID string, at time.Time, cause string) {
 	if session := d.store.Get(sessionID); session != nil && attention.OpensTurn(session.State) {
 		d.store.OpenTurnIfClosed(sessionID, d.turnOpensAtOnWake(sessionID, at))
@@ -127,19 +95,9 @@ func (d *Daemon) finishSnoozeWake(sessionID string, at time.Time, cause string) 
 	d.broadcastSessionStateChanged(sessionID)
 }
 
-// turnOpensAtOnWake is the instant a woken turn is stamped with.
-//
-// Normally that is the deadline: a snooze that lapsed at 11:00 has been owed
-// since 11:00, whether or not the daemon was running to notice. But membership
-// is `opened > settled`, and the settle that created the deferral is stamped at
-// the moment it was pressed — so a deadline that is not after it produces a turn
-// that reads as already closed, and the agent is silently lost rather than
-// deferred. That happens for a snooze whose deadline was already stale when it
-// arrived: clock skew across endpoints, or a client sending an instant it
-// computed a while ago.
-//
-// Such a deferral was over before it began, so it ends when we notice, and the
-// turn is owed from then.
+// turnOpensAtOnWake stamps a woken turn with the deadline — unless membership
+// (`opened > settled`) would read it as already closed and silently lose the
+// agent, in which case the turn is owed from now.
 func (d *Daemon) turnOpensAtOnWake(sessionID string, deadline time.Time) time.Time {
 	if deadline.After(d.store.TurnStamps(sessionID).SettledAt) {
 		return deadline
@@ -148,8 +106,6 @@ func (d *Daemon) turnOpensAtOnWake(sessionID string, deadline time.Time) time.Ti
 }
 
 // currentStateClaim is the session's state as a string, or "" if it is gone.
-// The trace wants the state a wake landed on, the same way traceSettle wants the
-// state a settle closed.
 func (d *Daemon) currentStateClaim(sessionID string) string {
 	session := d.store.Get(sessionID)
 	if session == nil {
@@ -158,20 +114,10 @@ func (d *Daemon) currentStateClaim(sessionID string) string {
 	return string(session.State)
 }
 
-// snoozeSuppressesTurn is the gate applyState consults before opening a turn.
-//
-// It reports whether this session is deferred past the state it just reached. A
-// state that breaks through both returns false *and* clears the snooze, because
-// a deferral interrupted by something the user could not have anticipated is
-// over: they are back in the loop with that agent, and silently resuming the
-// remainder later would re-assert an intent they have since moved past.
-//
-// It is called from inside applyState, after the state is committed and before
-// the turn opens, so the break-through opens the very turn the state would have
-// opened had nothing been deferred. The reason is read from the resolver's own
-// record rather than threaded through sessionStateChange: publishResolution
-// files it immediately before applying, so it already describes the state being
-// committed, and a caller outside the resolver has no reason to supply.
+// snoozeSuppressesTurn is the gate applyState consults after the state commits
+// and before the turn opens. A break-through state returns false AND clears the
+// snooze, so the break-through opens the very turn the state would have; the
+// reason comes from the resolver's record, filed immediately before applying.
 func (d *Daemon) snoozeSuppressesTurn(sessionID string, state protocol.SessionState) bool {
 	if d == nil || d.store == nil {
 		return false
@@ -191,9 +137,8 @@ func (d *Daemon) snoozeSuppressesTurn(sessionID string, state protocol.SessionSt
 	return false
 }
 
-// scheduleSnoozeWake arms (or replaces) a session's wake timer. A deadline
-// already in the past fires immediately, which is what makes a snooze that
-// lapsed during a restart behave like one that lapsed while the daemon was up.
+// scheduleSnoozeWake arms (or replaces) a session's wake timer; a past deadline
+// fires immediately, so a snooze that lapsed during a restart still wakes.
 func (d *Daemon) scheduleSnoozeWake(sessionID string, until time.Time) {
 	if d == nil || sessionID == "" {
 		return
@@ -214,10 +159,9 @@ func (d *Daemon) scheduleSnoozeWakeLocked(sessionID string, until time.Time) {
 	if window < 0 {
 		window = 0
 	}
-	// The ready channel is the handshake auto_settle.go and nudge_countdown.go
-	// both use: the closure blocks until `timer` is published, so the identity
-	// check in the fire path reads a fully written value even when a zero window
-	// fires immediately.
+	// Same ready-channel handshake as auto_settle.go: the closure blocks until
+	// `timer` is published, so the fire path's identity check reads a fully
+	// written value even when a zero window fires immediately.
 	ready := make(chan struct{})
 	var timer *time.Timer
 	timer = time.AfterFunc(window, func() {
@@ -228,23 +172,10 @@ func (d *Daemon) scheduleSnoozeWakeLocked(sessionID string, until time.Time) {
 	close(ready)
 }
 
-// fireSnoozeWake is the timer arriving.
-//
-// Two checks, because a fired timer can be stale in two different ways. The
-// identity check under the lock keeps a timer that lost a cancel-or-replace race
-// from waking a session at all. The deadline check in the store keeps one that
-// won that race but was replaced *in the gap between* — the lock is dropped
-// before the wake, and a snooze landing in that window has already written a
-// later deadline and armed its own timer. Clearing unconditionally there would
-// cash a promise the user had just replaced, waking the agent immediately
-// instead of at the time they chose; and the cancel wakeSnooze does would take
-// the replacement's timer with it, so the later deadline would never fire
-// either.
-//
-// So the timer path never cancels — its own entry is already gone, and anything
-// in the map now belongs to a newer snooze — and it clears only the deadline it
-// was armed for. Losing either check means someone else owns this session's
-// deferral now, and the right thing to do is nothing.
+// fireSnoozeWake is the timer arriving. Two staleness checks: the identity check
+// under the lock catches a lost cancel-or-replace race, and WakeTurnAt catches a
+// replacement made in the gap after the lock is dropped — clearing
+// unconditionally there would wake the agent instead of at the later deadline.
 func (d *Daemon) fireSnoozeWake(sessionID string, self *time.Timer, deadline time.Time) {
 	d.snoozeMu.Lock()
 	entry, ok := d.snoozeTimers[sessionID]
@@ -255,8 +186,8 @@ func (d *Daemon) fireSnoozeWake(sessionID string, self *time.Timer, deadline tim
 	delete(d.snoozeTimers, sessionID)
 	d.snoozeMu.Unlock()
 
-	// The hook fires however this ends: it means "this timer has finished", which
-	// is the only thing a test can wait on without knowing which snooze won.
+	// Fires however this ends: the only thing a test can wait on without knowing
+	// which snooze won.
 	if d.snoozeWakeHook != nil {
 		defer d.snoozeWakeHook(sessionID)
 	}
@@ -308,10 +239,8 @@ func (d *Daemon) stopSnoozeTimers() {
 	}
 }
 
-// rescheduleSnoozeWakes rebuilds the wake timers from the store at start-up.
-// The deadlines are persisted but the timers are not, so without this a snooze
-// would survive a restart as a session that never comes back — the worst
-// possible failure for a feature whose whole promise is that it returns.
+// rescheduleSnoozeWakes rebuilds the wake timers from the store at start-up;
+// without it a snooze survives a restart as a session that never comes back.
 func (d *Daemon) rescheduleSnoozeWakes() {
 	if d == nil || d.store == nil {
 		return
@@ -322,9 +251,8 @@ func (d *Daemon) rescheduleSnoozeWakes() {
 }
 
 // decorateSessionWithSnooze stamps the broadcast clone with a live snooze
-// deadline. A deadline in the past is left off: the wake is racing this
-// broadcast, and announcing a snooze that has already lapsed would park the row
-// in the snoozed section for as long as it took the timer to land.
+// deadline. A lapsed deadline is left off: the wake is racing this broadcast,
+// and announcing it would park the row snoozed until the timer lands.
 func (d *Daemon) decorateSessionWithSnooze(session *protocol.Session) {
 	if session == nil || d.store == nil {
 		return

--- a/internal/daemon/state_trace.go
+++ b/internal/daemon/state_trace.go
@@ -10,55 +10,30 @@ import (
 	"github.com/victorarias/attn/internal/statetrace"
 )
 
-// The daemon logs the state transitions it accepts and says nothing about the
-// ones it drops, which makes a stuck color impossible to diagnose from the log:
-// a stuck session is precisely one where nothing is being applied. These helpers
-// record every observation the daemon acts on — applied, vetoed before the store
-// door, discarded by the store, or skipped by its own source — into a capped
-// per-session ring, and mirror each one to the daemon log.
-//
-// Nothing here arbitrates: no function in this file can change which state a
-// session ends up in.
+// Per-session trace ring recording every state observation — applied, vetoed,
+// store-discarded, or skipped. Nothing here arbitrates: no function in this
+// file can change a session's state.
 
-// Source names for state evidence that does not come from the PTY layer (those
-// carry pty.Source through pty.Observation). These are deliberately named after
-// the mechanism, not the state it reports, because two of them can report the
-// same state for unrelated reasons.
+// Source names for non-PTY state evidence, named after the mechanism rather
+// than the state it reports.
 const (
-	// stateSourceHook is the agent's own state hook reporting through
-	// `attn _hook-state`.
-	stateSourceHook = "hook_state"
-	// stateSourceStopHook is the Stop hook holding a yielded turn open on the
-	// facts it reported (background work, a pending scheduled wakeup).
-	stateSourceStopHook = "hook_stop"
-	// stateSourceClassifier is the stop-time classification pipeline, including
-	// the rules that settle a turn without paying for the LLM call.
-	stateSourceClassifier = "classifier"
-	// stateSourceTranscript is the transcript watcher reading the agent's JSONL.
-	stateSourceTranscript = "transcript_watcher"
-	// stateSourcePluginDriver is an external agent driver's sequenced report.
+	stateSourceHook         = "hook_state"
+	stateSourceStopHook     = "hook_stop"
+	stateSourceClassifier   = "classifier"
+	stateSourceTranscript   = "transcript_watcher"
 	stateSourcePluginDriver = "plugin_driver"
-	// stateSourceHookNotify is Claude's Notification hook — the harness saying
-	// out loud that it is blocked on the user. It reports a notification_type,
-	// not a state.
+	// Reports a notification_type, not a state.
 	stateSourceHookNotify = "hook_notify"
-	// stateSourceHookStopFailure is Claude's StopFailure hook — the turn ended on
-	// an API error rather than on an answer. It reports an error_type.
+	// Claude's StopFailure hook (turn ended on an API error); reports an error_type.
 	stateSourceHookStopFailure = "hook_stop_failure"
-	// stateSourceHookCompaction is Claude's PreCompact/PostCompact pair bracketing
-	// the agent rewriting its own context.
-	stateSourceHookCompaction = "hook_compaction"
-	// stateSourceReviewer is the agent's resolved permission mode, reported as a
-	// fact on the state hook. It says who answers an approval request, which is
-	// what separates a real approval stall from a guardian's brief round trip.
+	stateSourceHookCompaction  = "hook_compaction"
+	// The agent's resolved permission mode — who answers an approval request.
 	stateSourceReviewer = "reviewer"
-	// stateSourceResolver is the evidence resolver's own verdict.
 	stateSourceResolver = "resolver"
 )
 
 // stateTraceRecordGateHook runs inside the recorder's lock, between the liveness
-// check and the write. Tests only: it is the seam where a concurrent removal
-// would have to interleave for the ring to leak.
+// check and the write. Tests only: the seam a concurrent removal must hit.
 var stateTraceRecordGateHook func(sessionID string)
 
 // stateTraceRecorder returns the daemon's trace ring, building it on first use
@@ -70,14 +45,9 @@ func (d *Daemon) stateTraceRecorder() *statetrace.Recorder {
 	return d.stateTrace
 }
 
-// recordStateObservation is the single write path into the trace.
-//
-// An observation for a session with no store row is logged and not ringed. Such
-// an id can never be read back — `attn state explain` needs a store row — and it
-// can never be cleaned up either, because the cleanup hangs off session removal.
-// Ringing it would leak one map entry per stale id for the daemon's lifetime,
-// and stale ids are not rare: a worker event racing a session removal produces
-// one every time. The daemon log is the right home for them.
+// recordStateObservation is the single write path into the trace. An observation
+// for a session with no store row is logged, never ringed — it would leak one
+// map entry per stale id.
 func (d *Daemon) recordStateObservation(sessionID string, obs statetrace.Observation) {
 	if strings.TrimSpace(sessionID) == "" {
 		return
@@ -88,15 +58,10 @@ func (d *Daemon) recordStateObservation(sessionID string, obs statetrace.Observa
 	if obs.ObservedAt.IsZero() {
 		obs.ObservedAt = obs.RecordedAt
 	}
-	// The liveness check runs inside the recorder's lock (RecordIf), not before
-	// it. Checking first and recording after leaves a window where the session is
-	// removed and its ring forgotten in between, and the writer then creates a
-	// fresh ring for an id that will never be forgotten again.
+	// The liveness check must stay inside the recorder's lock (RecordIf): checked
+	// before it, a racing removal mints a ring that is never forgotten again.
 	d.stateTraceRecorder().RecordIf(sessionID, obs, func() bool {
 		live := d.store != nil && d.store.Get(sessionID) != nil
-		// The hook runs after the check on purpose: check-then-write is the
-		// sequence that leaks when the two are not atomic, so this is where a
-		// racing removal has to be injected to falsify the lock.
 		if hook := stateTraceRecordGateHook; hook != nil {
 			hook(sessionID)
 		}
@@ -105,9 +70,7 @@ func (d *Daemon) recordStateObservation(sessionID string, obs statetrace.Observa
 	d.logf("%s", obs.LogLine(sessionID))
 }
 
-// traceStateChange records the fate of a change that reached applyState. The
-// origin is optional; without one the cause name stands in as the source, which
-// is all a daemon-internal transition can say about where it came from.
+// traceStateChange records the fate of a change that reached applyState.
 func (d *Daemon) traceStateChange(change sessionStateChange, outcome statetrace.Outcome, reason string) {
 	source := change.origin.source
 	if source == "" {
@@ -124,9 +87,8 @@ func (d *Daemon) traceStateChange(change sessionStateChange, outcome statetrace.
 	})
 }
 
-// traceStateVeto records an observation rejected before it reached applyState.
-// These are the interesting ones for a stuck color: the state never got near the
-// store, so no other log line mentions it at all.
+// traceStateVeto records an observation rejected before it reached applyState —
+// the ones no other log line mentions at all.
 func (d *Daemon) traceStateVeto(sessionID string, origin stateOrigin, claim, reason string) {
 	d.recordStateObservation(sessionID, statetrace.Observation{
 		Source:     origin.source,
@@ -139,8 +101,7 @@ func (d *Daemon) traceStateVeto(sessionID string, origin stateOrigin, claim, rea
 }
 
 // traceStateEvidence records an observation whose source does not drive session
-// state. It is recorded and goes no further — the observation never reaches
-// applyState, so it has no cause and cannot be applied or rejected by the store.
+// state; it never reaches applyState.
 func (d *Daemon) traceStateEvidence(sessionID string, origin stateOrigin, claim string) {
 	d.recordStateObservation(sessionID, statetrace.Observation{
 		Source:     origin.source,
@@ -151,9 +112,8 @@ func (d *Daemon) traceStateEvidence(sessionID string, origin stateOrigin, claim 
 	})
 }
 
-// traceStateSkip records a source that looked and reported no claim. A skip and
-// a missing observation look identical in the store; only the trace separates
-// "the classifier ran and had nothing to add" from "the classifier never ran".
+// traceStateSkip records a source that looked and reported no claim — only the
+// trace separates "ran and had nothing to add" from "never ran".
 func (d *Daemon) traceStateSkip(sessionID, source, reason string) {
 	d.recordStateObservation(sessionID, statetrace.Observation{
 		Source:  source,
@@ -162,8 +122,7 @@ func (d *Daemon) traceStateSkip(sessionID, source, reason string) {
 	})
 }
 
-// forgetStateTrace drops a session's ring when the session goes away, so the
-// recorder does not grow without bound across a long-lived daemon.
+// forgetStateTrace drops a session's ring when the session goes away.
 func (d *Daemon) forgetStateTrace(sessionID string) {
 	d.stateTraceRecorder().Forget(sessionID)
 }
@@ -219,10 +178,8 @@ func (d *Daemon) stateExplainResult(session *protocol.Session) *protocol.StateEx
 	return result
 }
 
-// handleHookNotification records Claude's Notification hook. The hook is
-// evidence, not a command: it lands ~6s after the event it describes, so acting
-// on it directly would paint a state the session may already have left. The
-// resolver weighs it against fresher sources.
+// handleHookNotification records Claude's Notification hook. Evidence, not a
+// command: it lands ~6s after the event, so the resolver weighs it.
 func (d *Daemon) handleHookNotification(conn net.Conn, msg *protocol.HookNotificationMessage) {
 	kind := strings.TrimSpace(msg.NotificationType)
 	if kind == "" {
@@ -238,9 +195,8 @@ func (d *Daemon) handleHookNotification(conn net.Conn, msg *protocol.HookNotific
 	d.sendOK(conn)
 }
 
-// handleHookStopFailure records Claude's StopFailure hook, which replaces Stop
-// when a turn ends on an API error. None of the end-of-turn work applies: there
-// is no finished turn to classify, narrate, or resume from.
+// handleHookStopFailure records Claude's StopFailure hook (replaces Stop on an
+// API error); no end-of-turn work applies — there is no finished turn.
 func (d *Daemon) handleHookStopFailure(conn net.Conn, msg *protocol.HookStopFailureMessage) {
 	errorType := strings.TrimSpace(msg.ErrorType)
 	if errorType == "" {
@@ -270,11 +226,8 @@ func (d *Daemon) handleHookCompaction(conn net.Conn, msg *protocol.HookCompactio
 	d.sendOK(conn)
 }
 
-// tracePermissionMode records the agent's resolved approval mode as a level.
-// It rides along on the state hook rather than being read from attn's launch
-// flags, which are not authoritative: a user's global agent settings can put a
-// guardian in the loop for a session attn launched without asking for one, and
-// the mode can change mid-session.
+// tracePermissionMode records the agent's resolved approval mode. It rides on
+// the state hook, not attn's launch flags: the mode can change mid-session.
 func (d *Daemon) tracePermissionMode(sessionID, mode string) {
 	mode = strings.TrimSpace(mode)
 	if mode == "" {

--- a/internal/daemon/ticket_reconcile.go
+++ b/internal/daemon/ticket_reconcile.go
@@ -20,65 +20,43 @@ import (
 
 // Orphaned-ticket reconciliation (docs/plans/2026-07-01-orphaned-ticket-
 // reconciliation.md). Invariant: no non-terminal ticket without a live owning
-// session. When an owning session ends, this seam judges every bound
-// non-terminal ticket: mid-flight deaths keep the Crashed stamp
-// (ticket_crash.go), and — for all deaths — the dead session's transcript is
-// deterministically pre-sliced (internal/transcript) and inlined into a single
-// tool-less, capped headless `claude -p` completion that judges it against the
-// ticket's brief and posts a structured verdict as an attn-authored comment.
-// The classifier never moves the column; the chief and the board badge
-// present, Victor decides.
+// session. The classifier annotates; it never moves the column.
 
 const (
-	// ticketReconcileCommentPrefix marks every reconciliation comment (verdict or
-	// failure note). The sweep's claim-crash repair keys on it to detect a claim
-	// whose verdict never landed.
+	// ticketReconcileCommentPrefix marks every reconciliation comment; the
+	// sweep's claim-crash repair keys on it.
 	ticketReconcileCommentPrefix = "🩺 Reconciliation"
 
 	defaultTicketReconcileModel = "haiku"
-	// The transcript is now deterministically pre-sliced and inlined, so the
-	// classifier is a single tool-less completion — it cannot loop on tools and
-	// cannot balloon on transcript size. These caps are a pure runaway backstop
-	// with real headroom, NOT the primary control: an observed haiku run costs
-	// ~$0.07 over ~2 model turns, so 4 turns / $0.20 leaves comfortable margin
-	// while still catching a true runaway well below the old $0.50 a big
-	// transcript used to blow.
+	// Runaway backstop, not the primary control. Measured: ~$0.07 over ~2 haiku
+	// turns, so 4 turns / $0.20 leaves comfortable margin.
 	defaultTicketReconcileMaxTurns     = 4
 	defaultTicketReconcileMaxBudgetUSD = "0.20"
 	defaultTicketReconcileTimeout      = 5 * time.Minute
 
-	// ticketReconcileFailureDetail{Head,Tail} bound the raw classifier output
-	// echoed into a rule-7 failure comment, keeping both ends of the capture:
-	// the head holds FailureOutput's stderr section (fatal CLI errors), the
-	// tail holds the end of stdout — a failed `--output-format json` run puts
-	// the human-readable error in the trailing result event.
+	// Both ends of the echoed classifier output matter: head holds stderr, tail
+	// holds the trailing `--output-format json` result event carrying the error.
 	ticketReconcileFailureDetailHead = 300
 	ticketReconcileFailureDetailTail = 700
 
-	// reconcileKind is the durable-queue job kind for orphaned-ticket
-	// reconciliation. The unique key is the ticket id, so every trigger for one
-	// ticket coalesces onto a single record.
+	// reconcileKind is the durable-queue job kind; unique key is the ticket id,
+	// so every trigger for one ticket coalesces onto a single record.
 	reconcileKind = "reconcile"
 
-	// ticketReconcileConcurrency bounds simultaneous classifier processes: a
-	// workspace teardown can kill several delegated sessions at once, and without
-	// a cap that is N parallel sonnet runs. It is the reconcile handler's per-kind
-	// MaxConcurrent in the durable queue (which now owns the cap the bespoke
-	// semaphore used to enforce).
+	// ticketReconcileConcurrency is the handler's per-kind MaxConcurrent: a
+	// workspace teardown can kill several delegated sessions at once.
 	ticketReconcileConcurrency = 2
 
-	// Sweep cadence. The grace period must comfortably exceed the classifier
-	// timeout (so the repair pass cannot fire on a run still in flight) and cover
-	// daemon-restart churn plus a quick close-then-resume; the claim cap turns a
-	// first-deploy backlog of historical orphans into a trickle, not a burst.
+	// The grace period must exceed the classifier timeout — repair must never
+	// fire on a run still in flight.
 	defaultTicketReconcileSweepInterval = 5 * time.Minute
 	defaultTicketReconcileGrace         = 15 * time.Minute
 	ticketReconcileSweepClaimCap        = 3
 )
 
-// ticketReconcileVerdictSchema is the JSON Schema enforced via --json-schema.
-// "could not determine" is deliberately NOT an assessment: machinery failure is
-// the rule-7 failure comment, kept forever distinguishable from a model verdict.
+// ticketReconcileVerdictSchema is enforced via --json-schema. "could not
+// determine" is deliberately NOT an assessment: machinery failure is the
+// rule-7 failure comment, kept distinguishable from a model verdict.
 const ticketReconcileVerdictSchema = `{
 	"type": "object",
 	"properties": {
@@ -100,9 +78,8 @@ const ticketReconcileVerdictSchema = `{
 	"additionalProperties": false
 }`
 
-// ticketReconcileInputs is everything the classifier run needs, captured
-// synchronously at the seam — the session row may be deleted moments later
-// (dropSessionRecord), so the async runner must never re-read the session.
+// ticketReconcileInputs is captured synchronously at the seam: the session row
+// may be deleted moments later, so the async runner must never re-read it.
 type ticketReconcileInputs struct {
 	TicketID       string
 	Title          string
@@ -114,11 +91,8 @@ type ticketReconcileInputs struct {
 	CloseContext   string // human framing: how the session ended, for prompt + comment
 }
 
-// reconcileInputsFromJob decodes the inputs the enqueue carried on the job
-// payload. A missing or undecodable payload is an error the handler treats as
-// terminal (the job cannot be run, and retrying would never fix a garbled
-// record). An empty ticket id means the payload was absent, which is the same
-// unrunnable record by another route.
+// reconcileInputsFromJob decodes the enqueue-time inputs; a missing or garbled
+// payload (including an empty ticket id) is terminal — retrying never fixes it.
 func reconcileInputsFromJob(job *jobs.Job) (ticketReconcileInputs, error) {
 	var in ticketReconcileInputs
 	if err := job.DecodePayload(&in); err != nil {
@@ -151,8 +125,6 @@ func (v *ticketReconcileVerdict) valid() bool {
 	}
 	return true
 }
-
-// --- tunables (constants with env overrides; Victor 2026-07-01: "yes tunable") ---
 
 func ticketReconcileModel() string {
 	if v := strings.TrimSpace(os.Getenv("ATTN_TICKET_RECONCILE_MODEL")); v != "" {
@@ -204,18 +176,9 @@ func ticketReconcileGrace() time.Duration {
 	return defaultTicketReconcileGrace
 }
 
-// --- the session-end seam ---
-
 // reconcileTicketsOnSessionEnd is the single ticket seam for a dying session,
-// fed the pre-clobber runtime state. Called from handlePTYExit (process death)
-// and dropSessionRecord (user close / reap / teardown backstop) — a user close
-// fires both, so the claim (a set-if-unset) dedupes: the first fire claims and
-// enqueues a durable reconcile task with the freshest inputs (the session row is
-// still present), and the loser exits. The claim also lights the board's orphan
-// badge immediately (reconciled_at). Enqueue replaces the old inline goroutine so
-// a daemon restart between here and the classifier run no longer loses the work —
-// the task survives in the profile DB, and the runner's cap-2 dispatch (not a
-// bespoke semaphore) bounds concurrent classifier processes.
+// fed the pre-clobber runtime state. Called from both handlePTYExit and
+// dropSessionRecord — a user close fires both, and the set-if-unset claim dedupes.
 func (d *Daemon) reconcileTicketsOnSessionEnd(sessionID, state string) {
 	if d.store == nil {
 		return
@@ -228,23 +191,12 @@ func (d *Daemon) reconcileTicketsOnSessionEnd(sessionID, state string) {
 	if len(tickets) == 0 {
 		return
 	}
-	// The session row is still present at both call sites; capture what the
-	// classifier needs NOW (dropSessionRecord deletes the row right after).
+	// Read before dropSessionRecord deletes the row.
 	session := d.store.Get(sessionID)
-	// The reconcile ENQUEUE needs a durable runner, but the crash stamp does not —
-	// crashTicket must run regardless so a mid-flight death is always marked. When
-	// the runner is unavailable (not expected in production, where the store is
-	// always present), the periodic sweep rediscovers the still-orphaned ticket and
-	// enqueues once the runner is up.
 	runner := d.jobQueueRef()
 
-	// An intentional close (user close, delegate teardown, workspace close) is
-	// not a crash, whatever the last runtime state was: the ticket stays where
-	// the agent last reported it (the common case: In Review, closed by Victor
-	// because the work is done). Only a spontaneous mid-flight death earns the
-	// Crashed stamp. Checked once per seam fire, while the session row is still
-	// present (both call sites guarantee it) — the durable half of the signal
-	// lives on that row.
+	// Only a spontaneous mid-flight death earns the Crashed stamp, and the
+	// durable half of that signal lives on the still-present session row.
 	intentionalClose := d.sessionCloseWasIntentional(sessionID)
 
 	for _, ticket := range tickets {
@@ -253,9 +205,6 @@ func (d *Daemon) reconcileTicketsOnSessionEnd(sessionID, state string) {
 		}
 		statusAtClaim := ticket.Status
 		if isMidFlightCrashState(state) && !intentionalClose {
-			// The blunt terminal stamp ships first (unchanged behavior); the
-			// classifier then annotates the crashed ticket with what was left
-			// (Victor 2026-07-01: crashes get verdicts too).
 			if !d.crashTicket(ticket.ID, sessionID, state) {
 				continue
 			}
@@ -301,9 +250,7 @@ func (d *Daemon) reconcileTicketsOnSessionEnd(sessionID, state string) {
 }
 
 // reconcileCloseContext frames how the session ended, for the prompt and the
-// verdict comment. The user response differs by case (crash → "retry",
-// closed-while-In-Review → "output ready, just review"), so the framing
-// matters even though it gates nothing.
+// verdict comment; it gates nothing.
 func (d *Daemon) reconcileCloseContext(sessionID, state string, column store.TicketStatus) string {
 	how := "ended at rest"
 	if isMidFlightCrashState(state) {
@@ -319,13 +266,10 @@ func (d *Daemon) reconcileCloseContext(sessionID, state string, column store.Tic
 	return fmt.Sprintf("%s (%s, last runtime state %s) while the ticket was %s", source, how, state, column)
 }
 
-// sessionCloseWasIntentional reports whether this session's death was an
-// attn/user-initiated close rather than a spontaneous process exit. Two
-// sources, either suffices: the in-memory forced-stop mark (fast path, set by
-// terminateSession moments before the seam fires) and the durable mark on the
-// session row (survives the mark's 30s TTL and a daemon restart, so the
-// startup reap re-running the seam still sees the close for what it was). It
-// gates the Crashed stamp and frames the reconcile comment.
+// sessionCloseWasIntentional reports an attn/user-initiated close vs a
+// spontaneous exit. Either source suffices: the in-memory forced-stop mark, or
+// the durable mark on the session row (survives the mark's 30s TTL and a
+// daemon restart, so the startup reap still sees the close for what it was).
 func (d *Daemon) sessionCloseWasIntentional(sessionID string) bool {
 	if d.hasForcedStopMark(sessionID) {
 		return true
@@ -333,9 +277,8 @@ func (d *Daemon) sessionCloseWasIntentional(sessionID string) bool {
 	return d.store != nil && d.store.SessionCloseIntentional(sessionID)
 }
 
-// hasForcedStopMark peeks (never consumes — stop-time classification suppression
-// owns the consume) at the forced-stop mark terminateSession sets before Kill,
-// distinguishing an attn-initiated close from a spontaneous process death.
+// hasForcedStopMark peeks (never consumes — stop-time classification
+// suppression owns the consume) at the mark terminateSession sets before Kill.
 func (d *Daemon) hasForcedStopMark(sessionID string) bool {
 	d.forcedStopMu.Lock()
 	defer d.forcedStopMu.Unlock()
@@ -343,14 +286,10 @@ func (d *Daemon) hasForcedStopMark(sessionID string) bool {
 	return ok && time.Since(markedAt) <= forcedStopSuppressTTL
 }
 
-// resolveReconcileTranscript locates the dead session's transcript via the
-// judged agent's driver, preferring the ticket's mirrored resume id (the
-// latest agent-native id — claude's from stop payloads, codex's from its hook
-// session_id sync; the session row's copy dies with the row). Only when no id
-// was mirrored does it fall back to the finder's cwd + time-anchor guess:
-// time.Now() at the death seam (fresh mod-time window), the ticket's CreatedAt
-// from the sweep (delegation ≈ spawn; an early anchor only widens the window).
-// "" means rule 7: comment, don't vanish.
+// resolveReconcileTranscript locates the dead session's transcript, preferring
+// the ticket's mirrored resume id (the session row's copy dies with the row),
+// falling back to the finder's cwd + time-anchor guess. "" means rule 7:
+// comment, don't vanish.
 func (d *Daemon) resolveReconcileTranscript(agentID, sessionID, cwd string, anchor time.Time, assignee string) string {
 	driver := agentdriver.Get(agentID)
 	if driver == nil {
@@ -368,39 +307,23 @@ func (d *Daemon) resolveReconcileTranscript(agentID, sessionID, cwd string, anch
 	return strings.TrimSpace(tf.FindTranscript(sessionID, cwd, anchor))
 }
 
-// --- the classifier run ---
-
-// reconcileTaskExecutor is the durable-runner ExecutorFunc for the reconcile
-// kind. It reads the classifier inputs captured at enqueue time (the session row
-// is long gone by run time), runs the headless classifier under the runner-owned
-// timeout ctx, and drives the reconciliation to its durable end: a verdict
-// comment, a rule-7 failure comment, or a logged drop (status moved during the
-// run — someone acted, the verdict is stale). The board's orphan badge
-// (reconciled_at) was already stamped at enqueue time by the claim.
-//
-// Return contract: nil in every case where the reconciliation reached a
-// conclusion (verdict posted, failure note posted, dropped, or inputs
-// unrecoverable) — a reconcile is one-shot, exactly as the inline version was,
-// so a classifier error becomes a posted failure note, not a runner retry. The
-// ONLY retryable error is a failure to POST the comment (a transient store
-// error): the verdict must eventually land, so the runner backs off and re-runs.
+// reconcileJobHandler runs the headless classifier from enqueue-time inputs.
+// Returns nil whenever a conclusion was reached — a classifier error becomes a
+// posted failure note. The only retryable error is failing to post the comment.
 func (d *Daemon) reconcileJobHandler(ctx context.Context, job *jobs.Job) (any, error) {
 	if d.ticketReconcileDone != nil {
-		// Test observation hook: fire once the run reaches any terminal outcome.
+		// Test hook: fires on any terminal outcome.
 		defer d.ticketReconcileDone(jobSubject(job))
 	}
 	in, err := reconcileInputsFromJob(job)
 	if err != nil {
-		// A record with no/garbled inputs can never be run into health; log and
-		// retire it (nil) so it doesn't hot-loop the dispatch queue.
+		// Garbled inputs can never run into health; retire (nil) to avoid a hot loop.
 		d.logf("ticket reconcile %s: %v", jobSubject(job), err)
 		return nil, nil
 	}
 	execFn := d.ticketReconcileExec
 	if execFn == nil {
-		// Test daemons without a wired classifier: the claim stands (provenance),
-		// but no classifier runs and no comment lands. Production always wires the
-		// real exec in New().
+		// Test daemons without a wired classifier; production always wires it in New().
 		d.logf("ticket reconcile %s: classifier not configured; skipping", in.TicketID)
 		return nil, nil
 	}
@@ -416,10 +339,6 @@ func (d *Daemon) reconcileJobHandler(ctx context.Context, job *jobs.Job) (any, e
 		}
 		switch {
 		case runErr != nil:
-			// The comment carries the raw cause, not just the keyword bucket:
-			// err summarizes (bucket + exit status), FailureOutput is the child's
-			// actual output tail — without it a failure is undiagnosable (the
-			// 2026-07-02 first fire surfaced only "keeper tools failed").
 			failReason = "classifier run failed: " + runErr.Error()
 			if raw := strings.TrimSpace(result.FailureOutput); raw != "" {
 				failReason += "\nClassifier output:\n" + truncateMiddleString(raw,
@@ -437,14 +356,12 @@ func (d *Daemon) reconcileJobHandler(ctx context.Context, job *jobs.Job) (any, e
 		}
 	}
 	if failReason != "" {
-		// The comment can be dropped (status moved) or fail to post; the log is
-		// the durable copy of what actually went wrong.
+		// The comment can be dropped or fail to post; the log is the durable copy.
 		d.logf("ticket reconcile %s: %s", in.TicketID, failReason)
 	}
 
-	// Drop rule: re-check the ticket after the run. A status change since the
-	// claim means someone (agent self-report racing the seam, the chief, Victor)
-	// acted — the verdict describes a state that no longer exists, drop silently.
+	// Drop rule: a status change since the claim means someone acted — the
+	// verdict describes a state that no longer exists, drop silently.
 	ticket, err := d.store.GetTicket(in.TicketID)
 	if err != nil || ticket == nil {
 		d.logf("ticket reconcile %s: ticket gone before verdict landed", in.TicketID)
@@ -457,28 +374,23 @@ func (d *Daemon) reconcileJobHandler(ctx context.Context, job *jobs.Job) (any, e
 	}
 
 	comment := renderTicketReconcileComment(in, verdict, failReason)
-	// Annotate-only ground-truth cross-check (ticket_reconcile_groundtruth.go):
-	// never mutates the verdict, never fails the reconcile — any problem (no
-	// cwd, no origin, no GitHub client, lookup errors) degrades to no
-	// annotation.
+	// Annotate-only cross-check: never mutates the verdict, never fails the
+	// reconcile — any problem degrades to no annotation.
 	if lines := d.reconcileGroundTruth(ctx, verdict, ticket.Cwd); len(lines) > 0 {
 		comment += "\n" + strings.Join(lines, "\n")
 	}
 	if _, err := d.store.AddTicketComment(in.TicketID, store.TicketAuthorAttn, comment, time.Now()); err != nil {
-		// The only retryable path: the verdict must land, so ask the runner to back
-		// off and re-run rather than silently dropping the reconciliation.
+		// The only retryable path: the verdict must land.
 		return nil, fmt.Errorf("post reconcile verdict comment: %w", err)
 	}
-	// The comment notifies participants (the chief is one via the created event);
-	// attn itself is an authoring identity, never an observer.
+	// attn is an authoring identity, never an observer.
 	d.notifyTicketObservers(in.TicketID)
 	d.publishTicketFact(FactTicketCommented, in.TicketID)
 	return nil, nil
 }
 
 // truncateMiddleString keeps the first head and last tail bytes of s, marking
-// the cut — both ends of a failed run's output matter (stderr leads, the fatal
-// result event trails).
+// the cut — both ends of a failed run's output matter.
 func truncateMiddleString(s string, head, tail int) string {
 	if len(s) <= head+tail {
 		return s
@@ -486,9 +398,8 @@ func truncateMiddleString(s string, head, tail int) string {
 	return s[:head] + " …(truncated) " + s[len(s)-tail:]
 }
 
-// renderTicketReconcileComment renders the durable verdict (or rule-7 failure
-// note). Everything starts with ticketReconcileCommentPrefix — the repair pass
-// keys on it.
+// renderTicketReconcileComment renders the durable verdict or rule-7 failure
+// note; everything starts with ticketReconcileCommentPrefix.
 func renderTicketReconcileComment(in ticketReconcileInputs, verdict *ticketReconcileVerdict, failReason string) string {
 	header := fmt.Sprintf("session %s (%s) — %s.", in.SessionID, in.Agent, in.CloseContext)
 	if verdict == nil {
@@ -508,14 +419,9 @@ func renderTicketReconcileComment(in ticketReconcileInputs, verdict *ticketRecon
 	return strings.Join(lines, "\n")
 }
 
-// execTicketReconcileClassifier is the production classifier spawn: always
-// Claude Code headless, regardless of which CLI the judged agent ran — a
-// transcript is just a file, and Claude Code is the one agent CLI with
-// enforceable turn/dollar caps (--max-turns / --max-budget-usd) and
-// schema-enforced output (--json-schema). The transcript is deterministically
-// pre-sliced (internal/transcript) and inlined into the prompt, so the run
-// needs no tools at all; the caps remain a runaway backstop, not the primary
-// control.
+// execTicketReconcileClassifier always spawns Claude Code headless regardless
+// of the judged agent's CLI — the one CLI with enforceable turn/dollar caps and
+// schema-enforced output.
 func (d *Daemon) execTicketReconcileClassifier(ctx context.Context, in ticketReconcileInputs) (agentdriver.HeadlessTaskResult, error) {
 	slice, err := transcript.ExtractConversationSlice(in.TranscriptPath, transcript.DefaultSliceOptions())
 	if err != nil {
@@ -584,15 +490,9 @@ Report via structured output:
 		in.TicketID, in.Title, in.Brief, in.StatusAtClaim, in.CloseContext, slice.Render())
 }
 
-// --- the sweep backstop ---
-
-// runTicketReconcileSweep is the periodic backstop for what the session-end
-// seam structurally cannot cover: tickets orphaned before the feature shipped,
-// and a daemon death mid-seam (the session-end claim landed but the enqueue did
-// not, so no reconcile task exists). No initial pass at boot — startup recovery's
-// reap routes dead-worker sessions through the seam itself; the first tick lands
-// after that churn settles. A daemon death mid-RUN no longer needs the sweep: the
-// durable task survives and the runner's orphan-recovery re-runs it.
+// runTicketReconcileSweep backstops what the seam cannot cover: pre-feature
+// orphans and a daemon death mid-seam (claim landed, enqueue lost). No boot
+// pass — startup recovery routes dead-worker sessions through the seam itself.
 func (d *Daemon) runTicketReconcileSweep() {
 	ticker := time.NewTicker(ticketReconcileSweepInterval())
 	defer ticker.Stop()
@@ -637,13 +537,8 @@ func (d *Daemon) ticketReconcileSweepPass(now time.Time) {
 			d.clearOrphanFirstSeen(ticket.ID)
 			continue
 		}
-		// The durable job record is the "already triggered" ledger: if one exists
-		// for this ticket (in any state), the session-end seam or a prior sweep
-		// already enqueued it and the queue owns it from here — including
-		// re-running one whose daemon died mid-flight. Only a ticket with NO job is
-		// a genuine sweep discovery (pre-feature orphan, or a seam whose claim
-		// landed but whose enqueue was lost to a crash — the abandoned-claim case
-		// the old maybeRepair pass covered, now recovered by enqueuing for real).
+		// The durable job record is the "already triggered" ledger: a job in ANY
+		// state means the queue owns this ticket from here.
 		if existing, err := runner.GetByKey(reconcileKind, ticket.ID); err != nil {
 			d.logf("ticket reconcile sweep: lookup job for %s: %v", ticket.ID, err)
 			continue
@@ -660,14 +555,11 @@ func (d *Daemon) ticketReconcileSweepPass(now time.Time) {
 		}
 		claims++
 		d.clearOrphanFirstSeen(ticket.ID)
-		// Light the board's orphan badge now (set-if-unset; a no-op if an abandoned
-		// session-end claim already set it), then enqueue the durable job.
 		if _, err := d.store.ClaimTicketReconciliation(ticket.ID, now); err != nil {
 			d.logf("ticket reconcile sweep: claim %s: %v", ticket.ID, err)
 		}
 
-		// The session row may still exist (exited-in-place) or be long gone; use
-		// the freshest source available for each input.
+		// The session row may or may not still exist; use the freshest source.
 		agentID := ticket.LastAgentID
 		cwd := ticket.Cwd
 		anchor := ticket.CreatedAt // delegation ≈ spawn; widens the codex window safely
@@ -696,16 +588,10 @@ func (d *Daemon) ticketReconcileSweepPass(now time.Time) {
 	}
 }
 
-// reconcileSessionLive answers "does this ticket still have a live owning
-// session?" from the same authority that feeds the death seam — the store row
-// plus the PTY backend:
-//   - no store row => dead (every close path deletes the row; that deletion ran
-//     the seam, but pre-feature orphans and mid-seam daemon deaths slip through);
-//   - row + backend runtime => the backend's liveness probe decides;
-//   - row + NO backend runtime => treat as LIVE. This is the conservative arm:
-//     CLI-registered and remote sessions never have a daemon PTY, and the
-//     exited-in-place case (row idle-clobbered, runtime removed) already ran the
-//     seam at exit — skipping it here loses nothing.
+// reconcileSessionLive: no store row => dead; row + backend runtime => the
+// liveness probe decides; row + NO backend runtime => LIVE (conservative:
+// CLI-registered and remote sessions never have a daemon PTY, and
+// exited-in-place already ran the seam at exit).
 func (d *Daemon) reconcileSessionLive(sessionID string) bool {
 	if d.store == nil || d.store.Get(sessionID) == nil {
 		return false

--- a/internal/daemon/ticket_reconcile_groundtruth.go
+++ b/internal/daemon/ticket_reconcile_groundtruth.go
@@ -13,53 +13,35 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-// Annotate-only ground-truth cross-check for reconciliation verdicts. The
-// classifier's verdict is produced from a stale, pre-sliced transcript and
-// can contradict reality (e.g. it can say a PR merge is "pending" hours
-// after the PR actually merged). This never mutates the verdict itself: it
-// extracts PR references from the verdict's free text and appends
-// "Ground-truth check" lines to the posted comment when a referenced PR is
-// positively known to be merged or closed. Two sources feed that knowledge:
-//
-//  1. The daemon's own tracked-PR rows (deterministic, no network). Note the
-//     store only tracks OPEN PRs today (see groundTruthTerminalStates), so
-//     this leg is forward-compatible rather than load-bearing.
-//  2. For referenced PRs ABSENT from the tracked open set — the common shape
-//     of the real bug, since merged/closed PRs vanish from the poller's
-//     `is:open` sweep — up to groundTruthMaxLookups targeted single-request
-//     GitHub lookups resolve the definitive state.
-//
-// Everything degrades to silence: no cwd, no origin remote, no GitHub client
-// for the host, lookup errors, or a still-open PR all produce no annotation,
-// and nothing here can fail the reconcile.
+// Annotate-only ground-truth cross-check for reconciliation verdicts: it never
+// mutates the verdict, only appends "Ground-truth check" lines when a PR the
+// verdict references is positively known merged/closed. Two sources: the
+// daemon's tracked-PR rows (deterministic), and capped GitHub lookups for refs
+// absent from the tracked open set — the common shape, since finished PRs
+// vanish from the `is:open` sweep. Everything degrades to silence; nothing here
+// can fail the reconcile.
 
-// groundTruthMaxLines caps how many Ground-truth check lines can be appended
-// to a single reconciliation comment.
+// groundTruthMaxLines caps Ground-truth check lines per reconciliation comment.
 const groundTruthMaxLines = 5
 
-// groundTruthMaxLookups caps the targeted GitHub lookups per reconcile: a
-// verdict is short free text, so more than a few PR references is noise, and
-// each lookup is a real API request.
+// groundTruthMaxLookups caps the targeted GitHub lookups per reconcile; each is
+// a real API request.
 const groundTruthMaxLookups = 3
 
-// groundTruthLookupTimeout bounds the TOTAL added latency of the lookup leg;
-// the executor's context is wrapped with it so a slow or wedged GitHub call
-// cannot stall the verdict comment.
+// groundTruthLookupTimeout bounds the TOTAL added latency of the lookup leg so
+// a wedged GitHub call cannot stall the verdict comment.
 const groundTruthLookupTimeout = 10 * time.Second
 
-// prStateFetcher resolves a PR's definitive lifecycle state. Production wires
-// github.Client.FetchPRState for the repo's host; tests substitute a fake via
-// the Daemon.ticketReconcilePRFetch seam.
+// prStateFetcher resolves a PR's definitive lifecycle state; tests substitute a
+// fake via the Daemon.ticketReconcilePRFetch seam.
 type prStateFetcher func(repo string, number int) (state string, merged bool, title string, err error)
 
-// groundTruthMaxPRNumber is a garbage guard: PR numbers extracted from free
-// text above this are treated as noise (e.g. a misparsed line number or hash)
-// rather than a real PR reference.
+// groundTruthMaxPRNumber is a garbage guard: numbers above this are treated as
+// noise (a misparsed line number or hash), not a PR reference.
 const groundTruthMaxPRNumber = 100000
 
-// groundTruthCaps records which best-effort limits the ground-truth
-// cross-check hit while building annotation lines. It drives a single debug
-// log line in reconcileGroundTruth; it never changes what gets annotated.
+// groundTruthCaps records which best-effort limits were hit; it drives one log
+// line and never changes what gets annotated.
 type groundTruthCaps struct {
 	lineCap   bool // groundTruthMaxLines reached
 	lookupCap bool // groundTruthMaxLookups reached
@@ -74,9 +56,8 @@ var (
 	prGitHubURLPattern = regexp.MustCompile(`(?i)github\.com/[\w.-]+/[\w.-]+/pull/(\d+)`)
 )
 
-// extractPRRefs scans text for PR number references (#123, "PR 123", and
-// github.com/.../pull/123 URLs), dedupes them, and returns them in first-seen
-// order. Numbers above groundTruthMaxPRNumber are dropped as garbage.
+// extractPRRefs scans text for PR references (#123, "PR 123", pull URLs),
+// deduped, in first-seen order; numbers past groundTruthMaxPRNumber are dropped.
 func extractPRRefs(text string) []int {
 	if strings.TrimSpace(text) == "" {
 		return nil
@@ -96,8 +77,6 @@ func extractPRRefs(text string) []int {
 		refs = append(refs, n)
 	}
 
-	// Match all three patterns over the full text and then sort matches by
-	// position so "first-seen order" is stable across pattern types.
 	type match struct {
 		pos int
 		num string
@@ -108,9 +87,7 @@ func extractPRRefs(text string) []int {
 			matches = append(matches, match{pos: loc[0], num: text[loc[2]:loc[3]]})
 		}
 	}
-	// Sort by position in the source text so "first-seen order" is stable
-	// across pattern types (all three patterns are matched independently
-	// above).
+	// Sort by source position so "first-seen order" is stable across patterns.
 	sort.Slice(matches, func(i, j int) bool { return matches[i].pos < matches[j].pos })
 	for _, m := range matches {
 		add(m.num)
@@ -118,31 +95,19 @@ func extractPRRefs(text string) []int {
 	return refs
 }
 
-// groundTruthTerminalStates are the PR.State values that positively confirm a
-// PR is finished (no longer open on GitHub). This is a positive allowlist,
-// not a "not open" blacklist: `internal/store`'s `prs` table is populated
-// exclusively from `is:open` GitHub search queries and is fully replaced
-// (delete + reinsert) on every poll, so a currently-tracked PR's `State`
-// field never holds a GitHub open/closed/merged value at all — it holds
-// attn's own workflow annotation (today, only protocol.PRStateWaiting =
-// "waiting", meaning "needs attention"). A "not open" blacklist would treat
-// every tracked (i.e. actually still-open) PR as finished and misfire on
-// every verdict that references one. Nothing writes "merged"/"closed" rows
-// today — the production path for finished PRs is the untracked-ref GitHub
-// lookup (groundTruthUntrackedLines) — but this leg starts firing with no
-// further changes if the poller is ever extended to persist terminal states.
+// groundTruthTerminalStates must stay a positive allowlist, never a "not open"
+// blacklist: the prs table holds only `is:open` results and its State field
+// carries attn's workflow annotation ("waiting"), not GitHub lifecycle, so a
+// blacklist would call every tracked still-open PR finished. Nothing writes
+// merged/closed rows today; this leg starts firing if the poller ever does.
 var groundTruthTerminalStates = map[string]bool{
 	"merged": true,
 	"closed": true,
 }
 
-// reconcileGroundTruthLines cross-checks refs against prs (the daemon's own
-// tracked-PR rows for repoSlug) and returns one "Ground-truth check" line per
-// referenced PR whose State positively confirms it is merged or closed. PRs
-// that are still open, in some other non-terminal state, or whose number
-// isn't tracked at all, produce no line — silence is the default; this only
-// fires when attn positively knows the referenced PR is finished. Capped at
-// groundTruthMaxLines lines.
+// reconcileGroundTruthLines cross-checks refs against the tracked-PR rows,
+// emitting one line per PR whose State positively confirms merged/closed;
+// silence otherwise. Capped at groundTruthMaxLines.
 func reconcileGroundTruthLines(refs []int, repoSlug string, prs []*protocol.PR) (lines []string, lineCap bool) {
 	if repoSlug == "" || len(prs) == 0 || len(refs) == 0 {
 		return nil, false
@@ -179,12 +144,10 @@ func groundTruthLine(number int, state, title string) string {
 		number, state, title)
 }
 
-// groundTruthUntrackedLines resolves referenced PRs that are ABSENT from the
-// tracked open set via targeted GitHub lookups. Because the store only tracks
-// open PRs, absence is the expected signature of a merged/closed PR — but it
-// can also mean "never tracked", so each candidate gets one definitive
-// lookup, capped at groundTruthMaxLookups. Merged or closed results produce a
-// line; open results, lookup errors, or a nil fetcher produce silence.
+// groundTruthUntrackedLines resolves refs ABSENT from the tracked open set —
+// absence is the expected signature of a finished PR, but can also mean "never
+// tracked", so each candidate gets one definitive lookup, capped. Merged/closed
+// produce a line; open results, lookup errors, or a nil fetcher produce silence.
 func groundTruthUntrackedLines(ctx context.Context, refs []int, tracked map[int]bool, repoSlug string, fetch prStateFetcher) (lines []string, caps groundTruthCaps) {
 	if fetch == nil || repoSlug == "" || len(refs) == 0 {
 		return nil, groundTruthCaps{}
@@ -222,10 +185,9 @@ func groundTruthUntrackedLines(ctx context.Context, refs []int, tracked map[int]
 	return lines, caps
 }
 
-// fetchPRStateCtx runs fetch under ctx: github.Client has no context plumbing
-// (its HTTP client owns a 30s per-request timeout), so the call runs in a
-// goroutine and the result is abandoned if ctx expires first — the goroutine
-// then finishes harmlessly against its own HTTP timeout.
+// fetchPRStateCtx runs fetch under ctx: github.Client has no context plumbing,
+// so the call runs in a goroutine and is abandoned if ctx expires first — it
+// then finishes harmlessly against its own 30s HTTP timeout.
 func fetchPRStateCtx(ctx context.Context, fetch prStateFetcher, repo string, number int) (state string, merged bool, title string, err error) {
 	type result struct {
 		state  string
@@ -246,12 +208,8 @@ func fetchPRStateCtx(ctx context.Context, fetch prStateFetcher, repo string, num
 	}
 }
 
-// reconcileGroundTruth assembles the full cross-check for a verdict: resolve
-// the ticket cwd's origin into host + owner/name slug, extract PR references
-// from the verdict's free text, annotate from tracked rows (deterministic),
-// then resolve untracked references through the host's GitHub client (capped,
-// time-bounded). Returns the lines to append to the comment; empty on any
-// missing prerequisite.
+// reconcileGroundTruth assembles the full cross-check for a verdict and returns
+// the lines to append to the comment; empty on any missing prerequisite.
 func (d *Daemon) reconcileGroundTruth(ctx context.Context, verdict *ticketReconcileVerdict, cwd string) []string {
 	if verdict == nil {
 		return nil

--- a/internal/daemon/ws_automations.go
+++ b/internal/daemon/ws_automations.go
@@ -6,37 +6,14 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-// WS wrappers for the automations surface: list definitions, list one
-// definition's runs, enable/disable, delete, cleanup, run-now, apply, and
-// validate. Every handler here delegates to the same action function in
-// automations_actions.go that the unix-socket transport uses
-// (handleAutomationCommand in automations.go), then d.sendToClient's the
-// per-action typed result — the two transports can never drift in what a
-// given action returns.
+// WS wrappers for the automations surface; each delegates to the action
+// function the unix-socket transport uses (automations_actions.go).
 //
-// Mutations here (set_enabled, delete, run, apply) can block behind
-// d.automationMu while it is held for an in-flight automation delivery
-// (clone/fetch, agent spawn), which can take tens of seconds — the
-// frontend's wrappers use a 30s timeout to match. The mutations resolve that
-// race in one of two ways:
-//
-//   - set_enabled, delete, and apply all abort, rather than mutating, once
-//     wsAutomationMutationTimeoutDuration's daemon-side deadline (25s, strictly
-//     inside the client's 30s) passes while still waiting on automationMu — see
-//     automationSetEnabled, automationDelete, and automationApplyLocked. So the
-//     client's timer can never fire before one of these either lands or is
-//     provably abandoned; a late store flip after a reported timeout is not
-//     possible.
-//   - run-now cannot use the same trick: automationRun durably claims the run
-//     via ClaimManualAutomationRun before waiting on automationMu, so an
-//     abandoned wait still leaves a pending run that will eventually deliver.
-//     Instead the client is expected to reuse the same request_id across a
-//     retry of the same click (ClaimManualAutomationRun is idempotent per
-//     request_id), so a retry after a client-side timeout dedups onto the
-//     original claim rather than creating a second one.
-//   - cleanup does not participate in this race at all: it never takes
-//     automationMu (see handleAutomationCleanupWS), so it has nothing to
-//     abort ahead of — the WS timeout there is only a defensive bound.
+// Mutations can block behind automationMu for tens of seconds during a
+// delivery. set_enabled/delete/apply abort at the daemon-side 25s deadline
+// (strictly inside the client's 30s timeout), so no store flip lands after a
+// reported timeout; run-now instead claims durably first
+// (ClaimManualAutomationRun is idempotent per request_id) so a retry dedups.
 
 func (d *Daemon) handleAutomationDefinitionsGetWS(client *wsClient, msg *protocol.AutomationDefinitionsGetMessage) {
 	result := d.actionAutomationDefinitionsGet(msg)
@@ -57,12 +34,8 @@ func (d *Daemon) handleAutomationSetEnabledWS(client *wsClient, msg *protocol.Au
 	}()
 }
 
-// handleAutomationDeleteWS is the WS counterpart of the unix-socket
-// CmdAutomationDelete path: soft-delete a definition. Unlike set_enabled's
-// result, there is no updated definition summary to return — a deleted
-// definition drops out of automation_definitions_get/automations_changed
-// listings entirely, so clients learn of the removal from the broadcast
-// automationDelete already sends, not from this result's payload.
+// handleAutomationDeleteWS soft-deletes a definition; clients learn of the
+// removal from automationDelete's broadcast, not this result's payload.
 func (d *Daemon) handleAutomationDeleteWS(client *wsClient, msg *protocol.AutomationDeleteMessage) {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), d.wsAutomationMutationTimeoutDuration())
@@ -72,13 +45,8 @@ func (d *Daemon) handleAutomationDeleteWS(client *wsClient, msg *protocol.Automa
 	}()
 }
 
-// handleAutomationCleanupWS is the WS counterpart of the unix-socket
-// CmdAutomationCleanup path: reclaim worktree disk space for every terminal
-// run of a definition right now. Unlike set_enabled/delete, cleanup never
-// blocks on automationMu (automationCleanup doesn't take it — it's disk-only
-// and doesn't race an in-flight delivery's row mutations), so there is no
-// abort-before-mutate deadline race to guard against; the timeout here is
-// just a defensive bound on how long a large worktree scan may run.
+// handleAutomationCleanupWS reclaims worktree disk space for a definition's
+// terminal runs.
 func (d *Daemon) handleAutomationCleanupWS(client *wsClient, msg *protocol.AutomationCleanupMessage) {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), d.wsAutomationMutationTimeoutDuration())
@@ -88,10 +56,8 @@ func (d *Daemon) handleAutomationCleanupWS(client *wsClient, msg *protocol.Autom
 	}()
 }
 
-// handleAutomationRunWS is the WS counterpart of the unix-socket
-// CmdAutomationRun path: run-now. A manual-trigger rejection (e.g. a
-// provider-driven definition) surfaces as success=false with the error text,
-// matching the socket path's behavior — it is not a transport-level failure.
+// handleAutomationRunWS is run-now. A manual-trigger rejection surfaces as
+// success=false with the error text, not a transport-level failure.
 func (d *Daemon) handleAutomationRunWS(client *wsClient, msg *protocol.AutomationRunMessage) {
 	go func() {
 		result := d.actionAutomationRun(context.Background(), msg)
@@ -99,11 +65,9 @@ func (d *Daemon) handleAutomationRunWS(client *wsClient, msg *protocol.Automatio
 	}()
 }
 
-// handleAutomationApplyWS is the WS counterpart of the unix-socket
-// CmdAutomationApply path, used by the app editor's Save. The app always
-// sends expected_id/expected_revision (see actionAutomationApply's doc
-// comment on why that's what makes them enforced here but not on the
-// socket/CLI path).
+// handleAutomationApplyWS backs the app editor's Save. The app always sends
+// expected_id/expected_revision, which is what enforces the guards on this
+// path but not on the socket/CLI path (see actionAutomationApply).
 func (d *Daemon) handleAutomationApplyWS(client *wsClient, msg *protocol.AutomationApplyMessage) {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), d.wsAutomationMutationTimeoutDuration())
@@ -113,19 +77,11 @@ func (d *Daemon) handleAutomationApplyWS(client *wsClient, msg *protocol.Automat
 	}()
 }
 
-// handleAutomationValidateWS is the WS counterpart of the unix-socket
-// CmdAutomationValidate path: validate-without-apply, so the editor can show
-// an error before Save.
-//
-// It takes no automationMu: validateAutomationSpec never mutates the store,
-// so it cannot contend with an in-flight apply/delete/set_enabled the way the
-// mutation handlers above can. It does still run on its own goroutine,
-// because "does not touch the store" is not the same as "is fast": each
-// location override is checked with git.ValidateLocalClone, which stats the
-// path and shells out to git twice. The dispatcher calls handlers inline on
-// the client's read loop, so validating synchronously would stall every other
-// message from that client behind those subprocesses — and a path on an
-// unresponsive mount would stall them indefinitely.
+// handleAutomationValidateWS is validate-without-apply for the editor. It runs
+// on its own goroutine even though it takes no automationMu: validation shells
+// out to git per location override, and the dispatcher calls handlers inline
+// on the client's read loop — a slow or hung path would stall every other
+// message from that client.
 func (d *Daemon) handleAutomationValidateWS(client *wsClient, msg *protocol.AutomationValidateMessage) {
 	go func() {
 		result := d.actionAutomationValidate(msg)

--- a/internal/daemon/ws_eviction.go
+++ b/internal/daemon/ws_eviction.go
@@ -11,55 +11,34 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-// The daemon gives up on a client it cannot keep fed in two places: the hub,
-// when a client misses maxSlowCount consecutive broadcasts, and the write pump,
-// when a single hand-off runs past wsWriteTimeout. Either way two things have to
-// happen, and they need different mechanisms:
-//
-//   - The client has to notice, fast. It cannot be told over the connection it
-//     is being evicted from: the WebSocket close frame travels the same TCP
-//     stream as the backlog that caused the eviction, behind everything already
-//     handed to the kernel. Measured through a 10 KB/s link, the daemon hung up
-//     after ~1s and the client read nothing for ~45s — its own timeout, not the
-//     daemon's answer. So the close frame is attempted, briefly, and then the
-//     transport is aborted. (Only the hub needs this: a write that runs out of
-//     time leaves the library tearing the transport down on its own.)
-//   - The client has to learn why, eventually. That reason arrives on the next
-//     connection instead (client_eviction_notice), keyed on the client_id the
-//     client repeats across reconnects.
+// Eviction happens in the hub (maxSlowCount missed broadcasts) and the write
+// pump (one hand-off past wsWriteTimeout). The close frame travels the same TCP
+// stream as the backlog, so a wedged client never reads it — Measured: through a
+// 10 KB/s link the daemon hung up after ~1s and the client read nothing for
+// ~45s. So: attempt the close briefly, abort the transport, and deliver the
+// reason on the next connection (client_eviction_notice), keyed on client_id.
 const (
-	// evictionCloseGrace bounds how long a hopeless connection is given to
-	// accept a close frame before the transport is aborted underneath it. It is
-	// a tripwire, not a budget: a client whose socket is writable takes
-	// microseconds, and one that needs a full second is by definition the case
-	// this exists for.
+	// evictionCloseGrace bounds the close-frame attempt before the transport is
+	// aborted. Tripwire: a writable socket takes microseconds.
 	evictionCloseGrace = 1 * time.Second
-	// evictionMemoryTTL is how long the hub remembers an eviction for a client
-	// that has not come back. The app reconnects on a backoff that caps at 5s
-	// and a circuit breaker that resets after 30s, so ten minutes is two orders
-	// of magnitude past the slowest return that is still the same visit.
+	// evictionMemoryTTL: reconnect backoff caps at 5s and the circuit breaker
+	// resets at 30s, so this is two orders of magnitude past a same-visit return.
 	evictionMemoryTTL = 10 * time.Minute
-	// maxRememberedEvictions bounds the map. One user, a handful of clients: a
-	// number this far past the real fleet is only ever reached by a client that
-	// evicts, reconnects with a fresh id, and evicts again — and dropping the
-	// oldest of those is the right answer anyway.
+	// maxRememberedEvictions bounds the map; only a client cycling fresh ids
+	// reaches it, and dropping the oldest of those is right anyway.
 	maxRememberedEvictions = 16
 )
 
-// evictionRecord is what the hub remembers about a client it hung up on, held
-// until that client comes back or the memory ages out.
+// evictionRecord is what the hub remembers about a client it hung up on.
 type evictionRecord struct {
 	at     time.Time
 	reason string
-	// undelivered counts the messages the client never got: the ones the hub
-	// could not enqueue, or the one the write pump could not hand over plus
-	// whatever was still queued behind it.
+	// undelivered counts messages the client never got.
 	undelivered int
 }
 
 // rememberEviction files an eviction under the client's id so the next hello
-// from that id can be answered with it. A client that never sent an id cannot
-// be told anything on its return, so the log line is all there is.
+// from that id can be answered with it; an id-less client only gets the log line.
 func (h *wsHub) rememberEviction(clientID string, record evictionRecord) {
 	if clientID == "" {
 		return
@@ -86,9 +65,8 @@ func (h *wsHub) rememberEviction(clientID string, record evictionRecord) {
 	h.evictions[clientID] = record
 }
 
-// takeEviction returns and forgets the eviction filed for this client id, if
-// there is one. Delivered once: a client that has been told does not need
-// telling again on its next reconnect.
+// takeEviction returns and forgets the eviction filed for this client id;
+// delivered once.
 func (h *wsHub) takeEviction(clientID string) (evictionRecord, bool) {
 	if clientID == "" {
 		return evictionRecord{}, false
@@ -111,12 +89,9 @@ func (h *wsHub) pruneEvictionsLocked(now time.Time) {
 	}
 }
 
-// evict drops a client the hub has given up on: it files the reason for the
-// client's return, stops feeding a connection nobody is reading, and hangs up
-// without waiting for the backlog to drain.
-//
-// Callers hold h.mu, so the hanging up runs on its own goroutine — closing a
-// wedged socket must never stall the fan-out for every other client.
+// evict drops a client the hub has given up on and files the reason for its
+// return. Callers hold h.mu, so the hang-up runs on its own goroutine — closing
+// a wedged socket must never stall the fan-out.
 func (h *wsHub) evict(client *wsClient, reason string) {
 	record := evictionRecord{
 		at:          time.Now(),
@@ -128,15 +103,9 @@ func (h *wsHub) evict(client *wsClient, reason string) {
 	go client.hangUp(websocket.StatusPolicyViolation, reason, evictionCloseGrace)
 }
 
-// hangUp ends a connection the daemon has given up on, within grace.
-//
-// The close frame is attempted first and is pure courtesy: on a healthy socket
-// it lands immediately and the client gets a proper status, which is why it is
-// worth trying at all. On the socket this exists for it cannot land, because a
-// close frame is ordinary stream data queued behind the backlog. So the
-// transport is aborted afterwards: SO_LINGER 0 discards the daemon's unsent
-// bytes and sends a RST, which is the only thing that reaches the peer without
-// waiting in that queue.
+// hangUp attempts the close frame (lands only on a healthy socket), then aborts
+// the transport: SO_LINGER 0 discards unsent bytes and sends a RST — the only
+// thing that reaches the peer without queuing behind the backlog.
 func (c *wsClient) hangUp(code websocket.StatusCode, reason string, grace time.Duration) {
 	closed := make(chan struct{})
 	go func() {
@@ -152,11 +121,9 @@ func (c *wsClient) hangUp(code websocket.StatusCode, reason string, grace time.D
 	c.abortTransport()
 }
 
-// abortTransport tears the connection down at the socket. The raw conn is the
-// one the HTTP server accepted (stashed by withRawConn); without it — a test
-// server, or any listener that does not run through initHTTPServer — this
-// degrades to nhooyr's own immediate close, which still skips the close
-// handshake but leaves the kernel to flush what it has queued.
+// abortTransport tears the connection down at the socket. Without the raw conn
+// (test servers, listeners outside initHTTPServer) this degrades to nhooyr's
+// CloseNow, which skips the handshake but lets the kernel flush its queue.
 func (c *wsClient) abortTransport() {
 	if c.rawConn == nil {
 		_ = c.conn.CloseNow()
@@ -168,9 +135,8 @@ func (c *wsClient) abortTransport() {
 	_ = c.rawConn.Close()
 }
 
-// rawConnKey carries the accepted connection from the HTTP server down to the
-// handler, which is the only way to reach it: the WebSocket handshake hijacks
-// the connection and hands back a wrapper with no way out to the socket.
+// rawConnKey carries the accepted connection down to the handler — the only way
+// to it: the WebSocket handshake hijacks the conn behind a wrapper.
 type rawConnKey struct{}
 
 func withRawConn(ctx context.Context, conn net.Conn) context.Context {
@@ -183,9 +149,7 @@ func rawConnFrom(ctx context.Context) net.Conn {
 }
 
 // sendEvictionNotice tells a returning client what happened to its last
-// connection. Sent from the hello handler, which is where the client names
-// itself; a client that has nothing waiting for it hears nothing, so hello
-// stays fire-and-forget for everyone else.
+// connection; sent from the hello handler, where the client names itself.
 func (d *Daemon) sendEvictionNotice(client *wsClient, record evictionRecord) {
 	notice := &protocol.ClientEvictionNoticeMessage{
 		Event:               protocol.EventClientEvictionNotice,

--- a/internal/daemon/ws_kitty.go
+++ b/internal/daemon/ws_kitty.go
@@ -1,22 +1,11 @@
 package daemon
 
-// The client-facing half of the kitty image feed. The worker observes and
-// stores; this translates its observations into the protocol clients speak, and
-// answers their pulls for the pixels behind a placement.
-//
-// Two capabilities answer two different questions, and keeping them apart is
-// what makes the remote relay work. CapabilityKittyImages is "describe images
-// to me": it gates the kitty_placements fan-out, because a client that draws no
-// images has nothing to do with the description. CapabilityBinaryPtyOutput is
-// "I take binary frames", the same bit that already picks PTY output's
-// transport, and it decides only how a blob travels — frame 0x02 or base64 in
-// JSON. A client can want one without the other: the hub relays kitty traffic
-// between daemons over a text pipe, so it asks for the descriptions and takes
-// its blobs as JSON.
-//
-// And nothing is correlated by request id: an answer names (session, image id,
-// generation), which is the key a client's blob cache uses, so a duplicate is an
-// idempotent refill rather than an orphan.
+// Client-facing half of the kitty image feed; the worker observes and stores.
+// Two capabilities, kept apart for the relay: CapabilityKittyImages gates the
+// kitty_placements fan-out, CapabilityBinaryPtyOutput decides only how a blob
+// travels (frame 0x02 vs base64 JSON) — the hub relay wants the first without
+// the second. Nothing is correlated by request id: answers name (session,
+// image id, generation), so a duplicate is an idempotent refill, not an orphan.
 
 import (
 	"context"
@@ -31,16 +20,9 @@ import (
 )
 
 // placementsToProtocol converts an observed placement set to its wire form.
-//
-// The result is never nil, unlike attachBlocksToProtocol's: kitty_placements
-// declares the array required precisely so the empty set survives the trip, and
-// a nil slice would marshal to null and hand the client something its type says
-// cannot happen. The empty set is the only message that says "stop drawing".
-//
-// attach_result.snapshot uses the same converter and reaches the opposite
-// result, correctly: that field is optional, so its omitempty drops the empty
-// slice. A restore has no prior placements to clear — the client is resetting
-// its model — so there absence and emptiness really are the same thing.
+// Never nil: the empty set is the only message that says "stop drawing", and a
+// nil slice would marshal to null. (attach_result.snapshot's omitempty dropping
+// it is fine — a restore has no prior placements to clear.)
 func placementsToProtocol(placements []pty.KittyPlacement) []protocol.KittyPlacement {
 	out := make([]protocol.KittyPlacement, len(placements))
 	for i, p := range placements {
@@ -80,10 +62,9 @@ func encodeKittyPlacementsMessage(sessionID string, event ptybackend.OutputEvent
 	return outboundMessage{kind: messageKindText, payload: payload}, nil
 }
 
-// kittyImageFormatCode translates ghostty's pixel layout to the protocol's own
-// code. Explicit rather than a cast: ghostty's values are a declaration order,
-// and a pin that reorders them would otherwise silently re-label every client's
-// pixels as a different layout.
+// kittyImageFormatCode translates ghostty's pixel layout to the protocol code.
+// Explicit, not a cast: a pin that reorders ghostty's values would otherwise
+// silently re-label every client's pixels.
 func kittyImageFormatCode(format ghosttyvt.KittyImageFormat) (byte, bool) {
 	switch format {
 	case ghosttyvt.KittyImageRGB:
@@ -98,18 +79,10 @@ func kittyImageFormatCode(format ghosttyvt.KittyImageFormat) (byte, bool) {
 	return 0, false
 }
 
-// handleGetKittyImage answers a client's pull for the pixels behind a
-// placement. It answers whatever the client advertised — asking is enough, and
-// an automation client that never opted into the description feed still needs
-// to be able to assert on an image. Only the transport is a capability
-// decision: CapabilityBinaryPtyOutput gets binary frame 0x02, everyone else
-// gets the same image base64'd into kitty_image_result.
-//
-// Every failure is an ordinary answer with success=false — an evicted or
-// unknown id, a backend that cannot serve images at all — because none of them
-// mean the session is broken, and the client's move in all cases is the same:
-// drop that placement's render until something re-describes it. A failure has
-// no pixels and so no frame, so it goes as JSON to both kinds of client.
+// handleGetKittyImage answers a client's pull for the pixels behind a placement.
+// Asking is enough — only the transport is a capability decision. Every failure
+// is an ordinary success=false answer (the session is not broken; the client
+// drops that placement's render), sent as JSON to both kinds of client.
 func (d *Daemon) handleGetKittyImage(client *wsClient, msg *protocol.GetKittyImageMessage) {
 	provider, ok := d.ptyBackend.(ptybackend.KittyImageProvider)
 	if !ok {
@@ -141,9 +114,8 @@ func (d *Daemon) handleGetKittyImage(client *wsClient, msg *protocol.GetKittyIma
 			d.sendKittyImageFailure(client, msg.ID, msg.ImageID, err.Error())
 			return
 		}
-		// Blocking, like PTY output: a blob is megabytes and one message, so a
-		// slow client is better made to wait than handed a placement whose
-		// pixels never arrive.
+		// Blocking, like PTY output: better a slow client waits than a placement
+		// whose pixels never arrive.
 		if !d.sendOutboundBlocking(client, outboundMessage{kind: messageKindBinary, payload: frame}, ptyOutputSendWait) {
 			d.logf("kitty image send failed: id=%s image=%d bytes=%d", msg.ID, image.ID, len(frame))
 		}
@@ -164,9 +136,8 @@ func (d *Daemon) handleGetKittyImage(client *wsClient, msg *protocol.GetKittyIma
 	})
 }
 
-// sendKittyImageFailure answers a pull that produced no pixels. The message
-// always names the image id: the client asked by id and correlates by id, and
-// an error that omits it cannot be matched to the placement it kills.
+// sendKittyImageFailure answers a pull that produced no pixels; it always names
+// the image id, which is what the client correlates by.
 func (d *Daemon) sendKittyImageFailure(client *wsClient, sessionID string, imageID int, reason string) {
 	d.sendToClient(client, protocol.KittyImageResultMessage{
 		Event:   protocol.EventKittyImageResult,

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -21,9 +21,8 @@ import (
 const (
 	SettingProjectsDirectory = "projects_directory"
 	SettingUIScale           = "uiScale"
-	// SettingTicketBoardScale scales fonts on the ticket board and ticket
-	// detail surfaces independently of the app-wide uiScale. Empty/unset =>
-	// the board follows uiScale.
+	// SettingTicketBoardScale scales ticket-board fonts independently of
+	// uiScale; empty => follows uiScale.
 	SettingTicketBoardScale  = "ticketBoardScale"
 	SettingClaudeExecutable  = "claude_executable"
 	SettingCodexExecutable   = "codex_executable"
@@ -39,163 +38,107 @@ const (
 	SettingKeeperCompact     = "workspace_keeper_compact"
 	SettingTailscaleEnabled  = "tailscale_enabled"
 	SettingWorkflowsEnabled  = "workflows_enabled"
-	// Model capture is an explicit, local-only opt-in because visible terminal
-	// text can contain source code, conversations, and secrets.
+	// Model capture is an explicit, local-only opt-in: visible terminal text
+	// can contain secrets.
 	SettingModelCaptureEnabled         = "model_capture.enabled"
 	SettingModelCaptureIntervalSeconds = "model_capture.interval_seconds"
 	SettingModelCaptureMaxGB           = "model_capture.max_gb"
 	// Read-only effective status surfaced to Settings.
 	SettingModelCapturePath  = "model_capture.path"
 	SettingModelCaptureBytes = "model_capture.bytes"
-	// SettingQueueModeEnabled selects the sidebar arrangement: off (the default)
-	// is the workspace tree alone; on adds the anchored chief slot and the "Your
-	// turn" band above it. It is daemon-owned because which arrangement is in
-	// effect is policy, not a rendering preference — later it changes what a turn
-	// is, not just how one is drawn. The daemon stamps turns and broadcasts
-	// turn_owed either way; only the app's rendering reads this.
+	// SettingQueueModeEnabled selects the sidebar arrangement (workspace tree
+	// alone vs chief slot + "Your turn" band). The daemon stamps turns either way.
 	SettingQueueModeEnabled = "queue_mode_enabled"
-	// SettingAutoApproveEnabled, when true, launches interactive agents in their
-	// native auto-approve mode (Claude `--permission-mode auto`, Codex
-	// `approvals_reviewer=auto_review`) so they can run unattended without
-	// stalling on permission gates. Off by default. Yolo overrides it.
+	// SettingAutoApproveEnabled launches interactive agents in their native
+	// auto-approve mode. Off by default; yolo overrides it.
 	SettingAutoApproveEnabled = "auto_approve_enabled"
-	// SettingAutoSettleEnabled turns on closing a turn for the user once they
-	// have steered the agent and it has gone back to work. Off by default: it
-	// mutates state nobody asked it to, so it ships opt-in like the queue itself.
+	// SettingAutoSettleEnabled closes a turn for the user once they have steered
+	// the agent back to work. Off by default — it mutates state unasked.
 	SettingAutoSettleEnabled = "auto_settle_enabled"
-	// SettingAutoSettleArmSeconds is how long a session must hold `working`
-	// before the visible countdown starts — the delay that proves the steering
-	// took. Empty/unset => defaultAutoSettleArmSeconds.
+	// SettingAutoSettleArmSeconds: how long a session holds `working` before the
+	// countdown starts. Empty => defaultAutoSettleArmSeconds.
 	SettingAutoSettleArmSeconds = "auto_settle_arm_seconds"
-	// SettingAutoSettleCountdownSeconds is how long the countdown on the terminal
-	// tile runs before the turn is settled — the window the user has to cancel.
-	// Empty/unset => defaultAutoSettleCountdownSeconds.
+	// SettingAutoSettleCountdownSeconds: the visible cancel window before the
+	// turn settles. Empty => defaultAutoSettleCountdownSeconds.
 	SettingAutoSettleCountdownSeconds = "auto_settle_countdown_seconds"
 	SettingKeybindingsConfig          = "keybindings_config"
 	SettingNewSessionYoloPrefix       = "new_session_yolo_"
-	// SettingNewSessionDestinationPrefix + a scope naming one repository on one
-	// target (e.g. "new_session_destination_local_/Users/v/projects/attn")
-	// remembers where that repository's last new session went: a fresh worktree
-	// or the main checkout. The picker opens on the remembered one, because a
-	// repository is habitually one or the other. Empty/unset => new worktree,
-	// which is what the picker has always defaulted to. Values are
-	// DestinationNewWorktree / DestinationMainRepo; opening an existing worktree
-	// is a one-off and writes nothing.
+	// SettingNewSessionDestinationPrefix + repo scope remembers where that repo's
+	// last new session went (DestinationNewWorktree / DestinationMainRepo).
+	// Empty => new worktree; opening an existing worktree writes nothing.
 	SettingNewSessionDestinationPrefix = "new_session_destination_"
 	DestinationNewWorktree             = "new_worktree"
 	DestinationMainRepo                = "main_repo"
-	// SettingChiefModelPrefix + agent (e.g. "chief_model_claude") pins the model a
-	// chief-of-staff launch uses, passed through as --model. Empty/unset => the
-	// agent's own default model. Only consulted for chief launches.
+	// SettingChiefModelPrefix + agent pins the model a chief-of-staff launch
+	// uses (--model). Empty => agent default; chief launches only.
 	SettingChiefModelPrefix = "chief_model_"
-	// SettingChiefEffortPrefix + agent (e.g. "chief_effort_claude") pins the
-	// reasoning effort a chief-of-staff launch uses, passed through as the
-	// agent's native effort mechanism (Claude --effort, Codex
-	// model_reasoning_effort). Empty/unset => the agent's own default. Only
-	// consulted for chief launches.
+	// SettingChiefEffortPrefix + agent pins a chief launch's reasoning effort
+	// via the agent's native mechanism. Empty => agent default.
 	SettingChiefEffortPrefix = "chief_effort_"
-	// SettingDefaultModelPrefix + agent (e.g. "default_model_claude") pins the
-	// model EVERY interactive launch of that agent uses (chief or not), passed
-	// through as --model. Empty/unset => the agent's own default. A per-spawn
-	// pin (delegation) or a chief_model_<agent> override still takes priority
-	// over this; see resolveLaunchModel.
+	// SettingDefaultModelPrefix + agent pins the model EVERY interactive launch
+	// uses; per-spawn pins and chief_model_<agent> outrank it (resolveLaunchModel).
 	SettingDefaultModelPrefix = "default_model_"
-	// SettingDefaultEffortPrefix + agent (e.g. "default_effort_claude") pins
-	// the reasoning effort EVERY interactive launch of that agent uses (chief
-	// or not), passed through as the agent's native effort mechanism (Claude
-	// --effort, Codex model_reasoning_effort). Empty/unset => the agent's own
-	// default. A per-spawn pin (delegation) or a chief_effort_<agent> override
-	// still takes priority over this; see resolveLaunchEffort.
+	// SettingDefaultEffortPrefix + agent: same, for reasoning effort
+	// (resolveLaunchEffort).
 	SettingDefaultEffortPrefix = "default_effort_"
 	// SettingNotebookRoot overrides the notebook's filesystem root. Empty =>
 	// the profile-derived default (~/attn-notebook[-profile]).
 	SettingNotebookRoot = "notebook.root"
-	// SettingNotebookRootEffective is a READ-ONLY, daemon-computed key surfaced in
-	// the settings payload (never stored, never accepted by set_setting): the
-	// absolute folder the notebook currently resolves to, so the UI can show where
-	// the notebook lives even when SettingNotebookRoot is blank (the default).
+	// SettingNotebookRootEffective is READ-ONLY and daemon-computed (never
+	// stored, never accepted by set_setting): the folder the notebook resolves to.
 	SettingNotebookRootEffective = "notebook.root.effective"
-	// SettingNotebookCronFrequency is the 5-field cron expression for the
-	// notebook's nightly maintenance slot (currently the daily-narrate backstop).
-	// Empty => the default ("0 3 * * *").
+	// SettingNotebookCronFrequency: cron expression for the notebook's nightly
+	// maintenance slot. Empty => "0 3 * * *".
 	SettingNotebookCronFrequency = "notebook.cron.frequency"
-	// SettingNotebookCronTimezone is the IANA timezone the frequency is
-	// evaluated in. Empty => the machine's local time.
+	// SettingNotebookCronTimezone: IANA timezone the frequency is evaluated in.
+	// Empty => local time.
 	SettingNotebookCronTimezone = "notebook.cron.timezone"
 	// SettingNotebookSummarizeSession configures the per-session summarize pass
-	// (the CHEAP tier). JSON {"agent":"claude"|"codex","model":"<id>"}; empty =>
-	// the built-in cheap default (Claude Haiku). See parseNotebookNarrationConfig.
+	// (CHEAP tier). JSON {"agent","model"}; empty => Claude Haiku default.
 	SettingNotebookSummarizeSession = "notebook.summarize_session"
-	// SettingNotebookSummarizeSessionEnabled independently gates the per-session
-	// summarize pass. Default ON preserves existing installs; only an explicit
-	// "false" stops new summaries and retires queued summaries without launching
-	// their agent. The keeper master switch still takes precedence over every duty.
+	// SettingNotebookSummarizeSessionEnabled gates the summarize pass. Default
+	// ON; only an explicit "false" disables. The keeper master switch outranks it.
 	SettingNotebookSummarizeSessionEnabled = "notebook.summarize_session.enabled"
-	// SettingNotebookNarrateWorkspace configures the curated-journal narrate pass (the
-	// STRONG tier). JSON {"agent":"claude"|"codex","model":"<id>"}; empty => the
-	// built-in strong default (Claude Sonnet). Claude is the default narrate agent
-	// because its native Write/Edit enforce read-before-write CAS on the shared
-	// journal; see parseNotebookNarrationConfig.
+	// SettingNotebookNarrateWorkspace configures the curated-journal narrate pass
+	// (STRONG tier). JSON {"agent","model"}; empty => Claude Sonnet, whose native
+	// Write/Edit enforce read-before-write CAS on the journal.
 	SettingNotebookNarrateWorkspace = "notebook.narrate_workspace"
-	// SettingNotebookNarrateWorkspaceEnabled independently gates every curated-
-	// journal narrate path. Default ON preserves existing installs; only an explicit
-	// "false" stops new narrations and retires queued narrations without launching
-	// their agent. Raw session summaries and context compaction remain independent.
+	// SettingNotebookNarrateWorkspaceEnabled gates every narrate path. Default
+	// ON; only an explicit "false" disables.
 	SettingNotebookNarrateWorkspaceEnabled = "notebook.narrate_workspace.enabled"
-	// SettingActivityEnabled gates session activity: one short present-tense line
-	// per session saying what its agent is doing right now, generated from the
-	// transcript. Off by default — it spends money per session per refresh and
-	// sends transcript excerpts to a model, so it is an explicit opt-in.
+	// SettingActivityEnabled gates session activity (one present-tense line per
+	// session from its transcript). Off by default: it spends money per session
+	// per refresh and sends transcript excerpts to a model.
 	SettingActivityEnabled = "activity.enabled"
 	// SettingActivityConfig selects the generator. JSON
 	// {"agent":"claude"|"codex","model":"<id>","effort":"<effort>"}; empty means
-	// UNCONFIGURED, and there is deliberately no default agent — see
-	// parseActivityConfig. Model and effort fall back per agent once one is
-	// chosen.
+	// UNCONFIGURED — deliberately no default agent (see parseActivityConfig).
 	SettingActivityConfig = "activity.config"
 	// SettingActivityIntervals is the per-presence-tier cadence, JSON
-	// {"watching":120,"present":300} in seconds. One setting rather than two
-	// because they are a single policy; the `away` tier is absent by design,
-	// since stop is not a rate.
+	// {"watching":120,"present":300} in seconds. No `away` tier by design:
+	// stop is not a rate.
 	SettingActivityIntervals = "activity.intervals"
-	// SettingActivityPresenceIdleSeconds is how long after the last input in the
-	// app the `present` tier survives. Default 90 and UNMEASURED; safe because
-	// `away` is self-healing.
+	// SettingActivityPresenceIdleSeconds is how long after the last app input
+	// the `present` tier survives. Default 90, UNMEASURED; safe because `away`
+	// is self-healing.
 	SettingActivityPresenceIdleSeconds = "activity.presence_idle_seconds"
-	// SettingChiefContextWindowCap caps the chief-of-staff session's effective
-	// context window (in tokens): auto-compaction triggers at this threshold
-	// instead of at the model's full window, so each cache-cold chief wake
-	// re-reads less context. Empty/unset => DefaultContextWindowCap. Applied only
-	// to chief launches; delegated interactive agents are never capped.
+	// SettingChiefContextWindowCap caps the chief session's effective context
+	// window (tokens) so each cache-cold wake re-reads less. Empty =>
+	// DefaultContextWindowCap; chief launches only.
 	SettingChiefContextWindowCap = "chief_context_window_cap"
-	// SettingHeadlessContextWindowCap caps every headless run (keeper narration,
-	// ticket reconciliation, workflow subagents) the same way. Headless runs are
-	// one-shot and cache-cold by construction; one that grows past this is treated
-	// as a bug, not accommodated. Empty/unset => DefaultContextWindowCap.
+	// SettingHeadlessContextWindowCap caps every headless run the same way; a
+	// run that grows past it is a bug, not accommodated. Empty =>
+	// DefaultContextWindowCap.
 	SettingHeadlessContextWindowCap = "headless_context_window_cap"
-	// SettingDefaultContextWindowCapPrefix + agent (e.g.
-	// "default_context_window_cap_claude") caps the effective context window of
-	// EVERY interactive launch of that agent (Claude:
-	// CLAUDE_CODE_AUTO_COMPACT_WINDOW; Codex: model_auto_compact_token_limit),
-	// so long-lived sessions compact at a chosen threshold instead of the
-	// agent's own default. Unlike the chief cap there is no built-in fallback:
-	// empty/unset => uncapped, preserving the agent's native behavior. A chief
-	// launch still takes chief_context_window_cap over this; see
-	// launchContextWindowCap.
+	// SettingDefaultContextWindowCapPrefix + agent caps EVERY interactive launch of
+	// that agent. Empty => uncapped; chief_context_window_cap outranks it.
 	SettingDefaultContextWindowCapPrefix = "default_context_window_cap_"
-	// SettingNotebookTasksEnabled is the master switch for ALL keeper async
-	// background duties (per-session summarize, workspace narrate, context
-	// compaction). Default ON: a blank/unset value means enabled, so existing
-	// installs keep running the keeper without an opt-in. Only an explicit "false"
-	// disables the whole group; the per-duty agent/model settings stay configurable
-	// but produce no background work while off. See notebookTasksEnabled and the
-	// enqueue/executor gates that honor it.
+	// SettingNotebookTasksEnabled is the master switch for ALL keeper background
+	// duties. Default ON (blank means enabled); only an explicit "false"
+	// disables the group.
 	SettingNotebookTasksEnabled = "notebook.tasks_enabled"
-	// SettingDBLastBackupAt is a READ-ONLY, daemon-computed key surfaced in the
-	// settings payload (never stored, never accepted by set_setting): the UTC
-	// RFC3339 timestamp of the most recently successful rotating database
-	// backup (see performDatabaseBackup). Absent/empty before the first
-	// successful backup this process lifetime.
+	// SettingDBLastBackupAt is READ-ONLY and daemon-computed: UTC RFC3339 stamp
+	// of the last successful rotating backup this process lifetime.
 	SettingDBLastBackupAt = "db.last_backup_at"
 )
 
@@ -229,10 +172,8 @@ func (d *Daemon) handleSetSettingWS(client *wsClient, msg *protocol.SetSettingMe
 	if msg.Key == SettingHeadlessContextWindowCap {
 		d.applyHeadlessContextWindowCap()
 	}
-	// Turning auto-settle off must stop a countdown already on screen rather than
-	// let it run out; turning it on has to reach the sessions already working,
-	// since there is no state transition coming to arm them. Both windows are
-	// re-read per arm, so a duration change needs neither.
+	// Off must stop a countdown already on screen; on must reach sessions
+	// already working. Durations are re-read per arm and need neither.
 	if msg.Key == SettingAutoSettleEnabled {
 		if parseBooleanSetting(msg.Value) {
 			d.armAutoSettleForRunningSessions()
@@ -250,17 +191,15 @@ func (d *Daemon) handleSetSettingWS(client *wsClient, msg *protocol.SetSettingMe
 	d.publishSettingsFact(FactSettingChanged, msg.Key)
 }
 
-// publishSettingsFact re-derives the tailscale serve state, which the settings
-// payload carries, and then publishes the caller's fact. Every fact that
-// re-pushes settings goes through here so none of them can forget the refresh.
+// publishSettingsFact refreshes the tailscale serve state, then publishes.
+// Every settings-re-pushing fact goes through here so none forgets the refresh.
 func (d *Daemon) publishSettingsFact(name, subject string) {
 	d.refreshTailscaleServeState()
 	d.publishFact(name, subject, nil)
 }
 
-// projectSettingsUpdated pushes the settings snapshot. changedKey is empty when
-// what moved was not a setting the user set — a plugin leaving, a backup
-// landing — and the wire message then carries no changed_key, as before.
+// projectSettingsUpdated pushes the settings snapshot; changedKey is empty when
+// what moved was not a user-set setting.
 func (d *Daemon) projectSettingsUpdated(changedKey string) {
 	d.projectSnapshot(snapshotSettings, func() {
 		event := &protocol.SettingsUpdatedMessage{
@@ -392,24 +331,16 @@ func (d *Daemon) settingsWithAgentAvailability() map[string]interface{} {
 	}
 	settings[SettingQueueModeEnabled] = strconv.FormatBool(parseBooleanSetting(stored[SettingQueueModeEnabled]))
 	settings[SettingAutoApproveEnabled] = strconv.FormatBool(parseBooleanSetting(stored[SettingAutoApproveEnabled]))
-	// Surface the EFFECTIVE auto-settle policy so the UI shows the concrete
-	// defaults (off, 30s, 15s) rather than absent keys it would have to guess at.
+	// Surface EFFECTIVE auto-settle policy, not absent keys.
 	settings[SettingAutoSettleEnabled] = strconv.FormatBool(parseBooleanSetting(stored[SettingAutoSettleEnabled]))
 	settings[SettingAutoSettleArmSeconds] = strconv.Itoa(int(resolveAutoSettleSeconds(stored[SettingAutoSettleArmSeconds], defaultAutoSettleArmSeconds) / time.Second))
 	settings[SettingAutoSettleCountdownSeconds] = strconv.Itoa(int(resolveAutoSettleSeconds(stored[SettingAutoSettleCountdownSeconds], defaultAutoSettleCountdownSeconds) / time.Second))
-	// Normalize the keeper master switch to its EFFECTIVE value so the UI toggle
-	// reflects the default-ON semantics (blank/unset => "true") rather than an
-	// absent key the frontend would read as off.
+	// These are default-ON: send EFFECTIVE values so the app never mistakes an
+	// absent key for off.
 	settings[SettingNotebookTasksEnabled] = strconv.FormatBool(d.notebookTasksEnabled())
-	// The summary duty is independently opt-out while remaining default-on for
-	// existing profiles. Surface its effective value for the same reason as the
-	// keeper master switch: the app should never mistake an absent key for off.
 	settings[SettingNotebookSummarizeSessionEnabled] = strconv.FormatBool(d.notebookSummariesEnabled())
-	// The narration duty follows the same default-on, independently opt-out
-	// contract as summaries. Always send its effective value to the app.
 	settings[SettingNotebookNarrateWorkspaceEnabled] = strconv.FormatBool(d.notebookWorkspaceNarrationEnabled())
-	// Surface the EFFECTIVE token caps so the UI shows the concrete default
-	// (128000) rather than an absent key when the operator has not set one.
+	// EFFECTIVE token caps too, so the UI shows the concrete default.
 	settings[SettingChiefContextWindowCap] = strconv.Itoa(resolveContextWindowCap(stored[SettingChiefContextWindowCap]))
 	settings[SettingHeadlessContextWindowCap] = strconv.Itoa(resolveContextWindowCap(stored[SettingHeadlessContextWindowCap]))
 	// Session activity. The toggle and the intervals are surfaced EFFECTIVE, so
@@ -466,9 +397,8 @@ func isAgentExecutableAvailable(configuredExecutable, defaultExecutable string) 
 	return err == nil
 }
 
-// chiefLaunchModel returns the configured model for a chief-of-staff launch of
-// the given agent (from chief_model_<agent>), or "" — the agent's own default —
-// when this is not a chief launch or no model is configured.
+// chiefLaunchModel returns chief_model_<agent>, or "" when not a chief launch
+// or unconfigured.
 func (d *Daemon) chiefLaunchModel(agent string, chief bool) string {
 	if !chief {
 		return ""
@@ -476,10 +406,8 @@ func (d *Daemon) chiefLaunchModel(agent string, chief bool) string {
 	return strings.TrimSpace(d.store.GetSetting(SettingChiefModelPrefix + strings.ToLower(strings.TrimSpace(agent))))
 }
 
-// chiefLaunchEffort returns the configured reasoning effort for a
-// chief-of-staff launch of the given agent (from chief_effort_<agent>), or
-// "" — the agent's own default — when this is not a chief launch or no
-// effort is configured.
+// chiefLaunchEffort returns chief_effort_<agent>, or "" when not a chief launch
+// or unconfigured.
 func (d *Daemon) chiefLaunchEffort(agent string, chief bool) string {
 	if !chief {
 		return ""
@@ -487,26 +415,18 @@ func (d *Daemon) chiefLaunchEffort(agent string, chief bool) string {
 	return strings.TrimSpace(d.store.GetSetting(SettingChiefEffortPrefix + strings.ToLower(strings.TrimSpace(agent))))
 }
 
-// defaultLaunchModel returns the configured default model for EVERY
-// interactive launch of the given agent (from default_model_<agent>), chief
-// or not, or "" — the agent's own default — when none is configured.
+// defaultLaunchModel returns default_model_<agent>, or "" when unconfigured.
 func (d *Daemon) defaultLaunchModel(agent string) string {
 	return strings.TrimSpace(d.store.GetSetting(SettingDefaultModelPrefix + strings.ToLower(strings.TrimSpace(agent))))
 }
 
-// defaultLaunchEffort returns the configured default reasoning effort for
-// EVERY interactive launch of the given agent (from default_effort_<agent>),
-// chief or not, or "" — the agent's own default — when none is configured.
+// defaultLaunchEffort returns default_effort_<agent>, or "" when unconfigured.
 func (d *Daemon) defaultLaunchEffort(agent string) string {
 	return strings.TrimSpace(d.store.GetSetting(SettingDefaultEffortPrefix + strings.ToLower(strings.TrimSpace(agent))))
 }
 
-// resolveLaunchModel picks the model an interactive launch of the given agent
-// should use, honoring precedence: an explicit per-spawn pin (requested,
-// e.g. a delegation's --model) wins outright; otherwise a chief-of-staff
-// launch takes chief_model_<agent>; otherwise every launch (chief or not)
-// falls back to the operator-configured default_model_<agent>; otherwise the
-// agent's own built-in default (an empty string, meaning no --model flag).
+// resolveLaunchModel: per-spawn pin, then chief_model_<agent> for chief
+// launches, then default_model_<agent>, then "" (the agent's own default).
 func (d *Daemon) resolveLaunchModel(agent string, chief bool, requested string) string {
 	if requested != "" {
 		return requested
@@ -517,10 +437,7 @@ func (d *Daemon) resolveLaunchModel(agent string, chief bool, requested string) 
 	return d.defaultLaunchModel(agent)
 }
 
-// resolveLaunchEffort mirrors resolveLaunchModel for reasoning effort:
-// explicit per-spawn pin, then chief_effort_<agent> for chief launches, then
-// the operator-configured default_effort_<agent> for any launch, then the
-// agent's own default.
+// resolveLaunchEffort mirrors resolveLaunchModel for reasoning effort.
 func (d *Daemon) resolveLaunchEffort(agent string, chief bool, requested string) string {
 	if requested != "" {
 		return requested
@@ -531,15 +448,9 @@ func (d *Daemon) resolveLaunchEffort(agent string, chief bool, requested string)
 	return d.defaultLaunchEffort(agent)
 }
 
-// launchContextWindowCap returns the effective context-window token cap for an
-// interactive launch of sessionID's agent, or 0 (no cap). Mirrors
-// resolveLaunchModel: the policy lives here, the driver only applies it. A
-// per-session pin (set_session_context_window_cap) wins outright — it is the
-// user's explicit act on this one session, so it outranks even the chief cap.
-// Otherwise a chief launch takes chief_context_window_cap (which defaults to
-// DefaultContextWindowCap, so the chief is always capped); every other launch
-// takes default_context_window_cap_<agent>, whose unset state means uncapped —
-// the agent's own compaction behavior.
+// launchContextWindowCap returns the effective token cap for an interactive
+// launch, or 0. Precedence: per-session pin, then chief_context_window_cap for
+// chief launches, then default_context_window_cap_<agent> (unset => uncapped).
 func (d *Daemon) launchContextWindowCap(sessionID, agent string, chief bool) int {
 	if session := d.store.Get(strings.TrimSpace(sessionID)); session != nil {
 		if cap := protocol.Deref(session.ContextWindowCap); cap > 0 {
@@ -558,9 +469,8 @@ func (d *Daemon) launchContextWindowCap(sessionID, agent string, chief bool) int
 	return 0
 }
 
-// applyHeadlessContextWindowCap pushes the headless_context_window_cap setting
-// into the process-global that the headless spawn seam reads. Called at startup
-// and on every settings change so headless runs always use the current value.
+// applyHeadlessContextWindowCap pushes headless_context_window_cap into the
+// process-global the headless spawn seam reads; called at startup and on change.
 func (d *Daemon) applyHeadlessContextWindowCap() {
 	if d.store == nil {
 		return
@@ -634,28 +544,22 @@ func (d *Daemon) validateSetting(key, value string) error {
 		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(key)), SettingNewSessionDestinationPrefix) {
 			return validateNewSessionDestination(value)
 		}
+		// Model names and effort levels are free-form / agent-native: accept
+		// anything and let the agent reject bad ones.
 		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(key)), SettingChiefModelPrefix) {
-			// Model names/aliases are free-form (like the reviewer_model
-			// setting); accept any value and let the agent reject bad ones.
 			return nil
 		}
 		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(key)), SettingChiefEffortPrefix) {
-			// Effort levels are agent-native (claude: low/medium/high/xhigh/max,
-			// codex: minimal/low/medium/high/xhigh); accept any value and let
-			// the agent reject bad ones. The UI constrains input.
 			return nil
 		}
 		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(key)), SettingDefaultModelPrefix) {
-			// Model names/aliases are free-form, same as chief_model_<agent>.
 			return nil
 		}
 		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(key)), SettingDefaultEffortPrefix) {
-			// Effort levels are agent-native, same as chief_effort_<agent>.
 			return nil
 		}
 		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(key)), SettingDefaultContextWindowCapPrefix) {
-			// Same bounds as the chief/headless caps; blank here means uncapped
-			// rather than DefaultContextWindowCap (see launchContextWindowCap).
+			// Same bounds as the chief/headless caps; blank means uncapped here.
 			return validateContextWindowCap(value)
 		}
 		if _, ok := isAgentExecutableSettingKey(key); ok {
@@ -665,9 +569,8 @@ func (d *Daemon) validateSetting(key, value string) error {
 	}
 }
 
-// validateAutoSettleSeconds accepts an empty value (meaning the built-in default)
-// or a whole number of seconds inside the bounds. label names which of the two
-// windows failed, since the two settings sit side by side in the UI.
+// validateAutoSettleSeconds accepts empty (the built-in default) or whole
+// seconds inside the bounds; label names which of the two windows failed.
 func validateAutoSettleSeconds(label, value string, minSeconds, maxSeconds int) error {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -683,9 +586,8 @@ func validateAutoSettleSeconds(label, value string, minSeconds, maxSeconds int) 
 	return nil
 }
 
-// validateNewSessionDestination accepts an empty value (no remembered choice,
-// so the picker keeps its new-worktree default) or one of the two destinations
-// the picker can record.
+// validateNewSessionDestination accepts empty (no remembered choice) or one of
+// the two destinations the picker can record.
 func validateNewSessionDestination(value string) error {
 	switch strings.TrimSpace(value) {
 	case "", DestinationNewWorktree, DestinationMainRepo:
@@ -724,17 +626,14 @@ func validateUIScale(value string) error {
 	return nil
 }
 
-// contextWindowCap bounds. The knob can only REDUCE the effective window (a value
-// above the model's real limit is clamped/ignored by the agent), so the ceiling
-// is a fat-finger guard rather than a hard limit; the floor keeps compaction from
-// thrashing on a pathologically small window.
+// contextWindowCap bounds. The knob can only REDUCE the window, so the ceiling
+// is a fat-finger guard; the floor keeps compaction from thrashing.
 const (
 	contextWindowCapMin = 10000
 	contextWindowCapMax = 2000000
 )
 
-// validateContextWindowCap accepts an empty value (meaning DefaultContextWindowCap)
-// or a whole number of tokens within [contextWindowCapMin, contextWindowCapMax].
+// validateContextWindowCap accepts empty or whole tokens inside the bounds.
 func validateContextWindowCap(value string) error {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -750,8 +649,8 @@ func validateContextWindowCap(value string) error {
 	return nil
 }
 
-// resolveContextWindowCap turns a stored setting value into an effective token
-// cap, applying DefaultContextWindowCap when unset/blank/unparseable.
+// resolveContextWindowCap turns a stored value into an effective token cap,
+// defaulting when unset/blank/unparseable.
 func resolveContextWindowCap(stored string) int {
 	if trimmed := strings.TrimSpace(stored); trimmed != "" {
 		if n, err := strconv.Atoi(trimmed); err == nil && n > 0 {
@@ -761,11 +660,8 @@ func resolveContextWindowCap(stored string) int {
 	return agentdriver.DefaultContextWindowCap
 }
 
-// validateNotebookRoot accepts an empty value (meaning the profile-derived
-// default) or an absolute path (a leading ~/ is expanded). It refuses a path
-// inside the attn data dir: the notebook must live OUTSIDE ~/.attn[-profile] so
-// it stays a plain, externally-syncable directory a dotfile-skipping scanner
-// won't miss.
+// validateNotebookRoot accepts empty (the profile-derived default) or an
+// absolute path outside the attn data dir; see normalizeExternalRoot.
 func validateNotebookRoot(value string) error {
 	if strings.TrimSpace(value) == "" {
 		return nil
@@ -777,15 +673,9 @@ func validateNotebookRoot(value string) error {
 	return nil
 }
 
-// normalizeExternalRoot expands a leading "~/" against the user's home
-// directory, requires the result to be an absolute path, cleans it, and
-// rejects a path that is (or is inside) the attn data dir — an external root
-// must live OUTSIDE ~/.attn[-profile] so it stays a plain, externally-syncable
-// directory a dotfile-skipping scanner won't miss. Empty input is the
-// caller's concern: it returns ("", nil) unchanged.
-//
-// Errors are unprefixed (e.g. "must be an absolute path") so each caller can
-// prefix them with its own vocabulary (notebook.root vs fs root).
+// normalizeExternalRoot expands ~/, requires an absolute path, and rejects a path
+// at or inside the attn data dir. Empty returns ("", nil); errors are unprefixed
+// so each caller adds its own vocabulary.
 func normalizeExternalRoot(value string) (string, error) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -807,12 +697,9 @@ func normalizeExternalRoot(value string) (string, error) {
 	if clean == dataDir || strings.HasPrefix(clean, dataDir+string(filepath.Separator)) {
 		return "", fmt.Errorf("must be outside the attn data dir (%s)", dataDir)
 	}
-	// fsdoc.Store deliberately permits symlinked roots, so a purely lexical
-	// comparison above can be defeated by a symlink into the data dir (e.g. a
-	// root under /tmp whose target is ~/.attn). Re-check on canonicalized
-	// forms; the canonical value is used ONLY for this comparison — we still
-	// return the original cleaned (non-canonical) path below so legitimate
-	// symlinked roots keep their own spelling.
+	// Symlinked roots are permitted, so a symlink can defeat the lexical check
+	// above. The canonical form is used ONLY for comparison — the cleaned path is
+	// returned, so legitimate symlinked roots keep their spelling.
 	canonRoot := canonicalizeForComparison(clean)
 	canonData := canonicalizeForComparison(dataDir)
 	if canonRoot == canonData || strings.HasPrefix(canonRoot, canonData+string(filepath.Separator)) {
@@ -821,12 +708,9 @@ func normalizeExternalRoot(value string) (string, error) {
 	return clean, nil
 }
 
-// canonicalizeForComparison resolves path to its canonical form for
-// containment checks: symlinks in the deepest existing ancestor are resolved
-// and any not-yet-existing remainder is re-joined lexically. Used ONLY for
-// comparison against the (equally canonicalized) attn data dir — the returned
-// value is never handed to callers as the root, so legitimate symlinked roots
-// keep their original spelling.
+// canonicalizeForComparison resolves symlinks in the deepest existing ancestor
+// and re-joins the rest lexically. Used ONLY for containment comparison; never
+// returned to callers as the root.
 func canonicalizeForComparison(path string) string {
 	clean := filepath.Clean(path)
 	ancestor := clean
@@ -837,8 +721,6 @@ func canonicalizeForComparison(path string) string {
 		}
 		parent := filepath.Dir(ancestor)
 		if parent == ancestor {
-			// Reached the root without finding an existing ancestor; fall back
-			// to the lexically cleaned input.
 			return clean
 		}
 		remainder = append([]string{filepath.Base(ancestor)}, remainder...)
@@ -851,13 +733,9 @@ func canonicalizeForComparison(path string) string {
 	return filepath.Join(append([]string{resolved}, remainder...)...)
 }
 
-// validateNotebookCronFrequency accepts an empty value (use the default) or a
-// cron expression the scheduler can fire. It rejects two parseable-but-wrong
-// forms: an embedded CRON_TZ=/TZ= prefix (a second timezone source that would
-// silently compete with notebook.cron.timezone) and a schedule whose date can
-// never occur (e.g. "0 0 30 2 *", Feb 30) — robfig cron returns the zero time for
-// those, which the scheduler would treat as perpetually due and re-fire in a
-// tight loop.
+// validateNotebookCronFrequency rejects an embedded CRON_TZ=/TZ= prefix (competes
+// with notebook.cron.timezone) and a never-occurring date like Feb 30 — robfig
+// returns the zero time for those, which the scheduler re-fires in a loop.
 func validateNotebookCronFrequency(value string) error {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -876,14 +754,13 @@ func validateNotebookCronFrequency(value string) error {
 	return nil
 }
 
-// hasCronTZPrefix reports whether a cron string carries a leading TZ=/CRON_TZ=
-// timezone prefix (the form robfig/cron's ParseStandard honors).
+// hasCronTZPrefix reports a leading TZ=/CRON_TZ= prefix (the form
+// robfig/cron's ParseStandard honors).
 func hasCronTZPrefix(expr string) bool {
 	return strings.HasPrefix(expr, "TZ=") || strings.HasPrefix(expr, "CRON_TZ=")
 }
 
-// validateNotebookCronTimezone accepts an empty value (local time) or an IANA
-// timezone name loadable on this machine.
+// validateNotebookCronTimezone accepts empty (local time) or a loadable IANA name.
 func validateNotebookCronTimezone(value string) error {
 	if strings.TrimSpace(value) == "" {
 		return nil
@@ -990,9 +867,8 @@ func (d *Daemon) validateNewSessionAgent(value string) error {
 	return nil
 }
 
-// validateKeybindingsConfig keeps daemon validation light: the frontend owns the
-// shortcut schema and tolerates anything unrecognized, so the daemon only
-// guarantees the stored blob is parseable JSON (or empty).
+// validateKeybindingsConfig only guarantees parseable JSON (or empty); the
+// frontend owns the shortcut schema.
 func validateKeybindingsConfig(value string) error {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {

--- a/internal/daemonctl/stop.go
+++ b/internal/daemonctl/stop.go
@@ -18,19 +18,13 @@ const (
 	stopSigkillWait = 2 * time.Second
 )
 
-// NonDaemonHolderSentinel is written into the pid file by non-daemon
-// processes that take the daemon lock (e.g. `attn db restore`, via
-// cmd/attn's acquireDaemonLock), replacing any stale daemon pid, so a
-// concurrent Stop observing a held lock never trusts a pid the current
-// holder didn't write. Content is only meaningful while the lock is held;
-// the next daemon acquire overwrites it with its own pid as usual.
+// NonDaemonHolderSentinel is written into the pid file by non-daemon lock
+// holders (e.g. `attn db restore`), so a concurrent Stop observing a held lock
+// never trusts a pid the current holder didn't write.
 const NonDaemonHolderSentinel = "non-daemon-holder"
 
-// flockFn is indirected to syscall.Flock so tests can inject a
-// non-EWOULDBLOCK failure (e.g. standing in for ENOLCK) without needing real
-// OS-level conditions to trigger it — EWOULDBLOCK is the only signal that
-// means a live daemon (or another non-daemon holder) actually holds the
-// lock; every other flock error is indeterminate and must fail closed.
+// flockFn is indirected so tests can inject a non-EWOULDBLOCK failure. Only
+// EWOULDBLOCK means the lock is held; every other flock error fails closed.
 var flockFn = syscall.Flock
 
 // StopResult describes the outcome of a Stop call.
@@ -41,22 +35,11 @@ type StopResult struct {
 	Note    string // human-readable detail for nil-error, not-stopped outcomes, e.g. "not running (no pid file)"
 }
 
-// Stop stops the daemon that owns pidPath, using the pid file's exclusive
-// flock as the liveness+ownership gate (mirrors stopProfileDaemon's semantics
-// exactly): if the lock can be acquired, no daemon or other holder owns the
-// file, so any pid on disk is stale and must never be signaled. Only
-// EWOULDBLOCK on the flock attempt means the lock is genuinely held; any
-// other flock error is indeterminate and fails closed rather than trusting a
-// pid nobody currently vouches for. When the lock is held, only content the
-// current holder is known to have written under that lock is trusted: the
-// daemon's own pid, or NonDaemonHolderSentinel for non-daemon holders like
-// `attn db restore` — anything else is a malformed-pid error. Not-running
-// outcomes (no pid file, stale pid file, sentinel-held lock, ESRCH on
-// signal) are nil-error results with Stopped=false and a Note. Errors are
-// reserved for genuine failures: open/read failures, an indeterminate flock
-// result, malformed pid contents, a pid matching this process or its parent
-// (refuse), SIGTERM delivery failure, or a process that survives SIGKILL
-// escalation.
+// Stop stops the daemon that owns pidPath. The pid file's exclusive flock is
+// the liveness+ownership gate (mirrors stopProfileDaemon): an acquirable lock
+// means any pid on disk is stale and never signaled; only EWOULDBLOCK means
+// held, any other flock error fails closed. Not-running outcomes are
+// nil-error results with Stopped=false and a Note; errors are genuine failures.
 func Stop(pidPath string) (StopResult, error) {
 	lockFile, err := os.OpenFile(pidPath, os.O_RDWR, 0)
 	if os.IsNotExist(err) {
@@ -66,26 +49,20 @@ func Stop(pidPath string) (StopResult, error) {
 		return StopResult{}, fmt.Errorf("could not open pid file: %w", err)
 	}
 	if flockErr := flockFn(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); flockErr == nil {
-		// Acquired the lock → no live daemon (or other holder) owns it. The
-		// pid on disk is stale; signaling it could hit a recycled, unrelated
-		// process.
+		// Acquired → no live holder; the pid on disk is stale and could be a
+		// recycled, unrelated process.
 		_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
 		lockFile.Close()
 		return StopResult{Note: "not running (stale pid file)"}, nil
 	} else if !errors.Is(flockErr, syscall.EWOULDBLOCK) {
-		// Any other flock failure means we cannot determine whether the
-		// lock is held. Fail closed rather than risk trusting a pid nobody
-		// currently vouches for.
+		// Indeterminate flock result: fail closed.
 		lockFile.Close()
 		return StopResult{}, fmt.Errorf("cannot determine daemon state: %w", flockErr)
 	}
 	lockFile.Close()
 
-	// The lock is held (EWOULDBLOCK) → some process owns this file and, by
-	// convention, wrote content under the lock proving what it is: the
-	// daemon writes its own pid, and non-daemon holders (acquireDaemonLock,
-	// e.g. `attn db restore`) overwrite it with NonDaemonHolderSentinel. Only
-	// numeric content is trusted as a signalable pid.
+	// Lock held: trust only content written under the lock — the daemon's own
+	// pid or NonDaemonHolderSentinel. Only numeric content is signalable.
 	data, err := os.ReadFile(pidPath)
 	if err != nil {
 		return StopResult{}, fmt.Errorf("could not read pid file: %w", err)
@@ -98,18 +75,13 @@ func Stop(pidPath string) (StopResult, error) {
 	if err != nil || pid <= 0 {
 		return StopResult{}, fmt.Errorf("malformed pid file %q", pidText)
 	}
-	// Never signal our own process tree (e.g. stopping the profile we're
-	// running under): killing it would take down this very command.
+	// Never signal our own process tree.
 	if pid == os.Getpid() || pid == os.Getppid() {
 		return StopResult{}, fmt.Errorf("refusing to stop pid %d: it is this command's own process tree", pid)
 	}
-	// Content ordering alone cannot prove pid genuinely holds the lock: a
-	// holder acquires the flock before it writes its own pid (or the
-	// sentinel), so a Stop racing that window sees EWOULDBLOCK plus
-	// whatever stale content was there first. Require positive proof
-	// instead: pid must itself have the file open right now. A stale pid
-	// (recycled or not), or a holder caught between acquiring the flock
-	// and writing its content, fails this check and is never signaled.
+	// A holder acquires the flock before writing its pid, so a racing Stop can
+	// see EWOULDBLOCK plus stale content. Require positive proof: pid must
+	// have the file open right now, or it is never signaled.
 	holds, err := pidHoldsPIDFile(pid, pidPath)
 	if err != nil {
 		return StopResult{}, fmt.Errorf("could not verify pid %d holds the daemon lock: %w", pid, err)
@@ -134,8 +106,8 @@ func Stop(pidPath string) (StopResult, error) {
 	return StopResult{}, fmt.Errorf("pid %d did not exit after SIGKILL", pid)
 }
 
-// lsofPath resolves the `lsof` binary once: PATH first, falling back to its
-// standard macOS location, since Stop may run with a trimmed PATH.
+// lsofPath resolves `lsof` once: PATH first, then its standard macOS location,
+// since Stop may run with a trimmed PATH.
 var lsofPath = resolveLsofPath()
 
 func resolveLsofPath() string {
@@ -145,19 +117,10 @@ func resolveLsofPath() string {
 	return "/usr/sbin/lsof"
 }
 
-// pidHoldsPIDFile reports whether pid currently has pidPath open, via
-// `lsof -t -- <path>`. This is the positive ownership proof that closes the
-// acquire-flock-then-write-content ordering gap: unlike trusting the
-// content under a held lock, a process cannot appear here without an open
-// file descriptor on pidPath at the moment of the check, regardless of how
-// far it has gotten writing content.
-//
-// Fail-closed: any exec/parse error is returned as an error (never signaled
-// on an inconclusive result). lsof exiting 1 with no output means "no
-// process holds the file" — not an error, just holds=false. Note Stop's own
-// process may itself have pidPath open at probe time (from the earlier
-// contention check) — the check below tests membership of the specific
-// content pid, not exclusivity, so that is harmless.
+// pidHoldsPIDFile reports whether pid has pidPath open (`lsof -t`) — the
+// positive proof that closes the acquire-flock-then-write ordering gap.
+// Fail-closed on exec/parse errors; lsof exit 1 with no output means no holder.
+// It tests membership, not exclusivity, so Stop's own open fd is harmless.
 func pidHoldsPIDFile(pid int, pidPath string) (bool, error) {
 	cmd := exec.Command(lsofPath, "-t", "--", pidPath)
 	var stdout, stderr bytes.Buffer

--- a/internal/docstore/docstore.go
+++ b/internal/docstore/docstore.go
@@ -77,6 +77,7 @@ type CollectionSchema struct {
 	Table      string      `json:"-"`
 }
 
+// Filter is one comparison against a declared or reserved field.
 type Filter struct {
 	Field string `json:"field"`
 	Op    Op     `json:"op"`

--- a/internal/docstore/docstore.go
+++ b/internal/docstore/docstore.go
@@ -1,31 +1,12 @@
 // Package docstore is attn's document primitive: JSON documents addressed by
-// (namespace, collection, id), read through one JSON-serializable query object,
-// with a collection's declared fields as the contract for what may be filtered
-// and sorted.
+// (namespace, collection, id), queried through one serializable query object.
+// It owns what a query MEANS and the SQL it compiles to, but no database
+// handle — internal/store executes what is compiled here. It also owns the
+// physical naming (TableName, FieldColumn); the store builds its DDL from
+// those names and invents none.
 //
-// This package owns what a query MEANS — the vocabulary, the validation, and
-// the SQL a validated query compiles to. It owns no database handle:
-// internal/store executes what is compiled here and scans the rows. That is the
-// same split internal/bus and internal/store/bus.go already use, semantics here
-// and persistence there, and it is what lets the query rules be tested without
-// a database.
-//
-// The query object is deliberately serializable end to end. Three surfaces will
-// eventually carry it — the Bun sidecar's SDK, extension UI, and `attn doc` —
-// and all three must carry the same thing, so a later transport adds transport
-// and not semantics.
-//
-// The store knows nothing about extensions. A namespace is an opaque
-// `owner/name` string; who may write under which owner is enforced where the
-// namespace is granted, not here.
-//
-// A collection is physically its own table, and a declared field an indexed
-// generated column in it, so this package also owns the naming those identifiers
-// use — see TableName and FieldColumn, and
-// docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md. The store builds
-// its DDL from those names; it does not invent any.
-//
-// See docs/plans/2026-08-03-ext-a3-doc-store.md.
+// See docs/plans/2026-08-03-ext-a3-doc-store.md and
+// docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md.
 package docstore
 
 import (
@@ -38,34 +19,24 @@ import (
 	"time"
 )
 
-// Limits on a result set. A live query's results are pushed as one message and
-// rendered as one list, so the bound that matters is "how big is a list a person
-// looks at".
-//
-// Receipt (2026-08-03, production ~/.attn): the lists attn already pushes whole
-// are tickets 7, sessions 11, notifications 8, workspaces 8. DefaultLimit is an
-// order of magnitude past that working set, MaxLimit two orders — a tripwire, so
-// only something broken or something that means to paginate ever feels it.
+// Result-set limits. Measured (2026-08-03, production ~/.attn): the lists attn
+// pushes whole are tickets 7, sessions 11, notifications 8, workspaces 8.
+// DefaultLimit is an order of magnitude past that, MaxLimit two — a tripwire.
 const (
 	DefaultLimit = 100
 	MaxLimit     = 1000
 )
 
-// Reserved field names. Both are real columns the store stamps, so they are
-// always available for filtering and sorting without being declared — "newest
-// first" and "changed since" need no schema. A collection may not declare a body
-// field under either name; the column would win and the declaration would be a
-// lie.
+// Reserved field names: real columns the store stamps, always filterable and
+// sortable without being declared. A collection may not declare a body field
+// under either name.
 const (
 	FieldCreatedAt = "created_at"
 	FieldUpdatedAt = "updated_at"
 )
 
-// FieldType is what a declared field holds. The type is not decoration: it
-// decides how a filter's bound is bound to the statement — comparing a number
-// field against a string bound would otherwise match nothing at all rather than
-// failing — and it is the affinity of the column the field is stored through,
-// so it also decides how two stored values compare with each other.
+// FieldType decides how a filter's bound is bound (a number field against a
+// string bound silently matches nothing) and the column's affinity.
 type FieldType string
 
 const (
@@ -74,9 +45,8 @@ const (
 	FieldBool   FieldType = "bool"
 )
 
-// Op is a filter comparison. Equality plus the four range operators is the whole
-// surface: it covers a pending-requests panel and a changed-since sweep.
-// Pagination is deliberately not built out of these — see Query.After.
+// Op is a filter comparison; pagination is deliberately not built out of these
+// — see Query.After.
 type Op string
 
 const (
@@ -95,22 +65,11 @@ type FieldSpec struct {
 	Type FieldType `json:"type"`
 }
 
-// CollectionSchema is a collection's declaration: which fields may be filtered
-// and sorted on. It is the API contract for queries, and it is deliberately not
-// a schema the body must satisfy — a document's body is arbitrary JSON, an
-// undeclared key is stored and read back untouched, and a declared field the
-// body omits is simply absent. Declaring a field says "you may query this", not
-// "this must exist".
-//
-// Physically a declared field is an indexed generated column over the body, so
-// the declaration is also what the store builds. Adding one is DDL and rewrites
-// no document; see docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md.
-//
-// Table is the collection's own table, minted by the store from the
-// declaration's row id and filled in on read. It is not part of the declaration
-// a caller writes, and Compile refuses a schema whose Table is not a minted
-// name — that check is the whole defence for the one identifier in the compiled
-// SQL that does not come from a validated field name.
+// CollectionSchema declares which fields may be filtered and sorted on; the body
+// stays arbitrary JSON. Table is minted by the store from the declaration's row
+// id and filled in on read, never written by a caller — Compile refuses a
+// non-minted Table, the whole defence for the one identifier not derived from a
+// validated field name.
 type CollectionSchema struct {
 	Namespace  string      `json:"namespace"`
 	Collection string      `json:"collection"`
@@ -118,33 +77,23 @@ type CollectionSchema struct {
 	Table      string      `json:"-"`
 }
 
-// Filter is one comparison against a declared or reserved field.
 type Filter struct {
 	Field string `json:"field"`
 	Op    Op     `json:"op"`
 	Value any    `json:"value"`
 }
 
-// Sort names the ordering field. Results always carry a stable total order —
-// Compile appends the document id as a tiebreaker, in the same direction as the
-// sort — so two documents sharing a sort value have a defined relative position.
+// Sort names the ordering field; Compile appends the document id as a tiebreaker
+// in the sort's direction, so the order is always total.
 type Sort struct {
 	Field string `json:"field"`
 	Desc  bool   `json:"desc,omitempty"`
 }
 
-// Query is the one representation every surface carries.
-//
-// A zero Limit means DefaultLimit rather than "unbounded": a query with no
-// ceiling is a wire message with no ceiling.
-//
-// After is the id of the last document of the previous page, and is how a
-// caller gets the next one. It has to be part of the query rather than a filter
-// a caller writes by hand: the visible order is (sort field, id), and a filter
-// can only constrain one of those, so `sort > value` skips every document tied
-// with the anchor and `sort >= value` returns the anchor again. Compile turns
-// After into a comparison against the whole ordering tuple, which is the only
-// form that neither skips nor repeats.
+// Query is the one representation every surface carries; a zero Limit means
+// DefaultLimit, never "unbounded". After (the previous page's last id) is part
+// of the query rather than a filter: a filter can constrain only one of (sort
+// field, id), so it either skips ties or repeats the anchor.
 type Query struct {
 	Namespace  string   `json:"namespace"`
 	Collection string   `json:"collection"`
@@ -154,14 +103,8 @@ type Query struct {
 	After      string   `json:"after,omitempty"`
 }
 
-// Document is one stored record. Body is the document as written, byte for byte
-// — record-shape evolution is handled by the reader (parse tolerantly, render
-// tolerantly), never by migrating stored documents.
-//
-// Rev is what makes a read-modify-write safe. It comes back on every read, so a
-// caller that read a document already holds the token that names the version it
-// read; handing that token back to a write is how the store can refuse an edit
-// built on a version somebody else has since replaced.
+// Document is one stored record. Body is byte-for-byte as written — shape
+// evolution is handled by tolerant readers, never by migrating documents.
 type Document struct {
 	ID        string          `json:"id"`
 	Body      json.RawMessage `json:"body"`
@@ -170,47 +113,26 @@ type Document struct {
 	UpdatedAt time.Time       `json:"updated_at"`
 }
 
-// Revisions.
-//
-// A document's revision counts writes to that document, starting at FirstRev.
-// It is per document rather than per collection or per store: what a caller
-// needs to know is whether the record they read is the record they are about to
-// overwrite, and a global counter would make every unrelated write look like a
-// conflict.
-//
-// ExpectAbsent is the one magic value, and it is unambiguous because revisions
-// start at 1: a caller that expects revision zero is a caller that expects no
-// document at all. That makes create-only fall out of the same field rather
-// than needing a second one.
-//
-// Width: the wire carries a revision as safeint (2^53-1) and the store as
-// SQLite INTEGER, which is 8 bytes whatever it is declared as. int32 would have
-// been 2.1 billion writes to ONE document — roughly seven years at ten writes a
-// second, which attn's uptime can reach — and overflowing it would silently make
-// a stale check pass, which is the exact failure this exists to prevent.
+// A revision counts writes to one document, starting at FirstRev. ExpectAbsent
+// is unambiguous because revisions start at 1: expecting rev zero is expecting
+// no document, so create-only falls out of the same field. int64 because an
+// int32 overflow (~7 years at 10 writes/s to one document) would silently make
+// a stale check pass — the exact failure this exists to prevent.
 const (
 	FirstRev     int64 = 1
 	ExpectAbsent int64 = 0
 )
 
-// ConflictError is a write refused because the document was not at the revision
-// the caller expected. It is a distinct type, not a string, because every
-// surface above has to be able to tell it apart from a failure: a conflict means
-// "read it again and retry", and everything else means "something is broken".
-//
-// Found and Actual describe what was there when the store looked, which is after
-// the write was refused — so they name the version that won rather than the
-// version that will still be current by the time the caller reads this. That is
-// what the caller wants: it says which write it lost to.
+// ConflictError is a write refused because the document was not at the expected
+// revision — a distinct type so surfaces can tell "read again and retry" from
+// "broken".
 type ConflictError struct {
 	Namespace  string
 	Collection string
 	ID         string
-	// Expected is the revision the caller asserted, or ExpectAbsent when the
-	// caller asserted the document did not exist.
-	Expected int64
-	// Found reports whether a document was there at all; Actual is its revision
-	// and is meaningless when Found is false.
+	Expected   int64
+	// Found reports whether a document was there at all; Actual is meaningless
+	// when Found is false.
 	Found  bool
 	Actual int64
 }
@@ -227,17 +149,13 @@ func (e *ConflictError) Error() string {
 	}
 }
 
-// IsConflict reports whether an error is a lost-update refusal. It is the check
-// a retry loop makes.
+// IsConflict reports whether an error is a lost-update refusal.
 func IsConflict(err error) bool {
 	var conflict *ConflictError
 	return errors.As(err, &conflict)
 }
 
-// UndeclaredCollectionError is every read or write against a collection nobody
-// declared. It is a type for the same reason ConflictError is: the surfaces
-// above have to tell "declare it first" from "something is broken", and a UI
-// host has to tell "kill this tile" from "retry".
+// UndeclaredCollectionError is a read or write against a collection nobody declared.
 type UndeclaredCollectionError struct {
 	Namespace  string
 	Collection string
@@ -254,27 +172,21 @@ func IsUndeclaredCollection(err error) bool {
 	return errors.As(err, &undeclared)
 }
 
-// InvalidQueryError is a query this collection cannot answer: an unknown field,
-// an operator that does not exist, a bound of the wrong type, a cursor pointing
-// at a document that is gone. It wraps the specific refusal rather than
-// replacing it — the message is the part an agent fixes the query from, and the
-// type is the part a program branches on.
+// InvalidQueryError wraps a refusal: the message is what an agent fixes the
+// query from, the type is what a program branches on.
 type InvalidQueryError struct{ Err error }
 
 func (e *InvalidQueryError) Error() string { return e.Err.Error() }
 func (e *InvalidQueryError) Unwrap() error { return e.Err }
 
-// IsInvalidQuery reports whether an error is a query this store refused to
-// compile.
+// IsInvalidQuery reports whether an error is a refused query.
 func IsInvalidQuery(err error) bool {
 	var invalid *InvalidQueryError
 	return errors.As(err, &invalid)
 }
 
-// InvalidQuery marks an error as a refusal to run a caller's query. It is
-// exported because a query can also be refused before it reaches Compile —
-// decoding one off the wire, for instance — and those refusals are the same
-// class to whoever asked.
+// InvalidQuery marks an error as a refusal; exported because a query can be
+// refused before it reaches Compile.
 func InvalidQuery(err error) error {
 	if err == nil {
 		return nil
@@ -285,11 +197,9 @@ func InvalidQuery(err error) error {
 	return &InvalidQueryError{Err: err}
 }
 
-// Compiled is a validated query as SQL. Table is the collection's table, Where
-// and Order are fragments the store splices into its own SELECT, and Args binds
-// Where's placeholders in order. Where is empty when nothing constrains the
-// query: the table already holds exactly one collection, so "everything" needs
-// no predicate at all.
+// Compiled is a validated query as SQL fragments the store splices into its own
+// SELECT, Args binding Where's placeholders in order. Where is empty when
+// nothing constrains the query — the table holds exactly one collection.
 type Compiled struct {
 	Table string
 	Where string
@@ -310,32 +220,23 @@ var (
 	reservedField = map[string]bool{FieldCreatedAt: true, FieldUpdatedAt: true}
 )
 
-// Physical naming. A collection is one table and a declared field is one
-// generated column in it, so these names end up spliced into SQL as
-// identifiers. Every one of them is derived here from something already
-// checked — an integer row id, or a field name matching fieldNameRe — so there
-// is no caller-supplied text in any identifier the store executes.
+// These names are spliced into SQL as identifiers; each derives from something
+// already checked (an integer row id, or a field name matching fieldNameRe).
 const (
-	// tablePrefix keeps minted tables recognisable in a schema dump and out of
-	// the way of attn's own tables.
 	tablePrefix = "doc_"
-	// fieldColumnPrefix keeps a declared field from colliding with the columns
-	// the store owns: a collection may declare a field called `id` or `body`
-	// without shadowing either.
+	// fieldColumnPrefix keeps a declared field (`id`, `body`) from shadowing the
+	// columns the store owns.
 	fieldColumnPrefix = "f_"
 )
 
-// TableName is the table holding a collection's documents, derived from its
-// declaration's row id. Derived rather than built from the address because a
-// namespace contains a slash and a collection name is caller-chosen: minting
-// from an integer means no identifier is ever a function of caller text.
+// TableName is minted from the declaration's row id, so no identifier is ever a
+// function of caller text.
 func TableName(id int64) string {
 	return fmt.Sprintf("%s%d", tablePrefix, id)
 }
 
-// ValidateTableName accepts a minted table name. Compile calls it before
-// splicing, so a schema that reached the compiler from anywhere but the store's
-// own read path fails loudly instead of composing SQL.
+// ValidateTableName accepts a minted table name; Compile calls it before
+// splicing, so a schema from anywhere but the store's read path fails loudly.
 func ValidateTableName(name string) error {
 	if name == "" {
 		return fmt.Errorf("docstore: collection has no table; a declaration must be read from the store before it can be queried")
@@ -351,20 +252,15 @@ func FieldColumn(field string) string {
 	return fieldColumnPrefix + field
 }
 
-// FieldExpression is what that column computes: the field read out of the body.
-// The store builds its DDL from this, and it is the reason a declaration
-// rewrites no document — the column is VIRTUAL, so it exists for every document
-// already stored the moment it is added.
+// FieldExpression is what that column computes; the column is VIRTUAL, which is
+// why a declaration rewrites no document.
 func FieldExpression(field string) string {
 	return "json_extract(body, '$." + field + "')"
 }
 
-// ColumnAffinity is the SQLite affinity a declared type maps to. This is where
-// the declared type stops being decoration: a body storing "5" in a number
-// field reads, compares, and orders as the number 5, because the column that
-// carries it is NUMERIC. A value with no such reading — an array, an object —
-// keeps its JSON text, which is what makes those still orderable rather than an
-// error.
+// ColumnAffinity maps a declared type to a SQLite affinity: "5" in a NUMERIC
+// column orders as the number 5, while an array or object keeps its JSON text
+// and stays orderable rather than erroring.
 func ColumnAffinity(t FieldType) string {
 	switch t {
 	case FieldNumber:
@@ -376,16 +272,14 @@ func ColumnAffinity(t FieldType) string {
 	}
 }
 
-// quoteIdent renders an identifier for SQL. Every identifier here already
-// matches a validating pattern, so this is belt-and-braces rather than the
-// defence — but it is what makes a field named like a keyword harmless.
+// quoteIdent is belt-and-braces over the validating patterns; it makes a
+// keyword-named field harmless.
 func quoteIdent(name string) string {
 	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
 
-// ValidateNamespace accepts an `owner/name` namespace. The store does not care
-// which owners exist; it cares that the string is a well-formed two-part name it
-// can index and a person can read.
+// ValidateNamespace accepts a well-formed `owner/name`; which owners exist is
+// not this package's concern.
 func ValidateNamespace(ns string) error {
 	if ns == "" {
 		return fmt.Errorf("docstore: namespace is required, as owner/name (for example ext/approval-gate)")
@@ -407,9 +301,7 @@ func ValidateCollection(name string) error {
 	return nil
 }
 
-// ValidateDocumentID accepts a document id. Ids are caller-chosen so a workflow
-// can address the record it owns by a name it already has, rather than storing a
-// generated id somewhere to find it again.
+// ValidateDocumentID accepts a caller-chosen document id.
 func ValidateDocumentID(id string) error {
 	if id == "" {
 		return fmt.Errorf("docstore: document id is required")
@@ -420,10 +312,8 @@ func ValidateDocumentID(id string) error {
 	return nil
 }
 
-// Validate checks a collection declaration. Field names are restricted to plain
-// identifiers because a declared field becomes both a JSON path and a column
-// name in the collection's table: this is the check that keeps every identifier
-// the store goes on to execute free of caller-shaped text.
+// Validate checks a declaration. Field names must be plain identifiers because a
+// declared field becomes both a JSON path and an executed column name.
 func (s CollectionSchema) Validate() error {
 	if err := ValidateNamespace(s.Namespace); err != nil {
 		return err
@@ -456,8 +346,6 @@ func (s CollectionSchema) Validate() error {
 	return nil
 }
 
-// field returns the declared spec for name, or false when the collection does
-// not declare it.
 func (s CollectionSchema) field(name string) (FieldSpec, bool) {
 	for _, f := range s.Fields {
 		if f.Name == name {
@@ -467,9 +355,8 @@ func (s CollectionSchema) field(name string) (FieldSpec, bool) {
 	return FieldSpec{}, false
 }
 
-// declaredNames lists the collection's queryable fields for an error message,
-// reserved names included, so a rejected query says what it could have asked
-// for instead of only what it could not.
+// declaredNames lists the queryable fields, reserved included, so a rejected
+// query says what it could have asked for.
 func (s CollectionSchema) declaredNames() string {
 	names := make([]string, 0, len(s.Fields)+2)
 	for _, f := range s.Fields {
@@ -480,19 +367,10 @@ func (s CollectionSchema) declaredNames() string {
 	return strings.Join(names, ", ")
 }
 
-// Compile validates q against the collection's declaration and returns it as
-// SQL. Every rejection names the collection, the offending part, and what is
-// available — the reader is an agent that must fix the query from the error
-// alone.
-//
-// anchor is the document q.After names, which the caller reads before compiling
-// because this package holds no database handle. It is nil when q.After is
-// empty, and its absence when q.After is set is an error rather than an empty
-// page: a cursor pointing at a document that no longer exists is a caller
-// mistake worth hearing about, not a silent end of results.
-// Every rejection is an *InvalidQueryError, typed once here rather than at each
-// return below: the callers above turn the type into an error code, and one
-// choke point is what keeps that mapping from becoming string matching.
+// Compile validates q against the declaration and returns it as SQL; every
+// rejection is an *InvalidQueryError, typed once here. anchor is the document
+// q.After names, read by the caller (this package holds no DB handle); nil with
+// q.After set is an error, not an empty page.
 func (q Query) Compile(schema CollectionSchema, anchor *Document) (Compiled, error) {
 	compiled, err := q.compile(schema, anchor)
 	if err != nil {
@@ -516,9 +394,8 @@ func (q Query) compile(schema CollectionSchema, anchor *Document) (Compiled, err
 		return Compiled{}, err
 	}
 
-	// No namespace or collection predicate: the table is the collection. That
-	// isolation is structural — there is no statement here that could reach
-	// another namespace's documents even if it were built wrong.
+	// No namespace/collection predicate: the table IS the collection, so the
+	// isolation is structural.
 	var where []string
 	var args []any
 
@@ -553,11 +430,8 @@ func (q Query) compile(schema CollectionSchema, anchor *Document) (Compiled, err
 		if desc {
 			dir = "DESC"
 		}
-		// The id tiebreaker is what makes the order total. Without it two
-		// documents sharing a sort value have no defined relative position, and
-		// a paginating reader can see one twice and the other never. It runs in
-		// the sort's own direction so the visible order is one uniformly
-		// directed tuple, which is what the After cursor compares against.
+		// The id tiebreaker runs in the sort's own direction, so the visible order
+		// is one uniformly directed tuple — what After compares against.
 		order = expr + " " + dir + ", id " + dir
 	}
 
@@ -590,20 +464,14 @@ func (q Query) compile(schema CollectionSchema, anchor *Document) (Compiled, err
 	}, nil
 }
 
-// afterTuple compiles the After cursor: "strictly past the anchor in the
-// visible order". The visible order is (sort field, id) both running the same
-// direction, so past-the-anchor is the tuple comparison
+// afterTuple compiles the After cursor as "strictly past the anchor in the
+// visible order (sort field, id)":
 //
 //	sort <cmp> value OR (sort = value AND id <cmp> anchorID)
 //
-// A range filter cannot express that second branch, which is why After exists:
-// with ties on the sort field, `sort > value` loses every document that shares
-// the anchor's value and `sort >= value` hands the anchor back.
-//
-// A missing or JSON-null sort value is a real case — a declared field says what
-// may be queried, not what a document must contain — and NULL compares as
-// nothing at all, so it is branched on rather than bound. SQLite sorts NULL
-// first, so in ASC every non-NULL row is past a NULL anchor and in DESC none is.
+// A missing or JSON-null sort value is a real case; NULL compares as nothing,
+// so it is branched on rather than bound. SQLite sorts NULL first: in ASC every
+// non-NULL row is past a NULL anchor, in DESC none is.
 func (q Query) afterTuple(table, sortExpr string, desc bool, anchor *Document) (string, []any, error) {
 	if q.After == "" {
 		return "", nil, fmt.Errorf("docstore: %s/%s was compiled with a cursor document but no after id", q.Namespace, q.Collection)
@@ -639,15 +507,10 @@ func (q Query) afterTuple(table, sortExpr string, desc bool, anchor *Document) (
 		return "(" + sortExpr + " IS NOT NULL OR id > ?)", []any{q.After}, nil
 	}
 
-	// The anchor's sort value is read back out of the table rather than bound
-	// from Go. A declared field says what may be queried, not what a document
-	// must hold, so a "number" field may legitimately contain an array or an
-	// object — values that have no bindable Go equivalent, and that the column
-	// carries as JSON text. Reading the value through the same column the ORDER
-	// BY uses makes the cursor compare exactly what the ordering compares, for
-	// every JSON shape and under the column's own affinity, with no Go-side
-	// reconstruction to disagree with either. The subquery is uncorrelated, so
-	// it is evaluated once per statement.
+	// The anchor's sort value is read back through the same column the ORDER BY
+	// uses, not bound from Go: a "number" field may hold an array or object with
+	// no bindable Go equivalent, and the column's own affinity must govern the
+	// comparison. The subquery is uncorrelated, evaluated once per statement.
 	value := "(SELECT " + sortExpr + " FROM " + table + " WHERE id = ?)"
 	valueArgs := []any{q.After}
 
@@ -663,13 +526,10 @@ func (q Query) afterTuple(table, sortExpr string, desc bool, anchor *Document) (
 	return clause, args, nil
 }
 
-// anchorSortIsNull reports whether the cursor document has no value for the sort
-// field — the field is absent, or is JSON null — which is what json_extract
-// yields as SQL NULL and what the branches above handle separately. It is a
-// structural question about the body, so it needs no type mapping.
+// anchorSortIsNull reports whether the cursor's sort field is absent or JSON
+// null — what json_extract yields as SQL NULL.
 func (q Query) anchorSortIsNull(anchor *Document) (bool, error) {
-	if reservedField[q.Sort.Field] {
-		// Both are stamped columns and are never NULL.
+	if reservedField[q.Sort.Field] { // stamped columns, never NULL
 		return false, nil
 	}
 	var body map[string]json.RawMessage
@@ -687,11 +547,9 @@ func (q Query) anchorSortIsNull(anchor *Document) (bool, error) {
 	return value == nil, nil
 }
 
-// fieldExpr resolves a field reference to SQL. A reserved name is one of the
-// store's own stamped columns and is written literally; anything else must be
-// declared, and resolves to that field's generated column, quoted because its
-// name descends from caller text. use names what the reference was for, so the
-// error says whether the filter or the sort is wrong.
+// fieldExpr resolves a field reference to SQL: a reserved name literally,
+// anything else through its declared generated column. use names whether the
+// filter or the sort is wrong.
 func (q Query) fieldExpr(schema CollectionSchema, name, use string) (string, FieldSpec, error) {
 	if name == "" {
 		return "", FieldSpec{}, fmt.Errorf("docstore: %s/%s has a %s with no field name", q.Namespace, q.Collection, use)
@@ -707,10 +565,8 @@ func (q Query) fieldExpr(schema CollectionSchema, name, use string) (string, Fie
 	return quoteIdent(FieldColumn(name)), spec, nil
 }
 
-// bindValue converts a filter bound to what the statement should carry, and
-// refuses a bound whose type cannot compare with the field's. A number field
-// compared against "5" would silently match nothing — JSON numbers and text
-// never compare equal in SQLite — which is the worst outcome of the three.
+// bindValue refuses a bound that cannot compare with the field's type: a number
+// field against "5" would silently match nothing.
 func (q Query) bindValue(f Filter, spec FieldSpec) (any, error) {
 	mismatch := func(want string) error {
 		return fmt.Errorf("docstore: %s/%s filter on %q needs a %s value, got %T (%v)",
@@ -719,12 +575,8 @@ func (q Query) bindValue(f Filter, spec FieldSpec) (any, error) {
 	if f.Value == nil {
 		return nil, fmt.Errorf("docstore: %s/%s filter on %q has no value", q.Namespace, q.Collection, f.Field)
 	}
-	// A reserved field is a stored timestamp column, compared as text. The bound
-	// is re-encoded rather than passed through, because text comparison only
-	// means what the caller intends when both sides carry the same encoding: a
-	// bound of "…T10:00:00Z" compared raw against stored stamps sorts above every
-	// stamp in that second. A caller may write any RFC3339 form — including the
-	// one an older store handed them — and get the comparison they asked for.
+	// A reserved field is a timestamp compared as text; re-encode to TimeFormat
+	// because a raw "…T10:00:00Z" bound sorts above every stamp in that second.
 	if reservedField[f.Field] {
 		switch v := f.Value.(type) {
 		case string:
@@ -781,27 +633,15 @@ func (q Query) bindValue(f Filter, spec FieldSpec) (any, error) {
 	return nil, fmt.Errorf("docstore: %s/%s filter on %q has undeclared type %q", q.Namespace, q.Collection, f.Field, spec.Type)
 }
 
-// TimeFormat is the stored timestamp encoding. Stamps live in TEXT columns and
-// are ordered and filtered as text, so the encoding has to make text order and
-// time order the same thing — which takes a fraction of a fixed width, always
-// present and always nine digits.
-//
-// time.RFC3339Nano, which this used to be, does not: it strips trailing zeros,
-// so widths vary and "…:00.5Z" sorts below "…:00.1234Z" while "…:00Z" sorts
-// above both ('Z' is 0x5A, above '.' and every digit). Only stamps inside the
-// same second compared wrongly, which is exactly where bursty writes land, and
-// it made every "changed since" filter drop rows in silence. Migration 91
-// rewrote the stored stamps.
-//
-// Always formatted from a UTC time, so the zone is always "Z" and every stored
-// stamp is the same 30 characters wide.
+// TimeFormat is the stored timestamp encoding. Stamps are ordered as text, so
+// the fraction must be fixed-width (nine digits, always present) and the zone
+// always "Z": RFC3339Nano strips trailing zeros, which made same-second stamps
+// compare wrongly and "changed since" filters drop rows in silence. Migration
+// 91 rewrote the stored stamps.
 const TimeFormat = "2006-01-02T15:04:05.000000000Z07:00"
 
-// ParseTime decodes a stamp in any RFC3339 form — TimeFormat's own, the
-// trailing-zero-stripped form stored before migration 91, a whole second with no
-// fraction at all, or a non-UTC offset — and normalizes it to UTC. Callers hand
-// timestamps in as strings from JSON, and the one they most often hand in is one
-// this store gave them, so the accepted set has to be wider than the stored one.
+// ParseTime decodes a stamp in any RFC3339 form — including the pre-migration-91
+// trailing-zero-stripped form this store once handed out — normalized to UTC.
 func ParseTime(s string) (time.Time, error) {
 	t, err := time.Parse(time.RFC3339, s)
 	if err != nil {
@@ -810,11 +650,9 @@ func ParseTime(s string) (time.Time, error) {
 	return t.UTC(), nil
 }
 
-// Target is the subject a change to this collection is published under, and the
-// key a subscription is matched on. Collection-grained rather than
-// document-grained: a live query's result set can change because a document it
-// does not currently contain started matching, so a subscriber has to hear about
-// the collection, not about the documents it happens to hold right now.
+// Target is the subject collection changes publish under and subscriptions match
+// on. Collection-grained: a live query's result set can change because a document
+// it does not contain started matching.
 func Target(namespace, collection string) string {
 	return namespace + "/" + collection
 }
@@ -822,16 +660,14 @@ func Target(namespace, collection string) string {
 // Target is the subject changes to the query's collection arrive under.
 func (q Query) Target() string { return Target(q.Namespace, q.Collection) }
 
-// Address is one document's full name, and the subject a change to it is
-// published under. The log then reads as a history of documents; matching a
-// change to the subscriptions that care about it uses Target, carried alongside.
+// Address is the subject a change to one document is published under;
+// subscription matching uses Target, carried alongside.
 func Address(namespace, collection, id string) string {
 	return Target(namespace, collection) + "/" + id
 }
 
-// ValidateBody accepts a document body: any JSON object. Objects only, because
-// a declared field is read with a JSON path and a bare array or scalar has no
-// place for one to live.
+// ValidateBody accepts any JSON object; objects only, because a declared field
+// is read with a JSON path a bare array or scalar lacks.
 func ValidateBody(body []byte) error {
 	if len(body) == 0 {
 		return fmt.Errorf("docstore: document body is required")

--- a/internal/ghosttyvt/ghosttyvt.go
+++ b/internal/ghosttyvt/ghosttyvt.go
@@ -1,20 +1,11 @@
 //go:build (darwin && arm64) || (linux && amd64) || (linux && arm64)
 
-// Package ghosttyvt is the worker-side owner of an authoritative parsed
-// terminal, backed by libghostty-vt (Ghostty's VT core) via cgo.
-//
-// It is the ONLY package that may include vt.h or touch native handles. It
-// exists so a client attach can be served by serializing the parsed grid +
-// scrollback (the tmux/zellij model) instead of replaying the app's raw byte
-// stream. Live output keeps streaming as raw bytes; only the attach/restore
-// path uses this package.
-//
-// It links on darwin/arm64 (the app host) AND the two Linux tuples: the daemon
-// runs headless on Linux, so the worker's restore path must serialize there
-// too. Every other target compiles the pure-Go stub (stub.go). The static
-// library + headers under third_party/ghostty-vt/<goos>_<goarch>/ are produced
-// per platform by scripts/build-libghostty-vt.sh (source of truth; gitignored
-// output). See docs/plans/2026-07-22-server-authoritative-terminal.md.
+// Package ghosttyvt is the worker-side authoritative parsed terminal, backed
+// by libghostty-vt via cgo; attach/restore is served by serializing it. It is
+// the ONLY package that may include vt.h or touch native handles. Links on
+// darwin/arm64 and linux/amd64+arm64; every other target compiles the pure-Go
+// stub (stub.go). Archives: third_party/ghostty-vt/<goos>_<goarch>/ from
+// scripts/build-libghostty-vt.sh. See docs/plans/2026-07-22-server-authoritative-terminal.md.
 package ghosttyvt
 
 /*
@@ -218,18 +209,15 @@ import (
 	"unsafe"
 )
 
-// Placeholder cell pixel size, used until a client reports the real one.
-// We never render, but resize + XTWINOPS size reports need non-zero pixel
-// dimensions. The values are immaterial to grid reflow; they only scale
-// pixel-unit size reports, which is exactly why they must be replaced — an
-// image emitter sizes its output from them.
+// Placeholder cell pixel size until a client reports the real one; image
+// emitters size output from pixel reports, so it must be replaced.
 const (
 	defaultCellWidthPx  = 8
 	defaultCellHeightPx = 16
 )
 
-// DefaultMaxScrollback is the scrollback cap (lines). ~0.8MB RSS measured for a
-// 10k-line 200x50 scrollback (see plan Phase 0 notes).
+// DefaultMaxScrollback is the scrollback cap (lines). Measured: ~0.8MB RSS for
+// a 10k-line 200x50 scrollback.
 const DefaultMaxScrollback = 10000
 
 // Options configures a new Terminal.
@@ -237,44 +225,32 @@ type Options struct {
 	// MaxScrollback caps retained scrollback lines. Zero uses DefaultMaxScrollback.
 	MaxScrollback int
 
-	// KittyImageStorageLimit is the kitty graphics image storage cap in
-	// bytes, applied at construction. The zero value disables the kitty
-	// graphics protocol entirely — deliberate: the library's own default is
-	// 10MB, and a silently-live worker-side parser desyncs the grid from the
-	// client model, which never parses kitty.
+	// KittyImageStorageLimit caps kitty image storage in bytes. Zero disables
+	// the protocol entirely — deliberate: the library default is 10MB, and a
+	// silently-live parser desyncs the grid from the client model.
 	KittyImageStorageLimit uint64
 }
 
-// Snapshot is a self-contained serialization of terminal state suitable for
-// reconstructing a terminal on a client. Serialize carries full state;
-// SerializeViewport carries only the visible viewport.
+// Snapshot is a self-contained serialization for reconstructing a terminal on
+// a client.
 type Snapshot struct {
 	Cols, Rows int
-	// VTDump is one self-contained VT stream (FORMAT_VT, unwrap=false, all
-	// extras, full scrollback) that reproduces the terminal when replayed into
-	// a fresh same-size terminal. It carries no interrogative sequences.
+	// VTDump replays into a fresh same-size terminal; no interrogative sequences.
 	VTDump []byte
 }
 
-// respSink accumulates bytes the terminal wants written back to the pty (query
-// responses: CPR, DA1, kitty CSI ? u, DECRQM…). It is what the cgo.Handle
-// references — deliberately NOT the Terminal — so the handle does not keep the
-// Terminal reachable, and the Terminal's finalizer can still reclaim a leaked
-// one. Its own mutex guards buf; goWritePty appends (synchronously during Write)
-// and DrainResponses reads+clears, independent of the Terminal's mutex.
-//
-// handle references this sink; C retains &handle as its userdata (see New).
+// respSink accumulates query-response bytes (CPR, DA1, …) headed back to the
+// pty. The cgo.Handle references the sink, NOT the Terminal, so the Terminal's
+// finalizer still runs; its own mutex guards buf, independent of the Terminal's.
 type respSink struct {
 	mu     sync.Mutex
 	buf    []byte
 	handle cgo.Handle
 }
 
-// Terminal wraps a native libghostty-vt terminal. All methods are safe for
-// concurrent use; each serializes on the Terminal's mutex.
-//
-// The caller MUST call Close exactly once when done; a finalizer is a backstop,
-// not a substitute (native memory + a cgo.Handle leak otherwise).
+// Terminal wraps a native libghostty-vt terminal; all methods serialize on its
+// mutex. Caller MUST Close exactly once — the finalizer is a backstop, not a
+// substitute (native memory + a cgo.Handle leak otherwise).
 type Terminal struct {
 	mu     sync.Mutex
 	term   C.GhosttyTerminal
@@ -282,10 +258,7 @@ type Terminal struct {
 	pinner runtime.Pinner // pins &sink.handle for C to retain as userdata
 	cols   int
 	rows   int
-	// Cell size in device pixels. The durable half of pixel geometry: a total
-	// pane size is only meaningful with the grid it was measured at, so the
-	// terminal keeps the per-cell number and every resize re-derives the total
-	// from it.
+	// Cell size in device pixels; every resize re-derives the total pane size.
 	cellW int
 	cellH int
 
@@ -301,8 +274,7 @@ func New(cols, rows int, opts Options) (*Terminal, error) {
 	if maxSB <= 0 {
 		maxSB = DefaultMaxScrollback
 	}
-	// Process-global and idempotent; without it ghostty rejects every f=100
-	// (PNG) kitty transmission, which is most of what real emitters send.
+	// Process-global, idempotent; without it ghostty rejects every PNG (f=100).
 	installPNGDecoder()
 	t := &Terminal{
 		cols:  cols,
@@ -319,16 +291,13 @@ func New(cols, rows int, opts Options) (*Terminal, error) {
 	if rc := C.ghostty_terminal_new(nil, &t.term, copts); rc != C.GHOSTTY_SUCCESS {
 		return nil, fmt.Errorf("ghosttyvt: terminal_new failed: rc=%d", int(rc))
 	}
-	// Written even when zero: zero is what overrides the library's 10MB default.
+	// Written even when zero: zero overrides the library's 10MB default.
 	if rc := C.ghosttyvt_set_kitty_limit(t.term, C.uint64_t(opts.KittyImageStorageLimit)); rc != C.GHOSTTY_SUCCESS {
 		C.ghostty_terminal_free(t.term)
 		return nil, fmt.Errorf("ghosttyvt: set kitty image storage limit failed: rc=%d", int(rc))
 	}
-	// The handle references the sink (not t) so it does not pin the Terminal.
-	// C retains the userdata past this call, so give it the *address* of the
-	// sink's handle field and pin that address: a runtime.Pinner is the
-	// supported way for C to legally hold a Go pointer. Unpinned in Close, after
-	// ghostty_terminal_free.
+	// C retains the userdata: pin &sink.handle (the supported way for C to hold
+	// a Go pointer); unpinned in Close, after ghostty_terminal_free.
 	t.sink.handle = cgo.NewHandle(t.sink)
 	t.pinner.Pin(&t.sink.handle)
 	if rc := C.ghosttyvt_install(t.term, unsafe.Pointer(&t.sink.handle)); rc != C.GHOSTTY_SUCCESS {
@@ -341,18 +310,16 @@ func New(cols, rows int, opts Options) (*Terminal, error) {
 	return t, nil
 }
 
-// Write feeds raw PTY bytes through the terminal's parser. It never fails;
-// malformed input is safe by design. Query responses produced during the write
-// are appended to the response buffer (see DrainResponses).
+// Write feeds raw PTY bytes through the parser (malformed input is safe);
+// query responses accumulate for DrainResponses.
 func (t *Terminal) Write(p []byte) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.writeLocked(p)
 }
 
-// SetColorTheme replaces the embedder-owned color defaults. Ghostty preserves
-// program-issued OSC overrides, so a later theme change does not erase an
-// application's deliberate palette mutation.
+// SetColorTheme replaces the embedder-owned color defaults; ghostty preserves
+// program-issued OSC overrides.
 func (t *Terminal) SetColorTheme(theme ColorTheme) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -376,8 +343,7 @@ func (t *Terminal) SetColorTheme(theme ColorTheme) error {
 	return nil
 }
 
-// Resize changes the terminal dimensions; the primary screen reflows when
-// wraparound is enabled.
+// Resize changes dimensions; the primary screen reflows when wraparound is on.
 func (t *Terminal) Resize(cols, rows int) {
 	if cols <= 0 || rows <= 0 {
 		return
@@ -387,24 +353,16 @@ func (t *Terminal) Resize(cols, rows int) {
 	t.resizeLocked(cols, rows)
 }
 
-// The DECAWM toggle that selects ghostty's no-reflow resize. Same bytes the
-// client writes around its own resize.
+// DECAWM toggle selecting ghostty's no-reflow resize; same bytes as the client.
 var (
 	disableWraparound = []byte("\x1b[?7l")
 	enableWraparound  = []byte("\x1b[?7h")
 )
 
-// ResizeNoReflow changes the terminal dimensions on ghostty's no-reflow resize
-// path, selected by temporarily disabling DEC wraparound (mode 7) when it is
-// enabled. It mirrors the client's resizeGhosttyWithoutReflow
-// (app/src/utils/ghosttyResize.ts) so the worker's grid stays frame-equal with
-// the client's across a resize: the same bytes then occupy the same rows on
-// both, which is what every row-indexed mapping between them rides on. The
-// toggle bytes are internal to this model and never reach any wire.
-//
-// With wraparound already disabled ghostty does not reflow, so the plain resize
-// is the same path — and writing the mode back on would enable a mode the
-// program had off.
+// ResizeNoReflow resizes on ghostty's no-reflow path by temporarily disabling
+// DECAWM, mirroring the client's resizeGhosttyWithoutReflow
+// (app/src/utils/ghosttyResize.ts) so worker and client grids stay frame-equal
+// — every row-indexed mapping rides on that. Toggle bytes never reach a wire.
 func (t *Terminal) ResizeNoReflow(cols, rows int) {
 	if cols <= 0 || rows <= 0 {
 		return
@@ -418,8 +376,7 @@ func (t *Terminal) ResizeNoReflow(cols, rows int) {
 		t.resizeLocked(cols, rows)
 		return
 	}
-	// Held across all three steps: an interleaved write would be parsed with
-	// wraparound off and wrap where the program meant it to.
+	// Held across all three steps: an interleaved write would parse wraparound-off.
 	t.writeLocked(disableWraparound)
 	defer t.writeLocked(enableWraparound)
 	t.resizeLocked(cols, rows)
@@ -433,16 +390,9 @@ func (t *Terminal) writeLocked(p []byte) {
 	C.ghostty_terminal_vt_write(t.term, (*C.uint8_t)(unsafe.Pointer(&p[0])), C.size_t(len(p)))
 }
 
-// SetCellPixelSize sets the cell size in device pixels used for pixel-unit
-// size reports (XTWINOPS, kitty cell metrics), and pushes it to the native
-// terminal immediately at the current grid size. Non-positive dimensions are
-// ignored. Construction keeps the 8x16 placeholder until real geometry arrives.
-//
-// "Immediately" is load-bearing: a program that has enabled in-band size
-// reports (DEC mode 2048) is told the new pixel size by this call, and a
-// program that has not still reads it out of the terminal the next time
-// anything asks. Waiting for the next grid resize would leave a session sized
-// from the placeholder for as long as its window sits still.
+// SetCellPixelSize sets the cell size in device pixels and pushes it to the
+// native terminal immediately — waiting for the next grid resize would leave a
+// still window sized from the placeholder. Non-positive dimensions are ignored.
 func (t *Terminal) SetCellPixelSize(w, h int) {
 	if w <= 0 || h <= 0 {
 		return
@@ -456,8 +406,7 @@ func (t *Terminal) SetCellPixelSize(w, h int) {
 	t.resizeLocked(t.cols, t.rows)
 }
 
-// resizeLocked resizes the native terminal and records the new size. Caller
-// holds t.mu and has validated cols/rows.
+// resizeLocked resizes the native terminal; caller holds t.mu, cols/rows valid.
 func (t *Terminal) resizeLocked(cols, rows int) {
 	if t.closed {
 		return
@@ -466,9 +415,8 @@ func (t *Terminal) resizeLocked(cols, rows int) {
 	t.cols, t.rows = cols, rows
 }
 
-// DrainResponses returns and clears the bytes the terminal wants written back
-// to the pty (query responses accumulated since the last drain). It reads the
-// sink under the sink's own lock, independent of the Terminal mutex.
+// DrainResponses returns and clears accumulated query-response bytes (sink
+// lock only, independent of t.mu).
 func (t *Terminal) DrainResponses() []byte {
 	s := t.sink
 	s.mu.Lock()
@@ -488,8 +436,7 @@ func (t *Terminal) Size() (cols, rows int) {
 	return t.cols, t.rows
 }
 
-// PlainText renders the terminal (viewport + scrollback) as plain UTF-8 text,
-// no escape sequences. Primarily for tests and block round-trip assertions.
+// PlainText renders the terminal (viewport + scrollback) as plain UTF-8 text.
 func (t *Terminal) PlainText() string {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -499,8 +446,7 @@ func (t *Terminal) PlainText() string {
 	return string(t.format(C.GHOSTTY_FORMATTER_FORMAT_PLAIN))
 }
 
-// CursorPos returns the active-screen cursor position in 0-indexed viewport
-// coordinates.
+// CursorPos returns the active-screen cursor position (0-indexed viewport).
 func (t *Terminal) CursorPos() (x, y int) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -510,26 +456,22 @@ func (t *Terminal) CursorPos() (x, y int) {
 	return t.cursorXYLocked()
 }
 
-// CursorVisible reports whether the cursor is visible (DECTCEM, DEC private
-// mode 25).
+// CursorVisible reports whether the cursor is visible (DECTCEM, mode 25).
 func (t *Terminal) CursorVisible() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return !t.closed && bool(C.ghosttyvt_cursor_visible(t.term))
 }
 
-// LeftRightMarginMode reports whether DECLRMM (DEC private mode 69) is enabled.
-// False on a failed read: the caller then trusts its scroll measurement, which
-// is the behavior a terminal without margins earns.
+// LeftRightMarginMode reports DECLRMM (mode 69); false on a failed read.
 func (t *Terminal) LeftRightMarginMode() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return !t.closed && bool(C.ghosttyvt_left_right_margin_mode(t.term))
 }
 
-// ViewportText returns the visible screen as plain text: one line per viewport
-// row, trailing blanks trimmed per row, every row terminated with \n. Returns
-// "" only if formatting fails.
+// ViewportText returns the visible screen as plain text, one \n-terminated
+// trimmed line per row; "" only if formatting fails.
 func (t *Terminal) ViewportText() string {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -540,9 +482,7 @@ func (t *Terminal) ViewportText() string {
 }
 
 // SerializeViewport returns a self-contained styled VT stream of the visible
-// screen only (no scrollback). Replaying it into a fresh terminal of Snapshot.
-// Cols x Snapshot.Rows reproduces the viewport content, styles, cursor
-// position, and cursor visibility.
+// screen only (no scrollback), including cursor position and visibility.
 func (t *Terminal) SerializeViewport() Snapshot {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -555,8 +495,8 @@ func (t *Terminal) SerializeViewport() Snapshot {
 		return Snapshot{Cols: t.cols, Rows: t.rows}
 	}
 
-	// The formatter emits its cursor CUP before tabstop resets, so restore the
-	// true position after all formatter state (0-indexed native coords → 1-based CUP).
+	// The formatter emits its cursor CUP before tabstop resets, so append the
+	// true position last (0-indexed native coords → 1-based CUP).
 	cx, cy := t.cursorXYLocked()
 	dump = fmt.Appendf(dump, "\x1b[%d;%dH", cy+1, cx+1)
 	if C.ghosttyvt_cursor_visible(t.term) {
@@ -567,27 +507,24 @@ func (t *Terminal) SerializeViewport() Snapshot {
 	return Snapshot{Cols: t.cols, Rows: t.rows, VTDump: dump}
 }
 
-// Serialize produces a Snapshot: one self-contained VT stream that reproduces
-// the terminal state (grid + scrollback + modes + cursor) when replayed into a
-// fresh same-size terminal.
+// Serialize produces a Snapshot of the whole terminal.
 func (t *Terminal) Serialize() Snapshot {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.serializeLocked()
 }
 
-// serializeLocked assumes t.mu is held. Exposed for callers that must capture a
-// snapshot atomically with an external watermark (e.g. the read-loop seq).
+// serializeLocked assumes t.mu is held; for callers capturing a snapshot
+// atomically with an external watermark (e.g. the read-loop seq).
 func (t *Terminal) serializeLocked() Snapshot {
 	if t.closed {
 		return Snapshot{Cols: t.cols, Rows: t.rows}
 	}
 	dump := t.serializeVTLocked()
 
-	// Upstream ordering bug: the VT dump emits the cursor CUP before tabstop
-	// resets, and setting tabstops moves the cursor — so without a corrective
-	// CUP the restored cursor lands on the last tabstop column. Append the true
-	// cursor position last. (0-indexed native coords → 1-based CUP.)
+	// Upstream ordering bug: the dump emits the cursor CUP before tabstop
+	// resets, which move the cursor — append the true position last
+	// (0-indexed native coords → 1-based CUP).
 	cx, cy := t.cursorXYLocked()
 	dump = fmt.Appendf(dump, "\x1b[%d;%dH", cy+1, cx+1)
 
@@ -598,12 +535,9 @@ func (t *Terminal) serializeLocked() Snapshot {
 	}
 }
 
-// serializeVTLocked returns the alt-screen-aware VT serialization of the whole
-// terminal (primary + alternate screens, scrollback, modes, cursor) via the
-// carried ghostty_terminal_serialize_vt patch. When the alternate screen is
-// active it emits the primary screen (scrollback + frame), then ?1049h, then
-// the alt frame — so a restored terminal keeps its primary content behind an
-// alt-screen app. Caller holds t.mu and must not call after Close.
+// serializeVTLocked serializes the whole terminal via the carried
+// ghostty_terminal_serialize_vt patch; with the alt screen active it emits
+// primary, ?1049h, then the alt frame. Caller holds t.mu, not after Close.
 func (t *Terminal) serializeVTLocked() []byte {
 	var ptr *C.uint8_t
 	var n C.size_t
@@ -624,8 +558,7 @@ func (t *Terminal) cursorXYLocked() (x, y int) {
 }
 
 // AltScreenActive reports whether the alternate screen (DEC 1049/1047/47) is
-// currently active. Blocks are a primary-screen concept: the block table
-// records this at pin time and excludes alt-pinned blocks at serialize.
+// active. Blocks are a primary-screen concept: alt-pinned ones are excluded.
 func (t *Terminal) AltScreenActive() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -641,8 +574,6 @@ func (t *Terminal) format(emit C.GhosttyFormatterFormat) []byte {
 	var f C.GhosttyFormatter
 	opts := C.ghosttyvt_make_opts(emit)
 	if rc := C.ghostty_formatter_terminal_new(nil, &f, t.term, opts); rc != C.GHOSTTY_SUCCESS {
-		// Formatter construction should not fail for a live terminal; return
-		// empty rather than panicking a worker over a snapshot.
 		return nil
 	}
 	defer C.ghostty_formatter_free(f)
@@ -658,10 +589,8 @@ func (t *Terminal) format(emit C.GhosttyFormatterFormat) []byte {
 	return C.GoBytes(unsafe.Pointer(ptr), C.int(n))
 }
 
-// formatViewport runs the formatter against the active screen's visible
-// viewport only. ok is false only when formatting fails; a successful blank
-// viewport returns a non-nil empty slice. Caller holds t.mu and must not call
-// after Close.
+// formatViewport formats the visible viewport only; ok is false only on
+// failure (a blank viewport is a non-nil empty slice). Caller holds t.mu.
 func (t *Terminal) formatViewport(emit C.GhosttyFormatterFormat) ([]byte, bool) {
 	var ptr *C.uint8_t
 	var n C.size_t
@@ -675,8 +604,7 @@ func (t *Terminal) formatViewport(emit C.GhosttyFormatterFormat) ([]byte, bool) 
 	return C.GoBytes(unsafe.Pointer(ptr), C.int(n)), true
 }
 
-// viewportTextLocked normalizes the selection formatter's text into a stable
-// row shape for classifier consumers. Caller holds t.mu.
+// viewportTextLocked normalizes formatter text into a stable row shape. Caller holds t.mu.
 func (t *Terminal) viewportTextLocked() string {
 	raw, ok := t.formatViewport(C.GHOSTTY_FORMATTER_FORMAT_PLAIN)
 	if !ok {
@@ -708,15 +636,13 @@ func (t *Terminal) Close() {
 	t.closed = true
 	C.ghostty_terminal_free(t.term)
 	t.term = nil
-	// Unpin only after the native terminal is gone (it can no longer read the
-	// userdata), then release the handle.
+	// Unpin only after the native terminal can no longer read the userdata.
 	t.pinner.Unpin()
 	t.sink.handle.Delete()
 	runtime.SetFinalizer(t, nil)
 }
 
-// finalize is the SetFinalizer backstop. It must not depend on t.mu being
-// uncontended; Close handles the real work and is idempotent.
+// finalize is the SetFinalizer backstop; Close is idempotent.
 func (t *Terminal) finalize() {
 	t.Close()
 }

--- a/internal/hostsession/manager.go
+++ b/internal/hostsession/manager.go
@@ -1,16 +1,10 @@
-// Package hostsession owns the headless agent hosts the daemon runs beside its
-// PTY sessions.
+// Package hostsession owns the daemon's headless agent hosts: one child
+// process per attn session, envelopes out on fd 3, verbs in on stdin, its own
+// stdout/stderr to a log file.
 //
-// A host is one child process per attn session that speaks a conversation
-// rather than a terminal: envelopes out on fd 3, verbs in on stdin, its own
-// stdout and stderr to a log file. The daemon never parses a host's render
-// bodies; it stamps them with the session and forwards them.
-//
-// The lifecycle rule this package exists to enforce: a host is spawned as a
-// PROCESS-GROUP LEADER and the group is killed, not the process. Hard-killing
-// the host alone orphans the tool subprocesses it started — reproduced three
-// times against pi 0.83.0 on 2026-08-04 — so every teardown path here ends in a
-// group sweep, including the paths where the host exits on its own.
+// Invariant: a host is spawned as a process-group leader and every teardown
+// path ends in a group sweep — hard-killing the host alone orphans its tool
+// subprocesses (reproduced 3x against pi 0.83.0, 2026-08-04).
 package hostsession
 
 import (
@@ -26,8 +20,7 @@ import (
 	"time"
 )
 
-// Event is one envelope a host emitted, already split into the parts the
-// daemon acts on (session, seq, kind) and the part it only forwards (body).
+// Event is one host envelope: the daemon acts on session/seq/kind, forwards Body.
 type Event struct {
 	SessionID string
 	Seq       int
@@ -40,49 +33,30 @@ type ExitInfo struct {
 	SessionID string
 	ExitCode  int
 	Signal    string
-	// LifecycleID matches the run this host was spawned for, so a late exit
-	// from a superseded host cannot retire the session that replaced it.
+	// LifecycleID matches the spawning run, so a late exit from a superseded
+	// host cannot retire the session that replaced it.
 	LifecycleID string
 }
 
+// SpawnOptions configures Spawn.
 type SpawnOptions struct {
 	SessionID   string
 	LifecycleID string
 	Command     []string
 	Env         []string
 	CWD         string
-	// LogPath collects the host's own stdout and stderr. pi loads the user's
-	// extensions, and any of them may print; keeping that away from the
-	// envelope fd is why the envelopes have their own.
+	// LogPath collects the host's own stdout/stderr, kept off the envelope fd.
 	LogPath string
 }
 
-// terminationGrace is how long a host gets to tear down cooperatively after
-// SIGTERM before the group is killed outright.
-//
-// Receipt (2026-08-05, this machine, compiled host, pi 0.83.0): SIGTERM to
-// process exit measured 3 ms across four idle hosts, and 3 ms for a host
-// mid-run with a live `sleep 47` bash tool — whose subprocess was gone by the
-// time the host had exited, because pi's own dispose tears its tools down.
-// 3 s is a tripwire a thousand times past that: a host that reaches it is
-// wedged, not busy, and the log says so.
+// terminationGrace bounds cooperative teardown after SIGTERM before the group
+// is killed outright. Measured: 3 ms SIGTERM-to-exit (pi 0.83.0, idle and
+// mid-run, 2026-08-05); 3 s is a tripwire — reaching it means wedged, not busy.
 const terminationGrace = 3 * time.Second
 
-// envelopeDrainGrace bounds how long a dead host's exit waits for its envelope
-// stream to finish.
-//
-// The exit must not be announced before the last envelope is delivered: the
-// daemon turns it into `session_exited`, and a client that sees the session end
-// before the run that was closing it would draw a run stuck open on a dead
-// session. Draining costs only the time to consume what the pipe already holds
-// — a pipe buffer is 64 KB — so this is microseconds of work.
-//
-// It is bounded because EOF is not guaranteed. pi spawns tool subprocesses that
-// inherit the host's fds and lead their own process groups, so one that outlives
-// the host and escapes the group sweep would hold the write end open forever and
-// the exit would never be announced. 2 s is many orders of magnitude past the
-// real drain; reaching it means something still holds the fd, which the log
-// names before the read end is closed out from under it.
+// envelopeDrainGrace bounds waiting out a dead host's envelope stream: the exit
+// must not be announced before the last envelope, but a tool child that
+// inherited fd 3 can hold the pipe open forever; 2 s means something holds it.
 const envelopeDrainGrace = 2 * time.Second
 
 type host struct {
@@ -93,16 +67,15 @@ type host struct {
 	stdin       *os.File
 	envelopes   *os.File
 	logFile     *os.File
-	// reaped closes as soon as the process is gone; exited closes once the
-	// host is fully finished — drained, deregistered, and about to be
-	// announced. Kill escalates on the first and returns on the second, so a
-	// caller that gets a nil error can spawn the same session id again.
+	// reaped closes when the process is gone; exited once teardown is complete.
+	// Kill escalates on the first and returns on the second.
 	reaped   chan struct{}
 	exited   chan struct{}
 	drained  chan struct{}
 	killOnce sync.Once
 }
 
+// Manager spawns and tears down the daemon's host processes.
 type Manager struct {
 	logf    func(format string, args ...interface{})
 	onEvent func(Event)
@@ -112,6 +85,7 @@ type Manager struct {
 	hosts map[string]*host
 }
 
+// New builds a Manager; nil callbacks are replaced with no-ops.
 func New(logf func(format string, args ...interface{}), onEvent func(Event), onExit func(ExitInfo)) *Manager {
 	if logf == nil {
 		logf = func(string, ...interface{}) {}
@@ -125,8 +99,10 @@ func New(logf func(format string, args ...interface{}), onEvent func(Event), onE
 	return &Manager{logf: logf, onEvent: onEvent, onExit: onExit, hosts: make(map[string]*host)}
 }
 
+// ErrNotFound reports a session id with no live host.
 var ErrNotFound = errors.New("host session not found")
 
+// Spawn starts a host for the session as a process-group leader.
 func (m *Manager) Spawn(opts SpawnOptions) error {
 	if opts.SessionID == "" {
 		return errors.New("host spawn needs a session id")
@@ -167,8 +143,7 @@ func (m *Manager) Spawn(opts SpawnOptions) error {
 	cmd.Stderr = logFile
 	// ExtraFiles[0] is the child's fd 3 — the envelope stream.
 	cmd.ExtraFiles = []*os.File{envelopeW}
-	// The whole point: the child leads its own process group, so its tool
-	// subprocesses are reachable as one unit no matter how it dies.
+	// The child leads its own process group so teardown can sweep it as a unit.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if err := cmd.Start(); err != nil {
@@ -179,8 +154,7 @@ func (m *Manager) Spawn(opts SpawnOptions) error {
 		stdinW.Close()
 		return fmt.Errorf("start host %v: %w", opts.Command, err)
 	}
-	// The child owns its copies now; holding ours open would keep the envelope
-	// reader from ever seeing EOF.
+	// Close our copies or the envelope reader never sees EOF.
 	envelopeW.Close()
 	stdinR.Close()
 
@@ -220,18 +194,10 @@ func openLog(path string) (*os.File, error) {
 	return file, nil
 }
 
-// maxEnvelopeBytes bounds one line off the envelope fd.
-//
-// Receipt: the largest body this protocol version produces is a `message_end`
-// carrying one whole assistant message, so the bound is the model's per-response
-// output cap. The largest `maxTokens` in pi 0.83.0's model catalog is 2,000,000
-// (vercel-ai-gateway, xai/grok-4.20-multi-agent); at 4 bytes per token — the
-// worst case for UTF-8 — that is 8 MB of text. 64 MB is 8x past the largest
-// message any model in the catalog can emit, and the scanner starts at 64 KB
-// and grows only on demand, so the ceiling costs nothing until something
-// abnormal reaches for it. A line that exceeds it is a protocol violation, and
-// the host is torn down naming the limit rather than silently truncating the
-// conversation.
+// maxEnvelopeBytes bounds one line off the envelope fd. Receipt: the largest
+// body is one assistant message; pi 0.83.0's largest catalog maxTokens is
+// 2,000,000 ≈ 8 MB at 4 bytes/token, so 64 MB is 8x past it. Exceeding it is a
+// protocol violation — the host is torn down naming the limit, never truncated.
 const maxEnvelopeBytes = 64 << 20
 
 func (m *Manager) readEnvelopes(h *host, r *os.File) {
@@ -261,8 +227,7 @@ func (m *Manager) readEnvelopes(h *host, r *os.File) {
 		if envelope.Body == nil {
 			envelope.Body = map[string]interface{}{}
 		}
-		// The host stamps its own session id; the daemon trusts the process it
-		// spawned, not the field, so a mismatch is a bug worth naming.
+		// The daemon trusts the process it spawned, not the stamped session id.
 		if envelope.SessionID != "" && envelope.SessionID != h.sessionID {
 			m.logf("host session %s: envelope claims session %s; using the spawned one", h.sessionID, envelope.SessionID)
 		}
@@ -278,16 +243,9 @@ func (m *Manager) readEnvelopes(h *host, r *os.File) {
 	}
 }
 
-// monitor waits for the host to die and then sweeps its process group, on
-// EVERY exit path — cooperative shutdown, crash, kill. This is the sweep that
-// catches the receipted bug: pi orphans its running tool subprocesses when the
-// host goes away without cleaning up.
-//
-// Sweeping after the reap is safe where it matters. A process group's id is
-// held until its LAST member leaves, and a pid cannot be reallocated while a
-// group carries it — so whenever there is actually an orphan to kill, this
-// pgid is still unambiguously ours. When the group is already empty the signal
-// is a harmless ESRCH.
+// monitor reaps the host and sweeps its process group on EVERY exit path — the
+// sweep that catches pi orphaning its tool subprocesses. Post-reap is safe: a
+// pgid is held until its last member leaves; an empty group is a harmless ESRCH.
 func (m *Manager) monitor(h *host) {
 	waitErr := h.cmd.Wait()
 	if err := syscall.Kill(-h.pgid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
@@ -297,8 +255,7 @@ func (m *Manager) monitor(h *host) {
 	h.stdin.Close()
 	h.logFile.Close()
 
-	// Everything the host said before it died reaches the daemon before the
-	// death does. See envelopeDrainGrace for why this is bounded.
+	// Drain before announcing the exit; see envelopeDrainGrace for the bound.
 	select {
 	case <-h.drained:
 	case <-time.After(envelopeDrainGrace):
@@ -356,6 +313,7 @@ func (m *Manager) send(sessionID string, verb map[string]interface{}) error {
 	return nil
 }
 
+// Has reports whether a live host exists for the session.
 func (m *Manager) Has(sessionID string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -363,6 +321,7 @@ func (m *Manager) Has(sessionID string) bool {
 	return ok
 }
 
+// SessionIDs lists the sessions with live hosts.
 func (m *Manager) SessionIDs() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -373,17 +332,11 @@ func (m *Manager) SessionIDs() []string {
 	return ids
 }
 
-// Kill tears a host down and returns once its process group is gone and the
-// host is deregistered — a caller that gets a nil error can spawn the same
-// session id again.
-//
-// The cooperative SIGTERM is the load-bearing half, not a courtesy: pi spawns
-// each tool subprocess into its OWN process group (measured 2026-08-05: a bash
-// `sleep 60` runs as the host's child but leads its own group), so the group
-// kill below cannot reach them. What reaches them is pi's dispose, which the
-// host runs on SIGTERM. The group kill is the backstop for the host itself and
-// whatever stayed in its group; a host wedged past the grace window can still
-// strand a detached tool child, and that is the residual this design accepts.
+// Kill tears a host down; nil error means the group is gone and the session id
+// can be respawned. The SIGTERM is load-bearing: pi's tool subprocesses lead
+// their OWN process groups (measured 2026-08-05), so only pi's dispose on
+// SIGTERM reaches them — the group kill is the backstop, and a host wedged past
+// the grace can still strand a detached tool child (accepted residual).
 func (m *Manager) Kill(sessionID string) error {
 	m.mu.Lock()
 	h, ok := m.hosts[sessionID]
@@ -398,9 +351,8 @@ func (m *Manager) Kill(sessionID string) error {
 		}
 	})
 
-	// The grace window is about the process, so it watches reaped; the return is
-	// about the teardown, so it waits out exited. Escalating on exited instead
-	// would count the envelope drain against the host's time to shut down.
+	// Escalate on reaped, return on exited — escalating on exited would count
+	// the envelope drain against the host's grace.
 	select {
 	case <-h.reaped:
 		<-h.exited
@@ -416,8 +368,7 @@ func (m *Manager) Kill(sessionID string) error {
 	return nil
 }
 
-// Shutdown tears down every live host. Used when the daemon itself is going
-// away, so no host outlives the daemon that owns it.
+// Shutdown tears down every live host so none outlives the daemon.
 func (m *Manager) Shutdown() {
 	for _, id := range m.SessionIDs() {
 		if err := m.Kill(id); err != nil && !errors.Is(err, ErrNotFound) {

--- a/internal/jobs/cron.go
+++ b/internal/jobs/cron.go
@@ -6,30 +6,12 @@ import (
 	"time"
 )
 
-// Recurring work runs on the queue as an ordinary job that re-arms itself.
-//
-// The alternative — a ticker goroutine per periodic duty that enqueues onto the
-// queue — is what this replaces. A ticker's next fire lives only in memory, so a
-// restart silently resets it, nothing shows the schedule, and every new duty
-// brings its own goroutine and its own shutdown wiring. A cron entry is a
-// durable record: it survives a restart with its next fire intact, it appears in
-// the background-work panel like everything else, and it is one registration.
-
-// CronKey is the coalescing key every cron entry uses. A kind has exactly one
-// recurring record, so the key only has to be stable, and a fixed one keeps the
-// entry addressable (GetByKey) without the caller knowing how arming works.
+// CronKey is the coalescing key every cron entry uses: one recurring record per kind.
 const CronKey = "cron"
 
-// RegisterCron wires a handler for a kind the queue fires every interval,
-// forever. The first fire is one interval after Start.
-//
-// A cron entry NEVER dies. An ordinary job that keeps failing is eventually
-// abandoned, because nobody wants a broken job retried until the end of time;
-// but a heartbeat that stops is a silent outage — no tick, no log, no panel
-// entry moving — so a failing fire is logged, recorded on the record, and
-// re-armed for the next interval instead of counting toward the attempt cap.
-// Handlers for recurring work should therefore treat their own errors as
-// reportable, not fatal.
+// RegisterCron wires a handler the queue fires every interval, first fire one
+// interval after Start. A cron entry NEVER dies: a failing fire is logged and
+// re-armed instead of counting toward the attempt cap.
 func (r *Runner) RegisterCron(kind string, interval time.Duration, fn HandlerFunc, cfg HandlerConfig) error {
 	if interval <= 0 {
 		return fmt.Errorf("jobs: cron interval for %s must be positive, got %s", kind, interval)
@@ -45,30 +27,17 @@ func (r *Runner) RegisterCron(kind string, interval time.Duration, fn HandlerFun
 	return nil
 }
 
-// cronInterval returns the recurrence for a kind, or 0 when the kind is not a
-// cron entry.
+// cronInterval returns the recurrence for a kind, or 0 when it is not a cron entry.
 func (r *Runner) cronInterval(kind string) time.Duration {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.handlers[kind].interval
 }
 
-// armCron gives every registered cron kind a recurring record that will fire. It
-// runs once, from Start.
-//
-// An existing record that is still on schedule — queued, failed, or running — is
-// left exactly as it is. Arming it again would push its ScheduledAt an interval
-// into the future on every boot, so a daemon restarted more often than the
-// interval would never tick at all: the failure mode a durable schedule exists to
-// rule out.
-//
-// An existing record in a TERMINAL state is revived. A cron entry is never
-// supposed to reach one, but it can: run a build that does not register the kind
-// (a rename, a rollback, a registration that errored and was only logged) and
-// dispatch kills its due entry as an unknown kind. Nothing in the queue selects a
-// dead row, and List hides cron entries, so without this the heartbeat is gone
-// for good the next time the kind comes back — silently, which is the one outcome
-// a heartbeat must never have.
+// armCron gives every registered cron kind a recurring record, once, from Start.
+// An on-schedule record is left alone: re-arming every boot would starve a daemon
+// restarted more often than the interval. A terminal record is revived — a build
+// that missed the registration killed it as unknown-kind, and nothing else selects it.
 func (r *Runner) armCron() {
 	r.mu.Lock()
 	kinds := make(map[string]time.Duration, len(r.handlers))
@@ -91,18 +60,15 @@ func (r *Runner) armCron() {
 		if existing != nil {
 			r.log("jobs: cron entry for %s was %s (%s); reviving it", kind, existing.State, existing.LastError)
 		}
-		// Enqueue coalesces onto the existing record when there is one, so a revive
-		// resets that same row to queued rather than minting a second entry.
+		// Enqueue coalesces, so a revive resets that row rather than minting a second.
 		if _, err := r.Enqueue(kind, EnqueueOptions{UniqueKey: CronKey, Delay: interval}); err != nil {
 			r.log("jobs: arm cron entry for %s: %v", kind, err)
 		}
 	}
 }
 
-// rearmCronLocked returns a finished cron job to queued, scheduled one interval
-// out. The caller holds ioMu and has already confirmed the kind recurs. runErr
-// is the fire's outcome: it is recorded so the panel and the log show a failing
-// heartbeat, but it never stops the recurrence (see RegisterCron).
+// rearmCronLocked returns a finished cron job to queued one interval out.
+// Caller holds ioMu. runErr is recorded but never stops the recurrence.
 func (r *Runner) rearmCronLocked(j *Job, interval time.Duration, runErr error) {
 	now := r.now()
 	j.State = StateQueued
@@ -122,17 +88,13 @@ func (r *Runner) rearmCronLocked(j *Job, interval time.Duration, runErr error) {
 	}
 }
 
-// ErrNotCron is returned when a cron-only operation names a kind that does not
-// recur.
+// ErrNotCron is returned when a cron-only operation names a kind that does not recur.
 var ErrNotCron = errors.New("jobs: kind is not a cron entry")
 
-// ErrCronKind is returned by Enqueue when a caller tries to enqueue ordinary work
-// onto a recurring kind. See the guard in Enqueue.
+// ErrCronKind is returned by Enqueue for ordinary work aimed at a recurring kind.
 var ErrCronKind = errors.New("jobs: kind is a cron entry and cannot be enqueued directly")
 
-// CronEntry returns the recurring record for kind — what the next fire is
-// scheduled for, and how the last one went. It is the read behind an operator
-// asking "is this heartbeat still beating?".
+// CronEntry returns the recurring record for kind: next fire and last outcome.
 func (r *Runner) CronEntry(kind string) (*Job, error) {
 	if r.disabled {
 		return nil, ErrDisabled

--- a/internal/jobs/job.go
+++ b/internal/jobs/job.go
@@ -1,25 +1,10 @@
-// Package jobs is the durable job queue.
+// Package jobs is the durable job queue: short, retryable units of work
+// persisted through a pluggable Store so a daemon crash never loses a job.
+// MUST NOT import internal/daemon (the daemon imports this package).
 //
-// It runs short, retryable units of work, persisting each job through a
-// pluggable Store (the daemon injects a SQLite-backed one) so a daemon crash
-// never loses a pending or in-flight job. It is deliberately daemon-agnostic:
-// it accepts a Store and a LogFunc at construction and MUST NOT import
-// internal/daemon (the daemon imports this package, so the reverse would be an
-// import cycle).
-//
-// A single dispatch goroutine selects eligible jobs and launches each as its own
-// goroutine, bounded by a per-kind concurrency cap (default 1): a kind is
-// serialized with itself while different kinds run in parallel. Every record
-// read-modify-write funnels through one store-level lock, so persistence stays
-// serialized even though handlers run concurrently.
-//
-// It replaces internal/tasks, carrying over the mechanics that package earned —
-// the commit fence, cancel-blocks-until-exit, capped exponential backoff with a
-// dead terminal state, per-kind concurrency caps, and the requeue-during-run
-// flag — on a generalized record. What is new: a job carries a payload and
-// returns a result, and coalescing is opt-in through UniqueKey rather than a law
-// of the record's identity. That is what lets two jobs of the same kind run at
-// once, which durable workflow activities require.
+// One dispatch goroutine launches each eligible job in its own goroutine under
+// a per-kind concurrency cap (default 1); every record read-modify-write
+// funnels through one store-level lock.
 package jobs
 
 import (
@@ -28,9 +13,8 @@ import (
 	"time"
 )
 
-// LogFunc matches the daemon's injected logger shape (see internal/pty,
-// internal/classifier). Runtime logging goes through it — never log.Printf, whose
-// stderr is discarded when the daemon runs in the background.
+// LogFunc is the daemon's injected logger shape. Never log.Printf: its stderr
+// is discarded when the daemon runs in the background.
 type LogFunc func(format string, args ...interface{})
 
 // State is a job's position in the lifecycle.
@@ -41,9 +25,6 @@ type LogFunc func(format string, args ...interface{})
 //	failed  -> queued                 (auto-requeue once now >= ScheduledAt and Attempts < max)
 //	failed  -> dead                   (no auto-requeue once Attempts >= max)
 //	failed|dead -> queued             (manual Retry, ScheduledAt = now)
-//
-// State is serialized as a plain string (not a Go enum) so the stored record
-// stays self-describing and forward-compatible.
 type State string
 
 const (
@@ -60,70 +41,35 @@ func (s State) Terminal() bool { return s == StateDone || s == StateDead }
 
 // Job is one durable unit of work.
 type Job struct {
-	// ID is opaque and generated at enqueue. Nothing parses it: coalescing
-	// identity lives in UniqueKey, so callers that want to address a job by what
-	// it is about use the kind+key surface rather than reconstructing an id.
-	ID string `json:"id"`
-	// Kind selects the handler (registered via Runner.Register).
+	ID   string `json:"id"`
 	Kind string `json:"kind"`
-	// UniqueKey is the optional coalescing identity within a kind. When set, a
-	// second Enqueue for the same kind+key targets the SAME record — the debounce
-	// collapses a burst of triggers into one run, and a trigger arriving mid-run
-	// re-runs the job rather than starting a second one. When empty the job is
-	// distinct: every Enqueue creates a new record, which is what lets two runs of
-	// the same kind carry different arguments and be in flight together.
+	// UniqueKey is the coalescing identity within a kind: a second Enqueue for
+	// the same kind+key targets the SAME record. Empty means a distinct job.
 	UniqueKey string `json:"unique_key,omitempty"`
-	// Priority orders selection among jobs that are all eligible; higher runs
-	// first. Ties fall through to ScheduledAt, then CreatedAt, so the
-	// longest-waiting job of a priority claims a freed slot first.
-	Priority int `json:"priority,omitempty"`
-	// Payload carries the run's inputs. It is opaque to the queue — only the
-	// handler that was enqueued with it interprets it — and it is the reason a job
-	// survives the disappearance of whatever it describes: a run that fires after
-	// its session and workspace rows are gone still holds everything it needs.
-	Payload json.RawMessage `json:"payload,omitempty"`
-	// Result is what the handler returned on success, persisted so a caller that
-	// was not waiting can still read the outcome. Nil for a job that has not
-	// succeeded.
-	Result json.RawMessage `json:"result,omitempty"`
-	// State is the lifecycle position; see State.
-	State State `json:"state"`
-	// Attempts counts how many times a handler has run for this record. It is
-	// incremented when a run starts, so a record in failed/dead reflects the
-	// number of handler invocations already spent.
-	Attempts int `json:"attempts"`
-	// MaxAttempts overrides the runner's attempt cap for this job. Zero means
-	// "use the runner default".
-	MaxAttempts int `json:"max_attempts,omitempty"`
-	// ScheduledAt is both the earliest time dispatch may run this job and the
-	// coalesce debounce anchor (UTC). A queued job is eligible once now has
-	// reached it; a failed job auto-requeues once now has reached it.
+	// Priority orders eligible jobs; higher first, ties by ScheduledAt then CreatedAt.
+	Priority    int             `json:"priority,omitempty"`
+	Payload     json.RawMessage `json:"payload,omitempty"`
+	Result      json.RawMessage `json:"result,omitempty"`
+	State       State           `json:"state"`
+	Attempts    int             `json:"attempts"`
+	MaxAttempts int             `json:"max_attempts,omitempty"`
+	// ScheduledAt (UTC) is the earliest dispatch time and the coalesce debounce anchor.
 	ScheduledAt time.Time `json:"scheduled_at"`
-	// LastError is the most recent handler failure message (display + diagnosis).
-	LastError string `json:"last_error,omitempty"`
-	// CreatedAt is when the record was first persisted (UTC).
-	CreatedAt time.Time `json:"created_at"`
-	// UpdatedAt is when the record was last persisted (UTC).
-	UpdatedAt time.Time `json:"updated_at"`
-	// Requeued records that a coalescing Enqueue arrived WHILE this job was
-	// running. The in-flight run cannot be overwritten without tearing its
-	// bookkeeping, so the re-enqueue sets this flag and pushes ScheduledAt; when
-	// the run finishes the runner honors the flag by returning to queued (re-run)
-	// instead of done, so a coalesced trigger that landed mid-run is never lost.
+	LastError   string    `json:"last_error,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	// Requeued records a coalescing Enqueue that arrived WHILE this job ran;
+	// finish() then returns it to queued so a mid-run trigger is never lost.
 	Requeued bool `json:"requeued,omitempty"`
 
-	// CommitGuard is the commit-fence latch for THIS run, injected by the runner
-	// before it invokes the handler. It is never persisted. The handler calls
-	// CommitGuard.Enter immediately before its single durable write and Leave
-	// after, so a concurrent Cancel either fences the run cleanly before commit or
-	// waits for the write to finish untorn. It is nil on records returned by
-	// List/Get/Enqueue (those are not live runs).
+	// CommitGuard is the commit fence for THIS run, injected by the runner and
+	// never persisted (nil on records from List/Get/Enqueue). The handler wraps
+	// its single durable write in Enter/Leave so a concurrent Cancel either
+	// fences before commit or waits for an untorn write.
 	CommitGuard *CommitGuard `json:"-"`
 }
 
-// DecodePayload unmarshals the job's payload into v. A job with no payload
-// leaves v untouched, so a handler whose payload type is all-optional does not
-// have to special-case the empty case.
+// DecodePayload unmarshals the job's payload into v; no payload leaves v untouched.
 func (j *Job) DecodePayload(v any) error {
 	if j == nil || len(j.Payload) == 0 {
 		return nil
@@ -134,10 +80,7 @@ func (j *Job) DecodePayload(v any) error {
 	return nil
 }
 
-// clone returns a deep copy so callers (dispatch, Cancel, status reads) can hand
-// out records without sharing the runner's mutable pointer. Payload and Result
-// are byte slices, so a shallow copy would alias them; copy them so a caller
-// mutating a clone never reaches the stored record.
+// clone deep-copies; Payload/Result are slices, so a shallow copy aliases the store.
 func (j *Job) clone() *Job {
 	if j == nil {
 		return nil

--- a/internal/jobs/runner.go
+++ b/internal/jobs/runner.go
@@ -12,141 +12,89 @@ import (
 	"github.com/google/uuid"
 )
 
-// Tuning defaults. Each is overridable per-runner through the matching Options
-// field (a zero value falls back to the default, resolved in New).
+// Tuning defaults, each overridable through the matching Options field.
 const (
-	// DefaultMaxAttempts is the attempt cap: a job that has failed this many
-	// times goes dead instead of auto-requeuing. A job may override it.
 	DefaultMaxAttempts = 5
-	// DefaultBackoffBase / DefaultBackoffCap bound the capped-exponential backoff
-	// schedule (1m, 2m, 4m, … capped at 1h).
-	DefaultBackoffBase = time.Minute
-	DefaultBackoffCap  = time.Hour
-	// DefaultHandlerTimeout is the per-handler context.WithTimeout the runner
-	// wraps around every invocation. A kind can override it via RegisterWith.
+	// Backoff schedule: 1m, 2m, 4m, … capped at 1h.
+	DefaultBackoffBase    = time.Minute
+	DefaultBackoffCap     = time.Hour
 	DefaultHandlerTimeout = 5 * time.Minute
-	// DefaultRetention is how long a successfully completed job is kept before
-	// trimming, mirroring bus.DefaultRetention. Only done jobs are trimmed:
-	// a dead job is the actionable record a failure notification points at, it
-	// only exists when nobody has acted on it, and it is not what grows.
-	DefaultRetention = 30 * 24 * time.Hour
-	// DefaultTrimInterval is how often retention runs.
+	// DefaultRetention mirrors bus.DefaultRetention. Only done jobs are trimmed:
+	// a dead job is the actionable record a failure notification points at.
+	DefaultRetention    = 30 * 24 * time.Hour
 	DefaultTrimInterval = time.Hour
-	// defaultPollInterval is how often the dispatch loop wakes to re-scan for a
-	// job whose ScheduledAt has arrived. The loop is level-triggered, so this only
-	// bounds scheduling latency for time-gated requeues.
+	// defaultPollInterval bounds latency for time-gated requeues; the loop is
+	// level-triggered otherwise.
 	defaultPollInterval = time.Second
 )
 
-// eligiblePageSize bounds one dispatch pass's read of claimable jobs, so a
-// pathological queue cannot pull an unbounded result set into memory every
-// second. Receipt: the real task tables this queue replaces held 146 rows
-// (~/.attn) and 206 rows (~/.attn-dev), all but a handful of them terminal and
-// therefore never eligible; the eligible working set is single digits. A
-// thousand is three orders of magnitude past that, so only something broken
-// reaches it — and dispatch says so out loud when it does rather than quietly
-// serving a truncated page.
+// eligiblePageSize bounds one dispatch pass's read of claimable jobs. Measured:
+// the task tables this queue replaced held 146 rows (~/.attn) and 206 rows
+// (~/.attn-dev), nearly all terminal; the eligible working set is single digits.
+// A tripwire three orders of magnitude past that; dispatch logs loudly when hit.
 const eligiblePageSize = 1000
 
-// ErrDisabled is returned by mutating runner methods when the runner was
-// constructed without a store. A disabled runner never starts a dispatch loop
-// and persists nothing; it exists so a consumer can hold a non-nil Runner before
-// the real one is built.
+// ErrDisabled is returned by mutating methods on a runner constructed without a
+// store; such a runner runs no loops and persists nothing.
 var ErrDisabled = errors.New("jobs: runner is disabled (no store)")
 
-// ErrUnknownKind is returned by Enqueue when no handler is registered for the
-// job's kind.
+// ErrUnknownKind is returned by Enqueue when no handler is registered for the kind.
 var ErrUnknownKind = errors.New("jobs: no handler registered for kind")
 
-// HandlerFunc runs one job to completion. It returns the job's result (nil when
-// the work produces no value) or an error, in which case the job goes failed and
-// may auto-requeue. The runner owns the context.WithTimeout wrapper around the
-// invocation; the handler body owns the work and calls job.CommitGuard.Enter and
-// Leave around its single durable write.
-//
-// A returned result must be JSON-marshallable. If it is not, the run is recorded
-// as FAILED with the marshal error: a result nobody can read is not a success,
-// and dropping it quietly would be exactly the silent truncation this queue
-// exists to avoid.
+// HandlerFunc runs one job to completion. The handler calls
+// job.CommitGuard.Enter/Leave around its single durable write. A result that is
+// not JSON-marshallable records the run as FAILED with the marshal error.
 type HandlerFunc func(ctx context.Context, job *Job) (any, error)
 
-// handler pairs a registered HandlerFunc with its per-kind timeout and
-// concurrency cap.
 type handler struct {
 	fn      HandlerFunc
 	timeout time.Duration
-	// limit is the max number of jobs OF THIS KIND that may run at once. It is
-	// always >= 1 after registration, so a kind is serialized with itself by
-	// default while different kinds run in parallel.
-	limit int
-	// interval is the recurrence for a cron kind (see cron.go) and zero for
-	// every other kind, which is what tells finish() to re-arm rather than
-	// retire the record.
+	limit   int // per-kind concurrency cap, always >= 1 after registration
+	// interval is the recurrence for a cron kind (cron.go), zero otherwise;
+	// non-zero tells finish() to re-arm rather than retire the record.
 	interval time.Duration
 }
 
-// HandlerConfig tunes a registered handler. The zero value is the default:
+// HandlerConfig tunes a registered handler; the zero value means
 // DefaultHandlerTimeout and a per-kind concurrency cap of 1.
 type HandlerConfig struct {
-	// Timeout is the per-invocation context.WithTimeout the runner wraps around
-	// every call to this handler. Zero ⇒ DefaultHandlerTimeout.
 	Timeout time.Duration
-	// MaxConcurrent bounds how many jobs of this kind may run simultaneously.
-	// Zero ⇒ 1 (a kind serialized with itself); different kinds always run in
-	// parallel regardless.
+	// MaxConcurrent caps concurrent jobs of this kind; different kinds always
+	// run in parallel regardless.
 	MaxConcurrent int
 }
 
 // EnqueueOptions tunes a single Enqueue call.
 type EnqueueOptions struct {
-	// UniqueKey opts this job into coalescing within its kind (see Job.UniqueKey).
-	// Leaving it empty enqueues a distinct job every time.
 	UniqueKey string
-	// Payload is the run's inputs, marshalled to JSON. Nil enqueues no payload.
-	Payload any
-	// Delay pushes ScheduledAt forward from now. For a coalescing job this is the
-	// debounce knob: re-enqueueing within the window keeps pushing the run later,
-	// collapsing a burst of triggers into one run. Zero means "run as soon as
-	// eligible".
+	Payload   any
+	// Delay pushes ScheduledAt forward from now; on a coalescing job it is the
+	// debounce knob, each re-enqueue pushing the run later.
 	Delay time.Duration
-	// RunNow forces ScheduledAt = now regardless of Delay, overriding a debounce
-	// already pending on a coalescing record. This is how a caller says "the
-	// window is over, run it".
-	RunNow bool
-	// Priority orders this job against other eligible jobs; higher runs first.
-	Priority int
-	// MaxAttempts overrides the runner's attempt cap for this job. Zero ⇒ the
-	// runner default.
+	// RunNow forces ScheduledAt = now, overriding a pending debounce.
+	RunNow      bool
+	Priority    int
 	MaxAttempts int
 }
 
-// Options configures a Runner at construction.
+// Options configures a Runner at construction; zero fields take the defaults.
 type Options struct {
 	// Store injects the persistence backend. A nil Store disables the runner.
 	Store Store
-	// Log receives runtime log lines. A nil Log is replaced with a no-op.
-	Log LogFunc
-	// Now injects the clock for deterministic backoff/coalescing tests. nil ⇒
-	// time.Now. The runner always normalizes to UTC.
-	Now func() time.Time
-	// PollInterval overrides the dispatch loop's re-scan interval (tests use a
-	// short interval to avoid real-time waits). Zero ⇒ defaultPollInterval.
+	Log   LogFunc
+	// Now injects the clock for tests; always normalized to UTC.
+	Now          func() time.Time
 	PollInterval time.Duration
-	// MaxAttempts overrides the default attempt cap. Zero ⇒ DefaultMaxAttempts.
-	MaxAttempts int
-	// BackoffBase / BackoffCap override the backoff schedule. Zero ⇒ the defaults.
-	BackoffBase time.Duration
-	BackoffCap  time.Duration
-	// Retention / TrimInterval override the done-job retention window and how
-	// often it runs. Zero ⇒ the defaults.
+	MaxAttempts  int
+	BackoffBase  time.Duration
+	BackoffCap   time.Duration
 	Retention    time.Duration
 	TrimInterval time.Duration
 }
 
-// Runner is the durable job queue. A single dispatch loop selects eligible jobs
-// and launches each as its own goroutine, bounded by a per-kind concurrency cap
-// (default 1). Every record read-modify-write funnels through ioMu, so
-// persistence stays serialized even though handlers run concurrently.
+// Runner is the durable job queue: one dispatch loop launching eligible jobs
+// under per-kind concurrency caps, with every record read-modify-write
+// serialized through ioMu.
 type Runner struct {
 	store    Store
 	log      LogFunc
@@ -160,50 +108,33 @@ type Runner struct {
 	retention    time.Duration
 	trimInterval time.Duration
 
-	// onChange, if set, fires after every lifecycle transition. It may be called
-	// CONCURRENTLY — from the dispatch goroutine, from each in-flight run's
-	// finish(), and from Enqueue/Retry/Remove on arbitrary caller goroutines — so
-	// it must be cheap, non-blocking, and safe to invoke from multiple goroutines.
+	// onChange fires after every lifecycle transition, possibly concurrently;
+	// it must be cheap and non-blocking.
 	onChange func(jobID string)
 
-	// onTerminalFailure, if set, fires exactly once when a job crosses into the
-	// terminal StateDead (retries exhausted) — the actionable "this background
-	// work gave up" signal. Like onChange it may be invoked from several
-	// goroutines. It always runs AFTER ioMu is released with a cloned record, so
-	// the callback may touch the store without lock-ordering risk.
+	// onTerminalFailure fires once when a job reaches StateDead, always AFTER
+	// ioMu is released and with a cloned record, so it may touch the store.
 	onTerminalFailure func(*Job)
 
 	mu       sync.Mutex
 	handlers map[string]handler
 	started  bool
 
-	// ioMu serializes every read-modify-write cycle on a job record. The dispatch
-	// loop, in-flight runs' finish(), and arbitrary callers' Enqueue/Retry all
-	// mutate the same records; without this a concurrent Enqueue and a
-	// claim/finish write would lost-update each other. When both locks are needed
-	// ioMu is ALWAYS the outer lock: it is acquired without holding mu, so there
-	// is no lock-ordering hazard.
+	// ioMu serializes every read-modify-write on a job record; without it a
+	// concurrent Enqueue and a claim/finish write would lost-update each other.
+	// When both locks are needed ioMu is ALWAYS the outer lock.
 	ioMu sync.Mutex
 
-	// runs holds every in-flight run keyed by job id. Cancel(id) fences and waits
-	// on its entry; Stop drains them all. Guarded by mu.
-	runs map[string]*activeRun
+	runs     map[string]*activeRun // in-flight runs by job id; guarded by mu
+	inflight map[string]int        // running count per kind, enforcing its cap; guarded by mu
 
-	// inflight counts currently-running jobs per kind. dispatch reads it to
-	// enforce each kind's concurrency cap; it is bumped when a run is claimed and
-	// dropped when the run goroutine exits. Guarded by mu.
-	inflight map[string]int
-
-	// wake nudges the dispatch loop to re-scan immediately after an Enqueue or
-	// Retry rather than waiting for the next poll tick. Buffered depth 1 so a
-	// nudge never blocks the caller.
+	// wake nudges the dispatch loop to re-scan; buffered depth 1 so a nudge
+	// never blocks the caller.
 	wake chan struct{}
 	done chan struct{} // closed by Stop to tell the loops to exit
 	exit chan struct{} // closed by the dispatch loop when it has fully exited
 
-	// lockToken is the single-instance ownership marker acquired by Start and
-	// released by Stop. Empty when not started.
-	lockToken string
+	lockToken string // single-instance ownership; empty when not started
 }
 
 // activeRun tracks one in-flight job so Cancel can fence its commit and block
@@ -217,8 +148,7 @@ type activeRun struct {
 }
 
 // New constructs a Runner. With a nil Store the runner is disabled: mutating
-// methods are safe no-ops returning ErrDisabled, Start/Stop do nothing, and
-// nothing is persisted.
+// methods are no-ops returning ErrDisabled and nothing is persisted.
 func New(opts Options) *Runner {
 	log := opts.Log
 	if log == nil {
@@ -250,32 +180,28 @@ func New(opts Options) *Runner {
 // Disabled reports whether the runner is a no-op (no store).
 func (r *Runner) Disabled() bool { return r.disabled }
 
-// OnChange registers a callback fired after every lifecycle transition. It is
-// optional and must be cheap; pass nil to clear.
+// OnChange registers a callback fired after every lifecycle transition; nil clears.
 func (r *Runner) OnChange(fn func(jobID string)) {
 	r.mu.Lock()
 	r.onChange = fn
 	r.mu.Unlock()
 }
 
-// OnTerminalFailure registers a callback fired once when a job reaches StateDead
-// (retries exhausted). It is optional and must be cheap and concurrency-safe;
-// pass nil to clear.
+// OnTerminalFailure registers a callback fired once when a job reaches
+// StateDead; it must be concurrency-safe, and nil clears it.
 func (r *Runner) OnTerminalFailure(fn func(*Job)) {
 	r.mu.Lock()
 	r.onTerminalFailure = fn
 	r.mu.Unlock()
 }
 
-// Register wires a handler for a kind with the default timeout and a
-// concurrency cap of 1.
+// Register wires a handler with the default timeout and a concurrency cap of 1.
 func (r *Runner) Register(kind string, fn HandlerFunc) error {
 	return r.RegisterWith(kind, fn, HandlerConfig{})
 }
 
-// RegisterWith wires a handler for a kind with an explicit timeout and per-kind
-// concurrency cap (see HandlerConfig). It is an error to register the same kind
-// twice or to pass a nil fn.
+// RegisterWith wires a handler with an explicit HandlerConfig; registering a
+// kind twice or passing a nil fn is an error.
 func (r *Runner) RegisterWith(kind string, fn HandlerFunc, cfg HandlerConfig) error {
 	if r.disabled {
 		return ErrDisabled
@@ -303,9 +229,8 @@ func (r *Runner) RegisterWith(kind string, fn HandlerFunc, cfg HandlerConfig) er
 	return nil
 }
 
-// Start recovers orphaned running jobs (reset to queued) and launches the
-// dispatch and retention loops. It is safe (no-op) on a disabled runner. Calling
-// Start twice is an error.
+// Start recovers orphaned running jobs and launches the dispatch and retention
+// loops; a no-op when disabled, an error when called twice.
 func (r *Runner) Start() error {
 	if r.disabled {
 		return nil
@@ -319,10 +244,8 @@ func (r *Runner) Start() error {
 		r.mu.Unlock()
 		return fmt.Errorf("jobs: init store: %w", err)
 	}
-	// Take exclusive ownership before doing anything else: a second live Runner on
-	// the same store would double-execute every job (its own dispatch loop, its
-	// own in-memory CommitGuard). Failing fast beats silently double-applying
-	// durable writes.
+	// Exclusive ownership first: a second live Runner on the same store would
+	// double-execute every job.
 	token, err := r.store.AcquireLock()
 	if err != nil {
 		r.mu.Unlock()
@@ -335,8 +258,6 @@ func (r *Runner) Start() error {
 	done := r.done
 	r.mu.Unlock()
 
-	// recoverOrphans is a read-modify-write over the store, so it holds ioMu like
-	// every other RMW path. It runs before the loops launch, so contention is nil.
 	r.ioMu.Lock()
 	n, err := r.store.RecoverOrphans(r.now())
 	r.ioMu.Unlock()
@@ -346,9 +267,6 @@ func (r *Runner) Start() error {
 		r.log("jobs: recovered %d orphan running job(s)", n)
 	}
 
-	// Arm the recurring entries before the loop starts so a cron kind registered
-	// on a fresh store has its first fire scheduled, not waiting on a trigger
-	// that will never come.
 	r.armCron()
 
 	go r.loop()
@@ -356,43 +274,32 @@ func (r *Runner) Start() error {
 	return nil
 }
 
-// Stop signals the loops to exit, then cancels and drains every in-flight run.
-// cancelAll honors each commit fence, so an already-committing run still
-// finishes its durable write untorn. Safe to call on a disabled or never-started
-// runner.
+// Stop signals the loops to exit, then cancels and drains every in-flight run,
+// honoring each commit fence so a committing run still writes untorn.
 func (r *Runner) Stop() {
 	r.mu.Lock()
 	if !r.started {
 		r.mu.Unlock()
 		return
 	}
-	// Flip started to false WHILE holding mu so a second concurrent Stop sees
-	// started==false and returns instead of double-closing done (which panics and
-	// would take the whole daemon down). Only the Stop that wins this transition
-	// closes done and waits on exit.
+	// Flip under mu so a concurrent second Stop returns instead of double-closing done.
 	r.started = false
 	done, exit := r.done, r.exit
 	token := r.lockToken
 	r.lockToken = ""
 	r.mu.Unlock()
 
-	// Order matters: runs are detached goroutines the dispatch loop does not join.
-	// First stop the loop launching MORE runs, THEN cancel and join everything
-	// still in flight, so cancelAll is guaranteed to terminate.
+	// Order matters: stop the loop launching MORE runs first, then cancel and
+	// join what is in flight, so cancelAll terminates.
 	close(done)
 	<-exit
 	r.cancelAll()
-
-	// Release ownership only after every run has exited, so no other Runner can
-	// claim the store while ours is still draining.
 	r.store.ReleaseLock(token)
 }
 
-// Enqueue persists a job for kind. With opts.UniqueKey set it coalesces onto the
-// existing record for that kind+key: a queued/failed/dead/done record is reset to
-// queued with a fresh schedule, and a record that is currently RUNNING is left to
-// finish with its Requeued flag set so the coalesced trigger re-runs it rather
-// than being lost. Without a unique key it always creates a new record.
+// Enqueue persists a job for kind. With opts.UniqueKey set it coalesces onto
+// the existing kind+key record (a RUNNING one gets Requeued instead of being
+// overwritten); without a key it always creates a new record.
 func (r *Runner) Enqueue(kind string, opts EnqueueOptions) (*Job, error) {
 	if r.disabled {
 		return nil, ErrDisabled
@@ -407,11 +314,8 @@ func (r *Runner) Enqueue(kind string, opts EnqueueOptions) (*Job, error) {
 	if !known {
 		return nil, fmt.Errorf("%w: %s", ErrUnknownKind, kind)
 	}
-	// A cron kind has exactly one record, addressed by CronKey, and finish() sends
-	// every record of that kind back around the recurrence. An enqueue carrying any
-	// other key would therefore mint a SECOND self-perpetuating entry — one that
-	// List hides and CronEntry never finds. Refuse instead: recurring work is
-	// scheduled by registering it, not by enqueueing it.
+	// Any other key on a cron kind mints a second self-perpetuating entry that
+	// List hides and CronEntry never finds.
 	if entry.interval > 0 && opts.UniqueKey != CronKey {
 		return nil, fmt.Errorf("%w: %s (use RegisterCron; a cron kind has one entry)", ErrCronKind, kind)
 	}
@@ -441,8 +345,6 @@ func (r *Runner) Enqueue(kind string, opts EnqueueOptions) (*Job, error) {
 	var job *Job
 	switch {
 	case existing == nil:
-		// Priority, MaxAttempts, and Payload are applied below, in the one place
-		// that also handles a coalescing re-enqueue carrying fresh values.
 		job = &Job{
 			ID:          uuid.NewString(),
 			Kind:        kind,
@@ -453,19 +355,14 @@ func (r *Runner) Enqueue(kind string, opts EnqueueOptions) (*Job, error) {
 			UpdatedAt:   now,
 		}
 	case existing.State == StateRunning:
-		// The job is running right now. Overwriting it would tear the in-flight
-		// run's bookkeeping, so instead record the demand: mark Requeued and push
-		// ScheduledAt to the requested time. When the run finishes, finish() sees
-		// Requeued and returns the job to queued instead of done, so this coalesced
-		// trigger is honored rather than lost.
+		// Overwriting an in-flight run tears its bookkeeping; Requeued makes
+		// finish() re-queue instead of retiring.
 		existing.Requeued = true
 		existing.ScheduledAt = scheduled
 		existing.UpdatedAt = now
 		job = existing
 	default:
-		// queued / failed / dead / done: coalesce by resetting the same record back
-		// to queued with a fresh schedule. Attempts reset because a new enqueue is
-		// new logical demand, not a continuation of the old failure run.
+		// Attempts reset because a new enqueue is new logical demand.
 		existing.State = StateQueued
 		existing.Attempts = 0
 		existing.LastError = ""
@@ -476,11 +373,8 @@ func (r *Runner) Enqueue(kind string, opts EnqueueOptions) (*Job, error) {
 		job = existing
 	}
 
-	// Apply the carried inputs after the branch settled on `job`, so they land the
-	// same way on a brand-new record, a mid-run requeue (so the re-run reads the
-	// fresh inputs), and a coalescing re-enqueue. A nil Payload LEAVES an existing
-	// payload intact: a bare re-trigger that carries no inputs must not wipe the
-	// ones a prior enqueue stashed.
+	// A nil Payload LEAVES an existing payload intact: a bare re-trigger must
+	// not wipe the inputs a prior enqueue stashed.
 	if payload != nil {
 		job.Payload = payload
 	}
@@ -499,9 +393,8 @@ func (r *Runner) Enqueue(kind string, opts EnqueueOptions) (*Job, error) {
 	return job.clone(), nil
 }
 
-// Retry forces a failed or dead job back to queued with ScheduledAt = now. It is
-// the manual-recovery action. A job that is queued/running/done is left as-is.
-// Returns the updated job, or nil if no such job exists.
+// Retry forces a failed or dead job back to queued with ScheduledAt = now; any
+// other state is left as-is.
 func (r *Runner) Retry(id string) (*Job, error) {
 	if r.disabled {
 		return nil, ErrDisabled
@@ -534,11 +427,9 @@ func (r *Runner) Retry(id string) (*Job, error) {
 	return existing.clone(), nil
 }
 
-// Cancel signals the running handler for id (if it is the one running) and DOES
-// NOT RETURN until that job's goroutine has fully exited. If the run is already
-// inside its commit fence, Cancel does not cancel the context — it waits for the
-// goroutine to finish its durable write and exit, so the write is never torn.
-// Cancel of a job that is not currently running returns immediately.
+// Cancel signals the running handler for id and DOES NOT RETURN until its
+// goroutine has fully exited. A run already inside its commit fence is not
+// canceled — Cancel waits for the durable write to finish untorn.
 func (r *Runner) Cancel(id string) {
 	if r.disabled {
 		return
@@ -552,12 +443,8 @@ func (r *Runner) Cancel(id string) {
 	r.fenceAndWait(run)
 }
 
-// fenceAndWait performs the shared cancel-and-block core. The CALLER must hold
-// r.mu and pass a non-nil run; fenceAndWait RELEASES r.mu before it blocks on the
-// done channel. It cancels the run's context only if the run has not yet entered
-// its commit fence — if the run is already committing it leaves the context alone
-// and just waits, so the blocks-until-exit contract finishes an in-progress
-// durable write untorn.
+// fenceAndWait cancels (unless already committing) and blocks until the run
+// exits. CALLER must hold r.mu; fenceAndWait RELEASES it before blocking.
 func (r *Runner) fenceAndWait(run *activeRun) {
 	if run.guard.tryFence() {
 		run.cancel()
@@ -567,15 +454,9 @@ func (r *Runner) fenceAndWait(run *activeRun) {
 	<-done
 }
 
-// Remove forgets a job entirely: it cancels the run if that job is currently
-// executing (blocking until the goroutine exits, honoring the commit fence) and
-// then deletes the record. It is the "the subject is gone" operation — a
-// workspace was removed, so its coalesced job should leave nothing behind.
-//
-// There is a narrow, data-safe window: between Cancel returning and the delete,
-// dispatch may claim a still-queued record and begin running it; the delete then
-// removes the row mid-run and finish() reloads, finds the record gone, and
-// discards its result.
+// Remove cancels the run if executing (blocking, honoring the commit fence) and
+// deletes the record. Between Cancel and the delete dispatch may re-claim it;
+// finish() then reloads, finds it gone, and discards the result.
 func (r *Runner) Remove(id string) {
 	if r.disabled {
 		return
@@ -591,9 +472,8 @@ func (r *Runner) Remove(id string) {
 	r.notifyChange(id)
 }
 
-// RemoveByKey is Remove addressed by what the job is about rather than by its
-// generated id. It is the surface a caller uses when a subject disappears, since
-// nothing outside the queue knows a coalescing job's id.
+// RemoveByKey is Remove addressed by kind+key, since nothing outside the queue
+// knows a coalescing job's id.
 func (r *Runner) RemoveByKey(kind, uniqueKey string) {
 	if r.disabled || uniqueKey == "" {
 		return
@@ -611,13 +491,9 @@ func (r *Runner) RemoveByKey(kind, uniqueKey string) {
 	r.Remove(existing.ID)
 }
 
-// List returns the work queue — every job something enqueued because it needed
-// doing — newest-updated first. Safe (returns nil) on a disabled runner.
-//
-// Cron entries are excluded. They are the queue's own scheduler rather than work
-// anyone is owed: each is permanently queued for its next fire, so listing them
-// alongside real jobs would put two rows that never resolve at the top of every
-// "what is the daemon working on" answer. Read one with CronEntry.
+// List returns the work queue newest-updated first. Cron entries are excluded —
+// each is permanently queued for its next fire and would sit unresolvable at the
+// top forever; read one with CronEntry.
 func (r *Runner) List() ([]*Job, error) {
 	if r.disabled {
 		return nil, nil
@@ -639,7 +515,7 @@ func (r *Runner) List() ([]*Job, error) {
 	return out, nil
 }
 
-// Get returns a single job by id, or nil if absent. Safe on a disabled runner.
+// Get returns a single job by id, or nil if absent.
 func (r *Runner) Get(id string) (*Job, error) {
 	if r.disabled {
 		return nil, nil
@@ -647,8 +523,7 @@ func (r *Runner) Get(id string) (*Job, error) {
 	return r.store.Load(id)
 }
 
-// GetByKey returns a coalescing job by kind+key, or nil if absent. Safe on a
-// disabled runner.
+// GetByKey returns a coalescing job by kind+key, or nil if absent.
 func (r *Runner) GetByKey(kind, uniqueKey string) (*Job, error) {
 	if r.disabled || uniqueKey == "" {
 		return nil, nil
@@ -658,18 +533,13 @@ func (r *Runner) GetByKey(kind, uniqueKey string) (*Job, error) {
 
 // --- dispatch loop ---------------------------------------------------------
 
-// loop is the single dispatch goroutine. It is level-triggered: each pass claims
-// and launches every currently-eligible job whose kind has a free concurrency
-// slot, draining until a pass can place nothing more, then waits for the next
-// nudge or poll tick. Handlers run concurrently; the loop never blocks on one.
+// loop is the single dispatch goroutine, level-triggered: each pass drains every
+// eligible job with a free slot, then waits for a nudge or poll tick.
 func (r *Runner) loop() {
 	defer close(r.exit)
 	ticker := time.NewTicker(r.pollInterval)
 	defer ticker.Stop()
 	for {
-		// Drain: keep dispatching until a pass launches nothing (queue empty or
-		// every eligible kind saturated), so a burst of enqueues does not stall
-		// behind the poll interval.
 		for {
 			select {
 			case <-r.done:
@@ -694,16 +564,10 @@ func (r *Runner) loop() {
 	}
 }
 
-// dispatch claims every currently-eligible job whose kind is under its per-kind
-// concurrency cap and launches each in its own goroutine. It reports whether it
-// made progress (launched a run, or failed an unknown-kind job in place) so the
-// loop keeps draining until a pass can place nothing more.
-//
-// The store read and every per-job claim write run under ioMu, so a concurrent
-// Enqueue/Retry cannot make a chosen record stale between selection and claim.
-// The per-kind in-flight accounting and the active-run registry live under mu,
-// which is only ever taken WHILE holding ioMu — preserving the ioMu-outer lock
-// order. Handlers are launched only AFTER both locks are released.
+// dispatch claims every eligible job under its per-kind cap and launches each in
+// its own goroutine, reporting whether it made progress. Selection and claim
+// writes hold ioMu (mu taken only inside it, ioMu-outer order); handlers launch
+// only AFTER both locks are released.
 func (r *Runner) dispatch() (progressed bool, err error) {
 	r.ioMu.Lock()
 
@@ -714,9 +578,6 @@ func (r *Runner) dispatch() (progressed bool, err error) {
 		return false, err
 	}
 	if len(eligible) >= eligiblePageSize {
-		// A full page means the queue is deeper than any healthy case. Say so: the
-		// page IS truncated, and a caller staring at a job that never runs needs to
-		// know the reason is backlog, not a lost enqueue.
 		r.log("jobs: eligible page full at limit %d; the queue is backlogged and this pass sees only the first %d",
 			eligiblePageSize, eligiblePageSize)
 	}
@@ -735,15 +596,12 @@ func (r *Runner) dispatch() (progressed bool, err error) {
 		if !r.runnable(j) {
 			continue
 		}
-		// Decide + reserve under mu: the handler registry and in-flight counts both
-		// live there. Reserving the slot before persisting the claim keeps a later
-		// candidate of the same kind in this very pass from over-committing the cap.
+		// Reserve the slot under mu before persisting the claim, so a later
+		// same-kind candidate in this pass cannot over-commit the cap.
 		r.mu.Lock()
 		exec, ok := r.handlers[j.Kind]
 		if !ok {
 			r.mu.Unlock()
-			// No handler for this kind (e.g. a stale record from an old build). Kill
-			// it outright rather than sending it around the retry schedule.
 			r.recordPermanentFailureLocked(j, fmt.Errorf("%w: %s", ErrUnknownKind, j.Kind))
 			deadJobs = append(deadJobs, j)
 			failedUnknownIDs = append(failedUnknownIDs, j.ID)
@@ -765,15 +623,14 @@ func (r *Runner) dispatch() (progressed bool, err error) {
 		r.runs[j.ID] = run
 		r.mu.Unlock()
 
-		// Persist the claim (state running) under ioMu — NOT under mu, which must
-		// never wrap store I/O.
+		// Persist the claim under ioMu — never wrap store I/O in mu.
 		j.State = StateRunning
 		j.Attempts++
 		j.Requeued = false
 		j.UpdatedAt = now
 		if err := r.store.Save(j); err != nil {
 			r.log("jobs: persist running state for %s: %v", j.ID, err)
-			// Roll the reservation back so the per-kind slot is not leaked forever.
+			// Roll the reservation back so the per-kind slot is not leaked.
 			r.mu.Lock()
 			delete(r.runs, j.ID)
 			r.inflight[j.Kind]--
@@ -801,10 +658,8 @@ func (r *Runner) dispatch() (progressed bool, err error) {
 	return len(failedUnknownIDs) > 0 || len(launch) > 0, nil
 }
 
-// runnable re-checks the attempt cap on a job the store offered as eligible. The
-// store cannot apply it: the cap may be the runner's default rather than the
-// job's own. A failed job at or past its cap should already be dead, so this is
-// the guard for a record whose MaxAttempts shrank under it.
+// runnable re-checks the attempt cap the store cannot apply (it may be the
+// runner default), guarding a record whose MaxAttempts shrank under it.
 func (r *Runner) runnable(j *Job) bool {
 	if j.State != StateFailed {
 		return true
@@ -820,30 +675,21 @@ func (r *Runner) attemptCap(j *Job) int {
 	return r.maxAttempts
 }
 
-// execute runs one already-claimed job (state == running in the store) through
-// its handler inside a runner-owned timeout, then records the outcome (done /
-// requeued / failed-with-backoff / dead) under ioMu. The ctx, cancel, guard, and
-// activeRun are all built by dispatch at claim time and the run is already
-// registered in r.runs, so a Cancel arriving before this goroutine is scheduled
-// still finds and fences it. The CommitGuard fences the handler's durable write
-// against a concurrent Cancel AND against the runner-owned timeout: once the
-// handler has entered its commit, neither cancels the context, so the single
-// durable write is never torn.
+// execute runs one already-claimed job through its handler inside a runner-owned
+// timeout, then records the outcome under ioMu. The run is registered in r.runs
+// before this goroutine is scheduled, so an early Cancel still fences it; the
+// CommitGuard fences the durable write against Cancel AND the timeout.
 func (r *Runner) execute(j *Job, exec handler, ctx context.Context, run *activeRun) {
 	guard := run.guard
 	cancel := run.cancel
 
-	// timeoutStop stops the deadline timer once the run has exited so it cannot
-	// fire (and consult the guard) after teardown.
+	// timeoutStop stops the deadline timer so it cannot fire after teardown.
 	timeoutStop := make(chan struct{})
 	timer := time.NewTimer(exec.timeout)
 	go func() {
 		defer timer.Stop()
 		select {
 		case <-timer.C:
-			// The deadline elapsed. Honor the commit fence: if the handler is already
-			// committing, do NOT cancel — let the durable write finish untorn (this
-			// goroutine still waits for the handler to return).
 			if guard.tryFence() {
 				cancel()
 			}
@@ -851,7 +697,6 @@ func (r *Runner) execute(j *Job, exec handler, ctx context.Context, run *activeR
 		}
 	}()
 
-	// Attach the guard so the handler body can fence its durable write.
 	jobForHandler := j.clone()
 	jobForHandler.CommitGuard = guard
 
@@ -876,29 +721,22 @@ func (r *Runner) execute(j *Job, exec handler, ctx context.Context, run *activeR
 	close(timeoutStop)
 	cancel()
 
-	// Record the terminal outcome BEFORE signaling exit, so Cancel's
-	// blocks-until-exit contract holds: when Cancel's <-run.done unblocks, the
-	// goroutine has fully exited AND the durable terminal record is already
-	// written.
+	// Record the terminal outcome BEFORE signaling exit: when Cancel's
+	// <-run.done unblocks, the durable terminal record is already written.
 	r.finish(j.ID, encoded, runErr)
 
-	// Deregister the run and free its per-kind slot, THEN signal exit. From here a
-	// Cancel that was already blocked on run.done unblocks; a Cancel arriving
-	// after this finds no entry for the id and returns immediately.
 	r.mu.Lock()
 	delete(r.runs, run.id)
 	r.inflight[run.kind]--
 	r.mu.Unlock()
 	close(run.done)
 
-	// A freed slot may admit a queued job of a now-uncapped kind; re-dispatch.
+	// A freed slot may admit a queued job of a now-uncapped kind.
 	r.nudge()
 }
 
 // finish records the terminal outcome of a run. It re-loads the record under
-// ioMu (a mid-run Enqueue may have flipped Requeued / pushed ScheduledAt) so it
-// honors any coalesced trigger that landed during the run rather than clobbering
-// it. The stored record is authoritative for everything except the run result.
+// ioMu so a coalesced trigger that landed mid-run is honored, not clobbered.
 func (r *Runner) finish(id string, result json.RawMessage, runErr error) {
 	r.ioMu.Lock()
 
@@ -908,15 +746,12 @@ func (r *Runner) finish(id string, result json.RawMessage, runErr error) {
 		r.log("jobs: reload %s before finish: %v", id, err)
 		return
 	}
-	if cur == nil {
-		// The record was deleted out from under the run; nothing to persist.
+	if cur == nil { // deleted out from under the run
 		r.ioMu.Unlock()
 		return
 	}
 
-	// A cron kind's record is a recurring entry, not a unit of work that
-	// completes: it goes back to queued for its next fire whatever happened here,
-	// including a failure (see RegisterCron).
+	// A cron record goes back to queued whatever happened here (see RegisterCron).
 	if interval := r.cronInterval(cur.Kind); interval > 0 {
 		cur.Result = result
 		r.rearmCronLocked(cur, interval, runErr)
@@ -928,11 +763,8 @@ func (r *Runner) finish(id string, result json.RawMessage, runErr error) {
 	wentDead := false
 	if runErr != nil {
 		if cur.Requeued {
-			// A re-enqueue arrived mid-run. Even though this run failed, honoring the
-			// explicit demand takes precedence over backoff: re-queue at the
-			// ScheduledAt that Enqueue set (now, for RunNow) instead of demoting a
-			// run-now demand to a backoff delay. Attempts reset because the re-enqueue
-			// is fresh logical demand, not a continuation of the failed run.
+			// A mid-run re-enqueue outranks backoff even on failure: keep its
+			// ScheduledAt, reset Attempts (fresh demand).
 			now := r.now()
 			cur.State = StateQueued
 			cur.Requeued = false
@@ -954,9 +786,7 @@ func (r *Runner) finish(id string, result json.RawMessage, runErr error) {
 		cur.Result = result
 		cur.UpdatedAt = now
 		if cur.Requeued {
-			// A re-enqueue arrived mid-run: honor it by re-queuing instead of marking
-			// done, so the coalesced trigger is not lost. ScheduledAt was set by that
-			// Enqueue; preserve it. Attempts reset (fresh logical work).
+			// Mid-run re-enqueue: re-queue instead of done, at its ScheduledAt.
 			cur.State = StateQueued
 			cur.Requeued = false
 			cur.Attempts = 0
@@ -981,9 +811,8 @@ func (r *Runner) finish(id string, result json.RawMessage, runErr error) {
 	}
 }
 
-// recordFailureLocked persists a failed outcome with capped-exponential backoff,
-// or dead once the attempt cap is reached. The caller holds ioMu. It reports
-// whether this transition crossed into StateDead so the caller can fire the
+// recordFailureLocked persists failed-with-backoff, or dead at the attempt cap.
+// Caller holds ioMu. Reports a StateDead crossing so the caller can fire the
 // terminal-failure hook AFTER releasing ioMu (never under it).
 func (r *Runner) recordFailureLocked(j *Job, cause error) (wentDead bool) {
 	now := r.now()
@@ -1007,15 +836,9 @@ func (r *Runner) recordFailureLocked(j *Job, cause error) (wentDead bool) {
 	return wentDead
 }
 
-// recordPermanentFailureLocked marks a job dead immediately, without spending an
-// attempt or scheduling a retry. The caller holds ioMu.
-//
-// Some failures cannot be retried into success: a job whose kind this binary has
-// no handler for fails identically on every pass. Sending those around the
-// backoff schedule is worse than useless — a job that is never claimed never
-// increments Attempts, so it never reaches the attempt cap, and it re-fails and
-// re-logs the same error on every backoff for as long as the daemon lives. Dying
-// once, loudly, with the kind named is the actionable outcome.
+// recordPermanentFailureLocked marks a job dead without spending an attempt or
+// scheduling a retry; caller holds ioMu. An unclaimable job never increments
+// Attempts, so backoff would re-fail it forever.
 func (r *Runner) recordPermanentFailureLocked(j *Job, cause error) {
 	now := r.now()
 	j.State = StateDead
@@ -1028,9 +851,8 @@ func (r *Runner) recordPermanentFailureLocked(j *Job, cause error) {
 	}
 }
 
-// notifyTerminalFailure invokes the terminal-failure hook (if set) with a cloned
-// record. Mirrors notifyChange: it snapshots the callback under mu and calls it
-// WITHOUT holding mu or ioMu, so the callback may touch the store freely.
+// notifyTerminalFailure invokes the hook with a cloned record and NO lock held,
+// so the callback may touch the store freely.
 func (r *Runner) notifyTerminalFailure(j *Job) {
 	r.mu.Lock()
 	fn := r.onTerminalFailure
@@ -1049,9 +871,8 @@ func (r *Runner) backoff(attempt int) time.Duration {
 	d := r.backoffBase
 	for i := 1; i < attempt; i++ {
 		d *= 2
-		// `d <= 0` guards int64 overflow: with a near-MaxInt64 cap and a large
-		// attempt count the doubling can wrap negative before reaching the cap,
-		// which would yield a past ScheduledAt and a hot retry loop.
+		// `d <= 0` guards int64 overflow: a wrapped-negative delay yields a past
+		// ScheduledAt and a hot retry loop.
 		if d <= 0 || d >= r.backoffCap {
 			return r.backoffCap
 		}
@@ -1063,11 +884,8 @@ func (r *Runner) backoff(attempt int) time.Duration {
 }
 
 // cancelAll cancels every in-flight run (honoring each commit fence) and blocks
-// until they have all exited. Used by Stop AFTER the dispatch loop has exited, so
-// no new run can be registered while it drains. It snapshots r.runs under mu and
-// then fences+waits without holding mu: a run that finishes between the snapshot
-// and the fence closes its done channel (tryFence on a settled guard is a safe
-// no-op) so <-run.done returns immediately.
+// until all have exited. Only valid AFTER the dispatch loop has exited, so no
+// new run can register while it drains.
 func (r *Runner) cancelAll() {
 	r.mu.Lock()
 	runs := make([]*activeRun, 0, len(r.runs))
@@ -1100,8 +918,6 @@ func (r *Runner) retentionLoop(done <-chan struct{}) {
 }
 
 // Trim runs one retention pass and reports how many completed jobs were removed.
-// It is exported so a test (or an operator surface) can run retention on demand
-// instead of waiting for the interval.
 func (r *Runner) Trim() int {
 	if r.disabled {
 		return 0
@@ -1128,13 +944,9 @@ func (r *Runner) nudge() {
 	}
 }
 
-// notifyWorkChange reports a transition on the two paths a cron entry travels —
-// its arming and each fire — and drops it for cron kinds. A heartbeat beating
-// every minute forever is not news, and routing it through the change hook would
-// append a durable event and re-push a snapshot per minute per entry for as long
-// as the daemon lives. Every other transition (retry, cancel, removal) is an
-// action someone took, so those report through notifyChange even for a cron
-// entry.
+// notifyWorkChange reports a transition, dropped for cron kinds: a heartbeat
+// firing forever would append a durable event and re-push a snapshot per fire.
+// User actions call notifyChange directly, even for a cron entry.
 func (r *Runner) notifyWorkChange(kind, jobID string) {
 	if r.cronInterval(kind) > 0 {
 		return
@@ -1142,9 +954,6 @@ func (r *Runner) notifyWorkChange(kind, jobID string) {
 	r.notifyChange(jobID)
 }
 
-// notifyChange reports one job's lifecycle transition. The id is required: a
-// consumer that is only told "something changed" has to re-list to find out
-// what, which is the whole problem the event bus behind this callback removes.
 func (r *Runner) notifyChange(jobID string) {
 	r.mu.Lock()
 	fn := r.onChange
@@ -1154,9 +963,8 @@ func (r *Runner) notifyChange(jobID string) {
 	}
 }
 
-// marshalPayload encodes a payload or result. A nil value encodes to nil rather
-// than the four bytes "null", so "carries nothing" and "carries the JSON null"
-// stay distinguishable — Enqueue relies on nil meaning "leave what is there".
+// marshalPayload encodes a payload or result. A nil value encodes to nil, not
+// "null" — Enqueue relies on nil meaning "leave what is there".
 func marshalPayload(v any) (json.RawMessage, error) {
 	if v == nil {
 		return nil, nil

--- a/internal/notebook/document.go
+++ b/internal/notebook/document.go
@@ -9,37 +9,25 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Document is a parsed Notebook markdown file: optional YAML frontmatter plus a
-// markdown body. A document parsed from disk re-serializes its frontmatter
-// content byte-for-byte — key order, comments, and scalar text (e.g. ids like
-// 007 or versions like 1.10) are all preserved — so fields written by Obsidian,
-// an external sync tool, or the user survive an attn rewrite untouched (the
-// "---" fence lines themselves are normalized to LF). Only an attn-constructed
-// document is serialized from the parsed map (in deterministic sorted-key order).
+// Document is a parsed Notebook markdown file: optional YAML frontmatter plus
+// body. A disk-parsed document re-serializes its frontmatter byte-for-byte, so
+// externally-written fields survive an attn rewrite untouched; only an
+// attn-constructed document is serialized from the map (sorted keys).
 type Document struct {
-	// Frontmatter holds every key from the YAML frontmatter block, parsed for
-	// reading (accessors). A nil map means the file had no frontmatter block.
-	// Mutating this map after Parse does NOT change what Bytes emits for a
-	// parsed document — construct a fresh Document (leaving rawFrontmatter
-	// empty) to serialize edited frontmatter.
+	// Frontmatter is read-only after Parse: mutating it does not change what
+	// Bytes emits — construct a fresh Document to serialize edited frontmatter.
 	Frontmatter map[string]any
-	// Body is the markdown content after the frontmatter block, with the
-	// closing fence (and its trailing newline) removed and the remainder kept
-	// byte-for-byte.
+	// Body is the markdown after the frontmatter block, kept byte-for-byte.
 	Body string
-	// rawFrontmatter is the exact YAML text between the fences as read from
-	// disk (empty for an attn-constructed document). When set, Bytes emits it
-	// verbatim, making round-trips byte-faithful.
+	// rawFrontmatter is the exact on-disk YAML; when set, Bytes emits it verbatim.
 	rawFrontmatter string
 }
 
 const frontmatterFence = "---"
 
-// Parse splits raw bytes into frontmatter and body. A file whose first line is
-// not a "---" fence, or that has no closing fence, is treated as having no
-// frontmatter (the whole content is the body) — never an error. Parse only
-// returns an error when a well-formed frontmatter block contains malformed
-// YAML; callers that must not fail should use ParsePermissive.
+// Parse splits raw bytes into frontmatter and body. A missing or unclosed
+// fence means no frontmatter, never an error; only malformed YAML inside a
+// well-formed block errors — callers that must not fail use ParsePermissive.
 func Parse(raw []byte) (Document, error) {
 	fm, body, ok := splitFrontmatter(string(raw))
 	if !ok {
@@ -55,11 +43,8 @@ func Parse(raw []byte) (Document, error) {
 	return Document{Frontmatter: meta, Body: body, rawFrontmatter: fm}, nil
 }
 
-// decodeFrontmatter decodes a YAML mapping into map[string]any, preserving every
-// key. Scalars keep their native YAML type (int/bool/float/string) EXCEPT
-// timestamps, which are kept as their literal text rather than coerced to
-// time.Time — so frontmatter dates and ids round-trip exactly and the string
-// accessors (Updated, etc.) work without type surprises.
+// decodeFrontmatter decodes a YAML mapping into map[string]any. Timestamps stay
+// literal text, not time.Time, so dates round-trip and string accessors work.
 func decodeFrontmatter(text []byte) (map[string]any, error) {
 	var root yaml.Node
 	if err := yaml.Unmarshal(text, &root); err != nil {
@@ -113,9 +98,8 @@ func nodeToValue(n *yaml.Node) any {
 	}
 }
 
-// ParsePermissive parses raw bytes and never fails: a malformed frontmatter
-// block falls back to treating the whole content as the body. Use it on the
-// read/list path, where agent- or human-authored files may be malformed.
+// ParsePermissive parses raw bytes and never fails: malformed frontmatter
+// falls back to treating the whole content as the body.
 func ParsePermissive(raw []byte) Document {
 	doc, err := Parse(raw)
 	if err != nil {
@@ -124,11 +108,9 @@ func ParsePermissive(raw []byte) Document {
 	return doc
 }
 
-// Bytes serializes the document back to disk form. Frontmatter keys are emitted
-// in deterministic (sorted) order. A document with no frontmatter serializes to
-// its body alone.
+// Bytes serializes the document back to disk form (sorted frontmatter keys;
+// no frontmatter → body alone).
 func (d Document) Bytes() []byte {
-	// A parsed document re-emits its frontmatter byte-for-byte.
 	if d.rawFrontmatter != "" {
 		return []byte(frontmatterFence + "\n" + d.rawFrontmatter + frontmatterFence + "\n" + d.Body)
 	}
@@ -140,9 +122,7 @@ func (d Document) Bytes() []byte {
 	enc := yaml.NewEncoder(&buf)
 	enc.SetIndent(2)
 	if err := enc.Encode(d.Frontmatter); err != nil {
-		// map[string]any from Parse always marshals; this is unreachable in
-		// practice, but degrade to body-only rather than panic.
-		return []byte(d.Body)
+		return []byte(d.Body) // practically unreachable; degrade rather than panic
 	}
 	_ = enc.Close()
 	buf.WriteString(frontmatterFence + "\n")
@@ -158,9 +138,8 @@ func (d Document) frontmatterString(key string) string {
 	return v
 }
 
-// Type returns the declared OKF `type` ("" if absent or non-string). For
-// read-compatibility with notes an external tool wrote before the field was
-// renamed, it falls back to a legacy `kind` value; attn always writes `type`.
+// Type returns the declared OKF `type` ("" if absent or non-string), falling
+// back to the legacy `kind` for read-compat; attn always writes `type`.
 func (d Document) Type() string {
 	if t := d.frontmatterString("type"); t != "" {
 		return t
@@ -168,10 +147,8 @@ func (d Document) Type() string {
 	return d.frontmatterString("kind")
 }
 
-// Title returns the note's title: the text of the first level-1 ATX heading
-// ("# Heading") in the body. A note's title is its `# H1` — attn does not read a
-// frontmatter `title:`. Returns "" when the body has no H1, in which case callers
-// fall back to the note's filename (its stable address).
+// Title returns the first H1's text — attn never reads a frontmatter `title:`.
+// "" when the body has no H1; callers fall back to the filename.
 func (d Document) Title() string { return firstH1(d.Body) }
 
 var (
@@ -179,11 +156,8 @@ var (
 	mdFenceRe = regexp.MustCompile("^[ \t]*(`{3,}|~{3,})")
 )
 
-// firstH1 returns the text of the first level-1 ATX heading in a markdown body,
-// or "" when there is none. It skips fenced code blocks (a "# " line inside ``` or
-// ~~~ is not a heading) and follows CommonMark's ATX rules: up to three leading
-// spaces, a single "#" then whitespace, and an optional trailing "#"-sequence that
-// is stripped from the returned title (so "# F# notes ##" → "F# notes").
+// firstH1 returns the first level-1 ATX heading's text, or "". It skips fenced
+// code blocks and follows CommonMark ATX rules (trailing #-sequence stripped).
 func firstH1(body string) string {
 	var fence byte // 0 outside a code fence; otherwise the marker rune ('`' or '~')
 	for line := range strings.SplitSeq(body, "\n") {
@@ -213,10 +187,8 @@ func (d Document) Summary() string { return d.frontmatterString("summary") }
 // Updated returns the declared update timestamp ("" if absent).
 func (d Document) Updated() string { return d.frontmatterString("updated") }
 
-// splitFrontmatter returns the YAML text between the leading fences and the body
-// after the closing fence. ok is false when the content does not open with a
-// "---" line or has no matching closing fence (both treated as no frontmatter).
-// Body bytes after the closing fence's newline are returned verbatim.
+// splitFrontmatter returns the YAML between the fences and the body after the
+// closing fence; ok is false when either fence is missing (no frontmatter).
 func splitFrontmatter(s string) (fm, body string, ok bool) {
 	nl := strings.IndexByte(s, '\n')
 	if nl < 0 {

--- a/internal/notebook/store.go
+++ b/internal/notebook/store.go
@@ -15,22 +15,17 @@ import (
 	"time"
 )
 
-// Store is the filesystem-canonical notebook backing a single root directory.
-// It is the single in-process writer for attn-originated mutations: every write
-// is serialized under mu and applied atomically (temp file + rename). Reads do
-// not take the lock.
+// Store is the filesystem-canonical notebook for one root directory. Every
+// write serializes under mu and applies atomically; reads do not take the lock.
 type Store struct {
 	root string
 	mu   sync.Mutex
 }
 
-// NewStore returns a Store rooted at the given absolute directory. The directory
-// need not exist yet; EnsureScaffold creates it.
+// NewStore returns a Store rooted at the given absolute directory, which need
+// not exist yet (EnsureScaffold creates it).
 func NewStore(root string) *Store {
-	// Normalize the root so containment checks compare against a canonical path.
-	// A root entered with a trailing slash (e.g. "~/Notebook/") would otherwise
-	// make abs's `HasPrefix(abs, root+separator)` test expect a doubled separator
-	// ("/Notebook//"), rejecting a perfectly valid "index.md" as escaping the root.
+	// Clean the root: a trailing slash would break abs's HasPrefix containment test.
 	if root != "" {
 		root = filepath.Clean(root)
 	}
@@ -40,14 +35,10 @@ func NewStore(root string) *Store {
 // Root returns the absolute notebook root directory.
 func (s *Store) Root() string { return s.root }
 
-// EnsureScaffold idempotently creates the root, the reserved directory layout,
-// and the reserved index/log files. It never clobbers an existing file. It
-// returns the notebook-relative paths of the files it actually wrote (empty on
-// an idempotent no-op run) so callers can record exactly those as self-writes —
-// recording reserved paths that were not rewritten would wrongly suppress a real
-// external edit to them. On a mid-scaffold failure it returns the files written
-// so far ALONGSIDE the error, so the caller can still account for attn's own
-// partial writes rather than letting them surface later as external edits.
+// EnsureScaffold idempotently creates the root, reserved directories, and
+// reserved files, never clobbering an existing file. It returns only the paths
+// it actually wrote — even alongside a mid-scaffold error — so callers record
+// exactly those as self-writes.
 func (s *Store) EnsureScaffold() (createdPaths []string, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -102,11 +93,9 @@ func (s *Store) Read(p string) (content []byte, hash string, err error) {
 	return content, Hash(content), nil
 }
 
-// Write creates or edits a note. An empty baseHash means create-only: it fails
-// with a Conflict if the file already exists. A non-empty baseHash is a
-// hash-CAS edit: it applies only if the on-disk hash still matches, else returns
-// a Conflict carrying the current hash. On success it returns the new hash and a
-// nil Conflict.
+// Write creates or edits a note. Empty baseHash = create-only (Conflict if the
+// file exists); non-empty = hash-CAS edit, returning a Conflict with the
+// current hash when the on-disk hash no longer matches.
 func (s *Store) Write(p string, content []byte, baseHash string) (newHash string, conflict *Conflict, err error) {
 	abs, err := s.abs(p)
 	if err != nil {
@@ -115,9 +104,8 @@ func (s *Store) Write(p string, content []byte, baseHash string) (newHash string
 	if int64(len(content)) > MaxFileSize {
 		return "", nil, fmt.Errorf("notebook: content for %q exceeds %d bytes", p, MaxFileSize)
 	}
-	// No type validation: OKF leaves the `type` vocabulary open, so the store is
-	// a permissive writer (it stores bytes) and the read/list path is the
-	// permissive consumer. The guidance, not the store, asks authors for a type.
+	// No type validation: the `type` vocabulary is open, so the store stays a
+	// permissive writer; guidance, not the store, asks authors for a type.
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -147,9 +135,8 @@ func (s *Store) Write(p string, content []byte, baseHash string) (newHash string
 
 var journalDateRE = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
 
-// AppendJournal appends an entry to the dated journal file (journal/<date>.md),
-// creating it with type:journal frontmatter on first write. Appends are
-// serialized and never conflict. dateISO must be YYYY-MM-DD.
+// AppendJournal appends an entry to journal/<date>.md, creating it with
+// type:journal frontmatter on first write. dateISO must be YYYY-MM-DD.
 func (s *Store) AppendJournal(dateISO, entry string) (relPath string, hash string, err error) {
 	if !journalDateRE.MatchString(dateISO) {
 		return "", "", fmt.Errorf("notebook: invalid journal date %q (want YYYY-MM-DD)", dateISO)
@@ -162,14 +149,10 @@ func (s *Store) AppendJournal(dateISO, entry string) (relPath string, hash strin
 	return rel, hash, err
 }
 
-// AppendJournalEntryOnce appends entry to journal/<date>.md, but only when
-// dedupeMarker is not already present in the file. It reports written=false (and
-// no error) when the marker is already there, so repeated calls for the same
-// logical entry are idempotent. dedupeMarker must be a stable string embedded in
-// entry (typically a hidden HTML comment): the journal file itself is the dedup
-// ledger, so suppression needs no separate bookkeeping and survives a daemon
-// restart. This is how attn auto-captures an event (a dispatch outcome) exactly
-// once even when more than one lifecycle path fires for it.
+// AppendJournalEntryOnce appends entry to journal/<date>.md unless dedupeMarker
+// is already present (then written=false, no error). The marker must be a stable
+// string embedded in entry: the journal file itself is the dedup ledger, so
+// idempotency survives a daemon restart with no separate bookkeeping.
 func (s *Store) AppendJournalEntryOnce(dateISO, dedupeMarker, entry string) (relPath string, written bool, hash string, err error) {
 	if !journalDateRE.MatchString(dateISO) {
 		return "", false, "", fmt.Errorf("notebook: invalid journal date %q (want YYYY-MM-DD)", dateISO)
@@ -189,8 +172,7 @@ func (s *Store) AppendJournalEntryOnce(dateISO, dedupeMarker, entry string) (rel
 func newJournalDoc(dateISO string) func() Document {
 	return func() Document {
 		return Document{
-			// The `# <date>` H1 in the body is the journal's title (Document.Title
-			// reads it); no redundant frontmatter `title:`.
+			// The H1 is the title (Document.Title reads it); no frontmatter title:.
 			Frontmatter: map[string]any{"type": TypeJournal},
 			Body:        "# " + dateISO + "\n",
 		}
@@ -198,33 +180,27 @@ func newJournalDoc(dateISO string) func() Document {
 }
 
 // AppendInbox appends an entry to the reserved chief inbox note (inbox.md),
-// creating it on first write. Like AppendJournal, appends are serialized under
-// the store lock and never conflict.
+// creating it on first write; appends serialize and never conflict.
 func (s *Store) AppendInbox(entry string) (relPath string, hash string, err error) {
 	if strings.TrimSpace(entry) == "" {
 		return "", "", fmt.Errorf("notebook: empty inbox entry")
 	}
 	hash, err = s.appendToNote(FileInbox, entry, func() Document {
-		// The `# Chief inbox` H1 in the template is the title; the note needs no
-		// frontmatter.
 		return Document{Body: inboxTemplate}
 	})
 	return FileInbox, hash, err
 }
 
-// appendToNote appends entry to the note at rel, creating it from newDoc() when
-// it does not yet exist. The whole read-modify-write runs under the store lock so
-// concurrent appends serialize and never conflict (unlike the hash-CAS Write).
+// appendToNote appends entry to rel, creating it from newDoc() when absent.
+// The read-modify-write runs under the store lock, so appends never conflict.
 func (s *Store) appendToNote(rel, entry string, newDoc func() Document) (hash string, err error) {
 	_, hash, err = s.appendToNoteOnce(rel, "", entry, newDoc)
 	return hash, err
 }
 
-// appendToNoteOnce is appendToNote with optional idempotency: when dedupeMarker is
-// non-empty and already present in the existing note, it appends nothing and
-// reports written=false. The read-check-write runs as one critical section under
-// the store lock, so the dedup test is atomic with the append and two callers
-// racing the same marker can never both write.
+// appendToNoteOnce is appendToNote with optional idempotency via dedupeMarker.
+// The read-check-write is one critical section under the store lock, so two
+// callers racing the same marker can never both write.
 func (s *Store) appendToNoteOnce(rel, dedupeMarker, entry string, newDoc func() Document) (written bool, hash string, err error) {
 	abs, err := s.abs(rel)
 	if err != nil {
@@ -239,9 +215,7 @@ func (s *Store) appendToNoteOnce(rel, dedupeMarker, entry string, newDoc func() 
 		return false, "", statErr
 	}
 	if dedupeMarker != "" && statErr == nil && bytes.Contains(existing, []byte(dedupeMarker)) {
-		// Already recorded — return the current hash so callers can still suppress
-		// the (absent) watcher event without surfacing a spurious write.
-		return false, Hash(existing), nil
+		return false, Hash(existing), nil // already recorded; hash lets callers still suppress
 	}
 	var doc Document
 	if statErr == nil {
@@ -260,19 +234,15 @@ func (s *Store) appendToNoteOnce(rel, dedupeMarker, entry string, newDoc func() 
 	return true, Hash(out), nil
 }
 
-// List returns the notes under the root, sorted by path. The optional prefix
-// (root-absolute or relative) filters to a subtree. The .attn/ dotdir and any
-// dotfile are skipped, and non-.md files are ignored. An uninitialized root
-// yields an empty list, not an error.
-// listFrontmatterScanLimit bounds how many leading bytes List reads per file to
-// extract frontmatter. Frontmatter lives at the top, so a small prefix is
-// enough — List never loads a whole (possibly externally-written, oversized)
-// body into memory just to render the tree.
+// listFrontmatterScanLimit bounds the leading bytes List reads per file — it
+// must never load a whole (possibly oversized, externally-written) body.
 const listFrontmatterScanLimit = 64 << 10 // 64 KiB
 
+// List returns the notes under the root, sorted by path; prefix scopes a
+// subtree. Dotfiles/dotdirs and non-.md files are skipped; an uninitialized
+// root yields an empty list, not an error.
 func (s *Store) List(prefix string) ([]Entry, error) {
-	// A non-empty prefix scopes a subtree on path-segment boundaries (so
-	// "knowledge/areas" does NOT match the sibling "knowledge/areas-archive").
+	// Prefix matches on path-segment boundaries, never partial names.
 	want := strings.Trim(strings.TrimSpace(prefix), "/")
 	var entries []Entry
 	walkErr := filepath.WalkDir(s.root, func(p string, dirent fs.DirEntry, err error) error {
@@ -281,10 +251,8 @@ func (s *Store) List(prefix string) ([]Entry, error) {
 				if p == s.root {
 					return fs.SkipAll // root not created yet => empty list
 				}
-				// A subtree vanished mid-walk. The root is externally syncable, so
-				// an external client can remove a directory during the scan; treat
-				// the gone path as empty rather than failing the whole List (and the
-				// UI-triggered Backlinks that calls it on every navigation).
+				// Subtree vanished mid-walk (root is externally syncable);
+				// treat as empty rather than failing the whole List.
 				return nil
 			}
 			return err
@@ -311,11 +279,8 @@ func (s *Store) List(prefix string) ([]Entry, error) {
 		if ierr != nil {
 			return nil
 		}
-		// The root is externally syncable/user-editable, so a note entry can be a
-		// symlink pointing outside the root (e.g. linked.md -> /outside/private.md).
-		// Read/Write defend against this via checkWithinResolvedRoot; List must too,
-		// or it would read and expose an outside file's frontmatter (title/summary)
-		// over the websocket. Skip any entry that resolves outside the root.
+		// A note can be a symlink pointing outside the root; without this check
+		// List would expose an outside file's frontmatter over the websocket.
 		if err := s.checkWithinResolvedRoot(p); err != nil {
 			return nil
 		}
@@ -345,16 +310,9 @@ func (s *Store) List(prefix string) ([]Entry, error) {
 	return entries, nil
 }
 
-// Backlinks returns the notes whose body contains a root-absolute markdown link
-// targeting the given note, sorted by path. The target's own note is excluded,
-// and a link's #anchor is ignored when matching. A target that does not exist on
-// disk still surfaces any notes that link to it (dangling-link discovery), so
-// the UI can show what points at a note before it is created.
-//
-// Cost note: this reads every note's body on each call. The Notebook is a small,
-// distilled store (that is the point), so a full scan is acceptable; if it ever
-// grows large, an incremental reverse index can replace this without changing
-// the signature.
+// Backlinks returns the notes linking to target (anchors ignored, self
+// excluded), sorted by path; a target absent on disk still surfaces its
+// linkers. Full scan per call — acceptable while the Notebook stays small.
 func (s *Store) Backlinks(target string) ([]Entry, error) {
 	want, err := CleanPath(target)
 	if err != nil {
@@ -370,10 +328,8 @@ func (s *Store) Backlinks(target string) ([]Entry, error) {
 			continue // a note linking to itself is not a backlink
 		}
 		if e.Size > MaxFileSize {
-			// attn never writes a note larger than MaxFileSize, so anything bigger
-			// is an oversized externally-synced file. Skip it rather than pull its
-			// whole body into memory on every navigation — List caps its own
-			// per-file read (listFrontmatterScanLimit) for the same reason.
+			// Bigger than attn ever writes = oversized externally-synced file;
+			// skip rather than pull its whole body into memory per navigation.
 			continue
 		}
 		content, _, rerr := s.Read(e.Path)
@@ -406,9 +362,8 @@ func bodyLinksTo(body, want string) bool {
 	return false
 }
 
-// abs resolves a notebook path to an absolute filesystem path, validating it and
-// defending against any escape outside the root — both lexical (".." after
-// Clean) and via symlinks inside the root that point elsewhere.
+// abs resolves a notebook path to an absolute filesystem path, rejecting both
+// lexical ("..") and symlink escapes from the root.
 func (s *Store) abs(p string) (string, error) {
 	rel, err := CleanPath(p)
 	if err != nil {
@@ -424,27 +379,16 @@ func (s *Store) abs(p string) (string, error) {
 	return abs, nil
 }
 
-// checkWithinResolvedRoot defends against symlink escape: it resolves the
-// deepest existing ancestor of abs and requires it to stay within the resolved
-// root. A symlinked directory or file inside the root that points outside is
-// rejected; a legitimately symlinked root itself (the user pointing
-// ~/attn-notebook at a synced folder) is allowed, because the root is resolved
-// too. The lexical guard in abs cannot catch this — a symlink uses no "..".
-//
-// A residual TOCTOU remains (a symlink could be planted between the check and
-// the syscall); for a single-user local app that is an accepted limit.
+// checkWithinResolvedRoot rejects symlink escape (which the lexical guard in
+// abs cannot catch) via EnsureWithinResolvedRoot.
 func (s *Store) checkWithinResolvedRoot(abs string) error {
 	return EnsureWithinResolvedRoot(s.root, abs)
 }
 
-// EnsureWithinResolvedRoot is the package-level symlink-containment check that
-// Store.checkWithinResolvedRoot delegates to, exported so daemon-side writers
-// that build paths under the same notebook root (e.g. the raw tier) can apply
-// the identical guard. It resolves the deepest existing ancestor of abs and
-// requires it to stay within the resolved root; a symlinked ancestor pointing
-// outside is rejected, while a legitimately symlinked root is allowed because
-// the root is resolved too. abs is expected to be lexically contained already;
-// this is the symlink layer on top. The same TOCTOU caveat as above applies.
+// EnsureWithinResolvedRoot requires abs's deepest existing ancestor to resolve
+// within the resolved root: a symlinked ancestor pointing outside is rejected,
+// a legitimately symlinked root is allowed. abs must already be lexically
+// contained. Residual TOCTOU accepted for a single-user local app.
 func EnsureWithinResolvedRoot(root, abs string) error {
 	realRoot, err := filepath.EvalSymlinks(root)
 	if err != nil {
@@ -465,8 +409,6 @@ func EnsureWithinResolvedRoot(root, abs string) error {
 		if !os.IsNotExist(err) {
 			return err
 		}
-		// The leaf (or a not-yet-created ancestor) does not exist; walk up to
-		// the deepest existing component and resolve that.
 		parent := filepath.Dir(probe)
 		if parent == probe {
 			return nil
@@ -475,8 +417,7 @@ func EnsureWithinResolvedRoot(root, abs string) error {
 	}
 }
 
-// readPrefix reads up to limit leading bytes of a file. Used by List to scan
-// frontmatter without loading large bodies.
+// readPrefix reads up to limit leading bytes of a file.
 func readPrefix(path string, limit int64) ([]byte, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -486,12 +427,9 @@ func readPrefix(path string, limit int64) ([]byte, error) {
 	return io.ReadAll(io.LimitReader(f, limit))
 }
 
-// writeAtomic writes content to absPath atomically: it creates parent
-// directories, writes to a uniquely-named temp file in the same directory, then
-// renames it into place. The temp file is removed on any error. The temp name is
-// dot-prefixed so it lands outside CleanPath's trackable set: a watcher observing
-// this directory (self or otherwise) must not treat the transient swap file's own
-// fsnotify events as a change to a real, trackable path.
+// writeAtomic writes via temp file + rename. The temp name is dot-prefixed so
+// it lands outside CleanPath's trackable set — a watcher must not treat the
+// transient swap file's events as a change to a real path.
 func writeAtomic(absPath string, content []byte) error {
 	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
 		return err

--- a/internal/notebook/watcher.go
+++ b/internal/notebook/watcher.go
@@ -13,30 +13,17 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
-// DefaultWatchDebounce is the fixed window, opened by the first event of a
-// burst, over which filesystem events are coalesced into one change
-// notification. It is not an idle/quiet window: later events in the same burst
-// do not extend it, so a burst flushes at most this long after it starts.
+// DefaultWatchDebounce is the fixed coalescing window opened by a burst's first
+// event — not an idle window; later events do not extend it.
 const DefaultWatchDebounce = 400 * time.Millisecond
 
-// selfWriteTTL caps how long an unconsumed NoteSelfWrite record lingers before
-// it is pruned. Suppression itself is one-shot: a record is consumed by the
-// first coalesced flush that contains its path (a single atomic write fires its
-// events within one debounce window, so all of attn's own events for that write
-// coalesce into that one flush). The TTL only bounds a record whose matching
-// event never arrives, so a stale record cannot suppress a real edit forever.
+// selfWriteTTL bounds an unconsumed NoteSelfWrite record whose event never
+// arrives, so a stale record cannot suppress a real edit forever.
 const selfWriteTTL = 3 * time.Second
 
-// Watcher observes a notebook root for changes made OUTSIDE attn — an external
-// markdown sync tool such as Obsidian, or the user editing files directly — and
-// invokes onChange with the affected notebook-relative paths. attn's own writes
-// are excluded: a daemon write records the path via NoteSelfWrite before it
-// mutates the file, so the resulting event is recognized and dropped.
-//
-// It lives in the notebook package (not the daemon) so it is unit testable
-// without a daemon and reuses the package's path rules; the daemon supplies
-// onChange (which broadcasts notebook_changed) and drives NoteSelfWrite from its
-// write handlers.
+// Watcher observes a notebook root for changes made outside attn and invokes
+// onChange with the affected notebook-relative paths. attn's own writes are
+// excluded: NoteSelfWrite records the path before the file is mutated.
 type Watcher struct {
 	root      string
 	debounce  time.Duration
@@ -52,40 +39,30 @@ type Watcher struct {
 	now        func() time.Time // injectable clock for tests
 }
 
-// selfWriteRecord is what NoteSelfWrite stores per path: when the record expires,
-// and the content hash attn wrote (empty for an unconditional suppression).
+// selfWriteRecord is the per-path suppression record: expiry plus the content
+// hash attn wrote (empty for an unconditional suppression).
 type selfWriteRecord struct {
 	expiry time.Time
 	hash   string
 }
 
-// SelfWrite identifies a notebook-relative path attn just wrote. A non-empty Hash
-// makes suppression content-aware: the matching filesystem event is dropped only
-// if the file on disk still holds exactly those bytes, so a genuine external edit
-// that lands in the SAME debounce window (different bytes, or a delete) is still
-// surfaced instead of being swallowed by the self-write. An empty Hash suppresses
-// the next event for the path unconditionally (used where the written content is
-// not readily available, e.g. the scaffold).
+// SelfWrite identifies a notebook-relative path attn just wrote. A non-empty
+// Hash makes suppression content-aware — an external edit in the same debounce
+// window still surfaces; an empty Hash suppresses the next event unconditionally.
 type SelfWrite struct {
 	Rel  string
 	Hash string
 }
 
-// NewWatcher starts watching root (which must already exist) and every
-// non-dotdir subdirectory under it, coalescing events over debounce before
-// calling onChange. Close stops it. It errors if root does not exist or is not a
-// directory, rather than silently watching nothing. Only .md files are
-// trackable (the notebook's rule); see NewWatcherWithCleaner for a generic root.
+// NewWatcher starts watching root (must exist — errors rather than silently
+// watching nothing) and every non-dotdir subdirectory, coalescing events over
+// debounce before calling onChange. .md files only; see NewWatcherWithCleaner.
 func NewWatcher(root string, debounce time.Duration, onChange func(paths []string)) (*Watcher, error) {
 	return NewWatcherWithCleaner(root, debounce, CleanPath, onChange)
 }
 
-// NewWatcherWithCleaner is NewWatcher with an injectable path-cleaning rule.
-// cleanPath decides which filesystem paths are trackable: it is handed a
-// root-relative slash-path and either returns the canonical form to key events
-// on, or an error to skip the path entirely. Passing CleanPath (the .md rule)
-// reproduces NewWatcher's behavior; a permissive cleaner (e.g. fsdoc.CleanPath)
-// makes the watcher generic over every file under root.
+// NewWatcherWithCleaner is NewWatcher with an injectable path rule: cleanPath
+// maps a root-relative slash-path to its canonical form, or errors to skip it.
 func NewWatcherWithCleaner(root string, debounce time.Duration, cleanPath func(string) (string, error), onChange func(paths []string)) (*Watcher, error) {
 	clean := filepath.Clean(root)
 	if info, err := os.Stat(clean); err != nil {
@@ -115,10 +92,8 @@ func NewWatcherWithCleaner(root string, debounce time.Duration, cleanPath func(s
 	return w, nil
 }
 
-// NoteSelfWrite marks paths as attn-originated so the next filesystem event for
-// each is treated as our own write, not an external edit. With a per-write content
-// hash, suppression is content-aware (see SelfWrite). A nil Watcher (none running
-// yet) is a no-op.
+// NoteSelfWrite marks paths as attn-originated so their next filesystem event
+// is dropped (see SelfWrite). A nil Watcher is a no-op.
 func (w *Watcher) NoteSelfWrite(writes ...SelfWrite) {
 	if w == nil || len(writes) == 0 {
 		return
@@ -135,9 +110,8 @@ func (w *Watcher) NoteSelfWrite(writes ...SelfWrite) {
 	}
 }
 
-// Close stops watching and waits for the event loop to return, so no onChange
-// can fire after it returns. It is safe to call more than once and on a nil
-// Watcher.
+// Close stops watching and waits for the event loop, so no onChange can fire
+// after it returns. Safe to call more than once and on a nil Watcher.
 func (w *Watcher) Close() error {
 	if w == nil {
 		return nil
@@ -176,19 +150,16 @@ func (w *Watcher) loop() {
 	}
 }
 
-// handleEvent records a trackable .md change into pending and, for a newly
-// created directory, attaches a watch so its future contents are observed
-// (fsnotify is not recursive).
+// handleEvent records a trackable change into pending; a newly created
+// directory gets a watch attached (fsnotify is not recursive).
 func (w *Watcher) handleEvent(ev fsnotify.Event, pending map[string]struct{}) {
 	if ev.Op&fsnotify.Create != 0 {
 		if info, err := os.Stat(ev.Name); err == nil && info.IsDir() {
 			if base := filepath.Base(ev.Name); base == "." || strings.HasPrefix(base, ".") {
 				return // skip .attn/ and any dotdir subtree
 			}
-			// Surface whatever addTree discovered even if the walk aborted partway
-			// (e.g. a permission error on a sibling subdir): the files found before
-			// the failure are real trackable paths whose parent dirs are already
-			// watched, so dropping them would silently miss external edits.
+			// Surface whatever addTree found even if the walk aborted partway;
+			// dropping already-discovered files would silently miss external edits.
 			files, _ := w.addTree(ev.Name)
 			for _, rel := range files {
 				pending[rel] = struct{}{}
@@ -220,11 +191,8 @@ func (w *Watcher) flush(pending map[string]struct{}) {
 }
 
 // dropSelfWrites removes paths attn just wrote (consuming each record once) and
-// prunes expired records. For a record that carries a content hash, suppression
-// is content-aware: the path is dropped only if the file on disk still holds
-// exactly the bytes attn wrote. If an external edit coalesced into the same
-// debounce window (so the on-disk bytes differ, or the file was deleted), the
-// path is surfaced instead of being swallowed by the self-write.
+// prunes expired records; a hashed record drops the path only if the on-disk
+// bytes still match, so a same-window external edit is surfaced.
 func (w *Watcher) dropSelfWrites(rels []string) []string {
 	w.mu.Lock()
 	now := w.now()
@@ -248,10 +216,8 @@ func (w *Watcher) dropSelfWrites(rels []string) []string {
 		out = append(out, rel)
 	}
 	w.mu.Unlock()
-	// Content-aware recheck runs OUTSIDE the lock (it reads files): surface a path
-	// whose on-disk bytes no longer match what attn wrote — an external edit that
-	// landed in the same window. dropSelfWrites is only ever called from the single
-	// loop goroutine, so this stays race-free.
+	// Recheck outside the lock (it reads files); only the single loop goroutine
+	// calls dropSelfWrites, so this stays race-free.
 	for _, rc := range pending {
 		if w.diskHash(rc.rel) != rc.hash {
 			out = append(out, rc.rel)
@@ -260,9 +226,8 @@ func (w *Watcher) dropSelfWrites(rels []string) []string {
 	return out
 }
 
-// diskHash returns the content hash of the note at rel on disk, or "" if it cannot
-// be read (e.g. it was deleted). "" never equals a real recorded hash, so an
-// unreadable or deleted path is treated as a change worth surfacing.
+// diskHash returns the content hash of rel on disk, or "" when unreadable —
+// "" never equals a real hash, so a deleted path surfaces as a change.
 func (w *Watcher) diskHash(rel string) string {
 	content, err := os.ReadFile(filepath.Join(w.root, filepath.FromSlash(rel)))
 	if err != nil {
@@ -271,9 +236,8 @@ func (w *Watcher) diskHash(rel string) string {
 	return Hash(content)
 }
 
-// addTree adds a watch for dir and every non-dotdir subdirectory, returning the
-// root-relative paths of the trackable files it contains (so files that appear
-// alongside a freshly created directory are not missed).
+// addTree watches dir and every non-dotdir subdirectory, returning the
+// trackable files it contains so a freshly created tree's files are not missed.
 func (w *Watcher) addTree(dir string) ([]string, error) {
 	var files []string
 	err := filepath.WalkDir(dir, func(p string, dirent fs.DirEntry, err error) error {
@@ -298,10 +262,8 @@ func (w *Watcher) addTree(dir string) ([]string, error) {
 	return files, err
 }
 
-// trackable reports whether an absolute path is trackable under this watcher's
-// cleanPath rule (no dotfile/dotdir segment under the root, plus whatever else
-// cleanPath enforces — e.g. .md-only for the notebook rule) and returns its
-// clean relative path.
+// trackable reports whether an absolute path passes the cleanPath rule and
+// returns its clean relative path.
 func (w *Watcher) trackable(absPath string) (string, bool) {
 	rel, err := filepath.Rel(w.root, absPath)
 	if err != nil {

--- a/internal/protocol/binaryframe.go
+++ b/internal/protocol/binaryframe.go
@@ -6,10 +6,8 @@ import (
 )
 
 // Binary websocket frames carry high-volume PTY output to clients that
-// advertised CapabilityBinaryPtyOutput in client_hello. Unlike every other
-// daemon event, these are not JSON: base64-in-JSON costs a 33% size
-// inflation plus a large transient-allocation churn (envelope string, base64
-// string, decoded bytes) on both sides of the socket for every chunk.
+// advertised CapabilityBinaryPtyOutput (base64-in-JSON costs 33% inflation +
+// allocation churn per chunk); others keep the JSON pty_output event.
 //
 // Frame layout (big-endian):
 //
@@ -18,15 +16,14 @@ import (
 //	offset 2      session id (L bytes, UTF-8)
 //	offset 2+L    seq (4 bytes, uint32)
 //	offset 6+L    raw PTY bytes (rest of frame)
-//
-// Clients that did not opt in keep receiving the JSON pty_output event.
 const BinaryFrameTypePtyOutput byte = 0x01
 
-// Kitty image blobs take the same route for the same reason, scaled up: a
-// stored image is decoded raw pixels, so a measured real emission is 1.9–6.5MB
-// and base64-in-JSON would add a third of that plus a multi-megabyte
-// JSON.parse stall on the UI thread. One frame carries one whole image; there
-// is no chunking, and none of it is retained by the decoder.
+// One frame carries one whole kitty image, no chunking. Measured: real
+// emissions are 1.9–6.5MB of raw pixels. No request id: answers match by
+// content key (session id, image id, generation) — the client blob-cache key —
+// so a duplicate is an idempotent cache fill. Clients without
+// CapabilityBinaryPtyOutput get the base64 kitty_image_result instead; hearing
+// about images at all is a separate bit (CapabilityKittyImages).
 //
 // Frame layout (big-endian):
 //
@@ -39,17 +36,6 @@ const BinaryFrameTypePtyOutput byte = 0x01
 //	offset 18+L    height in pixels (4 bytes, uint32)
 //	offset 22+L    pixel format (1 byte, KittyImageFormatCode*)
 //	offset 23+L    raw pixels (rest of frame)
-//
-// There is no request id here or on the JSON fallback: an answer is matched to
-// what asked for it by CONTENT KEY — (session id, image id, generation) — which
-// is the same key a client's blob cache is keyed on, so a duplicate answer is
-// an idempotent cache fill rather than an orphan.
-//
-// Clients that did not advertise CapabilityBinaryPtyOutput get the base64
-// kitty_image_result event instead — the same bit that picks pty_output's
-// transport picks this one, because it is the one that says a client can decode
-// a frame at all. Wanting to hear about images is a separate question
-// (CapabilityKittyImages), and the hub answers the two differently.
 const BinaryFrameTypeKittyImage byte = 0x02
 
 const binaryPtyHeaderBytes = 1 + 1 + 4 // type + id length + seq
@@ -57,14 +43,10 @@ const binaryPtyHeaderBytes = 1 + 1 + 4 // type + id length + seq
 // type + id length + image id + generation + width + height + format
 const binaryKittyImageHeaderBytes = 1 + 1 + 4 + 8 + 4 + 4 + 1
 
-// Kitty pixel layouts as the client protocol names and codes them. PNG is
-// absent on purpose: ghostty decodes PNG and inflates zlib before storing, so a
-// stored image is always one of these four raw layouts.
-//
-// The codes are the daemon's own, assigned here and translated from ghostty's
-// enum by an explicit switch at the boundary. Passing ghostty's value through
-// would make a pin that reorders its enum silently reinterpret every client's
-// pixels as a different layout.
+// Kitty pixel layouts. PNG is absent on purpose: ghostty decodes it before
+// storing. The codes are the daemon's own, translated from ghostty's enum at
+// the boundary — passing ghostty's value through would let a pin that reorders
+// its enum silently reinterpret every client's pixels.
 const (
 	KittyImageFormatCodeRGB       byte = 0
 	KittyImageFormatCodeRGBA      byte = 1
@@ -72,8 +54,8 @@ const (
 	KittyImageFormatCodeGray      byte = 3
 )
 
-// kittyImageFormatNames indexes the wire names by format code. One table, so a
-// layout added here cannot get a code without also getting a name.
+// kittyImageFormatNames indexes wire names by format code: one table, so a new
+// layout cannot get a code without a name.
 var kittyImageFormatNames = [...]string{
 	KittyImageFormatCodeRGB:       "rgb",
 	KittyImageFormatCodeRGBA:      "rgba",
@@ -82,8 +64,7 @@ var kittyImageFormatNames = [...]string{
 }
 
 // KittyImageFormatName maps a format code to the name the JSON
-// kitty_image_result carries. Both transports describe the same four layouts,
-// so the JSON answer names what the binary frame would have coded.
+// kitty_image_result carries.
 func KittyImageFormatName(code byte) (string, bool) {
 	if int(code) >= len(kittyImageFormatNames) {
 		return "", false
@@ -92,9 +73,8 @@ func KittyImageFormatName(code byte) (string, bool) {
 }
 
 // EncodeKittyImageFrame builds a binary kitty image frame. It rejects a format
-// code it has no name for: an unknown layout reaching a client is pixels
-// interpreted with the wrong stride, which renders as plausible garbage rather
-// than failing.
+// code it has no name for: an unknown layout renders as plausible garbage
+// (wrong stride) rather than failing.
 func EncodeKittyImageFrame(sessionID string, imageID uint32, generation uint64, width, height uint32, format byte, pixels []byte) ([]byte, error) {
 	if len(sessionID) == 0 || len(sessionID) > 255 {
 		return nil, fmt.Errorf("session id length %d out of range [1,255]", len(sessionID))
@@ -102,9 +82,6 @@ func EncodeKittyImageFrame(sessionID string, imageID uint32, generation uint64, 
 	if _, ok := KittyImageFormatName(format); !ok {
 		return nil, fmt.Errorf("unknown kitty image format code %d", format)
 	}
-	// Everything after the header is the image, so a frame with nothing after
-	// it describes an image that cannot be drawn. Saying so here beats a client
-	// sizing a texture from the header and uploading no pixels into it.
 	if len(pixels) == 0 {
 		return nil, fmt.Errorf("kitty image %d carries no pixels for its %dx%d header", imageID, width, height)
 	}
@@ -133,9 +110,8 @@ type KittyImageFrame struct {
 	Pixels     []byte
 }
 
-// DecodeKittyImageFrame parses a binary kitty image frame. Go has no client
-// that decodes one — the app does, in TypeScript — so this exists to pin the
-// layout against the encoder from the same table the encoder wrote.
+// DecodeKittyImageFrame parses a binary kitty image frame. The only real
+// decoder is the app's TypeScript; this pins the layout against the encoder.
 func DecodeKittyImageFrame(frame []byte) (KittyImageFrame, error) {
 	if len(frame) < binaryKittyImageHeaderBytes+1 {
 		return KittyImageFrame{}, fmt.Errorf("frame too short: %d bytes", len(frame))
@@ -178,8 +154,7 @@ func EncodePtyOutputFrame(sessionID string, seq uint32, data []byte) ([]byte, er
 }
 
 // DecodePtyOutputFrame parses a binary pty_output frame. The returned data
-// aliases the input frame; callers must not retain it past the frame's
-// lifetime.
+// aliases the input frame; callers must not retain it past the frame's lifetime.
 func DecodePtyOutputFrame(frame []byte) (sessionID string, seq uint32, data []byte, err error) {
 	if len(frame) < binaryPtyHeaderBytes+1 {
 		return "", 0, nil, fmt.Errorf("frame too short: %d bytes", len(frame))

--- a/internal/pty/blockfeed.go
+++ b/internal/pty/blockfeed.go
@@ -1,13 +1,9 @@
 package pty
 
-// OSC 133 block-tracking skeleton (Phase 3a rails). This file fixes the
-// integration contract for worker-owned command blocks: WHERE the segmenter
-// and block table plug into the PTY write path and the attach snapshot, and
-// under WHICH lock. The real implementations replace the no-ops in
-// newBlockFeeder without touching session.go — call sites, lock placement,
-// and the atomic {dump, blocks, watermark} triple are decided here, once.
-// Design: docs/plans/2026-07-23-terminal-restore-fidelity.md; implementation
-// contract: Phase 3a in docs/plans/2026-07-22-server-authoritative-terminal.md.
+// OSC 133 command-block integration: where the segmenter and block table plug
+// into the PTY write path and the attach snapshot, and under which lock.
+// Design: docs/plans/2026-07-23-terminal-restore-fidelity.md; contract:
+// Phase 3a in docs/plans/2026-07-22-server-authoritative-terminal.md.
 
 import "github.com/victorarias/attn/internal/ghosttyvt"
 
@@ -21,35 +17,29 @@ const (
 	osc133CommandEnd  osc133MarkerKind = 'D'
 )
 
-// osc133Marker is one parsed marker. Cmdline is the percent-decoded
-// cmdline_url payload of a C marker (nil when absent); ExitCode is the D
-// marker's exit status (nil when absent/unparsable).
+// osc133Marker is one parsed marker. Cmdline is a C marker's percent-decoded
+// cmdline_url (nil when absent); ExitCode is a D marker's exit status (nil
+// when absent/unparsable).
 type osc133Marker struct {
 	Kind     osc133MarkerKind
 	Cmdline  *string
 	ExitCode *int32
 }
 
-// blockRef is the position pin the block table holds for each marker —
-// backed by ghosttyvt.TrackedRef in production, by fakes in pure tests. The
-// ref follows its content across scrolling, scrollback pruning, and reflow;
-// ScreenPoint reports ok=false once the content is discarded.
+// blockRef is the position pin the block table holds per marker — a
+// ghosttyvt.TrackedRef in production. It follows its content across scrolling,
+// pruning, and reflow; ScreenPoint reports ok=false once the content is gone.
 type blockRef interface {
 	ScreenPoint() (x, y int, ok bool)
 	Free()
 }
 
 // AttachBlockData is one resolved command block in the attach snapshot. Rows
-// are SCREEN-space rows of the serialized VT dump, which equal client buffer
-// rows after the dump is written into a fresh same-size terminal (spike-
-// verified, including after scrollback pruning). Mirrors the planned protocol
-// AttachBlock shape; the protocol slice converts 1:1.
+// are SCREEN-space rows of the serialized VT dump.
 type AttachBlockData struct {
-	// ID is server-assigned, monotonic per session — authoritative from day
-	// one so a future block_event stream is purely additive.
+	// ID is server-assigned, monotonic per session.
 	ID uint64
-	// Pending marks the currently-open block (no command-end yet); at most
-	// one entry has it set, and EndRow is absent on it.
+	// Pending marks the currently-open block (at most one; EndRow absent).
 	Pending        bool
 	PromptRow      int32
 	InputRow       *int32
@@ -61,50 +51,34 @@ type AttachBlockData struct {
 	ExitCode *int32
 }
 
-// workerBlockTable owns command-block lifecycle state. The corpus in
-// testdata/osc133_block_corpus.json is its executable spec (proven against
-// the client TerminalBlockStore by app/src/utils/terminalBlocks.corpus.test.ts).
-// Implementations are PURE: no locks (every call arrives under replayMu via
-// blockFeeder), no cgo beyond the blockRef handles. Every retired ref —
-// cap eviction, self-heal replacement, alt-drop, Close — must be freed;
-// tests assert ghosttyvt.LiveTrackedRefs returns to baseline.
+// workerBlockTable owns command-block lifecycle state; its executable spec is
+// testdata/osc133_block_corpus.json, shared with the client TerminalBlockStore.
+// Implementations are PURE: no locks (calls arrive under replayMu), no cgo
+// beyond the blockRef handles; every retired ref must be freed.
 type workerBlockTable interface {
-	// ApplyMarker applies one marker whose position is pinned by ref. ref may
-	// be nil (pin failed, or stub terminal): the marker still advances
-	// lifecycle state so self-heal semantics hold, but the affected block
-	// becomes unserializable and is dropped at snapshot. altScreen records
-	// whether the alternate screen was active at pin time; such blocks are
-	// excluded from SnapshotBlocks (blocks are a primary-screen concept).
+	// ApplyMarker applies one marker pinned by ref. A nil ref still advances
+	// lifecycle state but makes the block unserializable. altScreen blocks are
+	// excluded from SnapshotBlocks — blocks are a primary-screen concept.
 	ApplyMarker(m osc133Marker, ref blockRef, altScreen bool)
-	// SnapshotBlocks resolves all blocks to SCREEN-space rows. A block whose
-	// essential refs (prompt or end) no longer resolve is dropped:
-	// correct-or-absent, never a wrong row.
+	// SnapshotBlocks resolves all blocks to SCREEN-space rows, dropping any
+	// whose essential refs no longer resolve: correct-or-absent.
 	SnapshotBlocks() []AttachBlockData
 	// Close frees every held ref. The table is unusable afterwards.
 	Close()
 }
 
-// blockFeeder owns the ghostty write path for a session: it writes plain
-// output to the terminal and pins a tracked ref at each OSC 133 marker's
-// cursor position for the block table. Where a marker begins and ends is the
-// feed segmenter's decision (kittyseg.go); this half only reacts to it. All
-// methods are called under replayMu (the same critical section that assigns
-// the seq watermark and serializes the dump), which is what makes the attach
-// snapshot an atomic {dump, blocks, watermark} triple.
+// blockFeeder owns the ghostty write path for a session: plain output to the
+// terminal, plus a tracked ref pinned at each OSC 133 marker's cursor. All
+// methods run under replayMu — what makes the attach snapshot an atomic
+// {dump, blocks, watermark} triple.
 type blockFeeder struct {
 	term  *ghosttyvt.Terminal
 	table workerBlockTable
 }
 
-// newBlockFeeder wires the feeder for a session's ghostty terminal. Returns
-// nil when the terminal is absent (construction failure, or nothing to feed):
-// callers nil-guard exactly like every other ghostty use, and the attach
-// snapshot simply carries no blocks.
-//
-// The worker block table is wired HERE — nowhere else. On the non-macOS stub,
-// TrackCursor returns nil so the table pins nothing and serves no blocks;
-// markers still arrive but resolve to unserializable blocks, degrading exactly
-// like every other ghostty use off macOS.
+// newBlockFeeder wires the feeder — and the worker block table, nowhere else —
+// for a session's ghostty terminal. Returns nil when the terminal is absent:
+// callers nil-guard, and the attach snapshot carries no blocks.
 func newBlockFeeder(term *ghosttyvt.Terminal) *blockFeeder {
 	if term == nil {
 		return nil
@@ -119,12 +93,10 @@ func (f *blockFeeder) write(segment []byte) {
 	}
 }
 
-// mark applies one OSC 133 marker at the cursor. It must be called in stream
-// order, after the plain bytes that preceded the marker have been written: the
-// cursor then sits on the cell the marker refers to (the row the prompt,
-// command or output renders on next), which is what the pin captures. A nil
-// marker is a sequence with no block event defined for its subtype — consumed,
-// with nothing to record. Caller holds replayMu.
+// mark applies one OSC 133 marker at the cursor. Must be called in stream
+// order, after the marker's preceding plain bytes are written, so the cursor
+// sits on the cell the pin captures. A nil marker is consumed with nothing
+// recorded. Caller holds replayMu.
 func (f *blockFeeder) mark(marker *osc133Marker) {
 	if marker == nil {
 		return
@@ -137,8 +109,7 @@ func (f *blockFeeder) mark(marker *osc133Marker) {
 }
 
 // snapshotBlocks resolves the block table to SCREEN-space rows. Caller holds
-// replayMu — the SAME hold that serializes the VT dump and reads the seq
-// watermark, so the three cannot disagree.
+// replayMu — the same hold that serializes the VT dump and reads the watermark.
 func (f *blockFeeder) snapshotBlocks() []AttachBlockData {
 	return f.table.SnapshotBlocks()
 }

--- a/internal/pty/blocktable.go
+++ b/internal/pty/blocktable.go
@@ -1,28 +1,12 @@
 package pty
 
 // Worker-side OSC 133 command-block table — the production workerBlockTable.
-//
-// It mirrors the client's TerminalBlockStore (app/src/utils/terminalBlocks.ts):
-// at most one pending block, self-heal when a command-end (133;D) is lost, a
-// cap of maxBlocks with oldest-first eviction. The lifecycle logic is proven
-// identical to the client store by the shared corpus
-// (testdata/osc133_block_corpus.json) in blocktable_test.go.
-//
-// The difference from the client is positional: the client stores absolute
-// buffer rows plus a text anchor and re-anchors on drift; the worker stores a
-// tracked grid ref per marker (blockRef) that follows its cell across
-// scrolling, pruning, and reflow, and resolves to a SCREEN-space row only at
-// snapshot time. Command text and exit code are captured at parse time — they
-// are unrecoverable from the grid later, which is the whole reason this table
-// exists.
-//
-// Refs are native memory. Every ref a block holds must be freed on every
-// retirement path (cap eviction, self-heal completion, bare-enter discard,
-// session Close). The rails leak counter (ghosttyvt.LiveTrackedRefs) makes a
-// missed Free a red test. A single marker's ref can be shared by two blocks
-// (self-heal: the healing marker is both the old block's end and the new
-// block's start), so refs are reference-counted; the native ref frees exactly
-// once, when the last holder releases it.
+// Lifecycle mirrors the client's TerminalBlockStore, proven identical by the
+// shared corpus (testdata/osc133_block_corpus.json). Positions are tracked grid
+// refs resolved to SCREEN-space rows at snapshot time; command text and exit
+// code are captured at parse time — unrecoverable from the grid later. Refs
+// are native memory: every retirement path must free them, and one marker's
+// ref can back two blocks (self-heal), hence the reference counting.
 
 const maxBlocks = 200
 
@@ -64,11 +48,8 @@ func (s *sharedRef) point() (x, y int, ok bool) {
 	return s.ref.ScreenPoint()
 }
 
-// trackedBlock is one command block. hasCommand mirrors the client's
-// "outputStartRow is set" — the marker that makes a bare Enter distinguishable
-// from a real command and that arms self-heal. altScreen records whether the
-// block was opened while the alternate screen was active; such blocks are
-// excluded at snapshot (blocks are a primary-screen concept).
+// trackedBlock is one command block. hasCommand distinguishes a bare Enter
+// from a real command and arms self-heal; altScreen blocks drop at snapshot.
 type trackedBlock struct {
 	id         uint64
 	promptRef  *sharedRef
@@ -82,8 +63,8 @@ type trackedBlock struct {
 }
 
 func (b *trackedBlock) release() {
-	// promptRef/inputRef (and self-heal end/prompt) can be the same *sharedRef;
-	// releasing each acquire keeps the reference count balanced.
+	// Fields can share a *sharedRef (self-heal); releasing each acquire keeps
+	// the count balanced.
 	for _, r := range []*sharedRef{b.promptRef, b.inputRef, b.outputRef, b.endRef} {
 		if r != nil {
 			r.release()
@@ -107,10 +88,9 @@ func newBlockTable() *blockTable {
 func (bt *blockTable) ApplyMarker(m osc133Marker, ref blockRef, altScreen bool) {
 	cur := newSharedRef(ref)
 
-	// Self-heal against a lost command-end: if a command already ran in the
-	// open block and a marker that begins a NEW command context arrives, the
-	// previous 133;D never reached us. Close the open block at this marker's
-	// position so two commands don't merge into one.
+	// Self-heal a lost command-end: a marker beginning a NEW command context
+	// while a command already ran means the previous 133;D never arrived —
+	// close the open block here so two commands don't merge.
 	if bt.pending != nil && bt.pending.hasCommand &&
 		(m.Kind == osc133PromptStart || m.Kind == osc133InputStart || m.Kind == osc133PreExec) {
 		bt.complete(bt.pending, cur, nil)
@@ -119,8 +99,8 @@ func (bt *blockTable) ApplyMarker(m osc133Marker, ref blockRef, altScreen bool) 
 
 	switch m.Kind {
 	case osc133PromptStart:
-		// A second prompt-start with no command in between (a redrawn prompt)
-		// replaces the open block; retire the one it displaces or its refs leak.
+		// A redrawn prompt replaces the open block; retire the displaced one
+		// or its refs leak.
 		if bt.pending != nil {
 			bt.pending.release()
 		}
@@ -131,8 +111,7 @@ func (bt *blockTable) ApplyMarker(m osc133Marker, ref blockRef, altScreen bool) 
 		if bt.pending == nil {
 			bt.pending = bt.openPending(cur, altScreen)
 		}
-		// A repeated input-start re-pins the input position; release the ref it
-		// replaces before overwriting the field.
+		// A repeated input-start re-pins; release the ref it replaces.
 		if bt.pending.inputRef != nil {
 			bt.pending.inputRef.release()
 		}
@@ -142,9 +121,8 @@ func (bt *blockTable) ApplyMarker(m osc133Marker, ref blockRef, altScreen bool) 
 		if bt.pending == nil {
 			bt.pending = bt.openPending(cur, altScreen)
 		}
-		// No release-on-replace guard here: outputRef is set only alongside
-		// hasCommand, so a repeated pre-exec always trips self-heal above and
-		// arrives with a fresh pending block whose outputRef is nil.
+		// No release-on-replace guard: a repeated pre-exec always trips
+		// self-heal above and arrives with a fresh pending block.
 		bt.pending.outputRef = cur
 		cur.acquire()
 		bt.pending.command = m.Cmdline
@@ -156,8 +134,7 @@ func (bt *blockTable) ApplyMarker(m osc133Marker, ref blockRef, altScreen bool) 
 		case p != nil && p.hasCommand:
 			bt.complete(p, cur, m.ExitCode)
 		case p != nil:
-			// Bare Enter at the prompt: nothing copyable. The id is still
-			// consumed (nextID already advanced), the block's refs are freed.
+			// Bare Enter at the prompt: nothing copyable; free the refs.
 			p.release()
 		}
 	}
@@ -190,10 +167,9 @@ func (bt *blockTable) complete(p *trackedBlock, endRef *sharedRef, exitCode *int
 	}
 }
 
-// SnapshotBlocks resolves every serializable block to SCREEN-space rows. A
-// completed block whose prompt or end ref no longer resolves is dropped
-// (correct-or-absent). The pending block, if any, is included with Pending set
-// so the client can re-arm it and continue the id sequence.
+// SnapshotBlocks resolves every serializable block to SCREEN-space rows,
+// dropping blocks whose essential refs no longer resolve (correct-or-absent).
+// The pending block carries Pending so the client can re-arm it.
 func (bt *blockTable) SnapshotBlocks() []AttachBlockData {
 	out := make([]AttachBlockData, 0, len(bt.completed)+1)
 	for _, b := range bt.completed {
@@ -222,8 +198,6 @@ func (bt *blockTable) Close() {
 }
 
 func (b *trackedBlock) resolve(pending bool) (AttachBlockData, bool) {
-	// Blocks pinned while the alternate screen was active are not primary-screen
-	// command blocks; exclude them from the restore payload.
 	if b.altScreen {
 		return AttachBlockData{}, false
 	}
@@ -244,8 +218,7 @@ func (b *trackedBlock) resolve(pending bool) (AttachBlockData, bool) {
 	if !pending {
 		_, y, ok := b.endRef.point()
 		if !ok {
-			// The end position is essential for a completed block; without it
-			// the block's extent is unknown — drop rather than show a wrong row.
+			// The end position is essential; drop rather than show a wrong row.
 			return AttachBlockData{}, false
 		}
 		row := int32(y)

--- a/internal/pty/harness_signals.go
+++ b/internal/pty/harness_signals.go
@@ -8,47 +8,31 @@ import (
 	agentdriver "github.com/victorarias/attn/internal/agent"
 )
 
-// Harness-owned state signals, read off the PTY stream.
-//
-// Both Claude Code and Codex already broadcast what they are doing, and attn has
-// been ignoring it in favour of scraping the rendered screen:
+// Harness-owned state signals, read off the PTY stream via the OSC 0/2 title:
 //
 //	ESC ] 0 ; ⠐ Run background sleep command BEL     claude, turn RUNNING
 //	ESC ] 0 ; ✳ Run background sleep command BEL     claude, turn NOT running
 //	ESC ] 0 ; ⠸ my-project BEL                       codex, busy
 //	ESC ] 0 ; my-project BEL                         codex, idle
 //
-// The title glyph is a *level*, repainted about once a second by claude and ten
-// times a second by codex, and it comes from the harness rather than from
-// guessing at its TUI. Measured against hook ground truth it tracks the turn to
-// within ~100ms in both directions.
-//
-// What it is for is bounding stuck states, not accuracy: a level that stops
-// arriving cannot get stuck the way an edge-triggered claim can. It is not a
-// detector on its own — claude's title goes silent for ~3.5s in the middle of a
-// blocking foreground tool call, so no TTL gives both a fast settle and no false
-// settle.
-//
-// Nothing here drives session state yet. The observations are recorded as
-// evidence so the traces can be compared against the current behavior before
-// anything starts arbitrating on them.
+// The glyph is a *level*, repainted ~1/s by claude and ~10/s by codex;
+// measured against hook ground truth it tracks the turn within ~100ms. It
+// bounds stuck states rather than detecting on its own — claude's title goes
+// silent ~3.5s mid blocking foreground tool call, so no TTL gives both a fast
+// settle and no false settle. Nothing here drives session state yet.
 
 const (
-	// heartbeatKeepalive bounds how often an unchanged heartbeat re-emits. The
-	// level says "still true", so a re-emit carries real information (the agent is
-	// alive right now), but at codex's ~10Hz repaint every frame would drown out
-	// every other kind of evidence in the observation ring. 1s matches claude's
-	// natural repaint rate.
+	// heartbeatKeepalive bounds how often an unchanged heartbeat re-emits: at
+	// codex's ~10Hz every frame would evict every other kind of evidence from
+	// the observation ring. 1s matches claude's natural repaint rate.
 	heartbeatKeepalive = time.Second
 
-	// claimBusy and claimNotBusy are the heartbeat's vocabulary. It deliberately
-	// does not speak in protocol state names: the title says whether the agent's
-	// turn is running, and nothing about *why* it stopped — an approval, a
-	// question, and a finished turn all look identical to it.
+	// The heartbeat's vocabulary — deliberately not protocol state names: the
+	// title says whether the turn runs, not WHY it stopped.
 	claimBusy    = "busy"
 	claimNotBusy = "not_busy"
-	// claimApproval is the title saying the agent is blocked on the user. Only
-	// codex has it; claude announces approvals on its Notification hook instead.
+	// claimApproval: blocked on the user. Codex only; claude announces
+	// approvals on its Notification hook instead.
 	claimApproval = "approval"
 )
 
@@ -57,24 +41,13 @@ const (
 	oscCodeTitle        = 2
 )
 
-// titleClassifier reads an OSC 0 title. It reports whether the agent's turn is
-// running, plus the title with its level glyph removed.
-//
-// The glyph is stripped because it is the noisiest part of the title and the
-// least informative: it cycles through spinner frames several times a second
-// while saying nothing that the busy/not-busy claim does not already say. What
-// is left is the turn summary, which changes only when the agent moves on to
-// something else — so consecutive observations of an unchanged level are
-// genuinely identical and collapse into one trace row instead of consuming one
-// ring slot per second and evicting every other kind of evidence.
-//
-// ok is false when the title says nothing about the agent — most often because a
-// subprocess overwrote it — in which case no observation is made and whatever
-// the previous level was still stands.
+// titleClassifier reads an OSC 0 title, reporting whether the turn is running
+// plus the title with its level glyph stripped (so unchanged levels collapse
+// into one trace row). ok is false when the title says nothing about the agent
+// (typically a subprocess overwrote it); the previous level then stands.
 type titleClassifier func(title string) (claim string, summary string, ok bool)
 
-// harnessSignalPolicy is the per-agent part. The mechanics below (scanning,
-// rate limiting, timestamping) are shared; only the reading of a title differs.
+// harnessSignalPolicy is the per-agent part; the mechanics are shared.
 type harnessSignalPolicy struct {
 	classifyTitle titleClassifier
 }
@@ -87,9 +60,8 @@ type harnessSignalObserver struct {
 	lastEmit  time.Time
 }
 
-// newHarnessSignalObserver builds the observer the driver asked for, or nil (as
-// a nil interface value, so callers' nil checks work) for an agent with no
-// harness signals.
+// newHarnessSignalObserver builds the observer the driver asked for, or nil
+// for an agent with no harness signals.
 func newHarnessSignalObserver(kind agentdriver.HarnessSignalKind) *harnessSignalObserver {
 	switch kind {
 	case agentdriver.HarnessSignalsClaude:
@@ -131,8 +103,8 @@ func (o *harnessSignalObserver) observeTitle(title string, now time.Time) (Obser
 	if !ok {
 		return Observation{}, false
 	}
-	// A level only needs re-stating periodically: it changed, or it has been long
-	// enough that "still true" is news.
+	// Re-state a level only when it changed or "still true" is old enough to
+	// be news.
 	if claim == o.lastClaim && now.Sub(o.lastEmit) < heartbeatKeepalive {
 		return Observation{}, false
 	}
@@ -159,29 +131,18 @@ func classifyClaudeTitle(title string) (string, string, bool) {
 	}
 }
 
-// codexApprovalMarker is what codex puts in its title while an approval prompt
-// is on screen: "[ . ] Action Required | <cwd>", switching the glyph to "!" the
-// moment it is answered. Measured on codex 0.145.0 driven through a real PTY
-// with --ask-for-approval untrusted.
-//
-// Matching harness UI text is a real cost and worth naming: a codex release
-// that rewords this silently drops the signal. It degrades safely — the title
-// stops looking busy, which is what it already did before this existed, so the
-// worst case is the behavior attn shipped without it. The alternative is worse:
-// codex has no notification escape at all (its OSC vocabulary is 0, 10, 11 —
-// there is no 777) and no approval hook, so the title is the only leading edge
-// available.
+// codexApprovalMarker is codex's title while an approval prompt is on screen:
+// "[ . ] Action Required | <cwd>", glyph flipping to "!" once answered.
+// Measured on codex 0.145.0 through a real PTY with --ask-for-approval
+// untrusted. Matching harness UI text is a real cost — a reworded release
+// silently drops the signal, degrading to pre-signal behavior — but codex has
+// no notification escape (OSC vocabulary is 0, 10, 11) and no approval hook.
 const codexApprovalMarker = "Action Required"
 
-// classifyCodexTitle reads Codex's title. A braille spinner frame means the turn
-// is running; the approval marker means it is blocked on the user; the bare
-// working directory means neither.
-//
-// Unlike claude there is no distinct idle glyph, so a title a subprocess
-// overwrote reads as not-busy. That is safe under a freshness rule — the level
-// that matters is *when busy frames last arrived* — and a live capture confirmed
-// a competing title repaint moves accuracy by 0.2pp, because the agent keeps
-// painting over it.
+// classifyCodexTitle reads Codex's title: braille spinner = running, approval
+// marker = blocked on the user, bare cwd = neither. No idle glyph, so an
+// overwritten title reads as not-busy — safe under the freshness rule; a live
+// capture measured a competing repaint moving accuracy by 0.2pp.
 func classifyCodexTitle(title string) (string, string, bool) {
 	first, ok := firstRune(title)
 	if !ok {
@@ -190,14 +151,8 @@ func classifyCodexTitle(title string) (string, string, bool) {
 	if isBrailleSpinner(first) {
 		return claimBusy, stripLevelGlyph(title), true
 	}
-	// The marker is a prefix on an otherwise ordinary title, so the summary is
-	// whatever follows the separator — the cwd, same as any other codex title.
-	//
-	// The marker alone does not mean a prompt is waiting. Codex leaves the words
-	// in place after the prompt is answered and flips only the glyph, so the
-	// pending form is the one that counts; reading the marker on its own would
-	// re-arm the approval on every repaint and leave the session yellow for the
-	// rest of its life.
+	// Codex leaves the marker words after the prompt is answered and flips
+	// only the glyph — the marker alone would re-arm the approval forever.
 	if strings.Contains(title, codexApprovalMarker) {
 		if codexApprovalPending(title) {
 			return claimApproval, codexTitleSummary(title), true
@@ -207,14 +162,9 @@ func classifyCodexTitle(title string) (string, string, bool) {
 	return claimNotBusy, stripLevelGlyph(title), true
 }
 
-// codexApprovalPending reads the glyph codex puts in front of the marker: "."
-// while the prompt is waiting for an answer, "!" once it has one. Measured on
-// codex 0.145.0.
-//
-// A title carrying the marker with neither glyph is treated as answered. The
-// cost of guessing wrong is asymmetric: a missed approval shows a session as not
-// waiting for a moment longer, while a stuck one shows it demanding attention
-// forever.
+// codexApprovalPending reads the glyph before the marker: "." while waiting,
+// "!" once answered (measured on codex 0.145.0). Neither glyph reads as
+// answered — a missed approval costs a moment, a stuck one nags forever.
 func codexApprovalPending(title string) bool {
 	prefix, _, found := strings.Cut(title, codexApprovalMarker)
 	if !found {
@@ -231,9 +181,8 @@ func codexTitleSummary(title string) string {
 	return strings.TrimSpace(title)
 }
 
-// stripLevelGlyph removes a leading level glyph and the space after it, leaving
-// the turn summary. A title that is only a glyph leaves an empty summary, which
-// is the honest answer: there was no summary.
+// stripLevelGlyph removes a leading level glyph and the space after it. A
+// glyph-only title leaves an empty summary — the honest answer.
 func stripLevelGlyph(title string) string {
 	trimmed := strings.TrimSpace(title)
 	first, size := utf8.DecodeRuneInString(trimmed)
@@ -243,8 +192,8 @@ func stripLevelGlyph(title string) string {
 	return trimmed
 }
 
-// isBrailleSpinner reports whether r is in the Braille Patterns block, which is
-// what both agents animate their spinners with.
+// isBrailleSpinner reports whether r is in the Braille Patterns block, which
+// both agents animate their spinners with.
 func isBrailleSpinner(r rune) bool {
 	return r >= 0x2800 && r <= 0x28FF
 }

--- a/internal/pty/kitty.go
+++ b/internal/pty/kitty.go
@@ -1,15 +1,8 @@
 package pty
 
-// What the worker says about kitty images, and how the pixels are fetched.
-//
-// The worker is the system's only kitty parser (see wirefeed.go): the APC bytes
-// never reach a client, so a client that wants to draw an image has to be told
-// where it is. That is two things and no more — an update carrying the whole
-// placement set of the active screen, and a pull for the pixels behind a
-// placement whose image the puller has not seen.
-//
-// Both are descriptions. Nothing here changes a grid, and a session that never
-// stores an image never reaches any of it.
+// Kitty image descriptions and pixel fetch. The worker is the system's only
+// kitty parser (see wirefeed.go); clients are told where images sit and pull
+// pixels on demand. Nothing here changes a grid.
 
 import (
 	"crypto/rand"
@@ -24,87 +17,54 @@ import (
 )
 
 // KittyPlacement is one image placed on the active screen, as ghostty resolved
-// it at observation time: geometry in both cells and pixels, the source rect,
-// and the generation of the image behind it.
-//
-// The observation IS the description — there is deliberately no second struct
-// to copy into. Ghostty resolves geometry the worker does not interpret, and a
-// hand-maintained mirror would rot the first time a pin resolves a new piece of
-// it. Callers outside this package name the type through pty.
+// it at observation time. Deliberately an alias, not a mirror struct: ghostty
+// owns the geometry, and a hand-maintained copy would rot on a pin bump.
 type KittyPlacement = ghosttyvt.KittyPlacement
 
 // KittyImage is one stored image copied out of a terminal: always raw pixels in
-// Format's layout, never PNG and never compressed, because ghostty decodes and
-// inflates before storing.
+// Format's layout, never PNG — ghostty decodes before storing.
 type KittyImage = ghosttyvt.KittyImage
 
-// PlacementUpdate is the FULL placement set of a session's active screen as of
-// the chunk stamped Seq — never a delta, and the empty set is an ordinary
-// update rather than a special case. Sets are tiny (zero to a handful), so
-// wholesale replacement costs nothing and makes a missed update self-healing:
-// the next one is the whole truth again.
-//
-// Seq ties the set to the bytes it was measured on. The read loop delivers an
-// update after fanning out the chunk with the same seq, so a consumer that
-// applies both in arrival order measures placements against the grid those
-// bytes produced.
+// PlacementUpdate is the FULL placement set of the active screen as of the
+// chunk stamped Seq — never a delta; the empty set is an ordinary update, so a
+// missed update is self-healing. The read loop delivers it after the chunk with
+// the same seq, so applying both in arrival order keeps set and grid aligned.
 type PlacementUpdate struct {
 	Seq        uint32
 	Placements []KittyPlacement
 }
 
 // ErrKittyImageNotFound reports that a terminal holds no image with the id
-// asked for — evicted at the storage limit, deleted by the program, or never
-// transmitted at all. It is an ordinary answer rather than a failure: the
-// asking client drops that placement's render, and a retransmission describes
-// the image again.
+// asked for. An ordinary answer, not a failure: the client drops that render.
 var ErrKittyImageNotFound = errors.New("kitty image not found")
 
-// SubscriberOption configures an attaching subscriber beyond its byte stream
-// and drop callback.
+// SubscriberOption configures an attaching subscriber.
 type SubscriberOption func(*sessionSubscriber)
 
-// OnPlacements delivers placement updates to this subscriber. Placements ride
-// the subscriber rather than a session-wide handler because an update is only
-// meaningful in order against that subscriber's own byte stream.
+// OnPlacements delivers placement updates to this subscriber. Rides the
+// subscriber, not a session-wide handler: an update is only meaningful in
+// order against that subscriber's own byte stream.
 func OnPlacements(fn func(PlacementUpdate)) SubscriberOption {
 	return func(sub *sessionSubscriber) {
 		sub.onPlacements = fn
 	}
 }
 
-// kittyStorageLimitEnv overrides the kitty image storage cap a new session's
-// terminal is built with, in BYTES. Images are on by default, so this is a
-// tripwire override rather than a feature flag: a value here is for tuning a
-// session that hit the ceiling, or for turning the protocol off.
-//
-// Zero is the one special value — it makes ghostty refuse every transmission,
-// so nothing is stored, no placement is ever observed, and the feed path never
-// leaves its no-cgo path. That is the escape hatch if a program's images ever
-// misbehave, and it is what FuzzKittyWireMirrorShipping still guards.
+// kittyStorageLimitEnv overrides the kitty image storage cap, in BYTES. Zero is
+// special: ghostty refuses every transmission, so nothing is stored, no
+// placement is observed, and the feed path never leaves its no-cgo path.
 const kittyStorageLimitEnv = "ATTN_KITTY_STORAGE_LIMIT"
 
-// kittyStorageLimitDefault is what a session gets with nothing in the
-// environment: 320MB, which is ghostty's own app default and within 5% of
-// kitty's.
-//
-// Set past where any real image lands, because the failure past it is total
-// rather than gradual. Ghostty refuses a single image larger than the WHOLE
-// limit outright (addImage returns error.OutOfMemory) and every emitter
-// measured in the A4 sweep transmits with q=2, which suppresses the response —
-// so an over-limit image does not degrade, it silently does not appear.
-// The largest legitimate single image the sweep produced is ~81.4MB, a
-// full-screen Pro Display XDR capture at 2x; 320MB clears that by about 4x.
-//
-// Under the limit, hitting it is ordinary: ghostty evicts the oldest image to
-// admit a new one, which is what an animation does all day and costs nothing.
+// kittyStorageLimitDefault is 320MB — ghostty's own app default, within 5% of
+// kitty's. An image larger than the WHOLE limit is refused silently (q=2
+// suppresses the response on every emitter measured in the A4 sweep), so the
+// tripwire sits far past the largest measured single image, ~81.4MB (2x XDR
+// full-screen capture) — about 4x. Under the limit, eviction is ordinary.
 const kittyStorageLimitDefault = 320_000_000
 
-// kittyStorageLimit resolves the cap for a session about to be spawned. A value
-// that is not a byte count is reported and treated as absent — meaning the
-// DEFAULT, not zero: a typo in a tuning variable must not silently turn images
-// off, and a spawn that fails over a diagnostic environment variable is worse
-// than either.
+// kittyStorageLimit resolves the cap for a session about to be spawned. A
+// non-numeric value is reported and treated as absent — the DEFAULT, not zero:
+// a typo must not silently turn images off, and a spawn must not fail over it.
 func kittyStorageLimit(logf LogFunc) uint64 {
 	raw := strings.TrimSpace(os.Getenv(kittyStorageLimitEnv))
 	if raw == "" {
@@ -126,39 +86,24 @@ func kittyStorageLimit(logf LogFunc) uint64 {
 }
 
 // mintKittyEpoch draws the per-terminal-instance offset folded into every kitty
-// generation this session reports. There are exactly two folds — the placement
-// read (wireFeeder.readPlacements) and the image serve (Session.kittyImage) —
-// and they must use the same value, or a placement stops naming the blob behind
-// it and no client can correlate the two again.
+// generation this session reports. Exactly two folds — wireFeeder.readPlacements
+// and Session.kittyImage — and they must use the same value, or placements stop
+// naming the blobs behind them. Ghostty numbers stamps per process while a
+// session id outlives its worker (respawn, daemon restart, revive); the app
+// caches by (session, image id, generation), so a fresh epoch per terminal is
+// what keeps a replacement worker from reusing a cached identity.
 //
-// Ghostty numbers its stamps per process, starting over with every terminal,
-// while a session id outlives its worker: runtime_respawned replaces the worker
-// process, and so do a daemon restart and a revive. Raw, a replacement worker
-// would describe (same session, same image id, same generation) for entirely
-// different pixels — and the app caches by exactly that triple, blobs and GPU
-// textures both, so it would redraw the dead worker's image and never pull the
-// new one. A fresh epoch per terminal makes every identity minted after a
-// respawn a new cache key by construction, which is one mechanism for all three
-// lifecycles and no wire change.
-//
-// The window is [2^32, 2^52). Ceiling receipt: generations ride JSON
-// (kitty_placements, the attach snapshot, kitty_image_result) into JS Numbers,
-// which are exact only to 2^53 — the binary frame decoder drops any generation
-// past Number.MAX_SAFE_INTEGER outright (app/src/pty/binaryPtyFrame.ts). An
-// epoch below 2^52 leaves 2^52 of stamp headroom above it, and a stamp moves by
-// one per storage mutation, so nothing a person sits in front of approaches it.
-// Floor receipt: 2^32 is past any stamp a real process reaches, so an epoched
-// identity is disjoint from a raw one.
+// Window [2^32, 2^52). Ceiling receipt: generations ride JSON into JS Numbers,
+// exact only to 2^53; the binary frame decoder drops generations past
+// Number.MAX_SAFE_INTEGER (app/src/pty/binaryPtyFrame.ts). Floor receipt: 2^32
+// is past any stamp a real process reaches, so epoched and raw are disjoint.
 func mintKittyEpoch() uint64 {
 	const floor = uint64(1) << 32
 	const span = uint64(1)<<52 - floor
 	var b [8]byte
 	if _, err := rand.Read(b[:]); err != nil {
-		// Effectively unreachable — crypto/rand does not fail on a platform the
-		// worker runs on. What the fallback protects is the invariant rather
-		// than the randomness: the epoch stays inside the window and is never
-		// zero, because a zero epoch is the defect above and a spawn that fails
-		// over entropy is worse than a predictable identity.
+		// Effectively unreachable; the fallback protects the invariant (inside
+		// the window, never zero), not the randomness.
 		return floor + uint64(time.Now().UnixNano())%span
 	}
 	return floor + binary.BigEndian.Uint64(b[:])%span

--- a/internal/pty/kittyseg.go
+++ b/internal/pty/kittyseg.go
@@ -1,63 +1,20 @@
 package pty
 
-// The worker's PTY feed segmenter — the ONE place that decides where a
-// sequence begins and ends.
+// The worker's PTY feed segmenter — the ONE place that decides where a kitty
+// APC or OSC 133 marker begins and ends; meaning is read elsewhere ("observe,
+// never interpret", docs/plans/2026-08-02-terminal-kitty-images.md).
 //
-// It cuts the raw stream into three kinds of run, which differ only in how the
-// consumer disposes of them:
+// Invariant: for any input, split into any chunks, the emissions concatenate
+// back to the input byte for byte, in order — minus only a tail held for the
+// next Feed. Extraction removes bytes from one side, so it is safe only from
+// GROUND with a reached terminator: outside ground the sequence's leading ESC
+// also exits the open sequence, and taking it away silently diverges the two
+// grids. Everything else replays to both sides as plain.
 //
-//   - plain output, which goes to the terminal AND to the wire;
-//   - a complete kitty graphics APC, which goes to the TERMINAL only — ghostty
-//     is the system's only kitty parser — while the wire carries layout bytes
-//     synthesized from what ghostty did with it;
-//   - a complete OSC 133 marker, which goes to the WIRE only, where the
-//     client's own parser reads it, while the worker's terminal is kept clean
-//     and the block table gets the parsed marker instead.
-//
-// The two extractions used to live in nested segmenters, an outer one for kitty
-// and an inner byte-pattern scan for OSC 133. They are one machine now because
-// they ask the same question and only a parser can answer it (see below); two
-// answers meant two chances to be wrong, and the inner one was.
-//
-// This file is the only place in attn that knows how a kitty escape or an OSC
-// 133 marker is DELIMITED, and it knows nothing else about either protocol.
-// Kitty ids, chunked transmissions, deletes, placement geometry, z-order are
-// all read back out of ghostty's authoritative state ("observe, never
-// interpret", docs/plans/2026-08-02-terminal-kitty-images.md); a marker's
-// meaning is parsed in osc133.go, from the payload this file hands it.
-//
-// The invariant everything here serves: for any input, split into any sequence
-// of chunks, the emissions concatenate back to that input byte for byte, in
-// order — minus only a tail held for the next Feed. Every byte is accounted for
-// exactly once, and which side of the feed it lands on is the emission's kind.
-// A byte dropped, doubled, or reordered here is a silent divergence between the
-// worker grid and the client grid, which is the bug class this plan exists to
-// remove.
-//
-// Delimiting an escape is not pattern matching, which is why this file carries
-// a parser state machine. Extraction REMOVES bytes from one side of the feed,
-// so it is safe only when the removed run is a whole sequence to both parsers
-// at once. The leading ESC of a kitty APC or an OSC 133 marker does double duty
-// whenever the stream is not in ground: it also ends the OSC, string, CSI or
-// escape that was open. Taking the sequence away then takes that exit with it,
-// and one side sits inside a sequence the other has already left — the two
-// grids diverge from the next byte on, silently, with no resync to catch it.
-//
-// So the machine answers exactly one question: would ghostty's parser be in
-// ground when this ESC arrives? Extraction happens only there, and only for a
-// sequence that reaches its terminator. Everything else — a sequence opened
-// mid-sequence, one a control byte cut short, one still unterminated at the
-// tripwire — is replayed to both sides as plain, which is always safe because
-// both ends are ghostty and parse identical bytes identically.
-//
-// Every transition below was MEASURED against the native terminal rather than
-// read off the VT spec, and TestKittySegmenterGroundMatchesGhostty holds them
-// to it: for a large set of byte sequences, this machine's idea of ground must
-// equal ghostty's. ghostty's sets are not the ones the spec suggests. C1 ST
-// ends every string EXCEPT an OSC; BEL ends only an OSC; half the C1 range
-// aborts a string; a raw C1 introducer opens a sequence from escape and CSI but
-// is inert in ground, and inside a string only three of the six introduce at
-// all. Change a rule here only with a measurement to point at.
+// Every transition here was MEASURED against the native terminal, not read off
+// the VT spec — ghostty's sets differ from the spec's — and
+// TestKittySegmenterGroundMatchesGhostty holds this machine's idea of ground
+// equal to ghostty's. Change a rule only with a measurement to point at.
 
 func indexOfByte(b []byte, target byte) int {
 	for i, c := range b {
@@ -69,91 +26,57 @@ func indexOfByte(b []byte, target byte) int {
 }
 
 // kittyAPCIntroducer is ESC _ G — APC plus kitty graphics' protocol byte.
-// Ghostty identifies kitty on that G alone, with the command following
-// immediately and no separator after it (src/terminal/apc.zig), so the
-// introducer is exactly these three bytes.
+// Ghostty identifies kitty on that G alone (src/terminal/apc.zig).
 var kittyAPCIntroducer = []byte{0x1b, 0x5f, 0x47}
 
-// kittySegMaxPendingBytes bounds what one unterminated APC can make the
-// segmenter buffer. It is a tripwire, not a correctness cliff: past it the held
-// bytes are emitted as plain, so they reach the terminal and the wire alike and
-// the two grids stay consistent — the only cost is an unstripped APC on the
-// wire.
-//
-// That consistency is also why the number must sit ABOVE what ghostty accepts
-// rather than below it. Ghostty's built-in kitty APC cap is 65 MiB
-// (Protocol.defaultMaxBytes(.kitty) in src/terminal/apc.zig, at the native pin
-// ab0b9da), measured over the payload after the `;`
-// (src/terminal/kitty/graphics_command.zig); attn never overrides it, and on
-// overflow ghostty drops the whole command rather than rendering part of one.
-// 72 MiB clears that cap with room for the control section and framing, so an
-// escape long enough to trip this threshold carries a payload ghostty has
-// already refused. Reaching it at all means a broken producer: kitty's own
-// convention chunks a transmission into escapes of 4 KiB or less.
+// kittySegMaxPendingBytes bounds what one unterminated APC can buffer — a
+// tripwire, not a correctness cliff: past it the held bytes replay as plain to
+// both sides. It must sit ABOVE what ghostty accepts: ghostty's kitty APC cap
+// is 65 MiB (Protocol.defaultMaxBytes(.kitty), src/terminal/apc.zig at native
+// pin ab0b9da), over the post-`;` payload; 72 MiB clears that plus framing, so
+// tripping it means a payload ghostty already refused.
 const kittySegMaxPendingBytes = 72 * 1024 * 1024
 
-// osc133MarkerMaxPendingBytes is the same tripwire for a held OSC 133 marker,
-// and the same disposal past it: the bytes replay as plain, so both sides see
-// them and only the block event is lost.
-//
-// Receipt. The largest marker anything can legitimately emit is a C marker,
-// whose payload is a percent-encoded command line: ESC ] 133 ; C ;
-// cmdline_url= … terminator, about 22 bytes of framing around the command. A
-// command line that can actually run is bounded by ARG_MAX, measured at 1 MiB
-// on this machine (`getconf ARG_MAX` = 1048576) and lower on Linux, where
-// MAX_ARG_STRLEN caps a single string at 128 KiB. Encoding can triple a byte
-// (`%3B`), so 3 MiB is the ceiling for a command that could be executed at all
-// — and attn's own emitter is far under it, escaping only six characters
-// (shell_startup.go) and observed at 61 bytes across the recorded fish corpus.
-// 16 MiB clears the ceiling five times over. Reaching it means a producer that
-// opened a marker and never closed it.
+// osc133MarkerMaxPendingBytes is the same tripwire for a held OSC 133 marker.
+// Receipt: the largest legitimate marker is a C marker carrying a
+// percent-encoded command line; ARG_MAX measured 1 MiB here (`getconf
+// ARG_MAX` = 1048576), encoding can triple a byte, so 3 MiB is the ceiling for
+// a runnable command — attn's own emitter was observed at 61 bytes. 16 MiB
+// clears it five times over.
 const osc133MarkerMaxPendingBytes = 16 * 1024 * 1024
 
 // kittySegMode is where ghostty's parser stands after everything fed so far.
-// The segmenter tracks it to answer one question — is the stream in ground? —
-// and holds bytes only in the modes holding() names.
+// Bytes are held only in the modes holding() names.
 type kittySegMode uint8
 
 const (
 	// kittySegGround: printing. The only mode an extraction can start in.
 	kittySegGround kittySegMode = iota
-	// kittySegEscape: an ESC that cannot introduce an extractable APC, either
-	// because ESC _ G did not follow or because it arrived outside ground.
+	// kittySegEscape: an ESC that cannot introduce an extractable APC.
 	kittySegEscape
-	// kittySegEscapeIntermediate: an escape that has taken an intermediate byte
-	// (ESC ( B and friends). Measured: once one lands, the string introducers
-	// stop introducing — ESC ( ] is a complete, if meaningless, escape and the
-	// stream is back in ground, where plain ESC ] would have opened an OSC.
+	// kittySegEscapeIntermediate: an escape that has taken an intermediate byte.
+	// Measured: once one lands, the string introducers stop introducing.
 	kittySegEscapeIntermediate
 	// kittySegCSI: inside ESC [ … final.
 	kittySegCSI
 	// kittySegOSC: inside ESC ] …, which ends on its own byte set.
 	kittySegOSC
-	// kittySegOSC133Prefix: inside an OSC that opened in GROUND and still
-	// matches osc133Prefix, so it may yet turn out to be a marker. Holds its
-	// bytes — no prefix of a marker this segmenter removes may reach the
-	// terminal ahead of the removal — but only ever the five that are still
-	// undecided. The first byte that diverges drops the hold and the run
-	// carries on as an ordinary OSC, so a title write never stalls the feed.
+	// kittySegOSC133Prefix: inside an OSC opened in GROUND that still matches
+	// osc133Prefix. Holds only the undecided bytes; the first divergent byte
+	// drops the hold, so a title write never stalls the feed.
 	kittySegOSC133Prefix
 	// kittySegOSC133Body: the marker prefix matched; holding to the terminator.
 	kittySegOSC133Body
 	// kittySegOpaque: inside a DCS, SOS, PM or APC string — including a kitty
 	// APC this segmenter has decided it cannot extract.
 	kittySegOpaque
-	// kittySegKitty: inside an extractable kitty APC. The only mode whose bytes
-	// are buffered rather than emitted, because extraction needs the whole
-	// sequence in hand.
+	// kittySegKitty: inside an extractable kitty APC, buffered whole.
 	kittySegKitty
 )
 
-// c1Executed reports the C1 bytes ghostty executes as controls and returns to
-// ground from escape, CSI, and every string state.
-//
-// Measured: from escape, CSI, DCS, SOS, PM, APC and a kitty APC alike, exactly
-// 80-8f, 91-97, 99-9a and 9c drop back to ground. The four holes are the C1
-// introducers — 90 DCS, 98 SOS, 9b CSI, 9d OSC, 9e PM, 9f APC — which open a
-// sequence instead, and 9d-9f sit past this range's end.
+// c1Executed reports the C1 bytes ghostty executes as controls, returning to
+// ground from escape, CSI, and every string state. Measured: exactly 80-8f,
+// 91-97, 99-9a and 9c; the holes are the C1 introducers.
 func c1Executed(b byte) bool {
 	switch {
 	case b >= 0x80 && b <= 0x8f:
@@ -169,26 +92,16 @@ func c1Executed(b byte) bool {
 }
 
 // kittySegAborts reports the single bytes that end a string sequence short of
-// its terminator.
-//
-// Measured: CAN and SUB abort everywhere, and a string additionally ends on
-// every c1Executed byte. BEL is deliberately absent — it ends an OSC and
-// nothing else, which is why a BEL inside a kitty payload is an ordinary byte
-// and this is not the OSC scanner.
+// its terminator. Measured: CAN and SUB abort everywhere, plus every
+// c1Executed byte. BEL is deliberately absent — it ends only an OSC.
 func kittySegAborts(b byte) bool {
 	return b == 0x18 || b == 0x1a || c1Executed(b)
 }
 
 // kittySegOpensInsideString reports the sequence a raw C1 introducer opens from
-// inside an already-open DCS, PM, APC or kitty string.
-//
-// Measured, and asymmetric — this is not the same set the escape state honours.
-// 90 (DCS), 9b (CSI) and 9d (OSC) cut the open string short and introduce their
-// own: a kitty command carrying one in its control section dispatches truncated
-// at that byte, and the text after it is swallowed by the new sequence instead
-// of printing. 98 (SOS), 9e (PM) and 9f (APC) do neither — the same command
-// still parses whole around them — so inside a string they are payload. An OSC
-// honours none of the six, which is why kittySegOSC is its own mode.
+// inside an open DCS, PM, APC or kitty string. Measured, and asymmetric from
+// the escape state: 90/9b/9d cut the string short and introduce their own;
+// 98/9e/9f are payload. An OSC honours none of the six — hence its own mode.
 func kittySegOpensInsideString(b byte) (kittySegMode, bool) {
 	switch b {
 	case 0x90:
@@ -202,11 +115,8 @@ func kittySegOpensInsideString(b byte) (kittySegMode, bool) {
 }
 
 // kittySegOpensC1 reports the sequence a raw C1 introducer opens from escape or
-// CSI state, where all six introduce — measured: ESC 98 swallows what follows
-// until C1 ST and is not ended by a would-be final, so it opens a string even
-// though the same byte is payload inside one. From GROUND they open nothing at
-// all: the stream is UTF-8, so ghostty decodes them to U+FFFD and keeps
-// printing.
+// CSI state, where all six introduce (measured). From GROUND they open
+// nothing: the stream is UTF-8, so they decode to U+FFFD and print.
 func kittySegOpensC1(b byte) (kittySegMode, bool) {
 	switch b {
 	case 0x98, 0x9e, 0x9f:
@@ -215,10 +125,8 @@ func kittySegOpensC1(b byte) (kittySegMode, bool) {
 	return kittySegOpensInsideString(b)
 }
 
-// kittySegOpens7Bit reports the sequence a byte opens from escape state, the
-// only mode where the 7-bit forms introduce anything: inside a CSI or a string
-// they are ordinary finals and payload, and after an intermediate byte they
-// stop introducing entirely (see kittySegEscapeIntermediate).
+// kittySegOpens7Bit reports the sequence a byte opens from escape state — the
+// only mode where the 7-bit forms introduce anything.
 func kittySegOpens7Bit(b byte) (kittySegMode, bool) {
 	switch b {
 	case 'P', 'X', '^', '_':
@@ -237,46 +145,35 @@ type feedSegKind uint8
 const (
 	// feedSegPlain: ordinary output. To the terminal and to the wire.
 	feedSegPlain feedSegKind = iota
-	// feedSegKittyAPC: one complete kitty graphics APC, introducer through
-	// terminator. To the terminal only; the wire carries synthesized layout
-	// bytes in its place.
+	// feedSegKittyAPC: one complete kitty APC, introducer through terminator.
+	// Terminal only; the wire carries synthesized layout bytes instead.
 	feedSegKittyAPC
-	// feedSegOSC133: one complete OSC 133 marker, introducer through
-	// terminator. To the wire only; the worker's terminal never sees it and
-	// the block table takes the parsed marker instead. OSC 133 produces no
-	// cells, so keeping it off one side costs the grids nothing.
+	// feedSegOSC133: one complete OSC 133 marker. Wire only; the block table
+	// takes the parsed marker. OSC 133 produces no cells, so the grids agree.
 	feedSegOSC133
 )
 
-// feedSegment is one emission. Bytes is never empty.
-//
-// The slice is valid only for the duration of its callback: it aliases either
-// the caller's chunk or the segmenter's own buffer, both of which the next call
-// reuses. Copy anything that has to outlive the callback.
+// feedSegment is one emission. Bytes is never empty and is valid only for the
+// duration of its callback — it aliases a buffer the next call reuses.
 type feedSegment struct {
 	Kind  feedSegKind
 	Bytes []byte
 	// Marker is what a feedSegOSC133 emission means — nil for a subtype no
-	// block event is defined for, in which case the bytes are still consumed.
-	// Always nil for the other kinds.
+	// block event is defined for (bytes still consumed).
 	Marker *osc133Marker
 }
 
-// feedSegmenter splits the PTY byte stream into the three dispositions above.
-// It buffers a partial extractable sequence (or a partial introducer) across
-// Feed calls, and carries the parser mode across them.
+// feedSegmenter splits the PTY byte stream into the three dispositions above,
+// carrying a partial sequence and the parser mode across Feed calls.
 type feedSegmenter struct {
 	mode    kittySegMode
 	pending []byte
 	// resume is how far into pending the scan has already looked. Meaningful
-	// only in the modes that hold body bytes; pending in kittySegGround is a
-	// suffix that might still become an introducer and is rescanned from the
-	// front, which costs two bytes.
+	// only in holding modes.
 	resume int
 }
 
-// holding reports whether the mode is one whose bytes are buffered rather than
-// emitted, which is what an extraction needs and what a resumed scan continues.
+// holding reports whether the mode buffers its bytes rather than emitting them.
 func (m kittySegMode) holding() bool {
 	return m == kittySegKitty || m == kittySegOSC133Prefix || m == kittySegOSC133Body
 }
@@ -290,8 +187,7 @@ func (m kittySegMode) maxPending() int {
 }
 
 // abandoned is where the parser stands once a held sequence is given up on at
-// the tripwire: both ends are still inside it, with nothing here that will
-// terminate it.
+// the tripwire: both ends are still inside it.
 func (m kittySegMode) abandoned() kittySegMode {
 	if m == kittySegKitty {
 		return kittySegOpaque
@@ -301,19 +197,13 @@ func (m kittySegMode) abandoned() kittySegMode {
 
 // Feed reports the chunk as ordered emissions, in stream order.
 //
-// Fast path: a chunk holding no ESC while the stream is in ground and nothing
-// is pending produces exactly one plain emission that passes the input slice
-// through — no copy, no allocation. That is every chunk of every session that
-// prints ordinary output. Ground is part of the condition because it is the
-// only mode an ESC-free chunk cannot move: measured, every non-ESC byte keeps
-// ghostty in ground, while inside a string a bare C1 or CAN still ends it. A
-// raw C1 introducer is inert in ground — the stream is UTF-8, so 0x9d decodes
-// to U+FFFD and prints rather than opening an OSC.
+// Fast path: an ESC-free chunk in ground with nothing pending passes the input
+// slice through — no copy, no allocation. Ground is part of the condition
+// because it is the only mode an ESC-free chunk cannot move (measured).
 //
 // Cost is amortized O(len(chunk)) even while a sequence stays open across many
-// calls: the chunk is appended to the buffer in place and only the new bytes
-// are scanned. Anything proportional to the bytes already buffered turns the
-// walk to the tripwire quadratic, and the tripwire is 72 MiB.
+// calls: only new bytes are scanned, or the walk to the 72 MiB tripwire goes
+// quadratic.
 func (s *feedSegmenter) Feed(chunk []byte, emit func(feedSegment)) {
 	if s.mode == kittySegGround && len(s.pending) == 0 && indexOfByte(chunk, oscESC) < 0 {
 		if len(chunk) > 0 {
@@ -326,10 +216,7 @@ func (s *feedSegmenter) Feed(chunk []byte, emit func(feedSegment)) {
 	// holding bytes back at the end costs a copy.
 	carried := len(s.pending) > 0
 	buffer := chunk
-	// holdStart is where the extractable sequence being held began, or -1 for
-	// none. Only one can be open at a time. A sequence open from an earlier
-	// chunk begins at buffer[0] and its scan continues where the last call
-	// stopped.
+	// holdStart is where the held extractable sequence began, or -1 for none.
 	holdStart := -1
 	i := 0
 	if carried {
@@ -341,15 +228,13 @@ func (s *feedSegmenter) Feed(chunk []byte, emit func(feedSegment)) {
 		}
 	}
 
-	// emitPlain closes the run that ends where an extraction begins.
 	emitPlain := func(from, to int) {
 		if to > from {
 			emit(feedSegment{Kind: feedSegPlain, Bytes: buffer[from:to]})
 		}
 	}
 
-	// plainStart trails i: every byte the machine walks past without extracting
-	// keeps accumulating into the current plain run instead of ending it.
+	// plainStart trails i: walked-past bytes accumulate into the plain run.
 	plainStart := 0
 
 scan:
@@ -358,15 +243,12 @@ scan:
 		switch s.mode {
 		case kittySegGround:
 			if b != oscESC {
-				// Measured: in ground every byte but ESC leaves the parser in
-				// ground, C1 included.
 				i++
 				continue
 			}
-			// Deciding what this ESC introduces needs the byte after it, and for
-			// a kitty APC the one after that. Hold when they have not arrived:
-			// no prefix of a sequence this segmenter removes may reach the far
-			// side ahead of the removal.
+			// Deciding what this ESC introduces needs one byte after it, two
+			// for a kitty APC. Hold when they have not arrived: no prefix of a
+			// removed sequence may reach the far side ahead of the removal.
 			if i+1 >= len(buffer) || (buffer[i+1] == kittyAPCIntroducer[1] && i+2 >= len(buffer)) {
 				emitPlain(plainStart, i)
 				s.hold(buffer, carried, i, i)
@@ -374,9 +256,7 @@ scan:
 			}
 			switch {
 			case buffer[i+1] == ']':
-				// An OSC opened in ground is the only kind that can be a
-				// marker. Whether it IS one takes four more bytes to know, and
-				// kittySegOSC133Prefix is where that is decided.
+				// Only an OSC opened in ground can be a marker.
 				holdStart = i
 				s.mode = kittySegOSC133Prefix
 				i += 2
@@ -404,20 +284,17 @@ scan:
 			}
 			switch {
 			case b == oscESC:
-				// Measured: ESC ESC is not ground — the second ESC restarts the
-				// escape rather than completing the first, and drops whatever
-				// intermediates the first had collected.
+				// Measured: ESC ESC restarts the escape and drops collected
+				// intermediates — not ground.
 				s.mode = kittySegEscape
 			case b == 0x18 || b == 0x1a || c1Executed(b):
 				s.mode = kittySegGround
 			case b >= 0x20 && b <= 0x2f:
 				s.mode = kittySegEscapeIntermediate
 			case b >= 0x30 && b <= 0x7e:
-				// A final byte, whatever introducers apply here having been
-				// taken out of this span already. Measured: from a bare escape,
-				// 30-4f, 51-57, 59-5a, 5c and 60-7e return to ground — that
-				// span minus P X [ ] ^ _ — and after an intermediate all of
-				// 30-7e does.
+				// A final byte. Measured: from a bare escape, 30-4f, 51-57,
+				// 59-5a, 5c and 60-7e return to ground; after an intermediate
+				// all of 30-7e does.
 				s.mode = kittySegGround
 			default:
 				// C0 controls, DEL and a0-ff all leave the parser mid-escape.
@@ -427,8 +304,7 @@ scan:
 		case kittySegCSI:
 			switch {
 			case b == oscESC:
-				// Measured: an ESC cancels the CSI and starts a new escape, so
-				// what follows is executed rather than swallowed.
+				// Measured: an ESC cancels the CSI and starts a new escape.
 				s.mode = kittySegEscape
 			case b == 0x18 || b == 0x1a:
 				s.mode = kittySegGround
@@ -439,8 +315,8 @@ scan:
 					s.mode = kittySegGround
 				}
 			case b >= 0x40 && b <= 0x7e:
-				// A final byte. Unlike escape, the 7-bit letters open nothing
-				// here — measured, CSI returns to ground on all of 40-7e.
+				// A final byte. Measured: CSI returns to ground on all of
+				// 40-7e — the 7-bit letters open nothing here.
 				s.mode = kittySegGround
 			}
 			i++
@@ -451,10 +327,8 @@ scan:
 				s.mode = kittySegEscape
 			case 0x07, 0x18, 0x1a:
 				// Measured: an OSC ends on BEL, CAN and SUB and on NOTHING
-				// else. C1 ST does not end one, and a raw C1 introducer inside
-				// one is payload rather than a new sequence — both of which the
-				// opaque strings do the other way round. That is why ghostty's
-				// OSC is a mode here and not a flavour of kittySegOpaque.
+				// else — C1 ST does not end one, and a raw C1 introducer
+				// inside is payload. The opposite of the opaque strings.
 				s.mode = kittySegGround
 			}
 			i++
@@ -467,9 +341,8 @@ scan:
 				}
 				continue
 			}
-			// Not a marker. These are an ordinary OSC's bytes, which this
-			// segmenter does not touch: drop the hold so they stay in the plain
-			// run, and read this byte again as OSC payload.
+			// Not a marker: drop the hold so the bytes stay in the plain run,
+			// and read this byte again as OSC payload.
 			holdStart = -1
 			s.mode = kittySegOSC
 
@@ -496,27 +369,21 @@ scan:
 					s.mode = kittySegGround
 					continue
 				}
-				// Measured: a stray ESC makes ghostty DISPATCH the marker and
-				// open a new escape, so cutting here would in fact be framing-
-				// safe. It is still replayed as plain, because the client runs
-				// its own parser over the wire (terminalOsc133.ts) and that one
-				// knows only BEL and ST — stripping a marker it would not have
-				// recognised leaves the two block tables disagreeing about a
-				// command only one of them saw. Identical bytes to both sides
-				// costs a block boundary on a malformed stream and nothing else.
+				// Measured: a stray ESC makes ghostty DISPATCH the marker, so
+				// cutting would be framing-safe — but the client's parser
+				// (terminalOsc133.ts) knows only BEL and ST, and stripping a
+				// marker it would not recognise splits the two block tables.
 				holdStart = -1
 				s.mode = kittySegEscape
 				i++
 			case b == 0x18 || b == 0x1a:
-				// Measured: CAN and SUB also DISPATCH the marker rather than
-				// aborting it, and leave the parser in ground. Same disposal,
-				// same reason.
+				// Measured: CAN and SUB also DISPATCH the marker and leave
+				// ground. Same disposal, same reason.
 				holdStart = -1
 				s.mode = kittySegGround
 				i++
 			default:
-				// Measured: an OSC swallows everything else — C1 ST and every
-				// C1 introducer included. See kittySegOSC.
+				// Measured: an OSC swallows everything else, C1 ST included.
 				i++
 			}
 
@@ -550,17 +417,13 @@ scan:
 					continue
 				}
 				// The ESC ends the APC for ghostty and opens a new escape.
-				// Extracting now would take that exit off the wire, so the
-				// whole sequence stays in the plain run instead: this is where
-				// an abandoned APC is disposed of, by replaying its bytes to
-				// both sides unchanged.
+				// Extracting would take that exit off the wire, so the whole
+				// abandoned APC replays to both sides as plain.
 				holdStart = -1
 				s.mode = kittySegEscape
 				i++
 			case b == 0x9c:
-				// Measured: C1 ST terminates a kitty APC exactly as ESC \ does,
-				// dispatching the command — so it is cut and stripped the same
-				// way, one byte instead of two.
+				// Measured: C1 ST terminates a kitty APC exactly as ESC \ does.
 				emitPlain(plainStart, holdStart)
 				i++
 				emit(feedSegment{Kind: feedSegKittyAPC, Bytes: buffer[holdStart:i]})
@@ -568,18 +431,15 @@ scan:
 				holdStart = -1
 				s.mode = kittySegGround
 			case kittySegAborts(b):
-				// A control that ends the APC without being a terminator. The
-				// aborting byte has its own effect on the grid (IND scrolls,
-				// CAN prints nothing), which synthesis cannot observe, so the
-				// sequence is replayed as plain and both parsers cut it in the
-				// same place.
+				// The aborting byte has its own grid effect (IND scrolls) that
+				// synthesis cannot observe; replay as plain so both parsers
+				// cut in the same place.
 				holdStart = -1
 				s.mode = kittySegGround
 				i++
 			default:
 				if mode, ok := kittySegOpensInsideString(b); ok {
-					// The APC ends here too, into a sequence rather than into
-					// ground. Same disposal: replay it all as plain.
+					// The APC ends here too, into a sequence. Same disposal.
 					holdStart = -1
 					s.mode = mode
 				}
@@ -592,8 +452,7 @@ scan:
 		if len(buffer)-holdStart > s.mode.maxPending() {
 			emitPlain(plainStart, len(buffer))
 			s.release()
-			// Both parsers are now inside a sequence neither will see
-			// terminated here; the stream stays opaque until something ends it.
+			// Both parsers are now inside a sequence nothing here terminates.
 			s.mode = s.mode.abandoned()
 			return
 		}
@@ -606,12 +465,8 @@ scan:
 }
 
 // emitMarker reports one complete OSC 133 marker: raw is its FULL bytes,
-// introducer through terminator, and the payload between them is what gives it
-// meaning.
-//
-// Only the two extracting terminators may reach here — BEL, or the two bytes of
-// ST after a matched prefix — which is what makes the payload slice safe. A
-// third terminator added to kittySegOSC133Body without widening this would index
+// introducer through terminator. Only the two extracting terminators may reach
+// here — BEL, or two-byte ST — a third added without widening this would index
 // backwards past the introducer.
 func emitMarker(emit func(feedSegment), raw []byte) {
 	payloadEnd := len(raw) - 1
@@ -626,11 +481,10 @@ func emitMarker(emit func(feedSegment), raw []byte) {
 	})
 }
 
-// hold keeps buffer[from:] for the next Feed, with resumeAt the absolute index
-// the body scan should continue from (pass from itself when the bytes are not
-// an open sequence). Keeping one that already sits at the front of the buffer it
-// is growing into costs nothing, which is what makes a long transmission
-// linear.
+// hold keeps buffer[from:] for the next Feed, resumeAt being the absolute
+// index the body scan continues from (pass from when the bytes are not an open
+// sequence). Keeping one already at the front of its own growing buffer costs
+// nothing — that is what makes a long transmission linear.
 func (s *feedSegmenter) hold(buffer []byte, carried bool, from, resumeAt int) {
 	if from >= len(buffer) {
 		s.release()
@@ -643,20 +497,15 @@ func (s *feedSegmenter) hold(buffer []byte, carried bool, from, resumeAt int) {
 		s.resume = resumeAt - from
 		return
 	}
-	// Everything else held here is small: a partial introducer, a partial OSC
-	// 133 prefix, or a marker body still short of its terminator — bounded by
-	// osc133MarkerMaxPendingBytes rather than by the APC tripwire, and in
-	// practice a handful of bytes. Copying it into a fresh slice hands back
-	// whatever capacity an APC that just finished in this same call had grown
-	// to, which is the whole point of not carrying the buffer forward.
+	// Everything else held here is small; copying into a fresh slice releases
+	// whatever capacity a just-finished APC had grown to.
 	s.pending = append([]byte(nil), buffer[from:]...)
 	s.resume = resumeAt - from
 }
 
-// release drops the buffer instead of keeping its capacity for the next
-// sequence. A finished APC may have grown to megabytes, and a session that
-// once carried one would otherwise hold that memory for its whole life. The
-// parser mode is not part of what it drops: the stream keeps running.
+// release drops the buffer instead of keeping its capacity: a finished APC may
+// have grown to megabytes, held otherwise for the session's whole life. The
+// parser mode is untouched.
 func (s *feedSegmenter) release() {
 	s.pending = nil
 	s.resume = 0

--- a/internal/pty/oscscan.go
+++ b/internal/pty/oscscan.go
@@ -1,38 +1,24 @@
 package pty
 
-// A read-only OSC scanner.
-//
-// The feed segmenter in kittyseg.go cannot be reused for this: it *strips* the
-// OSC 133 markers it finds, so that the server-authoritative restore rebuilds
-// blocks from structured data rather than by re-emitting markers into the VT
-// dump — and so that the marker's own grid effect stays off the worker's
-// terminal, which matters because native ghostty breaks the line on a mid-line
-// `OSC 133;A` and the wasm build the app renders does not (see wirefeed.go).
-// OSC 0 (window title) and OSC 777
-// (desktop notification) are different — the title is real terminal state the
-// client must keep, so nothing here may alter the byte stream. This scanner only
-// looks.
-//
-// It is also deliberately not corpus-locked to the frontend parser the way the
-// 133 segmenter is: nothing on the client side parses these, so there is no
-// parity contract to hold.
+// A read-only OSC scanner. Not the feed segmenter (kittyseg.go): that one
+// STRIPS what it finds, while OSC 0 (title) and OSC 777 (notification) are
+// real terminal state the client must keep — this scanner only looks, and
+// carries no parity contract with any frontend parser.
 
-// oscScanMaxPending abandons a never-terminated sequence so a producer that
-// emits an unterminated OSC cannot make the scanner buffer forever. A window
-// title is short; anything past this is not a title.
+// oscScanMaxPending abandons a never-terminated sequence so a broken producer
+// cannot make the scanner buffer forever; anything past this is not a title.
 const oscScanMaxPending = 4096
 
 // oscScanner finds complete `ESC ] <code> ; <payload> (BEL | ESC \)` sequences
 // across chunk boundaries. It reports what it saw and consumes nothing.
 type oscScanner struct {
-	// pending holds a sequence that started in an earlier chunk and has not been
-	// terminated yet.
+	// pending holds a sequence begun in an earlier chunk, not yet terminated.
 	pending []byte
 }
 
 // Feed reports every complete OSC sequence in chunk, in order. code is the
 // numeric introducer (0, 133, 777, …) and payload is everything between the
-// first `;` and the terminator. A sequence with no `;` reports an empty payload.
+// first `;` and the terminator (empty when there is no `;`).
 func (s *oscScanner) Feed(chunk []byte, emit func(code int, payload string)) {
 	if len(s.pending) == 0 && indexOfByte(chunk, oscESC) < 0 {
 		return
@@ -52,7 +38,7 @@ func (s *oscScanner) Feed(chunk []byte, emit func(code int, payload string)) {
 	for {
 		start := indexOfOSCIntroducer(buffer, from)
 		if start < 0 {
-			// Hold back a trailing lone ESC: the `]` may arrive in the next chunk.
+			// Hold a trailing lone ESC: the `]` may arrive in the next chunk.
 			if len(buffer) > 0 && buffer[len(buffer)-1] == oscESC {
 				s.pending = []byte{oscESC}
 			}
@@ -67,14 +53,12 @@ func (s *oscScanner) Feed(chunk []byte, emit func(code int, payload string)) {
 			}
 			from = next
 		case oscScanAbandoned:
-			// A stray ESC: the producer gave up on this sequence. Resume at the
-			// ESC, which may itself introduce the next one.
+			// Resume at the stray ESC, which may introduce the next one.
 			from = next
 		default: // oscScanIncomplete
 			if len(buffer)-start > oscScanMaxPending {
-				// Unterminated and oversized: drop it rather than hold the bytes,
-				// and resume past the introducer so a later well-formed sequence
-				// in the same stream is still seen.
+				// Drop the oversized hold; resume past the introducer so a
+				// later well-formed sequence is still seen.
 				from = start + 2
 				continue
 			}
@@ -97,21 +81,17 @@ func indexOfOSCIntroducer(buffer []byte, from int) int {
 type oscScanStatus int
 
 const (
-	// oscScanIncomplete: the sequence may still be terminated by a later chunk.
+	// oscScanIncomplete: may still be terminated by a later chunk.
 	oscScanIncomplete oscScanStatus = iota
 	// oscScanTerminated: a complete sequence.
 	oscScanTerminated
-	// oscScanAbandoned: a stray ESC that does not start ST. An OSC cannot contain
-	// one, so the producer gave up on this sequence — and waiting for a
-	// terminator that will never come would hide every later sequence in the
-	// stream.
+	// oscScanAbandoned: a stray ESC not starting ST — the producer gave up;
+	// waiting for a terminator that never comes would hide later sequences.
 	oscScanAbandoned
 )
 
-// scanOSCBody returns the bytes between the introducer and the terminator. For
-// oscScanTerminated, next is the index just past the terminator; for
-// oscScanAbandoned it is where to resume scanning (the stray ESC itself, which
-// may introduce the next sequence).
+// scanOSCBody returns the bytes between the introducer and the terminator;
+// next is just past the terminator, or the stray ESC to resume at (abandoned).
 func scanOSCBody(buffer []byte, from int) ([]byte, int, oscScanStatus) {
 	for i := from; i < len(buffer); i++ {
 		switch buffer[i] {
@@ -131,7 +111,7 @@ func scanOSCBody(buffer []byte, from int) ([]byte, int, oscScanStatus) {
 }
 
 // splitOSCBody parses `<digits>;<payload>` (or a bare `<digits>`). ok is false
-// for a body whose introducer is not numeric, which is not an OSC we can route.
+// for a non-numeric introducer, which is not an OSC we can route.
 func splitOSCBody(body []byte) (int, string, bool) {
 	code := 0
 	digits := 0

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -19,7 +19,7 @@ import (
 )
 
 // TerminalTheme carries the frontend's resolved terminal colors as "#rrggbb"
-// hex strings. Zero-value fields fall back to built-in dark defaults.
+// hex strings; zero-value fields fall back to built-in dark defaults.
 type TerminalTheme struct {
 	Foreground  string
 	Background  string
@@ -27,57 +27,42 @@ type TerminalTheme struct {
 	ANSIPalette [16]string
 }
 
-// Default OSC 10/11/12 colors, used for any TerminalTheme field that is empty
-// or fails hex validation. These match the frontend's built-in dark theme.
+// Default OSC 10/11/12 colors, matching the frontend's built-in dark theme.
 const (
 	defaultThemeForeground = "#d4d4d4"
 	defaultThemeBackground = "#1e1e1e"
 	defaultThemeCursor     = "#d4d4d4"
 )
 
-// infoSnapshotHook is a test-only seam invoked inside info() after the ghostty
-// snapshot is serialized but before the attach sequence watermark (LastSeq) is
-// read. It is nil in production. Tests set it to inject PTY writes into that
-// window to deterministically reproduce the snapshot/watermark consistency race.
+// infoSnapshotHook is a test-only seam fired inside info() between the ghostty
+// serialize and the LastSeq read. nil in production.
 var infoSnapshotHook func()
 
-// readLoopSeqGapHook is a test-only seam invoked in the read loop after a
-// chunk's sequence number is allocated but before the chunk is applied to
-// replay/screen state under replayMu. It is nil in production. Tests set it
-// to take snapshots inside that gap and deterministically verify the
-// snapshot's watermark never claims chunks its screen does not contain.
+// readLoopSeqGapHook is a test-only seam fired after a chunk's seq is
+// allocated but before the chunk is applied under replayMu. nil in production.
 var readLoopSeqGapHook func()
 
 type sessionSubscriber struct {
 	id     string
 	send   func(data []byte, seq uint32) bool
 	onDrop func(reason string)
-	// onPlacements receives the kitty placement set whenever a chunk moved it,
-	// interleaved with this subscriber's own byte stream. nil for subscribers
-	// that do not draw (the debug capture, the orphan-activity probe) and for
-	// every subscriber of a session that never stores an image. See OnPlacements.
+	// onPlacements receives the kitty placement set whenever a chunk moved it;
+	// nil for subscribers that do not draw. See OnPlacements.
 	onPlacements func(update PlacementUpdate)
 }
 
 type terminalQueries struct {
 	da1 bool
 	cpr bool
-	// osc10/osc11/osc12 count OCCURRENCES in the chunk, not presence — a chunk
-	// containing three OSC 11 queries (e.g. a TUI probing color support) must
-	// get three replies, or the caller under-answers and the program hangs
-	// waiting for a reply that already went out for an earlier query. Derived
-	// from oscQueryOrder below.
+	// osc10/osc11/osc12 count OCCURRENCES, not presence: each query needs its
+	// own reply or the program hangs. Derived from oscQueryOrder.
 	osc10 int
 	osc11 int
 	osc12 int
-	// oscQueryOrder lists the OSC color codes (10/11/12) queried in this
-	// chunk in the order they appeared. Real terminals answer OSC queries in
-	// ask order, and a client that writes a burst of mixed OSC10/11/12
-	// queries and pairs replies positionally depends on that order — a
-	// fixed-order reply (e.g. all OSC10 first) would mispair against it.
+	// oscQueryOrder lists the OSC color codes (10/11/12) queried, in ask order
+	// — clients that pair replies positionally depend on it.
 	oscQueryOrder []int
-	// da1BeforeCPR records that the chunk asked DA1 before CPR. Query-driven
-	// programs read replies sequentially, so the daemon answers in ask order.
+	// da1BeforeCPR records that the chunk asked DA1 before CPR.
 	da1BeforeCPR bool
 }
 
@@ -89,48 +74,32 @@ type Session struct {
 	metaMu sync.RWMutex
 	cols   uint16
 	rows   uint16
-	// Cell size in device pixels, derived from the total pane pixels a client
-	// last reported. Zero until some client reports geometry — a session spawns
-	// pixel-less and stays that way until the first fit. It is the cell size
-	// rather than the total that is remembered, because the total only means
-	// anything paired with the grid it was measured at: a later pixel-less
-	// resize re-derives its total from these.
+	// Cell size in device pixels; zero until the first fit. The cell is
+	// remembered rather than the total so a pixel-less resize can re-derive
+	// its total.
 	cellW uint16
 	cellH uint16
 
 	ptmx *os.File
 	cmd  *exec.Cmd
-	// cleanup removes spawn-time resources that must outlive shell startup,
-	// such as an isolated startup-file overlay for an interactive shell pane.
+	// cleanup removes spawn-time resources that must outlive shell startup.
 	cleanup func()
 
-	// ghostty is the server-authoritative parsed terminal (libghostty-vt). It
-	// backs approval-state detection, CPR replies, the grid/automation screen
-	// snapshot (Manager.Snapshot), and attach restore (see info()). It answers
-	// query responses during Write; the read loop forwards the responses the
-	// scan-based responder does not cover (e.g. kitty CSI ? u) so the worker is
-	// the complete query answerer and a snapshot-restored client can suppress
-	// every response.
+	// ghostty is the server-authoritative parsed terminal (libghostty-vt):
+	// approval detection, query replies, screen snapshots, attach restore.
 	ghostty *ghosttyvt.Terminal
-	// wireFeed owns writes into ghostty: it splits kitty APCs out of the
-	// stream, runs everything else through the OSC 133 scanner that maintains
-	// the worker-side command-block table (Phase 3a), and returns the bytes the
-	// wire carries in place of what it fed. nil exactly when ghostty is nil;
-	// every use is nil-guarded like ghostty's.
+	// wireFeed owns writes into ghostty and returns the bytes the wire carries
+	// instead. nil exactly when ghostty is nil; every use is nil-guarded.
 	wireFeed *wireFeeder
-	// kittyEpoch is the offset folded into every kitty generation that leaves
-	// this session, so a worker that replaces another under the same session id
-	// can never mint an identity a client already holds pixels for. Set where
-	// ghostty is constructed and never after; wireFeed holds the same value for
-	// the placement half, this field serves the image half (kittyImage). See
-	// mintKittyEpoch.
+	// kittyEpoch is the offset folded into every kitty generation this session
+	// reports; wireFeed holds the same value for the placement half, this
+	// field serves kittyImage. Set at construction. See mintKittyEpoch.
 	kittyEpoch uint64
 	seqCounter atomic.Uint32
 
-	// replayMu makes Ghostty feeds and lastReplaySeq atomic for snapshots, so a
-	// re-attaching frontend never drops a chunk that landed between the payload
-	// snapshot and the watermark read. Held briefly around each feed and around
-	// snapshot serialization; fanOut stays outside it.
+	// replayMu makes Ghostty feeds and lastReplaySeq atomic for snapshots, so
+	// a re-attaching frontend never drops a chunk that landed between the
+	// payload snapshot and the watermark read. fanOut stays outside it.
 	replayMu      sync.Mutex
 	lastReplaySeq uint32
 
@@ -138,34 +107,25 @@ type Session struct {
 	subscribers map[string]*sessionSubscriber
 
 	// writeMu guards every ptmx access that is not a Read: writes, the resize
-	// ioctl, and the close itself. os.File tolerates Read racing Close, but
-	// Fd() (which the resize ioctl needs) does not — it reads the descriptor
-	// while Close is destroying it. ptmxClosed makes the ordering explicit so a
-	// late resize or query reply becomes a no-op instead of touching a dead fd.
+	// ioctl, and the close — Fd() must not race Close. ptmxClosed makes a late
+	// caller a no-op instead of a use of a dead fd.
 	writeMu    sync.Mutex
 	ptmxClosed bool
 
-	// themeMu guards theme, which seeds OSC 10/11/12 (fg/bg/cursor color)
-	// replies. Set at spawn (SpawnOptions.Theme) and updated live via SetTheme;
-	// read from the read loop on every OSC color query.
+	// themeMu guards theme, which seeds OSC 10/11/12 replies.
 	themeMu sync.RWMutex
 	theme   TerminalTheme
 
-	// harnessSignals reads the agent's own OSC state signals off the PTY stream.
-	// Read-only: it never alters the bytes.
+	// harnessSignals and shellSignals read state signals off the RAW stream;
+	// neither alters the bytes. shellSignals is nil for non-shell agents.
 	harnessSignals *harnessSignalObserver
-	// shellSignals merges the foreground poll and the OSC 133 marker stream
-	// into one heartbeat claim for shell panes; nil for every other agent.
-	// Read-only on the stream: it never alters the bytes.
-	shellSignals *shellSignalArbiter
-	onState      func(obs Observation)
+	shellSignals   *shellSignalArbiter
+	onState        func(obs Observation)
 
-	// lastSignal is the most recent observation either observer emitted, kept so
-	// the level can be *read* rather than only heard as it goes past. A level says
-	// "this is still true", and a daemon that was not running when it was painted
-	// has no other way to learn it: an agent parked at its prompt writes nothing to
-	// the PTY, so a daemon restart would otherwise leave it with no evidence at all
-	// until the user typed. Written by both emitters, read from the info RPC.
+	// lastSignal is the most recent observation either observer emitted, kept
+	// so a restarted daemon can READ the level: an agent parked at its prompt
+	// writes nothing, so there would otherwise be no evidence until the user
+	// typed. Written by both emitters, read from the info RPC.
 	lastSignalMu sync.RWMutex
 	lastSignal   *Observation
 
@@ -236,14 +196,9 @@ func (s *Session) fanOut(data []byte, seq uint32) {
 }
 
 // fanOutPlacements hands one placement update to every subscriber that asked
-// for placements.
-//
-// Called from the read loop AFTER the chunk's bytes are fanned out, and with
-// replayMu released. The order is the contract: an update states where images
-// sit on the grid THOSE bytes produce, so a client that applied it first would
-// draw them against a screen it has not scrolled yet. The set itself was
-// captured inside the same critical section that stamped the seq, so what is
-// delivered here cannot have moved since.
+// for placements. Called AFTER the chunk's bytes are fanned out and with
+// replayMu released: an update states where images sit on the grid THOSE bytes
+// produce, so it must not arrive first.
 func (s *Session) fanOutPlacements(update PlacementUpdate) {
 	s.subMu.RLock()
 	var subs []*sessionSubscriber
@@ -259,15 +214,11 @@ func (s *Session) fanOutPlacements(update PlacementUpdate) {
 	}
 }
 
-// forceResync drops every subscriber with reason, which reaches each client as
-// a pty_desync: the frontend resets its terminal and immediately re-attaches,
-// and that attach serves a fresh server-authoritative snapshot. It is the same
-// round trip an overflowing client buffer already takes, reused as the escape
-// hatch for a chunk whose grid effect the wire could not express (wireFeeder) —
-// re-syncing by construction beats guessing at bytes.
-//
-// Must be called with replayMu released; the subscriber callbacks take their
-// own locks, exactly like fanOut.
+// forceResync drops every subscriber with reason, reaching each client as a
+// pty_desync: the frontend resets and re-attaches for a fresh snapshot — the
+// escape hatch for a chunk whose grid effect the wire could not express
+// (wireFeeder). Call with replayMu released; the callbacks take their own
+// locks.
 func (s *Session) forceResync(reason string) {
 	s.subMu.Lock()
 	subs := make([]*sessionSubscriber, 0, len(s.subscribers))
@@ -284,14 +235,11 @@ func (s *Session) forceResync(reason string) {
 	}
 }
 
-// PTY reads are coalesced before fan-out so sustained output (builds, logs,
-// `seq`-style floods) produces few large downstream messages instead of one
-// per read. macOS pty reads return tiny chunks under load (~100 bytes, the
-// tty queue's pacing), and every message costs real memory in the WebKit
-// frontend regardless of size — message count, not byte volume, is what
-// balloons the app during heavy output. Interactive traffic must not pay for
-// this: a read with nothing queued behind it is emitted immediately, so echo
-// latency is unchanged, and a flood batch is bounded by ptyCoalesceWindow.
+// PTY reads are coalesced before fan-out: macOS pty reads return tiny chunks
+// under load (~100 bytes), and MESSAGE COUNT, not byte volume, balloons the
+// WebKit frontend. A read with nothing queued behind it is emitted
+// immediately — echo latency unchanged; a flood batch is bounded by
+// ptyCoalesceWindow.
 const (
 	ptyReadBufBytes     = 16 * 1024
 	ptyCoalesceMaxBytes = 256 * 1024
@@ -304,11 +252,8 @@ type ptyRead struct {
 }
 
 // nextCoalescedRead returns the next batch of PTY output, blocking for the
-// first read. If no further read is already queued the first one is returned
-// as-is — the interactive path adds zero latency. A queued read means the
-// producer is outpacing the pipeline, so reads are folded in until the batch
-// reaches maxBytes or the window elapses. The returned error belongs to the
-// last read folded into the batch; callers must not receive again after it.
+// first read; with no further read queued it is returned as-is. The returned
+// error belongs to the last read folded in; callers must not receive after it.
 func nextCoalescedRead(reads <-chan ptyRead, maxBytes int, window time.Duration) ([]byte, error) {
 	first := <-reads
 	if first.err != nil {
@@ -383,13 +328,9 @@ func (s *Session) readLoop(onExit func(exitCode int, signal string), logf func(s
 				data := chunk[:boundary]
 				queries := detectTerminalQueries(data)
 
-				// The worker is the single, always-on responder for CPR, DA1, and
-				// OSC 10/11/12 — race-free regardless of frontend attach/replay
-				// timing, and unaffected by whether an interactive subscriber is
-				// attached. CPR and DA1 are answered below from the screen model
-				// / a static capability string (AGENTS.md pattern #7). OSC 10/11/12
-				// (fg/bg/cursor color) are answered here from the daemon-pushed
-				// theme (see SetTheme); the frontend does not answer any of these.
+				// The worker is the single, always-on responder for CPR, DA1,
+				// and OSC 10/11/12 — race-free regardless of frontend
+				// attach/replay timing; the frontend answers none of these.
 				if len(queries.oscQueryOrder) > 0 {
 					s.writeOSCColorResponses(queries, logf)
 				}
@@ -403,34 +344,20 @@ func (s *Session) readLoop(onExit func(exitCode int, signal string), logf func(s
 				placementsMoved := false
 				s.replayMu.Lock()
 				if s.wireFeed != nil {
-					// Feed the server-authoritative terminal under the same lock
-					// as the seq watermark so a snapshot stays atomic with it.
-					// The feeder pins block positions at OSC 133 markers and
-					// hands back the wire bytes for this chunk, which differ
-					// from the raw ones only when it extracted a kitty APC.
+					// Feed under the same lock as the seq watermark so a
+					// snapshot stays atomic with it; the placement set read in
+					// the same hold is tied to these bytes by the seq.
 					wire, resync = s.wireFeed.feed(data)
-					// Read the placement set in the same hold: it was measured on
-					// the grid this chunk produced, and the seq below is what ties
-					// it to those bytes for the client.
 					placements, placementsMoved = s.wireFeed.changedPlacements()
 				}
 				s.lastReplaySeq = seq
 				s.replayMu.Unlock()
 				// Drain ghostty's query responses AFTER the lock (the sink has
-				// its own mutex) and forward the responses the scanner does not
-				// cover (kitty CSI ? u, etc.) so the worker answers every query
-				// and a snapshot-restored client can suppress all of them.
+				// its own mutex).
 				s.drainGhosttyResponses(logf)
-				// The daemon is the single authority for CPR (cursor position)
-				// and DA1 (device attributes) replies. Answer after the chunk is
-				// applied so the reported cursor is current, and reply in the
-				// order the chunk asked (fish sends ESC[6n ESC[0c, but other
-				// programs may ask DA1 first and read replies sequentially). fish
-				// blocks its prompt redraw on the resize-triggered CPR+DA1 until it
-				// gets both; routing them through the daemon makes the replies
-				// race-free regardless of frontend attach/replay timing (the
-				// frontend no longer answers either). See writeCursorPositionResponse
-				// and writeDeviceAttributesResponse.
+				// Answer CPR/DA1 after the chunk is applied so the reported
+				// cursor is current, in ask order — fish sends ESC[6n ESC[0c
+				// and blocks its prompt redraw until it gets both.
 				if queries.da1BeforeCPR {
 					s.writeDeviceAttributesResponse(logf)
 					s.writeCursorPositionResponse(logf)
@@ -443,13 +370,12 @@ func (s *Session) readLoop(onExit func(exitCode int, signal string), logf func(s
 					}
 				}
 				// An empty wire chunk means the feeder is holding an
-				// unterminated escape: there is nothing for this seq to carry,
-				// and downstream dedup is `seq > last_seq`, which does not
-				// require the numbers to be dense.
+				// unterminated escape; dedup (`seq > last_seq`) tolerates the
+				// missing seq.
 				if len(wire) > 0 {
 					s.fanOut(wire, seq)
 				}
-				// After the bytes, never before them: the set describes the grid
+				// After the bytes, never before: the set describes the grid
 				// they produce.
 				if placementsMoved {
 					s.fanOutPlacements(PlacementUpdate{Seq: seq, Placements: placements})
@@ -460,9 +386,7 @@ func (s *Session) readLoop(onExit func(exitCode int, signal string), logf func(s
 					}
 					s.forceResync(resync)
 				}
-				// The signal observers read the RAW chunk, not the wire: they
-				// look for the agent's own OSC state signals, which the feeder
-				// never touches.
+				// The signal observers read the RAW chunk, not the wire.
 				if s.harnessSignals != nil && s.onState != nil {
 					for _, obs := range s.harnessSignals.Observe(data, time.Now()) {
 						s.emitSignal(obs)
@@ -521,17 +445,14 @@ func (s *Session) readLoop(onExit func(exitCode int, signal string), logf func(s
 	}
 }
 
-// attachSnapshotEnv gates server-authoritative snapshot attach. When set to "1"
-// the daemon serves a ghostty-serialized snapshot on attach and the worker
 // drainGhosttyResponses clears the ghostty terminal's accumulated query
-// responses and forwards the responses the scan-based responder does not cover
-// (kitty CSI ? u and any other non-CPR/DA1/OSC-color reports) to the PTY, so the
-// worker answers every query and a snapshot-restored client can suppress all
-// responses. Must be called after replayMu is released; the sink has its own lock.
+// responses and forwards the ones the scan-based responder does not cover
+// (kitty CSI ? u, etc.) to the PTY, so the worker answers every query and a
+// snapshot-restored client can suppress all responses. Call after replayMu is
+// released; the sink has its own lock.
 func (s *Session) drainGhosttyResponses(logf func(string, ...interface{})) {
 	// The nil check and the drain are one critical section: teardown nils the
-	// field under replayMu, so checking outside the lock would let a freed
-	// terminal be drained.
+	// field under replayMu, so checking outside would drain a freed terminal.
 	s.replayMu.Lock()
 	var drained []byte
 	if s.ghostty != nil {
@@ -553,12 +474,10 @@ func (s *Session) drainGhosttyResponses(logf func(string, ...interface{})) {
 	}
 }
 
-// stripScannerOwnedResponses removes, from a ghostty query-response stream, the
-// response classes the scan-based responder already emits — CPR (CSI … R), DA
-// (CSI … c), and OSC 10/11/12 color reports — so forwarding the remainder never
-// double-answers a query the scanner handles. Kitty keyboard reports (CSI ? … u),
-// DECRQM reports (CSI ? … $ y), and anything else are kept. Unrecognized bytes
-// are preserved so a partial/interleaved stream is never silently dropped.
+// stripScannerOwnedResponses removes the response classes the scan-based
+// responder already emits — CPR (CSI … R), DA (CSI … c), OSC 10/11/12 color
+// reports — so forwarding the remainder never double-answers. Unrecognized
+// bytes are preserved so a partial stream is never silently dropped.
 func stripScannerOwnedResponses(resp []byte) []byte {
 	out := make([]byte, 0, len(resp))
 	for i := 0; i < len(resp); {
@@ -580,8 +499,7 @@ func stripScannerOwnedResponses(resp []byte) []byte {
 			}
 			final := resp[j]
 			seq := resp[i : j+1]
-			// CPR (R) and DA (c) are the scanner's; drop them. Everything else
-			// (kitty u, DECRQM $y, …) is a gap the scanner misses — keep it.
+			// CPR (R) and DA (c) are the scanner's; keep the rest.
 			if final != 'R' && final != 'c' {
 				out = append(out, seq...)
 			}
@@ -600,7 +518,6 @@ func stripScannerOwnedResponses(resp []byte) []byte {
 				j++
 			}
 			seq := resp[i:j]
-			// OSC 10/11/12 color reports are the scanner's; drop them.
 			if !isOSCColorReport(seq) {
 				out = append(out, seq...)
 			}
@@ -614,7 +531,7 @@ func stripScannerOwnedResponses(resp []byte) []byte {
 }
 
 // isOSCColorReport reports whether an OSC sequence is a 10/11/12 color report
-// (ESC ] 1{0,1,2} ;). It matches the codes the scan-based responder answers.
+// (ESC ] 1{0,1,2} ;) — the codes the scan-based responder answers.
 func isOSCColorReport(seq []byte) bool {
 	const prefixLen = 5 // ESC ] 1 X ;
 	if len(seq) < prefixLen || seq[0] != 0x1b || seq[1] != ']' || seq[2] != '1' {
@@ -645,9 +562,8 @@ func parseExitStatus(waitErr error) (int, string) {
 }
 
 // emitSignal is the single exit for both signal observers: it remembers the
-// observation before handing it on, so the level survives in a readable form as
-// well as travelling as an event. Both callers run on their own goroutine (the
-// read loop, the shell foreground poller), which is why the field is guarded.
+// observation before handing it on. Both callers run on their own goroutine,
+// hence the guard.
 func (s *Session) emitSignal(obs Observation) {
 	s.lastSignalMu.Lock()
 	stored := obs
@@ -656,9 +572,8 @@ func (s *Session) emitSignal(obs Observation) {
 	s.onState(obs)
 }
 
-// LastSignal is the most recent level either observer emitted, and false when
-// the session has not produced one. It is what a reconnecting daemon reads to
-// recover evidence it was not running to hear.
+// LastSignal is the most recent level either observer emitted, false when none
+// — what a reconnecting daemon reads to recover evidence it missed.
 func (s *Session) LastSignal() (Observation, bool) {
 	s.lastSignalMu.RLock()
 	defer s.lastSignalMu.RUnlock()
@@ -708,29 +623,20 @@ func (s *Session) info() AttachInfo {
 		pid = s.cmd.Process.Pid
 	}
 
-	// Serialize the server-authoritative ghostty terminal and read the sequence
-	// watermark atomically, so a re-attaching frontend can dedup the live stream
-	// against LastSeq without a hole: every byte in the dump has seq <= LastSeq,
-	// and a live chunk it will apply has seq > LastSeq. Without this atomicity a
-	// chunk written between the serialize and the watermark read is in neither —
-	// lost. Supported-platform sessions always have a Ghostty terminal; the
-	// unsupported-platform buildability stub serializes no dump.
+	// Serialize the ghostty terminal and read the watermark atomically: every
+	// byte in the dump has seq <= LastSeq, every live chunk to apply has
+	// seq > LastSeq. Without this a chunk written between the two is lost.
 	s.replayMu.Lock()
 	var ghosttySnapshot []byte
-	// libghostty-vt does not surface a scrollback-truncation flag (the vestigial
-	// ghosttyvt.Snapshot.ScrollbackTruncated was removed in Phase 3a as always
-	// false), so the signal is reported false until the native serializer exposes
-	// one. The field is still plumbed for that future and for observability.
+	// libghostty-vt surfaces no scrollback-truncation flag yet; reported false
+	// until the native serializer exposes one.
 	var ghosttyTruncated bool
 	if s.ghostty != nil {
 		snapshot := s.ghostty.Serialize()
 		ghosttySnapshot = snapshot.VTDump
 	}
-	// Resolve command blocks and kitty placements inside the SAME hold as the
-	// dump and watermark: the attach snapshot is an atomic {dump, blocks,
-	// placements, watermark} quadruple, so a block row and an image position
-	// always index the dump they shipped with (Phase 3a contract, extended by
-	// the kitty phase).
+	// Blocks and placements resolve inside the SAME hold: the attach snapshot
+	// is an atomic {dump, blocks, placements, watermark} quadruple.
 	var ghosttyBlocks []AttachBlockData
 	var ghosttyPlacements []KittyPlacement
 	if s.wireFeed != nil {
@@ -740,16 +646,12 @@ func (s *Session) info() AttachInfo {
 	replayWatermark := s.lastReplaySeq
 	s.replayMu.Unlock()
 
-	// Test seam: drives a PTY write into the post-snapshot window to expose the
-	// race on unfixed code. Fired after the unlock so it never deadlocks the
-	// read loop. nil (zero overhead) in production.
+	// Test seam; fired after the unlock so it never deadlocks the read loop.
 	if infoSnapshotHook != nil {
 		infoSnapshotHook()
 	}
 
-	// LastSeq is the dedup boundary: it names the last chunk covered by this
-	// snapshot, so the frontend applies live chunks with seq > LastSeq and
-	// drops the rest as already-replayed. screenSnapshot() reports the same
+	// LastSeq is the dedup boundary. screenSnapshot() reports the same
 	// covered-chunk semantics; the two must not diverge or the first live
 	// chunk after an attach is silently lost (or double-applied).
 	return AttachInfo{
@@ -767,12 +669,9 @@ func (s *Session) info() AttachInfo {
 	}
 }
 
-// kittyImage copies one stored image out of the session's terminal.
-//
-// Under replayMu like every other terminal read: teardown nils the terminal
-// under that lock, so an unlocked check-then-use could copy out of a freed
-// handle. A session with no terminal, and an id the storage does not hold, give
-// the same ordinary answer — ErrKittyImageNotFound naming the id.
+// kittyImage copies one stored image out of the session's terminal. Under
+// replayMu like every terminal read: teardown nils the terminal under that
+// lock. No terminal and an unknown id give the same ordinary answer.
 func (s *Session) kittyImage(imageID uint32) (KittyImage, error) {
 	s.replayMu.Lock()
 	defer s.replayMu.Unlock()
@@ -783,29 +682,20 @@ func (s *Session) kittyImage(imageID uint32) (KittyImage, error) {
 	if !ok {
 		return KittyImage{}, fmt.Errorf("%w: image %d", ErrKittyImageNotFound, imageID)
 	}
-	// The second and last fold of the session's epoch (the placement read is the
-	// other). A client asks for pixels because a placement named a generation it
-	// has none for, and it stores what comes back under the generation the
-	// answer carries — so the two halves have to speak the same numbering or the
-	// pull repeats forever. See mintKittyEpoch.
+	// The second and last fold of the epoch (readPlacements is the other): the
+	// two halves must speak the same numbering or the pull repeats forever.
 	img.Generation += s.kittyEpoch
 	return img, nil
 }
 
 // screenSnapshot is a lean, read-only ghostty viewport serialization plus the
-// sequence watermark. Its styled VT stream replays into a fresh Ghostty model;
-// unlike info() it omits scrollback and replay history, so it is cheap enough to
-// call for many sessions at once (e.g. seeding every grid tile). It registers no
-// subscriber and claims no geometry.
+// sequence watermark — no scrollback or replay history, cheap enough for many
+// sessions at once; no subscriber, no geometry claim.
 //
-// The viewport and its watermark are captured atomically under replayMu — the
-// same critical section the read loop uses to apply a chunk and advance
-// lastReplaySeq — so LastSeq names exactly the last chunk baked into this
-// snapshot, matching info()/Attach semantics (the two must not diverge).
-// seqCounter would be wrong here: the read loop increments it BEFORE applying
-// the chunk, so a snapshot landing in that gap would claim to cover bytes the
-// screen does not contain, and an observer deduping the live stream against
-// LastSeq would silently drop the chunk carrying them.
+// Captured under replayMu so LastSeq names exactly the last chunk baked in,
+// matching info()/Attach semantics. seqCounter would be wrong here: the read
+// loop increments it BEFORE applying the chunk, so a snapshot in that gap
+// would claim bytes the screen does not contain.
 func (s *Session) screenSnapshot() SnapshotInfo {
 	s.metaMu.RLock()
 	cols := s.cols
@@ -856,14 +746,12 @@ func (s *Session) input(data []byte) error {
 }
 
 // resize applies a client's geometry to the grid, the worker terminal and the
-// kernel's winsize. xpixel/ypixel are the pane's TOTAL size in device pixels;
-// zero means the client has no pixel geometry, and the session then reports the
-// totals its remembered cell size implies rather than reporting zeros — an
-// attach-time reconcile must not blank out what a fit already measured.
+// kernel's winsize. xpixel/ypixel are the pane's TOTAL device pixels; zero
+// means no pixel geometry, and the session then reports the totals its
+// remembered cell size implies — an attach-time reconcile must not blank out
+// what a fit already measured.
 func (s *Session) resize(cols, rows, xpixel, ypixel uint16) error {
-	// The pane total is what a client can measure, but the cell is what an
-	// emitter and the terminal's own size reports are built from, so the
-	// derivation happens once, here, and everything downstream speaks cells.
+	// The cell is derived once, here; everything downstream speaks cells.
 	cellW, cellH := uint16(0), uint16(0)
 	if xpixel > 0 && ypixel > 0 && cols > 0 && rows > 0 {
 		cellW, cellH = xpixel/cols, ypixel/rows
@@ -880,14 +768,11 @@ func (s *Session) resize(cols, rows, xpixel, ypixel uint16) error {
 		}
 	}
 	s.metaMu.Unlock()
-	// The resize mutates the same terminal info() serializes and the block feed
-	// resolves rows against, so it belongs in that critical section.
-	//
-	// No-reflow, because every client frame is: the app's fit and its replay
-	// both resize with DEC wraparound off (app/src/utils/ghosttyResize.ts), so a
-	// reflowing worker would re-wrap history the clients keep unwrapped and the
-	// same bytes would occupy different rows on the two grids. Every row-indexed
-	// mapping across the wire — placements above all — rides on them being equal.
+	// The resize mutates the same terminal info() serializes, so it belongs in
+	// that critical section. No-reflow because every client frame is: the
+	// app's fit and replay resize with DEC wraparound off
+	// (app/src/utils/ghosttyResize.ts), and every row-indexed mapping across
+	// the wire — placements above all — rides on the grids being equal.
 	s.replayMu.Lock()
 	if s.ghostty != nil {
 		// Before the grid resize so the terminal never answers a size report
@@ -898,10 +783,8 @@ func (s *Session) resize(cols, rows, xpixel, ypixel uint16) error {
 		s.ghostty.ResizeNoReflow(int(cols), int(rows))
 	}
 	// A resize moves images without producing a byte of output, so no chunk
-	// carries the correction and the client cannot derive it: it never saw the
-	// placements move. Deferring to "the next chunk" fails exactly when no next
-	// chunk comes, which is the common case — a resize on an idle session leaves
-	// every image drawn where the old grid put it until something types.
+	// carries the correction; deferring to "the next chunk" fails on an idle
+	// session, the common case.
 	var placements []KittyPlacement
 	placementsHeld := false
 	if s.wireFeed != nil {
@@ -910,13 +793,9 @@ func (s *Session) resize(cols, rows, xpixel, ypixel uint16) error {
 	seq := s.lastReplaySeq
 	s.replayMu.Unlock()
 
-	// Stamped with the replay watermark rather than a fresh seq: no bytes were
-	// produced, so the set describes the grid as of the last chunk the client
-	// has. That makes a resize emission raceable against a concurrent chunk's
-	// emission at an equal or lower seq, and the resolution is the ordering rule
-	// clients apply — a set is taken when its seq is >= the last one applied.
-	// Because every emission carries the WHOLE set, any interleaving that drops
-	// one is healed by the next, and the loser is never a partial update.
+	// Stamped with the replay watermark, not a fresh seq: no bytes were
+	// produced. Clients take a set whose seq is >= the last applied, and every
+	// emission carries the WHOLE set, so any dropped one is healed by the next.
 	if placementsHeld {
 		s.fanOutPlacements(PlacementUpdate{Seq: seq, Placements: placements})
 	}
@@ -927,14 +806,13 @@ func (s *Session) resize(cols, rows, xpixel, ypixel uint16) error {
 	if s.ptmxClosed {
 		return nil
 	}
-	// X/Y are ws_xpixel/ws_ypixel: the pane's total pixel size, which is what an
-	// image emitter reads through TIOCGWINSZ to decide how large to draw.
+	// X/Y are ws_xpixel/ws_ypixel: the pane's total pixel size, which an image
+	// emitter reads through TIOCGWINSZ to decide how large to draw.
 	return creackpty.Setsize(s.ptmx, &creackpty.Winsize{Cols: cols, Rows: rows, X: xpixel, Y: ypixel})
 }
 
 // closePTMX closes the pty exactly once, shutting out the writers and the
-// resize ioctl that share writeMu. Both the read loop's deferred cleanup and
-// closePTY funnel through here.
+// resize ioctl that share writeMu.
 func (s *Session) closePTMX() {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
@@ -946,9 +824,8 @@ func (s *Session) closePTMX() {
 }
 
 // sigtermToHUPGrace is how long kill waits for a SIGTERM'd child before
-// escalating to SIGHUP. Interactive shells ignore SIGTERM by design but
-// every shell honors terminal hangup; without this escalation a shell
-// pane close stalls the full kill timeout and ends in SIGKILL.
+// escalating to SIGHUP: interactive shells ignore SIGTERM by design but every
+// shell honors terminal hangup.
 const sigtermToHUPGrace = 2 * time.Second
 
 func (s *Session) kill(sig syscall.Signal, waitTimeout time.Duration) error {
@@ -1000,15 +877,11 @@ func (s *Session) kill(sig syscall.Signal, waitTimeout time.Duration) error {
 	}
 }
 
-// closePTY releases the pty and the native terminal state behind it.
-//
-// The wire feed and the Ghostty terminal own native refs that info() resolves
-// and resize() moves, so their teardown takes replayMu — the same lock those
-// readers hold. Manager.Remove can hand an already-looked-up session to an
-// in-flight attach before closing it; without this hold that attach could read
-// or free the same native ref concurrently. Both fields are nil'd under the
-// lock so a reader that arrives after teardown sees absence, not a freed
-// handle.
+// closePTY releases the pty and the native terminal state behind it. Teardown
+// takes replayMu — the same lock info() and resize() hold — because
+// Manager.Remove can hand an already-looked-up session to an in-flight attach;
+// both fields are nil'd under the lock so a late reader sees absence, not a
+// freed handle.
 func (s *Session) closePTY() {
 	s.closePTMX()
 
@@ -1104,10 +977,9 @@ func (s *Session) currentTheme() TerminalTheme {
 	return s.theme
 }
 
-// writeOSCColorResponses answers every OSC 10/11/12 query in queries.oscQueryOrder,
-// one reply per query in the order the chunk asked — real terminals answer OSC
-// queries in ask order, and a client that writes a burst of mixed OSC10/11/12
-// queries and pairs replies positionally depends on that order.
+// writeOSCColorResponses answers every OSC 10/11/12 query in
+// queries.oscQueryOrder, one reply per query in ask order — the order a
+// positional-pairing client depends on.
 func (s *Session) writeOSCColorResponses(queries terminalQueries, logf func(string, ...interface{})) {
 	theme := s.currentTheme()
 	fg := hexColorToOSCValue(theme.Foreground, defaultThemeForeground)
@@ -1138,10 +1010,9 @@ func (s *Session) writeOSCColorResponses(queries terminalQueries, logf func(stri
 	}
 }
 
-// hexColorToOSCValue converts a "#rrggbb" hex color into the "rgb:RRRR/GGGG/BBBB"
-// value XTerm-style OSC color replies use, doubling each 8-bit channel to
-// 16-bit by repeating its hex pair. Falls back to fallbackHex (assumed valid)
-// when value is malformed or empty.
+// hexColorToOSCValue converts "#rrggbb" into the "rgb:RRRR/GGGG/BBBB" value
+// XTerm-style OSC color replies use, doubling each 8-bit channel by repeating
+// its hex pair. Falls back to fallbackHex (assumed valid) when malformed.
 func hexColorToOSCValue(value, fallbackHex string) string {
 	if !isValidHexColor(value) {
 		value = fallbackHex
@@ -1163,17 +1034,13 @@ func isValidHexColor(value string) bool {
 	return true
 }
 
-// writeCursorPositionResponse answers a CPR (cursor position report) query from
-// the authoritative screen model. The daemon is the single CPR responder for a
-// session: fish blocks its prompt redraw on the resize-triggered CPR until it
-// gets a reply, and routing every CPR through the daemon (which owns geometry,
-// AGENTS.md pattern #7) makes the reply race-free regardless of frontend
-// attach/replay timing. The frontend deliberately does not answer CPR, so there
-// is no double-reply to confuse the shell.
+// writeCursorPositionResponse answers a CPR query from the authoritative
+// screen model. The daemon is the single CPR responder — fish blocks its
+// prompt redraw on the resize-triggered CPR — and the frontend deliberately
+// does not answer, so there is no double-reply.
 func (s *Session) writeCursorPositionResponse(logf func(string, ...any)) {
 	row, col := 1, 1
-	// Read the cursor under replayMu: teardown nils the terminal under that
-	// lock, so an unlocked check-then-use could query a freed handle.
+	// Under replayMu: teardown nils the terminal under that lock.
 	s.replayMu.Lock()
 	if s.ghostty != nil {
 		x, y := s.ghostty.CursorPos()
@@ -1188,14 +1055,9 @@ func (s *Session) writeCursorPositionResponse(logf func(string, ...any)) {
 	}
 }
 
-// writeDeviceAttributesResponse answers a DA1 (primary device attributes) query.
-// Like CPR, the daemon is the single DA1 responder for a session: fish blocks its
-// prompt redraw on the resize-triggered DA1 until it gets a reply, and after a
-// reattach the frontend can be mid-remount/replay and miss it (fish then stalls
-// for its ~10 s query timeout). The reply is a static capability string identical
-// to the one the frontend would send, so routing every DA1 through the daemon
-// (which owns geometry/capabilities, AGENTS.md pattern #7) is safe and race-free.
-// The frontend deliberately does not answer DA1, so there is no double-reply.
+// writeDeviceAttributesResponse answers a DA1 query. Like CPR, the daemon is
+// the single responder: after a reattach the frontend can be mid-remount and
+// miss it, and fish then stalls for its ~10 s query timeout.
 func (s *Session) writeDeviceAttributesResponse(logf func(string, ...any)) {
 	// DA1 response: VT100 with Advanced Video Option.
 	s.writeMu.Lock()
@@ -1207,8 +1069,7 @@ func (s *Session) writeDeviceAttributesResponse(logf func(string, ...any)) {
 }
 
 // indexDA1Query returns the offset of the first CSI Primary Device Attributes
-// query (ESC [ c  or  ESC [ 0 c) in data, or -1. It ignores DA2 (ESC [ > c)
-// and other variants.
+// query (ESC [ c or ESC [ 0 c), or -1. It ignores DA2 (ESC [ > c).
 func indexDA1Query(data []byte) int {
 	for i := 0; i < len(data)-2; i++ {
 		if data[i] != 0x1b || data[i+1] != '[' {
@@ -1227,7 +1088,7 @@ func indexDA1Query(data []byte) int {
 }
 
 // indexCPRQuery returns the offset of the first DSR 6 / CPR query
-// (ESC [ 6 n) in data, or -1.
+// (ESC [ 6 n), or -1.
 func indexCPRQuery(data []byte) int {
 	for i := 0; i < len(data)-3; i++ {
 		if data[i] == 0x1b && data[i+1] == '[' && data[i+2] == '6' && data[i+3] == 'n' {
@@ -1240,9 +1101,7 @@ func indexCPRQuery(data []byte) int {
 func containsCPRQuery(data []byte) bool { return indexCPRQuery(data) >= 0 }
 
 // oscColorQueryPrefixes are the recognized OSC color query prefixes (ESC ]
-// <code> ; ?, terminated by BEL or ST — the prefix match is sufficient). An
-// OSC color SET (e.g. "\x1b]11;#000000\x1b\\", no "?") never matches: the
-// prefix requires "?" immediately after ";".
+// <code> ; ?). An OSC color SET (no "?") never matches.
 var oscColorQueryPrefixes = [...]struct {
 	code   int
 	prefix []byte
@@ -1253,8 +1112,7 @@ var oscColorQueryPrefixes = [...]struct {
 }
 
 // scanOSCColorQueries scans data for non-overlapping OSC 10/11/12 color
-// queries and returns their codes in encounter order — the order real
-// terminals answer in, and the order a positional-pairing client depends on.
+// queries and returns their codes in encounter order.
 func scanOSCColorQueries(data []byte) []int {
 	var codes []int
 	for i := 0; i < len(data); {

--- a/internal/pty/shell_signals.go
+++ b/internal/pty/shell_signals.go
@@ -9,78 +9,48 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// Shell state signals: the terminal's own answer to "is a command running",
-// for sessions with no harness to ask.
-//
-// A shell pane has none of the signals the agents provide — no hooks, no
-// transcript, no title glyph contract — but two independent readings exist.
-//
-// The first is the kernel's: which process group owns the terminal's
-// foreground. An interactive shell sitting at its prompt holds the foreground
-// itself; the moment it runs a command, job control hands the foreground to
-// the command's process group and takes it back when the command ends.
-// TIOCGPGRP on the PTY master reads that directly, so it works identically for
-// every shell with job control and needs nothing injected into the user's
-// shell. It is a level, polled once a second.
-//
-// The second is the shell's own, when shell integration is present: OSC 133
-// markers in the output stream. C (pre-exec) is a busy edge the instant a
-// command starts, D (command end) is a not-busy edge carrying the exit code,
-// A (prompt start) is a not-busy edge. Edges are immediate — a command that
-// starts and finishes between two polls is still seen — and they come from
-// whichever shell the user is actually typing at, including one on the far
-// side of an ssh session whose remote integration passes markers through.
-//
-// The two disagree in exactly one situation: a foreground program that
-// contains an inner shell at its prompt (ssh at a remote prompt, a nested
-// shell). The poll reads busy — a program does own the foreground — while the
-// markers say the user is at a prompt. shellSignalArbiter reconciles them with
-// one rule: a prompt marker keeps meaning "at prompt" only while the same
-// foreground program it arrived from stays in the foreground. The shell
-// itself taking the foreground back, or the foreground moving to a different
-// program, returns the verdict to the poll.
-//
-// One honest limit remains: without integration, a foreground program that is
-// itself waiting (an idle vim) reads as busy, because from this terminal's
-// point of view a program does own the foreground.
+// Shell state signals: "is a command running" for panes with no harness. Two
+// independent readings: the kernel's foreground process group (TIOCGPGRP on
+// the PTY master, a level polled 1/s) and OSC 133 markers when shell
+// integration is present (C = busy edge, D/A = not-busy edges; edges catch
+// commands shorter than a poll and pass through ssh). They disagree in one
+// case — a foreground program containing an inner shell at its prompt —
+// reconciled by one rule: a prompt marker means "at prompt" only while the
+// same foreground program it arrived from keeps the foreground. Honest limit:
+// without integration, an idle vim reads as busy.
 
 const (
-	// shellForegroundPollInterval is how often the foreground owner is read.
-	// One ioctl per second per shell pane; the resolver ticks at the same rate,
-	// so polling faster buys nothing.
+	// shellForegroundPollInterval: one ioctl per second per shell pane; the
+	// resolver ticks at the same rate, so polling faster buys nothing.
 	shellForegroundPollInterval = time.Second
 
-	// shellCommandDetailLimit bounds how much of a marker's cmdline is carried
-	// into the observation detail (trace/evidence strings, not UI).
+	// shellCommandDetailLimit bounds the cmdline carried into observation
+	// detail (trace/evidence strings, not UI).
 	shellCommandDetailLimit = 80
 )
 
 // shellSignalArbiter merges the foreground poll and the OSC 133 marker stream
-// into one coherent heartbeat claim. It is shared by two goroutines — the
-// poller and the session read loop — hence the lock; emission keeps the
-// change-or-keepalive rule the harness title observer uses.
+// into one heartbeat claim. Shared by two goroutines — the poller and the read
+// loop — hence the lock.
 type shellSignalArbiter struct {
 	mu sync.Mutex
 
 	// shellPgid is the shell's own process group — the foreground owner that
-	// means "at the prompt". Constant for the session's life: the shell is the
-	// PTY's session leader and never changes group.
+	// means "at the prompt". Constant for the session's life.
 	shellPgid int
 
-	// seg is this arbiter's own instance of the feed segmenter. It runs over
-	// the RAW chunk from the read loop, independently of the one in wireFeeder,
-	// and takes only the marker emissions — the same machine, so the same
-	// framing, without the heartbeat depending on the wire path's state.
+	// seg is this arbiter's own feed segmenter, run over the RAW chunk
+	// independently of wireFeeder's — same machine, same framing, no
+	// dependence on the wire path's state. Only marker emissions are taken.
 	seg feedSegmenter
 
-	// markerAtPrompt says the most recent marker verdict was a prompt; ownerPgid
-	// is the foreground program that verdict arrived from (0 when it arrived
-	// while the shell itself held the foreground, in which case the poll's own
-	// shell-pgid reading already agrees and no override is needed).
+	// markerAtPrompt says the most recent marker verdict was a prompt;
+	// ownerPgid is the foreground program it arrived from (0 when the shell
+	// itself held the foreground, where the poll already agrees).
 	markerAtPrompt bool
 	ownerPgid      int
-	// lastPolledFgPgid is what the poller last saw; it is what a prompt marker
-	// binds its ownership to.
+	// lastPolledFgPgid is what the poller last saw; a prompt marker binds its
+	// ownership to it.
 	lastPolledFgPgid int
 
 	lastClaim string
@@ -100,18 +70,15 @@ func (a *shellSignalArbiter) ObservePoll(fgPgid int, now time.Time) (Observation
 	var claim, detail string
 	switch {
 	case fgPgid == a.shellPgid:
-		// The shell reading its own prompt is definitive: whatever an inner
-		// shell said before, the user is typing at this one now.
+		// The shell holding its own prompt is definitive.
 		claim, detail = claimNotBusy, "shell at prompt"
 		a.markerAtPrompt, a.ownerPgid = false, 0
 	case a.markerAtPrompt && fgPgid == a.ownerPgid:
-		// The program the prompt marker came from still owns the foreground:
-		// an inner shell (ssh, a nested shell) is sitting at its prompt.
+		// An inner shell (ssh, nested shell) is sitting at its prompt.
 		claim, detail = claimNotBusy, "inner shell at prompt"
 	default:
 		claim, detail = claimBusy, "foreground command running"
-		// A different program took the foreground since the marker's verdict;
-		// the verdict no longer describes what is running.
+		// A different program took the foreground; the verdict is stale.
 		a.markerAtPrompt, a.ownerPgid = false, 0
 	}
 	return a.emit(claim, detail, now)
@@ -124,8 +91,8 @@ func (a *shellSignalArbiter) ObserveOutput(chunk []byte, now time.Time) []Observ
 		return nil
 	}
 	var out []Observation
-	// The segmenter is only ever fed from the read loop, but marker handling
-	// shares claim state with the poller, so take the lock across the feed.
+	// Marker handling shares claim state with the poller, so hold the lock
+	// across the feed.
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.seg.Feed(chunk, func(seg feedSegment) {
@@ -140,12 +107,9 @@ func (a *shellSignalArbiter) ObserveOutput(chunk []byte, now time.Time) []Observ
 }
 
 // observeMarker folds one marker into the merged claim. Caller holds mu.
-//
-// Command-start and command-end are edges, not level repaints: each one is a
-// distinct event carrying information a level cannot (the exit code, the
-// cmdline), and they arrive once per command rather than at a repaint rate —
-// so they skip the keepalive dedup. Prompt-start is a level restate and keeps
-// it: shells redraw prompts freely, and a D;exit already announced the edge.
+// Command-start/end are edges — once per command, carrying what a level cannot
+// — so they skip the keepalive dedup. Prompt-start is a level restate and
+// keeps it: shells redraw prompts freely.
 func (a *shellSignalArbiter) observeMarker(m *osc133Marker, now time.Time) (Observation, bool) {
 	switch m.Kind {
 	case osc133PreExec:
@@ -170,11 +134,9 @@ func (a *shellSignalArbiter) observeMarker(m *osc133Marker, now time.Time) (Obse
 	}
 }
 
-// bindPromptVerdict records a prompt verdict and pins it to the foreground
-// program it arrived from. Binding to the last polled reading — rather than to
-// "whatever is foreground at the next poll" — is what keeps the verdict from
-// leaking onto a command the user starts immediately after the prompt: a new
-// command gets a fresh pgid, which won't match, and the poll rules again.
+// bindPromptVerdict pins a prompt verdict to the LAST polled foreground
+// program, which keeps the verdict off a command started right after the
+// prompt: the new command's fresh pgid won't match, and the poll rules again.
 func (a *shellSignalArbiter) bindPromptVerdict() {
 	a.markerAtPrompt = true
 	a.ownerPgid = 0
@@ -183,9 +145,7 @@ func (a *shellSignalArbiter) bindPromptVerdict() {
 	}
 }
 
-// emit applies the change-or-keepalive rule: a level re-states itself only
-// when it changed or when "still true" is old enough to be news. Caller holds
-// mu.
+// emit applies the change-or-keepalive rule. Caller holds mu.
 func (a *shellSignalArbiter) emit(claim, detail string, now time.Time) (Observation, bool) {
 	if claim == a.lastClaim && now.Sub(a.lastEmit) < heartbeatKeepalive {
 		return Observation{}, false
@@ -209,8 +169,8 @@ func truncateDetail(s string, limit int) string {
 }
 
 // runShellForegroundPoller reads the foreground owner on a ticker and reports
-// level changes through onState until the session exits. It runs in its own
-// goroutine, spawned only for shell panes.
+// level changes through onState until the session exits. Its own goroutine,
+// spawned only for shell panes.
 func (s *Session) runShellForegroundPoller(interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -221,8 +181,7 @@ func (s *Session) runShellForegroundPoller(interval time.Duration) {
 		case <-ticker.C:
 			fgPgid, ok := s.foregroundProcessGroup()
 			if !ok {
-				// The fd is gone or the ioctl failed; whatever the last level
-				// was still stands, and process-exit evidence outranks it.
+				// fd gone or ioctl failed; the last level stands.
 				continue
 			}
 			if obs, ok := s.shellSignals.ObservePoll(fgPgid, time.Now()); ok {
@@ -244,8 +203,8 @@ func (s *Session) childProcessGroup() int {
 }
 
 // foregroundProcessGroup reads which process group owns the terminal's
-// foreground right now. It takes writeMu for the same reason resize does:
-// Fd() must not race the ptmx close.
+// foreground right now. Takes writeMu for the same reason resize does: Fd()
+// must not race the ptmx close.
 func (s *Session) foregroundProcessGroup() (int, bool) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()

--- a/internal/pty/wirefeed.go
+++ b/internal/pty/wirefeed.go
@@ -1,49 +1,13 @@
 package pty
 
-// Feed composition: the outer half of the worker's PTY feed path.
-//
-// kittyseg.go owns the framing — one machine that tracks where ghostty's parser
-// stands and cuts the stream into plain runs, complete kitty APCs, and complete
-// OSC 133 markers. This file decides where each of those goes, turning one
-// arriving chunk into two different things:
-//
-//   - the TERMINAL feed: the plain runs, every complete kitty APC, and every
-//     OSC 133 marker. The worker and app use the same Ghostty source pin, so the
-//     marker must reach both models; blockfeed.go pins a block-table entry after
-//     Ghostty applies it.
-//   - the WIRE bytes: the same stream with each APC replaced, in position, by
-//     bytes that leave a kitty-ignorant terminal on the same grid — an ST, then
-//     the scroll and the cursor the placement caused. In the shipping
-//     configuration the ST is all of it. Markers go out untouched; the client
-//     parses its own.
-//
-// Only the wire is missing something the terminal has: a kitty APC. Its gap is
-// filled with an ST because an ESC ends a part-built UTF-8 character; losing
-// those bytes without a substitute would let the decoders resolve the same
-// character differently. The APC also needs its ST on the WORKER, ahead of
-// everything measured, because ending a decode is itself a grid event. See
-// wireST and writeAPC.
-//
-// Both are produced in one call, under the caller's replayMu, in the same
-// critical section that advances the seq watermark. That is what keeps the
-// attach contract intact: a snapshot taken mid-transmission serves the
-// pre-placement grid, and everything the completing chunk did — terminal write,
-// observation, synthesized bytes — carries a seq above that snapshot's LastSeq.
-//
-// The synthesized bytes are OBSERVED, never predicted. Ghostty runs the APC and
-// the difference between the cursor before and after — pinned as tracked grid
-// refs, which makes a scroll visible as movement — is what gets written.
-// Nothing here knows what an image is. When the observation cannot answer (a
-// ref that no longer resolves, a cursor that moved backwards) the session
-// forces a snapshot re-push instead of guessing: a resync nobody notices beats
-// a silent divergence between the worker grid and the client's.
-//
-// Live by default: a session's terminal is built with kittyStorageLimitDefault,
-// so this path runs for real and its synthesis is what keeps the two grids
-// equal. ATTN_KITTY_STORAGE_LIMIT=0 turns the protocol off again — ghostty then
-// refuses every transmission, the generation stamp never moves, and the only
-// visible effect is that APC bytes are dropped from the wire instead of being
-// sent to a client that cannot parse them.
+// Outer half of the worker's PTY feed path: kittyseg.go cuts the stream, this
+// file routes it. The terminal gets plain runs, kitty APCs, and OSC 133
+// markers; the wire gets the same stream with each APC replaced in position by
+// an ST plus the OBSERVED scroll/cursor effect — never predicted. When an
+// observation cannot answer, the session forces a snapshot re-push instead of
+// guessing. All of it happens under the caller's replayMu, in the same critical
+// section that advances the seq watermark, which is what keeps attach
+// snapshots consistent. ATTN_KITTY_STORAGE_LIMIT=0 turns the protocol off.
 // Design: docs/plans/2026-08-02-terminal-kitty-images.md.
 
 import (
@@ -54,87 +18,58 @@ import (
 )
 
 // Resync reasons. They travel to the client as the pty_desync reason and land
-// in the daemon log, so each one names the observation that failed rather than
-// saying "kitty".
+// in the daemon log; each names the observation that failed.
 const (
-	// kittyResyncAnchorLost: the cell the cursor sat on before the APC could
-	// not be resolved afterwards, so how far the grid moved is unknowable.
+	// kittyResyncAnchorLost: the cursor's pre-APC cell could not be resolved
+	// afterwards, so how far the grid moved is unknowable.
 	kittyResyncAnchorLost = "kitty_layout_anchor_lost"
-	// kittyResyncAnchorClamped: the scroll pushed that cell to the top of
-	// retained history, where a cell that fell off the end is indistinguishable
-	// from one that stopped there — ghostty clamps a discarded ref rather than
-	// invalidating it. Reached by an image taller than the alternate screen,
-	// which keeps no history at all.
+	// kittyResyncAnchorClamped: the scroll pushed the anchor to the top of
+	// retained history (ghostty clamps a discarded ref), where a cell that fell
+	// off is indistinguishable from one that stopped there. Reached by an image
+	// taller than the alternate screen, which keeps no history.
 	kittyResyncAnchorClamped = "kitty_layout_anchor_clamped"
-	// kittyResyncReverseScroll: the grid moved DOWN under the cursor. Nothing a
-	// placement does looks like that, and synthesis does not express it.
+	// kittyResyncReverseScroll: the grid moved DOWN under the cursor, which no
+	// placement does and synthesis cannot express.
 	kittyResyncReverseScroll = "kitty_layout_reverse_scroll"
-	// kittyResyncUndescribedImage: ghostty's kitty state moved on bytes that
-	// went to the wire verbatim rather than through synthesis, and the diff
-	// found a placement created, re-placed, or retransmitted. That happens when
-	// an APC is one ghostty parses as kitty but the segmenter cannot cut out —
-	// an APC introduced from inside another sequence, whose leading ESC is also
-	// that sequence's exit (see kittyseg.go). Replaying those bytes keeps the
-	// two PARSERS in step, which is what the segmenter guarantees, but the
-	// client cannot parse kitty, so the image the worker just placed moved its
-	// grid and not the client's. Only a snapshot can settle that.
+	// kittyResyncUndescribedImage: kitty state moved on bytes that went to the
+	// wire verbatim (an APC the segmenter could not cut out — see kittyseg.go)
+	// and the diff found a placement created, re-placed, or retransmitted. The
+	// worker's grid moved and the client's did not; only a snapshot settles it.
 	kittyResyncUndescribedImage = "kitty_undescribed_image"
-	// kittyResyncStampWithoutDelta: the same verbatim bytes moved ghostty's
-	// kitty stamp and the diff that followed found NOTHING — the set before and
-	// the set after are equal. That is a placement created and destroyed inside
-	// one chunk, which an emitter reaches by drawing an image and clearing it in
-	// one 4 KiB PTY read. Whatever it scrolled is on the worker's grid, no wire
-	// byte described it, and the two sets being equal means no observation can
-	// ever name what moved. The stamp is the only witness there is.
+	// kittyResyncStampWithoutDelta: verbatim bytes moved ghostty's kitty stamp
+	// and the diff found NOTHING — a placement created and destroyed inside one
+	// chunk. Whatever it scrolled has no witness but the stamp.
 	kittyResyncStampWithoutDelta = "kitty_stamp_without_delta"
-	// kittyResyncMarginMode: DECLRMM (DEC private mode 69) was on when a
-	// described dispatch landed. A scroll confined to the left/right margin box
-	// moves the text inside those columns without moving the rows, and the
-	// tracked pair below measures rows — so a margin-box scroll reads as no
-	// scroll at all and the wire carries no SU for it. Measured: with margins
-	// `\x1b[4;14s` and a placement at the bottom of the box, the worker's text
-	// climbs two rows and the client's stays put under a cursor that agrees.
-	// This is a tripwire, not a repair: it fires on every described dispatch
-	// while margins are on, whether or not that dispatch actually scrolled the
-	// box, because the measurement cannot tell those apart. Nothing pays for it
-	// in practice — no emitter in the A4 sweep enables DECLRMM.
+	// kittyResyncMarginMode: DECLRMM (DEC mode 69) was on. A margin-box scroll
+	// moves text without moving rows, so the tracked pair reads no scroll and no
+	// SU goes out. Measured: margins `\x1b[4;14s` + placement at the box bottom
+	// climbs the worker's text two rows while the client's stays put. Fires on
+	// every described dispatch while margins are on — a tripwire, not a repair;
+	// no emitter in the A4 sweep enables DECLRMM.
 	kittyResyncMarginMode = "kitty_layout_margin_mode"
-	// kittyResyncScrollClamped: the placement scrolled the grid further than one
-	// SU can express. ghostty clamps SU to the height of the scroll region, so a
-	// taller scroll would push the client's oldest rows nowhere and leave its
-	// history short of the worker's while the viewport still agreed. Reachable
-	// because kitty's `r=` lets a 2x2 image claim any number of rows.
+	// kittyResyncScrollClamped: the placement scrolled further than one SU can
+	// express (ghostty clamps SU to the scroll region height), so the client's
+	// history would come out short. Reachable because kitty's `r=` lets a 2x2
+	// image claim any number of rows.
 	kittyResyncScrollClamped = "kitty_layout_scroll_clamped"
-	// kittyResyncPendingWrap: the cursor sat in the LAST COLUMN when a described
-	// dispatch landed. A cursor there may carry a pending wrap — the cell is
-	// written, the cursor has not moved, and the next printable byte wraps before
-	// it lands — and a dispatch consumes that bit on the worker while the wire's
-	// bytes leave the client's set. CursorPos reports the same column either way,
-	// so the measurement cannot tell a consumed wrap from an untouched one and the
-	// last column itself is the tripwire. Measured: print exactly a screen's width,
-	// place an image, print one more character — the worker stays on row 0 and the
-	// client wraps to row 1. DECAWM off makes the bit moot and this fires anyway,
-	// harmlessly, rather than growing a mode read for a case no emitter reaches
-	// (every emitter in the A4 sweep positions the cursor before transmitting).
+	// kittyResyncPendingWrap: the cursor sat in the LAST COLUMN, where a
+	// dispatch may consume a pending-wrap bit CursorPos cannot see. Measured:
+	// print a screen's width, place an image, print one more character — the
+	// worker stays on row 0, the client wraps to row 1. Fires on the column
+	// itself; every emitter in the A4 sweep positions the cursor first.
 	kittyResyncPendingWrap = "kitty_layout_pending_wrap"
 )
 
-// kittyPlacementKey identifies a placement across observations: kitty's own
-// image id plus placement id, which is the only pair ghostty keeps stable.
+// kittyPlacementKey identifies a placement across observations: kitty's image
+// id plus placement id, the only pair ghostty keeps stable.
 type kittyPlacementKey struct {
 	ImageID     uint32
 	PlacementID uint32
 }
 
 // kittyPlacementDelta is what one observation found changed in the active
-// screen's placement set. It answers two questions and neither is the wire's:
-// whether bytes the wire could not describe did anything but RETIRE a
-// placement (a resync — see unaccountedResync), and whether anything at all
-// moved (an update for the client, which carries the whole set rather than
-// this).
-//
-// Updated carries placements whose fields moved for ANY reason, a viewport
-// position that changed because the screen scrolled included.
+// screen's placement set. Updated carries placements whose fields moved for ANY
+// reason, a scrolled viewport position included.
 type kittyPlacementDelta struct {
 	Added   []ghosttyvt.KittyPlacement
 	Removed []kittyPlacementKey
@@ -153,63 +88,47 @@ type wireFeeder struct {
 	blocks *blockFeeder
 	seg    feedSegmenter
 
-	// wire is the assembly buffer for a chunk the feeder had to rewrite. It is
-	// reused across calls and handed out by feed, so it is valid only until the
-	// next feed — fanOut copies before it returns, which is the only consumer.
+	// wire is the assembly buffer for a rewritten chunk, reused across calls;
+	// the slice feed hands out is valid only until the next feed.
 	wire []byte
 
 	// generation is ghostty's kitty stamp as of the last change this feeder
-	// ACCOUNTED for. Every dispatch either goes through writeAPC, which
-	// describes it on the wire, or is one the wire cannot describe — and a
-	// difference between this and the terminal's own stamp is exactly the
-	// second kind. settleUnaccounted is where that difference is read, and it
-	// runs both at the end of a feed and before every described dispatch, so
-	// the two kinds can never be folded into one number.
-	//
-	// Raw, and deliberately: this is an internal change detector that never
-	// leaves the process, so folding the epoch into it would buy nothing and
-	// invite the two to be confused.
+	// ACCOUNTED for; a difference against the terminal's own stamp is exactly
+	// the undescribed kind, read in settleUnaccounted. Raw — the epoch is never
+	// folded into this internal change detector.
 	generation uint64
 
-	// epoch is the terminal-instance offset folded into every generation this
-	// feeder hands out; see mintKittyEpoch. Session.kittyEpoch carries the same
-	// value for the image half, and the two must match.
+	// epoch is the offset folded into every generation handed out; must match
+	// Session.kittyEpoch. See mintKittyEpoch.
 	epoch uint64
 
-	// placements is the placement set as of the last observation, the left side
-	// of the next diff.
+	// placements is the set as of the last observation, the left side of the
+	// next diff.
 	placements []ghosttyvt.KittyPlacement
-	// deltas holds what the observations in the MOST RECENT feed call found, so
-	// it stays bounded by one chunk. It is never handed out: unaccountedResync
-	// reads the tail of it for the resync decision, and changedPlacements()
-	// reads its emptiness as the whole test for "this chunk moved something".
+	// deltas holds what the MOST RECENT feed's observations found (bounded by
+	// one chunk). Never handed out: unaccountedResync reads its tail,
+	// changedPlacements reads its emptiness.
 	deltas []kittyPlacementDelta
 
 	// resync names the observation that failed during this feed, "" when none.
 	resync string
 
-	// logf reports a refused transmission, and nothing else. nil in tests that
-	// do not care.
+	// logf reports a refused transmission, nothing else. nil in tests.
 	logf LogFunc
 
-	// kittyLimit is the storage cap this session's terminal was BUILT with,
-	// carried rather than re-read so the log names the number in force here
-	// even if the environment moved after the spawn.
+	// kittyLimit is the cap this terminal was BUILT with, carried so the log
+	// names the number in force even if the environment moved after spawn.
 	kittyLimit uint64
 
 	// pending is the transmission being assembled across m=1 escapes, so a
-	// refusal is judged once, where a completed transmission should have
-	// stored. Zero between transmissions.
+	// refusal is judged once, at completion. Zero between transmissions.
 	pending kittyTransmission
 }
 
 // newWireFeeder wires the feed path for a session's ghostty terminal. Returns
 // nil when the terminal is absent, exactly like newBlockFeeder: callers
-// nil-guard, and a session without a terminal fans out its raw bytes unchanged.
-//
-// epoch is the session's kitty identity offset (mintKittyEpoch), which the
-// caller must also hold on the Session so the image serve folds the same one.
-// kittyLimit is the cap the terminal was built with, for the refusal log.
+// nil-guard, and a session without a terminal fans out raw bytes unchanged.
+// epoch must be the same value the caller holds on the Session (mintKittyEpoch).
 func newWireFeeder(term *ghosttyvt.Terminal, epoch uint64, logf LogFunc, kittyLimit uint64) *wireFeeder {
 	blocks := newBlockFeeder(term)
 	if blocks == nil {
@@ -226,19 +145,14 @@ func newWireFeeder(term *ghosttyvt.Terminal, epoch uint64, logf LogFunc, kittyLi
 }
 
 // feed writes one PTY chunk into the terminal and returns the bytes the wire
-// should carry for it, plus a resync reason when the chunk's grid effect could
-// not be expressed on the wire (see Session.forceResync). Caller holds replayMu.
+// should carry, plus a resync reason when the chunk's grid effect could not be
+// expressed (see Session.forceResync). Caller holds replayMu.
 //
-// The returned slice is the INPUT slice itself whenever the chunk needed no
-// rewriting — no kitty APC in it, nothing held from a previous chunk. That is
-// every chunk of every session today, so the common path allocates nothing and
-// copies nothing. Otherwise it is the feeder's assembly buffer, valid until the
-// next feed call.
-//
-// An empty result means the whole chunk was held: an APC that has not been
-// terminated yet contributes nothing to the wire until it completes. The caller
-// skips the fan-out rather than sending an empty message; downstream dedup is
-// `seq > last_seq`, which does not care that a seq never appeared.
+// The returned slice is the INPUT slice itself when no rewriting was needed —
+// the common path allocates and copies nothing — otherwise the feeder's
+// assembly buffer, valid until the next feed. An empty result means the whole
+// chunk was held (an unterminated APC); the caller skips the fan-out, and
+// downstream dedup (`seq > last_seq`) tolerates the missing seq.
 func (f *wireFeeder) feed(data []byte) ([]byte, string) {
 	f.deltas = f.deltas[:0]
 	f.resync = ""
@@ -247,11 +161,9 @@ func (f *wireFeeder) feed(data []byte) ([]byte, string) {
 		return nil, ""
 	}
 
-	// whole is set only by a plain run that IS the input slice, which no other
-	// emission can follow — that is the passthrough case, and it is the only
-	// emission allowed to survive its callback. Every other emitted slice
-	// aliases a buffer the segmenter may rewrite before Feed returns, so it is
-	// copied on the spot.
+	// whole marks the passthrough case: a plain run that IS the input slice.
+	// Every other emitted slice aliases a buffer the segmenter may rewrite
+	// before Feed returns, so it is copied on the spot.
 	whole := false
 	first := true
 	f.seg.Feed(data, func(seg feedSegment) {
@@ -266,10 +178,8 @@ func (f *wireFeeder) feed(data []byte) ([]byte, string) {
 		case feedSegKittyAPC:
 			f.writeAPC(seg.Bytes)
 		case feedSegOSC133:
-			// Both models consume the same marker bytes from the same Ghostty
-			// source revision. Write before mark() so the block-table pin lands
-			// on Ghostty's post-marker cursor — the row the prompt, command, or
-			// output will render on next.
+			// Write before mark() so the block-table pin lands on Ghostty's
+			// post-marker cursor.
 			f.wire = append(f.wire, seg.Bytes...)
 			f.blocks.write(seg.Bytes)
 			f.blocks.mark(seg.Marker)
@@ -277,23 +187,15 @@ func (f *wireFeeder) feed(data []byte) ([]byte, string) {
 		first = false
 	})
 
-	// Whatever the chunk's last bytes did to the terminal's kitty state, settled
-	// against what the wire carried for them. One cheap read per chunk buys the
-	// guarantee that no image ever lands on the worker's grid alone.
+	// Settle whatever the chunk's last bytes did to kitty state against what
+	// the wire carried for them.
 	settled := f.settleUnaccounted()
 
-	// A live placement moves on bytes that touch no kitty state at all — a
-	// scroll is the common one — and ghostty's stamp does not move with it, so
-	// the check above cannot see it. Re-reading at the end of every chunk that
-	// could have moved one is what keeps a described position from running a
-	// chunk (or a screenful) behind the grid it refers to. It is also why an
-	// observation the APC's own dispatch already took is not enough on its own:
-	// plain bytes after the APC, in the same chunk, scroll what it just placed.
-	//
-	// The gate is a slice length, not a terminal read. With no placements —
-	// every chunk of every session while the feature is dark — this costs one
-	// comparison and never crosses into cgo, and nothing except a placement's
-	// own dispatch can create the first one.
+	// A live placement moves on bytes that touch no kitty state (a scroll), and
+	// the stamp does not move with it — so re-observe at the end of any chunk
+	// that could have moved one, or a described position runs behind its grid.
+	// The gate is a slice length: with no placements this costs one comparison
+	// and never crosses into cgo.
 	if !settled && len(f.placements) > 0 {
 		f.observe()
 	}
@@ -304,72 +206,38 @@ func (f *wireFeeder) feed(data []byte) ([]byte, string) {
 	return f.wire, f.resync
 }
 
-// wireST is the ESC-led no-op this file substitutes wherever the two streams
-// differ: ST in its 7-bit form, ESC then backslash.
+// wireST is ST in its 7-bit form (ESC backslash) — the substitute written
+// wherever the two streams differ. Always 7-bit even when the APC ended in C1
+// ST: a raw 0x9c on the wire is a stray UTF-8 continuation byte to the client,
+// not an ST.
 //
-// Always the 7-bit form, even when the APC the worker consumed was terminated by
-// C1 ST (0x9c). A raw 0x9c on the wire is not an ST to the client — in ground
-// the stream is UTF-8, where 0x9c is a stray continuation byte that decodes
-// toward U+FFFD and puts a cell on the grid. The two-byte form is the only one
-// that means "no-op" on both sides.
-//
-// The rule it serves, which every extraction in this file obeys:
-//
-//	Wherever the two streams differ, BOTH sides get an ESC-led no-op at that
-//	position, so both parsers cross every extraction point in the same state.
-//
-// Extracting only from ground keeps the two VT PARSERS in step, and that is the
-// property the segmenter was built to give. It is not the whole of the state
-// ground implies: ground also holds a UTF-8 decoder, which may be part-way
-// through a character. An ESC ends that decode. So whichever side loses the
-// bytes must be given an ESC in their place, or the two decoders resolve the
-// same character differently and nothing later heals it.
-//
-// A kitty APC reaches the worker and not the wire, so the WIRE gets one (see
-// writeAPC). The APC also needs it on the worker for a reason that is about
-// measurement rather than decoding: see writeAPC.
+// The rule every extraction here obeys: wherever the two streams differ, BOTH
+// sides get an ESC-led no-op at that position. Ground also holds a UTF-8
+// decoder that may be mid-character; an ESC ends that decode, so whichever side
+// loses bytes must be given an ESC in their place or the two decoders resolve
+// the same character differently.
 var wireST = []byte{0x1b, '\\'}
 
 // writeAPC feeds one complete kitty APC to the terminal and appends whatever
-// the wire needs in its place. The ordering is the contract, and it has two
-// halves: end the pending decode on both sides BEFORE anything is measured, then
-// pin the cursor before the write, because a tracked ref is the only way to see
-// afterwards how far the grid moved under it.
+// the wire needs in its place. Ordering is the contract: end the pending decode
+// on both sides BEFORE anything is measured, then pin the cursor before the
+// write so a tracked ref can report how far the grid moved.
 func (f *wireFeeder) writeAPC(apc []byte) {
-	// Settle the chunk's earlier bytes before anything here is measured or
-	// claimed. Plain bytes ahead of this APC can carry a kitty escape ghostty
-	// dispatches and the segmenter could not extract; the stamp move that
-	// leaves is this feeder's only record of it, and the claim at the end of
-	// this function would take it as its own. See settleUnaccounted.
+	// Settle earlier bytes first: an undescribed kitty escape ahead of this APC
+	// leaves a stamp move the claim below would otherwise absorb.
 	f.settleUnaccounted()
 
-	// The abort, given to both sides, ahead of every measurement below.
-	//
-	// On the WIRE it stands in for the APC's own leading ESC, which the client
-	// would otherwise never see: it would keep holding a part-built character,
-	// and a following continuation byte would complete a different one from the
-	// replacement character the worker already resolved.
-	//
-	// On the WORKER it looks redundant — the APC's ESC would end the decode a
-	// moment later anyway — and it is not, because ending a decode is a GRID
-	// event. It writes a replacement character, and on the last column that
-	// character commits the deferred wrap and moves the cursor to the next row.
-	// Pinned before the abort, that movement falls inside the measured window and
-	// is attributed to the image; the client then performs the same abort itself
-	// off the ESC above AND applies the synthesized movement, landing a row too
-	// far. Doing the abort here, before the pin, leaves the measured window
-	// holding only what the image did. Both sides then start the APC from the
-	// same state, so measured movement is movement the client still needs.
-	//
-	// Safe unconditionally: the segmenter extracts only from ground, and from
-	// ground ghostty treats ST as a no-op, so on a stream with nothing pending
-	// this writes no cell and moves nothing. TestWireFeedPreSTOnlyEndsTheDecode
-	// pins that.
+	// The abort, to both sides, ahead of every measurement. On the WIRE it
+	// stands in for the APC's leading ESC. On the WORKER it is not redundant:
+	// ending a decode is a GRID event (a replacement character on the last
+	// column commits the deferred wrap), and doing it before the pin keeps the
+	// measured window holding only what the image did. Safe unconditionally:
+	// from ground ghostty treats ST as a no-op —
+	// TestWireFeedPreSTOnlyEndsTheDecode pins that.
 	f.term.Write(wireST)
 	f.wire = append(f.wire, wireST...)
 
-	// The settle above left f.generation equal to the terminal's stamp, so this
-	// is the pre-dispatch generation without a second crossing into ghostty.
+	// The settle above left f.generation equal to the terminal's stamp.
 	generation := f.generation
 	col, row := f.term.CursorPos()
 	before := f.term.TrackCursor()
@@ -377,22 +245,14 @@ func (f *wireFeeder) writeAPC(apc []byte) {
 	f.term.Write(apc)
 
 	stamped := f.term.KittyGeneration()
-	// Claimed here rather than at each exit below: every branch from this point
-	// on has either described the dispatch or resynced over it, so no later
-	// settle may see it again. The settle at entry is what makes the claim
-	// honest — it covers this dispatch's move and nothing that ran before it.
+	// Claimed here, once: every branch below has either described the dispatch
+	// or resynced over it, so no later settle may see it again.
 	f.generation = stamped
 	f.noteTransmission(apc, stamped != generation)
 	movedCol, movedRow := f.term.CursorPos()
-	// An unchanged generation means the storage did not change, so no placement
-	// appeared, so nothing scrolled the grid on an image's behalf — which is
-	// what makes the viewport cursor enough to decide here. On its own it would
-	// not be: a placement on the bottom row scrolls the grid while leaving the
-	// cursor's viewport row exactly where it was.
-	//
-	// This is the shipping configuration's every APC. A zero kitty storage
-	// limit makes ghostty refuse the transmission outright, so nothing is
-	// stamped and nothing moves.
+	// Unchanged generation means no placement appeared, so nothing scrolled on
+	// an image's behalf — only then is the viewport cursor enough to decide.
+	// This is the shipping configuration's every APC.
 	if stamped == generation && movedCol == col && movedRow == row {
 		freeTrackedRef(before)
 		return
@@ -411,77 +271,51 @@ func (f *wireFeeder) writeAPC(apc []byte) {
 		return
 	}
 
-	// The tracked pair reports how far the cursor moved relative to the CONTENT
-	// it sits on, which is not how far the grid moved: a placement that scrolls
-	// carries the cursor's own cell up with everything else. Taking the cursor's
-	// viewport movement back out of it leaves the scroll, and that identity
-	// holds on both screens and inside a scroll region — the three cases where
-	// the coordinate frames differ.
+	// The tracked pair reports cursor movement relative to CONTENT; taking the
+	// viewport movement back out leaves the scroll. The identity holds on both
+	// screens and inside a scroll region.
 	scrolled := (row - movedRow) + (landed - anchor)
 	if scrolled < 0 {
 		f.failResync(kittyResyncReverseScroll)
 		return
 	}
-	// An anchor on row 0 only means the pin was CLAMPED there on the alternate
-	// screen, which keeps no history: a cell that scrolls off has nowhere to go,
-	// so it stops at the top and the scroll it took with it is unrecoverable.
-	// Measured, and both directions of it: on alt, a placement that fits and one
-	// that scrolls the top row away report the identical (anchor 0, scrolled 0),
-	// so the amount cannot be recovered from the numbers and every alt anchor at
-	// row 0 has to resync — not only the ones that already look scrolled. On the
-	// primary screen the same reading is trustworthy, because the pin follows
-	// its cell into retained history and keeps reporting a real row; the only
-	// way to lose it there is the scrollback cap discarding the cell, which
-	// ScreenPoint reports as gone and kittyResyncAnchorLost handles above.
+	// On the alternate screen an anchor at row 0 only means the pin was CLAMPED
+	// there (no history), and the scroll amount is unrecoverable. Measured: a
+	// placement that fits and one that scrolls the top row away both report
+	// (anchor 0, scrolled 0). On the primary the pin follows its cell into
+	// history; losing it there reads as anchor-lost above.
 	if anchor == 0 && f.term.AltScreenActive() {
 		f.failResync(kittyResyncAnchorClamped)
 		return
 	}
 
-	// One SU carries at most a screen's worth of rows into history: ghostty
-	// clamps it to the scroll region, and a region is never taller than the
-	// screen. Past that the client's history comes out short by exactly the
-	// overflow while its viewport still agrees, so the tripwire is set at the
-	// largest scroll a single SU reproduces. Receipt:
-	// TestWireFeedSynthesizesTheLargestScrollOneSUCarries, which pins both sides
-	// of the boundary on an 8-row and a 12-row screen.
+	// One SU carries at most a screen's worth of rows (ghostty clamps to the
+	// scroll region). Receipt: TestWireFeedSynthesizesTheLargestScrollOneSUCarries
+	// pins both sides of the boundary on 8- and 12-row screens.
 	if _, screenRows := f.term.Size(); scrolled > screenRows {
 		f.failResync(kittyResyncScrollClamped)
 		return
 	}
 
-	// A margin-confined scroll is movement this measurement cannot see, so while
-	// DECLRMM is on the numbers below are not trustworthy on their own. The
-	// cursor moves still are — they agreed in every measured margin case — so the
-	// dispatch is described in full and the resync repairs the text: a resync is
-	// never a stop order, and a client that has not re-attached yet is better off
-	// with its cursor where the worker's is.
+	// Margin-confined scroll is movement this measurement cannot see. The
+	// cursor moves are still trustworthy (they agreed in every measured margin
+	// case), so the dispatch is described in full and the resync repairs the
+	// text — a resync is never a stop order.
 	if f.term.LeftRightMarginMode() {
 		f.failResync(kittyResyncMarginMode)
 	}
 
-	// The same shape as the margin tripwire: state the dispatch changed and the
-	// measurement cannot read, answered by a resync while the dispatch is still
-	// described in full. It sits after the early return above on measurement,
-	// not on faith — a query and a delete of an id that is not there, both sent
-	// with the cursor in the last column, leave the worker's pending wrap alone
-	// and their grids agree, so a dispatch that changed nothing needs no resync.
+	// Same shape: state changed that the measurement cannot read. Sits after
+	// the early return on measurement — a dispatch that changed nothing (query,
+	// delete of an absent id) needs no resync even in the last column.
 	if screenCols, _ := f.term.Size(); col == screenCols-1 {
 		f.failResync(kittyResyncPendingWrap)
 	}
 
-	// SU scrolls the active scroll region and leaves the cursor's viewport
-	// position alone, so the moves that follow are plain relative steps from
-	// where the pre-APC bytes already left the client's cursor.
-	//
-	// Every one of them is relative, and on both axes, for the same reason:
-	// absolute addressing is measured from a frame the worker cannot see. A row
-	// (CUP, VPA) is counted from the scroll region under origin mode; a column
-	// (CHA) is counted from the LEFT MARGIN when DECLRMM is on (`\x1b[?69h`), so
-	// an absolute column measured at the screen edge lands somewhere else on a
-	// client with margins set. The worker reports viewport coordinates and has
-	// no business knowing which modes the program turned on — a relative step is
-	// the same step in every frame.
+	// All moves are RELATIVE, on both axes: absolute addressing is measured
+	// from a frame the worker cannot see (origin mode for rows, DECLRMM's left
+	// margin for columns). A relative step is the same step in every frame. SU
+	// leaves the cursor's viewport position alone.
 	f.wire = appendCSI(f.wire, scrolled, 'S')
 	if movedRow > row {
 		f.wire = appendCSI(f.wire, movedRow-row, 'B')
@@ -499,24 +333,19 @@ func (f *wireFeeder) writeAPC(apc []byte) {
 // image across several escapes, each carrying `m=1` until the last, and nothing
 // is stored until that last one lands.
 type kittyTransmission struct {
-	// ask is the storage the image will occupy once decoded, from the geometry
-	// the first escape declared. Zero when it declared none (f=100, a PNG whose
-	// decoded size only ghostty knows), and then payload stands in.
+	// ask is the storage the image will occupy once decoded, from the declared
+	// geometry. Zero when none was declared (f=100 PNG); payload stands in.
 	ask uint64
 	// payload counts the base64 bytes seen across every escape so far.
 	payload uint64
 }
 
-// noteTransmission logs the one failure ghostty has no way to report: an image
-// refused for exceeding the storage limit. Every emitter measured in the A4
-// sweep transmits with `q=2`, which suppresses kitty's own response, so the
-// program is not told and neither is anyone else — the image simply never
-// appears. The worker is the only place that can see it, which is why this file
-// interprets an APC here and nowhere else.
+// noteTransmission logs the one failure ghostty cannot report: an image refused
+// for exceeding the storage limit. Every measured emitter sends q=2, which
+// suppresses kitty's own response, so the worker is the only witness.
 //
 // stored says whether ghostty's kitty generation moved on this escape, which is
-// the whole signal. Measured, and every row of it is a case this must not
-// mistake for a refusal:
+// the whole signal. Measured:
 //
 //	single transmission that fits      generation moves
 //	single transmission over the limit  UNCHANGED — the one true positive
@@ -528,9 +357,8 @@ type kittyTransmission struct {
 //	a=d delete of an id that is not there   unchanged — never a transmission
 //	eviction (a third image into a store that holds one)   moves
 //
-// So intermediate escapes are accumulated and never judged, and eviction — the
-// ordinary way an animation reuses its budget — is invisible here because
-// admitting the new image moves the stamp like any other store.
+// So intermediate escapes accumulate and are never judged, and eviction is
+// invisible here because admitting the new image moves the stamp.
 func (f *wireFeeder) noteTransmission(apc []byte, stored bool) {
 	ask, more, ok := parseKittyTransmission(apc)
 	if !ok {
@@ -562,14 +390,11 @@ func (f *wireFeeder) noteTransmission(apc []byte, stored bool) {
 	)
 }
 
-// parseKittyTransmission reads the four keys a refusal check needs out of one
-// complete APC — the action, `m`, and the declared geometry — plus the payload
-// length. It reports ok only for a transmission: kitty's default action is `t`,
-// so an escape with no `a=` at all is one, which is exactly what a continuation
-// escape looks like.
-//
-// Deliberately not a kitty parser. It reads what it recognizes and treats the
-// rest as absent, because the worst a misread can do here is drop a log line.
+// parseKittyTransmission reads the keys a refusal check needs out of one
+// complete APC. Deliberately not a kitty parser: it reads what it recognizes
+// and treats the rest as absent — the worst a misread does is drop a log line.
+// kitty's default action is `t`, so an escape with no `a=` is a transmission,
+// which is what a continuation escape looks like.
 func parseKittyTransmission(apc []byte) (t kittyTransmission, more bool, ok bool) {
 	body := apc
 	body = bytes.TrimPrefix(body, []byte("\x1b_G"))
@@ -581,7 +406,7 @@ func parseKittyTransmission(apc []byte) (t kittyTransmission, more bool, ok bool
 	control := body
 	if i := bytes.IndexByte(body, ';'); i >= 0 {
 		control = body[:i]
-		// Base64 in, raw bytes out: 4 encoded characters carry 3.
+		// Base64: 4 encoded characters carry 3 raw bytes.
 		t.payload = uint64(len(body)-i-1) * 3 / 4
 	}
 
@@ -607,15 +432,13 @@ func parseKittyTransmission(apc []byte) (t kittyTransmission, more bool, ok bool
 		return kittyTransmission{}, false, false
 	}
 	// Ghostty stores decoded RGBA whatever the wire format was, so declared
-	// pixels are the honest ask; a format that declares none (PNG) leaves this
-	// zero and the payload stands in.
+	// pixels are the honest ask.
 	t.ask = width * height * 4
 	return t, more, true
 }
 
 // appendCSI writes `ESC [ n <final>`, or nothing when n is zero — every
-// sequence synthesis uses is a no-op at zero, and an empty wire chunk is what
-// lets the caller skip a fan-out entirely.
+// sequence synthesis uses is a no-op at zero.
 func appendCSI(dst []byte, n int, final byte) []byte {
 	if n == 0 {
 		return dst
@@ -626,20 +449,14 @@ func appendCSI(dst []byte, n int, final byte) []byte {
 }
 
 // placementReadHook is a test-only seam fired on every read of the placement
-// set, so a test can hold both the feed path and the resize path to their cost:
-// a session with no images must never reach ghostty for placements at all. nil
-// (a single branch) in production.
+// set, so a test can assert a session with no images never reaches ghostty for
+// placements. nil in production.
 var placementReadHook func()
 
-// readPlacements is the only place the placement set is read out of ghostty —
-// the cgo crossing every caller here is gated to avoid. Callers hold replayMu.
-//
-// Being the only read is also what makes it the only place a generation crosses
-// out of ghostty's process-local numbering into the session's: every placement
-// exit (the live fan-out, the resize re-describe, the attach snapshot) draws
-// from here, so one fold covers all three. The set is freshly copied out per
-// call, so stamping it mutates nothing shared, and the offset is constant, so
-// the diff against the last observation is untouched.
+// readPlacements is the only place the placement set is read out of ghostty,
+// and therefore the one fold of the epoch on the placement side — every
+// placement exit (live fan-out, resize re-describe, attach snapshot) draws from
+// here. The set is freshly copied per call. Callers hold replayMu.
 func (f *wireFeeder) readPlacements() []ghosttyvt.KittyPlacement {
 	if placementReadHook != nil {
 		placementReadHook()
@@ -652,9 +469,8 @@ func (f *wireFeeder) readPlacements() []ghosttyvt.KittyPlacement {
 }
 
 // observe diffs ghostty's placement set against the last observation. Called
-// when the generation stamp moved — the terminal's own statement that the set
-// or its images changed — and at the end of any chunk that could have moved a
-// placement the terminal does not consider changed at all (see feed).
+// when the generation stamp moved, and at the end of any chunk that could have
+// moved a placement the terminal does not consider changed (see feed).
 func (f *wireFeeder) observe() {
 	current := f.readPlacements()
 	delta := diffKittyPlacements(f.placements, current)
@@ -664,23 +480,12 @@ func (f *wireFeeder) observe() {
 	}
 }
 
-// settleUnaccounted closes the books on everything the terminal's kitty state
-// has done that no dispatch through writeAPC accounted for, and reports whether
-// there was any. Whatever it finds happened on bytes the wire carried verbatim,
-// and the client ignores those, so the cost is decided by unaccountedResync.
-//
-// Called at two moments, and the pair is the whole accounting rule: at the end
-// of every feed, and at the ENTRY of every writeAPC, before that dispatch is
-// measured. The second is what keeps the claim honest. writeAPC ends by taking
-// the terminal's stamp as its own, and a stamp is a single number for the whole
-// terminal — so without a settle first, a described APC silently absorbs an
-// undescribed one that ran earlier in the same chunk, and the end-of-feed check
-// finds a stamp that already looks accounted for. Settling first means writeAPC
-// can only ever claim the move it made itself.
-//
-// After it returns, f.generation IS the terminal's current stamp, which is why
-// writeAPC reads its pre-dispatch generation from the field rather than from
-// ghostty: the settle already paid for that crossing.
+// settleUnaccounted closes the books on kitty state changes no writeAPC
+// dispatch accounted for, and reports whether there were any. Called at the end
+// of every feed AND at the entry of every writeAPC — the second is what keeps
+// the claim honest: without it, a described APC silently absorbs an undescribed
+// stamp move earlier in the same chunk. After it returns, f.generation IS the
+// terminal's current stamp.
 func (f *wireFeeder) settleUnaccounted() bool {
 	stamped := f.term.KittyGeneration()
 	if stamped == f.generation {
@@ -688,9 +493,8 @@ func (f *wireFeeder) settleUnaccounted() bool {
 	}
 	f.generation = stamped
 
-	// Scoped to the observations THIS settle records: the deltas already in the
-	// slice belong to dispatches that were described on the wire or resynced
-	// over at the time, and must not be judged a second time.
+	// Judge only the observations THIS settle records; earlier deltas were
+	// already described or resynced over.
 	before := len(f.deltas)
 	f.observe()
 	if reason, ok := unaccountedResync(f.deltas[before:]); ok {
@@ -699,30 +503,15 @@ func (f *wireFeeder) settleUnaccounted() bool {
 	return true
 }
 
-// unaccountedResync names what a generation move on bytes the wire carried
-// VERBATIM costs the client, given the observations that move produced. Reports
-// false when it costs nothing.
-//
-// The rule rests on one distinction: a resync exists for grid SCROLL the wire
-// never expressed, never for knowledge of the placement set. The set reaches
-// the client on its own, through changedPlacements' fan-out, whatever happened
-// here. And only bringing a placement into existence or putting a live one
-// somewhere new can scroll the grid — retiring one moves nothing, because
-// ghostty does not give back the rows an image took. So the exemption is
-// exactly a delta that is nothing but removals, and everything else resyncs:
-//
-//   - no delta at all, with the stamp moved: a placement that appeared and died
-//     inside this chunk. It left the before and after sets equal while its
-//     scroll stayed on the worker's grid, so nothing but the stamp can see it.
-//   - Added: a placement the wire never described came into existence.
-//   - Updated: a live {ImageID, PlacementID} put at a new spot, or an image
-//     retransmitted under one (ImageGeneration moves, the key does not). The
-//     first can scroll; the second is charged with it because this check cannot
-//     tell them apart, and an undescribed APC is rare enough to pay for that.
-//
-// Scroll noise cannot reach here: an ordinary scroll moves every live placement
-// but leaves ghostty's stamp alone, so this runs only when the terminal itself
-// says its kitty state changed on bytes nothing accounted for.
+// unaccountedResync names what a generation move on verbatim bytes costs the
+// client; false when it costs nothing. A resync exists for grid SCROLL the wire
+// never expressed, not for knowledge of the set (that fans out on its own).
+// Only creating or moving a placement can scroll, and retiring one moves
+// nothing — so a removals-only delta is exempt; everything else resyncs:
+// no delta at all (a placement born and dead inside one chunk, witnessed only
+// by the stamp), Added, or Updated (re-placed or retransmitted — charged
+// together because this check cannot tell them apart). Ordinary scrolls cannot
+// reach here: they move placements without moving the stamp.
 func unaccountedResync(deltas []kittyPlacementDelta) (string, bool) {
 	if len(deltas) == 0 {
 		return kittyResyncStampWithoutDelta, true
@@ -735,9 +524,7 @@ func unaccountedResync(deltas []kittyPlacementDelta) (string, bool) {
 	return "", false
 }
 
-// failResync records the first observation failure of this chunk. The APC's
-// grid effect is already in the terminal; the wire gets nothing for it, and the
-// snapshot the client re-attaches for carries the truth.
+// failResync records the first observation failure of this chunk.
 func (f *wireFeeder) failResync(reason string) {
 	if f.resync == "" {
 		f.resync = reason
@@ -745,13 +532,8 @@ func (f *wireFeeder) failResync(reason string) {
 }
 
 // changedPlacements reports the active screen's whole placement set when this
-// feed moved it — membership, geometry, or position — and nothing when it did
-// not. The caller stamps the set with the chunk's seq (Session.readLoop) and
-// hands it to the client.
-//
-// The returned slice needs no copy: observe REPLACES the set rather than
-// mutating it, so what is handed out stays the truth of the moment it
-// described.
+// feed moved it, and nothing when it did not. No copy needed: observe REPLACES
+// the set rather than mutating it.
 func (f *wireFeeder) changedPlacements() ([]ghosttyvt.KittyPlacement, bool) {
 	if len(f.deltas) == 0 {
 		return nil, false
@@ -760,29 +542,21 @@ func (f *wireFeeder) changedPlacements() ([]ghosttyvt.KittyPlacement, bool) {
 }
 
 // snapshotBlocks resolves the block table under the caller's replayMu — the
-// SAME hold that serializes the VT dump and reads the seq watermark.
+// same hold that serializes the VT dump and reads the seq watermark.
 func (f *wireFeeder) snapshotBlocks() []AttachBlockData {
 	return f.blocks.snapshotBlocks()
 }
 
 // snapshotPlacements resolves the active screen's placement set under the
-// caller's replayMu — the same hold as the dump, the blocks, and the watermark,
-// so an attaching client gets one consistent picture rather than four readings
-// of a moving terminal. Also the resize path's read (Session.resize).
+// caller's replayMu, same hold as the dump/blocks/watermark. Also the resize
+// path's read (Session.resize). Read fresh from the terminal, not from the last
+// observation: a resize reflows under the same lock without feeding a chunk.
 //
-// Read fresh from the terminal rather than reused from the last observation: a
-// resize reflows the grid under that same lock without feeding a chunk, so the
-// stored positions can be one reflow stale.
-//
-// The bool says whether this feeder holds any placement, which is NOT the same
-// as the returned set being non-empty: a reflow can drop the last placement, and
-// that reads as held-but-empty — the one thing that tells a client to stop
-// drawing. Only an unheld set skips the terminal, which is what keeps a session
-// without images off cgo here too.
-//
-// The stored set is deliberately left alone. It is the left side of the next
-// diff, and writing it from outside feed() would let a reflow absorb a mutation
-// the end-of-feed check has to see.
+// The bool says whether this feeder holds ANY placement, not whether the
+// returned set is non-empty: held-but-empty (a reflow dropped the last one)
+// tells a client to stop drawing. Only an unheld set skips the terminal, which
+// keeps imageless sessions off cgo. The stored set is deliberately left alone —
+// it is the left side of the next diff.
 func (f *wireFeeder) snapshotPlacements() ([]ghosttyvt.KittyPlacement, bool) {
 	if len(f.placements) == 0 {
 		return nil, false
@@ -797,15 +571,10 @@ func (f *wireFeeder) close() {
 }
 
 // trackedRows resolves where the cursor's cell ended up (anchor) and where the
-// cursor itself is now (landed), in rows counted from the top of retained
-// history.
-//
-// Both are read AFTER the write so they share one coordinate frame; resolving
-// the first one earlier would put it in a frame that scrollback pruning may
-// have shifted out from under it. That shared frame is what makes their
-// difference meaningful on both screens: on the primary the pinned cell keeps
-// its row while the active area slides down past it, on the alternate the
-// active area is fixed and the pinned cell slides up.
+// cursor is now (landed), in rows from the top of retained history. Both are
+// read AFTER the write so they share one coordinate frame — scrollback pruning
+// can shift the frame between reads — which is what makes their difference
+// meaningful on both screens.
 func trackedRows(before, after *ghosttyvt.TrackedRef) (anchor, landed int, ok bool) {
 	if before == nil || after == nil {
 		return 0, 0, false
@@ -827,10 +596,9 @@ func freeTrackedRef(ref *ghosttyvt.TrackedRef) {
 	}
 }
 
-// diffKittyPlacements reports what changed between two observations of the
-// active screen's placement set. Placements are compared whole: the fields are
-// all scalars, and a rule that named specific ones would rot the first time
-// ghostty resolved a new piece of geometry.
+// diffKittyPlacements reports what changed between two observations. Placements
+// are compared whole: all scalar fields, and a field-naming rule would rot on a
+// pin bump.
 func diffKittyPlacements(before, after []ghosttyvt.KittyPlacement) kittyPlacementDelta {
 	var delta kittyPlacementDelta
 	if len(before) == 0 && len(after) == 0 {

--- a/internal/ptybackend/backend.go
+++ b/internal/ptybackend/backend.go
@@ -15,10 +15,9 @@ const (
 	OutputEventKindOutput = "output"
 	OutputEventKindDesync = "desync"
 	OutputEventKindExit   = "exit"
-	// OutputEventKindPlacements carries the session's whole kitty placement set
-	// as of the chunk stamped Seq. It rides the attach stream rather than a
-	// side channel because it only means anything in order against the bytes:
-	// the positions were measured on the grid the same-seq output produces.
+	// OutputEventKindPlacements carries the whole kitty placement set as of the
+	// chunk stamped Seq; it rides the attach stream because positions only mean
+	// anything in order against the same-seq bytes.
 	OutputEventKindPlacements = "kitty_placements"
 )
 
@@ -36,8 +35,7 @@ type SpawnOptions struct {
 	YoloMode          bool
 	InitialPromptFile string
 
-	// Theme seeds the colors the session answers OSC 10/11/12 color queries
-	// with. Zero-value fields fall back to built-in defaults.
+	// Theme seeds the OSC 10/11/12 query answers; zero fields use defaults.
 	Theme pty.TerminalTheme
 
 	// Executable is the selected CLI path for opts.Agent.
@@ -55,46 +53,33 @@ type SpawnOptions struct {
 	// from the daemon's cache. Skips the ~130ms readLoginShellEnv in workers.
 	LoginShellEnv []string
 
-	// WorkflowGuidanceEnabled mirrors the daemon's workflows_enabled setting. When
-	// true the worker exports ATTN_WORKFLOW_GUIDANCE_ENABLED so the launched agent's
-	// instructions include the workflow-trigger guidance.
+	// WorkflowGuidanceEnabled mirrors workflows_enabled; exported as
+	// ATTN_WORKFLOW_GUIDANCE_ENABLED.
 	WorkflowGuidanceEnabled bool
 
-	// AutoApprove mirrors the daemon's auto_approve_enabled setting. When true the
-	// worker exports ATTN_AUTO_APPROVE so the launched agent starts in its native
-	// auto-approve mode (Claude --permission-mode auto). Yolo overrides it.
+	// AutoApprove mirrors auto_approve_enabled; exported as ATTN_AUTO_APPROVE.
+	// Yolo overrides it.
 	AutoApprove bool
-	// ApprovalRoute is the effective, launch-time destination for approval
-	// requests. The worker persists it so a replacement daemon can reconstruct
-	// guardian evidence without consulting a later global setting. Empty is
-	// accepted only for legacy/internal callers that predate route recording.
+	// ApprovalRoute is the effective launch-time approval destination,
+	// persisted so a replacement daemon can reconstruct guardian evidence.
+	// Empty only for legacy callers predating route recording.
 	ApprovalRoute launchcontract.ApprovalRoute
 	// TrustWorkingDirectory is set only for unattended daemon-owned launches.
 	TrustWorkingDirectory bool
 
-	// Model, when set, pins the launched agent's model via --model. Sourced from
-	// the chief_model_<agent> setting for chief launches or a delegation's
-	// --model flag; the worker exports it as ATTN_MODEL. Empty means the agent's
-	// own default.
+	// Model, when set, pins the agent's model via --model (exported as ATTN_MODEL).
 	Model string
 
-	// Effort, when set, pins the launched agent's reasoning effort via its
-	// native mechanism (Claude --effort, Codex model_reasoning_effort). Sourced
-	// from a delegation's --effort flag; the worker exports it as ATTN_EFFORT.
-	// Empty means the agent's own default.
+	// Effort, when set, pins reasoning effort via the agent's native mechanism
+	// (exported as ATTN_EFFORT).
 	Effort string
 
-	// ContextWindowCap, when > 0, is the token threshold the launched agent's
-	// context window is capped at; the worker exports it as
-	// ATTN_AUTO_COMPACT_WINDOW and the launched agent applies it (Claude:
-	// CLAUDE_CODE_AUTO_COMPACT_WINDOW; Codex: model_auto_compact_token_limit).
-	// The daemon owns the policy (chief_context_window_cap for chief launches,
-	// default_context_window_cap_<agent> for everything else); 0 means uncapped.
+	// ContextWindowCap, when > 0, caps the context window at that token
+	// threshold (exported as ATTN_AUTO_COMPACT_WINDOW); the daemon owns the policy.
 	ContextWindowCap int
 
-	// UnattendedLaunch is the daemon-owned launch contract. When set, it is the
-	// sole source for agent, executable, approval, trust, model, effort, and
-	// recovery policy across embedded, worker, and reload paths.
+	// UnattendedLaunch, when set, is the sole source for agent, executable,
+	// approval, trust, model, effort, and recovery policy across all paths.
 	UnattendedLaunch launchcontract.UnattendedLaunchSpec
 }
 
@@ -138,18 +123,16 @@ type AttachInfo struct {
 	ExitCode   *int
 	ExitSignal *string
 	// GhosttySnapshot is the server-authoritative VT serialization of the whole
-	// terminal from libghostty-vt (geometry is Cols/Rows). nil when absent.
+	// terminal (geometry Cols/Rows); nil when absent.
 	GhosttySnapshot []byte
-	// GhosttyBlocks are the worker's OSC 133 command blocks resolved to
-	// SCREEN-space rows of GhosttySnapshot, captured atomically with it and
-	// LastSeq (Phase 3a). nil when absent.
+	// GhosttyBlocks are OSC 133 command blocks resolved to SCREEN-space rows of
+	// GhosttySnapshot, captured atomically with it and LastSeq; nil when absent.
 	GhosttyBlocks []pty.AttachBlockData
-	// GhosttyPlacements is the kitty placement set of the screen
-	// GhosttySnapshot serializes, captured in that same hold. nil when the
-	// session holds no images.
+	// GhosttyPlacements is the serialized screen's kitty placement set,
+	// captured in the same hold; nil when the session holds no images.
 	GhosttyPlacements []pty.KittyPlacement
-	// GhosttyScrollbackTruncated reports whether the ghostty terminal dropped
-	// scrollback lines at its cap before GhosttySnapshot was serialized.
+	// GhosttyScrollbackTruncated: scrollback was dropped at the cap before
+	// GhosttySnapshot was serialized.
 	GhosttyScrollbackTruncated bool
 }
 
@@ -158,8 +141,8 @@ type OutputEvent struct {
 	Data   []byte
 	Seq    uint32
 	Reason string
-	// Placements is the full set on OutputEventKindPlacements, empty included —
-	// an empty set is how a client learns the last image is gone.
+	// Placements is the full set on OutputEventKindPlacements — an empty set is
+	// how a client learns the last image is gone.
 	Placements []pty.KittyPlacement
 }
 
@@ -171,11 +154,9 @@ type SessionInfo struct {
 	Running bool
 	State   string
 
-	// LastSignal is the newest level the session's signal observers emitted, and
-	// false when it has produced none. It is evidence rather than a state claim,
-	// and it is what lets a daemon that restarted learn what a quiet agent's
-	// heartbeat currently says instead of waiting for the next repaint that a
-	// session parked at its prompt will never produce.
+	// LastSignal is the newest signal-observer level (HasLastSignal false when
+	// none). Evidence, not a state claim: it lets a restarted daemon learn a
+	// quiet agent's heartbeat without waiting for a repaint that never comes.
 	LastSignal    pty.Observation
 	HasLastSignal bool
 
@@ -211,11 +192,10 @@ type Backend interface {
 	Spawn(ctx context.Context, opts SpawnOptions) error
 	Attach(ctx context.Context, sessionID, subscriberID string) (AttachInfo, Stream, error)
 	Input(ctx context.Context, sessionID string, data []byte) error
-	// Resize applies a new grid. xpixel/ypixel are the pane's total size in
-	// device pixels, or 0 when the caller has none to report.
+	// Resize applies a new grid; xpixel/ypixel are total device pixels, 0 when unknown.
 	Resize(ctx context.Context, sessionID string, cols, rows, xpixel, ypixel uint16) error
-	// SetTheme updates the colors the session answers OSC 10/11/12 color
-	// queries with. Best-effort: a worker predating the method returns nil.
+	// SetTheme updates the OSC 10/11/12 answer colors. Best-effort: a worker
+	// predating the method returns nil.
 	SetTheme(ctx context.Context, sessionID string, theme pty.TerminalTheme) error
 	// Kill returns nil only after the child process has exited.
 	Kill(ctx context.Context, sessionID string, sig syscall.Signal) error
@@ -234,13 +214,11 @@ type SessionInfoProvider interface {
 	SessionInfo(ctx context.Context, sessionID string) (SessionInfo, error)
 }
 
-// SessionLaunchParams carries the launch flags recorded by a live worker. The
-// worker registry is authoritative for the process that actually survived a
-// daemon restart; the durable launch intent is the fallback when no worker does.
+// SessionLaunchParams carries the launch flags recorded by a live worker —
+// authoritative after a daemon restart; the durable launch intent is the fallback.
 type SessionLaunchParams struct {
-	// Recorded is false for sessions whose worker predates launch-param recording.
-	// The daemon must NOT trust the other fields when false and must abort the
-	// reload rather than respawn with defaulted launch flags.
+	// Recorded is false when the worker predates launch-param recording; the
+	// daemon must then abort the reload rather than respawn with defaults.
 	Recorded          bool
 	YoloMode          bool
 	ApprovalRoute     launchcontract.ApprovalRoute
@@ -253,35 +231,26 @@ type SessionLaunchParams struct {
 	UnattendedLaunch  launchcontract.UnattendedLaunchSpec
 }
 
-// SessionLaunchParamsProvider is implemented by backends that can return the
-// recorded launch params for a live session (the worker backend, via the
-// per-session registry). Backends that cannot (e.g. embedded) omit it, and the
-// daemon aborts the reload rather than respawning with defaults.
+// SessionLaunchParamsProvider returns the recorded launch params for a live
+// session; backends that cannot (e.g. embedded) omit it and the reload aborts.
 type SessionLaunchParamsProvider interface {
 	SessionLaunchParams(ctx context.Context, sessionID string) (SessionLaunchParams, error)
 }
 
-// WorkerProcessProvider is implemented by backends that run each session in its
-// own worker subprocess. It exposes those PIDs (sessionID -> worker pid) so
-// diagnostics can sum per-session RSS via ps/vmmap — the dominant memory locus
-// for the worker backend. Backends without subprocesses (e.g. embedded) do not
-// implement it.
+// WorkerProcessProvider exposes per-session worker PIDs so diagnostics can sum
+// per-session RSS. Backends without subprocesses (e.g. embedded) omit it.
 type WorkerProcessProvider interface {
 	WorkerPIDs(ctx context.Context) map[string]int
 }
 
 // SnapshotProvider returns the current rendered screen of a session without
-// attaching. Backends that cannot serve a snapshot (e.g. a worker built before
-// the capability existed) return an error; callers degrade gracefully.
+// attaching. Backends that cannot return an error; callers degrade gracefully.
 type SnapshotProvider interface {
 	Snapshot(ctx context.Context, sessionID string) (pty.SnapshotInfo, error)
 }
 
-// KittyImageProvider copies one stored image out of a session's terminal, by
-// the ghostty image id a placement carries. Optional like SnapshotProvider: a
-// backend that cannot serve one (a worker built before the method existed)
-// simply is not asked twice — the caller drops that placement's render, and the
-// error names the id it could not find.
+// KittyImageProvider copies one stored image out of a session's terminal by
+// ghostty image id. Optional; on error the caller drops that placement's render.
 type KittyImageProvider interface {
 	KittyImage(ctx context.Context, sessionID string, imageID uint32) (pty.KittyImage, error)
 }

--- a/internal/rankkey/rankkey.go
+++ b/internal/rankkey/rankkey.go
@@ -1,26 +1,13 @@
-// Package rankkey computes fractional rank keys: short strings that sort by
-// byte (lexicographic) order and can always be subdivided, so a new key can be
-// inserted strictly between any two existing keys without rewriting the others.
+// Package rankkey computes fractional rank keys: short strings that sort in
+// byte order and can always be subdivided, so a key inserts strictly between
+// any two others without rewriting them (workspace ordering; a reorder is a
+// single-row write). A key is a base-36 fraction in (0,1) written without the
+// leading "0." over alphabet "0".."9","a".."z", so byte order matches numeric
+// order.
 //
-// This backs workspace ordering. A reorder becomes a single-row write (only the
-// moved workspace's key changes), which is safe across the daemon's websocket
-// fan-out to multiple clients.
-//
-// # Model
-//
-// A key is a base-36 fraction written without the leading "0.": the string
-// "v8" denotes the number 0.v8 in base 36. The alphabet is "0".."9","a".."z"
-// (digit value 0..35), so byte order on the strings matches numeric order on
-// the fractions. Every key denotes a value strictly between 0 and 1.
-//
-// Invariant: a generated key never ends in the minimum digit '0'. A trailing
-// '0' is a numeric no-op (0.v == 0.v0) that would create distinct strings with
-// the same value and break the "byte order == numeric order" guarantee.
-// Forbidding it keeps every key canonical and guarantees there is always room
-// to insert a smaller key just below any key by appending more digits.
-//
-// The empty string "" is a sentinel, not a key: as the low bound it means -inf
-// (MIN), as the high bound it means +inf (MAX).
+// Invariant: a generated key never ends in '0' — a trailing '0' is a numeric
+// no-op (0.v == 0.v0) that would break "byte order == numeric order". The
+// empty string "" is a sentinel, not a key: MIN as low bound, MAX as high.
 package rankkey
 
 import (
@@ -28,8 +15,7 @@ import (
 	"strings"
 )
 
-// digits is the base-36 alphabet. digits[0] is the minimum digit, digits[base-1]
-// the maximum.
+// digits is the base-36 alphabet, minimum digit first.
 const digits = "0123456789abcdefghijklmnopqrstuvwxyz"
 
 const base = len(digits)
@@ -39,8 +25,7 @@ func digitVal(b byte) int {
 	return strings.IndexByte(digits, b)
 }
 
-// digitAt returns the digit value of s at position i, or the supplied default
-// when s has no digit there (i past its end).
+// digitAt returns the digit value of s at position i, or def past its end.
 func digitAt(s string, i, def int) int {
 	if i < len(s) {
 		return digitVal(s[i])
@@ -48,90 +33,65 @@ func digitAt(s string, i, def int) int {
 	return def
 }
 
-// Between returns a key K with a < K < b under byte (lexicographic) order.
-//
-// a == "" means the low bound is MIN (-inf); b == "" means the high bound is
-// MAX (+inf). When the open interval (a, b) is non-empty Between always
-// succeeds, extending precision (appending digits) when there is no single
-// digit of room between a and b.
-//
-// It returns an error only when both bounds are real keys and a >= b, i.e. the
-// interval is empty or inverted.
-//
-// Algorithm: walk one base-36 fraction digit at a time. While a and b share a
-// digit, copy it. At the first position where they differ (da < db), if there
-// is a digit strictly between them emit the midpoint and stop. Otherwise the
-// digits are adjacent (db == da+1): emit da, which makes every later digit
-// strictly less than b regardless of value, so b stops constraining us — from
-// there we only have to stay strictly greater than a, achieved by descending
-// into a's tail and bumping the first position with room.
+// Between returns a key K with a < K < b under byte order. a == "" means MIN;
+// b == "" means MAX. When the open interval (a, b) is non-empty it always
+// succeeds, appending digits when no single digit of room exists; it errors
+// only when both bounds are real keys and a >= b.
 func Between(a, b string) (string, error) {
 	if a != "" && b != "" && a >= b {
 		return "", fmt.Errorf("rankkey: empty interval: a=%q must be < b=%q", a, b)
 	}
 
-	// bMax tracks whether the high bound is open (MAX, or already provably
-	// satisfied because we took a lower digit than b at some position).
+	// bMax: the high bound is open (MAX, or already provably satisfied because
+	// a lower digit than b's was taken at some position).
 	bMax := b == ""
 
 	var out strings.Builder
 	for i := 0; ; i++ {
 		da := digitAt(a, i, 0)
-		// When the high side is open, treat its digit as base ("one past max"),
-		// which leaves the whole digit range available below it.
+		// An open high side reads as base ("one past max"): the whole digit
+		// range below it is available.
 		db := base
 		if !bMax {
 			db = digitAt(b, i, base)
 		}
 
 		if da == db {
-			// Shared digit (only possible while both bounds are real and still
-			// agree at this position). Copy it and continue into finer precision.
 			out.WriteByte(digits[da])
 			continue
 		}
 
-		// da < db here (a < b guarantees the first differing digit has da < db).
+		// da < db (a < b guarantees it at the first differing digit).
 		if db-da >= 2 {
-			// Room for a digit strictly between da and db. The midpoint is at
-			// least da+1 >= 1, so it is never the trailing minimum digit.
+			// The midpoint is >= da+1 >= 1, never the trailing minimum digit.
 			out.WriteByte(digits[(da+db)/2])
 			return out.String(), nil
 		}
 
-		// db == da+1: adjacent, no room at this position. Emit da. Any digits we
-		// append after this are < the remainder of b, so b no longer constrains
-		// us; we now only need to stay strictly greater than a.
+		// db == da+1: adjacent. Emitting da makes every later digit < b's
+		// remainder, so b stops constraining; only "stay strictly above a" is left.
 		out.WriteByte(digits[da])
 		bMax = true
 
-		// Descend through the rest of a, copying its digits until we find a
-		// position where we can bump above a's digit (leaving room below for
-		// future inserts). a's digits are all < base, so such a position always
-		// exists within one more digit when a is exhausted.
+		// Descend a's tail to the first position with room to bump above its digit.
 		for i++; ; i++ {
 			da = digitAt(a, i, 0)
 			if da+1 < base {
-				// Bump to a value strictly above a's digit and below max. Choosing
-				// the midpoint of (da, base) keeps the key central and never lands
-				// on the minimum digit (it is >= da+1 >= 1).
+				// Midpoint of (da, base): central, and >= da+1 >= 1 so never the
+				// minimum digit.
 				out.WriteByte(digits[(da+base)/2])
 				return out.String(), nil
 			}
-			// a's digit is already the max here; we must keep matching it (the new
-			// key has to stay above a) and look one position deeper.
+			// a's digit is max here; keep matching it and look deeper.
 			out.WriteByte(digits[da])
 		}
 	}
 }
 
-// Seed returns n keys k0 < k1 < ... < k(n-1) in strict byte order, evenly
-// spaced with room to insert between any adjacent pair. It is the opening-order
-// seed and the migration backfill. n <= 0 yields an empty slice.
-//
-// Keys are produced by recursive midpoint subdivision of the open interval
-// (MIN, MAX), the same Between math used at runtime, so adjacent Seed outputs
-// are always Between-insertable by construction.
+// Seed returns n keys in strict byte order, evenly spaced (the opening-order
+// seed and migration backfill; n <= 0 yields nil). Recursive midpoint
+// subdivision uses the same Between math as runtime, so adjacent outputs are
+// always Between-insertable by construction.
 func Seed(n int) []string {
 	if n <= 0 {
 		return nil
@@ -150,8 +110,7 @@ func seedRange(keys []string, lo, hi int, low, high string) {
 	mid := (lo + hi) / 2
 	k, err := Between(low, high)
 	if err != nil {
-		// low < high always holds by construction, so this is unreachable; panic
-		// rather than emit a silently-broken seed.
+		// Unreachable (low < high by construction); panic over a broken seed.
 		panic(fmt.Sprintf("rankkey: Seed subdivision failed between %q and %q: %v", low, high, err))
 	}
 	keys[mid] = k
@@ -159,11 +118,11 @@ func seedRange(keys []string, lo, hi int, low, high string) {
 	seedRange(keys, mid+1, hi, k, high)
 }
 
-// After returns a key strictly greater than max under byte order. max == ""
-// yields the first key. It is the new-workspace append.
+// After returns a key strictly greater than max under byte order; max == ""
+// yields the first key. The new-workspace append.
 func After(max string) string {
 	if max == "" {
-		// First key: a central single digit leaves room on both sides.
+		// Central single digit leaves room on both sides.
 		return string(digits[base/2])
 	}
 	k, _ := Between(max, "")

--- a/internal/sessionstate/sessionstate.go
+++ b/internal/sessionstate/sessionstate.go
@@ -49,6 +49,7 @@ const (
 	ClaimTurnAborted Claim = "turn_aborted"
 )
 
+// Observation is one recorded piece of evidence.
 type Observation struct {
 	Source     Source
 	Claim      Claim

--- a/internal/sessionstate/sessionstate.go
+++ b/internal/sessionstate/sessionstate.go
@@ -1,15 +1,7 @@
-// Package sessionstate resolves what an agent session is doing from the evidence
-// collected about it.
-//
-// Sources record what they saw, this package decides what that means, and a tick
-// re-runs the decision so evidence expires. Every clause that can hold a session
-// in a state depends on evidence that either refreshes or ages out, which is what
-// makes a stuck state impossible rather than merely unlikely — the failure of the
-// arrangement it replaced, where each source wrote a state name directly and a
-// session stuck whenever the source that would have moved it on never fired.
-//
-// The package is pure — no daemon, store, or IO imports — so the rules are
-// table-tested directly instead of by standing up a daemon.
+// Package sessionstate resolves what an agent session is doing from recorded
+// evidence. Every clause that can hold a state depends on evidence that either
+// refreshes or ages out, which is what makes a stuck state impossible. Pure —
+// no daemon, store, or IO imports — so the rules are table-tested directly.
 package sessionstate
 
 import (
@@ -18,67 +10,45 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-// Source names where an observation came from. The resolver treats sources
+// Source names where an observation came from; the resolver treats sources
 // differently, so this is not merely diagnostic.
 type Source string
 
 const (
-	// SourceHeartbeat is the agent's own OSC 0 title glyph: a level, refreshed
-	// while its turn runs.
+	// SourceHeartbeat is the agent's OSC 0 title glyph: a level, refreshed while
+	// its turn runs.
 	SourceHeartbeat Source = "heartbeat"
-	// SourceBracket is a hook opening or closing a turn or a tool call. The
-	// primary level — the only signal that survives the multi-second title
-	// silence claude produces in the middle of a blocking tool call.
-	SourceBracket Source = "hook_bracket"
-	// SourceHarnessEvent is a one-shot harness announcement: an approval
-	// request, Claude's Notification hook.
+	// SourceBracket is a turn/tool hook — the only signal that survives claude's
+	// mid-tool-call title silence.
+	SourceBracket      Source = "hook_bracket"
 	SourceHarnessEvent Source = "harness_event"
-	// SourceClassifier is the stop-time verdict on a settled turn.
-	SourceClassifier Source = "classifier"
-	// SourceProcess is the PTY process itself. A level with no expiry: an exited
-	// process does not become un-exited.
+	SourceClassifier   Source = "classifier"
+	// SourceProcess is the PTY process itself: a level with no expiry.
 	SourceProcess Source = "process"
 )
 
-// Claim is what an observation asserts. Deliberately not a protocol state name:
-// a source reports what it saw, and only the resolver names a state. "The turn
-// is running" and "the session is working" are different statements, and
-// collapsing them is what let a heartbeat masquerade as an applied state.
+// Claim is what an observation asserts — deliberately not a protocol state
+// name: a source reports what it saw, and only the resolver names a state.
 type Claim string
 
 const (
-	// ClaimBusy: the agent's turn is running right now.
-	ClaimBusy Claim = "busy"
-	// ClaimSettled: the turn is over. It says nothing about why it ended — an
-	// approval, a question, and a finished turn all settle.
-	ClaimSettled Claim = "settled"
-	// ClaimApprovalPending: the agent asked for permission and has not been
-	// answered.
+	ClaimBusy            Claim = "busy"
+	ClaimSettled         Claim = "settled" // the turn is over, saying nothing about why
 	ClaimApprovalPending Claim = "approval_pending"
-	// ClaimNeedsInput: the agent is waiting on the user specifically, as opposed
-	// to having simply finished.
-	ClaimNeedsInput Claim = "needs_input"
-	// ClaimIdle: the agent finished and wants nothing.
-	ClaimIdle Claim = "idle"
-	// ClaimParked: the stop-time judge read a yielded turn as waiting on its own
-	// background work, not on the user. Only the background-work clause consumes
-	// it — outside a yield the claim describes nothing.
+	ClaimNeedsInput      Claim = "needs_input"
+	ClaimIdle            Claim = "idle"
+	// ClaimParked: a yielded turn is waiting on its own background work. Only the
+	// background-work clause consumes it.
 	ClaimParked Claim = "parked"
-	// ClaimExited: the process is gone.
 	ClaimExited Claim = "exited"
-	// ClaimStopFailed: the turn ended on an API error rather than on an answer.
-	// Distinct from ClaimNeedsInput because the agent did not ask anything — it
-	// was cut off — and a diagnosis that says so is worth more than one that
-	// reports a question nobody asked.
+	// ClaimStopFailed: the turn was cut off by an API error rather than asking
+	// anything — distinct from ClaimNeedsInput.
 	ClaimStopFailed Claim = "stop_failed"
-	// ClaimTurnAborted: the user halted the turn. Distinct from every settle above
-	// because nothing announces it — no agent fires a hook when its turn is
-	// interrupted — so it is the one turn ending that must be read out of the
-	// agent's transcript, and the one that leaves no answer to judge.
+	// ClaimTurnAborted: the user halted the turn. No agent announces it, so it is
+	// read out of the transcript and leaves no answer to judge.
 	ClaimTurnAborted Claim = "turn_aborted"
 )
 
-// Observation is one recorded piece of evidence.
 type Observation struct {
 	Source     Source
 	Claim      Claim
@@ -86,170 +56,113 @@ type Observation struct {
 	ObservedAt time.Time
 }
 
-// Evidence is everything the resolver may read about one session. The daemon
-// owns it and mutates it as observations arrive; the resolver only reads.
-//
-// Levels (Heartbeat, TurnOpen, ToolOpen, Process) describe a condition
-// that holds until it changes. Edges (LastHarnessEvent, LastClassifier) are
-// one-shot facts that stay until superseded.
+// Evidence is everything the resolver may read about one session; the daemon
+// owns and mutates it, the resolver only reads. Levels (Heartbeat, TurnOpen,
+// ToolOpen, Process) hold until they change; edges (LastHarnessEvent,
+// LastClassifier) are one-shot facts that stay until superseded.
 type Evidence struct {
-	// Heartbeat is the most recent title-glyph observation. Its freshness is
-	// what bounds how long a stale bracket may lie.
-	Heartbeat *Observation
-	// LastHarnessEvent is the most recent approval/notification edge.
+	// Heartbeat is the most recent title-glyph observation; its freshness bounds
+	// how long a stale bracket may lie.
+	Heartbeat        *Observation
 	LastHarnessEvent *Observation
-	// LastClassifier is the most recent stop-time verdict.
-	LastClassifier *Observation
-	// Process is the PTY lifecycle level.
-	Process *Observation
+	LastClassifier   *Observation
+	Process          *Observation
 
-	// TurnOpen: a prompt was submitted and no Stop has closed it.
 	TurnOpen bool
-	// TurnEverOpened: a turn has opened at least once in this session's life.
-	// It is what separates "settled" from "has not started yet", which look
-	// identical in every other field — a booting agent paints title frames, and
-	// codex flickers a busy one before its first prompt is even ready.
+	// TurnEverOpened separates "settled" from "has not started yet" — a booting
+	// agent paints title frames (codex flickers a busy one before its prompt).
 	TurnEverOpened bool
-	// ToolOpen: a tool call started and has not reported completion.
-	ToolOpen bool
-	// BackgroundWork: the turn yielded with asynchronous work outstanding, so
-	// it will auto-resume. Reported as a fact on the Stop payload.
+	ToolOpen       bool
+	// BackgroundWork: the turn yielded with async work outstanding and will
+	// auto-resume.
 	BackgroundWork bool
-	// PendingCron: the turn yielded with a scheduled wakeup that will resume it.
-	// It is evidence that the turn is over — a wakeup is only ever learned from a
-	// Stop — and not evidence about whether the user is wanted, so it names a
-	// settle without suppressing one.
+	// PendingCron: the turn yielded with a scheduled wakeup. Evidence the turn is
+	// over, not about whether the user is wanted.
 	PendingCron bool
-	// Compacting: the agent is rewriting its own context, between PreCompact and
-	// PostCompact. It is work that paints no spinner frames and opens no turn, so
-	// nothing else in this table can see it. Measured at 26s, which is long enough
-	// that a compaction between turns reads as a session that finished.
+	// Compacting: between PreCompact and PostCompact — work that paints no frames
+	// and opens no turn, so nothing else here can see it. Measured at 26s.
 	Compacting bool
-	// ReviewerInLoop: something other than the user answers approval requests —
-	// claude's permission classifier, codex's auto_review guardian. It does not
-	// suppress an approval state; it decides how long that state must hold
-	// before it is worth showing anyone.
+	// ReviewerInLoop: something other than the user answers approvals. It does
+	// not suppress the approval state, only how long it holds before being shown.
 	ReviewerInLoop bool
 
-	// LastBusyAt is when the heartbeat last said the turn was running. Staleness
-	// is measured from here rather than from the latest heartbeat: claude blips
-	// its not-busy glyph mid-turn (between tool calls, and while a foreground
-	// tool is still running), so treating any non-busy frame as an immediate
-	// settle would flip a healthy open turn to idle. Zero means the agent has
-	// never reported being busy, which is not the same as having gone quiet.
+	// LastBusyAt is when the heartbeat last said the turn was running; zero means
+	// never. Staleness is measured from here, not the latest heartbeat: claude
+	// blips its not-busy glyph mid-turn, so any non-busy frame read as a settle
+	// would flip a healthy open turn to idle.
 	LastBusyAt time.Time
 
-	// PromptIdleAt is when the harness last confirmed the agent is sitting at its
-	// prompt with nothing outstanding. Claude reports it via its Notification hook
-	// 60s after a settle nobody answered, once, cancelled if the user types first.
-	//
-	// Not an Observation, because it carries no claim about *why*: it fires for a
-	// finished turn exactly as for a question, so it cannot choose between idle and
-	// waiting_input. What it is, is an independent witness that the agent is not
-	// working — the one thing a lost Stop hook leaves attn unable to discover.
+	// PromptIdleAt is when the harness last confirmed the agent sitting at its
+	// prompt. It carries no claim about why, but it is an independent witness the
+	// agent is not working — the one thing a lost Stop hook hides.
 	PromptIdleAt time.Time
 
 	// ClassifyingSince is when a stop-time classification started, zero when none
-	// is running. It is the difference between "the turn settled and it is idle"
-	// and "the turn settled and we are still finding out", which look identical
-	// in every other field.
+	// runs: "settled and idle" vs "settled and still finding out".
 	ClassifyingSince time.Time
 
-	// LastMovement is when any evidence last changed. A session whose evidence
-	// has stopped moving entirely is stuck, which is a distinct condition from
-	// any state it might be reported in.
+	// LastMovement is when any evidence last changed; a frozen table means a
+	// stuck session, distinct from any state it might be reported in.
 	LastMovement time.Time
 }
 
-// Policy holds the timing constants. They are per-agent and measured, so they
-// are an input rather than package constants: a table test states the timing it
-// is testing instead of inheriting it.
+// Policy holds the timing constants: per-agent and measured, so an input rather
+// than package constants.
 type Policy struct {
-	// HeartbeatTTL is how long a busy heartbeat keeps a session working on its
-	// own, outranking every edge below it. It is a precedence window, not a
-	// liveness one: it has to be short, because a busy frame that stays
-	// authoritative too long suppresses the approval and question edges that are
-	// announced precisely when the agent stops painting frames.
+	// HeartbeatTTL is a precedence window, not a liveness one: it must be short,
+	// or a busy frame suppresses the approval/question edges announced exactly
+	// when the agent stops painting.
 	HeartbeatTTL time.Duration
 	// HeartbeatSettleAfter is how long busy frames must have stopped before their
-	// absence is read as the turn having ended. It answers a different question
-	// from HeartbeatTTL — "has it stopped for good" rather than "is it running
-	// right now" — and so it must be sized against the agent's worst repaint gap
-	// rather than its typical one.
+	// absence reads as a settle — sized against the worst repaint gap.
 	HeartbeatSettleAfter time.Duration
-	// StaleAfter is the heartbeat silence that closes a bracket whose closing
-	// hook never arrived. It must exceed the longest silence the agent produces
-	// mid-turn, or a slow tool call reads as a finished turn.
+	// StaleAfter is the heartbeat silence that closes a bracket whose closing hook
+	// never arrived; it must exceed the longest mid-turn silence.
 	StaleAfter time.Duration
-	// StuckAfter is total evidence silence — no source of any kind — after which
-	// the session is reported stuck rather than left in whatever it last showed.
 	StuckAfter time.Duration
-	// SettleGrace is how long past StaleAfter a stale bracket keeps its current
-	// state instead of asserting idle, waiting for a late explanation.
+	// SettleGrace is how long past StaleAfter a stale bracket holds instead of
+	// asserting idle, waiting for a late explanation.
 	SettleGrace time.Duration
 	// ClassifierTimeout bounds how long a running classification may hold a
-	// settle. Past it the session settles without the verdict, because a
-	// classifier that never returns must not be able to freeze a color.
+	// settle; a classifier that never returns must not freeze a color.
 	ClassifierTimeout time.Duration
-	// GuardianDwell is how long an approval must hold before it is published
-	// when a reviewer is in the loop. It is not a delay on genuine approval
-	// requests: with no reviewer the dwell is zero.
+	// GuardianDwell is how long an approval holds before publishing when a
+	// reviewer is in the loop; with no reviewer the dwell is zero.
 	GuardianDwell time.Duration
 }
 
-// Measured on claude 2.1.220 and codex 0.145.0 driven through a real PTY.
-// Claude repaints its title about once a second and goes silent for up to ~3.5s
-// in the middle of a blocking foreground tool call; codex repaints about ten
-// times a second and never goes quiet mid-turn. Hence claude's TTL carries ~55%
-// margin over its repaint interval and codex's carries ~5x.
+// Measured on claude 2.1.220 and codex 0.145.0 through a real PTY: claude
+// repaints its title ~1/s and goes silent up to ~3.5s inside a blocking tool
+// call; codex repaints ~10/s and never goes quiet mid-turn. Claude's TTL
+// carries ~55% margin over its repaint interval, codex's ~5x.
 const (
 	claudeHeartbeatTTL = 1500 * time.Millisecond
 	codexHeartbeatTTL  = 500 * time.Millisecond
-	// defaultHeartbeatSettleAfter is how long busy title frames must have stopped
-	// before their absence settles a session with no bracket open. It is separate
-	// from HeartbeatTTL because the TTL is sized to stay out of the way of approval
-	// edges (pushing it down) and a settle must survive the agent's worst repaint
-	// gap (pushing it up): claude repaints every ~1.92s during a `/compact`, past
-	// the 1.5s TTL. Five seconds clears that with margin for PTY read batching, and
-	// the latency only applies when the classifier declines to answer.
+	// Measured: claude repaints every ~1.92s during a `/compact`, past the 1.5s
+	// TTL; 5s clears that with margin for PTY read batching.
 	defaultHeartbeatSettleAfter = 5 * time.Second
-	// defaultStaleAfter is the heartbeat silence after which an open bracket stops
-	// being believed. It is consulted only when a closing hook was lost, so the
-	// trade is "how long a lost hook shows the wrong color" against "how sure we
-	// are the turn ended". A minute is far past any mid-turn silence either agent
-	// produces (claude's worst measured is ~3.5s inside a tool call); a lost hook
-	// showing green that long is the cheaper failure, with stuck at 90s behind it.
+	// Consulted only when a closing hook was lost. A minute is far past any
+	// measured mid-turn silence (claude's worst ~3.5s).
 	defaultStaleAfter = 60 * time.Second
 	defaultStuckAfter = 90 * time.Second
-	// guardianDwell is the round trip a guardian needs to answer in the user's
-	// place. Measured: 90ms for claude's permission classifier, low seconds for
-	// codex's auto_review. 60s is deliberately far above both — the cost of waiting
-	// is a late notification, the cost of not waiting is a yellow flash on every
-	// tool call of an unattended run.
+	// Measured 90ms for claude's permission classifier, low seconds for codex's
+	// auto_review; 60s is far above both — not waiting means a yellow flash on
+	// every tool call of an unattended run.
 	guardianDwell = 60 * time.Second
-	// defaultSettleGrace is the window past StaleAfter in which a stale bracket
-	// holds rather than asserting idle: the instant a bracket stops being believed
-	// is a bad moment to assert anything, because a late explanation is still
-	// possible. Bounded on purpose — holding forever would reproduce the stuck
-	// color it exists to avoid, and codex has no idle_prompt to unstick it.
+	// Bounded on purpose: holding forever reproduces the stuck color it avoids,
+	// and codex has no idle_prompt to unstick it.
 	defaultSettleGrace = 4 * time.Second
-	// defaultClassifierTimeout is generous on purpose. Overrunning it costs one
-	// visible settle that a late verdict then corrects; undershooting it
-	// reintroduces the flicker the gate exists to prevent.
+	// Generous on purpose: overrunning costs one visible settle a late verdict
+	// corrects; undershooting reintroduces flicker.
 	defaultClassifierTimeout = 30 * time.Second
-	// shellHeartbeatTTL: a shell pane's heartbeat is the foreground process
-	// group, polled once a second and re-emitted on the same 1s keepalive the
-	// title observers use. 2.5s carries margin for one missed poll plus worker
-	// RPC latency. The short agent TTLs exist to stay out of the way of
-	// approval edges; a shell has no such edges, so its TTL is sized for
-	// steadiness instead.
+	// A shell pane's heartbeat is the foreground process group on the 1s
+	// keepalive; 2.5s covers one missed poll plus worker RPC latency. A shell has
+	// no approval edges, so this is sized for steadiness, not precedence.
 	shellHeartbeatTTL = 2500 * time.Millisecond
 )
 
-// PolicyFor returns the timing for an agent. An agent with no measured numbers
-// gets the conservative end of each: a TTL short enough not to hold a session
-// working on a stale glyph, and a stale window long enough not to close a
-// bracket early.
+// PolicyFor returns the timing for an agent; an unmeasured one gets the
+// conservative end of each constant.
 func PolicyFor(agent string) Policy {
 	policy := Policy{
 		HeartbeatTTL:         codexHeartbeatTTL,
@@ -270,8 +183,7 @@ func PolicyFor(agent string) Policy {
 	return policy
 }
 
-// Reason names why the resolver reached a state. It is what `attn state explain`
-// shows, and it is the difference between "the color is wrong" and a diagnosis.
+// Reason names why the resolver reached a state; shown by `attn state explain`.
 type Reason string
 
 const (
@@ -302,58 +214,38 @@ const (
 type Resolution struct {
 	State  protocol.SessionState
 	Reason Reason
-	// Detail carries the winning observation's detail so a diagnosis does not
-	// require re-reading the evidence table.
 	Detail string
-	// Hold means "keep whatever the session already shows"; State is empty when it
-	// is set. A pure resolver cannot express "unchanged" any other way — it never
-	// reads the current state — and every clause that holds is time-bounded.
+	// Hold means "keep whatever the session already shows" (State empty): a pure
+	// resolver never reads the current state, and every holding clause is
+	// time-bounded.
 	Hold bool
 }
 
-// Resolve decides what a session is doing. Pure: same evidence and same clock
-// always give the same answer.
-//
-// The clauses are ordered, first match wins, and the order encodes trust rather
-// than recency. A fresh heartbeat outranks an open approval because the agent
-// cannot be blocked on the user while its turn is visibly running — that
-// combination means the approval was already answered and its closing edge was
-// lost.
+// Resolve decides what a session is doing. Pure: same evidence and clock, same
+// answer. Clauses are ordered, first match wins, and the order encodes trust — a
+// fresh heartbeat outranks an open approval because an agent visibly running
+// cannot be blocked on the user.
 func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
-	// A process that exited is terminal. Nothing below can outrank it, and no
-	// amount of stale evidence should keep a dead session colored as alive.
+	// Terminal; nothing below outranks it.
 	if e.Process != nil && e.Process.Claim == ClaimExited {
 		return Resolution{State: protocol.SessionStateIdle, Reason: ReasonProcessExited, Detail: e.Process.Detail}
 	}
 
-	// The clause that rescues a lost turn-open hook: the agent is visibly
-	// running, whatever the brackets say.
+	// Rescues a lost turn-open hook: visibly running outranks the brackets.
 	if fresh(e.Heartbeat, ClaimBusy, now, policy.HeartbeatTTL) {
 		return Resolution{State: protocol.SessionStateWorking, Reason: ReasonHeartbeatFresh, Detail: e.Heartbeat.Detail}
 	}
 
-	// The harness said in so many words that the agent is blocked on a person.
-	// That outranks every bracket below, because it is announced precisely when
-	// the turn stops looking like it is running.
-	//
-	// Nothing announces the answer — neither agent has a hook for it — so these
-	// edges are retired by the agent going busy past them, in the clearing switch
-	// in the daemon's recorder.
+	// Blocked on a person, announced exactly when the turn stops looking like it
+	// runs, so it outranks every bracket below. Nothing announces the answer:
+	// these edges retire only by the agent going busy past them.
 	if r, ok := harnessEdge(e); ok {
 		return r
 	}
 
-	// The user halted the turn. No agent reports this — the closing bracket is not
-	// late, it is never coming — so without this clause the turn stays open until
-	// the stale window retires it, and a halted agent reads as working for the
-	// whole minute that takes.
-	//
-	// It settles without consulting the classifier: an aborted turn left a
-	// truncated fragment and no answer, and a verdict drawn from that reports a
-	// question the agent never finished asking. It sits above compaction and
-	// background work because an abort ends everything the turn had running, and
-	// below the busy heartbeat because the agent visibly running again is the one
-	// thing that contradicts it.
+	// A halted turn's closing bracket is never coming. It settles without the
+	// classifier (no answer to judge) and sits above compaction/background work
+	// but below the busy heartbeat, which is what contradicts it.
 	if turnAborted(e) {
 		return Resolution{
 			State:  protocol.SessionStateIdle,
@@ -362,12 +254,8 @@ func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
 		}
 	}
 
-	// Compaction is work no other clause can see: it opens no turn and no tool
-	// call, and its title frames have gaps wide enough to read as a finished turn.
-	//
-	// This and the clause below both claim something is running on the strength of
-	// a fact from a hook, so both expire on total silence — a lost PostCompact or
-	// a task that resumed nothing must not pin the session green for good.
+	// Work no other clause can see. This and the clause below expire on total
+	// silence — a lost PostCompact must not pin the session green for good.
 	if e.Compacting {
 		if evidenceStoppedMoving(e, now, policy.StuckAfter) {
 			return Resolution{State: protocol.SessionStateUnknown, Reason: ReasonStuck}
@@ -375,29 +263,13 @@ func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
 		return Resolution{State: protocol.SessionStateWorking, Reason: ReasonCompacting}
 	}
 
-	// The turn yielded with work still running. The fact alone cannot say whether
-	// anyone is waited on — "I'll continue when the build finishes" and "done, I
-	// left the server running" yield identical payloads — so the stop is judged
-	// with the yield in view, and the verdict outranks every guess below it.
-	//
-	// A waiting/idle verdict means the judge read the ending as the user's turn:
-	// the process still running is a leftover, not a reason the turn will resume,
-	// so it settles (and rings) like any other ending. A parked verdict is the
-	// opposite answer — the turn waits on its own work and will resume without
-	// anyone — and it is affirmative evidence for the silence that follows: an
-	// agent sitting out a background wait paints no frames and fires its
-	// prompt-idle notification exactly as a finished one does, so neither total
-	// silence nor the confirmation says anything the verdict has not already
-	// answered. Parked therefore holds working without decaying to unknown —
-	// `unknown` opens a turn, and ringing the user because a build is slow is the
-	// failure this clause exists to remove. The hold is still bounded: the next
-	// busy frame spends the verdict, and the next turn clears the yield.
-	//
-	// With no verdict — the judge failed, declined, or is still out — the ladder
-	// is the old one: hold working while the judgment may yet land, let the
-	// harness's prompt-idle confirmation retire the yield (the safety valve that
-	// keeps a wrongly-held session from staying green forever), and decay to
-	// stuck on total silence.
+	// The turn yielded with work still running; the payload alone cannot say
+	// whether anyone is waited on, so the stop-time verdict outranks every guess
+	// below. A parked verdict is affirmative evidence for the silence that
+	// follows, so it holds working WITHOUT decaying to unknown (unknown opens a
+	// turn); it is still spent by the next busy frame. With no verdict, hold
+	// working while judgment may land, let prompt-idle retire the yield, and
+	// decay to stuck on total silence.
 	if e.BackgroundWork {
 		if r, ok := classifierVerdict(e); ok {
 			return r
@@ -417,33 +289,27 @@ func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
 		return Resolution{State: protocol.SessionStateWorking, Reason: ReasonBackgroundWork}
 	}
 
-	// The harness says the agent is parked at its prompt. That outranks an open
-	// bracket, because a bracket closes on a hook that may never come and this is
-	// a second hook, on a different trigger, saying the same turn is over. It sits
-	// below the approval clause because an unanswered approval is also "parked at
-	// the prompt", and approval is the more useful thing to say.
+	// Outranks an open bracket (a second hook on a different trigger saying the
+	// turn is over) but sits below approval: an unanswered approval is also
+	// "parked at the prompt".
 	if promptIdleConfirmed(e) {
 		return settled(e, ReasonPromptIdle, policy, now)
 	}
 
-	// An open bracket says work is outstanding. Whether to believe it is exactly
-	// what the heartbeat is for: a bracket whose closing hook was lost would
-	// otherwise hold the session working for the rest of its life.
+	// An open bracket says work is outstanding; the heartbeat decides whether to
+	// believe it, or a lost closing hook holds the session working forever.
 	if e.TurnOpen || e.ToolOpen {
-		// A bracket only outranks stuck while something is still arriving. For an
-		// agent with hooks but no heartbeat, heartbeatSilentFor answers "not silent"
-		// forever — it has nothing to have gone quiet from — so without this check
-		// the stale test below cannot retire the bracket and stuck is unreachable.
+		// For an agent with hooks but no heartbeat, heartbeatSilentFor answers
+		// "not silent" forever; without this check stuck is unreachable.
 		if evidenceStoppedMoving(e, now, policy.StuckAfter) {
 			return Resolution{State: protocol.SessionStateUnknown, Reason: ReasonStuck}
 		}
 		if !heartbeatSilentFor(e, now, policy.StaleAfter) {
 			return Resolution{State: protocol.SessionStateWorking, Reason: ReasonBracketOpen}
 		}
-		// The bracket is stale, which means the agent stopped painting frames — what
-		// a finished turn and an approval nobody has announced yet both look like.
-		// So hold for SettleGrace rather than assert idle into a late explanation,
-		// and let a verdict that already landed end the grace early.
+		// A finished turn and an unannounced approval look the same, so hold for
+		// SettleGrace rather than assert idle into a late explanation; a verdict
+		// that already landed ends the grace early.
 		if r, ok := classifierVerdict(e); ok {
 			return r
 		}
@@ -453,41 +319,28 @@ func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
 		return settled(e, ReasonBracketStale, policy, now)
 	}
 
-	// Brackets closed and no busy frames: the turn is over. This is what makes a
-	// settle independent of any particular source — the classifier is allowed to
-	// decline, and when it does nothing else contradicts the working state.
-	//
-	// It needs a turn to have happened, not merely a busy frame: a booting agent
-	// paints frames before its prompt is ready (codex flickers a busy one), and
-	// settling on those reports a turn finished before the agent has taken one.
+	// Brackets closed and no busy frames: the turn is over. Needs a turn to have
+	// happened, not merely a busy frame — a booting agent paints frames before
+	// its prompt is ready.
 	if e.Heartbeat != nil && everTookATurn(e) && !e.TurnOpen && !e.ToolOpen {
-		// The latest frame still says busy and has only gone quiet for longer than
-		// the TTL: a repaint gap, not a settle. An agent whose turn is over stops
-		// painting busy frames for good, so waiting out HeartbeatSettleAfter tells
-		// the two apart. Without it, every gap wider than the TTL settles and
-		// un-settles the session — one owed turn per gap.
+		// A gap only longer than the TTL is a repaint gap, not a settle; without
+		// HeartbeatSettleAfter every wide gap costs one owed turn.
 		if e.Heartbeat.Claim == ClaimBusy && !heartbeatSilentFor(e, now, policy.HeartbeatSettleAfter) {
 			return Resolution{State: protocol.SessionStateWorking, Reason: ReasonHeartbeatGap, Detail: e.Heartbeat.Detail}
 		}
 		return settled(e, ReasonHeartbeatSettled, policy, now)
 	}
 
-	// A wakeup is only ever learned from a Stop, so reaching here with one recorded
-	// means a turn ended and no bracket reopened one — a settle on its own
-	// evidence. It matters because the clause above needs a heartbeat and this does
-	// not: a session reporting hooks without a title (headless, remote) would
-	// otherwise resolve as though it had never spoken. It sits below the heartbeat
-	// so a wakeup that already fired is described by the agent that is visibly
-	// running rather than by the schedule that started it.
+	// A wakeup is only learned from a Stop, so one recorded here is a settle on
+	// its own evidence. It needs no heartbeat: a session reporting hooks without
+	// a title (headless, remote) would otherwise read as never having spoken.
 	if e.PendingCron && !e.TurnOpen && !e.ToolOpen {
 		return settled(e, ReasonCronPending, policy, now)
 	}
 
-	// An agent that has never taken a turn and says it is not running is sitting at
-	// its prompt. Saying so is the only thing that retires the `working` a session
-	// is handed at spawn, since every clause above requires a turn to have opened.
-	// The evidence is the agent's own title, not an absence of one: claude paints a
-	// not-busy glyph once its prompt is ready, codex after its boot flicker.
+	// Never took a turn and says it is not running: at its prompt — the only
+	// thing that retires the `working` handed out at spawn. The evidence is the
+	// agent's own not-busy title, not an absence of one.
 	if e.Heartbeat != nil && e.Heartbeat.Claim == ClaimSettled && !everTookATurn(e) {
 		return Resolution{State: protocol.SessionStateIdle, Reason: ReasonAtPrompt}
 	}
@@ -496,10 +349,9 @@ func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
 		return r
 	}
 
-	// Nothing has moved at all, which is its own diagnosis: a stuck session is
-	// otherwise indistinguishable from a correctly-quiet one. It needs a turn to
-	// have opened first — a launched-and-left-alone agent is silent because there
-	// is nothing to report, and nothing would ever contradict a stuck verdict.
+	// Needs a turn to have opened first: a launched-and-left-alone agent is
+	// silent because there is nothing to report, and nothing would ever
+	// contradict a stuck verdict.
 	if e.TurnEverOpened && evidenceStoppedMoving(e, now, policy.StuckAfter) {
 		return Resolution{State: protocol.SessionStateUnknown, Reason: ReasonStuck}
 	}
@@ -508,18 +360,10 @@ func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
 }
 
 // settled resolves a turn that is over, preferring the classifier's verdict and
-// falling back to the reason that got us here.
-//
-// When no verdict has landed but one is being computed, it holds. The classifier
-// is what separates idle from waiting_input, and it takes seconds: publishing
-// idle first and correcting it on arrival turns every question-ending turn into
-// a visible green-then-yellow flicker. Holding is bounded by ClassifierTimeout,
-// so a classifier that dies still settles the session.
-//
-// A registered wakeup does not change the answer. This table exists to say
-// whether the agent needs the user, and a cron does not answer that either way,
-// so it names why the session settled and nothing more. Suppressing the queue is
-// a user control — a pinned workspace — not something inferred from a schedule.
+// holding (bounded by ClassifierTimeout) while one is computed: publishing idle
+// first and correcting on arrival flickers green-then-yellow. A registered
+// wakeup does not change the answer — suppressing the queue is a user control,
+// not something inferred from a schedule.
 func settled(e Evidence, fallback Reason, policy Policy, now time.Time) Resolution {
 	if r, ok := classifierVerdict(e); ok {
 		return r
@@ -531,9 +375,7 @@ func settled(e Evidence, fallback Reason, policy Policy, now time.Time) Resoluti
 }
 
 // ClassifierVerdictPending reports whether a classification is running and
-// still worth waiting for. Consumers outside the resolver use the same bounded
-// definition when they must distinguish confirmed work from a working state the
-// resolver is temporarily holding while the verdict arrives.
+// still worth waiting for; exported so outside consumers share the same bound.
 func ClassifierVerdictPending(e Evidence, policy Policy, now time.Time) bool {
 	if e.ClassifyingSince.IsZero() {
 		return false
@@ -541,13 +383,9 @@ func ClassifierVerdictPending(e Evidence, policy Policy, now time.Time) bool {
 	return now.Sub(e.ClassifyingSince) <= policy.ClassifierTimeout
 }
 
-// harnessEdge reads the harness's own announcement that the agent is blocked on
-// a person, if one is still outstanding.
-//
-// The two edges differ only in what they say and what answers them, so they
-// share a clause rather than being ordered against each other: a turn cannot be
-// blocked on an approval and on a question at the same time, and whichever
-// arrived last is the one still outstanding.
+// harnessEdge reads an outstanding "blocked on a person" announcement. The edges
+// share one clause: a turn cannot be blocked on an approval and a question at
+// once, and the last arrival is the one outstanding.
 func harnessEdge(e Evidence) (Resolution, bool) {
 	if e.LastHarnessEvent == nil || supersededByBusy(e.LastHarnessEvent, e) {
 		return Resolution{}, false
@@ -567,13 +405,7 @@ func harnessEdge(e Evidence) (Resolution, bool) {
 		}, true
 	case ClaimStopFailed:
 		// A turn cut off by the API is blocked on a person as surely as a question
-		// is: the error is a rate limit to wait out, a bill to pay, or a login to
-		// renew, and the agent will not produce anything until one of those
-		// happens. Reported as waiting on the user because that is what it is —
-		// the detail carries which error, which is the part worth reading.
-		//
-		// Retired like the others, by the agent going busy again. That is the right
-		// edge whether the user fixed the cause or simply re-prompted.
+		// is (rate limit, bill, login); the detail carries which error.
 		return Resolution{
 			State:  protocol.SessionStateWaitingInput,
 			Reason: ReasonStopFailed,
@@ -584,41 +416,27 @@ func harnessEdge(e Evidence) (Resolution, bool) {
 	}
 }
 
-// turnAborted reports whether the harness recorded the user halting the turn,
-// with nothing since to spend that.
-//
-// It shares LastHarnessEvent with the edges above rather than taking a field of
-// its own: an abort is a one-shot harness announcement like the others, it
-// retires on the same terms — the agent going busy past it, or the next turn
-// opening — and it cannot coexist with them, because a turn the user halted is
-// not also blocked on an approval. harnessEdge ignores the claim, so the two
-// readers of the slot cannot both fire.
+// turnAborted reports a recorded halt with nothing since to spend it. It shares
+// LastHarnessEvent with harnessEdge, which ignores the claim, so the two readers
+// of the slot cannot both fire.
 func turnAborted(e Evidence) bool {
 	return e.LastHarnessEvent != nil &&
 		e.LastHarnessEvent.Claim == ClaimTurnAborted &&
 		!supersededByBusy(e.LastHarnessEvent, e)
 }
 
-// parkedVerdict reports whether the stop-time judge read the current yield as
-// the turn waiting on its own background work rather than on the user. Spent
-// the same way every verdict is: by the agent going busy past it — which for a
-// parked turn is precisely the resume it predicted.
+// parkedVerdict reports a stop-time verdict of "waiting on its own background
+// work", spent by the agent going busy past it — the resume it predicted.
 func parkedVerdict(e Evidence) bool {
 	return e.LastClassifier != nil &&
 		e.LastClassifier.Claim == ClaimParked &&
 		!supersededByBusy(e.LastClassifier, e)
 }
 
-// classifierVerdict reads the stop-time verdict, if one belongs to the current
-// turn. It answers only the two claims that name a state; parked is read by the
-// background-work clause alone, because outside a yield it describes nothing.
-//
-// A verdict describes the turn it was computed for and nothing else. The turn
-// bracket clears it when the next turn opens, but a turn may also start without
-// its hook — surviving that is the whole reason the heartbeat is here — so this
-// also drops a verdict the agent has since gone busy past. Otherwise a turn that
-// settles while its own classification is still running takes the previous
-// turn's answer instead of holding for its own.
+// classifierVerdict reads the stop-time verdict belonging to the current turn;
+// parked is read by the background-work clause alone. A verdict the agent has
+// gone busy past is dropped, or a turn settling mid-classification would take
+// the previous turn's answer.
 func classifierVerdict(e Evidence) (Resolution, bool) {
 	if e.LastClassifier == nil {
 		return Resolution{}, false
@@ -644,13 +462,8 @@ func classifierVerdict(e Evidence) (Resolution, bool) {
 	}
 }
 
-// DwellFor is how long a transition into state must hold before it is published.
-//
-// It is keyed on who is being asked first. With a guardian in the loop, an
-// approval request is addressed to the guardian, and showing it to the user
-// immediately produces a flash of attention-demanding color on every tool call
-// of an unattended run. With no guardian the user *is* the reviewer, so the
-// dwell is zero and a genuine request is not delayed by a millisecond.
+// DwellFor is how long a transition into state must hold before publishing: with
+// no reviewer in the loop the user IS the reviewer, so the dwell is zero.
 func DwellFor(state protocol.SessionState, e Evidence, policy Policy) time.Duration {
 	if state == protocol.SessionStatePendingApproval && e.ReviewerInLoop {
 		return policy.GuardianDwell
@@ -658,12 +471,9 @@ func DwellFor(state protocol.SessionState, e Evidence, policy Policy) time.Durat
 	return 0
 }
 
-// supersededByBusy reports whether the agent has painted a busy frame since o
-// was observed.
-//
-// Both edges this retires — an unanswered approval and a stop-time verdict —
-// describe a moment the agent was *not* running. A later busy frame is proof it
-// moved on, and neither edge has an announcement of its own to expire on.
+// supersededByBusy reports whether the agent painted a busy frame since o. The
+// edges this retires describe a moment the agent was not running and have no
+// announcement of their own to expire on.
 func supersededByBusy(o *Observation, e Evidence) bool {
 	if o == nil || e.LastBusyAt.IsZero() {
 		return false
@@ -676,17 +486,7 @@ func fresh(o *Observation, claim Claim, now time.Time, ttl time.Duration) bool {
 	return o != nil && o.Claim == claim && now.Sub(o.ObservedAt) <= ttl
 }
 
-// heartbeatSilentFor reports whether the agent has stopped saying it is busy for
-// longer than d.
-//
-// It reads LastBusyAt, not the latest heartbeat: claude blips its idle glyph
-// mid-turn, so only the absence of busy frames for a full window counts. An agent
-// that has never reported being busy is not silent — one with no harness signals
-// must not have its brackets closed out from under it.
-// everTookATurn reports whether this session has been seen doing anything at all.
-//
-// The classifier counts alongside the brackets: a verdict only exists because a
-// turn ended, and it outlives the bracket that produced it. A daemon restarted
+// everTookATurn counts the classifier alongside the brackets: a daemon restarted
 // mid-turn leaves exactly that shape — judged, with no bracket to show for it.
 func everTookATurn(e Evidence) bool {
 	if e.TurnOpen || e.ToolOpen || e.TurnEverOpened {
@@ -695,12 +495,8 @@ func everTookATurn(e Evidence) bool {
 	return e.LastClassifier != nil || !e.ClassifyingSince.IsZero()
 }
 
-// evidenceStoppedMoving reports whether every source has gone quiet for d.
-//
-// Deliberately not the heartbeat's question: that one asks whether the agent is
-// painting frames, which stops routinely mid-turn, while this asks whether
-// anything at all has been heard from. A frozen table means a lost session, not
-// whatever state it last showed.
+// evidenceStoppedMoving reports whether every source has gone quiet for d —
+// deliberately not the heartbeat's question, which stops routinely mid-turn.
 func evidenceStoppedMoving(e Evidence, now time.Time, d time.Duration) bool {
 	if e.LastMovement.IsZero() {
 		return false
@@ -708,16 +504,15 @@ func evidenceStoppedMoving(e Evidence, now time.Time, d time.Duration) bool {
 	return now.Sub(e.LastMovement) > d
 }
 
-// promptIdleConfirmed reports whether the harness has confirmed the agent is
-// sitting at its prompt, and nothing has happened since to spend that.
-//
-// LastBusyAt is the guard, not the 60s the notification happens to use: if the
-// agent painted a spinner after the confirmation, a new turn started and the
-// confirmation is spent. Nothing here breaks if claude retunes the timer.
+// promptIdleConfirmed guards on LastBusyAt, not the 60s the notification happens
+// to use, so nothing breaks if claude retunes it.
 func promptIdleConfirmed(e Evidence) bool {
 	return !e.PromptIdleAt.IsZero() && e.PromptIdleAt.After(e.LastBusyAt)
 }
 
+// heartbeatSilentFor reads LastBusyAt, not the latest heartbeat (claude blips its
+// idle glyph mid-turn). An agent that never reported busy is not silent — one
+// with no harness signals must not have its brackets closed out from under it.
 func heartbeatSilentFor(e Evidence, now time.Time, d time.Duration) bool {
 	if e.LastBusyAt.IsZero() {
 		return false

--- a/internal/statetrace/statetrace.go
+++ b/internal/statetrace/statetrace.go
@@ -1,19 +1,7 @@
-// Package statetrace records the state observations a session received and what
-// happened to each one.
-//
-// "Sometimes the color gets stuck" is unfalsifiable today: the daemon logs the
-// transitions it accepted and says nothing about the ones it dropped, so a
-// session sitting on a wrong color leaves no trace of whether the right
-// observation never arrived, arrived and was vetoed before reaching the store,
-// or arrived and lost to a newer writer. A stuck color is exactly the case where
-// nothing is being applied, so a log of applied transitions is blind to it.
-//
-// The recorder keeps a capped per-session ring of every observation, including
-// the rejected ones, with the reason for the rejection. It is pure bookkeeping:
-// nothing here influences which state a session ends up in, and it holds no
-// reference to the store. Phase 0 of the state-detection plan records into it
-// from every existing source without changing arbitration, so the current
-// behavior is captured as a baseline before the resolver replaces it.
+// Package statetrace keeps a capped per-session ring of every state
+// observation a session received — including rejected ones, with the reason —
+// so a stuck state is diagnosable. Pure bookkeeping: nothing here influences
+// which state a session ends up in, and it holds no reference to the store.
 package statetrace
 
 import (
@@ -23,52 +11,36 @@ import (
 	"time"
 )
 
-// DefaultCapacity is how many observations are kept per session. A session
-// producing an observation every second holds a bit over three minutes of
-// history, which covers the window a human takes to notice a wrong color and go
-// looking.
+// DefaultCapacity is how many observations are kept per session — at one per
+// second, a bit over three minutes of history.
 const DefaultCapacity = 256
 
-// Outcome is what became of an observation. The three rejection outcomes are
-// kept apart because they point at different bugs: a veto means a driver's
-// transition filter refused it, a discard means the store's own commit rule
-// refused it, and a skip means the source itself decided it had nothing to say.
+// Outcome is what became of an observation.
 type Outcome string
 
 const (
 	// OutcomeApplied means the state reached the store and was committed.
 	OutcomeApplied Outcome = "applied"
-	// OutcomeDiscarded means the observation reached applyState and the store's
-	// commit rule refused it (a stale classifier result, a losing plugin CAS).
+	// OutcomeDiscarded means applyState's commit rule refused it.
 	OutcomeDiscarded Outcome = "discarded"
-	// OutcomeVetoed means something rejected the observation before it ever
-	// reached applyState.
+	// OutcomeVetoed means it was rejected before ever reaching applyState.
 	OutcomeVetoed Outcome = "vetoed"
-	// OutcomeSkipped means the source produced no claim at all — it looked and
-	// decided there was nothing to report.
+	// OutcomeSkipped means the source produced no claim at all.
 	OutcomeSkipped Outcome = "skipped"
-	// OutcomeObserved means the observation was recorded as evidence and never
-	// offered to the store, because its source does not drive state. The harness
-	// signals are wired this way ahead of the resolver that will weigh them.
+	// OutcomeObserved means evidence only: its source does not drive state.
 	OutcomeObserved Outcome = "observed"
 )
 
-// Observation is one recorded piece of state evidence and its fate.
-//
-// ObservedAt and RecordedAt are both kept: an observation can reach the daemon
-// well after the moment it describes (the worker RPC hop, a slow classifier),
-// and the gap between the two is itself diagnostic.
+// Observation is one recorded piece of state evidence and its fate. The gap
+// between ObservedAt and RecordedAt is itself diagnostic.
 type Observation struct {
-	// Source names where the evidence came from — a pty source name, a hook, the
-	// classifier. Sources are free-form strings because they cross package
-	// boundaries that must not depend on this one.
+	// Source is a free-form name for where the evidence came from.
 	Source string
 	// Claim is the state the source argued for, or "" for a skip.
 	Claim string
 	// Detail is the human-readable why, carried verbatim from the source.
 	Detail string
-	// Cause names the applyState commit rule the observation travelled under, or
-	// "" when it never got that far.
+	// Cause names the applyState commit rule, or "" when it never got that far.
 	Cause string
 	// Outcome is what happened to it.
 	Outcome Outcome
@@ -78,18 +50,14 @@ type Observation struct {
 	ObservedAt time.Time
 	// RecordedAt is when the daemon acted on it.
 	RecordedAt time.Time
-	// Repeats counts how many identical observations this entry stands for beyond
-	// the first. A level source restates itself continuously — the OSC 0 title
-	// heartbeat repaints about once a second — and appending every restatement
-	// would evict the rest of the history from a bounded ring within a minute.
-	// Consecutive identical observations collapse into one entry whose RecordedAt
-	// tracks the latest, so the ring holds real history and still shows liveness.
+	// Repeats counts identical observations collapsed into this entry: a level
+	// source restating itself once a second would otherwise evict the ring's
+	// whole history within a minute.
 	Repeats int
 }
 
-// sameEvidenceAs reports whether two observations say the same thing, which is
-// what makes them collapsible. RecordedAt and ObservedAt deliberately do not
-// count: the whole point is that the newer one only updates the timestamps.
+// sameEvidenceAs reports whether two observations are collapsible; timestamps
+// deliberately do not count.
 func (o Observation) sameEvidenceAs(other Observation) bool {
 	return o.Source == other.Source &&
 		o.Claim == other.Claim &&
@@ -99,9 +67,8 @@ func (o Observation) sameEvidenceAs(other Observation) bool {
 		o.Detail == other.Detail
 }
 
-// LogLine renders one observation as a single daemon-log line. It is the form
-// the daemon writes on every recorded observation, so a log tail carries the
-// same trace the ring does for sessions that have already been forgotten.
+// LogLine renders one observation as a single daemon-log line, so a log tail
+// carries the trace for sessions whose ring is already forgotten.
 func (o Observation) LogLine(sessionID string) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "state trace: session=%s source=%s claim=%s outcome=%s", sessionID, orDash(o.Source), orDash(o.Claim), orDash(string(o.Outcome)))
@@ -130,17 +97,15 @@ func orDash(value string) string {
 	return value
 }
 
-// Recorder holds one ring per session. It is safe for concurrent use: every
-// state source in the daemon writes to it from its own goroutine.
+// Recorder holds one ring per session; safe for concurrent use.
 type Recorder struct {
 	mu       sync.Mutex
 	capacity int
 	rings    map[string]*ring
 }
 
-// New returns a recorder keeping capacity observations per session. A capacity
-// of zero or less falls back to DefaultCapacity rather than silently recording
-// nothing.
+// New returns a recorder keeping capacity observations per session; zero or
+// less falls back to DefaultCapacity.
 func New(capacity int) *Recorder {
 	if capacity <= 0 {
 		capacity = DefaultCapacity
@@ -156,24 +121,16 @@ func (r *Recorder) Capacity() int {
 	return r.capacity
 }
 
-// Record appends an observation, evicting the oldest once the ring is full. A
-// nil recorder records nothing, so callers need no guard.
+// Record appends an observation, evicting the oldest once the ring is full; a
+// nil recorder records nothing.
 func (r *Recorder) Record(sessionID string, obs Observation) {
 	r.RecordIf(sessionID, obs, nil)
 }
 
-// RecordIf appends an observation only when admit reports the session is still
-// one the recorder should hold a ring for. A nil admit always appends.
-//
-// admit runs while the recorder's lock is held, which is the whole point: the
-// caller's liveness check and the write are then atomic with respect to Forget.
-// Checking liveness before calling Record instead leaves a window — check
-// passes, the session is removed and its ring forgotten, the writer resumes and
-// creates a fresh ring for an id nothing will ever forget again — which is a
-// leak that grows for the daemon's lifetime.
-//
-// admit must not call back into the recorder, and must not take a lock that
-// anything holds while calling in here.
+// RecordIf appends only when admit says the session still deserves a ring (nil
+// always appends). admit runs under the recorder's lock so the check is atomic
+// with Forget — checking before Record can recreate a ring nothing will ever
+// forget. admit must not call the recorder or take a lock held while calling in.
 func (r *Recorder) RecordIf(sessionID string, obs Observation, admit func() bool) {
 	if r == nil || sessionID == "" {
 		return
@@ -203,8 +160,7 @@ func (r *Recorder) RecordIf(sessionID string, obs Observation, admit func() bool
 	target.push(obs)
 }
 
-// Observations returns the session's recorded observations, oldest first. The
-// slice is a copy; the caller may hold it while more arrive.
+// Observations returns a copy of the session's observations, oldest first.
 func (r *Recorder) Observations(sessionID string) []Observation {
 	if r == nil {
 		return nil
@@ -218,8 +174,7 @@ func (r *Recorder) Observations(sessionID string) []Observation {
 	return target.snapshot()
 }
 
-// SessionCount is how many sessions currently hold a ring. It exists so a leak —
-// a ring created for an id that will never be forgotten — is assertable.
+// SessionCount is how many sessions hold a ring, so a ring leak is assertable.
 func (r *Recorder) SessionCount() int {
 	if r == nil {
 		return 0
@@ -229,8 +184,7 @@ func (r *Recorder) SessionCount() int {
 	return len(r.rings)
 }
 
-// Forget drops a session's ring. Called when a session is unregistered so the
-// recorder does not grow without bound across a long-lived daemon.
+// Forget drops a session's ring so the recorder does not grow without bound.
 func (r *Recorder) Forget(sessionID string) {
 	if r == nil {
 		return
@@ -263,9 +217,8 @@ func (r *ring) push(obs Observation) {
 	r.start = (r.start + 1) % capacity
 }
 
-// newest returns a pointer to the most recently pushed observation, or nil when
-// the ring is empty. The pointer is into the ring's own storage so a collapsing
-// repeat can update it in place.
+// newest returns a pointer into the ring's own storage (nil when empty) so a
+// collapsing repeat can update it in place.
 func (r *ring) newest() *Observation {
 	if r.size == 0 {
 		return nil

--- a/internal/store/bus.go
+++ b/internal/store/bus.go
@@ -6,22 +6,13 @@ import (
 	"time"
 )
 
-// The durable event bus substrate (migration 84). This file is only persistence:
-// an append-only log whose AUTOINCREMENT seq doubles as the cursor space, plus a
-// registry of named consumers holding a position in that space. The delivery
-// semantics — ordering, at-least-once, filters, retention window — live in
-// internal/bus, which reaches this through an interface so neither package
-// depends on the other (the daemon adapts them, as it does for internal/jobs).
-//
-// The shape is lifted from the ticket event log (migration 56), which proved it:
-// a monotonic seq is a cursor space, and a consumer that was down catches up by
-// reading forward from its own bookmark. The difference is scope. Ticket cursors
-// are per-(identity, ticket) because "unread" is a per-ticket question; bus
-// cursors are one per consumer because a consumer is a program, not a reader.
+// Durable event bus substrate (migration 84): an append-only log whose
+// AUTOINCREMENT seq doubles as the cursor space, plus a registry of named
+// consumers. Delivery semantics live in internal/bus, reached through an
+// interface so neither package imports the other.
 
-// BusEvent is one fact on the log. Payload is opaque JSON (the empty string when
-// a fact carries nothing beyond its subject). Source names the publisher for
-// diagnosis, not for routing.
+// BusEvent is one fact on the log. Payload is opaque JSON (empty when the
+// subject says everything); Source names the publisher for diagnosis.
 type BusEvent struct {
 	Seq       int64
 	Name      string
@@ -31,11 +22,8 @@ type BusEvent struct {
 	CreatedAt time.Time
 }
 
-// BusConsumer is a durable consumer's registration and position. Filter is the
-// consumer's subscription expression, stored so `bus status` can report what a
-// consumer is watching without the consumer being live. Enabled=false is the kill
-// switch: a disabled consumer is not delivered to, and — deliberately — does not
-// pin the retention window.
+// BusConsumer is a durable consumer's registration and position. Enabled=false
+// is the kill switch: not delivered to, and deliberately not pinning retention.
 type BusConsumer struct {
 	Name      string
 	Cursor    int64
@@ -44,13 +32,8 @@ type BusConsumer struct {
 	UpdatedAt time.Time
 }
 
-// AppendBusEvent appends a fact and returns its seq.
-//
-// There is no dedup here, unlike the ticket event log. Ticket events dedup
-// against the previous event because a retried mutation must not double-post a
-// comment; bus facts are emitted by code that already decided something changed,
-// and two identical facts in a row are a real occurrence (a session entering the
-// same state twice), not a retry.
+// AppendBusEvent appends a fact and returns its seq. No dedup: two identical
+// facts in a row are a real occurrence, not a retry.
 func (s *Store) AppendBusEvent(e BusEvent, now time.Time) (int64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -61,10 +44,8 @@ func (s *Store) AppendBusEvent(e BusEvent, now time.Time) (int64, error) {
 	return appendBusEventWith(s.db, e, now)
 }
 
-// appendBusEventWith is the append itself, taking whatever runs the statement.
-// A composite write (see CommitDocumentWrite) passes its transaction so the fact
-// and the change it describes are one commit; AppendBusEvent passes the database
-// and gets SQLite's implicit single-statement transaction.
+// appendBusEventWith takes whatever runs the statement: a composite write (see
+// CommitDocumentWrite) passes its transaction so fact and change are one commit.
 func appendBusEventWith(x execer, e BusEvent, now time.Time) (int64, error) {
 	res, err := x.Exec(`
 		INSERT INTO bus_events (name, subject, payload, source, created_at)
@@ -76,10 +57,8 @@ func appendBusEventWith(x execer, e BusEvent, now time.Time) (int64, error) {
 	return res.LastInsertId()
 }
 
-// BusEventsSince returns up to limit events with seq greater than cursor, in seq
-// order. Filtering is the caller's job: a consumer reads the raw forward stream
-// and advances its cursor past events it does not want, which keeps the cursor
-// monotone and the query free of pattern matching.
+// BusEventsSince returns up to limit events with seq greater than cursor, in
+// seq order; filtering is the caller's job.
 func (s *Store) BusEventsSince(cursor int64, limit int) ([]BusEvent, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -114,10 +93,8 @@ func (s *Store) BusEventsSince(cursor int64, limit int) ([]BusEvent, error) {
 	return events, rows.Err()
 }
 
-// BusBounds returns the lowest and highest seq currently in the log; both are 0
-// when the log is empty. The low bound is what makes a trimmed-past cursor
-// detectable: a consumer whose cursor sits below it has missed events that no
-// longer exist.
+// BusBounds returns the lowest and highest seq in the log (both 0 when empty);
+// a cursor below the low bound has missed events that no longer exist.
 func (s *Store) BusBounds() (earliest, head int64, err error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -161,8 +138,7 @@ func (s *Store) GetBusConsumer(name string) (BusConsumer, bool, error) {
 }
 
 // SaveBusConsumer creates or updates a registration. An existing row keeps its
-// cursor and enabled bit: re-registering at startup must not rewind a consumer's
-// position, and must not silently re-enable one the operator killed.
+// cursor and enabled bit: startup must not rewind or silently re-enable one.
 func (s *Store) SaveBusConsumer(c BusConsumer, now time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -182,8 +158,7 @@ func (s *Store) SaveBusConsumer(c BusConsumer, now time.Time) error {
 	return err
 }
 
-// SetBusConsumerCursor persists a consumer's position. This is the write on the
-// delivery hot path, so it touches only the two columns it owns.
+// SetBusConsumerCursor persists a consumer's position (the delivery hot path).
 func (s *Store) SetBusConsumerCursor(name string, cursor int64, now time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -248,14 +223,9 @@ func (s *Store) ListBusConsumers() ([]BusConsumer, error) {
 	return out, rows.Err()
 }
 
-// TrimBusEvents deletes events older than cutoff that every ENABLED consumer has
-// already passed, and reports how many rows went. Both conditions must hold: the
-// age window bounds growth, and the cursor floor keeps a live-but-lagging
-// consumer from losing events it has not read.
-//
-// Disabled consumers are excluded from the floor on purpose. A killed extension
-// must not pin the log indefinitely; when it comes back below the floor,
-// internal/bus resumes it at head and logs the gap.
+// TrimBusEvents deletes events older than cutoff that every ENABLED consumer
+// has passed. Disabled consumers are excluded from the floor on purpose: a
+// killed consumer must not pin the log; internal/bus resumes it at head.
 func (s *Store) TrimBusEvents(cutoff time.Time) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -278,22 +248,11 @@ func (s *Store) TrimBusEvents(cutoff time.Time) (int, error) {
 	return int(n), err
 }
 
-// CompactBusEvents keeps only the newest fact per subject among the named ones,
-// and only below floor. It reports how many rows went.
-//
-// Which names may be compacted is a semantic question and is answered in
-// internal/bus; this is the SQL, the same split trimming uses. A compactable
-// name is one whose facts are pure invalidations — five of them about one
-// subject carry no more information than the newest, because the state itself
-// lives in the store and every consumer reads it from there.
-//
-// floor is the caller's cursor floor and is what makes this safe: a row at or
-// below it has been read by every enabled consumer, so removing it cannot cost
-// anyone a delivery, and reconcileGap's "below the earliest surviving seq means
-// trimmed" assumption stays true because no holes are punched above the floor.
-//
-// An empty name list is not "compact everything": it compacts nothing, because
-// a caller that named nothing asked for nothing.
+// CompactBusEvents keeps only the newest fact per subject among the named
+// names, at or below floor (the cursor floor: every enabled consumer has read
+// those rows, so removal costs no delivery and punches no holes above the
+// floor). Which names are compactable is internal/bus's call. An empty name
+// list compacts nothing, not everything.
 func (s *Store) CompactBusEvents(names []string, floor int64) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -310,9 +269,7 @@ func (s *Store) CompactBusEvents(names []string, floor int64) (int, error) {
 	for _, n := range names {
 		args = append(args, n)
 	}
-	// The correlated MAX is an index walk over idx_bus_events_subject (subject,
-	// seq): for each candidate row, the newest fact about the same subject is the
-	// last entry of that subject's index range.
+	// The correlated MAX walks idx_bus_events_subject (subject, seq).
 	res, err := s.db.Exec(`
 		DELETE FROM bus_events
 		WHERE name IN (`+placeholders+`)
@@ -330,14 +287,8 @@ func (s *Store) CompactBusEvents(names []string, floor int64) (int, error) {
 	return int(n), err
 }
 
-// BusLogSize reports how many facts the log holds and how many bytes of event
-// text they carry.
-//
-// Bytes is the weight of the rows themselves — name, subject, payload, source
-// and stamp — not the size of the database file: SQLite pages are shared with
-// every other table, so a file size would answer a different question than "is
-// the log outgrowing the data it describes". That is the question `attn bus
-// status` asks, and the one fact-class compaction exists to keep answerable.
+// BusLogSize reports the log's row count and event-text bytes. Bytes measures
+// the rows themselves, not the database file — SQLite pages are shared.
 func (s *Store) BusLogSize() (rows int64, bytes int64, err error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -10,53 +10,21 @@ import (
 	"github.com/victorarias/attn/internal/docstore"
 )
 
-// SQLite persistence for the document store. This file is only persistence:
-// what a query means, and the SQL a validated one compiles to, live in
-// internal/docstore, which reaches nothing — the same split internal/bus and
-// bus.go use.
-//
-// ONE TABLE PER COLLECTION. `document_collections` is the registry: one row per
-// declared collection, whose row id mints the name of the table holding its
-// documents (`doc_<id>`). A declared field is an indexed VIRTUAL generated
-// column over the body in that table, so a query reads an index instead of
-// scanning, while the body is still stored and returned byte for byte and
-// declaring a field rewrites no document. The measurement behind the shape is
-// in docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md.
-//
-// Isolation is structural rather than a check: a collection's documents are the
-// only rows in its table, so there is no read or write here that could reach
-// another namespace even if its predicate were wrong.
-//
-// Every identifier spliced into the SQL below comes from docstore — a table
-// name derived from an integer, a column name derived from a field name that
-// matched a validating pattern. None of it is caller text.
+// SQLite persistence for the document store; query semantics and SQL
+// compilation live in internal/docstore. One table per collection
+// (`doc_<registry-id>`); a declared field is an indexed VIRTUAL generated
+// column over the body. Every identifier spliced into SQL here comes from
+// docstore — derived from an integer or a validated field name, never caller
+// text. Design: docs/plans/2026-08-03-ext-a3.1-doc-store-physical-schema.md.
 
-// documentColumns is the read projection; body is returned byte for byte. The
-// generated columns are never selected: they exist to be filtered and ordered
-// on, and the body already carries what they compute.
-//
-// rev is in the projection rather than fetched on demand because it is the token
-// a read-modify-write hands back, and a caller that had to ask for it separately
-// would be reading a version it did not read the body of.
+// documentColumns is the read projection; body is returned byte for byte, and
+// generated columns are never selected.
 const documentColumns = `id, body, rev, created_at, updated_at`
 
 // DefineDocumentCollection records a collection's declaration and brings its
-// table into line with it, creating the table on first declaration. Redeclaring
-// is how a collection gains or loses a queryable field: an added field is a new
-// generated column plus its index, a removed one drops both, and a field whose
-// type changed is replaced so its column carries the new affinity. Documents are
-// never rewritten — a VIRTUAL column computes from the body, so it applies to
-// every document already stored the moment it exists.
-//
-// Registry row and DDL commit together. A declaration whose table did not get
-// built, or a table no declaration names, would each be a collection that
-// cannot be queried or cannot be found.
-//
-// The returned bool reports whether this was a redeclaration of an existing
-// collection. Only the define's own transaction can tell — a caller checking
-// existence first would race a concurrent define — and the caller needs the
-// distinction because a redeclare has watchers to wake and a first declaration
-// cannot.
+// table into line with it, creating it on first declaration; registry row and
+// DDL commit together. The bool reports a redeclaration (which has watchers to
+// wake) — only the define's own transaction can tell without racing.
 func (s *Store) DefineDocumentCollection(schema docstore.CollectionSchema, now time.Time) (bool, error) {
 	if s.db == nil {
 		return false, fmt.Errorf("store: no database")
@@ -114,9 +82,7 @@ func (s *Store) DefineDocumentCollection(schema docstore.CollectionSchema, now t
 }
 
 // DocumentCollection returns a collection's declaration with its table filled
-// in. The bool is false with a nil error when the collection was never declared
-// — a caller must tell "no such collection" apart from a read failure, because
-// the first is what every query against an undeclared collection has to report.
+// in; the bool is false with a nil error when it was never declared.
 func (s *Store) DocumentCollection(namespace, collection string) (*docstore.CollectionSchema, bool, error) {
 	if s.db == nil {
 		return nil, false, fmt.Errorf("store: no database")
@@ -129,8 +95,7 @@ func (s *Store) DocumentCollection(namespace, collection string) (*docstore.Coll
 	return &schema, true, nil
 }
 
-// ListDocumentCollections returns every declaration, namespace-major. It is the
-// operator's index of what exists.
+// ListDocumentCollections returns every declaration, namespace-major.
 func (s *Store) ListDocumentCollections() ([]docstore.CollectionSchema, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("store: no database")
@@ -161,10 +126,8 @@ func (s *Store) ListDocumentCollections() ([]docstore.CollectionSchema, error) {
 }
 
 // DeleteDocumentCollection removes a declaration and every document under it,
-// reporting how many documents went. Dropping the table is what returns the
-// space, and it happens in the same transaction as the registry delete: a
-// declaration without its table would leave a collection nothing can query, and
-// a table without its declaration would leave rows nothing can name.
+// reporting how many documents went; table drop and registry delete commit
+// together.
 func (s *Store) DeleteDocumentCollection(namespace, collection string) (int, error) {
 	if s.db == nil {
 		return 0, fmt.Errorf("store: no database")
@@ -200,28 +163,13 @@ func (s *Store) DeleteDocumentCollection(namespace, collection string) (int, err
 	return n, nil
 }
 
-// PutDocument writes a document, creating or fully replacing it, and returns the
-// revision it now has. created_at survives a replacement — it is when the record
-// first appeared, which is what a "newest first" query means by it — while
-// updated_at and rev move on every write.
-//
-// The schema names the table, which is why every caller reads the declaration
-// first: an undeclared collection has no storage, and that has to be an error a
-// caller reports rather than a table appearing by surprise.
-//
-// expected is the caller's assertion about what it is overwriting: nil writes
-// unconditionally, docstore.ExpectAbsent writes only if nothing is there, and a
-// revision writes only if the document is still at it. A failed assertion is a
-// *docstore.ConflictError and nothing is written.
-//
-// THE WRITE ITSELF IS ONE STATEMENT, which is what makes the check atomic: each
-// form below refuses in the same statement that would have written. Reading the
-// revision and then writing would be two, and the whole point of this is the
-// window between them. Whether that statement runs in SQLite's implicit
-// transaction (here) or inside one that also appends a fact
-// (CommitDocumentWrite) changes nothing about the check — the same statement
-// runs either way. The re-read below happens only on the failure path, to say
-// what the write lost to.
+// PutDocument writes a document, creating or fully replacing it, and returns
+// its new revision; created_at survives a replacement. expected: nil writes
+// unconditionally, docstore.ExpectAbsent only if nothing is there, a revision
+// only if the document is still at it — a failed assertion is a
+// *docstore.ConflictError and nothing is written. Each form checks and writes
+// in ONE statement; a separate read-then-write would reopen the race the check
+// exists to close.
 func (s *Store) PutDocument(schema docstore.CollectionSchema, id string, body []byte, now time.Time, expected *int64) (int64, error) {
 	table, err := s.documentTable(schema)
 	if err != nil {
@@ -239,7 +187,6 @@ func putDocumentWith(q rowQuerier, schema docstore.CollectionSchema, table, id s
 	)
 	switch {
 	case expected == nil:
-		// Upsert: the insert path starts at FirstRev, the update path advances.
 		stmt = `INSERT INTO ` + table + ` (id, body, rev, created_at, updated_at)
 		        VALUES (?, ?, ?, ?, ?)
 		        ON CONFLICT(id) DO UPDATE SET
@@ -249,17 +196,16 @@ func putDocumentWith(q rowQuerier, schema docstore.CollectionSchema, table, id s
 		        RETURNING rev`
 		args = []any{id, string(body), docstore.FirstRev, ts, ts}
 	case *expected == docstore.ExpectAbsent:
-		// DO NOTHING rather than letting the primary key raise: a conflicting
-		// insert then returns no row, which is the same "no row came back" signal
-		// the conditional update gives, so both refusals arrive one way.
+		// DO NOTHING so a conflicting insert refuses via "no row came back",
+		// the same signal the conditional update gives.
 		stmt = `INSERT INTO ` + table + ` (id, body, rev, created_at, updated_at)
 		        VALUES (?, ?, ?, ?, ?)
 		        ON CONFLICT(id) DO NOTHING
 		        RETURNING rev`
 		args = []any{id, string(body), docstore.FirstRev, ts, ts}
 	default:
-		// No insert path at all: expecting a revision is expecting a document,
-		// so a missing one must be refused rather than created.
+		// No insert path: expecting a revision is expecting a document, so a
+		// missing one is refused rather than created.
 		stmt = `UPDATE ` + table + ` SET body = ?, rev = rev + 1, updated_at = ?
 		        WHERE id = ? AND rev = ?
 		        RETURNING rev`
@@ -268,10 +214,8 @@ func putDocumentWith(q rowQuerier, schema docstore.CollectionSchema, table, id s
 
 	var rev int64
 	err := q.QueryRow(stmt, args...).Scan(&rev)
-	// No row came back is how every refusal arrives — but only an expectation can
-	// refuse one. The unconditional upsert always writes a row, so no row from it
-	// is a broken statement rather than a conflict, and reporting it as one would
-	// tell a caller to retry something that will never succeed.
+	// Only an expectation can refuse: the unconditional upsert always writes a
+	// row, so ErrNoRows from it is a broken statement, not a conflict.
 	if err == sql.ErrNoRows && expected != nil {
 		return 0, documentConflictWith(q, schema, table, id, *expected)
 	}
@@ -302,14 +246,9 @@ func getDocumentWith(q rowQuerier, namespace, collection, table, id string) (*do
 	return doc, true, nil
 }
 
-// DeleteDocument removes a document, reporting whether one was there. The caller
-// needs the difference: a delete that removed nothing must not announce a change
-// that did not happen.
-//
-// expected asserts which version is being removed, the same way PutDocument's
-// does — removing a record on the strength of a body you read is the same
-// lost-update hazard as overwriting one. A revision that no longer matches is a
-// *docstore.ConflictError and nothing is deleted.
+// DeleteDocument removes a document, reporting whether one was there. expected
+// asserts which version is being removed, as in PutDocument; a stale revision
+// is a *docstore.ConflictError and nothing is deleted.
 func (s *Store) DeleteDocument(schema docstore.CollectionSchema, id string, expected *int64) (bool, error) {
 	table, err := s.documentTable(schema)
 	if err != nil {
@@ -320,9 +259,8 @@ func (s *Store) DeleteDocument(schema docstore.CollectionSchema, id string, expe
 
 func deleteDocumentWith(x execQuerier, schema docstore.CollectionSchema, table, id string, expected *int64) (bool, error) {
 	if expected != nil && *expected == docstore.ExpectAbsent {
-		// "Delete this if it is not there" is not an assertion a delete can act
-		// on, and silently treating it as unconditional would delete a document
-		// the caller was trying to protect.
+		// Treating "expect absent" as unconditional would delete a document the
+		// caller was trying to protect.
 		return false, fmt.Errorf("store: deleting %s/%s/%s: rev %d means the document must not exist, which a delete cannot expect; pass the revision you read, or none to delete unconditionally",
 			schema.Namespace, schema.Collection, id, docstore.ExpectAbsent)
 	}
@@ -347,14 +285,10 @@ func deleteDocumentWith(x execQuerier, schema docstore.CollectionSchema, table, 
 	return n > 0, nil
 }
 
-// documentConflictWith describes a refused write. It reads the document again to
-// name the revision that won, because "your write was refused" without that is
-// an error a caller cannot act on. A read failure here is not worth losing the
-// conflict over — the refusal is the fact, the revision is the detail — so it
-// degrades to reporting the document as absent.
-//
-// The re-read runs on whatever refused the write, which inside a composite is
-// its transaction: reading around it would read a state the refusal never saw.
+// documentConflictWith describes a refused write, re-reading to name the
+// revision that won. The re-read must run on whatever refused the write —
+// inside a composite, its transaction — or it reads a state the refusal never
+// saw.
 func documentConflictWith(q rowQuerier, schema docstore.CollectionSchema, table, id string, expected int64) error {
 	conflict := &docstore.ConflictError{
 		Namespace: schema.Namespace, Collection: schema.Collection, ID: id, Expected: expected,
@@ -372,8 +306,7 @@ func documentConflictWith(q rowQuerier, schema docstore.CollectionSchema, table,
 }
 
 // DocumentWrite is one document mutation: a put of Body, or a removal when
-// Delete is set. Expected is the caller's assertion about the version being
-// replaced or removed, exactly as PutDocument and DeleteDocument take it.
+// Delete is set. Expected is as in PutDocument and DeleteDocument.
 type DocumentWrite struct {
 	Schema   docstore.CollectionSchema
 	ID       string
@@ -382,13 +315,9 @@ type DocumentWrite struct {
 	Expected *int64
 }
 
-// DocumentWriteResult is what a committed write is worth telling a caller.
-//
-// Changed reports whether the store actually moved, and is what separates a
-// delete that removed a document from one that found nothing there. Seq is the
-// fact's position on the durable log and is 0 exactly when Changed is false —
-// nothing changed, so nothing was announced. Rev is the document's new revision
-// and is 0 for a delete, which has no version to report.
+// DocumentWriteResult reports a committed write: Changed says whether the
+// store moved, Seq is the fact's log position (0 exactly when Changed is
+// false), Rev is the new revision (0 for a delete).
 type DocumentWriteResult struct {
 	Rev     int64
 	Seq     int64
@@ -396,23 +325,10 @@ type DocumentWriteResult struct {
 }
 
 // CommitDocumentWrite writes a document and appends the fact describing it in
-// ONE transaction, and is how every fact-bearing writer reaches the store.
-//
-// The composite exists because the two halves used to be separate commits: a
-// document write landed, and its fact was published afterwards and could fail
-// on its own (the bus logged and carried on). A crash between them left the
-// data changed and the log silent — permanently, since nothing re-derives facts
-// — which is the divergence B-track workflows would trigger on. After this,
-// a fact that cannot be made durable fails the whole write: the caller gets an
-// error and a retry instead of a store nobody was told about.
-//
-// The store stays fact-agnostic. It does not know what `document.changed` means
-// or how a subject is spelled; the caller builds the fact and this appends it.
-//
-// A write that changed nothing appends NO fact and returns no seq: a delete
-// that found nothing, or a refusal, is not a change, and waking every live
-// query on the collection to re-render an identical result set is the cost the
-// conditional write exists to avoid.
+// ONE transaction — a fact that cannot be made durable fails the whole write,
+// so the data and the log cannot diverge. The store stays fact-agnostic: the
+// caller builds the fact. A write that changed nothing appends NO fact and
+// returns no seq.
 func (s *Store) CommitDocumentWrite(w DocumentWrite, fact BusEvent, now time.Time) (DocumentWriteResult, error) {
 	table, err := s.documentTable(w.Schema)
 	if err != nil {
@@ -427,8 +343,8 @@ func (s *Store) CommitDocumentWrite(w DocumentWrite, fact BusEvent, now time.Tim
 		return DocumentWriteResult{}, fmt.Errorf("store: writing %s/%s/%s: %w",
 			w.Schema.Namespace, w.Schema.Collection, w.ID, err)
 	}
-	// Rolled back on every path that does not commit, including the ones that
-	// return no error: a delete that removed nothing has nothing to commit.
+	// Also rolls back the no-error paths: a delete that removed nothing has
+	// nothing to commit.
 	defer func() { _ = tx.Rollback() }()
 
 	var out DocumentWriteResult
@@ -465,16 +381,10 @@ func (s *Store) CommitDocumentWrite(w DocumentWrite, fact BusEvent, now time.Tim
 	return out, nil
 }
 
-// queryDocuments runs an already-compiled query. The compiled fragments are
-// built from a validated query against a stored declaration, so the only strings
-// spliced into the statement are ones docstore produced from identifiers it
-// checked; every caller-supplied value arrives as a bound argument.
-//
-// Unexported on purpose. A compiled query carries a table name, a column
-// affinity and a cursor value taken from the declaration it was compiled
-// against, so running one is only correct against the state it was compiled
-// from. Handing that pairing to callers is what produced three silent wrong
-// answers; ReadQuery owns both halves and is the way in from outside.
+// queryDocuments runs an already-compiled query; only docstore-checked
+// identifiers are spliced in, every caller value is a bound argument.
+// Unexported: a compiled query is only correct against the state it was
+// compiled from, so ReadQuery owns both halves and is the way in from outside.
 func (s *Store) queryDocuments(c docstore.Compiled) ([]docstore.Document, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("store: no database")
@@ -509,26 +419,18 @@ func queryDocumentsWith(q rowsQuerier, c docstore.Compiled) ([]docstore.Document
 }
 
 // QueryRead is one answer to one query: the documents, the declaration they
-// were computed against, and the log position they were true at. The
-// declaration is returned rather than assumed because the caller's copy may
-// already be out of date by the time it reads this — the one in here is the one
-// the answer actually means.
+// were computed against, and the log position they were true at.
 type QueryRead struct {
 	Schema    docstore.CollectionSchema
 	Documents []docstore.Document
 	AsOfSeq   int64
 }
 
-// readAsOfSeq is the log position an answer was true at: the highest seq in
-// bus_events, read inside the same transaction as the rows.
-//
-// Every document write commits its fact into that log, so this is exactly "the
-// last change this answer includes". Same transaction, not a second read: read
-// outside it and the number names a state the rows were never in.
-//
-// An empty log yields 0, which is a valid position meaning "before everything"
-// rather than a missing answer. Compaction removes rows but never the newest,
-// so it cannot lower MAX(seq) and the watermark is immune to it.
+// readAsOfSeq is the log position an answer was true at: MAX(seq) in
+// bus_events, read inside the same transaction as the rows — outside it the
+// number names a state the rows were never in. Empty log yields 0 ("before
+// everything"); compaction never removes the newest row, so it cannot lower
+// MAX(seq).
 func readAsOfSeq(q rowQuerier) (int64, error) {
 	var seq int64
 	if err := q.QueryRow(`SELECT COALESCE(MAX(seq), 0) FROM bus_events`).Scan(&seq); err != nil {
@@ -545,10 +447,9 @@ type DocumentRead struct {
 	AsOfSeq  int64
 }
 
-// ReadDocument answers a get in a single read transaction — the declaration,
-// the row, and the log position, all against one state of the database, for the
-// same reason ReadQuery does. The bool is false with a nil error when the
-// collection was never declared.
+// ReadDocument answers a get in a single read transaction, for the same reason
+// ReadQuery does; the bool is false with a nil error when the collection was
+// never declared.
 func (s *Store) ReadDocument(namespace, collection, id string) (DocumentRead, bool, error) {
 	if s.db == nil {
 		return DocumentRead{}, false, fmt.Errorf("store: no database")
@@ -583,12 +484,8 @@ type CountRead struct {
 }
 
 // CountQuery answers "how many match" with the same compile the query itself
-// uses, so a count and the page it describes cannot disagree about what
-// matches. Only the filter half of the compiled query is used: ordering and the
-// limit decide which matches come back, never how many there are.
-//
-// A query carrying an after cursor counts what follows the anchor, which is the
-// same thing paging through the rest of the answer would find.
+// uses, so a count and the page it describes cannot disagree; only the filter
+// half is used, and an after cursor counts what follows the anchor.
 func (s *Store) CountQuery(q docstore.Query) (CountRead, bool, error) {
 	if s.db == nil {
 		return CountRead{}, false, fmt.Errorf("store: no database")
@@ -636,29 +533,11 @@ func (s *Store) CountQuery(q docstore.Query) (CountRead, bool, error) {
 }
 
 // ReadQuery answers a query in a single read transaction, and is the only way
-// to run one from outside the store.
-//
-// Answering takes three reads: the declaration, which names the table and the
-// affinity of every column the SQL will compare; the cursor anchor, whose
-// presence and sort value decide which cursor clause gets compiled; and the
-// SELECT itself. Those used to be three separate transactions with the compile
-// in between, so the statement could be built against one state and executed
-// against another. That is not a narrow race — it produced a page that silently
-// came back empty when the anchor was deleted, a page that handed back the
-// anchor document itself when the anchor gained a sort value, and a filter that
-// silently matched nothing when a field's declared type changed underneath it.
-// None of the three reported an error, and each returned an answer that matched
-// no state the collection was ever in.
-//
-// One transaction removes the class rather than narrowing it: compile-time and
-// execute-time are the same instant, so there is no second state to disagree
-// with. Nothing is committed — a read transaction here buys a consistent
-// snapshot, not atomic writes. It costs one contiguous SHARED lock in place of
-// three brief ones, which is the same total work; what it denies a writer is
-// exactly the gap that produced the wrong answers.
-//
-// found reports whether the collection is declared at all, the same way
-// DocumentCollection does.
+// to run one from outside the store. Declaration read, anchor read, compile,
+// and SELECT must share one transaction: split across transactions the
+// statement can compile against one state and execute against another, which
+// silently returned wrong pages. found reports whether the collection is
+// declared, as in DocumentCollection.
 func (s *Store) ReadQuery(q docstore.Query) (QueryRead, bool, error) {
 	if s.db == nil {
 		return QueryRead{}, false, fmt.Errorf("store: no database")
@@ -667,8 +546,6 @@ func (s *Store) ReadQuery(q docstore.Query) (QueryRead, bool, error) {
 	if err != nil {
 		return QueryRead{}, false, fmt.Errorf("store: reading %s/%s: %w", q.Namespace, q.Collection, err)
 	}
-	// Rolled back rather than committed: a read transaction has nothing to
-	// commit, and rolling back is what releases the snapshot.
 	defer func() { _ = tx.Rollback() }()
 
 	schema, table, found, err := readCollectionTx(tx, q.Namespace, q.Collection)
@@ -678,9 +555,7 @@ func (s *Store) ReadQuery(q docstore.Query) (QueryRead, bool, error) {
 
 	var anchor *docstore.Document
 	if q.After != "" {
-		// A missing anchor stays nil, which is the case Compile refuses by name.
-		// Inside this transaction that refusal is now truthful: the anchor really
-		// is absent from the state the SELECT would have run against.
+		// A missing anchor stays nil; Compile refuses that case by name.
 		doc, ok, err := getDocumentWith(tx, schema.Namespace, schema.Collection, table, q.After)
 		if err != nil {
 			return QueryRead{}, false, err
@@ -705,8 +580,7 @@ func (s *Store) ReadQuery(q docstore.Query) (QueryRead, bool, error) {
 	return QueryRead{Schema: schema, Documents: docs, AsOfSeq: asOf}, true, nil
 }
 
-// CountDocuments reports how many documents a collection holds. It is what the
-// slow-query log reports alongside a duration.
+// CountDocuments reports how many documents a collection holds.
 func (s *Store) CountDocuments(schema docstore.CollectionSchema) (int, error) {
 	table, err := s.documentTable(schema)
 	if err != nil {
@@ -719,10 +593,8 @@ func (s *Store) CountDocuments(schema docstore.CollectionSchema) (int, error) {
 	return n, nil
 }
 
-// QueryPlan returns SQLite's plan for a compiled query, one row per step. It
-// exists so a test can assert that a filtered or sorted query reaches an index
-// rather than scanning the collection — the property this whole physical schema
-// is for, and one that no timing assertion could check without being flaky.
+// QueryPlan returns SQLite's plan for a compiled query, one row per step, so a
+// test can assert a query reaches an index rather than scanning.
 func (s *Store) QueryPlan(c docstore.Compiled) ([]string, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("store: no database")
@@ -769,17 +641,10 @@ func (s *Store) documentTable(schema docstore.CollectionSchema) (string, error) 
 // DDL
 // ---------------------------------------------------------------------------
 
-// createCollectionTable builds a collection's storage: the five stored columns,
-// an index for each reserved ordering column, and a generated column plus index
-// for every declared field.
-//
-// WITHOUT ROWID because a document is addressed by its id and never by position:
-// clustering the row on the id it is looked up by removes a whole B-tree and the
-// hop through it.
-//
-// rev is stored and not indexed. It is only ever read for a document already
-// being looked up by its primary key, or compared inside a write to that same
-// row, so an index over it would serve no query and cost every write.
+// createCollectionTable builds a collection's storage: stored columns, indexes
+// for the reserved ordering columns, and a generated column plus index per
+// declared field. WITHOUT ROWID clusters the row on the id it is looked up by;
+// rev is deliberately unindexed — it serves no query.
 func createCollectionTable(tx *sql.Tx, table string, fields []docstore.FieldSpec) error {
 	if err := docstore.ValidateTableName(table); err != nil {
 		return err
@@ -794,9 +659,7 @@ func createCollectionTable(tx *sql.Tx, table string, fields []docstore.FieldSpec
 		return err
 	}
 	// created_at and updated_at are queryable without being declared, so they
-	// are indexed unconditionally. Each index carries the id tiebreaker, which
-	// is what makes it serve the whole ordering tuple rather than only its
-	// first half — the same tuple the after cursor compares against.
+	// are indexed unconditionally.
 	for _, col := range []string{docstore.FieldCreatedAt, docstore.FieldUpdatedAt} {
 		if err := createFieldIndex(tx, table, col); err != nil {
 			return err
@@ -811,9 +674,8 @@ func createCollectionTable(tx *sql.Tx, table string, fields []docstore.FieldSpec
 }
 
 // alterCollectionTable brings an existing table into line with a new
-// declaration. A field whose type changed is dropped and re-added rather than
-// left alone: its column's affinity is how two stored values compare, so a
-// declaration that says "number" must not keep comparing as text.
+// declaration; a field whose type changed is dropped and re-added so its
+// column carries the new affinity.
 func alterCollectionTable(tx *sql.Tx, table string, before, after []docstore.FieldSpec) error {
 	if err := docstore.ValidateTableName(table); err != nil {
 		return err
@@ -850,10 +712,8 @@ func alterCollectionTable(tx *sql.Tx, table string, before, after []docstore.Fie
 
 func addFieldColumn(tx *sql.Tx, table string, f docstore.FieldSpec) error {
 	col := quoteIdent(docstore.FieldColumn(f.Name))
-	// VIRTUAL, not STORED: the index materialises the values that get compared,
-	// so storing them in the row as well would pay for them twice. SQLite also
-	// refuses to add a STORED column to an existing table, which is what would
-	// make redeclaring a rewrite instead of a one-statement change.
+	// VIRTUAL, not STORED: the index already materialises the compared values,
+	// and SQLite refuses to add a STORED column to an existing table.
 	_, err := tx.Exec(fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s %s GENERATED ALWAYS AS (%s) VIRTUAL`,
 		table, col, docstore.ColumnAffinity(f.Type), docstore.FieldExpression(f.Name)))
 	if err != nil {
@@ -872,9 +732,8 @@ func dropFieldColumn(tx *sql.Tx, table string, f docstore.FieldSpec) error {
 	return err
 }
 
-// createFieldIndex indexes one column with the id tiebreaker beside it, which is
-// the order every query asks for. One index serves both directions: SQLite walks
-// it backwards for a DESC ordering.
+// createFieldIndex indexes one column with the id tiebreaker beside it — the
+// tuple every query orders and cursors by; SQLite walks it backwards for DESC.
 func createFieldIndex(tx *sql.Tx, table, column string) error {
 	_, err := tx.Exec(fmt.Sprintf(`CREATE INDEX %s ON %s (%s, id)`,
 		quoteIdent(fieldIndexName(table, column)), table, quoteIdent(column)))
@@ -886,9 +745,8 @@ func fieldIndexName(table, column string) string {
 	return table + "_" + column
 }
 
-// quoteIdent renders an identifier for SQL. Every identifier reaching it is
-// already derived from a validated name; the quoting is what makes a field named
-// like a keyword harmless.
+// quoteIdent renders an already-validated identifier for SQL; quoting makes a
+// field named like a keyword harmless.
 func quoteIdent(name string) string {
 	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }

--- a/internal/store/file_activity.go
+++ b/internal/store/file_activity.go
@@ -8,20 +8,15 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-// FileActivitySourceOpened marks a file that was opened as a reader tile, by
-// any route (⌘+click on a link, `attn open`, or the file opener itself).
+// FileActivitySourceOpened marks a file opened as a reader tile, by any route.
 const FileActivitySourceOpened = "opened"
 
 // FileActivitySourceEdited marks a file an agent wrote, reported by the
-// tool-use hook. An edit is a weaker signal of intent than an open — the agent
-// chose the file, the user did not — so it carries less weight in the ranking,
-// but it still introduces a file the user has never opened. That is the case
-// the signal exists for: the plan the agent just wrote is one ⌘P away.
+// tool-use hook; a weaker intent signal than an open, so it weighs less.
 const FileActivitySourceEdited = "edited"
 
-// Ranking weights. An open is the baseline; an edit is worth less than an open
-// of the same age and frequency, and a file inside the caller's workspace beats
-// an equally-scored file from another one without hiding it.
+// Ranking weights: an open is the baseline, an edit weighs less, an
+// in-workspace file beats an equally-scored one without hiding it.
 const (
 	editedWeight     = 0.6
 	inWorkspaceBonus = 1.5
@@ -34,13 +29,8 @@ func sourceWeight(source string) float64 {
 	return 1
 }
 
-// RecordFileActivity records that something happened to a file, incrementing
-// the (path, source) counter and stamping the time. sessionID is the session
-// the activity belongs to, or "" when there is none; the most recent one wins.
-//
-// Keying on (path, source) rather than path alone keeps future sources — an
-// agent editing a file — accumulating independently, so a ranking change never
-// needs a migration.
+// RecordFileActivity increments the (path, source) counter and stamps the
+// time; sessionID is "" when there is none, and the most recent one wins.
 func (s *Store) RecordFileActivity(path, source, sessionID string) {
 	if path == "" || source == "" {
 		return
@@ -66,19 +56,10 @@ func (s *Store) RecordFileActivity(path, source, sessionID string) {
 		path, source, session, time.Now().Format(time.RFC3339))
 }
 
-// GetRecentFiles returns one entry per file, ranked by frecency — the same
-// frequency-weighted-by-recency scoring the location picker uses, so a file
-// opened often keeps its slot after a burst of one-off opens.
-//
-// A file can carry several sources (opened and edited); their scores add, with
-// each source weighted by sourceWeight, and the returned entry merges them:
-// the newest timestamp, the total count, and the source that was most recent.
-// Files under root — the caller's workspace — get inWorkspaceBonus, so the
-// project in front of you sorts first without other projects disappearing.
-//
-// Rows are not stat'd here: a summon of the opener must not touch the disk
-// once per remembered file. A file that has since disappeared is pruned when
-// opening it fails.
+// GetRecentFiles returns one entry per file, ranked by frecency; a file's
+// sources add (weighted by sourceWeight) and the merged entry keeps the newest
+// timestamp, total count, and most recent source. Rows are never stat'd here —
+// dead files are pruned when opening them fails.
 func (s *Store) GetRecentFiles(limit int, root string) []protocol.FileActivity {
 	if limit <= 0 {
 		limit = 20
@@ -90,10 +71,8 @@ func (s *Store) GetRecentFiles(limit int, root string) []protocol.FileActivity {
 		return nil
 	}
 
-	// Read every row: ranking happens below, so pre-truncating by last_at
-	// would hide old-but-frequent files. The table holds one row per file
-	// ever opened, and dead entries are dropped on a failed open, so it
-	// stays small.
+	// Read every row: pre-truncating by last_at would hide old-but-frequent
+	// files.
 	rows, err := s.db.Query(`SELECT path, source, session_id, last_at, count FROM file_activity`)
 	if err != nil {
 		return nil
@@ -123,10 +102,8 @@ func (s *Store) GetRecentFiles(limit int, root string) []protocol.FileActivity {
 			continue
 		}
 		existing.Count += entry.Count
-		// The most recent activity names the entry: its timestamp, its source,
-		// and the session that produced it. Timestamps are second-granular, so
-		// an open and an edit can land on the same one; the user's own action
-		// wins that tie.
+		// Most recent activity names the entry; timestamps are second-granular,
+		// so an open wins a same-second tie with an edit.
 		sameSecondOpen := entry.LastAt == existing.LastAt && entry.Source == FileActivitySourceOpened
 		if entry.LastAt > existing.LastAt || sameSecondOpen {
 			existing.LastAt = entry.LastAt
@@ -172,9 +149,8 @@ func workspacePrefix(root string) string {
 	return strings.TrimSuffix(root, "/") + "/"
 }
 
-// DeleteFileActivity forgets every source for a path. Called when opening a
-// remembered file fails because it no longer exists, so a dead entry costs one
-// failed open rather than a slot forever.
+// DeleteFileActivity forgets every source for a path; called when opening a
+// remembered file fails because it no longer exists.
 func (s *Store) DeleteFileActivity(path string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/store/jobs.go
+++ b/internal/store/jobs.go
@@ -8,42 +8,24 @@ import (
 	"github.com/victorarias/attn/internal/docstore"
 )
 
-// This is the SQLite persistence for the durable job queue (internal/jobs).
-//
-// Following the tickets/tasks convention, JobRecord is a store-local row type —
-// NOT internal/jobs.Job. The daemon owns the mapping between the two, which
-// keeps this package a leaf (internal/store imports neither internal/jobs nor
-// internal/daemon).
+// SQLite persistence for the durable job queue (internal/jobs). JobRecord is a
+// store-local row type, not internal/jobs.Job; the daemon owns the mapping so
+// this package stays a leaf.
 
-// sortableTimeFormat is the stored timestamp encoding for the two surfaces in
-// this package that keep their stamps in TEXT columns and compare them there:
-// the job queue (scheduled_at, created_at, updated_at) and the notifications
-// feed (created_at). Text order has to be time order, which takes a fraction of
-// a fixed width, always present and always nine digits.
-//
-// time.RFC3339Nano, which this used to be, does not: it strips trailing zeros,
-// so widths vary and "…:00Z" sorts above "…:00.5Z" ('Z' is 0x5A, above '.' and
-// every digit). Within one second the two orders disagreed, which made a job
-// scheduled on a whole second wait out the rest of that second before
-// `scheduled_at <= now` claimed it, and scrambled both feeds' listings among
-// rows written in the same second. Migration 94 rewrote the stored stamps.
-//
-// It is docstore.TimeFormat: the document store hit the same defect and this is
-// the same fix, so there is one spelling of it rather than two that must be kept
-// in step. Always formatted from a UTC time, so the zone is always "Z" and every
-// stored stamp is the same 30 characters wide.
+// sortableTimeFormat encodes stamps kept in TEXT columns and compared there
+// (jobs, notifications feed): text order must be time order, so the fraction is
+// fixed-width. RFC3339Nano strips trailing zeros and broke that — "…:00Z" sorts
+// above "…:00.5Z" — delaying whole-second scheduled_at claims; migration 94
+// rewrote the stored stamps. Always format from a UTC time.
 const sortableTimeFormat = docstore.TimeFormat
 
-// rowScanner is satisfied by both *sql.Row and *sql.Rows, so one scan helper
-// serves a single-row lookup and a listing. It lives here because the job queue
-// is its heaviest user; the notification surface shares it.
+// rowScanner is satisfied by both *sql.Row and *sql.Rows.
 type rowScanner interface {
 	Scan(dest ...any) error
 }
 
-// JobRecord is one durable job row. Payload and Result are carried opaquely as
-// JSON text because the store never interprets them — only the handler that was
-// enqueued with them does.
+// JobRecord is one durable job row. Payload and Result are opaque JSON text;
+// only the enqueued handler interprets them.
 type JobRecord struct {
 	ID          string
 	Kind        string
@@ -64,8 +46,7 @@ type JobRecord struct {
 const jobColumns = `id, kind, unique_key, priority, payload, result, state, attempts,
 	max_attempts, scheduled_at, last_error, requeued, created_at, updated_at`
 
-// execer is satisfied by both *sql.DB and *sql.Tx, so a write helper serves a
-// standalone call and a step inside someone else's transaction.
+// execer is satisfied by both *sql.DB and *sql.Tx.
 type execer interface {
 	Exec(query string, args ...any) (sql.Result, error)
 }
@@ -78,9 +59,7 @@ func (s *Store) UpsertJob(rec JobRecord) error {
 	return upsertJob(s.db, rec)
 }
 
-// upsertJob is UpsertJob's write, against whichever executor the caller has. The
-// legacy-task handover runs it inside its transaction so the old rows are
-// deleted in the same commit that writes their replacements.
+// upsertJob is UpsertJob's write, against whichever executor the caller has.
 func upsertJob(ex execer, rec JobRecord) error {
 	_, err := ex.Exec(
 		`INSERT INTO jobs (`+jobColumns+`)
@@ -110,9 +89,8 @@ func upsertJob(ex execer, rec JobRecord) error {
 	return nil
 }
 
-// GetJob returns the row for id. The bool is false (with a nil record and nil
-// error) when no such row exists — the queue must tell "no record" apart from a
-// read error.
+// GetJob returns the row for id; the bool is false with a nil error when no
+// such row exists.
 func (s *Store) GetJob(id string) (*JobRecord, bool, error) {
 	if s.db == nil {
 		return nil, false, fmt.Errorf("store: no database")
@@ -129,8 +107,7 @@ func (s *Store) GetJob(id string) (*JobRecord, bool, error) {
 }
 
 // GetJobByUniqueKey returns the row a kind coalesces onto for uniqueKey. An
-// empty key matches nothing: jobs without one are deliberately distinct, so
-// treating "" as a key would silently collapse them into a single record.
+// empty key matches nothing — treating "" as a key would collapse distinct jobs.
 func (s *Store) GetJobByUniqueKey(kind, uniqueKey string) (*JobRecord, bool, error) {
 	if s.db == nil {
 		return nil, false, fmt.Errorf("store: no database")
@@ -172,11 +149,10 @@ func (s *Store) ListJobs() ([]JobRecord, error) {
 	return collectJobRows(rows, "list jobs")
 }
 
-// EligibleJobs returns at most limit jobs claimable at now, ordered the way
-// dispatch claims them: highest priority first, then earliest scheduled, then
-// oldest. Queued and failed rows are both claimable — a failed row whose backoff
-// has elapsed is a retry — and the attempt cap is left to the queue, which knows
-// the runner-wide default a row may be relying on.
+// EligibleJobs returns at most limit jobs claimable at now, in dispatch order:
+// priority desc, scheduled asc, created asc. Queued and failed rows are both
+// claimable (an elapsed-backoff failure is a retry); the attempt cap is the
+// queue's job.
 func (s *Store) EligibleJobs(now time.Time, limit int) ([]JobRecord, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("store: no database")
@@ -193,10 +169,8 @@ func (s *Store) EligibleJobs(now time.Time, limit int) ([]JobRecord, error) {
 	return collectJobRows(rows, "eligible jobs")
 }
 
-// RecoverRunningJobs resets any job left in "running" back to "queued" with
-// scheduled_at = now, returning how many were recovered. A running row at
-// startup means a crash interrupted that job mid-run, so it is re-eligible
-// immediately.
+// RecoverRunningJobs resets jobs left in "running" back to "queued" at now: a
+// running row at startup means a crash interrupted it mid-run.
 func (s *Store) RecoverRunningJobs(now time.Time) (int, error) {
 	if s.db == nil {
 		return 0, fmt.Errorf("store: no database")
@@ -214,10 +188,8 @@ func (s *Store) RecoverRunningJobs(now time.Time) (int, error) {
 	return int(n), nil
 }
 
-// TrimDoneJobs deletes jobs that completed successfully before cutoff and
-// reports how many were removed. Only "done" rows are trimmed: a dead job is the
-// record a failure notification points at, and it is not what grows without
-// bound.
+// TrimDoneJobs deletes "done" rows older than cutoff. Dead jobs stay: a failure
+// notification points at them.
 func (s *Store) TrimDoneJobs(cutoff time.Time) (int, error) {
 	if s.db == nil {
 		return 0, fmt.Errorf("store: no database")
@@ -265,12 +237,8 @@ func scanJobRow(sc rowScanner) (*JobRecord, error) {
 	return &rec, nil
 }
 
-// parseStoreTime decodes a stored timestamp in any RFC3339 form — the
-// fixed-width one written today, the trailing-zero-stripped one written before
-// migration 94, or a whole second with no fraction at all. A blank/garbage value
-// yields the zero time rather than an error: a job with an unreadable timestamp
-// is still a real record, and the queue treats a zero scheduled_at as
-// "eligible now".
+// parseStoreTime decodes any RFC3339 form (pre-migration-94 stamps included).
+// Garbage yields the zero time, which the queue treats as "eligible now".
 func parseStoreTime(s string) time.Time {
 	t, err := docstore.ParseTime(s)
 	if err != nil {

--- a/internal/store/ticket_events.go
+++ b/internal/store/ticket_events.go
@@ -5,23 +5,11 @@ import (
 	"time"
 )
 
-// The ticket event log is the notification substrate for the work tracker (slice
-// 2 of docs/plans/2026-06-26-work-tracker.md). It re-homes the dispatch gateway's
-// settled mechanics: an append-only log with idempotent (deduped) events, a global
-// monotonic seq that doubles as the cursor space, and per-(identity, ticket)
-// cursors that express "unread". The decoupled notification handlers live in
-// internal/ticketnotify; this file is only the durable substrate.
-//
-// Cursors are keyed by (identity, ticket), not one global cursor per identity.
-// Session identities own ordinary participation; durable role identities own
-// role-scoped participation. A ticket newly assigned to an agent is delivered
-// from the start, and activity on one ticket never advances another ticket's
-// bookmark.
-//
-// Events are a SUPERSET of the display activity thread (slice 1): activity holds
-// the two human-facing kinds (status_change, comment); the event log carries all
-// six domain events the chief observes. Mutators append events transactionally —
-// they emit, but know nothing about who listens.
+// Ticket event log: append-only, deduped, global monotonic seq as the cursor
+// space, per-(identity, ticket) cursors expressing "unread". Notification
+// handlers live in internal/ticketnotify; this file is only the durable
+// substrate. Events are a superset of the display activity thread.
+// Design: docs/plans/2026-06-26-work-tracker.md (slice 2).
 
 // TicketEventKind is a domain event on a ticket.
 type TicketEventKind string
@@ -37,18 +25,15 @@ const (
 	TicketEventAssigned TicketEventKind = "assigned"
 	// TicketEventDescriptionEdited fires when the brief is edited.
 	TicketEventDescriptionEdited TicketEventKind = "description_edited"
-	// TicketEventAttachmentAdded is retained for historical attachment rows and
-	// events. New attachments use TicketEventAttachSubmitted.
+	// TicketEventAttachmentAdded is retained for historical rows; new
+	// attachments use TicketEventAttachSubmitted.
 	TicketEventAttachmentAdded TicketEventKind = "attachment_added"
-	// TicketEventAttachSubmitted fires when one or more artifacts are attached.
-	// Detail contains the versioned receipt payload.
+	// TicketEventAttachSubmitted fires on attach; Detail is the versioned receipt.
 	TicketEventAttachSubmitted TicketEventKind = "attach_submitted"
 )
 
-// TicketEvent is one entry in the append-only event log. Seq is the global
-// monotonic id (the cursor space). The payload columns are kind-specific:
-// FromStatus/ToStatus for status changes, Comment for notes, Detail for the
-// kind's salient value (new assignee, filename).
+// TicketEvent is one entry in the append-only event log; Seq is the global
+// monotonic id, and the payload columns are kind-specific.
 type TicketEvent struct {
 	Seq        int64
 	TicketID   string
@@ -61,18 +46,15 @@ type TicketEvent struct {
 	CreatedAt  time.Time
 }
 
-// signature is the dedup key: two events with the same signature on the same
-// ticket back-to-back are the same logical event (a retry), so only the first is
-// appended.
+// signature is the dedup key: back-to-back events with the same signature on
+// one ticket are the same logical event (a retry).
 func (e TicketEvent) signature() string {
 	return string(e.Kind) + "\x00" + string(e.FromStatus) + "\x00" + string(e.ToStatus) +
 		"\x00" + e.Comment + "\x00" + e.Detail + "\x00" + e.Author
 }
 
-// AppendTicketEvent appends an event to the log, deduped against the ticket's
-// most recent event. It returns the event's seq and whether a new row was written
-// (false when deduped). Most callers append within a mutator's transaction via
-// appendTicketEventTx; this is the standalone entry point.
+// AppendTicketEvent appends an event, deduped against the ticket's most recent
+// one, returning the seq and whether a new row was written.
 func (s *Store) AppendTicketEvent(e TicketEvent, now time.Time) (int64, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -96,8 +78,8 @@ func (s *Store) AppendTicketEvent(e TicketEvent, now time.Time) (int64, bool, er
 	return seq, appended, nil
 }
 
-// appendTicketEventTx is the transactional core, shared by ticket mutators so the
-// event lands atomically with the mutation that produced it.
+// appendTicketEventTx is shared by ticket mutators so the event lands
+// atomically with the mutation that produced it.
 func appendTicketEventTx(tx *sql.Tx, e TicketEvent, now time.Time) (int64, bool, error) {
 	var (
 		lastSeq                                    int64
@@ -118,10 +100,9 @@ func appendTicketEventTx(tx *sql.Tx, e TicketEvent, now time.Time) (int64, bool,
 			Author:     lauthor,
 		}
 		if prev.signature() == e.signature() {
-			return lastSeq, false, nil // idempotent: identical to the previous event
+			return lastSeq, false, nil
 		}
 	case sql.ErrNoRows:
-		// first event for this ticket
 	default:
 		return 0, false, err
 	}
@@ -140,9 +121,7 @@ func appendTicketEventTx(tx *sql.Tx, e TicketEvent, now time.Time) (int64, bool,
 	return seq, true, nil
 }
 
-// scanTicketEventRows scans a ticket_events result set whose columns are, in
-// order: seq, ticket_id, kind, author, from_status, to_status, comment, detail,
-// created_at. It closes rows.
+// scanTicketEventRows scans a full-column ticket_events result set and closes rows.
 func scanTicketEventRows(rows *sql.Rows) ([]TicketEvent, error) {
 	defer rows.Close()
 	var events []TicketEvent
@@ -184,44 +163,23 @@ func (s *Store) TicketEventsSince(cursor int64) ([]TicketEvent, error) {
 	return scanTicketEventRows(rows)
 }
 
-// The participation rule — who counts as involved with a ticket — has exactly one
-// definition: the ticket_participants view (migration 82), a (ticket_id, identity)
-// relation over four sources: current assignment, NON-COMMENT event authorship,
-// explicit subscription, and durable role ownership. Every query below asks the
-// view a different question rather than restating the rule:
-//
-//	tickets for an identity      WHERE identity = ?
-//	identities for a ticket      WHERE ticket_id = ?
-//	one identity on one ticket   both
-//
-// Two carve-outs are part of the rule, not of any caller:
-//
-// Comment authorship confers no participation. A one-shot comment on an arbitrary
-// ticket informs that ticket's participants without enrolling the commenter in its
-// future notifications (an agent dropping a note shouldn't then be nudged about
-// every later change). Standing interest is opt-in via assignment or an explicit
-// subscription instead.
-//
-// A created event on a ROLE-OWNED ticket is audit provenance, not participation.
-// The concrete session that minted the ticket on the role's behalf is recorded as
-// the author for the audit trail; the durable role identity is the participant, so
-// awareness survives the role moving to a different session.
+// The participation rule has exactly one definition: the ticket_participants
+// view (migration 82) — assignment, NON-COMMENT event authorship, explicit
+// subscription, durable role ownership. Queries below ask the view, never
+// restate the rule. Carve-outs baked into it: comment authorship confers no
+// participation, and a created event on a role-owned ticket is audit
+// provenance (the role, not the minting session, is the participant).
 
-// UnreadTicketEvents returns, for an identity, every event it has not yet
-// consumed across the tickets it participates in, excluding events it authored
-// itself. Each event is compared against the identity's OWN per-(identity, ticket)
-// cursor. Results are ordered by ticket then seq.
-//
-// This is the consume query: one statement folds the participant set, the
-// per-ticket cursors, and the self-author exclusion together, so a quiet or
-// closed ticket the identity has nothing new on costs only an indexed lookup.
+// UnreadTicketEvents returns every event an identity has not consumed across
+// the tickets it participates in, excluding its own, ordered by ticket then
+// seq.
 func (s *Store) UnreadTicketEvents(identity string) ([]TicketEvent, error) {
 	return s.UnreadTicketEventsFor(identity, identity)
 }
 
-// UnreadTicketEventsFor reads cursorIdentity's queue while excluding events by
-// authorIdentity. They differ for a durable role: the cursor belongs to the role,
-// while the current session remains the audited event author.
+// UnreadTicketEventsFor reads cursorIdentity's queue excluding events by
+// authorIdentity; they differ for a durable role, whose cursor belongs to the
+// role while the current session is the audited author.
 func (s *Store) UnreadTicketEventsFor(cursorIdentity, authorIdentity string) ([]TicketEvent, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -247,10 +205,8 @@ func (s *Store) UnreadTicketEventsFor(cursorIdentity, authorIdentity string) ([]
 	return scanTicketEventRows(rows)
 }
 
-// TicketParticipants returns the identities involved with a single ticket. This is
-// the exact inverse of UnreadTicketEvents — identities-for-a-ticket rather than
-// tickets-for-an-identity — over the same rule: when an event lands, the notifier
-// reaches exactly these identities, each of which sees only what it did not author.
+// TicketParticipants returns the identities involved with a single ticket —
+// the identities the notifier reaches when an event lands.
 func (s *Store) TicketParticipants(ticketID string) ([]string, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -296,9 +252,8 @@ func (s *Store) LatestTicketEventSeq() (int64, error) {
 }
 
 // GetTicketCursor returns an identity's cursor on a single ticket — the seq
-// through which it has consumed that ticket's events. An identity that has never
-// looked at the ticket starts at 0 (everything on it is unread), which is what
-// delivers a freshly-assigned ticket's full history.
+// consumed through; a never-seen ticket starts at 0, so its full history is
+// unread.
 func (s *Store) GetTicketCursor(identity, ticketID string) (int64, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -317,11 +272,8 @@ func (s *Store) GetTicketCursor(identity, ticketID string) (int64, error) {
 	return cursor, nil
 }
 
-// SetTicketCursor advances an identity's cursor on a single ticket. The write is
-// monotonic: it only ever moves the cursor FORWARD (MAX of the stored and proposed
-// seq). A cursor named "consumed through here" must never rewind, so a stale or
-// overlapping consume that writes a lower seq cannot resurrect already-consumed
-// events as unread or double-deliver them.
+// SetTicketCursor advances an identity's cursor on a single ticket; the write
+// is monotonic (see setTicketCursorTx).
 func (s *Store) SetTicketCursor(identity, ticketID string, cursor int64, now time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -332,16 +284,14 @@ func (s *Store) SetTicketCursor(identity, ticketID string, cursor int64, now tim
 	return setTicketCursorTx(s.db, identity, ticketID, cursor, now)
 }
 
-// ticketExecer is the Exec surface shared by *sql.DB and *sql.Tx, so a cursor write
-// can run either standalone or inside an enclosing mutation's transaction (e.g. the
-// delegation create that marks an agent's brief consumed atomically with the ticket).
+// ticketExecer is the Exec surface shared by *sql.DB and *sql.Tx, so a cursor
+// write can run standalone or inside an enclosing mutation's transaction.
 type ticketExecer interface {
 	Exec(query string, args ...any) (sql.Result, error)
 }
 
-// setTicketCursorTx is the monotonic cursor write. It only moves the cursor FORWARD
-// (MAX of stored and proposed), so a stale or overlapping write can never rewind a
-// cursor and resurrect already-consumed events as unread.
+// setTicketCursorTx only moves the cursor FORWARD (MAX of stored and
+// proposed): a stale write must never resurrect consumed events as unread.
 func setTicketCursorTx(ex ticketExecer, identity, ticketID string, cursor int64, now time.Time) error {
 	_, err := ex.Exec(`
 		INSERT INTO ticket_event_cursors (identity, ticket_id, cursor, updated_at)

--- a/internal/store/turn.go
+++ b/internal/store/turn.go
@@ -6,37 +6,22 @@ import (
 	"time"
 )
 
-// TurnStamps is the pair that decides whether a session owes the user a turn:
-// it does iff OpenedAt is after SettledAt. Both are zero for a session that has
-// never opened a turn.
-//
-// SnoozedUntil rides along rather than deciding anything, because a snooze
-// always settles the open turn as it is written — so a snoozed session already
-// reads as owing nothing, and the deadline is only there to say when it comes
-// back and to keep the next turn from opening before then.
+// TurnStamps decides whether a session owes the user a turn: it does iff
+// OpenedAt is after SettledAt; both zero means no turn ever opened.
+// SnoozedUntil decides nothing — a snooze settles the open turn as it is
+// written, so the deadline only says when the session comes back.
 type TurnStamps struct {
 	OpenedAt     time.Time
 	SettledAt    time.Time
 	SnoozedUntil time.Time
 }
 
-// OpenTurnIfClosed stamps the start of a turn, but only when no turn is already
-// open. Leaving an open turn alone is the whole state machine: a turn keeps the
-// age it was opened at, so a row never moves in the queue while the user works
-// with the agent, and a re-reported state cannot disturb it.
-//
-// The guard is a text comparison — turn_opened_at and turn_settled_at are TEXT
-// columns — so the stored encoding is the whole definition of "still open", and
-// it has to be one whose text order is time order within a second. That is
-// sortableTimeFormat. Under the RFC3339Nano this used to write, a stamp whose
-// fraction another stamp extends sorted above it ('Z' is 0x5A, above '.' and
-// every digit), so a turn settled inside the second it was opened in read as
-// still open and the next turn silently never opened. Whole-second opens are the
-// ordinary case, not a coincidence: a day-named snooze wakes on an exact second
-// and the woken turn is stamped with that deadline. Migration 95 rewrote the
-// stored stamps.
-//
-// It returns true when a turn was opened.
+// OpenTurnIfClosed stamps the start of a turn only when no turn is already
+// open, returning true when one was opened; an open turn keeps its age.
+// Trap: the guard is a TEXT comparison, so the stored encoding must sort in
+// time order within a second — sortableTimeFormat, not RFC3339Nano, whose
+// stripped fractions sorted a settle below its same-second open and silently
+// kept the turn open. Migration 95 rewrote the stored stamps.
 func (s *Store) OpenTurnIfClosed(id string, now time.Time) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -55,8 +40,6 @@ func (s *Store) OpenTurnIfClosed(id string, now time.Time) bool {
 		return true
 	}
 
-	// The condition lives in SQL so opening is atomic rather than
-	// read-modify-write.
 	result, err := s.db.Exec(`
 		UPDATE sessions SET turn_opened_at = ?
 		 WHERE id = ? AND (turn_opened_at = '' OR turn_opened_at <= turn_settled_at)`,
@@ -69,9 +52,8 @@ func (s *Store) OpenTurnIfClosed(id string, now time.Time) bool {
 	return err == nil && updated == 1
 }
 
-// SettleTurn closes whatever turn is open, unconditionally. Settling a session
-// that owes nothing is a no-op in effect but still recorded, so a later turn
-// opens against a stamp that is at least this recent.
+// SettleTurn closes whatever turn is open, unconditionally; settling a session
+// that owes nothing is still recorded.
 func (s *Store) SettleTurn(id string, now time.Time) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -96,17 +78,10 @@ func (s *Store) SettleTurn(id string, now time.Time) bool {
 	return err == nil && updated == 1
 }
 
-// SnoozeTurn defers a session until `until`: it closes whatever turn is open and
-// records the deadline in the same write.
-//
-// The two halves are one statement on purpose. A snooze that stamped the
-// deadline without settling would leave a turn open *and* suppressed — a row in
-// the queue that no state change can ever move — and the window in which that is
-// true is exactly the window a broadcast can land in.
-//
-// A deadline already in the past is stored as given rather than rejected. The
-// daemon's wake path fires immediately on it, which is what makes a snooze that
-// lapsed while the daemon was down behave like one that lapsed while it was up.
+// SnoozeTurn defers a session until `until`, settling the open turn and
+// recording the deadline in ONE statement — split, a broadcast could observe a
+// turn both open and suppressed. A past deadline is stored as given; the wake
+// path fires immediately on it.
 func (s *Store) SnoozeTurn(id string, until, now time.Time) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -133,12 +108,8 @@ func (s *Store) SnoozeTurn(id string, until, now time.Time) bool {
 	return err == nil && updated == 1
 }
 
-// WakeTurn clears a session's snooze without opening anything. Whether a turn
-// then opens is the daemon's call — it depends on the state the agent is in at
-// that instant — so this stays the narrow write.
-//
-// It reports whether a snooze was actually cleared, which is what lets the
-// caller stay quiet about a wake for a session that was not snoozed.
+// WakeTurn clears a session's snooze without opening anything — whether a turn
+// then opens is the daemon's call. Reports whether a snooze was cleared.
 func (s *Store) WakeTurn(id string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -163,17 +134,10 @@ func (s *Store) WakeTurn(id string) bool {
 	return err == nil && updated == 1
 }
 
-// WakeTurnAt clears a session's snooze only if the deadline it holds is exactly
-// the one given. It is what a fired timer uses instead of WakeTurn.
-//
-// A timer proves its identity against the daemon's map, but that map says
-// nothing about the store: a snooze written after the timer expired and before
-// it finished waking has already replaced the deadline, and an unconditional
-// clear would cash a promise the user had just replaced with a later one. The
-// stored deadline is the record of which snooze is current, so the clear is
-// conditioned on it.
-//
-// It reports whether the snooze it was told to end was still the live one.
+// WakeTurnAt clears a snooze only if the stored deadline is exactly the one
+// given — a fired timer uses this instead of WakeTurn, so a snooze re-written
+// while the timer was waking is not clobbered. Reports whether the snooze it
+// was told to end was still the live one.
 func (s *Store) WakeTurnAt(id string, deadline time.Time) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -203,9 +167,8 @@ func (s *Store) WakeTurnAt(id string, deadline time.Time) bool {
 	return err == nil && updated == 1
 }
 
-// SnoozedSessions is every live snooze, by session id. The daemon reads it once
-// at start-up to rebuild its wake timers, which is the only thing that makes a
-// snooze survive a restart — the timers themselves are in memory.
+// SnoozedSessions is every live snooze, by session id; the daemon reads it at
+// start-up to rebuild its in-memory wake timers.
 func (s *Store) SnoozedSessions() map[string]time.Time {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -240,8 +203,7 @@ func (s *Store) SnoozedSessions() map[string]time.Time {
 	return snoozed
 }
 
-// TurnStamps reads one session's stamps. Zero values mean no turn has ever
-// opened, which reads as owing nothing.
+// TurnStamps reads one session's stamps; zero values mean no turn ever opened.
 func (s *Store) TurnStamps(id string) TurnStamps {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -274,10 +236,6 @@ func (s *Store) setTurnStampsLocked(id string, stamps TurnStamps) {
 	s.turnStamps[id] = stamps
 }
 
-// parseTurnStamp decodes a stored turn stamp in any RFC3339 spelling — the
-// fixed-width one written today and the trailing-zero-stripped one written
-// before migration 95 — and yields the zero time for the ” that means "no turn
-// here" as well as for anything it cannot read. It is parseStoreTime, which the
-// job queue and the notifications feed already decode with: the columns hold one
-// encoding, so they get one decoder.
+// parseTurnStamp decodes any RFC3339 spelling (pre-migration-95 stamps
+// included), yielding zero time for ” and anything unreadable.
 func parseTurnStamp(value string) time.Time { return parseStoreTime(value) }

--- a/internal/testinv/testinv.go
+++ b/internal/testinv/testinv.go
@@ -1,69 +1,11 @@
-// Package testinv keeps an inventory of interesting states a package's tests are
-// supposed to reach, and fails the run when one of them stops being reached.
-//
-// The problem it exists for: a test suite can keep passing while it quietly
-// stops exercising the thing it was written for. The assertion still holds, but
-// the state it was meant to hold *about* is no longer produced — a refactor
-// removed the delay a backoff test was pacing on, a faster consumer means the
-// batch loop never sees a batch, a fixture drifted and the race the test provokes
-// no longer happens. Line coverage cannot see any of that: the lines still run.
-// It is a condition, not a location, that went missing.
-//
-// A cataloged state names such a condition and marks the spot where it occurs:
-//
-//	// package-level, in a _test.go file
-//	var sawBacklogBatch = testinv.Sometimes("a drain is handed a batch of more than one event")
-//
-//	func TestMain(m *testing.M) { os.Exit(testinv.Run(m)) }
-//
-//	// wherever the condition can be observed
-//	if len(batch) > 1 {
-//		sawBacklogBatch.Reached()
-//	}
-//
-// Reached says "this happened at least once" — not "this must happen here", and
-// not "this must happen every time". Any test in the package may be the one that
-// reaches it; no test owns it. That is the point: the claim is about the run, so
-// it survives the individual test that happens to satisfy it being rewritten or
-// deleted.
-//
-// # Scope
-//
-// One package, one process. `go test` runs each package in its own binary, so
-// the inventory is per-package and Run checks it when that package's tests are
-// done. Suite-wide aggregation would need a file drop and a summary step; it is
-// not built here.
-//
-// # Where a mark may live
-//
-// Marks belong in test files or test-only helpers. In practice the best host is
-// a test double that production code calls through — the package's in-memory
-// Store, its fake clock, its recording handler — because the condition it
-// observes is produced by the real code under test while the observation itself
-// costs production nothing. A condition that is only visible from inside
-// production code cannot be cataloged this way, and that is a deliberate limit,
-// not an oversight.
-//
-// # When enforcement is off
-//
-// A filtered run (`-run`, `-skip`, `-short`, `-list`) cannot be expected to reach
-// the whole inventory, so Run reports what it skipped and checks nothing. Be
-// aware that go test suppresses a passing binary's output, so that notice only
-// reaches the terminal under -v: a mark defends an unfiltered suite run, and
-// never a developer's inner loop.
-//
-// # What it costs
-//
-// A package that never calls Sometimes registers nothing and Run is m.Run. A
-// mark reads before it writes, so after the first hit it is an atomic load and a
-// predicted branch — 3.0ns, and no contended store per hit. Placing one inside a
-// test double that production code calls on a hot path is not a judgement call.
-//
-// # Reporting
-//
-// ATTN_TESTINV_VERBOSE=1 lists the whole inventory, reached and missing, instead
-// of only reporting what went wrong. `go test` hides a passing binary's output,
-// so pair it with -v.
+// Package testinv catalogs states a package's tests must reach at least once
+// per unfiltered run, and fails the run when one stops being reached — a
+// condition (not a location) that quietly stops occurring is invisible to line
+// coverage. Register marks in package-level vars in _test.go files with
+// Sometimes, route TestMain through Run, call Reached where the state occurs.
+// Scope is one package, one process. Marks live only in test files or test
+// doubles; filtered runs (-run, -skip, -short, -list) are reported, not
+// enforced. ATTN_TESTINV_VERBOSE=1 lists the whole inventory (pair with -v).
 package testinv
 
 import (
@@ -79,7 +21,7 @@ import (
 	"testing"
 )
 
-// Mark is one cataloged state. Get one from Sometimes; call Reached where the
+// Mark is one cataloged state: get it from Sometimes, call Reached where the
 // state occurs.
 type Mark struct {
 	what string
@@ -87,8 +29,8 @@ type Mark struct {
 	hit  atomic.Bool
 }
 
-// Reached records that the state happened. Safe from any goroutine, and cheap
-// enough to sit on a hot path: after the first hit it is a plain atomic load.
+// Reached records that the state happened. Safe from any goroutine; after the
+// first hit it is an atomic load and a predicted branch — measured 3.0ns.
 func (m *Mark) Reached() {
 	if m == nil || m.hit.Load() {
 		return
@@ -96,11 +38,10 @@ func (m *Mark) Reached() {
 	m.hit.Store(true)
 }
 
-// WasReached reports whether the state has happened yet. Tests that want to
-// assert about the catalog itself use this; ordinary marks do not need it.
+// WasReached reports whether the state has happened yet.
 func (m *Mark) WasReached() bool { return m != nil && m.hit.Load() }
 
-// String is the mark's description, so a mark drops into a %s without ceremony.
+// String is the mark's description.
 func (m *Mark) String() string {
 	if m == nil {
 		return "<nil mark>"
@@ -108,9 +49,8 @@ func (m *Mark) String() string {
 	return m.what
 }
 
-// catalog is one package's inventory. There is exactly one per test binary; the
-// type exists so the registry's own rules can be tested without registering into
-// the binary that is doing the testing.
+// catalog is one package's inventory; a type so the registry's rules can be
+// tested without registering into the binary doing the testing.
 type catalog struct {
 	mu      sync.Mutex
 	entries []*Mark
@@ -121,13 +61,9 @@ func newCatalog() *catalog { return &catalog{byWhat: map[string]string{}} }
 
 var defaultCatalog = newCatalog()
 
-// Sometimes registers a state that this package's tests must reach at least once
-// per unfiltered run, and returns the mark to call Reached on.
-//
-// Call it from a package-level var in a _test.go file: registration has to happen
-// before TestMain runs, and a var initializer is the only place that is
-// guaranteed. Descriptions must be unique within the package — a duplicate makes
-// the report ambiguous about which site went quiet, so it panics.
+// Sometimes registers a state this package's tests must reach at least once per
+// unfiltered run. Call it from a package-level var in a _test.go file —
+// registration must precede TestMain. A duplicate description panics.
 func Sometimes(what string) *Mark { return defaultCatalog.add(what, callerSite(2)) }
 
 func (c *catalog) add(what, site string) *Mark {
@@ -147,25 +83,9 @@ func (c *catalog) add(what, site string) *Mark {
 	return m
 }
 
-// Run runs the package's tests and then checks the inventory. Use it as the whole
-// body of TestMain:
-//
-//	func TestMain(m *testing.M) { os.Exit(testinv.Run(m)) }
-//
-// A package that already has a TestMain wraps its own setup around this call the
-// way it wrapped m.Run — Run substitutes for m.Run, it does not replace TestMain:
-//
-//	func TestMain(m *testing.M) {
-//		dir, _ := os.MkdirTemp("", "attn-test")
-//		config.ScopeTestEnvironment(dir)
-//		code := testinv.Run(m)
-//		os.RemoveAll(dir)
-//		os.Exit(code)
-//	}
-//
-// The returned code is the tests' own when they failed; a complete inventory
-// leaves it alone, and a state that was never reached turns a passing run into a
-// failing one.
+// Run substitutes for m.Run inside TestMain (it does not replace TestMain): it
+// runs the tests, then turns a passing run into a failing one when a cataloged
+// state was never reached.
 func Run(m *testing.M) int {
 	code := m.Run()
 
@@ -180,8 +100,7 @@ func Run(m *testing.M) int {
 	return code
 }
 
-// state is one inventory entry as review sees it, so review can be tested
-// without registering marks in the package under test.
+// state is one inventory entry as review sees it.
 type state struct {
 	what    string
 	site    string
@@ -199,10 +118,8 @@ func (c *catalog) snapshot() []state {
 	return out
 }
 
-// review turns the inventory into the text the run prints and says whether the
-// run should fail. skipped is the reason enforcement does not apply, or "";
-// testsPassed decides how the advice is worded, because "the tests still pass"
-// is only worth saying when they did.
+// review renders the inventory report and says whether the run should fail.
+// skipped is the reason enforcement does not apply, or "".
 func review(states []state, skipped string, testsPassed, verbose bool) (report string, incomplete bool) {
 	if len(states) == 0 {
 		return "", false
@@ -267,9 +184,8 @@ func plural(n int) string {
 	return fmt.Sprintf("%d cataloged states", n)
 }
 
-// filterReason names why this run cannot be expected to reach the whole
-// inventory, or "" when it can. Testing's flags are parsed by m.Run, so this is
-// only meaningful after it returns.
+// filterReason names why this run cannot reach the whole inventory, or "".
+// Testing's flags are parsed by m.Run, so only meaningful after it returns.
 func filterReason() string {
 	if v := testFlag("test.run"); v != "" {
 		return "this run is filtered by -run " + v
@@ -294,13 +210,11 @@ func testFlag(name string) string {
 	return f.Value.String()
 }
 
-// callerSite is the file:line the mark was registered from, so the report can
-// point at the var rather than making someone grep for the description.
+// callerSite is the package-relative file:line the mark was registered from.
 func callerSite(skip int) string {
 	_, file, line, ok := runtime.Caller(skip)
 	if !ok {
 		return "unknown"
 	}
-	// Package-relative is enough to find it and does not leak the build path.
 	return fmt.Sprintf("%s:%d", filepath.Join(filepath.Base(filepath.Dir(file)), filepath.Base(file)), line)
 }

--- a/internal/ticketnotify/notify.go
+++ b/internal/ticketnotify/notify.go
@@ -1,29 +1,9 @@
-// Package ticketnotify is the event-driven notification core of the work tracker
-// (slice 2 of docs/plans/2026-06-26-work-tracker.md). It is the decoupled layer
-// that sits above the store's append-only event log: every identity has a
-// per-ticket cursor, events past it are unread, and a shared pty-nudge asks the
-// owning session to consume them. A runtime may also run `ticket inbox --watch`,
-// which simply consumes the same queue before the countdown reaches its doorbell.
-//
-// Every observer reads through one or more identities. Ordinary assignment,
-// authorship, and explicit subscription use session identities. Durable product
-// roles use role identities, so their per-ticket cursors survive a change in the
-// session filling the role. There is no special "sees everything" observer: each
-// identity sees only tickets in its participation scope.
-//
-// This package re-homes the dispatch gateway's settled mechanics:
-//
-//	gateway                         here
-//	------------------------------  -----------------------------------------
-//	ack = output / consume pending  per-(identity, ticket) cursors: events past
-//	                                an identity's cursor on a ticket are unread
-//	bundle by sender                Consume groups unread events by ticket
-//	hardcoded chief id              observer IDs supplied by the caller
-//	watch / nudge race              either may consume; unread is authoritative
-//	never stream content to a PTY   Nudger carries only a fixed trigger
-//
-// It knows nothing about live sessions or real Monitors — it is built against the
-// store and proven by a simulation harness. Slice 3 wires it to real sessions.
+// Package ticketnotify is the event-driven notification core of the work
+// tracker (slice 2 of docs/plans/2026-06-26-work-tracker.md): every identity
+// has a per-ticket cursor over the store's append-only event log, events past
+// it are unread, and a shared pty-nudge asks the owning session to consume
+// them. Role identities keep a durable role's cursors across session changes;
+// no identity sees beyond its participation scope.
 package ticketnotify
 
 import (
@@ -33,12 +13,8 @@ import (
 	"github.com/victorarias/attn/internal/store"
 )
 
-// EventStore is the store surface the notifier needs. The real *store.Store
-// satisfies it; the harness uses the real store, so there is no mock to drift.
-//
-// UnreadTicketEvents folds the participant set, the per-(identity, ticket)
-// cursors, and the self-author exclusion into one query; SetTicketCursor advances
-// a single ticket's cursor for an identity.
+// EventStore is the store surface the notifier needs; the real *store.Store
+// satisfies it and the harness uses it, so there is no mock to drift.
 type EventStore interface {
 	UnreadTicketEventsFor(cursorIdentity, authorIdentity string) ([]store.TicketEvent, error)
 	SetTicketCursor(identity, ticketID string, cursor int64, now time.Time) error
@@ -53,31 +29,16 @@ type Observer struct {
 	DeliveryID string
 }
 
-// Bundle is an observer's unread events for a single ticket. Consume returns one
-// Bundle per ticket, in oldest-activity-first order — the gateway's "bundle by
-// sender", re-homed to "bundle by ticket".
+// Bundle is an observer's unread events for a single ticket.
 type Bundle struct {
 	TicketID string
 	Events   []store.TicketEvent
 }
 
-// Consume returns the observer's unread events, bundled by ticket, and advances
-// the observer's cursor on each of those tickets past everything just delivered.
-// A runtime may call this from `ticket inbox --watch`; a nudged session calls it
-// after the nudge lands. Both consume the same per-identity queue.
-//
-// Single-consumer-per-observer assumption: Consume reads unread events then writes
-// each touched ticket's cursor as separately-locked store calls, so two Consume
-// calls racing for the SAME observer can double-deliver. In practice an observer is
-// one session with one Monitor, so its consumes are serialized.
-//
-// The same non-atomicity applies WITHIN one ConsumeAll: it drains each identity in
-// turn, so a crash between two identities' cursor writes leaves one advanced and one
-// not, and the next consume replays those events. This is no longer an exotic path —
-// since every delegation binds a ticket, a chief that delegates routinely holds both
-// its session identity and the durable role identity on the same ticket. The failure
-// still costs at most a duplicate delivery, never a lost one, so it is documented
-// rather than fixed; a single transactional consume is the fix if it ever bites.
+// Consume returns the observer's unread events bundled by ticket and advances
+// the cursor on each. Not atomic: two Consumes racing for the SAME observer —
+// or a crash mid-ConsumeAll — can double-deliver, never lose. In practice an
+// observer is one session with one Monitor, so its consumes are serialized.
 func Consume(es EventStore, obs Observer, now time.Time) ([]Bundle, error) {
 	bundles, advance, err := pending(es, obs)
 	if err != nil {
@@ -91,10 +52,8 @@ func Consume(es EventStore, obs Observer, now time.Time) ([]Bundle, error) {
 	return bundles, nil
 }
 
-// ConsumeAll consumes several effective identities and merges their output by
-// event sequence. A chief session uses this for its ordinary session identity and
-// the durable chief role identity; an event in both scopes is delivered once while
-// both cursors advance.
+// ConsumeAll consumes several effective identities and merges by event
+// sequence; an event in more than one scope delivers once, every cursor moves.
 func ConsumeAll(es EventStore, observers []Observer, now time.Time) ([]Bundle, error) {
 	byTicket := map[string]map[int64]store.TicketEvent{}
 	for _, obs := range observers {
@@ -137,9 +96,8 @@ func Unread(es EventStore, obs Observer) (int, error) {
 	return n, nil
 }
 
-// UnreadAny counts the union only as a delivery predicate. Callers use it to
-// decide whether one session should be notified for any of its effective
-// identities; exact deduplication happens when ConsumeAll returns the events.
+// UnreadAny is a delivery predicate: whether any effective identity has unread
+// events. Exact deduplication happens in ConsumeAll.
 func UnreadAny(es EventStore, observers []Observer) (int, error) {
 	hasUnread := false
 	for _, obs := range observers {
@@ -163,11 +121,11 @@ type Delivery int
 const (
 	// DeliveryNone means there was nothing unread.
 	DeliveryNone Delivery = iota
-	// DeliveryNudge means a nudge-eligible observer was asked to consume. Only a
-	// fixed trigger is sent, never event content.
+	// DeliveryNudge means a nudge-eligible observer was asked to consume
+	// (fixed trigger only, never event content).
 	DeliveryNudge
-	// DeliveryDeferred means the observer is waiting for approval, so a doorbell
-	// could accidentally answer that prompt. A later eligible state rechecks it.
+	// DeliveryDeferred means the observer is waiting for approval — a doorbell
+	// could answer that prompt. A later eligible state rechecks it.
 	DeliveryDeferred
 )
 
@@ -177,20 +135,14 @@ type Nudger interface {
 	Nudge(observerID string) error
 }
 
-// Notify decides how to deliver an observer's pending events and, for the nudge
-// path, fires the Nudger. It does not consume (advance the cursor) — delivery only
-// triggers the observer to consume:
-//
-//   - nothing unread            -> DeliveryNone
-//   - nudge-eligible            -> DeliveryNudge (fixed trigger; it then consumes)
-//   - waiting for approval       -> DeliveryDeferred (recheck after it clears)
+// Notify decides how to deliver an observer's pending events, firing the
+// Nudger on the nudge path. It never consumes — delivery only triggers that.
 func Notify(es EventStore, obs Observer, nudgeEligible bool, nudger Nudger, now time.Time) (Delivery, error) {
 	return NotifyAny(es, []Observer{obs}, obs, nudgeEligible, nudger, now)
 }
 
-// NotifyAny makes one delivery decision for a session that observes through more
-// than one identity. deliveryObserver supplies the target; the observed identities
-// only determine whether anything is unread.
+// NotifyAny makes one delivery decision for a session observing through more
+// than one identity; deliveryObserver supplies the nudge target.
 func NotifyAny(es EventStore, observers []Observer, deliveryObserver Observer, nudgeEligible bool, nudger Nudger, now time.Time) (Delivery, error) {
 	unread, err := UnreadAny(es, observers)
 	if err != nil {
@@ -212,16 +164,10 @@ func NotifyAny(es EventStore, observers []Observer, deliveryObserver Observer, n
 	return DeliveryNudge, nil
 }
 
-// pending returns the observer's unread events, already bundled by ticket, and the
-// per-ticket cursor each bundle's ticket should advance to. The store's
-// UnreadTicketEvents has already applied the scope (tickets the identity is
-// assigned to or has authored an event on), the per-(identity, ticket) cursors, and
-// the self-author exclusion — so this only groups and orders the result.
-//
-// Because each ticket is compared against the identity's own cursor on THAT ticket
-// (default 0), a ticket the identity has never looked at — a fresh assignment, or a
-// reassignment to it — is delivered from the start, brief and all. Bundles are
-// ordered by their oldest unread event so cross-ticket order stays chronological.
+// pending groups the store's already-scoped unread events by ticket and
+// computes each ticket's advance cursor. A ticket the identity has never
+// looked at (cursor 0) delivers from the start, brief and all; bundles order
+// by oldest unread event so cross-ticket order stays chronological.
 func pending(es EventStore, obs Observer) (bundles []Bundle, advance map[string]int64, err error) {
 	authorID := obs.AuthorID
 	if authorID == "" {

--- a/internal/workflow/agentstub.go
+++ b/internal/workflow/agentstub.go
@@ -8,21 +8,10 @@ import (
 	"sync"
 )
 
-// AgentCall is the per-call spec handed to AgentStub.Run. It carries the agent()
-// invocation's identity (Ordinal), its inputs (Prompt, Schema), and the per-call
-// opts that select execution context (Isolation, Model, AgentType). It mirrors
-// native's agent(prompt, opts) shape so the real driver can honor each knob.
-//
-// Isolation is "" (none — share the writable working tree, the E3 default) or
-// "worktree" (run in a fresh git worktree as CWD; see driverAgent.Run). Unknown
-// values are normalized to "" upstream (host.go) so a typo never silently runs
-// in an unexpected mode. Model overrides the agent's default model when non-empty.
-// AgentType is carried for native parity but currently unused by the driver.
-//
-// Isolation/Model/AgentType are NOT part of the journal cache identity: the cache
-// predicate stays ordinal AND prompt_hash AND schema_hash (§6). Isolation changes
-// WHERE a live call runs, not WHAT its cached result is — so a resumed cache-hit
-// replays the journaled result and never re-creates a worktree.
+// AgentCall is the per-call spec handed to AgentStub.Run. Isolation/Model/
+// AgentType are NOT part of the journal cache identity — the predicate stays
+// ordinal AND prompt_hash AND schema_hash — so a resumed cache-hit replays the
+// journaled result and never re-creates a worktree.
 type AgentCall struct {
 	Ordinal   OrdinalPath
 	Prompt    string
@@ -32,29 +21,17 @@ type AgentCall struct {
 	AgentType string // native-parity carry; currently unused by the driver
 }
 
-// AgentStub is the agent() implementation behind the engine. DefaultStub is the
-// fake (E1/tests); driverAgent (E2/E3) spawns a real headless subagent. Run is
-// called on a worker goroutine and MUST be a pure deterministic function of its
-// inputs for replay tests to hold (the fakes are; the real driver is not, which
-// is why live runs do not assert ordinal replay).
-//
-// call.Schema is the per-call JSON Schema (nil when the call has no schema). The
-// fakes read call.Ordinal/call.Prompt/call.Schema and ignore the rest; the real
-// driver advertises the schema through the return_result sink and honors
-// call.Isolation/call.Model.
+// AgentStub is the agent() implementation behind the engine. Run is called on a
+// worker goroutine; replay tests only hold for a pure, deterministic Run.
 type AgentStub interface {
-	// Run returns the result for call. A returned error models a terminal subagent
-	// failure: the engine resolves the agent() promise to null and journals status
-	// "errored" (never rejects).
-	//
-	// ctx is the run's cancellation context: it is canceled when the run is canceled
-	// (attn workflow cancel) or hits the watchdog. A live driver MUST honor it so the
-	// headless subprocess is actually torn down; the fakes ignore it.
+	// Run returns the result for call. An error models a terminal subagent
+	// failure: the engine resolves the promise to null and journals status
+	// "errored", never rejects. A live driver MUST honor ctx to tear the
+	// subprocess down.
 	Run(ctx context.Context, call AgentCall) (json.RawMessage, error)
 }
 
-// DefaultStub returns a deterministic result derived from the prompt:
-// JSON string of sha256(prompt)[:12].
+// DefaultStub returns a deterministic result: JSON string of sha256(prompt)[:12].
 type DefaultStub struct{}
 
 func (DefaultStub) Run(_ context.Context, call AgentCall) (json.RawMessage, error) {
@@ -64,22 +41,15 @@ func (DefaultStub) Run(_ context.Context, call AgentCall) (json.RawMessage, erro
 	return b, nil
 }
 
-// StubFunc adapts a plain function to AgentStub. The adapted func keeps the
-// ctx-free shape (the fakes never need it); only the interface method carries ctx.
+// StubFunc adapts a plain ctx-free function to AgentStub.
 type StubFunc func(call AgentCall) (json.RawMessage, error)
 
 func (f StubFunc) Run(_ context.Context, call AgentCall) (json.RawMessage, error) {
 	return f(call)
 }
 
-// ScriptedStub is the resolution-ORDER injection seam. It gates when each call's
-// result is released back to the loop, letting a test release results in an
-// arbitrary (e.g. reversed) order to prove ordinal stability under reordered
-// resolution. Run blocks until the test releases the matching ordinal.
-//
-// Usage: construct with the deterministic result function, then from the test
-// goroutine call Release(ordinalString) in whatever order you choose. Each Run
-// blocks on its ordinal's gate until released. ReleaseAll() opens every gate.
+// ScriptedStub is the resolution-ORDER injection seam: each Run blocks until the
+// test releases its ordinal, proving ordinal stability under reordered resolution.
 type ScriptedStub struct {
 	resultFor func(ordinal OrdinalPath, prompt string) (json.RawMessage, error)
 
@@ -89,9 +59,7 @@ type ScriptedStub struct {
 	openAll  bool
 }
 
-// NewScriptedStub builds a gated stub. resultFor must be deterministic. The
-// schema is not part of the resultFor signature because the ordinal-stability
-// tests that use ScriptedStub do not vary by schema; Run accepts and ignores it.
+// NewScriptedStub builds a gated stub; resultFor must be deterministic.
 func NewScriptedStub(resultFor func(ordinal OrdinalPath, prompt string) (json.RawMessage, error)) *ScriptedStub {
 	return &ScriptedStub{
 		resultFor: resultFor,
@@ -125,8 +93,7 @@ func (s *ScriptedStub) Run(ctx context.Context, call AgentCall) (json.RawMessage
 	}
 }
 
-// Release opens the gate for a single ordinal (by its String()), unblocking that
-// call's Run. Safe to call before or after the corresponding Run begins.
+// Release opens the gate for one ordinal, before or after its Run begins.
 func (s *ScriptedStub) Release(ordinal string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/workflow/driveragent.go
+++ b/internal/workflow/driveragent.go
@@ -16,86 +16,61 @@ import (
 	"github.com/victorarias/attn/internal/git"
 )
 
-// headlessRunner is the seam over agent.RunHeadlessTask so driverAgent is
-// testable without spawning real binaries. The production implementation wraps
-// the registered driver's RunHeadlessTask; tests inject a fake.
+// headlessRunner is the seam over agent.RunHeadlessTask, so driverAgent is
+// testable without spawning real binaries.
 type headlessRunner interface {
 	Run(ctx context.Context, req agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error)
 }
 
-// resultToolName is the single MCP tool the result sink exposes.
 const resultToolName = "return_result"
 
-// defaultDriverAgentRetries is the OUTER (engine-level) re-spawn bound, beyond
-// the sink's in-turn isError self-correction. It handles a turn that ENDED
-// without ever writing a valid result (missing call), not a malformed call.
+// defaultDriverAgentRetries is the OUTER (engine-level) re-spawn bound: a turn
+// that ENDED without a valid result, not a malformed call (the sink
+// self-corrects those in-turn).
 const defaultDriverAgentRetries = 2
 
-// driverAgent is the real AgentStub: it spawns a headless subagent per agent()
-// call. With a schema it wires the schema-validating return_result sink and
-// reads the written result file; without a schema it returns the child's
-// captured final text. It honors the engine's error->null contract: a terminal
-// failure (no result after retries, or persistent non-zero exit) returns a Go
-// error, which the engine converts to a null resolution — it never throws past
-// the engine boundary.
+// driverAgent is the real AgentStub: one headless subagent per agent() call.
+// With a schema it wires the return_result sink and reads the result file;
+// without one it returns the child's final text.
 type driverAgent struct {
 	runner     headlessRunner
-	executable string // resolved agent binary path
+	executable string
 	model      string
-	attnExec   string // path to the attn binary (hosts the result-sink subcommand)
+	attnExec   string // hosts the result-sink subcommand
 	runTmpDir  string // per-call schema/result files live here
 	maxRetries int
 
-	// workingTree is the writable CWD handed to each subagent (native parity:
-	// agent() shares a writable working tree). Empty => fall back to runTmpDir so
-	// the agent still has a valid cwd. Scratch (schema/result/last-msg) always
-	// lives under runTmpDir, so a working tree here stays clean of attn files.
+	// workingTree is the writable CWD handed to each subagent (empty =>
+	// runTmpDir). Scratch always lives under runTmpDir, so the working tree
+	// stays clean of attn files.
 	workingTree string
-	// sessionMCPServers are the workflow session's MCP servers, attached to every
-	// subagent IN ADDITION to the return_result sink (native parity).
+	// sessionMCPServers attach IN ADDITION to the return_result sink.
 	sessionMCPServers []agentdriver.MCPServerSpec
-	// log is an optional diagnostics sink (e.g. the daemon logger). nil => silent.
-	// The worktree lifecycle uses it to record retained worktrees so a kept,
-	// mutated worktree can be found after the run.
+	// log records retained worktrees so a kept, mutated one can be found later.
 	log func(format string, args ...interface{})
 }
 
-// DriverAgentOptions configures NewDriverAgent.
+// DriverAgentOptions configures NewDriverAgent; zero fields take the defaults.
 type DriverAgentOptions struct {
-	// Provider is the agent name ("codex" or "claude").
-	Provider string
-	// Executable optionally overrides the resolved agent binary path.
+	Provider   string // "codex" or "claude"
 	Executable string
-	// Model is the model passed to the headless agent.
-	Model string
-	// RunTmpDir is the directory for per-call schema/result scratch files. It is
-	// created if missing. Empty => a fresh os.MkdirTemp dir owned by the agent.
-	RunTmpDir string
-	// AttnExecutable optionally overrides the attn binary path (defaults to the
-	// current process executable).
+	Model      string
+	// RunTmpDir is the per-call scratch dir, created if missing.
+	RunTmpDir      string
 	AttnExecutable string
-	// MaxRetries is the OUTER re-spawn bound. 0 => defaultDriverAgentRetries.
-	MaxRetries int
-	// Runner optionally injects a headlessRunner (tests). nil => the real driver.
+	MaxRetries     int
+	// Runner injects a headlessRunner for tests; nil => the real driver.
 	Runner headlessRunner
-	// WorkingTree is the writable working tree handed to each subagent as its CWD
-	// (native parity: agent() shares a writable tree). Empty => RunTmpDir is used
-	// as the CWD so subagents still run somewhere valid. Scratch files stay in
-	// RunTmpDir regardless, keeping the working tree free of attn artifacts.
-	WorkingTree string
-	// SessionMCPServers are the workflow session's MCP servers, threaded into each
-	// subagent request's ExtraMCPServers so their tools attach in addition to
-	// return_result (native parity). Empty is acceptable.
+	// WorkingTree is the writable CWD handed to each subagent; scratch files
+	// stay in RunTmpDir regardless.
+	WorkingTree       string
 	SessionMCPServers []agentdriver.MCPServerSpec
-	// LogFunc is an optional diagnostics sink for the worktree lifecycle (retained
-	// worktree paths, cleanup failures). nil => silent.
-	LogFunc func(format string, args ...interface{})
+	LogFunc           func(format string, args ...interface{})
 }
 
 var _ AgentStub = (*driverAgent)(nil)
 
-// NewDriverAgent constructs a driverAgent that spawns real subagents. It is wired
-// in production by `attn workflow run` via buildWorkflowStub.
+// NewDriverAgent constructs a driverAgent that spawns real subagents.
 func NewDriverAgent(opts DriverAgentOptions) (*driverAgent, error) {
 	provider := strings.TrimSpace(opts.Provider)
 	if provider == "" {
@@ -115,9 +90,7 @@ func NewDriverAgent(opts DriverAgentOptions) (*driverAgent, error) {
 		}
 		runner = headlessProviderRunner{provider: hp}
 
-		// Resolve a real binary only when using the real runner (tests inject a
-		// fake runner and may pass any or no executable). Reuse the driver we just
-		// looked up rather than fetching it a second time.
+		// Resolve a real binary only for the real runner; a fake may pass none.
 		if executable == "" {
 			resolved := driver.ResolveExecutable("")
 			path, err := exec.LookPath(resolved)
@@ -166,9 +139,6 @@ func NewDriverAgent(opts DriverAgentOptions) (*driverAgent, error) {
 	}, nil
 }
 
-// defaultRunCWD is the writable working directory handed to each subagent on the
-// non-isolated path: the working tree when set, else runTmpDir so the subagent
-// still runs somewhere valid.
 func (d *driverAgent) defaultRunCWD() string {
 	if d.workingTree != "" {
 		return d.workingTree
@@ -176,21 +146,9 @@ func (d *driverAgent) defaultRunCWD() string {
 	return d.runTmpDir
 }
 
-// Run implements AgentStub. With a schema it drives the return_result sink and
-// returns the validated result bytes; without a schema it returns the child's
-// captured final text encoded as a JSON string. Terminal failure returns a Go
-// error (engine -> null), never a thrown rejection.
-//
-// Execution context is per-call:
-//   - call.Isolation == "" (default): CWD is the shared writable working tree —
-//     byte-identical to E3.
-//   - call.Isolation == "worktree": the call runs in a FRESH git worktree as CWD
-//     so parallel mutating agents don't collide (see runIsolated). The structured
-//     result still returns via return_result; the worktree is the consumed side
-//     effect. It is auto-removed iff the agent left it git-clean, else KEPT.
-//
-// call.Model overrides d.model for this call when non-empty. call.AgentType is
-// carried for native parity but currently unused.
+// Run implements AgentStub. Terminal failure returns a Go error (engine -> null),
+// never a thrown rejection. Isolation "" runs in the shared working tree,
+// "worktree" in a fresh git worktree so parallel mutating agents don't collide.
 func (d *driverAgent) Run(ctx context.Context, call AgentCall) (json.RawMessage, error) {
 	model := d.model
 	if call.Model != "" {
@@ -202,9 +160,8 @@ func (d *driverAgent) Run(ctx context.Context, call AgentCall) (json.RawMessage,
 	return d.runInCWD(ctx, call, d.defaultRunCWD(), model)
 }
 
-// runInCWD dispatches the schema / no-schema path against an explicit CWD and
-// model. It is the single body both the default and worktree-isolated paths flow
-// through, so the only thing isolation changes is WHERE the subagent runs.
+// runInCWD is the single body both isolation modes flow through, so isolation
+// only changes WHERE the subagent runs.
 func (d *driverAgent) runInCWD(ctx context.Context, call AgentCall, cwd, model string) (json.RawMessage, error) {
 	if len(call.Schema) == 0 {
 		return d.runNoSchema(ctx, call.Prompt, cwd, model)
@@ -212,20 +169,9 @@ func (d *driverAgent) runInCWD(ctx context.Context, call AgentCall, cwd, model s
 	return d.runWithSchema(ctx, call.Ordinal, call.Prompt, call.Schema, cwd, model)
 }
 
-// runIsolated implements isolation:'worktree'. It resolves the repo root from the
-// shared working tree, creates a fresh worktree on a unique branch derived from
-// the call's ordinal, runs the subagent with that worktree as CWD, and then —
-// success OR failure — applies the §6/§7 cleanup rule:
-//
-//   - the agent left the worktree git-clean  -> remove it (and best-effort prune
-//     the branch): a no-op isolated call leaves nothing behind.
-//   - the agent made changes                 -> KEEP it: the mutations are the
-//     consumed side effect and must not be discarded; the retained path is logged.
-//
-// On CreateWorktree failure it returns a clear error (engine -> null) rather than
-// silently running in the wrong CWD. Scratch (schema/result) files stay under
-// runTmpDir as always, so the worktree's cleanliness reflects ONLY the subagent's
-// own edits, never attn artifacts.
+// runIsolated runs in a fresh worktree branched off the ordinal: a git-clean
+// worktree is removed afterward, a dirtied one is KEPT and its path logged.
+// Scratch stays under runTmpDir, so cleanliness reflects only the agent's edits.
 func (d *driverAgent) runIsolated(ctx context.Context, call AgentCall, model string) (json.RawMessage, error) {
 	repoRoot := git.ResolveMainRepoPath(d.defaultRunCWD())
 	if repoRoot == "" {
@@ -235,27 +181,23 @@ func (d *driverAgent) runIsolated(ctx context.Context, call AgentCall, model str
 	branch := worktreeBranchFor(call.Ordinal)
 	path := git.GenerateWorktreePath(repoRoot, branch)
 	if err := git.CreateWorktree(repoRoot, branch, path); err != nil {
-		// Fail closed: never fall back to the shared tree — that would defeat the
-		// whole point of isolation (parallel mutators must not collide).
+		// Fail closed: falling back to the shared tree would let parallel
+		// mutators collide.
 		return nil, fmt.Errorf("worktree isolation: create worktree for %s: %w", call.Ordinal.String(), err)
 	}
 
 	result, runErr := d.runInCWD(ctx, call, path, model)
 
-	// Cleanup applies regardless of the run outcome: a failed run that still dirtied
-	// the tree keeps its worktree (the user may inspect partial work); a clean run
-	// (success or failure) leaves nothing behind.
+	// Cleanup applies regardless of the run outcome; a failed run that dirtied
+	// the tree still keeps its worktree.
 	clean, cleanErr := git.IsWorktreeClean(path)
 	switch {
-	case cleanErr != nil:
-		// Could not determine cleanliness: keep the worktree to avoid discarding
-		// possible mutations, and surface the path so it can be found later.
+	case cleanErr != nil: // keep it rather than discard possible mutations
 		d.logf("worktree isolation: could not determine cleanliness of %q (%v); keeping it", path, cleanErr)
 	case clean:
 		if err := git.DeleteWorktree(repoRoot, path, true); err != nil {
 			d.logf("worktree isolation: remove clean worktree %q failed: %v", path, err)
 		} else {
-			// Best-effort branch prune; a leftover branch is harmless but untidy.
 			_ = git.DeleteBranch(repoRoot, branch, true)
 		}
 	default:
@@ -265,18 +207,13 @@ func (d *driverAgent) runIsolated(ctx context.Context, call AgentCall, model str
 	return result, runErr
 }
 
-// worktreeBranchFor derives a unique, filesystem-safe branch name for an isolated
-// call from its ordinal. The ordinal already disambiguates every call site /
-// parallel slot / pipeline stage in a run, so a short hash of it gives a stable,
-// collision-free branch per call.
+// worktreeBranchFor derives a filesystem-safe branch name from the ordinal,
+// which already disambiguates every call.
 func worktreeBranchFor(ordinal OrdinalPath) string {
 	sum := sha256.Sum256([]byte(ordinal.String()))
 	return "attn-wf/" + hex.EncodeToString(sum[:])[:12]
 }
 
-// logf emits a driver diagnostic. It is nil-safe (no logger wired in tests) and
-// kept lightweight so the worktree lifecycle leaves a trail without a hard
-// dependency on a logging sink.
 func (d *driverAgent) logf(format string, args ...interface{}) {
 	if d.log == nil {
 		return
@@ -284,10 +221,8 @@ func (d *driverAgent) logf(format string, args ...interface{}) {
 	d.log(format, args...)
 }
 
-// runNoSchema spawns a sink-less read-only agent and returns its final text,
-// JSON-encoded so the engine decodes it back to a JS string. cwd is the per-call
-// writable working directory (the shared tree, or an isolated worktree); model is
-// the per-call model.
+// runNoSchema returns the agent's final text JSON-encoded, so the engine decodes
+// it back to a JS string.
 func (d *driverAgent) runNoSchema(ctx context.Context, prompt, cwd, model string) (json.RawMessage, error) {
 	req := agentdriver.HeadlessTaskRequest{
 		Executable:      d.executable,
@@ -300,7 +235,6 @@ func (d *driverAgent) runNoSchema(ctx context.Context, prompt, cwd, model string
 	}
 	res, err := d.runner.Run(ctx, req)
 	if err != nil {
-		// Terminal failure -> null (the engine maps a non-nil error to null).
 		return nil, fmt.Errorf("headless agent failed: %s", diagnosticsOf(res, err))
 	}
 	encoded, encErr := json.Marshal(res.Text)
@@ -310,10 +244,9 @@ func (d *driverAgent) runNoSchema(ctx context.Context, prompt, cwd, model string
 	return encoded, nil
 }
 
-// runWithSchema wires the return_result sink, spawns the agent, and reads the
-// validated result file. On a missing result (the model never called the tool)
-// or a non-zero exit with no file, it re-spawns with a corrective prompt up to
-// maxRetries. Retries exhausted with no file -> error (engine -> null).
+// runWithSchema wires the return_result sink and reads the validated result
+// file, re-spawning with a corrective prompt up to maxRetries when none was
+// written; exhausted retries return an error.
 func (d *driverAgent) runWithSchema(ctx context.Context, ordinal OrdinalPath, prompt string, schema json.RawMessage, cwd, model string) (json.RawMessage, error) {
 	base := ordinalFileBase(ordinal)
 	schemaPath := filepath.Join(d.runTmpDir, base+".schema.json")
@@ -324,8 +257,7 @@ func (d *driverAgent) runWithSchema(ctx context.Context, ordinal OrdinalPath, pr
 	if err := os.WriteFile(schemaPath, schema, 0o600); err != nil {
 		return nil, fmt.Errorf("write result schema: %w", err)
 	}
-	// A stale result file from a prior call at the same ordinal would be read as a
-	// false success; clear it before the first spawn.
+	// A stale result file at the same ordinal would read as a false success.
 	_ = os.Remove(resultPath)
 
 	var lastDiag string
@@ -347,8 +279,7 @@ func (d *driverAgent) runWithSchema(ctx context.Context, ordinal OrdinalPath, pr
 			Schema:           schema,
 			ResultPath:       resultPath,
 			MCPServerCommand: d.attnExec,
-			// Scratch (schema/result) paths are absolute under runTmpDir; keep them
-			// absolute so the sink resolves them regardless of the writable CWD.
+			// Scratch paths stay absolute so the sink resolves them from any CWD.
 			MCPServerArgs: []string{
 				"_workflow-result-mcp",
 				"--tool-name", resultToolName,
@@ -365,13 +296,11 @@ func (d *driverAgent) runWithSchema(ctx context.Context, ordinal OrdinalPath, pr
 			lastDiag = ""
 		}
 
-		// A written, valid result file is success regardless of the exit code: the
-		// sink validated it in-turn, so it is schema-valid by construction. A
-		// non-zero exit AFTER a valid write is not a failure.
+		// A written result file is success regardless of exit code: the sink
+		// validated it in-turn.
 		if bytes, ok := readResultFile(resultPath); ok {
 			return bytes, nil
 		}
-		// No file: detect-missing. Loop to re-spawn with a corrective prompt.
 	}
 
 	if lastDiag == "" {
@@ -384,9 +313,7 @@ const schemaCallInstruction = "\n\nWhen you have the final answer, you MUST call
 
 const correctiveInstruction = "\n\nYour previous attempt did not produce a result: you did not call `return_result` with a schema-valid object. Call the `return_result` tool now, exactly once, with a JSON object matching the provided schema."
 
-// readResultFile reads a written result file and returns its bytes when present
-// and non-empty. A missing file (the model never called return_result) returns
-// ok=false — the detect-missing signal.
+// readResultFile reports ok=false when the file is missing or blank.
 func readResultFile(path string) (json.RawMessage, bool) {
 	b, err := os.ReadFile(path)
 	if err != nil || len(strings.TrimSpace(string(b))) == 0 {
@@ -395,8 +322,8 @@ func readResultFile(path string) (json.RawMessage, bool) {
 	return json.RawMessage(b), true
 }
 
-// ordinalFileBase derives a filesystem-safe base name from an ordinal (which
-// contains '/', ':', '#', '@'). A short hash keeps it unique and bounded.
+// ordinalFileBase hashes an ordinal, which contains '/', ':', '#', '@', into a
+// filesystem-safe base name.
 func ordinalFileBase(ordinal OrdinalPath) string {
 	sum := sha256.Sum256([]byte(ordinal.String()))
 	return "call-" + hex.EncodeToString(sum[:])[:16]

--- a/internal/workflow/ordinal.go
+++ b/internal/workflow/ordinal.go
@@ -9,20 +9,14 @@ import (
 type segKind int
 
 const (
-	// segPhase records a phase(title) progress boundary. NOTE: per the R-spec
-	// (§2.1), the phase is NOT part of the cache identity — renaming a phase must
-	// not invalidate calls. We therefore record a phase *sequence number* (not the
-	// title) so two identical call-sites in different phases get distinct ordinals,
-	// while a rename (same sequence) is inert.
+	// segPhase records a phase boundary as a *sequence number*, never the title:
+	// a rename must not invalidate cached calls.
 	segPhase segKind = iota
-	// segParallelSlot records the 0-based index of a thunk in parallel(thunks).
 	segParallelSlot
-	// segPipelineItem records the 0-based index of an item in pipeline(items, ...).
 	segPipelineItem
-	// segStage records the 0-based index of a stage in a pipeline.
 	segStage
-	// segCallsite records the lexical call-site of an agent() call plus a
-	// per-(prefix,callsite) loop counter to disambiguate repeated invocations.
+	// segCallsite is the lexical call-site of an agent() call plus a
+	// per-(prefix,callsite) loop counter disambiguating repeated invocations.
 	segCallsite
 )
 
@@ -43,7 +37,6 @@ func (k segKind) prefix() string {
 	}
 }
 
-// segment is one structural step from the run root toward a call site.
 type segment struct {
 	kind  segKind
 	index int    // slot/item/stage/phase-seq index; loop counter for callsite
@@ -57,14 +50,14 @@ func (s segment) String() string {
 	return s.kind.prefix() + strconv.Itoa(s.index)
 }
 
-// OrdinalPath is an immutable snapshot of the structural descent to a single
-// agent() call. The same logical call yields the same OrdinalPath on every
-// re-run, independent of promise-resolution timing.
+// OrdinalPath is an immutable snapshot of the structural descent to one agent()
+// call: the same logical call yields the same path on every re-run, independent
+// of promise-resolution timing.
 type OrdinalPath struct {
 	segs []segment
 }
 
-// String returns the canonical "/"-joined encoding used as the journal key.
+// String is the canonical "/"-joined encoding used as the journal key.
 func (p OrdinalPath) String() string {
 	if len(p.segs) == 0 {
 		return ""
@@ -76,33 +69,25 @@ func (p OrdinalPath) String() string {
 	return strings.Join(parts, "/")
 }
 
-// clone returns a deep copy so callers can hold a stable snapshot.
 func (p OrdinalPath) clone() OrdinalPath {
 	cp := make([]segment, len(p.segs))
 	copy(cp, p.segs)
 	return OrdinalPath{segs: cp}
 }
 
-// pathStack is the engine-owned, loop-goroutine-only structural-path context.
-// It is mutated synchronously during the descent into parallel/pipeline bodies
-// and read synchronously at each agent() invocation. It is NOT stored in goja.
+// pathStack is the engine-owned, loop-goroutine-only structural-path context,
+// mutated and read synchronously. NOT stored in goja.
 type pathStack struct {
 	segs []segment
 
-	// callCounter disambiguates repeated invocations of the same call-site. It is
-	// keyed by (current-prefix | callsite) so a loop body re-entered under a
-	// different slot/item counts independently. The map is snapshotted/restored
-	// around each push/pop so counters are lexically scoped to their subtree —
-	// this is what makes the counter a pure function of the structural descent.
+	// callCounter disambiguates repeated invocations of a call-site, keyed by
+	// (current-prefix | callsite). Snapshotted/restored around each push/pop so
+	// counters are lexically scoped to their subtree.
 	callCounter map[string]int
 
-	phaseSeq int // monotonic phase sequence number
-
-	// phaseTitle is the DISPLAY title of the current phase. It rides alongside
-	// phaseSeq across await boundaries (so a post-await agent() reads the phase
-	// in effect at its structural position) but is NEVER part of the ordinal:
-	// identity stays positional/sequential, so renaming a phase cannot invalidate
-	// a cached call.
+	phaseSeq int
+	// phaseTitle is DISPLAY-only; NEVER part of the ordinal, so renaming a phase
+	// cannot invalidate a cached call.
 	phaseTitle string
 }
 
@@ -110,22 +95,17 @@ func newPathStack() *pathStack {
 	return &pathStack{callCounter: map[string]int{}}
 }
 
-// prefix returns the canonical encoding of the current descent (without any
-// trailing callsite segment). It delegates to OrdinalPath.String() so the
-// canonical "/"-joined encoding has a single authority: a divergence between the
-// two would silently corrupt journal cache identity. String() only reads ps.segs,
-// so this stays zero-copy.
+// prefix delegates to OrdinalPath.String() so the encoding has a single
+// authority — a divergence silently corrupts journal cache identity.
 func (ps *pathStack) prefix() string {
 	return OrdinalPath{segs: ps.segs}.String()
 }
 
-// pushPop is the marker handle returned by push; calling it restores the stack
-// (segments + callCounter map) to its pre-push state.
+// pushPop restores the stack (segments + callCounter) to its pre-push state.
 type pushPop func()
 
-// push appends a structural marker and snapshots the counter scope. The returned
-// closure pops the marker and restores the counters captured before the push, so
-// counters are scoped to the subtree just like the path itself.
+// push appends a structural marker and snapshots the counter scope; the returned
+// closure pops and restores, scoping counters to the subtree.
 func (ps *pathStack) push(kind segKind, index int) pushPop {
 	savedLen := len(ps.segs)
 	savedCounters := make(map[string]int, len(ps.callCounter))
@@ -139,18 +119,16 @@ func (ps *pathStack) push(kind segKind, index int) pushPop {
 	}
 }
 
-// replace swaps in an entirely new descent path (used by stage/slot closures that
-// re-establish their captured path at async resolution time) and returns a
-// closure restoring the previous path + counters.
+// replace swaps in a new descent path — stage/slot closures re-establishing
+// their captured path at async resolution time — and returns a restoring closure.
 func (ps *pathStack) replace(newSegs []segment) pushPop {
 	savedSegs := ps.segs
 	savedCounters := ps.callCounter
 	cp := make([]segment, len(newSegs))
 	copy(cp, newSegs)
 	ps.segs = cp
-	// A re-established path gets a fresh counter scope: the captured path already
-	// uniquely identifies the subtree, and any agent() inside the callback counts
-	// from 0 within that re-established scope.
+	// Fresh scope: the captured path identifies the subtree, so calls inside the
+	// callback count from 0.
 	ps.callCounter = map[string]int{}
 	return func() {
 		ps.segs = savedSegs
@@ -158,21 +136,15 @@ func (ps *pathStack) replace(newSegs []segment) pushPop {
 	}
 }
 
-// snapshot returns an immutable copy of the current descent segments. Callers use
-// it both to capture a closure's path (parallel/pipeline construction) and as the
-// base for an agent() ordinal.
 func (ps *pathStack) snapshot() []segment {
 	cp := make([]segment, len(ps.segs))
 	copy(cp, ps.segs)
 	return cp
 }
 
-// stackState is a deep, immutable copy of the ENTIRE descent context (segments +
-// counter scope + phase sequence). It is the unit the AsyncContextTracker carries
-// across await boundaries so a continuation reads the same structural ordinal it
-// would have read had it run synchronously. Restoring it is what makes the
-// post-await agent() ordinal a pure function of structural position, not of
-// promise-resolution timing.
+// stackState is a deep copy of the descent context, carried by the
+// AsyncContextTracker across await boundaries so a post-await ordinal is a pure
+// function of structural position, not resolution timing.
 type stackState struct {
 	segs       []segment
 	counters   map[string]int
@@ -180,8 +152,6 @@ type stackState struct {
 	phaseTitle string
 }
 
-// captureState returns a deep copy of the full stack state for the tracker to
-// stash on a pending continuation.
 func (ps *pathStack) captureState() stackState {
 	segs := make([]segment, len(ps.segs))
 	copy(segs, ps.segs)
@@ -192,9 +162,8 @@ func (ps *pathStack) captureState() stackState {
 	return stackState{segs: segs, counters: counters, phaseSeq: ps.phaseSeq, phaseTitle: ps.phaseTitle}
 }
 
-// restoreState installs a previously-captured state. It deep-copies the captured
-// maps/slices so a restored continuation cannot mutate another continuation's
-// snapshot (each Resumed gets its own fresh, mutable working copy).
+// restoreState deep-copies so a restored continuation cannot mutate another
+// continuation's snapshot.
 func (ps *pathStack) restoreState(s stackState) {
 	segs := make([]segment, len(s.segs))
 	copy(segs, s.segs)
@@ -209,8 +178,7 @@ func (ps *pathStack) restoreState(s stackState) {
 }
 
 // ordinalFor reads the current path SYNCHRONOUSLY and appends the call-site
-// segment, advancing the per-(prefix,site) loop counter. This is the single point
-// where an agent() call's ordinal is fixed.
+// segment — the single point where an agent() call's ordinal is fixed.
 func (ps *pathStack) ordinalFor(site string) OrdinalPath {
 	key := ps.prefix() + "|" + site
 	counter := ps.callCounter[key]
@@ -222,11 +190,8 @@ func (ps *pathStack) ordinalFor(site string) OrdinalPath {
 	return OrdinalPath{segs: segs}
 }
 
-// setPhase replaces (or sets) the leading phase segment with the next sequence
-// number. Phases live at the top of the path. The title is stored for DISPLAY
-// only (phaseTitle) and is intentionally NOT part of the ordinal: identity is
-// positional/sequential, not label-based, so renaming a phase never invalidates
-// a cached call.
+// setPhase sets the leading phase segment to the next sequence number; the title
+// is display-only, NOT part of the ordinal.
 func (ps *pathStack) setPhase(title string) {
 	ps.phaseSeq++
 	seq := ps.phaseSeq
@@ -238,9 +203,7 @@ func (ps *pathStack) setPhase(title string) {
 	ps.segs = append([]segment{{kind: segPhase, index: seq}}, ps.segs...)
 }
 
-// currentPhase returns the DISPLAY title of the phase currently in effect (""
-// before any phase() call). Read synchronously at agent() dispatch so each call
-// records the phase active at its structural position.
+// currentPhase returns the display title in effect, read synchronously at dispatch.
 func (ps *pathStack) currentPhase() string {
 	return ps.phaseTitle
 }


### PR DESCRIPTION
## What

Comment density in hand-written non-test Go tripled since May (6% → 17% of lines), concentrated in recent work: package headers retelling their plan docs, per-field essays, narration of the following line, and justification written for the reviewer. This PR:

- compresses the 67 densest files (>22% comment lines): invariants, trap warnings, and measured receipts stay inline at a line or two; narration, design-doc retellings, and history go. Net −4,758 lines; the swept set drops from ~9,900 comment lines to ~4,700, and the overall ratio from 17.1% to 12.7%.
- states the policy in AGENTS.md: comments say what the code cannot show — a constraint, an invariant, a measured receipt — in one or two lines; package headers link to the design doc instead of retelling it; a comment addressed to the reviewer is a defect.

## Verification

Every touched Go file is token-stream identical to its previous version (go/scanner comparison ignoring comments — comments and gofmt whitespace are the only change), verified mechanically for all 69 files after the rebase. `gofmt -l` is silent, `go build ./...` and `go vet ./...` pass, and `go test` was run for the heaviest touched packages (daemon, pty, jobs, workflow, docstore). No `//go:` directives, `//nolint`, or cgo preambles were touched; `docs/plans/` links are preserved.

Live verification: exempt as a trivial comments/docs-only change (token-identical code, verified mechanically).

https://claude.ai/code/session_01AdM1oGRTFk3c75NPQQjPt2