### PR TITLE
feat(agent): let one agent list and peek at sessions without touching them

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -230,7 +230,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '225';
+export const PROTOCOL_VERSION = '226';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentPeekMessage, AgentPeekResult, AgentPeekScreen, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const activityStatusMessage = Convert.toActivityStatusMessage(json);
 //   const activityStatusResult = Convert.toActivityStatusResult(json);
@@ -10,6 +10,9 @@
 //   const agentClearQueueMessage = Convert.toAgentClearQueueMessage(json);
 //   const agentEventMessage = Convert.toAgentEventMessage(json);
 //   const agentHistoryMessage = Convert.toAgentHistoryMessage(json);
+//   const agentPeekMessage = Convert.toAgentPeekMessage(json);
+//   const agentPeekResult = Convert.toAgentPeekResult(json);
+//   const agentPeekScreen = Convert.toAgentPeekScreen(json);
 //   const agentPromptMessage = Convert.toAgentPromptMessage(json);
 //   const agentSetModelMessage = Convert.toAgentSetModelMessage(json);
 //   const agentToolDetailMessage = Convert.toAgentToolDetailMessage(json);
@@ -559,6 +562,47 @@ export interface AgentHistoryMessage {
 
 export enum AgentHistoryMessageCmd {
     AgentHistory = "agent_history",
+}
+
+export interface AgentPeekMessage {
+    cmd:               AgentPeekMessageCmd;
+    target_session_id: string;
+    [property: string]: any;
+}
+
+export enum AgentPeekMessageCmd {
+    AgentPeek = "agent_peek",
+}
+
+export interface AgentPeekResult {
+    agent:                   string;
+    label:                   string;
+    last_assistant_message?: string;
+    last_seen:               string;
+    screen?:                 Screen;
+    session_id:              string;
+    state:                   string;
+    state_reason?:           string;
+    state_since:             string;
+    todos:                   string[];
+    turn_owed?:              boolean;
+    workspace_id:            string;
+    workspace_title?:        string;
+    [property: string]: any;
+}
+
+export interface Screen {
+    cols: number;
+    rows: number;
+    text: string;
+    [property: string]: any;
+}
+
+export interface AgentPeekScreen {
+    cols: number;
+    rows: number;
+    text: string;
+    [property: string]: any;
 }
 
 export interface AgentPromptMessage {
@@ -4598,6 +4642,7 @@ export enum ReposUpdatedMessageEvent {
 
 export interface Response {
     activity_status_result?:               ActivityStatusResultObject;
+    agent_peek_result?:                    AgentPeekResultObject;
     authors?:                              AuthorElement[];
     data?:                                 string;
     delegate_result?:                      DelegateResultObject;
@@ -4650,6 +4695,23 @@ export interface ActivityStatusResultObject {
     error?:        string;
     presence_tier: string;
     sessions:      SessionElement[];
+    [property: string]: any;
+}
+
+export interface AgentPeekResultObject {
+    agent:                   string;
+    label:                   string;
+    last_assistant_message?: string;
+    last_seen:               string;
+    screen?:                 Screen;
+    session_id:              string;
+    state:                   string;
+    state_reason?:           string;
+    state_since:             string;
+    todos:                   string[];
+    turn_owed?:              boolean;
+    workspace_id:            string;
+    workspace_title?:        string;
     [property: string]: any;
 }
 
@@ -6985,6 +7047,30 @@ export class Convert {
 
     public static agentHistoryMessageToJson(value: AgentHistoryMessage): string {
         return JSON.stringify(uncast(value, r("AgentHistoryMessage")), null, 2);
+    }
+
+    public static toAgentPeekMessage(json: string): AgentPeekMessage {
+        return cast(JSON.parse(json), r("AgentPeekMessage"));
+    }
+
+    public static agentPeekMessageToJson(value: AgentPeekMessage): string {
+        return JSON.stringify(uncast(value, r("AgentPeekMessage")), null, 2);
+    }
+
+    public static toAgentPeekResult(json: string): AgentPeekResult {
+        return cast(JSON.parse(json), r("AgentPeekResult"));
+    }
+
+    public static agentPeekResultToJson(value: AgentPeekResult): string {
+        return JSON.stringify(uncast(value, r("AgentPeekResult")), null, 2);
+    }
+
+    public static toAgentPeekScreen(json: string): AgentPeekScreen {
+        return cast(JSON.parse(json), r("AgentPeekScreen"));
+    }
+
+    public static agentPeekScreenToJson(value: AgentPeekScreen): string {
+        return JSON.stringify(uncast(value, r("AgentPeekScreen")), null, 2);
     }
 
     public static toAgentPromptMessage(json: string): AgentPromptMessage {
@@ -10838,6 +10924,35 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("AgentHistoryMessageCmd") },
         { json: "id", js: "id", typ: "" },
     ], "any"),
+    "AgentPeekMessage": o([
+        { json: "cmd", js: "cmd", typ: r("AgentPeekMessageCmd") },
+        { json: "target_session_id", js: "target_session_id", typ: "" },
+    ], "any"),
+    "AgentPeekResult": o([
+        { json: "agent", js: "agent", typ: "" },
+        { json: "label", js: "label", typ: "" },
+        { json: "last_assistant_message", js: "last_assistant_message", typ: u(undefined, "") },
+        { json: "last_seen", js: "last_seen", typ: "" },
+        { json: "screen", js: "screen", typ: u(undefined, r("Screen")) },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "state", js: "state", typ: "" },
+        { json: "state_reason", js: "state_reason", typ: u(undefined, "") },
+        { json: "state_since", js: "state_since", typ: "" },
+        { json: "todos", js: "todos", typ: a("") },
+        { json: "turn_owed", js: "turn_owed", typ: u(undefined, true) },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
+        { json: "workspace_title", js: "workspace_title", typ: u(undefined, "") },
+    ], "any"),
+    "Screen": o([
+        { json: "cols", js: "cols", typ: 0 },
+        { json: "rows", js: "rows", typ: 0 },
+        { json: "text", js: "text", typ: "" },
+    ], "any"),
+    "AgentPeekScreen": o([
+        { json: "cols", js: "cols", typ: 0 },
+        { json: "rows", js: "rows", typ: 0 },
+        { json: "text", js: "text", typ: "" },
+    ], "any"),
     "AgentPromptMessage": o([
         { json: "cmd", js: "cmd", typ: r("AgentPromptMessageCmd") },
         { json: "id", js: "id", typ: "" },
@@ -13242,6 +13357,7 @@ const typeMap: any = {
     ], "any"),
     "Response": o([
         { json: "activity_status_result", js: "activity_status_result", typ: u(undefined, r("ActivityStatusResultObject")) },
+        { json: "agent_peek_result", js: "agent_peek_result", typ: u(undefined, r("AgentPeekResultObject")) },
         { json: "authors", js: "authors", typ: u(undefined, a(r("AuthorElement"))) },
         { json: "data", js: "data", typ: u(undefined, "") },
         { json: "delegate_result", js: "delegate_result", typ: u(undefined, r("DelegateResultObject")) },
@@ -13292,6 +13408,21 @@ const typeMap: any = {
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "presence_tier", js: "presence_tier", typ: "" },
         { json: "sessions", js: "sessions", typ: a(r("SessionElement")) },
+    ], "any"),
+    "AgentPeekResultObject": o([
+        { json: "agent", js: "agent", typ: "" },
+        { json: "label", js: "label", typ: "" },
+        { json: "last_assistant_message", js: "last_assistant_message", typ: u(undefined, "") },
+        { json: "last_seen", js: "last_seen", typ: "" },
+        { json: "screen", js: "screen", typ: u(undefined, r("Screen")) },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "state", js: "state", typ: "" },
+        { json: "state_reason", js: "state_reason", typ: u(undefined, "") },
+        { json: "state_since", js: "state_since", typ: "" },
+        { json: "todos", js: "todos", typ: a("") },
+        { json: "turn_owed", js: "turn_owed", typ: u(undefined, true) },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
+        { json: "workspace_title", js: "workspace_title", typ: u(undefined, "") },
     ], "any"),
     "DocCollectionsResultObject": o([
         { json: "collections", js: "collections", typ: a(r("Schema")) },
@@ -14682,6 +14813,9 @@ const typeMap: any = {
     ],
     "AgentHistoryMessageCmd": [
         "agent_history",
+    ],
+    "AgentPeekMessageCmd": [
+        "agent_peek",
     ],
     "AgentPromptMessageCmd": [
         "agent_prompt",

--- a/changelog.d/agent-peek-and-list.yaml
+++ b/changelog.d/agent-peek-and-list.yaml
@@ -1,0 +1,9 @@
+kind: added
+area: cli
+change: >
+  An attn-living agent can now observe its neighbours: `attn agent list` names
+  every session on the daemon with a short id, name, workspace, state, and
+  whether a turn is owed, and `attn agent peek <id>` reads one session's state,
+  todos, last assistant message, and rendered screen. Peek is passive by
+  construction — it serves only what the daemon already holds, so the observed
+  agent never notices and loses nothing.

--- a/cmd/attn/agent.go
+++ b/cmd/attn/agent.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/client"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// `attn agent` is how one attn-living agent observes another. `list` is the
+// address book — session ids are exposed nowhere else an agent looks — and
+// `peek` reads a session without interrupting it.
+
+const agentShortIDLength = 8
+
+func runAgent() {
+	if len(os.Args) < 3 || os.Args[2] == "-h" || os.Args[2] == "--help" {
+		writeAgentHelp(os.Stdout)
+		return
+	}
+	switch os.Args[2] {
+	case "list":
+		if hasHelpFlag(os.Args[3:]) {
+			writeAgentHelp(os.Stdout)
+			return
+		}
+		runAgentList(os.Args[3:])
+	case "peek":
+		if hasHelpFlag(os.Args[3:]) {
+			writeAgentHelp(os.Stdout)
+			return
+		}
+		runAgentPeek(os.Args[3:])
+	default:
+		fmt.Fprintf(os.Stderr, "agent: unknown command %q\n", os.Args[2])
+		writeAgentHelp(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+type agentListArgs struct {
+	json bool
+}
+
+func parseAgentListArgs(args []string) (agentListArgs, error) {
+	fs := flag.NewFlagSet("agent list", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOut := fs.Bool("json", false, "print the machine result as JSON")
+	if err := fs.Parse(args); err != nil {
+		return agentListArgs{}, err
+	}
+	if fs.NArg() != 0 {
+		return agentListArgs{}, errors.New("agent list takes no arguments")
+	}
+	return agentListArgs{json: *jsonOut}, nil
+}
+
+// agentListRow is the address-book projection: everything another agent needs
+// to pick a target and address it, nothing more.
+type agentListRow struct {
+	ID        string `json:"id"`
+	Label     string `json:"label"`
+	Agent     string `json:"agent"`
+	Workspace string `json:"workspace"`
+	Directory string `json:"directory"`
+	State     string `json:"state"`
+	TurnOwed  bool   `json:"turn_owed"`
+}
+
+func runAgentList(args []string) {
+	parsed, err := parseAgentListArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "agent list: %v\n", err)
+		writeAgentHelp(os.Stderr)
+		os.Exit(2)
+	}
+	result, err := client.New("").List("")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "agent list: %v\n", err)
+		os.Exit(1)
+	}
+	rows := agentListRows(result)
+	if parsed.json {
+		printJSON(rows)
+		return
+	}
+	printAgentList(os.Stdout, rows)
+}
+
+func agentListRows(result *client.ListResult) []agentListRow {
+	workspaceTitles := make(map[string]string, len(result.Workspaces))
+	for _, workspace := range result.Workspaces {
+		workspaceTitles[workspace.ID] = workspace.Title
+	}
+	rows := make([]agentListRow, 0, len(result.Sessions))
+	for _, session := range result.Sessions {
+		rows = append(rows, agentListRow{
+			ID:        session.ID,
+			Label:     session.Label,
+			Agent:     string(session.Agent),
+			Workspace: workspaceTitles[session.WorkspaceID],
+			Directory: session.Directory,
+			State:     string(session.State),
+			TurnOwed:  protocol.Deref(session.TurnOwed),
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Workspace != rows[j].Workspace {
+			return rows[i].Workspace < rows[j].Workspace
+		}
+		return rows[i].Label < rows[j].Label
+	})
+	return rows
+}
+
+func printAgentList(w io.Writer, rows []agentListRow) {
+	if len(rows) == 0 {
+		fmt.Fprintln(w, "No sessions on this daemon.")
+		return
+	}
+	fmt.Fprintf(w, "%-*s  %-18s  %-8s  %-20s  %-16s  %s\n", agentShortIDLength, "ID", "NAME", "AGENT", "WORKSPACE", "STATE", "TURN")
+	for _, row := range rows {
+		turn := "-"
+		if row.TurnOwed {
+			turn = "owed"
+		}
+		fmt.Fprintf(
+			w,
+			"%-*s  %-18s  %-8s  %-20s  %-16s  %s\n",
+			agentShortIDLength, agentShortID(row.ID),
+			agentListCell(row.Label, 18),
+			agentListCell(row.Agent, 8),
+			agentListCell(row.Workspace, 20),
+			agentListCell(row.State, 16),
+			turn,
+		)
+	}
+	fmt.Fprintf(w, "\nAn ID here is what `attn agent peek <id>` takes; --json carries full ids.\n")
+}
+
+func agentShortID(id string) string {
+	if len(id) <= agentShortIDLength {
+		return id
+	}
+	return id[:agentShortIDLength]
+}
+
+// agentListCell truncates a value to keep columns aligned; the full value is
+// always available via --json.
+func agentListCell(value string, width int) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	runes := []rune(value)
+	if len(runes) <= width {
+		return value
+	}
+	return string(runes[:width-1]) + "…"
+}
+
+type agentPeekArgs struct {
+	target string
+	json   bool
+}
+
+func parseAgentPeekArgs(args []string) (agentPeekArgs, error) {
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		return agentPeekArgs{}, errors.New("exactly one target session id is required")
+	}
+	target := strings.TrimSpace(args[0])
+	fs := flag.NewFlagSet("agent peek", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOut := fs.Bool("json", false, "print the machine result as JSON")
+	if err := fs.Parse(args[1:]); err != nil {
+		return agentPeekArgs{}, err
+	}
+	if target == "" || fs.NArg() != 0 {
+		return agentPeekArgs{}, errors.New("exactly one target session id is required")
+	}
+	return agentPeekArgs{target: target, json: *jsonOut}, nil
+}
+
+func runAgentPeek(args []string) {
+	parsed, err := parseAgentPeekArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "agent peek: %v\n", err)
+		writeAgentHelp(os.Stderr)
+		os.Exit(2)
+	}
+	result, err := client.New("").AgentPeek(parsed.target)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "agent peek: %s\n", agentPeekErrorMessage(parsed.target, err))
+		os.Exit(1)
+	}
+	if parsed.json {
+		printJSON(result)
+		return
+	}
+	printAgentPeek(os.Stdout, result)
+}
+
+// agentPeekErrorMessage names the session the caller asked for: the reader is
+// an agent that must fix its own command line, not a human staring at a UI.
+func agentPeekErrorMessage(target string, err error) string {
+	message := strings.TrimSpace(err.Error())
+	switch strings.TrimSpace(strings.TrimPrefix(message, "daemon error: ")) {
+	case "session_not_found":
+		return fmt.Sprintf("no session matches %q; `attn agent list` names the sessions on this daemon", target)
+	case "ambiguous_session":
+		return fmt.Sprintf("%q matches more than one session; give more of the id (`attn agent list --json` carries full ids)", target)
+	}
+	return message
+}
+
+func printAgentPeek(w io.Writer, result *protocol.AgentPeekResult) {
+	fmt.Fprintf(w, "session %s (%s) — %s\n", result.SessionID, result.Agent, result.Label)
+	workspace := strings.TrimSpace(protocol.Deref(result.WorkspaceTitle))
+	if workspace != "" {
+		fmt.Fprintf(w, "workspace: %s\n", workspace)
+	}
+	fmt.Fprintf(w, "state: %s", result.State)
+	if reason := strings.TrimSpace(protocol.Deref(result.StateReason)); reason != "" {
+		fmt.Fprintf(w, " (%s)", reason)
+	}
+	if since := formatAgentPeekTime(result.StateSince); since != "" {
+		fmt.Fprintf(w, " since %s", since)
+	}
+	fmt.Fprintln(w)
+	if protocol.Deref(result.TurnOwed) {
+		fmt.Fprintln(w, "turn: owed to this session")
+	}
+	if len(result.Todos) > 0 {
+		fmt.Fprintln(w, "\ntodos:")
+		for _, todo := range result.Todos {
+			fmt.Fprintf(w, "  %s\n", todo)
+		}
+	}
+	if message := strings.TrimSpace(protocol.Deref(result.LastAssistantMessage)); message != "" {
+		fmt.Fprintln(w, "\nlast assistant message:")
+		for _, line := range strings.Split(message, "\n") {
+			fmt.Fprintf(w, "  %s\n", line)
+		}
+	}
+	if result.Screen != nil {
+		fmt.Fprintf(w, "\nscreen (%dx%d):\n", result.Screen.Cols, result.Screen.Rows)
+		for _, line := range strings.Split(strings.TrimRight(result.Screen.Text, "\n"), "\n") {
+			fmt.Fprintf(w, "  %s\n", line)
+		}
+	} else {
+		fmt.Fprintln(w, "\nscreen unavailable")
+	}
+}
+
+// formatAgentPeekTime shows local wall-clock time; peek is read while looking
+// at a live daemon, so the date matters only when it is not today.
+func formatAgentPeekTime(value string) string {
+	parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(value))
+	if err != nil {
+		return strings.TrimSpace(value)
+	}
+	local := parsed.Local()
+	if local.Format("2006-01-02") == time.Now().Format("2006-01-02") {
+		return local.Format("15:04:05")
+	}
+	return local.Format("2006-01-02 15:04:05")
+}
+
+func writeAgentHelp(w io.Writer) {
+	fmt.Fprint(w, `usage: attn agent <command>
+
+commands:
+  list [--json]
+        the address book: every session on this daemon with its short id,
+        name, workspace, state, and whether a turn is owed. Read-only.
+  peek <id> [--json]
+        observe a session without interrupting it: state, todos, last
+        assistant message, and the rendered screen. Passive — the observed
+        agent never notices. <id> is a full session id or a unique prefix.
+`)
+}

