### PR TITLE
feat(bus): show what the event bus is doing, in the CLI and the app

### DIFF
--- a/app/src/components/EventBusSettings.css
+++ b/app/src/components/EventBusSettings.css
@@ -1,0 +1,187 @@
+/* Event Bus settings section. Only the classes this section owns; the block,
+   intro, kicker, pill, action, hint, empty and warning vocabulary comes from
+   SettingsModal.css. */
+
+.bus-state {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+/* Health first: what is wrong, in the daemon's own words. */
+.bus-health {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.bus-health-entry {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 6px;
+  background: color-mix(in srgb, #ff9f7a 8%, transparent);
+}
+
+.bus-health-entry.error {
+  background: color-mix(in srgb, #ff6b6b 10%, transparent);
+}
+
+.bus-health-message {
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  line-height: 1.45;
+}
+
+/* The log's headline numbers. */
+.bus-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 8px;
+}
+
+.bus-stat {
+  display: grid;
+  gap: 2px;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 6px;
+  background: var(--color-bg-elevated);
+}
+
+.bus-stat-label {
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.bus-stat-value {
+  color: var(--color-text-primary);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: var(--font-size-sm);
+  font-variant-numeric: tabular-nums;
+}
+
+.bus-section-head {
+  display: grid;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.bus-section-head h4 {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+}
+
+/* Tables are grid row lists, as everywhere else in settings. Wide content
+   scrolls inside its own box rather than pushing the modal sideways. */
+.bus-table {
+  display: grid;
+  gap: 0;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 6px;
+  overflow-x: auto;
+}
+
+.bus-row {
+  display: grid;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 10px;
+  border-top: 1px solid var(--color-border-subtle);
+  min-width: 0;
+}
+
+.bus-row:first-child {
+  border-top: none;
+}
+
+.bus-producers .bus-row {
+  grid-template-columns: minmax(180px, 1fr) repeat(5, minmax(56px, auto));
+}
+
+.bus-consumers .bus-row {
+  grid-template-columns: minmax(180px, 1fr) repeat(3, minmax(56px, auto)) auto;
+}
+
+.bus-head {
+  background: var(--color-bg-elevated);
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.bus-row.surging {
+  background: color-mix(in srgb, #ff9f7a 7%, transparent);
+}
+
+.bus-row.disabled .bus-name,
+.bus-row.disabled .bus-num {
+  opacity: 0.55;
+}
+
+.bus-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  min-width: 0;
+  color: var(--color-text-primary);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: var(--font-size-xs);
+  overflow-wrap: anywhere;
+}
+
+.bus-filter {
+  color: var(--color-text-dimmed);
+  font-size: var(--font-size-xs);
+}
+
+.bus-num {
+  color: var(--color-text-secondary);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: var(--font-size-xs);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.bus-head .bus-num {
+  color: var(--color-text-tertiary);
+}
+
+.bus-row-action {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.bus-more {
+  justify-self: start;
+  padding: 4px 0;
+  border: none;
+  background: none;
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+}
+
+.bus-more:hover {
+  color: var(--color-text-secondary);
+}
+
+.bus-footer {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+}

--- a/app/src/components/EventBusSettings.test.tsx
+++ b/app/src/components/EventBusSettings.test.tsx
@@ -1,0 +1,229 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventBusSettings } from './EventBusSettings';
+import type { BusStatus } from '../hooks/daemonBusEvents';
+
+const producer = (over: Partial<BusStatus['producers'][number]> = {}) => ({
+  name: 'session.state.changed',
+  events: 232213,
+  bytes: 17_900_000,
+  subjects: 103,
+  share: 0.737,
+  recent_per_hour: 1701,
+  baseline_per_hour: 1816,
+  sustained_per_hour: 680,
+  surging: true,
+  surge_window_seconds: 86400,
+  surge_per_hour: 1816,
+  ...over,
+});
+
+const consumer = (over: Partial<BusStatus['consumers'][number]> = {}) => ({
+  name: 'notifier',
+  cursor: 100,
+  lag: 0,
+  filter: 'session.*',
+  enabled: true,
+  updated_at: '2026-08-10T19:00:00Z',
+  live: true,
+  stalled: '',
+  oldest_unread_at: '',
+  holds_retention_floor: false,
+  ...over,
+});
+
+const status = (over: Partial<BusStatus> = {}): BusStatus => ({
+  earliest: 1,
+  head: 315188,
+  rows: 315188,
+  bytes: 23_815_114,
+  oldestAt: '2026-08-02T10:24:55Z',
+  newestAt: '2026-08-10T19:28:01Z',
+  delivering: true,
+  retentionSeconds: 30 * 86400,
+  recentWindowSeconds: 3600,
+  baselineWindowSeconds: 86400,
+  surgeRatePerHour: 1000,
+  producers: [producer()],
+  consumers: [],
+  health: [],
+  ...over,
+});
+
+const renderPane = (value: BusStatus, setEnabled = vi.fn().mockResolvedValue({ consumer: 'x' })) => {
+  const getBusStatus = vi.fn().mockResolvedValue(value);
+  render(<EventBusSettings getBusStatus={getBusStatus} setConsumerEnabled={setEnabled} />);
+  return { getBusStatus, setEnabled };
+};
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.setSystemTime(new Date('2026-08-10T19:30:00Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('EventBusSettings', () => {
+  // The page exists because nobody could see what the bus was doing. Reading it
+  // more than once per open would be the other failure — a diagnostics page that
+  // costs battery to leave open.
+  it('reads the bus once on open and does not loop', async () => {
+    const { getBusStatus } = renderPane(status());
+    await waitFor(() => screen.getByTestId('bus-producers'));
+
+    expect(getBusStatus).toHaveBeenCalledTimes(1);
+    await act(() => vi.advanceTimersByTimeAsync(5_000));
+    expect(getBusStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes on a slow interval while it stays open', async () => {
+    const { getBusStatus } = renderPane(status());
+    await waitFor(() => screen.getByTestId('bus-producers'));
+
+    await act(() => vi.advanceTimersByTimeAsync(30_000));
+    expect(getBusStatus).toHaveBeenCalledTimes(2);
+  });
+
+  // The producers table is the surface that would have caught the flap in a
+  // glance: who is writing, how much of the log they own, across how few
+  // subjects.
+  it('shows each producer with its share, subjects and rates, loudest first', async () => {
+    renderPane(status({
+      producers: [producer(), producer({
+        name: 'pr.updated', events: 53182, share: 0.169, subjects: 107,
+        recent_per_hour: 279, baseline_per_hour: 329, sustained_per_hour: 148,
+        surging: false, surge_window_seconds: 0, surge_per_hour: 0,
+      })],
+    }));
+
+    const loud = await screen.findByTestId('bus-producer-session.state.changed');
+    expect(loud).toHaveTextContent('232,213');
+    expect(loud).toHaveTextContent('73.7%');
+    expect(loud).toHaveTextContent('103');
+    // A producer over the tripwire is marked, not left for the reader to spot.
+    expect(loud).toHaveTextContent('Loud');
+
+    expect(screen.getByTestId('bus-producer-pr.updated')).not.toHaveTextContent('Loud');
+  });
+
+  // A quiet tail is collapsed, never silently dropped: the count and the share
+  // it accounts for are always on screen.
+  it('states what the collapsed tail holds and can expand it', async () => {
+    renderPane(status({
+      producers: [
+        producer(),
+        producer({ name: 'ticket.created', events: 4, share: 0.002, surging: false }),
+        producer({ name: 'plugin.installed', events: 1, share: 0.001, surging: false }),
+      ],
+    }));
+    await screen.findByTestId('bus-producers');
+
+    expect(screen.queryByTestId('bus-producer-ticket.created')).toBeNull();
+    const toggle = screen.getByTestId('bus-toggle-quiet');
+    expect(toggle).toHaveTextContent('2 quieter classes');
+    expect(toggle).toHaveTextContent('5 events');
+    expect(toggle).toHaveTextContent('0.3% of the log');
+
+    fireEvent.click(toggle);
+    expect(screen.getByTestId('bus-producer-ticket.created')).toBeInTheDocument();
+  });
+
+  // Health arrives as finished sentences from the daemon. The page renders them
+  // rather than re-deriving "this is bad" from the numbers, which is what keeps
+  // it and `attn bus status` saying the same thing.
+  it('renders the daemon health findings verbatim', async () => {
+    renderPane(status({
+      health: [
+        {
+          level: 'error',
+          kind: 'consumer_lagging',
+          subject: 'notifier',
+          message: 'consumer notifier is 41,000 events behind and not advancing; its cursor has not moved for 2h',
+        },
+        {
+          level: 'warn',
+          kind: 'producer_surging',
+          subject: 'session.state.changed',
+          message: 'producer session.state.changed is publishing 1816 events/hour sustained over the last 24h, past the 1000/hour tripwire',
+        },
+      ],
+    }));
+
+    const health = await screen.findByTestId('bus-health');
+    expect(health).toHaveTextContent('41,000 events behind and not advancing');
+    expect(health).toHaveTextContent('past the 1000/hour tripwire');
+    expect(health).toHaveTextContent('Error');
+    expect(health).toHaveTextContent('Warning');
+  });
+
+  // An empty consumer table is the real state of this bus today. It has to read
+  // as a fact about the system, not as a page that failed to load.
+  it('explains an empty consumer list rather than showing a blank table', async () => {
+    renderPane(status());
+    const empty = await screen.findByTestId('bus-no-consumers');
+    expect(empty).toHaveTextContent('No durable consumers are registered');
+    expect(screen.queryByTestId('bus-consumers')).toBeNull();
+  });
+
+  it('marks a disabled consumer, the retention floor, and one that is not running', async () => {
+    renderPane(status({
+      consumers: [
+        consumer({ name: 'killed', enabled: false, cursor: 12, lag: 315176 }),
+        consumer({ name: 'pinner', holds_retention_floor: true, lag: 41000, oldest_unread_at: '2026-08-03T19:30:00Z' }),
+        consumer({ name: 'absent', live: false }),
+        consumer({ name: 'failing', stalled: 'handler blew up' }),
+      ],
+    }));
+    await screen.findByTestId('bus-consumers');
+
+    expect(screen.getByTestId('bus-consumer-killed')).toHaveTextContent('Disabled');
+    expect(screen.getByTestId('bus-consumer-pinner')).toHaveTextContent('Retention floor');
+    expect(screen.getByTestId('bus-consumer-pinner')).toHaveTextContent('41,000');
+    // 7 days of waiting, from the oldest unread stamp.
+    expect(screen.getByTestId('bus-consumer-pinner')).toHaveTextContent('7d');
+    expect(screen.getByTestId('bus-consumer-absent')).toHaveTextContent('Not running');
+    expect(screen.getByTestId('bus-consumer-failing')).toHaveTextContent('Stalled');
+  });
+
+  // `delivering: false` means the snapshot could not know whether a loop is
+  // running, so the page must not accuse anyone of being down.
+  it('does not claim a consumer is down when delivery is not observable', async () => {
+    renderPane(status({ delivering: false, consumers: [consumer({ name: 'absent', live: false })] }));
+    await screen.findByTestId('bus-consumers');
+
+    expect(screen.getByTestId('bus-consumer-absent')).not.toHaveTextContent('Not running');
+  });
+
+  // The way in needs the way out: disable and enable are the same button.
+  it('toggles a consumer and re-reads the result', async () => {
+    const setEnabled = vi.fn().mockResolvedValue({ consumer: 'notifier' });
+    const { getBusStatus } = renderPane(status({ consumers: [consumer()] }), setEnabled);
+    await screen.findByTestId('bus-consumers');
+
+    fireEvent.click(screen.getByTestId('bus-consumer-toggle-notifier'));
+    await waitFor(() => expect(setEnabled).toHaveBeenCalledWith('notifier', false));
+    // The daemon is authoritative: the row reflects a re-read, not a local guess.
+    await waitFor(() => expect(getBusStatus).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows the failure when the toggle is refused', async () => {
+    const setEnabled = vi.fn().mockRejectedValue(new Error('no consumer named notifier'));
+    renderPane(status({ consumers: [consumer()] }), setEnabled);
+    await screen.findByTestId('bus-consumers');
+
+    fireEvent.click(screen.getByTestId('bus-consumer-toggle-notifier'));
+    await waitFor(() => screen.getByText('no consumer named notifier'));
+  });
+
+  it('offers a retry when the bus cannot be read at all', async () => {
+    const getBusStatus = vi.fn().mockRejectedValue(new Error('disk gone'));
+    render(<EventBusSettings getBusStatus={getBusStatus} setConsumerEnabled={vi.fn()} />);
+
+    await waitFor(() => screen.getByText('disk gone'));
+    getBusStatus.mockResolvedValue(status());
+    fireEvent.click(screen.getByText('Try again'));
+    await waitFor(() => screen.getByTestId('bus-producers'));
+  });
+});

--- a/app/src/components/EventBusSettings.test.tsx
+++ b/app/src/components/EventBusSettings.test.tsx
@@ -196,6 +196,18 @@ describe('EventBusSettings', () => {
     expect(screen.getByTestId('bus-consumer-absent')).not.toHaveTextContent('Not running');
   });
 
+  // `delivering: false` means two different things depending on who read the
+  // snapshot. The CLI read the database; this page always read the daemon, so it
+  // must not borrow the CLI's sentence and claim a transport it did not use.
+  it('says the daemon has no delivery loops rather than claiming it read the database', async () => {
+    renderPane(status({ delivering: false }));
+    await screen.findByTestId('bus-producers');
+
+    const footer = screen.getByTestId('bus-refresh').parentElement as HTMLElement;
+    expect(footer).toHaveTextContent('Read from the daemon');
+    expect(footer).not.toHaveTextContent('from the database');
+  });
+
   // The way in needs the way out: disable and enable are the same button.
   it('toggles a consumer and re-reads the result', async () => {
     const setEnabled = vi.fn().mockResolvedValue({ consumer: 'notifier' });

--- a/app/src/components/EventBusSettings.tsx
+++ b/app/src/components/EventBusSettings.tsx
@@ -145,8 +145,10 @@ export function EventBusSettings({ getBusStatus, setConsumerEnabled }: EventBusS
 
         {status.health.length > 0 && (
           <ul className="bus-health" data-testid="bus-health">
-            {status.health.map((h, i) => (
-              <li key={`${h.kind}:${h.subject}:${i}`} className={`bus-health-entry ${h.level}`}>
+            {/* kind+subject identifies a finding: health() emits at most one of
+                each kind per consumer, producer, or floor. */}
+            {status.health.map((h) => (
+              <li key={`${h.kind}:${h.subject}`} className={`bus-health-entry ${h.level}`}>
                 <span className={`settings-pill ${h.level === 'error' ? 'bad' : 'warn'}`}>
                   {h.level === 'error' ? 'Error' : 'Warning'}
                 </span>

--- a/app/src/components/EventBusSettings.tsx
+++ b/app/src/components/EventBusSettings.tsx
@@ -303,10 +303,13 @@ export function EventBusSettings({ getBusStatus, setConsumerEnabled }: EventBusS
           >
             {loading ? 'Reading…' : 'Refresh'}
           </button>
+          {/* This page always reads the daemon, so `delivering: false` here can
+              only mean the daemon runs no durable delivery loops — never the
+              CLI's other meaning, that the snapshot came from the database. */}
           <span className="settings-hint">
             {status.delivering
               ? 'Read from the daemon that owns delivery, so a consumer that is registered but not running is visible.'
-              : 'Read from the database rather than from the running daemon, so whether a delivery loop is actually running is not visible.'}
+              : 'Read from the daemon, which is running no durable delivery loops right now, so there is nothing to report as running or stalled.'}
           </span>
         </div>
       </div>

--- a/app/src/components/EventBusSettings.tsx
+++ b/app/src/components/EventBusSettings.tsx
@@ -1,0 +1,326 @@
+// app/src/components/EventBusSettings.tsx
+//
+// The durable event bus, surfaced in Settings › Event Bus: what the log holds,
+// which fact classes are writing to it and how fast, which consumers are reading
+// it and how far behind they are, and what is wrong with any of it.
+//
+// This exists because a producer bug once wrote two thirds of the log for a week
+// and was found by accident. Nothing in attn showed what the bus was doing.
+//
+// Every number here is computed by the daemon — the same bus.Status that
+// `attn bus status` renders — so the two surfaces cannot disagree. In
+// particular the health list arrives as finished sentences: this component
+// renders them, it does not decide what counts as unhealthy.
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { BusConsumerStatus, BusStatus } from '../hooks/daemonBusEvents';
+import './EventBusSettings.css';
+
+interface EventBusSettingsProps {
+  getBusStatus: () => Promise<BusStatus>;
+  setConsumerEnabled: (consumer: string, enabled: boolean) => Promise<{ consumer: string }>;
+}
+
+// How often the page re-reads while it is open. The daemon answers with one
+// aggregate pass over the whole log — 209ms at 945k rows, measured — so this is
+// deliberately slow: attn runs all day, and a diagnostics page must not cost
+// battery to leave open. The component only mounts while its section is
+// selected, so closing Settings or navigating away stops it.
+const REFRESH_MS = 30_000;
+
+// Producers below this share are the long tail of a healthy log (35 of 50
+// classes in production hold 0.3% between them). They are collapsed rather than
+// dropped — the count and their combined share are always stated, and one click
+// shows them.
+const QUIET_SHARE = 0.005;
+
+const formatBytes = (n: number): string => {
+  if (n >= 1 << 20) return `${(n / (1 << 20)).toFixed(1)} MB`;
+  if (n >= 1 << 10) return `${(n / (1 << 10)).toFixed(1)} KB`;
+  return `${n} B`;
+};
+
+const formatCount = (n: number): string => n.toLocaleString();
+
+const formatRate = (n: number): string => (n >= 10 ? n.toFixed(0) : n.toFixed(1));
+
+/** Renders a span the way someone says it: "8d", "3h", "12m", "40s". */
+const formatSpan = (seconds: number): string => {
+  if (!Number.isFinite(seconds) || seconds <= 0) return '';
+  if (seconds >= 48 * 3600) return `${Math.round(seconds / 86400)}d`;
+  if (seconds >= 3600) return `${Math.round(seconds / 3600)}h`;
+  if (seconds >= 60) return `${Math.round(seconds / 60)}m`;
+  return `${Math.round(seconds)}s`;
+};
+
+/** Age of an RFC3339 stamp, as a span. Empty for an absent or unparseable one. */
+const formatAge = (iso: string, now: number): string => {
+  if (!iso) return '';
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return '';
+  return formatSpan((now - t) / 1000);
+};
+
+export function EventBusSettings({ getBusStatus, setConsumerEnabled }: EventBusSettingsProps) {
+  const [status, setStatus] = useState<BusStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [showQuiet, setShowQuiet] = useState(false);
+  const [pendingConsumer, setPendingConsumer] = useState<string | null>(null);
+  // Guards against an older answer landing after a newer one.
+  const seqRef = useRef(0);
+
+  const refresh = useCallback(async () => {
+    const seq = ++seqRef.current;
+    setLoading(true);
+    try {
+      const next = await getBusStatus();
+      if (seqRef.current !== seq) return;
+      setStatus(next);
+      setError(null);
+    } catch (err) {
+      if (seqRef.current !== seq) return;
+      setError(err instanceof Error ? err.message : 'Could not read the event bus');
+    } finally {
+      if (seqRef.current === seq) setLoading(false);
+    }
+  }, [getBusStatus]);
+
+  useEffect(() => {
+    void refresh();
+    const id = window.setInterval(() => { void refresh(); }, REFRESH_MS);
+    return () => window.clearInterval(id);
+  }, [refresh]);
+
+  const toggleConsumer = useCallback(async (consumer: BusConsumerStatus) => {
+    setPendingConsumer(consumer.name);
+    try {
+      await setConsumerEnabled(consumer.name, !consumer.enabled);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not change the consumer');
+    } finally {
+      setPendingConsumer(null);
+    }
+  }, [setConsumerEnabled, refresh]);
+
+  if (error && !status) {
+    return (
+      <section className="settings-block">
+        {renderIntro()}
+        <div className="settings-block-body">
+          <div className="bus-state">
+            <span className="settings-warning">{error}</span>
+            <button type="button" className="settings-action" onClick={() => void refresh()}>
+              Try again
+            </button>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  if (!status) {
+    return (
+      <section className="settings-block">
+        {renderIntro()}
+        <div className="settings-block-body">
+          <div className="bus-state" data-testid="bus-loading">Reading the event log…</div>
+        </div>
+      </section>
+    );
+  }
+
+  const now = Date.now();
+  const loud = status.producers.filter((p) => p.share >= QUIET_SHARE);
+  const quiet = status.producers.filter((p) => p.share < QUIET_SHARE);
+  const quietEvents = quiet.reduce((sum, p) => sum + p.events, 0);
+  const quietShare = quiet.reduce((sum, p) => sum + p.share, 0);
+  const shownProducers = showQuiet ? status.producers : loud;
+
+  return (
+    <section className="settings-block" data-testid="settings-bus">
+      {renderIntro()}
+      <div className="settings-block-body">
+        {error && <span className="settings-warning">{error}</span>}
+
+        {status.health.length > 0 && (
+          <ul className="bus-health" data-testid="bus-health">
+            {status.health.map((h, i) => (
+              <li key={`${h.kind}:${h.subject}:${i}`} className={`bus-health-entry ${h.level}`}>
+                <span className={`settings-pill ${h.level === 'error' ? 'bad' : 'warn'}`}>
+                  {h.level === 'error' ? 'Error' : 'Warning'}
+                </span>
+                <span className="bus-health-message">{h.message}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="bus-summary" data-testid="bus-summary">
+          <div className="bus-stat">
+            <span className="bus-stat-label">Events</span>
+            <span className="bus-stat-value">{formatCount(status.rows)}</span>
+          </div>
+          <div className="bus-stat">
+            <span className="bus-stat-label">Weight</span>
+            <span className="bus-stat-value">{formatBytes(status.bytes)}</span>
+          </div>
+          <div className="bus-stat">
+            <span className="bus-stat-label">Seq</span>
+            <span className="bus-stat-value">{status.earliest}–{status.head}</span>
+          </div>
+          <div className="bus-stat">
+            <span className="bus-stat-label">Oldest</span>
+            <span className="bus-stat-value">{formatAge(status.oldestAt, now) || '—'}</span>
+          </div>
+          <div className="bus-stat">
+            <span className="bus-stat-label">Retention</span>
+            <span className="bus-stat-value">{formatSpan(status.retentionSeconds)}</span>
+          </div>
+        </div>
+
+        <div className="bus-section-head">
+          <h4>Producers</h4>
+          <span className="settings-hint">
+            Rates are events per hour over the last {formatSpan(status.recentWindowSeconds)} and{' '}
+            {formatSpan(status.baselineWindowSeconds)}. Far fewer subjects than events means a
+            producer republishing the same entity rather than describing change.
+          </span>
+        </div>
+        {shownProducers.length === 0 ? (
+          <p className="settings-empty">Nothing has been published yet.</p>
+        ) : (
+          <div className="bus-table bus-producers" data-testid="bus-producers">
+            <div className="bus-row bus-head">
+              <span>Fact</span>
+              <span className="bus-num">Events</span>
+              <span className="bus-num">Share</span>
+              <span className="bus-num">Subjects</span>
+              <span className="bus-num">{formatSpan(status.recentWindowSeconds)}/h</span>
+              <span className="bus-num">{formatSpan(status.baselineWindowSeconds)}/h</span>
+            </div>
+            {shownProducers.map((p) => (
+              <div
+                key={p.name}
+                className={`bus-row${p.surging ? ' surging' : ''}`}
+                data-testid={`bus-producer-${p.name}`}
+              >
+                <span className="bus-name">
+                  {p.name}
+                  {p.surging && <span className="settings-pill warn">Loud</span>}
+                </span>
+                <span className="bus-num">{formatCount(p.events)}</span>
+                <span className="bus-num">{(p.share * 100).toFixed(1)}%</span>
+                <span className="bus-num">{formatCount(p.subjects)}</span>
+                <span className="bus-num">{formatRate(p.recent_per_hour)}</span>
+                <span className="bus-num">{formatRate(p.baseline_per_hour)}</span>
+              </div>
+            ))}
+          </div>
+        )}
+        {quiet.length > 0 && (
+          <button
+            type="button"
+            className="bus-more"
+            data-testid="bus-toggle-quiet"
+            onClick={() => setShowQuiet((v) => !v)}
+          >
+            {showQuiet
+              ? 'Hide the quieter classes'
+              : `Show ${quiet.length} quieter class${quiet.length === 1 ? '' : 'es'} — ${formatCount(quietEvents)} events, ${(quietShare * 100).toFixed(1)}% of the log`}
+          </button>
+        )}
+
+        <div className="bus-section-head">
+          <h4>Consumers</h4>
+          <span className="settings-hint">
+            Disabling a consumer stops delivery to it and stops it holding retention open. Its
+            cursor is kept, but once trimming passes it, enabling resumes at head with a logged gap.
+          </span>
+        </div>
+        {status.consumers.length === 0 ? (
+          <p className="settings-empty" data-testid="bus-no-consumers">
+            No durable consumers are registered. Every subscriber on this bus is ephemeral, so
+            nothing holds a cursor and nothing pins retention.
+          </p>
+        ) : (
+          <div className="bus-table bus-consumers" data-testid="bus-consumers">
+            <div className="bus-row bus-head">
+              <span>Consumer</span>
+              <span className="bus-num">Cursor</span>
+              <span className="bus-num">Lag</span>
+              <span className="bus-num">Waiting</span>
+              <span />
+            </div>
+            {status.consumers.map((c) => (
+              <div
+                key={c.name}
+                className={`bus-row${c.enabled ? '' : ' disabled'}`}
+                data-testid={`bus-consumer-${c.name}`}
+              >
+                <span className="bus-name">
+                  {c.name}
+                  {c.holds_retention_floor && (
+                    <span className="settings-pill" title="Retention stops at this consumer's cursor">
+                      Retention floor
+                    </span>
+                  )}
+                  {!c.enabled && <span className="settings-pill warn">Disabled</span>}
+                  {c.stalled && <span className="settings-pill bad">Stalled</span>}
+                  {status.delivering && c.enabled && !c.live && (
+                    <span className="settings-pill bad">Not running</span>
+                  )}
+                  <span className="bus-filter">{c.filter || 'all facts'}</span>
+                </span>
+                <span className="bus-num">{formatCount(c.cursor)}</span>
+                <span className="bus-num">{formatCount(c.lag)}</span>
+                <span className="bus-num">{formatAge(c.oldest_unread_at, now) || '—'}</span>
+                <span className="bus-row-action">
+                  <button
+                    type="button"
+                    className={`settings-action${c.enabled ? ' danger' : ''}`}
+                    data-testid={`bus-consumer-toggle-${c.name}`}
+                    disabled={pendingConsumer !== null}
+                    onClick={() => void toggleConsumer(c)}
+                  >
+                    {c.enabled ? 'Disable' : 'Enable'}
+                  </button>
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="bus-footer">
+          <button
+            type="button"
+            className="settings-action"
+            data-testid="bus-refresh"
+            disabled={loading}
+            onClick={() => void refresh()}
+          >
+            {loading ? 'Reading…' : 'Refresh'}
+          </button>
+          <span className="settings-hint">
+            {status.delivering
+              ? 'Read from the daemon that owns delivery, so a consumer that is registered but not running is visible.'
+              : 'Read from the database rather than from the running daemon, so whether a delivery loop is actually running is not visible.'}
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function renderIntro() {
+  return (
+    <div className="settings-block-intro">
+      <span className="settings-kicker">Event Bus</span>
+      <h3>Durable event log</h3>
+      <p className="settings-description">
+        The spine every state change travels on. This is what it holds, who writes to it, and who
+        reads it — the same picture <code>attn bus status</code> prints.
+      </p>
+    </div>
+  );
+}

--- a/app/src/components/SettingsModal.test.tsx
+++ b/app/src/components/SettingsModal.test.tsx
@@ -3,7 +3,11 @@ import { act, fireEvent, render, screen, waitFor } from '../test/utils';
 import { SettingsModal } from './SettingsModal';
 import { getSettingsAutomationHandle } from './settingsAutomation';
 
-const daemonApi = vi.hoisted(() => ({ sendGetSettings: vi.fn() }));
+const daemonApi = vi.hoisted(() => ({
+  sendGetSettings: vi.fn(),
+  sendBusStatusGet: vi.fn(() => new Promise(() => {})),
+  sendBusSetConsumerEnabled: vi.fn(),
+}));
 vi.mock('../contexts/DaemonApiContext', () => ({ useDaemonApi: () => daemonApi }));
 
 describe('SettingsModal', () => {

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -11,6 +11,7 @@ import {
   PluginListResult,
 } from '../hooks/useDaemonSocket';
 import { BackgroundTasksSettings } from './BackgroundTasksSettings';
+import { EventBusSettings } from './EventBusSettings';
 import {
   assertValidSettingsSectionID,
   setSettingsAutomationHandle,
@@ -96,7 +97,7 @@ interface SettingsModalProps {
   taskChangeSignal?: number;
 }
 
-type SettingsSectionID = 'general' | 'connectivity' | 'plugins' | 'agents' | 'data' | 'review' | 'hygiene' | 'backgroundTasks';
+type SettingsSectionID = 'general' | 'connectivity' | 'plugins' | 'agents' | 'data' | 'review' | 'hygiene' | 'backgroundTasks' | 'eventBus';
 
 // Fallback shown when the daemon has not yet sent a normalized value; the daemon
 // mirrors this default (agent.DefaultContextWindowCap) for both context-window caps.
@@ -199,7 +200,7 @@ export function SettingsModal({
   retryTask,
   taskChangeSignal,
 }: SettingsModalProps) {
-  const { sendGetSettings } = useDaemonApi();
+  const { sendGetSettings, sendBusStatusGet, sendBusSetConsumerEnabled } = useDaemonApi();
   const [projectsDir, setProjectsDir] = useState(settings.projects_directory || '');
   const [notebookRoot, setNotebookRoot] = useState(settings['notebook.root'] || '');
   const [agentExecutables, setAgentExecutables] = useState<Record<SessionAgent, string>>({});
@@ -1067,6 +1068,14 @@ export function SettingsModal({
           description: 'The durable task runner: compaction, summaries, narration, and reconciliation, with retry.',
           count: 1,
           keywords: 'background tasks runner durable compaction summarize narrate reconcile retry failed dead queue',
+        },
+        {
+          id: 'eventBus',
+          label: 'Event bus',
+          title: 'Event bus',
+          description: 'The durable event log: what it holds, which facts are written to it and how fast, and who reads it.',
+          count: 1,
+          keywords: 'event bus log durable facts producers consumers cursor lag retention compaction trim stalled disabled kill switch seq',
         },
       ],
     },
@@ -2768,6 +2777,13 @@ export function SettingsModal({
     </>
   );
 
+  const renderEventBusSettings = () => (
+    <EventBusSettings
+      getBusStatus={sendBusStatusGet}
+      setConsumerEnabled={sendBusSetConsumerEnabled}
+    />
+  );
+
   const renderSelectedSection = () => {
     switch (selectedSection) {
       case 'general':
@@ -2784,6 +2800,8 @@ export function SettingsModal({
         return renderHygieneSettings();
       case 'backgroundTasks':
         return renderBackgroundTasksSettings();
+      case 'eventBus':
+        return renderEventBusSettings();
       case 'connectivity':
       default:
         return renderConnectivitySettings();

--- a/app/src/components/settingsAutomation.ts
+++ b/app/src/components/settingsAutomation.ts
@@ -14,6 +14,7 @@ const SETTINGS_SECTION_IDS = [
   'review',
   'hygiene',
   'backgroundTasks',
+  'eventBus',
 ] as const;
 
 export type SettingsAutomationSectionID = (typeof SETTINGS_SECTION_IDS)[number];

--- a/app/src/hooks/daemonBusEvents.ts
+++ b/app/src/hooks/daemonBusEvents.ts
@@ -1,0 +1,96 @@
+// Event-bus diagnostics: the two results the bus settings page waits on.
+//
+// Its own module rather than a case in the hook's switch, because the domain is
+// self-contained — nothing else in the app reads bus internals — and the switch
+// is already long. Reached from the switch's `default` chain.
+
+import type {
+  BusConsumerStatus,
+  BusHealthEntry,
+  BusProducerStatus,
+} from '../types/generated';
+import { type PendingRequests, settlePendingRequest } from './daemonPendingRequests';
+
+export type { BusConsumerStatus, BusHealthEntry, BusProducerStatus };
+
+/** The daemon's whole picture of the bus, as the settings page draws it. */
+export interface BusStatus {
+  earliest: number;
+  head: number;
+  rows: number;
+  bytes: number;
+  /** RFC3339; empty on an empty log. */
+  oldestAt: string;
+  newestAt: string;
+  /**
+   * The snapshot came from the process owning the delivery loops, which is what
+   * makes each consumer's `live` field mean anything.
+   */
+  delivering: boolean;
+  retentionSeconds: number;
+  recentWindowSeconds: number;
+  baselineWindowSeconds: number;
+  surgeRatePerHour: number;
+  producers: BusProducerStatus[];
+  consumers: BusConsumerStatus[];
+  health: BusHealthEntry[];
+}
+
+// A loosely typed view of the wire event: these arrive as parsed JSON, so every
+// field is checked rather than asserted.
+interface BusDaemonEvent {
+  event?: string;
+  success?: boolean;
+  error?: string;
+  [key: string]: unknown;
+}
+
+const num = (value: unknown): number => (typeof value === 'number' && Number.isFinite(value) ? value : 0);
+const str = (value: unknown): string => (typeof value === 'string' ? value : '');
+const list = <T,>(value: unknown): T[] => (Array.isArray(value) ? (value as T[]) : []);
+
+const toBusStatus = (event: BusDaemonEvent): BusStatus => ({
+  earliest: num(event.earliest),
+  head: num(event.head),
+  rows: num(event.rows),
+  bytes: num(event.bytes),
+  oldestAt: str(event.oldest_at),
+  newestAt: str(event.newest_at),
+  delivering: event.delivering === true,
+  retentionSeconds: num(event.retention_seconds),
+  recentWindowSeconds: num(event.recent_window_seconds),
+  baselineWindowSeconds: num(event.baseline_window_seconds),
+  surgeRatePerHour: num(event.surge_rate_per_hour),
+  producers: list<BusProducerStatus>(event.producers),
+  consumers: list<BusConsumerStatus>(event.consumers),
+  health: list<BusHealthEntry>(event.health),
+});
+
+/**
+ * Settles a bus result, or returns false for an event this module does not own
+ * so the caller can keep looking.
+ */
+export function handleBusDaemonEvent(event: BusDaemonEvent, pending: PendingRequests): boolean {
+  switch (event.event) {
+    case 'bus_status_result':
+      settlePendingRequest(
+        pending,
+        'bus_status_get',
+        event,
+        toBusStatus,
+        'Reading the event bus failed',
+      );
+      return true;
+    case 'bus_set_consumer_enabled_result':
+      settlePendingRequest(
+        pending,
+        'bus_set_consumer_enabled',
+        event,
+        (settled): { consumer: string } => ({ consumer: str(settled.consumer) }),
+        'Changing the consumer failed',
+      );
+      return true;
+    default:
+      return false;
+  }
+}

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -63,6 +63,7 @@ import { recordPtyCommand, recordWsBinaryPtyOutput, recordWsJsonParse } from '..
 import { decodeBinaryFrame } from '../pty/binaryPtyFrame';
 import { kittyImageBlobFromResult, kittyImageCache } from '../utils/kittyImageCache';
 import { resolveDaemonWebSocketURL, type DaemonEndpointProfile } from '../utils/daemonEndpoint';
+import { handleBusDaemonEvent, type BusStatus } from './daemonBusEvents';
 import { handleFsDaemonEvent } from './daemonFsEvents';
 import { handleNotebookDaemonEvent } from './daemonNotebookEvents';
 import {
@@ -785,6 +786,10 @@ const ATTACH_RETRY_DELAY_MS = 150;
 // git and GitHub commands below, which wait on the network or a subprocess, set
 // their own in minutes.
 const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+// Bus status is one aggregate pass over the whole event log. Measured on a copy
+// of production, 209ms at 945k rows — so 30s is roughly a hundred times the
+// worst real log, a tripwire for a scan that has hung rather than a budget.
+const BUS_STATUS_TIMEOUT_MS = 30_000;
 const GIT_METADATA_TIMEOUT_MS = 30 * 60_000;
 const GIT_DIFF_TIMEOUT_MS = 10 * 60_000;
 const GIT_WORKTREE_TIMEOUT_MS = 30 * 60_000;
@@ -2900,6 +2905,7 @@ export function useDaemonSocket({
             if (handleNotebookDaemonEvent(data, { pending, onNotebookChanged: callbacksRef.current.onNotebookChanged })) break;
             if (handleMarkdownAnnotationDaemonEvent(data, mdAnnotationsPendingRef.current)) break;
             if (handleSessionAnnotationDaemonEvent(data, pending)) break;
+            if (handleBusDaemonEvent(data, pending)) break;
             break;
           }
         }
@@ -3234,6 +3240,32 @@ export function useDaemonSocket({
       'list_past_conversations',
       {},
       'Listing past conversations timed out',
+    );
+  }, [sendRequest]);
+
+  // Reads the event bus's operator picture — the same snapshot `attn bus status`
+  // renders, computed daemon-side so the two can never disagree.
+  //
+  // The daemon answers with one aggregate pass over the whole log, which is
+  // why the default timeout is not enough for a large one.
+  const sendBusStatusGet = useCallback((): Promise<BusStatus> => {
+    return sendRequest<BusStatus>(
+      'bus_status_get',
+      {},
+      'Reading the event bus timed out',
+      BUS_STATUS_TIMEOUT_MS,
+    );
+  }, [sendRequest]);
+
+  // Flips a durable consumer's kill switch, matching `attn bus enable|disable`.
+  const sendBusSetConsumerEnabled = useCallback((
+    consumer: string,
+    enabled: boolean,
+  ): Promise<{ consumer: string }> => {
+    return sendRequest<{ consumer: string }>(
+      'bus_set_consumer_enabled',
+      { consumer, enabled },
+      'Changing the consumer timed out',
     );
   }, [sendRequest]);
 
@@ -5401,6 +5433,8 @@ export function useDaemonSocket({
     sendAgentHistory,
     sendAgentSetModel,
     sendListPastConversations,
+    sendBusStatusGet,
+    sendBusSetConsumerEnabled,
     sendTriggerNudge,
     sendSettleTurn,
     sendSnoozeTurn,

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -226,7 +226,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '223';
+export const PROTOCOL_VERSION = '224';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const activityStatusMessage = Convert.toActivityStatusMessage(json);
 //   const activityStatusResult = Convert.toActivityStatusResult(json);
@@ -52,6 +52,13 @@
 //   const browserControlRequestMessage = Convert.toBrowserControlRequestMessage(json);
 //   const browserControlResponseMessage = Convert.toBrowserControlResponseMessage(json);
 //   const browserControlResultMessage = Convert.toBrowserControlResultMessage(json);
+//   const busConsumerStatus = Convert.toBusConsumerStatus(json);
+//   const busHealthEntry = Convert.toBusHealthEntry(json);
+//   const busProducerStatus = Convert.toBusProducerStatus(json);
+//   const busSetConsumerEnabledMessage = Convert.toBusSetConsumerEnabledMessage(json);
+//   const busSetConsumerEnabledResultMessage = Convert.toBusSetConsumerEnabledResultMessage(json);
+//   const busStatusGetMessage = Convert.toBusStatusGetMessage(json);
+//   const busStatusResultMessage = Convert.toBusStatusResultMessage(json);
 //   const cancelCountdownMessage = Convert.toCancelCountdownMessage(json);
 //   const chiefOfStaffResultMessage = Convert.toChiefOfStaffResultMessage(json);
 //   const clearSessionActivityMessage = Convert.toClearSessionActivityMessage(json);
@@ -1205,6 +1212,141 @@ export interface BrowserControlResultMessage {
 
 export enum BrowserControlResultMessageCmd {
     BrowserControlResult = "browser_control_result",
+}
+
+export interface BusConsumerStatus {
+    cursor:                number;
+    enabled:               boolean;
+    filter:                string;
+    holds_retention_floor: boolean;
+    lag:                   number;
+    live:                  boolean;
+    name:                  string;
+    oldest_unread_at:      string;
+    stalled:               string;
+    updated_at:            string;
+    [property: string]: any;
+}
+
+export interface BusHealthEntry {
+    kind:    string;
+    level:   string;
+    message: string;
+    subject: string;
+    [property: string]: any;
+}
+
+export interface BusProducerStatus {
+    baseline_per_hour:    number;
+    bytes:                number;
+    events:               number;
+    name:                 string;
+    recent_per_hour:      number;
+    share:                number;
+    subjects:             number;
+    surge_per_hour:       number;
+    surge_window_seconds: number;
+    surging:              boolean;
+    sustained_per_hour:   number;
+    [property: string]: any;
+}
+
+export interface BusSetConsumerEnabledMessage {
+    cmd:        BusSetConsumerEnabledMessageCmd;
+    consumer:   string;
+    enabled:    boolean;
+    request_id: string;
+    [property: string]: any;
+}
+
+export enum BusSetConsumerEnabledMessageCmd {
+    BusSetConsumerEnabled = "bus_set_consumer_enabled",
+}
+
+export interface BusSetConsumerEnabledResultMessage {
+    consumer:   string;
+    error?:     string;
+    event:      BusSetConsumerEnabledResultMessageEvent;
+    request_id: string;
+    success:    boolean;
+    [property: string]: any;
+}
+
+export enum BusSetConsumerEnabledResultMessageEvent {
+    BusSetConsumerEnabledResult = "bus_set_consumer_enabled_result",
+}
+
+export interface BusStatusGetMessage {
+    cmd:        BusStatusGetMessageCmd;
+    request_id: string;
+    [property: string]: any;
+}
+
+export enum BusStatusGetMessageCmd {
+    BusStatusGet = "bus_status_get",
+}
+
+export interface BusStatusResultMessage {
+    baseline_window_seconds: number;
+    bytes:                   number;
+    consumers:               ConsumerElement[];
+    delivering:              boolean;
+    earliest:                number;
+    error?:                  string;
+    event:                   BusStatusResultMessageEvent;
+    head:                    number;
+    health:                  HealthElement[];
+    newest_at:               string;
+    oldest_at:               string;
+    producers:               ProducerElement[];
+    recent_window_seconds:   number;
+    request_id:              string;
+    retention_seconds:       number;
+    rows:                    number;
+    success:                 boolean;
+    surge_rate_per_hour:     number;
+    [property: string]: any;
+}
+
+export interface ConsumerElement {
+    cursor:                number;
+    enabled:               boolean;
+    filter:                string;
+    holds_retention_floor: boolean;
+    lag:                   number;
+    live:                  boolean;
+    name:                  string;
+    oldest_unread_at:      string;
+    stalled:               string;
+    updated_at:            string;
+    [property: string]: any;
+}
+
+export enum BusStatusResultMessageEvent {
+    BusStatusResult = "bus_status_result",
+}
+
+export interface HealthElement {
+    kind:    string;
+    level:   string;
+    message: string;
+    subject: string;
+    [property: string]: any;
+}
+
+export interface ProducerElement {
+    baseline_per_hour:    number;
+    bytes:                number;
+    events:               number;
+    name:                 string;
+    recent_per_hour:      number;
+    share:                number;
+    subjects:             number;
+    surge_per_hour:       number;
+    surge_window_seconds: number;
+    surging:              boolean;
+    sustained_per_hour:   number;
+    [property: string]: any;
 }
 
 export interface CancelCountdownMessage {
@@ -7154,6 +7296,62 @@ export class Convert {
         return JSON.stringify(uncast(value, r("BrowserControlResultMessage")), null, 2);
     }
 
+    public static toBusConsumerStatus(json: string): BusConsumerStatus {
+        return cast(JSON.parse(json), r("BusConsumerStatus"));
+    }
+
+    public static busConsumerStatusToJson(value: BusConsumerStatus): string {
+        return JSON.stringify(uncast(value, r("BusConsumerStatus")), null, 2);
+    }
+
+    public static toBusHealthEntry(json: string): BusHealthEntry {
+        return cast(JSON.parse(json), r("BusHealthEntry"));
+    }
+
+    public static busHealthEntryToJson(value: BusHealthEntry): string {
+        return JSON.stringify(uncast(value, r("BusHealthEntry")), null, 2);
+    }
+
+    public static toBusProducerStatus(json: string): BusProducerStatus {
+        return cast(JSON.parse(json), r("BusProducerStatus"));
+    }
+
+    public static busProducerStatusToJson(value: BusProducerStatus): string {
+        return JSON.stringify(uncast(value, r("BusProducerStatus")), null, 2);
+    }
+
+    public static toBusSetConsumerEnabledMessage(json: string): BusSetConsumerEnabledMessage {
+        return cast(JSON.parse(json), r("BusSetConsumerEnabledMessage"));
+    }
+
+    public static busSetConsumerEnabledMessageToJson(value: BusSetConsumerEnabledMessage): string {
+        return JSON.stringify(uncast(value, r("BusSetConsumerEnabledMessage")), null, 2);
+    }
+
+    public static toBusSetConsumerEnabledResultMessage(json: string): BusSetConsumerEnabledResultMessage {
+        return cast(JSON.parse(json), r("BusSetConsumerEnabledResultMessage"));
+    }
+
+    public static busSetConsumerEnabledResultMessageToJson(value: BusSetConsumerEnabledResultMessage): string {
+        return JSON.stringify(uncast(value, r("BusSetConsumerEnabledResultMessage")), null, 2);
+    }
+
+    public static toBusStatusGetMessage(json: string): BusStatusGetMessage {
+        return cast(JSON.parse(json), r("BusStatusGetMessage"));
+    }
+
+    public static busStatusGetMessageToJson(value: BusStatusGetMessage): string {
+        return JSON.stringify(uncast(value, r("BusStatusGetMessage")), null, 2);
+    }
+
+    public static toBusStatusResultMessage(json: string): BusStatusResultMessage {
+        return cast(JSON.parse(json), r("BusStatusResultMessage"));
+    }
+
+    public static busStatusResultMessageToJson(value: BusStatusResultMessage): string {
+        return JSON.stringify(uncast(value, r("BusStatusResultMessage")), null, 2);
+    }
+
     public static toCancelCountdownMessage(json: string): CancelCountdownMessage {
         return cast(JSON.parse(json), r("CancelCountdownMessage"));
     }
@@ -11001,6 +11199,105 @@ const typeMap: any = {
         { json: "request_id", js: "request_id", typ: "" },
         { json: "success", js: "success", typ: true },
     ], "any"),
+    "BusConsumerStatus": o([
+        { json: "cursor", js: "cursor", typ: 0 },
+        { json: "enabled", js: "enabled", typ: true },
+        { json: "filter", js: "filter", typ: "" },
+        { json: "holds_retention_floor", js: "holds_retention_floor", typ: true },
+        { json: "lag", js: "lag", typ: 0 },
+        { json: "live", js: "live", typ: true },
+        { json: "name", js: "name", typ: "" },
+        { json: "oldest_unread_at", js: "oldest_unread_at", typ: "" },
+        { json: "stalled", js: "stalled", typ: "" },
+        { json: "updated_at", js: "updated_at", typ: "" },
+    ], "any"),
+    "BusHealthEntry": o([
+        { json: "kind", js: "kind", typ: "" },
+        { json: "level", js: "level", typ: "" },
+        { json: "message", js: "message", typ: "" },
+        { json: "subject", js: "subject", typ: "" },
+    ], "any"),
+    "BusProducerStatus": o([
+        { json: "baseline_per_hour", js: "baseline_per_hour", typ: 3.14 },
+        { json: "bytes", js: "bytes", typ: 0 },
+        { json: "events", js: "events", typ: 0 },
+        { json: "name", js: "name", typ: "" },
+        { json: "recent_per_hour", js: "recent_per_hour", typ: 3.14 },
+        { json: "share", js: "share", typ: 3.14 },
+        { json: "subjects", js: "subjects", typ: 0 },
+        { json: "surge_per_hour", js: "surge_per_hour", typ: 3.14 },
+        { json: "surge_window_seconds", js: "surge_window_seconds", typ: 3.14 },
+        { json: "surging", js: "surging", typ: true },
+        { json: "sustained_per_hour", js: "sustained_per_hour", typ: 3.14 },
+    ], "any"),
+    "BusSetConsumerEnabledMessage": o([
+        { json: "cmd", js: "cmd", typ: r("BusSetConsumerEnabledMessageCmd") },
+        { json: "consumer", js: "consumer", typ: "" },
+        { json: "enabled", js: "enabled", typ: true },
+        { json: "request_id", js: "request_id", typ: "" },
+    ], "any"),
+    "BusSetConsumerEnabledResultMessage": o([
+        { json: "consumer", js: "consumer", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("BusSetConsumerEnabledResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "BusStatusGetMessage": o([
+        { json: "cmd", js: "cmd", typ: r("BusStatusGetMessageCmd") },
+        { json: "request_id", js: "request_id", typ: "" },
+    ], "any"),
+    "BusStatusResultMessage": o([
+        { json: "baseline_window_seconds", js: "baseline_window_seconds", typ: 3.14 },
+        { json: "bytes", js: "bytes", typ: 0 },
+        { json: "consumers", js: "consumers", typ: a(r("ConsumerElement")) },
+        { json: "delivering", js: "delivering", typ: true },
+        { json: "earliest", js: "earliest", typ: 0 },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("BusStatusResultMessageEvent") },
+        { json: "head", js: "head", typ: 0 },
+        { json: "health", js: "health", typ: a(r("HealthElement")) },
+        { json: "newest_at", js: "newest_at", typ: "" },
+        { json: "oldest_at", js: "oldest_at", typ: "" },
+        { json: "producers", js: "producers", typ: a(r("ProducerElement")) },
+        { json: "recent_window_seconds", js: "recent_window_seconds", typ: 3.14 },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "retention_seconds", js: "retention_seconds", typ: 3.14 },
+        { json: "rows", js: "rows", typ: 0 },
+        { json: "success", js: "success", typ: true },
+        { json: "surge_rate_per_hour", js: "surge_rate_per_hour", typ: 3.14 },
+    ], "any"),
+    "ConsumerElement": o([
+        { json: "cursor", js: "cursor", typ: 0 },
+        { json: "enabled", js: "enabled", typ: true },
+        { json: "filter", js: "filter", typ: "" },
+        { json: "holds_retention_floor", js: "holds_retention_floor", typ: true },
+        { json: "lag", js: "lag", typ: 0 },
+        { json: "live", js: "live", typ: true },
+        { json: "name", js: "name", typ: "" },
+        { json: "oldest_unread_at", js: "oldest_unread_at", typ: "" },
+        { json: "stalled", js: "stalled", typ: "" },
+        { json: "updated_at", js: "updated_at", typ: "" },
+    ], "any"),
+    "HealthElement": o([
+        { json: "kind", js: "kind", typ: "" },
+        { json: "level", js: "level", typ: "" },
+        { json: "message", js: "message", typ: "" },
+        { json: "subject", js: "subject", typ: "" },
+    ], "any"),
+    "ProducerElement": o([
+        { json: "baseline_per_hour", js: "baseline_per_hour", typ: 3.14 },
+        { json: "bytes", js: "bytes", typ: 0 },
+        { json: "events", js: "events", typ: 0 },
+        { json: "name", js: "name", typ: "" },
+        { json: "recent_per_hour", js: "recent_per_hour", typ: 3.14 },
+        { json: "share", js: "share", typ: 3.14 },
+        { json: "subjects", js: "subjects", typ: 0 },
+        { json: "surge_per_hour", js: "surge_per_hour", typ: 3.14 },
+        { json: "surge_window_seconds", js: "surge_window_seconds", typ: 3.14 },
+        { json: "surging", js: "surging", typ: true },
+        { json: "sustained_per_hour", js: "sustained_per_hour", typ: 3.14 },
+    ], "any"),
     "CancelCountdownMessage": o([
         { json: "cmd", js: "cmd", typ: r("CancelCountdownMessageCmd") },
         { json: "session_id", js: "session_id", typ: "" },
@@ -14449,6 +14746,18 @@ const typeMap: any = {
     ],
     "BrowserControlResultMessageCmd": [
         "browser_control_result",
+    ],
+    "BusSetConsumerEnabledMessageCmd": [
+        "bus_set_consumer_enabled",
+    ],
+    "BusSetConsumerEnabledResultMessageEvent": [
+        "bus_set_consumer_enabled_result",
+    ],
+    "BusStatusGetMessageCmd": [
+        "bus_status_get",
+    ],
+    "BusStatusResultMessageEvent": [
+        "bus_status_result",
     ],
     "CancelCountdownMessageCmd": [
         "cancel_countdown",

--- a/changelog.d/bus-observability.yaml
+++ b/changelog.d/bus-observability.yaml
@@ -1,0 +1,19 @@
+kind: added
+area: daemon
+change: >
+  The durable event bus can be looked at. `attn bus status` and a new
+  Settings › Event Bus page show the same picture — what the log holds, which
+  fact classes write to it and at what rate, how much of the log each one owns,
+  which consumers read it and how far behind they are, and which one is holding
+  retention open. Both render one snapshot the daemon computes, so they cannot
+  disagree; the app can enable and disable a consumer from the page, the same
+  switch `attn bus enable|disable` throws.
+notes: >
+  Health findings are written by the daemon as sentences ("consumer X is 41,000
+  events behind and not advancing"), not left as numbers to interpret. A fact
+  class sustaining above 1000 events/hour over 6 or 24 hours is called out on
+  both surfaces and logged once per retention pass, naming the rate, the window
+  and the tripwire — the class that once wrote two thirds of the log for a week
+  would have announced itself on day one. The whole aggregate is one pass over
+  the log, 209ms at 945k rows, so nothing polls it: the page reads on open and
+  every 30s while it is visible.

--- a/cmd/attn/bus.go
+++ b/cmd/attn/bus.go
@@ -108,15 +108,19 @@ type busStatusJSON struct {
 }
 
 type busProducerReport struct {
-	Name            string  `json:"name"`
-	Events          int64   `json:"events"`
-	Bytes           int64   `json:"bytes"`
-	Subjects        int64   `json:"subjects"`
-	Share           float64 `json:"share"`
-	RecentPerHour   float64 `json:"recent_per_hour"`
-	BaselinePerHour float64 `json:"baseline_per_hour"`
-	SurgePerHour    float64 `json:"surge_per_hour"`
-	Surging         bool    `json:"surging"`
+	Name             string  `json:"name"`
+	Events           int64   `json:"events"`
+	Bytes            int64   `json:"bytes"`
+	Subjects         int64   `json:"subjects"`
+	Share            float64 `json:"share"`
+	RecentPerHour    float64 `json:"recent_per_hour"`
+	BaselinePerHour  float64 `json:"baseline_per_hour"`
+	SustainedPerHour float64 `json:"sustained_per_hour"`
+	SurgePerHour     float64 `json:"surge_per_hour"`
+	// SurgeWindowSeconds names which window tripped, so a script can act on the
+	// crossing without parsing the health sentence written for a human.
+	SurgeWindowSeconds float64 `json:"surge_window_seconds"`
+	Surging            bool    `json:"surging"`
 }
 
 type busConsumerReport struct {
@@ -161,7 +165,8 @@ func busStatusReport(s bus.Status) busStatusJSON {
 		out.Producers = append(out.Producers, busProducerReport{
 			Name: p.Name, Events: p.Events, Bytes: p.Bytes, Subjects: p.Subjects,
 			Share: p.Share, RecentPerHour: p.RecentPerHour,
-			BaselinePerHour: p.BaselinePerHour, SurgePerHour: p.SurgePerHour,
+			BaselinePerHour: p.BaselinePerHour, SustainedPerHour: p.SustainedPerHour,
+			SurgePerHour: p.SurgePerHour, SurgeWindowSeconds: p.SurgeWindow.Seconds(),
 			Surging: p.Surging,
 		})
 	}

--- a/cmd/attn/bus.go
+++ b/cmd/attn/bus.go
@@ -55,8 +55,10 @@ func writeBusHelp(w io.Writer) {
 commands:
   status [--json]
         show the event log's live window, how many events it holds and what
-        they weigh, and every registered consumer's cursor, filter, enabled
-        bit, and lag (head - cursor).
+        they weigh; every fact class writing to it with its share and its
+        recent rates, loudest first; every registered consumer's cursor,
+        filter, enabled bit, and lag (head - cursor, plus how long its oldest
+        unread event has waited); and what is wrong with any of it.
 
   trim
         run one retention pass now instead of waiting for the daemon's hourly
@@ -75,6 +77,9 @@ commands:
 `)
 }
 
+// The --json shape. Every field the human rendering shows is here, because a
+// script reading this must never have to shell out twice or re-derive a rate.
+// The original fields keep their names and meaning.
 type busStatusJSON struct {
 	Earliest int64 `json:"earliest"`
 	Head     int64 `json:"head"`
@@ -84,18 +89,104 @@ type busStatusJSON struct {
 	// that data is written. Bytes counts the event text — name, subject, payload,
 	// source, stamp — not the size of the database file, which is shared with
 	// every other table and would answer a different question.
-	Rows      int64               `json:"rows"`
-	Bytes     int64               `json:"bytes"`
-	Consumers []busConsumerReport `json:"consumers"`
+	Rows     int64  `json:"rows"`
+	Bytes    int64  `json:"bytes"`
+	OldestAt string `json:"oldest_at,omitempty"`
+	NewestAt string `json:"newest_at,omitempty"`
+	// Delivering is false when the snapshot was read from the database rather
+	// than from the daemon that owns the delivery loops, which is what makes
+	// each consumer's `live` field meaningless.
+	Delivering        bool                `json:"delivering"`
+	RetentionSeconds  float64             `json:"retention_seconds"`
+	SurgeRatePerHour  float64             `json:"surge_rate_per_hour"`
+	SurgeWindowSecs   float64             `json:"surge_window_seconds"`
+	RecentWindowSecs  float64             `json:"recent_window_seconds"`
+	BaselineWindowSec float64             `json:"baseline_window_seconds"`
+	Producers         []busProducerReport `json:"producers"`
+	Consumers         []busConsumerReport `json:"consumers"`
+	Health            []busHealthReport   `json:"health"`
+}
+
+type busProducerReport struct {
+	Name            string  `json:"name"`
+	Events          int64   `json:"events"`
+	Bytes           int64   `json:"bytes"`
+	Subjects        int64   `json:"subjects"`
+	Share           float64 `json:"share"`
+	RecentPerHour   float64 `json:"recent_per_hour"`
+	BaselinePerHour float64 `json:"baseline_per_hour"`
+	SurgePerHour    float64 `json:"surge_per_hour"`
+	Surging         bool    `json:"surging"`
 }
 
 type busConsumerReport struct {
-	Name      string `json:"name"`
-	Cursor    int64  `json:"cursor"`
-	Lag       int64  `json:"lag"`
-	Filter    string `json:"filter"`
-	Enabled   bool   `json:"enabled"`
-	UpdatedAt string `json:"updated_at,omitempty"`
+	Name                string `json:"name"`
+	Cursor              int64  `json:"cursor"`
+	Lag                 int64  `json:"lag"`
+	Filter              string `json:"filter"`
+	Enabled             bool   `json:"enabled"`
+	UpdatedAt           string `json:"updated_at,omitempty"`
+	Live                bool   `json:"live"`
+	Stalled             string `json:"stalled,omitempty"`
+	OldestUnreadAt      string `json:"oldest_unread_at,omitempty"`
+	HoldsRetentionFloor bool   `json:"holds_retention_floor"`
+}
+
+type busHealthReport struct {
+	Level   string `json:"level"`
+	Kind    string `json:"kind"`
+	Subject string `json:"subject"`
+	Message string `json:"message"`
+}
+
+func busStatusReport(s bus.Status) busStatusJSON {
+	out := busStatusJSON{
+		Earliest:          s.Earliest,
+		Head:              s.Head,
+		Rows:              s.Rows,
+		Bytes:             s.Bytes,
+		OldestAt:          formatBusTime(s.OldestAt),
+		NewestAt:          formatBusTime(s.NewestAt),
+		Delivering:        s.Delivering,
+		RetentionSeconds:  s.RetentionWindow.Seconds(),
+		SurgeRatePerHour:  bus.SurgeRatePerHour,
+		SurgeWindowSecs:   bus.SurgeWindow.Seconds(),
+		RecentWindowSecs:  bus.RecentWindow.Seconds(),
+		BaselineWindowSec: bus.BaselineWindow.Seconds(),
+		Producers:         []busProducerReport{},
+		Consumers:         []busConsumerReport{},
+		Health:            []busHealthReport{},
+	}
+	for _, p := range s.Producers {
+		out.Producers = append(out.Producers, busProducerReport{
+			Name: p.Name, Events: p.Events, Bytes: p.Bytes, Subjects: p.Subjects,
+			Share: p.Share, RecentPerHour: p.RecentPerHour,
+			BaselinePerHour: p.BaselinePerHour, SurgePerHour: p.SurgePerHour,
+			Surging: p.Surging,
+		})
+	}
+	for _, c := range s.Consumers {
+		out.Consumers = append(out.Consumers, busConsumerReport{
+			Name: c.Name, Cursor: c.Cursor, Lag: c.Lag, Filter: c.Filter,
+			Enabled: c.Enabled, UpdatedAt: formatBusTime(c.UpdatedAt),
+			Live: c.Live, Stalled: c.Stalled,
+			OldestUnreadAt:      formatBusTime(c.OldestUnreadAt),
+			HoldsRetentionFloor: c.HoldsRetentionFloor,
+		})
+	}
+	for _, h := range s.Health {
+		out.Health = append(out.Health, busHealthReport{
+			Level: h.Level, Kind: h.Kind, Subject: h.Subject, Message: h.Message,
+		})
+	}
+	return out
+}
+
+func formatBusTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
 }
 
 func runBusStatus(args []string) {
@@ -116,40 +207,19 @@ func runBusStatus(args []string) {
 	s, closeStore := openBusStore()
 	defer closeStore()
 
-	earliest, head, err := s.BusBounds()
+	// The same snapshot the daemon serves the app, computed by the same code
+	// against the same database. This bus registers no consumer and is never
+	// started: it is here to read, so Live and Stalled stay unset and the
+	// snapshot says so (delivering=false).
+	b := bus.New(bus.Options{Store: daemon.NewBusStore(s), Compactable: daemon.CompactableFacts})
+	status, err := b.Status()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "bus status: reading log bounds: %v\n", err)
+		fmt.Fprintf(os.Stderr, "bus status: %v\n", err)
 		os.Exit(1)
-	}
-	rows, err := s.ListBusConsumers()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "bus status: listing consumers: %v\n", err)
-		os.Exit(1)
-	}
-	logRows, logBytes, err := s.BusLogSize()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "bus status: measuring the log: %v\n", err)
-		os.Exit(1)
-	}
-
-	report := busStatusJSON{Earliest: earliest, Head: head, Rows: logRows, Bytes: logBytes}
-	for _, r := range rows {
-		lag := head - r.Cursor
-		if lag < 0 {
-			lag = 0
-		}
-		entry := busConsumerReport{
-			Name: r.Name, Cursor: r.Cursor, Lag: lag,
-			Filter: r.Filter, Enabled: r.Enabled,
-		}
-		if !r.UpdatedAt.IsZero() {
-			entry.UpdatedAt = r.UpdatedAt.UTC().Format(time.RFC3339)
-		}
-		report.Consumers = append(report.Consumers, entry)
 	}
 
 	if asJSON {
-		out, err := json.MarshalIndent(report, "", "  ")
+		out, err := json.MarshalIndent(busStatusReport(status), "", "  ")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "bus status: %v\n", err)
 			os.Exit(1)
@@ -157,18 +227,106 @@ func runBusStatus(args []string) {
 		fmt.Println(string(out))
 		return
 	}
+	writeBusStatus(os.Stdout, status, time.Now())
+}
 
-	fmt.Printf("log: seq %d..%d, %d event(s) holding %s\n", earliest, head, logRows, humanBytes(logBytes))
-	if len(report.Consumers) == 0 {
-		fmt.Println("no registered consumers")
-		return
+// busProducerLines caps the producer table in the human rendering. The loudest
+// classes are the point; a real log carries ~50 of them and the tail is noise on
+// a terminal. What is dropped is named and totalled below the table, and --json
+// never truncates.
+const busProducerLines = 15
+
+// writeBusStatus renders the snapshot for a terminal: the log, then who writes
+// to it, then who reads it, then what is wrong. Health goes last because it is
+// what the reader leaves with.
+func writeBusStatus(w io.Writer, s bus.Status, now time.Time) {
+	fmt.Fprintf(w, "log: seq %d..%d, %d event(s) holding %s",
+		s.Earliest, s.Head, s.Rows, humanBytes(s.Bytes))
+	if !s.OldestAt.IsZero() {
+		fmt.Fprintf(w, "; oldest %s old, retention %s",
+			humanAge(now.Sub(s.OldestAt)), humanAge(s.RetentionWindow))
 	}
-	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "CONSUMER\tCURSOR\tLAG\tENABLED\tFILTER")
-	for _, c := range report.Consumers {
-		fmt.Fprintf(tw, "%s\t%d\t%d\t%t\t%s\n", c.Name, c.Cursor, c.Lag, c.Enabled, c.Filter)
+	fmt.Fprintln(w)
+
+	if len(s.Producers) > 0 {
+		fmt.Fprintf(w, "\nproducers (rates per hour over the last %s and %s):\n",
+			humanAge(bus.RecentWindow), humanAge(bus.BaselineWindow))
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "FACT\tEVENTS\tSHARE\tSUBJECTS\tBYTES\t1H/H\t24H/H")
+		shown := s.Producers
+		if len(shown) > busProducerLines {
+			shown = shown[:busProducerLines]
+		}
+		for _, p := range shown {
+			name := p.Name
+			if p.Surging {
+				name += " !"
+			}
+			fmt.Fprintf(tw, "%s\t%d\t%.1f%%\t%d\t%s\t%.0f\t%.0f\n",
+				name, p.Events, p.Share*100, p.Subjects, humanBytes(p.Bytes),
+				p.RecentPerHour, p.BaselinePerHour)
+		}
+		_ = tw.Flush()
+		// A quiet truncation would read as "these are all the fact classes".
+		// Say what was left out and what it adds up to, and where to see it.
+		if rest := s.Producers[len(shown):]; len(rest) > 0 {
+			var events int64
+			var share float64
+			for _, p := range rest {
+				events += p.Events
+				share += p.Share
+			}
+			fmt.Fprintf(w, "... and %d quieter class(es) holding %d event(s), %.1f%% of the log (--json lists every one)\n",
+				len(rest), events, share*100)
+		}
 	}
-	_ = tw.Flush()
+
+	fmt.Fprintln(w)
+	if len(s.Consumers) == 0 {
+		fmt.Fprintln(w, "no registered consumers: every subscriber on this bus is ephemeral,")
+		fmt.Fprintln(w, "so nothing holds a cursor and nothing pins retention.")
+	} else {
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "CONSUMER\tCURSOR\tLAG\tOLDEST UNREAD\tENABLED\tFILTER")
+		for _, c := range s.Consumers {
+			name := c.Name
+			if c.HoldsRetentionFloor {
+				name += " (retention floor)"
+			}
+			unread := "-"
+			if !c.OldestUnreadAt.IsZero() {
+				unread = humanAge(now.Sub(c.OldestUnreadAt))
+			}
+			fmt.Fprintf(tw, "%s\t%d\t%d\t%s\t%t\t%s\n",
+				name, c.Cursor, c.Lag, unread, c.Enabled, c.Filter)
+		}
+		_ = tw.Flush()
+	}
+
+	if len(s.Health) > 0 {
+		fmt.Fprintln(w)
+		for _, h := range s.Health {
+			fmt.Fprintf(w, "%s: %s\n", strings.ToUpper(h.Level), h.Message)
+		}
+	}
+	if !s.Delivering {
+		fmt.Fprintln(w, "\n(read from the database, not from the daemon: whether a consumer's")
+		fmt.Fprintln(w, "delivery loop is actually running is not visible from here.)")
+	}
+}
+
+// humanAge renders a duration at the scale an operator reads it at.
+func humanAge(d time.Duration) string {
+	switch {
+	case d >= 48*time.Hour:
+		return fmt.Sprintf("%.0fd", d.Hours()/24)
+	case d >= time.Hour:
+		return fmt.Sprintf("%.0fh", d.Hours())
+	case d >= time.Minute:
+		return fmt.Sprintf("%.0fm", d.Minutes())
+	default:
+		return fmt.Sprintf("%.0fs", d.Seconds())
+	}
 }
 
 // runBusTrim runs one retention pass against the profile database.

--- a/cmd/attn/bus_test.go
+++ b/cmd/attn/bus_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/bus"
+)
+
+// The human rendering is the whole product for anyone on a terminal, and it is
+// the one place that decides what to leave out. A cap nobody can see is the
+// failure mode: these check that what is dropped is still counted out loud, and
+// that the JSON drops nothing at all.
+
+var busRenderNow = time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+
+func renderBusStatus(s bus.Status) string {
+	var buf bytes.Buffer
+	writeBusStatus(&buf, s, busRenderNow)
+	return buf.String()
+}
+
+func busStatusFixture(producers ...bus.Producer) bus.Status {
+	s := bus.Status{
+		Earliest:        1,
+		Head:            1000,
+		Rows:            1000,
+		Bytes:           64_000,
+		OldestAt:        busRenderNow.Add(-8 * 24 * time.Hour),
+		NewestAt:        busRenderNow,
+		RetentionWindow: 30 * 24 * time.Hour,
+		Producers:       producers,
+	}
+	return s
+}
+
+func TestBusStatusRenderingCountsWhatItLeavesOut(t *testing.T) {
+	producers := []bus.Producer{{
+		Name: "session.state.changed", Events: 800, Share: 0.8, Subjects: 4,
+		RecentPerHour: 40, BaselinePerHour: 33,
+	}}
+	// One more class than the table shows, each holding 10 events.
+	for i := 0; i < busProducerLines; i++ {
+		producers = append(producers, bus.Producer{
+			Name: fmt.Sprintf("quiet.%d", i), Events: 10, Share: 0.01, Subjects: 2,
+		})
+	}
+	out := renderBusStatus(busStatusFixture(producers...))
+
+	if strings.Contains(out, "quiet.14") {
+		t.Fatalf("the table should stop at %d rows:\n%s", busProducerLines, out)
+	}
+	// A silent truncation reads as "that is everything". The tail has to be
+	// counted, with the share it accounts for and the way to see it.
+	for _, want := range []string{"and 1 quieter class", "10 event", "--json"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output does not state what it dropped (%q missing):\n%s", want, out)
+		}
+	}
+}
+
+func TestBusStatusRenderingSaysNothingAboutATailThatIsNotThere(t *testing.T) {
+	out := renderBusStatus(busStatusFixture(bus.Producer{
+		Name: "pr.updated", Events: 1000, Share: 1, Subjects: 100,
+	}))
+
+	if strings.Contains(out, "quieter class") {
+		t.Errorf("a fully shown table must not claim a hidden tail:\n%s", out)
+	}
+}
+
+func TestBusStatusRenderingMarksALoudProducerAndPrintsTheFindings(t *testing.T) {
+	s := busStatusFixture(
+		bus.Producer{
+			Name: "session.state.changed", Events: 900, Share: 0.9, Subjects: 4,
+			RecentPerHour: 1800, BaselinePerHour: 1892, SustainedPerHour: 680,
+			Surging: true, SurgeWindow: bus.BaselineWindow, SurgePerHour: 1892,
+		},
+		bus.Producer{Name: "pr.updated", Events: 100, Share: 0.1, Subjects: 50},
+	)
+	s.Health = []bus.Health{
+		{Level: bus.HealthError, Kind: bus.HealthConsumerLagging, Subject: "notifier",
+			Message: "consumer notifier is 41,141 events behind and not advancing"},
+		{Level: bus.HealthWarn, Kind: bus.HealthProducerSurging, Subject: "session.state.changed",
+			Message: "producer session.state.changed is publishing 1892 events/hour"},
+	}
+	out := renderBusStatus(s)
+
+	loud := producerRow(t, out, "session.state.changed")
+	if !strings.Contains(loud, "!") {
+		t.Errorf("a loud producer is not marked in the table: %q", loud)
+	}
+	if quiet := producerRow(t, out, "pr.updated"); strings.Contains(quiet, "!") {
+		t.Errorf("a quiet producer must not be marked: %q", quiet)
+	}
+	// The findings are the daemon's sentences, printed as-is and led by severity.
+	if !strings.Contains(out, "ERROR: consumer notifier is 41,141 events behind") {
+		t.Errorf("the lagging finding is missing:\n%s", out)
+	}
+	if !strings.Contains(out, "WARN: producer session.state.changed is publishing") {
+		t.Errorf("the surging finding is missing:\n%s", out)
+	}
+}
+
+// An empty log is what a fresh install has, and the command opens on it.
+func TestBusStatusRenderingOnAnEmptyLog(t *testing.T) {
+	out := renderBusStatus(bus.Status{RetentionWindow: 30 * 24 * time.Hour})
+	if out == "" {
+		t.Fatal("an empty log must still be described")
+	}
+	if strings.Contains(out, "ERROR") || strings.Contains(out, "WARN") {
+		t.Errorf("nothing is wrong with an empty log:\n%s", out)
+	}
+}
+
+// --json is the scripting surface, so it carries every window a decision could
+// be made on — including which one tripped, which the human view only says in
+// prose.
+func TestBusStatusJSONCarriesBothSustainedWindows(t *testing.T) {
+	report := busStatusReport(busStatusFixture(bus.Producer{
+		Name: "session.state.changed", Events: 1000, Share: 1, Subjects: 4,
+		RecentPerHour: 1800, BaselinePerHour: 1892, SustainedPerHour: 680,
+		Surging: true, SurgeWindow: bus.BaselineWindow, SurgePerHour: 1892,
+	}))
+	raw, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded struct {
+		Producers []struct {
+			SustainedPerHour   float64 `json:"sustained_per_hour"`
+			SurgePerHour       float64 `json:"surge_per_hour"`
+			SurgeWindowSeconds float64 `json:"surge_window_seconds"`
+			Surging            bool    `json:"surging"`
+		} `json:"producers"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(decoded.Producers) != 1 {
+		t.Fatalf("producers = %d, want 1", len(decoded.Producers))
+	}
+	p := decoded.Producers[0]
+	if p.SustainedPerHour != 680 {
+		t.Errorf("sustained_per_hour = %v, want the 6h rate 680", p.SustainedPerHour)
+	}
+	if p.SurgeWindowSeconds != bus.BaselineWindow.Seconds() {
+		t.Errorf("surge_window_seconds = %v, want the 24h window that tripped", p.SurgeWindowSeconds)
+	}
+	if p.SurgePerHour != 1892 || !p.Surging {
+		t.Errorf("surge = %v/h surging=%v, want 1892 and true", p.SurgePerHour, p.Surging)
+	}
+}
+
+// The table row for a fact, matched on the name starting the line so the marker
+// column and the health sentences below cannot stand in for it.
+func producerRow(t *testing.T, out, name string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), name) {
+			return line
+		}
+	}
+	t.Fatalf("no table row for %q in:\n%s", name, out)
+	return ""
+}

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -82,8 +82,12 @@ type Store interface {
 	// Compact keeps only the newest fact per subject among the named ones, at or
 	// below floor.
 	Compact(names []string, floor int64) (int, error)
-	// Size reports the log's row count and event-text bytes.
-	Size() (rows, bytes int64, err error)
+	// Producers reports every fact class with its totals and its counts at or
+	// after each cutoff, loudest first. It also carries the log's row count and
+	// bytes, summed across classes — one pass answers both questions.
+	Producers(cutoffs []time.Time) ([]ProducerRow, error)
+	// EventTimeAt stamps the first event at or above seq, for age questions.
+	EventTimeAt(seq int64) (time.Time, bool, error)
 }
 
 // Handler receives one event. An error stalls the consumer with backoff and
@@ -721,76 +725,6 @@ func (b *Bus) consumerFloor() (int64, error) {
 		return 0, fmt.Errorf("reading log bounds: %w", err)
 	}
 	return head, nil
-}
-
-// ConsumerStatus is one row of Status.
-type ConsumerStatus struct {
-	Name    string
-	Cursor  int64
-	Lag     int64
-	Filter  string
-	Enabled bool
-	// Live is true when this process has a delivery loop for the consumer.
-	Live bool
-	// Stalled carries the current failure message when a handler is failing.
-	Stalled string
-}
-
-// Status reports the log head and every registration, for operator inspection.
-// Rows and Bytes are the log's actual weight — the receipt that it stays
-// proportional to the data it describes, not to write frequency.
-type Status struct {
-	Head      int64
-	Earliest  int64
-	Rows      int64
-	Bytes     int64
-	Consumers []ConsumerStatus
-}
-
-// Status snapshots the bus for `attn bus status`.
-func (b *Bus) Status() (Status, error) {
-	if b.store == nil {
-		return Status{}, nil
-	}
-	earliest, head, err := b.store.Bounds()
-	if err != nil {
-		return Status{}, err
-	}
-	rows, err := b.store.ListConsumers()
-	if err != nil {
-		return Status{}, err
-	}
-	logRows, logBytes, err := b.store.Size()
-	if err != nil {
-		return Status{}, err
-	}
-
-	b.mu.Lock()
-	live := make(map[string]*durable, len(b.durables))
-	for _, d := range b.durables {
-		live[d.name] = d
-	}
-	b.mu.Unlock()
-
-	out := Status{Head: head, Earliest: earliest, Rows: logRows, Bytes: logBytes}
-	for _, r := range rows {
-		cs := ConsumerStatus{
-			Name:    r.Name,
-			Cursor:  r.Cursor,
-			Lag:     head - r.Cursor,
-			Filter:  r.Filter,
-			Enabled: r.Enabled,
-		}
-		if cs.Lag < 0 {
-			cs.Lag = 0
-		}
-		if d, ok := live[r.Name]; ok {
-			cs.Live = true
-			cs.Stalled = d.stallReason()
-		}
-		out.Consumers = append(out.Consumers, cs)
-	}
-	return out, nil
 }
 
 func (d *durable) position() int64 {

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -632,7 +632,8 @@ func (b *Bus) advance(d *durable, seq int64) error {
 	return nil
 }
 
-// retain runs the retention window.
+// retain runs the bus's own periodic duties: reclaim what retention allows,
+// then say so when a producer is writing far more than any healthy one does.
 func (b *Bus) retain() {
 	ticker := time.NewTicker(b.trimInterval)
 	defer ticker.Stop()
@@ -642,6 +643,31 @@ func (b *Bus) retain() {
 			return
 		case <-ticker.C:
 			_, _ = b.Trim()
+			b.ReportLoudProducers()
+		}
+	}
+}
+
+// ReportLoudProducers writes one loud log line per fact class over the tripwire,
+// and nothing at all otherwise.
+//
+// This is the half of bus observability that does not wait to be looked at. The
+// producer bug this exists for wrote two thirds of the log for a week and was
+// found by accident during unrelated work; a page nobody opens would not have
+// caught it either. Each line names the fact, the rate, the ceiling it crossed,
+// and the window — everything needed to act on it without reading this code.
+func (b *Bus) ReportLoudProducers() {
+	if b.store == nil {
+		return
+	}
+	status, err := b.Status()
+	if err != nil {
+		b.log("bus: reading the log to check producer rates: %v", err)
+		return
+	}
+	for _, h := range status.Health {
+		if h.Kind == HealthProducerSurging {
+			b.log("bus: %s", h.Message)
 		}
 	}
 }

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -637,6 +637,10 @@ func (b *Bus) advance(d *durable, seq int64) error {
 func (b *Bus) retain() {
 	ticker := time.NewTicker(b.trimInterval)
 	defer ticker.Stop()
+	// Report before the first tick, not an hour into the run: a producer already
+	// past the ceiling is past it at startup, and a daemon restarted more often
+	// than trimInterval would otherwise never say so.
+	b.ReportLoudProducers()
 	for {
 		select {
 		case <-b.ctx.Done():

--- a/internal/bus/bus_test.go
+++ b/internal/bus/bus_test.go
@@ -3,6 +3,7 @@ package bus
 import (
 	"context"
 	"errors"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -195,14 +196,52 @@ func (m *memStore) Compact(names []string, floor int64) (int, error) {
 	return removed, nil
 }
 
-func (m *memStore) Size() (int64, int64, error) {
+// Producers mirrors the SQLite aggregate: one row per fact class, loudest
+// first, each carrying its totals and one count per cutoff.
+func (m *memStore) Producers(cutoffs []time.Time) ([]ProducerRow, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	var bytes int64
+	byName := map[string]*ProducerRow{}
+	subjects := map[string]map[string]bool{}
 	for _, e := range m.events {
-		bytes += int64(len(e.Name) + len(e.Subject) + len(e.Payload) + len(e.Source))
+		row, ok := byName[e.Name]
+		if !ok {
+			row = &ProducerRow{Name: e.Name, Recent: make([]int64, len(cutoffs))}
+			byName[e.Name] = row
+			subjects[e.Name] = map[string]bool{}
+		}
+		row.Events++
+		row.Bytes += int64(len(e.Name) + len(e.Subject) + len(e.Payload) + len(e.Source))
+		subjects[e.Name][e.Subject] = true
+		for i, c := range cutoffs {
+			if !e.CreatedAt.Before(c) {
+				row.Recent[i]++
+			}
+		}
 	}
-	return int64(len(m.events)), bytes, nil
+	out := make([]ProducerRow, 0, len(byName))
+	for name, row := range byName {
+		row.Subjects = int64(len(subjects[name]))
+		out = append(out, *row)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Events != out[j].Events {
+			return out[i].Events > out[j].Events
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out, nil
+}
+
+func (m *memStore) EventTimeAt(seq int64) (time.Time, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.events {
+		if e.Seq >= seq {
+			return e.CreatedAt, true, nil
+		}
+	}
+	return time.Time{}, false, nil
 }
 
 // appendOutOfBand puts an event on the log the way a store transaction does:

--- a/internal/bus/status.go
+++ b/internal/bus/status.go
@@ -1,0 +1,441 @@
+package bus
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+// The bus's operator picture: what the log holds, who writes to it, who reads
+// it, and what is wrong. Computed once here and rendered twice — `attn bus
+// status` runs it against the database directly, the daemon serves the same
+// snapshot to the app. Neither surface derives anything of its own, so the two
+// can never disagree about whether something is healthy.
+
+const (
+	// RecentWindow and BaselineWindow are the two rates a producer is reported
+	// at: what it is doing now, and what it has been doing.
+	RecentWindow   = time.Hour
+	BaselineWindow = 24 * time.Hour
+
+	// SurgeWindow and SurgeRatePerHour are the loud-producer tripwire.
+	//
+	// It is an absolute ceiling, not a multiple of the producer's own history,
+	// because a relative baseline cannot be set on this data: measured over 8
+	// days of production, an hour compared against the mean of its preceding 24
+	// reaches 35x on healthy classes (an idle night drags the baseline to near
+	// zero) and would fire 48 times; day-over-day still swings 4-6x on the loud
+	// classes. Any threshold that catches a real flap also cries wolf.
+	//
+	// Sustained rate separates cleanly, because hours of smoothing absorb the
+	// burstiness that defeats the relative comparison. Measured over the same 8
+	// days of production, against the loudest healthy class (pr.updated):
+	//
+	//	window  healthy max  flapping class     headroom at 1000/h
+	//	6h        480/h      5763/h peak          2.08x
+	//	24h       357/h      1075-2265/h          2.80x
+	//
+	// The ceiling is checked on BOTH windows because they catch different
+	// things. The 6h window catches a flap starting, within hours. The 24h
+	// window catches one that is simply always loud — the state this bus was
+	// already in, where an evening lull drops the 6h rate below the line while
+	// the producer still writes two thirds of the log.
+	//
+	// The headroom is deliberately thinner than a tripwire usually gets, because
+	// the two errors do not cost the same: a false positive is one WARN line in
+	// the daemon log, and a false negative is what already happened — a producer
+	// writing two thirds of the log for a week, found by accident.
+	SurgeWindow      = 6 * time.Hour
+	SurgeRatePerHour = 1000.0
+
+	// StallAge is how long an enabled consumer may hold unread events without
+	// its cursor moving before it is called stalled. Delivery polls every
+	// DefaultPollInterval (5s) and a failing handler retries at most
+	// DefaultRetryCap (2m) apart, so a healthy consumer — even one retrying —
+	// advances well inside this. 5 minutes is 2.5x past the retry cap.
+	StallAge = 5 * time.Minute
+)
+
+// ProducerRow is what the Store seam hands back for one fact class: the raw
+// counts, with no rate or share derived. The policy — which windows, what
+// counts as loud — lives on this side of the seam.
+type ProducerRow struct {
+	Name     string
+	Events   int64
+	Bytes    int64
+	Subjects int64
+	// Recent is aligned with the cutoffs Producers was given, one count each.
+	Recent []int64
+}
+
+// Producer is one fact class's contribution to the log.
+type Producer struct {
+	Name     string
+	Events   int64
+	Bytes    int64
+	Subjects int64
+	// Share is this class's fraction of the log's rows, 0..1.
+	Share float64
+	// RecentPerHour and BaselinePerHour are mean rates over RecentWindow and
+	// BaselineWindow. SustainedPerHour is the rate over SurgeWindow.
+	RecentPerHour    float64
+	BaselinePerHour  float64
+	SustainedPerHour float64
+	// Surging is set when either sustained window crossed SurgeRatePerHour;
+	// SurgeWindow names the one that did, and SurgePerHour is its rate.
+	Surging      bool
+	SurgeWindow  time.Duration
+	SurgePerHour float64
+}
+
+// surge decides whether a producer trips the ceiling, and on which window. The
+// loudest crossing wins, so the message reports the worst of the two rather
+// than whichever happened to be checked first.
+func (p *Producer) surge() {
+	windows := []struct {
+		d    time.Duration
+		rate float64
+	}{
+		{SurgeWindow, p.SustainedPerHour},
+		{BaselineWindow, p.BaselinePerHour},
+	}
+	for _, w := range windows {
+		if w.rate >= SurgeRatePerHour && w.rate > p.SurgePerHour {
+			p.Surging = true
+			p.SurgeWindow = w.d
+			p.SurgePerHour = w.rate
+		}
+	}
+}
+
+// ConsumerStatus is one durable consumer's registration, position, and lag.
+type ConsumerStatus struct {
+	Name      string
+	Cursor    int64
+	Lag       int64
+	Filter    string
+	Enabled   bool
+	UpdatedAt time.Time
+	// Live is true when this process has a delivery loop for the consumer, and
+	// is meaningful only when Status.Delivering is set.
+	Live bool
+	// Stalled carries the current failure message when a handler is failing.
+	Stalled string
+	// OldestUnreadAt stamps the oldest event this consumer has not read; zero
+	// when it is caught up. Lag counts events, this says how long they waited.
+	OldestUnreadAt time.Time
+	// HoldsRetentionFloor marks the enabled consumer whose cursor is the floor
+	// retention stops at — the one pinning the log.
+	HoldsRetentionFloor bool
+}
+
+// Health levels, ordered by how much they want attention.
+const (
+	HealthWarn  = "warn"
+	HealthError = "error"
+)
+
+// Health kinds. Machine-readable so a surface can style or filter by them; the
+// Message is the whole sentence and needs no assembly.
+const (
+	HealthConsumerDisabled  = "consumer_disabled"
+	HealthConsumerStalled   = "consumer_stalled"
+	HealthConsumerNotLive   = "consumer_not_live"
+	HealthConsumerLagging   = "consumer_lagging"
+	HealthRetentionPinned   = "retention_pinned"
+	HealthProducerSurging   = "producer_surging"
+)
+
+// Health is one thing wrong, said plainly. A surface renders Message; it does
+// not re-derive the finding from the numbers.
+type Health struct {
+	Level   string
+	Kind    string
+	Subject string
+	Message string
+}
+
+// Status is the whole operator picture.
+type Status struct {
+	Head     int64
+	Earliest int64
+	Rows     int64
+	Bytes    int64
+	// OldestAt and NewestAt bound the log in time; zero on an empty log.
+	OldestAt time.Time
+	NewestAt time.Time
+	// Delivering says this snapshot came from a process that owns the delivery
+	// loops. Only then do Live and Stalled mean anything, and only then can a
+	// registered-but-not-running consumer be reported — `attn bus status` reads
+	// the database from outside the daemon and knows neither.
+	Delivering bool
+	// RetentionWindow is the age past which retention drops events.
+	RetentionWindow time.Duration
+
+	Producers []Producer
+	Consumers []ConsumerStatus
+	Health    []Health
+}
+
+// Status snapshots the bus. Everything both surfaces show is computed here.
+func (b *Bus) Status() (Status, error) {
+	if b.store == nil {
+		return Status{}, nil
+	}
+	now := b.now()
+
+	earliest, head, err := b.store.Bounds()
+	if err != nil {
+		return Status{}, err
+	}
+	consumers, err := b.store.ListConsumers()
+	if err != nil {
+		return Status{}, err
+	}
+	// Cutoffs are positional; the reads below must match this order.
+	cutoffs := []time.Time{
+		now.Add(-RecentWindow),
+		now.Add(-SurgeWindow),
+		now.Add(-BaselineWindow),
+	}
+	producers, err := b.store.Producers(cutoffs)
+	if err != nil {
+		return Status{}, err
+	}
+
+	out := Status{
+		Head:            head,
+		Earliest:        earliest,
+		Delivering:      b.delivering(),
+		RetentionWindow: b.retention,
+	}
+	for _, p := range producers {
+		out.Rows += p.Events
+		out.Bytes += p.Bytes
+	}
+	if out.Rows > 0 {
+		if t, ok, err := b.store.EventTimeAt(earliest); err == nil && ok {
+			out.OldestAt = t
+		}
+		if t, ok, err := b.store.EventTimeAt(head); err == nil && ok {
+			out.NewestAt = t
+		}
+	}
+
+	for _, p := range producers {
+		entry := Producer{
+			Name:             p.Name,
+			Events:           p.Events,
+			Bytes:            p.Bytes,
+			Subjects:         p.Subjects,
+			RecentPerHour:    perHour(p.Recent[0], RecentWindow),
+			SustainedPerHour: perHour(p.Recent[1], SurgeWindow),
+			BaselinePerHour:  perHour(p.Recent[2], BaselineWindow),
+		}
+		if out.Rows > 0 {
+			entry.Share = float64(p.Events) / float64(out.Rows)
+		}
+		entry.surge()
+		out.Producers = append(out.Producers, entry)
+	}
+
+	live := b.liveDurables()
+	floor := retentionFloorName(consumers)
+	for _, c := range consumers {
+		entry := ConsumerStatus{
+			Name:                c.Name,
+			Cursor:              c.Cursor,
+			Lag:                 max64(head-c.Cursor, 0),
+			Filter:              c.Filter,
+			Enabled:             c.Enabled,
+			UpdatedAt:           c.UpdatedAt,
+			HoldsRetentionFloor: c.Name == floor,
+		}
+		if entry.Lag > 0 {
+			if t, ok, err := b.store.EventTimeAt(c.Cursor + 1); err == nil && ok {
+				entry.OldestUnreadAt = t
+			}
+		}
+		if d, ok := live[c.Name]; ok {
+			entry.Live = true
+			entry.Stalled = d.stallReason()
+		}
+		out.Consumers = append(out.Consumers, entry)
+	}
+
+	out.Health = health(out, now)
+	return out, nil
+}
+
+// health turns the snapshot into the warnings a user should read, so no surface
+// has to infer "this is bad" from a number. Ordered worst first.
+func health(s Status, now time.Time) []Health {
+	var out []Health
+	for _, c := range s.Consumers {
+		switch {
+		case c.Stalled != "":
+			out = append(out, Health{
+				Level: HealthError, Kind: HealthConsumerStalled, Subject: c.Name,
+				Message: fmt.Sprintf("consumer %s is stalled at seq %d and is retrying: %s",
+					c.Name, c.Cursor+1, c.Stalled),
+			})
+		case c.Enabled && c.Lag > 0 && stale(c.UpdatedAt, now):
+			msg := fmt.Sprintf("consumer %s is %s behind and not advancing; its cursor has not moved for %s",
+				c.Name, events(c.Lag), roundDuration(now.Sub(c.UpdatedAt)))
+			if !c.OldestUnreadAt.IsZero() {
+				msg += fmt.Sprintf(", and its oldest unread event has waited %s",
+					roundDuration(now.Sub(c.OldestUnreadAt)))
+			}
+			out = append(out, Health{
+				Level: HealthError, Kind: HealthConsumerLagging, Subject: c.Name, Message: msg,
+			})
+		case s.Delivering && c.Enabled && !c.Live:
+			out = append(out, Health{
+				Level: HealthWarn, Kind: HealthConsumerNotLive, Subject: c.Name,
+				Message: fmt.Sprintf("consumer %s is registered and enabled but has no delivery loop in this daemon, so nothing is reading its %s backlog",
+					c.Name, events(c.Lag)),
+			})
+		case !c.Enabled:
+			out = append(out, Health{
+				Level: HealthWarn, Kind: HealthConsumerDisabled, Subject: c.Name,
+				Message: fmt.Sprintf("consumer %s is disabled: it is not being delivered to, and it does not hold retention open — once trimming passes its cursor at seq %d, enabling it resumes at head with a logged gap",
+					c.Name, c.Cursor),
+			})
+		}
+	}
+	for _, c := range s.Consumers {
+		// A consumer legitimately holding the floor a little back is the system
+		// working. It is worth saying only when it is also the reason old events
+		// survive: it has fallen behind the retention window itself.
+		if !c.HoldsRetentionFloor || c.OldestUnreadAt.IsZero() {
+			continue
+		}
+		age := now.Sub(c.OldestUnreadAt)
+		if age <= s.RetentionWindow {
+			continue
+		}
+		out = append(out, Health{
+			Level: HealthWarn, Kind: HealthRetentionPinned, Subject: c.Name,
+			Message: fmt.Sprintf("consumer %s pins the retention floor at seq %d: its oldest unread event is %s old, past the %s window, so nothing below it can be trimmed",
+				c.Name, c.Cursor, roundDuration(age), roundDuration(s.RetentionWindow)),
+		})
+	}
+	for _, p := range s.Producers {
+		if !p.Surging {
+			continue
+		}
+		out = append(out, Health{
+			Level: HealthWarn, Kind: HealthProducerSurging, Subject: p.Name,
+			Message: surgeMessage(p),
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Level == HealthError && out[j].Level != HealthError
+	})
+	return out
+}
+
+// surgeMessage names the number, the tripwire it crossed, and the window — the
+// three things an agent needs to act on it without reading this code.
+func surgeMessage(p Producer) string {
+	return fmt.Sprintf("producer %s is publishing %.0f events/hour sustained over the last %s, past the %.0f/hour tripwire; it holds %s (%.0f%% of the log) across %d subject(s)",
+		p.Name, p.SurgePerHour, roundDuration(p.SurgeWindow), SurgeRatePerHour,
+		events(p.Events), p.Share*100, p.Subjects)
+}
+
+// retentionFloorName is the enabled consumer whose cursor retention stops at.
+// Disabled consumers are excluded exactly as the trim does — they do not pin.
+func retentionFloorName(consumers []Consumer) string {
+	name := ""
+	floor := int64(-1)
+	for _, c := range consumers {
+		if !c.Enabled {
+			continue
+		}
+		if floor < 0 || c.Cursor < floor {
+			floor = c.Cursor
+			name = c.Name
+		}
+	}
+	return name
+}
+
+func (b *Bus) liveDurables() map[string]*durable {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make(map[string]*durable, len(b.durables))
+	for _, d := range b.durables {
+		out[d.name] = d
+	}
+	return out
+}
+
+// delivering reports whether this process owns delivery loops, which is what
+// makes Live and Stalled trustworthy. A Bus built to read the database — `attn
+// bus status` — registers nothing and never starts.
+func (b *Bus) delivering() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.started && len(b.durables) > 0
+}
+
+func perHour(count int64, window time.Duration) float64 {
+	if window <= 0 {
+		return 0
+	}
+	return float64(count) / window.Hours()
+}
+
+func stale(updatedAt, now time.Time) bool {
+	// A registration that never recorded a write cannot be called stalled.
+	return !updatedAt.IsZero() && now.Sub(updatedAt) >= StallAge
+}
+
+func events(n int64) string {
+	if n == 1 {
+		return "1 event"
+	}
+	return fmt.Sprintf("%s events", humanCount(n))
+}
+
+// humanCount groups thousands so a six-figure backlog reads as one at a glance.
+func humanCount(n int64) string {
+	s := fmt.Sprintf("%d", n)
+	if n < 0 || len(s) <= 3 {
+		return s
+	}
+	head := len(s) % 3
+	if head == 0 {
+		head = 3
+	}
+	out := s[:head]
+	for i := head; i < len(s); i += 3 {
+		out += "," + s[i:i+3]
+	}
+	return out
+}
+
+// roundDuration renders a span the way someone says it out loud, so a message
+// reads "24h" and "3d" rather than "24h0m0s" and "72h0m0s".
+func roundDuration(d time.Duration) string {
+	switch {
+	case d >= 48*time.Hour:
+		return fmt.Sprintf("%.0fd", d.Hours()/24)
+	case d >= time.Hour:
+		if m := int(d.Minutes()) % 60; m != 0 {
+			return fmt.Sprintf("%dh%dm", int(d.Hours()), m)
+		}
+		return fmt.Sprintf("%.0fh", d.Hours())
+	case d >= time.Minute:
+		return fmt.Sprintf("%.0fm", d.Minutes())
+	default:
+		return fmt.Sprintf("%.0fs", d.Seconds())
+	}
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/bus/status.go
+++ b/internal/bus/status.go
@@ -138,12 +138,12 @@ const (
 // Health kinds. Machine-readable so a surface can style or filter by them; the
 // Message is the whole sentence and needs no assembly.
 const (
-	HealthConsumerDisabled  = "consumer_disabled"
-	HealthConsumerStalled   = "consumer_stalled"
-	HealthConsumerNotLive   = "consumer_not_live"
-	HealthConsumerLagging   = "consumer_lagging"
-	HealthRetentionPinned   = "retention_pinned"
-	HealthProducerSurging   = "producer_surging"
+	HealthConsumerDisabled = "consumer_disabled"
+	HealthConsumerStalled  = "consumer_stalled"
+	HealthConsumerNotLive  = "consumer_not_live"
+	HealthConsumerLagging  = "consumer_lagging"
+	HealthRetentionPinned  = "retention_pinned"
+	HealthProducerSurging  = "producer_surging"
 )
 
 // Health is one thing wrong, said plainly. A surface renders Message; it does

--- a/internal/bus/status_test.go
+++ b/internal/bus/status_test.go
@@ -1,0 +1,438 @@
+package bus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Status is the one computation two surfaces render, and the tripwire is the
+// half nobody has to be looking at. Both are driven here on a fixed clock: a
+// rate is a claim about a window, and a test that cannot place events inside
+// one is not testing the claim.
+
+var statusNow = time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+
+// statusBus builds a bus over a memStore with the clock pinned, so "the last
+// hour" is a place events can be put rather than a race with the wall.
+func statusBus(t *testing.T) (*Bus, *memStore) {
+	t.Helper()
+	s := newMemStore()
+	b := New(Options{Store: s, Now: func() time.Time { return statusNow }})
+	return b, s
+}
+
+// publishAt appends n events of a class at a fixed age, spread across subjects.
+func publishAt(t *testing.T, s *memStore, name string, subjects, n int, ago time.Duration) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		subject := fmt.Sprintf("%s_%d", name, i%subjects)
+		if _, err := s.Append(Event{
+			Name: name, Subject: subject, Source: "test",
+		}, statusNow.Add(-ago)); err != nil {
+			t.Fatalf("append %s: %v", name, err)
+		}
+	}
+}
+
+func producer(t *testing.T, s Status, name string) Producer {
+	t.Helper()
+	for _, p := range s.Producers {
+		if p.Name == name {
+			return p
+		}
+	}
+	t.Fatalf("no producer %q in status", name)
+	return Producer{}
+}
+
+func findHealth(s Status, kind, subject string) (Health, bool) {
+	for _, h := range s.Health {
+		if h.Kind == kind && h.Subject == subject {
+			return h, true
+		}
+	}
+	return Health{}, false
+}
+
+func TestStatusReportsProducerRatesAndShare(t *testing.T) {
+	b, s := statusBus(t)
+	publishAt(t, s, "session.state.changed", 3, 60, 30*time.Minute)
+	publishAt(t, s, "session.state.changed", 3, 120, 5*time.Hour)
+	publishAt(t, s, "pr.updated", 20, 20, 2*time.Hour)
+
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.Rows != 200 {
+		t.Fatalf("rows = %d, want 200", status.Rows)
+	}
+
+	loud := producer(t, status, "session.state.changed")
+	// 60 events inside a 1h window is 60/hour; 180 inside 24h is 7.5/hour.
+	if loud.RecentPerHour != 60 {
+		t.Errorf("recent rate = %v, want 60", loud.RecentPerHour)
+	}
+	if loud.BaselinePerHour != 7.5 {
+		t.Errorf("baseline rate = %v, want 7.5", loud.BaselinePerHour)
+	}
+	if want := 180.0 / 200.0; loud.Share != want {
+		t.Errorf("share = %v, want %v", loud.Share, want)
+	}
+	if loud.Subjects != 3 {
+		t.Errorf("subjects = %d, want 3", loud.Subjects)
+	}
+}
+
+// The tripwire is an absolute ceiling on a sustained window, and it must not
+// fire on a producer that is merely busy right now.
+func TestStatusDoesNotCallABurstySmallProducerLoud(t *testing.T) {
+	b, s := statusBus(t)
+	// 900 events in the last 10 minutes: a 5400/hour instantaneous rate, far
+	// past the ceiling — but only 900 across either sustained window.
+	publishAt(t, s, "pr.updated", 40, 900, 10*time.Minute)
+
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	p := producer(t, status, "pr.updated")
+	if p.Surging {
+		t.Errorf("a burst inside one window is not a sustained rate; surge = %v/h over %s",
+			p.SurgePerHour, p.SurgeWindow)
+	}
+	if _, ok := findHealth(status, HealthProducerSurging, "pr.updated"); ok {
+		t.Error("a burst must not raise a health warning")
+	}
+}
+
+// Onset: a class crossing the ceiling on the 6h window is caught within hours,
+// which is the whole point — the bug this exists for ran for a week.
+func TestStatusCatchesASurgeOnTheSustainedWindow(t *testing.T) {
+	b, s := statusBus(t)
+	// 6001 events spread over the last 6 hours: just past 1000/hour.
+	for i := 0; i < 6001; i++ {
+		publishAt(t, s, "session.state.changed", 2, 1, time.Duration(i%360)*time.Minute)
+	}
+
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	p := producer(t, status, "session.state.changed")
+	if !p.Surging {
+		t.Fatalf("sustained %v/h did not trip the %v/h ceiling", p.SustainedPerHour, SurgeRatePerHour)
+	}
+	h, ok := findHealth(status, HealthProducerSurging, "session.state.changed")
+	if !ok {
+		t.Fatal("a surging producer must raise a health warning")
+	}
+	// The line has to be actionable on its own: the number, the ceiling it
+	// crossed, and the window it was measured over.
+	for _, want := range []string{"session.state.changed", "1000/hour", "events/hour"} {
+		if !strings.Contains(h.Message, want) {
+			t.Errorf("message %q is missing %q", h.Message, want)
+		}
+	}
+}
+
+// Standing loudness: an evening lull drops the 6h rate below the line while the
+// producer still owns most of the log. That is the state production was in.
+func TestStatusCatchesAStandingLoudProducerOnTheBaselineWindow(t *testing.T) {
+	b, s := statusBus(t)
+	// Quiet for the last 6 hours, very loud in the 18 before that.
+	publishAt(t, s, "session.state.changed", 4, 200, 3*time.Hour)
+	for i := 0; i < 24000; i++ {
+		publishAt(t, s, "session.state.changed", 4, 1, 7*time.Hour+time.Duration(i%600)*time.Minute)
+	}
+
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	p := producer(t, status, "session.state.changed")
+	if p.SustainedPerHour >= SurgeRatePerHour {
+		t.Fatalf("this case needs a quiet 6h window; sustained = %v/h", p.SustainedPerHour)
+	}
+	if !p.Surging {
+		t.Fatalf("a producer at %v/h over 24h must still be called loud", p.BaselinePerHour)
+	}
+	if p.SurgeWindow != BaselineWindow {
+		t.Errorf("surge window = %s, want the 24h window that tripped", p.SurgeWindow)
+	}
+}
+
+// ReportLoudProducers is the surface nobody has to be looking at. It says
+// nothing when everything is fine — a tripwire working code never feels.
+func TestReportLoudProducersIsSilentOnAHealthyLog(t *testing.T) {
+	s := newMemStore()
+	var lines []string
+	var mu sync.Mutex
+	b := New(Options{
+		Store: s,
+		Now:   func() time.Time { return statusNow },
+		Log: func(format string, args ...interface{}) {
+			mu.Lock()
+			lines = append(lines, fmt.Sprintf(format, args...))
+			mu.Unlock()
+		},
+	})
+	publishAt(t, s, "pr.updated", 30, 400, 3*time.Hour)
+
+	b.ReportLoudProducers()
+	if len(lines) != 0 {
+		t.Fatalf("want silence on a healthy log, got %q", lines)
+	}
+}
+
+func TestReportLoudProducersNamesTheFactRateAndWindow(t *testing.T) {
+	s := newMemStore()
+	var lines []string
+	var mu sync.Mutex
+	b := New(Options{
+		Store: s,
+		Now:   func() time.Time { return statusNow },
+		Log: func(format string, args ...interface{}) {
+			mu.Lock()
+			lines = append(lines, fmt.Sprintf(format, args...))
+			mu.Unlock()
+		},
+	})
+	for i := 0; i < 7000; i++ {
+		publishAt(t, s, "session.state.changed", 2, 1, time.Duration(i%360)*time.Minute)
+	}
+
+	b.ReportLoudProducers()
+	if len(lines) != 1 {
+		t.Fatalf("want exactly one line for one loud class, got %q", lines)
+	}
+	for _, want := range []string{"session.state.changed", "1000/hour", "% of the log"} {
+		if !strings.Contains(lines[0], want) {
+			t.Errorf("line %q is missing %q", lines[0], want)
+		}
+	}
+}
+
+func TestStatusReportsConsumerLagAndTheRetentionFloor(t *testing.T) {
+	b, s := statusBus(t)
+	publishAt(t, s, "session.state.changed", 4, 100, 3*time.Hour)
+
+	if err := s.SaveConsumer(Consumer{Name: "behind", Cursor: 10, Enabled: true}, statusNow); err != nil {
+		t.Fatalf("SaveConsumer: %v", err)
+	}
+	if err := s.SaveConsumer(Consumer{Name: "ahead", Cursor: 90, Enabled: true}, statusNow); err != nil {
+		t.Fatalf("SaveConsumer: %v", err)
+	}
+
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	var behind, ahead ConsumerStatus
+	for _, c := range status.Consumers {
+		switch c.Name {
+		case "behind":
+			behind = c
+		case "ahead":
+			ahead = c
+		}
+	}
+	if behind.Lag != 90 {
+		t.Errorf("behind lag = %d, want 90", behind.Lag)
+	}
+	if !behind.HoldsRetentionFloor {
+		t.Error("the lowest enabled cursor holds the retention floor")
+	}
+	if ahead.HoldsRetentionFloor {
+		t.Error("only one consumer holds the floor, and it is the lowest")
+	}
+	// Lag counts events; this says how long the oldest has waited.
+	if behind.OldestUnreadAt.IsZero() {
+		t.Error("a consumer with lag must report the age of its oldest unread event")
+	}
+	if !ahead.OldestUnreadAt.IsZero() && ahead.Lag == 0 {
+		t.Error("a caught-up consumer has no oldest unread event")
+	}
+}
+
+// The oldest UNREAD event is the one after the cursor, not the one at it. The
+// cursor names what was already handled, so reporting its stamp would age the
+// backlog by one event and read as "waiting" when the consumer is caught up.
+func TestStatusDatesTheOldestUnreadEventFromAfterTheCursor(t *testing.T) {
+	b, s := statusBus(t)
+	// Distinct ages, so an off-by-one is visible rather than absorbed.
+	publishAt(t, s, "pr.updated", 1, 1, 9*time.Hour) // seq 1
+	publishAt(t, s, "pr.updated", 1, 1, 5*time.Hour) // seq 2
+	publishAt(t, s, "pr.updated", 1, 1, 1*time.Hour) // seq 3
+
+	if err := s.SaveConsumer(Consumer{Name: "reader", Cursor: 1, Enabled: true}, statusNow); err != nil {
+		t.Fatalf("SaveConsumer: %v", err)
+	}
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	got := status.Consumers[0].OldestUnreadAt
+	want := statusNow.Add(-5 * time.Hour)
+	if !got.Equal(want) {
+		t.Fatalf("oldest unread = %s, want seq 2 at %s (seq 1 is already read)", got, want)
+	}
+
+	// And a consumer at the head is waiting on nothing.
+	if err := s.SetCursor("reader", 3, statusNow); err != nil {
+		t.Fatalf("SetCursor: %v", err)
+	}
+	status, err = b.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if !status.Consumers[0].OldestUnreadAt.IsZero() {
+		t.Errorf("a caught-up consumer reported an oldest unread event at %s",
+			status.Consumers[0].OldestUnreadAt)
+	}
+}
+
+// A disabled consumer is a deliberate state, but it is also the state that
+// silently stops work. The user must be told, not left to read a false column.
+func TestStatusWarnsAboutADisabledConsumer(t *testing.T) {
+	b, s := statusBus(t)
+	publishAt(t, s, "pr.updated", 4, 10, time.Hour)
+	if err := s.SaveConsumer(Consumer{Name: "killed", Cursor: 2, Enabled: false}, statusNow); err != nil {
+		t.Fatalf("SaveConsumer: %v", err)
+	}
+
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	h, ok := findHealth(status, HealthConsumerDisabled, "killed")
+	if !ok {
+		t.Fatal("a disabled consumer must raise a warning")
+	}
+	if !strings.Contains(h.Message, "killed") || !strings.Contains(h.Message, "disabled") {
+		t.Errorf("message %q must name the consumer and its state", h.Message)
+	}
+	// A disabled consumer does not pin the log, exactly as trimming treats it.
+	for _, c := range status.Consumers {
+		if c.Name == "killed" && c.HoldsRetentionFloor {
+			t.Error("a disabled consumer must not be shown holding the retention floor")
+		}
+	}
+}
+
+// "41,000 events behind and not advancing" is the sentence the brief asked for:
+// a lag that is not moving is different from a lag that is being worked through.
+func TestStatusSaysWhenAnEnabledConsumerStopsAdvancing(t *testing.T) {
+	b, s := statusBus(t)
+	publishAt(t, s, "session.state.changed", 4, 100, 3*time.Hour)
+	if err := s.SaveConsumer(Consumer{Name: "stuck", Cursor: 1, Enabled: true}, statusNow.Add(-StallAge)); err != nil {
+		t.Fatalf("SaveConsumer: %v", err)
+	}
+
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	h, ok := findHealth(status, HealthConsumerLagging, "stuck")
+	if !ok {
+		t.Fatal("a consumer whose cursor stopped moving while behind must be reported")
+	}
+	if h.Level != HealthError {
+		t.Errorf("level = %q, want %q", h.Level, HealthError)
+	}
+	for _, want := range []string{"stuck", "99 events", "not advancing"} {
+		if !strings.Contains(h.Message, want) {
+			t.Errorf("message %q is missing %q", h.Message, want)
+		}
+	}
+}
+
+// A consumer that is behind but visibly catching up is the system working.
+func TestStatusDoesNotCallAMovingConsumerStalled(t *testing.T) {
+	b, s := statusBus(t)
+	publishAt(t, s, "session.state.changed", 4, 100, 3*time.Hour)
+	if err := s.SaveConsumer(Consumer{Name: "catching-up", Cursor: 1, Enabled: true}, statusNow.Add(-time.Second)); err != nil {
+		t.Fatalf("SaveConsumer: %v", err)
+	}
+
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if h, ok := findHealth(status, HealthConsumerLagging, "catching-up"); ok {
+		t.Errorf("a consumer that just advanced is not stalled: %q", h.Message)
+	}
+}
+
+// Live and Stalled only mean something when the snapshot came from the process
+// that owns delivery. `attn bus status` reads the database from outside it, and
+// must not therefore accuse every consumer of not running.
+func TestStatusOnlyClaimsDeliveryKnowledgeWhenItHasIt(t *testing.T) {
+	b, s := statusBus(t)
+	publishAt(t, s, "pr.updated", 2, 5, time.Hour)
+	if err := s.SaveConsumer(Consumer{Name: "elsewhere", Cursor: 5, Enabled: true}, statusNow); err != nil {
+		t.Fatalf("SaveConsumer: %v", err)
+	}
+
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.Delivering {
+		t.Error("a bus with no registered consumers is not delivering")
+	}
+	if _, ok := findHealth(status, HealthConsumerNotLive, "elsewhere"); ok {
+		t.Error("a reader outside the daemon cannot know a consumer is not running")
+	}
+
+	// The same registration, seen by a bus that does own delivery loops.
+	running, _ := statusBus(t)
+	running.store = s
+	if err := running.Register("mine", All, func(context.Context, Event) error { return nil }); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := running.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(running.Stop)
+
+	status, err = running.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if !status.Delivering {
+		t.Fatal("a started bus with a registered consumer is delivering")
+	}
+	if _, ok := findHealth(status, HealthConsumerNotLive, "elsewhere"); !ok {
+		t.Error("a daemon that owns delivery must report a registration nothing is reading")
+	}
+}
+
+func TestStatusOnAnEmptyLog(t *testing.T) {
+	b, _ := statusBus(t)
+	status, err := b.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.Rows != 0 || len(status.Producers) != 0 || len(status.Health) != 0 {
+		t.Fatalf("empty log must report nothing: %+v", status)
+	}
+	if !status.OldestAt.IsZero() {
+		t.Error("an empty log has no oldest event")
+	}
+}
+
+// A store that cannot answer must fail the snapshot rather than render a
+// confident picture of a log it could not read.
+func TestStatusFailsWhenTheLogCannotBeRead(t *testing.T) {
+	b, s := statusBus(t)
+	s.setBoundsErr(errors.New("disk gone"))
+	if _, err := b.Status(); err == nil {
+		t.Fatal("want an error when the log's bounds cannot be read")
+	}
+}

--- a/internal/bus/status_test.go
+++ b/internal/bus/status_test.go
@@ -218,6 +218,42 @@ func TestReportLoudProducersNamesTheFactRateAndWindow(t *testing.T) {
 	}
 }
 
+// A restart must not buy a loud producer an hour of silence. The retention tick
+// is an hour apart, so the first report has to come before it — otherwise a
+// daemon restarted more often than that never reports at all.
+func TestStartReportsLoudProducersBeforeTheFirstTick(t *testing.T) {
+	s := newMemStore()
+	said := make(chan string, 8)
+	b := New(Options{
+		Store:        s,
+		Now:          func() time.Time { return statusNow },
+		TrimInterval: time.Hour,
+		Log: func(format string, args ...interface{}) {
+			select {
+			case said <- fmt.Sprintf(format, args...):
+			default:
+			}
+		},
+	})
+	for i := 0; i < 7000; i++ {
+		publishAt(t, s, "session.state.changed", 2, 1, time.Duration(i%360)*time.Minute)
+	}
+
+	if err := b.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer b.Stop()
+
+	select {
+	case line := <-said:
+		if !strings.Contains(line, "session.state.changed") || !strings.Contains(line, "1000/hour") {
+			t.Fatalf("first line does not report the loud producer: %q", line)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Start never reported the loud producer; it waited for the retention tick")
+	}
+}
+
 func TestStatusReportsConsumerLagAndTheRetentionFloor(t *testing.T) {
 	b, s := statusBus(t)
 	publishAt(t, s, "session.state.changed", 4, 100, 3*time.Hour)

--- a/internal/daemon/bus.go
+++ b/internal/daemon/bus.go
@@ -195,6 +195,16 @@ const (
 // CompactableFacts are the fact classes retention may reduce to one row per
 // subject — store-backed invalidations where only the newest carries
 // information. Session and ticket facts are deliberately absent.
+//
+// The three loudest classes in a real log are session.state.changed (74%),
+// pr.updated (17%) and plugin.health.changed. All three are subject-only with a
+// nil payload and project to a store re-read, so on delivery semantics alone
+// they qualify: a consumer that missed four of five is not missing anything the
+// fifth does not carry. They stay out anyway, because compaction would delete
+// the created_at history `attn bus status` computes producer rates from —
+// exactly the evidence that catches a producer flapping. Compaction bounds the
+// log by the data it describes; these classes are the ones whose write rate is
+// itself the signal. Bound them by fixing the producer, not by hiding the rows.
 var CompactableFacts = []string{FactDocumentChanged, FactDocumentCollectionRemoved, FactDocumentCollectionRedeclared}
 
 // projection maps facts to the wire traffic they produce.

--- a/internal/daemon/bus_store.go
+++ b/internal/daemon/bus_store.go
@@ -99,7 +99,27 @@ func (a *sqlBusStore) Compact(names []string, floor int64) (int, error) {
 	return a.store.CompactBusEvents(names, floor)
 }
 
-func (a *sqlBusStore) Size() (int64, int64, error) { return a.store.BusLogSize() }
+func (a *sqlBusStore) Producers(cutoffs []time.Time) ([]bus.ProducerRow, error) {
+	rows, err := a.store.BusProducers(cutoffs)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]bus.ProducerRow, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, bus.ProducerRow{
+			Name:     r.Name,
+			Events:   r.Events,
+			Bytes:    r.Bytes,
+			Subjects: r.Subjects,
+			Recent:   r.Recent,
+		})
+	}
+	return out, nil
+}
+
+func (a *sqlBusStore) EventTimeAt(seq int64) (time.Time, bool, error) {
+	return a.store.BusEventTimeAt(seq)
+}
 
 func busConsumerFromRow(r store.BusConsumer) bus.Consumer {
 	return bus.Consumer{

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -131,7 +131,7 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdAgentSetModel: commandMetadata(ScopeSession, true, true),
 	// Local: a conversation's history is a file in THIS daemon's data dir, so
 	// the answer is never merged from an endpoint.
-	protocol.CmdListPastConversations:                 commandMetadata(ScopeHubLocal, false, false),
+	protocol.CmdListPastConversations: commandMetadata(ScopeHubLocal, false, false),
 	// Local: the bus is this daemon's own spine, and a remote endpoint's log is
 	// its own diagnostic. Merging two would describe neither.
 	protocol.CmdBusStatusGet: commandMetadata(ScopeHubLocal, false, false),

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -132,6 +132,12 @@ var CommandMeta = map[string]CommandMetadata{
 	// Local: a conversation's history is a file in THIS daemon's data dir, so
 	// the answer is never merged from an endpoint.
 	protocol.CmdListPastConversations:                 commandMetadata(ScopeHubLocal, false, false),
+	// Local: the bus is this daemon's own spine, and a remote endpoint's log is
+	// its own diagnostic. Merging two would describe neither.
+	protocol.CmdBusStatusGet: commandMetadata(ScopeHubLocal, false, false),
+	// Logged: flipping a consumer's kill switch is an operator decision worth a
+	// record, and the log is where its effect shows up.
+	protocol.CmdBusSetConsumerEnabled:                 commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdPtyResize:                             commandMetadata(ScopeSession, true, true),
 	protocol.CmdKillSession:                           commandMetadata(ScopeSession, true, true),
 	protocol.CmdReloadSession:                         commandMetadata(ScopeSession, true, true),

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -1303,6 +1303,10 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleAgentSetModel(client, msg.(*protocol.AgentSetModelMessage))
 	case protocol.CmdListPastConversations: // wire: list_past_conversations
 		d.handleListPastConversations(client, msg.(*protocol.ListPastConversationsMessage))
+	case protocol.CmdBusStatusGet: // wire: bus_status_get
+		d.handleBusStatusGet(client, msg.(*protocol.BusStatusGetMessage))
+	case protocol.CmdBusSetConsumerEnabled: // wire: bus_set_consumer_enabled
+		d.handleBusSetConsumerEnabled(client, msg.(*protocol.BusSetConsumerEnabledMessage))
 	case protocol.CmdPtyResize: // wire: pty_resize
 		d.handlePtyResize(client, msg.(*protocol.PtyResizeMessage))
 	case protocol.CmdKillSession: // wire: kill_session

--- a/internal/daemon/ws_bus.go
+++ b/internal/daemon/ws_bus.go
@@ -1,0 +1,161 @@
+package daemon
+
+import (
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/bus"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// The app's window onto the event bus, answering with the same bus.Status that
+// `attn bus status` renders. The daemon adds nothing of its own: one
+// computation, two presentations, so the CLI and the app can never disagree
+// about whether a consumer is behind or a producer is loud.
+//
+// Unlike the CLI's, this snapshot comes from the process that owns the delivery
+// loops, so it can also report which consumers are actually running and what
+// their handlers are failing on.
+
+// handleBusStatusGet answers on the asking client alone: it is one window's
+// diagnostic question, and the answer changes nothing any other window shows.
+//
+// The aggregate walks the whole log (209ms at 945k rows, measured), so it runs
+// on its own goroutine rather than blocking the socket reader.
+func (d *Daemon) handleBusStatusGet(client *wsClient, msg *protocol.BusStatusGetMessage) {
+	requestID := strings.TrimSpace(msg.RequestID)
+	if requestID == "" {
+		d.sendCommandError(client, protocol.CmdBusStatusGet, "bus_status_get is missing a request id")
+		return
+	}
+	go func() {
+		result := protocol.BusStatusResultMessage{
+			Event:     protocol.EventBusStatusResult,
+			RequestID: requestID,
+		}
+		status, err := d.BusStatus()
+		if err != nil {
+			result.Error = protocol.Ptr(err.Error())
+			d.sendToClient(client, result)
+			return
+		}
+		fillBusStatusResult(&result, status)
+		result.Success = true
+		d.sendToClient(client, result)
+	}()
+}
+
+// handleBusSetConsumerEnabled flips the kill switch the CLI writes.
+//
+// It writes the database row directly rather than asking the running bus,
+// because that bit is database-only BY DESIGN — delivery re-reads it every
+// cycle, so the switch works whether or not the daemon is healthy. Going
+// through the daemon here would be a second mechanism for the same bit.
+func (d *Daemon) handleBusSetConsumerEnabled(client *wsClient, msg *protocol.BusSetConsumerEnabledMessage) {
+	requestID := strings.TrimSpace(msg.RequestID)
+	name := strings.TrimSpace(msg.Consumer)
+	result := protocol.BusSetConsumerEnabledResultMessage{
+		Event:     protocol.EventBusSetConsumerEnabledResult,
+		RequestID: requestID,
+		Consumer:  name,
+	}
+	if requestID == "" {
+		d.sendCommandError(client, protocol.CmdBusSetConsumerEnabled, "bus_set_consumer_enabled is missing a request id")
+		return
+	}
+	if name == "" {
+		result.Error = protocol.Ptr("bus_set_consumer_enabled: consumer is required")
+		d.sendToClient(client, result)
+		return
+	}
+	if d.store == nil {
+		result.Error = protocol.Ptr("bus_set_consumer_enabled: no store")
+		d.sendToClient(client, result)
+		return
+	}
+	if _, ok, err := d.store.GetBusConsumer(name); err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		d.sendToClient(client, result)
+		return
+	} else if !ok {
+		result.Error = protocol.Ptr("no consumer named " + name)
+		d.sendToClient(client, result)
+		return
+	}
+	if err := d.store.SetBusConsumerEnabled(name, msg.Enabled, time.Now()); err != nil {
+		result.Error = protocol.Ptr(err.Error())
+		d.sendToClient(client, result)
+		return
+	}
+	verb := "disabled"
+	if msg.Enabled {
+		verb = "enabled"
+	}
+	d.logf("bus: consumer %s %s from the app", name, verb)
+	result.Success = true
+	d.sendToClient(client, result)
+}
+
+// fillBusStatusResult copies the snapshot onto the wire message. Every derived
+// number is already computed; nothing here decides anything.
+func fillBusStatusResult(out *protocol.BusStatusResultMessage, s bus.Status) {
+	out.Earliest = int(s.Earliest)
+	out.Head = int(s.Head)
+	out.Rows = int(s.Rows)
+	out.Bytes = int(s.Bytes)
+	out.OldestAt = formatBusStamp(s.OldestAt)
+	out.NewestAt = formatBusStamp(s.NewestAt)
+	out.Delivering = s.Delivering
+	out.RetentionSeconds = s.RetentionWindow.Seconds()
+	out.RecentWindowSeconds = bus.RecentWindow.Seconds()
+	out.BaselineWindowSeconds = bus.BaselineWindow.Seconds()
+	out.SurgeRatePerHour = bus.SurgeRatePerHour
+
+	out.Producers = make([]protocol.BusProducerStatus, 0, len(s.Producers))
+	for _, p := range s.Producers {
+		out.Producers = append(out.Producers, protocol.BusProducerStatus{
+			Name:               p.Name,
+			Events:             int(p.Events),
+			Bytes:              int(p.Bytes),
+			Subjects:           int(p.Subjects),
+			Share:              p.Share,
+			RecentPerHour:      p.RecentPerHour,
+			BaselinePerHour:    p.BaselinePerHour,
+			SustainedPerHour:   p.SustainedPerHour,
+			Surging:            p.Surging,
+			SurgeWindowSeconds: p.SurgeWindow.Seconds(),
+			SurgePerHour:       p.SurgePerHour,
+		})
+	}
+	out.Consumers = make([]protocol.BusConsumerStatus, 0, len(s.Consumers))
+	for _, c := range s.Consumers {
+		out.Consumers = append(out.Consumers, protocol.BusConsumerStatus{
+			Name:                c.Name,
+			Cursor:              int(c.Cursor),
+			Lag:                 int(c.Lag),
+			Filter:              c.Filter,
+			Enabled:             c.Enabled,
+			UpdatedAt:           formatBusStamp(c.UpdatedAt),
+			Live:                c.Live,
+			Stalled:             c.Stalled,
+			OldestUnreadAt:      formatBusStamp(c.OldestUnreadAt),
+			HoldsRetentionFloor: c.HoldsRetentionFloor,
+		})
+	}
+	out.Health = make([]protocol.BusHealthEntry, 0, len(s.Health))
+	for _, h := range s.Health {
+		out.Health = append(out.Health, protocol.BusHealthEntry{
+			Level:   h.Level,
+			Kind:    h.Kind,
+			Subject: h.Subject,
+			Message: h.Message,
+		})
+	}
+}
+
+func formatBusStamp(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}

--- a/internal/daemon/ws_bus_test.go
+++ b/internal/daemon/ws_bus_test.go
@@ -1,0 +1,151 @@
+package daemon
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// The two bus handlers are the glue the app talks to, and their refusal branches
+// are the ones a user meets when something is already wrong. A refusal that says
+// nothing is worse than no command at all, so each is checked for the sentence
+// it sends back — not just for "success is false".
+
+func busTestClient() *wsClient {
+	return &wsClient{send: make(chan outboundMessage, 4)}
+}
+
+func nextBusMessage(t *testing.T, client *wsClient, into any) {
+	t.Helper()
+	select {
+	case outbound := <-client.send:
+		if err := json.Unmarshal(outbound.payload, into); err != nil {
+			t.Fatalf("decode outbound: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the handler answered nothing")
+	}
+}
+
+func TestBusStatusGetAnswersTheAskingClient(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "daemon.sock"))
+	d.ensureEventBus()
+	if _, err := d.eventBus.Publish(FactSessionStateChanged, "sess-1", nil); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	client := busTestClient()
+
+	d.handleBusStatusGet(client, &protocol.BusStatusGetMessage{RequestID: "r1"})
+
+	var result protocol.BusStatusResultMessage
+	nextBusMessage(t, client, &result)
+	if !result.Success {
+		t.Fatalf("bus_status_result success=false error=%q", protocol.Deref(result.Error))
+	}
+	if result.RequestID != "r1" {
+		t.Errorf("request_id = %q, want r1", result.RequestID)
+	}
+	if result.Rows != 1 || len(result.Producers) != 1 {
+		t.Fatalf("rows=%d producers=%d, want the one published fact", result.Rows, len(result.Producers))
+	}
+	if result.Producers[0].Name != FactSessionStateChanged {
+		t.Errorf("producer = %q, want %q", result.Producers[0].Name, FactSessionStateChanged)
+	}
+	// Windows travel with the numbers: a rate is meaningless without the span it
+	// was measured over, and no surface should hardcode its own.
+	if result.RecentWindowSeconds <= 0 || result.BaselineWindowSeconds <= 0 || result.SurgeRatePerHour <= 0 {
+		t.Errorf("result does not carry the windows and the tripwire: %+v", result)
+	}
+}
+
+// A request id is how the app pairs an answer with the promise waiting for it.
+// Without one there is nothing to settle, so this fails loudly rather than
+// sending a result nobody can match.
+func TestBusStatusGetWithoutARequestIDIsACommandError(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "daemon.sock"))
+	client := busTestClient()
+
+	d.handleBusStatusGet(client, &protocol.BusStatusGetMessage{RequestID: "  "})
+
+	var msg protocol.CommandErrorMessage
+	nextBusMessage(t, client, &msg)
+	if protocol.Deref(msg.Cmd) != protocol.CmdBusStatusGet {
+		t.Fatalf("cmd = %q, want %q", protocol.Deref(msg.Cmd), protocol.CmdBusStatusGet)
+	}
+	if msg.Error == "" {
+		t.Error("the refusal must say what was wrong")
+	}
+}
+
+func TestBusSetConsumerEnabledFlipsTheDatabaseBit(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "daemon.sock"))
+	consumer := store.BusConsumer{Name: "notifier", Cursor: 7, Filter: "session.*", Enabled: true}
+	if err := d.store.SaveBusConsumer(consumer, time.Now()); err != nil {
+		t.Fatalf("SaveBusConsumer: %v", err)
+	}
+	client := busTestClient()
+
+	d.handleBusSetConsumerEnabled(client, &protocol.BusSetConsumerEnabledMessage{
+		RequestID: "r1", Consumer: "notifier", Enabled: false,
+	})
+
+	var result protocol.BusSetConsumerEnabledResultMessage
+	nextBusMessage(t, client, &result)
+	if !result.Success {
+		t.Fatalf("success=false error=%q", protocol.Deref(result.Error))
+	}
+	stored, ok, err := d.store.GetBusConsumer("notifier")
+	if err != nil || !ok {
+		t.Fatalf("GetBusConsumer: %v, ok=%v", err, ok)
+	}
+	if stored.Enabled {
+		t.Error("the row is still enabled; the kill switch must be the database bit itself")
+	}
+	// The cursor is kept: disabling stops delivery, it does not forget position.
+	if stored.Cursor != 7 {
+		t.Errorf("cursor = %d, want 7", stored.Cursor)
+	}
+}
+
+func TestBusSetConsumerEnabledRefusesAnUnknownConsumerByName(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "daemon.sock"))
+	client := busTestClient()
+
+	d.handleBusSetConsumerEnabled(client, &protocol.BusSetConsumerEnabledMessage{
+		RequestID: "r1", Consumer: "nope", Enabled: true,
+	})
+
+	var result protocol.BusSetConsumerEnabledResultMessage
+	nextBusMessage(t, client, &result)
+	if result.Success {
+		t.Fatal("a consumer that does not exist must not report success")
+	}
+	if got := protocol.Deref(result.Error); got != "no consumer named nope" {
+		t.Errorf("error = %q, want it to name the consumer that was asked for", got)
+	}
+	if result.Consumer != "nope" {
+		t.Errorf("consumer = %q, want the asked-for name echoed back", result.Consumer)
+	}
+}
+
+func TestBusSetConsumerEnabledRefusesAnEmptyConsumer(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "daemon.sock"))
+	client := busTestClient()
+
+	d.handleBusSetConsumerEnabled(client, &protocol.BusSetConsumerEnabledMessage{
+		RequestID: "r1", Consumer: "   ", Enabled: true,
+	})
+
+	var result protocol.BusSetConsumerEnabledResultMessage
+	nextBusMessage(t, client, &result)
+	if result.Success {
+		t.Fatal("an empty consumer name must not report success")
+	}
+	if protocol.Deref(result.Error) == "" {
+		t.Error("the refusal must say what was wrong")
+	}
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -251,6 +251,8 @@ const (
 	CmdAgentHistory                          = "agent_history"
 	CmdAgentSetModel                         = "agent_set_model"
 	CmdListPastConversations                 = "list_past_conversations"
+	CmdBusStatusGet                          = "bus_status_get"
+	CmdBusSetConsumerEnabled                 = "bus_set_consumer_enabled"
 	CmdPtyResize                             = "pty_resize"
 	CmdKillSession                           = "kill_session"
 	CmdReloadSession                         = "reload_session"
@@ -420,6 +422,8 @@ const (
 	EventOpenMarkdownResult              = "open_markdown_result"
 	EventSessionMessagesGetResult        = "session_messages_get_result"
 	EventPastConversationsResult         = "past_conversations_result"
+	EventBusStatusResult                 = "bus_status_result"
+	EventBusSetConsumerEnabledResult     = "bus_set_consumer_enabled_result"
 	EventSessionAnnotationsGetResult     = "session_annotations_get_result"
 	EventSessionAnnotationsSaveResult    = "session_annotations_save_result"
 	EventSessionAnnotationsClearResult   = "session_annotations_clear_result"
@@ -1623,6 +1627,20 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 		var msg ListPastConversationsMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, fmt.Errorf("unmarshal list_past_conversations: %w", err)
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdBusStatusGet:
+		var msg BusStatusGetMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, fmt.Errorf("unmarshal bus_status_get: %w", err)
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdBusSetConsumerEnabled:
+		var msg BusSetConsumerEnabledMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, fmt.Errorf("unmarshal bus_set_consumer_enabled: %w", err)
 		}
 		return peek.Cmd, &msg, nil
 

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "223"
+const ProtocolVersion = "224"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -801,6 +801,185 @@ type BrowserControlResultMessage struct {
 	Success bool `json:"success"`
 }
 
+type BusConsumerStatus struct {
+	// Cursor corresponds to the JSON schema field "cursor".
+	Cursor int `json:"cursor"`
+
+	// Enabled corresponds to the JSON schema field "enabled".
+	Enabled bool `json:"enabled"`
+
+	// Filter corresponds to the JSON schema field "filter".
+	Filter string `json:"filter"`
+
+	// HoldsRetentionFloor corresponds to the JSON schema field
+	// "holds_retention_floor".
+	HoldsRetentionFloor bool `json:"holds_retention_floor"`
+
+	// Lag corresponds to the JSON schema field "lag".
+	Lag int `json:"lag"`
+
+	// Live corresponds to the JSON schema field "live".
+	Live bool `json:"live"`
+
+	// Name corresponds to the JSON schema field "name".
+	Name string `json:"name"`
+
+	// OldestUnreadAt corresponds to the JSON schema field "oldest_unread_at".
+	OldestUnreadAt string `json:"oldest_unread_at"`
+
+	// Stalled corresponds to the JSON schema field "stalled".
+	Stalled string `json:"stalled"`
+
+	// UpdatedAt corresponds to the JSON schema field "updated_at".
+	UpdatedAt string `json:"updated_at"`
+}
+
+type BusHealthEntry struct {
+	// Kind corresponds to the JSON schema field "kind".
+	Kind string `json:"kind"`
+
+	// Level corresponds to the JSON schema field "level".
+	Level string `json:"level"`
+
+	// Message corresponds to the JSON schema field "message".
+	Message string `json:"message"`
+
+	// Subject corresponds to the JSON schema field "subject".
+	Subject string `json:"subject"`
+}
+
+type BusProducerStatus struct {
+	// BaselinePerHour corresponds to the JSON schema field "baseline_per_hour".
+	BaselinePerHour float64 `json:"baseline_per_hour"`
+
+	// Bytes corresponds to the JSON schema field "bytes".
+	Bytes int `json:"bytes"`
+
+	// Events corresponds to the JSON schema field "events".
+	Events int `json:"events"`
+
+	// Name corresponds to the JSON schema field "name".
+	Name string `json:"name"`
+
+	// RecentPerHour corresponds to the JSON schema field "recent_per_hour".
+	RecentPerHour float64 `json:"recent_per_hour"`
+
+	// Share corresponds to the JSON schema field "share".
+	Share float64 `json:"share"`
+
+	// Subjects corresponds to the JSON schema field "subjects".
+	Subjects int `json:"subjects"`
+
+	// SurgePerHour corresponds to the JSON schema field "surge_per_hour".
+	SurgePerHour float64 `json:"surge_per_hour"`
+
+	// SurgeWindowSeconds corresponds to the JSON schema field "surge_window_seconds".
+	SurgeWindowSeconds float64 `json:"surge_window_seconds"`
+
+	// Surging corresponds to the JSON schema field "surging".
+	Surging bool `json:"surging"`
+
+	// SustainedPerHour corresponds to the JSON schema field "sustained_per_hour".
+	SustainedPerHour float64 `json:"sustained_per_hour"`
+}
+
+type BusSetConsumerEnabledMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Consumer corresponds to the JSON schema field "consumer".
+	Consumer string `json:"consumer"`
+
+	// Enabled corresponds to the JSON schema field "enabled".
+	Enabled bool `json:"enabled"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+}
+
+type BusSetConsumerEnabledResultMessage struct {
+	// Consumer corresponds to the JSON schema field "consumer".
+	Consumer string `json:"consumer"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
+type BusStatusGetMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+}
+
+type BusStatusResultMessage struct {
+	// BaselineWindowSeconds corresponds to the JSON schema field
+	// "baseline_window_seconds".
+	BaselineWindowSeconds float64 `json:"baseline_window_seconds"`
+
+	// Bytes corresponds to the JSON schema field "bytes".
+	Bytes int `json:"bytes"`
+
+	// Consumers corresponds to the JSON schema field "consumers".
+	Consumers []BusConsumerStatus `json:"consumers"`
+
+	// Delivering corresponds to the JSON schema field "delivering".
+	Delivering bool `json:"delivering"`
+
+	// Earliest corresponds to the JSON schema field "earliest".
+	Earliest int `json:"earliest"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// Head corresponds to the JSON schema field "head".
+	Head int `json:"head"`
+
+	// Health corresponds to the JSON schema field "health".
+	Health []BusHealthEntry `json:"health"`
+
+	// NewestAt corresponds to the JSON schema field "newest_at".
+	NewestAt string `json:"newest_at"`
+
+	// OldestAt corresponds to the JSON schema field "oldest_at".
+	OldestAt string `json:"oldest_at"`
+
+	// Producers corresponds to the JSON schema field "producers".
+	Producers []BusProducerStatus `json:"producers"`
+
+	// RecentWindowSeconds corresponds to the JSON schema field
+	// "recent_window_seconds".
+	RecentWindowSeconds float64 `json:"recent_window_seconds"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// RetentionSeconds corresponds to the JSON schema field "retention_seconds".
+	RetentionSeconds float64 `json:"retention_seconds"`
+
+	// Rows corresponds to the JSON schema field "rows".
+	Rows int `json:"rows"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+
+	// SurgeRatePerHour corresponds to the JSON schema field "surge_rate_per_hour".
+	SurgeRatePerHour float64 `json:"surge_rate_per_hour"`
+}
+
 type CancelCountdownMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -2076,6 +2076,119 @@ model PastConversationsResultMessage {
   truncated: boolean;
 }
 
+// Asks for the durable event bus's operator picture: what the log holds, which
+// fact classes write to it and how fast, which consumers read it and how far
+// behind they are, and what is wrong with any of it.
+//
+// Answering costs one aggregate pass over the whole log, so this is asked on
+// demand — when the page is opened and on a slow refresh while it is — never on
+// a tick that runs whether or not anyone is looking.
+model BusStatusGetMessage {
+  cmd: "bus_status_get";
+  request_id: string;
+}
+
+// One fact class's contribution to the log. The rates are means over the
+// windows named in the result, already divided out.
+model BusProducerStatus {
+  // The dotted fact name, e.g. `session.state.changed`.
+  name: string;
+  events: safeint;
+  // Event text these rows hold, not database pages.
+  bytes: safeint;
+  // Distinct subjects these events describe. Far fewer subjects than events
+  // means a producer republishing the same entity rather than describing change.
+  subjects: safeint;
+  // Fraction of the log's rows, 0..1.
+  share: float64;
+  recent_per_hour: float64;
+  baseline_per_hour: float64;
+  sustained_per_hour: float64;
+  // The rate crossed the tripwire on one of the sustained windows.
+  surging: boolean;
+  // Which window tripped, and its rate. Zero when not surging.
+  surge_window_seconds: float64;
+  surge_per_hour: float64;
+}
+
+// One durable consumer's registration, position, and lag.
+model BusConsumerStatus {
+  name: string;
+  cursor: safeint;
+  // Events between this cursor and the log head.
+  lag: safeint;
+  filter: string;
+  enabled: boolean;
+  // RFC3339; empty when the registration never recorded a write.
+  updated_at: string;
+  // This daemon owns a delivery loop for it. Meaningful only when the result's
+  // `delivering` is set.
+  live: boolean;
+  // The current failure message when its handler is failing.
+  stalled: string;
+  // RFC3339 stamp of the oldest event it has not read; empty when caught up.
+  // Lag counts events, this says how long they have waited.
+  oldest_unread_at: string;
+  // Its cursor is the floor retention stops at — it is pinning the log.
+  holds_retention_floor: boolean;
+}
+
+// One thing wrong, said in a whole sentence. A client renders `message`; it does
+// not re-derive the finding from the numbers. `kind` is for styling and
+// filtering only.
+model BusHealthEntry {
+  // "warn" or "error".
+  level: string;
+  kind: string;
+  // The consumer or fact name the finding is about.
+  subject: string;
+  message: string;
+}
+
+// Result of bus_status_get.
+model BusStatusResultMessage {
+  event: "bus_status_result";
+  request_id: string;
+  success: boolean;
+  error?: string;
+  earliest: safeint;
+  head: safeint;
+  rows: safeint;
+  bytes: safeint;
+  // RFC3339 bounds of the log in time; empty on an empty log.
+  oldest_at: string;
+  newest_at: string;
+  // The snapshot came from the process that owns the delivery loops, which is
+  // what makes each consumer's `live` field mean anything.
+  delivering: boolean;
+  retention_seconds: float64;
+  recent_window_seconds: float64;
+  baseline_window_seconds: float64;
+  surge_rate_per_hour: float64;
+  producers: BusProducerStatus[];
+  consumers: BusConsumerStatus[];
+  health: BusHealthEntry[];
+}
+
+// Flips a durable consumer's kill switch, the same bit `attn bus enable|disable`
+// writes. Disabling stops delivery and stops the consumer pinning retention; its
+// cursor is preserved, and re-enabling resumes from wherever trimming left it.
+model BusSetConsumerEnabledMessage {
+  cmd: "bus_set_consumer_enabled";
+  consumer: string;
+  enabled: boolean;
+  request_id: string;
+}
+
+// Result of bus_set_consumer_enabled.
+model BusSetConsumerEnabledResultMessage {
+  event: "bus_set_consumer_enabled_result";
+  request_id: string;
+  consumer: string;
+  success: boolean;
+  error?: string;
+}
+
 // xpixel/ypixel are the pane's TOTAL size in device pixels, the units
 // TIOCGWINSZ's ws_xpixel/ws_ypixel and XTWINOPS speak, so image emitters can
 // size an image to the space they were given. Absent or 0 means the client has
@@ -4804,4 +4917,6 @@ alias DaemonEvent =
   | MarkdownAnnotationsSaveResultMessage
   | MarkdownAnnotationsClearResultMessage
   | MarkdownAnnotationsSubmitResultMessage
-  | PastConversationsResultMessage;
+  | PastConversationsResultMessage
+  | BusStatusResultMessage
+  | BusSetConsumerEnabledResultMessage;

--- a/internal/store/bus.go
+++ b/internal/store/bus.go
@@ -287,6 +287,97 @@ func (s *Store) CompactBusEvents(names []string, floor int64) (int, error) {
 	return int(n), err
 }
 
+// BusProducer is one fact class's contribution to the log: how many events it
+// holds, what they weigh, how many distinct entities they describe, and how many
+// landed inside each cutoff BusProducers was asked about.
+type BusProducer struct {
+	Name     string
+	Events   int64
+	Bytes    int64
+	Subjects int64
+	// Recent is aligned with the cutoffs passed to BusProducers, one count per
+	// cutoff, each counting events at or after it.
+	Recent []int64
+}
+
+// BusProducers reports every fact class on the log with its totals and its
+// counts inside each cutoff, loudest first. Which windows are worth asking about
+// is internal/bus's call, so this takes the cutoffs rather than naming them.
+//
+// One pass over bus_events answers all of it, including the row count and bytes
+// BusLogSize would scan for separately — the aggregate subsumes it rather than
+// paying for the table twice. Measured on a copy of production: 209ms at 945k
+// rows (~0.22us/row), against 106ms for BusLogSize alone. That is an on-demand
+// cost, which is why nothing polls it on a timer.
+func (s *Store) BusProducers(cutoffs []time.Time) ([]BusProducer, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+	var (
+		columns strings.Builder
+		args    []any
+	)
+	for _, c := range cutoffs {
+		columns.WriteString(", COALESCE(SUM(created_at >= ?), 0)")
+		args = append(args, formatTicketTime(c))
+	}
+	rows, err := s.db.Query(`
+		SELECT name,
+		       COUNT(*),
+		       COALESCE(SUM(LENGTH(name) + LENGTH(subject) + LENGTH(payload) + LENGTH(source) + LENGTH(created_at)), 0),
+		       COUNT(DISTINCT subject)`+columns.String()+`
+		FROM bus_events
+		GROUP BY name
+		ORDER BY COUNT(*) DESC, name ASC
+	`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []BusProducer
+	for rows.Next() {
+		p := BusProducer{Recent: make([]int64, len(cutoffs))}
+		dest := []any{&p.Name, &p.Events, &p.Bytes, &p.Subjects}
+		for i := range p.Recent {
+			dest = append(dest, &p.Recent[i])
+		}
+		if err := rows.Scan(dest...); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// BusEventTimeAt returns the timestamp of the first event at or above seq, and
+// whether one exists. Both callers ask an age question — how old the log's tail
+// is, and how long a consumer's oldest unread event has been waiting — and both
+// resolve through the seq primary key, so neither scans.
+func (s *Store) BusEventTimeAt(seq int64) (time.Time, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return time.Time{}, false, nil
+	}
+	var createdAt string
+	err := s.db.QueryRow(`
+		SELECT created_at FROM bus_events WHERE seq >= ? ORDER BY seq ASC LIMIT 1
+	`, seq).Scan(&createdAt)
+	switch err {
+	case nil:
+		return parseTicketTime(createdAt), true, nil
+	case sql.ErrNoRows:
+		return time.Time{}, false, nil
+	default:
+		return time.Time{}, false, err
+	}
+}
+
 // BusLogSize reports the log's row count and event-text bytes. Bytes measures
 // the rows themselves, not the database file — SQLite pages are shared.
 func (s *Store) BusLogSize() (rows int64, bytes int64, err error) {

--- a/internal/store/bus_producers_test.go
+++ b/internal/store/bus_producers_test.go
@@ -1,0 +1,187 @@
+package store
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// The producer aggregate is the surface that would have caught a producer
+// writing most of the log. These tests seed a log shaped like the real one —
+// one class dominating, a long tail behind it — because the counts, the share,
+// and the window boundaries are all things a wrong query gets subtly wrong on
+// realistic data and exactly right on three rows.
+
+// seedBusLog writes a log in the shape production had: one loud class
+// republishing a handful of subjects, a moderate one, and a quiet tail.
+func seedBusLog(t *testing.T, s *Store, now time.Time) {
+	t.Helper()
+	// Loud: 40 inside the last hour, 60 more inside the last 24, 100 older.
+	for i := 0; i < 40; i++ {
+		appendBus(t, s, "session.state.changed", fmt.Sprintf("sess_%d", i%4), now.Add(-30*time.Minute))
+	}
+	for i := 0; i < 60; i++ {
+		appendBus(t, s, "session.state.changed", fmt.Sprintf("sess_%d", i%4), now.Add(-6*time.Hour))
+	}
+	for i := 0; i < 100; i++ {
+		appendBus(t, s, "session.state.changed", fmt.Sprintf("sess_%d", i%4), now.Add(-72*time.Hour))
+	}
+	// Moderate: 10 in the last 24, nothing in the last hour.
+	for i := 0; i < 10; i++ {
+		appendBus(t, s, "pr.updated", fmt.Sprintf("pr_%d", i), now.Add(-3*time.Hour))
+	}
+	// Quiet tail.
+	appendBus(t, s, "ticket.created", "tk_1", now.Add(-2*time.Hour))
+}
+
+func producerByName(t *testing.T, rows []BusProducer, name string) BusProducer {
+	t.Helper()
+	for _, r := range rows {
+		if r.Name == name {
+			return r
+		}
+	}
+	t.Fatalf("no producer %q in %d row(s)", name, len(rows))
+	return BusProducer{}
+}
+
+func TestBusProducersCountsEachWindowAndRanksLoudestFirst(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+	now := busBase.Add(96 * time.Hour)
+	seedBusLog(t, s, now)
+
+	rows, err := s.BusProducers([]time.Time{
+		now.Add(-time.Hour),
+		now.Add(-6 * time.Hour),
+		now.Add(-24 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("BusProducers: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("want 3 fact classes, got %d: %+v", len(rows), rows)
+	}
+	// Loudest first is what makes the table answer "who is writing all this?"
+	// without the reader sorting it themselves.
+	if rows[0].Name != "session.state.changed" {
+		t.Fatalf("want the loudest class first, got %q", rows[0].Name)
+	}
+
+	loud := producerByName(t, rows, "session.state.changed")
+	if loud.Events != 200 {
+		t.Errorf("events = %d, want 200", loud.Events)
+	}
+	// Four subjects across 200 events is the shape that says "republishing",
+	// and it is the column that separates a busy producer from a flapping one.
+	if loud.Subjects != 4 {
+		t.Errorf("subjects = %d, want 4", loud.Subjects)
+	}
+	if got := loud.Recent; got[0] != 40 || got[1] != 100 || got[2] != 100 {
+		t.Errorf("window counts = %v, want [40 100 100]", got)
+	}
+	if loud.Bytes <= 0 {
+		t.Errorf("bytes = %d, want the event text to be measured", loud.Bytes)
+	}
+
+	moderate := producerByName(t, rows, "pr.updated")
+	if got := moderate.Recent; got[0] != 0 || got[1] != 10 || got[2] != 10 {
+		t.Errorf("pr.updated window counts = %v, want [0 10 10]", got)
+	}
+}
+
+// The aggregate replaced a separate BusLogSize scan, so it has to agree with it
+// exactly — otherwise the page and the log's own weight would tell two stories.
+func TestBusProducersTotalsMatchBusLogSize(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+	now := busBase.Add(96 * time.Hour)
+	seedBusLog(t, s, now)
+
+	rows, err := s.BusProducers([]time.Time{now.Add(-time.Hour)})
+	if err != nil {
+		t.Fatalf("BusProducers: %v", err)
+	}
+	var events, bytes int64
+	for _, r := range rows {
+		events += r.Events
+		bytes += r.Bytes
+	}
+	wantRows, wantBytes, err := s.BusLogSize()
+	if err != nil {
+		t.Fatalf("BusLogSize: %v", err)
+	}
+	if events != wantRows {
+		t.Errorf("summed events = %d, BusLogSize rows = %d", events, wantRows)
+	}
+	if bytes != wantBytes {
+		t.Errorf("summed bytes = %d, BusLogSize bytes = %d", bytes, wantBytes)
+	}
+}
+
+// An empty log must answer "nothing", not fail. It is the state a fresh
+// install is in, and the page opens on it.
+func TestBusProducersOnAnEmptyLog(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	rows, err := s.BusProducers([]time.Time{time.Now().Add(-time.Hour)})
+	if err != nil {
+		t.Fatalf("BusProducers: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("want no rows on an empty log, got %+v", rows)
+	}
+}
+
+// Asking for no windows still has to answer the totals: the cutoff list is
+// built from policy that could legitimately shrink to nothing.
+func TestBusProducersWithoutCutoffs(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+	now := busBase.Add(96 * time.Hour)
+	seedBusLog(t, s, now)
+
+	rows, err := s.BusProducers(nil)
+	if err != nil {
+		t.Fatalf("BusProducers: %v", err)
+	}
+	loud := producerByName(t, rows, "session.state.changed")
+	if loud.Events != 200 || len(loud.Recent) != 0 {
+		t.Fatalf("events = %d, recent = %v; want 200 and no window counts", loud.Events, loud.Recent)
+	}
+}
+
+// EventTimeAt answers both age questions: how old the log's tail is, and how
+// long a consumer's oldest unread event has waited. A cursor past the head has
+// no such event, and saying so is different from saying "the epoch".
+func TestBusEventTimeAt(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	first := appendBus(t, s, "session.state.changed", "sess_1", busBase)
+	appendBus(t, s, "pr.updated", "pr_1", busBase.Add(2*time.Hour))
+	last := appendBus(t, s, "ticket.created", "tk_1", busBase.Add(5*time.Hour))
+
+	at, ok, err := s.BusEventTimeAt(first)
+	if err != nil || !ok {
+		t.Fatalf("BusEventTimeAt(%d) = %v, %v, %v", first, at, ok, err)
+	}
+	if !at.Equal(busBase) {
+		t.Errorf("oldest = %s, want %s", at, busBase)
+	}
+
+	// The first event at or ABOVE the seq, so a cursor sitting on a trimmed
+	// row still reports the oldest thing that consumer has left to read.
+	at, ok, err = s.BusEventTimeAt(first + 1)
+	if err != nil || !ok {
+		t.Fatalf("BusEventTimeAt(%d) = %v, %v, %v", first+1, at, ok, err)
+	}
+	if !at.Equal(busBase.Add(2 * time.Hour)) {
+		t.Errorf("next = %s, want %s", at, busBase.Add(2*time.Hour))
+	}
+
+	if _, ok, err := s.BusEventTimeAt(last + 1); err != nil || ok {
+		t.Errorf("past the head: ok = %v, err = %v; want false, nil", ok, err)
+	}
+}


### PR DESCRIPTION
A producer bug wrote 66% of the durable bus log for a week and was found by
accident, during unrelated sizing work. Nothing in attn showed what the bus was
doing — not the log's weight, not who was writing to it, not how far behind
anything reading it was. This adds that picture to both surfaces, and a tripwire
so the next loud producer announces itself instead of waiting to be noticed.

## One computation, two presentations

`bus.Status` (`internal/bus/status.go`) is the whole snapshot: log bounds and
weight, per-fact-class counts/bytes/subjects/rates/share, per-consumer
cursor/lag/oldest-unread/enabled/live/retention-floor, and a `Health` list of
findings written as finished sentences. `attn bus status` runs it against the
database; the daemon serves the same struct to the app over
`bus_status_get`/`bus_status_result`. Neither surface derives anything of its
own, so they cannot disagree about whether a consumer is behind or a producer is
loud.

`attn bus status` keeps every field it had and gains the rest; `--json` carries
everything, including the classes the human view collapses.

The app page (Settings › Event Bus) also enables and disables a consumer. That
bit stays **database-only by design** — delivery re-reads it every cycle, so the
kill switch works whether or not the daemon is healthy — so the handler writes
the row directly rather than routing through the running bus, which would be a
second mechanism for the same bit.

## The tripwire is an absolute ceiling, and here is why

The brief asked for "far above its own recorded baseline". I measured that
against 8 days of the real log and it does not work:

- An hour compared against the mean of its preceding 24 reaches **35x on healthy
  classes** — an idle night drags the baseline to near zero — and would have
  fired ~48 times over those 8 days.
- Day-over-day still swings **4–6x** on the loud classes.

Any relative threshold that catches a real flap also cries wolf. Sustained rate
separates cleanly, because hours of smoothing absorb the burstiness that defeats
the comparison. Same 8 days, healthy maximum is the loudest *healthy* class
(`pr.updated`):

| window | healthy max | flapping class | headroom at 1000/h |
|---|---|---|---|
| 6h | 480/h | 5763/h peak | 2.08x |
| 24h | 357/h | 1075–2265/h | 2.80x |

`SurgeRatePerHour = 1000` is checked on **both** windows, because they catch
different things: 6h catches a flap starting, within hours; 24h catches one that
is simply always loud — the state this bus was already in, where an evening lull
drops the 6h rate below the line while the producer still owns two thirds of the
log. Checking only 6h was the first implementation, and against real data the
worst producer in the log showed no warning at all.

The headroom is thinner than a tripwire usually gets on purpose: a false positive
is one WARN line in the daemon log; a false negative is what already happened.

The log line names the number, the ceiling, and the window, so it is actionable
without reading this code:

```
bus: producer session.state.changed is publishing 1890 events/hour sustained over
the last 24h, past the 1000/hour tripwire; it holds 234,494 events (74% of the
log) across 104 subject(s)
```

It runs once per retention pass **and once at startup** — the tick is an hour
apart, so a daemon restarted more often than that would otherwise never report a
producer that is already past the ceiling.

## Compaction coverage: verdict per class

Checked `session.state.changed`, `pr.updated`, `plugin.health.changed` against
`CompactableFacts`. None of the three are in it, and none are being added.

All three are subject-only with a nil payload and project to a store re-read, so
on **delivery semantics** alone they qualify: newest-per-subject genuinely wins,
and a consumer that missed four of five is not missing anything the fifth does
not carry. (`bus.Register` has no production callers today, so there is no
durable consumer whose replay could disagree — but the semantics hold
regardless.)

They stay out because compaction would delete the `created_at` history the
producer rates are computed from — blinding the exact surface built to catch the
flap. Compaction bounds the log by the data it describes; these are the classes
whose write *rate* is itself the signal. Bound them by fixing the producer (#830),
not by hiding the rows. Recorded beside `CompactableFacts` so the next reader
does not have to re-derive it.

## Cost

One aggregate answers all of it, subsuming the pre-existing `BusLogSize` scan:

- **209ms at 945k rows** (~0.22us/row), against 106ms for `BusLogSize` alone —
  net new cost ~103ms. Measured on a copy of production, not a fixture.
- **103–105ms end to end over the WebSocket** at 318k rows, the real log size.
- No new index, no migration.

That is an on-demand cost, which is why nothing polls it. The daemon runs the
scan on its own goroutine and answers only the asking client. The page reads on
open and every 30s while its section is mounted — closing Settings or navigating
away stops it. No animation, no per-second refresh.

## Live verification

Throwaway profile `busobs` installed from this branch, seeded with a copy of the
production log (318k events, 8 days, 50 fact classes) plus two consumers: one
enabled and stuck 41k events back, one disabled. Preflight PASS, protocol 224
across CLI/app/daemon. Profile cleaned afterwards.

`attn bus status`:

```
log: seq 24..318354, 318331 event(s) holding 22.9 MB; oldest 8d old, retention 30d

producers (rates per hour over the last 1h and 24h):
FACT                      EVENTS  SHARE  SUBJECTS  BYTES     1H/H  24H/H
session.state.changed !   234494  73.7%  104       17.2 MB   2755  1892
pr.updated                53490   16.8%  108       3.4 MB    362   338
plugin.health.changed     15080   4.7%   1         706.9 KB  194   207
pr.details.changed        8921    2.8%   110       656.4 KB  125   59
task.changed              1824    0.6%   81        125.5 KB  207   46
workspace.status.changed  1136    0.4%   41        97.8 KB   13    5
session.pty.resized       1065    0.3%   97        120.0 KB  32    8
workspace.layout.changed  337     0.1%   40        365.5 KB  9     3
session.activity.changed  194     0.1%   20        15.2 KB   41    8
ratelimit.hit             161     0.1%   2         12.4 KB   1     1
ticket.status_changed     138     0.0%   36        7.4 KB    8     2
pr.disappeared            101     0.0%   101       6.4 KB    1     1
session.branch.changed    101     0.0%   29        7.7 KB    2     1
pr.appeared               99      0.0%   99        6.0 KB    1     1
session.unregistered      91      0.0%   91        51.7 KB   1     1
... and 35 quieter class(es) holding 1099 event(s), 0.3% of the log (--json lists every one)

CONSUMER                    CURSOR  LAG     OLDEST UNREAD  ENABLED  FILTER
notifier (retention floor)  277213  41141   21h            true     session.state.changed,pr.updated
ticket-archiver             120     318234  8d             false

ERROR: consumer notifier is 41,141 events behind and not advancing; its cursor has not moved for 2h, and its oldest unread event has waited 21h15m
WARN: consumer ticket-archiver is disabled: it is not being delivered to, and it does not hold retention open — once trimming passes its cursor at seq 120, enabling it resumes at head with a logged gap
WARN: producer session.state.changed is publishing 1892 events/hour sustained over the last 24h, past the 1000/hour tripwire; it holds 234,494 events (74% of the log) across 104 subject(s)

(read from the database, not from the daemon: whether a consumer's
delivery loop is actually running is not visible from here.)
```

The settings page, captured from the same state, shows the identical three
findings at the top (ERROR for the lagging consumer, WARNING for the disabled
one, WARNING for the loud producer), the same summary numbers, `LOUD` on
`session.state.changed`, the quiet tail collapsed behind "Show 45 quieter
classes — 4,522 events, 1.4% of the log", and both consumers with their pills —
`RETENTION FLOOR` + Disable on `notifier`, `DISABLED` + Enable on
`ticket-archiver`. Screenshot went to the maintainer directly (this repo's PRs
carry text receipts).

Also driven over the daemon socket, the path the app uses:

- `bus_status_get` → 103ms, 50 producers, 2 consumers, 3 health findings.
- `bus_set_consumer_enabled` disabling `notifier` → the retention floor moves off
  it in the next snapshot, exactly the trim semantics.
- an unknown consumer is refused by name: `no consumer named nope`.
- `bus: consumer notifier disabled from the app` in `daemon.log`.
- the tripwire line above appeared 4 seconds after `daemon ensure`, from the
  startup report.

An empty consumer table is not a blank table: with no durable consumers
registered — the state production is actually in — the page says so and explains
that every subscriber is ephemeral, so nothing holds a cursor and nothing pins
retention.

## Tests

- `internal/store/bus_producers_test.go` — window counts, loudest-first ordering,
  totals agreeing with `BusLogSize` exactly, empty log, no cutoffs, and
  `BusEventTimeAt`'s at-or-above semantics, on a log seeded in production's shape.
- `internal/bus/status_test.go` — rates and share on a pinned clock, burst-is-not-
  sustained, surge onset on 6h, standing loudness on 24h, tripwire silence and
  content, consumer lag and retention floor, disabled/stalled/not-live findings,
  `Delivering` gating, startup report before the first tick.
- `app/src/components/EventBusSettings.test.tsx` — reads once on open and does not
  loop, refreshes only on the slow interval, renders health verbatim, collapses
  the quiet tail while always stating its count and share, marks disabled /
  retention-floor / stalled / not-running, does not accuse anyone of being down
  when delivery is not observable, toggles and re-reads, surfaces a refused
  toggle and a failed read.

Mutation-tested rather than assumed: dropping the 24h window from the surge
check, dropping the enabled guard from the retention floor, dating the oldest
unread from the cursor instead of after it, dropping the `delivering` guard,
dropping the quiet tail, speeding the refresh 10x, and skipping the re-read after
a toggle each turn a test red. The oldest-unread mutation initially survived —
the existing assertion only checked non-zero — which is why
`TestStatusDatesTheOldestUnreadEventFromAfterTheCursor` exists.

## Surfaces walked

CLI (`attn bus status`, `--json`), daemon + app (new request/result pair,
`ScopeHubLocal`, greppable `// wire:` comments, `CommandMeta` entries), protocol
(regenerated, `ProtocolVersion` 224 in both places — 223 went to #829), docs
(changelog fragment; the compaction verdict beside `CompactableFacts`). Linux is
unaffected: the new code is pure Go with no platform paths. No plugin or SDK
surface touches the bus.

## Not in scope

No projection/wire coalescing (separate design). No retention policy or cap
changes — this surfaces state, it does not change it. No remote-endpoint bus UI;
local daemon only.

https://claude.ai/code/session_01MNcPxEYQXJFFfBB3NTmMGN
