### PR TITLE
fix(apps): a parked runtime stays parked through delivery

### DIFF
--- a/changelog.d/parked-app-runtime-stays-parked.yaml
+++ b/changelog.d/parked-app-runtime-stays-parked.yaml
@@ -1,0 +1,13 @@
+kind: fixed
+area: app
+change: >
+  A parked app runtime now stays parked. Delivering an event to an app no longer
+  restarts a runtime that attn has given up on: the delivery fails with an error
+  naming the state and `attn app runtime restart`, which is still the way back.
+notes: >
+  Every delivery attempt went through the same call that `attn app runtime
+  restart` uses, and the bus retries a failing delivery forever, so a broken
+  runtime was handed a fresh restart budget every couple of minutes and parking
+  never held. Measured on a host binary that exits immediately: three parkings
+  and three critical notifications in five and a half minutes, which the ambient
+  surface would have turned into a permanent alarm.

--- a/internal/daemon/app_consumers.go
+++ b/internal/daemon/app_consumers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/victorarias/attn/internal/docstore"
 	"github.com/victorarias/attn/internal/jobs"
 	"github.com/victorarias/attn/internal/store"
+	"github.com/victorarias/attn/internal/supervise"
 )
 
 // Apps as bus consumers: registration, delivery, the invocation log, and the
