### PR TITLE
feat(notifications): give notifications a severity and critical an ambient surface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,6 +281,14 @@ clean:
 	rm -f $(BINARY_NAME)
 
 # Type generation pipeline: TypeSpec -> JSON Schema -> go-jsonschema/quicktype
+#
+# LC_ALL=C is load-bearing, not hygiene. The `*.json` globs below are sorted by
+# the shell's collation, and quicktype names an anonymous type after whichever
+# schema it meets first — so the same inputs under en_US.UTF-8 rename types in
+# lockstep down the file (FileElement -> ChangedFileElement, and so on), a
+# ~1200-line diff that says nothing. Generating under C makes the output depend
+# only on the schemas.
+generate-types: export LC_ALL = C
 generate-types:
 	rm -rf internal/protocol/schema/tsp-output/json-schema
 	cd internal/protocol/schema && pnpm exec tsp compile .

--- a/app/src/App.chiefOfStaffClose.test.tsx
+++ b/app/src/App.chiefOfStaffClose.test.tsx
@@ -192,7 +192,7 @@ describe('chief-of-staff session is protected from close', () => {
       getPresentations: vi.fn(async () => []),
       connectionError: null,
       hasReceivedInitialState: true,
-      sendNotificationList: vi.fn(async () => ({ notifications: [], unreadCount: 0 })),
+      sendNotificationList: vi.fn(async () => ({ notifications: [], unreadCount: 0, critical: { count: 0, title: '' } })),
       sendNotificationMarkRead: vi.fn(async () => 0),
       rateLimit: null,
       warnings: [],

--- a/app/src/App.criticalNotificationCadence.test.tsx
+++ b/app/src/App.criticalNotificationCadence.test.tsx
@@ -1,0 +1,197 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { act, render } from '@testing-library/react';
+import App from './App';
+import { WHATS_NEW_ID, WHATS_NEW_STORAGE_KEY } from './hooks/useWhatsNew';
+import type { CriticalNotificationState } from './hooks/useDaemonSocket';
+
+// notifications_updated fires on every notification write and carries a fresh
+// critical-state object each time, so an unchanged pair still arrives with a new
+// identity. App holds it behind an equality guard so the identity below the
+// socket changes only when the pair does — the witness is the identity of the
+// criticalNotifications prop the Sidebar receives.
+//
+// This does not claim the header actions stop rebuilding. That memo has other
+// deps that are fresh on every render, so it rebuilds regardless; what is pinned
+// here is the one identity this code owns.
+
+const mockUseSessionStore = vi.fn();
+const mockUseDaemonStore = vi.fn();
+const mockUseDaemonSocket = vi.fn();
+
+const { criticalSeen } = vi.hoisted(() => ({ criticalSeen: [] as unknown[] }));
+
+let notifyCritical: ((unread: number, critical: CriticalNotificationState) => void) | null = null;
+
+vi.mock('@tauri-apps/plugin-deep-link', () => ({
+  onOpenUrl: vi.fn(async () => () => {}),
+  getCurrent: vi.fn(async () => []),
+}));
+vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn(async () => {}) }));
+vi.mock('./components/GhosttyTerminal', async () => {
+  const React = await import('react');
+  return { GhosttyTerminal: React.forwardRef(function MockTerminal() { return null; }) };
+});
+
+// Sidebar stub that records the critical-state identity it is handed on each
+// render. Reading identity rather than a render count is deliberate: App
+// re-renders on every broadcast regardless — the change signal an open panel
+// needs — so a render count cannot tell a repeat from a real change.
+vi.mock('./components/Sidebar', () => ({
+  EditorIcon: () => null,
+  WorkflowIcon: () => null,
+  DiffIcon: () => null,
+  PRsIcon: () => null,
+  NotebookIcon: () => null,
+  MarkdownIcon: () => null,
+  Sidebar: ({ criticalNotifications }: { criticalNotifications: unknown }) => {
+    criticalSeen.push(criticalNotifications);
+    return null;
+  },
+}));
+
+vi.mock('./components/Dashboard', () => ({ Dashboard: () => null }));
+vi.mock('./components/AttentionDrawer', () => ({ AttentionDrawer: () => null }));
+vi.mock('./components/LocationPicker', () => ({ LocationPicker: () => null }));
+vi.mock('./components/UndoToast', () => ({ UndoToast: () => null }));
+vi.mock('./components/SessionTerminalWorkspace', () => ({ SessionTerminalWorkspace: () => null }));
+vi.mock('./components/ErrorToast', () => ({
+  ErrorToast: () => null,
+  useErrorToast: () => ({ message: null, showError: vi.fn(), clearError: vi.fn() }),
+}));
+vi.mock('./hooks/useKeyboardShortcuts', () => ({ useKeyboardShortcuts: vi.fn() }));
+vi.mock('./hooks/useUIScale', () => ({
+  useUIScale: () => ({ scale: 1, increaseScale: vi.fn(), decreaseScale: vi.fn(), resetScale: vi.fn() }),
+}));
+vi.mock('./hooks/useOpenPR', () => ({ useOpenPR: () => vi.fn() }));
+vi.mock('./hooks/usePRsNeedingAttention', () => ({ usePRsNeedingAttention: () => ({ needsAttention: [] }) }));
+vi.mock('./store/sessions', () => ({ useSessionStore: () => mockUseSessionStore() }));
+vi.mock('./store/daemonSessions', () => ({ useDaemonStore: () => mockUseDaemonStore() }));
+vi.mock('./hooks/useDaemonSocket', () => ({
+  useDaemonSocket: (args: {
+    onNotificationsUpdated?: (unread: number, critical: CriticalNotificationState) => void;
+  }) => {
+    notifyCritical = args.onNotificationsUpdated ?? null;
+    return mockUseDaemonSocket(args);
+  },
+}));
+vi.mock('./pty/bridge', async () => {
+  const actual = await vi.importActual<typeof import('./pty/bridge')>('./pty/bridge');
+  return { ...actual, ptySpawn: vi.fn(async () => {}) };
+});
+
+function broadcast(unread: number, critical: CriticalNotificationState) {
+  act(() => {
+    notifyCritical?.(unread, critical);
+  });
+}
+
+function latestCritical() {
+  return criticalSeen[criticalSeen.length - 1];
+}
+
+describe('critical notification cadence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    criticalSeen.length = 0;
+    notifyCritical = null;
+    localStorage.clear();
+    localStorage.setItem(WHATS_NEW_STORAGE_KEY, WHATS_NEW_ID);
+
+    mockUseSessionStore.mockReturnValue({
+      sessions: [],
+      activeSessionId: null,
+      connect: vi.fn(async () => {}),
+      connected: true,
+      launcherConfig: { executables: {} },
+      createSession: vi.fn(async () => 's1'),
+      closeSession: vi.fn(),
+      setActiveSession: vi.fn(),
+      takeSessionSpawnArgs: vi.fn(() => null),
+      reloadSession: vi.fn(async () => {}),
+      setLauncherConfig: vi.fn(),
+      syncFromDaemonSessions: vi.fn(),
+      syncFromDaemonWorkspaces: vi.fn(),
+    });
+
+    mockUseDaemonStore.mockImplementation(() => ({
+      daemonSessions: [],
+      setDaemonSessions: vi.fn(),
+      prs: [], setPRs: vi.fn(),
+      repoStates: [], setRepoStates: vi.fn(),
+      authorStates: [], setAuthorStates: vi.fn(),
+    }));
+
+    const fn = vi.fn();
+    mockUseDaemonSocket.mockReturnValue({
+      sendPRAction: fn, sendMutePR: fn, sendMuteRepo: fn, sendMuteAuthor: fn, sendPRVisited: fn,
+      sendRefreshPRs: vi.fn(async () => ({ success: true })),
+      sendUnregisterSession: vi.fn(async () => {}),
+      sendRegisterWorkspace: fn,
+      sendUnregisterWorkspace: vi.fn(async () => {}),
+      sendMuteWorkspace: vi.fn(async () => ({ success: true })),
+      sendSetSetting: fn,
+      sendSetClientPresence: fn,
+      sendCreateWorktree: vi.fn(async () => ({ success: true, path: '/tmp/new' })),
+      sendDeleteWorktree: vi.fn(async () => ({ success: true })),
+      sendGetRecentLocations: vi.fn(async () => ({ success: true, locations: [] })),
+      sendCreateWorktreeFromBranch: vi.fn(async () => ({ success: true, path: '/tmp/new' })),
+      sendFetchRemotes: vi.fn(async () => ({ success: true })),
+      sendFetchPRDetails: vi.fn(async () => ({ success: true })),
+      sendEnsureRepo: vi.fn(async () => ({ success: true, path: '/tmp/repo' })),
+      sendSubscribeGitStatus: fn, sendUnsubscribeGitStatus: fn,
+      sendSessionSelected: fn, sendWorkspaceSelected: fn,
+      sendWorkspaceClosePane: vi.fn(async () => ({ success: true })),
+      sendWorkspaceAddSessionPane: vi.fn(async () => ({ success: true })),
+      requestTileContent: fn,
+      sendGetFileDiff: vi.fn(async () => ({ success: true, original: '', modified: '' })),
+      getRepoInfo: vi.fn(async () => ({ success: true, is_git_repo: true, branch: 'main' })),
+      listWorkflowRuns: vi.fn(async () => ({ success: true, runs: [] })),
+      getPresentations: vi.fn(async () => []),
+      connectionError: null,
+      hasReceivedInitialState: true,
+      sendNotificationList: vi.fn(async () => ({
+        notifications: [], unreadCount: 0, critical: { count: 0, title: '' },
+      })),
+      sendNotificationMarkRead: vi.fn(async () => 0),
+      rateLimit: null,
+      warnings: [],
+      clearWarnings: fn,
+      sendSetTerminalTheme: fn,
+    });
+  });
+
+  it('keeps one identity when a broadcast repeats the same critical state', () => {
+    render(<App />);
+
+    broadcast(4, { count: 2, title: 'Plugin stopped' });
+    const afterFirst = latestCritical();
+
+    broadcast(4, { count: 2, title: 'Plugin stopped' });
+
+    expect(latestCritical()).toBe(afterFirst);
+  });
+
+  it('takes the new one when the surface has to clear', () => {
+    render(<App />);
+
+    broadcast(4, { count: 2, title: 'Plugin stopped' });
+    const withCritical = latestCritical();
+
+    broadcast(2, { count: 0, title: '' });
+
+    expect(latestCritical()).not.toBe(withCritical);
+    expect(latestCritical()).toEqual({ count: 0, title: '' });
+  });
+
+  it('takes the new one when only the newest critical title changes', () => {
+    render(<App />);
+
+    broadcast(4, { count: 1, title: 'Plugin stopped' });
+    const first = latestCritical();
+
+    broadcast(5, { count: 2, title: 'App runtime parked' });
+
+    expect(latestCritical()).not.toBe(first);
+    expect(latestCritical()).toEqual({ count: 2, title: 'App runtime parked' });
+  });
+});

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -25,6 +25,13 @@
   --color-error: #ef4444;
   --color-warning: #f59e0b;
 
+  /* Notification severity. Aliases rather than new colors, so the feed cannot
+     drift from the status colors above; named separately because the panel and
+     the ambient critical surface style by severity, not by "error". */
+  --color-severity-info: var(--color-accent);
+  --color-severity-warning: var(--color-warning);
+  --color-severity-critical: var(--color-error);
+
   color-scheme: dark;
 
   /* Theme colors (dark defaults) */

