### PR TITLE
docs: the home–garden–crew arc — spine plan, vocabulary, absorption ledger

### DIFF
--- a/changelog.d/home-garden-crew-arc-plan.yaml
+++ b/changelog.d/home-garden-crew-arc-plan.yaml
@@ -1,0 +1,11 @@
+kind: internal
+area: docs
+change: >
+  The central-server ground pass grew into the home–garden–crew arc's spine
+  plan: the code-verified map of the hub/relay, the home daemon / outpost /
+  enrollment concepts it surfaced (with glossary entries), the fence that
+  defers the multi-machine price until the uplink channel exists, the arc's
+  sequencing (messaging, vocabulary and fence, garden, crew, uplink,
+  server), and the smallest honest first version of the server. The garden
+  and messaging plans now name their stage in the arc, and the garden
+  plan's backwards PR-flow analogy is corrected.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -311,6 +311,47 @@ equally resumable, so what a session was last seen doing is context for the user
 and never the reason it survives or is reaped. A session that cannot be brought
 back is **reaped**: the row and its pane go, rather than lingering as a Reload
 that cannot work.
+## Home daemon
+
+A daemon that is **its own home** — standalone, complete, owning its garden,
+its crew, and every other piece of user-level shared state. Every fresh
+install starts as a home daemon, and the user's app talks to one. "Home" is
+not a rank or a different binary: it is the default state of any daemon that
+nobody has enrolled, and the one that may have enrolled others.
+
+The ownership rule underneath: **every piece of state has exactly one owner
+daemon; everyone else is a client of it.** Sessions are owned by the daemon
+where they run — including on outposts; the garden and the crew are owned by
+a home daemon, because one board and one roster are their whole point.
+
+The central server (closed, operated, optional) connects **home daemons to
+each other** — federation, a different relationship from home↔outpost
+ownership. Outposts never meet the server; a home represents its whole
+fleet. Plan:
+[docs/plans/2026-08-10-home-garden-crew-arc.md](plans/2026-08-10-home-garden-crew-arc.md).
+
+## Outpost
+
+A daemon **enrolled to a home**: it keeps owning its own sessions, but
+garden and crew asks pass to its home over the **uplink** (the generic
+outpost-asks-home intent channel). An outpost holds no garden state at all —
+not a copy, not a cache; reads pass through like writes.
+
+**Enrollment** is the recorded, mutual act that makes an outpost: the
+outpost persists its home's daemon id, and only a connection presenting that
+identity acts as home. Every daemon has exactly one home; a second home
+dialing an already-enrolled outpost is a loud re-home decision, never silent
+adoption.
+
+Until the uplink is built, outposts are **fenced**: garden and crew surfaces
+refuse on an outpost with an error naming the home and the plan tracking the
+gap. Everything outposts do today — sessions, PTY, PR flows, local
+tickets — is unaffected.
+
+The transport vocabulary is older than these words and stays: **hub** (the
+code's name for the dialing side), **endpoint** (a stored SSH target), and
+**remote** (the dialed machine) describe the plumbing; home and outpost
+describe the ownership relationship carried over it.
 
 ## Conversation session
 

--- a/docs/plans/2026-08-06-the-garden-vertical-slices.md
+++ b/docs/plans/2026-08-06-the-garden-vertical-slices.md
@@ -78,9 +78,12 @@ to fix.
 ## Design decisions (cross-slice)
 
 - **Storage: docstore, `core/garden` namespace.** Collections `seeds` and
-  `notes` (audit/progress entries keyed by seed id — a separate collection,
-  not an embedded array, so a long-tended seed never bloats its own
-  document). Live queries, bus change events, and revision-checked writes
+  `notes` (keyed by seed id — a separate collection, not an embedded array,
+  so a long-tended seed never bloats its own document). Notes are the
+  general historical-context surface, not just machine audit (Victor,
+  2026-08-10): an agent writes what happened and what it learned, addressed
+  to whoever tends that seed next; a note scoped to the whole effort goes on
+  the crown, which works with no extra machinery because a crown is a seed. Live queries, bus change events, and revision-checked writes
   come free; schema can move fast while the shape settles. Single-writer
   invariants (one active tender) are enforced in daemon code, the
   `applyState` way — not by table constraints.

--- a/docs/plans/2026-08-06-the-garden-vertical-slices.md
+++ b/docs/plans/2026-08-06-the-garden-vertical-slices.md
@@ -83,7 +83,15 @@ to fix.
   general historical-context surface, not just machine audit (Victor,
   2026-08-10): an agent writes what happened and what it learned, addressed
   to whoever tends that seed next; a note scoped to the whole effort goes on
-  the crown, which works with no extra machinery because a crown is a seed. Live queries, bus change events, and revision-checked writes
+  the crown, which works with no extra machinery because a crown is a seed.
+  The read side is part of the surface (Victor, 2026-08-10): notes appear
+  where the tender already looks — a seed's show includes its recent notes
+  and, when the seed sits in a plot, the crown's — never behind a verb
+  nobody is told to run. Volume stays under the agent's control: the
+  default shows the most recent few and names what it withheld ("12 more —
+  `attn seed notes <id>`"), with the full list pageable and filterable.
+  A silent truncation here recreates the unread bulletin board this
+  surface exists to replace. Live queries, bus change events, and revision-checked writes
   come free; schema can move fast while the shape settles. Single-writer
   invariants (one active tender) are enforced in daemon code, the
   `applyState` way — not by table constraints.

--- a/docs/plans/2026-08-06-the-garden-vertical-slices.md
+++ b/docs/plans/2026-08-06-the-garden-vertical-slices.md
@@ -2,6 +2,13 @@
 
 ## Alignment
 
+Stage 3 of the **home–garden–crew arc**
+([docs/plans/2026-08-10-home-garden-crew-arc.md](2026-08-10-home-garden-crew-arc.md)),
+which owns the sequencing around this plan: the home/outpost vocabulary,
+the fence that keeps these slices home-only, the uplink that later unfences
+outposts (and gates ticket retirement), and the central server. This plan
+owns the garden itself.
+
 First vertical through
 [docs/vision/friendly-home-for-agents.md](../vision/friendly-home-for-agents.md):
 the fine-grained, addressable work graph — **seeds** — for any attn-living
@@ -93,8 +100,14 @@ to fix.
   the daemon the app talks to. A garden per daemon is a split brain: a remote
   delegate asking its own daemon would see an empty garden, and remotely
   planted seeds would never reach the panel. So a remote session's seed
-  commands must reach the hub's garden over the relay, the way PR flows
-  already do. Cross-machine and offline syncing is real and wanted, and rides
+  commands must reach the hub's garden over the relay. (An earlier draft said
+  "the way PR flows already do" — the 2026-08-09 central-server ground pass
+  found that analogy backwards: PR flows travel hub → remote, keyed on ids
+  the hub already knows, while seed commands need remote → hub, a direction
+  with no path today. The shape that fixes it — an inverted request/response
+  over the existing relay connection — is in
+  [docs/plans/2026-08-10-home-garden-crew-arc.md](2026-08-10-home-garden-crew-arc.md).)
+  Cross-machine and offline syncing is real and wanted, and rides
   the central-server arc (see the vision's blindspot) — hub-local is the
   honest first version, not the end state.
 - **Server-ready, not server-dependent.** The future central server (closed,
@@ -450,11 +463,16 @@ Acceptance:
   itself is the first rendering, not a commitment — whether the garden
   becomes the app's front door is a named question in the vision, decided
   with the foundational rendering work.
-- The relay mechanics for remote sessions: how `attn seed …` from a session
+- ~~The relay mechanics for remote sessions: how `attn seed …` from a session
   on a remote daemon reaches the hub's garden (relayed command vs. another
-  path), and what happens when the hub is unreachable. Must be answered
-  before slice 5's dispatch acceptance can include a remote delegate;
-  cross-machine syncing proper stays with the central-server arc.
+  path), and what happens when the hub is unreachable.~~ Answered by the
+  2026-08-09 central-server ground pass: an inverted request/response over
+  the existing relay (remote daemon pushes an intent event to its connected
+  hub-kind client; the hub applies and the result returns), and a loud
+  refusal when no hub is connected — see
+  [docs/plans/2026-08-10-home-garden-crew-arc.md](2026-08-10-home-garden-crew-arc.md).
+  Still to build before slice 5's dispatch acceptance can include a remote
+  delegate; cross-machine syncing proper stays with the central-server arc.
 - Whether `ready` should exclude seeds whose tender session is dead vs.
   recoverable (interacts with daemon-owned revive). Slice 3 decides.
 - Crew references: free-string member names are knowingly un-validated

--- a/docs/plans/2026-08-06-the-garden-vertical-slices.md
+++ b/docs/plans/2026-08-06-the-garden-vertical-slices.md
@@ -91,7 +91,9 @@ to fix.
   default shows the most recent few and names what it withheld ("12 more —
   `attn seed notes <id>`"), with the full list pageable and filterable.
   A silent truncation here recreates the unread bulletin board this
-  surface exists to replace. Live queries, bus change events, and revision-checked writes
+  surface exists to replace. Prose quality for crown bodies and notes is
+  the [density gate](2026-08-10-prose-density-gate.md)'s job, not this
+  plan's. Live queries, bus change events, and revision-checked writes
   come free; schema can move fast while the shape settles. Single-writer
   invariants (one active tender) are enforced in daemon code, the
   `applyState` way — not by table constraints.

--- a/docs/plans/2026-08-08-converse-and-observe.md
+++ b/docs/plans/2026-08-08-converse-and-observe.md
@@ -2,6 +2,11 @@
 
 ## Goal
 
+Stage 1 of the **home–garden–crew arc**
+([2026-08-10-home-garden-crew-arc.md](2026-08-10-home-garden-crew-arc.md));
+message state is daemon-local by design, so this vertical needs no fence
+and cross-daemon addressing waits for the arc's uplink.
+
 First vertical through the **agents converse and observe** rock in
 [docs/vision/friendly-home-for-agents.md](../vision/friendly-home-for-agents.md):
 an attn-living agent inspects what another session is doing without
@@ -281,7 +286,12 @@ only channel.
   making polite delivery late.
 - Whether peek's screen text should ever travel to remote/hub sessions
   (relay is a text pipe, so mechanically fine) — out of v1 scope, noted for
-  the server-as-client arc.
+  the server-as-client arc. Cross-daemon msg and peek more broadly hit the
+  missing remote→hub direction the central-server ground pass mapped; when
+  they leave one daemon, they ride the generic "remote daemon asks its hub"
+  channel from
+  [2026-08-10-home-garden-crew-arc.md](2026-08-10-home-garden-crew-arc.md),
+  not a bespoke path.
 
 ## Follow-ups
 

--- a/docs/plans/2026-08-08-converse-and-observe.md
+++ b/docs/plans/2026-08-08-converse-and-observe.md
@@ -121,8 +121,18 @@ CLI exemplars to mimic: `cmd/attn/state_explain.go` (read, session-scoped,
 
 ## Implementation Steps
 
-### Slice 1 — peek
+Each slice is its own PR, against main, peek first (Victor, 2026-08-10):
+slice 1 is read-only and merges fast, proving the protocol plumbing before
+the heavier slice lands on top.
 
+### Slice 1 — peek and list
+
+- [ ] `attn agent list`: sessions on this daemon — short id, name,
+      workspace, state, turn-owed — served from the same store the app
+      snapshot reads. Read-only, no PTY contact. This is the address
+      book: session ids are not exposed anywhere a user or agent
+      otherwise sees, so list is the only source of the ids every other
+      `attn agent` command takes.
 - [ ] Protocol: `AgentPeekMessage` / `AgentPeekResult` in `main.tsp`,
       `make generate-types`, version bump, `CommandMeta` (`ScopeSession`),
       decoder case.
@@ -136,15 +146,17 @@ CLI exemplars to mimic: `cmd/attn/state_explain.go` (read, session-scoped,
 - [ ] Tests: store-backed daemon test (state+todos), transcript fixture,
       snapshot-less degrade; CLI output golden.
 
-Acceptance: from session A, `attn agent peek B` shows B's state, todos,
-last assistant message, and screen while B is mid-turn — and B's transcript
-shows no reaction of any kind.
+Acceptance: from session A, `attn agent list` names B and its id;
+`attn agent peek B` shows B's state, todos, last assistant message, and
+screen while B is mid-turn — and B's transcript shows no reaction of any
+kind.
 
 ### Slice 2 — msg
 
 - [ ] Migration: create `agent_messages`, drop
-      `chief_of_staff_dispatch_messages` (never written; check
-      `MAX(version)` in real DBs before numbering).
+      `chief_of_staff_dispatch_messages` (never written; drop approved by
+      Victor 2026-08-10 — state that in the PR, no further receipts
+      needed; check `MAX(version)` in real DBs before numbering).
 - [ ] Protocol: `AgentMsgMessage` / `AgentMsgResult` (`delivered | queued`),
       version bump.
 - [ ] Daemon: `handleAgentMsg` — persist row, compose attributed prompt,
@@ -180,6 +192,14 @@ shows no reaction of any kind.
       first (bracketed paste of multi-KB text through the fence), set the
       tripwire past it, and make the error name the limit, its value, and
       the ask.
+- [ ] Discoverability: `attn agent` group joins `writeHelp`, and the
+      embedded attn skill (`internal/agent/attn_skill/`) gets a
+      converse-and-observe reference plus its capability-index line —
+      agents read errors, help, and skills, never our code, and the skill
+      is the only surface that teaches the verbs *before* first contact
+      (the composed prompt teaches the reply path after). Ships in this
+      slice, not before: the skill advertises the verbs only once both
+      exist.
 - [ ] Tests: delivery mid-idle, queue-then-deliver across a state change,
       attribution format (boundary line included), self-msg, cap error,
       guard verdicts (dedupe repeat, rate throttle, full queue — each
@@ -268,6 +288,15 @@ only channel.
   deference to "from trellis", the envelope never changes — and granting
   weight to a name is safe only because attribution is daemon-composed
   and unforgeable.
+- **Deliver whenever the guard allows** (Victor, 2026-08-10): no
+  prefer-idle politeness in v1 — waiting for idle means a message to an
+  agent grinding a long turn arrives after the moment that made it worth
+  sending. The socket-transport follow-up makes mid-turn delivery polite
+  for claude targets instead of making polite delivery late.
+- **Discovery ships with the primitives** (Victor, 2026-08-10): `attn
+  agent list` lands in slice 1 beside peek — both prior arts shipped the
+  pair, and ids exist nowhere else — and help + embedded-skill
+  discoverability closes slice 2.
 - **Loop guard ships in v1** (Victor, 2026-08-08; reverses the ping-pong
   open question in the first draft of this plan). The draft ruling — no
   rate machinery, single-user garden, visible panes — fell to evidence:
@@ -277,13 +306,6 @@ only channel.
 
 ## Open Questions
 
-- **`working`-state delivery for claude targets**: mid-turn injection is
-  memory-safe for claude and queued-by-doorbell for codex, but whether msg
-  should *prefer* waiting for idle (politeness) over immediate delivery is
-  a product feel question — v1 delivers whenever the guard allows, matching
-  ticket nudges. The socket transport follow-up is the likely long-term
-  answer for claude targets: it makes mid-turn delivery polite instead of
-  making polite delivery late.
 - Whether peek's screen text should ever travel to remote/hub sessions
   (relay is a text pipe, so mechanically fine) — out of v1 scope, noted for
   the server-as-client arc. Cross-daemon msg and peek more broadly hit the
@@ -307,8 +329,6 @@ only channel.
   socket's wire format, and hold behavior for attn-launched sessions
   (bypass-class receivers hold unattributed posts unless
   `crossSessionInbound: accept`, which attn's managed settings could set).
-- `attn agent` group joins `writeHelp` once both subcommands exist
-  (`ticket` precedent: wired before advertised).
 - Glossary entries for *peek* and *message* when the vocabulary survives
   first contact.
 - Crew addressing (`attn agent msg trellis`) after the daemon crew

--- a/docs/plans/2026-08-10-home-garden-crew-arc.md
+++ b/docs/plans/2026-08-10-home-garden-crew-arc.md
@@ -1,0 +1,326 @@
+# Plan: the home–garden–crew arc
+
+Spine plan for the arc that takes attn from single-daemon sessions to a
+crewed, multi-machine home: agent messaging, home daemons and outposts, the
+garden, the crew primitive, the uplink, the central server. Stage detail
+lives in the stage plans — [messaging](2026-08-08-converse-and-observe.md),
+[the garden](2026-08-06-the-garden-vertical-slices.md), the crew plan when
+it is written. This doc owns what none of them can: the vocabulary, the
+sequencing, the fence, and the server.
+
+`docs/glossary.md` owns the terms (home daemon, outpost, enrollment). The
+server stances already ruled — closed source, operated by Victor,
+optional-never-required, sole-applier, union-by-prefix never merge, API-key
+auth — are taken as given.
+
+## Concepts
+
+**One owner per piece of state.** Ownership is per kind of state, never per
+machine rank; everyone else is a client of the owner.
+
+| state | owner | everyone else |
+|---|---|---|
+| sessions, PTY, local tickets | the daemon they run on | live in-memory mirror at the home, discarded on disconnect |
+| the garden, the crew | the home daemon | outposts ask over the uplink; nothing flows down, reads included |
+| the cross-home union | nobody — it is a view | the server renders it, routed by daemon prefix, and writes nothing |
+
+**Every daemon has exactly one home.** A **home daemon** is standalone and
+complete — it owns its garden and crew, every fresh install starts as one,
+and the user's app talks to one. An **outpost** is a daemon enrolled to a
+home: it keeps its own sessions and passes garden and crew asks upward.
+**Enrollment** is the recorded, mutual act: the outpost persists its home's
+daemon id (`d-<32 hex>`, `internal/daemon/instance_id.go:16`). A second
+home dialing an enrolled outpost is a loud re-home decision, never silent
+adoption.
+
+**The uplink is one generic channel.** Outpost-asks-home: an intent
+envelope with a kind, sent over the relay connection the home already
+dialed, answered with a result. Seeds are its first rider; cross-daemon msg
+and peek ride the same channel later. Never a bespoke path per feature.
+
+**Home↔outpost is ownership; home↔server is federation.** The server
+connects home daemons to each other and owns nothing. Outposts never meet
+the server; a home represents its whole fleet.
+
+```mermaid
+flowchart LR
+  op["outpost<br/>owns: its sessions"] -- "uplink: garden + crew asks" --> home["home daemon<br/>owns: garden, crew, its sessions"]
+  home -- "revisions up" --> srv["server<br/>owns: nothing<br/>renders the union"]
+  srv -. "intents down" .-> home
+  home2["another home daemon"] -- "revisions up" --> srv
+  srv -. "intents down" .-> home2
+```
+
+## The arc
+
+```mermaid
+flowchart LR
+  msg["1 · messaging v1<br/>(per-daemon)"] --> vocab["2 · vocabulary + fence<br/>(glossary, enrollment record,<br/>hard refusals)"]
+  vocab --> garden["3 · the garden<br/>(home-only, fenced)"]
+  garden --> crew["4 · crew primitive<br/>(home-only, fenced)"]
+  vocab --> uplink["5 · the uplink<br/>(unfences outposts)"]
+  garden --> uplink
+  uplink --> retire["ticket retirement<br/>(gated on the uplink)"]
+  uplink --> server["6 · central server<br/>(federates homes)"]
+  crew --> server
+```
+
+### Stage 1 — messaging v1 (per-daemon)
+
+[2026-08-08-converse-and-observe.md](2026-08-08-converse-and-observe.md),
+build-ready: peek then msg, both sessions on one daemon. Message state is
+daemon-local by design — no split-brain risk, no fence needed. Cross-daemon
+addressing errors as an unknown session until it rides the uplink.
+
+### Stage 2 — vocabulary and the fence
+
+The stage that makes deferral safe. Small; lands before or with the
+garden's first slice.
+
+- [ ] Glossary: home daemon, outpost, enrollment (this PR).
+- [ ] Bootstrap writes the **enrollment record** on the remote — the home's
+      daemon id beside the outpost's own `daemon-id` file, same flock
+      mechanics. Bootstrap already installs files there, so this is the
+      cheapest first slice of enrollment, and it is exactly what the
+      uplink will check later.
+- [ ] The daemon reads the record at start and reports "outpost of its
+      home" in health and `initial_state`.
+- [ ] A fence helper: garden and crew surfaces call it and, on an outpost,
+      fail hard with a named error — the home's id, where the garden
+      lives, and a pointer to this plan. The fence *is* the tracking.
+- [ ] Re-home: bootstrap against a remote enrolled to a different home
+      stops and asks, never overwrites.
+
+Explicitly unchanged: everything outposts do today — sessions, PTY, PR/git
+flows, local tickets.
+
+```mermaid
+sequenceDiagram
+  participant Home as home daemon (Sync / bootstrap)
+  participant R as remote daemon
+  Home->>R: install binary + write enrollment record (over ssh)
+  Note over R: record: my home's daemon id,<br/>beside my own daemon-id file
+  Home->>R: connect — hello presents the home's daemon id
+  R->>R: check hello against the record
+  alt ids match
+    R->>Home: initial_state reports "outpost of this home"
+  else different home
+    R-->>Home: not my home — loud re-home decision,<br/>never silent adoption
+  end
+```
+
+### Stage 3 — the garden (home-only, fenced)
+
+[2026-08-06-the-garden-vertical-slices.md](2026-08-06-the-garden-vertical-slices.md)
+as planned, entirely at the home daemon. Seed ids stay
+fully-qualified-ready: `<daemon-id>/<local-id>` minted only at the
+boundary; the docstore id charset forbids `/`
+(`internal/docstore/docstore.go:218`), so qualified forms cannot leak into
+local storage. A seed command on an outpost hits the stage-2 fence.
+
+**Ticket retirement is gated on the uplink, not just on "garden usable".**
+Every delegation is ticket-tracked, including on outposts, and outpost
+tickets are daemon-local — retiring tickets while outposts are fenced
+would strand outpost delegations. "No two-system era" holds at home; the
+retirement pass waits for stage 5.
+
+### Stage 4 — the crew primitive (home-only, fenced)
+
+The crew hardens from the hand-run skill simulation into the daemon, at the
+home, behind the same fence: identity, charters, handoffs, and wake priming
+are home-owned state. A member's *sessions* may run on an outpost — sessions
+stay outpost-owned — but the member lives at home. Detail owed in its own
+plan; this stage pins its place in the sequence.
+
+### Stage 5 — the uplink (unfences outposts)
+
+- The outpost daemon pushes an intent envelope (kind, payload,
+  `request_id`) to the connected client whose hello presents its enrolled
+  home's id; the home applies against its own store and answers over the
+  normal outward path; the outpost settles the parked CLI request — the
+  `browser_control` promise-parking pattern, mirrored
+  (`internal/hub/manager.go:1065-1140`).
+- The enrollment check is a correctness guard against accidental
+  cross-homing, not cryptography; the adversarial boundary stays the SSH
+  key, as everywhere else.
+- Home not connected → loud refusal, nothing queues.
+- Riders, in order: seed commands (unfencing stage 3), cross-daemon
+  msg/peek (extending stage 1), ticket retirement's outpost leg.
+- Price: protocol bump, intent/result messages, routing on both daemons,
+  the enrollment check. No new transport, no new auth, no new machinery
+  class.
+
+```mermaid
+sequenceDiagram
+  participant CLI as attn seed … (outpost session)
+  participant OP as outpost daemon
+  participant Home as home daemon
+  CLI->>OP: command over unix socket
+  alt the enrolled home is connected
+    OP->>Home: intent event (request_id parked)
+    Note over Home: applies to its own garden<br/>(sole applier)
+    Home->>OP: result event, normal outward path
+    OP->>CLI: settled
+  else home not connected
+    OP->>CLI: loud refusal — "home not connected,<br/>the seed was not planted" (nothing queues)
+  end
+```
+
+### Stage 6 — the central server (federates homes)
+
+- **Each home dials the server**: one outbound WSS connection, minted API
+  key from config. NAT-friendly; the server never needs a path into
+  anyone's machine. Outposts never connect.
+- **Up: a durable bus consumer on the home** with a persisted cursor — on
+  each garden fact, re-read the document, push id + revision + body.
+  At-least-once with resume is the bus's existing contract
+  (`internal/bus/bus.go:14-19`); the server dedupes on revision. No
+  field-by-field diffing, ever — the revision is the truth.
+- **Down: intents, not writes.** The server forwards a mutation intent to
+  the seed's home; the home applies; the change flows back up the feed.
+- **v0 scope**: garden mirror (read/web view) + recognition routing
+  (laurels to a member on another home land at that home's next
+  connection). Single user, one key per home, no rotation ceremony.
+  Server code lives in its own closed repo.
+- **v0 does not do**: multi-master, merge, offline mutation queues beyond
+  bus retention, agent control from the web, or cross-home visibility
+  *inside* a home (the union exists only at the server; an in-home view of
+  another home's seeds would be a read-only mirror added on evidence,
+  never a second writer). The sole-applier stance means none of these
+  requires a schema change later.
+- attn-side surface: a `server` config block (URL + key), the outbound
+  client, the bus consumer, `attn server status` beside `attn bus status`
+  (cursor + connection state are the whole health story; `attn bus
+  disable` already covers runaway-sync emergencies).
+
+```mermaid
+sequenceDiagram
+  participant Web as web view
+  participant S as server
+  participant H as home daemon (the seed's home)
+  H->>S: push id + revision + body (bus consumer, cursor)
+  Web->>S: edit a seed
+  S->>H: forward the intent (never a write)
+  H->>H: apply to its garden (sole applier)
+  H->>S: changed revision flows back up the feed
+  S->>Web: union view updates
+```
+
+## Ground: what exists today (receipts vs main `2b65761d`, 2026-08-09)
+
+**Topology — the hub dials, always.** An endpoint is an SSH target in the
+hub's `endpoints` table (`internal/store/endpoints.go:24-32`). The hub
+spawns `ssh <target> … attn ws-relay` and speaks WebSocket through the ssh
+child's stdio (`internal/hub/transport.go:42-92`); `ws-relay` is a byte
+pump into the remote daemon's loopback-only WS server
+(`cmd/attn/main.go:560-575`). The remote never initiates and has no
+reachable listener. Endpoints are app-managed only — no CLI surface.
+
+```mermaid
+flowchart LR
+  subgraph mac["Mac — home (code says: hub)"]
+    app["app"] <--> hub["home daemon"]
+    hstore[("own SQLite,<br/>bus, jobs")]
+    hub --- hstore
+  end
+  subgraph linux["Linux — future outpost (code says: remote)"]
+    relay["attn ws-relay"] --> rdaemon["remote daemon<br/>(binds loopback only)"]
+    rstore[("own SQLite,<br/>bus, jobs")]
+    rdaemon --- rstore
+  end
+  hub -- "ssh &lt;target&gt; — WebSocket<br/>over ssh stdio, the only way in" --> relay
+  hub -- "commands: raw bytes,<br/>keyed on ids the hub knows" --> rdaemon
+  rdaemon -- "snapshots → in-memory mirror,<br/>+ verbatim event allowlist" --> hub
+  rstore -. "tickets, documents, bus facts:<br/>never cross, either direction" .- hstore
+```
+
+**Relay — outward commands, mirrored events.** App commands are forwarded
+as their original raw bytes, keyed on ids the hub already knows
+(`internal/daemon/websocket.go:1219`, `internal/hub/manager.go:1047-1063`);
+the routing principle is stated at
+`internal/daemon/websocket.go:1326-1416` — a command forwards when the
+state it mutates lives in the owning daemon's store. Events come back
+re-composed into an in-memory mirror, plus a verbatim allowlist
+(`internal/hub/manager.go:791-828`) into `broadcastRawWSMessage`
+(`internal/daemon/websocket.go:1659`), the enumerated bus exception
+(`internal/daemon/bus.go:50-52`). The one request/response precedent —
+`browser_control` (`internal/hub/manager.go:1065-1140`) — is hub-initiated
+like everything else.
+
+**Identity — daemon yes, session no.** Every daemon mints a durable
+`d-<32 hex>` id under an flock (`internal/daemon/instance_id.go:16-78`)
+and sends it in `initial_state` (`internal/daemon/websocket.go:719`).
+"Hub" is unmodeled: the relationship lives only in the hub-side
+`endpoints` table; the remote persists nothing, and `ClientKind: "hub"` is
+an unverified self-declaration it ignores
+(`internal/daemon/websocket.go:128`). Session ids are bare UUIDs resolved
+across endpoints by first-match scan — no namespace, no collision
+detection (`internal/hub/manager.go:901-913`).
+
+**Auth — the SSH key is the whole boundary.** `ATTN_WS_AUTH_TOKEN` is
+default-empty, enforced only when the remote sets it, and not forwarded in
+the env the hub exports over ssh (`internal/hub/ssh.go:37-65`,
+`internal/daemon/websocket.go:661-670`) — a no-op in practice. No API-key
+store, no rotation, no per-endpoint credential anywhere. The server is the
+first component that needs real authentication; there is nothing to reuse.
+
+**Coherence.** Protocol mismatch hard-drops and retries on a slow 30 s
+loop (`internal/hub/manager.go:645-647,519-529`). Fingerprint mismatch
+keeps the connection with status `binary_mismatch`
+(`internal/hub/manager.go:652-655,1811-1837`); the real gate is the
+frontend refusing new sessions on any endpoint not `connected`
+(`app/src/App.tsx:2049-2052`). The user's Sync click is the sole path that
+reinstalls a running remote (`internal/hub/manager.go:272-289`).
+
+**Nothing sync-shaped exists.** The remote mirror is in-memory,
+wholesale-replaced per snapshot, emptied on disconnect
+(`internal/hub/manager.go:73,1142-1159,1195-1210`). Equality is the
+hand-maintained `sessionsMatch` (`internal/hub/manager.go:1352-1382`),
+whose comment trail records real omitted-field bugs. The bus is
+per-daemon: durable consumers hold a cursor in their own SQLite
+(`internal/bus/bus.go:90-108`); nothing correlates two daemons' buses.
+
+**Stores are complete and private.** No ticket, notebook, document,
+automation, or workflow command routes remotely, and none of their events
+are relayed. `attn ticket` on a remote writes to that machine's SQLite;
+the hub never learns. This is the split brain the garden's one-home stance
+exists to avoid.
+
+## Decisions
+
+- **Fence, don't pay early** (Victor, 2026-08-10): seeds and crew land
+  home-only; outposts refuse with a named error until the uplink exists.
+  Tracking is this plan plus the fence errors pointing at it; stage 2's
+  record and id readiness make stage 5 purely additive.
+- **"Outpost"** (Victor, 2026-08-10), over field/enrolled/remote daemon.
+- **The uplink is generic** (2026-08-10): seeds, msg, peek, and ticket
+  retirement's outpost leg are riders, never bespoke paths.
+- **Home↔outpost is ownership; home↔server is federation** (Victor,
+  2026-08-10): the server connects home daemons and owns nothing.
+- **Loud refusal over local queueing** when home or a server peer is
+  unreachable: a queue is a second sync engine, refused without evidence.
+- **Enrollment before the uplink**: building the channel first would
+  hard-code "whoever connected first is my home."
+- **The garden plan's PR-flow analogy was backwards** (found 2026-08-09,
+  corrected in place): PR flows travel home → remote, keyed on ids the
+  home knows; seed commands need the opposite direction, which does not
+  exist until the uplink.
+
+## Open forks
+
+- **Server transport**: persistent WSS (recommended — matches everything
+  else, live push path for intents) vs polled HTTPS (simpler server,
+  second delivery rhythm).
+- Whether the server gets a product name.
+
+## Landmines named, not defused
+
+- `sessionsMatch` hand-maintained equality: a new session field that skips
+  it silently stops updating the mirror
+  (`internal/hub/manager.go:1352-1382`). Revision-based sync avoids the
+  class; the session mirror keeps the risk.
+- First-match session resolution across endpoints: a UUID collision
+  misroutes silently (`internal/hub/manager.go:901-913`).
+- No endpoint CLI: a headless user cannot add an endpoint at all. Separate
+  itch; the server arc trips on it the first time someone configures a
+  home from a script.

--- a/docs/plans/2026-08-10-home-garden-crew-arc.md
+++ b/docs/plans/2026-08-10-home-garden-crew-arc.md
@@ -314,6 +314,31 @@ exists to avoid.
 - **Stage 2 ships as its own PR** (Victor, 2026-08-10), not folded into
   garden slice 1.
 
+## Absorbed surfaces (Victor, 2026-08-10)
+
+Two existing surfaces fail the vision's names-its-reader principle and are
+frozen for new construction now, retired once their absorbers land. Receipt:
+workspace context was never written in 4 of 6 live workspaces; the two that
+used it (revisions 40 and 20) were hand-maintaining crown-shaped documents —
+Area / Current Picture / Threads / Timeline / Decisions — whose canonical
+content already lives in plan docs. The Notebook's automated writers
+(keeper, summarizer, compacter) are all turned off and nothing was missed.
+
+| Job | Old home | New home |
+| --- | --- | --- |
+| What is happening right now | workspace context | `agent peek` / `agent list` (stage 1) |
+| Tell another session something | workspace context | `agent msg` (stage 1) |
+| Effort-level current picture and plan | workspace context, Notebook | the crown's body (stage 3) |
+| Historical context: what happened, what was learned | workspace context, Notebook journal | notes on the seed, or on the crown when effort-scoped — a crown is a seed, so this needs no extra machinery (stage 3) |
+| Delegation artifacts | Notebook | the seed's page (stage 3) |
+| Durable knowledge | Notebook | repo docs and glossary, as today |
+| Continuity of perspective | Notebook journal | crew handoffs (stage 4) |
+
+Notes are the general agent-facing historical-context surface, not a
+machine audit trail: written by an agent to whoever tends that seed next —
+anchored to the thing they are about and read at tending time, which is
+what workspace context never had.
+
 ## Open forks
 
 - Whether the server gets a product name (deferred; naming can happen any

--- a/docs/plans/2026-08-10-home-garden-crew-arc.md
+++ b/docs/plans/2026-08-10-home-garden-crew-arc.md
@@ -29,7 +29,7 @@ complete — it owns its garden and crew, every fresh install starts as one,
 and the user's app talks to one. An **outpost** is a daemon enrolled to a
 home: it keeps its own sessions and passes garden and crew asks upward.
 **Enrollment** is the recorded, mutual act: the outpost persists its home's
-daemon id (`d-<32 hex>`, `internal/daemon/instance_id.go:16`). A second
+daemon id (`d-<32 hex>`, `internal/daemon/instance_id.go:66`). A second
 home dialing an enrolled outpost is a loud re-home decision, never silent
 adoption.
 
@@ -115,7 +115,7 @@ sequenceDiagram
 as planned, entirely at the home daemon. Seed ids stay
 fully-qualified-ready: `<daemon-id>/<local-id>` minted only at the
 boundary; the docstore id charset forbids `/`
-(`internal/docstore/docstore.go:218`), so qualified forms cannot leak into
+(`internal/docstore/docstore.go:307`), so qualified forms cannot leak into
 local storage. A seed command on an outpost hits the stage-2 fence.
 
 **Ticket retirement is gated on the uplink, not just on "garden usable".**
@@ -236,31 +236,31 @@ flowchart LR
 
 **Relay — outward commands, mirrored events.** App commands are forwarded
 as their original raw bytes, keyed on ids the hub already knows
-(`internal/daemon/websocket.go:1219`, `internal/hub/manager.go:1047-1063`);
+(`internal/daemon/websocket.go:1383-1471`, `internal/hub/manager.go:1047-1063`);
 the routing principle is stated at
 `internal/daemon/websocket.go:1326-1416` — a command forwards when the
 state it mutates lives in the owning daemon's store. Events come back
 re-composed into an in-memory mirror, plus a verbatim allowlist
 (`internal/hub/manager.go:791-828`) into `broadcastRawWSMessage`
-(`internal/daemon/websocket.go:1659`), the enumerated bus exception
+(`internal/daemon/websocket.go:1811`), the enumerated bus exception
 (`internal/daemon/bus.go:50-52`). The one request/response precedent —
 `browser_control` (`internal/hub/manager.go:1065-1140`) — is hub-initiated
 like everything else.
 
 **Identity — daemon yes, session no.** Every daemon mints a durable
-`d-<32 hex>` id under an flock (`internal/daemon/instance_id.go:16-78`)
-and sends it in `initial_state` (`internal/daemon/websocket.go:719`).
+`d-<32 hex>` id under an flock (`internal/daemon/instance_id.go:66`)
+and sends it in `initial_state` (`internal/daemon/websocket.go:772-773`).
 "Hub" is unmodeled: the relationship lives only in the hub-side
 `endpoints` table; the remote persists nothing, and `ClientKind: "hub"` is
 an unverified self-declaration it ignores
-(`internal/daemon/websocket.go:128`). Session ids are bare UUIDs resolved
+(`internal/hub/manager.go:593`). Session ids are bare UUIDs resolved
 across endpoints by first-match scan — no namespace, no collision
 detection (`internal/hub/manager.go:901-913`).
 
 **Auth — the SSH key is the whole boundary.** `ATTN_WS_AUTH_TOKEN` is
 default-empty, enforced only when the remote sets it, and not forwarded in
 the env the hub exports over ssh (`internal/hub/ssh.go:37-65`,
-`internal/daemon/websocket.go:661-670`) — a no-op in practice. No API-key
+`internal/daemon/websocket.go:655-660`) — a no-op in practice. No API-key
 store, no rotation, no per-endpoint credential anywhere. The server is the
 first component that needs real authentication; there is nothing to reuse.
 
@@ -269,7 +269,7 @@ loop (`internal/hub/manager.go:645-647,519-529`). Fingerprint mismatch
 keeps the connection with status `binary_mismatch`
 (`internal/hub/manager.go:652-655,1811-1837`); the real gate is the
 frontend refusing new sessions on any endpoint not `connected`
-(`app/src/App.tsx:2049-2052`). The user's Sync click is the sole path that
+(`app/src/App.tsx:2076`). The user's Sync click is the sole path that
 reinstalls a running remote (`internal/hub/manager.go:272-289`).
 
 **Nothing sync-shaped exists.** The remote mirror is in-memory,

--- a/docs/plans/2026-08-10-home-garden-crew-arc.md
+++ b/docs/plans/2026-08-10-home-garden-crew-arc.md
@@ -305,13 +305,19 @@ exists to avoid.
   corrected in place): PR flows travel home → remote, keyed on ids the
   home knows; seed commands need the opposite direction, which does not
   exist until the uplink.
+- **Server transport is persistent WSS** (Victor, 2026-08-10), over polled
+  HTTPS. Polling has no interval that is both quiet and alive: fast is
+  idle burn, slow is a dead-feeling web UI, and either way it adds a
+  second delivery rhythm to a push-shaped system. Reconnect/backoff is
+  reuse of the hub's dial path, not new machinery; heartbeats are
+  mandatory, not optional.
+- **Stage 2 ships as its own PR** (Victor, 2026-08-10), not folded into
+  garden slice 1.
 
 ## Open forks
 
-- **Server transport**: persistent WSS (recommended — matches everything
-  else, live push path for intents) vs polled HTTPS (simpler server,
-  second delivery rhythm).
-- Whether the server gets a product name.
+- Whether the server gets a product name (deferred; naming can happen any
+  day before the server ships).
 
 ## Landmines named, not defused
 

--- a/docs/vision/friendly-home-for-agents.md
+++ b/docs/vision/friendly-home-for-agents.md
@@ -52,6 +52,14 @@ builders.
   primitives, and the extensibility mechanism lets each user grow their own.
 - **Grown, not bolted on.** The crew generalizes the chief. The work graph grows
   from tickets, the store, and the bus. Nothing here starts from a blank page.
+- **Every durable surface names its reader.** A surface earns existence by
+  naming who reads it and when: a handoff is read by the successor at wake,
+  a seed note by the next tender, a ticket by its participants. Writers
+  without an addressed reader produce narration into a drawer. The receipt
+  (2026-08-10): workspace context was never written in 4 of 6 live
+  workspaces, and the two that used it were hand-maintaining crown-shaped
+  documents the garden makes native; the Notebook-as-journal had all its
+  writers turned off and nothing was missed.
 - **Retire what does not carry weight.** Machinery that scratched the wrong itch
   is removed once its replacement proves itself — not preserved out of sunk
   cost, and not removed before the replacement earns it.

--- a/docs/vision/friendly-home-for-agents.md
+++ b/docs/vision/friendly-home-for-agents.md
@@ -249,8 +249,13 @@ Blindspots — flag for a `ground` pass before their first chunk:
   is a union routed by daemon prefix, never a merge — fully qualified seed
   ids (`<daemon-id>/<local-id>`, prefix minted only at the boundary) make
   identity collisions impossible by construction, and every seed has one
-  home hub that applies its writes. The ground pass owns the sync and
-  transport mechanics and the smallest honest first version.
+  home hub that applies its writes. ~~The ground pass owns the sync and
+  transport mechanics and the smallest honest first version.~~ Ground pass
+  done 2026-08-09, and grown on 2026-08-10 into the arc's spine plan: the
+  verified map of the hub/relay, the **home daemon / outpost / enrollment**
+  concepts the pass surfaced, the fence that defers the multi-machine
+  price, and the smallest honest first version of the server all live in
+  [docs/plans/2026-08-10-home-garden-crew-arc.md](../plans/2026-08-10-home-garden-crew-arc.md).
 - **Seed grain and schema.** ~~Study the beads *UX* specifically (not its
   implementation) before committing a schema.~~ Ground pass done 2026-08-06;
   findings and the resulting schema decisions (ids are identity, edges are


### PR DESCRIPTION
The central-server ground pass grew into the spine plan for attn's biggest arc: messaging, home and outpost daemons, the garden, the crew, and the central server, each stage depending on the ones before it.

**The arc plan** (`docs/plans/2026-08-10-home-garden-crew-arc.md`) carries: the concepts (one owner per piece of state; home daemon / outpost / enrollment; the generic uplink channel; home↔server as federation, a different relationship from home↔outpost ownership); the six-stage sequencing with ticket retirement gated on the uplink; the fence ruling — seeds and crew land home-only, outposts refuse with a named error until the uplink exists, and bootstrap writes the enrollment record now so unfencing is purely additive; the code-verified ground map of today's hub/relay (receipts against main `2b65761d`); dated decisions including WSS over polled HTTPS for the server transport; and the absorption ledger retiring workspace context and the Notebook into surfaces with addressed readers, with the production-database receipt (4 of 6 workspace contexts never written once; the two that were are hand-maintained crown-shaped documents).

**Glossary** gains home daemon and outpost. **The vision** gains the names-its-reader principle. **The garden and messaging plans** now name their stage in the arc; the garden plan's backwards PR-flow analogy is corrected, and seed notes gain their read-side ruling (visible at show, volume under the reader's control, silent truncation forbidden).

Docs-only; no behavior change; live verification not applicable. All six mermaid diagrams parse-verified.

https://claude.ai/code/session_012Bu5dMFLdBfrEo4WmQkF53