### PR TITLE
fix(jobs): retry a refused cron arm and say which kind and why

### DIFF
--- a/changelog.d/cron-arming-retries-and-says-why.yaml
+++ b/changelog.d/cron-arming-retries-and-says-why.yaml
@@ -1,0 +1,11 @@
+kind: fixed
+area: jobs
+change: >
+  A periodic tick whose recurring record the database refused to write is no
+  longer lost until the next daemon restart. Arming a cron kind now retries on
+  the queue's own backoff until the record lands, and while it has not, the
+  daemon log and any caller reading the entry both name the kind and the
+  underlying error instead of reporting nothing at all. The job queue's
+  single-instance lock also moves next to the daemon's own attn.pid, so one
+  daemon means one queue — the same file in production, and no longer one lock
+  shared by every daemon a test process builds.

--- a/internal/daemon/job_store.go
+++ b/internal/daemon/job_store.go
@@ -18,8 +18,11 @@ var _ jobs.Store = (*sqlJobStore)(nil)
 // (which imports both internal/jobs and internal/store) so neither of those
 // packages depends on the other.
 //
-// The single-instance lock is a file lock in the profile data dir — one queue per
-// profile, matching one daemon per profile.
+// The single-instance lock is a file lock in the daemon's own data root, beside
+// the attn.pid that already marks one daemon per root — one queue per daemon.
+// config.ValidateDaemonIsolation refuses to start a daemon whose data root is not
+// the profile data dir unless its database is separately isolated, so a root of
+// its own always means a store of its own.
 type sqlJobStore struct {
 	store   *store.Store
 	lockDir string
@@ -27,9 +30,13 @@ type sqlJobStore struct {
 }
 
 // newSQLJobStore builds the adapter over the daemon's store, locking under the
-// profile data dir.
+// daemon's data root.
 func (d *Daemon) newSQLJobStore() *sqlJobStore {
-	return &sqlJobStore{store: d.store, lockDir: config.DataDir(), log: d.logf}
+	lockDir := d.dataRoot
+	if lockDir == "" {
+		lockDir = config.DataDir()
+	}
+	return &sqlJobStore{store: d.store, lockDir: lockDir, log: d.logf}
 }
 
 // jobSubject names the entity a background job acts on — the workspace, session,

--- a/internal/daemon/job_store_testing_test.go
+++ b/internal/daemon/job_store_testing_test.go
@@ -7,11 +7,9 @@ import (
 )
 
 // newTestJobStore builds the queue's persistence over the test daemon's own
-// SQLite store, with the single-instance lock in a per-test temp dir.
-//
-// The lock dir is NOT config.DataDir() (what production uses): a test binary
-// builds many daemons in one process against one scoped data dir, so a shared
-// lock would let the first started runner block every later one.
+// SQLite store, with the single-instance lock in a per-test temp dir. A runner
+// this helper builds is not the daemon's own, so it takes a lock dir of its own
+// rather than contending with startJobQueue's over the daemon's data root.
 func newTestJobStore(t *testing.T, d *Daemon) jobs.Store {
 	t.Helper()
 	return &sqlJobStore{store: d.store, lockDir: t.TempDir(), log: func(string, ...any) {}}

--- a/internal/daemon/periodic_cron_test.go
+++ b/internal/daemon/periodic_cron_test.go
@@ -14,12 +14,11 @@ import (
 func TestStartJobQueueArmsThePeriodicTicks(t *testing.T) {
 	d := newBubbleDaemon(t)
 	notebookRoot := t.TempDir()
-	// In a bubble because arming is asynchronous: startJobQueue hands the two cron
-	// entries to the runner, whose dispatch goroutine writes them. Reading the
-	// entries straight afterwards used to be a race the test won on an idle
-	// machine and lost under full-suite load, reported as "notebook_cron is not
-	// armed". synctest.Wait returns only once that goroutine has parked, so the
-	// read happens after the write by construction.
+	// Arming is synchronous inside startJobQueue, so a missing entry here is never
+	// an early read: either the runner never started or the store refused the
+	// write. Both used to be logged into a test daemon's nil logger and dropped,
+	// which is how this failing under full-suite load survived a triage as a race.
+	// CronEntry carries the reason now, so the fatal below prints it.
 	synctest.Test(t, func(t *testing.T) {
 		d.store.SetSetting(SettingNotebookRoot, notebookRoot)
 		d.startJobQueue()

--- a/internal/jobs/cron.go
+++ b/internal/jobs/cron.go
@@ -35,9 +35,6 @@ func (r *Runner) cronInterval(kind string) time.Duration {
 }
 
 // armCron gives every registered cron kind a recurring record, once, from Start.
-// An on-schedule record is left alone: re-arming every boot would starve a daemon
-// restarted more often than the interval. A terminal record is revived — a build
-// that missed the registration killed it as unknown-kind, and nothing else selects it.
 func (r *Runner) armCron() {
 	r.mu.Lock()
 	kinds := make(map[string]time.Duration, len(r.handlers))
@@ -49,22 +46,109 @@ func (r *Runner) armCron() {
 	r.mu.Unlock()
 
 	for kind, interval := range kinds {
-		existing, err := r.GetByKey(kind, CronKey)
-		if err != nil {
-			r.log("jobs: read cron entry for %s: %v", kind, err)
-			continue
-		}
-		if existing != nil && !existing.State.Terminal() {
-			continue
-		}
-		if existing != nil {
-			r.log("jobs: cron entry for %s was %s (%s); reviving it", kind, existing.State, existing.LastError)
-		}
-		// Enqueue coalesces, so a revive resets that row rather than minting a second.
-		if _, err := r.Enqueue(kind, EnqueueOptions{UniqueKey: CronKey, Delay: interval}); err != nil {
-			r.log("jobs: arm cron entry for %s: %v", kind, err)
+		r.armCronKind(kind, interval)
+	}
+}
+
+// pendingArm is a cron kind the store refused to arm. It lives in memory because
+// a kind that failed to arm left NO record behind: dispatch never selects it and
+// finish() never re-arms it, so there is nothing durable to retry from.
+type pendingArm struct {
+	interval time.Duration
+	attempts int
+	retryAt  time.Time
+	lastErr  error
+}
+
+// armCronKind writes one kind's recurring record, parking it for retry when the
+// store refuses.
+func (r *Runner) armCronKind(kind string, interval time.Duration) {
+	if err := r.writeCronEntry(kind, interval); err != nil {
+		r.deferCronArm(kind, interval, err)
+		return
+	}
+	r.mu.Lock()
+	pending := r.pendingArms[kind]
+	delete(r.pendingArms, kind)
+	r.mu.Unlock()
+	if pending != nil {
+		r.log("jobs: cron %s is armed after %d failed attempt(s)", kind, pending.attempts)
+	}
+}
+
+// writeCronEntry is the arming write for one kind. An on-schedule record is left
+// alone: re-arming every boot would starve a daemon restarted more often than the
+// interval. A terminal record is revived — a build that missed the registration
+// killed it as unknown-kind, and nothing else selects it.
+func (r *Runner) writeCronEntry(kind string, interval time.Duration) error {
+	existing, err := r.GetByKey(kind, CronKey)
+	if err != nil {
+		return fmt.Errorf("read cron entry: %w", err)
+	}
+	if existing != nil && !existing.State.Terminal() {
+		return nil
+	}
+	if existing != nil {
+		r.log("jobs: cron entry for %s was %s (%s); reviving it", kind, existing.State, existing.LastError)
+	}
+	// Enqueue coalesces, so a revive resets that row rather than minting a second.
+	if _, err := r.Enqueue(kind, EnqueueOptions{UniqueKey: CronKey, Delay: interval}); err != nil {
+		return fmt.Errorf("enqueue cron entry: %w", err)
+	}
+	return nil
+}
+
+// deferCronArm parks a failed arm on the runner's standard backoff and says so.
+func (r *Runner) deferCronArm(kind string, interval time.Duration, cause error) {
+	r.mu.Lock()
+	pending := r.pendingArms[kind]
+	if pending == nil {
+		pending = &pendingArm{interval: interval}
+		r.pendingArms[kind] = pending
+	}
+	pending.attempts++
+	pending.lastErr = cause
+	pending.retryAt = r.now().Add(r.backoff(pending.attempts))
+	attempts, retryAt := pending.attempts, pending.retryAt
+	r.mu.Unlock()
+	r.log("jobs: CRON %s IS NOT ARMED (attempt %d): %v — it will not fire until it is; retrying at %s",
+		kind, attempts, cause, retryAt.Format(time.RFC3339))
+}
+
+// retryCronArming re-attempts every parked arm whose backoff has elapsed. The
+// dispatch loop calls it once per pass, so it costs one uncontended mutex on a
+// runner with nothing parked — which is every runner that is healthy.
+func (r *Runner) retryCronArming() {
+	r.mu.Lock()
+	if len(r.pendingArms) == 0 {
+		r.mu.Unlock()
+		return
+	}
+	now := r.now()
+	due := make(map[string]time.Duration, len(r.pendingArms))
+	for kind, pending := range r.pendingArms {
+		if !now.Before(pending.retryAt) {
+			due[kind] = pending.interval
 		}
 	}
+	r.mu.Unlock()
+	for kind, interval := range due {
+		r.armCronKind(kind, interval)
+	}
+}
+
+// cronArmError reports why a kind has no recurring record, or nil when the
+// runner has no explanation to offer.
+func (r *Runner) cronArmError(kind string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.startErr != nil {
+		return fmt.Errorf("the runner did not start: %w", r.startErr)
+	}
+	if pending := r.pendingArms[kind]; pending != nil {
+		return fmt.Errorf("arming it has failed %d time(s), last: %w", pending.attempts, pending.lastErr)
+	}
+	return nil
 }
 
 // rearmCronLocked returns a finished cron job to queued one interval out.
@@ -84,7 +168,9 @@ func (r *Runner) rearmCronLocked(j *Job, interval time.Duration, runErr error) {
 		j.LastError = ""
 	}
 	if err := r.store.Save(j); err != nil {
-		r.log("jobs: re-arm cron entry for %s: %v", j.Kind, err)
+		// The claim write left the row RUNNING, which dispatch never selects; only
+		// the orphan recovery at the next Start puts it back in the rotation.
+		r.log("jobs: CRON %s DID NOT RE-ARM: %v — it will not fire again until the daemon restarts", j.Kind, err)
 	}
 }
 
@@ -95,6 +181,8 @@ var ErrNotCron = errors.New("jobs: kind is not a cron entry")
 var ErrCronKind = errors.New("jobs: kind is a cron entry and cannot be enqueued directly")
 
 // CronEntry returns the recurring record for kind: next fire and last outcome.
+// A missing record is an error whenever the runner knows why it is missing —
+// "no entry, no error" reads as "not armed yet" and explains nothing.
 func (r *Runner) CronEntry(kind string) (*Job, error) {
 	if r.disabled {
 		return nil, ErrDisabled
@@ -102,5 +190,12 @@ func (r *Runner) CronEntry(kind string) (*Job, error) {
 	if r.cronInterval(kind) <= 0 {
 		return nil, fmt.Errorf("%w: %s", ErrNotCron, kind)
 	}
-	return r.GetByKey(kind, CronKey)
+	entry, err := r.GetByKey(kind, CronKey)
+	if err != nil || entry != nil {
+		return entry, err
+	}
+	if armErr := r.cronArmError(kind); armErr != nil {
+		return nil, fmt.Errorf("jobs: cron entry for %s is not armed: %w", kind, armErr)
+	}
+	return nil, nil
 }

--- a/internal/jobs/cron_test.go
+++ b/internal/jobs/cron_test.go
@@ -3,6 +3,9 @@ package jobs
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
@@ -212,6 +215,104 @@ func TestArmingRevivesACronEntryAPriorBuildKilled(t *testing.T) {
 			t.Fatalf("the revived cron entry never fired; it sits at state=%q scheduled=%s", j.State, j.ScheduledAt)
 		}
 	})
+}
+
+// The store can refuse the arming write — a busy SQLite under load is the case
+// that happens. A kind that fails to arm has no record at all: dispatch never
+// selects it and finish() never re-arms it, so noting the error and moving on
+// retires the duty until someone restarts the daemon. Arming keeps trying, and
+// while it has not landed it says so both in the log and to a caller asking.
+func TestArmingRetriesUntilTheStoreTakesTheCronEntry(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var logMu sync.Mutex
+		var logged []string
+		r, store := newBubbleRunner(t, func(o *Options) {
+			o.Log = func(format string, args ...any) {
+				logMu.Lock()
+				logged = append(logged, fmt.Sprintf(format, args...))
+				logMu.Unlock()
+			}
+		})
+		var fires atomic.Int64
+		if err := r.RegisterCron(cronKind, time.Hour, func(context.Context, *Job) (any, error) {
+			fires.Add(1)
+			return nil, nil
+		}, HandlerConfig{}); err != nil {
+			t.Fatalf("register cron: %v", err)
+		}
+
+		store.refuseSaves(errors.New("database is locked"))
+		mustStart(t, r)
+		synctest.Wait()
+
+		entry, err := r.CronEntry(cronKind)
+		if entry != nil {
+			t.Fatalf("a store that refused every write still produced a cron entry: %+v", entry)
+		}
+		if err == nil {
+			t.Fatal("an unarmed cron entry reported no error, which reads exactly like a healthy one that has not been written yet")
+		}
+		for _, want := range []string{cronKind, "database is locked"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("CronEntry error %q does not name %q", err, want)
+			}
+		}
+		logMu.Lock()
+		lines := strings.Join(logged, "\n")
+		logMu.Unlock()
+		if !strings.Contains(lines, cronKind) || !strings.Contains(lines, "database is locked") {
+			t.Fatalf("nothing in the log names the kind and the cause:\n%s", lines)
+		}
+
+		store.healSaves()
+		// The retry is one backoff away and the dispatch loop is what runs it.
+		time.Sleep(DefaultBackoffBase + time.Second)
+		synctest.Wait()
+
+		armed, err := r.CronEntry(cronKind)
+		if err != nil || armed == nil {
+			t.Fatalf("cron entry after the store recovered: %v (%+v)", err, armed)
+		}
+		if armed.State != StateQueued {
+			t.Fatalf("re-armed cron entry state = %s, want queued", armed.State)
+		}
+		// Armed is not the same as beating: let the interval elapse and watch it fire.
+		time.Sleep(time.Hour)
+		synctest.Wait()
+		if got := fires.Load(); got != 1 {
+			t.Fatalf("the re-armed cron fired %d times over its interval, want 1", got)
+		}
+	})
+}
+
+// A runner whose Start failed arms nothing at all, so every kind it registered is
+// missing for a reason it alone knows. Losing the single-instance lock to another
+// runner is how that happens.
+func TestCronEntryReportsARunnerThatNeverStarted(t *testing.T) {
+	store := newMemStore()
+	opts := Options{Store: store, PollInterval: testPoll, Log: func(string, ...any) {}}
+
+	holder := New(opts)
+	mustStart(t, holder)
+	t.Cleanup(holder.Stop)
+
+	blocked := New(opts)
+	if err := blocked.RegisterCron(cronKind, time.Hour, func(context.Context, *Job) (any, error) {
+		return nil, nil
+	}, HandlerConfig{}); err != nil {
+		t.Fatalf("register cron: %v", err)
+	}
+	if err := blocked.Start(); !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("second Start = %v, want ErrAlreadyRunning", err)
+	}
+
+	entry, err := blocked.CronEntry(cronKind)
+	if entry != nil {
+		t.Fatalf("a runner that never started produced a cron entry: %+v", entry)
+	}
+	if !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("CronEntry on a runner that never started = %v, want it to carry %v", err, ErrAlreadyRunning)
+	}
 }
 
 // Enqueueing ordinary work onto a recurring kind would mint a second record that

--- a/internal/jobs/memstore_test.go
+++ b/internal/jobs/memstore_test.go
@@ -18,6 +18,9 @@ type memStore struct {
 	// saveErr, when set, makes the next Save fail. Tests use it to drive the
 	// claim-rollback path.
 	saveErr error
+	// stickySaveErr keeps saveErr in place instead of spending it on one call, so
+	// a test can hold the store down across several attempts.
+	stickySaveErr bool
 }
 
 func newMemStore() *memStore { return &memStore{jobs: make(map[string]*Job)} }
@@ -78,7 +81,9 @@ func (m *memStore) Save(j *Job) error {
 	defer m.mu.Unlock()
 	if m.saveErr != nil {
 		err := m.saveErr
-		m.saveErr = nil
+		if !m.stickySaveErr {
+			m.saveErr = nil
+		}
 		return err
 	}
 	if j.Requeued && j.State == StateRunning {
@@ -163,6 +168,20 @@ func (m *memStore) failNextSave(err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.saveErr = err
+}
+
+// refuseSaves fails every Save until healSaves: a store that is down, rather
+// than one that is momentarily busy.
+func (m *memStore) refuseSaves(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.saveErr, m.stickySaveErr = err, true
+}
+
+func (m *memStore) healSaves() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.saveErr, m.stickySaveErr = nil, false
 }
 
 // fakeClock is a manually advanced clock so backoff and debounce windows are

--- a/internal/jobs/runner.go
+++ b/internal/jobs/runner.go
@@ -119,6 +119,11 @@ type Runner struct {
 	mu       sync.Mutex
 	handlers map[string]handler
 	started  bool
+	// startErr is the last Start failure, kept so a caller asking about a cron
+	// entry that is missing because nothing started learns that, not silence.
+	startErr error
+	// pendingArms holds the cron kinds arming could not write yet (cron.go).
+	pendingArms map[string]*pendingArm
 
 	// ioMu serializes every read-modify-write on a job record; without it a
 	// concurrent Enqueue and a claim/finish write would lost-update each other.
@@ -164,6 +169,7 @@ func New(opts Options) *Runner {
 		now:          func() time.Time { return now().UTC() },
 		disabled:     opts.Store == nil,
 		handlers:     make(map[string]handler),
+		pendingArms:  make(map[string]*pendingArm),
 		runs:         make(map[string]*activeRun),
 		inflight:     make(map[string]int),
 		pollInterval: nonZeroDuration(opts.PollInterval, defaultPollInterval),
@@ -240,17 +246,21 @@ func (r *Runner) Start() error {
 		r.mu.Unlock()
 		return errors.New("jobs: runner already started")
 	}
-	if err := r.store.Init(); err != nil {
+	if initErr := r.store.Init(); initErr != nil {
+		startErr := fmt.Errorf("jobs: init store: %w", initErr)
+		r.startErr = startErr
 		r.mu.Unlock()
-		return fmt.Errorf("jobs: init store: %w", err)
+		return startErr
 	}
 	// Exclusive ownership first: a second live Runner on the same store would
 	// double-execute every job.
 	token, err := r.store.AcquireLock()
 	if err != nil {
+		r.startErr = err
 		r.mu.Unlock()
 		return err
 	}
+	r.startErr = nil
 	r.lockToken = token
 	r.started = true
 	r.done = make(chan struct{})
@@ -540,6 +550,9 @@ func (r *Runner) loop() {
 	ticker := time.NewTicker(r.pollInterval)
 	defer ticker.Stop()
 	for {
+		// A cron kind the store refused to arm has no record to dispatch, so this
+		// loop is the only thing left that can bring it back.
+		r.retryCronArming()
 		for {
 			select {
 			case <-r.done:


### PR DESCRIPTION
`armCron` logged its enqueue error and moved on. A cron kind that fails to arm
leaves **no record at all** — dispatch never selects it and `finish()` never
re-arms it — so that duty was gone until the next daemon restart, and the only
evidence was work that silently never happened. The failing tripwire test
(`TestStartJobQueueArmsThePeriodicTicks`) said `notebook_cron is not armed` and
nothing more, which is why the flake behind it survived a triage.

## The failure that actually happened

Instrumenting `AcquireDirLock` and running the daemon suite reproduced it:

```
BEFORE (unmodified main, go test ./internal/daemon -count=3 -v)
  --- FAIL: TestStartJobQueueArmsThePeriodicTicks   (2 of the 3 passes)
  72 × AcquireDirLock REFUSED at <pkg data dir>/.runner.lock (held by pid 15192, ours 15192)

AFTER (same command, this branch)
  PASS, 0 refusals
```

The queue's single-instance lock was one file in `config.DataDir()`. A test
binary builds many daemons against one package-scoped data dir, so one live test
daemon's runner refused every other test daemon's `Runner.Start()` — with *our own
pid* in the lock file, which `lockHolderAlive` correctly reads as live. `Start()`
returned `ErrAlreadyRunning`, `armCron` never ran, and the entry was missing.
Both diagnostics were swallowed twice over: `armCron` dropped its error, and
`NewForTesting` sets `logger: nil`, so `d.logf` is a no-op in tests.

## What changed

- **Arming retries.** A refused arm is parked on the queue's own backoff (1m, 2m,
  … capped at 1h) and re-attempted by the dispatch loop until the record lands. A
  cron entry never dies, so there is no attempt cap — but there is no hot loop
  either, since every retry is at least one backoff apart.
- **Every failure names itself.** The log carries the kind, the store's error, the
  attempt, and the next try; a successful retry logs the recovery. `CronEntry`
  returns *why* a kind has no record — a parked arm's cause, or a `Start` that
  failed before arming ran — instead of `(nil, nil)`, which reads exactly like a
  healthy entry nobody has written yet. That is what the red test now prints.
- **`rearmCronLocked`'s sibling failure states its consequence**: the claim write
  left the row `RUNNING`, which dispatch never selects, so only the orphan
  recovery at the next `Start` puts it back in the rotation.
- **The lock moves to the daemon's own data root**, beside the `attn.pid` that
  already marks one daemon per root. The same file in production —
  `ValidateDaemonIsolation` refuses to start a daemon whose data root is not the
  profile data dir unless its database is separately isolated, so a root of its
  own always means a store of its own. In a test process it is what stops one
  daemon's runner from blocking every other one's queue.

## Verification

Live, on a real headless daemon (own profile, own data dir, real SQLite), with a
trigger forcing the `notebook_cron` insert to fail:

```
00:30:13 jobs: CRON notebook_cron IS NOT ARMED (attempt 1): enqueue cron entry:
         store: upsert job 96d69a3a…: database is locked (simulated)
         — it will not fire until it is; retrying at 2026-08-09T22:31:13Z
   (trigger dropped)
00:31:14 jobs: cron notebook_cron is armed after 1 failed attempt(s)

sqlite> select kind, unique_key, state from jobs;
notebook_cron|cron|queued
```

Before this change that heartbeat stayed dead until someone restarted the daemon.

Automated: two new bubbled tests in `internal/jobs` (a store that refuses the
arming write, and a runner refused the single-instance lock), both
mutation-checked — dropping the retry or the `CronEntry` reason turns each red on
its load-bearing assertion. `go test ./internal/jobs -race`, the full Go suite,
and `./internal/daemon -count=3` are green.

Tier: background-runner change with no protocol, PTY, or UI surface (nothing on
the wire reads cron entries), so the witness is a real daemon driven headlessly
rather than the packaged app.
