### PR TITLE
feat(harness): record scenario runs to per-launch mp4 segments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
             frontend:
               - 'app/src/**'
               - 'app/e2e/**'
+              - 'app/scripts/**'
               - 'app/test-harness/**'
               - 'app/public/**'
               - 'app/index.html'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,11 @@ description. Record the run, publish, paste the emitted markdown:
 pass the profile you installed for this verification, the same name you will
 `profile clean` later. `--app <owner>` overrides for a non-attn window.
 
+Harness runs record themselves: `ATTN_HARNESS_RECORD=1` makes every
+`createScenarioRunner` scenario (and each serial-matrix or soak leg) write
+`recording-NN.mp4` segments into its artifacts dir, publishable with the same
+`publish` command. Details in `app/scripts/real-app-harness/CLAUDE.md`.
+
 The evidence repo is public and the clip shows whatever the window shows —
 session names, transcripts, tickets. Watch the recording before publishing;
 re-record rather than push something that should not be on the open internet.

--- a/app/scripts/real-app-harness/AGENTS.md
+++ b/app/scripts/real-app-harness/AGENTS.md
@@ -85,6 +85,26 @@ sweep the whole catalog. Catalog entries marked `soakOnly: true` (e.g.
 `run-serial-matrix.mjs` entirely, so matrix behavior never changes when a
 soak-only probe is added.
 
+## Recordings
+
+`ATTN_HARNESS_RECORD=1` records the app window of every
+`createScenarioRunner` scenario to `<runDir>/recording-NN.mp4` — one segment
+per app launch, listed in `<runDir>/recording.json` — with zero per-scenario
+wiring (`windowRecording.mjs`, wired in `scenarioRunner.mjs`). The env var
+passes through `run-serial-matrix.mjs` and `run-soak.mjs` to every leg.
+Capture is `WindowRecorder.swift`, compiled on demand like `InputDriver.swift`
+and using ScreenCaptureKit's desktop-independent window filter: it records the
+window's own content even parked almost fully off-screen (how
+`uiAutomationClient` keeps bridge-driven windows) or occluded —
+`screencapture -v` records black there, which is why it is not used (receipts
+in the swift header). It needs the Screen Recording permission of whatever
+context runs the harness; the binary is codesigned so the grant survives
+rebuilds. An app relaunch rotates to a new segment. Recording failures trace
+and never fail a run. Publish a segment as PR evidence with
+`scripts/pr-evidence.sh publish` (repo root). Default off: a matrix run must
+not pay recording CPU/disk unasked. Ad-hoc scenarios without the runner do
+not record, matching the verdict-line contract's scope.
+
 ## Real-App Parity
 
 - Scenarios must match real app usage. Do not invent command sequences that the app cannot perform.

