### PR TITLE
docs(plans): keep the rollback stack question open

### DIFF
--- a/changelog.d/rollback-stack-question-open.yaml
+++ b/changelog.d/rollback-stack-question-open.yaml
@@ -1,0 +1,7 @@
+kind: internal
+area: docs
+change: >
+  The A4 plan records bare rollback's shipped undo semantics (a second
+  bare rollback returns to where you started) and keeps the alternative
+  — a stack walking further back through serving history, Victor's lean
+  — as an open question to revisit at the end of the platform work.

--- a/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
+++ b/docs/plans/2026-08-06-ext-a4-app-registry-and-runtime.md
@@ -513,6 +513,13 @@ recovery drain, bare-rollback trap):
   a version returns to the version that was serving before the current one
   — the registry records the pointer at every flip — and says which version
   it chose and why. No recorded previous fails loud with the version list.
+  *Shipped* (#858) with undo semantics: the pointer swaps on every move, so
+  a second bare rollback returns to where you started (`cd -`), stated in
+  `--help` and tested. **Open, deliberately until the platform work's end:**
+  Victor leans toward a stack instead — each bare rollback walking one step
+  further back through serving history. Undo was shipped first because its
+  meaning never depends on how many times it has run; revisit once real
+  rollback usage exists to judge against.
 - **Restart must not forget a park.** The park persists and is restored at
   daemon startup before anything can lazy-start the broken host; `attn app
   runtime restart` stays the only unpark and clears the persisted state.


### PR DESCRIPTION
Bare `attn app rollback` shipped in #858 with undo semantics: the previously-serving pointer swaps on every move, so a second bare rollback returns to where you started. Victor's lean is a stack instead — each bare rollback walking one step further back through serving history. This records that as a deliberate open question in the A4 plan, to be revisited against real rollback usage at the end of the platform work, and notes why undo shipped first (its meaning never depends on how many times it has run).

Docs only.

https://claude.ai/code/session_01429snMWPwXjv1NeqUdV57c