### PR TITLE
fix(plugins): report plugin health only when it moves

### DIFF
--- a/changelog.d/fix-plugin-health-delta-gate.yaml
+++ b/changelog.d/fix-plugin-health-delta-gate.yaml
@@ -1,0 +1,14 @@
+kind: fixed
+area: plugins
+change: >
+  A connected plugin whose health is not moving no longer costs anything. The
+  15-second healthcheck now reports only when the verdict changes, instead of
+  publishing an event, rebuilding the plugin catalog off disk and writing a log
+  line on every poll.
+symptom: >
+  With attn idle and nothing to report, each connected plugin produced 5,760
+  events a day, and every one of them re-scanned both plugin directories from
+  disk and re-sent the plugin list to every open window. It was the loudest
+  thing on the wire while the machine should have been asleep. Plugin status in
+  Settings still updates the moment a plugin becomes unhealthy, crashes, or
+  recovers.

--- a/changelog.d/fix-plugin-health-delta-gate.yaml
+++ b/changelog.d/fix-plugin-health-delta-gate.yaml
@@ -1,10 +1,10 @@
 kind: fixed
 area: plugins
 change: >
-  A connected plugin whose health is not moving no longer costs anything. The
-  15-second healthcheck now reports only when the verdict changes, instead of
-  publishing an event, rebuilding the plugin catalog off disk and writing a log
-  line on every poll.
+  A connected plugin whose health is not moving no longer wakes the rest of
+  attn. The 15-second healthcheck still asks, but now reports only when the
+  verdict changes, instead of publishing an event, rebuilding the plugin catalog
+  off disk and writing a log line on every poll.
 symptom: >
   With attn idle and nothing to report, each connected plugin produced 5,760
   events a day, and every one of them re-scanned both plugin directories from

--- a/internal/daemon/plugin_rpc.go
+++ b/internal/daemon/plugin_rpc.go
@@ -370,15 +370,23 @@ func (p *pluginConnection) request(ctx context.Context, method string, params in
 	}
 }
 
-func (p *pluginConnection) setHealth(status, message string, at time.Time) {
+// setHealth records a health observation and reports whether it moved. The
+// check timestamp is not part of that answer: it advances every poll and no
+// client renders it, so gating on it would publish a fact 5,760 times a day per
+// plugin with nothing to say.
+func (p *pluginConnection) setHealth(status, message string, at time.Time) bool {
 	p.healthMu.Lock()
 	defer p.healthMu.Unlock()
-	p.healthStatus = strings.TrimSpace(status)
-	if p.healthStatus == "" {
-		p.healthStatus = "unknown"
+	next := strings.TrimSpace(status)
+	if next == "" {
+		next = "unknown"
 	}
-	p.healthMessage = strings.TrimSpace(message)
+	nextMessage := strings.TrimSpace(message)
+	changed := next != p.healthStatus || nextMessage != p.healthMessage
+	p.healthStatus = next
+	p.healthMessage = nextMessage
 	p.lastHealthAt = at
+	return changed
 }
 
 func (p *pluginConnection) healthSnapshot() (string, string, time.Time) {
@@ -660,9 +668,7 @@ func (d *Daemon) checkPluginHealth(plugin *pluginConnection) {
 		Now: now.Format(time.RFC3339Nano),
 	}, &result)
 	if err != nil {
-		plugin.setHealth("unhealthy", err.Error(), now)
-		d.logf("plugin health plugin=%s status=unhealthy error=%s", plugin.name, providerLogValue(err.Error()))
-		d.publishFact(FactPluginHealthChanged, plugin.name, nil)
+		d.reportPluginHealth(plugin, now, "unhealthy", err.Error())
 		return
 	}
 	if !result.OK {
@@ -670,13 +676,27 @@ func (d *Daemon) checkPluginHealth(plugin *pluginConnection) {
 		if message == "" {
 			message = "plugin reported unhealthy"
 		}
-		plugin.setHealth("unhealthy", message, now)
-		d.logf("plugin health plugin=%s status=unhealthy error=%s", plugin.name, providerLogValue(message))
-		d.publishFact(FactPluginHealthChanged, plugin.name, nil)
+		d.reportPluginHealth(plugin, now, "unhealthy", message)
 		return
 	}
 
-	plugin.setHealth("healthy", result.Message, now)
-	d.logf("plugin health plugin=%s status=healthy", plugin.name)
+	d.reportPluginHealth(plugin, now, "healthy", result.Message)
+}
+
+// reportPluginHealth records a poll's verdict and publishes only the ones that
+// moved. A steady plugin is silent: no fact, no durable bus row, no plugins
+// catalog rebuild (which re-scans both plugin directories from disk), and no log
+// line, while attn is idle. Crash and recovery still surface — they arrive as
+// supervisor phase transitions and connect/disconnect facts, not as a poll
+// verdict.
+func (d *Daemon) reportPluginHealth(plugin *pluginConnection, at time.Time, status, message string) {
+	if !plugin.setHealth(status, message, at) {
+		return
+	}
+	if status == "healthy" {
+		d.logf("plugin health plugin=%s status=healthy", plugin.name)
+	} else {
+		d.logf("plugin health plugin=%s status=%s error=%s", plugin.name, status, providerLogValue(message))
+	}
 	d.publishFact(FactPluginHealthChanged, plugin.name, nil)
 }

--- a/internal/daemon/plugin_rpc_test.go
+++ b/internal/daemon/plugin_rpc_test.go
@@ -478,6 +478,98 @@ func TestDaemon_PluginHealthCheckRecordsStatus(t *testing.T) {
 	})
 }
 
