### PR TITLE
docs(plans): record the rulings on A4's four open items

### DIFF
--- a/changelog.d/a4-open-items-ruled.yaml
+++ b/changelog.d/a4-open-items-ruled.yaml
@@ -1,0 +1,8 @@
+kind: internal
+area: docs
+change: >
+  The A4 plan records Victor's rulings on the four open items the exit
+  proof left: upload the app-runtime sidecar to hub remotes, make bare
+  rollback return to the previously-serving version, persist a runtime
+  park across daemon restarts, and surface pinned bus retention with a
+  warning notification instead of an expiry clock.

--- a/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
+++ b/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
@@ -495,6 +495,32 @@ than a defect:
   re-arms. Correct for a deliberate act, worth knowing as a way back that is
   not the restart verb.
 
+### Rulings on the four (2026-08-11)
+
+Victor ruled on all four after re-running the failure loop live on the
+merged head (lazy start, missing-binary path, crash-loop park, held park,
+recovery drain, bare-rollback trap):
+
+- **Hub sidecar: fix.** Bootstrap uploads `attn-app-runtime` beside the
+  `attn` binary so hub-managed remotes can run apps.
+- **Bare rollback: previously-serving.** `attn app rollback <name>` without
+  a version returns to the version that was serving before the current one
+  — the registry records the pointer at every flip — and says which version
+  it chose and why. No recorded previous fails loud with the version list.
+- **Restart must not forget a park.** The park persists and is restored at
+  daemon startup before anything can lazy-start the broken host; `attn app
+  runtime restart` stays the only unpark and clears the persisted state.
+  The original critical notification stands; a restore adds no second one.
+- **Retention floor: still no clock, but never silent.** Events pinned by an
+  enabled consumer are never dropped and no expiry exists — that stands.
+  What changes: a recurring check emits one warning notification per episode
+  when a consumer pins the floor past a threshold measured from healthy
+  data, and `attn bus status` and the settings page mark the consumer the
+  same way. Visibility instead of a clock.
+
+Each ruling was delegated for implementation the same day; this section
+records the decisions, and the PRs that land them carry their own receipts.
+
 ## Out of scope
 
 - UI tiles, panels, the `@attn/app` UI SDK, import maps — A5, which builds


### PR DESCRIPTION
The A4 exit proof recorded four observations as open product decisions in the plan doc (docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md). Victor ruled on all four on 2026-08-11 after re-running the failure loop live on the merged head. This PR records the rulings next to the observations they answer:

- **Hub sidecar: fix.** Bootstrap uploads `attn-app-runtime` beside the `attn` binary so hub-managed remotes can run apps.
- **Bare rollback: previously-serving**, with the choice named in the output and a loud error when no previous exists.
- **A park survives daemon restarts**; `attn app runtime restart` remains the only unpark.
- **Pinned bus retention: no expiry clock, but never silent** — one warning notification per episode past a measured threshold, marked identically in `attn bus status` and the settings page.

Docs only; each ruling's implementation is in flight separately and carries its own receipts.

https://claude.ai/code/session_01429snMWPwXjv1NeqUdV57c