--- a/app/scripts/real-app-harness/WindowRecorder.swift
+++ b/app/scripts/real-app-harness/WindowRecorder.swift
@@ -1,0 +1,160 @@
+// Records one window to an H.264 mp4 until SIGINT/SIGTERM, then finalizes and
+// exits 0. Usage: WindowRecorder <windowId> <outputPath> [fps]
+//
+// ScreenCaptureKit's desktop-independent window filter composites the window's
+// own content wherever the window is — parked almost fully off-screen (the
+// harness parks bridge-driven windows with ~20px visible), occluded, or moved.
+// `screencapture -v -l` cannot do this: it records the screen region, so a
+// parked window yields black frames (measured 2026-08-11; the SCK probe of a
+// 97%-off-screen window returned its full content).
+//
+// SCK delivers frames only when the window repaints, so a quiet stretch adds
+// no frames; the final re-append at stop time gives the file its true
+// wall-clock duration, with still gaps in between.
+//
+// The window closing stops the stream (didStopWithError): the file is
+// finalized with everything up to the close and the process exits 0 — the
+// caller treats a self-exited recorder like a stopped one.
+
+import AVFoundation
+import CoreGraphics
+import Foundation
+import ScreenCaptureKit
+
+func fail(_ message: String, code: Int32) -> Never {
+    FileHandle.standardError.write("\(message)\n".data(using: .utf8)!)
+    exit(code)
+}
+
+guard CommandLine.arguments.count >= 3, let windowIdArg = UInt32(CommandLine.arguments[1]) else {
+    fail("usage: WindowRecorder <windowId> <outputPath> [fps]", code: 2)
+}
+let targetWindowId = CGWindowID(windowIdArg)
+let outputURL = URL(fileURLWithPath: CommandLine.arguments[2])
+let fps = CommandLine.arguments.count > 3 ? Int32(CommandLine.arguments[3]) ?? 15 : 15
+
+// SkyLight asserts (CGS_REQUIRE_INIT) if ScreenCaptureKit touches the window
+// server from a background thread before the process has a connection; force
+// one on the main thread first.
+_ = CGMainDisplayID()
+
+final class Recorder: NSObject, SCStreamOutput, SCStreamDelegate {
+    private var stream: SCStream?
+    private var writer: AVAssetWriter?
+    private var input: AVAssetWriterInput?
+    private var adaptor: AVAssetWriterInputPixelBufferAdaptor?
+    private var sessionStarted = false
+    private var lastPixelBuffer: CVPixelBuffer?
+    private var lastPTS = CMTime.zero
+    private var finalizing = false
+    private let queue = DispatchQueue(label: "window-recorder")
+
+    func start() async throws {
+        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+        guard let window = content.windows.first(where: { $0.windowID == targetWindowId }) else {
+            fail("window \(targetWindowId) not found among \(content.windows.count) shareable windows", code: 3)
+        }
+        let filter = SCContentFilter(desktopIndependentWindow: window)
+        let scale = CGFloat(filter.pointPixelScale)
+        // H.264 wants even dimensions.
+        let width = max(2, Int(filter.contentRect.width * scale) & ~1)
+        let height = max(2, Int(filter.contentRect.height * scale) & ~1)
+
+        let writer = try AVAssetWriter(outputURL: outputURL, fileType: .mp4)
+        let input = AVAssetWriterInput(mediaType: .video, outputSettings: [
+            AVVideoCodecKey: AVVideoCodecType.h264,
+            AVVideoWidthKey: width,
+            AVVideoHeightKey: height,
+        ])
+        input.expectsMediaDataInRealTime = true
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(assetWriterInput: input, sourcePixelBufferAttributes: nil)
+        guard writer.canAdd(input) else { fail("writer rejected video input", code: 4) }
+        writer.add(input)
+        guard writer.startWriting() else {
+            fail("writer failed to start: \(writer.error?.localizedDescription ?? "unknown")", code: 4)
+        }
+        self.writer = writer
+        self.input = input
+        self.adaptor = adaptor
+
+        let config = SCStreamConfiguration()
+        config.width = width
+        config.height = height
+        config.minimumFrameInterval = CMTime(value: 1, timescale: fps)
+        config.queueDepth = 8
+        config.showsCursor = true
+
+        let stream = SCStream(filter: filter, configuration: config, delegate: self)
+        try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: queue)
+        try await stream.startCapture()
+        self.stream = stream
+    }
+
+    func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
+        guard type == .screen, !finalizing,
+              let attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, createIfNecessary: false) as? [[SCStreamFrameInfo: Any]],
+              let statusRaw = attachments.first?[.status] as? Int,
+              SCFrameStatus(rawValue: statusRaw) == .complete,
+              let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer),
+              let input, let adaptor, input.isReadyForMoreMediaData
+        else { return }
+        let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+        if !sessionStarted {
+            writer?.startSession(atSourceTime: pts)
+            sessionStarted = true
+        }
+        adaptor.append(pixelBuffer, withPresentationTime: pts)
+        lastPixelBuffer = pixelBuffer
+        lastPTS = pts
+    }
+
+    func stream(_ stream: SCStream, didStopWithError error: Error) {
+        FileHandle.standardError.write("stream stopped: \(error.localizedDescription)\n".data(using: .utf8)!)
+        stopAndFinalize()
+    }
+
+    func stopAndFinalize() {
+        queue.async { [self] in
+            if finalizing { return }
+            finalizing = true
+            guard let writer, let input, sessionStarted else {
+                // No frame ever arrived; a zero-frame mp4 is useless, so leave
+                // nothing behind and let the caller report the empty segment.
+                try? FileManager.default.removeItem(at: outputURL)
+                exit(0)
+            }
+            // Re-append the last frame stamped now, so the file spans the real
+            // recording window even when the app repainted rarely.
+            let now = CMClockGetTime(CMClockGetHostTimeClock())
+            if let lastPixelBuffer, let adaptor, input.isReadyForMoreMediaData, now > lastPTS {
+                adaptor.append(lastPixelBuffer, withPresentationTime: now)
+            }
+            input.markAsFinished()
+            writer.finishWriting {
+                exit(writer.status == .completed ? 0 : 4)
+            }
+        }
+    }
+}
+
+let recorder = Recorder()
+
+let signalQueue = DispatchQueue(label: "window-recorder-signals")
+var signalSources: [DispatchSourceSignal] = []
+for sig in [SIGINT, SIGTERM] {
+    signal(sig, SIG_IGN)
+    let source = DispatchSource.makeSignalSource(signal: sig, queue: signalQueue)
+    source.setEventHandler { recorder.stopAndFinalize() }
+    source.resume()
+    signalSources.append(source)
+}
+
+Task {
+    do {
+        try await recorder.start()
+    } catch {
+        fail("capture failed to start: \(error.localizedDescription)", code: 4)
+    }
+}
+
+dispatchMain()

