### PR TITLE
feat(app): the runtime sidecar — dispatch, invocation log, auto-disable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ coverage.out
 app/src-tauri/binaries/
 app/src-tauri/bundled-plugins/*
 !app/src-tauri/bundled-plugins/.gitkeep
+app/src-tauri/app-runtime/
+dist/app-runtime/
 
 # Claude Code local config. settings.json is the shared, checked-in part (repo
 # hooks); everything else here is per-machine. The pattern must exclude the

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,8 @@ coverage.out
 app/src-tauri/binaries/
 app/src-tauri/bundled-plugins/*
 !app/src-tauri/bundled-plugins/.gitkeep
-app/src-tauri/app-runtime/
+app/src-tauri/app-runtime/*
+!app/src-tauri/app-runtime/.gitkeep
 dist/app-runtime/
 
 # Claude Code local config. settings.json is the shared, checked-in part (repo

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run build build-linux-amd64 build-linux-arm64 publish-native-vt install install-daemon install-dev install-daemon-dev dev verify-ghostty-vt-wasm test test-hooks test-v test-quick test-watch test-all test-frontend test-e2e test-harness clean generate-types check-types build-app ensure-codesign-identity sign-app app-screenshot dist release release-skip-tests
+.PHONY: run build build-linux-amd64 build-linux-arm64 build-app-runtime-host build-app-runtime-host-linux-amd64 build-app-runtime-host-linux-arm64 publish-native-vt install install-daemon install-dev install-daemon-dev dev verify-ghostty-vt-wasm test test-hooks test-v test-quick test-watch test-all test-frontend test-e2e test-harness clean generate-types check-types build-app ensure-codesign-identity sign-app app-screenshot dist release release-skip-tests
 
 # Bare `make` does the full prod inner loop: install + open the app.
 # `make install` is install-only (for scripts/CI that drive the launch
@@ -34,7 +34,13 @@ BUILD_TIME ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 SOURCE_FINGERPRINT ?= $(shell bash ./scripts/source-fingerprint.sh --field fingerprint)
 GIT_COMMIT ?= $(shell bash ./scripts/source-fingerprint.sh --field commit)
 OUTPUT ?= $(BINARY_NAME)
-GO_LDFLAGS = -X github.com/victorarias/attn/internal/buildinfo.Version=$(VERSION) -X github.com/victorarias/attn/internal/buildinfo.BuildTime=$(BUILD_TIME) -X github.com/victorarias/attn/internal/buildinfo.SourceFingerprint=$(SOURCE_FINGERPRINT) -X github.com/victorarias/attn/internal/buildinfo.GitCommit=$(GIT_COMMIT)
+# Guards the macOS-only branches below (code signing, the lsof port check). It
+# was used by three recipes and defined by none, so `$(UNAME_S)` expanded to
+# empty and `install-daemon` skipped signing entirely: the copied binary kept its
+# ad-hoc linker signature inside a properly signed bundle, and macOS answered
+# `daemon ensure` with Killed: 9.
+UNAME_S := $(shell uname -s)
+GO_LDFLAGS =-X github.com/victorarias/attn/internal/buildinfo.Version=$(VERSION) -X github.com/victorarias/attn/internal/buildinfo.BuildTime=$(BUILD_TIME) -X github.com/victorarias/attn/internal/buildinfo.SourceFingerprint=$(SOURCE_FINGERPRINT) -X github.com/victorarias/attn/internal/buildinfo.GitCommit=$(GIT_COMMIT)
 # Honor the repository's .tool-versions even when an older standalone Zig is
 # earlier on PATH (the app's WASM builder follows the same order).
 ZIG ?= $(shell if command -v asdf >/dev/null 2>&1; then asdf which zig 2>/dev/null || command -v zig; else command -v zig; fi)
@@ -100,15 +106,32 @@ build: $(NATIVE_VT_DEP)
 # the target GOOS/GOARCH + zig as the cgo cross-compiler: passing them on the
 # sub-make command line exports them, so the sub-make's `go env` resolves the
 # Linux archive dependency (download-first) before the cross cgo link.
-build-linux-amd64:
+# The daemon's Linux targets carry the app runtime host with them. A daemon that
+# runs on a Linux remote and cannot start its runtime there is a silently
+# darwin-only platform, so the two travel together rather than by convention.
+build-linux-amd64: build-app-runtime-host-linux-amd64
 	$(MAKE) build GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
 		CC='$(ZIG) cc -target x86_64-linux-gnu' \
 		CXX='$(ZIG) c++ -target x86_64-linux-gnu'
 
-build-linux-arm64:
+build-linux-arm64: build-app-runtime-host-linux-arm64
 	$(MAKE) build GOOS=linux GOARCH=arm64 CGO_ENABLED=1 \
 		CC='$(ZIG) cc -target aarch64-linux-gnu' \
 		CXX='$(ZIG) c++ -target aarch64-linux-gnu'
+
+# attn's shared app runtime: a bun --compile standalone binary, per platform. The
+# native build stages into the Tauri resource dir so the next app build collects
+# it; the cross builds stage under dist/ for a remote install to pick up.
+APP_RUNTIME_HOST_DIR ?= app/src-tauri/app-runtime
+
+build-app-runtime-host:
+	bash ./scripts/build-app-runtime-host.sh $(APP_RUNTIME_HOST_DIR)
+
+build-app-runtime-host-linux-amd64:
+	bash ./scripts/build-app-runtime-host.sh dist/app-runtime/linux_amd64 bun-linux-x64
+
+build-app-runtime-host-linux-arm64:
+	bash ./scripts/build-app-runtime-host.sh dist/app-runtime/linux_arm64 bun-linux-arm64
 
 GOTESTSUM=$(HOME)/go/bin/gotestsum
 

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -37,7 +37,8 @@
     "targets": "all",
     "externalBin": ["binaries/attn"],
     "resources": {
-      "bundled-plugins/": "plugins/"
+      "bundled-plugins/": "plugins/",
+      "app-runtime/": "app-runtime/"
     },
     "icon": [
       "icons/32x32.png",

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -201,7 +201,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '220';
+export const PROTOCOL_VERSION = '221';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentEventMessage, AgentPromptMessage, AppApplyMessage, AppApplyResult, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, ApprovePRMessage, AppSetEnabledMessage, AppSetEnabledResult, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, DocUndefineMessage, DocUndefineResult, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentEventMessage, AgentPromptMessage, AppApplyMessage, AppApplyResult, AppConsumerInfo, AppInvocationInfo, AppListMessage, AppListResult, AppLogsMessage, AppLogsResult, AppRemoveMessage, AppRemoveResult, AppRollbackMessage, AppRollbackResult, ApprovePRMessage, AppRuntimeInfo, AppRuntimeRestartMessage, AppRuntimeRestartResult, AppRuntimeStatusMessage, AppRuntimeStatusResult, AppSetEnabledMessage, AppSetEnabledResult, AppStallInfo, AppStatusMessage, AppStatusResult, AppSummary, AppVersionInfo, AppWatchMessage, AppWatchResult, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, DocUndefineMessage, DocUndefineResult, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const activityStatusMessage = Convert.toActivityStatusMessage(json);
 //   const activityStatusResult = Convert.toActivityStatusResult(json);
@@ -14,17 +14,27 @@
 //   const appInvocationInfo = Convert.toAppInvocationInfo(json);
 //   const appListMessage = Convert.toAppListMessage(json);
 //   const appListResult = Convert.toAppListResult(json);
+//   const appLogsMessage = Convert.toAppLogsMessage(json);
+//   const appLogsResult = Convert.toAppLogsResult(json);
 //   const appRemoveMessage = Convert.toAppRemoveMessage(json);
 //   const appRemoveResult = Convert.toAppRemoveResult(json);
 //   const appRollbackMessage = Convert.toAppRollbackMessage(json);
 //   const appRollbackResult = Convert.toAppRollbackResult(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
+//   const appRuntimeInfo = Convert.toAppRuntimeInfo(json);
+//   const appRuntimeRestartMessage = Convert.toAppRuntimeRestartMessage(json);
+//   const appRuntimeRestartResult = Convert.toAppRuntimeRestartResult(json);
+//   const appRuntimeStatusMessage = Convert.toAppRuntimeStatusMessage(json);
+//   const appRuntimeStatusResult = Convert.toAppRuntimeStatusResult(json);
 //   const appSetEnabledMessage = Convert.toAppSetEnabledMessage(json);
 //   const appSetEnabledResult = Convert.toAppSetEnabledResult(json);
+//   const appStallInfo = Convert.toAppStallInfo(json);
 //   const appStatusMessage = Convert.toAppStatusMessage(json);
 //   const appStatusResult = Convert.toAppStatusResult(json);
 //   const appSummary = Convert.toAppSummary(json);
 //   const appVersionInfo = Convert.toAppVersionInfo(json);
+//   const appWatchMessage = Convert.toAppWatchMessage(json);
+//   const appWatchResult = Convert.toAppWatchResult(json);
 //   const attachBlock = Convert.toAttachBlock(json);
 //   const attachPolicy = Convert.toAttachPolicy(json);
 //   const attachResultMessage = Convert.toAttachResultMessage(json);
@@ -626,6 +636,25 @@ export interface CurrentVersion {
     [property: string]: any;
 }
 
+export interface AppLogsMessage {
+    cmd:    AppLogsMessageCmd;
+    lines?: number;
+    name:   string;
+    [property: string]: any;
+}
+
+export enum AppLogsMessageCmd {
+    AppLogs = "app_logs",
+}
+
+export interface AppLogsResult {
+    lines:     string[];
+    name:      string;
+    path:      string;
+    truncated: boolean;
+    [property: string]: any;
+}
+
 export interface AppRemoveMessage {
     cmd:  AppRemoveMessageCmd;
     name: string;
@@ -675,6 +704,70 @@ export enum ApprovePRMessageCmd {
     ApprovePR = "approve_pr",
 }
 
+export interface AppRuntimeInfo {
+    connected:        boolean;
+    connected_at?:    string;
+    desired:          string;
+    generation:       number;
+    last_exit?:       string;
+    next_restart_at?: string;
+    phase:            string;
+    pid?:             number;
+    restart_attempt:  number;
+    running:          boolean;
+    started_at?:      string;
+    [property: string]: any;
+}
+
+export interface AppRuntimeRestartMessage {
+    cmd: AppRuntimeRestartMessageCmd;
+    [property: string]: any;
+}
+
+export enum AppRuntimeRestartMessageCmd {
+    AppRuntimeRestart = "app_runtime_restart",
+}
+
+export interface AppRuntimeRestartResult {
+    runtime: Runtime;
+    was:     string;
+    [property: string]: any;
+}
+
+export interface Runtime {
+    connected:        boolean;
+    connected_at?:    string;
+    desired:          string;
+    generation:       number;
+    last_exit?:       string;
+    next_restart_at?: string;
+    phase:            string;
+    pid?:             number;
+    restart_attempt:  number;
+    running:          boolean;
+    started_at?:      string;
+    [property: string]: any;
+}
+
+export interface AppRuntimeStatusMessage {
+    cmd: AppRuntimeStatusMessageCmd;
+    [property: string]: any;
+}
+
+export enum AppRuntimeStatusMessageCmd {
+    AppRuntimeStatus = "app_runtime_status",
+}
+
+export interface AppRuntimeStatusResult {
+    apps:         number;
+    apps_enabled: number;
+    host_error?:  string;
+    host_path?:   string;
+    log_path:     string;
+    runtime?:     Runtime;
+    [property: string]: any;
+}
+
 export interface AppSetEnabledMessage {
     cmd:     AppSetEnabledMessageCmd;
     enabled: boolean;
@@ -693,6 +786,16 @@ export interface AppSetEnabledResult {
     [property: string]: any;
 }
 
+export interface AppStallInfo {
+    attempts:    number;
+    disables_at: string;
+    event_name:  string;
+    event_seq:   number;
+    last_error:  string;
+    since:       string;
+    [property: string]: any;
+}
+
 export interface AppStatusMessage {
     cmd:  AppStatusMessageCmd;
     name: string;
@@ -706,12 +809,14 @@ export enum AppStatusMessageCmd {
 export interface AppStatusResult {
     app:         App;
     invocations: number;
-    recent?:     RecentElement[];
+    recent?:     InvocationElement[];
+    runtime?:    Runtime;
+    stall?:      Stall;
     versions:    number;
     [property: string]: any;
 }
 
-export interface RecentElement {
+export interface InvocationElement {
     duration_ms:   number;
     error:         string;
     event_name:    string;
@@ -722,6 +827,16 @@ export interface RecentElement {
     started_at:    string;
     status:        string;
     version_id:    number;
+    [property: string]: any;
+}
+
+export interface Stall {
+    attempts:    number;
+    disables_at: string;
+    event_name:  string;
+    event_seq:   number;
+    last_error:  string;
+    since:       string;
     [property: string]: any;
 }
 
@@ -739,6 +854,21 @@ export interface AppVersionInfo {
     content_hash:  string;
     created_at:    string;
     id:            number;
+    [property: string]: any;
+}
+
+export interface AppWatchMessage {
+    cmd:  AppWatchMessageCmd;
+    name: string;
+    [property: string]: any;
+}
+
+export enum AppWatchMessageCmd {
+    AppWatch = "app_watch",
+}
+
+export interface AppWatchResult {
+    invocation: InvocationElement;
     [property: string]: any;
 }
 
@@ -4574,10 +4704,14 @@ export interface Response {
     activity_status_result?:               ActivityStatusResultObject;
     app_apply_result?:                     AppApplyResultObject;
     app_list_result?:                      AppListResultObject;
+    app_logs_result?:                      AppLogsResultObject;
     app_remove_result?:                    AppRemoveResultObject;
     app_rollback_result?:                  AppRollbackResultObject;
+    app_runtime_restart_result?:           AppRuntimeRestartResultObject;
+    app_runtime_status_result?:            AppRuntimeStatusResultObject;
     app_set_enabled_result?:               AppSetEnabledResultObject;
     app_status_result?:                    AppStatusResultObject;
+    app_watch_result?:                     AppWatchResultObject;
     authors?:                              AuthorElement[];
     data?:                                 string;
     delegate_result?:                      DelegateResultObject;
@@ -4648,6 +4782,14 @@ export interface AppListResultObject {
     [property: string]: any;
 }
 
+export interface AppLogsResultObject {
+    lines:     string[];
+    name:      string;
+    path:      string;
+    truncated: boolean;
+    [property: string]: any;
+}
+
 export interface AppRemoveResultObject {
     consumer_removed: boolean;
     invocations_kept: number;
@@ -4666,6 +4808,22 @@ export interface AppRollbackResultObject {
     [property: string]: any;
 }
 
+export interface AppRuntimeRestartResultObject {
+    runtime: Runtime;
+    was:     string;
+    [property: string]: any;
+}
+
+export interface AppRuntimeStatusResultObject {
+    apps:         number;
+    apps_enabled: number;
+    host_error?:  string;
+    host_path?:   string;
+    log_path:     string;
+    runtime?:     Runtime;
+    [property: string]: any;
+}
+
 export interface AppSetEnabledResultObject {
     consumer: string;
     enabled:  boolean;
@@ -4676,8 +4834,15 @@ export interface AppSetEnabledResultObject {
 export interface AppStatusResultObject {
     app:         App;
     invocations: number;
-    recent?:     RecentElement[];
+    recent?:     InvocationElement[];
+    runtime?:    Runtime;
+    stall?:      Stall;
     versions:    number;
+    [property: string]: any;
+}
+
+export interface AppWatchResultObject {
+    invocation: InvocationElement;
     [property: string]: any;
 }
 
@@ -6982,6 +7147,22 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AppListResult")), null, 2);
     }
 
+    public static toAppLogsMessage(json: string): AppLogsMessage {
+        return cast(JSON.parse(json), r("AppLogsMessage"));
+    }
+
+    public static appLogsMessageToJson(value: AppLogsMessage): string {
+        return JSON.stringify(uncast(value, r("AppLogsMessage")), null, 2);
+    }
+
+    public static toAppLogsResult(json: string): AppLogsResult {
+        return cast(JSON.parse(json), r("AppLogsResult"));
+    }
+
+    public static appLogsResultToJson(value: AppLogsResult): string {
+        return JSON.stringify(uncast(value, r("AppLogsResult")), null, 2);
+    }
+
     public static toAppRemoveMessage(json: string): AppRemoveMessage {
         return cast(JSON.parse(json), r("AppRemoveMessage"));
     }
@@ -7022,6 +7203,46 @@ export class Convert {
         return JSON.stringify(uncast(value, r("ApprovePRMessage")), null, 2);
     }
 
+    public static toAppRuntimeInfo(json: string): AppRuntimeInfo {
+        return cast(JSON.parse(json), r("AppRuntimeInfo"));
+    }
+
+    public static appRuntimeInfoToJson(value: AppRuntimeInfo): string {
+        return JSON.stringify(uncast(value, r("AppRuntimeInfo")), null, 2);
+    }
+
+    public static toAppRuntimeRestartMessage(json: string): AppRuntimeRestartMessage {
+        return cast(JSON.parse(json), r("AppRuntimeRestartMessage"));
+    }
+
+    public static appRuntimeRestartMessageToJson(value: AppRuntimeRestartMessage): string {
+        return JSON.stringify(uncast(value, r("AppRuntimeRestartMessage")), null, 2);
+    }
+
+    public static toAppRuntimeRestartResult(json: string): AppRuntimeRestartResult {
+        return cast(JSON.parse(json), r("AppRuntimeRestartResult"));
+    }
+
+    public static appRuntimeRestartResultToJson(value: AppRuntimeRestartResult): string {
+        return JSON.stringify(uncast(value, r("AppRuntimeRestartResult")), null, 2);
+    }
+
+    public static toAppRuntimeStatusMessage(json: string): AppRuntimeStatusMessage {
+        return cast(JSON.parse(json), r("AppRuntimeStatusMessage"));
+    }
+
+    public static appRuntimeStatusMessageToJson(value: AppRuntimeStatusMessage): string {
+        return JSON.stringify(uncast(value, r("AppRuntimeStatusMessage")), null, 2);
+    }
+
+    public static toAppRuntimeStatusResult(json: string): AppRuntimeStatusResult {
+        return cast(JSON.parse(json), r("AppRuntimeStatusResult"));
+    }
+
+    public static appRuntimeStatusResultToJson(value: AppRuntimeStatusResult): string {
+        return JSON.stringify(uncast(value, r("AppRuntimeStatusResult")), null, 2);
+    }
+
     public static toAppSetEnabledMessage(json: string): AppSetEnabledMessage {
         return cast(JSON.parse(json), r("AppSetEnabledMessage"));
     }
@@ -7036,6 +7257,14 @@ export class Convert {
 
     public static appSetEnabledResultToJson(value: AppSetEnabledResult): string {
         return JSON.stringify(uncast(value, r("AppSetEnabledResult")), null, 2);
+    }
+
+    public static toAppStallInfo(json: string): AppStallInfo {
+        return cast(JSON.parse(json), r("AppStallInfo"));
+    }
+
+    public static appStallInfoToJson(value: AppStallInfo): string {
+        return JSON.stringify(uncast(value, r("AppStallInfo")), null, 2);
     }
 
     public static toAppStatusMessage(json: string): AppStatusMessage {
@@ -7068,6 +7297,22 @@ export class Convert {
 
     public static appVersionInfoToJson(value: AppVersionInfo): string {
         return JSON.stringify(uncast(value, r("AppVersionInfo")), null, 2);
+    }
+
+    public static toAppWatchMessage(json: string): AppWatchMessage {
+        return cast(JSON.parse(json), r("AppWatchMessage"));
+    }
+
+    public static appWatchMessageToJson(value: AppWatchMessage): string {
+        return JSON.stringify(uncast(value, r("AppWatchMessage")), null, 2);
+    }
+
+    public static toAppWatchResult(json: string): AppWatchResult {
+        return cast(JSON.parse(json), r("AppWatchResult"));
+    }
+
+    public static appWatchResultToJson(value: AppWatchResult): string {
+        return JSON.stringify(uncast(value, r("AppWatchResult")), null, 2);
     }
 
     public static toAttachBlock(json: string): AttachBlock {
@@ -10845,6 +11090,17 @@ const typeMap: any = {
         { json: "created_at", js: "created_at", typ: "" },
         { json: "id", js: "id", typ: 0 },
     ], "any"),
+    "AppLogsMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AppLogsMessageCmd") },
+        { json: "lines", js: "lines", typ: u(undefined, 0) },
+        { json: "name", js: "name", typ: "" },
+    ], "any"),
+    "AppLogsResult": o([
+        { json: "lines", js: "lines", typ: a("") },
+        { json: "name", js: "name", typ: "" },
+        { json: "path", js: "path", typ: "" },
+        { json: "truncated", js: "truncated", typ: true },
+    ], "any"),
     "AppRemoveMessage": o([
         { json: "cmd", js: "cmd", typ: r("AppRemoveMessageCmd") },
         { json: "name", js: "name", typ: "" },
@@ -10872,6 +11128,50 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("ApprovePRMessageCmd") },
         { json: "id", js: "id", typ: "" },
     ], "any"),
+    "AppRuntimeInfo": o([
+        { json: "connected", js: "connected", typ: true },
+        { json: "connected_at", js: "connected_at", typ: u(undefined, "") },
+        { json: "desired", js: "desired", typ: "" },
+        { json: "generation", js: "generation", typ: 0 },
+        { json: "last_exit", js: "last_exit", typ: u(undefined, "") },
+        { json: "next_restart_at", js: "next_restart_at", typ: u(undefined, "") },
+        { json: "phase", js: "phase", typ: "" },
+        { json: "pid", js: "pid", typ: u(undefined, 0) },
+        { json: "restart_attempt", js: "restart_attempt", typ: 0 },
+        { json: "running", js: "running", typ: true },
+        { json: "started_at", js: "started_at", typ: u(undefined, "") },
+    ], "any"),
+    "AppRuntimeRestartMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AppRuntimeRestartMessageCmd") },
+    ], "any"),
+    "AppRuntimeRestartResult": o([
+        { json: "runtime", js: "runtime", typ: r("Runtime") },
+        { json: "was", js: "was", typ: "" },
+    ], "any"),
+    "Runtime": o([
+        { json: "connected", js: "connected", typ: true },
+        { json: "connected_at", js: "connected_at", typ: u(undefined, "") },
+        { json: "desired", js: "desired", typ: "" },
+        { json: "generation", js: "generation", typ: 0 },
+        { json: "last_exit", js: "last_exit", typ: u(undefined, "") },
+        { json: "next_restart_at", js: "next_restart_at", typ: u(undefined, "") },
+        { json: "phase", js: "phase", typ: "" },
+        { json: "pid", js: "pid", typ: u(undefined, 0) },
+        { json: "restart_attempt", js: "restart_attempt", typ: 0 },
+        { json: "running", js: "running", typ: true },
+        { json: "started_at", js: "started_at", typ: u(undefined, "") },
+    ], "any"),
+    "AppRuntimeStatusMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AppRuntimeStatusMessageCmd") },
+    ], "any"),
+    "AppRuntimeStatusResult": o([
+        { json: "apps", js: "apps", typ: 0 },
+        { json: "apps_enabled", js: "apps_enabled", typ: 0 },
+        { json: "host_error", js: "host_error", typ: u(undefined, "") },
+        { json: "host_path", js: "host_path", typ: u(undefined, "") },
+        { json: "log_path", js: "log_path", typ: "" },
+        { json: "runtime", js: "runtime", typ: u(undefined, r("Runtime")) },
+    ], "any"),
     "AppSetEnabledMessage": o([
         { json: "cmd", js: "cmd", typ: r("AppSetEnabledMessageCmd") },
         { json: "enabled", js: "enabled", typ: true },
@@ -10882,6 +11182,14 @@ const typeMap: any = {
         { json: "enabled", js: "enabled", typ: true },
         { json: "name", js: "name", typ: "" },
     ], "any"),
+    "AppStallInfo": o([
+        { json: "attempts", js: "attempts", typ: 0 },
+        { json: "disables_at", js: "disables_at", typ: "" },
+        { json: "event_name", js: "event_name", typ: "" },
+        { json: "event_seq", js: "event_seq", typ: 0 },
+        { json: "last_error", js: "last_error", typ: "" },
+        { json: "since", js: "since", typ: "" },
+    ], "any"),
     "AppStatusMessage": o([
         { json: "cmd", js: "cmd", typ: r("AppStatusMessageCmd") },
         { json: "name", js: "name", typ: "" },
@@ -10889,10 +11197,12 @@ const typeMap: any = {
     "AppStatusResult": o([
         { json: "app", js: "app", typ: r("App") },
         { json: "invocations", js: "invocations", typ: 0 },
-        { json: "recent", js: "recent", typ: u(undefined, a(r("RecentElement"))) },
+        { json: "recent", js: "recent", typ: u(undefined, a(r("InvocationElement"))) },
+        { json: "runtime", js: "runtime", typ: u(undefined, r("Runtime")) },
+        { json: "stall", js: "stall", typ: u(undefined, r("Stall")) },
         { json: "versions", js: "versions", typ: 0 },
     ], "any"),
-    "RecentElement": o([
+    "InvocationElement": o([
         { json: "duration_ms", js: "duration_ms", typ: 0 },
         { json: "error", js: "error", typ: "" },
         { json: "event_name", js: "event_name", typ: "" },
@@ -10903,6 +11213,14 @@ const typeMap: any = {
         { json: "started_at", js: "started_at", typ: "" },
         { json: "status", js: "status", typ: "" },
         { json: "version_id", js: "version_id", typ: 0 },
+    ], "any"),
+    "Stall": o([
+        { json: "attempts", js: "attempts", typ: 0 },
+        { json: "disables_at", js: "disables_at", typ: "" },
+        { json: "event_name", js: "event_name", typ: "" },
+        { json: "event_seq", js: "event_seq", typ: 0 },
+        { json: "last_error", js: "last_error", typ: "" },
+        { json: "since", js: "since", typ: "" },
     ], "any"),
     "AppSummary": o([
         { json: "consumer", js: "consumer", typ: u(undefined, r("Consumer")) },
@@ -10916,6 +11234,13 @@ const typeMap: any = {
         { json: "content_hash", js: "content_hash", typ: "" },
         { json: "created_at", js: "created_at", typ: "" },
         { json: "id", js: "id", typ: 0 },
+    ], "any"),
+    "AppWatchMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AppWatchMessageCmd") },
+        { json: "name", js: "name", typ: "" },
+    ], "any"),
+    "AppWatchResult": o([
+        { json: "invocation", js: "invocation", typ: r("InvocationElement") },
     ], "any"),
     "AttachBlock": o([
         { json: "command", js: "command", typ: u(undefined, "") },
@@ -13188,10 +13513,14 @@ const typeMap: any = {
         { json: "activity_status_result", js: "activity_status_result", typ: u(undefined, r("ActivityStatusResultObject")) },
         { json: "app_apply_result", js: "app_apply_result", typ: u(undefined, r("AppApplyResultObject")) },
         { json: "app_list_result", js: "app_list_result", typ: u(undefined, r("AppListResultObject")) },
+        { json: "app_logs_result", js: "app_logs_result", typ: u(undefined, r("AppLogsResultObject")) },
         { json: "app_remove_result", js: "app_remove_result", typ: u(undefined, r("AppRemoveResultObject")) },
         { json: "app_rollback_result", js: "app_rollback_result", typ: u(undefined, r("AppRollbackResultObject")) },
+        { json: "app_runtime_restart_result", js: "app_runtime_restart_result", typ: u(undefined, r("AppRuntimeRestartResultObject")) },
+        { json: "app_runtime_status_result", js: "app_runtime_status_result", typ: u(undefined, r("AppRuntimeStatusResultObject")) },
         { json: "app_set_enabled_result", js: "app_set_enabled_result", typ: u(undefined, r("AppSetEnabledResultObject")) },
         { json: "app_status_result", js: "app_status_result", typ: u(undefined, r("AppStatusResultObject")) },
+        { json: "app_watch_result", js: "app_watch_result", typ: u(undefined, r("AppWatchResultObject")) },
         { json: "authors", js: "authors", typ: u(undefined, a(r("AuthorElement"))) },
         { json: "data", js: "data", typ: u(undefined, "") },
         { json: "delegate_result", js: "delegate_result", typ: u(undefined, r("DelegateResultObject")) },
@@ -13254,6 +13583,12 @@ const typeMap: any = {
     "AppListResultObject": o([
         { json: "apps", js: "apps", typ: a(r("App")) },
     ], "any"),
+    "AppLogsResultObject": o([
+        { json: "lines", js: "lines", typ: a("") },
+        { json: "name", js: "name", typ: "" },
+        { json: "path", js: "path", typ: "" },
+        { json: "truncated", js: "truncated", typ: true },
+    ], "any"),
     "AppRemoveResultObject": o([
         { json: "consumer_removed", js: "consumer_removed", typ: true },
         { json: "invocations_kept", js: "invocations_kept", typ: 0 },
@@ -13268,6 +13603,18 @@ const typeMap: any = {
         { json: "previous_version_id", js: "previous_version_id", typ: u(undefined, 0) },
         { json: "version_id", js: "version_id", typ: 0 },
     ], "any"),
+    "AppRuntimeRestartResultObject": o([
+        { json: "runtime", js: "runtime", typ: r("Runtime") },
+        { json: "was", js: "was", typ: "" },
+    ], "any"),
+    "AppRuntimeStatusResultObject": o([
+        { json: "apps", js: "apps", typ: 0 },
+        { json: "apps_enabled", js: "apps_enabled", typ: 0 },
+        { json: "host_error", js: "host_error", typ: u(undefined, "") },
+        { json: "host_path", js: "host_path", typ: u(undefined, "") },
+        { json: "log_path", js: "log_path", typ: "" },
+        { json: "runtime", js: "runtime", typ: u(undefined, r("Runtime")) },
+    ], "any"),
     "AppSetEnabledResultObject": o([
         { json: "consumer", js: "consumer", typ: "" },
         { json: "enabled", js: "enabled", typ: true },
@@ -13276,8 +13623,13 @@ const typeMap: any = {
     "AppStatusResultObject": o([
         { json: "app", js: "app", typ: r("App") },
         { json: "invocations", js: "invocations", typ: 0 },
-        { json: "recent", js: "recent", typ: u(undefined, a(r("RecentElement"))) },
+        { json: "recent", js: "recent", typ: u(undefined, a(r("InvocationElement"))) },
+        { json: "runtime", js: "runtime", typ: u(undefined, r("Runtime")) },
+        { json: "stall", js: "stall", typ: u(undefined, r("Stall")) },
         { json: "versions", js: "versions", typ: 0 },
+    ], "any"),
+    "AppWatchResultObject": o([
+        { json: "invocation", js: "invocation", typ: r("InvocationElement") },
     ], "any"),
     "DocCollectionsResultObject": o([
         { json: "collections", js: "collections", typ: a(r("Schema")) },
@@ -14618,6 +14970,9 @@ const typeMap: any = {
     "AppListMessageCmd": [
         "app_list",
     ],
+    "AppLogsMessageCmd": [
+        "app_logs",
+    ],
     "AppRemoveMessageCmd": [
         "app_remove",
     ],
@@ -14627,11 +14982,20 @@ const typeMap: any = {
     "ApprovePRMessageCmd": [
         "approve_pr",
     ],
+    "AppRuntimeRestartMessageCmd": [
+        "app_runtime_restart",
+    ],
+    "AppRuntimeStatusMessageCmd": [
+        "app_runtime_status",
+    ],
     "AppSetEnabledMessageCmd": [
         "app_set_enabled",
     ],
     "AppStatusMessageCmd": [
         "app_status",
+    ],
+    "AppWatchMessageCmd": [
+        "app_watch",
     ],
     "AttachResultMessageEvent": [
         "attach_result",

--- a/apphost/package.json
+++ b/apphost/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "attn-app-runtime",
+  "version": "0.1.0",
+  "private": true,
+  "description": "attn's shared app runtime: the supervised Bun sidecar every installed app's handlers execute in.",
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.0",
+    "typescript": "5.8.3"
+  }
+}

--- a/apphost/src/dispatch.ts
+++ b/apphost/src/dispatch.ts
@@ -1,0 +1,156 @@
+// Running one handler: load the version's bundle, find the handler the daemon
+// named, and call it with a context scoped to the app.
+//
+// Two rules shape this file.
+//
+// The daemon decides which handler runs. It holds the frozen declaration and the
+// same pattern-matching the bus filter uses, so resolving an event name to a
+// subscription here would be a second implementation of a rule that already
+// exists — free to drift, and drifting silently.
+//
+// A version is a path. Versions are content-addressed, so every distinct build
+// lives at its own absolute path and `import()` caches by path: a new version is
+// a fresh module by construction, and an in-flight dispatch keeps running the one
+// it started on. Nothing unloads, nothing is invalidated, and a stale bundle
+// cannot be served — the failure mode a reload-by-name cache exists to fight
+// simply has no way to occur here.
+
+import { pathToFileURL } from "node:url"
+import { RpcConnection } from "./rpc.ts"
+
+/** What the daemon sends to run one handler. */
+export interface DispatchParams {
+  /** The daemon's id for this dispatch. Every callback carries it back. */
+  dispatch: string
+  app: string
+  version_id: number
+  /** Absolute path to this version's bundle. */
+  artifact: string
+  /** The subscription pattern to invoke — a key of the bundle's default export. */
+  handler: string
+  /** The collections this version declared, by name. */
+  collections: string[]
+  event: {
+    name: string
+    subject: string
+    seq: number
+    payload: unknown
+    published_at: string
+  }
+}
+
+/** What the daemon gets back. A handler that threw is a result, not an RPC error. */
+export interface DispatchResult {
+  ok: boolean
+  error?: string
+}
+
+type Handler = (event: DispatchParams["event"], ctx: unknown) => unknown
+
+/**
+ * Bundles already imported, by absolute path. It only ever grows, which is
+ * correct for the lifetime of one runtime: a version that ran is a version that
+ * can run again on a rollback, and the entries are small. A runtime restart is
+ * what empties it, and the supervisor provides those.
+ */
+const modules = new Map<string, Promise<Record<string, Handler>>>()
+
+async function loadHandlers(artifact: string): Promise<Record<string, Handler>> {
+  let pending = modules.get(artifact)
+  if (!pending) {
+    pending = importHandlers(artifact)
+    modules.set(artifact, pending)
+    // A bundle that fails to import must not be remembered as broken forever: the
+    // artifact may be mid-write, or the disk may have had a bad moment, and the
+    // bus is going to retry this delivery.
+    pending.catch(() => modules.delete(artifact))
+  }
+  return pending
+}
+
+async function importHandlers(artifact: string): Promise<Record<string, Handler>> {
+  const module = (await import(pathToFileURL(artifact).href)) as { default?: unknown }
+  const handlers = module.default
+  if (!handlers || typeof handlers !== "object") {
+    throw new Error(
+      `${artifact} has no default export; an app's entrypoint default-exports its handlers, as \`export default { "session.state.changed": onChange } satisfies Handlers\``,
+    )
+  }
+  return handlers as Record<string, Handler>
+}
+
+/** Builds `ctx.collections`, one object per collection the version declared. */
+function collectionsFor(
+  conn: RpcConnection,
+  dispatch: string,
+  declared: string[],
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const name of declared) {
+    // Every call carries the dispatch id and the collection, and no namespace:
+    // the daemon resolves which app is asking from its own record of the dispatch
+    // in flight, so an app cannot name a namespace at all, let alone another's.
+    const call = (op: string, params: Record<string, unknown>) =>
+      conn.call(`app.collection.${op}`, { dispatch, collection: name, ...params })
+    out[name] = {
+      get: (id: string) => call("get", { id }),
+      put: (id: string, body: unknown, options?: { ifRev?: number }) =>
+        call("put", { id, body, if_rev: options?.ifRev }),
+      delete: (id: string) => call("delete", { id }),
+      query: (options?: unknown) => call("query", { query: options ?? {} }),
+      count: (options?: unknown) => call("count", { query: options ?? {} }),
+    }
+  }
+  return out
+}
+
+/**
+ * Runs one dispatch and describes what happened.
+ *
+ * A handler that throws produces `{ok: false, error}` — a normal answer, not an
+ * RPC failure. The distinction is what lets the daemon tell an app's fault from
+ * the runtime's: only a transport error or a dead process reaches the daemon as
+ * an RPC failure, and only those are the runtime's to answer for.
+ */
+export async function runDispatch(
+  conn: RpcConnection,
+  params: DispatchParams,
+): Promise<DispatchResult> {
+  let handlers: Record<string, Handler>
+  try {
+    handlers = await loadHandlers(params.artifact)
+  } catch (err) {
+    return { ok: false, error: describeFailure(err) }
+  }
+
+  const handler = handlers[params.handler]
+  if (typeof handler !== "function") {
+    const declared = Object.keys(handlers)
+    return {
+      ok: false,
+      error:
+        `app ${params.app} version ${params.version_id} subscribes to ${params.handler} but its default export has no handler under that key. ` +
+        (declared.length > 0
+          ? `It exports: ${declared.join(", ")}.`
+          : "It exports no handlers at all.") +
+        " The generated Handlers type makes this a compile error — the bundle is out of step with its manifest.",
+    }
+  }
+
+  const ctx = {
+    app: params.app,
+    version: params.version_id,
+    collections: collectionsFor(conn, params.dispatch, params.collections),
+  }
+  try {
+    await handler(params.event, ctx)
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: describeFailure(err) }
+  }
+}
+
+function describeFailure(err: unknown): string {
+  if (err instanceof Error) return err.stack?.trim() || `${err.name}: ${err.message}`
+  return String(err)
+}

