### PR TITLE
fix(tickets): give the board feed its own slim row

### DIFF
--- a/app/src/components/PaneTicketChip.test.tsx
+++ b/app/src/components/PaneTicketChip.test.tsx
@@ -1,23 +1,18 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { PaneTicketChip } from './PaneTicketChip';
-import type { Ticket } from '../hooks/useDaemonSocket';
+import type { TicketRow } from '../hooks/useDaemonSocket';
 import { TicketStatus } from '../types/generated';
 
-function makeTicket(overrides: Partial<Ticket> = {}): Ticket {
+function makeTicket(overrides: Partial<TicketRow> = {}): TicketRow {
   return {
     id: 'store-migration',
     title: 'Migrate the store',
-    description: '',
     status: TicketStatus.Working,
     assignee: 'sess-1',
     cwd: '/repo',
     last_agent_id: 'codex',
-    project_id: '',
-    created_at: '2026-06-27T10:00:00Z',
     updated_at: '2026-06-27T10:05:00Z',
-    activity: [],
-    artifacts: [],
     ...overrides,
   };
 }

--- a/app/src/components/PaneTicketChip.tsx
+++ b/app/src/components/PaneTicketChip.tsx
@@ -1,5 +1,5 @@
 import './PaneTicketChip.css';
-import type { Ticket } from '../hooks/useDaemonSocket';
+import type { TicketRow } from '../hooks/useDaemonSocket';
 
 // A clickable chip in the agent pane header (.workspace-pane-header) for the
 // ticket bound to that session. It carries a status-tinted rule (via
@@ -19,7 +19,7 @@ export function PaneTicketChip({
   sessionId,
   onToggle,
 }: {
-  ticket: Ticket;
+  ticket: TicketRow;
   unread: boolean;
   open: boolean;
   sessionId: string;

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -29,7 +29,7 @@ import { HeaderSettlingIndicator } from '../SettlingIndicator';
 import { HeaderPresentationChip } from '../PresentationChip';
 import { PaneTicketChip } from '../PaneTicketChip';
 import { TicketDetailPanel } from '../TicketDetailPanel';
-import type { Ticket } from '../../hooks/useDaemonSocket';
+import type { Ticket, TicketRow } from '../../hooks/useDaemonSocket';
 import { useEscapeStack } from '../../hooks/useEscapeStack';
 import type { Presentation } from '../../types/generated';
 import { useGhosttyPaneRuntime } from './useGhosttyPaneRuntime';
@@ -136,7 +136,7 @@ interface SessionTerminalWorkspaceProps {
     presentation?: Presentation;
     // The board row for the ticket bound to this session (assignee == id), when
     // one exists. Drives the pane-header ticket chip + in-pane overlay.
-    ticket?: Ticket;
+    ticket?: TicketRow;
   }>;
   // Daemon-facing ticket actions, threaded straight into the overlay's
   // TicketDetailPanel. Optional so a workspace without ticket wiring still

--- a/app/src/components/TicketBoardPanel.test.tsx
+++ b/app/src/components/TicketBoardPanel.test.tsx
@@ -8,23 +8,18 @@ import {
   groupTicketsByColumn,
   STATUS_COLUMNS,
 } from './TicketBoardPanel';
-import type { Ticket } from '../hooks/useDaemonSocket';
+import type { TicketRow } from '../hooks/useDaemonSocket';
 import { TicketStatus } from '../types/generated';
 
-function makeTicket(overrides: Partial<Ticket> = {}): Ticket {
+function makeTicket(overrides: Partial<TicketRow> = {}): TicketRow {
   return {
     id: 'tk-1',
     title: 'A ticket',
-    description: '',
     status: TicketStatus.Todo,
     assignee: 'sess-1',
     cwd: '/repo',
     last_agent_id: 'codex',
-    project_id: '',
-    created_at: '2026-06-27T10:00:00Z',
     updated_at: '2026-06-27T10:05:00Z',
-    activity: [],
-    artifacts: [],
     ...overrides,
   };
 }

--- a/app/src/components/TicketBoardPanel.tsx
+++ b/app/src/components/TicketBoardPanel.tsx
@@ -1,12 +1,12 @@
 import { useMemo, useState } from 'react';
-import type { Ticket } from '../hooks/useDaemonSocket';
+import type { TicketRow } from '../hooks/useDaemonSocket';
 import { TicketStatus } from '../types/generated';
 import { isTicketOrphaned } from '../utils/ticketOrphan';
 import './TicketBoardPanel.css';
 
 export type BoardFilter = 'all' | 'blocked' | 'in_review' | 'closed_today';
 
-type TicketStatusValue = Ticket['status'];
+type TicketStatusValue = TicketRow['status'];
 
 /** Statuses that own a flow column (terminal-bad statuses do not — they fold into Done). */
 type FlowStatus =
@@ -85,7 +85,7 @@ export function relativeTime(iso: string, now: Date = new Date()): string {
 }
 
 /** Narrow the ticket set per the active filter BEFORE bucketing, so per-column counts reflect what is shown. */
-export function applyFilter(tickets: Ticket[], filter: BoardFilter, now: Date = new Date()): Ticket[] {
+export function applyFilter(tickets: TicketRow[], filter: BoardFilter, now: Date = new Date()): TicketRow[] {
   return (tickets ?? []).filter((t) => {
     if (filter === 'blocked') return t.status === 'blocked';
     if (filter === 'in_review') return t.status === 'in_review';
@@ -99,9 +99,9 @@ export interface BoardColumnData {
   label: string;
   empty: string;
   /** Cards for this column's own status, preserving incoming order (created_at desc). */
-  cards: Ticket[];
+  cards: TicketRow[];
   /** Only populated for the Done column: terminal-bad tickets in the CLOSED sub-lane. */
-  terminalBad: Ticket[];
+  terminalBad: TicketRow[];
 }
 
 /**
@@ -109,7 +109,7 @@ export interface BoardColumnData {
  * are attached to the Done column's `terminalBad` lane rather than getting a
  * column of their own. Pure and side-effect free.
  */
-export function groupTicketsByColumn(visible: Ticket[]): BoardColumnData[] {
+export function groupTicketsByColumn(visible: TicketRow[]): BoardColumnData[] {
   const terminalBad = visible.filter((t) => TERMINAL_BAD_STATUSES.includes(t.status));
   return STATUS_COLUMNS.map((col) => ({
     status: col.status,
@@ -123,7 +123,7 @@ export function groupTicketsByColumn(visible: Ticket[]): BoardColumnData[] {
 export interface TicketBoardPanelProps {
   isOpen: boolean;
   /** useDaemonStore().tickets — non-archived, created_at desc. Read-only. */
-  tickets: Ticket[];
+  tickets: TicketRow[];
   /** App.tsx: setSelectedTicketId(id) + openDockPanel('ticketDetail'). */
   onOpenTicket: (ticketId: string) => void;
   /** closeDockPanel('board'). */
@@ -250,7 +250,7 @@ export function TicketBoardPanel({ isOpen, tickets = [], onOpenTicket, onClose }
 }
 
 interface BoardCardProps {
-  ticket: Ticket;
+  ticket: TicketRow;
   index: number;
   onOpen: (ticketId: string) => void;
   terminalBad?: boolean;

--- a/app/src/components/TicketBoardSurface.tsx
+++ b/app/src/components/TicketBoardSurface.tsx
@@ -1,12 +1,12 @@
 import FocusTrap from 'focus-trap-react';
-import type { Ticket } from '../hooks/useDaemonSocket';
+import type { TicketRow } from '../hooks/useDaemonSocket';
 import { useEscapeStack } from '../hooks/useEscapeStack';
 import { TicketBoardPanel } from './TicketBoardPanel';
 import './TicketBoardSurface.css';
 
 export interface TicketBoardSurfaceProps {
   isOpen: boolean;
-  tickets: Ticket[];
+  tickets: TicketRow[];
   onOpenTicket: (ticketId: string) => void;
   onClose: () => void;
 }

--- a/app/src/components/TicketDetailPanel.tsx
+++ b/app/src/components/TicketDetailPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { open } from '@tauri-apps/plugin-dialog';
-import type { Ticket } from '../hooks/useDaemonSocket';
+import type { Ticket, TicketRow } from '../hooks/useDaemonSocket';
 import { isTicketOrphaned } from '../utils/ticketOrphan';
 import { writeClipboardText } from '../utils/clipboardBridge';
 import { Markdown } from './Markdown';
@@ -12,7 +12,7 @@ interface TicketDetailPanelProps {
   // The bare board row for this ticket (from the store). It gives an instant
   // header while the full record loads, and its updated_at drives a live
   // re-fetch when the ticket changes under an open panel.
-  ticketRow?: Ticket;
+  ticketRow?: TicketRow;
   fetchTicket: (ticketId: string) => Promise<Ticket>;
   // Chief/user actions (slice 4c). Optional so the panel can render read-only
   // when an owner does not wire them. Each resolves once the daemon confirms;

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -20,6 +20,7 @@ import type {
   Task as GeneratedTask,
   Notification as GeneratedNotification,
   Ticket as GeneratedTicket,
+  TicketRow as GeneratedTicketRow,
   MarkdownAnnotation,
   Presentation,
   PresentationRound,
@@ -112,6 +113,9 @@ export interface PastConversationsResult {
 }
 
 export type Ticket = GeneratedTicket;
+// The board feed's row. Slimmer than Ticket on purpose: the brief, the history
+// thread and the artifacts come from a read by id, not from a whole-board push.
+export type TicketRow = GeneratedTicketRow;
 export type DaemonWorkspace = GeneratedWorkspaceSnapshot;
 export type DaemonPR = GeneratedPR;
 export type DaemonWorktree = GeneratedWorktree;
@@ -226,7 +230,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '224';
+export const PROTOCOL_VERSION = '225';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a
@@ -595,9 +599,9 @@ interface UseDaemonSocketOptions {
   // are root-relative; origin is agent|ui|external. Mirrors onNotebookChanged for
   // the generic filesystem surface (fs_changed).
   onFsChanged?: (origin: string, paths: string[], root: string) => void;
-  // Fired with the non-archived ticket board (bare rows) on initial_state and on
+  // Fired with the non-archived ticket board (slim rows) on initial_state and on
   // every tickets_updated broadcast. The detail view fetches full records itself.
-  onTicketsUpdate?: (tickets: Ticket[]) => void;
+  onTicketsUpdate?: (tickets: TicketRow[]) => void;
   // Fired when a presentation is created or its status/latest-round state changes.
   onPresentationAdded?: (presentation: Presentation) => void;
   onPresentationUpdated?: (presentation: Presentation) => void;

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -4,7 +4,7 @@ import { invoke, isTauri } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import type { Session } from '../store/sessions';
 import type { Presentation } from '../types/generated';
-import type { Ticket } from './useDaemonSocket';
+import type { TicketRow } from './useDaemonSocket';
 import type { SessionAgent } from '../types/sessionAgent';
 import type { TerminalSplitDirection } from '../types/workspace';
 import { SHORTCUTS, type ShortcutId, type Combo, isChord } from '../shortcuts/registry';
@@ -103,7 +103,7 @@ interface UseUiAutomationBridgeArgs {
   // the live ticket rows; openDockPanel above is reused to mount the dock.
   openTicketDetail?: (ticketId: string) => void;
   closeTicketDetail?: () => void;
-  tickets?: Ticket[];
+  tickets?: TicketRow[];
   // Automations panel (profile-level). Mutation verbs drive the real panel
   // controls (toggle/run-now/select), same rationale as the ticket panel
   // above; the bridge only needs to open the dock and read the rendered DOM.

--- a/app/src/store/daemonSessions.ts
+++ b/app/src/store/daemonSessions.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { DaemonSession, DaemonPR, RepoState, AuthorState, Ticket } from '../hooks/useDaemonSocket';
+import { DaemonSession, DaemonPR, RepoState, AuthorState, TicketRow } from '../hooks/useDaemonSocket';
 
 interface DaemonStore {
   // Sessions from daemon (attn-tracked sessions)
@@ -8,8 +8,8 @@ interface DaemonStore {
 
   // Work-tracker board: non-archived tickets (bare rows). The detail view fetches
   // the full record on demand via get_ticket.
-  tickets: Ticket[];
-  setTickets: (tickets: Ticket[]) => void;
+  tickets: TicketRow[];
+  setTickets: (tickets: TicketRow[]) => void;
 
   // PRs from daemon
   prs: DaemonPR[];

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
+//   import { Convert, ActivityStatusMessage, ActivityStatusResult, ActivityStatusSession, AddEndpointMessage, AgentAttachMessage, AgentClearQueueMessage, AgentEventMessage, AgentHistoryMessage, AgentPromptMessage, AgentSetModelMessage, AgentToolDetailMessage, ApprovePRMessage, AttachBlock, AttachPolicy, AttachResultMessage, AttachSessionMessage, AttachSnapshot, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationApplyResultMessage, AutomationCleanupMessage, AutomationCleanupResultMessage, AutomationDefinitionGetMessage, AutomationDefinitionResultMessage, AutomationDefinitionSummary, AutomationDefinitionsGetMessage, AutomationDefinitionsResultMessage, AutomationDeleteMessage, AutomationDeleteResultMessage, AutomationRunMessage, AutomationRunResultMessage, AutomationRunSummary, AutomationRunsGetMessage, AutomationRunsResultMessage, AutomationSetEnabledMessage, AutomationSetEnabledResultMessage, AutomationValidateMessage, AutomationValidateResultMessage, AutomationsChangedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, BusConsumerStatus, BusHealthEntry, BusProducerStatus, BusSetConsumerEnabledMessage, BusSetConsumerEnabledResultMessage, BusStatusGetMessage, BusStatusResultMessage, CancelCountdownMessage, ChiefOfStaffResultMessage, ClearSessionActivityMessage, ClearSessionsMessage, ClearWarningsMessage, ClientEvictionNoticeMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, DocCollectionsMessage, DocCollectionsResult, DocCountMessage, DocCountResult, DocDefineMessage, DocDefineResult, DocDeleteMessage, DocDeleteResult, DocGetMessage, DocGetResult, DocPutMessage, DocPutResult, DocQueryMessage, DocQueryResult, DocSubscribeMessage, DocSubscribeResult, DocUndefineMessage, DocUndefineResult, DocumentCollectionSchema, DocumentConflict, DocumentFieldSpec, DocumentFilter, DocumentQuery, DocumentRevision, DocumentSort, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileActivity, FileDiffResultMessage, FilesEditedMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetKittyImageMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, HookCompactionMessage, HookNotificationMessage, HookStopFailureMessage, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, KittyImageResultMessage, KittyPlacement, KittyPlacementsMessage, ListBranchesMessage, ListEndpointsMessage, ListPastConversationsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationSeverity, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PastConversation, PastConversationsResultMessage, PathInspection, PinSessionMessage, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentFilesMessage, RecentFilesResultMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, ReloadSessionMessage, ReloadSessionResultMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionAnnotation, SessionAnnotationsClearMessage, SessionAnnotationsClearResultMessage, SessionAnnotationsGetMessage, SessionAnnotationsGetResultMessage, SessionAnnotationsSaveMessage, SessionAnnotationsSaveResultMessage, SessionAnnotationsSubmitMessage, SessionAnnotationsSubmitResultMessage, SessionContextWindowCapResultMessage, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionMessage, SessionMessagesGetMessage, SessionMessagesGetResultMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetClientPresenceMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionContextWindowCapMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SettleTurnMessage, SnoozeTurnMessage, SpawnResultMessage, SpawnSessionMessage, StateExplainEntry, StateExplainMessage, StateExplainResult, StateMessage, StopMessage, StoredDocument, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, TerminalPointerActivityMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketRow, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WakeTurnMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./generated";
 //
 //   const activityStatusMessage = Convert.toActivityStatusMessage(json);
 //   const activityStatusResult = Convert.toActivityStatusResult(json);
@@ -388,6 +388,7 @@
 //   const ticketResultMessage = Convert.toTicketResultMessage(json);
 //   const ticketResumeMessage = Convert.toTicketResumeMessage(json);
 //   const ticketResumeResultMessage = Convert.toTicketResumeResultMessage(json);
+//   const ticketRow = Convert.toTicketRow(json);
 //   const ticketShowMessage = Convert.toTicketShowMessage(json);
 //   const ticketShowResult = Convert.toTicketShowResult(json);
 //   const ticketStatus = Convert.toTicketStatus(json);
@@ -2986,33 +2987,15 @@ export interface RepoElement {
 }
 
 export interface TicketElement {
-    activity:          ActivityElement[];
-    archived_at?:      string;
-    artifacts:         ArtifactElement[];
-    assignee:          string;
-    closed_at?:        string;
-    created_at:        string;
-    cwd:               string;
-    description:       string;
-    id:                string;
-    last_agent_id:     string;
-    latest_event_seq?: number;
-    project_id:        string;
-    reconciled_at?:    string;
-    status:            TicketStatus;
-    title:             string;
-    updated_at:        string;
-    [property: string]: any;
-}
-
-export interface ActivityElement {
-    author:       string;
-    comment?:     string;
-    created_at:   string;
-    from_status?: TicketStatus;
-    id:           number;
-    kind:         TicketActivityKind;
-    to_status?:   TicketStatus;
+    assignee:       string;
+    closed_at?:     string;
+    cwd:            string;
+    id:             string;
+    last_agent_id:  string;
+    reconciled_at?: string;
+    status:         TicketStatus;
+    title:          string;
+    updated_at:     string;
     [property: string]: any;
 }
 
@@ -3024,19 +3007,6 @@ export enum TicketStatus {
     InReview = "in_review",
     Todo = "todo",
     Working = "working",
-}
-
-export enum TicketActivityKind {
-    Attach = "attach",
-    Comment = "comment",
-    StatusChange = "status_change",
-}
-
-export interface ArtifactElement {
-    filename:      string;
-    notebook_path: string;
-    path:          string;
-    [property: string]: any;
 }
 
 export interface WarningElement {
@@ -4863,6 +4833,13 @@ export interface TicketAttachResultObject {
     [property: string]: any;
 }
 
+export interface ArtifactElement {
+    filename:      string;
+    notebook_path: string;
+    path:          string;
+    [property: string]: any;
+}
+
 export interface CatchUp {
     events:    EventObject[];
     ticket_id: string;
@@ -4911,12 +4888,49 @@ export interface TicketInboxResultObject {
 }
 
 export interface TicketListResultObject {
-    tickets: TicketElement[];
+    tickets: TicketObject[];
     [property: string]: any;
 }
 
+export interface TicketObject {
+    activity:          ActivityElement[];
+    archived_at?:      string;
+    artifacts:         ArtifactElement[];
+    assignee:          string;
+    closed_at?:        string;
+    created_at:        string;
+    cwd:               string;
+    description:       string;
+    id:                string;
+    last_agent_id:     string;
+    latest_event_seq?: number;
+    project_id:        string;
+    reconciled_at?:    string;
+    status:            TicketStatus;
+    title:             string;
+    updated_at:        string;
+    [property: string]: any;
+}
+
+export interface ActivityElement {
+    author:       string;
+    comment?:     string;
+    created_at:   string;
+    from_status?: TicketStatus;
+    id:           number;
+    kind:         TicketActivityKind;
+    to_status?:   TicketStatus;
+    [property: string]: any;
+}
+
+export enum TicketActivityKind {
+    Attach = "attach",
+    Comment = "comment",
+    StatusChange = "status_change",
+}
+
 export interface TicketShowResultObject {
-    ticket: TicketElement;
+    ticket: TicketObject;
     [property: string]: any;
 }
 
@@ -5955,7 +5969,7 @@ export enum TicketListMessageCmd {
 }
 
 export interface TicketListResult {
-    tickets: TicketElement[];
+    tickets: TicketObject[];
     [property: string]: any;
 }
 
@@ -5964,7 +5978,7 @@ export interface TicketResultMessage {
     event:      TicketResultMessageEvent;
     request_id: string;
     success:    boolean;
-    ticket?:    TicketElement;
+    ticket?:    TicketObject;
     [property: string]: any;
 }
 
@@ -5998,6 +6012,19 @@ export enum TicketResumeResultMessageEvent {
     TicketResumeResult = "ticket_resume_result",
 }
 
+export interface TicketRow {
+    assignee:       string;
+    closed_at?:     string;
+    cwd:            string;
+    id:             string;
+    last_agent_id:  string;
+    reconciled_at?: string;
+    status:         TicketStatus;
+    title:          string;
+    updated_at:     string;
+    [property: string]: any;
+}
+
 export interface TicketShowMessage {
     cmd:                TicketShowMessageCmd;
     source_session_id?: string;
@@ -6010,7 +6037,7 @@ export enum TicketShowMessageCmd {
 }
 
 export interface TicketShowResult {
-    ticket: TicketElement;
+    ticket: TicketObject;
     [property: string]: any;
 }
 
@@ -6225,7 +6252,7 @@ export interface WebSocketEvent {
     stash_ref?:                string;
     success?:                  boolean;
     target_path?:              string;
-    ticket?:                   TicketElement;
+    ticket?:                   TicketObject;
     tickets?:                  TicketElement[];
     tile_id?:                  string;
     tile_kind?:                string;
@@ -9984,6 +10011,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("TicketResumeResultMessage")), null, 2);
     }
 
+    public static toTicketRow(json: string): TicketRow {
+        return cast(JSON.parse(json), r("TicketRow"));
+    }
+
+    public static ticketRowToJson(value: TicketRow): string {
+        return JSON.stringify(uncast(value, r("TicketRow")), null, 2);
+    }
+
     public static toTicketShowMessage(json: string): TicketShowMessage {
         return cast(JSON.parse(json), r("TicketShowMessage"));
     }
@@ -12270,36 +12305,15 @@ const typeMap: any = {
         { json: "repo", js: "repo", typ: "" },
     ], "any"),
     "TicketElement": o([
-        { json: "activity", js: "activity", typ: a(r("ActivityElement")) },
-        { json: "archived_at", js: "archived_at", typ: u(undefined, "") },
-        { json: "artifacts", js: "artifacts", typ: a(r("ArtifactElement")) },
         { json: "assignee", js: "assignee", typ: "" },
         { json: "closed_at", js: "closed_at", typ: u(undefined, "") },
-        { json: "created_at", js: "created_at", typ: "" },
         { json: "cwd", js: "cwd", typ: "" },
-        { json: "description", js: "description", typ: "" },
         { json: "id", js: "id", typ: "" },
         { json: "last_agent_id", js: "last_agent_id", typ: "" },
-        { json: "latest_event_seq", js: "latest_event_seq", typ: u(undefined, 0) },
-        { json: "project_id", js: "project_id", typ: "" },
         { json: "reconciled_at", js: "reconciled_at", typ: u(undefined, "") },
         { json: "status", js: "status", typ: r("TicketStatus") },
         { json: "title", js: "title", typ: "" },
         { json: "updated_at", js: "updated_at", typ: "" },
-    ], "any"),
-    "ActivityElement": o([
-        { json: "author", js: "author", typ: "" },
-        { json: "comment", js: "comment", typ: u(undefined, "") },
-        { json: "created_at", js: "created_at", typ: "" },
-        { json: "from_status", js: "from_status", typ: u(undefined, r("TicketStatus")) },
-        { json: "id", js: "id", typ: 0 },
-        { json: "kind", js: "kind", typ: r("TicketActivityKind") },
-        { json: "to_status", js: "to_status", typ: u(undefined, r("TicketStatus")) },
-    ], "any"),
-    "ArtifactElement": o([
-        { json: "filename", js: "filename", typ: "" },
-        { json: "notebook_path", js: "notebook_path", typ: "" },
-        { json: "path", js: "path", typ: "" },
     ], "any"),
     "WarningElement": o([
         { json: "code", js: "code", typ: "" },
@@ -13417,6 +13431,11 @@ const typeMap: any = {
         { json: "state", js: "state", typ: r("TicketStatus") },
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
+    "ArtifactElement": o([
+        { json: "filename", js: "filename", typ: "" },
+        { json: "notebook_path", js: "notebook_path", typ: "" },
+        { json: "path", js: "path", typ: "" },
+    ], "any"),
     "CatchUp": o([
         { json: "events", js: "events", typ: a(r("EventObject")) },
         { json: "ticket_id", js: "ticket_id", typ: "" },
@@ -13446,10 +13465,37 @@ const typeMap: any = {
         { json: "last_user_activity_at", js: "last_user_activity_at", typ: u(undefined, "") },
     ], "any"),
     "TicketListResultObject": o([
-        { json: "tickets", js: "tickets", typ: a(r("TicketElement")) },
+        { json: "tickets", js: "tickets", typ: a(r("TicketObject")) },
+    ], "any"),
+    "TicketObject": o([
+        { json: "activity", js: "activity", typ: a(r("ActivityElement")) },
+        { json: "archived_at", js: "archived_at", typ: u(undefined, "") },
+        { json: "artifacts", js: "artifacts", typ: a(r("ArtifactElement")) },
+        { json: "assignee", js: "assignee", typ: "" },
+        { json: "closed_at", js: "closed_at", typ: u(undefined, "") },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "cwd", js: "cwd", typ: "" },
+        { json: "description", js: "description", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "last_agent_id", js: "last_agent_id", typ: "" },
+        { json: "latest_event_seq", js: "latest_event_seq", typ: u(undefined, 0) },
+        { json: "project_id", js: "project_id", typ: "" },
+        { json: "reconciled_at", js: "reconciled_at", typ: u(undefined, "") },
+        { json: "status", js: "status", typ: r("TicketStatus") },
+        { json: "title", js: "title", typ: "" },
+        { json: "updated_at", js: "updated_at", typ: "" },
+    ], "any"),
+    "ActivityElement": o([
+        { json: "author", js: "author", typ: "" },
+        { json: "comment", js: "comment", typ: u(undefined, "") },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "from_status", js: "from_status", typ: u(undefined, r("TicketStatus")) },
+        { json: "id", js: "id", typ: 0 },
+        { json: "kind", js: "kind", typ: r("TicketActivityKind") },
+        { json: "to_status", js: "to_status", typ: u(undefined, r("TicketStatus")) },
     ], "any"),
     "TicketShowResultObject": o([
-        { json: "ticket", js: "ticket", typ: r("TicketElement") },
+        { json: "ticket", js: "ticket", typ: r("TicketObject") },
     ], "any"),
     "TicketStatusResultObject": o([
         { json: "applied", js: "applied", typ: true },
@@ -14068,14 +14114,14 @@ const typeMap: any = {
         { json: "status", js: "status", typ: u(undefined, "") },
     ], "any"),
     "TicketListResult": o([
-        { json: "tickets", js: "tickets", typ: a(r("TicketElement")) },
+        { json: "tickets", js: "tickets", typ: a(r("TicketObject")) },
     ], "any"),
     "TicketResultMessage": o([
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("TicketResultMessageEvent") },
         { json: "request_id", js: "request_id", typ: "" },
         { json: "success", js: "success", typ: true },
-        { json: "ticket", js: "ticket", typ: u(undefined, r("TicketElement")) },
+        { json: "ticket", js: "ticket", typ: u(undefined, r("TicketObject")) },
     ], "any"),
     "TicketResumeMessage": o([
         { json: "cmd", js: "cmd", typ: r("TicketResumeMessageCmd") },
@@ -14091,13 +14137,24 @@ const typeMap: any = {
         { json: "success", js: "success", typ: true },
         { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
     ], "any"),
+    "TicketRow": o([
+        { json: "assignee", js: "assignee", typ: "" },
+        { json: "closed_at", js: "closed_at", typ: u(undefined, "") },
+        { json: "cwd", js: "cwd", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "last_agent_id", js: "last_agent_id", typ: "" },
+        { json: "reconciled_at", js: "reconciled_at", typ: u(undefined, "") },
+        { json: "status", js: "status", typ: r("TicketStatus") },
+        { json: "title", js: "title", typ: "" },
+        { json: "updated_at", js: "updated_at", typ: "" },
+    ], "any"),
     "TicketShowMessage": o([
         { json: "cmd", js: "cmd", typ: r("TicketShowMessageCmd") },
         { json: "source_session_id", js: "source_session_id", typ: u(undefined, "") },
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
     "TicketShowResult": o([
-        { json: "ticket", js: "ticket", typ: r("TicketElement") },
+        { json: "ticket", js: "ticket", typ: r("TicketObject") },
     ], "any"),
     "TicketStatusResult": o([
         { json: "applied", js: "applied", typ: true },
@@ -14230,7 +14287,7 @@ const typeMap: any = {
         { json: "stash_ref", js: "stash_ref", typ: u(undefined, "") },
         { json: "success", js: "success", typ: u(undefined, true) },
         { json: "target_path", js: "target_path", typ: u(undefined, "") },
-        { json: "ticket", js: "ticket", typ: u(undefined, r("TicketElement")) },
+        { json: "ticket", js: "ticket", typ: u(undefined, r("TicketObject")) },
         { json: "tickets", js: "tickets", typ: u(undefined, a(r("TicketElement"))) },
         { json: "tile_id", js: "tile_id", typ: u(undefined, "") },
         { json: "tile_kind", js: "tile_kind", typ: u(undefined, "") },
@@ -15046,11 +15103,6 @@ const typeMap: any = {
         "todo",
         "working",
     ],
-    "TicketActivityKind": [
-        "attach",
-        "comment",
-        "status_change",
-    ],
     "WorkspaceLayoutPaneKind": [
         "agent",
     ],
@@ -15353,6 +15405,11 @@ const typeMap: any = {
         "created",
         "description_edited",
         "status_changed",
+    ],
+    "TicketActivityKind": [
+        "attach",
+        "comment",
+        "status_change",
     ],
     "WorkspaceContextMaintenanceAction": [
         "compact",

--- a/app/src/utils/ticketOrphan.ts
+++ b/app/src/utils/ticketOrphan.ts
@@ -1,4 +1,4 @@
-import type { Ticket } from '../hooks/useDaemonSocket';
+import type { TicketRow } from '../hooks/useDaemonSocket';
 
 /** Statuses where a dead owner no longer matters — the ticket is closed. */
 const TERMINAL_STATUSES = new Set<string>(['done', 'failed', 'crashed']);
@@ -12,7 +12,7 @@ const TERMINAL_STATUSES = new Set<string>(['done', 'failed', 'crashed']);
  * closed ticket does not need an owner.
  */
 export function isTicketOrphaned(
-  t: Pick<Ticket, 'status' | 'reconciled_at'> | null | undefined,
+  t: Pick<TicketRow, 'status' | 'reconciled_at'> | null | undefined,
 ): boolean {
   if (!t) return false;
   return Boolean(t.reconciled_at) && !TERMINAL_STATUSES.has(t.status);

--- a/app/src/utils/tickets.ts
+++ b/app/src/utils/tickets.ts
@@ -1,4 +1,4 @@
-import type { Ticket } from '../hooks/useDaemonSocket';
+import type { TicketRow } from '../hooks/useDaemonSocket';
 
 // The single home for the session -> bound-ticket rule: a ticket is bound to a
 // session when it is that session's assignee. Store rows are non-archived and
@@ -8,8 +8,8 @@ import type { Ticket } from '../hooks/useDaemonSocket';
 // Extracted from useUiAutomationBridge's `ticket_open_via_dashboard`, which now
 // reuses it, so the pane chip and the automation bridge resolve identically.
 export function boundTicketForSession(
-  tickets: Ticket[],
+  tickets: TicketRow[],
   sessionId: string,
-): Ticket | undefined {
+): TicketRow | undefined {
   return tickets.find((ticket) => ticket.assignee === sessionId);
 }

--- a/changelog.d/fix-tickets-slim-board-rows.yaml
+++ b/changelog.d/fix-tickets-slim-board-rows.yaml
@@ -1,0 +1,13 @@
+kind: fixed
+area: tickets
+change: >
+  The ticket board is no longer sent as a 220KB message. The board feed now
+  carries only what a board draws — title, column, owner, timestamps — instead
+  of every ticket's full brief, and a bulk ticket change sends one board update
+  instead of one per ticket. Opening a ticket still shows its full brief and
+  history, and `attn ticket list --json` still carries descriptions.
+symptom: >
+  Every ticket change re-sent the whole board to every open window, and 89% of
+  that message was delegation briefs that nothing on the board renders. A
+  connecting window received the same payload again as part of its startup
+  snapshot.

--- a/internal/daemon/bus_coalesce_test.go
+++ b/internal/daemon/bus_coalesce_test.go
@@ -51,6 +51,25 @@ func TestCoalesceSnapshotsKeepsDistinctSnapshotsSeparate(t *testing.T) {
 	}
 }
 
+// The board was the one whole-list projection outside the machinery: it pushed
+// its 200KB message per fact even inside a bulk block. It is a snapshot like
+// every other list, so it collapses like one.
+func TestCoalesceSnapshotsCollapsesTheTicketBoard(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	var boards int
+	d.ticketsBroadcastHook = func([]protocol.TicketRow) { boards++ }
+
+	d.coalesceSnapshots(func() {
+		for _, id := range []string{"tk-1", "tk-2", "tk-3", "tk-4", "tk-5"} {
+			d.publishTicketFact(FactTicketStatusChanged, id)
+		}
+	})
+
+	if boards != 1 {
+		t.Fatalf("five ticket facts in one bulk block pushed %d boards, want 1", boards)
+	}
+}
+
 func TestUncoalescedFactsPushOncePerFact(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	trace := wireRecorder(d)

--- a/internal/daemon/bus_test.go
+++ b/internal/daemon/bus_test.go
@@ -37,7 +37,7 @@ func TestTicketMutationPublishesAFactAndPushesTheBoardOnce(t *testing.T) {
 	t.Cleanup(d.stopEventBus)
 
 	var boards int
-	d.ticketsBroadcastHook = func([]protocol.Ticket) { boards++ }
+	d.ticketsBroadcastHook = func([]protocol.TicketRow) { boards++ }
 
 	now := time.Now()
 	if _, err := d.store.CreateTicket(store.Ticket{ID: "tk-1", Title: "work"}, "sess-a", now); err != nil {
@@ -301,7 +301,7 @@ func TestBoardStillPushesWhenTheBusAppendFails(t *testing.T) {
 	backing := rewireBusWithFailingAppend(t, d)
 
 	var boards int
-	d.ticketsBroadcastHook = func([]protocol.Ticket) { boards++ }
+	d.ticketsBroadcastHook = func([]protocol.TicketRow) { boards++ }
 
 	now := time.Now()
 	if _, err := d.store.CreateTicket(store.Ticket{ID: "tk-1", Title: "work"}, "sess-a", now); err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -395,7 +395,7 @@ type Daemon struct {
 	workflowEngineMu      sync.Mutex
 	workflowEngineConn    map[string]workflowEngineSink
 	workflowBroadcastHook func(*protocol.WorkflowRunUpdatedMessage) // optional, tests only
-	ticketsBroadcastHook  func([]protocol.Ticket)                   // optional, tests only
+	ticketsBroadcastHook  func([]protocol.TicketRow)                // optional, tests only
 
 	// automationsBroadcastHook mirrors workflowBroadcastHook for the automations
 	// WS surface (automations_broadcast.go): invoked before every

--- a/internal/daemon/ticket_actions_test.go
+++ b/internal/daemon/ticket_actions_test.go
@@ -227,7 +227,7 @@ func TestTicketChangeStatusBroadcastsBoard(t *testing.T) {
 	if board == nil {
 		t.Fatal("the status change fired no tickets_updated board push")
 	}
-	var moved *protocol.Ticket
+	var moved *protocol.TicketRow
 	for i := range board {
 		if board[i].ID == ticketID {
 			moved = &board[i]

--- a/internal/daemon/ticket_attach_test.go
+++ b/internal/daemon/ticket_attach_test.go
@@ -262,7 +262,7 @@ func TestTicketAttachNotifiesChiefAndBroadcasts(t *testing.T) {
 	}
 }
 
-func containsTicketID(tickets []protocol.Ticket, id string) bool {
+func containsTicketID(tickets []protocol.TicketRow, id string) bool {
 	for _, ticket := range tickets {
 		if ticket.ID == id {
 			return true

--- a/internal/daemon/ticket_board.go
+++ b/internal/daemon/ticket_board.go
@@ -14,12 +14,31 @@ import (
 // tickets_updated broadcast per mutation, and a get_ticket request/result for one
 // row's detail. Pushes carry bare rows so a busy board stays cheap.
 
-// ticketsForBroadcast is the payload of both initial_state and tickets_updated.
-func (d *Daemon) ticketsForBroadcast() []protocol.Ticket {
-	return d.ticketRows(store.TicketListFilter{})
+// ticketsForBroadcast is the payload of both initial_state and tickets_updated:
+// the whole non-archived board as slim rows. The brief stays off it — the board
+// is re-pushed on every ticket mutation and to every client on connect, and no
+// client renders a description from a row.
+func (d *Daemon) ticketsForBroadcast() []protocol.TicketRow {
+	if d.store == nil {
+		return nil
+	}
+	rows, err := d.store.ListTickets(store.TicketListFilter{})
+	if err != nil {
+		d.logf("list tickets: %v", err)
+		return nil
+	}
+	out := make([]protocol.TicketRow, 0, len(rows))
+	for _, t := range rows {
+		if t != nil {
+			out = append(out, ticketToProtocolRow(t))
+		}
+	}
+	return out
 }
 
-// ticketRows lists the board through a filter as bare wire rows, newest first.
+// ticketRows lists the board through a filter as full wire records without the
+// activity thread, newest first. This is the agent's board read (ticket_list),
+// which carries the brief; the app's feed uses ticketsForBroadcast.
 func (d *Daemon) ticketRows(filter store.TicketListFilter) []protocol.Ticket {
 	if d.store == nil {
 		return nil
@@ -94,22 +113,26 @@ func (d *Daemon) publishTicketFact(name, ticketID string) {
 }
 
 // projectTicketsUpdated re-pushes the whole non-archived board to every client.
+// Like every other whole-list projection it goes through projectSnapshot, so a
+// bulk ticket operation puts one board on the wire instead of one per ticket.
 func (d *Daemon) projectTicketsUpdated() {
 	if d.store == nil {
 		return
 	}
-	tickets := d.ticketsForBroadcast()
-	// TicketsUpdatedMessage is its own top-level event, so the wsHub's
-	// WebSocketEvent-only broadcastListener cannot see it; tests use this hook.
-	if d.ticketsBroadcastHook != nil {
-		d.ticketsBroadcastHook(tickets)
-	}
-	if d.wsHub == nil {
-		return
-	}
-	d.broadcastMessage(&protocol.TicketsUpdatedMessage{
-		Event:   protocol.EventTicketsUpdated,
-		Tickets: tickets,
+	d.projectSnapshot(snapshotTickets, func() {
+		tickets := d.ticketsForBroadcast()
+		// TicketsUpdatedMessage is its own top-level event, so the wsHub's
+		// WebSocketEvent-only broadcastListener cannot see it; tests use this hook.
+		if d.ticketsBroadcastHook != nil {
+			d.ticketsBroadcastHook(tickets)
+		}
+		if d.wsHub == nil {
+			return
+		}
+		d.broadcastMessage(&protocol.TicketsUpdatedMessage{
+			Event:   protocol.EventTicketsUpdated,
+			Tickets: tickets,
+		})
 	})
 }
 
@@ -169,6 +192,26 @@ func ticketToProtocol(t *store.Ticket) protocol.Ticket {
 		pt.Activity = append(pt.Activity, ticketActivityToProtocol(a))
 	}
 	return pt
+}
+
+// ticketToProtocolRow maps a store ticket to its board-feed row.
+func ticketToProtocolRow(t *store.Ticket) protocol.TicketRow {
+	row := protocol.TicketRow{
+		ID:          t.ID,
+		Title:       t.Title,
+		Status:      protocol.TicketStatus(t.Status),
+		Assignee:    t.Assignee,
+		Cwd:         t.Cwd,
+		LastAgentID: t.LastAgentID,
+		UpdatedAt:   t.UpdatedAt.Format(time.RFC3339),
+	}
+	if t.ClosedAt != nil {
+		row.ClosedAt = protocol.Ptr(t.ClosedAt.Format(time.RFC3339))
+	}
+	if t.ReconciledAt != nil {
+		row.ReconciledAt = protocol.Ptr(t.ReconciledAt.Format(time.RFC3339))
+	}
+	return row
 }
 
 func (d *Daemon) ticketToProtocolFull(t *store.Ticket) (protocol.Ticket, error) {

--- a/internal/daemon/ticket_board_test.go
+++ b/internal/daemon/ticket_board_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -26,7 +27,7 @@ func readTicketResult(t *testing.T, ch chan outboundMessage, target any) {
 }
 
 // ticketIDs collects the ids of a broadcast board feed, for membership assertions.
-func ticketIDs(tickets []protocol.Ticket) []string {
+func ticketIDs(tickets []protocol.TicketRow) []string {
 	ids := make([]string, 0, len(tickets))
 	for _, tk := range tickets {
 		ids = append(ids, tk.ID)
@@ -37,12 +38,12 @@ func ticketIDs(tickets []protocol.Ticket) []string {
 // captureTicketBroadcasts records every tickets_updated board push the daemon makes,
 // via the in-process hook, so a test can assert the post-mutation board push
 // deterministically. Returns an accessor for the most recent broadcast.
-func captureTicketBroadcasts(d *Daemon) (latest func() []protocol.Ticket) {
-	var broadcasts [][]protocol.Ticket
-	d.ticketsBroadcastHook = func(tickets []protocol.Ticket) {
+func captureTicketBroadcasts(d *Daemon) (latest func() []protocol.TicketRow) {
+	var broadcasts [][]protocol.TicketRow
+	d.ticketsBroadcastHook = func(tickets []protocol.TicketRow) {
 		broadcasts = append(broadcasts, tickets)
 	}
-	return func() []protocol.Ticket {
+	return func() []protocol.TicketRow {
 		if len(broadcasts) == 0 {
 			return nil
 		}
@@ -193,9 +194,9 @@ func artifactNames(artifacts []protocol.TicketArtifact) []string {
 	return names
 }
 
-// The board feed is the non-archived set, and each row is BARE — activity and
-// artifacts stay empty so a busy board is cheap to broadcast; the detail fetch
-// loads them.
+// The board feed is the non-archived set, and each row is SLIM — the brief, the
+// history thread and the artifacts belong to a read by id, so a busy board is
+// cheap to broadcast and cheap to bootstrap.
 func TestTicketsForBroadcastBareNonArchived(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	now := time.Now()
@@ -220,7 +221,87 @@ func TestTicketsForBroadcastBareNonArchived(t *testing.T) {
 	if len(board) != 1 || board[0].ID != "open-one" {
 		t.Fatalf("board = %+v, want only the non-archived open-one", board)
 	}
-	if len(board[0].Activity) != 0 || len(board[0].Artifacts) != 0 {
-		t.Fatalf("board row should be bare, got activity=%d artifacts=%d", len(board[0].Activity), len(board[0].Artifacts))
+}
+
+// The board row carries exactly what a board renders. The brief is the bulk of a
+// ticket and no client reads it off a row — it is fetched by id — so it must not
+// be on a message pushed to every client on every ticket mutation.
+func TestBoardRowCarriesTheBoardAndNotTheBrief(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	now := time.Now()
+	brief := strings.Repeat("a delegation brief nobody renders from a board row. ", 200)
+	if _, err := d.store.CreateTicket(store.Ticket{
+		ID:          "store-migration",
+		Title:       "Migrate the store",
+		Description: brief,
+		Status:      store.TicketStatusWorking,
+		Assignee:    "sess-1",
+		Cwd:         "/repo",
+		LastAgentID: "codex",
+	}, "chief-1", now); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := d.store.AddTicketComment("store-migration", "chief-1", "a note", now.Add(time.Minute)); err != nil {
+		t.Fatalf("comment: %v", err)
+	}
+
+	board := d.ticketsForBroadcast()
+	if len(board) != 1 {
+		t.Fatalf("board = %+v, want one row", board)
+	}
+	raw, err := json.Marshal(board[0])
+	if err != nil {
+		t.Fatalf("marshal row: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("unmarshal row: %v", err)
+	}
+	for _, field := range []string{"description", "activity", "artifacts"} {
+		if _, present := wire[field]; present {
+			t.Fatalf("board row carries %q: %s", field, raw)
+		}
+	}
+	if strings.Contains(string(raw), "delegation brief") {
+		t.Fatalf("the brief reached the board row: %s", raw)
+	}
+	// What the app does read off a row: the card, the orphan rule, the resume
+	// affordance, and updated_at (which drives the open detail view's re-fetch).
+	for field, want := range map[string]any{
+		"id":            "store-migration",
+		"title":         "Migrate the store",
+		"status":        string(store.TicketStatusWorking),
+		"assignee":      "sess-1",
+		"cwd":           "/repo",
+		"last_agent_id": "codex",
+	} {
+		if wire[field] != want {
+			t.Fatalf("row %s = %v, want %v", field, wire[field], want)
+		}
+	}
+	if wire["updated_at"] == "" || wire["updated_at"] == nil {
+		t.Fatalf("row is missing updated_at: %s", raw)
+	}
+}
+
+// Slimming the app's board feed must not reach the agent's board read: an agent
+// lists tickets to find work, and the brief is the work.
+func TestTicketListRowsStillCarryTheBrief(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	if _, err := d.store.CreateTicket(store.Ticket{
+		ID:          "store-migration",
+		Title:       "Migrate the store",
+		Description: "move the store to X",
+		Status:      store.TicketStatusTodo,
+	}, "chief-1", time.Now()); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	rows := d.ticketRows(store.TicketListFilter{})
+	if len(rows) != 1 {
+		t.Fatalf("rows = %+v, want one", rows)
+	}
+	if rows[0].Description != "move the store to X" {
+		t.Fatalf("ticket_list row description = %q, want the brief", rows[0].Description)
 	}
 }

--- a/internal/daemon/ticket_revive.go
+++ b/internal/daemon/ticket_revive.go
@@ -36,25 +36,30 @@ func (d *Daemon) reviveCrashedTicketsForSession(sessionID string) {
 	if len(tickets) == 0 {
 		return
 	}
-	for _, ticket := range tickets {
-		if ticket == nil {
-			continue
+	// One session can own several crashed tickets, so this is a bulk operation:
+	// every ticket still publishes its own fact, and the board they all re-push
+	// collapses to a single wire message.
+	d.coalesceSnapshots(func() {
+		for _, ticket := range tickets {
+			if ticket == nil {
+				continue
+			}
+			if _, err := d.store.SetTicketStatus(
+				ticket.ID,
+				store.TicketStatusWorking,
+				store.TicketAuthorAttn,
+				"session was reloaded and is running again",
+				time.Now(),
+			); err != nil {
+				d.logf("ticket revive for %s: %v", sessionID, err)
+				continue
+			}
+			d.logf("ticket %q revived: session %s is live again", ticket.ID, sessionID)
+			// attn authored the move; notify the chief/participants the work is back on.
+			d.notifyTicketObservers(ticket.ID)
+			// Each revived ticket is its own status change, so each publishes its own
+			// fact rather than one anonymous board refresh at the end.
+			d.publishTicketFact(FactTicketStatusChanged, ticket.ID)
 		}
-		if _, err := d.store.SetTicketStatus(
-			ticket.ID,
-			store.TicketStatusWorking,
-			store.TicketAuthorAttn,
-			"session was reloaded and is running again",
-			time.Now(),
-		); err != nil {
-			d.logf("ticket revive for %s: %v", sessionID, err)
-			continue
-		}
-		d.logf("ticket %q revived: session %s is live again", ticket.ID, sessionID)
-		// attn authored the move; notify the chief/participants the work is back on.
-		d.notifyTicketObservers(ticket.ID)
-		// Each revived ticket is its own status change, so each publishes its own
-		// fact rather than one anonymous board refresh at the end.
-		d.publishTicketFact(FactTicketStatusChanged, ticket.ID)
-	}
+	})
 }

--- a/internal/daemon/ticket_revive_test.go
+++ b/internal/daemon/ticket_revive_test.go
@@ -231,3 +231,40 @@ func TestRecoveryAdoptRevivesCrashedTicketToWorking(t *testing.T) {
 		t.Fatalf("status after adopt = %q, want working", ticket.Status)
 	}
 }
+
+// A session can own more than one crashed ticket. Each revival is its own status
+// change and publishes its own fact, but the board they all re-push is one list:
+// the client sees one board, not one per ticket.
+func TestReviveOfSeveralTicketsPushesTheBoardOnce(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	var boards int
+	d.ticketsBroadcastHook = func([]protocol.TicketRow) { boards++ }
+
+	now := time.Now()
+	for _, id := range []string{"tk-a", "tk-b", "tk-c"} {
+		if _, err := d.store.CreateTicket(store.Ticket{
+			ID: id, Title: id, Status: store.TicketStatusWorking, Assignee: "sess-1",
+		}, "chief-1", now); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+		if _, err := d.store.SetTicketStatus(id, store.TicketStatusCrashed, store.TicketAuthorAttn, "died", now); err != nil {
+			t.Fatalf("crash %s: %v", id, err)
+		}
+	}
+	boards = 0
+
+	d.reviveCrashedTicketsForSession("sess-1")
+
+	if boards != 1 {
+		t.Fatalf("reviving three tickets pushed %d boards, want 1", boards)
+	}
+	for _, id := range []string{"tk-a", "tk-b", "tk-c"} {
+		ticket, err := d.store.GetTicket(id)
+		if err != nil || ticket == nil {
+			t.Fatalf("GetTicket %s: %v, %v", id, ticket, err)
+		}
+		if ticket.Status != store.TicketStatusWorking {
+			t.Fatalf("%s status = %q, want working", id, ticket.Status)
+		}
+	}
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "224"
+const ProtocolVersion = "225"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -2715,7 +2715,7 @@ type InitialStateMessage struct {
 	SourceFingerprint *string `json:"source_fingerprint,omitempty,omitzero"`
 
 	// Tickets corresponds to the JSON schema field "tickets".
-	Tickets []Ticket `json:"tickets,omitempty,omitzero"`
+	Tickets []TicketRow `json:"tickets,omitempty,omitzero"`
 
 	// Warnings corresponds to the JSON schema field "warnings".
 	Warnings []DaemonWarning `json:"warnings,omitempty,omitzero"`
@@ -6161,6 +6161,35 @@ type TicketResumeResultMessage struct {
 	WorkspaceID *string `json:"workspace_id,omitempty,omitzero"`
 }
 
+type TicketRow struct {
+	// Assignee corresponds to the JSON schema field "assignee".
+	Assignee string `json:"assignee"`
+
+	// ClosedAt corresponds to the JSON schema field "closed_at".
+	ClosedAt *string `json:"closed_at,omitempty,omitzero"`
+
+	// Cwd corresponds to the JSON schema field "cwd".
+	Cwd string `json:"cwd"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
+
+	// LastAgentID corresponds to the JSON schema field "last_agent_id".
+	LastAgentID string `json:"last_agent_id"`
+
+	// ReconciledAt corresponds to the JSON schema field "reconciled_at".
+	ReconciledAt *string `json:"reconciled_at,omitempty,omitzero"`
+
+	// Status corresponds to the JSON schema field "status".
+	Status TicketStatus `json:"status"`
+
+	// Title corresponds to the JSON schema field "title".
+	Title string `json:"title"`
+
+	// UpdatedAt corresponds to the JSON schema field "updated_at".
+	UpdatedAt string `json:"updated_at"`
+}
+
 type TicketShowMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -6267,7 +6296,7 @@ type TicketsUpdatedMessage struct {
 	Event string `json:"event"`
 
 	// Tickets corresponds to the JSON schema field "tickets".
-	Tickets []Ticket `json:"tickets"`
+	Tickets []TicketRow `json:"tickets"`
 }
 
 type TodosMessage struct {
@@ -6520,7 +6549,7 @@ type WebSocketEvent struct {
 	Ticket *Ticket `json:"ticket,omitempty,omitzero"`
 
 	// Tickets corresponds to the JSON schema field "tickets".
-	Tickets []Ticket `json:"tickets,omitempty,omitzero"`
+	Tickets []TicketRow `json:"tickets,omitempty,omitzero"`
 
 	// TileID corresponds to the JSON schema field "tile_id".
 	TileID *string `json:"tile_id,omitempty,omitzero"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -367,9 +367,11 @@ model TicketArtifact {
   path: string;
 }
 
-// Ticket is the wire shape of a durable tracked-work record. `activity` and
-// `artifacts` are the full history thread and current attach files — populated on the
-// get_ticket full record, and left empty on the list / board feed for cheapness.
+// Ticket is the wire shape of a durable tracked-work record — a read by id
+// (get_ticket, ticket_show) or the agent's board read (ticket_list), which
+// carries the brief. `activity` and `artifacts` are the full history thread and
+// current attach files: populated on a full record, left empty on the
+// ticket_list rows. The app's board feed carries TicketRow instead.
 model Ticket {
   id: string;
   title: string;
@@ -392,6 +394,26 @@ model Ticket {
   latest_event_seq?: int32;
   activity: TicketActivity[];
   artifacts: TicketArtifact[];
+}
+
+// TicketRow is a ticket as the board feed carries it — the whole non-archived
+// board is re-pushed on every ticket mutation and again on connect, so it holds
+// only what a board renders: identity, the column, who owns it, and the stamps
+// the app reads (updated_at drives the open detail view's live refresh,
+// closed_at the recently-closed filter, reconciled_at the orphan badge). The
+// brief, the history thread and the artifacts are detail-sized and belong to a
+// read by id (get_ticket over the socket, ticket_show over the CLI), never to a
+// list push.
+model TicketRow {
+  id: string;
+  title: string;
+  status: TicketStatus;
+  assignee: string;
+  cwd: string;
+  last_agent_id: string;
+  updated_at: string;
+  closed_at?: string;
+  reconciled_at?: string;
 }
 
 model PR {
@@ -896,8 +918,8 @@ model TicketInboxMessage {
 // an agent finds a ticket-id here before it can comment on (or take/subscribe to) it.
 // Unlike the write verbs it is NOT identity-scoped — it is a global board read, so
 // source_session_id is optional and unused, present only for command-shape uniformity.
-// Rows carry the description (the brief) but not the activity thread (bare rows, like
-// the broadcast).
+// Rows carry the description (the brief) but not the activity thread — unlike the
+// app's board feed, whose TicketRow drops the brief too.
 model TicketListMessage {
   cmd: "ticket_list";
   source_session_id?: string;
@@ -2872,7 +2894,7 @@ model InitialStateMessage {
   github_hosts?: string[];
   settings?: Record<string>;
   warnings?: DaemonWarning[];
-  tickets?: Ticket[];
+  tickets?: TicketRow[];
 }
 
 model EndpointStatusChangedMessage {
@@ -2990,13 +3012,13 @@ model ChiefOfStaffResultMessage {
   error?: string;
 }
 
-// TicketsUpdatedMessage is the live board feed: the non-archived ticket rows
-// (bare — no activity/artifacts), re-pushed whenever any ticket mutates. It is
-// the same shape carried in InitialStateMessage.tickets, so a client renders the
-// board identically from the bootstrap snapshot and from each update.
+// TicketsUpdatedMessage is the live board feed: the non-archived ticket rows,
+// re-pushed whenever any ticket mutates. It is the same shape carried in
+// InitialStateMessage.tickets, so a client renders the board identically from
+// the bootstrap snapshot and from each update.
 model TicketsUpdatedMessage {
   event: "tickets_updated";
-  tickets: Ticket[];
+  tickets: TicketRow[];
 }
 
 // TicketResultMessage is the reply to a get_ticket request, correlated by
@@ -4797,7 +4819,7 @@ model WebSocketEvent {
 
   workspace_context_result?: WorkspaceContextResult;
   ticket?: Ticket;
-  tickets?: Ticket[];
+  tickets?: TicketRow[];
   workspace_contexts?: WorkspaceContext[];
 }
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -404,6 +404,11 @@ model Ticket {
 // brief, the history thread and the artifacts are detail-sized and belong to a
 // read by id (get_ticket over the socket, ticket_show over the CLI), never to a
 // list push.
+//
+// In generated.ts quicktype names an array's element type after the property
+// that holds it, not after the model: TicketRow arrives as `TicketElement` and
+// `Ticket` as `TicketObject`. Import the aliases at the top of
+// useDaemonSocket.ts (`TicketRow`, `Ticket`) rather than either generated name.
 model TicketRow {
   id: string;
   title: string;


### PR DESCRIPTION
The whole non-archived board is re-pushed to every open window on every ticket
mutation, and again on connect inside `initial_state`. Each row carried its full
`description` — the brief an agent was handed, often thousands of words — and on
the measured board that made `tickets_updated` the single largest message attn
sends: 226 KB, of which the board renders a title, a column and an assignee.

The measurement behind `docs/plans/2026-08-10-projection-coalescing.md` named
this as one of the two producers to fix rather than a reason to build
projection-side coalescing machinery.

## What changed

`TicketRow` is a new protocol model: the ticket as the *board feed* carries it —
identity, the column, who owns it, and the stamps the app actually reads
(`updated_at` drives the open detail view's live refresh, `closed_at` the
recently-closed filter, `reconciled_at` the orphan badge). `tickets_updated`,
`initial_state.tickets` and the `WebSocketEvent` union carry `TicketRow[]`.

The brief, the history thread and the artifacts are detail-sized and belong to a
read by id — `get_ticket` over the socket, which is what the detail panel
already calls, or `ticket_show` over the CLI. Nothing in the app read
`description` off a board row.

`TicketListResult` — `attn ticket list --json`, the agent/CLI read — is
untouched and still returns full `Ticket` records with descriptions. That is why
this is a second model rather than an optional field on `Ticket`: the two
consumers genuinely want different things, and making `description` optional
would have made both of them lie.

While in here, the crashed-ticket revive path (one session can own several
crashed tickets) is wrapped in `coalesceSnapshots`, so a revival still publishes
one fact per ticket but pushes the board once instead of once per ticket. No new
coalescing machinery — this is the existing bulk-operation seam.

## Receipts

Same daemon, same profile, same board — 49 non-archived tickets carrying 200,444
bytes of descriptions, seeded from a copy of a real database. Byte counts are
what an observer client read off the socket, for one ticket mutation and one
connect:

| message | before (`main`) | after | |
|---|---|---|---|
| `tickets_updated` | 226,406 B | **14,001 B** | 16.2× smaller |
| `initial_state` | 237,068 B | **24,663 B** | 9.6× smaller |

## Verification

- `TestBoardRowCarriesTheBoardAndNotTheBrief` marshals a board row and asserts
  the brief and the thread are not on it, field by field;
  `TestTicketListRowsStillCarryTheBrief` pins the CLI read keeping them.
- `TestCoalesceSnapshotsCollapsesTheTicketBoard` and
  `TestReviveOfSeveralTicketsPushesTheBoardOnce` pin the one-push revive.
- Frontend suite (243 files) and `tsc --noEmit` green; board and chip fixtures
  are slim rows now. The tripwire against the brief creeping back onto the feed
  is the Go test above, not the generated types — quicktype gives every wire
  model an `[property: string]: any` index signature, so TypeScript will not
  catch an extra field for you.
- Live on an isolated profile installed from this branch, against that seeded
  board: `real-app:scenario-ticket-lifecycle` passes with 0 failures, the board
  renders, and the detail panel still shows the description and the full history
  thread — it fetches by id (screenshot in the run artifacts).

Protocol version 225.

https://claude.ai/code/session_01XyiRXwGmqAZaEX8Dyy4E32
