### PR TITLE
fix(tickets): let a revived agent's first report land

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -201,7 +201,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '219';
+export const PROTOCOL_VERSION = '220';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -4588,6 +4588,7 @@ export interface ObservationElement {
 }
 
 export interface TicketAttachResultObject {
+    applied:      boolean;
     artifacts:    ArtifactElement[];
     catch_up?:    CatchUp;
     deduplicated: boolean;
@@ -4626,6 +4627,7 @@ export enum TicketEventKind {
 }
 
 export interface TicketCommentResultObject {
+    applied:   boolean;
     catch_up?: CatchUp;
     ticket_id: string;
     [property: string]: any;
@@ -4655,6 +4657,7 @@ export interface TicketShowResultObject {
 }
 
 export interface TicketStatusResultObject {
+    applied:   boolean;
     catch_up?: CatchUp;
     status:    TicketStatus;
     ticket_id: string;
@@ -5542,6 +5545,7 @@ export interface FileObject {
 }
 
 export interface TicketAttachResult {
+    applied:      boolean;
     artifacts:    ArtifactElement[];
     catch_up?:    CatchUp;
     deduplicated: boolean;
@@ -5592,6 +5596,7 @@ export enum TicketCommentMessageCmd {
 }
 
 export interface TicketCommentResult {
+    applied:   boolean;
     catch_up?: CatchUp;
     ticket_id: string;
     [property: string]: any;
@@ -5744,6 +5749,7 @@ export interface TicketShowResult {
 }
 
 export interface TicketStatusResult {
+    applied:   boolean;
     catch_up?: CatchUp;
     status:    TicketStatus;
     ticket_id: string;
@@ -12848,6 +12854,7 @@ const typeMap: any = {
         { json: "source", js: "source", typ: "" },
     ], "any"),
     "TicketAttachResultObject": o([
+        { json: "applied", js: "applied", typ: true },
         { json: "artifacts", js: "artifacts", typ: a(r("ArtifactElement")) },
         { json: "catch_up", js: "catch_up", typ: u(undefined, r("CatchUp")) },
         { json: "deduplicated", js: "deduplicated", typ: true },
@@ -12871,6 +12878,7 @@ const typeMap: any = {
         { json: "to_status", js: "to_status", typ: u(undefined, r("TicketStatus")) },
     ], "any"),
     "TicketCommentResultObject": o([
+        { json: "applied", js: "applied", typ: true },
         { json: "catch_up", js: "catch_up", typ: u(undefined, r("CatchUp")) },
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
@@ -12890,6 +12898,7 @@ const typeMap: any = {
         { json: "ticket", js: "ticket", typ: r("TicketElement") },
     ], "any"),
     "TicketStatusResultObject": o([
+        { json: "applied", js: "applied", typ: true },
         { json: "catch_up", js: "catch_up", typ: u(undefined, r("CatchUp")) },
         { json: "status", js: "status", typ: r("TicketStatus") },
         { json: "ticket_id", js: "ticket_id", typ: "" },
@@ -13418,6 +13427,7 @@ const typeMap: any = {
         { json: "source_path", js: "source_path", typ: "" },
     ], "any"),
     "TicketAttachResult": o([
+        { json: "applied", js: "applied", typ: true },
         { json: "artifacts", js: "artifacts", typ: a(r("ArtifactElement")) },
         { json: "catch_up", js: "catch_up", typ: u(undefined, r("CatchUp")) },
         { json: "deduplicated", js: "deduplicated", typ: true },
@@ -13448,6 +13458,7 @@ const typeMap: any = {
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
     "TicketCommentResult": o([
+        { json: "applied", js: "applied", typ: true },
         { json: "catch_up", js: "catch_up", typ: u(undefined, r("CatchUp")) },
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
@@ -13533,6 +13544,7 @@ const typeMap: any = {
         { json: "ticket", js: "ticket", typ: r("TicketElement") },
     ], "any"),
     "TicketStatusResult": o([
+        { json: "applied", js: "applied", typ: true },
         { json: "catch_up", js: "catch_up", typ: u(undefined, r("CatchUp")) },
         { json: "status", js: "status", typ: r("TicketStatus") },
         { json: "ticket_id", js: "ticket_id", typ: "" },

--- a/changelog.d/revived-agent-first-report-lands.yaml
+++ b/changelog.d/revived-agent-first-report-lands.yaml
@@ -1,0 +1,13 @@
+kind: fixed
+area: daemon
+change: >
+  An agent that dies and comes back can report on its ticket again. attn shows an
+  agent any ticket activity it has not read before letting it write, so the two
+  notes attn itself leaves when a session dies and is reloaded — "ended
+  mid-flight", "running again" — used to block that agent's very first report,
+  every time, on news about its own death. One delegated agent was turned away
+  once, said "done", and its report never landed. attn's own notes about a ticket
+  no longer cost the write: they are printed beside the update and the update
+  goes through. A word from someone else — the user, the chief, another agent —
+  still comes first, and now says so plainly: it is shown, marked read, and the
+  same command run again applies the update.

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -923,14 +923,16 @@ func runTicketStatus(args []string) {
 		os.Exit(1)
 	}
 	if result.CatchUp != nil {
-		printTicketMutationCatchUp("ticket status", result.CatchUp, parsed.JSON, result)
-		os.Exit(1)
+		printTicketMutationCatchUp("ticket status", result.CatchUp, result.Applied, parsed.JSON)
 	}
 	if parsed.JSON {
 		printJSON(result)
-		return
+	} else if result.Applied {
+		fmt.Printf("ticket %s → %s\n", result.TicketID, result.Status)
 	}
-	fmt.Printf("ticket %s → %s\n", result.TicketID, result.Status)
+	if !result.Applied {
+		os.Exit(1)
+	}
 }
 
 type stringListFlag []string
@@ -1021,16 +1023,18 @@ func runTicketAttach(args []string) {
 		os.Exit(1)
 	}
 	if result.CatchUp != nil {
-		printTicketMutationCatchUp("ticket attach", result.CatchUp, parsed.JSON, result)
-		os.Exit(1)
+		printTicketMutationCatchUp("ticket attach", result.CatchUp, result.Applied, parsed.JSON)
 	}
 	if parsed.JSON {
 		printJSON(result)
-		return
+	} else if result.Applied {
+		fmt.Printf("attached %d artifact(s) to ticket %s → %s\n", len(result.Artifacts), result.TicketID, result.State)
+		for _, artifact := range result.Artifacts {
+			fmt.Printf("  %s\n", artifact.Path)
+		}
 	}
-	fmt.Printf("attached %d artifact(s) to ticket %s → %s\n", len(result.Artifacts), result.TicketID, result.State)
-	for _, artifact := range result.Artifacts {
-		fmt.Printf("  %s\n", artifact.Path)
+	if !result.Applied {
+		os.Exit(1)
 	}
 }
 
@@ -1310,23 +1314,32 @@ func runTicketComment(args []string) {
 		os.Exit(1)
 	}
 	if result.CatchUp != nil {
-		printTicketMutationCatchUp("ticket comment", result.CatchUp, parsed.JSON, result)
-		os.Exit(1)
+		printTicketMutationCatchUp("ticket comment", result.CatchUp, result.Applied, parsed.JSON)
 	}
 	if parsed.JSON {
 		printJSON(result)
-		return
+	} else if result.Applied {
+		fmt.Printf("commented on ticket %s\n", result.TicketID)
 	}
-	fmt.Printf("commented on ticket %s\n", result.TicketID)
+	if !result.Applied {
+		os.Exit(1)
+	}
 }
 
-func printTicketMutationCatchUp(command string, bundle *protocol.TicketEventBundle, jsonOutput bool, result any) {
-	if jsonOutput {
-		printJSON(result)
-	} else {
+// printTicketMutationCatchUp renders ticket activity the caller had not read, which
+// the daemon consumed on its behalf, and says whether the write still ran. Both
+// notices go to stderr so --json keeps stdout parseable. The retry sentence is
+// load-bearing: the events are marked read now, so the same command a second time
+// goes through, and an agent told only "did not run" stops there.
+func printTicketMutationCatchUp(command string, bundle *protocol.TicketEventBundle, applied, jsonOutput bool) {
+	if !jsonOutput {
 		fprintTicketInbox(os.Stdout, &protocol.TicketInboxResult{Bundles: []protocol.TicketEventBundle{*bundle}})
 	}
-	fmt.Fprintf(os.Stderr, "%s: unread ticket activity was shown above; the requested update did not run — review it and retry\n", command)
+	if applied {
+		fmt.Fprintf(os.Stderr, "%s: attn's own updates on this ticket are shown above and are now marked read; your update ran.\n", command)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "%s: unread ticket activity is shown above and is now marked read; the requested update did NOT run — retry the same command to apply it.\n", command)
 }
 
 // ticketIDArgs is a single ticket-id positional plus the common session/json flags —

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -1332,14 +1332,19 @@ func runTicketComment(args []string) {
 // load-bearing: the events are marked read now, so the same command a second time
 // goes through, and an agent told only "did not run" stops there.
 func printTicketMutationCatchUp(command string, bundle *protocol.TicketEventBundle, applied, jsonOutput bool) {
-	if !jsonOutput {
+	// --json leaves the events in catch_up rather than rendering them, so the
+	// notice must not point at output that is not there.
+	where := "shown above"
+	if jsonOutput {
+		where = "in this result's catch_up"
+	} else {
 		fprintTicketInbox(os.Stdout, &protocol.TicketInboxResult{Bundles: []protocol.TicketEventBundle{*bundle}})
 	}
 	if applied {
-		fmt.Fprintf(os.Stderr, "%s: attn's own updates on this ticket are shown above and are now marked read; your update ran.\n", command)
+		fmt.Fprintf(os.Stderr, "%s: attn's own updates on this ticket are %s and are now marked read; your update ran.\n", command, where)
 		return
 	}
-	fmt.Fprintf(os.Stderr, "%s: unread ticket activity is shown above and is now marked read; the requested update did NOT run — retry the same command to apply it.\n", command)
+	fmt.Fprintf(os.Stderr, "%s: unread ticket activity is %s and is now marked read; the requested update did NOT run — retry the same command to apply it.\n", command, where)
 }
 
 // ticketIDArgs is a single ticket-id positional plus the common session/json flags —

--- a/internal/agent/attn_skill/references/tickets.md
+++ b/internal/agent/attn_skill/references/tickets.md
@@ -81,6 +81,21 @@ overwritten.
 After attaching, edit only the canonical source. Report meaningful changes on the
 ticket so participants know to re-read it.
 
+## Read before you write
+
+`ticket status`, `ticket comment`, and `ticket attach` all deliver ticket activity you
+had not read yet, printed above their own output.
+
+- When the activity came from **another participant** — the user, the chief, a sibling
+  agent — the command prints it, marks it read, and **does not run**, exiting 1. That is
+  deliberate: their word may change what you were about to write. Read it, then **run the
+  same command again** — the second attempt goes through. Never treat the refusal as the
+  end of the road; an agent that stops there leaves its report unwritten.
+- When it is only **attn's own bookkeeping** — the crash stamp, the "session was reloaded"
+  flip, a reconciliation verdict — the command prints it and still runs. Those records
+  describe what happened to your session while it was down; they are news to you, but
+  nothing to answer.
+
 ## Creating a ticket
 
 - **Delegation** mints a `working`, **bound** ticket — its description is the brief handed

--- a/internal/daemon/ticket_attach.go
+++ b/internal/daemon/ticket_attach.go
@@ -159,9 +159,10 @@ func (d *Daemon) submitTicketAttach(msg *protocol.TicketAttachMessage, author st
 		rollbackInstalledAttachFiles(staged)
 		return nil, err
 	}
-	if len(outcome.ConflictEvents) > 0 {
+	catchUp := ticketMutationCatchUp(ticketID, outcome.CatchUp)
+	d.afterTicketMutationCatchUpLocked(author, outcome.CatchUp)
+	if outcome.Blocked {
 		rollbackInstalledAttachFiles(staged)
-		d.afterTicketMutationCatchUpLocked(author, outcome.ConflictEvents)
 		d.deliveryMu.Unlock()
 		currentStatus := currentTicket.Status
 		if current, getErr := d.store.GetTicket(ticketID); getErr == nil && current != nil {
@@ -172,7 +173,8 @@ func (d *Daemon) submitTicketAttach(msg *protocol.TicketAttachMessage, author st
 			Artifacts:   []protocol.TicketArtifact{},
 			Fingerprint: fingerprint,
 			State:       protocol.TicketStatus(currentStatus),
-			CatchUp:     ticketMutationCatchUp(ticketID, outcome.ConflictEvents),
+			CatchUp:     catchUp,
+			Applied:     false,
 		}, nil
 	}
 	d.deliveryMu.Unlock()
@@ -201,6 +203,8 @@ func (d *Daemon) submitTicketAttach(msg *protocol.TicketAttachMessage, author st
 		EventSeq:     int(record.EventSeq),
 		State:        protocol.TicketStatus(record.Status),
 		Deduplicated: record.Deduplicated,
+		CatchUp:      catchUp,
+		Applied:      true,
 	}, nil
 }
 

--- a/internal/daemon/ticket_attach_test.go
+++ b/internal/daemon/ticket_attach_test.go
@@ -156,8 +156,8 @@ func TestTicketAttachCatchUpRollsBackInstalledFile(t *testing.T) {
 	msg := &protocol.TicketAttachMessage{Cmd: protocol.CmdTicketAttach, SourceSessionID: agentID, Files: []protocol.TicketAttachFile{source}}
 
 	first := callTicketAttach(t, d, msg)
-	if !first.Ok || first.TicketAttachResult == nil || first.TicketAttachResult.CatchUp == nil {
-		t.Fatalf("first response = %+v, want catch-up", first)
+	if !first.Ok || first.TicketAttachResult == nil || first.TicketAttachResult.CatchUp == nil || first.TicketAttachResult.Applied {
+		t.Fatalf("first response = %+v, want catch-up without the attach", first)
 	}
 	destination := filepath.Join(root, "tickets", ticketID, "design.md")
 	if _, err := os.Stat(destination); !os.IsNotExist(err) {
@@ -165,7 +165,7 @@ func TestTicketAttachCatchUpRollsBackInstalledFile(t *testing.T) {
 	}
 
 	retry := callTicketAttach(t, d, msg)
-	if !retry.Ok || retry.TicketAttachResult == nil || retry.TicketAttachResult.CatchUp != nil {
+	if !retry.Ok || retry.TicketAttachResult == nil || retry.TicketAttachResult.CatchUp != nil || !retry.TicketAttachResult.Applied {
 		t.Fatalf("retry response = %+v", retry)
 	}
 	if _, err := os.Stat(destination); err != nil {

--- a/internal/daemon/ticket_buffer_test.go
+++ b/internal/daemon/ticket_buffer_test.go
@@ -258,8 +258,8 @@ func TestMutationCatchUpRebuildsRemainingUnreadFromNewAttention(t *testing.T) {
 		_, outcome, err := d.store.AddTicketCommentWithOptions(
 			"first", sessionID, "should not land", d.ticketMutationOptions(sessionID), now,
 		)
-		if err == nil && len(outcome.ConflictEvents) > 0 {
-			d.afterTicketMutationCatchUpLocked(sessionID, outcome.ConflictEvents)
+		if err == nil && len(outcome.CatchUp) > 0 {
+			d.afterTicketMutationCatchUpLocked(sessionID, outcome.CatchUp)
 		}
 		d.deliveryMu.Unlock()
 		catchUpDone <- catchUpResult{outcome: outcome, err: err}
@@ -273,7 +273,7 @@ func TestMutationCatchUpRebuildsRemainingUnreadFromNewAttention(t *testing.T) {
 	close(resumeStaleRebuild)
 	<-rebuildDone
 	result := <-catchUpDone
-	if result.err != nil || len(result.outcome.ConflictEvents) == 0 {
+	if result.err != nil || len(result.outcome.CatchUp) == 0 {
 		t.Fatalf("mutation outcome = %+v err=%v, want catch-up", result.outcome, result.err)
 	}
 

--- a/internal/daemon/ticket_comment.go
+++ b/internal/daemon/ticket_comment.go
@@ -48,10 +48,11 @@ func (d *Daemon) handleTicketComment(conn net.Conn, msg *protocol.TicketCommentM
 	}
 	result := &protocol.TicketCommentResult{
 		TicketID: ticketID,
-		CatchUp:  ticketMutationCatchUp(ticketID, outcome.ConflictEvents),
+		CatchUp:  ticketMutationCatchUp(ticketID, outcome.CatchUp),
+		Applied:  !outcome.Blocked,
 	}
-	if len(outcome.ConflictEvents) > 0 {
-		d.afterTicketMutationCatchUpLocked(sourceSessionID, outcome.ConflictEvents)
+	d.afterTicketMutationCatchUpLocked(sourceSessionID, outcome.CatchUp)
+	if outcome.Blocked {
 		d.deliveryMu.Unlock()
 		_ = json.NewEncoder(conn).Encode(protocol.Response{Ok: true, TicketCommentResult: result})
 		return

--- a/internal/daemon/ticket_revive_test.go
+++ b/internal/daemon/ticket_revive_test.go
@@ -121,6 +121,72 @@ func TestRespawnLeavesNonCrashedTicketAlone(t *testing.T) {
 	}
 }
 
+// The observed bug (2026-08-09): a revived agent's FIRST report was always
+// refused. Dying and coming back writes two attn-authored events on its ticket —
+// the crash stamp and the crashed→working flip — and the mutation gate refused
+// any write while unread activity existed, so the first report died on activity
+// describing the agent's own death. The delegated agent that hit it did not
+// retry; it told its user "done" and its report never landed. The report must go
+// through on the first attempt, with the records it missed delivered beside it.
+func TestRevivedSessionReportsOnFirstAttempt(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	sessionID := delegateBoundSession(t, d)
+	ticketID := boundTicketID(t, d, sessionID)
+
+	d.store.UpdateState(sessionID, protocol.StateWorking)
+	d.handlePTYExit(ptybackend.ExitInfo{ID: sessionID, ExitCode: 1})
+	respawnDelegatedSession(t, d, sessionID)
+
+	resp := callSetTicketStatus(t, d, sessionID, string(protocol.DispatchWorkStateReadyForReview), "PR is up")
+	result := resp.TicketStatusResult
+	if !resp.Ok || result == nil || !result.Applied {
+		t.Fatalf("first report after revive = %+v, want applied", resp)
+	}
+	if result.Status != protocol.TicketStatusInReview {
+		t.Fatalf("reported status = %q, want in_review", result.Status)
+	}
+	if result.CatchUp == nil || len(result.CatchUp.Events) != 2 {
+		t.Fatalf("catch-up = %+v, want the crash and revive records delivered beside the report", result.CatchUp)
+	}
+	ticket, err := d.store.GetTicket(ticketID)
+	if err != nil || ticket == nil || ticket.Status != store.TicketStatusInReview {
+		t.Fatalf("ticket after report = %+v (err %v)", ticket, err)
+	}
+}
+
+// A peer's word that landed while the agent was down still gates its first
+// report: the crash records ride along in the same catch-up, but the comment
+// must be read before the agent may write over it.
+func TestRevivedSessionStillGatedByPeerActivity(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	sessionID := delegateBoundSession(t, d)
+	ticketID := boundTicketID(t, d, sessionID)
+
+	d.store.UpdateState(sessionID, protocol.StateWorking)
+	d.handlePTYExit(ptybackend.ExitInfo{ID: sessionID, ExitCode: 1})
+	if _, err := d.store.AddTicketComment(ticketID, "chief-peer", "scope changed while you were down", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	respawnDelegatedSession(t, d, sessionID)
+
+	first := callSetTicketStatus(t, d, sessionID, string(protocol.DispatchWorkStateReadyForReview), "should not land")
+	result := first.TicketStatusResult
+	if !first.Ok || result == nil || result.Applied {
+		t.Fatalf("first report = %+v, want refused", first)
+	}
+	if result.CatchUp == nil || len(result.CatchUp.Events) != 3 {
+		t.Fatalf("catch-up = %+v, want crash, peer comment and revive shown", result.CatchUp)
+	}
+
+	// Reading cost the write, not the ability to write: the same command retried
+	// goes through, which is what the refusal tells the agent to do.
+	retry := callSetTicketStatus(t, d, sessionID, string(protocol.DispatchWorkStateReadyForReview), "now reviewed")
+	if !retry.Ok || retry.TicketStatusResult == nil || !retry.TicketStatusResult.Applied ||
+		retry.TicketStatusResult.Status != protocol.TicketStatusInReview {
+		t.Fatalf("retry = %+v", retry)
+	}
+}
+
 // Daemon-restart safety: startup recovery adopting a still-live worker for a
 // crash-stamped ticket's session (a reap on an earlier boot stamped it, the
 // worker survived) moves the ticket back to Working — the same durable-vs-

--- a/internal/daemon/ticket_status.go
+++ b/internal/daemon/ticket_status.go
@@ -84,13 +84,14 @@ func (d *Daemon) handleSetTicketStatus(conn net.Conn, msg *protocol.SetTicketSta
 	result := &protocol.TicketStatusResult{
 		TicketID: ticketID,
 		Status:   protocol.TicketStatus(status),
-		CatchUp:  ticketMutationCatchUp(ticketID, outcome.ConflictEvents),
+		CatchUp:  ticketMutationCatchUp(ticketID, outcome.CatchUp),
+		Applied:  !outcome.Blocked,
 	}
-	if len(outcome.ConflictEvents) > 0 {
+	d.afterTicketMutationCatchUpLocked(sourceSessionID, outcome.CatchUp)
+	if outcome.Blocked {
 		if current, getErr := d.store.GetTicket(ticketID); getErr == nil && current != nil {
 			result.Status = protocol.TicketStatus(current.Status)
 		}
-		d.afterTicketMutationCatchUpLocked(sourceSessionID, outcome.ConflictEvents)
 		d.deliveryMu.Unlock()
 		_ = json.NewEncoder(conn).Encode(protocol.Response{Ok: true, TicketStatusResult: result})
 		return

--- a/internal/daemon/ticket_status_test.go
+++ b/internal/daemon/ticket_status_test.go
@@ -124,8 +124,8 @@ func TestSetTicketStatusCatchesUpBeforeMutating(t *testing.T) {
 	}
 
 	first := callSetTicketStatus(t, d, sessionID, string(protocol.DispatchWorkStateReadyForReview), "should not land")
-	if !first.Ok || first.TicketStatusResult == nil || first.TicketStatusResult.CatchUp == nil {
-		t.Fatalf("first response = %+v, want catch-up", first)
+	if !first.Ok || first.TicketStatusResult == nil || first.TicketStatusResult.CatchUp == nil || first.TicketStatusResult.Applied {
+		t.Fatalf("first response = %+v, want catch-up without the move", first)
 	}
 	ticket, _ := d.store.GetTicket(ticketID)
 	if ticket.Status != store.TicketStatusWorking {
@@ -133,7 +133,8 @@ func TestSetTicketStatusCatchesUpBeforeMutating(t *testing.T) {
 	}
 
 	retry := callSetTicketStatus(t, d, sessionID, string(protocol.DispatchWorkStateReadyForReview), "now reviewed")
-	if !retry.Ok || retry.TicketStatusResult == nil || retry.TicketStatusResult.CatchUp != nil || retry.TicketStatusResult.Status != protocol.TicketStatusInReview {
+	if !retry.Ok || retry.TicketStatusResult == nil || retry.TicketStatusResult.CatchUp != nil ||
+		!retry.TicketStatusResult.Applied || retry.TicketStatusResult.Status != protocol.TicketStatusInReview {
 		t.Fatalf("retry response = %+v", retry)
 	}
 }

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "219"
+const ProtocolVersion = "220"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -5573,6 +5573,9 @@ type TicketAttachMessage struct {
 }
 
 type TicketAttachResult struct {
+	// Applied corresponds to the JSON schema field "applied".
+	Applied bool `json:"applied"`
+
 	// Artifacts corresponds to the JSON schema field "artifacts".
 	Artifacts []TicketArtifact `json:"artifacts"`
 
@@ -5647,6 +5650,9 @@ type TicketCommentMessage struct {
 }
 
 type TicketCommentResult struct {
+	// Applied corresponds to the JSON schema field "applied".
+	Applied bool `json:"applied"`
+
 	// CatchUp corresponds to the JSON schema field "catch_up".
 	CatchUp *TicketEventBundle `json:"catch_up,omitempty,omitzero"`
 
@@ -5865,6 +5871,9 @@ const TicketStatusFailed TicketStatus = "failed"
 const TicketStatusInReview TicketStatus = "in_review"
 
 type TicketStatusResult struct {
+	// Applied corresponds to the JSON schema field "applied".
+	Applied bool `json:"applied"`
+
 	// CatchUp corresponds to the JSON schema field "catch_up".
 	CatchUp *TicketEventBundle `json:"catch_up,omitempty,omitzero"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -779,6 +779,7 @@ model TicketStatusResult {
   ticket_id: string;
   status: TicketStatus;
   catch_up?: TicketEventBundle;
+  applied: boolean; // false when catch_up had to be read first and the move did not run
 }
 
 // TicketCreateMessage mints a standalone backlog ticket — unbound (no assignee, no
@@ -821,6 +822,7 @@ model TicketCommentMessage {
 model TicketCommentResult {
   ticket_id: string;
   catch_up?: TicketEventBundle;
+  applied: boolean; // false when catch_up had to be read first and the comment did not post
 }
 
 // PresentOpenMessage opens a new presentation (or a new round on an existing
@@ -1006,6 +1008,7 @@ model TicketAttachResult {
   state: TicketStatus;
   deduplicated: boolean;
   catch_up?: TicketEventBundle;
+  applied: boolean; // false when catch_up had to be read first and nothing was attached
 }
 
 model TicketAttachResultMessage {

--- a/internal/store/ticket_mutation.go
+++ b/internal/store/ticket_mutation.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -30,11 +31,22 @@ type TicketMutationOptions struct {
 	ExpectedEventSeq *int64
 }
 
-// TicketMutationOutcome reports a CLI catch-up conflict. A non-empty slice means
-// the transaction advanced only this ticket's applicable cursors and deliberately
-// did not execute the mutation callback.
+// TicketMutationOutcome reports unread activity the mutation consumed. CatchUp is
+// owed to the caller either way; Blocked says whether reading it also cost the
+// caller its write — true means the transaction advanced this ticket's applicable
+// cursors and deliberately did not execute the mutation callback.
 type TicketMutationOutcome struct {
-	ConflictEvents []TicketEvent
+	CatchUp []TicketEvent
+	Blocked bool
+}
+
+// blocksTicketMutation reports whether an unread event must be read before the
+// caller may write. Only another participant's word does. attn's own bookkeeping
+// (the crash stamp, the crashed→working flip, a reconciliation verdict) records
+// what happened TO a session while it was dead, so refusing on it made a revived
+// agent's first report fail every time — on activity describing its own death.
+func blocksTicketMutation(event TicketEvent) bool {
+	return strings.TrimSpace(event.Author) != TicketAuthorAttn
 }
 
 func (s *Store) withTicketMutation(
@@ -55,6 +67,7 @@ func (s *Store) withTicketMutation(
 	}
 	defer tx.Rollback()
 
+	var outcome TicketMutationOutcome
 	if options.ExpectedEventSeq != nil {
 		actual, err := latestTicketEventSeqTx(tx, ticketID)
 		if err != nil {
@@ -64,20 +77,23 @@ func (s *Store) withTicketMutation(
 			return TicketMutationOutcome{}, fmt.Errorf("%w: expected event %d, latest is %d", ErrStaleTicketEventSeq, *options.ExpectedEventSeq, actual)
 		}
 	} else if len(options.Observers) > 0 {
-		conflicts, err := consumeTargetTicketEventsTx(tx, ticketID, options.Observers, now)
+		consumed, err := consumeTargetTicketEventsTx(tx, ticketID, options.Observers, now)
 		if err != nil {
 			return TicketMutationOutcome{}, err
 		}
-		if len(conflicts) > 0 {
+		if len(consumed) > 0 {
 			if key := strings.TrimSpace(options.AttentionKey); key != "" {
 				if err := setTicketDeliveryAttentionTx(tx, key, now); err != nil {
 					return TicketMutationOutcome{}, err
 				}
 			}
-			if err := tx.Commit(); err != nil {
-				return TicketMutationOutcome{}, err
+			if slices.ContainsFunc(consumed, blocksTicketMutation) {
+				if err := tx.Commit(); err != nil {
+					return TicketMutationOutcome{}, err
+				}
+				return TicketMutationOutcome{CatchUp: consumed, Blocked: true}, nil
 			}
-			return TicketMutationOutcome{ConflictEvents: conflicts}, nil
+			outcome.CatchUp = consumed
 		}
 	}
 
@@ -87,7 +103,7 @@ func (s *Store) withTicketMutation(
 	if err := tx.Commit(); err != nil {
 		return TicketMutationOutcome{}, err
 	}
-	return TicketMutationOutcome{}, nil
+	return outcome, nil
 }
 
 func latestTicketEventSeqTx(tx *sql.Tx, ticketID string) (int64, error) {

--- a/internal/store/ticket_mutation_test.go
+++ b/internal/store/ticket_mutation_test.go
@@ -31,7 +31,7 @@ func TestTicketMutationConsumesTargetUnreadBeforeMutating(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if updated != nil || len(outcome.ConflictEvents) != 1 || outcome.ConflictEvents[0].Comment != "new target context" {
+	if updated != nil || !outcome.Blocked || len(outcome.CatchUp) != 1 || outcome.CatchUp[0].Comment != "new target context" {
 		t.Fatalf("first attempt updated=%+v outcome=%+v", updated, outcome)
 	}
 	target, _ := s.GetTicket("target")
@@ -51,8 +51,81 @@ func TestTicketMutationConsumesTargetUnreadBeforeMutating(t *testing.T) {
 	}
 
 	updated, outcome, err = s.SetTicketStatusWithOptions("target", TicketStatusDone, "worker", "done", options, now.Add(4*time.Second))
-	if err != nil || updated == nil || len(outcome.ConflictEvents) != 0 || updated.Status != TicketStatusDone {
+	if err != nil || updated == nil || outcome.Blocked || len(outcome.CatchUp) != 0 || updated.Status != TicketStatusDone {
 		t.Fatalf("retry updated=%+v outcome=%+v err=%v", updated, outcome, err)
+	}
+}
+
+// attn's own bookkeeping is delivered, not charged for: an agent whose ticket
+// carries only attn-authored unread events writes on the first attempt and gets
+// those events back beside the result.
+func TestTicketMutationAppliesThroughAttnAuthoredCatchUp(t *testing.T) {
+	s := New()
+	defer s.Close()
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	if _, err := s.CreateTicket(Ticket{ID: "target", Title: "Target", Assignee: "worker", Status: TicketStatusWorking}, "chief", now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.SetTicketStatus("target", TicketStatusCrashed, TicketAuthorAttn, "agent process ended mid-flight without reporting", now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.SetTicketStatus("target", TicketStatusWorking, TicketAuthorAttn, "session was reloaded and is running again", now.Add(2*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	options := TicketMutationOptions{
+		Observers:    []TicketMutationObserver{{CursorIdentity: "worker", AuthorIdentity: "worker"}},
+		AttentionKey: "worker",
+	}
+
+	updated, outcome, err := s.SetTicketStatusWithOptions("target", TicketStatusInReview, "worker", "PR is up", options, now.Add(3*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.Blocked || updated == nil || updated.Status != TicketStatusInReview {
+		t.Fatalf("first attempt updated=%+v outcome=%+v", updated, outcome)
+	}
+	if len(outcome.CatchUp) != 2 {
+		t.Fatalf("catch-up = %+v, want the crash and revive records delivered", outcome.CatchUp)
+	}
+	unread, err := s.UnreadTicketEventsFor("worker", "worker")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unread) != 0 {
+		t.Fatalf("unread after delivery = %+v, want the cursor advanced", unread)
+	}
+}
+
+// A peer's word in the same unread batch still costs the write: the agent must
+// read it before it may report over it.
+func TestTicketMutationBlocksWhenAttnCatchUpCarriesAPeerEvent(t *testing.T) {
+	s := New()
+	defer s.Close()
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	if _, err := s.CreateTicket(Ticket{ID: "target", Title: "Target", Assignee: "worker", Status: TicketStatusWorking}, "chief", now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.SetTicketStatus("target", TicketStatusCrashed, TicketAuthorAttn, "agent process ended mid-flight without reporting", now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.AddTicketComment("target", "chief", "scope changed while you were down", now.Add(2*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	options := TicketMutationOptions{
+		Observers:    []TicketMutationObserver{{CursorIdentity: "worker", AuthorIdentity: "worker"}},
+		AttentionKey: "worker",
+	}
+
+	updated, outcome, err := s.SetTicketStatusWithOptions("target", TicketStatusDone, "worker", "done", options, now.Add(3*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated != nil || !outcome.Blocked || len(outcome.CatchUp) != 2 {
+		t.Fatalf("updated=%+v outcome=%+v, want blocked with both records shown", updated, outcome)
+	}
+	target, _ := s.GetTicket("target")
+	if target.Status != TicketStatusCrashed {
+		t.Fatalf("blocked mutation changed status to %s", target.Status)
 	}
 }
 


### PR DESCRIPTION
## The bug

A delegated agent that dies and is revived could not report on its ticket on the first attempt — deterministically, every time.

Dying and coming back writes two events on the bound ticket, both authored by `attn` itself: the crash stamp (`agent process ended mid-flight without reporting`) and the crashed→working flip (`session was reloaded and is running again`); reconciliation usually adds a verdict comment as a third. The CLI mutation gate (`store.withTicketMutation`) refused *any* write while unread activity existed on the ticket — it printed the activity, marked it read, and exited 1 so the agent reads before it writes. So a revived agent's first `attn ticket status` / `ticket comment` / `ticket attach` always failed, on activity describing its own death.

The retry would have worked (the refusal clears the unread), but agents do not retry. Observed live on 2026-08-09: a revived delegated agent was refused once, told its user "done", and its report never landed.

## The contract shipped

**Only another participant's word gates a write.** attn's own bookkeeping about a ticket never does.

- Unread activity authored by the user, the chief, or a sibling agent still refuses the mutation and exits 1 — their word may change what the agent was about to write. The message now names the contract explicitly: *"unread ticket activity is shown above and is now marked read; the requested update did NOT run — retry the same command to apply it."*
- Unread activity authored by `attn` (crash stamp, revive flip, reconciliation verdict, an automation's failure note) is delivered as catch-up **beside a successful mutation**. It is news to the agent — it was dead when the events landed — but there is nothing to answer.
- A mixed batch is gated: the peer event decides, and everything consumed is shown.

Cursor advance, attention repair, and nudge-countdown cancellation are unchanged and now run on both paths, so delivering catch-up alongside a success does not leave a stale nudge armed.

### Why not the alternatives

- **Revive pre-clears activity up to the revive point.** It loses real messages: a chief comment posted while the agent was down would be marked read without ever being shown, and a revived agent's context replays its *conversation*, not the ticket thread. It is also revive-specific — the same trap exists wherever attn stamps a ticket about a session that is not alive.
- **Only improve the error text.** Shipped anyway (see the refusal message above), but it is the floor, not the fix. A deterministic first-attempt failure is still a trap when it is labeled.

## What changed

- `internal/store/ticket_mutation.go` — `TicketMutationOutcome` splits "what was consumed" (`CatchUp`) from "did it cost the write" (`Blocked`); `blocksTicketMutation` is the one-line predicate that decides.
- `internal/daemon/ticket_{status,comment,attach}.go` — carry the catch-up on both paths; report `applied`.
- `cmd/attn/main.go` — the three commands print catch-up either way, exit 1 only when refused, and both notices go to stderr so `--json` stdout stays parseable.
- Protocol 220: `applied` on `TicketStatusResult`, `TicketCommentResult`, `TicketAttachResult`.
- `internal/agent/attn_skill/references/tickets.md` — a "Read before you write" section, so an agent knows to retry.

## Verification

**Tests.** `internal/store`: an attn-only unread batch applies and returns its catch-up with the cursor advanced; a batch carrying one peer comment blocks and leaves the ticket alone. `internal/daemon`: `TestRevivedSessionReportsOnFirstAttempt` drives a real crash (`handlePTYExit` mid-flight) and a real respawn, then asserts the first report applies with both records delivered; `TestRevivedSessionStillGatedByPeerActivity` adds a peer comment during the downtime and asserts refusal-then-retry. Mutation-checked: reverting `blocksTicketMutation` to the old always-gate behavior turns both new tests red on their load-bearing assertion.

**Live witness** (throwaway profile `revivetrap`, packaged app + daemon installed from this branch, protocol 220 on both, cleaned up afterwards). A real `claude` agent, ticket bound and working, mid-turn; its pty-worker SIGKILLed by a pid captured from the daemon's own registry; ticket stamped `crashed`; daemon restarted and the app reopened; session revived through `reload_session` and the ticket flipped back to `working`. Then the revived session's **first** report:

```
$ attn ticket status ready_for_review --session <id> --comment "..."
revive-fixture-7-876z
  [22:26:14Z] status_changed by attn (working → crashed)
    agent process ended mid-flight without reporting
  [22:26:32Z] commented by attn
    🩺 Reconciliation verdict — session … the agent process exited on its own …
  [22:28:02Z] status_changed by attn (crashed → working)
    session was reloaded and is running again
ticket revive-fixture-7-876z → in_review
(stderr) ticket status: attn's own updates on this ticket are shown above and are now marked read; your update ran.
exit 0
```

All three attn records delivered; the report landed on the first attempt.

And the gate still holds, on the same live session:

```
$ attn ticket comment revive-fixture-7-876z -m "peer: scope changed, do not close yet" --session <other-session>
$ attn ticket status in_progress --session <id> --comment "back on it"
  [22:28:20Z] commented by <other-session>
    peer: scope changed, do not close yet
(stderr) ticket status: unread ticket activity is shown above and is now marked read; the requested update did NOT run — retry the same command to apply it.
exit 1
$ attn ticket status in_progress --session <id> --comment "back on it"
ticket revive-fixture-7-876z → working
exit 0
```

`--json` on a refused mutation returns `applied: false` with the catch-up in the payload and nothing but JSON on stdout.

## Surfaces walked

- **CLI** — all three mutating commands.
- **Daemon** — the three handlers; the app's optimistic-concurrency path (`expected_event_seq`) never produces catch-up and always reports `applied: true`.
- **Protocol** — `main.tsp` → `generate-types` → `generated.go` + `generated.ts`, `ProtocolVersion` 219→220 in `constants.go` and `useDaemonSocket.ts`.
- **Linux** — pure Go, no platform code.
- **App/plugins/SDK** — no consumer reads ticket `catch_up`; the added field is additive.
- **Docs** — changelog fragment; attn skill reference.

The epic branch's `pi-host-delegate` scenario has a revived-agent leg that becomes the packaged e2e regression for this once that epic merges. I do not own that scenario; this PR does not touch `epic/pi-headless-host`.

## Noticed, not fixed

After a hard worker SIGKILL with the daemon alive, `reload_session` cannot revive the session: `Remove` cannot reach the dead worker's socket, so the backend registry keeps the id and `Spawn` returns `session already exists`. The session only becomes reloadable after a daemon restart clears the stale entry. Pre-existing and unrelated to this change — flagging it, not fixing it here.


https://claude.ai/code/session_019UmUszqz2JEhp6S4g3Fgzd
