### PR TITLE
fix(tickets): attach a chief's delegations to the role, not to its session

### DIFF
--- a/changelog.d/chief-delegation-participation-follows-the-role.yaml
+++ b/changelog.d/chief-delegation-participation-follows-the-role.yaml
@@ -1,0 +1,14 @@
+kind: fixed
+area: daemon
+change: >
+  A delegation the chief of staff starts now attaches to the chief role rather
+  than to the session holding it, so handing the role to another agent hands over
+  the ticket notifications with it. The retired chief goes quiet and the new one
+  is nudged.
+symptom: >
+  The chief was attached to the tickets it delegated twice — once as the durable
+  role and once as itself. Only the role moved on a handover, so an agent that had
+  been chief kept being nudged about every ticket it ever delegated, for as long
+  as it ran, while the new chief received the same activity. Existing tickets are
+  corrected on first launch; a ticket someone filed and the chief later picked up
+  for a delegation also stops dropping the filer from its notifications.

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -25,7 +25,9 @@ session — the brief is its description, the session is its assignee — and yo
 participant on the ticket you created. That ticket is the channel in both
 directions: the agent reports its work state onto it, and you reach the agent with
 `attn ticket comment <ticket-id> -m "<note>"`. The chief of staff is also a
-participant on every delegation ticket, whoever started it.
+participant on every delegation ticket, whoever started it — and when the chief is
+the one delegating, that participation belongs to the ROLE. It moves to whoever
+holds the role next, instead of following the session that delegated.
 
 Follow-up: all runtimes receive the same ticket nudge when activity remains unread;
 Claude may also arm a Monitor on `attn ticket inbox --watch` to consume updates

