### PR TITLE
fix(build): define UNAME_S so install-daemon signs the binary on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,12 @@ BUILD_TIME ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 SOURCE_FINGERPRINT ?= $(shell bash ./scripts/source-fingerprint.sh --field fingerprint)
 GIT_COMMIT ?= $(shell bash ./scripts/source-fingerprint.sh --field commit)
 OUTPUT ?= $(BINARY_NAME)
+# Guards the macOS-only branches below (code signing, the lsof port check). It
+# was used by three recipes and defined by none, so `$(UNAME_S)` expanded to
+# empty and `install-daemon` skipped signing entirely: the copied binary kept its
+# ad-hoc linker signature inside a properly signed bundle, and macOS answered
+# `daemon ensure` with Killed: 9.
+UNAME_S := $(shell uname -s)
 GO_LDFLAGS = -X github.com/victorarias/attn/internal/buildinfo.Version=$(VERSION) -X github.com/victorarias/attn/internal/buildinfo.BuildTime=$(BUILD_TIME) -X github.com/victorarias/attn/internal/buildinfo.SourceFingerprint=$(SOURCE_FINGERPRINT) -X github.com/victorarias/attn/internal/buildinfo.GitCommit=$(GIT_COMMIT)
 # Honor the repository's .tool-versions even when an older standalone Zig is
 # earlier on PATH (the app's WASM builder follows the same order).

--- a/changelog.d/makefile-uname-s-codesign.yaml
+++ b/changelog.d/makefile-uname-s-codesign.yaml
@@ -1,0 +1,7 @@
+kind: fixed
+area: build
+change: >
+  `make install-daemon` signs the daemon binary again on macOS. The recipe's
+  Darwin check read `$(UNAME_S)`, which was referenced by three recipes and
+  defined by none, so signing was silently skipped and the freshly installed
+  sidecar died with `Killed: 9` at `daemon ensure`. `UNAME_S` is now defined.


### PR DESCRIPTION
## Intent / Why

`make install-daemon` (and `install-daemon-dev`) ends with macOS killing the freshly installed daemon: `daemon ensure` reports `Killed: 9`. The recipe's codesign block is guarded by `if [ "$(UNAME_S)" = "Darwin" ]`, and `UNAME_S` was referenced by three Makefile recipes but defined by none — it expanded to empty, the guard never matched, and signing was silently skipped, leaving the sidecar with its ad-hoc linker signature inside a properly signed bundle. This forced everyone off the cheap daemon-only install tier onto full app builds.

## Summary

- define `UNAME_S := $(shell uname -s)`, with a comment explaining what it guards and what the absence broke

This is the same one-line fix that already landed on `epic/ext-a4` in #826, brought to main so main-based worktrees get working daemon-only installs before the epic lands. The epic sync will merge cleanly (identical line).

## Verification

- root-caused and fixed on the epic in #826 with a live install receipt; re-hit independently on a main worktree in #830's live verification, where hand-codesigning confirmed the diagnosis
- `make -n install-daemon` parses; changelog fragment validated with `go run ./cmd/changelog-check`

https://claude.ai/code/session_01429snMWPwXjv1NeqUdV57c