### PR TITLE
docs(agents): publish on change, not on tick — producer-rate discipline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -466,6 +466,15 @@ carries the enumerated exception list.
 - Retention trims past the age window but never past an **enabled** consumer's
   cursor. Disabled consumers do not pin the log; they resume at head with a
   logged gap.
+- A producer publishes when the fact changed, not when a timer ticked. Every
+  fact costs a durable row plus, through its projection, a push to every
+  client, so a producer's steady-state rate is part of its design: before
+  shipping a publisher inside a periodic loop, know its facts/hour idle and
+  busy, and make sure a tick where nothing moved publishes nothing. The
+  canonical failure is the 2026-08 evidence flap — a reason string that
+  renamed itself every second and silently wrote 66% of the whole log.
+  Measured healthy rates and the wire-load reconsider threshold live in
+  [docs/plans/2026-08-10-projection-coalescing.md](docs/plans/2026-08-10-projection-coalescing.md).
 - Operator surface: `attn bus status`, `attn bus disable|enable <consumer>`.
   The enabled bit is database-only on purpose — the kill switch must not depend
   on the daemon it kills.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,11 @@ forgets that position and `--since <RFC3339>` replays from an instant.
 - Complexity belongs at the boundary. The daemon owns orchestration and stays
   authoritative (`applyState`, `wireProjections`); the frontend renders what it
   is told.
+- Idle systems must be idle. Anything recurring — a timer, a watcher, a "did
+  it change?" gate — does real work (publishes, pushes, scans, repaints) only
+  when something moved; a gate comparing an unstable value (clock-derived,
+  sampled) fires forever while nothing changes. Verify new recurring work
+  stays silent on a quiet live session.
 - No continuously repainting animations. attn renders GPU terminals, often on
   high-refresh displays, beside agents that run all day — a permanent repaint
   loop is a battery and thermal bug no test will catch.
@@ -466,12 +471,6 @@ carries the enumerated exception list.
 - Retention trims past the age window but never past an **enabled** consumer's
   cursor. Disabled consumers do not pin the log; they resume at head with a
   logged gap.
-- Publish freely on real change — the bus is built for it, and a fact a
-  consumer needs must never be skipped to save traffic. The one rule: a
-  publish reports a change, so a periodic loop where nothing moved this tick
-  publishes nothing. Sanity ceiling: every healthy fact name measures under
-  500 facts/hour (loudest observed: 480/h); a producer sustaining thousands
-  per hour is republishing something that did not change.
 - Operator surface: `attn bus status`, `attn bus disable|enable <consumer>`.
   The enabled bit is database-only on purpose — the kill switch must not depend
   on the daemon it kills.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -466,15 +466,12 @@ carries the enumerated exception list.
 - Retention trims past the age window but never past an **enabled** consumer's
   cursor. Disabled consumers do not pin the log; they resume at head with a
   logged gap.
-- A producer publishes when the fact changed, not when a timer ticked. Every
-  fact costs a durable row plus, through its projection, a push to every
-  client, so a producer's steady-state rate is part of its design: before
-  shipping a publisher inside a periodic loop, know its facts/hour idle and
-  busy, and make sure a tick where nothing moved publishes nothing. The
-  canonical failure is the 2026-08 evidence flap — a reason string that
-  renamed itself every second and silently wrote 66% of the whole log.
-  Measured healthy rates and the wire-load reconsider threshold live in
-  [docs/plans/2026-08-10-projection-coalescing.md](docs/plans/2026-08-10-projection-coalescing.md).
+- Publish freely on real change — the bus is built for it, and a fact a
+  consumer needs must never be skipped to save traffic. The one rule: a
+  publish reports a change, so a periodic loop where nothing moved this tick
+  publishes nothing. Sanity ceiling: every healthy fact name measures under
+  500 facts/hour (loudest observed: 480/h); a producer sustaining thousands
+  per hour is republishing something that did not change.
 - Operator surface: `attn bus status`, `attn bus disable|enable <consumer>`.
   The enabled bit is database-only on purpose — the kill switch must not depend
   on the daemon it kills.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,7 +338,8 @@ forgets that position and `--since <RFC3339>` replays from an instant.
   it change?" gate — does real work (publishes, pushes, scans, repaints) only
   when something moved; a gate comparing an unstable value (clock-derived,
   sampled) fires forever while nothing changes. Verify new recurring work
-  stays silent on a quiet live session.
+  stays silent on a quiet live session — and still fires on every real
+  change; never suppress work a consumer needs to save traffic.
 - No continuously repainting animations. attn renders GPU terminals, often on
   high-refresh displays, beside agents that run all day — a permanent repaint
   loop is a battery and thermal bug no test will catch.

--- a/changelog.d/agents-guide-producer-rate.yaml
+++ b/changelog.d/agents-guide-producer-rate.yaml
@@ -1,8 +1,7 @@
 kind: internal
 area: docs
 change: >
-  AGENTS.md's event-bus rules gain a producer-rate discipline: a publisher
-  fires when the fact changed, not when a timer ticked, and a producer's
-  steady-state facts/hour is part of its design. Written after the evidence
-  flap silently wrote 66% of the durable log; points at the projection
-  coalescing doc for the measured healthy rates.
+  AGENTS.md's event-bus rules state the publish discipline plainly: publish
+  freely on real change, but a periodic loop where nothing moved this tick
+  publishes nothing, with a measured sanity ceiling (healthy fact names all
+  run under 500 facts/hour).

--- a/changelog.d/agents-guide-producer-rate.yaml
+++ b/changelog.d/agents-guide-producer-rate.yaml
@@ -1,0 +1,8 @@
+kind: internal
+area: docs
+change: >
+  AGENTS.md's event-bus rules gain a producer-rate discipline: a publisher
+  fires when the fact changed, not when a timer ticked, and a producer's
+  steady-state facts/hour is part of its design. Written after the evidence
+  flap silently wrote 66% of the durable log; points at the projection
+  coalescing doc for the measured healthy rates.

--- a/changelog.d/agents-guide-producer-rate.yaml
+++ b/changelog.d/agents-guide-producer-rate.yaml
@@ -1,7 +1,7 @@
 kind: internal
 area: docs
 change: >
-  AGENTS.md's event-bus rules state the publish discipline plainly: publish
-  freely on real change, but a periodic loop where nothing moved this tick
-  publishes nothing, with a measured sanity ceiling (healthy fact names all
-  run under 500 facts/hour).
+  AGENTS.md's change discipline gains "idle systems must be idle": recurring
+  work — timers, watchers, changed-gates — does real work only when something
+  moved, and a gate comparing an unstable value fires forever while nothing
+  changes. New recurring work is verified silent on a quiet live session.


### PR DESCRIPTION
## Intent / Why

A recent producer bug did recurring work on every sampling tick while nothing changed, and quietly dominated the durable bus log. The defect class is general — publishes, pushes, scans, repaints — but the guide only warned about its repaint instance.

## Summary

One bullet added to AGENTS.md's Change discipline, directly above the no-repainting rule it generalizes:

- idle systems must be idle: recurring work (timers, watchers, changed-gates) does real work only when something moved;
- the named trap: a gate comparing an unstable value (clock-derived, sampled) fires forever while nothing changes;
- the check: new recurring work is verified silent on a quiet live session.

Deliberately loud producers stay untouched — the rule targets unintentional volume, not volume.

## Verification

Docs-only; changelog fragment validated with `go run ./cmd/changelog-check`.

https://claude.ai/code/session_01429snMWPwXjv1NeqUdV57c