--- a/internal/daemon/delegate_ticket.go
+++ b/internal/daemon/delegate_ticket.go
@@ -34,22 +34,14 @@ func ticketSlug(label string) string {
 // session, starting in Working. The chief of staff is always a participant via
 // its durable ROLE identity — owner when it initiated (which is also what marks
 // the session `delegated_from_chief`), subscriber otherwise — so its view
-// survives the session filling the role changing. A creator that IS the chief
-// holds both identities; ticketnotify.ConsumeAll merges them by event seq.
+// survives the session filling the role changing.
 func (d *Daemon) createDelegatedTicket(creatorSessionID string, ownedByChiefRole bool, session *protocol.Session, brief, label, agent string) (string, error) {
 	if d.delegationTicketCreateHook != nil {
 		if err := d.delegationTicketCreateHook(); err != nil {
 			return "", err
 		}
 	}
-	ownerRole := ""
-	chiefRoleIdentity := store.TicketRoleIdentity(store.TicketRoleChiefOfStaff)
-	subscribers := []string{creatorSessionID}
-	if ownedByChiefRole {
-		ownerRole = store.TicketRoleChiefOfStaff
-	} else {
-		subscribers = append(subscribers, chiefRoleIdentity)
-	}
+	ownerRole, subscribers := delegationTicketAttachment(creatorSessionID, ownedByChiefRole)
 	created, err := d.createTicketWithUniqueSlug(store.Ticket{
 		Title:       label,
 		Description: brief,
@@ -69,14 +61,7 @@ func (d *Daemon) createDelegatedTicket(creatorSessionID string, ownedByChiefRole
 // description already went out in the spawn prompt); the previous assignee stays
 // subscribed.
 func (d *Daemon) adoptDelegatedTicket(creatorSessionID string, ownedByChiefRole bool, session *protocol.Session, ticketID, agent string, confirm bool) (string, error) {
-	ownerRole := ""
-	chiefRoleIdentity := store.TicketRoleIdentity(store.TicketRoleChiefOfStaff)
-	subscribers := []string{creatorSessionID}
-	if ownedByChiefRole {
-		ownerRole = store.TicketRoleChiefOfStaff
-	} else {
-		subscribers = append(subscribers, chiefRoleIdentity)
-	}
+	ownerRole, subscribers := delegationTicketAttachment(creatorSessionID, ownedByChiefRole)
 	adopted, err := d.store.AdoptTicketForDelegation(
 		ticketID, session.ID, session.Directory, agent, creatorSessionID,
 		ownerRole, subscribers, confirm, time.Now(),
@@ -85,6 +70,20 @@ func (d *Daemon) adoptDelegatedTicket(creatorSessionID string, ownedByChiefRole 
 		return "", err
 	}
 	return adopted.ID, nil
+}
+
+// delegationTicketAttachment decides who the delegating side attaches as. A chief
+// delegation attaches the ROLE and nothing else: the role owner row is the
+// attachment, and the events the acting session writes carry that role, so the
+// attachment moves with the role instead of stranding a personal subscription on
+// the session that happened to hold it. Any other delegator attaches personally
+// and pulls the chief role in as a subscriber, because the chief follows every
+// delegation whether or not it started it.
+func delegationTicketAttachment(creatorSessionID string, ownedByChiefRole bool) (ownerRole string, subscribers []string) {
+	if ownedByChiefRole {
+		return store.TicketRoleChiefOfStaff, nil
+	}
+	return "", []string{creatorSessionID, store.TicketRoleIdentity(store.TicketRoleChiefOfStaff)}
 }
 
 // ticketSlugSequentialAttempts bounds the readable base-2, base-3, ... walk

--- a/internal/daemon/delegate_ticket_test.go
+++ b/internal/daemon/delegate_ticket_test.go
@@ -81,16 +81,20 @@ func TestCreateDelegatedTicketFallsBackPastSequentialRange(t *testing.T) {
 }
 
 // Participation is the routing contract: the delegated agent (assignee), the
-// delegator, and the chief of staff each reach the ticket, for an ordinary
-// delegation as much as a chief-initiated one.
+// delegator, and the chief of staff each reach the ticket. Who the delegator IS
+// decides how it attaches — an ordinary session personally, the chief through
+// its durable role and never also as itself, so the attachment transfers with
+// the role instead of following the session that held it at delegation time.
 func TestCreateDelegatedTicketParticipants(t *testing.T) {
 	chiefRole := store.TicketRoleIdentity(store.TicketRoleChiefOfStaff)
 	for _, tc := range []struct {
 		name             string
 		ownedByChiefRole bool
+		want             []string
+		absent           string
 	}{
-		{"ordinary delegation", false},
-		{"chief delegation", true},
+		{"ordinary delegation", false, []string{"sess-delegated", "sess-creator", chiefRole}, ""},
+		{"chief delegation", true, []string{"sess-delegated", chiefRole}, "sess-creator"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
@@ -107,10 +111,13 @@ func TestCreateDelegatedTicketParticipants(t *testing.T) {
 			for _, p := range participants {
 				got[p] = true
 			}
-			for _, want := range []string{"sess-delegated", "sess-creator", chiefRole} {
+			for _, want := range tc.want {
 				if !got[want] {
 					t.Fatalf("participants = %v, missing %q", participants, want)
 				}
+			}
+			if tc.absent != "" && got[tc.absent] {
+				t.Fatalf("participants = %v, want %q attached through the role only", participants, tc.absent)
 			}
 
 			// Role ownership stays reserved for chief-initiated delegations: it is what

--- a/internal/daemon/ticket_notify_test.go
+++ b/internal/daemon/ticket_notify_test.go
@@ -323,70 +323,70 @@ func TestTicketNudgesActiveChiefAcrossRuntimes(t *testing.T) {
 // delegate. A consumes one report, the role transfers to B, and the next report
 // reaches only B. The role cursor means B receives exactly the post-transfer
 // unread event: nothing A consumed is replayed and nothing new is skipped.
-// Left unconverted deliberately. Mechanically this test fits in a bubble, but its
-// windows are parked (nudgeWindowOverride) and its final assertion only holds
-// while they are: run the nudge window out for real and the retired chief is
-// doorbelled too, because delegateForNotify leaves it a personal participant on
-// the ticket and nudgeCount cannot tell a personal nudge from a role one. Making
-// it honest means either a narrower probe or a product answer about what a
-// retired chief still hears, and both are outside a test-only sweep.
+//
+// The windows run out for real here rather than being parked and hand-fired,
+// which is what makes A's silence mean something: every countdown the daemon
+// could have armed for A fires well inside the sleep, so zero nudges is A having
+// no attachment left, not a timer that had not come due yet.
 func TestChiefTicketContinuityAcrossRoleTransfer(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.nudgeWindowOverride = time.Hour
-	t.Cleanup(d.stopNudgeCountdowns)
-	chiefA, agentID, inputs := delegateForNotify(t, d, "codex")
-	ticketID := boundTicketID(t, d, agentID)
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		chiefA, agentID, inputs := delegateForNotify(t, d, "codex")
+		ticketID := boundTicketID(t, d, agentID)
 
-	now := string(protocol.TimestampNow())
-	chiefB := "chief-b"
-	d.store.Add(&protocol.Session{
-		ID: chiefB, Label: "replacement chief", Agent: protocol.SessionAgentCodex,
-		Directory: "/tmp/chief-b", WorkspaceID: "workspace-chief-b",
-		State: protocol.SessionStateIdle, StateSince: now, StateUpdatedAt: now, LastSeen: now,
+		now := string(protocol.TimestampNow())
+		chiefB := "chief-b"
+		d.store.Add(&protocol.Session{
+			ID: chiefB, Label: "replacement chief", Agent: protocol.SessionAgentCodex,
+			Directory: "/tmp/chief-b", WorkspaceID: "workspace-chief-b",
+			State: protocol.SessionStateIdle, StateSince: now, StateUpdatedAt: now, LastSeen: now,
+		})
+		d.store.UpdateState(chiefA, protocol.StateIdle)
+		d.store.UpdateState(agentID, protocol.StateIdle)
+
+		// A consumes the first agent report, advancing the durable role cursor.
+		callSetTicketStatus(t, d, agentID, string(protocol.DispatchWorkStateNeedsInput), "need a decision")
+		first := callTicketInbox(t, d, chiefA)
+		if len(first) != 1 || len(first[0].Events) != 1 ||
+			first[0].Events[0].ToStatus == nil || *first[0].Events[0].ToStatus != protocol.TicketStatusBlocked {
+			t.Fatalf("chief A first inbox = %+v, want only the blocked report", first)
+		}
+		nudgesA := nudgeCount(inputs(chiefA))
+
+		// Transfer the singleton profile role. No cursor copy occurs; only delivery is
+		// retargeted and A's stale role nudge state is cleared.
+		if err := d.store.SetProfileRole(profileRoleChiefOfStaff, chiefB); err != nil {
+			t.Fatalf("transfer chief role: %v", err)
+		}
+		d.retargetChiefTicketDelivery(chiefA, chiefB)
+
+		callSetTicketStatus(t, d, agentID, string(protocol.DispatchWorkStateReadyForReview), "ready now")
+		if deadline := currentNudgeDeadline(d, chiefA); !deadline.IsZero() {
+			t.Fatalf("retired chief still has a countdown armed for %s", deadline)
+		}
+		// Past the longest window any observer of this ticket could have been given.
+		time.Sleep(2 * d.ticketBufferWindow())
+		synctest.Wait()
+		if !wasNudged(inputs(chiefB)) {
+			t.Fatal("replacement chief was not nudged about unread chief-owned ticket activity")
+		}
+		if got := nudgeCount(inputs(chiefA)); got != nudgesA {
+			t.Fatalf("retired chief was nudged about a ticket it delegated as chief: %d -> %d", nudgesA, got)
+		}
+
+		second := callTicketInbox(t, d, chiefB)
+		if len(second) != 1 || second[0].TicketID != ticketID || len(second[0].Events) != 1 {
+			t.Fatalf("chief B inbox = %+v, want exactly one post-cursor event for %s", second, ticketID)
+		}
+		event := second[0].Events[0]
+		if event.ToStatus == nil || *event.ToStatus != protocol.TicketStatusInReview || event.Author != agentID {
+			t.Fatalf("chief B event = %+v, want agent's in-review report", event)
+		}
+		if again := callTicketInbox(t, d, chiefB); len(again) != 0 {
+			t.Fatalf("chief B second inbox = %+v, want no duplicate activity", again)
+		}
 	})
-	d.store.UpdateState(chiefA, protocol.StateIdle)
-	d.store.UpdateState(agentID, protocol.StateIdle)
-
-	// A consumes the first agent report, advancing the durable role cursor.
-	callSetTicketStatus(t, d, agentID, string(protocol.DispatchWorkStateNeedsInput), "need a decision")
-	first := callTicketInbox(t, d, chiefA)
-	if len(first) != 1 || len(first[0].Events) != 1 ||
-		first[0].Events[0].ToStatus == nil || *first[0].Events[0].ToStatus != protocol.TicketStatusBlocked {
-		t.Fatalf("chief A first inbox = %+v, want only the blocked report", first)
-	}
-	nudgesA := nudgeCount(inputs(chiefA))
-
-	// Transfer the singleton profile role. No cursor copy occurs; only delivery is
-	// retargeted and A's stale role nudge state is cleared.
-	if err := d.store.SetProfileRole(profileRoleChiefOfStaff, chiefB); err != nil {
-		t.Fatalf("transfer chief role: %v", err)
-	}
-	d.retargetChiefTicketDelivery(chiefA, chiefB)
-
-	callSetTicketStatus(t, d, agentID, string(protocol.DispatchWorkStateReadyForReview), "ready now")
-	deadline := time.Now().Add(time.Second)
-	for currentNudgeTimer(d, chiefB) == nil && time.Now().Before(deadline) {
-		time.Sleep(time.Millisecond)
-	}
-	fireNudgeNow(t, d, chiefB)
-	if !wasNudged(inputs(chiefB)) {
-		t.Fatal("replacement chief was not nudged about unread chief-owned ticket activity")
-	}
-	if got := nudgeCount(inputs(chiefA)); got != nudgesA {
-		t.Fatalf("retired chief received a role nudge after transfer: %d -> %d", nudgesA, got)
-	}
-
-	second := callTicketInbox(t, d, chiefB)
-	if len(second) != 1 || second[0].TicketID != ticketID || len(second[0].Events) != 1 {
-		t.Fatalf("chief B inbox = %+v, want exactly one post-cursor event for %s", second, ticketID)
-	}
-	event := second[0].Events[0]
-	if event.ToStatus == nil || *event.ToStatus != protocol.TicketStatusInReview || event.Author != agentID {
-		t.Fatalf("chief B event = %+v, want agent's in-review report", event)
-	}
-	if again := callTicketInbox(t, d, chiefB); len(again) != 0 {
-		t.Fatalf("chief B second inbox = %+v, want no duplicate activity", again)
-	}
 }
 
 // A chief can still participate personally through the ordinary explicit

--- a/internal/daemon/ticket_read_test.go
+++ b/internal/daemon/ticket_read_test.go
@@ -175,11 +175,11 @@ func TestTicketInboxRoutesOrdinaryDelegationToCreatorAndChief(t *testing.T) {
 	}
 }
 
-// When the creator IS the chief, it holds two identities on the ticket (its session
-// subscription and the durable chief role). ticketnotify.ConsumeAll merges the two
-// queues by event seq, so the agent's report is delivered exactly once — no
-// dedup guard of our own is needed.
-func TestTicketInboxDoesNotDuplicateWhenChiefIsTheCreator(t *testing.T) {
+// When the creator IS the chief, the ticket attaches to the durable role and to
+// nothing else: the acting session gets no subscription of its own, so nothing
+// keeps nudging it once the role moves on. It still observes through both of its
+// identities, and the agent's report reaches its inbox once, through the role.
+func TestChiefCreatedTicketAttachesTheRoleAndNotTheSession(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}
 	_, chiefSessionID, _ := setupDelegationSource(t, d, backend)
@@ -206,23 +206,34 @@ func TestTicketInboxDoesNotDuplicateWhenChiefIsTheCreator(t *testing.T) {
 		t.Fatalf("chief observers = %+v, want session and role identities", observers)
 	}
 	subscribed, err := d.store.IsTicketSubscribed(chiefSessionID, ticketID)
-	if err != nil || !subscribed {
-		t.Fatalf("chief session subscribed = %v (err %v), want true as the creator", subscribed, err)
+	if err != nil || subscribed {
+		t.Fatalf("chief session subscribed = %v (err %v), want the role to carry the creator's attachment", subscribed, err)
+	}
+	participants, err := d.store.TicketParticipants(ticketID)
+	if err != nil {
+		t.Fatalf("TicketParticipants: %v", err)
+	}
+	for _, identity := range participants {
+		if identity == chiefSessionID {
+			t.Fatalf("participants = %v, want the chief attached through its role only", participants)
+		}
 	}
 
 	callTicketInbox(t, d, chiefSessionID)
 	callSetTicketStatus(t, d, agentSession, string(protocol.DispatchWorkStateReadyForReview), "take a look")
 
-	// The merge is load-bearing here, not incidental: BOTH identities have the report
-	// queued, so an unmerged consume would hand the chief the same event twice.
+	// The report is queued on the role and on nothing else, so the chief's own
+	// session identity has an empty queue.
+	queued := map[string]int{}
 	for _, observer := range observers {
 		events, err := d.store.UnreadTicketEventsFor(observer.ID, observer.AuthorID)
 		if err != nil {
 			t.Fatalf("UnreadTicketEventsFor(%s): %v", observer.ID, err)
 		}
-		if len(events) != 1 {
-			t.Fatalf("identity %s queue = %+v, want the report queued once", observer.ID, events)
-		}
+		queued[observer.ID] = len(events)
+	}
+	if queued[chiefSessionID] != 0 || queued[store.TicketRoleIdentity(store.TicketRoleChiefOfStaff)] != 1 {
+		t.Fatalf("queued per identity = %v, want the report on the role alone", queued)
 	}
 
 	bundles := callTicketInbox(t, d, chiefSessionID)

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -964,6 +964,86 @@ CREATE TABLE IF NOT EXISTS document_collections (
 	// generator that a session has written nothing new and needs no run at all.
 	// Applied by applyMigration97. See docs/plans/2026-08-07-session-activity.md.
 	{97, "add the activity line and its transcript cursor to sessions", ``},
+	// 98 is burned on another branch (the app registry); do not reuse it.
+	//
+	// Participation earned by acting as a durable role belongs to the ROLE, not
+	// to the session that filled it at the time. The event now says so directly:
+	// author stays the session for audit provenance, author_role names the role
+	// it acted as, and the view attributes participation accordingly. That
+	// replaces migration 82's approximation — "a created event on a
+	// role-owned ticket is the role's" — which was right for a ticket the chief
+	// minted and wrong for a backlog ticket the chief later adopted, where it
+	// silently dropped the original author's participation.
+	//
+	// The backfill recognizes the delegating transaction by its timestamp: the
+	// role owner row is written in the same transaction as the events the acting
+	// session wrote (created when the chief minted the ticket, assigned plus
+	// status_changed when it adopted one), so all of them share a second. Only
+	// those three kinds are considered, so a comment or an attach that happened to
+	// land in the same second on the same ticket is not swept up with them.
+	//
+	// Rows are carried, never recreated; the only DELETE removes the acting
+	// session's personal subscription — the session-bound second copy of an
+	// attachment the role already holds. A chief that had also subscribed to its
+	// own delegation by hand is indistinguishable from that and loses the
+	// hand-made row too.
+	// Applied by applyMigration99, whose ALTER is column-guarded.
+	{99, "attribute role-acted ticket events to the role", ``},
+}
+
+// migration99SQL is everything migration 99 does after its guarded ALTER.
+const migration99SQL = `
+		UPDATE ticket_events SET author_role = (
+			SELECT ro.role FROM ticket_role_owners ro
+			WHERE ro.ticket_id = ticket_events.ticket_id
+				AND ro.created_at = ticket_events.created_at
+			LIMIT 1
+		)
+		WHERE kind IN ('created', 'assigned', 'status_changed') AND EXISTS (
+			SELECT 1 FROM ticket_role_owners ro
+			WHERE ro.ticket_id = ticket_events.ticket_id
+				AND ro.created_at = ticket_events.created_at
+		);
+
+		DELETE FROM ticket_subscriptions
+		WHERE EXISTS (
+			SELECT 1 FROM ticket_events e
+			WHERE e.ticket_id = ticket_subscriptions.ticket_id
+				AND e.author_role != ''
+				AND e.author = ticket_subscriptions.identity
+		);
+
+		DROP VIEW IF EXISTS ticket_participants;
+		CREATE VIEW ticket_participants (ticket_id, identity) AS
+			SELECT id, assignee FROM tickets WHERE assignee != ''
+			UNION
+			SELECT e.ticket_id, e.author FROM ticket_events e
+			WHERE e.author != '' AND e.kind != 'commented' AND e.author_role = ''
+			UNION
+			SELECT e.ticket_id, ('role:' || e.author_role) FROM ticket_events e
+			WHERE e.kind != 'commented' AND e.author_role != ''
+			UNION
+			SELECT ticket_id, identity FROM ticket_subscriptions WHERE identity != ''
+			UNION
+			SELECT ticket_id, ('role:' || role) FROM ticket_role_owners WHERE role != '';
+`
+
+// applyMigration99 adds ticket_events.author_role, then backfills and redefines
+// the participant view from migration99SQL. The ALTER is column-guarded so a
+// rewound schema_migrations table re-runs it without failing on work already
+// done; the rest is idempotent on its own.
+func applyMigration99(tx *sql.Tx) error {
+	has, err := columnExists(tx, "ticket_events", "author_role")
+	if err != nil {
+		return err
+	}
+	if !has {
+		if _, err := tx.Exec("ALTER TABLE ticket_events ADD COLUMN author_role TEXT NOT NULL DEFAULT ''"); err != nil {
+			return err
+		}
+	}
+	_, err = tx.Exec(migration99SQL)
+	return err
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -1274,6 +1354,11 @@ func migrateDB(db *sql.DB, dbPath string) error {
 			}
 		} else if m.version == 97 {
 			if err := applyMigration97(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 99 {
+			if err := applyMigration99(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -984,9 +984,10 @@ CREATE TABLE IF NOT EXISTS document_collections (
 	//
 	// Rows are carried, never recreated; the only DELETE removes the acting
 	// session's personal subscription — the session-bound second copy of an
-	// attachment the role already holds. A chief that had also subscribed to its
-	// own delegation by hand is indistinguishable from that and loses the
-	// hand-made row too.
+	// attachment the role already holds. It is recognized by the same shared
+	// second, so a subscription the chief made by hand at some other time
+	// survives, and a bystander who happened to write in the delegating second
+	// keeps theirs.
 	// Applied by applyMigration99, whose ALTER is column-guarded.
 	{99, "attribute role-acted ticket events to the role", ``},
 }
@@ -1011,6 +1012,7 @@ const migration99SQL = `
 			WHERE e.ticket_id = ticket_subscriptions.ticket_id
 				AND e.author_role != ''
 				AND e.author = ticket_subscriptions.identity
+				AND e.created_at = ticket_subscriptions.created_at
 		);
 
 		DROP VIEW IF EXISTS ticket_participants;

--- a/internal/store/ticket_events.go
+++ b/internal/store/ticket_events.go
@@ -35,10 +35,15 @@ const (
 // TicketEvent is one entry in the append-only event log; Seq is the global
 // monotonic id, and the payload columns are kind-specific.
 type TicketEvent struct {
-	Seq        int64
-	TicketID   string
-	Kind       TicketEventKind
-	Author     string
+	Seq      int64
+	TicketID string
+	Kind     TicketEventKind
+	Author   string
+	// AuthorRole is the durable role the author was acting as. Empty for an
+	// ordinary action. When set, Author stays the session for audit provenance
+	// while participation attaches to the role, so the attachment survives the
+	// role moving to another session.
+	AuthorRole string
 	FromStatus TicketStatus
 	ToStatus   TicketStatus
 	Comment    string
@@ -108,9 +113,9 @@ func appendTicketEventTx(tx *sql.Tx, e TicketEvent, now time.Time) (int64, bool,
 	}
 
 	res, err := tx.Exec(`
-		INSERT INTO ticket_events (ticket_id, kind, author, from_status, to_status, comment, detail, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-	`, e.TicketID, string(e.Kind), e.Author, string(e.FromStatus), string(e.ToStatus), e.Comment, e.Detail, formatTicketTime(now))
+		INSERT INTO ticket_events (ticket_id, kind, author, author_role, from_status, to_status, comment, detail, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, e.TicketID, string(e.Kind), e.Author, e.AuthorRole, string(e.FromStatus), string(e.ToStatus), e.Comment, e.Detail, formatTicketTime(now))
 	if err != nil {
 		return 0, false, err
 	}
@@ -132,7 +137,7 @@ func scanTicketEventRows(rows *sql.Rows) ([]TicketEvent, error) {
 			from, to  string
 			createdAt string
 		)
-		if err := rows.Scan(&e.Seq, &e.TicketID, &kind, &e.Author, &from, &to, &e.Comment, &e.Detail, &createdAt); err != nil {
+		if err := rows.Scan(&e.Seq, &e.TicketID, &kind, &e.Author, &e.AuthorRole, &from, &to, &e.Comment, &e.Detail, &createdAt); err != nil {
 			return nil, err
 		}
 		e.Kind = TicketEventKind(kind)
@@ -154,7 +159,7 @@ func (s *Store) TicketEventsSince(cursor int64) ([]TicketEvent, error) {
 		return nil, nil
 	}
 	rows, err := s.db.Query(`
-		SELECT seq, ticket_id, kind, author, from_status, to_status, comment, detail, created_at
+		SELECT seq, ticket_id, kind, author, author_role, from_status, to_status, comment, detail, created_at
 		FROM ticket_events WHERE seq > ? ORDER BY seq ASC
 	`, cursor)
 	if err != nil {
@@ -164,11 +169,11 @@ func (s *Store) TicketEventsSince(cursor int64) ([]TicketEvent, error) {
 }
 
 // The participation rule has exactly one definition: the ticket_participants
-// view (migration 82) — assignment, NON-COMMENT event authorship, explicit
-// subscription, durable role ownership. Queries below ask the view, never
-// restate the rule. Carve-outs baked into it: comment authorship confers no
-// participation, and a created event on a role-owned ticket is audit
-// provenance (the role, not the minting session, is the participant).
+// view (migration 82, refined by 99) — assignment, NON-COMMENT event
+// authorship, explicit subscription, durable role ownership. Queries below ask
+// the view, never restate the rule. Carve-outs baked into it: comment
+// authorship confers no participation, and an event carrying an author_role is
+// the ROLE's participation, not the acting session's.
 
 // UnreadTicketEvents returns every event an identity has not consumed across
 // the tickets it participates in, excluding its own, ordered by ticket then
@@ -188,7 +193,7 @@ func (s *Store) UnreadTicketEventsFor(cursorIdentity, authorIdentity string) ([]
 		return nil, nil
 	}
 	rows, err := s.db.Query(`
-		SELECT e.seq, e.ticket_id, e.kind, e.author, e.from_status, e.to_status, e.comment, e.detail, e.created_at
+		SELECT e.seq, e.ticket_id, e.kind, e.author, e.author_role, e.from_status, e.to_status, e.comment, e.detail, e.created_at
 		FROM ticket_events e
 		LEFT JOIN ticket_event_cursors c
 			ON c.identity = ? AND c.ticket_id = e.ticket_id

--- a/internal/store/ticket_mutation.go
+++ b/internal/store/ticket_mutation.go
@@ -147,7 +147,7 @@ func unreadTargetTicketEventsTx(
 	ticketID, cursorIdentity, authorIdentity string,
 ) ([]TicketEvent, error) {
 	rows, err := tx.Query(`
-		SELECT e.seq, e.ticket_id, e.kind, e.author, e.from_status, e.to_status, e.comment, e.detail, e.created_at
+		SELECT e.seq, e.ticket_id, e.kind, e.author, e.author_role, e.from_status, e.to_status, e.comment, e.detail, e.created_at
 		FROM ticket_events e
 		LEFT JOIN ticket_event_cursors c
 			ON c.identity = ? AND c.ticket_id = e.ticket_id

--- a/internal/store/ticket_role_participation_test.go
+++ b/internal/store/ticket_role_participation_test.go
@@ -74,7 +74,7 @@ func TestMigration99DetachesPastChiefSessionsFromTheirDelegations(t *testing.T) 
 		INSERT INTO ticket_event_cursors (identity, ticket_id, cursor, updated_at) VALUES
 			('role:chief_of_staff', 'minted', 1, '2026-08-01T10:05:00Z');
 
-	`+migration82View+`
+	` + migration82View + `
 		ALTER TABLE ticket_events DROP COLUMN author_role;
 		DELETE FROM schema_migrations WHERE version >= 99;
 	`); err != nil {

--- a/internal/store/ticket_role_participation_test.go
+++ b/internal/store/ticket_role_participation_test.go
@@ -54,21 +54,25 @@ func TestMigration99DetachesPastChiefSessionsFromTheirDelegations(t *testing.T) 
 	if _, err := db.Exec(`
 		INSERT INTO tickets (id, title, description, status, assignee, cwd, last_agent_id, created_at, updated_at) VALUES
 			('minted',  'Minted',  'Delegated from scratch.', 'working', 'agent-1', '/tmp/1', 'codex', '2026-08-01T10:00:00Z', '2026-08-01T10:00:00Z'),
-			('adopted', 'Adopted', 'Filed, then delegated.',  'working', 'agent-2', '/tmp/2', 'codex', '2026-08-01T09:00:00Z', '2026-08-01T11:00:00Z');
+			('adopted', 'Adopted', 'Filed, then delegated.',  'working', 'agent-2', '/tmp/2', 'codex', '2026-08-01T09:00:00Z', '2026-08-01T11:00:00Z'),
+			('watched', 'Watched', 'Delegated, then re-followed by hand.', 'working', 'agent-3', '/tmp/3', 'codex', '2026-08-01T11:30:00Z', '2026-08-01T12:00:00Z');
 
 		INSERT INTO ticket_events (ticket_id, kind, author, from_status, to_status, comment, detail, created_at) VALUES
 			('minted',  'created',        'chief-a',  '', 'working', '', '',        '2026-08-01T10:00:00Z'),
 			('adopted', 'created',        'author-x', '', 'todo',    '', '',        '2026-08-01T09:00:00Z'),
 			('adopted', 'assigned',       'chief-a',  '', '',        '', 'agent-2', '2026-08-01T11:00:00Z'),
-			('adopted', 'status_changed', 'chief-a',  'todo', 'working', '', '',    '2026-08-01T11:00:00Z');
+			('adopted', 'status_changed', 'chief-a',  'todo', 'working', '', '',    '2026-08-01T11:00:00Z'),
+			('watched', 'created',        'chief-a',  '', 'working', '', '',        '2026-08-01T11:30:00Z');
 
 		INSERT INTO ticket_role_owners (role, ticket_id, created_at) VALUES
 			('chief_of_staff', 'minted',  '2026-08-01T10:00:00Z'),
-			('chief_of_staff', 'adopted', '2026-08-01T11:00:00Z');
+			('chief_of_staff', 'adopted', '2026-08-01T11:00:00Z'),
+			('chief_of_staff', 'watched', '2026-08-01T11:30:00Z');
 
 		INSERT INTO ticket_subscriptions (identity, ticket_id, created_at) VALUES
 			('chief-a', 'minted',  '2026-08-01T10:00:00Z'),
 			('chief-a', 'adopted', '2026-08-01T11:00:00Z'),
+			('chief-a', 'watched', '2026-08-01T12:00:00Z'),
 			('watcher', 'minted',  '2026-08-01T10:30:00Z');
 
 		INSERT INTO ticket_event_cursors (identity, ticket_id, cursor, updated_at) VALUES
@@ -112,6 +116,12 @@ func TestMigration99DetachesPastChiefSessionsFromTheirDelegations(t *testing.T) 
 	adopted := participantSet(t, migrated, "adopted")
 	if !adopted["agent-2"] || !adopted["author-x"] {
 		t.Errorf("adopted participants = %v, want the assignee and the original author carried", adopted)
+	}
+	// A subscription the chief made by hand is a different act at a different
+	// time, so the sweep leaves it alone even on a ticket the chief delegated.
+	watching, err := migrated.IsTicketSubscribed("chief-a", "watched")
+	if err != nil || !watching {
+		t.Errorf("hand-made subscription survived = %v (err %v), want it carried", watching, err)
 	}
 	cursor, err := migrated.GetTicketCursor(role, "minted")
 	if err != nil || cursor != 1 {

--- a/internal/store/ticket_role_participation_test.go
+++ b/internal/store/ticket_role_participation_test.go
@@ -1,0 +1,184 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// migration82View is the participant rule as migration 82 defined it, restored
+// so the fixture below is a faithful pre-99 database rather than a new one with
+// some columns removed.
+const migration82View = `
+	DROP VIEW IF EXISTS ticket_participants;
+	CREATE VIEW ticket_participants (ticket_id, identity) AS
+		SELECT id, assignee FROM tickets WHERE assignee != ''
+		UNION
+		SELECT e.ticket_id, e.author FROM ticket_events e
+		WHERE e.author != '' AND e.kind != 'commented'
+			AND NOT (
+				e.kind = 'created' AND EXISTS (
+					SELECT 1 FROM ticket_role_owners ro WHERE ro.ticket_id = e.ticket_id
+				)
+			)
+		UNION
+		SELECT ticket_id, identity FROM ticket_subscriptions WHERE identity != ''
+		UNION
+		SELECT ticket_id, ('role:' || role) FROM ticket_role_owners WHERE role != '';
+`
+
+func participantSet(t *testing.T, s *Store, ticketID string) map[string]bool {
+	t.Helper()
+	identities, err := s.TicketParticipants(ticketID)
+	if err != nil {
+		t.Fatalf("TicketParticipants(%s): %v", ticketID, err)
+	}
+	set := map[string]bool{}
+	for _, identity := range identities {
+		set[identity] = true
+	}
+	return set
+}
+
+// A database written before migration 99 carries the chief's delegations as
+// personal subscriptions on whichever session held the role at the time, so the
+// board keeps nudging that session long after the role moved on. The migration
+// carries every row it can and removes only those subscriptions, on both shapes
+// of delegation: a ticket the chief minted, and a backlog ticket it adopted.
+func TestMigration99DetachesPastChiefSessionsFromTheirDelegations(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "migration-99.db")
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB setup: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO tickets (id, title, description, status, assignee, cwd, last_agent_id, created_at, updated_at) VALUES
+			('minted',  'Minted',  'Delegated from scratch.', 'working', 'agent-1', '/tmp/1', 'codex', '2026-08-01T10:00:00Z', '2026-08-01T10:00:00Z'),
+			('adopted', 'Adopted', 'Filed, then delegated.',  'working', 'agent-2', '/tmp/2', 'codex', '2026-08-01T09:00:00Z', '2026-08-01T11:00:00Z');
+
+		INSERT INTO ticket_events (ticket_id, kind, author, from_status, to_status, comment, detail, created_at) VALUES
+			('minted',  'created',        'chief-a',  '', 'working', '', '',        '2026-08-01T10:00:00Z'),
+			('adopted', 'created',        'author-x', '', 'todo',    '', '',        '2026-08-01T09:00:00Z'),
+			('adopted', 'assigned',       'chief-a',  '', '',        '', 'agent-2', '2026-08-01T11:00:00Z'),
+			('adopted', 'status_changed', 'chief-a',  'todo', 'working', '', '',    '2026-08-01T11:00:00Z');
+
+		INSERT INTO ticket_role_owners (role, ticket_id, created_at) VALUES
+			('chief_of_staff', 'minted',  '2026-08-01T10:00:00Z'),
+			('chief_of_staff', 'adopted', '2026-08-01T11:00:00Z');
+
+		INSERT INTO ticket_subscriptions (identity, ticket_id, created_at) VALUES
+			('chief-a', 'minted',  '2026-08-01T10:00:00Z'),
+			('chief-a', 'adopted', '2026-08-01T11:00:00Z'),
+			('watcher', 'minted',  '2026-08-01T10:30:00Z');
+
+		INSERT INTO ticket_event_cursors (identity, ticket_id, cursor, updated_at) VALUES
+			('role:chief_of_staff', 'minted', 1, '2026-08-01T10:05:00Z');
+
+	`+migration82View+`
+		ALTER TABLE ticket_events DROP COLUMN author_role;
+		DELETE FROM schema_migrations WHERE version >= 99;
+	`); err != nil {
+		t.Fatalf("seed pre-99 database: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close pre-99 database: %v", err)
+	}
+
+	migrated, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = migrated.Close() })
+
+	role := TicketRoleIdentity(TicketRoleChiefOfStaff)
+	for _, ticketID := range []string{"minted", "adopted"} {
+		participants := participantSet(t, migrated, ticketID)
+		if participants["chief-a"] {
+			t.Errorf("%s: chief-a is still attached personally after the migration", ticketID)
+		}
+		if !participants[role] {
+			t.Errorf("%s: the chief role lost its attachment", ticketID)
+		}
+	}
+
+	// Everything that was not the acting chief's own attachment is carried: the
+	// assignees, an unrelated watcher, the person who filed the adopted ticket,
+	// and the role's cursor, which is what stops the next chief being handed
+	// history the previous one already read.
+	minted := participantSet(t, migrated, "minted")
+	if !minted["agent-1"] || !minted["watcher"] {
+		t.Errorf("minted participants = %v, want the assignee and the watcher carried", minted)
+	}
+	adopted := participantSet(t, migrated, "adopted")
+	if !adopted["agent-2"] || !adopted["author-x"] {
+		t.Errorf("adopted participants = %v, want the assignee and the original author carried", adopted)
+	}
+	cursor, err := migrated.GetTicketCursor(role, "minted")
+	if err != nil || cursor != 1 {
+		t.Errorf("role cursor on minted = %d (err %v), want the pre-migration 1", cursor, err)
+	}
+}
+
+// The rule the migration encodes, stated on live writes: a delegation the chief
+// role performs attaches the role, and a ticket someone else filed keeps its
+// author attached even after the chief adopts it for a delegation.
+func TestRoleActedEventsAttachTheRoleAndLeaveOtherAuthorsAlone(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+	role := TicketRoleIdentity(TicketRoleChiefOfStaff)
+
+	if _, err := s.CreateRoleOwnedTicket(Ticket{
+		ID: "minted", Title: "Minted", Description: "Delegated from scratch.",
+		Status: TicketStatusWorking, Assignee: "agent-1",
+	}, "chief-a", TicketRoleChiefOfStaff, ticketBase); err != nil {
+		t.Fatalf("CreateRoleOwnedTicket: %v", err)
+	}
+	minted := participantSet(t, s, "minted")
+	if minted["chief-a"] || !minted[role] {
+		t.Fatalf("minted participants = %v, want the role attached and not the acting session", minted)
+	}
+
+	if _, err := s.CreateTicket(Ticket{
+		ID: "filed", Title: "Filed", Description: "Someone else's idea.",
+		Status: TicketStatusTodo,
+	}, "author-x", ticketBase); err != nil {
+		t.Fatalf("CreateTicket: %v", err)
+	}
+	if _, err := s.AdoptTicketForDelegation(
+		"filed", "agent-2", "/repo", "codex", "chief-a",
+		TicketRoleChiefOfStaff, nil, false, ticketBase.Add(time.Hour),
+	); err != nil {
+		t.Fatalf("AdoptTicketForDelegation: %v", err)
+	}
+	adopted := participantSet(t, s, "filed")
+	if adopted["chief-a"] {
+		t.Fatalf("adopted participants = %v, want the acting chief attached through the role", adopted)
+	}
+	if !adopted["author-x"] || !adopted[role] || !adopted["agent-2"] {
+		t.Fatalf("adopted participants = %v, want the filer, the role, and the assignee", adopted)
+	}
+}
+
+// An ordinary session that delegates a ticket the chief role happens to own is
+// not acting as the role, so it stays personally attached exactly as before.
+func TestNonRoleDelegatorKeepsItsOwnAttachment(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	if _, err := s.CreateRoleOwnedTicket(Ticket{
+		ID: "handed-on", Title: "Handed on", Description: "Chief delegated it first.",
+		Status: TicketStatusWorking, Assignee: "agent-1",
+	}, "chief-a", TicketRoleChiefOfStaff, ticketBase); err != nil {
+		t.Fatalf("CreateRoleOwnedTicket: %v", err)
+	}
+	if _, err := s.AdoptTicketForDelegation(
+		"handed-on", "agent-2", "/repo", "codex", "session-peer",
+		"", []string{"session-peer"}, true, ticketBase.Add(time.Hour),
+	); err != nil {
+		t.Fatalf("AdoptTicketForDelegation: %v", err)
+	}
+	participants := participantSet(t, s, "handed-on")
+	if !participants["session-peer"] {
+		t.Fatalf("participants = %v, want the ordinary delegator attached personally", participants)
+	}
+}

--- a/internal/store/tickets.go
+++ b/internal/store/tickets.go
@@ -301,7 +301,11 @@ func (s *Store) createTicket(t Ticket, author, ownerRole string, subscribers []s
 		TicketID: t.ID,
 		Kind:     TicketEventCreated,
 		Author:   author,
-		ToStatus: t.Status,
+		// Minting a role-owned ticket is the role's act: the role carries the
+		// creator's attachment, so the session filling it now is not left with a
+		// second, session-bound copy the next role holder cannot inherit.
+		AuthorRole: ownerRole,
+		ToStatus:   t.Status,
 	}, now)
 	if err != nil {
 		return nil, err
@@ -595,13 +599,13 @@ func (s *Store) SetTicketStatusWithOptions(
 	var updated *Ticket
 	outcome, err := s.withTicketMutation(id, options, now, func(tx *sql.Tx) error {
 		var mutationErr error
-		updated, mutationErr = setTicketStatusTx(tx, id, to, author, comment, now)
+		updated, mutationErr = setTicketStatusTx(tx, id, to, author, "", comment, now)
 		return mutationErr
 	})
 	return updated, outcome, err
 }
 
-func setTicketStatusTx(tx *sql.Tx, id string, to TicketStatus, author, comment string, now time.Time) (*Ticket, error) {
+func setTicketStatusTx(tx *sql.Tx, id string, to TicketStatus, author, authorRole, comment string, now time.Time) (*Ticket, error) {
 	current, err := scanTicket(tx.QueryRow(ticketSelect+` WHERE id = ?`, id))
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("%w: %q", ErrTicketNotFound, id)
@@ -637,6 +641,7 @@ func setTicketStatusTx(tx *sql.Tx, id string, to TicketStatus, author, comment s
 		TicketID:   id,
 		Kind:       TicketEventStatusChanged,
 		Author:     author,
+		AuthorRole: authorRole,
 		FromStatus: from,
 		ToStatus:   to,
 		Comment:    comment,
@@ -822,15 +827,19 @@ func (s *Store) AdoptTicketForDelegation(id, sessionID, cwd, lastAgentID, author
 	`, sessionID, cwd, lastAgentID, formatTicketTime(now), id); err != nil {
 		return nil, err
 	}
+	// Adoption is the same delegation act as minting, so it attaches the same way:
+	// when a role delegated this ticket, the events the acting session writes here
+	// carry the role. An ordinary session adopting a ticket the role happens to own
+	// passes no ownerRole and stays personally attached, as before.
 	if previousAssignee != sessionID {
 		if _, _, err := appendTicketEventTx(tx, TicketEvent{
-			TicketID: id, Kind: TicketEventAssigned, Author: author, Detail: sessionID,
+			TicketID: id, Kind: TicketEventAssigned, Author: author, AuthorRole: ownerRole, Detail: sessionID,
 		}, now); err != nil {
 			return nil, err
 		}
 	}
 	if current.Status != TicketStatusWorking {
-		if _, err := setTicketStatusTx(tx, id, TicketStatusWorking, author, "", now); err != nil {
+		if _, err := setTicketStatusTx(tx, id, TicketStatusWorking, author, ownerRole, "", now); err != nil {
 			return nil, err
 		}
 	}
@@ -1088,7 +1097,7 @@ func submitTicketAttachTx(
 		return nil, err
 	}
 	if status != nil {
-		updated, updateErr := setTicketStatusTx(tx, ticketID, *status, author, "", now)
+		updated, updateErr := setTicketStatusTx(tx, ticketID, *status, author, "", "", now)
 		if updateErr != nil {
 			return nil, updateErr
 		}


### PR DESCRIPTION
## What

When the chief of staff delegates, the ticket now attaches to the chief **role**
alone. Handing the role to another agent hands the ticket notifications with it:
the retired chief goes quiet, the new chief is nudged.

Before, the ticket attached twice — to the durable role, and to the session that
happened to hold the role, as a personal subscription. Only the role moved on a
handover, so an agent that had been chief kept being nudged about every ticket it
had ever delegated, for as long as it ran, while the new chief received the same
activity.

Genuinely personal participation is untouched: an explicit `attn ticket subscribe`
still works, and an ordinary session delegating a ticket the chief role happens to
own stays attached as itself.

## Which representation, and why

Two ways to make the attachment role-bound: record it at **creation time**, or
retarget the creator's rows at **transfer time**. Creation time, because the ticket
already had the right vocabulary and transfer time would need to guess which of a
retired chief's rows were role work.

Concretely, `ticket_events` gains `author_role`: the durable role the author was
acting as. `author` stays the session for audit provenance; participation follows
`author_role`. The delegation paths (mint and adopt) stamp it and stop subscribing
the acting chief personally.

That replaces migration 82's approximation — *"a `created` event on a role-owned
ticket belongs to the role"* — which had two problems the stamp does not:

- it missed the **adopt** path entirely, where the chief writes `assigned` and
  `status_changed` rather than `created`, so the acting session stayed attached;
- it fired on tickets it should not have. A backlog ticket filed by session X and
  later adopted by the chief for a delegation silently dropped **X's**
  participation, because X's `created` event was on a now-role-owned ticket.

**One deliberate behavior change beyond the chief.** Fixing the second point means
the filer of an adopted backlog ticket keeps its participation, where today it
loses it. Measured before the change: filing a ticket as `someone-else` and adopting
it as the chief left participants `[assignee, role:chief_of_staff]` — the filer was
gone. Call it out if you would rather keep the old carve-out; it is one `WHERE`
clause.

## Migration 99

Carries every row. It recognizes the delegating transaction by its timestamp — the
role owner row is written in the same transaction as the events beside it, so they
share a second — stamps those events with the role, and deletes only the acting
session's personal subscription. Restricted to `created`/`assigned`/`status_changed`
so a comment landing in the same second is not swept up, and the subscription it
deletes must carry the delegating second itself, so a subscription the chief made by
hand at some other time survives and a bystander who happened to subscribe in that
second keeps theirs.

Dry run against a copy of a real `~/.attn/attn.db` (97 → 99, 41 tickets, 239 events):

```
events stamped with a role:  5 (all chief-minted, all `created`)
ticket_subscriptions:        66 -> 66   (nothing to remove on this database)
ticket_events:               239 -> 239
ticket_event_cursors:        73 -> 73
tickets:                     41 -> 41
ticket_role_owners:          5 -> 5
```

`TestMigration99DetachesPastChiefSessionsFromTheirDelegations` covers the case that
database does not have, seeded from a populated pre-99 schema (old column dropped,
migration 82's view restored) with both shapes of delegation.

## The parked test

`TestChiefTicketContinuityAcrossRoleTransfer` was the one test the synctest sweep
(#809, #819) could not convert: its nudge count could not tell a role nudge from a
personal one, so it only passed with parked windows and a hand-fired timer. With the
distinction real it runs bubbled, and the windows run out instead — the retired
chief's zero nudges is now a fact about attachment rather than a timer that had not
come due.

## Verification

Mutation-checked both halves of the fix (restore the personal subscription; drop the
`created` stamp) — each turns three tests red, including the bubbled one at its
role-nudge assertion. Dropping the migration's `DELETE` turns the migration test red
on both ticket shapes.

Live, on a throwaway profile (`rolefix`, preflight PASS, cleaned up after): promoted
a session to chief, delegated from it, transferred the role to a second session, and
had the delegated agent report `ready_for_review`.

```
minted ticket: ticket_events.author_role = chief_of_staff
               ticket_subscriptions      = (empty)
               participants              = [assignee, role:chief_of_staff]

chief A (retired):  no unread ticket activity
chief B (current):  attn-fix-chief
                      created by chief-a-live
                      status_changed by <agent> (working → in_review)
```

## Surfaces

CLI (`attn ticket inbox`, exercised live), daemon and store, the shipped delegation
reference (participation now stated as role-bound), a changelog fragment. No protocol
change — `author_role` is server-side routing and never crosses the wire — so no
version bump and no frontend change. Pure Go and SQL, so Linux is unaffected.
