### PR TITLE
ci(protocol): fail when the generated types drift from the schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       daemon: ${{ steps.filter.outputs.daemon }}
+      generated: ${{ steps.filter.outputs.generated }}
       frontend: ${{ steps.filter.outputs.frontend }}
       tauri: ${{ steps.filter.outputs.tauri }}
       plugins: ${{ steps.filter.outputs.plugins }}
@@ -47,6 +48,15 @@ jobs:
               - 'app/vite.config.ts'
               - 'internal/protocol/schema/**'
               - '.github/workflows/ci.yml'
+            # Every input to the type pipeline plus both of its outputs. The
+            # outputs are listed so a hand-edit is gated even when no schema
+            # moved — that edit is exactly what this catches.
+            generated:
+              - 'internal/protocol/schema/**'
+              - 'internal/protocol/generated.go'
+              - 'app/src/types/generated.ts'
+              - 'Makefile'
+              - '.github/workflows/ci.yml'
             tauri:
               - 'app/src-tauri/**'
               - '.github/workflows/ci.yml'
@@ -71,6 +81,42 @@ jobs:
 
       - name: Gate
         run: ./scripts/changelog-gate.sh "${{ github.base_ref }}" "${{ github.head_ref }}"
+
+  # generated.go and generated.ts are compiled from internal/protocol/schema, and
+  # nothing was checking that the committed copies match. The other jobs cannot:
+  # the generated TS interfaces carry an `any` index signature, so `tsc` accepts a
+  # file with a wire field deleted from it — measured, exit 0. This regenerates
+  # from the schema and fails on any difference.
+  generated-types:
+    name: Generated types
+    needs: changes
+    if: needs.changes.outputs.generated == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      # The TypeSpec compiler the recipe invokes as `pnpm exec tsp`.
+      - name: Install schema toolchain
+        working-directory: internal/protocol/schema
+        run: pnpm install --frozen-lockfile
+
+      - name: Regenerate and diff
+        run: make check-types
 
   backend:
     name: Daemon

--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,12 @@ generate-types: ensure-go-jsonschema
 		--no-prefer-unions --no-prefer-unknown \
 		-o app/src/types/generated.ts
 
-# CI check: verify generated files are up-to-date
+# CI check: verify generated files are up-to-date.
+#
+# This flags *committed* drift, which is what CI sees. generate-types rewrites
+# the files in place first, so an uncommitted hand-edit is overwritten before the
+# diff runs and this passes silently — commit the edit if you are trying to
+# reproduce a drift failure locally.
 check-types: generate-types
 	git diff --exit-code internal/protocol/generated.go app/src/types/generated.ts
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run build build-linux-amd64 build-linux-arm64 publish-native-vt install install-daemon install-dev install-daemon-dev dev verify-ghostty-vt-wasm test test-hooks test-v test-quick test-watch test-all test-frontend test-e2e test-harness clean generate-types check-types build-app ensure-codesign-identity sign-app app-screenshot dist release release-skip-tests
+.PHONY: run build build-linux-amd64 build-linux-arm64 publish-native-vt install install-daemon install-dev install-daemon-dev dev verify-ghostty-vt-wasm test test-hooks test-v test-quick test-watch test-all test-frontend test-e2e test-harness clean generate-types ensure-go-jsonschema check-types build-app ensure-codesign-identity sign-app app-screenshot dist release release-skip-tests
 
 # Bare `make` does the full prod inner loop: install + open the app.
 # `make install` is install-only (for scripts/CI that drive the launch
@@ -288,6 +288,27 @@ clean:
 
 # Type generation pipeline: TypeSpec -> JSON Schema -> go-jsonschema/quicktype
 #
+# go-jsonschema is the third generator input, and it was the only one with no
+# pin: the recipe ran whatever `go install` had last left behind. Two machines on
+# different versions could disagree about generated.go the same way collation
+# made them disagree about generated.ts, and check-types would blame the change
+# rather than the tool. Bump this deliberately, and regenerate in the same commit.
+GO_JSONSCHEMA_VERSION ?= v0.24.1
+# Where `go install` actually puts it. The recipe hardcoded ~/go/bin, which is
+# right only when GOBIN is unset — under asdf (and any other GOBIN) the install
+# lands elsewhere and the recipe dies on a missing binary.
+GO_BIN_DIR := $(or $(shell go env GOBIN),$(shell go env GOPATH)/bin)
+GO_JSONSCHEMA := $(GO_BIN_DIR)/go-jsonschema
+
+# Installs only on a version mismatch, so the usual run costs one `go version`
+# and never touches the network.
+ensure-go-jsonschema:
+	@have=$$(go version -m $(GO_JSONSCHEMA) 2>/dev/null | awk '$$1=="mod"{print $$3}'); \
+	if [ "$$have" != "$(GO_JSONSCHEMA_VERSION)" ]; then \
+		echo "go-jsonschema: installing $(GO_JSONSCHEMA_VERSION) (have: $${have:-none})"; \
+		go install github.com/atombender/go-jsonschema@$(GO_JSONSCHEMA_VERSION); \
+	fi
+
 # LC_ALL=C is load-bearing, not hygiene. The `*.json` globs below are sorted by
 # the shell's collation, and quicktype names an anonymous type after whichever
 # schema it meets first — so the same inputs under en_US.UTF-8 rename types in