--- a/cmd/attn/agent_test.go
+++ b/cmd/attn/agent_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/client"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func TestParseAgentPeekArgs(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		want    agentPeekArgs
+		wantErr bool
+	}{
+		{name: "target only", args: []string{"abc"}, want: agentPeekArgs{target: "abc"}},
+		{name: "json", args: []string{"abc", "--json"}, want: agentPeekArgs{target: "abc", json: true}},
+		{name: "no target", args: nil, wantErr: true},
+		{name: "flag first", args: []string{"--json", "abc"}, wantErr: true},
+		{name: "two targets", args: []string{"abc", "def"}, wantErr: true},
+		{name: "unknown flag", args: []string{"abc", "--nope"}, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseAgentPeekArgs(tc.args)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAgentListRowsJoinWorkspaceTitlesAndSort(t *testing.T) {
+	rows := agentListRows(&client.ListResult{
+		Sessions: []protocol.Session{
+			{ID: "bbbb2222-1111", Label: "zeta", Agent: "claude", WorkspaceID: "ws-2", State: "idle"},
+			{ID: "aaaa1111-2222", Label: "alpha", Agent: "codex", WorkspaceID: "ws-1", State: "working", TurnOwed: protocol.Ptr(true)},
+		},
+		Workspaces: []protocol.Workspace{
+			{ID: "ws-1", Title: "attn"},
+			{ID: "ws-2", Title: "notes"},
+		},
+	})
+	if len(rows) != 2 {
+		t.Fatalf("rows = %+v", rows)
+	}
+	if rows[0].Workspace != "attn" || rows[0].Label != "alpha" || !rows[0].TurnOwed {
+		t.Fatalf("first row = %+v", rows[0])
+	}
+	if rows[1].Workspace != "notes" || rows[1].TurnOwed {
+		t.Fatalf("second row = %+v", rows[1])
+	}
+}
+
+func TestPrintAgentListShowsShortIDsAndTurn(t *testing.T) {
+	var out bytes.Buffer
+	printAgentList(&out, []agentListRow{
+		{ID: "aaaa1111-2222-3333", Label: "alpha", Agent: "codex", Workspace: "attn", State: "working", TurnOwed: true},
+		{ID: "bbbb2222-1111-4444", Label: "zeta", Agent: "claude", Workspace: "notes", State: "idle"},
+	})
+	text := out.String()
+	for _, want := range []string{"aaaa1111", "bbbb2222", "alpha", "working", "owed", "attn agent peek"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "aaaa1111-2222") {
+		t.Fatalf("output leaked a full id where the short id belongs:\n%s", text)
+	}
+}
+
+func TestPrintAgentListEmpty(t *testing.T) {
+	var out bytes.Buffer
+	printAgentList(&out, nil)
+	if !strings.Contains(out.String(), "No sessions") {
+		t.Fatalf("output = %q", out.String())
+	}
+}
+
+func TestPrintAgentPeekShowsEverySection(t *testing.T) {
+	var out bytes.Buffer
+	printAgentPeek(&out, &protocol.AgentPeekResult{
+		SessionID:            "aaaa1111-2222",
+		Label:                "builder",
+		Agent:                "claude",
+		WorkspaceID:          "ws-1",
+		WorkspaceTitle:       protocol.Ptr("attn"),
+		State:                "working",
+		StateReason:          protocol.Ptr("classifier_verdict"),
+		StateSince:           "2026-08-10T10:00:00Z",
+		LastSeen:             "2026-08-10T10:05:00Z",
+		TurnOwed:             protocol.Ptr(true),
+		Todos:                []string{"[✓] read the plan", "[→] build peek"},
+		LastAssistantMessage: protocol.Ptr("working on it\nsecond line"),
+		Screen:               &protocol.AgentPeekScreen{Text: "$ go test\nok\n", Cols: 80, Rows: 24},
+	})
+	text := out.String()
+	for _, want := range []string{
+		"session aaaa1111-2222 (claude) — builder",
+		"workspace: attn",
+		"state: working (classifier_verdict)",
+		"turn: owed",
+		"[→] build peek",
+		"working on it",
+		"  second line",
+		"screen (80x24):",
+		"$ go test",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestPrintAgentPeekDegradesWithoutOptionalSections(t *testing.T) {
+	var out bytes.Buffer
+	printAgentPeek(&out, &protocol.AgentPeekResult{
+		SessionID:  "bbbb2222",
+		Label:      "quiet",
+		Agent:      "codex",
+		State:      "idle",
+		StateSince: "2026-08-10T10:00:00Z",
+		LastSeen:   "2026-08-10T10:00:00Z",
+		Todos:      []string{},
+	})
+	text := out.String()
+	if !strings.Contains(text, "screen unavailable") {
+		t.Fatalf("output missing the screen degrade line:\n%s", text)
+	}
+	for _, unwanted := range []string{"todos:", "last assistant message:", "turn:"} {
+		if strings.Contains(text, unwanted) {
+			t.Fatalf("output has %q for an empty section:\n%s", unwanted, text)
+		}
+	}
+}
+
+func TestAgentPeekErrorMessagesNameTheTarget(t *testing.T) {
+	notFound := agentPeekErrorMessage("abc", errors.New("daemon error: session_not_found"))
+	if !strings.Contains(notFound, `"abc"`) || !strings.Contains(notFound, "attn agent list") {
+		t.Fatalf("not-found message = %q", notFound)
+	}
+	ambiguous := agentPeekErrorMessage("a", errors.New("daemon error: ambiguous_session"))
+	if !strings.Contains(ambiguous, "more than one session") {
+		t.Fatalf("ambiguous message = %q", ambiguous)
+	}
+	other := agentPeekErrorMessage("abc", errors.New("dial unix: no daemon"))
+	if !strings.Contains(other, "no daemon") {
+		t.Fatalf("other message = %q", other)
+	}
+}

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -230,6 +230,9 @@ func main() {
 	case "session":
 		maybePrintProfileBanner()
 		runSession()
+	case "agent":
+		maybePrintProfileBanner()
+		runAgent()
 	case "state":
 		maybePrintProfileBanner()
 		runState()
@@ -626,6 +629,8 @@ func writeHelp(w io.Writer) {
 
 commands:
   presence                          check whether the current shell runs inside attn
+  agent list                        name every session running here
+  agent peek <id>                   read a session without interrupting it
 	  session <command>                 inspect a session's conversation
   state explain <id>                replay why a session's state is what it is
   delegate --brief-file <path>      start another agent with a delegated brief

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -379,6 +379,23 @@ func (c *Client) StateExplain(targetSessionID string) (*protocol.StateExplainRes
 	return resp.StateExplainResult, nil
 }
 
+// AgentPeek reads another session's daemon-held snapshot — state, todos, last
+// assistant message, rendered screen. Passive: the observed session is never
+// touched. The target may be a full session id or a unique prefix.
+func (c *Client) AgentPeek(targetSessionID string) (*protocol.AgentPeekResult, error) {
+	resp, err := c.send(protocol.AgentPeekMessage{
+		Cmd:             protocol.CmdAgentPeek,
+		TargetSessionID: targetSessionID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.AgentPeekResult == nil {
+		return nil, errors.New("daemon returned no agent peek result")
+	}
+	return resp.AgentPeekResult, nil
+}
+
 // SendStop sends a stop signal with transcript path for classification
 // StopFacts carries what the Stop hook observed about whether the turn actually
 // finished. The daemon decides what it means; see nonTerminalStopState there. A

--- a/internal/daemon/agent_peek.go
+++ b/internal/daemon/agent_peek.go
@@ -1,0 +1,121 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"strings"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/ptybackend"
+	"github.com/victorarias/attn/internal/transcript"
+)
+
+// agent_peek is the passive half of agents conversing and observing: one agent
+// reads another session's state, todos, last assistant message, and rendered
+// screen, all from what the daemon already holds. Nothing here writes to the
+// target's PTY or wakes its agent — watching must cost the observed session
+// nothing.
+
+// agentPeekMessageMaxChars bounds the last assistant message. Same receipt as
+// the annotatable window (ws_session_message.go): the largest prose block seen
+// across 120 transcripts was 18,713 chars, so 64KiB is a tripwire only a
+// runaway transcript touches.
+const agentPeekMessageMaxChars = annotatableMessageMaxChars
+
+// agentPeekSnapshotTimeout matches the model-capture snapshot budget: the
+// worker answers from its parsed terminal without touching the agent process.
+const agentPeekSnapshotTimeout = modelCaptureSnapshotTimeout
+
+func (d *Daemon) handleAgentPeek(conn net.Conn, msg *protocol.AgentPeekMessage) {
+	session, errCode := d.resolveSessionByIDOrPrefix(msg.TargetSessionID)
+	if session == nil {
+		d.sendError(conn, errCode)
+		return
+	}
+	_ = json.NewEncoder(conn).Encode(protocol.Response{
+		Ok:              true,
+		AgentPeekResult: d.agentPeekResult(session),
+	})
+}
+
+// resolveSessionByIDOrPrefix accepts a full session id or a unique prefix —
+// `attn agent list` prints 8-char short ids, and every other `attn agent`
+// command takes them back. The error code names what went wrong: an ambiguous
+// prefix is the caller's to lengthen, not ours to guess.
+func (d *Daemon) resolveSessionByIDOrPrefix(target string) (*protocol.Session, string) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return nil, "session_not_found"
+	}
+	if session := d.store.Get(target); session != nil {
+		return session, ""
+	}
+	var match *protocol.Session
+	for _, session := range d.store.List("") {
+		if !strings.HasPrefix(session.ID, target) {
+			continue
+		}
+		if match != nil {
+			return nil, "ambiguous_session"
+		}
+		match = session
+	}
+	if match == nil {
+		return nil, "session_not_found"
+	}
+	return match, ""
+}
+
+func (d *Daemon) agentPeekResult(session *protocol.Session) *protocol.AgentPeekResult {
+	decorated := d.sessionForBroadcast(session)
+	result := &protocol.AgentPeekResult{
+		SessionID:   decorated.ID,
+		Label:       decorated.Label,
+		Agent:       string(decorated.Agent),
+		WorkspaceID: decorated.WorkspaceID,
+		State:       string(decorated.State),
+		StateSince:  decorated.StateSince,
+		LastSeen:    decorated.LastSeen,
+		StateReason: decorated.StateReason,
+		TurnOwed:    decorated.TurnOwed,
+		Todos:       decorated.Todos,
+	}
+	if result.Todos == nil {
+		result.Todos = []string{}
+	}
+	if workspace := d.store.GetWorkspace(decorated.WorkspaceID); workspace != nil {
+		result.WorkspaceTitle = protocol.Ptr(workspace.Title)
+	}
+	if path := d.inspectableTranscriptPath(session); path != "" {
+		if message, err := transcript.ExtractLastAssistantMessage(path, agentPeekMessageMaxChars); err == nil && strings.TrimSpace(message) != "" {
+			result.LastAssistantMessage = protocol.Ptr(message)
+		}
+	}
+	result.Screen = d.agentPeekScreen(session.ID)
+	return result
+}
+
+// agentPeekScreen degrades to nil — never an error — when the backend cannot
+// serve a snapshot (no provider, old worker, no rendered frame yet).
+func (d *Daemon) agentPeekScreen(sessionID string) *protocol.AgentPeekScreen {
+	provider, ok := d.ptyBackend.(ptybackend.SnapshotProvider)
+	if !ok {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), agentPeekSnapshotTimeout)
+	defer cancel()
+	snapshot, err := provider.Snapshot(ctx, sessionID)
+	if err != nil {
+		d.logf("agent peek snapshot unavailable: session=%s err=%v", sessionID, err)
+		return nil
+	}
+	if snapshot.Screen == nil || !snapshot.Screen.HasText {
+		return nil
+	}
+	return &protocol.AgentPeekScreen{
+		Text: snapshot.Screen.Text,
+		Cols: int(snapshot.Screen.Cols),
+		Rows: int(snapshot.Screen.Rows),
+	}
+}

--- a/internal/daemon/agent_peek_test.go
+++ b/internal/daemon/agent_peek_test.go
@@ -1,0 +1,119 @@
+package daemon
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/pty"
+)
+
+func callAgentPeek(t *testing.T, d *Daemon, target string) protocol.Response {
+	t.Helper()
+	return callHandler(t, func(conn net.Conn) {
+		d.handleAgentPeek(conn, &protocol.AgentPeekMessage{Cmd: protocol.CmdAgentPeek, TargetSessionID: target})
+	})
+}
+
+// Peek assembles everything from what the daemon already holds: the store
+// snapshot (state, todos, workspace), the transcript file, and nothing else
+// when no screen snapshot is available — a backend that cannot serve one
+// degrades to an absent screen, never an error.
+func TestHandleAgentPeekReturnsStateTodosWorkspaceAndLastMessage(t *testing.T) {
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	transcriptDir := filepath.Join(codexHome, "sessions", "2026", "08", "10")
+	if err := os.MkdirAll(transcriptDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	content := strings.Join([]string{
+		`{"timestamp":"2026-08-10T10:00:00Z","type":"session_meta","payload":{"id":"native-peek"}}`,
+		`{"timestamp":"2026-08-10T10:00:01Z","type":"event_msg","payload":{"type":"agent_message","message":"first answer"}}`,
+		`{"timestamp":"2026-08-10T10:00:02Z","type":"event_msg","payload":{"type":"agent_message","message":"latest answer"}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(transcriptDir, "rollout.jsonl"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	d := NewForTesting(filepath.Join(t.TempDir(), "attn.sock"))
+	workspaceID := addCharacterizationSession(t, d, "peek-target", protocol.SessionAgentCodex, protocol.SessionStateWorking)
+	d.store.UpdateTodos("peek-target", []string{"[✓] read the plan", "[→] build peek"})
+	d.store.SetResumeSessionID("peek-target", "native-peek")
+
+	resp := callAgentPeek(t, d, "peek-target")
+	if !resp.Ok || resp.AgentPeekResult == nil {
+		t.Fatalf("response = %+v", resp)
+	}
+	result := resp.AgentPeekResult
+	if result.SessionID != "peek-target" || result.State != string(protocol.SessionStateWorking) {
+		t.Fatalf("result identity/state = %+v", result)
+	}
+	if len(result.Todos) != 2 || result.Todos[1] != "[→] build peek" {
+		t.Fatalf("todos = %v", result.Todos)
+	}
+	if result.WorkspaceID != workspaceID {
+		t.Fatalf("workspace id = %q, want %q", result.WorkspaceID, workspaceID)
+	}
+	if protocol.Deref(result.LastAssistantMessage) != "latest answer" {
+		t.Fatalf("last assistant message = %q", protocol.Deref(result.LastAssistantMessage))
+	}
+	if result.Screen != nil {
+		t.Fatalf("screen = %+v, want absent when the backend has no snapshot", result.Screen)
+	}
+}
+
+// The address book prints 8-char short ids, so peek must resolve a unique
+// prefix — and refuse an ambiguous one by name rather than guessing.
+func TestHandleAgentPeekResolvesPrefixesAndNamesFailures(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "attn.sock"))
+	addCharacterizationSession(t, d, "aaa-first", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+	addCharacterizationSession(t, d, "aab-second", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+
+	resp := callAgentPeek(t, d, "aaa")
+	if !resp.Ok || resp.AgentPeekResult == nil || resp.AgentPeekResult.SessionID != "aaa-first" {
+		t.Fatalf("unique prefix response = %+v", resp)
+	}
+
+	ambiguous := callAgentPeek(t, d, "aa")
+	if ambiguous.Ok || protocol.Deref(ambiguous.Error) != "ambiguous_session" {
+		t.Fatalf("ambiguous response = %+v", ambiguous)
+	}
+
+	missing := callAgentPeek(t, d, "zzz")
+	if missing.Ok || protocol.Deref(missing.Error) != "session_not_found" {
+		t.Fatalf("missing response = %+v", missing)
+	}
+}
+
+type peekSnapshotBackend struct {
+	*fakeSpawnBackend
+	snapshot pty.SnapshotInfo
+}
+
+func (b *peekSnapshotBackend) Snapshot(context.Context, string) (pty.SnapshotInfo, error) {
+	return b.snapshot, nil
+}
+
+func TestHandleAgentPeekServesTheRenderedScreen(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "attn.sock"))
+	addCharacterizationSession(t, d, "peek-screen", protocol.SessionAgentClaude, protocol.SessionStateWorking)
+	d.ptyBackend = &peekSnapshotBackend{
+		fakeSpawnBackend: &fakeSpawnBackend{},
+		snapshot: pty.SnapshotInfo{
+			Screen: &pty.ViewportSnapshot{Text: "$ make test\nok\n", HasText: true, Cols: 80, Rows: 24},
+		},
+	}
+
+	resp := callAgentPeek(t, d, "peek-screen")
+	if !resp.Ok || resp.AgentPeekResult == nil || resp.AgentPeekResult.Screen == nil {
+		t.Fatalf("response = %+v", resp)
+	}
+	screen := resp.AgentPeekResult.Screen
+	if screen.Text != "$ make test\nok\n" || screen.Cols != 80 || screen.Rows != 24 {
+		t.Fatalf("screen = %+v", screen)
+	}
+}

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -42,6 +42,7 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdSessionInstructions:        commandMetadata(ScopeSession, false, true),
 	protocol.CmdSessionTranscript:          commandMetadata(ScopeSession, false, true),
 	protocol.CmdStateExplain:               commandMetadata(ScopeSession, false, true),
+	protocol.CmdAgentPeek:                  commandMetadata(ScopeSession, false, true),
 	protocol.CmdStop:                       commandMetadata(ScopeSession, false, true),
 	protocol.CmdTodos:                      commandMetadata(ScopeSession, false, true),
 	protocol.CmdFilesEdited:                commandMetadata(ScopeSession, false, true),

--- a/internal/daemon/command_routing_test.go
+++ b/internal/daemon/command_routing_test.go
@@ -146,6 +146,7 @@ var sessionCommandsAnsweredWhereTheyLand = map[string]string{
 	protocol.CmdSessionInstructions: "arrives from the agent process over the unix socket",
 	protocol.CmdSessionTranscript:   "arrives from the agent process over the unix socket",
 	protocol.CmdStateExplain:        "arrives from the agent process over the unix socket",
+	protocol.CmdAgentPeek:           "arrives from the agent process over the unix socket",
 	protocol.CmdTicketCreate:        "arrives from the agent process over the unix socket",
 	protocol.CmdTicketInbox:         "arrives from the agent process over the unix socket",
 	protocol.CmdSetTicketStatus:     "arrives from the agent process over the unix socket",

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2536,6 +2536,8 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleSessionTranscript(conn, msg.(*protocol.SessionTranscriptMessage))
 	case protocol.CmdStateExplain: // wire: state_explain
 		d.handleStateExplain(conn, msg.(*protocol.StateExplainMessage))
+	case protocol.CmdAgentPeek: // wire: agent_peek
+		d.handleAgentPeek(conn, msg.(*protocol.AgentPeekMessage))
 	case protocol.CmdStop: // wire: stop
 		d.handleStop(conn, msg.(*protocol.StopMessage))
 	case protocol.CmdTodos: // wire: todos

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "225"
+const ProtocolVersion = "226"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only
@@ -161,6 +161,7 @@ const (
 	CmdSessionInstructions                   = "session_instructions"
 	CmdSessionTranscript                     = "session_transcript"
 	CmdStateExplain                          = "state_explain"
+	CmdAgentPeek                             = "agent_peek"
 	CmdStop                                  = "stop"
 	CmdTodos                                 = "todos"
 	CmdFilesEdited                           = "files_edited"
@@ -1058,6 +1059,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdStateExplain:
 		var msg StateExplainMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdAgentPeek:
+		var msg AgentPeekMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -96,6 +96,67 @@ type AgentHistoryMessage struct {
 	ID string `json:"id"`
 }
 
+type AgentPeekMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// TargetSessionID corresponds to the JSON schema field "target_session_id".
+	TargetSessionID string `json:"target_session_id"`
+}
+
+type AgentPeekResult struct {
+	// Agent corresponds to the JSON schema field "agent".
+	Agent string `json:"agent"`
+
+	// Label corresponds to the JSON schema field "label".
+	Label string `json:"label"`
+
+	// LastAssistantMessage corresponds to the JSON schema field
+	// "last_assistant_message".
+	LastAssistantMessage *string `json:"last_assistant_message,omitempty,omitzero"`
+
+	// LastSeen corresponds to the JSON schema field "last_seen".
+	LastSeen string `json:"last_seen"`
+
+	// Screen corresponds to the JSON schema field "screen".
+	Screen *AgentPeekScreen `json:"screen,omitempty,omitzero"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID string `json:"session_id"`
+
+	// State corresponds to the JSON schema field "state".
+	State string `json:"state"`
+
+	// StateReason corresponds to the JSON schema field "state_reason".
+	StateReason *string `json:"state_reason,omitempty,omitzero"`
+
+	// StateSince corresponds to the JSON schema field "state_since".
+	StateSince string `json:"state_since"`
+
+	// Todos corresponds to the JSON schema field "todos".
+	Todos []string `json:"todos"`
+
+	// TurnOwed corresponds to the JSON schema field "turn_owed".
+	TurnOwed *bool `json:"turn_owed,omitempty,omitzero"`
+
+	// WorkspaceID corresponds to the JSON schema field "workspace_id".
+	WorkspaceID string `json:"workspace_id"`
+
+	// WorkspaceTitle corresponds to the JSON schema field "workspace_title".
+	WorkspaceTitle *string `json:"workspace_title,omitempty,omitzero"`
+}
+
+type AgentPeekScreen struct {
+	// Cols corresponds to the JSON schema field "cols".
+	Cols int `json:"cols"`
+
+	// Rows corresponds to the JSON schema field "rows".
+	Rows int `json:"rows"`
+
+	// Text corresponds to the JSON schema field "text".
+	Text string `json:"text"`
+}
+
 type AgentPromptMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -4603,6 +4664,9 @@ type Response struct {
 	// ActivityStatusResult corresponds to the JSON schema field
 	// "activity_status_result".
 	ActivityStatusResult *ActivityStatusResult `json:"activity_status_result,omitempty,omitzero"`
+
+	// AgentPeekResult corresponds to the JSON schema field "agent_peek_result".
+	AgentPeekResult *AgentPeekResult `json:"agent_peek_result,omitempty,omitzero"`
 
 	// Authors corresponds to the JSON schema field "authors".
 	Authors []AuthorState `json:"authors,omitempty,omitzero"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -734,6 +734,15 @@ model StateExplainMessage {
   target_session_id: string;
 }
 
+// One agent observes another without interrupting it: state, todos, the last
+// assistant message, and the rendered screen, all served from what the daemon
+// already holds. Passive by construction — nothing here touches the target's
+// PTY or generates input, so watching costs the observed agent nothing.
+model AgentPeekMessage {
+  cmd: "agent_peek";
+  target_session_id: string;    // full id or unique prefix (the short id from `attn agent list`)
+}
+
 // A Stop is not always terminal: the turn may yield with background work still
 // in flight (it auto-resumes on completion) or park on a pending scheduled
 // wakeup. These carry that as FACTS observed by the hook — the statuses of the
@@ -4203,6 +4212,7 @@ model Response {
   session_instructions_result?: SessionInstructionsResult;
   session_transcript_result?: SessionTranscriptResult;
   state_explain_result?: StateExplainResult;
+  agent_peek_result?: AgentPeekResult;
   doc_define_result?: DocDefineResult;
   doc_undefine_result?: DocUndefineResult;
   doc_collections_result?: DocCollectionsResult;
@@ -4244,6 +4254,35 @@ model StateExplainResult {
   // capacity is the ring size, so a full ring can be reported as truncated
   // rather than read as the whole history.
   capacity: int32;
+}
+
+// The target's rendered viewport, plain text from the worker's parsed
+// terminal. Viewport only: scrollback is not part of the snapshot RPC.
+model AgentPeekScreen {
+  text: string;
+  cols: int32;
+  rows: int32;
+}
+
+model AgentPeekResult {
+  session_id: string;
+  label: string;
+  agent: string;
+  workspace_id: string;
+  workspace_title?: string;
+  state: string;
+  state_reason?: string;
+  state_since: string;
+  last_seen: string;
+  turn_owed?: boolean;
+  // The flat strings the todo hook stores, served as-is; consumers parse the
+  // [✓]/[→]/[ ] prefix if they care.
+  todos: string[];
+  // Absent is not an error: a session with no inspectable transcript, or one
+  // that has said nothing yet, simply has no message to show.
+  last_assistant_message?: string;
+  // Absent when the backend cannot serve a snapshot (old worker, no frame).
+  screen?: AgentPeekScreen;
 }
 
 model EvidenceExcerpt {


### PR DESCRIPTION
Agents living inside attn cannot see each other. A session knows its own id and
nothing else — not who else is running, not what they are doing. This is the
read-only half of the converse-and-observe vertical from
`docs/plans/2026-08-08-converse-and-observe.md`: the address book, and a way to
look without touching.

## What this adds

**`attn agent list`** — the address book. Every session on the daemon, with an
8-char short id, its name, workspace, state, and whether a turn is owed. Session
ids are exposed nowhere else, so without this there is no way for one agent to
name another. `--json` carries the full ids for anything that needs them.

```
ID        NAME                 AGENT   WORKSPACE        STATE     TURN
8010386f  peekwalk-a           shell   peekwalk-a       idle
97ffa61e  peekwalk-b           claude  peekwalk-b       working   owed
```

**`attn agent peek <id>`** — one session's state, todos, last assistant message,
and rendered screen. The id may be the short id, any unique prefix, or the full
id; an ambiguous prefix is refused by name rather than guessed at.

**Peek is passive by construction.** It assembles the answer from what the
daemon already holds — the store snapshot, the transcript file on disk, and the
worker's already-parsed terminal. Nothing in this path writes to the target's
PTY, generates input, or wakes its agent. Being watched costs the observed
session nothing: no tokens, no interruption, no trace in its transcript.

Everything degrades rather than fails. A backend with no snapshot provider, an
older worker, or a session that has not rendered a frame yet yields an absent
screen, not an error. Same for a session with no transcript or no todos.

## Shape

- `agent_peek` / `agent_peek_result` on the protocol (`ProtocolVersion` 225 → 226,
  lockstep across `main.tsp`, `constants.go`, and `useDaemonSocket.ts`).
- `internal/daemon/agent_peek.go` — the whole daemon side. Resolution by id or
  unique prefix, decoration through `sessionForBroadcast`, last message through
  the existing `inspectableTranscriptPath` identity ladder, screen through the
  optional `ptybackend.SnapshotProvider`.
- `cmd/attn/agent.go` — the CLI surface for both subcommands, plus `--json`.
- `client.AgentPeek` for the socket call.
- The message cap reuses the annotatable-window receipt: the largest prose block
  across 120 transcripts measured 18,713 chars, so 64KiB is a tripwire only a
  runaway transcript touches.

Both subcommands appear in the top-level `writeHelp`, so bare `attn` names
the address book. The plan filed that under slice 2's discoverability item
alongside the embedded-skill reference; the help half lands here because the
verbs it names exist here, and the skill reference still waits for `msg` so it
can advertise the pair.

`agent_peek` is scoped to a session and answered where it lands, like every
other command that arrives from an agent process over the unix socket — recorded
with that reason in `sessionCommandsAnsweredWhereTheyLand`.

## Verification

Automated: `go build ./...`, `go vet`, the full `go test ./...`, `pnpm test`
(2714 passed / 15 skipped), `pnpm exec tsc --noEmit`, `changelog-check`, and
`make build-linux-amd64` producing a verified ELF x86-64 binary — `cmd/attn` and
`internal/**` still cross-compile for the Linux remotes.

Live, on a throwaway `peekwalk` profile (never `dev`, never production), built
and installed from this branch:

- Bundled preflight passed every check, including `protocol.cli_app` and
  `protocol.app_daemon`. Run without the profile selected it correctly *failed*
  against the production app's older protocol — proof the profile scoping was
  real and the evidence came from this build.
- Two real sessions in separate workspaces: a shell and a Claude session.
- `attn agent list` rendered the table both from a plain shell and from inside a
  session's own pane, showing the short ids, agents, workspaces, states, and
  `owed` in the TURN column.
- `attn agent peek <b>` mid-turn returned `state: working (background_work)`,
  `turn: owed to this session`, the last assistant message
  (*"Waiting for the 90-second sleep to complete; I'll say done when it
  finishes."*), and the full 140x40 rendered screen. `--json` carried the same
  with `cols/rows: 140 40`.
- Error paths: an unknown id printed *no session matches "zzzz"; `attn agent
  list` names the sessions on this daemon*; a short id resolved to its full
  session.
- **Passivity proven at the source.** After repeated peeks at the Claude
  session, its transcript contained only the entries for the brief typed into it
  — no reaction of any kind to being watched.

One thing worth naming: peek's `todos` came back empty for the Claude session
even though its pane showed a task list. That is by design — the plan rules that
todos ship as the flat strings the hook already stores, and Claude Code's
in-pane list is not that payload. The populated-todos path is covered by unit
test rather than by that live walk.
