### PR TITLE
feat(testing): record PR evidence and publish it to the evidence repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,13 +181,13 @@ A PR with a visible change carries a recording of the live verification in its
 description. Record the run, publish, paste the emitted markdown:
 
 ```bash
-./scripts/pr-evidence.sh record --seconds 20 --out clip.mp4   # window-scoped; records the ATTN_PROFILE you are verifying on
-./scripts/pr-evidence.sh publish clip.mp4                     # pushes mp4+gif to victorarias/attn-pr-evidence, prints the markdown
+./scripts/pr-evidence.sh record --profile <name> --seconds 20 --out clip.mp4
+./scripts/pr-evidence.sh publish clip.mp4   # pushes mp4+gif to victorarias/attn-pr-evidence, prints the markdown
 ```
 
-`record` targets the window of the profile you are already live-verifying on
-(`attn-$ATTN_PROFILE`); `--app <owner>` overrides when the window belongs to
-another bundle.
+`record` captures the window of the named profile's app (`attn-<name>.app`) —
+pass the profile you installed for this verification, the same name you will
+`profile clean` later. `--app <owner>` overrides for a non-attn window.
 
 The evidence repo is public and the clip shows whatever the window shows —
 session names, transcripts, tickets. Watch the recording before publishing;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,10 @@ description. Record the run, publish, paste the emitted markdown:
 ./scripts/pr-evidence.sh publish clip.mp4                     # pushes mp4+gif to victorarias/attn-pr-evidence, prints the markdown
 ```
 
+The evidence repo is public and the clip shows whatever the window shows —
+session names, transcripts, tickets. Watch the recording before publishing;
+re-record rather than push something that should not be on the open internet.
+
 The GIF renders inline in the PR; the mp4 beside it is the full-quality
 master. GitHub never inline-plays a repo-hosted mp4 — only the GIF embeds —
 and images render only under 10MB, so keep clips around 20s (the script warns

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,9 +181,13 @@ A PR with a visible change carries a recording of the live verification in its
 description. Record the run, publish, paste the emitted markdown:
 
 ```bash
