### PR TITLE
fix(testing): wait on daemon startup signals

### DIFF
--- a/app/e2e/daemon-readiness.spec.ts
+++ b/app/e2e/daemon-readiness.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+import { spawn, type ChildProcess } from 'child_process';
+import * as fs from 'fs';
+import * as net from 'net';
+import * as os from 'os';
+import * as path from 'path';
+import { waitForDaemonSocket } from './daemonReadiness';
+
+async function stopChild(proc: ChildProcess): Promise<void> {
+  if (proc.exitCode !== null || proc.signalCode !== null) return;
+  await new Promise<void>((resolve) => {
+    proc.once('exit', () => resolve());
+    proc.kill('SIGTERM');
+  });
+}
+
+test('daemon readiness follows socket creation without a wall-clock poll', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'attn-ready-'));
+  const socketPath = path.join(tempDir, 'attn.sock');
+  const proc = spawn(process.execPath, ['-e', 'process.stdin.resume()'], { stdio: 'pipe' });
+  const server = net.createServer();
+
+  try {
+    const ready = waitForDaemonSocket(proc, socketPath);
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(socketPath, resolve);
+    });
+    await expect(ready).resolves.toBeUndefined();
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await stopChild(proc);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('daemon readiness reports an early child exit with its diagnostics', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'attn-ready-'));
+  const socketPath = path.join(tempDir, 'attn.sock');
+  const proc = spawn(process.execPath, ['-e', 'process.exit(23)']);
+
+  try {
+    await expect(waitForDaemonSocket(proc, socketPath, () => 'daemon log: fixture failed'))
+      .rejects.toThrow(/code 23[\s\S]*daemon log: fixture failed/);
+  } finally {
+    await stopChild(proc);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/app/e2e/daemonReadiness.ts
+++ b/app/e2e/daemonReadiness.ts
@@ -1,0 +1,75 @@
+import type { ChildProcess } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+function processExitReason(code: number | null, signal: NodeJS.Signals | null): string {
+  if (signal) return `signal ${signal}`;
+  if (code !== null) return `code ${code}`;
+  return 'an unknown status';
+}
+
+// Daemon startup has no healthy duration contract: a loaded CI runner can delay
+// the child without making it unhealthy. Readiness is the socket appearing;
+// failure is the child exiting first. The Playwright test budget remains the
+// outer tripwire for a process that is alive but genuinely wedged.
+export function waitForDaemonSocket(
+  proc: ChildProcess,
+  socketPath: string,
+  getDebugInfo?: () => string,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let watcher: fs.FSWatcher | undefined;
+
+    const finish = (complete: () => void) => {
+      if (settled) return;
+      settled = true;
+      proc.off('exit', onExit);
+      if (watcher) {
+        watcher.off('error', onWatchError);
+        watcher.close();
+      }
+      complete();
+    };
+
+    const debugSuffix = () => {
+      const debug = getDebugInfo?.().trim();
+      return debug ? `\n${debug}` : '';
+    };
+
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      finish(() => reject(new Error(
+        `Daemon exited before creating socket ${socketPath} with ${processExitReason(code, signal)}.${debugSuffix()}`,
+      )));
+    };
+
+    const onWatchError = (error: Error) => {
+      finish(() => reject(new Error(
+        `Failed to watch for daemon socket ${socketPath}: ${error.message}.${debugSuffix()}`,
+      )));
+    };
+
+    const checkReady = () => {
+      if (fs.existsSync(socketPath)) {
+        finish(resolve);
+      }
+    };
+
+    proc.once('exit', onExit);
+    try {
+      watcher = fs.watch(path.dirname(socketPath), checkReady);
+      watcher.once('error', onWatchError);
+    } catch (error) {
+      onWatchError(error instanceof Error ? error : new Error(String(error)));
+      return;
+    }
+
+    // Close both setup races: the child may have exited or created the socket
+    // before its listener/watch was installed.
+    if (proc.exitCode !== null || proc.signalCode !== null) {
+      onExit(proc.exitCode, proc.signalCode);
+      return;
+    }
+    checkReady();
+  });
+}

