### PR TITLE
feat(hub): ship the app runtime host to remote endpoints

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -11,6 +11,8 @@ on:
       - "go.sum"
       - "cmd/**"
       - "internal/**"
+      - "apphost/**"
+      - "scripts/build-app-runtime-host.sh"
   workflow_dispatch:
 
 jobs:
@@ -58,6 +60,24 @@ jobs:
             exit 1
           fi
           file ${{ matrix.output }}
+
+      # The release publishes the app runtime host beside the daemon, because a
+      # hub installed from a release has no way to build one for a Linux remote.
+      # Building it here is what keeps that step from being first exercised on
+      # release day.
+      - name: Read bun pin
+        id: bun
+        run: echo "version=$(awk '/^bun / { print $2 }' .tool-versions)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ steps.bun.outputs.version }}
+
+      - name: Build app runtime host
+        run: |
+          bash ./scripts/build-app-runtime-host.sh /tmp/app-runtime-${{ matrix.label }}
+          file /tmp/app-runtime-${{ matrix.label }}/attn-app-runtime
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,6 +296,32 @@ jobs:
         run: |
           gh release upload "${RELEASE_TAG}" /tmp/attn-linux-amd64 --clobber
 
+      # The app runtime host travels with the daemon: a hub installed from a
+      # release has no source checkout to build one from, so without this asset
+      # it can never give a Linux remote a runtime and every app there parks.
+      # Built natively on this runner rather than cross-compiled — the runner is
+      # the target platform.
+      - name: Read bun pin
+        id: bun
+        run: echo "version=$(awk '/^bun / { print $2 }' .tool-versions)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ steps.bun.outputs.version }}
+
+      - name: Build Linux amd64 app runtime host
+        run: |
+          bash ./scripts/build-app-runtime-host.sh /tmp/app-runtime-amd64
+          mv /tmp/app-runtime-amd64/attn-app-runtime /tmp/attn-app-runtime-linux-amd64
+          file /tmp/attn-app-runtime-linux-amd64
+
+      - name: Upload Linux amd64 app runtime host
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${RELEASE_TAG}" /tmp/attn-app-runtime-linux-amd64 --clobber
+
   linux-arm64:
     name: Linux arm64 daemon
     needs: tauri
@@ -343,6 +369,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${RELEASE_TAG}" /tmp/attn-linux-arm64 --clobber
+
+      # The app runtime host travels with the daemon: a hub installed from a
+      # release has no source checkout to build one from, so without this asset
+      # it can never give a Linux remote a runtime and every app there parks.
+      # Built natively on this runner rather than cross-compiled — the runner is
+      # the target platform.
+      - name: Read bun pin
+        id: bun
+        run: echo "version=$(awk '/^bun / { print $2 }' .tool-versions)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ steps.bun.outputs.version }}
+
+      - name: Build Linux arm64 app runtime host
+        run: |
+          bash ./scripts/build-app-runtime-host.sh /tmp/app-runtime-arm64
+          mv /tmp/app-runtime-arm64/attn-app-runtime /tmp/attn-app-runtime-linux-arm64
+          file /tmp/attn-app-runtime-linux-arm64
+
+      - name: Upload Linux arm64 app runtime host
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${RELEASE_TAG}" /tmp/attn-app-runtime-linux-arm64 --clobber
 
   # Nothing is public until every gate above has passed and every asset is
   # attached. A failure anywhere leaves the draft for inspection: fix it, re-run

--- a/changelog.d/hub-ships-the-app-runtime-to-remotes.yaml
+++ b/changelog.d/hub-ships-the-app-runtime-to-remotes.yaml
@@ -1,0 +1,14 @@
+kind: fixed
+area: daemon
+change: >
+  Apps now run on remote endpoints. Setting up a remote machine installed the
+  attn binary and nothing else, so the daemon there had no app runtime host to
+  start: every app it hosted parked, and the events they were due were recorded
+  as runtime failures instead. The setup now ships the runtime host beside the
+  binary, matching the remote's platform, and skips the transfer when the
+  machine already has that exact build. A machine that cannot be given one says
+  so by name — which file, on which host, and what would produce it — and still
+  runs sessions.
+symptom: >
+  On a remote endpoint, every app showed as parked and its events were charged
+  to the runtime rather than to the app.

--- a/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
+++ b/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
@@ -502,7 +502,13 @@ merged head (lazy start, missing-binary path, crash-loop park, held park,
 recovery drain, bare-rollback trap):
 
 - **Hub sidecar: fix.** Bootstrap uploads `attn-app-runtime` beside the
-  `attn` binary so hub-managed remotes can run apps.
+  `attn` binary so hub-managed remotes can run apps. *Shipped:* the host is
+  built for the remote's platform from the checkout (or downloaded from the
+  release, which now publishes `attn-app-runtime-linux-{amd64,arm64}`),
+  transferred only when its content hash differs — it is ~90MB and endpoints
+  sync on a timer — and named per profile on the remote, because
+  profile-isolated daemons share one `~/.local/bin` and one shared file name
+  would have the newest sync replace another profile's runtime.
 - **Bare rollback: previously-serving.** `attn app rollback <name>` without
   a version returns to the version that was serving before the current one
   — the registry records the pointer at every flip — and says which version