@@ -472,7 +473,11 @@ func (d *Daemon) awaitAppRuntime(ctx context.Context) (*appRuntimeConnection, er
 	if runtime != nil {
 		return runtime, nil
 	}
-	if err := d.ensureAppRuntime(); err != nil {
+	if err := d.startAppRuntimeForDispatch(); err != nil {
+		if errors.Is(err, supervise.ErrParked) {
+			return nil, runtimeFailure(
+				"the app runtime is parked after repeated crashes and is not being restarted; `attn app runtime status` shows why it exited and `attn app runtime restart` tries again")
+		}
 		return nil, runtimeFailure("%v", err)
 	}
 	wait := d.appConnectWait()

--- a/internal/daemon/app_runtime.go
+++ b/internal/daemon/app_runtime.go
@@ -146,10 +146,25 @@ func (d *Daemon) ensureAppRuntimeSupervisor() *supervise.Supervisor {
 // ensureAppRuntime starts the sidecar, or adopts it if it is already running.
 // It doubles as un-park: supervise.Ensure resets the restart counter, which is
 // what `attn app runtime restart` needs after a crash loop.
-//
-// It is called from the dispatch path, so an app installed into a daemon that
-// has never run one starts the runtime without a restart.
 func (d *Daemon) ensureAppRuntime() error {
+	return d.startAppRuntime(true)
+}
+
+// startAppRuntimeForDispatch is the dispatch path's way in: it starts the
+// runtime lazily, so an app installed into a daemon that has never run one needs
+// no restart, but it leaves a parked runtime parked and answers ErrParked.
+//
+// Reviving here would make parking unreachable. Every delivery attempt passes
+// through this, and the bus retries a failing delivery forever, so a reviving
+// call would hand the crash loop a fresh restart budget every couple of minutes:
+// the runtime would never rest at parked, and each parking on the way would
+// raise its own critical notification. Measured on a broken host: three parkings
+// and three notifications in five and a half minutes.
+func (d *Daemon) startAppRuntimeForDispatch() error {
+	return d.startAppRuntime(false)
+}
+
+func (d *Daemon) startAppRuntime(revive bool) error {
 	host, err := resolveAppRuntimeHost()
 	if err != nil {
 		return err
@@ -161,7 +176,7 @@ func (d *Daemon) ensureAppRuntime() error {
 	if err := os.MkdirAll(d.appsDir, 0o755); err != nil {
 		return fmt.Errorf("creating the app artifact directory %s to start the runtime in: %w", d.appsDir, err)
 	}
-	return d.ensureAppRuntimeSupervisor().Ensure(appRuntimeChildName, func(req supervise.StartRequest) (supervise.Process, error) {
+	start := func(req supervise.StartRequest) (supervise.Process, error) {
 		cmd := exec.Command(host)
 		cmd.Dir = d.appsDir
 		cmd.Env = d.appRuntimeEnv(req.Generation)
@@ -170,7 +185,12 @@ func (d *Daemon) ensureAppRuntime() error {
 			return nil, fmt.Errorf("start the app runtime (%s): %w", host, err)
 		}
 		return process, nil
-	})
+	}
+	supervisor := d.ensureAppRuntimeSupervisor()
+	if revive {
+		return supervisor.Ensure(appRuntimeChildName, start)
+	}
+	return supervisor.EnsureUnlessParked(appRuntimeChildName, start)
 }
 
 // appRuntimeEnv is what the sidecar is launched with. It is the plugin

--- a/internal/daemon/app_runtime_test.go
+++ b/internal/daemon/app_runtime_test.go
@@ -952,6 +952,76 @@ func TestParkedRuntimeIsVisibleOnEveryAppAndRevivable(t *testing.T) {
 	// against a fake clock; here the stub crashes too fast to watch.
 }
 
+// Parked has to survive traffic. Dispatch is the loudest caller the runtime has
+// — one per fact, for as long as facts keep arriving — so a dispatch that
+// revived the child would give a broken host a fresh restart budget every few
+// seconds and park it again at the end of each one. Measured on a broken host
+// before the split: three parkings and three critical notifications in five and
+// a half minutes.
+func TestDispatchLeavesAParkedRuntimeParked(t *testing.T) {
+	d := newAppDaemon(t)
+	d.appRuntimeSupervise = supervise.Options{GiveUpAfter: 1}
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+	t.Setenv(appRuntimeHostOverride, writeExecutableStub(t, "exit 3"))
+	t.Cleanup(d.stopAppRuntime)
+
+	if err := d.ensureAppRuntime(); err != nil {
+		t.Fatalf("ensure runtime: %v", err)
+	}
+	waitFor(t, "the crash-looping runtime to be parked", func() bool {
+		snapshot, ok := d.appRuntimeSnapshot()
+		return ok && snapshot.Phase == supervise.PhaseParked
+	})
+	parked, _ := d.appRuntimeSnapshot()
+
+	for seq := int64(1); seq <= 3; seq++ {
+		err := d.deliverAppEvent(context.Background(), "greeter", appEvent("ticket.created", "tk-1", seq))
+		if !isRuntimeFailure(err) {
+			t.Fatalf("dispatch %d into a parked runtime returned %v, want a runtime failure", seq, err)
+		}
+		// The app's owner reads this line and nothing else: it has to name the
+		// state and the one command that leaves it.
+		if !strings.Contains(err.Error(), "parked") || !strings.Contains(err.Error(), "attn app runtime restart") {
+			t.Fatalf("the dispatch error does not say what happened or how to fix it: %q", err)
+		}
+	}
+
+	after, ok := d.appRuntimeSnapshot()
+	if !ok || after.Phase != supervise.PhaseParked {
+		t.Fatalf("three dispatches moved the runtime off parked: %+v", after)
+	}
+	if after.Generation != parked.Generation {
+		t.Fatalf("generation went %d → %d, so a dispatch started the runtime again",
+			parked.Generation, after.Generation)
+	}
+	// One outage, one notification. Re-parking would write one per revival, and
+	// these are critical — the surface that cannot be ignored is the one that
+	// must not repeat.
+	if notes := appNotifications(t, d, notificationKindAppRuntimeParked); len(notes) != 1 {
+		t.Fatalf("app-runtime-parked notifications = %d, want 1", len(notes))
+	}
+	// Not the app's fault, so it must not be on the auto-disable clock while the
+	// runtime is down.
+	rows := invocationsOf(t, d, "greeter")
+	if len(rows) != 3 {
+		t.Fatalf("recorded %d invocation(s), want 3", len(rows))
+	}
+	for _, row := range rows {
+		if row.Status != appInvocationStatusRuntimeError {
+			t.Fatalf("status = %q, want %q", row.Status, appInvocationStatusRuntimeError)
+		}
+	}
+	if stall, ok := d.appStallSnapshot("greeter"); ok {
+		t.Fatalf("a parked runtime put the app on the auto-disable clock: %+v", stall)
+	}
+
+	// And the deliberate way in still revives it — the split must not turn parked
+	// into a dead end.
+	if revived := appRuntimeRestart(t, d); revived.Runtime.Phase == string(supervise.PhaseParked) {
+		t.Fatalf("restart left the runtime parked: %+v", revived.Runtime)
+	}
+}
+
 // A runtime whose api_version does not match is refused at hello rather than
 // half-served, and the refusal says it is a stale install.
 func TestRuntimeWithTheWrongAPIVersionIsRefusedAtHello(t *testing.T) {

--- a/internal/supervise/supervise.go
+++ b/internal/supervise/supervise.go
@@ -242,11 +242,31 @@ func New(opts Options) *Supervisor {
 	}
 }
 
+// ErrParked says the child is one the supervisor has given up restarting, and
+// the caller asked not to revive it.
+var ErrParked = errors.New("supervise: child is parked")
+
 // Ensure declares that a named child should be running, launching it if nothing
 // is running or scheduled for it. Calling it again replaces the StartFunc used
 // by the next start and is otherwise a no-op for a live child — so it is also
 // how a parked child is revived, which resets its restart attempts.
 func (s *Supervisor) Ensure(name string, start StartFunc) error {
+	return s.ensure(name, start, true)
+}
+
+// EnsureUnlessParked is Ensure for a caller that runs per unit of traffic rather
+// than per deliberate act: it starts the child, but reports ErrParked instead of
+// reviving one the supervisor has given up on.
+//
+// Reviving has to stay deliberate. Ensure resets the restart budget, so a caller
+// on a hot path calling it makes the give-up tripwire unreachable — the child
+// crash-loops for as long as traffic keeps arriving, and every parking on the
+// way is announced again.
+func (s *Supervisor) EnsureUnlessParked(name string, start StartFunc) error {
+	return s.ensure(name, start, false)
+}
+
+func (s *Supervisor) ensure(name string, start StartFunc, revive bool) error {
 	if err := validateName(name); err != nil {
 		return err
 	}
@@ -270,6 +290,10 @@ func (s *Supervisor) Ensure(name string, start StartFunc) error {
 			return nil
 		}
 		if c.phase == PhaseParked {
+			if !revive {
+				s.mu.Unlock()
+				return ErrParked
+			}
 			c.restartAttempt = 0
 		}
 	}

--- a/internal/supervise/supervise_test.go
+++ b/internal/supervise/supervise_test.go
@@ -335,6 +335,64 @@ func TestEnsureRevivesParkedChild(t *testing.T) {
 	}
 }
 
+// And parking is only reversible deliberately. A caller that runs per unit of
+// traffic — the app runtime's dispatch path — must leave a parked child parked,
+// or the tripwire it crossed cannot hold: traffic would hand it a fresh restart
+// budget over and over, and every parking on the way would be announced again.
+func TestEnsureUnlessParkedLeavesAParkedChildAlone(t *testing.T) {
+	clock := newFakeClock()
+	launcher := &fakeLauncher{}
+	var mu sync.Mutex
+	var gaveUp int
+	supervisor := New(Options{
+		Clock:       clock,
+		GiveUpAfter: 1,
+		OnGiveUp: func(string, Snapshot) {
+			mu.Lock()
+			gaveUp++
+			mu.Unlock()
+		},
+	})
+	_ = supervisor.EnsureUnlessParked("fixture", launcher.start)
+
+	launcher.handle(0).exit(Exit{Error: "boom"})
+	waitFor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.Phase == PhaseBackoff
+	})
+	clock.Advance(RestartBackoff[0])
+	waitFor(t, func() bool { return launcher.count() == 2 })
+	launcher.handle(1).exit(Exit{Error: "boom"})
+	waitFor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.Phase == PhaseParked
+	})
+
+	// Traffic keeps arriving. None of it restarts anything, and none of it
+	// announces a second parking.
+	for range 5 {
+		if err := supervisor.EnsureUnlessParked("fixture", launcher.start); !errors.Is(err, ErrParked) {
+			t.Fatalf("EnsureUnlessParked on a parked child = %v, want ErrParked", err)
+		}
+		clock.Advance(time.Hour)
+	}
+	if got := launcher.count(); got != 2 {
+		t.Fatalf("starts = %d, want the 2 from before parking", got)
+	}
+	mu.Lock()
+	announced := gaveUp
+	mu.Unlock()
+	if announced != 1 {
+		t.Fatalf("OnGiveUp calls = %d, want 1 — one parking is one announcement", announced)
+	}
+
+	// The deliberate way back still works.
+	if err := supervisor.Ensure("fixture", launcher.start); err != nil {
+		t.Fatalf("Ensure on parked child: %v", err)
+	}
+	waitFor(t, func() bool { return launcher.count() == 3 })
+}
+
 func TestNeverParksWithNegativeGiveUpAfter(t *testing.T) {
 	clock := newFakeClock()
 	launcher := &fakeLauncher{}


### PR DESCRIPTION
Found by the A4 exit proof: parking the app runtime did not hold.

`awaitAppRuntime` — the path every single event delivery takes — called the same
`supervise.Ensure` that `attn app runtime restart` calls, and `Ensure` un-parks.
The bus retries a failing delivery forever, so a runtime attn had given up on was
handed a fresh restart budget every couple of minutes, burned it on ten more
crashes, and parked again. Parked was unreachable in practice, and each parking
on the way wrote its own notification — which, now that those are `critical`,
would have become a permanent ambient alarm.

Measured on the exit-proof profile with a host binary that exits immediately,
before this change: seven parkings and seven critical notifications in fourteen
minutes, one every ~2m10s. Each delivery also burned the full 10s connect
timeout while the doomed child was starting.

## The change

`supervise` grows `EnsureUnlessParked`, for a caller that runs per unit of
traffic rather than per deliberate act: it starts a stopped child, and answers
`ErrParked` for one the supervisor has given up on rather than reviving it.
`Ensure` is unchanged, so the deliberate ways in — `attn app runtime restart`,
daemon startup — still revive.

Dispatch uses it and turns `ErrParked` into a runtime failure that names the
state and the way back. It stays a runtime failure, not an app failure: the app
is not charged for the outage on its auto-disable clock.

## Live verification

Throwaway profile `a4exit`, daemon installed from this branch, real app
(`ticketwatch`) subscribed to `ticket.*`, host binary swapped for one that exits
3.

Parked once, at generation 13, after the supervisor's ten attempts. Then eight
minutes of traffic — bus retries plus three new tickets:

```
00:24:50 parked notifications since restart: 1 | state: parked, generation 13
...
00:31:51 parked notifications since restart: 1 | state: parked, generation 13
```

No restart, no second notification, where the pre-fix rate was one every ~2m10s.
The retries themselves now fail in 0ms instead of waiting out the connect
timeout, and say why:

```
STARTED               SEQ  EVENT           STATUS         MS  ERROR
2026-08-10T22:31:51Z  603  ticket.created  runtime_error  0   the app runtime is parked after repeated
                                                              crashes and is not being restarted; `attn app
                                                              runtime status` shows why it exited and `attn
                                                              app runtime restart` tries again
```

Restoring the host and running `attn app runtime restart` revived it
("revived the app runtime: it was parked after crash-looping"), and the app
drained its backlog to `cursor 679, 0 event(s) behind`.

## Tests

- `internal/supervise`: `TestEnsureUnlessParkedLeavesAParkedChildAlone` — parks a
  child, calls `EnsureUnlessParked` five times for `ErrParked` with no new start
  and one give-up announcement, then proves `Ensure` still revives.
- `internal/daemon`: `TestDispatchLeavesAParkedRuntimeParked` — three dispatches
  into a parked runtime leave the generation where it was, write one
  `app_runtime_parked` notification, record three `runtime_error` invocations,
  keep the app off the auto-disable clock, and return an error naming
  `attn app runtime restart`.

Both go red on the one-word mutation (`startAppRuntime(false)` → `true`): the
daemon test on the error text first, and on the generation assertion alone once
that one is removed.