### PR TITLE
fix(state): read a running turn from the title's shape, not a glyph list

### DIFF
--- a/changelog.d/heartbeat-survives-a-changed-spinner-glyph.yaml
+++ b/changelog.d/heartbeat-survives-a-changed-spinner-glyph.yaml
@@ -1,0 +1,21 @@
+kind: fixed
+area: daemon
+change: >
+  A Claude session running a long tool call no longer goes grey. attn reads
+  whether an agent is running from the spinner glyph the harness paints into the
+  terminal title, and it recognised only the braille spinner Claude used up to
+  2.1.227. Claude 2.1.228 animates half circles instead, so every session
+  launched after that update lost its heartbeat entirely and left the hooks that
+  bracket a tool call as the only sign of life — and those are silent for the
+  whole call. Any tool call longer than ninety seconds, which a test run or a
+  wait on CI passes easily, therefore read as a session that had stopped
+  explaining itself: attn painted it unknown and asked for attention it did not
+  need, then recovered the moment the call returned. Whether the turn is running
+  is now read from the shape of the title rather than a list of glyphs, so a
+  spinner Claude has not shipped yet still reads as running, and a title attn
+  cannot read at all still counts as the agent being alive instead of counting
+  as nothing.
+symptom: >
+  A session turned grey with "unknown" and asked for attention while its agent
+  was plainly working, then went back to green on its own a few minutes later.
+  Sessions started before the Claude Code 2.1.228 update were unaffected.

--- a/docs/plans/2026-07-25-agent-state-detection.md
+++ b/docs/plans/2026-07-25-agent-state-detection.md
@@ -66,6 +66,24 @@ codex:   ESC ] 0 ; ⠸ attn--fix-state-detec... BEL       <- spinner prefix = bu
   running. A level that stops arriving cannot get stuck — though the spike below
   shows it goes briefly silent mid-tool, which is why it corroborates rather than
   leads.
+
+  Re-measured 2026-08-11 on claude 2.1.228 through a real PTY: the running glyph
+  is no longer braille but `◐`/`◑` (U+25D0/U+25D1), `✳` is unchanged, and 170
+  paints arrived ~960ms apart across one 150s blocking tool call with no gap at
+  all. Recognising the running glyph by name is what went blind on that release —
+  every session started after it lost its heartbeat, leaving the hooks that
+  bracket a tool call as the only evidence, and a tool call longer than
+  `StuckAfter` read as a session that had stopped explaining itself. Claude is
+  now read by the *shape* of the title: `✳` is the resting glyph and any other
+  status symbol is a spinner frame, so a glyph claude has not shipped yet still
+  reads as running. A title with no status symbol claims nothing and is reported
+  as liveness alone, because whoever painted it was running at that instant —
+  which is the whole question the stuck tripwire asks.
+
+  Parked-on-approval was measured the same day: claude paints `✳` once as it
+  parks and then nothing at all until the prompt is answered. Silence therefore
+  does not mean the agent is gone, and the liveness rule cannot mask an approval
+  — there are no paints to mask it with.
 - **OSC 777 is real but strictly redundant with the `Notification` hook.** Claude
   emits `ESC ] 777 ; notify ; Claude Code ; <message> BEL` — it appears in three
   of the nine captures (`run_approval`, `run_approval2`, `run_claude_fg`), the

--- a/internal/daemon/session_evidence.go
+++ b/internal/daemon/session_evidence.go
@@ -147,6 +147,13 @@ func (d *Daemon) recordPTYEvidence(sessionID string, obs pty.Observation) {
 			})
 			return
 		}
+		// A title nobody can read is still someone painting: it stamps
+		// LastMovement (updateIf does that for every write) and leaves the level
+		// alone. Filed as settled instead, it would retire an open turn.
+		if obs.Claim == "unclassified" {
+			d.recordEvidence(sessionID, at, func(*sessionstate.Evidence) {})
+			return
+		}
 		claim := sessionstate.ClaimSettled
 		if obs.Claim == "busy" {
 			claim = sessionstate.ClaimBusy

--- a/internal/daemon/session_evidence_test.go
+++ b/internal/daemon/session_evidence_test.go
@@ -50,6 +50,30 @@ func TestHeartbeatEvidenceKeepsItsObservationTime(t *testing.T) {
 	}
 }
 