--- a/internal/apps/apps.go
+++ b/internal/apps/apps.go
@@ -27,6 +27,26 @@ import (
 // name, so it is the intersection of what all three accept.
 var nameRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 
+// RuntimeHostBinaryName is the compiled sidecar every app's handlers run in.
+// Three places need the same string and none of them can see the others: the
+// build (scripts/build-app-runtime-host.sh) writes it, the daemon resolves it
+// beside itself, and the hub ships it to a remote alongside the attn binary.
+// TestRuntimeHostBinaryNameMatchesTheBuild pins the build to this one.
+const RuntimeHostBinaryName = "attn-app-runtime"
+
+// RuntimeHostBinaryNameForProfile is the same binary under the name a given
+// profile installs it as. One machine hosts several profile-isolated daemons —
+// `~/.local/bin/attn` beside `~/.local/bin/attn-dev` — and each resolves its
+// runtime beside its own binary, so sharing one file name there would have the
+// newest sync silently replace another profile's sidecar with a different build.
+func RuntimeHostBinaryNameForProfile(profile string) string {
+	p := strings.TrimSpace(profile)
+	if p == "" {
+		return RuntimeHostBinaryName
+	}
+	return RuntimeHostBinaryName + "-" + p
+}
+
 // MaxNameLength bounds an app name. The tripwire is the document namespace: the
 // store validates `owner/name` and an app's namespace is `app/<name>`, so a name
 // nobody could address is refused here, where the error can say so, rather than

--- a/internal/apps/apps_test.go
+++ b/internal/apps/apps_test.go
@@ -1,6 +1,9 @@
 package apps
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -87,5 +90,34 @@ func TestDerivedIdentities(t *testing.T) {
 	}
 	if got := Namespace("approval-gate"); got != "app/approval-gate" {
 		t.Errorf("Namespace = %q", got)
+	}
+}
+
+// The build writes the sidecar under a name the daemon and the hub both look
+// for. Nothing links the shell script to this constant, so a rename there would
+// produce a daemon that cannot find its runtime and a remote that is shipped a
+// file nobody starts.
+func TestRuntimeHostBinaryNameMatchesTheBuild(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate this test's own file")
+	}
+	script := filepath.Join(filepath.Dir(file), "..", "..", "scripts", "build-app-runtime-host.sh")
+	contents, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatalf("reading %s: %v", script, err)
+	}
+	want := `binary_name="` + RuntimeHostBinaryName + `"`
+	if !strings.Contains(string(contents), want) {
+		t.Fatalf("%s does not build %q (looked for %s)", script, RuntimeHostBinaryName, want)
+	}
+}
+
+func TestRuntimeHostBinaryNameForProfile(t *testing.T) {
+	if got := RuntimeHostBinaryNameForProfile(""); got != "attn-app-runtime" {
+		t.Errorf("default profile = %q", got)
+	}
+	if got := RuntimeHostBinaryNameForProfile("dev"); got != "attn-app-runtime-dev" {
+		t.Errorf("named profile = %q", got)
 	}
 }

--- a/internal/daemon/app_runtime.go
+++ b/internal/daemon/app_runtime.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/victorarias/attn/internal/apps"
+	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/store"
 	"github.com/victorarias/attn/internal/supervise"
 )
@@ -38,10 +40,10 @@ const (
 	// `attn app runtime status` both have to mean one thing.
 	appRuntimeChildName = "runtime"
 
-	// appRuntimeBinaryName is the compiled sidecar. Changing it here alone
-	// produces a daemon that cannot find its runtime — scripts/build-app-runtime-host.sh
-	// writes this name.
-	appRuntimeBinaryName = "attn-app-runtime"
+	// appRuntimeBinaryName is the compiled sidecar. The name lives in
+	// internal/apps because the build, this daemon and the hub's remote install
+	// all have to agree on it.
+	appRuntimeBinaryName = apps.RuntimeHostBinaryName
 
 	// appRuntimeAPIVersion is the host contract this daemon speaks. A host
 	// presenting anything else is refused at hello rather than half-served: the
@@ -77,17 +79,7 @@ func resolveAppRuntimeHost() (string, error) {
 		return "", fmt.Errorf("resolving this daemon's own executable to find %s beside it: %w", appRuntimeBinaryName, err)
 	}
 
-	candidates := []string{}
-	// Inside a .app the daemon is Contents/MacOS/attn and Tauri stages resources
-	// under Contents/Resources.
-	macOSDir := filepath.Dir(executable)
-	contentsDir := filepath.Dir(macOSDir)
-	if filepath.Base(macOSDir) == "MacOS" && filepath.Base(contentsDir) == "Contents" {
-		candidates = append(candidates, filepath.Join(contentsDir, "Resources", "app-runtime", appRuntimeBinaryName))
-	}
-	// A checkout, and every Linux install: beside the daemon binary.
-	candidates = append(candidates, filepath.Join(macOSDir, appRuntimeBinaryName))
-
+	candidates := appRuntimeHostCandidates(executable, config.Profile())
 	for _, candidate := range candidates {
 		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
 			return candidate, nil
@@ -96,6 +88,28 @@ func resolveAppRuntimeHost() (string, error) {
 	return "", fmt.Errorf(
 		"the app runtime binary %s is not installed; looked in %s. It is built by `make build-app-runtime-host` (or any `make install`), and %s overrides the location",
 		appRuntimeBinaryName, strings.Join(candidates, " and "), appRuntimeHostOverride)
+}
+
+// appRuntimeHostCandidates lists where a daemon at `executable` looks for its
+// sidecar, in order.
+func appRuntimeHostCandidates(executable, profile string) []string {
+	candidates := []string{}
+	// Inside a .app the daemon is Contents/MacOS/attn and Tauri stages resources
+	// under Contents/Resources.
+	binDir := filepath.Dir(executable)
+	contentsDir := filepath.Dir(binDir)
+	if filepath.Base(binDir) == "MacOS" && filepath.Base(contentsDir) == "Contents" {
+		candidates = append(candidates, filepath.Join(contentsDir, "Resources", "app-runtime", appRuntimeBinaryName))
+	}
+	// A checkout, and every Linux install: beside the daemon binary. A named
+	// profile looks for its own copy first — profile-isolated daemons on a remote
+	// share one `~/.local/bin`, and each needs the sidecar built from the same
+	// source as the binary beside it. A checkout is the case that keeps the
+	// unsuffixed name last: there `./attn` serves whatever profile is exported.
+	if profile != "" {
+		candidates = append(candidates, filepath.Join(binDir, apps.RuntimeHostBinaryNameForProfile(profile)))
+	}
+	return append(candidates, filepath.Join(binDir, appRuntimeBinaryName))
 }
 
 // appRuntimeLogDir sits beside the plugin log tree rather than under the app

--- a/internal/daemon/app_runtime_test.go
+++ b/internal/daemon/app_runtime_test.go
@@ -1051,3 +1051,35 @@ func TestAppRuntimeHelloSniffIgnoresEverythingElse(t *testing.T) {
 		}
 	}
 }