-./scripts/pr-evidence.sh record --seconds 20 --out clip.mp4   # window-scoped; --app attn-dev by default
+./scripts/pr-evidence.sh record --seconds 20 --out clip.mp4   # window-scoped; records the ATTN_PROFILE you are verifying on
 ./scripts/pr-evidence.sh publish clip.mp4                     # pushes mp4+gif to victorarias/attn-pr-evidence, prints the markdown
 ```
+
+`record` targets the window of the profile you are already live-verifying on
+(`attn-$ATTN_PROFILE`); `--app <owner>` overrides when the window belongs to
+another bundle.
 
 The evidence repo is public and the clip shows whatever the window shows —
 session names, transcripts, tickets. Watch the recording before publishing;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,22 @@ output as product evidence.
 - On failure, inspect captured pane text and native screenshots before diagnosis.
 - Remote scenarios target the local OrbStack VM (`attn-remote@orb`); provision with `pnpm --dir app run real-app:provision-remote`.
 
+### Evidence recordings
+
+A PR with a visible change carries a recording of the live verification in its
+description. Record the run, publish, paste the emitted markdown:
+
+```bash
+./scripts/pr-evidence.sh record --seconds 20 --out clip.mp4   # window-scoped; --app attn-dev by default
+./scripts/pr-evidence.sh publish clip.mp4                     # pushes mp4+gif to victorarias/attn-pr-evidence, prints the markdown
+```
+
+The GIF renders inline in the PR; the mp4 beside it is the full-quality
+master. GitHub never inline-plays a repo-hosted mp4 — only the GIF embeds —
+and images render only under 10MB, so keep clips around 20s (the script warns
+past the limit). Rendering receipts, one section per embed form:
+[attn-pr-evidence#1](https://github.com/victorarias/attn-pr-evidence/issues/1).
+
 ## Hit every surface
 
 The most common defect is a change that works on the path you tested and is

--- a/changelog.d/salty-pigeon-pr-evidence-recordings.yaml
+++ b/changelog.d/salty-pigeon-pr-evidence-recordings.yaml
@@ -1,0 +1,6 @@
+kind: internal
+area: testing
+change: >
+  scripts/pr-evidence.sh records an app window to mp4 and publishes mp4+gif to
+  victorarias/attn-pr-evidence, emitting the markdown that embeds the gif
+  inline in a PR description as testing evidence.

--- a/scripts/pr-evidence.sh
+++ b/scripts/pr-evidence.sh
@@ -68,7 +68,7 @@ cmd_record() {
   # 20s default: busy terminal content converts at ~320KB/s of gif at the
   # publish defaults (receipt: 6s live attn window -> 1.9MB), so 20s stays
   # well under GitHub's 10MB inline-render limit; 30s flirts with it.
-  local app="attn-dev" seconds=20 out=""
+  local app="" seconds=20 out=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --app) app="$2"; shift 2 ;;
@@ -77,6 +77,12 @@ cmd_record() {
       *) die "record: unknown argument $1" ;;
     esac
   done
+  # Record the profile the caller is already verifying on (attn-<profile>.app
+  # owns a window named after itself); never guess between running profiles.
+  if [[ -z "$app" ]]; then
+    [[ -n "${ATTN_PROFILE:-}" ]] || die "no --app and no ATTN_PROFILE; pass --app <owner> (e.g. attn-<profile>) or select a profile first"
+    app="attn-$ATTN_PROFILE"
+  fi
   [[ -n "$out" ]] || out="evidence-$(date +%Y%m%d-%H%M%S).mp4"
 
   local id_and_width

--- a/scripts/pr-evidence.sh
+++ b/scripts/pr-evidence.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PR evidence recordings: capture an app window to mp4, publish mp4+gif to the
+# evidence repo, and emit the markdown to paste into a PR description.
+#
+#   pr-evidence.sh record  [--app <owner>] [--seconds N] [--out FILE]
+#   pr-evidence.sh publish [--dir <name>] [--fps N] [--width N] FILE.mp4 ...
+#
+# GitHub inline-renders a GIF referenced from a public repo's raw URL, but a
+# repo-hosted mp4 (raw, blob, or release asset) is only ever a click-through
+# link, and <video> tags are stripped. Receipts, one section per embed form:
+# https://github.com/victorarias/attn-pr-evidence/issues/1. Hence the pair:
+# GIF for the inline preview, mp4 as the full-quality master.
+
+EVIDENCE_REPO="${ATTN_PR_EVIDENCE_REPO:-victorarias/attn-pr-evidence}"
+
+usage() {
+  sed -n '4,9p' "$0" | sed 's/^# \{0,1\}//'
+  exit 2
+}
+
+die() {
+  echo "pr-evidence: $*" >&2
+  exit 1
+}
+
+# Prints "<window-id> <width>" for the largest on-screen layer-0 window owned
+# by $1; with WINID_LIST=1, prints every attn* owner instead (for the error
+# path). CGWindowID is not reachable from AppleScript, so this goes through a
+# throwaway swift script.
+window_id_for_app() {
+  local owner="$1"
+  local swift_src
+  swift_src="$(mktemp -t pr-evidence-winid).swift"
+  cat > "$swift_src" <<'EOF'
+import CoreGraphics
+import Foundation
+let opts: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+guard let list = CGWindowListCopyWindowInfo(opts, kCGNullWindowID) as? [[String: Any]] else { exit(1) }
+let target = CommandLine.arguments.count > 1 ? CommandLine.arguments[1] : ""
+var best: (id: Int, area: Int, width: Int) = (0, 0, 0)
+var owners = Set<String>()
+for w in list {
+    guard (w[kCGWindowLayer as String] as? Int ?? -1) == 0 else { continue }
+    let owner = w[kCGWindowOwnerName as String] as? String ?? ""
+    if owner.hasPrefix("attn") { owners.insert(owner) }
+    guard owner == target, let num = w[kCGWindowNumber as String] as? Int,
+          let bounds = w[kCGWindowBounds as String] as? [String: Any],
+          let width = bounds["Width"] as? Int, let height = bounds["Height"] as? Int
+    else { continue }
+    if width * height > best.area { best = (num, width * height, width) }
+}
+if ProcessInfo.processInfo.environment["WINID_LIST"] != nil {
+    print(owners.sorted().joined(separator: " "))
+    exit(0)
+}
+guard best.id != 0 else { exit(3) }
+print("\(best.id) \(best.width)")
+EOF
+  swift "$swift_src" "$owner"
+}
+
+cmd_record() {
+  # 20s default: busy terminal content converts at ~320KB/s of gif at the
+  # publish defaults (receipt: 6s live attn window -> 1.9MB), so 20s stays
+  # well under GitHub's 10MB inline-render limit; 30s flirts with it.
+  local app="attn-dev" seconds=20 out=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --app) app="$2"; shift 2 ;;
+      --seconds) seconds="$2"; shift 2 ;;
+      --out) out="$2"; shift 2 ;;
+      *) die "record: unknown argument $1" ;;
+    esac
+  done
+  [[ -n "$out" ]] || out="evidence-$(date +%Y%m%d-%H%M%S).mp4"
+
+  local id_and_width
+  if ! id_and_width="$(window_id_for_app "$app")"; then
+    local candidates
+    candidates="$(WINID_LIST=1 window_id_for_app "$app")"
+    die "no on-screen window owned by \"$app\"; attn-family owners on screen: ${candidates:-none}. Pass --app <owner>."
+  fi
+  local win_id="${id_and_width%% *}"
+
+  echo "recording window $win_id of $app for ${seconds}s -> $out"
+  screencapture -x -v -V "$seconds" -l "$win_id" "$out"
+  [[ -s "$out" ]] || die "screencapture produced no file (screen-recording permission?)"
+  echo "recorded $out ($(du -h "$out" | cut -f1 | tr -d ' '))"
+}
+
+cmd_publish() {
+  local dir="" fps=10 width=960
+  local files=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dir) dir="$2"; shift 2 ;;
+      --fps) fps="$2"; shift 2 ;;
+      --width) width="$2"; shift 2 ;;
+      -*) die "publish: unknown argument $1" ;;
+      *) files+=("$1"); shift ;;
+    esac
+  done
+  [[ ${#files[@]} -gt 0 ]] || usage
+  for f in "${files[@]}"; do
+    [[ -f "$f" ]] || die "no such file: $f"
+  done
+  if [[ -z "$dir" ]]; then
+    dir="$(git branch --show-current 2>/dev/null || true)"
+    [[ -n "$dir" ]] || die "not on a git branch; pass --dir <name>"
+  fi
+  dir="${dir//\//-}"
+
+  local clone
+  clone="$(mktemp -d -t pr-evidence)"
+  trap 'rm -rf "$clone"' EXIT
+  gh repo clone "$EVIDENCE_REPO" "$clone" -- --depth 1 --quiet
+
+  mkdir -p "$clone/$dir"
+  local names=()
+  for f in "${files[@]}"; do
+    local base gif
+    base="$(basename "$f")"
+    gif="${base%.*}.gif"
+    cp "$f" "$clone/$dir/$base"
+    # Halve retina pixels, cap width, 10fps, per-clip palette. Receipt: a 3s
+    # 3644x2370 attn window clip -> 362KB gif at these defaults.
+    ffmpeg -loglevel error -y -i "$f" \
+      -vf "fps=$fps,scale='min($width,iw/2)':-2:flags=lanczos,split[s0][s1];[s0]palettegen=stats_mode=diff[p];[s1][p]paletteuse=dither=bayer:bayer_scale=4" \
+      "$clone/$dir/$gif"
+    local gif_bytes
+    gif_bytes="$(stat -f %z "$clone/$dir/$gif")"
+    if (( gif_bytes > 10485760 )); then
+      echo "warning: $gif is $((gif_bytes / 1048576))MB; GitHub inline-renders images only under 10MB — shorten the clip or lower --fps/--width" >&2
+    fi
+    names+=("$base")
+  done
+
+  git -C "$clone" add "$dir"
+  git -C "$clone" commit --quiet -m "evidence: $dir"
+  # Another agent may publish concurrently; rebase once and retry.
+  git -C "$clone" push --quiet || { git -C "$clone" pull --rebase --quiet && git -C "$clone" push --quiet; }
+  local sha
+  sha="$(git -C "$clone" rev-parse HEAD)"
+
+  echo
+  echo "published to $EVIDENCE_REPO@${sha:0:10}/$dir — paste into the PR description:"
+  echo
+  for base in "${names[@]}"; do
+    local raw="https://raw.githubusercontent.com/$EVIDENCE_REPO/$sha/$dir"
+    echo "![${base%.*}]($raw/${base%.*}.gif)"
+    echo
+    echo "[Full-quality recording (mp4)]($raw/$base)"
+    echo
+  done
+}
+
+case "${1:-}" in
+  record) shift; cmd_record "$@" ;;
+  publish) shift; cmd_publish "$@" ;;
+  *) usage ;;
+esac

--- a/scripts/pr-evidence.sh
+++ b/scripts/pr-evidence.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 # PR evidence recordings: capture an app window to mp4, publish mp4+gif to the
 # evidence repo, and emit the markdown to paste into a PR description.
 #
-#   pr-evidence.sh record  [--app <owner>] [--seconds N] [--out FILE]
+#   pr-evidence.sh record  --profile <name> [--seconds N] [--out FILE]
+#                          (or --app <owner> for a non-attn window)
 #   pr-evidence.sh publish [--dir <name>] [--fps N] [--width N] FILE.mp4 ...
 #
 # GitHub inline-renders a GIF referenced from a public repo's raw URL, but a
@@ -68,20 +69,23 @@ cmd_record() {
   # 20s default: busy terminal content converts at ~320KB/s of gif at the
   # publish defaults (receipt: 6s live attn window -> 1.9MB), so 20s stays
   # well under GitHub's 10MB inline-render limit; 30s flirts with it.
-  local app="" seconds=20 out=""
+  local app="" profile="" seconds=20 out=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
+      --profile) profile="$2"; shift 2 ;;
       --app) app="$2"; shift 2 ;;
       --seconds) seconds="$2"; shift 2 ;;
       --out) out="$2"; shift 2 ;;
       *) die "record: unknown argument $1" ;;
     esac
   done
-  # Record the profile the caller is already verifying on (attn-<profile>.app
-  # owns a window named after itself); never guess between running profiles.
+  # Record the profile under verification (attn-<profile>.app owns a window
+  # named after itself; bare "prod" is attn.app). ATTN_PROFILE only exists in
+  # the shell that eval'd profile-env, so it is a fallback, never the story.
   if [[ -z "$app" ]]; then
-    [[ -n "${ATTN_PROFILE:-}" ]] || die "no --app and no ATTN_PROFILE; pass --app <owner> (e.g. attn-<profile>) or select a profile first"
-    app="attn-$ATTN_PROFILE"
+    profile="${profile:-${ATTN_PROFILE:-}}"
+    [[ -n "$profile" ]] || die "which window? pass --profile <name> (the profile you are verifying on) or --app <owner>"
+    if [[ "$profile" == "prod" ]]; then app="attn"; else app="attn-$profile"; fi
   fi
   [[ -n "$out" ]] || out="evidence-$(date +%Y%m%d-%H%M%S).mp4"
 

--- a/scripts/pr-evidence.sh
+++ b/scripts/pr-evidence.sh
@@ -58,7 +58,10 @@ if ProcessInfo.processInfo.environment["WINID_LIST"] != nil {
 guard best.id != 0 else { exit(3) }
 print("\(best.id) \(best.width)")
 EOF
-  swift "$swift_src" "$owner"
+  local status=0
+  swift "$swift_src" "$owner" || status=$?
+  rm -f "$swift_src" "${swift_src%.swift}"
+  return "$status"
 }
 
 cmd_record() {
@@ -140,7 +143,7 @@ cmd_publish() {
   git -C "$clone" add "$dir"
   git -C "$clone" commit --quiet -m "evidence: $dir"
   # Another agent may publish concurrently; rebase once and retry.
-  git -C "$clone" push --quiet || { git -C "$clone" pull --rebase --quiet && git -C "$clone" push --quiet; }
+  git -C "$clone" push --quiet || { git -C "$clone" pull --rebase --quiet && git -C "$clone" push --quiet; } || die "push to $EVIDENCE_REPO failed"
   local sha
   sha="$(git -C "$clone" rev-parse HEAD)"
 


### PR DESCRIPTION
## What

A process for putting screen recordings in PR descriptions as evidence of testing, plus the script that runs it: `scripts/pr-evidence.sh`.

- `record` captures a single app window (`screencapture -x -v -l <windowid>`, window id resolved via CoreGraphics) to mp4 — retina, no cropping, no other windows.
- `publish` converts each mp4 to a GIF (10fps, ≤960px, per-clip palette), pushes both to [attn-pr-evidence](https://github.com/victorarias/attn-pr-evidence) under a per-branch directory, and prints sha-pinned markdown ready to paste into the PR description.

AGENTS.md documents the process next to live verification, so agents record the verification run they already perform.

## Why mp4 + GIF

GitHub only inline-plays videos uploaded through its own web UI (user-attachments), which has no API. Every repo-hosted mp4 form — raw URL, blob `?raw=true`, release asset, `<video>` tag — renders as a plain link or is stripped. A GIF referenced from a public repo's raw URL does render inline. Measured, one section per embed form: [attn-pr-evidence#1](https://github.com/victorarias/attn-pr-evidence/issues/1). So the GIF is the inline preview and the mp4 beside it is the full-quality master.

Numbers with receipts: busy terminal content converts at ~320KB/s of GIF at the publish defaults (6s live attn window → 1.9MB), so the 20s record default stays well under GitHub's 10MB image render limit; the script warns past it.

## Evidence

The process, run on itself — recorded and published by this branch's `pr-evidence.sh`:

![dogfood](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/40633cff8e09601a0c76f66e4226228e5fd85463/salty-pigeon/dogfood.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/40633cff8e09601a0c76f66e4226228e5fd85463/salty-pigeon/dogfood.mp4)

https://claude.ai/code/session_01GcYDxzNUutctekU9xV2ZDA
