### PR TITLE
fix(apps): roll back to the version that was serving, not the id below

### DIFF
--- a/changelog.d/app-rollback-previously-serving.yaml
+++ b/changelog.d/app-rollback-previously-serving.yaml
@@ -1,0 +1,12 @@
+kind: fixed
+area: cli
+change: >
+  `attn app rollback <name>` with no version now returns to the version that was
+  serving immediately before the current one, instead of the version with the
+  next id down. Those differ exactly when rollback matters: after a broken
+  version is rolled off and a fix applied, the next id down is the broken one.
+  The registry now records what each pointer move replaced, so the command
+  follows a fact rather than guessing, and says why it chose that version.
+  Rolling back twice returns to where you started. An app with no recorded
+  predecessor — one carried across this change, or on its first version — is
+  refused with its version list rather than sent somewhere arbitrary.

--- a/cmd/attn/app.go
+++ b/cmd/attn/app.go
@@ -90,8 +90,15 @@ commands:
         byte-identical content again is the same version, not a new one.
 
   rollback <name> [version]
-        point the app at a version it already has — the one before the current
-        one, or the one you name. Builds nothing: the artifact is still on disk.
+        point the app at a version it already has — the one you name, or with no
+        version, the one that was serving immediately before the current one.
+        That is a recorded pointer, not the next id down. If a broken version
+        was rolled off before the current one was applied, the next id down is
+        that broken version; what was serving is the one you kept running.
+        Rolling back again returns to where you started, because every move
+        records what it replaced.
+
+        Builds nothing: the artifact is still on disk.
 
   dev <path>
         apply on every change, and print every handler invocation as it runs.

--- a/cmd/attn/app_build.go
+++ b/cmd/attn/app_build.go
@@ -167,15 +167,26 @@ func runAppRollback(args []string) {
 		writeJSON(result)
 		return
 	}
-	// Naming a version explicitly can move the pointer forward, and calling that
+	target := fmt.Sprintf("version %d (%s)", result.VersionID, appbuild.ShortHash(result.ContentHash))
+	switch {
+	// Bare rollback follows a recorded pointer rather than the version list, and
+	// the id it lands on can be higher than the one it left — rolling back off a
+	// rollback is exactly that. Saying which version was serving is what makes
+	// the choice checkable, and it is always backwards in time, whatever the ids
+	// did.
+	case versionID == 0 && result.PreviousVersionID != nil:
+		fmt.Printf("rolled app %s back to %s, which was serving before version %d\n",
+			result.Name, target, *result.PreviousVersionID)
+	// A version named explicitly can move the pointer forward, and calling that
 	// "rolled back" would be a lie about which direction the app just went.
-	verb := "rolled app %s back to version %d (%s)\n"
-	if result.PreviousVersionID != nil && *result.PreviousVersionID < result.VersionID {
-		verb = "moved app %s forward to version %d (%s)\n"
-	}
-	fmt.Printf(verb, result.Name, result.VersionID, appbuild.ShortHash(result.ContentHash))
-	if result.PreviousVersionID != nil {
-		fmt.Printf("  was on version %d\n", *result.PreviousVersionID)
+	case result.PreviousVersionID != nil && *result.PreviousVersionID < result.VersionID:
+		fmt.Printf("moved app %s forward to %s\n  was on version %d\n",
+			result.Name, target, *result.PreviousVersionID)
+	case result.PreviousVersionID != nil:
+		fmt.Printf("rolled app %s back to %s\n  was on version %d\n",
+			result.Name, target, *result.PreviousVersionID)
+	default:
+		fmt.Printf("rolled app %s back to %s\n", result.Name, target)
 	}
 	fmt.Printf("  artifact %s\n", result.ArtifactPath)
 }