+
+// Where a daemon looks for its sidecar. The profile-suffixed name exists for
+// remotes: several profile-isolated daemons install into one ~/.local/bin, and
+// each has to start the runtime built from the same source as the binary beside
+// it — not whichever profile synced last.
+func TestAppRuntimeHostCandidates(t *testing.T) {
+	bundled := appRuntimeHostCandidates("/Applications/attn.app/Contents/MacOS/attn", "")
+	if len(bundled) != 2 || bundled[0] != "/Applications/attn.app/Contents/Resources/app-runtime/attn-app-runtime" {
+		t.Fatalf("bundled candidates = %v", bundled)
+	}
+
+	remote := appRuntimeHostCandidates("/home/v/.local/bin/attn-dev", "dev")
+	want := []string{
+		"/home/v/.local/bin/attn-app-runtime-dev",
+		"/home/v/.local/bin/attn-app-runtime",
+	}
+	if len(remote) != len(want) {
+		t.Fatalf("profile candidates = %v, want %v", remote, want)
+	}
+	for i := range want {
+		if remote[i] != want[i] {
+			t.Fatalf("profile candidates = %v, want %v", remote, want)
+		}
+	}
+
+	// A checkout keeps working under any profile: `./attn` is one binary and the
+	// staged sidecar beside it carries no suffix.
+	checkout := appRuntimeHostCandidates("/src/attn/attn", "dev")
+	if checkout[len(checkout)-1] != "/src/attn/attn-app-runtime" {
+		t.Fatalf("checkout candidates = %v", checkout)
+	}
+}

--- a/internal/hub/bootstrap.go
+++ b/internal/hub/bootstrap.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/victorarias/attn/internal/apps"
 	"github.com/victorarias/attn/internal/buildinfo"
 	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/enrollment"