--- a/apphost/src/index.ts
+++ b/apphost/src/index.ts
@@ -1,0 +1,148 @@
+// attn's shared app runtime.
+//
+// One supervised Bun process runs the handlers of every installed app. It is not
+// a sandbox and does not pretend to be one: isolation between apps is failure
+// attribution, not an OS boundary. What it owes the daemon is an honest answer
+// per dispatch — this app's handler threw, or it did not — because a whole-process
+// death cannot name a culprit and must never be charged to whichever app happened
+// to be running.
+//
+// It ships as a `bun build --compile` standalone binary. The Bun runtime is inside
+// the executable, so a daemon launched by the macOS app needs no PATH resolution
+// and a user's machine needs no toolchain to run apps. There is deliberately no
+// PATH-resolution fallback: one mechanism, one failure class.
+//
+// See docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md.
+
+import { AsyncLocalStorage } from "node:async_hooks"
+import { RpcConnection, RPC_METHOD_NOT_FOUND, describe, type RpcRequest } from "./rpc.ts"
+import { runDispatch, type DispatchParams } from "./dispatch.ts"
+
+/**
+ * The runtime contract this host speaks. The daemon refuses a host that does not
+ * match, because a version skew between the daemon and a binary inside an old app
+ * bundle is exactly the case a silent mismatch would turn into wrong behavior.
+ */
+const APP_RUNTIME_API_VERSION = 1
+
+/**
+ * Which app a line of output came from.
+ *
+ * Handler code writes to the same stdout as everything else in this process, and
+ * a shared log with no attribution cannot answer `attn app logs <name>`. The
+ * storage is async-scoped, so a log written after an `await` inside a handler is
+ * still tagged with the app that wrote it.
+ */
+const currentApp = new AsyncLocalStorage<string>()
+
+/** The tag `attn app logs <name>` filters on. Kept in step with appRuntimeLogTag in Go. */
+function tag(app: string | undefined): string {
+  return app ? `[app ${app}] ` : "[runtime] "
+}
+
+/**
+ * Routes everything this process prints through the app tag.
+ *
+ * It patches console rather than asking apps to use a logger: an app author
+ * writes console.log, and output that vanishes because it did not go through the
+ * approved channel is worse than no capture at all.
+ */
+function captureConsole(): void {
+  const write = (stream: NodeJS.WriteStream, args: unknown[]) => {
+    const prefix = tag(currentApp.getStore())
+    const text = args.map(render).join(" ")
+    for (const line of text.split("\n")) stream.write(`${prefix}${line}\n`)
+  }
+  console.log = (...args: unknown[]) => write(process.stdout, args)
+  console.info = (...args: unknown[]) => write(process.stdout, args)
+  console.debug = (...args: unknown[]) => write(process.stdout, args)
+  console.warn = (...args: unknown[]) => write(process.stderr, args)
+  console.error = (...args: unknown[]) => write(process.stderr, args)
+}
+
+function render(value: unknown): string {
+  if (typeof value === "string") return value
+  if (value instanceof Error) return value.stack?.trim() || `${value.name}: ${value.message}`
+  try {
+    return JSON.stringify(value) ?? String(value)
+  } catch {
+    return String(value)
+  }
+}
+
+/** Says why the process cannot start, then stops. The supervisor restarts it. */
+function fatal(message: string): never {
+  process.stderr.write(`${tag(undefined)}${message}\n`)
+  process.exit(1)
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim()
+  if (!value) {
+    fatal(
+      `${name} is not set. The app runtime is launched by the attn daemon, which injects it; running this binary by hand is not a supported way to start it.`,
+    )
+  }
+  return value
+}
+
+async function main(): Promise<void> {
+  captureConsole()
+
+  const socketPath = requiredEnv("ATTN_SOCKET_PATH")
+  const generation = Number(requiredEnv("ATTN_APP_RUNTIME_GENERATION"))
+  if (!Number.isSafeInteger(generation) || generation <= 0) {
+    fatal(
+      `ATTN_APP_RUNTIME_GENERATION is ${process.env.ATTN_APP_RUNTIME_GENERATION}, which is not a positive integer. The supervisor fences stale processes by generation, so a host that cannot present its own is refused.`,
+    )
+  }
+
+  // Declared before the connection so the read loop can reach it: a dispatch can
+  // arrive on the same tick the hello result does.
+  let connection: RpcConnection
+  const serve = async (request: RpcRequest): Promise<unknown> => {
+    switch (request.method) {
+      case "app.dispatch": {
+        const params = request.params as DispatchParams
+        // The tag follows the handler through every await it makes.
+        return currentApp.run(params.app, () => runDispatch(connection, params))
+      }
+      case "app.runtime.ping":
+        // A liveness answer the daemon can ask for without running app code.
+        return { ok: true, api_version: APP_RUNTIME_API_VERSION }
+      default:
+        throw Object.assign(new Error(`unknown method ${request.method}`), {
+          code: RPC_METHOD_NOT_FOUND,
+        })
+    }
+  }
+
+  connection = new RpcConnection(socketPath, serve)
+  try {
+    await connection.ready()
+  } catch (err) {
+    fatal(`cannot reach the attn daemon at ${socketPath}: ${describe(err)}`)
+  }
+
+  try {
+    await connection.call("app_runtime.hello", {
+      generation,
+      api_version: APP_RUNTIME_API_VERSION,
+      pid: process.pid,
+    })
+  } catch (err) {
+    fatal(`the daemon refused this app runtime: ${describe(err)}`)
+  }
+
+  console.log(`app runtime ready (generation ${generation}, pid ${process.pid})`)
+
+  // The process lives as long as its connection. A dropped socket is the
+  // supervisor's business, not something to paper over with a reconnect loop
+  // here: the supervisor already owns backoff, generation fencing and parking,
+  // and a second reconnect policy underneath it would fight the first.
+  const ended = await connection.done()
+  process.stderr.write(`${tag(undefined)}connection to the daemon ended: ${ended.message}\n`)
+  process.exit(1)
+}
+
+void main()

--- a/apphost/src/rpc.ts
+++ b/apphost/src/rpc.ts
@@ -1,0 +1,213 @@
+// The socket half of the app runtime: newline-delimited JSON-RPC 2.0 over the
+// daemon's unix socket, full duplex.
+//
+// It is the same framing the plugin protocol uses (internal/daemon/plugin_rpc.go)
+// and deliberately not a second one — the daemon already has a reader that
+// switches to line framing after a hello, and a sidecar that spoke its own
+// dialect would be a second wire format to keep correct for no gain.
+//
+// Both directions carry requests. The daemon asks this process to run a handler;
+// this process asks the daemon to read and write documents while that handler
+// runs. Ids are per-direction, so the two spaces may collide harmlessly.
+
+import { connect, type Socket } from "node:net"
+
+export interface RpcRequest {
+  method: string
+  params: unknown
+  /** Echo this back verbatim: the daemon matches responses by the id's raw text. */
+  id: unknown
+}
+
+export interface RpcError {
+  code: number
+  message: string
+}
+
+export const RPC_PARSE_ERROR = -32700
+export const RPC_INVALID_REQUEST = -32600
+export const RPC_METHOD_NOT_FOUND = -32601
+export const RPC_INTERNAL_ERROR = -32603
+
+interface RpcFrame {
+  jsonrpc?: string
+  id?: unknown
+  method?: string
+  params?: unknown
+  result?: unknown
+  error?: RpcError
+}
+
+/** Thrown when the daemon answers one of our calls with an error frame. */
+export class RpcCallError extends Error {
+  readonly code: number
+  constructor(code: number, message: string) {
+    super(message)
+    this.name = "RpcCallError"
+    this.code = code
+  }
+}
+
+type Pending = {
+  resolve: (value: unknown) => void
+  reject: (reason: Error) => void
+}
+
+/**
+ * One connection to the daemon.
+ *
+ * `onRequest` handles inbound calls. It is invoked without awaiting, so a slow
+ * handler never blocks the read loop — a dispatch that takes a second must not
+ * stall the document reads of a dispatch already in flight.
+ */
+export class RpcConnection {
+  private readonly socket: Socket
+  private readonly pending = new Map<string, Pending>()
+  private buffer = ""
+  private nextId = 0
+  private closed: Error | null = null
+
+  constructor(
+    socketPath: string,
+    private readonly onRequest: (request: RpcRequest) => Promise<unknown>,
+  ) {
+    this.socket = connect(socketPath)
+    this.socket.setNoDelay(true)
+    this.socket.on("data", (chunk) => this.consume(chunk))
+    this.socket.on("error", (err) => this.fail(err))
+    this.socket.on("close", () => this.fail(new Error("the daemon closed the connection")))
+  }
+
+  /** Resolves once the socket is connected, or rejects if it never gets there. */
+  ready(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (this.closed) {
+        reject(this.closed)
+        return
+      }
+      this.socket.once("connect", () => resolve())
+      this.socket.once("error", (err) => reject(err))
+    })
+  }
+
+  /** Resolves when the connection ends, whatever ends it. */
+  done(): Promise<Error> {
+    return new Promise((resolve) => {
+      if (this.closed) {
+        resolve(this.closed)
+        return
+      }
+      this.socket.once("close", () =>
+        resolve(this.closed ?? new Error("the daemon closed the connection")),
+      )
+    })
+  }
+
+  /** Calls the daemon and resolves with its result. */
+  call(method: string, params: unknown): Promise<unknown> {
+    if (this.closed) return Promise.reject(this.closed)
+    this.nextId += 1
+    const id = this.nextId
+    const key = String(id)
+    return new Promise((resolve, reject) => {
+      this.pending.set(key, { resolve, reject })
+      try {
+        this.write({ jsonrpc: "2.0", id, method, params })
+      } catch (err) {
+        this.pending.delete(key)
+        reject(err instanceof Error ? err : new Error(String(err)))
+      }
+    })
+  }
+
+  respond(id: unknown, result: unknown): void {
+    this.write({ jsonrpc: "2.0", id, result })
+  }
+
+  respondError(id: unknown, code: number, message: string): void {
+    this.write({ jsonrpc: "2.0", id, error: { code, message } })
+  }
+
+  close(): void {
+    this.socket.destroy()
+  }
+
+  private write(frame: RpcFrame): void {
+    if (this.closed) throw this.closed
+    this.socket.write(`${JSON.stringify(frame)}\n`)
+  }
+
+  private consume(chunk: Buffer): void {
+    this.buffer += chunk.toString("utf8")
+    for (;;) {
+      const newline = this.buffer.indexOf("\n")
+      if (newline < 0) break
+      const line = this.buffer.slice(0, newline).trim()
+      this.buffer = this.buffer.slice(newline + 1)
+      if (line === "") continue
+      let frame: RpcFrame
+      try {
+        frame = JSON.parse(line) as RpcFrame
+      } catch {
+        // A frame we cannot parse is the daemon's to know about; there is no id
+        // to answer, so say it once on stderr and keep reading.
+        process.stderr.write(`app runtime: unparseable frame from the daemon: ${line}\n`)
+        continue
+      }
+      this.route(frame)
+    }
+  }
+
+  private route(frame: RpcFrame): void {
+    // A frame with a method is the daemon calling us; one without is an answer to
+    // a call we made. Same rule the daemon applies in the other direction.
+    if (frame.method) {
+      void this.serve(frame)
+      return
+    }
+    const key = frame.id === undefined ? "" : String(frame.id)
+    const pending = this.pending.get(key)
+    if (!pending) return
+    this.pending.delete(key)
+    if (frame.error) {
+      pending.reject(new RpcCallError(frame.error.code, frame.error.message))
+      return
+    }
+    pending.resolve(frame.result)
+  }
+
+  private async serve(frame: RpcFrame): Promise<void> {
+    const id = frame.id
+    if (id === undefined || id === null) {
+      // Every inbound call must be answerable. A notification would be a request
+      // whose failure nobody learns about.
+      process.stderr.write(`app runtime: ignoring ${frame.method} with no id\n`)
+      return
+    }
+    try {
+      const result = await this.onRequest({
+        method: frame.method ?? "",
+        params: frame.params,
+        id,
+      })
+      this.respond(id, result)
+    } catch (err) {
+      this.respondError(id, RPC_INTERNAL_ERROR, describe(err))
+    }
+  }
+
+  private fail(err: Error): void {
+    if (this.closed) return
+    this.closed = err
+    for (const [, pending] of this.pending) pending.reject(err)
+    this.pending.clear()
+  }
+}
+
+/** Renders anything thrown as a message, keeping a stack when there is one. */
+export function describe(err: unknown): string {
+  if (err instanceof Error) {
+    return err.stack?.trim() || `${err.name}: ${err.message}`
+  }
+  return String(err)
+}

--- a/apphost/tsconfig.json
+++ b/apphost/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/changelog.d/app-apply-pipeline-and-scaffold.yaml
+++ b/changelog.d/app-apply-pipeline-and-scaffold.yaml
@@ -17,9 +17,7 @@ notes: >
   compiler holds your entrypoint to, and the manifest and the bundle together
   make the content hash. Applying the same app twice records nothing the second
   time — same hash, same version, no new row. Rollback is a pointer, so it
-  builds nothing and every version stays on disk. `attn app dev` today streams
-  apply results and build errors; handler invocations are not streamed because
-  nothing dispatches to apps yet. Typechecking uses a pinned TypeScript that
+  builds nothing and every version stays on disk. Typechecking uses a pinned TypeScript that
   attn installs once, on the first apply, and shares across apps; bundling uses
   bun, which must be on your PATH.
   Design: docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md.

--- a/changelog.d/app-runtime-dispatch-and-auto-disable.yaml
+++ b/changelog.d/app-runtime-dispatch-and-auto-disable.yaml
@@ -1,0 +1,28 @@
+kind: added
+area: cli
+change: >
+  Installed apps now run. attn dispatches the facts an app subscribes to into
+  its handlers, records every run, and shows you the result: `attn app status
+  <name>` lists recent invocations, `attn app logs <name>` shows what the app
+  printed, and `attn app dev <path>` streams invocations beside its build
+  output. `attn app runtime status` and `attn app runtime restart` are the
+  shared process every app's handlers run in.
+notes: >
+  One process for every app, not one each. That is the design: attn knows which
+  app's handler was running when something threw and charges the failure to
+  that app, but a runtime that dies is nobody's fault — no app moves closer to
+  being switched off because the shared process crashed. A handler that throws
+  keeps its event: the app retries it with backoff and never skips ahead, which
+  is what makes at-least-once delivery real. An app stuck on the same event for
+  fifteen minutes is disabled, because a stalled app holds the event log open
+  for every other consumer; you get a notification saying which event and which
+  error, and `attn app enable <name>` resumes it with a clean slate. A handler
+  reaches only the collections its own manifest declares, in its own document
+  namespace — there is no way to name another app's. Applying a new version
+  re-points the next dispatch without disturbing one already running. Runs are
+  kept for 30 days, or the newest 20,000 per app, whichever comes first — an app
+  watching a busy part of attn can record hundreds of thousands of runs a month,
+  and the recent ones are the ones worth reading. If the shared runtime
+  crash-loops attn parks it and says so on every app's status; `attn app runtime
+  restart` is the way back.
+  Design: docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md.

--- a/cmd/attn/app.go
+++ b/cmd/attn/app.go
@@ -324,13 +324,22 @@ func indentBlock(prefix, text string) string {
 	return b.String()
 }
 
+// appRuntimeNeverStarted is what a daemon that has never started a runtime says.
+//
+// "no *enabled* app", because a disabled app is never due a fact: a daemon whose
+// every app is switched off will never start a runtime, and the sentence has to
+// read as the settled state it is rather than as something that has not happened
+// yet. `attn app runtime status` carries the enabled count in the same answer, so
+// a reader who wants the number has it.
+const appRuntimeNeverStarted = "not started — no enabled app has been due a fact since this daemon came up"
+
 // appRuntimeCell says where this app's handlers actually run. It is one line
 // because `attn app runtime status` is the full picture; what belongs here is
 // the answer to "is my app not running because of my app, or because of the
 // runtime" — and a parked runtime is the loudest form of the second.
 func appRuntimeCell(info *protocol.AppRuntimeInfo) string {
 	if info == nil {
-		return "not started — no app has been due a fact since this daemon came up"
+		return appRuntimeNeverStarted
 	}
 	switch {
 	case info.Phase == "parked":

--- a/cmd/attn/app.go
+++ b/cmd/attn/app.go
@@ -56,6 +56,10 @@ func runApp() {
 		runAppSetEnabled(args, false)
 	case "remove":
 		runAppRemove(args)
+	case "logs":
+		runAppLogs(args)
+	case "runtime":
+		runAppRuntime(args)
 	default:
 		fmt.Fprintf(os.Stderr, "app: unknown command %q\n", os.Args[2])
 		writeAppHelp(os.Stderr)
@@ -90,7 +94,9 @@ commands:
         one, or the one you name. Builds nothing: the artifact is still on disk.
 
   dev <path>
-        apply on every change. Shows apply results and build errors.
+        apply on every change, and print every handler invocation as it runs.
+        Shows apply results and build errors too, so one window is the whole
+        edit-run-read loop.
 
   list [--json]
         every registered app: the version it runs, whether it is enabled, and
@@ -119,6 +125,21 @@ commands:
         row. Version history, the invocation log and every document under
         app/<name> survive — deleting your data is a separate act, and this is
         not it.
+
+  logs <name> [--lines N]
+        what the app printed. Every app's handlers run in one shared process, so
+        its output is tagged per app and this reads the tag back. The name
+        "runtime" means the whole log, tags and all — that is where a runtime
+        that will not start says why.
+
+  runtime status [--json]
+        the shared runtime every app's handlers run in: whether it is up, which
+        binary it launches, and how many apps are installed and enabled.
+
+  runtime restart
+        kill the running runtime and start a fresh one. Also the way back from
+        "parked", which is where a runtime that crash-looped ends up. There is
+        one runtime for every app, so this takes no app name.
 `)
 }
 
@@ -250,6 +271,15 @@ func runAppStatus(args []string) {
 			apps.ConsumerName(app.Name))
 	}
 	fmt.Printf("  documents:  %s\n", apps.Namespace(app.Name))
