### PR TITLE
fix(sessions): recover resumable sessions after machine crashes

### DIFF
--- a/app/e2e/session-restore-reconnect.spec.ts
+++ b/app/e2e/session-restore-reconnect.spec.ts
@@ -54,7 +54,7 @@ test.describe('Session restore and reconnect harness', () => {
     await expect(page.locator('[data-testid="sidebar-session-restore-s2"][data-state="waiting_input"]')).not.toHaveClass(/selected/);
   });
 
-  test('reconnects after daemon restart and marks stale Claude sessions recoverable when worker is missing', async ({ page, daemon }) => {
+  test('reconnects after daemon restart and drops a stale session it cannot bring back', async ({ page, daemon }) => {
     await daemon.start();
 
     await daemon.injectSession({
@@ -75,11 +75,10 @@ test.describe('Session restore and reconnect harness', () => {
 
     await daemon.restart();
 
-    // Session remains tracked and is marked recoverable (claude sessions with a
-    // missing worker can be revived from their stored launch intent).
-    await expect(page.locator('[data-testid="session-reconnect-s1"]')).toHaveCount(1, { timeout: 15000 });
-    await expect(page.locator('[data-testid="session-reconnect-s1"][data-state="recoverable"]')).toBeVisible({ timeout: 15000 });
-    await expect(page.locator('.warning-banner')).toContainText(/can be recovered/i, { timeout: 10000 });
+    // The injected row was never launched, so nothing on disk can restore its
+    // conversation: startup recovery reaps it along with its pane.
+    await expect(page.locator('[data-testid="session-reconnect-s1"]')).toHaveCount(0, { timeout: 15000 });
+    await expect(page.locator('[data-testid="sidebar-session-reconnect-s1"]')).toHaveCount(0);
 
     await daemon.injectSession({
       id: 'reconnect-s2',

--- a/app/package.json
+++ b/app/package.json
@@ -34,6 +34,7 @@
     "real-app:scenario-tr204": "node scripts/real-app-harness/scenario-tr204-local-relaunch-formatting.mjs",
     "real-app:scenario-tr301": "node scripts/real-app-harness/scenario-tr301-local-utility-session-switch.mjs",
     "real-app:scenario-codex-resume": "node scripts/real-app-harness/scenario-codex-resume-mapping.mjs",
+    "real-app:scenario-crash-recovery": "node scripts/real-app-harness/scenario-crash-recovery-resumability.mjs",
     "real-app:scenario-automation-pr-continuity": "node scripts/real-app-harness/scenario-automation-pr-continuity.mjs",
     "real-app:scenario-automation-scheduled-cleanup": "node scripts/real-app-harness/scenario-automation-scheduled-cleanup.mjs",
     "real-app:scenario-automation-lifecycle": "node scripts/real-app-harness/scenario-automation-lifecycle.mjs",

--- a/app/scripts/real-app-harness/scenario-crash-recovery-resumability.mjs
+++ b/app/scripts/real-app-harness/scenario-crash-recovery-resumability.mjs
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+
+// A machine crash, reproduced: every pty worker and the daemon are SIGKILLed
+// at once, so nothing gets to say goodbye and no worker can be re-adopted on
+// the way back. What must survive is every session attn can still bring back —
+// whatever agent it is and whatever it was last seen doing — and what must not
+// is a session with nothing left to reopen.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import {
+  createSessionAndWaitForInitialPane,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+  relaunchAppAndConnect,
+} from './common.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { createScenarioRunner } from './scenarioRunner.mjs';
+import { cleanupSessionViaAppClose } from './scenarioCleanup.mjs';
+import {
+  captureSessionArtifacts,
+  sleep,
+  waitForFirstWorkspacePane,
+  waitForPaneText,
+  waitForPaneVisible,
+} from './scenarioAssertions.mjs';
+import {
+  ensureClaudeInitialPanePromptReady,
+  ensureCodexInitialPanePromptReady,
+} from './scenarioAgents.mjs';
+import { currentHarnessProfile, dataDirForProfile } from './harnessProfile.mjs';
+
+const execFileAsync = promisify(execFile);
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') args.shift();
+  const options = parseCommonArgs(args);
+  return { options, help: args.includes('--help') || args.includes('-h') };
+}
+
+// The resume id is the evidence under test, so the scenario reads it where the
+// daemon writes it rather than inferring it from the screen.
+async function readPersistedResumeId(dataDir, sessionId) {
+  const dbPath = path.join(dataDir, 'attn.db');
+  const { stdout } = await execFileAsync('sqlite3', [
+    `file:${dbPath}?mode=ro`,
+    `select coalesce(resume_session_id, '') from sessions where id = '${sessionId}';`,
+  ]);
+  return stdout.trim();
+}
+
+// The rollout `codex resume <id>` would reopen. Located the way the daemon's
+// driver locates it: the first line's session_meta names the id.
+function findCodexRollout(resumeId) {
+  const root = path.join(process.env.CODEX_HOME || path.join(os.homedir(), '.codex'), 'sessions');
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries = [];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      if (!entry.name.endsWith('.jsonl')) continue;
+      let head = '';
+      try {
+        head = fs.readFileSync(full, 'utf8').split('\n', 1)[0] || '';
+      } catch {
+        continue;
+      }
+      if (head.includes(`"id":"${resumeId}"`)) return full;
+    }
+  }
+  return null;
+}
+
+async function waitFor(description, predicate, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let last = null;
+  while (Date.now() < deadline) {
+    last = await predicate();
+    if (last) return last;
+    await sleep(500);
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+// A crash leaves no orderly shutdown behind: SIGKILL every worker this
+// profile's registry knows about, then the daemon itself. The registry is what
+// makes this precise — only PIDs attn recorded for this profile are signalled.
+function killProfileRuntimeLikeACrash(dataDir, log) {
+  const killed = { workers: [], daemon: null };
+  const workersRoot = path.join(dataDir, 'workers');
+  const instances = fs.existsSync(workersRoot) ? fs.readdirSync(workersRoot) : [];
+  for (const instance of instances) {
+    const registryDir = path.join(workersRoot, instance, 'registry');
+    if (!fs.existsSync(registryDir)) continue;
+    for (const entry of fs.readdirSync(registryDir)) {
+      const raw = fs.readFileSync(path.join(registryDir, entry), 'utf8');
+      const record = JSON.parse(raw);
+      const pid = Number(record.pid ?? record.Pid ?? record.worker_pid);
+      if (!Number.isInteger(pid) || pid <= 1) continue;
+      try {
+        process.kill(pid, 'SIGKILL');
+        killed.workers.push({ session: entry, pid });
+      } catch (error) {
+        log(`worker ${entry} pid ${pid} already gone: ${error.message}`);
+      }
+    }
+  }
+  const pidFile = path.join(dataDir, 'attn.pid');
+  if (fs.existsSync(pidFile)) {
+    const pid = Number(fs.readFileSync(pidFile, 'utf8').trim());
+    if (Number.isInteger(pid) && pid > 1) {
+      try {
+        process.kill(pid, 'SIGKILL');
+        killed.daemon = pid;
+      } catch (error) {
+        log(`daemon pid ${pid} already gone: ${error.message}`);
+      }
+    }
+  }
+  return killed;
+}
+
+function daemonLogTail(dataDir, lines = 200) {
+  const logPath = path.join(dataDir, 'daemon.log');
+  if (!fs.existsSync(logPath)) return '';
+  return fs.readFileSync(logPath, 'utf8').split('\n').slice(-lines).join('\n');
+}
+
+async function submitCodexPrompt(client, sessionId, paneId, text) {
+  await client.request('type_pane_via_ui', { sessionId, paneId, text });
+  // Codex reads a fast character stream as a paste and makes the next Enter a
+  // newline; wait past that window so this is a real submit.
+  await sleep(250);
+  await client.request('type_pane_via_ui', { sessionId, paneId, text: '\n' });
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-crash-recovery-resumability.mjs');
+    return;
+  }
+
+  const profile = currentHarnessProfile();
+  const dataDir = dataDirForProfile(profile);
+  const runner = createScenarioRunner(options, {
+    scenarioId: 'CRASH-REC',
+    tier: 'tier2-local-real-agent',
+    prefix: 'scenario-crash-recovery-resumability',
+    metadata: { agents: 'codex+claude+shell', focus: 'crash keeps what it can bring back' },
+  });
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+
+  const token = `CRASHREC${Date.now()}`;
+  let codexSessionId = null;
+  let codexPaneId = null;
+  let codexResumeId = null;
+  let claudeSessionId = null;
+
+  try {
+    await runner.step('launch_app', async () => {
+      await launchFreshAppAndConnect(client, observer);
+    });
+
+    // Codex, with a conversation behind it: a rollout on disk and the native
+    // resume id attn persisted from it. This is the session the crash used to
+    // delete.
+    codexSessionId = await runner.step('create_codex_session_with_a_conversation', async () => {
+      const sessionId = await createSessionAndWaitForInitialPane({
+        client,
+        observer,
+        cwd: runner.sessionDir,
+        label: `crashrec-codex-${runner.runId}`,
+        agent: 'codex',
+        promptReadyFn: ensureCodexInitialPanePromptReady,
+      });
+      const pane = await waitForFirstWorkspacePane(client, sessionId, 'codex pane', 20_000);
+      codexPaneId = pane.paneId;
+      // Codex reports its native rollout id at session start; until the daemon
+      // has persisted it there is no resume target and the scenario would be
+      // testing the wrong thing.
+      codexResumeId = await waitFor(
+        'codex to report its native resume id',
+        async () => (await readPersistedResumeId(dataDir, sessionId)) || null,
+        90_000,
+      );
+      await submitCodexPrompt(client, sessionId, pane.paneId, `Reply with exactly ${token} and nothing else.`);
+      // The rollout is the conversation. Waiting for the token to land in it is
+      // what makes "the crash did not lose the conversation" a real claim: the
+      // pane would show the token from the local echo alone.
+      const rollout = await waitFor(
+        'the token to reach the codex rollout on disk',
+        () => {
+          const file = findCodexRollout(codexResumeId);
+          if (!file) return null;
+          return fs.readFileSync(file, 'utf8').includes(token) ? file : null;
+        },
+        120_000,
+      );
+      runner.writeJson('codex-conversation.json', { resumeId: codexResumeId, rollout });
+      return sessionId;
+    });
+
+    // Claude, booted to its prompt and never asked anything: it writes its
+    // transcript on the first turn, so there is nothing on disk to resume and
+    // nothing to keep.
+    claudeSessionId = await runner.step('create_claude_session_that_never_took_a_turn', async () => {
+      return createSessionAndWaitForInitialPane({
+        client,
+        observer,
+        cwd: runner.sessionDir,
+        label: `crashrec-claude-${runner.runId}`,
+        agent: 'claude',
+        promptReadyFn: ensureClaudeInitialPanePromptReady,
+      });
+    });
+
+    await runner.step('record_state_before_the_crash', async () => {
+      const claudeResumeId = await readPersistedResumeId(dataDir, claudeSessionId);
+      const claudeTranscript = path.join(
+        process.env.ATTN_TOOL_HOME || os.homedir(),
+        '.claude',
+        'projects',
+      );
+      const claudeHasTranscript = fs.existsSync(claudeTranscript)
+        && fs.readdirSync(claudeTranscript).some((dir) => fs.existsSync(path.join(claudeTranscript, dir, `${claudeResumeId}.jsonl`)));
+      if (claudeHasTranscript) {
+        throw new Error('the claude session already has a transcript; it cannot stand in for the unresumable case');
+      }
+      runner.writeJson('before-crash.json', {
+        codex: { session: observer.getSession(codexSessionId), resumeId: codexResumeId },
+        claude: { session: observer.getSession(claudeSessionId), resumeId: claudeResumeId, hasTranscript: false },
+      });
+    });
+
+    const killed = await runner.step('crash_the_machine', async () => {
+      const result = killProfileRuntimeLikeACrash(dataDir, (m) => runner.log(m));
+      runner.writeJson('killed.json', result);
+      if (result.workers.length === 0) {
+        throw new Error('no pty workers were killed; the crash was not reproduced');
+      }
+      // Let the OS reap them before anything tries to adopt them.
+      await sleep(1_000);
+      return result;
+    });
+    runner.log(`crashed: ${killed.workers.length} workers, daemon pid ${killed.daemon}`);
+
+    await runner.step('reboot_into_the_app', async () => {
+      await relaunchAppAndConnect(client, observer);
+      // Startup recovery runs before clients cross the barrier, but the
+      // observer's first snapshot can beat the deferred pass; give it a beat.
+      await sleep(2_000);
+      runner.writeText('daemon-after-reboot.log', daemonLogTail(dataDir));
+    });
+
+    await runner.step('assert_the_resumable_codex_session_survived', async () => {
+      const session = await waitFor(
+        'the codex session to settle on a recovery verdict',
+        async () => {
+          const current = observer.getSession(codexSessionId);
+          return current && current.state === 'recoverable' ? current : null;
+        },
+        30_000,
+      ).catch(() => observer.getSession(codexSessionId));
+      if (!session) {
+        throw new Error('the codex session was deleted by startup recovery despite having a rollout to resume');
+      }
+      if (session.state !== 'recoverable') {
+        throw new Error(`codex session state = ${session.state}, want recoverable`);
+      }
+      const recovery = daemonLogTail(dataDir, 400)
+        .split('\n')
+        .filter((line) => line.includes('worker session reconciliation summary'))
+        .pop();
+      runner.writeJson('after-crash-codex.json', { session, recovery });
+      if (!recovery || !/marked_recoverable=[1-9]/.test(recovery)) {
+        throw new Error(`reconciliation summary did not mark anything recoverable: ${recovery}`);
+      }
+    });
+
+    await runner.step('assert_the_unresumable_claude_session_was_reaped', async () => {
+      const session = observer.getSession(claudeSessionId);
+      if (session) {
+        throw new Error(`claude session survived as ${session.state}; it has no transcript to resume`);
+      }
+      // Reaped means the pane goes with the row: no Reload is offered for a
+      // session that could not take one.
+      const workspace = observer.getWorkspace(claudeSessionId);
+      if (workspace) {
+        throw new Error('the reaped claude session left its workspace pane behind');
+      }
+    });
+
+    await runner.step('revive_the_codex_pane_and_read_the_old_conversation_back', async () => {
+      await client.request('select_session', { sessionId: codexSessionId });
+      const pane = await waitForFirstWorkspacePane(client, codexSessionId, 'revived codex pane', 30_000);
+      await waitForPaneVisible(client, codexSessionId, pane.paneId, 30_000);
+      await waitForPaneText(
+        client,
+        codexSessionId,
+        pane.paneId,
+        (text) => text.includes(token),
+        'the resumed codex conversation still carries what was said before the crash',
+        120_000,
+      );
+      const revived = await client.request('read_pane_text', { sessionId: codexSessionId, paneId: pane.paneId }, { timeoutMs: 20_000 });
+      runner.writeText('revived-pane.txt', revived?.text || '');
+      await captureSessionArtifacts(client, runner.runDir, 'revived-codex', codexSessionId);
+      const session = observer.getSession(codexSessionId);
+      if (!session || session.state === 'recoverable') {
+        throw new Error(`codex session state after revive = ${session?.state}; want a live state`);
+      }
+    });
+
+    const summary = runner.finishSuccess({
+      codexSessionId,
+      claudeSessionId,
+      token,
+      artifacts: { runDir: runner.runDir, trace: runner.tracePath },
+    });
+    console.log(JSON.stringify(summary, null, 2));
+  } catch (error) {
+    if (codexSessionId) {
+      await captureSessionArtifacts(client, runner.runDir, 'failure', codexSessionId).catch(() => {});
+    }
+    runner.writeText('daemon-on-failure.log', daemonLogTail(dataDir, 400));
+    const summary = runner.finishFailure(error, { codexSessionId, claudeSessionId, token });
+    console.error(summary.error);
+    process.exitCode = 1;
+  } finally {
+    for (const sessionId of [codexSessionId, claudeSessionId]) {
+      if (sessionId) {
+        await cleanupSessionViaAppClose(client, observer, sessionId).catch(() => {});
+      }
+    }
+    await client.quitApp().catch(() => {});
+    await observer.close().catch(() => {});
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exit(1);
+});

--- a/app/scripts/real-app-harness/scenarioCatalog.mjs
+++ b/app/scripts/real-app-harness/scenarioCatalog.mjs
@@ -245,6 +245,12 @@ export const scenarioCatalog = [
     timeoutMs: 360_000,
   },
   {
+    id: 'crash-recovery',
+    label: 'A machine crash keeps every session it can bring back and reaps the rest',
+    command: ['pnpm', 'run', 'real-app:scenario-crash-recovery'],
+    timeoutMs: 360_000,
+  },
+  {
     id: 'ghostty-scroll',
     label: 'Ghostty scrollback anchoring while output streams',
     command: ['pnpm', 'run', 'real-app:scenario-ghostty-scroll'],

--- a/changelog.d/crash-recovery-durable-resumability.yaml
+++ b/changelog.d/crash-recovery-durable-resumability.yaml
@@ -1,0 +1,9 @@
+kind: fixed
+area: sessions
+change: >
+  A computer crash no longer deletes sessions attn could have brought back.
+  Startup recovery now keeps a session whose worker is gone whenever its
+  conversation is still on disk and there is a launch intent to relaunch from,
+  whatever agent it is and whatever it was last seen doing — where before only
+  Claude sessions survived, and an idle one survived by accident. Sessions with
+  nothing left to reopen are reaped as before.

--- a/changelog.d/crash-recovery-durable-resumability.yaml
+++ b/changelog.d/crash-recovery-durable-resumability.yaml
@@ -6,4 +6,6 @@ change: >
   conversation is still on disk and there is a launch intent to relaunch from,
   whatever agent it is and whatever it was last seen doing — where before only
   Claude sessions survived, and an idle one survived by accident. Sessions with
-  nothing left to reopen are reaped as before.
+  nothing left to reopen are reaped as before. Plugin capabilities alone no
+  longer keep a crashed session: the plugin must have left an open run handle or
+  persisted metadata for that session.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -301,8 +301,9 @@ a pane revives itself from when it mounts. It is decided from two durable
 things and nothing else: a launch intent, which says how to start a
 replacement, and a restoration target that is still on disk, which says what
 the replacement reopens — an agent-native resume id the agent's driver still
-recognises, a conversation host's own session file, or a plugin's persisted
-per-session handle.
+recognises, a conversation host's own session file, the launch intent's seed
+(a source conversation or an initial prompt the host had not said yet), or a
+plugin's persisted per-session handle.
 
 Recoverability and activity are separate axes. A crash takes `idle`, `working`,
 `waiting_input`, and `pending_approval` sessions down together and leaves them

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -293,6 +293,24 @@ accumulates state across deliveries; the daemon re-runs the query when a write t
 the collection says the answer may have moved. A skipped delivery is not a lost
 update — the next one supersedes it.
 
+## Recoverable
+
+A session is **recoverable** when its runtime is gone but attn can still bring
+its conversation back — the state the sidebar offers a Reload on, and the state
+a pane revives itself from when it mounts. It is decided from two durable
+things and nothing else: a launch intent, which says how to start a
+replacement, and a restoration target that is still on disk, which says what
+the replacement reopens — an agent-native resume id the agent's driver still
+recognises, a conversation host's own session file, or a plugin's persisted
+per-session handle.
+
+Recoverability and activity are separate axes. A crash takes `idle`, `working`,
+`waiting_input`, and `pending_approval` sessions down together and leaves them
+equally resumable, so what a session was last seen doing is context for the user
+and never the reason it survives or is reaped. A session that cannot be brought
+back is **reaped**: the row and its pane go, rather than lingering as a Reload
+that cannot work.
+
 ## Conversation session
 
 A **conversation session** is an attn session whose agent runs headless in a
@@ -425,10 +443,9 @@ finished.
 
 An agent becomes a conversation agent by its plugin driver registering the
 `conversation` capability. Everything else about launching it — argv, env, cwd —
-comes back from the same `driver.spawn` call a PTY-backed agent uses. That
-capability is also what makes its sessions recoverable rather than reaped: a
-conversation always has somewhere to come back from, so it never has to declare
-the PTY agents' `resume`.
+comes back from the same `driver.spawn` call a PTY-backed agent uses. It never
+has to declare the PTY agents' `resume`: that capability describes an agent
+resumed from an argv flag, and a host is resumed from its own session file.
 
 ## nisse
 

--- a/docs/plans/2026-04-16-plugin-system.md
+++ b/docs/plans/2026-04-16-plugin-system.md
@@ -98,6 +98,7 @@ These were proposed in conversation but not explicitly confirmed:
 5. Plugin responds `{ argv, env, cwd }`. attn spawns that command in a PTY under the session. **Attn owns the PTY. Plugin owns agent-specific semantics.**
 6. Plugin stages companion files (extensions, hooks) however it likes. Plugin monitors the agent however it likes.
 7. Plugin reports state via `session.report_state`, `session.report_stop`, `session.report_metadata`. The daemon supplies a fresh `run_id` per launched PTY and persists the spawning plugin as that run's owner; only that owner can report or receive close notification for the run. The plugin sequences reports within that run so asynchronous work cannot overwrite newer status or a replacement run.
+   Crash recovery keeps a plugin-driven session only when attn has per-session evidence for the replacement to consume: an open run handle or persisted metadata. Advertising `resume` or `conversation` capability alone does not make a particular session recoverable.
 8. When an attn-owned plugin agent PTY exits or has been killed successfully, attn calls `driver.session_closed` on the recorded run owner so the plugin can dispose bridge tokens, watchers, classifiers, and staged launch resources for that run.
 9. Plugin exits intentionally when attn shuts down or removes it. Unexpected exits are supervised and do not terminate attn-owned agent PTYs.
 

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -30,7 +30,6 @@ var _ TranscriptWatcherBehaviorProvider = (*Claude)(nil)
 var _ ClassifierProvider = (*Claude)(nil)
 var _ ExecutableClassifierProvider = (*Claude)(nil)
 var _ LaunchPreparer = (*Claude)(nil)
-var _ SessionRecoveryPolicyProvider = (*Claude)(nil)
 var _ RecoveredStatePolicyProvider = (*Claude)(nil)
 var _ ResumePolicyProvider = (*Claude)(nil)
 var _ ResumeAvailabilityProvider = (*Claude)(nil)
@@ -571,10 +570,6 @@ func (c *Claude) BootstrapBytes() int64 {
 
 func (c *Claude) NewTranscriptWatcherBehavior() TranscriptWatcherBehavior {
 	return &claudeTranscriptWatcherBehavior{}
-}
-
-func (c *Claude) RecoverOnMissingPTY() bool {
-	return true
 }
 
 // RecoveredRunningState mirrors the default recovered-state mapping. Claude has

--- a/internal/agent/daemon_policy.go
+++ b/internal/agent/daemon_policy.go
@@ -12,12 +12,6 @@ import (
 // ErrNoNewAssistantTurn indicates there is no new assistant turn to classify.
 var ErrNoNewAssistantTurn = errors.New("no new assistant turn")
 
-// SessionRecoveryPolicyProvider customizes startup behavior when a stored session
-// is missing a live PTY backend runtime.
-type SessionRecoveryPolicyProvider interface {
-	RecoverOnMissingPTY() bool
-}
-
 // RecoveredStatePolicyProvider customizes how a recovered session's PTY state
 // maps onto a session state at startup. The second return is whether the driver
 // has an opinion at all; see RecoveredRunningSessionState.
@@ -59,16 +53,6 @@ type TranscriptClassificationExtractor interface {
 // that need an explicit executable path at classification time.
 type ExecutableClassifierProvider interface {
 	ClassifyWithExecutable(text, executable, workDir string, timeout time.Duration) (string, error)
-}
-
-func RecoverOnMissingPTY(d Driver) bool {
-	if d == nil {
-		return false
-	}
-	if p, ok := d.(SessionRecoveryPolicyProvider); ok {
-		return p.RecoverOnMissingPTY()
-	}
-	return false
 }
 
 // RecoveredRunningSessionState maps a recovered worker's cached PTY state onto a

--- a/internal/agent/daemon_policy_test.go
+++ b/internal/agent/daemon_policy_test.go
@@ -29,15 +29,6 @@ func (d executableClassifierDriver) ClassifyWithExecutable(text, executable, wor
 	return "idle", nil
 }
 
-func TestRecoverOnMissingPTY(t *testing.T) {
-	if !RecoverOnMissingPTY(Get("claude")) {
-		t.Fatal("claude should be recoverable when PTY is missing")
-	}
-	if RecoverOnMissingPTY(Get("codex")) {
-		t.Fatal("codex should not be recoverable when PTY is missing")
-	}
-}
-
 func TestRecoveredRunningSessionState_DefaultAndAgentOverrides(t *testing.T) {
 	defaultDriver := noPolicyDriver{
 		testDriver: testDriver{

--- a/internal/daemon/agent_msg_test.go
+++ b/internal/daemon/agent_msg_test.go
@@ -263,11 +263,11 @@ func TestAgentMsgSizeRefusalsSurviveTheSocket(t *testing.T) {
 	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
 
 	d := NewForTesting(sockPath)
-	addCharacterizationSession(t, d, "sender-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
-	addCharacterizationSession(t, d, "target-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
 	go d.Start()
 	defer d.Stop()
 	waitForSocket(t, sockPath, 5*time.Second)
+	addCharacterizationSession(t, d, "sender-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
+	addCharacterizationSession(t, d, "target-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
 
 	c := client.New(sockPath)
 

--- a/internal/daemon/attach_revive_test.go
+++ b/internal/daemon/attach_revive_test.go
@@ -27,6 +27,11 @@ func (b *attachReviveBackend) Attach(context.Context, string, string) (ptybacken
 
 func newAttachReviveTestDaemon(t *testing.T, state protocol.SessionState, intent *store.LaunchIntent) (*Daemon, *attachReviveBackend, *wsClient, string) {
 	t.Helper()
+	return newAttachReviveTestDaemonForAgent(t, protocol.SessionAgentClaude, state, intent)
+}
+
+func newAttachReviveTestDaemonForAgent(t *testing.T, agent protocol.SessionAgent, state protocol.SessionState, intent *store.LaunchIntent) (*Daemon, *attachReviveBackend, *wsClient, string) {
+	t.Helper()
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	t.Cleanup(func() { _ = d.store.Close() })
 	backend := &attachReviveBackend{}
@@ -37,7 +42,7 @@ func newAttachReviveTestDaemon(t *testing.T, state protocol.SessionState, intent
 	d.store.Add(&protocol.Session{
 		ID:             "recoverable",
 		Label:          "recoverable",
-		Agent:          protocol.SessionAgentClaude,
+		Agent:          agent,
 		Directory:      cwd,
 		WorkspaceID:    "workspace",
 		State:          state,
@@ -94,6 +99,40 @@ func TestAttachReviveRespawnsRecoverableSessionFromStoredIntent(t *testing.T) {
 	}
 	if opts.Cols != 101 || opts.Rows != 37 || !opts.YoloMode || opts.Executable != intent.Executable || opts.Model != intent.Model || opts.Effort != intent.Effort {
 		t.Fatalf("spawn options = %+v, want attach geometry and stored intent", opts)
+	}
+}
+
+// Mounting the pane is what brings a crashed codex session back, and it has to
+// come back to the same conversation: the native rollout id attn persisted is
+// what the relaunch resumes, under the launch policy the session already had.
+func TestAttachReviveResumesCodexFromItsNativeRolloutID(t *testing.T) {
+	home := newRecoveryHome(t)
+	home.resumableCodex(t, "native-rollout-1")
+	intent := store.LaunchIntent{Executable: "/opt/codex", Model: "gpt-5", Effort: "high"}
+	d, backend, client, _ := newAttachReviveTestDaemonForAgent(t, protocol.SessionAgentCodex, protocol.SessionStateRecoverable, &intent)
+	d.store.SetResumeSessionID("recoverable", "native-rollout-1")
+
+	d.handleAttachSession(client, &protocol.AttachSessionMessage{
+		Cmd:          protocol.CmdAttachSession,
+		ID:           "recoverable",
+		AttachPolicy: protocol.Ptr(protocol.AttachPolicyRevive),
+		Cols:         protocol.Ptr(120),
+		Rows:         protocol.Ptr(40),
+	})
+
+	result := readAttachReviveResult(t, client)
+	if !result.Success || !protocol.Deref(result.Revived) {
+		t.Fatalf("attach result = %+v, want success with revived=true", result)
+	}
+	opts, spawned := backend.LastSpawn()
+	if !spawned {
+		t.Fatal("backend Spawn not called")
+	}
+	if opts.ResumeSessionID != "native-rollout-1" {
+		t.Fatalf("resume_session_id = %q, want the persisted native rollout id", opts.ResumeSessionID)
+	}
+	if opts.Agent != string(protocol.SessionAgentCodex) || opts.Executable != intent.Executable || opts.Model != intent.Model || opts.Effort != intent.Effort {
+		t.Fatalf("spawn options = %+v, want the stored launch intent", opts)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1175,7 +1175,10 @@ func (d *Daemon) pruneSessionsWithoutPTY(cutoff time.Time) int {
 		if sessionUpdatedAfter(session, cutoff) {
 			continue
 		}
-		if d.recoverOnMissingPTY(session) {
+		if d.canReviveSession(session) {
+			if session.State == protocol.SessionStateRecoverable {
+				continue
+			}
 			d.applyState(sessionStateChange{
 				sessionID: session.ID,
 				state:     string(protocol.SessionStateRecoverable),
@@ -1193,35 +1196,71 @@ func (d *Daemon) pruneSessionsWithoutPTY(cutoff time.Time) int {
 	return removed
 }
 
-func (d *Daemon) recoverOnMissingPTY(session *protocol.Session) bool {
-	if session == nil {
+// canReviveSession is the whole crash-recovery decision: whether the daemon
+// still holds, durably, what it takes to bring this session's conversation
+// back. Every session whose runtime is gone passes through it — kept as
+// `recoverable` when it holds, reaped when it does not.
+//
+// What the session was last seen doing is no part of it: a crash takes `idle`,
+// `working`, `waiting_input`, and `pending_approval` sessions down together and
+// leaves them equally resumable, so activity state is context for the user,
+// never the gate. Neither is the agent's name, nor a driver's advertised
+// capability — only per-session evidence on disk that the revive path will
+// actually consume.
+func (d *Daemon) canReviveSession(session *protocol.Session) bool {
+	if session == nil || d.store == nil {
 		return false
 	}
-	if agentdriver.RecoverOnMissingPTY(agentdriver.Get(string(session.Agent))) {
+	// A close the user asked for is not a crash to come back from; the row only
+	// outlives the mark when the daemon died between marking and removing it.
+	if d.store.SessionCloseIntentional(session.ID) {
+		return false
+	}
+	// How to start the replacement. reviveSessionForAttach refuses without one,
+	// so a session missing it has no way back whatever else is on disk.
+	intent, ok := d.store.LaunchIntent(session.ID)
+	if !ok {
+		return false
+	}
+	return d.sessionConversationSurvives(session, intent)
+}
+
+// sessionConversationSurvives reports whether this session's conversation is
+// still where a replacement runtime would look for it — or that there was never
+// one to lose.
+func (d *Daemon) sessionConversationSurvives(session *protocol.Session, intent store.LaunchIntent) bool {
+	// A shell keeps no conversation; the intent describes it completely.
+	if string(session.Agent) == protocol.AgentShellValue {
 		return true
 	}
-	if run := d.store.GetAgentDriverRun(session.ID); run.RunID != "" {
+	// A PTY agent resumes from an agent-native id attn persisted, and its driver
+	// is what knows whether that target is still on disk — the same question the
+	// spawn and reload paths ask before handing the id to the agent.
+	driver := agentdriver.Get(string(session.Agent))
+	resumeID := agentdriver.ResolveSpawnResumeSessionID(driver, session.ID, "", d.store.GetResumeSessionID(session.ID))
+	if agentdriver.ResumeAvailable(driver, resumeID) {
 		return true
 	}
-	if strings.TrimSpace(d.store.GetAgentMetadata(session.ID)) != "" {
+	// A conversation host's history is a file under attn's data dir that a
+	// replacement reopens. Before it has written one, what the replacement opens
+	// instead is the intent's own seed: the conversation it was forked from, or
+	// the brief it never got to say.
+	if hostSessionStateDirHoldsConversation(session.ID) {
 		return true
 	}
-	if d.plugins != nil {
-		if driver, ok := d.plugins.driver(string(session.Agent)); ok {
-			if driver.Capabilities["resume"] {
-				return true
-			}
-			// A conversation session is recoverable by definition: its whole
-			// history is the host's own session file under attn's data dir, and a
-			// replacement host reopens it. There is no `resume` capability to
-			// declare — that one describes a driver that can resume a PTY agent's
-			// transcript from an argv flag, which a host does not have.
-			if driver.Capabilities[pluginDriverConversationCapability] {
-				return true
-			}
+	if strings.TrimSpace(intent.InitialPrompt) != "" {
+		return true
+	}
+	if resumeFile := strings.TrimSpace(intent.ResumeConversationFile); resumeFile != "" {
+		if _, err := os.Stat(resumeFile); err == nil {
+			return true
 		}
 	}
-	return false
+	// A plugin runtime keeps its own history and leaves attn a per-session
+	// handle to it. Read from the store, not asked of the plugin: at startup the
+	// plugin has usually not reconnected.
+	return d.store.GetAgentDriverRun(session.ID).RunID != "" ||
+		strings.TrimSpace(d.store.GetAgentMetadata(session.ID)) != ""
 }
 
 func (d *Daemon) pluginDriverReportsState(agent protocol.SessionAgent) bool {
@@ -1524,9 +1563,6 @@ func (d *Daemon) reconcileSessionsWithWorkerBackend(ctx context.Context, allowId
 		if _, ok := liveIDs[session.ID]; ok {
 			continue
 		}
-		if session.State == protocol.SessionStateIdle || session.State == protocol.SessionStateRecoverable {
-			continue
-		}
 		if sessionUpdatedAfter(session, demotionCutoff) {
 			report.SkippedRecent++
 			continue
@@ -1547,7 +1583,11 @@ func (d *Daemon) reconcileSessionsWithWorkerBackend(ctx context.Context, allowId
 			report.SkippedIdle++
 			continue
 		}
-		if d.recoverOnMissingPTY(session) {
+		if d.canReviveSession(session) {
+			// Already parked there by an earlier pass; the verdict has not changed.
+			if session.State == protocol.SessionStateRecoverable {
+				continue
+			}
 			d.applyState(sessionStateChange{
 				sessionID: session.ID,
 				state:     string(protocol.SessionStateRecoverable),

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -471,7 +471,7 @@ func TestDaemon_ReseedWorkspaceStatusesAfterRecovery(t *testing.T) {
 	d.store.Add(&protocol.Session{
 		ID:             sessionID,
 		Label:          "claude",
-		Agent:          protocol.SessionAgentClaude, // recoverable: prune keeps it
+		Agent:          protocol.SessionAgentClaude,
 		Directory:      cwd,
 		State:          protocol.SessionStateWorking,
 		StateSince:     nowStr,
@@ -479,6 +479,9 @@ func TestDaemon_ReseedWorkspaceStatusesAfterRecovery(t *testing.T) {
 		LastSeen:       nowStr,
 		WorkspaceID:    workspaceID,
 	})
+	// Recoverable: a transcript to resume and an intent to relaunch from.
+	newRecoveryHome(t).resumableClaude(t, sessionID)
+	giveRestorationEvidence(t, d, sessionID, sessionID)
 	d.workspaces.associateSession(sessionID, workspaceID, "claude")
 
 	// Seed the cached rollup the way loadWorkspacesFromStore does at startup.
@@ -822,8 +825,10 @@ func TestDaemon_ReconcileSessionsWithWorkerBackend(t *testing.T) {
 	if report.StateUpdated != 2 {
 		t.Fatalf("state_updated = %d, want 2", report.StateUpdated)
 	}
-	if report.Reaped != 1 {
-		t.Fatalf("reaped = %d, want 1", report.Reaped)
+	// Both missing sessions go: neither has a resume target, and being idle is
+	// not a reason to keep one.
+	if report.Reaped != 2 {
+		t.Fatalf("reaped = %d, want 2", report.Reaped)
 	}
 	if report.MarkedIdle != 0 {
 		t.Fatalf("marked_idle = %d, want 0", report.MarkedIdle)
@@ -872,17 +877,11 @@ func TestDaemon_ReconcileSessionsWithWorkerBackend(t *testing.T) {
 		t.Fatalf("live-exited state = %s, want %s", liveExited.State, protocol.SessionStateIdle)
 	}
 
-	missingRunning := d.store.Get("missing-running")
-	if missingRunning != nil {
-		t.Fatal("missing-running session should be reaped (non-claude agent without live PTY)")
+	if missingRunning := d.store.Get("missing-running"); missingRunning != nil {
+		t.Fatal("missing-running session should be reaped: no worker and nothing to resume")
 	}
-
-	missingIdle := d.store.Get("missing-idle")
-	if missingIdle == nil {
-		t.Fatal("missing-idle session missing after reconcile")
-	}
-	if missingIdle.State != protocol.SessionStateIdle {
-		t.Fatalf("missing-idle state = %s, want idle", missingIdle.State)
+	if missingIdle := d.store.Get("missing-idle"); missingIdle != nil {
+		t.Fatal("missing-idle session should be reaped: idle is not evidence of anything to come back to")
 	}
 }
 
@@ -954,142 +953,6 @@ func TestDaemon_ReconcileSessionsWithWorkerBackend_ReapRemovesEmptyWorkspace(t *
 	}
 	if _, ok := d.workspaces.snapshot("ws-stale"); ok {
 		t.Fatal("empty workspace still registered after session reap")
-	}
-}
-
-func TestDaemon_ReconcileSessionsWithWorkerBackend_ClaudeSessionsRecoverable(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	now := string(protocol.TimestampNow())
-
-	// Claude session without live PTY should be marked recoverable
-	d.store.Add(&protocol.Session{
-		ID:             "claude-stale",
-		Label:          "claude-stale",
-		Agent:          protocol.SessionAgentClaude,
-		Directory:      "/tmp/claude-stale",
-		State:          protocol.SessionStateWorking,
-		StateSince:     now,
-		StateUpdatedAt: now,
-		LastSeen:       now,
-	})
-
-	// Codex session without live PTY should be reaped
-	d.store.Add(&protocol.Session{
-		ID:             "codex-stale",
-		Label:          "codex-stale",
-		Agent:          protocol.SessionAgentCodex,
-		Directory:      "/tmp/codex-stale",
-		State:          protocol.SessionStateWorking,
-		StateSince:     now,
-		StateUpdatedAt: now,
-		LastSeen:       now,
-	})
-
-	// Copilot session without live PTY should be reaped
-	d.store.Add(&protocol.Session{
-		ID:             "copilot-stale",
-		Label:          "copilot-stale",
-		Agent:          protocol.SessionAgentCopilot,
-		Directory:      "/tmp/copilot-stale",
-		State:          protocol.SessionStateWorking,
-		StateSince:     now,
-		StateUpdatedAt: now,
-		LastSeen:       now,
-	})
-
-	d.store.Add(&protocol.Session{
-		ID:             "plugin-metadata-stale",
-		Label:          "plugin-metadata-stale",
-		Agent:          "snipe",
-		Directory:      "/tmp/plugin-metadata-stale",
-		State:          protocol.SessionStateWorking,
-		StateSince:     now,
-		StateUpdatedAt: now,
-		LastSeen:       now,
-	})
-	if !d.store.BeginAgentDriverRun("plugin-metadata-stale", "snipe-plugin", "run-metadata") {
-		t.Fatal("BeginAgentDriverRun(plugin-metadata-stale) failed")
-	}
-	if !d.store.ApplyAgentDriverMetadata("plugin-metadata-stale", "run-metadata", 1, `{"native_id":"resume-me"}`) {
-		t.Fatal("ApplyAgentDriverMetadata(plugin-metadata-stale) failed")
-	}
-	d.store.EndAgentDriverRun("plugin-metadata-stale")
-
-	d.store.Add(&protocol.Session{
-		ID:             "plugin-capability-stale",
-		Label:          "plugin-capability-stale",
-		Agent:          "snipe-live",
-		Directory:      "/tmp/plugin-capability-stale",
-		State:          protocol.SessionStateWorking,
-		StateSince:     now,
-		StateUpdatedAt: now,
-		LastSeen:       now,
-	})
-	plugin := &pluginConnection{name: "snipe-live-plugin"}
-	if err := d.plugins.register(plugin); err != nil {
-		t.Fatalf("register plugin: %v", err)
-	}
-	if err := d.plugins.registerDriver(plugin, pluginDriverRegisterParams{
-		Agent:        "snipe-live",
-		Capabilities: map[string]bool{"resume": true},
-	}); err != nil {
-		t.Fatalf("register resumable driver: %v", err)
-	}
-
-	d.store.Add(&protocol.Session{
-		ID:             "plugin-owned-stale",
-		Label:          "plugin-owned-stale",
-		Agent:          "resume-before-register",
-		Directory:      "/tmp/plugin-owned-stale",
-		State:          protocol.SessionStateWorking,
-		StateSince:     now,
-		StateUpdatedAt: now,
-		LastSeen:       now,
-	})
-	if !d.store.BeginAgentDriverRun("plugin-owned-stale", "offline-plugin", "run-offline") {
-		t.Fatal("BeginAgentDriverRun(plugin-owned-stale) failed")
-	}
-
-	d.ptyBackend = &fakeWorkerReconcileBackend{
-		liveIDs: nil,
-		info:    map[string]ptybackend.SessionInfo{},
-	}
-
-	report := d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
-
-	if report.MarkedRecoverable != 4 {
-		t.Fatalf("marked_recoverable = %d, want 4", report.MarkedRecoverable)
-	}
-	if report.Reaped != 2 {
-		t.Fatalf("reaped = %d, want 2", report.Reaped)
-	}
-
-	// Claude session should be recoverable.
-	claudeSession := d.store.Get("claude-stale")
-	if claudeSession == nil {
-		t.Fatal("claude-stale session should not be reaped")
-	}
-	if claudeSession.State != protocol.SessionStateRecoverable {
-		t.Fatalf("claude-stale state = %s, want recoverable", claudeSession.State)
-	}
-	for _, id := range []string{"plugin-metadata-stale", "plugin-capability-stale", "plugin-owned-stale"} {
-		session := d.store.Get(id)
-		if session == nil || session.State != protocol.SessionStateRecoverable {
-			t.Fatalf("%s session = %+v, want recoverable plugin session", id, session)
-		}
-	}
-
-	// Non-claude sessions should be removed
-	if d.store.Get("codex-stale") != nil {
-		t.Fatal("codex-stale session should be reaped")
-	}
-	if d.store.Get("copilot-stale") != nil {
-		t.Fatal("copilot-stale session should be reaped")
-	}
-
-	secondReport := d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
-	if secondReport.MarkedRecoverable != 0 {
-		t.Fatalf("second marked_recoverable = %d, want 0", secondReport.MarkedRecoverable)
 	}
 }
 
@@ -1174,8 +1037,10 @@ func TestDaemon_PruneSessionsWithoutPTY_SkipsSessionsRegisteredAfterCutoff(t *te
 		t.Fatalf("state = %s, want %s untouched", session.State, protocol.SessionStateLaunching)
 	}
 
-	// Same session, no cutoff: the claude driver recovers on a missing PTY, which
-	// is what the guard above is holding off.
+	// Same session, no cutoff: it has a transcript and an intent, so the verdict
+	// the guard above was holding off is `recoverable`.
+	newRecoveryHome(t).resumableClaude(t, "just-registered")
+	giveRestorationEvidence(t, d, "just-registered", "just-registered")
 	if removed := d.pruneSessionsWithoutPTY(time.Time{}); removed != 0 {
 		t.Fatalf("pruneSessionsWithoutPTY(zero) removed = %d, want 0", removed)
 	}
@@ -1203,6 +1068,7 @@ func TestDaemon_PruneSessionsWithoutPTY_PreservesPluginMetadataForResume(t *test
 	if !d.store.ApplyAgentDriverMetadata("plugin-resume", "run-resume", 1, `{"native_id":"resume-me"}`) {
 		t.Fatal("ApplyAgentDriverMetadata(plugin-resume) failed")
 	}
+	giveLaunchIntent(t, d, "plugin-resume")
 
 	if removed := d.pruneSessionsWithoutPTY(time.Time{}); removed != 0 {
 		t.Fatalf("pruneSessionsWithoutPTY removed = %d, want 0", removed)
@@ -1347,7 +1213,7 @@ func TestDaemon_RunDeferredWorkerReconciliationForcesIdleDemotion(t *testing.T) 
 
 	session := d.store.Get("stale-running")
 	if session != nil {
-		t.Fatal("stale-running session should be reaped (non-claude agent without live PTY)")
+		t.Fatal("stale-running session should be reaped: no worker and nothing to resume")
 	}
 
 	warnings := d.getWarnings()

--- a/internal/daemon/host_session_revive_test.go
+++ b/internal/daemon/host_session_revive_test.go
@@ -77,27 +77,26 @@ func TestHostExitForAClosedSessionMovesNothing(t *testing.T) {
 
 // The daemon restarting is the other way a host dies. A conversation session
 // must come back as recoverable rather than be reaped: its history is on disk
-// under attn's data dir, and a replacement host reopens it.
-//
-// The driver deliberately does not declare `resume` — that capability describes
-// a PTY agent resumed from an argv flag, which a host does not have — so this is
-// exactly the case the old rules dropped.
+// under attn's data dir, and a replacement host reopens it. Nothing about that
+// needs the plugin to have reconnected — the file is the evidence.
 func TestConversationSessionSurvivesADaemonRestart(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	registerConversationDriver(t, d, "nisse")
 	addHostSession(t, d, "conv-r3")
+	d.store.SetLaunchIntent("conv-r3", store.LaunchIntent{ApprovalRoute: launchcontract.ApprovalRouteUser})
+	writeHostConversationFile(t, "conv-r3")
 	// The exit path already closed the driver run, which is what made this
 	// session look like an ordinary agent with nothing behind it.
 	d.store.EndAgentDriverRun("conv-r3")
 
 	session := d.store.Get("conv-r3")
-	if !d.recoverOnMissingPTY(session) {
+	if !d.canReviveSession(session) {
 		t.Fatal("a conversation session with no live host was going to be dropped, not recovered")
 	}
 }
 
-// The same rule must not sweep up an ordinary plugin agent that declares
-// neither capability: it has nothing to come back to.
+// The same rule must not sweep up an ordinary plugin agent with nothing behind
+// it. The launch intent is there, so what is being asserted is the second half
+// of the decision: how to relaunch is known, what to relaunch into is not.
 func TestNonConversationPluginSessionIsStillReaped(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	plugin := &pluginConnection{name: "snipe-plugin"}
@@ -115,9 +114,24 @@ func TestNonConversationPluginSessionIsStillReaped(t *testing.T) {
 		ID: "plain-1", Agent: "snipe", Label: "plain-1", Directory: t.TempDir(),
 		State: protocol.StateIdle, StateSince: now, StateUpdatedAt: now, LastSeen: now,
 	})
+	d.store.SetLaunchIntent("plain-1", store.LaunchIntent{ApprovalRoute: launchcontract.ApprovalRouteUser})
 
-	if d.recoverOnMissingPTY(d.store.Get("plain-1")) {
+	if d.canReviveSession(d.store.Get("plain-1")) {
 		t.Fatal("an agent with nothing to resume was marked recoverable")
+	}
+}
+
+// writeHostConversationFile puts a pi session file where a replacement host
+// looks for one, which is what makes the conversation survive its host.
+func writeHostConversationFile(t *testing.T, sessionID string) {
+	t.Helper()
+	dir := hostSessionStateDir(sessionID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir host state dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	if err := os.WriteFile(filepath.Join(dir, "session.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write host session file: %v", err)
 	}
 }
 

--- a/internal/daemon/session_recovery_evidence_test.go
+++ b/internal/daemon/session_recovery_evidence_test.go
@@ -1,0 +1,407 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/launchcontract"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/ptybackend"
+	"github.com/victorarias/attn/internal/store"
+	"github.com/victorarias/attn/internal/toolhome"
+	"github.com/victorarias/attn/internal/workspacelayout"
+)
+
+// A machine crash kills every worker at once and says nothing about any of
+// them. What decides whether a session survives it is the evidence left on
+// disk, so these tests are written in those terms: a resume target its driver
+// can still find, and a launch intent to start the replacement from.
+
+// recoveryHome points the tool homes at temp dirs once, so one test can give
+// several sessions resume targets without each fixture clobbering the last.
+type recoveryHome struct {
+	claudeProjects string
+	codexSessions  string
+}
+
+func newRecoveryHome(t *testing.T) recoveryHome {
+	t.Helper()
+	home, codexHome := t.TempDir(), t.TempDir()
+	t.Setenv(toolhome.EnvVar, home)
+	t.Setenv("CODEX_HOME", codexHome)
+	h := recoveryHome{
+		claudeProjects: filepath.Join(home, ".claude", "projects", "proj"),
+		codexSessions:  filepath.Join(codexHome, "sessions", "2026", "08", "10"),
+	}
+	for _, dir := range []string{h.claudeProjects, h.codexSessions} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	return h
+}
+
+// resumableClaude writes the transcript `claude --resume <id>` needs.
+func (h recoveryHome) resumableClaude(t *testing.T, resumeID string) {
+	t.Helper()
+	path := filepath.Join(h.claudeProjects, resumeID+".jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write claude transcript for %s: %v", resumeID, err)
+	}
+}
+
+// resumableCodex writes the rollout `codex resume <id>` needs.
+func (h recoveryHome) resumableCodex(t *testing.T, resumeID string) {
+	t.Helper()
+	rollout := []byte(`{"type":"session_meta","payload":{"id":"` + resumeID + `","cwd":"/tmp"}}` + "\n")
+	path := filepath.Join(h.codexSessions, "rollout-"+resumeID+".jsonl")
+	if err := os.WriteFile(path, rollout, 0o644); err != nil {
+		t.Fatalf("write codex rollout for %s: %v", resumeID, err)
+	}
+}
+
+// giveRestorationEvidence files the two durable things startup recovery looks
+// for: where the conversation is, and how to relaunch into it.
+func giveRestorationEvidence(t *testing.T, d *Daemon, sessionID, resumeID string) {
+	t.Helper()
+	d.store.SetResumeSessionID(sessionID, resumeID)
+	giveLaunchIntent(t, d, sessionID)
+}
+
+func giveLaunchIntent(t *testing.T, d *Daemon, sessionID string) {
+	t.Helper()
+	d.store.SetLaunchIntent(sessionID, store.LaunchIntent{ApprovalRoute: launchcontract.ApprovalRouteUser})
+}
+
+func addStaleSession(t *testing.T, d *Daemon, id string, agent protocol.SessionAgent, state protocol.SessionState) {
+	t.Helper()
+	now := string(protocol.TimestampNow())
+	d.store.Add(&protocol.Session{
+		ID:             id,
+		Label:          id,
+		Agent:          agent,
+		Directory:      "/tmp/" + id,
+		State:          state,
+		StateSince:     now,
+		StateUpdatedAt: now,
+		LastSeen:       now,
+	})
+	t.Cleanup(func() { d.store.Remove(id) })
+}
+
+func deadWorkerBackend() *fakeWorkerReconcileBackend {
+	return &fakeWorkerReconcileBackend{liveIDs: nil, info: map[string]ptybackend.SessionInfo{}}
+}
+
+func saveTwoPaneLayout(workspaceID, firstSessionID, secondSessionID string) workspacelayout.WorkspaceLayout {
+	pane := func(sessionID string) workspacelayout.Pane {
+		return workspacelayout.Pane{
+			PaneID:    "pane-" + sessionID,
+			RuntimeID: sessionID,
+			SessionID: sessionID,
+			Kind:      workspacelayout.PaneKindAgent,
+			Title:     workspacelayout.DefaultPaneTitle,
+		}
+	}
+	return workspacelayout.WorkspaceLayout{
+		WorkspaceID:  workspaceID,
+		ActivePaneID: "pane-" + firstSessionID,
+		Layout: workspacelayout.Node{
+			Type:      "split",
+			SplitID:   "split-" + workspaceID,
+			Direction: workspacelayout.DirectionVertical,
+			Ratio:     workspacelayout.DefaultSplitRatio,
+			Children: []workspacelayout.Node{
+				{Type: "pane", PaneID: "pane-" + firstSessionID},
+				{Type: "pane", PaneID: "pane-" + secondSessionID},
+			},
+		},
+		Panes: []workspacelayout.Pane{pane(firstSessionID), pane(secondSessionID)},
+	}
+}
+
+// The defect this replaces: a crash deleted a `working` codex session that had
+// a rollout on disk and kept an `idle` one that did not, because recovery asked
+// which agent it was and whether it looked busy. Both axes are gone — every
+// agent with a resume target survives, in every state.
+func TestRecoveryKeepsAnyResumableSessionWhateverItWasDoing(t *testing.T) {
+	home := newRecoveryHome(t)
+	states := []protocol.SessionState{
+		protocol.SessionStateIdle,
+		protocol.SessionStateWorking,
+		protocol.SessionStateWaitingInput,
+		protocol.SessionStatePendingApproval,
+	}
+	for _, state := range states {
+		for _, agent := range []protocol.SessionAgent{protocol.SessionAgentCodex, protocol.SessionAgentClaude} {
+			t.Run(string(agent)+"/"+string(state), func(t *testing.T) {
+				d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+				id := "crashed-" + string(agent) + "-" + string(state)
+				resumeID := "native-" + id
+				addStaleSession(t, d, id, agent, state)
+				if agent == protocol.SessionAgentCodex {
+					home.resumableCodex(t, resumeID)
+				} else {
+					home.resumableClaude(t, resumeID)
+				}
+				giveRestorationEvidence(t, d, id, resumeID)
+				d.ptyBackend = deadWorkerBackend()
+
+				report := d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+				if report.MarkedRecoverable != 1 {
+					t.Fatalf("marked_recoverable = %d, want 1", report.MarkedRecoverable)
+				}
+				session := d.store.Get(id)
+				if session == nil {
+					t.Fatal("a resumable session was deleted by startup recovery")
+				}
+				if session.State != protocol.SessionStateRecoverable {
+					t.Fatalf("state = %q, want recoverable", session.State)
+				}
+			})
+		}
+	}
+}
+
+// The other half of the same rule: nothing to come back to means the row goes,
+// and it goes the one way a row ever goes — reaped, with its pane. A session
+// left sitting in `recoverable` with a resume id pointing at nothing would
+// offer the user a Reload that cannot work.
+func TestRecoveryReapsWhatItCannotBringBack(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(t *testing.T, d *Daemon, home recoveryHome, id string)
+	}{
+		{
+			name: "resume target never existed",
+			setup: func(t *testing.T, d *Daemon, _ recoveryHome, id string) {
+				giveRestorationEvidence(t, d, id, "native-"+id)
+			},
+		},
+		{
+			name: "resume target is gone from disk",
+			setup: func(t *testing.T, d *Daemon, home recoveryHome, id string) {
+				home.resumableCodex(t, "native-"+id)
+				giveRestorationEvidence(t, d, id, "native-"+id)
+				if err := os.RemoveAll(home.codexSessions); err != nil {
+					t.Fatalf("remove rollouts: %v", err)
+				}
+			},
+		},
+		{
+			name: "no launch intent to relaunch from",
+			setup: func(t *testing.T, d *Daemon, home recoveryHome, id string) {
+				home.resumableCodex(t, "native-"+id)
+				d.store.SetResumeSessionID(id, "native-"+id)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := newRecoveryHome(t)
+			d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+			id := "unrecoverable"
+			addStaleSession(t, d, id, protocol.SessionAgentCodex, protocol.SessionStateWorking)
+			tc.setup(t, d, home, id)
+			d.ptyBackend = deadWorkerBackend()
+
+			report := d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+			if report.Reaped != 1 {
+				t.Fatalf("reaped = %d, want 1", report.Reaped)
+			}
+			if session := d.store.Get(id); session != nil {
+				t.Fatalf("session = %+v, want reaped: there is nothing to bring it back to", session)
+			}
+		})
+	}
+}
+
+// A verdict is only as good as the evidence behind it right now. A session
+// parked in `recoverable` whose rollout has since been pruned is not a session
+// waiting to be reloaded, it is a dead row, and skipping it because of the
+// state it is already in would keep it forever.
+func TestRecoveryRedecidesSessionsAlreadyParkedAsRecoverable(t *testing.T) {
+	home := newRecoveryHome(t)
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	addStaleSession(t, d, "still-there", protocol.SessionAgentCodex, protocol.SessionStateRecoverable)
+	addStaleSession(t, d, "target-pruned", protocol.SessionAgentCodex, protocol.SessionStateRecoverable)
+	home.resumableCodex(t, "native-still-there")
+	giveRestorationEvidence(t, d, "still-there", "native-still-there")
+	giveRestorationEvidence(t, d, "target-pruned", "native-target-pruned")
+	d.ptyBackend = deadWorkerBackend()
+
+	report := d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+	if session := d.store.Get("still-there"); session == nil || session.State != protocol.SessionStateRecoverable {
+		t.Fatalf("still-there = %+v, want left recoverable", session)
+	}
+	// It was already there, so nothing moved and nothing is announced.
+	if report.MarkedRecoverable != 0 {
+		t.Fatalf("marked_recoverable = %d, want 0 for a session already parked there", report.MarkedRecoverable)
+	}
+	if session := d.store.Get("target-pruned"); session != nil {
+		t.Fatalf("target-pruned = %+v, want reaped once its rollout was gone", session)
+	}
+}
+
+// A close the user asked for is not a crash. The mark outlives the daemon
+// precisely so a reap that runs on the next boot can still tell the two apart.
+func TestRecoveryDoesNotResurrectAnIntentionalClose(t *testing.T) {
+	home := newRecoveryHome(t)
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	addStaleSession(t, d, "closed-on-purpose", protocol.SessionAgentCodex, protocol.SessionStateWorking)
+	home.resumableCodex(t, "native-closed-on-purpose")
+	giveRestorationEvidence(t, d, "closed-on-purpose", "native-closed-on-purpose")
+	d.store.MarkSessionIntentionalClose("closed-on-purpose", time.Now())
+	d.ptyBackend = deadWorkerBackend()
+
+	d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+	if session := d.store.Get("closed-on-purpose"); session != nil {
+		t.Fatalf("session = %+v, want gone: the user already dismissed it", session)
+	}
+}
+
+// A shell holds no conversation, so there is nothing to check for and nothing
+// to lose: the intent describes it completely and the pane comes back.
+func TestRecoveryKeepsShellPanes(t *testing.T) {
+	newRecoveryHome(t)
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	addStaleSession(t, d, "utility-shell", protocol.SessionAgentShell, protocol.SessionStateIdle)
+	giveLaunchIntent(t, d, "utility-shell")
+	d.ptyBackend = deadWorkerBackend()
+
+	d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+	session := d.store.Get("utility-shell")
+	if session == nil || session.State != protocol.SessionStateRecoverable {
+		t.Fatalf("session = %+v, want recoverable", session)
+	}
+}
+
+// A plugin runtime is judged on the handle it persisted, not on what a
+// reconnected driver says it can do in general: the capability is about the
+// driver, the handle is about this conversation. At startup the plugin has
+// usually not reconnected anyway.
+func TestRecoveryJudgesPluginSessionsOnTheirPersistedHandle(t *testing.T) {
+	newRecoveryHome(t)
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+
+	addStaleSession(t, d, "plugin-with-handle", "snipe", protocol.SessionStateWorking)
+	giveLaunchIntent(t, d, "plugin-with-handle")
+	if !d.store.BeginAgentDriverRun("plugin-with-handle", "snipe-plugin", "run-handle") {
+		t.Fatal("BeginAgentDriverRun(plugin-with-handle) failed")
+	}
+	if !d.store.ApplyAgentDriverMetadata("plugin-with-handle", "run-handle", 1, `{"native_id":"resume-me"}`) {
+		t.Fatal("ApplyAgentDriverMetadata(plugin-with-handle) failed")
+	}
+	d.store.EndAgentDriverRun("plugin-with-handle")
+
+	addStaleSession(t, d, "plugin-capability-only", "snipe-live", protocol.SessionStateWorking)
+	giveLaunchIntent(t, d, "plugin-capability-only")
+	plugin := &pluginConnection{name: "snipe-live-plugin"}
+	if err := d.ensurePluginRegistry().register(plugin); err != nil {
+		t.Fatalf("register plugin: %v", err)
+	}
+	if err := d.ensurePluginRegistry().registerDriver(plugin, pluginDriverRegisterParams{
+		Agent:        "snipe-live",
+		Capabilities: map[string]bool{"resume": true},
+	}); err != nil {
+		t.Fatalf("register resumable driver: %v", err)
+	}
+
+	d.ptyBackend = deadWorkerBackend()
+	d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+	if session := d.store.Get("plugin-with-handle"); session == nil || session.State != protocol.SessionStateRecoverable {
+		t.Fatalf("plugin-with-handle = %+v, want recoverable", session)
+	}
+	if session := d.store.Get("plugin-capability-only"); session != nil {
+		t.Fatalf("plugin-capability-only = %+v, want reaped: nothing names the conversation", session)
+	}
+}
+
+// A conversation session's history is a file under attn's data dir, and before
+// the host has written one the intent's own brief is what the replacement
+// opens. Neither needs the plugin to be back.
+func TestRecoveryKeepsConversationSessionsFromTheirOwnHistory(t *testing.T) {
+	newRecoveryHome(t)
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+
+	addStaleSession(t, d, "conv-with-history", "nisse", protocol.SessionStateIdle)
+	giveLaunchIntent(t, d, "conv-with-history")
+	stateDir := hostSessionStateDir("conv-with-history")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir host state dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stateDir) })
+	if err := os.WriteFile(filepath.Join(stateDir, "session.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write host session file: %v", err)
+	}
+
+	addStaleSession(t, d, "conv-crashed-early", "nisse", protocol.SessionStateWorking)
+	d.store.SetLaunchIntent("conv-crashed-early", store.LaunchIntent{
+		ApprovalRoute: launchcontract.ApprovalRouteUser,
+		InitialPrompt: "review the crash recovery plan",
+	})
+
+	addStaleSession(t, d, "conv-empty", "nisse", protocol.SessionStateWorking)
+	giveLaunchIntent(t, d, "conv-empty")
+
+	d.ptyBackend = deadWorkerBackend()
+	d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+	for _, id := range []string{"conv-with-history", "conv-crashed-early"} {
+		if session := d.store.Get(id); session == nil || session.State != protocol.SessionStateRecoverable {
+			t.Fatalf("%s = %+v, want recoverable", id, session)
+		}
+	}
+	if session := d.store.Get("conv-empty"); session != nil {
+		t.Fatalf("conv-empty = %+v, want reaped: no history and no brief to reopen", session)
+	}
+}
+
+// The layout follows the verdict: a recoverable session keeps its pane, so the
+// user has somewhere to click Reload, and only the reaped one takes its pane
+// down with it.
+func TestRecoveryKeepsThePaneOfARecoverableSession(t *testing.T) {
+	home := newRecoveryHome(t)
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	workspaceID := "ws-crash"
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd: protocol.CmdRegisterWorkspace, ID: workspaceID, Title: "crash", Directory: "/tmp/crash",
+	})
+	for _, id := range []string{"pane-keeps", "pane-goes"} {
+		addStaleSession(t, d, id, protocol.SessionAgentCodex, protocol.SessionStateWorking)
+		d.associateSessionWithWorkspace(id, workspaceID)
+	}
+	home.resumableCodex(t, "native-pane-keeps")
+	giveRestorationEvidence(t, d, "pane-keeps", "native-pane-keeps")
+	giveRestorationEvidence(t, d, "pane-goes", "native-pane-goes")
+	if err := d.store.SaveWorkspaceLayout(saveTwoPaneLayout(workspaceID, "pane-keeps", "pane-goes")); err != nil {
+		t.Fatalf("SaveWorkspaceLayout: %v", err)
+	}
+
+	d.ptyBackend = deadWorkerBackend()
+	d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+	layout := d.store.GetWorkspaceLayout(workspaceID)
+	if layout == nil {
+		t.Fatal("workspace layout was removed with the reaped session")
+	}
+	sessions := map[string]bool{}
+	for _, pane := range layout.Panes {
+		sessions[pane.SessionID] = true
+	}
+	if !sessions["pane-keeps"] {
+		t.Fatalf("recoverable session lost its pane; layout panes = %+v", layout.Panes)
+	}
+	if sessions["pane-goes"] {
+		t.Fatalf("reaped session kept its pane; layout panes = %+v", layout.Panes)
+	}
+}


### PR DESCRIPTION
## Intent / Why

A machine crash could delete sessions that attn still had enough durable state to reopen. Startup recovery made that decision from a static agent policy and skipped some activity states before examining resumability, so survival depended on the agent name and what the session happened to be doing when the machine went down.

This change gives startup recovery one invariant: a missing-runtime session survives only when it was not intentionally closed, has a persisted launch intent, and has a restoration target that the revive path actually consumes. That target may be an agent-native resume ID, conversation-host history or its intent seed, or a persisted per-session plugin handle. Activity state remains user context; it no longer decides whether the session is kept or reaped.

## Summary

- Route both startup pruning and worker reconciliation through the same durable-resumability decision.
- Remove the legacy SessionRecoveryPolicyProvider and Claude override, the daemon recovery-policy helper, the idle/recoverable reconciliation bypass, and the plugin capability-only fallback.
- Cover the invariant with evidence-driven daemon tests and an isolated real-app machine-crash recovery scenario, and document recoverability in the glossary and changelog.
- Register the socket size-limit test synthetic sessions after daemon startup. Those fixtures intentionally have no launch intent, so the new invariant correctly reaps them during startup; creating them afterward keeps that unrelated test focused on socket behavior.

## Verification

- `make test` — passed.
- `pnpm --dir app test` — 2,709 frontend tests passed.
- `pnpm --dir app exec playwright test e2e/session-restore-reconnect.spec.ts` — focused reconnect E2E passed.
- `"$profile_app/Contents/MacOS/attn" preflight` — bundled preflight passed.
- `pnpm --dir app run real-app:scenario-crash-recovery` — isolated real machine-crash recovery scenario passed.