@@ -28,6 +29,13 @@ type RemotePlatform struct {
 	GOOS         string
 	GOARCH       string
 	ArtifactName string
+	// RuntimeArtifactName is the app runtime host for this platform — the Bun
+	// sidecar every installed app's handlers execute in. It travels with the
+	// binary rather than being fetched on demand: a remote daemon that cannot
+	// start its runtime parks every app it hosts.
+	RuntimeArtifactName string
+	// BunTarget is what `bun build --compile --target=` calls this platform.
+	BunTarget string
 }
 
 type Bootstrapper struct {
@@ -68,7 +76,7 @@ func (b *Bootstrapper) EnsureRemoteReady(ctx context.Context, sshTarget, profile
 
 	preferSourceBuild := sourceCheckoutAvailable()
 	var localBinary string
-	binaryUpdated := false
+	binariesUpdated := false
 	if remoteVersion != localVersion || preferSourceBuild {
 		localBinary, err = b.ensureLocalBinary(ctx, platform, localVersion)
 		if err != nil {
@@ -92,11 +100,31 @@ func (b *Bootstrapper) EnsureRemoteReady(ctx context.Context, sshTarget, profile
 		}
 	}
 
+	remoteInstallPath, err := b.resolveRemoteInstall(ctx, sshTarget, profile)
+	if err != nil {
+		return fmt.Errorf("resolve the install path on %s: %w", sshTarget, err)
+	}
+
 	if shouldInstall {
-		if err := b.installRemoteBinary(ctx, sshTarget, profile, localBinary); err != nil {
+		if err := b.installRemoteBinary(ctx, sshTarget, profile, localBinary, remoteInstallPath); err != nil {
 			return fmt.Errorf("install attn on %s: %w", sshTarget, err)
 		}
-		binaryUpdated = true
+		binariesUpdated = true
+	}
+
+	// The app runtime host ships beside the binary and is gated on its own
+	// content, so it is checked on every sync rather than only when the binary
+	// moved: the two are built from different trees and an apphost-only change
+	// leaves the attn binary identical. A remote that cannot get one still runs
+	// sessions — only apps park — so this reports and continues.
+	runtimeUpdated, err := b.ensureRemoteAppRuntime(ctx, sshTarget, profile, platform, localVersion, remoteInstallPath)
+	if err != nil {
+		b.logf("%v", err)
+	}
+	if runtimeUpdated {
+		// A replaced sidecar is a new file; the running one keeps the old inode
+		// until something restarts it, and the daemon is what starts it.
+		binariesUpdated = true
 	}
 
 	// Enroll before the daemon starts, so a remote coming up for the first time
@@ -107,7 +135,7 @@ func (b *Bootstrapper) EnsureRemoteReady(ctx context.Context, sshTarget, profile
 		return err
 	}
 
-	if err := b.ensureRemoteDaemonRunning(ctx, sshTarget, profile, binaryUpdated); err != nil {
+	if err := b.ensureRemoteDaemonRunning(ctx, sshTarget, profile, binariesUpdated); err != nil {
 		return fmt.Errorf("ensure remote daemon on %s: %w", sshTarget, err)
 	}
 	return nil
@@ -199,14 +227,33 @@ func (b *Bootstrapper) detectRemotePlatform(ctx context.Context, sshTarget, prof
 	if fields[0] != "Linux" {
 		return RemotePlatform{}, fmt.Errorf("unsupported platform %q (Linux only)", out)
 	}
+	return remoteLinuxPlatform(fields[1])
+}
 
-	switch fields[1] {
+// remoteLinuxPlatform maps a Linux `uname -m` onto the artifacts a remote needs.
+// The Go and Bun names for the same machine disagree (amd64 vs x64), and each is
+// the one its own toolchain accepts, so both are recorded here rather than
+// derived at the call site.
+func remoteLinuxPlatform(machine string) (RemotePlatform, error) {
+	switch machine {
 	case "x86_64", "amd64":
-		return RemotePlatform{GOOS: "linux", GOARCH: "amd64", ArtifactName: "attn-linux-amd64"}, nil
+		return RemotePlatform{
+			GOOS:                "linux",
+			GOARCH:              "amd64",
+			ArtifactName:        "attn-linux-amd64",
+			RuntimeArtifactName: apps.RuntimeHostBinaryName + "-linux-amd64",
+			BunTarget:           "bun-linux-x64",
+		}, nil
 	case "aarch64", "arm64":
-		return RemotePlatform{GOOS: "linux", GOARCH: "arm64", ArtifactName: "attn-linux-arm64"}, nil
+		return RemotePlatform{
+			GOOS:                "linux",
+			GOARCH:              "arm64",
+			ArtifactName:        "attn-linux-arm64",
+			RuntimeArtifactName: apps.RuntimeHostBinaryName + "-linux-arm64",
+			BunTarget:           "bun-linux-arm64",
+		}, nil
 	default:
-		return RemotePlatform{}, fmt.Errorf("unsupported architecture %q", fields[1])
+		return RemotePlatform{}, fmt.Errorf("unsupported architecture %q", machine)
 	}
 }
 
@@ -279,7 +326,7 @@ func (b *Bootstrapper) ensureLocalBinary(ctx context.Context, platform RemotePla
 	}
 
 	if version != "" && version != "dev" {
-		if err := b.downloadReleaseBinary(ctx, version, platform, filepath.Dir(cachePath)); err == nil {
+		if err := b.downloadReleaseArtifact(ctx, version, platform.ArtifactName, filepath.Dir(cachePath)); err == nil {
 			return cachePath, nil
 		} else {
 			b.logf("release download failed for %s %s: %v", version, platform.ArtifactName, err)
@@ -292,17 +339,135 @@ func (b *Bootstrapper) ensureLocalBinary(ctx context.Context, platform RemotePla
 	return cachePath, nil
 }
 
-func (b *Bootstrapper) downloadReleaseBinary(ctx context.Context, version string, platform RemotePlatform, destDir string) error {
+func (b *Bootstrapper) downloadReleaseArtifact(ctx context.Context, version, artifact, destDir string) error {
 	tag := version
 	if !strings.HasPrefix(tag, "v") {
 		tag = "v" + tag
 	}
-	cmd := exec.CommandContext(ctx, "gh", "release", "download", tag, "--repo", githubRepo, "--pattern", platform.ArtifactName, "--dir", destDir, "--clobber")
+	cmd := exec.CommandContext(ctx, "gh", "release", "download", tag, "--repo", githubRepo, "--pattern", artifact, "--dir", destDir, "--clobber")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("gh release download %s: %s", tag, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// appRuntimeCacheDir is where prepared app runtime hosts live, keyed by what
+// produced them.
+//
+// A source build overwrites one file per platform instead of accumulating a copy
+// per attn build: the sidecar is built from apphost/, which no version or
+// daemon-binary fingerprint covers, so any such key would serve a stale runtime
+// after an apphost-only edit — and the artifact is ~90MB, so a key per build is
+// also a disk leak. The compile is fast enough (~0.4s measured, bun embeds its
+// runtime rather than compiling it) that rebuilding every sync costs nothing. A
+// downloaded release artifact is immutable and does cache per version.
+func appRuntimeCacheDir(home, key string) string {
+	return filepath.Join(home, ".attn", "remotes", "app-runtime", key)
+}
+
+// ensureLocalAppRuntime produces the app runtime host for the remote's platform
+// and returns its local path. Source build first, published artifact second —
+// the same order, and for the same reason, as the attn binary beside it.
+func (b *Bootstrapper) ensureLocalAppRuntime(ctx context.Context, platform RemotePlatform, version string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	var reasons []string
+	if sourceCheckoutAvailable() {
+		stageDir := appRuntimeCacheDir(home, platform.GOOS+"_"+platform.GOARCH)
+		if err := b.buildAppRuntimeFromSource(ctx, platform, stageDir); err == nil {
+			return filepath.Join(stageDir, apps.RuntimeHostBinaryName), nil
+		} else {
+			reasons = append(reasons, fmt.Sprintf("source build: %v", err))
+		}
+	}
+
+	if version != "" && version != "dev" {
+		cachePath := filepath.Join(appRuntimeCacheDir(home, version), platform.RuntimeArtifactName)
+		if info, err := os.Stat(cachePath); err == nil && info.Mode().IsRegular() {
+			return cachePath, nil
+		}
+		if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+			return "", err
+		}
+		if err := b.downloadReleaseArtifact(ctx, version, platform.RuntimeArtifactName, filepath.Dir(cachePath)); err == nil {
+			return cachePath, nil
+		} else {
+			reasons = append(reasons, fmt.Sprintf("release download: %v", err))
+		}
+	} else {
+		reasons = append(reasons, "no published release to download it from (this hub reports version "+version+")")
+	}
+
+	return "", fmt.Errorf("no %s available (%s)", platform.RuntimeArtifactName, strings.Join(reasons, "; "))
+}
+
+func (b *Bootstrapper) buildAppRuntimeFromSource(ctx context.Context, platform RemotePlatform, stageDir string) error {
+	root := sourceRoot()
+	if root == "" {
+		return fmt.Errorf("source checkout not available")
+	}
+	if platform.BunTarget == "" {
+		return fmt.Errorf("no bun target for %s/%s", platform.GOOS, platform.GOARCH)
+	}
+	script := filepath.Join(root, "scripts", "build-app-runtime-host.sh")
+	if _, err := os.Stat(script); err != nil {
+		return fmt.Errorf("%s is not in this checkout", script)
+	}
+	cmd := exec.CommandContext(ctx, "bash", script, stageDir, platform.BunTarget)
+	cmd.Dir = root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// remoteAppRuntimePath is where the sidecar lands on the remote: beside the attn
+// binary that starts it, under the name that binary's profile resolves.
+func remoteAppRuntimePath(remoteInstallPath, profile string) string {
+	return filepath.Join(filepath.Dir(remoteInstallPath), apps.RuntimeHostBinaryNameForProfile(profile))
+}
+
+// ensureRemoteAppRuntime ships the app runtime host to the remote and reports
+// whether it changed. The gate is content: the artifact is ~90MB, and a hub that
+// syncs its endpoints on a timer would otherwise push it across the network on
+// every pass.
+//
+// Its error is the missing-sidecar report, so it names the remote path, the
+// platform, and what would make the upload possible — the daemon on the far end
+// can only say the file is not there.
+func (b *Bootstrapper) ensureRemoteAppRuntime(ctx context.Context, sshTarget, profile string, platform RemotePlatform, version, remoteInstallPath string) (bool, error) {
+	remotePath := remoteAppRuntimePath(remoteInstallPath, profile)
+
+	localPath, err := b.ensureLocalAppRuntime(ctx, platform, version)
+	if err != nil {
+		return false, fmt.Errorf(
+			"the app runtime host is missing from %s at %s: %w. Apps on that daemon park until it is there; run the hub from a source checkout with bun installed, or copy %s there yourself",
+			sshTarget, remotePath, err, platform.RuntimeArtifactName)
+	}
+
+	localHash, err := fileSHA256(localPath)
+	if err != nil {
+		return false, fmt.Errorf("hash the local app runtime host %s: %w", localPath, err)
+	}
+	remoteHash, err := b.remoteFileSHA256(ctx, sshTarget, profile, shellQuote(remotePath))
+	if err != nil {
+		return false, fmt.Errorf("hash the app runtime host on %s at %s: %w", sshTarget, remotePath, err)
+	}
+	if remoteHash == localHash {
+		return false, nil
+	}
+
+	if err := b.uploadRemoteFile(ctx, sshTarget, profile, localPath, remotePath); err != nil {
+		return false, fmt.Errorf(
+			"the app runtime host could not be installed on %s at %s: %w. Apps on that daemon park until it is there",
+			sshTarget, remotePath, err)
+	}
+	b.logf("installed the app runtime host on %s at %s (%s)", sshTarget, remotePath, localHash[:12])
+	return true, nil
 }
 
 func sourceRoot() string {
@@ -346,27 +511,29 @@ func fileSHA256(path string) (string, error) {
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }
 
-func (b *Bootstrapper) remoteBinarySHA256(ctx context.Context, sshTarget, profile string) (string, error) {
-	binName := remoteBinaryName(profile)
-	script := fmt.Sprintf(`
-ATTN_BIN="${ATTN_REMOTE_ATTN_BIN:-$HOME/.local/bin/%s}"
-if [ ! -x "$ATTN_BIN" ] && [ -z "${ATTN_REMOTE_ATTN_BIN:-}" ]; then
-  ATTN_BIN="$(command -v %s 2>/dev/null || true)"
-fi
-if [ -z "$ATTN_BIN" ] || [ ! -f "$ATTN_BIN" ]; then
+// remoteSHA256Script hashes whatever pathExpr expands to in the remote shell —
+// a quoted literal, or a variable an earlier line resolved. A file that is not
+// there answers NOT_FOUND rather than failing: "no copy yet" is the first sync,
+// not an error.
+func remoteSHA256Script(pathExpr string) string {
+	return fmt.Sprintf(`
+if [ ! -f %[1]s ]; then
   printf NOT_FOUND
   exit 0
 fi
 if command -v sha256sum >/dev/null 2>&1; then
-  sha256sum "$ATTN_BIN" | awk '{print $1}'
+  sha256sum %[1]s | awk '{print $1}'
   exit 0
 fi
 if command -v shasum >/dev/null 2>&1; then
-  shasum -a 256 "$ATTN_BIN" | awk '{print $1}'
+  shasum -a 256 %[1]s | awk '{print $1}'
   exit 0
 fi
 printf NO_HASH_TOOL
-`, binName, binName)
+`, pathExpr)
+}
+
+func (b *Bootstrapper) runRemoteSHA256(ctx context.Context, sshTarget, profile, script string) (string, error) {
 	out, err := runSSH(ctx, sshTarget, profile, script)
 	if err != nil {
 		return "", err
@@ -380,6 +547,23 @@ printf NO_HASH_TOOL
 	default:
 		return value, nil
 	}
+}
+
+// remoteFileSHA256 returns the hash of a remote file, or "" when it is not
+// there. pathExpr is a shell expression, so callers quote their own literals.
+func (b *Bootstrapper) remoteFileSHA256(ctx context.Context, sshTarget, profile, pathExpr string) (string, error) {
+	return b.runRemoteSHA256(ctx, sshTarget, profile, remoteSHA256Script(pathExpr))
+}
+
+func (b *Bootstrapper) remoteBinarySHA256(ctx context.Context, sshTarget, profile string) (string, error) {
+	binName := remoteBinaryName(profile)
+	resolve := fmt.Sprintf(`
+ATTN_BIN="${ATTN_REMOTE_ATTN_BIN:-$HOME/.local/bin/%s}"
+if [ ! -x "$ATTN_BIN" ] && [ -z "${ATTN_REMOTE_ATTN_BIN:-}" ]; then
+  ATTN_BIN="$(command -v %s 2>/dev/null || true)"
+fi
+`, binName, binName)
+	return b.runRemoteSHA256(ctx, sshTarget, profile, resolve+remoteSHA256Script(`"$ATTN_BIN"`))
 }
 
 func (b *Bootstrapper) localBinaryCacheKey(version string) (string, bool, error) {
@@ -511,21 +695,37 @@ func resolveRemoteInstallPath(remoteHome, override, profile string) string {
 	return path
 }
 
-func (b *Bootstrapper) installRemoteBinary(ctx context.Context, sshTarget, profile, localBinary string) error {
+// resolveRemoteInstall asks the remote where $HOME is and returns the path the
+// attn binary installs to. Every file this bootstrap ships lands beside it.
+func (b *Bootstrapper) resolveRemoteInstall(ctx context.Context, sshTarget, profile string) (string, error) {
 	remoteHome, err := runSSH(ctx, sshTarget, profile, `printf '%s' "$HOME"`)
 	if err != nil {
-		return err
+		return "", err
 	}
-	remoteInstallPath := resolveRemoteInstallPath(strings.TrimSpace(remoteHome), os.Getenv("ATTN_REMOTE_ATTN_BIN"), profile)
-	remoteInstallDir := filepath.Dir(remoteInstallPath)
-	remoteTmpPath := filepath.Join("/tmp", fmt.Sprintf("%s.%d.%d.tmp", filepath.Base(remoteInstallPath), os.Getpid(), time.Now().UnixNano()))
+	return resolveRemoteInstallPath(strings.TrimSpace(remoteHome), os.Getenv("ATTN_REMOTE_ATTN_BIN"), profile), nil
+}
+
+func (b *Bootstrapper) installRemoteBinary(ctx context.Context, sshTarget, profile, localBinary, remoteInstallPath string) error {
 	attnDir := remoteAttnDirShell(profile)
-	if _, err := runSSH(ctx, sshTarget, profile, fmt.Sprintf("mkdir -p %s %s", shellQuote(remoteInstallDir), attnDir)); err != nil {
+	if _, err := runSSH(ctx, sshTarget, profile, fmt.Sprintf("mkdir -p %s", attnDir)); err != nil {
 		return err
 	}
-	file, err := os.Open(localBinary)
+	return b.uploadRemoteFile(ctx, sshTarget, profile, localBinary, remoteInstallPath)
+}
+
+// uploadRemoteFile streams a local executable to the remote and installs it in
+// place. `install` unlinks the destination before writing it, so replacing a
+// binary that is running right now hands the new file a new inode instead of
+// failing with ETXTBSY — the running process keeps the old one until it exits.
+func (b *Bootstrapper) uploadRemoteFile(ctx context.Context, sshTarget, profile, localPath, remotePath string) error {
+	remoteDir := filepath.Dir(remotePath)
+	remoteTmpPath := filepath.Join("/tmp", fmt.Sprintf("%s.%d.%d.tmp", filepath.Base(remotePath), os.Getpid(), time.Now().UnixNano()))
+	if _, err := runSSH(ctx, sshTarget, profile, fmt.Sprintf("mkdir -p %s", shellQuote(remoteDir))); err != nil {
+		return err
+	}
+	file, err := os.Open(localPath)
 	if err != nil {
-		return fmt.Errorf("open local binary: %w", err)
+		return fmt.Errorf("open %s: %w", localPath, err)
 	}
 	defer file.Close()
 	cmd := exec.CommandContext(
@@ -536,7 +736,7 @@ func (b *Bootstrapper) installRemoteBinary(ctx context.Context, sshTarget, profi
 	cmd.Stdin = file
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("copy binary over ssh: %s", strings.TrimSpace(string(out)))
+		return fmt.Errorf("copy %s over ssh: %s", filepath.Base(localPath), strings.TrimSpace(string(out)))
 	}
 	if probe, probeErr := runSSH(
 		ctx,
@@ -544,7 +744,7 @@ func (b *Bootstrapper) installRemoteBinary(ctx context.Context, sshTarget, profi
 		profile,
 		fmt.Sprintf("if [ -f %s ]; then wc -c < %s; else printf MISSING; fi", shellQuote(remoteTmpPath), shellQuote(remoteTmpPath)),
 	); probeErr == nil {
-		b.logf("remote binary upload probe: target=%s tmp=%s result=%s", sshTarget, remoteTmpPath, strings.TrimSpace(probe))
+		b.logf("remote upload probe: target=%s tmp=%s result=%s", sshTarget, remoteTmpPath, strings.TrimSpace(probe))
 	}
 	_, err = runSSH(
 		ctx,
@@ -553,7 +753,7 @@ func (b *Bootstrapper) installRemoteBinary(ctx context.Context, sshTarget, profi
 		fmt.Sprintf(
 			"install -m 755 %s %s && rm -f %s",
 			shellQuote(remoteTmpPath),
-			shellQuote(remoteInstallPath),
+			shellQuote(remotePath),
 			shellQuote(remoteTmpPath),
 		),
 	)
@@ -670,7 +870,7 @@ printf 'stopped\n'
 	}
 }
 
-func (b *Bootstrapper) ensureRemoteDaemonRunning(ctx context.Context, sshTarget, profile string, binaryUpdated bool) error {
+func (b *Bootstrapper) ensureRemoteDaemonRunning(ctx context.Context, sshTarget, profile string, binariesUpdated bool) error {
 	state, err := b.probeRemoteDaemon(ctx, sshTarget, profile)
 	if err != nil {
 		return err
@@ -683,7 +883,7 @@ func (b *Bootstrapper) ensureRemoteDaemonRunning(ctx context.Context, sshTarget,
 		state = remoteDaemonState{}
 	}
 
-	if (state.Running || state.Starting) && binaryUpdated {
+	if (state.Running || state.Starting) && binariesUpdated {
 		if err := b.restartRemoteDaemon(ctx, sshTarget, profile, state.PID); err != nil {
 			return err
 		}

--- a/internal/hub/bootstrap_test.go
+++ b/internal/hub/bootstrap_test.go
@@ -216,3 +216,68 @@ func TestResolveRemoteInstallPath(t *testing.T) {
 		}
 	}
 }
+
+// The app runtime host lands beside the attn binary that starts it, because
+// that is the one place the remote daemon looks. A named profile gets its own
+// copy: several profile-isolated daemons share one ~/.local/bin, and one shared
+// file name would have the newest sync replace another profile's runtime.
+func TestRemoteAppRuntimePath(t *testing.T) {
+	cases := []struct {
+		remoteInstallPath string
+		profile           string
+		want              string
+	}{
+		{"/home/v/.local/bin/attn", "", "/home/v/.local/bin/attn-app-runtime"},
+		{"/home/v/.local/bin/attn-dev", "dev", "/home/v/.local/bin/attn-app-runtime-dev"},
+		{"/home/v/.attn/harness/run-1/bin/attn", "", "/home/v/.attn/harness/run-1/bin/attn-app-runtime"},
+	}
+	for _, c := range cases {
+		if got := remoteAppRuntimePath(c.remoteInstallPath, c.profile); got != c.want {
+			t.Errorf("remoteAppRuntimePath(%q, %q) = %q, want %q", c.remoteInstallPath, c.profile, got, c.want)
+		}
+	}
+}
+
+// Go and Bun name the same machine differently, and a target either toolchain
+// rejects is a cross-build that fails at the last step of a remote sync.
+func TestRemoteLinuxPlatformArtifacts(t *testing.T) {
+	cases := []struct {
+		machine   string
+		goarch    string
+		runtime   string
+		bunTarget string
+	}{
+		{"x86_64", "amd64", "attn-app-runtime-linux-amd64", "bun-linux-x64"},
+		{"amd64", "amd64", "attn-app-runtime-linux-amd64", "bun-linux-x64"},
+		{"aarch64", "arm64", "attn-app-runtime-linux-arm64", "bun-linux-arm64"},
+		{"arm64", "arm64", "attn-app-runtime-linux-arm64", "bun-linux-arm64"},
+	}
+	for _, c := range cases {
+		platform, err := remoteLinuxPlatform(c.machine)
+		if err != nil {
+			t.Fatalf("remoteLinuxPlatform(%q): %v", c.machine, err)
+		}
+		if platform.GOARCH != c.goarch || platform.RuntimeArtifactName != c.runtime || platform.BunTarget != c.bunTarget {
+			t.Errorf("remoteLinuxPlatform(%q) = %+v, want goarch %s runtime %s bun %s",
+				c.machine, platform, c.goarch, c.runtime, c.bunTarget)
+		}
+	}
+	if _, err := remoteLinuxPlatform("riscv64"); err == nil {
+		t.Fatal("an unsupported architecture was accepted")
+	}
+}
+
+// A file that is not there yet answers NOT_FOUND rather than failing the sync:
+// the first bootstrap of a remote has no copy of anything.
+func TestRemoteSHA256ScriptHandlesAMissingFile(t *testing.T) {
+	script := remoteSHA256Script(shellQuote("/home/v/.local/bin/attn-app-runtime"))
+	if !strings.Contains(script, "printf NOT_FOUND") {
+		t.Fatalf("hash script has no missing-file answer: %s", script)
+	}
+	if !strings.Contains(script, `sha256sum '/home/v/.local/bin/attn-app-runtime'`) {
+		t.Fatalf("hash script does not hash the path it was given: %s", script)
+	}
+	if !strings.Contains(script, "shasum -a 256") {
+		t.Fatalf("hash script has no shasum fallback: %s", script)
+	}
+}


### PR DESCRIPTION
A hub-managed remote endpoint received exactly one file — the `attn` binary —
so the daemon there had no app runtime host to start. Every app installed on
such a remote parked, and the facts those apps were due were recorded as
`runtime_error` rather than charged to the app. This was recorded as an open
item by A4's exit proof and ruled "fix" on 2026-08-11
(`docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md`).

## What changes

`internal/hub/bootstrap.go` now ships the app runtime host beside the binary.

- **Where it comes from.** Source checkout first (`scripts/build-app-runtime-host.sh`
  with the remote's bun target), published release artifact second — the same
  order, and for the same reason, as the `attn` binary beside it. The release
  workflow now publishes `attn-app-runtime-linux-{amd64,arm64}`, because a hub
  installed from a release has no source tree and could otherwise never give a
  Linux remote a runtime. The release-preflight job builds it too, so that step
  is not first exercised on release day.
- **When it is transferred.** Only when the content hash differs. The artifact
  is ~90MB (measured: 93,694,096 bytes for linux/arm64) and endpoints sync on a
  timer, so an unconditional push would move it across the network every pass.
  The check runs on every sync rather than only when the binary moved: the two
  are built from different trees, and an `apphost/`-only change leaves the
  `attn` binary byte-identical.
- **Coherence.** A changed host restarts the remote daemon, the same way a
  changed binary does — `install` unlinks before writing, so the running sidecar
  keeps its old inode until something restarts it, and the daemon is what starts
  it.
- **Naming.** The host lands as `attn-app-runtime-<profile>` for a named
  profile. Profile-isolated daemons share one `~/.local/bin` (that is why
  `remoteBinaryName` exists at all), and one shared file name would have the
  newest sync replace another profile's runtime with a different build. The
  daemon looks for the profile-suffixed name first and the bare name second, so
  a checkout and a `.app` bundle resolve exactly as before.
- **The way out.** A remote that cannot be given a host still runs sessions —
  the sync reports and continues — and the report names the host, the path, the
  platform artifact, every reason it failed, and what would produce one.

`attn-app-runtime` now has one definition (`apps.RuntimeHostBinaryName`), with a
test pinning the build script to it: three places need that string and none of
them can see the others.

## Local caching

A source build overwrites one file per platform under
`~/.attn/remotes/app-runtime/<goos>_<goarch>/` rather than accumulating a copy
per hub build. The sidecar is built from `apphost/`, which no version or
daemon-binary fingerprint covers, so any such key would serve a stale runtime
after an apphost-only edit — and at ~90MB a key per build is also a disk leak.
The compile is 0.4s measured (bun embeds its runtime rather than compiling it),
so rebuilding on every sync costs nothing. A downloaded release artifact is
immutable and does cache per version.

## Live verification

Throwaway profile `hubrt` installed from this branch (macOS hub) against the
OrbStack VM `attn-remote@orb` (linux/arm64), whose `~/.local/bin` was empty at
the start.

**1. Fresh provision ships both files.**

```
remote upload probe: target=attn-remote@orb tmp=/tmp/attn-hubrt.…tmp result=61522304
remote upload probe: target=attn-remote@orb tmp=/tmp/attn-app-runtime-hubrt.…tmp result=93694096
installed the app runtime host on attn-remote@orb at /home/victor/.local/bin/attn-app-runtime-hubrt (3cafc0dc738a)
```

The endpoint reached `connected`; the VM's `~/.local/bin` held `attn-hubrt` and
`attn-app-runtime-hubrt`, and the remote copy's sha256 matched the local one.

**2. The remote daemon dispatches a real app invocation.** An app scaffolded
and applied on the VM (`attn app new` / `attn app apply`, subscribing to
`document.changed`), then a document written through the CLI on the VM:

```
$ attn-hubrt app runtime status
  state:    connected (connected, pid 2021747), generation 1
  binary:   /home/victor/.local/bin/attn-app-runtime-hubrt

$ attn-hubrt app status greeter
    STARTED               VERSION  SEQ  EVENT             HANDLER           STATUS  MS   ERROR
    2026-08-11T21:42:36Z  1        4    document.changed  document.changed  ok      109

$ attn-hubrt app logs greeter
greeter saw document.changed for user/demo/notes/n1 at seq 4
```

The daemon resolved the profile-suffixed name on its own, with no override.

**3. A sync with nothing to move moves nothing.** Re-bootstrapping with both
hashes matching finished in 1.5s with no upload probe and no "installed" line,
and the remote runtime kept the same pid and generation — no daemon restart, no
runtime churn.

**4. A replaced host is re-shipped and picked up.** Deleting the remote copy and
re-syncing re-uploaded it (~2s) and restarted the remote daemon; the next fact
dispatched against the fresh host (`seq 11 … ok 37ms`).

**5. Binary changed, host unchanged.** After `make install-daemon PROFILE=hubrt`
(new `SourceFingerprint`), the endpoint parked in `binary_mismatch` as expected;
the sync re-uploaded the 61MB `attn` binary and skipped the 93MB host on its
hash, and dispatch survived the daemon restart (`seq 19 … ok 125ms`).

**6. The missing-host path, witnessed.** Simulating a hub without bun (the
build script's own guard) while the release carries no such asset yet:

```
the app runtime host is missing from attn-remote@orb at /home/victor/.local/bin/attn-app-runtime-hubrt:
no attn-app-runtime-linux-arm64 available (source build: bun is not on PATH; the app runtime host is a
bun --compile binary; release download: gh release download v0.11.1: no assets match the file pattern).
Apps on that daemon park until it is there; run the hub from a source checkout with bun installed, or
copy attn-app-runtime-linux-arm64 there yourself
```

The endpoint stayed connected through it. (One wording fix was made after this
capture — `copy a attn-…` → `copy attn-…`; the rest of the message is verbatim.)

No recording: nothing in this change is visible in the app window — the surface
is the bootstrap, the remote filesystem and the CLI.

## Surfaces walked

- **CLI:** unchanged. `attn app runtime status` on the remote reports the
  resolved path, which is how the new layout is inspected.
- **Daemon and app:** endpoint sync path only; no protocol change, no migration,
  no new wire traffic.
- **Protocol:** untouched (`generated.go`/`generated.ts` unchanged,
  `ProtocolVersion` unchanged).
- **Linux:** this is the Linux path; verified on the arm64 VM. The amd64 leg
  differs only in the artifact and bun target, both pinned by a unit test.
- **Plugins and SDK:** unaffected.
- **Docs:** A4 plan's ruling records what shipped; changelog fragment added.

Applying an app *on* a remote still needs bun on that machine (`attn app apply`
builds CLI-side, by design) — running one does not, which is what this PR
fixes.

https://claude.ai/code/session_01HoRmmmiehworTbJph5spNR