@@ -295,10 +316,10 @@ clean:
 # ~1200-line diff that says nothing. Generating under C makes the output depend
 # only on the schemas.
 generate-types: export LC_ALL = C
-generate-types:
+generate-types: ensure-go-jsonschema
 	rm -rf internal/protocol/schema/tsp-output/json-schema
 	cd internal/protocol/schema && pnpm exec tsp compile .
-	$(HOME)/go/bin/go-jsonschema -p protocol --only-models --tags json --resolve-extension json \
+	$(GO_JSONSCHEMA) -p protocol --only-models --tags json --resolve-extension json \
 		--capitalization ID --capitalization URL --capitalization SHA --capitalization PR --capitalization CI \
 		-o internal/protocol/generated.go \
 		internal/protocol/schema/tsp-output/json-schema/*.json

--- a/changelog.d/generated-types-ci-gate.yaml
+++ b/changelog.d/generated-types-ci-gate.yaml
@@ -1,0 +1,10 @@
+kind: internal
+area: build
+change: >
+  CI now regenerates the protocol types from the TypeSpec schema and fails on
+  any difference, so a stale or hand-edited generated.go / generated.ts cannot
+  merge. Nothing was checking this: the generated TypeScript interfaces carry
+  an `any` index signature, so deleting a wire field from generated.ts still
+  type-checks. The recipe also pins go-jsonschema — the one generator input
+  that had no version — and resolves it through GOBIN instead of assuming
+  ~/go/bin.


### PR DESCRIPTION
## What

CI regenerates the protocol types from `internal/protocol/schema` and fails on any
difference. A stale or hand-edited `internal/protocol/generated.go` /
`app/src/types/generated.ts` can no longer merge.

## Why

Both files are compiled output, and nothing verified that the committed copies match
what the schema produces. The existing jobs cannot do it:

- **Frontend** runs `tsc`, but quicktype emits an `any` index signature on every
  generated interface, so a missing wire field is not a type error.
- **Daemon** compiles Go against `generated.go`, which is only a check of the file
  against itself.

Measured, on this branch, by deleting `transcript_path?: string;` from `SetSessionResumeIDMessage`
in `generated.ts` and committing it:

```
tsc exit=0            # the field is simply gone, and nothing objects
check-types exit=2    # +    transcript_path?:  string;
```

So today a dropped field reaches the app as a runtime-only absence — the wire carries
it, the type says it does not exist, and the code that would have read it was never
written. This is also the class of drift that produced the ~1200-line phantom diff in
#829 and had both the author and the reviewer chasing the wrong mechanism, so it is
worth a gate rather than vigilance.

## What changed

**`.github/workflows/ci.yml`** — a `Generated types` job behind a new `generated`
path filter. The filter lists the pipeline's inputs *and* both of its outputs, so a
hand-edit is gated even when no schema moved; that edit is exactly what this catches.

**`Makefile`** — two things the recipe needed before it could be trusted off one
machine:

- `go-jsonschema` was the only generator input with no version pin. The recipe ran
  whatever `go install` had last left behind, so two machines on different versions
  could disagree about `generated.go` the same way collation made them disagree about
  `generated.ts` (fixed in #829). Pinned to `v0.24.1` — the version that produces the
  committed file today; v0.23.0 also reproduces it byte-clean, so the pin is a
  deliberate choice rather than a rescue. It installs only on a version mismatch, so
  the usual run costs one `go version` and no network.
- The binary was resolved as `$(HOME)/go/bin/go-jsonschema`, correct only when `GOBIN`
  is unset. Under asdf the install lands elsewhere: `make check-types` on a clean
  checkout failed here with `No such file or directory` / `Error 127` before this
  change.

## Verification

- `make check-types` green on a clean tree, from a checkout where `go-jsonschema` was
  absent (the pin installed it, second run reinstalled nothing).
- The drift probe above: hand-edit committed, `tsc` passes, the gate fails and names
  the missing line. Probe commit dropped; not in this branch.
- `go run ./cmd/changelog-check` clean.

## Two things a reviewer should know

- `npx quicktype@26.0.0` fetches from npm at run time, so this job inherits npm-outage
  flakiness. Vendoring it is a bigger change than this one, and the version pin is the
  part that matters for reproducibility.
- A skipped path-filtered job produces no check, same as `Daemon` and `Frontend`. If
  this becomes a required check in branch protection it needs the `frontend-e2e-gate`
  treatment; it is not one today.
