### PR TITLE
fix(daemon): wait for startup recovery before seeding agent-msg socket test sessions

### DIFF
--- a/changelog.d/flaky-agent-msg-startup-reaper.yaml
+++ b/changelog.d/flaky-agent-msg-startup-reaper.yaml
@@ -1,0 +1,11 @@
+kind: internal
+area: daemon tests
+change: >
+  The agent-msg socket test now waits for startup recovery to finish before
+  seeding its backdated sessions, so the startup reaper can no longer remove
+  the sender mid-test.
+notes: >
+  TestAgentMsgSizeRefusalsSurviveTheSocket failed under CI load with
+  "sender_session_not_found": the socket appears before recovery runs, and
+  the deliberately backdated characterization sessions are outside the
+  reaper's own-run guard. Test-only change; no daemon behavior touched.

--- a/internal/daemon/agent_msg_test.go
+++ b/internal/daemon/agent_msg_test.go
@@ -266,6 +266,10 @@ func TestAgentMsgSizeRefusalsSurviveTheSocket(t *testing.T) {
 	go d.Start()
 	defer d.Stop()
 	waitForSocket(t, sockPath, 5*time.Second)
+	// The socket appears before startup recovery finishes, and recovery reaps
+	// sessions with no PTY — these seeded rows are deliberately backdated, so
+	// the reaper's own-run guard cannot protect them. Seed only after it ran.
+	waitForRecovery(t, d)
 	addCharacterizationSession(t, d, "sender-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
 	addCharacterizationSession(t, d, "target-session-id", protocol.SessionAgentClaude, protocol.SessionStateIdle)
 


### PR DESCRIPTION
## What

`TestAgentMsgSizeRefusalsSurviveTheSocket` failed ~1 in 5 under CI load with
`daemon error: sender_session_not_found`. The test now waits for startup
recovery to finish (`waitForRecovery`) before seeding its sessions. Test-only
change; no daemon behavior is touched.

## Root cause

The test runs `go d.Start()` and waits only for the socket file, but the
socket appears before startup recovery runs. It then seeds sessions via
`addCharacterizationSession`, which deliberately backdates
`LastSeen`/`StateUpdatedAt` to `2000-01-01`. Startup recovery's
`pruneSessionsWithoutPTY` reaps sessions with no live PTY, and its own-run
guard only protects sessions updated after recovery started — a backdated row
is exactly what it cannot protect. Under load the reaper lands after test
setup and removes the sender, so the daemon answers the send with
`sender_session_not_found`.

The fix is the package's existing pattern: `TestDaemon_RegisterAndQuery` and
friends already call `waitForRecovery(t, d)` right after `waitForSocket`.

## Every instance, not just the one that flaked

Audited every `go d.Start()` site in `internal/daemon` tests: this is the
only one that seeds backdated sessions after starting the daemon. Every
other post-start site registers sessions through the socket with fresh
timestamps (protected by the prune's cutoff guard) or spawns real PTYs, so
no other test carries this race.

## Verification

Reproduced first, then fixed, on the same harness: 14 `timeout`-bounded CPU
spinners on a 10-core machine, one test-binary run per iteration.

- Unfixed (origin/main): **1 failure in 40 runs**, exactly
  `sender_session_not_found`.
- Fixed: **120/120 pass** under the same load.
- Full `go test ./internal/daemon` green on an unloaded machine.
- `gofmt`, `go vet ./internal/daemon`, and `go run ./cmd/changelog-check`
  clean.

This is a test-only Go change with no app-observable behavior, so unit-level
verification is the right tier per the repo guide; no live app install.

https://claude.ai/code/session_01JFyBEwqep7dhgd3cWFjbFE