--- a/app/src/App.followNextTurn.test.tsx
+++ b/app/src/App.followNextTurn.test.tsx
@@ -233,7 +233,7 @@ describe('waiting at home for the next turn', () => {
       getPresentations: vi.fn(async () => []),
       connectionError: null,
       hasReceivedInitialState: true,
-      sendNotificationList: vi.fn(async () => ({ notifications: [], unreadCount: 0 })),
+      sendNotificationList: vi.fn(async () => ({ notifications: [], unreadCount: 0, critical: { count: 0, title: '' } })),
       sendNotificationMarkRead: vi.fn(async () => 0),
       rateLimit: null,
       warnings: [],

--- a/app/src/App.sessionlessWorkspace.test.tsx
+++ b/app/src/App.sessionlessWorkspace.test.tsx
@@ -254,7 +254,7 @@ describe('tile-only (sessionless) workspace selection and render', () => {
       getPresentations: vi.fn(async () => []),
       connectionError: null,
       hasReceivedInitialState: true,
-      sendNotificationList: vi.fn(async () => ({ notifications: [], unreadCount: 0 })),
+      sendNotificationList: vi.fn(async () => ({ notifications: [], unreadCount: 0, critical: { count: 0, title: '' } })),
       sendNotificationMarkRead: vi.fn(async () => 0),
       rateLimit: null,
       warnings: [],

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -551,8 +551,16 @@ function App() {
   // beside the unread count rather than derived from a listed feed: the panel
   // only lists while open, and this surface has to be right whether or not the
   // user has ever opened it.
-  const [criticalNotifications, setCriticalNotifications] =
+  // Every broadcast carries a fresh object, so replace only on a real change:
+  // notifications_updated fires on each notification write, and a new identity
+  // for an unchanged pair would rebuild the header actions each time.
+  const [criticalNotifications, setCriticalNotificationsState] =
     useState<CriticalNotificationState>({ count: 0, title: '' });
+  const setCriticalNotifications = useCallback((next: CriticalNotificationState) => {
+    setCriticalNotificationsState((prev) =>
+      prev.count === next.count && prev.title === next.title ? prev : next,
+    );
+  }, []);
 
   // Connect to daemon WebSocket. The whole return value goes into context
   // below, for everything under AppContent; App destructures only the names
@@ -647,7 +655,7 @@ function App() {
     return () => {
       cancelled = true;
     };
-  }, [hasReceivedInitialState, sendNotificationList]);
+  }, [hasReceivedInitialState, sendNotificationList, setCriticalNotifications]);
 
   // Seed the presentation-notice list once the socket is up. The
   // presentation_added/updated broadcasts keep it live thereafter.
@@ -749,6 +757,11 @@ function AppContent({
   clearGitStatus,
   registerSessionExitHandler,
 }: AppContentProps) {
+  // The bell only cares whether anything critical is unread, not how many or
+  // which — depending on the flag keeps the header actions off the broadcast's
+  // cadence and on the state change the user can actually see.
+  const hasCriticalNotification = criticalNotifications.count > 0;
+
   // Every daemon command, read from the context App publishes rather than
   // threaded down as a hundred props.
   const {
@@ -3523,7 +3536,7 @@ function AppContent({
       // The bell half of the ambient critical surface: while something critical
       // is unread the badge stops being the brand accent (see
       // CriticalNotificationStrip.css).
-      toneClassName: criticalNotifications.count > 0 ? 'has-critical' : undefined,
+      toneClassName: hasCriticalNotification ? 'has-critical' : undefined,
       onClick: toggleNotificationsPanel,
     },
     {
@@ -3547,7 +3560,7 @@ function AppContent({
     openBoardSurface,
     notificationsPanelOpen,
     notificationsUnread,
-    criticalNotifications,
+    hasCriticalNotification,
     automationsPanelOpen,
     toggleNotificationsPanel,
   ]);

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -61,7 +61,7 @@ import {
   readWorkspaceSelectionStyle,
   type WorkspaceSelectionStyle,
 } from './utils/workspaceSelectionStyle';
-import { useDaemonSocket, DaemonWorktree, DaemonSession, DaemonWorkspace, DaemonPR, DaemonEndpoint, DaemonPlugin, DaemonPluginIssue, GitStatusUpdate, SessionExitInfo } from './hooks/useDaemonSocket';
+import { useDaemonSocket, DaemonWorktree, DaemonSession, DaemonWorkspace, DaemonPR, DaemonEndpoint, DaemonPlugin, DaemonPluginIssue, GitStatusUpdate, SessionExitInfo, CriticalNotificationState } from './hooks/useDaemonSocket';
 import type { Presentation } from './types/generated';
 import { useSessionWorkspaceController } from './hooks/useSessionWorkspaceController';
 import { isAttentionSessionState, normalizeSessionState, type UISessionState } from './types/sessionState';
@@ -547,6 +547,12 @@ function App() {
   // notifications panel re-lists. Seeded once initial state arrives (below).
   const [notificationsUnread, setNotificationsUnread] = useState(0);
   const [notificationsChangeSignal, setNotificationsChangeSignal] = useState(0);
+  // Drives the ambient critical surface (sidebar strip + bell escalation). Kept
+  // beside the unread count rather than derived from a listed feed: the panel
+  // only lists while open, and this surface has to be right whether or not the
+  // user has ever opened it.
+  const [criticalNotifications, setCriticalNotifications] =
+    useState<CriticalNotificationState>({ count: 0, title: '' });
 
   // Connect to daemon WebSocket. The whole return value goes into context
   // below, for everything under AppContent; App destructures only the names
@@ -574,8 +580,9 @@ function App() {
     onTasksChanged: () => setTaskChangeSignal((n) => n + 1),
     // A notifications_updated broadcast carries the authoritative unread count;
     // set the badge and bump the signal so an open panel re-lists.
-    onNotificationsUpdated: (unread) => {
+    onNotificationsUpdated: (unread, critical) => {
       setNotificationsUnread(unread);
+      setCriticalNotifications(critical);
       setNotificationsChangeSignal((n) => n + 1);
     },
     onTicketsUpdate: setTickets,
@@ -630,7 +637,9 @@ function App() {
     let cancelled = false;
     sendNotificationList()
       .then((r) => {
-        if (!cancelled) setNotificationsUnread(r.unreadCount);
+        if (cancelled) return;
+        setNotificationsUnread(r.unreadCount);
+        setCriticalNotifications(r.critical);
       })
       .catch(() => {
         /* transient (not connected / timeout); the next broadcast reseeds */
@@ -679,6 +688,7 @@ function App() {
           settingError={settingError}
           clearSettingError={() => setSettingError(null)}
           notificationsUnread={notificationsUnread}
+          criticalNotifications={criticalNotifications}
           notificationsChangeSignal={notificationsChangeSignal}
           fsChangeSignals={fsChangeSignals}
           notebookTaskChangeSignal={notebookTaskChangeSignal}
@@ -708,6 +718,7 @@ interface AppContentProps {
   settingError: string | null;
   clearSettingError: () => void;
   notificationsUnread: number;
+  criticalNotifications: CriticalNotificationState;
   notificationsChangeSignal: number;
   fsChangeSignals: Record<string, number>;
   notebookTaskChangeSignal: number;
@@ -731,6 +742,7 @@ function AppContent({
   settingError,
   clearSettingError,
   notificationsUnread,
+  criticalNotifications,
   notificationsChangeSignal,
   fsChangeSignals,
   notebookTaskChangeSignal,
@@ -1717,6 +1729,9 @@ function AppContent({
   }, []);
   const toggleNotificationsPanel = useCallback(() => {
     setNotificationsPanelOpen((open) => !open);
+  }, []);
+  const openNotificationsPanel = useCallback(() => {
+    setNotificationsPanelOpen(true);
   }, []);
   const closeNotificationsPanel = useCallback(() => {
     setNotificationsPanelOpen(false);
@@ -3505,6 +3520,10 @@ function AppContent({
       icon: <NotificationsBellIcon />,
       active: notificationsPanelOpen,
       badge: notificationsUnread > 0 ? notificationsUnread : undefined,
+      // The bell half of the ambient critical surface: while something critical
+      // is unread the badge stops being the brand accent (see
+      // CriticalNotificationStrip.css).
+      toneClassName: criticalNotifications.count > 0 ? 'has-critical' : undefined,
       onClick: toggleNotificationsPanel,
     },
     {
@@ -3528,6 +3547,7 @@ function AppContent({
     openBoardSurface,
     notificationsPanelOpen,
     notificationsUnread,
+    criticalNotifications,
     automationsPanelOpen,
     toggleNotificationsPanel,
   ]);
@@ -3746,6 +3766,8 @@ function AppContent({
           tileContents={tileContents}
           collapsed={sidebarCollapsed}
           headerActions={sidebarHeaderActions}
+          criticalNotifications={criticalNotifications}
+          onOpenNotifications={openNotificationsPanel}
           gridLayout={gridLayout}
           onSelectGridLayout={handleSelectGridLayout}
           dockItems={dockItems}

--- a/app/src/App.worktreeCleanup.test.tsx
+++ b/app/src/App.worktreeCleanup.test.tsx
@@ -344,7 +344,7 @@ describe('worktree cleanup prompt', () => {
       getPresentations: vi.fn(async () => []),
       connectionError: null,
       hasReceivedInitialState: true,
-      sendNotificationList: vi.fn(async () => ({ notifications: [], unreadCount: 0 })),
+      sendNotificationList: vi.fn(async () => ({ notifications: [], unreadCount: 0, critical: { count: 0, title: '' } })),
       sendNotificationMarkRead: vi.fn(async () => 0),
       rateLimit: null,
       warnings: [],

--- a/app/src/components/CriticalNotificationStrip.ambient.test.tsx
+++ b/app/src/components/CriticalNotificationStrip.ambient.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { CriticalNotificationStrip } from './CriticalNotificationStrip';
+
+// The ambient critical surface exists to be impossible to miss while something
+// critical is unread, and to be gone the moment nothing is. Both halves matter:
+// a surface that lingers after the user has dealt with everything trains them to
+// ignore it, which is the same defect as never showing it.
+describe('CriticalNotificationStrip', () => {
+  it('renders nothing at all when no critical notification is unread', () => {
+    const { container } = render(
+      <CriticalNotificationStrip count={0} title="" onOpen={vi.fn()} />,
+    );
+    // Absent, not merely hidden: an emptied surface must not hold sidebar space.
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('appears while a critical notification is unread and names it', () => {
+    render(<CriticalNotificationStrip count={1} title="Plugin stopped" onOpen={vi.fn()} />);
+
+    expect(screen.getByRole('button')).toHaveAccessibleName(
+      '1 unread critical notification: Plugin stopped. Open notifications.',
+    );
+    expect(screen.getByText('Plugin stopped')).toBeInTheDocument();
+  });
+
+  it('shows the count only once it says more than the title does', () => {
+    const { rerender } = render(
+      <CriticalNotificationStrip count={1} title="Plugin stopped" onOpen={vi.fn()} />,
+    );
+    expect(screen.queryByText('1')).toBeNull();
+
+    rerender(<CriticalNotificationStrip count={3} title="Plugin stopped" onOpen={vi.fn()} />);
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toHaveAccessibleName(
+      '3 unread critical notifications, newest: Plugin stopped. Open notifications.',
+    );
+  });
+
+  it('unmounts when the last critical notification is read', () => {
+    const { container, rerender } = render(
+      <CriticalNotificationStrip count={2} title="App runtime parked" onOpen={vi.fn()} />,
+    );
+    expect(screen.getByText('App runtime parked')).toBeInTheDocument();
+
+    // One of the two read: still up, because one is still unread.
+    rerender(<CriticalNotificationStrip count={1} title="App runtime parked" onOpen={vi.fn()} />);
+    expect(screen.getByText('App runtime parked')).toBeInTheDocument();
+
+    // The last one read: gone.
+    rerender(<CriticalNotificationStrip count={0} title="" onOpen={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('opens the notifications panel when clicked', async () => {
+    const onOpen = vi.fn();
+    render(<CriticalNotificationStrip count={1} title="Plugin stopped" onOpen={onOpen} />);
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  // A critical notification the daemon could not name is still a critical
+  // notification; the surface must not collapse to a blank row.
+  it('falls back to a generic label when the title is empty', () => {
+    render(<CriticalNotificationStrip count={1} title="" onOpen={vi.fn()} />);
+    expect(screen.getByText('Critical notification')).toBeInTheDocument();
+  });
+});

--- a/app/src/components/CriticalNotificationStrip.css
+++ b/app/src/components/CriticalNotificationStrip.css
@@ -1,0 +1,73 @@
+/* The ambient critical surface: a strip under the sidebar header that stays up
+   while any critical notification is unread, and the bell escalation that goes
+   with it (`.sidebar-tool-btn.has-critical`, styled here so both halves of the
+   surface live in one file).
+
+   Deliberately static — no pulse, no blink, no transition on appear. attn runs
+   all day beside GPU terminals; a surface whose whole job is to persist must
+   cost nothing to keep on screen. */
+
+.critical-strip {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: calc(100% - 16px);
+  margin: 0 8px 6px;
+  padding: 7px 9px;
+  border: 1px solid color-mix(in srgb, var(--color-severity-critical) 34%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--color-severity-critical) 12%, transparent);
+  cursor: pointer;
+  text-align: left;
+}
+
+.critical-strip:hover {
+  background: color-mix(in srgb, var(--color-severity-critical) 18%, transparent);
+}
+
+.critical-strip-mark {
+  flex: none;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--color-severity-critical);
+}
+
+.critical-strip-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: color-mix(in srgb, var(--color-severity-critical) 30%, var(--color-text-primary));
+  font-size: var(--font-size-sm);
+}
+
+.critical-strip-count {
+  flex: none;
+  color: var(--color-severity-critical);
+  font: 700 10px/1 ui-monospace, monospace;
+}
+
+/* Bell escalation. The badge is the sidebar's existing unread count; while
+   something critical is unread it stops being the brand accent. */
+.sidebar-tool-btn.has-critical {
+  border-color: color-mix(in srgb, var(--color-severity-critical) 55%, transparent);
+  background: color-mix(in srgb, var(--color-severity-critical) 16%, transparent);
+  color: color-mix(in srgb, var(--color-severity-critical) 55%, var(--color-text-primary));
+}
+
+.sidebar-tool-btn.has-critical:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-severity-critical) 24%, transparent);
+  border-color: color-mix(in srgb, var(--color-severity-critical) 70%, transparent);
+}
+
+.sidebar-tool-btn.has-critical .sidebar-tool-badge {
+  background: var(--color-severity-critical);
+  color: #fff;
+  /* Two rings: the panel color first so the badge reads as lifted off the
+     sidebar, then the severity tint. */
+  box-shadow:
+    0 0 0 2px var(--color-bg-panel),
+    0 0 0 4px color-mix(in srgb, var(--color-severity-critical) 40%, transparent);
+}

--- a/app/src/components/CriticalNotificationStrip.tsx
+++ b/app/src/components/CriticalNotificationStrip.tsx
@@ -1,0 +1,49 @@
+// app/src/components/CriticalNotificationStrip.tsx
+//
+// The ambient half of notification severity: while at least one critical
+// notification is unread, a strip sits under the sidebar header naming the
+// newest one, and the notifications bell escalates to match (see
+// `.sidebar-tool-btn.has-critical` in this component's stylesheet, applied by
+// Sidebar from the same count).
+//
+// It renders nothing at all when the count is zero, so "cleared" is an unmount
+// rather than a hidden element — there is no state in which an emptied surface
+// still occupies the sidebar.
+//
+// Its input comes from the daemon on both the notification_list result and the
+// notifications_updated broadcast, never derived from a fetched list: the panel
+// only lists while it is open, and a user who has never opened it must still be
+// unable to miss something critical.
+import './CriticalNotificationStrip.css';
+
+interface CriticalNotificationStripProps {
+  // How many critical notifications are unread. Zero renders nothing.
+  count: number;
+  // Title of the newest unread critical notification.
+  title: string;
+  // Opens the notifications panel.
+  onOpen: () => void;
+}
+
+export function CriticalNotificationStrip({ count, title, onOpen }: CriticalNotificationStripProps) {
+  if (count <= 0) return null;
+
+  // The count only earns its place once it says something the title does not.
+  const label = title || 'Critical notification';
+  const ariaLabel =
+    count === 1
+      ? `1 unread critical notification: ${label}. Open notifications.`
+      : `${count} unread critical notifications, newest: ${label}. Open notifications.`;
+
+  return (
+    <button type="button" className="critical-strip" onClick={onOpen} aria-label={ariaLabel}>
+      <span className="critical-strip-mark" aria-hidden="true" />
+      <span className="critical-strip-text">{label}</span>
+      {count > 1 && (
+        <span className="critical-strip-count" aria-hidden="true">
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/app/src/components/NotificationsPanel.css
+++ b/app/src/components/NotificationsPanel.css
@@ -117,10 +117,70 @@
   gap: 6px;
 }
 
+/* Severity drives one custom property per row, and everything below reads it:
+   the left spine, the unread dot, the tag. --color-severity-* are defined in
+   App.css :root — an undefined var() is a silent no-op, so they are declared
+   there rather than assumed. */
+.notification-row.sev-info {
+  --sev: var(--color-severity-info);
+}
+
+.notification-row.sev-warning {
+  --sev: var(--color-severity-warning);
+  border-color: color-mix(in srgb, var(--color-severity-warning) 22%, var(--color-border-subtle));
+}
+
+.notification-row.sev-critical {
+  --sev: var(--color-severity-critical);
+  border-color: color-mix(in srgb, var(--color-severity-critical) 32%, var(--color-border-subtle));
+  background: color-mix(in srgb, var(--color-severity-critical) 7%, var(--color-bg-elevated));
+}
+
+.notification-row.sev-critical.is-expanded {
+  background: color-mix(in srgb, var(--color-severity-critical) 10%, var(--color-bg-elevated));
+}
+
 .notification-row {
+  position: relative;
+  padding-left: 2px;
   border: 1px solid var(--color-border-subtle);
   border-radius: 9px;
   background: color-mix(in srgb, var(--color-bg-elevated) 55%, transparent);
+  overflow: hidden;
+}
+
+/* The spine. A read row keeps it, dimmed: severity is a property of the event,
+   not of whether the user has seen it. */
+.notification-row::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--sev, transparent);
+}
+
+.notification-row:not(.is-unread)::before {
+  opacity: 0.35;
+}
+
+.notification-sev-tag {
+  flex: none;
+  padding: 2px 5px;
+  border-radius: 4px;
+  color: var(--sev);
+  background: color-mix(in srgb, var(--sev) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--sev) 30%, transparent);
+  font: 700 9px/1 ui-monospace, monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* info is the mundane case and carries no tag — a feed where every row shouts
+   is a feed nobody reads. */
+.notification-row.sev-info .notification-sev-tag {
+  display: none;
 }
 
 .notification-row.is-expanded {
@@ -149,7 +209,7 @@
 }
 
 .notification-row.is-unread .notification-dot {
-  background: var(--accent, #4c9aff);
+  background: var(--sev, var(--accent, #4c9aff));
 }
 
 .notification-row-title {

--- a/app/src/components/NotificationsPanel.severity.test.tsx
+++ b/app/src/components/NotificationsPanel.severity.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { NotificationsPanel } from './NotificationsPanel';
+import type { DaemonNotification } from '../hooks/useDaemonSocket';
+import { NotificationSeverity } from '../types/generated';
+
+function notification(over: Partial<DaemonNotification>): DaemonNotification {
+  return {
+    id: 'n1',
+    kind: 'task_failed',
+    severity: NotificationSeverity.Info,
+    title: 'Something happened',
+    body: 'body',
+    detail: '',
+    source_kind: '',
+    source_id: '',
+    created_at: new Date().toISOString(),
+    read_at: '',
+    ...over,
+  } as DaemonNotification;
+}
+
+function renderPanel(notifications: DaemonNotification[]) {
+  const listNotifications = vi.fn().mockResolvedValue({
+    notifications,
+    unreadCount: notifications.filter((n) => !n.read_at).length,
+    critical: { count: 0, title: '' },
+  });
+  render(
+    <NotificationsPanel
+      open
+      onClose={vi.fn()}
+      listNotifications={listNotifications}
+      markRead={vi.fn().mockResolvedValue(0)}
+      retryTask={vi.fn().mockResolvedValue(null)}
+      changeSignal={0}
+    />,
+  );
+  return { listNotifications };
+}
+
+function rowFor(title: string): HTMLElement {
+  const row = screen.getByText(title).closest('li');
+  if (!row) throw new Error(`no row for ${title}`);
+  return row;
+}
+
+// Severity is what the panel styles each row by, so the class that carries it
+// has to be on the row for every value — including one the daemon may send that
+// this build does not know, which must land somewhere rather than nowhere.
+describe('NotificationsPanel severity', () => {
+  it('styles each row by its severity', async () => {
+    renderPanel([
+      notification({ id: 'a', severity: NotificationSeverity.Critical, title: 'Plugin stopped' }),
+      notification({ id: 'b', severity: NotificationSeverity.Warning, title: 'Ticket reconciliation failed' }),
+      notification({ id: 'c', severity: NotificationSeverity.Info, title: 'Compaction finished' }),
+    ]);
+
+    await waitFor(() => expect(screen.getByText('Plugin stopped')).toBeInTheDocument());
+
+    expect(rowFor('Plugin stopped')).toHaveClass('sev-critical');
+    expect(rowFor('Ticket reconciliation failed')).toHaveClass('sev-warning');
+    expect(rowFor('Compaction finished')).toHaveClass('sev-info');
+  });
+
+  it('treats an unrecognized severity as info rather than leaving a row unstyled', async () => {
+    renderPanel([
+      notification({ id: 'a', severity: 'catastrophic' as DaemonNotification['severity'], title: 'From the future' }),
+    ]);
+
+    await waitFor(() => expect(screen.getByText('From the future')).toBeInTheDocument());
+
+    expect(rowFor('From the future')).toHaveClass('sev-info');
+  });
+
+  it('keeps severity on a row after it is read', async () => {
+    renderPanel([
+      notification({
+        id: 'a',
+        severity: NotificationSeverity.Critical,
+        title: 'Plugin stopped',
+        read_at: new Date().toISOString(),
+      }),
+    ]);
+
+    await waitFor(() => expect(screen.getByText('Plugin stopped')).toBeInTheDocument());
+
+    const row = rowFor('Plugin stopped');
+    // Severity describes the event, not whether the user has seen it.
+    expect(row).toHaveClass('sev-critical');
+    expect(row).not.toHaveClass('is-unread');
+  });
+});

--- a/app/src/components/NotificationsPanel.tsx
+++ b/app/src/components/NotificationsPanel.tsx
@@ -25,6 +25,21 @@ interface NotificationsPanelProps {
   changeSignal: number;
 }
 
+// severityClass maps a notification's severity onto its row modifier, treating
+// anything unrecognized as info. The daemon normalizes too; this is the client
+// half of the same closed set, so a daemon a version ahead cannot render a row
+// with no styling at all.
+function severityClass(severity: string | undefined): string {
+  switch (severity) {
+    case 'critical':
+      return 'sev-critical';
+    case 'warning':
+      return 'sev-warning';
+    default:
+      return 'sev-info';
+  }
+}
+
 // formatCreatedAt renders an RFC3339 created_at as a short relative phrase
 // ("now", "5m ago", "3h ago", "2d ago"). Returns '' for an unparseable value.
 function formatCreatedAt(iso: string): string {
@@ -175,11 +190,12 @@ export function NotificationsPanel({
                 return (
                   <li
                     key={n.id}
-                    className={`notification-row${unread ? ' is-unread' : ''}${expanded ? ' is-expanded' : ''}`}
+                    className={`notification-row ${severityClass(n.severity)}${unread ? ' is-unread' : ''}${expanded ? ' is-expanded' : ''}`}
                   >
                     <button type="button" className="notification-row-head" onClick={() => handleToggle(n)}>
                       <span className="notification-dot" aria-hidden="true" />
                       <span className="notification-row-title">{n.title}</span>
+                      <span className="notification-sev-tag">{n.severity}</span>
                       <span className="notification-row-time">{formatCreatedAt(n.created_at)}</span>
                     </button>
                     {expanded ? (

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -11,6 +11,8 @@ import { StateIndicator } from './StateIndicator';
 import { SessionLabel } from './SessionLabel';
 import { QueueBands, QueueSnoozedSection } from './QueueBands';
 import { SidebarNudgeBar, deriveNudgeMode } from './NudgeIndicator';
+import { CriticalNotificationStrip } from './CriticalNotificationStrip';
+import type { CriticalNotificationState } from '../hooks/useDaemonSocket';
 import { SidebarSettlingBar } from './SettlingIndicator';
 import { formatShortcut } from '../shortcuts/formatShortcut';
 import { isAttentionSessionState, type UISessionState } from '../types/sessionState';
@@ -130,6 +132,10 @@ interface SidebarProps {
   tileContents?: Record<string, TileContentState>;
   collapsed: boolean;
   headerActions: SidebarHeaderAction[];
+  // The ambient critical-notification surface. Optional so existing Sidebar
+  // tests render without wiring it; absent or zero-count renders nothing.
+  criticalNotifications?: CriticalNotificationState;
+  onOpenNotifications?: () => void;
   // Current grid shape + a handler to choose a new one (also opens grid mode).
   // Optional so existing Sidebar tests render without wiring the grid picker.
   gridLayout?: GridLayout;
@@ -348,6 +354,8 @@ export function Sidebar({
   tileContents = {},
   collapsed,
   headerActions,
+  criticalNotifications,
+  onOpenNotifications,
   gridLayout,
   onSelectGridLayout,
   dockItems = [],
@@ -991,6 +999,16 @@ export function Sidebar({
           </div>
         </div>
       </div>
+
+      {/* Above Home, because it outranks it: Home is where you go when nothing
+          is owed, and this only exists when something is. */}
+      {onOpenNotifications && (
+        <CriticalNotificationStrip
+          count={criticalNotifications?.count ?? 0}
+          title={criticalNotifications?.title ?? ''}
+          onOpen={onOpenNotifications}
+        />
+      )}
 
       {/* Home sits above everything, the chief's slot included: it is the one
           row that is not an agent, and it is where the queue leaves you once

--- a/app/src/hooks/useDaemonSocket.criticalNotifications.test.tsx
+++ b/app/src/hooks/useDaemonSocket.criticalNotifications.test.tsx
@@ -1,0 +1,144 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { isTauri } from '@tauri-apps/api/core';
+import { PROTOCOL_VERSION, useDaemonSocket } from './useDaemonSocket';
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+
+  readonly url: string;
+  readyState = FakeWebSocket.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  sent: string[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+    queueMicrotask(() => {
+      this.readyState = FakeWebSocket.OPEN;
+      this.onopen?.(new Event('open'));
+    });
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.(new CloseEvent('close'));
+  }
+
+  emit(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+}
+
+async function waitForOpenSocket(): Promise<FakeWebSocket> {
+  await waitFor(() => {
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(0);
+  });
+  const ws = FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+  await waitFor(() => {
+    expect(ws.readyState).toBe(FakeWebSocket.OPEN);
+  });
+  return ws;
+}
+
+// The ambient critical surface is driven by the broadcast, not by a listed feed,
+// because the panel only lists while it is open. So what the broadcast carries is
+// the whole contract: get it wrong and a user who never opens the panel never
+// learns that something critical is unread.
+describe('useDaemonSocket critical notifications', () => {
+  let originalWebSocket: typeof WebSocket;
+
+  beforeEach(() => {
+    originalWebSocket = globalThis.WebSocket;
+    FakeWebSocket.instances = [];
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+    vi.mocked(isTauri).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket;
+    vi.clearAllMocks();
+  });
+
+  async function renderWithBroadcast() {
+    const onNotificationsUpdated = vi.fn();
+    renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate: vi.fn(),
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        onNotificationsUpdated,
+        wsUrl: 'ws://localhost:9999/ws',
+      }),
+    );
+    const ws = await waitForOpenSocket();
+    act(() => {
+      ws.emit({
+        event: 'initial_state',
+        protocol_version: PROTOCOL_VERSION,
+        sessions: [],
+        workspaces: [],
+        prs: [],
+        repos: [],
+        authors: [],
+        settings: {},
+      });
+    });
+    return { ws, onNotificationsUpdated };
+  }
+
+  it('carries the critical count and title off the broadcast', async () => {
+    const { ws, onNotificationsUpdated } = await renderWithBroadcast();
+
+    act(() => {
+      ws.emit({
+        event: 'notifications_updated',
+        unread_count: 4,
+        unread_critical_count: 2,
+        critical_title: 'Plugin stopped',
+      });
+    });
+
+    expect(onNotificationsUpdated).toHaveBeenCalledWith(4, { count: 2, title: 'Plugin stopped' });
+  });
+
+  it('reports the surface cleared when the last critical one is read', async () => {
+    const { ws, onNotificationsUpdated } = await renderWithBroadcast();
+
+    act(() => {
+      ws.emit({
+        event: 'notifications_updated',
+        unread_count: 1,
+        unread_critical_count: 0,
+      });
+    });
+
+    expect(onNotificationsUpdated).toHaveBeenCalledWith(1, { count: 0, title: '' });
+  });
+
+  // A daemon older than the app sends neither field. That must read as "nothing
+  // critical" — the surface staying down is the safe failure, and inventing a
+  // count from a missing field would put up a banner nothing can clear.
+  it('treats a broadcast without the severity fields as nothing critical', async () => {
+    const { ws, onNotificationsUpdated } = await renderWithBroadcast();
+
+    act(() => {
+      ws.emit({ event: 'notifications_updated', unread_count: 3 });
+    });
+
+    expect(onNotificationsUpdated).toHaveBeenCalledWith(3, { count: 0, title: '' });
+  });
+});

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -225,7 +225,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '222';
+export const PROTOCOL_VERSION = '223';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -456,6 +456,24 @@ export interface NotebookReadResult {
 export type Task = GeneratedTask;
 export type DaemonNotification = GeneratedNotification;
 
+// The ambient critical surface's whole input: how many critical notifications
+// are unread and what the newest one is called. The daemon computes both in one
+// read and sends them on both the list result and the notifications_updated
+// broadcast, so the surface never has to derive them from a list it may not have
+// fetched — a panel the user never opened must not be why they miss something.
+export interface CriticalNotificationState {
+  count: number;
+  title: string;
+}
+
+// readCriticalState pulls the pair off any message that carries it, defaulting
+// to "nothing critical" for a daemon that predates the fields.
+function readCriticalState(data: Record<string, unknown>): CriticalNotificationState {
+  const count = typeof data.unread_critical_count === 'number' ? data.unread_critical_count : 0;
+  const title = typeof data.critical_title === 'string' ? data.critical_title : '';
+  return { count, title };
+}
+
 // The outcome of a Notebook hash-CAS save. conflict=true means the note changed
 // on disk since the editor loaded it, so the write did NOT apply; currentHash is
 // the hash now on disk, for the editor to reconcile against. Mirrors the daemon's
@@ -571,7 +589,7 @@ interface UseDaemonSocketOptions {
   // Fired when the global notifications feed changes (a notification is added or
   // one/all are marked read). Carries the authoritative post-change unread count
   // so the sidebar badge updates without a re-list; an open panel re-lists.
-  onNotificationsUpdated?: (unreadCount: number) => void;
+  onNotificationsUpdated?: (unreadCount: number, critical: CriticalNotificationState) => void;
   // Fired when files under the root change (any client/agent/external write). paths
   // are root-relative; origin is agent|ui|external. Mirrors onNotebookChanged for
   // the generic filesystem surface (fs_changed).
@@ -1761,6 +1779,7 @@ export function useDaemonSocket({
             // immediately; an open notifications panel re-lists for the new row.
             callbacksRef.current.onNotificationsUpdated?.(
               typeof data.unread_count === 'number' ? data.unread_count : 0,
+              readCriticalState(data),
             );
             break;
 
@@ -1938,6 +1957,7 @@ export function useDaemonSocket({
               pending.resolve({
                 notifications: (data.notifications || []) as DaemonNotification[],
                 unreadCount: typeof data.unread_count === 'number' ? data.unread_count : 0,
+                critical: readCriticalState(data),
               });
             } else {
               pending.reject(new Error(data.error || 'Notification list failed'));
@@ -4613,12 +4633,14 @@ export function useDaemonSocket({
   const sendNotificationList = useCallback((): Promise<{
     notifications: DaemonNotification[];
     unreadCount: number;
+    critical: CriticalNotificationState;
   }> => {
     const requestId = nextRequestID('notification_list');
     const key = `notification_list:${requestId}`;
     return sendKeyedRequest<{
     notifications: DaemonNotification[];
     unreadCount: number;
+    critical: CriticalNotificationState;
   }>(key, { cmd: 'notification_list', request_id: requestId }, 'Notification list timed out');
   }, [nextRequestID, sendKeyedRequest]);
 

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -5267,6 +5267,7 @@ export interface SetSessionResumeIDMessage {
     cmd:               SetSessionResumeIDMessageCmd;
     id:                string;
     resume_session_id: string;
+    transcript_path?:  string;
     [property: string]: any;
 }
 
@@ -13449,6 +13450,7 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("SetSessionResumeIDMessageCmd") },
         { json: "id", js: "id", typ: "" },
         { json: "resume_session_id", js: "resume_session_id", typ: "" },
+        { json: "transcript_path", js: "transcript_path", typ: u(undefined, "") },
     ], "any"),
     "SetSettingMessage": o([
         { json: "cmd", js: "cmd", typ: r("SetSettingMessageCmd") },

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, DocUndefineMessage, DocUndefineResult, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const activityStatusMessage = Convert.toActivityStatusMessage(json);
 //   const activityStatusResult = Convert.toActivityStatusResult(json);
@@ -27,21 +27,21 @@
 //   const automationCleanupResultMessage = Convert.toAutomationCleanupResultMessage(json);
 //   const automationDefinitionGetMessage = Convert.toAutomationDefinitionGetMessage(json);
 //   const automationDefinitionResultMessage = Convert.toAutomationDefinitionResultMessage(json);
+//   const automationDefinitionSummary = Convert.toAutomationDefinitionSummary(json);
 //   const automationDefinitionsGetMessage = Convert.toAutomationDefinitionsGetMessage(json);
 //   const automationDefinitionsResultMessage = Convert.toAutomationDefinitionsResultMessage(json);
-//   const automationDefinitionSummary = Convert.toAutomationDefinitionSummary(json);
 //   const automationDeleteMessage = Convert.toAutomationDeleteMessage(json);
 //   const automationDeleteResultMessage = Convert.toAutomationDeleteResultMessage(json);
 //   const automationRunMessage = Convert.toAutomationRunMessage(json);
 //   const automationRunResultMessage = Convert.toAutomationRunResultMessage(json);
+//   const automationRunSummary = Convert.toAutomationRunSummary(json);
 //   const automationRunsGetMessage = Convert.toAutomationRunsGetMessage(json);
 //   const automationRunsResultMessage = Convert.toAutomationRunsResultMessage(json);
-//   const automationRunSummary = Convert.toAutomationRunSummary(json);
-//   const automationsChangedMessage = Convert.toAutomationsChangedMessage(json);
 //   const automationSetEnabledMessage = Convert.toAutomationSetEnabledMessage(json);
 //   const automationSetEnabledResultMessage = Convert.toAutomationSetEnabledResultMessage(json);
 //   const automationValidateMessage = Convert.toAutomationValidateMessage(json);
 //   const automationValidateResultMessage = Convert.toAutomationValidateResultMessage(json);
+//   const automationsChangedMessage = Convert.toAutomationsChangedMessage(json);
 //   const bootstrapEndpointMessage = Convert.toBootstrapEndpointMessage(json);
 //   const branch = Convert.toBranch(json);
 //   const branchChangedMessage = Convert.toBranchChangedMessage(json);
@@ -94,6 +94,8 @@
 //   const docQueryResult = Convert.toDocQueryResult(json);
 //   const docSubscribeMessage = Convert.toDocSubscribeMessage(json);
 //   const docSubscribeResult = Convert.toDocSubscribeResult(json);
+//   const docUndefineMessage = Convert.toDocUndefineMessage(json);
+//   const docUndefineResult = Convert.toDocUndefineResult(json);
 //   const documentCollectionSchema = Convert.toDocumentCollectionSchema(json);
 //   const documentConflict = Convert.toDocumentConflict(json);
 //   const documentFieldSpec = Convert.toDocumentFieldSpec(json);
@@ -101,8 +103,6 @@
 //   const documentQuery = Convert.toDocumentQuery(json);
 //   const documentRevision = Convert.toDocumentRevision(json);
 //   const documentSort = Convert.toDocumentSort(json);
-//   const docUndefineMessage = Convert.toDocUndefineMessage(json);
-//   const docUndefineResult = Convert.toDocUndefineResult(json);
 //   const endpointActionResultMessage = Convert.toEndpointActionResultMessage(json);
 //   const endpointCapabilities = Convert.toEndpointCapabilities(json);
 //   const endpointInfo = Convert.toEndpointInfo(json);
@@ -236,6 +236,11 @@
 //   const openBrowserMessage = Convert.toOpenBrowserMessage(json);
 //   const openMarkdownMessage = Convert.toOpenMarkdownMessage(json);
 //   const openMarkdownResultMessage = Convert.toOpenMarkdownResultMessage(json);
+//   const pR = Convert.toPR(json);
+//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
+//   const pRRole = Convert.toPRRole(json);
+//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
+//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
 //   const pastConversation = Convert.toPastConversation(json);
 //   const pastConversationsResultMessage = Convert.toPastConversationsResultMessage(json);
 //   const pathInspection = Convert.toPathInspection(json);
@@ -245,14 +250,7 @@
 //   const pluginInfo = Convert.toPluginInfo(json);
 //   const pluginIssue = Convert.toPluginIssue(json);
 //   const pluginsUpdatedMessage = Convert.toPluginsUpdatedMessage(json);
-//   const pR = Convert.toPR(json);
-//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
 //   const presentAnnotation = Convert.toPresentAnnotation(json);
-//   const presentation = Convert.toPresentation(json);
-//   const presentationAddedMessage = Convert.toPresentationAddedMessage(json);
-//   const presentationComment = Convert.toPresentationComment(json);
-//   const presentationRound = Convert.toPresentationRound(json);
-//   const presentationUpdatedMessage = Convert.toPresentationUpdatedMessage(json);
 //   const presentCloseMessage = Convert.toPresentCloseMessage(json);
 //   const presentCloseResultMessage = Convert.toPresentCloseResultMessage(json);
 //   const presentCommentInput = Convert.toPresentCommentInput(json);
@@ -264,14 +262,16 @@
 //   const presentOpenResult = Convert.toPresentOpenResult(json);
 //   const presentSubmitRoundMessage = Convert.toPresentSubmitRoundMessage(json);
 //   const presentSubmitRoundResultMessage = Convert.toPresentSubmitRoundResultMessage(json);
-//   const pRRole = Convert.toPRRole(json);
-//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
-//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
+//   const presentation = Convert.toPresentation(json);
+//   const presentationAddedMessage = Convert.toPresentationAddedMessage(json);
+//   const presentationComment = Convert.toPresentationComment(json);
+//   const presentationRound = Convert.toPresentationRound(json);
+//   const presentationUpdatedMessage = Convert.toPresentationUpdatedMessage(json);
 //   const ptyDesyncMessage = Convert.toPtyDesyncMessage(json);
 //   const ptyInputMessage = Convert.toPtyInputMessage(json);
 //   const ptyOutputMessage = Convert.toPtyOutputMessage(json);
-//   const ptyResizedMessage = Convert.toPtyResizedMessage(json);
 //   const ptyResizeMessage = Convert.toPtyResizeMessage(json);
+//   const ptyResizedMessage = Convert.toPtyResizedMessage(json);
 //   const queryAuthorsMessage = Convert.toQueryAuthorsMessage(json);
 //   const queryMessage = Convert.toQueryMessage(json);
 //   const queryPRsMessage = Convert.toQueryPRsMessage(json);
@@ -319,12 +319,12 @@
 //   const sessionSelectedMessage = Convert.toSessionSelectedMessage(json);
 //   const sessionState = Convert.toSessionState(json);
 //   const sessionStateChangedMessage = Convert.toSessionStateChangedMessage(json);
-//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const sessionTodosUpdatedMessage = Convert.toSessionTodosUpdatedMessage(json);
 //   const sessionTranscriptEvent = Convert.toSessionTranscriptEvent(json);
 //   const sessionTranscriptMessage = Convert.toSessionTranscriptMessage(json);
 //   const sessionTranscriptResult = Convert.toSessionTranscriptResult(json);
 //   const sessionUnregisteredMessage = Convert.toSessionUnregisteredMessage(json);
+//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const setChiefOfStaffMessage = Convert.toSetChiefOfStaffMessage(json);
 //   const setClientPresenceMessage = Convert.toSetClientPresenceMessage(json);
 //   const setEndpointRemoteWebMessage = Convert.toSetEndpointRemoteWebMessage(json);
@@ -334,9 +334,9 @@
 //   const setSettingMessage = Convert.toSetSettingMessage(json);
 //   const setTerminalThemeMessage = Convert.toSetTerminalThemeMessage(json);
 //   const setTicketStatusMessage = Convert.toSetTicketStatusMessage(json);
+//   const setWorkspaceRankMessage = Convert.toSetWorkspaceRankMessage(json);
 //   const settingsUpdatedMessage = Convert.toSettingsUpdatedMessage(json);
 //   const settleTurnMessage = Convert.toSettleTurnMessage(json);
-//   const setWorkspaceRankMessage = Convert.toSetWorkspaceRankMessage(json);
 //   const snoozeTurnMessage = Convert.toSnoozeTurnMessage(json);
 //   const spawnResultMessage = Convert.toSpawnResultMessage(json);
 //   const spawnSessionMessage = Convert.toSpawnSessionMessage(json);
@@ -387,11 +387,11 @@
 //   const ticketStatusResult = Convert.toTicketStatusResult(json);
 //   const ticketSubscribeMessage = Convert.toTicketSubscribeMessage(json);
 //   const ticketSubscribeResult = Convert.toTicketSubscribeResult(json);
-//   const ticketsUpdatedMessage = Convert.toTicketsUpdatedMessage(json);
 //   const ticketTakeMessage = Convert.toTicketTakeMessage(json);
 //   const ticketTakeResult = Convert.toTicketTakeResult(json);
 //   const ticketUnsubscribeMessage = Convert.toTicketUnsubscribeMessage(json);
 //   const ticketUnsubscribeResult = Convert.toTicketUnsubscribeResult(json);
+//   const ticketsUpdatedMessage = Convert.toTicketsUpdatedMessage(json);
 //   const todosMessage = Convert.toTodosMessage(json);
 //   const triggerNudgeMessage = Convert.toTriggerNudgeMessage(json);
 //   const uninstallPluginMessage = Convert.toUninstallPluginMessage(json);
@@ -445,8 +445,8 @@
 //   const workspaceLayoutSetSplitRatioMessage = Convert.toWorkspaceLayoutSetSplitRatioMessage(json);
 //   const workspaceLayoutSplitDirection = Convert.toWorkspaceLayoutSplitDirection(json);
 //   const workspaceLayoutUndockTileMessage = Convert.toWorkspaceLayoutUndockTileMessage(json);
-//   const workspaceLayoutUpdatedMessage = Convert.toWorkspaceLayoutUpdatedMessage(json);
 //   const workspaceLayoutUpdateTileMessage = Convert.toWorkspaceLayoutUpdateTileMessage(json);
+//   const workspaceLayoutUpdatedMessage = Convert.toWorkspaceLayoutUpdatedMessage(json);
 //   const workspaceRegisteredMessage = Convert.toWorkspaceRegisteredMessage(json);
 //   const workspaceSelectedMessage = Convert.toWorkspaceSelectedMessage(json);
 //   const workspaceStateChangedMessage = Convert.toWorkspaceStateChangedMessage(json);
@@ -834,6 +834,19 @@ export enum AutomationDefinitionResultMessageEvent {
     AutomationDefinitionResult = "automation_definition_result",
 }
 
+export interface AutomationDefinitionSummary {
+    enabled:             boolean;
+    id:                  string;
+    last_run?:           LastRun;
+    name:                string;
+    revision:            number;
+    schedule_cron?:      string;
+    schedule_time_zone?: string;
+    trigger_type:        string;
+    updated_at:          string;
+    [property: string]: any;
+}
+
 export interface AutomationDefinitionsGetMessage {
     cmd:         AutomationDefinitionsGetMessageCmd;
     request_id?: string;
@@ -855,19 +868,6 @@ export interface AutomationDefinitionsResultMessage {
 
 export enum AutomationDefinitionsResultMessageEvent {
     AutomationDefinitionsResult = "automation_definitions_result",
-}
-
-export interface AutomationDefinitionSummary {
-    enabled:             boolean;
-    id:                  string;
-    last_run?:           LastRun;
-    name:                string;
-    revision:            number;
-    schedule_cron?:      string;
-    schedule_time_zone?: string;
-    trigger_type:        string;
-    updated_at:          string;
-    [property: string]: any;
 }
 
 export interface AutomationDeleteMessage {
@@ -919,6 +919,22 @@ export enum AutomationRunResultMessageEvent {
     AutomationRunResult = "automation_run_result",
 }
 
+export interface AutomationRunSummary {
+    cancel_reason?:  string;
+    created_at:      string;
+    definition_id:   string;
+    delivered_at?:   string;
+    id:              string;
+    last_error?:     string;
+    occurrence_key?: string;
+    pane_id?:        string;
+    session_id?:     string;
+    state:           string;
+    ticket_id?:      string;
+    updated_at:      string;
+    [property: string]: any;
+}
+
 export interface AutomationRunsGetMessage {
     cmd:           AutomationRunsGetMessageCmd;
     definition_id: string;
@@ -943,32 +959,6 @@ export interface AutomationRunsResultMessage {
 
 export enum AutomationRunsResultMessageEvent {
     AutomationRunsResult = "automation_runs_result",
-}
-
-export interface AutomationRunSummary {
-    cancel_reason?:  string;
-    created_at:      string;
-    definition_id:   string;
-    delivered_at?:   string;
-    id:              string;
-    last_error?:     string;
-    occurrence_key?: string;
-    pane_id?:        string;
-    session_id?:     string;
-    state:           string;
-    ticket_id?:      string;
-    updated_at:      string;
-    [property: string]: any;
-}
-
-export interface AutomationsChangedMessage {
-    definition_ids: string[];
-    event:          AutomationsChangedMessageEvent;
-    [property: string]: any;
-}
-
-export enum AutomationsChangedMessageEvent {
-    AutomationsChanged = "automations_changed",
 }
 
 export interface AutomationSetEnabledMessage {
@@ -1017,6 +1007,16 @@ export interface AutomationValidateResultMessage {
 
 export enum AutomationValidateResultMessageEvent {
     AutomationValidateResult = "automation_validate_result",
+}
+
+export interface AutomationsChangedMessage {
+    definition_ids: string[];
+    event:          AutomationsChangedMessageEvent;
+    [property: string]: any;
+}
+
+export enum AutomationsChangedMessageEvent {
+    AutomationsChanged = "automations_changed",
 }
 
 export interface BootstrapEndpointMessage {
@@ -1733,6 +1733,24 @@ export interface DocSubscribeResult {
     [property: string]: any;
 }
 
+export interface DocUndefineMessage {
+    cmd:        DocUndefineMessageCmd;
+    collection: string;
+    namespace:  string;
+    [property: string]: any;
+}
+
+export enum DocUndefineMessageCmd {
+    DocUndefine = "doc_undefine",
+}
+
+export interface DocUndefineResult {
+    collection:        string;
+    documents_removed: number;
+    namespace:         string;
+    [property: string]: any;
+}
+
 export interface DocumentCollectionSchema {
     collection: string;
     fields:     FieldElement[];
@@ -1782,24 +1800,6 @@ export interface DocumentRevision {
 export interface DocumentSort {
     desc?: boolean;
     field: string;
-    [property: string]: any;
-}
-
-export interface DocUndefineMessage {
-    cmd:        DocUndefineMessageCmd;
-    collection: string;
-    namespace:  string;
-    [property: string]: any;
-}
-
-export enum DocUndefineMessageCmd {
-    DocUndefine = "doc_undefine",
-}
-
-export interface DocUndefineResult {
-    collection:        string;
-    documents_removed: number;
-    namespace:         string;
     [property: string]: any;
 }
 
@@ -2508,7 +2508,7 @@ export interface PresentationElement {
 
 export interface Round {
     base_sha:        string;
-    changed_files?:  ChangedFileElement[];
+    changed_files?:  FileElement[];
     created_at:      string;
     head_sha:        string;
     id:              string;
@@ -2520,7 +2520,7 @@ export interface Round {
     [property: string]: any;
 }
 
-export interface ChangedFileElement {
+export interface FileElement {
     additions?:   number;
     annotations?: AnnotationElement[];
     deletions?:   number;
@@ -2537,7 +2537,7 @@ export interface AnnotationElement {
 }
 
 export interface Manifest {
-    files:    ChangedFileElement[];
+    files:    FileElement[];
     skip:     string[];
     summary?: string;
     title:    string;
@@ -3746,6 +3746,69 @@ export enum OpenMarkdownResultMessageEvent {
     OpenMarkdownResult = "open_markdown_result",
 }
 
+export interface PR {
+    approved_by_me:         boolean;
+    author:                 string;
+    ci_status?:             string;
+    comment_count?:         number;
+    details_fetched:        boolean;
+    details_fetched_at?:    string;
+    has_new_changes:        boolean;
+    head_branch?:           string;
+    head_sha?:              string;
+    heat_state?:            HeatState;
+    host:                   string;
+    id:                     string;
+    last_heat_activity_at?: string;
+    last_polled:            string;
+    last_updated:           string;
+    mergeable?:             boolean;
+    mergeable_state?:       string;
+    muted:                  boolean;
+    number:                 number;
+    reason:                 string;
+    repo:                   string;
+    review_status?:         string;
+    role:                   PRRole;
+    state:                  string;
+    title:                  string;
+    url:                    string;
+    [property: string]: any;
+}
+
+export interface PRActionResultMessage {
+    action:  string;
+    error?:  string;
+    event:   PRActionResultMessageEvent;
+    id:      string;
+    success: boolean;
+    [property: string]: any;
+}
+
+export enum PRActionResultMessageEvent {
+    PRActionResult = "pr_action_result",
+}
+
+export interface PRVisitedMessage {
+    cmd: PRVisitedMessageCmd;
+    id:  string;
+    [property: string]: any;
+}
+
+export enum PRVisitedMessageCmd {
+    PRVisited = "pr_visited",
+}
+
+export interface PRsUpdatedMessage {
+    event: PRsUpdatedMessageEvent;
+    prs?:  PRElement[];
+    [property: string]: any;
+}
+
+export enum PRsUpdatedMessageEvent {
+    PrsUpdated = "prs_updated",
+}
+
 export interface PastConversation {
     bytes:      number;
     cwd:        string;
@@ -3896,115 +3959,11 @@ export interface PluginElement {
     [property: string]: any;
 }
 
-export interface PR {
-    approved_by_me:         boolean;
-    author:                 string;
-    ci_status?:             string;
-    comment_count?:         number;
-    details_fetched:        boolean;
-    details_fetched_at?:    string;
-    has_new_changes:        boolean;
-    head_branch?:           string;
-    head_sha?:              string;
-    heat_state?:            HeatState;
-    host:                   string;
-    id:                     string;
-    last_heat_activity_at?: string;
-    last_polled:            string;
-    last_updated:           string;
-    mergeable?:             boolean;
-    mergeable_state?:       string;
-    muted:                  boolean;
-    number:                 number;
-    reason:                 string;
-    repo:                   string;
-    review_status?:         string;
-    role:                   PRRole;
-    state:                  string;
-    title:                  string;
-    url:                    string;
-    [property: string]: any;
-}
-
-export interface PRActionResultMessage {
-    action:  string;
-    error?:  string;
-    event:   PRActionResultMessageEvent;
-    id:      string;
-    success: boolean;
-    [property: string]: any;
-}
-
-export enum PRActionResultMessageEvent {
-    PRActionResult = "pr_action_result",
-}
-
 export interface PresentAnnotation {
     comments:   string[];
     line_end:   number;
     line_start: number;
     [property: string]: any;
-}
-
-export interface Presentation {
-    created_at:             string;
-    id:                     string;
-    kind:                   string;
-    latest_round_seq:       number;
-    latest_round_submitted: boolean;
-    repo_path:              string;
-    session_id:             string;
-    status:                 string;
-    ticket_id?:             string;
-    title:                  string;
-    [property: string]: any;
-}
-
-export interface PresentationAddedMessage {
-    event:        PresentationAddedMessageEvent;
-    presentation: PresentationElement;
-    [property: string]: any;
-}
-
-export enum PresentationAddedMessageEvent {
-    PresentationAdded = "presentation_added",
-}
-
-export interface PresentationComment {
-    author:     string;
-    content:    string;
-    created_at: string;
-    filepath:   string;
-    id:         string;
-    line_end:   number;
-    line_start: number;
-    round_id:   string;
-    side:       string;
-    [property: string]: any;
-}
-
-export interface PresentationRound {
-    base_sha:        string;
-    changed_files?:  ChangedFileElement[];
-    created_at:      string;
-    head_sha:        string;
-    id:              string;
-    manifest:        Manifest;
-    presentation_id: string;
-    seq:             number;
-    submitted_at?:   string;
-    verdict?:        string;
-    [property: string]: any;
-}
-
-export interface PresentationUpdatedMessage {
-    event:        PresentationUpdatedMessageEvent;
-    presentation: PresentationElement;
-    [property: string]: any;
-}
-
-export enum PresentationUpdatedMessageEvent {
-    PresentationUpdated = "presentation_updated",
 }
 
 export interface PresentCloseMessage {
@@ -4068,7 +4027,7 @@ export interface PresentFile {
 }
 
 export interface PresentManifestView {
-    files:    ChangedFileElement[];
+    files:    FileElement[];
     skip:     string[];
     summary?: string;
     title:    string;
@@ -4133,24 +4092,65 @@ export enum PresentSubmitRoundResultMessageEvent {
     PresentSubmitRoundResult = "present_submit_round_result",
 }
 
-export interface PRsUpdatedMessage {
-    event: PRsUpdatedMessageEvent;
-    prs?:  PRElement[];
+export interface Presentation {
+    created_at:             string;
+    id:                     string;
+    kind:                   string;
+    latest_round_seq:       number;
+    latest_round_submitted: boolean;
+    repo_path:              string;
+    session_id:             string;
+    status:                 string;
+    ticket_id?:             string;
+    title:                  string;
     [property: string]: any;
 }
 
-export enum PRsUpdatedMessageEvent {
-    PrsUpdated = "prs_updated",
-}
-
-export interface PRVisitedMessage {
-    cmd: PRVisitedMessageCmd;
-    id:  string;
+export interface PresentationAddedMessage {
+    event:        PresentationAddedMessageEvent;
+    presentation: PresentationElement;
     [property: string]: any;
 }
 
-export enum PRVisitedMessageCmd {
-    PRVisited = "pr_visited",
+export enum PresentationAddedMessageEvent {
+    PresentationAdded = "presentation_added",
+}
+
+export interface PresentationComment {
+    author:     string;
+    content:    string;
+    created_at: string;
+    filepath:   string;
+    id:         string;
+    line_end:   number;
+    line_start: number;
+    round_id:   string;
+    side:       string;
+    [property: string]: any;
+}
+
+export interface PresentationRound {
+    base_sha:        string;
+    changed_files?:  FileElement[];
+    created_at:      string;
+    head_sha:        string;
+    id:              string;
+    manifest:        Manifest;
+    presentation_id: string;
+    seq:             number;
+    submitted_at?:   string;
+    verdict?:        string;
+    [property: string]: any;
+}
+
+export interface PresentationUpdatedMessage {
+    event:        PresentationUpdatedMessageEvent;
+    presentation: PresentationElement;
+    [property: string]: any;
+}
+
+export enum PresentationUpdatedMessageEvent {
+    PresentationUpdated = "presentation_updated",
 }
 
 export interface PtyDesyncMessage {
@@ -4188,20 +4188,6 @@ export enum PtyOutputMessageEvent {
     PtyOutput = "pty_output",
 }
 
-export interface PtyResizedMessage {
-    cols:    number;
-    event:   PtyResizedMessageEvent;
-    id:      string;
-    rows:    number;
-    xpixel?: number;
-    ypixel?: number;
-    [property: string]: any;
-}
-
-export enum PtyResizedMessageEvent {
-    PtyResized = "pty_resized",
-}
-
 export interface PtyResizeMessage {
     cmd:     PtyResizeMessageCmd;
     cols:    number;
@@ -4214,6 +4200,20 @@ export interface PtyResizeMessage {
 
 export enum PtyResizeMessageCmd {
     PtyResize = "pty_resize",
+}
+
+export interface PtyResizedMessage {
+    cols:    number;
+    event:   PtyResizedMessageEvent;
+    id:      string;
+    rows:    number;
+    xpixel?: number;
+    ypixel?: number;
+    [property: string]: any;
+}
+
+export enum PtyResizedMessageEvent {
+    PtyResized = "pty_resized",
 }
 
 export interface QueryAuthorsMessage {
@@ -4281,7 +4281,7 @@ export enum RecentFilesMessageCmd {
 export interface RecentFilesResultMessage {
     error?:     string;
     event:      RecentFilesResultMessageEvent;
-    files:      FileElement[];
+    files:      FileObject[];
     request_id: string;
     success:    boolean;
     [property: string]: any;
@@ -4291,7 +4291,7 @@ export enum RecentFilesResultMessageEvent {
     RecentFilesResult = "recent_files_result",
 }
 
-export interface FileElement {
+export interface FileObject {
     count:       number;
     last_at:     string;
     path:        string;
@@ -5146,16 +5146,6 @@ export enum SessionStateChangedMessageEvent {
     SessionStateChanged = "session_state_changed",
 }
 
-export interface SessionsUpdatedMessage {
-    event:     SessionsUpdatedMessageEvent;
-    sessions?: SessionObject[];
-    [property: string]: any;
-}
-
-export enum SessionsUpdatedMessageEvent {
-    SessionsUpdated = "sessions_updated",
-}
-
 export interface SessionTodosUpdatedMessage {
     event:   SessionTodosUpdatedMessageEvent;
     session: SessionObject;
@@ -5205,6 +5195,16 @@ export interface SessionUnregisteredMessage {
 
 export enum SessionUnregisteredMessageEvent {
     SessionUnregistered = "session_unregistered",
+}
+
+export interface SessionsUpdatedMessage {
+    event:     SessionsUpdatedMessageEvent;
+    sessions?: SessionObject[];
+    [property: string]: any;
+}
+
+export enum SessionsUpdatedMessageEvent {
+    SessionsUpdated = "sessions_updated",
 }
 
 export interface SetChiefOfStaffMessage {
@@ -5320,6 +5320,18 @@ export enum DispatchWorkState {
     ReadyForReview = "ready_for_review",
 }
 
+export interface SetWorkspaceRankMessage {
+    cmd:                SetWorkspaceRankMessageCmd;
+    next_workspace_id?: string;
+    prev_workspace_id?: string;
+    workspace_id:       string;
+    [property: string]: any;
+}
+
+export enum SetWorkspaceRankMessageCmd {
+    SetWorkspaceRank = "set_workspace_rank",
+}
+
 export interface SettingsUpdatedMessage {
     changed_key?: string;
     error?:       string;
@@ -5341,18 +5353,6 @@ export interface SettleTurnMessage {
 
 export enum SettleTurnMessageCmd {
     SettleTurn = "settle_turn",
-}
-
-export interface SetWorkspaceRankMessage {
-    cmd:                SetWorkspaceRankMessageCmd;
-    next_workspace_id?: string;
-    prev_workspace_id?: string;
-    workspace_id:       string;
-    [property: string]: any;
-}
-
-export enum SetWorkspaceRankMessageCmd {
-    SetWorkspaceRank = "set_workspace_rank",
 }
 
 export interface SnoozeTurnMessage {
@@ -5650,7 +5650,7 @@ export interface TicketAttachMessage {
     cmd:                 TicketAttachMessageCmd;
     comment?:            string;
     expected_event_seq?: number;
-    files:               FileObject[];
+    files:               TicketAttachMessageFile[];
     request_id?:         string;
     source_session_id:   string;
     state?:              DispatchWorkState;
@@ -5662,7 +5662,7 @@ export enum TicketAttachMessageCmd {
     TicketAttach = "ticket_attach",
 }
 
-export interface FileObject {
+export interface TicketAttachMessageFile {
     filename:    string;
     source_path: string;
     [property: string]: any;
@@ -5897,16 +5897,6 @@ export interface TicketSubscribeResult {
     [property: string]: any;
 }
 
-export interface TicketsUpdatedMessage {
-    event:   TicketsUpdatedMessageEvent;
-    tickets: TicketElement[];
-    [property: string]: any;
-}
-
-export enum TicketsUpdatedMessageEvent {
-    TicketsUpdated = "tickets_updated",
-}
-
 export interface TicketTakeMessage {
     cmd:               TicketTakeMessageCmd;
     confirm?:          boolean;
@@ -5940,6 +5930,16 @@ export enum TicketUnsubscribeMessageCmd {
 export interface TicketUnsubscribeResult {
     ticket_id: string;
     [property: string]: any;
+}
+
+export interface TicketsUpdatedMessage {
+    event:   TicketsUpdatedMessageEvent;
+    tickets: TicketElement[];
+    [property: string]: any;
+}
+
+export enum TicketsUpdatedMessageEvent {
+    TicketsUpdated = "tickets_updated",
 }
 
 export interface TodosMessage {
@@ -6623,16 +6623,6 @@ export enum WorkspaceLayoutUndockTileMessageCmd {
     WorkspaceLayoutUndockTile = "workspace_layout_undock_tile",
 }
 
-export interface WorkspaceLayoutUpdatedMessage {
-    event:            WorkspaceLayoutUpdatedMessageEvent;
-    workspace_layout: Layout;
-    [property: string]: any;
-}
-
-export enum WorkspaceLayoutUpdatedMessageEvent {
-    WorkspaceLayoutUpdated = "workspace_layout_updated",
-}
-
 export interface WorkspaceLayoutUpdateTileMessage {
     cmd:              WorkspaceLayoutUpdateTileMessageCmd;
     request_id:       string;
@@ -6645,6 +6635,16 @@ export interface WorkspaceLayoutUpdateTileMessage {
 
 export enum WorkspaceLayoutUpdateTileMessageCmd {
     WorkspaceLayoutUpdateTile = "workspace_layout_update_tile",
+}
+
+export interface WorkspaceLayoutUpdatedMessage {
+    event:            WorkspaceLayoutUpdatedMessageEvent;
+    workspace_layout: Layout;
+    [property: string]: any;
+}
+
+export enum WorkspaceLayoutUpdatedMessageEvent {
+    WorkspaceLayoutUpdated = "workspace_layout_updated",
 }
 
 export interface WorkspaceRegisteredMessage {
@@ -6954,6 +6954,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AutomationDefinitionResultMessage")), null, 2);
     }
 
+    public static toAutomationDefinitionSummary(json: string): AutomationDefinitionSummary {
+        return cast(JSON.parse(json), r("AutomationDefinitionSummary"));
+    }
+
+    public static automationDefinitionSummaryToJson(value: AutomationDefinitionSummary): string {
+        return JSON.stringify(uncast(value, r("AutomationDefinitionSummary")), null, 2);
+    }
+
     public static toAutomationDefinitionsGetMessage(json: string): AutomationDefinitionsGetMessage {
         return cast(JSON.parse(json), r("AutomationDefinitionsGetMessage"));
     }
@@ -6968,14 +6976,6 @@ export class Convert {
 
     public static automationDefinitionsResultMessageToJson(value: AutomationDefinitionsResultMessage): string {
         return JSON.stringify(uncast(value, r("AutomationDefinitionsResultMessage")), null, 2);
-    }
-
-    public static toAutomationDefinitionSummary(json: string): AutomationDefinitionSummary {
-        return cast(JSON.parse(json), r("AutomationDefinitionSummary"));
-    }
-
-    public static automationDefinitionSummaryToJson(value: AutomationDefinitionSummary): string {
-        return JSON.stringify(uncast(value, r("AutomationDefinitionSummary")), null, 2);
     }
 
     public static toAutomationDeleteMessage(json: string): AutomationDeleteMessage {
@@ -7010,6 +7010,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AutomationRunResultMessage")), null, 2);
     }
 
+    public static toAutomationRunSummary(json: string): AutomationRunSummary {
+        return cast(JSON.parse(json), r("AutomationRunSummary"));
+    }
+
+    public static automationRunSummaryToJson(value: AutomationRunSummary): string {
+        return JSON.stringify(uncast(value, r("AutomationRunSummary")), null, 2);
+    }
+
     public static toAutomationRunsGetMessage(json: string): AutomationRunsGetMessage {
         return cast(JSON.parse(json), r("AutomationRunsGetMessage"));
     }
@@ -7024,22 +7032,6 @@ export class Convert {
 
     public static automationRunsResultMessageToJson(value: AutomationRunsResultMessage): string {
         return JSON.stringify(uncast(value, r("AutomationRunsResultMessage")), null, 2);
-    }
-
-    public static toAutomationRunSummary(json: string): AutomationRunSummary {
-        return cast(JSON.parse(json), r("AutomationRunSummary"));
-    }
-
-    public static automationRunSummaryToJson(value: AutomationRunSummary): string {
-        return JSON.stringify(uncast(value, r("AutomationRunSummary")), null, 2);
-    }
-
-    public static toAutomationsChangedMessage(json: string): AutomationsChangedMessage {
-        return cast(JSON.parse(json), r("AutomationsChangedMessage"));
-    }
-
-    public static automationsChangedMessageToJson(value: AutomationsChangedMessage): string {
-        return JSON.stringify(uncast(value, r("AutomationsChangedMessage")), null, 2);
     }
 
     public static toAutomationSetEnabledMessage(json: string): AutomationSetEnabledMessage {
@@ -7072,6 +7064,14 @@ export class Convert {
 
     public static automationValidateResultMessageToJson(value: AutomationValidateResultMessage): string {
         return JSON.stringify(uncast(value, r("AutomationValidateResultMessage")), null, 2);
+    }
+
+    public static toAutomationsChangedMessage(json: string): AutomationsChangedMessage {
+        return cast(JSON.parse(json), r("AutomationsChangedMessage"));
+    }
+
+    public static automationsChangedMessageToJson(value: AutomationsChangedMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationsChangedMessage")), null, 2);
     }
 
     public static toBootstrapEndpointMessage(json: string): BootstrapEndpointMessage {
@@ -7490,6 +7490,22 @@ export class Convert {
         return JSON.stringify(uncast(value, r("DocSubscribeResult")), null, 2);
     }
 
+    public static toDocUndefineMessage(json: string): DocUndefineMessage {
+        return cast(JSON.parse(json), r("DocUndefineMessage"));
+    }
+
+    public static docUndefineMessageToJson(value: DocUndefineMessage): string {
+        return JSON.stringify(uncast(value, r("DocUndefineMessage")), null, 2);
+    }
+
+    public static toDocUndefineResult(json: string): DocUndefineResult {
+        return cast(JSON.parse(json), r("DocUndefineResult"));
+    }
+
+    public static docUndefineResultToJson(value: DocUndefineResult): string {
+        return JSON.stringify(uncast(value, r("DocUndefineResult")), null, 2);
+    }
+
     public static toDocumentCollectionSchema(json: string): DocumentCollectionSchema {
         return cast(JSON.parse(json), r("DocumentCollectionSchema"));
     }
@@ -7544,22 +7560,6 @@ export class Convert {
 
     public static documentSortToJson(value: DocumentSort): string {
         return JSON.stringify(uncast(value, r("DocumentSort")), null, 2);
-    }
-
-    public static toDocUndefineMessage(json: string): DocUndefineMessage {
-        return cast(JSON.parse(json), r("DocUndefineMessage"));
-    }
-
-    public static docUndefineMessageToJson(value: DocUndefineMessage): string {
-        return JSON.stringify(uncast(value, r("DocUndefineMessage")), null, 2);
-    }
-
-    public static toDocUndefineResult(json: string): DocUndefineResult {
-        return cast(JSON.parse(json), r("DocUndefineResult"));
-    }
-
-    public static docUndefineResultToJson(value: DocUndefineResult): string {
-        return JSON.stringify(uncast(value, r("DocUndefineResult")), null, 2);
     }
 
     public static toEndpointActionResultMessage(json: string): EndpointActionResultMessage {
@@ -8626,6 +8626,46 @@ export class Convert {
         return JSON.stringify(uncast(value, r("OpenMarkdownResultMessage")), null, 2);
     }
 
+    public static toPR(json: string): PR {
+        return cast(JSON.parse(json), r("PR"));
+    }
+
+    public static pRToJson(value: PR): string {
+        return JSON.stringify(uncast(value, r("PR")), null, 2);
+    }
+
+    public static toPRActionResultMessage(json: string): PRActionResultMessage {
+        return cast(JSON.parse(json), r("PRActionResultMessage"));
+    }
+
+    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
+        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
+    }
+
+    public static toPRRole(json: string): PRRole {
+        return cast(JSON.parse(json), r("PRRole"));
+    }
+
+    public static pRRoleToJson(value: PRRole): string {
+        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
+    }
+
+    public static toPRVisitedMessage(json: string): PRVisitedMessage {
+        return cast(JSON.parse(json), r("PRVisitedMessage"));
+    }
+
+    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
+        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
+    }
+
+    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
+        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
+    }
+
+    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
+    }
+
     public static toPastConversation(json: string): PastConversation {
         return cast(JSON.parse(json), r("PastConversation"));
     }
@@ -8698,68 +8738,12 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PluginsUpdatedMessage")), null, 2);
     }
 
-    public static toPR(json: string): PR {
-        return cast(JSON.parse(json), r("PR"));
-    }
-
-    public static pRToJson(value: PR): string {
-        return JSON.stringify(uncast(value, r("PR")), null, 2);
-    }
-
-    public static toPRActionResultMessage(json: string): PRActionResultMessage {
-        return cast(JSON.parse(json), r("PRActionResultMessage"));
-    }
-
-    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
-        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
-    }
-
     public static toPresentAnnotation(json: string): PresentAnnotation {
         return cast(JSON.parse(json), r("PresentAnnotation"));
     }
 
     public static presentAnnotationToJson(value: PresentAnnotation): string {
         return JSON.stringify(uncast(value, r("PresentAnnotation")), null, 2);
-    }
-
-    public static toPresentation(json: string): Presentation {
-        return cast(JSON.parse(json), r("Presentation"));
-    }
-
-    public static presentationToJson(value: Presentation): string {
-        return JSON.stringify(uncast(value, r("Presentation")), null, 2);
-    }
-
-    public static toPresentationAddedMessage(json: string): PresentationAddedMessage {
-        return cast(JSON.parse(json), r("PresentationAddedMessage"));
-    }
-
-    public static presentationAddedMessageToJson(value: PresentationAddedMessage): string {
-        return JSON.stringify(uncast(value, r("PresentationAddedMessage")), null, 2);
-    }
-
-    public static toPresentationComment(json: string): PresentationComment {
-        return cast(JSON.parse(json), r("PresentationComment"));
-    }
-
-    public static presentationCommentToJson(value: PresentationComment): string {
-        return JSON.stringify(uncast(value, r("PresentationComment")), null, 2);
-    }
-
-    public static toPresentationRound(json: string): PresentationRound {
-        return cast(JSON.parse(json), r("PresentationRound"));
-    }
-
-    public static presentationRoundToJson(value: PresentationRound): string {
-        return JSON.stringify(uncast(value, r("PresentationRound")), null, 2);
-    }
-
-    public static toPresentationUpdatedMessage(json: string): PresentationUpdatedMessage {
-        return cast(JSON.parse(json), r("PresentationUpdatedMessage"));
-    }
-
-    public static presentationUpdatedMessageToJson(value: PresentationUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("PresentationUpdatedMessage")), null, 2);
     }
 
     public static toPresentCloseMessage(json: string): PresentCloseMessage {
@@ -8850,28 +8834,44 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PresentSubmitRoundResultMessage")), null, 2);
     }
 
-    public static toPRRole(json: string): PRRole {
-        return cast(JSON.parse(json), r("PRRole"));
+    public static toPresentation(json: string): Presentation {
+        return cast(JSON.parse(json), r("Presentation"));
     }
 
-    public static pRRoleToJson(value: PRRole): string {
-        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
+    public static presentationToJson(value: Presentation): string {
+        return JSON.stringify(uncast(value, r("Presentation")), null, 2);
     }
 
-    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
-        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
+    public static toPresentationAddedMessage(json: string): PresentationAddedMessage {
+        return cast(JSON.parse(json), r("PresentationAddedMessage"));
     }
 
-    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
+    public static presentationAddedMessageToJson(value: PresentationAddedMessage): string {
+        return JSON.stringify(uncast(value, r("PresentationAddedMessage")), null, 2);
     }
 
-    public static toPRVisitedMessage(json: string): PRVisitedMessage {
-        return cast(JSON.parse(json), r("PRVisitedMessage"));
+    public static toPresentationComment(json: string): PresentationComment {
+        return cast(JSON.parse(json), r("PresentationComment"));
     }
 
-    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
-        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
+    public static presentationCommentToJson(value: PresentationComment): string {
+        return JSON.stringify(uncast(value, r("PresentationComment")), null, 2);
+    }
+
+    public static toPresentationRound(json: string): PresentationRound {
+        return cast(JSON.parse(json), r("PresentationRound"));
+    }
+
+    public static presentationRoundToJson(value: PresentationRound): string {
+        return JSON.stringify(uncast(value, r("PresentationRound")), null, 2);
+    }
+
+    public static toPresentationUpdatedMessage(json: string): PresentationUpdatedMessage {
+        return cast(JSON.parse(json), r("PresentationUpdatedMessage"));
+    }
+
+    public static presentationUpdatedMessageToJson(value: PresentationUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("PresentationUpdatedMessage")), null, 2);
     }
 
     public static toPtyDesyncMessage(json: string): PtyDesyncMessage {
@@ -8898,20 +8898,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PtyOutputMessage")), null, 2);
     }
 
-    public static toPtyResizedMessage(json: string): PtyResizedMessage {
-        return cast(JSON.parse(json), r("PtyResizedMessage"));
-    }
-
-    public static ptyResizedMessageToJson(value: PtyResizedMessage): string {
-        return JSON.stringify(uncast(value, r("PtyResizedMessage")), null, 2);
-    }
-
     public static toPtyResizeMessage(json: string): PtyResizeMessage {
         return cast(JSON.parse(json), r("PtyResizeMessage"));
     }
 
     public static ptyResizeMessageToJson(value: PtyResizeMessage): string {
         return JSON.stringify(uncast(value, r("PtyResizeMessage")), null, 2);
+    }
+
+    public static toPtyResizedMessage(json: string): PtyResizedMessage {
+        return cast(JSON.parse(json), r("PtyResizedMessage"));
+    }
+
+    public static ptyResizedMessageToJson(value: PtyResizedMessage): string {
+        return JSON.stringify(uncast(value, r("PtyResizedMessage")), null, 2);
     }
 
     public static toQueryAuthorsMessage(json: string): QueryAuthorsMessage {
@@ -9290,14 +9290,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SessionStateChangedMessage")), null, 2);
     }
 
-    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
-        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
-    }
-
-    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
-    }
-
     public static toSessionTodosUpdatedMessage(json: string): SessionTodosUpdatedMessage {
         return cast(JSON.parse(json), r("SessionTodosUpdatedMessage"));
     }
@@ -9336,6 +9328,14 @@ export class Convert {
 
     public static sessionUnregisteredMessageToJson(value: SessionUnregisteredMessage): string {
         return JSON.stringify(uncast(value, r("SessionUnregisteredMessage")), null, 2);
+    }
+
+    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
+        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
+    }
+
+    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
     }
 
     public static toSetChiefOfStaffMessage(json: string): SetChiefOfStaffMessage {
@@ -9410,6 +9410,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SetTicketStatusMessage")), null, 2);
     }
 
+    public static toSetWorkspaceRankMessage(json: string): SetWorkspaceRankMessage {
+        return cast(JSON.parse(json), r("SetWorkspaceRankMessage"));
+    }
+
+    public static setWorkspaceRankMessageToJson(value: SetWorkspaceRankMessage): string {
+        return JSON.stringify(uncast(value, r("SetWorkspaceRankMessage")), null, 2);
+    }
+
     public static toSettingsUpdatedMessage(json: string): SettingsUpdatedMessage {
         return cast(JSON.parse(json), r("SettingsUpdatedMessage"));
     }
@@ -9424,14 +9432,6 @@ export class Convert {
 
     public static settleTurnMessageToJson(value: SettleTurnMessage): string {
         return JSON.stringify(uncast(value, r("SettleTurnMessage")), null, 2);
-    }
-
-    public static toSetWorkspaceRankMessage(json: string): SetWorkspaceRankMessage {
-        return cast(JSON.parse(json), r("SetWorkspaceRankMessage"));
-    }
-
-    public static setWorkspaceRankMessageToJson(value: SetWorkspaceRankMessage): string {
-        return JSON.stringify(uncast(value, r("SetWorkspaceRankMessage")), null, 2);
     }
 
     public static toSnoozeTurnMessage(json: string): SnoozeTurnMessage {
@@ -9834,14 +9834,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("TicketSubscribeResult")), null, 2);
     }
 
-    public static toTicketsUpdatedMessage(json: string): TicketsUpdatedMessage {
-        return cast(JSON.parse(json), r("TicketsUpdatedMessage"));
-    }
-
-    public static ticketsUpdatedMessageToJson(value: TicketsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("TicketsUpdatedMessage")), null, 2);
-    }
-
     public static toTicketTakeMessage(json: string): TicketTakeMessage {
         return cast(JSON.parse(json), r("TicketTakeMessage"));
     }
@@ -9872,6 +9864,14 @@ export class Convert {
 
     public static ticketUnsubscribeResultToJson(value: TicketUnsubscribeResult): string {
         return JSON.stringify(uncast(value, r("TicketUnsubscribeResult")), null, 2);
+    }
+
+    public static toTicketsUpdatedMessage(json: string): TicketsUpdatedMessage {
+        return cast(JSON.parse(json), r("TicketsUpdatedMessage"));
+    }
+
+    public static ticketsUpdatedMessageToJson(value: TicketsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("TicketsUpdatedMessage")), null, 2);
     }
 
     public static toTodosMessage(json: string): TodosMessage {
@@ -10298,20 +10298,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUndockTileMessage")), null, 2);
     }
 
-    public static toWorkspaceLayoutUpdatedMessage(json: string): WorkspaceLayoutUpdatedMessage {
-        return cast(JSON.parse(json), r("WorkspaceLayoutUpdatedMessage"));
-    }
-
-    public static workspaceLayoutUpdatedMessageToJson(value: WorkspaceLayoutUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdatedMessage")), null, 2);
-    }
-
     public static toWorkspaceLayoutUpdateTileMessage(json: string): WorkspaceLayoutUpdateTileMessage {
         return cast(JSON.parse(json), r("WorkspaceLayoutUpdateTileMessage"));
     }
 
     public static workspaceLayoutUpdateTileMessageToJson(value: WorkspaceLayoutUpdateTileMessage): string {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdateTileMessage")), null, 2);
+    }
+
+    public static toWorkspaceLayoutUpdatedMessage(json: string): WorkspaceLayoutUpdatedMessage {
+        return cast(JSON.parse(json), r("WorkspaceLayoutUpdatedMessage"));
+    }
+
+    public static workspaceLayoutUpdatedMessageToJson(value: WorkspaceLayoutUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdatedMessage")), null, 2);
     }
 
     public static toWorkspaceRegisteredMessage(json: string): WorkspaceRegisteredMessage {
@@ -10783,17 +10783,6 @@ const typeMap: any = {
         { json: "spec_yaml", js: "spec_yaml", typ: u(undefined, "") },
         { json: "success", js: "success", typ: true },
     ], "any"),
-    "AutomationDefinitionsGetMessage": o([
-        { json: "cmd", js: "cmd", typ: r("AutomationDefinitionsGetMessageCmd") },
-        { json: "request_id", js: "request_id", typ: u(undefined, "") },
-    ], "any"),
-    "AutomationDefinitionsResultMessage": o([
-        { json: "definitions", js: "definitions", typ: u(undefined, a(r("Items"))) },
-        { json: "error", js: "error", typ: u(undefined, "") },
-        { json: "event", js: "event", typ: r("AutomationDefinitionsResultMessageEvent") },
-        { json: "request_id", js: "request_id", typ: u(undefined, "") },
-        { json: "success", js: "success", typ: true },
-    ], "any"),
     "AutomationDefinitionSummary": o([
         { json: "enabled", js: "enabled", typ: true },
         { json: "id", js: "id", typ: "" },
@@ -10804,6 +10793,17 @@ const typeMap: any = {
         { json: "schedule_time_zone", js: "schedule_time_zone", typ: u(undefined, "") },
         { json: "trigger_type", js: "trigger_type", typ: "" },
         { json: "updated_at", js: "updated_at", typ: "" },
+    ], "any"),
+    "AutomationDefinitionsGetMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutomationDefinitionsGetMessageCmd") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    ], "any"),
+    "AutomationDefinitionsResultMessage": o([
+        { json: "definitions", js: "definitions", typ: u(undefined, a(r("Items"))) },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("AutomationDefinitionsResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "success", js: "success", typ: true },
     ], "any"),
     "AutomationDeleteMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationDeleteMessageCmd") },
@@ -10830,20 +10830,6 @@ const typeMap: any = {
         { json: "run", js: "run", typ: u(undefined, r("LastRun")) },
         { json: "success", js: "success", typ: true },
     ], "any"),
-    "AutomationRunsGetMessage": o([
-        { json: "cmd", js: "cmd", typ: r("AutomationRunsGetMessageCmd") },
-        { json: "definition_id", js: "definition_id", typ: "" },
-        { json: "request_id", js: "request_id", typ: u(undefined, "") },
-    ], "any"),
-    "AutomationRunsResultMessage": o([
-        { json: "definition_id", js: "definition_id", typ: "" },
-        { json: "error", js: "error", typ: u(undefined, "") },
-        { json: "event", js: "event", typ: r("AutomationRunsResultMessageEvent") },
-        { json: "request_id", js: "request_id", typ: u(undefined, "") },
-        { json: "runs", js: "runs", typ: u(undefined, a(r("LastRun"))) },
-        { json: "success", js: "success", typ: true },
-        { json: "truncated", js: "truncated", typ: u(undefined, true) },
-    ], "any"),
     "AutomationRunSummary": o([
         { json: "cancel_reason", js: "cancel_reason", typ: u(undefined, "") },
         { json: "created_at", js: "created_at", typ: "" },
@@ -10858,9 +10844,19 @@ const typeMap: any = {
         { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
         { json: "updated_at", js: "updated_at", typ: "" },
     ], "any"),
-    "AutomationsChangedMessage": o([
-        { json: "definition_ids", js: "definition_ids", typ: a("") },
-        { json: "event", js: "event", typ: r("AutomationsChangedMessageEvent") },
+    "AutomationRunsGetMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutomationRunsGetMessageCmd") },
+        { json: "definition_id", js: "definition_id", typ: "" },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    ], "any"),
+    "AutomationRunsResultMessage": o([
+        { json: "definition_id", js: "definition_id", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("AutomationRunsResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "runs", js: "runs", typ: u(undefined, a(r("LastRun"))) },
+        { json: "success", js: "success", typ: true },
+        { json: "truncated", js: "truncated", typ: u(undefined, true) },
     ], "any"),
     "AutomationSetEnabledMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationSetEnabledMessageCmd") },
@@ -10885,6 +10881,10 @@ const typeMap: any = {
         { json: "event", js: "event", typ: r("AutomationValidateResultMessageEvent") },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
         { json: "success", js: "success", typ: true },
+    ], "any"),
+    "AutomationsChangedMessage": o([
+        { json: "definition_ids", js: "definition_ids", typ: a("") },
+        { json: "event", js: "event", typ: r("AutomationsChangedMessageEvent") },
     ], "any"),
     "BootstrapEndpointMessage": o([
         { json: "cmd", js: "cmd", typ: r("BootstrapEndpointMessageCmd") },
@@ -11305,6 +11305,16 @@ const typeMap: any = {
         { json: "order", js: "order", typ: a("") },
         { json: "upsert", js: "upsert", typ: a(r("Document")) },
     ], "any"),
+    "DocUndefineMessage": o([
+        { json: "cmd", js: "cmd", typ: r("DocUndefineMessageCmd") },
+        { json: "collection", js: "collection", typ: "" },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
+    "DocUndefineResult": o([
+        { json: "collection", js: "collection", typ: "" },
+        { json: "documents_removed", js: "documents_removed", typ: 0 },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
     "DocumentCollectionSchema": o([
         { json: "collection", js: "collection", typ: "" },
         { json: "fields", js: "fields", typ: a(r("FieldElement")) },
@@ -11342,16 +11352,6 @@ const typeMap: any = {
     "DocumentSort": o([
         { json: "desc", js: "desc", typ: u(undefined, true) },
         { json: "field", js: "field", typ: "" },
-    ], "any"),
-    "DocUndefineMessage": o([
-        { json: "cmd", js: "cmd", typ: r("DocUndefineMessageCmd") },
-        { json: "collection", js: "collection", typ: "" },
-        { json: "namespace", js: "namespace", typ: "" },
-    ], "any"),
-    "DocUndefineResult": o([
-        { json: "collection", js: "collection", typ: "" },
-        { json: "documents_removed", js: "documents_removed", typ: 0 },
-        { json: "namespace", js: "namespace", typ: "" },
     ], "any"),
     "EndpointActionResultMessage": o([
         { json: "action", js: "action", typ: "" },
@@ -11773,7 +11773,7 @@ const typeMap: any = {
     ], "any"),
     "Round": o([
         { json: "base_sha", js: "base_sha", typ: "" },
-        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("ChangedFileElement"))) },
+        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("FileElement"))) },
         { json: "created_at", js: "created_at", typ: "" },
         { json: "head_sha", js: "head_sha", typ: "" },
         { json: "id", js: "id", typ: "" },
@@ -11783,7 +11783,7 @@ const typeMap: any = {
         { json: "submitted_at", js: "submitted_at", typ: u(undefined, "") },
         { json: "verdict", js: "verdict", typ: u(undefined, "") },
     ], "any"),
-    "ChangedFileElement": o([
+    "FileElement": o([
         { json: "additions", js: "additions", typ: u(undefined, 0) },
         { json: "annotations", js: "annotations", typ: u(undefined, a(r("AnnotationElement"))) },
         { json: "deletions", js: "deletions", typ: u(undefined, 0) },
@@ -11796,7 +11796,7 @@ const typeMap: any = {
         { json: "line_start", js: "line_start", typ: 0 },
     ], "any"),
     "Manifest": o([
-        { json: "files", js: "files", typ: a(r("ChangedFileElement")) },
+        { json: "files", js: "files", typ: a(r("FileElement")) },
         { json: "skip", js: "skip", typ: a("") },
         { json: "summary", js: "summary", typ: u(undefined, "") },
         { json: "title", js: "title", typ: "" },
@@ -12483,6 +12483,49 @@ const typeMap: any = {
         { json: "tile_id", js: "tile_id", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
     ], "any"),
+    "PR": o([
+        { json: "approved_by_me", js: "approved_by_me", typ: true },
+        { json: "author", js: "author", typ: "" },
+        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
+        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
+        { json: "details_fetched", js: "details_fetched", typ: true },
+        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
+        { json: "has_new_changes", js: "has_new_changes", typ: true },
+        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
+        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
+        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
+        { json: "host", js: "host", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
+        { json: "last_polled", js: "last_polled", typ: "" },
+        { json: "last_updated", js: "last_updated", typ: "" },
+        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
+        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
+        { json: "muted", js: "muted", typ: true },
+        { json: "number", js: "number", typ: 0 },
+        { json: "reason", js: "reason", typ: "" },
+        { json: "repo", js: "repo", typ: "" },
+        { json: "review_status", js: "review_status", typ: u(undefined, "") },
+        { json: "role", js: "role", typ: r("PRRole") },
+        { json: "state", js: "state", typ: "" },
+        { json: "title", js: "title", typ: "" },
+        { json: "url", js: "url", typ: "" },
+    ], "any"),
+    "PRActionResultMessage": o([
+        { json: "action", js: "action", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
+        { json: "id", js: "id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "PRVisitedMessage": o([
+        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
+        { json: "id", js: "id", typ: "" },
+    ], "any"),
+    "PRsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
+        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
+    ], "any"),
     "PastConversation": o([
         { json: "bytes", js: "bytes", typ: 0 },
         { json: "cwd", js: "cwd", typ: "" },
@@ -12589,88 +12632,10 @@ const typeMap: any = {
         { json: "runtime_state", js: "runtime_state", typ: "" },
         { json: "version", js: "version", typ: "" },
     ], "any"),
-    "PR": o([
-        { json: "approved_by_me", js: "approved_by_me", typ: true },
-        { json: "author", js: "author", typ: "" },
-        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
-        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
-        { json: "details_fetched", js: "details_fetched", typ: true },
-        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
-        { json: "has_new_changes", js: "has_new_changes", typ: true },
-        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
-        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
-        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
-        { json: "host", js: "host", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
-        { json: "last_polled", js: "last_polled", typ: "" },
-        { json: "last_updated", js: "last_updated", typ: "" },
-        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
-        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
-        { json: "muted", js: "muted", typ: true },
-        { json: "number", js: "number", typ: 0 },
-        { json: "reason", js: "reason", typ: "" },
-        { json: "repo", js: "repo", typ: "" },
-        { json: "review_status", js: "review_status", typ: u(undefined, "") },
-        { json: "role", js: "role", typ: r("PRRole") },
-        { json: "state", js: "state", typ: "" },
-        { json: "title", js: "title", typ: "" },
-        { json: "url", js: "url", typ: "" },
-    ], "any"),
-    "PRActionResultMessage": o([
-        { json: "action", js: "action", typ: "" },
-        { json: "error", js: "error", typ: u(undefined, "") },
-        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
-        { json: "id", js: "id", typ: "" },
-        { json: "success", js: "success", typ: true },
-    ], "any"),
     "PresentAnnotation": o([
         { json: "comments", js: "comments", typ: a("") },
         { json: "line_end", js: "line_end", typ: 0 },
         { json: "line_start", js: "line_start", typ: 0 },
-    ], "any"),
-    "Presentation": o([
-        { json: "created_at", js: "created_at", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "kind", js: "kind", typ: "" },
-        { json: "latest_round_seq", js: "latest_round_seq", typ: 0 },
-        { json: "latest_round_submitted", js: "latest_round_submitted", typ: true },
-        { json: "repo_path", js: "repo_path", typ: "" },
-        { json: "session_id", js: "session_id", typ: "" },
-        { json: "status", js: "status", typ: "" },
-        { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
-        { json: "title", js: "title", typ: "" },
-    ], "any"),
-    "PresentationAddedMessage": o([
-        { json: "event", js: "event", typ: r("PresentationAddedMessageEvent") },
-        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
-    ], "any"),
-    "PresentationComment": o([
-        { json: "author", js: "author", typ: "" },
-        { json: "content", js: "content", typ: "" },
-        { json: "created_at", js: "created_at", typ: "" },
-        { json: "filepath", js: "filepath", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "line_end", js: "line_end", typ: 0 },
-        { json: "line_start", js: "line_start", typ: 0 },
-        { json: "round_id", js: "round_id", typ: "" },
-        { json: "side", js: "side", typ: "" },
-    ], "any"),
-    "PresentationRound": o([
-        { json: "base_sha", js: "base_sha", typ: "" },
-        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("ChangedFileElement"))) },
-        { json: "created_at", js: "created_at", typ: "" },
-        { json: "head_sha", js: "head_sha", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "manifest", js: "manifest", typ: r("Manifest") },
-        { json: "presentation_id", js: "presentation_id", typ: "" },
-        { json: "seq", js: "seq", typ: 0 },
-        { json: "submitted_at", js: "submitted_at", typ: u(undefined, "") },
-        { json: "verdict", js: "verdict", typ: u(undefined, "") },
-    ], "any"),
-    "PresentationUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("PresentationUpdatedMessageEvent") },
-        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
     ], "any"),
     "PresentCloseMessage": o([
         { json: "cmd", js: "cmd", typ: r("PresentCloseMessageCmd") },
@@ -12709,7 +12674,7 @@ const typeMap: any = {
         { json: "path", js: "path", typ: "" },
     ], "any"),
     "PresentManifestView": o([
-        { json: "files", js: "files", typ: a(r("ChangedFileElement")) },
+        { json: "files", js: "files", typ: a(r("FileElement")) },
         { json: "skip", js: "skip", typ: a("") },
         { json: "summary", js: "summary", typ: u(undefined, "") },
         { json: "title", js: "title", typ: "" },
@@ -12750,13 +12715,48 @@ const typeMap: any = {
         { json: "round_id", js: "round_id", typ: "" },
         { json: "success", js: "success", typ: true },
     ], "any"),
-    "PRsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
-        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
-    ], "any"),
-    "PRVisitedMessage": o([
-        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
+    "Presentation": o([
+        { json: "created_at", js: "created_at", typ: "" },
         { json: "id", js: "id", typ: "" },
+        { json: "kind", js: "kind", typ: "" },
+        { json: "latest_round_seq", js: "latest_round_seq", typ: 0 },
+        { json: "latest_round_submitted", js: "latest_round_submitted", typ: true },
+        { json: "repo_path", js: "repo_path", typ: "" },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "status", js: "status", typ: "" },
+        { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
+        { json: "title", js: "title", typ: "" },
+    ], "any"),
+    "PresentationAddedMessage": o([
+        { json: "event", js: "event", typ: r("PresentationAddedMessageEvent") },
+        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
+    ], "any"),
+    "PresentationComment": o([
+        { json: "author", js: "author", typ: "" },
+        { json: "content", js: "content", typ: "" },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "filepath", js: "filepath", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "line_end", js: "line_end", typ: 0 },
+        { json: "line_start", js: "line_start", typ: 0 },
+        { json: "round_id", js: "round_id", typ: "" },
+        { json: "side", js: "side", typ: "" },
+    ], "any"),
+    "PresentationRound": o([
+        { json: "base_sha", js: "base_sha", typ: "" },
+        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("FileElement"))) },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "head_sha", js: "head_sha", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "manifest", js: "manifest", typ: r("Manifest") },
+        { json: "presentation_id", js: "presentation_id", typ: "" },
+        { json: "seq", js: "seq", typ: 0 },
+        { json: "submitted_at", js: "submitted_at", typ: u(undefined, "") },
+        { json: "verdict", js: "verdict", typ: u(undefined, "") },
+    ], "any"),
+    "PresentationUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("PresentationUpdatedMessageEvent") },
+        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
     ], "any"),
     "PtyDesyncMessage": o([
         { json: "event", js: "event", typ: r("PtyDesyncMessageEvent") },
@@ -12775,17 +12775,17 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "seq", js: "seq", typ: 0 },
     ], "any"),
-    "PtyResizedMessage": o([
+    "PtyResizeMessage": o([
+        { json: "cmd", js: "cmd", typ: r("PtyResizeMessageCmd") },
         { json: "cols", js: "cols", typ: 0 },
-        { json: "event", js: "event", typ: r("PtyResizedMessageEvent") },
         { json: "id", js: "id", typ: "" },
         { json: "rows", js: "rows", typ: 0 },
         { json: "xpixel", js: "xpixel", typ: u(undefined, 0) },
         { json: "ypixel", js: "ypixel", typ: u(undefined, 0) },
     ], "any"),
-    "PtyResizeMessage": o([
-        { json: "cmd", js: "cmd", typ: r("PtyResizeMessageCmd") },
+    "PtyResizedMessage": o([
         { json: "cols", js: "cols", typ: 0 },
+        { json: "event", js: "event", typ: r("PtyResizedMessageEvent") },
         { json: "id", js: "id", typ: "" },
         { json: "rows", js: "rows", typ: 0 },
         { json: "xpixel", js: "xpixel", typ: u(undefined, 0) },
@@ -12820,11 +12820,11 @@ const typeMap: any = {
     "RecentFilesResultMessage": o([
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("RecentFilesResultMessageEvent") },
-        { json: "files", js: "files", typ: a(r("FileElement")) },
+        { json: "files", js: "files", typ: a(r("FileObject")) },
         { json: "request_id", js: "request_id", typ: "" },
         { json: "success", js: "success", typ: true },
     ], "any"),
-    "FileElement": o([
+    "FileObject": o([
         { json: "count", js: "count", typ: 0 },
         { json: "last_at", js: "last_at", typ: "" },
         { json: "path", js: "path", typ: "" },
@@ -13387,10 +13387,6 @@ const typeMap: any = {
         { json: "event", js: "event", typ: r("SessionStateChangedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionObject") },
     ], "any"),
-    "SessionsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
-        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionObject"))) },
-    ], "any"),
     "SessionTodosUpdatedMessage": o([
         { json: "event", js: "event", typ: r("SessionTodosUpdatedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionObject") },
@@ -13419,6 +13415,10 @@ const typeMap: any = {
     "SessionUnregisteredMessage": o([
         { json: "event", js: "event", typ: r("SessionUnregisteredMessageEvent") },
         { json: "session", js: "session", typ: r("SessionObject") },
+    ], "any"),
+    "SessionsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
+        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionObject"))) },
     ], "any"),
     "SetChiefOfStaffMessage": o([
         { json: "chief_of_staff", js: "chief_of_staff", typ: true },
@@ -13471,6 +13471,12 @@ const typeMap: any = {
         { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
         { json: "work_state", js: "work_state", typ: r("DispatchWorkState") },
     ], "any"),
+    "SetWorkspaceRankMessage": o([
+        { json: "cmd", js: "cmd", typ: r("SetWorkspaceRankMessageCmd") },
+        { json: "next_workspace_id", js: "next_workspace_id", typ: u(undefined, "") },
+        { json: "prev_workspace_id", js: "prev_workspace_id", typ: u(undefined, "") },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
+    ], "any"),
     "SettingsUpdatedMessage": o([
         { json: "changed_key", js: "changed_key", typ: u(undefined, "") },
         { json: "error", js: "error", typ: u(undefined, "") },
@@ -13481,12 +13487,6 @@ const typeMap: any = {
     "SettleTurnMessage": o([
         { json: "cmd", js: "cmd", typ: r("SettleTurnMessageCmd") },
         { json: "session_id", js: "session_id", typ: "" },
-    ], "any"),
-    "SetWorkspaceRankMessage": o([
-        { json: "cmd", js: "cmd", typ: r("SetWorkspaceRankMessageCmd") },
-        { json: "next_workspace_id", js: "next_workspace_id", typ: u(undefined, "") },
-        { json: "prev_workspace_id", js: "prev_workspace_id", typ: u(undefined, "") },
-        { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "SnoozeTurnMessage": o([
         { json: "cmd", js: "cmd", typ: r("SnoozeTurnMessageCmd") },
@@ -13675,13 +13675,13 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("TicketAttachMessageCmd") },
         { json: "comment", js: "comment", typ: u(undefined, "") },
         { json: "expected_event_seq", js: "expected_event_seq", typ: u(undefined, 0) },
-        { json: "files", js: "files", typ: a(r("FileObject")) },
+        { json: "files", js: "files", typ: a(r("TicketAttachMessageFile")) },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
         { json: "source_session_id", js: "source_session_id", typ: "" },
         { json: "state", js: "state", typ: u(undefined, r("DispatchWorkState")) },
         { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
     ], "any"),
-    "FileObject": o([
+    "TicketAttachMessageFile": o([
         { json: "filename", js: "filename", typ: "" },
         { json: "source_path", js: "source_path", typ: "" },
     ], "any"),
@@ -13817,10 +13817,6 @@ const typeMap: any = {
         { json: "ticket_id", js: "ticket_id", typ: "" },
         { json: "unread_count", js: "unread_count", typ: u(undefined, 0) },
     ], "any"),
-    "TicketsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("TicketsUpdatedMessageEvent") },
-        { json: "tickets", js: "tickets", typ: a(r("TicketElement")) },
-    ], "any"),
     "TicketTakeMessage": o([
         { json: "cmd", js: "cmd", typ: r("TicketTakeMessageCmd") },
         { json: "confirm", js: "confirm", typ: u(undefined, true) },
@@ -13839,6 +13835,10 @@ const typeMap: any = {
     ], "any"),
     "TicketUnsubscribeResult": o([
         { json: "ticket_id", js: "ticket_id", typ: "" },
+    ], "any"),
+    "TicketsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("TicketsUpdatedMessageEvent") },
+        { json: "tickets", js: "tickets", typ: a(r("TicketElement")) },
     ], "any"),
     "TodosMessage": o([
         { json: "cmd", js: "cmd", typ: r("TodosMessageCmd") },
@@ -14251,10 +14251,6 @@ const typeMap: any = {
         { json: "tile_id", js: "tile_id", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
-    "WorkspaceLayoutUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("WorkspaceLayoutUpdatedMessageEvent") },
-        { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
-    ], "any"),
     "WorkspaceLayoutUpdateTileMessage": o([
         { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutUpdateTileMessageCmd") },
         { json: "request_id", js: "request_id", typ: "" },
@@ -14262,6 +14258,10 @@ const typeMap: any = {
         { json: "tile_params", js: "tile_params", typ: "" },
         { json: "tile_session_id", js: "tile_session_id", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: "" },
+    ], "any"),
+    "WorkspaceLayoutUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("WorkspaceLayoutUpdatedMessageEvent") },
+        { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
     ], "any"),
     "WorkspaceRegisteredMessage": o([
         { json: "event", js: "event", typ: r("WorkspaceRegisteredMessageEvent") },
@@ -14398,9 +14398,6 @@ const typeMap: any = {
     "AutomationRunsResultMessageEvent": [
         "automation_runs_result",
     ],
-    "AutomationsChangedMessageEvent": [
-        "automations_changed",
-    ],
     "AutomationSetEnabledMessageCmd": [
         "automation_set_enabled",
     ],
@@ -14412,6 +14409,9 @@ const typeMap: any = {
     ],
     "AutomationValidateResultMessageEvent": [
         "automation_validate_result",
+    ],
+    "AutomationsChangedMessageEvent": [
+        "automations_changed",
     ],
     "BootstrapEndpointMessageCmd": [
         "bootstrap_endpoint",
@@ -14914,6 +14914,15 @@ const typeMap: any = {
     "OpenMarkdownResultMessageEvent": [
         "open_markdown_result",
     ],
+    "PRActionResultMessageEvent": [
+        "pr_action_result",
+    ],
+    "PRVisitedMessageCmd": [
+        "pr_visited",
+    ],
+    "PRsUpdatedMessageEvent": [
+        "prs_updated",
+    ],
     "PastConversationsResultMessageEvent": [
         "past_conversations_result",
     ],
@@ -14928,15 +14937,6 @@ const typeMap: any = {
     ],
     "PluginsUpdatedMessageEvent": [
         "plugins_updated",
-    ],
-    "PRActionResultMessageEvent": [
-        "pr_action_result",
-    ],
-    "PresentationAddedMessageEvent": [
-        "presentation_added",
-    ],
-    "PresentationUpdatedMessageEvent": [
-        "presentation_updated",
     ],
     "PresentCloseMessageCmd": [
         "present_close",
@@ -14956,11 +14956,11 @@ const typeMap: any = {
     "PresentSubmitRoundResultMessageEvent": [
         "present_submit_round_result",
     ],
-    "PRsUpdatedMessageEvent": [
-        "prs_updated",
+    "PresentationAddedMessageEvent": [
+        "presentation_added",
     ],
-    "PRVisitedMessageCmd": [
-        "pr_visited",
+    "PresentationUpdatedMessageEvent": [
+        "presentation_updated",
     ],
     "PtyDesyncMessageEvent": [
         "pty_desync",
@@ -14971,11 +14971,11 @@ const typeMap: any = {
     "PtyOutputMessageEvent": [
         "pty_output",
     ],
-    "PtyResizedMessageEvent": [
-        "pty_resized",
-    ],
     "PtyResizeMessageCmd": [
         "pty_resize",
+    ],
+    "PtyResizedMessageEvent": [
+        "pty_resized",
     ],
     "QueryAuthorsMessageCmd": [
         "query_authors",
@@ -15100,9 +15100,6 @@ const typeMap: any = {
     "SessionStateChangedMessageEvent": [
         "session_state_changed",
     ],
-    "SessionsUpdatedMessageEvent": [
-        "sessions_updated",
-    ],
     "SessionTodosUpdatedMessageEvent": [
         "session_todos_updated",
     ],
@@ -15111,6 +15108,9 @@ const typeMap: any = {
     ],
     "SessionUnregisteredMessageEvent": [
         "session_unregistered",
+    ],
+    "SessionsUpdatedMessageEvent": [
+        "sessions_updated",
     ],
     "SetChiefOfStaffMessageCmd": [
         "set_chief_of_staff",
@@ -15146,14 +15146,14 @@ const typeMap: any = {
         "needs_input",
         "ready_for_review",
     ],
+    "SetWorkspaceRankMessageCmd": [
+        "set_workspace_rank",
+    ],
     "SettingsUpdatedMessageEvent": [
         "settings_updated",
     ],
     "SettleTurnMessageCmd": [
         "settle_turn",
-    ],
-    "SetWorkspaceRankMessageCmd": [
-        "set_workspace_rank",
     ],
     "SnoozeTurnMessageCmd": [
         "snooze_turn",
@@ -15243,14 +15243,14 @@ const typeMap: any = {
     "TicketSubscribeMessageCmd": [
         "ticket_subscribe",
     ],
-    "TicketsUpdatedMessageEvent": [
-        "tickets_updated",
-    ],
     "TicketTakeMessageCmd": [
         "ticket_take",
     ],
     "TicketUnsubscribeMessageCmd": [
         "ticket_unsubscribe",
+    ],
+    "TicketsUpdatedMessageEvent": [
+        "tickets_updated",
     ],
     "TodosMessageCmd": [
         "todos",
@@ -15385,11 +15385,11 @@ const typeMap: any = {
     "WorkspaceLayoutUndockTileMessageCmd": [
         "workspace_layout_undock_tile",
     ],
-    "WorkspaceLayoutUpdatedMessageEvent": [
-        "workspace_layout_updated",
-    ],
     "WorkspaceLayoutUpdateTileMessageCmd": [
         "workspace_layout_update_tile",
+    ],
+    "WorkspaceLayoutUpdatedMessageEvent": [
+        "workspace_layout_updated",
     ],
     "WorkspaceRegisteredMessageEvent": [
         "workspace_registered",

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDefinitionSummary, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationRunSummary, AutomationsChangedMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, DocUndefineMessage, DocUndefineResult, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SettleTurnMessage, SetWorkspaceRankMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const activityStatusMessage = Convert.toActivityStatusMessage(json);
 //   const activityStatusResult = Convert.toActivityStatusResult(json);
@@ -27,21 +27,21 @@
 //   const automationCleanupResultMessage = Convert.toAutomationCleanupResultMessage(json);
 //   const automationDefinitionGetMessage = Convert.toAutomationDefinitionGetMessage(json);
 //   const automationDefinitionResultMessage = Convert.toAutomationDefinitionResultMessage(json);
-//   const automationDefinitionSummary = Convert.toAutomationDefinitionSummary(json);
 //   const automationDefinitionsGetMessage = Convert.toAutomationDefinitionsGetMessage(json);
 //   const automationDefinitionsResultMessage = Convert.toAutomationDefinitionsResultMessage(json);
+//   const automationDefinitionSummary = Convert.toAutomationDefinitionSummary(json);
 //   const automationDeleteMessage = Convert.toAutomationDeleteMessage(json);
 //   const automationDeleteResultMessage = Convert.toAutomationDeleteResultMessage(json);
 //   const automationRunMessage = Convert.toAutomationRunMessage(json);
 //   const automationRunResultMessage = Convert.toAutomationRunResultMessage(json);
-//   const automationRunSummary = Convert.toAutomationRunSummary(json);
 //   const automationRunsGetMessage = Convert.toAutomationRunsGetMessage(json);
 //   const automationRunsResultMessage = Convert.toAutomationRunsResultMessage(json);
+//   const automationRunSummary = Convert.toAutomationRunSummary(json);
+//   const automationsChangedMessage = Convert.toAutomationsChangedMessage(json);
 //   const automationSetEnabledMessage = Convert.toAutomationSetEnabledMessage(json);
 //   const automationSetEnabledResultMessage = Convert.toAutomationSetEnabledResultMessage(json);
 //   const automationValidateMessage = Convert.toAutomationValidateMessage(json);
 //   const automationValidateResultMessage = Convert.toAutomationValidateResultMessage(json);
-//   const automationsChangedMessage = Convert.toAutomationsChangedMessage(json);
 //   const bootstrapEndpointMessage = Convert.toBootstrapEndpointMessage(json);
 //   const branch = Convert.toBranch(json);
 //   const branchChangedMessage = Convert.toBranchChangedMessage(json);
@@ -94,8 +94,6 @@
 //   const docQueryResult = Convert.toDocQueryResult(json);
 //   const docSubscribeMessage = Convert.toDocSubscribeMessage(json);
 //   const docSubscribeResult = Convert.toDocSubscribeResult(json);
-//   const docUndefineMessage = Convert.toDocUndefineMessage(json);
-//   const docUndefineResult = Convert.toDocUndefineResult(json);
 //   const documentCollectionSchema = Convert.toDocumentCollectionSchema(json);
 //   const documentConflict = Convert.toDocumentConflict(json);
 //   const documentFieldSpec = Convert.toDocumentFieldSpec(json);
@@ -103,6 +101,8 @@
 //   const documentQuery = Convert.toDocumentQuery(json);
 //   const documentRevision = Convert.toDocumentRevision(json);
 //   const documentSort = Convert.toDocumentSort(json);
+//   const docUndefineMessage = Convert.toDocUndefineMessage(json);
+//   const docUndefineResult = Convert.toDocUndefineResult(json);
 //   const endpointActionResultMessage = Convert.toEndpointActionResultMessage(json);
 //   const endpointCapabilities = Convert.toEndpointCapabilities(json);
 //   const endpointInfo = Convert.toEndpointInfo(json);
@@ -231,15 +231,11 @@
 //   const notificationListResultMessage = Convert.toNotificationListResultMessage(json);
 //   const notificationMarkReadMessage = Convert.toNotificationMarkReadMessage(json);
 //   const notificationMarkReadResultMessage = Convert.toNotificationMarkReadResultMessage(json);
+//   const notificationSeverity = Convert.toNotificationSeverity(json);
 //   const notificationsUpdatedMessage = Convert.toNotificationsUpdatedMessage(json);
 //   const openBrowserMessage = Convert.toOpenBrowserMessage(json);
 //   const openMarkdownMessage = Convert.toOpenMarkdownMessage(json);
 //   const openMarkdownResultMessage = Convert.toOpenMarkdownResultMessage(json);
-//   const pR = Convert.toPR(json);
-//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
-//   const pRRole = Convert.toPRRole(json);
-//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
-//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
 //   const pastConversation = Convert.toPastConversation(json);
 //   const pastConversationsResultMessage = Convert.toPastConversationsResultMessage(json);
 //   const pathInspection = Convert.toPathInspection(json);
@@ -249,7 +245,14 @@
 //   const pluginInfo = Convert.toPluginInfo(json);
 //   const pluginIssue = Convert.toPluginIssue(json);
 //   const pluginsUpdatedMessage = Convert.toPluginsUpdatedMessage(json);
+//   const pR = Convert.toPR(json);
+//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
 //   const presentAnnotation = Convert.toPresentAnnotation(json);
+//   const presentation = Convert.toPresentation(json);
+//   const presentationAddedMessage = Convert.toPresentationAddedMessage(json);
+//   const presentationComment = Convert.toPresentationComment(json);
+//   const presentationRound = Convert.toPresentationRound(json);
+//   const presentationUpdatedMessage = Convert.toPresentationUpdatedMessage(json);
 //   const presentCloseMessage = Convert.toPresentCloseMessage(json);
 //   const presentCloseResultMessage = Convert.toPresentCloseResultMessage(json);
 //   const presentCommentInput = Convert.toPresentCommentInput(json);
@@ -261,16 +264,14 @@
 //   const presentOpenResult = Convert.toPresentOpenResult(json);
 //   const presentSubmitRoundMessage = Convert.toPresentSubmitRoundMessage(json);
 //   const presentSubmitRoundResultMessage = Convert.toPresentSubmitRoundResultMessage(json);
-//   const presentation = Convert.toPresentation(json);
-//   const presentationAddedMessage = Convert.toPresentationAddedMessage(json);
-//   const presentationComment = Convert.toPresentationComment(json);
-//   const presentationRound = Convert.toPresentationRound(json);
-//   const presentationUpdatedMessage = Convert.toPresentationUpdatedMessage(json);
+//   const pRRole = Convert.toPRRole(json);
+//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
+//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
 //   const ptyDesyncMessage = Convert.toPtyDesyncMessage(json);
 //   const ptyInputMessage = Convert.toPtyInputMessage(json);
 //   const ptyOutputMessage = Convert.toPtyOutputMessage(json);
-//   const ptyResizeMessage = Convert.toPtyResizeMessage(json);
 //   const ptyResizedMessage = Convert.toPtyResizedMessage(json);
+//   const ptyResizeMessage = Convert.toPtyResizeMessage(json);
 //   const queryAuthorsMessage = Convert.toQueryAuthorsMessage(json);
 //   const queryMessage = Convert.toQueryMessage(json);
 //   const queryPRsMessage = Convert.toQueryPRsMessage(json);
@@ -318,12 +319,12 @@
 //   const sessionSelectedMessage = Convert.toSessionSelectedMessage(json);
 //   const sessionState = Convert.toSessionState(json);
 //   const sessionStateChangedMessage = Convert.toSessionStateChangedMessage(json);
+//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const sessionTodosUpdatedMessage = Convert.toSessionTodosUpdatedMessage(json);
 //   const sessionTranscriptEvent = Convert.toSessionTranscriptEvent(json);
 //   const sessionTranscriptMessage = Convert.toSessionTranscriptMessage(json);
 //   const sessionTranscriptResult = Convert.toSessionTranscriptResult(json);
 //   const sessionUnregisteredMessage = Convert.toSessionUnregisteredMessage(json);
-//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const setChiefOfStaffMessage = Convert.toSetChiefOfStaffMessage(json);
 //   const setClientPresenceMessage = Convert.toSetClientPresenceMessage(json);
 //   const setEndpointRemoteWebMessage = Convert.toSetEndpointRemoteWebMessage(json);
@@ -333,9 +334,9 @@
 //   const setSettingMessage = Convert.toSetSettingMessage(json);
 //   const setTerminalThemeMessage = Convert.toSetTerminalThemeMessage(json);
 //   const setTicketStatusMessage = Convert.toSetTicketStatusMessage(json);
-//   const setWorkspaceRankMessage = Convert.toSetWorkspaceRankMessage(json);
 //   const settingsUpdatedMessage = Convert.toSettingsUpdatedMessage(json);
 //   const settleTurnMessage = Convert.toSettleTurnMessage(json);
+//   const setWorkspaceRankMessage = Convert.toSetWorkspaceRankMessage(json);
 //   const snoozeTurnMessage = Convert.toSnoozeTurnMessage(json);
 //   const spawnResultMessage = Convert.toSpawnResultMessage(json);
 //   const spawnSessionMessage = Convert.toSpawnSessionMessage(json);
@@ -386,11 +387,11 @@
 //   const ticketStatusResult = Convert.toTicketStatusResult(json);
 //   const ticketSubscribeMessage = Convert.toTicketSubscribeMessage(json);
 //   const ticketSubscribeResult = Convert.toTicketSubscribeResult(json);
+//   const ticketsUpdatedMessage = Convert.toTicketsUpdatedMessage(json);
 //   const ticketTakeMessage = Convert.toTicketTakeMessage(json);
 //   const ticketTakeResult = Convert.toTicketTakeResult(json);
 //   const ticketUnsubscribeMessage = Convert.toTicketUnsubscribeMessage(json);
 //   const ticketUnsubscribeResult = Convert.toTicketUnsubscribeResult(json);
-//   const ticketsUpdatedMessage = Convert.toTicketsUpdatedMessage(json);
 //   const todosMessage = Convert.toTodosMessage(json);
 //   const triggerNudgeMessage = Convert.toTriggerNudgeMessage(json);
 //   const uninstallPluginMessage = Convert.toUninstallPluginMessage(json);
@@ -444,8 +445,8 @@
 //   const workspaceLayoutSetSplitRatioMessage = Convert.toWorkspaceLayoutSetSplitRatioMessage(json);
 //   const workspaceLayoutSplitDirection = Convert.toWorkspaceLayoutSplitDirection(json);
 //   const workspaceLayoutUndockTileMessage = Convert.toWorkspaceLayoutUndockTileMessage(json);
-//   const workspaceLayoutUpdateTileMessage = Convert.toWorkspaceLayoutUpdateTileMessage(json);
 //   const workspaceLayoutUpdatedMessage = Convert.toWorkspaceLayoutUpdatedMessage(json);
+//   const workspaceLayoutUpdateTileMessage = Convert.toWorkspaceLayoutUpdateTileMessage(json);
 //   const workspaceRegisteredMessage = Convert.toWorkspaceRegisteredMessage(json);
 //   const workspaceSelectedMessage = Convert.toWorkspaceSelectedMessage(json);
 //   const workspaceStateChangedMessage = Convert.toWorkspaceStateChangedMessage(json);
@@ -833,19 +834,6 @@ export enum AutomationDefinitionResultMessageEvent {
     AutomationDefinitionResult = "automation_definition_result",
 }
 
-export interface AutomationDefinitionSummary {
-    enabled:             boolean;
-    id:                  string;
-    last_run?:           LastRun;
-    name:                string;
-    revision:            number;
-    schedule_cron?:      string;
-    schedule_time_zone?: string;
-    trigger_type:        string;
-    updated_at:          string;
-    [property: string]: any;
-}
-
 export interface AutomationDefinitionsGetMessage {
     cmd:         AutomationDefinitionsGetMessageCmd;
     request_id?: string;
@@ -867,6 +855,19 @@ export interface AutomationDefinitionsResultMessage {
 
 export enum AutomationDefinitionsResultMessageEvent {
     AutomationDefinitionsResult = "automation_definitions_result",
+}
+
+export interface AutomationDefinitionSummary {
+    enabled:             boolean;
+    id:                  string;
+    last_run?:           LastRun;
+    name:                string;
+    revision:            number;
+    schedule_cron?:      string;
+    schedule_time_zone?: string;
+    trigger_type:        string;
+    updated_at:          string;
+    [property: string]: any;
 }
 
 export interface AutomationDeleteMessage {
@@ -918,22 +919,6 @@ export enum AutomationRunResultMessageEvent {
     AutomationRunResult = "automation_run_result",
 }
 
-export interface AutomationRunSummary {
-    cancel_reason?:  string;
-    created_at:      string;
-    definition_id:   string;
-    delivered_at?:   string;
-    id:              string;
-    last_error?:     string;
-    occurrence_key?: string;
-    pane_id?:        string;
-    session_id?:     string;
-    state:           string;
-    ticket_id?:      string;
-    updated_at:      string;
-    [property: string]: any;
-}
-
 export interface AutomationRunsGetMessage {
     cmd:           AutomationRunsGetMessageCmd;
     definition_id: string;
@@ -958,6 +943,32 @@ export interface AutomationRunsResultMessage {
 
 export enum AutomationRunsResultMessageEvent {
     AutomationRunsResult = "automation_runs_result",
+}
+
+export interface AutomationRunSummary {
+    cancel_reason?:  string;
+    created_at:      string;
+    definition_id:   string;
+    delivered_at?:   string;
+    id:              string;
+    last_error?:     string;
+    occurrence_key?: string;
+    pane_id?:        string;
+    session_id?:     string;
+    state:           string;
+    ticket_id?:      string;
+    updated_at:      string;
+    [property: string]: any;
+}
+
+export interface AutomationsChangedMessage {
+    definition_ids: string[];
+    event:          AutomationsChangedMessageEvent;
+    [property: string]: any;
+}
+
+export enum AutomationsChangedMessageEvent {
+    AutomationsChanged = "automations_changed",
 }
 
 export interface AutomationSetEnabledMessage {
@@ -1006,16 +1017,6 @@ export interface AutomationValidateResultMessage {
 
 export enum AutomationValidateResultMessageEvent {
     AutomationValidateResult = "automation_validate_result",
-}
-
-export interface AutomationsChangedMessage {
-    definition_ids: string[];
-    event:          AutomationsChangedMessageEvent;
-    [property: string]: any;
-}
-
-export enum AutomationsChangedMessageEvent {
-    AutomationsChanged = "automations_changed",
 }
 
 export interface BootstrapEndpointMessage {
@@ -1732,24 +1733,6 @@ export interface DocSubscribeResult {
     [property: string]: any;
 }
 
-export interface DocUndefineMessage {
-    cmd:        DocUndefineMessageCmd;
-    collection: string;
-    namespace:  string;
-    [property: string]: any;
-}
-
-export enum DocUndefineMessageCmd {
-    DocUndefine = "doc_undefine",
-}
-
-export interface DocUndefineResult {
-    collection:        string;
-    documents_removed: number;
-    namespace:         string;
-    [property: string]: any;
-}
-
 export interface DocumentCollectionSchema {
     collection: string;
     fields:     FieldElement[];
@@ -1799,6 +1782,24 @@ export interface DocumentRevision {
 export interface DocumentSort {
     desc?: boolean;
     field: string;
+    [property: string]: any;
+}
+
+export interface DocUndefineMessage {
+    cmd:        DocUndefineMessageCmd;
+    collection: string;
+    namespace:  string;
+    [property: string]: any;
+}
+
+export enum DocUndefineMessageCmd {
+    DocUndefine = "doc_undefine",
+}
+
+export interface DocUndefineResult {
+    collection:        string;
+    documents_removed: number;
+    namespace:         string;
     [property: string]: any;
 }
 
@@ -2507,7 +2508,7 @@ export interface PresentationElement {
 
 export interface Round {
     base_sha:        string;
-    changed_files?:  FileElement[];
+    changed_files?:  ChangedFileElement[];
     created_at:      string;
     head_sha:        string;
     id:              string;
@@ -2519,7 +2520,7 @@ export interface Round {
     [property: string]: any;
 }
 
-export interface FileElement {
+export interface ChangedFileElement {
     additions?:   number;
     annotations?: AnnotationElement[];
     deletions?:   number;
@@ -2536,7 +2537,7 @@ export interface AnnotationElement {
 }
 
 export interface Manifest {
-    files:    FileElement[];
+    files:    ChangedFileElement[];
     skip:     string[];
     summary?: string;
     title:    string;
@@ -3618,10 +3619,17 @@ export interface Notification {
     id:          string;
     kind:        string;
     read_at:     string;
+    severity:    NotificationSeverity;
     source_id:   string;
     source_kind: string;
     title:       string;
     [property: string]: any;
+}
+
+export enum NotificationSeverity {
+    Critical = "critical",
+    Info = "info",
+    Warning = "warning",
 }
 
 export interface NotificationListMessage {
@@ -3635,12 +3643,14 @@ export enum NotificationListMessageCmd {
 }
 
 export interface NotificationListResultMessage {
-    error?:         string;
-    event:          NotificationListResultMessageEvent;
-    notifications?: NotificationElement[];
-    request_id:     string;
-    success:        boolean;
-    unread_count:   number;
+    critical_title?:       string;
+    error?:                string;
+    event:                 NotificationListResultMessageEvent;
+    notifications?:        NotificationElement[];
+    request_id:            string;
+    success:               boolean;
+    unread_count:          number;
+    unread_critical_count: number;
     [property: string]: any;
 }
 
@@ -3655,6 +3665,7 @@ export interface NotificationElement {
     id:          string;
     kind:        string;
     read_at:     string;
+    severity:    NotificationSeverity;
     source_id:   string;
     source_kind: string;
     title:       string;
@@ -3686,8 +3697,10 @@ export enum NotificationMarkReadResultMessageEvent {
 }
 
 export interface NotificationsUpdatedMessage {
-    event:        NotificationsUpdatedMessageEvent;
-    unread_count: number;
+    critical_title?:       string;
+    event:                 NotificationsUpdatedMessageEvent;
+    unread_count:          number;
+    unread_critical_count: number;
     [property: string]: any;
 }
 
@@ -3731,69 +3744,6 @@ export interface OpenMarkdownResultMessage {
 
 export enum OpenMarkdownResultMessageEvent {
     OpenMarkdownResult = "open_markdown_result",
-}
-
-export interface PR {
-    approved_by_me:         boolean;
-    author:                 string;
-    ci_status?:             string;
-    comment_count?:         number;
-    details_fetched:        boolean;
-    details_fetched_at?:    string;
-    has_new_changes:        boolean;
-    head_branch?:           string;
-    head_sha?:              string;
-    heat_state?:            HeatState;
-    host:                   string;
-    id:                     string;
-    last_heat_activity_at?: string;
-    last_polled:            string;
-    last_updated:           string;
-    mergeable?:             boolean;
-    mergeable_state?:       string;
-    muted:                  boolean;
-    number:                 number;
-    reason:                 string;
-    repo:                   string;
-    review_status?:         string;
-    role:                   PRRole;
-    state:                  string;
-    title:                  string;
-    url:                    string;
-    [property: string]: any;
-}
-
-export interface PRActionResultMessage {
-    action:  string;
-    error?:  string;
-    event:   PRActionResultMessageEvent;
-    id:      string;
-    success: boolean;
-    [property: string]: any;
-}
-
-export enum PRActionResultMessageEvent {
-    PRActionResult = "pr_action_result",
-}
-
-export interface PRVisitedMessage {
-    cmd: PRVisitedMessageCmd;
-    id:  string;
-    [property: string]: any;
-}
-
-export enum PRVisitedMessageCmd {
-    PRVisited = "pr_visited",
-}
-
-export interface PRsUpdatedMessage {
-    event: PRsUpdatedMessageEvent;
-    prs?:  PRElement[];
-    [property: string]: any;
-}
-
-export enum PRsUpdatedMessageEvent {
-    PrsUpdated = "prs_updated",
 }
 
 export interface PastConversation {
@@ -3946,11 +3896,115 @@ export interface PluginElement {
     [property: string]: any;
 }
 
+export interface PR {
+    approved_by_me:         boolean;
+    author:                 string;
+    ci_status?:             string;
+    comment_count?:         number;
+    details_fetched:        boolean;
+    details_fetched_at?:    string;
+    has_new_changes:        boolean;
+    head_branch?:           string;
+    head_sha?:              string;
+    heat_state?:            HeatState;
+    host:                   string;
+    id:                     string;
+    last_heat_activity_at?: string;
+    last_polled:            string;
+    last_updated:           string;
+    mergeable?:             boolean;
+    mergeable_state?:       string;
+    muted:                  boolean;
+    number:                 number;
+    reason:                 string;
+    repo:                   string;
+    review_status?:         string;
+    role:                   PRRole;
+    state:                  string;
+    title:                  string;
+    url:                    string;
+    [property: string]: any;
+}
+
+export interface PRActionResultMessage {
+    action:  string;
+    error?:  string;
+    event:   PRActionResultMessageEvent;
+    id:      string;
+    success: boolean;
+    [property: string]: any;
+}
+
+export enum PRActionResultMessageEvent {
+    PRActionResult = "pr_action_result",
+}
+
 export interface PresentAnnotation {
     comments:   string[];
     line_end:   number;
     line_start: number;
     [property: string]: any;
+}
+
+export interface Presentation {
+    created_at:             string;
+    id:                     string;
+    kind:                   string;
+    latest_round_seq:       number;
+    latest_round_submitted: boolean;
+    repo_path:              string;
+    session_id:             string;
+    status:                 string;
+    ticket_id?:             string;
+    title:                  string;
+    [property: string]: any;
+}
+
+export interface PresentationAddedMessage {
+    event:        PresentationAddedMessageEvent;
+    presentation: PresentationElement;
+    [property: string]: any;
+}
+
+export enum PresentationAddedMessageEvent {
+    PresentationAdded = "presentation_added",
+}
+
+export interface PresentationComment {
+    author:     string;
+    content:    string;
+    created_at: string;
+    filepath:   string;
+    id:         string;
+    line_end:   number;
+    line_start: number;
+    round_id:   string;
+    side:       string;
+    [property: string]: any;
+}
+
+export interface PresentationRound {
+    base_sha:        string;
+    changed_files?:  ChangedFileElement[];
+    created_at:      string;
+    head_sha:        string;
+    id:              string;
+    manifest:        Manifest;
+    presentation_id: string;
+    seq:             number;
+    submitted_at?:   string;
+    verdict?:        string;
+    [property: string]: any;
+}
+
+export interface PresentationUpdatedMessage {
+    event:        PresentationUpdatedMessageEvent;
+    presentation: PresentationElement;
+    [property: string]: any;
+}
+
+export enum PresentationUpdatedMessageEvent {
+    PresentationUpdated = "presentation_updated",
 }
 
 export interface PresentCloseMessage {
@@ -4014,7 +4068,7 @@ export interface PresentFile {
 }
 
 export interface PresentManifestView {
-    files:    FileElement[];
+    files:    ChangedFileElement[];
     skip:     string[];
     summary?: string;
     title:    string;
@@ -4079,65 +4133,24 @@ export enum PresentSubmitRoundResultMessageEvent {
     PresentSubmitRoundResult = "present_submit_round_result",
 }
 
-export interface Presentation {
-    created_at:             string;
-    id:                     string;
-    kind:                   string;
-    latest_round_seq:       number;
-    latest_round_submitted: boolean;
-    repo_path:              string;
-    session_id:             string;
-    status:                 string;
-    ticket_id?:             string;
-    title:                  string;
+export interface PRsUpdatedMessage {
+    event: PRsUpdatedMessageEvent;
+    prs?:  PRElement[];
     [property: string]: any;
 }
 
-export interface PresentationAddedMessage {
-    event:        PresentationAddedMessageEvent;
-    presentation: PresentationElement;
+export enum PRsUpdatedMessageEvent {
+    PrsUpdated = "prs_updated",
+}
+
+export interface PRVisitedMessage {
+    cmd: PRVisitedMessageCmd;
+    id:  string;
     [property: string]: any;
 }
 
-export enum PresentationAddedMessageEvent {
-    PresentationAdded = "presentation_added",
-}
-
-export interface PresentationComment {
-    author:     string;
-    content:    string;
-    created_at: string;
-    filepath:   string;
-    id:         string;
-    line_end:   number;
-    line_start: number;
-    round_id:   string;
-    side:       string;
-    [property: string]: any;
-}
-
-export interface PresentationRound {
-    base_sha:        string;
-    changed_files?:  FileElement[];
-    created_at:      string;
-    head_sha:        string;
-    id:              string;
-    manifest:        Manifest;
-    presentation_id: string;
-    seq:             number;
-    submitted_at?:   string;
-    verdict?:        string;
-    [property: string]: any;
-}
-
-export interface PresentationUpdatedMessage {
-    event:        PresentationUpdatedMessageEvent;
-    presentation: PresentationElement;
-    [property: string]: any;
-}
-
-export enum PresentationUpdatedMessageEvent {
-    PresentationUpdated = "presentation_updated",
+export enum PRVisitedMessageCmd {
+    PRVisited = "pr_visited",
 }
 
 export interface PtyDesyncMessage {
@@ -4175,20 +4188,6 @@ export enum PtyOutputMessageEvent {
     PtyOutput = "pty_output",
 }
 
-export interface PtyResizeMessage {
-    cmd:     PtyResizeMessageCmd;
-    cols:    number;
-    id:      string;
-    rows:    number;
-    xpixel?: number;
-    ypixel?: number;
-    [property: string]: any;
-}
-
-export enum PtyResizeMessageCmd {
-    PtyResize = "pty_resize",
-}
-
 export interface PtyResizedMessage {
     cols:    number;
     event:   PtyResizedMessageEvent;
@@ -4201,6 +4200,20 @@ export interface PtyResizedMessage {
 
 export enum PtyResizedMessageEvent {
     PtyResized = "pty_resized",
+}
+
+export interface PtyResizeMessage {
+    cmd:     PtyResizeMessageCmd;
+    cols:    number;
+    id:      string;
+    rows:    number;
+    xpixel?: number;
+    ypixel?: number;
+    [property: string]: any;
+}
+
+export enum PtyResizeMessageCmd {
+    PtyResize = "pty_resize",
 }
 
 export interface QueryAuthorsMessage {
@@ -4268,7 +4281,7 @@ export enum RecentFilesMessageCmd {
 export interface RecentFilesResultMessage {
     error?:     string;
     event:      RecentFilesResultMessageEvent;
-    files:      FileObject[];
+    files:      FileElement[];
     request_id: string;
     success:    boolean;
     [property: string]: any;
@@ -4278,7 +4291,7 @@ export enum RecentFilesResultMessageEvent {
     RecentFilesResult = "recent_files_result",
 }
 
-export interface FileObject {
+export interface FileElement {
     count:       number;
     last_at:     string;
     path:        string;
@@ -5133,6 +5146,16 @@ export enum SessionStateChangedMessageEvent {
     SessionStateChanged = "session_state_changed",
 }
 
+export interface SessionsUpdatedMessage {
+    event:     SessionsUpdatedMessageEvent;
+    sessions?: SessionObject[];
+    [property: string]: any;
+}
+
+export enum SessionsUpdatedMessageEvent {
+    SessionsUpdated = "sessions_updated",
+}
+
 export interface SessionTodosUpdatedMessage {
     event:   SessionTodosUpdatedMessageEvent;
     session: SessionObject;
@@ -5182,16 +5205,6 @@ export interface SessionUnregisteredMessage {
 
 export enum SessionUnregisteredMessageEvent {
     SessionUnregistered = "session_unregistered",
-}
-
-export interface SessionsUpdatedMessage {
-    event:     SessionsUpdatedMessageEvent;
-    sessions?: SessionObject[];
-    [property: string]: any;
-}
-
-export enum SessionsUpdatedMessageEvent {
-    SessionsUpdated = "sessions_updated",
 }
 
 export interface SetChiefOfStaffMessage {
@@ -5254,7 +5267,6 @@ export interface SetSessionResumeIDMessage {
     cmd:               SetSessionResumeIDMessageCmd;
     id:                string;
     resume_session_id: string;
-    transcript_path?:  string;
     [property: string]: any;
 }
 
@@ -5307,18 +5319,6 @@ export enum DispatchWorkState {
     ReadyForReview = "ready_for_review",
 }
 
-export interface SetWorkspaceRankMessage {
-    cmd:                SetWorkspaceRankMessageCmd;
-    next_workspace_id?: string;
-    prev_workspace_id?: string;
-    workspace_id:       string;
-    [property: string]: any;
-}
-
-export enum SetWorkspaceRankMessageCmd {
-    SetWorkspaceRank = "set_workspace_rank",
-}
-
 export interface SettingsUpdatedMessage {
     changed_key?: string;
     error?:       string;
@@ -5340,6 +5340,18 @@ export interface SettleTurnMessage {
 
 export enum SettleTurnMessageCmd {
     SettleTurn = "settle_turn",
+}
+
+export interface SetWorkspaceRankMessage {
+    cmd:                SetWorkspaceRankMessageCmd;
+    next_workspace_id?: string;
+    prev_workspace_id?: string;
+    workspace_id:       string;
+    [property: string]: any;
+}
+
+export enum SetWorkspaceRankMessageCmd {
+    SetWorkspaceRank = "set_workspace_rank",
 }
 
 export interface SnoozeTurnMessage {
@@ -5637,7 +5649,7 @@ export interface TicketAttachMessage {
     cmd:                 TicketAttachMessageCmd;
     comment?:            string;
     expected_event_seq?: number;
-    files:               TicketAttachMessageFile[];
+    files:               FileObject[];
     request_id?:         string;
     source_session_id:   string;
     state?:              DispatchWorkState;
@@ -5649,7 +5661,7 @@ export enum TicketAttachMessageCmd {
     TicketAttach = "ticket_attach",
 }
 
-export interface TicketAttachMessageFile {
+export interface FileObject {
     filename:    string;
     source_path: string;
     [property: string]: any;
@@ -5884,6 +5896,16 @@ export interface TicketSubscribeResult {
     [property: string]: any;
 }
 
+export interface TicketsUpdatedMessage {
+    event:   TicketsUpdatedMessageEvent;
+    tickets: TicketElement[];
+    [property: string]: any;
+}
+
+export enum TicketsUpdatedMessageEvent {
+    TicketsUpdated = "tickets_updated",
+}
+
 export interface TicketTakeMessage {
     cmd:               TicketTakeMessageCmd;
     confirm?:          boolean;
@@ -5917,16 +5939,6 @@ export enum TicketUnsubscribeMessageCmd {
 export interface TicketUnsubscribeResult {
     ticket_id: string;
     [property: string]: any;
-}
-
-export interface TicketsUpdatedMessage {
-    event:   TicketsUpdatedMessageEvent;
-    tickets: TicketElement[];
-    [property: string]: any;
-}
-
-export enum TicketsUpdatedMessageEvent {
-    TicketsUpdated = "tickets_updated",
 }
 
 export interface TodosMessage {
@@ -6610,6 +6622,16 @@ export enum WorkspaceLayoutUndockTileMessageCmd {
     WorkspaceLayoutUndockTile = "workspace_layout_undock_tile",
 }
 
+export interface WorkspaceLayoutUpdatedMessage {
+    event:            WorkspaceLayoutUpdatedMessageEvent;
+    workspace_layout: Layout;
+    [property: string]: any;
+}
+
+export enum WorkspaceLayoutUpdatedMessageEvent {
+    WorkspaceLayoutUpdated = "workspace_layout_updated",
+}
+
 export interface WorkspaceLayoutUpdateTileMessage {
     cmd:              WorkspaceLayoutUpdateTileMessageCmd;
     request_id:       string;
@@ -6622,16 +6644,6 @@ export interface WorkspaceLayoutUpdateTileMessage {
 
 export enum WorkspaceLayoutUpdateTileMessageCmd {
     WorkspaceLayoutUpdateTile = "workspace_layout_update_tile",
-}
-
-export interface WorkspaceLayoutUpdatedMessage {
-    event:            WorkspaceLayoutUpdatedMessageEvent;
-    workspace_layout: Layout;
-    [property: string]: any;
-}
-
-export enum WorkspaceLayoutUpdatedMessageEvent {
-    WorkspaceLayoutUpdated = "workspace_layout_updated",
 }
 
 export interface WorkspaceRegisteredMessage {
@@ -6941,14 +6953,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AutomationDefinitionResultMessage")), null, 2);
     }
 
-    public static toAutomationDefinitionSummary(json: string): AutomationDefinitionSummary {
-        return cast(JSON.parse(json), r("AutomationDefinitionSummary"));
-    }
-
-    public static automationDefinitionSummaryToJson(value: AutomationDefinitionSummary): string {
-        return JSON.stringify(uncast(value, r("AutomationDefinitionSummary")), null, 2);
-    }
-
     public static toAutomationDefinitionsGetMessage(json: string): AutomationDefinitionsGetMessage {
         return cast(JSON.parse(json), r("AutomationDefinitionsGetMessage"));
     }
@@ -6963,6 +6967,14 @@ export class Convert {
 
     public static automationDefinitionsResultMessageToJson(value: AutomationDefinitionsResultMessage): string {
         return JSON.stringify(uncast(value, r("AutomationDefinitionsResultMessage")), null, 2);
+    }
+
+    public static toAutomationDefinitionSummary(json: string): AutomationDefinitionSummary {
+        return cast(JSON.parse(json), r("AutomationDefinitionSummary"));
+    }
+
+    public static automationDefinitionSummaryToJson(value: AutomationDefinitionSummary): string {
+        return JSON.stringify(uncast(value, r("AutomationDefinitionSummary")), null, 2);
     }
 
     public static toAutomationDeleteMessage(json: string): AutomationDeleteMessage {
@@ -6997,14 +7009,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AutomationRunResultMessage")), null, 2);
     }
 
-    public static toAutomationRunSummary(json: string): AutomationRunSummary {
-        return cast(JSON.parse(json), r("AutomationRunSummary"));
-    }
-
-    public static automationRunSummaryToJson(value: AutomationRunSummary): string {
-        return JSON.stringify(uncast(value, r("AutomationRunSummary")), null, 2);
-    }
-
     public static toAutomationRunsGetMessage(json: string): AutomationRunsGetMessage {
         return cast(JSON.parse(json), r("AutomationRunsGetMessage"));
     }
@@ -7019,6 +7023,22 @@ export class Convert {
 
     public static automationRunsResultMessageToJson(value: AutomationRunsResultMessage): string {
         return JSON.stringify(uncast(value, r("AutomationRunsResultMessage")), null, 2);
+    }
+
+    public static toAutomationRunSummary(json: string): AutomationRunSummary {
+        return cast(JSON.parse(json), r("AutomationRunSummary"));
+    }
+
+    public static automationRunSummaryToJson(value: AutomationRunSummary): string {
+        return JSON.stringify(uncast(value, r("AutomationRunSummary")), null, 2);
+    }
+
+    public static toAutomationsChangedMessage(json: string): AutomationsChangedMessage {
+        return cast(JSON.parse(json), r("AutomationsChangedMessage"));
+    }
+
+    public static automationsChangedMessageToJson(value: AutomationsChangedMessage): string {
+        return JSON.stringify(uncast(value, r("AutomationsChangedMessage")), null, 2);
     }
 
     public static toAutomationSetEnabledMessage(json: string): AutomationSetEnabledMessage {
@@ -7051,14 +7071,6 @@ export class Convert {
 
     public static automationValidateResultMessageToJson(value: AutomationValidateResultMessage): string {
         return JSON.stringify(uncast(value, r("AutomationValidateResultMessage")), null, 2);
-    }
-
-    public static toAutomationsChangedMessage(json: string): AutomationsChangedMessage {
-        return cast(JSON.parse(json), r("AutomationsChangedMessage"));
-    }
-
-    public static automationsChangedMessageToJson(value: AutomationsChangedMessage): string {
-        return JSON.stringify(uncast(value, r("AutomationsChangedMessage")), null, 2);
     }
 
     public static toBootstrapEndpointMessage(json: string): BootstrapEndpointMessage {
@@ -7477,22 +7489,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("DocSubscribeResult")), null, 2);
     }
 
-    public static toDocUndefineMessage(json: string): DocUndefineMessage {
-        return cast(JSON.parse(json), r("DocUndefineMessage"));
-    }
-
-    public static docUndefineMessageToJson(value: DocUndefineMessage): string {
-        return JSON.stringify(uncast(value, r("DocUndefineMessage")), null, 2);
-    }
-
-    public static toDocUndefineResult(json: string): DocUndefineResult {
-        return cast(JSON.parse(json), r("DocUndefineResult"));
-    }
-
-    public static docUndefineResultToJson(value: DocUndefineResult): string {
-        return JSON.stringify(uncast(value, r("DocUndefineResult")), null, 2);
-    }
-
     public static toDocumentCollectionSchema(json: string): DocumentCollectionSchema {
         return cast(JSON.parse(json), r("DocumentCollectionSchema"));
     }
@@ -7547,6 +7543,22 @@ export class Convert {
 
     public static documentSortToJson(value: DocumentSort): string {
         return JSON.stringify(uncast(value, r("DocumentSort")), null, 2);
+    }
+
+    public static toDocUndefineMessage(json: string): DocUndefineMessage {
+        return cast(JSON.parse(json), r("DocUndefineMessage"));
+    }
+
+    public static docUndefineMessageToJson(value: DocUndefineMessage): string {
+        return JSON.stringify(uncast(value, r("DocUndefineMessage")), null, 2);
+    }
+
+    public static toDocUndefineResult(json: string): DocUndefineResult {
+        return cast(JSON.parse(json), r("DocUndefineResult"));
+    }
+
+    public static docUndefineResultToJson(value: DocUndefineResult): string {
+        return JSON.stringify(uncast(value, r("DocUndefineResult")), null, 2);
     }
 
     public static toEndpointActionResultMessage(json: string): EndpointActionResultMessage {
@@ -8573,6 +8585,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("NotificationMarkReadResultMessage")), null, 2);
     }
 
+    public static toNotificationSeverity(json: string): NotificationSeverity {
+        return cast(JSON.parse(json), r("NotificationSeverity"));
+    }
+
+    public static notificationSeverityToJson(value: NotificationSeverity): string {
+        return JSON.stringify(uncast(value, r("NotificationSeverity")), null, 2);
+    }
+
     public static toNotificationsUpdatedMessage(json: string): NotificationsUpdatedMessage {
         return cast(JSON.parse(json), r("NotificationsUpdatedMessage"));
     }
@@ -8603,46 +8623,6 @@ export class Convert {
 
     public static openMarkdownResultMessageToJson(value: OpenMarkdownResultMessage): string {
         return JSON.stringify(uncast(value, r("OpenMarkdownResultMessage")), null, 2);
-    }
-
-    public static toPR(json: string): PR {
-        return cast(JSON.parse(json), r("PR"));
-    }
-
-    public static pRToJson(value: PR): string {
-        return JSON.stringify(uncast(value, r("PR")), null, 2);
-    }
-
-    public static toPRActionResultMessage(json: string): PRActionResultMessage {
-        return cast(JSON.parse(json), r("PRActionResultMessage"));
-    }
-
-    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
-        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
-    }
-
-    public static toPRRole(json: string): PRRole {
-        return cast(JSON.parse(json), r("PRRole"));
-    }
-
-    public static pRRoleToJson(value: PRRole): string {
-        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
-    }
-
-    public static toPRVisitedMessage(json: string): PRVisitedMessage {
-        return cast(JSON.parse(json), r("PRVisitedMessage"));
-    }
-
-    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
-        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
-    }
-
-    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
-        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
-    }
-
-    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
     }
 
     public static toPastConversation(json: string): PastConversation {
@@ -8717,12 +8697,68 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PluginsUpdatedMessage")), null, 2);
     }
 
+    public static toPR(json: string): PR {
+        return cast(JSON.parse(json), r("PR"));
+    }
+
+    public static pRToJson(value: PR): string {
+        return JSON.stringify(uncast(value, r("PR")), null, 2);
+    }
+
+    public static toPRActionResultMessage(json: string): PRActionResultMessage {
+        return cast(JSON.parse(json), r("PRActionResultMessage"));
+    }
+
+    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
+        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
+    }
+
     public static toPresentAnnotation(json: string): PresentAnnotation {
         return cast(JSON.parse(json), r("PresentAnnotation"));
     }
 
     public static presentAnnotationToJson(value: PresentAnnotation): string {
         return JSON.stringify(uncast(value, r("PresentAnnotation")), null, 2);
+    }
+
+    public static toPresentation(json: string): Presentation {
+        return cast(JSON.parse(json), r("Presentation"));
+    }
+
+    public static presentationToJson(value: Presentation): string {
+        return JSON.stringify(uncast(value, r("Presentation")), null, 2);
+    }
+
+    public static toPresentationAddedMessage(json: string): PresentationAddedMessage {
+        return cast(JSON.parse(json), r("PresentationAddedMessage"));
+    }
+
+    public static presentationAddedMessageToJson(value: PresentationAddedMessage): string {
+        return JSON.stringify(uncast(value, r("PresentationAddedMessage")), null, 2);
+    }
+
+    public static toPresentationComment(json: string): PresentationComment {
+        return cast(JSON.parse(json), r("PresentationComment"));
+    }
+
+    public static presentationCommentToJson(value: PresentationComment): string {
+        return JSON.stringify(uncast(value, r("PresentationComment")), null, 2);
+    }
+
+    public static toPresentationRound(json: string): PresentationRound {
+        return cast(JSON.parse(json), r("PresentationRound"));
+    }
+
+    public static presentationRoundToJson(value: PresentationRound): string {
+        return JSON.stringify(uncast(value, r("PresentationRound")), null, 2);
+    }
+
+    public static toPresentationUpdatedMessage(json: string): PresentationUpdatedMessage {
+        return cast(JSON.parse(json), r("PresentationUpdatedMessage"));
+    }
+
+    public static presentationUpdatedMessageToJson(value: PresentationUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("PresentationUpdatedMessage")), null, 2);
     }
 
     public static toPresentCloseMessage(json: string): PresentCloseMessage {
@@ -8813,44 +8849,28 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PresentSubmitRoundResultMessage")), null, 2);
     }
 
-    public static toPresentation(json: string): Presentation {
-        return cast(JSON.parse(json), r("Presentation"));
+    public static toPRRole(json: string): PRRole {
+        return cast(JSON.parse(json), r("PRRole"));
     }
 
-    public static presentationToJson(value: Presentation): string {
-        return JSON.stringify(uncast(value, r("Presentation")), null, 2);
+    public static pRRoleToJson(value: PRRole): string {
+        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
     }
 
-    public static toPresentationAddedMessage(json: string): PresentationAddedMessage {
-        return cast(JSON.parse(json), r("PresentationAddedMessage"));
+    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
+        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
     }
 
-    public static presentationAddedMessageToJson(value: PresentationAddedMessage): string {
-        return JSON.stringify(uncast(value, r("PresentationAddedMessage")), null, 2);
+    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
     }
 
-    public static toPresentationComment(json: string): PresentationComment {
-        return cast(JSON.parse(json), r("PresentationComment"));
+    public static toPRVisitedMessage(json: string): PRVisitedMessage {
+        return cast(JSON.parse(json), r("PRVisitedMessage"));
     }
 
-    public static presentationCommentToJson(value: PresentationComment): string {
-        return JSON.stringify(uncast(value, r("PresentationComment")), null, 2);
-    }
-
-    public static toPresentationRound(json: string): PresentationRound {
-        return cast(JSON.parse(json), r("PresentationRound"));
-    }
-
-    public static presentationRoundToJson(value: PresentationRound): string {
-        return JSON.stringify(uncast(value, r("PresentationRound")), null, 2);
-    }
-
-    public static toPresentationUpdatedMessage(json: string): PresentationUpdatedMessage {
-        return cast(JSON.parse(json), r("PresentationUpdatedMessage"));
-    }
-
-    public static presentationUpdatedMessageToJson(value: PresentationUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("PresentationUpdatedMessage")), null, 2);
+    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
+        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
     }
 
     public static toPtyDesyncMessage(json: string): PtyDesyncMessage {
@@ -8877,20 +8897,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PtyOutputMessage")), null, 2);
     }
 
-    public static toPtyResizeMessage(json: string): PtyResizeMessage {
-        return cast(JSON.parse(json), r("PtyResizeMessage"));
-    }
-
-    public static ptyResizeMessageToJson(value: PtyResizeMessage): string {
-        return JSON.stringify(uncast(value, r("PtyResizeMessage")), null, 2);
-    }
-
     public static toPtyResizedMessage(json: string): PtyResizedMessage {
         return cast(JSON.parse(json), r("PtyResizedMessage"));
     }
 
     public static ptyResizedMessageToJson(value: PtyResizedMessage): string {
         return JSON.stringify(uncast(value, r("PtyResizedMessage")), null, 2);
+    }
+
+    public static toPtyResizeMessage(json: string): PtyResizeMessage {
+        return cast(JSON.parse(json), r("PtyResizeMessage"));
+    }
+
+    public static ptyResizeMessageToJson(value: PtyResizeMessage): string {
+        return JSON.stringify(uncast(value, r("PtyResizeMessage")), null, 2);
     }
 
     public static toQueryAuthorsMessage(json: string): QueryAuthorsMessage {
@@ -9269,6 +9289,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SessionStateChangedMessage")), null, 2);
     }
 
+    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
+        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
+    }
+
+    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
+    }
+
     public static toSessionTodosUpdatedMessage(json: string): SessionTodosUpdatedMessage {
         return cast(JSON.parse(json), r("SessionTodosUpdatedMessage"));
     }
@@ -9307,14 +9335,6 @@ export class Convert {
 
     public static sessionUnregisteredMessageToJson(value: SessionUnregisteredMessage): string {
         return JSON.stringify(uncast(value, r("SessionUnregisteredMessage")), null, 2);
-    }
-
-    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
-        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
-    }
-
-    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
     }
 
     public static toSetChiefOfStaffMessage(json: string): SetChiefOfStaffMessage {
@@ -9389,14 +9409,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SetTicketStatusMessage")), null, 2);
     }
 
-    public static toSetWorkspaceRankMessage(json: string): SetWorkspaceRankMessage {
-        return cast(JSON.parse(json), r("SetWorkspaceRankMessage"));
-    }
-
-    public static setWorkspaceRankMessageToJson(value: SetWorkspaceRankMessage): string {
-        return JSON.stringify(uncast(value, r("SetWorkspaceRankMessage")), null, 2);
-    }
-
     public static toSettingsUpdatedMessage(json: string): SettingsUpdatedMessage {
         return cast(JSON.parse(json), r("SettingsUpdatedMessage"));
     }
@@ -9411,6 +9423,14 @@ export class Convert {
 
     public static settleTurnMessageToJson(value: SettleTurnMessage): string {
         return JSON.stringify(uncast(value, r("SettleTurnMessage")), null, 2);
+    }
+
+    public static toSetWorkspaceRankMessage(json: string): SetWorkspaceRankMessage {
+        return cast(JSON.parse(json), r("SetWorkspaceRankMessage"));
+    }
+
+    public static setWorkspaceRankMessageToJson(value: SetWorkspaceRankMessage): string {
+        return JSON.stringify(uncast(value, r("SetWorkspaceRankMessage")), null, 2);
     }
 
     public static toSnoozeTurnMessage(json: string): SnoozeTurnMessage {
@@ -9813,6 +9833,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("TicketSubscribeResult")), null, 2);
     }
 
+    public static toTicketsUpdatedMessage(json: string): TicketsUpdatedMessage {
+        return cast(JSON.parse(json), r("TicketsUpdatedMessage"));
+    }
+
+    public static ticketsUpdatedMessageToJson(value: TicketsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("TicketsUpdatedMessage")), null, 2);
+    }
+
     public static toTicketTakeMessage(json: string): TicketTakeMessage {
         return cast(JSON.parse(json), r("TicketTakeMessage"));
     }
@@ -9843,14 +9871,6 @@ export class Convert {
 
     public static ticketUnsubscribeResultToJson(value: TicketUnsubscribeResult): string {
         return JSON.stringify(uncast(value, r("TicketUnsubscribeResult")), null, 2);
-    }
-
-    public static toTicketsUpdatedMessage(json: string): TicketsUpdatedMessage {
-        return cast(JSON.parse(json), r("TicketsUpdatedMessage"));
-    }
-
-    public static ticketsUpdatedMessageToJson(value: TicketsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("TicketsUpdatedMessage")), null, 2);
     }
 
     public static toTodosMessage(json: string): TodosMessage {
@@ -10277,20 +10297,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUndockTileMessage")), null, 2);
     }
 
-    public static toWorkspaceLayoutUpdateTileMessage(json: string): WorkspaceLayoutUpdateTileMessage {
-        return cast(JSON.parse(json), r("WorkspaceLayoutUpdateTileMessage"));
-    }
-
-    public static workspaceLayoutUpdateTileMessageToJson(value: WorkspaceLayoutUpdateTileMessage): string {
-        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdateTileMessage")), null, 2);
-    }
-
     public static toWorkspaceLayoutUpdatedMessage(json: string): WorkspaceLayoutUpdatedMessage {
         return cast(JSON.parse(json), r("WorkspaceLayoutUpdatedMessage"));
     }
 
     public static workspaceLayoutUpdatedMessageToJson(value: WorkspaceLayoutUpdatedMessage): string {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdatedMessage")), null, 2);
+    }
+
+    public static toWorkspaceLayoutUpdateTileMessage(json: string): WorkspaceLayoutUpdateTileMessage {
+        return cast(JSON.parse(json), r("WorkspaceLayoutUpdateTileMessage"));
+    }
+
+    public static workspaceLayoutUpdateTileMessageToJson(value: WorkspaceLayoutUpdateTileMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdateTileMessage")), null, 2);
     }
 
     public static toWorkspaceRegisteredMessage(json: string): WorkspaceRegisteredMessage {
@@ -10762,17 +10782,6 @@ const typeMap: any = {
         { json: "spec_yaml", js: "spec_yaml", typ: u(undefined, "") },
         { json: "success", js: "success", typ: true },
     ], "any"),
-    "AutomationDefinitionSummary": o([
-        { json: "enabled", js: "enabled", typ: true },
-        { json: "id", js: "id", typ: "" },
-        { json: "last_run", js: "last_run", typ: u(undefined, r("LastRun")) },
-        { json: "name", js: "name", typ: "" },
-        { json: "revision", js: "revision", typ: 0 },
-        { json: "schedule_cron", js: "schedule_cron", typ: u(undefined, "") },
-        { json: "schedule_time_zone", js: "schedule_time_zone", typ: u(undefined, "") },
-        { json: "trigger_type", js: "trigger_type", typ: "" },
-        { json: "updated_at", js: "updated_at", typ: "" },
-    ], "any"),
     "AutomationDefinitionsGetMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationDefinitionsGetMessageCmd") },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
@@ -10783,6 +10792,17 @@ const typeMap: any = {
         { json: "event", js: "event", typ: r("AutomationDefinitionsResultMessageEvent") },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
         { json: "success", js: "success", typ: true },
+    ], "any"),
+    "AutomationDefinitionSummary": o([
+        { json: "enabled", js: "enabled", typ: true },
+        { json: "id", js: "id", typ: "" },
+        { json: "last_run", js: "last_run", typ: u(undefined, r("LastRun")) },
+        { json: "name", js: "name", typ: "" },
+        { json: "revision", js: "revision", typ: 0 },
+        { json: "schedule_cron", js: "schedule_cron", typ: u(undefined, "") },
+        { json: "schedule_time_zone", js: "schedule_time_zone", typ: u(undefined, "") },
+        { json: "trigger_type", js: "trigger_type", typ: "" },
+        { json: "updated_at", js: "updated_at", typ: "" },
     ], "any"),
     "AutomationDeleteMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationDeleteMessageCmd") },
@@ -10809,6 +10829,20 @@ const typeMap: any = {
         { json: "run", js: "run", typ: u(undefined, r("LastRun")) },
         { json: "success", js: "success", typ: true },
     ], "any"),
+    "AutomationRunsGetMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AutomationRunsGetMessageCmd") },
+        { json: "definition_id", js: "definition_id", typ: "" },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    ], "any"),
+    "AutomationRunsResultMessage": o([
+        { json: "definition_id", js: "definition_id", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("AutomationRunsResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "runs", js: "runs", typ: u(undefined, a(r("LastRun"))) },
+        { json: "success", js: "success", typ: true },
+        { json: "truncated", js: "truncated", typ: u(undefined, true) },
+    ], "any"),
     "AutomationRunSummary": o([
         { json: "cancel_reason", js: "cancel_reason", typ: u(undefined, "") },
         { json: "created_at", js: "created_at", typ: "" },
@@ -10823,19 +10857,9 @@ const typeMap: any = {
         { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
         { json: "updated_at", js: "updated_at", typ: "" },
     ], "any"),
-    "AutomationRunsGetMessage": o([
-        { json: "cmd", js: "cmd", typ: r("AutomationRunsGetMessageCmd") },
-        { json: "definition_id", js: "definition_id", typ: "" },
-        { json: "request_id", js: "request_id", typ: u(undefined, "") },
-    ], "any"),
-    "AutomationRunsResultMessage": o([
-        { json: "definition_id", js: "definition_id", typ: "" },
-        { json: "error", js: "error", typ: u(undefined, "") },
-        { json: "event", js: "event", typ: r("AutomationRunsResultMessageEvent") },
-        { json: "request_id", js: "request_id", typ: u(undefined, "") },
-        { json: "runs", js: "runs", typ: u(undefined, a(r("LastRun"))) },
-        { json: "success", js: "success", typ: true },
-        { json: "truncated", js: "truncated", typ: u(undefined, true) },
+    "AutomationsChangedMessage": o([
+        { json: "definition_ids", js: "definition_ids", typ: a("") },
+        { json: "event", js: "event", typ: r("AutomationsChangedMessageEvent") },
     ], "any"),
     "AutomationSetEnabledMessage": o([
         { json: "cmd", js: "cmd", typ: r("AutomationSetEnabledMessageCmd") },
@@ -10860,10 +10884,6 @@ const typeMap: any = {
         { json: "event", js: "event", typ: r("AutomationValidateResultMessageEvent") },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
         { json: "success", js: "success", typ: true },
-    ], "any"),
-    "AutomationsChangedMessage": o([
-        { json: "definition_ids", js: "definition_ids", typ: a("") },
-        { json: "event", js: "event", typ: r("AutomationsChangedMessageEvent") },
     ], "any"),
     "BootstrapEndpointMessage": o([
         { json: "cmd", js: "cmd", typ: r("BootstrapEndpointMessageCmd") },
@@ -11284,16 +11304,6 @@ const typeMap: any = {
         { json: "order", js: "order", typ: a("") },
         { json: "upsert", js: "upsert", typ: a(r("Document")) },
     ], "any"),
-    "DocUndefineMessage": o([
-        { json: "cmd", js: "cmd", typ: r("DocUndefineMessageCmd") },
-        { json: "collection", js: "collection", typ: "" },
-        { json: "namespace", js: "namespace", typ: "" },
-    ], "any"),
-    "DocUndefineResult": o([
-        { json: "collection", js: "collection", typ: "" },
-        { json: "documents_removed", js: "documents_removed", typ: 0 },
-        { json: "namespace", js: "namespace", typ: "" },
-    ], "any"),
     "DocumentCollectionSchema": o([
         { json: "collection", js: "collection", typ: "" },
         { json: "fields", js: "fields", typ: a(r("FieldElement")) },
@@ -11331,6 +11341,16 @@ const typeMap: any = {
     "DocumentSort": o([
         { json: "desc", js: "desc", typ: u(undefined, true) },
         { json: "field", js: "field", typ: "" },
+    ], "any"),
+    "DocUndefineMessage": o([
+        { json: "cmd", js: "cmd", typ: r("DocUndefineMessageCmd") },
+        { json: "collection", js: "collection", typ: "" },
+        { json: "namespace", js: "namespace", typ: "" },
+    ], "any"),
+    "DocUndefineResult": o([
+        { json: "collection", js: "collection", typ: "" },
+        { json: "documents_removed", js: "documents_removed", typ: 0 },
+        { json: "namespace", js: "namespace", typ: "" },
     ], "any"),
     "EndpointActionResultMessage": o([
         { json: "action", js: "action", typ: "" },
@@ -11752,7 +11772,7 @@ const typeMap: any = {
     ], "any"),
     "Round": o([
         { json: "base_sha", js: "base_sha", typ: "" },
-        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("FileElement"))) },
+        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("ChangedFileElement"))) },
         { json: "created_at", js: "created_at", typ: "" },
         { json: "head_sha", js: "head_sha", typ: "" },
         { json: "id", js: "id", typ: "" },
@@ -11762,7 +11782,7 @@ const typeMap: any = {
         { json: "submitted_at", js: "submitted_at", typ: u(undefined, "") },
         { json: "verdict", js: "verdict", typ: u(undefined, "") },
     ], "any"),
-    "FileElement": o([
+    "ChangedFileElement": o([
         { json: "additions", js: "additions", typ: u(undefined, 0) },
         { json: "annotations", js: "annotations", typ: u(undefined, a(r("AnnotationElement"))) },
         { json: "deletions", js: "deletions", typ: u(undefined, 0) },
@@ -11775,7 +11795,7 @@ const typeMap: any = {
         { json: "line_start", js: "line_start", typ: 0 },
     ], "any"),
     "Manifest": o([
-        { json: "files", js: "files", typ: a(r("FileElement")) },
+        { json: "files", js: "files", typ: a(r("ChangedFileElement")) },
         { json: "skip", js: "skip", typ: a("") },
         { json: "summary", js: "summary", typ: u(undefined, "") },
         { json: "title", js: "title", typ: "" },
@@ -12393,6 +12413,7 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "kind", js: "kind", typ: "" },
         { json: "read_at", js: "read_at", typ: "" },
+        { json: "severity", js: "severity", typ: r("NotificationSeverity") },
         { json: "source_id", js: "source_id", typ: "" },
         { json: "source_kind", js: "source_kind", typ: "" },
         { json: "title", js: "title", typ: "" },
@@ -12402,12 +12423,14 @@ const typeMap: any = {
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
     ], "any"),
     "NotificationListResultMessage": o([
+        { json: "critical_title", js: "critical_title", typ: u(undefined, "") },
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("NotificationListResultMessageEvent") },
         { json: "notifications", js: "notifications", typ: u(undefined, a(r("NotificationElement"))) },
         { json: "request_id", js: "request_id", typ: "" },
         { json: "success", js: "success", typ: true },
         { json: "unread_count", js: "unread_count", typ: 0 },
+        { json: "unread_critical_count", js: "unread_critical_count", typ: 0 },
     ], "any"),
     "NotificationElement": o([
         { json: "body", js: "body", typ: "" },
@@ -12416,6 +12439,7 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "kind", js: "kind", typ: "" },
         { json: "read_at", js: "read_at", typ: "" },
+        { json: "severity", js: "severity", typ: r("NotificationSeverity") },
         { json: "source_id", js: "source_id", typ: "" },
         { json: "source_kind", js: "source_kind", typ: "" },
         { json: "title", js: "title", typ: "" },
@@ -12433,8 +12457,10 @@ const typeMap: any = {
         { json: "unread_count", js: "unread_count", typ: 0 },
     ], "any"),
     "NotificationsUpdatedMessage": o([
+        { json: "critical_title", js: "critical_title", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("NotificationsUpdatedMessageEvent") },
         { json: "unread_count", js: "unread_count", typ: 0 },
+        { json: "unread_critical_count", js: "unread_critical_count", typ: 0 },
     ], "any"),
     "OpenBrowserMessage": o([
         { json: "cmd", js: "cmd", typ: r("OpenBrowserMessageCmd") },
@@ -12455,49 +12481,6 @@ const typeMap: any = {
         { json: "success", js: "success", typ: true },
         { json: "tile_id", js: "tile_id", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
-    ], "any"),
-    "PR": o([
-        { json: "approved_by_me", js: "approved_by_me", typ: true },
-        { json: "author", js: "author", typ: "" },
-        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
-        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
-        { json: "details_fetched", js: "details_fetched", typ: true },
-        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
-        { json: "has_new_changes", js: "has_new_changes", typ: true },
-        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
-        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
-        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
-        { json: "host", js: "host", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
-        { json: "last_polled", js: "last_polled", typ: "" },
-        { json: "last_updated", js: "last_updated", typ: "" },
-        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
-        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
-        { json: "muted", js: "muted", typ: true },
-        { json: "number", js: "number", typ: 0 },
-        { json: "reason", js: "reason", typ: "" },
-        { json: "repo", js: "repo", typ: "" },
-        { json: "review_status", js: "review_status", typ: u(undefined, "") },
-        { json: "role", js: "role", typ: r("PRRole") },
-        { json: "state", js: "state", typ: "" },
-        { json: "title", js: "title", typ: "" },
-        { json: "url", js: "url", typ: "" },
-    ], "any"),
-    "PRActionResultMessage": o([
-        { json: "action", js: "action", typ: "" },
-        { json: "error", js: "error", typ: u(undefined, "") },
-        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
-        { json: "id", js: "id", typ: "" },
-        { json: "success", js: "success", typ: true },
-    ], "any"),
-    "PRVisitedMessage": o([
-        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
-        { json: "id", js: "id", typ: "" },
-    ], "any"),
-    "PRsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
-        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
     ], "any"),
     "PastConversation": o([
         { json: "bytes", js: "bytes", typ: 0 },
@@ -12605,10 +12588,88 @@ const typeMap: any = {
         { json: "runtime_state", js: "runtime_state", typ: "" },
         { json: "version", js: "version", typ: "" },
     ], "any"),
+    "PR": o([
+        { json: "approved_by_me", js: "approved_by_me", typ: true },
+        { json: "author", js: "author", typ: "" },
+        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
+        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
+        { json: "details_fetched", js: "details_fetched", typ: true },
+        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
+        { json: "has_new_changes", js: "has_new_changes", typ: true },
+        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
+        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
+        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
+        { json: "host", js: "host", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
+        { json: "last_polled", js: "last_polled", typ: "" },
+        { json: "last_updated", js: "last_updated", typ: "" },
+        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
+        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
+        { json: "muted", js: "muted", typ: true },
+        { json: "number", js: "number", typ: 0 },
+        { json: "reason", js: "reason", typ: "" },
+        { json: "repo", js: "repo", typ: "" },
+        { json: "review_status", js: "review_status", typ: u(undefined, "") },
+        { json: "role", js: "role", typ: r("PRRole") },
+        { json: "state", js: "state", typ: "" },
+        { json: "title", js: "title", typ: "" },
+        { json: "url", js: "url", typ: "" },
+    ], "any"),
+    "PRActionResultMessage": o([
+        { json: "action", js: "action", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
+        { json: "id", js: "id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
     "PresentAnnotation": o([
         { json: "comments", js: "comments", typ: a("") },
         { json: "line_end", js: "line_end", typ: 0 },
         { json: "line_start", js: "line_start", typ: 0 },
+    ], "any"),
+    "Presentation": o([
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "kind", js: "kind", typ: "" },
+        { json: "latest_round_seq", js: "latest_round_seq", typ: 0 },
+        { json: "latest_round_submitted", js: "latest_round_submitted", typ: true },
+        { json: "repo_path", js: "repo_path", typ: "" },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "status", js: "status", typ: "" },
+        { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
+        { json: "title", js: "title", typ: "" },
+    ], "any"),
+    "PresentationAddedMessage": o([
+        { json: "event", js: "event", typ: r("PresentationAddedMessageEvent") },
+        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
+    ], "any"),
+    "PresentationComment": o([
+        { json: "author", js: "author", typ: "" },
+        { json: "content", js: "content", typ: "" },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "filepath", js: "filepath", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "line_end", js: "line_end", typ: 0 },
+        { json: "line_start", js: "line_start", typ: 0 },
+        { json: "round_id", js: "round_id", typ: "" },
+        { json: "side", js: "side", typ: "" },
+    ], "any"),
+    "PresentationRound": o([
+        { json: "base_sha", js: "base_sha", typ: "" },
+        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("ChangedFileElement"))) },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "head_sha", js: "head_sha", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "manifest", js: "manifest", typ: r("Manifest") },
+        { json: "presentation_id", js: "presentation_id", typ: "" },
+        { json: "seq", js: "seq", typ: 0 },
+        { json: "submitted_at", js: "submitted_at", typ: u(undefined, "") },
+        { json: "verdict", js: "verdict", typ: u(undefined, "") },
+    ], "any"),
+    "PresentationUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("PresentationUpdatedMessageEvent") },
+        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
     ], "any"),
     "PresentCloseMessage": o([
         { json: "cmd", js: "cmd", typ: r("PresentCloseMessageCmd") },
@@ -12647,7 +12708,7 @@ const typeMap: any = {
         { json: "path", js: "path", typ: "" },
     ], "any"),
     "PresentManifestView": o([
-        { json: "files", js: "files", typ: a(r("FileElement")) },
+        { json: "files", js: "files", typ: a(r("ChangedFileElement")) },
         { json: "skip", js: "skip", typ: a("") },
         { json: "summary", js: "summary", typ: u(undefined, "") },
         { json: "title", js: "title", typ: "" },
@@ -12688,48 +12749,13 @@ const typeMap: any = {
         { json: "round_id", js: "round_id", typ: "" },
         { json: "success", js: "success", typ: true },
     ], "any"),
-    "Presentation": o([
-        { json: "created_at", js: "created_at", typ: "" },
+    "PRsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
+        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
+    ], "any"),
+    "PRVisitedMessage": o([
+        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
         { json: "id", js: "id", typ: "" },
-        { json: "kind", js: "kind", typ: "" },
-        { json: "latest_round_seq", js: "latest_round_seq", typ: 0 },
-        { json: "latest_round_submitted", js: "latest_round_submitted", typ: true },
-        { json: "repo_path", js: "repo_path", typ: "" },
-        { json: "session_id", js: "session_id", typ: "" },
-        { json: "status", js: "status", typ: "" },
-        { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
-        { json: "title", js: "title", typ: "" },
-    ], "any"),
-    "PresentationAddedMessage": o([
-        { json: "event", js: "event", typ: r("PresentationAddedMessageEvent") },
-        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
-    ], "any"),
-    "PresentationComment": o([
-        { json: "author", js: "author", typ: "" },
-        { json: "content", js: "content", typ: "" },
-        { json: "created_at", js: "created_at", typ: "" },
-        { json: "filepath", js: "filepath", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "line_end", js: "line_end", typ: 0 },
-        { json: "line_start", js: "line_start", typ: 0 },
-        { json: "round_id", js: "round_id", typ: "" },
-        { json: "side", js: "side", typ: "" },
-    ], "any"),
-    "PresentationRound": o([
-        { json: "base_sha", js: "base_sha", typ: "" },
-        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("FileElement"))) },
-        { json: "created_at", js: "created_at", typ: "" },
-        { json: "head_sha", js: "head_sha", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "manifest", js: "manifest", typ: r("Manifest") },
-        { json: "presentation_id", js: "presentation_id", typ: "" },
-        { json: "seq", js: "seq", typ: 0 },
-        { json: "submitted_at", js: "submitted_at", typ: u(undefined, "") },
-        { json: "verdict", js: "verdict", typ: u(undefined, "") },
-    ], "any"),
-    "PresentationUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("PresentationUpdatedMessageEvent") },
-        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
     ], "any"),
     "PtyDesyncMessage": o([
         { json: "event", js: "event", typ: r("PtyDesyncMessageEvent") },
@@ -12748,17 +12774,17 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "seq", js: "seq", typ: 0 },
     ], "any"),
-    "PtyResizeMessage": o([
-        { json: "cmd", js: "cmd", typ: r("PtyResizeMessageCmd") },
+    "PtyResizedMessage": o([
         { json: "cols", js: "cols", typ: 0 },
+        { json: "event", js: "event", typ: r("PtyResizedMessageEvent") },
         { json: "id", js: "id", typ: "" },
         { json: "rows", js: "rows", typ: 0 },
         { json: "xpixel", js: "xpixel", typ: u(undefined, 0) },
         { json: "ypixel", js: "ypixel", typ: u(undefined, 0) },
     ], "any"),
-    "PtyResizedMessage": o([
+    "PtyResizeMessage": o([
+        { json: "cmd", js: "cmd", typ: r("PtyResizeMessageCmd") },
         { json: "cols", js: "cols", typ: 0 },
-        { json: "event", js: "event", typ: r("PtyResizedMessageEvent") },
         { json: "id", js: "id", typ: "" },
         { json: "rows", js: "rows", typ: 0 },
         { json: "xpixel", js: "xpixel", typ: u(undefined, 0) },
@@ -12793,11 +12819,11 @@ const typeMap: any = {
     "RecentFilesResultMessage": o([
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("RecentFilesResultMessageEvent") },
-        { json: "files", js: "files", typ: a(r("FileObject")) },
+        { json: "files", js: "files", typ: a(r("FileElement")) },
         { json: "request_id", js: "request_id", typ: "" },
         { json: "success", js: "success", typ: true },
     ], "any"),
-    "FileObject": o([
+    "FileElement": o([
         { json: "count", js: "count", typ: 0 },
         { json: "last_at", js: "last_at", typ: "" },
         { json: "path", js: "path", typ: "" },
@@ -13360,6 +13386,10 @@ const typeMap: any = {
         { json: "event", js: "event", typ: r("SessionStateChangedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionObject") },
     ], "any"),
+    "SessionsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
+        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionObject"))) },
+    ], "any"),
     "SessionTodosUpdatedMessage": o([
         { json: "event", js: "event", typ: r("SessionTodosUpdatedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionObject") },
@@ -13388,10 +13418,6 @@ const typeMap: any = {
     "SessionUnregisteredMessage": o([
         { json: "event", js: "event", typ: r("SessionUnregisteredMessageEvent") },
         { json: "session", js: "session", typ: r("SessionObject") },
-    ], "any"),
-    "SessionsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
-        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionObject"))) },
     ], "any"),
     "SetChiefOfStaffMessage": o([
         { json: "chief_of_staff", js: "chief_of_staff", typ: true },
@@ -13423,7 +13449,6 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("SetSessionResumeIDMessageCmd") },
         { json: "id", js: "id", typ: "" },
         { json: "resume_session_id", js: "resume_session_id", typ: "" },
-        { json: "transcript_path", js: "transcript_path", typ: u(undefined, "") },
     ], "any"),
     "SetSettingMessage": o([
         { json: "cmd", js: "cmd", typ: r("SetSettingMessageCmd") },
@@ -13444,12 +13469,6 @@ const typeMap: any = {
         { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
         { json: "work_state", js: "work_state", typ: r("DispatchWorkState") },
     ], "any"),
-    "SetWorkspaceRankMessage": o([
-        { json: "cmd", js: "cmd", typ: r("SetWorkspaceRankMessageCmd") },
-        { json: "next_workspace_id", js: "next_workspace_id", typ: u(undefined, "") },
-        { json: "prev_workspace_id", js: "prev_workspace_id", typ: u(undefined, "") },
-        { json: "workspace_id", js: "workspace_id", typ: "" },
-    ], "any"),
     "SettingsUpdatedMessage": o([
         { json: "changed_key", js: "changed_key", typ: u(undefined, "") },
         { json: "error", js: "error", typ: u(undefined, "") },
@@ -13460,6 +13479,12 @@ const typeMap: any = {
     "SettleTurnMessage": o([
         { json: "cmd", js: "cmd", typ: r("SettleTurnMessageCmd") },
         { json: "session_id", js: "session_id", typ: "" },
+    ], "any"),
+    "SetWorkspaceRankMessage": o([
+        { json: "cmd", js: "cmd", typ: r("SetWorkspaceRankMessageCmd") },
+        { json: "next_workspace_id", js: "next_workspace_id", typ: u(undefined, "") },
+        { json: "prev_workspace_id", js: "prev_workspace_id", typ: u(undefined, "") },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "SnoozeTurnMessage": o([
         { json: "cmd", js: "cmd", typ: r("SnoozeTurnMessageCmd") },
@@ -13648,13 +13673,13 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("TicketAttachMessageCmd") },
         { json: "comment", js: "comment", typ: u(undefined, "") },
         { json: "expected_event_seq", js: "expected_event_seq", typ: u(undefined, 0) },
-        { json: "files", js: "files", typ: a(r("TicketAttachMessageFile")) },
+        { json: "files", js: "files", typ: a(r("FileObject")) },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
         { json: "source_session_id", js: "source_session_id", typ: "" },
         { json: "state", js: "state", typ: u(undefined, r("DispatchWorkState")) },
         { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
     ], "any"),
-    "TicketAttachMessageFile": o([
+    "FileObject": o([
         { json: "filename", js: "filename", typ: "" },
         { json: "source_path", js: "source_path", typ: "" },
     ], "any"),
@@ -13790,6 +13815,10 @@ const typeMap: any = {
         { json: "ticket_id", js: "ticket_id", typ: "" },
         { json: "unread_count", js: "unread_count", typ: u(undefined, 0) },
     ], "any"),
+    "TicketsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("TicketsUpdatedMessageEvent") },
+        { json: "tickets", js: "tickets", typ: a(r("TicketElement")) },
+    ], "any"),
     "TicketTakeMessage": o([
         { json: "cmd", js: "cmd", typ: r("TicketTakeMessageCmd") },
         { json: "confirm", js: "confirm", typ: u(undefined, true) },
@@ -13808,10 +13837,6 @@ const typeMap: any = {
     ], "any"),
     "TicketUnsubscribeResult": o([
         { json: "ticket_id", js: "ticket_id", typ: "" },
-    ], "any"),
-    "TicketsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("TicketsUpdatedMessageEvent") },
-        { json: "tickets", js: "tickets", typ: a(r("TicketElement")) },
     ], "any"),
     "TodosMessage": o([
         { json: "cmd", js: "cmd", typ: r("TodosMessageCmd") },
@@ -14224,6 +14249,10 @@ const typeMap: any = {
         { json: "tile_id", js: "tile_id", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
+    "WorkspaceLayoutUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("WorkspaceLayoutUpdatedMessageEvent") },
+        { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
+    ], "any"),
     "WorkspaceLayoutUpdateTileMessage": o([
         { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutUpdateTileMessageCmd") },
         { json: "request_id", js: "request_id", typ: "" },
@@ -14231,10 +14260,6 @@ const typeMap: any = {
         { json: "tile_params", js: "tile_params", typ: "" },
         { json: "tile_session_id", js: "tile_session_id", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: "" },
-    ], "any"),
-    "WorkspaceLayoutUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("WorkspaceLayoutUpdatedMessageEvent") },
-        { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
     ], "any"),
     "WorkspaceRegisteredMessage": o([
         { json: "event", js: "event", typ: r("WorkspaceRegisteredMessageEvent") },
@@ -14371,6 +14396,9 @@ const typeMap: any = {
     "AutomationRunsResultMessageEvent": [
         "automation_runs_result",
     ],
+    "AutomationsChangedMessageEvent": [
+        "automations_changed",
+    ],
     "AutomationSetEnabledMessageCmd": [
         "automation_set_enabled",
     ],
@@ -14382,9 +14410,6 @@ const typeMap: any = {
     ],
     "AutomationValidateResultMessageEvent": [
         "automation_validate_result",
-    ],
-    "AutomationsChangedMessageEvent": [
-        "automations_changed",
     ],
     "BootstrapEndpointMessageCmd": [
         "bootstrap_endpoint",
@@ -14858,6 +14883,11 @@ const typeMap: any = {
     "NotebookWriteResultMessageEvent": [
         "notebook_write_result",
     ],
+    "NotificationSeverity": [
+        "critical",
+        "info",
+        "warning",
+    ],
     "NotificationListMessageCmd": [
         "notification_list",
     ],
@@ -14882,15 +14912,6 @@ const typeMap: any = {
     "OpenMarkdownResultMessageEvent": [
         "open_markdown_result",
     ],
-    "PRActionResultMessageEvent": [
-        "pr_action_result",
-    ],
-    "PRVisitedMessageCmd": [
-        "pr_visited",
-    ],
-    "PRsUpdatedMessageEvent": [
-        "prs_updated",
-    ],
     "PastConversationsResultMessageEvent": [
         "past_conversations_result",
     ],
@@ -14905,6 +14926,15 @@ const typeMap: any = {
     ],
     "PluginsUpdatedMessageEvent": [
         "plugins_updated",
+    ],
+    "PRActionResultMessageEvent": [
+        "pr_action_result",
+    ],
+    "PresentationAddedMessageEvent": [
+        "presentation_added",
+    ],
+    "PresentationUpdatedMessageEvent": [
+        "presentation_updated",
     ],
     "PresentCloseMessageCmd": [
         "present_close",
@@ -14924,11 +14954,11 @@ const typeMap: any = {
     "PresentSubmitRoundResultMessageEvent": [
         "present_submit_round_result",
     ],
-    "PresentationAddedMessageEvent": [
-        "presentation_added",
+    "PRsUpdatedMessageEvent": [
+        "prs_updated",
     ],
-    "PresentationUpdatedMessageEvent": [
-        "presentation_updated",
+    "PRVisitedMessageCmd": [
+        "pr_visited",
     ],
     "PtyDesyncMessageEvent": [
         "pty_desync",
@@ -14939,11 +14969,11 @@ const typeMap: any = {
     "PtyOutputMessageEvent": [
         "pty_output",
     ],
-    "PtyResizeMessageCmd": [
-        "pty_resize",
-    ],
     "PtyResizedMessageEvent": [
         "pty_resized",
+    ],
+    "PtyResizeMessageCmd": [
+        "pty_resize",
     ],
     "QueryAuthorsMessageCmd": [
         "query_authors",
@@ -15068,6 +15098,9 @@ const typeMap: any = {
     "SessionStateChangedMessageEvent": [
         "session_state_changed",
     ],
+    "SessionsUpdatedMessageEvent": [
+        "sessions_updated",
+    ],
     "SessionTodosUpdatedMessageEvent": [
         "session_todos_updated",
     ],
@@ -15076,9 +15109,6 @@ const typeMap: any = {
     ],
     "SessionUnregisteredMessageEvent": [
         "session_unregistered",
-    ],
-    "SessionsUpdatedMessageEvent": [
-        "sessions_updated",
     ],
     "SetChiefOfStaffMessageCmd": [
         "set_chief_of_staff",
@@ -15114,14 +15144,14 @@ const typeMap: any = {
         "needs_input",
         "ready_for_review",
     ],
-    "SetWorkspaceRankMessageCmd": [
-        "set_workspace_rank",
-    ],
     "SettingsUpdatedMessageEvent": [
         "settings_updated",
     ],
     "SettleTurnMessageCmd": [
         "settle_turn",
+    ],
+    "SetWorkspaceRankMessageCmd": [
+        "set_workspace_rank",
     ],
     "SnoozeTurnMessageCmd": [
         "snooze_turn",
@@ -15211,14 +15241,14 @@ const typeMap: any = {
     "TicketSubscribeMessageCmd": [
         "ticket_subscribe",
     ],
+    "TicketsUpdatedMessageEvent": [
+        "tickets_updated",
+    ],
     "TicketTakeMessageCmd": [
         "ticket_take",
     ],
     "TicketUnsubscribeMessageCmd": [
         "ticket_unsubscribe",
-    ],
-    "TicketsUpdatedMessageEvent": [
-        "tickets_updated",
     ],
     "TodosMessageCmd": [
         "todos",
@@ -15353,11 +15383,11 @@ const typeMap: any = {
     "WorkspaceLayoutUndockTileMessageCmd": [
         "workspace_layout_undock_tile",
     ],
-    "WorkspaceLayoutUpdateTileMessageCmd": [
-        "workspace_layout_update_tile",
-    ],
     "WorkspaceLayoutUpdatedMessageEvent": [
         "workspace_layout_updated",
+    ],
+    "WorkspaceLayoutUpdateTileMessageCmd": [
+        "workspace_layout_update_tile",
     ],
     "WorkspaceRegisteredMessageEvent": [
         "workspace_registered",

--- a/changelog.d/notification-severity-levels.yaml
+++ b/changelog.d/notification-severity-levels.yaml
@@ -1,0 +1,11 @@
+kind: added
+area: app
+change: >
+  Notifications now carry a severity — info, warning, or critical — and the
+  panel styles each one by it. A background job that exhausts its retries is a
+  warning; everything else stays info. Critical additionally gets an ambient
+  surface outside the panel: while any critical notification is unread, a strip
+  sits at the top of the sidebar naming the newest one and the notifications
+  bell turns red, and both disappear when the last one is read. Notifications
+  that were already in the feed are carried across as info rather than
+  relevelled, so nothing you had already dealt with comes back louder.

--- a/internal/daemon/notifications.go
+++ b/internal/daemon/notifications.go
@@ -16,6 +16,7 @@ func notificationToProtocol(rec store.NotificationRecord) protocol.Notification 
 	pn := protocol.Notification{
 		ID:         rec.ID,
 		Kind:       rec.Kind,
+		Severity:   protocol.NotificationSeverity(store.NormalizeNotificationSeverity(string(rec.Severity))),
 		Title:      rec.Title,
 		Body:       rec.Body,
 		Detail:     rec.Detail,
@@ -55,12 +56,20 @@ func (d *Daemon) sendNotificationListWSResult(client *wsClient, requestID string
 	if err == nil {
 		err = unreadErr
 	}
+	criticalCount, criticalTitle, criticalErr := d.store.UnreadCriticalNotifications()
+	if err == nil {
+		err = criticalErr
+	}
 	msg := protocol.NotificationListResultMessage{
-		Event:         protocol.EventNotificationListResult,
-		RequestID:     requestID,
-		Success:       err == nil,
-		Notifications: notificationsToProtocol(list),
-		UnreadCount:   unread,
+		Event:               protocol.EventNotificationListResult,
+		RequestID:           requestID,
+		Success:             err == nil,
+		Notifications:       notificationsToProtocol(list),
+		UnreadCount:         unread,
+		UnreadCriticalCount: criticalCount,
+	}
+	if criticalTitle != "" {
+		msg.CriticalTitle = protocol.Ptr(criticalTitle)
 	}
 	if err != nil {
 		msg.Error = protocol.Ptr(err.Error())
@@ -169,7 +178,10 @@ func renderTaskFailureNotification(t *jobs.Job) store.NotificationRecord {
 		attemptWord = "attempts"
 	}
 	return store.NotificationRecord{
-		Kind:       notificationKindTaskFailed,
+		Kind: notificationKindTaskFailed,
+		// A dead job stays dead until the user retries it, but nothing else
+		// degrades while it waits — that is warning, not critical.
+		Severity:   store.NotificationWarning,
 		Title:      title,
 		Body:       fmt.Sprintf("attn retried %d %s and gave up. Retry to run it again.", t.Attempts, attemptWord),
 		Detail:     t.LastError,
@@ -186,15 +198,23 @@ func renderTaskFailureNotification(t *jobs.Job) store.NotificationRecord {
 // failure callback. A nil store broadcasts an unread count of 0.
 func (d *Daemon) projectNotificationsUpdated() {
 	d.projectSnapshot(snapshotNotifs, func() {
-		unread := 0
+		unread, criticalCount, criticalTitle := 0, 0, ""
 		if d.store != nil {
 			if n, err := d.store.UnreadNotificationCount(); err == nil {
 				unread = n
 			}
+			if n, title, err := d.store.UnreadCriticalNotifications(); err == nil {
+				criticalCount, criticalTitle = n, title
+			}
 		}
-		d.broadcastMessage(protocol.NotificationsUpdatedMessage{
-			Event:       protocol.EventNotificationsUpdated,
-			UnreadCount: unread,
-		})
+		msg := protocol.NotificationsUpdatedMessage{
+			Event:               protocol.EventNotificationsUpdated,
+			UnreadCount:         unread,
+			UnreadCriticalCount: criticalCount,
+		}
+		if criticalTitle != "" {
+			msg.CriticalTitle = protocol.Ptr(criticalTitle)
+		}
+		d.broadcastMessage(msg)
 	})
 }

--- a/internal/daemon/notifications_test.go
+++ b/internal/daemon/notifications_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/victorarias/attn/internal/jobs"
+	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/store"
 )
 
@@ -75,5 +76,58 @@ func TestRenderTaskFailureNotification(t *testing.T) {
 	}
 	if want := "attn retried 2 attempts and gave up. Retry to run it again."; other.Body != want {
 		t.Fatalf("plural body = %q, want %q", other.Body, want)
+	}
+}
+
+// A dead background job is a warning: it stays failed until the user retries it,
+// but nothing keeps degrading while it waits. It is deliberately not critical —
+// the ambient surface is reserved for what breaks silently and stays broken.
+func TestTaskFailureNotificationIsWarning(t *testing.T) {
+	if got := renderTaskFailureNotification(&jobs.Job{
+		ID: "job-9", Kind: reconcileKind, Attempts: 1,
+	}).Severity; got != store.NotificationWarning {
+		t.Fatalf("severity = %q, want warning", got)
+	}
+
+	d := &Daemon{store: store.New()}
+	d.notifyTaskTerminalFailure(&jobs.Job{
+		ID: "job-1", Kind: compactContextKind, State: jobs.StateDead, Attempts: 3,
+	})
+	list, err := d.store.ListNotifications()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 1 || list[0].Severity != store.NotificationWarning {
+		t.Fatalf("persisted severity = %+v, want one warning row", list)
+	}
+
+	// A warning does not light the ambient critical surface.
+	n, title, err := d.store.UnreadCriticalNotifications()
+	if err != nil {
+		t.Fatalf("unread critical: %v", err)
+	}
+	if n != 0 || title != "" {
+		t.Fatalf("a dead job lit the critical surface: (%d, %q)", n, title)
+	}
+}
+
+// The wire shape carries the stored severity, and normalizes on the way out so a
+// row holding something unrecognized reaches the app as info rather than as a
+// severity it has no styling for.
+func TestNotificationToProtocolCarriesSeverity(t *testing.T) {
+	for _, tc := range []struct {
+		stored store.NotificationSeverity
+		want   protocol.NotificationSeverity
+	}{
+		{store.NotificationInfo, protocol.NotificationSeverityInfo},
+		{store.NotificationWarning, protocol.NotificationSeverityWarning},
+		{store.NotificationCritical, protocol.NotificationSeverityCritical},
+		{"", protocol.NotificationSeverityInfo},
+		{"nonsense", protocol.NotificationSeverityInfo},
+	} {
+		got := notificationToProtocol(store.NotificationRecord{Severity: tc.stored})
+		if got.Severity != tc.want {
+			t.Fatalf("stored %q → wire %q, want %q", tc.stored, got.Severity, tc.want)
+		}
 	}
 }

--- a/internal/daemon/testdata/wire/producers.golden
+++ b/internal/daemon/testdata/wire/producers.golden
@@ -231,7 +231,8 @@
 --- 19 notifications_updated
 {
   "event": "notifications_updated",
-  "unread_count": 0
+  "unread_count": 0,
+  "unread_critical_count": 0
 }
 --- 20 notebook_changed
 {

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "222"
+const ProtocolVersion = "223"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -3317,6 +3317,9 @@ type Notification struct {
 	// ReadAt corresponds to the JSON schema field "read_at".
 	ReadAt string `json:"read_at"`
 
+	// Severity corresponds to the JSON schema field "severity".
+	Severity NotificationSeverity `json:"severity"`
+
 	// SourceID corresponds to the JSON schema field "source_id".
 	SourceID string `json:"source_id"`
 
@@ -3336,6 +3339,9 @@ type NotificationListMessage struct {
 }
 
 type NotificationListResultMessage struct {
+	// CriticalTitle corresponds to the JSON schema field "critical_title".
+	CriticalTitle *string `json:"critical_title,omitempty,omitzero"`
+
 	// Error corresponds to the JSON schema field "error".
 	Error *string `json:"error,omitempty,omitzero"`
 
@@ -3353,6 +3359,10 @@ type NotificationListResultMessage struct {
 
 	// UnreadCount corresponds to the JSON schema field "unread_count".
 	UnreadCount int `json:"unread_count"`
+
+	// UnreadCriticalCount corresponds to the JSON schema field
+	// "unread_critical_count".
+	UnreadCriticalCount int `json:"unread_critical_count"`
 }
 
 type NotificationMarkReadMessage struct {
@@ -3383,12 +3393,25 @@ type NotificationMarkReadResultMessage struct {
 	UnreadCount int `json:"unread_count"`
 }
 
+type NotificationSeverity string
+
+const NotificationSeverityCritical NotificationSeverity = "critical"
+const NotificationSeverityInfo NotificationSeverity = "info"
+const NotificationSeverityWarning NotificationSeverity = "warning"
+
 type NotificationsUpdatedMessage struct {
+	// CriticalTitle corresponds to the JSON schema field "critical_title".
+	CriticalTitle *string `json:"critical_title,omitempty,omitzero"`
+
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
 
 	// UnreadCount corresponds to the JSON schema field "unread_count".
 	UnreadCount int `json:"unread_count"`
+
+	// UnreadCriticalCount corresponds to the JSON schema field
+	// "unread_critical_count".
+	UnreadCriticalCount int `json:"unread_critical_count"`
 }
 
 type OpenBrowserMessage struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -4348,9 +4348,19 @@ model TasksChangedMessage {
 // (e.g. "task" + the task id) so the detail dialog's Retry can act on it. kind and
 // source_kind are plain strings (not enums) to avoid the quicktype identical-enum
 // merge that drops a generated export.
+// How much a notification wants the user. The panel styles the feed by it, and
+// critical additionally earns an ambient surface outside the panel that stays up
+// while any critical notification is unread.
+enum NotificationSeverity {
+  info,
+  warning,
+  critical,
+}
+
 model Notification {
   id: string;
   kind: string;
+  severity: NotificationSeverity;
   title: string;
   body: string;
   detail: string;
@@ -4369,6 +4379,12 @@ model NotificationListResultMessage {
   error?: string;
   notifications?: Notification[];
   unread_count: int32;
+  // The ambient critical surface's whole input, carried here as well as on the
+  // broadcast so a client that just connected renders it from its seeding list
+  // without a second read. critical_title names the newest unread critical
+  // notification and is absent when the count is zero.
+  unread_critical_count: int32;
+  critical_title?: string;
 }
 
 // Result of notification_mark_read. unread_count is the post-mark count so the
@@ -4387,6 +4403,11 @@ model NotificationMarkReadResultMessage {
 model NotificationsUpdatedMessage {
   event: "notifications_updated";
   unread_count: int32;
+  // The ambient critical surface is driven entirely by these two, so it appears
+  // and clears on the broadcast alone — a panel that was never opened is not a
+  // reason for the user to miss something critical.
+  unread_critical_count: int32;
+  critical_title?: string;
 }
 
 // ---- Generic filesystem surface results (fs_*) ----

--- a/internal/store/notifications.go
+++ b/internal/store/notifications.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -19,11 +20,45 @@ import (
 // (same package), so a blank/garbage value decodes to the zero time. The encoding
 // is the fixed-width one because created_at orders this feed as text.
 
+// NotificationSeverity is how much a notification wants the user. Unlike Kind,
+// which is open, this is a closed set: the app styles the feed by it and gives
+// critical an ambient surface outside the panel, so an unrecognized value must
+// resolve to something rather than render as nothing.
+type NotificationSeverity string
+
+const (
+	// NotificationInfo is the default weight and the value every row written
+	// before the severity column carries.
+	NotificationInfo NotificationSeverity = "info"
+	// NotificationWarning is something that failed and stays failed until the
+	// user acts, but costs them nothing until they get to it.
+	NotificationWarning NotificationSeverity = "warning"
+	// NotificationCritical is something that is broken now and will stay broken
+	// silently — it earns a surface the user cannot miss.
+	NotificationCritical NotificationSeverity = "critical"
+)
+
+// NormalizeNotificationSeverity maps any input onto the closed set, falling back
+// to info. It runs on write and on scan, not just on write: the column is plain
+// TEXT and nothing stops a hand-written row from holding a typo, and an
+// unrecognized value must not reach the app as a severity it has no styling for.
+func NormalizeNotificationSeverity(raw string) NotificationSeverity {
+	switch NotificationSeverity(strings.ToLower(strings.TrimSpace(raw))) {
+	case NotificationWarning:
+		return NotificationWarning
+	case NotificationCritical:
+		return NotificationCritical
+	default:
+		return NotificationInfo
+	}
+}
+
 // NotificationRecord is one durable notification row. ReadAt is the zero time
 // while unread; a non-zero ReadAt marks it read.
 type NotificationRecord struct {
 	ID         string
 	Kind       string // e.g. "task_failed" (extensible)
+	Severity   NotificationSeverity
 	Title      string
 	Body       string
 	Detail     string
@@ -44,10 +79,11 @@ func (s *Store) AddNotification(rec NotificationRecord, now time.Time) (Notifica
 	rec.ID = uuid.NewString()
 	rec.CreatedAt = now.UTC()
 	rec.ReadAt = time.Time{}
+	rec.Severity = NormalizeNotificationSeverity(string(rec.Severity))
 	_, err := s.db.Exec(
-		`INSERT INTO notifications (id, kind, title, body, detail, source_kind, source_id, created_at, read_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, '')`,
-		rec.ID, rec.Kind, rec.Title, rec.Body, rec.Detail, rec.SourceKind, rec.SourceID,
+		`INSERT INTO notifications (id, kind, severity, title, body, detail, source_kind, source_id, created_at, read_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, '')`,
+		rec.ID, rec.Kind, string(rec.Severity), rec.Title, rec.Body, rec.Detail, rec.SourceKind, rec.SourceID,
 		rec.CreatedAt.Format(sortableTimeFormat),
 	)
 	if err != nil {
@@ -62,7 +98,7 @@ func (s *Store) ListNotifications() ([]NotificationRecord, error) {
 		return nil, fmt.Errorf("store: no database")
 	}
 	rows, err := s.db.Query(
-		`SELECT id, kind, title, body, detail, source_kind, source_id, created_at, read_at
+		`SELECT id, kind, severity, title, body, detail, source_kind, source_id, created_at, read_at
 		 FROM notifications ORDER BY created_at DESC, id DESC`)
 	if err != nil {
 		return nil, fmt.Errorf("store: list notifications: %w", err)
@@ -91,6 +127,36 @@ func (s *Store) UnreadNotificationCount() (int, error) {
 		return 0, fmt.Errorf("store: unread notification count: %w", err)
 	}
 	return n, nil
+}
+
+// UnreadCriticalNotifications returns how many critical notifications are unread
+// and the title of the newest of them (empty when the count is zero). Together
+// they are the whole input to the app's ambient critical surface, so they are
+// read in one statement — the surface must never show a count from one instant
+// beside a title from another.
+//
+// The severity comparison is normalization-free on purpose: a row whose severity
+// is a typo is not critical, which is the same answer NormalizeNotificationSeverity
+// gives it.
+func (s *Store) UnreadCriticalNotifications() (int, string, error) {
+	if s.db == nil {
+		return 0, "", fmt.Errorf("store: no database")
+	}
+	var (
+		n     int
+		title string
+	)
+	critical := string(NotificationCritical)
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*),
+		        COALESCE((SELECT title FROM notifications
+		                  WHERE read_at = '' AND severity = ?
+		                  ORDER BY created_at DESC, id DESC LIMIT 1), '')
+		 FROM notifications WHERE read_at = '' AND severity = ?`,
+		critical, critical).Scan(&n, &title); err != nil {
+		return 0, "", fmt.Errorf("store: unread critical notifications: %w", err)
+	}
+	return n, title, nil
 }
 
 // MarkNotificationRead marks one notification read. Idempotent: the WHERE read_at
@@ -129,13 +195,14 @@ func (s *Store) MarkAllNotificationsRead(now time.Time) (int, error) {
 
 func scanNotificationRow(sc rowScanner) (*NotificationRecord, error) {
 	var (
-		rec                 NotificationRecord
-		createdStr, readStr string
+		rec                              NotificationRecord
+		severityStr, createdStr, readStr string
 	)
-	if err := sc.Scan(&rec.ID, &rec.Kind, &rec.Title, &rec.Body, &rec.Detail,
+	if err := sc.Scan(&rec.ID, &rec.Kind, &severityStr, &rec.Title, &rec.Body, &rec.Detail,
 		&rec.SourceKind, &rec.SourceID, &createdStr, &readStr); err != nil {
 		return nil, err
 	}
+	rec.Severity = NormalizeNotificationSeverity(severityStr)
 	rec.CreatedAt = parseStoreTime(createdStr)
 	rec.ReadAt = parseStoreTime(readStr)
 	return &rec, nil

--- a/internal/store/notifications_test.go
+++ b/internal/store/notifications_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -145,5 +146,228 @@ func TestNotifications_MarkAllRead(t *testing.T) {
 	}
 	if flipped != 0 {
 		t.Fatalf("second mark-all flipped %d, want 0", flipped)
+	}
+}
+
+func TestNotifications_SeverityRoundTrip(t *testing.T) {
+	s := New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	for _, severity := range []NotificationSeverity{NotificationInfo, NotificationWarning, NotificationCritical} {
+		rec, err := s.AddNotification(NotificationRecord{
+			Kind:     "task_failed",
+			Severity: severity,
+			Title:    string(severity),
+		}, now)
+		if err != nil {
+			t.Fatalf("add %s: %v", severity, err)
+		}
+		if rec.Severity != severity {
+			t.Fatalf("returned severity = %q, want %q", rec.Severity, severity)
+		}
+	}
+
+	all, err := s.ListNotifications()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 notifications, got %d", len(all))
+	}
+	for _, got := range all {
+		if string(got.Severity) != got.Title {
+			t.Fatalf("read back severity %q for row titled %q", got.Severity, got.Title)
+		}
+	}
+}
+
+func TestNotifications_SeverityNormalizes(t *testing.T) {
+	for _, tc := range []struct {
+		raw  string
+		want NotificationSeverity
+	}{
+		{"", NotificationInfo},
+		{"info", NotificationInfo},
+		{"warning", NotificationWarning},
+		{"critical", NotificationCritical},
+		{"  Critical ", NotificationCritical},
+		{"WARNING", NotificationWarning},
+		{"criticial", NotificationInfo}, // a typo is not critical
+		{"error", NotificationInfo},
+		{"0", NotificationInfo},
+	} {
+		if got := NormalizeNotificationSeverity(tc.raw); got != tc.want {
+			t.Fatalf("NormalizeNotificationSeverity(%q) = %q, want %q", tc.raw, got, tc.want)
+		}
+	}
+
+	// The same rule has to hold through the database, not just in the helper:
+	// an unrecognized value written to the row must read back as info.
+	s := New()
+	now := time.Now().UTC()
+	if _, err := s.AddNotification(NotificationRecord{
+		Kind: "task_failed", Severity: NotificationSeverity("CRITICIAL"), Title: "typo",
+	}, now); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	all, err := s.ListNotifications()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if all[0].Severity != NotificationInfo {
+		t.Fatalf("typo severity read back as %q, want info", all[0].Severity)
+	}
+}
+
+// A notification feed that predates the severity column must survive the
+// migration with its rows intact and every one of them reading as info: the
+// column is added, never recreated, and its DEFAULT is what carries them.
+func TestMigration100CarriesPreSeverityNotifications(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB: %v", err)
+	}
+	defer s.Close()
+
+	// Put the table back the way a store before migration 100 had it, with two
+	// notifications already in it — one read, one not.
+	if _, err := s.db.Exec(`ALTER TABLE notifications DROP COLUMN severity`); err != nil {
+		t.Fatalf("drop severity column: %v", err)
+	}
+	base := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+	for i, row := range []struct{ id, title, readAt string }{
+		{"n1", "Older failure", base.Format(sortableTimeFormat)},
+		{"n2", "Newer failure", ""},
+	} {
+		if _, err := s.db.Exec(
+			`INSERT INTO notifications (id, kind, title, body, detail, source_kind, source_id, created_at, read_at)
+			 VALUES (?, 'task_failed', ?, 'body', 'detail', 'task', 't1', ?, ?)`,
+			row.id, row.title, base.Add(time.Duration(i)*time.Second).Format(sortableTimeFormat), row.readAt,
+		); err != nil {
+			t.Fatalf("plant pre-severity row %s: %v", row.id, err)
+		}
+	}
+
+	// Sanity: the planted schema really is the old one, so a pass here would
+	// mean the test proves nothing.
+	if _, err := s.ListNotifications(); err == nil {
+		t.Fatal("the planted schema already has severity; this test would pass without the migration")
+	}
+
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version >= 100`); err != nil {
+		t.Fatalf("unrecord migration 100: %v", err)
+	}
+	if err := migrateDB(s.db, dbPath); err != nil {
+		t.Fatalf("migrateDB: %v", err)
+	}
+
+	all, err := s.ListNotifications()
+	if err != nil {
+		t.Fatalf("list after migration: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("carried %d rows, want 2", len(all))
+	}
+	for _, got := range all {
+		if got.Severity != NotificationInfo {
+			t.Fatalf("carried row %q has severity %q, want info", got.Title, got.Severity)
+		}
+		if got.Body != "body" || got.Detail != "detail" || got.SourceID != "t1" {
+			t.Fatalf("carried row %q lost fields: %+v", got.Title, got)
+		}
+	}
+	// The read/unread split survives too — a migration that reset read_at would
+	// re-raise every notification the user had already dealt with.
+	unread, err := s.UnreadNotificationCount()
+	if err != nil {
+		t.Fatalf("unread count: %v", err)
+	}
+	if unread != 1 {
+		t.Fatalf("unread = %d, want 1", unread)
+	}
+
+	// The guarded ALTER makes a re-run a no-op rather than an error.
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version >= 100`); err != nil {
+		t.Fatalf("unrecord migration 100 again: %v", err)
+	}
+	if err := migrateDB(s.db, dbPath); err != nil {
+		t.Fatalf("re-run migrateDB: %v", err)
+	}
+	if again, err := s.ListNotifications(); err != nil || len(again) != 2 {
+		t.Fatalf("re-run changed the feed: %v (err %v)", again, err)
+	}
+}
+
+func TestNotifications_UnreadCritical(t *testing.T) {
+	s := New()
+	base := time.Now().UTC().Truncate(time.Millisecond)
+
+	// Nothing critical yet: a warning and an info do not count, and the title is
+	// empty rather than borrowed from them.
+	if _, err := s.AddNotification(NotificationRecord{
+		Kind: "task_failed", Severity: NotificationWarning, Title: "Dead job",
+	}, base); err != nil {
+		t.Fatalf("add warning: %v", err)
+	}
+	if _, err := s.AddNotification(NotificationRecord{
+		Kind: "note", Severity: NotificationInfo, Title: "Mundane",
+	}, base.Add(time.Second)); err != nil {
+		t.Fatalf("add info: %v", err)
+	}
+	n, title, err := s.UnreadCriticalNotifications()
+	if err != nil {
+		t.Fatalf("unread critical: %v", err)
+	}
+	if n != 0 || title != "" {
+		t.Fatalf("with no critical rows got (%d, %q), want (0, \"\")", n, title)
+	}
+
+	older, err := s.AddNotification(NotificationRecord{
+		Kind: "plugin_parked", Severity: NotificationCritical, Title: "Older critical",
+	}, base.Add(2*time.Second))
+	if err != nil {
+		t.Fatalf("add older critical: %v", err)
+	}
+	newer, err := s.AddNotification(NotificationRecord{
+		Kind: "plugin_parked", Severity: NotificationCritical, Title: "Newer critical",
+	}, base.Add(3*time.Second))
+	if err != nil {
+		t.Fatalf("add newer critical: %v", err)
+	}
+
+	// Two unread, and the title is the NEWEST one's — not whichever the storage
+	// engine happened to return first.
+	n, title, err = s.UnreadCriticalNotifications()
+	if err != nil {
+		t.Fatalf("unread critical: %v", err)
+	}
+	if n != 2 || title != "Newer critical" {
+		t.Fatalf("got (%d, %q), want (2, \"Newer critical\")", n, title)
+	}
+
+	// Reading the newest falls back to the older one rather than emptying the
+	// title while a critical notification is still unread.
+	if err := s.MarkNotificationRead(newer.ID, base.Add(4*time.Second)); err != nil {
+		t.Fatalf("mark read: %v", err)
+	}
+	n, title, err = s.UnreadCriticalNotifications()
+	if err != nil {
+		t.Fatalf("unread critical: %v", err)
+	}
+	if n != 1 || title != "Older critical" {
+		t.Fatalf("after reading the newest got (%d, %q), want (1, \"Older critical\")", n, title)
+	}
+
+	// Reading the last one clears the surface entirely.
+	if err := s.MarkNotificationRead(older.ID, base.Add(5*time.Second)); err != nil {
+		t.Fatalf("mark read: %v", err)
+	}
+	n, title, err = s.UnreadCriticalNotifications()
+	if err != nil {
+		t.Fatalf("unread critical: %v", err)
+	}
+	if n != 0 || title != "" {
+		t.Fatalf("after reading every critical got (%d, %q), want (0, \"\")", n, title)
 	}
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -990,6 +990,14 @@ CREATE TABLE IF NOT EXISTS document_collections (
 	// keeps theirs.
 	// Applied by applyMigration99, whose ALTER is column-guarded.
 	{99, "attribute role-acted ticket events to the role", ``},
+	// How much a notification wants the user: info, warning, or critical. Rows
+	// written before this migration are all task failures, which the producer now
+	// stamps warning, but they are carried at the column default rather than
+	// rewritten — a notification already sitting in the feed has been seen at its
+	// old weight, and promoting it retroactively would raise an alarm about
+	// something the user already dealt with.
+	// Applied by applyMigration100, whose ALTER is column-guarded.
+	{100, "add the severity level to notifications", ``},
 }
 
 // migration99SQL is everything migration 99 does after its guarded ALTER.
@@ -1361,6 +1369,11 @@ func migrateDB(db *sql.DB, dbPath string) error {
 			}
 		} else if m.version == 99 {
 			if err := applyMigration99(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 100 {
+			if err := applyMigration100(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -2498,6 +2511,17 @@ func applyMigration97(tx *sql.Tx) error {
 		}
 	}
 	return nil
+}
+
+// applyMigration100 adds the notification severity column. Guarded on the
+// column, and the DEFAULT is what carries every existing row to 'info'.
+func applyMigration100(tx *sql.Tx) error {
+	has, err := columnExists(tx, "notifications", "severity")
+	if err != nil || has {
+		return err
+	}
+	_, err = tx.Exec("ALTER TABLE notifications ADD COLUMN severity TEXT NOT NULL DEFAULT 'info'")
+	return err
 }
 
 // applyMigration93 adds the note a user writes alongside a session's


### PR DESCRIPTION
Notifications had one weight. Everything in the feed looked the same, so a
background job that gave up after five retries read exactly like a workspace
narration finishing, and anything that genuinely needed the user only existed
while the panel happened to be open.

This gives a notification a severity — `info`, `warning`, or `critical` — styles
the panel by it, and gives `critical` an ambient presence outside the panel so a
user who never opens it still cannot miss one.

## The ambient surface

While at least one critical notification is unread:

- a strip sits at the top of the sidebar, above Home, naming the newest one and
  carrying the count when there is more than one;
- the notifications bell escalates — red border, red badge.

Both disappear when the last critical one is read. The strip is an unmount, not
a hidden element: there is no state where an emptied surface still takes space.
Nothing about it animates — attn renders GPU terminals all day, so a permanent
repaint loop is a battery bug no test catches.

The collapsed icon rail has no room for a title, so there the bell escalation
alone carries it. That is deliberate, and verified live in both sidebar states.

## What each severity means

- `critical` — something is degraded and stays degraded until the user acts.
- `warning` — something failed and stopped; nothing else degrades while it waits.
  The dead-background-job notification is stamped `warning`.
- `info` — everything else, and the column default.

`critical` has **no producer on `main` yet**. The event that earns it — a plugin
runtime parked after repeated restarts — only exists on `epic/ext-a4`, and its
producer stamps critical there. Shipping the level and its surface to `main`
first is deliberate: `main` syncs into the epic continuously, while epic → main
only lands with the whole epic, so the alternative was holding this behind an
unrelated epic's schedule. Live verification of the critical path below used
hand-inserted rows, since no code path on this branch writes one.

## Carrying existing notifications

Migration 100 adds the column with `DEFAULT 'info'` and carries every existing
row at that default rather than rewriting it. Rows written before this are all
task failures, which the producer now stamps `warning` — but a notification
already sitting in the feed has been seen at its old weight, and promoting it
retroactively would raise an alarm about something the user already dealt with.
`TestMigration100CarriesPreSeverityNotifications` populates the old schema and
asserts the rows survive; mutating the migration to drop-and-recreate fails it on
`carried 0 rows, want 2`.

An unrecognized severity from a newer daemon normalizes to `info` on both read
and write, so a row always lands somewhere rather than nowhere.

## Surfaces

- **Store** — column, normalization on read and write, and
  `UnreadCriticalNotifications` returning the count and the newest title from one
  statement so they come from one instant.
- **Protocol** — `NotificationSeverity` enum, `severity` on `Notification`, and
  `unread_critical_count` / `critical_title` on **both** `notification_list_result`
  and `notifications_updated`. `ProtocolVersion` 221 → 222 in
  `internal/protocol/constants.go` and `app/src/hooks/useDaemonSocket.ts`;
  generated files regenerated, never hand-edited.
- **Daemon** — the dead-job producer stamps `warning`; both the list result and
  the broadcast projection carry the critical pair.
- **App** — panel styling, the strip, the bell escalation, and three new CSS
  variables (`--color-severity-{info,warning,critical}`) defined in `App.css`,
  since an undefined `var()` is a silent no-op.
- **CLI** — no surface exists. The notifications feed has never been reachable
  from `cmd/attn`; nothing was skipped.

The ambient state comes off the wire on both the list result and the broadcast,
never derived from a fetched list — the panel only lists while it is open, so
deriving it would mean a user who never opens the panel never learns anything is
critical. A broadcast from an older daemon carries neither field and reads as
"nothing critical": the surface staying down is the safe failure.

## Verification

Automated: store round-trip, normalization, and migration-carry tests; producer
stamping tests; frontend tests for the strip appearing and clearing, the panel's
per-severity classes, and the socket reading the critical pair off both message
shapes (including the missing-field case). `go test ./...`, 240 frontend test
files, `tsc --noEmit`, `pnpm run build`, `go vet`, `gofmt`, and `changelog-check`
all green. The wire golden moves by exactly `+ "unread_critical_count": 0`.

Live, on a throwaway `sevcheck` profile installed from this branch (preflight
PASS, protocol 222 on both sides, since removed with `attn profile clean`):

- Migration applied to a real database: `MAX(version)` = 100,
  `PRAGMA table_info(notifications)` shows `severity TEXT NOT NULL DEFAULT 'info'`.
- Five rows seeded — two critical unread, one warning unread, one info unread,
  one info read. A WebSocket client saw `unread_critical_count = 2`,
  `critical_title = "Plugin stopped"` (the newer of the two), and per-row
  `severity` on every notification.
- In the running app: the strip read "Plugin stopped 2" above Home and the bell
  was escalated with a red badge; the panel showed red / red / amber / blue
  spines with CRITICAL and WARNING tags and no tag on info; **Mark all read**
  removed the strip from the DOM and dropped the bell back to normal in the same
  frame. Collapsing to the icon rail kept the escalated bell.

Screenshots of all four states were captured from the running packaged app and
shared with the maintainer directly; this repo has no place to host them.