--- a/app/scripts/real-app-harness/scenarioRunner.mjs
+++ b/app/scripts/real-app-harness/scenarioRunner.mjs
@@ -3,6 +3,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { assertPackagedAppBuildMatchesCurrentSource } from './buildPreflight.mjs';
 import { createRunContext, emitVerdict, FIRST_FAILURE_MAX_LENGTH } from './common.mjs';
+import { MacOSDriver } from './macosDriver.mjs';
+import { createScenarioRecorder, recordingEnabled } from './windowRecording.mjs';
 
 // Collapse to a single line and cap length so the verdict's firstFailure field
 // can never break the one-line ATTN_VERDICT contract regardless of what the
@@ -186,6 +188,20 @@ export function createScenarioRunner(options, {
     process.stdout.write(line);
   };
 
+  // ATTN_HARNESS_RECORD=1 records the app window to runDir/recording-NN.mp4,
+  // one segment per app launch. The recorder follows the window by polling, so
+  // no scenario has to wire anything; when disabled nothing runs at all.
+  let recorder = null;
+  if (recordingEnabled()) {
+    const recordingDriver = new MacOSDriver({ appPath: options.appPath });
+    recorder = createScenarioRecorder({
+      runDir,
+      resolveWindowId: () => recordingDriver.mainWindowId(),
+      log: appendTrace,
+    });
+    recorder.start();
+  }
+
   const runRegisteredCleanup = async (reason) => {
     if (cleanupPromise) {
       return cleanupPromise;
@@ -218,6 +234,10 @@ export function createScenarioRunner(options, {
       return;
     }
     finalized = true;
+    // Not awaited: the recorder's screencapture child keeps the event loop
+    // alive until it has finalized its file, and an orphaned recorder (signal
+    // path exits immediately) finalizes on its own after the SIGINT.
+    void recorder?.stop();
     releaseScenarioLock?.();
     process.removeListener('exit', exitHandler);
     for (const [signal, handler] of signalHandlers.entries()) {

--- a/app/scripts/real-app-harness/windowRecording.mjs
+++ b/app/scripts/real-app-harness/windowRecording.mjs
@@ -102,7 +102,9 @@ export function startWindowRecording({ windowId, outputPath, command, spawnFn = 
           ? `recorder ignored SIGINT for ${FINALIZE_TRIPWIRE_MS}ms and was SIGKILLed; the file is likely unplayable`
           : bytes === 0
             ? `recorder exited ${code} with no output${stderr ? `: ${stderr.trim()}` : ''}`
-            : null;
+            : code !== 0
+              ? `recorder exited ${code} leaving a possibly unplayable file${stderr ? `: ${stderr.trim()}` : ''}`
+              : null;
       return { windowId, outputPath, bytes, exitCode: code, failure };
     },
   };

--- a/app/scripts/real-app-harness/windowRecording.mjs
+++ b/app/scripts/real-app-harness/windowRecording.mjs
@@ -1,0 +1,214 @@
+import { execFile, spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+// Records the app window of a scenario run to mp4 segments in the run's
+// artifacts dir, via the compiled WindowRecorder.swift (ScreenCaptureKit
+// desktop-independent window capture — see its header for why plain
+// `screencapture -v` cannot record the harness's parked windows).
+//
+// An app relaunch means a new segment against the new window id — hence the
+// window-id poll. Recording never fails a scenario: every failure path logs
+// and continues.
+
+const execFileAsync = promisify(execFile);
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const RECORDER_SOURCE = path.join(SCRIPT_DIR, 'WindowRecorder.swift');
+const RECORDER_BUILD_DIR = path.join(SCRIPT_DIR, '.build');
+const RECORDER_BINARY = path.join(RECORDER_BUILD_DIR, 'attn-window-recorder');
+const CODESIGN_IDENTITY_SCRIPT = path.resolve(SCRIPT_DIR, '..', '..', '..', 'scripts', 'macos-codesign-identity.sh');
+
+export function recordingEnabled(env = process.env) {
+  const value = String(env.ATTN_HARNESS_RECORD ?? '').trim().toLowerCase();
+  return value === '1' || value === 'true' || value === 'on';
+}
+
+// Same content-hash rebuild and best-effort codesign as InputDriver
+// (macosDriver.mjs ensureInputDriver): a stable signature keeps the TCC
+// screen-recording grant attached to the binary across rebuilds.
+export async function ensureWindowRecorder() {
+  fs.mkdirSync(RECORDER_BUILD_DIR, { recursive: true });
+  const sourceHash = createHash('sha256').update(fs.readFileSync(RECORDER_SOURCE)).digest('hex');
+  const fingerprintPath = `${RECORDER_BINARY}.fingerprint`;
+  const builtFromHash = fs.existsSync(fingerprintPath)
+    ? fs.readFileSync(fingerprintPath, 'utf8').trim()
+    : null;
+  if (!fs.existsSync(RECORDER_BINARY) || builtFromHash !== sourceHash) {
+    await execFileAsync('/usr/bin/swiftc', ['-O', RECORDER_SOURCE, '-o', RECORDER_BINARY], {
+      timeout: 120_000,
+    });
+    fs.writeFileSync(fingerprintPath, `${sourceHash}\n`);
+    if (process.platform === 'darwin' && fs.existsSync(CODESIGN_IDENTITY_SCRIPT)) {
+      const { stdout } = await execFileAsync('bash', [CODESIGN_IDENTITY_SCRIPT, 'find'], { timeout: 5_000 });
+      const identity = stdout.toString().trim();
+      if (identity && identity !== '-') {
+        await execFileAsync('/usr/bin/codesign', ['--force', '--sign', identity, RECORDER_BINARY], {
+          timeout: 10_000,
+        });
+      }
+    }
+  }
+  return RECORDER_BINARY;
+}
+
+// SIGINT-to-exit was <1s in every measured finalization; 10s only catches a
+// recorder that will never finalize, and then SIGKILL abandons the file.
+const FINALIZE_TRIPWIRE_MS = 10_000;
+
+export function startWindowRecording({ windowId, outputPath, command, spawnFn = spawn }) {
+  const child = spawnFn(command, [String(windowId), outputPath], {
+    stdio: ['ignore', 'ignore', 'pipe'],
+  });
+  let stderr = '';
+  child.stderr?.on('data', (chunk) => {
+    if (stderr.length < 4096) stderr += chunk;
+  });
+
+  const exited = new Promise((resolve) => {
+    child.once('error', (error) => resolve({ code: null, spawnError: error }));
+    child.once('exit', (code) => resolve({ code, spawnError: null }));
+  });
+
+  return {
+    windowId,
+    outputPath,
+    async stop() {
+      let forced = false;
+      try {
+        child.kill('SIGINT');
+      } catch {
+        // Already dead; `exited` below settles from the buffered event.
+      }
+      const tripwire = setTimeout(() => {
+        forced = true;
+        try {
+          child.kill('SIGKILL');
+        } catch {}
+      }, FINALIZE_TRIPWIRE_MS);
+      tripwire.unref();
+      const { code, spawnError } = await exited;
+      clearTimeout(tripwire);
+
+      let bytes = 0;
+      try {
+        bytes = fs.statSync(outputPath).size;
+      } catch {}
+      const failure = spawnError
+        ? `recorder failed to spawn: ${spawnError.message}`
+        : forced
+          ? `recorder ignored SIGINT for ${FINALIZE_TRIPWIRE_MS}ms and was SIGKILLed; the file is likely unplayable`
+          : bytes === 0
+            ? `recorder exited ${code} with no output${stderr ? `: ${stderr.trim()}` : ''}`
+            : null;
+      return { windowId, outputPath, bytes, exitCode: code, failure };
+    },
+  };
+}
+
+// Follows a scenario's app window across launches: polls resolveWindowId and
+// keeps exactly one recording running against the current window id, rotating
+// to a new numbered segment when the id changes (app relaunch) and finalizing
+// the old one. stop() is idempotent and safe to call without awaiting — the
+// recorder child keeps the event loop alive until it has finalized.
+export function createScenarioRecorder({
+  runDir,
+  resolveWindowId,
+  log = () => {},
+  pollIntervalMs = 1_000,
+  spawnFn = spawn,
+  commandFn = ensureWindowRecorder,
+}) {
+  let active = null;
+  let segmentIndex = 0;
+  let pollPromise = null;
+  let stopped = false;
+  const segments = [];
+  let timer = null;
+  let commandPromise = null;
+
+  const finalizeActive = async () => {
+    if (!active) return;
+    const handle = active;
+    active = null;
+    const result = await handle.stop();
+    segments.push(result);
+    if (result.failure) {
+      log('recording:segment-failed', { path: result.outputPath, failure: result.failure });
+    } else {
+      log('recording:segment', { path: result.outputPath, bytes: result.bytes });
+    }
+  };
+
+  const poll = async () => {
+    if (pollPromise || stopped) return;
+    pollPromise = (async () => {
+      try {
+        commandPromise ??= commandFn();
+        let command;
+        try {
+          command = await commandPromise;
+        } catch (error) {
+          // A recorder binary that cannot build will never build this run;
+          // disable instead of logging a failed compile once per poll.
+          log('recording:disabled', { error: error instanceof Error ? error.message : String(error) });
+          stopped = true;
+          if (timer) {
+            clearInterval(timer);
+            timer = null;
+          }
+          return;
+        }
+        const windowId = await resolveWindowId();
+        if (stopped) return;
+        if (active && active.windowId === windowId) return;
+        await finalizeActive();
+        if (windowId && !stopped) {
+          segmentIndex += 1;
+          const outputPath = path.join(runDir, `recording-${String(segmentIndex).padStart(2, '0')}.mp4`);
+          active = startWindowRecording({ windowId, outputPath, command, spawnFn });
+          log('recording:start', { path: outputPath, windowId });
+        }
+      } catch (error) {
+        log('recording:poll-error', { error: error instanceof Error ? error.message : String(error) });
+      } finally {
+        pollPromise = null;
+      }
+    })();
+    await pollPromise;
+  };
+
+  return {
+    start() {
+      if (timer || stopped) return;
+      timer = setInterval(poll, pollIntervalMs);
+      void poll();
+    },
+    async stop() {
+      if (stopped) return segments;
+      stopped = true;
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+      if (pollPromise) {
+        await pollPromise.catch(() => {});
+      }
+      await finalizeActive();
+      const usable = segments.filter((s) => !s.failure);
+      if (usable.length > 0) {
+        try {
+          fs.writeFileSync(
+            path.join(runDir, 'recording.json'),
+            `${JSON.stringify({ segments }, null, 2)}\n`,
+            'utf8'
+          );
+        } catch {}
+      }
+      log('recording:done', { segments: segments.length, usable: usable.length });
+      return segments;
+    },
+  };
+}

--- a/app/scripts/real-app-harness/windowRecording.test.mjs
+++ b/app/scripts/real-app-harness/windowRecording.test.mjs
@@ -1,0 +1,254 @@
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createScenarioRecorder, recordingEnabled, startWindowRecording } from './windowRecording.mjs';
+
+const FAKE_RECORDER = '/fake/attn-window-recorder';
+
+class FakeChild extends EventEmitter {
+  constructor() {
+    super();
+    this.stderr = new EventEmitter();
+    this.signals = [];
+  }
+
+  kill(signal) {
+    this.signals.push(signal);
+  }
+}
+
+function makeSpawnFn() {
+  const calls = [];
+  const spawnFn = (command, args) => {
+    const child = new FakeChild();
+    calls.push({ command, args, child });
+    return child;
+  };
+  return { calls, spawnFn };
+}
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'window-recording-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.useRealTimers();
+});
+
+describe('recordingEnabled', () => {
+  it('is off by default and for falsy spellings', () => {
+    expect(recordingEnabled({})).toBe(false);
+    expect(recordingEnabled({ ATTN_HARNESS_RECORD: '' })).toBe(false);
+    expect(recordingEnabled({ ATTN_HARNESS_RECORD: '0' })).toBe(false);
+    expect(recordingEnabled({ ATTN_HARNESS_RECORD: 'false' })).toBe(false);
+    expect(recordingEnabled({ ATTN_HARNESS_RECORD: 'off' })).toBe(false);
+  });
+
+  it('accepts 1/true/on in any case', () => {
+    expect(recordingEnabled({ ATTN_HARNESS_RECORD: '1' })).toBe(true);
+    expect(recordingEnabled({ ATTN_HARNESS_RECORD: 'true' })).toBe(true);
+    expect(recordingEnabled({ ATTN_HARNESS_RECORD: 'ON' })).toBe(true);
+  });
+});
+
+describe('startWindowRecording', () => {
+  it('records the window id and SIGINTs the child on stop', async () => {
+    const { calls, spawnFn } = makeSpawnFn();
+    const outputPath = path.join(tmpDir, 'segment.mp4');
+    const handle = startWindowRecording({ windowId: 42, outputPath, command: FAKE_RECORDER, spawnFn });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe(FAKE_RECORDER);
+    expect(calls[0].args).toEqual(['42', outputPath]);
+
+    fs.writeFileSync(outputPath, 'movie-bytes');
+    const stopPromise = handle.stop();
+    expect(calls[0].child.signals).toEqual(['SIGINT']);
+    calls[0].child.emit('exit', 0);
+
+    const result = await stopPromise;
+    expect(result).toMatchObject({ windowId: 42, outputPath, exitCode: 0, failure: null });
+    expect(result.bytes).toBeGreaterThan(0);
+  });
+
+  it('reports a failure when the child exits with no output file', async () => {
+    const { calls, spawnFn } = makeSpawnFn();
+    const handle = startWindowRecording({
+      windowId: 7,
+      outputPath: path.join(tmpDir, 'missing.mp4'),
+      command: FAKE_RECORDER,
+      spawnFn,
+    });
+
+    const stopPromise = handle.stop();
+    calls[0].child.stderr.emit('data', 'no such window');
+    calls[0].child.emit('exit', 1);
+
+    const result = await stopPromise;
+    expect(result.bytes).toBe(0);
+    expect(result.failure).toContain('no output');
+    expect(result.failure).toContain('no such window');
+  });
+
+  it('SIGKILLs a child that ignores SIGINT and names the tripwire', async () => {
+    vi.useFakeTimers();
+    const { calls, spawnFn } = makeSpawnFn();
+    const handle = startWindowRecording({
+      windowId: 7,
+      outputPath: path.join(tmpDir, 'stuck.mp4'),
+      command: FAKE_RECORDER,
+      spawnFn,
+    });
+
+    const stopPromise = handle.stop();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(calls[0].child.signals).toEqual(['SIGINT', 'SIGKILL']);
+    calls[0].child.emit('exit', null);
+
+    const result = await stopPromise;
+    expect(result.failure).toContain('SIGKILL');
+  });
+
+  it('reports a spawn failure instead of throwing', async () => {
+    const { calls, spawnFn } = makeSpawnFn();
+    const handle = startWindowRecording({
+      windowId: 7,
+      outputPath: path.join(tmpDir, 'spawn-fail.mp4'),
+      command: FAKE_RECORDER,
+      spawnFn,
+    });
+
+    const stopPromise = handle.stop();
+    calls[0].child.emit('error', new Error('ENOENT'));
+
+    const result = await stopPromise;
+    expect(result.failure).toContain('failed to spawn');
+  });
+});
+
+describe('createScenarioRecorder', () => {
+  function makeRecorder({ windowIds }) {
+    vi.useFakeTimers();
+    const { calls, spawnFn } = makeSpawnFn();
+    const ids = [...windowIds];
+    const logs = [];
+    const recorder = createScenarioRecorder({
+      runDir: tmpDir,
+      resolveWindowId: async () => (ids.length > 1 ? ids.shift() : ids[0]),
+      log: (message, details) => logs.push({ message, details }),
+      spawnFn,
+      commandFn: async () => FAKE_RECORDER,
+    });
+    return { recorder, calls, logs };
+  }
+
+  it('starts a segment when the window appears and keeps it while the id is stable', async () => {
+    const { recorder, calls } = makeRecorder({ windowIds: [null, 11, 11] });
+    recorder.start();
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toContain('11');
+    expect(calls[0].args).toContain(path.join(tmpDir, 'recording-01.mp4'));
+  });
+
+  it('rotates to a new segment when the window id changes', async () => {
+    const { recorder, calls } = makeRecorder({ windowIds: [11, 22] });
+    recorder.start();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(calls).toHaveLength(1);
+
+    fs.writeFileSync(path.join(tmpDir, 'recording-01.mp4'), 'segment-one');
+    const advance = vi.advanceTimersByTimeAsync(1_500);
+    await Promise.resolve();
+    calls[0].child.emit('exit', 0);
+    await advance;
+
+    expect(calls[0].child.signals).toEqual(['SIGINT']);
+    expect(calls).toHaveLength(2);
+    expect(calls[1].args).toContain('22');
+    expect(calls[1].args).toContain(path.join(tmpDir, 'recording-02.mp4'));
+  });
+
+  it('finalizes segments on stop and writes the manifest', async () => {
+    const { recorder, calls, logs } = makeRecorder({ windowIds: [11] });
+    recorder.start();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(calls).toHaveLength(1);
+
+    fs.writeFileSync(path.join(tmpDir, 'recording-01.mp4'), 'segment-one');
+    const stopPromise = recorder.stop();
+    await Promise.resolve();
+    calls[0].child.emit('exit', 0);
+    const segments = await stopPromise;
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0].failure).toBeNull();
+    const manifest = JSON.parse(fs.readFileSync(path.join(tmpDir, 'recording.json'), 'utf8'));
+    expect(manifest.segments).toHaveLength(1);
+    expect(logs.some((entry) => entry.message === 'recording:done')).toBe(true);
+  });
+
+  it('starts nothing after stop and writes no manifest without a window', async () => {
+    const { recorder, calls } = makeRecorder({ windowIds: [null] });
+    recorder.start();
+    await vi.advanceTimersByTimeAsync(2_000);
+    const segments = await recorder.stop();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(calls).toHaveLength(0);
+    expect(segments).toHaveLength(0);
+    expect(fs.existsSync(path.join(tmpDir, 'recording.json'))).toBe(false);
+  });
+
+  it('disables itself when the recorder binary cannot build', async () => {
+    vi.useFakeTimers();
+    const { calls, spawnFn } = makeSpawnFn();
+    const logs = [];
+    const recorder = createScenarioRecorder({
+      runDir: tmpDir,
+      resolveWindowId: async () => 11,
+      log: (message, details) => logs.push({ message, details }),
+      spawnFn,
+      commandFn: async () => {
+        throw new Error('swiftc exploded');
+      },
+    });
+    recorder.start();
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    expect(calls).toHaveLength(0);
+    expect(logs.filter((entry) => entry.message === 'recording:disabled')).toHaveLength(1);
+    const segments = await recorder.stop();
+    expect(segments).toHaveLength(0);
+  });
+
+  it('tolerates resolveWindowId failures and keeps polling', async () => {
+    vi.useFakeTimers();
+    const { calls, spawnFn } = makeSpawnFn();
+    const logs = [];
+    let attempts = 0;
+    const recorder = createScenarioRecorder({
+      runDir: tmpDir,
+      resolveWindowId: async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error('driver not ready');
+        return 33;
+      },
+      log: (message, details) => logs.push({ message, details }),
+      spawnFn,
+      commandFn: async () => FAKE_RECORDER,
+    });
+    recorder.start();
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    expect(logs.some((entry) => entry.message === 'recording:poll-error')).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toContain('33');
+  });
+});

