### PR TITLE
test(synctest): take the paced-test remainder to zero candidates

### DIFF
--- a/changelog.d/synctest-remainder-and-retention-pass.yaml
+++ b/changelog.d/synctest-remainder-and-retention-pass.yaml
@@ -1,0 +1,11 @@
+kind: internal
+area: testing
+change: >
+  The paced-test triage from the previous sweep now ends at zero unverified
+  candidates: 87 more tests run inside a `testing/synctest` bubble on their
+  shipped intervals, and every test still paced carries a recorded reason —
+  a child process, a real socket, fsnotify, real file mtimes, a goroutine
+  parked on a mutex, or an assertion on real elapsed wall-clock. The daemon's
+  converted subset drops from 94.6s to 6.0s. The job runner's periodic
+  retention pass, which had never executed in any test because its hourly
+  ticker ran on real time, gets one of its own.

--- a/docs/plans/2026-08-09-testing-adoption-wave.md
+++ b/docs/plans/2026-08-09-testing-adoption-wave.md
@@ -147,7 +147,8 @@ Named per the boil-the-ocean rule; each needs an explicit go.
       fallback to fix 1 alone); extended toxiproxy test; live verification
 - [ ] Track B1: three rapid property files (pty scanners, docstore,
       workspacelayout)
-- [ ] Track B2: triage map, then bubble-able conversions
+- [x] Track B2: triage map, then bubble-able conversions (two passes; candidate
+      column at zero)
 - [ ] Track C: AGENTS.md testing-tools note
 - [ ] Track D: none until explicitly picked
 - [ ] Changelog fragments per PR
@@ -172,12 +173,18 @@ Named per the boil-the-ocean rule; each needs an explicit go.
 
 ## Track B2 triage map (2026-08-09)
 
-Measured on `test/synctest-sweep`. A test counts as **paced** when its body
-sleeps, waits on `time.After`, or spins a deadline-bounded poll loop. Tags are
-resolved through the fixtures a test calls, two levels deep, so a test inherits
-the boundary its helper crosses.
+A test counts as **paced** when its body sleeps, waits on `time.After`, or spins
+a deadline-bounded poll loop.
 
-| package | paced | converted here | boundary-bound | candidate, not converted |
+The sweep ran in two passes. The first pass converted what was already known to
+be safe and left a remainder of unverified candidates; the second pass took that
+remainder to zero, either by converting a candidate or by giving it a reason.
+
+**First pass** (the triage itself), measured on `test/synctest-sweep` against
+its merge base. Tags are resolved through the fixtures a test calls, two levels
+deep, so a test inherits the boundary its helper crosses.
+
+| package | paced | converted | boundary-bound | candidate, not converted |
 |---|---|---|---|---|
 | `internal/daemon` | 199 | 20 | 59 | 120 |
 | `internal/jobs` | 21 | 17 | 0 | 2 |
@@ -188,10 +195,31 @@ the boundary its helper crosses.
 | `internal/workflow` | 4 | 3 | 1 | 0 |
 | **total** | **264** | **47** | **85** | **130** |
 
-"Paced" and "boundary-bound" are measured against this branch's merge base;
-"converted here" counts the `synctest.Test` call sites this PR adds. The two
-`internal/jobs` tests the spike had already bubbled are not counted as
-converted here.
+**Closing state**, counted on the tree itself rather than against a merge base,
+so it can be re-derived at any time: a test is *bubbled* if its body contains a
+`synctest.Test` call, and *still paced* if it does not and its body sleeps,
+waits on `time.After`, or spins a poll loop.
+
+| package | bubbled | still paced | of those, with a recorded reason | candidate |
+|---|---|---|---|---|
+| `internal/daemon` | 106 | 98 | 98 | 0 |
+| `internal/jobs` | 21 | 0 | — | 0 |
+| `internal/pty` | 0 | 14 | 14 | 0 |
+| `internal/ptybackend` | 1 | 10 | 10 | 0 |
+| `internal/ptyworker` | 7 | 2 | 2 | 0 |
+| `internal/daemonctl` | 0 | 6 | 6 | 0 |
+| `internal/workflow` | 3 | 1 | 1 | 0 |
+| **total** | **138** | **131** | **131** | **0** |
+
+The two scans differ by a handful per package — the first pass resolved a test's
+tags through the helpers it calls, two levels deep, and this one reads bodies
+only. Neither is wrong; they answer slightly different questions, and the
+column that matters is the last one either way.
+
+The population is the tree at `39c3c8c4`. Paced tests that landed on main after
+that — `activity_test.go` (7, from the activity line) and `ws_eviction_test.go`
+(4, Track A's own) — are not in it. A scan run later will find them; that is new
+work arriving, not the sweep leaving something behind.
 
 (The brief's raw `grep` counts — daemon 194, ptybackend 22, pty 21, ptyworker
 12, jobs 10, daemonctl 7, workflow 6 — count *lines*, including sleeps inside
@@ -222,7 +250,26 @@ What actually pins a bubble to real time:
 5. **A CPU-bound goroutine.** `internal/workflow`'s `while(true){}` watchdog
    test spins in goja; a spinning goroutine is never durably blocked.
 
-Three house rules make a daemon fit inside a bubble; all three are written up
+The second pass added three more, all found by converting a test and watching it
+hang:
+
+6. **A claim about a goroutine parked on a lock.** `go doc testing/synctest` is
+   explicit that locking a `sync.Mutex` is *not* durable blocking. A test whose
+   subject is "this writer is stuck behind that lock" — `doorbellMu`,
+   `autoSettleFireMu`, the spawn lock, the evidence and trace tables — has no
+   state a bubble can settle into, so `synctest.Wait()` hangs instead of
+   returning. This is the largest single class in the remainder.
+7. **An assertion on real elapsed wall-clock.** `delegation_operation_test.go`
+   asserts a slow preparation took *more* than 100ms of real time. Under a fake
+   clock that reads zero and the assertion is vacuous — converting it would
+   quietly delete the test's only claim.
+8. **A goroutine with no exit path.** `go d.wsHub.run()` loops forever over its
+   channels. A bubble ends only when its last goroutine exits, so a test that
+   starts the hub inside one never finishes (measured: hangs to the binary's own
+   timeout). Giving the hub a quit channel is a production change, and this
+   sweep is test-only.
+
+Four house rules make a daemon fit inside a bubble; all four are written up
 where they are used, in `internal/daemon/synctest_test.go`:
 
 1. Build the daemon **outside** the bubble (`database/sql`'s `connectionOpener`
@@ -234,12 +281,62 @@ where they are used, in `internal/daemon/synctest_test.go`:
    ahead: a turn opened outside and settled inside settles *before* it opened
    and still reads as owed. This cost an hour of debugging on
    `TestAutoSettle_RealTimersSettleTheTurn`.
+4. Let every goroutine the body started **finish** before the body returns —
+   including one the code under test spawned and left sleeping. `handleStop`
+   starts a classifier that retries the transcript read for 2s; a test that only
+   cares about `handleStop`'s synchronous effects still has to run that window
+   out (`settleStopClassification`) or the bubble reports blocked goroutines.
+   The same shape appears wherever production polls: `handleDelegateWS` checks
+   its operation every 100ms, and the spawn probe waits out its own 250ms read
+   deadline. On a fake clock those windows are free — sleep past them.
 
 One more, from D1 and worth repeating: `synctest.Wait()` is a happens-before
 edge for the race detector, `time.Sleep` is **not**. State a timer writes still
 needs its own lock.
 
-### Converted in this PR
+### Converted in the second pass
+
+87 more: 86 in `internal/daemon`, 1 in `internal/ptybackend`.
+
+- `notebook_narration_test.go` (18), `notebook_daily_narrate_test.go` (10),
+  `notebook_tasks_enabled_test.go` (6) — the cluster the first pass named as the
+  biggest remaining win, and it was: the executor stub never execs, so every
+  poll over job-queue state collapses to a `synctest.Wait()`.
+- `plugin_rpc_test.go` (9), `plugin_supervisor_test.go` (7) — the open question
+  was whether the plugin runtime spawns a real interpreter. It does not: these
+  drive the RPC over `net.Pipe`, which is channel-backed and bubble-safe, read
+  deadlines included. The supervisor tests now run the shipped restart backoff
+  rather than a turned-down copy of it.
+- `transcript_watcher_abort_test.go` (5) — the first pass filed these under
+  fsnotify. They do not use fsnotify; the watcher polls the transcript on a
+  ticker, which is exactly what a bubble is for.
+- `workspace_keeper_test.go` (5) — context-compaction debounce and timeouts.
+- `browser_test.go` (3), `reload_test.go` (3), `daemon_test.go` (3),
+  `spawn_characterization_test.go` (2), `stop_terminality_test.go` (2),
+  `ticket_buffer_test.go` (2), `tilecontent_test.go` (2), `ws_tasks_test.go` (2),
+  and one each in `automations_test.go`, `bus_test.go`, `delegate_test.go`,
+  `plugin_driver_test.go`, `session_state_characterization_test.go`,
+  `workspace_test.go`, `ws_plugins_test.go`.
+- `internal/ptybackend` — `TestWorkerStream_PublishOverflowWaitsForBufferSpace`,
+  pure channels and a timer.
+
+Two corrections to the first pass's classification came out of this:
+`reload_test.go` drives a `fakeReloadBackend`, not `ptybackend` worker
+processes — 3 of its 6 convert cleanly, and the other 3 are blocked by an
+fsnotify watcher the *notebook root setting* starts, not by workers.
+`tilecontent_test.go` is not wholly mtime-bound either; only one of its tests
+needs the real clock to move.
+
+New shared helpers, in `internal/daemon/synctest_test.go`: `requireOutbound` and
+`requireNoOutbound`, which replace `select { case <-client.send: ... case
+<-time.After(2s): }` with a settled read. The negative is the one that changes
+meaning — outside a bubble "nothing was sent" is only ever "nothing yet".
+
+`waitForNudgeDeadline`, `waitForNudgeDeadlineBefore` and `waitForBus` are gone.
+`bus_test.go` in particular no longer turns `PollInterval` down to 5ms: it runs
+the shipped `bus.DefaultPollInterval` and sleeps two periods of fake time.
+
+### Converted in the first pass
 
 - `internal/jobs` — all remaining paced tests (`runner_test.go` ×14 beyond the
   spike's two pre-existing call sites, `cron_test.go` ×3). `waitFor` deleted.
@@ -275,44 +372,89 @@ intervals no longer need turning down, so nothing needs to outrun them.
 
 ### Boundary-bound, with reasons
 
+Every paced test that is not converted is here. Where the reason is not obvious
+from the file's imports it is also written above the test itself.
+
+Child processes and real fds:
+
 - `internal/daemonctl` (6/6) — every `stop_test.go` case forks a helper
-  process to hold or release the pid lock. Child process.
-- `internal/pty` (10/14) — real PTYs and read loops over real fds.
-- `internal/ptybackend` (9/11) — worker child processes and the control socket.
-- `internal/daemon/daemon_test.go` (25 of 35 paced) and `testharness_test.go`
-  (5/5) — a started daemon: listener, WebSocket hub, spawned sessions.
+  process to hold or release the pid lock.
+- `internal/pty` (14/14) — real PTYs and read loops over real fds. The first
+  pass listed 5 of these as candidates; all 5 go through `manager.Spawn` or an
+  `os/exec` helper, so the correct count is 14.
+- `internal/ptybackend` (10/11) — worker child processes and the control
+  socket. `embedded_test.go`'s concurrent-close probe belongs here for a
+  different reason: it needs 16 goroutines *actually running* while `Close`
+  lands, and a bubble only advances once they are all parked.
 - `internal/daemon/plugin_worktree_test.go` (14) — `exec.Command` per case.
-- `internal/daemon/fs_watch_test.go`, `transcript_watcher_abort_test.go`,
-  `notebook_test.go` — fsnotify.
-- `internal/daemon/tilecontent_test.go` — real mtime granularity (see rule 4).
-- `internal/daemon/reload_test.go` — `ptybackend` worker processes.
+- `internal/daemon/plugin_runtime_test.go` (3),
+  `plugin_driver_e2e_test.go` (2), `codex_resume_e2e_test.go` (1),
+  `real_agent_harness_test.go` (1) — real plugin and agent processes.
+- `internal/ptyworker` (2/9) — `reap_test.go` waits on a real child dying,
+  `runtime_test.go`'s theme RPC spawns a real PTY.
+
+A started daemon (listener, WebSocket hub, or both):
+
+- `internal/daemon/daemon_test.go` (31) and `testharness_test.go` (5).
+- `internal/daemon/documents_socket_test.go` (1),
+  `toxiproxy_slow_client_test.go` (1) — a real socket is the subject.
+- `internal/daemon/stop_terminality_test.go` (2), `ws_tasks_test.go` (1),
+  `workspace_context_test.go` (1), `fs_test.go` (7) — `go d.wsHub.run()`
+  (rule 8). `fs_test.go` also carries fsnotify.
+
+fsnotify:
+
+- `internal/daemon/fs_watch_test.go` (5), `notebook_test.go` (6).
+- `internal/daemon/reload_test.go` (3) — not worker processes, as the first pass
+  had it: setting the notebook root starts a watcher.
+
+Lock-parking claims (rule 6):
+
+- `internal/daemon/spawn_lock_test.go` (2), `ws_automations_test.go` (2),
+  `auto_settle_test.go` (1), `session_evidence_test.go` (1),
+  `state_trace_test.go` (1), `ticket_buffer_test.go` (1),
+  `nudge_countdown_test.go` (1).
+
+One-offs:
+
+- `internal/daemon/tilecontent_test.go` (1) — real mtime granularity (rule 4).
+- `internal/daemon/automations_test.go` (1) — `httptest` server, a real socket.
+- `internal/daemon/gitstatus_test.go` (1) — git child process.
+- `internal/daemon/delegation_operation_test.go` (1) — asserts real elapsed
+  wall-clock (rule 7).
 - `internal/workflow/loop_test.go::TestContextCancelInterrupts` — CPU-bound
   goja loop by design.
 - `internal/daemon/ticket_notify_test.go::TestChiefTicketContinuityAcrossRoleTransfer`
-  — mechanically bubble-able, deliberately left alone. Its final assertion
-  ("the retired chief received no role nudge") holds only while the nudge
-  window is parked; run the window out for real and the retired chief *is*
-  doorbelled, because the fixture leaves it a personal participant on the
-  ticket and `nudgeCount` cannot tell a personal nudge from a role one. Fixing
-  that needs either a narrower probe or a product answer, both outside a
-  test-only sweep. The reason is recorded above the test.
+  — bubble-able, parked on purpose; see below.
 
-### Candidates not converted (the honest remainder)
+### Where the 130 candidates went
 
-120 paced daemon tests carry no boundary signal and were not converted here.
-They are not a backlog of known-good conversions — they are unverified
-candidates, and the classification is static analysis, not a passing bubble.
-The largest clusters, in the order worth taking them:
+The first pass left 130 tests classified by static analysis and nothing else.
+Every one now has a verdict from running it:
 
-- `notebook_narration_test.go` (16) and `notebook_daily_narrate_test.go` (6) —
-  poll the job queue for executor task state against a stubbed executable. If
-  the stub really never execs, these are `synctest.Wait()` one-liners and the
-  single biggest remaining win.
-- `plugin_rpc_test.go` (9), `plugin_supervisor_test.go` (7) — need a check for
-  whether the plugin runtime spawns a real interpreter.
-- `fs_test.go` (7) — separate the fsnotify cases from the pure-logic ones.
-- `workspace_keeper_test.go` (5), `ticket_buffer_test.go` (3),
-  `ws_tasks_test.go` (3) — store+queue polling, same shape as the jobs work.
+| outcome | count |
+|---|---|
+| converted and green under `-race -count=20` | 76 |
+| reclassified boundary-bound, reason recorded | 52 |
+| not paced after all (`internal/jobs` scanner artifact) | 2 |
+
+The 87 conversions in this pass are 76 of those candidates plus 11 tests the
+first pass had filed as boundary-bound for a reason that did not hold —
+`transcript_watcher_abort_test.go` (5), `reload_test.go` (3),
+`tilecontent_test.go` (2), `internal/ptybackend` (1).
+
+Of the 52 reclassifications, 9 are the lock-parking class the first pass had no
+name for, and the rest resolve to signals it already knew: a started hub, a real
+socket, fsnotify, a child process.
+
+One test stays parked on purpose, unchanged:
+`ticket_notify_test.go::TestChiefTicketContinuityAcrossRoleTransfer`. It is
+mechanically bubble-able. Its final assertion ("the retired chief received no
+role nudge") holds only while the nudge window is parked; run the window out for
+real and the retired chief *is* doorbelled, because the fixture leaves it a
+personal participant on the ticket and `nudgeCount` cannot tell a personal nudge
+from a role one. That needs a narrower probe or a product answer, both outside a
+test-only sweep. The reason is recorded above the test.
 
 ### Timings
 
@@ -342,6 +484,25 @@ means something is the converted subset alone:
 That is the honest summary of the whole sweep: it buys determinism and
 fidelity (production intervals actually execute), not wall-clock.
 
+#### Second pass
+
+Same machine, `go test -count=3`, this branch against `39c3c8c4`.
+
+| subset | before | after |
+|---|---|---|
+| the 86 converted daemon tests | 94.6s | 6.0s |
+| `internal/jobs` whole package | 0.68s | 0.91s |
+| `internal/ptybackend` whole package | 6.46s | 5.48s |
+| `internal/daemon` whole package | 403.6s | 327.0s |
+
+The subset number is the one to read: 94.6s of it was tolerance windows and poll
+loops, and 88.6s of that is gone. The whole-package figure moves this time —
+86 tests is enough to show through — but a 6-minute package still has minutes of
+run-to-run spread, so treat the 77s as directionally right and not as a receipt.
+
+`internal/jobs` grows slightly because it gained a test rather than converting
+one: the retention pass below now runs 25 hours of fake time.
+
 ### Finding: the retention pass had never run in a test
 
 `TestRetentionTrimsCompletedJobsAndKeepsDeadOnes` went red on conversion. The
@@ -351,3 +512,16 @@ across the test's 48-hour window — and trimmed the record before the manual
 time and never fired at all. The conversion parks it (`TrimInterval` 30 days)
 to keep the subject singular, but the discovery stands: the periodic retention
 pass has no test of its own. Worth one.
+
+**Written in the second pass.**
+`TestThePeriodicRetentionPassTrimsOnItsOwnInterval` (`internal/jobs`) is that
+test. It leaves `TrimInterval` at the shipped `DefaultTrimInterval` — one hour,
+the value that had never executed — and a 24-hour retention policy, then runs
+the bubble clock forward and asserts three things the ticker owes: through 23
+ticks it trims nothing, the tick after the policy window trims exactly the aged
+completed job, and it leaves the young completed job and the dead one alone. The
+runner's own log line is the receipt that the pass ran once, not zero times and
+not twice: `jobs: trimmed 1 completed job(s) older than 24h0m0s`.
+
+Mutation-checked by setting `DefaultTrimInterval` to 24h in production code:
+three assertions fail. The production change was reverted.

--- a/internal/daemon/auto_settle_test.go
+++ b/internal/daemon/auto_settle_test.go
@@ -502,6 +502,9 @@ func TestAutoSettleSettingsSurfaceEffectiveDefaults(t *testing.T) {
 // opens a fresh one; if the transition wins the timer sees a non-working session
 // and declines. Either way the user still owes this session a turn, which is why
 // that is the invariant asserted rather than a particular interleaving.
+// Boundary-bound: the hook holds the settle open while a concurrent transition
+// parks on autoSettleFireMu. A goroutine blocked on a sync.Mutex is not durably
+// blocked, so a bubble has no instant at which to call the race staged.
 func TestAutoSettle_ConcurrentApprovalKeepsTheTurn(t *testing.T) {
 	d, id := newAutoSettleDaemon(t)
 	if !d.applyState(sessionStateChange{sessionID: id, state: protocol.StateWorking, cause: liveSignal{}}) {

--- a/internal/daemon/automations_test.go
+++ b/internal/daemon/automations_test.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/automation"
@@ -455,22 +456,21 @@ location: {type: directory, path: "` + t.TempDir() + `"}
 }
 
 func TestAutomationRecoveryWaitsForInitialGitHubDiscovery(t *testing.T) {
-	ready := make(chan struct{})
-	recovered := make(chan struct{})
-	go recoverAutomationsAfterGitHubReady(ready, func() { close(recovered) })
+	synctest.Test(t, func(t *testing.T) {
+		ready := make(chan struct{})
+		recovered := make(chan struct{})
+		go recoverAutomationsAfterGitHubReady(ready, func() { close(recovered) })
 
-	select {
-	case <-recovered:
-		t.Fatal("automation recovery ran before GitHub host discovery completed")
-	case <-time.After(50 * time.Millisecond):
-	}
+		synctest.Wait()
+		select {
+		case <-recovered:
+			t.Fatal("automation recovery ran before GitHub host discovery completed")
+		default:
+		}
 
-	close(ready)
-	select {
-	case <-recovered:
-	case <-time.After(time.Second):
-		t.Fatal("automation recovery did not resume after GitHub host discovery completed")
-	}
+		close(ready)
+		requireDone(t, recovered, "automation recovery did not resume after GitHub host discovery completed")
+	})
 }
 
 func TestAutomationRecoveryLeavesGitHubRunsForFreshProviderObservation(t *testing.T) {
@@ -588,6 +588,8 @@ location:
 	}
 }
 
+// Boundary-bound: the GitHub client talks to an httptest.NewServer over a real
+// TCP socket, so the observer's work is not durably blocked.
 func TestManualPRRefreshFeedsGitHubAutomationObserver(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/daemon/browser_test.go
+++ b/internal/daemon/browser_test.go
@@ -3,8 +3,10 @@ package daemon
 import (
 	"encoding/json"
 	"net"
+	"path/filepath"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
@@ -129,41 +131,43 @@ func TestBrowserControlRejectsNonObjectParams(t *testing.T) {
 }
 
 func TestOpenBrowserRetargetsExistingTileAtSameURL(t *testing.T) {
-	d, _, workspaceID := setupMarkdownWorkspace(t)
-	d.setSelectedSession("session-1")
+	base := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	synctest.Test(t, func(t *testing.T) {
+		d, _, workspaceID := setupMarkdownWorkspaceOn(t, base)
+		stopDaemonBackground(t, d)
+		d.setSelectedSession("session-1")
 
-	firstClient, firstServer := net.Pipe()
-	go d.handleOpenBrowser(firstServer, &protocol.OpenBrowserMessage{
-		Cmd: protocol.CmdOpenBrowser,
-		URL: "http://localhost:3000",
-	})
-	var firstResp protocol.Response
-	if err := json.NewDecoder(firstClient).Decode(&firstResp); err != nil || !firstResp.Ok {
-		t.Fatalf("first open browser response = (%+v, %v)", firstResp, err)
-	}
-	_ = firstClient.Close()
+		firstClient, firstServer := net.Pipe()
+		go d.handleOpenBrowser(firstServer, &protocol.OpenBrowserMessage{
+			Cmd: protocol.CmdOpenBrowser,
+			URL: "http://localhost:3000",
+		})
+		var firstResp protocol.Response
+		if err := json.NewDecoder(firstClient).Decode(&firstResp); err != nil || !firstResp.Ok {
+			t.Fatalf("first open browser response = (%+v, %v)", firstResp, err)
+		}
+		_ = firstClient.Close()
 
-	host := newWorkspaceProtocolTestClient()
-	host.trustedTauriOrigin = true
-	host.browserHostAuthenticated = true
-	host.connectedAt = time.Now()
-	host.setIdentity("tauri-app", "test", []string{
-		protocol.CapabilityWorkspaceSessions,
-		protocol.CapabilityBrowserHost,
-	})
-	d.wsHub.mu.Lock()
-	d.wsHub.clients[host] = true
-	d.wsHub.mu.Unlock()
+		host := newWorkspaceProtocolTestClient()
+		host.trustedTauriOrigin = true
+		host.browserHostAuthenticated = true
+		host.connectedAt = time.Now()
+		host.setIdentity("tauri-app", "test", []string{
+			protocol.CapabilityWorkspaceSessions,
+			protocol.CapabilityBrowserHost,
+		})
+		d.wsHub.mu.Lock()
+		d.wsHub.clients[host] = true
+		d.wsHub.mu.Unlock()
 
-	secondClient, secondServer := net.Pipe()
-	defer secondClient.Close()
-	go d.handleOpenBrowser(secondServer, &protocol.OpenBrowserMessage{
-		Cmd: protocol.CmdOpenBrowser,
-		URL: "http://localhost:3000",
-	})
+		secondClient, secondServer := net.Pipe()
+		defer secondClient.Close()
+		go d.handleOpenBrowser(secondServer, &protocol.OpenBrowserMessage{
+			Cmd: protocol.CmdOpenBrowser,
+			URL: "http://localhost:3000",
+		})
 
-	select {
-	case outbound := <-host.send:
+		outbound := requireOutbound(t, host, "no browser navigation request reached the host")
 		var request protocol.BrowserControlRequestMessage
 		if err := json.Unmarshal(outbound.payload, &request); err != nil {
 			t.Fatal(err)
@@ -174,15 +178,13 @@ func TestOpenBrowserRetargetsExistingTileAtSameURL(t *testing.T) {
 			protocol.Deref(request.Text) != "http://localhost:3000" {
 			t.Fatalf("request = %+v", request)
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for browser navigation request")
-	}
 
-	_ = secondClient.SetReadDeadline(time.Now().Add(2 * time.Second))
-	var secondResp protocol.Response
-	if err := json.NewDecoder(secondClient).Decode(&secondResp); err != nil || !secondResp.Ok {
-		t.Fatalf("second open browser response = (%+v, %v)", secondResp, err)
-	}
+		_ = secondClient.SetReadDeadline(time.Now().Add(2 * time.Second))
+		var secondResp protocol.Response
+		if err := json.NewDecoder(secondClient).Decode(&secondResp); err != nil || !secondResp.Ok {
+			t.Fatalf("second open browser response = (%+v, %v)", secondResp, err)
+		}
+	})
 }
 
 func TestOpenBrowserTargetsSelectedSession(t *testing.T) {
@@ -375,44 +377,46 @@ func TestBrowserControlTargetUsesExplicitWorkspace(t *testing.T) {
 }
 
 func TestBrowserControlBrokersToCapableClient(t *testing.T) {
-	d, _, _ := setupMarkdownWorkspace(t)
-	d.setSelectedSession("session-1")
-	largeResult := strings.Repeat("A", 64*1024)
+	base := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	synctest.Test(t, func(t *testing.T) {
+		d, _, _ := setupMarkdownWorkspaceOn(t, base)
+		stopDaemonBackground(t, d)
+		d.setSelectedSession("session-1")
+		largeResult := strings.Repeat("A", 64*1024)
 
-	openClient, openServer := net.Pipe()
-	go d.handleOpenBrowser(openServer, &protocol.OpenBrowserMessage{
-		Cmd: protocol.CmdOpenBrowser,
-		URL: "http://localhost:3000",
-	})
-	var openResp protocol.Response
-	if err := json.NewDecoder(openClient).Decode(&openResp); err != nil || !openResp.Ok {
-		t.Fatalf("open browser response = (%+v, %v)", openResp, err)
-	}
-	_ = openClient.Close()
+		openClient, openServer := net.Pipe()
+		go d.handleOpenBrowser(openServer, &protocol.OpenBrowserMessage{
+			Cmd: protocol.CmdOpenBrowser,
+			URL: "http://localhost:3000",
+		})
+		var openResp protocol.Response
+		if err := json.NewDecoder(openClient).Decode(&openResp); err != nil || !openResp.Ok {
+			t.Fatalf("open browser response = (%+v, %v)", openResp, err)
+		}
+		_ = openClient.Close()
 
-	host := newWorkspaceProtocolTestClient()
-	host.trustedTauriOrigin = true
-	host.browserHostAuthenticated = true
-	host.connectedAt = time.Now()
-	host.setIdentity("tauri-app", "test", []string{
-		protocol.CapabilityWorkspaceSessions,
-		protocol.CapabilityBrowserHost,
-	})
-	d.wsHub.mu.Lock()
-	d.wsHub.clients[host] = true
-	d.wsHub.mu.Unlock()
+		host := newWorkspaceProtocolTestClient()
+		host.trustedTauriOrigin = true
+		host.browserHostAuthenticated = true
+		host.connectedAt = time.Now()
+		host.setIdentity("tauri-app", "test", []string{
+			protocol.CapabilityWorkspaceSessions,
+			protocol.CapabilityBrowserHost,
+		})
+		d.wsHub.mu.Lock()
+		d.wsHub.clients[host] = true
+		d.wsHub.mu.Unlock()
 
-	clientConn, serverConn := net.Pipe()
-	defer clientConn.Close()
-	go d.handleBrowserControl(serverConn, &protocol.BrowserControlMessage{
-		Cmd:      protocol.CmdBrowserControl,
-		Action:   "type",
-		Selector: protocol.Ptr("#query"),
-		Text:     protocol.Ptr("browser text"),
-	})
+		clientConn, serverConn := net.Pipe()
+		defer clientConn.Close()
+		go d.handleBrowserControl(serverConn, &protocol.BrowserControlMessage{
+			Cmd:      protocol.CmdBrowserControl,
+			Action:   "type",
+			Selector: protocol.Ptr("#query"),
+			Text:     protocol.Ptr("browser text"),
+		})
 
-	select {
-	case outbound := <-host.send:
+		outbound := requireOutbound(t, host, "no browser control request reached the host")
 		var request protocol.BrowserControlRequestMessage
 		if err := json.Unmarshal(outbound.payload, &request); err != nil {
 			t.Fatal(err)
@@ -429,57 +433,57 @@ func TestBrowserControlBrokersToCapableClient(t *testing.T) {
 			Success:   true,
 			Data:      protocol.Ptr(largeResult),
 		})
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for browser control request")
-	}
 
-	_ = clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
-	var resp protocol.Response
-	if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
-		t.Fatal(err)
-	}
-	if !resp.Ok || protocol.Deref(resp.Data) != largeResult {
-		t.Fatalf("response = %+v", resp)
-	}
+		_ = clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		var resp protocol.Response
+		if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
+			t.Fatal(err)
+		}
+		if !resp.Ok || protocol.Deref(resp.Data) != largeResult {
+			t.Fatalf("response = %+v", resp)
+		}
+	})
 }
 
 func TestRemoteBrowserControlReturnsResultToHubClient(t *testing.T) {
-	d, _, workspaceID := setupMarkdownWorkspace(t)
-	d.setSelectedSession("session-1")
+	base := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	synctest.Test(t, func(t *testing.T) {
+		d, _, workspaceID := setupMarkdownWorkspaceOn(t, base)
+		stopDaemonBackground(t, d)
+		d.setSelectedSession("session-1")
 
-	openClient, openServer := net.Pipe()
-	go d.handleOpenBrowser(openServer, &protocol.OpenBrowserMessage{
-		Cmd: protocol.CmdOpenBrowser,
-		URL: "http://localhost:3000",
-	})
-	var openResp protocol.Response
-	if err := json.NewDecoder(openClient).Decode(&openResp); err != nil || !openResp.Ok {
-		t.Fatalf("open browser response = (%+v, %v)", openResp, err)
-	}
-	_ = openClient.Close()
+		openClient, openServer := net.Pipe()
+		go d.handleOpenBrowser(openServer, &protocol.OpenBrowserMessage{
+			Cmd: protocol.CmdOpenBrowser,
+			URL: "http://localhost:3000",
+		})
+		var openResp protocol.Response
+		if err := json.NewDecoder(openClient).Decode(&openResp); err != nil || !openResp.Ok {
+			t.Fatalf("open browser response = (%+v, %v)", openResp, err)
+		}
+		_ = openClient.Close()
 
-	host := newWorkspaceProtocolTestClient()
-	host.trustedTauriOrigin = true
-	host.browserHostAuthenticated = true
-	host.connectedAt = time.Now()
-	host.setIdentity("tauri-app", "test", []string{
-		protocol.CapabilityWorkspaceSessions,
-		protocol.CapabilityBrowserHost,
-	})
-	d.wsHub.mu.Lock()
-	d.wsHub.clients[host] = true
-	d.wsHub.mu.Unlock()
+		host := newWorkspaceProtocolTestClient()
+		host.trustedTauriOrigin = true
+		host.browserHostAuthenticated = true
+		host.connectedAt = time.Now()
+		host.setIdentity("tauri-app", "test", []string{
+			protocol.CapabilityWorkspaceSessions,
+			protocol.CapabilityBrowserHost,
+		})
+		d.wsHub.mu.Lock()
+		d.wsHub.clients[host] = true
+		d.wsHub.mu.Unlock()
 
-	hubClient := newWorkspaceProtocolTestClient()
-	go d.handleRemoteBrowserControl(hubClient, &protocol.BrowserControlMessage{
-		Cmd:         protocol.CmdBrowserControl,
-		Action:      "get_title",
-		RequestID:   protocol.Ptr("remote-request-1"),
-		WorkspaceID: protocol.Ptr(workspaceID),
-	})
+		hubClient := newWorkspaceProtocolTestClient()
+		go d.handleRemoteBrowserControl(hubClient, &protocol.BrowserControlMessage{
+			Cmd:         protocol.CmdBrowserControl,
+			Action:      "get_title",
+			RequestID:   protocol.Ptr("remote-request-1"),
+			WorkspaceID: protocol.Ptr(workspaceID),
+		})
 
-	select {
-	case outbound := <-host.send:
+		outbound := requireOutbound(t, host, "no browser control request reached the host")
 		var request protocol.BrowserControlRequestMessage
 		if err := json.Unmarshal(outbound.payload, &request); err != nil {
 			t.Fatal(err)
@@ -490,14 +494,10 @@ func TestRemoteBrowserControlReturnsResultToHubClient(t *testing.T) {
 			Success:   true,
 			Data:      protocol.Ptr(`"Remote title"`),
 		})
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for browser host request")
-	}
 
-	select {
-	case outbound := <-hubClient.send:
+		hubOutbound := requireOutbound(t, hubClient, "no browser control response reached the hub client")
 		var response protocol.BrowserControlResponseMessage
-		if err := json.Unmarshal(outbound.payload, &response); err != nil {
+		if err := json.Unmarshal(hubOutbound.payload, &response); err != nil {
 			t.Fatal(err)
 		}
 		if response.Event != protocol.EventBrowserControlResponse ||
@@ -506,9 +506,7 @@ func TestRemoteBrowserControlReturnsResultToHubClient(t *testing.T) {
 			protocol.Deref(response.Data) != `"Remote title"` {
 			t.Fatalf("response = %+v", response)
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for browser control response")
-	}
+	})
 }
 
 func TestBrowserControlIgnoresResultFromDifferentHost(t *testing.T) {

--- a/internal/daemon/bus_test.go
+++ b/internal/daemon/bus_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/bus"
@@ -17,16 +18,16 @@ import (
 // fake internal/bus uses. A green run in internal/bus only proves the delivery
 // logic; this proves the SQLite adapter carries the same semantics.
 
-func waitForBus(t *testing.T, what string, cond func() bool) {
+// requireBus runs the bus's own safety-net poll out and then asks once. Inside a
+// bubble that poll is the slowest thing that can still deliver, so a condition
+// still false afterwards is false for good.
+func requireBus(t *testing.T, what string, cond func() bool) {
 	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		if cond() {
-			return
-		}
-		time.Sleep(2 * time.Millisecond)
+	time.Sleep(2 * bus.DefaultPollInterval)
+	synctest.Wait()
+	if !cond() {
+		t.Fatalf("timed out waiting for %s", what)
 	}
-	t.Fatalf("timed out waiting for %s", what)
 }
 
 // A ticket mutation publishes a durable, subject-carrying fact — and still
@@ -140,83 +141,86 @@ func TestActivityFactProjectsTheSessionSnapshot(t *testing.T) {
 // up from its persisted cursor when it comes back.
 func TestDurableConsumerCatchesUpOverTheSQLiteAdapter(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	backing := d.newSQLBusStore()
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		backing := d.newSQLBusStore()
 
-	var (
-		mu   sync.Mutex
-		seen []string
-	)
-	record := func(_ context.Context, ev bus.Event) error {
-		mu.Lock()
-		seen = append(seen, ev.Name+":"+ev.Subject)
-		mu.Unlock()
-		return nil
-	}
-	snapshot := func() []string {
-		mu.Lock()
-		defer mu.Unlock()
-		return append([]string(nil), seen...)
-	}
-
-	first := bus.New(bus.Options{Store: backing, PollInterval: 5 * time.Millisecond})
-	if err := first.Register("ticket-watcher", bus.Filter{"ticket.*"}, record); err != nil {
-		t.Fatalf("Register: %v", err)
-	}
-	if err := first.Start(); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-	if _, err := first.Publish(FactTicketCreated, "tk-1", nil); err != nil {
-		t.Fatalf("Publish: %v", err)
-	}
-	waitForBus(t, "the first delivery", func() bool { return len(snapshot()) == 1 })
-	first.Stop()
-
-	// Facts published while the consumer is gone, including one it filters out.
-	offline := bus.New(bus.Options{Store: backing})
-	for _, fact := range []struct{ name, subject string }{
-		{FactTicketCommented, "tk-1"},
-		{FactSessionStateChanged, "sess-9"},
-		{FactTicketStatusChanged, "tk-1"},
-	} {
-		if _, err := offline.Publish(fact.name, fact.subject, nil); err != nil {
-			t.Fatalf("Publish(%s): %v", fact.name, err)
+		var (
+			mu   sync.Mutex
+			seen []string
+		)
+		record := func(_ context.Context, ev bus.Event) error {
+			mu.Lock()
+			seen = append(seen, ev.Name+":"+ev.Subject)
+			mu.Unlock()
+			return nil
 		}
-	}
-
-	second := bus.New(bus.Options{Store: backing, PollInterval: 5 * time.Millisecond})
-	if err := second.Register("ticket-watcher", bus.Filter{"ticket.*"}, record); err != nil {
-		t.Fatalf("Register: %v", err)
-	}
-	if err := second.Start(); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-	t.Cleanup(second.Stop)
-
-	waitForBus(t, "catch-up", func() bool { return len(snapshot()) == 3 })
-	got := snapshot()
-	want := []string{
-		FactTicketCreated + ":tk-1",
-		FactTicketCommented + ":tk-1",
-		FactTicketStatusChanged + ":tk-1",
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("delivered %v, want %v", got, want)
+		snapshot := func() []string {
+			mu.Lock()
+			defer mu.Unlock()
+			return append([]string(nil), seen...)
 		}
-	}
 
-	// The cursor advanced past the filtered-out fact too, so a narrow consumer is
-	// not permanently reported as lagging.
-	rec, ok, err := d.store.GetBusConsumer("ticket-watcher")
-	if err != nil || !ok {
-		t.Fatalf("GetBusConsumer: %v (found=%v)", err, ok)
-	}
-	if rec.Cursor != 4 {
-		t.Fatalf("persisted cursor is %d, want 4 (head)", rec.Cursor)
-	}
-	if rec.Filter != "ticket.*" {
-		t.Fatalf("persisted filter is %q", rec.Filter)
-	}
+		first := bus.New(bus.Options{Store: backing})
+		if err := first.Register("ticket-watcher", bus.Filter{"ticket.*"}, record); err != nil {
+			t.Fatalf("Register: %v", err)
+		}
+		if err := first.Start(); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		if _, err := first.Publish(FactTicketCreated, "tk-1", nil); err != nil {
+			t.Fatalf("Publish: %v", err)
+		}
+		requireBus(t, "the first delivery", func() bool { return len(snapshot()) == 1 })
+		first.Stop()
+
+		// Facts published while the consumer is gone, including one it filters out.
+		offline := bus.New(bus.Options{Store: backing})
+		for _, fact := range []struct{ name, subject string }{
+			{FactTicketCommented, "tk-1"},
+			{FactSessionStateChanged, "sess-9"},
+			{FactTicketStatusChanged, "tk-1"},
+		} {
+			if _, err := offline.Publish(fact.name, fact.subject, nil); err != nil {
+				t.Fatalf("Publish(%s): %v", fact.name, err)
+			}
+		}
+
+		second := bus.New(bus.Options{Store: backing})
+		if err := second.Register("ticket-watcher", bus.Filter{"ticket.*"}, record); err != nil {
+			t.Fatalf("Register: %v", err)
+		}
+		if err := second.Start(); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		t.Cleanup(second.Stop)
+
+		requireBus(t, "catch-up", func() bool { return len(snapshot()) == 3 })
+		got := snapshot()
+		want := []string{
+			FactTicketCreated + ":tk-1",
+			FactTicketCommented + ":tk-1",
+			FactTicketStatusChanged + ":tk-1",
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("delivered %v, want %v", got, want)
+			}
+		}
+
+		// The cursor advanced past the filtered-out fact too, so a narrow consumer is
+		// not permanently reported as lagging.
+		rec, ok, err := d.store.GetBusConsumer("ticket-watcher")
+		if err != nil || !ok {
+			t.Fatalf("GetBusConsumer: %v (found=%v)", err, ok)
+		}
+		if rec.Cursor != 4 {
+			t.Fatalf("persisted cursor is %d, want 4 (head)", rec.Cursor)
+		}
+		if rec.Filter != "ticket.*" {
+			t.Fatalf("persisted filter is %q", rec.Filter)
+		}
+	})
 }
 
 // Status is the operator surface: head, cursors, and the lag between them.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"syscall"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	agentdriver "github.com/victorarias/attn/internal/agent"
@@ -4104,45 +4105,49 @@ func TestDaemon_AdvertisesClaudeHeadlessTaskWithManagedAuthentication(t *testing
 }
 
 func TestDaemon_EnsureTailscaleServeFromSettingsAndBroadcast_BroadcastsUpdatedState(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "daemon.sock"))
-	d.store.SetSetting(SettingTailscaleEnabled, "true")
-	d.tailscale = newTailscaleRuntimeWithCLI(&fakeTailscaleCLI{
-		run: func(args []string) ([]byte, error) {
-			switch strings.Join(args, " ") {
-			case "status --json":
-				return []byte(`{"BackendState":"NeedsLogin","AuthURL":"https://login.tailscale.example/auth","Self":{"DNSName":"gpu-box.tail.ts.net."}}`), nil
-			case "serve status --json":
-				return []byte(`{}`), nil
-			default:
-				t.Fatalf("unexpected tailscale command: %q", strings.Join(args, " "))
-				return nil, nil
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		d.store.SetSetting(SettingTailscaleEnabled, "true")
+		d.tailscale = newTailscaleRuntimeWithCLI(&fakeTailscaleCLI{
+			run: func(args []string) ([]byte, error) {
+				switch strings.Join(args, " ") {
+				case "status --json":
+					return []byte(`{"BackendState":"NeedsLogin","AuthURL":"https://login.tailscale.example/auth","Self":{"DNSName":"gpu-box.tail.ts.net."}}`), nil
+				case "serve status --json":
+					return []byte(`{}`), nil
+				default:
+					t.Fatalf("unexpected tailscale command: %q", strings.Join(args, " "))
+					return nil, nil
+				}
+			},
+		})
+
+		d.ensureTailscaleServeFromSettingsAndBroadcast()
+
+		synctest.Wait()
+		select {
+		case outbound := <-d.wsHub.broadcast:
+			if outbound.kind != messageKindText {
+				t.Fatalf("broadcast kind = %v, want text", outbound.kind)
 			}
-		},
+			var msg protocol.SettingsUpdatedMessage
+			if err := json.Unmarshal(outbound.payload, &msg); err != nil {
+				t.Fatalf("unmarshal broadcast payload: %v", err)
+			}
+			if msg.Event != protocol.EventSettingsUpdated {
+				t.Fatalf("broadcast event = %q, want %q", msg.Event, protocol.EventSettingsUpdated)
+			}
+			if got := msg.Settings["tailscale_status"]; got != tailscaleStatusNeedsLogin {
+				t.Fatalf("broadcast tailscale_status = %v, want %s", got, tailscaleStatusNeedsLogin)
+			}
+			if got := msg.Settings["tailscale_auth_url"]; got != "https://login.tailscale.example/auth" {
+				t.Fatalf("broadcast tailscale_auth_url = %v, want auth url", got)
+			}
+		default:
+			t.Fatal("expected settings_updated broadcast")
+		}
 	})
-
-	d.ensureTailscaleServeFromSettingsAndBroadcast()
-
-	select {
-	case outbound := <-d.wsHub.broadcast:
-		if outbound.kind != messageKindText {
-			t.Fatalf("broadcast kind = %v, want text", outbound.kind)
-		}
-		var msg protocol.SettingsUpdatedMessage
-		if err := json.Unmarshal(outbound.payload, &msg); err != nil {
-			t.Fatalf("unmarshal broadcast payload: %v", err)
-		}
-		if msg.Event != protocol.EventSettingsUpdated {
-			t.Fatalf("broadcast event = %q, want %q", msg.Event, protocol.EventSettingsUpdated)
-		}
-		if got := msg.Settings["tailscale_status"]; got != tailscaleStatusNeedsLogin {
-			t.Fatalf("broadcast tailscale_status = %v, want %s", got, tailscaleStatusNeedsLogin)
-		}
-		if got := msg.Settings["tailscale_auth_url"]; got != "https://login.tailscale.example/auth" {
-			t.Fatalf("broadcast tailscale_auth_url = %v, want auth url", got)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("expected settings_updated broadcast")
-	}
 }
 
 func TestDaemon_SettingsIncludePTYBackendMode(t *testing.T) {
@@ -5216,73 +5221,69 @@ func TestClassifySessionState_SkipsNoNewAssistantTurn(t *testing.T) {
 }
 
 func TestClassifySessionState_ClaudeConcurrentDuplicateTurnRunsOnce(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	mockClassifier := newBlockingClassifier(protocol.StateWaitingInput)
-	d.classifier = mockClassifier
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		mockClassifier := newBlockingClassifier(protocol.StateWaitingInput)
+		d.classifier = mockClassifier
 
-	now := time.Now()
-	nowStr := string(protocol.NewTimestamp(now))
-	d.store.Add(&protocol.Session{
-		ID:             "sess-2",
-		Agent:          protocol.SessionAgentClaude,
-		Label:          "test",
-		Directory:      "/tmp",
-		State:          protocol.StateWorking,
-		StateSince:     nowStr,
-		StateUpdatedAt: nowStr,
-		LastSeen:       nowStr,
-	})
+		now := time.Now()
+		nowStr := string(protocol.NewTimestamp(now))
+		d.store.Add(&protocol.Session{
+			ID:             "sess-2",
+			Agent:          protocol.SessionAgentClaude,
+			Label:          "test",
+			Directory:      "/tmp",
+			State:          protocol.StateWorking,
+			StateSince:     nowStr,
+			StateUpdatedAt: nowStr,
+			LastSeen:       nowStr,
+		})
 
-	transcriptPath := filepath.Join(t.TempDir(), "transcript.jsonl")
-	content := fmt.Sprintf(
-		`{"type":"user","uuid":"u2","timestamp":"%s","message":{"role":"user","content":"hello"}}
+		transcriptPath := filepath.Join(t.TempDir(), "transcript.jsonl")
+		content := fmt.Sprintf(
+			`{"type":"user","uuid":"u2","timestamp":"%s","message":{"role":"user","content":"hello"}}
 {"type":"assistant","uuid":"a2","timestamp":"%s","message":{"role":"assistant","content":[{"type":"text","text":"Hello! What can I help you with today?"}]}}
 `,
-		now.Add(-1*time.Second).UTC().Format(time.RFC3339Nano),
-		now.UTC().Format(time.RFC3339Nano),
-	)
-	if err := os.WriteFile(transcriptPath, []byte(content), 0644); err != nil {
-		t.Fatalf("write transcript: %v", err)
-	}
+			now.Add(-1*time.Second).UTC().Format(time.RFC3339Nano),
+			now.UTC().Format(time.RFC3339Nano),
+		)
+		if err := os.WriteFile(transcriptPath, []byte(content), 0644); err != nil {
+			t.Fatalf("write transcript: %v", err)
+		}
 
-	firstDone := make(chan struct{})
-	go func() {
-		d.classifySessionState("sess-2", transcriptPath)
-		close(firstDone)
-	}()
+		firstDone := make(chan struct{})
+		go func() {
+			d.classifySessionState("sess-2", transcriptPath)
+			close(firstDone)
+		}()
 
-	select {
-	case <-mockClassifier.started:
-	case <-time.After(2 * time.Second):
-		t.Fatal("classifier did not start for first classification")
-	}
+		synctest.Wait()
+		select {
+		case <-mockClassifier.started:
+		default:
+			t.Fatal("classifier did not start for first classification")
+		}
 
-	secondDone := make(chan struct{})
-	go func() {
-		d.classifySessionState("sess-2", transcriptPath)
-		close(secondDone)
-	}()
+		secondDone := make(chan struct{})
+		go func() {
+			d.classifySessionState("sess-2", transcriptPath)
+			close(secondDone)
+		}()
 
-	select {
-	case <-secondDone:
-	case <-time.After(2 * time.Second):
-		t.Fatal("second classification did not return promptly")
-	}
+		requireDone(t, secondDone, "second classification did not return promptly")
 
-	if got := mockClassifier.CallCount(); got != 1 {
-		t.Fatalf("classifier calls=%d, want 1 while duplicate turn in flight", got)
-	}
+		if got := mockClassifier.CallCount(); got != 1 {
+			t.Fatalf("classifier calls=%d, want 1 while duplicate turn in flight", got)
+		}
 
-	close(mockClassifier.release)
-	select {
-	case <-firstDone:
-	case <-time.After(2 * time.Second):
-		t.Fatal("first classification did not complete")
-	}
+		close(mockClassifier.release)
+		requireDone(t, firstDone, "first classification did not complete")
 
-	if got := mockClassifier.CallCount(); got != 1 {
-		t.Fatalf("classifier calls=%d, want 1", got)
-	}
+		if got := mockClassifier.CallCount(); got != 1 {
+			t.Fatalf("classifier calls=%d, want 1", got)
+		}
+	})
 }
 
 // A finished run publishes its verdict as soon as it is classified, whatever
@@ -5332,56 +5333,57 @@ func TestClassifySessionState_PublishesImmediatelyAfterALongRun(t *testing.T) {
 }
 
 func TestHandleStop_SkipsClassificationForForcedStopSession(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	mockClassifier := &countingClassifier{state: protocol.StateWaitingInput}
-	d.classifier = mockClassifier
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		mockClassifier := &countingClassifier{state: protocol.StateWaitingInput}
+		d.classifier = mockClassifier
 
-	now := time.Now()
-	nowStr := string(protocol.NewTimestamp(now))
-	d.store.Add(&protocol.Session{
-		ID:             "sess-forced-stop",
-		Agent:          protocol.SessionAgentCodex,
-		Label:          "forced-stop",
-		Directory:      "/tmp",
-		State:          protocol.StateIdle,
-		StateSince:     nowStr,
-		StateUpdatedAt: nowStr,
-		LastSeen:       nowStr,
-	})
-	d.markForcedStopClassification("sess-forced-stop")
-
-	serverConn, clientConn := net.Pipe()
-	defer clientConn.Close()
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		d.handleStop(serverConn, &protocol.StopMessage{
+		now := time.Now()
+		nowStr := string(protocol.NewTimestamp(now))
+		d.store.Add(&protocol.Session{
 			ID:             "sess-forced-stop",
-			TranscriptPath: "",
+			Agent:          protocol.SessionAgentCodex,
+			Label:          "forced-stop",
+			Directory:      "/tmp",
+			State:          protocol.StateIdle,
+			StateSince:     nowStr,
+			StateUpdatedAt: nowStr,
+			LastSeen:       nowStr,
 		})
-		_ = serverConn.Close()
-	}()
+		d.markForcedStopClassification("sess-forced-stop")
 
-	var resp protocol.Response
-	if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
-		t.Fatalf("decode stop response: %v", err)
-	}
-	if !resp.Ok {
-		t.Fatalf("stop response ok=%v, want true", resp.Ok)
-	}
+		serverConn, clientConn := net.Pipe()
+		defer clientConn.Close()
 
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("handleStop did not return")
-	}
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			d.handleStop(serverConn, &protocol.StopMessage{
+				ID:             "sess-forced-stop",
+				TranscriptPath: "",
+			})
+			_ = serverConn.Close()
+		}()
 
-	time.Sleep(50 * time.Millisecond)
-	if got := mockClassifier.CallCount(); got != 0 {
-		t.Fatalf("classifier calls=%d, want 0", got)
-	}
-	if d.consumeForcedStopClassification("sess-forced-stop") {
-		t.Fatal("forced-stop suppression token should be consumed by handleStop")
-	}
+		var resp protocol.Response
+		if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
+			t.Fatalf("decode stop response: %v", err)
+		}
+		if !resp.Ok {
+			t.Fatalf("stop response ok=%v, want true", resp.Ok)
+		}
+
+		requireDone(t, done, "handleStop did not return")
+
+		// Nothing is left that could classify: the tolerance window this used to buy
+		// with 50ms is now the settled bubble itself.
+		settleStopClassification(t)
+		if got := mockClassifier.CallCount(); got != 0 {
+			t.Fatalf("classifier calls=%d, want 0", got)
+		}
+		if d.consumeForcedStopClassification("sess-forced-stop") {
+			t.Fatal("forced-stop suppression token should be consumed by handleStop")
+		}
+	})
 }

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/git"
@@ -801,26 +802,32 @@ func TestDelegateRejectsRemoteSourceSession(t *testing.T) {
 }
 
 func TestDelegateWebSocketCommandReturnsResult(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	backend := &fakeSpawnBackend{}
-	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
-	consumeDelegatedPrompt(t, backend)
-	client := newWorkspaceProtocolTestClient()
-	client.setIdentity("test", "protocol-"+protocol.ProtocolVersion, []string{protocol.CapabilityWorkspaceSessions})
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		backend := &fakeSpawnBackend{}
+		_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+		consumeDelegatedPrompt(t, backend)
+		client := newWorkspaceProtocolTestClient()
+		client.setIdentity("test", "protocol-"+protocol.ProtocolVersion, []string{protocol.CapabilityWorkspaceSessions})
 
-	payload, err := json.Marshal(protocol.DelegateMessage{
-		Cmd:             protocol.CmdDelegate,
-		SourceSessionID: sourceSessionID,
-		Brief:           "Handle this through the websocket dispatcher.",
-		Agent:           protocol.Ptr("codex"),
-	})
-	if err != nil {
-		t.Fatalf("marshal delegate message: %v", err)
-	}
-	d.handleClientMessage(client, payload)
+		payload, err := json.Marshal(protocol.DelegateMessage{
+			Cmd:             protocol.CmdDelegate,
+			SourceSessionID: sourceSessionID,
+			Brief:           "Handle this through the websocket dispatcher.",
+			Agent:           protocol.Ptr("codex"),
+		})
+		if err != nil {
+			t.Fatalf("marshal delegate message: %v", err)
+		}
+		d.handleClientMessage(client, payload)
 
-	select {
-	case outbound := <-client.send:
+		// handleDelegateWS polls the operation every 100ms until it leaves
+		// accepted/preparing. A settled bubble means that poll is the only thing
+		// left that can move, so run a generous number of them out — on the fake
+		// clock they are free.
+		time.Sleep(time.Second)
+		outbound := requireOutbound(t, client, "no delegate_result reached the client")
 		var result protocol.DelegateResultMessage
 		if err := json.Unmarshal(outbound.payload, &result); err != nil {
 			t.Fatalf("decode delegate result: %v", err)
@@ -831,9 +838,7 @@ func TestDelegateWebSocketCommandReturnsResult(t *testing.T) {
 		if result.Result.WorkspaceID != "workspace-source" {
 			t.Fatalf("workspace = %q, want workspace-source", result.Result.WorkspaceID)
 		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for delegate_result")
-	}
+	})
 }
 
 func TestDelegateKillsSpawnedRuntimeWhenPersistenceFails(t *testing.T) {

--- a/internal/daemon/delegation_operation_test.go
+++ b/internal/daemon/delegation_operation_test.go
@@ -139,6 +139,9 @@ func TestDelegationOperationConcurrentRetriesConverge(t *testing.T) {
 	}
 }
 
+// Boundary-bound twice over: the launch creates a real git worktree (child
+// process), and the acceptance assertion measures real elapsed wall-clock —
+// under a fake clock time.Since would read zero and prove nothing.
 func TestDelegationOperationAcceptedBeforeSlowPreparation(t *testing.T) {
 	root := t.TempDir()
 	mainRepo := filepath.Join(root, "repo")

--- a/internal/daemon/fs_test.go
+++ b/internal/daemon/fs_test.go
@@ -16,6 +16,17 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
+// Boundary-bound, the whole paced set in this file. Four tests
+// (TestFsWriteBroadcastsUiChange, TestFsWriteNormalizesEchoedPath,
+// TestFsChangedExternalEditNotSelfWrite,
+// TestFsCommandsOmittedRootResolvesToNotebookRoot) start the real hub with
+// `go d.wsHub.run()`, whose loop has no exit path — a bubble would never end.
+// The rest (TestFsCommandsWithExplicitRootActOnThatDirectory,
+// TestFsWriteBroadcastsResolvedRoot, TestFsRenameDeleteNotebookCouplingIsRootConditional)
+// start a real fsnotify watcher through fsWatch, whose goroutine parks in kqueue
+// and so is never durably blocked. Giving the hub a quit channel is a production
+// change, which is why these stay on real time.
+
 // newFsDaemon returns a test daemon whose root (notebook.root, shared by the fs
 // surface) points at an isolated temp dir.
 func newFsDaemon(t *testing.T) *Daemon {

--- a/internal/daemon/gitstatus_test.go
+++ b/internal/daemon/gitstatus_test.go
@@ -96,6 +96,8 @@ func TestReadFileDiff_HeadRefFileDoesNotExist(t *testing.T) {
 	}
 }
 
+// Boundary-bound: both the fixture repository and handleGetFileDiff itself shell
+// out to git, and a child process is a real fd nobody is durably blocked on.
 func TestHandleGetFileDiff_EchoesRequestID(t *testing.T) {
 	dir, _, shaV1, shaV2 := fileDiffTestRepo(t, "src/file.ts", "v1", "v2")
 

--- a/internal/daemon/notebook_daily_narrate_test.go
+++ b/internal/daemon/notebook_daily_narrate_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	agentdriver "github.com/victorarias/attn/internal/agent"
@@ -29,48 +30,54 @@ func pinUTCSlot(t *testing.T, d *Daemon) {
 // next scheduled slot. NOTE: the daily narrate has no enabled gate and uses its own
 // state file.
 func TestEnqueueDueDailyNarratesFirstObservationAnchorsWithoutFiring(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	root := installNotebookNarrationRunner(t, d)
-	pinUTCSlot(t, d)
-	d.markNotebookWorkspaceActivity("ws-A")
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		root := installNotebookNarrationRunner(t, d)
+		pinUTCSlot(t, d)
+		d.markNotebookWorkspaceActivity("ws-A")
 
-	d.enqueueDueDailyNarrates(mustTime(t, "2026-06-14T12:00:00Z"))
+		d.enqueueDueDailyNarrates(mustTime(t, "2026-06-14T12:00:00Z"))
 
-	state, _ := notebook.LoadNarrateCronState(root)
-	if state.ScheduledFrom == "" {
-		t.Fatal("first observation should anchor the schedule")
-	}
-	if taskExists(t, d, notebookNarrateWorkspaceKind, "ws-A") {
-		t.Fatal("first observation enqueued a narrate before the first scheduled slot")
-	}
-	// The activity set must NOT be drained when the cron only anchors (no fire).
-	if got := d.drainNotebookNarrateActivity(); len(got) != 1 || got[0] != "ws-A" {
-		t.Fatalf("first observation drained the activity set: %v", got)
-	}
+		state, _ := notebook.LoadNarrateCronState(root)
+		if state.ScheduledFrom == "" {
+			t.Fatal("first observation should anchor the schedule")
+		}
+		if taskExists(t, d, notebookNarrateWorkspaceKind, "ws-A") {
+			t.Fatal("first observation enqueued a narrate before the first scheduled slot")
+		}
+		// The activity set must NOT be drained when the cron only anchors (no fire).
+		if got := d.drainNotebookNarrateActivity(); len(got) != 1 || got[0] != "ws-A" {
+			t.Fatalf("first observation drained the activity set: %v", got)
+		}
+	})
 }
 
 // An anchored schedule whose next slot is still in the future does not enqueue, and
 // leaves the anchor untouched.
 func TestEnqueueDueDailyNarratesNotDueLeavesAnchor(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	root := installNotebookNarrationRunner(t, d)
-	pinUTCSlot(t, d)
-	d.markNotebookWorkspaceActivity("ws-A")
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		root := installNotebookNarrationRunner(t, d)
+		pinUTCSlot(t, d)
+		d.markNotebookWorkspaceActivity("ws-A")
 
-	// Anchor at 04:00 UTC; the next "0 3 * * *" slot is the following day 03:00.
-	if err := notebook.SaveNarrateCronState(root, notebook.NarrateCronState{ScheduledFrom: "2026-06-14T04:00:00Z"}); err != nil {
-		t.Fatalf("seed state: %v", err)
-	}
+		// Anchor at 04:00 UTC; the next "0 3 * * *" slot is the following day 03:00.
+		if err := notebook.SaveNarrateCronState(root, notebook.NarrateCronState{ScheduledFrom: "2026-06-14T04:00:00Z"}); err != nil {
+			t.Fatalf("seed state: %v", err)
+		}
 
-	d.enqueueDueDailyNarrates(mustTime(t, "2026-06-14T05:00:00Z"))
+		d.enqueueDueDailyNarrates(mustTime(t, "2026-06-14T05:00:00Z"))
 
-	state, _ := notebook.LoadNarrateCronState(root)
-	if state.ScheduledFrom != "2026-06-14T04:00:00Z" {
-		t.Fatalf("not-due tick mutated the anchor: %q", state.ScheduledFrom)
-	}
-	if taskExists(t, d, notebookNarrateWorkspaceKind, "ws-A") {
-		t.Fatal("not-due tick enqueued a narrate")
-	}
+		state, _ := notebook.LoadNarrateCronState(root)
+		if state.ScheduledFrom != "2026-06-14T04:00:00Z" {
+			t.Fatalf("not-due tick mutated the anchor: %q", state.ScheduledFrom)
+		}
+		if taskExists(t, d, notebookNarrateWorkspaceKind, "ws-A") {
+			t.Fatal("not-due tick enqueued a narrate")
+		}
+	})
 }
 
 // A due schedule fires once: it enqueues narrate_workspace for the active workspace
@@ -78,111 +85,119 @@ func TestEnqueueDueDailyNarratesNotDueLeavesAnchor(t *testing.T) {
 // does NOT re-fire, and — because the set was cleared on the first fire — a later due
 // day with no new activity enqueues nothing.
 func TestEnqueueDueDailyNarratesDueFiresOnceAndClearsActivity(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	root := installNotebookNarrationRunner(t, d)
-	pinUTCSlot(t, d)
-	// Live workspace row so the drain does not skip it as removed.
-	d.store.AddWorkspace(&protocol.Workspace{ID: "ws-A", Title: "ws-A", Directory: t.TempDir()})
-	d.markNotebookWorkspaceActivity("ws-A")
-	// Block the narrate so the enqueued record stays observable.
-	d.narrateWorkspaceExecution = blockingExecution(t)
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		root := installNotebookNarrationRunner(t, d)
+		pinUTCSlot(t, d)
+		// Live workspace row so the drain does not skip it as removed.
+		d.store.AddWorkspace(&protocol.Workspace{ID: "ws-A", Title: "ws-A", Directory: t.TempDir()})
+		d.markNotebookWorkspaceActivity("ws-A")
+		// Block the narrate so the enqueued record stays observable.
+		d.narrateWorkspaceExecution = blockingExecution(t)
 
-	// Anchor a day back so 2026-06-14T03:00 is the due slot.
-	if err := notebook.SaveNarrateCronState(root, notebook.NarrateCronState{ScheduledFrom: "2026-06-13T03:00:00Z"}); err != nil {
-		t.Fatalf("seed state: %v", err)
-	}
+		// Anchor a day back so 2026-06-14T03:00 is the due slot.
+		if err := notebook.SaveNarrateCronState(root, notebook.NarrateCronState{ScheduledFrom: "2026-06-13T03:00:00Z"}); err != nil {
+			t.Fatalf("seed state: %v", err)
+		}
 
-	now := mustTime(t, "2026-06-14T12:00:00Z")
-	d.enqueueDueDailyNarrates(now)
+		now := mustTime(t, "2026-06-14T12:00:00Z")
+		d.enqueueDueDailyNarrates(now)
 
-	state, _ := notebook.LoadNarrateCronState(root)
-	if state.ScheduledFrom != now.UTC().Format(time.RFC3339) {
-		t.Fatalf("due fire did not advance the anchor to now: %q", state.ScheduledFrom)
-	}
-	if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-A") {
-		t.Fatal("due fire did not enqueue narrate_workspace for the active workspace")
-	}
-	task, err := d.jobQueue.GetByKey(notebookNarrateWorkspaceKind, "ws-A")
-	if err != nil || task == nil {
-		t.Fatalf("get narrate task: %v", err)
-	}
-	var carried narrateWorkspacePayload
-	if err := task.DecodePayload(&carried); err != nil {
-		t.Fatalf("decode narrate payload: %v", err)
-	}
-	if !carried.DailyPass {
-		t.Fatalf("daily narrate job missing the daily-pass flag: %s", task.Payload)
-	}
+		state, _ := notebook.LoadNarrateCronState(root)
+		if state.ScheduledFrom != now.UTC().Format(time.RFC3339) {
+			t.Fatalf("due fire did not advance the anchor to now: %q", state.ScheduledFrom)
+		}
+		if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-A") {
+			t.Fatal("due fire did not enqueue narrate_workspace for the active workspace")
+		}
+		task, err := d.jobQueue.GetByKey(notebookNarrateWorkspaceKind, "ws-A")
+		if err != nil || task == nil {
+			t.Fatalf("get narrate task: %v", err)
+		}
+		var carried narrateWorkspacePayload
+		if err := task.DecodePayload(&carried); err != nil {
+			t.Fatalf("decode narrate payload: %v", err)
+		}
+		if !carried.DailyPass {
+			t.Fatalf("daily narrate job missing the daily-pass flag: %s", task.Payload)
+		}
 
-	// The activity set was cleared on the fire, so a later due day with no new
-	// activity advances the anchor but enqueues nothing new.
-	d.store.AddWorkspace(&protocol.Workspace{ID: "ws-B", Title: "ws-B", Directory: t.TempDir()})
-	d.enqueueDueDailyNarrates(mustTime(t, "2026-06-15T12:00:00Z"))
-	if taskExists(t, d, notebookNarrateWorkspaceKind, "ws-B") {
-		t.Fatal("a later due day with no new activity enqueued a narrate")
-	}
+		// The activity set was cleared on the fire, so a later due day with no new
+		// activity advances the anchor but enqueues nothing new.
+		d.store.AddWorkspace(&protocol.Workspace{ID: "ws-B", Title: "ws-B", Directory: t.TempDir()})
+		d.enqueueDueDailyNarrates(mustTime(t, "2026-06-15T12:00:00Z"))
+		if taskExists(t, d, notebookNarrateWorkspaceKind, "ws-B") {
+			t.Fatal("a later due day with no new activity enqueued a narrate")
+		}
+	})
 }
 
 // The gate is exact: only workspaces in the activity set are narrated. A due fire
 // narrates the active ws-A and NOT the idle ws-B.
 func TestEnqueueDueDailyNarratesGatesOnActivity(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	root := installNotebookNarrationRunner(t, d)
-	pinUTCSlot(t, d)
-	d.store.AddWorkspace(&protocol.Workspace{ID: "ws-A", Title: "ws-A", Directory: t.TempDir()})
-	d.store.AddWorkspace(&protocol.Workspace{ID: "ws-B", Title: "ws-B", Directory: t.TempDir()})
-	d.narrateWorkspaceExecution = blockingExecution(t)
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		root := installNotebookNarrationRunner(t, d)
+		pinUTCSlot(t, d)
+		d.store.AddWorkspace(&protocol.Workspace{ID: "ws-A", Title: "ws-A", Directory: t.TempDir()})
+		d.store.AddWorkspace(&protocol.Workspace{ID: "ws-B", Title: "ws-B", Directory: t.TempDir()})
+		d.narrateWorkspaceExecution = blockingExecution(t)
 
-	// Only ws-A saw activity. ws-B is idle.
-	d.markNotebookWorkspaceActivity("ws-A")
+		// Only ws-A saw activity. ws-B is idle.
+		d.markNotebookWorkspaceActivity("ws-A")
 
-	if err := notebook.SaveNarrateCronState(root, notebook.NarrateCronState{ScheduledFrom: "2026-06-13T03:00:00Z"}); err != nil {
-		t.Fatalf("seed state: %v", err)
-	}
-	d.enqueueDueDailyNarrates(mustTime(t, "2026-06-14T12:00:00Z"))
+		if err := notebook.SaveNarrateCronState(root, notebook.NarrateCronState{ScheduledFrom: "2026-06-13T03:00:00Z"}); err != nil {
+			t.Fatalf("seed state: %v", err)
+		}
+		d.enqueueDueDailyNarrates(mustTime(t, "2026-06-14T12:00:00Z"))
 
-	if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-A") {
-		t.Fatal("active workspace ws-A was not narrated")
-	}
-	// Give the worker a beat; ws-B must never get a task.
-	time.Sleep(20 * time.Millisecond)
-	task, err := d.jobQueue.GetByKey(notebookNarrateWorkspaceKind, "ws-B")
-	if err != nil {
-		t.Fatalf("get ws-B narrate: %v", err)
-	}
-	if task != nil {
-		t.Fatalf("idle workspace ws-B was unexpectedly narrated: %+v", task)
-	}
+		if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-A") {
+			t.Fatal("active workspace ws-A was not narrated")
+		}
+		// taskExists already settled the bubble, so ws-B's absence is final.
+		task, err := d.jobQueue.GetByKey(notebookNarrateWorkspaceKind, "ws-B")
+		if err != nil {
+			t.Fatalf("get ws-B narrate: %v", err)
+		}
+		if task != nil {
+			t.Fatalf("idle workspace ws-B was unexpectedly narrated: %+v", task)
+		}
+	})
 }
 
 // A workspace in the activity set whose row was removed before the fire is skipped:
 // its removal-boundary final retrospective already ran. The anchor still advances.
 func TestEnqueueDueDailyNarratesSkipsRemovedWorkspace(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	root := installNotebookNarrationRunner(t, d)
-	pinUTCSlot(t, d)
-	d.narrateWorkspaceExecution = blockingExecution(t)
-	// ws-gone was active but its row is gone (no AddWorkspace).
-	d.markNotebookWorkspaceActivity("ws-gone")
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		root := installNotebookNarrationRunner(t, d)
+		pinUTCSlot(t, d)
+		d.narrateWorkspaceExecution = blockingExecution(t)
+		// ws-gone was active but its row is gone (no AddWorkspace).
+		d.markNotebookWorkspaceActivity("ws-gone")
 
-	if err := notebook.SaveNarrateCronState(root, notebook.NarrateCronState{ScheduledFrom: "2026-06-13T03:00:00Z"}); err != nil {
-		t.Fatalf("seed state: %v", err)
-	}
-	now := mustTime(t, "2026-06-14T12:00:00Z")
-	d.enqueueDueDailyNarrates(now)
+		if err := notebook.SaveNarrateCronState(root, notebook.NarrateCronState{ScheduledFrom: "2026-06-13T03:00:00Z"}); err != nil {
+			t.Fatalf("seed state: %v", err)
+		}
+		now := mustTime(t, "2026-06-14T12:00:00Z")
+		d.enqueueDueDailyNarrates(now)
 
-	state, _ := notebook.LoadNarrateCronState(root)
-	if state.ScheduledFrom != now.UTC().Format(time.RFC3339) {
-		t.Fatalf("anchor did not advance on a fire that skipped a removed workspace: %q", state.ScheduledFrom)
-	}
-	time.Sleep(20 * time.Millisecond)
-	task, err := d.jobQueue.GetByKey(notebookNarrateWorkspaceKind, "ws-gone")
-	if err != nil {
-		t.Fatalf("get ws-gone narrate: %v", err)
-	}
-	if task != nil {
-		t.Fatalf("removed workspace was narrated by the daily cron: %+v", task)
-	}
+		state, _ := notebook.LoadNarrateCronState(root)
+		if state.ScheduledFrom != now.UTC().Format(time.RFC3339) {
+			t.Fatalf("anchor did not advance on a fire that skipped a removed workspace: %q", state.ScheduledFrom)
+		}
+		synctest.Wait()
+		task, err := d.jobQueue.GetByKey(notebookNarrateWorkspaceKind, "ws-gone")
+		if err != nil {
+			t.Fatalf("get ws-gone narrate: %v", err)
+		}
+		if task != nil {
+			t.Fatalf("removed workspace was narrated by the daily cron: %+v", task)
+		}
+	})
 }
 
 // --- activity hooks ---
@@ -190,18 +205,22 @@ func TestEnqueueDueDailyNarratesSkipsRemovedWorkspace(t *testing.T) {
 // A session Stop marks its workspace active (the handleStop path), so the daily cron
 // will narrate it.
 func TestHandleStopMarksWorkspaceActivity(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
-	installNotebookNarrationRunner(t, d)
-	d.summarizeSessionExecution = blockingExecution(t)
-	d.narrateWorkspaceExecution = blockingExecution(t)
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+		installNotebookNarrationRunner(t, d)
+		d.summarizeSessionExecution = blockingExecution(t)
+		d.narrateWorkspaceExecution = blockingExecution(t)
 
-	d.handleStop(drainingConn(t), &protocol.StopMessage{ID: "session-1"})
+		d.handleStop(drainingConn(t), &protocol.StopMessage{ID: "session-1"})
 
-	got := d.drainNotebookNarrateActivity()
-	if len(got) != 1 || got[0] != "ws-1" {
-		t.Fatalf("stop did not mark ws-1 active: %v", got)
-	}
+		got := d.drainNotebookNarrateActivity()
+		if len(got) != 1 || got[0] != "ws-1" {
+			t.Fatalf("stop did not mark ws-1 active: %v", got)
+		}
+		settleStopClassification(t)
+	})
 }
 
 // A content-CHANGING context update marks the workspace active; a no-op update
@@ -242,117 +261,129 @@ func TestContextWriteMarksActivityOnlyWhenChanged(t *testing.T) {
 // A daily-flagged narrate whose agent leaves the block UNCHANGED goes DONE (not
 // failed): a daily refresh that finds nothing new is a clean no-op.
 func TestNarrateWorkspaceDailyPassUnchangedIsDone(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
-	root := installNotebookNarrationRunner(t, d)
-	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+		root := installNotebookNarrationRunner(t, d)
+		d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
 
-	journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
-	if err := os.MkdirAll(filepath.Dir(journal), 0o755); err != nil {
-		t.Fatalf("mkdir journal: %v", err)
-	}
-	prior := "## ws-1 — 2026-06-15\n<!-- attn:wsnarr:ws-1 -->\n\nalready narrated today\n\nsource: workspace:ws-1\n"
-	if err := os.WriteFile(journal, []byte(prior), 0o644); err != nil {
-		t.Fatalf("seed prior entry: %v", err)
-	}
+		journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
+		if err := os.MkdirAll(filepath.Dir(journal), 0o755); err != nil {
+			t.Fatalf("mkdir journal: %v", err)
+		}
+		prior := "## ws-1 — 2026-06-15\n<!-- attn:wsnarr:ws-1 -->\n\nalready narrated today\n\nsource: workspace:ws-1\n"
+		if err := os.WriteFile(journal, []byte(prior), 0o644); err != nil {
+			t.Fatalf("seed prior entry: %v", err)
+		}
 
-	// Daily-pass agent no-ops: leaves the block exactly as-is.
-	d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		return agentdriver.HeadlessTaskResult{Diagnostics: "nothing new"}, nil
-	}
+		// Daily-pass agent no-ops: leaves the block exactly as-is.
+		d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			return agentdriver.HeadlessTaskResult{Diagnostics: "nothing new"}, nil
+		}
 
-	if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{
-		UniqueKey: "ws-1",
-		Payload:   narrateWorkspacePayload{DailyPass: true},
-	}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	waitForTaskState(t, d, notebookNarrateWorkspaceKind, "ws-1", jobs.StateDone)
+		if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{
+			UniqueKey: "ws-1",
+			Payload:   narrateWorkspacePayload{DailyPass: true},
+		}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		requireTaskState(t, d, notebookNarrateWorkspaceKind, "ws-1", jobs.StateDone)
+	})
 }
 
 // A daily-flagged narrate whose agent writes NO entry at all goes DONE (not failed):
 // an absent block on a daily refresh is also a clean no-op.
 func TestNarrateWorkspaceDailyPassAbsentIsDone(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
-	installNotebookNarrationRunner(t, d)
-	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+		installNotebookNarrationRunner(t, d)
+		d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
 
-	// Daily-pass agent writes nothing.
-	d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		return agentdriver.HeadlessTaskResult{Diagnostics: "no entry"}, nil
-	}
+		// Daily-pass agent writes nothing.
+		d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			return agentdriver.HeadlessTaskResult{Diagnostics: "no entry"}, nil
+		}
 
-	if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{
-		UniqueKey: "ws-1",
-		Payload:   narrateWorkspacePayload{DailyPass: true},
-	}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	waitForTaskState(t, d, notebookNarrateWorkspaceKind, "ws-1", jobs.StateDone)
+		if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{
+			UniqueKey: "ws-1",
+			Payload:   narrateWorkspacePayload{DailyPass: true},
+		}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		requireTaskState(t, d, notebookNarrateWorkspaceKind, "ws-1", jobs.StateDone)
+	})
 }
 
 // A daily-flagged REMOVAL pass keeps STRICT gating: an unchanged/absent block still
 // FAILS, because the removal retrospective must actually be written.
 func TestNarrateWorkspaceDailyFlagRemovalPassStillStrict(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	// No workspace row for ws-removed -> IS_REMOVAL_PASS derived true; the daily flag
-	// must not relax a removal pass.
-	root := installNotebookNarrationRunner(t, d)
-	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		// No workspace row for ws-removed -> IS_REMOVAL_PASS derived true; the daily flag
+		// must not relax a removal pass.
+		root := installNotebookNarrationRunner(t, d)
+		d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
 
-	journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
-	if err := os.MkdirAll(filepath.Dir(journal), 0o755); err != nil {
-		t.Fatalf("mkdir journal: %v", err)
-	}
-	prior := "## ws-removed — 2026-06-15\n<!-- attn:wsnarr:ws-removed -->\n\nprior\n\nsource: workspace:ws-removed\n"
-	if err := os.WriteFile(journal, []byte(prior), 0o644); err != nil {
-		t.Fatalf("seed prior entry: %v", err)
-	}
+		journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
+		if err := os.MkdirAll(filepath.Dir(journal), 0o755); err != nil {
+			t.Fatalf("mkdir journal: %v", err)
+		}
+		prior := "## ws-removed — 2026-06-15\n<!-- attn:wsnarr:ws-removed -->\n\nprior\n\nsource: workspace:ws-removed\n"
+		if err := os.WriteFile(journal, []byte(prior), 0o644); err != nil {
+			t.Fatalf("seed prior entry: %v", err)
+		}
 
-	d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		return agentdriver.HeadlessTaskResult{Diagnostics: "no-op"}, nil
-	}
+		d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			return agentdriver.HeadlessTaskResult{Diagnostics: "no-op"}, nil
+		}
 
-	if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{
-		UniqueKey: "ws-removed",
-		Payload:   narrateWorkspacePayload{DailyPass: true},
-	}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	task := waitForNonDoneFailure(t, d, notebookNarrateWorkspaceKind, "ws-removed")
-	if task.State == jobs.StateDone {
-		t.Fatal("daily flag wrongly relaxed a removal pass to done")
-	}
+		if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{
+			UniqueKey: "ws-removed",
+			Payload:   narrateWorkspacePayload{DailyPass: true},
+		}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		task := requireTaskFailure(t, d, notebookNarrateWorkspaceKind, "ws-removed")
+		if task.State == jobs.StateDone {
+			t.Fatal("daily flag wrongly relaxed a removal pass to done")
+		}
+	})
 }
 
 // A NON-flagged routine (session-end) pass with an unchanged block still FAILS —
 // unchanged behavior, preserving the retry-until-the-digest-lands property.
 func TestNarrateWorkspaceRoutinePassUnchangedStillFails(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
-	root := installNotebookNarrationRunner(t, d)
-	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+		root := installNotebookNarrationRunner(t, d)
+		d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
 
-	journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
-	if err := os.MkdirAll(filepath.Dir(journal), 0o755); err != nil {
-		t.Fatalf("mkdir journal: %v", err)
-	}
-	prior := "## ws-1 — 2026-06-15\n<!-- attn:wsnarr:ws-1 -->\n\nactive-day entry\n\nsource: workspace:ws-1\n"
-	if err := os.WriteFile(journal, []byte(prior), 0o644); err != nil {
-		t.Fatalf("seed prior entry: %v", err)
-	}
+		journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
+		if err := os.MkdirAll(filepath.Dir(journal), 0o755); err != nil {
+			t.Fatalf("mkdir journal: %v", err)
+		}
+		prior := "## ws-1 — 2026-06-15\n<!-- attn:wsnarr:ws-1 -->\n\nactive-day entry\n\nsource: workspace:ws-1\n"
+		if err := os.WriteFile(journal, []byte(prior), 0o644); err != nil {
+			t.Fatalf("seed prior entry: %v", err)
+		}
 
-	d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		return agentdriver.HeadlessTaskResult{Diagnostics: "no-op"}, nil
-	}
+		d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			return agentdriver.HeadlessTaskResult{Diagnostics: "no-op"}, nil
+		}
 
-	// No daily-pass payload -> strict gating.
-	if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{UniqueKey: "ws-1"}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	task := waitForNonDoneFailure(t, d, notebookNarrateWorkspaceKind, "ws-1")
-	if !strings.Contains(task.LastError, "unchanged") {
-		t.Fatalf("routine pass last error = %q, want unchanged rejection", task.LastError)
-	}
+		// No daily-pass payload -> strict gating.
+		if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{UniqueKey: "ws-1"}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		task := requireTaskFailure(t, d, notebookNarrateWorkspaceKind, "ws-1")
+		if !strings.Contains(task.LastError, "unchanged") {
+			t.Fatalf("routine pass last error = %q, want unchanged rejection", task.LastError)
+		}
+	})
 }

--- a/internal/daemon/notebook_narration_test.go
+++ b/internal/daemon/notebook_narration_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	agentdriver "github.com/victorarias/attn/internal/agent"
@@ -176,8 +177,11 @@ func TestBuildNarrateWorkspacePromptEmbedsBriefPathsAndRemovalFlag(t *testing.T)
 // installNotebookNarrationRunner enables the daemon's runner over a temp root and
 // registers BOTH narration executors (real bodies), so the executors' resolve-
 // inputs / verify-ledger logic runs for real. The agent spawn itself is replaced
-// per-test via d.summarizeSessionExecution / d.narrateWorkspaceExecution. A fast
-// poll interval avoids real-time waits. Returns the notebook root.
+// per-test via d.summarizeSessionExecution / d.narrateWorkspaceExecution.
+// Returns the notebook root.
+//
+// Its callers run inside a synctest bubble, so the runner keeps its production
+// poll interval: a tick costs no wall-clock time there.
 func installNotebookNarrationRunner(t *testing.T, d *Daemon) string {
 	t.Helper()
 	root := t.TempDir()
@@ -185,9 +189,8 @@ func installNotebookNarrationRunner(t *testing.T, d *Daemon) string {
 	d.store.SetSetting(canonicalExecutableSettingKey("claude"), writeFakeAgentExecutable(t))
 
 	runner := jobs.New(jobs.Options{
-		Store:        newTestJobStore(t, d),
-		Log:          func(string, ...interface{}) {},
-		PollInterval: 2 * time.Millisecond,
+		Store: newTestJobStore(t, d),
+		Log:   func(string, ...interface{}) {},
 	})
 	if err := runner.RegisterWith(notebookSummarizeSessionKind, d.summarizeSessionHandler,
 		jobs.HandlerConfig{Timeout: notebookSummarizeSessionTimeout}); err != nil {
@@ -218,6 +221,12 @@ func writeFakeAgentExecutable(t *testing.T) string {
 	return path
 }
 
+// requireTaskState asserts a queued task reached want. It is a bubble helper:
+// synctest.Wait() returns once every runner goroutine is durably blocked, so the
+// queue has settled and there is a single state to read — no deadline, no poll.
+// waitForTaskState is requireTaskState for callers outside a bubble, where the
+// only way to know a job reached a state is to keep asking. activity_test.go is
+// the remaining one.
 func waitForTaskState(t *testing.T, d *Daemon, kind, subject string, want jobs.State) *jobs.Job {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
@@ -236,91 +245,121 @@ func waitForTaskState(t *testing.T, d *Daemon, kind, subject string, want jobs.S
 	}
 }
 
+func requireTaskState(t *testing.T, d *Daemon, kind, subject string, want jobs.State) *jobs.Job {
+	t.Helper()
+	synctest.Wait()
+	task, err := d.jobQueue.GetByKey(kind, subject)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if task == nil || task.State != want {
+		t.Fatalf("task %s:%s settled at %s, want %s (last=%+v)", kind, subject, taskState(task), want, task)
+	}
+	return task
+}
+
+// taskState renders a possibly-absent task's state for a failure message.
+func taskState(task *jobs.Job) jobs.State {
+	if task == nil {
+		return "<absent>"
+	}
+	return task.State
+}
+
 // --- summarize_session executor ---
 
 func TestSummarizeSessionExecutorVerifiesDigestLedger(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	now := string(protocol.TimestampNow())
-	d.store.Add(&protocol.Session{
-		ID: "session-1", Label: "session-1", Agent: protocol.SessionAgentClaude,
-		Directory: t.TempDir(), State: protocol.SessionStateIdle,
-		StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		now := string(protocol.TimestampNow())
+		d.store.Add(&protocol.Session{
+			ID: "session-1", Label: "session-1", Agent: protocol.SessionAgentClaude,
+			Directory: t.TempDir(), State: protocol.SessionStateIdle,
+			StateSince: now, StateUpdatedAt: now, LastSeen: now,
+		})
+		root := installNotebookNarrationRunner(t, d)
+
+		// A solo session (no workspace) lands its digest under the reserved _solo bucket.
+		soloBucket := filepath.Join(notebook.RawSessionsDir(root), notebookSoloSessionBucket)
+		digest := filepath.Join(soloBucket, "session-1.md")
+
+		// The fake agent writes the digest where the prompt told it to: success.
+		d.summarizeSessionExecution = func(_ context.Context, _ agentdriver.HeadlessTaskProvider, req agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			if err := os.WriteFile(digest, []byte("# Session Digest\n"), 0o644); err != nil {
+				t.Fatalf("fake write digest: %v", err)
+			}
+			// The prompt points the agent at the per-workspace bucket path.
+			if !strings.Contains(req.Prompt, "RAW_DIGEST_PATH: "+digest) {
+				t.Fatalf("prompt RAW_DIGEST_PATH not the bucketed path:\n%s", req.Prompt)
+			}
+			// The request widens to the digest's bucket dir for a Codex-backed narrate.
+			if len(req.ExtraWritableRoots) != 1 || req.ExtraWritableRoots[0] != soloBucket {
+				t.Fatalf("ExtraWritableRoots = %v, want [%s]", req.ExtraWritableRoots, soloBucket)
+			}
+			return agentdriver.HeadlessTaskResult{}, nil
+		}
+
+		if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{UniqueKey: "session-1"}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		requireTaskState(t, d, notebookSummarizeSessionKind, "session-1", jobs.StateDone)
+
+		if _, err := os.Stat(digest); err != nil {
+			t.Fatalf("digest not written: %v", err)
+		}
 	})
-	root := installNotebookNarrationRunner(t, d)
-
-	// A solo session (no workspace) lands its digest under the reserved _solo bucket.
-	soloBucket := filepath.Join(notebook.RawSessionsDir(root), notebookSoloSessionBucket)
-	digest := filepath.Join(soloBucket, "session-1.md")
-
-	// The fake agent writes the digest where the prompt told it to: success.
-	d.summarizeSessionExecution = func(_ context.Context, _ agentdriver.HeadlessTaskProvider, req agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		if err := os.WriteFile(digest, []byte("# Session Digest\n"), 0o644); err != nil {
-			t.Fatalf("fake write digest: %v", err)
-		}
-		// The prompt points the agent at the per-workspace bucket path.
-		if !strings.Contains(req.Prompt, "RAW_DIGEST_PATH: "+digest) {
-			t.Fatalf("prompt RAW_DIGEST_PATH not the bucketed path:\n%s", req.Prompt)
-		}
-		// The request widens to the digest's bucket dir for a Codex-backed narrate.
-		if len(req.ExtraWritableRoots) != 1 || req.ExtraWritableRoots[0] != soloBucket {
-			t.Fatalf("ExtraWritableRoots = %v, want [%s]", req.ExtraWritableRoots, soloBucket)
-		}
-		return agentdriver.HeadlessTaskResult{}, nil
-	}
-
-	if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{UniqueKey: "session-1"}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	waitForTaskState(t, d, notebookSummarizeSessionKind, "session-1", jobs.StateDone)
-
-	if _, err := os.Stat(digest); err != nil {
-		t.Fatalf("digest not written: %v", err)
-	}
 }
 
 func TestSummarizeSessionExecutorFailsWhenDigestMissing(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	now := string(protocol.TimestampNow())
-	d.store.Add(&protocol.Session{
-		ID: "session-1", Label: "session-1", Agent: protocol.SessionAgentClaude,
-		Directory: t.TempDir(), State: protocol.SessionStateIdle,
-		StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		now := string(protocol.TimestampNow())
+		d.store.Add(&protocol.Session{
+			ID: "session-1", Label: "session-1", Agent: protocol.SessionAgentClaude,
+			Directory: t.TempDir(), State: protocol.SessionStateIdle,
+			StateSince: now, StateUpdatedAt: now, LastSeen: now,
+		})
+		installNotebookNarrationRunner(t, d)
+
+		// The agent "succeeds" but writes nothing: the file is the ledger, so the run
+		// must fail (it goes failed/requeued, never done on the first attempt).
+		d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			return agentdriver.HeadlessTaskResult{Diagnostics: "claimed done"}, nil
+		}
+
+		if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{UniqueKey: "session-1"}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		task := requireTaskFailure(t, d, notebookSummarizeSessionKind, "session-1")
+		if !strings.Contains(task.LastError, "did not write digest") {
+			t.Fatalf("last error = %q, want digest-missing", task.LastError)
+		}
 	})
-	installNotebookNarrationRunner(t, d)
-
-	// The agent "succeeds" but writes nothing: the file is the ledger, so the run
-	// must fail (it goes failed/requeued, never done on the first attempt).
-	d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		return agentdriver.HeadlessTaskResult{Diagnostics: "claimed done"}, nil
-	}
-
-	if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{UniqueKey: "session-1"}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	task := waitForNonDoneFailure(t, d, notebookSummarizeSessionKind, "session-1")
-	if !strings.Contains(task.LastError, "did not write digest") {
-		t.Fatalf("last error = %q, want digest-missing", task.LastError)
-	}
 }
 
 func TestSummarizeSessionExecutorSkipsRemovedSession(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	installNotebookNarrationRunner(t, d)
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		installNotebookNarrationRunner(t, d)
 
-	executed := false
-	d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		executed = true
-		return agentdriver.HeadlessTaskResult{}, nil
-	}
+		executed := false
+		d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			executed = true
+			return agentdriver.HeadlessTaskResult{}, nil
+		}
 
-	// No session row exists -> the executor no-ops successfully (nothing to retry).
-	if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{UniqueKey: "gone-session"}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	waitForTaskState(t, d, notebookSummarizeSessionKind, "gone-session", jobs.StateDone)
-	if executed {
-		t.Fatal("executor ran the agent for a removed session")
-	}
+		// No session row exists -> the executor no-ops successfully (nothing to retry).
+		if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{UniqueKey: "gone-session"}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		requireTaskState(t, d, notebookSummarizeSessionKind, "gone-session", jobs.StateDone)
+		if executed {
+			t.Fatal("executor ran the agent for a removed session")
+		}
+	})
 }
 
 // TestSummarizeSessionExecutorUsesCarriedPayloadWhenRowGone is the core fix: after a
@@ -329,52 +368,55 @@ func TestSummarizeSessionExecutorSkipsRemovedSession(t *testing.T) {
 // (RawSessionsDir/<wsID>/<sid>.md), NOT the _solo bucket — using the transcript path
 // and workspace id carried on the task, since neither row exists to re-derive from.
 func TestSummarizeSessionExecutorUsesCarriedPayloadWhenRowGone(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	root := installNotebookNarrationRunner(t, d)
-	// NO session row and NO workspace row: the teardown already removed both. Block
-	// any narrate the re-narrate hook enqueues so it cannot race to done/fail.
-	d.narrateWorkspaceExecution = blockingExecution(t)
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		root := installNotebookNarrationRunner(t, d)
+		// NO session row and NO workspace row: the teardown already removed both. Block
+		// any narrate the re-narrate hook enqueues so it cannot race to done/fail.
+		d.narrateWorkspaceExecution = blockingExecution(t)
 
-	carriedTranscript := filepath.Join(t.TempDir(), "final-turn.jsonl")
-	if err := os.WriteFile(carriedTranscript, []byte("{}\n"), 0o644); err != nil {
-		t.Fatalf("seed transcript: %v", err)
-	}
-	wsBucket := filepath.Join(notebook.RawSessionsDir(root), "ws-gone")
-	digest := filepath.Join(wsBucket, "session-1.md")
-	soloDigest := filepath.Join(notebook.RawSessionsDir(root), notebookSoloSessionBucket, "session-1.md")
-
-	d.summarizeSessionExecution = func(_ context.Context, _ agentdriver.HeadlessTaskProvider, req agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		// The carried transcript (not a re-derived one) flows into the prompt.
-		if !strings.Contains(req.Prompt, "TRANSCRIPT_PATH: "+carriedTranscript) {
-			t.Fatalf("prompt did not use carried transcript path:\n%s", req.Prompt)
+		carriedTranscript := filepath.Join(t.TempDir(), "final-turn.jsonl")
+		if err := os.WriteFile(carriedTranscript, []byte("{}\n"), 0o644); err != nil {
+			t.Fatalf("seed transcript: %v", err)
 		}
-		// The carried workspace id routes the digest to the workspace bucket.
-		if !strings.Contains(req.Prompt, "RAW_DIGEST_PATH: "+digest) {
-			t.Fatalf("digest not routed to workspace bucket:\n%s", req.Prompt)
-		}
-		if err := os.WriteFile(digest, []byte("# Final session digest\n"), 0o644); err != nil {
-			t.Fatalf("fake write digest: %v", err)
-		}
-		return agentdriver.HeadlessTaskResult{}, nil
-	}
+		wsBucket := filepath.Join(notebook.RawSessionsDir(root), "ws-gone")
+		digest := filepath.Join(wsBucket, "session-1.md")
+		soloDigest := filepath.Join(notebook.RawSessionsDir(root), notebookSoloSessionBucket, "session-1.md")
 
-	if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{
-		UniqueKey: "session-1",
-		Payload: summarizeSessionPayload{
-			Transcript:  carriedTranscript,
-			WorkspaceID: protocol.Ptr("ws-gone"),
-		},
-	}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	waitForTaskState(t, d, notebookSummarizeSessionKind, "session-1", jobs.StateDone)
+		d.summarizeSessionExecution = func(_ context.Context, _ agentdriver.HeadlessTaskProvider, req agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			// The carried transcript (not a re-derived one) flows into the prompt.
+			if !strings.Contains(req.Prompt, "TRANSCRIPT_PATH: "+carriedTranscript) {
+				t.Fatalf("prompt did not use carried transcript path:\n%s", req.Prompt)
+			}
+			// The carried workspace id routes the digest to the workspace bucket.
+			if !strings.Contains(req.Prompt, "RAW_DIGEST_PATH: "+digest) {
+				t.Fatalf("digest not routed to workspace bucket:\n%s", req.Prompt)
+			}
+			if err := os.WriteFile(digest, []byte("# Final session digest\n"), 0o644); err != nil {
+				t.Fatalf("fake write digest: %v", err)
+			}
+			return agentdriver.HeadlessTaskResult{}, nil
+		}
 
-	if _, err := os.Stat(digest); err != nil {
-		t.Fatalf("digest not written to workspace bucket: %v", err)
-	}
-	if _, err := os.Stat(soloDigest); err == nil {
-		t.Fatal("digest leaked into the _solo bucket instead of the workspace bucket")
-	}
+		if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{
+			UniqueKey: "session-1",
+			Payload: summarizeSessionPayload{
+				Transcript:  carriedTranscript,
+				WorkspaceID: protocol.Ptr("ws-gone"),
+			},
+		}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		requireTaskState(t, d, notebookSummarizeSessionKind, "session-1", jobs.StateDone)
+
+		if _, err := os.Stat(digest); err != nil {
+			t.Fatalf("digest not written to workspace bucket: %v", err)
+		}
+		if _, err := os.Stat(soloDigest); err == nil {
+			t.Fatal("digest leaked into the _solo bucket instead of the workspace bucket")
+		}
+	})
 }
 
 // TestSummarizeSessionReNarratesWhenWorkspaceRemoved proves the timing-gap hook: a
@@ -382,38 +424,41 @@ func TestSummarizeSessionExecutorUsesCarriedPayloadWhenRowGone(t *testing.T) {
 // zero-debounce narrate_workspace so the removal retrospective is rewritten with the
 // now-available digest.
 func TestSummarizeSessionReNarratesWhenWorkspaceRemoved(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	root := installNotebookNarrationRunner(t, d)
-	// Block narrate so the re-enqueued record stays observable instead of running.
-	d.narrateWorkspaceExecution = blockingExecution(t)
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		root := installNotebookNarrationRunner(t, d)
+		// Block narrate so the re-enqueued record stays observable instead of running.
+		d.narrateWorkspaceExecution = blockingExecution(t)
 
-	carriedTranscript := filepath.Join(t.TempDir(), "turn.jsonl")
-	if err := os.WriteFile(carriedTranscript, []byte("{}\n"), 0o644); err != nil {
-		t.Fatalf("seed transcript: %v", err)
-	}
-	digest := filepath.Join(notebook.RawSessionsDir(root), "ws-gone", "session-1.md")
-	d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		if err := os.WriteFile(digest, []byte("# digest\n"), 0o644); err != nil {
-			t.Fatalf("fake write digest: %v", err)
+		carriedTranscript := filepath.Join(t.TempDir(), "turn.jsonl")
+		if err := os.WriteFile(carriedTranscript, []byte("{}\n"), 0o644); err != nil {
+			t.Fatalf("seed transcript: %v", err)
 		}
-		return agentdriver.HeadlessTaskResult{}, nil
-	}
+		digest := filepath.Join(notebook.RawSessionsDir(root), "ws-gone", "session-1.md")
+		d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			if err := os.WriteFile(digest, []byte("# digest\n"), 0o644); err != nil {
+				t.Fatalf("fake write digest: %v", err)
+			}
+			return agentdriver.HeadlessTaskResult{}, nil
+		}
 
-	// No workspace row for ws-gone, both rows gone -> the hook should re-narrate.
-	if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{
-		UniqueKey: "session-1",
-		Payload: summarizeSessionPayload{
-			Transcript:  carriedTranscript,
-			WorkspaceID: protocol.Ptr("ws-gone"),
-		},
-	}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	waitForTaskState(t, d, notebookSummarizeSessionKind, "session-1", jobs.StateDone)
+		// No workspace row for ws-gone, both rows gone -> the hook should re-narrate.
+		if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{
+			UniqueKey: "session-1",
+			Payload: summarizeSessionPayload{
+				Transcript:  carriedTranscript,
+				WorkspaceID: protocol.Ptr("ws-gone"),
+			},
+		}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		requireTaskState(t, d, notebookSummarizeSessionKind, "session-1", jobs.StateDone)
 
-	if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-gone") {
-		t.Fatal("digest success for a removed workspace did not re-enqueue a narrate")
-	}
+		if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-gone") {
+			t.Fatal("digest success for a removed workspace did not re-enqueue a narrate")
+		}
+	})
 }
 
 // TestSummarizeSessionDoesNotReNarrateWhenWorkspacePresent proves the hook is scoped
@@ -421,152 +466,159 @@ func TestSummarizeSessionReNarratesWhenWorkspaceRemoved(t *testing.T) {
 // NOT burn an extra strong-tier narrate (the active workspace's pending narrate
 // already covers the fresh digest).
 func TestSummarizeSessionDoesNotReNarrateWhenWorkspacePresent(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	setupWorkspaceContextSession(t, d, "session-1", "ws-live")
-	root := installNotebookNarrationRunner(t, d)
-	d.narrateWorkspaceExecution = blockingExecution(t)
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		setupWorkspaceContextSession(t, d, "session-1", "ws-live")
+		root := installNotebookNarrationRunner(t, d)
+		d.narrateWorkspaceExecution = blockingExecution(t)
 
-	digest := filepath.Join(notebook.RawSessionsDir(root), "ws-live", "session-1.md")
-	d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		if err := os.WriteFile(digest, []byte("# digest\n"), 0o644); err != nil {
-			t.Fatalf("fake write digest: %v", err)
+		digest := filepath.Join(notebook.RawSessionsDir(root), "ws-live", "session-1.md")
+		d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			if err := os.WriteFile(digest, []byte("# digest\n"), 0o644); err != nil {
+				t.Fatalf("fake write digest: %v", err)
+			}
+			return agentdriver.HeadlessTaskResult{}, nil
 		}
-		return agentdriver.HeadlessTaskResult{}, nil
-	}
 
-	if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{
-		UniqueKey: "session-1",
-		Payload:   summarizeSessionPayload{WorkspaceID: protocol.Ptr("ws-live")},
-	}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	waitForTaskState(t, d, notebookSummarizeSessionKind, "session-1", jobs.StateDone)
+		if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{
+			UniqueKey: "session-1",
+			Payload:   summarizeSessionPayload{WorkspaceID: protocol.Ptr("ws-live")},
+		}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		requireTaskState(t, d, notebookSummarizeSessionKind, "session-1", jobs.StateDone)
 
-	// The workspace is alive -> no re-narrate. Give the worker a beat; the narrate
-	// record must never appear.
-	time.Sleep(20 * time.Millisecond)
-	task, err := d.jobQueue.GetByKey(notebookNarrateWorkspaceKind, "ws-live")
-	if err != nil {
-		t.Fatalf("get narrate: %v", err)
-	}
-	if task != nil {
-		t.Fatalf("live workspace unexpectedly got a re-narrate task: %+v", task)
-	}
+		// The workspace is alive -> no re-narrate. requireTaskState already settled
+		// the bubble, so the record is absent because nothing enqueued it, not
+		// because the read was early.
+		task, err := d.jobQueue.GetByKey(notebookNarrateWorkspaceKind, "ws-live")
+		if err != nil {
+			t.Fatalf("get narrate: %v", err)
+		}
+		if task != nil {
+			t.Fatalf("live workspace unexpectedly got a re-narrate task: %+v", task)
+		}
+	})
 }
 
 // --- narrate_workspace executor ---
 
 func TestNarrateWorkspaceExecutorActiveDayVerifiesMarker(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
-	root := installNotebookNarrationRunner(t, d)
-	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+		root := installNotebookNarrationRunner(t, d)
+		d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
 
-	d.narrateWorkspaceExecution = func(_ context.Context, _ agentdriver.HeadlessTaskProvider, req agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		// Active day -> the live workspace row exists -> IS_REMOVAL_PASS false.
-		if !strings.Contains(req.Prompt, "IS_REMOVAL_PASS: false") {
-			t.Fatalf("expected active-day prompt, got removal flag set")
+		d.narrateWorkspaceExecution = func(_ context.Context, _ agentdriver.HeadlessTaskProvider, req agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			// Active day -> the live workspace row exists -> IS_REMOVAL_PASS false.
+			if !strings.Contains(req.Prompt, "IS_REMOVAL_PASS: false") {
+				t.Fatalf("expected active-day prompt, got removal flag set")
+			}
+			// The Codex sandbox widens to the whole notebook root.
+			if len(req.ExtraWritableRoots) != 1 || req.ExtraWritableRoots[0] != root {
+				t.Fatalf("ExtraWritableRoots = %v, want [%s]", req.ExtraWritableRoots, root)
+			}
+			journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
+			body := "## Chifplace — 2026-06-15\n<!-- attn:wsnarr:ws-1 -->\n\nDid work.\n"
+			if err := os.WriteFile(journal, []byte(body), 0o644); err != nil {
+				t.Fatalf("fake write journal: %v", err)
+			}
+			return agentdriver.HeadlessTaskResult{}, nil
 		}
-		// The Codex sandbox widens to the whole notebook root.
-		if len(req.ExtraWritableRoots) != 1 || req.ExtraWritableRoots[0] != root {
-			t.Fatalf("ExtraWritableRoots = %v, want [%s]", req.ExtraWritableRoots, root)
+
+		if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{UniqueKey: "ws-1"}); err != nil {
+			t.Fatalf("enqueue: %v", err)
 		}
+		requireTaskState(t, d, notebookNarrateWorkspaceKind, "ws-1", jobs.StateDone)
+
 		journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
-		body := "## Chifplace — 2026-06-15\n<!-- attn:wsnarr:ws-1 -->\n\nDid work.\n"
-		if err := os.WriteFile(journal, []byte(body), 0o644); err != nil {
-			t.Fatalf("fake write journal: %v", err)
+		content, err := os.ReadFile(journal)
+		if err != nil {
+			t.Fatalf("read journal: %v", err)
 		}
-		return agentdriver.HeadlessTaskResult{}, nil
-	}
-
-	if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{UniqueKey: "ws-1"}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	waitForTaskState(t, d, notebookNarrateWorkspaceKind, "ws-1", jobs.StateDone)
-
-	journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
-	content, err := os.ReadFile(journal)
-	if err != nil {
-		t.Fatalf("read journal: %v", err)
-	}
-	if !strings.Contains(string(content), "attn:wsnarr:ws-1") {
-		t.Fatalf("journal missing workspace marker:\n%s", content)
-	}
+		if !strings.Contains(string(content), "attn:wsnarr:ws-1") {
+			t.Fatalf("journal missing workspace marker:\n%s", content)
+		}
+	})
 }
 
 func TestNarrateWorkspaceExecutorRemovalPassDerivesFlagFromAbsentRow(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	root := installNotebookNarrationRunner(t, d)
-	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
-	// No workspace row for ws-removed -> IS_REMOVAL_PASS must be derived true.
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		root := installNotebookNarrationRunner(t, d)
+		d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+		// No workspace row for ws-removed -> IS_REMOVAL_PASS must be derived true.
 
-	var sawRemoval bool
-	d.narrateWorkspaceExecution = func(_ context.Context, _ agentdriver.HeadlessTaskProvider, req agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		sawRemoval = strings.Contains(req.Prompt, "IS_REMOVAL_PASS: true")
-		// Title falls back to the id when the row is gone.
-		if !strings.Contains(req.Prompt, "WORKSPACE_TITLE: ws-removed") {
-			t.Fatalf("removal prompt did not fall back title to id:\n%s", req.Prompt)
+		var sawRemoval bool
+		d.narrateWorkspaceExecution = func(_ context.Context, _ agentdriver.HeadlessTaskProvider, req agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			sawRemoval = strings.Contains(req.Prompt, "IS_REMOVAL_PASS: true")
+			// Title falls back to the id when the row is gone.
+			if !strings.Contains(req.Prompt, "WORKSPACE_TITLE: ws-removed") {
+				t.Fatalf("removal prompt did not fall back title to id:\n%s", req.Prompt)
+			}
+			journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
+			body := "## ws-removed — 2026-06-15\n<!-- attn:wsnarr:ws-removed -->\n\nRetrospective.\n"
+			if err := os.WriteFile(journal, []byte(body), 0o644); err != nil {
+				t.Fatalf("fake write journal: %v", err)
+			}
+			return agentdriver.HeadlessTaskResult{}, nil
 		}
-		journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
-		body := "## ws-removed — 2026-06-15\n<!-- attn:wsnarr:ws-removed -->\n\nRetrospective.\n"
-		if err := os.WriteFile(journal, []byte(body), 0o644); err != nil {
-			t.Fatalf("fake write journal: %v", err)
-		}
-		return agentdriver.HeadlessTaskResult{}, nil
-	}
 
-	if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{UniqueKey: "ws-removed"}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	waitForTaskState(t, d, notebookNarrateWorkspaceKind, "ws-removed", jobs.StateDone)
-	if !sawRemoval {
-		t.Fatal("removal pass did not derive IS_REMOVAL_PASS=true from absent workspace row")
-	}
+		if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{UniqueKey: "ws-removed"}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		requireTaskState(t, d, notebookNarrateWorkspaceKind, "ws-removed", jobs.StateDone)
+		if !sawRemoval {
+			t.Fatal("removal pass did not derive IS_REMOVAL_PASS=true from absent workspace row")
+		}
+	})
 }
 
 func TestNarrateWorkspaceExecutorFailsWhenMarkerMissing(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
-	root := installNotebookNarrationRunner(t, d)
-	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+		root := installNotebookNarrationRunner(t, d)
+		d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
 
-	// Agent writes the day's file but NOT this workspace's marker -> ledger says no.
-	d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
-		if err := os.WriteFile(journal, []byte("## Other — 2026-06-15\n<!-- attn:wsnarr:other-ws -->\n"), 0o644); err != nil {
-			t.Fatalf("fake write journal: %v", err)
+		// Agent writes the day's file but NOT this workspace's marker -> ledger says no.
+		d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
+			if err := os.WriteFile(journal, []byte("## Other — 2026-06-15\n<!-- attn:wsnarr:other-ws -->\n"), 0o644); err != nil {
+				t.Fatalf("fake write journal: %v", err)
+			}
+			return agentdriver.HeadlessTaskResult{Diagnostics: "wrote wrong marker"}, nil
 		}
-		return agentdriver.HeadlessTaskResult{Diagnostics: "wrote wrong marker"}, nil
-	}
 
-	if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{UniqueKey: "ws-1"}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	task := waitForNonDoneFailure(t, d, notebookNarrateWorkspaceKind, "ws-1")
-	if !strings.Contains(task.LastError, "did not write") {
-		t.Fatalf("last error = %q, want marker-missing", task.LastError)
-	}
+		if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{UniqueKey: "ws-1"}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		task := requireTaskFailure(t, d, notebookNarrateWorkspaceKind, "ws-1")
+		if !strings.Contains(task.LastError, "did not write") {
+			t.Fatalf("last error = %q, want marker-missing", task.LastError)
+		}
+	})
 }
 
-// waitForNonDoneFailure waits until a task has recorded a failure (LastError set
-// and not done). The runner auto-requeues failed tasks, so the task may cycle
-// failed->queued->running; we only assert it recorded the failure at least once.
-func waitForNonDoneFailure(t *testing.T, d *Daemon, kind, subject string) *jobs.Job {
+// requireTaskFailure asserts a task recorded a failure (LastError set and not
+// done). The runner auto-requeues a failed task behind its backoff, so once the
+// bubble settles the record sits queued with the failure it just recorded.
+func requireTaskFailure(t *testing.T, d *Daemon, kind, subject string) *jobs.Job {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		task, err := d.jobQueue.GetByKey(kind, subject)
-		if err != nil {
-			t.Fatalf("get task: %v", err)
-		}
-		if task != nil && task.LastError != "" && task.State != jobs.StateDone {
-			return task
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("task %s:%s never recorded a failure (last=%+v)", kind, subject, task)
-		}
-		time.Sleep(2 * time.Millisecond)
+	synctest.Wait()
+	task, err := d.jobQueue.GetByKey(kind, subject)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
 	}
+	if task == nil || task.LastError == "" || task.State == jobs.StateDone {
+		t.Fatalf("task %s:%s recorded no failure (last=%+v)", kind, subject, task)
+	}
+	return task
 }
 
 // --- triggers ---
@@ -574,49 +626,57 @@ func waitForNonDoneFailure(t *testing.T, d *Daemon, kind, subject string) *jobs.
 // TestHandleStopEnqueuesNarrationForWorkspaceSession proves a Stop on a workspace
 // session enqueues BOTH a per-session digest and a coalesced workspace narrate.
 func TestHandleStopEnqueuesNarrationForWorkspaceSession(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
-	installNotebookNarrationRunner(t, d)
-	// Block both executors so the enqueued records stay observable.
-	d.summarizeSessionExecution = blockingExecution(t)
-	d.narrateWorkspaceExecution = blockingExecution(t)
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+		installNotebookNarrationRunner(t, d)
+		// Block both executors so the enqueued records stay observable.
+		d.summarizeSessionExecution = blockingExecution(t)
+		d.narrateWorkspaceExecution = blockingExecution(t)
 
-	d.handleStop(drainingConn(t), &protocol.StopMessage{ID: "session-1"})
+		d.handleStop(drainingConn(t), &protocol.StopMessage{ID: "session-1"})
 
-	if !taskExists(t, d, notebookSummarizeSessionKind, "session-1") {
-		t.Fatal("stop did not enqueue summarize_session")
-	}
-	if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-1") {
-		t.Fatal("stop did not enqueue narrate_workspace for the live workspace")
-	}
+		if !taskExists(t, d, notebookSummarizeSessionKind, "session-1") {
+			t.Fatal("stop did not enqueue summarize_session")
+		}
+		if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-1") {
+			t.Fatal("stop did not enqueue narrate_workspace for the live workspace")
+		}
+		settleStopClassification(t)
+	})
 }
 
 // TestHandleStopEnqueuesOnlyDigestForSoloSession proves a Stop on a session with no
 // workspace enqueues the digest but no workspace narrate.
 func TestHandleStopEnqueuesOnlyDigestForSoloSession(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	now := string(protocol.TimestampNow())
-	d.store.Add(&protocol.Session{
-		ID: "solo", Label: "solo", Agent: protocol.SessionAgentClaude,
-		Directory: t.TempDir(), State: protocol.SessionStateIdle,
-		StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		now := string(protocol.TimestampNow())
+		d.store.Add(&protocol.Session{
+			ID: "solo", Label: "solo", Agent: protocol.SessionAgentClaude,
+			Directory: t.TempDir(), State: protocol.SessionStateIdle,
+			StateSince: now, StateUpdatedAt: now, LastSeen: now,
+		})
+		installNotebookNarrationRunner(t, d)
+		d.summarizeSessionExecution = blockingExecution(t)
+
+		d.handleStop(drainingConn(t), &protocol.StopMessage{ID: "solo"})
+
+		if !taskExists(t, d, notebookSummarizeSessionKind, "solo") {
+			t.Fatal("stop did not enqueue summarize_session for solo session")
+		}
+		// No workspace -> no narrate task at all.
+		task, err := d.jobQueue.GetByKey(notebookNarrateWorkspaceKind, "")
+		if err != nil {
+			t.Fatalf("get narrate: %v", err)
+		}
+		if task != nil {
+			t.Fatalf("solo session unexpectedly enqueued a narrate task: %+v", task)
+		}
+		settleStopClassification(t)
 	})
-	installNotebookNarrationRunner(t, d)
-	d.summarizeSessionExecution = blockingExecution(t)
-
-	d.handleStop(drainingConn(t), &protocol.StopMessage{ID: "solo"})
-
-	if !taskExists(t, d, notebookSummarizeSessionKind, "solo") {
-		t.Fatal("stop did not enqueue summarize_session for solo session")
-	}
-	// No workspace -> no narrate task at all.
-	task, err := d.jobQueue.GetByKey(notebookNarrateWorkspaceKind, "")
-	if err != nil {
-		t.Fatalf("get narrate: %v", err)
-	}
-	if task != nil {
-		t.Fatalf("solo session unexpectedly enqueued a narrate task: %+v", task)
-	}
 }
 
 // TestHandleStopCarriesTranscriptAndWorkspaceOnThePayload proves the Stop trigger
@@ -624,75 +684,82 @@ func TestHandleStopEnqueuesOnlyDigestForSoloSession(t *testing.T) {
 // where both the session row and the workspace row still exist — so the debounced run
 // can still resolve them after a teardown deletes both rows.
 func TestHandleStopCarriesTranscriptAndWorkspaceOnThePayload(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
-	installNotebookNarrationRunner(t, d)
-	// Block both executors so the enqueued summarize record stays observable.
-	d.summarizeSessionExecution = blockingExecution(t)
-	d.narrateWorkspaceExecution = blockingExecution(t)
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+		installNotebookNarrationRunner(t, d)
+		// Block both executors so the enqueued summarize record stays observable.
+		d.summarizeSessionExecution = blockingExecution(t)
+		d.narrateWorkspaceExecution = blockingExecution(t)
 
-	transcript := filepath.Join(t.TempDir(), "turn.jsonl")
-	if err := os.WriteFile(transcript, []byte("{}\n"), 0o644); err != nil {
-		t.Fatalf("seed transcript: %v", err)
-	}
+		transcript := filepath.Join(t.TempDir(), "turn.jsonl")
+		if err := os.WriteFile(transcript, []byte("{}\n"), 0o644); err != nil {
+			t.Fatalf("seed transcript: %v", err)
+		}
 
-	d.handleStop(drainingConn(t), &protocol.StopMessage{ID: "session-1", TranscriptPath: transcript})
+		d.handleStop(drainingConn(t), &protocol.StopMessage{ID: "session-1", TranscriptPath: transcript})
 
-	if !taskExists(t, d, notebookSummarizeSessionKind, "session-1") {
-		t.Fatal("stop did not enqueue summarize_session")
-	}
-	task, err := d.jobQueue.GetByKey(notebookSummarizeSessionKind, "session-1")
-	if err != nil || task == nil {
-		t.Fatalf("get summarize task: %v", err)
-	}
-	var carried summarizeSessionPayload
-	if err := task.DecodePayload(&carried); err != nil {
-		t.Fatalf("decode summarize payload: %v", err)
-	}
-	if carried.Transcript != transcript {
-		t.Fatalf("summarize payload transcript = %q, want %q", carried.Transcript, transcript)
-	}
-	if carried.WorkspaceID == nil || *carried.WorkspaceID != "ws-1" {
-		t.Fatalf("summarize payload workspace = %v, want ws-1", carried.WorkspaceID)
-	}
+		if !taskExists(t, d, notebookSummarizeSessionKind, "session-1") {
+			t.Fatal("stop did not enqueue summarize_session")
+		}
+		task, err := d.jobQueue.GetByKey(notebookSummarizeSessionKind, "session-1")
+		if err != nil || task == nil {
+			t.Fatalf("get summarize task: %v", err)
+		}
+		var carried summarizeSessionPayload
+		if err := task.DecodePayload(&carried); err != nil {
+			t.Fatalf("decode summarize payload: %v", err)
+		}
+		if carried.Transcript != transcript {
+			t.Fatalf("summarize payload transcript = %q, want %q", carried.Transcript, transcript)
+		}
+		if carried.WorkspaceID == nil || *carried.WorkspaceID != "ws-1" {
+			t.Fatalf("summarize payload workspace = %v, want ws-1", carried.WorkspaceID)
+		}
+		settleStopClassification(t)
+	})
 }
 
 // TestWorkspaceRemovalEnqueuesFinalNarrate proves the removal boundary enqueues the
 // final retrospective narrate that overrides a pending active-day debounce (RunNow ->
 // ScheduledAt is not pushed forward).
 func TestWorkspaceRemovalEnqueuesFinalNarrate(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
-	installNotebookNarrationRunner(t, d)
-	d.narrateWorkspaceExecution = blockingExecution(t)
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+		installNotebookNarrationRunner(t, d)
+		d.narrateWorkspaceExecution = blockingExecution(t)
 
-	// Pre-seed a far-future debounced active-day narrate.
-	if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{
-		UniqueKey: "ws-1", Delay: time.Hour,
-	}); err != nil {
-		t.Fatalf("seed pending narrate: %v", err)
-	}
-	before, err := d.jobQueue.GetByKey(notebookNarrateWorkspaceKind, "ws-1")
-	if err != nil || before == nil {
-		t.Fatalf("get seeded task: %v", err)
-	}
+		// Pre-seed a far-future debounced active-day narrate.
+		if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{
+			UniqueKey: "ws-1", Delay: time.Hour,
+		}); err != nil {
+			t.Fatalf("seed pending narrate: %v", err)
+		}
+		before, err := d.jobQueue.GetByKey(notebookNarrateWorkspaceKind, "ws-1")
+		if err != nil || before == nil {
+			t.Fatalf("get seeded task: %v", err)
+		}
 
-	// Remove the workspace (the app's UnregisterWorkspace path).
-	d.handleUnregisterWorkspace(nil, &protocol.UnregisterWorkspaceMessage{ID: "ws-1"})
+		// Remove the workspace (the app's UnregisterWorkspace path).
+		d.handleUnregisterWorkspace(nil, &protocol.UnregisterWorkspaceMessage{ID: "ws-1"})
 
-	if d.store.GetWorkspace("ws-1") != nil {
-		t.Fatal("workspace not removed")
-	}
-	after, err := d.jobQueue.GetByKey(notebookNarrateWorkspaceKind, "ws-1")
-	if err != nil || after == nil {
-		t.Fatalf("get final task: %v", err)
-	}
-	// RunNow overrode the hour-long debounce: the final attempt is no later than the
-	// seeded one (in practice much sooner / now).
-	if after.ScheduledAt.After(before.ScheduledAt) {
-		t.Fatalf("final narrate did not override the pending debounce: before=%s after=%s",
-			before.ScheduledAt, after.ScheduledAt)
-	}
+		if d.store.GetWorkspace("ws-1") != nil {
+			t.Fatal("workspace not removed")
+		}
+		after, err := d.jobQueue.GetByKey(notebookNarrateWorkspaceKind, "ws-1")
+		if err != nil || after == nil {
+			t.Fatalf("get final task: %v", err)
+		}
+		// RunNow overrode the hour-long debounce: the final attempt is no later than the
+		// seeded one (in practice much sooner / now).
+		if after.ScheduledAt.After(before.ScheduledAt) {
+			t.Fatalf("final narrate did not override the pending debounce: before=%s after=%s",
+				before.ScheduledAt, after.ScheduledAt)
+		}
+	})
 }
 
 // TestNarrationTriggersAreNilSafeBeforeRunner proves the Stop and removal triggers
@@ -753,61 +820,67 @@ func assertJournalUntouched(t *testing.T, root string) {
 // agent runs, and nothing lands under the journal dir. The base raw-floor PR added
 // rawTierFilename precisely for this; this is the missing load-bearing test.
 func TestSummarizeSessionExecutorRejectsTraversalSessionID(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	now := string(protocol.TimestampNow())
-	craftedID := "../../../journal/2026-06-15"
-	d.store.Add(&protocol.Session{
-		ID: craftedID, Label: craftedID, Agent: protocol.SessionAgentClaude,
-		Directory: t.TempDir(), State: protocol.SessionStateIdle,
-		StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		now := string(protocol.TimestampNow())
+		craftedID := "../../../journal/2026-06-15"
+		d.store.Add(&protocol.Session{
+			ID: craftedID, Label: craftedID, Agent: protocol.SessionAgentClaude,
+			Directory: t.TempDir(), State: protocol.SessionStateIdle,
+			StateSince: now, StateUpdatedAt: now, LastSeen: now,
+		})
+		root := installNotebookNarrationRunner(t, d)
+
+		ran := false
+		d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			ran = true
+			return agentdriver.HeadlessTaskResult{}, nil
+		}
+
+		if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{UniqueKey: craftedID}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		task := requireTaskFailure(t, d, notebookSummarizeSessionKind, craftedID)
+		if !strings.Contains(task.LastError, "unsafe session id") {
+			t.Fatalf("last error = %q, want unsafe-session-id rejection", task.LastError)
+		}
+		if ran {
+			t.Fatal("executor spawned the agent for a traversal session id")
+		}
+		assertJournalUntouched(t, root)
 	})
-	root := installNotebookNarrationRunner(t, d)
-
-	ran := false
-	d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		ran = true
-		return agentdriver.HeadlessTaskResult{}, nil
-	}
-
-	if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{UniqueKey: craftedID}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	task := waitForNonDoneFailure(t, d, notebookSummarizeSessionKind, craftedID)
-	if !strings.Contains(task.LastError, "unsafe session id") {
-		t.Fatalf("last error = %q, want unsafe-session-id rejection", task.LastError)
-	}
-	if ran {
-		t.Fatal("executor spawned the agent for a traversal session id")
-	}
-	assertJournalUntouched(t, root)
 }
 
 // TestNarrateWorkspaceExecutorRejectsTraversalWorkspaceID proves a crafted workspace
 // id is rejected (so the narrate pass is never handed a CONTEXT_SNAPSHOT_PATH/journal
 // read target that climbed out of the raw tier) and nothing lands under the journal.
 func TestNarrateWorkspaceExecutorRejectsTraversalWorkspaceID(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	root := installNotebookNarrationRunner(t, d)
-	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		root := installNotebookNarrationRunner(t, d)
+		d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
 
-	craftedID := "../../../journal/2026-06-15"
-	ran := false
-	d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		ran = true
-		return agentdriver.HeadlessTaskResult{}, nil
-	}
+		craftedID := "../../../journal/2026-06-15"
+		ran := false
+		d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			ran = true
+			return agentdriver.HeadlessTaskResult{}, nil
+		}
 
-	if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{UniqueKey: craftedID}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	task := waitForNonDoneFailure(t, d, notebookNarrateWorkspaceKind, craftedID)
-	if !strings.Contains(task.LastError, "unsafe workspace id") {
-		t.Fatalf("last error = %q, want unsafe-workspace-id rejection", task.LastError)
-	}
-	if ran {
-		t.Fatal("executor spawned the agent for a traversal workspace id")
-	}
-	assertJournalUntouched(t, root)
+		if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{UniqueKey: craftedID}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		task := requireTaskFailure(t, d, notebookNarrateWorkspaceKind, craftedID)
+		if !strings.Contains(task.LastError, "unsafe workspace id") {
+			t.Fatalf("last error = %q, want unsafe-workspace-id rejection", task.LastError)
+		}
+		if ran {
+			t.Fatal("executor spawned the agent for a traversal workspace id")
+		}
+		assertJournalUntouched(t, root)
+	})
 }
 
 // --- ledger freshness (no false done off a prior run's file) ---
@@ -816,35 +889,38 @@ func TestNarrateWorkspaceExecutorRejectsTraversalWorkspaceID(t *testing.T) {
 // agent leaves the prior digest byte-identical is treated as a failure, not a false
 // done — otherwise a stale digest (missing the new turns) would report success.
 func TestSummarizeSessionExecutorRequiresFreshDigest(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	now := string(protocol.TimestampNow())
-	d.store.Add(&protocol.Session{
-		ID: "session-1", Label: "session-1", Agent: protocol.SessionAgentClaude,
-		Directory: t.TempDir(), State: protocol.SessionStateIdle,
-		StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		now := string(protocol.TimestampNow())
+		d.store.Add(&protocol.Session{
+			ID: "session-1", Label: "session-1", Agent: protocol.SessionAgentClaude,
+			Directory: t.TempDir(), State: protocol.SessionStateIdle,
+			StateSince: now, StateUpdatedAt: now, LastSeen: now,
+		})
+		root := installNotebookNarrationRunner(t, d)
+
+		digest := filepath.Join(notebook.RawSessionsDir(root), notebookSoloSessionBucket, "session-1.md")
+		if err := os.MkdirAll(filepath.Dir(digest), 0o755); err != nil {
+			t.Fatalf("mkdir bucket: %v", err)
+		}
+		if err := os.WriteFile(digest, []byte("# Session Digest\n\nprior run\n"), 0o644); err != nil {
+			t.Fatalf("seed prior digest: %v", err)
+		}
+
+		// Agent no-ops: leaves the prior digest exactly as-is.
+		d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			return agentdriver.HeadlessTaskResult{Diagnostics: "no-op"}, nil
+		}
+
+		if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{UniqueKey: "session-1"}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		task := requireTaskFailure(t, d, notebookSummarizeSessionKind, "session-1")
+		if !strings.Contains(task.LastError, "unchanged") {
+			t.Fatalf("last error = %q, want unchanged-digest rejection", task.LastError)
+		}
 	})
-	root := installNotebookNarrationRunner(t, d)
-
-	digest := filepath.Join(notebook.RawSessionsDir(root), notebookSoloSessionBucket, "session-1.md")
-	if err := os.MkdirAll(filepath.Dir(digest), 0o755); err != nil {
-		t.Fatalf("mkdir bucket: %v", err)
-	}
-	if err := os.WriteFile(digest, []byte("# Session Digest\n\nprior run\n"), 0o644); err != nil {
-		t.Fatalf("seed prior digest: %v", err)
-	}
-
-	// Agent no-ops: leaves the prior digest exactly as-is.
-	d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		return agentdriver.HeadlessTaskResult{Diagnostics: "no-op"}, nil
-	}
-
-	if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{UniqueKey: "session-1"}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	task := waitForNonDoneFailure(t, d, notebookSummarizeSessionKind, "session-1")
-	if !strings.Contains(task.LastError, "unchanged") {
-		t.Fatalf("last error = %q, want unchanged-digest rejection", task.LastError)
-	}
 }
 
 // TestNarrateWorkspaceExecutorRequiresFreshEntry proves the removal retrospective
@@ -852,31 +928,34 @@ func TestSummarizeSessionExecutorRequiresFreshDigest(t *testing.T) {
 // agent leaves this workspace's marker block byte-identical fails (and is retried),
 // instead of being marked done off the prior block.
 func TestNarrateWorkspaceExecutorRequiresFreshEntry(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	root := installNotebookNarrationRunner(t, d)
-	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		root := installNotebookNarrationRunner(t, d)
+		d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
 
-	journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
-	if err := os.MkdirAll(filepath.Dir(journal), 0o755); err != nil {
-		t.Fatalf("mkdir journal: %v", err)
-	}
-	prior := "## ws-1 — 2026-06-15\n<!-- attn:wsnarr:ws-1 -->\n\nactive-day entry\n\nsource: workspace:ws-1\n"
-	if err := os.WriteFile(journal, []byte(prior), 0o644); err != nil {
-		t.Fatalf("seed prior entry: %v", err)
-	}
+		journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
+		if err := os.MkdirAll(filepath.Dir(journal), 0o755); err != nil {
+			t.Fatalf("mkdir journal: %v", err)
+		}
+		prior := "## ws-1 — 2026-06-15\n<!-- attn:wsnarr:ws-1 -->\n\nactive-day entry\n\nsource: workspace:ws-1\n"
+		if err := os.WriteFile(journal, []byte(prior), 0o644); err != nil {
+			t.Fatalf("seed prior entry: %v", err)
+		}
 
-	// Removal-pass agent no-ops: leaves the active-day block exactly as-is.
-	d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		return agentdriver.HeadlessTaskResult{Diagnostics: "no-op"}, nil
-	}
+		// Removal-pass agent no-ops: leaves the active-day block exactly as-is.
+		d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			return agentdriver.HeadlessTaskResult{Diagnostics: "no-op"}, nil
+		}
 
-	if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{UniqueKey: "ws-1"}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	task := waitForNonDoneFailure(t, d, notebookNarrateWorkspaceKind, "ws-1")
-	if !strings.Contains(task.LastError, "unchanged") {
-		t.Fatalf("last error = %q, want unchanged-entry rejection", task.LastError)
-	}
+		if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{UniqueKey: "ws-1"}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		task := requireTaskFailure(t, d, notebookNarrateWorkspaceKind, "ws-1")
+		if !strings.Contains(task.LastError, "unchanged") {
+			t.Fatalf("last error = %q, want unchanged-entry rejection", task.LastError)
+		}
+	})
 }
 
 // --- marker prefix collision (sibling whose id is a prefix) ---
@@ -917,35 +996,38 @@ func TestWorkspaceNarrationBlockNoPrefixCollision(t *testing.T) {
 // only its OWN workspace's digest bucket, so one workspace's journal entry cannot be
 // contaminated with a sibling's (or a solo session's) digests.
 func TestNarrateWorkspaceScopesSessionsToWorkspace(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	setupWorkspaceContextSession(t, d, "session-a", "ws-1")
-	root := installNotebookNarrationRunner(t, d)
-	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		setupWorkspaceContextSession(t, d, "session-a", "ws-1")
+		root := installNotebookNarrationRunner(t, d)
+		d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
 
-	wantDir, err := notebookWorkspaceSessionsDir(root, "ws-1")
-	if err != nil {
-		t.Fatalf("workspace sessions dir: %v", err)
-	}
-	if wantDir == notebook.RawSessionsDir(root) {
-		t.Fatal("per-workspace dir collapsed to the shared flat sessions dir")
-	}
-
-	d.narrateWorkspaceExecution = func(_ context.Context, _ agentdriver.HeadlessTaskProvider, req agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		if !strings.Contains(req.Prompt, "RAW_SESSIONS_DIR: "+wantDir) {
-			t.Fatalf("narrate prompt RAW_SESSIONS_DIR not scoped to ws-1:\n%s", req.Prompt)
+		wantDir, err := notebookWorkspaceSessionsDir(root, "ws-1")
+		if err != nil {
+			t.Fatalf("workspace sessions dir: %v", err)
 		}
-		journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
-		body := "## ws-1 — 2026-06-15\n<!-- attn:wsnarr:ws-1 -->\n\nwork.\n"
-		if err := os.WriteFile(journal, []byte(body), 0o644); err != nil {
-			t.Fatalf("fake write journal: %v", err)
+		if wantDir == notebook.RawSessionsDir(root) {
+			t.Fatal("per-workspace dir collapsed to the shared flat sessions dir")
 		}
-		return agentdriver.HeadlessTaskResult{}, nil
-	}
 
-	if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{UniqueKey: "ws-1"}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	waitForTaskState(t, d, notebookNarrateWorkspaceKind, "ws-1", jobs.StateDone)
+		d.narrateWorkspaceExecution = func(_ context.Context, _ agentdriver.HeadlessTaskProvider, req agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			if !strings.Contains(req.Prompt, "RAW_SESSIONS_DIR: "+wantDir) {
+				t.Fatalf("narrate prompt RAW_SESSIONS_DIR not scoped to ws-1:\n%s", req.Prompt)
+			}
+			journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
+			body := "## ws-1 — 2026-06-15\n<!-- attn:wsnarr:ws-1 -->\n\nwork.\n"
+			if err := os.WriteFile(journal, []byte(body), 0o644); err != nil {
+				t.Fatalf("fake write journal: %v", err)
+			}
+			return agentdriver.HeadlessTaskResult{}, nil
+		}
+
+		if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{UniqueKey: "ws-1"}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		requireTaskState(t, d, notebookNarrateWorkspaceKind, "ws-1", jobs.StateDone)
+	})
 }
 
 // --- config-time validation (fail fast, not mid-run hang) ---
@@ -988,20 +1070,15 @@ func TestDaemon_ValidatesNotebookNarrationAgentAndExecutable(t *testing.T) {
 	}
 }
 
+// taskExists reports whether a record exists for kind:subject once the bubble has
+// settled. Both answers are then final: an absent record is absent because nobody
+// enqueued it, not because the read arrived early.
 func taskExists(t *testing.T, d *Daemon, kind, subject string) bool {
 	t.Helper()
-	deadline := time.Now().Add(time.Second)
-	for {
-		task, err := d.jobQueue.GetByKey(kind, subject)
-		if err != nil {
-			t.Fatalf("get task: %v", err)
-		}
-		if task != nil {
-			return true
-		}
-		if time.Now().After(deadline) {
-			return false
-		}
-		time.Sleep(2 * time.Millisecond)
+	synctest.Wait()
+	task, err := d.jobQueue.GetByKey(kind, subject)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
 	}
+	return task != nil
 }

--- a/internal/daemon/notebook_tasks_enabled_test.go
+++ b/internal/daemon/notebook_tasks_enabled_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"testing/synctest"
 
 	agentdriver "github.com/victorarias/attn/internal/agent"
 	"github.com/victorarias/attn/internal/jobs"
@@ -84,52 +85,58 @@ func TestNotebookWorkspaceNarrationEnabledDefaultsOn(t *testing.T) {
 // leaves journal narration alone while preventing summary records from being
 // created. Re-enabling restores the enqueue path without changing its model.
 func TestNotebookSummariesDisabledOnlySkipsSummaries(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	installNotebookNarrationRunner(t, d)
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		installNotebookNarrationRunner(t, d)
 
-	d.store.SetSetting(SettingNotebookSummarizeSessionEnabled, "false")
-	d.enqueueSummarizeSession("session-off", "", "")
-	d.enqueueNarrateWorkspace("ws-on")
-	assertNoTask(t, d, notebookSummarizeSessionKind, "session-off")
-	if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-on") {
-		t.Fatal("summary switch must not disable journal narration")
-	}
+		d.store.SetSetting(SettingNotebookSummarizeSessionEnabled, "false")
+		d.enqueueSummarizeSession("session-off", "", "")
+		d.enqueueNarrateWorkspace("ws-on")
+		assertNoTask(t, d, notebookSummarizeSessionKind, "session-off")
+		if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-on") {
+			t.Fatal("summary switch must not disable journal narration")
+		}
 
-	d.store.SetSetting(SettingNotebookSummarizeSessionEnabled, "true")
-	d.enqueueSummarizeSession("session-on", "", "")
-	if !taskExists(t, d, notebookSummarizeSessionKind, "session-on") {
-		t.Fatal("summarize must enqueue once its duty switch is on")
-	}
+		d.store.SetSetting(SettingNotebookSummarizeSessionEnabled, "true")
+		d.enqueueSummarizeSession("session-on", "", "")
+		if !taskExists(t, d, notebookSummarizeSessionKind, "session-on") {
+			t.Fatal("summarize must enqueue once its duty switch is on")
+		}
+	})
 }
 
 // TestNotebookNarrationDisabledOnlySkipsNarration proves the switch gates every
 // narration enqueue path without disabling session summaries. Re-enabling restores
 // routine narration without changing its agent/model configuration.
 func TestNotebookNarrationDisabledOnlySkipsNarration(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	installNotebookNarrationRunner(t, d)
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		installNotebookNarrationRunner(t, d)
 
-	d.store.SetSetting(SettingNotebookNarrateWorkspace, `{"agent":"claude","model":"claude-custom"}`)
-	d.store.SetSetting(SettingNotebookNarrateWorkspaceEnabled, "false")
-	d.enqueueNarrateWorkspace("ws-routine-off")
-	d.enqueueDailyNarrateWorkspace("ws-daily-off")
-	d.enqueueFinalNarrateWorkspace("ws-final-off")
-	d.enqueueSummarizeSession("session-on", "", "")
-	assertNoTask(t, d, notebookNarrateWorkspaceKind, "ws-routine-off")
-	assertNoTask(t, d, notebookNarrateWorkspaceKind, "ws-daily-off")
-	assertNoTask(t, d, notebookNarrateWorkspaceKind, "ws-final-off")
-	if !taskExists(t, d, notebookSummarizeSessionKind, "session-on") {
-		t.Fatal("narration switch must not disable session summaries")
-	}
+		d.store.SetSetting(SettingNotebookNarrateWorkspace, `{"agent":"claude","model":"claude-custom"}`)
+		d.store.SetSetting(SettingNotebookNarrateWorkspaceEnabled, "false")
+		d.enqueueNarrateWorkspace("ws-routine-off")
+		d.enqueueDailyNarrateWorkspace("ws-daily-off")
+		d.enqueueFinalNarrateWorkspace("ws-final-off")
+		d.enqueueSummarizeSession("session-on", "", "")
+		assertNoTask(t, d, notebookNarrateWorkspaceKind, "ws-routine-off")
+		assertNoTask(t, d, notebookNarrateWorkspaceKind, "ws-daily-off")
+		assertNoTask(t, d, notebookNarrateWorkspaceKind, "ws-final-off")
+		if !taskExists(t, d, notebookSummarizeSessionKind, "session-on") {
+			t.Fatal("narration switch must not disable session summaries")
+		}
 
-	d.store.SetSetting(SettingNotebookNarrateWorkspaceEnabled, "true")
-	d.enqueueNarrateWorkspace("ws-routine-on")
-	if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-routine-on") {
-		t.Fatal("narration must enqueue once its duty switch is on")
-	}
-	if got := d.store.GetSetting(SettingNotebookNarrateWorkspace); got != `{"agent":"claude","model":"claude-custom"}` {
-		t.Fatalf("narration model config changed across toggle: %s", got)
-	}
+		d.store.SetSetting(SettingNotebookNarrateWorkspaceEnabled, "true")
+		d.enqueueNarrateWorkspace("ws-routine-on")
+		if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-routine-on") {
+			t.Fatal("narration must enqueue once its duty switch is on")
+		}
+		if got := d.store.GetSetting(SettingNotebookNarrateWorkspace); got != `{"agent":"claude","model":"claude-custom"}` {
+			t.Fatalf("narration model config changed across toggle: %s", got)
+		}
+	})
 }
 
 // TestNotebookTasksDisabledSkipsEnqueue proves the master switch gates the
@@ -137,26 +144,29 @@ func TestNotebookNarrationDisabledOnlySkipsNarration(t *testing.T) {
 // a workspace narrate create no durable record at all; flipping it back on (here via
 // the default-ON unset) restores enqueueing.
 func TestNotebookTasksDisabledSkipsEnqueue(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	installNotebookNarrationRunner(t, d)
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		installNotebookNarrationRunner(t, d)
 
-	d.store.SetSetting(SettingNotebookTasksEnabled, "false")
-	d.enqueueSummarizeSession("session-off", "", "")
-	d.enqueueNarrateWorkspace("ws-off")
-	// The gate returns synchronously without touching the runner, so an immediate
-	// Get is authoritative — no record was created.
-	assertNoTask(t, d, notebookSummarizeSessionKind, "session-off")
-	assertNoTask(t, d, notebookNarrateWorkspaceKind, "ws-off")
+		d.store.SetSetting(SettingNotebookTasksEnabled, "false")
+		d.enqueueSummarizeSession("session-off", "", "")
+		d.enqueueNarrateWorkspace("ws-off")
+		// The gate returns synchronously without touching the runner, so an immediate
+		// Get is authoritative — no record was created.
+		assertNoTask(t, d, notebookSummarizeSessionKind, "session-off")
+		assertNoTask(t, d, notebookNarrateWorkspaceKind, "ws-off")
 
-	d.store.SetSetting(SettingNotebookTasksEnabled, "true")
-	d.enqueueSummarizeSession("session-on", "", "")
-	d.enqueueNarrateWorkspace("ws-on")
-	if !taskExists(t, d, notebookSummarizeSessionKind, "session-on") {
-		t.Fatal("summarize must enqueue once the master switch is on")
-	}
-	if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-on") {
-		t.Fatal("narrate must enqueue once the master switch is on")
-	}
+		d.store.SetSetting(SettingNotebookTasksEnabled, "true")
+		d.enqueueSummarizeSession("session-on", "", "")
+		d.enqueueNarrateWorkspace("ws-on")
+		if !taskExists(t, d, notebookSummarizeSessionKind, "session-on") {
+			t.Fatal("summarize must enqueue once the master switch is on")
+		}
+		if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-on") {
+			t.Fatal("narrate must enqueue once the master switch is on")
+		}
+	})
 }
 
 // TestNotebookTasksDisabledExecutorNoOps proves the master switch is also honored at
@@ -164,55 +174,64 @@ func TestNotebookTasksDisabledSkipsEnqueue(t *testing.T) {
 // directly past the enqueue gate) is retired as a no-op success without invoking the
 // agent, so a stale queued run cannot fire background work after the toggle is off.
 func TestNotebookTasksDisabledExecutorNoOps(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	installNotebookNarrationRunner(t, d)
-	d.store.SetSetting(SettingNotebookTasksEnabled, "false")
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		installNotebookNarrationRunner(t, d)
+		d.store.SetSetting(SettingNotebookTasksEnabled, "false")
 
-	d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		t.Fatal("summarize executor ran the agent while the master switch was off")
-		return agentdriver.HeadlessTaskResult{}, nil
-	}
+		d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			t.Fatal("summarize executor ran the agent while the master switch was off")
+			return agentdriver.HeadlessTaskResult{}, nil
+		}
 
-	if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{UniqueKey: "session-1"}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	waitForTaskState(t, d, notebookSummarizeSessionKind, "session-1", jobs.StateDone)
+		if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{UniqueKey: "session-1"}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		requireTaskState(t, d, notebookSummarizeSessionKind, "session-1", jobs.StateDone)
+	})
 }
 
 // TestNotebookSummariesDisabledExecutorNoOps covers the queued-before-toggle
 // case: the durable record completes without spawning a headless agent.
 func TestNotebookSummariesDisabledExecutorNoOps(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	installNotebookNarrationRunner(t, d)
-	d.store.SetSetting(SettingNotebookSummarizeSessionEnabled, "false")
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		installNotebookNarrationRunner(t, d)
+		d.store.SetSetting(SettingNotebookSummarizeSessionEnabled, "false")
 
-	d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		t.Fatal("summarize executor ran the agent while session summaries were off")
-		return agentdriver.HeadlessTaskResult{}, nil
-	}
+		d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			t.Fatal("summarize executor ran the agent while session summaries were off")
+			return agentdriver.HeadlessTaskResult{}, nil
+		}
 
-	if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{UniqueKey: "session-1"}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	waitForTaskState(t, d, notebookSummarizeSessionKind, "session-1", jobs.StateDone)
+		if _, err := d.jobQueue.Enqueue(notebookSummarizeSessionKind, jobs.EnqueueOptions{UniqueKey: "session-1"}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		requireTaskState(t, d, notebookSummarizeSessionKind, "session-1", jobs.StateDone)
+	})
 }
 
 // TestNotebookNarrationDisabledExecutorNoOps covers the queued-before-toggle
 // case: the durable record completes without spawning a headless agent.
 func TestNotebookNarrationDisabledExecutorNoOps(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	installNotebookNarrationRunner(t, d)
-	d.store.SetSetting(SettingNotebookNarrateWorkspaceEnabled, "false")
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		installNotebookNarrationRunner(t, d)
+		d.store.SetSetting(SettingNotebookNarrateWorkspaceEnabled, "false")
 
-	d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
-		t.Fatal("narrate executor ran the agent while journal narration was off")
-		return agentdriver.HeadlessTaskResult{}, nil
-	}
+		d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			t.Fatal("narrate executor ran the agent while journal narration was off")
+			return agentdriver.HeadlessTaskResult{}, nil
+		}
 
-	if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{UniqueKey: "ws-1"}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	waitForTaskState(t, d, notebookNarrateWorkspaceKind, "ws-1", jobs.StateDone)
+		if _, err := d.jobQueue.Enqueue(notebookNarrateWorkspaceKind, jobs.EnqueueOptions{UniqueKey: "ws-1"}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		requireTaskState(t, d, notebookNarrateWorkspaceKind, "ws-1", jobs.StateDone)
+	})
 }
 
 // assertNoTask fails if a record exists for the given kind/subject. Unlike

--- a/internal/daemon/nudge_countdown_test.go
+++ b/internal/daemon/nudge_countdown_test.go
@@ -31,29 +31,27 @@ func currentNudgeDeadline(d *Daemon, sessionID string) time.Time {
 	return time.Time{}
 }
 
-func waitForNudgeDeadline(t *testing.T, d *Daemon, sessionID string) time.Time {
-	t.Helper()
-	limit := time.Now().Add(time.Second)
-	for time.Now().Before(limit) {
-		if deadline := currentNudgeDeadline(d, sessionID); !deadline.IsZero() {
-			return deadline
-		}
-		time.Sleep(time.Millisecond)
-	}
-	t.Fatalf("no nudge deadline armed for %s", sessionID)
-	return time.Time{}
-}
-
-// settledNudgeDeadline is waitForNudgeDeadline for a synctest bubble: arming can
-// happen on another goroutine, so settle the bubble first and then read the
-// deadline once. A missing deadline here means nothing is going to arm one, not
-// that the poll was early.
+// settledNudgeDeadline reads a session's armed countdown deadline inside a
+// synctest bubble: arming can happen on another goroutine, so settle the bubble
+// first and then read the deadline once. A missing deadline here means nothing is
+// going to arm one, not that the poll was early.
 func settledNudgeDeadline(t *testing.T, d *Daemon, sessionID string) time.Time {
 	t.Helper()
 	synctest.Wait()
 	deadline := currentNudgeDeadline(d, sessionID)
 	if deadline.IsZero() {
 		t.Fatalf("no nudge deadline armed for %s once the daemon settled", sessionID)
+	}
+	return deadline
+}
+
+// settledNudgeDeadlineBefore is settledNudgeDeadline for the pull-forward case:
+// the deadline that matters is not merely armed, it has moved ahead of a bound.
+func settledNudgeDeadlineBefore(t *testing.T, d *Daemon, sessionID string, before time.Time) time.Time {
+	t.Helper()
+	deadline := settledNudgeDeadline(t, d, sessionID)
+	if !deadline.Before(before) {
+		t.Fatalf("%s deadline = %s, want before %s", sessionID, deadline, before)
 	}
 	return deadline
 }
@@ -271,6 +269,9 @@ func TestNudgeCountdownCancelsOnPendingApproval(t *testing.T) {
 	}
 }
 
+// Boundary-bound: the fence being tested is doorbellMu, and the state goroutine
+// proves it by parking on that mutex. A bubble cannot see a goroutine waiting
+// for a lock, so it has no way to say "held" rather than "not yet run".
 func TestDoorbellWriteDoesNotInterleaveWithPendingApproval(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	sessionID := "doorbell-state-fence"

--- a/internal/daemon/plugin_driver_test.go
+++ b/internal/daemon/plugin_driver_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
@@ -502,48 +503,48 @@ func TestPluginDriverReports_StateStopAndMetadataAreOwnedByRegisteredAgent(t *te
 }
 
 func TestPluginReportedStateFlushesDeferredTicketNudge(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.nudgeWindowOverride = time.Hour
-	t.Cleanup(d.stopNudgeCountdowns)
-	_, sessionID, inputs := delegateForNotify(t, d, "codex")
-	ticketID := boundTicketID(t, d, sessionID)
-	setSessionAgent(t, d, sessionID, protocol.SessionAgent("snipe"))
-	if !d.store.BeginAgentDriverRun(sessionID, "snipe-plugin", "run-nudge") {
-		t.Fatal("failed to begin plugin driver run")
-	}
+	base := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		d := base
+		d.nudgeWindowOverride = time.Hour
+		stopDaemonBackground(t, d)
+		_, sessionID, inputs := delegateForNotify(t, d, "codex")
+		ticketID := boundTicketID(t, d, sessionID)
+		setSessionAgent(t, d, sessionID, protocol.SessionAgent("snipe"))
+		if !d.store.BeginAgentDriverRun(sessionID, "snipe-plugin", "run-nudge") {
+			t.Fatal("failed to begin plugin driver run")
+		}
 
-	if !d.applyPluginReportedState(pluginReportStateParams{
-		SessionID: sessionID,
-		RunID:     "run-nudge",
-		Seq:       1,
-		State:     protocol.StatePendingApproval,
-	}) {
-		t.Fatal("pending approval plugin report was rejected")
-	}
-	commentOnTicket(t, d, ticketID, "review this update")
-	if currentNudgeTimer(d, sessionID) != nil {
-		t.Fatal("pending approval plugin session armed a countdown")
-	}
+		if !d.applyPluginReportedState(pluginReportStateParams{
+			SessionID: sessionID,
+			RunID:     "run-nudge",
+			Seq:       1,
+			State:     protocol.StatePendingApproval,
+		}) {
+			t.Fatal("pending approval plugin report was rejected")
+		}
+		commentOnTicket(t, d, ticketID, "review this update")
+		if currentNudgeTimer(d, sessionID) != nil {
+			t.Fatal("pending approval plugin session armed a countdown")
+		}
 
-	if !d.applyPluginReportedState(pluginReportStateParams{
-		SessionID: sessionID,
-		RunID:     "run-nudge",
-		Seq:       2,
-		State:     protocol.StateWorking,
-	}) {
-		t.Fatal("working plugin report was rejected")
-	}
-	deadline := time.Now().Add(time.Second)
-	for currentNudgeTimer(d, sessionID) == nil && time.Now().Before(deadline) {
-		time.Sleep(time.Millisecond)
-	}
-	if currentNudgeTimer(d, sessionID) == nil {
-		t.Fatal("eligible plugin state did not re-arm the deferred nudge")
-	}
-	fireNudgeNow(t, d, sessionID)
-	if !wasNudged(inputs(sessionID)) {
-		t.Fatal("eligible plugin session was not nudged after approval cleared")
-	}
+		if !d.applyPluginReportedState(pluginReportStateParams{
+			SessionID: sessionID,
+			RunID:     "run-nudge",
+			Seq:       2,
+			State:     protocol.StateWorking,
+		}) {
+			t.Fatal("working plugin report was rejected")
+		}
+		synctest.Wait()
+		if currentNudgeTimer(d, sessionID) == nil {
+			t.Fatal("eligible plugin state did not re-arm the deferred nudge")
+		}
+		fireNudgeNow(t, d, sessionID)
+		if !wasNudged(inputs(sessionID)) {
+			t.Fatal("eligible plugin session was not nudged after approval cleared")
+		}
+	})
 }
 
 func TestPluginDriverReports_ReregisteredAgentCannotTakeOverActiveRun(t *testing.T) {

--- a/internal/daemon/plugin_rpc_test.go
+++ b/internal/daemon/plugin_rpc_test.go
@@ -7,135 +7,133 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
 )
 
 func TestDaemon_HandleConnection_LegacySocketMessageStillWorks(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	serverConn, clientConn := net.Pipe()
-	defer clientConn.Close()
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		serverConn, clientConn := net.Pipe()
+		defer clientConn.Close()
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		d.handleConnection(serverConn)
-	}()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			d.handleConnection(serverConn)
+		}()
 
-	heartbeatPayload, err := json.Marshal(protocol.HeartbeatMessage{
-		Cmd: protocol.CmdHeartbeat,
-		ID:  "legacy-session",
+		heartbeatPayload, err := json.Marshal(protocol.HeartbeatMessage{
+			Cmd: protocol.CmdHeartbeat,
+			ID:  "legacy-session",
+		})
+		if err != nil {
+			t.Fatalf("marshal legacy heartbeat: %v", err)
+		}
+		if _, err := clientConn.Write(heartbeatPayload); err != nil {
+			t.Fatalf("write legacy heartbeat: %v", err)
+		}
+
+		var resp protocol.Response
+		if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
+			t.Fatalf("decode legacy heartbeat response: %v", err)
+		}
+		if !resp.Ok {
+			t.Fatalf("legacy heartbeat response ok=%v, want true", resp.Ok)
+		}
+
+		requireDone(t, done, "legacy connection did not finish")
 	})
-	if err != nil {
-		t.Fatalf("marshal legacy heartbeat: %v", err)
-	}
-	if _, err := clientConn.Write(heartbeatPayload); err != nil {
-		t.Fatalf("write legacy heartbeat: %v", err)
-	}
-
-	var resp protocol.Response
-	if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
-		t.Fatalf("decode legacy heartbeat response: %v", err)
-	}
-	if !resp.Ok {
-		t.Fatalf("legacy heartbeat response ok=%v, want true", resp.Ok)
-	}
-
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("legacy connection did not finish")
-	}
 }
 
 func TestDaemon_HandleConnection_PluginHelloRegistersLongLivedConnection(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.pluginDir = filepath.Join(t.TempDir(), "plugins")
-	writeTestPluginManifest(t, d.pluginDir, "worktree-provider")
-	serverConn, clientConn := net.Pipe()
-	defer clientConn.Close()
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		d.pluginDir = filepath.Join(t.TempDir(), "plugins")
+		writeTestPluginManifest(t, d.pluginDir, "worktree-provider")
+		serverConn, clientConn := net.Pipe()
+		defer clientConn.Close()
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		d.handleConnection(serverConn)
-	}()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			d.handleConnection(serverConn)
+		}()
 
-	sendPluginHello(t, clientConn, "worktree-provider")
-	helloResp := decodeJSONRPCMessage(t, clientConn)
-	if helloResp.Error != nil {
-		t.Fatalf("hello error = %#v, want nil", helloResp.Error)
-	}
-	var result pluginHelloResult
-	if err := json.Unmarshal(helloResp.Result, &result); err != nil {
-		t.Fatalf("decode hello result: %v", err)
-	}
-	if !result.OK {
-		t.Fatal("hello result ok=false, want true")
-	}
-	if got := d.plugins.get("worktree-provider"); got == nil {
-		t.Fatal("plugin registry missing worktree-provider after hello")
-	}
-	assertPluginConnectionBroadcast(t, readPluginUpdatedBroadcast(t, d), true)
+		sendPluginHello(t, clientConn, "worktree-provider")
+		helloResp := decodeJSONRPCMessage(t, clientConn)
+		if helloResp.Error != nil {
+			t.Fatalf("hello error = %#v, want nil", helloResp.Error)
+		}
+		var result pluginHelloResult
+		if err := json.Unmarshal(helloResp.Result, &result); err != nil {
+			t.Fatalf("decode hello result: %v", err)
+		}
+		if !result.OK {
+			t.Fatal("hello result ok=false, want true")
+		}
+		if got := d.plugins.get("worktree-provider"); got == nil {
+			t.Fatal("plugin registry missing worktree-provider after hello")
+		}
+		assertPluginConnectionBroadcast(t, readPluginUpdatedBroadcast(t, d), true)
 
-	_ = clientConn.Close()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("plugin connection did not close after client disconnect")
-	}
-	assertPluginConnectionBroadcast(t, readPluginUpdatedBroadcast(t, d), false)
+		_ = clientConn.Close()
+		requireDone(t, done, "plugin connection did not close after client disconnect")
+		assertPluginConnectionBroadcast(t, readPluginUpdatedBroadcast(t, d), false)
+	})
 }
 
 func TestDaemon_HandleConnection_PluginHelloCanArriveAcrossWrites(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	serverConn, clientConn := net.Pipe()
-	defer clientConn.Close()
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		serverConn, clientConn := net.Pipe()
+		defer clientConn.Close()
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		d.handleConnection(serverConn)
-	}()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			d.handleConnection(serverConn)
+		}()
 
-	payload, err := json.Marshal(jsonRPCMessage{
-		JSONRPC: "2.0",
-		ID:      json.RawMessage("1"),
-		Method:  "hello",
-		Params: mustMarshalPluginHelloParams(t, pluginHelloParams{
-			Name:           "split-provider",
-			Version:        "0.1.0",
-			AttnAPIVersion: pluginAPIVersion,
-			Generation:     1,
-		}),
+		payload, err := json.Marshal(jsonRPCMessage{
+			JSONRPC: "2.0",
+			ID:      json.RawMessage("1"),
+			Method:  "hello",
+			Params: mustMarshalPluginHelloParams(t, pluginHelloParams{
+				Name:           "split-provider",
+				Version:        "0.1.0",
+				AttnAPIVersion: pluginAPIVersion,
+				Generation:     1,
+			}),
+		})
+		if err != nil {
+			t.Fatalf("marshal split hello: %v", err)
+		}
+
+		splitAt := len(payload) / 2
+		if _, err := clientConn.Write(payload[:splitAt]); err != nil {
+			t.Fatalf("write first hello fragment: %v", err)
+		}
+		if _, err := clientConn.Write(payload[splitAt:]); err != nil {
+			t.Fatalf("write second hello fragment: %v", err)
+		}
+
+		resp := decodeJSONRPCMessage(t, clientConn)
+		if resp.Error != nil {
+			t.Fatalf("split hello error=%#v, want nil", resp.Error)
+		}
+		if got := d.plugins.get("split-provider"); got == nil {
+			t.Fatal("plugin registry missing split-provider after fragmented hello")
+		}
+
+		_ = clientConn.Close()
+		requireDone(t, done, "fragmented plugin connection did not close after client disconnect")
 	})
-	if err != nil {
-		t.Fatalf("marshal split hello: %v", err)
-	}
-
-	splitAt := len(payload) / 2
-	if _, err := clientConn.Write(payload[:splitAt]); err != nil {
-		t.Fatalf("write first hello fragment: %v", err)
-	}
-	if _, err := clientConn.Write(payload[splitAt:]); err != nil {
-		t.Fatalf("write second hello fragment: %v", err)
-	}
-
-	resp := decodeJSONRPCMessage(t, clientConn)
-	if resp.Error != nil {
-		t.Fatalf("split hello error=%#v, want nil", resp.Error)
-	}
-	if got := d.plugins.get("split-provider"); got == nil {
-		t.Fatal("plugin registry missing split-provider after fragmented hello")
-	}
-
-	_ = clientConn.Close()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("fragmented plugin connection did not close after client disconnect")
-	}
 }
 
 func TestParsePluginHelloRejectsOldAPIAndMissingGeneration(t *testing.T) {
@@ -184,80 +182,82 @@ func TestParsePluginHelloRejectsOldAPIAndMissingGeneration(t *testing.T) {
 }
 
 func TestDaemon_PluginConnectionGenerationDrivesDisconnectRecovery(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	clock := newFakePluginClock()
-	launcher := &fakePluginLauncher{}
-	d.pluginSupervisor = newTestPluginSupervisor(clock, launcher)
-	if err := d.pluginSupervisor.Ensure(pluginManifest{Name: "supervised"}); err != nil {
-		t.Fatalf("Ensure: %v", err)
-	}
-	initial, _ := d.pluginSupervisor.Snapshot("supervised")
-	client, done := startPluginPipeGeneration(t, d, "supervised", nil, initial.Generation)
-	connected, _ := d.pluginSupervisor.Snapshot("supervised")
-	if connected.Phase != pluginPhaseConnected {
-		t.Fatalf("phase=%q after hello, want connected", connected.Phase)
-	}
-	_ = client.Close()
-	<-done
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		clock := newFakePluginClock()
+		launcher := &fakePluginLauncher{}
+		d.pluginSupervisor = newTestPluginSupervisor(t, clock, launcher)
+		if err := d.pluginSupervisor.Ensure(pluginManifest{Name: "supervised"}); err != nil {
+			t.Fatalf("Ensure: %v", err)
+		}
+		initial, _ := d.pluginSupervisor.Snapshot("supervised")
+		client, done := startPluginPipeGeneration(t, d, "supervised", nil, initial.Generation)
+		connected, _ := d.pluginSupervisor.Snapshot("supervised")
+		if connected.Phase != pluginPhaseConnected {
+			t.Fatalf("phase=%q after hello, want connected", connected.Phase)
+		}
+		_ = client.Close()
+		<-done
 
-	clock.Advance(pluginDisconnectGrace)
-	waitForSupervisor(t, func() bool {
-		snapshot, _ := d.pluginSupervisor.Snapshot("supervised")
-		return snapshot.Phase == pluginPhaseBackoff
+		clock.Advance(pluginDisconnectGrace)
+		requireSupervisor(t, func() bool {
+			snapshot, _ := d.pluginSupervisor.Snapshot("supervised")
+			return snapshot.Phase == pluginPhaseBackoff
+		}, "the expired disconnect grace did not land the plugin in backoff")
+		clock.Advance(pluginRestartBackoff[0])
+		requireSupervisor(t, func() bool { return launcher.count() == 2 }, "the elapsed backoff did not restart the plugin")
+		restarted, _ := d.pluginSupervisor.Snapshot("supervised")
+		if restarted.Generation == initial.Generation {
+			t.Fatal("restart did not advance generation")
+		}
+
+		serverConn, staleConn := net.Pipe()
+		staleDone := make(chan struct{})
+		go func() {
+			defer close(staleDone)
+			d.handleConnection(serverConn)
+		}()
+		sendPluginHelloWithGeneration(t, staleConn, "supervised", nil, initial.Generation)
+		if response := decodeJSONRPCMessage(t, staleConn); response.Error == nil {
+			t.Fatal("stale generation hello succeeded")
+		}
+		_ = staleConn.Close()
+		<-staleDone
+
+		current, currentDone := startPluginPipeGeneration(t, d, "supervised", nil, restarted.Generation)
+		d.pluginSupervisor.Stop("supervised", pluginStopRemove)
+		_ = current.Close()
+		<-currentDone
 	})
-	clock.Advance(pluginRestartBackoff[0])
-	waitForSupervisor(t, func() bool { return launcher.count() == 2 })
-	restarted, _ := d.pluginSupervisor.Snapshot("supervised")
-	if restarted.Generation == initial.Generation {
-		t.Fatal("restart did not advance generation")
-	}
-
-	serverConn, staleConn := net.Pipe()
-	staleDone := make(chan struct{})
-	go func() {
-		defer close(staleDone)
-		d.handleConnection(serverConn)
-	}()
-	sendPluginHelloWithGeneration(t, staleConn, "supervised", nil, initial.Generation)
-	if response := decodeJSONRPCMessage(t, staleConn); response.Error == nil {
-		t.Fatal("stale generation hello succeeded")
-	}
-	_ = staleConn.Close()
-	<-staleDone
-
-	current, currentDone := startPluginPipeGeneration(t, d, "supervised", nil, restarted.Generation)
-	d.pluginSupervisor.Stop("supervised", pluginStopRemove)
-	_ = current.Close()
-	<-currentDone
 }
 
 func TestDaemon_HandleConnection_PluginHelloRegistersSurfaces(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	serverConn, clientConn := net.Pipe()
-	defer clientConn.Close()
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		serverConn, clientConn := net.Pipe()
+		defer clientConn.Close()
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		d.handleConnection(serverConn)
-	}()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			d.handleConnection(serverConn)
+		}()
 
-	sendPluginHelloWithSurfaces(t, clientConn, "hello-provider", []string{"worktree.create"})
-	if resp := decodeJSONRPCMessage(t, clientConn); resp.Error != nil {
-		t.Fatalf("provider hello error=%#v, want nil", resp.Error)
-	}
+		sendPluginHelloWithSurfaces(t, clientConn, "hello-provider", []string{"worktree.create"})
+		if resp := decodeJSONRPCMessage(t, clientConn); resp.Error != nil {
+			t.Fatalf("provider hello error=%#v, want nil", resp.Error)
+		}
 
-	handlers := d.plugins.handlersForSurface("worktree.create")
-	if len(handlers) != 1 || handlers[0].PluginName != "hello-provider" {
-		t.Fatalf("worktree.create handlers=%v, want hello-provider only", handlers)
-	}
+		handlers := d.plugins.handlersForSurface("worktree.create")
+		if len(handlers) != 1 || handlers[0].PluginName != "hello-provider" {
+			t.Fatalf("worktree.create handlers=%v, want hello-provider only", handlers)
+		}
 
-	_ = clientConn.Close()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("provider plugin connection did not close after client disconnect")
-	}
+		_ = clientConn.Close()
+		requireDone(t, done, "provider plugin connection did not close after client disconnect")
+	})
 }
 
 func TestPluginRegistry_OrdersHandlersByUserPriority(t *testing.T) {
@@ -291,202 +291,191 @@ func TestPluginRegistry_OrdersHandlersByUserPriority(t *testing.T) {
 }
 
 func TestDaemon_HandleConnection_PluginHelloRejectsUnknownSurface(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	serverConn, clientConn := net.Pipe()
-	defer clientConn.Close()
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		serverConn, clientConn := net.Pipe()
+		defer clientConn.Close()
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		d.handleConnection(serverConn)
-	}()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			d.handleConnection(serverConn)
+		}()
 
-	sendPluginHelloWithSurfaces(t, clientConn, "typo-provider", []string{"worktree.cretae"})
-	resp := decodeJSONRPCMessage(t, clientConn)
-	if resp.Error == nil {
-		t.Fatal("unknown surface hello error=nil, want rejection")
-	}
-	if got := d.plugins.get("typo-provider"); got != nil {
-		t.Fatalf("typo provider registered unexpectedly: %#v", got)
-	}
+		sendPluginHelloWithSurfaces(t, clientConn, "typo-provider", []string{"worktree.cretae"})
+		resp := decodeJSONRPCMessage(t, clientConn)
+		if resp.Error == nil {
+			t.Fatal("unknown surface hello error=nil, want rejection")
+		}
+		if got := d.plugins.get("typo-provider"); got != nil {
+			t.Fatalf("typo provider registered unexpectedly: %#v", got)
+		}
 
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("unknown surface connection did not close")
-	}
+		requireDone(t, done, "unknown surface connection did not close")
+	})
 }
 
 func TestDaemon_CallPlugin_RoundTripsRequestAndResponse(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	serverConn, clientConn := net.Pipe()
-	defer clientConn.Close()
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		serverConn, clientConn := net.Pipe()
+		defer clientConn.Close()
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		d.handleConnection(serverConn)
-	}()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			d.handleConnection(serverConn)
+		}()
 
-	sendPluginHello(t, clientConn, "probe-plugin")
-	helloResp := decodeJSONRPCMessage(t, clientConn)
-	if helloResp.Error != nil {
-		t.Fatalf("hello error = %#v, want nil", helloResp.Error)
-	}
-
-	type probeResult struct {
-		Accepted bool `json:"accepted"`
-	}
-	resultCh := make(chan error, 1)
-	var result probeResult
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		resultCh <- d.callPlugin(ctx, "probe-plugin", "transport.probe", map[string]string{"kind": "roundtrip"}, &result)
-	}()
-
-	request := decodeJSONRPCMessage(t, clientConn)
-	if request.Method != "transport.probe" {
-		t.Fatalf("plugin request method=%q, want transport.probe", request.Method)
-	}
-	var params map[string]string
-	if err := json.Unmarshal(request.Params, &params); err != nil {
-		t.Fatalf("decode plugin request params: %v", err)
-	}
-	if got := params["kind"]; got != "roundtrip" {
-		t.Fatalf("plugin request params.kind=%q, want roundtrip", got)
-	}
-
-	responseResult, err := json.Marshal(probeResult{Accepted: true})
-	if err != nil {
-		t.Fatalf("marshal plugin response result: %v", err)
-	}
-	if err := json.NewEncoder(clientConn).Encode(jsonRPCMessage{
-		JSONRPC: "2.0",
-		ID:      request.ID,
-		Result:  responseResult,
-	}); err != nil {
-		t.Fatalf("encode plugin response: %v", err)
-	}
-
-	select {
-	case err := <-resultCh:
-		if err != nil {
-			t.Fatalf("callPlugin error: %v", err)
+		sendPluginHello(t, clientConn, "probe-plugin")
+		helloResp := decodeJSONRPCMessage(t, clientConn)
+		if helloResp.Error != nil {
+			t.Fatalf("hello error = %#v, want nil", helloResp.Error)
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("callPlugin did not complete")
-	}
-	if !result.Accepted {
-		t.Fatal("callPlugin result accepted=false, want true")
-	}
 
-	_ = clientConn.Close()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("plugin connection did not close after round trip")
-	}
+		type probeResult struct {
+			Accepted bool `json:"accepted"`
+		}
+		resultCh := make(chan error, 1)
+		var result probeResult
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			resultCh <- d.callPlugin(ctx, "probe-plugin", "transport.probe", map[string]string{"kind": "roundtrip"}, &result)
+		}()
+
+		request := decodeJSONRPCMessage(t, clientConn)
+		if request.Method != "transport.probe" {
+			t.Fatalf("plugin request method=%q, want transport.probe", request.Method)
+		}
+		var params map[string]string
+		if err := json.Unmarshal(request.Params, &params); err != nil {
+			t.Fatalf("decode plugin request params: %v", err)
+		}
+		if got := params["kind"]; got != "roundtrip" {
+			t.Fatalf("plugin request params.kind=%q, want roundtrip", got)
+		}
+
+		responseResult, err := json.Marshal(probeResult{Accepted: true})
+		if err != nil {
+			t.Fatalf("marshal plugin response result: %v", err)
+		}
+		if err := json.NewEncoder(clientConn).Encode(jsonRPCMessage{
+			JSONRPC: "2.0",
+			ID:      request.ID,
+			Result:  responseResult,
+		}); err != nil {
+			t.Fatalf("encode plugin response: %v", err)
+		}
+
+		synctest.Wait()
+		select {
+		case err := <-resultCh:
+			if err != nil {
+				t.Fatalf("callPlugin error: %v", err)
+			}
+		default:
+			t.Fatal("callPlugin did not complete")
+		}
+		if !result.Accepted {
+			t.Fatal("callPlugin result accepted=false, want true")
+		}
+
+		_ = clientConn.Close()
+		requireDone(t, done, "plugin connection did not close after round trip")
+	})
 }
 
 func TestDaemon_Surfaces_OrderHandlersAndCleanUpOnDisconnect(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
 
-	lowClient, lowDone := startPluginPipe(t, d, "alpha-provider", []string{"worktree.create", "worktree.delete"})
-	defer lowClient.Close()
-	highClient, highDone := startPluginPipe(t, d, "zeta-provider", []string{"worktree.create"})
-	defer highClient.Close()
+		lowClient, lowDone := startPluginPipe(t, d, "alpha-provider", []string{"worktree.create", "worktree.delete"})
+		defer lowClient.Close()
+		highClient, highDone := startPluginPipe(t, d, "zeta-provider", []string{"worktree.create"})
+		defer highClient.Close()
 
-	handlers := d.plugins.handlersForSurface("worktree.create")
-	if len(handlers) != 2 {
-		t.Fatalf("worktree.create handler count=%d, want 2", len(handlers))
-	}
-	if handlers[0].PluginName != "alpha-provider" || handlers[1].PluginName != "zeta-provider" {
-		t.Fatalf("worktree.create handler order=%v, want alpha-provider then zeta-provider", handlers)
-	}
-	deleteHandlers := d.plugins.handlersForSurface("worktree.delete")
-	if len(deleteHandlers) != 1 || deleteHandlers[0].PluginName != "alpha-provider" {
-		t.Fatalf("worktree.delete handlers=%v, want alpha-provider only", deleteHandlers)
-	}
+		handlers := d.plugins.handlersForSurface("worktree.create")
+		if len(handlers) != 2 {
+			t.Fatalf("worktree.create handler count=%d, want 2", len(handlers))
+		}
+		if handlers[0].PluginName != "alpha-provider" || handlers[1].PluginName != "zeta-provider" {
+			t.Fatalf("worktree.create handler order=%v, want alpha-provider then zeta-provider", handlers)
+		}
+		deleteHandlers := d.plugins.handlersForSurface("worktree.delete")
+		if len(deleteHandlers) != 1 || deleteHandlers[0].PluginName != "alpha-provider" {
+			t.Fatalf("worktree.delete handlers=%v, want alpha-provider only", deleteHandlers)
+		}
 
-	_ = highClient.Close()
-	select {
-	case <-highDone:
-	case <-time.After(2 * time.Second):
-		t.Fatal("zeta provider connection did not close")
-	}
-	handlers = d.plugins.handlersForSurface("worktree.create")
-	if len(handlers) != 1 || handlers[0].PluginName != "alpha-provider" {
-		t.Fatalf("worktree.create handlers after disconnect=%v, want alpha-provider only", handlers)
-	}
+		_ = highClient.Close()
+		requireDone(t, highDone, "zeta provider connection did not close")
+		handlers = d.plugins.handlersForSurface("worktree.create")
+		if len(handlers) != 1 || handlers[0].PluginName != "alpha-provider" {
+			t.Fatalf("worktree.create handlers after disconnect=%v, want alpha-provider only", handlers)
+		}
 
-	_ = lowClient.Close()
-	select {
-	case <-lowDone:
-	case <-time.After(2 * time.Second):
-		t.Fatal("alpha provider connection did not close")
-	}
+		_ = lowClient.Close()
+		requireDone(t, lowDone, "alpha provider connection did not close")
+	})
 }
 
 func TestDaemon_PluginHealthCheckRecordsStatus(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.pluginDir = filepath.Join(t.TempDir(), "plugins")
-	writeTestPluginManifest(t, d.pluginDir, "health-provider")
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		d.pluginDir = filepath.Join(t.TempDir(), "plugins")
+		writeTestPluginManifest(t, d.pluginDir, "health-provider")
 
-	client, done := startPluginPipe(t, d, "health-provider", []string{"worktree.create"})
-	defer client.Close()
+		client, done := startPluginPipe(t, d, "health-provider", []string{"worktree.create"})
+		defer client.Close()
 
-	plugin := d.plugins.get("health-provider")
-	if plugin == nil {
-		t.Fatal("plugin registry missing health-provider")
-	}
-
-	healthDone := make(chan struct{})
-	go func() {
-		defer close(healthDone)
-		request := decodeJSONRPCMessage(t, client)
-		if request.Method != pluginHealthMethod {
-			t.Errorf("health method=%q, want %s", request.Method, pluginHealthMethod)
-			return
+		plugin := d.plugins.get("health-provider")
+		if plugin == nil {
+			t.Fatal("plugin registry missing health-provider")
 		}
-		result, err := json.Marshal(pluginHealthResult{OK: true})
-		if err != nil {
-			t.Errorf("marshal health result: %v", err)
-			return
+
+		healthDone := make(chan struct{})
+		go func() {
+			defer close(healthDone)
+			request := decodeJSONRPCMessage(t, client)
+			if request.Method != pluginHealthMethod {
+				t.Errorf("health method=%q, want %s", request.Method, pluginHealthMethod)
+				return
+			}
+			result, err := json.Marshal(pluginHealthResult{OK: true})
+			if err != nil {
+				t.Errorf("marshal health result: %v", err)
+				return
+			}
+			if err := json.NewEncoder(client).Encode(jsonRPCMessage{
+				JSONRPC: "2.0",
+				ID:      request.ID,
+				Result:  result,
+			}); err != nil {
+				t.Errorf("encode health result: %v", err)
+			}
+		}()
+
+		d.checkPluginHealth(plugin)
+		requireDone(t, healthDone, "health request did not complete")
+
+		plugins := d.pluginsUpdatedMessage().Plugins
+		if len(plugins) != 1 {
+			t.Fatalf("plugin count=%d, want 1", len(plugins))
 		}
-		if err := json.NewEncoder(client).Encode(jsonRPCMessage{
-			JSONRPC: "2.0",
-			ID:      request.ID,
-			Result:  result,
-		}); err != nil {
-			t.Errorf("encode health result: %v", err)
+		if got := protocol.Deref(plugins[0].HealthStatus); got != "healthy" {
+			t.Fatalf("health status=%q, want healthy", got)
 		}
-	}()
+		if protocol.Deref(plugins[0].LastHealthAt) == "" {
+			t.Fatal("last health timestamp empty")
+		}
 
-	d.checkPluginHealth(plugin)
-	select {
-	case <-healthDone:
-	case <-time.After(2 * time.Second):
-		t.Fatal("health request did not complete")
-	}
-
-	plugins := d.pluginsUpdatedMessage().Plugins
-	if len(plugins) != 1 {
-		t.Fatalf("plugin count=%d, want 1", len(plugins))
-	}
-	if got := protocol.Deref(plugins[0].HealthStatus); got != "healthy" {
-		t.Fatalf("health status=%q, want healthy", got)
-	}
-	if protocol.Deref(plugins[0].LastHealthAt) == "" {
-		t.Fatal("last health timestamp empty")
-	}
-
-	_ = client.Close()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("health provider connection did not close")
-	}
+		_ = client.Close()
+		requireDone(t, done, "health provider connection did not close")
+	})
 }
 
 func startPluginPipe(t *testing.T, d *Daemon, name string, surfaces []string) (net.Conn, <-chan struct{}) {
@@ -560,6 +549,7 @@ func mustMarshalPluginHelloParams(t *testing.T, params pluginHelloParams) json.R
 
 func readPluginUpdatedBroadcast(t *testing.T, d *Daemon) map[string]interface{} {
 	t.Helper()
+	synctest.Wait()
 	select {
 	case outbound := <-d.wsHub.broadcast:
 		var event map[string]interface{}
@@ -570,8 +560,8 @@ func readPluginUpdatedBroadcast(t *testing.T, d *Daemon) map[string]interface{} 
 			t.Fatalf("plugin broadcast event=%v, want %q", event["event"], protocol.EventPluginsUpdated)
 		}
 		return event
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for plugins_updated broadcast")
+	default:
+		t.Fatal("no plugins_updated broadcast was published")
 		return nil
 	}
 }

--- a/internal/daemon/plugin_supervisor_test.go
+++ b/internal/daemon/plugin_supervisor_test.go
@@ -7,208 +7,224 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
 func TestPluginSupervisorRestartsExitsWithCappedBackoff(t *testing.T) {
-	clock := newFakePluginClock()
-	launcher := &fakePluginLauncher{}
-	supervisor := newTestPluginSupervisor(clock, launcher)
-	manifest := pluginManifest{Name: "fixture"}
+	synctest.Test(t, func(t *testing.T) {
+		clock := newFakePluginClock()
+		launcher := &fakePluginLauncher{}
+		supervisor := newTestPluginSupervisor(t, clock, launcher)
+		manifest := pluginManifest{Name: "fixture"}
 
-	if err := supervisor.Ensure(manifest); err != nil {
-		t.Fatalf("Ensure: %v", err)
-	}
-	for attempt := 1; attempt <= len(pluginRestartBackoff)+2; attempt++ {
-		handle := launcher.handle(attempt - 1)
-		handle.exit(pluginExit{ExitCode: intPtr(0)})
-		waitForSupervisor(t, func() bool {
+		if err := supervisor.Ensure(manifest); err != nil {
+			t.Fatalf("Ensure: %v", err)
+		}
+		for attempt := 1; attempt <= len(pluginRestartBackoff)+2; attempt++ {
+			handle := launcher.handle(attempt - 1)
+			handle.exit(pluginExit{ExitCode: intPtr(0)})
+			requireSupervisor(t, func() bool {
+				snapshot, _ := supervisor.Snapshot("fixture")
+				return snapshot.Phase == pluginPhaseBackoff && snapshot.RestartAttempt == attempt
+			}, fmt.Sprintf("exit %d did not land the plugin in backoff at that attempt", attempt))
 			snapshot, _ := supervisor.Snapshot("fixture")
-			return snapshot.Phase == pluginPhaseBackoff && snapshot.RestartAttempt == attempt
-		})
-		snapshot, _ := supervisor.Snapshot("fixture")
-		index := attempt - 1
-		if index >= len(pluginRestartBackoff) {
-			index = len(pluginRestartBackoff) - 1
+			index := attempt - 1
+			if index >= len(pluginRestartBackoff) {
+				index = len(pluginRestartBackoff) - 1
+			}
+			wantDelay := pluginRestartBackoff[index]
+			if got := snapshot.NextRestartAt.Sub(clock.Now()); got != wantDelay {
+				t.Fatalf("attempt %d delay=%s, want %s", attempt, got, wantDelay)
+			}
+			clock.Advance(wantDelay)
+			requireSupervisor(t, func() bool { return launcher.count() == attempt+1 },
+				fmt.Sprintf("the elapsed backoff did not start attempt %d", attempt+1))
 		}
-		wantDelay := pluginRestartBackoff[index]
-		if got := snapshot.NextRestartAt.Sub(clock.Now()); got != wantDelay {
-			t.Fatalf("attempt %d delay=%s, want %s", attempt, got, wantDelay)
-		}
-		clock.Advance(wantDelay)
-		waitForSupervisor(t, func() bool { return launcher.count() == attempt+1 })
-	}
+	})
 }
 
 func TestPluginSupervisorRetriesStartFailure(t *testing.T) {
-	clock := newFakePluginClock()
-	launcher := &fakePluginLauncher{startErrors: []error{errors.New("bun missing")}}
-	supervisor := newTestPluginSupervisor(clock, launcher)
+	synctest.Test(t, func(t *testing.T) {
+		clock := newFakePluginClock()
+		launcher := &fakePluginLauncher{startErrors: []error{errors.New("bun missing")}}
+		supervisor := newTestPluginSupervisor(t, clock, launcher)
 
-	if err := supervisor.Ensure(pluginManifest{Name: "fixture"}); err == nil {
-		t.Fatal("Ensure error=nil, want start failure")
-	}
-	snapshot, _ := supervisor.Snapshot("fixture")
-	if snapshot.Phase != pluginPhaseBackoff || snapshot.RestartAttempt != 1 || snapshot.LastExit == nil {
-		t.Fatalf("snapshot=%+v, want first backoff with exit", snapshot)
-	}
-	clock.Advance(250 * time.Millisecond)
-	waitForSupervisor(t, func() bool { return launcher.count() == 2 })
-	snapshot, _ = supervisor.Snapshot("fixture")
-	if snapshot.Phase != pluginPhaseStarting || !snapshot.Running {
-		t.Fatalf("snapshot=%+v, want restarted process", snapshot)
-	}
+		if err := supervisor.Ensure(pluginManifest{Name: "fixture"}); err == nil {
+			t.Fatal("Ensure error=nil, want start failure")
+		}
+		snapshot, _ := supervisor.Snapshot("fixture")
+		if snapshot.Phase != pluginPhaseBackoff || snapshot.RestartAttempt != 1 || snapshot.LastExit == nil {
+			t.Fatalf("snapshot=%+v, want first backoff with exit", snapshot)
+		}
+		clock.Advance(250 * time.Millisecond)
+		requireSupervisor(t, func() bool { return launcher.count() == 2 }, "the retry after a start failure never launched")
+		snapshot, _ = supervisor.Snapshot("fixture")
+		if snapshot.Phase != pluginPhaseStarting || !snapshot.Running {
+			t.Fatalf("snapshot=%+v, want restarted process", snapshot)
+		}
+	})
 }
 
 func TestPluginSupervisorResetsAttemptsOnlyAfterStableConnection(t *testing.T) {
-	clock := newFakePluginClock()
-	launcher := &fakePluginLauncher{}
-	supervisor := newTestPluginSupervisor(clock, launcher)
-	_ = supervisor.Ensure(pluginManifest{Name: "fixture"})
-	launcher.handle(0).exit(pluginExit{Error: "crash"})
-	waitForSupervisor(t, func() bool {
+	synctest.Test(t, func(t *testing.T) {
+		clock := newFakePluginClock()
+		launcher := &fakePluginLauncher{}
+		supervisor := newTestPluginSupervisor(t, clock, launcher)
+		_ = supervisor.Ensure(pluginManifest{Name: "fixture"})
+		launcher.handle(0).exit(pluginExit{Error: "crash"})
+		requireSupervisor(t, func() bool {
+			snapshot, _ := supervisor.Snapshot("fixture")
+			return snapshot.RestartAttempt == 1
+		}, "the crash did not record a restart attempt")
+		clock.Advance(250 * time.Millisecond)
+		requireSupervisor(t, func() bool { return launcher.count() == 2 }, "the elapsed backoff did not restart the plugin")
 		snapshot, _ := supervisor.Snapshot("fixture")
-		return snapshot.RestartAttempt == 1
+		if !supervisor.NoteConnected("fixture", snapshot.Generation) {
+			t.Fatal("NoteConnected rejected current generation")
+		}
+		clock.Advance(pluginStableConnection - time.Millisecond)
+		snapshot, _ = supervisor.Snapshot("fixture")
+		if snapshot.RestartAttempt != 1 {
+			t.Fatalf("attempt=%d before stability window, want 1", snapshot.RestartAttempt)
+		}
+		clock.Advance(time.Millisecond)
+		snapshot, _ = supervisor.Snapshot("fixture")
+		if snapshot.RestartAttempt != 0 || snapshot.Phase != pluginPhaseConnected {
+			t.Fatalf("snapshot=%+v after stability window, want connected attempt 0", snapshot)
+		}
 	})
-	clock.Advance(250 * time.Millisecond)
-	waitForSupervisor(t, func() bool { return launcher.count() == 2 })
-	snapshot, _ := supervisor.Snapshot("fixture")
-	if !supervisor.NoteConnected("fixture", snapshot.Generation) {
-		t.Fatal("NoteConnected rejected current generation")
-	}
-	clock.Advance(pluginStableConnection - time.Millisecond)
-	snapshot, _ = supervisor.Snapshot("fixture")
-	if snapshot.RestartAttempt != 1 {
-		t.Fatalf("attempt=%d before stability window, want 1", snapshot.RestartAttempt)
-	}
-	clock.Advance(time.Millisecond)
-	snapshot, _ = supervisor.Snapshot("fixture")
-	if snapshot.RestartAttempt != 0 || snapshot.Phase != pluginPhaseConnected {
-		t.Fatalf("snapshot=%+v after stability window, want connected attempt 0", snapshot)
-	}
 }
 
 func TestPluginSupervisorDisconnectGraceReconnectAndKill(t *testing.T) {
-	clock := newFakePluginClock()
-	launcher := &fakePluginLauncher{}
-	supervisor := newTestPluginSupervisor(clock, launcher)
-	_ = supervisor.Ensure(pluginManifest{Name: "fixture"})
-	snapshot, _ := supervisor.Snapshot("fixture")
-	generation := snapshot.Generation
-	if !supervisor.NoteConnected("fixture", generation) {
-		t.Fatal("NoteConnected rejected current generation")
-	}
-
-	supervisor.NoteDisconnected("fixture", generation)
-	clock.Advance(pluginDisconnectGrace - time.Millisecond)
-	if got := launcher.handle(0).killCount(); got != 0 {
-		t.Fatalf("kills before grace=%d, want 0", got)
-	}
-	if !supervisor.NoteConnected("fixture", generation) {
-		t.Fatal("same-generation reconnect was rejected")
-	}
-	clock.Advance(time.Millisecond)
-	if got := launcher.handle(0).killCount(); got != 0 {
-		t.Fatalf("kills after canceled grace=%d, want 0", got)
-	}
-
-	supervisor.NoteDisconnected("fixture", generation)
-	clock.Advance(pluginDisconnectGrace)
-	if got := launcher.handle(0).killCount(); got != 1 {
-		t.Fatalf("kills after expired grace=%d, want 1", got)
-	}
-	waitForSupervisor(t, func() bool {
+	synctest.Test(t, func(t *testing.T) {
+		clock := newFakePluginClock()
+		launcher := &fakePluginLauncher{}
+		supervisor := newTestPluginSupervisor(t, clock, launcher)
+		_ = supervisor.Ensure(pluginManifest{Name: "fixture"})
 		snapshot, _ := supervisor.Snapshot("fixture")
-		return snapshot.Phase == pluginPhaseBackoff
+		generation := snapshot.Generation
+		if !supervisor.NoteConnected("fixture", generation) {
+			t.Fatal("NoteConnected rejected current generation")
+		}
+
+		supervisor.NoteDisconnected("fixture", generation)
+		clock.Advance(pluginDisconnectGrace - time.Millisecond)
+		if got := launcher.handle(0).killCount(); got != 0 {
+			t.Fatalf("kills before grace=%d, want 0", got)
+		}
+		if !supervisor.NoteConnected("fixture", generation) {
+			t.Fatal("same-generation reconnect was rejected")
+		}
+		clock.Advance(time.Millisecond)
+		if got := launcher.handle(0).killCount(); got != 0 {
+			t.Fatalf("kills after canceled grace=%d, want 0", got)
+		}
+
+		supervisor.NoteDisconnected("fixture", generation)
+		clock.Advance(pluginDisconnectGrace)
+		if got := launcher.handle(0).killCount(); got != 1 {
+			t.Fatalf("kills after expired grace=%d, want 1", got)
+		}
+		requireSupervisor(t, func() bool {
+			snapshot, _ := supervisor.Snapshot("fixture")
+			return snapshot.Phase == pluginPhaseBackoff
+		}, "the kill after the expired grace did not land the plugin in backoff")
 	})
 }
 
 func TestPluginSupervisorRestartsProcessThatNeverConnects(t *testing.T) {
-	clock := newFakePluginClock()
-	launcher := &fakePluginLauncher{}
-	supervisor := newTestPluginSupervisor(clock, launcher)
-	_ = supervisor.Ensure(pluginManifest{Name: "fixture"})
+	synctest.Test(t, func(t *testing.T) {
+		clock := newFakePluginClock()
+		launcher := &fakePluginLauncher{}
+		supervisor := newTestPluginSupervisor(t, clock, launcher)
+		_ = supervisor.Ensure(pluginManifest{Name: "fixture"})
 
-	clock.Advance(pluginDisconnectGrace)
-	if got := launcher.handle(0).killCount(); got != 1 {
-		t.Fatalf("kills after startup grace=%d, want 1", got)
-	}
-	waitForSupervisor(t, func() bool {
-		snapshot, _ := supervisor.Snapshot("fixture")
-		return snapshot.Phase == pluginPhaseBackoff && snapshot.RestartAttempt == 1
+		clock.Advance(pluginDisconnectGrace)
+		if got := launcher.handle(0).killCount(); got != 1 {
+			t.Fatalf("kills after startup grace=%d, want 1", got)
+		}
+		requireSupervisor(t, func() bool {
+			snapshot, _ := supervisor.Snapshot("fixture")
+			return snapshot.Phase == pluginPhaseBackoff && snapshot.RestartAttempt == 1
+		}, "the never-connected kill did not land the plugin in backoff")
+		clock.Advance(pluginRestartBackoff[0])
+		requireSupervisor(t, func() bool { return launcher.count() == 2 }, "the elapsed backoff did not restart the plugin")
 	})
-	clock.Advance(pluginRestartBackoff[0])
-	waitForSupervisor(t, func() bool { return launcher.count() == 2 })
 }
 
 func TestPluginSupervisorIntentionalStopAndShutdownNeverRestart(t *testing.T) {
-	clock := newFakePluginClock()
-	launcher := &fakePluginLauncher{}
-	supervisor := newTestPluginSupervisor(clock, launcher)
-	_ = supervisor.Ensure(pluginManifest{Name: "one"})
-	_ = supervisor.Ensure(pluginManifest{Name: "two"})
-	one, _ := supervisor.Snapshot("one")
-	if !supervisor.NoteConnected("one", one.Generation) {
-		t.Fatal("connect one")
-	}
-	supervisor.NoteDisconnected("one", one.Generation)
-	supervisor.Stop("one", pluginStopRemove)
-
-	stopped, _ := supervisor.Snapshot("one")
-	if stopped.Phase != pluginPhaseStopped || stopped.Running || stopped.Desired != pluginDesiredStopped {
-		t.Fatalf("stopped snapshot=%+v", stopped)
-	}
-	if supervisor.NoteConnected("one", one.Generation) {
-		t.Fatal("stale generation reconnect accepted")
-	}
-	clock.Advance(time.Hour)
-	if got := launcher.count(); got != 2 {
-		t.Fatalf("starts after intentional stop=%d, want 2", got)
-	}
-
-	supervisor.Shutdown()
-	clock.Advance(time.Hour)
-	if got := launcher.count(); got != 2 {
-		t.Fatalf("starts after shutdown=%d, want 2", got)
-	}
-	for _, name := range []string{"one", "two"} {
-		snapshot, _ := supervisor.Snapshot(name)
-		if snapshot.Phase != pluginPhaseStopped || snapshot.Running {
-			t.Fatalf("%s snapshot=%+v after shutdown", name, snapshot)
+	synctest.Test(t, func(t *testing.T) {
+		clock := newFakePluginClock()
+		launcher := &fakePluginLauncher{}
+		supervisor := newTestPluginSupervisor(t, clock, launcher)
+		_ = supervisor.Ensure(pluginManifest{Name: "one"})
+		_ = supervisor.Ensure(pluginManifest{Name: "two"})
+		one, _ := supervisor.Snapshot("one")
+		if !supervisor.NoteConnected("one", one.Generation) {
+			t.Fatal("connect one")
 		}
-	}
+		supervisor.NoteDisconnected("one", one.Generation)
+		supervisor.Stop("one", pluginStopRemove)
+
+		stopped, _ := supervisor.Snapshot("one")
+		if stopped.Phase != pluginPhaseStopped || stopped.Running || stopped.Desired != pluginDesiredStopped {
+			t.Fatalf("stopped snapshot=%+v", stopped)
+		}
+		if supervisor.NoteConnected("one", one.Generation) {
+			t.Fatal("stale generation reconnect accepted")
+		}
+		clock.Advance(time.Hour)
+		if got := launcher.count(); got != 2 {
+			t.Fatalf("starts after intentional stop=%d, want 2", got)
+		}
+
+		supervisor.Shutdown()
+		clock.Advance(time.Hour)
+		if got := launcher.count(); got != 2 {
+			t.Fatalf("starts after shutdown=%d, want 2", got)
+		}
+		for _, name := range []string{"one", "two"} {
+			snapshot, _ := supervisor.Snapshot(name)
+			if snapshot.Phase != pluginPhaseStopped || snapshot.Running {
+				t.Fatalf("%s snapshot=%+v after shutdown", name, snapshot)
+			}
+		}
+	})
 }
 
 func TestPluginSupervisorSnapshotsStartingConnectedBackoffAndStopped(t *testing.T) {
-	clock := newFakePluginClock()
-	launcher := &fakePluginLauncher{}
-	supervisor := newTestPluginSupervisor(clock, launcher)
-	_ = supervisor.Ensure(pluginManifest{Name: "fixture"})
+	synctest.Test(t, func(t *testing.T) {
+		clock := newFakePluginClock()
+		launcher := &fakePluginLauncher{}
+		supervisor := newTestPluginSupervisor(t, clock, launcher)
+		_ = supervisor.Ensure(pluginManifest{Name: "fixture"})
 
-	snapshot, _ := supervisor.Snapshot("fixture")
-	if snapshot.Phase != pluginPhaseStarting || !snapshot.Running || snapshot.Connected {
-		t.Fatalf("starting snapshot=%+v", snapshot)
-	}
-	if !supervisor.NoteConnected("fixture", snapshot.Generation) {
-		t.Fatal("connect current generation")
-	}
-	snapshot, _ = supervisor.Snapshot("fixture")
-	if snapshot.Phase != pluginPhaseConnected || !snapshot.Connected {
-		t.Fatalf("connected snapshot=%+v", snapshot)
-	}
-	launcher.handle(0).exit(pluginExit{Error: "boom"})
-	waitForSupervisor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		if snapshot.Phase != pluginPhaseStarting || !snapshot.Running || snapshot.Connected {
+			t.Fatalf("starting snapshot=%+v", snapshot)
+		}
+		if !supervisor.NoteConnected("fixture", snapshot.Generation) {
+			t.Fatal("connect current generation")
+		}
 		snapshot, _ = supervisor.Snapshot("fixture")
-		return snapshot.Phase == pluginPhaseBackoff
+		if snapshot.Phase != pluginPhaseConnected || !snapshot.Connected {
+			t.Fatalf("connected snapshot=%+v", snapshot)
+		}
+		launcher.handle(0).exit(pluginExit{Error: "boom"})
+		requireSupervisor(t, func() bool {
+			snapshot, _ = supervisor.Snapshot("fixture")
+			return snapshot.Phase == pluginPhaseBackoff
+		}, "the exit did not land the plugin in backoff")
+		if snapshot.LastExit == nil || snapshot.NextRestartAt.IsZero() {
+			t.Fatalf("backoff snapshot=%+v", snapshot)
+		}
+		supervisor.Stop("fixture", pluginStopRemove)
+		snapshot, _ = supervisor.Snapshot("fixture")
+		if snapshot.Phase != pluginPhaseStopped {
+			t.Fatalf("stopped snapshot=%+v", snapshot)
+		}
 	})
-	if snapshot.LastExit == nil || snapshot.NextRestartAt.IsZero() {
-		t.Fatalf("backoff snapshot=%+v", snapshot)
-	}
-	supervisor.Stop("fixture", pluginStopRemove)
-	snapshot, _ = supervisor.Snapshot("fixture")
-	if snapshot.Phase != pluginPhaseStopped {
-		t.Fatalf("stopped snapshot=%+v", snapshot)
-	}
 }
 
 func TestExecPluginProcessLauncherRunsExecutableWithoutBun(t *testing.T) {
@@ -245,10 +261,17 @@ func TestExecPluginProcessLauncherRunsExecutableWithoutBun(t *testing.T) {
 	}
 }
 
-func newTestPluginSupervisor(clock *fakePluginClock, launcher *fakePluginLauncher) *pluginSupervisor {
-	return newPluginSupervisor(launcher, clock, func(manifest pluginManifest, generation uint64) []string {
+// newTestPluginSupervisor builds a supervisor over the fake clock and launcher, and
+// shuts it down on cleanup. The shutdown is load-bearing inside a bubble: every
+// supervised plugin owns a goroutine parked on its process handle's exit channel,
+// and one still parked when the test body returns is a blocked bubble goroutine.
+func newTestPluginSupervisor(t *testing.T, clock *fakePluginClock, launcher *fakePluginLauncher) *pluginSupervisor {
+	t.Helper()
+	supervisor := newPluginSupervisor(launcher, clock, func(manifest pluginManifest, generation uint64) []string {
 		return []string{fmt.Sprintf("ATTN_PLUGIN_NAME=%s", manifest.Name), fmt.Sprintf("ATTN_PLUGIN_GENERATION=%d", generation)}
 	}, nil)
+	t.Cleanup(supervisor.Shutdown)
+	return supervisor
 }
 
 type fakePluginLauncher struct {
@@ -391,14 +414,14 @@ func (t *fakePluginTimer) Stop() bool {
 	return true
 }
 
-func waitForSupervisor(t *testing.T, condition func() bool) {
+// requireSupervisor asserts a supervisor condition holds once the bubble has
+// settled. The supervisor reacts to a process exit and to a fired backoff timer on
+// its own goroutine; synctest.Wait() returns after those have run, so the condition
+// is read against a settled supervisor rather than polled at it.
+func requireSupervisor(t *testing.T, condition func() bool, what string) {
 	t.Helper()
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		if condition() {
-			return
-		}
-		time.Sleep(time.Millisecond)
+	synctest.Wait()
+	if !condition() {
+		t.Fatal(what)
 	}
-	t.Fatal("supervisor condition did not become true")
 }

--- a/internal/daemon/reload_test.go
+++ b/internal/daemon/reload_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"syscall"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	agentdriver "github.com/victorarias/attn/internal/agent"
@@ -198,8 +199,21 @@ func (b *fakeReloadBackend) spawnCountFor(id string) int {
 
 func newReloadTestDaemon(t *testing.T, backend *fakeReloadBackend) *Daemon {
 	t.Helper()
+	return newReloadTestDaemonOn(t, newReloadTestBase(t), backend)
+}
+
+// newReloadTestBase builds the daemon a bubbled reload test needs: constructed
+// outside the bubble, its store closed by the outer T. Pair it with
+// newReloadTestDaemonOn inside synctest.Test.
+func newReloadTestBase(t *testing.T) *Daemon {
+	t.Helper()
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	t.Cleanup(func() { _ = d.store.Close() })
+	return d
+}
+
+func newReloadTestDaemonOn(t *testing.T, d *Daemon, backend *fakeReloadBackend) *Daemon {
+	t.Helper()
 	d.ptyBackend = backend
 	return d
 }
@@ -506,6 +520,10 @@ func TestReloadSessionAgentSkipsUnsupportedAgent(t *testing.T) {
 	}
 }
 
+// Boundary-bound: setting the notebook root starts the notebook fsnotify
+// watcher, whose goroutine parks in kqueue. That is a real fd nobody is durably
+// blocked on, so a bubble here hangs (measured: the 25s test timeout, with the
+// watcher the only goroutine left).
 func TestReloadSessionAgentRecomposesPluginChiefInstructionsBeforeKill(t *testing.T) {
 	backend := &fakeReloadBackend{
 		liveIDs: []string{"plugin-chief"},
@@ -591,6 +609,7 @@ func TestReloadSessionAgentRecomposesPluginChiefInstructionsBeforeKill(t *testin
 	}
 }
 
+// Boundary-bound: same notebook fsnotify watcher as the test above.
 func TestReloadSessionAgentLeavesPluginWorkerAliveWhenResumeCannotBePrepared(t *testing.T) {
 	backend := &fakeReloadBackend{
 		liveIDs: []string{"plugin-chief"},
@@ -634,6 +653,8 @@ func TestReloadSessionAgentLeavesPluginWorkerAliveWhenResumeCannotBePrepared(t *
 	}
 }
 
+// Boundary-bound: same notebook fsnotify watcher. Its three sibling
+// set-chief-of-staff tests bubble because they never set a notebook root.
 func TestSetChiefOfStaffRejectsPluginRoleChangeWhenResumePreflightFails(t *testing.T) {
 	for _, test := range []struct {
 		name         string
@@ -751,24 +772,28 @@ func TestReloadSessionAgentRespawnFailureBroadcastsSessionExited(t *testing.T) {
 // Promotion AND demotion both reload, so the new chief status reaches the system
 // prompt either way (assign injects guidance, demote drops it).
 func TestSetChiefOfStaffReloadsOnAssignAndDemote(t *testing.T) {
-	backend := &fakeReloadBackend{
-		liveIDs: []string{"chief"},
-		info:    ptybackend.SessionInfo{Cols: 80, Rows: 24},
-		params:  ptybackend.SessionLaunchParams{Recorded: true},
-	}
-	d := newReloadTestDaemon(t, backend)
-	addReloadSession(d, "chief", protocol.SessionAgentClaude, protocol.SessionStateIdle)
-	client := newRenameTestClient()
+	base := newReloadTestBase(t)
+	synctest.Test(t, func(t *testing.T) {
+		backend := &fakeReloadBackend{
+			liveIDs: []string{"chief"},
+			info:    ptybackend.SessionInfo{Cols: 80, Rows: 24},
+			params:  ptybackend.SessionLaunchParams{Recorded: true},
+		}
+		d := newReloadTestDaemonOn(t, base, backend)
+		stopDaemonBackground(t, d)
+		addReloadSession(d, "chief", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+		client := newRenameTestClient()
 
-	d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
-		Cmd: protocol.CmdSetChiefOfStaff, SessionID: "chief", ChiefOfStaff: true,
-	})
-	waitForSpawnCount(t, backend, 1, "assign")
+		d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
+			Cmd: protocol.CmdSetChiefOfStaff, SessionID: "chief", ChiefOfStaff: true,
+		})
+		requireSpawnCount(t, backend, 1, "assign")
 
-	d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
-		Cmd: protocol.CmdSetChiefOfStaff, SessionID: "chief", ChiefOfStaff: false,
+		d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
+			Cmd: protocol.CmdSetChiefOfStaff, SessionID: "chief", ChiefOfStaff: false,
+		})
+		requireSpawnCount(t, backend, 2, "demote")
 	})
-	waitForSpawnCount(t, backend, 2, "demote")
 }
 
 // Two reloads of the same session fired concurrently (a rapid double-toggle, or a
@@ -824,33 +849,37 @@ func TestReloadSessionAgentSerializesConcurrentReloads(t *testing.T) {
 // chief via the single-holder upsert. Both must reload: the new chief to gain the
 // guidance, the displaced one to drop it now instead of keeping it until it restarts.
 func TestSetChiefOfStaffRoleTransferReloadsBothChiefs(t *testing.T) {
-	backend := &fakeReloadBackend{
-		liveIDs: []string{"alice", "bob"},
-		info:    ptybackend.SessionInfo{Cols: 80, Rows: 24},
-		params:  ptybackend.SessionLaunchParams{Recorded: true},
-	}
-	d := newReloadTestDaemon(t, backend)
-	addReloadSession(d, "alice", protocol.SessionAgentClaude, protocol.SessionStateIdle)
-	addReloadSession(d, "bob", protocol.SessionAgentClaude, protocol.SessionStateIdle)
-	client := newRenameTestClient()
+	base := newReloadTestBase(t)
+	synctest.Test(t, func(t *testing.T) {
+		backend := &fakeReloadBackend{
+			liveIDs: []string{"alice", "bob"},
+			info:    ptybackend.SessionInfo{Cols: 80, Rows: 24},
+			params:  ptybackend.SessionLaunchParams{Recorded: true},
+		}
+		d := newReloadTestDaemonOn(t, base, backend)
+		stopDaemonBackground(t, d)
+		addReloadSession(d, "alice", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+		addReloadSession(d, "bob", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+		client := newRenameTestClient()
 
-	d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
-		Cmd: protocol.CmdSetChiefOfStaff, SessionID: "alice", ChiefOfStaff: true,
+		d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
+			Cmd: protocol.CmdSetChiefOfStaff, SessionID: "alice", ChiefOfStaff: true,
+		})
+		requireSpawnCount(t, backend, 1, "assign alice")
+
+		// Transfer the role to bob while alice still holds it.
+		d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
+			Cmd: protocol.CmdSetChiefOfStaff, SessionID: "bob", ChiefOfStaff: true,
+		})
+		requireSpawnCount(t, backend, 3, "transfer to bob")
+
+		if got := backend.spawnCountFor("bob"); got != 1 {
+			t.Fatalf("bob (new chief) respawns = %d, want 1", got)
+		}
+		if got := backend.spawnCountFor("alice"); got != 2 {
+			t.Fatalf("alice respawns = %d, want 2 (1 assign + 1 displaced-on-transfer)", got)
+		}
 	})
-	waitForSpawnCount(t, backend, 1, "assign alice")
-
-	// Transfer the role to bob while alice still holds it.
-	d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
-		Cmd: protocol.CmdSetChiefOfStaff, SessionID: "bob", ChiefOfStaff: true,
-	})
-	waitForSpawnCount(t, backend, 3, "transfer to bob")
-
-	if got := backend.spawnCountFor("bob"); got != 1 {
-		t.Fatalf("bob (new chief) respawns = %d, want 1", got)
-	}
-	if got := backend.spawnCountFor("alice"); got != 2 {
-		t.Fatalf("alice respawns = %d, want 2 (1 assign + 1 displaced-on-transfer)", got)
-	}
 }
 
 // The reload is destructive (kill + respawn), unlike the doorbell it replaced. A
@@ -858,53 +887,56 @@ func TestSetChiefOfStaffRoleTransferReloadsBothChiefs(t *testing.T) {
 // demoting a session that isn't the chief (a ClearProfileRole no-op), or re-assigning
 // the session that already holds the role.
 func TestSetChiefOfStaffNoReloadOnNoOpToggle(t *testing.T) {
-	backend := &fakeReloadBackend{
-		liveIDs: []string{"chief", "other"},
-		info:    ptybackend.SessionInfo{Cols: 80, Rows: 24},
-		params:  ptybackend.SessionLaunchParams{Recorded: true},
-	}
-	d := newReloadTestDaemon(t, backend)
-	addReloadSession(d, "chief", protocol.SessionAgentClaude, protocol.SessionStateIdle)
-	addReloadSession(d, "other", protocol.SessionAgentClaude, protocol.SessionStateIdle)
-	client := newRenameTestClient()
+	base := newReloadTestBase(t)
+	synctest.Test(t, func(t *testing.T) {
+		backend := &fakeReloadBackend{
+			liveIDs: []string{"chief", "other"},
+			info:    ptybackend.SessionInfo{Cols: 80, Rows: 24},
+			params:  ptybackend.SessionLaunchParams{Recorded: true},
+		}
+		d := newReloadTestDaemonOn(t, base, backend)
+		stopDaemonBackground(t, d)
+		addReloadSession(d, "chief", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+		addReloadSession(d, "other", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+		client := newRenameTestClient()
 
-	// Demote a session that holds no role: nothing changes, nothing should reload.
-	d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
-		Cmd: protocol.CmdSetChiefOfStaff, SessionID: "other", ChiefOfStaff: false,
-	})
-	assertSpawnCountStaysBelow(t, backend, 1, "no-op demote of a non-chief")
+		// Demote a session that holds no role: nothing changes, nothing should reload.
+		d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
+			Cmd: protocol.CmdSetChiefOfStaff, SessionID: "other", ChiefOfStaff: false,
+		})
+		assertSpawnCountStaysBelow(t, backend, 1, "no-op demote of a non-chief")
 
-	// Real assign reloads once.
-	d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
-		Cmd: protocol.CmdSetChiefOfStaff, SessionID: "chief", ChiefOfStaff: true,
-	})
-	waitForSpawnCount(t, backend, 1, "assign chief")
+		// Real assign reloads once.
+		d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
+			Cmd: protocol.CmdSetChiefOfStaff, SessionID: "chief", ChiefOfStaff: true,
+		})
+		requireSpawnCount(t, backend, 1, "assign chief")
 
-	// Re-assigning the SAME session that already holds the role changes nothing.
-	d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
-		Cmd: protocol.CmdSetChiefOfStaff, SessionID: "chief", ChiefOfStaff: true,
+		// Re-assigning the SAME session that already holds the role changes nothing.
+		d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
+			Cmd: protocol.CmdSetChiefOfStaff, SessionID: "chief", ChiefOfStaff: true,
+		})
+		assertSpawnCountStaysBelow(t, backend, 2, "redundant re-assign of the current chief")
 	})
-	assertSpawnCountStaysBelow(t, backend, 2, "redundant re-assign of the current chief")
 }
 
-// assertSpawnCountStaysBelow gives any (incorrectly fired) async reload a window to
-// land, then asserts the spawn count never reached want.
+// assertSpawnCountStaysBelow asserts the spawn count never reached want. The
+// window a wrongly-fired async reload needed is now a settled bubble: there is no
+// goroutine left that could still spawn.
 func assertSpawnCountStaysBelow(t *testing.T, backend *fakeReloadBackend, want int, label string) {
 	t.Helper()
-	time.Sleep(100 * time.Millisecond)
+	synctest.Wait()
 	if got := backend.spawnCount(); got >= want {
 		t.Fatalf("%s: spawn count = %d, want < %d (no-op toggle must not reload)", label, got, want)
 	}
 }
 
-func waitForSpawnCount(t *testing.T, backend *fakeReloadBackend, want int, label string) {
+// requireSpawnCount settles the bubble and reads the count once: the reload is
+// async, and a settled bubble is the instant after which nothing more will spawn.
+func requireSpawnCount(t *testing.T, backend *fakeReloadBackend, want int, label string) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if backend.spawnCount() >= want {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
+	synctest.Wait()
+	if got := backend.spawnCount(); got < want {
+		t.Fatalf("%s: respawn count = %d, want >= %d", label, got, want)
 	}
-	t.Fatalf("%s: respawn count = %d, want >= %d", label, backend.spawnCount(), want)
 }

--- a/internal/daemon/session_evidence_test.go
+++ b/internal/daemon/session_evidence_test.go
@@ -458,6 +458,9 @@ func TestEvidenceIsNotRecordedForAnUnknownSession(t *testing.T) {
 //
 // The hook parks the writer *after* it has read the store row and *before* it
 // appends — the exact window that leaks when the check sits outside the lock.
+// Boundary-bound: the removal is supposed to park on the evidence table's lock
+// while the writer holds it, and a mutex wait is invisible to a bubble — there
+// is no settled instant that means "the removal got as far as it can".
 func TestEvidenceDoesNotLeakWhenRemovalRacesTheWrite(t *testing.T) {
 	d := newTraceDaemon(t)
 	id := "sess-evidence-race"

--- a/internal/daemon/session_state_characterization_test.go
+++ b/internal/daemon/session_state_characterization_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
@@ -129,57 +130,57 @@ func TestSessionStateCharacterization_AHookOnlyFilesEvidence(t *testing.T) {
 
 func TestSessionStateCharacterization_ALateVerdictDoesNotOverwriteAnApproval(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "state.sock"))
-	sessionID := "stale-classifier"
-	addCharacterizationSession(t, d, sessionID, protocol.SessionAgentCodex, protocol.SessionStateWorking)
-	classifier := newBlockingClassifier(protocol.StateIdle)
-	d.classifier = classifier
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		sessionID := "stale-classifier"
+		addCharacterizationSession(t, d, sessionID, protocol.SessionAgentCodex, protocol.SessionStateWorking)
+		classifier := newBlockingClassifier(protocol.StateIdle)
+		d.classifier = classifier
 
-	transcriptPath := filepath.Join(t.TempDir(), "transcript.jsonl")
-	content := `{"type":"assistant","message":{"role":"assistant","content":"Finished."}}` + "\n"
-	if err := os.WriteFile(transcriptPath, []byte(content), 0o644); err != nil {
-		t.Fatalf("write transcript: %v", err)
-	}
-	capture := captureBroadcasts(d)
+		transcriptPath := filepath.Join(t.TempDir(), "transcript.jsonl")
+		content := `{"type":"assistant","message":{"role":"assistant","content":"Finished."}}` + "\n"
+		if err := os.WriteFile(transcriptPath, []byte(content), 0o644); err != nil {
+			t.Fatalf("write transcript: %v", err)
+		}
+		capture := captureBroadcasts(d)
 
-	classified := make(chan struct{})
-	go func() {
-		d.classifySessionState(sessionID, transcriptPath)
-		close(classified)
-	}()
+		classified := make(chan struct{})
+		go func() {
+			d.classifySessionState(sessionID, transcriptPath)
+			close(classified)
+		}()
 
-	select {
-	case <-classifier.started:
-	case <-time.After(2 * time.Second):
+		synctest.Wait()
+		select {
+		case <-classifier.started:
+		default:
+			close(classifier.release)
+			t.Fatal("classifier did not start")
+		}
+
+		d.handleState(&syncConn{}, &protocol.StateMessage{ID: sessionID, State: protocol.StatePendingApproval})
+		d.resolveAllSessions(time.Now())
+		fresh := d.store.Get(sessionID)
+		if fresh.State != protocol.SessionStatePendingApproval {
+			t.Fatalf("state=%q before the verdict lands; the rest proves nothing", fresh.State)
+		}
+		stateEventsBeforeRelease := characterizationEventCount(capture.snapshot(), protocol.EventSessionStateChanged, sessionID)
 		close(classifier.release)
-		t.Fatal("classifier did not start")
-	}
+		requireDone(t, classified, "classifier did not finish")
 
-	d.handleState(&syncConn{}, &protocol.StateMessage{ID: sessionID, State: protocol.StatePendingApproval})
-	d.resolveAllSessions(time.Now())
-	fresh := d.store.Get(sessionID)
-	if fresh.State != protocol.SessionStatePendingApproval {
-		t.Fatalf("state=%q before the verdict lands; the rest proves nothing", fresh.State)
-	}
-	stateEventsBeforeRelease := characterizationEventCount(capture.snapshot(), protocol.EventSessionStateChanged, sessionID)
-	close(classifier.release)
-	select {
-	case <-classified:
-	case <-time.After(2 * time.Second):
-		t.Fatal("classifier did not finish")
-	}
+		d.resolveAllSessions(time.Now())
 
-	d.resolveAllSessions(time.Now())
-
-	after := d.store.Get(sessionID)
-	if after == nil || after.State != protocol.SessionStatePendingApproval {
-		t.Fatalf("session=%+v, the late verdict overwrote pending_approval", after)
-	}
-	if after.StateUpdatedAt != fresh.StateUpdatedAt || after.LastSeen != fresh.LastSeen {
-		t.Fatalf("stale classifier changed timestamps: fresh=%+v after=%+v", fresh, after)
-	}
-	if got := characterizationEventCount(capture.snapshot(), protocol.EventSessionStateChanged, sessionID); got != stateEventsBeforeRelease {
-		t.Fatalf("stale classifier emitted state event: before=%d after=%d", stateEventsBeforeRelease, got)
-	}
+		after := d.store.Get(sessionID)
+		if after == nil || after.State != protocol.SessionStatePendingApproval {
+			t.Fatalf("session=%+v, the late verdict overwrote pending_approval", after)
+		}
+		if after.StateUpdatedAt != fresh.StateUpdatedAt || after.LastSeen != fresh.LastSeen {
+			t.Fatalf("stale classifier changed timestamps: fresh=%+v after=%+v", fresh, after)
+		}
+		if got := characterizationEventCount(capture.snapshot(), protocol.EventSessionStateChanged, sessionID); got != stateEventsBeforeRelease {
+			t.Fatalf("stale classifier emitted state event: before=%d after=%d", stateEventsBeforeRelease, got)
+		}
+	})
 }
 
 func TestSessionStateCharacterization_PluginCASGatesEffects(t *testing.T) {

--- a/internal/daemon/spawn_characterization_test.go
+++ b/internal/daemon/spawn_characterization_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/launchcontract"
@@ -14,9 +15,19 @@ import (
 	"github.com/victorarias/attn/internal/workspacelayout"
 )
 
+// spawnProbeReadDeadline bounds how long the plugin probe waits for a second
+// driver.spawn request that must never arrive.
+const spawnProbeReadDeadline = 250 * time.Millisecond
+
 func newSpawnCharacterizationDaemon(t *testing.T) (*Daemon, *fakeSpawnBackend, *wsClient, string) {
 	t.Helper()
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	return newSpawnCharacterizationDaemonOn(t, NewForTesting(filepath.Join(t.TempDir(), "test.sock")))
+}
+
+// newSpawnCharacterizationDaemonOn is newSpawnCharacterizationDaemon against a
+// daemon the caller built outside a synctest bubble.
+func newSpawnCharacterizationDaemonOn(t *testing.T, d *Daemon) (*Daemon, *fakeSpawnBackend, *wsClient, string) {
+	t.Helper()
 	backend := &fakeSpawnBackend{}
 	d.ptyBackend = backend
 	client := newWorkspaceProtocolTestClient()
@@ -237,82 +248,87 @@ func TestSpawnCharacterizationRejectsPluginChiefWithoutResumeCapability(t *testi
 }
 
 func TestSpawnCharacterizationPluginChiefResumeFailureMentionsCapability(t *testing.T) {
-	d, _, client, cwd := newSpawnCharacterizationDaemon(t)
-	plugin, done := startPluginPipe(t, d, "characterization-plugin-error", nil)
-	defer func() { _ = plugin.Close(); <-done }()
-	registerTestPluginDriver(t, plugin, "characterization-error", map[string]bool{"launch_instructions": true})
-	addTestWorkspace(d, "workspace", cwd)
-	msg := spawnCharacterizationMessage("plugin-chief-error", "workspace", cwd)
-	msg.Agent, msg.ChiefOfStaff = "characterization-error", protocol.Ptr(true)
-	d.handleSpawnSession(client, msg)
-	select {
-	case outbound := <-client.send:
+	base := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	synctest.Test(t, func(t *testing.T) {
+		d, _, client, cwd := newSpawnCharacterizationDaemonOn(t, base)
+		stopDaemonBackground(t, d)
+		plugin, done := startPluginPipe(t, d, "characterization-plugin-error", nil)
+		defer func() { _ = plugin.Close(); <-done }()
+		registerTestPluginDriver(t, plugin, "characterization-error", map[string]bool{"launch_instructions": true})
+		addTestWorkspace(d, "workspace", cwd)
+		msg := spawnCharacterizationMessage("plugin-chief-error", "workspace", cwd)
+		msg.Agent, msg.ChiefOfStaff = "characterization-error", protocol.Ptr(true)
+		d.handleSpawnSession(client, msg)
+		outbound := requireOutbound(t, client, "no spawn failure reached the client")
 		if !strings.Contains(string(outbound.payload), "resume capability") {
 			t.Fatalf("failure payload = %s, want resume capability", outbound.payload)
 		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for spawn failure")
-	}
+	})
 }
 
 func TestSpawnCharacterizationAlreadyLivePluginRespawnSkipsPluginPrep(t *testing.T) {
-	d, backend, client, cwd := newSpawnCharacterizationDaemon(t)
-	plugin, pluginDone := startPluginPipe(t, d, "characterization-live-plugin", nil)
-	defer func() { _ = plugin.Close(); <-pluginDone }()
-	registerTestPluginDriver(t, plugin, "characterization-live", nil)
-	addTestWorkspace(d, "workspace", cwd)
+	base := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	synctest.Test(t, func(t *testing.T) {
+		d, backend, client, cwd := newSpawnCharacterizationDaemonOn(t, base)
+		stopDaemonBackground(t, d)
+		plugin, pluginDone := startPluginPipe(t, d, "characterization-live-plugin", nil)
+		defer func() { _ = plugin.Close(); <-pluginDone }()
+		registerTestPluginDriver(t, plugin, "characterization-live", nil)
+		addTestWorkspace(d, "workspace", cwd)
 
-	driverSpawns := make(chan bool, 1)
-	go func() {
-		request := decodeJSONRPCMessage(t, plugin)
-		if request.Method != "driver.spawn" {
-			driverSpawns <- false
-			return
-		}
-		respondPluginRequest(t, plugin, request, pluginDriverSpawnResult{Argv: []string{"characterization-live"}})
+		driverSpawns := make(chan bool, 1)
+		go func() {
+			request := decodeJSONRPCMessage(t, plugin)
+			if request.Method != "driver.spawn" {
+				driverSpawns <- false
+				return
+			}
+			respondPluginRequest(t, plugin, request, pluginDriverSpawnResult{Argv: []string{"characterization-live"}})
 
-		_ = plugin.SetReadDeadline(time.Now().Add(250 * time.Millisecond))
-		var secondRequest jsonRPCMessage
-		if err := json.NewDecoder(plugin).Decode(&secondRequest); err != nil {
-			driverSpawns <- false
-			return
-		}
-		driverSpawns <- secondRequest.Method == "driver.spawn"
-		if secondRequest.Method == "driver.spawn" {
-			respondPluginRequest(t, plugin, secondRequest, pluginDriverSpawnResult{Argv: []string{"characterization-live"}})
-		}
-	}()
+			_ = plugin.SetReadDeadline(time.Now().Add(spawnProbeReadDeadline))
+			var secondRequest jsonRPCMessage
+			if err := json.NewDecoder(plugin).Decode(&secondRequest); err != nil {
+				driverSpawns <- false
+				return
+			}
+			driverSpawns <- secondRequest.Method == "driver.spawn"
+			if secondRequest.Method == "driver.spawn" {
+				respondPluginRequest(t, plugin, secondRequest, pluginDriverSpawnResult{Argv: []string{"characterization-live"}})
+			}
+		}()
 
-	msg := spawnCharacterizationMessage("already-live-plugin", "workspace", cwd)
-	msg.Agent = "characterization-live"
-	d.handleSpawnSession(client, msg)
-	expectSpawnResult(t, client, msg.ID, true)
-
-	backend.mu.Lock()
-	backend.sessionIDs = []string{msg.ID}
-	backend.mu.Unlock()
-
-	secondSpawnDone := make(chan struct{})
-	go func() {
+		msg := spawnCharacterizationMessage("already-live-plugin", "workspace", cwd)
+		msg.Agent = "characterization-live"
 		d.handleSpawnSession(client, msg)
-		close(secondSpawnDone)
-	}()
-	select {
-	case <-secondSpawnDone:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for already-live spawn result")
-	}
-	expectSpawnResult(t, client, msg.ID, true)
+		expectSpawnResult(t, client, msg.ID, true)
 
-	select {
-	case gotSecondDriverSpawn := <-driverSpawns:
-		if gotSecondDriverSpawn {
-			t.Fatal("already-live respawn sent a second driver.spawn request")
+		backend.mu.Lock()
+		backend.sessionIDs = []string{msg.ID}
+		backend.mu.Unlock()
+
+		secondSpawnDone := make(chan struct{})
+		go func() {
+			d.handleSpawnSession(client, msg)
+			close(secondSpawnDone)
+		}()
+		requireDone(t, secondSpawnDone, "the already-live spawn never returned")
+		expectSpawnResult(t, client, msg.ID, true)
+
+		// The probe reports only once its own 250ms read deadline expires, and a
+		// settled bubble is exactly the state where nothing else will move the
+		// clock — so run it out.
+		time.Sleep(spawnProbeReadDeadline)
+		synctest.Wait()
+		select {
+		case gotSecondDriverSpawn := <-driverSpawns:
+			if gotSecondDriverSpawn {
+				t.Fatal("already-live respawn sent a second driver.spawn request")
+			}
+		default:
+			t.Fatal("the plugin spawn probe never reported")
 		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for plugin spawn probe")
-	}
-	if got := spawnCount(backend); got != 1 {
-		t.Fatalf("Spawn calls = %d, want 1", got)
-	}
+		if got := spawnCount(backend); got != 1 {
+			t.Fatalf("Spawn calls = %d, want 1", got)
+		}
+	})
 }

--- a/internal/daemon/spawn_lock_test.go
+++ b/internal/daemon/spawn_lock_test.go
@@ -99,6 +99,10 @@ func requireSpawnSuccess(t *testing.T, client *wsClient, sessionID string) {
 	}
 }
 
+// Boundary-bound: the test hands the scheduler the second spawn with
+// runtime.Gosched() while it queues on the per-session spawn lock. A spinning
+// goroutine is never durably blocked, and neither is one parked on a mutex, so
+// there is no instant a bubble could call settled.
 func TestConcurrentSameSessionSpawnsSpawnOnce(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := newBlockingSpawnBackend()
@@ -170,6 +174,9 @@ waitForSecond:
 	requireSpawnSuccess(t, secondClient, sessionID)
 }
 
+// Boundary-bound: the claim is that session B never blocks on session A's lock.
+// A regression makes B park on a mutex, which a bubble reads as "not yet
+// settled" rather than "blocked" — it would hang instead of failing.
 func TestDifferentSessionSpawnsDoNotSerialize(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}

--- a/internal/daemon/state_trace_test.go
+++ b/internal/daemon/state_trace_test.go
@@ -175,6 +175,9 @@ func TestTraceIsDroppedWhenTheSessionRecordGoes(t *testing.T) {
 //
 // The hook fires inside the recorder's lock, which is exactly where the removal
 // must be attempted for the race to be real.
+// Boundary-bound for the same reason as the evidence twin: the removal blocks on
+// the recorder's lock inside forgetStateTrace, and a bubble cannot observe a
+// goroutine waiting for a mutex.
 func TestTraceDoesNotLeakWhenRemovalRacesTheWrite(t *testing.T) {
 	d := newTraceDaemon(t)
 	id := "sess-racing"

--- a/internal/daemon/stop_terminality_test.go
+++ b/internal/daemon/stop_terminality_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/classifier"
@@ -128,6 +129,9 @@ func TestStopIsNonTerminal_LegacyHookClassifies(t *testing.T) {
 // through to the end-of-turn path — classification on a yield reads a
 // not-yet-flushed transcript and is what used to mis-detect these sessions as
 // idle/unknown.
+// Boundary-bound: this and the cron test below run a started daemon — a real
+// unix listener, a real client dialing it. Their yielded-stop siblings bubble
+// because they drive handleStop directly.
 func TestDaemon_StopCommand_BackgroundWork_StaysWorking(t *testing.T) {
 	useFreeWSPort(t)
 
@@ -162,6 +166,7 @@ func TestDaemon_StopCommand_BackgroundWork_StaysWorking(t *testing.T) {
 // TestDaemon_StopCommand_PendingCron_Settles pins that a cron-parked stop runs
 // the end-of-turn path like any other: the classifier gets its say, and the
 // session settles into the user's queue instead of being excused from it.
+// Boundary-bound: started daemon and a real socket, as above.
 func TestDaemon_StopCommand_PendingCron_Settles(t *testing.T) {
 	useFreeWSPort(t)
 
@@ -214,9 +219,8 @@ func (c *recordingClassifier) Texts() []string {
 // claude session whose turn ran, settled its heartbeat, and then yielded on a
 // Stop reporting one running background task, with the judge's answer faked.
 // It replays the 2026-08-01 incident's timeline up to the verdict.
-func yieldedStopDaemon(t *testing.T, verdict string) (*Daemon, *recordingClassifier) {
+func yieldedStopDaemon(t *testing.T, d *Daemon, verdict string) (*Daemon, *recordingClassifier) {
 	t.Helper()
-	d := NewForTesting(filepath.Join(shortTempDir(t), "test.sock"))
 	judge := &recordingClassifier{state: verdict}
 	d.classifier = judge
 	d.classificationTranscriptExtractor = func(*protocol.Session, string, int, time.Time) (string, string, error) {
@@ -249,16 +253,11 @@ func yieldedStopDaemon(t *testing.T, verdict string) (*Daemon, *recordingClassif
 		BackgroundTaskStatuses: []string{"running"},
 	})
 
-	// The judgment is dispatched async; wait for its verdict to land as evidence.
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		if e, ok := d.evidenceTable().snapshot("yielded"); ok && e.LastClassifier != nil {
-			break
-		}
-		if !time.Now().Before(deadline) {
-			t.Fatalf("yield verdict never landed as evidence (classifier calls: %d)", len(judge.Texts()))
-		}
-		time.Sleep(10 * time.Millisecond)
+	// The judgment is dispatched async, on the retry loop handleStop owns; run it
+	// out and the verdict is either filed or never coming.
+	settleStopClassification(t)
+	if e, ok := d.evidenceTable().snapshot("yielded"); !ok || e.LastClassifier == nil {
+		t.Fatalf("yield verdict never landed as evidence (classifier calls: %d)", len(judge.Texts()))
 	}
 	return d, judge
 }
@@ -268,26 +267,30 @@ func yieldedStopDaemon(t *testing.T, verdict string) (*Daemon, *recordingClassif
 // 60s idle_prompt notification — which used to settle the session idle and ring
 // the user mid-build — no longer outranks the verdict.
 func TestDaemon_YieldedStop_ParkedVerdictHoldsWorkingPastPromptIdle(t *testing.T) {
-	d, judge := yieldedStopDaemon(t, classifier.VerdictParked)
+	base := NewForTesting(filepath.Join(shortTempDir(t), "test.sock"))
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, base)
+		d, judge := yieldedStopDaemon(t, base, classifier.VerdictParked)
 
-	// The judge must have seen the yield: the harness-facts line is the
-	// precondition of the parked verdict.
-	texts := judge.Texts()
-	if len(texts) != 1 || !strings.Contains(texts[0], "[harness facts]") {
-		t.Fatalf("judge input missing the harness-facts line: %q", texts)
-	}
+		// The judge must have seen the yield: the harness-facts line is the
+		// precondition of the parked verdict.
+		texts := judge.Texts()
+		if len(texts) != 1 || !strings.Contains(texts[0], "[harness facts]") {
+			t.Fatalf("judge input missing the harness-facts line: %q", texts)
+		}
 
-	// The notification that broke the incident open, a minute into the wait.
-	d.recordNotificationEvidence("yielded", notifyIdlePrompt, "Claude is waiting for your input")
-	d.resolveAllSessions(time.Now())
+		// The notification that broke the incident open, a minute into the wait.
+		d.recordNotificationEvidence("yielded", notifyIdlePrompt, "Claude is waiting for your input")
+		d.resolveAllSessions(time.Now())
 
-	sess := d.store.Get("yielded")
-	if sess == nil {
-		t.Fatal("session missing after resolve")
-	}
-	if sess.State != protocol.StateWorking {
-		t.Fatalf("state = %s, want %s: a parked verdict outranks the prompt-idle confirmation", sess.State, protocol.StateWorking)
-	}
+		sess := d.store.Get("yielded")
+		if sess == nil {
+			t.Fatal("session missing after resolve")
+		}
+		if sess.State != protocol.StateWorking {
+			t.Fatalf("state = %s, want %s: a parked verdict outranks the prompt-idle confirmation", sess.State, protocol.StateWorking)
+		}
+	})
 }
 
 // TestDaemon_YieldedStop_DoneVerdictSettles pins the inverse failure the parked
@@ -295,17 +298,21 @@ func TestDaemon_YieldedStop_ParkedVerdictHoldsWorkingPastPromptIdle(t *testing.T
 // (a dev server, a watcher) settles into the user's queue on its verdict instead
 // of sitting green forever behind a task that will never exit.
 func TestDaemon_YieldedStop_DoneVerdictSettles(t *testing.T) {
-	d, _ := yieldedStopDaemon(t, protocol.StateIdle)
+	base := NewForTesting(filepath.Join(shortTempDir(t), "test.sock"))
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, base)
+		d, _ := yieldedStopDaemon(t, base, protocol.StateIdle)
 
-	d.resolveAllSessions(time.Now())
+		d.resolveAllSessions(time.Now())
 
-	sess := d.store.Get("yielded")
-	if sess == nil {
-		t.Fatal("session missing after resolve")
-	}
-	if sess.State != protocol.StateIdle {
-		t.Fatalf("state = %s, want %s: an idle verdict on a yield means the running process is a leftover", sess.State, protocol.StateIdle)
-	}
+		sess := d.store.Get("yielded")
+		if sess == nil {
+			t.Fatal("session missing after resolve")
+		}
+		if sess.State != protocol.StateIdle {
+			t.Fatalf("state = %s, want %s: an idle verdict on a yield means the running process is a leftover", sess.State, protocol.StateIdle)
+		}
+	})
 }
 
 // waitForResolvedState waits out the resolve tick. Nothing applies a state at the

--- a/internal/daemon/synctest_test.go
+++ b/internal/daemon/synctest_test.go
@@ -3,11 +3,13 @@ package daemon
 import (
 	"path/filepath"
 	"testing"
+	"testing/synctest"
+	"time"
 )
 
 // Support for running daemon tests inside a `testing/synctest` bubble, where
 // time.Now is a fake clock that advances only when every goroutine in the bubble
-// is durably blocked. Two rules make a daemon fit inside one, and both are
+// is durably blocked. Four rules make a daemon fit inside one, and all are
 // consequences of the same thing — the bubble is the boundary.
 //
 // 1. Build the daemon OUTSIDE the bubble. store.New opens a database/sql handle,
@@ -25,10 +27,21 @@ import (
 //    decades in the future. A turn opened outside and settled inside settles
 //    BEFORE it opened, and reads as still owed.
 //
+// 4. Let every goroutine the body started finish before the body returns. The
+//    bubble ends only when the last goroutine in it exits, so one still parked
+//    when the test body returns is reported as "blocked goroutines remain".
+//    Something the code under test spawned and left sleeping counts — see
+//    settleStopClassification.
+//
 // What cannot come inside at all: a real socket, a real PTY, a child process, an
 // fsnotify watcher. A goroutine blocked on a real file descriptor is not
 // durably blocked, so the fake clock never advances and the bubble hangs. Those
 // tests keep their poll helpers.
+//
+// Nor can a goroutine with no exit path: `go d.wsHub.run()` loops forever over
+// its channels, so a test that starts the hub inside a bubble never finishes
+// (measured: the bubble hangs until the test binary's own timeout). Giving the
+// hub a quit channel is a production change, so those tests stay boundary-bound.
 
 // newBubbleDaemon builds a daemon for a synctest bubble. Call it ABOVE
 // synctest.Test with the outer T — see rule 1.
@@ -52,4 +65,57 @@ func stopDaemonBackground(t *testing.T, d *Daemon) {
 		d.stopNotebookWatcher()
 		d.stopFsWatchers()
 	})
+}
+
+// requireDone asserts a goroutine's done channel has been closed. Inside a bubble
+// there is nothing to wait on with a deadline: synctest.Wait() returns once every
+// other goroutine is durably blocked, so a channel still open at that point is
+// open because the goroutine never finished, not because the read was early.
+func requireDone(t *testing.T, done <-chan struct{}, what string) {
+	t.Helper()
+	synctest.Wait()
+	select {
+	case <-done:
+	default:
+		t.Fatal(what)
+	}
+}
+
+// requireNoOutbound asserts a WebSocket test client was sent nothing. Outside a
+// bubble this claim costs a tolerance window and is only ever "nothing yet";
+// after synctest.Wait there is nothing left that could still send.
+func requireNoOutbound(t *testing.T, client *wsClient, what string) {
+	t.Helper()
+	synctest.Wait()
+	select {
+	case outbound := <-client.send:
+		t.Fatalf("%s: %s", what, string(outbound.payload))
+	default:
+	}
+}
+
+// requireOutbound is requireNoOutbound's positive: the message the daemon owes
+// this client is on its queue once the bubble has settled, or it is never coming.
+func requireOutbound(t *testing.T, client *wsClient, what string) outboundMessage {
+	t.Helper()
+	synctest.Wait()
+	select {
+	case outbound := <-client.send:
+		return outbound
+	default:
+		t.Fatal(what)
+		return outboundMessage{}
+	}
+}
+
+// settleStopClassification lets the goroutine handleStop spawns run out. That
+// goroutine re-reads the stop transcript on a retry loop (internal/agent's
+// claudeTranscriptRetryWindow, 2s, every 100ms) and outlives the assertions of a
+// test that only cares about handleStop's synchronous side effects. Outside a
+// bubble it is invisible; inside one it is a bubble goroutine still sleeping when
+// the body returns, which is rule 4. Sleeping past its window retires it.
+func settleStopClassification(t *testing.T) {
+	t.Helper()
+	time.Sleep(4 * time.Second)
+	synctest.Wait()
 }

--- a/internal/daemon/ticket_buffer_test.go
+++ b/internal/daemon/ticket_buffer_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
@@ -101,79 +102,68 @@ func TestTicketDeadlineOnlyBypassesObserverBufferForDoneTransition(t *testing.T)
 }
 
 func TestDoneTransitionPullsObserversForwardAndPiggybacksBufferedActivity(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.nudgeWindowOverride = time.Minute
-	d.ticketBufferWindowOverride = time.Hour
-	t.Cleanup(d.stopNudgeCountdowns)
-	chiefID, assignees, _ := delegateMany(t, d, "codex", "finish the design", "investigate the follow-up")
-	assignee, otherAssignee := assignees[0], assignees[1]
-	ticketID := boundTicketID(t, d, assignee)
-	otherTicketID := boundTicketID(t, d, otherAssignee)
-	d.setSelectedSession(assignee)
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		d.nudgeWindowOverride = time.Minute
+		d.ticketBufferWindowOverride = time.Hour
+		stopDaemonBackground(t, d)
+		chiefID, assignees, _ := delegateMany(t, d, "codex", "finish the design", "investigate the follow-up")
+		assignee, otherAssignee := assignees[0], assignees[1]
+		ticketID := boundTicketID(t, d, assignee)
+		otherTicketID := boundTicketID(t, d, otherAssignee)
+		d.setSelectedSession(assignee)
 
-	subscriberID := "subscriber"
-	d.store.Add(&protocol.Session{ID: subscriberID, Label: subscriberID, Agent: protocol.SessionAgentCodex, Directory: t.TempDir(), State: protocol.StateIdle})
-	for _, subscribedTicketID := range []string{ticketID, otherTicketID} {
-		if err := d.store.AddTicketSubscription(subscriberID, subscribedTicketID, time.Now()); err != nil {
+		subscriberID := "subscriber"
+		d.store.Add(&protocol.Session{ID: subscriberID, Label: subscriberID, Agent: protocol.SessionAgentCodex, Directory: t.TempDir(), State: protocol.StateIdle})
+		for _, subscribedTicketID := range []string{ticketID, otherTicketID} {
+			if err := d.store.AddTicketSubscription(subscriberID, subscribedTicketID, time.Now()); err != nil {
+				t.Fatal(err)
+			}
+		}
+		for _, observer := range []string{chiefID, subscriberID} {
+			_ = callTicketInbox(t, d, observer)
+			if err := d.store.SetTicketDeliveryAttention(d.ticketAttentionKey(observer), time.Now()); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if _, err := d.store.AddTicketComment(ticketID, assignee, "implementation finished", time.Now()); err != nil {
 			t.Fatal(err)
 		}
-	}
-	for _, observer := range []string{chiefID, subscriberID} {
-		_ = callTicketInbox(t, d, observer)
-		if err := d.store.SetTicketDeliveryAttention(d.ticketAttentionKey(observer), time.Now()); err != nil {
+		d.notifyTicketObservers(ticketID)
+		if _, err := d.store.AddTicketComment(otherTicketID, otherAssignee, "related investigation update", time.Now()); err != nil {
 			t.Fatal(err)
 		}
-	}
-
-	if _, err := d.store.AddTicketComment(ticketID, assignee, "implementation finished", time.Now()); err != nil {
-		t.Fatal(err)
-	}
-	d.notifyTicketObservers(ticketID)
-	if _, err := d.store.AddTicketComment(otherTicketID, otherAssignee, "related investigation update", time.Now()); err != nil {
-		t.Fatal(err)
-	}
-	d.notifyTicketObservers(otherTicketID)
-	for _, observer := range []string{chiefID, subscriberID} {
-		deadline := waitForNudgeDeadline(t, d, observer)
-		if deadline.Before(time.Now().Add(59 * time.Minute)) {
-			t.Fatalf("%s comment deadline = %s, want buffered", observer, deadline)
+		d.notifyTicketObservers(otherTicketID)
+		for _, observer := range []string{chiefID, subscriberID} {
+			deadline := settledNudgeDeadline(t, d, observer)
+			if deadline.Before(time.Now().Add(59 * time.Minute)) {
+				t.Fatalf("%s comment deadline = %s, want buffered", observer, deadline)
+			}
 		}
-	}
 
-	callSetTicketStatus(t, d, assignee, string(protocol.DispatchWorkStateCompleted), "accepted plan attached")
-	for _, observer := range []string{chiefID, subscriberID} {
-		waitForNudgeDeadlineBefore(t, d, observer, time.Now().Add(61*time.Second))
-	}
-	// A daemon restart loses only the in-memory countdown. Rebuilding from the
-	// durable unread completion event must retain immediate eligibility.
-	d.cancelNudgeCountdown(chiefID, "simulate daemon restart")
-	d.notifyUnreadTicketSession(chiefID, time.Now())
-	waitForNudgeDeadlineBefore(t, d, chiefID, time.Now().Add(61*time.Second))
-
-	watch := protocol.TicketInboxModeWatch
-	chiefBundles := callTicketInboxMode(t, d, chiefID, &watch)
-	assertDoneFlushBundles(t, chiefBundles, ticketID, assignee, otherTicketID, otherAssignee)
-	subscriberBundles := callTicketInbox(t, d, subscriberID)
-	assertDoneFlushBundles(t, subscriberBundles, ticketID, assignee, otherTicketID, otherAssignee)
-	if again := callTicketInbox(t, d, chiefID); len(again) != 0 {
-		t.Fatalf("chief replayed completion = %+v", again)
-	}
-	if again := callTicketInbox(t, d, subscriberID); len(again) != 0 {
-		t.Fatalf("subscriber replayed completion = %+v", again)
-	}
-}
-
-func waitForNudgeDeadlineBefore(t *testing.T, d *Daemon, sessionID string, before time.Time) time.Time {
-	t.Helper()
-	limit := time.Now().Add(time.Second)
-	for time.Now().Before(limit) {
-		if deadline := currentNudgeDeadline(d, sessionID); !deadline.IsZero() && deadline.Before(before) {
-			return deadline
+		callSetTicketStatus(t, d, assignee, string(protocol.DispatchWorkStateCompleted), "accepted plan attached")
+		for _, observer := range []string{chiefID, subscriberID} {
+			settledNudgeDeadlineBefore(t, d, observer, time.Now().Add(61*time.Second))
 		}
-		time.Sleep(time.Millisecond)
-	}
-	t.Fatalf("%s deadline = %s, want before %s", sessionID, currentNudgeDeadline(d, sessionID), before)
-	return time.Time{}
+		// A daemon restart loses only the in-memory countdown. Rebuilding from the
+		// durable unread completion event must retain immediate eligibility.
+		d.cancelNudgeCountdown(chiefID, "simulate daemon restart")
+		d.notifyUnreadTicketSession(chiefID, time.Now())
+		settledNudgeDeadlineBefore(t, d, chiefID, time.Now().Add(61*time.Second))
+
+		watch := protocol.TicketInboxModeWatch
+		chiefBundles := callTicketInboxMode(t, d, chiefID, &watch)
+		assertDoneFlushBundles(t, chiefBundles, ticketID, assignee, otherTicketID, otherAssignee)
+		subscriberBundles := callTicketInbox(t, d, subscriberID)
+		assertDoneFlushBundles(t, subscriberBundles, ticketID, assignee, otherTicketID, otherAssignee)
+		if again := callTicketInbox(t, d, chiefID); len(again) != 0 {
+			t.Fatalf("chief replayed completion = %+v", again)
+		}
+		if again := callTicketInbox(t, d, subscriberID); len(again) != 0 {
+			t.Fatalf("subscriber replayed completion = %+v", again)
+		}
+	})
 }
 
 func assertDoneFlushBundles(t *testing.T, bundles []protocol.TicketEventBundle, ticketID, assignee, otherTicketID, otherAssignee string) {
@@ -202,6 +192,12 @@ func assertDoneFlushBundles(t *testing.T, bundles []protocol.TicketEventBundle, 
 	}
 }
 
+// Boundary-bound: the claim under test is that the catch-up goroutine stays
+// parked on d.deliveryMu while reconstruction holds it. A goroutine blocked on a
+// sync.Mutex is explicitly NOT durably blocked, so a bubble cannot tell "still
+// waiting for the lock" from "about to run" — synctest.Wait would never return.
+// The 100ms here is the wall-clock price of an assertion the fake clock cannot
+// make.
 func TestMutationCatchUpRebuildsRemainingUnreadFromNewAttention(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.nudgeWindowOverride = time.Second
@@ -284,30 +280,32 @@ func TestMutationCatchUpRebuildsRemainingUnreadFromNewAttention(t *testing.T) {
 }
 
 func TestExplicitInboxConsumesDuringObserverBuffer(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.nudgeWindowOverride = time.Second
-	d.ticketBufferWindowOverride = time.Hour
-	t.Cleanup(d.stopNudgeCountdowns)
-	chiefID, agentID, _ := delegateForNotify(t, d, "codex")
-	ticketID := boundTicketID(t, d, agentID)
-	if bundles := callTicketInbox(t, d, chiefID); len(bundles) != 0 {
-		t.Fatalf("initial chief inbox = %+v", bundles)
-	}
-	if err := d.store.SetTicketDeliveryAttention(d.ticketAttentionKey(chiefID), time.Now()); err != nil {
-		t.Fatal(err)
-	}
-	d.setSelectedSession(agentID)
-	callSetTicketStatus(t, d, agentID, string(protocol.DispatchWorkStateNeedsInput), "need a decision")
-	deadline := waitForNudgeDeadline(t, d, chiefID)
-	if deadline.Before(time.Now().Add(59 * time.Minute)) {
-		t.Fatalf("needs-input observer deadline = %s, want buffered", deadline)
-	}
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		d.nudgeWindowOverride = time.Second
+		d.ticketBufferWindowOverride = time.Hour
+		stopDaemonBackground(t, d)
+		chiefID, agentID, _ := delegateForNotify(t, d, "codex")
+		ticketID := boundTicketID(t, d, agentID)
+		if bundles := callTicketInbox(t, d, chiefID); len(bundles) != 0 {
+			t.Fatalf("initial chief inbox = %+v", bundles)
+		}
+		if err := d.store.SetTicketDeliveryAttention(d.ticketAttentionKey(chiefID), time.Now()); err != nil {
+			t.Fatal(err)
+		}
+		d.setSelectedSession(agentID)
+		callSetTicketStatus(t, d, agentID, string(protocol.DispatchWorkStateNeedsInput), "need a decision")
+		deadline := settledNudgeDeadline(t, d, chiefID)
+		if deadline.Before(time.Now().Add(59 * time.Minute)) {
+			t.Fatalf("needs-input observer deadline = %s, want buffered", deadline)
+		}
 
-	bundles := callTicketInbox(t, d, chiefID)
-	if len(bundles) != 1 || bundles[0].TicketID != ticketID {
-		t.Fatalf("explicit inbox = %+v, want immediate catch-up", bundles)
-	}
-	if currentNudgeTimer(d, chiefID) != nil {
-		t.Fatal("explicit inbox left the buffered countdown armed")
-	}
+		bundles := callTicketInbox(t, d, chiefID)
+		if len(bundles) != 1 || bundles[0].TicketID != ticketID {
+			t.Fatalf("explicit inbox = %+v, want immediate catch-up", bundles)
+		}
+		if currentNudgeTimer(d, chiefID) != nil {
+			t.Fatal("explicit inbox left the buffered countdown armed")
+		}
+	})
 }

--- a/internal/daemon/tilecontent_test.go
+++ b/internal/daemon/tilecontent_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"syscall"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/hub"
@@ -58,7 +59,14 @@ func TestReadMarkdownFile(t *testing.T) {
 // the daemon, a test client, the workspace id, and the session/pane ids.
 func setupMarkdownWorkspace(t *testing.T) (*Daemon, *wsClient, string) {
 	t.Helper()
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	return setupMarkdownWorkspaceOn(t, NewForTesting(filepath.Join(t.TempDir(), "test.sock")))
+}
+
+// setupMarkdownWorkspaceOn is setupMarkdownWorkspace against a daemon the caller
+// already built — the shape a synctest bubble needs, where the daemon is
+// constructed outside and everything it touches happens inside.
+func setupMarkdownWorkspaceOn(t *testing.T, d *Daemon) (*Daemon, *wsClient, string) {
+	t.Helper()
 	client := newWorkspaceProtocolTestClient()
 	workspaceID := "workspace-md"
 	d.handleRegisterWorkspace(client, &protocol.RegisterWorkspaceMessage{
@@ -159,62 +167,62 @@ func TestWorkspaceTileContentGetRejectsUnsupportedTileKind(t *testing.T) {
 }
 
 func TestWorkspaceTileContentReloadOnlyReachesSubscribedClients(t *testing.T) {
-	d, subscribed, workspaceID := setupMarkdownWorkspace(t)
-	unrelated := newWorkspaceProtocolTestClient()
-	file := filepath.Join(t.TempDir(), "private.md")
-	if err := os.WriteFile(file, []byte("# Private"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := d.dockTile(workspaceID, "pane-1", markdownTileIDForPath(file), string(workspacelayout.TileKindMarkdown), file, "", protocol.WorkspaceLayoutDockEdgeRight, nil); err != nil {
-		t.Fatalf("dockTile: %v", err)
-	}
+	base := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	synctest.Test(t, func(t *testing.T) {
+		d, subscribed, workspaceID := setupMarkdownWorkspaceOn(t, base)
+		stopDaemonBackground(t, d)
+		unrelated := newWorkspaceProtocolTestClient()
+		file := filepath.Join(t.TempDir(), "private.md")
+		if err := os.WriteFile(file, []byte("# Private"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := d.dockTile(workspaceID, "pane-1", markdownTileIDForPath(file), string(workspacelayout.TileKindMarkdown), file, "", protocol.WorkspaceLayoutDockEdgeRight, nil); err != nil {
+			t.Fatalf("dockTile: %v", err)
+		}
 
-	d.wsHub.clients[subscribed] = true
-	d.wsHub.clients[unrelated] = true
-	d.handleWorkspaceTileContentGet(subscribed, &protocol.WorkspaceTileContentGetMessage{
-		Cmd:         protocol.CmdWorkspaceTileContentGet,
-		WorkspaceID: workspaceID,
-		TileID:      markdownTileIDForPath(file),
+		d.wsHub.clients[subscribed] = true
+		d.wsHub.clients[unrelated] = true
+		d.handleWorkspaceTileContentGet(subscribed, &protocol.WorkspaceTileContentGetMessage{
+			Cmd:         protocol.CmdWorkspaceTileContentGet,
+			WorkspaceID: workspaceID,
+			TileID:      markdownTileIDForPath(file),
+		})
+		_ = expectTileContent(t, subscribed, markdownTileIDForPath(file))
+
+		d.broadcastTileContentNow(workspaceID, markdownTileIDForPath(file))
+		got := expectTileContent(t, subscribed, markdownTileIDForPath(file))
+		if got.Content != "# Private" {
+			t.Fatalf("content = %q, want the file body", got.Content)
+		}
+		requireNoOutbound(t, unrelated, "unrelated client received private tile content")
 	})
-	_ = expectTileContent(t, subscribed, markdownTileIDForPath(file))
-
-	d.broadcastTileContentNow(workspaceID, markdownTileIDForPath(file))
-	got := expectTileContent(t, subscribed, markdownTileIDForPath(file))
-	if got.Content != "# Private" {
-		t.Fatalf("content = %q, want the file body", got.Content)
-	}
-	select {
-	case outbound := <-unrelated.send:
-		t.Fatalf("unrelated client received private tile content: %s", string(outbound.payload))
-	case <-time.After(20 * time.Millisecond):
-	}
 }
 
 func TestBroadcastTileContentDropsStaleRetargetedRead(t *testing.T) {
-	d, client, workspaceID := setupMarkdownWorkspace(t)
-	oldFile := filepath.Join(t.TempDir(), "old.md")
-	newFile := filepath.Join(t.TempDir(), "new.md")
-	tileID := markdownTileIDForPath(oldFile)
-	if err := d.dockTile(workspaceID, "pane-1", tileID, string(workspacelayout.TileKindMarkdown), oldFile, "", protocol.WorkspaceLayoutDockEdgeRight, nil); err != nil {
-		t.Fatalf("dock old tile: %v", err)
-	}
-	d.wsHub.clients[client] = true
-	client.subscribeTileContent(workspaceID, tileID)
-	if err := d.dockTile(workspaceID, "pane-1", tileID, string(workspacelayout.TileKindMarkdown), newFile, "", protocol.WorkspaceLayoutDockEdgeRight, nil); err != nil {
-		t.Fatalf("retarget tile: %v", err)
-	}
+	base := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	synctest.Test(t, func(t *testing.T) {
+		d, client, workspaceID := setupMarkdownWorkspaceOn(t, base)
+		stopDaemonBackground(t, d)
+		oldFile := filepath.Join(t.TempDir(), "old.md")
+		newFile := filepath.Join(t.TempDir(), "new.md")
+		tileID := markdownTileIDForPath(oldFile)
+		if err := d.dockTile(workspaceID, "pane-1", tileID, string(workspacelayout.TileKindMarkdown), oldFile, "", protocol.WorkspaceLayoutDockEdgeRight, nil); err != nil {
+			t.Fatalf("dock old tile: %v", err)
+		}
+		d.wsHub.clients[client] = true
+		client.subscribeTileContent(workspaceID, tileID)
+		if err := d.dockTile(workspaceID, "pane-1", tileID, string(workspacelayout.TileKindMarkdown), newFile, "", protocol.WorkspaceLayoutDockEdgeRight, nil); err != nil {
+			t.Fatalf("retarget tile: %v", err)
+		}
 
-	d.broadcastTileContent(workspaceID, tileID, string(workspacelayout.TileKindMarkdown), oldFile, "# Old", nil)
-	select {
-	case outbound := <-client.send:
-		t.Fatalf("client received stale tile content: %s", string(outbound.payload))
-	case <-time.After(20 * time.Millisecond):
-	}
+		d.broadcastTileContent(workspaceID, tileID, string(workspacelayout.TileKindMarkdown), oldFile, "# Old", nil)
+		requireNoOutbound(t, client, "client received stale tile content")
 
-	d.broadcastTileContent(workspaceID, tileID, string(workspacelayout.TileKindMarkdown), newFile, "# New", nil)
-	if got := expectTileContent(t, client, tileID); got.Content != "# New" || got.Path != newFile {
-		t.Fatalf("tile content = %+v, want current retargeted file", got)
-	}
+		d.broadcastTileContent(workspaceID, tileID, string(workspacelayout.TileKindMarkdown), newFile, "# New", nil)
+		if got := expectTileContent(t, client, tileID); got.Content != "# New" || got.Path != newFile {
+			t.Fatalf("tile content = %+v, want current retargeted file", got)
+		}
+	})
 }
 
 func TestDockTileMovePreservesExistingFraction(t *testing.T) {
@@ -711,6 +719,10 @@ func TestOpenMarkdownWSUnknownSessionFails(t *testing.T) {
 	}
 }
 
+// Boundary-bound: the sleep buys a real filesystem nanosecond, not a schedule.
+// The change detector compares the file's mtime, and a bubble's clock does not
+// reach the filesystem — fake time would advance while the second write landed
+// inside the same mtime tick as the first.
 func TestCollectChangedMarkdownTilesTracksMultipleTiles(t *testing.T) {
 	d, client, workspaceID := setupMarkdownWorkspace(t)
 	d.wsHub.clients[client] = true

--- a/internal/daemon/transcript_watcher_abort_test.go
+++ b/internal/daemon/transcript_watcher_abort_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
@@ -120,36 +121,39 @@ func TestTheWatcherSettlesATurnTheUserHalted(t *testing.T) {
 			home, _ := toolhome.Dir()
 
 			d := newTraceDaemon(t)
-			id := "sess-halted-" + tc.name
-			addCharacterizationSession(t, d, id, tc.agent, protocol.SessionStateWorking)
-			session := d.store.Get(id)
+			synctest.Test(t, func(t *testing.T) {
+				stopDaemonBackground(t, d)
+				id := "sess-halted-" + tc.name
+				addCharacterizationSession(t, d, id, tc.agent, protocol.SessionStateWorking)
+				session := d.store.Get(id)
 
-			// The turn the user is about to halt. Its closing hook is the one that
-			// never arrives.
-			d.recordBracketEvidence(id, protocol.StateWorking)
+				// The turn the user is about to halt. Its closing hook is the one that
+				// never arrives.
+				d.recordBracketEvidence(id, protocol.StateWorking)
 
-			startedAt := time.Now()
-			path := tc.seed(t, home, session.Directory, id)
-			d.startTranscriptWatcher(id, tc.agent, session.Directory, startedAt)
-			t.Cleanup(func() { d.stopTranscriptWatcher(id) })
+				startedAt := time.Now()
+				path := tc.seed(t, home, session.Directory, id)
+				d.startTranscriptWatcher(id, tc.agent, session.Directory, startedAt)
+				t.Cleanup(func() { d.stopTranscriptWatcher(id) })
 
-			// Let the watcher find the file before the abort lands, so the test
-			// exercises the tail rather than the bootstrap read.
-			waitForTranscriptDiscovery(t, d, id)
-			writeLine(t, path, tc.abort(time.Now()))
+				// Let the watcher find the file before the abort lands, so the test
+				// exercises the tail rather than the bootstrap read.
+				requireTranscriptDiscovery(t, d, id)
+				writeLine(t, path, tc.abort(time.Now()))
 
-			evidence := waitForAbortEvidence(t, d, id)
-			if evidence.TurnOpen || evidence.ToolOpen {
-				t.Fatalf("the halted turn left a bracket open: %+v", evidence)
-			}
+				evidence := requireAbortEvidence(t, d, id)
+				if evidence.TurnOpen || evidence.ToolOpen {
+					t.Fatalf("the halted turn left a bracket open: %+v", evidence)
+				}
 
-			d.resolveAllSessions(time.Now())
-			if state := d.store.Get(id).State; state != protocol.SessionStateIdle {
-				t.Fatalf("state %q, want idle: a halted turn is over the moment it is halted", state)
-			}
-			if got := sessionstate.Resolve(evidence, sessionstate.PolicyFor(string(tc.agent)), time.Now()); got.Reason != sessionstate.ReasonTurnAborted {
-				t.Fatalf("reason %q, want turn_aborted: the diagnosis is half the point", got.Reason)
-			}
+				d.resolveAllSessions(time.Now())
+				if state := d.store.Get(id).State; state != protocol.SessionStateIdle {
+					t.Fatalf("state %q, want idle: a halted turn is over the moment it is halted", state)
+				}
+				if got := sessionstate.Resolve(evidence, sessionstate.PolicyFor(string(tc.agent)), time.Now()); got.Reason != sessionstate.ReasonTurnAborted {
+					t.Fatalf("reason %q, want turn_aborted: the diagnosis is half the point", got.Reason)
+				}
+			})
 		})
 	}
 }
@@ -166,34 +170,37 @@ func TestAHaltFromBeforeTheSessionStartedIsIgnored(t *testing.T) {
 			home, _ := toolhome.Dir()
 
 			d := newTraceDaemon(t)
-			id := "sess-replayed-halt-" + tc.name
-			addCharacterizationSession(t, d, id, tc.agent, protocol.SessionStateWorking)
-			session := d.store.Get(id)
-			d.recordBracketEvidence(id, protocol.StateWorking)
+			synctest.Test(t, func(t *testing.T) {
+				stopDaemonBackground(t, d)
+				id := "sess-replayed-halt-" + tc.name
+				addCharacterizationSession(t, d, id, tc.agent, protocol.SessionStateWorking)
+				session := d.store.Get(id)
+				d.recordBracketEvidence(id, protocol.StateWorking)
 
-			// The transcript already holds a halt from an earlier life, and the
-			// watcher starts after it — exactly what a resume looks like.
-			startedAt := time.Now()
-			path := tc.seed(t, home, session.Directory, id)
-			writeLine(t, path, tc.abort(startedAt.Add(-2*time.Hour)))
+				// The transcript already holds a halt from an earlier life, and the
+				// watcher starts after it — exactly what a resume looks like.
+				startedAt := time.Now()
+				path := tc.seed(t, home, session.Directory, id)
+				writeLine(t, path, tc.abort(startedAt.Add(-2*time.Hour)))
 
-			d.startTranscriptWatcher(id, tc.agent, session.Directory, startedAt)
-			t.Cleanup(func() { d.stopTranscriptWatcher(id) })
-			waitForTranscriptDiscovery(t, d, id)
+				d.startTranscriptWatcher(id, tc.agent, session.Directory, startedAt)
+				t.Cleanup(func() { d.stopTranscriptWatcher(id) })
+				requireTranscriptDiscovery(t, d, id)
 
-			// Long enough for several polls to have read the bootstrap window.
-			time.Sleep(4 * transcriptPollInterval)
+				// Long enough for several polls to have read the bootstrap window.
+				advancePolls(4)
 
-			got, ok := d.evidenceTable().snapshot(id)
-			if !ok {
-				t.Fatal("no evidence recorded")
-			}
-			if got.LastHarnessEvent != nil && got.LastHarnessEvent.Claim == sessionstate.ClaimTurnAborted {
-				t.Fatal("a halt replayed out of history settled a session that is working")
-			}
-			if !got.TurnOpen {
-				t.Fatal("the open turn was closed by a halt from a previous session")
-			}
+				got, ok := d.evidenceTable().snapshot(id)
+				if !ok {
+					t.Fatal("no evidence recorded")
+				}
+				if got.LastHarnessEvent != nil && got.LastHarnessEvent.Claim == sessionstate.ClaimTurnAborted {
+					t.Fatal("a halt replayed out of history settled a session that is working")
+				}
+				if !got.TurnOpen {
+					t.Fatal("the open turn was closed by a halt from a previous session")
+				}
+			})
 		})
 	}
 }
@@ -206,32 +213,35 @@ func TestAnUndatedHaltIsIgnored(t *testing.T) {
 	home, _ := toolhome.Dir()
 
 	d := newTraceDaemon(t)
-	id := "sess-undated-halt"
-	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
-	session := d.store.Get(id)
-	d.recordBracketEvidence(id, protocol.StateWorking)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		id := "sess-undated-halt"
+		addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+		session := d.store.Get(id)
+		d.recordBracketEvidence(id, protocol.StateWorking)
 
-	projects := filepath.Join(home, ".claude", "projects", "a-project")
-	if err := os.MkdirAll(projects, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	path := filepath.Join(projects, id+".jsonl")
-	writeLine(t, path, `{"type":"user","message":{"role":"user","content":"write an essay"}}`)
+		projects := filepath.Join(home, ".claude", "projects", "a-project")
+		if err := os.MkdirAll(projects, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		path := filepath.Join(projects, id+".jsonl")
+		writeLine(t, path, `{"type":"user","message":{"role":"user","content":"write an essay"}}`)
 
-	d.startTranscriptWatcher(id, protocol.SessionAgentClaude, session.Directory, time.Now())
-	t.Cleanup(func() { d.stopTranscriptWatcher(id) })
-	waitForTranscriptDiscovery(t, d, id)
+		d.startTranscriptWatcher(id, protocol.SessionAgentClaude, session.Directory, time.Now())
+		t.Cleanup(func() { d.stopTranscriptWatcher(id) })
+		requireTranscriptDiscovery(t, d, id)
 
-	writeLine(t, path, `{"type":"user","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user]"}]},"interruptedMessageId":"msg_01"}`)
-	time.Sleep(4 * transcriptPollInterval)
+		writeLine(t, path, `{"type":"user","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user]"}]},"interruptedMessageId":"msg_01"}`)
+		advancePolls(4)
 
-	got, ok := d.evidenceTable().snapshot(id)
-	if !ok {
-		t.Fatal("no evidence recorded")
-	}
-	if got.LastHarnessEvent != nil && got.LastHarnessEvent.Claim == sessionstate.ClaimTurnAborted {
-		t.Fatal("an undated halt was filed as though it had just happened")
-	}
+		got, ok := d.evidenceTable().snapshot(id)
+		if !ok {
+			t.Fatal("no evidence recorded")
+		}
+		if got.LastHarnessEvent != nil && got.LastHarnessEvent.Claim == sessionstate.ClaimTurnAborted {
+			t.Fatal("an undated halt was filed as though it had just happened")
+		}
+	})
 }
 
 // The halt is dated by the agent, not by the poll that read it. Half a second of
@@ -282,57 +292,57 @@ func TestACopilotAbortNobodyAskedForStillClosesTheTurn(t *testing.T) {
 	home, _ := toolhome.Dir()
 
 	d := newTraceDaemon(t)
-	id := "sess-copilot-tool-failure"
-	addCharacterizationSession(t, d, id, protocol.SessionAgentCopilot, protocol.SessionStateWorking)
-	session := d.store.Get(id)
-	d.recordBracketEvidence(id, protocol.StateWorking)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		id := "sess-copilot-tool-failure"
+		addCharacterizationSession(t, d, id, protocol.SessionAgentCopilot, protocol.SessionStateWorking)
+		session := d.store.Get(id)
+		d.recordBracketEvidence(id, protocol.StateWorking)
 
-	var seed func(t *testing.T, home, dir, sessionID string) string
-	for _, tc := range haltedTurnCases() {
-		if tc.name == "copilot" {
-			seed = tc.seed
+		var seed func(t *testing.T, home, dir, sessionID string) string
+		for _, tc := range haltedTurnCases() {
+			if tc.name == "copilot" {
+				seed = tc.seed
+			}
 		}
-	}
-	path := seed(t, home, session.Directory, id)
+		path := seed(t, home, session.Directory, id)
 
-	d.startTranscriptWatcher(id, protocol.SessionAgentCopilot, session.Directory, time.Now())
-	t.Cleanup(func() { d.stopTranscriptWatcher(id) })
-	waitForTranscriptDiscovery(t, d, id)
+		d.startTranscriptWatcher(id, protocol.SessionAgentCopilot, session.Directory, time.Now())
+		t.Cleanup(func() { d.stopTranscriptWatcher(id) })
+		requireTranscriptDiscovery(t, d, id)
 
-	writeLine(t, path, fmt.Sprintf(
-		`{"type":"abort","timestamp":%q,"data":{"reason":"tool_failure"}}`,
-		time.Now().UTC().Format(time.RFC3339Nano),
-	))
+		writeLine(t, path, fmt.Sprintf(
+			`{"type":"abort","timestamp":%q,"data":{"reason":"tool_failure"}}`,
+			time.Now().UTC().Format(time.RFC3339Nano),
+		))
 
-	got := waitForClosedTurnBracket(t, d, id)
-	if got.LastHarnessEvent != nil && got.LastHarnessEvent.Claim == sessionstate.ClaimTurnAborted {
-		t.Fatal("copilot giving up on its own was filed as the user halting the turn")
-	}
+		got := requireClosedTurnBracket(t, d, id)
+		if got.LastHarnessEvent != nil && got.LastHarnessEvent.Claim == sessionstate.ClaimTurnAborted {
+			t.Fatal("copilot giving up on its own was filed as the user halting the turn")
+		}
 
-	// The bracket is what pins the session, and for copilot it pins it from the
-	// moment the abort lands: with no heartbeat to go silent, the resolver's stale
-	// test cannot retire the bracket at all, so `bracket_open` holds until the
-	// stuck timer converts it to `unknown`. Settling the turn is the classifier's
-	// job — this only has to prove nothing is still claiming the turn is running.
-	policy := sessionstate.PolicyFor(string(protocol.SessionAgentCopilot))
-	if reason := sessionstate.Resolve(got, policy, time.Now()).Reason; reason == sessionstate.ReasonBracketOpen {
-		t.Fatalf("reason %q: the abandoned turn held the session open", reason)
-	}
+		// The bracket is what pins the session, and for copilot it pins it from the
+		// moment the abort lands: with no heartbeat to go silent, the resolver's stale
+		// test cannot retire the bracket at all, so `bracket_open` holds until the
+		// stuck timer converts it to `unknown`. Settling the turn is the classifier's
+		// job — this only has to prove nothing is still claiming the turn is running.
+		policy := sessionstate.PolicyFor(string(protocol.SessionAgentCopilot))
+		if reason := sessionstate.Resolve(got, policy, time.Now()).Reason; reason == sessionstate.ReasonBracketOpen {
+			t.Fatalf("reason %q: the abandoned turn held the session open", reason)
+		}
+	})
 }
 
-// waitForClosedTurnBracket blocks until the watcher has closed the evidence
-// brackets, which for copilot is the only thing that ends an abandoned turn.
-func waitForClosedTurnBracket(t *testing.T, d *Daemon, sessionID string) sessionstate.Evidence {
+// requireClosedTurnBracket asserts the watcher has closed the evidence brackets,
+// which for copilot is the only thing that ends an abandoned turn.
+func requireClosedTurnBracket(t *testing.T, d *Daemon, sessionID string) sessionstate.Evidence {
 	t.Helper()
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if got, ok := d.evidenceTable().snapshot(sessionID); ok && !got.TurnOpen && !got.ToolOpen {
-			return got
-		}
-		time.Sleep(transcriptPollInterval / 2)
+	advancePolls(2)
+	got, ok := d.evidenceTable().snapshot(sessionID)
+	if !ok || got.TurnOpen || got.ToolOpen {
+		t.Fatal("the abandoned turn left its bracket open")
 	}
-	t.Fatal("the abandoned turn left its bracket open")
-	return sessionstate.Evidence{}
+	return got
 }
 
 // A user who quotes the marker back at claude — asking about it, pasting a log —
@@ -343,35 +353,38 @@ func TestATranscriptLineThatMerelyMentionsTheMarkerIsNotAHalt(t *testing.T) {
 	home, _ := toolhome.Dir()
 
 	d := newTraceDaemon(t)
-	id := "sess-marker-mention"
-	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
-	session := d.store.Get(id)
-	d.recordBracketEvidence(id, protocol.StateWorking)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		id := "sess-marker-mention"
+		addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+		session := d.store.Get(id)
+		d.recordBracketEvidence(id, protocol.StateWorking)
 
-	projects := filepath.Join(home, ".claude", "projects", "a-project")
-	if err := os.MkdirAll(projects, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	path := filepath.Join(projects, id+".jsonl")
-	writeLine(t, path, `{"type":"user","message":{"role":"user","content":"why do i see [Request interrupted by user] in my logs?"}}`)
+		projects := filepath.Join(home, ".claude", "projects", "a-project")
+		if err := os.MkdirAll(projects, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		path := filepath.Join(projects, id+".jsonl")
+		writeLine(t, path, `{"type":"user","message":{"role":"user","content":"why do i see [Request interrupted by user] in my logs?"}}`)
 
-	d.startTranscriptWatcher(id, protocol.SessionAgentClaude, session.Directory, time.Now())
-	t.Cleanup(func() { d.stopTranscriptWatcher(id) })
-	waitForTranscriptDiscovery(t, d, id)
+		d.startTranscriptWatcher(id, protocol.SessionAgentClaude, session.Directory, time.Now())
+		t.Cleanup(func() { d.stopTranscriptWatcher(id) })
+		requireTranscriptDiscovery(t, d, id)
 
-	// Long enough for several polls to have read the line and decided nothing.
-	time.Sleep(4 * transcriptPollInterval)
+		// Long enough for several polls to have read the line and decided nothing.
+		advancePolls(4)
 
-	got, ok := d.evidenceTable().snapshot(id)
-	if !ok {
-		t.Fatal("no evidence recorded")
-	}
-	if got.LastHarnessEvent != nil && got.LastHarnessEvent.Claim == sessionstate.ClaimTurnAborted {
-		t.Fatal("a prompt that quotes the marker was read as the user halting the turn")
-	}
-	if !got.TurnOpen {
-		t.Fatal("the turn was closed by a line that only talked about interrupts")
-	}
+		got, ok := d.evidenceTable().snapshot(id)
+		if !ok {
+			t.Fatal("no evidence recorded")
+		}
+		if got.LastHarnessEvent != nil && got.LastHarnessEvent.Claim == sessionstate.ClaimTurnAborted {
+			t.Fatal("a prompt that quotes the marker was read as the user halting the turn")
+		}
+		if !got.TurnOpen {
+			t.Fatal("the turn was closed by a line that only talked about interrupts")
+		}
+	})
 }
 
 func writeLine(t *testing.T, path, line string) {
@@ -386,36 +399,34 @@ func writeLine(t *testing.T, path, line string) {
 	}
 }
 
-// waitForTranscriptDiscovery blocks until the watcher has adopted a transcript,
-// which is the point from which appended lines are tailed.
-func waitForTranscriptDiscovery(t *testing.T, d *Daemon, sessionID string) {
+// requireTranscriptDiscovery advances past enough of the watcher's own polls for
+// it to have adopted a transcript, which is the point from which appended lines
+// are tailed. The watcher is a plain time.Ticker over the filesystem — no
+// fsnotify — so it runs at its shipped 500ms interval inside a bubble and two
+// ticks of fake time cost nothing.
+func requireTranscriptDiscovery(t *testing.T, d *Daemon, sessionID string) {
 	t.Helper()
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		d.watchersMu.Lock()
-		watcher := d.transcriptWatch[sessionID]
-		d.watchersMu.Unlock()
-		if watcher != nil && d.findTranscriptPathForWatcher(watcher) != "" {
-			// One more poll so the watcher itself has adopted it.
-			time.Sleep(3 * transcriptPollInterval)
-			return
-		}
-		time.Sleep(transcriptPollInterval / 2)
+	advancePolls(2)
+	d.watchersMu.Lock()
+	watcher := d.transcriptWatch[sessionID]
+	d.watchersMu.Unlock()
+	if watcher == nil || d.findTranscriptPathForWatcher(watcher) == "" {
+		t.Fatal("watcher never discovered the transcript")
 	}
-	t.Fatal("watcher never discovered the transcript")
 }
 
-func waitForAbortEvidence(t *testing.T, d *Daemon, sessionID string) sessionstate.Evidence {
+// advancePolls runs n of the transcript watcher's polls to completion.
+func advancePolls(n int) {
+	time.Sleep(time.Duration(n) * transcriptPollInterval)
+	synctest.Wait()
+}
+
+func requireAbortEvidence(t *testing.T, d *Daemon, sessionID string) sessionstate.Evidence {
 	t.Helper()
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if got, ok := d.evidenceTable().snapshot(sessionID); ok &&
-			got.LastHarnessEvent != nil &&
-			got.LastHarnessEvent.Claim == sessionstate.ClaimTurnAborted {
-			return got
-		}
-		time.Sleep(transcriptPollInterval / 2)
+	advancePolls(2)
+	got, ok := d.evidenceTable().snapshot(sessionID)
+	if !ok || got.LastHarnessEvent == nil || got.LastHarnessEvent.Claim != sessionstate.ClaimTurnAborted {
+		t.Fatal("the halted turn was never filed as evidence")
 	}
-	t.Fatal("the halted turn was never filed as evidence")
-	return sessionstate.Evidence{}
+	return got
 }

--- a/internal/daemon/workspace_context_test.go
+++ b/internal/daemon/workspace_context_test.go
@@ -34,6 +34,9 @@ func setupWorkspaceContextSession(t *testing.T, d *Daemon, sessionID, workspaceI
 	d.workspaces.associateSession(sessionID, workspaceID, sessionID)
 }
 
+// Boundary-bound: the broadcast assertion needs the WebSocket hub fanning out,
+// and `go d.wsHub.run()` has no exit path — a bubble ends only when its last
+// goroutine does, so this one would never finish.
 func TestWorkspaceContextCheckoutEditUpdateAndStatus(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")

--- a/internal/daemon/workspace_keeper_test.go
+++ b/internal/daemon/workspace_keeper_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/jobs"
@@ -365,34 +366,38 @@ func TestCompactContextTimeoutAndCancellationProtectContext(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-			setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
-			d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
-			d.keeperCompactThreshold = 1
-			if name == "timeout" {
-				d.keeperCompactTimeout = 20 * time.Millisecond
-			} else {
-				d.keeperCompactTimeout = time.Second
-			}
-			started := make(chan struct{})
-			d.workspaceContextCompactionExecution = func(
-				ctx context.Context, _ keeperCompactConfig, _ *protocol.WorkspaceContext,
-			) (keeperCompactExecution, error) {
-				close(started)
-				<-ctx.Done()
-				return keeperCompactExecution{}, ctx.Err()
-			}
-			installTestCompactQueue(t, d)
-			if _, _, err := d.store.UpdateWorkspaceContext("workspace-1", keeperSource, "session-1", 0); err != nil {
-				t.Fatalf("seed context: %v", err)
-			}
-			if _, err := d.jobQueue.Enqueue(compactContextKind, jobs.EnqueueOptions{UniqueKey: "workspace-1"}); err != nil {
-				t.Fatalf("enqueue: %v", err)
-			}
-			<-started
-			stop(t, d)
-			deadline := time.Now().Add(2 * time.Second)
-			for {
+			d := newBubbleDaemon(t)
+			synctest.Test(t, func(t *testing.T) {
+				stopDaemonBackground(t, d)
+				setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+				d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
+				d.keeperCompactThreshold = 1
+				if name == "timeout" {
+					d.keeperCompactTimeout = 20 * time.Millisecond
+				} else {
+					d.keeperCompactTimeout = time.Second
+				}
+				started := make(chan struct{})
+				d.workspaceContextCompactionExecution = func(
+					ctx context.Context, _ keeperCompactConfig, _ *protocol.WorkspaceContext,
+				) (keeperCompactExecution, error) {
+					close(started)
+					<-ctx.Done()
+					return keeperCompactExecution{}, ctx.Err()
+				}
+				installTestCompactQueue(t, d)
+				if _, _, err := d.store.UpdateWorkspaceContext("workspace-1", keeperSource, "session-1", 0); err != nil {
+					t.Fatalf("seed context: %v", err)
+				}
+				if _, err := d.jobQueue.Enqueue(compactContextKind, jobs.EnqueueOptions{UniqueKey: "workspace-1"}); err != nil {
+					t.Fatalf("enqueue: %v", err)
+				}
+				<-started
+				stop(t, d)
+				// Past the run timeout on the bubble clock: the timeout case needs it to
+				// elapse, the cancellation case has already aborted and only settles.
+				time.Sleep(2 * d.keeperCompactTimeout)
+				synctest.Wait()
 				current, err := d.store.GetWorkspaceContext("workspace-1")
 				if err != nil {
 					t.Fatalf("get current context: %v", err)
@@ -404,14 +409,10 @@ func TestCompactContextTimeoutAndCancellationProtectContext(t *testing.T) {
 				if err != nil {
 					t.Fatalf("get task: %v", err)
 				}
-				if task != nil && task.State != jobs.StateRunning {
-					break
+				if task == nil || task.State == jobs.StateRunning {
+					t.Fatalf("compaction run did not stop: %+v", task)
 				}
-				if time.Now().After(deadline) {
-					t.Fatal("compaction run did not stop")
-				}
-				time.Sleep(5 * time.Millisecond)
-			}
+			})
 		})
 	}
 }
@@ -420,50 +421,52 @@ func TestCompactContextTimeoutAndCancellationProtectContext(t *testing.T) {
 // fence: a Cancel that arrives after the executor has entered its commit waits
 // for the durable write to finish untorn.
 func TestCompactContextCancellationWaitsForAdmittedCommit(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
-	d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
-	d.keeperCompactThreshold = 1
-	d.workspaceContextCompactionExecution = fakeCompaction(keeperCandidate)
-	commitStarted := make(chan struct{})
-	releaseCommit := make(chan struct{})
-	d.workspaceContextBeforeKeeperApply = func() {
-		close(commitStarted)
-		<-releaseCommit
-	}
-	installTestCompactQueue(t, d)
-	if _, _, err := d.store.UpdateWorkspaceContext("workspace-1", keeperSource, "session-1", 0); err != nil {
-		t.Fatalf("seed context: %v", err)
-	}
-	if _, err := d.jobQueue.Enqueue(compactContextKind, jobs.EnqueueOptions{UniqueKey: "workspace-1"}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	<-commitStarted
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+		d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
+		d.keeperCompactThreshold = 1
+		d.workspaceContextCompactionExecution = fakeCompaction(keeperCandidate)
+		commitStarted := make(chan struct{})
+		releaseCommit := make(chan struct{})
+		d.workspaceContextBeforeKeeperApply = func() {
+			close(commitStarted)
+			<-releaseCommit
+		}
+		installTestCompactQueue(t, d)
+		if _, _, err := d.store.UpdateWorkspaceContext("workspace-1", keeperSource, "session-1", 0); err != nil {
+			t.Fatalf("seed context: %v", err)
+		}
+		if _, err := d.jobQueue.Enqueue(compactContextKind, jobs.EnqueueOptions{UniqueKey: "workspace-1"}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		<-commitStarted
 
-	cancelID := jobIDForKey(t, d.jobQueue, compactContextKind, "workspace-1")
-	cancelDone := make(chan struct{})
-	go func() {
-		d.jobQueue.Cancel(cancelID)
-		close(cancelDone)
-	}()
-	select {
-	case <-cancelDone:
-		t.Fatal("cancellation returned before the admitted commit finished")
-	case <-time.After(20 * time.Millisecond):
-	}
-	close(releaseCommit)
-	select {
-	case <-cancelDone:
-	case <-time.After(time.Second):
-		t.Fatal("cancellation did not return after commit completion")
-	}
-	current, err := d.store.GetWorkspaceContext("workspace-1")
-	if err != nil {
-		t.Fatalf("get current context: %v", err)
-	}
-	if current.Content != keeperCandidate || current.Revision != 2 {
-		t.Fatalf("admitted commit was not applied: %+v", current)
-	}
+		cancelID := jobIDForKey(t, d.jobQueue, compactContextKind, "workspace-1")
+		cancelDone := make(chan struct{})
+		go func() {
+			d.jobQueue.Cancel(cancelID)
+			close(cancelDone)
+		}()
+		// The bubble settles with the commit still held, so the cancel is parked on the
+		// fence — not merely slower than a tolerance window.
+		synctest.Wait()
+		select {
+		case <-cancelDone:
+			t.Fatal("cancellation returned before the admitted commit finished")
+		default:
+		}
+		close(releaseCommit)
+		requireDone(t, cancelDone, "cancellation did not return after commit completion")
+		current, err := d.store.GetWorkspaceContext("workspace-1")
+		if err != nil {
+			t.Fatalf("get current context: %v", err)
+		}
+		if current.Content != keeperCandidate || current.Revision != 2 {
+			t.Fatalf("admitted commit was not applied: %+v", current)
+		}
+	})
 }
 
 // TestWorkspaceDeletionCancelsCompactionBeforeRemovingContext proves the
@@ -505,56 +508,55 @@ func TestWorkspaceDeletionCancelsCompactionBeforeRemovingContext(t *testing.T) {
 // context-write trigger enqueues a coalesced compaction once the doc crosses the
 // size threshold, and that the runner runs it to a committed revision.
 func TestWorkspaceContextCompactionEnqueuesOnThresholdViaTrigger(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
-	d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
-	d.keeperCompactThreshold = 1
-	d.keeperCompactDebounce = 5 * time.Millisecond
-	calls := make(chan struct{}, 1)
-	d.workspaceContextCompactionExecution = func(
-		context.Context, keeperCompactConfig, *protocol.WorkspaceContext,
-	) (keeperCompactExecution, error) {
-		select {
-		case calls <- struct{}{}:
-		default:
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+		d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
+		d.keeperCompactThreshold = 1
+		d.keeperCompactDebounce = 5 * time.Millisecond
+		calls := make(chan struct{}, 1)
+		d.workspaceContextCompactionExecution = func(
+			context.Context, keeperCompactConfig, *protocol.WorkspaceContext,
+		) (keeperCompactExecution, error) {
+			select {
+			case calls <- struct{}{}:
+			default:
+			}
+			return keeperCompactExecution{Candidate: keeperCandidate}, nil
 		}
-		return keeperCompactExecution{Candidate: keeperCandidate}, nil
-	}
-	installTestCompactQueue(t, d)
+		installTestCompactQueue(t, d)
 
-	checkout, err := d.checkoutWorkspaceContext(&protocol.WorkspaceContextCheckoutMessage{SourceSessionID: "session-1"})
-	if err != nil {
-		t.Fatalf("checkout context: %v", err)
-	}
-	if err := os.WriteFile(checkout.Path, []byte(keeperSource), 0o600); err != nil {
-		t.Fatalf("edit context: %v", err)
-	}
-	if _, changed, err := d.updateWorkspaceContext(&protocol.WorkspaceContextUpdateMessage{SourceSessionID: "session-1"}); err != nil || !changed {
-		t.Fatalf("publish context: changed=%v err=%v", changed, err)
-	}
+		checkout, err := d.checkoutWorkspaceContext(&protocol.WorkspaceContextCheckoutMessage{SourceSessionID: "session-1"})
+		if err != nil {
+			t.Fatalf("checkout context: %v", err)
+		}
+		if err := os.WriteFile(checkout.Path, []byte(keeperSource), 0o600); err != nil {
+			t.Fatalf("edit context: %v", err)
+		}
+		if _, changed, err := d.updateWorkspaceContext(&protocol.WorkspaceContextUpdateMessage{SourceSessionID: "session-1"}); err != nil || !changed {
+			t.Fatalf("publish context: changed=%v err=%v", changed, err)
+		}
 
-	select {
-	case <-calls:
-	case <-time.After(time.Second):
-		t.Fatal("trigger did not enqueue a compaction")
-	}
-	deadline := time.Now().Add(time.Second)
-	for {
+		// The debounce is a real delay the runner honors; run it out on the bubble clock.
+		time.Sleep(2 * d.keeperCompactDebounce)
+		synctest.Wait()
+		select {
+		case <-calls:
+		default:
+			t.Fatal("trigger did not enqueue a compaction")
+		}
 		current, getErr := d.store.GetWorkspaceContext("workspace-1")
 		if getErr != nil {
 			t.Fatalf("get current context: %v", getErr)
 		}
-		if current.Revision == 2 {
-			if current.Content != keeperCandidate {
-				t.Fatalf("compacted content = %q", current.Content)
-			}
-			break
-		}
-		if time.Now().After(deadline) {
+		if current.Revision != 2 {
 			t.Fatalf("context revision = %d, want 2", current.Revision)
 		}
-		time.Sleep(5 * time.Millisecond)
-	}
+		if current.Content != keeperCandidate {
+			t.Fatalf("compacted content = %q", current.Content)
+		}
+	})
 }
 
 // TestWorkspaceContextCompactionInlineFallbackWhenQueueDisabled proves that with
@@ -594,51 +596,41 @@ func TestWorkspaceContextCompactionInlineFallbackWhenQueueDisabled(t *testing.T)
 // size re-check: a doc edited below the threshold during the debounce window is a
 // no-op success (no LLM pass, no revision bump).
 func TestWorkspaceContextCompactionReChecksThresholdAfterDebounce(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
-	d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
-	// Threshold far above the seeded doc size so the run-time re-check no-ops.
-	d.keeperCompactThreshold = 1 << 20
-	executed := false
-	d.workspaceContextCompactionExecution = func(
-		context.Context, keeperCompactConfig, *protocol.WorkspaceContext,
-	) (keeperCompactExecution, error) {
-		executed = true
-		return keeperCompactExecution{Candidate: keeperCandidate}, nil
-	}
-	installTestCompactQueue(t, d)
-	if _, _, err := d.store.UpdateWorkspaceContext("workspace-1", keeperSource, "session-1", 0); err != nil {
-		t.Fatalf("seed context: %v", err)
-	}
-	// Enqueue directly (the trigger would gate it, but a pre-debounce enqueue may
-	// have outlived a shrink); the executor must re-check and no-op.
-	if _, err := d.jobQueue.Enqueue(compactContextKind, jobs.EnqueueOptions{UniqueKey: "workspace-1"}); err != nil {
-		t.Fatalf("enqueue: %v", err)
-	}
-	deadline := time.Now().Add(time.Second)
-	for {
-		task, err := d.jobQueue.GetByKey(compactContextKind, "workspace-1")
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+		d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
+		// Threshold far above the seeded doc size so the run-time re-check no-ops.
+		d.keeperCompactThreshold = 1 << 20
+		executed := false
+		d.workspaceContextCompactionExecution = func(
+			context.Context, keeperCompactConfig, *protocol.WorkspaceContext,
+		) (keeperCompactExecution, error) {
+			executed = true
+			return keeperCompactExecution{Candidate: keeperCandidate}, nil
+		}
+		installTestCompactQueue(t, d)
+		if _, _, err := d.store.UpdateWorkspaceContext("workspace-1", keeperSource, "session-1", 0); err != nil {
+			t.Fatalf("seed context: %v", err)
+		}
+		// Enqueue directly (the trigger would gate it, but a pre-debounce enqueue may
+		// have outlived a shrink); the executor must re-check and no-op.
+		if _, err := d.jobQueue.Enqueue(compactContextKind, jobs.EnqueueOptions{UniqueKey: "workspace-1"}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		requireTaskState(t, d, compactContextKind, "workspace-1", jobs.StateDone)
+		if executed {
+			t.Fatal("executor ran despite the doc being below the size threshold")
+		}
+		current, err := d.store.GetWorkspaceContext("workspace-1")
 		if err != nil {
-			t.Fatalf("get task: %v", err)
+			t.Fatalf("get current context: %v", err)
 		}
-		if task != nil && task.State == jobs.StateDone {
-			break
+		if current.Revision != 1 {
+			t.Fatalf("context was modified by a below-threshold run: %+v", current)
 		}
-		if time.Now().After(deadline) {
-			t.Fatalf("task did not finish: %+v", task)
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	if executed {
-		t.Fatal("executor ran despite the doc being below the size threshold")
-	}
-	current, err := d.store.GetWorkspaceContext("workspace-1")
-	if err != nil {
-		t.Fatalf("get current context: %v", err)
-	}
-	if current.Revision != 1 {
-		t.Fatalf("context was modified by a below-threshold run: %+v", current)
-	}
+	})
 }
 
 // TestWorkspaceTeardownDoesNotPanicBeforeTheJobQueueExists proves the runtime
@@ -697,50 +689,58 @@ func TestWorkspaceTeardownDoesNotPanicBeforeTheJobQueueExists(t *testing.T) {
 // keep that bound so a hung/runaway agent cannot block the synchronous IPC
 // response indefinitely.
 func TestManualWorkspaceContextCompactionAppliesTimeout(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
-	d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
-	d.keeperCompactThreshold = 1
-	d.keeperCompactTimeout = 20 * time.Millisecond
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+		d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
+		d.keeperCompactThreshold = 1
+		d.keeperCompactTimeout = 20 * time.Millisecond
 
-	gotDeadline := make(chan bool, 1)
-	d.workspaceContextCompactionExecution = func(
-		ctx context.Context, _ keeperCompactConfig, _ *protocol.WorkspaceContext,
-	) (keeperCompactExecution, error) {
-		_, hasDeadline := ctx.Deadline()
-		gotDeadline <- hasDeadline
-		// A runaway agent: block until the context aborts. With a deadline the
-		// manual command returns promptly; without one it would hang here forever.
-		<-ctx.Done()
-		return keeperCompactExecution{}, ctx.Err()
-	}
-	if _, _, err := d.store.UpdateWorkspaceContext("workspace-1", keeperSource, "session-1", 0); err != nil {
-		t.Fatalf("seed context: %v", err)
-	}
-
-	done := make(chan error, 1)
-	go func() {
-		_, err := d.compactWorkspaceContextForSession(context.Background(), "session-1")
-		done <- err
-	}()
-
-	select {
-	case hasDeadline := <-gotDeadline:
-		if !hasDeadline {
-			t.Fatal("manual compaction executor ctx has NO deadline")
+		gotDeadline := make(chan bool, 1)
+		d.workspaceContextCompactionExecution = func(
+			ctx context.Context, _ keeperCompactConfig, _ *protocol.WorkspaceContext,
+		) (keeperCompactExecution, error) {
+			_, hasDeadline := ctx.Deadline()
+			gotDeadline <- hasDeadline
+			// A runaway agent: block until the context aborts. With a deadline the
+			// manual command returns promptly; without one it would hang here forever.
+			<-ctx.Done()
+			return keeperCompactExecution{}, ctx.Err()
 		}
-	case <-time.After(time.Second):
-		t.Fatal("manual compaction executor was not invoked")
-	}
-
-	select {
-	case err := <-done:
-		if !errors.Is(err, context.DeadlineExceeded) {
-			t.Fatalf("manual compaction error = %v, want context deadline exceeded", err)
+		if _, _, err := d.store.UpdateWorkspaceContext("workspace-1", keeperSource, "session-1", 0); err != nil {
+			t.Fatalf("seed context: %v", err)
 		}
-	case <-time.After(time.Second):
-		t.Fatal("manual compaction did not abort within the configured timeout")
-	}
+
+		done := make(chan error, 1)
+		go func() {
+			_, err := d.compactWorkspaceContextForSession(context.Background(), "session-1")
+			done <- err
+		}()
+
+		synctest.Wait()
+		select {
+		case hasDeadline := <-gotDeadline:
+			if !hasDeadline {
+				t.Fatal("manual compaction executor ctx has NO deadline")
+			}
+		default:
+			t.Fatal("manual compaction executor was not invoked")
+		}
+
+		// Past the configured per-run timeout: without a deadline on the executor's
+		// context the runaway agent would still be blocked here.
+		time.Sleep(2 * d.keeperCompactTimeout)
+		synctest.Wait()
+		select {
+		case err := <-done:
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("manual compaction error = %v, want context deadline exceeded", err)
+			}
+		default:
+			t.Fatal("manual compaction did not abort within the configured timeout")
+		}
+	})
 }
 
 // TestMigrateKeeperCompactSettingKey covers the one-time rename of the persisted

--- a/internal/daemon/workspace_test.go
+++ b/internal/daemon/workspace_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
-	"time"
+	"testing/synctest"
 
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/workspacelayout"
@@ -324,55 +324,54 @@ func TestHandleRegisterWorkspace_BroadcastsRegisteredThenStateChanged(t *testing
 
 func TestHandleConnection_MuteWorkspaceDispatchesSocketCommand(t *testing.T) {
 	d := newDaemonForTest(t)
-	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
-		Cmd:       protocol.CmdRegisterWorkspace,
-		ID:        "ws1",
-		Title:     "Workspace 1",
-		Directory: "/repo",
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+			Cmd:       protocol.CmdRegisterWorkspace,
+			ID:        "ws1",
+			Title:     "Workspace 1",
+			Directory: "/repo",
+		})
+		cap := captureBroadcasts(d)
+
+		serverConn, clientConn := net.Pipe()
+		defer clientConn.Close()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			d.handleConnection(serverConn)
+		}()
+
+		if err := json.NewEncoder(clientConn).Encode(protocol.MuteWorkspaceMessage{
+			Cmd:         protocol.CmdMuteWorkspace,
+			WorkspaceID: "ws1",
+		}); err != nil {
+			t.Fatalf("send mute_workspace command: %v", err)
+		}
+		var resp protocol.Response
+		if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
+			t.Fatalf("decode mute_workspace response: %v", err)
+		}
+		if !resp.Ok {
+			t.Fatalf("mute_workspace response ok=false error=%v", resp.Error)
+		}
+		requireDone(t, done, "mute_workspace connection did not finish")
+
+		workspace := d.store.GetWorkspace("ws1")
+		if workspace == nil {
+			t.Fatal("workspace missing from store after mute")
+		}
+		if !workspace.Muted {
+			t.Fatal("workspace not muted in store after socket command")
+		}
+		events := cap.snapshot()
+		if len(events) != 1 {
+			t.Fatalf("expected one workspace_state_changed broadcast, got %d: %+v", len(events), events)
+		}
+		if events[0].Event != protocol.EventWorkspaceStateChanged || events[0].Workspace == nil || !events[0].Workspace.Muted {
+			t.Fatalf("unexpected broadcast: %+v", events[0])
+		}
 	})
-	cap := captureBroadcasts(d)
-
-	serverConn, clientConn := net.Pipe()
-	defer clientConn.Close()
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		d.handleConnection(serverConn)
-	}()
-
-	if err := json.NewEncoder(clientConn).Encode(protocol.MuteWorkspaceMessage{
-		Cmd:         protocol.CmdMuteWorkspace,
-		WorkspaceID: "ws1",
-	}); err != nil {
-		t.Fatalf("send mute_workspace command: %v", err)
-	}
-	var resp protocol.Response
-	if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
-		t.Fatalf("decode mute_workspace response: %v", err)
-	}
-	if !resp.Ok {
-		t.Fatalf("mute_workspace response ok=false error=%v", resp.Error)
-	}
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("mute_workspace connection did not finish")
-	}
-
-	workspace := d.store.GetWorkspace("ws1")
-	if workspace == nil {
-		t.Fatal("workspace missing from store after mute")
-	}
-	if !workspace.Muted {
-		t.Fatal("workspace not muted in store after socket command")
-	}
-	events := cap.snapshot()
-	if len(events) != 1 {
-		t.Fatalf("expected one workspace_state_changed broadcast, got %d: %+v", len(events), events)
-	}
-	if events[0].Event != protocol.EventWorkspaceStateChanged || events[0].Workspace == nil || !events[0].Workspace.Muted {
-		t.Fatalf("unexpected broadcast: %+v", events[0])
-	}
 }
 
 func TestHandleUnregisterWorkspace_BroadcastsOnlyForKnown(t *testing.T) {

--- a/internal/daemon/ws_automations_test.go
+++ b/internal/daemon/ws_automations_test.go
@@ -930,6 +930,10 @@ func TestAutomationDefinitionGetWSAfterToggleDerivesFromSpecJSON(t *testing.T) {
 // automationMu for longer than the frontend's 30s client timeout lets the
 // toggle flip after the UI has already reported "timed out" — invisible to
 // the user who believes their click had no effect.
+// Boundary-bound: the behavior under test IS a goroutine waiting on
+// d.automationMu. A goroutine blocked on a sync.Mutex is explicitly not
+// durably blocked, so a bubble's clock would never reach the release and the
+// deadline would never fire.
 func TestAutomationSetEnabledWSDeadlineAbortsWithoutMutating(t *testing.T) {
 	s := store.New()
 	d := &Daemon{store: s, wsHub: newWSHub(), wsAutomationMutationTimeout: 50 * time.Millisecond}
@@ -1012,6 +1016,8 @@ func TestAutomationSetEnabledWSDeadlineAbortsWithoutMutating(t *testing.T) {
 // same already-delivered run once the held lock frees. automationDeliveryHook
 // does not apply here — it only affects deliverObservedAutomationRun's
 // provider-observation path, not automationRun's manual-run path.
+// Boundary-bound for the same reason as the deadline test above: both retries
+// queue on d.automationMu, and a mutex wait is invisible to a bubble.
 func TestAutomationRunWSRetryWithSameRequestIDDoesNotDuplicate(t *testing.T) {
 	s := store.New()
 	d := &Daemon{store: s, wsHub: newWSHub()}

--- a/internal/daemon/ws_plugins_test.go
+++ b/internal/daemon/ws_plugins_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
@@ -77,43 +78,46 @@ func TestDaemon_HandleListPluginsWS_ReturnsInstalledPlugins(t *testing.T) {
 }
 
 func TestDaemon_PluginsUpdatedMessageIncludesSupervisorBackoff(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "daemon.sock"))
-	d.pluginDir = filepath.Join(t.TempDir(), "plugins")
-	writeTestPluginManifest(t, d.pluginDir, "recovering-provider")
-	manifest, err := loadPluginManifest(filepath.Join(d.pluginDir, "recovering-provider", pluginManifestName))
-	if err != nil {
-		t.Fatalf("load manifest: %v", err)
-	}
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		d.pluginDir = filepath.Join(t.TempDir(), "plugins")
+		writeTestPluginManifest(t, d.pluginDir, "recovering-provider")
+		manifest, err := loadPluginManifest(filepath.Join(d.pluginDir, "recovering-provider", pluginManifestName))
+		if err != nil {
+			t.Fatalf("load manifest: %v", err)
+		}
 
-	clock := newFakePluginClock()
-	launcher := &fakePluginLauncher{}
-	d.pluginSupervisor = newTestPluginSupervisor(clock, launcher)
-	if err := d.pluginSupervisor.Ensure(manifest); err != nil {
-		t.Fatalf("Ensure: %v", err)
-	}
-	launcher.handle(0).exit(pluginExit{ExitCode: intPtr(17)})
-	waitForSupervisor(t, func() bool {
-		snapshot, _ := d.pluginSupervisor.Snapshot(manifest.Name)
-		return snapshot.Phase == pluginPhaseBackoff
+		clock := newFakePluginClock()
+		launcher := &fakePluginLauncher{}
+		d.pluginSupervisor = newTestPluginSupervisor(t, clock, launcher)
+		if err := d.pluginSupervisor.Ensure(manifest); err != nil {
+			t.Fatalf("Ensure: %v", err)
+		}
+		launcher.handle(0).exit(pluginExit{ExitCode: intPtr(17)})
+		requireSupervisor(t, func() bool {
+			snapshot, _ := d.pluginSupervisor.Snapshot(manifest.Name)
+			return snapshot.Phase == pluginPhaseBackoff
+		}, "the plugin exit did not land the supervisor in backoff")
+
+		plugins := d.pluginsUpdatedMessage().Plugins
+		if len(plugins) != 1 {
+			t.Fatalf("plugin count=%d, want 1", len(plugins))
+		}
+		plugin := plugins[0]
+		if got := protocol.Deref(plugin.RuntimePhase); got != string(pluginPhaseBackoff) {
+			t.Fatalf("runtime phase=%q, want backoff", got)
+		}
+		if got := protocol.Deref(plugin.RestartAttempt); got != 1 {
+			t.Fatalf("restart attempt=%d, want 1", got)
+		}
+		if plugin.NextRestartAt == nil || *plugin.NextRestartAt != clock.Now().Add(pluginRestartBackoff[0]).Format(time.RFC3339Nano) {
+			t.Fatalf("next restart=%v, want first backoff deadline", plugin.NextRestartAt)
+		}
+		if plugin.LastExit == nil || !strings.Contains(*plugin.LastExit, "exit code 17") {
+			t.Fatalf("last exit=%v, want exit code 17", plugin.LastExit)
+		}
 	})
-
-	plugins := d.pluginsUpdatedMessage().Plugins
-	if len(plugins) != 1 {
-		t.Fatalf("plugin count=%d, want 1", len(plugins))
-	}
-	plugin := plugins[0]
-	if got := protocol.Deref(plugin.RuntimePhase); got != string(pluginPhaseBackoff) {
-		t.Fatalf("runtime phase=%q, want backoff", got)
-	}
-	if got := protocol.Deref(plugin.RestartAttempt); got != 1 {
-		t.Fatalf("restart attempt=%d, want 1", got)
-	}
-	if plugin.NextRestartAt == nil || *plugin.NextRestartAt != clock.Now().Add(pluginRestartBackoff[0]).Format(time.RFC3339Nano) {
-		t.Fatalf("next restart=%v, want first backoff deadline", plugin.NextRestartAt)
-	}
-	if plugin.LastExit == nil || !strings.Contains(*plugin.LastExit, "exit code 17") {
-		t.Fatalf("last exit=%v, want exit code 17", plugin.LastExit)
-	}
 }
 
 func TestDaemon_HandleInstallPluginWS_InstallsGitSource(t *testing.T) {
@@ -174,7 +178,7 @@ func TestDaemon_HandleRemovePluginWSStopsSupervisorAfterDeletingFiles(t *testing
 	}
 	clock := newFakePluginClock()
 	launcher := &fakePluginLauncher{}
-	d.pluginSupervisor = newTestPluginSupervisor(clock, launcher)
+	d.pluginSupervisor = newTestPluginSupervisor(t, clock, launcher)
 	if err := d.pluginSupervisor.Ensure(manifest); err != nil {
 		t.Fatalf("Ensure: %v", err)
 	}
@@ -208,7 +212,7 @@ func TestDaemon_HandleRemovePluginWSKeepsSupervisorRunningWhenDeletionFails(t *t
 	}
 	clock := newFakePluginClock()
 	launcher := &fakePluginLauncher{}
-	d.pluginSupervisor = newTestPluginSupervisor(clock, launcher)
+	d.pluginSupervisor = newTestPluginSupervisor(t, clock, launcher)
 	if err := d.pluginSupervisor.Ensure(manifest); err != nil {
 		t.Fatalf("Ensure: %v", err)
 	}
@@ -240,7 +244,7 @@ func TestDaemon_BundledPluginIsAvailableAndInertByDefault(t *testing.T) {
 	d.bundledPluginDir = filepath.Join(t.TempDir(), "bundled-plugins")
 	writeTestPluginManifest(t, d.bundledPluginDir, "attn-opencode")
 	launcher := &fakePluginLauncher{}
-	d.pluginSupervisor = newTestPluginSupervisor(newFakePluginClock(), launcher)
+	d.pluginSupervisor = newTestPluginSupervisor(t, newFakePluginClock(), launcher)
 
 	d.startInstalledPlugins()
 	if got := launcher.count(); got != 0 {
@@ -262,7 +266,7 @@ func TestDaemon_InstallAndUninstallBundledPluginUpdatesProfileState(t *testing.T
 	d.bundledPluginDir = filepath.Join(t.TempDir(), "bundled-plugins")
 	writeTestPluginManifest(t, d.bundledPluginDir, "attn-opencode")
 	launcher := &fakePluginLauncher{}
-	d.pluginSupervisor = newTestPluginSupervisor(newFakePluginClock(), launcher)
+	d.pluginSupervisor = newTestPluginSupervisor(t, newFakePluginClock(), launcher)
 	client := &wsClient{send: make(chan outboundMessage, 2)}
 
 	d.handleInstallBundledPluginWS(client, &protocol.InstallBundledPluginMessage{Name: "attn-opencode"})

--- a/internal/daemon/ws_tasks_test.go
+++ b/internal/daemon/ws_tasks_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/jobs"
@@ -137,44 +138,47 @@ func TestTasksToProtocolSkipsNil(t *testing.T) {
 // record's id/kind/state mapped through.
 func TestSendTaskListWSResult(t *testing.T) {
 	d := newNotebookDaemon(t)
-	runner, _ := installInstrumentedTaskRunner(t, d)
-	if _, err := runner.Enqueue(testTaskKind, jobs.EnqueueOptions{UniqueKey: "ws-a"}); err != nil {
-		t.Fatalf("enqueue ws-a: %v", err)
-	}
-	if _, err := runner.Enqueue(testTaskKind, jobs.EnqueueOptions{UniqueKey: "ws-b"}); err != nil {
-		t.Fatalf("enqueue ws-b: %v", err)
-	}
-	// Let the worker run both to a terminal state so the records are stable.
-	waitForTaskState(t, d, testTaskKind, "ws-a", jobs.StateDone)
-	waitForTaskState(t, d, testTaskKind, "ws-b", jobs.StateDone)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		runner, _ := installInstrumentedTaskRunner(t, d)
+		if _, err := runner.Enqueue(testTaskKind, jobs.EnqueueOptions{UniqueKey: "ws-a"}); err != nil {
+			t.Fatalf("enqueue ws-a: %v", err)
+		}
+		if _, err := runner.Enqueue(testTaskKind, jobs.EnqueueOptions{UniqueKey: "ws-b"}); err != nil {
+			t.Fatalf("enqueue ws-b: %v", err)
+		}
+		// Let the worker run both to a terminal state so the records are stable.
+		requireTaskState(t, d, testTaskKind, "ws-a", jobs.StateDone)
+		requireTaskState(t, d, testTaskKind, "ws-b", jobs.StateDone)
 
-	client := &wsClient{send: make(chan outboundMessage, 4)}
-	d.sendTaskListWSResult(client, "list-1")
+		client := &wsClient{send: make(chan outboundMessage, 4)}
+		d.sendTaskListWSResult(client, "list-1")
 
-	var msg protocol.TaskListResultMessage
-	readNotebookWSEvent(t, client.send, &msg)
-	if msg.Event != protocol.EventTaskListResult || msg.RequestID != "list-1" || !msg.Success {
-		t.Fatalf("list result = %+v, want success task_list_result for list-1", msg)
-	}
-	got := map[string]protocol.Task{}
-	for _, task := range msg.Tasks {
-		got[task.Subject] = task
-	}
-	if len(got) != 2 {
-		t.Fatalf("listed %d tasks, want 2: %+v", len(msg.Tasks), msg.Tasks)
-	}
-	for _, subject := range []string{"ws-a", "ws-b"} {
-		task, ok := got[subject]
-		if !ok {
-			t.Fatalf("subject %q missing from list: %+v", subject, msg.Tasks)
+		var msg protocol.TaskListResultMessage
+		readNotebookWSEvent(t, client.send, &msg)
+		if msg.Event != protocol.EventTaskListResult || msg.RequestID != "list-1" || !msg.Success {
+			t.Fatalf("list result = %+v, want success task_list_result for list-1", msg)
 		}
-		if task.Kind != testTaskKind || task.State != string(jobs.StateDone) {
-			t.Fatalf("task %q = %+v, want kind=%s state=done", subject, task, testTaskKind)
+		got := map[string]protocol.Task{}
+		for _, task := range msg.Tasks {
+			got[task.Subject] = task
 		}
-		if want := jobIDForKey(t, runner, testTaskKind, subject); task.ID != want {
-			t.Fatalf("task %q id = %q, want %q", subject, task.ID, want)
+		if len(got) != 2 {
+			t.Fatalf("listed %d tasks, want 2: %+v", len(msg.Tasks), msg.Tasks)
 		}
-	}
+		for _, subject := range []string{"ws-a", "ws-b"} {
+			task, ok := got[subject]
+			if !ok {
+				t.Fatalf("subject %q missing from list: %+v", subject, msg.Tasks)
+			}
+			if task.Kind != testTaskKind || task.State != string(jobs.StateDone) {
+				t.Fatalf("task %q = %+v, want kind=%s state=done", subject, task, testTaskKind)
+			}
+			if want := jobIDForKey(t, runner, testTaskKind, subject); task.ID != want {
+				t.Fatalf("task %q id = %q, want %q", subject, task.ID, want)
+			}
+		}
+	})
 }
 
 // TestSendTaskListWSResultNilRunner confirms a nil runner is a successful
@@ -198,40 +202,43 @@ func TestSendTaskListWSResultNilRunner(t *testing.T) {
 // must carry the task flipped back to queued with NextAttemptAt advanced to ~now.
 func TestSendTaskRetryWSResultRequeuesDeadTask(t *testing.T) {
 	d := newNotebookDaemon(t)
-	runner, shouldFail := installInstrumentedTaskRunner(t, d)
-	shouldFail.Store(true)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		runner, shouldFail := installInstrumentedTaskRunner(t, d)
+		shouldFail.Store(true)
 
-	if _, err := runner.Enqueue(testTaskKind, jobs.EnqueueOptions{UniqueKey: "ws-fail"}); err != nil {
-		t.Fatalf("enqueue ws-fail: %v", err)
-	}
-	dead := waitForTaskState(t, d, testTaskKind, "ws-fail", jobs.StateDead)
-	if dead.LastError == "" {
-		t.Fatalf("dead task has no last_error: %+v", dead)
-	}
+		if _, err := runner.Enqueue(testTaskKind, jobs.EnqueueOptions{UniqueKey: "ws-fail"}); err != nil {
+			t.Fatalf("enqueue ws-fail: %v", err)
+		}
+		dead := requireTaskState(t, d, testTaskKind, "ws-fail", jobs.StateDead)
+		if dead.LastError == "" {
+			t.Fatalf("dead task has no last_error: %+v", dead)
+		}
 
-	before := time.Now()
-	client := &wsClient{send: make(chan outboundMessage, 4)}
-	d.sendTaskRetryWSResult(client, "retry-1", dead.ID)
+		before := time.Now()
+		client := &wsClient{send: make(chan outboundMessage, 4)}
+		d.sendTaskRetryWSResult(client, "retry-1", dead.ID)
 
-	var msg protocol.TaskRetryResultMessage
-	readNotebookWSEvent(t, client.send, &msg)
-	if msg.Event != protocol.EventTaskRetryResult || msg.RequestID != "retry-1" || !msg.Success {
-		t.Fatalf("retry result = %+v, want success task_retry_result for retry-1", msg)
-	}
-	if msg.Task == nil || msg.Task.State != string(jobs.StateQueued) {
-		t.Fatalf("retry result task = %+v, want state queued", msg.Task)
-	}
-	if msg.Task.Attempts != 0 {
-		t.Fatalf("retry result attempts = %d, want 0 (reset)", msg.Task.Attempts)
-	}
-	nextAt, err := time.Parse(time.RFC3339, msg.Task.NextAttemptAt)
-	if err != nil {
-		t.Fatalf("parse next_attempt_at %q: %v", msg.Task.NextAttemptAt, err)
-	}
-	// Retry sets NextAttemptAt = now; allow a small skew on either side of the call.
-	if nextAt.Before(before.Add(-2*time.Second)) || nextAt.After(time.Now().Add(2*time.Second)) {
-		t.Fatalf("next_attempt_at = %s, want ~now (between %s and %s)", nextAt, before, time.Now())
-	}
+		var msg protocol.TaskRetryResultMessage
+		readNotebookWSEvent(t, client.send, &msg)
+		if msg.Event != protocol.EventTaskRetryResult || msg.RequestID != "retry-1" || !msg.Success {
+			t.Fatalf("retry result = %+v, want success task_retry_result for retry-1", msg)
+		}
+		if msg.Task == nil || msg.Task.State != string(jobs.StateQueued) {
+			t.Fatalf("retry result task = %+v, want state queued", msg.Task)
+		}
+		if msg.Task.Attempts != 0 {
+			t.Fatalf("retry result attempts = %d, want 0 (reset)", msg.Task.Attempts)
+		}
+		nextAt, err := time.Parse(time.RFC3339, msg.Task.NextAttemptAt)
+		if err != nil {
+			t.Fatalf("parse next_attempt_at %q: %v", msg.Task.NextAttemptAt, err)
+		}
+		// Retry sets NextAttemptAt = now; allow a small skew on either side of the call.
+		if nextAt.Before(before.Add(-2*time.Second)) || nextAt.After(time.Now().Add(2*time.Second)) {
+			t.Fatalf("next_attempt_at = %s, want ~now (between %s and %s)", nextAt, before, time.Now())
+		}
+	})
 }
 
 // TestSendTaskRetryWSResultNilRunner confirms the disabled-runner retry path
@@ -258,6 +265,9 @@ func TestSendTaskRetryWSResultNilRunner(t *testing.T) {
 // cannot see: a renamed event or a broken broadcast message would slip past them but
 // is caught here. (That the runner invokes OnChange at all is a tasks-package property
 // already covered by internal/tasks; this test owns the daemon's wiring of it.)
+// Boundary-bound: this one runs the real hub (`go d.wsHub.run()`), whose loop has
+// no exit path — a bubble would never finish. Its siblings above bubble because
+// they drive the client channel directly.
 func TestTasksChangedBroadcastReachesClient(t *testing.T) {
 	d := newNotebookDaemon(t)
 	client := &wsClient{send: make(chan outboundMessage, 8)}

--- a/internal/jobs/runner_test.go
+++ b/internal/jobs/runner_test.go
@@ -3,7 +3,9 @@ package jobs
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -791,6 +793,103 @@ func TestRetentionTrimsCompletedJobsAndKeepsDeadOnes(t *testing.T) {
 		}
 		if store.count() != 1 {
 			t.Errorf("store holds %d records, want 1", store.count())
+		}
+	})
+}
+
+// TestThePeriodicRetentionPassTrimsOnItsOwnInterval covers the runner's own
+// retention ticker, which the test above deliberately parks. Until the bubble
+// arrived the pass had never executed in any test at all: its ticker ran on real
+// time while the tests ran on an injected clock, so an hour of test time never
+// reached it. Here it runs at its shipped interval, with nobody calling Trim.
+func TestThePeriodicRetentionPassTrimsOnItsOwnInterval(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var mu sync.Mutex
+		var trims []string
+		r, store := newBubbleRunner(t, func(o *Options) {
+			o.MaxAttempts = 1
+			o.Retention = 24 * time.Hour
+			// TrimInterval is left at DefaultTrimInterval (1h) on purpose: the
+			// interval under test is the shipped one.
+			o.Log = func(format string, args ...any) {
+				if !strings.HasPrefix(format, "jobs: trimmed") {
+					return
+				}
+				mu.Lock()
+				trims = append(trims, fmt.Sprintf(format, args...))
+				mu.Unlock()
+			}
+		})
+		trimCount := func() int {
+			mu.Lock()
+			defer mu.Unlock()
+			return len(trims)
+		}
+		mustRegister(t, r, "ok", func(context.Context, *Job) (any, error) { return nil, nil })
+		mustRegister(t, r, "bad", func(context.Context, *Job) (any, error) {
+			return nil, errors.New("boom")
+		})
+		mustStart(t, r)
+
+		old, err := r.Enqueue("ok", EnqueueOptions{})
+		if err != nil {
+			t.Fatalf("enqueue ok: %v", err)
+		}
+		dead, err := r.Enqueue("bad", EnqueueOptions{})
+		if err != nil {
+			t.Fatalf("enqueue bad: %v", err)
+		}
+		synctest.Wait()
+		if got := mustGet(t, r, old.ID).State; got != StateDone {
+			t.Fatalf("the succeeding job settled at %s, want done", got)
+		}
+		if got := mustGet(t, r, dead.ID).State; got != StateDead {
+			t.Fatalf("the failing job settled at %s, want dead", got)
+		}
+
+		// Just inside the retention window: 23 ticks have fired and every one of
+		// them found nothing old enough to take.
+		time.Sleep(24*time.Hour - time.Minute)
+		synctest.Wait()
+		if j, _ := r.Get(old.ID); j == nil {
+			t.Error("a job younger than the retention window was trimmed")
+		}
+		if got := trimCount(); got != 0 {
+			t.Errorf("retention reported %d trims inside the window, want 0: %v", got, trims)
+		}
+
+		// A second completed job, enqueued a minute before the first ages out. It
+		// is the control: the pass that takes the old record must leave it alone.
+		young, err := r.Enqueue("ok", EnqueueOptions{})
+		if err != nil {
+			t.Fatalf("enqueue young: %v", err)
+		}
+		synctest.Wait()
+		if got := mustGet(t, r, young.ID).State; got != StateDone {
+			t.Fatalf("the second job settled at %s, want done", got)
+		}
+
+		// Past the window plus one interval: the first tick after the record aged
+		// out is the one that takes it. A pass on any interval longer than an hour
+		// would still be holding it here.
+		time.Sleep(time.Hour + 2*time.Minute)
+		synctest.Wait()
+		if j, _ := r.Get(old.ID); j != nil {
+			t.Error("the aged-out job survived the periodic retention pass")
+		}
+		if j, _ := r.Get(young.ID); j == nil {
+			t.Error("the periodic pass trimmed a job younger than the retention window")
+		}
+		if j, _ := r.Get(dead.ID); j == nil {
+			t.Error("the periodic pass trimmed the dead job; it is the actionable record")
+		}
+		if got := store.count(); got != 2 {
+			t.Errorf("store holds %d records, want 2 (the young one and the dead one)", got)
+		}
+		if got := trimCount(); got != 1 {
+			t.Errorf("retention reported %d trimming passes, want exactly 1: %v", got, trims)
+		} else if want := "jobs: trimmed 1 completed job(s) older than 24h0m0s"; trims[0] != want {
+			t.Errorf("retention pass reported %q, want %q", trims[0], want)
 		}
 	})
 }

--- a/internal/ptybackend/worker_test.go
+++ b/internal/ptybackend/worker_test.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/victorarias/attn/internal/launchcontract"
@@ -1007,44 +1008,52 @@ func TestWorkerBackend_GetSession_PrunesDeadRegistryEntry(t *testing.T) {
 }
 
 func TestWorkerStream_PublishOverflowWaitsForBufferSpace(t *testing.T) {
-	stream := &workerStream{
-		events: make(chan OutputEvent, 1),
-		done:   make(chan struct{}),
-	}
-	if ok := stream.publish(OutputEvent{Kind: OutputEventKindOutput, Data: []byte("a"), Seq: 1}); !ok {
-		t.Fatal("first publish should succeed")
-	}
-
-	resultCh := make(chan bool, 1)
-	start := time.Now()
-	go func() {
-		resultCh <- stream.publish(OutputEvent{Kind: OutputEventKindOutput, Data: []byte("b"), Seq: 2})
-	}()
-
-	select {
-	case ok := <-resultCh:
-		t.Fatalf("publish returned early with ok=%v", ok)
-	case <-time.After(streamPublishWait + 50*time.Millisecond):
-	}
-
-	select {
-	case <-stream.events:
-	case <-time.After(time.Second):
-		t.Fatal("timed out draining first buffered event")
-	}
-
-	select {
-	case ok := <-resultCh:
-		if !ok {
-			t.Fatal("second publish should succeed after buffer space is available")
+	synctest.Test(t, func(t *testing.T) {
+		stream := &workerStream{
+			events: make(chan OutputEvent, 1),
+			done:   make(chan struct{}),
 		}
-	case <-time.After(time.Second):
-		t.Fatal("second publish did not resume after draining buffer")
-	}
+		if ok := stream.publish(OutputEvent{Kind: OutputEventKindOutput, Data: []byte("a"), Seq: 1}); !ok {
+			t.Fatal("first publish should succeed")
+		}
 
-	if elapsed := time.Since(start); elapsed < streamPublishWait {
-		t.Fatalf("publish on full buffer resumed too quickly: %v", elapsed)
-	}
+		resultCh := make(chan bool, 1)
+		start := time.Now()
+		go func() {
+			resultCh <- stream.publish(OutputEvent{Kind: OutputEventKindOutput, Data: []byte("b"), Seq: 2})
+		}()
+
+		// publish() re-arms its backpressure timer forever rather than giving
+		// up, so run past one full period and let the bubble settle: the
+		// publisher is still parked, and nothing but the drain below frees it.
+		time.Sleep(streamPublishWait + 50*time.Millisecond)
+		synctest.Wait()
+		select {
+		case ok := <-resultCh:
+			t.Fatalf("publish returned early with ok=%v", ok)
+		default:
+		}
+
+		select {
+		case <-stream.events:
+		default:
+			t.Fatal("timed out draining first buffered event")
+		}
+
+		synctest.Wait()
+		select {
+		case ok := <-resultCh:
+			if !ok {
+				t.Fatal("second publish should succeed after buffer space is available")
+			}
+		default:
+			t.Fatal("second publish did not resume after draining buffer")
+		}
+
+		if elapsed := time.Since(start); elapsed < streamPublishWait {
+			t.Fatalf("publish on full buffer resumed too quickly: %v", elapsed)
+		}
+	})
 }
 
 func TestValidateSessionID(t *testing.T) {


### PR DESCRIPTION
## What

The previous sweep (#809) left 130 tests classified by static analysis alone —
"no boundary signal found", never actually run in a bubble. This takes that
remainder to zero: every one now has a verdict from running it.

- **87 more conversions** into `testing/synctest` — 86 in `internal/daemon`,
  1 in `internal/ptybackend`.
- **52 reclassifications** as boundary-bound, each with its reason recorded.
- **2** turned out not to be paced at all (a `time` reference elsewhere in the
  file, not in the test).

Plus the test #809 asked for: the job runner's periodic retention pass, which
had **never executed in any test** because its hourly ticker ran on real time
under the old `fakeClock`.

Test-only. No production code changes anywhere.

## The conversions

The big clusters the triage map predicted, confirmed by running them:

- `notebook_narration_test.go` (18), `notebook_daily_narrate_test.go` (10),
  `notebook_tasks_enabled_test.go` (6) — the executor stub never execs, so every
  poll over job-queue state collapses to a `synctest.Wait()`.
- `plugin_rpc_test.go` (9), `plugin_supervisor_test.go` (7) — the open question
  was whether the plugin runtime spawns a real interpreter. It does not: these
  drive the RPC over `net.Pipe`, which is channel-backed and bubble-safe, read
  deadlines included.
- `transcript_watcher_abort_test.go` (5), `workspace_keeper_test.go` (5), and
  smaller sets in `browser_test.go`, `reload_test.go`, `daemon_test.go`,
  `spawn_characterization_test.go`, `stop_terminality_test.go`,
  `ticket_buffer_test.go`, `tilecontent_test.go`, `ws_tasks_test.go`.

Converted tests keep their assertions and run the **shipped** intervals rather
than turned-down copies. `bus_test.go` no longer drops `PollInterval` from 5s to
5ms; the plugin supervisor tests now exercise the real restart backoff.

Two helpers land in `internal/daemon/synctest_test.go`: `requireOutbound` and
`requireNoOutbound`, replacing `select { case <-client.send: … case
<-time.After(2s): }`. The negative is the one that changes meaning — outside a
bubble, "nothing was sent" is only ever "nothing yet".

`waitForNudgeDeadline`, `waitForNudgeDeadlineBefore` and `waitForBus` are gone.

## Three new boundary rules

Each found by converting a test and watching it hang:

1. **A claim about a goroutine parked on a lock.** `go doc testing/synctest` is
   explicit that locking a `sync.Mutex` is not durable blocking. A test whose
   subject is "this writer is stuck behind that lock" — `doorbellMu`,
   `autoSettleFireMu`, the spawn lock, the evidence and trace tables — has no
   state a bubble can settle into, so `synctest.Wait()` hangs instead of
   returning. 9 tests.
2. **An assertion on real elapsed wall-clock.** Under a fake clock
   `time.Since(start) > 100ms` reads zero; converting would quietly delete the
   test's only claim.
3. **A goroutine with no exit path.** `go d.wsHub.run()` loops forever over its
   channels, and a bubble ends only when its last goroutine exits. Giving the
   hub a quit channel is a production change; this sweep is test-only.

## Two corrections to #809's map

- `reload_test.go` drives a `fakeReloadBackend`, not `ptybackend` worker
  processes. 3 of its 6 convert; the other 3 are blocked by an fsnotify watcher
  that *setting the notebook root* starts.
- `internal/pty` has no convertible tests — all 14 go through `manager.Spawn` or
  an `os/exec` helper, not the 9/5 split the map recorded.

## The retention pass test

`TestThePeriodicRetentionPassTrimsOnItsOwnInterval` leaves `TrimInterval` at the
shipped `DefaultTrimInterval` — one hour, the value that had never executed —
with a 24-hour retention policy. Through 23 ticks it trims nothing; the tick
after the policy window trims exactly the aged completed job and leaves the
young completed job and the dead one alone. The runner's own log line is the
receipt that the pass ran once rather than zero or twice:
`jobs: trimmed 1 completed job(s) older than 24h0m0s`.

Mutation-checked by setting `DefaultTrimInterval` to 24h in production code:
three assertions fail. That change was reverted.

## Numbers

`go test -count=3`, same machine, this branch against `39c3c8c4`:

| subset | before | after |
|---|---|---|
| the 86 converted daemon tests | 94.6s | 6.0s |
| `internal/daemon` whole package | 403.6s | 327.0s |
| `internal/ptybackend` whole package | 6.46s | 5.48s |
| `internal/jobs` whole package | 0.68s | 0.91s |

The subset number is the one to read; 88.6s of tolerance windows and poll loops
is gone. The whole-package figure moves this time — 86 tests is enough to show
through — but a 6-minute package has minutes of run-to-run spread, so treat it
as directional, not as a receipt. `internal/jobs` grows because it *gained* a
test that runs 25 hours of fake time.

Every converted test is green at `-race -count=20`; all three packages are green
at `-count=1` on the rebased branch.

## One finding worth flagging

`TestStartJobQueueArmsThePeriodicTicks` — the cron-arm flake #809 reported as
retired ("20/20 clean") — **failed once** in a full-suite `-count=3` run at
`39c3c8c4`, i.e. on merged main, unmodified by this PR. It has not reproduced
since: 300 isolated runs and five further full-suite runs are clean, and the
failure message was not captured. The class is not as dead as #809 claimed;
recorded in the plan doc rather than left as a passing-by-luck belief.

## Also

The triage map in `docs/plans/2026-08-09-testing-adoption-wave.md` is updated:
the candidate column is zero, both scans are shown with their methodology, the
new boundary rules and corrections are written down, and the closing state names
its population (tests that landed on main after `39c3c8c4` are not in it).

Changelog fragment: `changelog.d/synctest-remainder-and-retention-pass.yaml`.
