### PR TITLE
fix(workspace): keep zoom mode in one place

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3916,11 +3916,12 @@ function AppContent({
                         setActiveSession(paneSessionId);
                       }
                     }}
-                    onZoomModeChange={(zoomed) => {
+                    zoomActive={Boolean(zoomModeBySessionId[workspace.id])}
+                    onSetZoomActive={(active) => {
                       setZoomModeBySessionId((prev) => (
-                        prev[workspace.id] === zoomed
+                        prev[workspace.id] === active
                           ? prev
-                          : { ...prev, [workspace.id]: zoomed }
+                          : { ...prev, [workspace.id]: active }
                       ));
                     }}
                     onNavigateOutOfSession={handleNavigateOutOfSession}

--- a/app/src/components/SessionTerminalWorkspace.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { forwardRef, useEffect, useImperativeHandle, type ReactNode } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useState, type ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SessionTerminalWorkspace } from './SessionTerminalWorkspace';
 import type { PaneRuntimeEventRouter } from './SessionTerminalWorkspace/paneRuntimeEventRouter';
@@ -62,6 +62,29 @@ const { registeredShortcuts } = vi.hoisted(() => ({
 const mockEventRouter: PaneRuntimeEventRouter = {
   registerBinding: vi.fn(() => () => {}),
 };
+
+// Zoom mode lives in App, so a standalone render needs a host to hold it.
+function ZoomHost({ workspace, activePaneId }: { workspace: TerminalWorkspaceState; activePaneId: string }) {
+  const [zoomActive, setZoomActive] = useState(false);
+  return (
+    <SessionTerminalWorkspace
+      workspaceId="workspace-session-1"
+      workspaceSessions={[{ id: 'session-1', label: 'Session 1', agent: 'claude', cwd: '/tmp/repo' }]}
+      workspace={workspace}
+      activePaneId={activePaneId}
+      fontSize={14}
+      enabled
+      isActiveSession
+      eventRouter={mockEventRouter}
+      onSplitPane={vi.fn()}
+      onClosePane={vi.fn()}
+      onFocusPane={vi.fn()}
+      onNavigateOutOfSession={vi.fn()}
+      zoomActive={zoomActive}
+      onSetZoomActive={setZoomActive}
+    />
+  );
+}
 
 const { mockPtyAttach, mockPtyDetach, mockPtyResize, mockPtyWrite } = vi.hoisted(() => ({
   mockPtyAttach: vi.fn(() => Promise.resolve()),
@@ -941,20 +964,7 @@ describe('SessionTerminalWorkspace', () => {
 
   it('lets zoom arm before splitting and applies once a split exists', () => {
     const { container, rerender } = render(
-      <SessionTerminalWorkspace
-        workspaceId="workspace-session-1"
-        workspaceSessions={[{ id: "session-1", label: "Session 1", agent: "claude", cwd: "/tmp/repo" }]}
-        workspace={createSingleAgentWorkspace()}
-        activePaneId={SESSION_PANE_ID}
-        fontSize={14}
-        enabled
-        isActiveSession
-        eventRouter={mockEventRouter}
-        onSplitPane={vi.fn()}
-        onClosePane={vi.fn()}
-        onFocusPane={vi.fn()}
-        onNavigateOutOfSession={vi.fn()}
-      />
+      <ZoomHost workspace={createSingleAgentWorkspace()} activePaneId={SESSION_PANE_ID} />
     );
 
     act(() => {
@@ -965,9 +975,7 @@ describe('SessionTerminalWorkspace', () => {
     expect(container.querySelector('[data-split-id="root"]')).toBeNull();
 
     rerender(
-      <SessionTerminalWorkspace
-        workspaceId="workspace-session-1"
-        workspaceSessions={[{ id: "session-1", label: "Session 1", agent: "claude", cwd: "/tmp/repo" }]}
+      <ZoomHost
         workspace={{
           agents: [{ id: SESSION_PANE_ID, runtimeId: 'session-1', sessionId: 'session-1', title: 'Session 1' }, { id: 'pane-session-1', runtimeId: 'runtime-session-1', title: "Session", sessionId: 'session-1' }],
           layoutTree: {
@@ -982,14 +990,6 @@ describe('SessionTerminalWorkspace', () => {
           },
         }}
         activePaneId={SESSION_PANE_ID}
-        fontSize={14}
-        enabled
-        isActiveSession
-        eventRouter={mockEventRouter}
-        onSplitPane={vi.fn()}
-        onClosePane={vi.fn()}
-        onFocusPane={vi.fn()}
-        onNavigateOutOfSession={vi.fn()}
       />
     );
 
@@ -1024,20 +1024,7 @@ describe('SessionTerminalWorkspace', () => {
     };
 
     const { container, rerender } = render(
-      <SessionTerminalWorkspace
-        workspaceId="workspace-session-1"
-        workspaceSessions={[{ id: "session-1", label: "Session 1", agent: "claude", cwd: "/tmp/repo" }]}
-        workspace={workspace}
-        activePaneId="bottom-right"
-        fontSize={14}
-        enabled
-        isActiveSession
-        eventRouter={mockEventRouter}
-        onSplitPane={vi.fn()}
-        onClosePane={vi.fn()}
-        onFocusPane={vi.fn()}
-        onNavigateOutOfSession={vi.fn()}
-      />
+      <ZoomHost workspace={workspace} activePaneId="bottom-right" />
     );
 
     expect(container.querySelector('[data-split-id="root"]')).toHaveAttribute('data-split-ratio', '0.500');
@@ -1052,20 +1039,7 @@ describe('SessionTerminalWorkspace', () => {
     expect(container.querySelector('[data-split-id="right"]')).toHaveAttribute('data-split-ratio', '0.240');
 
     rerender(
-      <SessionTerminalWorkspace
-        workspaceId="workspace-session-1"
-        workspaceSessions={[{ id: "session-1", label: "Session 1", agent: "claude", cwd: "/tmp/repo" }]}
-        workspace={workspace}
-        activePaneId={SESSION_PANE_ID}
-        fontSize={14}
-        enabled
-        isActiveSession
-        eventRouter={mockEventRouter}
-        onSplitPane={vi.fn()}
-        onClosePane={vi.fn()}
-        onFocusPane={vi.fn()}
-        onNavigateOutOfSession={vi.fn()}
-      />
+      <ZoomHost workspace={workspace} activePaneId={SESSION_PANE_ID} />
     );
 
     expect(container.querySelector('[data-session-terminal-workspace="workspace-session-1"]')).toHaveAttribute('data-zoomed-pane-id', SESSION_PANE_ID);

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render } from '@testing-library/react';
 import { SessionTerminalWorkspace } from './index';
@@ -103,31 +103,38 @@ function renderSplit(overrides: {
   const onUndockTile = overrides.onUndockTile ?? vi.fn();
   const onFocusPane = overrides.onFocusPane ?? vi.fn();
   const eventRouter = createPaneRuntimeEventRouterController();
-  const element = (workspace: TerminalWorkspaceState) => (
-    <SessionTerminalWorkspace
-      workspaceId="workspace-split"
-      workspaceSessions={[{ id: 'sess-1', label: 'shell', agent: 'shell', cwd: '/tmp/project' }]}
-      workspace={workspace}
-      workspaceSelectionStyle={overrides.workspaceSelectionStyle}
-      activePaneId="pane-term"
-      fontSize={13}
-      enabled
-      isActiveSession
-      eventRouter={eventRouter}
-      onSplitPane={vi.fn()}
-      onClosePane={onClosePane}
-      onFocusPane={onFocusPane}
-      onNavigateOutOfSession={vi.fn()}
-      onUndockTile={onUndockTile}
-      tileContents={{
-        [tileContentKey('workspace-split', 'tile-notes')]: {
-          path: '/tmp/project/NOTES.md',
-          content: '# Project notes',
-        },
-      }}
-      onRequestTileContent={vi.fn()}
-    />
-  );
+  // Zoom mode lives in App, so a standalone render needs a host to hold it.
+  function ZoomHost({ workspace }: { workspace: TerminalWorkspaceState }) {
+    const [zoomActive, setZoomActive] = useState(false);
+    return (
+      <SessionTerminalWorkspace
+        workspaceId="workspace-split"
+        workspaceSessions={[{ id: 'sess-1', label: 'shell', agent: 'shell', cwd: '/tmp/project' }]}
+        workspace={workspace}
+        workspaceSelectionStyle={overrides.workspaceSelectionStyle}
+        activePaneId="pane-term"
+        fontSize={13}
+        enabled
+        isActiveSession
+        eventRouter={eventRouter}
+        onSplitPane={vi.fn()}
+        onClosePane={onClosePane}
+        onFocusPane={onFocusPane}
+        onNavigateOutOfSession={vi.fn()}
+        onUndockTile={onUndockTile}
+        zoomActive={zoomActive}
+        onSetZoomActive={setZoomActive}
+        tileContents={{
+          [tileContentKey('workspace-split', 'tile-notes')]: {
+            path: '/tmp/project/NOTES.md',
+            content: '# Project notes',
+          },
+        }}
+        onRequestTileContent={vi.fn()}
+      />
+    );
+  }
+  const element = (workspace: TerminalWorkspaceState) => <ZoomHost workspace={workspace} />;
   const utils = render(element(paneAndTileWorkspace()), { wrapper: NotebookSurfaceTestWrapper });
   const setWorkspace = (workspace: TerminalWorkspaceState) => utils.rerender(element(workspace));
   return { ...utils, setWorkspace, onClosePane, onUndockTile, onFocusPane };

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.zoomMode.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.zoomMode.test.tsx
@@ -1,0 +1,145 @@
+import { useState, useSyncExternalStore } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render } from '@testing-library/react';
+import { SessionTerminalWorkspace } from './index';
+import { createPaneRuntimeEventRouterController } from './paneRuntimeEventRouter';
+import type { TerminalWorkspaceState } from '../../types/workspace';
+
+// Zoom mode is a layout flag — no terminal needed, and the real one drags in
+// the Ghostty WASM model.
+vi.mock('../GhosttyTerminal', async () => {
+  const React = await import('react');
+  return {
+    GhosttyTerminal: React.forwardRef(function MockTerminal() {
+      return null;
+    }),
+  };
+});
+
+function singlePaneWorkspace(): TerminalWorkspaceState {
+  return {
+    agents: [{ id: 'pane-a', runtimeId: 'rt-a', sessionId: 'session-a', title: 'shell' }],
+    layoutTree: { type: 'pane', paneId: 'pane-a' },
+  };
+}
+
+// Stands in for the daemon session store: a source that pushes new values at
+// React from outside the render cycle, the way a WebSocket snapshot burst does.
+function createBurstStore() {
+  const listeners = new Set<() => void>();
+  let version = 0;
+  return {
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    getSnapshot() {
+      return version;
+    },
+    push() {
+      version += 1;
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+  };
+}
+
+// App's shape around zoom mode: it owns the flag, re-renders on every daemon
+// session snapshot, and hands the workspace a fresh inline setter each time.
+function renderUnderBurstingParent() {
+  const onSetZoomActive = vi.fn();
+  const store = createBurstStore();
+
+  function Harness() {
+    useSyncExternalStore(store.subscribe, store.getSnapshot);
+    const [zoomBySession, setZoomBySession] = useState<Record<string, boolean>>({});
+    return (
+      <SessionTerminalWorkspace
+        workspaceId="workspace-a"
+        workspace={singlePaneWorkspace()}
+        activePaneId="pane-a"
+        fontSize={13}
+        enabled
+        isActiveSession
+        eventRouter={createPaneRuntimeEventRouterController()}
+        onSplitPane={vi.fn()}
+        onClosePane={vi.fn()}
+        onFocusPane={vi.fn()}
+        onNavigateOutOfSession={vi.fn()}
+        zoomActive={Boolean(zoomBySession['workspace-a'])}
+        onSetZoomActive={(active) => {
+          onSetZoomActive(active);
+          setZoomBySession((prev) => (
+            prev['workspace-a'] === active ? prev : { ...prev, 'workspace-a': active }
+          ));
+        }}
+      />
+    );
+  }
+
+  const view = render(<Harness />);
+  return { ...view, onSetZoomActive, store };
+}
+
+function zoomedPaneId(container: HTMLElement) {
+  return container
+    .querySelector('[data-session-terminal-workspace="workspace-a"]')
+    ?.getAttribute('data-zoomed-pane-id') ?? null;
+}
+
+describe('SessionTerminalWorkspace zoom mode', () => {
+  // Regression: the workspace used to keep its own zoom flag and push it back
+  // to App from an effect that depended on App's inline callback. Since App
+  // writes what it receives into its own state, every parent render produced
+  // another write and another parent render. A burst of daemon session
+  // snapshots keeps that cycle from settling and React aborts the tree with
+  // error #185 (maximum update depth). Zoom mode now lives in App, so the
+  // workspace only ever writes it from the shortcut.
+  it('never writes zoom mode back to the parent on its own', () => {
+    const { onSetZoomActive, store } = renderUnderBurstingParent();
+
+    expect(onSetZoomActive).not.toHaveBeenCalled();
+
+    for (let i = 0; i < 300; i += 1) {
+      act(() => {
+        store.push();
+      });
+    }
+
+    expect(onSetZoomActive).not.toHaveBeenCalled();
+  });
+
+  it('toggles zoom mode through the parent', () => {
+    const { container, onSetZoomActive } = renderUnderBurstingParent();
+
+    expect(zoomedPaneId(container)).toBe('');
+
+    fireEvent.keyDown(window, { key: 'z', metaKey: true, shiftKey: true });
+
+    expect(onSetZoomActive.mock.calls).toEqual([[true]]);
+    expect(zoomedPaneId(container)).toBe('pane-a');
+
+    fireEvent.keyDown(window, { key: 'z', metaKey: true, shiftKey: true });
+
+    expect(onSetZoomActive.mock.calls).toEqual([[true], [false]]);
+    expect(zoomedPaneId(container)).toBe('');
+  });
+
+  it('keeps zoom mode across a burst of session updates', () => {
+    const { container, store } = renderUnderBurstingParent();
+
+    fireEvent.keyDown(window, { key: 'z', metaKey: true, shiftKey: true });
+    expect(zoomedPaneId(container)).toBe('pane-a');
+
+    for (let i = 0; i < 300; i += 1) {
+      act(() => {
+        store.push();
+      });
+    }
+
+    expect(zoomedPaneId(container)).toBe('pane-a');
+  });
+});

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -61,6 +61,10 @@ function suppressTerminalMouseDuringResize(durationMs = RESIZE_MOUSE_SUPPRESSION
   );
 }
 
+// The tile's content request is an effect dependency, so the no-op stand-in
+// has to keep one identity.
+const noRequestContent = () => {};
+
 function zoomLayoutTowardLeaf(node: TerminalLayoutNode, leafId: string): TerminalLayoutNode {
   if (node.type !== 'split') {
     return node;
@@ -1134,7 +1138,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
                 onUpdateTile?.(tileLeaf.tileId, tileLeaf.tileParams ?? '', sessionId)
               )}
               onHeaderPointerDown={(event) => beginLeafDrag(tileLeaf.tileId, event)}
-              onRequestContent={onRequestTileContent ?? (() => {})}
+              onRequestContent={onRequestTileContent ?? noRequestContent}
               bodyRef={tileBodyRefFor(tileLeaf.tileId)}
             />
           </div>

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -186,7 +186,11 @@ interface SessionTerminalWorkspaceProps {
   // daemon use the selected session).
   onOpenMarkdown?: (path: string, sessionId: string) => void;
   onTerminalModelRecovered?: () => void;
-  onZoomModeChange?: (zoomed: boolean) => void;
+  // Zoom is a mode, not a target: it always widens whichever leaf is focused,
+  // so it is a flag rather than a leaf id that has to chase focus. App owns it
+  // because the dock's zoom chip reads it too.
+  zoomActive?: boolean;
+  onSetZoomActive?: (active: boolean) => void;
   onNavigateOutOfSession: (direction: TerminalNavigationDirection) => void;
   onResizeSplit?: (splitId: string, ratio: number) => Promise<unknown> | void;
   // Move an existing leaf (terminal pane or docked tile) beside an anchor leaf,
@@ -241,7 +245,8 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     onOpenPresentation,
     onOpenMarkdown,
     onTerminalModelRecovered,
-    onZoomModeChange,
+    zoomActive = false,
+    onSetZoomActive,
     onNavigateOutOfSession,
     onResizeSplit,
     onMoveLeaf,
@@ -258,9 +263,6 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     onRequestTileContent,
   }, ref) {
     const [maximizedLeafId, setMaximizedLeafId] = useState<string | null>(null);
-    // Zoom is a mode, not a target: it always widens whichever leaf is focused,
-    // so it is a flag rather than a leaf id that has to chase focus.
-    const [zoomActive, setZoomActive] = useState(false);
     // The docked tile that currently owns workspace focus, or null when a
     // terminal pane does. `activePaneId` is derived from the focused session, so
     // it can only ever name an agent pane; this is the other half of the focus
@@ -598,10 +600,6 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       }
     }, [paneIds, ticketOverlayPaneId]);
 
-    useEffect(() => {
-      onZoomModeChange?.(Boolean(effectiveZoomedPaneId));
-    }, [effectiveZoomedPaneId, onZoomModeChange]);
-
     // Focusing the terminal is a leaf handoff, not just a DOM focus call: it
     // has to release any focused tile. `activePaneId` does not change here (the
     // pane was already the session's active one), so without the release the
@@ -767,14 +765,14 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     }, [activeLeafId, activeLeafIsTile, handleClosePane, onUndockTile]);
 
     const toggleMaximizeActivePane = useCallback(() => {
-      setZoomActive(false);
+      onSetZoomActive?.(false);
       setMaximizedLeafId((current) => (current ? null : activeLeafId));
-    }, [activeLeafId]);
+    }, [activeLeafId, onSetZoomActive]);
 
     const toggleZoomActivePane = useCallback(() => {
       setMaximizedLeafId(null);
-      setZoomActive((current) => !current);
-    }, []);
+      onSetZoomActive?.(!zoomActive);
+    }, [onSetZoomActive, zoomActive]);
 
     // Focus a leaf by id: a tile takes DOM focus in place (the session's pane
     // focus is left alone), a pane goes through the session-level focus path.

--- a/changelog.d/zoom-mode-readback-crash-under-burst.yaml
+++ b/changelog.d/zoom-mode-readback-crash-under-burst.yaml
@@ -1,0 +1,14 @@
+kind: fixed
+area: app
+change: >
+  A busy board no longer takes the window down. A workspace kept its own copy
+  of whether it was zoomed and reported that copy back to the app on every
+  render rather than only when the zoom actually changed, and the app
+  re-rendered on every report — a loop that stayed invisible while updates were
+  sparse and ran away once a few hundred session updates arrived at once, as a
+  busy multi-session board or a reconnect replay delivers. React gave up on the
+  whole tree and the window went blank. Zoom mode is now kept in one place, so
+  there is nothing to report back and nothing to loop on.
+symptom: >
+  The window went blank while many sessions were updating at once, or right
+  after the app reconnected to the daemon.


### PR DESCRIPTION
Bursting a few hundred session updates at the app could take the React tree
down with minified error #185 (maximum update depth exceeded), reported out of
`onZoomModeChange` in `App.tsx` via `SessionTerminalWorkspace`. Found during
the WS-eviction work (#810) and reproduced twice there, unrelated to that
change.

## Root cause

`SessionTerminalWorkspace` kept its own `zoomActive` flag and pushed it up to
`App` from an effect that listed the parent's callback in its dependencies:

```ts
useEffect(() => {
  onZoomModeChange?.(Boolean(effectiveZoomedPaneId));
}, [effectiveZoomedPaneId, onZoomModeChange]);
```

`App` creates that callback inline inside the workspace map, so its identity
changes on every `App` render, and the callback writes what it receives back
into `App`'s own `zoomModeBySessionId` state. Every parent render therefore
produced a notification, and every notification produced another parent
render. React's eager bail-out on a state write that changes nothing normally
cuts the cycle after one turn, which is why this stayed invisible: the
bail-out is only available when the fiber has no pending update. Under a
sustained stream of daemon session snapshots there always is one, so the cycle
keeps scheduling commits until React's nested-update limit trips and it throws
away the tree.

## The fix

`App` already kept a copy of the flag — `zoomModeBySessionId`, which the dock's
zoom chip reads — so the whole readback existed to keep a duplicate in sync.
The fix is to keep only `App`'s copy: the workspace takes `zoomActive` as a
prop and writes it through `onSetZoomActive` from the shortcut. That removes
the effect, the callback, and the duplicated state, so the child no longer
writes to the parent outside an event handler and the cycle is structurally
impossible rather than merely broken.

One behavior shifts slightly. `App` used to receive the *effective* value,
which went false for a frame whenever the focused leaf left the layout (a pane
closing), so the dock chip flickered and settled back. `App` now holds the
requested mode and the workspace still derives what it renders, so a pane
closing under an active zoom no longer blinks the chip.

An earlier revision of this PR fixed the dependency array with a ref instead.
React Doctor flagged that correctly — the ref write happened during render, and
the effect-to-parent pattern itself was the smell — so it was replaced with
this.

## Scope

A sweep of every `useEffect`/`useLayoutEffect` in `app/src` that both invokes a
prop callback and lists it as a dependency turned up three siblings —
`MarkdownReader`'s `onAnnotationsCountChange`, `PresentTour`'s
`onAnnotationAnchorsChange`, `WorkspaceDockTile`'s `onRequestContent`. All
three receive a stable identity from their parent (a `useState` setter or a
`useCallback`), so none of them can churn. This callback was the only inline
one, and no daemon-side behavior changed.

## Tests

`SessionTerminalWorkspace.zoomMode.test.tsx` mounts the workspace under a
parent shaped like `App` — re-rendering off an external store, holding the zoom
flag, handing down a fresh inline setter each render — and covers three things:
the workspace never writes zoom mode back on its own (including across 300
external store updates), the shortcut toggles it through the parent and the
rendered layout follows, and an active zoom survives a burst.

Two existing zoom tests rendered the workspace standalone and relied on it
owning the flag; they now render through a small host that holds it, which is
what `App` does.

Full frontend suite, macOS 26.5.2 arm64: 233 files, 2607 passed / 15 skipped
(2622). CI's Frontend job on ubuntu-latest reports 2602 passed / 20 skipped
over the same 2622 — five specs skip on Linux and run here.

## Live verification

Isolated profiles installed from this branch; bundled preflight PASS. A probe
created shell sessions in the running app, zoomed a split pane, and then drove
the daemon WebSocket directly with 1200 `rename_session` commands — each
publishes `session.renamed`, whose projection re-pushes the session snapshot to
every client.

On the reshaped build (profile `r185zoom`, 6 sessions, 1200 messages):

```
CONTROL maximize after toggle: pane-6e71cdba…    CONTROL maximize after untoggle: null
zoom before toggle: null
zoom after toggle: pane-6e71cdba…
zoom after 1200-message burst: pane-6e71cdba…
zoom after untoggle: null
ping={"frontendReady":true,"pong":true}
```

Zoom arms, holds through the burst, and releases; the app stays responsive.
The maximize line is a control — it shares the same shortcut gate and this
change does not touch it.

The loop itself was measured earlier against the unmodified code on profile
`r185burst`, by counting calls into `App`'s `onZoomModeChange` through a
temporary bridge field: **1674** notifications while creating six sessions and
**189** during the burst, against **33** and **0** with the fix. The 33 are the
genuine ones — mount and unmount across six workspaces. With the state lifted
the count is now structurally zero, since nothing calls back.

Worth stating plainly: neither build actually crashed under this burst — the
app stayed responsive both times. What the runs show is the runaway feedback
loop the crash reports, measured live, and its removal. The original crash was
hit while the app was simultaneously being pushed into WebSocket eviction,
which this probe does not recreate.

Both profiles were removed with `attn profile clean` after the runs.