+// A steady plugin costs nothing: the 15-second poll publishes a fact only when
+// the verdict moves, so an idle daemon writes no bus rows and pushes no catalog.
+func TestDaemon_PluginHealthPublishesOnlyWhenItMoves(t *testing.T) {
+	d := newBubbleDaemon(t)
+	synctest.Test(t, func(t *testing.T) {
+		stopDaemonBackground(t, d)
+		d.pluginDir = filepath.Join(t.TempDir(), "plugins")
+		writeTestPluginManifest(t, d.pluginDir, "health-provider")
+
+		client, done := startPluginPipe(t, d, "health-provider", []string{"worktree.create"})
+		defer client.Close()
+
+		plugin := d.plugins.get("health-provider")
+		if plugin == nil {
+			t.Fatal("plugin registry missing health-provider")
+		}
+
+		poll := func(answer pluginHealthResult) {
+			t.Helper()
+			answered := make(chan struct{})
+			go func() {
+				defer close(answered)
+				request := decodeJSONRPCMessage(t, client)
+				if request.Method != pluginHealthMethod {
+					t.Errorf("health method=%q, want %s", request.Method, pluginHealthMethod)
+					return
+				}
+				result, err := json.Marshal(answer)
+				if err != nil {
+					t.Errorf("marshal health result: %v", err)
+					return
+				}
+				if err := json.NewEncoder(client).Encode(jsonRPCMessage{
+					JSONRPC: "2.0",
+					ID:      request.ID,
+					Result:  result,
+				}); err != nil {
+					t.Errorf("encode health result: %v", err)
+				}
+			}()
+			d.checkPluginHealth(plugin)
+			requireDone(t, answered, "health request did not complete")
+		}
+
+		facts := func() int {
+			t.Helper()
+			events, err := d.store.BusEventsSince(0, 100)
+			if err != nil {
+				t.Fatalf("BusEventsSince: %v", err)
+			}
+			count := 0
+			for _, ev := range events {
+				if ev.Name == FactPluginHealthChanged && ev.Subject == "health-provider" {
+					count++
+				}
+			}
+			return count
+		}
+
+		// unknown -> healthy is a move; staying healthy is not.
+		poll(pluginHealthResult{OK: true})
+		poll(pluginHealthResult{OK: true})
+		poll(pluginHealthResult{OK: true})
+		if got := facts(); got != 1 {
+			t.Fatalf("three healthy polls published %d facts, want 1", got)
+		}
+
+		poll(pluginHealthResult{OK: false, Message: "provider down"})
+		poll(pluginHealthResult{OK: false, Message: "provider down"})
+		if got := facts(); got != 2 {
+			t.Fatalf("after two identical unhealthy polls: %d facts, want 2", got)
+		}
+
+		// The reason moving is a move even while the status holds.
+		poll(pluginHealthResult{OK: false, Message: "worktree provider timed out"})
+		if got := facts(); got != 3 {
+			t.Fatalf("a new unhealthy message published %d facts, want 3", got)
+		}
+
+		poll(pluginHealthResult{OK: true})
+		if got := facts(); got != 4 {
+			t.Fatalf("recovery published %d facts, want 4", got)
+		}
+		if status, _, _ := plugin.healthSnapshot(); status != "healthy" {
+			t.Fatalf("health status=%q, want healthy", status)
+		}
+
+		_ = client.Close()
+		requireDone(t, done, "health provider connection did not close")
+	})
+}
+
 func startPluginPipe(t *testing.T, d *Daemon, name string, surfaces []string) (net.Conn, <-chan struct{}) {
 	return startPluginPipeGeneration(t, d, name, surfaces, 1)
 }


