### PR TITLE
fix(apps): keep a parked app runtime parked across daemon restarts

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -230,7 +230,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '230';
+export const PROTOCOL_VERSION = '231';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 // Identifies this app process to the daemon across its own reconnects, so a

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -846,6 +846,7 @@ export interface AppRuntimeInfo {
     generation:       number;
     last_exit?:       string;
     next_restart_at?: string;
+    parked_at?:       string;
     phase:            string;
     pid?:             number;
     restart_attempt:  number;
@@ -876,6 +877,7 @@ export interface Runtime {
     generation:       number;
     last_exit?:       string;
     next_restart_at?: string;
+    parked_at?:       string;
     phase:            string;
     pid?:             number;
     restart_attempt:  number;
@@ -11788,6 +11790,7 @@ const typeMap: any = {
         { json: "generation", js: "generation", typ: 0 },
         { json: "last_exit", js: "last_exit", typ: u(undefined, "") },
         { json: "next_restart_at", js: "next_restart_at", typ: u(undefined, "") },
+        { json: "parked_at", js: "parked_at", typ: u(undefined, "") },
         { json: "phase", js: "phase", typ: "" },
         { json: "pid", js: "pid", typ: u(undefined, 0) },
         { json: "restart_attempt", js: "restart_attempt", typ: 0 },
@@ -11808,6 +11811,7 @@ const typeMap: any = {
         { json: "generation", js: "generation", typ: 0 },
         { json: "last_exit", js: "last_exit", typ: u(undefined, "") },
         { json: "next_restart_at", js: "next_restart_at", typ: u(undefined, "") },
+        { json: "parked_at", js: "parked_at", typ: u(undefined, "") },
         { json: "phase", js: "phase", typ: "" },
         { json: "pid", js: "pid", typ: u(undefined, 0) },
         { json: "restart_attempt", js: "restart_attempt", typ: 0 },

--- a/changelog.d/app-runtime-park-survives-restart.yaml
+++ b/changelog.d/app-runtime-park-survives-restart.yaml
@@ -1,0 +1,17 @@
+kind: fixed
+area: daemon
+change: >
+  A shared app runtime attn has given up on now stays given up on across a
+  daemon restart. Every installed app's handlers run in one background process,
+  and when that process crash-loops attn stops restarting it, says so once, and
+  waits for `attn app runtime restart`. That decision used to live only in
+  memory, so the next daemon start — an upgrade, a crash, a reboot — began the
+  whole crash loop again, spent another few minutes on it, and raised a second
+  critical alert about an outage the user had already been told about. The
+  decision is now written down and read back before anything can start the
+  runtime, `attn app runtime status` reports how long it has been parked rather
+  than restarting the clock, and the restart command clears the record along
+  with the park.
+symptom: >
+  After a broken app runtime was reported as stopped, restarting attn started
+  it crashing again and produced a second "Apps stopped running" alert.

--- a/cmd/attn/app_runtime.go
+++ b/cmd/attn/app_runtime.go
@@ -160,6 +160,11 @@ func writeAppRuntimeInfo(info protocol.AppRuntimeInfo) {
 	fmt.Printf("  state:    %s (%s), generation %d\n", info.Phase, connected, info.Generation)
 	if info.Phase == "parked" {
 		fmt.Printf("            attn gave up restarting it after %d attempts; no app's handlers are running.\n", info.RestartAttempt)
+		if info.ParkedAt != nil {
+			// The park outlives the daemon that made it, so this is not "a moment
+			// ago" — it is how long apps have actually been dead.
+			fmt.Printf("            parked since %s.\n", *info.ParkedAt)
+		}
 		fmt.Printf("            `attn app runtime restart` tries again.\n")
 	} else if info.RestartAttempt > 0 {
 		fmt.Printf("            restart attempt %d\n", info.RestartAttempt)

--- a/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
+++ b/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
@@ -471,7 +471,18 @@ dispatch uses `EnsureUnlessParked` and answers a runtime failure naming the way
 back. Re-verified: one parking, then eight minutes of traffic with the
 generation unchanged and no second notification.
 
-**Four things observed and deliberately not changed**, each a decision rather
+**A second defect, found and fixed after A4 landed.** The park lived only in
+the supervisor's memory, so a daemon restart — an upgrade, a crash, a reboot —
+forgot it, lazy-started the still-broken host on the first due fact, re-armed
+the whole crash loop, and raised a second critical notification for one outage.
+The give-up is now a `supervised_parks` row (migration 103) written when it
+happens and handed back to the supervisor by `supervise.AdoptParked` inside
+`ensureAppRuntimeSupervisor`, so every way to reach the supervisor finds the
+park already applied. `attn app runtime restart` deletes the row along with the
+park; nothing else does, and a runtime binary that changed since the park stays
+parked until someone asks for it.
+
+**Three things observed and deliberately not changed**, each a decision rather
 than a defect:
 
 - A hub-managed remote endpoint never gets a sidecar.
@@ -490,10 +501,6 @@ than a defect:
   fault — so nothing disables it and its consumer holds the retention floor for
   as long as the outage lasts. Whether a parked runtime should start a clock of
   its own is the open question A4 leaves; the roadmap gate did not ask for one.
-- A restarted daemon forgets the park: a fresh supervisor has no memory of it,
-  so the first dispatch lazy-starts a still-broken host and the crash loop
-  re-arms. Correct for a deliberate act, worth knowing as a way back that is
-  not the restart verb.
 
 ### Rulings on the four (2026-08-11)
 

--- a/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
+++ b/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
@@ -475,7 +475,7 @@ generation unchanged and no second notification.
 the supervisor's memory, so a daemon restart — an upgrade, a crash, a reboot —
 forgot it, lazy-started the still-broken host on the first due fact, re-armed
 the whole crash loop, and raised a second critical notification for one outage.
-The give-up is now a `supervised_parks` row (migration 103) written when it
+The give-up is now a `supervised_parks` row (migration 104) written when it
 happens and handed back to the supervisor by `supervise.AdoptParked` inside
 `ensureAppRuntimeSupervisor`, so every way to reach the supervisor finds the
 park already applied. `attn app runtime restart` deletes the row along with the

--- a/internal/daemon/app_runtime.go
+++ b/internal/daemon/app_runtime.go
@@ -150,11 +150,68 @@ func (d *Daemon) ensureAppRuntimeSupervisor() *supervise.Supervisor {
 		options.OnChange = func(string) {
 			d.publishFact(FactAppRuntimeChanged, appRuntimeChildName, nil)
 		}
-		options.OnGiveUp = d.notifyAppRuntimeParked
+		options.OnGiveUp = d.recordAppRuntimeParked
 		options.Logf = d.logf
 		d.appRuntimeSupervisor = supervise.New(options)
+		d.adoptPersistedParkLocked(d.appRuntimeSupervisor)
 	}
 	return d.appRuntimeSupervisor
+}
+
+// adoptPersistedParkLocked hands a previous daemon's give-up to the supervisor
+// being built, so it opens already parked.
+//
+// It lives here, in the constructor, rather than in a startup step: every way to
+// reach the supervisor — a dispatch, `attn app runtime status`, the restart verb,
+// the sidecar saying hello — goes through ensureAppRuntimeSupervisor, so no
+// caller can outrun the restore and spawn a host attn has already given up on.
+// A startup step would leave that ordering to be maintained by hand.
+func (d *Daemon) adoptPersistedParkLocked(supervisor *supervise.Supervisor) {
+	if d.store == nil {
+		return
+	}
+	park, ok, err := d.store.GetSupervisedPark(appRuntimeChildName)
+	if err != nil {
+		d.logf("apps: reading the persisted app-runtime park: %v", err)
+		return
+	}
+	if !ok {
+		return
+	}
+	exit := &supervise.Exit{
+		At:       park.ExitAt,
+		ExitCode: park.ExitCode,
+		Signal:   park.ExitSignal,
+		Error:    park.ExitError,
+	}
+	if err := supervisor.AdoptParked(appRuntimeChildName, supervise.Park{
+		ParkedAt:       park.ParkedAt,
+		RestartAttempt: park.RestartAttempt,
+		LastExit:       exit,
+	}); err != nil {
+		d.logf("apps: restoring the app runtime's park: %v", err)
+		return
+	}
+	d.logf("app runtime is still parked from %s (%d restarts, last exit: %s); `attn app runtime restart` tries again",
+		park.ParkedAt.Format(time.RFC3339), park.RestartAttempt, exit.String())
+}
+
+// restoreAppRuntimePark builds the supervisor at daemon start when — and only
+// when — a previous daemon left a park behind, so `attn app runtime status`
+// answers "parked" from the first moment rather than from whatever later call
+// happens to build one.
+//
+// Building it unconditionally would be wrong: a daemon that has never run an app
+// would then report a stopped runtime instead of never having started one, and
+// that difference is the whole of "is something broken here".
+func (d *Daemon) restoreAppRuntimePark() {
+	if d.store == nil {
+		return
+	}
+	if _, ok, err := d.store.GetSupervisedPark(appRuntimeChildName); err != nil || !ok {
+		return
+	}
+	d.ensureAppRuntimeSupervisor()
 }
 
 // ensureAppRuntime starts the sidecar, or adopts it if it is already running.
@@ -201,10 +258,32 @@ func (d *Daemon) startAppRuntime(revive bool) error {
 		return process, nil
 	}
 	supervisor := d.ensureAppRuntimeSupervisor()
-	if revive {
-		return supervisor.Ensure(appRuntimeChildName, start)
+	if !revive {
+		return supervisor.EnsureUnlessParked(appRuntimeChildName, start)
 	}
-	return supervisor.EnsureUnlessParked(appRuntimeChildName, start)
+	err = supervisor.Ensure(appRuntimeChildName, start)
+	// The supervisor has left parked whether or not the launch succeeded — a
+	// failed start goes to backoff, not back to parked — so the durable record of
+	// the park goes with it. Keeping it would re-park the runtime on the next
+	// daemon start, which is the way out being a door that opens once.
+	d.forgetAppRuntimePark()
+	return err
+}
+
+// forgetAppRuntimePark deletes the persisted park. Reviving is deliberate and
+// rare, so it logs when it actually erased something.
+func (d *Daemon) forgetAppRuntimePark() {
+	if d.store == nil {
+		return
+	}
+	cleared, err := d.store.ClearSupervisedPark(appRuntimeChildName)
+	if err != nil {
+		d.logf("apps: clearing the persisted app-runtime park: %v", err)
+		return
+	}
+	if cleared {
+		d.logf("app runtime revived; it will start again on the next daemon start too")
+	}
 }
 
 // appRuntimeEnv is what the sidecar is launched with. It is the plugin
@@ -246,10 +325,15 @@ func (d *Daemon) appRuntimeSnapshot() (supervise.Snapshot, bool) {
 // sidecar crash-looped past the give-up tripwire.
 const notificationKindAppRuntimeParked = "app_runtime_parked"
 
-// notifyAppRuntimeParked is the supervisor's OnGiveUp sink. Unlike a parked
-// plugin, a parked app runtime has a way back — `attn app runtime restart` — so
-// the copy names it.
-func (d *Daemon) notifyAppRuntimeParked(_ string, snapshot supervise.Snapshot) {
+// recordAppRuntimeParked is the supervisor's OnGiveUp sink: it makes the park
+// durable and then tells the user about it. Unlike a parked plugin, a parked app
+// runtime has a way back — `attn app runtime restart` — so the copy names it.
+//
+// Persisting comes first. A daemon that dies between the two writes should come
+// back parked and silent rather than running and about to crash-loop: the
+// notification says the runtime is not being restarted, and the durable park is
+// what makes that true past this process.
+func (d *Daemon) recordAppRuntimeParked(_ string, snapshot supervise.Snapshot) {
 	detail := ""
 	if snapshot.LastExit != nil {
 		detail = snapshot.LastExit.String()
@@ -258,6 +342,7 @@ func (d *Daemon) notifyAppRuntimeParked(_ string, snapshot supervise.Snapshot) {
 	if d.store == nil {
 		return
 	}
+	d.persistAppRuntimePark(snapshot)
 	record, err := d.store.AddNotification(store.NotificationRecord{
 		Kind:     notificationKindAppRuntimeParked,
 		Severity: store.NotificationCritical,
@@ -274,6 +359,32 @@ func (d *Daemon) notifyAppRuntimeParked(_ string, snapshot supervise.Snapshot) {
 		return
 	}
 	d.publishFact(FactNotificationCreated, record.ID, nil)
+}
+
+// persistAppRuntimePark writes the park so the next daemon inherits it.
+//
+// A park that lived only in memory was the bug: daemon restarts are ordinary
+// (an upgrade, a crash, a reboot), and each one lazy-started the same broken
+// host, spent the whole backoff schedule on it again, and raised a second
+// critical notification for one outage the user had already been told about.
+func (d *Daemon) persistAppRuntimePark(snapshot supervise.Snapshot) {
+	park := store.SupervisedPark{
+		Child:          appRuntimeChildName,
+		ParkedAt:       snapshot.ParkedAt,
+		RestartAttempt: snapshot.RestartAttempt,
+	}
+	if park.ParkedAt.IsZero() {
+		park.ParkedAt = d.appNow()
+	}
+	if snapshot.LastExit != nil {
+		park.ExitAt = snapshot.LastExit.At
+		park.ExitCode = snapshot.LastExit.ExitCode
+		park.ExitSignal = snapshot.LastExit.Signal
+		park.ExitError = snapshot.LastExit.Error
+	}
+	if err := d.store.SaveSupervisedPark(park); err != nil {
+		d.logf("apps: persisting the app-runtime park: %v", err)
+	}
 }
 
 // appNow is the daemon's clock for everything app-runtime — the stall clock most

--- a/internal/daemon/app_runtime_ipc.go
+++ b/internal/daemon/app_runtime_ipc.go
@@ -197,6 +197,9 @@ func (d *Daemon) appRuntimeInfo(snapshot supervise.Snapshot) protocol.AppRuntime
 	if !snapshot.NextRestartAt.IsZero() {
 		info.NextRestartAt = protocol.Ptr(stampForWire(snapshot.NextRestartAt))
 	}
+	if !snapshot.ParkedAt.IsZero() {
+		info.ParkedAt = protocol.Ptr(stampForWire(snapshot.ParkedAt))
+	}
 	if snapshot.LastExit != nil {
 		info.LastExit = protocol.Ptr(snapshot.LastExit.String())
 	}

--- a/internal/daemon/app_runtime_park_test.go
+++ b/internal/daemon/app_runtime_park_test.go
@@ -1,0 +1,238 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/store"
+	"github.com/victorarias/attn/internal/supervise"
+)
+
+// A park has to survive the daemon that made it.
+//
+// Restarts are ordinary — an upgrade, a crash, a reboot — and while the park
+// lived only in the supervisor's memory each one lazy-started the same broken
+// host, spent the whole backoff schedule on it again, and raised a second
+// critical notification for one outage the user had already been told about.
+func TestParkedRuntimeSurvivesADaemonRestart(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "attn.db")
+	launches := filepath.Join(t.TempDir(), "launches")
+	t.Setenv(appRuntimeHostOverride, countingHostStub(t, launches))
+
+	first := newAppDaemonOn(t, dbPath)
+	first.appRuntimeSupervise = supervise.Options{GiveUpAfter: 1}
+	installApp(t, first, "greeter", subscribing("ticket.*"))
+	if err := first.ensureAppRuntime(); err != nil {
+		t.Fatalf("ensure runtime: %v", err)
+	}
+	waitFor(t, "the crash-looping runtime to be parked", func() bool {
+		snapshot, ok := first.appRuntimeSnapshot()
+		return ok && snapshot.Phase == supervise.PhaseParked
+	})
+	parked, _ := first.appRuntimeSnapshot()
+	if parked.ParkedAt.IsZero() {
+		t.Fatal("a parked runtime carries no park time")
+	}
+	launchesBefore := launchCount(t, launches)
+
+	// The daemon goes away — an upgrade, a crash, a reboot. Its database does not.
+	first.stopAppRuntime()
+	stopAppDaemon(t, first)
+
+	second := newAppDaemonOn(t, dbPath)
+	second.appRuntimeSupervise = supervise.Options{GiveUpAfter: 1}
+	t.Cleanup(second.stopAppRuntime)
+	second.restoreAppRuntimePark()
+
+	status := appRuntimeStatus(t, second)
+	if status.Runtime == nil {
+		t.Fatal("the restarted daemon reports no runtime at all, so nothing tells a reader why apps are dead")
+	}
+	if status.Runtime.Phase != string(supervise.PhaseParked) {
+		t.Fatalf("phase after restart = %q, want parked", status.Runtime.Phase)
+	}
+	if status.Runtime.ParkedAt == nil {
+		t.Fatal("the restored park carries no timestamp")
+	}
+	if got, want := *status.Runtime.ParkedAt, stampForWire(parked.ParkedAt); got != want {
+		t.Fatalf("parked_at = %q after restart, want the original %q", got, want)
+	}
+	if status.Runtime.RestartAttempt != parked.RestartAttempt {
+		t.Fatalf("restart_attempt = %d after restart, want the original %d",
+			status.Runtime.RestartAttempt, parked.RestartAttempt)
+	}
+	if status.Runtime.LastExit == nil || !strings.Contains(*status.Runtime.LastExit, "3") {
+		t.Fatalf("last_exit after restart = %v, want the recorded exit code 3", status.Runtime.LastExit)
+	}
+
+	// The point of all of it: the broken host is never launched again.
+	if got := launchCount(t, launches); got != launchesBefore {
+		t.Fatalf("the restarted daemon launched the host %d more time(s); a restored park must spawn nothing",
+			got-launchesBefore)
+	}
+	// One outage, one critical notification. A second one for the same park is
+	// the surface that cannot be ignored repeating itself.
+	if notes := appNotifications(t, second, notificationKindAppRuntimeParked); len(notes) != 1 {
+		t.Fatalf("app-runtime-parked notifications after a restart = %d, want the original 1", len(notes))
+	}
+}
+
+// The restore has to be in place before anything can lazy-start the runtime. A
+// dispatch is the caller that would: it arrives on the first fact an app is due,
+// which on a fresh daemon is immediately.
+func TestRestoredParkIsInPlaceBeforeTheFirstDispatch(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "attn.db")
+	launches := filepath.Join(t.TempDir(), "launches")
+	t.Setenv(appRuntimeHostOverride, countingHostStub(t, launches))
+
+	seedParkedRuntime(t, dbPath, 10)
+
+	d := newAppDaemonOn(t, dbPath)
+	d.appRuntimeSupervise = supervise.Options{GiveUpAfter: 1}
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+	t.Cleanup(d.stopAppRuntime)
+
+	// No restoreAppRuntimePark call: the dispatch path builds the supervisor
+	// itself, and it must find the park already applied. This is the race the
+	// persisted park exists to close, so it is asserted rather than commented.
+	err := d.deliverAppEvent(context.Background(), "greeter", appEvent("ticket.created", "tk-1", 1))
+	if !isRuntimeFailure(err) {
+		t.Fatalf("dispatch into a restored park returned %v, want a runtime failure", err)
+	}
+	if !strings.Contains(err.Error(), "parked") || !strings.Contains(err.Error(), "attn app runtime restart") {
+		t.Fatalf("the dispatch error does not say what happened or how to fix it: %q", err)
+	}
+	if got := launchCount(t, launches); got != 0 {
+		t.Fatalf("a dispatch launched the host %d time(s) despite the persisted park", got)
+	}
+	snapshot, ok := d.appRuntimeSnapshot()
+	if !ok || snapshot.Phase != supervise.PhaseParked {
+		t.Fatalf("snapshot after a dispatch = %+v, want parked", snapshot)
+	}
+	// Not the app's fault, so it must not be on the auto-disable clock.
+	rows := invocationsOf(t, d, "greeter")
+	if len(rows) != 1 || rows[0].Status != appInvocationStatusRuntimeError {
+		t.Fatalf("invocations = %+v, want one runtime_error", rows)
+	}
+	if _, stalled := d.appStallSnapshot("greeter"); stalled {
+		t.Fatal("the app is on the auto-disable clock for the runtime being parked")
+	}
+}
+
+// The way out has to erase the way in. A restart that revived the runtime but
+// left the row behind would re-park it on the next daemon start — the door back
+// from parked opening exactly once.
+func TestRestartClearsThePersistedPark(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "attn.db")
+	seedParkedRuntime(t, dbPath, 10)
+	t.Setenv(appRuntimeHostOverride, writeExecutableStub(t, "sleep 60"))
+
+	d := newAppDaemonOn(t, dbPath)
+	t.Cleanup(d.stopAppRuntime)
+	d.restoreAppRuntimePark()
+
+	revived := appRuntimeRestart(t, d)
+	if revived.Was != string(supervise.PhaseParked) {
+		t.Fatalf("was = %q, want parked", revived.Was)
+	}
+	if revived.Runtime.Phase == string(supervise.PhaseParked) || revived.Runtime.ParkedAt != nil {
+		t.Fatalf("restart left the runtime parked: %+v", revived.Runtime)
+	}
+	if _, ok, err := d.store.GetSupervisedPark(appRuntimeChildName); err != nil || ok {
+		t.Fatalf("the persisted park outlived the restart: ok=%v err=%v", ok, err)
+	}
+}
+
+// A daemon that has never run an app must still say so. Reading the park back is
+// not a reason to build a supervisor, and "not started" is a different answer
+// from "stopped" — the second sends a reader looking for a fault.
+func TestRestoreLeavesAnUnparkedDaemonUntouched(t *testing.T) {
+	d := newAppDaemonOn(t, filepath.Join(t.TempDir(), "attn.db"))
+	installApp(t, d, "greeter", subscribing("ticket.*"))
+	t.Setenv(appRuntimeHostOverride, writeExecutableStub(t, "sleep 60"))
+
+	d.restoreAppRuntimePark()
+
+	if status := appRuntimeStatus(t, d); status.Runtime != nil {
+		t.Fatalf("a daemon with no persisted park reported a runtime: %+v", status.Runtime)
+	}
+}
+
+// ---------------------------------------------------------------------------
+
+// newAppDaemonOn is newAppDaemon against a database the test owns, so one test
+// can park a runtime, drop the daemon, and bring a second one up over the same
+// state — which is all a daemon restart is.
+func newAppDaemonOn(t *testing.T, dbPath string) *Daemon {
+	t.Helper()
+	persistent, err := store.NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("open %s: %v", dbPath, err)
+	}
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	// The bus is built around the store it was constructed with, so the two move
+	// together or the daemon publishes into a database nobody reads.
+	d.stopEventBus()
+	_ = d.store.Close()
+	d.store = persistent
+	d.eventBus = nil
+	d.ensureEventBus()
+	if err := d.eventBus.Start(); err != nil {
+		t.Fatalf("start the event bus: %v", err)
+	}
+	t.Cleanup(func() { stopAppDaemon(t, d) })
+	return d
+}
+
+// stopAppDaemon takes a daemon down the way a process exit does, database and
+// all. Idempotent, so a test may end one early and still have its cleanup run.
+func stopAppDaemon(t *testing.T, d *Daemon) {
+	t.Helper()
+	d.stopEventBus()
+	_ = d.store.Close()
+}
+
+// seedParkedRuntime writes the row a previous daemon's give-up would have left.
+func seedParkedRuntime(t *testing.T, dbPath string, attempts int) time.Time {
+	t.Helper()
+	s, err := store.NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("open %s: %v", dbPath, err)
+	}
+	defer func() { _ = s.Close() }()
+	parkedAt := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Millisecond)
+	code := 3
+	if err := s.SaveSupervisedPark(store.SupervisedPark{
+		Child:          appRuntimeChildName,
+		ParkedAt:       parkedAt,
+		RestartAttempt: attempts,
+		ExitAt:         parkedAt,
+		ExitCode:       &code,
+	}); err != nil {
+		t.Fatalf("seed park: %v", err)
+	}
+	return parkedAt
+}
+
+// countingHostStub is a runtime host that records every launch and dies, so a
+// test can assert a spawn that must not happen rather than only its aftermath.
+func countingHostStub(t *testing.T, marks string) string {
+	t.Helper()
+	return writeExecutableStub(t, "echo started >> "+marks+"\nexit 3")
+}
+
+func launchCount(t *testing.T, marks string) int {
+	t.Helper()
+	data, err := os.ReadFile(marks)
+	if os.IsNotExist(err) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("read launch marks: %v", err)
+	}
+	return strings.Count(string(data), "started")
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1087,6 +1087,10 @@ func (d *Daemon) Start() error {
 	d.listener = listener
 	d.log("daemon started")
 	d.startInstalledPlugins()
+	// A give-up outlives the daemon that made it, and this is where it is read
+	// back — before the consumers that would otherwise lazy-start the runtime on
+	// their first due fact.
+	d.restoreAppRuntimePark()
 	// Apps get their consumers here, not their runtime: the sidecar starts on the
 	// first fact an app is actually due, so a user with installed-but-quiet apps
 	// pays nothing for them.

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "230"
+const ProtocolVersion = "231"
 
 // Error codes. A failed response may carry one beside its message text, naming
 // what a caller can do about it rather than leaving it to match English. Only

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -423,6 +423,9 @@ type AppRuntimeInfo struct {
 	// NextRestartAt corresponds to the JSON schema field "next_restart_at".
 	NextRestartAt *string `json:"next_restart_at,omitempty,omitzero"`
 
+	// ParkedAt corresponds to the JSON schema field "parked_at".
+	ParkedAt *string `json:"parked_at,omitempty,omitzero"`
+
 	// Phase corresponds to the JSON schema field "phase".
 	Phase string `json:"phase"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -4286,6 +4286,11 @@ model AppRuntimeInfo {
   "connected_at"?: string;
   // When the next restart fires, while backing off.
   "next_restart_at"?: string;
+  // When attn gave up restarting. Present only while parked, and it survives a
+  // daemon restart: a park has one timestamp for as long as it lasts, so a
+  // reader can tell a runtime that has been down since this morning from one
+  // that just crash-looped.
+  "parked_at"?: string;
   // How the last process ended, rendered. Absent when it has never exited.
   "last_exit"?: string;
 }

--- a/internal/store/apps_test.go
+++ b/internal/store/apps_test.go
@@ -357,13 +357,16 @@ func TestApps_MigrationCarriesRowsWithNoPredecessor(t *testing.T) {
 	s.Close()
 
 	// Rewind to the schema as it stood before 103, with the app rows still there.
+	// The recorded version is the maximum, so every later migration goes too —
+	// dropping 103's row alone would leave the version ahead of it and skip the
+	// migration under test. The later ones re-run, which they tolerate.
 	db, err := OpenDB(path)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
 	for _, stmt := range []string{
 		"ALTER TABLE apps DROP COLUMN previous_version_id",
-		"DELETE FROM schema_migrations WHERE version = 103",
+		"DELETE FROM schema_migrations WHERE version >= 103",
 	} {
 		if _, err := db.Exec(stmt); err != nil {
 			t.Fatalf("rewinding with %q: %v", stmt, err)

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1087,6 +1087,15 @@ CREATE INDEX IF NOT EXISTS idx_app_invocations_started ON app_invocations(starte
 	// pointer move, and bare rollback says so rather than guessing.
 	// Applied by applyMigration103, whose ALTER is column-guarded.
 	{103, "record the previously-serving version of each app", ``},
+	{104, "remember a parked supervised child across daemon restarts", `CREATE TABLE IF NOT EXISTS supervised_parks (
+    child           TEXT PRIMARY KEY,
+    parked_at       TEXT NOT NULL,
+    restart_attempt INTEGER NOT NULL DEFAULT 0,
+    exit_at         TEXT NOT NULL DEFAULT '',
+    exit_code       INTEGER,
+    exit_signal     TEXT NOT NULL DEFAULT '',
+    exit_error      TEXT NOT NULL DEFAULT ''
+);`},
 }
 
 // migration99SQL is everything migration 99 does after its guarded ALTER.

--- a/internal/store/supervised_parks.go
+++ b/internal/store/supervised_parks.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// Parked supervised children (migration 103).
+// Parked supervised children (migration 104).
 //
 // internal/supervise parks a child that keeps dying without ever running
 // stably: it stops restarting it, and only a deliberate act brings it back. That

--- a/internal/store/supervised_parks.go
+++ b/internal/store/supervised_parks.go
@@ -1,0 +1,129 @@
+package store
+
+import (
+	"database/sql"
+	"time"
+)
+
+// Parked supervised children (migration 103).
+//
+// internal/supervise parks a child that keeps dying without ever running
+// stably: it stops restarting it, and only a deliberate act brings it back. That
+// decision lives in the supervisor's memory, which ends with the daemon process
+// — so a restart used to forget it, spawn the still-broken child, and burn the
+// whole crash loop again before parking it a second time. This table is that
+// decision made durable.
+//
+// One row per supervised child name, written when the give-up happens and
+// deleted by whatever revives it. No row means no park: absence is the normal
+// state, not a missing record.
+//
+// The shared app runtime is the only writer today. A supervised plugin that
+// keeps dying is reinstalled rather than un-parked, so persisting its give-up
+// would be a record nothing reads; the table is keyed by child name so a second
+// consumer can join without a schema change, not because one is planned.
+
+// SupervisedPark is one child's parking, as it survives a restart. Everything
+// after Child mirrors what the supervisor's snapshot reports, so a restored park
+// answers `attn app runtime status` exactly as the original did — the park's own
+// timestamp most of all, which must not become the moment it was restored.
+type SupervisedPark struct {
+	Child          string
+	ParkedAt       time.Time
+	RestartAttempt int
+	ExitAt         time.Time
+	ExitCode       *int
+	ExitSignal     string
+	ExitError      string
+}
+
+// SaveSupervisedPark records a park, replacing any earlier one for that child.
+func (s *Store) SaveSupervisedPark(park SupervisedPark) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	exitAt := ""
+	if !park.ExitAt.IsZero() {
+		exitAt = park.ExitAt.UTC().Format(sortableTimeFormat)
+	}
+	var exitCode any
+	if park.ExitCode != nil {
+		exitCode = *park.ExitCode
+	}
+	_, err := s.db.Exec(`
+		INSERT INTO supervised_parks (child, parked_at, restart_attempt, exit_at, exit_code, exit_signal, exit_error)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(child) DO UPDATE SET
+			parked_at = excluded.parked_at,
+			restart_attempt = excluded.restart_attempt,
+			exit_at = excluded.exit_at,
+			exit_code = excluded.exit_code,
+			exit_signal = excluded.exit_signal,
+			exit_error = excluded.exit_error
+	`, park.Child, park.ParkedAt.UTC().Format(sortableTimeFormat), park.RestartAttempt,
+		exitAt, exitCode, park.ExitSignal, park.ExitError)
+	return err
+}
+
+// GetSupervisedPark loads one child's park. The false return is the ordinary
+// answer for a healthy child.
+func (s *Store) GetSupervisedPark(child string) (SupervisedPark, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return SupervisedPark{}, false, nil
+	}
+	var (
+		park     SupervisedPark
+		parkedAt string
+		exitAt   string
+		exitCode sql.NullInt64
+	)
+	err := s.db.QueryRow(`
+		SELECT child, parked_at, restart_attempt, exit_at, exit_code, exit_signal, exit_error
+		FROM supervised_parks WHERE child = ?
+	`, child).Scan(&park.Child, &parkedAt, &park.RestartAttempt, &exitAt, &exitCode,
+		&park.ExitSignal, &park.ExitError)
+	switch err {
+	case nil:
+	case sql.ErrNoRows:
+		return SupervisedPark{}, false, nil
+	default:
+		return SupervisedPark{}, false, err
+	}
+	park.ParkedAt = parseStoreTime(parkedAt)
+	if exitAt != "" {
+		park.ExitAt = parseStoreTime(exitAt)
+	}
+	if exitCode.Valid {
+		code := int(exitCode.Int64)
+		park.ExitCode = &code
+	}
+	return park, true, nil
+}
+
+// ClearSupervisedPark deletes a child's park and reports whether there was one.
+// Every way out of parked calls it: a park the supervisor has already left but
+// the database still remembers is the same bug this table exists to fix, only
+// pointing the other way.
+func (s *Store) ClearSupervisedPark(child string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return false, nil
+	}
+	result, err := s.db.Exec(`DELETE FROM supervised_parks WHERE child = ?`, child)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}

--- a/internal/store/supervised_parks_test.go
+++ b/internal/store/supervised_parks_test.go
@@ -1,0 +1,113 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSupervisedParkSurvivesReopeningTheDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "attn.db")
+	s, err := NewWithDB(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	parkedAt := time.Date(2026, 8, 11, 9, 30, 0, 0, time.UTC)
+	code := 3
+	park := SupervisedPark{
+		Child:          "runtime",
+		ParkedAt:       parkedAt,
+		RestartAttempt: 10,
+		ExitAt:         parkedAt.Add(-time.Second),
+		ExitCode:       &code,
+		ExitError:      "the host died on startup",
+	}
+	if err := s.SaveSupervisedPark(park); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reopened, err := NewWithDB(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+
+	got, ok, err := reopened.GetSupervisedPark("runtime")
+	if err != nil || !ok {
+		t.Fatalf("get after reopen: ok=%v err=%v", ok, err)
+	}
+	if !got.ParkedAt.Equal(parkedAt) {
+		t.Fatalf("ParkedAt=%s, want %s", got.ParkedAt, parkedAt)
+	}
+	if got.RestartAttempt != 10 {
+		t.Fatalf("RestartAttempt=%d, want 10", got.RestartAttempt)
+	}
+	if !got.ExitAt.Equal(park.ExitAt) {
+		t.Fatalf("ExitAt=%s, want %s", got.ExitAt, park.ExitAt)
+	}
+	if got.ExitCode == nil || *got.ExitCode != 3 {
+		t.Fatalf("ExitCode=%v, want 3", got.ExitCode)
+	}
+	if got.ExitError != park.ExitError {
+		t.Fatalf("ExitError=%q, want %q", got.ExitError, park.ExitError)
+	}
+}
+
+// A child that never exited has no code to record, and one that was never parked
+// has no row. Both are ordinary answers, not missing data.
+func TestSupervisedParkHandlesAbsenceAndClearing(t *testing.T) {
+	s, err := NewWithDB(filepath.Join(t.TempDir(), "attn.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	if _, ok, err := s.GetSupervisedPark("runtime"); ok || err != nil {
+		t.Fatalf("get before any park: ok=%v err=%v", ok, err)
+	}
+	if cleared, err := s.ClearSupervisedPark("runtime"); cleared || err != nil {
+		t.Fatalf("clear before any park: cleared=%v err=%v", cleared, err)
+	}
+
+	if err := s.SaveSupervisedPark(SupervisedPark{
+		Child:      "runtime",
+		ParkedAt:   time.Now().UTC(),
+		ExitSignal: "killed",
+	}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, ok, err := s.GetSupervisedPark("runtime")
+	if err != nil || !ok {
+		t.Fatalf("get: ok=%v err=%v", ok, err)
+	}
+	if got.ExitCode != nil {
+		t.Fatalf("ExitCode=%v for a signalled exit, want nil", got.ExitCode)
+	}
+	if got.ExitSignal != "killed" || !got.ExitAt.IsZero() {
+		t.Fatalf("got=%+v, want signal killed and no exit time", got)
+	}
+
+	// A second park replaces the first rather than colliding on the primary key.
+	later := time.Now().UTC().Add(time.Hour)
+	if err := s.SaveSupervisedPark(SupervisedPark{Child: "runtime", ParkedAt: later, RestartAttempt: 4}); err != nil {
+		t.Fatalf("re-save: %v", err)
+	}
+	replaced, _, err := s.GetSupervisedPark("runtime")
+	if err != nil {
+		t.Fatalf("get after re-save: %v", err)
+	}
+	if replaced.RestartAttempt != 4 || replaced.ExitSignal != "" {
+		t.Fatalf("got=%+v, want the newer park to have replaced the older one whole", replaced)
+	}
+
+	if cleared, err := s.ClearSupervisedPark("runtime"); !cleared || err != nil {
+		t.Fatalf("clear: cleared=%v err=%v", cleared, err)
+	}
+	if _, ok, _ := s.GetSupervisedPark("runtime"); ok {
+		t.Fatal("the park is still there after clearing it")
+	}
+}

--- a/internal/supervise/park_test.go
+++ b/internal/supervise/park_test.go
@@ -1,0 +1,142 @@
+package supervise
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// A park has one timestamp for as long as it lasts, and it is the moment the
+// supervisor gave up — not the moment of the exit that pushed it over, and not
+// the moment anything asked about it afterwards.
+func TestParkingStampsWhenItHappened(t *testing.T) {
+	clock := newFakeClock()
+	launcher := &fakeLauncher{}
+	supervisor := New(Options{Clock: clock, GiveUpAfter: 1})
+	_ = supervisor.Ensure("fixture", launcher.start)
+
+	launcher.handle(0).exit(Exit{Error: "boom"})
+	waitFor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.Phase == PhaseBackoff
+	})
+	clock.Advance(RestartBackoff[0])
+	waitFor(t, func() bool { return launcher.count() == 2 })
+	launcher.handle(1).exit(Exit{Error: "boom"})
+	waitFor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.Phase == PhaseParked
+	})
+
+	parked, _ := supervisor.Snapshot("fixture")
+	if !parked.ParkedAt.Equal(clock.Now()) {
+		t.Fatalf("ParkedAt=%s, want the give-up moment %s", parked.ParkedAt, clock.Now())
+	}
+	clock.Advance(time.Hour)
+	if later, _ := supervisor.Snapshot("fixture"); !later.ParkedAt.Equal(parked.ParkedAt) {
+		t.Fatalf("ParkedAt moved %s → %s while nothing happened", parked.ParkedAt, later.ParkedAt)
+	}
+
+	// Leaving parked clears it: a running child has no park to be timestamped.
+	if err := supervisor.Ensure("fixture", launcher.start); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if revived, _ := supervisor.Snapshot("fixture"); !revived.ParkedAt.IsZero() {
+		t.Fatalf("ParkedAt=%s after revival, want zero", revived.ParkedAt)
+	}
+}
+
+// AdoptParked is how a consumer that persisted a give-up hands it back. The
+// restored child must be exactly where the give-up left it — including never
+// having been launched by this supervisor.
+func TestAdoptParkedRestoresWithoutLaunching(t *testing.T) {
+	clock := newFakeClock()
+	launcher := &fakeLauncher{}
+	supervisor := New(Options{Clock: clock, GiveUpAfter: 10})
+
+	parkedAt := clock.Now().Add(-3 * time.Hour)
+	park := Park{
+		ParkedAt:       parkedAt,
+		RestartAttempt: 10,
+		LastExit:       &Exit{At: parkedAt, ExitCode: intPtr(1)},
+	}
+	if err := supervisor.AdoptParked("fixture", park); err != nil {
+		t.Fatalf("AdoptParked: %v", err)
+	}
+
+	snapshot, ok := supervisor.Snapshot("fixture")
+	if !ok {
+		t.Fatal("the adopted child is not supervised")
+	}
+	if snapshot.Phase != PhaseParked || snapshot.Running || !snapshot.NextRestartAt.IsZero() {
+		t.Fatalf("snapshot=%+v, want parked with nothing running or scheduled", snapshot)
+	}
+	if snapshot.Desired != DesiredRunning {
+		t.Fatalf("Desired=%q, want running — parking is the supervisor giving up, not the consumer", snapshot.Desired)
+	}
+	if !snapshot.ParkedAt.Equal(parkedAt) {
+		t.Fatalf("ParkedAt=%s, want the original %s", snapshot.ParkedAt, parkedAt)
+	}
+	if snapshot.RestartAttempt != 10 {
+		t.Fatalf("RestartAttempt=%d, want 10", snapshot.RestartAttempt)
+	}
+	if snapshot.LastExit == nil || snapshot.LastExit.ExitCode == nil || *snapshot.LastExit.ExitCode != 1 {
+		t.Fatalf("LastExit=%+v, want the recorded exit code 1", snapshot.LastExit)
+	}
+
+	// Nothing scheduled means nothing runs, however long anyone waits.
+	clock.Advance(24 * time.Hour)
+	if got := launcher.count(); got != 0 {
+		t.Fatalf("starts after adopting a park=%d, want 0", got)
+	}
+
+	// Traffic finds it parked, and only the deliberate act revives it.
+	if err := supervisor.EnsureUnlessParked("fixture", launcher.start); !errors.Is(err, ErrParked) {
+		t.Fatalf("EnsureUnlessParked=%v, want ErrParked", err)
+	}
+	if got := launcher.count(); got != 0 {
+		t.Fatalf("EnsureUnlessParked started the child %d time(s)", got)
+	}
+	if err := supervisor.Ensure("fixture", launcher.start); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	waitFor(t, func() bool { return launcher.count() == 1 })
+	revived, _ := supervisor.Snapshot("fixture")
+	if revived.Phase == PhaseParked || revived.RestartAttempt != 0 {
+		t.Fatalf("revived=%+v, want a running child with its budget back", revived)
+	}
+}
+
+// Adopting is a restore, not an announcement: the child was parked before this
+// supervisor existed, so nothing moved and nobody is told again.
+func TestAdoptParkedIsSilent(t *testing.T) {
+	changes, giveUps := 0, 0
+	supervisor := New(Options{
+		Clock:    newFakeClock(),
+		OnChange: func(string) { changes++ },
+		OnGiveUp: func(string, Snapshot) { giveUps++ },
+	})
+	if err := supervisor.AdoptParked("fixture", Park{ParkedAt: time.Now()}); err != nil {
+		t.Fatalf("AdoptParked: %v", err)
+	}
+	if changes != 0 || giveUps != 0 {
+		t.Fatalf("OnChange=%d OnGiveUp=%d, want 0 and 0", changes, giveUps)
+	}
+}
+
+// A persisted park describes a child an earlier process gave up on. Applying it
+// over a live child would replace what this process knows with a stale record.
+func TestAdoptParkedRefusesASupervisedChild(t *testing.T) {
+	launcher := &fakeLauncher{}
+	supervisor := New(Options{Clock: newFakeClock()})
+	if err := supervisor.Ensure("fixture", launcher.start); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if err := supervisor.AdoptParked("fixture", Park{ParkedAt: time.Now()}); err == nil {
+		t.Fatal("AdoptParked onto a running child succeeded")
+	}
+	if snapshot, _ := supervisor.Snapshot("fixture"); snapshot.Phase == PhaseParked {
+		t.Fatalf("a refused adopt still parked the child: %+v", snapshot)
+	}
+	supervisor.Shutdown()
+}

--- a/internal/supervise/supervise.go
+++ b/internal/supervise/supervise.go
@@ -121,6 +121,19 @@ type Snapshot struct {
 	StartedAt      time.Time
 	ConnectedAt    time.Time
 	NextRestartAt  time.Time
+	ParkedAt       time.Time
+	LastExit       *Exit
+}
+
+// Park is a parking as something outside the supervisor remembers it.
+//
+// The supervisor's own memory ends with its process, so a consumer that must
+// keep a child parked across restarts persists this and hands it back with
+// AdoptParked. ParkedAt is the moment the give-up happened, not the moment it
+// was restored: a park has one timestamp for as long as it lasts.
+type Park struct {
+	ParkedAt       time.Time
+	RestartAttempt int
 	LastExit       *Exit
 }
 
@@ -198,6 +211,7 @@ type child struct {
 	startedAt      time.Time
 	connectedAt    time.Time
 	nextRestartAt  time.Time
+	parkedAt       time.Time
 	lastExit       *Exit
 
 	restartTimer    Timer
@@ -266,6 +280,42 @@ func (s *Supervisor) EnsureUnlessParked(name string, start StartFunc) error {
 	return s.ensure(name, start, false)
 }
 
+// AdoptParked begins supervising a child that is already parked, without ever
+// launching it.
+//
+// It is the restore half of Park: a consumer that persisted a give-up hands it
+// back here, and the child lands exactly where the give-up left it — nothing
+// running, nothing scheduled, EnsureUnlessParked refused, Ensure the only way
+// out. Nothing is announced, because nothing moved: the child was parked before
+// this supervisor existed and it is parked now.
+//
+// A name that is already supervised is refused. Adopting onto a live child would
+// overwrite what this process knows with a record an earlier one wrote.
+func (s *Supervisor) AdoptParked(name string, park Park) error {
+	if err := validateName(name); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.shutdown {
+		return fmt.Errorf("supervise: supervisor is shut down, cannot adopt %q", name)
+	}
+	if s.children[name] != nil {
+		return fmt.Errorf("supervise: child %q is already supervised, so a persisted park cannot be adopted onto it", name)
+	}
+	s.children[name] = &child{
+		name: name,
+		// Still wanted, still not running: parking is the supervisor giving up,
+		// not the consumer changing its mind.
+		desired:        DesiredRunning,
+		phase:          PhaseParked,
+		parkedAt:       park.ParkedAt,
+		restartAttempt: park.RestartAttempt,
+		lastExit:       copyExit(park.LastExit),
+	}
+	return nil
+}
+
 func (s *Supervisor) ensure(name string, start StartFunc, revive bool) error {
 	if err := validateName(name); err != nil {
 		return err
@@ -327,6 +377,7 @@ func (s *Supervisor) Stop(name string) {
 	c.generation++
 	c.connectedAt = time.Time{}
 	c.nextRestartAt = time.Time{}
+	c.parkedAt = time.Time{}
 	stopTimer(&c.restartTimer)
 	stopTimer(&c.disconnectTimer)
 	stopTimer(&c.stabilityTimer)
@@ -429,22 +480,31 @@ func snapshotOf(c *child) Snapshot {
 		StartedAt:      c.startedAt,
 		ConnectedAt:    c.connectedAt,
 		NextRestartAt:  c.nextRestartAt,
+		ParkedAt:       c.parkedAt,
 	}
-	if c.lastExit != nil {
-		exit := *c.lastExit
-		if c.lastExit.ExitCode != nil {
-			code := *c.lastExit.ExitCode
-			exit.ExitCode = &code
-		}
-		snapshot.LastExit = &exit
-	}
+	snapshot.LastExit = copyExit(c.lastExit)
 	return snapshot
+}
+
+// copyExit deep-copies an exit so neither side of a hand-off shares the other's
+// memory — the supervisor keeps mutating its copy, and ExitCode is a pointer.
+func copyExit(from *Exit) *Exit {
+	if from == nil {
+		return nil
+	}
+	exit := *from
+	if from.ExitCode != nil {
+		code := *from.ExitCode
+		exit.ExitCode = &code
+	}
+	return &exit
 }
 
 func (s *Supervisor) spawnLocked(c *child) error {
 	c.generation++
 	c.phase = PhaseStarting
 	c.nextRestartAt = time.Time{}
+	c.parkedAt = time.Time{}
 	stopTimer(&c.restartTimer)
 	generation := c.generation
 	process, err := s.startChild(c, generation)
@@ -533,6 +593,7 @@ func (s *Supervisor) scheduleRestartLocked(c *child) {
 	if s.giveUpAfter > 0 && c.restartAttempt >= s.giveUpAfter {
 		c.phase = PhaseParked
 		c.nextRestartAt = time.Time{}
+		c.parkedAt = s.clock.Now()
 		detail := "no exit recorded"
 		if c.lastExit != nil {
 			detail = c.lastExit.String()


### PR DESCRIPTION
Every installed app's handlers run in one supervised Bun sidecar. When that
sidecar crash-loops, `internal/supervise` parks it after ten restarts: attn
stops restarting it, writes one critical notification, and waits for
`attn app runtime restart`. #842 already made sure traffic cannot un-park it.

The park lived only in the supervisor's memory. A daemon restart — an upgrade, a
crash, a reboot; none of them rare — forgot it. The fresh daemon lazy-started the
still-broken host on the first due fact, re-armed the whole crash loop, spent
another ~2 minutes on it, and raised a **second** critical notification for one
outage the user had already been told about.

## What changed

**The park is durable.** A give-up writes a `supervised_parks` row (migration
104): the park's own timestamp, the restart count, and how the last process
ended. Persisting happens before the notification is written, so a daemon that
dies between the two comes back parked and silent rather than running and about
to crash-loop.

**The restore is structural, not a startup step.** `supervise.AdoptParked` puts a
child back exactly where the give-up left it — nothing running, nothing
scheduled, `EnsureUnlessParked` refused, `Ensure` the only way out — and the
daemon calls it from inside `ensureAppRuntimeSupervisor`. Every way to reach the
supervisor (a dispatch, `runtime status`, the restart verb, the sidecar saying
hello) goes through that constructor, so no caller can outrun the restore and
spawn a host attn has given up on. `Start` additionally builds the supervisor
when — and only when — a park exists, so `attn app runtime status` answers
"parked" from the first moment; building it unconditionally would turn "no
runtime has been started" into "stopped" on every daemon that has never had an
app, and that difference is the whole of "is something broken here".

**Restoring announces nothing.** No fact, no second notification: the runtime was
parked before this daemon existed and it is parked now. The original critical
notification is a durable row and still stands.

**The way out erases the way in.** `attn app runtime restart` stays the single
un-park verb and now deletes the row along with the park — whether or not the
launch itself succeeded, because a failed start goes to backoff rather than back
to parked. A restart that cannot even resolve the host binary returns before the
supervisor is touched, so the park and its row both survive; that is the same
early return the verb already had.

**Status carries the original park timestamp.** `AppRuntimeInfo.parked_at`
(protocol 231) and a `parked since <stamp>` line in `attn app runtime status`, so
a reader sees how long apps have actually been dead rather than a clock that
restarts with the daemon.

### A deliberate reading

If the runtime binary changed since the park — the restart *is* the upgrade that
fixes it — the runtime stays parked. Nothing auto-unparks on any signal other
than the explicit verb, and no heuristic guesses that a new binary is a working
one. Verified below.

## Verification

Unit and integration tests cover: park → daemon stop/start → still parked with
the original timestamp, no spawn attempt, no second notification; the restart
verb clearing the persisted row; and the ordering, asserted rather than
commented — a dispatch into a daemon that has never built a supervisor finds the
park already applied and launches nothing. Each of the three halves (persist,
adopt, clear) was mutated to confirm the tests go red on it.

Live on a throwaway `parksurv` profile, from a full `make install PROFILE=parksurv`
build of this branch, against a fresh database (migrations applied from scratch to
104), with a real app (`ticket.*` subscriber) and a host binary swapped for
`exit 1`:

```
# parked after 11 launches, ~2 minutes
  state:    parked (not connected), generation 11
            attn gave up restarting it after 10 attempts; no app's handlers are running.
            parked since 2026-08-11T22:14:38Z.
            `attn app runtime restart` tries again.

supervised_parks: runtime|2026-08-11T22:14:38.660470000Z|10|1|exit status 1
notifications:    f2e85b2d…|critical|Apps stopped running     (1)
host launches:    11

# stop the daemon, start it again — the host is still broken
  state:    parked (not connected), generation 0        <- this daemon started it zero times
            parked since 2026-08-11T22:14:38Z.          <- the original moment, not now

# a second ticket, so a dispatch is due; and four more delivery attempts
# at the bus's two-minute retry cap
host launches:    11        (unchanged — nothing was spawned)
notifications:    1         (unchanged)
invocations:      runtime_error, "the app runtime is parked after repeated
                  crashes and is not being restarted; … `attn app runtime
                  restart` tries again"

# restart the daemon again, now pointing at the real host binary
  state:    parked (not connected), generation 0        <- a fixed binary is not consent to un-park

# the deliberate act
revived the app runtime: it was parked after crash-looping, and is starting again
  state:    starting (not connected), generation 2
supervised_parks: 0

# traffic resumes, and the revival survives its own daemon restart
invocations:      ok|ticket.created|14ms, ok|ticket.created|2ms
after a restart:  "not started — no enabled app has been due a fact since this
                  daemon came up", then a ticket lazy-starts it, connected,
                  generation 1, handler ok
notifications:    1 for the whole run
```

No recording: `app.runtime.changed` has no `wireProjections` entry, so nothing
about the runtime is rendered in the app — the surfaces this changes are the
daemon and `attn app runtime status`.

Profile cleaned after the run.

## Surfaces walked

- **CLI** — `attn app runtime status` gains `parked since`; `restart` unchanged
  in shape, now clearing the row.
- **Daemon** — persist, adopt, clear; `Start` restores before
  `registerAppConsumers`, the only thing that can lazy-start the runtime.
- **Protocol** — `parked_at` on `AppRuntimeInfo`, regenerated, `ProtocolVersion`
  230 → 231 in both lockstep spots.
- **Bus** — no new fact and no projection: a restore is not a state change.
  Parking still publishes `app.runtime.changed` exactly as before.
- **Linux** — pure Go, no build constraints touched.
- **Plugins** — the other `supervise` consumer is untouched; `AdoptParked` is
  opt-in and a supervised plugin that keeps dying is reinstalled rather than
  un-parked, so persisting its give-up would be a record nothing reads. The
  table is keyed by child name so a second consumer can join without a schema
  change, not because one is planned.
- **Docs** — the A4 plan doc's "restarted daemon forgets the park" entry moves
  from an observed decision to a fixed defect; `changelog.d/` fragment added.

### One test adjusted, and why

`TestApps_MigrationCarriesRowsWithNoPredecessor` (from #858) rewound the schema
by deleting migration 103's row. The recorded version is
`MAX(schema_migrations.version)`, so that only rewinds while 103 is the last
migration — with 104 present the version stays at 104 and the migration under
test is skipped, so the column it adds never comes back. It now deletes from the
rewind point up, which is what "the schema as it stood before 103" means. The
later migrations re-run and tolerate it. The assertions are untouched; this was a
latent trap for whoever added the next migration, and it is disarmed rather than
worked around.

## Numbers, settled at merge

Migration **104** — main is at 103 (#858), rechecked after rebasing onto
`origin/main`. Protocol **231** — main landed its own 230 (`auto_settle_dismiss_armed`)
while this branch was in flight; sharing 230 would have two builds agreeing on a
version that describes two different shapes, so this took the next one.

https://claude.ai/code/session_01HoGDZvEakUGj6wrfKoszvR
