### PR TITLE
fix(sessions): make the context-window cap outrank the user's own settings

### DIFF
--- a/changelog.d/fluffy-otter-context-cap-beats-user-settings.yaml
+++ b/changelog.d/fluffy-otter-context-cap-beats-user-settings.yaml
@@ -1,0 +1,10 @@
+kind: fixed
+area: sessions
+change: >
+  A context-window cap now holds even when ~/.claude/settings.json sets
+  CLAUDE_CODE_AUTO_COMPACT_WINDOW in its env block. Claude Code copies a
+  settings file's env over the environment it was launched with, so the cap
+  attn exported at spawn was silently replaced and the session compacted at
+  the user's global value instead of the configured one. attn now also writes
+  the cap into the settings file it passes to the launch, which Claude Code
+  applies after the user's own.

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -3116,7 +3116,7 @@ func runAgentDirectly(requestedAgent string) {
 		opts.ConfigOverrides = cp.GenerateConfigOverrides(opts)
 	}
 	if hp, ok := agentdriver.GetHookProvider(driver); ok {
-		content := hp.GenerateHooksConfig(sessionID, opts.SocketPath, opts.WrapperPath)
+		content := hp.GenerateHooksConfig(opts)
 		settingsPath, err := wrapper.WriteSettingsConfig(os.TempDir(), sessionID, content)
 		if err != nil {
 			cleanup()

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -139,6 +139,8 @@ func (c *Claude) BuildEnv(opts SpawnOpts) []string {
 	// Cap the effective context window so auto-compaction fires at the configured
 	// threshold. The daemon owns the policy of who gets a cap (chief setting vs
 	// default_context_window_cap_<agent>); this only applies what it resolved.
+	// The spawn environment alone does not settle it — the user's settings can
+	// overwrite this key, so claudeSettingsEnv repeats it in the --settings file.
 	if opts.AutoCompactWindow > 0 {
 		env = append(env, "CLAUDE_CODE_AUTO_COMPACT_WINDOW="+strconv.Itoa(opts.AutoCompactWindow))
 	}
@@ -540,8 +542,23 @@ func (c *Claude) PrepareLaunch(opts SpawnOpts) error {
 
 // --- HookProvider ---
 
-func (c *Claude) GenerateHooksConfig(sessionID, socketPath, wrapperPath string) string {
-	return hooks.Generate(sessionID, socketPath, wrapperPath)
+func (c *Claude) GenerateHooksConfig(opts SpawnOpts) string {
+	return hooks.Generate(opts.SessionID, opts.SocketPath, opts.WrapperPath, claudeSettingsEnv(opts))
+}
+
+// claudeSettingsEnv is the `env` block of the --settings file attn writes for a
+// launch. Only knobs that must outrank the user's own configuration belong here:
+// Claude Code copies each settings file's env onto its process environment,
+// so `"env": {"CLAUDE_CODE_AUTO_COMPACT_WINDOW": "300000"}` in
+// ~/.claude/settings.json silently replaces the value attn exported at spawn.
+// The --settings scope is applied after the user's, so the cap set here holds.
+func claudeSettingsEnv(opts SpawnOpts) map[string]string {
+	if opts.AutoCompactWindow <= 0 {
+		return nil
+	}
+	return map[string]string{
+		"CLAUDE_CODE_AUTO_COMPACT_WINDOW": strconv.Itoa(opts.AutoCompactWindow),
+	}
 }
 
 // --- TranscriptFinder ---

--- a/internal/agent/context_window_cap_test.go
+++ b/internal/agent/context_window_cap_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"slices"
 	"strings"
 	"testing"
@@ -50,6 +51,50 @@ func TestClaudeBuildEnv_ContextWindowCap(t *testing.T) {
 			if env := (&Claude{}).BuildEnv(opts); envHasCap(env) {
 				t.Fatalf("uncapped env unexpectedly carried the cap: %#v", env)
 			}
+		}
+	})
+}
+
+// The spawn environment alone does not settle the cap: Claude Code copies each
+// settings file's `env` block over its own process environment, so a user with
+// "env": {"CLAUDE_CODE_AUTO_COMPACT_WINDOW": ...} in ~/.claude/settings.json
+// replaces whatever attn exported. The generated --settings file is applied
+// after the user's, so the cap must appear there too.
+func TestClaudeGenerateHooksConfig_ContextWindowCap(t *testing.T) {
+	parseEnv := func(t *testing.T, content string) map[string]string {
+		t.Helper()
+		var parsed struct {
+			Env map[string]string `json:"env"`
+		}
+		if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+			t.Fatalf("settings config is not valid JSON: %v", err)
+		}
+		return parsed.Env
+	}
+
+	t.Run("capped launch pins the window in the settings file", func(t *testing.T) {
+		content := (&Claude{}).GenerateHooksConfig(SpawnOpts{
+			SessionID:         "sess-1",
+			SocketPath:        "/tmp/attn.sock",
+			WrapperPath:       "/tmp/attn",
+			AutoCompactWindow: 200000,
+		})
+		if got := parseEnv(t, content)["CLAUDE_CODE_AUTO_COMPACT_WINDOW"]; got != "200000" {
+			t.Fatalf("settings env cap = %q, want %q; content: %s", got, "200000", content)
+		}
+	})
+
+	t.Run("uncapped launch writes no env block", func(t *testing.T) {
+		content := (&Claude{}).GenerateHooksConfig(SpawnOpts{
+			SessionID:   "sess-1",
+			SocketPath:  "/tmp/attn.sock",
+			WrapperPath: "/tmp/attn",
+		})
+		if env := parseEnv(t, content); len(env) != 0 {
+			t.Fatalf("uncapped settings unexpectedly carried env %#v", env)
+		}
+		if strings.Contains(content, "CLAUDE_CODE_AUTO_COMPACT_WINDOW") {
+			t.Fatalf("uncapped settings mentioned the cap: %s", content)
 		}
 	})
 }

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -252,8 +252,10 @@ type SpawnOpts struct {
 // HookProvider generates hook/settings configurations for agents that support them.
 type HookProvider interface {
 	// GenerateHooksConfig returns settings/hooks config file content; the
-	// caller writes it to a temp file and passes --settings to the agent.
-	GenerateHooksConfig(sessionID, socketPath, wrapperPath string) string
+	// caller writes it to a temp file and passes --settings to the agent. It
+	// takes the whole launch because that file is also how a launch knob the
+	// user's own settings could otherwise overwrite reaches the agent.
+	GenerateHooksConfig(opts SpawnOpts) string
 }
 
 // ConfigOverrideProvider generates per-launch CLI config overrides.

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -22,6 +22,13 @@ type Hook struct {
 // SettingsConfig represents Claude Code settings with hooks
 type SettingsConfig struct {
 	Hooks map[string][]HookEntry `json:"hooks"`
+	// Env carries launch knobs that must beat the user's own configuration.
+	// Claude Code copies every settings file's `env` block onto its own
+	// process environment at startup, overwriting what the parent exported, so
+	// a knob attn only sets in the spawn environment loses to the same key in
+	// ~/.claude/settings.json. This file is passed with --settings, whose scope
+	// is applied last of the non-managed scopes, so what lands here wins.
+	Env map[string]string `json:"env,omitempty"`
 }
 
 type sessionStartHookSpecificOutput struct {
@@ -153,8 +160,10 @@ func ChiefGuidance(root string, hasSelfMonitor bool) string {
 - %[5]s`, root, ticketWaitingGuidance, wakeBoundary, delegationBoundary, TicketAwarenessGuidance())
 }
 
-// Generate generates settings configuration with hooks for a session
-func Generate(sessionID, socketPath, wrapperPath string) string {
+// Generate generates settings configuration with hooks for a session. env, when
+// non-empty, becomes the file's `env` block — see SettingsConfig.Env for why a
+// launch knob has to travel here rather than only in the spawn environment.
+func Generate(sessionID, socketPath, wrapperPath string, env map[string]string) string {
 	wrapper := strings.TrimSpace(wrapperPath)
 	if wrapper == "" {
 		wrapper = "attn"
@@ -163,6 +172,7 @@ func Generate(sessionID, socketPath, wrapperPath string) string {
 	socketCmd := shellQuote(strings.TrimSpace(socketPath))
 
 	config := SettingsConfig{
+		Env: env,
 		Hooks: map[string][]HookEntry{
 			"SessionStart": {
 				{

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -10,7 +10,7 @@ func TestGenerateHooks(t *testing.T) {
 	sessionID := "abc123"
 	socketPath := "/home/user/.claude-manager.sock"
 
-	settings := Generate(sessionID, socketPath, "/tmp/attn")
+	settings := Generate(sessionID, socketPath, "/tmp/attn", nil)
 
 	// Verify it's valid JSON
 	var parsed map[string]interface{}
@@ -52,7 +52,7 @@ func TestGenerateHooks(t *testing.T) {
 // it stays a single spawn: _hook-tool-use resets the working state AND records
 // any markdown the call wrote, instead of a second hook entry doing the latter.
 func TestGenerateHooks_CatchAllPostToolUseIsOneSpawn(t *testing.T) {
-	settings := Generate("abc123", "/tmp/test.sock", "/tmp/attn")
+	settings := Generate("abc123", "/tmp/test.sock", "/tmp/attn", nil)
 
 	var parsed SettingsConfig
 	if err := json.Unmarshal([]byte(settings), &parsed); err != nil {
@@ -89,7 +89,7 @@ func TestGenerateHooks_ContainsSessionID(t *testing.T) {
 	sessionID := "unique-session-id-12345"
 	socketPath := "/tmp/test.sock"
 
-	hooks := Generate(sessionID, socketPath, "/tmp/attn")
+	hooks := Generate(sessionID, socketPath, "/tmp/attn", nil)
 
 	if !strings.Contains(hooks, sessionID) {
 		t.Error("generated hooks should contain session ID")
@@ -100,7 +100,7 @@ func TestGenerateHooks_ContainsSocketPath(t *testing.T) {
 	sessionID := "test"
 	socketPath := "/custom/path/to/socket.sock"
 
-	hooks := Generate(sessionID, socketPath, "/tmp/attn")
+	hooks := Generate(sessionID, socketPath, "/tmp/attn", nil)
 
 	if !strings.Contains(hooks, socketPath) {
 		t.Error("generated hooks should contain socket path")
@@ -108,7 +108,7 @@ func TestGenerateHooks_ContainsSocketPath(t *testing.T) {
 }
 
 func TestGenerateHooks_HasStopHook(t *testing.T) {
-	hooks := Generate("test", "/tmp/test.sock", "/tmp/attn")
+	hooks := Generate("test", "/tmp/test.sock", "/tmp/attn", nil)
 
 	if !strings.Contains(hooks, "Stop") {
 		t.Error("hooks should include Stop event for waiting state")
@@ -116,7 +116,7 @@ func TestGenerateHooks_HasStopHook(t *testing.T) {
 }
 
 func TestGenerateHooks_HasSessionStartHook(t *testing.T) {
-	hooks := Generate("test", "/tmp/test.sock", "/tmp/attn")
+	hooks := Generate("test", "/tmp/test.sock", "/tmp/attn", nil)
 
 	for _, expected := range []string{
 		"SessionStart",
@@ -134,7 +134,7 @@ func TestGenerateHooks_HasSessionStartHook(t *testing.T) {
 // evidence silently absent rather than failing anything.
 func TestGenerateHooks_HasNotificationHook(t *testing.T) {
 	var parsed SettingsConfig
-	if err := json.Unmarshal([]byte(Generate("abc123", "/tmp/test.sock", "/tmp/attn")), &parsed); err != nil {
+	if err := json.Unmarshal([]byte(Generate("abc123", "/tmp/test.sock", "/tmp/attn", nil)), &parsed); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
 
@@ -148,7 +148,7 @@ func TestGenerateHooks_HasNotificationHook(t *testing.T) {
 }
 
 func TestGenerateHooks_HasUserPromptSubmitHook(t *testing.T) {
-	hooks := Generate("test", "/tmp/test.sock", "/tmp/attn")
+	hooks := Generate("test", "/tmp/test.sock", "/tmp/attn", nil)
 
 	if !strings.Contains(hooks, "UserPromptSubmit") {
 		t.Error("hooks should include UserPromptSubmit event for working state")
@@ -156,7 +156,7 @@ func TestGenerateHooks_HasUserPromptSubmitHook(t *testing.T) {
 }
 
 func TestGenerateHooks_UsesWrapperPath(t *testing.T) {
-	hooks := Generate("test", "/tmp/test.sock", "/Users/testuser/Applications/attn.app/Contents/MacOS/attn")
+	hooks := Generate("test", "/tmp/test.sock", "/Users/testuser/Applications/attn.app/Contents/MacOS/attn", nil)
 
 	if !strings.Contains(hooks, "'/Users/testuser/Applications/attn.app/Contents/MacOS/attn' _hook-stop") {
 		t.Error("hooks should include wrapper path in stop hook command")
@@ -164,11 +164,42 @@ func TestGenerateHooks_UsesWrapperPath(t *testing.T) {
 }
 
 func TestGenerateHooks_DefaultsWrapperToAttn(t *testing.T) {
-	hooks := Generate("test", "/tmp/test.sock", "")
+	hooks := Generate("test", "/tmp/test.sock", "", nil)
 
 	if !strings.Contains(hooks, "'attn' _hook-stop") {
 		t.Error("hooks should default wrapper path to 'attn'")
 	}
+}
+
+func TestGenerateHooks_EnvBlock(t *testing.T) {
+	decode := func(t *testing.T, content string) map[string]any {
+		t.Helper()
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		return parsed
+	}
+
+	t.Run("carries the supplied env", func(t *testing.T) {
+		parsed := decode(t, Generate("test", "/tmp/test.sock", "/tmp/attn", map[string]string{"CLAUDE_CODE_AUTO_COMPACT_WINDOW": "128000"}))
+		env, ok := parsed["env"].(map[string]any)
+		if !ok {
+			t.Fatalf("env block missing: %#v", parsed)
+		}
+		if got := env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"]; got != "128000" {
+			t.Fatalf("env cap = %v, want \"128000\"", got)
+		}
+	})
+
+	t.Run("omits an empty env", func(t *testing.T) {
+		if _, present := decode(t, Generate("test", "/tmp/test.sock", "/tmp/attn", nil))["env"]; present {
+			t.Error("nil env should not emit an env block")
+		}
+		if _, present := decode(t, Generate("test", "/tmp/test.sock", "/tmp/attn", map[string]string{}))["env"]; present {
+			t.Error("empty env should not emit an env block")
+		}
+	})
 }
 
 func TestGenerateCodexConfigOverrides_UsesStableEnvBasedCommands(t *testing.T) {

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -38,7 +38,7 @@ func WriteSettingsConfig(tmpDir, sessionID, content string) (string, error) {
 
 // WriteHooksConfig writes a temporary hooks configuration file.
 func WriteHooksConfig(tmpDir, sessionID, socketPath, wrapperPath string) (string, error) {
-	content := hooks.Generate(sessionID, socketPath, wrapperPath)
+	content := hooks.Generate(sessionID, socketPath, wrapperPath, nil)
 	return WriteSettingsConfig(tmpDir, sessionID, content)
 }
 


### PR DESCRIPTION
A session's context-window cap did not survive a user who sets the same knob in
their own Claude Code settings. Victor hit this on production attn: a session
pinned to 500,000 tokens was heading for auto-compaction anyway, because
`~/.claude/settings.json` carries `"env": {"CLAUDE_CODE_AUTO_COMPACT_WINDOW": "300000"}`.

## Root cause

attn only put the cap in the environment of the process it spawns. Claude Code
copies **every** settings file's `env` block onto its own `process.env` at
startup — an unconditional `Object.assign`, not a fill-in-the-blanks merge — and
then resolves the auto-compact window from `process.env` before it looks at any
setting. So the user's `env` entry replaces whatever attn exported, and the
session compacts at the user's global number instead of the configured one.

The generated settings file attn already writes and passes with `--settings` is
the one channel that wins: Claude Code applies the scopes in the order
globalConfig → user → project/local → **--settings** → managed, so what lands in
the flag file beats the user's file. The cap now travels there as well as in the
spawn environment.

## Receipts (Claude Code 2.1.227/2.1.228)

Same inherited `CLAUDE_CODE_AUTO_COMPACT_WINDOW=111111`, same
`~/.claude/settings.json` value of `300000`, one headless run each, asking the
agent to print the variable it actually holds:

| launch | value Claude Code holds |
| --- | --- |
| no `--settings` | `300000` — the user's file wins over the spawn environment |
| `--settings` file whose `env` sets `222222` | `222222` — the flag scope wins over the user's file |

The control for the pre-fix shape: taking the settings file this branch's daemon
actually generated, stripping only its new `env` block, and launching with the
cap in the environment alone yields `300000` — the exact defect.

## Live verification

Throwaway profile `capfix1` (`make install PROFILE=capfix1`, preflight PASS,
protocol 229 across CLI/app/daemon), `default_context_window_cap_claude=137000`,
one real Claude session spawned by the daemon into it:

- the generated `--settings` file carries
  `"env": {"CLAUDE_CODE_AUTO_COMPACT_WINDOW": "137000"}` beside its ten unchanged hook events;
- the live session, asked to print the variable, answers `CAPPROBE=137000`
  while the user's global settings still say `300000`.

No recording: nothing about this is visible in the app — the change is which
number the launched agent ends up holding. Profile cleaned after.

## Surfaces walked

- **CLI / launch path** — the cap rides `SpawnOpts` into the one place that
  writes the settings file; `HookProvider.GenerateHooksConfig` now takes the
  whole launch rather than three loose strings, since that file is also how a
  launch knob reaches the agent. Claude is its only implementor.
- **Headless** — unaffected: those runs launch with `--setting-sources ""`,
  which drops the user's settings entirely.
- **Codex** — unaffected: its cap is a `-c model_auto_compact_token_limit=…`
  CLI override, which already outranks `config.toml`.
- **Protocol** — unchanged; no daemon/app message moved.
- **Linux** — `GOOS=linux GOARCH=amd64 go build ./...` green.

## Tests

- `internal/agent`: the generated settings file pins the window when a cap
  applies and writes no `env` block when none does.
- `internal/hooks`: `Generate` emits the supplied `env` and omits an empty one.