### PR DESCRIPTION
Every connected plugin is polled for health every 15 seconds, and until now every
poll published a `plugin.health.changed` fact whether or not the answer had
moved. That fact is not cheap: the hub projection rebuilds the plugin catalog,
which re-scans both plugin directories from disk, re-sends the whole plugin list
to every open window, and the poll writes a log line — 5,760 events per plugin
per day with nothing to say. On the measured machine it was the loudest producer
on an idle daemon.

This is what the measurement behind `docs/plans/2026-08-10-projection-coalescing.md`
found: 14,919 gaps of ~14s in the bus log, all from one plugin, all identical.
The conclusion there was to fix the producer rather than build coalescing
machinery in the projection layer, and that is what this does — the same rule
AGENTS.md now states as "idle systems must be idle".

## What changed

`setHealth` reports whether the observation moved, comparing status and message
only. The check timestamp is deliberately not part of that answer: it advances
on every poll and no client renders it, so gating on it would publish forever
while nothing changes. `reportPluginHealth` is the single seam every poll verdict
goes through, and it publishes (and logs) only the ones that moved.

`last_health_at` still advances every 15s in the daemon's own state, so
`attn plugin list` still shows when a plugin was last checked. It is just not a
reason to wake the wire.

## Real signals still surface

- **A plugin whose verdict changes** — healthy → unhealthy, or unhealthy with a
  new message — publishes on the very next poll, exactly as before.
- **A crash** does not depend on the poll at all: the process dies, the
  supervisor moves the plugin's phase (`connected` → `backoff` → `starting` →
  `connected`) and each transition publishes `plugin.health.changed` through the
  supervisor's `onChange`, alongside the connect/disconnect facts. Recovery
  arrives the same way, and the first poll after a restart publishes too,
  because a fresh connection starts from "has not been checked".
- The one case this cannot see is a plugin that goes unhealthy and back between
  two polls without its process dying — and a 15-second sampler never could;
  that is unchanged.

## Receipt: idle daemon, `plugin.health.changed` over 300s

Same profile, same machine, same two bundled plugins connected (`attn-pi`,
`attn-opencode`), nothing else running, counted from the `bus_events` table:

| | facts in 300s | per plugin |
|---|---|---|
| before (`main`) | **42** | 21 (one per 15s poll) |
| after | **0** | 0 |

Extrapolated: 5,760 facts/day/plugin → 0 while a plugin's health is steady.

## Verification

- `TestDaemon_PluginHealthPublishesOnlyWhenItMoves` (synctest, pipe-backed
  plugin) drives repeated healthy polls, an unhealthy verdict repeated, a
  changed unhealthy message, and a recovery, asserting the fact count after
  each. Mutation-checked: reverting the gate fails it.
- Live on an isolated profile installed from this branch, with the app running:
  Settings → Plugins renders `attn-opencode` as DEGRADED / UNHEALTHY with its
  message and `attn-pi` as healthy, and the daemon log shows publishes only at
  the connect handshake and the first poll verdict, then silence.

https://claude.ai/code/session_01XyiRXwGmqAZaEX8Dyy4E32