+	fmt.Printf("  runtime:    %s\n", appRuntimeCell(result.Runtime))
+	if result.Stall != nil {
+		// The stall clock is the only thing here that ends with the app being
+		// switched off, so it says when, not just that.
+		fmt.Printf("  stalled:    on event %d (%s) since %s, %d attempt(s)\n",
+			result.Stall.EventSeq, result.Stall.EventName, result.Stall.Since, result.Stall.Attempts)
+		fmt.Print(indentBlock("              ", result.Stall.LastError))
+		fmt.Printf("              disables itself at %s unless it succeeds first\n", result.Stall.DisablesAt)
+	}
 	fmt.Printf("  history:    %d version(s), %d invocation(s)\n", result.Versions, result.Invocations)
 	if len(result.Recent) == 0 {
 		fmt.Println("  recent:     no invocations recorded")
@@ -259,11 +289,57 @@ func runAppStatus(args []string) {
 	w := tabwriter.NewWriter(os.Stdout, 4, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "\tSTARTED\tVERSION\tSEQ\tEVENT\tHANDLER\tSTATUS\tMS\tERROR")
 	for _, inv := range result.Recent {
+		// One line per invocation, so the error is its first line only — a
+		// JavaScript stack pasted into a column destroys the table it is in. The
+		// stall block above carries the whole thing for the failure that matters,
+		// and `attn app logs <name>` has what the handler printed.
 		fmt.Fprintf(w, "\t%s\t%d\t%d\t%s\t%s\t%s\t%d\t%s\n",
 			inv.StartedAt, inv.VersionID, inv.EventSeq, inv.EventName, inv.Handler,
-			inv.Status, inv.DurationMs, inv.Error)
+			inv.Status, inv.DurationMs, firstErrorLine(inv.Error))
 	}
 	w.Flush()
+}
+
+// firstErrorLine is one row's worth of an error, with a marker when there is
+// more. Without the marker a reader has no way to know a stack was cut.
+func firstErrorLine(text string) string {
+	line, rest, found := strings.Cut(strings.TrimRight(text, "\n"), "\n")
+	if found && strings.TrimSpace(rest) != "" {
+		return line + " …"
+	}
+	return line
+}
+
+// indentBlock puts prefix in front of every line of text, so a multi-line value
+// in an aligned block stays inside its column. A handler's error carries the
+// JavaScript stack that threw it, which is the most useful thing on the screen
+// and also the only value here that is never one line.
+func indentBlock(prefix, text string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(strings.TrimRight(text, "\n"), "\n") {
+		b.WriteString(prefix)
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// appRuntimeCell says where this app's handlers actually run. It is one line
+// because `attn app runtime status` is the full picture; what belongs here is
+// the answer to "is my app not running because of my app, or because of the
+// runtime" — and a parked runtime is the loudest form of the second.
+func appRuntimeCell(info *protocol.AppRuntimeInfo) string {
+	if info == nil {
+		return "not started — no app has been due a fact since this daemon came up"
+	}
+	switch {
+	case info.Phase == "parked":
+		return "PARKED — it crash-looped and attn stopped restarting it, so no app's handlers run. `attn app runtime restart`"
+	case info.Connected:
+		return fmt.Sprintf("running (%s), generation %d", info.Phase, info.Generation)
+	default:
+		return fmt.Sprintf("%s — not connected yet", info.Phase)
+	}
 }
 
 func runAppSetEnabled(args []string, enabled bool) {

--- a/cmd/attn/app_build.go
+++ b/cmd/attn/app_build.go
@@ -194,7 +194,8 @@ func runAppDev(args []string) {
 	}
 	// Parse before watching so a directory that is not an app says so now rather
 	// than after the first save.
-	if _, err := appbuild.LoadManifest(abs); err != nil {
+	manifest, err := appbuild.LoadManifest(abs)
+	if err != nil {
 		appFail("dev", err)
 	}
 
@@ -208,14 +209,15 @@ func runAppDev(args []string) {
 	}
 
 	fmt.Printf("watching %s — every change is parsed, typechecked, bundled and applied\n", abs)
-	// Say what this does not show. Streaming what an app actually does needs the
-	// runtime that dispatches to it, which is not in this attn; promising it here
-	// would have the reader wait for output that cannot arrive.
-	fmt.Printf("shows apply results and build errors. Handler invocations are not streamed: nothing dispatches to apps yet — `attn app status <name>` is where that will appear.\n")
+	fmt.Printf("shows apply results, build errors, and every handler invocation as it runs\n")
 	fmt.Printf("ctrl-c to stop\n\n")
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+
+	stopWatching := make(chan struct{})
+	defer close(stopWatching)
+	go devWatchInvocations(manifest.Name, stopWatching)
 
 	devApply(abs)
 
@@ -266,6 +268,46 @@ func devApply(dir string) {
 	fmt.Printf("%s  ", stamp)
 	printApplied(result, res)
 	fmt.Printf("  in %s\n\n", time.Since(started).Round(time.Millisecond))
+}
+
+// devDialRetry is how long the invocation stream waits before dialling again
+// after the daemon closed on it. A `dev` session outlives a daemon restart —
+// installing a new build is a normal thing to do while writing an app — and a
+// stream that quietly never came back would read as "my handler stopped
+// running".
+const devDialRetry = 2 * time.Second
+
+// devWatchInvocations prints every invocation of the app being edited, beside
+// the apply results, until dev stops.
+//
+// It says nothing about a daemon it cannot reach. `attn app dev` builds and
+// typechecks perfectly well against a stopped daemon (the apply itself will say
+// so, loudly, with the socket path), and repeating that here every two seconds
+// would bury the build output this command exists to show.
+func devWatchInvocations(app string, stop <-chan struct{}) {
+	for {
+		_ = appClient().AppWatch(app, stop, func(inv protocol.AppInvocationInfo) bool {
+			fmt.Printf("%s  %s\n", time.Now().Format("15:04:05"), devInvocationLine(inv))
+			return true
+		})
+		select {
+		case <-stop:
+			return
+		case <-time.After(devDialRetry):
+		}
+	}
+}
+
+func devInvocationLine(inv protocol.AppInvocationInfo) string {
+	line := fmt.Sprintf("%s  %s(%s) in %dms", inv.Status, inv.Handler, inv.EventName, inv.DurationMs)
+	if inv.EventSubject != "" {
+		line = fmt.Sprintf("%s  %s(%s %s) in %dms",
+			inv.Status, inv.Handler, inv.EventName, inv.EventSubject, inv.DurationMs)
+	}
+	if inv.Error != "" {
+		line += "\n            " + inv.Error
+	}
+	return line
 }
 
 // devRelevant filters the noise. node_modules and .git are large and never part

--- a/cmd/attn/app_runtime.go
+++ b/cmd/attn/app_runtime.go
@@ -130,7 +130,12 @@ func runAppRuntimeStatus(args []string) {
 	if result.Runtime == nil {
 		// Never started is not stopped. Saying "stopped" for a daemon that has had
 		// no reason to start one would send the reader looking for a fault.
-		fmt.Println("  state:    not started — no app has been due a fact since this daemon came up")
+		fmt.Printf("  state:    %s\n", appRuntimeNeverStarted)
+		if result.Apps > 0 && result.AppsEnabled == 0 {
+			// The one case where "has not happened yet" is wrong: this daemon will
+			// never start a runtime, and nothing about waiting will change that.
+			fmt.Printf("            every installed app is disabled, so nothing will start one — `attn app enable <name>`\n")
+		}
 	} else {
 		writeAppRuntimeInfo(*result.Runtime)
 	}

--- a/cmd/attn/app_runtime.go
+++ b/cmd/attn/app_runtime.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/victorarias/attn/internal/apps"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// `attn app logs` and `attn app runtime` — the two commands that are about the
+// shared process rather than about one app.
+//
+// Every installed app's handlers run in one supervised Bun sidecar. That is the
+// design, not an implementation detail leaking out: isolation between apps is
+// failure attribution, not an OS boundary. So "why is my app not doing
+// anything" has two possible answers — the app, or the runtime — and these are
+// how a reader tells them apart.
+
+func runAppLogs(args []string) {
+	name := ""
+	lines := 0
+	for i := 0; i < len(args); i++ {
+		switch arg := args[i]; {
+		case arg == "-h", arg == "--help":
+			writeAppHelp(os.Stdout)
+			return
+		case arg == "--lines":
+			i++
+			if i >= len(args) {
+				appFail("logs", fmt.Errorf("--lines needs a number"))
+			}
+			n, err := strconv.Atoi(args[i])
+			if err != nil || n <= 0 {
+				appFail("logs", fmt.Errorf("--lines takes a positive number; got %q", args[i]))
+			}
+			lines = n
+		case strings.HasPrefix(arg, "--lines="):
+			n, err := strconv.Atoi(strings.TrimPrefix(arg, "--lines="))
+			if err != nil || n <= 0 {
+				appFail("logs", fmt.Errorf("--lines takes a positive number; got %q", arg))
+			}
+			lines = n
+		case strings.HasPrefix(arg, "-"):
+			appFail("logs", fmt.Errorf("unknown flag %q", arg))
+		default:
+			if name != "" {
+				appFail("logs", fmt.Errorf("takes one app name; got %q and %q", name, arg))
+			}
+			name = arg
+		}
+	}
+	if name == "" {
+		fmt.Fprintln(os.Stderr, "usage: attn app logs <name> [--lines N]")
+		fmt.Fprintln(os.Stderr, "       attn app logs runtime   # the whole shared log")
+		os.Exit(2)
+	}
+	// `runtime` is not an app and never can be — internal/apps reserves it — so
+	// the name check has to let it through here.
+	if name != appRuntimeName {
+		if err := apps.ValidateName(name); err != nil {
+			appFail("logs", err)
+		}
+	}
+
+	result, err := appClient().AppLogs(name, lines)
+	if err != nil {
+		appFail("logs", err)
+	}
+	if len(result.Lines) == 0 {
+		// Naming the file is the actionable half: an empty answer can mean the app
+		// has never printed anything, or that the runtime has never started.
+		fmt.Printf("no output from %s yet (%s)\n", name, result.Path)
+		return
+	}
+	if result.Truncated {
+		fmt.Printf("... older lines dropped; %s has the rest\n", result.Path)
+	}
+	for _, line := range result.Lines {
+		fmt.Println(line)
+	}
+}
+
+// appRuntimeName is the shared runtime's name on every surface: the supervised
+// child, the log file, and `attn app logs runtime`.
+const appRuntimeName = "runtime"
+
+func runAppRuntime(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: attn app runtime status|restart")
+		os.Exit(2)
+	}
+	rest := args[1:]
+	switch args[0] {
+	case "status":
+		runAppRuntimeStatus(rest)
+	case "restart":
+		runAppRuntimeRestart(rest)
+	case "-h", "--help":
+		writeAppHelp(os.Stdout)
+	default:
+		appFail("runtime", fmt.Errorf("unknown command %q; it is status or restart", args[0]))
+	}
+}
+
+func runAppRuntimeStatus(args []string) {
+	asJSON := false
+	for _, arg := range args {
+		switch arg {
+		case "--json":
+			asJSON = true
+		case "-h", "--help":
+			writeAppHelp(os.Stdout)
+			return
+		default:
+			appFail("runtime status", fmt.Errorf("unknown argument %q; runtime status takes no app name — there is one runtime for every app", arg))
+		}
+	}
+	result, err := appClient().AppRuntimeStatus()
+	if err != nil {
+		appFail("runtime status", err)
+	}
+	if asJSON {
+		writeJSON(result)
+		return
+	}
+	fmt.Println("app runtime")
+	if result.Runtime == nil {
+		// Never started is not stopped. Saying "stopped" for a daemon that has had
+		// no reason to start one would send the reader looking for a fault.
+		fmt.Println("  state:    not started — no app has been due a fact since this daemon came up")
+	} else {
+		writeAppRuntimeInfo(*result.Runtime)
+	}
+	fmt.Printf("  apps:     %d installed, %d enabled\n", result.Apps, result.AppsEnabled)
+	if result.HostPath != nil {
+		fmt.Printf("  binary:   %s\n", *result.HostPath)
+	}
+	if result.HostError != nil {
+		fmt.Printf("  binary:   NOT FOUND — %s\n", *result.HostError)
+	}
+	fmt.Printf("  log:      %s\n", result.LogPath)
+}
+
+func writeAppRuntimeInfo(info protocol.AppRuntimeInfo) {
+	connected := "not connected"
+	if info.Connected {
+		connected = "connected"
+		if info.Pid != nil {
+			connected = fmt.Sprintf("connected, pid %d", *info.Pid)
+		}
+	}
+	fmt.Printf("  state:    %s (%s), generation %d\n", info.Phase, connected, info.Generation)
+	if info.Phase == "parked" {
+		fmt.Printf("            attn gave up restarting it after %d attempts; no app's handlers are running.\n", info.RestartAttempt)
+		fmt.Printf("            `attn app runtime restart` tries again.\n")
+	} else if info.RestartAttempt > 0 {
+		fmt.Printf("            restart attempt %d\n", info.RestartAttempt)
+	}
+	if info.StartedAt != nil {
+		fmt.Printf("  started:  %s\n", *info.StartedAt)
+	}
+	if info.NextRestartAt != nil {
+		fmt.Printf("  retry at: %s\n", *info.NextRestartAt)
+	}
+	if info.LastExit != nil {
+		fmt.Printf("  last exit: %s\n", *info.LastExit)
+	}
+}
+
+// appRuntimeRestartTakesNoName is the teaching error. Somebody typing an app
+// name here believes apps restart individually, and the answer is the design,
+// not the syntax — so it says what the runtime is before it says what to type.
+func appRuntimeRestartTakesNoName(arg string) error {
+	return fmt.Errorf(
+		"takes no app name, and %q looks like one. Every app's handlers run in one shared runtime, so restarting it restarts them all — there is nothing per-app to restart. To stop one app, `attn app disable %s`.",
+		arg, arg)
+}
+
+func runAppRuntimeRestart(args []string) {
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help":
+			writeAppHelp(os.Stdout)
+			return
+		default:
+			appFail("runtime restart", appRuntimeRestartTakesNoName(arg))
+		}
+	}
+	result, err := appClient().AppRuntimeRestart()
+	if err != nil {
+		appFail("runtime restart", err)
+	}
+	switch result.Was {
+	case "parked":
+		fmt.Println("revived the app runtime: it was parked after crash-looping, and is starting again")
+	case "stopped":
+		fmt.Println("started the app runtime")
+	default:
+		fmt.Printf("restarted the app runtime (was %s)\n", result.Was)
+	}
+	writeAppRuntimeInfo(result.Runtime)
+}

--- a/cmd/attn/app_runtime_test.go
+++ b/cmd/attn/app_runtime_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// `attn app runtime` is about the shared process, and the commands that could be
+// mistaken for per-app ones have to say why they are not.
+
+func TestRuntimeRestartRefusesAnAppNameAndExplainsWhy(t *testing.T) {
+	err := appRuntimeRestartTakesNoName("greeter")
+	if err == nil {
+		t.Fatal("naming an app was accepted")
+	}
+	msg := err.Error()
+	// Three things a reader needs: that the name is the problem, why there is
+	// nothing per-app to restart, and what to run instead.
+	for _, want := range []string{`"greeter"`, "one shared runtime", "attn app disable greeter"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("the refusal does not contain %q: %s", want, msg)
+		}
+	}
+}
+
+// A runtime the daemon has never started is rendered as that, not as "stopped":
+// the two send a reader to different places.
+func TestRuntimeCellDistinguishesNeverStartedFromParked(t *testing.T) {
+	if got := appRuntimeCell(nil); !strings.Contains(got, "not started") {
+		t.Fatalf("a runtime that has never run renders as %q", got)
+	}
+	parked := appRuntimeCell(&protocol.AppRuntimeInfo{Phase: "parked", Generation: 4})
+	if !strings.Contains(parked, "PARKED") || !strings.Contains(parked, "attn app runtime restart") {
+		t.Fatalf("a parked runtime renders as %q, which does not name the way back", parked)
+	}
+	running := appRuntimeCell(&protocol.AppRuntimeInfo{Phase: "connected", Connected: true, Generation: 2})
+	if !strings.Contains(running, "running") {
+		t.Fatalf("a connected runtime renders as %q", running)
+	}
+	starting := appRuntimeCell(&protocol.AppRuntimeInfo{Phase: "starting", Generation: 1})
+	if !strings.Contains(starting, "not connected") {
+		t.Fatalf("a runtime that has not dialed back renders as %q", starting)
+	}
+}
+
+// A handler's error carries the JavaScript stack that threw it. Both places it
+// is rendered have to survive that: the aligned table takes one line, the stall
+// block takes all of them inside its column.
+func TestAMultiLineHandlerErrorSurvivesBothRenderings(t *testing.T) {
+	stack := "Error: the ticket store is unreachable\n    at onTicket (bundle.js:5:18)\n    at M (native:6:1)"
+
+	row := firstErrorLine(stack)
+	if strings.Contains(row, "\n") {
+		t.Fatalf("the table cell is multi-line: %q", row)
+	}
+	if !strings.HasSuffix(row, "…") {
+		t.Fatalf("the table cell %q does not say it was cut", row)
+	}
+
+	block := indentBlock("  > ", stack)
+	for _, line := range strings.Split(strings.TrimRight(block, "\n"), "\n") {
+		if !strings.HasPrefix(line, "  > ") {
+			t.Fatalf("a continuation line escaped its column: %q", line)
+		}
+	}
+	if got := firstErrorLine("just the one line"); got != "just the one line" {
+		t.Fatalf("a single-line error was changed to %q", got)
+	}
+}

--- a/cmd/attn/app_runtime_test.go
+++ b/cmd/attn/app_runtime_test.go
@@ -28,8 +28,15 @@ func TestRuntimeRestartRefusesAnAppNameAndExplainsWhy(t *testing.T) {
 // A runtime the daemon has never started is rendered as that, not as "stopped":
 // the two send a reader to different places.
 func TestRuntimeCellDistinguishesNeverStartedFromParked(t *testing.T) {
-	if got := appRuntimeCell(nil); !strings.Contains(got, "not started") {
+	got := appRuntimeCell(nil)
+	if !strings.Contains(got, "not started") {
 		t.Fatalf("a runtime that has never run renders as %q", got)
+	}
+	// A disabled app is never due a fact, so a daemon whose apps are all off will
+	// never start a runtime. Saying "no app has been due a fact" reads as
+	// not-yet when it is in fact settled.
+	if !strings.Contains(got, "no enabled app") {
+		t.Fatalf("the never-started sentence is not honest about disabled apps: %q", got)
 	}
 	parked := appRuntimeCell(&protocol.AppRuntimeInfo{Phase: "parked", Generation: 4})
 	if !strings.Contains(parked, "PARKED") || !strings.Contains(parked, "attn app runtime restart") {

--- a/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
+++ b/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
@@ -365,7 +365,7 @@ fully-CI'd, fully-reviewed merge at the end.
    consumers wired to slice 1, auto-disable, `logs`. The compiled host
    binary cross-compiles for linux amd64/arm64 beside the Go daemon's
    existing cross targets — tracked here so the stage cannot close
-   darwin-only.
+   darwin-only. *Shipped:* see "Slice 5 receipts" below.
 6. **Exit proof** — the roadmap's exit, run live: an agent writes a real app
    in a scaffolded directory, applies it, sees invocations in the log,
    breaks it and watches auto-disable park it, fixes and re-enables it,
@@ -377,6 +377,65 @@ Verification: A4 touches daemon lifecycle, protocol, and background runners
 — live verification in a running non-production app is mandatory for slices
 3–6; slices 1–2 are daemon-internal and carry harness tests plus the live
 proof at slice 6.
+
+### Slice 5 receipts
+
+Measured 2026-08-09 on an M-series Mac, throwaway profile `a4rt5` installed
+from the branch, against a scaffolded app (`ticketwatch`) subscribing to
+`ticket.*` and writing a document per fact.
+
+**Cold start — `appRuntimeConnectWait = 10s`.** The runtime starts lazily, on
+the first fact an app is due, so the first dispatch after a daemon start pays
+the whole cold start. First invocation end to end — spawn the compiled host,
+connect back over the unix socket, hello, import the bundle, run the handler,
+write a document — was **77ms**. The ten-second wait is ~130× that. A delivery
+that hits it stalls and retries rather than failing anything permanently.
+
+**Handler duration — `appDispatchTimeout = 60s`.** Warm invocations of the
+same document-writing handler ran at **0–1ms** (n=10, one burst), and the
+in-`app dev` measurement agreed at 1ms. Sixty seconds is between four and five
+orders of magnitude past that, which is the point: the timeout exists only so a
+handler awaiting something that never resolves becomes a failure the app owns,
+instead of holding its delivery open forever and pinning the log's retention
+floor for everybody.
+
+**Invocation log size — `AppInvocationRetention = 30d` *and*
+`AppInvocationsPerApp = 20,000`.** Measured over 7.5 days of Victor's
+production event log (275,845 facts): the loudest fact by a wide margin is
+`session.state.changed` at **1,141/hour** — and it is what a scaffolded app
+subscribes to out of the box. Thirty days of that is ~820,000 invocation rows,
+well over a hundred megabytes for a single app, on a database that is 51MB
+today. The quietest domain an app would realistically watch, `ticket.*`, runs
+at **27/day** — three orders of magnitude below.
+
+So the age window cannot bound this table on its own, and a second limit is not
+redundancy: the age window says when a row stops being *useful* (an invocation
+whose event has aged off the durable log cannot be re-read against it, which is
+why it matches the bus's own `DefaultRetention`), and the per-app cap says how
+large the log is allowed to *get*. 20,000 rows is ~17 hours of the loudest
+possible app — a whole working day of "what did it do this morning" — and about
+4MB. At the ticket rate it is two years, so for anything quiet the age window
+trims first and the cap is never felt.
+
+**Backoff, observed rather than asserted.** A handler made to throw produced
+attempts at 22:57:07, :11, :19 and :35 on the same event seq — 4s, 8s, 16s —
+with the consumer's cursor parked one behind throughout, then version 4 of the
+app succeeded on that same seq and the cursor advanced. Stall-don't-skip, live.
+
+**Fixed on the way through**, both found by doing the verification rather than
+by a test:
+
+- `UNAME_S` was referenced by three Makefile recipes and defined by none, so it
+  expanded to empty and `make install-daemon` skipped code signing entirely.
+  The copied binary kept its ad-hoc linker signature inside a properly signed
+  bundle and macOS answered `daemon ensure` with `Killed: 9`. The daemon-only
+  install tier did not work for anyone; now it does.
+- `scripts/build-app-runtime-host.sh` resolved a relative `stage_dir` against
+  the wrong directory: it `cd`s to `apphost/` before invoking bun, and bun
+  reads `--outfile` from its own cwd. Both Linux cross-builds reported success
+  and left an empty tree, writing the ELF under `apphost/dist/` instead. The
+  native build was unaffected because its default stage dir is absolute — which
+  is exactly how a cross-only break stays invisible.
 
 ## Out of scope
 

--- a/internal/appbuild/scaffold.go
+++ b/internal/appbuild/scaffold.go
@@ -186,6 +186,7 @@ You can write the whole thing from this file. Nothing else needs reading.
     attn app apply .        build and install this app
     attn app dev .          the same, on every save
     attn app status %s
+    attn app logs %s        what the app printed
     attn app rollback %s
     attn app disable %s     stop delivering to it, keep it installed
 
@@ -228,9 +229,15 @@ document body is stored and read back untouched.
 ## Failure
 
 A handler that throws fails that delivery. attn retries it with backoff rather
-than skipping it, records every attempt, and if the app stays stuck on one event
-long enough, disables the app — one broken app must not hold everyone's event log
-open. `+"`attn app enable %s`"+` puts it back.
+than skipping it, records every attempt, and if the app stays stuck on the same
+event for fifteen minutes, disables the app — one broken app must not hold
+everyone's event log open. `+"`attn app enable %s`"+` puts it back, with a clean
+slate.
+
+Every app's handlers run in one shared process, so anything you print goes to a
+log attn tags per app: `+"`attn app logs %s`"+` reads your lines back, and
+`+"`attn app logs runtime`"+` shows the whole thing — which is where a runtime
+that will not start says why.
 
 ## Rules worth knowing before you start
 
@@ -243,5 +250,5 @@ open. `+"`attn app enable %s`"+` puts it back.
   version, and `+"`attn app rollback`"+` is a pointer move, not a rebuild.
 - attn does not remember where this directory is. It is yours; keep it wherever
   you keep code.
-`, name, name, name, name, SDKModule, name)
+`, name, name, name, name, name, SDKModule, name, name)
 }

--- a/internal/apps/apps.go
+++ b/internal/apps/apps.go
@@ -17,6 +17,8 @@ package apps
 import (
 	"fmt"
 	"regexp"
+	"sort"
+	"strings"
 )
 
 // nameRe is the app-name rule: lowercase letters, digits and dashes, starting
@@ -32,6 +34,43 @@ var nameRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 // attn's longest today is "approval-gate" at 13.
 const MaxNameLength = 64
 
+// reserved is the set of names an app may not take. Two groups, one rule.
+//
+// `runtime` is the shared sidecar's own name: it is the supervised child, the
+// subject of `app.runtime.*` diagnostics and the stem of `runtime.log`. The rest
+// are the `attn app` subcommands. The grammar never confuses either group with an
+// app — a subcommand and its argument sit in different positions — but every
+// human-facing surface would: "app runtime parked" and `attn app logs runtime`
+// stop having one meaning the moment an app can be called that.
+//
+// Refusing them costs nothing while zero real apps exist. Refusing them later is
+// a migration, so the list is deliberately generous rather than minimal.
+var reserved = map[string]string{
+	"runtime":  "the shared app runtime is called `runtime`",
+	"new":      "it is an `attn app` subcommand",
+	"apply":    "it is an `attn app` subcommand",
+	"rollback": "it is an `attn app` subcommand",
+	"enable":   "it is an `attn app` subcommand",
+	"disable":  "it is an `attn app` subcommand",
+	"remove":   "it is an `attn app` subcommand",
+	"list":     "it is an `attn app` subcommand",
+	"status":   "it is an `attn app` subcommand",
+	"logs":     "it is an `attn app` subcommand",
+	"dev":      "it is an `attn app` subcommand",
+}
+
+// ReservedNames lists what ValidateName refuses, sorted. It is exported so an
+// error, a test or a scaffold can name the whole set rather than restate part of
+// it.
+func ReservedNames() []string {
+	out := make([]string, 0, len(reserved))
+	for name := range reserved {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // ValidateName reports whether a string can be an app name, and says what is
 // wrong when it cannot.
 func ValidateName(name string) error {
@@ -43,6 +82,10 @@ func ValidateName(name string) error {
 	}
 	if !nameRe.MatchString(name) {
 		return fmt.Errorf("app name %q must be lowercase letters, digits and dashes, starting with a letter or digit (for example approval-gate)", name)
+	}
+	if why, taken := reserved[name]; taken {
+		return fmt.Errorf("app name %q is reserved because %s; an app named %q would make every log line, fact and notification about it ambiguous. Reserved names: %s",
+			name, why, name, strings.Join(ReservedNames(), ", "))
 	}
 	return nil
 }

--- a/internal/apps/apps_test.go
+++ b/internal/apps/apps_test.go
@@ -45,6 +45,42 @@ func TestNameErrorsSayWhatIsWrong(t *testing.T) {
 	}
 }
 
+// The reserved set is refused by the same rule every surface uses, so a manifest,
+// the CLI and the daemon cannot disagree about whether `runtime` is an app.
+func TestReservedNamesAreRefused(t *testing.T) {
+	for _, name := range ReservedNames() {
+		err := ValidateName(name)
+		if err == nil {
+			t.Fatalf("ValidateName(%q) = nil, want a refusal", name)
+		}
+		// The refusal teaches: why this one, and what else is taken.
+		if !strings.Contains(err.Error(), "reserved") {
+			t.Errorf("ValidateName(%q) does not say the name is reserved: %v", name, err)
+		}
+		for _, other := range ReservedNames() {
+			if !strings.Contains(err.Error(), other) {
+				t.Errorf("ValidateName(%q) does not list reserved name %q: %v", name, other, err)
+			}
+		}
+	}
+}
+
+// `runtime` is the one that is not a subcommand: it is the supervised child's own
+// name, and the reason the whole list exists. Naming it explicitly keeps a future
+// edit to the map from quietly dropping it.
+func TestRuntimeIsReserved(t *testing.T) {
+	if err := ValidateName("runtime"); err == nil {
+		t.Fatal("an app could be named runtime, which collides with the shared runtime")
+	}
+	// A name that merely contains a reserved word is still fine — the rule is the
+	// whole name, not a substring.
+	for _, ok := range []string{"runtime-monitor", "my-runtime", "statusboard"} {
+		if err := ValidateName(ok); err != nil {
+			t.Errorf("ValidateName(%q) = %v, want nil", ok, err)
+		}
+	}
+}
+
 func TestDerivedIdentities(t *testing.T) {
 	if got := ConsumerName("approval-gate"); got != "app:approval-gate" {
 		t.Errorf("ConsumerName = %q", got)

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -190,7 +190,6 @@ type Bus struct {
 
 type durable struct {
 	name    string
-	filter  Filter
 	handler Handler
 
 	wake chan struct{}
@@ -209,7 +208,11 @@ type durable struct {
 	done     chan struct{}
 	launched bool
 
-	mu       sync.Mutex
+	mu sync.Mutex
+	// filter is under the same lock as the position because SetFilter changes it
+	// while the delivery loop is reading it — an app's subscriptions move when a
+	// new version is applied, and the loop must not be racing the change.
+	filter   Filter
 	cursor   int64
 	enabled  bool
 	stalled  string
@@ -548,6 +551,77 @@ func (b *Bus) Unregister(name string) error {
 	return nil
 }
 
+// SetFilter changes what a registered consumer receives, keeping its cursor and
+// its enabled bit.
+//
+// It exists because a consumer's subscriptions can outlive neither the consumer
+// nor its position: an app declares its event patterns in its manifest, and
+// applying a new version can change them. Unregister-then-Register would express
+// the same intent and delete the cursor on the way through — the app would resume
+// at head and silently skip everything published while it was being updated.
+// Register refuses a name it already serves, so this is the only way to say "same
+// consumer, different subscriptions".
+//
+// A name that is not registered here is an error rather than a silent no-op: the
+// caller believes it is changing a live consumer's behavior, and learning
+// otherwise from later missing deliveries is the worst way to find out.
+func (b *Bus) SetFilter(name string, filter Filter) error {
+	b.mu.Lock()
+	var found *durable
+	for _, d := range b.durables {
+		if d.name == name {
+			found = d
+			break
+		}
+	}
+	started := b.started
+	b.mu.Unlock()
+	if found == nil {
+		return fmt.Errorf("bus: consumer %s is not registered, so its filter cannot be changed", name)
+	}
+	// Persist first, then swap what the loop reads. The other order would have the
+	// loop filtering by a rule no restart would reproduce if the write failed.
+	//
+	// Before Start there is nothing persisted to correct: Register only holds the
+	// consumer in memory, and Start writes every one of them with the filter it
+	// carries at that moment — which is this one.
+	if b.store != nil && started {
+		existing, ok, err := b.store.GetConsumer(name)
+		if err != nil {
+			return fmt.Errorf("bus: reading consumer %s to change its filter: %w", name, err)
+		}
+		if !ok {
+			return fmt.Errorf("bus: consumer %s has no registration to change", name)
+		}
+		if err := b.store.SaveConsumer(Consumer{
+			Name:    name,
+			Cursor:  existing.Cursor,
+			Filter:  filter.String(),
+			Enabled: existing.Enabled,
+		}, b.now()); err != nil {
+			return fmt.Errorf("bus: saving the filter of consumer %s: %w", name, err)
+		}
+	}
+	found.setFilter(filter)
+	return nil
+}
+
+// Registered reports whether this process serves a consumer under name.
+//
+// It is how a caller chooses between Register and SetFilter without guessing
+// from an error string: those two are not interchangeable — one mints a cursor,
+// the other preserves it — and picking the wrong one is silent.
+func (b *Bus) Registered(name string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, d := range b.durables {
+		if d.name == name {
+			return true
+		}
+	}
+	return false
+}
+
 // newDurable builds a consumer and its cancel scope. Callers that also touch the
 // consumer set hold b.mu; the bus context it reads is fixed at construction.
 func (b *Bus) newDurable(name string, filter Filter, h Handler) *durable {
@@ -657,7 +731,7 @@ func (b *Bus) initConsumer(d *durable, head int64) error {
 		if err := b.store.SaveConsumer(Consumer{
 			Name:    d.name,
 			Cursor:  head,
-			Filter:  d.filter.String(),
+			Filter:  d.filterExpr(),
 			Enabled: true,
 		}, now); err != nil {
 			return fmt.Errorf("bus: registering consumer %s: %w", d.name, err)
@@ -669,7 +743,7 @@ func (b *Bus) initConsumer(d *durable, head int64) error {
 	if err := b.store.SaveConsumer(Consumer{
 		Name:    d.name,
 		Cursor:  existing.Cursor,
-		Filter:  d.filter.String(),
+		Filter:  d.filterExpr(),
 		Enabled: existing.Enabled,
 	}, now); err != nil {
 		return fmt.Errorf("bus: updating consumer %s: %w", d.name, err)
@@ -799,7 +873,7 @@ func (b *Bus) drain(d *durable) error {
 				}
 				return nil
 			}
-			if !d.filter.Matches(ev.Name) {
+			if !d.matches(ev.Name) {
 				// Unwanted events still advance the cursor, batched into one write
 				// at the next matching event or at the end of the batch.
 				skipped = ev.Seq
@@ -1061,6 +1135,24 @@ func (b *Bus) Status() (Status, error) {
 		out.Consumers = append(out.Consumers, cs)
 	}
 	return out, nil
+}
+
+func (d *durable) matches(name string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.filter.Matches(name)
+}
+
+func (d *durable) filterExpr() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.filter.String()
+}
+
+func (d *durable) setFilter(f Filter) {
+	d.mu.Lock()
+	d.filter = f
+	d.mu.Unlock()
 }
 
 func (d *durable) position() int64 {

--- a/internal/bus/filter.go
+++ b/internal/bus/filter.go
@@ -61,6 +61,15 @@ func (f Filter) Matches(name string) bool {
 	return false
 }
 
+// MatchPattern reports whether one pattern selects an event name.
+//
+// Exported because a subscriber sometimes has to answer a second question about
+// the same patterns — the app runtime resolves which of an app's declared
+// subscriptions a delivered fact came from, so it can name the handler to run.
+// A private copy of this rule in that caller would be free to drift from the
+// filter that decided the delivery in the first place.
+func MatchPattern(pattern, name string) bool { return matchPattern(pattern, name) }
+
 func matchPattern(pattern, name string) bool {
 	switch {
 	case pattern == "*" || pattern == "":

--- a/internal/bus/lifecycle_test.go
+++ b/internal/bus/lifecycle_test.go
@@ -3,6 +3,7 @@ package bus
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -512,4 +513,83 @@ func TestRegisterAfterStartRollsBackWhenRegistrationFails(t *testing.T) {
 		t.Fatalf("Publish: %v", err)
 	}
 	waitFor(t, "the retried registration to deliver", func() bool { return rec.count() >= 1 })
+}
+
+// An app's subscriptions change when a new version is applied, and the consumer
+// serving it must follow without losing its place. This is the property that
+// rules out unregister-then-register: that pair expresses the same intent and
+// deletes the cursor on the way through, so the app would resume at head and skip
+// whatever was published while it was being updated.
+func TestSetFilterChangesDeliveryAndKeepsTheCursor(t *testing.T) {
+	s := newMemStore()
+	b := testBus(t, s)
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	rec := newRecorder()
+	if err := b.Register("app:notes", Filter{"ticket.*"}, rec.handle); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if _, err := b.Publish("ticket.commented", "t1", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	waitFor(t, "the first subscription to deliver", func() bool { return rec.count() >= 1 })
+
+	before, ok, err := s.GetConsumer("app:notes")
+	if err != nil || !ok {
+		t.Fatalf("reading the consumer: found=%v err=%v", ok, err)
+	}
+
+	if err := b.SetFilter("app:notes", Filter{"session.*"}); err != nil {
+		t.Fatalf("SetFilter: %v", err)
+	}
+
+	after, ok, err := s.GetConsumer("app:notes")
+	if err != nil || !ok {
+		t.Fatalf("reading the consumer after SetFilter: found=%v err=%v", ok, err)
+	}
+	if after.Cursor != before.Cursor {
+		t.Fatalf("cursor moved from %d to %d; changing subscriptions must not move a consumer's position", before.Cursor, after.Cursor)
+	}
+	if after.Filter != "session.*" {
+		t.Fatalf("persisted filter is %q, want session.*; a filter that is not persisted is one a restart forgets", after.Filter)
+	}
+	if !after.Enabled {
+		t.Fatal("SetFilter cleared the enabled bit; the kill switch is not its business")
+	}
+
+	// The new subscription is what the live loop uses, and the old one is gone.
+	if _, err := b.Publish("ticket.commented", "t2", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if _, err := b.Publish("session.state.changed", "s1", nil); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	waitFor(t, "the new subscription to deliver", func() bool { return rec.count() >= 2 })
+
+	names, _ := rec.snapshot()
+	if len(names) != 2 || names[1] != "session.state.changed" {
+		t.Fatalf("delivered %v; want the second delivery to be the newly subscribed fact and the unsubscribed one to be skipped", names)
+	}
+}
+
+// A caller changing the filter of a consumer nobody serves is told so. Answering
+// success would let an app believe its new subscriptions are live and learn
+// otherwise only from deliveries that never arrive.
+func TestSetFilterRefusesAnUnregisteredConsumer(t *testing.T) {
+	b := testBus(t, newMemStore())
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	err := b.SetFilter("app:ghost", All)
+	if err == nil {
+		t.Fatal("SetFilter on an unregistered consumer returned nil")
+	}
+	if !strings.Contains(err.Error(), "app:ghost") {
+		t.Errorf("the refusal does not name the consumer: %v", err)
+	}
 }

--- a/internal/client/apps.go
+++ b/internal/client/apps.go
@@ -1,6 +1,12 @@
 package client
 
-import "github.com/victorarias/attn/internal/protocol"
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
 
 // The app registry's client surface. Everything goes through the daemon, like
 // the document store's and unlike `attn bus`: removing an app has to stop a
@@ -77,4 +83,82 @@ func (c *Client) AppRollback(name string, versionID int) (*protocol.AppRollbackR
 		return nil, err
 	}
 	return resp.AppRollbackResult, nil
+}
+
+// AppLogs reads the shared runtime's captured output, filtered to one app. The
+// name `runtime` means the whole log, which is where a startup failure appears.
+func (c *Client) AppLogs(name string, lines int) (*protocol.AppLogsResult, error) {
+	msg := protocol.AppLogsMessage{Cmd: protocol.CmdAppLogs, Name: name}
+	if lines > 0 {
+		msg.Lines = protocol.Ptr(lines)
+	}
+	resp, err := c.send(msg)
+	if err != nil {
+		return nil, err
+	}
+	return resp.AppLogsResult, nil
+}
+
+func (c *Client) AppRuntimeStatus() (*protocol.AppRuntimeStatusResult, error) {
+	resp, err := c.send(protocol.AppRuntimeStatusMessage{Cmd: protocol.CmdAppRuntimeStatus})
+	if err != nil {
+		return nil, err
+	}
+	return resp.AppRuntimeStatusResult, nil
+}
+
+func (c *Client) AppRuntimeRestart() (*protocol.AppRuntimeRestartResult, error) {
+	resp, err := c.send(protocol.AppRuntimeRestartMessage{Cmd: protocol.CmdAppRuntimeRestart})
+	if err != nil {
+		return nil, err
+	}
+	return resp.AppRuntimeRestartResult, nil
+}
+
+// AppWatch streams an app's invocations until onInvocation returns false, the
+// daemon closes the connection, or stop is closed.
+//
+// It keeps its own connection rather than going through send: this is the one
+// app command whose answer is a stream, and `attn app dev` runs it beside a
+// filesystem watcher for as long as the developer is editing.
+func (c *Client) AppWatch(name string, stop <-chan struct{}, onInvocation func(protocol.AppInvocationInfo) bool) error {
+	conn, err := net.Dial("unix", c.socketPath)
+	if err != nil {
+		return explainConnectError(c.socketPath, err)
+	}
+	defer conn.Close()
+
+	if err := json.NewEncoder(conn).Encode(protocol.AppWatchMessage{Cmd: protocol.CmdAppWatch, Name: name}); err != nil {
+		return fmt.Errorf("send app_watch: %w", err)
+	}
+	// Closing the connection is what unblocks the decode below; there is no
+	// cancellable read on a net.Conn short of a deadline nobody would pick.
+	if stop != nil {
+		done := make(chan struct{})
+		defer close(done)
+		go func() {
+			select {
+			case <-stop:
+				_ = conn.Close()
+			case <-done:
+			}
+		}()
+	}
+
+	decoder := json.NewDecoder(conn)
+	for {
+		var resp protocol.Response
+		if err := decoder.Decode(&resp); err != nil {
+			return nil
+		}
+		if !resp.Ok {
+			return fmt.Errorf("%s", protocol.Deref(resp.Error))
+		}
+		if resp.AppWatchResult == nil {
+			continue
+		}
+		if !onInvocation(resp.AppWatchResult.Invocation) {
+			return nil
+		}
+	}
 }

--- a/internal/daemon/app_apply.go
+++ b/internal/daemon/app_apply.go
@@ -105,6 +105,11 @@ func (d *Daemon) handleAppApply(conn net.Conn, msg *protocol.AppApplyMessage) {
 	if source := strings.TrimSpace(protocol.Deref(msg.SourcePath)); source != "" {
 		d.logf("app apply %s: version %d (%s) from %s", name, version.ID, appbuild.ShortHash(hash), source)
 	}
+	// Subscriptions and collections both come from the manifest, so both can
+	// differ from the version before this one. Re-pointing here rather than off
+	// the fact keeps it synchronous with the apply: the reply the author reads
+	// means the new version is already the one that will run.
+	d.syncAppRuntimeForVersion(name)
 	d.publishAppVersionChanged(name, version, previous, appVersionReasonApply)
 
 	result := protocol.AppApplyResult{
@@ -157,6 +162,7 @@ func (d *Daemon) handleAppRollback(conn net.Conn, msg *protocol.AppRollbackMessa
 		d.sendError(conn, fmt.Sprintf("app rollback %s: %v", name, err))
 		return
 	}
+	d.syncAppRuntimeForVersion(name)
 	d.publishAppVersionChanged(name, target, app.CurrentVersionID, appVersionReasonRollback)
 
 	result := protocol.AppRollbackResult{

--- a/internal/daemon/app_autodisable_test.go
+++ b/internal/daemon/app_autodisable_test.go
@@ -1,0 +1,308 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/apps"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// The auto-disable clock: one rule, one number, and everything that must NOT
+// trip it.
+//
+// The clock measures fifteen minutes of wall time stuck on the same event, so
+// every test here drives an injected clock. A test that waited out the real
+// window would take a quarter of an hour and prove less, and one that shortened
+// the constant would be testing a number the product does not ship.
+
+// appTestClock is the daemon's clock for these tests, moved by hand.
+type appTestClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newAppTestClock(d *Daemon) *appTestClock {
+	clock := &appTestClock{now: time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)}
+	d.appClock = clock.Now
+	return clock
+}
+
+func (c *appTestClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *appTestClock) advance(by time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(by)
+	c.mu.Unlock()
+}
+
+func appEnabled(t *testing.T, d *Daemon, name string) bool {
+	t.Helper()
+	consumer, ok, err := d.store.GetBusConsumer(apps.ConsumerName(name))
+	if err != nil || !ok {
+		t.Fatalf("consumer for %s: %v ok=%t", name, err, ok)
+	}
+	return consumer.Enabled
+}
+
+func appNotifications(t *testing.T, d *Daemon, kind string) []store.NotificationRecord {
+	t.Helper()
+	all, err := d.store.ListNotifications()
+	if err != nil {
+		t.Fatalf("list notifications: %v", err)
+	}
+	var out []store.NotificationRecord
+	for _, record := range all {
+		if record.Kind == kind {
+			out = append(out, record)
+		}
+	}
+	return out
+}
+
+// failEvery makes a sidecar whose handler always throws.
+func failEvery(message string) func(*fakeAppRuntime, appDispatchRequest) error {
+	return func(*fakeAppRuntime, appDispatchRequest) error { return errors.New(message) }
+}
+
+// The rule itself, and all three of its effects. Asserting only the enabled bit
+// would let a silent auto-disable ship: the bit stops delivery, the fact reaches
+// the rest of the daemon, and the notification is the only one a person sees.
+func TestAppStuckOnOneEventIsDisabledAndSaysSoThreeWays(t *testing.T) {
+	d := newAppDaemon(t)
+	clock := newAppTestClock(d)
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+	startFakeAppRuntime(t, d, failEvery("TypeError: undefined is not a function"))
+	stuck := appEvent("ticket.created", "tk-1", 12)
+
+	// Four failures inside the window change nothing: the rule is time stalled,
+	// not attempts burned.
+	for i := 0; i < 4; i++ {
+		if err := d.deliverAppEvent(context.Background(), "greeter", stuck); err == nil {
+			t.Fatal("a throwing handler reported success")
+		}
+		clock.advance(3 * time.Minute)
+		if !appEnabled(t, d, "greeter") {
+			t.Fatalf("greeter was disabled after %d failure(s) inside the window", i+1)
+		}
+	}
+
+	// The one that crosses fifteen minutes: four failures put the clock at
+	// twelve, so this is the first delivery past the window.
+	clock.advance(4 * time.Minute)
+	if err := d.deliverAppEvent(context.Background(), "greeter", stuck); err == nil {
+		t.Fatal("a throwing handler reported success")
+	}
+
+	if appEnabled(t, d, "greeter") {
+		t.Fatal("greeter is still enabled after 15 minutes stuck on one event")
+	}
+	facts := appFacts(t, d, FactAppEnabledChanged)
+	if len(facts) != 1 || facts[0].Subject != "greeter" {
+		t.Fatalf("app.enabled.changed facts = %+v, want one for greeter", facts)
+	}
+	notes := appNotifications(t, d, notificationKindAppAutoDisabled)
+	if len(notes) != 1 {
+		t.Fatalf("auto-disable notifications = %d, want 1", len(notes))
+	}
+	// The notification has to carry the way back, or the app is off forever as
+	// far as its owner knows.
+	if !strings.Contains(notes[0].Body, "attn app enable greeter") {
+		t.Fatalf("the notification does not name the way back: %q", notes[0].Body)
+	}
+	if !strings.Contains(notes[0].Body, "ticket.created") || !strings.Contains(notes[0].Detail, "TypeError") {
+		t.Fatalf("the notification does not say what failed: body=%q detail=%q", notes[0].Body, notes[0].Detail)
+	}
+	// And the clock is cleared, so re-enabling does not disable it again on the
+	// very next failure.
+	if stall, ok := d.appStallSnapshot("greeter"); ok {
+		t.Fatalf("the disabled app is still on the clock: %+v", stall)
+	}
+}
+
+// Slow is not stuck. A handler that takes minutes but succeeds never touches
+// the clock, however long the app has been running.
+func TestSlowButSucceedingAppIsNeverDisabled(t *testing.T) {
+	d := newAppDaemon(t)
+	clock := newAppTestClock(d)
+	installApp(t, d, "slowpoke", subscribing("ticket.*"))
+	startFakeAppRuntime(t, d, func(*fakeAppRuntime, appDispatchRequest) error {
+		// Each run "takes" ten minutes on the daemon's clock.
+		clock.advance(10 * time.Minute)
+		return nil
+	})
+
+	for seq := int64(1); seq <= 6; seq++ {
+		if err := d.deliverAppEvent(context.Background(), "slowpoke", appEvent("ticket.created", "tk", seq)); err != nil {
+			t.Fatalf("a succeeding handler failed: %v", err)
+		}
+	}
+	if !appEnabled(t, d, "slowpoke") {
+		t.Fatal("an app that succeeded on every event, slowly, was disabled")
+	}
+	if _, ok := d.appStallSnapshot("slowpoke"); ok {
+		t.Fatal("a succeeding app is on the auto-disable clock")
+	}
+	rows := invocationsOf(t, d, "slowpoke")
+	if len(rows) != 6 {
+		t.Fatalf("recorded %d invocation(s), want 6", len(rows))
+	}
+	if rows[0].Duration < 10*time.Minute {
+		t.Fatalf("recorded duration %s, want the ten minutes the handler took", rows[0].Duration)
+	}
+}
+
+// Unreliable is not stuck either. An app failing on a different fact every time
+// is making progress: its cursor keeps moving, so it is not holding the log.
+func TestAppFailingOnDistinctEventsIsNeverDisabled(t *testing.T) {
+	d := newAppDaemon(t)
+	clock := newAppTestClock(d)
+	installApp(t, d, "flaky", subscribing("ticket.*"))
+	startFakeAppRuntime(t, d, failEvery("intermittent"))
+
+	for seq := int64(1); seq <= 10; seq++ {
+		if err := d.deliverAppEvent(context.Background(), "flaky", appEvent("ticket.created", "tk", seq)); err == nil {
+			t.Fatal("a throwing handler reported success")
+		}
+		clock.advance(5 * time.Minute)
+		if !appEnabled(t, d, "flaky") {
+			t.Fatalf("flaky was disabled after failing on %d distinct events", seq)
+		}
+	}
+	// Its clock restarted at every new event, so it never accumulated a stall.
+	stall, ok := d.appStallSnapshot("flaky")
+	if !ok || stall.seq != 10 || stall.attempts != 1 {
+		t.Fatalf("stall = %+v (present=%t), want a fresh clock on the last event", stall, ok)
+	}
+}
+
+// Rule 2 again, at the clock rather than at the classification: a sidecar that
+// is down for longer than the window disables nobody.
+func TestARuntimeOutageLongerThanTheWindowDisablesNothing(t *testing.T) {
+	d := newAppDaemon(t)
+	clock := newAppTestClock(d)
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+	// A runtime binary that starts and dies without ever connecting: the outage.
+	t.Setenv(appRuntimeHostOverride, writeExecutableStub(t, "exit 0"))
+	d.appRuntimeSupervise.GiveUpAfter = 1
+	// The connect wait is the one thing here that is real time rather than the
+	// injected clock, and the runtime is never going to connect.
+	d.appRuntimeWait = 20 * time.Millisecond
+
+	stuck := appEvent("ticket.created", "tk-1", 4)
+	// Fail once, then let the daemon's clock run past the window entirely.
+	if err := d.deliverAppEvent(context.Background(), "greeter", stuck); !isRuntimeFailure(err) {
+		t.Fatalf("error %v was not classified as the runtime's", err)
+	}
+	clock.advance(2 * appAutoDisableStall)
+	if err := d.deliverAppEvent(context.Background(), "greeter", stuck); !isRuntimeFailure(err) {
+		t.Fatalf("error %v was not classified as the runtime's", err)
+	}
+
+	if !appEnabled(t, d, "greeter") {
+		t.Fatal("an app was disabled because the runtime was down")
+	}
+	if notes := appNotifications(t, d, notificationKindAppAutoDisabled); len(notes) != 0 {
+		t.Fatalf("a runtime outage wrote %d auto-disable notification(s)", len(notes))
+	}
+}
+
+// Enabling is the way back, and it has to clear the streak too — otherwise a
+// re-enabled app is disabled again by its very next failure.
+func TestEnablingClearsTheStreakAndResumesDelivery(t *testing.T) {
+	d := newAppDaemon(t)
+	clock := newAppTestClock(d)
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+	var throw = true
+	startFakeAppRuntime(t, d, func(*fakeAppRuntime, appDispatchRequest) error {
+		if throw {
+			return errors.New("boom")
+		}
+		return nil
+	})
+	stuck := appEvent("ticket.created", "tk-1", 3)
+
+	_ = d.deliverAppEvent(context.Background(), "greeter", stuck)
+	clock.advance(appAutoDisableStall + time.Minute)
+	_ = d.deliverAppEvent(context.Background(), "greeter", stuck)
+	if appEnabled(t, d, "greeter") {
+		t.Fatal("the app was not disabled")
+	}
+
+	resp := appSetEnabled(t, d, "greeter", true)
+	if !resp.Ok {
+		t.Fatalf("enable: %v", protocol.Deref(resp.Error))
+	}
+	if !appEnabled(t, d, "greeter") {
+		t.Fatal("enable did not flip the consumer bit back")
+	}
+	if stall, ok := d.appStallSnapshot("greeter"); ok {
+		t.Fatalf("enable left the old stall clock running: %+v", stall)
+	}
+
+	// The next failure starts a fresh window rather than tripping the old one.
+	_ = d.deliverAppEvent(context.Background(), "greeter", stuck)
+	if !appEnabled(t, d, "greeter") {
+		t.Fatal("a re-enabled app was disabled again by its first failure")
+	}
+	stall, ok := d.appStallSnapshot("greeter")
+	if !ok || !stall.since.Equal(clock.Now()) {
+		t.Fatalf("stall = %+v (present=%t), want a window starting now", stall, ok)
+	}
+
+	// And it really does deliver again.
+	throw = false
+	if err := d.deliverAppEvent(context.Background(), "greeter", stuck); err != nil {
+		t.Fatalf("a re-enabled app did not deliver: %v", err)
+	}
+}
+
+// Disabling releases the retention floor. This is the whole reason auto-disable
+// exists: a stalled consumer holds the durable log open for everybody, and the
+// observable consequence is that nothing can be compacted past it.
+func TestADisabledAppNoLongerHoldsTheRetentionFloor(t *testing.T) {
+	d := newAppDaemon(t)
+	clock := newAppTestClock(d)
+	installApp(t, d, "greeter", subscribing(FactDocumentChanged))
+	startFakeAppRuntime(t, d, failEvery("boom"))
+
+	// Several invalidations about one subject. Compaction reduces those to the
+	// newest — but only at or below the floor every enabled consumer has passed.
+	for i := 0; i < 4; i++ {
+		d.publishFact(FactDocumentChanged, "app/greeter/seen/tk-1", nil)
+	}
+	waitFor(t, "the app to stall on the first fact", func() bool {
+		_, ok := d.appStallSnapshot("greeter")
+		return ok
+	})
+
+	removed, err := d.eventBus.Trim()
+	if err != nil {
+		t.Fatalf("trim: %v", err)
+	}
+	if removed != 0 {
+		t.Fatalf("compaction removed %d event(s) while a stalled enabled consumer sat at the bottom of the log", removed)
+	}
+
+	clock.advance(appAutoDisableStall + time.Minute)
+	waitFor(t, "the stalled app to be disabled", func() bool { return !appEnabled(t, d, "greeter") })
+
+	// Nothing else moved. The only difference is that a disabled consumer does
+	// not pin the log.
+	removed, err = d.eventBus.Trim()
+	if err != nil {
+		t.Fatalf("trim after the auto-disable: %v", err)
+	}
+	if removed == 0 {
+		t.Fatal("the disabled app is still holding the retention floor down")
+	}
+}

--- a/internal/daemon/app_consumers.go
+++ b/internal/daemon/app_consumers.go
@@ -1,0 +1,682 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/appbuild"
+	"github.com/victorarias/attn/internal/apps"
+	"github.com/victorarias/attn/internal/bus"
+	"github.com/victorarias/attn/internal/docstore"
+	"github.com/victorarias/attn/internal/jobs"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// Apps as bus consumers: registration, delivery, the invocation log, and the
+// clock that disables an app stuck on one event.
+//
+// An app is an ordinary durable consumer — `app:<name>`, a persisted cursor,
+// at-least-once, stall-don't-skip, cursor-after-handler. None of that is
+// reimplemented here. What this file adds is what happens between "the bus
+// handed us a fact" and "the cursor moved": resolve the version and the handler,
+// dispatch into the shared sidecar, record what happened, and decide whose fault
+// it was.
+//
+// The last of those is the part worth reading twice. A handler that threw is the
+// app's fault and advances its stall clock. A sidecar that died, or was never
+// there, is the runtime's — it stalls the delivery exactly the same way, but it
+// must never move an app closer to being disabled. Nothing else in attn can tell
+// those apart, so this file has to.
+//
+// See docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md.
+
+const (
+	appInvocationStatusOK = "ok"
+	// appInvocationStatusError is a handler that threw: the app's own fault.
+	appInvocationStatusError = "error"
+	// appInvocationStatusRuntimeError is a dispatch that never reached a handler,
+	// or whose answer never came back. It is recorded — a reader looking at an app
+	// that is doing nothing deserves to see why — but it is not held against the
+	// app.
+	appInvocationStatusRuntimeError = "runtime_error"
+)
+
+// appRuntimeConnectWait is how long a delivery waits for the sidecar to come up
+// before treating its absence as a runtime failure.
+//
+// The runtime starts lazily, on the first fact an app is due, so the very first
+// dispatch after a daemon start pays a cold start. Spawn, connect, hello, import
+// the bundle and run the handler was measured end to end at 77ms (receipt in the
+// plan doc); ten seconds is ~130× that, and a delivery that hits it stalls and
+// retries rather than failing anything permanently.
+const appRuntimeConnectWait = 10 * time.Second
+
+// appConnectWait is that tripwire, overridable so a test that dispatches into a
+// runtime which will never connect does not cost ten real seconds per delivery.
+func (d *Daemon) appConnectWait() time.Duration {
+	if d.appRuntimeWait > 0 {
+		return d.appRuntimeWait
+	}
+	return appRuntimeConnectWait
+}
+
+// appAutoDisableStall is the whole auto-disable rule: an app that has been stuck
+// on the SAME event for this long is disabled.
+//
+// One clock, no failure-count clause. The thing that has to be prevented is one
+// broken app pinning the durable log's retention floor open for everybody, and
+// that is a function of wall time stalled, not of how many times the retry
+// happened to fire. A count would also punish a fast-failing app more than a
+// slow one for the same amount of harm.
+//
+// Fifteen minutes is roughly five rounds at the bus's two-minute retry cap —
+// long enough that a transient dependency (a git remote, a rebooting service)
+// recovers untouched, short enough that a genuinely broken app does not hold the
+// log for an afternoon.
+const appAutoDisableStall = 15 * time.Minute
+
+// notificationKindAppAutoDisabled marks the notification an auto-disable writes.
+const notificationKindAppAutoDisabled = "app_auto_disabled"
+
+// appStall is one app's position against the auto-disable clock. There is an
+// entry only while an app is failing; a success deletes it.
+//
+// It is in memory on purpose. The clock measures a stall that is happening now,
+// and a daemon restart genuinely does reset it: the app gets its window again
+// against a runtime that has also just restarted, which is the generous reading
+// and the right one.
+type appStall struct {
+	seq       int64
+	eventName string
+	since     time.Time
+	attempts  int
+	lastError string
+}
+
+// appDispatchPlan is everything one delivery needs, read once per event.
+type appDispatchPlan struct {
+	app         string
+	namespace   string
+	versionID   int64
+	artifact    string
+	handler     string
+	collections []string
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+// registerAppConsumers gives every registered app its durable consumer. It runs
+// once at daemon start, after the bus is up.
+//
+// A registration failure for one app is logged and the others still start: one
+// app with a corrupt declaration must not take the rest of them down.
+func (d *Daemon) registerAppConsumers() {
+	if d.store == nil || d.eventBus == nil {
+		return
+	}
+	rows, err := d.store.ListApps()
+	if err != nil {
+		d.logf("apps: listing apps to register their consumers: %v", err)
+		return
+	}
+	for _, row := range rows {
+		if err := d.registerAppConsumer(row.Name); err != nil {
+			d.logf("apps: %v", err)
+		}
+	}
+}
+
+// registerAppConsumer registers, or re-points, one app's consumer.
+//
+// Registering is what mints the cursor, and a fresh consumer starts at head:
+// an app installed today is not asking to be handed a month of backlog. An app
+// that already has a cursor keeps it, which is what makes a daemon restart
+// invisible to a running app.
+//
+// A live consumer whose app has been re-applied with different subscriptions
+// gets SetFilter rather than a re-registration: unregister-then-register would
+// delete the cursor on the way through, and the app would silently skip every
+// fact published while it was being updated.
+func (d *Daemon) registerAppConsumer(name string) error {
+	filter, err := d.appFilter(name)
+	if err != nil {
+		return err
+	}
+	consumer := apps.ConsumerName(name)
+	if d.eventBus.Registered(consumer) {
+		if err := d.eventBus.SetFilter(consumer, filter); err != nil {
+			return fmt.Errorf("re-pointing the bus consumer for app %q at its new subscriptions: %w", name, err)
+		}
+		return nil
+	}
+	if err := d.eventBus.Register(consumer, filter, d.appEventHandler(name)); err != nil {
+		return fmt.Errorf("registering the bus consumer for app %q: %w", name, err)
+	}
+	return nil
+}
+
+// appFilter reads an app's declared subscriptions off its current version.
+//
+// An app with no version yet subscribes to nothing rather than to everything:
+// bus.ParseFilter reads an empty expression as All, and an app whose code has
+// never been built must not be woken by every fact in the system.
+func (d *Daemon) appFilter(name string) (bus.Filter, error) {
+	manifest, _, err := d.appDeclaration(name)
+	if err != nil {
+		return nil, err
+	}
+	patterns := manifest.EventPatterns()
+	if len(patterns) == 0 {
+		return bus.Filter{appNoSubscriptionsPattern}, nil
+	}
+	return bus.Filter(patterns), nil
+}
+
+// appNoSubscriptionsPattern is a fact name nothing publishes, used as the filter
+// of an app that declared no subscriptions. A filter has to be *something*, and
+// every other candidate — empty, "*" — means "everything" somewhere in the bus.
+const appNoSubscriptionsPattern = "app.subscribes.to.nothing"
+
+// appDeclaration loads an app's current version and the manifest frozen into it.
+// The zero AppVersion with a nil error means the app exists but has no version.
+func (d *Daemon) appDeclaration(name string) (appbuild.Manifest, store.AppVersion, error) {
+	row, ok, err := d.store.GetApp(name)
+	if err != nil {
+		return appbuild.Manifest{}, store.AppVersion{}, fmt.Errorf("reading app %q: %w", name, err)
+	}
+	if !ok || row.CurrentVersionID == 0 {
+		return appbuild.Manifest{}, store.AppVersion{}, nil
+	}
+	version, ok, err := d.store.GetAppVersion(row.CurrentVersionID)
+	if err != nil {
+		return appbuild.Manifest{}, store.AppVersion{}, fmt.Errorf("reading version %d of app %q: %w", row.CurrentVersionID, name, err)
+	}
+	if !ok {
+		return appbuild.Manifest{}, store.AppVersion{}, nil
+	}
+	var manifest appbuild.Manifest
+	if err := json.Unmarshal([]byte(version.Declaration), &manifest); err != nil {
+		return appbuild.Manifest{}, store.AppVersion{}, fmt.Errorf(
+			"the declaration frozen into version %d of app %q is not readable (%v); that snapshot is written at apply time and never edited, so this version cannot be run — `attn app rollback %s` moves off it",
+			version.ID, name, err, name)
+	}
+	return manifest, version, nil
+}
+
+// declareAppCollections creates the document collections a version declared, in
+// the app's own namespace.
+//
+// It runs at registration and after every apply, and it is idempotent: declaring
+// a collection that already exists with the same fields is a no-op in the store.
+// A collection an older version declared and this one dropped is left alone —
+// the documents in it are the user's data, and a version bump is not consent to
+// delete them.
+func (d *Daemon) declareAppCollections(name string, manifest appbuild.Manifest) {
+	namespace := apps.Namespace(name)
+	for _, collection := range manifest.Collections {
+		schema := docstore.CollectionSchema{Namespace: namespace, Collection: collection.Name}
+		for _, field := range collection.Fields {
+			schema.Fields = append(schema.Fields, docstore.FieldSpec{Name: field, Type: docstore.FieldString})
+		}
+		if err := schema.Validate(); err != nil {
+			d.logf("apps: app %s declares collection %q, which the document store refuses: %v", name, collection.Name, err)
+			continue
+		}
+		redeclared, err := d.store.DefineDocumentCollection(schema, d.appNow())
+		if err != nil {
+			d.logf("apps: declaring collection %s/%s for app %s: %v", namespace, collection.Name, name, err)
+			continue
+		}
+		if redeclared {
+			d.publishCollectionRedeclared(namespace, collection.Name)
+		}
+	}
+}
+
+// syncAppRuntimeForVersion re-points an app's consumer and collections after its
+// version moved. Called from apply and rollback, whose subscriptions and
+// collections can both differ from the version before.
+func (d *Daemon) syncAppRuntimeForVersion(name string) {
+	if d.store == nil {
+		return
+	}
+	manifest, _, err := d.appDeclaration(name)
+	if err != nil {
+		d.logf("apps: %v", err)
+		return
+	}
+	d.declareAppCollections(name, manifest)
+	if d.eventBus == nil {
+		return
+	}
+	if err := d.registerAppConsumer(name); err != nil {
+		d.logf("apps: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Delivery
+// ---------------------------------------------------------------------------
+
+func (d *Daemon) appEventHandler(name string) bus.Handler {
+	return func(ctx context.Context, ev bus.Event) error {
+		return d.deliverAppEvent(ctx, name, ev)
+	}
+}
+
+// deliverAppEvent runs one fact through one app.
+//
+// Returning an error stalls this app's consumer on this event and has the bus
+// redeliver it with backoff — never skip it. That is true for both failure
+// classes; what differs is what gets recorded and whether the stall clock moves.
+func (d *Daemon) deliverAppEvent(ctx context.Context, name string, ev bus.Event) error {
+	plan, err := d.planAppDispatch(name, ev)
+	if err != nil {
+		return err
+	}
+	if plan == nil {
+		// Nothing to run: no version, or a fact that matches the app's filter but
+		// no declared subscription. Advance rather than stall — there is no code
+		// here to succeed on a retry, and a permanent stall would pin retention.
+		return nil
+	}
+
+	started := d.appNow()
+	result, dispatchErr := d.dispatchToAppRuntime(ctx, plan, ev)
+	took := d.appNow().Sub(started)
+
+	// The consumer is going away (daemon stop, `attn app remove`). Record nothing
+	// and let the bus put the event back: an interrupted delivery did not happen.
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	invocation := store.AppInvocation{
+		AppName:      name,
+		VersionID:    plan.versionID,
+		EventSeq:     ev.Seq,
+		EventName:    ev.Name,
+		EventSubject: ev.Subject,
+		Handler:      plan.handler,
+		Duration:     took,
+		StartedAt:    started,
+	}
+
+	switch {
+	case dispatchErr != nil && isRuntimeFailure(dispatchErr):
+		invocation.Status = appInvocationStatusRuntimeError
+		invocation.Error = dispatchErr.Error()
+		d.recordAppInvocation(invocation)
+		// Rule 2: the runtime died, so no app is closer to being disabled than it
+		// was. Clearing rather than merely not-advancing is deliberate — leaving a
+		// clock running through an outage would charge the app for the minutes the
+		// sidecar was down.
+		d.clearAppStall(name)
+		return dispatchErr
+
+	case dispatchErr != nil && errors.Is(dispatchErr, context.DeadlineExceeded):
+		// A handler that never returned. Nothing else can attribute this: the
+		// process is healthy and the app's code is what is stuck.
+		invocation.Status = appInvocationStatusError
+		invocation.Error = fmt.Sprintf(
+			"the handler for %s did not return within %s; attn abandoned the dispatch. A handler awaits attn's own APIs, which always settle — an await on something else needs its own timeout.",
+			ev.Name, appDispatchTimeout)
+		d.recordAppInvocation(invocation)
+		d.noteAppFailure(name, ev, invocation.Error)
+		return errors.New(invocation.Error)
+
+	case dispatchErr != nil:
+		invocation.Status = appInvocationStatusRuntimeError
+		invocation.Error = dispatchErr.Error()
+		d.recordAppInvocation(invocation)
+		d.clearAppStall(name)
+		return dispatchErr
+
+	case !result.OK:
+		invocation.Status = appInvocationStatusError
+		invocation.Error = result.Error
+		d.recordAppInvocation(invocation)
+		d.noteAppFailure(name, ev, result.Error)
+		return fmt.Errorf("app %s handler %s threw: %s", name, plan.handler, firstLine(result.Error))
+
+	default:
+		invocation.Status = appInvocationStatusOK
+		d.recordAppInvocation(invocation)
+		d.clearAppStall(name)
+		return nil
+	}
+}
+
+// planAppDispatch resolves what should run. A nil plan with a nil error means
+// there is nothing to run for this fact.
+func (d *Daemon) planAppDispatch(name string, ev bus.Event) (*appDispatchPlan, error) {
+	manifest, version, err := d.appDeclaration(name)
+	if err != nil {
+		return nil, err
+	}
+	if version.ID == 0 {
+		return nil, nil
+	}
+	handler := resolveAppHandler(manifest.EventPatterns(), ev.Name)
+	if handler == "" {
+		return nil, nil
+	}
+	plan := &appDispatchPlan{
+		app:       name,
+		namespace: apps.Namespace(name),
+		versionID: version.ID,
+		artifact:  version.ArtifactPath,
+		handler:   handler,
+	}
+	for _, collection := range manifest.Collections {
+		plan.collections = append(plan.collections, collection.Name)
+	}
+	return plan, nil
+}
+
+// resolveAppHandler picks which declared subscription a fact arrived under.
+//
+// Exact wins over a wildcard, and among wildcards the longest prefix wins, so an
+// app that declares both `session.*` and `session.state.changed` gets the
+// specific handler for the specific fact. The matching itself is the bus's, not
+// a copy of it.
+func resolveAppHandler(patterns []string, eventName string) string {
+	best := ""
+	for _, pattern := range patterns {
+		if !bus.MatchPattern(pattern, eventName) {
+			continue
+		}
+		if pattern == eventName {
+			return pattern
+		}
+		if len(pattern) > len(best) {
+			best = pattern
+		}
+	}
+	return best
+}
+
+// dispatchToAppRuntime sends one handler run to the sidecar and waits for it, or
+// for the delivery to be cancelled.
+func (d *Daemon) dispatchToAppRuntime(ctx context.Context, plan *appDispatchPlan, ev bus.Event) (appDispatchResult, error) {
+	runtime, err := d.awaitAppRuntime(ctx)
+	if err != nil {
+		return appDispatchResult{}, err
+	}
+
+	dispatch := &appDispatch{
+		app:         plan.app,
+		namespace:   plan.namespace,
+		versionID:   plan.versionID,
+		collections: make(map[string]struct{}, len(plan.collections)),
+	}
+	for _, collection := range plan.collections {
+		dispatch.collections[collection] = struct{}{}
+	}
+	d.registerAppDispatch(dispatch)
+	// Released whatever happens, including the abandoned-timeout path: an id left
+	// behind would let a handler that finally woke up write documents from outside
+	// any delivery.
+	defer d.releaseAppDispatch(dispatch.id)
+
+	var payload any
+	if len(ev.Payload) > 0 {
+		payload = json.RawMessage(ev.Payload)
+	}
+	request := appDispatchRequest{
+		Dispatch:    dispatch.id,
+		App:         plan.app,
+		VersionID:   plan.versionID,
+		Artifact:    plan.artifact,
+		Handler:     plan.handler,
+		Collections: plan.collections,
+		Event: appDispatchEvent{
+			Name:        ev.Name,
+			Subject:     ev.Subject,
+			Seq:         ev.Seq,
+			Payload:     payload,
+			PublishedAt: stampForWire(ev.CreatedAt),
+		},
+	}
+	if request.Collections == nil {
+		request.Collections = []string{}
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, appDispatchTimeout)
+	defer cancel()
+	result, err := runtime.dispatch(callCtx, request)
+	if err != nil {
+		if ctx.Err() == nil && callCtx.Err() != nil {
+			// Our own deadline, not the caller's: a hung handler.
+			return appDispatchResult{}, context.DeadlineExceeded
+		}
+		if ctx.Err() != nil {
+			return appDispatchResult{}, ctx.Err()
+		}
+		// The transport failed — the socket died mid-call, or the process did.
+		return appDispatchResult{}, runtimeFailure("%v", err)
+	}
+	return result, nil
+}
+
+// awaitAppRuntime returns the live sidecar, starting it if it is not running and
+// waiting a bounded time for it to connect.
+func (d *Daemon) awaitAppRuntime(ctx context.Context) (*appRuntimeConnection, error) {
+	runtime, ready := d.appRuntimeOrReady()
+	if runtime != nil {
+		return runtime, nil
+	}
+	if err := d.ensureAppRuntime(); err != nil {
+		return nil, runtimeFailure("%v", err)
+	}
+	wait := d.appConnectWait()
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ready:
+		if runtime := d.appRuntimeConnected(); runtime != nil {
+			return runtime, nil
+		}
+		return nil, runtimeFailure("the app runtime connected and went away again before this handler could run")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-timer.C:
+		return nil, runtimeFailure(
+			"the app runtime did not connect within %s; `attn app runtime status` shows what it is doing and `attn app logs runtime` shows what it printed",
+			wait)
+	}
+}
+
+// appRuntimeOrReady hands back the live connection, or the channel that closes
+// when one arrives. Both under the same lock: fetching them separately leaves a
+// window where the connection lands between the check and the wait, and the
+// waiter sleeps out its whole timeout beside a healthy runtime.
+func (d *Daemon) appRuntimeOrReady() (*appRuntimeConnection, chan struct{}) {
+	d.appRuntimeMu.Lock()
+	defer d.appRuntimeMu.Unlock()
+	if d.appRuntimeConn != nil {
+		return d.appRuntimeConn, nil
+	}
+	if d.appRuntimeReady == nil {
+		d.appRuntimeReady = make(chan struct{})
+	}
+	return nil, d.appRuntimeReady
+}
+
+func (d *Daemon) recordAppInvocation(invocation store.AppInvocation) {
+	if d.store == nil {
+		return
+	}
+	id, err := d.store.AppendAppInvocation(invocation)
+	if err != nil {
+		d.logf("apps: recording an invocation of app %s: %v", invocation.AppName, err)
+		return
+	}
+	d.notifyAppWatchers(appInvocationForWire(id, invocation), invocation.AppName)
+}
+
+// firstLine trims a stack trace down to its message, for a log line and a bus
+// error that already have the whole text recorded beside them.
+func firstLine(s string) string {
+	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+		return strings.TrimSpace(s[:idx])
+	}
+	return strings.TrimSpace(s)
+}
+
+// ---------------------------------------------------------------------------
+// The auto-disable clock
+// ---------------------------------------------------------------------------
+
+// noteAppFailure advances the stall clock for an app-attributed failure, and
+// disables the app if it has been stuck on this event past the window.
+//
+// The clock is per event, not per app: an app failing on a different fact every
+// time is not stuck, it is unreliable, and unreliable does not pin the retention
+// floor. Only the same seq failing over and over does.
+func (d *Daemon) noteAppFailure(name string, ev bus.Event, message string) {
+	now := d.appNow()
+
+	d.appStallMu.Lock()
+	if d.appStalls == nil {
+		d.appStalls = make(map[string]*appStall)
+	}
+	stall := d.appStalls[name]
+	if stall == nil || stall.seq != ev.Seq {
+		stall = &appStall{seq: ev.Seq, eventName: ev.Name, since: now}
+		d.appStalls[name] = stall
+	}
+	stall.attempts++
+	stall.lastError = message
+	stalled := now.Sub(stall.since)
+	attempts := stall.attempts
+	d.appStallMu.Unlock()
+
+	if stalled < appAutoDisableStall {
+		return
+	}
+	d.autoDisableApp(name, ev, stalled, attempts, message)
+}
+
+func (d *Daemon) clearAppStall(name string) {
+	d.appStallMu.Lock()
+	delete(d.appStalls, name)
+	d.appStallMu.Unlock()
+}
+
+// appStallSnapshot reports what an app is stuck on, for `attn app status`.
+func (d *Daemon) appStallSnapshot(name string) (appStall, bool) {
+	d.appStallMu.Lock()
+	defer d.appStallMu.Unlock()
+	stall, ok := d.appStalls[name]
+	if !ok {
+		return appStall{}, false
+	}
+	return *stall, true
+}
+
+// autoDisableApp flips the app off, says so on the bus, and tells the user.
+//
+// All three, because each answers a different question: the consumer bit stops
+// delivery and releases the retention floor, the fact reaches anything in the
+// daemon watching the app, and the notification is the only one of the three a
+// person ever sees. An auto-disable nobody is told about is a feature that
+// silently stops working.
+func (d *Daemon) autoDisableApp(name string, ev bus.Event, stalled time.Duration, attempts int, message string) {
+	consumer := apps.ConsumerName(name)
+	flipped, err := d.store.SetBusConsumerEnabled(consumer, false, d.appNow())
+	if err != nil {
+		d.logf("apps: disabling app %s after %s stalled on %s: %v", name, stalled.Round(time.Second), ev.Name, err)
+		return
+	}
+	if !flipped {
+		// Already off, or removed while this delivery was failing.
+		return
+	}
+	// The window restarts from here. Enabling the app again is the supported way
+	// back, and it clears this too; leaving the old clock in place would disable a
+	// re-enabled app on its very next failure.
+	d.clearAppStall(name)
+
+	d.logf("apps: disabled %s — stuck on %s (seq %d) for %s across %d attempts: %s",
+		name, ev.Name, ev.Seq, stalled.Round(time.Second), attempts, firstLine(message))
+	d.publishFact(FactAppEnabledChanged, name, appEnabledChanged{
+		Name: name, Consumer: consumer, Enabled: false,
+	})
+	if d.store == nil {
+		return
+	}
+	if _, err := d.store.AddNotification(store.NotificationRecord{
+		Kind:  notificationKindAppAutoDisabled,
+		Title: fmt.Sprintf("App disabled: %s", name),
+		Body: fmt.Sprintf(
+			"%s failed on the same event (%s, seq %d) for %s across %d attempts, so attn disabled it — a stalled app holds the event log open for every other consumer. Fix the handler and `attn app enable %s`; `attn app status %s` shows the failures.",
+			name, ev.Name, ev.Seq, stalled.Round(time.Minute), attempts, name, name),
+		Detail:     message,
+		SourceKind: "app",
+		SourceID:   name,
+	}, d.appNow()); err != nil {
+		d.logf("notifications: add app-auto-disabled notification for %s: %v", name, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Invocation retention
+// ---------------------------------------------------------------------------
+
+const (
+	// appInvocationRetentionKind is the cron entry that trims the invocation log.
+	appInvocationRetentionKind = "app_invocation_retention"
+	// appInvocationRetentionInterval is how often it runs. Hourly, like the bus's
+	// own retention pass: the log grows continuously and a daily sweep would let a
+	// busy day's worth accumulate before anything looked at it.
+	appInvocationRetentionInterval = time.Hour
+	appInvocationRetentionTimeout  = 30 * time.Second
+
+	// AppInvocationRetention is the age window for the invocation log. It matches
+	// the bus's own DefaultRetention, which is the useful property: an invocation
+	// whose event has been trimmed off the durable log cannot be re-read against
+	// it, so the row has nothing left to tell anyone.
+	AppInvocationRetention = 30 * 24 * time.Hour
+
+	// AppInvocationsPerApp is how many invocations one app keeps, whatever their
+	// age. The age window alone does not bound this table, because how many rows
+	// thirty days holds is entirely a property of what the app subscribed to.
+	//
+	// The receipt, measured over 7.5 days of Victor's production log (275,845
+	// facts): the loudest fact is `session.state.changed` at 1,141/hour, and it is
+	// what a scaffolded app subscribes to out of the box. Thirty days of that is
+	// ~820,000 rows — well over a hundred megabytes for one app, on a database
+	// that is 51MB today. The quietest domain an app would realistically watch
+	// (`ticket.*`) runs at 27/day, three orders of magnitude below.
+	//
+	// 20,000 rows is ~17 hours of the loudest possible app — a whole working day
+	// of "what did it do this morning" — and about 4MB. For anything quieter the
+	// age window trims first and the cap is never felt: at the ticket rate, 20,000
+	// rows is two years.
+	AppInvocationsPerApp = 20_000
+)
+
+// appInvocationRetentionHandler is the cron entry. It reports how many rows went
+// so a run that is doing nothing and a run that is not happening look different
+// in the task list.
+func (d *Daemon) appInvocationRetentionHandler(_ context.Context, _ *jobs.Job) (any, error) {
+	if d.store == nil {
+		return map[string]any{"removed": 0}, nil
+	}
+	removed, err := d.store.TrimAppInvocations(d.appNow().Add(-AppInvocationRetention), AppInvocationsPerApp)
+	if err != nil {
+		return nil, fmt.Errorf("trimming the app invocation log: %w", err)
+	}
+	if removed > 0 {
+		d.logf("apps: trimmed %d invocation(s) — older than %s, or past the newest %d of an app",
+			removed, AppInvocationRetention, AppInvocationsPerApp)
+	}
+	return map[string]any{"removed": removed}, nil
+}

--- a/internal/daemon/app_runtime.go
+++ b/internal/daemon/app_runtime.go
@@ -1,0 +1,375 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/store"
+	"github.com/victorarias/attn/internal/supervise"
+)
+
+// The app runtime's daemon half: one supervised Bun sidecar that runs the
+// handlers of every installed app.
+//
+// One process, not one per app. Isolation between apps here is failure
+// attribution, not an OS boundary — the daemon knows which app's handler was
+// running when something threw, and charges it to that app. What it must never
+// do is charge an app for the process dying: a sidecar-wide crash has no culprit,
+// and blaming whichever app happened to be mid-dispatch would auto-disable
+// innocent apps every time the runtime was restarted. Every failure below is
+// therefore classified before it is recorded (see appFailureClass).
+//
+// Supervision — backoff, generation fencing, the stability window, the
+// disconnect grace and the give-up tripwire — is internal/supervise's, the same
+// machinery the plugin runtime uses. This file is only how a runtime binary
+// becomes a process, and what happens when there is no process to dispatch to.
+//
+// See docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md.
+
+const (
+	// appRuntimeChildName is the supervised child's name. It is also the
+	// reserved app name (internal/apps), because `attn app logs runtime` and
+	// `attn app runtime status` both have to mean one thing.
+	appRuntimeChildName = "runtime"
+
+	// appRuntimeBinaryName is the compiled sidecar. Changing it here alone
+	// produces a daemon that cannot find its runtime — scripts/build-app-runtime-host.sh
+	// writes this name.
+	appRuntimeBinaryName = "attn-app-runtime"
+
+	// appRuntimeAPIVersion is the host contract this daemon speaks. A host
+	// presenting anything else is refused at hello rather than half-served: the
+	// case this guards is an old binary inside a stale app bundle meeting a new
+	// daemon, where every symptom of the skew would otherwise appear later and
+	// somewhere else.
+	appRuntimeAPIVersion = 1
+)
+
+// appRuntimeHostOverride lets a test — and a developer running a checkout's
+// daemon against a stage dir — point at a specific host binary.
+const appRuntimeHostOverride = "ATTN_APP_RUNTIME_HOST"
+
+// resolveAppRuntimeHost finds the sidecar binary.
+//
+// Two locations, in order, and no PATH search: the runtime is a compiled
+// artifact attn ships, not a tool the user installs, and resolving it from PATH
+// is how a daemon launched by the macOS app (whose PATH is minimal) would find a
+// different one — or a stranger's.
+func resolveAppRuntimeHost() (string, error) {
+	if override := strings.TrimSpace(os.Getenv(appRuntimeHostOverride)); override != "" {
+		if _, err := os.Stat(override); err != nil {
+			return "", fmt.Errorf("%s points at %s, which is not there (%v)", appRuntimeHostOverride, override, err)
+		}
+		return override, nil
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("locating this daemon's own executable to find %s beside it: %w", appRuntimeBinaryName, err)
+	}
+	executable, err = filepath.EvalSymlinks(executable)
+	if err != nil {
+		return "", fmt.Errorf("resolving this daemon's own executable to find %s beside it: %w", appRuntimeBinaryName, err)
+	}
+
+	candidates := []string{}
+	// Inside a .app the daemon is Contents/MacOS/attn and Tauri stages resources
+	// under Contents/Resources.
+	macOSDir := filepath.Dir(executable)
+	contentsDir := filepath.Dir(macOSDir)
+	if filepath.Base(macOSDir) == "MacOS" && filepath.Base(contentsDir) == "Contents" {
+		candidates = append(candidates, filepath.Join(contentsDir, "Resources", "app-runtime", appRuntimeBinaryName))
+	}
+	// A checkout, and every Linux install: beside the daemon binary.
+	candidates = append(candidates, filepath.Join(macOSDir, appRuntimeBinaryName))
+
+	for _, candidate := range candidates {
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf(
+		"the app runtime binary %s is not installed; looked in %s. It is built by `make build-app-runtime-host` (or any `make install`), and %s overrides the location",
+		appRuntimeBinaryName, strings.Join(candidates, " and "), appRuntimeHostOverride)
+}
+
+// appRuntimeLogDir sits beside the plugin log tree rather than under the app
+// artifact store: everything under appsDir is named after an app, and a `log`
+// directory there would be one collision away from an app called log.
+func appRuntimeLogDir(socketPath string) string {
+	return filepath.Join(filepath.Dir(socketPath), "app-runtime-log")
+}
+
+// AppRuntimeLogPath is where the shared sidecar's captured output lands.
+// `attn app logs` reads it and filters by the per-app tag the host writes.
+func AppRuntimeLogPath(socketPath string) string {
+	return filepath.Join(appRuntimeLogDir(socketPath), appRuntimeChildName+".log")
+}
+
+// appRuntimeAppTag is the prefix the host puts on every line an app's handler
+// printed. It is the whole of `attn app logs <name>`'s filter, and it is
+// duplicated in apphost/src/index.ts because the two sides are different
+// languages; the parity test is TestAppLogTagMatchesTheHost.
+func appRuntimeAppTag(app string) string { return "[app " + app + "] " }
+
+// appRuntimeSelfTag prefixes the host's own lines — everything not written from
+// inside a handler.
+const appRuntimeSelfTag = "[runtime] "
+
+// ensureAppRuntimeSupervisor builds the supervisor on first use.
+//
+// The tunable half comes from appRuntimeSupervise — the clock and the give-up
+// tripwire, which a test overrides so a crash loop can be watched without
+// waiting out the real backoff schedule. Everything the daemon owns is set here
+// and cannot be overridden.
+func (d *Daemon) ensureAppRuntimeSupervisor() *supervise.Supervisor {
+	d.appRuntimeMu.Lock()
+	defer d.appRuntimeMu.Unlock()
+	if d.appRuntimeSupervisor == nil {
+		options := d.appRuntimeSupervise
+		options.LogDir = appRuntimeLogDir(d.socketPath)
+		options.OnChange = func(string) {
+			d.publishFact(FactAppRuntimeChanged, appRuntimeChildName, nil)
+		}
+		options.OnGiveUp = d.notifyAppRuntimeParked
+		options.Logf = d.logf
+		d.appRuntimeSupervisor = supervise.New(options)
+	}
+	return d.appRuntimeSupervisor
+}
+
+// ensureAppRuntime starts the sidecar, or adopts it if it is already running.
+// It doubles as un-park: supervise.Ensure resets the restart counter, which is
+// what `attn app runtime restart` needs after a crash loop.
+//
+// It is called from the dispatch path, so an app installed into a daemon that
+// has never run one starts the runtime without a restart.
+func (d *Daemon) ensureAppRuntime() error {
+	host, err := resolveAppRuntimeHost()
+	if err != nil {
+		return err
+	}
+	// The artifact store is the sidecar's working directory, and a daemon whose
+	// apps have all been removed — or that has never had one — does not have it.
+	// exec refuses to chdir into a directory that is not there, so the runtime
+	// would fail to start for a reason that has nothing to do with the runtime.
+	if err := os.MkdirAll(d.appsDir, 0o755); err != nil {
+		return fmt.Errorf("creating the app artifact directory %s to start the runtime in: %w", d.appsDir, err)
+	}
+	return d.ensureAppRuntimeSupervisor().Ensure(appRuntimeChildName, func(req supervise.StartRequest) (supervise.Process, error) {
+		cmd := exec.Command(host)
+		cmd.Dir = d.appsDir
+		cmd.Env = d.appRuntimeEnv(req.Generation)
+		process, err := supervise.StartCommand(cmd, req.Log)
+		if err != nil {
+			return nil, fmt.Errorf("start the app runtime (%s): %w", host, err)
+		}
+		return process, nil
+	})
+}
+
+// appRuntimeEnv is what the sidecar is launched with. It is the plugin
+// environment's shape — a scrubbed base plus explicit overrides — because the
+// daemon may itself be running inside an agent session whose CLAUDE_CODE_*
+// variables would otherwise leak into app code.
+func (d *Daemon) appRuntimeEnv(generation uint64) []string {
+	return d.pluginCommandEnv(
+		"ATTN_SOCKET_PATH="+d.socketPath,
+		"ATTN_APP_RUNTIME_GENERATION="+strconv.FormatUint(generation, 10),
+	)
+}
+
+// stopAppRuntime ends supervision. Called from daemon shutdown; a stopped
+// runtime is restarted by the next Ensure.
+func (d *Daemon) stopAppRuntime() {
+	d.appRuntimeMu.Lock()
+	supervisor := d.appRuntimeSupervisor
+	d.appRuntimeMu.Unlock()
+	if supervisor != nil {
+		supervisor.Shutdown()
+	}
+}
+
+// appRuntimeSnapshot reports supervision state, and whether there is a
+// supervisor at all. A daemon that has never had an app has never built one, and
+// saying "no runtime has been started" is a different answer from "stopped".
+func (d *Daemon) appRuntimeSnapshot() (supervise.Snapshot, bool) {
+	d.appRuntimeMu.Lock()
+	supervisor := d.appRuntimeSupervisor
+	d.appRuntimeMu.Unlock()
+	if supervisor == nil {
+		return supervise.Snapshot{}, false
+	}
+	return supervisor.Snapshot(appRuntimeChildName)
+}
+
+// notificationKindAppRuntimeParked marks the notification written when the
+// sidecar crash-looped past the give-up tripwire.
+const notificationKindAppRuntimeParked = "app_runtime_parked"
+
+// notifyAppRuntimeParked is the supervisor's OnGiveUp sink. Unlike a parked
+// plugin, a parked app runtime has a way back — `attn app runtime restart` — so
+// the copy names it.
+func (d *Daemon) notifyAppRuntimeParked(_ string, snapshot supervise.Snapshot) {
+	detail := ""
+	if snapshot.LastExit != nil {
+		detail = snapshot.LastExit.String()
+	}
+	d.logf("app runtime parked after %d restarts without a stable connection: %s", snapshot.RestartAttempt, detail)
+	if d.store == nil {
+		return
+	}
+	if _, err := d.store.AddNotification(store.NotificationRecord{
+		Kind:  notificationKindAppRuntimeParked,
+		Title: "Apps stopped running",
+		Body: fmt.Sprintf(
+			"attn restarted the shared app runtime %d times without it ever staying up, and has stopped trying. No app's handlers are running. `attn app runtime status` shows why it exited; `attn app runtime restart` tries again.",
+			snapshot.RestartAttempt),
+		Detail:     detail,
+		SourceKind: "app_runtime",
+		SourceID:   appRuntimeChildName,
+	}, d.appNow()); err != nil {
+		d.logf("notifications: add app-runtime-parked notification: %v", err)
+	}
+}
+
+// appNow is the daemon's clock for everything app-runtime — the stall clock most
+// of all, which measures a fifteen-minute window no test may wait out.
+func (d *Daemon) appNow() time.Time {
+	if d.appClock != nil {
+		return d.appClock()
+	}
+	return time.Now()
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+// appDispatchTimeout bounds one handler run.
+//
+// It exists because of what has no other way out: a handler that awaits
+// something that never resolves would hold its app's delivery forever, recording
+// no failure, never advancing the stall clock, and pinning the event log's
+// retention floor for everybody. A hung handler must become a failure the app
+// owns.
+//
+// The number is a tripwire, not a budget. A scaffolded handler doing real
+// document work was measured at 0–1ms warm (receipt in the plan doc); sixty
+// seconds is four to five orders of magnitude past that, so an app has to be
+// broken to feel it.
+const appDispatchTimeout = 60 * time.Second
+
+// appDispatchRequest is `app.dispatch`, the daemon's one call into the sidecar.
+//
+// Handler is resolved here rather than in the host: the daemon holds the frozen
+// declaration and the same pattern matching the bus filter uses, and a second
+// implementation of that rule in TypeScript is one free to drift.
+//
+// Artifact is an absolute path, and that is the whole of the hot-reload story:
+// versions are content-addressed, so each one has its own path, `import()`
+// caches by path, and a dispatch that started on the old version keeps the module
+// it started on while the next dispatch gets the new one.
+type appDispatchRequest struct {
+	Dispatch    string           `json:"dispatch"`
+	App         string           `json:"app"`
+	VersionID   int64            `json:"version_id"`
+	Artifact    string           `json:"artifact"`
+	Handler     string           `json:"handler"`
+	Collections []string         `json:"collections"`
+	Event       appDispatchEvent `json:"event"`
+}
+
+type appDispatchEvent struct {
+	Name        string `json:"name"`
+	Subject     string `json:"subject"`
+	Seq         int64  `json:"seq"`
+	Payload     any    `json:"payload"`
+	PublishedAt string `json:"published_at"`
+}
+
+// appDispatchResult is the host's answer. A handler that threw comes back as
+// ok:false with the text — a normal answer, not an RPC failure — which is
+// exactly how an app's fault is told apart from the runtime's.
+type appDispatchResult struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
+// appDispatch is one in-flight handler run, as the daemon sees it.
+//
+// It is the reason an app cannot address another app's documents: a collection
+// callback from the sidecar carries this dispatch's id and a collection name,
+// and the daemon resolves the namespace from its own record here. The wire has
+// no namespace field for an app to fill in.
+type appDispatch struct {
+	id          string
+	app         string
+	namespace   string
+	versionID   int64
+	collections map[string]struct{}
+}
+
+// registerAppDispatch mints an id and records the dispatch so its callbacks can
+// be resolved.
+func (d *Daemon) registerAppDispatch(dispatch *appDispatch) {
+	d.appDispatchMu.Lock()
+	defer d.appDispatchMu.Unlock()
+	if d.appDispatches == nil {
+		d.appDispatches = make(map[string]*appDispatch)
+	}
+	d.appDispatchSeq++
+	dispatch.id = strconv.FormatUint(d.appDispatchSeq, 10)
+	d.appDispatches[dispatch.id] = dispatch
+}
+
+func (d *Daemon) releaseAppDispatch(id string) {
+	d.appDispatchMu.Lock()
+	defer d.appDispatchMu.Unlock()
+	delete(d.appDispatches, id)
+}
+
+// lookupAppDispatch resolves a collection callback to the dispatch that is
+// allowed to make it. A callback for an id that is no longer in flight is a
+// handler that kept a reference to its context and used it after returning, and
+// it is refused rather than served against whatever app is running now.
+func (d *Daemon) lookupAppDispatch(id string) (*appDispatch, error) {
+	d.appDispatchMu.Lock()
+	defer d.appDispatchMu.Unlock()
+	dispatch, ok := d.appDispatches[id]
+	if !ok {
+		return nil, fmt.Errorf(
+			"dispatch %s is not in flight; a collection can only be reached from inside the handler it was given to, and this call arrived after that handler returned",
+			id)
+	}
+	return dispatch, nil
+}
+
+// appRuntimeFailure marks an error as the runtime's rather than the app's, so
+// the delivery path classifies it without matching on text.
+type appRuntimeFailure struct{ err error }
+
+func (e *appRuntimeFailure) Error() string { return e.err.Error() }
+func (e *appRuntimeFailure) Unwrap() error { return e.err }
+
+func runtimeFailure(format string, args ...any) error {
+	return &appRuntimeFailure{err: fmt.Errorf(format, args...)}
+}
+
+// isRuntimeFailure reports whether a dispatch failure belongs to the runtime.
+func isRuntimeFailure(err error) bool {
+	var failure *appRuntimeFailure
+	return errors.As(err, &failure)
+}
+
+// appRuntimeConnected returns the live sidecar connection, or nil.
+func (d *Daemon) appRuntimeConnected() *appRuntimeConnection {
+	d.appRuntimeMu.Lock()
+	defer d.appRuntimeMu.Unlock()
+	return d.appRuntimeConn
+}

--- a/internal/daemon/app_runtime_ipc.go
+++ b/internal/daemon/app_runtime_ipc.go
@@ -1,0 +1,329 @@
+package daemon
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/victorarias/attn/internal/apps"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+	"github.com/victorarias/attn/internal/supervise"
+)
+
+// The runtime's IPC surface: `attn app logs`, `attn app runtime status`,
+// `attn app runtime restart`, and the invocation stream `attn app dev` renders.
+//
+// `runtime` is addressed here as itself rather than as an app, which is the
+// whole reason internal/apps refuses it as an app name: one word cannot mean
+// both the shared process and somebody's automation.
+
+// appLogDefaultLines is how many matching lines `attn app logs` returns when the
+// caller does not say. Enough to see a handler's last few runs and the error
+// that ended them; `--lines` asks for more.
+const appLogDefaultLines = 200
+
+// appLogMaxLines bounds one answer. The log is a file the runtime appends to for
+// as long as the daemon lives, and a request for all of it is a socket message
+// with no ceiling.
+const appLogMaxLines = 10000
+
+func (d *Daemon) handleAppLogs(conn net.Conn, msg *protocol.AppLogsMessage) {
+	name := strings.TrimSpace(msg.Name)
+	whole := name == appRuntimeChildName
+	if !whole {
+		if err := apps.ValidateName(name); err != nil {
+			d.sendError(conn, err.Error())
+			return
+		}
+		if d.store == nil {
+			d.sendError(conn, "no database")
+			return
+		}
+		if _, ok, err := d.store.GetApp(name); err != nil {
+			d.sendError(conn, fmt.Sprintf("reading app %q: %v", name, err))
+			return
+		} else if !ok {
+			d.sendError(conn, d.unknownAppError("logs", name))
+			return
+		}
+	}
+
+	limit := int(protocol.Deref(msg.Lines))
+	if limit <= 0 {
+		limit = appLogDefaultLines
+	}
+	if limit > appLogMaxLines {
+		d.sendError(conn, fmt.Sprintf(
+			"app logs %s: asked for %d lines, and the most this returns in one answer is %d. Read %s directly for more.",
+			name, limit, appLogMaxLines, AppRuntimeLogPath(d.socketPath)))
+		return
+	}
+
+	path := AppRuntimeLogPath(d.socketPath)
+	lines, truncated, err := readAppLog(path, name, whole, limit)
+	if err != nil {
+		d.sendError(conn, fmt.Sprintf("app logs %s: reading %s: %v", name, path, err))
+		return
+	}
+	d.sendDocResponse(conn, protocol.Response{
+		Ok: true,
+		AppLogsResult: &protocol.AppLogsResult{
+			Name: name, Path: path, Lines: lines, Truncated: truncated,
+		},
+	})
+}
+
+// readAppLog tails the shared runtime log, keeping the lines one app wrote.
+//
+// A log file that is not there is an empty answer, not an error: the runtime
+// writes it on its first start, and "no lines yet" is exactly what a caller
+// asking before then should hear.
+//
+// It reads the whole file rather than seeking from the end. The file is one
+// daemon's runtime output — bounded by uptime, not by history — and a backwards
+// scan that has to respect line boundaries and a tag filter is a lot of
+// machinery to save milliseconds on a diagnostic command.
+func readAppLog(path, app string, whole bool, limit int) ([]string, bool, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, false, nil
+		}
+		return nil, false, err
+	}
+	defer file.Close()
+
+	tag := appRuntimeAppTag(app)
+	kept := make([]string, 0, limit)
+	truncated := false
+	scanner := bufio.NewScanner(file)
+	// A handler can print a long line — a stack trace, a JSON body — and the
+	// default 64KB would end the scan on it rather than truncating the line.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !whole {
+			if !strings.HasPrefix(line, tag) {
+				continue
+			}
+			line = strings.TrimPrefix(line, tag)
+		}
+		if len(kept) == limit {
+			kept = kept[1:]
+			truncated = true
+		}
+		kept = append(kept, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, false, err
+	}
+	return kept, truncated, nil
+}
+
+func (d *Daemon) handleAppRuntimeStatus(conn net.Conn, _ *protocol.AppRuntimeStatusMessage) {
+	result := protocol.AppRuntimeStatusResult{LogPath: AppRuntimeLogPath(d.socketPath)}
+	if host, err := resolveAppRuntimeHost(); err != nil {
+		result.HostError = protocol.Ptr(err.Error())
+	} else {
+		result.HostPath = protocol.Ptr(host)
+	}
+	if d.store != nil {
+		rows, err := d.store.ListApps()
+		if err != nil {
+			d.sendError(conn, fmt.Sprintf("listing apps: %v", err))
+			return
+		}
+		result.Apps = len(rows)
+		for _, row := range rows {
+			consumer, ok, err := d.store.GetBusConsumer(apps.ConsumerName(row.Name))
+			if err == nil && ok && consumer.Enabled {
+				result.AppsEnabled++
+			}
+		}
+	}
+	if snapshot, ok := d.appRuntimeSnapshot(); ok {
+		info := d.appRuntimeInfo(snapshot)
+		result.Runtime = &info
+	}
+	d.sendDocResponse(conn, protocol.Response{Ok: true, AppRuntimeStatusResult: &result})
+}
+
+// handleAppRuntimeRestart bounces the sidecar: kill what is running, start a
+// fresh generation. Stop-then-Ensure covers both cases the verb has to serve —
+// a healthy runtime gets restarted, and a parked one is revived, because Ensure
+// is also un-park.
+func (d *Daemon) handleAppRuntimeRestart(conn net.Conn, _ *protocol.AppRuntimeRestartMessage) {
+	was := string(supervise.PhaseStopped)
+	if snapshot, ok := d.appRuntimeSnapshot(); ok {
+		was = string(snapshot.Phase)
+	}
+	d.ensureAppRuntimeSupervisor().Stop(appRuntimeChildName)
+	if err := d.ensureAppRuntime(); err != nil {
+		d.sendError(conn, fmt.Sprintf("app runtime restart: %v", err))
+		return
+	}
+	snapshot, _ := d.appRuntimeSnapshot()
+	info := d.appRuntimeInfo(snapshot)
+	d.sendDocResponse(conn, protocol.Response{
+		Ok: true,
+		AppRuntimeRestartResult: &protocol.AppRuntimeRestartResult{
+			Was: was, Runtime: info,
+		},
+	})
+}
+
+// appRuntimeInfo renders a supervision snapshot for the wire, joined to the
+// connected process's pid — which the supervisor does not know, because it
+// supervises a process and the pid that matters is the one that said hello.
+func (d *Daemon) appRuntimeInfo(snapshot supervise.Snapshot) protocol.AppRuntimeInfo {
+	info := protocol.AppRuntimeInfo{
+		Phase:          string(snapshot.Phase),
+		Desired:        string(snapshot.Desired),
+		Running:        snapshot.Running,
+		Connected:      snapshot.Connected,
+		Generation:     int(snapshot.Generation),
+		RestartAttempt: int(snapshot.RestartAttempt),
+	}
+	if !snapshot.StartedAt.IsZero() {
+		info.StartedAt = protocol.Ptr(stampForWire(snapshot.StartedAt))
+	}
+	if !snapshot.ConnectedAt.IsZero() {
+		info.ConnectedAt = protocol.Ptr(stampForWire(snapshot.ConnectedAt))
+	}
+	if !snapshot.NextRestartAt.IsZero() {
+		info.NextRestartAt = protocol.Ptr(stampForWire(snapshot.NextRestartAt))
+	}
+	if snapshot.LastExit != nil {
+		info.LastExit = protocol.Ptr(snapshot.LastExit.String())
+	}
+	if runtime := d.appRuntimeConnected(); runtime != nil {
+		info.Pid = protocol.Ptr(runtime.pid)
+	}
+	return info
+}
+
+// ---------------------------------------------------------------------------
+// The invocation stream
+// ---------------------------------------------------------------------------
+
+// appWatcher is one open `app_watch` connection.
+//
+// Deliveries are dropped rather than queued when the buffer fills: this is a
+// developer watching their handlers run, and a slow reader must not be able to
+// slow down the delivery loop that feeds it. A watcher that misses a burst can
+// read the whole record back with `attn app status`.
+type appWatcher struct {
+	app    string
+	events chan protocol.AppInvocationInfo
+}
+
+func (d *Daemon) addAppWatcher(watcher *appWatcher) {
+	d.appWatcherMu.Lock()
+	defer d.appWatcherMu.Unlock()
+	if d.appWatchers == nil {
+		d.appWatchers = make(map[*appWatcher]struct{})
+	}
+	d.appWatchers[watcher] = struct{}{}
+}
+
+func (d *Daemon) removeAppWatcher(watcher *appWatcher) {
+	d.appWatcherMu.Lock()
+	defer d.appWatcherMu.Unlock()
+	delete(d.appWatchers, watcher)
+}
+
+// notifyAppWatchers fans one recorded invocation out to whoever is watching that
+// app. Called from the delivery path, so it must never block.
+func (d *Daemon) notifyAppWatchers(info protocol.AppInvocationInfo, app string) {
+	d.appWatcherMu.Lock()
+	watchers := make([]*appWatcher, 0, len(d.appWatchers))
+	for watcher := range d.appWatchers {
+		if watcher.app == app {
+			watchers = append(watchers, watcher)
+		}
+	}
+	d.appWatcherMu.Unlock()
+	for _, watcher := range watchers {
+		select {
+		case watcher.events <- info:
+		default:
+		}
+	}
+}
+
+func (d *Daemon) handleAppWatch(conn net.Conn, msg *protocol.AppWatchMessage) {
+	name := strings.TrimSpace(msg.Name)
+	if err := apps.ValidateName(name); err != nil {
+		d.sendError(conn, err.Error())
+		return
+	}
+	watcher := &appWatcher{app: name, events: make(chan protocol.AppInvocationInfo, 64)}
+	d.addAppWatcher(watcher)
+	defer d.removeAppWatcher(watcher)
+
+	// The caller learns the subscription is live before the first invocation, so
+	// `attn app dev` can say it is watching rather than sitting silent.
+	if err := json.NewEncoder(conn).Encode(protocol.Response{Ok: true}); err != nil {
+		return
+	}
+
+	// A client that goes away between invocations would otherwise sit here until
+	// the daemon stops. Reading from the connection is how that is noticed: the
+	// caller sends nothing, so any read that returns means the socket closed.
+	gone := make(chan struct{})
+	go func() {
+		defer close(gone)
+		_, _ = conn.Read(make([]byte, 1))
+	}()
+
+	encoder := json.NewEncoder(conn)
+	for {
+		select {
+		case <-d.done:
+			return
+		case <-gone:
+			return
+		case info := <-watcher.events:
+			result := info
+			if err := encoder.Encode(protocol.Response{
+				Ok:             true,
+				AppWatchResult: &protocol.AppWatchResult{Invocation: result},
+			}); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// appInvocationForWire renders a recorded invocation, so the streamed shape and
+// the one `attn app status` returns cannot drift.
+func appInvocationForWire(id int64, inv store.AppInvocation) protocol.AppInvocationInfo {
+	return protocol.AppInvocationInfo{
+		ID:           int(id),
+		VersionID:    int(inv.VersionID),
+		EventSeq:     int(inv.EventSeq),
+		EventName:    inv.EventName,
+		EventSubject: inv.EventSubject,
+		Handler:      inv.Handler,
+		Status:       inv.Status,
+		Error:        inv.Error,
+		DurationMs:   int(inv.Duration.Milliseconds()),
+		StartedAt:    stampForWire(inv.StartedAt),
+	}
+}
+
+// appStallForWire renders the auto-disable clock, including when it fires.
+func appStallForWire(stall appStall) protocol.AppStallInfo {
+	return protocol.AppStallInfo{
+		EventSeq:   int(stall.seq),
+		EventName:  stall.eventName,
+		Since:      stampForWire(stall.since),
+		Attempts:   stall.attempts,
+		LastError:  stall.lastError,
+		DisablesAt: stampForWire(stall.since.Add(appAutoDisableStall)),
+	}
+}

--- a/internal/daemon/app_runtime_ipc_test.go
+++ b/internal/daemon/app_runtime_ipc_test.go
@@ -1,0 +1,373 @@
+package daemon
+
+import (
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/apps"
+	"github.com/victorarias/attn/internal/jobs"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// `attn app logs`, the invocation stream, and the invocation log's retention —
+// the three surfaces that answer "what has this app been doing".
+
+func appLogs(t *testing.T, d *Daemon, name string, lines int) protocol.Response {
+	t.Helper()
+	msg := &protocol.AppLogsMessage{Cmd: protocol.CmdAppLogs, Name: name}
+	if lines > 0 {
+		msg.Lines = protocol.Ptr(lines)
+	}
+	return docCall(t, func(c net.Conn) { d.handleAppLogs(c, msg) })
+}
+
+func writeRuntimeLog(t *testing.T, d *Daemon, lines ...string) {
+	t.Helper()
+	path := AppRuntimeLogPath(d.socketPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir log dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write runtime log: %v", err)
+	}
+}
+
+// One process, many apps, one log file. `attn app logs <name>` reads back the
+// tag the host writes, and `runtime` is how a reader sees the whole thing —
+// including the lines no app wrote, which is where a runtime that will not
+// start says why.
+func TestAppLogsFiltersByTagAndRuntimeShowsEverything(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+	writeRuntimeLog(t, d,
+		appRuntimeSelfTag+"starting, api version 1",
+		appRuntimeAppTag("greeter")+"hello from greeter",
+		appRuntimeAppTag("auditor")+"hello from auditor",
+		appRuntimeAppTag("greeter")+"and again",
+	)
+
+	resp := appLogs(t, d, "greeter", 0)
+	if !resp.Ok {
+		t.Fatalf("app logs greeter: %v", protocol.Deref(resp.Error))
+	}
+	got := resp.AppLogsResult.Lines
+	want := []string{"hello from greeter", "and again"}
+	if len(got) != len(want) {
+		t.Fatalf("lines = %q, want %q", got, want)
+	}
+	for i := range want {
+		// The tag is stripped: it is attn's plumbing, not something the app printed.
+		if got[i] != want[i] {
+			t.Fatalf("line %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if resp.AppLogsResult.Path != AppRuntimeLogPath(d.socketPath) {
+		t.Fatalf("path = %q, want the runtime log", resp.AppLogsResult.Path)
+	}
+
+	whole := appLogs(t, d, appRuntimeChildName, 0)
+	if !whole.Ok {
+		t.Fatalf("app logs runtime: %v", protocol.Deref(whole.Error))
+	}
+	if len(whole.AppLogsResult.Lines) != 4 {
+		t.Fatalf("runtime log lines = %q, want all four", whole.AppLogsResult.Lines)
+	}
+	if !strings.Contains(whole.AppLogsResult.Lines[0], "api version 1") {
+		t.Fatalf("the runtime's own lines are missing: %q", whole.AppLogsResult.Lines)
+	}
+}
+
+// The tag is written in TypeScript and read in Go, so nothing but a test keeps
+// the two spellings the same. A drift here makes `attn app logs <name>` return
+// nothing at all, with no error to explain it.
+func TestAppLogTagMatchesTheHost(t *testing.T) {
+	source, err := os.ReadFile(filepath.Join("..", "..", "apphost", "src", "index.ts"))
+	if err != nil {
+		t.Fatalf("read the app runtime host: %v", err)
+	}
+	// The Go side builds "[app <name>] " and "[runtime] "; the host has to write
+	// exactly those prefixes.
+	if !strings.Contains(string(source), "[app ${app}] ") {
+		t.Fatalf("the host does not write the per-app tag %q that `attn app logs` filters on", appRuntimeAppTag("<name>"))
+	}
+	if !strings.Contains(string(source), appRuntimeSelfTag) {
+		t.Fatalf("the host does not write the runtime tag %q", appRuntimeSelfTag)
+	}
+}
+
+// A log file that does not exist is an empty answer, not an error: the runtime
+// writes it on its first start, and a caller asking before then is asking a
+// reasonable question.
+func TestAppLogsBeforeTheRuntimeEverRanIsEmptyNotAnError(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+
+	resp := appLogs(t, d, "greeter", 0)
+	if !resp.Ok {
+		t.Fatalf("app logs before any runtime ran: %v", protocol.Deref(resp.Error))
+	}
+	if len(resp.AppLogsResult.Lines) != 0 {
+		t.Fatalf("lines = %q, want none", resp.AppLogsResult.Lines)
+	}
+	// The path is still named, which is the actionable half of an empty answer.
+	if resp.AppLogsResult.Path == "" {
+		t.Fatal("an empty answer did not say where the log would be")
+	}
+}
+
+// A limit someone can hit is a limit they must see.
+func TestAppLogsRefusesAnAskPastItsCeilingByName(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+
+	resp := appLogs(t, d, "greeter", appLogMaxLines+1)
+	if resp.Ok {
+		t.Fatal("an ask past the ceiling was served")
+	}
+	msg := protocol.Deref(resp.Error)
+	for _, want := range []string{"10001", "10000", AppRuntimeLogPath(d.socketPath)} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("the refusal does not name %q: %s", want, msg)
+		}
+	}
+}
+
+// Truncation is reported rather than silent: a reader who sees exactly N lines
+// has to know whether that is all of them.
+func TestAppLogsSaysWhenItDroppedOlderLines(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+	lines := make([]string, 0, 5)
+	for _, text := range []string{"one", "two", "three", "four", "five"} {
+		lines = append(lines, appRuntimeAppTag("greeter")+text)
+	}
+	writeRuntimeLog(t, d, lines...)
+
+	resp := appLogs(t, d, "greeter", 2)
+	if !resp.Ok {
+		t.Fatalf("app logs: %v", protocol.Deref(resp.Error))
+	}
+	if !resp.AppLogsResult.Truncated {
+		t.Fatal("older lines were dropped without saying so")
+	}
+	// The newest, not the oldest: a tail is what a reader wants.
+	if got := resp.AppLogsResult.Lines; len(got) != 2 || got[0] != "four" || got[1] != "five" {
+		t.Fatalf("lines = %q, want the last two", got)
+	}
+}
+
+// `attn app dev` renders this stream. It has to reach a watcher as the handler
+// runs, not only when the developer next asks for status.
+func TestAppWatchStreamsInvocationsAsTheyHappen(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+	installApp(t, d, "auditor", subscribing("ticket.*"))
+	startFakeAppRuntime(t, d, nil)
+
+	watcher := &appWatcher{app: "greeter", events: make(chan protocol.AppInvocationInfo, 4)}
+	d.addAppWatcher(watcher)
+	t.Cleanup(func() { d.removeAppWatcher(watcher) })
+
+	if err := d.deliverAppEvent(t.Context(), "auditor", appEvent("ticket.created", "tk-1", 1)); err != nil {
+		t.Fatalf("deliver to auditor: %v", err)
+	}
+	if err := d.deliverAppEvent(t.Context(), "greeter", appEvent("ticket.created", "tk-2", 2)); err != nil {
+		t.Fatalf("deliver to greeter: %v", err)
+	}
+
+	select {
+	case info := <-watcher.events:
+		if info.EventSubject != "tk-2" {
+			// The auditor's invocation must not reach a watcher of greeter.
+			t.Fatalf("the stream carried %+v, want greeter's own invocation", info)
+		}
+		if info.Status != appInvocationStatusOK || info.Handler != "ticket.*" {
+			t.Fatalf("streamed invocation = %+v", info)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the invocation never reached the watcher")
+	}
+	if len(watcher.events) != 0 {
+		t.Fatalf("%d extra invocation(s) reached a watcher of greeter", len(watcher.events))
+	}
+}
+
+// A slow watcher must not be able to slow down delivery. Dropping is the
+// deliberate choice: `attn app status` has the whole record.
+func TestASlowWatcherIsDroppedRatherThanBlockingDelivery(t *testing.T) {
+	d := newAppDaemon(t)
+	watcher := &appWatcher{app: "greeter", events: make(chan protocol.AppInvocationInfo)}
+	d.addAppWatcher(watcher)
+	t.Cleanup(func() { d.removeAppWatcher(watcher) })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.notifyAppWatchers(protocol.AppInvocationInfo{EventSubject: "tk-1"}, "greeter")
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a watcher nobody is reading blocked the delivery path")
+	}
+}
+
+// Retention trims by age across every app, including apps that no longer exist:
+// removing an app keeps its invocation history, and nothing else would ever
+// reap those rows.
+func TestInvocationRetentionTrimsByAgeAcrossEveryApp(t *testing.T) {
+	d := newAppDaemon(t)
+	clock := newAppTestClock(d)
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+
+	old := clock.Now().Add(-AppInvocationRetention - time.Hour)
+	fresh := clock.Now().Add(-time.Hour)
+	for _, row := range []struct {
+		app  string
+		when time.Time
+	}{
+		{"greeter", old},
+		{"greeter", fresh},
+		{"removed-app", old},
+		{"removed-app", fresh},
+	} {
+		if _, err := d.store.AppendAppInvocation(store.AppInvocation{
+			AppName: row.app, VersionID: 1, EventSeq: 1, EventName: "ticket.created",
+			Handler: "ticket.*", Status: appInvocationStatusOK, StartedAt: row.when,
+		}); err != nil {
+			t.Fatalf("append invocation: %v", err)
+		}
+	}
+
+	result, err := d.appInvocationRetentionHandler(t.Context(), &jobs.Job{})
+	if err != nil {
+		t.Fatalf("retention pass: %v", err)
+	}
+	if removed := result.(map[string]any)["removed"]; removed != 2 {
+		t.Fatalf("removed = %v, want 2 — one per app, including the removed one", removed)
+	}
+	for _, app := range []string{"greeter", "removed-app"} {
+		rows, err := d.store.ListAppInvocations(app, 10)
+		if err != nil {
+			t.Fatalf("list invocations for %s: %v", app, err)
+		}
+		if len(rows) != 1 || !rows[0].StartedAt.Equal(fresh.UTC()) {
+			t.Fatalf("%s kept %+v, want only the fresh row", app, rows)
+		}
+	}
+}
+
+// The age window cannot bound the table on its own — how many rows thirty days
+// holds is a property of what the app subscribed to, and the loudest fact in attn
+// runs three orders of magnitude above the quietest. The per-app cap is what
+// makes the size predictable, and it keeps the newest rows: the ones a reader
+// asking "what did it just do" is looking for.
+func TestInvocationRetentionCapsEachAppAtItsNewestRows(t *testing.T) {
+	d := newAppDaemon(t)
+	clock := newAppTestClock(d)
+	installApp(t, d, "loud", subscribing("ticket.*"))
+
+	const cap = 5
+	// Every row is inside the age window, so only the cap can remove anything.
+	for i := 0; i < cap+4; i++ {
+		if _, err := d.store.AppendAppInvocation(store.AppInvocation{
+			AppName: "loud", VersionID: 1, EventSeq: int64(i), EventName: "ticket.created",
+			Handler: "ticket.*", Status: appInvocationStatusOK,
+			StartedAt: clock.Now().Add(time.Duration(i) * time.Second),
+		}); err != nil {
+			t.Fatalf("append invocation: %v", err)
+		}
+	}
+
+	removed, err := d.store.TrimAppInvocations(clock.Now().Add(-AppInvocationRetention), cap)
+	if err != nil {
+		t.Fatalf("trim: %v", err)
+	}
+	if removed != 4 {
+		t.Fatalf("removed = %d, want 4 — nine rows capped at five", removed)
+	}
+	rows, err := d.store.ListAppInvocations("loud", 100)
+	if err != nil {
+		t.Fatalf("list invocations: %v", err)
+	}
+	if len(rows) != cap {
+		t.Fatalf("kept %d rows, want %d", len(rows), cap)
+	}
+	// ListAppInvocations is newest first, so the survivors are seqs 8..4.
+	for i, row := range rows {
+		if want := int64(cap + 3 - i); row.EventSeq != want {
+			t.Fatalf("row %d is seq %d, want %d — the cap dropped the wrong end", i, row.EventSeq, want)
+		}
+	}
+}
+
+// `attn app status` is where a reader looks when an app is doing nothing, so it
+// has to carry the stall clock — including when it fires.
+func TestAppStatusCarriesTheStallClockAndWhenItFires(t *testing.T) {
+	d := newAppDaemon(t)
+	clock := newAppTestClock(d)
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+	startFakeAppRuntime(t, d, func(*fakeAppRuntime, appDispatchRequest) error {
+		return errors.New("ReferenceError: ticket is not defined")
+	})
+
+	if err := d.deliverAppEvent(t.Context(), "greeter", appEvent("ticket.created", "tk-1", 9)); err == nil {
+		t.Fatal("a throwing handler reported success")
+	}
+	resp := appStatus(t, d, "greeter")
+	if !resp.Ok {
+		t.Fatalf("app status: %v", protocol.Deref(resp.Error))
+	}
+	stall := resp.AppStatusResult.Stall
+	if stall == nil {
+		t.Fatal("a stalled app's status carried no stall")
+	}
+	if stall.EventSeq != 9 || stall.EventName != "ticket.created" || stall.Attempts != 1 {
+		t.Fatalf("stall = %+v", stall)
+	}
+	if !strings.Contains(stall.LastError, "ReferenceError") {
+		t.Fatalf("stall does not say what failed: %q", stall.LastError)
+	}
+	want := stampForWire(clock.Now().Add(appAutoDisableStall))
+	if stall.DisablesAt != want {
+		t.Fatalf("disables at %q, want %q", stall.DisablesAt, want)
+	}
+
+	// A success clears it, and status says so by omission rather than by a stale
+	// entry nobody updated.
+	d.clearAppStall("greeter")
+	if again := appStatus(t, d, "greeter"); again.AppStatusResult.Stall != nil {
+		t.Fatalf("a recovered app still reports a stall: %+v", again.AppStatusResult.Stall)
+	}
+}
+
+// A reserved name cannot become an app, at the daemon as well as in the name
+// rule — `runtime` in particular, because `attn app logs runtime` already means
+// the shared process.
+func TestApplyRefusesAReservedAppName(t *testing.T) {
+	d := newAppDaemon(t)
+	for _, name := range apps.ReservedNames() {
+		resp := docCall(t, func(c net.Conn) {
+			d.handleAppApply(c, &protocol.AppApplyMessage{
+				Cmd: protocol.CmdAppApply, Name: name,
+				ContentHash: "sha256:whatever",
+				Declaration: `{"name":"` + name + `","subscribe":[{"events":["ticket.*"]}]}`,
+			})
+		})
+		if resp.Ok {
+			t.Fatalf("apply installed an app called %q", name)
+		}
+		if !strings.Contains(protocol.Deref(resp.Error), "reserved") {
+			t.Fatalf("apply of %q did not say the name is reserved: %s", name, protocol.Deref(resp.Error))
+		}
+	}
+	if rows, err := d.store.ListApps(); err != nil || len(rows) != 0 {
+		t.Fatalf("apps = %+v (err %v), want none installed", rows, err)
+	}
+}

--- a/internal/daemon/app_runtime_rpc.go
+++ b/internal/daemon/app_runtime_rpc.go
@@ -1,0 +1,358 @@
+package daemon
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"github.com/victorarias/attn/internal/docstore"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// The sidecar's side of the socket: how the app runtime connects, what it may
+// ask the daemon for, and how a dispatch travels.
+//
+// It speaks the same newline-delimited JSON-RPC as a plugin (jsonrpc_peer.go
+// holds the transport both share) but it is not a plugin and does not enter the
+// plugin registry: a plugin is an extension the user installed, and this is one
+// process attn ships and owns.
+//
+// The methods the sidecar may call are exactly the collection operations, and
+// each one is scoped by the daemon's own record of the dispatch in flight — see
+// appDispatch. There is no namespace on the wire to get wrong.
+
+const appRuntimeHelloMethod = "app_runtime.hello"
+
+type appRuntimeHelloParams struct {
+	Generation uint64 `json:"generation"`
+	APIVersion int    `json:"api_version"`
+	PID        int    `json:"pid"`
+}
+
+type appRuntimeHelloResult struct {
+	OK bool `json:"ok"`
+}
+
+// appRuntimeConnection is the live sidecar.
+type appRuntimeConnection struct {
+	*jsonrpcPeer
+
+	generation  uint64
+	pid         int
+	connectedAt time.Time
+}
+
+func (c *appRuntimeConnection) dispatch(ctx context.Context, req appDispatchRequest) (appDispatchResult, error) {
+	var result appDispatchResult
+	if err := c.request(ctx, "app runtime", "app.dispatch", req, &result); err != nil {
+		return appDispatchResult{}, err
+	}
+	return result, nil
+}
+
+// parseAppRuntimeHello recognizes the sidecar's opening frame.
+//
+// It runs before the plugin hello sniff, because the plugin parser treats any
+// JSON-RPC frame as a plugin's and would refuse this one with "first plugin
+// method must be hello" — a true sentence about the wrong protocol.
+func parseAppRuntimeHello(data []byte) (json.RawMessage, appRuntimeHelloParams, bool, error) {
+	var msg jsonRPCMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return nil, appRuntimeHelloParams{}, false, nil
+	}
+	if msg.Method != appRuntimeHelloMethod {
+		return nil, appRuntimeHelloParams{}, false, nil
+	}
+	if msg.JSONRPC != "2.0" {
+		return msg.ID, appRuntimeHelloParams{}, true, errors.New(`jsonrpc must be "2.0"`)
+	}
+	if jsonRPCIDKey(msg.ID) == "" {
+		return msg.ID, appRuntimeHelloParams{}, true, errors.New(appRuntimeHelloMethod + " requires an id")
+	}
+	var params appRuntimeHelloParams
+	if err := json.Unmarshal(msg.Params, &params); err != nil {
+		return msg.ID, appRuntimeHelloParams{}, true, fmt.Errorf("decode %s params: %w", appRuntimeHelloMethod, err)
+	}
+	if params.Generation == 0 {
+		return msg.ID, appRuntimeHelloParams{}, true, errors.New("params.generation is required; the supervisor fences stale runtimes by generation")
+	}
+	if params.APIVersion != appRuntimeAPIVersion {
+		return msg.ID, appRuntimeHelloParams{}, true, fmt.Errorf(
+			"app runtime api version %d, but this daemon speaks %d; the runtime binary and the daemon ship together, so this is a stale install rather than a configuration to change",
+			params.APIVersion, appRuntimeAPIVersion)
+	}
+	return msg.ID, params, true, nil
+}
+
+// handleAppRuntimeConnection owns the sidecar's connection for its whole life.
+func (d *Daemon) handleAppRuntimeConnection(conn net.Conn, reader *bufio.Reader, helloID json.RawMessage, params appRuntimeHelloParams) {
+	runtime := &appRuntimeConnection{
+		jsonrpcPeer: newJSONRPCPeer(conn, reader),
+		generation:  params.Generation,
+		pid:         params.PID,
+		connectedAt: d.appNow(),
+	}
+	if !d.ensureAppRuntimeSupervisor().NoteConnected(appRuntimeChildName, runtime.generation) {
+		_ = runtime.send(jsonRPCFailure(helloID, jsonRPCInvalidRequest,
+			"this app runtime's generation is no longer current; a newer one has already been started"))
+		return
+	}
+	d.setAppRuntimeConnection(runtime)
+	defer func() {
+		// Same ordering as the plugin path: note the disconnect before the
+		// connection stops being reachable, so a replacement's NoteConnected
+		// cancels the grace timer instead of an old defer arming it after the new
+		// process is already healthy.
+		d.ensureAppRuntimeSupervisor().NoteDisconnected(appRuntimeChildName, runtime.generation)
+		d.clearAppRuntimeConnection(runtime)
+		// Every dispatch waiting on this process learns now. Without it each one
+		// would wait out its whole timeout for an answer that can never come.
+		runtime.closePending(io.EOF)
+	}()
+
+	if err := runtime.send(jsonRPCResult(helloID, appRuntimeHelloResult{OK: true})); err != nil {
+		return
+	}
+	d.logf("app runtime connected (generation %d, pid %d)", runtime.generation, runtime.pid)
+	d.publishFact(FactAppRuntimeChanged, appRuntimeChildName, nil)
+
+	for {
+		data, err := readSocketFrame(reader)
+		if err != nil {
+			return
+		}
+		var msg jsonRPCMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			_ = runtime.send(jsonRPCFailure(nil, jsonRPCParseError, "parse JSON-RPC message"))
+			continue
+		}
+		if msg.JSONRPC != "2.0" {
+			_ = runtime.send(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, `jsonrpc must be "2.0"`))
+			continue
+		}
+		if msg.Method == "" {
+			if !runtime.routeResponse(msg) {
+				// The caller's context expired first and it has already given up.
+				// Saying so on the wire would be noise the host cannot act on.
+				d.logf("app runtime: answer to request %s arrived with nobody waiting", jsonRPCIDKey(msg.ID))
+			}
+			continue
+		}
+		// Off the read loop: several apps dispatch concurrently over this one
+		// socket, and a collection read for one must not hold up another app's
+		// answers behind it.
+		go d.serveAppRuntimeMethod(runtime, msg)
+	}
+}
+
+func (d *Daemon) setAppRuntimeConnection(runtime *appRuntimeConnection) {
+	d.appRuntimeMu.Lock()
+	d.appRuntimeConn = runtime
+	// Wakes every delivery parked on the cold start.
+	if d.appRuntimeReady != nil {
+		close(d.appRuntimeReady)
+		d.appRuntimeReady = nil
+	}
+	d.appRuntimeMu.Unlock()
+}
+
+// clearAppRuntimeConnection drops the connection only if it is still the current
+// one. A slow teardown must not unpublish a replacement that has already
+// connected.
+func (d *Daemon) clearAppRuntimeConnection(runtime *appRuntimeConnection) {
+	d.appRuntimeMu.Lock()
+	if d.appRuntimeConn == runtime {
+		d.appRuntimeConn = nil
+	}
+	d.appRuntimeMu.Unlock()
+	d.publishFact(FactAppRuntimeChanged, appRuntimeChildName, nil)
+}
+
+func (d *Daemon) serveAppRuntimeMethod(runtime *appRuntimeConnection, msg jsonRPCMessage) {
+	if jsonRPCIDKey(msg.ID) == "" {
+		_ = runtime.send(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, "app runtime method calls require an id"))
+		return
+	}
+	result, err := d.appRuntimeMethod(msg)
+	if err != nil {
+		_ = runtime.send(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, err.Error()))
+		return
+	}
+	_ = runtime.send(jsonRPCResult(msg.ID, result))
+}
+
+// appCollectionParams is what every collection callback carries. There is
+// deliberately no namespace: the daemon reads it off the dispatch record, so an
+// app cannot name one — its own or anybody else's.
+type appCollectionParams struct {
+	Dispatch   string          `json:"dispatch"`
+	Collection string          `json:"collection"`
+	ID         string          `json:"id"`
+	Body       json.RawMessage `json:"body"`
+	IfRev      *int64          `json:"if_rev"`
+	Query      *docstore.Query `json:"query"`
+}
+
+func (d *Daemon) appRuntimeMethod(msg jsonRPCMessage) (any, error) {
+	switch msg.Method {
+	case "app.collection.get", "app.collection.put", "app.collection.delete",
+		"app.collection.query", "app.collection.count":
+	default:
+		return nil, fmt.Errorf("unknown method %q", msg.Method)
+	}
+
+	var params appCollectionParams
+	if err := json.Unmarshal(msg.Params, &params); err != nil {
+		return nil, fmt.Errorf("decode %s params: %w", msg.Method, err)
+	}
+	dispatch, err := d.lookupAppDispatch(params.Dispatch)
+	if err != nil {
+		return nil, err
+	}
+	if _, declared := dispatch.collections[params.Collection]; !declared {
+		return nil, fmt.Errorf(
+			"app %s did not declare a collection named %q; ctx.collections only carries what attn-app.toml declares, and adding a [[collections]] block plus `attn app apply` is what creates one",
+			dispatch.app, params.Collection)
+	}
+
+	switch msg.Method {
+	case "app.collection.get":
+		return d.appCollectionGet(dispatch, params)
+	case "app.collection.put":
+		return d.appCollectionPut(dispatch, params)
+	case "app.collection.delete":
+		return d.appCollectionDelete(dispatch, params)
+	case "app.collection.query":
+		return d.appCollectionQuery(dispatch, params)
+	default:
+		return d.appCollectionCount(dispatch, params)
+	}
+}
+
+// appDocument is one document as the SDK's Document type sees it.
+type appDocument struct {
+	ID        string          `json:"id"`
+	Body      json.RawMessage `json:"body"`
+	Rev       int64           `json:"rev"`
+	CreatedAt string          `json:"created_at"`
+	UpdatedAt string          `json:"updated_at"`
+}
+
+func appDocumentOf(doc docstore.Document) appDocument {
+	return appDocument{
+		ID:        doc.ID,
+		Body:      doc.Body,
+		Rev:       doc.Rev,
+		CreatedAt: stampForWire(doc.CreatedAt),
+		UpdatedAt: stampForWire(doc.UpdatedAt),
+	}
+}
+
+func (d *Daemon) appCollectionGet(dispatch *appDispatch, params appCollectionParams) (any, error) {
+	read, declared, err := d.store.ReadDocument(dispatch.namespace, params.Collection, params.ID)
+	if err != nil {
+		return nil, err
+	}
+	if !declared {
+		return nil, undeclaredCollectionError(dispatch.namespace, params.Collection)
+	}
+	if !read.Found {
+		// The SDK types this as Document | null, so the absent case is a value
+		// rather than a failure: "no such document" is an ordinary answer.
+		return nil, nil
+	}
+	return appDocumentOf(*read.Document), nil
+}
+
+func (d *Daemon) appCollectionPut(dispatch *appDispatch, params appCollectionParams) (any, error) {
+	schema, err := d.collectionFor(dispatch.namespace, params.Collection)
+	if err != nil {
+		return nil, err
+	}
+	if err := docstore.ValidateDocumentID(params.ID); err != nil {
+		return nil, err
+	}
+	if err := docstore.ValidateBody(params.Body); err != nil {
+		return nil, err
+	}
+	fact := documentChangedFact(dispatch.namespace, params.Collection, params.ID, false)
+	written, err := d.store.CommitDocumentWrite(store.DocumentWrite{
+		Schema: *schema, ID: params.ID, Body: params.Body, Expected: params.IfRev,
+	}, fact, d.appNow())
+	if err != nil {
+		return nil, err
+	}
+	d.announceCommittedWrite(fact, written.Seq)
+	// Read back rather than synthesize: the SDK hands the caller a Document, and
+	// the timestamps on it are the store's, not this call's idea of now.
+	read, _, err := d.store.ReadDocument(dispatch.namespace, params.Collection, params.ID)
+	if err == nil && read.Found {
+		return appDocumentOf(*read.Document), nil
+	}
+	return appDocument{ID: params.ID, Body: params.Body, Rev: written.Rev}, nil
+}
+
+func (d *Daemon) appCollectionDelete(dispatch *appDispatch, params appCollectionParams) (any, error) {
+	schema, err := d.collectionFor(dispatch.namespace, params.Collection)
+	if err != nil {
+		return nil, err
+	}
+	fact := documentChangedFact(dispatch.namespace, params.Collection, params.ID, true)
+	written, err := d.store.CommitDocumentWrite(store.DocumentWrite{
+		Schema: *schema, ID: params.ID, Delete: true, Expected: params.IfRev,
+	}, fact, d.appNow())
+	if err != nil {
+		return nil, err
+	}
+	if written.Changed {
+		d.announceCommittedWrite(fact, written.Seq)
+	}
+	return written.Changed, nil
+}
+
+// appQuery fills in the two fields the app is not allowed to choose.
+func (d *Daemon) appQuery(dispatch *appDispatch, params appCollectionParams) docstore.Query {
+	q := docstore.Query{}
+	if params.Query != nil {
+		q = *params.Query
+	}
+	q.Namespace = dispatch.namespace
+	q.Collection = params.Collection
+	return q
+}
+
+func (d *Daemon) appCollectionQuery(dispatch *appDispatch, params appCollectionParams) (any, error) {
+	read, took, err := d.runDocQuery(d.appQuery(dispatch, params))
+	if err != nil {
+		return nil, err
+	}
+	d.logSlowDocQuery(read.Schema, took)
+	out := make([]appDocument, 0, len(read.Documents))
+	for _, doc := range read.Documents {
+		out = append(out, appDocumentOf(doc))
+	}
+	return out, nil
+}
+
+func (d *Daemon) appCollectionCount(dispatch *appDispatch, params appCollectionParams) (any, error) {
+	q := d.appQuery(dispatch, params)
+	if err := docstore.ValidateNamespace(q.Namespace); err != nil {
+		return nil, docstore.InvalidQuery(err)
+	}
+	if err := docstore.ValidateCollection(q.Collection); err != nil {
+		return nil, docstore.InvalidQuery(err)
+	}
+	read, found, err := d.store.CountQuery(q)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, undeclaredCollectionError(q.Namespace, q.Collection)
+	}
+	return read.Count, nil
+}

--- a/internal/daemon/app_runtime_test.go
+++ b/internal/daemon/app_runtime_test.go
@@ -1,0 +1,974 @@
+package daemon
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/appbuild"
+	"github.com/victorarias/attn/internal/apps"
+	"github.com/victorarias/attn/internal/bus"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+	"github.com/victorarias/attn/internal/supervise"
+)
+
+// The app runtime as the daemon sees it: a sidecar on the other end of a socket
+// that answers `app.dispatch` and calls back for documents.
+//
+// Every test here stands up a fake sidecar rather than the compiled Bun host.
+// What is being pinned is the daemon's half — which app a failure is charged to,
+// what the invocation log records, which namespace a callback resolves to — and
+// running real JavaScript to prove any of that would make the test slower and
+// tell it less.
+
+// ---------------------------------------------------------------------------
+// The fake sidecar
+// ---------------------------------------------------------------------------
+
+// fakeAppRuntime is a sidecar that connects over a pipe and runs a Go function
+// as every handler.
+type fakeAppRuntime struct {
+	t    *testing.T
+	conn net.Conn
+
+	// handler runs in place of the app's code. Returning an error is a handler
+	// that threw; the sidecar reports it as ok:false, which is how an app's fault
+	// reaches the daemon.
+	handler func(*fakeAppRuntime, appDispatchRequest) error
+
+	writeMu sync.Mutex
+
+	mu         sync.Mutex
+	dispatches []appDispatchRequest
+	pending    map[string]chan jsonRPCMessage
+	nextID     int
+}
+
+// startFakeAppRuntime connects a sidecar to d and waits until the daemon has
+// adopted it, so a dispatch that follows cannot race the connection.
+func startFakeAppRuntime(t *testing.T, d *Daemon, handler func(*fakeAppRuntime, appDispatchRequest) error) *fakeAppRuntime {
+	t.Helper()
+	serverConn, clientConn := net.Pipe()
+	runtime := &fakeAppRuntime{
+		t:       t,
+		conn:    clientConn,
+		handler: handler,
+		pending: make(map[string]chan jsonRPCMessage),
+	}
+
+	served := make(chan struct{})
+	go func() {
+		defer close(served)
+		d.handleConnection(serverConn)
+	}()
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		select {
+		case <-served:
+		case <-time.After(2 * time.Second):
+			t.Error("the daemon did not let go of the app runtime connection")
+		}
+	})
+
+	reader := bufio.NewReader(clientConn)
+	runtime.sendRaw(jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`"hello"`),
+		Method:  appRuntimeHelloMethod,
+		Params:  mustJSON(t, appRuntimeHelloParams{Generation: 1, APIVersion: appRuntimeAPIVersion, PID: 4242}),
+	})
+	frame, err := readSocketFrame(reader)
+	if err != nil {
+		t.Fatalf("app runtime hello got no answer: %v", err)
+	}
+	var ack jsonRPCMessage
+	if err := json.Unmarshal(frame, &ack); err != nil {
+		t.Fatalf("decode hello answer: %v", err)
+	}
+	if ack.Error != nil {
+		t.Fatalf("hello refused: %s", ack.Error.Message)
+	}
+	go runtime.serve(reader)
+
+	// The daemon publishes the connection from the same goroutine that answered
+	// hello, so an answered hello does not yet mean appRuntimeConnected() is set.
+	waitFor(t, "the daemon to adopt the app runtime", func() bool {
+		return d.appRuntimeConnected() != nil
+	})
+	return runtime
+}
+
+// serve is the sidecar's read loop: dispatches run the handler, everything else
+// is an answer to a callback this sidecar made.
+func (f *fakeAppRuntime) serve(reader *bufio.Reader) {
+	for {
+		data, err := readSocketFrame(reader)
+		if err != nil {
+			f.mu.Lock()
+			for _, ch := range f.pending {
+				close(ch)
+			}
+			f.pending = map[string]chan jsonRPCMessage{}
+			f.mu.Unlock()
+			return
+		}
+		var msg jsonRPCMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			continue
+		}
+		if msg.Method == "" {
+			f.mu.Lock()
+			ch := f.pending[jsonRPCIDKey(msg.ID)]
+			delete(f.pending, jsonRPCIDKey(msg.ID))
+			f.mu.Unlock()
+			if ch != nil {
+				ch <- msg
+			}
+			continue
+		}
+		if msg.Method != "app.dispatch" {
+			f.sendRaw(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, "the fake sidecar only serves app.dispatch"))
+			continue
+		}
+		var req appDispatchRequest
+		if err := json.Unmarshal(msg.Params, &req); err != nil {
+			f.sendRaw(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, err.Error()))
+			continue
+		}
+		f.mu.Lock()
+		f.dispatches = append(f.dispatches, req)
+		f.mu.Unlock()
+		// On its own goroutine: a handler that calls back into the daemon would
+		// otherwise deadlock against this loop, which is the answer's only reader.
+		go func(id json.RawMessage, req appDispatchRequest) {
+			result := appDispatchResult{OK: true}
+			if f.handler != nil {
+				if err := f.handler(f, req); err != nil {
+					result = appDispatchResult{OK: false, Error: err.Error()}
+				}
+			}
+			f.sendRaw(jsonRPCResult(id, result))
+		}(msg.ID, req)
+	}
+}
+
+func (f *fakeAppRuntime) sendRaw(msg jsonRPCMessage) {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return
+	}
+	f.writeMu.Lock()
+	defer f.writeMu.Unlock()
+	_, _ = f.conn.Write(append(data, '\n'))
+}
+
+// call makes a collection callback, the way a handler's ctx.collections does.
+func (f *fakeAppRuntime) call(method string, params appCollectionParams) (json.RawMessage, error) {
+	f.mu.Lock()
+	f.nextID++
+	id := json.RawMessage(fmt.Sprintf(`"cb-%d"`, f.nextID))
+	answer := make(chan jsonRPCMessage, 1)
+	f.pending[jsonRPCIDKey(id)] = answer
+	f.mu.Unlock()
+
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, err
+	}
+	f.sendRaw(jsonRPCMessage{JSONRPC: "2.0", ID: id, Method: method, Params: body})
+
+	select {
+	case msg, ok := <-answer:
+		if !ok {
+			return nil, errors.New("the connection closed before the daemon answered")
+		}
+		if msg.Error != nil {
+			return nil, errors.New(msg.Error.Message)
+		}
+		return msg.Result, nil
+	case <-time.After(5 * time.Second):
+		return nil, fmt.Errorf("the daemon never answered %s", method)
+	}
+}
+
+func (f *fakeAppRuntime) dispatchLog() []appDispatchRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]appDispatchRequest, len(f.dispatches))
+	copy(out, f.dispatches)
+	return out
+}
+
+func mustJSON(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal %T: %v", v, err)
+	}
+	return data
+}
+
+// waitFor blocks until cond holds. It exists because several of the signals
+// these tests wait on — the daemon adopting a connection, the bus advancing a
+// cursor — are reached from another goroutine with no channel to hand back.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// ---------------------------------------------------------------------------
+// App fixtures
+// ---------------------------------------------------------------------------
+
+// newAppDaemon is a daemon with the event bus running, which is what every app
+// surface assumes: registration persists a consumer row only once the bus has
+// started, and a test reading that row off a stopped bus would be asserting
+// against a state production never sees.
+func newAppDaemon(t *testing.T) *Daemon {
+	t.Helper()
+	d := newDaemonForTest(t)
+	if err := d.eventBus.Start(); err != nil {
+		t.Fatalf("start the event bus: %v", err)
+	}
+	// Registered first so it runs LAST: a sidecar or a parked handler released by
+	// a later cleanup has to be gone before the bus stops waiting on it.
+	t.Cleanup(d.stopEventBus)
+	return d
+}
+
+// installApp writes the rows one apply produces: a version carrying the frozen
+// declaration, and the app pointed at it.
+func installApp(t *testing.T, d *Daemon, name string, manifest appbuild.Manifest) store.AppVersion {
+	t.Helper()
+	manifest.Name = name
+	if manifest.AttnAppAPI == 0 {
+		manifest.AttnAppAPI = appbuild.APIVersion
+	}
+	if manifest.Entrypoint == "" {
+		manifest.Entrypoint = "src/index.ts"
+	}
+	declaration, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal declaration: %v", err)
+	}
+	now := time.Now().UTC()
+	if err := d.store.SaveApp(name, now); err != nil {
+		t.Fatalf("save app %s: %v", name, err)
+	}
+	hash := fmt.Sprintf("sha256:%s-%x", name, len(declaration))
+	version, _, err := d.store.CommitAppVersion(store.AppVersion{
+		AppName:      name,
+		ContentHash:  hash,
+		Declaration:  string(declaration),
+		ArtifactPath: filepath.Join("apps", name, hash+".js"),
+	}, now)
+	if err != nil {
+		t.Fatalf("commit version for %s: %v", name, err)
+	}
+	if err := d.store.SetAppCurrentVersion(name, version.ID, now); err != nil {
+		t.Fatalf("point %s at version %d: %v", name, version.ID, err)
+	}
+	d.syncAppRuntimeForVersion(name)
+	return version
+}
+
+func subscribing(events ...string) appbuild.Manifest {
+	return appbuild.Manifest{Subscribe: []appbuild.Subscribe{{Events: events}}}
+}
+
+func appEvent(name, subject string, seq int64) bus.Event {
+	return bus.Event{Name: name, Subject: subject, Seq: seq, CreatedAt: time.Now().UTC()}
+}
+
+func invocationsOf(t *testing.T, d *Daemon, name string) []store.AppInvocation {
+	t.Helper()
+	rows, err := d.store.ListAppInvocations(name, 50)
+	if err != nil {
+		t.Fatalf("list invocations for %s: %v", name, err)
+	}
+	return rows
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+// The whole happy path, through the real bus: a published fact reaches the
+// handler, the invocation is recorded against the version that ran, and the
+// cursor moves past the event.
+func TestAppConsumerDispatchesAndAdvancesItsCursor(t *testing.T) {
+	d := newAppDaemon(t)
+	version := installApp(t, d, "greeter", subscribing("ticket.*"))
+	runtime := startFakeAppRuntime(t, d, nil)
+
+	d.publishFact("ticket.created", "tk-1", map[string]string{"title": "work"})
+
+	waitFor(t, "the handler to be dispatched", func() bool { return len(runtime.dispatchLog()) == 1 })
+	got := runtime.dispatchLog()[0]
+	if got.App != "greeter" || got.Handler != "ticket.*" {
+		t.Fatalf("dispatch = app %q handler %q, want greeter/ticket.*", got.App, got.Handler)
+	}
+	if got.VersionID != version.ID {
+		t.Fatalf("dispatch carried version %d, want the RUNNING version %d", got.VersionID, version.ID)
+	}
+	if got.Event.Name != "ticket.created" || got.Event.Subject != "tk-1" {
+		t.Fatalf("dispatch event = %+v", got.Event)
+	}
+	if got.Artifact == "" {
+		t.Fatal("dispatch carried no artifact path, so the host has nothing to import")
+	}
+
+	waitFor(t, "the invocation to be recorded", func() bool { return len(invocationsOf(t, d, "greeter")) == 1 })
+	inv := invocationsOf(t, d, "greeter")[0]
+	if inv.Status != appInvocationStatusOK {
+		t.Fatalf("status = %q (%s), want ok", inv.Status, inv.Error)
+	}
+	if inv.VersionID != version.ID {
+		t.Fatalf("invocation stamped version %d, want %d", inv.VersionID, version.ID)
+	}
+
+	waitFor(t, "the cursor to advance past the delivered event", func() bool {
+		consumer, ok, err := d.store.GetBusConsumer(apps.ConsumerName("greeter"))
+		return err == nil && ok && consumer.Cursor >= got.Event.Seq
+	})
+}
+
+// A handler that throws is the app's fault: the text is recorded, and the bus
+// is told to keep the event rather than skip it.
+func TestAppHandlerThrowRecordsFailureAndKeepsTheEvent(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+	startFakeAppRuntime(t, d, func(_ *fakeAppRuntime, _ appDispatchRequest) error {
+		return errors.New("TypeError: cannot read properties of undefined\n    at handle (index.ts:4:11)")
+	})
+
+	err := d.deliverAppEvent(context.Background(), "greeter", appEvent("ticket.created", "tk-1", 7))
+	if err == nil {
+		t.Fatal("a thrown handler returned no error, so the bus would advance past the event")
+	}
+	if !strings.Contains(err.Error(), "TypeError") {
+		t.Fatalf("the bus was told %q, which does not name what threw", err)
+	}
+
+	rows := invocationsOf(t, d, "greeter")
+	if len(rows) != 1 {
+		t.Fatalf("recorded %d invocation(s), want 1", len(rows))
+	}
+	if rows[0].Status != appInvocationStatusError {
+		t.Fatalf("status = %q, want %q", rows[0].Status, appInvocationStatusError)
+	}
+	// The whole text, not the first line: the stack is what a developer acts on,
+	// and the bus error is the only place it gets shortened.
+	if !strings.Contains(rows[0].Error, "at handle (index.ts:4:11)") {
+		t.Fatalf("recorded error lost the stack: %q", rows[0].Error)
+	}
+	// The app is on the clock now, and the clock names the event it is stuck on.
+	stall, ok := d.appStallSnapshot("greeter")
+	if !ok || stall.seq != 7 || stall.attempts != 1 {
+		t.Fatalf("stall = %+v (present=%t), want seq 7 attempt 1", stall, ok)
+	}
+}
+
+// Rule 2: the sidecar dying is the runtime's failure. It stalls delivery like
+// any other, but no app is closer to being switched off for it.
+func TestSidecarDeathIsARuntimeFailureAndDoesNotBlameTheApp(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+
+	// The app is already failing on this event when the runtime dies.
+	var die atomic.Bool
+	startFakeAppRuntime(t, d, func(f *fakeAppRuntime, _ appDispatchRequest) error {
+		if die.Load() {
+			// The process goes away mid-handler and never answers. Closing the
+			// socket is exactly what the daemon sees when the sidecar is killed.
+			_ = f.conn.Close()
+		}
+		return errors.New("boom")
+	})
+	if err := d.deliverAppEvent(context.Background(), "greeter", appEvent("ticket.created", "tk-1", 3)); err == nil {
+		t.Fatal("the throwing handler reported success")
+	}
+	if _, ok := d.appStallSnapshot("greeter"); !ok {
+		t.Fatal("a thrown handler did not start the stall clock")
+	}
+
+	die.Store(true)
+	err := d.deliverAppEvent(context.Background(), "greeter", appEvent("ticket.created", "tk-1", 3))
+	if err == nil {
+		t.Fatal("a dispatch into a dead sidecar reported success")
+	}
+	if !isRuntimeFailure(err) {
+		t.Fatalf("error %q was not classified as the runtime's", err)
+	}
+
+	rows := invocationsOf(t, d, "greeter")
+	if len(rows) != 2 {
+		t.Fatalf("recorded %d invocation(s), want 2", len(rows))
+	}
+	if rows[0].Status != appInvocationStatusRuntimeError {
+		t.Fatalf("status = %q, want %q — a dead sidecar is not the app's fault",
+			rows[0].Status, appInvocationStatusRuntimeError)
+	}
+	// The clock is cleared, not merely left alone: an app must not be charged for
+	// the minutes the runtime was down.
+	if stall, ok := d.appStallSnapshot("greeter"); ok {
+		t.Fatalf("the runtime dying left the app on the auto-disable clock: %+v", stall)
+	}
+}
+
+// A runtime that is not installed at all reaches the same class, and says where
+// to look — this is what a broken install looks like from inside `app status`.
+func TestMissingRuntimeBinaryIsARuntimeFailure(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+	t.Setenv(appRuntimeHostOverride, filepath.Join(t.TempDir(), "not-installed"))
+
+	err := d.deliverAppEvent(context.Background(), "greeter", appEvent("ticket.created", "tk-1", 1))
+	if !isRuntimeFailure(err) {
+		t.Fatalf("error %v was not classified as the runtime's", err)
+	}
+	if stall, ok := d.appStallSnapshot("greeter"); ok {
+		t.Fatalf("a missing runtime binary put the app on the auto-disable clock: %+v", stall)
+	}
+	rows := invocationsOf(t, d, "greeter")
+	if len(rows) != 1 || rows[0].Status != appInvocationStatusRuntimeError {
+		t.Fatalf("invocations = %+v, want one runtime_error", rows)
+	}
+	if !strings.Contains(rows[0].Error, appRuntimeHostOverride) {
+		t.Fatalf("the recorded error does not say how to point attn at a runtime: %q", rows[0].Error)
+	}
+}
+
+// A delivery whose context is cancelled — `attn app remove`, daemon stop —
+// returns promptly and records nothing. An interrupted delivery did not happen.
+func TestCancelledDeliveryReturnsPromptlyAndRecordsNothing(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	// LIFO cleanup: registered after the harness's own, so it runs FIRST and a
+	// failing assert below cannot leave the handler parked forever (#793).
+	t.Cleanup(func() { close(release) })
+	startFakeAppRuntime(t, d, func(_ *fakeAppRuntime, _ appDispatchRequest) error {
+		close(entered)
+		<-release
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- d.deliverAppEvent(ctx, "greeter", appEvent("ticket.created", "tk-1", 1)) }()
+	<-entered
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("a cancelled delivery returned %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a cancelled delivery did not return; removing an app would hang on its in-flight handler")
+	}
+	if rows := invocationsOf(t, d, "greeter"); len(rows) != 0 {
+		t.Fatalf("a cancelled delivery recorded %d invocation(s): %+v", len(rows), rows)
+	}
+}
+
+// `attn app remove` has to come back while a handler is still running. The
+// consumer's delivery loop is what Unregister waits for, and that loop is
+// parked inside the dispatch — so an uninterruptible dispatch would hang the
+// command for as long as the app's code felt like running.
+func TestRemovingAnAppWithAnInFlightDispatchReturnsPromptly(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	// LIFO: registered after the sidecar's cleanup below would be wrong — this
+	// has to run FIRST, so a failed assert releases the handler instead of
+	// reading as a hang (#793).
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+	var once sync.Once
+	startFakeAppRuntime(t, d, func(*fakeAppRuntime, appDispatchRequest) error {
+		once.Do(func() { close(entered) })
+		<-release
+		return nil
+	})
+
+	d.publishFact("ticket.created", "tk-1", nil)
+	<-entered
+
+	removed := make(chan protocol.Response, 1)
+	go func() { removed <- appRemove(t, d, "greeter") }()
+	select {
+	case resp := <-removed:
+		if !resp.Ok {
+			t.Fatalf("app remove: %v", protocol.Deref(resp.Error))
+		}
+		if !resp.AppRemoveResult.ConsumerRemoved {
+			t.Fatal("remove did not report deleting the consumer")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("app remove hung on an in-flight handler")
+	}
+
+	// The interrupted delivery recorded nothing: it did not happen.
+	if rows := invocationsOf(t, d, "greeter"); len(rows) != 0 {
+		t.Fatalf("an interrupted delivery recorded %d invocation(s): %+v", len(rows), rows)
+	}
+	if _, ok, err := d.store.GetBusConsumer(apps.ConsumerName("greeter")); err != nil || ok {
+		t.Fatalf("the consumer row survived the remove (ok=%t, err=%v)", ok, err)
+	}
+}
+
+// A sidecar answer that arrives after its caller gave up — a retired consumer,
+// an abandoned timeout — is dropped without a word on the wire. There is
+// nothing the host could do with a complaint about a request it has forgotten.
+func TestALateAnswerWithNobodyWaitingIsDropped(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+	// The far end has to be drained or the peer's write blocks: net.Pipe is
+	// unbuffered, and this test is about what happens after a request goes out.
+	go func() { _, _ = io.Copy(io.Discard, clientConn) }()
+	peer := newJSONRPCPeer(serverConn, bufio.NewReader(serverConn))
+
+	if routed := peer.routeResponse(jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`"gone"`),
+		Result:  json.RawMessage(`{"ok":true}`),
+	}); routed {
+		t.Fatal("an answer nobody was waiting for was reported as routed")
+	}
+
+	// And a caller that gave up leaves nothing behind for the next one to trip on.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		waitFor(t, "the abandoned request to go out", func() bool {
+			peer.pendingMu.Lock()
+			defer peer.pendingMu.Unlock()
+			return len(peer.pending) == 1
+		})
+		cancel()
+	}()
+	var out appDispatchResult
+	if err := peer.request(ctx, "app runtime", "app.dispatch", appDispatchRequest{}, &out); !errors.Is(err, context.Canceled) {
+		t.Fatalf("a request whose caller gave up returned %v, want context.Canceled", err)
+	}
+	if routed := peer.routeResponse(jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Result:  json.RawMessage(`{"ok":true}`),
+	}); routed {
+		t.Fatal("the abandoned request was still holding its slot in the pending map")
+	}
+}
+
+// A callback that arrives after its dispatch ended is refused, not served
+// against whatever app is running now. This is the same seam that makes a late
+// answer from a retired consumer harmless.
+func TestCollectionCallbackAfterTheHandlerReturnedIsRefused(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "greeter", appbuild.Manifest{
+		Subscribe:   []appbuild.Subscribe{{Events: []string{"ticket.*"}}},
+		Collections: []appbuild.Collection{{Name: "seen"}},
+	})
+
+	var escaped string
+	runtime := startFakeAppRuntime(t, d, func(f *fakeAppRuntime, req appDispatchRequest) error {
+		escaped = req.Dispatch
+		return nil
+	})
+	if err := d.deliverAppEvent(context.Background(), "greeter", appEvent("ticket.created", "tk-1", 1)); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+
+	_, err := runtime.call("app.collection.get", appCollectionParams{
+		Dispatch: escaped, Collection: "seen", ID: "tk-1",
+	})
+	if err == nil {
+		t.Fatal("a collection call from a finished handler was served")
+	}
+	if !strings.Contains(err.Error(), "after that handler returned") {
+		t.Fatalf("the refusal does not say what went wrong: %q", err)
+	}
+}
+
+// The isolation proof. There is no namespace on the wire, so the only way an
+// app could reach another's documents is by naming a collection it did not
+// declare — and that is refused by name.
+func TestAppCannotReachACollectionItDidNotDeclare(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "neighbour", appbuild.Manifest{
+		Subscribe:   []appbuild.Subscribe{{Events: []string{"ticket.*"}}},
+		Collections: []appbuild.Collection{{Name: "secrets"}},
+	})
+	installApp(t, d, "greeter", appbuild.Manifest{
+		Subscribe:   []appbuild.Subscribe{{Events: []string{"ticket.*"}}},
+		Collections: []appbuild.Collection{{Name: "seen"}},
+	})
+
+	var refusal error
+	var wrote appDocument
+	runtime := startFakeAppRuntime(t, d, func(f *fakeAppRuntime, req appDispatchRequest) error {
+		// Its own collection works, and lands in its own namespace.
+		raw, err := f.call("app.collection.put", appCollectionParams{
+			Dispatch: req.Dispatch, Collection: "seen", ID: "tk-1",
+			Body: json.RawMessage(`{"note":"mine"}`),
+		})
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal(raw, &wrote); err != nil {
+			return err
+		}
+		// The neighbour's is not reachable, by any spelling.
+		_, refusal = f.call("app.collection.get", appCollectionParams{
+			Dispatch: req.Dispatch, Collection: "secrets", ID: "anything",
+		})
+		return nil
+	})
+	_ = runtime
+
+	if err := d.deliverAppEvent(context.Background(), "greeter", appEvent("ticket.created", "tk-1", 1)); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+	if wrote.ID != "tk-1" {
+		t.Fatalf("the app could not write its own collection: %+v", wrote)
+	}
+	if refusal == nil {
+		t.Fatal("greeter read a collection belonging to neighbour")
+	}
+	if !strings.Contains(refusal.Error(), "did not declare a collection") {
+		t.Fatalf("the refusal does not teach: %q", refusal)
+	}
+
+	// And the document really is in the app's own namespace.
+	read, declared, err := d.store.ReadDocument(apps.Namespace("greeter"), "seen", "tk-1")
+	if err != nil || !declared || !read.Found {
+		t.Fatalf("document not in %s: declared=%t found=%t err=%v", apps.Namespace("greeter"), declared, read.Found, err)
+	}
+}
+
+// Hot reload: applying a new version re-points the next dispatch without
+// touching the one already running. Content-addressed artifacts are what make
+// that true — each version is its own module path.
+func TestHotReloadStampsTheNewVersionOnTheNextDispatch(t *testing.T) {
+	d := newAppDaemon(t)
+	first := installApp(t, d, "greeter", subscribing("ticket.*"))
+
+	inFlight := make(chan struct{})
+	release := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+	runtime := startFakeAppRuntime(t, d, func(_ *fakeAppRuntime, req appDispatchRequest) error {
+		if req.VersionID == first.ID {
+			close(inFlight)
+			<-release
+		}
+		return nil
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- d.deliverAppEvent(context.Background(), "greeter", appEvent("ticket.created", "tk-1", 1))
+	}()
+	<-inFlight
+
+	// A second apply lands while the first handler is still running.
+	second := installApp(t, d, "greeter", subscribing("ticket.*", "session.*"))
+	if second.ID == first.ID {
+		t.Fatal("the second apply produced the same version, so this proves nothing")
+	}
+
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("the in-flight delivery failed: %v", err)
+	}
+	if err := d.deliverAppEvent(context.Background(), "greeter", appEvent("ticket.created", "tk-2", 2)); err != nil {
+		t.Fatalf("the second delivery failed: %v", err)
+	}
+
+	log := runtime.dispatchLog()
+	if len(log) != 2 {
+		t.Fatalf("dispatches = %d, want 2", len(log))
+	}
+	if log[0].VersionID != first.ID {
+		t.Fatalf("the in-flight dispatch was re-stamped to %d, want the OLD version %d", log[0].VersionID, first.ID)
+	}
+	if log[1].VersionID != second.ID {
+		t.Fatalf("the next dispatch used version %d, want the NEW version %d", log[1].VersionID, second.ID)
+	}
+	if log[0].Artifact == log[1].Artifact {
+		t.Fatalf("both versions resolved to the same artifact %q, so import() would hand back the old module", log[0].Artifact)
+	}
+	// The re-apply also re-pointed the consumer's subscriptions, without going
+	// through an unregister that would have dropped the cursor.
+	consumer, ok, err := d.store.GetBusConsumer(apps.ConsumerName("greeter"))
+	if err != nil || !ok {
+		t.Fatalf("consumer: %v ok=%t", err, ok)
+	}
+	if !strings.Contains(consumer.Filter, "session.*") {
+		t.Fatalf("filter = %q, want the new version's subscriptions", consumer.Filter)
+	}
+}
+
+// A fact an app's filter lets through but that matches no declared subscription
+// advances rather than stalls: there is no handler to succeed on a retry, and a
+// permanent stall would pin the log's retention floor.
+func TestUnhandledFactAdvancesRatherThanStalling(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+	runtime := startFakeAppRuntime(t, d, nil)
+
+	if err := d.deliverAppEvent(context.Background(), "greeter", appEvent("session.state.changed", "s-1", 1)); err != nil {
+		t.Fatalf("an unhandled fact stalled the consumer: %v", err)
+	}
+	if got := len(runtime.dispatchLog()); got != 0 {
+		t.Fatalf("an unhandled fact produced %d dispatch(es)", got)
+	}
+	if rows := invocationsOf(t, d, "greeter"); len(rows) != 0 {
+		t.Fatalf("an unhandled fact recorded %d invocation(s)", len(rows))
+	}
+}
+
+// Exact beats a wildcard, and the longest prefix beats a shorter one: an app
+// declaring both gets the handler it wrote for the specific fact.
+func TestHandlerResolutionPrefersTheMostSpecificSubscription(t *testing.T) {
+	patterns := []string{"*", "session.*", "session.state.changed", "ticket.*"}
+	for _, tc := range []struct{ event, want string }{
+		{"session.state.changed", "session.state.changed"},
+		{"session.spawned", "session.*"},
+		{"ticket.created", "ticket.*"},
+		{"pr.merged", "*"},
+	} {
+		if got := resolveAppHandler(patterns, tc.event); got != tc.want {
+			t.Errorf("resolveAppHandler(%q) = %q, want %q", tc.event, got, tc.want)
+		}
+	}
+	if got := resolveAppHandler([]string{"ticket.*"}, "session.spawned"); got != "" {
+		t.Errorf("an unmatched fact resolved to handler %q", got)
+	}
+}
+
+// An app with no subscriptions must not be woken by everything. bus.ParseFilter
+// reads an empty expression as All, so the empty case needs its own answer.
+func TestAppWithNoSubscriptionsSubscribesToNothing(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "quiet", appbuild.Manifest{})
+
+	filter, err := d.appFilter("quiet")
+	if err != nil {
+		t.Fatalf("appFilter: %v", err)
+	}
+	if len(filter) != 1 || filter[0] != appNoSubscriptionsPattern {
+		t.Fatalf("filter = %v, want the nothing-matches pattern", filter)
+	}
+	for _, name := range []string{"ticket.created", "session.state.changed", "app.enabled.changed"} {
+		if bus.MatchPattern(filter[0], name) {
+			t.Fatalf("an app that declared no subscriptions would be woken by %s", name)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Supervision surface
+// ---------------------------------------------------------------------------
+
+// writeExecutableStub writes a shell script the supervisor can launch as the
+// runtime host. The real compiled sidecar is Bun and takes a second to build;
+// what these tests need from it is a process that lives or dies on command.
+func writeExecutableStub(t *testing.T, script string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "attn-app-runtime")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
+		t.Fatalf("write runtime stub: %v", err)
+	}
+	return path
+}
+
+func appRuntimeStatus(t *testing.T, d *Daemon) *protocol.AppRuntimeStatusResult {
+	t.Helper()
+	resp := docCall(t, func(c net.Conn) {
+		d.handleAppRuntimeStatus(c, &protocol.AppRuntimeStatusMessage{Cmd: protocol.CmdAppRuntimeStatus})
+	})
+	if !resp.Ok {
+		t.Fatalf("app runtime status: %v", protocol.Deref(resp.Error))
+	}
+	return resp.AppRuntimeStatusResult
+}
+
+func appRuntimeRestart(t *testing.T, d *Daemon) *protocol.AppRuntimeRestartResult {
+	t.Helper()
+	resp := docCall(t, func(c net.Conn) {
+		d.handleAppRuntimeRestart(c, &protocol.AppRuntimeRestartMessage{Cmd: protocol.CmdAppRuntimeRestart})
+	})
+	if !resp.Ok {
+		t.Fatalf("app runtime restart: %v", protocol.Deref(resp.Error))
+	}
+	return resp.AppRuntimeRestartResult
+}
+
+// `attn app runtime status` before anything has started, and `restart` as the
+// way to start one. "Never started" is a different answer from "stopped", and
+// saying the second would send a reader looking for a fault.
+func TestRuntimeStatusIsHonestBeforeAnythingHasStarted(t *testing.T) {
+	d := newAppDaemon(t)
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+	host := writeExecutableStub(t, "sleep 60")
+	t.Setenv(appRuntimeHostOverride, host)
+
+	before := appRuntimeStatus(t, d)
+	if before.Runtime != nil {
+		t.Fatalf("a daemon that has never run an app reported a runtime: %+v", before.Runtime)
+	}
+	if before.HostPath == nil || *before.HostPath != host {
+		t.Fatalf("host path = %v, want %s", before.HostPath, host)
+	}
+	if before.Apps != 1 || before.AppsEnabled != 1 {
+		t.Fatalf("apps = %d installed / %d enabled, want 1/1", before.Apps, before.AppsEnabled)
+	}
+	if before.LogPath != AppRuntimeLogPath(d.socketPath) {
+		t.Fatalf("log path = %q, want %q", before.LogPath, AppRuntimeLogPath(d.socketPath))
+	}
+
+	t.Cleanup(d.stopAppRuntime)
+	started := appRuntimeRestart(t, d)
+	if started.Was != "stopped" {
+		t.Fatalf("was = %q, want stopped", started.Was)
+	}
+	if started.Runtime.Desired != "running" {
+		t.Fatalf("after a restart the runtime is %+v, want desired running", started.Runtime)
+	}
+	if after := appRuntimeStatus(t, d); after.Runtime == nil {
+		t.Fatal("status still reports no runtime after one was started")
+	}
+}
+
+// A parked runtime is a whole-system outage: every app's status says so, a
+// notification is written, and `attn app runtime restart` is the way back.
+func TestParkedRuntimeIsVisibleOnEveryAppAndRevivable(t *testing.T) {
+	d := newAppDaemon(t)
+	// One restart, then park. The tripwire is ten in production; the point here
+	// is the crossing, not the count.
+	d.appRuntimeSupervise = supervise.Options{GiveUpAfter: 1}
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+	installApp(t, d, "auditor", subscribing("pr.*"))
+	t.Setenv(appRuntimeHostOverride, writeExecutableStub(t, "exit 3"))
+	t.Cleanup(d.stopAppRuntime)
+
+	if err := d.ensureAppRuntime(); err != nil {
+		t.Fatalf("ensure runtime: %v", err)
+	}
+	waitFor(t, "the crash-looping runtime to be parked", func() bool {
+		snapshot, ok := d.appRuntimeSnapshot()
+		return ok && snapshot.Phase == supervise.PhaseParked
+	})
+
+	for _, name := range []string{"greeter", "auditor"} {
+		resp := appStatus(t, d, name)
+		if !resp.Ok {
+			t.Fatalf("app status %s: %v", name, protocol.Deref(resp.Error))
+		}
+		runtime := resp.AppStatusResult.Runtime
+		if runtime == nil {
+			t.Fatalf("app status %s carried no runtime, so a reader cannot tell why nothing runs", name)
+		}
+		if runtime.Phase != string(supervise.PhaseParked) {
+			t.Fatalf("app status %s reported runtime phase %q, want parked", name, runtime.Phase)
+		}
+		if runtime.LastExit == nil || !strings.Contains(*runtime.LastExit, "3") {
+			t.Fatalf("app status %s does not say how the runtime died: %v", name, runtime.LastExit)
+		}
+	}
+
+	// The only one of these three a person ever sees.
+	notifications, err := d.store.ListNotifications()
+	if err != nil {
+		t.Fatalf("list notifications: %v", err)
+	}
+	var parked *store.NotificationRecord
+	for i := range notifications {
+		if notifications[i].Kind == notificationKindAppRuntimeParked {
+			parked = &notifications[i]
+		}
+	}
+	if parked == nil {
+		t.Fatalf("no app-runtime-parked notification among %d", len(notifications))
+	}
+	if !strings.Contains(parked.Body, "attn app runtime restart") {
+		t.Fatalf("the notification does not name the way back: %q", parked.Body)
+	}
+
+	revived := appRuntimeRestart(t, d)
+	if revived.Was != string(supervise.PhaseParked) {
+		t.Fatalf("was = %q, want parked — that answer is what tells a reader it was revived", revived.Was)
+	}
+	if revived.Runtime.Phase == string(supervise.PhaseParked) {
+		t.Fatalf("restart left the runtime parked: %+v", revived.Runtime)
+	}
+	// The revived runtime gets its restart budget back rather than re-parking on
+	// its first exit — TestStopClearsTheRestartBudget is where that is pinned
+	// against a fake clock; here the stub crashes too fast to watch.
+}
+
+// A runtime whose api_version does not match is refused at hello rather than
+// half-served, and the refusal says it is a stale install.
+func TestRuntimeWithTheWrongAPIVersionIsRefusedAtHello(t *testing.T) {
+	_, _, recognized, err := parseAppRuntimeHello([]byte(
+		`{"jsonrpc":"2.0","id":"1","method":"app_runtime.hello","params":{"generation":1,"api_version":99,"pid":7}}`))
+	if !recognized {
+		t.Fatal("the app runtime hello was not recognized as one")
+	}
+	if err == nil {
+		t.Fatal("a runtime speaking api version 99 was accepted")
+	}
+	if !strings.Contains(err.Error(), "stale install") {
+		t.Fatalf("the refusal does not say what to do: %q", err)
+	}
+}
+
+// A plugin's hello must not be mistaken for a runtime's, and the runtime sniff
+// runs first — so it also has to leave everything else alone.
+func TestAppRuntimeHelloSniffIgnoresEverythingElse(t *testing.T) {
+	for _, frame := range []string{
+		`{"jsonrpc":"2.0","id":"1","method":"hello","params":{"name":"worktree-provider"}}`,
+		`{"cmd":"heartbeat","id":"sess"}`,
+		`not json at all`,
+	} {
+		if _, _, recognized, _ := parseAppRuntimeHello([]byte(frame)); recognized {
+			t.Fatalf("the app runtime sniff claimed %q", frame)
+		}
+	}
+}

