### PR TITLE
feat(notifications): make a parked runtime critical, and make all three arrive

### DIFF
--- a/changelog.d/parked-runtime-notifications-are-critical.yaml
+++ b/changelog.d/parked-runtime-notifications-are-critical.yaml
@@ -1,0 +1,16 @@
+kind: changed
+area: app
+change: >
+  A parked plugin runtime and a parked app runtime now raise critical
+  notifications, so they get the ambient surface — the sidebar strip and the red
+  bell — instead of sitting quietly in the feed. An auto-disabled app raises a
+  warning. All three now reach an open app the moment they happen.
+notes: >
+  Nothing retries a parked runtime, so the notification announcing it is the last
+  word the user gets: while it is parked no app's handlers run and no plugin is
+  restarted, and the only way back is a person running `attn app runtime restart`
+  or reinstalling the plugin. That is what critical is for. An auto-disabled app
+  is one app off with everything else still running, which is a warning. The app
+  runtime's parked notification and the auto-disable notification were also
+  written to the database without publishing `notification.created`, so they only
+  reached an open app whenever something else happened to re-push the feed.

--- a/internal/daemon/app_autodisable_test.go
+++ b/internal/daemon/app_autodisable_test.go
@@ -122,6 +122,14 @@ func TestAppStuckOnOneEventIsDisabledAndSaysSoThreeWays(t *testing.T) {
 	if !strings.Contains(notes[0].Body, "ticket.created") || !strings.Contains(notes[0].Detail, "TypeError") {
 		t.Fatalf("the notification does not say what failed: body=%q detail=%q", notes[0].Body, notes[0].Detail)
 	}
+	// One app is off; everything else still runs. That is a warning, and it
+	// reaches the app now rather than at whatever re-pushes the feed next.
+	if notes[0].Severity != store.NotificationWarning {
+		t.Fatalf("severity = %q, want warning", notes[0].Severity)
+	}
+	if created := appFacts(t, d, FactNotificationCreated); len(created) != 1 || created[0].Subject != notes[0].ID {
+		t.Fatalf("notification.created facts = %+v, want one for %s", created, notes[0].ID)
+	}
 	// And the clock is cleared, so re-enabling does not disable it again on the
 	// very next failure.
 	if stall, ok := d.appStallSnapshot("greeter"); ok {

--- a/internal/daemon/app_consumers.go
+++ b/internal/daemon/app_consumers.go
@@ -612,18 +612,22 @@ func (d *Daemon) autoDisableApp(name string, ev bus.Event, stalled time.Duration
 	if d.store == nil {
 		return
 	}
-	if _, err := d.store.AddNotification(store.NotificationRecord{
-		Kind:  notificationKindAppAutoDisabled,
-		Title: fmt.Sprintf("App disabled: %s", name),
+	record, err := d.store.AddNotification(store.NotificationRecord{
+		Kind:     notificationKindAppAutoDisabled,
+		Severity: store.NotificationWarning,
+		Title:    fmt.Sprintf("App disabled: %s", name),
 		Body: fmt.Sprintf(
 			"%s failed on the same event (%s, seq %d) for %s across %d attempts, so attn disabled it — a stalled app holds the event log open for every other consumer. Fix the handler and `attn app enable %s`; `attn app status %s` shows the failures.",
 			name, ev.Name, ev.Seq, stalled.Round(time.Minute), attempts, name, name),
 		Detail:     message,
 		SourceKind: "app",
 		SourceID:   name,
-	}, d.appNow()); err != nil {
+	}, d.appNow())
+	if err != nil {
 		d.logf("notifications: add app-auto-disabled notification for %s: %v", name, err)
+		return
 	}
+	d.publishFact(FactNotificationCreated, record.ID, nil)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/daemon/app_runtime.go
+++ b/internal/daemon/app_runtime.go
@@ -224,18 +224,22 @@ func (d *Daemon) notifyAppRuntimeParked(_ string, snapshot supervise.Snapshot) {
 	if d.store == nil {
 		return
 	}
-	if _, err := d.store.AddNotification(store.NotificationRecord{
-		Kind:  notificationKindAppRuntimeParked,
-		Title: "Apps stopped running",
+	record, err := d.store.AddNotification(store.NotificationRecord{
+		Kind:     notificationKindAppRuntimeParked,
+		Severity: store.NotificationCritical,
+		Title:    "Apps stopped running",
 		Body: fmt.Sprintf(
 			"attn restarted the shared app runtime %d times without it ever staying up, and has stopped trying. No app's handlers are running. `attn app runtime status` shows why it exited; `attn app runtime restart` tries again.",
 			snapshot.RestartAttempt),
 		Detail:     detail,
 		SourceKind: "app_runtime",
 		SourceID:   appRuntimeChildName,
-	}, d.appNow()); err != nil {
+	}, d.appNow())
+	if err != nil {
 		d.logf("notifications: add app-runtime-parked notification: %v", err)
+		return
 	}
+	d.publishFact(FactNotificationCreated, record.ID, nil)
 }
 
 // appNow is the daemon's clock for everything app-runtime — the stall clock most

--- a/internal/daemon/app_runtime_test.go
+++ b/internal/daemon/app_runtime_test.go
@@ -930,6 +930,15 @@ func TestParkedRuntimeIsVisibleOnEveryAppAndRevivable(t *testing.T) {
 	if !strings.Contains(parked.Body, "attn app runtime restart") {
 		t.Fatalf("the notification does not name the way back: %q", parked.Body)
 	}
+	// No app's handlers run and nothing retries on its own, so this is the
+	// notification that earns the ambient surface — and it has to reach the app
+	// when it happens, not whenever the feed is re-pushed next.
+	if parked.Severity != store.NotificationCritical {
+		t.Fatalf("severity = %q, want critical", parked.Severity)
+	}
+	if created := appFacts(t, d, FactNotificationCreated); len(created) != 1 || created[0].Subject != parked.ID {
+		t.Fatalf("notification.created facts = %+v, want one for %s", created, parked.ID)
+	}
 
 	revived := appRuntimeRestart(t, d)
 	if revived.Was != string(supervise.PhaseParked) {

--- a/internal/daemon/plugin_runtime.go
+++ b/internal/daemon/plugin_runtime.go
@@ -130,6 +130,7 @@ func (d *Daemon) notifyPluginParked(name string, snapshot pluginRuntimeSnapshot)
 	}
 	record, err := d.store.AddNotification(store.NotificationRecord{
 		Kind:       notificationKindPluginParked,
+		Severity:   store.NotificationCritical,
 		Title:      fmt.Sprintf("Plugin stopped: %s", name),
 		Body:       fmt.Sprintf("attn restarted it %d times without it ever staying up, and has stopped trying. Reinstall the plugin, or restart attn, to try again.", snapshot.RestartAttempt),
 		Detail:     detail,

--- a/internal/daemon/plugin_supervisor_test.go
+++ b/internal/daemon/plugin_supervisor_test.go
@@ -11,6 +11,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/victorarias/attn/internal/store"
 	"github.com/victorarias/attn/internal/supervise"
 )
 
@@ -132,6 +133,11 @@ func TestParkedPluginRaisesADurableNotification(t *testing.T) {
 	}
 	if !strings.Contains(record.Detail, "exit code 9") {
 		t.Fatalf("notification detail=%q, want the last exit", record.Detail)
+	}
+	// Nothing retries a parked plugin, so this is the last word the user gets on
+	// it: critical, with the ambient surface that comes with it.
+	if record.Severity != store.NotificationCritical {
+		t.Fatalf("severity = %q, want critical", record.Severity)
 	}
 }
 


### PR DESCRIPTION
Main shipped notification severity (info | warning | critical) with an ambient
surface for critical — a sidebar strip and a red bell outside the panel. This
stamps the A4 epic's own producers and fixes a delivery gap found while reading
them.

## What changes

- **Parked plugin runtime → critical.** Nothing retries a parked plugin. The
  notification is the only word the user gets that it stopped.
- **Parked app runtime → critical.** While it is parked, no installed app's
  handlers run at all, and the way back is a person typing
  `attn app runtime restart`.
- **App auto-disabled → warning.** One app is off; everything else still runs,
  and the notification names the way back (`attn app enable <name>`).
- **Two of the three now publish `notification.created`.** The app runtime's
  parked notification and the auto-disable notification were written to the
  database and never announced, so an open app learned about them only when
  something else happened to re-push the notification snapshot. The plugin one
  already published; these two now match it.

## Why these two are critical and the third is not

Severity is about how much the notification wants the user, and the dividing
line here is whether anything else will fix it. A parked runtime is not retried
by anything: it stays broken, silently, until a person acts, and while it is
broken every app in the system is inert. An auto-disabled app is a bounded
failure with the rest of the system healthy — it is something that failed and
stays failed until the user gets to it, which is exactly what warning means.

## Tests

Assertions added to the three existing tests that already cover these
notifications, rather than new ones — the behaviour is a property of the
notification each producer already writes.

- `TestParkedPluginRaisesADurableNotification`
- `TestParkedRuntimeIsVisibleOnEveryAppAndRevivable`
- `TestAppStuckOnOneEventIsDisabledAndSaysSoThreeWays`

Both mutations are red: removing a `Severity:` line fails with
`severity = "info", want critical/warning`, and neutralizing a `publishFact`
fails with `notification.created facts = [], want one for <id>`.

## Verification

Go suite green. The live witness for the critical surface — the strip and the
red bell appearing when the app runtime parks — is the A4 exit proof (slice 6),
which parks the runtime on a real profile; it is recorded on the epic→main PR
rather than duplicated here.

Part of A4 (`docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md`),
targeting `epic/ext-a4`.