### PR TITLE
fix(sessions): keep one reason while a turn keeps running

### DIFF
--- a/app/src/components/StateIndicator.test.tsx
+++ b/app/src/components/StateIndicator.test.tsx
@@ -89,7 +89,7 @@ describe('StateIndicator', () => {
   // Every other state says what it means by its own name; a tooltip repeating
   // that is noise.
   it('does not explain states that speak for themselves', () => {
-    render(<StateIndicator state="working" reason="heartbeat_fresh" />);
+    render(<StateIndicator state="working" reason="heartbeat_busy" />);
     expect(screen.getByTestId('state-indicator')).not.toHaveAttribute('title');
   });
 

--- a/changelog.d/evidence-reason-flap.yaml
+++ b/changelog.d/evidence-reason-flap.yaml
@@ -1,0 +1,9 @@
+kind: fixed
+area: sessions
+change: >
+  A running session no longer renames itself once a second. The reason behind a
+  state named the freshness window the tick happened to sample the agent's last
+  title frame in, so a busy turn crossing that window — which a turn painting a
+  frame roughly once a second does constantly — was reported as a change, and
+  every one of those wrote a durable event and pushed the session to every open
+  client. A turn that keeps running now has one reason for as long as it runs.

--- a/internal/attention/turn_test.go
+++ b/internal/attention/turn_test.go
@@ -51,7 +51,7 @@ func TestBreaksSnooze(t *testing.T) {
 		{"a session sitting at its prompt", protocol.SessionStateIdle, string(sessionstate.ReasonAtPrompt), false},
 		{"a question", protocol.SessionStateWaitingInput, string(sessionstate.ReasonQuestionOpen), false},
 		{"an approval", protocol.SessionStatePendingApproval, string(sessionstate.ReasonApprovalOpen), false},
-		{"working", protocol.SessionStateWorking, string(sessionstate.ReasonHeartbeatFresh), false},
+		{"working", protocol.SessionStateWorking, string(sessionstate.ReasonHeartbeatBusy), false},
 		{"scheduled", protocol.SessionStateScheduled, string(sessionstate.ReasonCronPending), false},
 		{"recoverable, which the daemon revives unattended", protocol.SessionStateRecoverable, "", false},
 

--- a/internal/daemon/session_evidence_test.go
+++ b/internal/daemon/session_evidence_test.go
@@ -183,7 +183,7 @@ func TestTheResolveTickPublishesTheResolution(t *testing.T) {
 	}
 	// The reason names the clause that won, which is the whole diagnostic value
 	// of the row: "working" alone never explains a wrong color.
-	if !strings.Contains(got.Detail, string(sessionstate.ReasonHeartbeatFresh)) {
+	if !strings.Contains(got.Detail, string(sessionstate.ReasonHeartbeatBusy)) {
 		t.Fatalf("detail %q does not name the winning clause", got.Detail)
 	}
 }
@@ -613,7 +613,7 @@ func TestACodexApprovalTitleBecomesAnApproval(t *testing.T) {
 	}
 	if got.Heartbeat == nil || got.Heartbeat.Claim != sessionstate.ClaimBusy {
 		// Guard the exact hazard: an approval title that still reads busy is
-		// invisible, because ReasonHeartbeatFresh returns before the approval
+		// invisible, because ReasonHeartbeatBusy returns before the approval
 		// clause is reached.
 	} else {
 		t.Fatal("the approval title left the heartbeat busy, which hides the approval")
@@ -626,5 +626,116 @@ func TestACodexApprovalTitleBecomesAnApproval(t *testing.T) {
 	res := sessionstate.Resolve(got, sessionstate.PolicyFor(string(protocol.SessionAgentCodex)), at)
 	if res.State != protocol.SessionStatePendingApproval {
 		t.Fatalf("resolved %q (%s), want pending_approval", res.State, res.Reason)
+	}
+}
+
+// stateChangesSince counts the session.state.changed facts the bus logged past
+// cursor, and returns the new cursor.
+func stateChangesSince(t *testing.T, d *Daemon, cursor int64) (int, int64) {
+	t.Helper()
+	events, err := d.store.BusEventsSince(cursor, 1000)
+	if err != nil {
+		t.Fatalf("BusEventsSince: %v", err)
+	}
+	count := 0
+	for _, event := range events {
+		if event.Name == FactSessionStateChanged {
+			count++
+		}
+		cursor = event.Seq
+	}
+	return count, cursor
+}
+
+// The evidence tick is the daemon's loudest publisher: it re-resolves every live
+// session once a second and broadcasts whenever the answer is news. A busy claude
+// session repaints its title about once a second too, so the tick samples the
+// newest frame at every age between two of them, walking across the 1.5s
+// precedence TTL and back all turn long.
+//
+// While the reason named the window that age happened to land in, every one of
+// those crossings was news: a durable bus row and a decorated snapshot pushed to
+// every connected client, once a second, for a session that never moved.
+// Measured over 7.5 production days, session.state.changed was 74.7% of the whole
+// bus log and two thirds of it was this.
+func TestTheEvidenceTickIsSilentWhileTheTurnKeepsRunning(t *testing.T) {
+	d := newTraceDaemon(t)
+	t.Cleanup(d.stopEventBus)
+	id := "sess-tick-quiet"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+	d.recordBracketEvidence(id, protocol.StateWorking)
+
+	base := time.Now()
+	// The first tick is where the reason becomes known, so it is legitimately
+	// news. The sweep is counted from after it.
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", Detail: "⠐ working", At: base})
+	d.resolveAllSessions(base)
+	_, cursor := stateChangesSince(t, d, 0)
+
+	// Ten ticks of a turn that never stops, sampled alternately inside and
+	// outside the TTL — the drift between a 1s tick and a ~1s repaint.
+	for tick := 1; tick <= 10; tick++ {
+		now := base.Add(time.Duration(tick) * time.Second)
+		age := 1200 * time.Millisecond
+		if tick%2 == 1 {
+			age = 1800 * time.Millisecond
+		}
+		d.recordPTYEvidence(id, pty.Observation{
+			Source: pty.SourceHeartbeat,
+			Claim:  "busy",
+			Detail: "⠐ working",
+			At:     now.Add(-age),
+		})
+		d.resolveAllSessions(now)
+	}
+
+	if published, _ := stateChangesSince(t, d, cursor); published != 0 {
+		t.Fatalf("the tick published %d state changes for a turn that never moved", published)
+	}
+}
+
+// The other half of the same gate: quiet is only correct while nothing changes.
+// A reason that moves without the state — the session is now compacting, which
+// is still `working` but a different account of it — is what the tooltip is for,
+// and it has to reach the client.
+func TestTheEvidenceTickPublishesAReasonThatMovesOnItsOwn(t *testing.T) {
+	d := newTraceDaemon(t)
+	t.Cleanup(d.stopEventBus)
+	id := "sess-tick-news"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+	d.recordBracketEvidence(id, protocol.StateWorking)
+
+	base := time.Now()
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", Detail: "⠐ working", At: base})
+	d.resolveAllSessions(base)
+	_, cursor := stateChangesSince(t, d, 0)
+
+	// Compaction outranks the bracket, and paints no frames of its own, so the
+	// heartbeat has to be past the TTL for it to be reached.
+	d.recordCompactionEvidence(id, true)
+	now := base.Add(2 * time.Second)
+	d.resolveAllSessions(now)
+
+	published, cursor := stateChangesSince(t, d, cursor)
+	if published != 1 {
+		t.Fatalf("compaction published %d state changes, want 1: the reason moved", published)
+	}
+	if got := d.stateReasons().get(id); got != string(sessionstate.ReasonCompacting) {
+		t.Fatalf("reason %q, want %q", got, sessionstate.ReasonCompacting)
+	}
+	if state := d.store.Get(id).State; state != protocol.SessionStateWorking {
+		t.Fatalf("state %q, want working: compaction is work", state)
+	}
+
+	// And a state that moves publishes too, which is the case the gate exists to
+	// let through.
+	d.recordProcessEvidence(id, true)
+	d.resolveAllSessions(now.Add(time.Second))
+
+	if published, _ = stateChangesSince(t, d, cursor); published == 0 {
+		t.Fatal("an exited process published nothing")
+	}
+	if state := d.store.Get(id).State; state != protocol.SessionStateIdle {
+		t.Fatalf("state %q, want idle after the process exited", state)
 	}
 }

--- a/internal/daemon/session_evidence_test.go
+++ b/internal/daemon/session_evidence_test.go
@@ -656,8 +656,10 @@ func stateChangesSince(t *testing.T, d *Daemon, cursor int64) (int, int64) {
 // While the reason named the window that age happened to land in, every one of
 // those crossings was news: a durable bus row and a decorated snapshot pushed to
 // every connected client, once a second, for a session that never moved.
-// Measured over 7.5 production days, session.state.changed was 74.7% of the whole
-// bus log and two thirds of it was this.
+// Measured over 8.4 production days, session.state.changed was 73.7% of the whole
+// bus log (233,497 of 316,721 facts), and 81.6% of consecutive facts for one
+// session landed within a second of the previous one — the tick period, not
+// anything a session did.
 func TestTheEvidenceTickIsSilentWhileTheTurnKeepsRunning(t *testing.T) {
 	d := newTraceDaemon(t)
 	t.Cleanup(d.stopEventBus)

--- a/internal/sessionstate/clause_order_test.go
+++ b/internal/sessionstate/clause_order_test.go
@@ -51,7 +51,7 @@ func TestClauseOrder(t *testing.T) {
 				LastHarnessEvent: seen(SourceHarnessEvent, ClaimApprovalPending, 5*time.Second),
 			},
 			wantState:  protocol.SessionStateWorking,
-			wantReason: ReasonHeartbeatFresh,
+			wantReason: ReasonHeartbeatBusy,
 		},
 		{
 			why: "an unanswered approval outranks a parked wakeup and an open " +

--- a/internal/sessionstate/sessionstate.go
+++ b/internal/sessionstate/sessionstate.go
@@ -188,8 +188,11 @@ func PolicyFor(agent string) Policy {
 type Reason string
 
 const (
-	ReasonProcessExited     Reason = "process_exited"
-	ReasonHeartbeatFresh    Reason = "heartbeat_fresh"
+	ReasonProcessExited Reason = "process_exited"
+	// ReasonHeartbeatBusy covers every believable busy frame, however recently it
+	// was painted: the windows it crosses decide precedence and settling, not
+	// whether the agent is running.
+	ReasonHeartbeatBusy     Reason = "heartbeat_busy"
 	ReasonApprovalOpen      Reason = "approval_open"
 	ReasonQuestionOpen      Reason = "question_open"
 	ReasonCronPending       Reason = "cron_pending"
@@ -197,7 +200,6 @@ const (
 	ReasonPromptIdle        Reason = "prompt_idle"
 	ReasonBracketStale      Reason = "bracket_stale"
 	ReasonHeartbeatSettled  Reason = "heartbeat_settled"
-	ReasonHeartbeatGap      Reason = "heartbeat_gap"
 	ReasonSettleGrace       Reason = "settle_grace"
 	ReasonAwaitingVerdict   Reason = "awaiting_verdict"
 	ReasonBackgroundWork    Reason = "background_work"
@@ -234,7 +236,7 @@ func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
 
 	// Rescues a lost turn-open hook: visibly running outranks the brackets.
 	if fresh(e.Heartbeat, ClaimBusy, now, policy.HeartbeatTTL) {
-		return Resolution{State: protocol.SessionStateWorking, Reason: ReasonHeartbeatFresh, Detail: e.Heartbeat.Detail}
+		return running(e)
 	}
 
 	// Blocked on a person, announced exactly when the turn stops looking like it
@@ -306,7 +308,7 @@ func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
 			return Resolution{State: protocol.SessionStateUnknown, Reason: ReasonStuck}
 		}
 		if !heartbeatSilentFor(e, now, policy.StaleAfter) {
-			return Resolution{State: protocol.SessionStateWorking, Reason: ReasonBracketOpen}
+			return running(e)
 		}
 		// A finished turn and an unannounced approval look the same, so hold for
 		// SettleGrace rather than assert idle into a late explanation; a verdict
@@ -327,7 +329,7 @@ func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
 		// A gap only longer than the TTL is a repaint gap, not a settle; without
 		// HeartbeatSettleAfter every wide gap costs one owed turn.
 		if e.Heartbeat.Claim == ClaimBusy && !heartbeatSilentFor(e, now, policy.HeartbeatSettleAfter) {
-			return Resolution{State: protocol.SessionStateWorking, Reason: ReasonHeartbeatGap, Detail: e.Heartbeat.Detail}
+			return running(e)
 		}
 		return settled(e, ReasonHeartbeatSettled, policy, now)
 	}
@@ -358,6 +360,21 @@ func Resolve(e Evidence, policy Policy, now time.Time) Resolution {
 	}
 
 	return Resolution{State: protocol.SessionStateUnknown, Reason: ReasonNoEvidence}
+}
+
+// running is the one answer for a turn that is going. Three clauses reach one,
+// separated by windows a working agent crosses all turn long, so a reason named
+// after the window renamed a session that never moved. The bracket names it when
+// one is open: it is the witness that holds while title frames come and go.
+func running(e Evidence) Resolution {
+	if e.TurnOpen || e.ToolOpen {
+		return Resolution{State: protocol.SessionStateWorking, Reason: ReasonBracketOpen}
+	}
+	detail := ""
+	if e.Heartbeat != nil {
+		detail = e.Heartbeat.Detail
+	}
+	return Resolution{State: protocol.SessionStateWorking, Reason: ReasonHeartbeatBusy, Detail: detail}
 }
 
 // settled resolves a turn that is over, preferring the classifier's verdict and

--- a/internal/sessionstate/sessionstate_test.go
+++ b/internal/sessionstate/sessionstate_test.go
@@ -49,7 +49,7 @@ func TestResolve(t *testing.T) {
 				Heartbeat: seen(SourceHeartbeat, ClaimBusy, 200*time.Millisecond),
 			},
 			wantState:  protocol.SessionStateWorking,
-			wantReason: ReasonHeartbeatFresh,
+			wantReason: ReasonHeartbeatBusy,
 		},
 		{
 			// A lost Stop hook used to hold the session working forever. Once the
@@ -162,7 +162,7 @@ func TestResolve(t *testing.T) {
 				LastBusyAt: now.Add(-50 * time.Millisecond),
 			},
 			wantState:  protocol.SessionStateWorking,
-			wantReason: ReasonHeartbeatFresh,
+			wantReason: ReasonBracketOpen,
 		},
 		{
 			// Only a full window with no busy frame at all settles it, however
@@ -364,7 +364,7 @@ func TestResolve(t *testing.T) {
 				LastHarnessEvent: seen(SourceHarnessEvent, ClaimApprovalPending, 30*time.Second),
 			},
 			wantState:  protocol.SessionStateWorking,
-			wantReason: ReasonHeartbeatFresh,
+			wantReason: ReasonHeartbeatBusy,
 		},
 		{
 			// Once the heartbeat expires, the approval stands again.
@@ -426,7 +426,7 @@ func TestResolve(t *testing.T) {
 				LastBusyAt:  now.Add(-100 * time.Millisecond),
 			},
 			wantState:  protocol.SessionStateWorking,
-			wantReason: ReasonHeartbeatFresh,
+			wantReason: ReasonHeartbeatBusy,
 		},
 		{
 			// A yield is judged, and the verdict outranks the yield's own guess. An
@@ -730,7 +730,7 @@ func TestResolve(t *testing.T) {
 				LastMovement:     now.Add(-100 * time.Millisecond),
 			},
 			wantState:  protocol.SessionStateWorking,
-			wantReason: ReasonHeartbeatFresh,
+			wantReason: ReasonBracketOpen,
 		},
 		{
 			// An abort is not an approval: the agent asked nothing, so the session
@@ -1029,6 +1029,73 @@ func TestHeartbeatTTLExpiryCannotSettleAnOpenBracket(t *testing.T) {
 	}
 }
 
+// A running turn must resolve to ONE answer for as long as it keeps painting
+// busy frames — the same state, the same reason, the same detail.
+//
+// The resolver is sampled once a second by a loop that publishes whenever its
+// answer changes, so an answer that moves while the session does not is a flood
+// rather than a cosmetic wobble. A turn painting frames roughly once a second is
+// sampled at every age between two frames, so it crosses the TTL in both
+// directions all turn long; naming the windows in the reason made a busy session
+// rename itself about once a second, and each rename wrote a durable bus fact
+// and pushed a decorated snapshot to every client. Measured on 7.5 production
+// days: 66% of the entire bus log was this rename.
+//
+// The sweep is per millisecond and runs to the end of the span the frame is
+// believed, because the flap lived at one boundary inside it and a coarser sweep
+// steps over the next one.
+func TestARunningTurnKeepsOneAnswerWhileItKeepsPainting(t *testing.T) {
+	policy := testPolicy()
+	for _, tc := range []struct {
+		name     string
+		evidence func(age time.Duration) Evidence
+		believed time.Duration
+	}{
+		{
+			// Claude with hooks: the shape the flap was measured on.
+			name: "an open bracket believes a frame until the stale window",
+			evidence: func(age time.Duration) Evidence {
+				return Evidence{
+					TurnOpen:       true,
+					TurnEverOpened: true,
+					Heartbeat:      seen(SourceHeartbeat, ClaimBusy, age),
+					LastBusyAt:     now.Add(-age),
+					LastMovement:   now.Add(-age),
+				}
+			},
+			believed: policy.StaleAfter,
+		},
+		{
+			// The same turn with no bracket to hold it — a lost turn-open hook, or
+			// an agent that reports no brackets at all. The heartbeat is then the
+			// only witness, and it is believed only to the settle window.
+			name: "a bare heartbeat believes a frame until the settle window",
+			evidence: func(age time.Duration) Evidence {
+				return Evidence{
+					TurnEverOpened: true,
+					Heartbeat:      seen(SourceHeartbeat, ClaimBusy, age),
+					LastBusyAt:     now.Add(-age),
+					LastMovement:   now.Add(-age),
+				}
+			},
+			believed: policy.HeartbeatSettleAfter,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			want := Resolve(tc.evidence(0), policy, now)
+			if want.State != protocol.SessionStateWorking {
+				t.Fatalf("the freshest frame resolved %s, want working", want.State)
+			}
+			for age := time.Duration(0); age <= tc.believed; age += time.Millisecond {
+				if got := Resolve(tc.evidence(age), policy, now); got != want {
+					t.Fatalf("a %s-old busy frame resolved %+v, want the %+v it resolved at 0: the answer moved while the session did not",
+						age, got, want)
+				}
+			}
+		})
+	}
+}
+
 // Same for the stale window: a bracket holds until the silence passes it.
 func TestBracketStalenessBoundary(t *testing.T) {
 	policy := testPolicy()
@@ -1179,7 +1246,7 @@ func TestShellLifecycleResolvesOnTheForegroundHeartbeatAlone(t *testing.T) {
 				LastBusyAt: now.Add(-time.Second),
 			},
 			wantState:  protocol.SessionStateWorking,
-			wantReason: ReasonHeartbeatFresh,
+			wantReason: ReasonHeartbeatBusy,
 		},
 		{
 			// The command ended and the shell took the foreground back. No

--- a/internal/sessionstate/sessionstate_test.go
+++ b/internal/sessionstate/sessionstate_test.go
@@ -1038,8 +1038,10 @@ func TestHeartbeatTTLExpiryCannotSettleAnOpenBracket(t *testing.T) {
 // sampled at every age between two frames, so it crosses the TTL in both
 // directions all turn long; naming the windows in the reason made a busy session
 // rename itself about once a second, and each rename wrote a durable bus fact
-// and pushed a decorated snapshot to every client. Measured on 7.5 production
-// days: 66% of the entire bus log was this rename.
+// and pushed a decorated snapshot to every client. Measured over 8.4 production
+// days: session.state.changed was 73.7% of the whole bus log, and 81.6% of
+// consecutive facts for one session landed within a second of the previous one —
+// the tick period, not anything a session did.
 //
 // The sweep is per millisecond and runs to the end of the span the frame is
 // believed, because the flap lived at one boundary inside it and a coarser sweep


### PR DESCRIPTION
`session.state.changed` is 73.7% of attn's entire durable bus log — 233,497 of
316,721 facts over 8.4 production days. Almost none of it is a session changing.

## What was happening

The evidence resolver names a state with a *reason*, and the daemon re-resolves
every live session once a second, publishing whenever that answer is news. Two of
the reasons were named after a window rather than after a finding:

- `heartbeat_fresh` — a busy title frame inside `HeartbeatTTL` (1.5s for claude).
- `heartbeat_gap` — the same busy frame past the TTL but inside the settle window.

The TTL is a *precedence* window: it decides whether a busy frame outranks the
harness edges, not whether the agent is running. Claude paints a frame roughly
once a second, so the one-second tick samples the newest frame at every age
between two frames and crosses that 1.5s boundary in both directions all turn
long. With a bracket open the answer alternated `heartbeat_fresh` ⇄
`bracket_open`; with no bracket, `heartbeat_fresh` ⇄ `heartbeat_gap`. Same state,
same evidence, different name — and every rename wrote a durable bus row and
pushed a decorated session snapshot to every connected client, about once a
second per busy session, all day.

Receipt for the mechanism, straight off the production log: 81.6% of consecutive
`session.state.changed` facts for the same session (190,503 of 233,394) arrive
within one second of the previous one. That is the tick period, not anything a
session did.

## The fix

Every clause that reaches a running turn now returns one answer, built in one
place:

```go
func running(e Evidence) Resolution {
	if e.TurnOpen || e.ToolOpen {
		return Resolution{State: working, Reason: ReasonBracketOpen}
	}
	return Resolution{State: working, Reason: ReasonHeartbeatBusy, Detail: …}
}
```

The bracket names it when one is open: it is the witness that holds while title
frames come and go. `heartbeat_fresh` and `heartbeat_gap` were both named after
the windows rather than the finding, so they collapse into `heartbeat_busy`.

**Clause precedence is untouched.** A busy frame inside the TTL still outranks the
harness edges — the rescue for a lost turn-open hook — and every window still does
its own job. Only the label the winning clause hands back changed; the bracket
path is byte-identical to before, and the heartbeat path defers to it.

No debounce, no coalescing, no gate weakening: a reason that genuinely moves
without the state (a turn that starts compacting) still publishes, and so does
every state change.

## Verification

**Unit.** `TestARunningTurnKeepsOneAnswerWhileItKeepsPainting`
(`internal/sessionstate`) sweeps the age of the last busy frame per millisecond
across the whole span it is believed — to `StaleAfter` with a bracket, to
`HeartbeatSettleAfter` without — and requires one identical `Resolution`
throughout. `TestTheEvidenceTickIsSilentWhileTheTurnKeepsRunning`
(`internal/daemon`) drives ten real ticks with the frame age alternating either
side of the TTL and asserts zero facts on the bus; reverting only the naming
turns it red at **10 facts over 10 ticks** — one per second, matching production.
`TestTheEvidenceTickPublishesAReasonThatMovesOnItsOwn` holds the other side of the
gate: compaction (same state, different reason) publishes, and so does an exited
process.

**Live.** Throwaway `flapfix` profile, packaged app installed from this branch,
sessions spawned through the app; a delegated claude session ran the same
four-minute workload (twenty blocking `sleep 12` tool calls) against a pre-fix
daemon and a fixed one on the same profile.

| daemon | `session.state.changed` for the busy session |
|---|---|
| pre-fix | **103** in four minutes of one turn (~26/min); 79 of 102 consecutive facts ≤1s apart |
| this branch | **2** — both at spawn; zero for the rest of the turn (0 in the 225s window sampled while it was `working`) |

Sampling `state_reason` once a second on the pre-fix daemon shows the alternation
directly; on this branch the busy session reads `bracket_open` for the whole turn.
`attn state explain` still reads sensibly — `at_prompt` for the idle session,
`bracket_open` for the busy one, with the heartbeat and hook observations behind
them.

## Not in this PR

Projection/wire coalescing and bus retention/observability are separate work.