--- a/internal/daemon/apps.go
+++ b/internal/daemon/apps.go
@@ -120,18 +120,18 @@ func (d *Daemon) handleAppStatus(conn net.Conn, msg *protocol.AppStatusMessage) 
 	}
 	result := protocol.AppStatusResult{App: summary, Versions: versions, Invocations: invocations}
 	for _, inv := range recent {
-		result.Recent = append(result.Recent, protocol.AppInvocationInfo{
-			ID:           int(inv.ID),
-			VersionID:    int(inv.VersionID),
-			EventSeq:     int(inv.EventSeq),
-			EventName:    inv.EventName,
-			EventSubject: inv.EventSubject,
-			Handler:      inv.Handler,
-			Status:       inv.Status,
-			Error:        inv.Error,
-			DurationMs:   int(inv.Duration.Milliseconds()),
-			StartedAt:    stampForWire(inv.StartedAt),
-		})
+		result.Recent = append(result.Recent, appInvocationForWire(inv.ID, inv))
+	}
+	// The two things only the running daemon knows: whether the shared runtime is
+	// up, and whether this app is on the auto-disable clock. Both absent when
+	// there is nothing to report, never defaulted.
+	if snapshot, ok := d.appRuntimeSnapshot(); ok {
+		info := d.appRuntimeInfo(snapshot)
+		result.Runtime = &info
+	}
+	if stall, ok := d.appStallSnapshot(name); ok {
+		info := appStallForWire(stall)
+		result.Stall = &info
 	}
 	d.sendDocResponse(conn, protocol.Response{Ok: true, AppStatusResult: &result})
 }