--- a/internal/daemon/app_apply.go
+++ b/internal/daemon/app_apply.go
@@ -181,7 +181,8 @@ func (d *Daemon) handleAppRollback(conn net.Conn, msg *protocol.AppRollbackMessa
 // reader's terms: a version that is not this app's is refused by listing the
 // ones that are, and an app already on the version asked for is refused rather
 // than answered with a success that changed nothing and a fact about a move that
-// did not happen.
+// did not happen. Every refusal ends with the app's version list, so the caller
+// can fix its next call from the error alone.
 //
 // versions arrives newest-id-first, as ListAppVersions returns it.
 func pickRollbackTarget(name string, app store.App, versions []store.AppVersion, requested *int) (store.AppVersion, error) {
@@ -200,16 +201,30 @@ func pickRollbackTarget(name string, app store.App, versions []store.AppVersion,
 		}
 		return store.AppVersion{}, fmt.Errorf("app rollback %s: version %d is not a version of this app; %s", name, id, versionsSentence(versions, app.CurrentVersionID))
 	}
-	// No version named: the one applied before the current one, which is the
-	// highest id below the pointer. "The newest that is not current" would roll
-	// *forward* for an app already rolled back, which is not what the verb says.
+	// No version named: whatever was serving immediately before the current one,
+	// which the registry records at every pointer move. The numerically previous
+	// id is a different question and answers it wrong exactly when rollback
+	// matters — an app that went good, broken, fixed has the broken one below its
+	// pointer, and that is the version an operator is running from.
+	//
+	// Because the predecessor is rewritten on every move, rolling back twice
+	// returns to where the first rollback started. That flip-flop is the point:
+	// "back" always means the version that was serving a moment ago.
+	if app.CurrentVersionID == 0 {
+		return store.AppVersion{}, fmt.Errorf("app rollback %s: it is not on any version, so there is no back to go to; name one of them. %s",
+			name, versionsSentence(versions, 0))
+	}
+	if app.PreviousVersionID == 0 {
+		return store.AppVersion{}, fmt.Errorf("app rollback %s: nothing is recorded as serving before version %d, so bare rollback has no target; name the version to roll onto. %s",
+			name, app.CurrentVersionID, versionsSentence(versions, app.CurrentVersionID))
+	}
 	for _, v := range versions {
-		if app.CurrentVersionID == 0 || v.ID < app.CurrentVersionID {
+		if v.ID == app.PreviousVersionID {
 			return v, nil
 		}
 	}
-	return store.AppVersion{}, fmt.Errorf("app rollback %s: version %d is its oldest, so there is nothing before it; %s",
-		name, app.CurrentVersionID, versionsSentence(versions, app.CurrentVersionID))
+	return store.AppVersion{}, fmt.Errorf("app rollback %s: version %d is recorded as serving before version %d but is not among this app's versions; name the version to roll onto. %s",
+		name, app.PreviousVersionID, app.CurrentVersionID, versionsSentence(versions, app.CurrentVersionID))
 }
 
 // versionsSentence lists what an app actually has, marking the current one. It

--- a/internal/daemon/app_apply_test.go
+++ b/internal/daemon/app_apply_test.go
@@ -293,15 +293,101 @@ func TestAppRollbackToANamedVersion(t *testing.T) {
 		t.Fatalf("rolled back to %d, want %d", resp.AppRollbackResult.VersionID, first.VersionID)
 	}
 
-	// From the oldest version, the default rollback has nowhere to go and says so
-	// rather than rolling forward onto a newer one.
+	// An explicit rollback is a pointer move like any other, so it records what it
+	// replaced: bare rollback now goes back to the version that was serving a
+	// moment ago, even though that means moving to a higher id.
 	resp = appRollback(t, d, "approval-gate", 0)
+	if !resp.Ok {
+		t.Fatalf("rollback: %v", protocol.Deref(resp.Error))
+	}
+	if resp.AppRollbackResult.VersionID != third.VersionID {
+		t.Fatalf("bare rollback landed on %d, want the version that was serving, %d",
+			resp.AppRollbackResult.VersionID, third.VersionID)
+	}
+}
+
+// The bug this pointer exists for: an operator who rolled a broken version off
+// and then applied a fix has the broken version sitting one id below the
+// pointer. Bare rollback must return to what was running, not to what broke.
+func TestAppRollbackSkipsAVersionThatWasRolledOff(t *testing.T) {
+	d := appApplyDaemon(t)
+	good := applyOK(t, d, "approval-gate", declarationFor("approval-gate", "good"), "export default {}\n")
+	broken := applyOK(t, d, "approval-gate", declarationFor("approval-gate", "broken"), "export default { broken: true }\n")
+	if resp := appRollback(t, d, "approval-gate", good.VersionID); !resp.Ok {
+		t.Fatalf("rollback off the broken version: %v", protocol.Deref(resp.Error))
+	}
+	fixed := applyOK(t, d, "approval-gate", declarationFor("approval-gate", "fixed"), "export default { fixed: true }\n")
+
+	resp := appRollback(t, d, "approval-gate", 0)
+	if !resp.Ok {
+		t.Fatalf("rollback: %v", protocol.Deref(resp.Error))
+	}
+	switch got := resp.AppRollbackResult.VersionID; got {
+	case good.VersionID:
+	case broken.VersionID:
+		t.Fatalf("bare rollback landed on the version that was rolled off (%d)", broken.VersionID)
+	default:
+		t.Fatalf("bare rollback landed on %d, want %d", got, good.VersionID)
+	}
+	if p := resp.AppRollbackResult.PreviousVersionID; p == nil || *p != fixed.VersionID {
+		t.Fatalf("previous = %v, want %d", p, fixed.VersionID)
+	}
+}
+
+// Rolling back twice flips between the two most recent serving versions, because
+// every move rewrites the predecessor. It is the consequence of "back means what
+// was serving a moment ago", and it is what makes rollback undoable.
+func TestAppRollbackTwiceFlipsBetweenTwoVersions(t *testing.T) {
+	d := appApplyDaemon(t)
+	first := applyOK(t, d, "approval-gate", declarationFor("approval-gate", "first"), "export default {}\n")
+	second := applyOK(t, d, "approval-gate", declarationFor("approval-gate", "second"), "export default { two: true }\n")
+
+	for i, want := range []int{first.VersionID, second.VersionID, first.VersionID} {
+		resp := appRollback(t, d, "approval-gate", 0)
+		if !resp.Ok {
+			t.Fatalf("rollback %d: %v", i+1, protocol.Deref(resp.Error))
+		}
+		if got := resp.AppRollbackResult.VersionID; got != want {
+			t.Fatalf("rollback %d landed on %d, want %d", i+1, got, want)
+		}
+	}
+}
+
+// An app on its first version has no predecessor to follow, and the numerically
+// previous id is not one — there is nothing below it. The refusal has to name the
+// situation and list the versions, because that is all the caller gets.
+func TestAppRollbackWithoutARecordedPreviousRefusesLoudly(t *testing.T) {
+	d := appApplyDaemon(t)
+	only := applyOK(t, d, "approval-gate", declarationFor("approval-gate", "first"), "export default {}\n")
+
+	resp := appRollback(t, d, "approval-gate", 0)
 	if resp.Ok {
-		t.Fatal("rollback from the oldest version reported success")
+		t.Fatal("rollback with no recorded predecessor reported success")
 	}
 	msg := protocol.Deref(resp.Error)
-	if !strings.Contains(msg, "oldest") || !strings.Contains(msg, fmt.Sprint(third.VersionID)) {
-		t.Errorf("error does not explain and list the versions: %s", msg)
+	if !strings.Contains(msg, "nothing is recorded as serving before") {
+		t.Errorf("error does not name the situation: %s", msg)
+	}
+	if !strings.Contains(msg, fmt.Sprint(only.VersionID)) || !strings.Contains(msg, "current") {
+		t.Errorf("error does not list the versions: %s", msg)
+	}
+}
+
+// Re-applying byte-identical content moves nothing, so it must not overwrite the
+// predecessor with the current version — that would strand an app on its newest
+// version with nowhere to roll back to after an idle dev loop.
+func TestAppRollbackSurvivesAReapplyOfTheCurrentVersion(t *testing.T) {
+	d := appApplyDaemon(t)
+	first := applyOK(t, d, "approval-gate", declarationFor("approval-gate", "first"), "export default {}\n")
+	applyOK(t, d, "approval-gate", declarationFor("approval-gate", "second"), "export default { two: true }\n")
+	applyOK(t, d, "approval-gate", declarationFor("approval-gate", "second"), "export default { two: true }\n")
+
+	resp := appRollback(t, d, "approval-gate", 0)
+	if !resp.Ok {
+		t.Fatalf("rollback: %v", protocol.Deref(resp.Error))
+	}
+	if got := resp.AppRollbackResult.VersionID; got != first.VersionID {
+		t.Fatalf("rolled back to %d, want %d", got, first.VersionID)
 	}
 }
 

--- a/internal/store/apps.go
+++ b/internal/store/apps.go
@@ -25,12 +25,42 @@ import (
 
 // App is one registered app. CurrentVersionID is 0 until a version has been
 // applied — a registry row can exist ahead of its first successful build.
+//
+// PreviousVersionID is what was serving immediately before CurrentVersionID, and
+// it is 0 until the pointer has moved at least once off a real version. It is
+// the fact bare `attn app rollback` follows, so it is maintained by every path
+// that moves the pointer and by nothing else.
 type App struct {
-	Name             string
-	CurrentVersionID int64
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
+	Name              string
+	CurrentVersionID  int64
+	PreviousVersionID int64
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
 }
+
+// movePointerSQL sets an app's current version and carries the version it
+// replaced into previous_version_id. Both pointer-moving statements share it, so
+// there is one place the predecessor can be recorded and no way to move the
+// pointer without recording it.
+//
+// The CASE keeps the predecessor unchanged when the move is a no-op — re-applying
+// byte-identical content lands on the version already current, and overwriting
+// the predecessor with itself would make a rollback that changed nothing lose the
+// version it could have gone back to. SQLite evaluates every assignment against
+// the pre-update row, so current_version_id on the right-hand side is the
+// outgoing one.
+//
+// Parameters, in order: the incoming version id (twice), the stamp, the name.
+const movePointerSQL = `
+	UPDATE apps SET
+		previous_version_id = CASE
+			WHEN current_version_id IS NOT NULL AND current_version_id <> ?
+			THEN current_version_id
+			ELSE previous_version_id
+		END,
+		current_version_id = ?,
+		updated_at = ?
+	WHERE name = ?`
 
 // AppVersion is an immutable record of one built artifact. ContentHash is the
 // version's identity: applying byte-identical content again reuses this row
@@ -98,7 +128,7 @@ func (s *Store) GetApp(name string) (App, bool, error) {
 		return App{}, false, nil
 	}
 	app, err := scanApp(s.db.QueryRow(`
-		SELECT name, current_version_id, created_at, updated_at FROM apps WHERE name = ?
+		SELECT name, current_version_id, previous_version_id, created_at, updated_at FROM apps WHERE name = ?
 	`, name))
 	switch err {
 	case nil:
@@ -119,7 +149,7 @@ func (s *Store) ListApps() ([]App, error) {
 		return nil, nil
 	}
 	rows, err := s.db.Query(`
-		SELECT name, current_version_id, created_at, updated_at FROM apps ORDER BY name ASC
+		SELECT name, current_version_id, previous_version_id, created_at, updated_at FROM apps ORDER BY name ASC
 	`)
 	if err != nil {
 		return nil, err
@@ -220,9 +250,7 @@ func (s *Store) CommitAppVersion(v AppVersion, now time.Time) (AppVersion, bool,
 		return AppVersion{}, false, err
 	}
 
-	if _, err := tx.Exec(`
-		UPDATE apps SET current_version_id = ?, updated_at = ? WHERE name = ?
-	`, v.ID, stamp, v.AppName); err != nil {
+	if _, err := tx.Exec(movePointerSQL, v.ID, v.ID, stamp, v.AppName); err != nil {
 		return AppVersion{}, false, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -251,9 +279,8 @@ func (s *Store) SetAppCurrentVersion(name string, versionID int64, now time.Time
 	case owner != name:
 		return fmt.Errorf("store: app version %d belongs to app %q, not %q", versionID, owner, name)
 	}
-	res, err := s.db.Exec(`
-		UPDATE apps SET current_version_id = ?, updated_at = ? WHERE name = ?
-	`, versionID, now.UTC().Format(sortableTimeFormat), name)
+	stamp := now.UTC().Format(sortableTimeFormat)
+	res, err := s.db.Exec(movePointerSQL, versionID, versionID, stamp, name)
 	if err != nil {
 		return err
 	}
@@ -460,15 +487,17 @@ func (s *Store) TrimAppInvocations(cutoff time.Time, perApp int) (int, error) {
 
 func scanApp(row rowScanner) (App, error) {
 	var (
-		app       App
-		versionID sql.NullInt64
-		createdAt string
-		updatedAt string
+		app        App
+		versionID  sql.NullInt64
+		previousID sql.NullInt64
+		createdAt  string
+		updatedAt  string
 	)
-	if err := row.Scan(&app.Name, &versionID, &createdAt, &updatedAt); err != nil {
+	if err := row.Scan(&app.Name, &versionID, &previousID, &createdAt, &updatedAt); err != nil {
 		return App{}, err
 	}
 	app.CurrentVersionID = versionID.Int64
+	app.PreviousVersionID = previousID.Int64
 	app.CreatedAt = parseStoreTime(createdAt)
 	app.UpdatedAt = parseStoreTime(updatedAt)
 	return app, nil

--- a/internal/store/apps_test.go
+++ b/internal/store/apps_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -146,6 +147,62 @@ func TestApps_RollbackMovesThePointerOnly(t *testing.T) {
 	}
 }
 
+// Every path that moves the pointer records the version it replaced, and a
+// no-op move leaves that record alone. This is what bare `attn app rollback`
+// reads, so the two writers have to agree.
+func TestApps_PointerMovesRecordWhatTheyReplaced(t *testing.T) {
+	s := New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	older, newer := seedApps(t, s, now)
+
+	previousOf := func(step string) int64 {
+		t.Helper()
+		app, ok, err := s.GetApp("approval-gate")
+		if err != nil || !ok {
+			t.Fatalf("%s: get app: %v ok=%t", step, err, ok)
+		}
+		return app.PreviousVersionID
+	}
+
+	// The first version had nothing before it; the second replaced it.
+	if got := previousOf("after two applies"); got != older.ID {
+		t.Fatalf("previous after the second apply = %d, want %d", got, older.ID)
+	}
+
+	// Re-applying the version already current moves nothing, so the predecessor
+	// must survive — otherwise an idle dev loop erases the way back.
+	if _, _, err := s.CommitAppVersion(AppVersion{
+		AppName:      "approval-gate",
+		ContentHash:  newer.ContentHash,
+		Declaration:  "ignored",
+		ArtifactPath: "ignored",
+	}, now.Add(time.Hour)); err != nil {
+		t.Fatalf("re-apply: %v", err)
+	}
+	if got := previousOf("after a no-op re-apply"); got != older.ID {
+		t.Fatalf("a no-op re-apply rewrote the predecessor to %d, want %d", got, older.ID)
+	}
+
+	// A rollback is a pointer move like any other and records the same way, which
+	// is what lets a second rollback undo the first.
+	if err := s.SetAppCurrentVersion("approval-gate", older.ID, now.Add(2*time.Hour)); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if got := previousOf("after a rollback"); got != newer.ID {
+		t.Fatalf("previous after the rollback = %d, want %d", got, newer.ID)
+	}
+
+	// An app whose pointer has never moved off a real version has no predecessor,
+	// and reports 0 rather than guessing at one.
+	other, _, err := s.GetApp("standup-digest")
+	if err != nil {
+		t.Fatalf("get the single-version app: %v", err)
+	}
+	if other.PreviousVersionID != 0 {
+		t.Fatalf("a first apply invented a predecessor: %d", other.PreviousVersionID)
+	}
+}
+
 // Removal takes the registry row and nothing else: versions and invocations are
 // history, and `attn app remove` says so by counting what it kept.
 func TestApps_DeleteKeepsVersionsAndInvocations(t *testing.T) {
@@ -282,5 +339,51 @@ func TestApps_CommitVersionRefusesAnIncompleteRow(t *testing.T) {
 	}
 	if apps, err := s.ListApps(); err != nil || len(apps) != 0 {
 		t.Fatalf("a refused commit left rows behind: %+v (%v)", apps, err)
+	}
+}
+
+// A database written before this column existed carries its app rows across the
+// migration with no predecessor rather than inventing one: what was serving
+// before is history the registry never recorded, and deriving it from ids is the
+// bug bare rollback exists to avoid.
+func TestApps_MigrationCarriesRowsWithNoPredecessor(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "attn.db")
+	s, err := NewWithDB(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	seedApps(t, s, now)
+	s.Close()
+
+	// Rewind to the schema as it stood before 103, with the app rows still there.
+	db, err := OpenDB(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	for _, stmt := range []string{
+		"ALTER TABLE apps DROP COLUMN previous_version_id",
+		"DELETE FROM schema_migrations WHERE version = 103",
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("rewinding with %q: %v", stmt, err)
+		}
+	}
+	db.Close()
+
+	s, err = NewWithDB(path)
+	if err != nil {
+		t.Fatalf("reopen after rewind: %v", err)
+	}
+	defer s.Close()
+	app, ok, err := s.GetApp("approval-gate")
+	if err != nil || !ok {
+		t.Fatalf("get app after migration: %v ok=%t", err, ok)
+	}
+	if app.CurrentVersionID == 0 {
+		t.Fatal("the migration lost the current version pointer")
+	}
+	if app.PreviousVersionID != 0 {
+		t.Fatalf("the migration invented a predecessor: %d", app.PreviousVersionID)
 	}
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1075,6 +1075,18 @@ CREATE TABLE IF NOT EXISTS app_invocations (
 -- order.
 CREATE INDEX IF NOT EXISTS idx_app_invocations_app ON app_invocations(app_name, started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_app_invocations_started ON app_invocations(started_at);`},
+	// What was serving immediately before the version an app is on now. Bare
+	// `attn app rollback <name>` follows it, because "the version before this
+	// one" is the operator's get-me-back-to-what-worked, and the numerically
+	// previous id is a different question with a different answer — the app that
+	// went good, broken, fixed rolls back onto the broken one under the old rule.
+	//
+	// Nothing backfills it: what was serving before is history the registry never
+	// recorded, and inventing it from ids would reproduce the bug this fixes. An
+	// app carried across this migration has no recorded previous until its next
+	// pointer move, and bare rollback says so rather than guessing.
+	// Applied by applyMigration103, whose ALTER is column-guarded.
+	{103, "record the previously-serving version of each app", ``},
 }
 
 // migration99SQL is everything migration 99 does after its guarded ALTER.
@@ -1451,6 +1463,11 @@ func migrateDB(db *sql.DB, dbPath string) error {
 			}
 		} else if m.version == 100 {
 			if err := applyMigration100(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 103 {
+			if err := applyMigration103(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -2598,6 +2615,19 @@ func applyMigration100(tx *sql.Tx) error {
 		return err
 	}
 	_, err = tx.Exec("ALTER TABLE notifications ADD COLUMN severity TEXT NOT NULL DEFAULT 'info'")
+	return err
+}
+
+// applyMigration103 adds the previously-serving version pointer to the app
+// registry. Guarded on the column, and NULL is the honest carried value: an app
+// that existed before this migration has no recorded predecessor until its next
+// pointer move.
+func applyMigration103(tx *sql.Tx) error {
+	has, err := columnExists(tx, "apps", "previous_version_id")
+	if err != nil || has {
+		return err
+	}
+	_, err = tx.Exec("ALTER TABLE apps ADD COLUMN previous_version_id INTEGER")
 	return err
 }
 


### PR DESCRIPTION
Bare `attn app rollback <name>` picked the numerically previous version id. That
is the wrong answer in exactly the situation rollback exists for: an operator who
rolls a broken version off and then applies a fix has that broken version sitting
one id below the pointer, so "back" landed on the thing they were escaping.

Bare rollback now means **the version that was serving immediately before the
current one**.

## How

The registry records what each pointer move replaced. Both writers — apply and
rollback — go through one shared `UPDATE` (`movePointerSQL`) that carries the
outgoing version into `apps.previous_version_id`, so there is no way to move the
pointer without recording it. A no-op move — re-applying byte-identical content,
which lands on the version already current — leaves the record alone, so an idle
dev loop cannot erase the way back.

Rolling back twice returns to where you started, because every move rewrites the
predecessor. That is the consequence of "back means what was serving a moment
ago", and it is what makes rollback undoable. It is stated in `attn app rollback
--help` and tested.

Nothing backfills the column. What was serving before is history the registry
never recorded, and deriving it from ids would reproduce the bug this fixes. An
app carried across migration 103, or one on its first version, is refused with
the situation named and its version list attached.

Explicit-version rollback and every other `attn app` verb are unchanged. No wire
change: `AppRollbackResult.PreviousVersionID` already carries the version the app
was on, which for the bare form is exactly the "serving before" the CLI now
names.

## Live verification

Throwaway profile `rbpick` installed from this branch (`make install
PROFILE=rbpick`), preflight PASS, protocol 229 CLI/app/daemon. An app `rbapp`
built to the shape of the bug: v1 and v2 good, **v3 broken**, rolled explicitly
back off v3, then **v4** applied as the fix.

Bare rollback from v4 — the id below it is 3, the broken one:

```
$ attn app rollback rbapp
rolled app rbapp back to version 1 (2938222d4e6e), which was serving before version 4
  artifact /Users/victor/.attn-rbpick/apps/rbapp/2938…/bundle.js
```

Again — it undoes itself:

```
$ attn app rollback rbapp
rolled app rbapp back to version 4 (f2aa919ce25b), which was serving before version 1
```

The sharpest case. Explicitly moved onto the broken v3, whose numerically
previous id is 2; bare rollback returns to what was actually serving, v1:

```
$ attn app rollback rbapp 3
moved app rbapp forward to version 3 (8113e47271b4)
  was on version 1

$ attn app rollback rbapp
rolled app rbapp back to version 1 (2938222d4e6e), which was serving before version 3
```

The error, on a fresh app with one version and no recorded predecessor (exit 1):

```
$ attn app rollback freshapp
app rollback: daemon error: app rollback freshapp: nothing is recorded as
serving before version 5, so bare rollback has no target; name the version to
roll onto. its versions, newest first: 5 (c6e02eee0039) — current
```

Profile cleaned (`attn profile clean rbpick`) — daemon stopped, bundle and data
dir removed.

## Tests

- Store: every pointer move records what it replaced; a no-op re-apply does not;
  a first apply invents no predecessor.
- Store: a database rewound to the pre-103 schema with app rows in it carries
  them across the migration with the pointer intact and no predecessor. Verified
  non-vacuous — with the migration dispatch disabled the test fails on the
  missing column.
- Daemon: bare rollback skips a version that was rolled off; rolling back twice
  flips between the two most recent serving versions; no recorded predecessor
  refuses loudly with the version list; a no-op re-apply does not strand the app.

## Surfaces

CLI (`attn app rollback` and its help), daemon (`handleAppRollback`), store
(migration 103). No protocol change, no frontend surface — `attn app status`
already renders the serving version and needed nothing. Linux-clean: pure Go,
no build constraints touched.

Migration numbering re-checked against `origin/main` at branch time and after
rebase: main's highest is 102, so 103 is free.

## Hit every surface

If you added a way in, add the way out: bare rollback's way out is bare rollback
— it flips, so there is no one-way door here.