+// An unreadable title is liveness and nothing else. Filing it as a level would
+// let a subprocess's title settle a running turn; dropping it is what let a
+// changed spinner glyph run a working session into `unknown`.
+func TestAnUnclassifiedTitleMovesEvidenceWithoutClaimingALevel(t *testing.T) {
+	d := newTraceDaemon(t)
+	id := "sess-hb-unclassified"
+	addCharacterizationSession(t, d, id, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+	busyAt := time.Now().Add(-2 * time.Minute)
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "busy", At: busyAt})
+
+	d.recordPTYEvidence(id, pty.Observation{Source: pty.SourceHeartbeat, Claim: "unclassified", Detail: "htop", At: time.Now()})
+
+	got := evidenceOf(t, d, id)
+	if got.Heartbeat == nil || got.Heartbeat.Claim != sessionstate.ClaimBusy {
+		t.Fatalf("heartbeat %+v, want the busy level to still stand", got.Heartbeat)
+	}
+	if !got.LastBusyAt.Equal(busyAt) {
+		t.Fatalf("LastBusyAt %s, want it left at %s", got.LastBusyAt, busyAt)
+	}
+	if !got.LastMovement.After(busyAt) {
+		t.Fatalf("LastMovement %s, want it advanced past %s", got.LastMovement, busyAt)
+	}
+}
+
 func TestNotBusyHeartbeatEvidenceIsSettled(t *testing.T) {
 	d := newTraceDaemon(t)
 	id := "sess-hb-settled"

--- a/internal/pty/harness_signals.go
+++ b/internal/pty/harness_signals.go
@@ -3,6 +3,7 @@ package pty
 import (
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	agentdriver "github.com/victorarias/attn/internal/agent"
@@ -10,7 +11,7 @@ import (
 
 // Harness-owned state signals, read off the PTY stream via the OSC 0/2 title:
 //
-//	ESC ] 0 ; ⠐ Run background sleep command BEL     claude, turn RUNNING
+//	ESC ] 0 ; ◐ Run background sleep command BEL     claude, turn RUNNING
 //	ESC ] 0 ; ✳ Run background sleep command BEL     claude, turn NOT running
 //	ESC ] 0 ; ⠸ my-project BEL                       codex, busy
 //	ESC ] 0 ; my-project BEL                         codex, idle
@@ -19,7 +20,21 @@ import (
 // measured against hook ground truth it tracks the turn within ~100ms. It
 // bounds stuck states rather than detecting on its own — claude's title goes
 // silent ~3.5s mid blocking foreground tool call, so no TTL gives both a fast
-// settle and no false settle. Nothing here drives session state yet.
+// settle and no false settle.
+//
+// Claude animates the running glyph and has changed which glyphs it animates
+// with (braille through 2.1.227, ◐/◑ from 2.1.228), so the busy rule is the
+// shape of the title rather than a glyph list: claude prefixes a status symbol,
+// ✳ is the resting one, and any other symbol is a spinner frame. Measured on
+// 2.1.228 through a real PTY: 170 paints ~960ms apart across one 150s blocking
+// tool call, and ✳ painted once on parking at a permission prompt followed by
+// total silence until it was answered.
+//
+// A title that starts with no status symbol claims nothing about the agent
+// (typically a subprocess overwrote it) and is reported as claimUnclassified
+// rather than dropped: whoever painted it was running at that instant, which is
+// what the resolver's stuck tripwire asks. Reading the glyph can go wrong; going
+// blind must not follow.
 
 const (
 	// heartbeatKeepalive bounds how often an unchanged heartbeat re-emits: at
@@ -34,6 +49,9 @@ const (
 	// claimApproval: blocked on the user. Codex only; claude announces
 	// approvals on its Notification hook instead.
 	claimApproval = "approval"
+	// claimUnclassified: a title arrived that says nothing about the agent. It
+	// carries liveness and no level — the previous level still stands.
+	claimUnclassified = "unclassified"
 )
 
 const (
@@ -113,21 +131,22 @@ func (o *harnessSignalObserver) observeTitle(title string, now time.Time) (Obser
 	return newObservation(SourceHeartbeat, claim, summary, now), true
 }
 
-// classifyClaudeTitle reads Claude Code's title glyph: a braille spinner frame
-// while the turn runs, U+2733 EIGHT SPOKED ASTERISK when it does not. Anything
-// else is not claude talking.
+// classifyClaudeTitle reads Claude Code's title glyph: U+2733 EIGHT SPOKED
+// ASTERISK while the turn is not running, any other status symbol a frame of the
+// running spinner. Claude has changed the spinner's glyphs between releases, so
+// naming them is what goes blind; the resting glyph is the one that has held.
 func classifyClaudeTitle(title string) (string, string, bool) {
 	first, ok := firstRune(title)
 	if !ok {
 		return "", "", false
 	}
 	switch {
-	case isBrailleSpinner(first):
-		return claimBusy, stripLevelGlyph(title), true
 	case first == '✳':
 		return claimNotBusy, stripLevelGlyph(title), true
+	case isStatusGlyph(first):
+		return claimBusy, stripLevelGlyph(title), true
 	default:
-		return "", "", false
+		return claimUnclassified, strings.TrimSpace(title), true
 	}
 }
 
@@ -186,7 +205,7 @@ func codexTitleSummary(title string) string {
 func stripLevelGlyph(title string) string {
 	trimmed := strings.TrimSpace(title)
 	first, size := utf8.DecodeRuneInString(trimmed)
-	if isBrailleSpinner(first) || first == '✳' {
+	if isStatusGlyph(first) {
 		return strings.TrimSpace(trimmed[size:])
 	}
 	return trimmed
@@ -196,6 +215,13 @@ func stripLevelGlyph(title string) string {
 // both agents animate their spinners with.
 func isBrailleSpinner(r rune) bool {
 	return r >= 0x2800 && r <= 0x28FF
+}
+
+// isStatusGlyph reports whether r is a symbol an agent would prefix its title
+// with. Braille spinner frames, ◐/◑, and ✳ are all Unicode symbols, while a
+// title a subprocess wrote starts with the text of a path or a command.
+func isStatusGlyph(r rune) bool {
+	return unicode.IsSymbol(r)
 }
 
 // firstRune returns the first non-space rune of s.

--- a/internal/pty/harness_signals_test.go
+++ b/internal/pty/harness_signals_test.go
@@ -48,9 +48,14 @@ func TestClaudeTitleHeartbeat(t *testing.T) {
 		claim   string
 		summary string
 	}{
-		// The braille block is the spinner; claude cycles through its frames.
+		// Claude cycles the running glyph and has changed which glyphs it cycles
+		// through: braille up to 2.1.227, half circles from 2.1.228. Both read as
+		// busy because busy is "a status symbol that is not the resting one",
+		// which is what survives the next change.
 		{name: "braille spinner is busy", title: "⠐ Run background sleep command", claim: claimBusy, summary: "Run background sleep command"},
-		{name: "another spinner frame", title: "⠸ Editing files", claim: claimBusy, summary: "Editing files"},
+		{name: "another braille frame", title: "⠸ Editing files", claim: claimBusy, summary: "Editing files"},
+		{name: "2.1.228 half circle is busy", title: "◐ Run background sleep command", claim: claimBusy, summary: "Run background sleep command"},
+		{name: "the other half circle frame", title: "◑ Editing files", claim: claimBusy, summary: "Editing files"},
 		{name: "asterisk is not busy", title: "✳ Run background sleep command", claim: claimNotBusy, summary: "Run background sleep command"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -71,14 +76,27 @@ func TestClaudeTitleHeartbeat(t *testing.T) {
 	}
 }
 
-// A title claude did not write says nothing about claude. Reporting not-busy for
-// it would let any subprocess that sets a title settle the session.
-func TestClaudeIgnoresAForeignTitle(t *testing.T) {
+// A title claude did not write says nothing about claude, and claiming a level
+// for it would let any subprocess that sets a title settle the session. It is
+// still reported: someone painted it, which is all the stuck tripwire asks.
+func TestClaudeReportsAForeignTitleAsLivenessOnly(t *testing.T) {
 	o := newHarnessSignalObserver(agentdriver.HarnessSignalsClaude)
-	for _, foreign := range []string{"victor@mac: ~", "htop", ""} {
-		if got := observeAt(o, time.Now(), title(foreign)); got != nil {
-			t.Fatalf("title %q produced %+v", foreign, got)
+	now := time.Now()
+	// A second past the keepalive: unchanged levels collapse, and unclassified
+	// is a level like any other.
+	for i, foreign := range []string{"victor@mac: ~", "htop"} {
+		got := onlySignal(t, observeAt(o, now.Add(time.Duration(i)*2*time.Second), title(foreign)))
+		if got.Claim != claimUnclassified {
+			t.Fatalf("title %q claimed %q, want %q", foreign, got.Claim, claimUnclassified)
 		}
+	}
+}
+
+// An empty title is not a paint: there is nothing to have witnessed.
+func TestClaudeIgnoresAnEmptyTitle(t *testing.T) {
+	o := newHarnessSignalObserver(agentdriver.HarnessSignalsClaude)
+	if got := observeAt(o, time.Now(), title("")); got != nil {
+		t.Fatalf("empty title produced %+v", got)
 	}
 }
 
@@ -245,8 +263,8 @@ func TestCodexTitleReportsAnApproval(t *testing.T) {
 // Claude's title has no approval marker — it announces approvals on the
 // Notification hook instead — so the marker must not leak across agents.
 func TestClaudeTitleHasNoApprovalMarker(t *testing.T) {
-	claim, _, ok := classifyClaudeTitle("[ . ] Action Required | whatever")
-	if ok {
-		t.Fatalf("claude classified a codex title as %q", claim)
+	claim, _, _ := classifyClaudeTitle("[ . ] Action Required | whatever")
+	if claim != claimUnclassified {
+		t.Fatalf("claude read a codex title as %q, want %q", claim, claimUnclassified)
 	}
 }


### PR DESCRIPTION
## The bug

A Claude session running a long tool call turns grey. attn reads whether a turn is
running from the spinner glyph the harness paints into the OSC 0 terminal title,
and `classifyClaudeTitle` recognised exactly two things: the Braille Patterns
block (U+2800–U+28FF) as busy, and `✳` U+2733 as not busy. Anything else returned
`ok=false` and produced **no observation at all**.

Claude Code 2.1.228 animates its running glyph with half circles — `◐` U+25D0 /
`◑` U+25D1 — instead of braille. So every session started after that update did
not get a degraded heartbeat, it got no heartbeat: one lonely `not_busy` frame at
boot (`✳` is unchanged) and nothing for the rest of its life.

With the heartbeat gone, the hooks that bracket a tool call are the only evidence
left, and they are silent for the call's whole duration. `Evidence.LastMovement`
therefore freezes for as long as the call runs, and the open-bracket clause in
`sessionstate.Resolve` trips `evidenceStoppedMoving(StuckAfter)` at 90 seconds and
resolves `unknown` / `stuck` — which opens a turn *and* breaks a snooze
(`internal/attention/turn.go`). The session heals itself the moment the call
returns, which is what makes it read as a flake rather than a regression.

Ninety seconds is inside what a test run, a `make test`, or a wait on CI takes
routinely. Observed live on three sessions in one evening on one machine.

## Measurements

Claude 2.1.228 driven through a real PTY (`creack/pty`, trusted cwd), logging
every OSC it wrote:

```
   780ms  OSC0  claim=not_busy   U+2733  "✳ Claude Code"
  13.52s  OSC0  claim=UNMATCHED  U+25D0  "◐ Claude Code"
  14.51s  OSC0  claim=UNMATCHED  U+25D1  "◑ Run measurement script with 150 second delay"
  15.44s  OSC0  claim=UNMATCHED  U+25D0  "◐ Run measurement script with 150 second delay"
  … 170 paints, every ~960ms, unbroken straight through one 150s blocking bash …
```

Two things this pins down:

1. **The title is still painted ~1/s, including during the whole blocking tool
   call.** The evidence attn needed was arriving the entire time; it was thrown
   away at the classifier. The pre-existing "~3.5s of mid-tool silence" receipt
   still holds.
2. **The semantics did not change.** `✳` still means resting. Only the busy
   glyph moved.

Parked-on-approval, measured the same way (no `--dangerously-skip-permissions`):

```
t=14.5s..19.3s   ◐/◑ every ~960ms          (running)
t=20.2s          ✳ "Create temporary marker file"   (parks on the permission prompt)
t=20.2s..2m44s   nothing at all
```

Claude paints `✳` once as it parks and then goes completely silent until the
prompt is answered. Silence is therefore not evidence of death — it also means
parked — which is why the liveness rule below cannot mask an approval: there are
no paints to mask it with, and `harnessEdge` outranks `stuck` by three clauses
anyway.

Correlation across the sessions live on the machine at the time, busy-heartbeat
rows per session over 40 minutes (binary confirmed per process with `lsof -d
txt`):

| claude | busy heartbeats | went `unknown` |
|---|---|---|
| 2.1.226 (×4 sessions) | 327–580 each | no |
| 2.1.227 (×2 sessions) | 990, 1249 | no |
| 2.1.228 (×3 sessions) | **0** | yes |

## The fix

Naming the busy glyph is what went blind, so the rule is now the *shape* of the
title rather than a list:

- `✳` is the resting glyph — the one that has held across releases.
- Any **other status symbol** is a spinner frame, so a glyph Claude has not
  shipped yet still reads as running.
- A title that starts with **no status symbol** (a subprocess overwrote it)
  claims nothing about the agent and is reported as `claimUnclassified` rather
  than dropped: it stamps `LastMovement` and leaves the level alone, because
  whoever painted it was running at that instant — which is the whole question
  the stuck tripwire asks.

That last part is the point of the change beyond tonight's glyph. Reading the
glyph can go wrong; going blind must not follow. Filing an unreadable title as a
*level* instead would be the opposite mistake — it would let any subprocess's
title settle a running turn — so it deliberately carries liveness and nothing
else.

Codex is untouched: its title has no distinct idle glyph and its classifier
already treats anything non-braille as not-busy, which is safe under its own
freshness rule.

## Verification

Unit: the 2.1.228 glyphs classify busy, an unreadable title reports liveness
without claiming a level (`TestAnUnclassifiedTitleMovesEvidenceWithoutClaimingALevel`
asserts the busy level and `LastBusyAt` both survive while `LastMovement`
advances). The pre-existing test that a foreign title produces *nothing* now
asserts it produces liveness — its original invariant, that a foreign title must
never claim a level, is what it still guards. Full Go suite green.

Live, on a throwaway profile installed from this branch (`preflight` PASS), a
real Claude 2.1.228 session driven through one 150-second tool call:

```
[probe] t=+3s    working/bracket_open
[probe] t=+168s  idle/classifier_verdict
[probe] PASS: never reached unknown across the whole tool call
```

and the heartbeat itself is back — **85 busy frames** for that run, appearing in
the trace as `heartbeat busy ×64` unbroken across the call, then `not_busy` on
settle. On the same build before this change the count is 0. Profile cleaned up
after.

No recording: the visible change is a session that *does not* turn grey after 90
seconds, which a 20-second clip cannot carry. The state trace above is the
evidence.

https://claude.ai/code/session_01QBGiYJMT6NPQv8uQh1JUA9