@@ -188,6 +188,12 @@ func (d *Daemon) handleAppSetEnabled(conn net.Conn, msg *protocol.AppSetEnabledM
 			"app %q: its bus consumer %s was removed while %s was running, so nothing was changed. "+
 				"`attn app status %s` shows what is left.", name, consumer, verb, name))
 		return
+	}
+	if msg.Enabled {
+		// Enabling is the way back from an auto-disable, so it clears the streak
+		// that caused one. Without this the app would be disabled again on its very
+		// next failure, against a clock it never got to restart.
+		d.clearAppStall(name)
 	}
 	d.publishFact(FactAppEnabledChanged, name, appEnabledChanged{
 		Name: name, Consumer: consumer, Enabled: msg.Enabled,

--- a/internal/daemon/bus.go
+++ b/internal/daemon/bus.go
@@ -276,6 +276,13 @@ const (
 	// consumer that has to drain the outgoing version's handlers knows which one
 	// that is without racing the pointer it would otherwise read back.
 	FactAppVersionChanged = "app.version.changed"
+	// FactAppRuntimeChanged: the shared app runtime's supervision state moved —
+	// started, connected, backing off, parked, stopped. Subject is the runtime's
+	// child name rather than an app's, because the entity that moved is the one
+	// process every app shares. It carries no payload: the state is the
+	// supervisor's and a reader asks it (`attn app runtime status`) rather than
+	// trusting a copy that was true when the fact was written.
+	FactAppRuntimeChanged = "app.runtime.changed"
 )
 
 // CompactableFacts are the fact classes the retention pass may reduce to one

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -172,6 +172,13 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdAppRemove:     commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdAppApply:      commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdAppRollback:   commandMetadata(ScopeHubLocal, false, true),
+	// The shared runtime is the hub's own child process, so these are hub-local
+	// for the same reason. app_watch holds its connection open for as long as the
+	// caller wants invocations, so it is logged once at open like the rest.
+	protocol.CmdAppLogs:           commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdAppRuntimeStatus:  commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdAppRuntimeRestart: commandMetadata(ScopeHubLocal, false, true),
+	protocol.CmdAppWatch:          commandMetadata(ScopeHubLocal, false, true),
 }
 
 func shouldLogWSCommand(cmd string) bool {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -39,6 +39,7 @@ import (
 	"github.com/victorarias/attn/internal/ptybackend"
 	"github.com/victorarias/attn/internal/statetrace"
 	"github.com/victorarias/attn/internal/store"
+	"github.com/victorarias/attn/internal/supervise"
 	"github.com/victorarias/attn/internal/transcript"
 	"github.com/victorarias/attn/internal/workspacelayout"
 )
@@ -330,7 +331,38 @@ type Daemon struct {
 	// the data directory rather than the socket path because the CLI that builds
 	// an artifact derives it the same way: a socket relocated by
 	// ATTN_SOCKET_PATH would leave the two looking in different places.
-	appsDir             string
+	appsDir string
+	// The shared app runtime. appRuntimeMu guards the supervisor and the live
+	// sidecar connection together: "is there a process" and "is it reachable"
+	// are read as one answer by `attn app runtime status` and by every dispatch.
+	appRuntimeMu         sync.Mutex
+	appRuntimeSupervisor *supervise.Supervisor
+	// appRuntimeSupervise is the tunable half of that supervision — the clock
+	// and the give-up tripwire. A test sets it so a crash loop can be watched
+	// without waiting out the real backoff; production leaves it zero.
+	appRuntimeSupervise supervise.Options
+	// appRuntimeWait overrides appRuntimeConnectWait, for the same reason.
+	appRuntimeWait time.Duration
+	appRuntimeConn *appRuntimeConnection
+	// appRuntimeReady closes when a sidecar connects, and is replaced with a
+	// fresh open channel when one goes away. It is how a delivery waits for a
+	// cold start on a real signal instead of a poll.
+	appRuntimeReady chan struct{}
+	// appDispatches is what is running right now, by dispatch id. A collection
+	// callback resolves its app through this and nowhere else.
+	appDispatchMu  sync.Mutex
+	appDispatches  map[string]*appDispatch
+	appDispatchSeq uint64
+	// appStalls is the auto-disable clock, one entry per app that is currently
+	// failing on an event. See appStall.
+	appStallMu sync.Mutex
+	appStalls  map[string]*appStall
+	// appWatchers are the open `app_watch` connections `attn app dev` renders.
+	appWatcherMu sync.Mutex
+	appWatchers  map[*appWatcher]struct{}
+	// appClock is the clock every app-runtime duration is measured against.
+	// Injected by tests so the fifteen-minute stall window costs no wall time.
+	appClock            func() time.Time
 	removePlugin        func(pluginDir, name string) error
 	pluginActionMu      sync.Mutex
 	bundledPluginMu     sync.Mutex
@@ -1007,6 +1039,10 @@ func (d *Daemon) Start() error {
 	d.listener = listener
 	d.log("daemon started")
 	d.startInstalledPlugins()
+	// Apps get their consumers here, not their runtime: the sidecar starts on the
+	// first fact an app is actually due, so a user with installed-but-quiet apps
+	// pays nothing for them.
+	d.registerAppConsumers()
 
 	// Start WebSocket hub with daemon's logger
 	d.wsHub.logf = d.logf
@@ -1691,6 +1727,7 @@ func (d *Daemon) Stop() {
 		d.hubManager.Stop()
 	}
 	d.stopInstalledPlugins()
+	d.stopAppRuntime()
 	d.stopAllTranscriptWatchers()
 	d.stopNudgeCountdowns()
 	d.stopAutoSettleTimers()
@@ -2405,6 +2442,18 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		return
 	}
 
+	// The app runtime is sniffed first: the plugin parser treats every JSON-RPC
+	// frame as a plugin's, so it would refuse this one with a true sentence about
+	// the wrong protocol.
+	if runtimeHelloID, runtimeParams, runtimeMode, err := parseAppRuntimeHello(data); runtimeMode {
+		if err != nil {
+			_ = json.NewEncoder(conn).Encode(jsonRPCFailure(runtimeHelloID, jsonRPCInvalidRequest, err.Error()))
+			return
+		}
+		d.handleAppRuntimeConnection(conn, reader, runtimeHelloID, runtimeParams)
+		return
+	}
+
 	helloID, helloParams, pluginMode, err := parsePluginHello(data)
 	if pluginMode {
 		if err != nil {
@@ -2483,6 +2532,14 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleAppApply(conn, msg.(*protocol.AppApplyMessage))
 	case protocol.CmdAppRollback: // wire: app_rollback
 		d.handleAppRollback(conn, msg.(*protocol.AppRollbackMessage))
+	case protocol.CmdAppLogs: // wire: app_logs
+		d.handleAppLogs(conn, msg.(*protocol.AppLogsMessage))
+	case protocol.CmdAppRuntimeStatus: // wire: app_runtime_status
+		d.handleAppRuntimeStatus(conn, msg.(*protocol.AppRuntimeStatusMessage))
+	case protocol.CmdAppRuntimeRestart: // wire: app_runtime_restart
+		d.handleAppRuntimeRestart(conn, msg.(*protocol.AppRuntimeRestartMessage))
+	case protocol.CmdAppWatch: // wire: app_watch
+		d.handleAppWatch(conn, msg.(*protocol.AppWatchMessage))
 	case protocol.CmdTicketCreate: // wire: ticket_create
 		d.handleTicketCreate(conn, msg.(*protocol.TicketCreateMessage))
 	case protocol.CmdTicketComment: // wire: ticket_comment

--- a/internal/daemon/jsonrpc_peer.go
+++ b/internal/daemon/jsonrpc_peer.go
@@ -1,0 +1,154 @@
+package daemon
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+)
+
+// jsonrpcPeer is the transport half of a connection to a supervised child:
+// newline-delimited JSON-RPC 2.0, full duplex, over the daemon's unix socket.
+//
+// Two children speak it — a plugin (internal/daemon/plugin_rpc.go) and the shared
+// app runtime (app_runtime_rpc.go) — and they share this rather than each owning
+// a copy, because the parts that are easy to get subtly wrong are exactly the
+// parts that are identical: id correlation, unblocking in-flight callers when the
+// socket dies, and serializing writes against a reader on another goroutine.
+//
+// What is NOT here is everything that differs: who the child is, how it is
+// authenticated, which methods it may call, and what happens when it disconnects.
+// Those belong to each child's own file.
+//
+// Two rules the callers depend on:
+//
+//   - Ids are per-direction. The daemon numbers its own requests; the child
+//     numbers its. The two spaces may collide harmlessly, because a frame with a
+//     method is a call and a frame without one is an answer.
+//   - Correlation is by the id's raw JSON text, so a child must echo the id
+//     verbatim. Answering `"1"` to a request with id `1` does not match.
+type jsonrpcPeer struct {
+	conn   net.Conn
+	reader *bufio.Reader
+
+	writeMu sync.Mutex
+
+	pendingMu sync.Mutex
+	pending   map[string]chan jsonRPCMessage
+	nextID    uint64
+	closed    bool
+}
+
+func newJSONRPCPeer(conn net.Conn, reader *bufio.Reader) *jsonrpcPeer {
+	return &jsonrpcPeer{
+		conn:    conn,
+		reader:  reader,
+		pending: make(map[string]chan jsonRPCMessage),
+	}
+}
+
+func (p *jsonrpcPeer) send(msg jsonRPCMessage) error {
+	p.writeMu.Lock()
+	defer p.writeMu.Unlock()
+	return json.NewEncoder(p.conn).Encode(msg)
+}
+
+// closePending fails every in-flight request. Without it a caller waiting on a
+// child that just died would wait out its whole context rather than learning the
+// connection is gone.
+func (p *jsonrpcPeer) closePending(err error) {
+	p.pendingMu.Lock()
+	defer p.pendingMu.Unlock()
+	if p.closed {
+		return
+	}
+	p.closed = true
+	for key, ch := range p.pending {
+		delete(p.pending, key)
+		ch <- jsonRPCMessage{
+			Error: &jsonRPCError{Code: jsonRPCInternalError, Message: err.Error()},
+		}
+	}
+}
+
+// routeResponse hands an answer to the caller waiting for it, reporting whether
+// anyone was. A response nobody is waiting for is the caller's context having
+// expired first, which the caller has already handled.
+func (p *jsonrpcPeer) routeResponse(msg jsonRPCMessage) bool {
+	key := jsonRPCIDKey(msg.ID)
+	if key == "" {
+		return false
+	}
+
+	p.pendingMu.Lock()
+	ch, exists := p.pending[key]
+	if exists {
+		delete(p.pending, key)
+	}
+	p.pendingMu.Unlock()
+	if !exists {
+		return false
+	}
+	ch <- msg
+	return true
+}
+
+// request calls the child and waits for its answer or the context, whichever
+// comes first. `label` names the child in the error text ("plugin", "app
+// runtime"), because the caller of a failed call is usually not near enough to
+// the connection to know which one answered.
+func (p *jsonrpcPeer) request(ctx context.Context, label, method string, params interface{}, result interface{}) error {
+	payload, err := json.Marshal(params)
+	if err != nil {
+		return fmt.Errorf("marshal %s request params: %w", label, err)
+	}
+
+	p.pendingMu.Lock()
+	if p.closed {
+		p.pendingMu.Unlock()
+		return fmt.Errorf("%s connection is closed", label)
+	}
+	p.nextID++
+	id := strconv.FormatUint(p.nextID, 10)
+	responseCh := make(chan jsonRPCMessage, 1)
+	p.pending[id] = responseCh
+	p.pendingMu.Unlock()
+
+	request := jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(id),
+		Method:  method,
+		Params:  payload,
+	}
+	if err := p.send(request); err != nil {
+		p.pendingMu.Lock()
+		delete(p.pending, id)
+		p.pendingMu.Unlock()
+		return fmt.Errorf("send %s request: %w", label, err)
+	}
+
+	select {
+	case <-ctx.Done():
+		p.pendingMu.Lock()
+		delete(p.pending, id)
+		p.pendingMu.Unlock()
+		return ctx.Err()
+	case response := <-responseCh:
+		if response.Error != nil {
+			return fmt.Errorf("%s %s: %s", label, method, response.Error.Message)
+		}
+		if result == nil {
+			return nil
+		}
+		if len(response.Result) == 0 {
+			return fmt.Errorf("%s %s returned no result", label, method)
+		}
+		if err := json.Unmarshal(response.Result, result); err != nil {
+			return fmt.Errorf("decode %s %s result: %w", label, method, err)
+		}
+		return nil
+	}
+}

--- a/internal/daemon/plugin_rpc.go
+++ b/internal/daemon/plugin_rpc.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -247,18 +246,10 @@ func validatePluginSurfaces(values []string) ([]string, error) {
 }
 
 type pluginConnection struct {
+	*jsonrpcPeer
+
 	name       string
 	generation uint64
-
-	conn   net.Conn
-	reader *bufio.Reader
-
-	writeMu sync.Mutex
-
-	pendingMu sync.Mutex
-	pending   map[string]chan jsonRPCMessage
-	nextID    uint64
-	closed    bool
 
 	healthMu      sync.RWMutex
 	healthStatus  string
@@ -268,106 +259,15 @@ type pluginConnection struct {
 
 func newPluginConnection(conn net.Conn, reader *bufio.Reader, params pluginHelloParams) *pluginConnection {
 	return &pluginConnection{
+		jsonrpcPeer:  newJSONRPCPeer(conn, reader),
 		name:         strings.TrimSpace(params.Name),
 		generation:   params.Generation,
-		conn:         conn,
-		reader:       reader,
-		pending:      make(map[string]chan jsonRPCMessage),
 		healthStatus: "unknown",
 	}
 }
 
-func (p *pluginConnection) send(msg jsonRPCMessage) error {
-	p.writeMu.Lock()
-	defer p.writeMu.Unlock()
-	return json.NewEncoder(p.conn).Encode(msg)
-}
-
-func (p *pluginConnection) closePending(err error) {
-	p.pendingMu.Lock()
-	defer p.pendingMu.Unlock()
-	if p.closed {
-		return
-	}
-	p.closed = true
-	for key, ch := range p.pending {
-		delete(p.pending, key)
-		ch <- jsonRPCMessage{
-			Error: &jsonRPCError{Code: jsonRPCInternalError, Message: err.Error()},
-		}
-	}
-}
-
-func (p *pluginConnection) routeResponse(msg jsonRPCMessage) bool {
-	key := jsonRPCIDKey(msg.ID)
-	if key == "" {
-		return false
-	}
-
-	p.pendingMu.Lock()
-	ch, exists := p.pending[key]
-	if exists {
-		delete(p.pending, key)
-	}
-	p.pendingMu.Unlock()
-	if !exists {
-		return false
-	}
-	ch <- msg
-	return true
-}
-
 func (p *pluginConnection) request(ctx context.Context, method string, params interface{}, result interface{}) error {
-	payload, err := json.Marshal(params)
-	if err != nil {
-		return fmt.Errorf("marshal plugin request params: %w", err)
-	}
-
-	p.pendingMu.Lock()
-	if p.closed {
-		p.pendingMu.Unlock()
-		return errors.New("plugin connection is closed")
-	}
-	p.nextID++
-	id := strconv.FormatUint(p.nextID, 10)
-	responseCh := make(chan jsonRPCMessage, 1)
-	p.pending[id] = responseCh
-	p.pendingMu.Unlock()
-
-	request := jsonRPCMessage{
-		JSONRPC: "2.0",
-		ID:      json.RawMessage(id),
-		Method:  method,
-		Params:  payload,
-	}
-	if err := p.send(request); err != nil {
-		p.pendingMu.Lock()
-		delete(p.pending, id)
-		p.pendingMu.Unlock()
-		return fmt.Errorf("send plugin request: %w", err)
-	}
-
-	select {
-	case <-ctx.Done():
-		p.pendingMu.Lock()
-		delete(p.pending, id)
-		p.pendingMu.Unlock()
-		return ctx.Err()
-	case response := <-responseCh:
-		if response.Error != nil {
-			return fmt.Errorf("plugin %s: %s", method, response.Error.Message)
-		}
-		if result == nil {
-			return nil
-		}
-		if len(response.Result) == 0 {
-			return fmt.Errorf("plugin %s returned no result", method)
-		}
-		if err := json.Unmarshal(response.Result, result); err != nil {
-			return fmt.Errorf("decode plugin %s result: %w", method, err)
-		}
-		return nil
-	}
+	return p.jsonrpcPeer.request(ctx, "plugin", method, params, result)
 }
 
 func (p *pluginConnection) setHealth(status, message string, at time.Time) {

--- a/internal/daemon/workspace_keeper.go
+++ b/internal/daemon/workspace_keeper.go
@@ -328,6 +328,16 @@ func (d *Daemon) startJobQueue() {
 		); err != nil {
 			d.logf("session activity: register scan tick: %v", err)
 		}
+		// The app invocation log is the third periodic duty. It trims on the same
+		// queue as the others so there is one place to look when it stops running.
+		if err := runner.RegisterCron(
+			appInvocationRetentionKind,
+			appInvocationRetentionInterval,
+			d.appInvocationRetentionHandler,
+			jobs.HandlerConfig{Timeout: appInvocationRetentionTimeout},
+		); err != nil {
+			d.logf("apps: register invocation retention tick: %v", err)
+		}
 		if err := runner.RegisterCron(
 			automationScheduleKind,
 			automationScheduleInterval,

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "220"
+const ProtocolVersion = "221"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only
@@ -120,6 +120,10 @@ const (
 	CmdAppRemove                             = "app_remove"
 	CmdAppApply                              = "app_apply"
 	CmdAppRollback                           = "app_rollback"
+	CmdAppLogs                               = "app_logs"
+	CmdAppRuntimeStatus                      = "app_runtime_status"
+	CmdAppRuntimeRestart                     = "app_runtime_restart"
+	CmdAppWatch                              = "app_watch"
 	CmdGetTicket                             = "get_ticket"
 	CmdTicketChangeStatus                    = "ticket_change_status"
 	CmdTicketAddComment                      = "ticket_add_comment"
@@ -752,6 +756,34 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdAppRollback:
 		var msg AppRollbackMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAppLogs:
+		var msg AppLogsMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAppRuntimeStatus:
+		var msg AppRuntimeStatusMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAppRuntimeRestart:
+		var msg AppRuntimeRestartMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAppWatch:
+		var msg AppWatchMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -176,6 +176,31 @@ type AppListResult struct {
 	Apps []AppSummary `json:"apps"`
 }
 
+type AppLogsMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Lines corresponds to the JSON schema field "lines".
+	Lines *int `json:"lines,omitempty,omitzero"`
+
+	// Name corresponds to the JSON schema field "name".
+	Name string `json:"name"`
+}
+
+type AppLogsResult struct {
+	// Lines corresponds to the JSON schema field "lines".
+	Lines []string `json:"lines"`
+
+	// Name corresponds to the JSON schema field "name".
+	Name string `json:"name"`
+
+	// Path corresponds to the JSON schema field "path".
+	Path string `json:"path"`
+
+	// Truncated corresponds to the JSON schema field "truncated".
+	Truncated bool `json:"truncated"`
+}
+
 type AppRemoveMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -229,6 +254,79 @@ type AppRollbackResult struct {
 	VersionID int `json:"version_id"`
 }
 
+type AppRuntimeInfo struct {
+	// Connected corresponds to the JSON schema field "connected".
+	Connected bool `json:"connected"`
+
+	// ConnectedAt corresponds to the JSON schema field "connected_at".
+	ConnectedAt *string `json:"connected_at,omitempty,omitzero"`
+
+	// Desired corresponds to the JSON schema field "desired".
+	Desired string `json:"desired"`
+
+	// Generation corresponds to the JSON schema field "generation".
+	Generation int `json:"generation"`
+
+	// LastExit corresponds to the JSON schema field "last_exit".
+	LastExit *string `json:"last_exit,omitempty,omitzero"`
+
+	// NextRestartAt corresponds to the JSON schema field "next_restart_at".
+	NextRestartAt *string `json:"next_restart_at,omitempty,omitzero"`
+
+	// Phase corresponds to the JSON schema field "phase".
+	Phase string `json:"phase"`
+
+	// Pid corresponds to the JSON schema field "pid".
+	Pid *int `json:"pid,omitempty,omitzero"`
+
+	// RestartAttempt corresponds to the JSON schema field "restart_attempt".
+	RestartAttempt int `json:"restart_attempt"`
+
+	// Running corresponds to the JSON schema field "running".
+	Running bool `json:"running"`
+
+	// StartedAt corresponds to the JSON schema field "started_at".
+	StartedAt *string `json:"started_at,omitempty,omitzero"`
+}
+
+type AppRuntimeRestartMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+}
+
+type AppRuntimeRestartResult struct {
+	// Runtime corresponds to the JSON schema field "runtime".
+	Runtime AppRuntimeInfo `json:"runtime"`
+
+	// Was corresponds to the JSON schema field "was".
+	Was string `json:"was"`
+}
+
+type AppRuntimeStatusMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+}
+
+type AppRuntimeStatusResult struct {
+	// Apps corresponds to the JSON schema field "apps".
+	Apps int `json:"apps"`
+
+	// AppsEnabled corresponds to the JSON schema field "apps_enabled".
+	AppsEnabled int `json:"apps_enabled"`
+
+	// HostError corresponds to the JSON schema field "host_error".
+	HostError *string `json:"host_error,omitempty,omitzero"`
+
+	// HostPath corresponds to the JSON schema field "host_path".
+	HostPath *string `json:"host_path,omitempty,omitzero"`
+
+	// LogPath corresponds to the JSON schema field "log_path".
+	LogPath string `json:"log_path"`
+
+	// Runtime corresponds to the JSON schema field "runtime".
+	Runtime *AppRuntimeInfo `json:"runtime,omitempty,omitzero"`
+}
+
 type AppSetEnabledMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -251,6 +349,26 @@ type AppSetEnabledResult struct {
 	Name string `json:"name"`
 }
 
+type AppStallInfo struct {
+	// Attempts corresponds to the JSON schema field "attempts".
+	Attempts int `json:"attempts"`
+
+	// DisablesAt corresponds to the JSON schema field "disables_at".
+	DisablesAt string `json:"disables_at"`
+
+	// EventName corresponds to the JSON schema field "event_name".
+	EventName string `json:"event_name"`
+
+	// EventSeq corresponds to the JSON schema field "event_seq".
+	EventSeq int `json:"event_seq"`
+
+	// LastError corresponds to the JSON schema field "last_error".
+	LastError string `json:"last_error"`
+
+	// Since corresponds to the JSON schema field "since".
+	Since string `json:"since"`
+}
+
 type AppStatusMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -268,6 +386,12 @@ type AppStatusResult struct {
 
 	// Recent corresponds to the JSON schema field "recent".
 	Recent []AppInvocationInfo `json:"recent,omitempty,omitzero"`
+
+	// Runtime corresponds to the JSON schema field "runtime".
+	Runtime *AppRuntimeInfo `json:"runtime,omitempty,omitzero"`
+
+	// Stall corresponds to the JSON schema field "stall".
+	Stall *AppStallInfo `json:"stall,omitempty,omitzero"`
 
 	// Versions corresponds to the JSON schema field "versions".
 	Versions int `json:"versions"`
@@ -302,6 +426,19 @@ type AppVersionInfo struct {
 
 	// ID corresponds to the JSON schema field "id".
 	ID int `json:"id"`
+}
+
+type AppWatchMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Name corresponds to the JSON schema field "name".
+	Name string `json:"name"`
+}
+
+type AppWatchResult struct {
+	// Invocation corresponds to the JSON schema field "invocation".
+	Invocation AppInvocationInfo `json:"invocation"`
 }
 
 type ApprovePRMessage struct {
@@ -4526,11 +4663,22 @@ type Response struct {
 	// AppListResult corresponds to the JSON schema field "app_list_result".
 	AppListResult *AppListResult `json:"app_list_result,omitempty,omitzero"`
 
+	// AppLogsResult corresponds to the JSON schema field "app_logs_result".
+	AppLogsResult *AppLogsResult `json:"app_logs_result,omitempty,omitzero"`
+
 	// AppRemoveResult corresponds to the JSON schema field "app_remove_result".
 	AppRemoveResult *AppRemoveResult `json:"app_remove_result,omitempty,omitzero"`
 
 	// AppRollbackResult corresponds to the JSON schema field "app_rollback_result".
 	AppRollbackResult *AppRollbackResult `json:"app_rollback_result,omitempty,omitzero"`
+
+	// AppRuntimeRestartResult corresponds to the JSON schema field
+	// "app_runtime_restart_result".
+	AppRuntimeRestartResult *AppRuntimeRestartResult `json:"app_runtime_restart_result,omitempty,omitzero"`
+
+	// AppRuntimeStatusResult corresponds to the JSON schema field
+	// "app_runtime_status_result".
+	AppRuntimeStatusResult *AppRuntimeStatusResult `json:"app_runtime_status_result,omitempty,omitzero"`
 
 	// AppSetEnabledResult corresponds to the JSON schema field
 	// "app_set_enabled_result".
@@ -4538,6 +4686,9 @@ type Response struct {
 
 	// AppStatusResult corresponds to the JSON schema field "app_status_result".
 	AppStatusResult *AppStatusResult `json:"app_status_result,omitempty,omitzero"`
+
+	// AppWatchResult corresponds to the JSON schema field "app_watch_result".
+	AppWatchResult *AppWatchResult `json:"app_watch_result,omitempty,omitzero"`
 
 	// Authors corresponds to the JSON schema field "authors".
 	Authors []AuthorState `json:"authors,omitempty,omitzero"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -3920,15 +3920,137 @@ model AppStatusMessage {
 }
 
 // What is known about one app, and only what is known: the registry row, the
-// consumer if there is one, and the invocations recorded so far. Fields the
-// runtime owns are absent until the runtime exists — an app's status must not
-// claim a health it cannot observe.
+// consumer if there is one, the invocations recorded so far, and the shared
+// runtime's state. An app's status must not claim a health it cannot observe, so
+// every field the runtime owns is absent when there is no runtime.
 model AppStatusResult {
   "app": AppSummary;
   "versions": safeint;
   "invocations": safeint;
   // The most recent invocations, newest first, when any have been recorded.
   "recent"?: AppInvocationInfo[];
+  // The shared runtime every app's handlers execute in. Absent until it has been
+  // started once — a daemon with quiet apps starts no sidecar, and reporting a
+  // "stopped" runtime that was never asked to run would read as a fault.
+  "runtime"?: AppRuntimeInfo;
+  // What this app is currently stuck on, when it is stuck. Present only while a
+  // handler is failing on the same event; a successful delivery clears it.
+  "stall"?: AppStallInfo;
+}
+
+// The shared app runtime as the supervisor sees it. One process for every app —
+// isolation between apps is failure attribution, not an OS boundary — so this
+// answer is the same whichever app's status asked for it.
+model AppRuntimeInfo {
+  // "starting" | "connected" | "backoff" | "stopped" | "parked". Parked is the
+  // one that needs acting on: it means attn gave up restarting and no app's
+  // handlers are running until `attn app runtime restart`.
+  "phase": string;
+  // "running" | "stopped" — what attn is trying to achieve, as opposed to where
+  // it currently is.
+  "desired": string;
+  "running": boolean;
+  "connected": boolean;
+  // Increments on every start. The supervisor fences stale processes by it, so a
+  // generation that keeps climbing is a crash loop in one number.
+  "generation": safeint;
+  "restart_attempt": int32;
+  // The connected runtime's process id. Absent when nothing is connected.
+  "pid"?: safeint;
+  "started_at"?: string;
+  "connected_at"?: string;
+  // When the next restart fires, while backing off.
+  "next_restart_at"?: string;
+  // How the last process ended, rendered. Absent when it has never exited.
+  "last_exit"?: string;
+}
+
+// An app that has failed on the same event long enough to be on the clock.
+//
+// `disables_at` is the whole point of reporting this: an app stalled on one
+// event holds the durable log's retention floor open for every other consumer,
+// so attn disables it, and the reader is entitled to know when.
+model AppStallInfo {
+  "event_seq": safeint;
+  "event_name": string;
+  // When the app first failed on this event.
+  "since": string;
+  "attempts": int32;
+  "last_error": string;
+  "disables_at": string;
+}
+
+// The shared runtime's own surface, addressed as `runtime` rather than as an app
+// — which is why no app may be called that.
+model AppRuntimeStatusMessage {
+  "cmd": "app_runtime_status";
+}
+
+model AppRuntimeStatusResult {
+  // Absent when the runtime has never been started in this daemon.
+  "runtime"?: AppRuntimeInfo;
+  // How many apps are registered, and how many of those are enabled — the answer
+  // to "should anything be running at all".
+  "apps": safeint;
+  "apps_enabled": safeint;
+  // The binary that gets launched. Absent, with `host_error` set, when it cannot
+  // be found: a runtime that will never start must say so before it is asked to.
+  "host_path"?: string;
+  "host_error"?: string;
+  // Where the runtime's captured output lands. `attn app logs` reads it.
+  "log_path": string;
+}
+
+// Restart the shared runtime: kill the current process if there is one, and
+// start a fresh generation. It is also the way out of `parked` — a crash-looped
+// runtime is not retried until somebody asks.
+//
+// It takes no app name, deliberately. There is one runtime for every app, so
+// naming one would suggest a per-app restart that does not exist.
+model AppRuntimeRestartMessage {
+  "cmd": "app_runtime_restart";
+}
+
+model AppRuntimeRestartResult {
+  // The phase the runtime was in before the restart, so the answer says what
+  // actually changed — reviving a parked runtime and bouncing a healthy one are
+  // different acts with the same verb.
+  "was": string;
+  "runtime": AppRuntimeInfo;
+}
+
+// The shared runtime's captured stdout and stderr, filtered to one app.
+//
+// Every app's handlers print to the same process's output, so the runtime tags
+// each line with the app that wrote it and this reads the tag back. `runtime` as
+// the name means the whole log, untagged lines included — the runtime's own
+// output, which is where a startup failure appears.
+model AppLogsMessage {
+  "cmd": "app_logs";
+  "name": string;
+  // How many matching lines to return, newest last. 0 means the default.
+  "lines"?: int32;
+}
+
+model AppLogsResult {
+  "name": string;
+  "path": string;
+  // Matching lines in the order they were written, with the app tag removed.
+  "lines": string[];
+  // True when older matching lines were dropped to honour the limit.
+  "truncated": boolean;
+}
+
+// Stream an app's invocations as they are recorded. The connection stays open
+// and one result is written per invocation, which is what `attn app dev` renders
+// beside its apply results: an app author editing a handler sees the handler run.
+model AppWatchMessage {
+  "cmd": "app_watch";
+  "name": string;
+}
+
+model AppWatchResult {
+  "invocation": AppInvocationInfo;
 }
 
 model AppInvocationInfo {
@@ -4102,6 +4224,10 @@ model Response {
   app_remove_result?: AppRemoveResult;
   app_apply_result?: AppApplyResult;
   app_rollback_result?: AppRollbackResult;
+  app_logs_result?: AppLogsResult;
+  app_runtime_status_result?: AppRuntimeStatusResult;
+  app_runtime_restart_result?: AppRuntimeRestartResult;
+  app_watch_result?: AppWatchResult;
 }
 
 // One recorded state observation and its fate. Outcome separates the ways an

--- a/internal/store/apps.go
+++ b/internal/store/apps.go
@@ -399,6 +399,65 @@ func (s *Store) ListAppInvocations(name string, limit int) ([]AppInvocation, err
 	return out, rows.Err()
 }
 
+// TrimAppInvocations drops invocations that started before cutoff, then drops
+// everything past the newest perApp rows of each app. It reports how many went.
+//
+// Two limits because they answer two different questions. The age window is when
+// a row stops being useful: an invocation whose event has aged off the durable
+// log cannot be re-examined against it. The per-app cap is how large the log is
+// allowed to get, which the age window cannot bound — how many rows thirty days
+// holds depends entirely on how loud the app's subscription is, and the loudest
+// one in attn is three orders of magnitude above the quietest. Both values and
+// their receipts live with the caller (internal/daemon, AppInvocationRetention
+// and AppInvocationsPerApp) — the store keeps no policy. A perApp of zero or
+// less skips the cap.
+//
+// Both sweeps run across every app in one statement rather than per app:
+// retention is a property of the table, and a sweep that walked the registry
+// would miss the rows of an app that has been removed, which are exactly the ones
+// nothing will ever read again.
+func (s *Store) TrimAppInvocations(cutoff time.Time, perApp int) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return 0, nil
+	}
+	removed := 0
+	res, err := s.db.Exec(`DELETE FROM app_invocations WHERE started_at < ?`,
+		cutoff.UTC().Format(sortableTimeFormat))
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	removed += int(n)
+
+	if perApp <= 0 {
+		return removed, nil
+	}
+	// The ordering matches ListAppInvocations exactly — newest first, id breaking
+	// a same-timestamp tie — so what the cap keeps is what a reader can see.
+	res, err = s.db.Exec(`
+		DELETE FROM app_invocations WHERE id IN (
+			SELECT id FROM (
+				SELECT id, ROW_NUMBER() OVER (
+					PARTITION BY app_name ORDER BY started_at DESC, id DESC
+				) AS rank FROM app_invocations
+			) WHERE rank > ?
+		)`, perApp)
+	if err != nil {
+		return removed, err
+	}
+	n, err = res.RowsAffected()
+	if err != nil {
+		return removed, err
+	}
+	return removed + int(n), nil
+}
+
 func scanApp(row rowScanner) (App, error) {
 	var (
 		app       App

--- a/internal/supervise/supervise.go
+++ b/internal/supervise/supervise.go
@@ -284,6 +284,12 @@ func (s *Supervisor) Ensure(name string, start StartFunc) error {
 }
 
 // Stop kills a child and stops supervising it until the next Ensure.
+//
+// It also ends the crash-loop episode: the restart budget counts restarts the
+// supervisor chose, and a deliberate stop is not one of them. Without the reset,
+// stop-then-start — which is what a "restart" verb is — would revive a parked
+// child with no budget left, and the next single exit would park it again. That
+// makes the way back from parked a door that opens once.
 func (s *Supervisor) Stop(name string) {
 	s.mu.Lock()
 	c := s.children[name]
@@ -293,6 +299,7 @@ func (s *Supervisor) Stop(name string) {
 	}
 	c.desired = DesiredStopped
 	c.phase = PhaseStopped
+	c.restartAttempt = 0
 	c.generation++
 	c.connectedAt = time.Time{}
 	c.nextRestartAt = time.Time{}

--- a/internal/supervise/supervise_test.go
+++ b/internal/supervise/supervise_test.go
@@ -263,6 +263,47 @@ func TestParksAfterGiveUpTripwireAndAnnouncesOnce(t *testing.T) {
 	}
 }
 
+// Stop-then-Ensure is what every "restart" verb is built from, and it has to
+// hand back a full restart budget. A revived child that still carries the
+// attempts that parked it would park again on its first exit, which makes the
+// way back from parked a door that opens once.
+func TestStopClearsTheRestartBudget(t *testing.T) {
+	clock := newFakeClock()
+	launcher := &fakeLauncher{}
+	supervisor := New(Options{Clock: clock, GiveUpAfter: 1})
+	_ = supervisor.Ensure("fixture", launcher.start)
+
+	launcher.handle(0).exit(Exit{Error: "boom"})
+	waitFor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.Phase == PhaseBackoff
+	})
+	clock.Advance(RestartBackoff[0])
+	waitFor(t, func() bool { return launcher.count() == 2 })
+	launcher.handle(1).exit(Exit{Error: "boom"})
+	waitFor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.Phase == PhaseParked
+	})
+
+	supervisor.Stop("fixture")
+	if snapshot, _ := supervisor.Snapshot("fixture"); snapshot.RestartAttempt != 0 {
+		t.Fatalf("restart attempts = %d after Stop, want the episode ended", snapshot.RestartAttempt)
+	}
+	if err := supervisor.Ensure("fixture", launcher.start); err != nil {
+		t.Fatalf("Ensure after Stop: %v", err)
+	}
+	waitFor(t, func() bool { return launcher.count() == 3 })
+
+	// The proof that the budget really came back: one exit puts it in backoff
+	// rather than straight back into the park.
+	launcher.handle(2).exit(Exit{Error: "boom"})
+	waitFor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.Phase == PhaseBackoff
+	})
+}
+
 // Parking is reversible: the consumer's ordinary "this should be running" call
 // revives the child with a clean restart budget.
 func TestEnsureRevivesParkedChild(t *testing.T) {

--- a/scripts/build-app-profile.sh
+++ b/scripts/build-app-profile.sh
@@ -43,6 +43,10 @@ cp "$attn" "app/src-tauri/binaries/attn-aarch64-apple-darwin"
 # available in the catalog; the daemon still requires a per-profile opt-in.
 bash ./scripts/build-bundled-plugins.sh
 
+# The shared app runtime, compiled the same way and for the same reason: a
+# GUI-spawned daemon cannot resolve bun on a developer PATH.
+bash ./scripts/build-app-runtime-host.sh
+
 cd app
 pnpm install
 
@@ -92,7 +96,7 @@ if [ "$(uname -s)" = "Darwin" ]; then
   if [ -z "$identity" ]; then identity="-"; fi
   while IFS= read -r executable; do
     codesign --force --sign "$identity" "$executable"
-  done < <(find "${bundle_dir}/Contents/Resources/plugins" -type f -perm -111 2>/dev/null | sort)
+  done < <(find "${bundle_dir}/Contents/Resources/plugins" "${bundle_dir}/Contents/Resources/app-runtime" -type f -perm -111 2>/dev/null | sort)
   codesign --force --sign "$identity" "${bundle_dir}/Contents/MacOS/attn"
   codesign --force --sign "$identity" "${bundle_dir}"
 fi

--- a/scripts/build-app-runtime-host.sh
+++ b/scripts/build-app-runtime-host.sh
@@ -79,8 +79,13 @@ remove_bun_linker_signature() {
 }
 
 echo "building the app runtime host${bun_target:+ for ${bun_target}}"
-rm -rf "${stage_dir}"
+# The binary, not the directory: the native stage dir is a Tauri resource path,
+# which cargo's build script resolves before anything has built into it. It is
+# checked in as an empty directory holding a .gitkeep, and removing it here would
+# fail a fresh checkout's `cargo build` with `resource path 'app-runtime' doesn't
+# exist`.
 mkdir -p "${stage_dir}"
+rm -f "${stage_dir}/${binary_name}"
 
 compile_args=("${source_dir}/src/index.ts" --compile --minify --outfile "${stage_dir}/${binary_name}")
 if [[ -n "${bun_target}" ]]; then

--- a/scripts/build-app-runtime-host.sh
+++ b/scripts/build-app-runtime-host.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds attn's shared app runtime host — the Bun sidecar every installed app's
+# handlers execute in — as a `bun build --compile` standalone binary.
+#
+# Compiling rather than shipping source is what makes the runtime reachable at
+# all: bun lives on a developer PATH that `pathutil.EnsureGUIPath()` does not
+# reconstruct, so a daemon launched by the macOS app cannot find it. The Bun
+# runtime is embedded in the executable, so running apps needs no toolchain on the
+# user's machine; bun is required only by `attn app apply`, which builds CLI-side.
+#
+# Usage: build-app-runtime-host.sh [stage_dir] [bun_target]
+#
+#   stage_dir   where to place the binary. Defaults to the Tauri resource dir, so
+#               a plain run stages it for the next app build.
+#   bun_target  a `bun build --compile --target=` triple. Empty means the host
+#               platform. Cross targets (bun-linux-x64, bun-linux-arm64) exist so
+#               the runtime is not silently darwin-only: the daemon runs on Linux
+#               remotes.
+#
+# The Mach-O trailer fixups are the same ones the bundled-plugin build carries
+# (oven-sh/bun#32159) and are Darwin-only by construction — a Linux-target binary
+# has no code signature to strip.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+stage_dir="${1:-${repo_root}/app/src-tauri/app-runtime}"
+bun_target="${2:-}"
+
+# Resolved against the caller's directory before anything else, because the
+# compile below runs from apphost/ and bun reads --outfile relative to its own
+# cwd. A relative stage_dir would be created where the caller meant and written
+# one directory deeper, leaving the build reporting success over an empty tree.
+case "${stage_dir}" in
+  /*) ;;
+  *) stage_dir="$(pwd)/${stage_dir}" ;;
+esac
+
+# BinaryName is the same string internal/daemon looks for. Changing it here alone
+# produces a daemon that cannot find its runtime.
+binary_name="attn-app-runtime"
+source_dir="${repo_root}/apphost"
+
+minimum_bun_version="1.3.14"
+if ! command -v bun >/dev/null 2>&1; then
+  echo "bun is not on PATH; the app runtime host is a bun --compile binary" >&2
+  exit 1
+fi
+bun_version="$(bun --version)"
+if [[ "$(printf '%s\n' "${minimum_bun_version}" "${bun_version}" | sort -V | head -1)" != "${minimum_bun_version}" ]]; then
+  echo "bun ${bun_version} is too old to produce signable --compile binaries; need >= ${minimum_bun_version}" >&2
+  exit 1
+fi
+
+# Strips the ad-hoc signature bun's linker leaves, plus any bytes past the
+# Mach-O's declared LC_CODE_SIGNATURE end. Without it every later
+# `codesign --force --sign` of this binary fails strict validation.
+remove_bun_linker_signature() {
+  local executable="$1"
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    return
+  fi
+  command -v otool >/dev/null 2>&1 || return 0
+
+  local signature_end file_size
+  signature_end="$(otool -l "${executable}" | awk '
+    $1 == "cmd" && $2 == "LC_CODE_SIGNATURE" { in_signature = 1; next }
+    in_signature && $1 == "dataoff" { dataoff = $2; next }
+    in_signature && $1 == "datasize" { print dataoff + $2; exit }
+  ')"
+  if [[ -z "${signature_end}" ]]; then
+    return
+  fi
+  file_size="$(stat -f '%z' "${executable}")"
+  if (( file_size > signature_end )); then
+    truncate -s "${signature_end}" "${executable}"
+  fi
+  codesign --remove-signature "${executable}"
+}
+
+echo "building the app runtime host${bun_target:+ for ${bun_target}}"
+rm -rf "${stage_dir}"
+mkdir -p "${stage_dir}"
+
+compile_args=("${source_dir}/src/index.ts" --compile --minify --outfile "${stage_dir}/${binary_name}")
+if [[ -n "${bun_target}" ]]; then
+  compile_args+=(--target="${bun_target}")
+fi
+(cd "${source_dir}" && bun build "${compile_args[@]}")
+
+# bun leaves these beside the output; they are not part of the artifact.
+find "${stage_dir}" -maxdepth 1 -name '*.bun-build' -delete
+
+# A cross-compiled binary is not this host's Mach-O, so both the trailer fixup and
+# signing apply only to a native build.
+#
+# Signing here, rather than leaving it to the app bundle's signing pass as the
+# bundled-plugin build does, is what makes the artifact runnable from a checkout:
+# stripping bun's ad-hoc signature leaves a binary macOS refuses to execute at all
+# (SIGKILL, no diagnostic), and the daemon resolves this binary beside itself when
+# it is not running from a .app. The bundle pass re-signs with --force afterwards,
+# so signing twice costs nothing.
+if [[ -z "${bun_target}" ]]; then
+  remove_bun_linker_signature "${stage_dir}/${binary_name}"
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    identity="${MACOS_CODESIGN_IDENTITY:-}"
+    if [[ -z "${identity}" ]]; then
+      identity="$(bash "${repo_root}/scripts/macos-codesign-identity.sh" find)"
+    fi
+    codesign --force --sign "${identity:--}" "${stage_dir}/${binary_name}"
+  fi
+fi
+chmod 0755 "${stage_dir}/${binary_name}"
+
+echo "  ${stage_dir}/${binary_name}"

--- a/scripts/source-fingerprint.sh
+++ b/scripts/source-fingerprint.sh
@@ -76,6 +76,12 @@ should_exclude_path() {
     plugins/attn-pi/spike-harness/*) return 0 ;;
     plugins/attn-pi/package.json|plugins/attn-pi/bun.lock|plugins/attn-pi/attn-plugin.toml|plugins/attn-pi/README.md) return 1 ;;
     scripts/build-app-profile.sh|scripts/build-bundled-plugins.sh) return 1 ;;
+    # The app runtime host is compiled into the bundle, so its source and its
+    # build script move the fingerprint. The generic scripts/* rule below ignores
+    # everything it does not name.
+    apphost/src/*) return 1 ;;
+    apphost/package.json|apphost/tsconfig.json) return 1 ;;
+    scripts/build-app-runtime-host.sh) return 1 ;;
     app/scripts/real-app-harness/*) return 0 ;;
     app/scripts/*)                  return 0 ;;
     app/e2e/*)                      return 0 ;;


### PR DESCRIPTION
Installed apps now run. This is A4 slice 5: the shared Bun sidecar, handler
dispatch, the per-app bus consumers, the invocation log, auto-disable, and
`attn app logs`.

Design: `docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md`. Targets
`epic/ext-a4`.

## The three rules this is built on

**App code runs in the sidecar, never the daemon.** One shared supervised Bun
process for every installed app, started lazily on the first fact an app is
actually due — a user with installed-but-quiet apps pays nothing for them. It
ships as a `bun --compile` standalone binary (`apphost/`), so a daemon launched
by the macOS app needs no PATH resolution and a user's machine needs no
toolchain. Supervision is `internal/supervise`, the same machinery the plugin
runtime uses.

**A sidecar-wide crash is a RUNTIME failure class, never an app's.** The daemon
knows which app's handler was running when something threw and charges that app;
what it must never do is charge an app for the process dying. Every failure is
classified before it is recorded, and a runtime failure *clears* the app's stall
clock rather than merely not advancing it — leaving the clock running through an
outage would charge the app for minutes the sidecar was down.

**Apps are ordinary durable bus consumers.** `app:<name>`, registered at daemon
start and on apply, cursor from head. At-least-once, stall-don't-skip,
cursor-after-handler — consumed, not forked. A re-applied app gets `SetFilter`
rather than a re-registration, because unregister-then-register would delete the
cursor on the way through and silently skip every fact published while the app
was being updated.

## What a reader gets

```
$ attn app status ticketwatch
  consumer:   app:ticketwatch — enabled, cursor 46, 1 event(s) behind
  runtime:    running (connected), generation 4
  stalled:    on event 47 (ticket.created) since 22:57:04Z, 3 attempt(s)
              Error: the ticket store is unreachable
                  at onTicket (…/bundle.js:5:18)
              disables itself at 23:12:04Z unless it succeeds first
```

Every limit says its value and the ask. `attn app runtime restart ticketwatch`
answers with the design, not the syntax: *"takes no app name, and "ticketwatch"
looks like one. Every app's handlers run in one shared runtime, so restarting it
restarts them all — there is nothing per-app to restart. To stop one app, `attn
app disable ticketwatch`."*

## Auto-disable

One clock, no failure-count clause: an app stuck on the *same* event for fifteen
minutes is disabled. The harm being prevented is a stalled consumer pinning the
durable log's retention floor open for everybody, and that is a function of wall
time stalled, not of how many times the retry happened to fire — a count would
also punish a fast-failing app more than a slow one for the same harm. Firing
flips the bit, publishes the fact, and writes a durable notification naming the
app, the event and the last error; the tests assert all three. `attn app enable`
clears the streak and resumes.

## Proof

Tests (`-race` green across `internal/daemon`, `internal/store`, `internal/bus`,
`internal/apps`, `internal/supervise`, `internal/appbuild`, `cmd/attn`) pin:
cursor advance with the RUNNING version id; a handler throw recording failure
text and redelivering without skipping; `attn app remove` during an in-flight
dispatch returning promptly; a late sidecar answer with nobody waiting being
dropped; a sidecar death recorded as a runtime failure that does not advance the
app's clock; a crash-looping runtime parking and saying so on every app's status;
auto-disable flipping the bit *and* publishing *and* notifying, on an injected
clock; a slow-but-succeeding app never touching the clock; distinct-event
failures never firing it; a disabled app releasing the retention floor (proved
through the real `Trim`, which returns 0 while the stalled app is enabled and >0
after); revive and healthy restart; reserved names refused; hot reload stamping
the new id for the next dispatch and the old one for the in-flight; and a handler
being unable to name a collection its manifest did not declare.

### Live receipts

Throwaway profile `a4rt5`, full `make install PROFILE=a4rt5` from this branch,
bundled preflight PASS (0 failed, 0 warnings), profile cleaned afterwards.

- A scaffolded app applied and enabled, then driven with real `ticket.*` facts
  from `attn ticket new` / `attn ticket comment`.
- Invocations in `attn app status`, handler documents readable with
  `attn doc get app/ticketwatch seen <id>`, `attn app logs ticketwatch` showing
  the app's own lines filtered out of the shared log, `attn app dev` streaming
  `ok ticket.*(ticket.created …) in 1ms` beside its apply output.
- Hot reload: version 2 applied mid-flight, the next dispatch stamped version 2.
- The sidecar killed **by the pid the daemon reported for it** — supervision
  restarted it at generation 2 with `last exit: signal: killed` recorded, the app
  stayed enabled with no stall, and the next fact dispatched normally.
- A handler made to throw produced attempts at 22:57:07, :11, :19, :35 on the
  same seq — 4s, 8s, 16s of bus backoff — with the cursor parked one behind
  throughout, then version 4 succeeded on that same seq and the cursor advanced.

Measurements and the numbers they justify are written into the plan doc under
"Slice 5 receipts": cold start **77ms** end to end (→ `appRuntimeConnectWait`
10s), warm handler **0–1ms** (→ `appDispatchTimeout` 60s), and the invocation
log's size, below.

### The retention receipt changed the design

I had written a 30-day age window with a hand-waved "roughly a dozen facts per
session-hour" behind it. Measuring 7.5 days of real production log (275,845
facts) says the loudest fact is `session.state.changed` at **1,141/hour** — and
that is what a scaffolded app subscribes to out of the box. Thirty days of it is
~820,000 rows, well over a hundred megabytes for one app, against a database
that is 51MB today. `ticket.*`, the quiet end, runs at 27/day.

So the age window cannot bound the table: how many rows thirty days holds is
entirely a property of what the app subscribed to. There are now two limits with
two distinct jobs — the age window for when a row stops being *useful* (an
invocation whose event has aged off the durable log cannot be re-read against it,
which is why it matches the bus's own retention), and `AppInvocationsPerApp =
20,000` for how large the log may *get*: ~17 hours of the loudest possible app,
about 4MB, and two years at the ticket rate, so anything quiet never feels it.

## Two build bugs the verification found

Neither is app-runtime code; both were breaking documented workflows silently.

- **`UNAME_S` was referenced by three Makefile recipes and defined by none.** It
  expanded to empty, so `make install-daemon` skipped code signing: the copied
  binary kept its ad-hoc linker signature inside a properly signed bundle and
  macOS answered `daemon ensure` with `Killed: 9`. The cheap daemon-only install
  tier AGENTS.md prescribes did not work for anybody.
- **`scripts/build-app-runtime-host.sh` resolved a relative `stage_dir` against
  the wrong directory.** It `cd`s to `apphost/` before invoking bun, and bun reads
  `--outfile` from its own cwd, so both Linux cross-builds reported success over
  an empty tree and wrote the ELF under `apphost/dist/`. The native build was
  unaffected because its default stage dir is absolute — which is exactly how a
  cross-only break stays invisible. Both targets now produce real ELF binaries
  (x86-64 and aarch64) where the Makefile promises them.

## Surfaces walked

CLI (`app logs`, `app runtime status|restart`, runtime and stall rows on `app
status`, `app dev` streaming); daemon and app (protocol 221, `generated.ts` moved
with `generated.go`, `useDaemonSocket.ts` bumped in lockstep); the four new
commands added to `CommandMeta`; Linux (`GOOS=linux go build ./...` clean, host
binary cross-compiled for amd64 and arm64); docs (plan-doc receipts, scaffold
AGENTS.md now teaches the failure model and `attn app logs`, changelog fragment).
The slice-4 changelog fragment said invocations are not streamed — both compile
into the same release, so that sentence is gone.

Out of scope by design, per the plan: UI surfaces (A5), apps as fact producers,
pi-host adoption of supervise, a wipe verb, per-handler cursors.

https://claude.ai/code/session_019WNzAtCygzMJjmr9Z4r6sY