--- a/app/scripts/real-app-harness/windowRecording.test.mjs
+++ b/app/scripts/real-app-harness/windowRecording.test.mjs
@@ -95,6 +95,22 @@ describe('startWindowRecording', () => {
     expect(result.failure).toContain('no such window');
   });
 
+  it('treats a non-zero exit with a partial file as a failure', async () => {
+    const { calls, spawnFn } = makeSpawnFn();
+    const outputPath = path.join(tmpDir, 'partial.mp4');
+    const handle = startWindowRecording({ windowId: 7, outputPath, command: FAKE_RECORDER, spawnFn });
+
+    fs.writeFileSync(outputPath, 'headerless-partial-bytes');
+    const stopPromise = handle.stop();
+    calls[0].child.stderr.emit('data', 'writer failed');
+    calls[0].child.emit('exit', 4);
+
+    const result = await stopPromise;
+    expect(result.bytes).toBeGreaterThan(0);
+    expect(result.failure).toContain('exited 4');
+    expect(result.failure).toContain('writer failed');
+  });
+
   it('SIGKILLs a child that ignores SIGINT and names the tripwire', async () => {
     vi.useFakeTimers();
     const { calls, spawnFn } = makeSpawnFn();

--- a/changelog.d/candid-heron-harness-recordings.yaml
+++ b/changelog.d/candid-heron-harness-recordings.yaml
@@ -1,0 +1,6 @@
+kind: internal
+area: harness
+change: >
+  ATTN_HARNESS_RECORD=1 records the app window of every createScenarioRunner
+  scenario to per-launch mp4 segments in the run's artifacts dir, for PR
+  evidence and failure diagnosis.


### PR DESCRIPTION
## What

`ATTN_HARNESS_RECORD=1` makes every `createScenarioRunner` scenario record its app window to `<runDir>/recording-NN.mp4` — one segment per app launch, listed in `recording.json` — with zero per-scenario wiring. The env var flows through the serial matrix and soak runner, so any leg can be recorded. Default off: a matrix run should not pay recording CPU/disk unasked. Recording failures trace and never fail a run.

Recordings serve two purposes: PR evidence (publish a segment with `scripts/pr-evidence.sh publish`, from #847) and failure diagnosis — a failing run's artifacts now can include the actual footage next to pane text and screenshots.

## How

Capture is a new `WindowRecorder.swift` (compiled on demand and codesigned like `InputDriver.swift`) built on ScreenCaptureKit's desktop-independent window filter, driven by a window-id poller in `windowRecording.mjs` that starts, rotates, and finalizes segments as the scenario's window appears, relaunches, or dies. `scenarioRunner.mjs` starts it when enabled and stops it in `finalizeRunner`, covering success, failure, and signal exits.

Three measured facts shaped this (receipts in the swift/mjs headers):

- The harness parks bridge-driven windows almost fully off-screen (`uiAutomationClient` → `window_park`, ~20px visible). `screencapture -v -l` composites only the on-screen region — it recorded black frames with a 20px sliver. ScreenCaptureKit's `SCContentFilter(desktopIndependentWindow:)` records the window's full content wherever it is: verified with a 97%-off-screen window returning complete retina frames.
- A recorder whose window closes never exits on its own; segments must be stopped explicitly, and an app relaunch means a new segment against the new window id — hence the poller.
- SCK delivers frames only when the window repaints, so quiet stretches cost nothing; a final re-append at stop time gives each file its true wall-clock duration.

## Verification

- 12 unit tests over the poller/segment lifecycle (rotation, stop races, SIGKILL tripwire, build-failure disable); all 204 harness tests pass.
- Live on a profile installed from this branch: `scenario-tr204-local-relaunch-formatting` with recording on passed and produced two segments — rotation observed at the relaunch, both playable, frames showing the full parked window (below). A control run without the env var produced zero recording artifacts and no recorder work.

## Evidence

Segment 1 of the tr204 run (launch → session → relaunch), recorded by this branch's harness recorder from a window parked 97% off-screen, published with `pr-evidence.sh`:

![tr204 harness recording](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/c9bf6cbef3066f4b08014e9121d311aae42f82f0/candid-heron/tr204-recording.gif)

[Full-quality recording (mp4)](https://raw.githubusercontent.com/victorarias/attn-pr-evidence/c9bf6cbef3066f4b08014e9121d311aae42f82f0/candid-heron/tr204-recording.mp4)

https://claude.ai/code/session_01GcYDxzNUutctekU9xV2ZDA