--- a/app/e2e/fixtures.ts
+++ b/app/e2e/fixtures.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as net from 'net';
 import { e2ePorts, resolveAttnBinaryPath } from './profileEnv';
+import { waitForDaemonSocket } from './daemonReadiness';
 import { WHATS_NEW_ID, WHATS_NEW_STORAGE_KEY } from '../src/hooks/useWhatsNew';
 
 // Mock GitHub Server
@@ -120,26 +121,6 @@ async function killTestDaemons(): Promise<void> {
   }
 }
 
-async function waitForSocket(
-  socketPath: string,
-  timeoutMs: number,
-  getDebugInfo?: () => string
-): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      const suffix = getDebugInfo ? ` ${getDebugInfo()}` : '';
-      reject(new Error(`Daemon timeout after ${timeoutMs}ms.${suffix}`));
-    }, timeoutMs);
-    const check = setInterval(() => {
-      if (fs.existsSync(socketPath)) {
-        clearInterval(check);
-        clearTimeout(timeout);
-        resolve();
-      }
-    }, 100);
-  });
-}
-
 // Create a bin directory with minimal agent stubs so the daemon reports agents
 // as available on CI machines that have no real agent CLIs installed.
 // Returns the bin dir path and a cleanup function.
@@ -164,6 +145,17 @@ function createFakeAgentStubs(): { binDir: string; cleanup: () => void } {
 // sun_path at 104 bytes. os.tmpdir() (/var/folders/...) is already too long.
 function makeDaemonTempDir(prefix: string): string {
   return fs.mkdtempSync(path.join('/tmp', prefix));
+}
+
+function daemonStartDebugInfo(tempDir: string, stdout: string, stderr: string): string {
+  const logPath = path.join(tempDir, 'daemon.log');
+  let daemonLog = '';
+  try {
+    daemonLog = fs.readFileSync(logPath, 'utf8');
+  } catch {
+    daemonLog = '(daemon log was not created)';
+  }
+  return `stdout: ${stdout}\nstderr: ${stderr}\ndaemon log: ${daemonLog}`;
 }
 
 // Daemon launcher - creates isolated temp directory for DB and socket
@@ -191,6 +183,7 @@ async function startDaemon(ghUrl: string): Promise<{ proc: ChildProcess; socketP
     env: {
       ...process.env,
       PATH: `${stubs.binDir}${path.delimiter}${process.env.PATH}`,
+      ATTN_DATA_DIR: tempDir,
       ATTN_WS_PORT: TEST_DAEMON_PORT, // Use test port to avoid conflicts with production daemon
       ATTN_SOCKET_PATH: socketPath, // Test isolation: separate socket
       ATTN_DB_PATH: dbPath, // Test isolation: separate database
@@ -218,7 +211,7 @@ async function startDaemon(ghUrl: string): Promise<{ proc: ChildProcess; socketP
     console.log(`[Daemon] Process exited with code ${code}, signal ${signal}`);
   });
 
-  await waitForSocket(socketPath, 5000, () => `stdout: ${stdout}\nstderr: ${stderr}`);
+  await waitForDaemonSocket(proc, socketPath, () => daemonStartDebugInfo(tempDir, stdout, stderr));
   console.log(`Daemon started with socket at ${socketPath}`);
 
   return {
@@ -280,6 +273,7 @@ function createManagedDaemon(ghUrl: string): ManagedDaemon {
       env: {
         ...process.env,
         PATH: `${stubs.binDir}${path.delimiter}${process.env.PATH}`,
+        ATTN_DATA_DIR: tempDir,
         ATTN_WS_PORT: TEST_DAEMON_PORT,
         ATTN_SOCKET_PATH: socketPath,
         ATTN_DB_PATH: dbPath,
@@ -307,7 +301,7 @@ function createManagedDaemon(ghUrl: string): ManagedDaemon {
       proc = null;
     });
 
-    await waitForSocket(socketPath, 5000, () => `stdout: ${stdout}\nstderr: ${stderr}`);
+    await waitForDaemonSocket(proc, socketPath, () => daemonStartDebugInfo(tempDir, stdout, stderr));
     console.log(`[Managed daemon] started with socket ${socketPath}`);
   };
 

--- a/changelog.d/brisk-badger-ci-flake-fixes.yaml
+++ b/changelog.d/brisk-badger-ci-flake-fixes.yaml
@@ -1,0 +1,9 @@
+kind: internal
+area: tests
+change: >
+  Closed the remaining false-attribution paths in the active CI flake ledger.
+  End-to-end daemon startup now follows Unix socket creation and child exit
+  instead of racing a fixed deadline, with isolated daemon logs attached to an
+  early failure. Startup-recovery tests now wait for the daemon's real recovery
+  completion signal before asserting pruned state instead of querying while the
+  recovery goroutine is still running.

--- a/docs/plans/2026-08-11-ci-flake-ledger.md
+++ b/docs/plans/2026-08-11-ci-flake-ledger.md
@@ -1,0 +1,95 @@
+# Plan: close the active CI flake ledger
+
+## Goal
+
+Remove the root causes behind the active entries in issue #796 without weakening
+the scenarios they protect. Treat failures on branches that predate an existing
+fix as historical evidence rather than changing current code again.
+
+## Findings
+
+- `agent pane stays painted after opening a shell split` failed by reading the
+  last trace entry after a healthy draw; that entry can be a no-op paint with
+  `quads: null`. Current main already fixes this in `487adce1` by reading
+  `lastRealDraw`. The Aug 9 occurrences came from branches without that commit.
+- `agent stays painted when split races a chunked redraw` and `hovering a chooser
+  row does not change the Enter target` did not reach their scenarios. Both
+  failed in `app/e2e/fixtures.ts` because a live child process had not created
+  its Unix socket before the fixture's fixed five-second deadline. The same
+  fixture failure has also been attributed to session-restore and state-color
+  tests.
+- `TestDaemon_PrunesSessionsWithoutLivePTYOnStart` queries after the Unix socket
+  appears, but startup PTY recovery deliberately continues in a goroutine. The
+  test sometimes observes the seeded session before recovery prunes it.
+
+## Architecture Map
+
+```text
+E2E today:
+test -> spawn daemon -> poll socket path + fixed deadline -> scenario
+
+E2E target:
+test -> spawn daemon -> watch socket directory
+                    \-> observe child exit
+                       -> socket exists: scenario
+                       -> child exits: fail with process/log evidence
+
+Go test today:
+Start -> socket/listener ready -> recovery goroutine -> prune seeded session
+ test ---------------------------> query (races recovery)
+
+Go test target:
+Start -> socket/listener ready -> recovery goroutine -> close recovery signal
+ test --------------------------------------------------> query
+```
+
+## Boundaries
+
+- The E2E fixture owns process readiness. Individual scenarios must not grow
+  retries or larger time budgets to compensate for daemon startup.
+- `Daemon` owns startup recovery state and its completion signal. Tests wait on
+  that real lifecycle edge rather than sleeping or polling.
+- Terminal paint assertions and RepoOptions keyboard behavior stay unchanged;
+  the observed failures provide no evidence that either product behavior is
+  wrong on current main.
+
+## Implementation Steps
+
+- [x] Replace the E2E socket interval and fixed startup deadline with a
+      race-safe filesystem watch plus child-exit handling for both daemon
+      launchers; retain actionable stdout, stderr, and daemon-log diagnostics.
+- [x] Add a waitable daemon recovery completion signal and change the shared Go
+      test helper to wait on it.
+- [x] Update `TestDaemon_PrunesSessionsWithoutLivePTYOnStart` to wait for
+      recovery rather than sleeping for startup and querying mid-recovery.
+- [x] Add focused tests for readiness success/child-exit cleanup and recovery
+      signaling where the seam can be tested without wall-clock timing.
+- [x] Run the targeted Go test under repetition and race detection, the exact
+      E2E scenarios that received the false attribution, frontend
+      tests/typecheck, and the relevant broader suites.
+- [x] Add one internal changelog fragment for the flake fixes.
+
+## Decisions
+
+- Do not modify the current split-paint test for the dominant ledger entry; its
+  fix is already on main and the later failures executed older test code.
+- Fix the shared E2E launcher once. Raising its deadline would leave an
+  unmeasured limit and preserve false attribution to whichever scenario happens
+  to start next.
+- Keep startup recovery asynchronous in production. Registration during that
+  window is intentional and protected by the recovery cutoff; only tests that
+  assert post-recovery state need the completion edge.
+- Scope both E2E daemon launchers with `ATTN_DATA_DIR` as well as their explicit
+  database and socket paths. Startup diagnostics now come from the same isolated
+  directory instead of risking inherited profile paths.
+
+## Verification
+
+- `go test ./internal/daemon`: passed.
+- Recovery signal and startup-prune tests: 25 consecutive passes and clean under
+  the race detector.
+- `pnpm --dir app exec tsc --noEmit`: passed.
+- `pnpm --dir app test`: 243 files passed; 2,714 tests passed and 15 skipped.
+- Readiness seam E2E: both socket-creation and child-exit cases passed.
+- Exact ledger scenarios passed: chunked split redraw and LocationPicker
+  hover/Enter targeting.

--- a/internal/daemon/agent_msg_test.go
+++ b/internal/daemon/agent_msg_test.go
@@ -266,6 +266,7 @@ func TestAgentMsgSizeRefusalsSurviveTheSocket(t *testing.T) {
 	go d.Start()
 	defer d.Stop()
 	waitForSocket(t, sockPath, 5*time.Second)
+	waitForRecovery(t, d)
 	addCharacterizationSession(t, d, "sender-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
 	addCharacterizationSession(t, d, "target-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -299,10 +299,11 @@ type Daemon struct {
 	// snooze can land in. Tests only; nil in production. See snooze.go.
 	snoozeWakeGapHook func(sessionID string)
 
-	recoveryMu    sync.RWMutex
-	recovering    bool
-	notebookMu    sync.Mutex
-	notebookStore *notebook.Store
+	recoveryMu      sync.RWMutex
+	recovering      bool
+	recoverySettled chan struct{}
+	notebookMu      sync.Mutex
+	notebookStore   *notebook.Store
 	// notebookWatcher observes notebook.root for external edits; guarded by its
 	// own mutex (distinct from notebookMu) so notebookStoreFor can start it
 	// without nesting locks. Lazily started on first notebook use.
@@ -570,6 +571,12 @@ func (d *Daemon) setRecovering(value bool) {
 	var pending []*wsClient
 
 	d.recoveryMu.Lock()
+	if value && !d.recovering {
+		d.recoverySettled = make(chan struct{})
+	}
+	if !value && d.recovering && d.recoverySettled != nil {
+		close(d.recoverySettled)
+	}
 	d.recovering = value
 	if !value {
 		pending = make([]*wsClient, 0, len(d.pendingInitialWS))
@@ -591,6 +598,21 @@ func (d *Daemon) isRecovering() bool {
 	d.recoveryMu.RLock()
 	defer d.recoveryMu.RUnlock()
 	return d.recovering
+}
+
+var recoveryAlreadySettled = func() <-chan struct{} {
+	settled := make(chan struct{})
+	close(settled)
+	return settled
+}()
+
+func (d *Daemon) recoverySettledSignal() <-chan struct{} {
+	d.recoveryMu.RLock()
+	defer d.recoveryMu.RUnlock()
+	if !d.recovering || d.recoverySettled == nil {
+		return recoveryAlreadySettled
+	}
+	return d.recoverySettled
 }
 
 func (d *Daemon) scheduleInitialState(client *wsClient) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -169,13 +169,7 @@ func waitForSocket(t *testing.T, sockPath string, timeout time.Duration) {
 
 func waitForRecovery(t *testing.T, d *Daemon) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	for d.isRecovering() {
-		if time.Now().After(deadline) {
-			t.Fatal("daemon recovery did not finish before test setup")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	<-d.recoverySettledSignal()
 }
 
 func shortTempDir(t *testing.T) string {
@@ -429,9 +423,9 @@ func TestDaemon_PrunesSessionsWithoutLivePTYOnStart(t *testing.T) {
 			t.Fatalf("daemon start error: %v", err)
 		}
 		t.Fatal("daemon exited unexpectedly during startup")
-	case <-time.After(75 * time.Millisecond):
+	case <-d.startedCh:
 	}
-	waitForSocket(t, sockPath, 3*time.Second)
+	waitForRecovery(t, d)
 
 	c := client.New(sockPath)
 	sessions, err := c.Query("")
@@ -449,6 +443,27 @@ func TestDaemon_PrunesSessionsWithoutLivePTYOnStart(t *testing.T) {
 	if warnings[0].Code != "stale_sessions_pruned" {
 		t.Fatalf("warning code = %q, want stale_sessions_pruned", warnings[0].Code)
 	}
+}
+
+func TestDaemon_RecoverySettledSignalFollowsEachRecoveryCycle(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+
+	if settled := d.recoverySettledSignal(); settled != recoveryAlreadySettled {
+		t.Fatal("a daemon outside recovery returned a blocking signal")
+	}
+
+	d.setRecovering(true)
+	first := d.recoverySettledSignal()
+	d.setRecovering(false)
+	<-first
+
+	d.setRecovering(true)
+	second := d.recoverySettledSignal()
+	if second == first {
+		t.Fatal("a new recovery cycle reused the prior completion signal")
+	}
+	d.setRecovering(false)
+	<-second
 }
 
 // Startup recovery rewrites session states directly in the store (prune marks a


### PR DESCRIPTION
## Summary

- replace the shared E2E daemon startup poll and fixed deadline with Unix-socket creation and child-exit signals
- include isolated stdout, stderr, and daemon-log evidence when startup fails
- expose a recovery-cycle completion signal so daemon startup tests assert post-recovery state without sleeping or polling
- document the active issue #796 root causes and preserve the existing product assertions unchanged

## Root cause

Several E2E failures attributed to terminal redraw and LocationPicker scenarios happened before those scenarios ran: a healthy daemon child had not created its socket before the fixture's fixed deadline. Separately, `TestDaemon_PrunesSessionsWithoutLivePTYOnStart` queried the store while asynchronous startup PTY recovery could still be pruning the seeded session.

CI found the same ordering bug in `TestAgentMsgSizeRefusalsSurviveTheSocket`: it seeded its sender and target after the socket appeared but before recovery settled, so recovery could prune them before the message was handled. It now waits on the same recovery completion edge before seeding.

The dominant split-paint ledger entry is already fixed on main by `487adce1`; its later occurrences ran older branch code.

## Validation

- `go test ./internal/daemon`
- targeted startup-prune and recovery-signal tests, 25 consecutive runs
- socket message size-refusal test, 25 consecutive runs
- targeted tests under `go test -race`
- `pnpm --dir app exec tsc --noEmit`
- `pnpm --dir app test` — 243 files, 2,714 passed, 15 skipped
- Playwright readiness success and early-exit diagnostics
- exact LocationPicker hover/Enter and chunked split-redraw scenarios against the branch binary
- `go run ./cmd/changelog-check`

No protocol or user-visible behavior changes.